### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # GeoLibre Desktop
 
-Lightweight, cloud-native desktop GIS prototype built with **Tauri v2**, **React**, **TypeScript**, and **MapLibre GL JS**.
+Lightweight, cloud-native desktop GIS prototype built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS**, and **DuckDB-WASM Spatial**.
 
-## Features (v0.1 MVP)
+## Features (v0.4.0)
 
 - MapLibre map with OpenFreeMap Liberty basemap
 - Load local GeoJSON, GeoParquet, GeoPackage, and Shapefile layers
@@ -10,9 +10,9 @@ Lightweight, cloud-native desktop GIS prototype built with **Tauri v2**, **React
 - Live style panel (fill, stroke, opacity, circle radius)
 - Attribute table for imported vector layers
 - Save/open `.geolibre.json` projects
-- Processing toolbox (bounds, count + placeholders)
-- Plugin system (basemap + sample GeoJSON plugins)
-- Optional Python FastAPI sidecar (design only)
+- Processing toolbox with local bounds and feature count algorithms
+- Plugin system with basemap, layer control, swipe, street view, lidar, GeoAgent, and GeoEditor integrations
+- Optional Python FastAPI sidecar for heavier processing workflows
 
 ## Prerequisites
 

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolibre-desktop",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/geolibre-desktop/src-tauri/Cargo.lock
+++ b/apps/geolibre-desktop/src-tauri/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-desktop"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/apps/geolibre-desktop/src-tauri/Cargo.toml
+++ b/apps/geolibre-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-desktop"
-version = "0.3.0"
+version = "0.4.0"
 description = "GeoLibre Desktop — lightweight cloud-native desktop GIS"
 authors = ["GeoLibre Contributors"]
 edition = "2021"

--- a/apps/geolibre-desktop/src-tauri/tauri.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "GeoLibre Desktop",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "identifier": "org.geolibre.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/backend/geolibre_server/pyproject.toml
+++ b/backend/geolibre_server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolibre-server"
-version = "0.3.0"
+version = "0.4.0"
 description = "Optional Python processing sidecar for GeoLibre Desktop"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,9 +9,9 @@ hide:
     <h1>MapLibre-powered GIS for local projects and modern geospatial workflows.</h1>
     <p class="hero__lead">
       GeoLibre is a lightweight desktop GIS prototype built with Tauri, React,
-      TypeScript, and MapLibre GL JS. It focuses on fast local GeoJSON work,
-      project files, styling, plugins, and a practical path toward cloud-native
-      formats.
+      TypeScript, MapLibre GL JS, and DuckDB-WASM Spatial. It focuses on fast
+      local vector data work, project files, styling, plugins, and a practical
+      path toward cloud-native geospatial workflows.
     </p>
     <div class="hero__actions">
       <a class="md-button md-button--primary" href="/demo/">Open live demo</a>
@@ -35,9 +35,9 @@ Use an OpenFreeMap basemap, pan and zoom smoothly, and toggle built-in map contr
 </div>
 
 <div class="feature-card" markdown>
-### Local GeoJSON projects
+### Local vector projects
 
-Load GeoJSON, inspect attributes, style layers, reorder visibility, and save or reopen `.geolibre.json` projects from the desktop app.
+Load GeoJSON, GeoParquet, GeoPackage, and Shapefile data, inspect attributes, style layers, reorder visibility, and save or reopen `.geolibre.json` projects from the desktop app.
 </div>
 
 <div class="feature-card" markdown>
@@ -56,11 +56,11 @@ The processing toolbox includes client-side algorithms now, with a roadmap towar
 
 ## Try it in the browser
 
-The live demo is the browser-capable version of the GeoLibre desktop UI. It is useful for exploring the map, loading browser-selected GeoJSON files, styling layers, and testing plugins. Desktop-only file dialogs and filesystem save/open operations still require the installed Tauri app.
+The live demo is the browser-capable version of the GeoLibre desktop UI. It is useful for exploring the map, loading browser-selected GeoJSON, GeoParquet, GeoPackage, and zipped Shapefile data, styling layers, and testing plugins. Desktop-only file dialogs and filesystem save/open operations still require the installed Tauri app.
 
 [Open the live demo](/demo/){ .md-button .md-button--primary }
 [Read the architecture](architecture.md){ .md-button }
 
 ## Project status
 
-GeoLibre is an active prototype. The current implementation includes the map workspace, project format, plugin API, and core UI patterns. See the [roadmap](roadmap.md) for planned work on cloud-native formats, DuckDB Spatial, the Python processing sidecar, and external plugin loading.
+GeoLibre is an active prototype. Version 0.4.0 includes the map workspace, project format, plugin API, browser vector import, DuckDB-WASM Spatial loading, and core UI patterns. See the [roadmap](roadmap.md) for planned work on PMTiles, COGs, SQL workflows, the Python processing sidecar, and external plugin loading.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolibre",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolibre",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -16,7 +16,7 @@
       }
     },
     "apps/geolibre-desktop": {
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@carbonplan/zarr-layer": "^0.3.1",
         "@deck.gl/core": "^9.3.2",
@@ -12861,7 +12861,7 @@
     },
     "packages/core": {
       "name": "@geolibre/core",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "uuid": "^11.1.0",
         "zustand": "^5.0.3"
@@ -12873,7 +12873,7 @@
     },
     "packages/map": {
       "name": "@geolibre/map",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@geolibre/core": "*",
         "@turf/bbox": "^7.2.0",
@@ -12896,7 +12896,7 @@
     },
     "packages/plugins": {
       "name": "@geolibre/plugins",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@carbonplan/zarr-layer": "^0.3.1",
         "@deck.gl/core": "^9.3.2",
@@ -13073,7 +13073,7 @@
     },
     "packages/processing": {
       "name": "@geolibre/processing",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@geolibre/core": "*",
         "@turf/bbox": "^7.2.0"
@@ -13085,7 +13085,7 @@
     },
     "packages/ui": {
       "name": "@geolibre/ui",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-dropdown-menu": "^2.1.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geolibre",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "GeoLibre Desktop — lightweight cloud-native desktop GIS",
   "workspaces": [
     "apps/*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/core",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/map",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/plugins",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/processing/package.json
+++ b/packages/processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/processing",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/ui",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",


### PR DESCRIPTION
## Summary
- Bump all workspace package versions (root, desktop app, Tauri crate, backend sidecar, and core/map/plugins/processing/ui packages) from 0.3.0 to 0.4.0
- Refresh the README and docs landing page to describe DuckDB-WASM Spatial loading, multi-format vector import (GeoJSON, GeoParquet, GeoPackage, Shapefile), and the expanded plugin set

## Test plan
- [x] pre-commit run --all-files passes (includes npm build)
- [ ] Verify the desktop app reports version 0.4.0