### PR TITLE
feat: add blank basemap option for new maps

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
@@ -1,4 +1,5 @@
 import {
+  BLANK_BASEMAP,
   createDefaultMapView,
   OPENFREEMAP_BASEMAPS,
   useAppStore,
@@ -22,6 +23,7 @@ import { useMemo, useState } from "react";
 
 const DEFAULT_BASEMAP_ID = "liberty";
 const CUSTOM_BASEMAP_ID = "custom";
+const BLANK_BASEMAP_ID = "blank";
 const DEFAULT_PROJECT_NAME = "Untitled Project";
 
 const THREE_D_MAP_VIEW: MapViewState = {
@@ -32,7 +34,10 @@ const THREE_D_MAP_VIEW: MapViewState = {
 };
 
 type PresetBasemapId = (typeof OPENFREEMAP_BASEMAPS)[number]["id"];
-type BasemapChoice = PresetBasemapId | typeof CUSTOM_BASEMAP_ID;
+type BasemapChoice =
+  | PresetBasemapId
+  | typeof CUSTOM_BASEMAP_ID
+  | typeof BLANK_BASEMAP_ID;
 
 interface NewProjectDialogProps {
   onSaveCurrentProject: () => Promise<boolean>;
@@ -53,6 +58,7 @@ export function NewProjectDialog({
 
   const customStyleUrl = customUrl.trim();
   const isCustomSelected = selectedBasemapId === CUSTOM_BASEMAP_ID;
+  const isBlankSelected = selectedBasemapId === BLANK_BASEMAP_ID;
   const selectedPreset = OPENFREEMAP_BASEMAPS.find(
     (basemap) => basemap.id === selectedBasemapId,
   );
@@ -67,7 +73,7 @@ export function NewProjectDialog({
   }, [customStyleUrl]);
   const canCreate = isCustomSelected
     ? isCustomUrlValid
-    : Boolean(selectedPreset);
+    : isBlankSelected || Boolean(selectedPreset);
 
   const resetForm = () => {
     setSelectedBasemapId(DEFAULT_BASEMAP_ID);
@@ -87,8 +93,10 @@ export function NewProjectDialog({
 
     const basemapStyleUrl = isCustomSelected
       ? customStyleUrl
+      : isBlankSelected
+        ? BLANK_BASEMAP
       : selectedPreset?.styleUrl;
-    if (!basemapStyleUrl) return;
+    if (basemapStyleUrl == null) return;
 
     newProject({
       name: projectName.trim() || DEFAULT_PROJECT_NAME,
@@ -175,7 +183,8 @@ export function NewProjectDialog({
             <DialogHeader>
               <DialogTitle>New map</DialogTitle>
               <DialogDescription>
-                Choose an OpenFreeMap basemap or provide a MapLibre style URL.
+                Choose a blank background, an OpenFreeMap basemap, or a
+                MapLibre style URL.
               </DialogDescription>
             </DialogHeader>
             <form className="space-y-5" onSubmit={handleCreate}>
@@ -209,6 +218,20 @@ export function NewProjectDialog({
                       {basemap.name}
                     </button>
                   ))}
+                  <button
+                    type="button"
+                    aria-pressed={isBlankSelected}
+                    className={cn(
+                      "h-10 rounded-md border px-3 text-sm font-medium transition-colors",
+                      "hover:bg-accent hover:text-accent-foreground",
+                      isBlankSelected
+                        ? "border-primary bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground"
+                        : "border-input bg-background",
+                    )}
+                    onClick={() => setSelectedBasemapId(BLANK_BASEMAP_ID)}
+                  >
+                    Blank
+                  </button>
                 </div>
               </div>
 

--- a/docs/project-format.md
+++ b/docs/project-format.md
@@ -9,7 +9,7 @@ Projects are saved as **`.geolibre.json`** files.
 | `version` | string | Format version (`0.1.0`) |
 | `name` | string | Project display name |
 | `mapView` | object | `center`, `zoom`, `bearing`, `pitch`, optional `bbox` |
-| `basemapStyleUrl` | string | MapLibre style JSON URL |
+| `basemapStyleUrl` | string | MapLibre style JSON URL, or an empty string for a blank background |
 | `layers` | array | Layer definitions (see below) |
 | `styles` | object | Map of layer id → `LayerStyle` |
 | `metadata` | object | Free-form project metadata |

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2,6 +2,11 @@ import type { FeatureCollection } from "geojson";
 
 export const OPENFREEMAP_BASEMAPS = [
   {
+    id: "liberty",
+    name: "Liberty",
+    styleUrl: "https://tiles.openfreemap.org/styles/liberty",
+  },
+  {
     id: "positron",
     name: "Positron",
     styleUrl: "https://tiles.openfreemap.org/styles/positron",
@@ -10,11 +15,6 @@ export const OPENFREEMAP_BASEMAPS = [
     id: "bright",
     name: "Bright",
     styleUrl: "https://tiles.openfreemap.org/styles/bright",
-  },
-  {
-    id: "liberty",
-    name: "Liberty",
-    styleUrl: "https://tiles.openfreemap.org/styles/liberty",
   },
   {
     id: "dark",
@@ -35,6 +35,8 @@ export const OPENFREEMAP_BASEMAPS = [
 
 export const DEFAULT_BASEMAP =
   "https://tiles.openfreemap.org/styles/liberty";
+
+export const BLANK_BASEMAP = "";
 
 export const PROJECT_VERSION = "0.1.0";
 

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -22,6 +22,12 @@ const DEFAULT_PROJECTION: maplibregl.ProjectionSpecification = {
 const DEFAULT_MAX_PITCH = 85;
 const BLANK_BACKGROUND_LAYER_ID = "geolibre-blank-background";
 const BLANK_BACKGROUND_COLOR = "#ffffff";
+const LAYER_CONTROL_EXCLUDED_LAYERS = [
+  BLANK_BACKGROUND_LAYER_ID,
+  highlightFillLayerId(),
+  highlightLineLayerId(),
+  highlightCircleLayerId(),
+];
 const TERRAIN_SOURCE_ID = "geolibre-terrain-dem";
 const TERRAIN_SOURCE: maplibregl.RasterDEMSourceSpecification = {
   type: "raster-dem",
@@ -597,11 +603,11 @@ export class MapController {
       this.getNamedStyleLayers(layer),
     );
     if (namedStyleLayers.length === 0) {
-      return { excludeLayers: [BLANK_BACKGROUND_LAYER_ID] };
+      return { excludeLayers: LAYER_CONTROL_EXCLUDED_LAYERS };
     }
 
     return {
-      excludeLayers: [BLANK_BACKGROUND_LAYER_ID],
+      excludeLayers: LAYER_CONTROL_EXCLUDED_LAYERS,
       layers: namedStyleLayers.map(({ id }) => id),
       layerStates: Object.fromEntries(
         namedStyleLayers.map(({ id, name, layer }) => [

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_BASEMAP } from "@geolibre/core";
+import { BLANK_BASEMAP, DEFAULT_BASEMAP } from "@geolibre/core";
 import type { GeoLibreLayer, MapViewState } from "@geolibre/core";
 import bbox from "@turf/bbox";
 import type { Feature, FeatureCollection, Geometry } from "geojson";
@@ -20,6 +20,8 @@ const DEFAULT_PROJECTION: maplibregl.ProjectionSpecification = {
   type: "globe",
 };
 const DEFAULT_MAX_PITCH = 85;
+const BLANK_BACKGROUND_LAYER_ID = "geolibre-blank-background";
+const BLANK_BACKGROUND_COLOR = "#ffffff";
 const TERRAIN_SOURCE_ID = "geolibre-terrain-dem";
 const TERRAIN_SOURCE: maplibregl.RasterDEMSourceSpecification = {
   type: "raster-dem",
@@ -41,6 +43,29 @@ const EMPTY_HIGHLIGHT: FeatureCollection = {
   features: [],
 };
 
+function createBlankMapStyle(): maplibregl.StyleSpecification {
+  return {
+    version: 8,
+    sources: {},
+    layers: [
+      {
+        id: BLANK_BACKGROUND_LAYER_ID,
+        type: "background",
+        paint: {
+          "background-color": BLANK_BACKGROUND_COLOR,
+        },
+      },
+    ],
+  };
+}
+
+function resolveMapStyle(
+  styleUrl: string | undefined,
+): string | maplibregl.StyleSpecification {
+  if (styleUrl === BLANK_BASEMAP) return createBlankMapStyle();
+  return styleUrl ?? DEFAULT_BASEMAP;
+}
+
 interface NamedLayerState {
   visible: boolean;
   opacity: number;
@@ -50,6 +75,7 @@ interface NamedLayerState {
 interface LayerControlConfig {
   layers?: string[];
   layerStates?: Record<string, NamedLayerState>;
+  excludeLayers?: string[];
 }
 
 interface GeoLibreLayerLabelWindow extends Window {
@@ -130,7 +156,7 @@ export class MapController {
     this.basemapStyleUrl = options.styleUrl ?? DEFAULT_BASEMAP;
     this.map = new maplibregl.Map({
       container,
-      style: this.basemapStyleUrl,
+      style: resolveMapStyle(this.basemapStyleUrl),
       center: view?.center ?? [-100, 40],
       zoom: view?.zoom ?? 2,
       bearing: view?.bearing ?? 0,
@@ -249,7 +275,7 @@ export class MapController {
     if (!this.map) return;
     this.basemapStyleUrl = url;
     this.removeLayerControl();
-    this.map.setStyle(url);
+    this.map.setStyle(resolveMapStyle(url));
   }
 
   applyView(view: MapViewState): void {
@@ -570,9 +596,12 @@ export class MapController {
     const namedStyleLayers = layers.flatMap((layer) =>
       this.getNamedStyleLayers(layer),
     );
-    if (namedStyleLayers.length === 0) return {};
+    if (namedStyleLayers.length === 0) {
+      return { excludeLayers: [BLANK_BACKGROUND_LAYER_ID] };
+    }
 
     return {
+      excludeLayers: [BLANK_BACKGROUND_LAYER_ID],
       layers: namedStyleLayers.map(({ id }) => id),
       layerStates: Object.fromEntries(
         namedStyleLayers.map(({ id, name, layer }) => [


### PR DESCRIPTION
## Summary
- Add a "Blank" basemap choice in the New Map dialog so a project can start with a plain background instead of an OpenFreeMap basemap or a custom style URL.
- Render the blank background via a generated MapLibre style with a single background layer, and exclude it from the layer control so it does not appear as a toggleable layer.
- Document that `basemapStyleUrl` may be an empty string to represent a blank background.

## Test plan
- [ ] Open the New Map dialog, select "Blank", and create a project; verify the map shows a plain white background.
- [ ] Confirm the blank background does not appear in the layer control.
- [ ] Verify existing OpenFreeMap and custom style URL options still work and that switching basemaps behaves correctly.