### PR TITLE
feat: add Street View plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ npm run dev
 
 Open http://localhost:1420 — map works; file dialogs require Tauri.
 
+## Environment variables
+
+The Street View plugin can use Google Street View and Mapillary imagery. Create `apps/geolibre-desktop/.env.local` and set one or both provider credentials:
+
+```env
+VITE_GOOGLE_MAPS_API_KEY=your_google_maps_api_key
+VITE_MAPILLARY_ACCESS_TOKEN=your_mapillary_access_token
+```
+
+For Google Street View, enable the Maps Embed API for the key in Google Cloud. For Mapillary, create an app in the Mapillary developer dashboard and use its client access token.
+
+Restart `npm run dev` or `npm run tauri:dev` after changing these values. Vite only exposes variables with the `VITE_` prefix to the frontend.
+
 ## Run (desktop)
 
 ```bash

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -22,10 +22,12 @@
     "@tauri-apps/api": "^2.2.0",
     "@tauri-apps/plugin-dialog": "^2.2.0",
     "@tauri-apps/plugin-fs": "^2.2.0",
+    "mapillary-js": "^4.1.2",
     "maplibre-gl": "^5.1.1",
-    "maplibre-gl-basemap-control": "^0.1.0",
+    "maplibre-gl-basemap-control": "^0.2.0",
     "maplibre-gl-geo-editor": "^0.7.3",
     "maplibre-gl-geoagent": "^0.4.2",
+    "maplibre-gl-streetview": "^0.3.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/apps/geolibre-desktop/src-tauri/tauri.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.conf.json
@@ -20,7 +20,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' https:; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval'; worker-src blob: 'self'",
+      "csp": "default-src 'self'; connect-src 'self' https:; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval'; worker-src blob: 'self'; frame-src 'self' https://www.google.com",
       "capabilities": ["default"]
     }
   },

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -4,6 +4,7 @@ import {
   maplibreGeoAgentPlugin,
   maplibreGeoEditorPlugin,
   maplibreLayerControlPlugin,
+  maplibreStreetViewPlugin,
   PluginManager,
 } from "@geolibre/plugins";
 import type { MapController } from "@geolibre/map";
@@ -16,6 +17,7 @@ manager.registerAll([
   maplibreBasemapControlPlugin,
   maplibreGeoAgentPlugin,
   maplibreGeoEditorPlugin,
+  maplibreStreetViewPlugin,
 ]);
 
 export function getPluginManager(): PluginManager {

--- a/apps/geolibre-desktop/src/main.tsx
+++ b/apps/geolibre-desktop/src/main.tsx
@@ -6,6 +6,8 @@ import "@geoman-io/maplibre-geoman-free/dist/maplibre-geoman.css";
 import "maplibre-gl-basemap-control/style.css";
 import "maplibre-gl-geo-editor/style.css";
 import "maplibre-gl-geoagent/style.css";
+import "maplibre-gl-streetview/style.css";
+import "mapillary-js/dist/mapillary.css";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,10 +28,12 @@
         "@tauri-apps/api": "^2.2.0",
         "@tauri-apps/plugin-dialog": "^2.2.0",
         "@tauri-apps/plugin-fs": "^2.2.0",
+        "mapillary-js": "^4.1.2",
         "maplibre-gl": "^5.1.1",
-        "maplibre-gl-basemap-control": "^0.1.0",
+        "maplibre-gl-basemap-control": "^0.2.0",
         "maplibre-gl-geo-editor": "^0.7.3",
         "maplibre-gl-geoagent": "^0.4.2",
+        "maplibre-gl-streetview": "^0.3.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -5646,6 +5648,12 @@
       "integrity": "sha512-DauBl25PKZZ0WVJr42a6CNvI6efsdzofl9sajqZr2Gf5Gu733WkDdUGiPkUHXiUvYGzNNlFQde2wdZdfQPG+yw==",
       "license": "MIT"
     },
+    "node_modules/@types/earcut": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.4.tgz",
+      "integrity": "sha512-qp3m9PPz4gULB9MhjGID7wpo3gJ4bTGXm7ltNDsmOvsPduTeHp8wSW9YckBj3mljeOh4F0m2z/0JKAALRKbmLQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -5680,11 +5688,35 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-1.0.7.tgz",
+      "integrity": "sha512-YBtzT2ztNF6R/9+UXj2wTGFnC9NklAnASt3sC0h2m1bbH7G6FyBIkt4AN8ThZpNfxUo1b2iMVO0UawiJymEt8A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/pbf": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
+      "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/polylabel": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/polylabel/-/polylabel-1.1.3.tgz",
+      "integrity": "sha512-9Zw2KoDpi+T4PZz2G6pO2xArE0m/GSMTW1MIxF2s8ZY8x9XDO6fv9um0ydRGvcbkFLlaq8yNK6eZxnmMZtDgWQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/rbush": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/rbush/-/rbush-3.0.4.tgz",
+      "integrity": "sha512-knSt9cCW8jj1ZSFcFeBZaX++OucmfPxxHiRwTahZfJlnQsek7O0bazTJHWD2RVj9LEoejUYF2de3/stf+QXcXw==",
       "license": "MIT"
     },
     "node_modules/@types/react": {
@@ -5723,12 +5755,24 @@
         "@types/geojson": "*"
       }
     },
+    "node_modules/@types/three": {
+      "version": "0.134.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.134.0.tgz",
+      "integrity": "sha512-4YB+99Rgqq27EjiYTItEoZtdjLnTh8W9LxowgpC9eWsjaQJIL4Kn/ZcUKAnW3gB/jS4hqGN8iqmid+RcUZDzpA==",
+      "license": "MIT"
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/virtual-dom": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/virtual-dom/-/virtual-dom-2.1.4.tgz",
+      "integrity": "sha512-Y7L/frVydXRd16MevczslJZQu+QWsrqZlj6ytk7mST3xen0fkx7Ollw31By/89A8Wq+nfNWm/IoTR1ac/0fRhA==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -6058,6 +6102,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/browser-split": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/browser-split/-/browser-split-0.0.1.tgz",
+      "integrity": "sha512-JhvgRb2ihQhsljNda3BI8/UcRHVzrVwo3Q+P8vDtSiyobXuFpuZ9mq+MbRGMnC22CjW3RrfXdg6j6ITX8M+7Ow==",
+      "license": "MIT"
+    },
     "node_modules/browserslist": {
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
@@ -6145,6 +6195,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/caniuse-lite": {
@@ -6533,6 +6592,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+    },
     "node_modules/dompurify": {
       "version": "3.4.7",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
@@ -6593,6 +6657,16 @@
       "peer": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/error": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/error/-/error-4.4.0.tgz",
+      "integrity": "sha512-SNDKualLUtT4StGFP7xNfuFybL2f6iJujFtrWuvJqGbVQGaN+adE23veqzPz1hjUjTunLi2EnJ+0SJxtbJreKw==",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "string-template": "~0.2.0",
+        "xtend": "~4.0.0"
       }
     },
     "node_modules/es-define-property": {
@@ -6692,6 +6766,14 @@
       "peer": true,
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/ev-store": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ev-store/-/ev-store-7.0.0.tgz",
+      "integrity": "sha512-otazchNRnGzp2YarBJ+GXKVGvhxVATB1zmaStxJBYet0Dyq7A9VhH8IUEB/gRcL6Ch52lfpgPTRJ2m49epyMsQ==",
+      "dependencies": {
+        "individual": "^3.0.0"
       }
     },
     "node_modules/event-target-shim": {
@@ -7187,6 +7269,16 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "license": "MIT",
+      "dependencies": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
+      }
+    },
     "node_modules/google-auth-library": {
       "version": "10.6.2",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
@@ -7674,6 +7766,31 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/individual": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/individual/-/individual-3.0.0.tgz",
+      "integrity": "sha512-rUY5vtT748NMRbEMrTNiFfy29BgGZwGXUi2NFUVMWQrogSLzlJvQV9eeMWi+g1aVaQ53tpyLAQtd5x/JH0Nh1g=="
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -7761,6 +7878,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
+      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-promise": {
@@ -8009,6 +8135,57 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/mapillary-js": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/mapillary-js/-/mapillary-js-4.1.2.tgz",
+      "integrity": "sha512-LYj6xbp/Y9wfBkr/prRwgJGb3+KwvzUri0yl5QEpMEH7oC1p52ErshWmPXysKefmm6JaFML4D7FJ89viwJ4T5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/earcut": "^2.1.1",
+        "@types/node": "^14.14.31",
+        "@types/pako": "^1.0.2",
+        "@types/pbf": "^3.0.2",
+        "@types/polylabel": "^1.0.5",
+        "@types/rbush": "^3.0.0",
+        "@types/three": "^0.134.0",
+        "@types/virtual-dom": "^2.1.1",
+        "earcut": "^2.2.3",
+        "martinez-polygon-clipping": "^0.7.1",
+        "pako": "^2.0.4",
+        "pbf": "^3.2.1",
+        "polylabel": "^1.1.0",
+        "rbush": "^3.0.1",
+        "rxjs": "^7.3.0",
+        "s2-geometry": "^1.2.10",
+        "three": "^0.134.0",
+        "virtual-dom": "^2.1.1"
+      }
+    },
+    "node_modules/mapillary-js/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "license": "MIT"
+    },
+    "node_modules/mapillary-js/node_modules/earcut": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
+      "license": "ISC"
+    },
+    "node_modules/mapillary-js/node_modules/pbf": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
+      "integrity": "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
     "node_modules/maplibre-gl": {
       "version": "5.24.0",
       "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.24.0.tgz",
@@ -8044,9 +8221,9 @@
       }
     },
     "node_modules/maplibre-gl-basemap-control": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-basemap-control/-/maplibre-gl-basemap-control-0.1.0.tgz",
-      "integrity": "sha512-haej5pD7QGXxEX6G+9Re8vx1b0iMMrDJvja3Cj8LU/CL05fSlHSvfwZ+Q1BcIXNthTYSIh3CSW6AB51efG1B6A==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-basemap-control/-/maplibre-gl-basemap-control-0.2.0.tgz",
+      "integrity": "sha512-ymh65Add5NnbIAXctblaRCnLzNIInTuFa5+srtSMAEP/6QOKB5FX+6A6oCYG3Hnkx3c9StafIc10CJ+GL8SjFw==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -8145,6 +8322,28 @@
         }
       }
     },
+    "node_modules/maplibre-gl-streetview": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-streetview/-/maplibre-gl-streetview-0.3.1.tgz",
+      "integrity": "sha512-4dp1aJ/lj6nAZwc4w1+UqgoBD65Zpxzo4580c9yIS3EWUp5BlqXFhckejFBqW/zZRGqZ06Fp3NfIrvTXPb94zg==",
+      "license": "MIT",
+      "dependencies": {
+        "mapillary-js": "^4.1.2"
+      },
+      "peerDependencies": {
+        "maplibre-gl": ">=3.0.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/marked": {
       "version": "18.0.4",
       "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.4.tgz",
@@ -8156,6 +8355,23 @@
       "engines": {
         "node": ">= 20"
       }
+    },
+    "node_modules/martinez-polygon-clipping": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/martinez-polygon-clipping/-/martinez-polygon-clipping-0.7.4.tgz",
+      "integrity": "sha512-jBEwrKtA0jTagUZj2bnmb4Yg2s4KnJGRePStgI7bAVjtcipKiF39R4LZ2V/UT61jMYWrTcBhPazexeqd6JAVtw==",
+      "license": "MIT",
+      "dependencies": {
+        "robust-predicates": "^2.0.4",
+        "splaytree": "^0.1.4",
+        "tinyqueue": "^1.2.0"
+      }
+    },
+    "node_modules/martinez-polygon-clipping/node_modules/tinyqueue": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-1.2.3.tgz",
+      "integrity": "sha512-Qz9RgWuO9l8lT+Y9xvbzhPT2efIUIFd69N7eF7tJ9lnQl0iLj1M7peK7IoUGZL9DJHw9XftqLreccfxcQgYLxA==",
+      "license": "ISC"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -8240,6 +8456,15 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/min-document": {
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.2.tgz",
+      "integrity": "sha512-8S5I8db/uZN8r9HSLFVWPdJCvYOejMcEC82VIzNUc6Zkklf/d1gg2psfE79/vyhWOj4+J8MtwmoOz3TmvaGu5A==",
+      "license": "MIT",
+      "dependencies": {
+        "dom-walk": "^0.1.0"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -8301,6 +8526,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/next-tick": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
+      "integrity": "sha512-f7h4svPtl+QidoBv4taKXUjJ70G2asaZ8G28nS0OkqaalX8dwwrtWtyxEDPK62AC00ur/+/E0pUwBwY5EPn15Q==",
+      "license": "MIT"
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -8457,6 +8688,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -8602,6 +8839,21 @@
         "bignumber.js": "^9.1.0",
         "splaytree-ts": "^1.0.2"
       }
+    },
+    "node_modules/polylabel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/polylabel/-/polylabel-1.1.0.tgz",
+      "integrity": "sha512-bxaGcA40sL3d6M4hH72Z4NdLqxpXRsCFk8AITYg6x1rn1Ei3izf00UMLklerBZTO49aPA3CYrIwVulx2Bce2pA==",
+      "license": "ISC",
+      "dependencies": {
+        "tinyqueue": "^2.0.3"
+      }
+    },
+    "node_modules/polylabel/node_modules/tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
+      "license": "ISC"
     },
     "node_modules/postcss": {
       "version": "8.5.15",
@@ -8771,6 +9023,15 @@
       "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
       "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
       "license": "ISC"
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/protobufjs": {
       "version": "7.6.1",
@@ -9179,6 +9440,33 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/s2-geometry": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/s2-geometry/-/s2-geometry-1.2.10.tgz",
+      "integrity": "sha512-5WejfQu1XZ25ZerW8uL6xP1sM2krcOYKhI6TbfybGRf+vTQLrm3E+4n0+1lWg+MYqFjPzoe51zKhn2sBRMCt5g==",
+      "license": "(MIT or Apache-2 or ISC)",
+      "dependencies": {
+        "long": "^3.2.0"
+      }
+    },
+    "node_modules/s2-geometry/node_modules/long": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+      "integrity": "sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -9390,6 +9678,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/splaytree": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-0.1.4.tgz",
+      "integrity": "sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ==",
+      "license": "MIT"
+    },
     "node_modules/splaytree-ts": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/splaytree-ts/-/splaytree-ts-1.0.2.tgz",
@@ -9405,6 +9699,11 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/string-template": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
+      "integrity": "sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw=="
     },
     "node_modules/strnum": {
       "version": "2.3.0",
@@ -9604,6 +9903,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/three": {
+      "version": "0.134.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.134.0.tgz",
+      "integrity": "sha512-LbBerg7GaSPjYtTOnu41AMp7tV6efUNR3p4Wk5NzkSsNTBuA5mDGOfwwZL1jhhVMLx9V20HolIUo0+U3AXehbg==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
@@ -9942,6 +10247,22 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/virtual-dom": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/virtual-dom/-/virtual-dom-2.1.1.tgz",
+      "integrity": "sha512-wb6Qc9Lbqug0kRqo/iuApfBpJJAq14Sk1faAnSmtqXiwahg7PVTvWMs9L02Z8nNIMqbwsxzBAA90bbtRLbw0zg==",
+      "license": "MIT",
+      "dependencies": {
+        "browser-split": "0.0.1",
+        "error": "^4.3.0",
+        "ev-store": "^7.0.0",
+        "global": "^4.3.0",
+        "is-object": "^1.0.1",
+        "next-tick": "^0.2.2",
+        "x-is-array": "0.1.0",
+        "x-is-string": "0.1.0"
+      }
+    },
     "node_modules/vite": {
       "version": "6.4.2",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
@@ -10126,6 +10447,16 @@
         }
       }
     },
+    "node_modules/x-is-array": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/x-is-array/-/x-is-array-0.1.0.tgz",
+      "integrity": "sha512-goHPif61oNrr0jJgsXRfc8oqtYzvfiMJpTqwE7Z4y9uH+T3UozkGqQ4d2nX9mB9khvA8U2o/UbPOFjgC7hLWIA=="
+    },
+    "node_modules/x-is-string": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
+      "integrity": "sha512-GojqklwG8gpzOVEVki5KudKNoq7MbbjYZCbyWzEz7tyPA7eleiE0+ePwOWQQRb5fm86rD3S8Tc0tSFf3AOv50w=="
+    },
     "node_modules/xml-naming": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
@@ -10148,6 +10479,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/yallist": {
@@ -10261,9 +10601,10 @@
       "dependencies": {
         "@geolibre/core": "*",
         "@geoman-io/maplibre-geoman-free": "^0.7.1",
-        "maplibre-gl-basemap-control": "^0.1.0",
+        "maplibre-gl-basemap-control": "^0.2.0",
         "maplibre-gl-geo-editor": "^0.7.3",
-        "maplibre-gl-geoagent": "^0.4.2"
+        "maplibre-gl-geoagent": "^0.4.2",
+        "maplibre-gl-streetview": "^0.3.1"
       },
       "devDependencies": {
         "@types/geojson": "^7946.0.16",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -11,9 +11,10 @@
   "dependencies": {
     "@geolibre/core": "*",
     "@geoman-io/maplibre-geoman-free": "^0.7.1",
-    "maplibre-gl-basemap-control": "^0.1.0",
+    "maplibre-gl-basemap-control": "^0.2.0",
     "maplibre-gl-geo-editor": "^0.7.3",
-    "maplibre-gl-geoagent": "^0.4.2"
+    "maplibre-gl-geoagent": "^0.4.2",
+    "maplibre-gl-streetview": "^0.3.1"
   },
   "devDependencies": {
     "@types/geojson": "^7946.0.16",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -6,6 +6,7 @@ export { cartoLightPlugin } from "./plugins/carto-light";
 export { maplibreBasemapControlPlugin } from "./plugins/maplibre-basemap-control";
 export { maplibreGeoEditorPlugin } from "./plugins/maplibre-geo-editor";
 export { maplibreGeoAgentPlugin } from "./plugins/maplibre-geoagent";
+export { maplibreStreetViewPlugin } from "./plugins/maplibre-streetview";
 export {
   sampleGeoJsonPlugin,
   setSampleGeoJson,

--- a/packages/plugins/src/plugins/maplibre-basemap-control.ts
+++ b/packages/plugins/src/plugins/maplibre-basemap-control.ts
@@ -12,7 +12,7 @@ let basemapControl: BasemapControl | null = null;
 export const maplibreBasemapControlPlugin: GeoLibrePlugin = {
   id: "maplibre-gl-basemap-control",
   name: "Basemap Control",
-  version: "0.1.0",
+  version: "0.2.0",
   activate: (app: GeoLibreAppAPI) => {
     if (!basemapControl) {
       basemapControl = new BasemapControl(getBasemapControlOptions(app));

--- a/packages/plugins/src/plugins/maplibre-streetview.ts
+++ b/packages/plugins/src/plugins/maplibre-streetview.ts
@@ -1,0 +1,49 @@
+import {
+  StreetViewControl,
+  type StreetViewControlOptions,
+} from "maplibre-gl-streetview";
+import type { GeoLibreAppAPI, GeoLibrePlugin } from "../types";
+
+const streetViewEnv = (
+  import.meta as ImportMeta & {
+    env?: Record<string, string | undefined>;
+  }
+).env;
+
+const STREET_VIEW_OPTIONS = {
+  collapsed: true,
+  position: "top-right",
+  title: "Street View",
+  panelWidth: 420,
+  panelHeight: 320,
+  defaultProvider: "google",
+  googleApiKey: streetViewEnv?.VITE_GOOGLE_MAPS_API_KEY,
+  mapillaryAccessToken: streetViewEnv?.VITE_MAPILLARY_ACCESS_TOKEN,
+} satisfies StreetViewControlOptions;
+
+let streetViewControl: StreetViewControl | null = null;
+
+export const maplibreStreetViewPlugin: GeoLibrePlugin = {
+  id: "maplibre-gl-streetview",
+  name: "Street View",
+  version: "0.3.1",
+  activate: (app: GeoLibreAppAPI) => {
+    if (!streetViewControl) {
+      streetViewControl = new StreetViewControl(STREET_VIEW_OPTIONS);
+    }
+
+    const added = app.addMapControl(
+      streetViewControl,
+      STREET_VIEW_OPTIONS.position,
+    );
+    if (!added) {
+      streetViewControl = null;
+      return false;
+    }
+  },
+  deactivate: (app: GeoLibreAppAPI) => {
+    if (!streetViewControl) return;
+    app.removeMapControl(streetViewControl);
+    streetViewControl = null;
+  },
+};

--- a/packages/plugins/src/plugins/maplibre-streetview.ts
+++ b/packages/plugins/src/plugins/maplibre-streetview.ts
@@ -10,15 +10,26 @@ const streetViewEnv = (
   }
 ).env;
 
+const googleApiKey = streetViewEnv?.VITE_GOOGLE_MAPS_API_KEY;
+const mapillaryAccessToken = streetViewEnv?.VITE_MAPILLARY_ACCESS_TOKEN;
+
+// Pick a default provider that actually has credentials so the panel does not
+// open onto a provider it cannot authenticate. Google wins when both are set.
+const defaultProvider: StreetViewControlOptions["defaultProvider"] = googleApiKey
+  ? "google"
+  : mapillaryAccessToken
+    ? "mapillary"
+    : "google";
+
 const STREET_VIEW_OPTIONS = {
   collapsed: true,
   position: "top-right",
   title: "Street View",
   panelWidth: 420,
   panelHeight: 320,
-  defaultProvider: "google",
-  googleApiKey: streetViewEnv?.VITE_GOOGLE_MAPS_API_KEY,
-  mapillaryAccessToken: streetViewEnv?.VITE_MAPILLARY_ACCESS_TOKEN,
+  defaultProvider,
+  googleApiKey,
+  mapillaryAccessToken,
 } satisfies StreetViewControlOptions;
 
 let streetViewControl: StreetViewControl | null = null;


### PR DESCRIPTION
## Summary
- Add a Street View map control plugin backed by Google Street View and Mapillary imagery, registered in the desktop app's plugin manager.
- Read provider credentials from `VITE_GOOGLE_MAPS_API_KEY` and `VITE_MAPILLARY_ACCESS_TOKEN` environment variables.
- Document the required environment variables and provider setup in the README.

## Test plan
- [ ] `npm run build` passes (tsc type-check + vite build)
- [ ] Plugin appears as a toggleable Street View control on the map
- [ ] With a valid Google Maps API key, Street View imagery loads
- [ ] With a valid Mapillary access token, Mapillary imagery loads