### PR TITLE
feat: add LiDAR layer support via LidarControl

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -6,6 +6,7 @@ import {
 } from "@geolibre/map";
 import {
   openFlatGeobufAddVectorLayerPanel,
+  openLidarLayerPanel,
   openPMTilesLayerPanel,
   openZarrLayerPanel,
   type GeoLibreMapControlPosition,
@@ -147,6 +148,9 @@ export function TopToolbar({
   const handleAddZarrLayer = () => {
     openZarrLayerPanel(appApi);
   };
+  const handleAddLidarLayer = () => {
+    openLidarLayerPanel(appApi);
+  };
   const toggleMapControl = (control: ToolbarMapControl) => {
     setControlsVisible((current) => {
       const visible = !current[control];
@@ -202,6 +206,9 @@ export function TopToolbar({
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={handleAddZarrLayer}>
             Add Zarr Layer
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={handleAddLidarLayer}>
+            Add LiDAR Layer
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/apps/geolibre-desktop/src/lib/lidar-style.ts
+++ b/apps/geolibre-desktop/src/lib/lidar-style.ts
@@ -239,7 +239,8 @@ const openLidarSelectMenu = (
       item.classList.add("is-selected", "is-active");
       item.setAttribute("aria-selected", "true");
     }
-    item.addEventListener("click", () => {
+    item.addEventListener("click", (event) => {
+      event.stopPropagation();
       select.value = option.value;
       select.dispatchEvent(new Event("change", { bubbles: true }));
       syncLidarSelectProxy(select, button);
@@ -252,6 +253,7 @@ const openLidarSelectMenu = (
   const items = Array.from(
     menu.querySelectorAll<HTMLButtonElement>("button"),
   );
+  menu.addEventListener("click", (event) => event.stopPropagation());
   menu.addEventListener("keydown", (event) => {
     const current = items.indexOf(document.activeElement as HTMLButtonElement);
     if (event.key === "ArrowDown") {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -48,6 +48,7 @@ export type LayerType =
   | "vector-tiles"
   | "pmtiles"
   | "zarr"
+  | "lidar"
   | "cog"
   | "flatgeobuf"
   | "geoparquet"

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -70,6 +70,10 @@ const EMPTY_HIGHLIGHT: FeatureCollection = {
   features: [],
 };
 
+function isCustomControllableLayer(layer: GeoLibreLayer): boolean {
+  return typeof layer.metadata.customLayerType === "string";
+}
+
 function nativeLayerSuffix(layerId: string): string | undefined {
   const suffix = layerId.split("-").pop();
   if (!suffix) return undefined;
@@ -759,7 +763,9 @@ export class MapController {
       ...nativeStyleLayerIds,
     ];
     const controllableLayers = layers.filter(
-      (layer) => this.getNativeLayerIds(layer).length > 0,
+      (layer) =>
+        this.getNativeLayerIds(layer).length > 0 ||
+        isCustomControllableLayer(layer),
     );
 
     if (controllableLayers.length === 0) {
@@ -918,7 +924,11 @@ export class MapController {
         // GeoJSON-backed layers derive bounds from their features; other
         // layer types fall back to their source bounds (TileJSON) when
         // advertised, and return null (no zoom-to-bounds) otherwise.
-        return getLayerBounds(layer) ?? this.getLayerSourceBounds(layer);
+        return (
+          getLayerBounds(layer) ??
+          this.getLayerMetadataBounds(layer) ??
+          this.getLayerSourceBounds(layer)
+        );
       },
       getNativeLayerIds: (layerId) => this.getNativeLayerIdsByLayerId(layerId),
       removeLayer: (layerId) => {
@@ -945,7 +955,26 @@ export class MapController {
       .map((id) => this.map?.getLayer(id))
       .find((item) => Boolean(item));
 
-    return nativeLayer?.type ?? "custom";
+    return (
+      nativeLayer?.type ??
+      (typeof layer.metadata.customLayerType === "string"
+        ? layer.metadata.customLayerType
+        : "custom")
+    );
+  }
+
+  private getLayerMetadataBounds(
+    layer: GeoLibreLayer,
+  ): [number, number, number, number] | null {
+    const bounds = layer.source.bounds;
+    if (
+      Array.isArray(bounds) &&
+      bounds.length === 4 &&
+      bounds.every((value) => Number.isFinite(value))
+    ) {
+      return bounds as [number, number, number, number];
+    }
+    return null;
   }
 
   private getLayerSourceBounds(

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -7,6 +7,7 @@ export { maplibreBasemapControlPlugin } from "./plugins/maplibre-basemap-control
 export {
   maplibreComponentsPlugin,
   openFlatGeobufAddVectorLayerPanel,
+  openLidarLayerPanel,
   openPMTilesLayerPanel,
   openZarrLayerPanel,
 } from "./plugins/maplibre-components";

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -11,6 +11,8 @@ import type {
   ControlGrid,
   ControlGridOptions,
   DefaultControlName,
+  LidarControl,
+  LidarLayerAdapter,
   PMTilesLayerControl,
   PMTilesLayerControlOptions,
   PMTilesLayerEventHandler,
@@ -20,6 +22,10 @@ import type {
   ZarrLayerEventHandler,
   ZarrLayerInfo,
 } from "maplibre-gl-components";
+import type {
+  LidarControlEventHandler,
+  PointCloudInfo,
+} from "maplibre-gl-lidar";
 import type {
   GeoLibreAppAPI,
   GeoLibreMapControlPosition,
@@ -34,10 +40,20 @@ type PMTilesLayerControlConstructor =
   (typeof import("maplibre-gl-components"))["PMTilesLayerControl"];
 type ZarrLayerControlConstructor =
   (typeof import("maplibre-gl-components"))["ZarrLayerControl"];
+type LidarControlConstructor =
+  (typeof import("maplibre-gl-components"))["LidarControl"];
+type LidarLayerAdapterConstructor =
+  (typeof import("maplibre-gl-components"))["LidarLayerAdapter"];
+
+interface LidarControlClickOutsideState {
+  _clickOutsideHandler?: ((event: MouseEvent) => void) | null;
+}
 
 interface ComponentsConstructors {
   AddVectorControl: AddVectorControlConstructor;
   ControlGrid: ControlGridConstructor;
+  LidarControl: LidarControlConstructor;
+  LidarLayerAdapter: LidarLayerAdapterConstructor;
   PMTilesLayerControl: PMTilesLayerControlConstructor;
   ZarrLayerControl: ZarrLayerControlConstructor;
 }
@@ -46,6 +62,7 @@ let componentsControlPosition: GeoLibreMapControlPosition = "top-right";
 const flatGeobufControlPosition: GeoLibreMapControlPosition = "top-left";
 const pmtilesControlPosition: GeoLibreMapControlPosition = "top-left";
 const zarrControlPosition: GeoLibreMapControlPosition = "top-left";
+const lidarControlPosition: GeoLibreMapControlPosition = "top-left";
 
 const FLATGEOBUF_SAMPLE_URL =
   "https://flatgeobuf.org/test/data/UScounties.fgb";
@@ -53,6 +70,8 @@ const PMTILES_SAMPLE_URL =
   "https://overturemaps-extras-us-west-2.s3.us-west-2.amazonaws.com/tiles/2026-05-20.0/buildings.pmtiles";
 const ZARR_SAMPLE_URL =
   "https://carbonplan-maps.s3.us-west-2.amazonaws.com/v2/demo/4d/tavg-prec-month";
+const LIDAR_SAMPLE_URL =
+  "https://s3.amazonaws.com/hobu-lidar/autzen-classified.copc.laz";
 
 const COMPONENT_CONTROL_NAMES = [
   "spinGlobe",
@@ -148,16 +167,32 @@ const ZARR_OPTIONS = {
   fontColor: "hsl(var(--popover-foreground))",
 } satisfies ZarrLayerControlOptions;
 
+const LIDAR_OPTIONS = {
+  title: "Add LiDAR Layer",
+  collapsed: false,
+  className: "geolibre-lidar-layer-control",
+  panelWidth: 365,
+  maxHeight: 520,
+  pointSize: 2,
+  colorScheme: "elevation",
+  pickable: false,
+  autoZoom: true,
+} satisfies ConstructorParameters<LidarControlConstructor>[0];
+
 let componentsControl: ControlGrid | null = null;
 let flatGeobufControl: AddVectorControl | null = null;
 let pmtilesControl: PMTilesLayerControl | null = null;
 let zarrControl: ZarrLayerControl | null = null;
+let lidarControl: LidarControl | null = null;
+let lidarLayerAdapter: LidarLayerAdapter | null = null;
 let flatGeobufControlMounted = false;
 let pmtilesControlMounted = false;
 let zarrControlMounted = false;
+let lidarControlMounted = false;
 let flatGeobufStoreUnsubscribe: (() => void) | null = null;
 let pmtilesStoreUnsubscribe: (() => void) | null = null;
 let zarrStoreUnsubscribe: (() => void) | null = null;
+let lidarStoreUnsubscribe: (() => void) | null = null;
 let pluginActive = false;
 let componentsControlRevision = 0;
 let componentsConstructorsPromise: Promise<ComponentsConstructors> | null =
@@ -168,11 +203,15 @@ const getComponentsConstructors = (): Promise<ComponentsConstructors> => {
     ({
       AddVectorControl: AddVectorControlClass,
       ControlGrid: ControlGridClass,
+      LidarControl: LidarControlClass,
+      LidarLayerAdapter: LidarLayerAdapterClass,
       PMTilesLayerControl: PMTilesLayerControlClass,
       ZarrLayerControl: ZarrLayerControlClass,
     }) => ({
       AddVectorControl: AddVectorControlClass,
       ControlGrid: ControlGridClass,
+      LidarControl: LidarControlClass,
+      LidarLayerAdapter: LidarLayerAdapterClass,
       PMTilesLayerControl: PMTilesLayerControlClass,
       ZarrLayerControl: ZarrLayerControlClass,
     }),
@@ -233,6 +272,7 @@ export const maplibreComponentsPlugin: GeoLibrePlugin = {
     teardownFlatGeobufControl(app);
     teardownPMTilesControl(app);
     teardownZarrControl(app);
+    teardownLidarControl(app);
     if (!componentsControl) return;
     app.removeMapControl(componentsControl);
     componentsControl = null;
@@ -262,6 +302,10 @@ export function openPMTilesLayerPanel(app: GeoLibreAppAPI): void {
 
 export function openZarrLayerPanel(app: GeoLibreAppAPI): void {
   void openStandaloneZarrControl(app);
+}
+
+export function openLidarLayerPanel(app: GeoLibreAppAPI): void {
+  void openStandaloneLidarControl(app);
 }
 
 function getComponentsOptions(
@@ -349,6 +393,38 @@ async function openStandaloneZarrControl(
   return true;
 }
 
+async function openStandaloneLidarControl(
+  app: GeoLibreAppAPI,
+): Promise<boolean> {
+  const {
+    LidarControl: LidarControlClass,
+    LidarLayerAdapter: LidarLayerAdapterClass,
+  } =
+    await getComponentsConstructors();
+
+  lidarControl ??= createLidarControl(
+    LidarControlClass,
+    LidarLayerAdapterClass,
+  );
+
+  if (!lidarControlMounted) {
+    const added = app.addMapControl(lidarControl, lidarControlPosition);
+    if (!added) {
+      lidarControl = null;
+      return false;
+    }
+    lidarControlMounted = true;
+  }
+
+  setTimeout(() => {
+    disableLidarClickOutsideCollapse(lidarControl);
+    showLidarControl(lidarControl);
+    lidarControl?.expand();
+    seedLidarDefaultUrl(lidarControl);
+  }, 0);
+  return true;
+}
+
 function createFlatGeobufControl(
   AddVectorControlClass: AddVectorControlConstructor,
 ): AddVectorControl {
@@ -370,6 +446,43 @@ function createFlatGeobufControl(
     );
     for (const layer of removedLayers) {
       flatGeobufControl?.removeLayer(layer.id);
+    }
+  });
+  return control;
+}
+
+function createLidarControl(
+  LidarControlClass: LidarControlConstructor,
+  LidarLayerAdapterClass: LidarLayerAdapterConstructor,
+): LidarControl {
+  const control = new LidarControlClass(LIDAR_OPTIONS);
+  lidarLayerAdapter = new LidarLayerAdapterClass(control);
+  control.on("collapse", () => hideLidarControl(control));
+  control.on("load", createLidarLoadHandler());
+  control.on("unload", createLidarUnloadHandler());
+  lidarStoreUnsubscribe ??= useAppStore.subscribe((state, previous) => {
+    const currentById = new Map(state.layers.map((layer) => [layer.id, layer]));
+
+    for (const layer of previous.layers) {
+      if (!isLidarControlLayer(layer)) continue;
+
+      const currentLayer = currentById.get(layer.id);
+      if (!currentLayer) {
+        if (hasLidarPointCloud(layer.id)) {
+          lidarLayerAdapter?.removeLayer(layer.id);
+        }
+        continue;
+      }
+
+      if (!isLidarControlLayer(currentLayer)) continue;
+
+      if (currentLayer.visible !== layer.visible) {
+        lidarLayerAdapter?.setVisibility(currentLayer.id, currentLayer.visible);
+      }
+
+      if (currentLayer.opacity !== layer.opacity) {
+        lidarLayerAdapter?.setOpacity(currentLayer.id, currentLayer.opacity);
+      }
     }
   });
   return control;
@@ -492,6 +605,50 @@ function teardownZarrControl(app: GeoLibreAppAPI): void {
   }
   zarrControl = null;
   zarrControlMounted = false;
+}
+
+function teardownLidarControl(app: GeoLibreAppAPI): void {
+  lidarStoreUnsubscribe?.();
+  lidarStoreUnsubscribe = null;
+  lidarLayerAdapter?.destroy();
+  lidarLayerAdapter = null;
+  if (lidarControl && lidarControlMounted) {
+    app.removeMapControl(lidarControl);
+  }
+  lidarControl = null;
+  lidarControlMounted = false;
+}
+
+function createLidarLoadHandler(): LidarControlEventHandler {
+  return (event) => {
+    if (!event.pointCloud || !("source" in event.pointCloud)) return;
+
+    const store = useAppStore.getState();
+    const layer = createLidarStoreLayer(event.pointCloud);
+    if (store.layers.some((item) => item.id === layer.id)) {
+      store.updateLayer(layer.id, {
+        metadata: layer.metadata,
+        opacity: layer.opacity,
+        source: layer.source,
+        visible: layer.visible,
+      });
+      return;
+    }
+    store.addLayer(layer);
+  };
+}
+
+function createLidarUnloadHandler(): LidarControlEventHandler {
+  return (event) => {
+    const pointCloudId = event.pointCloud?.id;
+    if (!pointCloudId) return;
+
+    const store = useAppStore.getState();
+    const layer = store.layers.find((item) => item.id === pointCloudId);
+    if (layer && isLidarControlLayer(layer)) {
+      store.removeLayer(pointCloudId);
+    }
+  };
 }
 
 function createFlatGeobufLayerAddHandler(
@@ -694,6 +851,41 @@ function createZarrStoreLayer(
   };
 }
 
+function createLidarStoreLayer(pointCloud: PointCloudInfo): GeoLibreLayer {
+  return {
+    id: pointCloud.id,
+    name: pointCloud.name || layerNameFromUrl(pointCloud.source, pointCloud.id),
+    type: "lidar",
+    source: {
+      bounds: [
+        pointCloud.bounds.minX,
+        pointCloud.bounds.minY,
+        pointCloud.bounds.maxX,
+        pointCloud.bounds.maxY,
+      ],
+      sourceId: pointCloud.id,
+      type: "lidar",
+      url: pointCloud.source,
+    },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {
+      customLayerType: "lidar",
+      externalNativeLayer: true,
+      hasClassification: pointCloud.hasClassification,
+      hasIntensity: pointCloud.hasIntensity,
+      hasRGB: pointCloud.hasRGB,
+      identifiable: false,
+      pointCount: pointCloud.pointCount,
+      sourceId: pointCloud.id,
+      sourceKind: "lidar-url",
+      wkt: pointCloud.wkt,
+    },
+    sourcePath: pointCloud.source,
+  };
+}
+
 function isFlatGeobufControlLayer(layer: GeoLibreLayer): boolean {
   return (
     layer.type === "flatgeobuf" &&
@@ -718,6 +910,14 @@ function isZarrControlLayer(layer: GeoLibreLayer): boolean {
   );
 }
 
+function isLidarControlLayer(layer: GeoLibreLayer): boolean {
+  return (
+    layer.type === "lidar" &&
+    layer.metadata.sourceKind === "lidar-url" &&
+    layer.metadata.externalNativeLayer === true
+  );
+}
+
 function layerNameFromUrl(url: string, fallback: string): string {
   try {
     const fileName = new URL(url).pathname.split("/").pop() ?? fallback;
@@ -725,4 +925,55 @@ function layerNameFromUrl(url: string, fallback: string): string {
   } catch {
     return fallback;
   }
+}
+
+function seedLidarDefaultUrl(control: LidarControl | null): void {
+  const panel = findLidarPanel(control);
+  const input = panel?.querySelector<HTMLInputElement>(".lidar-control-input");
+  if (!input || input.value.trim()) return;
+  input.value = LIDAR_SAMPLE_URL;
+}
+
+function hideLidarControl(control: LidarControl | null): void {
+  const container = control?.getContainer();
+  if (container) container.style.display = "none";
+}
+
+function showLidarControl(control: LidarControl | null): void {
+  const container = control?.getContainer();
+  if (container) container.style.display = "";
+}
+
+function disableLidarClickOutsideCollapse(control: LidarControl | null): void {
+  const clickOutsideState = control as unknown as
+    | LidarControlClickOutsideState
+    | null;
+  const handler = clickOutsideState?._clickOutsideHandler;
+  if (!handler) return;
+  document.removeEventListener("click", handler);
+  clickOutsideState._clickOutsideHandler = null;
+}
+
+function hasLidarPointCloud(id: string): boolean {
+  return lidarControl?.getPointClouds().some((pointCloud) => pointCloud.id === id)
+    ?? false;
+}
+
+function findLidarPanel(control: LidarControl | null): HTMLElement | null {
+  const mapContainer = control?.getMap()?.getContainer();
+  if (!mapContainer) return null;
+
+  const panels = Array.from(
+    mapContainer.querySelectorAll<HTMLElement>(".lidar-control-panel"),
+  );
+
+  return (
+    panels.find(
+      (panel) =>
+        panel.querySelector(".lidar-control-title")?.textContent ===
+        LIDAR_OPTIONS.title,
+    ) ??
+    panels[panels.length - 1] ??
+    null
+  );
 }

--- a/packages/plugins/src/plugins/maplibre-lidar.ts
+++ b/packages/plugins/src/plugins/maplibre-lidar.ts
@@ -17,7 +17,7 @@ const LIDAR_OPTIONS = {
   maxHeight: 520,
   pointSize: 2,
   colorScheme: "elevation",
-  pickable: true,
+  pickable: false,
   autoZoom: true,
   shareUrl: true,
   restoreFromUrl: true,
@@ -26,6 +26,10 @@ const LIDAR_OPTIONS = {
 let lidarControl: LidarControl | null = null;
 let pluginActive = false;
 
+interface LidarControlClickOutsideState {
+  _clickOutsideHandler?: ((event: MouseEvent) => void) | null;
+}
+
 const mountLidarControl = (app: GeoLibreAppAPI): boolean => {
   if (!lidarControl) return false;
   const added = app.addMapControl(lidarControl, lidarPosition);
@@ -33,7 +37,10 @@ const mountLidarControl = (app: GeoLibreAppAPI): boolean => {
     lidarControl = null;
     return false;
   }
-  setTimeout(() => lidarControl?.expand(), 0);
+  setTimeout(() => {
+    disableLidarClickOutsideCollapse(lidarControl);
+    lidarControl?.expand();
+  }, 0);
   return true;
 };
 
@@ -71,7 +78,10 @@ export const maplibreLidarPlugin: GeoLibrePlugin = {
     app.removeMapControl(lidarControl);
     const added = app.addMapControl(lidarControl, lidarPosition);
     if (!added) return false;
-    setTimeout(() => lidarControl?.expand(), 0);
+    setTimeout(() => {
+      disableLidarClickOutsideCollapse(lidarControl);
+      lidarControl?.expand();
+    }, 0);
   },
 };
 
@@ -80,4 +90,14 @@ function getLidarOptions(): LidarControlOptions {
     ...LIDAR_OPTIONS,
     position: lidarPosition,
   };
+}
+
+function disableLidarClickOutsideCollapse(control: LidarControl | null): void {
+  const clickOutsideState = control as unknown as
+    | LidarControlClickOutsideState
+    | null;
+  const handler = clickOutsideState?._clickOutsideHandler;
+  if (!handler) return;
+  document.removeEventListener("click", handler);
+  clickOutsideState._clickOutsideHandler = null;
 }


### PR DESCRIPTION
## Summary
- Wire `LidarControl` and `LidarLayerAdapter` into the components plugin and expose an "Add LiDAR Layer" option in the TopToolbar.
- Add a `lidar` layer type and sync point cloud visibility, opacity, and removal with the app layer store.
- Support metadata-derived layer bounds for zoom-to and keep the LiDAR panel open by disabling click-outside collapse.

## Test plan
- [ ] `npm run build` passes
- [ ] Open the app, add a LiDAR layer from the TopToolbar, and confirm the point cloud renders
- [ ] Toggle visibility/opacity and confirm the map updates
- [ ] Remove the layer and confirm the point cloud is removed from the map