### PR TITLE
chore: bump maplibre-gl-streetview to 0.4.0

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -27,7 +27,7 @@
     "maplibre-gl-basemap-control": "^0.2.0",
     "maplibre-gl-geo-editor": "^0.7.3",
     "maplibre-gl-geoagent": "^0.4.2",
-    "maplibre-gl-streetview": "^0.3.1",
+    "maplibre-gl-streetview": "^0.4.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "maplibre-gl-basemap-control": "^0.2.0",
         "maplibre-gl-geo-editor": "^0.7.3",
         "maplibre-gl-geoagent": "^0.4.2",
-        "maplibre-gl-streetview": "^0.3.1",
+        "maplibre-gl-streetview": "^0.4.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -8323,9 +8323,9 @@
       }
     },
     "node_modules/maplibre-gl-streetview": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-streetview/-/maplibre-gl-streetview-0.3.1.tgz",
-      "integrity": "sha512-4dp1aJ/lj6nAZwc4w1+UqgoBD65Zpxzo4580c9yIS3EWUp5BlqXFhckejFBqW/zZRGqZ06Fp3NfIrvTXPb94zg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-streetview/-/maplibre-gl-streetview-0.4.0.tgz",
+      "integrity": "sha512-526dZM0jEIfYbT94jb5vEVod70Aj2qsta3pt97HotMIvlY00A2H4EsGjqlfmEgfyWBzFoB3sNcHvsr1GKmDFOg==",
       "license": "MIT",
       "dependencies": {
         "mapillary-js": "^4.1.2"
@@ -10604,7 +10604,7 @@
         "maplibre-gl-basemap-control": "^0.2.0",
         "maplibre-gl-geo-editor": "^0.7.3",
         "maplibre-gl-geoagent": "^0.4.2",
-        "maplibre-gl-streetview": "^0.3.1"
+        "maplibre-gl-streetview": "^0.4.0"
       },
       "devDependencies": {
         "@types/geojson": "^7946.0.16",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -14,7 +14,7 @@
     "maplibre-gl-basemap-control": "^0.2.0",
     "maplibre-gl-geo-editor": "^0.7.3",
     "maplibre-gl-geoagent": "^0.4.2",
-    "maplibre-gl-streetview": "^0.3.1"
+    "maplibre-gl-streetview": "^0.4.0"
   },
   "devDependencies": {
     "@types/geojson": "^7946.0.16",

--- a/packages/plugins/src/plugins/maplibre-streetview.ts
+++ b/packages/plugins/src/plugins/maplibre-streetview.ts
@@ -37,7 +37,7 @@ let streetViewControl: StreetViewControl | null = null;
 export const maplibreStreetViewPlugin: GeoLibrePlugin = {
   id: "maplibre-gl-streetview",
   name: "Street View",
-  version: "0.3.1",
+  version: "0.4.0",
   activate: (app: GeoLibreAppAPI) => {
     if (!streetViewControl) {
       streetViewControl = new StreetViewControl(STREET_VIEW_OPTIONS);


### PR DESCRIPTION
## Summary
- Bump `maplibre-gl-streetview` from 0.3.1 to 0.4.0 across the workspace (root lockfile, plugins package, desktop app).
- Update the Street View plugin's declared `version` to 0.4.0 to match.

## Test plan
- [x] `npm run build` passes (via pre-commit)
- [ ] Street View control loads and functions in the desktop app