### PR TITLE
fix(ci): use tauri-apps/tauri-action@v0.6 instead of non-existent v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
         run: npm ci
 
       - name: Build and upload release assets
-        uses: tauri-apps/tauri-action@v1
+        uses: tauri-apps/tauri-action@v0.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary
- The release workflow referenced `tauri-apps/tauri-action@v1`, which does not exist, causing all four platform builds to fail immediately at job setup
- Updated to `@v0.6`, the latest major version tag available for the action

## Test plan
- [ ] Merge this PR, then re-run the failed release (or create a new one) and verify all builds proceed past the setup step