### PR TITLE
chore: increase Node.js memory limit in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,7 @@ jobs:
         uses: tauri-apps/tauri-action@v0.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_OPTIONS: --max-old-space-size=4096
         with:
           projectPath: apps/geolibre-desktop
           releaseId: ${{ github.event.release.id }}


### PR DESCRIPTION
Added NODE_OPTIONS to set the maximum old space size to 4096 MB in the GitHub Actions release workflow, improving memory management during the build process.