### PR TITLE
feat: layer control adapter, basemap toggle, and drag-reorder

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -109,6 +109,7 @@ export function TopToolbar({
       projectName: defaultProjectName,
       mapView: mapControllerRef.current?.readView() ?? state.mapView,
       basemapStyleUrl: state.basemapStyleUrl,
+      basemapVisible: state.basemapVisible,
       layers: state.layers,
       metadata: state.metadata,
     });

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -110,6 +110,7 @@ export function TopToolbar({
       mapView: mapControllerRef.current?.readView() ?? state.mapView,
       basemapStyleUrl: state.basemapStyleUrl,
       basemapVisible: state.basemapVisible,
+      basemapOpacity: state.basemapOpacity,
       layers: state.layers,
       metadata: state.metadata,
     });

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -323,7 +323,7 @@ export function AttributeTable() {
           <span className="text-xs text-muted-foreground">— {layer.name}</span>
         ) : (
           <span className="text-xs text-muted-foreground">
-            — select a GeoJSON layer
+            — select a vector layer
           </span>
         )}
         <Input
@@ -360,7 +360,7 @@ export function AttributeTable() {
       >
         {!layer?.geojson ? (
           <p className="p-4 text-xs text-muted-foreground">
-            Attribute table requires a GeoJSON layer.
+            Attribute table requires a vector layer.
           </p>
         ) : (
           <table className="min-w-full table-fixed caption-bottom text-sm">

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -83,6 +83,15 @@ export function LayerPanel({
   );
   const visibleLayers = [...layers].reverse();
   const backgroundSelected = selectedLayerId === BACKGROUND_SELECTION_ID;
+  const allLayersVisible =
+    basemapVisible && layers.every((layer) => layer.visible);
+  const toggleAllLayers = () => {
+    const nextVisible = !allLayersVisible;
+    for (const layer of layers) {
+      setLayerVisibility(layer.id, nextVisible);
+    }
+    setBasemapVisible(nextVisible);
+  };
   const draggedDisplayIndex = draggedLayerId
     ? visibleLayers.findIndex((layer) => layer.id === draggedLayerId)
     : -1;
@@ -164,16 +173,34 @@ export function LayerPanel({
       />
       <div className="flex items-center justify-between border-b px-3 py-1.5">
         <span className="text-sm font-semibold">Layers</span>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-7 w-7"
-          title="Collapse layers"
-          aria-label="Collapse layers"
-          onClick={() => setIsCollapsed(true)}
-        >
-          <PanelLeftClose className="h-4 w-4" />
-        </Button>
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            title={allLayersVisible ? "Hide all layers" : "Show all layers"}
+            aria-label={
+              allLayersVisible ? "Hide all layers" : "Show all layers"
+            }
+            onClick={toggleAllLayers}
+          >
+            {allLayersVisible ? (
+              <Eye className="h-4 w-4" />
+            ) : (
+              <EyeOff className="h-4 w-4 text-muted-foreground" />
+            )}
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            title="Collapse layers"
+            aria-label="Collapse layers"
+            onClick={() => setIsCollapsed(true)}
+          >
+            <PanelLeftClose className="h-4 w-4" />
+          </Button>
+        </div>
       </div>
       <ScrollArea className="flex-1">
         <div className="space-y-1 p-2">

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -1,4 +1,5 @@
 import {
+  type DragEvent as ReactDragEvent,
   type MouseEvent as ReactMouseEvent,
   type RefObject,
   useState,
@@ -23,6 +24,7 @@ import {
   ChevronUp,
   Eye,
   EyeOff,
+  GripVertical,
   Info,
   Layers,
   MousePointerClick,
@@ -53,14 +55,63 @@ export function LayerPanel({
   const selectLayer = useAppStore((s) => s.selectLayer);
   const identifyLayerId = useAppStore((s) => s.identifyLayerId);
   const setIdentifyLayer = useAppStore((s) => s.setIdentifyLayer);
+  const basemapVisible = useAppStore((s) => s.basemapVisible);
+  const setBasemapVisible = useAppStore((s) => s.setBasemapVisible);
   const setLayerVisibility = useAppStore((s) => s.setLayerVisibility);
   const setLayerOpacity = useAppStore((s) => s.setLayerOpacity);
   const reorderLayer = useAppStore((s) => s.reorderLayer);
+  const moveLayer = useAppStore((s) => s.moveLayer);
   const removeLayer = useAppStore((s) => s.removeLayer);
   const [metadataLayer, setMetadataLayer] = useState<GeoLibreLayer | null>(null);
   const [layerPendingRemoval, setLayerPendingRemoval] =
     useState<GeoLibreLayer | null>(null);
   const [isCollapsed, setIsCollapsed] = useState(isMobileViewport);
+  const [draggedLayerId, setDraggedLayerId] = useState<string | null>(null);
+  const [dropTargetLayerId, setDropTargetLayerId] = useState<string | null>(
+    null,
+  );
+  const visibleLayers = [...layers].reverse();
+
+  const resetDragState = () => {
+    setDraggedLayerId(null);
+    setDropTargetLayerId(null);
+  };
+
+  const handleLayerDragStart = (
+    event: ReactDragEvent<HTMLElement>,
+    layerId: string,
+  ) => {
+    event.stopPropagation();
+    event.dataTransfer.effectAllowed = "move";
+    event.dataTransfer.setData("text/plain", layerId);
+    setDraggedLayerId(layerId);
+  };
+
+  const handleLayerDragOver = (
+    event: ReactDragEvent<HTMLDivElement>,
+    layerId: string,
+  ) => {
+    if (!draggedLayerId || draggedLayerId === layerId) return;
+    event.preventDefault();
+    event.stopPropagation();
+    event.dataTransfer.dropEffect = "move";
+    setDropTargetLayerId(layerId);
+  };
+
+  const handleLayerDrop = (
+    event: ReactDragEvent<HTMLDivElement>,
+    layerId: string,
+    displayIndex: number,
+  ) => {
+    if (!draggedLayerId || draggedLayerId === layerId) {
+      resetDragState();
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    moveLayer(draggedLayerId, layers.length - 1 - displayIndex);
+    resetDragState();
+  };
 
   if (isCollapsed) {
     return (
@@ -113,21 +164,30 @@ export function LayerPanel({
         <div className="space-y-1 p-2">
           {layers.length === 0 && (
             <p className="px-2 py-4 text-xs text-muted-foreground">
-              No layers. Add data from the toolbar.
+              No data layers. Add data from the toolbar.
             </p>
           )}
-          {[...layers].reverse().map((layer) => {
+          {visibleLayers.map((layer, displayIndex) => {
             const canIdentify =
               layer.type === "geojson" || layer.type === "vector-tiles";
             const identifyActive = identifyLayerId === layer.id;
             return (
               <div
                 key={layer.id}
-                className={`rounded-md border p-2 ${
+                className={`rounded-md border p-2 transition-colors ${
                   selectedLayerId === layer.id
                     ? "border-primary bg-primary/5"
                     : "border-transparent bg-muted/30"
+                } ${
+                  draggedLayerId === layer.id ? "opacity-50" : ""
+                } ${
+                  dropTargetLayerId === layer.id
+                    ? "border-primary bg-primary/10"
+                    : ""
                 }`}
+                onDragOver={(e) => handleLayerDragOver(e, layer.id)}
+                onDrop={(e) => handleLayerDrop(e, layer.id, displayIndex)}
+                onDragEnd={resetDragState}
                 onClick={() => selectLayer(layer.id)}
                 onKeyDown={(e) => {
                   if (e.key === "Enter") selectLayer(layer.id);
@@ -136,6 +196,18 @@ export function LayerPanel({
                 tabIndex={0}
               >
                 <div className="flex items-center gap-1">
+                  <span
+                    role="button"
+                    tabIndex={0}
+                    draggable
+                    title="Drag to reorder"
+                    aria-label={`Drag ${layer.name} to reorder`}
+                    className="cursor-grab rounded p-0.5 text-muted-foreground hover:bg-muted active:cursor-grabbing"
+                    onClick={(e) => e.stopPropagation()}
+                    onDragStart={(e) => handleLayerDragStart(e, layer.id)}
+                  >
+                    <GripVertical className="h-3.5 w-3.5" />
+                  </span>
                   <button
                     type="button"
                     className="rounded p-0.5 hover:bg-muted"
@@ -271,6 +343,40 @@ export function LayerPanel({
               </div>
             );
           })}
+          <div className="rounded-md border border-border bg-muted/20 p-2">
+            <div className="flex items-center gap-1">
+              <span
+                title="Background cannot be reordered"
+                className="rounded p-0.5 text-muted-foreground/50"
+              >
+                <GripVertical className="h-3.5 w-3.5" />
+              </span>
+              <button
+                type="button"
+                className="rounded p-0.5 hover:bg-muted"
+                title={
+                  basemapVisible ? "Hide background" : "Show background"
+                }
+                aria-label={
+                  basemapVisible ? "Hide background" : "Show background"
+                }
+                onClick={() => setBasemapVisible(!basemapVisible)}
+              >
+                {basemapVisible ? (
+                  <Eye className="h-3.5 w-3.5" />
+                ) : (
+                  <EyeOff className="h-3.5 w-3.5 text-muted-foreground" />
+                )}
+              </button>
+              <Layers className="h-3.5 w-3.5 text-muted-foreground" />
+              <span className="flex-1 truncate text-sm font-medium">
+                Background
+              </span>
+              <span className="text-[10px] uppercase text-muted-foreground">
+                basemap
+              </span>
+            </div>
+          </div>
         </div>
       </ScrollArea>
       <Separator />

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -39,6 +39,15 @@ interface LayerPanelProps {
   onResizeStart: (event: ReactMouseEvent<HTMLDivElement>) => void;
 }
 
+const BACKGROUND_SELECTION_ID = "__geolibre-background__";
+
+function layerTypeLabel(layer: GeoLibreLayer): string {
+  if (layer.type === "geojson" || layer.type === "vector-tiles") {
+    return "vector";
+  }
+  return layer.type;
+}
+
 function isMobileViewport(): boolean {
   return (
     typeof window !== "undefined" &&
@@ -56,7 +65,9 @@ export function LayerPanel({
   const identifyLayerId = useAppStore((s) => s.identifyLayerId);
   const setIdentifyLayer = useAppStore((s) => s.setIdentifyLayer);
   const basemapVisible = useAppStore((s) => s.basemapVisible);
+  const basemapOpacity = useAppStore((s) => s.basemapOpacity);
   const setBasemapVisible = useAppStore((s) => s.setBasemapVisible);
+  const setBasemapOpacity = useAppStore((s) => s.setBasemapOpacity);
   const setLayerVisibility = useAppStore((s) => s.setLayerVisibility);
   const setLayerOpacity = useAppStore((s) => s.setLayerOpacity);
   const reorderLayer = useAppStore((s) => s.reorderLayer);
@@ -71,6 +82,10 @@ export function LayerPanel({
     null,
   );
   const visibleLayers = [...layers].reverse();
+  const backgroundSelected = selectedLayerId === BACKGROUND_SELECTION_ID;
+  const draggedDisplayIndex = draggedLayerId
+    ? visibleLayers.findIndex((layer) => layer.id === draggedLayerId)
+    : -1;
 
   const resetDragState = () => {
     setDraggedLayerId(null);
@@ -174,16 +189,12 @@ export function LayerPanel({
             return (
               <div
                 key={layer.id}
-                className={`rounded-md border p-2 transition-colors ${
+                className={`relative rounded-md border p-2 transition-colors ${
                   selectedLayerId === layer.id
                     ? "border-primary bg-primary/5"
-                    : "border-transparent bg-muted/30"
+                    : "border-border bg-background hover:border-muted-foreground/40 hover:bg-muted/20"
                 } ${
                   draggedLayerId === layer.id ? "opacity-50" : ""
-                } ${
-                  dropTargetLayerId === layer.id
-                    ? "border-primary bg-primary/10"
-                    : ""
                 }`}
                 onDragOver={(e) => handleLayerDragOver(e, layer.id)}
                 onDrop={(e) => handleLayerDrop(e, layer.id, displayIndex)}
@@ -195,6 +206,15 @@ export function LayerPanel({
                 role="button"
                 tabIndex={0}
               >
+                {dropTargetLayerId === layer.id &&
+                  draggedDisplayIndex > displayIndex && (
+                    <div className="pointer-events-none absolute -top-1 left-2 right-2 h-1 rounded-full bg-primary shadow-[0_0_0_2px_hsl(var(--background))]" />
+                  )}
+                {dropTargetLayerId === layer.id &&
+                  draggedDisplayIndex >= 0 &&
+                  draggedDisplayIndex < displayIndex && (
+                    <div className="pointer-events-none absolute -bottom-1 left-2 right-2 h-1 rounded-full bg-primary shadow-[0_0_0_2px_hsl(var(--background))]" />
+                  )}
                 <div className="flex items-center gap-1">
                   <span
                     role="button"
@@ -226,7 +246,7 @@ export function LayerPanel({
                     {layer.name}
                   </span>
                   <span className="text-[10px] uppercase text-muted-foreground">
-                    {layer.type}
+                    {layerTypeLabel(layer)}
                   </span>
                 </div>
                 {isPlaceholderLayer(layer) && (
@@ -343,7 +363,19 @@ export function LayerPanel({
               </div>
             );
           })}
-          <div className="rounded-md border border-border bg-muted/20 p-2">
+          <div
+            className={`rounded-md border p-2 transition-colors ${
+              backgroundSelected
+                ? "border-primary bg-primary/5"
+                : "border-border bg-background hover:border-muted-foreground/40 hover:bg-muted/20"
+            }`}
+            onClick={() => selectLayer(BACKGROUND_SELECTION_ID)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") selectLayer(BACKGROUND_SELECTION_ID);
+            }}
+            role="button"
+            tabIndex={0}
+          >
             <div className="flex items-center gap-1">
               <span
                 title="Background cannot be reordered"
@@ -360,7 +392,10 @@ export function LayerPanel({
                 aria-label={
                   basemapVisible ? "Hide background" : "Show background"
                 }
-                onClick={() => setBasemapVisible(!basemapVisible)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setBasemapVisible(!basemapVisible);
+                }}
               >
                 {basemapVisible ? (
                   <Eye className="h-3.5 w-3.5" />
@@ -375,6 +410,22 @@ export function LayerPanel({
               <span className="text-[10px] uppercase text-muted-foreground">
                 basemap
               </span>
+            </div>
+            <div className="mt-2 flex items-center gap-1">
+              <span className="text-[10px] text-muted-foreground">
+                Opacity
+              </span>
+              <Slider
+                className="flex-1"
+                min={0}
+                max={1}
+                step={0.05}
+                value={[basemapOpacity]}
+                onValueChange={([v]) =>
+                  setBasemapOpacity(v ?? basemapOpacity)
+                }
+                onClick={(e) => e.stopPropagation()}
+              />
             </div>
           </div>
         </div>

--- a/docs/project-format.md
+++ b/docs/project-format.md
@@ -11,6 +11,7 @@ Projects are saved as **`.geolibre.json`** files.
 | `mapView` | object | `center`, `zoom`, `bearing`, `pitch`, optional `bbox` |
 | `basemapStyleUrl` | string | MapLibre style JSON URL, or an empty string for a blank background |
 | `basemapVisible` | boolean | Whether the Background layer is visible |
+| `basemapOpacity` | number | Background layer opacity from `0` to `1` |
 | `layers` | array | Layer definitions (see below) |
 | `styles` | object | Map of layer id → `LayerStyle` |
 | `metadata` | object | Free-form project metadata |

--- a/docs/project-format.md
+++ b/docs/project-format.md
@@ -10,6 +10,7 @@ Projects are saved as **`.geolibre.json`** files.
 | `name` | string | Project display name |
 | `mapView` | object | `center`, `zoom`, `bearing`, `pitch`, optional `bbox` |
 | `basemapStyleUrl` | string | MapLibre style JSON URL, or an empty string for a blank background |
+| `basemapVisible` | boolean | Whether the Background layer is visible |
 | `layers` | array | Layer definitions (see below) |
 | `styles` | object | Map of layer id → `LayerStyle` |
 | `metadata` | object | Free-form project metadata |

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -32,6 +32,7 @@ export function createEmptyProject(
     mapView: options.mapView ?? createDefaultMapView(),
     basemapStyleUrl: options.basemapStyleUrl ?? DEFAULT_BASEMAP,
     basemapVisible: true,
+    basemapOpacity: 1,
     layers: [],
     styles: {},
     metadata: {},
@@ -53,6 +54,7 @@ export function parseProject(json: string): GeoLibreProject {
     mapView: data.mapView,
     basemapStyleUrl: data.basemapStyleUrl ?? DEFAULT_BASEMAP,
     basemapVisible: data.basemapVisible ?? true,
+    basemapOpacity: data.basemapOpacity ?? 1,
     layers: (data.layers ?? []).map(normalizeLayer),
     styles: data.styles ?? {},
     metadata: data.metadata ?? {},
@@ -75,6 +77,7 @@ export function projectFromStore(state: {
   mapView: MapViewState;
   basemapStyleUrl: string;
   basemapVisible: boolean;
+  basemapOpacity: number;
   layers: GeoLibreLayer[];
   metadata: Record<string, unknown>;
 }): GeoLibreProject {
@@ -88,6 +91,7 @@ export function projectFromStore(state: {
     mapView: state.mapView,
     basemapStyleUrl: state.basemapStyleUrl,
     basemapVisible: state.basemapVisible,
+    basemapOpacity: state.basemapOpacity,
     layers: state.layers,
     styles,
     metadata: state.metadata,
@@ -99,6 +103,7 @@ export function applyProjectToStore(project: GeoLibreProject): {
   mapView: MapViewState;
   basemapStyleUrl: string;
   basemapVisible: boolean;
+  basemapOpacity: number;
   layers: GeoLibreLayer[];
   metadata: Record<string, unknown>;
 } {
@@ -113,6 +118,7 @@ export function applyProjectToStore(project: GeoLibreProject): {
     mapView: project.mapView,
     basemapStyleUrl: project.basemapStyleUrl,
     basemapVisible: project.basemapVisible ?? true,
+    basemapOpacity: project.basemapOpacity ?? 1,
     layers,
     metadata: project.metadata,
   };

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -31,6 +31,7 @@ export function createEmptyProject(
     name,
     mapView: options.mapView ?? createDefaultMapView(),
     basemapStyleUrl: options.basemapStyleUrl ?? DEFAULT_BASEMAP,
+    basemapVisible: true,
     layers: [],
     styles: {},
     metadata: {},
@@ -51,6 +52,7 @@ export function parseProject(json: string): GeoLibreProject {
     name: data.name,
     mapView: data.mapView,
     basemapStyleUrl: data.basemapStyleUrl ?? DEFAULT_BASEMAP,
+    basemapVisible: data.basemapVisible ?? true,
     layers: (data.layers ?? []).map(normalizeLayer),
     styles: data.styles ?? {},
     metadata: data.metadata ?? {},
@@ -72,6 +74,7 @@ export function projectFromStore(state: {
   projectName: string;
   mapView: MapViewState;
   basemapStyleUrl: string;
+  basemapVisible: boolean;
   layers: GeoLibreLayer[];
   metadata: Record<string, unknown>;
 }): GeoLibreProject {
@@ -84,6 +87,7 @@ export function projectFromStore(state: {
     name: state.projectName,
     mapView: state.mapView,
     basemapStyleUrl: state.basemapStyleUrl,
+    basemapVisible: state.basemapVisible,
     layers: state.layers,
     styles,
     metadata: state.metadata,
@@ -94,6 +98,7 @@ export function applyProjectToStore(project: GeoLibreProject): {
   projectName: string;
   mapView: MapViewState;
   basemapStyleUrl: string;
+  basemapVisible: boolean;
   layers: GeoLibreLayer[];
   metadata: Record<string, unknown>;
 } {
@@ -107,6 +112,7 @@ export function applyProjectToStore(project: GeoLibreProject): {
     projectName: project.name,
     mapView: project.mapView,
     basemapStyleUrl: project.basemapStyleUrl,
+    basemapVisible: project.basemapVisible ?? true,
     layers,
     metadata: project.metadata,
   };

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -24,6 +24,7 @@ export interface AppState {
   mapView: MapViewState;
   basemapStyleUrl: string;
   basemapVisible: boolean;
+  basemapOpacity: number;
   layers: GeoLibreLayer[];
   selectedLayerId: string | null;
   selectedFeatureId: string | null;
@@ -42,6 +43,7 @@ export interface AppState {
   setMapView: (view: Partial<MapViewState>, markDirty?: boolean) => void;
   setBasemapStyleUrl: (url: string) => void;
   setBasemapVisible: (visible: boolean) => void;
+  setBasemapOpacity: (opacity: number) => void;
   selectLayer: (id: string | null) => void;
   selectFeature: (id: string | null) => void;
   setIdentifyLayer: (id: string | null) => void;
@@ -79,6 +81,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   mapView: createDefaultMapView(),
   basemapStyleUrl: DEFAULT_BASEMAP,
   basemapVisible: true,
+  basemapOpacity: 1,
   layers: [],
   selectedLayerId: null,
   selectedFeatureId: null,
@@ -102,6 +105,8 @@ export const useAppStore = create<AppState>((set, get) => ({
   setBasemapStyleUrl: (url) => set({ basemapStyleUrl: url, isDirty: true }),
   setBasemapVisible: (visible) =>
     set({ basemapVisible: visible, isDirty: true }),
+  setBasemapOpacity: (opacity) =>
+    set({ basemapOpacity: opacity, isDirty: true }),
   selectLayer: (id) => set({ selectedLayerId: id, selectedFeatureId: null }),
   selectFeature: (id) => set({ selectedFeatureId: id }),
   setIdentifyLayer: (id) => set({ identifyLayerId: id }),

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -23,6 +23,7 @@ export interface AppState {
   isDirty: boolean;
   mapView: MapViewState;
   basemapStyleUrl: string;
+  basemapVisible: boolean;
   layers: GeoLibreLayer[];
   selectedLayerId: string | null;
   selectedFeatureId: string | null;
@@ -40,6 +41,7 @@ export interface AppState {
   setPointerCoords: (coords: [number, number] | null) => void;
   setMapView: (view: Partial<MapViewState>, markDirty?: boolean) => void;
   setBasemapStyleUrl: (url: string) => void;
+  setBasemapVisible: (visible: boolean) => void;
   selectLayer: (id: string | null) => void;
   selectFeature: (id: string | null) => void;
   setIdentifyLayer: (id: string | null) => void;
@@ -61,6 +63,7 @@ export interface AppState {
   setLayerOpacity: (id: string, opacity: number) => void;
   setLayerStyle: (id: string, style: Partial<LayerStyle>) => void;
   reorderLayer: (id: string, direction: "up" | "down") => void;
+  moveLayer: (id: string, targetIndex: number) => void;
   addGeoJsonLayer: (
     name: string,
     geojson: FeatureCollection,
@@ -75,6 +78,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   isDirty: false,
   mapView: createDefaultMapView(),
   basemapStyleUrl: DEFAULT_BASEMAP,
+  basemapVisible: true,
   layers: [],
   selectedLayerId: null,
   selectedFeatureId: null,
@@ -96,6 +100,8 @@ export const useAppStore = create<AppState>((set, get) => ({
       isDirty: markDirty || s.isDirty,
     })),
   setBasemapStyleUrl: (url) => set({ basemapStyleUrl: url, isDirty: true }),
+  setBasemapVisible: (visible) =>
+    set({ basemapVisible: visible, isDirty: true }),
   selectLayer: (id) => set({ selectedLayerId: id, selectedFeatureId: null }),
   selectFeature: (id) => set({ selectedFeatureId: id }),
   setIdentifyLayer: (id) => set({ identifyLayerId: id }),
@@ -214,6 +220,20 @@ export const useAppStore = create<AppState>((set, get) => ({
       const next = [...s.layers];
       const [item] = next.splice(idx, 1);
       next.splice(target, 0, item);
+      return { layers: next, isDirty: true };
+    }),
+
+  moveLayer: (id, targetIndex) =>
+    set((s) => {
+      const currentIndex = s.layers.findIndex((layer) => layer.id === id);
+      if (currentIndex < 0) return s;
+      const next = [...s.layers];
+      const [layer] = next.splice(currentIndex, 1);
+      const nextIndex = Math.min(Math.max(targetIndex, 0), next.length);
+      next.splice(nextIndex, 0, layer);
+      if (next.every((item, index) => item.id === s.layers[index]?.id)) {
+        return s;
+      }
       return { layers: next, isDirty: true };
     }),
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -105,6 +105,7 @@ export interface GeoLibreProject {
   name: string;
   mapView: MapViewState;
   basemapStyleUrl: string;
+  basemapVisible: boolean;
   layers: GeoLibreLayer[];
   styles: Record<string, LayerStyle>;
   metadata: Record<string, unknown>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -106,6 +106,7 @@ export interface GeoLibreProject {
   mapView: MapViewState;
   basemapStyleUrl: string;
   basemapVisible: boolean;
+  basemapOpacity: number;
   layers: GeoLibreLayer[];
   styles: Record<string, LayerStyle>;
   metadata: Record<string, unknown>;

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -109,6 +109,7 @@ export const MapCanvas = memo(function MapCanvas({
 
   const basemapStyleUrl = useAppStore((s) => s.basemapStyleUrl);
   const basemapVisible = useAppStore((s) => s.basemapVisible);
+  const basemapOpacity = useAppStore((s) => s.basemapOpacity);
   const mapView = useAppStore((s) => s.mapView);
   const layers = useAppStore((s) => s.layers);
   const selectedLayerId = useAppStore((s) => s.selectedLayerId);
@@ -145,6 +146,7 @@ export const MapCanvas = memo(function MapCanvas({
     map.on("load", () => {
       mc.waitAndSyncLayers(useAppStore.getState().layers);
       mc.setBasemapVisible(useAppStore.getState().basemapVisible);
+      mc.setBasemapOpacity(useAppStore.getState().basemapOpacity);
       const state = useAppStore.getState();
       mc.highlightFeature(
         state.layers.find((layer) => layer.id === state.selectedLayerId),
@@ -215,6 +217,9 @@ export const MapCanvas = memo(function MapCanvas({
       controller.current?.setBasemapVisible(
         useAppStore.getState().basemapVisible,
       );
+      controller.current?.setBasemapOpacity(
+        useAppStore.getState().basemapOpacity,
+      );
       const state = useAppStore.getState();
       controller.current?.highlightFeature(
         state.layers.find((layer) => layer.id === state.selectedLayerId),
@@ -227,6 +232,10 @@ export const MapCanvas = memo(function MapCanvas({
   useEffect(() => {
     controller.current?.setBasemapVisible(basemapVisible);
   }, [basemapVisible]);
+
+  useEffect(() => {
+    controller.current?.setBasemapOpacity(basemapOpacity);
+  }, [basemapOpacity]);
 
   useEffect(() => {
     controller.current?.waitAndSyncLayers(layers);

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -108,6 +108,7 @@ export const MapCanvas = memo(function MapCanvas({
   const controller = useRef<MapController | null>(null);
 
   const basemapStyleUrl = useAppStore((s) => s.basemapStyleUrl);
+  const basemapVisible = useAppStore((s) => s.basemapVisible);
   const mapView = useAppStore((s) => s.mapView);
   const layers = useAppStore((s) => s.layers);
   const selectedLayerId = useAppStore((s) => s.selectedLayerId);
@@ -143,6 +144,7 @@ export const MapCanvas = memo(function MapCanvas({
     map.on("moveend", updateView);
     map.on("load", () => {
       mc.waitAndSyncLayers(useAppStore.getState().layers);
+      mc.setBasemapVisible(useAppStore.getState().basemapVisible);
       const state = useAppStore.getState();
       mc.highlightFeature(
         state.layers.find((layer) => layer.id === state.selectedLayerId),
@@ -210,6 +212,9 @@ export const MapCanvas = memo(function MapCanvas({
     prevBasemap.current = basemapStyleUrl;
     map.once("style.load", () => {
       controller.current?.waitAndSyncLayers(useAppStore.getState().layers);
+      controller.current?.setBasemapVisible(
+        useAppStore.getState().basemapVisible,
+      );
       const state = useAppStore.getState();
       controller.current?.highlightFeature(
         state.layers.find((layer) => layer.id === state.selectedLayerId),
@@ -218,6 +223,10 @@ export const MapCanvas = memo(function MapCanvas({
     });
     controller.current?.setStyle(basemapStyleUrl);
   }, [basemapStyleUrl]);
+
+  useEffect(() => {
+    controller.current?.setBasemapVisible(basemapVisible);
+  }, [basemapVisible]);
 
   useEffect(() => {
     controller.current?.waitAndSyncLayers(layers);

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -3,7 +3,11 @@ import type { GeoLibreLayer, MapViewState } from "@geolibre/core";
 import bbox from "@turf/bbox";
 import type { Feature, FeatureCollection, Geometry } from "geojson";
 import maplibregl from "maplibre-gl";
-import { LayerControl } from "maplibre-gl-layer-control";
+import {
+  LayerControl,
+  type CustomLayerAdapter,
+  type LayerState,
+} from "maplibre-gl-layer-control";
 import {
   circleLayerId,
   fillLayerId,
@@ -72,16 +76,9 @@ function resolveMapStyle(
   return styleUrl ?? DEFAULT_BASEMAP;
 }
 
-interface NamedLayerState {
-  visible: boolean;
-  opacity: number;
-  name: string;
-}
-
 interface LayerControlConfig {
-  layers?: string[];
-  layerStates?: Record<string, NamedLayerState>;
   excludeLayers?: string[];
+  customLayerAdapters?: CustomLayerAdapter[];
 }
 
 interface GeoLibreLayerLabelWindow extends Window {
@@ -599,39 +596,149 @@ export class MapController {
   private createLayerControlConfig(
     layers: GeoLibreLayer[],
   ): LayerControlConfig {
-    const namedStyleLayers = layers.flatMap((layer) =>
-      this.getNamedStyleLayers(layer),
+    const nativeStyleLayerIds = layers.flatMap((layer) =>
+      this.getCandidateStyleLayers(layer).map(({ id }) => id),
     );
-    if (namedStyleLayers.length === 0) {
-      return { excludeLayers: LAYER_CONTROL_EXCLUDED_LAYERS };
+    const excludeLayers = [
+      ...LAYER_CONTROL_EXCLUDED_LAYERS,
+      ...nativeStyleLayerIds,
+    ];
+    const controllableLayers = layers.filter(
+      (layer) => this.getNativeLayerIds(layer).length > 0,
+    );
+
+    if (controllableLayers.length === 0) {
+      return { excludeLayers };
     }
 
     return {
-      excludeLayers: LAYER_CONTROL_EXCLUDED_LAYERS,
-      layers: namedStyleLayers.map(({ id }) => id),
-      layerStates: Object.fromEntries(
-        namedStyleLayers.map(({ id, name, layer }) => [
-          id,
-          {
-            visible: layer.visible,
-            opacity: layer.opacity,
-            name,
-          },
-        ]),
-      ),
+      excludeLayers,
+      customLayerAdapters: [this.createGeoLibreLayerAdapter(controllableLayers)],
     };
   }
 
   private createLayerControlSignature(config: LayerControlConfig): string {
     return JSON.stringify({
-      layers: config.layers ?? [],
-      names: Object.fromEntries(
-        Object.entries(config.layerStates ?? {}).map(([id, state]) => [
-          id,
-          state.name,
-        ]),
+      excluded: config.excludeLayers ?? [],
+      layers: config.customLayerAdapters?.flatMap((adapter) =>
+        adapter.getLayerIds().map((id) => {
+          const state = adapter.getLayerState(id);
+          return {
+            id,
+            name: state?.name,
+            opacity: state?.opacity,
+            visible: state?.visible,
+            symbol: adapter.getSymbolType?.(id),
+          };
+        }),
       ),
     });
+  }
+
+  private createGeoLibreLayerAdapter(
+    layers: GeoLibreLayer[],
+  ): CustomLayerAdapter {
+    const layerById = new Map(layers.map((layer) => [layer.id, layer]));
+
+    return {
+      type: "geolibre",
+      getLayerIds: () => layers.map((layer) => layer.id),
+      getLayerState: (layerId) => {
+        const layer = layerById.get(layerId);
+        if (!layer) return null;
+        return {
+          visible: layer.visible,
+          opacity: layer.opacity,
+          name: layer.name,
+          isCustomLayer: true,
+          customLayerType: this.getLayerSymbolType(layer),
+        } satisfies LayerState;
+      },
+      setVisibility: (layerId, visible) => {
+        for (const nativeId of this.getNativeLayerIdsByLayerId(layerId)) {
+          this.map?.setLayoutProperty(
+            nativeId,
+            "visibility",
+            visible ? "visible" : "none",
+          );
+        }
+      },
+      setOpacity: (layerId, opacity) => {
+        const layer = layerById.get(layerId);
+        if (!layer) return;
+        for (const nativeId of this.getNativeLayerIds(layer)) {
+          this.setNativeLayerOpacity(nativeId, layer, opacity);
+        }
+      },
+      getName: (layerId) => layerById.get(layerId)?.name ?? layerId,
+      getSymbolType: (layerId) => {
+        const layer = layerById.get(layerId);
+        return layer ? this.getLayerSymbolType(layer) : "custom";
+      },
+      getBounds: (layerId) => {
+        const layer = layerById.get(layerId);
+        return layer ? getLayerBounds(layer) : null;
+      },
+      getNativeLayerIds: (layerId) => this.getNativeLayerIdsByLayerId(layerId),
+      removeLayer: (layerId) => {
+        if (this.map) removeLayerFromMap(this.map, layerId);
+      },
+    };
+  }
+
+  private getNativeLayerIdsByLayerId(layerId: string): string[] {
+    const layer = this.syncedLayers.find((item) => item.id === layerId);
+    return layer ? this.getNativeLayerIds(layer) : [];
+  }
+
+  private getNativeLayerIds(layer: GeoLibreLayer): string[] {
+    return this.getCandidateStyleLayers(layer)
+      .map(({ id }) => id)
+      .filter((id) => this.map?.getLayer(id));
+  }
+
+  private getLayerSymbolType(layer: GeoLibreLayer): string {
+    const nativeLayer = this.getNativeLayerIds(layer)
+      .map((id) => this.map?.getLayer(id))
+      .find((item): item is maplibregl.LayerSpecification => Boolean(item));
+
+    return nativeLayer?.type ?? "custom";
+  }
+
+  private setNativeLayerOpacity(
+    nativeLayerId: string,
+    layer: GeoLibreLayer,
+    opacity: number,
+  ): void {
+    const nativeLayer = this.map?.getLayer(nativeLayerId);
+    if (!nativeLayer || !this.map) return;
+
+    if (nativeLayer.type === "fill") {
+      this.map.setPaintProperty(
+        nativeLayerId,
+        "fill-opacity",
+        layer.style.fillOpacity * opacity,
+      );
+      return;
+    }
+
+    if (nativeLayer.type === "line") {
+      this.map.setPaintProperty(nativeLayerId, "line-opacity", opacity);
+      return;
+    }
+
+    if (nativeLayer.type === "circle") {
+      this.map.setPaintProperty(
+        nativeLayerId,
+        "circle-opacity",
+        layer.style.fillOpacity * opacity,
+      );
+      return;
+    }
+
+    if (nativeLayer.type === "raster") {
+      this.map.setPaintProperty(nativeLayerId, "raster-opacity", opacity);
+    }
   }
 
   private getNamedStyleLayers(layer: GeoLibreLayer): Array<{

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -746,6 +746,11 @@ export class MapController {
   }
 
   private createLayerControlSignature(config: LayerControlConfig): string {
+    // Only structural attributes belong in the signature. Opacity and
+    // visibility are managed in place by the control and persisted to the
+    // store; including them here would destroy and recreate the control
+    // (collapsing it and interrupting the drag) on every slider or checkbox
+    // interaction.
     return JSON.stringify({
       excluded: config.excludeLayers ?? [],
       layers: config.customLayerAdapters?.flatMap((adapter) =>
@@ -754,8 +759,6 @@ export class MapController {
           return {
             id,
             name: state?.name,
-            opacity: state?.opacity,
-            visible: state?.visible,
             symbol: adapter.getSymbolType?.(id),
           };
         }),

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -98,7 +98,7 @@ interface LayerControlConfig {
   customLayerAdapters?: CustomLayerAdapter[];
 }
 
-interface LayerControlBackgroundState {
+interface LayerControlInternalState {
   panel?: HTMLElement;
   state?: {
     layerStates?: Record<
@@ -175,6 +175,7 @@ export class MapController {
   private basemapOriginalPaintValues = new Map<string, Map<string, unknown>>();
   private syncedLayers: GeoLibreLayer[] = [];
   private layerIds: string[] = [];
+  private styleReady = false;
   private controlVisibility: Record<BuiltInMapControl, boolean> = {
     ...DEFAULT_BUILT_IN_CONTROL_VISIBILITY,
   };
@@ -202,20 +203,16 @@ export class MapController {
       attributionControl: false,
       maplibreLogo: false,
     });
-    this.map.on("style.load", () => {
+    const handleStyleReady = () => {
+      this.styleReady = true;
       this.enforceDefaultProjection();
       this.addTerrainSource();
       this.applyBasemapVisibility();
       this.applyBasemapOpacity();
       this.addLayerControl();
-    });
-    this.map.once("load", () => {
-      this.enforceDefaultProjection();
-      this.addTerrainSource();
-      this.applyBasemapVisibility();
-      this.applyBasemapOpacity();
-      this.addLayerControl();
-    });
+    };
+    this.map.on("style.load", handleStyleReady);
+    this.map.once("load", handleStyleReady);
     this.map.once("idle", () => this.enforceDefaultProjection());
     this.addNavigationControl();
     this.addFullscreenControl();
@@ -230,6 +227,10 @@ export class MapController {
 
   getMap(): maplibregl.Map | null {
     return this.map;
+  }
+
+  private isStyleReady(): boolean {
+    return Boolean(this.map && this.styleReady);
   }
 
   addControl(
@@ -309,12 +310,14 @@ export class MapController {
     this.removeLayerControl();
     this.map?.remove();
     this.map = null;
+    this.styleReady = false;
     this.publishLayerDisplayNames([]);
   }
 
   setStyle(url: string): void {
     if (!this.map) return;
     this.basemapStyleUrl = url;
+    this.styleReady = false;
     this.basemapOriginalPaintValues.clear();
     this.removeLayerControl();
     this.map.setStyle(resolveMapStyle(url));
@@ -323,13 +326,13 @@ export class MapController {
   setBasemapVisible(visible: boolean): void {
     this.basemapVisible = visible;
     this.applyBasemapVisibility();
-    this.syncLayerControlBackgroundState();
+    this.syncLayerControlState();
   }
 
   setBasemapOpacity(opacity: number): void {
     this.basemapOpacity = opacity;
     this.applyBasemapOpacity();
-    this.syncLayerControlBackgroundState();
+    this.syncLayerControlState();
   }
 
   applyView(view: MapViewState): void {
@@ -368,7 +371,7 @@ export class MapController {
   }
 
   syncLayers(layers: GeoLibreLayer[]): void {
-    if (!this.map || !this.map.isStyleLoaded()) return;
+    if (!this.isStyleReady()) return;
 
     const nextIds = layers.map((l) => l.id);
     for (const id of this.layerIds) {
@@ -386,6 +389,7 @@ export class MapController {
     this.applyBasemapOpacity();
     this.publishLayerDisplayNames(layers);
     this.refreshLayerControl(layers);
+    this.syncLayerControlState();
   }
 
   private styleLoadHandler: (() => void) | null = null;
@@ -395,12 +399,16 @@ export class MapController {
 
     if (this.styleLoadHandler) {
       this.map.off("style.load", this.styleLoadHandler);
+      this.map.off("load", this.styleLoadHandler);
     }
 
-    const run = () => this.syncLayers(layers);
+    const run = () => {
+      if (this.styleLoadHandler !== run) return;
+      this.syncLayers(layers);
+    };
     this.styleLoadHandler = run;
 
-    if (this.map.isStyleLoaded()) {
+    if (this.isStyleReady()) {
       run();
     } else {
       this.map.once("load", run);
@@ -409,7 +417,7 @@ export class MapController {
   }
 
   private applyBasemapVisibility(): void {
-    if (!this.map || !this.map.isStyleLoaded()) return;
+    if (!this.isStyleReady()) return;
 
     for (const layer of this.getBasemapStyleLayers()) {
       try {
@@ -425,7 +433,7 @@ export class MapController {
   }
 
   private applyBasemapOpacity(): void {
-    if (!this.map || !this.map.isStyleLoaded()) return;
+    if (!this.isStyleReady()) return;
 
     for (const layer of this.getBasemapStyleLayers()) {
       const properties = OPACITY_PAINT_PROPERTIES[layer.type] ?? [];
@@ -436,7 +444,7 @@ export class MapController {
   }
 
   private getBasemapStyleLayers(): maplibregl.LayerSpecification[] {
-    if (!this.map || !this.map.isStyleLoaded()) return [];
+    if (!this.isStyleReady()) return [];
 
     const userStyleLayerIds = new Set(
       this.syncedLayers.flatMap((layer) =>
@@ -509,7 +517,7 @@ export class MapController {
     featureId: string | null,
     options: { fit?: boolean } = {},
   ): void {
-    if (!this.map || !this.map.isStyleLoaded()) return;
+    if (!this.isStyleReady()) return;
 
     if (!layer?.geojson || !featureId) {
       this.syncHighlight(EMPTY_HIGHLIGHT);
@@ -574,7 +582,7 @@ export class MapController {
   }
 
   private syncHighlight(featureCollection: FeatureCollection): void {
-    if (!this.map || !this.map.isStyleLoaded()) return;
+    if (!this.isStyleReady()) return;
 
     const source = this.map.getSource(highlightSourceId());
     if (source) {
@@ -660,7 +668,7 @@ export class MapController {
     if (
       !this.map ||
       !this.controlVisibility.terrain ||
-      !this.map.isStyleLoaded()
+      !this.isStyleReady()
     ) {
       return false;
     }
@@ -693,8 +701,8 @@ export class MapController {
       this.layerControl,
       this.controlPositions["layer-control"],
     );
-    this.syncLayerControlBackgroundState();
-    window.setTimeout(() => this.syncLayerControlBackgroundState(), 100);
+    this.syncLayerControlState();
+    window.setTimeout(() => this.syncLayerControlState(), 100);
     return true;
   }
 
@@ -719,6 +727,11 @@ export class MapController {
 
     this.removeLayerControl();
     this.addLayerControl();
+  }
+
+  private syncLayerControlState(): void {
+    this.syncLayerControlBackgroundState();
+    this.syncLayerControlLayerStates(this.syncedLayers);
   }
 
   private createLayerControlConfig(
@@ -768,7 +781,7 @@ export class MapController {
 
   private syncLayerControlBackgroundState(): void {
     if (!this.layerControl) return;
-    const control = this.layerControl as unknown as LayerControlBackgroundState;
+    const control = this.layerControl as unknown as LayerControlInternalState;
 
     const backgroundState =
       control.state?.layerStates?.Background ??
@@ -784,22 +797,69 @@ export class MapController {
       backgroundState.opacity = this.basemapOpacity;
     }
 
-    const backgroundItem = control.panel?.querySelector(
-      '[data-layer-id="Background"]',
-    );
+    const backgroundItem = this.getLayerControlItem("Background");
     if (!backgroundItem) return;
 
-    const checkbox = backgroundItem.querySelector(
+    this.updateLayerControlItem(backgroundItem, {
+      name: "Background",
+      visible: this.basemapVisible,
+      opacity: this.basemapOpacity,
+    });
+  }
+
+  private syncLayerControlLayerStates(layers: GeoLibreLayer[]): void {
+    if (!this.layerControl) return;
+    const control = this.layerControl as unknown as LayerControlInternalState;
+
+    for (const layer of layers) {
+      const layerState = control.state?.layerStates?.[layer.id];
+      if (layerState) {
+        layerState.visible = layer.visible;
+        layerState.opacity = layer.opacity;
+        layerState.name = layer.name;
+      }
+
+      const layerItem = this.getLayerControlItem(layer.id);
+      if (!layerItem) continue;
+      this.updateLayerControlItem(layerItem, {
+        name: layer.name,
+        visible: layer.visible,
+        opacity: layer.opacity,
+      });
+    }
+  }
+
+  private getLayerControlItem(layerId: string): HTMLElement | null {
+    const control = this.layerControl as unknown as LayerControlInternalState;
+    const items = control.panel?.querySelectorAll(".layer-control-item") ?? [];
+    return (
+      Array.from(items).find(
+        (item) => (item as HTMLElement).dataset.layerId === layerId,
+      ) as HTMLElement | undefined
+    ) ?? null;
+  }
+
+  private updateLayerControlItem(
+    item: HTMLElement,
+    state: { name: string; visible: boolean; opacity: number },
+  ): void {
+    const checkbox = item.querySelector(
       ".layer-control-checkbox",
     ) as HTMLInputElement | null;
-    if (checkbox) checkbox.checked = this.basemapVisible;
+    if (checkbox) checkbox.checked = state.visible;
 
-    const opacity = backgroundItem.querySelector(
+    const opacity = item.querySelector(
       ".layer-control-opacity",
     ) as HTMLInputElement | null;
     if (opacity) {
-      opacity.value = String(this.basemapOpacity);
-      opacity.title = `Opacity: ${Math.round(this.basemapOpacity * 100)}%`;
+      opacity.value = String(state.opacity);
+      opacity.title = `Opacity: ${Math.round(state.opacity * 100)}%`;
+    }
+
+    const name = item.querySelector(".layer-control-name") as HTMLElement | null;
+    if (name) {
+      name.textContent = state.name;
+      name.title = state.name;
     }
   }
 

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -371,17 +371,18 @@ export class MapController {
   }
 
   syncLayers(layers: GeoLibreLayer[]): void {
-    if (!this.isStyleReady()) return;
+    if (!this.isStyleReady() || !this.map) return;
+    const map = this.map;
 
     const nextIds = layers.map((l) => l.id);
     for (const id of this.layerIds) {
       if (!nextIds.includes(id)) {
-        removeLayerFromMap(this.map, id);
+        removeLayerFromMap(map, id);
       }
     }
 
     for (const [index, layer] of layers.entries()) {
-      syncLayer(this.map, layer, this.getBeforeStyleLayerId(layers, index));
+      syncLayer(map, layer, this.getBeforeStyleLayerId(layers, index));
     }
     this.layerIds = nextIds;
     this.syncedLayers = layers;
@@ -417,11 +418,12 @@ export class MapController {
   }
 
   private applyBasemapVisibility(): void {
-    if (!this.isStyleReady()) return;
+    if (!this.isStyleReady() || !this.map) return;
+    const map = this.map;
 
     for (const layer of this.getBasemapStyleLayers()) {
       try {
-        this.map.setLayoutProperty(
+        map.setLayoutProperty(
           layer.id,
           "visibility",
           this.basemapVisible ? "visible" : "none",
@@ -444,7 +446,8 @@ export class MapController {
   }
 
   private getBasemapStyleLayers(): maplibregl.LayerSpecification[] {
-    if (!this.isStyleReady()) return [];
+    if (!this.isStyleReady() || !this.map) return [];
+    const map = this.map;
 
     const userStyleLayerIds = new Set(
       this.syncedLayers.flatMap((layer) =>
@@ -453,7 +456,7 @@ export class MapController {
     );
     const nonBasemapStyleLayerIds = new Set(NON_BASEMAP_STYLE_LAYER_IDS);
 
-    return (this.map.getStyle().layers ?? []).filter(
+    return (map.getStyle().layers ?? []).filter(
       (layer) =>
         !userStyleLayerIds.has(layer.id) &&
         !nonBasemapStyleLayerIds.has(layer.id),
@@ -582,13 +585,14 @@ export class MapController {
   }
 
   private syncHighlight(featureCollection: FeatureCollection): void {
-    if (!this.isStyleReady()) return;
+    if (!this.isStyleReady() || !this.map) return;
+    const map = this.map;
 
-    const source = this.map.getSource(highlightSourceId());
+    const source = map.getSource(highlightSourceId());
     if (source) {
       (source as maplibregl.GeoJSONSource).setData(featureCollection);
     } else {
-      this.map.addSource(highlightSourceId(), {
+      map.addSource(highlightSourceId(), {
         type: "geojson",
         data: featureCollection,
       });

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -32,6 +32,11 @@ const LAYER_CONTROL_EXCLUDED_LAYERS = [
   highlightLineLayerId(),
   highlightCircleLayerId(),
 ];
+const NON_BASEMAP_STYLE_LAYER_IDS = [
+  highlightFillLayerId(),
+  highlightLineLayerId(),
+  highlightCircleLayerId(),
+];
 const TERRAIN_SOURCE_ID = "geolibre-terrain-dem";
 const TERRAIN_SOURCE: maplibregl.RasterDEMSourceSpecification = {
   type: "raster-dem",
@@ -139,6 +144,7 @@ export class MapController {
   private layerControl: LayerControl | null = null;
   private layerControlSignature = "";
   private basemapStyleUrl = DEFAULT_BASEMAP;
+  private basemapVisible = true;
   private syncedLayers: GeoLibreLayer[] = [];
   private layerIds: string[] = [];
   private controlVisibility: Record<BuiltInMapControl, boolean> = {
@@ -171,11 +177,13 @@ export class MapController {
     this.map.on("style.load", () => {
       this.enforceDefaultProjection();
       this.addTerrainSource();
+      this.applyBasemapVisibility();
       this.addLayerControl();
     });
     this.map.once("load", () => {
       this.enforceDefaultProjection();
       this.addTerrainSource();
+      this.applyBasemapVisibility();
       this.addLayerControl();
     });
     this.map.once("idle", () => this.enforceDefaultProjection());
@@ -281,6 +289,11 @@ export class MapController {
     this.map.setStyle(resolveMapStyle(url));
   }
 
+  setBasemapVisible(visible: boolean): void {
+    this.basemapVisible = visible;
+    this.applyBasemapVisibility();
+  }
+
   applyView(view: MapViewState): void {
     if (!this.map) return;
     this.map.jumpTo({
@@ -331,6 +344,7 @@ export class MapController {
     }
     this.layerIds = nextIds;
     this.syncedLayers = layers;
+    this.applyBasemapVisibility();
     this.publishLayerDisplayNames(layers);
     this.refreshLayerControl(layers);
   }
@@ -353,6 +367,35 @@ export class MapController {
       this.map.once("load", run);
     }
     this.map.on("style.load", run);
+  }
+
+  private applyBasemapVisibility(): void {
+    if (!this.map || !this.map.isStyleLoaded()) return;
+
+    const userStyleLayerIds = new Set(
+      this.syncedLayers.flatMap((layer) =>
+        this.getCandidateStyleLayers(layer).map(({ id }) => id),
+      ),
+    );
+    const nonBasemapStyleLayerIds = new Set(NON_BASEMAP_STYLE_LAYER_IDS);
+
+    for (const layer of this.map.getStyle().layers ?? []) {
+      if (
+        userStyleLayerIds.has(layer.id) ||
+        nonBasemapStyleLayerIds.has(layer.id)
+      ) {
+        continue;
+      }
+      try {
+        this.map.setLayoutProperty(
+          layer.id,
+          "visibility",
+          this.basemapVisible ? "visible" : "none",
+        );
+      } catch {
+        // Some third-party custom style layers may not expose layout properties.
+      }
+    }
   }
 
   fitLayer(layer: GeoLibreLayer): void {
@@ -700,7 +743,7 @@ export class MapController {
   private getLayerSymbolType(layer: GeoLibreLayer): string {
     const nativeLayer = this.getNativeLayerIds(layer)
       .map((id) => this.map?.getLayer(id))
-      .find((item): item is maplibregl.LayerSpecification => Boolean(item));
+      .find((item) => Boolean(item));
 
     return nativeLayer?.type ?? "custom";
   }

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -37,6 +37,17 @@ const NON_BASEMAP_STYLE_LAYER_IDS = [
   highlightLineLayerId(),
   highlightCircleLayerId(),
 ];
+const OPACITY_PAINT_PROPERTIES: Record<string, string[]> = {
+  background: ["background-opacity"],
+  circle: ["circle-opacity"],
+  fill: ["fill-opacity"],
+  "fill-extrusion": ["fill-extrusion-opacity"],
+  heatmap: ["heatmap-opacity"],
+  hillshade: ["hillshade-exaggeration"],
+  line: ["line-opacity"],
+  raster: ["raster-opacity"],
+  symbol: ["icon-opacity", "text-opacity"],
+};
 const TERRAIN_SOURCE_ID = "geolibre-terrain-dem";
 const TERRAIN_SOURCE: maplibregl.RasterDEMSourceSpecification = {
   type: "raster-dem",
@@ -84,6 +95,20 @@ function resolveMapStyle(
 interface LayerControlConfig {
   excludeLayers?: string[];
   customLayerAdapters?: CustomLayerAdapter[];
+}
+
+interface LayerControlBackgroundState {
+  panel?: HTMLElement;
+  state?: {
+    layerStates?: Record<
+      string,
+      {
+        visible: boolean;
+        opacity: number;
+        name: string;
+      }
+    >;
+  };
 }
 
 interface GeoLibreLayerLabelWindow extends Window {
@@ -145,6 +170,8 @@ export class MapController {
   private layerControlSignature = "";
   private basemapStyleUrl = DEFAULT_BASEMAP;
   private basemapVisible = true;
+  private basemapOpacity = 1;
+  private basemapOriginalPaintValues = new Map<string, Map<string, unknown>>();
   private syncedLayers: GeoLibreLayer[] = [];
   private layerIds: string[] = [];
   private controlVisibility: Record<BuiltInMapControl, boolean> = {
@@ -178,12 +205,14 @@ export class MapController {
       this.enforceDefaultProjection();
       this.addTerrainSource();
       this.applyBasemapVisibility();
+      this.applyBasemapOpacity();
       this.addLayerControl();
     });
     this.map.once("load", () => {
       this.enforceDefaultProjection();
       this.addTerrainSource();
       this.applyBasemapVisibility();
+      this.applyBasemapOpacity();
       this.addLayerControl();
     });
     this.map.once("idle", () => this.enforceDefaultProjection());
@@ -285,6 +314,7 @@ export class MapController {
   setStyle(url: string): void {
     if (!this.map) return;
     this.basemapStyleUrl = url;
+    this.basemapOriginalPaintValues.clear();
     this.removeLayerControl();
     this.map.setStyle(resolveMapStyle(url));
   }
@@ -292,6 +322,13 @@ export class MapController {
   setBasemapVisible(visible: boolean): void {
     this.basemapVisible = visible;
     this.applyBasemapVisibility();
+    this.syncLayerControlBackgroundState();
+  }
+
+  setBasemapOpacity(opacity: number): void {
+    this.basemapOpacity = opacity;
+    this.applyBasemapOpacity();
+    this.syncLayerControlBackgroundState();
   }
 
   applyView(view: MapViewState): void {
@@ -345,6 +382,7 @@ export class MapController {
     this.layerIds = nextIds;
     this.syncedLayers = layers;
     this.applyBasemapVisibility();
+    this.applyBasemapOpacity();
     this.publishLayerDisplayNames(layers);
     this.refreshLayerControl(layers);
   }
@@ -372,20 +410,7 @@ export class MapController {
   private applyBasemapVisibility(): void {
     if (!this.map || !this.map.isStyleLoaded()) return;
 
-    const userStyleLayerIds = new Set(
-      this.syncedLayers.flatMap((layer) =>
-        this.getCandidateStyleLayers(layer).map(({ id }) => id),
-      ),
-    );
-    const nonBasemapStyleLayerIds = new Set(NON_BASEMAP_STYLE_LAYER_IDS);
-
-    for (const layer of this.map.getStyle().layers ?? []) {
-      if (
-        userStyleLayerIds.has(layer.id) ||
-        nonBasemapStyleLayerIds.has(layer.id)
-      ) {
-        continue;
-      }
+    for (const layer of this.getBasemapStyleLayers()) {
       try {
         this.map.setLayoutProperty(
           layer.id,
@@ -395,6 +420,63 @@ export class MapController {
       } catch {
         // Some third-party custom style layers may not expose layout properties.
       }
+    }
+  }
+
+  private applyBasemapOpacity(): void {
+    if (!this.map || !this.map.isStyleLoaded()) return;
+
+    for (const layer of this.getBasemapStyleLayers()) {
+      const properties = OPACITY_PAINT_PROPERTIES[layer.type] ?? [];
+      for (const property of properties) {
+        this.setBasemapPaintOpacity(layer.id, property);
+      }
+    }
+  }
+
+  private getBasemapStyleLayers(): maplibregl.LayerSpecification[] {
+    if (!this.map || !this.map.isStyleLoaded()) return [];
+
+    const userStyleLayerIds = new Set(
+      this.syncedLayers.flatMap((layer) =>
+        this.getCandidateStyleLayers(layer).map(({ id }) => id),
+      ),
+    );
+    const nonBasemapStyleLayerIds = new Set(NON_BASEMAP_STYLE_LAYER_IDS);
+
+    return (this.map.getStyle().layers ?? []).filter(
+      (layer) =>
+        !userStyleLayerIds.has(layer.id) &&
+        !nonBasemapStyleLayerIds.has(layer.id),
+    );
+  }
+
+  private setBasemapPaintOpacity(layerId: string, property: string): void {
+    if (!this.map) return;
+
+    let originalPaintValues = this.basemapOriginalPaintValues.get(layerId);
+    if (!originalPaintValues) {
+      originalPaintValues = new Map<string, unknown>();
+      this.basemapOriginalPaintValues.set(layerId, originalPaintValues);
+    }
+    if (!originalPaintValues.has(property)) {
+      originalPaintValues.set(
+        property,
+        this.map.getPaintProperty(layerId, property),
+      );
+    }
+
+    const original = originalPaintValues.get(property);
+    const opacity =
+      this.basemapOpacity >= 1
+        ? original
+        : typeof original === "number"
+          ? original * this.basemapOpacity
+          : this.basemapOpacity;
+    try {
+      this.map.setPaintProperty(layerId, property, opacity);
+    } catch {
+      // Some third-party custom style layers may not expose paint properties.
     }
   }
 
@@ -610,6 +692,8 @@ export class MapController {
       this.layerControl,
       this.controlPositions["layer-control"],
     );
+    this.syncLayerControlBackgroundState();
+    window.setTimeout(() => this.syncLayerControlBackgroundState(), 100);
     return true;
   }
 
@@ -676,6 +760,43 @@ export class MapController {
         }),
       ),
     });
+  }
+
+  private syncLayerControlBackgroundState(): void {
+    if (!this.layerControl) return;
+    const control = this.layerControl as unknown as LayerControlBackgroundState;
+
+    const backgroundState =
+      control.state?.layerStates?.Background ??
+      (control.state?.layerStates
+        ? (control.state.layerStates.Background = {
+            visible: this.basemapVisible,
+            opacity: this.basemapOpacity,
+            name: "Background",
+          })
+        : null);
+    if (backgroundState) {
+      backgroundState.visible = this.basemapVisible;
+      backgroundState.opacity = this.basemapOpacity;
+    }
+
+    const backgroundItem = control.panel?.querySelector(
+      '[data-layer-id="Background"]',
+    );
+    if (!backgroundItem) return;
+
+    const checkbox = backgroundItem.querySelector(
+      ".layer-control-checkbox",
+    ) as HTMLInputElement | null;
+    if (checkbox) checkbox.checked = this.basemapVisible;
+
+    const opacity = backgroundItem.querySelector(
+      ".layer-control-opacity",
+    ) as HTMLInputElement | null;
+    if (opacity) {
+      opacity.value = String(this.basemapOpacity);
+      opacity.title = `Opacity: ${Math.round(this.basemapOpacity * 100)}%`;
+    }
   }
 
   private createGeoLibreLayerAdapter(

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -1,4 +1,4 @@
-import { BLANK_BASEMAP, DEFAULT_BASEMAP } from "@geolibre/core";
+import { BLANK_BASEMAP, DEFAULT_BASEMAP, useAppStore } from "@geolibre/core";
 import type { GeoLibreLayer, MapViewState } from "@geolibre/core";
 import bbox from "@turf/bbox";
 import type { Feature, FeatureCollection, Geometry } from "geojson";
@@ -17,6 +17,7 @@ import {
   highlightLineLayerId,
   highlightSourceId,
   lineLayerId,
+  sourceId,
 } from "./geojson-loader";
 import { removeLayerFromMap, syncLayer } from "./layer-sync";
 
@@ -819,20 +820,15 @@ export class MapController {
         } satisfies LayerState;
       },
       setVisibility: (layerId, visible) => {
-        for (const nativeId of this.getNativeLayerIdsByLayerId(layerId)) {
-          this.map?.setLayoutProperty(
-            nativeId,
-            "visibility",
-            visible ? "visible" : "none",
-          );
-        }
+        // Update the store (the source of truth) and let the layer sync
+        // pass apply the visibility change to the map, so it is not undone
+        // by the next syncLayers.
+        useAppStore.getState().setLayerVisibility(layerId, visible);
       },
       setOpacity: (layerId, opacity) => {
-        const layer = layerById.get(layerId);
-        if (!layer) return;
-        for (const nativeId of this.getNativeLayerIds(layer)) {
-          this.setNativeLayerOpacity(nativeId, layer, opacity);
-        }
+        // Persist opacity to the layer model; syncLayer derives paint from
+        // layer.opacity, so updating the store keeps the map and UI in sync.
+        useAppStore.getState().setLayerOpacity(layerId, opacity);
       },
       getName: (layerId) => layerById.get(layerId)?.name ?? layerId,
       getSymbolType: (layerId) => {
@@ -841,11 +837,17 @@ export class MapController {
       },
       getBounds: (layerId) => {
         const layer = layerById.get(layerId);
-        return layer ? getLayerBounds(layer) : null;
+        if (!layer) return null;
+        // GeoJSON-backed layers derive bounds from their features; other
+        // layer types fall back to their source bounds (TileJSON) when
+        // advertised, and return null (no zoom-to-bounds) otherwise.
+        return getLayerBounds(layer) ?? this.getLayerSourceBounds(layer);
       },
       getNativeLayerIds: (layerId) => this.getNativeLayerIdsByLayerId(layerId),
       removeLayer: (layerId) => {
-        if (this.map) removeLayerFromMap(this.map, layerId);
+        // Remove the logical layer from the store; syncLayers then tears
+        // down the native sources/layers, keeping project state in sync.
+        useAppStore.getState().removeLayer(layerId);
       },
     };
   }
@@ -869,40 +871,21 @@ export class MapController {
     return nativeLayer?.type ?? "custom";
   }
 
-  private setNativeLayerOpacity(
-    nativeLayerId: string,
+  private getLayerSourceBounds(
     layer: GeoLibreLayer,
-    opacity: number,
-  ): void {
-    const nativeLayer = this.map?.getLayer(nativeLayerId);
-    if (!nativeLayer || !this.map) return;
-
-    if (nativeLayer.type === "fill") {
-      this.map.setPaintProperty(
-        nativeLayerId,
-        "fill-opacity",
-        layer.style.fillOpacity * opacity,
-      );
-      return;
+  ): [number, number, number, number] | null {
+    const source = this.map?.getSource(sourceId(layer.id)) as
+      | { bounds?: [number, number, number, number] }
+      | undefined;
+    const bounds = source?.bounds;
+    if (
+      Array.isArray(bounds) &&
+      bounds.length === 4 &&
+      bounds.every((value) => Number.isFinite(value))
+    ) {
+      return bounds;
     }
-
-    if (nativeLayer.type === "line") {
-      this.map.setPaintProperty(nativeLayerId, "line-opacity", opacity);
-      return;
-    }
-
-    if (nativeLayer.type === "circle") {
-      this.map.setPaintProperty(
-        nativeLayerId,
-        "circle-opacity",
-        layer.style.fillOpacity * opacity,
-      );
-      return;
-    }
-
-    if (nativeLayer.type === "raster") {
-      this.map.setPaintProperty(nativeLayerId, "raster-opacity", opacity);
-    }
+    return null;
   }
 
   private getNamedStyleLayers(layer: GeoLibreLayer): Array<{

--- a/sample-data/example.geolibre.json
+++ b/sample-data/example.geolibre.json
@@ -9,6 +9,7 @@
   },
   "basemapStyleUrl": "https://tiles.openfreemap.org/styles/liberty",
   "basemapVisible": true,
+  "basemapOpacity": 1,
   "layers": [],
   "styles": {},
   "metadata": {

--- a/sample-data/example.geolibre.json
+++ b/sample-data/example.geolibre.json
@@ -8,6 +8,7 @@
     "pitch": 0
   },
   "basemapStyleUrl": "https://tiles.openfreemap.org/styles/liberty",
+  "basemapVisible": true,
   "layers": [],
   "styles": {},
   "metadata": {


### PR DESCRIPTION
## Summary
- Integrate the layer control through a single GeoLibre custom layer adapter that drives visibility, opacity, bounds, name, symbol type, and removal on logical GeoLibre layers, with symbol-aware opacity for fill, line, circle, and raster types.
- Add a Background (basemap) visibility toggle, persisted as `basemapVisible` in the project format and app store, wired through the map canvas and controller.
- Add drag-and-drop layer reordering in the layer panel, backed by a new `moveLayer` store action.
- Update the project format docs and sample project for the new `basemapVisible` field.

## Test plan
- [ ] `pre-commit run --all-files` passes (includes `npm run build`)
- [ ] Layer control lists each GeoLibre layer once; visibility/opacity toggles work for vector and raster layers
- [ ] Background toggle shows/hides the basemap and round-trips through save/load
- [ ] Drag-and-drop reorders layers and updates draw order on the map