### PR TITLE
chore: update maplibre-gl-components to version 0.17.3 in package.json and package-lock.json

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -36,7 +36,7 @@
     "mapillary-js": "^4.1.2",
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-basemap-control": "^0.2.1",
-    "maplibre-gl-components": "^0.17.1",
+    "maplibre-gl-components": "^0.17.3",
     "maplibre-gl-geo-editor": "^0.7.3",
     "maplibre-gl-geoagent": "^0.4.2",
     "maplibre-gl-lidar": "^0.14.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "mapillary-js": "^4.1.2",
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-basemap-control": "^0.2.1",
-        "maplibre-gl-components": "^0.17.1",
+        "maplibre-gl-components": "^0.17.3",
         "maplibre-gl-geo-editor": "^0.7.3",
         "maplibre-gl-geoagent": "^0.4.2",
         "maplibre-gl-lidar": "^0.14.1",
@@ -77,9 +77,9 @@
       }
     },
     "apps/geolibre-desktop/node_modules/maplibre-gl-components": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.17.1.tgz",
-      "integrity": "sha512-1WSa8LbW2lC4WeytT22gswW0SZxmHPc99tvEMY7qPFyQJeqBs9ZtsL+4zDVC3WqGAKmlQYrYHOOGzFWEtoaQYw==",
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.17.3.tgz",
+      "integrity": "sha512-u/3FX/Rw19HodsvfZbhtg+KD+tg5PthvE+1cwWClNcL9rTNWoj6mkoxd+DcCRT28jAqE77OCuOxjBbM64fw20w==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",
@@ -108,7 +108,7 @@
         "maplibre-gl": ">=5.24.0",
         "react": ">=19.2.6",
         "react-dom": ">=19.2.6",
-        "three": ">=0.184.0"
+        "three": ">=0.178.0"
       },
       "peerDependenciesMeta": {
         "@carbonplan/zarr-layer": {
@@ -6732,7 +6732,7 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/raf": {
@@ -6752,7 +6752,7 @@
       "version": "18.3.29",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.29.tgz",
       "integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -6763,7 +6763,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -7592,7 +7592,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -11872,7 +11872,7 @@
         "jspdf": "^2.5.2",
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-basemap-control": "^0.2.1",
-        "maplibre-gl-components": "^0.17.1",
+        "maplibre-gl-components": "^0.17.3",
         "maplibre-gl-geo-editor": "^0.7.3",
         "maplibre-gl-geoagent": "^0.4.2",
         "maplibre-gl-lidar": "^0.14.1",
@@ -11896,9 +11896,9 @@
       }
     },
     "packages/plugins/node_modules/maplibre-gl-components": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.17.1.tgz",
-      "integrity": "sha512-1WSa8LbW2lC4WeytT22gswW0SZxmHPc99tvEMY7qPFyQJeqBs9ZtsL+4zDVC3WqGAKmlQYrYHOOGzFWEtoaQYw==",
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.17.3.tgz",
+      "integrity": "sha512-u/3FX/Rw19HodsvfZbhtg+KD+tg5PthvE+1cwWClNcL9rTNWoj6mkoxd+DcCRT28jAqE77OCuOxjBbM64fw20w==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",
@@ -11927,7 +11927,7 @@
         "maplibre-gl": ">=5.24.0",
         "react": ">=19.2.6",
         "react-dom": ">=19.2.6",
-        "three": ">=0.184.0"
+        "three": ">=0.178.0"
       },
       "peerDependenciesMeta": {
         "@carbonplan/zarr-layer": {

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -23,7 +23,7 @@
     "jspdf": "^2.5.2",
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-basemap-control": "^0.2.1",
-    "maplibre-gl-components": "^0.17.1",
+    "maplibre-gl-components": "^0.17.3",
     "maplibre-gl-geo-editor": "^0.7.3",
     "maplibre-gl-geoagent": "^0.4.2",
     "maplibre-gl-lidar": "^0.14.1",


### PR DESCRIPTION
- Updated maplibre-gl-components from version 0.17.1 to 0.17.3 across package.json files in geolibre-desktop and plugins.
- Adjusted related dependencies and integrity checks in package-lock.json to reflect the new version.