### PR TITLE
chore: bump version to 0.3.0 for all packages

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolibre-desktop",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/geolibre-desktop/src-tauri/Cargo.lock
+++ b/apps/geolibre-desktop/src-tauri/Cargo.lock
@@ -996,7 +996,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-desktop"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/apps/geolibre-desktop/src-tauri/Cargo.toml
+++ b/apps/geolibre-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-desktop"
-version = "0.2.0"
+version = "0.3.0"
 description = "GeoLibre Desktop — lightweight cloud-native desktop GIS"
 authors = ["GeoLibre Contributors"]
 edition = "2021"

--- a/apps/geolibre-desktop/src-tauri/tauri.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "GeoLibre Desktop",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "identifier": "org.geolibre.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/backend/geolibre_server/pyproject.toml
+++ b/backend/geolibre_server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolibre-server"
-version = "0.2.0"
+version = "0.3.0"
 description = "Optional Python processing sidecar for GeoLibre Desktop"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolibre",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolibre",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -16,7 +16,7 @@
       }
     },
     "apps/geolibre-desktop": {
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@duckdb/duckdb-wasm": "^1.29.0",
         "@geolibre/core": "*",
@@ -10986,7 +10986,7 @@
     },
     "packages/core": {
       "name": "@geolibre/core",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "uuid": "^11.1.0",
         "zustand": "^5.0.3"
@@ -10998,7 +10998,7 @@
     },
     "packages/map": {
       "name": "@geolibre/map",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@geolibre/core": "*",
         "@turf/bbox": "^7.2.0",
@@ -11021,7 +11021,7 @@
     },
     "packages/plugins": {
       "name": "@geolibre/plugins",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@geolibre/core": "*",
         "@geoman-io/maplibre-geoman-free": "^0.7.1",
@@ -11039,7 +11039,7 @@
     },
     "packages/processing": {
       "name": "@geolibre/processing",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@geolibre/core": "*",
         "@turf/bbox": "^7.2.0"
@@ -11051,7 +11051,7 @@
     },
     "packages/ui": {
       "name": "@geolibre/ui",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-dropdown-menu": "^2.1.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geolibre",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "GeoLibre Desktop — lightweight cloud-native desktop GIS",
   "workspaces": [
     "apps/*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/core",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/map",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/plugins",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/processing/package.json
+++ b/packages/processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/processing",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/ui",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",


### PR DESCRIPTION
Update the version number across all relevant files and packages from 0.2.0 to 0.3.0 to maintain consistency for the upcoming release.