### PR TITLE
feat: add collapsible layer, style, and attribute panels

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -1,5 +1,6 @@
 import { useAppStore } from "@geolibre/core";
 import {
+  Button,
   Input,
   ScrollArea,
   Table,
@@ -9,6 +10,11 @@ import {
   TableHeader,
   TableRow,
 } from "@geolibre/ui";
+import {
+  PanelBottomClose,
+  PanelBottomOpen,
+  TableProperties,
+} from "lucide-react";
 
 export function AttributeTable() {
   const selectedLayerId = useAppStore((s) => s.selectedLayerId);
@@ -41,13 +47,22 @@ export function AttributeTable() {
 
   if (!attributeTableOpen) {
     return (
-      <button
-        type="button"
-        className="h-6 shrink-0 border-t bg-muted/30 text-center text-xs text-muted-foreground hover:bg-muted/50"
-        onClick={() => setAttributeTableOpen(true)}
-      >
-        Show attribute table
-      </button>
+      <section className="flex h-11 shrink-0 items-center gap-2 border-t bg-card px-3">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          title="Expand attribute table"
+          aria-label="Expand attribute table"
+          onClick={() => setAttributeTableOpen(true)}
+        >
+          <PanelBottomOpen className="h-4 w-4" />
+        </Button>
+        <TableProperties className="h-4 w-4 text-muted-foreground" />
+        <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Attribute table
+        </span>
+      </section>
     );
   }
 
@@ -68,13 +83,16 @@ export function AttributeTable() {
           value={attributeFilter}
           onChange={(e) => setAttributeFilter(e.target.value)}
         />
-        <button
-          type="button"
-          className="text-xs text-muted-foreground hover:underline"
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          title="Collapse attribute table"
+          aria-label="Collapse attribute table"
           onClick={() => setAttributeTableOpen(false)}
         >
-          Hide
-        </button>
+          <PanelBottomClose className="h-4 w-4" />
+        </Button>
       </div>
       <ScrollArea className="flex-1">
         {!layer?.geojson ? (

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -20,6 +20,9 @@ import {
   Eye,
   EyeOff,
   Info,
+  Layers,
+  PanelLeftClose,
+  PanelLeftOpen,
   Trash2,
   ZoomIn,
 } from "lucide-react";
@@ -37,10 +40,46 @@ export function LayerPanel({ mapControllerRef }: LayerPanelProps) {
   const reorderLayer = useAppStore((s) => s.reorderLayer);
   const removeLayer = useAppStore((s) => s.removeLayer);
   const [metadataLayer, setMetadataLayer] = useState<GeoLibreLayer | null>(null);
+  const [isCollapsed, setIsCollapsed] = useState(false);
+
+  if (isCollapsed) {
+    return (
+      <aside className="flex w-11 shrink-0 flex-col items-center border-r bg-card py-2">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          title="Expand layers"
+          aria-label="Expand layers"
+          onClick={() => setIsCollapsed(false)}
+        >
+          <PanelLeftOpen className="h-4 w-4" />
+        </Button>
+        <div className="mt-3 flex flex-col items-center gap-2 text-muted-foreground">
+          <Layers className="h-4 w-4" />
+          <span className="[writing-mode:vertical-rl] rotate-180 text-[10px] font-semibold uppercase tracking-wide">
+            Layers
+          </span>
+        </div>
+      </aside>
+    );
+  }
 
   return (
     <aside className="flex w-64 shrink-0 flex-col border-r bg-card">
-      <div className="border-b px-3 py-2 text-sm font-semibold">Layers</div>
+      <div className="flex items-center justify-between border-b px-3 py-1.5">
+        <span className="text-sm font-semibold">Layers</span>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          title="Collapse layers"
+          aria-label="Collapse layers"
+          onClick={() => setIsCollapsed(true)}
+        >
+          <PanelLeftClose className="h-4 w-4" />
+        </Button>
+      </div>
       <ScrollArea className="flex-1">
         <div className="space-y-1 p-2">
           {layers.length === 0 && (

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1,17 +1,59 @@
 import { useAppStore } from "@geolibre/core";
-import { Input, Label, ScrollArea, Separator } from "@geolibre/ui";
+import { Button, Input, Label, ScrollArea, Separator } from "@geolibre/ui";
+import {
+  PanelRightClose,
+  PanelRightOpen,
+  SlidersHorizontal,
+} from "lucide-react";
+import { useState } from "react";
 
 export function StylePanel() {
   const selectedLayerId = useAppStore((s) => s.selectedLayerId);
   const layers = useAppStore((s) => s.layers);
   const setLayerStyle = useAppStore((s) => s.setLayerStyle);
+  const [isCollapsed, setIsCollapsed] = useState(false);
 
   const layer = layers.find((l) => l.id === selectedLayerId);
+
+  if (isCollapsed) {
+    return (
+      <aside className="flex w-11 shrink-0 flex-col items-center border-l bg-card py-2">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          title="Expand style"
+          aria-label="Expand style"
+          onClick={() => setIsCollapsed(false)}
+        >
+          <PanelRightOpen className="h-4 w-4" />
+        </Button>
+        <div className="mt-3 flex flex-col items-center gap-2 text-muted-foreground">
+          <SlidersHorizontal className="h-4 w-4" />
+          <span className="[writing-mode:vertical-rl] rotate-180 text-[10px] font-semibold uppercase tracking-wide">
+            Style
+          </span>
+        </div>
+      </aside>
+    );
+  }
 
   if (!layer) {
     return (
       <aside className="flex w-64 shrink-0 flex-col border-l bg-card">
-        <div className="border-b px-3 py-2 text-sm font-semibold">Style</div>
+        <div className="flex items-center justify-between border-b px-3 py-1.5">
+          <span className="text-sm font-semibold">Style</span>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            title="Collapse style"
+            aria-label="Collapse style"
+            onClick={() => setIsCollapsed(true)}
+          >
+            <PanelRightClose className="h-4 w-4" />
+          </Button>
+        </div>
         <p className="p-4 text-xs text-muted-foreground">
           Select a layer to edit its style.
         </p>
@@ -23,8 +65,20 @@ export function StylePanel() {
 
   return (
     <aside className="flex w-64 shrink-0 flex-col border-l bg-card">
-      <div className="border-b px-3 py-2 text-sm font-semibold">
-        Style — {layer.name}
+      <div className="flex items-center justify-between gap-2 border-b px-3 py-1.5">
+        <span className="truncate text-sm font-semibold">
+          Style — {layer.name}
+        </span>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 shrink-0"
+          title="Collapse style"
+          aria-label="Collapse style"
+          onClick={() => setIsCollapsed(true)}
+        >
+          <PanelRightClose className="h-4 w-4" />
+        </Button>
       </div>
       <ScrollArea className="flex-1 p-3">
         <div className="space-y-4">

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -44,7 +44,25 @@ export function MapCanvas({ controllerRef }: MapCanvasProps) {
       updateView();
     });
 
+    let resizeFrame: number | null = null;
+    const resizeMap = () => {
+      if (resizeFrame !== null) {
+        window.cancelAnimationFrame(resizeFrame);
+      }
+      resizeFrame = window.requestAnimationFrame(() => {
+        resizeFrame = null;
+        mc.getMap()?.resize();
+      });
+    };
+    const resizeObserver = new ResizeObserver(resizeMap);
+    resizeObserver.observe(containerRef.current);
+    resizeMap();
+
     return () => {
+      resizeObserver.disconnect();
+      if (resizeFrame !== null) {
+        window.cancelAnimationFrame(resizeFrame);
+      }
       mc.destroy();
       controller.current = null;
       if (controllerRef) controllerRef.current = null;


### PR DESCRIPTION
## Summary
- Add collapse/expand toggles to the Layers, Style, and Attribute Table panels so users can reclaim screen space for the map.
- Replace the plain text toggles with icon buttons and a consistent collapsed rail (vertical label for side panels, slim header bar for the attribute table).
- Resize the map to fill the freed area whenever the container changes size, using a ResizeObserver with a debounced requestAnimationFrame.

## Test plan
- [ ] Collapse and expand each panel (Layers, Style, Attribute Table) and confirm the map resizes to fill the available space without visual gaps.
- [ ] Verify the map remains correctly sized after rapidly toggling panels and on window resize.
- [ ] Confirm panel toggle buttons have accessible labels and tooltips.