### PR TITLE
feat: add basemap control plugin

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -23,6 +23,7 @@
     "@tauri-apps/plugin-dialog": "^2.2.0",
     "@tauri-apps/plugin-fs": "^2.2.0",
     "maplibre-gl": "^5.1.1",
+    "maplibre-gl-basemap-control": "^0.1.0",
     "maplibre-gl-geo-editor": "^0.7.3",
     "maplibre-gl-geoagent": "^0.4.2",
     "react": "^18.3.1",

--- a/apps/geolibre-desktop/src-tauri/tauri.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.conf.json
@@ -20,7 +20,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' https://tiles.openfreemap.org https://*.openfreemap.org https://basemaps.cartocdn.com https://*.cartocdn.com https://tile.openstreetmap.org https://*.openstreetmap.org https://s3.amazonaws.com; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval'; worker-src blob: 'self'",
+      "csp": "default-src 'self'; connect-src 'self' https:; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval'; worker-src blob: 'self'",
       "capabilities": ["default"]
     }
   },

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -1,5 +1,6 @@
 import { useAppStore } from "@geolibre/core";
 import {
+  maplibreBasemapControlPlugin,
   maplibreGeoAgentPlugin,
   maplibreGeoEditorPlugin,
   maplibreLayerControlPlugin,
@@ -12,6 +13,7 @@ import { useSyncExternalStore } from "react";
 const manager = new PluginManager();
 manager.registerAll([
   maplibreLayerControlPlugin,
+  maplibreBasemapControlPlugin,
   maplibreGeoAgentPlugin,
   maplibreGeoEditorPlugin,
 ]);

--- a/apps/geolibre-desktop/src/main.tsx
+++ b/apps/geolibre-desktop/src/main.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "@geoman-io/maplibre-geoman-free/dist/maplibre-geoman.css";
+import "maplibre-gl-basemap-control/style.css";
 import "maplibre-gl-geo-editor/style.css";
 import "maplibre-gl-geoagent/style.css";
 import "./index.css";

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@tauri-apps/plugin-dialog": "^2.2.0",
         "@tauri-apps/plugin-fs": "^2.2.0",
         "maplibre-gl": "^5.1.1",
+        "maplibre-gl-basemap-control": "^0.1.0",
         "maplibre-gl-geo-editor": "^0.7.3",
         "maplibre-gl-geoagent": "^0.4.2",
         "react": "^18.3.1",
@@ -8042,6 +8043,25 @@
         "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
       }
     },
+    "node_modules/maplibre-gl-basemap-control": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-basemap-control/-/maplibre-gl-basemap-control-0.1.0.tgz",
+      "integrity": "sha512-haej5pD7QGXxEX6G+9Re8vx1b0iMMrDJvja3Cj8LU/CL05fSlHSvfwZ+Q1BcIXNthTYSIh3CSW6AB51efG1B6A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "maplibre-gl": ">=3.0.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/maplibre-gl-geo-editor": {
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/maplibre-gl-geo-editor/-/maplibre-gl-geo-editor-0.7.3.tgz",
@@ -10241,6 +10261,7 @@
       "dependencies": {
         "@geolibre/core": "*",
         "@geoman-io/maplibre-geoman-free": "^0.7.1",
+        "maplibre-gl-basemap-control": "^0.1.0",
         "maplibre-gl-geo-editor": "^0.7.3",
         "maplibre-gl-geoagent": "^0.4.2"
       },

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@geolibre/core": "*",
     "@geoman-io/maplibre-geoman-free": "^0.7.1",
+    "maplibre-gl-basemap-control": "^0.1.0",
     "maplibre-gl-geo-editor": "^0.7.3",
     "maplibre-gl-geoagent": "^0.4.2"
   },

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -3,6 +3,7 @@ export { PluginManager } from "./plugin-manager";
 export { maplibreLayerControlPlugin } from "./plugins/layer-control";
 export { osmBasemapPlugin } from "./plugins/osm-basemap";
 export { cartoLightPlugin } from "./plugins/carto-light";
+export { maplibreBasemapControlPlugin } from "./plugins/maplibre-basemap-control";
 export { maplibreGeoEditorPlugin } from "./plugins/maplibre-geo-editor";
 export { maplibreGeoAgentPlugin } from "./plugins/maplibre-geoagent";
 export {

--- a/packages/plugins/src/plugins/maplibre-basemap-control.ts
+++ b/packages/plugins/src/plugins/maplibre-basemap-control.ts
@@ -1,0 +1,80 @@
+import {
+  BasemapControl,
+  type BasemapControlEventPayload,
+  type BasemapControlOptions,
+} from "maplibre-gl-basemap-control";
+import type { GeoLibreAppAPI, GeoLibrePlugin } from "../types";
+
+const BASEMAP_CONTROL_POSITION = "top-right";
+
+let basemapControl: BasemapControl | null = null;
+
+export const maplibreBasemapControlPlugin: GeoLibrePlugin = {
+  id: "maplibre-gl-basemap-control",
+  name: "Basemap Control",
+  version: "0.1.0",
+  activate: (app: GeoLibreAppAPI) => {
+    if (!basemapControl) {
+      basemapControl = new BasemapControl(getBasemapControlOptions(app));
+      basemapControl.on("basemapchange", (event) => {
+        handleBasemapChange(app, event);
+      });
+    }
+
+    const added = app.addMapControl(
+      basemapControl,
+      BASEMAP_CONTROL_POSITION,
+    );
+    if (!added) {
+      basemapControl = null;
+      return false;
+    }
+    basemapControl.setState({
+      activeBasemapId: getBasemapIdForStyleUrl(app.getActiveBasemap()),
+    });
+  },
+  deactivate: (app: GeoLibreAppAPI) => {
+    if (!basemapControl) return;
+    app.removeMapControl(basemapControl);
+    basemapControl = null;
+  },
+};
+
+function getBasemapControlOptions(
+  app: GeoLibreAppAPI,
+): BasemapControlOptions {
+  return {
+    collapsed: true,
+    position: BASEMAP_CONTROL_POSITION,
+    title: "Basemaps",
+  };
+}
+
+function handleBasemapChange(
+  app: GeoLibreAppAPI,
+  event: BasemapControlEventPayload,
+): void {
+  if (event.type !== "basemapchange") return;
+  const { source } = event.basemap;
+  if (source.type !== "style" && source.type !== "vector-style") return;
+  app.setBasemap(source.url);
+}
+
+function getBasemapIdForStyleUrl(url: string): string | undefined {
+  if (url === "https://tiles.openfreemap.org/styles/positron") {
+    return "openfreemap-positron";
+  }
+  if (url === "https://tiles.openfreemap.org/styles/bright") {
+    return "openfreemap-bright";
+  }
+  if (url === "https://tiles.openfreemap.org/styles/liberty") {
+    return "openfreemap-liberty";
+  }
+  if (url === "https://tiles.openfreemap.org/styles/dark") {
+    return "openfreemap-dark";
+  }
+  if (url === "https://tiles.openfreemap.org/styles/fiord") {
+    return "openfreemap-fiord";
+  }
+  return undefined;
+}

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -32,7 +32,7 @@ let geoEditorControl: GeoEditor | null = null;
 
 export const maplibreGeoEditorPlugin: GeoLibrePlugin = {
   id: "maplibre-gl-geo-editor",
-  name: "MapLibre GeoEditor",
+  name: "GeoEditor",
   version: "0.7.3",
   activate: (app: GeoLibreAppAPI) => {
     if (!geoEditorControl) {

--- a/packages/plugins/src/plugins/maplibre-geoagent.ts
+++ b/packages/plugins/src/plugins/maplibre-geoagent.ts
@@ -18,7 +18,7 @@ let geoAgentControl: GeoAgentControl | null = null;
 
 export const maplibreGeoAgentPlugin: GeoLibrePlugin = {
   id: "maplibre-gl-geoagent",
-  name: "MapLibre GeoAgent",
+  name: "GeoAgent",
   version: "0.4.2",
   activate: (app: GeoLibreAppAPI) => {
     if (!geoAgentControl) {


### PR DESCRIPTION
## Summary
- Add a Basemap Control plugin that wraps `maplibre-gl-basemap-control`, letting users switch between OpenFreeMap styles from a collapsible control on the map.
- Shorten the GeoEditor and GeoAgent plugin display names for a cleaner plugin menu.
- Broaden the `connect-src` CSP directive to allow arbitrary HTTPS sources so new basemap providers work without per-host allowlisting.

## Test plan
- [ ] `npm run build` succeeds
- [ ] Toggle the Basemap Control plugin on and confirm the control appears top-right
- [ ] Switch between OpenFreeMap styles and confirm the basemap updates
- [ ] Confirm the active basemap is highlighted when the control opens