### PR TITLE
feat: import GeoParquet, GeoPackage, and Shapefile vector files

### DIFF
--- a/.github/workflows/netlify-preview.yml
+++ b/.github/workflows/netlify-preview.yml
@@ -97,4 +97,13 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PREVIEW_URL: ${{ steps.netlify.outputs.preview_url }}
         run: |
-          gh pr comment "$PR_NUMBER" --body "Netlify preview: $PREVIEW_URL"
+          existing_comment_id="$(
+            gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+              --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | startswith("Netlify preview: "))) | .id' \
+              | head -n 1
+          )"
+          if [ -z "$existing_comment_id" ]; then
+            gh pr comment "$PR_NUMBER" --body "Netlify preview: $PREVIEW_URL"
+          else
+            echo "Netlify preview comment already exists: $existing_comment_id"
+          fi

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Lightweight, cloud-native desktop GIS prototype built with **Tauri v2**, **React
 ## Features (v0.1 MVP)
 
 - MapLibre map with OpenFreeMap Liberty basemap
-- Load local GeoJSON layers
+- Load local GeoJSON, GeoParquet, GeoPackage, and Shapefile layers
 - Layer panel (visibility, opacity, reorder, remove)
 - Live style panel (fill, stroke, opacity, circle radius)
-- Attribute table for GeoJSON
+- Attribute table for imported vector layers
 - Save/open `.geolibre.json` projects
 - Processing toolbox (bounds, count + placeholders)
 - Plugin system (basemap + sample GeoJSON plugins)
@@ -34,7 +34,7 @@ npm install
 npm run dev
 ```
 
-Open http://localhost:1420 — map works; file dialogs require Tauri.
+Open http://localhost:1420. The map and browser vector import work for GeoJSON, GeoParquet, GeoPackage, and zipped Shapefiles. You can choose files from Add Vector Layer or drag them onto the app. Desktop filesystem dialogs require Tauri.
 
 ## Environment variables
 

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview",
     "tauri": "tauri",
     "tauri:dev": "tauri dev",
-    "tauri:build": "tauri build"
+    "tauri:build": "node ../../scripts/tauri-build.mjs"
   },
   "dependencies": {
     "@carbonplan/zarr-layer": "^0.3.1",

--- a/apps/geolibre-desktop/src-tauri/capabilities/default.json
+++ b/apps/geolibre-desktop/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "dialog:default",
     "fs:default",
+    "fs:allow-read-file",
     "fs:allow-read-text-file",
     "fs:allow-write-text-file",
     {

--- a/apps/geolibre-desktop/src-tauri/tauri.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.conf.json
@@ -26,7 +26,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
+    "targets": ["deb", "rpm"],
     "icon": [
       "icons/icon.png",
       "icons/32x32.png",

--- a/apps/geolibre-desktop/src-tauri/tauri.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.conf.json
@@ -26,7 +26,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["deb", "rpm"],
+    "targets": "all",
     "icon": [
       "icons/icon.png",
       "icons/32x32.png",

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -24,8 +24,8 @@ import {
   useState,
 } from "react";
 import {
-  openGeoJsonFileWithFallback,
   openLocalDataFileWithFallback,
+  openVectorFileWithFallback,
 } from "../../lib/tauri-io";
 
 export type AddDataKind = "xyz" | "wms" | "vector" | "raster";
@@ -36,7 +36,7 @@ interface AddDataDialogProps {
   onOpenChange: (open: boolean) => void;
 }
 
-type VectorMode = "geojson-file" | "geojson-url" | "vector-tiles";
+type VectorMode = "vector-file" | "geojson-url" | "vector-tiles";
 type RasterMode = "tiles" | "cog-url" | "file";
 
 const KIND_LABELS: Record<AddDataKind, string> = {
@@ -151,10 +151,10 @@ export function AddDataDialog({
   const [wmsTransparent, setWmsTransparent] = useState(true);
   const [wmsTileSize, setWmsTileSize] = useState("256");
 
-  const [vectorMode, setVectorMode] = useState<VectorMode>("geojson-file");
+  const [vectorMode, setVectorMode] = useState<VectorMode>("vector-file");
   const [vectorUrl, setVectorUrl] = useState("");
   const [vectorSourceLayer, setVectorSourceLayer] = useState("");
-  const [selectedGeoJson, setSelectedGeoJson] = useState<{
+  const [selectedVector, setSelectedVector] = useState<{
     data: FeatureCollection;
     path: string;
   } | null>(null);
@@ -187,10 +187,10 @@ export function AddDataDialog({
     setWmsFormat("image/png");
     setWmsTransparent(true);
     setWmsTileSize("256");
-    setVectorMode("geojson-file");
+    setVectorMode("vector-file");
     setVectorUrl("");
     setVectorSourceLayer("");
-    setSelectedGeoJson(null);
+    setSelectedVector(null);
     setRasterMode("tiles");
     setRasterUrl("");
     setRasterTileSize("256");
@@ -205,7 +205,7 @@ export function AddDataDialog({
       return "Add a WMS GetMap service as a tiled raster layer.";
     }
     if (kind === "vector") {
-      return "Add GeoJSON data or a MapLibre vector tile source.";
+      return "Add GeoJSON, GeoParquet, GeoPackage, Shapefile, or a MapLibre vector tile source.";
     }
     if (kind === "raster") {
       return "Add raster tiles now, or register raster files and COG URLs for project tracking.";
@@ -227,12 +227,12 @@ export function AddDataDialog({
     closeDialog();
   };
 
-  const handleChooseGeoJson = async () => {
+  const handleChooseVector = async () => {
     setError(null);
     try {
-      const result = await openGeoJsonFileWithFallback();
+      const result = await openVectorFileWithFallback();
       if (!result) return;
-      setSelectedGeoJson(result);
+      setSelectedVector(result);
       setLayerName((current) =>
         current.trim() && current !== "Vector Layer"
           ? current
@@ -319,12 +319,12 @@ export function AddDataDialog({
       }
 
       if (kind === "vector") {
-        if (vectorMode === "geojson-file") {
-          if (!selectedGeoJson) throw new Error("Choose a GeoJSON file.");
+        if (vectorMode === "vector-file") {
+          if (!selectedVector) throw new Error("Choose a vector file.");
           const id = addGeoJsonLayer(
             name,
-            selectedGeoJson.data,
-            selectedGeoJson.path,
+            selectedVector.data,
+            selectedVector.path,
             beforeLayer,
           );
           const layer = useAppStore.getState().layers.find((l) => l.id === id);
@@ -528,24 +528,24 @@ export function AddDataDialog({
                     setVectorMode(event.target.value as VectorMode)
                   }
                 >
-                  <option value="geojson-file">GeoJSON file</option>
+                  <option value="vector-file">Vector file</option>
                   <option value="geojson-url">GeoJSON URL</option>
                   <option value="vector-tiles">Vector tile source URL</option>
                 </select>
               </div>
-              {vectorMode === "geojson-file" ? (
+              {vectorMode === "vector-file" ? (
                 <div className="flex flex-wrap items-center gap-2">
                   <Button
                     type="button"
                     variant="outline"
-                    onClick={handleChooseGeoJson}
+                    onClick={handleChooseVector}
                   >
                     <FileUp className="mr-2 h-3.5 w-3.5" />
                     Choose file
                   </Button>
                   <span className="min-w-0 truncate text-xs text-muted-foreground">
-                    {selectedGeoJson
-                      ? fileNameFromPath(selectedGeoJson.path)
+                    {selectedVector
+                      ? fileNameFromPath(selectedVector.path)
                       : "No file selected"}
                   </span>
                 </div>

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -65,6 +65,7 @@ export function DesktopShell({
   const verticalResizeGuideRef = useRef<HTMLDivElement>(null);
   const mapControllerRef = useRef<MapController | null>(null);
   const dragDepthRef = useRef(0);
+  const dropMessageTimeoutRef = useRef<number | null>(null);
   const addGeoJsonLayer = useAppStore((s) => s.addGeoJsonLayer);
   const [isDraggingFiles, setIsDraggingFiles] = useState(false);
   const [dropMessage, setDropMessage] = useState<string | null>(null);
@@ -82,10 +83,22 @@ export function DesktopShell({
   };
 
   const clearDropMessageLater = useCallback(() => {
-    window.setTimeout(() => {
+    if (dropMessageTimeoutRef.current !== null) {
+      window.clearTimeout(dropMessageTimeoutRef.current);
+    }
+    dropMessageTimeoutRef.current = window.setTimeout(() => {
+      dropMessageTimeoutRef.current = null;
       setDropMessage(null);
       setDropError(null);
     }, 4000);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (dropMessageTimeoutRef.current !== null) {
+        window.clearTimeout(dropMessageTimeoutRef.current);
+      }
+    };
   }, []);
 
   const addImportedVectorLayers = useCallback(

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -62,6 +62,7 @@ export function DesktopShell({
   onToggleThemeMode,
 }: DesktopShellProps) {
   const shellRef = useRef<HTMLDivElement>(null);
+  const verticalResizeGuideRef = useRef<HTMLDivElement>(null);
   const mapControllerRef = useRef<MapController | null>(null);
   const dragDepthRef = useRef(0);
   const addGeoJsonLayer = useAppStore((s) => s.addGeoJsonLayer);
@@ -74,6 +75,7 @@ export function DesktopShell({
   const [stylePanelWidth, setStylePanelWidth] = useState(
     DEFAULT_SIDE_PANEL_WIDTH,
   );
+  const deferPanelResize = isTauri();
   const shellStyle: ShellStyle = {
     "--layer-panel-width": `${layerPanelWidth}px`,
     "--style-panel-width": `${stylePanelWidth}px`,
@@ -228,6 +230,7 @@ export function DesktopShell({
 
       const startX = event.clientX;
       const startWidth = layerPanelWidth;
+      const panelRect = event.currentTarget.parentElement?.getBoundingClientRect();
       let nextWidth = startWidth;
       let resizeFrame: number | null = null;
       const previousCursor = document.body.style.cursor;
@@ -245,6 +248,15 @@ export function DesktopShell({
         if (resizeFrame !== null) return;
         resizeFrame = window.requestAnimationFrame(() => {
           resizeFrame = null;
+          if (deferPanelResize) {
+            if (verticalResizeGuideRef.current && panelRect) {
+              verticalResizeGuideRef.current.style.left = `${
+                panelRect.left + nextWidth
+              }px`;
+              verticalResizeGuideRef.current.classList.remove("hidden");
+            }
+            return;
+          }
           shellRef.current?.style.setProperty(
             "--layer-panel-width",
             `${nextWidth}px`,
@@ -263,6 +275,7 @@ export function DesktopShell({
           "--layer-panel-width",
           `${nextWidth}px`,
         );
+        verticalResizeGuideRef.current?.classList.add("hidden");
         setLayerPanelWidth(nextWidth);
         window.dispatchEvent(new Event(PANEL_RESIZE_END_EVENT));
         document.body.style.cursor = previousCursor;
@@ -272,7 +285,7 @@ export function DesktopShell({
       window.addEventListener("mousemove", onMouseMove);
       window.addEventListener("mouseup", onMouseUp);
     },
-    [layerPanelWidth],
+    [deferPanelResize, layerPanelWidth],
   );
 
   const startStylePanelResize = useCallback(
@@ -282,6 +295,7 @@ export function DesktopShell({
 
       const startX = event.clientX;
       const startWidth = stylePanelWidth;
+      const panelRect = event.currentTarget.parentElement?.getBoundingClientRect();
       let nextWidth = startWidth;
       let resizeFrame: number | null = null;
       const previousCursor = document.body.style.cursor;
@@ -299,6 +313,15 @@ export function DesktopShell({
         if (resizeFrame !== null) return;
         resizeFrame = window.requestAnimationFrame(() => {
           resizeFrame = null;
+          if (deferPanelResize) {
+            if (verticalResizeGuideRef.current && panelRect) {
+              verticalResizeGuideRef.current.style.left = `${
+                panelRect.right - nextWidth
+              }px`;
+              verticalResizeGuideRef.current.classList.remove("hidden");
+            }
+            return;
+          }
           shellRef.current?.style.setProperty(
             "--style-panel-width",
             `${nextWidth}px`,
@@ -317,6 +340,7 @@ export function DesktopShell({
           "--style-panel-width",
           `${nextWidth}px`,
         );
+        verticalResizeGuideRef.current?.classList.add("hidden");
         setStylePanelWidth(nextWidth);
         window.dispatchEvent(new Event(PANEL_RESIZE_END_EVENT));
         document.body.style.cursor = previousCursor;
@@ -326,7 +350,7 @@ export function DesktopShell({
       window.addEventListener("mousemove", onMouseMove);
       window.addEventListener("mouseup", onMouseUp);
     },
-    [stylePanelWidth],
+    [deferPanelResize, stylePanelWidth],
   );
 
   return (
@@ -359,6 +383,10 @@ export function DesktopShell({
       <AttributeTable />
       <StatusBar />
       <ProcessingDialog mapControllerRef={mapControllerRef} />
+      <div
+        ref={verticalResizeGuideRef}
+        className="pointer-events-none fixed bottom-7 top-11 z-50 hidden w-px bg-primary shadow-[0_0_0_1px_hsl(var(--primary)/0.25)]"
+      />
       {isDraggingFiles ? (
         <div className="pointer-events-none absolute inset-0 z-50 flex items-center justify-center bg-background/70 backdrop-blur-sm">
           <div className="rounded-md border bg-background px-4 py-3 text-sm font-medium shadow-lg">

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -2,7 +2,9 @@ import { useAppStore } from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
 import { MapCanvas } from "@geolibre/map";
 import {
+  type CSSProperties,
   type DragEvent,
+  type MouseEvent as ReactMouseEvent,
   useCallback,
   useEffect,
   useRef,
@@ -42,16 +44,40 @@ type ImportedVectorLayer = Awaited<
   ReturnType<typeof loadDroppedVectorFiles>
 >[number];
 
+const DEFAULT_SIDE_PANEL_WIDTH = 256;
+const MIN_SIDE_PANEL_WIDTH = 180;
+const MAX_SIDE_PANEL_WIDTH = 460;
+const PANEL_RESIZE_START_EVENT = "geolibre:panel-resize-start";
+const PANEL_RESIZE_END_EVENT = "geolibre:panel-resize-end";
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+type ShellStyle = CSSProperties &
+  Record<"--layer-panel-width" | "--style-panel-width", string>;
+
 export function DesktopShell({
   themeMode,
   onToggleThemeMode,
 }: DesktopShellProps) {
+  const shellRef = useRef<HTMLDivElement>(null);
   const mapControllerRef = useRef<MapController | null>(null);
   const dragDepthRef = useRef(0);
   const addGeoJsonLayer = useAppStore((s) => s.addGeoJsonLayer);
   const [isDraggingFiles, setIsDraggingFiles] = useState(false);
   const [dropMessage, setDropMessage] = useState<string | null>(null);
   const [dropError, setDropError] = useState<string | null>(null);
+  const [layerPanelWidth, setLayerPanelWidth] = useState(
+    DEFAULT_SIDE_PANEL_WIDTH,
+  );
+  const [stylePanelWidth, setStylePanelWidth] = useState(
+    DEFAULT_SIDE_PANEL_WIDTH,
+  );
+  const shellStyle: ShellStyle = {
+    "--layer-panel-width": `${layerPanelWidth}px`,
+    "--style-panel-width": `${stylePanelWidth}px`,
+  };
 
   const clearDropMessageLater = useCallback(() => {
     window.setTimeout(() => {
@@ -195,9 +221,119 @@ export function DesktopShell({
     [clearDropMessageLater, finishVectorDrop],
   );
 
+  const startLayerPanelResize = useCallback(
+    (event: ReactMouseEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      const startX = event.clientX;
+      const startWidth = layerPanelWidth;
+      let nextWidth = startWidth;
+      let resizeFrame: number | null = null;
+      const previousCursor = document.body.style.cursor;
+      const previousUserSelect = document.body.style.userSelect;
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+      window.dispatchEvent(new Event(PANEL_RESIZE_START_EVENT));
+
+      const onMouseMove = (moveEvent: MouseEvent) => {
+        nextWidth = clamp(
+          startWidth + moveEvent.clientX - startX,
+          MIN_SIDE_PANEL_WIDTH,
+          MAX_SIDE_PANEL_WIDTH,
+        );
+        if (resizeFrame !== null) return;
+        resizeFrame = window.requestAnimationFrame(() => {
+          resizeFrame = null;
+          shellRef.current?.style.setProperty(
+            "--layer-panel-width",
+            `${nextWidth}px`,
+          );
+        });
+      };
+
+      const onMouseUp = () => {
+        window.removeEventListener("mousemove", onMouseMove);
+        window.removeEventListener("mouseup", onMouseUp);
+        if (resizeFrame !== null) {
+          window.cancelAnimationFrame(resizeFrame);
+          resizeFrame = null;
+        }
+        shellRef.current?.style.setProperty(
+          "--layer-panel-width",
+          `${nextWidth}px`,
+        );
+        setLayerPanelWidth(nextWidth);
+        window.dispatchEvent(new Event(PANEL_RESIZE_END_EVENT));
+        document.body.style.cursor = previousCursor;
+        document.body.style.userSelect = previousUserSelect;
+      };
+
+      window.addEventListener("mousemove", onMouseMove);
+      window.addEventListener("mouseup", onMouseUp);
+    },
+    [layerPanelWidth],
+  );
+
+  const startStylePanelResize = useCallback(
+    (event: ReactMouseEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      const startX = event.clientX;
+      const startWidth = stylePanelWidth;
+      let nextWidth = startWidth;
+      let resizeFrame: number | null = null;
+      const previousCursor = document.body.style.cursor;
+      const previousUserSelect = document.body.style.userSelect;
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+      window.dispatchEvent(new Event(PANEL_RESIZE_START_EVENT));
+
+      const onMouseMove = (moveEvent: MouseEvent) => {
+        nextWidth = clamp(
+          startWidth + startX - moveEvent.clientX,
+          MIN_SIDE_PANEL_WIDTH,
+          MAX_SIDE_PANEL_WIDTH,
+        );
+        if (resizeFrame !== null) return;
+        resizeFrame = window.requestAnimationFrame(() => {
+          resizeFrame = null;
+          shellRef.current?.style.setProperty(
+            "--style-panel-width",
+            `${nextWidth}px`,
+          );
+        });
+      };
+
+      const onMouseUp = () => {
+        window.removeEventListener("mousemove", onMouseMove);
+        window.removeEventListener("mouseup", onMouseUp);
+        if (resizeFrame !== null) {
+          window.cancelAnimationFrame(resizeFrame);
+          resizeFrame = null;
+        }
+        shellRef.current?.style.setProperty(
+          "--style-panel-width",
+          `${nextWidth}px`,
+        );
+        setStylePanelWidth(nextWidth);
+        window.dispatchEvent(new Event(PANEL_RESIZE_END_EVENT));
+        document.body.style.cursor = previousCursor;
+        document.body.style.userSelect = previousUserSelect;
+      };
+
+      window.addEventListener("mousemove", onMouseMove);
+      window.addEventListener("mouseup", onMouseUp);
+    },
+    [stylePanelWidth],
+  );
+
   return (
     <div
+      ref={shellRef}
       className="relative flex h-full flex-col bg-background"
+      style={shellStyle}
       onDragEnter={handleDragEnter}
       onDragLeave={handleDragLeave}
       onDragOver={handleDragOver}
@@ -209,11 +345,16 @@ export function DesktopShell({
         onToggleThemeMode={onToggleThemeMode}
       />
       <div className="flex min-h-0 flex-1 flex-col md:flex-row">
-        <LayerPanel mapControllerRef={mapControllerRef} />
+        <LayerPanel
+          mapControllerRef={mapControllerRef}
+          onResizeStart={startLayerPanelResize}
+        />
         <main className="relative min-h-72 min-w-0 flex-1 md:min-h-0">
           <MapCanvas controllerRef={mapControllerRef} />
         </main>
-        <StylePanel />
+        <StylePanel
+          onResizeStart={startStylePanelResize}
+        />
       </div>
       <AttributeTable />
       <StatusBar />

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -1,6 +1,18 @@
+import { useAppStore } from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
 import { MapCanvas } from "@geolibre/map";
-import { useRef } from "react";
+import {
+  type DragEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import {
+  isTauri,
+  loadDroppedVectorFiles,
+  loadDroppedVectorPaths,
+} from "../../lib/tauri-io";
 import { AttributeTable } from "../panels/AttributeTable";
 import { LayerPanel } from "../panels/LayerPanel";
 import { StylePanel } from "../panels/StylePanel";
@@ -14,14 +26,183 @@ interface DesktopShellProps {
   onToggleThemeMode: () => void;
 }
 
+function hasDroppedFiles(event: DragEvent<HTMLElement>): boolean {
+  return Array.from(event.dataTransfer.types).includes("Files");
+}
+
+function fileNameFromPath(path: string): string {
+  return path.split(/[/\\]/).pop() ?? path;
+}
+
+function layerNameFromPath(path: string): string {
+  return fileNameFromPath(path).replace(/\.[^.]+$/, "") || "Vector Layer";
+}
+
+type ImportedVectorLayer = Awaited<
+  ReturnType<typeof loadDroppedVectorFiles>
+>[number];
+
 export function DesktopShell({
   themeMode,
   onToggleThemeMode,
 }: DesktopShellProps) {
   const mapControllerRef = useRef<MapController | null>(null);
+  const dragDepthRef = useRef(0);
+  const addGeoJsonLayer = useAppStore((s) => s.addGeoJsonLayer);
+  const [isDraggingFiles, setIsDraggingFiles] = useState(false);
+  const [dropMessage, setDropMessage] = useState<string | null>(null);
+  const [dropError, setDropError] = useState<string | null>(null);
+
+  const clearDropMessageLater = useCallback(() => {
+    window.setTimeout(() => {
+      setDropMessage(null);
+      setDropError(null);
+    }, 4000);
+  }, []);
+
+  const addImportedVectorLayers = useCallback(
+    (importedLayers: ImportedVectorLayer[]) => {
+      let lastLayerId: string | null = null;
+      for (const layer of importedLayers) {
+        lastLayerId = addGeoJsonLayer(
+          layerNameFromPath(layer.path),
+          layer.data,
+          layer.path,
+        );
+      }
+
+      const importedLayer = useAppStore
+        .getState()
+        .layers.find((layer) => layer.id === lastLayerId);
+      if (importedLayer) mapControllerRef.current?.fitLayer(importedLayer);
+    },
+    [addGeoJsonLayer],
+  );
+
+  const finishVectorDrop = useCallback(
+    (importedLayers: ImportedVectorLayer[]) => {
+      if (!importedLayers.length) {
+        throw new Error("Drop a supported vector file.");
+      }
+      addImportedVectorLayers(importedLayers);
+      setDropMessage(
+        `Added ${importedLayers.length} vector layer${
+          importedLayers.length === 1 ? "" : "s"
+        }.`,
+      );
+    },
+    [addImportedVectorLayers],
+  );
+
+  useEffect(() => {
+    if (!isTauri()) return;
+
+    let unlisten: (() => void) | null = null;
+    let disposed = false;
+
+    void import("@tauri-apps/api/webview").then(({ getCurrentWebview }) => {
+      if (disposed) return;
+      void getCurrentWebview()
+        .onDragDropEvent(async (event) => {
+          if (event.payload.type === "enter" || event.payload.type === "over") {
+            setIsDraggingFiles(true);
+            return;
+          }
+
+          if (event.payload.type === "leave") {
+            setIsDraggingFiles(false);
+            return;
+          }
+
+          setIsDraggingFiles(false);
+          setDropError(null);
+          setDropMessage("Importing vector data...");
+
+          try {
+            finishVectorDrop(await loadDroppedVectorPaths(event.payload.paths));
+          } catch (error) {
+            setDropMessage(null);
+            setDropError(
+              error instanceof Error
+                ? error.message
+                : "Could not import files.",
+            );
+          } finally {
+            clearDropMessageLater();
+          }
+        })
+        .then((nextUnlisten) => {
+          if (disposed) {
+            nextUnlisten();
+          } else {
+            unlisten = nextUnlisten;
+          }
+        })
+        .catch((error) => {
+          console.warn("Could not attach Tauri drag and drop handler", error);
+        });
+    });
+
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, [clearDropMessageLater, finishVectorDrop]);
+
+  const handleDragEnter = useCallback((event: DragEvent<HTMLDivElement>) => {
+    if (!hasDroppedFiles(event)) return;
+    event.preventDefault();
+    dragDepthRef.current += 1;
+    setIsDraggingFiles(true);
+  }, []);
+
+  const handleDragOver = useCallback((event: DragEvent<HTMLDivElement>) => {
+    if (!hasDroppedFiles(event)) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "copy";
+  }, []);
+
+  const handleDragLeave = useCallback((event: DragEvent<HTMLDivElement>) => {
+    if (!hasDroppedFiles(event)) return;
+    event.preventDefault();
+    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+    if (dragDepthRef.current === 0) setIsDraggingFiles(false);
+  }, []);
+
+  const handleDrop = useCallback(
+    async (event: DragEvent<HTMLDivElement>) => {
+      if (!hasDroppedFiles(event)) return;
+      event.preventDefault();
+      dragDepthRef.current = 0;
+      setIsDraggingFiles(false);
+      setDropError(null);
+      setDropMessage("Importing vector data...");
+
+      try {
+        const importedLayers = await loadDroppedVectorFiles(
+          event.dataTransfer.files,
+        );
+        finishVectorDrop(importedLayers);
+      } catch (error) {
+        setDropMessage(null);
+        setDropError(
+          error instanceof Error ? error.message : "Could not import files.",
+        );
+      } finally {
+        clearDropMessageLater();
+      }
+    },
+    [clearDropMessageLater, finishVectorDrop],
+  );
 
   return (
-    <div className="flex h-full flex-col bg-background">
+    <div
+      className="relative flex h-full flex-col bg-background"
+      onDragEnter={handleDragEnter}
+      onDragLeave={handleDragLeave}
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+    >
       <TopToolbar
         mapControllerRef={mapControllerRef}
         themeMode={themeMode}
@@ -37,6 +218,22 @@ export function DesktopShell({
       <AttributeTable />
       <StatusBar />
       <ProcessingDialog mapControllerRef={mapControllerRef} />
+      {isDraggingFiles ? (
+        <div className="pointer-events-none absolute inset-0 z-50 flex items-center justify-center bg-background/70 backdrop-blur-sm">
+          <div className="rounded-md border bg-background px-4 py-3 text-sm font-medium shadow-lg">
+            Drop vector files to add layers
+          </div>
+        </div>
+      ) : null}
+      {dropMessage || dropError ? (
+        <div
+          className={`pointer-events-none absolute bottom-10 left-1/2 z-50 -translate-x-1/2 rounded-md border bg-background px-3 py-2 text-sm shadow-lg ${
+            dropError ? "text-destructive" : "text-foreground"
+          }`}
+        >
+          {dropError ?? dropMessage}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -3,20 +3,64 @@ import {
   Button,
   Input,
   ScrollArea,
-  Table,
   TableBody,
   TableCell,
   TableHead,
   TableHeader,
   TableRow,
 } from "@geolibre/ui";
+import type { Feature } from "geojson";
 import {
+  ArrowDown,
+  ArrowUp,
   PanelBottomClose,
   PanelBottomOpen,
   TableProperties,
+  X,
 } from "lucide-react";
+import {
+  type MouseEvent as ReactMouseEvent,
+  useRef,
+  useState,
+} from "react";
+
+type SortDirection = "asc" | "desc";
+type SortKey = "__featureId" | string;
+type ColumnWidths = Record<string, number>;
+
+const DEFAULT_FEATURE_ID_COLUMN_WIDTH = 72;
+const DEFAULT_ATTRIBUTE_COLUMN_WIDTH = 160;
+const MIN_FEATURE_ID_COLUMN_WIDTH = 48;
+const MAX_FEATURE_ID_COLUMN_WIDTH = 180;
+const MIN_ATTRIBUTE_COLUMN_WIDTH = 72;
+const MAX_ATTRIBUTE_COLUMN_WIDTH = 520;
+const DEFAULT_TABLE_HEIGHT = 192;
+const MIN_TABLE_HEIGHT = 96;
+const MAX_TABLE_HEIGHT = 520;
+const PANEL_RESIZE_START_EVENT = "geolibre:panel-resize-start";
+const PANEL_RESIZE_END_EVENT = "geolibre:panel-resize-end";
+
+function compareAttributeValues(a: unknown, b: unknown): number {
+  if (a == null && b == null) return 0;
+  if (a == null) return -1;
+  if (b == null) return 1;
+
+  if (typeof a === "number" && typeof b === "number") return a - b;
+
+  const aNumber = Number(a);
+  const bNumber = Number(b);
+  if (Number.isFinite(aNumber) && Number.isFinite(bNumber)) {
+    return aNumber - bNumber;
+  }
+
+  return String(a).localeCompare(String(b), undefined, {
+    numeric: true,
+    sensitivity: "base",
+  });
+}
 
 export function AttributeTable() {
+  const tableSectionRef = useRef<HTMLElement>(null);
   const selectedLayerId = useAppStore((s) => s.selectedLayerId);
   const layers = useAppStore((s) => s.layers);
   const attributeFilter = useAppStore((s) => s.attributeFilter);
@@ -25,16 +69,46 @@ export function AttributeTable() {
   const selectFeature = useAppStore((s) => s.selectFeature);
   const attributeTableOpen = useAppStore((s) => s.ui.attributeTableOpen);
   const setAttributeTableOpen = useAppStore((s) => s.setAttributeTableOpen);
+  const zoomToSelectedFeature = useAppStore(
+    (s) => s.ui.zoomToSelectedFeature,
+  );
+  const setZoomToSelectedFeature = useAppStore(
+    (s) => s.setZoomToSelectedFeature,
+  );
+  const [sort, setSort] = useState<{
+    key: SortKey;
+    direction: SortDirection;
+  }>({
+    key: "__featureId",
+    direction: "asc",
+  });
+  const [columnWidths, setColumnWidths] = useState<ColumnWidths>({});
+  const [tableHeight, setTableHeight] = useState(DEFAULT_TABLE_HEIGHT);
 
   const layer = layers.find((l) => l.id === selectedLayerId);
   const features = layer?.geojson?.features ?? [];
 
   const filterLower = attributeFilter.toLowerCase();
-  const filtered = features.filter((f, idx) => {
+  const indexedFeatures = features.map((feature, index) => ({
+    feature,
+    featureId: String(feature.id ?? index),
+  }));
+  const filtered = indexedFeatures.filter(({ feature, featureId }) => {
     if (!filterLower) return true;
-    const id = String(f.id ?? idx);
-    const props = JSON.stringify(f.properties ?? {}).toLowerCase();
-    return id.includes(filterLower) || props.includes(filterLower);
+    const props = JSON.stringify(feature.properties ?? {}).toLowerCase();
+    return featureId.includes(filterLower) || props.includes(filterLower);
+  });
+  const sorted = [...filtered].sort((a, b) => {
+    const aValue =
+      sort.key === "__featureId"
+        ? a.featureId
+        : a.feature.properties?.[sort.key];
+    const bValue =
+      sort.key === "__featureId"
+        ? b.featureId
+        : b.feature.properties?.[sort.key];
+    const result = compareAttributeValues(aValue, bValue);
+    return sort.direction === "asc" ? result : -result;
   });
 
   const propKeys = new Set<string>();
@@ -44,6 +118,142 @@ export function AttributeTable() {
     }
   }
   const columns = Array.from(propKeys).slice(0, 8);
+  const tableColumns = ["__featureId", ...columns];
+
+  const columnWidth = (key: SortKey) =>
+    columnWidths[key] ??
+    (key === "__featureId"
+      ? DEFAULT_FEATURE_ID_COLUMN_WIDTH
+      : DEFAULT_ATTRIBUTE_COLUMN_WIDTH);
+
+  const columnWidthLimits = (key: SortKey) =>
+    key === "__featureId"
+      ? {
+          max: MAX_FEATURE_ID_COLUMN_WIDTH,
+          min: MIN_FEATURE_ID_COLUMN_WIDTH,
+        }
+      : {
+          max: MAX_ATTRIBUTE_COLUMN_WIDTH,
+          min: MIN_ATTRIBUTE_COLUMN_WIDTH,
+        };
+
+  const startColumnResize = (
+    key: SortKey,
+    event: ReactMouseEvent<HTMLDivElement>,
+  ) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const startX = event.clientX;
+    const startWidth = columnWidth(key);
+    const { min, max } = columnWidthLimits(key);
+
+    const onMouseMove = (moveEvent: MouseEvent) => {
+      const nextWidth = Math.min(
+        max,
+        Math.max(min, startWidth + moveEvent.clientX - startX),
+      );
+      setColumnWidths((current) => ({ ...current, [key]: nextWidth }));
+    };
+
+    const onMouseUp = () => {
+      window.removeEventListener("mousemove", onMouseMove);
+      window.removeEventListener("mouseup", onMouseUp);
+    };
+
+    window.addEventListener("mousemove", onMouseMove);
+    window.addEventListener("mouseup", onMouseUp);
+  };
+
+  const startTableResize = (event: ReactMouseEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const startY = event.clientY;
+    const startHeight = tableHeight;
+    let nextHeight = startHeight;
+    let resizeFrame: number | null = null;
+    const previousCursor = document.body.style.cursor;
+    const previousUserSelect = document.body.style.userSelect;
+    document.body.style.cursor = "row-resize";
+    document.body.style.userSelect = "none";
+    window.dispatchEvent(new Event(PANEL_RESIZE_START_EVENT));
+
+    const onMouseMove = (moveEvent: MouseEvent) => {
+      const availableHeight = Math.max(
+        MIN_TABLE_HEIGHT,
+        window.innerHeight - 180,
+      );
+      const maxHeight = Math.min(MAX_TABLE_HEIGHT, availableHeight);
+      nextHeight = Math.min(
+        maxHeight,
+        Math.max(MIN_TABLE_HEIGHT, startHeight + startY - moveEvent.clientY),
+      );
+      if (resizeFrame !== null) return;
+      resizeFrame = window.requestAnimationFrame(() => {
+        resizeFrame = null;
+        if (tableSectionRef.current) {
+          tableSectionRef.current.style.height = `${nextHeight}px`;
+        }
+      });
+    };
+
+    const onMouseUp = () => {
+      window.removeEventListener("mousemove", onMouseMove);
+      window.removeEventListener("mouseup", onMouseUp);
+      if (resizeFrame !== null) {
+        window.cancelAnimationFrame(resizeFrame);
+        resizeFrame = null;
+      }
+      if (tableSectionRef.current) {
+        tableSectionRef.current.style.height = `${nextHeight}px`;
+      }
+      setTableHeight(nextHeight);
+      window.dispatchEvent(new Event(PANEL_RESIZE_END_EVENT));
+      document.body.style.cursor = previousCursor;
+      document.body.style.userSelect = previousUserSelect;
+    };
+
+    window.addEventListener("mousemove", onMouseMove);
+    window.addEventListener("mouseup", onMouseUp);
+  };
+
+  const toggleSort = (key: SortKey) => {
+    setSort((current) => ({
+      key,
+      direction:
+        current.key === key && current.direction === "asc" ? "desc" : "asc",
+    }));
+  };
+
+  const renderSortIcon = (key: SortKey) => {
+    if (sort.key !== key) return null;
+    return sort.direction === "asc" ? (
+      <ArrowUp className="h-3.5 w-3.5" />
+    ) : (
+      <ArrowDown className="h-3.5 w-3.5" />
+    );
+  };
+
+  const sortableHeader = (key: SortKey, label: string) => (
+    <div className="relative flex h-full min-h-10 items-center">
+      <button
+        type="button"
+        className="flex h-full min-w-0 flex-1 items-center gap-1 pr-3 text-left font-medium"
+        onClick={() => toggleSort(key)}
+      >
+        <span className="truncate">{label}</span>
+        {renderSortIcon(key)}
+      </button>
+      <div
+        role="separator"
+        aria-orientation="vertical"
+        aria-label={`Resize ${label} column`}
+        className="absolute -right-2 top-0 h-full w-3 cursor-col-resize select-none border-r border-transparent hover:border-primary"
+        onMouseDown={(event) => startColumnResize(key, event)}
+      />
+    </div>
+  );
 
   if (!attributeTableOpen) {
     return (
@@ -67,8 +277,30 @@ export function AttributeTable() {
   }
 
   return (
-    <section className="flex h-48 shrink-0 flex-col border-t bg-card">
+    <section
+      ref={tableSectionRef}
+      className="relative flex shrink-0 flex-col border-t bg-card"
+      style={{ height: tableHeight }}
+    >
+      <div
+        role="separator"
+        aria-orientation="horizontal"
+        aria-label="Resize attribute table"
+        className="absolute -top-1 left-0 right-0 z-20 h-2 cursor-row-resize select-none border-t border-transparent hover:border-primary"
+        onMouseDown={startTableResize}
+      />
       <div className="flex items-center gap-2 border-b px-3 py-1.5">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          title="Collapse attribute table"
+          aria-label="Collapse attribute table"
+          onClick={() => setAttributeTableOpen(false)}
+        >
+          <PanelBottomClose className="h-4 w-4" />
+        </Button>
+        <TableProperties className="h-4 w-4 text-muted-foreground" />
         <span className="text-sm font-semibold">Attribute table</span>
         {layer ? (
           <span className="text-xs text-muted-foreground">— {layer.name}</span>
@@ -83,47 +315,71 @@ export function AttributeTable() {
           value={attributeFilter}
           onChange={(e) => setAttributeFilter(e.target.value)}
         />
+        <label className="flex items-center gap-1.5 whitespace-nowrap text-xs text-muted-foreground">
+          <input
+            type="checkbox"
+            checked={zoomToSelectedFeature}
+            onChange={(event) =>
+              setZoomToSelectedFeature(event.target.checked)
+            }
+          />
+          Zoom to selection
+        </label>
         <Button
           variant="ghost"
           size="icon"
           className="h-7 w-7"
-          title="Collapse attribute table"
-          aria-label="Collapse attribute table"
-          onClick={() => setAttributeTableOpen(false)}
+          title="Clear selected feature"
+          aria-label="Clear selected feature"
+          disabled={!selectedFeatureId}
+          onClick={() => selectFeature(null)}
         >
-          <PanelBottomClose className="h-4 w-4" />
+          <X className="h-4 w-4" />
         </Button>
       </div>
-      <ScrollArea className="flex-1">
+      <ScrollArea
+        type="always"
+        className="flex-1 [&_[data-orientation=vertical]]:!top-11 [&_[data-orientation=vertical]]:!h-[calc(100%-2.75rem)]"
+      >
         {!layer?.geojson ? (
           <p className="p-4 text-xs text-muted-foreground">
             Attribute table requires a GeoJSON layer.
           </p>
         ) : (
-          <Table>
-            <TableHeader>
+          <table className="min-w-full table-fixed caption-bottom text-sm">
+            <colgroup>
+              {tableColumns.map((col) => (
+                <col key={col} style={{ width: columnWidth(col) }} />
+              ))}
+            </colgroup>
+            <TableHeader className="sticky top-0 z-10 bg-card shadow-sm">
               <TableRow>
-                <TableHead className="w-12">#</TableHead>
+                <TableHead className="bg-card">
+                  {sortableHeader("__featureId", "#")}
+                </TableHead>
                 {columns.map((col) => (
-                  <TableHead key={col}>{col}</TableHead>
+                  <TableHead key={col} className="bg-card">
+                    {sortableHeader(col, col)}
+                  </TableHead>
                 ))}
               </TableRow>
             </TableHeader>
             <TableBody>
-              {filtered.map((feature, idx) => {
-                const fid = String(feature.id ?? idx);
-                const selected = selectedFeatureId === fid;
+              {sorted.map(({ feature, featureId }: {
+                feature: Feature;
+                featureId: string;
+              }) => {
+                const selected = selectedFeatureId === featureId;
                 return (
                   <TableRow
-                    key={fid}
+                    key={featureId}
                     data-state={selected ? "selected" : undefined}
                     className="cursor-pointer"
                     onClick={() => {
-                      selectFeature(fid);
-                      // TODO(v0.2): Highlight selected feature on map
+                      selectFeature(featureId);
                     }}
                   >
-                    <TableCell>{fid}</TableCell>
+                    <TableCell>{featureId}</TableCell>
                     {columns.map((col) => (
                       <TableCell key={col}>
                         {String(feature.properties?.[col] ?? "")}
@@ -133,7 +389,7 @@ export function AttributeTable() {
                 );
               })}
             </TableBody>
-          </Table>
+          </table>
         )}
       </ScrollArea>
     </section>

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -23,6 +23,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { isTauri } from "../../lib/tauri-io";
 
 type SortDirection = "asc" | "desc";
 type SortKey = "__featureId" | string;
@@ -61,6 +62,7 @@ function compareAttributeValues(a: unknown, b: unknown): number {
 
 export function AttributeTable() {
   const tableSectionRef = useRef<HTMLElement>(null);
+  const tableResizeGuideRef = useRef<HTMLDivElement>(null);
   const selectedLayerId = useAppStore((s) => s.selectedLayerId);
   const layers = useAppStore((s) => s.layers);
   const attributeFilter = useAppStore((s) => s.attributeFilter);
@@ -84,6 +86,7 @@ export function AttributeTable() {
   });
   const [columnWidths, setColumnWidths] = useState<ColumnWidths>({});
   const [tableHeight, setTableHeight] = useState(DEFAULT_TABLE_HEIGHT);
+  const deferTableResize = isTauri();
 
   const layer = layers.find((l) => l.id === selectedLayerId);
   const features = layer?.geojson?.features ?? [];
@@ -192,6 +195,15 @@ export function AttributeTable() {
       if (resizeFrame !== null) return;
       resizeFrame = window.requestAnimationFrame(() => {
         resizeFrame = null;
+        if (deferTableResize) {
+          if (tableResizeGuideRef.current) {
+            tableResizeGuideRef.current.style.top = `${
+              startY + startHeight - nextHeight
+            }px`;
+            tableResizeGuideRef.current.classList.remove("hidden");
+          }
+          return;
+        }
         if (tableSectionRef.current) {
           tableSectionRef.current.style.height = `${nextHeight}px`;
         }
@@ -208,6 +220,7 @@ export function AttributeTable() {
       if (tableSectionRef.current) {
         tableSectionRef.current.style.height = `${nextHeight}px`;
       }
+      tableResizeGuideRef.current?.classList.add("hidden");
       setTableHeight(nextHeight);
       window.dispatchEvent(new Event(PANEL_RESIZE_END_EVENT));
       document.body.style.cursor = previousCursor;
@@ -288,6 +301,10 @@ export function AttributeTable() {
         aria-label="Resize attribute table"
         className="absolute -top-1 left-0 right-0 z-20 h-2 cursor-row-resize select-none border-t border-transparent hover:border-primary"
         onMouseDown={startTableResize}
+      />
+      <div
+        ref={tableResizeGuideRef}
+        className="pointer-events-none fixed left-0 right-0 z-50 hidden h-px bg-primary shadow-[0_0_0_1px_hsl(var(--primary)/0.25)]"
       />
       <div className="flex items-center gap-2 border-b px-3 py-1.5">
         <Button

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -25,6 +25,7 @@ import {
   EyeOff,
   Info,
   Layers,
+  MousePointerClick,
   PanelLeftClose,
   PanelLeftOpen,
   Trash2,
@@ -50,6 +51,8 @@ export function LayerPanel({
   const layers = useAppStore((s) => s.layers);
   const selectedLayerId = useAppStore((s) => s.selectedLayerId);
   const selectLayer = useAppStore((s) => s.selectLayer);
+  const identifyLayerId = useAppStore((s) => s.identifyLayerId);
+  const setIdentifyLayer = useAppStore((s) => s.setIdentifyLayer);
   const setLayerVisibility = useAppStore((s) => s.setLayerVisibility);
   const setLayerOpacity = useAppStore((s) => s.setLayerOpacity);
   const reorderLayer = useAppStore((s) => s.reorderLayer);
@@ -113,131 +116,161 @@ export function LayerPanel({
               No layers. Add data from the toolbar.
             </p>
           )}
-          {[...layers].reverse().map((layer) => (
-            <div
-              key={layer.id}
-              className={`rounded-md border p-2 ${
-                selectedLayerId === layer.id
-                  ? "border-primary bg-primary/5"
-                  : "border-transparent bg-muted/30"
-              }`}
-              onClick={() => selectLayer(layer.id)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") selectLayer(layer.id);
-              }}
-              role="button"
-              tabIndex={0}
-            >
-              <div className="flex items-center gap-1">
-                <button
-                  type="button"
-                  className="rounded p-0.5 hover:bg-muted"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setLayerVisibility(layer.id, !layer.visible);
-                  }}
-                >
-                  {layer.visible ? (
-                    <Eye className="h-3.5 w-3.5" />
-                  ) : (
-                    <EyeOff className="h-3.5 w-3.5 text-muted-foreground" />
-                  )}
-                </button>
-                <span className="flex-1 truncate text-sm font-medium">
-                  {layer.name}
-                </span>
-                <span className="text-[10px] uppercase text-muted-foreground">
-                  {layer.type}
-                </span>
-              </div>
-              {isPlaceholderLayer(layer) && (
-                <p className="mt-1 text-[10px] text-amber-600">
-                  {placeholderMessage(layer)}
-                </p>
-              )}
-              <div className="mt-2 flex items-center gap-1">
-                <span className="text-[10px] text-muted-foreground">Opacity</span>
-                <Slider
-                  className="flex-1"
-                  min={0}
-                  max={1}
-                  step={0.05}
-                  value={[layer.opacity]}
-                  onValueChange={([v]) =>
-                    setLayerOpacity(layer.id, v ?? layer.opacity)
-                  }
-                  onClick={(e) => e.stopPropagation()}
-                />
-              </div>
-              <div className="mt-2 flex gap-1">
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-7 w-7"
-                  title="Move up"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    reorderLayer(layer.id, "up");
-                  }}
-                >
-                  <ChevronUp className="h-3.5 w-3.5" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-7 w-7"
-                  title="Move down"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    reorderLayer(layer.id, "down");
-                  }}
-                >
-                  <ChevronDown className="h-3.5 w-3.5" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-7 w-7"
-                  title="Zoom to layer"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    if (layer.geojson) {
-                      mapControllerRef.current?.fitLayer(layer);
-                    } else {
-                      // TODO(v0.3): zoom to layer for non-GeoJSON types
-                      console.info("Zoom to layer not available for this type");
+          {[...layers].reverse().map((layer) => {
+            const canIdentify =
+              layer.type === "geojson" || layer.type === "vector-tiles";
+            const identifyActive = identifyLayerId === layer.id;
+            return (
+              <div
+                key={layer.id}
+                className={`rounded-md border p-2 ${
+                  selectedLayerId === layer.id
+                    ? "border-primary bg-primary/5"
+                    : "border-transparent bg-muted/30"
+                }`}
+                onClick={() => selectLayer(layer.id)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") selectLayer(layer.id);
+                }}
+                role="button"
+                tabIndex={0}
+              >
+                <div className="flex items-center gap-1">
+                  <button
+                    type="button"
+                    className="rounded p-0.5 hover:bg-muted"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setLayerVisibility(layer.id, !layer.visible);
+                    }}
+                  >
+                    {layer.visible ? (
+                      <Eye className="h-3.5 w-3.5" />
+                    ) : (
+                      <EyeOff className="h-3.5 w-3.5 text-muted-foreground" />
+                    )}
+                  </button>
+                  <span className="flex-1 truncate text-sm font-medium">
+                    {layer.name}
+                  </span>
+                  <span className="text-[10px] uppercase text-muted-foreground">
+                    {layer.type}
+                  </span>
+                </div>
+                {isPlaceholderLayer(layer) && (
+                  <p className="mt-1 text-[10px] text-amber-600">
+                    {placeholderMessage(layer)}
+                  </p>
+                )}
+                <div className="mt-2 flex items-center gap-1">
+                  <span className="text-[10px] text-muted-foreground">Opacity</span>
+                  <Slider
+                    className="flex-1"
+                    min={0}
+                    max={1}
+                    step={0.05}
+                    value={[layer.opacity]}
+                    onValueChange={([v]) =>
+                      setLayerOpacity(layer.id, v ?? layer.opacity)
                     }
-                  }}
-                >
-                  <ZoomIn className="h-3.5 w-3.5" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-7 w-7"
-                  title="Metadata"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setMetadataLayer(layer);
-                  }}
-                >
-                  <Info className="h-3.5 w-3.5" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-7 w-7 text-destructive"
-                  title="Remove layer"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setLayerPendingRemoval(layer);
-                  }}
-                >
-                  <Trash2 className="h-3.5 w-3.5" />
-                </Button>
+                    onClick={(e) => e.stopPropagation()}
+                  />
+                </div>
+                <div className="mt-2 flex gap-1">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7"
+                    title="Move up"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      reorderLayer(layer.id, "up");
+                    }}
+                  >
+                    <ChevronUp className="h-3.5 w-3.5" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7"
+                    title="Move down"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      reorderLayer(layer.id, "down");
+                    }}
+                  >
+                    <ChevronDown className="h-3.5 w-3.5" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7"
+                    title="Zoom to layer"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (layer.geojson) {
+                        mapControllerRef.current?.fitLayer(layer);
+                      } else {
+                        // TODO(v0.3): zoom to layer for non-GeoJSON types
+                        console.info("Zoom to layer not available for this type");
+                      }
+                    }}
+                  >
+                    <ZoomIn className="h-3.5 w-3.5" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className={`h-7 w-7 ${
+                      identifyActive
+                        ? "border border-primary bg-primary text-primary-foreground shadow-sm hover:bg-primary/90 hover:text-primary-foreground"
+                        : ""
+                    }`}
+                    title={
+                      canIdentify
+                        ? identifyActive
+                          ? "Deactivate identify"
+                          : "Identify features"
+                        : "Identify is only available for vector layers"
+                    }
+                    disabled={!canIdentify}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (!canIdentify) return;
+                      selectLayer(layer.id);
+                      setIdentifyLayer(identifyActive ? null : layer.id);
+                    }}
+                  >
+                    <MousePointerClick className="h-3.5 w-3.5" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7"
+                    title="Metadata"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setMetadataLayer(layer);
+                    }}
+                  >
+                    <Info className="h-3.5 w-3.5" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 text-destructive"
+                    title="Remove layer"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setLayerPendingRemoval(layer);
+                    }}
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </ScrollArea>
       <Separator />

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -1,4 +1,8 @@
-import { useState } from "react";
+import {
+  type MouseEvent as ReactMouseEvent,
+  type RefObject,
+  useState,
+} from "react";
 import { useAppStore } from "@geolibre/core";
 import type { GeoLibreLayer } from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
@@ -28,7 +32,8 @@ import {
 } from "lucide-react";
 
 interface LayerPanelProps {
-  mapControllerRef: React.RefObject<MapController | null>;
+  mapControllerRef: RefObject<MapController | null>;
+  onResizeStart: (event: ReactMouseEvent<HTMLDivElement>) => void;
 }
 
 function isMobileViewport(): boolean {
@@ -38,7 +43,10 @@ function isMobileViewport(): boolean {
   );
 }
 
-export function LayerPanel({ mapControllerRef }: LayerPanelProps) {
+export function LayerPanel({
+  mapControllerRef,
+  onResizeStart,
+}: LayerPanelProps) {
   const layers = useAppStore((s) => s.layers);
   const selectedLayerId = useAppStore((s) => s.selectedLayerId);
   const selectLayer = useAppStore((s) => s.selectLayer);
@@ -75,7 +83,16 @@ export function LayerPanel({ mapControllerRef }: LayerPanelProps) {
   }
 
   return (
-    <aside className="flex max-h-56 w-full shrink-0 flex-col border-b bg-card md:max-h-none md:w-64 md:border-b-0 md:border-r">
+    <aside
+      className="relative flex max-h-56 w-full shrink-0 flex-col border-b bg-card md:max-h-none md:w-[var(--layer-panel-width)] md:border-b-0 md:border-r"
+    >
+      <div
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize Layers panel"
+        className="absolute -right-1 top-0 z-20 hidden h-full w-2 cursor-col-resize select-none border-r border-transparent hover:border-primary md:block"
+        onMouseDown={onResizeStart}
+      />
       <div className="flex items-center justify-between border-b px-3 py-1.5">
         <span className="text-sm font-semibold">Layers</span>
         <Button

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -6,6 +6,8 @@ import {
 } from "@geolibre/core";
 import { Button, Input, Label, ScrollArea, Separator, Slider } from "@geolibre/ui";
 import {
+  ChevronDown,
+  ChevronUp,
   PanelRightClose,
   PanelRightOpen,
   SlidersHorizontal,
@@ -35,6 +37,81 @@ function styleValue<K extends keyof LayerStyle>(
   key: K,
 ): LayerStyle[K] {
   return style[key] ?? DEFAULT_LAYER_STYLE[key];
+}
+
+function clampNumber(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function stepPrecision(step: number): number {
+  const [, decimals = ""] = String(step).split(".");
+  return decimals.length;
+}
+
+interface NumericStyleInputProps {
+  id: string;
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  onChange: (value: number) => void;
+}
+
+function NumericStyleInput({
+  id,
+  label,
+  value,
+  min,
+  max,
+  step,
+  onChange,
+}: NumericStyleInputProps) {
+  const normalize = (next: number) =>
+    Number(clampNumber(next, min, max).toFixed(stepPrecision(step)));
+
+  const stepValue = (direction: 1 | -1) => {
+    onChange(normalize(value + direction * step));
+  };
+
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={id}>{label}</Label>
+      <div className="relative">
+        <Input
+          id={id}
+          type="number"
+          min={min}
+          max={max}
+          step={step}
+          className="pr-9 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+          value={value}
+          onChange={(event) => {
+            const next = Number(event.target.value);
+            if (Number.isFinite(next)) onChange(normalize(next));
+          }}
+        />
+        <div className="absolute right-1 top-0.5 flex h-8 w-7 flex-col overflow-hidden rounded border bg-background">
+          <button
+            type="button"
+            className="flex h-1/2 items-center justify-center text-foreground hover:bg-accent"
+            aria-label={`Increase ${label}`}
+            onClick={() => stepValue(1)}
+          >
+            <ChevronUp className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            className="flex h-1/2 items-center justify-center border-t text-foreground hover:bg-accent"
+            aria-label={`Decrease ${label}`}
+            onClick={() => stepValue(-1)}
+          >
+            <ChevronDown className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 interface RasterStyleSliderProps {
@@ -318,54 +395,39 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
               }
             />
           </div>
-          <div className="space-y-2">
-            <Label htmlFor="strokeWidth">Stroke width</Label>
-            <Input
-              id="strokeWidth"
-              type="number"
-              min={0}
-              max={20}
-              step={0.5}
-              value={style.strokeWidth}
-              onChange={(e) =>
-                setLayerStyle(layer.id, {
-                  strokeWidth: Number(e.target.value),
-                })
-              }
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="fillOpacity">Fill opacity</Label>
-            <Input
-              id="fillOpacity"
-              type="number"
-              min={0}
-              max={1}
-              step={0.05}
-              value={style.fillOpacity}
-              onChange={(e) =>
-                setLayerStyle(layer.id, {
-                  fillOpacity: Number(e.target.value),
-                })
-              }
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="circleRadius">Circle radius</Label>
-            <Input
-              id="circleRadius"
-              type="number"
-              min={1}
-              max={50}
-              step={1}
-              value={style.circleRadius}
-              onChange={(e) =>
-                setLayerStyle(layer.id, {
-                  circleRadius: Number(e.target.value),
-                })
-              }
-            />
-          </div>
+          <NumericStyleInput
+            id="strokeWidth"
+            label="Stroke width"
+            min={0}
+            max={20}
+            step={0.5}
+            value={style.strokeWidth}
+            onChange={(strokeWidth) =>
+              setLayerStyle(layer.id, { strokeWidth })
+            }
+          />
+          <NumericStyleInput
+            id="fillOpacity"
+            label="Fill opacity"
+            min={0}
+            max={1}
+            step={0.05}
+            value={style.fillOpacity}
+            onChange={(fillOpacity) =>
+              setLayerStyle(layer.id, { fillOpacity })
+            }
+          />
+          <NumericStyleInput
+            id="circleRadius"
+            label="Circle radius"
+            min={1}
+            max={50}
+            step={1}
+            value={style.circleRadius}
+            onChange={(circleRadius) =>
+              setLayerStyle(layer.id, { circleRadius })
+            }
+          />
         </div>
       </ScrollArea>
       <Separator />

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -10,7 +10,14 @@ import {
   PanelRightOpen,
   SlidersHorizontal,
 } from "lucide-react";
-import { useState } from "react";
+import {
+  type MouseEvent as ReactMouseEvent,
+  useState,
+} from "react";
+
+interface StylePanelProps {
+  onResizeStart: (event: ReactMouseEvent<HTMLDivElement>) => void;
+}
 
 function isMobileViewport(): boolean {
   return (
@@ -70,7 +77,7 @@ function RasterStyleSlider({
   );
 }
 
-export function StylePanel() {
+export function StylePanel({ onResizeStart }: StylePanelProps) {
   const selectedLayerId = useAppStore((s) => s.selectedLayerId);
   const layers = useAppStore((s) => s.layers);
   const setLayerOpacity = useAppStore((s) => s.setLayerOpacity);
@@ -78,6 +85,16 @@ export function StylePanel() {
   const [isCollapsed, setIsCollapsed] = useState(isMobileViewport);
 
   const layer = layers.find((l) => l.id === selectedLayerId);
+
+  const resizeHandle = (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="Resize Style panel"
+      className="absolute -left-1 top-0 z-20 hidden h-full w-2 cursor-col-resize select-none border-l border-transparent hover:border-primary md:block"
+      onMouseDown={onResizeStart}
+    />
+  );
 
   if (isCollapsed) {
     return (
@@ -104,7 +121,10 @@ export function StylePanel() {
 
   if (!layer) {
     return (
-      <aside className="flex max-h-56 w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-64 md:border-l md:border-t-0">
+      <aside
+        className="relative flex max-h-56 w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0"
+      >
+        {resizeHandle}
         <div className="flex items-center justify-between border-b px-3 py-1.5">
           <span className="text-sm font-semibold">Style</span>
           <Button
@@ -132,7 +152,10 @@ export function StylePanel() {
 
   if (hasRasterPaintControls) {
     return (
-      <aside className="flex max-h-56 w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-64 md:border-l md:border-t-0">
+      <aside
+        className="relative flex max-h-56 w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0"
+      >
+        {resizeHandle}
         <div className="flex items-center justify-between gap-2 border-b px-3 py-1.5">
           <span className="truncate text-sm font-semibold">
             Style - {layer.name}
@@ -221,7 +244,10 @@ export function StylePanel() {
 
   if (!hasVectorPaintControls) {
     return (
-      <aside className="flex max-h-56 w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-64 md:border-l md:border-t-0">
+      <aside
+        className="relative flex max-h-56 w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0"
+      >
+        {resizeHandle}
         <div className="flex items-center justify-between gap-2 border-b px-3 py-1.5">
           <span className="truncate text-sm font-semibold">
             Style - {layer.name}
@@ -249,7 +275,10 @@ export function StylePanel() {
   }
 
   return (
-    <aside className="flex max-h-56 w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-64 md:border-l md:border-t-0">
+    <aside
+      className="relative flex max-h-56 w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0"
+    >
+      {resizeHandle}
       <div className="flex items-center justify-between gap-2 border-b px-3 py-1.5">
         <span className="truncate text-sm font-semibold">
           Style - {layer.name}

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -344,9 +344,50 @@ body,
   outline: none;
 }
 
-.maplibregl-ctrl button.maplibregl-ctrl-globe .maplibregl-ctrl-icon,
 .maplibregl-ctrl button.maplibregl-ctrl-globe-enabled .maplibregl-ctrl-icon {
   background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='22' fill='none' stroke='%2333b5e5' viewBox='0 0 22 22'%3E%3Ccircle cx='11' cy='11' r='8.5'/%3E%3Cpath d='M17.5 11c0 4.819-3.02 8.5-6.5 8.5S4.5 15.819 4.5 11 7.52 2.5 11 2.5s6.5 3.681 6.5 8.5Z'/%3E%3Cpath d='M13.5 11c0 2.447-.331 4.64-.853 6.206-.262.785-.562 1.384-.872 1.777-.314.399-.58.517-.775.517s-.461-.118-.775-.517c-.31-.393-.61-.992-.872-1.777C8.831 15.64 8.5 13.446 8.5 11s.331-4.64.853-6.206c.262-.785.562-1.384.872-1.777.314-.399.58-.517.775-.517s.461.118.775.517c.31.393.61.992.872 1.777.522 1.565.853 3.76.853 6.206Z'/%3E%3Cpath d='M11 7.5c-1.909 0-3.622-.166-4.845-.428-.616-.132-1.08-.283-1.379-.434a1.3 1.3 0 0 1-.224-.138q.07-.058.224-.138c.299-.151.763-.302 1.379-.434C7.378 5.666 9.091 5.5 11 5.5s3.622.166 4.845.428c.616.132 1.08.283 1.379.434.105.053.177.1.224.138q-.07.058-.224.138c-.299.151-.763.302-1.379.434-1.223.262-2.936.428-4.845.428ZM4.486 6.436ZM11 16.5c-1.909 0-3.622-.166-4.845-.428-.616-.132-1.08-.283-1.379-.434a1.3 1.3 0 0 1-.224-.138 1.3 1.3 0 0 1 .224-.138c.299-.151.763-.302 1.379-.434C7.378 14.666 9.091 14.5 11 14.5s3.622.166 4.845.428c.616.132 1.08.283 1.379.434.105.053.177.1.224.138a1.3 1.3 0 0 1-.224.138c-.299.151-.763.302-1.379.434-1.223.262-2.936.428-4.845.428Zm-6.514-1.064ZM11 12.5c-2.46 0-4.672-.222-6.255-.574-.796-.177-1.406-.38-1.805-.59a1.5 1.5 0 0 1-.39-.272.3.3 0 0 1-.047-.064.3.3 0 0 1 .048-.064c.066-.073.189-.167.389-.272.399-.21 1.009-.413 1.805-.59C6.328 9.722 8.54 9.5 11 9.5s4.672.222 6.256.574c.795.177 1.405.38 1.804.59.2.105.323.2.39.272a.3.3 0 0 1 .047.064.3.3 0 0 1-.048.064 1.4 1.4 0 0 1-.389.272c-.399.21-1.009.413-1.804.59-1.584.352-3.796.574-6.256.574Zm-8.501-1.51v.002zm0 .018v.002zm17.002.002v-.002zm0-.018v-.002z'/%3E%3C/svg%3E");
+}
+
+.geolibre-identify-popup .maplibregl-popup-content {
+  background: hsl(var(--popover));
+  border: 1px solid hsl(var(--border));
+  box-shadow:
+    0 10px 15px -3px rgb(0 0 0 / 0.18),
+    0 4px 6px -4px rgb(0 0 0 / 0.18);
+  color: hsl(var(--popover-foreground));
+}
+
+.geolibre-identify-popup .maplibregl-popup-close-button {
+  color: hsl(var(--muted-foreground));
+}
+
+.geolibre-identify-popup .maplibregl-popup-close-button:hover {
+  background: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
+}
+
+.geolibre-identify-popup.maplibregl-popup-anchor-top .maplibregl-popup-tip,
+.geolibre-identify-popup.maplibregl-popup-anchor-top-left
+  .maplibregl-popup-tip,
+.geolibre-identify-popup.maplibregl-popup-anchor-top-right
+  .maplibregl-popup-tip {
+  border-bottom-color: hsl(var(--popover));
+}
+
+.geolibre-identify-popup.maplibregl-popup-anchor-bottom .maplibregl-popup-tip,
+.geolibre-identify-popup.maplibregl-popup-anchor-bottom-left
+  .maplibregl-popup-tip,
+.geolibre-identify-popup.maplibregl-popup-anchor-bottom-right
+  .maplibregl-popup-tip {
+  border-top-color: hsl(var(--popover));
+}
+
+.geolibre-identify-popup.maplibregl-popup-anchor-left .maplibregl-popup-tip {
+  border-right-color: hsl(var(--popover));
+}
+
+.geolibre-identify-popup.maplibregl-popup-anchor-right .maplibregl-popup-tip {
+  border-left-color: hsl(var(--popover));
 }
 
 .swipe-control-panel .swipe-control-select {

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -39,7 +39,7 @@ function getDatabase(): Promise<duckdb.AsyncDuckDB> {
 
 async function createDatabase(): Promise<duckdb.AsyncDuckDB> {
   const bundle = await duckdb.selectBundle(MANUAL_BUNDLES);
-  const worker = new Worker(bundle.mainWorker!);
+  const worker = new Worker(bundle.mainWorker!, { type: "module" });
   const logger = new duckdb.ConsoleLogger(duckdb.LogLevel.WARNING);
   const db = new duckdb.AsyncDuckDB(logger, worker);
   await db.instantiate(bundle.mainModule, bundle.pthreadWorker);
@@ -68,13 +68,17 @@ function sourceSql(fileName: string, extension: string): string {
   return `SELECT * FROM ST_Read(${quotedName})`;
 }
 
-function toFeatureCollection(rows: Record<string, unknown>[]): FeatureCollection {
+function toFeatureCollection(
+  rows: Record<string, unknown>[],
+): FeatureCollection<Geometry | null> {
   const features = rows.map((row) => {
     const rawGeometry = row[GEOMETRY_JSON_COLUMN];
-    if (typeof rawGeometry !== "string") {
-      throw new Error("DuckDB returned a feature without GeoJSON geometry.");
-    }
-    const geometry = JSON.parse(rawGeometry) as Geometry;
+    // ST_AsGeoJSON returns SQL NULL for rows with missing/NULL geometries.
+    // GeoJSON Features may legally have a null geometry, so keep the row.
+    const geometry =
+      typeof rawGeometry === "string"
+        ? (JSON.parse(rawGeometry) as Geometry)
+        : null;
     const properties: Record<string, unknown> = {};
 
     for (const [key, value] of Object.entries(row)) {
@@ -86,7 +90,7 @@ function toFeatureCollection(rows: Record<string, unknown>[]): FeatureCollection
       type: "Feature",
       geometry,
       properties,
-    } satisfies Feature;
+    } satisfies Feature<Geometry | null>;
   });
 
   return {
@@ -146,7 +150,9 @@ export async function loadDuckDbVectorFile(
         geometryColumn,
       )}) AS ${quoteIdentifier(GEOMETRY_JSON_COLUMN)} FROM (${sql}) AS data`,
     );
-    return toFeatureCollection(rowsFromResult(result));
+    // Features may carry a null geometry; the app's layer model treats them as
+    // a regular FeatureCollection and the map ignores null geometries.
+    return toFeatureCollection(rowsFromResult(result)) as FeatureCollection;
   } finally {
     await connection.close();
   }

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -1,0 +1,153 @@
+import * as duckdb from "@duckdb/duckdb-wasm";
+import duckdbWasmEh from "@duckdb/duckdb-wasm/dist/duckdb-eh.wasm?url";
+import ehWorker from "@duckdb/duckdb-wasm/dist/duckdb-browser-eh.worker.js?url";
+import duckdbWasmMvp from "@duckdb/duckdb-wasm/dist/duckdb-mvp.wasm?url";
+import mvpWorker from "@duckdb/duckdb-wasm/dist/duckdb-browser-mvp.worker.js?url";
+import type { Feature, FeatureCollection, Geometry } from "geojson";
+
+const GEOMETRY_JSON_COLUMN = "__geolibre_geometry_geojson";
+
+const MANUAL_BUNDLES: duckdb.DuckDBBundles = {
+  mvp: {
+    mainModule: duckdbWasmMvp,
+    mainWorker: mvpWorker,
+  },
+  eh: {
+    mainModule: duckdbWasmEh,
+    mainWorker: ehWorker,
+  },
+};
+
+let dbPromise: Promise<duckdb.AsyncDuckDB> | null = null;
+
+interface DuckDbRow {
+  toJSON?: () => Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface DuckDbVectorFile {
+  name: string;
+  extension: string;
+  data: Uint8Array<ArrayBuffer>;
+  siblingFiles?: DuckDbVectorFile[];
+}
+
+function getDatabase(): Promise<duckdb.AsyncDuckDB> {
+  dbPromise ??= createDatabase();
+  return dbPromise;
+}
+
+async function createDatabase(): Promise<duckdb.AsyncDuckDB> {
+  const bundle = await duckdb.selectBundle(MANUAL_BUNDLES);
+  const worker = new Worker(bundle.mainWorker!);
+  const logger = new duckdb.ConsoleLogger(duckdb.LogLevel.WARNING);
+  const db = new duckdb.AsyncDuckDB(logger, worker);
+  await db.instantiate(bundle.mainModule, bundle.pthreadWorker);
+  return db;
+}
+
+function quoteSqlString(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function quoteIdentifier(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`;
+}
+
+function rowsFromResult(result: { toArray: () => DuckDbRow[] }) {
+  return result.toArray().map((row) =>
+    typeof row.toJSON === "function" ? row.toJSON() : { ...row },
+  );
+}
+
+function sourceSql(fileName: string, extension: string): string {
+  const quotedName = quoteSqlString(fileName);
+  if (extension === "parquet" || extension === "geoparquet") {
+    return `SELECT * FROM read_parquet(${quotedName})`;
+  }
+  return `SELECT * FROM ST_Read(${quotedName})`;
+}
+
+function toFeatureCollection(rows: Record<string, unknown>[]): FeatureCollection {
+  const features = rows.map((row) => {
+    const rawGeometry = row[GEOMETRY_JSON_COLUMN];
+    if (typeof rawGeometry !== "string") {
+      throw new Error("DuckDB returned a feature without GeoJSON geometry.");
+    }
+    const geometry = JSON.parse(rawGeometry) as Geometry;
+    const properties: Record<string, unknown> = {};
+
+    for (const [key, value] of Object.entries(row)) {
+      if (key === GEOMETRY_JSON_COLUMN || value instanceof Uint8Array) continue;
+      properties[key] = normalizePropertyValue(value);
+    }
+
+    return {
+      type: "Feature",
+      geometry,
+      properties,
+    } satisfies Feature;
+  });
+
+  return {
+    type: "FeatureCollection",
+    features,
+  };
+}
+
+function normalizePropertyValue(value: unknown): unknown {
+  if (typeof value === "bigint") {
+    const numberValue = Number(value);
+    return Number.isSafeInteger(numberValue) ? numberValue : value.toString();
+  }
+  if (value instanceof Date) return value.toISOString();
+  if (Array.isArray(value)) return value.map(normalizePropertyValue);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [
+        key,
+        normalizePropertyValue(item),
+      ]),
+    );
+  }
+  return value;
+}
+
+export async function loadDuckDbVectorFile(
+  file: DuckDbVectorFile,
+): Promise<FeatureCollection> {
+  const db = await getDatabase();
+  const connection = await db.connect();
+
+  try {
+    await db.registerFileBuffer(file.name, file.data);
+    for (const sibling of file.siblingFiles ?? []) {
+      await db.registerFileBuffer(sibling.name, sibling.data);
+    }
+    await connection.query("INSTALL spatial");
+    await connection.query("LOAD spatial");
+
+    const sql = sourceSql(file.name, file.extension);
+    const description = rowsFromResult(
+      await connection.query(`DESCRIBE ${sql}`),
+    );
+    const geometryColumn = description.find(
+      (row) =>
+        typeof row.column_type === "string" &&
+        row.column_type.toUpperCase() === "GEOMETRY",
+    )?.column_name;
+
+    if (typeof geometryColumn !== "string") {
+      throw new Error("DuckDB did not find a GEOMETRY column in this file.");
+    }
+
+    const result = await connection.query(
+      `SELECT *, ST_AsGeoJSON(${quoteIdentifier(
+        geometryColumn,
+      )}) AS ${quoteIdentifier(GEOMETRY_JSON_COLUMN)} FROM (${sql}) AS data`,
+    );
+    return toFeatureCollection(rowsFromResult(result));
+  } finally {
+    await connection.close();
+  }
+}

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -1,9 +1,11 @@
 import { parseProject, type GeoLibreProject } from "@geolibre/core";
 import { open, save } from "@tauri-apps/plugin-dialog";
-import { readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
+import { readFile, readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
 import type { FeatureCollection } from "geojson";
+import shp from "shpjs";
+import type { DuckDbVectorFile } from "./duckdb-vector-loader";
 
-function isTauri(): boolean {
+export function isTauri(): boolean {
   return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 }
 
@@ -64,8 +66,241 @@ const GEOLIBRE_PROJECT_FILE_TYPES: BrowserFilePickerType[] = [
   },
 ];
 
+const VECTOR_FILE_ACCEPT =
+  ".geojson,.json,.zip,.shp,.gpkg,.parquet,.geoparquet";
+
+const SHAPEFILE_SIDECAR_EXTENSIONS = ["dbf", "shx", "prj", "cpg"];
+
+const DROPPED_VECTOR_FILE_EXTENSIONS = new Set([
+  "geojson",
+  "json",
+  "zip",
+  "shp",
+  "shx",
+  "dbf",
+  "prj",
+  "cpg",
+  "gpkg",
+  "parquet",
+  "geoparquet",
+]);
+
+const VECTOR_FILE_FILTERS: FileDialogFilter[] = [
+  {
+    name: "Vector data",
+    extensions: [
+      "geojson",
+      "json",
+      "zip",
+      "shp",
+      "gpkg",
+      "parquet",
+      "geoparquet",
+    ],
+  },
+];
+
 function isAbortError(error: unknown): boolean {
   return error instanceof DOMException && error.name === "AbortError";
+}
+
+function fileExtension(path: string): string {
+  const name = browserSafeFileName(path).toLowerCase();
+  if (name.endsWith(".geoparquet")) return "geoparquet";
+  return name.split(".").pop() ?? "";
+}
+
+function pathWithoutExtension(path: string): string {
+  return path.replace(/\.[^.\\/]+$/, "");
+}
+
+function isVectorFileName(path: string): boolean {
+  return DROPPED_VECTOR_FILE_EXTENSIONS.has(fileExtension(path));
+}
+
+function assertFeatureCollection(value: unknown): FeatureCollection {
+  if (
+    value &&
+    typeof value === "object" &&
+    (value as { type?: unknown }).type === "FeatureCollection" &&
+    Array.isArray((value as { features?: unknown }).features)
+  ) {
+    return value as FeatureCollection;
+  }
+  throw new Error("The selected file did not produce a GeoJSON FeatureCollection.");
+}
+
+function mergeFeatureCollections(
+  collections: FeatureCollection[],
+): FeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: collections.flatMap((collection) => collection.features),
+  };
+}
+
+function normalizeShapefileResult(value: unknown): FeatureCollection {
+  if (Array.isArray(value)) {
+    return mergeFeatureCollections(value.map(assertFeatureCollection));
+  }
+  return assertFeatureCollection(value);
+}
+
+async function parseGeoJsonText(
+  text: string,
+): Promise<FeatureCollection> {
+  return assertFeatureCollection(JSON.parse(text));
+}
+
+async function parseShapefileZip(
+  data: ArrayBuffer | Uint8Array,
+): Promise<FeatureCollection> {
+  return normalizeShapefileResult(await shp(data));
+}
+
+async function loadDuckDbVector(file: DuckDbVectorFile) {
+  const { loadDuckDbVectorFile } = await import("./duckdb-vector-loader");
+  return loadDuckDbVectorFile(file);
+}
+
+async function fileToDuckDbVectorFile(file: File): Promise<DuckDbVectorFile> {
+  return {
+    name: file.name,
+    extension: fileExtension(file.name),
+    data: new Uint8Array(await file.arrayBuffer()),
+  };
+}
+
+async function loadBrowserVectorFile(
+  file: File,
+  siblingFiles: DuckDbVectorFile[] = [],
+): Promise<{
+  data: FeatureCollection;
+  path: string;
+}> {
+  const extension = fileExtension(file.name);
+  if (extension === "geojson" || extension === "json") {
+    return {
+      data: await parseGeoJsonText(await file.text()),
+      path: file.name,
+    };
+  }
+
+  if (extension === "zip") {
+    return {
+      data: await parseShapefileZip(await file.arrayBuffer()),
+      path: file.name,
+    };
+  }
+
+  return {
+    data: await loadDuckDbVector({
+      name: file.name,
+      extension,
+      data: new Uint8Array(await file.arrayBuffer()),
+      siblingFiles,
+    }),
+    path: file.name,
+  };
+}
+
+async function openVectorFileBrowser(): Promise<{
+  data: FeatureCollection;
+  path: string;
+} | null> {
+  return new Promise((resolve, reject) => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = VECTOR_FILE_ACCEPT;
+    input.onchange = async () => {
+      try {
+        const file = input.files?.[0];
+        if (!file) {
+          resolve(null);
+          return;
+        }
+
+        resolve(await loadBrowserVectorFile(file));
+      } catch (error) {
+        reject(error);
+      }
+    };
+    input.click();
+  });
+}
+
+async function openVectorFileTauri(): Promise<{
+  data: FeatureCollection;
+  path: string;
+} | null> {
+  const selected = await open({
+    multiple: false,
+    filters: VECTOR_FILE_FILTERS,
+  });
+  if (!selected || typeof selected !== "string") return null;
+  return loadTauriVectorFile(selected);
+}
+
+async function loadTauriVectorFile(path: string): Promise<{
+  data: FeatureCollection;
+  path: string;
+}> {
+  const extension = fileExtension(path);
+  if (extension === "geojson" || extension === "json") {
+    return {
+      data: await parseGeoJsonText(await readTextFile(path)),
+      path,
+    };
+  }
+
+  if (extension === "zip") {
+    return {
+      data: await parseShapefileZip(await readFile(path)),
+      path,
+    };
+  }
+
+  try {
+    const siblingFiles = extension === "shp" ? await readShapefileSiblings(path) : [];
+    return {
+      data: await loadDuckDbVector({
+        name: browserSafeFileName(path),
+        extension,
+        data: await readFile(path),
+        siblingFiles,
+      }),
+      path,
+    };
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : "Unknown error";
+    throw new Error(
+      `Could not convert this vector file with DuckDB-WASM. ${detail}`,
+    );
+  }
+}
+
+async function readShapefileSiblings(
+  path: string,
+): Promise<DuckDbVectorFile[]> {
+  const basePath = pathWithoutExtension(path);
+  const siblings = await Promise.all(
+    SHAPEFILE_SIDECAR_EXTENSIONS.map(async (extension) => {
+      const siblingPath = `${basePath}.${extension}`;
+      try {
+        return {
+          name: browserSafeFileName(siblingPath),
+          extension,
+          data: await readFile(siblingPath),
+        };
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  return siblings.filter(
+    (sibling): sibling is DuckDbVectorFile => sibling !== null,
+  );
 }
 
 async function openProjectFileBrowser(): Promise<{
@@ -188,7 +423,7 @@ export async function openGeoJsonFile(): Promise<{
   });
   if (!selected || typeof selected !== "string") return null;
   const text = await readTextFile(selected);
-  const data = JSON.parse(text) as FeatureCollection;
+  const data = await parseGeoJsonText(text);
   return { data, path: selected };
 }
 
@@ -244,7 +479,7 @@ export function openGeoJsonFileBrowser(): Promise<{
       }
       const text = await file.text();
       resolve({
-        data: JSON.parse(text) as FeatureCollection,
+        data: await parseGeoJsonText(text),
         path: file.name,
       });
     };
@@ -258,4 +493,64 @@ export async function openGeoJsonFileWithFallback(): Promise<{
 } | null> {
   if (isTauri()) return openGeoJsonFile();
   return openGeoJsonFileBrowser();
+}
+
+export async function openVectorFileWithFallback(): Promise<{
+  data: FeatureCollection;
+  path: string;
+} | null> {
+  if (isTauri()) return openVectorFileTauri();
+  return openVectorFileBrowser();
+}
+
+export async function loadDroppedVectorFiles(
+  droppedFiles: FileList | File[],
+): Promise<Array<{ data: FeatureCollection; path: string }>> {
+  const files = Array.from(droppedFiles).filter((file) =>
+    isVectorFileName(file.name),
+  );
+  if (!files.length) return [];
+
+  const filesByBaseName = new Map<string, File[]>();
+  for (const file of files) {
+    const baseName = pathWithoutExtension(file.name).toLowerCase();
+    filesByBaseName.set(baseName, [...(filesByBaseName.get(baseName) ?? []), file]);
+  }
+
+  const layers: Array<{ data: FeatureCollection; path: string }> = [];
+  for (const file of files) {
+    const extension = fileExtension(file.name);
+    if (SHAPEFILE_SIDECAR_EXTENSIONS.includes(extension)) continue;
+
+    const siblingFiles =
+      extension === "shp"
+        ? await Promise.all(
+            (filesByBaseName.get(pathWithoutExtension(file.name).toLowerCase()) ?? [])
+              .filter((candidate) =>
+                SHAPEFILE_SIDECAR_EXTENSIONS.includes(
+                  fileExtension(candidate.name),
+                ),
+              )
+              .map(fileToDuckDbVectorFile),
+          )
+        : [];
+    layers.push(await loadBrowserVectorFile(file, siblingFiles));
+  }
+
+  return layers;
+}
+
+export async function loadDroppedVectorPaths(
+  paths: string[],
+): Promise<Array<{ data: FeatureCollection; path: string }>> {
+  const vectorPaths = paths.filter(isVectorFileName);
+  if (!vectorPaths.length) return [];
+
+  const layers: Array<{ data: FeatureCollection; path: string }> = [];
+  for (const path of vectorPaths) {
+    if (SHAPEFILE_SIDECAR_EXTENSIONS.includes(fileExtension(path))) continue;
+    layers.push(await loadTauriVectorFile(path));
+  }
+
+  return layers;
 }

--- a/apps/geolibre-desktop/src/vite-env.d.ts
+++ b/apps/geolibre-desktop/src/vite-env.d.ts
@@ -4,3 +4,8 @@ declare module "*.geojson?url" {
   const url: string;
   export default url;
 }
+
+declare module "shpjs" {
+  const shp: (input: unknown) => Promise<unknown>;
+  export default shp;
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,22 +28,22 @@ flowchart LR
 
 ## State flow
 
-1. User adds GeoJSON through the Tauri dialog or browser file picker.
-2. Parsed GeoJSON is passed to `addGeoJsonLayer` in the store.
+1. User adds GeoJSON, GeoParquet, GeoPackage, or Shapefile data through the Tauri dialog, browser file picker, or drag and drop.
+2. The selected vector data is parsed directly or converted to GeoJSON with DuckDB-WASM Spatial, then passed to `addGeoJsonLayer` in the store.
 3. `MapCanvas` subscribes to `layers`, then `MapController.syncLayers` updates MapLibre sources and layers.
 4. Style panel updates `layer.style`, then sync updates paint properties.
 5. Desktop save uses `projectFromStore` and writes `.geolibre.json` to disk.
 
 ## DuckDB-WASM
 
-Reserved for v0.4 (`@duckdb/duckdb-wasm` dependency in app). Planned flow:
+Vector file import uses DuckDB-WASM for formats that need conversion before MapLibre can render them:
 
 ```sql
 INSTALL spatial;
 LOAD spatial;
 ```
 
-Query results will register as `duckdb-query` layer placeholders, then full layer support in v0.4.
+GeoParquet is read with DuckDB's Parquet reader after loading Spatial. GeoPackage and loose Shapefile paths are read through Spatial `ST_Read` when the WebAssembly extension can load the GDAL-backed reader. Zipped Shapefiles are parsed in the browser with `shpjs`.
 
 ## Python sidecar (v0.5)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,7 +22,7 @@ npm install
 npm run dev
 ```
 
-Open `http://localhost:1420`. The map and browser GeoJSON import work in this mode. Desktop filesystem dialogs require Tauri.
+Open `http://localhost:1420`. The map and browser vector import work in this mode for GeoJSON, GeoParquet, GeoPackage, and zipped Shapefiles. Use Add Vector Layer or drag files onto the app. Desktop filesystem dialogs require Tauri.
 
 ## Run the desktop app
 

--- a/docs/project-format.md
+++ b/docs/project-format.md
@@ -47,7 +47,7 @@ Projects are saved as **`.geolibre.json`** files.
 | `pmtiles` | Placeholder (v0.3) |
 | `cog` | Placeholder (v0.3) |
 | `flatgeobuf` | Placeholder (v0.3) |
-| `geoparquet` | Placeholder (v0.3) |
+| `geoparquet` | Imported as GeoJSON via DuckDB-WASM |
 | `duckdb-query` | Placeholder (v0.4) |
 
 ## Example

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "npm run build -w geolibre-desktop",
     "tauri": "npm run tauri -w geolibre-desktop",
     "tauri:dev": "npm run tauri dev -w geolibre-desktop",
-    "tauri:build": "npm run tauri build -w geolibre-desktop"
+    "tauri:build": "node scripts/tauri-build.mjs"
   },
   "engines": {
     "node": ">=18"

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -33,6 +33,7 @@ export interface AppState {
   ui: {
     processingOpen: boolean;
     attributeTableOpen: boolean;
+    zoomToSelectedFeature: boolean;
   };
 
   setPointerCoords: (coords: [number, number] | null) => void;
@@ -43,6 +44,7 @@ export interface AppState {
   setAttributeFilter: (filter: string) => void;
   setProcessingOpen: (open: boolean) => void;
   setAttributeTableOpen: (open: boolean) => void;
+  setZoomToSelectedFeature: (enabled: boolean) => void;
 
   newProject: (options?: CreateProjectOptions & { name?: string }) => void;
   loadProject: (project: GeoLibreProject, path?: string | null) => void;
@@ -81,6 +83,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   ui: {
     processingOpen: false,
     attributeTableOpen: false,
+    zoomToSelectedFeature: false,
   },
 
   setPointerCoords: (coords) => set({ pointerCoords: coords }),
@@ -97,6 +100,8 @@ export const useAppStore = create<AppState>((set, get) => ({
     set((s) => ({ ui: { ...s.ui, processingOpen: open } })),
   setAttributeTableOpen: (open) =>
     set((s) => ({ ui: { ...s.ui, attributeTableOpen: open } })),
+  setZoomToSelectedFeature: (enabled) =>
+    set((s) => ({ ui: { ...s.ui, zoomToSelectedFeature: enabled } })),
 
   newProject: (options = {}) => {
     const project = createEmptyProject(options.name, options);
@@ -169,6 +174,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         s.selectedLayerId === id
           ? (s.layers.find((l) => l.id !== id)?.id ?? null)
           : s.selectedLayerId,
+      selectedFeatureId: s.selectedLayerId === id ? null : s.selectedFeatureId,
       isDirty: true,
     })),
 

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -26,6 +26,7 @@ export interface AppState {
   layers: GeoLibreLayer[];
   selectedLayerId: string | null;
   selectedFeatureId: string | null;
+  identifyLayerId: string | null;
   pointerCoords: [number, number] | null;
   metadata: Record<string, unknown>;
   recentProjects: RecentProjectEntry[];
@@ -41,6 +42,7 @@ export interface AppState {
   setBasemapStyleUrl: (url: string) => void;
   selectLayer: (id: string | null) => void;
   selectFeature: (id: string | null) => void;
+  setIdentifyLayer: (id: string | null) => void;
   setAttributeFilter: (filter: string) => void;
   setProcessingOpen: (open: boolean) => void;
   setAttributeTableOpen: (open: boolean) => void;
@@ -76,6 +78,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   layers: [],
   selectedLayerId: null,
   selectedFeatureId: null,
+  identifyLayerId: null,
   pointerCoords: null,
   metadata: {},
   recentProjects: [],
@@ -95,6 +98,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   setBasemapStyleUrl: (url) => set({ basemapStyleUrl: url, isDirty: true }),
   selectLayer: (id) => set({ selectedLayerId: id, selectedFeatureId: null }),
   selectFeature: (id) => set({ selectedFeatureId: id }),
+  setIdentifyLayer: (id) => set({ identifyLayerId: id }),
   setAttributeFilter: (filter) => set({ attributeFilter: filter }),
   setProcessingOpen: (open) =>
     set((s) => ({ ui: { ...s.ui, processingOpen: open } })),
@@ -112,6 +116,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       isDirty: false,
       selectedLayerId: null,
       selectedFeatureId: null,
+      identifyLayerId: null,
       pointerCoords: null,
       attributeFilter: "",
     });
@@ -125,6 +130,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       isDirty: false,
       selectedLayerId: applied.layers[0]?.id ?? null,
       selectedFeatureId: null,
+      identifyLayerId: null,
     });
     if (path) {
       const entry: RecentProjectEntry = {
@@ -175,6 +181,7 @@ export const useAppStore = create<AppState>((set, get) => ({
           ? (s.layers.find((l) => l.id !== id)?.id ?? null)
           : s.selectedLayerId,
       selectedFeatureId: s.selectedLayerId === id ? null : s.selectedFeatureId,
+      identifyLayerId: s.identifyLayerId === id ? null : s.identifyLayerId,
       isDirty: true,
     })),
 

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -1,24 +1,35 @@
 import { useAppStore } from "@geolibre/core";
 import maplibregl from "maplibre-gl";
-import { useEffect, useRef } from "react";
+import { memo, useEffect, useRef } from "react";
 import { createMapController, type MapController } from "./map-controller";
 import "maplibre-gl/dist/maplibre-gl.css";
 import "maplibre-gl-layer-control/style.css";
 import "./layer-control-overrides.css";
 
+const PANEL_RESIZE_START_EVENT = "geolibre:panel-resize-start";
+const PANEL_RESIZE_END_EVENT = "geolibre:panel-resize-end";
+
 export interface MapCanvasProps {
   controllerRef?: React.MutableRefObject<MapController | null>;
 }
 
-export function MapCanvas({ controllerRef }: MapCanvasProps) {
+export const MapCanvas = memo(function MapCanvas({
+  controllerRef,
+}: MapCanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const controller = useRef<MapController | null>(null);
 
   const basemapStyleUrl = useAppStore((s) => s.basemapStyleUrl);
   const mapView = useAppStore((s) => s.mapView);
   const layers = useAppStore((s) => s.layers);
+  const selectedLayerId = useAppStore((s) => s.selectedLayerId);
+  const selectedFeatureId = useAppStore((s) => s.selectedFeatureId);
+  const zoomToSelectedFeature = useAppStore(
+    (s) => s.ui.zoomToSelectedFeature,
+  );
   const setMapView = useAppStore((s) => s.setMapView);
   const setPointerCoords = useAppStore((s) => s.setPointerCoords);
+  const previousSelectedFeatureKey = useRef<string | null>(null);
 
   useEffect(() => {
     if (!containerRef.current || controller.current) return;
@@ -41,11 +52,23 @@ export function MapCanvas({ controllerRef }: MapCanvasProps) {
     map.on("moveend", updateView);
     map.on("load", () => {
       mc.waitAndSyncLayers(useAppStore.getState().layers);
+      const state = useAppStore.getState();
+      mc.highlightFeature(
+        state.layers.find((layer) => layer.id === state.selectedLayerId),
+        state.selectedFeatureId,
+      );
       updateView();
     });
 
     let resizeFrame: number | null = null;
+    let panelResizeActive = false;
+    let resizeAfterPanelResize = false;
     const resizeMap = () => {
+      if (panelResizeActive) {
+        resizeAfterPanelResize = true;
+        return;
+      }
+
       if (resizeFrame !== null) {
         window.cancelAnimationFrame(resizeFrame);
       }
@@ -54,12 +77,31 @@ export function MapCanvas({ controllerRef }: MapCanvasProps) {
         mc.getMap()?.resize();
       });
     };
+    const onPanelResizeStart = () => {
+      panelResizeActive = true;
+      resizeAfterPanelResize = false;
+      if (resizeFrame !== null) {
+        window.cancelAnimationFrame(resizeFrame);
+        resizeFrame = null;
+      }
+    };
+    const onPanelResizeEnd = () => {
+      panelResizeActive = false;
+      if (resizeAfterPanelResize) {
+        resizeAfterPanelResize = false;
+      }
+      resizeMap();
+    };
     const resizeObserver = new ResizeObserver(resizeMap);
     resizeObserver.observe(containerRef.current);
+    window.addEventListener(PANEL_RESIZE_START_EVENT, onPanelResizeStart);
+    window.addEventListener(PANEL_RESIZE_END_EVENT, onPanelResizeEnd);
     resizeMap();
 
     return () => {
       resizeObserver.disconnect();
+      window.removeEventListener(PANEL_RESIZE_START_EVENT, onPanelResizeStart);
+      window.removeEventListener(PANEL_RESIZE_END_EVENT, onPanelResizeEnd);
       if (resizeFrame !== null) {
         window.cancelAnimationFrame(resizeFrame);
       }
@@ -77,6 +119,11 @@ export function MapCanvas({ controllerRef }: MapCanvasProps) {
     prevBasemap.current = basemapStyleUrl;
     map.once("style.load", () => {
       controller.current?.waitAndSyncLayers(useAppStore.getState().layers);
+      const state = useAppStore.getState();
+      controller.current?.highlightFeature(
+        state.layers.find((layer) => layer.id === state.selectedLayerId),
+        state.selectedFeatureId,
+      );
     });
     controller.current?.setStyle(basemapStyleUrl);
   }, [basemapStyleUrl]);
@@ -84,6 +131,22 @@ export function MapCanvas({ controllerRef }: MapCanvasProps) {
   useEffect(() => {
     controller.current?.waitAndSyncLayers(layers);
   }, [layers]);
+
+  useEffect(() => {
+    const layer = layers.find((item) => item.id === selectedLayerId);
+    const nextKey =
+      selectedLayerId && selectedFeatureId
+        ? `${selectedLayerId}:${selectedFeatureId}`
+        : null;
+    const shouldFit = Boolean(
+      zoomToSelectedFeature &&
+      nextKey && nextKey !== previousSelectedFeatureKey.current,
+    );
+    previousSelectedFeatureKey.current = nextKey;
+    controller.current?.highlightFeature(layer, selectedFeatureId, {
+      fit: shouldFit,
+    });
+  }, [layers, selectedLayerId, selectedFeatureId, zoomToSelectedFeature]);
 
   useEffect(() => {
     const map = controller.current?.getMap();
@@ -109,4 +172,4 @@ export function MapCanvas({ controllerRef }: MapCanvasProps) {
       data-testid="map-canvas"
     />
   );
-}
+});

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -1,6 +1,11 @@
-import { useAppStore } from "@geolibre/core";
+import { useAppStore, type GeoLibreLayer } from "@geolibre/core";
 import maplibregl from "maplibre-gl";
 import { memo, useEffect, useRef } from "react";
+import {
+  circleLayerId,
+  fillLayerId,
+  lineLayerId,
+} from "./geojson-loader";
 import { createMapController, type MapController } from "./map-controller";
 import "maplibre-gl/dist/maplibre-gl.css";
 import "maplibre-gl-layer-control/style.css";
@@ -8,9 +13,92 @@ import "./layer-control-overrides.css";
 
 const PANEL_RESIZE_START_EVENT = "geolibre:panel-resize-start";
 const PANEL_RESIZE_END_EVENT = "geolibre:panel-resize-end";
+const MAX_IDENTIFY_PROPERTIES = 24;
 
 export interface MapCanvasProps {
   controllerRef?: React.MutableRefObject<MapController | null>;
+}
+
+function stringifyIdentifyValue(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+function createIdentifyPopupElement(
+  layerName: string,
+  properties: Record<string, unknown>,
+  featureId?: string | number,
+): HTMLElement {
+  const root = document.createElement("div");
+  root.className = "min-w-48 max-w-80 text-xs";
+
+  const title = document.createElement("div");
+  title.className = "mb-2 font-semibold text-foreground";
+  title.textContent = layerName;
+  root.appendChild(title);
+
+  const rows = document.createElement("div");
+  rows.className = "max-h-64 overflow-auto";
+  root.appendChild(rows);
+
+  const appendRow = (key: string, value: unknown) => {
+    const row = document.createElement("div");
+    row.className = "grid grid-cols-[minmax(5rem,0.45fr)_1fr] gap-2 border-t py-1";
+
+    const keyCell = document.createElement("div");
+    keyCell.className = "break-words font-medium text-muted-foreground";
+    keyCell.textContent = key;
+
+    const valueCell = document.createElement("div");
+    valueCell.className = "break-words text-foreground";
+    valueCell.textContent = stringifyIdentifyValue(value);
+
+    row.append(keyCell, valueCell);
+    rows.appendChild(row);
+  };
+
+  if (featureId != null) appendRow("id", featureId);
+
+  const entries = Object.entries(properties).slice(0, MAX_IDENTIFY_PROPERTIES);
+  if (entries.length === 0 && featureId == null) {
+    const empty = document.createElement("div");
+    empty.className = "text-muted-foreground";
+    empty.textContent = "No attributes";
+    rows.appendChild(empty);
+  } else {
+    for (const [key, value] of entries) appendRow(key, value);
+  }
+
+  return root;
+}
+
+function identifyStyleLayerIds(layerId: string): string[] {
+  return [
+    circleLayerId(layerId),
+    lineLayerId(layerId),
+    fillLayerId(layerId),
+    `layer-${layerId}-vector`,
+  ];
+}
+
+function findFeatureId(
+  layer: GeoLibreLayer,
+  feature: maplibregl.MapGeoJSONFeature,
+): string | null {
+  if (feature.id != null) return String(feature.id);
+  if (!layer.geojson) return null;
+
+  const properties = feature.properties ?? {};
+  const propertyKeys = Object.keys(properties);
+  const index = layer.geojson.features.findIndex((candidate) => {
+    const candidateProperties = candidate.properties ?? {};
+    return propertyKeys.every(
+      (key) => candidateProperties[key] === properties[key],
+    );
+  });
+
+  return index >= 0 ? String(layer.geojson.features[index].id ?? index) : null;
 }
 
 export const MapCanvas = memo(function MapCanvas({
@@ -24,12 +112,15 @@ export const MapCanvas = memo(function MapCanvas({
   const layers = useAppStore((s) => s.layers);
   const selectedLayerId = useAppStore((s) => s.selectedLayerId);
   const selectedFeatureId = useAppStore((s) => s.selectedFeatureId);
+  const identifyLayerId = useAppStore((s) => s.identifyLayerId);
   const zoomToSelectedFeature = useAppStore(
     (s) => s.ui.zoomToSelectedFeature,
   );
+  const selectFeature = useAppStore((s) => s.selectFeature);
   const setMapView = useAppStore((s) => s.setMapView);
   const setPointerCoords = useAppStore((s) => s.setPointerCoords);
   const previousSelectedFeatureKey = useRef<string | null>(null);
+  const identifyPopup = useRef<maplibregl.Popup | null>(null);
 
   useEffect(() => {
     if (!containerRef.current || controller.current) return;
@@ -147,6 +238,60 @@ export const MapCanvas = memo(function MapCanvas({
       fit: shouldFit,
     });
   }, [layers, selectedLayerId, selectedFeatureId, zoomToSelectedFeature]);
+
+  useEffect(() => {
+    const map = controller.current?.getMap();
+    const layer = layers.find((item) => item.id === identifyLayerId);
+    if (!map || !layer) {
+      identifyPopup.current?.remove();
+      identifyPopup.current = null;
+      if (map) map.getCanvas().style.cursor = "";
+      return;
+    }
+
+    map.getCanvas().style.cursor = "crosshair";
+
+    const handleIdentifyClick = (event: maplibregl.MapMouseEvent) => {
+      const queryLayerIds = identifyStyleLayerIds(layer.id).filter((id) =>
+        map.getLayer(id),
+      );
+      if (queryLayerIds.length === 0) return;
+
+      const [feature] = map.queryRenderedFeatures(event.point, {
+        layers: queryLayerIds,
+      });
+      if (!feature) return;
+
+      const featureId = findFeatureId(layer, feature);
+      if (featureId != null) selectFeature(featureId);
+
+      identifyPopup.current?.remove();
+      identifyPopup.current = new maplibregl.Popup({
+        className: "geolibre-identify-popup",
+        closeButton: true,
+        closeOnClick: false,
+        maxWidth: "360px",
+      })
+        .setLngLat(event.lngLat)
+        .setDOMContent(
+          createIdentifyPopupElement(
+            layer.name,
+            feature.properties ?? {},
+            featureId ?? feature.id,
+          ),
+        )
+        .addTo(map);
+    };
+
+    map.on("click", handleIdentifyClick);
+
+    return () => {
+      map.off("click", handleIdentifyClick);
+      identifyPopup.current?.remove();
+      identifyPopup.current = null;
+      map.getCanvas().style.cursor = "";
+    };
+  }, [identifyLayerId, layers, selectFeature]);
 
   useEffect(() => {
     const map = controller.current?.getMap();

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -252,18 +252,30 @@ export const MapCanvas = memo(function MapCanvas({
     map.getCanvas().style.cursor = "crosshair";
 
     const handleIdentifyClick = (event: maplibregl.MapMouseEvent) => {
+      const clearIdentifyResult = () => {
+        selectFeature(null);
+        identifyPopup.current?.remove();
+        identifyPopup.current = null;
+      };
+
       const queryLayerIds = identifyStyleLayerIds(layer.id).filter((id) =>
         map.getLayer(id),
       );
-      if (queryLayerIds.length === 0) return;
+      if (queryLayerIds.length === 0) {
+        clearIdentifyResult();
+        return;
+      }
 
       const [feature] = map.queryRenderedFeatures(event.point, {
         layers: queryLayerIds,
       });
-      if (!feature) return;
+      if (!feature) {
+        clearIdentifyResult();
+        return;
+      }
 
       const featureId = findFeatureId(layer, feature);
-      if (featureId != null) selectFeature(featureId);
+      selectFeature(featureId);
 
       identifyPopup.current?.remove();
       identifyPopup.current = new maplibregl.Popup({

--- a/packages/map/src/geojson-loader.ts
+++ b/packages/map/src/geojson-loader.ts
@@ -68,3 +68,19 @@ export function lineLayerId(layerId: string): string {
 export function circleLayerId(layerId: string): string {
   return `layer-${layerId}-circle`;
 }
+
+export function highlightSourceId(): string {
+  return "geolibre-highlight-source";
+}
+
+export function highlightFillLayerId(): string {
+  return "geolibre-highlight-fill";
+}
+
+export function highlightLineLayerId(): string {
+  return "geolibre-highlight-line";
+}
+
+export function highlightCircleLayerId(): string {
+  return "geolibre-highlight-circle";
+}

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -1,11 +1,17 @@
 import { DEFAULT_BASEMAP } from "@geolibre/core";
 import type { GeoLibreLayer, MapViewState } from "@geolibre/core";
+import bbox from "@turf/bbox";
+import type { Feature, FeatureCollection, Geometry } from "geojson";
 import maplibregl from "maplibre-gl";
 import { LayerControl } from "maplibre-gl-layer-control";
 import {
   circleLayerId,
   fillLayerId,
   getLayerBounds,
+  highlightCircleLayerId,
+  highlightFillLayerId,
+  highlightLineLayerId,
+  highlightSourceId,
   lineLayerId,
 } from "./geojson-loader";
 import { removeLayerFromMap, syncLayer } from "./layer-sync";
@@ -29,6 +35,10 @@ const TERRAIN_SOURCE: maplibregl.RasterDEMSourceSpecification = {
 const TERRAIN_OPTIONS: maplibregl.TerrainSpecification = {
   source: TERRAIN_SOURCE_ID,
   exaggeration: 1,
+};
+const EMPTY_HIGHLIGHT: FeatureCollection = {
+  type: "FeatureCollection",
+  features: [],
 };
 
 interface NamedLayerState {
@@ -339,6 +349,39 @@ export class MapController {
     );
   }
 
+  highlightFeature(
+    layer: GeoLibreLayer | undefined,
+    featureId: string | null,
+    options: { fit?: boolean } = {},
+  ): void {
+    if (!this.map || !this.map.isStyleLoaded()) return;
+
+    if (!layer?.geojson || !featureId) {
+      this.syncHighlight(EMPTY_HIGHLIGHT);
+      return;
+    }
+
+    const feature = this.findFeature(layer, featureId);
+    if (!feature?.geometry) {
+      this.syncHighlight(EMPTY_HIGHLIGHT);
+      return;
+    }
+
+    const featureCollection: FeatureCollection = {
+      type: "FeatureCollection",
+      features: [feature as Feature<Geometry>],
+    };
+    this.syncHighlight(featureCollection);
+
+    if (options.fit) {
+      this.fitFeature(featureCollection);
+    }
+  }
+
+  clearFeatureHighlight(): void {
+    this.syncHighlight(EMPTY_HIGHLIGHT);
+  }
+
   private enforceDefaultProjection(): void {
     if (!this.map) return;
     try {
@@ -346,6 +389,115 @@ export class MapController {
       this.map.setProjection(DEFAULT_PROJECTION);
     } catch {
       this.map.once("idle", () => this.enforceDefaultProjection());
+    }
+  }
+
+  private findFeature(
+    layer: GeoLibreLayer,
+    featureId: string,
+  ): Feature | undefined {
+    return layer.geojson?.features.find(
+      (feature, index) => String(feature.id ?? index) === featureId,
+    );
+  }
+
+  private fitFeature(featureCollection: FeatureCollection): void {
+    if (!this.map || featureCollection.features.length === 0) return;
+    const box = bbox(featureCollection) as [number, number, number, number];
+    if (box.some((value) => !Number.isFinite(value))) return;
+
+    if (box[0] === box[2] && box[1] === box[3]) {
+      this.map.flyTo({
+        center: [box[0], box[1]],
+        zoom: Math.max(this.map.getZoom(), 14),
+        duration: 800,
+      });
+      return;
+    }
+
+    this.fitBounds(box);
+  }
+
+  private syncHighlight(featureCollection: FeatureCollection): void {
+    if (!this.map || !this.map.isStyleLoaded()) return;
+
+    const source = this.map.getSource(highlightSourceId());
+    if (source) {
+      (source as maplibregl.GeoJSONSource).setData(featureCollection);
+    } else {
+      this.map.addSource(highlightSourceId(), {
+        type: "geojson",
+        data: featureCollection,
+      });
+    }
+
+    this.ensureHighlightLayer({
+      id: highlightFillLayerId(),
+      type: "fill",
+      source: highlightSourceId(),
+      filter: [
+        "match",
+        ["geometry-type"],
+        ["Polygon", "MultiPolygon"],
+        true,
+        false,
+      ],
+      paint: {
+        "fill-color": "#facc15",
+        "fill-opacity": 0.32,
+        "fill-outline-color": "#111827",
+      },
+    });
+
+    this.ensureHighlightLayer({
+      id: highlightLineLayerId(),
+      type: "line",
+      source: highlightSourceId(),
+      filter: [
+        "match",
+        ["geometry-type"],
+        ["LineString", "MultiLineString", "Polygon", "MultiPolygon"],
+        true,
+        false,
+      ],
+      paint: {
+        "line-color": "#facc15",
+        "line-width": 5,
+        "line-opacity": 0.9,
+      },
+    });
+
+    this.ensureHighlightLayer({
+      id: highlightCircleLayerId(),
+      type: "circle",
+      source: highlightSourceId(),
+      filter: [
+        "match",
+        ["geometry-type"],
+        ["Point", "MultiPoint"],
+        true,
+        false,
+      ],
+      paint: {
+        "circle-color": "#facc15",
+        "circle-radius": 9,
+        "circle-opacity": 0.95,
+        "circle-stroke-color": "#111827",
+        "circle-stroke-width": 3,
+      },
+    });
+  }
+
+  private ensureHighlightLayer(spec: maplibregl.AddLayerObject): void {
+    if (!this.map) return;
+    if (!this.map.getLayer(spec.id)) {
+      this.map.addLayer(spec);
+      return;
+    }
+    try {
+      this.map.moveLayer(spec.id);
+    } catch {
+      // Style reloads can remove layers while selection is syncing.
     }
   }
 

--- a/packages/ui/src/components/scroll-area.tsx
+++ b/packages/ui/src/components/scroll-area.tsx
@@ -15,6 +15,7 @@ export const ScrollArea = React.forwardRef<
       {children}
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />
+    <ScrollBar orientation="horizontal" />
     <ScrollAreaPrimitive.Corner />
   </ScrollAreaPrimitive.Root>
 ));
@@ -28,16 +29,16 @@ const ScrollBar = React.forwardRef<
     ref={ref}
     orientation={orientation}
     className={cn(
-      "flex touch-none select-none transition-colors",
+      "group z-30 flex touch-none select-none rounded-full bg-muted/70 transition-colors hover:bg-muted",
       orientation === "vertical" &&
-        "h-full w-2.5 border-l border-l-transparent p-[1px]",
+        "h-full w-3.5 border-l border-border/60 p-0.5",
       orientation === "horizontal" &&
-        "h-2.5 flex-col border-t border-t-transparent p-[1px]",
+        "h-3.5 flex-col border-t border-border/60 p-0.5",
       className,
     )}
     {...props}
   >
-    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-muted-foreground/45 transition-colors hover:bg-muted-foreground/70 active:bg-primary group-hover:bg-muted-foreground/60" />
   </ScrollAreaPrimitive.ScrollAreaScrollbar>
 ));
 ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName;

--- a/scripts/tauri-build.mjs
+++ b/scripts/tauri-build.mjs
@@ -1,0 +1,22 @@
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const userArgs = process.argv.slice(2);
+const buildArgs =
+  userArgs.length === 0 && process.platform === "linux"
+    ? ["--bundles", "deb,rpm"]
+    : userArgs;
+
+const result = spawnSync(
+  "npm",
+  ["run", "tauri", "-w", "geolibre-desktop", "--", "build", ...buildArgs],
+  {
+    cwd: repoRoot,
+    shell: process.platform === "win32",
+    stdio: "inherit",
+  },
+);
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary
- Extend the Add Vector Layer dialog and add drag-and-drop so users can load GeoParquet, GeoPackage, and Shapefile data alongside GeoJSON.
- Convert formats MapLibre cannot render directly into GeoJSON with DuckDB-WASM Spatial, and parse zipped Shapefiles in the browser with shpjs.
- Update the Tauri filesystem capabilities for binary file reads and refresh the README and docs to describe the supported vector formats.

## Test plan
- [ ] `pre-commit run --all-files` passes (includes the production build/typecheck)
- [ ] In the browser, import a GeoJSON, GeoParquet, GeoPackage, and zipped Shapefile via Add Vector Layer and confirm each renders and the map fits
- [ ] Drag those same files onto the app window and confirm layers are added with a status toast
- [ ] In the desktop (Tauri) build, choose a loose .shp with its sidecar files and confirm it loads via DuckDB Spatial