### PR TITLE
fix: disable WebKitGTK DMABUF renderer on Linux

### DIFF
--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -12,8 +12,11 @@ pub fn run() {
 #[cfg(target_os = "linux")]
 fn configure_linux_webkit() {
     // WebKitGTK's DMABUF renderer can fail to allocate GBM buffers on some
-    // Linux graphics stacks, leaving the Tauri window blank.
-    std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    // Linux graphics stacks, leaving the Tauri window blank. Only set the
+    // default when unset so an explicit user/distributor value wins.
+    if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
+        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    }
 }
 
 #[cfg(not(target_os = "linux"))]

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -1,8 +1,20 @@
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    configure_linux_webkit();
+
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .run(tauri::generate_context!())
         .expect("error while running GeoLibre Desktop");
 }
+
+#[cfg(target_os = "linux")]
+fn configure_linux_webkit() {
+    // WebKitGTK's DMABUF renderer can fail to allocate GBM buffers on some
+    // Linux graphics stacks, leaving the Tauri window blank.
+    std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+}
+
+#[cfg(not(target_os = "linux"))]
+fn configure_linux_webkit() {}


### PR DESCRIPTION
## Summary
- Set `WEBKIT_DISABLE_DMABUF_RENDERER=1` at startup on Linux so the desktop window renders instead of appearing blank.
- WebKitGTK's DMABUF renderer can fail to allocate GBM buffers on some Linux graphics stacks; this forces a working renderer path.
- No-op on non-Linux platforms.

## Test plan
- [ ] Launch the desktop app on a Linux machine that previously showed a blank window and confirm the map UI renders.
- [ ] Confirm macOS and Windows builds are unaffected.