### PR TITLE
feat: add multi-source Add Data dialog to desktop app

### DIFF
--- a/.github/workflows/netlify-preview.yml
+++ b/.github/workflows/netlify-preview.yml
@@ -64,6 +64,7 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          set -euo pipefail
           test -n "$NETLIFY_AUTH_TOKEN"
           test -n "$NETLIFY_SITE_ID"
           if [ -n "$PR_NUMBER" ]; then
@@ -73,8 +74,13 @@ jobs:
             deploy_alias="manual-$GITHUB_RUN_NUMBER"
             deploy_message="Manual preview for $GITHUB_REF_NAME"
           fi
+          deploy_dir="$RUNNER_TEMP/geolibre-netlify-site"
+          rm -rf "$deploy_dir"
+          mkdir -p "$deploy_dir"
+          cp -R site/. "$deploy_dir/"
+          cd "$deploy_dir"
           npx --yes netlify-cli@latest deploy \
-            --dir site \
+            --dir . \
             --site "$NETLIFY_SITE_ID" \
             --auth "$NETLIFY_AUTH_TOKEN" \
             --alias "$deploy_alias" \

--- a/.github/workflows/netlify-preview.yml
+++ b/.github/workflows/netlify-preview.yml
@@ -1,0 +1,94 @@
+name: Netlify Preview
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: netlify-preview-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    name: Deploy preview
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements-docs.txt
+
+      - name: Install documentation dependencies
+        run: python -m pip install -r requirements-docs.txt
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Build web demo
+        run: npm run build -w geolibre-desktop
+        env:
+          GEOLIBRE_APP_BASE: ./
+
+      - name: Build documentation
+        run: mkdocs build --strict --site-dir site
+
+      - name: Add web demo to site
+        run: |
+          mkdir -p site/demo
+          cp -R apps/geolibre-desktop/dist/. site/demo/
+          test -f site/demo/index.html
+
+      - name: Deploy to Netlify
+        id: netlify
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          test -n "$NETLIFY_AUTH_TOKEN"
+          test -n "$NETLIFY_SITE_ID"
+          if [ -n "$PR_NUMBER" ]; then
+            deploy_alias="pr-$PR_NUMBER"
+            deploy_message="Preview for PR #$PR_NUMBER"
+          else
+            deploy_alias="manual-$GITHUB_RUN_NUMBER"
+            deploy_message="Manual preview for $GITHUB_REF_NAME"
+          fi
+          npx --yes netlify-cli@latest deploy \
+            --dir site \
+            --site "$NETLIFY_SITE_ID" \
+            --auth "$NETLIFY_AUTH_TOKEN" \
+            --alias "$deploy_alias" \
+            --message "$deploy_message" \
+            --json | tee netlify-deploy.json
+          preview_url="$(node -e "const fs = require('fs'); const data = JSON.parse(fs.readFileSync('netlify-deploy.json', 'utf8')); console.log(data.deploy_url || data.url);")"
+          test -n "$preview_url"
+          echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"
+
+      - name: Comment preview URL
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PREVIEW_URL: ${{ steps.netlify.outputs.preview_url }}
+        run: |
+          gh pr comment "$PR_NUMBER" --body "Netlify preview: $PREVIEW_URL"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+  skip: [npm-build]
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -137,6 +137,7 @@ export function AddDataDialog({
   const title = kind ? KIND_LABELS[kind] : "Add Data";
 
   const [layerName, setLayerName] = useState("");
+  const [beforeLayerId, setBeforeLayerId] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -177,6 +178,7 @@ export function AddDataDialog({
         raster: "Raster Layer",
       }[kind],
     );
+    setBeforeLayerId("");
     setXyzUrl("");
     setXyzTileSize("256");
     setWmsEndpoint("");
@@ -218,8 +220,10 @@ export function AddDataDialog({
     onOpenChange(next);
   };
 
+  const beforeLayer = beforeLayerId.trim() || null;
+
   const addAndClose = (layer: GeoLibreLayer) => {
-    addLayer(layer);
+    addLayer(layer, beforeLayer);
     closeDialog();
   };
 
@@ -321,6 +325,7 @@ export function AddDataDialog({
             name,
             selectedGeoJson.data,
             selectedGeoJson.path,
+            beforeLayer,
           );
           const layer = useAppStore.getState().layers.find((l) => l.id === id);
           if (layer) mapControllerRef.current?.fitLayer(layer);
@@ -331,7 +336,7 @@ export function AddDataDialog({
         if (vectorMode === "geojson-url") {
           if (!vectorUrl.trim()) throw new Error("Enter a GeoJSON URL.");
           const data = await fetchGeoJson(vectorUrl.trim());
-          const id = addGeoJsonLayer(name, data, vectorUrl.trim());
+          const id = addGeoJsonLayer(name, data, vectorUrl.trim(), beforeLayer);
           const layer = useAppStore.getState().layers.find((l) => l.id === id);
           if (layer) mapControllerRef.current?.fitLayer(layer);
           closeDialog();
@@ -413,6 +418,16 @@ export function AddDataDialog({
               id="add-data-layer-name"
               value={layerName}
               onChange={(event) => setLayerName(event.target.value)}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="add-data-before-id">Before Id</Label>
+            <Input
+              id="add-data-before-id"
+              placeholder="Optional layer id"
+              value={beforeLayerId}
+              onChange={(event) => setBeforeLayerId(event.target.value)}
             />
           </div>
 

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -1,0 +1,651 @@
+import {
+  DEFAULT_LAYER_STYLE,
+  type GeoLibreLayer,
+  useAppStore,
+} from "@geolibre/core";
+import type { MapController } from "@geolibre/map";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+} from "@geolibre/ui";
+import type { FeatureCollection } from "geojson";
+import { Database, FileUp, Globe2, Image, Map as MapIcon } from "lucide-react";
+import {
+  type FormEvent,
+  type RefObject,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import {
+  openGeoJsonFileWithFallback,
+  openLocalDataFileWithFallback,
+} from "../../lib/tauri-io";
+
+export type AddDataKind = "xyz" | "wms" | "vector" | "raster";
+
+interface AddDataDialogProps {
+  kind: AddDataKind | null;
+  mapControllerRef: RefObject<MapController | null>;
+  onOpenChange: (open: boolean) => void;
+}
+
+type VectorMode = "geojson-file" | "geojson-url" | "vector-tiles";
+type RasterMode = "tiles" | "cog-url" | "file";
+
+const KIND_LABELS: Record<AddDataKind, string> = {
+  xyz: "Add XYZ Layer",
+  wms: "Add WMS Layer",
+  vector: "Add Vector Layer",
+  raster: "Add Raster Layer",
+};
+
+const SELECT_CLASS =
+  "flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
+
+function createLayerId(): string {
+  return crypto.randomUUID();
+}
+
+function fileNameFromPath(path: string): string {
+  return path.split(/[/\\]/).pop() ?? path;
+}
+
+function layerNameFromPath(path: string, fallback: string): string {
+  return fileNameFromPath(path).replace(/\.[^.]+$/, "") || fallback;
+}
+
+function createBaseLayer(
+  name: string,
+  type: GeoLibreLayer["type"],
+  source: Record<string, unknown>,
+  metadata: Record<string, unknown> = {},
+): GeoLibreLayer {
+  return {
+    id: createLayerId(),
+    name,
+    type,
+    source,
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata,
+  };
+}
+
+function appendQuery(endpoint: string, params: Array<[string, string]>): string {
+  const separator = endpoint.includes("?")
+    ? endpoint.endsWith("?") || endpoint.endsWith("&")
+      ? ""
+      : "&"
+    : "?";
+  const query = params
+    .map(([key, value]) => {
+      const encodedValue =
+        value === "{bbox-epsg-3857}" ? value : encodeURIComponent(value);
+      return `${encodeURIComponent(key)}=${encodedValue}`;
+    })
+    .join("&");
+  return `${endpoint}${separator}${query}`;
+}
+
+function createWmsTileUrl(options: {
+  endpoint: string;
+  layers: string;
+  styles: string;
+  format: string;
+  transparent: boolean;
+  tileSize: number;
+}): string {
+  return appendQuery(options.endpoint, [
+    ["SERVICE", "WMS"],
+    ["REQUEST", "GetMap"],
+    ["VERSION", "1.1.1"],
+    ["LAYERS", options.layers],
+    ["STYLES", options.styles],
+    ["FORMAT", options.format],
+    ["TRANSPARENT", options.transparent ? "TRUE" : "FALSE"],
+    ["SRS", "EPSG:3857"],
+    ["BBOX", "{bbox-epsg-3857}"],
+    ["WIDTH", String(options.tileSize)],
+    ["HEIGHT", String(options.tileSize)],
+  ]);
+}
+
+async function fetchGeoJson(url: string): Promise<FeatureCollection> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+  return (await response.json()) as FeatureCollection;
+}
+
+export function AddDataDialog({
+  kind,
+  mapControllerRef,
+  onOpenChange,
+}: AddDataDialogProps) {
+  const open = kind !== null;
+  const addLayer = useAppStore((s) => s.addLayer);
+  const addGeoJsonLayer = useAppStore((s) => s.addGeoJsonLayer);
+  const title = kind ? KIND_LABELS[kind] : "Add Data";
+
+  const [layerName, setLayerName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const [xyzUrl, setXyzUrl] = useState("");
+  const [xyzTileSize, setXyzTileSize] = useState("256");
+
+  const [wmsEndpoint, setWmsEndpoint] = useState("");
+  const [wmsLayers, setWmsLayers] = useState("");
+  const [wmsStyles, setWmsStyles] = useState("");
+  const [wmsFormat, setWmsFormat] = useState("image/png");
+  const [wmsTransparent, setWmsTransparent] = useState(true);
+  const [wmsTileSize, setWmsTileSize] = useState("256");
+
+  const [vectorMode, setVectorMode] = useState<VectorMode>("geojson-file");
+  const [vectorUrl, setVectorUrl] = useState("");
+  const [vectorSourceLayer, setVectorSourceLayer] = useState("");
+  const [selectedGeoJson, setSelectedGeoJson] = useState<{
+    data: FeatureCollection;
+    path: string;
+  } | null>(null);
+
+  const [rasterMode, setRasterMode] = useState<RasterMode>("tiles");
+  const [rasterUrl, setRasterUrl] = useState("");
+  const [rasterTileSize, setRasterTileSize] = useState("256");
+  const [selectedRasterPath, setSelectedRasterPath] = useState<string | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (!kind) return;
+    setError(null);
+    setIsSubmitting(false);
+    setLayerName(
+      {
+        xyz: "XYZ Layer",
+        wms: "WMS Layer",
+        vector: "Vector Layer",
+        raster: "Raster Layer",
+      }[kind],
+    );
+    setXyzUrl("");
+    setXyzTileSize("256");
+    setWmsEndpoint("");
+    setWmsLayers("");
+    setWmsStyles("");
+    setWmsFormat("image/png");
+    setWmsTransparent(true);
+    setWmsTileSize("256");
+    setVectorMode("geojson-file");
+    setVectorUrl("");
+    setVectorSourceLayer("");
+    setSelectedGeoJson(null);
+    setRasterMode("tiles");
+    setRasterUrl("");
+    setRasterTileSize("256");
+    setSelectedRasterPath(null);
+  }, [kind]);
+
+  const description = useMemo(() => {
+    if (kind === "xyz") {
+      return "Add a raster tile template using x, y, and z placeholders.";
+    }
+    if (kind === "wms") {
+      return "Add a WMS GetMap service as a tiled raster layer.";
+    }
+    if (kind === "vector") {
+      return "Add GeoJSON data or a MapLibre vector tile source.";
+    }
+    if (kind === "raster") {
+      return "Add raster tiles now, or register raster files and COG URLs for project tracking.";
+    }
+    return "";
+  }, [kind]);
+
+  const closeDialog = () => onOpenChange(false);
+
+  const addAndClose = (layer: GeoLibreLayer) => {
+    addLayer(layer);
+    closeDialog();
+  };
+
+  const handleChooseGeoJson = async () => {
+    setError(null);
+    const result = await openGeoJsonFileWithFallback();
+    if (!result) return;
+    setSelectedGeoJson(result);
+    setLayerName((current) =>
+      current.trim() && current !== "Vector Layer"
+        ? current
+        : layerNameFromPath(result.path, "Vector Layer"),
+    );
+  };
+
+  const handleChooseRasterFile = async () => {
+    setError(null);
+    const result = await openLocalDataFileWithFallback({
+      filters: [
+        {
+          name: "Raster",
+          extensions: ["tif", "tiff", "png", "jpg", "jpeg"],
+        },
+      ],
+      accept: ".tif,.tiff,.png,.jpg,.jpeg",
+    });
+    if (!result) return;
+    setSelectedRasterPath(result.path);
+    setLayerName((current) =>
+      current.trim() && current !== "Raster Layer"
+        ? current
+        : layerNameFromPath(result.path, "Raster Layer"),
+    );
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!kind) return;
+    setError(null);
+    setIsSubmitting(true);
+
+    try {
+      const name = layerName.trim() || KIND_LABELS[kind].replace("Add ", "");
+
+      if (kind === "xyz") {
+        if (!xyzUrl.trim()) throw new Error("Enter an XYZ tile URL template.");
+        addAndClose(
+          createBaseLayer(name, "xyz", {
+            type: "raster",
+            tiles: [xyzUrl.trim()],
+            tileSize: Number(xyzTileSize) || 256,
+          }),
+        );
+        return;
+      }
+
+      if (kind === "wms") {
+        if (!wmsEndpoint.trim()) throw new Error("Enter a WMS service URL.");
+        if (!wmsLayers.trim()) {
+          throw new Error("Enter one or more WMS layer names.");
+        }
+        const tileSize = Number(wmsTileSize) || 256;
+        const tileUrl = createWmsTileUrl({
+          endpoint: wmsEndpoint.trim(),
+          layers: wmsLayers.trim(),
+          styles: wmsStyles.trim(),
+          format: wmsFormat,
+          transparent: wmsTransparent,
+          tileSize,
+        });
+        addAndClose(
+          createBaseLayer(
+            name,
+            "wms",
+            {
+              type: "raster",
+              tiles: [tileUrl],
+              tileSize,
+              url: wmsEndpoint.trim(),
+              layers: wmsLayers.trim(),
+              styles: wmsStyles.trim(),
+              format: wmsFormat,
+              transparent: wmsTransparent,
+            },
+            { service: "wms" },
+          ),
+        );
+        return;
+      }
+
+      if (kind === "vector") {
+        if (vectorMode === "geojson-file") {
+          if (!selectedGeoJson) throw new Error("Choose a GeoJSON file.");
+          const id = addGeoJsonLayer(
+            name,
+            selectedGeoJson.data,
+            selectedGeoJson.path,
+          );
+          const layer = useAppStore.getState().layers.find((l) => l.id === id);
+          if (layer) mapControllerRef.current?.fitLayer(layer);
+          closeDialog();
+          return;
+        }
+
+        if (vectorMode === "geojson-url") {
+          if (!vectorUrl.trim()) throw new Error("Enter a GeoJSON URL.");
+          const data = await fetchGeoJson(vectorUrl.trim());
+          const id = addGeoJsonLayer(name, data, vectorUrl.trim());
+          const layer = useAppStore.getState().layers.find((l) => l.id === id);
+          if (layer) mapControllerRef.current?.fitLayer(layer);
+          closeDialog();
+          return;
+        }
+
+        if (!vectorUrl.trim()) throw new Error("Enter a vector tile source URL.");
+        if (!vectorSourceLayer.trim()) {
+          throw new Error("Enter the vector tile source layer name.");
+        }
+        addAndClose(
+          createBaseLayer(name, "vector-tiles", {
+            type: "vector",
+            url: vectorUrl.trim(),
+            sourceLayer: vectorSourceLayer.trim(),
+          }),
+        );
+        return;
+      }
+
+      if (rasterMode === "tiles") {
+        if (!rasterUrl.trim()) {
+          throw new Error("Enter a raster tile URL template.");
+        }
+        addAndClose(
+          createBaseLayer(name, "raster", {
+            type: "raster",
+            tiles: [rasterUrl.trim()],
+            tileSize: Number(rasterTileSize) || 256,
+          }),
+        );
+        return;
+      }
+
+      if (rasterMode === "cog-url") {
+        if (!rasterUrl.trim()) throw new Error("Enter a raster URL.");
+        addAndClose(
+          createBaseLayer(
+            name,
+            "cog",
+            { type: "raster", url: rasterUrl.trim() },
+            { placeholder: true, sourceKind: "cog-url" },
+          ),
+        );
+        return;
+      }
+
+      if (!selectedRasterPath) throw new Error("Choose a raster file.");
+      const layer = createBaseLayer(
+        name,
+        "cog",
+        { type: "raster", path: selectedRasterPath },
+        { placeholder: true, sourceKind: "raster-file" },
+      );
+      layer.sourcePath = selectedRasterPath;
+      addAndClose(layer);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not add layer.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Database className="h-4 w-4" />
+            {title}
+          </DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="space-y-1.5">
+            <Label htmlFor="add-data-layer-name">Layer name</Label>
+            <Input
+              id="add-data-layer-name"
+              value={layerName}
+              onChange={(event) => setLayerName(event.target.value)}
+            />
+          </div>
+
+          {kind === "xyz" && (
+            <div className="grid gap-3 sm:grid-cols-[1fr_7rem]">
+              <div className="space-y-1.5">
+                <Label htmlFor="xyz-url">Tile URL template</Label>
+                <Input
+                  id="xyz-url"
+                  placeholder="https://example.com/{z}/{x}/{y}.png"
+                  value={xyzUrl}
+                  onChange={(event) => setXyzUrl(event.target.value)}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="xyz-tile-size">Tile size</Label>
+                <Input
+                  id="xyz-tile-size"
+                  inputMode="numeric"
+                  value={xyzTileSize}
+                  onChange={(event) => setXyzTileSize(event.target.value)}
+                />
+              </div>
+            </div>
+          )}
+
+          {kind === "wms" && (
+            <div className="space-y-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="wms-endpoint">Service URL</Label>
+                <Input
+                  id="wms-endpoint"
+                  placeholder="https://example.com/geoserver/wms"
+                  value={wmsEndpoint}
+                  onChange={(event) => setWmsEndpoint(event.target.value)}
+                />
+              </div>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="space-y-1.5">
+                  <Label htmlFor="wms-layers">Layers</Label>
+                  <Input
+                    id="wms-layers"
+                    placeholder="workspace:layer"
+                    value={wmsLayers}
+                    onChange={(event) => setWmsLayers(event.target.value)}
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="wms-styles">Styles</Label>
+                  <Input
+                    id="wms-styles"
+                    value={wmsStyles}
+                    onChange={(event) => setWmsStyles(event.target.value)}
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="wms-format">Format</Label>
+                  <select
+                    id="wms-format"
+                    className={SELECT_CLASS}
+                    value={wmsFormat}
+                    onChange={(event) => setWmsFormat(event.target.value)}
+                  >
+                    <option value="image/png">PNG</option>
+                    <option value="image/jpeg">JPEG</option>
+                  </select>
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="wms-tile-size">Tile size</Label>
+                  <Input
+                    id="wms-tile-size"
+                    inputMode="numeric"
+                    value={wmsTileSize}
+                    onChange={(event) => setWmsTileSize(event.target.value)}
+                  />
+                </div>
+              </div>
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={wmsTransparent}
+                  onChange={(event) => setWmsTransparent(event.target.checked)}
+                />
+                Transparent background
+              </label>
+            </div>
+          )}
+
+          {kind === "vector" && (
+            <div className="space-y-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="vector-mode">Source type</Label>
+                <select
+                  id="vector-mode"
+                  className={SELECT_CLASS}
+                  value={vectorMode}
+                  onChange={(event) =>
+                    setVectorMode(event.target.value as VectorMode)
+                  }
+                >
+                  <option value="geojson-file">GeoJSON file</option>
+                  <option value="geojson-url">GeoJSON URL</option>
+                  <option value="vector-tiles">Vector tile source URL</option>
+                </select>
+              </div>
+              {vectorMode === "geojson-file" ? (
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={handleChooseGeoJson}
+                  >
+                    <FileUp className="mr-2 h-3.5 w-3.5" />
+                    Choose file
+                  </Button>
+                  <span className="min-w-0 truncate text-xs text-muted-foreground">
+                    {selectedGeoJson
+                      ? fileNameFromPath(selectedGeoJson.path)
+                      : "No file selected"}
+                  </span>
+                </div>
+              ) : (
+                <div className="space-y-1.5">
+                  <Label htmlFor="vector-url">
+                    {vectorMode === "geojson-url"
+                      ? "GeoJSON URL"
+                      : "Source URL"}
+                  </Label>
+                  <Input
+                    id="vector-url"
+                    placeholder={
+                      vectorMode === "geojson-url"
+                        ? "https://example.com/data.geojson"
+                        : "mapbox://tileset or https://example.com/tiles.json"
+                    }
+                    value={vectorUrl}
+                    onChange={(event) => setVectorUrl(event.target.value)}
+                  />
+                </div>
+              )}
+              {vectorMode === "vector-tiles" && (
+                <div className="space-y-1.5">
+                  <Label htmlFor="vector-source-layer">Source layer</Label>
+                  <Input
+                    id="vector-source-layer"
+                    value={vectorSourceLayer}
+                    onChange={(event) => setVectorSourceLayer(event.target.value)}
+                  />
+                </div>
+              )}
+            </div>
+          )}
+
+          {kind === "raster" && (
+            <div className="space-y-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="raster-mode">Source type</Label>
+                <select
+                  id="raster-mode"
+                  className={SELECT_CLASS}
+                  value={rasterMode}
+                  onChange={(event) =>
+                    setRasterMode(event.target.value as RasterMode)
+                  }
+                >
+                  <option value="tiles">Raster tile URL template</option>
+                  <option value="cog-url">COG or raster URL</option>
+                  <option value="file">Raster file</option>
+                </select>
+              </div>
+              {rasterMode === "file" ? (
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={handleChooseRasterFile}
+                  >
+                    <Image className="mr-2 h-3.5 w-3.5" />
+                    Choose file
+                  </Button>
+                  <span className="min-w-0 truncate text-xs text-muted-foreground">
+                    {selectedRasterPath
+                      ? fileNameFromPath(selectedRasterPath)
+                      : "No file selected"}
+                  </span>
+                </div>
+              ) : (
+                <div className="grid gap-3 sm:grid-cols-[1fr_7rem]">
+                  <div className="space-y-1.5">
+                    <Label htmlFor="raster-url">
+                      {rasterMode === "tiles"
+                        ? "Tile URL template"
+                        : "Raster URL"}
+                    </Label>
+                    <Input
+                      id="raster-url"
+                      placeholder={
+                        rasterMode === "tiles"
+                          ? "https://example.com/{z}/{x}/{y}.png"
+                          : "https://example.com/image.tif"
+                      }
+                      value={rasterUrl}
+                      onChange={(event) => setRasterUrl(event.target.value)}
+                    />
+                  </div>
+                  {rasterMode === "tiles" && (
+                    <div className="space-y-1.5">
+                      <Label htmlFor="raster-tile-size">Tile size</Label>
+                      <Input
+                        id="raster-tile-size"
+                        inputMode="numeric"
+                        value={rasterTileSize}
+                        onChange={(event) =>
+                          setRasterTileSize(event.target.value)
+                        }
+                      />
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+
+          {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="ghost" onClick={closeDialog}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {kind === "wms" ? (
+                <Globe2 className="mr-2 h-3.5 w-3.5" />
+              ) : kind === "raster" ? (
+                <Image className="mr-2 h-3.5 w-3.5" />
+              ) : (
+                <MapIcon className="mr-2 h-3.5 w-3.5" />
+              )}
+              Add layer
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -213,6 +213,11 @@ export function AddDataDialog({
 
   const closeDialog = () => onOpenChange(false);
 
+  const handleOpenChange = (next: boolean) => {
+    if (!next && isSubmitting) return;
+    onOpenChange(next);
+  };
+
   const addAndClose = (layer: GeoLibreLayer) => {
     addLayer(layer);
     closeDialog();
@@ -220,14 +225,18 @@ export function AddDataDialog({
 
   const handleChooseGeoJson = async () => {
     setError(null);
-    const result = await openGeoJsonFileWithFallback();
-    if (!result) return;
-    setSelectedGeoJson(result);
-    setLayerName((current) =>
-      current.trim() && current !== "Vector Layer"
-        ? current
-        : layerNameFromPath(result.path, "Vector Layer"),
-    );
+    try {
+      const result = await openGeoJsonFileWithFallback();
+      if (!result) return;
+      setSelectedGeoJson(result);
+      setLayerName((current) =>
+        current.trim() && current !== "Vector Layer"
+          ? current
+          : layerNameFromPath(result.path, "Vector Layer"),
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not read file.");
+    }
   };
 
   const handleChooseRasterFile = async () => {
@@ -387,7 +396,7 @@ export function AddDataDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-xl">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
@@ -630,7 +639,12 @@ export function AddDataDialog({
           {error ? <p className="text-sm text-destructive">{error}</p> : null}
 
           <div className="flex justify-end gap-2">
-            <Button type="button" variant="ghost" onClick={closeDialog}>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={closeDialog}
+              disabled={isSubmitting}
+            >
               Cancel
             </Button>
             <Button type="submit" disabled={isSubmitting}>

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -21,7 +21,7 @@ import {
   Input,
 } from "@geolibre/ui";
 import {
-  FileJson,
+  Database,
   FolderOpen,
   Layers,
   Map,
@@ -35,11 +35,8 @@ import {
 import { useState } from "react";
 import { createAppAPI, usePluginRegistry } from "../../hooks/usePlugins";
 import type { ThemeMode } from "../../hooks/useThemeMode";
-import {
-  openGeoJsonFileWithFallback,
-  openProjectFile,
-  saveProjectFile,
-} from "../../lib/tauri-io";
+import { openProjectFile, saveProjectFile } from "../../lib/tauri-io";
+import { AddDataDialog, type AddDataKind } from "./AddDataDialog";
 import { AboutDialog } from "./AboutDialog";
 import { NewProjectDialog } from "./NewProjectDialog";
 
@@ -81,7 +78,6 @@ export function TopToolbar({
   onToggleThemeMode,
 }: TopToolbarProps) {
   const loadProject = useAppStore((s) => s.loadProject);
-  const addGeoJsonLayer = useAppStore((s) => s.addGeoJsonLayer);
   const setProcessingOpen = useAppStore((s) => s.setProcessingOpen);
   const projectName = useAppStore((s) => s.projectName);
   const projectPath = useAppStore((s) => s.projectPath);
@@ -99,6 +95,7 @@ export function TopToolbar({
       {} as Record<ToolbarMapControl, boolean>,
     ),
   );
+  const [addDataKind, setAddDataKind] = useState<AddDataKind | null>(null);
 
   const handleOpen = async () => {
     const result = await openProjectFile();
@@ -124,18 +121,6 @@ export function TopToolbar({
     setProjectPath(path);
     markSaved();
     return true;
-  };
-
-  const handleAddGeoJson = async () => {
-    const result = await openGeoJsonFileWithFallback();
-    if (!result) return;
-    const name =
-      result.path.split(/[/\\]/).pop()?.replace(/\.[^.]+$/, "") ?? "Layer";
-    addGeoJsonLayer(name, result.data, result.path);
-    const layer = useAppStore
-      .getState()
-      .layers.find((l) => l.sourcePath === result.path);
-    if (layer) mapControllerRef.current?.fitLayer(layer);
   };
 
   const {
@@ -171,15 +156,30 @@ export function TopToolbar({
         <Save className="h-3.5 w-3.5 sm:mr-1" />
         <span className="hidden sm:inline">Save</span>
       </Button>
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={handleAddGeoJson}
-        aria-label="Add GeoJSON"
-      >
-        <FileJson className="h-3.5 w-3.5 sm:mr-1" />
-        <span className="hidden sm:inline">Add GeoJSON</span>
-      </Button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="sm" aria-label="Add Data">
+            <Database className="h-3.5 w-3.5 sm:mr-1" />
+            <span className="hidden sm:inline">Add Data</span>
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          <DropdownMenuLabel>Add data</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={() => setAddDataKind("xyz")}>
+            Add XYZ Layer
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setAddDataKind("wms")}>
+            Add WMS Layer
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setAddDataKind("vector")}>
+            Add Vector Layer
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setAddDataKind("raster")}>
+            Add Raster Layer
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
       <Button
         variant="ghost"
         size="sm"
@@ -272,6 +272,13 @@ export function TopToolbar({
           })}
         </DropdownMenuContent>
       </DropdownMenu>
+      <AddDataDialog
+        kind={addDataKind}
+        mapControllerRef={mapControllerRef}
+        onOpenChange={(open) => {
+          if (!open) setAddDataKind(null);
+        }}
+      />
       <AboutDialog />
       <div className="ml-auto flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
         <Button

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -47,6 +47,8 @@ export function LayerPanel({ mapControllerRef }: LayerPanelProps) {
   const reorderLayer = useAppStore((s) => s.reorderLayer);
   const removeLayer = useAppStore((s) => s.removeLayer);
   const [metadataLayer, setMetadataLayer] = useState<GeoLibreLayer | null>(null);
+  const [layerPendingRemoval, setLayerPendingRemoval] =
+    useState<GeoLibreLayer | null>(null);
   const [isCollapsed, setIsCollapsed] = useState(isMobileViewport);
 
   if (isCollapsed) {
@@ -208,9 +210,10 @@ export function LayerPanel({ mapControllerRef }: LayerPanelProps) {
                   variant="ghost"
                   size="icon"
                   className="h-7 w-7 text-destructive"
+                  title="Remove layer"
                   onClick={(e) => {
                     e.stopPropagation();
-                    removeLayer(layer.id);
+                    setLayerPendingRemoval(layer);
                   }}
                 >
                   <Trash2 className="h-3.5 w-3.5" />
@@ -225,21 +228,68 @@ export function LayerPanel({ mapControllerRef }: LayerPanelProps) {
         {/* TODO(v0.3): Add PMTiles, COG, FlatGeobuf, GeoParquet layer types */}
         Advanced formats: see docs/roadmap.md
       </p>
-      <Dialog open={!!metadataLayer} onOpenChange={(open) => { if (!open) setMetadataLayer(null); }}>
+      <Dialog
+        open={!!metadataLayer}
+        onOpenChange={(open) => {
+          if (!open) setMetadataLayer(null);
+        }}
+      >
         <DialogContent>
           <DialogHeader>
             <DialogTitle>{metadataLayer?.name} Metadata</DialogTitle>
-            <DialogDescription>Layer metadata and source information</DialogDescription>
+            <DialogDescription>
+              Layer metadata and source information
+            </DialogDescription>
           </DialogHeader>
           <ScrollArea className="max-h-80">
             <pre className="whitespace-pre-wrap break-all text-xs">
-              {metadataLayer && JSON.stringify(
-                { ...metadataLayer.metadata, sourcePath: metadataLayer.sourcePath },
-                null,
-                2,
-              )}
+              {metadataLayer &&
+                JSON.stringify(
+                  {
+                    ...metadataLayer.metadata,
+                    sourcePath: metadataLayer.sourcePath,
+                  },
+                  null,
+                  2,
+                )}
             </pre>
           </ScrollArea>
+        </DialogContent>
+      </Dialog>
+      <Dialog
+        open={!!layerPendingRemoval}
+        onOpenChange={(open) => {
+          if (!open) setLayerPendingRemoval(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Remove layer?</DialogTitle>
+            <DialogDescription>
+              This removes {layerPendingRemoval?.name ?? "this layer"} from the
+              project and map.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => setLayerPendingRemoval(null)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={() => {
+                if (!layerPendingRemoval) return;
+                removeLayer(layerPendingRemoval.id);
+                setLayerPendingRemoval(null);
+              }}
+            >
+              Remove
+            </Button>
+          </div>
         </DialogContent>
       </Dialog>
     </aside>

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -91,7 +91,7 @@ export function LayerPanel({ mapControllerRef }: LayerPanelProps) {
         <div className="space-y-1 p-2">
           {layers.length === 0 && (
             <p className="px-2 py-4 text-xs text-muted-foreground">
-              No layers. Add GeoJSON from the toolbar.
+              No layers. Add data from the toolbar.
             </p>
           )}
           {[...layers].reverse().map((layer) => (

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1,5 +1,10 @@
-import { useAppStore } from "@geolibre/core";
-import { Button, Input, Label, ScrollArea, Separator } from "@geolibre/ui";
+import {
+  DEFAULT_LAYER_STYLE,
+  type LayerStyle,
+  type LayerType,
+  useAppStore,
+} from "@geolibre/core";
+import { Button, Input, Label, ScrollArea, Separator, Slider } from "@geolibre/ui";
 import {
   PanelRightClose,
   PanelRightOpen,
@@ -14,9 +19,61 @@ function isMobileViewport(): boolean {
   );
 }
 
+function isRasterPaintLayer(type: LayerType): boolean {
+  return type === "raster" || type === "wms" || type === "xyz";
+}
+
+function styleValue<K extends keyof LayerStyle>(
+  style: LayerStyle,
+  key: K,
+): LayerStyle[K] {
+  return style[key] ?? DEFAULT_LAYER_STYLE[key];
+}
+
+interface RasterStyleSliderProps {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  onChange: (value: number) => void;
+  format?: (value: number) => string;
+}
+
+function RasterStyleSlider({
+  label,
+  value,
+  min,
+  max,
+  step,
+  onChange,
+  format = (next) => next.toFixed(2),
+}: RasterStyleSliderProps) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-3">
+        <Label className="text-xs">{label}</Label>
+        <span className="shrink-0 font-mono text-xs text-muted-foreground">
+          {format(value)}
+        </span>
+      </div>
+      <Slider
+        min={min}
+        max={max}
+        step={step}
+        value={[value]}
+        onValueChange={([next]) => {
+          if (typeof next === "number") onChange(next);
+        }}
+      />
+    </div>
+  );
+}
+
 export function StylePanel() {
   const selectedLayerId = useAppStore((s) => s.selectedLayerId);
   const layers = useAppStore((s) => s.layers);
+  const setLayerOpacity = useAppStore((s) => s.setLayerOpacity);
   const setLayerStyle = useAppStore((s) => s.setLayerStyle);
   const [isCollapsed, setIsCollapsed] = useState(isMobileViewport);
 
@@ -71,6 +128,96 @@ export function StylePanel() {
   const { style } = layer;
   const hasVectorPaintControls =
     layer.type === "geojson" || layer.type === "vector-tiles";
+  const hasRasterPaintControls = isRasterPaintLayer(layer.type);
+
+  if (hasRasterPaintControls) {
+    return (
+      <aside className="flex max-h-56 w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-64 md:border-l md:border-t-0">
+        <div className="flex items-center justify-between gap-2 border-b px-3 py-1.5">
+          <span className="truncate text-sm font-semibold">
+            Style - {layer.name}
+          </span>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 shrink-0"
+            title="Collapse style"
+            aria-label="Collapse style"
+            onClick={() => setIsCollapsed(true)}
+          >
+            <PanelRightClose className="h-4 w-4" />
+          </Button>
+        </div>
+        <ScrollArea className="flex-1 p-3">
+          <div className="space-y-4">
+            <RasterStyleSlider
+              label="Opacity"
+              value={layer.opacity}
+              min={0}
+              max={1}
+              step={0.05}
+              onChange={(value) => setLayerOpacity(layer.id, value)}
+            />
+            <RasterStyleSlider
+              label="Brightness Min"
+              value={styleValue(style, "rasterBrightnessMin")}
+              min={0}
+              max={1}
+              step={0.05}
+              onChange={(value) =>
+                setLayerStyle(layer.id, { rasterBrightnessMin: value })
+              }
+            />
+            <RasterStyleSlider
+              label="Brightness Max"
+              value={styleValue(style, "rasterBrightnessMax")}
+              min={0}
+              max={1}
+              step={0.05}
+              onChange={(value) =>
+                setLayerStyle(layer.id, { rasterBrightnessMax: value })
+              }
+            />
+            <RasterStyleSlider
+              label="Saturation"
+              value={styleValue(style, "rasterSaturation")}
+              min={-1}
+              max={1}
+              step={0.05}
+              onChange={(value) =>
+                setLayerStyle(layer.id, { rasterSaturation: value })
+              }
+            />
+            <RasterStyleSlider
+              label="Contrast"
+              value={styleValue(style, "rasterContrast")}
+              min={-1}
+              max={1}
+              step={0.05}
+              onChange={(value) =>
+                setLayerStyle(layer.id, { rasterContrast: value })
+              }
+            />
+            <RasterStyleSlider
+              label="Hue Rotate"
+              value={styleValue(style, "rasterHueRotate")}
+              min={0}
+              max={360}
+              step={1}
+              onChange={(value) =>
+                setLayerStyle(layer.id, { rasterHueRotate: value })
+              }
+              format={(value) => value.toFixed(0)}
+            />
+          </div>
+        </ScrollArea>
+        <Separator />
+        <p className="p-2 text-[10px] text-muted-foreground">
+          Changes apply live to MapLibre raster paint properties.
+        </p>
+      </aside>
+    );
+  }
 
   if (!hasVectorPaintControls) {
     return (
@@ -91,8 +238,7 @@ export function StylePanel() {
           </Button>
         </div>
         <p className="p-4 text-xs text-muted-foreground">
-          Paint controls are available for vector layers. Use layer opacity in
-          the Layers panel for this layer type.
+          Style controls are not available for this layer type yet.
         </p>
         <Separator />
         <p className="p-2 text-[10px] text-muted-foreground">

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -69,12 +69,44 @@ export function StylePanel() {
   }
 
   const { style } = layer;
+  const hasVectorPaintControls =
+    layer.type === "geojson" || layer.type === "vector-tiles";
+
+  if (!hasVectorPaintControls) {
+    return (
+      <aside className="flex max-h-56 w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-64 md:border-l md:border-t-0">
+        <div className="flex items-center justify-between gap-2 border-b px-3 py-1.5">
+          <span className="truncate text-sm font-semibold">
+            Style - {layer.name}
+          </span>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 shrink-0"
+            title="Collapse style"
+            aria-label="Collapse style"
+            onClick={() => setIsCollapsed(true)}
+          >
+            <PanelRightClose className="h-4 w-4" />
+          </Button>
+        </div>
+        <p className="p-4 text-xs text-muted-foreground">
+          Paint controls are available for vector layers. Use layer opacity in
+          the Layers panel for this layer type.
+        </p>
+        <Separator />
+        <p className="p-2 text-[10px] text-muted-foreground">
+          Selected layer type: {layer.type}
+        </p>
+      </aside>
+    );
+  }
 
   return (
     <aside className="flex max-h-56 w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-64 md:border-l md:border-t-0">
       <div className="flex items-center justify-between gap-2 border-b px-3 py-1.5">
         <span className="truncate text-sm font-semibold">
-          Style — {layer.name}
+          Style - {layer.name}
         </span>
         <Button
           variant="ghost"

--- a/apps/geolibre-desktop/src/lib/swipe-style.ts
+++ b/apps/geolibre-desktop/src/lib/swipe-style.ts
@@ -2,6 +2,10 @@ const SWIPE_STYLE_ID = "maplibre-gl-swipe-style-fixes";
 const SWIPE_SELECT_PROXY_CLASS = "swipe-select-proxy";
 const SWIPE_SELECT_MENU_CLASS = "swipe-select-menu";
 
+interface GeoLibreLayerLabelWindow extends Window {
+  __GEOLIBRE_LAYER_LABELS__?: Record<string, string>;
+}
+
 const SWIPE_SELECT_FIXES = `
 .swipe-control-panel .swipe-control-select {
   color: #111827;
@@ -90,6 +94,40 @@ const SWIPE_SELECT_FIXES = `
 .swipe-select-menu button.is-selected {
   background: #4a90d9;
   color: #fff;
+}
+
+.swipe-control-panel .swipe-layer-item input[type="checkbox"] {
+  appearance: none;
+  -webkit-appearance: none;
+  align-items: center;
+  background: #fff;
+  border: 1px solid #cbd5e1;
+  border-radius: 2px;
+  box-sizing: border-box;
+  display: inline-flex;
+  flex: 0 0 auto;
+  height: 14px;
+  justify-content: center;
+  margin: 0;
+  width: 14px;
+}
+
+.swipe-control-panel .swipe-layer-item input[type="checkbox"]:hover {
+  border-color: #4a90d9;
+}
+
+.swipe-control-panel .swipe-layer-item input[type="checkbox"]:focus-visible {
+  box-shadow: 0 0 0 2px rgba(74, 144, 217, 0.18);
+  outline: none;
+}
+
+.swipe-control-panel .swipe-layer-item input[type="checkbox"]:checked {
+  background-color: #4a90d9;
+  border-color: #4a90d9;
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 10 10' fill='none'%3E%3Cpath d='M2 5 4 7 8 3' stroke='%23fff' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 10px 10px;
 }
 `;
 
@@ -219,9 +257,62 @@ const enhanceSwipeSelects = () => {
     .forEach(enhanceSwipeSelect);
 };
 
+let swipeEnhanceFrame: number | null = null;
+
+const getSwipeLayerLabel = (layerId: string): string => {
+  if (layerId === "__basemap__") return "Basemap";
+  return (
+    (window as GeoLibreLayerLabelWindow).__GEOLIBRE_LAYER_LABELS__?.[layerId] ??
+    layerId
+  );
+};
+
+const syncSwipeLayerLabels = () => {
+  document
+    .querySelectorAll<HTMLInputElement>(
+      '.swipe-control-panel .swipe-layer-item input[type="checkbox"][data-layer-id]',
+    )
+    .forEach((checkbox) => {
+      const layerId = checkbox.dataset.layerId;
+      if (!layerId) return;
+
+      const label = checkbox.parentElement?.querySelector<HTMLLabelElement>(
+        `label[for="${CSS.escape(checkbox.id)}"]`,
+      );
+      if (!label) return;
+
+      const displayName = getSwipeLayerLabel(layerId);
+      const title =
+        layerId === "__basemap__" ? "Basemap" : `${displayName} (${layerId})`;
+      if (label.textContent !== displayName) {
+        label.textContent = displayName;
+      }
+      if (label.title !== title) {
+        label.title = title;
+      }
+    });
+};
+
+const enhanceSwipePanel = () => {
+  enhanceSwipeSelects();
+  syncSwipeLayerLabels();
+};
+
+const scheduleEnhanceSwipePanel = () => {
+  if (swipeEnhanceFrame !== null) return;
+  swipeEnhanceFrame = window.requestAnimationFrame(() => {
+    swipeEnhanceFrame = null;
+    enhanceSwipePanel();
+  });
+};
+
 if (typeof document !== "undefined") {
   document.addEventListener("click", closeSwipeSelectMenu);
   window.addEventListener("resize", closeSwipeSelectMenu);
+  window.addEventListener(
+    "geolibre-layer-labels-change",
+    scheduleEnhanceSwipePanel,
+  );
   window.addEventListener(
     "scroll",
     (event) => {
@@ -234,7 +325,7 @@ if (typeof document !== "undefined") {
     true,
   );
 
-  const observer = new MutationObserver(enhanceSwipeSelects);
+  const observer = new MutationObserver(scheduleEnhanceSwipePanel);
   observer.observe(document.body, { childList: true, subtree: true });
-  enhanceSwipeSelects();
+  scheduleEnhanceSwipePanel();
 }

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -7,6 +7,50 @@ function isTauri(): boolean {
   return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 }
 
+interface FileDialogFilter {
+  name: string;
+  extensions: string[];
+}
+
+interface LocalDataFileOptions {
+  filters: FileDialogFilter[];
+  accept: string;
+  readText?: boolean;
+}
+
+export async function openLocalDataFileWithFallback(
+  options: LocalDataFileOptions,
+): Promise<{
+  path: string;
+  text?: string;
+} | null> {
+  if (isTauri()) {
+    const selected = await open({
+      multiple: false,
+      filters: options.filters,
+    });
+    if (!selected || typeof selected !== "string") return null;
+    const text = options.readText ? await readTextFile(selected) : undefined;
+    return { path: selected, text };
+  }
+
+  return new Promise((resolve) => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = options.accept;
+    input.onchange = async () => {
+      const file = input.files?.[0];
+      if (!file) {
+        resolve(null);
+        return;
+      }
+      const text = options.readText ? await file.text() : undefined;
+      resolve({ path: file.name, text });
+    };
+    input.click();
+  });
+}
+
 export async function openGeoJsonFile(): Promise<{
   data: FeatureCollection;
   path: string;

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -7,6 +7,10 @@ function isTauri(): boolean {
   return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 }
 
+function browserSafeFileName(path: string): string {
+  return path.split(/[/\\]/).pop() || "project.geolibre.json";
+}
+
 interface FileDialogFilter {
   name: string;
   extensions: string[];
@@ -16,6 +20,125 @@ interface LocalDataFileOptions {
   filters: FileDialogFilter[];
   accept: string;
   readText?: boolean;
+}
+
+interface BrowserFilePickerType {
+  description: string;
+  accept: Record<string, string[]>;
+}
+
+interface BrowserOpenFileHandle {
+  name: string;
+  getFile: () => Promise<File>;
+}
+
+interface BrowserWritableFileStream {
+  write: (data: string | Blob) => Promise<void>;
+  close: () => Promise<void>;
+}
+
+interface BrowserSaveFileHandle {
+  name: string;
+  createWritable: () => Promise<BrowserWritableFileStream>;
+}
+
+interface BrowserFilePickerWindow extends Window {
+  showOpenFilePicker?: (options: {
+    multiple?: boolean;
+    types?: BrowserFilePickerType[];
+    excludeAcceptAllOption?: boolean;
+  }) => Promise<BrowserOpenFileHandle[]>;
+  showSaveFilePicker?: (options: {
+    suggestedName?: string;
+    types?: BrowserFilePickerType[];
+    excludeAcceptAllOption?: boolean;
+  }) => Promise<BrowserSaveFileHandle>;
+}
+
+const GEOLIBRE_PROJECT_FILE_TYPES: BrowserFilePickerType[] = [
+  {
+    description: "GeoLibre Project",
+    accept: {
+      "application/json": [".geolibre", ".json"],
+    },
+  },
+];
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}
+
+async function openProjectFileBrowser(): Promise<{
+  project: GeoLibreProject;
+  path: string;
+} | null> {
+  const pickerWindow = window as BrowserFilePickerWindow;
+  if (pickerWindow.showOpenFilePicker) {
+    try {
+      const [handle] = await pickerWindow.showOpenFilePicker({
+        multiple: false,
+        types: GEOLIBRE_PROJECT_FILE_TYPES,
+        excludeAcceptAllOption: false,
+      });
+      if (!handle) return null;
+      const file = await handle.getFile();
+      return {
+        project: parseProject(await file.text()),
+        path: handle.name || file.name,
+      };
+    } catch (error) {
+      if (isAbortError(error)) return null;
+      console.warn("Browser project file picker failed", error);
+    }
+  }
+
+  const result = await openLocalDataFileWithFallback({
+    filters: [{ name: "GeoLibre Project", extensions: ["geolibre", "json"] }],
+    accept: ".geolibre,.json,.geolibre.json",
+    readText: true,
+  });
+  if (!result?.text) return null;
+  return {
+    project: parseProject(result.text),
+    path: result.path,
+  };
+}
+
+async function saveProjectFileBrowser(
+  content: string,
+  defaultName?: string,
+): Promise<string | null> {
+  const fileName = browserSafeFileName(defaultName ?? "project.geolibre.json");
+  const pickerWindow = window as BrowserFilePickerWindow;
+
+  if (pickerWindow.showSaveFilePicker) {
+    try {
+      const handle = await pickerWindow.showSaveFilePicker({
+        suggestedName: fileName,
+        types: GEOLIBRE_PROJECT_FILE_TYPES,
+        excludeAcceptAllOption: false,
+      });
+      const writable = await handle.createWritable();
+      await writable.write(content);
+      await writable.close();
+      return handle.name || fileName;
+    } catch (error) {
+      if (isAbortError(error)) return null;
+      console.warn("Browser project save picker failed", error);
+    }
+  }
+
+  const blob = new Blob([content], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = fileName;
+  link.style.display = "none";
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+  return fileName;
 }
 
 export async function openLocalDataFileWithFallback(
@@ -73,7 +196,10 @@ export async function openProjectFile(): Promise<{
   project: GeoLibreProject;
   path: string;
 } | null> {
-  if (!isTauri()) return null;
+  if (!isTauri()) {
+    return openProjectFileBrowser();
+  }
+
   const selected = await open({
     multiple: false,
     filters: [{ name: "GeoLibre Project", extensions: ["geolibre", "json"] }],
@@ -88,7 +214,10 @@ export async function saveProjectFile(
   content: string,
   defaultName?: string,
 ): Promise<string | null> {
-  if (!isTauri()) return null;
+  if (!isTauri()) {
+    return saveProjectFileBrowser(content, defaultName);
+  }
+
   const path = await save({
     filters: [{ name: "GeoLibre Project", extensions: ["geolibre", "json"] }],
     defaultPath: defaultName ?? "project.geolibre.json",

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -1,15 +1,17 @@
 import react from "@vitejs/plugin-react";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
 import type {
   RollupLog,
   RollupOptions,
   WarningHandlerWithDefault,
 } from "rollup";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 
 const GEOAGENT_BROWSER_BUNDLE = "maplibre-gl-geoagent/dist/browser-";
 const GIS_CHUNK_WARNING_LIMIT_KB = 5000;
 const APP_BASE = process.env.GEOLIBRE_APP_BASE;
+const WMS_PROXY_PATH = "/__geolibre_wms_proxy";
 
 function manualChunks(id: string): string | undefined {
   if (!id.includes("node_modules")) return undefined;
@@ -36,9 +38,53 @@ function onwarn(
   defaultHandler(warning);
 }
 
+function wmsProxyPlugin(): Plugin {
+  return {
+    name: "geolibre-wms-proxy",
+    configureServer(server) {
+      server.middlewares.use(WMS_PROXY_PATH, async (req, res) => {
+        try {
+          await proxyWmsRequest(req, res);
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : "WMS proxy request failed";
+          res.statusCode = 502;
+          res.setHeader("content-type", "text/plain");
+          res.end(message);
+        }
+      });
+    },
+  };
+}
+
+async function proxyWmsRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  const requestUrl = new URL(req.url ?? "", `http://localhost${WMS_PROXY_PATH}`);
+  const target = requestUrl.searchParams.get("url");
+  if (!target || !/^https?:\/\//i.test(target)) {
+    res.statusCode = 400;
+    res.setHeader("content-type", "text/plain");
+    res.end("Missing or invalid WMS target URL");
+    return;
+  }
+
+  const response = await fetch(target);
+  const contentType =
+    response.headers.get("content-type") ?? "application/octet-stream";
+  const body = Buffer.from(await response.arrayBuffer());
+
+  res.statusCode = response.status;
+  res.setHeader("access-control-allow-origin", "*");
+  res.setHeader("cache-control", "public, max-age=3600");
+  res.setHeader("content-type", contentType);
+  res.end(body);
+}
+
 export default defineConfig({
   base: APP_BASE,
-  plugins: [react()],
+  plugins: [react(), wmsProxyPlugin()],
   clearScreen: false,
   server: {
     port: 1420,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,7 +37,7 @@ nav:
   - Home: index.md
   - Getting Started: getting-started.md
   - Downloads: downloads.md
-  - Live Demo: https://geolibre.app/demo/
+  - Live Demo: /demo/
   - Documentation:
       - Architecture: architecture.md
       - Project Format: project-format.md

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -50,7 +50,7 @@ export interface AppState {
   setProjectName: (name: string) => void;
   markSaved: () => void;
 
-  addLayer: (layer: GeoLibreLayer) => void;
+  addLayer: (layer: GeoLibreLayer, beforeLayerId?: string | null) => void;
   removeLayer: (id: string) => void;
   updateLayer: (id: string, patch: Partial<GeoLibreLayer>) => void;
   setLayerVisibility: (id: string, visible: boolean) => void;
@@ -61,6 +61,7 @@ export interface AppState {
     name: string,
     geojson: FeatureCollection,
     sourcePath?: string,
+    beforeLayerId?: string | null,
   ) => string;
 }
 
@@ -139,12 +140,27 @@ export const useAppStore = create<AppState>((set, get) => ({
   setProjectName: (name) => set({ projectName: name, isDirty: true }),
   markSaved: () => set({ isDirty: false }),
 
-  addLayer: (layer) =>
-    set((s) => ({
-      layers: [...s.layers, layer],
-      selectedLayerId: layer.id,
-      isDirty: true,
-    })),
+  addLayer: (layer, beforeLayerId = null) =>
+    set((s) => {
+      const layers = [...s.layers];
+      const beforeIndex = beforeLayerId
+        ? layers.findIndex((l) => l.id === beforeLayerId)
+        : -1;
+      const layerWithBeforeId =
+        beforeLayerId && beforeIndex < 0
+          ? { ...layer, beforeId: beforeLayerId }
+          : { ...layer, beforeId: layer.beforeId };
+      if (beforeIndex >= 0) {
+        layers.splice(beforeIndex, 0, layerWithBeforeId);
+      } else {
+        layers.push(layerWithBeforeId);
+      }
+      return {
+        layers,
+        selectedLayerId: layer.id,
+        isDirty: true,
+      };
+    }),
 
   removeLayer: (id) =>
     set((s) => ({
@@ -188,7 +204,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       return { layers: next, isDirty: true };
     }),
 
-  addGeoJsonLayer: (name, geojson, sourcePath) => {
+  addGeoJsonLayer: (name, geojson, sourcePath, beforeLayerId = null) => {
     const id = uuidv4();
     const layer: GeoLibreLayer = {
       id,
@@ -202,7 +218,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       geojson,
       sourcePath,
     };
-    get().addLayer(layer);
+    get().addLayer(layer, beforeLayerId);
     return id;
   },
 }));

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -75,6 +75,7 @@ export interface GeoLibreLayer {
   opacity: number;
   style: LayerStyle;
   metadata: Record<string, unknown>;
+  beforeId?: string;
   geojson?: FeatureCollection;
   sourcePath?: string;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -56,6 +56,11 @@ export interface LayerStyle {
   strokeWidth: number;
   fillOpacity: number;
   circleRadius: number;
+  rasterBrightnessMin: number;
+  rasterBrightnessMax: number;
+  rasterSaturation: number;
+  rasterContrast: number;
+  rasterHueRotate: number;
 }
 
 export const DEFAULT_LAYER_STYLE: LayerStyle = {
@@ -64,6 +69,11 @@ export const DEFAULT_LAYER_STYLE: LayerStyle = {
   strokeWidth: 2,
   fillOpacity: 0.6,
   circleRadius: 6,
+  rasterBrightnessMin: 0,
+  rasterBrightnessMax: 1,
+  rasterSaturation: 0,
+  rasterContrast: 0,
+  rasterHueRotate: 0,
 };
 
 export interface GeoLibreLayer {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -40,6 +40,8 @@ export const PROJECT_VERSION = "0.1.0";
 
 export type LayerType =
   | "geojson"
+  | "raster"
+  | "wms"
   | "xyz"
   | "vector-tiles"
   | "pmtiles"

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -22,8 +22,12 @@ export function syncLayer(
     return;
   }
 
-  if (layer.type === "xyz") {
-    syncXyzLayer(map, layer, beforeId);
+  if (
+    layer.type === "raster" ||
+    layer.type === "wms" ||
+    layer.type === "xyz"
+  ) {
+    syncRasterTileLayer(map, layer, beforeId);
     return;
   }
 
@@ -53,64 +57,79 @@ function syncGeoJsonLayer(
   const opacity = layer.opacity;
 
   if (profile.hasPolygon) {
-    ensureLayer(map, fillLayerId(layer.id), {
-      id: fillLayerId(layer.id),
-      type: "fill",
-      source: src,
-      filter: [
-        "match",
-        ["geometry-type"],
-        ["Polygon", "MultiPolygon"],
-        true,
-        false,
-      ],
-      paint: fillPaint(layer.style, opacity),
-      layout: { visibility },
-    }, beforeId);
+    ensureLayer(
+      map,
+      fillLayerId(layer.id),
+      {
+        id: fillLayerId(layer.id),
+        type: "fill",
+        source: src,
+        filter: [
+          "match",
+          ["geometry-type"],
+          ["Polygon", "MultiPolygon"],
+          true,
+          false,
+        ],
+        paint: fillPaint(layer.style, opacity),
+        layout: { visibility },
+      },
+      beforeId,
+    );
   } else {
     removeIfExists(map, fillLayerId(layer.id));
   }
 
   if (profile.hasLine || profile.hasPolygon) {
-    ensureLayer(map, lineLayerId(layer.id), {
-      id: lineLayerId(layer.id),
-      type: "line",
-      source: src,
-      filter: [
-        "match",
-        ["geometry-type"],
-        ["LineString", "MultiLineString", "Polygon", "MultiPolygon"],
-        true,
-        false,
-      ],
-      paint: linePaint(layer.style, opacity),
-      layout: { visibility },
-    }, beforeId);
+    ensureLayer(
+      map,
+      lineLayerId(layer.id),
+      {
+        id: lineLayerId(layer.id),
+        type: "line",
+        source: src,
+        filter: [
+          "match",
+          ["geometry-type"],
+          ["LineString", "MultiLineString", "Polygon", "MultiPolygon"],
+          true,
+          false,
+        ],
+        paint: linePaint(layer.style, opacity),
+        layout: { visibility },
+      },
+      beforeId,
+    );
   } else {
     removeIfExists(map, lineLayerId(layer.id));
   }
 
   if (profile.hasPoint) {
-    ensureLayer(map, circleLayerId(layer.id), {
-      id: circleLayerId(layer.id),
-      type: "circle",
-      source: src,
-      filter: [
-        "match",
-        ["geometry-type"],
-        ["Point", "MultiPoint"],
-        true,
-        false,
-      ],
-      paint: circlePaint(layer.style, opacity),
-      layout: { visibility },
-    }, beforeId);
+    ensureLayer(
+      map,
+      circleLayerId(layer.id),
+      {
+        id: circleLayerId(layer.id),
+        type: "circle",
+        source: src,
+        filter: [
+          "match",
+          ["geometry-type"],
+          ["Point", "MultiPoint"],
+          true,
+          false,
+        ],
+        paint: circlePaint(layer.style, opacity),
+        layout: { visibility },
+      },
+      beforeId,
+    );
   } else {
     removeIfExists(map, circleLayerId(layer.id));
   }
 }
 
-function syncXyzLayer(
+function syncRasterTileLayer(
   map: maplibregl.Map,
   layer: GeoLibreLayer,
   beforeId?: string,
@@ -118,16 +137,23 @@ function syncXyzLayer(
   const src = sourceId(layer.id);
   const lid = `layer-${layer.id}-raster`;
   const tiles = (layer.source.tiles as string[]) ?? [];
+  const tileSize = (layer.source.tileSize as number | undefined) ?? 256;
+  if (tiles.length === 0) return;
   if (!map.getSource(src)) {
-    map.addSource(src, { type: "raster", tiles, tileSize: 256 });
+    map.addSource(src, { type: "raster", tiles, tileSize });
   }
-  ensureLayer(map, lid, {
-    id: lid,
-    type: "raster",
-    source: src,
-    paint: { "raster-opacity": layer.opacity },
-    layout: { visibility: layer.visible ? "visible" : "none" },
-  }, beforeId);
+  ensureLayer(
+    map,
+    lid,
+    {
+      id: lid,
+      type: "raster",
+      source: src,
+      paint: { "raster-opacity": layer.opacity },
+      layout: { visibility: layer.visible ? "visible" : "none" },
+    },
+    beforeId,
+  );
 }
 
 function syncVectorTileLayer(

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -10,6 +10,8 @@ import {
 import { isPlaceholderLayer } from "./placeholders";
 import { circlePaint, fillPaint, linePaint } from "./style-mapper";
 
+const WMS_PROXY_PATH = "/__geolibre_wms_proxy";
+
 export function syncLayer(
   map: maplibregl.Map,
   layer: GeoLibreLayer,
@@ -136,7 +138,7 @@ function syncRasterTileLayer(
 ): void {
   const src = sourceId(layer.id);
   const lid = `layer-${layer.id}-raster`;
-  const tiles = (layer.source.tiles as string[]) ?? [];
+  const tiles = getRenderableRasterTiles(layer);
   const tileSize = (layer.source.tileSize as number | undefined) ?? 256;
   if (tiles.length === 0) return;
   if (!map.getSource(src)) {
@@ -154,6 +156,30 @@ function syncRasterTileLayer(
     },
     beforeId,
   );
+}
+
+function getRenderableRasterTiles(layer: GeoLibreLayer): string[] {
+  const tiles = (layer.source.tiles as string[]) ?? [];
+  if (layer.type !== "wms" || !isViteDevServer()) return tiles;
+  return tiles.map(proxyWmsTileUrl);
+}
+
+function isViteDevServer(): boolean {
+  return Boolean(
+    (
+      import.meta as ImportMeta & {
+        env?: { DEV?: boolean };
+      }
+    ).env?.DEV,
+  );
+}
+
+function proxyWmsTileUrl(tileUrl: string): string {
+  const encodedUrl = encodeURIComponent(tileUrl).replaceAll(
+    "%7Bbbox-epsg-3857%7D",
+    "{bbox-epsg-3857}",
+  );
+  return `${WMS_PROXY_PATH}?url=${encodedUrl}`;
 }
 
 function syncVectorTileLayer(

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -8,7 +8,7 @@ import {
   sourceId,
 } from "./geojson-loader";
 import { isPlaceholderLayer } from "./placeholders";
-import { circlePaint, fillPaint, linePaint } from "./style-mapper";
+import { circlePaint, fillPaint, linePaint, rasterPaint } from "./style-mapper";
 
 const WMS_PROXY_PATH = "/__geolibre_wms_proxy";
 
@@ -151,7 +151,7 @@ function syncRasterTileLayer(
       id: lid,
       type: "raster",
       source: src,
-      paint: { "raster-opacity": layer.opacity },
+      paint: rasterPaint(layer.style, layer.opacity),
       layout: { visibility: layer.visible ? "visible" : "none" },
     },
     beforeId,

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -195,14 +195,19 @@ function syncVectorTileLayer(
   }
   const styleLayerId = `layer-${layer.id}-vector`;
   const sourceLayer = (layer.source.sourceLayer as string) ?? "";
-  ensureLayer(map, styleLayerId, {
-    id: styleLayerId,
-    type: "fill",
-    source: src,
-    "source-layer": sourceLayer,
-    paint: fillPaint(layer.style, layer.opacity),
-    layout: { visibility: layer.visible ? "visible" : "none" },
-  }, beforeId);
+  ensureLayer(
+    map,
+    styleLayerId,
+    {
+      id: styleLayerId,
+      type: "fill",
+      source: src,
+      "source-layer": sourceLayer,
+      paint: fillPaint(layer.style, layer.opacity),
+      layout: { visibility: layer.visible ? "visible" : "none" },
+    },
+    beforeId,
+  );
 }
 
 function ensureLayer(
@@ -225,13 +230,31 @@ function ensureLayer(
         map.setLayoutProperty(id, key, value);
       }
     }
+    moveLayer(map, id, beforeId);
     return;
   }
-  map.addLayer(spec, beforeId);
+  const validBeforeId = beforeId && map.getLayer(beforeId) ? beforeId : undefined;
+  map.addLayer(spec, validBeforeId);
 }
 
 function removeIfExists(map: maplibregl.Map, id: string): void {
   if (map.getLayer(id)) map.removeLayer(id);
+}
+
+function moveLayer(
+  map: maplibregl.Map,
+  id: string,
+  beforeId?: string,
+): void {
+  try {
+    if (beforeId && beforeId !== id && map.getLayer(beforeId)) {
+      map.moveLayer(id, beforeId);
+      return;
+    }
+    map.moveLayer(id);
+  } catch {
+    // Reordering can race style reloads; the next sync pass will retry.
+  }
 }
 
 export function removeLayerFromMap(

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -287,8 +287,8 @@ export class MapController {
       }
     }
 
-    for (const layer of layers) {
-      syncLayer(this.map, layer);
+    for (const [index, layer] of layers.entries()) {
+      syncLayer(this.map, layer, this.getBeforeStyleLayerId(layers, index));
     }
     this.layerIds = nextIds;
     this.syncedLayers = layers;
@@ -454,25 +454,8 @@ export class MapController {
   }> {
     if (!this.map) return [];
 
-    const styleLayers: Array<{ id: string; suffix?: string }> = [];
-    if (layer.type === "geojson") {
-      styleLayers.push(
-        { id: fillLayerId(layer.id), suffix: "Polygons" },
-        { id: lineLayerId(layer.id), suffix: "Lines" },
-        { id: circleLayerId(layer.id), suffix: "Points" },
-      );
-    } else if (
-      layer.type === "raster" ||
-      layer.type === "wms" ||
-      layer.type === "xyz"
-    ) {
-      styleLayers.push({ id: `layer-${layer.id}-raster` });
-    } else if (layer.type === "vector-tiles") {
-      styleLayers.push({ id: `layer-${layer.id}-vector` });
-    }
-
-    const existingStyleLayers = styleLayers.filter(({ id }) =>
-      this.map?.getLayer(id),
+    const existingStyleLayers = this.getCandidateStyleLayers(layer).filter(
+      ({ id }) => this.map?.getLayer(id),
     );
     return existingStyleLayers.map(({ id, suffix }) => ({
       id,
@@ -482,6 +465,65 @@ export class MapController {
           : layer.name,
       layer,
     }));
+  }
+
+  private getBeforeStyleLayerId(
+    layers: GeoLibreLayer[],
+    layerIndex: number,
+  ): string | undefined {
+    if (!this.map) return undefined;
+
+    for (const layer of layers.slice(layerIndex + 1)) {
+      const beforeLayer = this.getCandidateStyleLayers(layer).find(({ id }) =>
+        this.map?.getLayer(id),
+      );
+      if (beforeLayer) return beforeLayer.id;
+    }
+
+    if (layerIndex >= 0) {
+      return this.getExternalBeforeStyleLayerId(layers[layerIndex]);
+    }
+
+    return undefined;
+  }
+
+  private getExternalBeforeStyleLayerId(
+    layer: GeoLibreLayer | undefined,
+  ): string | undefined {
+    if (!this.map || !layer?.beforeId) return undefined;
+    if (
+      this.getCandidateStyleLayers(layer).some(({ id }) => id === layer.beforeId)
+    ) {
+      return undefined;
+    }
+    return this.map.getLayer(layer.beforeId) ? layer.beforeId : undefined;
+  }
+
+  private getCandidateStyleLayers(layer: GeoLibreLayer): Array<{
+    id: string;
+    suffix?: string;
+  }> {
+    if (layer.type === "geojson") {
+      return [
+        { id: fillLayerId(layer.id), suffix: "Polygons" },
+        { id: lineLayerId(layer.id), suffix: "Lines" },
+        { id: circleLayerId(layer.id), suffix: "Points" },
+      ];
+    }
+
+    if (
+      layer.type === "raster" ||
+      layer.type === "wms" ||
+      layer.type === "xyz"
+    ) {
+      return [{ id: `layer-${layer.id}-raster` }];
+    }
+
+    if (layer.type === "vector-tiles") {
+      return [{ id: `layer-${layer.id}-vector` }];
+    }
+
+    return [];
   }
 
   private publishLayerDisplayNames(layers: GeoLibreLayer[]): void {

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -2,7 +2,12 @@ import { DEFAULT_BASEMAP } from "@geolibre/core";
 import type { GeoLibreLayer, MapViewState } from "@geolibre/core";
 import maplibregl from "maplibre-gl";
 import { LayerControl } from "maplibre-gl-layer-control";
-import { getLayerBounds } from "./geojson-loader";
+import {
+  circleLayerId,
+  fillLayerId,
+  getLayerBounds,
+  lineLayerId,
+} from "./geojson-loader";
 import { removeLayerFromMap, syncLayer } from "./layer-sync";
 
 const DEFAULT_PROJECTION: maplibregl.ProjectionSpecification = {
@@ -25,6 +30,21 @@ const TERRAIN_OPTIONS: maplibregl.TerrainSpecification = {
   source: TERRAIN_SOURCE_ID,
   exaggeration: 1,
 };
+
+interface NamedLayerState {
+  visible: boolean;
+  opacity: number;
+  name: string;
+}
+
+interface LayerControlConfig {
+  layers?: string[];
+  layerStates?: Record<string, NamedLayerState>;
+}
+
+interface GeoLibreLayerLabelWindow extends Window {
+  __GEOLIBRE_LAYER_LABELS__?: Record<string, string>;
+}
 
 export type BuiltInMapControl =
   | "navigation"
@@ -78,7 +98,9 @@ export class MapController {
   private attributionControl: maplibregl.AttributionControl | null = null;
   private logoControl: maplibregl.LogoControl | null = null;
   private layerControl: LayerControl | null = null;
+  private layerControlSignature = "";
   private basemapStyleUrl = DEFAULT_BASEMAP;
+  private syncedLayers: GeoLibreLayer[] = [];
   private layerIds: string[] = [];
   private controlVisibility: Record<BuiltInMapControl, boolean> = {
     ...DEFAULT_BUILT_IN_CONTROL_VISIBILITY,
@@ -210,6 +232,7 @@ export class MapController {
     this.removeLayerControl();
     this.map?.remove();
     this.map = null;
+    this.publishLayerDisplayNames([]);
   }
 
   setStyle(url: string): void {
@@ -268,6 +291,9 @@ export class MapController {
       syncLayer(this.map, layer);
     }
     this.layerIds = nextIds;
+    this.syncedLayers = layers;
+    this.publishLayerDisplayNames(layers);
+    this.refreshLayerControl(layers);
   }
 
   private styleLoadHandler: (() => void) | null = null;
@@ -344,12 +370,17 @@ export class MapController {
     ) {
       return false;
     }
+    const layerControlConfig = this.createLayerControlConfig(this.syncedLayers);
+    this.layerControlSignature = this.createLayerControlSignature(
+      layerControlConfig,
+    );
     this.layerControl = new LayerControl({
       basemapStyleUrl: this.basemapStyleUrl,
       collapsed: true,
       panelWidth: 340,
       panelMinWidth: 240,
       panelMaxWidth: 450,
+      ...layerControlConfig,
     });
     this.map.addControl(
       this.layerControl,
@@ -362,6 +393,107 @@ export class MapController {
     if (!this.map || !this.layerControl) return;
     this.removeControl(this.layerControl);
     this.layerControl = null;
+  }
+
+  private refreshLayerControl(layers: GeoLibreLayer[]): void {
+    if (
+      !this.map ||
+      !this.layerControl ||
+      !this.controlVisibility["layer-control"]
+    ) {
+      return;
+    }
+
+    const layerControlConfig = this.createLayerControlConfig(layers);
+    const nextSignature = this.createLayerControlSignature(layerControlConfig);
+    if (nextSignature === this.layerControlSignature) return;
+
+    this.removeLayerControl();
+    this.addLayerControl();
+  }
+
+  private createLayerControlConfig(
+    layers: GeoLibreLayer[],
+  ): LayerControlConfig {
+    const namedStyleLayers = layers.flatMap((layer) =>
+      this.getNamedStyleLayers(layer),
+    );
+    if (namedStyleLayers.length === 0) return {};
+
+    return {
+      layers: namedStyleLayers.map(({ id }) => id),
+      layerStates: Object.fromEntries(
+        namedStyleLayers.map(({ id, name, layer }) => [
+          id,
+          {
+            visible: layer.visible,
+            opacity: layer.opacity,
+            name,
+          },
+        ]),
+      ),
+    };
+  }
+
+  private createLayerControlSignature(config: LayerControlConfig): string {
+    return JSON.stringify({
+      layers: config.layers ?? [],
+      names: Object.fromEntries(
+        Object.entries(config.layerStates ?? {}).map(([id, state]) => [
+          id,
+          state.name,
+        ]),
+      ),
+    });
+  }
+
+  private getNamedStyleLayers(layer: GeoLibreLayer): Array<{
+    id: string;
+    name: string;
+    layer: GeoLibreLayer;
+  }> {
+    if (!this.map) return [];
+
+    const styleLayers: Array<{ id: string; suffix?: string }> = [];
+    if (layer.type === "geojson") {
+      styleLayers.push(
+        { id: fillLayerId(layer.id), suffix: "Polygons" },
+        { id: lineLayerId(layer.id), suffix: "Lines" },
+        { id: circleLayerId(layer.id), suffix: "Points" },
+      );
+    } else if (
+      layer.type === "raster" ||
+      layer.type === "wms" ||
+      layer.type === "xyz"
+    ) {
+      styleLayers.push({ id: `layer-${layer.id}-raster` });
+    } else if (layer.type === "vector-tiles") {
+      styleLayers.push({ id: `layer-${layer.id}-vector` });
+    }
+
+    const existingStyleLayers = styleLayers.filter(({ id }) =>
+      this.map?.getLayer(id),
+    );
+    return existingStyleLayers.map(({ id, suffix }) => ({
+      id,
+      name:
+        existingStyleLayers.length > 1 && suffix
+          ? `${layer.name} ${suffix}`
+          : layer.name,
+      layer,
+    }));
+  }
+
+  private publishLayerDisplayNames(layers: GeoLibreLayer[]): void {
+    if (typeof window === "undefined") return;
+
+    const labelWindow = window as GeoLibreLayerLabelWindow;
+    labelWindow.__GEOLIBRE_LAYER_LABELS__ = Object.fromEntries(
+      layers
+        .flatMap((layer) => this.getNamedStyleLayers(layer))
+        .map(({ id, name }) => [id, name]),
+    );
+    window.dispatchEvent(new CustomEvent("geolibre-layer-labels-change"));
   }
 
   private addNavigationControl(): boolean {

--- a/packages/map/src/style-mapper.ts
+++ b/packages/map/src/style-mapper.ts
@@ -1,4 +1,11 @@
-import type { LayerStyle } from "@geolibre/core";
+import { DEFAULT_LAYER_STYLE, type LayerStyle } from "@geolibre/core";
+
+function styleValue<K extends keyof LayerStyle>(
+  style: LayerStyle,
+  key: K,
+): LayerStyle[K] {
+  return style[key] ?? DEFAULT_LAYER_STYLE[key];
+}
 
 export function fillPaint(style: LayerStyle, opacity: number) {
   return {
@@ -23,5 +30,16 @@ export function circlePaint(style: LayerStyle, opacity: number) {
     "circle-opacity": style.fillOpacity * opacity,
     "circle-stroke-color": style.strokeColor,
     "circle-stroke-width": style.strokeWidth,
+  };
+}
+
+export function rasterPaint(style: LayerStyle, opacity: number) {
+  return {
+    "raster-opacity": opacity,
+    "raster-brightness-min": styleValue(style, "rasterBrightnessMin"),
+    "raster-brightness-max": styleValue(style, "rasterBrightnessMax"),
+    "raster-saturation": styleValue(style, "rasterSaturation"),
+    "raster-contrast": styleValue(style, "rasterContrast"),
+    "raster-hue-rotate": styleValue(style, "rasterHueRotate"),
   };
 }


### PR DESCRIPTION
## Summary
- Replace the single "Add GeoJSON" toolbar button with an "Add Data" dropdown menu supporting XYZ, WMS, vector, and raster layers via a new `AddDataDialog`.
- Unify XYZ and WMS sources through a shared raster tile sync path and extend the layer type set with `raster` and `wms`.
- Add a reusable local file picker (`openLocalDataFileWithFallback`) for raster files, with Tauri and browser fallbacks.

## Test plan
- [ ] `pre-commit run --all-files` passes (includes the production build/typecheck)
- [ ] Add an XYZ tile layer and confirm it renders on the map
- [ ] Add a WMS layer and confirm tiles load
- [ ] Add a GeoJSON layer from file and URL, confirm the map fits to the layer
- [ ] Add a raster tile / COG URL / raster file and confirm it is tracked in the layer panel