### PR TITLE
Fix Bun trusted dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ cd GeoLibre
 npm install
 ```
 
+Bun users can run `bun install`. The root `trustedDependencies` list allows the known install scripts for `core-js`, `@google/genai`, and `protobufjs`.
+
 ## Run (web dev — map in browser)
 
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,6 +16,8 @@ cd GeoLibre
 npm install
 ```
 
+Bun users can run `bun install`. The root `trustedDependencies` list allows the known install scripts for `core-js`, `@google/genai`, and `protobufjs`.
+
 ## Run the browser UI
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
     "apps/*",
     "packages/*"
   ],
+  "trustedDependencies": [
+    "@google/genai",
+    "core-js",
+    "protobufjs"
+  ],
   "scripts": {
     "dev": "npm run dev -w geolibre-desktop",
     "build": "npm run build -w geolibre-desktop",


### PR DESCRIPTION
## Summary
- Add Bun `trustedDependencies` for `core-js`, `@google/genai`, and `protobufjs`
- Document Bun install behavior in the README and getting started guide

Closes #34

## Testing
- npm run build
- pre-commit run --all-files