### PR TITLE
fix: make plugin menu reactively reflect toggle state

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -19,7 +19,7 @@ import {
   Save,
   Wrench,
 } from "lucide-react";
-import { createAppAPI, getPluginManager } from "../../hooks/usePlugins";
+import { createAppAPI, usePluginRegistry } from "../../hooks/usePlugins";
 import {
   openGeoJsonFileWithFallback,
   openProjectFile,
@@ -79,7 +79,7 @@ export function TopToolbar({ mapControllerRef }: TopToolbarProps) {
     if (layer) mapControllerRef.current?.fitLayer(layer);
   };
 
-  const plugins = getPluginManager().list();
+  const { plugins, isActive, toggle } = usePluginRegistry();
   const appApi = createAppAPI();
 
   return (
@@ -122,10 +122,10 @@ export function TopToolbar({ mapControllerRef }: TopToolbarProps) {
           {plugins.map((p) => (
             <DropdownMenuItem
               key={p.id}
-              onClick={() => getPluginManager().toggle(p.id, appApi)}
+              onClick={() => toggle(p.id, appApi)}
             >
               {p.name}
-              {getPluginManager().isActive(p.id) ? " ✓" : ""}
+              {isActive(p.id) ? " ✓" : ""}
             </DropdownMenuItem>
           ))}
         </DropdownMenuContent>

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -6,13 +6,29 @@ import {
   sampleGeoJsonPlugin,
   setSampleGeoJson,
 } from "@geolibre/plugins";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useSyncExternalStore } from "react";
 import sampleGeojson from "../../../../sample-data/sample.geojson?url";
 
 const manager = new PluginManager();
+manager.registerAll([osmBasemapPlugin, cartoLightPlugin, sampleGeoJsonPlugin]);
 
 export function getPluginManager(): PluginManager {
   return manager;
+}
+
+export function usePluginRegistry() {
+  useSyncExternalStore(
+    (listener) => manager.subscribe(listener),
+    () => manager.getVersion(),
+    () => manager.getVersion(),
+  );
+
+  return {
+    plugins: manager.list(),
+    isActive: (id: string) => manager.isActive(id),
+    toggle: (id: string, appApi: ReturnType<typeof createAppAPI>) =>
+      manager.toggle(id, appApi),
+  };
 }
 
 export function usePlugins() {
@@ -21,12 +37,6 @@ export function usePlugins() {
   useEffect(() => {
     if (initialized.current) return;
     initialized.current = true;
-
-    manager.registerAll([
-      osmBasemapPlugin,
-      cartoLightPlugin,
-      sampleGeoJsonPlugin,
-    ]);
 
     fetch(sampleGeojson)
       .then((r) => r.json())

--- a/packages/plugins/src/plugin-manager.ts
+++ b/packages/plugins/src/plugin-manager.ts
@@ -3,9 +3,13 @@ import type { GeoLibreAppAPI, GeoLibrePlugin } from "./types";
 export class PluginManager {
   private plugins = new Map<string, GeoLibrePlugin>();
   private active = new Set<string>();
+  private listeners = new Set<() => void>();
+  private version = 0;
 
   register(plugin: GeoLibrePlugin): void {
+    const previous = this.plugins.get(plugin.id);
     this.plugins.set(plugin.id, plugin);
+    if (previous !== plugin) this.notify();
   }
 
   registerAll(plugins: GeoLibrePlugin[]): void {
@@ -20,11 +24,21 @@ export class PluginManager {
     return this.active.has(id);
   }
 
+  getVersion(): number {
+    return this.version;
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
   activate(id: string, app: GeoLibreAppAPI): void {
     const plugin = this.plugins.get(id);
     if (!plugin || this.active.has(id)) return;
     plugin.activate(app);
     this.active.add(id);
+    this.notify();
   }
 
   deactivate(id: string, app: GeoLibreAppAPI): void {
@@ -32,10 +46,16 @@ export class PluginManager {
     if (!plugin || !this.active.has(id)) return;
     plugin.deactivate(app);
     this.active.delete(id);
+    this.notify();
   }
 
   toggle(id: string, app: GeoLibreAppAPI): void {
     if (this.active.has(id)) this.deactivate(id, app);
     else this.activate(id, app);
+  }
+
+  private notify(): void {
+    this.version += 1;
+    for (const listener of this.listeners) listener();
   }
 }


### PR DESCRIPTION
## Summary
- The Tools menu read plugin state once at render time, so the active checkmark never updated after toggling a plugin.
- Added a lightweight subscription mechanism to `PluginManager` (`subscribe`/`getVersion`, with `notify` on register/activate/deactivate).
- Consume it from a new `usePluginRegistry` hook via `useSyncExternalStore`, so `TopToolbar` re-renders when plugins toggle. Plugin registration is now done once at module init.

## Test plan
- [ ] Open the Tools menu, toggle a plugin, and confirm the checkmark updates immediately.
- [ ] Toggle multiple plugins on/off and verify each reflects its current state.
- [ ] `npm run build` passes (also enforced via pre-commit).