### PR TITLE
feat: add maplibre-gl-components control plugin to desktop app

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -12,7 +12,14 @@
     "tauri:build": "tauri build"
   },
   "dependencies": {
+    "@carbonplan/zarr-layer": "^0.3.1",
+    "@deck.gl/core": "^9.3.2",
+    "@deck.gl/layers": "^9.3.2",
+    "@deck.gl/mapbox": "^9.3.2",
+    "@developmentseed/deck.gl-geotiff": "^0.2.0",
+    "@developmentseed/deck.gl-raster": "^0.7.0",
     "@duckdb/duckdb-wasm": "^1.29.0",
+    "@dvt3d/maplibre-three-plugin": "^1.6.0",
     "@geolibre/core": "*",
     "@geolibre/map": "*",
     "@geolibre/plugins": "*",
@@ -23,16 +30,20 @@
     "@tauri-apps/plugin-dialog": "^2.2.0",
     "@tauri-apps/plugin-fs": "^2.2.0",
     "@tauri-apps/plugin-opener": "^2.5.4",
+    "jspdf": "^2.5.2",
     "mapillary-js": "^4.1.2",
-    "maplibre-gl": "^5.1.1",
+    "maplibre-gl": "^5.24.0",
     "maplibre-gl-basemap-control": "^0.2.1",
+    "maplibre-gl-components": "^0.16.3",
     "maplibre-gl-geo-editor": "^0.7.3",
     "maplibre-gl-geoagent": "^0.4.2",
     "maplibre-gl-lidar": "^0.14.1",
     "maplibre-gl-streetview": "^0.4.0",
     "maplibre-gl-swipe": "^0.7.1",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "shpjs": "^6.2.0",
+    "three": "^0.178.0"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.2.7",

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -1,6 +1,7 @@
 import { useAppStore } from "@geolibre/core";
 import {
   maplibreBasemapControlPlugin,
+  maplibreComponentsPlugin,
   maplibreGeoAgentPlugin,
   maplibreGeoEditorPlugin,
   maplibreLayerControlPlugin,
@@ -23,6 +24,7 @@ manager.registerAll([
   maplibreLidarPlugin,
   maplibreStreetViewPlugin,
   maplibreSwipePlugin,
+  maplibreComponentsPlugin,
 ]);
 
 export function getPluginManager(): PluginManager {

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -94,6 +94,35 @@ body,
   overflow: visible;
 }
 
+.geolibre-components-control {
+  padding: 10px !important;
+}
+
+.geolibre-components-control.maplibre-gl-control-grid--collapsed {
+  height: 29px;
+  padding: 0 !important;
+  width: 29px;
+}
+
+.geolibre-components-control.maplibre-gl-control-grid--collapsed
+  .maplibre-gl-control-grid-header,
+.geolibre-components-control.maplibre-gl-control-grid--collapsed
+  .maplibre-gl-control-grid-wrench {
+  height: 29px !important;
+  width: 29px !important;
+}
+
+.geolibre-components-control.maplibre-gl-control-grid--collapsed
+  .maplibre-gl-control-grid-wrench
+  svg {
+  height: 16px;
+  width: 16px;
+}
+
+.geolibre-components-control .maplibre-gl-control-grid-content > * {
+  margin: 4px !important;
+}
+
 .geolibre-components-control .maplibre-gl-control-grid-floating-panel {
   box-sizing: border-box;
   max-width: min(340px, calc(100vw - 32px));
@@ -161,7 +190,13 @@ body,
 
 .maplibregl-ctrl-top-left
   .geolibre-components-control
+  .left[class*="panel"],
+.maplibregl-ctrl-top-left
+  .geolibre-components-control
   .right[class*="panel"],
+.maplibregl-ctrl-bottom-left
+  .geolibre-components-control
+  .left[class*="panel"],
 .maplibregl-ctrl-bottom-left
   .geolibre-components-control
   .right[class*="panel"] {
@@ -172,9 +207,15 @@ body,
 .maplibregl-ctrl-top-right
   .geolibre-components-control
   .left[class*="panel"],
+.maplibregl-ctrl-top-right
+  .geolibre-components-control
+  .right[class*="panel"],
 .maplibregl-ctrl-bottom-right
   .geolibre-components-control
-  .left[class*="panel"] {
+  .left[class*="panel"],
+.maplibregl-ctrl-bottom-right
+  .geolibre-components-control
+  .right[class*="panel"] {
   left: auto !important;
   right: 0 !important;
 }

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -52,6 +52,257 @@ body,
   margin: 0;
 }
 
+.geolibre-components-control .maplibregl-ctrl-group,
+.geolibre-components-control .maplibregl-ctrl {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+}
+
+.geolibre-components-control .maplibre-gl-control-grid-content button {
+  align-items: center;
+  box-sizing: border-box;
+  display: flex !important;
+  justify-content: center;
+  line-height: 0;
+  padding: 0;
+}
+
+.geolibre-components-control .maplibre-gl-control-grid-content button > svg,
+.geolibre-components-control
+  .maplibre-gl-control-grid-content
+  .maplibregl-ctrl-icon {
+  display: block;
+  flex: 0 0 auto;
+  margin: 0 auto;
+}
+
+.geolibre-components-control
+  .maplibre-gl-control-grid-content
+  button
+  > span:not(.maplibregl-ctrl-icon) {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  margin: 0;
+  width: 100%;
+}
+
+.geolibre-components-control,
+.geolibre-components-control .maplibre-gl-control-grid {
+  overflow: visible;
+}
+
+.geolibre-components-control .maplibre-gl-control-grid-floating-panel {
+  box-sizing: border-box;
+  max-width: min(340px, calc(100vw - 32px));
+}
+
+.geolibre-components-control
+  .maplibre-gl-control-grid-floating-panel
+  > .maplibregl-ctrl {
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.geolibre-components-control
+  .maplibre-gl-control-grid-floating-panel
+  .maplibre-gl-search-input-wrapper {
+  gap: 6px !important;
+  padding-left: 6px !important;
+  padding-right: 6px !important;
+  width: 100% !important;
+}
+
+.geolibre-components-control
+  .maplibre-gl-control-grid-floating-panel
+  > .maplibre-gl-search {
+  display: block !important;
+  justify-content: normal !important;
+}
+
+.maplibregl-ctrl-top-left
+  .geolibre-components-control
+  .maplibre-gl-control-grid-floating-panel,
+.maplibregl-ctrl-bottom-left
+  .geolibre-components-control
+  .maplibre-gl-control-grid-floating-panel {
+  left: 0 !important;
+  max-width: 100% !important;
+  right: auto !important;
+  width: 100% !important;
+}
+
+.maplibregl-ctrl-top-right
+  .geolibre-components-control
+  .maplibre-gl-control-grid-floating-panel,
+.maplibregl-ctrl-bottom-right
+  .geolibre-components-control
+  .maplibre-gl-control-grid-floating-panel {
+  left: auto !important;
+  right: 0 !important;
+}
+
+.geolibre-components-control .maplibre-gl-control-grid-relocated {
+  box-sizing: border-box;
+  max-width: min(340px, calc(100vw - 32px)) !important;
+}
+
+.maplibregl-ctrl-top-left
+  .geolibre-components-control
+  .maplibre-gl-control-grid-relocated,
+.maplibregl-ctrl-bottom-left
+  .geolibre-components-control
+  .maplibre-gl-control-grid-relocated {
+  max-width: 100% !important;
+  width: 100% !important;
+}
+
+.maplibregl-ctrl-top-left
+  .geolibre-components-control
+  .right[class*="panel"],
+.maplibregl-ctrl-bottom-left
+  .geolibre-components-control
+  .right[class*="panel"] {
+  left: 0 !important;
+  right: auto !important;
+}
+
+.maplibregl-ctrl-top-right
+  .geolibre-components-control
+  .left[class*="panel"],
+.maplibregl-ctrl-bottom-right
+  .geolibre-components-control
+  .left[class*="panel"] {
+  left: auto !important;
+  right: 0 !important;
+}
+
+.geolibre-components-control input:not([type="checkbox"]):not([type="radio"]):not(
+    [type="range"]
+  ),
+.geolibre-components-control select,
+.geolibre-components-control textarea {
+  background-color: #fff !important;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  box-sizing: border-box;
+  color: #111827 !important;
+  color-scheme: light;
+}
+
+.geolibre-components-control input::placeholder,
+.geolibre-components-control textarea::placeholder {
+  color: #6b7280 !important;
+}
+
+.geolibre-components-control select option {
+  background-color: #fff;
+  color: #111827;
+}
+
+.geolibre-components-control input[type="radio"] {
+  appearance: none;
+  background-color: #fff;
+  border: 2px solid #6b7280;
+  border-radius: 50%;
+  color-scheme: light;
+  display: inline-grid;
+  flex: 0 0 auto;
+  height: 14px;
+  margin: 0;
+  opacity: 1;
+  place-content: center;
+  width: 14px;
+}
+
+.geolibre-components-control input[type="radio"]::before {
+  background-color: #0f766e;
+  border-radius: 50%;
+  content: "";
+  height: 6px;
+  transform: scale(0);
+  width: 6px;
+}
+
+.geolibre-components-control input[type="radio"]:checked {
+  border-color: #0f766e;
+}
+
+.geolibre-components-control input[type="radio"]:checked::before {
+  transform: scale(1);
+}
+
+.geolibre-components-control input[type="radio"]:focus-visible {
+  box-shadow: 0 0 0 2px rgba(15, 118, 110, 0.2);
+  outline: none;
+}
+
+.geolibre-components-control
+  .maplibre-gl-control-grid-header
+  input[type="number"] {
+  color-scheme: light;
+  font-size: 12px;
+  height: 22px;
+  line-height: 22px;
+  padding: 1px 0 1px 4px !important;
+  width: 44px !important;
+}
+
+.geolibre-components-control
+  .maplibre-gl-control-grid-header
+  input[type="number"]::-webkit-inner-spin-button,
+.geolibre-components-control
+  .maplibre-gl-control-grid-header
+  input[type="number"]::-webkit-outer-spin-button {
+  height: 20px;
+  margin: 0;
+  opacity: 1;
+  width: 18px;
+}
+
+.geolibre-components-control
+  .maplibre-gl-splat-panel
+  input[type="number"] {
+  font-size: 12px !important;
+  height: 32px;
+  line-height: 32px;
+  padding-bottom: 4px !important;
+  padding-right: 4px !important;
+  padding-top: 4px !important;
+}
+
+.geolibre-components-control
+  .maplibre-gl-splat-panel
+  input[type="number"]::-webkit-inner-spin-button,
+.geolibre-components-control
+  .maplibre-gl-splat-panel
+  input[type="number"]::-webkit-outer-spin-button {
+  height: 28px;
+  margin: 0;
+  opacity: 1;
+  width: 18px;
+}
+
+.geolibre-components-control .maplibre-gl-splat-panel > button {
+  align-items: center !important;
+  display: flex !important;
+  justify-content: center !important;
+  line-height: 1 !important;
+  min-height: 30px;
+}
+
+.geolibre-components-control input:not([type="checkbox"]):not([type="radio"]):not(
+    [type="range"]
+  ):focus,
+.geolibre-components-control select:focus,
+.geolibre-components-control textarea:focus {
+  border-color: #2f8f85;
+  box-shadow: 0 0 0 2px rgba(47, 143, 133, 0.16);
+  outline: none;
+}
+
 .maplibregl-ctrl button.maplibregl-ctrl-globe .maplibregl-ctrl-icon,
 .maplibregl-ctrl button.maplibregl-ctrl-globe-enabled .maplibregl-ctrl-icon {
   background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='22' fill='none' stroke='%2333b5e5' viewBox='0 0 22 22'%3E%3Ccircle cx='11' cy='11' r='8.5'/%3E%3Cpath d='M17.5 11c0 4.819-3.02 8.5-6.5 8.5S4.5 15.819 4.5 11 7.52 2.5 11 2.5s6.5 3.681 6.5 8.5Z'/%3E%3Cpath d='M13.5 11c0 2.447-.331 4.64-.853 6.206-.262.785-.562 1.384-.872 1.777-.314.399-.58.517-.775.517s-.461-.118-.775-.517c-.31-.393-.61-.992-.872-1.777C8.831 15.64 8.5 13.446 8.5 11s.331-4.64.853-6.206c.262-.785.562-1.384.872-1.777.314-.399.58-.517.775-.517s.461.118.775.517c.31.393.61.992.872 1.777.522 1.565.853 3.76.853 6.206Z'/%3E%3Cpath d='M11 7.5c-1.909 0-3.622-.166-4.845-.428-.616-.132-1.08-.283-1.379-.434a1.3 1.3 0 0 1-.224-.138q.07-.058.224-.138c.299-.151.763-.302 1.379-.434C7.378 5.666 9.091 5.5 11 5.5s3.622.166 4.845.428c.616.132 1.08.283 1.379.434.105.053.177.1.224.138q-.07.058-.224.138c-.299.151-.763.302-1.379.434-1.223.262-2.936.428-4.845.428ZM4.486 6.436ZM11 16.5c-1.909 0-3.622-.166-4.845-.428-.616-.132-1.08-.283-1.379-.434a1.3 1.3 0 0 1-.224-.138 1.3 1.3 0 0 1 .224-.138c.299-.151.763-.302 1.379-.434C7.378 14.666 9.091 14.5 11 14.5s3.622.166 4.845.428c.616.132 1.08.283 1.379.434.105.053.177.1.224.138a1.3 1.3 0 0 1-.224.138c-.299.151-.763.302-1.379.434-1.223.262-2.936.428-4.845.428Zm-6.514-1.064ZM11 12.5c-2.46 0-4.672-.222-6.255-.574-.796-.177-1.406-.38-1.805-.59a1.5 1.5 0 0 1-.39-.272.3.3 0 0 1-.047-.064.3.3 0 0 1 .048-.064c.066-.073.189-.167.389-.272.399-.21 1.009-.413 1.805-.59C6.328 9.722 8.54 9.5 11 9.5s4.672.222 6.256.574c.795.177 1.405.38 1.804.59.2.105.323.2.39.272a.3.3 0 0 1 .047.064.3.3 0 0 1-.048.064 1.4 1.4 0 0 1-.389.272c-.399.21-1.009.413-1.804.59-1.584.352-3.796.574-6.256.574Zm-8.501-1.51v.002zm0 .018v.002zm17.002.002v-.002zm0-.018v-.002z'/%3E%3C/svg%3E");

--- a/apps/geolibre-desktop/src/main.tsx
+++ b/apps/geolibre-desktop/src/main.tsx
@@ -4,6 +4,7 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 import "@geoman-io/maplibre-geoman-free/dist/maplibre-geoman.css";
 import "maplibre-gl-basemap-control/style.css";
+import "maplibre-gl-components/style.css";
 import "maplibre-gl-geo-editor/style.css";
 import "maplibre-gl-geoagent/style.css";
 import "maplibre-gl-streetview/style.css";

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,14 @@
     "apps/geolibre-desktop": {
       "version": "0.3.0",
       "dependencies": {
+        "@carbonplan/zarr-layer": "^0.3.1",
+        "@deck.gl/core": "^9.3.2",
+        "@deck.gl/layers": "^9.3.2",
+        "@deck.gl/mapbox": "^9.3.2",
+        "@developmentseed/deck.gl-geotiff": "^0.2.0",
+        "@developmentseed/deck.gl-raster": "^0.7.0",
         "@duckdb/duckdb-wasm": "^1.29.0",
+        "@dvt3d/maplibre-three-plugin": "^1.6.0",
         "@geolibre/core": "*",
         "@geolibre/map": "*",
         "@geolibre/plugins": "*",
@@ -29,16 +36,20 @@
         "@tauri-apps/plugin-dialog": "^2.2.0",
         "@tauri-apps/plugin-fs": "^2.2.0",
         "@tauri-apps/plugin-opener": "^2.5.4",
+        "jspdf": "^2.5.2",
         "mapillary-js": "^4.1.2",
-        "maplibre-gl": "^5.1.1",
+        "maplibre-gl": "^5.24.0",
         "maplibre-gl-basemap-control": "^0.2.1",
+        "maplibre-gl-components": "^0.16.3",
         "maplibre-gl-geo-editor": "^0.7.3",
         "maplibre-gl-geoagent": "^0.4.2",
         "maplibre-gl-lidar": "^0.14.1",
         "maplibre-gl-streetview": "^0.4.0",
         "maplibre-gl-swipe": "^0.7.1",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "shpjs": "^6.2.0",
+        "three": "^0.178.0"
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2.2.7",
@@ -53,6 +64,153 @@
         "typescript": "^5.7.3",
         "vite": "^6.0.11"
       }
+    },
+    "apps/geolibre-desktop/node_modules/@dvt3d/maplibre-three-plugin": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@dvt3d/maplibre-three-plugin/-/maplibre-three-plugin-1.6.0.tgz",
+      "integrity": "sha512-o8NXuWa+SUL/S5yxWVQHCAv471yiZauGoBnqGDBMVXy3RnWFPPaZ1TbYfeBieiCZO45HfK9uFkWvRC8OWS5LVA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "three": "^0.178.0"
+      }
+    },
+    "apps/geolibre-desktop/node_modules/maplibre-gl-components": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.16.3.tgz",
+      "integrity": "sha512-EGOrOATD+SvR1ggsAU1/y5IfEfMoUz4V0698kv+yvfq8vgq23lf8rB+MSdFxG0ZCpN2Dxsq6s69WRaJ/byJg5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "flatgeobuf": "^4.4.0",
+        "geotiff-geokeys-to-proj4": "^2024.4.13",
+        "maplibre-gl-geo-editor": "^0.7.3",
+        "maplibre-gl-layer-control": "^0.14.1",
+        "maplibre-gl-lidar": "^0.11.1",
+        "maplibre-gl-planetary-computer": "^0.2.2",
+        "maplibre-gl-splat": "^0.2.2",
+        "maplibre-gl-streetview": "^0.3.1",
+        "maplibre-gl-swipe": "^0.7.1",
+        "maplibre-gl-usgs-lidar": "^0.7.3",
+        "pmtiles": "^4.4.0"
+      },
+      "peerDependencies": {
+        "@carbonplan/zarr-layer": "^0.3.1",
+        "@deck.gl/core": "^9.2.6",
+        "@deck.gl/mapbox": "^9.2.6",
+        "@developmentseed/deck.gl-geotiff": "^0.2.0",
+        "@dvt3d/maplibre-three-plugin": "^1.3.0",
+        "jspdf": ">=2.5.0",
+        "maplibre-gl": ">=5.16.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0",
+        "three": "^0.178.0"
+      },
+      "peerDependenciesMeta": {
+        "@carbonplan/zarr-layer": {
+          "optional": true
+        },
+        "@deck.gl/core": {
+          "optional": true
+        },
+        "@deck.gl/mapbox": {
+          "optional": true
+        },
+        "@developmentseed/deck.gl-geotiff": {
+          "optional": true
+        },
+        "@dvt3d/maplibre-three-plugin": {
+          "optional": true
+        },
+        "jspdf": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "three": {
+          "optional": true
+        }
+      }
+    },
+    "apps/geolibre-desktop/node_modules/maplibre-gl-components/node_modules/maplibre-gl-lidar": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-lidar/-/maplibre-gl-lidar-0.11.1.tgz",
+      "integrity": "sha512-Z/4VdlZZu1KQ2q8OwAs9uNvHuhffh6JqP7nCiS4u/Zbk+oA1SRR3WOi2HsbvGzc/d41FfgS32BTVkI49CEBI4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@deck.gl/core": "^9.0.0",
+        "@deck.gl/extensions": "^9.0.0",
+        "@deck.gl/layers": "^9.0.0",
+        "@deck.gl/mapbox": "^9.0.0",
+        "@loaders.gl/core": "^4.3.4",
+        "@loaders.gl/las": "^4.3.4",
+        "@types/proj4": "^2.5.6",
+        "copc": "^0.0.8",
+        "maplibre-gl-layer-control": "^0.11.0",
+        "proj4": "^2.20.2"
+      },
+      "peerDependencies": {
+        "maplibre-gl": ">=3.0.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "apps/geolibre-desktop/node_modules/maplibre-gl-components/node_modules/maplibre-gl-lidar/node_modules/maplibre-gl-layer-control": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-layer-control/-/maplibre-gl-layer-control-0.11.0.tgz",
+      "integrity": "sha512-OFAIuAhc64rzBW5VGl2DZ8rmPb2sz3z/Dn04Yc8YQn+vyuIN5S0Cfp+ojPD1SMiXTm7W/BAfmfr/JQpwm+nerQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "maplibre-gl": ">=3.0.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "apps/geolibre-desktop/node_modules/maplibre-gl-components/node_modules/maplibre-gl-streetview": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-streetview/-/maplibre-gl-streetview-0.3.1.tgz",
+      "integrity": "sha512-4dp1aJ/lj6nAZwc4w1+UqgoBD65Zpxzo4580c9yIS3EWUp5BlqXFhckejFBqW/zZRGqZ06Fp3NfIrvTXPb94zg==",
+      "license": "MIT",
+      "dependencies": {
+        "mapillary-js": "^4.1.2"
+      },
+      "peerDependencies": {
+        "maplibre-gl": ">=3.0.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "apps/geolibre-desktop/node_modules/three": {
+      "version": "0.178.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.178.0.tgz",
+      "integrity": "sha512-ybFIB0+x8mz0wnZgSGy2MO/WCO6xZhQSZnmfytSPyNpM0sBafGRVhdaj+erYh5U+RhQOAg/eXqw5uVDiM2BjhQ==",
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -799,6 +957,68 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@carbonplan/zarr-layer": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@carbonplan/zarr-layer/-/zarr-layer-0.3.1.tgz",
+      "integrity": "sha512-lXca1C+s+/lmB81uoPxj0uf72A0lavU/k28lpTskdt5SPWH0ALjy3qzsWR0F/eGP0Me/wgMdPto9B7YuJl1fEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@developmentseed/raster-reproject": "^0.1.0",
+        "delaunator": "^5.0.1",
+        "proj4": "^2.20.2",
+        "zarrita": "^0.5.4"
+      },
+      "peerDependencies": {
+        "mapbox-gl": "*",
+        "maplibre-gl": "*"
+      },
+      "peerDependenciesMeta": {
+        "mapbox-gl": {
+          "optional": true
+        },
+        "maplibre-gl": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@carbonplan/zarr-layer/node_modules/@developmentseed/raster-reproject": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@developmentseed/raster-reproject/-/raster-reproject-0.1.0.tgz",
+      "integrity": "sha512-ARk8IM6VPzL3ltAZNenZCAm9NkzqOnrxjEvf8m2t91bmkmloDPBkRCMxMzKrMJE79/XxcZyXDDvLOI1UKlYSBQ==",
+      "license": "MIT"
+    },
+    "node_modules/@carbonplan/zarr-layer/node_modules/@zarrita/storage": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.1.4.tgz",
+      "integrity": "sha512-qURfJAQcQGRfDQ4J9HaCjGaj3jlJKc66bnRk6G/IeLUsM7WKyG7Bzsuf1EZurSXyc0I4LVcu6HaeQQ4d3kZ16g==",
+      "license": "MIT",
+      "dependencies": {
+        "reference-spec-reader": "^0.2.0",
+        "unzipit": "1.4.3"
+      }
+    },
+    "node_modules/@carbonplan/zarr-layer/node_modules/unzipit": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unzipit/-/unzipit-1.4.3.tgz",
+      "integrity": "sha512-gsq2PdJIWWGhx5kcdWStvNWit9FVdTewm4SEG7gFskWs+XCVaULt9+BwuoBtJiRE8eo3L1IPAOrbByNLtLtIlg==",
+      "license": "MIT",
+      "dependencies": {
+        "uzip-module": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@carbonplan/zarr-layer/node_modules/zarrita": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.5.4.tgz",
+      "integrity": "sha512-i88iN2+HqIQ+uiCEWLfhjbYNXAJD7IrM4h3lFwFclfqEOOhxp10amRWtqmgN5jbuy3+h0LwdyLVVzk4y9rTLgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@zarrita/storage": "^0.1.3",
+        "numcodecs": "^0.3.2"
+      }
+    },
     "node_modules/@deck.gl/core": {
       "version": "9.3.2",
       "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-9.3.2.tgz",
@@ -837,6 +1057,51 @@
         "@deck.gl/core": "~9.3.0",
         "@luma.gl/core": "~9.3.3",
         "@luma.gl/engine": "~9.3.3"
+      }
+    },
+    "node_modules/@deck.gl/geo-layers": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-9.3.2.tgz",
+      "integrity": "sha512-3sndOyq5A3b2DMCBWFCeX9/QkBSp5MD8EUD3eu4hHfCDV4IrbJHtxE/pv60J848Yz8D5u7ftUqXf9gLWnEeBeg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@loaders.gl/3d-tiles": "^4.4.1",
+        "@loaders.gl/gis": "^4.4.1",
+        "@loaders.gl/loader-utils": "^4.4.1",
+        "@loaders.gl/mvt": "^4.4.1",
+        "@loaders.gl/schema": "^4.4.1",
+        "@loaders.gl/terrain": "^4.4.1",
+        "@loaders.gl/tiles": "^4.4.1",
+        "@loaders.gl/wms": "^4.4.1",
+        "@luma.gl/gltf": "^9.3.3",
+        "@luma.gl/shadertools": "^9.3.3",
+        "@math.gl/core": "^4.1.0",
+        "@math.gl/culling": "^4.1.0",
+        "@math.gl/web-mercator": "^4.1.0",
+        "@types/geojson": "^7946.0.8",
+        "a5-js": "^0.7.2",
+        "h3-js": "^4.4.0",
+        "long": "^3.2.0"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "~9.3.0",
+        "@deck.gl/extensions": "~9.3.0",
+        "@deck.gl/layers": "~9.3.0",
+        "@deck.gl/mesh-layers": "~9.3.0",
+        "@loaders.gl/core": "^4.4.1",
+        "@luma.gl/core": "~9.3.3",
+        "@luma.gl/engine": "~9.3.3"
+      }
+    },
+    "node_modules/@deck.gl/geo-layers/node_modules/long": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
+      "integrity": "sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/@deck.gl/layers": {
@@ -880,6 +1145,151 @@
         "@luma.gl/core": "~9.3.3",
         "@math.gl/web-mercator": "^4.1.0"
       }
+    },
+    "node_modules/@deck.gl/mesh-layers": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-9.3.2.tgz",
+      "integrity": "sha512-9KeEnEx8PYalFPq/jSb1983QtjwZeuz64OfHH8I2VOB3eOhtRDxaTAaelbkVkD3E9HqlU2dD6f9huYsuv1WZfw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@loaders.gl/gltf": "^4.4.1",
+        "@loaders.gl/schema": "^4.4.1",
+        "@luma.gl/gltf": "^9.3.3",
+        "@luma.gl/shadertools": "^9.3.3"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "~9.3.0",
+        "@luma.gl/core": "~9.3.3",
+        "@luma.gl/engine": "~9.3.3",
+        "@luma.gl/gltf": "~9.3.3",
+        "@luma.gl/shadertools": "~9.3.3"
+      }
+    },
+    "node_modules/@developmentseed/affine": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@developmentseed/affine/-/affine-0.7.0.tgz",
+      "integrity": "sha512-O00T3nLFY8DiEqTIpKzEDc6wyVLth4DoFc0gPE6EiaEdFM4lQsQnH8x5mrknDB7jeLyKW2aPnNyBxoPqS7JKHA==",
+      "license": "MIT"
+    },
+    "node_modules/@developmentseed/deck.gl-geotiff": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@developmentseed/deck.gl-geotiff/-/deck.gl-geotiff-0.2.0.tgz",
+      "integrity": "sha512-X44JtDP7SjOhKGC/ynkTsdphURE87v4rKVcf81DzPxE7rnPZmEtidQFBYsyqYV+aVYFvfvQfX4CZgnDnZV54dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@developmentseed/deck.gl-raster": "^0.2.0",
+        "@developmentseed/raster-reproject": "^0.2.0",
+        "flatbush": "^4.5.0",
+        "geotiff": "2.1.3",
+        "proj4": "^2.20.2"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "^9.2.6",
+        "@deck.gl/geo-layers": "^9.2.6",
+        "@deck.gl/layers": "^9.2.6",
+        "@deck.gl/mesh-layers": "^9.2.6",
+        "@luma.gl/core": "^9.2.6"
+      }
+    },
+    "node_modules/@developmentseed/deck.gl-geotiff/node_modules/@developmentseed/deck.gl-raster": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@developmentseed/deck.gl-raster/-/deck.gl-raster-0.2.0.tgz",
+      "integrity": "sha512-+D2me1CR5BDyYPjXL6cZsG5r8BAa+KgDftErRZikY1hBqiFOdWi4iwm2oJNxdVc+YpaPOLc54o9CXTvSD48VaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@developmentseed/raster-reproject": "^0.2.0",
+        "@math.gl/core": "^4.1.0",
+        "@math.gl/culling": "^4.1.0",
+        "@math.gl/web-mercator": "^4.1.0"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "^9.2.6",
+        "@deck.gl/geo-layers": "^9.2.6",
+        "@deck.gl/layers": "^9.2.6",
+        "@deck.gl/mesh-layers": "^9.2.6",
+        "@luma.gl/core": "^9.2.6",
+        "@luma.gl/shadertools": "^9.2.6"
+      }
+    },
+    "node_modules/@developmentseed/deck.gl-geotiff/node_modules/@developmentseed/raster-reproject": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@developmentseed/raster-reproject/-/raster-reproject-0.2.0.tgz",
+      "integrity": "sha512-jr8UeDLFqTsqxMcJwe+iOabBi5LpPL9ZKCXVwXdLDk2gvTs8T8WY0PtR8gMfeUFFECzFSuKFlslh1nbuK5eAzA==",
+      "license": "MIT"
+    },
+    "node_modules/@developmentseed/deck.gl-geotiff/node_modules/geotiff": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.3.tgz",
+      "integrity": "sha512-PT6uoF5a1+kbC3tHmZSUsLHBp2QJlHasxxxxPW47QIY1VBKpFB+FcDvX+MxER6UzgLQZ0xDzJ9s48B9JbOCTqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@petamoriken/float16": "^3.4.7",
+        "lerc": "^3.0.0",
+        "pako": "^2.0.4",
+        "parse-headers": "^2.0.2",
+        "quick-lru": "^6.1.1",
+        "web-worker": "^1.2.0",
+        "xml-utils": "^1.0.2",
+        "zstddec": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10.19"
+      }
+    },
+    "node_modules/@developmentseed/deck.gl-geotiff/node_modules/zstddec": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
+      "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg==",
+      "license": "MIT AND BSD-3-Clause"
+    },
+    "node_modules/@developmentseed/deck.gl-raster": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@developmentseed/deck.gl-raster/-/deck.gl-raster-0.7.0.tgz",
+      "integrity": "sha512-I9X81fus7r9MoOZUwMj6GAR24diPGlMT2ep3N5vQOnmfntT+kGSLYX1EEkO6jwKBO0roOMrqb/8U2JkPhtT/gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@developmentseed/affine": "^0.7.0",
+        "@developmentseed/proj": "^0.7.0",
+        "@developmentseed/raster-reproject": "^0.7.0",
+        "@math.gl/core": "^4.1.0",
+        "@math.gl/culling": "^4.1.0",
+        "@math.gl/web-mercator": "^4.1.0"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "^9.3.0",
+        "@deck.gl/geo-layers": "^9.3.0",
+        "@deck.gl/layers": "^9.3.0",
+        "@deck.gl/mesh-layers": "^9.3.0",
+        "@developmentseed/morecantile": "^0.7.0",
+        "@luma.gl/core": "^9.3.2",
+        "@luma.gl/shadertools": "^9.3.2"
+      }
+    },
+    "node_modules/@developmentseed/morecantile": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@developmentseed/morecantile/-/morecantile-0.7.0.tgz",
+      "integrity": "sha512-m9tWDase9COlP/EZ2KK/ydraRU/5yfwvmF/y/2g/iFMFW1vYHQTW/8JYjmo84SiJXUifDDY2xoA3ErYlcWJctg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@developmentseed/affine": "^0.7.0"
+      }
+    },
+    "node_modules/@developmentseed/proj": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@developmentseed/proj/-/proj-0.7.0.tgz",
+      "integrity": "sha512-3EPvX29sM3iCn+avpGKz18ZzlRJdn53SbkmFWJXDWh/fNreP3RjcDJGBbvfwnZnVtiLUqnTzM8V4fLKnYHKj0A==",
+      "license": "MIT",
+      "dependencies": {
+        "wkt-parser": "1.5.5"
+      }
+    },
+    "node_modules/@developmentseed/raster-reproject": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@developmentseed/raster-reproject/-/raster-reproject-0.7.0.tgz",
+      "integrity": "sha512-2tZzANK0nZIV3Y5E2qYhbNtdjN04LKQYECPZsGii1r5ylGySoKjh3oJzVBCKfRq/PTEZTtVol0r7krmT6Ry8fQ==",
+      "license": "MIT"
     },
     "node_modules/@duckdb/duckdb-wasm": {
       "version": "1.32.0",
@@ -1532,6 +1942,63 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@loaders.gl/3d-tiles": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/3d-tiles/-/3d-tiles-4.4.2.tgz",
+      "integrity": "sha512-rf2R7x/+t41hQpaQ3iKofooE6unZ0+sGlYUXBo7lYFEnoMmalzrOI6jCs+CV96TALMPQcpfPa566XWF74XkaBQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@loaders.gl/compression": "4.4.2",
+        "@loaders.gl/crypto": "4.4.2",
+        "@loaders.gl/draco": "4.4.2",
+        "@loaders.gl/gltf": "4.4.2",
+        "@loaders.gl/images": "4.4.2",
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/math": "4.4.2",
+        "@loaders.gl/tiles": "4.4.2",
+        "@loaders.gl/zip": "4.4.2",
+        "@math.gl/core": "^4.1.0",
+        "@math.gl/culling": "^4.1.0",
+        "@math.gl/geospatial": "^4.1.0",
+        "@probe.gl/log": "^4.1.1",
+        "long": "^5.2.1"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/compression": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/compression/-/compression-4.4.2.tgz",
+      "integrity": "sha512-/LzblCXn6wOg7ca2zkUOTO0zhjjaPAOqlLp4/kwd57v7KZU8M8aKUNlU1DAuWKW9p/+TpGsLKwDqOCO+hjrOnQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/worker-utils": "4.4.2",
+        "@types/pako": "^1.0.1",
+        "fflate": "0.7.4",
+        "pako": "1.0.11",
+        "snappyjs": "^0.6.1"
+      },
+      "optionalDependencies": {
+        "@types/brotli": "^1.3.0",
+        "brotli": "^1.3.2",
+        "lz4js": "^0.2.0",
+        "zstd-codec": "^0.1"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/compression/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)",
+      "peer": true
+    },
     "node_modules/@loaders.gl/core": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-4.4.2.tgz",
@@ -1543,6 +2010,120 @@
         "@loaders.gl/schema-utils": "4.4.2",
         "@loaders.gl/worker-utils": "4.4.2",
         "@probe.gl/log": "^4.1.1"
+      }
+    },
+    "node_modules/@loaders.gl/crypto": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/crypto/-/crypto-4.4.2.tgz",
+      "integrity": "sha512-3QQxNFmCeznMIsY/ZD4pYO4SvS4i3nq5aJJ993DEIZVB1i0z19OmyJu4TSovvirXXrNWPQRJFPUUwdPxol9wLA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/worker-utils": "4.4.2",
+        "@types/crypto-js": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/draco": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/draco/-/draco-4.4.2.tgz",
+      "integrity": "sha512-UByWIt/yhxMFBIlyoqJYaj0rnTz/wwDWbI4CVQc/MzbLZW7NtUkDyYDcjbjE2SBWpu6Ef4ryojGd/NWIA3Yknw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/schema-utils": "4.4.2",
+        "@loaders.gl/worker-utils": "4.4.2",
+        "draco3d": "1.5.7"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/geoarrow": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/geoarrow/-/geoarrow-4.4.2.tgz",
+      "integrity": "sha512-FGCtUsvTwdxiNqS8cEtys1FdM/m6pwMzvNEa32sHfrI4Si465Oa2iJkyu2q/XMgL/vhfE/G3EezpVKZARbCzkw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@math.gl/polygon": "^4.1.0",
+        "apache-arrow": ">= 17.0.0"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/gis": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gis/-/gis-4.4.2.tgz",
+      "integrity": "sha512-VMs1XcqUCqLczfySsI9VA/L3WDuuNRPqVoHcXU3FZuSe49x++gtwmxF1TEhJCaQINk0CkCOnxBbKOz3I9M1e3w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@loaders.gl/geoarrow": "4.4.2",
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/schema-utils": "4.4.2",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@math.gl/polygon": "^4.1.0",
+        "pbf": "^3.2.1"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/gis/node_modules/@mapbox/point-geometry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/@loaders.gl/gis/node_modules/@mapbox/vector-tile": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
+      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@mapbox/point-geometry": "~0.1.0"
+      }
+    },
+    "node_modules/@loaders.gl/gis/node_modules/pbf": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
+      "integrity": "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
+    "node_modules/@loaders.gl/gltf": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gltf/-/gltf-4.4.2.tgz",
+      "integrity": "sha512-aBvI7P/1GxePdHIvuyTM4A8yt3F5ph4dq0mkyJHmEjBl1Cwh3mDZJI1JSlZAFVilTZ6NxJZOiHUYWe1pBloVvw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@loaders.gl/draco": "4.4.2",
+        "@loaders.gl/images": "4.4.2",
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/textures": "4.4.2",
+        "@math.gl/core": "^4.1.0"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
       }
     },
     "node_modules/@loaders.gl/images": {
@@ -1584,6 +2165,52 @@
         "@probe.gl/stats": "^4.1.1"
       }
     },
+    "node_modules/@loaders.gl/math": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/math/-/math-4.4.2.tgz",
+      "integrity": "sha512-Pcm1DKrzH3EqC5PkBxQX0oVjmXM3RIm2Gfj0cXQoqly+8c/NBtQrcBA9tl12h2ozZe8Ednue/kockbGsyKAx5A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@math.gl/core": "^4.1.0"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/mvt": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/mvt/-/mvt-4.4.2.tgz",
+      "integrity": "sha512-yji3TAUofTA3GXvvyemwfrRwbd1ILpv2qe4mRduHdzjJdy2httH1cCKkesavFuLeRQqEuVyhhxYK+aSAbdt9Kg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@loaders.gl/gis": "4.4.2",
+        "@loaders.gl/images": "4.4.2",
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/schema": "4.4.2",
+        "@math.gl/polygon": "^4.1.0",
+        "@probe.gl/stats": "^4.1.1",
+        "pbf": "^3.2.1"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/mvt/node_modules/pbf": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
+      "integrity": "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
     "node_modules/@loaders.gl/schema": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.4.2.tgz",
@@ -1608,11 +2235,177 @@
         "@loaders.gl/core": "~4.4.0"
       }
     },
+    "node_modules/@loaders.gl/terrain": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/terrain/-/terrain-4.4.2.tgz",
+      "integrity": "sha512-ScE90mhUrIOOf+248+G8bxgg5xfLptE94gVxtYsLysyG8b4Ne2WEb6J2gpvQqmaLz3k9OqgPR7M8F1zI5BVO0w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@loaders.gl/images": "4.4.2",
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/schema": "4.4.2",
+        "@mapbox/martini": "^0.2.0"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/textures": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/textures/-/textures-4.4.2.tgz",
+      "integrity": "sha512-+GKcHEE0GjpuSJ6qbuRsB0CaOSUhJ1epUvhMP5GVK7I6+bwSvG8nqmRRGXFQNmYsbFANwG+wjwKf16wqJwP6vg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@loaders.gl/images": "4.4.2",
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/worker-utils": "4.4.2",
+        "@math.gl/types": "^4.1.0",
+        "ktx-parse": "^0.7.0",
+        "texture-compressor": "^1.0.2"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/tiles": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/tiles/-/tiles-4.4.2.tgz",
+      "integrity": "sha512-DHqMC38e6IEzWEDc15GfIKsZT82VZH7ocF79xLRScey0eZfCb3qI5nDLeg5adSBBsHkG3Li0S0PEnwxQmKT3qw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/math": "4.4.2",
+        "@math.gl/core": "^4.1.0",
+        "@math.gl/culling": "^4.1.0",
+        "@math.gl/geospatial": "^4.1.0",
+        "@math.gl/web-mercator": "^4.1.0",
+        "@probe.gl/stats": "^4.1.1"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/wms": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/wms/-/wms-4.4.2.tgz",
+      "integrity": "sha512-7uhis6fOTHeqRLIU1EPoC1oqeXVk5p1pM136fSqMw0CbVSNj87b0FFMwlJwzwTfL8Vte8GyKrNcDa47PjaT19Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@loaders.gl/images": "4.4.2",
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/schema": "4.4.2",
+        "@loaders.gl/xml": "4.4.2",
+        "@turf/rewind": "^5.1.5",
+        "deep-strict-equal": "^0.2.0"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/wms/node_modules/@turf/boolean-clockwise": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
+      "integrity": "sha512-FqbmEEOJ4rU4/2t7FKx0HUWmjFEVqR+NJrFP7ymGSjja2SQ7Q91nnBihGuT+yuHHl6ElMjQ3ttsB/eTmyCycxA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5"
+      }
+    },
+    "node_modules/@loaders.gl/wms/node_modules/@turf/clone": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
+      "integrity": "sha512-//pITsQ8xUdcQ9pVb4JqXiSqG4dos5Q9N4sYFoWghX21tfOV2dhc5TGqYOhnHrQS7RiKQL1vQ48kIK34gQ5oRg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@loaders.gl/wms/node_modules/@turf/helpers": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
+      "integrity": "sha512-/lF+JR+qNDHZ8bF9d+Cp58nxtZWJ3sqFe6n3u3Vpj+/0cqkjk4nXKYBSY0azm+GIYB5mWKxUXvuP/m0ZnKj1bw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@loaders.gl/wms/node_modules/@turf/invariant": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.2.0.tgz",
+      "integrity": "sha512-28RCBGvCYsajVkw2EydpzLdcYyhSA77LovuOvgCJplJWaNVyJYH6BOR3HR9w50MEkPqb/Vc/jdo6I6ermlRtQA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@loaders.gl/wms/node_modules/@turf/meta": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.2.0.tgz",
+      "integrity": "sha512-ZjQ3Ii62X9FjnK4hhdsbT+64AYRpaI8XMBMcyftEOGSmPMUVnkbvuv3C9geuElAXfQU7Zk1oWGOcrGOD9zr78Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@turf/helpers": "^5.1.5"
+      }
+    },
+    "node_modules/@loaders.gl/wms/node_modules/@turf/rewind": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-5.1.5.tgz",
+      "integrity": "sha512-Gdem7JXNu+G4hMllQHXRFRihJl3+pNl7qY+l4qhQFxq+hiU1cQoVFnyoleIqWKIrdK/i2YubaSwc3SCM7N5mMw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@turf/boolean-clockwise": "^5.1.5",
+        "@turf/clone": "^5.1.5",
+        "@turf/helpers": "^5.1.5",
+        "@turf/invariant": "^5.1.5",
+        "@turf/meta": "^5.1.5"
+      }
+    },
     "node_modules/@loaders.gl/worker-utils": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.4.2.tgz",
       "integrity": "sha512-oiZ0SoC1QKrOkhYPlVZ6Q06CtmuFRyZw2rwzmT08ZyaGtOArIJHDjlhxzwWiv+6fdws47Ub5uIGsdI1Ab1xYsA==",
       "license": "MIT",
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/xml": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/xml/-/xml-4.4.2.tgz",
+      "integrity": "sha512-OOPqpYH1PK9szuzXh3Oy7aErMXTXB+aiKi79LPCI93Wsb8pdbQiDiRRW8X/op9qABhxpCAMXF5N89eDJv3XdtQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@loaders.gl/loader-utils": "4.4.2",
+        "@loaders.gl/schema": "4.4.2",
+        "fast-xml-parser": "^5.3.6"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "~4.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/zip": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/zip/-/zip-4.4.2.tgz",
+      "integrity": "sha512-KdgmJRNra9+9jt2zzHUvFXnBqwzeN7dW4MEgTmH/NtraGy8bz5Tk5NrIUj8JXPxhx+vP2vxUWbeCEUoLGO/m9A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@loaders.gl/compression": "4.4.2",
+        "@loaders.gl/crypto": "4.4.2",
+        "@loaders.gl/loader-utils": "4.4.2",
+        "jszip": "^3.1.5",
+        "md5": "^2.3.0"
+      },
       "peerDependencies": {
         "@loaders.gl/core": "~4.4.0"
       }
@@ -1643,6 +2436,24 @@
       },
       "peerDependencies": {
         "@luma.gl/core": "~9.3.0",
+        "@luma.gl/shadertools": "~9.3.0"
+      }
+    },
+    "node_modules/@luma.gl/gltf": {
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/@luma.gl/gltf/-/gltf-9.3.3.tgz",
+      "integrity": "sha512-/wty4PHYeQelXvDJesyuMdqtAfpL1XcyEQffcEAwKwu9w7JdkygSShdUwTT1iF7no0uGKuWgq824dVC9WBBQcw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@loaders.gl/core": "~4.4.0",
+        "@loaders.gl/gltf": "~4.4.0",
+        "@loaders.gl/textures": "~4.4.0",
+        "@math.gl/core": "^4.1.0"
+      },
+      "peerDependencies": {
+        "@luma.gl/core": "~9.3.0",
+        "@luma.gl/engine": "~9.3.0",
         "@luma.gl/shadertools": "~9.3.0"
       }
     },
@@ -1679,6 +2490,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/@mapbox/martini": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/martini/-/martini-0.2.0.tgz",
+      "integrity": "sha512-7hFhtkb0KTLEls+TRw/rWayq5EeHtTaErgm/NskVoXmtgAQu/9D299aeyj6mzAR/6XUnYRp2lU+4IcrYRFjVsQ==",
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/@mapbox/point-geometry": {
       "version": "1.1.0",
@@ -1782,6 +2600,27 @@
       "integrity": "sha512-FrdHBCVG3QdrworwrUSzXIaK+/9OCRLscxI2OUy6sLOHyHgBMyfnEGs99/m3KNvs+95BsnQLWklVfpKfQzfwKA==",
       "license": "MIT",
       "dependencies": {
+        "@math.gl/types": "4.1.0"
+      }
+    },
+    "node_modules/@math.gl/culling": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@math.gl/culling/-/culling-4.1.0.tgz",
+      "integrity": "sha512-jFmjFEACnP9kVl8qhZxFNhCyd47qPfSVmSvvjR0/dIL6R9oD5zhR1ub2gN16eKDO/UM7JF9OHKU3EBIfeR7gtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@math.gl/core": "4.1.0",
+        "@math.gl/types": "4.1.0"
+      }
+    },
+    "node_modules/@math.gl/geospatial": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@math.gl/geospatial/-/geospatial-4.1.0.tgz",
+      "integrity": "sha512-BzsUhpVvnmleyYF6qdqJIip6FtIzJmnWuPTGhlBuPzh7VBHLonCFSPtQpbkRuoyAlbSyaGXcVt6p6lm9eK2vtg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@math.gl/core": "4.1.0",
         "@math.gl/types": "4.1.0"
       }
     },
@@ -1915,6 +2754,12 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/@petamoriken/float16": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.3.tgz",
+      "integrity": "sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==",
+      "license": "MIT"
     },
     "node_modules/@probe.gl/env": {
       "version": "4.1.1",
@@ -2923,6 +3768,12 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@repeaterjs/repeater": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.6.tgz",
+      "integrity": "sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -3438,6 +4289,21 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@sparkjsdev/spark": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@sparkjsdev/spark/-/spark-0.1.10.tgz",
+      "integrity": "sha512-CiijdZQuj7KPDUqIZPiEqyUkJCYo1JqR05vq/V+ElxMwqR7L70ZuZDyIKcasjZHSiPB8pGRMH8HZGqUKO9aRPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.8.2"
+      }
+    },
+    "node_modules/@sparkjsdev/spark/node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/@strands-agents/sdk": {
       "version": "1.3.0",
@@ -5924,6 +6790,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/brotli": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/brotli/-/brotli-1.3.5.tgz",
+      "integrity": "sha512-9xoNr+bcxT236/7ZgcWw/6Pb2RRetE13p4bFy1xYSckKwyOiRfmInay8baUWZgH7/284Wl6IPe7+nOI9+OQg/A==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/command-line-args": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
@@ -5935,6 +6812,13 @@
       "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
       "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
       "license": "MIT"
+    },
+    "node_modules/@types/crypto-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.2.2.tgz",
+      "integrity": "sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/d3-voronoi": {
       "version": "1.1.12",
@@ -6006,12 +6890,25 @@
       "integrity": "sha512-9Zw2KoDpi+T4PZz2G6pO2xArE0m/GSMTW1MIxF2s8ZY8x9XDO6fv9um0ydRGvcbkFLlaq8yNK6eZxnmMZtDgWQ==",
       "license": "MIT"
     },
+    "node_modules/@types/proj4": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@types/proj4/-/proj4-2.5.6.tgz",
+      "integrity": "sha512-zfMrPy9fx+8DchqM0kIUGeu2tTVB5ApO1KGAYcSGFS8GoqRIkyL41xq2yCx/iV3sOLzo7v4hEgViSLTiPI1L0w==",
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/rbush": {
       "version": "3.0.4",
@@ -6093,6 +6990,27 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@zarrita/storage": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.2.0.tgz",
+      "integrity": "sha512-855ZXqtnds7spnT8vNvD+MXa3QExP1m2GqShe8yt7uZXHnQLgJHgkpVwFjE1B0KDDRO0ki09hmk6OboTaIfPsQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "reference-spec-reader": "^0.2.0",
+        "unzipit": "2.0.0"
+      }
+    },
+    "node_modules/a5-js": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/a5-js/-/a5-js-0.7.3.tgz",
+      "integrity": "sha512-3aoMwHmNkyuMDHS4q6GRRInpOawamen2pokIbc0MQmR9cqG0Y9+B0bZpzswwetjrSG2ckbYtShH+nKru6+3O5Q==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "gl-matrix": "^3.4.3"
       }
     },
     "node_modules/abort-controller": {
@@ -6236,6 +7154,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
@@ -6264,6 +7192,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
       }
     },
     "node_modules/autoprefixer": {
@@ -6301,6 +7241,16 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/base64-js": {
@@ -6402,6 +7352,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
     "node_modules/browser-split": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/browser-split/-/browser-split-0.0.1.tgz",
@@ -6442,11 +7403,39 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/buf-compare": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buf-compare/-/buf-compare-1.0.1.tgz",
+      "integrity": "sha512-Bvx4xH00qweepGc43xFvMs5BKASXTbHaHm6+kDYIK9p/4iFwjATQkmPKHQSgJZzKbAymhztRbXUf1Nqhzl73/Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/but-unzip": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/but-unzip/-/but-unzip-0.1.10.tgz",
+      "integrity": "sha512-hLfQ9WlUimmv/okzsRl6AYG3Ew5HNWhWgUslSR93FsDdeL0MAoQvmC/BJfs35lqEAO5t/QD7Y4vCFcPJtijt3A==",
+      "license": "Apache-2.0"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -6527,6 +7516,26 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -6556,6 +7565,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/chokidar": {
@@ -6778,6 +7797,39 @@
       "integrity": "sha512-2xRqm/f/2UqDS5qqkjOyDb6uVIjkVw6SGmQlMoTQliVWkZhPfIbUJTubUl3mTloaWqKcjlS/urmP1CYoxelsEg==",
       "license": "Apache-2.0"
     },
+    "node_modules/core-assert": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/core-assert/-/core-assert-0.2.1.tgz",
+      "integrity": "sha512-IG97qShIP+nrJCXMCgkNZgH7jZQ4n8RpPyPeXX++T6avR/KhLhgLiHKoEn5Rc1KjfycSfA9DMa6m+4C4eguHhw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buf-compare": "^1.0.0",
+        "is-error": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -6838,6 +7890,26 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/cssesc": {
@@ -6907,6 +7979,34 @@
         }
       }
     },
+    "node_modules/deep-strict-equal": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/deep-strict-equal/-/deep-strict-equal-0.2.0.tgz",
+      "integrity": "sha512-3daSWyvZ/zwJvuMGlzG1O+Ow0YSadGfb3jsh9xoCutv2tWyB9dA4YvR9L9/fSdDZa2dByYQe+TqapSGUrjnkoA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "core-assert": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/delaunator/node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -6950,6 +8050,13 @@
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -7351,6 +8458,13 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -7403,6 +8517,41 @@
       "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-24.12.23.tgz",
       "integrity": "sha512-dLVCAISd5mhls514keQzmEG6QHmUUsNuWsb4tFafIUwvvgDjXhtfAYSKOzt5SWOy+qByV5pbsDZ+Vb7HUOBEdA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/flatbush": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/flatbush/-/flatbush-4.5.1.tgz",
+      "integrity": "sha512-5tpuZV/26A5gRYfqyof3/ZTWeARKgZgd9aBrJLGNSGeasdO2PRb/2lIwDHBIuvPhKK2Y4ELuHbRGtegOwH3Lqg==",
+      "license": "ISC",
+      "dependencies": {
+        "flatqueue": "^3.0.0"
+      }
+    },
+    "node_modules/flatgeobuf": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/flatgeobuf/-/flatgeobuf-4.4.0.tgz",
+      "integrity": "sha512-uUt1xxywP+q8K73MmyKtapF4++dMCzvoqH+ojBTsCtZBbnQEg5qy0Ujze61Rwmpmt6Ra526jpRFHtEkFun5YVw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@repeaterjs/repeater": "3.0.6",
+        "flatbuffers": "25.9.23",
+        "slice-source": "0.4.1"
+      },
+      "optionalDependencies": {
+        "ol": ">=10"
+      }
+    },
+    "node_modules/flatgeobuf/node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/flatqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/flatqueue/-/flatqueue-3.0.0.tgz",
+      "integrity": "sha512-y1deYaVt+lIc/d2uIcWDNd0CrdQTO5xoCjeFdhX0kSXvm2Acm0o+3bAOiYklTEoRyzwio3sv3/IiBZdusbAe2Q==",
+      "license": "ISC"
     },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
@@ -7548,6 +8697,32 @@
     "node_modules/geolibre-desktop": {
       "resolved": "apps/geolibre-desktop",
       "link": true
+    },
+    "node_modules/geotiff": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-3.0.5.tgz",
+      "integrity": "sha512-OWcL9S9+yDZ6iAlXMt32T1iwUApJM8UiD47xbm6ZP1h33d10fqkPs14EG/ttT5EnefpZSx3G15iDFC5FxUNUwA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@petamoriken/float16": "^3.9.3",
+        "lerc": "^3.0.0",
+        "pako": "^2.0.4",
+        "parse-headers": "^2.0.2",
+        "quick-lru": "^6.1.1",
+        "web-worker": "^1.5.0",
+        "xml-utils": "^1.10.2",
+        "zstddec": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=10.19"
+      }
+    },
+    "node_modules/geotiff-geokeys-to-proj4": {
+      "version": "2024.4.13",
+      "resolved": "https://registry.npmjs.org/geotiff-geokeys-to-proj4/-/geotiff-geokeys-to-proj4-2024.4.13.tgz",
+      "integrity": "sha512-Jgtm/lcPkgB44wCqQHaVQx5/fyhmiVDRUKQcI/vMolsED8/GRWBnn5qkQo/CgutQg9xkGzig21DY9Px9mFRdvg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
@@ -8017,6 +9192,18 @@
         }
       }
     },
+    "node_modules/h3-js": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/h3-js/-/h3-js-4.4.0.tgz",
+      "integrity": "sha512-DvJh07MhGgY2KcC4OeZc8SSyA+ZXpdvoh6uCzGpoKvWtZxJB+g6VXXC1+eWYkaMIsLz7J/ErhOalHCpcs1KYog==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=4",
+        "npm": ">=3",
+        "yarn": ">=1.3.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -8058,6 +9245,20 @@
       "peer": true,
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/http-errors": {
@@ -8131,6 +9332,26 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/image-size": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.7.5.tgz",
+      "integrity": "sha512-Hiyv+mXHfFEP7LzUL/llg9RwFxxY+o9N3JVLIeG5E7iFIFAalxvRU9UZthBdYDEVnzHMgjnKJPPpay5BWf1g9g==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/individual": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/individual/-/individual-3.0.0.tgz",
@@ -8176,6 +9397,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/is-core-module": {
       "version": "2.16.2",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
@@ -8191,6 +9419,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-error": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-error/-/is-error-2.2.2.tgz",
+      "integrity": "sha512-IOQqts/aHWbiisY5DuPJQ0gcbvaLFCa7fBa9xoLfxBZvQ+ZI/Zh9xoI7Gk+G64N0FdK4AbibytHht2tWgpJWLg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -8252,6 +9487,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -8362,6 +9604,37 @@
         "node": ">=6"
       }
     },
+    "node_modules/jspdf": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.2.tgz",
+      "integrity": "sha512-myeX9c+p7znDWPk0eTrujCzNjT+CXdXyk7YmJq5nD5V7uLLKmSXnlQ/Jn/kuo3X09Op70Apm0rQSnFWyGK8uEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.6",
+        "core-js": "^3.6.0",
+        "dompurify": "^2.5.4",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
+    "node_modules/jspdf/node_modules/dompurify": {
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.9.tgz",
+      "integrity": "sha512-i6mvVmWN4xo9LrhCOZrDgSs9noW6nOahbrmzjRbPF36YPyj5Ue5lgok0MHDWkG7xzpWFO2OYttXdzM7rJxHvNA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true
+    },
+    "node_modules/jspdf/node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/jsts": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/jsts/-/jsts-2.7.1.tgz",
@@ -8370,6 +9643,26 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "peer": true,
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)",
+      "peer": true
     },
     "node_modules/jwa": {
       "version": "2.0.1",
@@ -8398,11 +9691,34 @@
       "integrity": "sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==",
       "license": "ISC"
     },
+    "node_modules/ktx-parse": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ktx-parse/-/ktx-parse-0.7.1.tgz",
+      "integrity": "sha512-FeA3g56ksdFNwjXJJsc1CCc7co+AJYDp6ipIp878zZ2bU8kWROatLYf39TQEd4/XRSUvBXovQ8gaVKWPXsCLEQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/laz-perf": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/laz-perf/-/laz-perf-0.0.6.tgz",
       "integrity": "sha512-ZBqC+BBlofznDIY3SfjXDBVdIhYfz7bq8HAHztlw4XOnu++nHiWtCGPgzpdeAhPkByc68DaKNy3E3rY4XrdRtQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/lerc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
+      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -8485,6 +9801,14 @@
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/lz4js": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/lz4js/-/lz4js-0.2.0.tgz",
+      "integrity": "sha512-gY2Ia9Lm7Ep8qMiuGRhvUq0Q7qUereeldZPP1PMEJxPtEWHJLqw9pgX68oHajBH0nzJK4MaZEA/YNV3jT8u8Bg==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/mapillary-js": {
       "version": "4.1.2",
@@ -8575,6 +9899,47 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/maplibre-gl-basemap-control/-/maplibre-gl-basemap-control-0.2.1.tgz",
       "integrity": "sha512-V1jgpF7965m7veY92IDEIN1yQaQaq+xxWtmCbsyHCFsM0dWCDGLkxyIpDsezr7nPCyfJ2JPbBAeBAjvM4H3b8Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "maplibre-gl": ">=3.0.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/maplibre-gl-components": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.5.0.tgz",
+      "integrity": "sha512-Cj0fA65IxsFkggko1LSXxAmNUygyI/NdLj5bFO6FrtU6i3XhPH983PNrFf0aV77Q4H9BNM6f01gp+T8+DWmvAg==",
+      "license": "MIT",
+      "dependencies": {
+        "maplibre-gl-layer-control": "^0.8.2"
+      },
+      "peerDependencies": {
+        "maplibre-gl": ">=5.14.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/maplibre-gl-components/node_modules/maplibre-gl-layer-control": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-layer-control/-/maplibre-gl-layer-control-0.8.2.tgz",
+      "integrity": "sha512-0AKia2bkrLWQSDVFbMtNpODt3EraZ/Dfr3c8VFHSevq9NDZ6wOHz0GpfVYCw1UbIarrMspyRLAlvLOjPDLA1jQ==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -8703,6 +10068,84 @@
         }
       }
     },
+    "node_modules/maplibre-gl-planetary-computer": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-planetary-computer/-/maplibre-gl-planetary-computer-0.2.2.tgz",
+      "integrity": "sha512-9QPkuEH8sMcQsINMcmhXXEpTF1uDykKb3OeQ1fXQyHkSVmV4YOVh0+bJrQGZhRq84OBpHqQarF0cirzKBo1S8g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "maplibre-gl": ">=3.0.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/maplibre-gl-splat": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-splat/-/maplibre-gl-splat-0.2.2.tgz",
+      "integrity": "sha512-WSBtvwvB/GR4hvUcUCG/L47nvQiCeSvYs2SkfNwnAHsIu6ld0PrfcT03sLWzbJK/Y0sCPXttl3xuRR7XpEe5Rw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dvt3d/maplibre-three-plugin": "^1.3.0",
+        "@sparkjsdev/spark": "^0.1.10",
+        "maplibre-gl-layer-control": "^0.8.2",
+        "three": "^0.178.0"
+      },
+      "peerDependencies": {
+        "maplibre-gl": ">=3.0.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/maplibre-gl-splat/node_modules/@dvt3d/maplibre-three-plugin": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@dvt3d/maplibre-three-plugin/-/maplibre-three-plugin-1.6.0.tgz",
+      "integrity": "sha512-o8NXuWa+SUL/S5yxWVQHCAv471yiZauGoBnqGDBMVXy3RnWFPPaZ1TbYfeBieiCZO45HfK9uFkWvRC8OWS5LVA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "three": "^0.178.0"
+      }
+    },
+    "node_modules/maplibre-gl-splat/node_modules/maplibre-gl-layer-control": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-layer-control/-/maplibre-gl-layer-control-0.8.2.tgz",
+      "integrity": "sha512-0AKia2bkrLWQSDVFbMtNpODt3EraZ/Dfr3c8VFHSevq9NDZ6wOHz0GpfVYCw1UbIarrMspyRLAlvLOjPDLA1jQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "maplibre-gl": ">=3.0.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/maplibre-gl-splat/node_modules/three": {
+      "version": "0.178.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.178.0.tgz",
+      "integrity": "sha512-ybFIB0+x8mz0wnZgSGy2MO/WCO6xZhQSZnmfytSPyNpM0sBafGRVhdaj+erYh5U+RhQOAg/eXqw5uVDiM2BjhQ==",
+      "license": "MIT"
+    },
     "node_modules/maplibre-gl-streetview": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/maplibre-gl-streetview/-/maplibre-gl-streetview-0.4.0.tgz",
@@ -8730,6 +10173,81 @@
       "resolved": "https://registry.npmjs.org/maplibre-gl-swipe/-/maplibre-gl-swipe-0.7.1.tgz",
       "integrity": "sha512-npJSCnHmf6j/7IfNg6eqaRWJT8S6iS+wKfJjQDmQgjVIVvgHoiAnoOx65XZsZ0i9LtNGaxsE5Z3N51992VQyHQ==",
       "license": "MIT",
+      "peerDependencies": {
+        "maplibre-gl": ">=3.0.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/maplibre-gl-usgs-lidar": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-usgs-lidar/-/maplibre-gl-usgs-lidar-0.7.3.tgz",
+      "integrity": "sha512-jG/HntYbIx3ZjvZfpYjFpo/HaLuScMWsGQcCTprq2PK7xrs4kb5OQKmf3MFuE+z8JiE6kM3D/rQTCrhtU/AeXw==",
+      "license": "MIT",
+      "dependencies": {
+        "maplibre-gl-components": "^0.5.0",
+        "maplibre-gl-layer-control": "^0.11.0",
+        "maplibre-gl-lidar": "^0.11.0",
+        "topojson-client": "^3.1.0"
+      },
+      "peerDependencies": {
+        "maplibre-gl": ">=3.0.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/maplibre-gl-usgs-lidar/node_modules/maplibre-gl-layer-control": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-layer-control/-/maplibre-gl-layer-control-0.11.0.tgz",
+      "integrity": "sha512-OFAIuAhc64rzBW5VGl2DZ8rmPb2sz3z/Dn04Yc8YQn+vyuIN5S0Cfp+ojPD1SMiXTm7W/BAfmfr/JQpwm+nerQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "maplibre-gl": ">=3.0.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/maplibre-gl-usgs-lidar/node_modules/maplibre-gl-lidar": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-lidar/-/maplibre-gl-lidar-0.11.1.tgz",
+      "integrity": "sha512-Z/4VdlZZu1KQ2q8OwAs9uNvHuhffh6JqP7nCiS4u/Zbk+oA1SRR3WOi2HsbvGzc/d41FfgS32BTVkI49CEBI4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@deck.gl/core": "^9.0.0",
+        "@deck.gl/extensions": "^9.0.0",
+        "@deck.gl/layers": "^9.0.0",
+        "@deck.gl/mapbox": "^9.0.0",
+        "@loaders.gl/core": "^4.3.4",
+        "@loaders.gl/las": "^4.3.4",
+        "@types/proj4": "^2.5.6",
+        "copc": "^0.0.8",
+        "maplibre-gl-layer-control": "^0.11.0",
+        "proj4": "^2.20.2"
+      },
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
         "react": ">=18.0.0",
@@ -8780,6 +10298,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
       }
     },
     "node_modules/media-typer": {
@@ -9012,6 +10542,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/numcodecs": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.3.2.tgz",
+      "integrity": "sha512-6YSPnmZgg0P87jnNhi3s+FVLOcIn3y+1CTIgUulA3IdASzK9fJM87sUFkpyA+be9GibGRaST2wCgkD+6U+fWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.8.0"
+      }
+    },
+    "node_modules/numcodecs/node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -9041,6 +10586,55 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ol": {
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-10.9.0.tgz",
+      "integrity": "sha512-svbbgVQUmEHaKpLQ8kRySojs59Brvgl2zYIrqG9eQNXGfsbi55rQasZIDpwpQzDL6OlzrUb0H4hQaiX9wDoGmA==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "dependencies": {
+        "@types/rbush": "4.0.0",
+        "earcut": "^3.0.0",
+        "geotiff": "^3.0.5 || ^3.1.0-beta.0",
+        "pbf": "4.0.1",
+        "rbush": "^4.0.0",
+        "zarrita": "^0.7.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/openlayers"
+      }
+    },
+    "node_modules/ol/node_modules/@types/rbush": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/rbush/-/rbush-4.0.0.tgz",
+      "integrity": "sha512-+N+2H39P8X+Hy1I5mC6awlTX54k3FhiUmvt7HWzGJZvF+syUAAxP/stwppS8JE84YHqFgRMv6fCy31202CMFxQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/ol/node_modules/pbf": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
+      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
+    "node_modules/ol/node_modules/rbush": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-4.0.1.tgz",
+      "integrity": "sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "quickselect": "^3.0.0"
       }
     },
     "node_modules/on-finished": {
@@ -9105,6 +10699,18 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
       "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
       "license": "(MIT AND Zlib)"
+    },
+    "node_modules/parse-headers": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
+      "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==",
+      "license": "MIT"
+    },
+    "node_modules/parsedbf": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parsedbf/-/parsedbf-2.0.0.tgz",
+      "integrity": "sha512-WNjKn/cwgGBkXqQLif+2VMEahcRHkBRU0/RfBWZ7Vj7snRNNW63yW1mVuuHRDyXTRxuGCzAHHBcr/Fn+U/bXjQ==",
+      "license": "MIT"
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -9171,6 +10777,13 @@
         "pbf": "bin/pbf"
       }
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -9220,6 +10833,21 @@
       "engines": {
         "node": ">=16.20.0"
       }
+    },
+    "node_modules/pmtiles": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/pmtiles/-/pmtiles-4.4.1.tgz",
+      "integrity": "sha512-5oTeQc/yX/ft1evbpIlnoCZugQuug/iYIAj/ZTqIqzdGek4uZEho99En890EE6NOSI3JTI3IG8R7r8+SltphxA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "fflate": "^0.8.2"
+      }
+    },
+    "node_modules/pmtiles/node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/point-in-polygon": {
       "version": "1.1.0",
@@ -9445,6 +11073,13 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/proj4": {
       "version": "2.20.8",
       "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.20.8.tgz",
@@ -9538,11 +11173,33 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quick-lru": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
+      "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/quickselect": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
       "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
       "license": "ISC"
+    },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -9699,6 +11356,29 @@
         "pify": "^2.3.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -9711,6 +11391,19 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/reference-spec-reader": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/reference-spec-reader/-/reference-spec-reader-0.2.0.tgz",
+      "integrity": "sha512-q0mfCi5yZSSHXpCyxjgQeaORq3tvDsxDyzaadA/5+AbAUwRyRuuTh0aRQuE/vAOt/qzzxidJ5iDeu1cLHaNBlQ==",
+      "license": "MIT"
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
@@ -9771,6 +11464,16 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/robust-predicates": {
@@ -9985,6 +11688,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -10013,6 +11723,17 @@
       "peer": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shpjs": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/shpjs/-/shpjs-6.2.0.tgz",
+      "integrity": "sha512-8cR/RKYHQepmVyBMtzZQ+1bnSbWrtLXS6aoEJmpUlOSHtSUddterebVxYmIWq2g9kOEX9jm2kjHiikyPX7cNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "but-unzip": "^0.1.4",
+        "parsedbf": "^2.0.0",
+        "proj4": "^2.1.4"
       }
     },
     "node_modules/side-channel": {
@@ -10093,6 +11814,19 @@
       "integrity": "sha512-hNj1/oZ7ygsfmPZ7ZfN5MUBRoGg1gtpnImuJBgLO0ljQ67DtJuiQaiYdS4lUA6s0KCwnPhGivtC/WRwIZLkHyg==",
       "license": "MIT"
     },
+    "node_modules/slice-source": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/slice-source/-/slice-source-0.4.1.tgz",
+      "integrity": "sha512-YiuPbxpCj4hD9Qs06hGAz/OZhQ0eDuALN0lRWJez0eD/RevzKqGdUx1IOMUnXgpr+sXZLq3g8ERwbAH0bCb8vg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/snappyjs": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/snappyjs/-/snappyjs-0.6.1.tgz",
+      "integrity": "sha512-YIK6I2lsH072UE0aOFxxY1dPDCS43I5ktqHpeAsuLNYWkE5pGxRGWfDM4/vSUfNzXjC1Ivzt3qx31PCLmc9yqg==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -10115,6 +11849,23 @@
       "integrity": "sha512-0kGecIZNIReCSiznK3uheYB8sbstLjCZLiwcQwbmLhgHJj2gz6OnSPkVzJQCMnmEz1BQ4gPK59ylhBoEWOhGNA==",
       "license": "BDS-3-Clause"
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -10124,6 +11875,23 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/string-template": {
       "version": "0.2.1",
@@ -10197,6 +11965,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/sweepline-intersections": {
@@ -10304,6 +12082,30 @@
       "license": "MIT",
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || insiders"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
+    "node_modules/texture-compressor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/texture-compressor/-/texture-compressor-1.0.2.tgz",
+      "integrity": "sha512-dStVgoaQ11mA5htJ+RzZ51ZxIZqNOgWKAIvtjLrW1AliQQLCmrDqNzQZ8Jh91YealQ95DXt4MEduLzJmbs6lig==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "argparse": "^1.0.10",
+        "image-size": "^0.7.4"
+      },
+      "bin": {
+        "texture-compressor": "bin/texture-compressor.js"
       }
     },
     "node_modules/thenify": {
@@ -10562,6 +12364,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/unzipit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unzipit/-/unzipit-2.0.0.tgz",
+      "integrity": "sha512-DVeVIWUZCAQPNzm5sB0hpsG1GygTTdBnzNtYYEpInkttx5evkyqRgZi6rTczoySqp8hO5jHVKzrH0f23X8FZLg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -10646,8 +12458,17 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/uuid": {
       "version": "11.1.1",
@@ -10661,6 +12482,12 @@
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }
+    },
+    "node_modules/uzip-module": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/uzip-module/-/uzip-module-1.0.3.tgz",
+      "integrity": "sha512-AMqwWZaknLM77G+VPYNZLEruMGWGzyigPK3/Whg99B3S6vGHuqsyl5ZrOv1UUF3paGK1U6PM0cnayioaryg/fA==",
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -10803,6 +12630,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/web-worker": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+      "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -10906,6 +12739,12 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/xml-utils": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.10.2.tgz",
+      "integrity": "sha512-RqM+2o1RYs6T8+3DzDSoTRAUfrvaejbVHcp3+thnAtDKo8LskR+HomLajEy5UjTz24rpka7AxVBRR3g2wTUkJA==",
+      "license": "CC0-1.0"
+    },
     "node_modules/xmlhttprequest": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
@@ -10946,6 +12785,17 @@
         "url": "https://github.com/sponsors/eemeli"
       }
     },
+    "node_modules/zarrita": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.7.3.tgz",
+      "integrity": "sha512-wChTQ1Ox75INoQCzKAfLWAfB70JJ4KjdW8Sz5x4ZWrFB4Dw+YZdnxHTL0xSdsrB9EmKSeK7fS1Y+I2ibhfGbkw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@zarrita/storage": "^0.2.0",
+        "numcodecs": "^0.3.2"
+      }
+    },
     "node_modules/zod": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
@@ -10964,6 +12814,21 @@
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
       }
+    },
+    "node_modules/zstd-codec": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/zstd-codec/-/zstd-codec-0.1.5.tgz",
+      "integrity": "sha512-v3fyjpK8S/dpY/X5WxqTK3IoCnp/ZOLxn144GZVlNUjtwAchzrVo03h+oMATFhCIiJ5KTr4V3vDQQYz4RU684g==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/zstddec": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.2.0.tgz",
+      "integrity": "sha512-oyPnDa1X5c13+Y7mA/FDMNJrn4S8UNBe0KCqtDmor40Re7ALrPN6npFwyYVRRh+PqozZQdeg23QtbcamZnG5rA==",
+      "license": "MIT AND BSD-3-Clause",
+      "optional": true
     },
     "node_modules/zustand": {
       "version": "5.0.13",
@@ -11013,7 +12878,7 @@
         "@geolibre/core": "*",
         "@turf/bbox": "^7.2.0",
         "@turf/helpers": "^7.2.0",
-        "maplibre-gl": "^5.1.1",
+        "maplibre-gl": "^5.24.0",
         "maplibre-gl-layer-control": "^0.14.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -11033,19 +12898,178 @@
       "name": "@geolibre/plugins",
       "version": "0.3.0",
       "dependencies": {
+        "@carbonplan/zarr-layer": "^0.3.1",
+        "@deck.gl/core": "^9.3.2",
+        "@deck.gl/layers": "^9.3.2",
+        "@deck.gl/mapbox": "^9.3.2",
+        "@developmentseed/deck.gl-geotiff": "^0.2.0",
+        "@developmentseed/deck.gl-raster": "^0.7.0",
+        "@dvt3d/maplibre-three-plugin": "^1.6.0",
         "@geolibre/core": "*",
         "@geoman-io/maplibre-geoman-free": "^0.7.1",
+        "jspdf": "^2.5.2",
+        "maplibre-gl": "^5.24.0",
         "maplibre-gl-basemap-control": "^0.2.1",
+        "maplibre-gl-components": "^0.16.3",
         "maplibre-gl-geo-editor": "^0.7.3",
         "maplibre-gl-geoagent": "^0.4.2",
         "maplibre-gl-lidar": "^0.14.1",
         "maplibre-gl-streetview": "^0.4.0",
-        "maplibre-gl-swipe": "^0.7.1"
+        "maplibre-gl-swipe": "^0.7.1",
+        "shpjs": "^6.2.0",
+        "three": "^0.178.0"
       },
       "devDependencies": {
         "@types/geojson": "^7946.0.16",
         "typescript": "^5.7.3"
       }
+    },
+    "packages/plugins/node_modules/@dvt3d/maplibre-three-plugin": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@dvt3d/maplibre-three-plugin/-/maplibre-three-plugin-1.6.0.tgz",
+      "integrity": "sha512-o8NXuWa+SUL/S5yxWVQHCAv471yiZauGoBnqGDBMVXy3RnWFPPaZ1TbYfeBieiCZO45HfK9uFkWvRC8OWS5LVA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "three": "^0.178.0"
+      }
+    },
+    "packages/plugins/node_modules/maplibre-gl-components": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.16.3.tgz",
+      "integrity": "sha512-EGOrOATD+SvR1ggsAU1/y5IfEfMoUz4V0698kv+yvfq8vgq23lf8rB+MSdFxG0ZCpN2Dxsq6s69WRaJ/byJg5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "flatgeobuf": "^4.4.0",
+        "geotiff-geokeys-to-proj4": "^2024.4.13",
+        "maplibre-gl-geo-editor": "^0.7.3",
+        "maplibre-gl-layer-control": "^0.14.1",
+        "maplibre-gl-lidar": "^0.11.1",
+        "maplibre-gl-planetary-computer": "^0.2.2",
+        "maplibre-gl-splat": "^0.2.2",
+        "maplibre-gl-streetview": "^0.3.1",
+        "maplibre-gl-swipe": "^0.7.1",
+        "maplibre-gl-usgs-lidar": "^0.7.3",
+        "pmtiles": "^4.4.0"
+      },
+      "peerDependencies": {
+        "@carbonplan/zarr-layer": "^0.3.1",
+        "@deck.gl/core": "^9.2.6",
+        "@deck.gl/mapbox": "^9.2.6",
+        "@developmentseed/deck.gl-geotiff": "^0.2.0",
+        "@dvt3d/maplibre-three-plugin": "^1.3.0",
+        "jspdf": ">=2.5.0",
+        "maplibre-gl": ">=5.16.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0",
+        "three": "^0.178.0"
+      },
+      "peerDependenciesMeta": {
+        "@carbonplan/zarr-layer": {
+          "optional": true
+        },
+        "@deck.gl/core": {
+          "optional": true
+        },
+        "@deck.gl/mapbox": {
+          "optional": true
+        },
+        "@developmentseed/deck.gl-geotiff": {
+          "optional": true
+        },
+        "@dvt3d/maplibre-three-plugin": {
+          "optional": true
+        },
+        "jspdf": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "three": {
+          "optional": true
+        }
+      }
+    },
+    "packages/plugins/node_modules/maplibre-gl-components/node_modules/maplibre-gl-lidar": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-lidar/-/maplibre-gl-lidar-0.11.1.tgz",
+      "integrity": "sha512-Z/4VdlZZu1KQ2q8OwAs9uNvHuhffh6JqP7nCiS4u/Zbk+oA1SRR3WOi2HsbvGzc/d41FfgS32BTVkI49CEBI4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@deck.gl/core": "^9.0.0",
+        "@deck.gl/extensions": "^9.0.0",
+        "@deck.gl/layers": "^9.0.0",
+        "@deck.gl/mapbox": "^9.0.0",
+        "@loaders.gl/core": "^4.3.4",
+        "@loaders.gl/las": "^4.3.4",
+        "@types/proj4": "^2.5.6",
+        "copc": "^0.0.8",
+        "maplibre-gl-layer-control": "^0.11.0",
+        "proj4": "^2.20.2"
+      },
+      "peerDependencies": {
+        "maplibre-gl": ">=3.0.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "packages/plugins/node_modules/maplibre-gl-components/node_modules/maplibre-gl-lidar/node_modules/maplibre-gl-layer-control": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-layer-control/-/maplibre-gl-layer-control-0.11.0.tgz",
+      "integrity": "sha512-OFAIuAhc64rzBW5VGl2DZ8rmPb2sz3z/Dn04Yc8YQn+vyuIN5S0Cfp+ojPD1SMiXTm7W/BAfmfr/JQpwm+nerQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "maplibre-gl": ">=3.0.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "packages/plugins/node_modules/maplibre-gl-components/node_modules/maplibre-gl-streetview": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-streetview/-/maplibre-gl-streetview-0.3.1.tgz",
+      "integrity": "sha512-4dp1aJ/lj6nAZwc4w1+UqgoBD65Zpxzo4580c9yIS3EWUp5BlqXFhckejFBqW/zZRGqZ06Fp3NfIrvTXPb94zg==",
+      "license": "MIT",
+      "dependencies": {
+        "mapillary-js": "^4.1.2"
+      },
+      "peerDependencies": {
+        "maplibre-gl": ">=3.0.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "packages/plugins/node_modules/three": {
+      "version": "0.178.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.178.0.tgz",
+      "integrity": "sha512-ybFIB0+x8mz0wnZgSGy2MO/WCO6xZhQSZnmfytSPyNpM0sBafGRVhdaj+erYh5U+RhQOAg/eXqw5uVDiM2BjhQ==",
+      "license": "MIT"
     },
     "packages/processing": {
       "name": "@geolibre/processing",

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -12,7 +12,7 @@
     "@geolibre/core": "*",
     "@turf/bbox": "^7.2.0",
     "@turf/helpers": "^7.2.0",
-    "maplibre-gl": "^5.1.1",
+    "maplibre-gl": "^5.24.0",
     "maplibre-gl-layer-control": "^0.14.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -9,14 +9,26 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
+    "@carbonplan/zarr-layer": "^0.3.1",
+    "@deck.gl/core": "^9.3.2",
+    "@deck.gl/layers": "^9.3.2",
+    "@deck.gl/mapbox": "^9.3.2",
+    "@developmentseed/deck.gl-geotiff": "^0.2.0",
+    "@developmentseed/deck.gl-raster": "^0.7.0",
+    "@dvt3d/maplibre-three-plugin": "^1.6.0",
     "@geolibre/core": "*",
     "@geoman-io/maplibre-geoman-free": "^0.7.1",
+    "jspdf": "^2.5.2",
+    "maplibre-gl": "^5.24.0",
     "maplibre-gl-basemap-control": "^0.2.1",
+    "maplibre-gl-components": "^0.16.3",
     "maplibre-gl-geo-editor": "^0.7.3",
     "maplibre-gl-geoagent": "^0.4.2",
     "maplibre-gl-lidar": "^0.14.1",
     "maplibre-gl-streetview": "^0.4.0",
-    "maplibre-gl-swipe": "^0.7.1"
+    "maplibre-gl-swipe": "^0.7.1",
+    "shpjs": "^6.2.0",
+    "three": "^0.178.0"
   },
   "devDependencies": {
     "@types/geojson": "^7946.0.16",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -4,6 +4,7 @@ export { maplibreLayerControlPlugin } from "./plugins/layer-control";
 export { osmBasemapPlugin } from "./plugins/osm-basemap";
 export { cartoLightPlugin } from "./plugins/carto-light";
 export { maplibreBasemapControlPlugin } from "./plugins/maplibre-basemap-control";
+export { maplibreComponentsPlugin } from "./plugins/maplibre-components";
 export { maplibreGeoEditorPlugin } from "./plugins/maplibre-geo-editor";
 export { maplibreGeoAgentPlugin } from "./plugins/maplibre-geoagent";
 export { maplibreLidarPlugin } from "./plugins/maplibre-lidar";

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -12,7 +12,6 @@ import type {
 let componentsControlPosition: GeoLibreMapControlPosition = "top-right";
 
 const COMPONENT_CONTROL_NAMES = [
-  "globe",
   "spinGlobe",
   "fullscreen",
   "north",

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -1,0 +1,128 @@
+import type {
+  ControlGrid,
+  ControlGridOptions,
+  DefaultControlName,
+} from "maplibre-gl-components";
+import type {
+  GeoLibreAppAPI,
+  GeoLibreMapControlPosition,
+  GeoLibrePlugin,
+} from "../types";
+
+let componentsControlPosition: GeoLibreMapControlPosition = "top-right";
+
+const COMPONENT_CONTROL_NAMES = [
+  "globe",
+  "spinGlobe",
+  "fullscreen",
+  "north",
+  "terrain",
+  "search",
+  "viewState",
+  "inspect",
+  "vectorDataset",
+  "basemap",
+  "measure",
+  "geoEditor",
+  "bookmark",
+  "print",
+  "swipe",
+  "streetView",
+  "addVector",
+  "cogLayer",
+  "zarrLayer",
+  "pmtilesLayer",
+  "stacLayer",
+  "stacSearch",
+  "planetaryComputer",
+  "gaussianSplat",
+  "lidar",
+  "usgsLidar",
+] satisfies DefaultControlName[];
+
+const COMPONENTS_OPTIONS = {
+  className: "geolibre-components-control",
+  collapsed: false,
+  columns: 5,
+  defaultControls: COMPONENT_CONTROL_NAMES,
+  excludeLayers: [
+    "usgs-lidar-*",
+    "lidar-*",
+    "mapbox-gl-draw-*",
+    "gl-draw-*",
+    "gm_*",
+    "inspect-highlight-*",
+    "measure-*",
+  ],
+  gap: 2,
+  rows: 5,
+  showRowColumnControls: true,
+} satisfies Omit<ControlGridOptions, "position" | "basemapStyleUrl">;
+
+let componentsControl: ControlGrid | null = null;
+let pluginActive = false;
+
+const mountComponentsControl = (app: GeoLibreAppAPI): boolean => {
+  if (!componentsControl) return false;
+  const added = app.addMapControl(
+    componentsControl,
+    componentsControlPosition,
+  );
+  if (!added) {
+    componentsControl = null;
+    return false;
+  }
+  setTimeout(() => componentsControl?.expand(), 0);
+  return true;
+};
+
+export const maplibreComponentsPlugin: GeoLibrePlugin = {
+  id: "maplibre-gl-components",
+  name: "Components",
+  version: "0.16.3",
+  activate: (app: GeoLibreAppAPI) => {
+    pluginActive = true;
+    if (componentsControl) return mountComponentsControl(app);
+
+    void import("maplibre-gl-components").then(
+      ({ ControlGrid: ControlGridClass }) => {
+        if (!pluginActive || componentsControl) return;
+        componentsControl = new ControlGridClass(
+          getComponentsOptions(app),
+        );
+        mountComponentsControl(app);
+      },
+    );
+  },
+  deactivate: (app: GeoLibreAppAPI) => {
+    pluginActive = false;
+    if (!componentsControl) return;
+    app.removeMapControl(componentsControl);
+    componentsControl = null;
+  },
+  getMapControlPosition: () => componentsControlPosition,
+  setMapControlPosition: (
+    app: GeoLibreAppAPI,
+    position: GeoLibreMapControlPosition,
+  ) => {
+    componentsControlPosition = position;
+    if (!componentsControl) return;
+    app.removeMapControl(componentsControl);
+    const added = app.addMapControl(
+      componentsControl,
+      componentsControlPosition,
+    );
+    if (!added) return false;
+    setTimeout(() => componentsControl?.expand(), 0);
+  },
+};
+
+function getComponentsOptions(
+  app: GeoLibreAppAPI,
+): ControlGridOptions {
+  return {
+    ...COMPONENTS_OPTIONS,
+    basemapStyleUrl: app.getActiveBasemap(),
+    position: componentsControlPosition,
+  };
+}

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -9,6 +9,9 @@ import type {
   GeoLibrePlugin,
 } from "../types";
 
+type ControlGridConstructor =
+  (typeof import("maplibre-gl-components"))["ControlGrid"];
+
 let componentsControlPosition: GeoLibreMapControlPosition = "top-right";
 
 const COMPONENT_CONTROL_NAMES = [
@@ -60,6 +63,40 @@ const COMPONENTS_OPTIONS = {
 
 let componentsControl: ControlGrid | null = null;
 let pluginActive = false;
+let componentsControlRevision = 0;
+let controlGridConstructorPromise: Promise<ControlGridConstructor> | null =
+  null;
+
+const getControlGridConstructor = (): Promise<ControlGridConstructor> => {
+  controlGridConstructorPromise ??= import(
+    "maplibre-gl-components"
+  ).then(({ ControlGrid: ControlGridClass }) => ControlGridClass);
+  return controlGridConstructorPromise;
+};
+
+const createComponentsControl = async (
+  app: GeoLibreAppAPI,
+): Promise<ControlGrid | null> => {
+  const ControlGridClass = await getControlGridConstructor();
+  if (!pluginActive) return null;
+  return new ControlGridClass(getComponentsOptions(app));
+};
+
+const createAndMountComponentsControl = (app: GeoLibreAppAPI): void => {
+  const revision = ++componentsControlRevision;
+  void createComponentsControl(app).then((control) => {
+    if (
+      !pluginActive ||
+      componentsControl ||
+      !control ||
+      revision !== componentsControlRevision
+    ) {
+      return;
+    }
+    componentsControl = control;
+    mountComponentsControl(app);
+  });
+};
 
 const mountComponentsControl = (app: GeoLibreAppAPI): boolean => {
   if (!componentsControl) return false;
@@ -82,19 +119,11 @@ export const maplibreComponentsPlugin: GeoLibrePlugin = {
   activate: (app: GeoLibreAppAPI) => {
     pluginActive = true;
     if (componentsControl) return mountComponentsControl(app);
-
-    void import("maplibre-gl-components").then(
-      ({ ControlGrid: ControlGridClass }) => {
-        if (!pluginActive || componentsControl) return;
-        componentsControl = new ControlGridClass(
-          getComponentsOptions(app),
-        );
-        mountComponentsControl(app);
-      },
-    );
+    createAndMountComponentsControl(app);
   },
   deactivate: (app: GeoLibreAppAPI) => {
     pluginActive = false;
+    componentsControlRevision += 1;
     if (!componentsControl) return;
     app.removeMapControl(componentsControl);
     componentsControl = null;
@@ -107,12 +136,8 @@ export const maplibreComponentsPlugin: GeoLibrePlugin = {
     componentsControlPosition = position;
     if (!componentsControl) return;
     app.removeMapControl(componentsControl);
-    const added = app.addMapControl(
-      componentsControl,
-      componentsControlPosition,
-    );
-    if (!added) return false;
-    setTimeout(() => componentsControl?.expand(), 0);
+    componentsControl = null;
+    createAndMountComponentsControl(app);
   },
 };
 


### PR DESCRIPTION
## Summary
- Add a new `maplibreComponentsPlugin` that mounts a unified `ControlGrid` from `maplibre-gl-components`, bundling map tools (search, terrain, COG/Zarr/PMTiles/STAC layers, gaussian splat, lidar, swipe, street view, and more) into a single grid control.
- Register the plugin in the desktop app and add its supporting dependencies (deck.gl, three.js, jspdf, shpjs, zarr-layer) plus a maplibre-gl bump to `^5.24.0`.
- Add CSS in `index.css` to style the control grid, floating panels, inputs, and radio buttons consistently in the light theme.

## Test plan
- [ ] `npm run build` succeeds (verified via pre-commit gate).
- [ ] Launch the desktop app and confirm the Components control grid renders and expands.
- [ ] Exercise the bundled tools (search, terrain, layer loaders, swipe) and verify panels position correctly in each control corner.