### PR TITLE
feat: add Flatgeobuf vector layer via AddVectorControl

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -4,7 +4,10 @@ import {
   DEFAULT_BUILT_IN_CONTROL_VISIBILITY,
   type MapController,
 } from "@geolibre/map";
-import type { GeoLibreMapControlPosition } from "@geolibre/plugins";
+import {
+  openFlatGeobufAddVectorLayerPanel,
+  type GeoLibreMapControlPosition,
+} from "@geolibre/plugins";
 import {
   Button,
   DropdownMenu,
@@ -133,6 +136,9 @@ export function TopToolbar({
     setMapControlPosition,
   } = usePluginRegistry();
   const appApi = createAppAPI(mapControllerRef);
+  const handleAddFlatGeobufLayer = () => {
+    openFlatGeobufAddVectorLayerPanel(appApi);
+  };
   const toggleMapControl = (control: ToolbarMapControl) => {
     setControlsVisible((current) => {
       const visible = !current[control];
@@ -176,6 +182,9 @@ export function TopToolbar({
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => setAddDataKind("vector")}>
             Add Vector Layer
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={handleAddFlatGeobufLayer}>
+            Add Flatgeobuf Layer
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => setAddDataKind("raster")}>
             Add Raster Layer

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -184,7 +184,7 @@ export function TopToolbar({
             Add Vector Layer
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={handleAddFlatGeobufLayer}>
-            Add Flatgeobuf Layer
+            Add FlatGeobuf Layer
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => setAddDataKind("raster")}>
             Add Raster Layer

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -48,6 +48,13 @@ function layerTypeLabel(layer: GeoLibreLayer): string {
   return layer.type;
 }
 
+function hasNativeIdentifyLayers(layer: GeoLibreLayer): boolean {
+  return (
+    Array.isArray(layer.metadata.nativeLayerIds) &&
+    layer.metadata.nativeLayerIds.length > 0
+  );
+}
+
 function isMobileViewport(): boolean {
   return (
     typeof window !== "undefined" &&
@@ -211,7 +218,9 @@ export function LayerPanel({
           )}
           {visibleLayers.map((layer, displayIndex) => {
             const canIdentify =
-              layer.type === "geojson" || layer.type === "vector-tiles";
+              layer.type === "geojson" ||
+              layer.type === "vector-tiles" ||
+              hasNativeIdentifyLayers(layer);
             const identifyActive = identifyLayerId === layer.id;
             return (
               <div

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -32,6 +32,13 @@ function isRasterPaintLayer(type: LayerType): boolean {
   return type === "raster" || type === "wms" || type === "xyz";
 }
 
+function hasExternalNativeLayers(layer: { metadata: Record<string, unknown> }) {
+  return (
+    Array.isArray(layer.metadata.nativeLayerIds) &&
+    layer.metadata.nativeLayerIds.length > 0
+  );
+}
+
 function styleValue<K extends keyof LayerStyle>(
   style: LayerStyle,
   key: K,
@@ -224,7 +231,9 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
 
   const { style } = layer;
   const hasVectorPaintControls =
-    layer.type === "geojson" || layer.type === "vector-tiles";
+    layer.type === "geojson" ||
+    layer.type === "vector-tiles" ||
+    hasExternalNativeLayers(layer);
   const hasRasterPaintControls = isRasterPaintLayer(layer.type);
 
   if (hasRasterPaintControls) {

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -178,6 +178,95 @@ body,
   max-width: min(340px, calc(100vw - 32px)) !important;
 }
 
+.geolibre-flatgeobuf-control {
+  background-color: hsl(var(--popover)) !important;
+  color: hsl(var(--popover-foreground)) !important;
+  overflow: visible;
+}
+
+.geolibre-flatgeobuf-control .maplibre-gl-add-vector-button {
+  display: none !important;
+}
+
+.geolibre-flatgeobuf-control .maplibre-gl-add-vector-panel {
+  background-color: hsl(var(--popover)) !important;
+  border: 1px solid hsl(var(--border));
+  box-shadow: 0 12px 32px rgb(0 0 0 / 0.28);
+  color: hsl(var(--popover-foreground)) !important;
+}
+
+.geolibre-flatgeobuf-control .maplibre-gl-add-vector-header {
+  border-bottom-color: hsl(var(--border)) !important;
+}
+
+.geolibre-flatgeobuf-control .maplibre-gl-add-vector-title,
+.geolibre-flatgeobuf-control .maplibre-gl-add-vector-form-group label,
+.geolibre-flatgeobuf-control .maplibre-gl-add-vector-checkbox-label,
+.geolibre-flatgeobuf-control .maplibre-gl-add-vector-slider-value,
+.geolibre-flatgeobuf-control .maplibre-gl-add-vector-list-header,
+.geolibre-flatgeobuf-control .maplibre-gl-add-vector-list-label {
+  color: hsl(var(--popover-foreground)) !important;
+}
+
+.geolibre-flatgeobuf-control .maplibre-gl-add-vector-close,
+.geolibre-flatgeobuf-control .maplibre-gl-add-vector-list-remove {
+  color: hsl(var(--muted-foreground)) !important;
+}
+
+.geolibre-flatgeobuf-control .maplibre-gl-add-vector-close:hover,
+.geolibre-flatgeobuf-control .maplibre-gl-add-vector-list-remove:hover {
+  color: hsl(var(--foreground)) !important;
+}
+
+.geolibre-flatgeobuf-control .maplibre-gl-add-vector-input,
+.geolibre-flatgeobuf-control .maplibre-gl-add-vector-select,
+.geolibre-flatgeobuf-control .maplibre-gl-add-vector-textarea,
+.geolibre-flatgeobuf-control .maplibre-gl-add-vector-minzoom-input {
+  background-color: hsl(var(--background)) !important;
+  border: 1px solid hsl(var(--input)) !important;
+  color: hsl(var(--foreground)) !important;
+}
+
+.geolibre-flatgeobuf-control .maplibre-gl-add-vector-input::placeholder,
+.geolibre-flatgeobuf-control .maplibre-gl-add-vector-textarea::placeholder {
+  color: hsl(var(--muted-foreground)) !important;
+}
+
+.geolibre-flatgeobuf-control .maplibre-gl-add-vector-input:focus,
+.geolibre-flatgeobuf-control .maplibre-gl-add-vector-select:focus,
+.geolibre-flatgeobuf-control .maplibre-gl-add-vector-textarea:focus,
+.geolibre-flatgeobuf-control .maplibre-gl-add-vector-minzoom-input:focus {
+  border-color: hsl(var(--ring)) !important;
+  box-shadow: 0 0 0 1px hsl(var(--ring));
+  outline: none;
+}
+
+.geolibre-flatgeobuf-control .maplibre-gl-add-vector-select option {
+  background-color: hsl(var(--popover));
+  color: hsl(var(--popover-foreground));
+}
+
+.geolibre-flatgeobuf-control .maplibre-gl-add-vector-format-hint {
+  color: hsl(var(--muted-foreground)) !important;
+}
+
+.geolibre-flatgeobuf-control .maplibre-gl-add-vector-mode-btn {
+  background-color: hsl(var(--secondary)) !important;
+  border-color: hsl(var(--border)) !important;
+  color: hsl(var(--secondary-foreground)) !important;
+}
+
+.geolibre-flatgeobuf-control .maplibre-gl-add-vector-mode-btn--active,
+.geolibre-flatgeobuf-control .maplibre-gl-add-vector-btn--primary {
+  background-color: hsl(var(--primary)) !important;
+  border-color: hsl(var(--primary)) !important;
+  color: hsl(var(--primary-foreground)) !important;
+}
+
+.geolibre-flatgeobuf-control .maplibre-gl-add-vector-slider {
+  accent-color: hsl(var(--primary));
+}
+
 .maplibregl-ctrl-top-left
   .geolibre-components-control
   .maplibre-gl-control-grid-relocated,

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -73,12 +73,20 @@ function createIdentifyPopupElement(
   return root;
 }
 
-function identifyStyleLayerIds(layerId: string): string[] {
+function nativeIdentifyLayerIds(layer: GeoLibreLayer): string[] {
+  const nativeLayerIds = layer.metadata.nativeLayerIds;
+  return Array.isArray(nativeLayerIds)
+    ? nativeLayerIds.filter((id): id is string => typeof id === "string")
+    : [];
+}
+
+function identifyStyleLayerIds(layer: GeoLibreLayer): string[] {
   return [
-    circleLayerId(layerId),
-    lineLayerId(layerId),
-    fillLayerId(layerId),
-    `layer-${layerId}-vector`,
+    ...nativeIdentifyLayerIds(layer),
+    circleLayerId(layer.id),
+    lineLayerId(layer.id),
+    fillLayerId(layer.id),
+    `layer-${layer.id}-vector`,
   ];
 }
 
@@ -276,7 +284,7 @@ export const MapCanvas = memo(function MapCanvas({
         identifyPopup.current = null;
       };
 
-      const queryLayerIds = identifyStyleLayerIds(layer.id).filter((id) =>
+      const queryLayerIds = identifyStyleLayerIds(layer).filter((id) =>
         map.getLayer(id),
       );
       if (queryLayerIds.length === 0) {

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -43,10 +43,7 @@ export function syncLayer(
 }
 
 function isExternalNativeLayer(layer: GeoLibreLayer): boolean {
-  return (
-    Array.isArray(layer.metadata.nativeLayerIds) &&
-    layer.metadata.nativeLayerIds.length > 0
-  );
+  return getExternalNativeLayerIds(layer).length > 0;
 }
 
 function syncExternalNativeLayer(

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -11,12 +11,16 @@ import { isPlaceholderLayer } from "./placeholders";
 import { circlePaint, fillPaint, linePaint, rasterPaint } from "./style-mapper";
 
 const WMS_PROXY_PATH = "/__geolibre_wms_proxy";
-
 export function syncLayer(
   map: maplibregl.Map,
   layer: GeoLibreLayer,
   beforeId?: string,
 ): void {
+  if (isExternalNativeLayer(layer)) {
+    syncExternalNativeLayer(map, layer, beforeId);
+    return;
+  }
+
   if (isPlaceholderLayer(layer)) return;
 
   if (layer.type === "geojson" && layer.geojson) {
@@ -35,6 +39,64 @@ export function syncLayer(
 
   if (layer.type === "vector-tiles") {
     syncVectorTileLayer(map, layer, beforeId);
+  }
+}
+
+function isExternalNativeLayer(layer: GeoLibreLayer): boolean {
+  return (
+    Array.isArray(layer.metadata.nativeLayerIds) &&
+    layer.metadata.nativeLayerIds.length > 0
+  );
+}
+
+function syncExternalNativeLayer(
+  map: maplibregl.Map,
+  layer: GeoLibreLayer,
+  beforeId?: string,
+): void {
+  const nativeLayerIds = getExternalNativeLayerIds(layer);
+  for (const nativeLayerId of nativeLayerIds) {
+    const nativeLayer = map.getLayer(nativeLayerId);
+    if (!nativeLayer) continue;
+
+    map.setLayoutProperty(
+      nativeLayerId,
+      "visibility",
+      layer.visible ? "visible" : "none",
+    );
+
+    setExternalNativeLayerPaint(map, nativeLayerId, nativeLayer.type, layer);
+
+    moveLayer(map, nativeLayerId, beforeId);
+  }
+}
+
+function setExternalNativeLayerPaint(
+  map: maplibregl.Map,
+  nativeLayerId: string,
+  nativeLayerType: string,
+  layer: GeoLibreLayer,
+): void {
+  const paint =
+    nativeLayerType === "fill"
+      ? fillPaint(layer.style, layer.opacity)
+      : nativeLayerType === "line"
+        ? linePaint(layer.style, layer.opacity)
+        : nativeLayerType === "circle"
+          ? circlePaint(layer.style, layer.opacity)
+          : nativeLayerType === "raster"
+            ? rasterPaint(layer.style, layer.opacity)
+            : null;
+
+  if (!paint) return;
+
+  for (const [property, value] of Object.entries(paint)) {
+    try {
+      map.setPaintProperty(nativeLayerId, property, value);
+    } catch {
+      // External controls can create heterogeneous style layers. Ignore paint
+      // properties that do not apply to a specific native layer type.
+    }
   }
 }
 
@@ -260,8 +322,10 @@ function moveLayer(
 export function removeLayerFromMap(
   map: maplibregl.Map,
   layerId: string,
+  layer?: GeoLibreLayer,
 ): void {
   for (const id of [
+    ...getExternalNativeLayerIds(layer),
     fillLayerId(layerId),
     lineLayerId(layerId),
     circleLayerId(layerId),
@@ -270,6 +334,20 @@ export function removeLayerFromMap(
   ]) {
     if (map.getLayer(id)) map.removeLayer(id);
   }
-  const src = sourceId(layerId);
-  if (map.getSource(src)) map.removeSource(src);
+  for (const src of [getExternalSourceId(layer), sourceId(layerId)]) {
+    if (src && map.getSource(src)) map.removeSource(src);
+  }
+}
+
+function getExternalNativeLayerIds(layer?: GeoLibreLayer): string[] {
+  const nativeLayerIds = layer?.metadata.nativeLayerIds;
+  return Array.isArray(nativeLayerIds)
+    ? nativeLayerIds.filter((id): id is string => typeof id === "string")
+    : [];
+}
+
+function getExternalSourceId(layer?: GeoLibreLayer): string | undefined {
+  return typeof layer?.metadata.sourceId === "string"
+    ? layer.metadata.sourceId
+    : undefined;
 }

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -70,6 +70,12 @@ const EMPTY_HIGHLIGHT: FeatureCollection = {
   features: [],
 };
 
+function nativeLayerSuffix(layerId: string): string | undefined {
+  const suffix = layerId.split("-").pop();
+  if (!suffix) return undefined;
+  return suffix.charAt(0).toUpperCase() + suffix.slice(1);
+}
+
 function createBlankMapStyle(): maplibregl.StyleSpecification {
   return {
     version: 8,
@@ -377,7 +383,11 @@ export class MapController {
     const nextIds = layers.map((l) => l.id);
     for (const id of this.layerIds) {
       if (!nextIds.includes(id)) {
-        removeLayerFromMap(map, id);
+        removeLayerFromMap(
+          map,
+          id,
+          this.syncedLayers.find((layer) => layer.id === id),
+        );
       }
     }
 
@@ -1011,6 +1021,13 @@ export class MapController {
     id: string;
     suffix?: string;
   }> {
+    const nativeLayerIds = layer.metadata.nativeLayerIds;
+    if (Array.isArray(nativeLayerIds) && nativeLayerIds.length > 0) {
+      return nativeLayerIds
+        .filter((id): id is string => typeof id === "string")
+        .map((id) => ({ id, suffix: nativeLayerSuffix(id) }));
+    }
+
     if (layer.type === "geojson") {
       return [
         { id: fillLayerId(layer.id), suffix: "Polygons" },

--- a/packages/map/src/placeholders.ts
+++ b/packages/map/src/placeholders.ts
@@ -10,6 +10,13 @@ export const PLACEHOLDER_LAYER_TYPES = new Set([
 ]);
 
 export function isPlaceholderLayer(layer: GeoLibreLayer): boolean {
+  if (
+    Array.isArray(layer.metadata.nativeLayerIds) &&
+    layer.metadata.nativeLayerIds.length > 0
+  ) {
+    return false;
+  }
+
   return (
     PLACEHOLDER_LAYER_TYPES.has(layer.type) ||
     layer.metadata.placeholder === true

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -4,7 +4,10 @@ export { maplibreLayerControlPlugin } from "./plugins/layer-control";
 export { osmBasemapPlugin } from "./plugins/osm-basemap";
 export { cartoLightPlugin } from "./plugins/carto-light";
 export { maplibreBasemapControlPlugin } from "./plugins/maplibre-basemap-control";
-export { maplibreComponentsPlugin } from "./plugins/maplibre-components";
+export {
+  maplibreComponentsPlugin,
+  openFlatGeobufAddVectorLayerPanel,
+} from "./plugins/maplibre-components";
 export { maplibreGeoEditorPlugin } from "./plugins/maplibre-geo-editor";
 export { maplibreGeoAgentPlugin } from "./plugins/maplibre-geoagent";
 export { maplibreLidarPlugin } from "./plugins/maplibre-lidar";

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -1,4 +1,13 @@
+import {
+  DEFAULT_LAYER_STYLE,
+  type GeoLibreLayer,
+  useAppStore,
+} from "@geolibre/core";
 import type {
+  AddVectorControl,
+  AddVectorEventHandler,
+  AddVectorLayerInfo,
+  AddVectorControlOptions,
   ControlGrid,
   ControlGridOptions,
   DefaultControlName,
@@ -11,8 +20,19 @@ import type {
 
 type ControlGridConstructor =
   (typeof import("maplibre-gl-components"))["ControlGrid"];
+type AddVectorControlConstructor =
+  (typeof import("maplibre-gl-components"))["AddVectorControl"];
+
+interface ComponentsConstructors {
+  AddVectorControl: AddVectorControlConstructor;
+  ControlGrid: ControlGridConstructor;
+}
 
 let componentsControlPosition: GeoLibreMapControlPosition = "top-right";
+const flatGeobufControlPosition: GeoLibreMapControlPosition = "top-left";
+
+const FLATGEOBUF_SAMPLE_URL =
+  "https://flatgeobuf.org/test/data/UScounties.fgb";
 
 const COMPONENT_CONTROL_NAMES = [
   "spinGlobe",
@@ -61,23 +81,42 @@ const COMPONENTS_OPTIONS = {
   showRowColumnControls: true,
 } satisfies Omit<ControlGridOptions, "position" | "basemapStyleUrl">;
 
+const ADD_VECTOR_OPTIONS = {
+  backgroundColor: "hsl(var(--popover))",
+  className: "geolibre-flatgeobuf-control",
+  collapsed: false,
+  defaultFormat: "flatgeobuf",
+  defaultPickable: false,
+  defaultUrl: FLATGEOBUF_SAMPLE_URL,
+  fontColor: "hsl(var(--popover-foreground))",
+} satisfies AddVectorControlOptions;
+
 let componentsControl: ControlGrid | null = null;
+let flatGeobufControl: AddVectorControl | null = null;
+let flatGeobufControlMounted = false;
+let flatGeobufStoreUnsubscribe: (() => void) | null = null;
 let pluginActive = false;
 let componentsControlRevision = 0;
-let controlGridConstructorPromise: Promise<ControlGridConstructor> | null =
+let componentsConstructorsPromise: Promise<ComponentsConstructors> | null =
   null;
 
-const getControlGridConstructor = (): Promise<ControlGridConstructor> => {
-  controlGridConstructorPromise ??= import(
-    "maplibre-gl-components"
-  ).then(({ ControlGrid: ControlGridClass }) => ControlGridClass);
-  return controlGridConstructorPromise;
+const getComponentsConstructors = (): Promise<ComponentsConstructors> => {
+  componentsConstructorsPromise ??= import("maplibre-gl-components").then(
+    ({
+      AddVectorControl: AddVectorControlClass,
+      ControlGrid: ControlGridClass,
+    }) => ({
+      AddVectorControl: AddVectorControlClass,
+      ControlGrid: ControlGridClass,
+    }),
+  );
+  return componentsConstructorsPromise;
 };
 
 const createComponentsControl = async (
   app: GeoLibreAppAPI,
 ): Promise<ControlGrid | null> => {
-  const ControlGridClass = await getControlGridConstructor();
+  const { ControlGrid: ControlGridClass } = await getComponentsConstructors();
   if (!pluginActive) return null;
   return new ControlGridClass(getComponentsOptions(app));
 };
@@ -141,6 +180,12 @@ export const maplibreComponentsPlugin: GeoLibrePlugin = {
   },
 };
 
+export function openFlatGeobufAddVectorLayerPanel(
+  app: GeoLibreAppAPI,
+): void {
+  void openStandaloneFlatGeobufControl(app);
+}
+
 function getComponentsOptions(
   app: GeoLibreAppAPI,
 ): ControlGridOptions {
@@ -149,4 +194,139 @@ function getComponentsOptions(
     basemapStyleUrl: app.getActiveBasemap(),
     position: componentsControlPosition,
   };
+}
+
+async function openStandaloneFlatGeobufControl(
+  app: GeoLibreAppAPI,
+): Promise<boolean> {
+  const { AddVectorControl: AddVectorControlClass } =
+    await getComponentsConstructors();
+
+  flatGeobufControl ??= createFlatGeobufControl(AddVectorControlClass);
+
+  if (!flatGeobufControlMounted) {
+    const added = app.addMapControl(
+      flatGeobufControl,
+      flatGeobufControlPosition,
+    );
+    if (!added) {
+      flatGeobufControl = null;
+      return false;
+    }
+    flatGeobufControlMounted = true;
+  }
+
+  setTimeout(() => {
+    flatGeobufControl?.show();
+    flatGeobufControl?.expand();
+  }, 0);
+  return true;
+}
+
+function createFlatGeobufControl(
+  AddVectorControlClass: AddVectorControlConstructor,
+): AddVectorControl {
+  const control = new AddVectorControlClass(ADD_VECTOR_OPTIONS);
+  control.on("collapse", () => control.hide());
+  control.on("layeradd", createFlatGeobufLayerAddHandler(control));
+  control.on("layerremove", (event) => {
+    if (!event.layerId) return;
+    const store = useAppStore.getState();
+    if (store.layers.some((layer) => layer.id === event.layerId)) {
+      store.removeLayer(event.layerId);
+    }
+  });
+  flatGeobufStoreUnsubscribe ??= useAppStore.subscribe((state, previous) => {
+    const removedLayers = previous.layers.filter(
+      (layer) =>
+        isFlatGeobufControlLayer(layer) &&
+        !state.layers.some((current) => current.id === layer.id),
+    );
+    for (const layer of removedLayers) {
+      flatGeobufControl?.removeLayer(layer.id);
+    }
+  });
+  return control;
+}
+
+function createFlatGeobufLayerAddHandler(
+  control: AddVectorControl,
+): AddVectorEventHandler {
+  return (event) => {
+    if (!event.layerId) return;
+    const layerInfo = event.state.layers.find(
+      (layer) => layer.id === event.layerId,
+    );
+    if (!layerInfo) return;
+
+    const store = useAppStore.getState();
+    const layer = createFlatGeobufStoreLayer(event.layerId, layerInfo, control);
+    if (store.layers.some((item) => item.id === layer.id)) {
+      store.updateLayer(layer.id, {
+        metadata: layer.metadata,
+        opacity: layer.opacity,
+        source: layer.source,
+        visible: layer.visible,
+      });
+      return;
+    }
+    store.addLayer(layer);
+  };
+}
+
+function createFlatGeobufStoreLayer(
+  id: string,
+  layerInfo: AddVectorLayerInfo,
+  control: AddVectorControl,
+): GeoLibreLayer {
+  const nativeLayerIds = control
+    .getLayerIds()
+    .filter((layerId) => layerInfo.layerIds.includes(layerId));
+  const url = layerInfo.url;
+
+  return {
+    id,
+    name: layerNameFromUrl(url, id),
+    type: "flatgeobuf",
+    source: {
+      type: "geojson",
+      url,
+      sourceId: layerInfo.sourceId,
+    },
+    visible: true,
+    opacity: layerInfo.opacity,
+    style: {
+      ...DEFAULT_LAYER_STYLE,
+      fillOpacity: 1,
+      fillColor: layerInfo.fillColor,
+      strokeColor: layerInfo.strokeColor,
+    },
+    metadata: {
+      externalNativeLayer: true,
+      featureCount: layerInfo.featureCount,
+      format: layerInfo.format,
+      geometryTypes: layerInfo.geometryTypes,
+      nativeLayerIds,
+      sourceId: layerInfo.sourceId,
+      sourceKind: "flatgeobuf-url",
+    },
+    sourcePath: url,
+  };
+}
+
+function isFlatGeobufControlLayer(layer: GeoLibreLayer): boolean {
+  return (
+    layer.type === "flatgeobuf" &&
+    layer.metadata.sourceKind === "flatgeobuf-url" &&
+    layer.metadata.externalNativeLayer === true
+  );
+}
+
+function layerNameFromUrl(url: string, fallback: string): string {
+  try {
+    const fileName = new URL(url).pathname.split("/").pop() ?? fallback;
+    return fileName.replace(/\.[^.]+$/, "") || fallback;
+  } catch {
+    return fallback;
+  }
 }

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -163,6 +163,7 @@ export const maplibreComponentsPlugin: GeoLibrePlugin = {
   deactivate: (app: GeoLibreAppAPI) => {
     pluginActive = false;
     componentsControlRevision += 1;
+    teardownFlatGeobufControl(app);
     if (!componentsControl) return;
     app.removeMapControl(componentsControl);
     componentsControl = null;
@@ -247,6 +248,16 @@ function createFlatGeobufControl(
     }
   });
   return control;
+}
+
+function teardownFlatGeobufControl(app: GeoLibreAppAPI): void {
+  flatGeobufStoreUnsubscribe?.();
+  flatGeobufStoreUnsubscribe = null;
+  if (flatGeobufControl && flatGeobufControlMounted) {
+    app.removeMapControl(flatGeobufControl);
+  }
+  flatGeobufControl = null;
+  flatGeobufControlMounted = false;
 }
 
 function createFlatGeobufLayerAddHandler(


### PR DESCRIPTION
## Summary
- Add an "Add Flatgeobuf Layer" toolbar entry that opens the maplibre-gl-components AddVectorControl, letting users load remote Flatgeobuf URLs onto the map.
- Manage these externally created native map layers through `metadata.nativeLayerIds`, so layer sync, removal, identify, and the style panel treat them like first-class layers.
- Style the AddVectorControl panel to match the app theme.

## Test plan
- [ ] Open the Add Data menu and choose "Add Flatgeobuf Layer"; confirm the panel opens themed correctly.
- [ ] Load the sample Flatgeobuf URL and verify the layer renders on the map.
- [ ] Toggle visibility, adjust opacity/colors in the Style panel, and confirm the native layers update.
- [ ] Use Identify on the loaded layer and confirm features are queried.
- [ ] Remove the layer from the Layer panel and confirm its native layers and source are cleaned up.