### PR TITLE
feat: broaden local vector format support via DuckDB Spatial

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Lightweight, cloud-native desktop GIS prototype built with **Tauri v2**, **React
 ## Features (v0.4.0)
 
 - MapLibre map with OpenFreeMap Liberty basemap
-- Load local GeoJSON, GeoParquet, GeoPackage, and Shapefile layers
+- Load local vector layers supported by DuckDB-WASM Spatial, including common formats such as GeoJSON, GeoParquet, GeoPackage, Shapefile, FlatGeobuf, KML, and GML
 - Layer panel (visibility, opacity, reorder, remove)
 - Live style panel (fill, stroke, opacity, circle radius)
 - Attribute table for imported vector layers
@@ -36,7 +36,7 @@ Bun users can run `bun install`. The root `trustedDependencies` list allows the 
 npm run dev
 ```
 
-Open http://localhost:5173. The map and browser vector import work for GeoJSON, GeoParquet, GeoPackage, and zipped Shapefiles. You can choose files from Add Vector Layer or drag them onto the app. Desktop filesystem dialogs require Tauri.
+Open http://localhost:5173. The map and browser vector import support local vector files that DuckDB-WASM Spatial can read, including common formats such as GeoJSON, GeoParquet, GeoPackage, Shapefile, FlatGeobuf, KML, and GML, with direct handling for GeoJSON and zipped Shapefiles. You can choose files from Add Vector Layer or drag them onto the app. Desktop filesystem dialogs require Tauri.
 
 ## Environment variables
 

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -205,7 +205,7 @@ export function AddDataDialog({
       return "Add a WMS GetMap service as a tiled raster layer.";
     }
     if (kind === "vector") {
-      return "Add GeoJSON, GeoParquet, GeoPackage, Shapefile, or a MapLibre vector tile source.";
+      return "Add local vector files supported by DuckDB Spatial, GeoJSON URLs, or MapLibre vector tile sources.";
     }
     if (kind === "raster") {
       return "Add raster tiles now, or register raster files and COG URLs for project tracking.";

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -68,6 +68,24 @@ const GEOLIBRE_PROJECT_FILE_TYPES: BrowserFilePickerType[] = [
 
 const SHAPEFILE_SIDECAR_EXTENSIONS = ["dbf", "shx", "prj", "cpg"];
 
+// Auxiliary files that accompany Shapefiles (spatial indexes, metadata, etc.)
+// but are never standalone vector layers. Skipping them keeps a single such
+// file from aborting an otherwise valid drag-and-drop import.
+const NON_VECTOR_SIDECAR_EXTENSIONS = [
+  ...SHAPEFILE_SIDECAR_EXTENSIONS,
+  "sbn",
+  "sbx",
+  "qix",
+  "qpj",
+  "aih",
+  "ain",
+  "atx",
+  "fbn",
+  "fbx",
+  "ixs",
+  "mxs",
+];
+
 function isAbortError(error: unknown): boolean {
   return error instanceof DOMException && error.name === "AbortError";
 }
@@ -82,8 +100,15 @@ function pathWithoutExtension(path: string): string {
   return path.replace(/\.[^.\\/]+$/, "");
 }
 
+function isGeoLibreProjectFile(path: string): boolean {
+  const name = browserSafeFileName(path).toLowerCase();
+  return name.endsWith(".geolibre") || name.endsWith(".geolibre.json");
+}
+
 function isVectorFileName(path: string): boolean {
-  return !SHAPEFILE_SIDECAR_EXTENSIONS.includes(fileExtension(path));
+  if (isGeoLibreProjectFile(path)) return false;
+  if (browserSafeFileName(path).toLowerCase().endsWith(".shp.xml")) return false;
+  return !NON_VECTOR_SIDECAR_EXTENSIONS.includes(fileExtension(path));
 }
 
 function assertFeatureCollection(value: unknown): FeatureCollection {

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -66,39 +66,7 @@ const GEOLIBRE_PROJECT_FILE_TYPES: BrowserFilePickerType[] = [
   },
 ];
 
-const VECTOR_FILE_ACCEPT =
-  ".geojson,.json,.zip,.shp,.gpkg,.parquet,.geoparquet";
-
 const SHAPEFILE_SIDECAR_EXTENSIONS = ["dbf", "shx", "prj", "cpg"];
-
-const DROPPED_VECTOR_FILE_EXTENSIONS = new Set([
-  "geojson",
-  "json",
-  "zip",
-  "shp",
-  "shx",
-  "dbf",
-  "prj",
-  "cpg",
-  "gpkg",
-  "parquet",
-  "geoparquet",
-]);
-
-const VECTOR_FILE_FILTERS: FileDialogFilter[] = [
-  {
-    name: "Vector data",
-    extensions: [
-      "geojson",
-      "json",
-      "zip",
-      "shp",
-      "gpkg",
-      "parquet",
-      "geoparquet",
-    ],
-  },
-];
 
 function isAbortError(error: unknown): boolean {
   return error instanceof DOMException && error.name === "AbortError";
@@ -115,7 +83,7 @@ function pathWithoutExtension(path: string): string {
 }
 
 function isVectorFileName(path: string): boolean {
-  return DROPPED_VECTOR_FILE_EXTENSIONS.has(fileExtension(path));
+  return !SHAPEFILE_SIDECAR_EXTENSIONS.includes(fileExtension(path));
 }
 
 function assertFeatureCollection(value: unknown): FeatureCollection {
@@ -180,17 +148,26 @@ async function loadBrowserVectorFile(
 }> {
   const extension = fileExtension(file.name);
   if (extension === "geojson" || extension === "json") {
-    return {
-      data: await parseGeoJsonText(await file.text()),
-      path: file.name,
-    };
+    try {
+      return {
+        data: await parseGeoJsonText(await file.text()),
+        path: file.name,
+      };
+    } catch {
+      // Some GDAL-backed vector formats use .json but are not GeoJSON
+      // FeatureCollections. Let DuckDB Spatial try them before failing.
+    }
   }
 
   if (extension === "zip") {
-    return {
-      data: await parseShapefileZip(await file.arrayBuffer()),
-      path: file.name,
-    };
+    try {
+      return {
+        data: await parseShapefileZip(await file.arrayBuffer()),
+        path: file.name,
+      };
+    } catch {
+      // DuckDB Spatial may be able to read zipped vector data that shpjs cannot.
+    }
   }
 
   return {
@@ -211,7 +188,6 @@ async function openVectorFileBrowser(): Promise<{
   return new Promise((resolve, reject) => {
     const input = document.createElement("input");
     input.type = "file";
-    input.accept = VECTOR_FILE_ACCEPT;
     input.onchange = async () => {
       try {
         const file = input.files?.[0];
@@ -235,7 +211,6 @@ async function openVectorFileTauri(): Promise<{
 } | null> {
   const selected = await open({
     multiple: false,
-    filters: VECTOR_FILE_FILTERS,
   });
   if (!selected || typeof selected !== "string") return null;
   return loadTauriVectorFile(selected);
@@ -247,21 +222,31 @@ async function loadTauriVectorFile(path: string): Promise<{
 }> {
   const extension = fileExtension(path);
   if (extension === "geojson" || extension === "json") {
-    return {
-      data: await parseGeoJsonText(await readTextFile(path)),
-      path,
-    };
+    try {
+      return {
+        data: await parseGeoJsonText(await readTextFile(path)),
+        path,
+      };
+    } catch {
+      // Some GDAL-backed vector formats use .json but are not GeoJSON
+      // FeatureCollections. Let DuckDB Spatial try them before failing.
+    }
   }
 
   if (extension === "zip") {
-    return {
-      data: await parseShapefileZip(await readFile(path)),
-      path,
-    };
+    try {
+      return {
+        data: await parseShapefileZip(await readFile(path)),
+        path,
+      };
+    } catch {
+      // DuckDB Spatial may be able to read zipped vector data that shpjs cannot.
+    }
   }
 
   try {
-    const siblingFiles = extension === "shp" ? await readShapefileSiblings(path) : [];
+    const siblingFiles =
+      extension === "shp" ? await readShapefileSiblings(path) : [];
     return {
       data: await loadDuckDbVector({
         name: browserSafeFileName(path),
@@ -506,15 +491,19 @@ export async function openVectorFileWithFallback(): Promise<{
 export async function loadDroppedVectorFiles(
   droppedFiles: FileList | File[],
 ): Promise<Array<{ data: FeatureCollection; path: string }>> {
-  const files = Array.from(droppedFiles).filter((file) =>
+  const droppedFileArray = Array.from(droppedFiles);
+  const files = droppedFileArray.filter((file) =>
     isVectorFileName(file.name),
   );
   if (!files.length) return [];
 
   const filesByBaseName = new Map<string, File[]>();
-  for (const file of files) {
+  for (const file of droppedFileArray) {
     const baseName = pathWithoutExtension(file.name).toLowerCase();
-    filesByBaseName.set(baseName, [...(filesByBaseName.get(baseName) ?? []), file]);
+    filesByBaseName.set(baseName, [
+      ...(filesByBaseName.get(baseName) ?? []),
+      file,
+    ]);
   }
 
   const layers: Array<{ data: FeatureCollection; path: string }> = [];
@@ -525,7 +514,10 @@ export async function loadDroppedVectorFiles(
     const siblingFiles =
       extension === "shp"
         ? await Promise.all(
-            (filesByBaseName.get(pathWithoutExtension(file.name).toLowerCase()) ?? [])
+            (
+              filesByBaseName.get(pathWithoutExtension(file.name).toLowerCase()) ??
+              []
+            )
               .filter((candidate) =>
                 SHAPEFILE_SIDECAR_EXTENSIONS.includes(
                   fileExtension(candidate.name),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,7 +28,7 @@ flowchart LR
 
 ## State flow
 
-1. User adds GeoJSON, GeoParquet, GeoPackage, or Shapefile data through the Tauri dialog, browser file picker, or drag and drop.
+1. User adds local vector data supported by DuckDB-WASM Spatial through the Tauri dialog, browser file picker, or drag and drop.
 2. The selected vector data is parsed directly or converted to GeoJSON with DuckDB-WASM Spatial, then passed to `addGeoJsonLayer` in the store.
 3. `MapCanvas` subscribes to `layers`, then `MapController.syncLayers` updates MapLibre sources and layers.
 4. Style panel updates `layer.style`, then sync updates paint properties.
@@ -43,7 +43,7 @@ INSTALL spatial;
 LOAD spatial;
 ```
 
-GeoParquet is read with DuckDB's Parquet reader after loading Spatial. GeoPackage and loose Shapefile paths are read through Spatial `ST_Read` when the WebAssembly extension can load the GDAL-backed reader. Zipped Shapefiles are parsed in the browser with `shpjs`.
+GeoParquet is read with DuckDB's Parquet reader after loading Spatial. Other local vector formats are passed to Spatial `ST_Read` when the WebAssembly extension can load the GDAL-backed reader. Zipped Shapefiles are parsed with `shpjs` first, then DuckDB Spatial is tried if that parser cannot read the file.
 
 ## Python sidecar (v0.5)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,7 +24,7 @@ Bun users can run `bun install`. The root `trustedDependencies` list allows the 
 npm run dev
 ```
 
-Open `http://localhost:5173`. The map and browser vector import work in this mode for GeoJSON, GeoParquet, GeoPackage, and zipped Shapefiles. Use Add Vector Layer or drag files onto the app. Desktop filesystem dialogs require Tauri.
+Open `http://localhost:5173`. The map and browser vector import support local vector files that DuckDB-WASM Spatial can read, with direct handling for GeoJSON and zipped Shapefiles. Use Add Vector Layer or drag files onto the app. Desktop filesystem dialogs require Tauri.
 
 ## Run the desktop app
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ Use an OpenFreeMap basemap, pan and zoom smoothly, and toggle built-in map contr
 <div class="feature-card" markdown>
 ### Local vector projects
 
-Load GeoJSON, GeoParquet, GeoPackage, and Shapefile data, inspect attributes, style layers, reorder visibility, and save or reopen `.geolibre.json` projects from the desktop app.
+Load local vector data supported by DuckDB-WASM Spatial, inspect attributes, style layers, reorder visibility, and save or reopen `.geolibre.json` projects from the desktop app.
 </div>
 
 <div class="feature-card" markdown>
@@ -56,7 +56,7 @@ The processing toolbox includes client-side algorithms now, with a roadmap towar
 
 ## Try it in the browser
 
-The live demo is the browser-capable version of the GeoLibre desktop UI. It is useful for exploring the map, loading browser-selected GeoJSON, GeoParquet, GeoPackage, and zipped Shapefile data, styling layers, and testing plugins. Desktop-only file dialogs and filesystem save/open operations still require the installed Tauri app.
+The live demo is the browser-capable version of the GeoLibre desktop UI. It is useful for exploring the map, loading browser-selected vector data supported by DuckDB-WASM Spatial, styling layers, and testing plugins. Desktop-only file dialogs and filesystem save/open operations still require the installed Tauri app.
 
 [Open the live demo](/demo/){ .md-button .md-button--primary }
 [Read the architecture](architecture.md){ .md-button }


### PR DESCRIPTION
## Summary
- Remove the hardcoded vector file extension allowlist from the file picker, Tauri dialog, and drag-and-drop handling so any format DuckDB-WASM Spatial can read is accepted (FlatGeobuf, KML, GML, and more, in addition to GeoJSON, GeoParquet, GeoPackage, and Shapefile).
- Keep direct parsing for GeoJSON and zipped Shapefiles, falling back to DuckDB Spatial when those parsers cannot read the file.
- Update README and docs to describe the broadened format support.

## Test plan
- [ ] `npm run build` passes (verified via pre-commit `npm build` hook)
- [ ] Load GeoJSON, GeoParquet, GeoPackage, and zipped Shapefile via Add Vector Layer and drag-and-drop
- [ ] Load a non-allowlisted format (e.g. FlatGeobuf) through the Tauri dialog