### PR TITLE
fix(ci): remove unsupported action inputs and add plain binary upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,22 +23,21 @@ jobs:
             os: ubuntu-22.04
             args: --bundles deb,rpm,appimage
             rust-targets: ""
-            artifact-name: geolibre-linux-x64
+
           - name: Windows x64
-            os: windows-latest
+            os: windows-2025
             args: --no-sign
             rust-targets: ""
-            artifact-name: geolibre-windows-x64
+
           - name: macOS Apple Silicon
             os: macos-latest
             args: --target aarch64-apple-darwin --no-sign
             rust-targets: aarch64-apple-darwin
-            artifact-name: geolibre-macos-arm64
+
           - name: macOS Intel
             os: macos-latest
             args: --target x86_64-apple-darwin --no-sign
             rust-targets: x86_64-apple-darwin
-            artifact-name: geolibre-macos-x64
 
     steps:
       - name: Checkout repository
@@ -88,5 +87,4 @@ jobs:
           releaseId: ${{ github.event.release.id }}
           tagName: ${{ github.event.release.tag_name }}
           args: ${{ matrix.args }}
-          uploadWorkflowArtifacts: true
-          workflowArtifactNamePattern: ${{ matrix.artifact-name }}-[bundle]
+          uploadPlainBinary: true


### PR DESCRIPTION
## Summary
- Remove `uploadWorkflowArtifacts` and `workflowArtifactNamePattern` inputs that are not supported in tauri-action v0.6, eliminating the "Unexpected input(s)" warnings on all four build jobs
- Add `uploadPlainBinary: true` to include standalone executable binaries in release assets (adds the missing Linux binary)
- Pin `windows-latest` to `windows-2025` ahead of the June 15 runner deprecation

## Test plan
- [ ] Create a new release and verify no "Unexpected input(s)" warnings appear
- [ ] Confirm a plain Linux binary is included in the release assets
- [ ] Verify all four platform builds complete successfully