### PR TITLE
feat: make desktop app layout responsive on small screens

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
@@ -37,7 +37,7 @@ export function AboutDialog() {
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <Button variant="ghost" size="sm">
+        <Button variant="ghost" size="sm" aria-label="About">
           <Info className="h-3.5 w-3.5 sm:mr-1" />
           <span className="hidden sm:inline">About</span>
         </Button>

--- a/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
@@ -38,8 +38,8 @@ export function AboutDialog() {
     <Dialog>
       <DialogTrigger asChild>
         <Button variant="ghost" size="sm">
-          <Info className="mr-1 h-3.5 w-3.5" />
-          About
+          <Info className="h-3.5 w-3.5 sm:mr-1" />
+          <span className="hidden sm:inline">About</span>
         </Button>
       </DialogTrigger>
       <DialogContent className="max-w-md">

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -27,9 +27,9 @@ export function DesktopShell({
         themeMode={themeMode}
         onToggleThemeMode={onToggleThemeMode}
       />
-      <div className="flex min-h-0 flex-1">
+      <div className="flex min-h-0 flex-1 flex-col md:flex-row">
         <LayerPanel mapControllerRef={mapControllerRef} />
-        <main className="relative min-w-0 flex-1">
+        <main className="relative min-h-72 min-w-0 flex-1 md:min-h-0">
           <MapCanvas controllerRef={mapControllerRef} />
         </main>
         <StylePanel />

--- a/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
@@ -129,7 +129,7 @@ export function NewProjectDialog({
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
-        <Button variant="ghost" size="sm">
+        <Button variant="ghost" size="sm" aria-label="New project">
           <FilePlus2 className="h-3.5 w-3.5 sm:mr-1" />
           <span className="hidden sm:inline">New</span>
         </Button>

--- a/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
@@ -130,8 +130,8 @@ export function NewProjectDialog({
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
         <Button variant="ghost" size="sm">
-          <FilePlus2 className="h-3.5 w-3.5" />
-          New
+          <FilePlus2 className="h-3.5 w-3.5 sm:mr-1" />
+          <span className="hidden sm:inline">New</span>
         </Button>
       </DialogTrigger>
       <DialogContent className="max-w-xl">

--- a/apps/geolibre-desktop/src/components/layout/StatusBar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/StatusBar.tsx
@@ -13,11 +13,15 @@ export function StatusBar() {
     : "—";
 
   return (
-    <footer className="flex h-7 shrink-0 items-center gap-4 border-t bg-muted/40 px-3 font-mono text-xs text-muted-foreground">
+    <footer className="flex h-7 shrink-0 items-center gap-4 overflow-x-auto border-t bg-muted/40 px-3 font-mono text-xs text-muted-foreground">
       <span>Coords: {coordText}</span>
-      <span>Zoom: {mapView.zoom.toFixed(2)}</span>
-      <span>Bearing: {mapView.bearing.toFixed(1)}°</span>
-      <span>Pitch: {mapView.pitch.toFixed(1)}°</span>
+      <span className="whitespace-nowrap">Zoom: {mapView.zoom.toFixed(2)}</span>
+      <span className="whitespace-nowrap">
+        Bearing: {mapView.bearing.toFixed(1)}°
+      </span>
+      <span className="whitespace-nowrap">
+        Pitch: {mapView.pitch.toFixed(1)}°
+      </span>
       <span className="truncate">BBox: {bboxText}</span>
     </footer>
   );

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -157,37 +157,37 @@ export function TopToolbar({
   };
 
   return (
-    <header className="flex h-11 shrink-0 items-center gap-1 border-b bg-card px-2">
-      <span className="mr-2 flex items-center gap-1.5 text-sm font-semibold text-primary">
+    <header className="flex min-h-11 shrink-0 flex-wrap items-center gap-1 border-b bg-card px-2 py-1 md:flex-nowrap">
+      <span className="mr-1 flex shrink-0 items-center gap-1.5 text-sm font-semibold text-primary md:mr-2">
         <Map className="h-4 w-4" />
-        GeoLibre Desktop
+        <span className="hidden sm:inline">GeoLibre Desktop</span>
       </span>
       <NewProjectDialog onSaveCurrentProject={handleSave} />
       <Button variant="ghost" size="sm" onClick={handleOpen}>
-        <FolderOpen className="mr-1 h-3.5 w-3.5" />
-        Open
+        <FolderOpen className="h-3.5 w-3.5 sm:mr-1" />
+        <span className="hidden sm:inline">Open</span>
       </Button>
       <Button variant="ghost" size="sm" onClick={handleSave}>
-        <Save className="mr-1 h-3.5 w-3.5" />
-        Save
+        <Save className="h-3.5 w-3.5 sm:mr-1" />
+        <span className="hidden sm:inline">Save</span>
       </Button>
       <Button variant="ghost" size="sm" onClick={handleAddGeoJson}>
-        <FileJson className="mr-1 h-3.5 w-3.5" />
-        Add GeoJSON
+        <FileJson className="h-3.5 w-3.5 sm:mr-1" />
+        <span className="hidden sm:inline">Add GeoJSON</span>
       </Button>
       <Button
         variant="ghost"
         size="sm"
         onClick={() => setProcessingOpen(true)}
       >
-        <Wrench className="mr-1 h-3.5 w-3.5" />
-        Processing
+        <Wrench className="h-3.5 w-3.5 sm:mr-1" />
+        <span className="hidden sm:inline">Processing</span>
       </Button>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button variant="ghost" size="sm">
-            <SlidersHorizontal className="mr-1 h-3.5 w-3.5" />
-            Controls
+            <SlidersHorizontal className="h-3.5 w-3.5 sm:mr-1" />
+            <span className="hidden sm:inline">Controls</span>
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start">
@@ -207,8 +207,8 @@ export function TopToolbar({
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button variant="ghost" size="sm">
-            <Puzzle className="mr-1 h-3.5 w-3.5" />
-            Plugins
+            <Puzzle className="h-3.5 w-3.5 sm:mr-1" />
+            <span className="hidden sm:inline">Plugins</span>
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start">
@@ -286,10 +286,10 @@ export function TopToolbar({
             <Moon className="h-3.5 w-3.5" />
           )}
         </Button>
-        <Layers className="mr-1 inline h-3 w-3" />
+        <Layers className="mr-1 hidden h-3 w-3 md:inline" />
         <Input
           aria-label="Project name"
-          className="h-7 w-44 border-transparent px-2 text-xs shadow-none focus-visible:border-input"
+          className="hidden h-7 w-44 border-transparent px-2 text-xs shadow-none focus-visible:border-input md:block"
           value={projectName}
           onChange={(event) => setProjectName(event.target.value)}
           onBlur={(event) => {
@@ -298,7 +298,7 @@ export function TopToolbar({
           }}
         />
         {projectPath ? (
-          <span className="truncate">{projectPath}</span>
+          <span className="hidden truncate lg:inline">{projectPath}</span>
         ) : null}
       </div>
     </header>

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -163,15 +163,20 @@ export function TopToolbar({
         <span className="hidden sm:inline">GeoLibre Desktop</span>
       </span>
       <NewProjectDialog onSaveCurrentProject={handleSave} />
-      <Button variant="ghost" size="sm" onClick={handleOpen}>
+      <Button variant="ghost" size="sm" onClick={handleOpen} aria-label="Open">
         <FolderOpen className="h-3.5 w-3.5 sm:mr-1" />
         <span className="hidden sm:inline">Open</span>
       </Button>
-      <Button variant="ghost" size="sm" onClick={handleSave}>
+      <Button variant="ghost" size="sm" onClick={handleSave} aria-label="Save">
         <Save className="h-3.5 w-3.5 sm:mr-1" />
         <span className="hidden sm:inline">Save</span>
       </Button>
-      <Button variant="ghost" size="sm" onClick={handleAddGeoJson}>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={handleAddGeoJson}
+        aria-label="Add GeoJSON"
+      >
         <FileJson className="h-3.5 w-3.5 sm:mr-1" />
         <span className="hidden sm:inline">Add GeoJSON</span>
       </Button>
@@ -179,13 +184,14 @@ export function TopToolbar({
         variant="ghost"
         size="sm"
         onClick={() => setProcessingOpen(true)}
+        aria-label="Processing"
       >
         <Wrench className="h-3.5 w-3.5 sm:mr-1" />
         <span className="hidden sm:inline">Processing</span>
       </Button>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button variant="ghost" size="sm">
+          <Button variant="ghost" size="sm" aria-label="Controls">
             <SlidersHorizontal className="h-3.5 w-3.5 sm:mr-1" />
             <span className="hidden sm:inline">Controls</span>
           </Button>
@@ -206,7 +212,7 @@ export function TopToolbar({
       </DropdownMenu>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button variant="ghost" size="sm">
+          <Button variant="ghost" size="sm" aria-label="Plugins">
             <Puzzle className="h-3.5 w-3.5 sm:mr-1" />
             <span className="hidden sm:inline">Plugins</span>
           </Button>

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -31,6 +31,13 @@ interface LayerPanelProps {
   mapControllerRef: React.RefObject<MapController | null>;
 }
 
+function isMobileViewport(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    window.matchMedia("(max-width: 767px)").matches
+  );
+}
+
 export function LayerPanel({ mapControllerRef }: LayerPanelProps) {
   const layers = useAppStore((s) => s.layers);
   const selectedLayerId = useAppStore((s) => s.selectedLayerId);
@@ -40,11 +47,11 @@ export function LayerPanel({ mapControllerRef }: LayerPanelProps) {
   const reorderLayer = useAppStore((s) => s.reorderLayer);
   const removeLayer = useAppStore((s) => s.removeLayer);
   const [metadataLayer, setMetadataLayer] = useState<GeoLibreLayer | null>(null);
-  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [isCollapsed, setIsCollapsed] = useState(isMobileViewport);
 
   if (isCollapsed) {
     return (
-      <aside className="flex w-11 shrink-0 flex-col items-center border-r bg-card py-2">
+      <aside className="flex h-11 w-full shrink-0 items-center gap-2 border-b bg-card px-2 md:h-auto md:w-11 md:flex-col md:border-b-0 md:border-r md:py-2">
         <Button
           variant="ghost"
           size="icon"
@@ -55,9 +62,9 @@ export function LayerPanel({ mapControllerRef }: LayerPanelProps) {
         >
           <PanelLeftOpen className="h-4 w-4" />
         </Button>
-        <div className="mt-3 flex flex-col items-center gap-2 text-muted-foreground">
+        <div className="flex items-center gap-2 text-muted-foreground md:mt-3 md:flex-col">
           <Layers className="h-4 w-4" />
-          <span className="[writing-mode:vertical-rl] rotate-180 text-[10px] font-semibold uppercase tracking-wide">
+          <span className="text-[10px] font-semibold uppercase tracking-wide md:[writing-mode:vertical-rl] md:rotate-180">
             Layers
           </span>
         </div>
@@ -66,7 +73,7 @@ export function LayerPanel({ mapControllerRef }: LayerPanelProps) {
   }
 
   return (
-    <aside className="flex w-64 shrink-0 flex-col border-r bg-card">
+    <aside className="flex max-h-56 w-full shrink-0 flex-col border-b bg-card md:max-h-none md:w-64 md:border-b-0 md:border-r">
       <div className="flex items-center justify-between border-b px-3 py-1.5">
         <span className="text-sm font-semibold">Layers</span>
         <Button

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -7,17 +7,24 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 
+function isMobileViewport(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    window.matchMedia("(max-width: 767px)").matches
+  );
+}
+
 export function StylePanel() {
   const selectedLayerId = useAppStore((s) => s.selectedLayerId);
   const layers = useAppStore((s) => s.layers);
   const setLayerStyle = useAppStore((s) => s.setLayerStyle);
-  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [isCollapsed, setIsCollapsed] = useState(isMobileViewport);
 
   const layer = layers.find((l) => l.id === selectedLayerId);
 
   if (isCollapsed) {
     return (
-      <aside className="flex w-11 shrink-0 flex-col items-center border-l bg-card py-2">
+      <aside className="flex h-11 w-full shrink-0 items-center gap-2 border-t bg-card px-2 md:h-auto md:w-11 md:flex-col md:border-l md:border-t-0 md:py-2">
         <Button
           variant="ghost"
           size="icon"
@@ -28,9 +35,9 @@ export function StylePanel() {
         >
           <PanelRightOpen className="h-4 w-4" />
         </Button>
-        <div className="mt-3 flex flex-col items-center gap-2 text-muted-foreground">
+        <div className="flex items-center gap-2 text-muted-foreground md:mt-3 md:flex-col">
           <SlidersHorizontal className="h-4 w-4" />
-          <span className="[writing-mode:vertical-rl] rotate-180 text-[10px] font-semibold uppercase tracking-wide">
+          <span className="text-[10px] font-semibold uppercase tracking-wide md:[writing-mode:vertical-rl] md:rotate-180">
             Style
           </span>
         </div>
@@ -40,7 +47,7 @@ export function StylePanel() {
 
   if (!layer) {
     return (
-      <aside className="flex w-64 shrink-0 flex-col border-l bg-card">
+      <aside className="flex max-h-56 w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-64 md:border-l md:border-t-0">
         <div className="flex items-center justify-between border-b px-3 py-1.5">
           <span className="text-sm font-semibold">Style</span>
           <Button
@@ -64,7 +71,7 @@ export function StylePanel() {
   const { style } = layer;
 
   return (
-    <aside className="flex w-64 shrink-0 flex-col border-l bg-card">
+    <aside className="flex max-h-56 w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-64 md:border-l md:border-t-0">
       <div className="flex items-center justify-between gap-2 border-b px-3 py-1.5">
         <span className="truncate text-sm font-semibold">
           Style — {layer.name}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -80,6 +80,10 @@
   margin-top: 1.3rem;
 }
 
+.md-typeset > p > .md-button + .md-button {
+  margin-left: 0.6rem;
+}
+
 .hero__media {
   margin: 0;
 }
@@ -121,5 +125,18 @@
 @media screen and (min-width: 76.25em) {
   .hero {
     grid-template-columns: minmax(18rem, 0.9fr) minmax(20rem, 1.1fr);
+  }
+}
+
+@media screen and (max-width: 30em) {
+  .md-typeset > p > .md-button {
+    display: block;
+    text-align: center;
+    width: 100%;
+  }
+
+  .md-typeset > p > .md-button + .md-button {
+    margin-left: 0;
+    margin-top: 0.6rem;
   }
 }

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -139,4 +139,13 @@
     margin-left: 0;
     margin-top: 0.6rem;
   }
+
+  .hero__actions {
+    flex-direction: column;
+  }
+
+  .hero__actions .md-button {
+    text-align: center;
+    width: 100%;
+  }
 }

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -79,7 +79,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   attributeFilter: "",
   ui: {
     processingOpen: false,
-    attributeTableOpen: true,
+    attributeTableOpen: false,
   },
 
   setPointerCoords: (coords) => set({ pointerCoords: coords }),


### PR DESCRIPTION
## Summary
- Stack the layer panel, map canvas, and style panel vertically on narrow viewports and switch to the side-by-side layout from the `md` breakpoint up.
- Collapse toolbar button labels to icon-only on small screens, hide the app title and project name/path inputs until there is room, and auto-collapse the side panels on mobile.
- Make the docs hero buttons stack full-width on small screens.

## Test plan
- [ ] `pre-commit run --all-files` passes (includes `npm run build`).
- [ ] Resize the desktop app below the `md` breakpoint and confirm panels stack and remain usable.
- [ ] Confirm toolbar buttons show icons only on narrow widths and labels return on wider screens.
- [ ] View the docs landing page on a narrow viewport and confirm the hero buttons stack.