### PR TITLE
ci: add GitHub Actions release workflow for desktop app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+name: Release Desktop App
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux x64
+            os: ubuntu-22.04
+            args: --bundles deb,rpm,appimage
+            rust-targets: ""
+            artifact-name: geolibre-linux-x64
+          - name: Windows x64
+            os: windows-latest
+            args: --no-sign
+            rust-targets: ""
+            artifact-name: geolibre-windows-x64
+          - name: macOS Apple Silicon
+            os: macos-latest
+            args: --target aarch64-apple-darwin --no-sign
+            rust-targets: aarch64-apple-darwin
+            artifact-name: geolibre-macos-arm64
+          - name: macOS Intel
+            os: macos-latest
+            args: --target x86_64-apple-darwin --no-sign
+            rust-targets: x86_64-apple-darwin
+            artifact-name: geolibre-macos-x64
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install macOS Rust target
+        if: matrix.rust-targets != ''
+        run: rustup target add ${{ matrix.rust-targets }}
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            curl \
+            file \
+            libayatana-appindicator3-dev \
+            libfuse2 \
+            librsvg2-dev \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev \
+            libxdo-dev \
+            patchelf \
+            rpm \
+            wget
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Build and upload release assets
+        uses: tauri-apps/tauri-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          projectPath: apps/geolibre-desktop
+          releaseId: ${{ github.event.release.id }}
+          tagName: ${{ github.event.release.tag_name }}
+          args: ${{ matrix.args }}
+          uploadWorkflowArtifacts: true
+          workflowArtifactNamePattern: ${{ matrix.artifact-name }}-[bundle]


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow that builds cross-platform desktop installers (Linux deb/rpm/AppImage, Windows exe, macOS ARM and Intel dmg) when a GitHub release is published
- Uses tauri-action to build and automatically upload release assets

## Test plan
- [ ] Create a draft GitHub release and verify the workflow triggers
- [ ] Confirm build artifacts are uploaded for all four platform targets