### PR TITLE
feat: add Zarr layer support via ZarrLayerControl

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -7,6 +7,7 @@ import {
 import {
   openFlatGeobufAddVectorLayerPanel,
   openPMTilesLayerPanel,
+  openZarrLayerPanel,
   type GeoLibreMapControlPosition,
 } from "@geolibre/plugins";
 import {
@@ -143,6 +144,9 @@ export function TopToolbar({
   const handleAddPMTilesLayer = () => {
     openPMTilesLayerPanel(appApi);
   };
+  const handleAddZarrLayer = () => {
+    openZarrLayerPanel(appApi);
+  };
   const toggleMapControl = (control: ToolbarMapControl) => {
     setControlsVisible((current) => {
       const visible = !current[control];
@@ -192,6 +196,9 @@ export function TopToolbar({
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={handleAddPMTilesLayer}>
             Add PMTiles Layer
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={handleAddZarrLayer}>
+            Add Zarr Layer
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => setAddDataKind("raster")}>
             Add Raster Layer

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -49,6 +49,8 @@ function layerTypeLabel(layer: GeoLibreLayer): string {
 }
 
 function hasNativeIdentifyLayers(layer: GeoLibreLayer): boolean {
+  if (layer.metadata.identifiable === false) return false;
+
   return (
     Array.isArray(layer.metadata.nativeLayerIds) &&
     layer.metadata.nativeLayerIds.length > 0

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -405,6 +405,8 @@ body,
   .maplibre-gl-zarr-layer-input[type="number"]::-webkit-outer-spin-button {
   cursor: pointer;
   opacity: 1;
+  transform: scale(1.15);
+  transform-origin: center;
 }
 
 .geolibre-zarr-control .maplibre-gl-zarr-layer-input:focus,

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -405,7 +405,7 @@ body,
   .maplibre-gl-zarr-layer-input[type="number"]::-webkit-outer-spin-button {
   cursor: pointer;
   opacity: 1;
-  transform: scale(1.15);
+  transform: scale(1.3);
   transform-origin: center;
 }
 

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -404,11 +404,7 @@ body,
 .geolibre-zarr-control
   .maplibre-gl-zarr-layer-input[type="number"]::-webkit-outer-spin-button {
   cursor: pointer;
-  height: 1.75rem;
   opacity: 1;
-  transform: scale(1.45);
-  transform-origin: center;
-  width: 1.125rem;
 }
 
 .geolibre-zarr-control .maplibre-gl-zarr-layer-input:focus,

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -314,6 +314,146 @@ body,
   color: hsl(var(--destructive)) !important;
 }
 
+.geolibre-zarr-control {
+  background-color: hsl(var(--popover)) !important;
+  color: hsl(var(--popover-foreground)) !important;
+  overflow: visible;
+}
+
+.geolibre-zarr-control .maplibre-gl-zarr-layer-button {
+  display: none !important;
+}
+
+.geolibre-zarr-control .maplibre-gl-zarr-layer-panel {
+  background-color: hsl(var(--popover)) !important;
+  border: 1px solid hsl(var(--border));
+  box-shadow: 0 12px 32px rgb(0 0 0 / 0.28);
+  color: hsl(var(--popover-foreground)) !important;
+  max-width: min(340px, calc(100vw - 32px));
+}
+
+.geolibre-zarr-control .maplibre-gl-zarr-layer-header {
+  background-color: hsl(var(--card)) !important;
+  border-bottom-color: hsl(var(--border)) !important;
+  color: hsl(var(--foreground)) !important;
+}
+
+.geolibre-zarr-control .maplibre-gl-zarr-layer-title,
+.geolibre-zarr-control .maplibre-gl-zarr-layer-form-group > label,
+.geolibre-zarr-control .maplibre-gl-zarr-layer-checkbox-label,
+.geolibre-zarr-control .maplibre-gl-zarr-layer-slider-value,
+.geolibre-zarr-control .maplibre-gl-zarr-layer-list-header,
+.geolibre-zarr-control .maplibre-gl-zarr-layer-list-label {
+  color: hsl(var(--foreground)) !important;
+}
+
+.geolibre-zarr-control .maplibre-gl-zarr-layer-close,
+.geolibre-zarr-control .maplibre-gl-zarr-layer-list-remove {
+  color: hsl(var(--muted-foreground)) !important;
+}
+
+.geolibre-zarr-control .maplibre-gl-zarr-layer-close:hover,
+.geolibre-zarr-control .maplibre-gl-zarr-layer-list-remove:hover {
+  background-color: hsl(var(--accent)) !important;
+  color: hsl(var(--accent-foreground)) !important;
+}
+
+.geolibre-zarr-control .maplibre-gl-zarr-layer-list {
+  background-color: hsl(var(--card)) !important;
+  border-color: hsl(var(--border)) !important;
+  color: hsl(var(--foreground)) !important;
+}
+
+.geolibre-zarr-control .maplibre-gl-zarr-layer-list-item {
+  border-bottom-color: hsl(var(--border)) !important;
+  color: hsl(var(--foreground)) !important;
+}
+
+.geolibre-zarr-control .maplibre-gl-zarr-layer-input,
+.geolibre-zarr-control .maplibre-gl-zarr-layer-select {
+  background-color: hsl(var(--background)) !important;
+  border: 1px solid hsl(var(--input)) !important;
+  color: hsl(var(--foreground)) !important;
+}
+
+.geolibre-zarr-control .maplibre-gl-zarr-layer-select {
+  appearance: none;
+  background-image:
+    linear-gradient(45deg, transparent 50%, hsl(var(--foreground)) 50%),
+    linear-gradient(135deg, hsl(var(--foreground)) 50%, transparent 50%);
+  background-position:
+    calc(100% - 14px) 50%,
+    calc(100% - 9px) 50%;
+  background-repeat: no-repeat;
+  background-size: 5px 5px;
+  color-scheme: light dark;
+  padding-right: 2rem !important;
+}
+
+.geolibre-zarr-control .maplibre-gl-zarr-layer-input::placeholder {
+  color: hsl(var(--muted-foreground)) !important;
+}
+
+.geolibre-zarr-control .maplibre-gl-zarr-layer-input[type="number"] {
+  min-height: 2rem;
+  padding-right: 0.5rem !important;
+}
+
+.geolibre-zarr-control
+  .maplibre-gl-zarr-layer-input[type="number"]::-webkit-inner-spin-button,
+.geolibre-zarr-control
+  .maplibre-gl-zarr-layer-input[type="number"]::-webkit-outer-spin-button {
+  cursor: pointer;
+  height: 1.75rem;
+  opacity: 1;
+  transform: scale(1.45);
+  transform-origin: center;
+  width: 1.125rem;
+}
+
+.geolibre-zarr-control .maplibre-gl-zarr-layer-input:focus,
+.geolibre-zarr-control .maplibre-gl-zarr-layer-select:focus {
+  border-color: hsl(var(--ring)) !important;
+  box-shadow: 0 0 0 1px hsl(var(--ring)) !important;
+  outline: none;
+}
+
+.geolibre-zarr-control .maplibre-gl-zarr-layer-select option {
+  background-color: hsl(var(--popover));
+  color: hsl(var(--popover-foreground));
+}
+
+.geolibre-zarr-control .maplibre-gl-zarr-layer-btn {
+  background-color: hsl(var(--card)) !important;
+  border: 1px solid hsl(var(--border)) !important;
+  color: hsl(var(--foreground)) !important;
+}
+
+.geolibre-zarr-control .maplibre-gl-zarr-layer-btn:hover:not(:disabled) {
+  background-color: hsl(var(--accent)) !important;
+  color: hsl(var(--accent-foreground)) !important;
+}
+
+.geolibre-zarr-control .maplibre-gl-zarr-layer-btn:disabled {
+  color: hsl(var(--muted-foreground)) !important;
+  opacity: 0.65;
+}
+
+.geolibre-zarr-control .maplibre-gl-zarr-layer-btn--primary {
+  background-color: hsl(var(--primary)) !important;
+  border-color: hsl(var(--primary)) !important;
+  color: hsl(var(--primary-foreground)) !important;
+}
+
+.geolibre-zarr-control .maplibre-gl-zarr-layer-status--error {
+  color: hsl(var(--destructive)) !important;
+}
+
+.geolibre-zarr-control .maplibre-gl-zarr-layer-checkbox,
+.geolibre-zarr-control .maplibre-gl-zarr-layer-slider {
+  accent-color: hsl(var(--primary));
+}
+
 .geolibre-flatgeobuf-control .maplibre-gl-add-vector-panel {
   background-color: hsl(var(--popover)) !important;
   border: 1px solid hsl(var(--border));

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -47,6 +47,7 @@ export type LayerType =
   | "xyz"
   | "vector-tiles"
   | "pmtiles"
+  | "zarr"
   | "cog"
   | "flatgeobuf"
   | "geoparquet"

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -56,11 +56,15 @@ function syncExternalNativeLayer(
     const nativeLayer = map.getLayer(nativeLayerId);
     if (!nativeLayer) continue;
 
-    map.setLayoutProperty(
-      nativeLayerId,
-      "visibility",
-      layer.visible ? "visible" : "none",
-    );
+    try {
+      map.setLayoutProperty(
+        nativeLayerId,
+        "visibility",
+        layer.visible ? "visible" : "none",
+      );
+    } catch {
+      // Custom layers from external controls may not accept layout updates.
+    }
 
     setExternalNativeLayerPaint(map, nativeLayerId, nativeLayer.type, layer);
 

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -8,6 +8,7 @@ export {
   maplibreComponentsPlugin,
   openFlatGeobufAddVectorLayerPanel,
   openPMTilesLayerPanel,
+  openZarrLayerPanel,
 } from "./plugins/maplibre-components";
 export { maplibreGeoEditorPlugin } from "./plugins/maplibre-geo-editor";
 export { maplibreGeoAgentPlugin } from "./plugins/maplibre-geoagent";

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -15,6 +15,10 @@ import type {
   PMTilesLayerControlOptions,
   PMTilesLayerEventHandler,
   PMTilesLayerInfo,
+  ZarrLayerControl,
+  ZarrLayerControlOptions,
+  ZarrLayerEventHandler,
+  ZarrLayerInfo,
 } from "maplibre-gl-components";
 import type {
   GeoLibreAppAPI,
@@ -28,21 +32,27 @@ type AddVectorControlConstructor =
   (typeof import("maplibre-gl-components"))["AddVectorControl"];
 type PMTilesLayerControlConstructor =
   (typeof import("maplibre-gl-components"))["PMTilesLayerControl"];
+type ZarrLayerControlConstructor =
+  (typeof import("maplibre-gl-components"))["ZarrLayerControl"];
 
 interface ComponentsConstructors {
   AddVectorControl: AddVectorControlConstructor;
   ControlGrid: ControlGridConstructor;
   PMTilesLayerControl: PMTilesLayerControlConstructor;
+  ZarrLayerControl: ZarrLayerControlConstructor;
 }
 
 let componentsControlPosition: GeoLibreMapControlPosition = "top-right";
 const flatGeobufControlPosition: GeoLibreMapControlPosition = "top-left";
 const pmtilesControlPosition: GeoLibreMapControlPosition = "top-left";
+const zarrControlPosition: GeoLibreMapControlPosition = "top-left";
 
 const FLATGEOBUF_SAMPLE_URL =
   "https://flatgeobuf.org/test/data/UScounties.fgb";
 const PMTILES_SAMPLE_URL =
   "https://overturemaps-extras-us-west-2.s3.us-west-2.amazonaws.com/tiles/2026-05-20.0/buildings.pmtiles";
+const ZARR_SAMPLE_URL =
+  "https://carbonplan-maps.s3.us-west-2.amazonaws.com/v2/demo/4d/tavg-prec-month";
 
 const COMPONENT_CONTROL_NAMES = [
   "spinGlobe",
@@ -114,13 +124,40 @@ const PMTILES_OPTIONS = {
   fontColor: "hsl(var(--popover-foreground))",
 } satisfies PMTilesLayerControlOptions;
 
+const ZARR_OPTIONS = {
+  backgroundColor: "hsl(var(--popover))",
+  className: "geolibre-zarr-control",
+  collapsed: false,
+  defaultClim: [0, 300],
+  defaultColormap: [
+    "#f7fbff",
+    "#deebf7",
+    "#c6dbef",
+    "#9ecae1",
+    "#6baed6",
+    "#4292c6",
+    "#2171b5",
+    "#08519c",
+    "#08306b",
+  ],
+  defaultOpacity: 0.85,
+  defaultPickable: false,
+  defaultSelector: { band: "prec", month: 1 },
+  defaultUrl: ZARR_SAMPLE_URL,
+  defaultVariable: "climate",
+  fontColor: "hsl(var(--popover-foreground))",
+} satisfies ZarrLayerControlOptions;
+
 let componentsControl: ControlGrid | null = null;
 let flatGeobufControl: AddVectorControl | null = null;
 let pmtilesControl: PMTilesLayerControl | null = null;
+let zarrControl: ZarrLayerControl | null = null;
 let flatGeobufControlMounted = false;
 let pmtilesControlMounted = false;
+let zarrControlMounted = false;
 let flatGeobufStoreUnsubscribe: (() => void) | null = null;
 let pmtilesStoreUnsubscribe: (() => void) | null = null;
+let zarrStoreUnsubscribe: (() => void) | null = null;
 let pluginActive = false;
 let componentsControlRevision = 0;
 let componentsConstructorsPromise: Promise<ComponentsConstructors> | null =
@@ -132,10 +169,12 @@ const getComponentsConstructors = (): Promise<ComponentsConstructors> => {
       AddVectorControl: AddVectorControlClass,
       ControlGrid: ControlGridClass,
       PMTilesLayerControl: PMTilesLayerControlClass,
+      ZarrLayerControl: ZarrLayerControlClass,
     }) => ({
       AddVectorControl: AddVectorControlClass,
       ControlGrid: ControlGridClass,
       PMTilesLayerControl: PMTilesLayerControlClass,
+      ZarrLayerControl: ZarrLayerControlClass,
     }),
   );
   return componentsConstructorsPromise;
@@ -193,6 +232,7 @@ export const maplibreComponentsPlugin: GeoLibrePlugin = {
     componentsControlRevision += 1;
     teardownFlatGeobufControl(app);
     teardownPMTilesControl(app);
+    teardownZarrControl(app);
     if (!componentsControl) return;
     app.removeMapControl(componentsControl);
     componentsControl = null;
@@ -218,6 +258,10 @@ export function openFlatGeobufAddVectorLayerPanel(
 
 export function openPMTilesLayerPanel(app: GeoLibreAppAPI): void {
   void openStandalonePMTilesControl(app);
+}
+
+export function openZarrLayerPanel(app: GeoLibreAppAPI): void {
+  void openStandaloneZarrControl(app);
 }
 
 function getComponentsOptions(
@@ -281,6 +325,30 @@ async function openStandalonePMTilesControl(
   return true;
 }
 
+async function openStandaloneZarrControl(
+  app: GeoLibreAppAPI,
+): Promise<boolean> {
+  const { ZarrLayerControl: ZarrLayerControlClass } =
+    await getComponentsConstructors();
+
+  zarrControl ??= createZarrControl(ZarrLayerControlClass);
+
+  if (!zarrControlMounted) {
+    const added = app.addMapControl(zarrControl, zarrControlPosition);
+    if (!added) {
+      zarrControl = null;
+      return false;
+    }
+    zarrControlMounted = true;
+  }
+
+  setTimeout(() => {
+    zarrControl?.show();
+    zarrControl?.expand();
+  }, 0);
+  return true;
+}
+
 function createFlatGeobufControl(
   AddVectorControlClass: AddVectorControlConstructor,
 ): AddVectorControl {
@@ -302,6 +370,63 @@ function createFlatGeobufControl(
     );
     for (const layer of removedLayers) {
       flatGeobufControl?.removeLayer(layer.id);
+    }
+  });
+  return control;
+}
+
+function createZarrControl(
+  ZarrLayerControlClass: ZarrLayerControlConstructor,
+): ZarrLayerControl {
+  const control = new ZarrLayerControlClass(ZARR_OPTIONS);
+  control.on("collapse", () => control.hide());
+  control.on("layeradd", createZarrLayerAddHandler());
+  control.on("layerremove", (event) => {
+    const store = useAppStore.getState();
+    const activeLayerIds = new Set(event.state.layers.map((layer) => layer.id));
+    for (const layer of store.layers) {
+      if (!isZarrControlLayer(layer)) continue;
+      const shouldRemove = event.layerId
+        ? layer.id === event.layerId
+        : !activeLayerIds.has(layer.id);
+      if (shouldRemove) {
+        store.removeLayer(layer.id);
+      }
+    }
+  });
+  zarrStoreUnsubscribe ??= useAppStore.subscribe((state, previous) => {
+    const currentById = new Map(state.layers.map((layer) => [layer.id, layer]));
+
+    for (const layer of previous.layers) {
+      if (!isZarrControlLayer(layer)) continue;
+
+      const currentLayer = currentById.get(layer.id);
+      if (!currentLayer) {
+        zarrControl?.removeLayer(layer.id);
+        continue;
+      }
+
+      if (!isZarrControlLayer(currentLayer)) continue;
+
+      if (currentLayer.visible !== layer.visible) {
+        zarrControl?.setLayerVisibility(
+          currentLayer.id,
+          currentLayer.visible,
+          currentLayer.opacity,
+        );
+      }
+
+      if (currentLayer.opacity !== layer.opacity) {
+        if (currentLayer.visible) {
+          zarrControl?.setLayerOpacity(currentLayer.id, currentLayer.opacity);
+        } else {
+          zarrControl?.setLayerVisibility(
+            currentLayer.id,
+            false,
+            currentLayer.opacity,
+          );
+        }
+      }
     }
   });
   return control;
@@ -359,6 +484,16 @@ function teardownPMTilesControl(app: GeoLibreAppAPI): void {
   pmtilesControlMounted = false;
 }
 
+function teardownZarrControl(app: GeoLibreAppAPI): void {
+  zarrStoreUnsubscribe?.();
+  zarrStoreUnsubscribe = null;
+  if (zarrControl && zarrControlMounted) {
+    app.removeMapControl(zarrControl);
+  }
+  zarrControl = null;
+  zarrControlMounted = false;
+}
+
 function createFlatGeobufLayerAddHandler(
   control: AddVectorControl,
 ): AddVectorEventHandler {
@@ -376,6 +511,30 @@ function createFlatGeobufLayerAddHandler(
         metadata: layer.metadata,
         opacity: layer.opacity,
         source: layer.source,
+        visible: layer.visible,
+      });
+      return;
+    }
+    store.addLayer(layer);
+  };
+}
+
+function createZarrLayerAddHandler(): ZarrLayerEventHandler {
+  return (event) => {
+    if (!event.layerId) return;
+    const layerInfo = event.state.layers.find(
+      (layer) => layer.id === event.layerId,
+    );
+    if (!layerInfo) return;
+
+    const store = useAppStore.getState();
+    const layer = createZarrStoreLayer(event.layerId, layerInfo);
+    if (store.layers.some((item) => item.id === layer.id)) {
+      store.updateLayer(layer.id, {
+        metadata: layer.metadata,
+        opacity: layer.opacity,
+        source: layer.source,
+        style: layer.style,
         visible: layer.visible,
       });
       return;
@@ -490,6 +649,51 @@ function createPMTilesStoreLayer(
   };
 }
 
+function createZarrStoreLayer(
+  id: string,
+  layerInfo: ZarrLayerInfo,
+): GeoLibreLayer {
+  const name =
+    layerInfo.name ||
+    [layerNameFromUrl(layerInfo.url, id), layerInfo.variable]
+      .filter(Boolean)
+      .join(" - ");
+
+  return {
+    id,
+    name,
+    type: "zarr",
+    source: {
+      clim: layerInfo.clim,
+      colormap: layerInfo.colormap,
+      selector: layerInfo.selector,
+      sourceId: layerInfo.id,
+      type: "raster",
+      url: layerInfo.url,
+      variable: layerInfo.variable,
+    },
+    visible: true,
+    opacity: layerInfo.opacity,
+    style: {
+      ...DEFAULT_LAYER_STYLE,
+      fillOpacity: 1,
+    },
+    metadata: {
+      clim: layerInfo.clim,
+      colormap: layerInfo.colormap,
+      externalNativeLayer: true,
+      identifiable: false,
+      nativeLayerIds: [layerInfo.id],
+      selector: layerInfo.selector,
+      sourceId: layerInfo.id,
+      sourceKind: "zarr-url",
+      tileType: "raster",
+      variable: layerInfo.variable,
+    },
+    sourcePath: layerInfo.url,
+  };
+}
+
 function isFlatGeobufControlLayer(layer: GeoLibreLayer): boolean {
   return (
     layer.type === "flatgeobuf" &&
@@ -502,6 +706,14 @@ function isPMTilesControlLayer(layer: GeoLibreLayer): boolean {
   return (
     layer.type === "pmtiles" &&
     layer.metadata.sourceKind === "pmtiles-url" &&
+    layer.metadata.externalNativeLayer === true
+  );
+}
+
+function isZarrControlLayer(layer: GeoLibreLayer): boolean {
+  return (
+    layer.type === "zarr" &&
+    layer.metadata.sourceKind === "zarr-url" &&
     layer.metadata.externalNativeLayer === true
   );
 }


### PR DESCRIPTION
## Summary
- Wire the `ZarrLayerControl` from `maplibre-gl-components` into the components plugin, with a toolbar entry to add multidimensional Zarr raster layers
- Add a `zarr` layer type and sync control state (add/remove, visibility, opacity) with the app store
- Mark Zarr layers as non-identifiable since they are custom WebGL layers without queryable features, and guard `setLayoutProperty` for custom external layers

## Test plan
- [ ] `pre-commit run --all-files` passes (includes `npm run build`)
- [ ] Add a Zarr layer from the toolbar and confirm it renders
- [ ] Toggle visibility and adjust opacity from the layer panel and the control
- [ ] Remove the layer from both the panel and the control and confirm state stays in sync