### PR TITLE
feat: add light/dark theme toggle to desktop app

### DIFF
--- a/apps/geolibre-desktop/src/App.tsx
+++ b/apps/geolibre-desktop/src/App.tsx
@@ -1,7 +1,15 @@
 import { DesktopShell } from "./components/layout/DesktopShell";
 import { usePlugins } from "./hooks/usePlugins";
+import { useThemeMode } from "./hooks/useThemeMode";
 
 export default function App() {
+  const { themeMode, toggleThemeMode } = useThemeMode();
+
   usePlugins();
-  return <DesktopShell />;
+  return (
+    <DesktopShell
+      themeMode={themeMode}
+      onToggleThemeMode={toggleThemeMode}
+    />
+  );
 }

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -7,13 +7,26 @@ import { StylePanel } from "../panels/StylePanel";
 import { ProcessingDialog } from "../processing/ProcessingDialog";
 import { StatusBar } from "./StatusBar";
 import { TopToolbar } from "./TopToolbar";
+import type { ThemeMode } from "../../hooks/useThemeMode";
 
-export function DesktopShell() {
+interface DesktopShellProps {
+  themeMode: ThemeMode;
+  onToggleThemeMode: () => void;
+}
+
+export function DesktopShell({
+  themeMode,
+  onToggleThemeMode,
+}: DesktopShellProps) {
   const mapControllerRef = useRef<MapController | null>(null);
 
   return (
     <div className="flex h-full flex-col bg-background">
-      <TopToolbar mapControllerRef={mapControllerRef} />
+      <TopToolbar
+        mapControllerRef={mapControllerRef}
+        themeMode={themeMode}
+        onToggleThemeMode={onToggleThemeMode}
+      />
       <div className="flex min-h-0 flex-1">
         <LayerPanel mapControllerRef={mapControllerRef} />
         <main className="relative min-w-0 flex-1">

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -25,13 +25,16 @@ import {
   FolderOpen,
   Layers,
   Map,
+  Moon,
   Puzzle,
   Save,
   SlidersHorizontal,
+  Sun,
   Wrench,
 } from "lucide-react";
 import { useState } from "react";
 import { createAppAPI, usePluginRegistry } from "../../hooks/usePlugins";
+import type { ThemeMode } from "../../hooks/useThemeMode";
 import {
   openGeoJsonFileWithFallback,
   openProjectFile,
@@ -41,6 +44,8 @@ import { NewProjectDialog } from "./NewProjectDialog";
 
 interface TopToolbarProps {
   mapControllerRef: React.RefObject<MapController | null>;
+  themeMode: ThemeMode;
+  onToggleThemeMode: () => void;
 }
 
 type ToolbarMapControl = Exclude<BuiltInMapControl, "layer-control">;
@@ -69,7 +74,11 @@ const PLUGIN_POSITION_ITEMS: Array<{
   { value: "bottom-right", label: "Bottom right" },
 ];
 
-export function TopToolbar({ mapControllerRef }: TopToolbarProps) {
+export function TopToolbar({
+  mapControllerRef,
+  themeMode,
+  onToggleThemeMode,
+}: TopToolbarProps) {
   const loadProject = useAppStore((s) => s.loadProject);
   const addGeoJsonLayer = useAppStore((s) => s.addGeoJsonLayer);
   const setProcessingOpen = useAppStore((s) => s.setProcessingOpen);
@@ -257,6 +266,24 @@ export function TopToolbar({ mapControllerRef }: TopToolbarProps) {
         </DropdownMenuContent>
       </DropdownMenu>
       <div className="ml-auto flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+        <Button
+          aria-label={
+            themeMode === "dark" ? "Switch to light mode" : "Switch to dark mode"
+          }
+          className="h-7 w-7 shrink-0"
+          onClick={onToggleThemeMode}
+          size="icon"
+          title={
+            themeMode === "dark" ? "Switch to light mode" : "Switch to dark mode"
+          }
+          variant="ghost"
+        >
+          {themeMode === "dark" ? (
+            <Sun className="h-3.5 w-3.5" />
+          ) : (
+            <Moon className="h-3.5 w-3.5" />
+          )}
+        </Button>
         <Layers className="mr-1 inline h-3 w-3" />
         <Input
           aria-label="Project name"

--- a/apps/geolibre-desktop/src/hooks/useThemeMode.ts
+++ b/apps/geolibre-desktop/src/hooks/useThemeMode.ts
@@ -1,0 +1,31 @@
+import { useCallback, useLayoutEffect, useState } from "react";
+
+export type ThemeMode = "light" | "dark";
+
+function getInitialThemeMode(): ThemeMode {
+  if (typeof window === "undefined") {
+    return "light";
+  }
+
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+export function useThemeMode() {
+  const [themeMode, setThemeMode] = useState<ThemeMode>(getInitialThemeMode);
+
+  useLayoutEffect(() => {
+    const isDark = themeMode === "dark";
+    document.documentElement.classList.toggle("dark", isDark);
+    document.documentElement.style.colorScheme = themeMode;
+  }, [themeMode]);
+
+  const toggleThemeMode = useCallback(() => {
+    setThemeMode((currentThemeMode) =>
+      currentThemeMode === "dark" ? "light" : "dark",
+    );
+  }, []);
+
+  return { themeMode, toggleThemeMode };
+}


### PR DESCRIPTION
## Summary
- Add a `useThemeMode` hook that initializes from the OS `prefers-color-scheme` preference and keeps the document `dark` class and `color-scheme` in sync.
- Wire the hook through `App` and `DesktopShell` to a new toolbar icon button that toggles between light and dark at runtime.

## Test plan
- [ ] Launch the desktop app and confirm it starts in the OS-preferred theme.
- [ ] Click the toolbar sun/moon button and verify the UI switches between light and dark.
- [ ] Confirm the toggle button label and icon update to reflect the current mode.