### PR TITLE
feat: add MBTiles layer support

### DIFF
--- a/apps/geolibre-desktop/src-tauri/Cargo.lock
+++ b/apps/geolibre-desktop/src-tauri/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,6 +949,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,7 +1253,9 @@ dependencies = [
 name = "geolibre-desktop"
 version = "0.4.0"
 dependencies = [
+ "flate2",
  "reqwest 0.12.28",
+ "rusqlite",
  "serde",
  "serde_json",
  "tauri",
@@ -1435,6 +1461,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1447,6 +1482,15 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -1966,6 +2010,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2968,6 +3023,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.11.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -4392,6 +4461,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/apps/geolibre-desktop/src-tauri/Cargo.toml
+++ b/apps/geolibre-desktop/src-tauri/Cargo.toml
@@ -18,5 +18,7 @@ tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-opener = "2"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
+flate2 = "1"
+rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -3,6 +3,12 @@ mod earth_engine_oauth;
 use earth_engine_oauth::{
     poll_earth_engine_oauth, start_earth_engine_oauth, EarthEngineOAuthState,
 };
+use flate2::read::{GzDecoder, ZlibDecoder};
+use rusqlite::{params, Connection, OpenFlags, OptionalExtension};
+use serde::Serialize;
+use serde_json::Value;
+use std::io::Read;
+use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 use tauri::Manager;
 
@@ -20,6 +26,8 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             close_oauth_popups,
             fetch_url_bytes,
+            read_mbtiles_metadata,
+            read_mbtiles_tile,
             start_earth_engine_oauth,
             poll_earth_engine_oauth
         ])
@@ -59,6 +67,201 @@ fn fetch_url_bytes(url: String) -> Result<Vec<u8>, String> {
         .bytes()
         .map(|bytes| bytes.to_vec())
         .map_err(|error| format!("Could not read response body: {error}"))
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MbtilesMetadata {
+    name: String,
+    format: String,
+    tile_type: String,
+    source_layers: Vec<String>,
+    min_zoom: Option<i64>,
+    max_zoom: Option<i64>,
+    bounds: Option<[f64; 4]>,
+    center: Option<[f64; 3]>,
+    scheme: String,
+}
+
+#[tauri::command]
+fn read_mbtiles_metadata(path: String) -> Result<MbtilesMetadata, String> {
+    let connection = open_mbtiles(&path)?;
+    let metadata = read_metadata_rows(&connection)?;
+    let fallback_name = Path::new(&path)
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .unwrap_or("MBTiles Layer")
+        .to_string();
+    let format = metadata
+        .get("format")
+        .map(|value| value.to_ascii_lowercase())
+        .unwrap_or_else(|| "pbf".to_string());
+    let tile_type = match format.as_str() {
+        "pbf" | "mvt" | "protobuf" => "vector",
+        _ => "raster",
+    }
+    .to_string();
+
+    Ok(MbtilesMetadata {
+        name: metadata
+            .get("name")
+            .filter(|value| !value.trim().is_empty())
+            .cloned()
+            .unwrap_or(fallback_name),
+        format,
+        tile_type,
+        source_layers: read_vector_source_layers(metadata.get("json")),
+        min_zoom: metadata
+            .get("minzoom")
+            .and_then(|value| value.parse::<i64>().ok()),
+        max_zoom: metadata
+            .get("maxzoom")
+            .and_then(|value| value.parse::<i64>().ok()),
+        bounds: metadata.get("bounds").and_then(|value| parse_bounds(value)),
+        center: metadata.get("center").and_then(|value| parse_center(value)),
+        scheme: metadata
+            .get("scheme")
+            .map(|value| value.to_ascii_lowercase())
+            .unwrap_or_else(|| "tms".to_string()),
+    })
+}
+
+#[tauri::command]
+fn read_mbtiles_tile(path: String, z: u32, x: u32, y: u32) -> Result<Vec<u8>, String> {
+    let connection = open_mbtiles(&path)?;
+    let scheme = read_metadata_value(&connection, "scheme")?
+        .map(|value| value.to_ascii_lowercase())
+        .unwrap_or_else(|| "tms".to_string());
+    let tile_row = if scheme == "xyz" {
+        i64::from(y)
+    } else {
+        let row_count = 1_i64
+            .checked_shl(z)
+            .ok_or_else(|| "Tile zoom level is too large".to_string())?;
+        row_count - 1 - i64::from(y)
+    };
+    if tile_row < 0 {
+        return Ok(Vec::new());
+    }
+
+    let tile_data = connection
+        .query_row(
+            "SELECT tile_data FROM tiles WHERE zoom_level = ?1 AND tile_column = ?2 AND tile_row = ?3",
+            params![i64::from(z), i64::from(x), tile_row],
+            |row| row.get::<_, Vec<u8>>(0),
+        )
+        .optional()
+        .map_err(|error| format!("Could not read MBTiles tile: {error}"))?;
+
+    Ok(tile_data
+        .map(decompress_tile_data)
+        .transpose()?
+        .unwrap_or_default())
+}
+
+fn open_mbtiles(path: &str) -> Result<Connection, String> {
+    if !Path::new(path).exists() {
+        return Err("The selected MBTiles file does not exist".to_string());
+    }
+
+    Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .map_err(|error| format!("Could not open MBTiles file: {error}"))
+}
+
+fn read_metadata_rows(
+    connection: &Connection,
+) -> Result<std::collections::HashMap<String, String>, String> {
+    let mut statement = connection
+        .prepare("SELECT name, value FROM metadata")
+        .map_err(|error| format!("Could not read MBTiles metadata: {error}"))?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
+        .map_err(|error| format!("Could not query MBTiles metadata: {error}"))?;
+
+    let mut metadata = std::collections::HashMap::new();
+    for row in rows {
+        let (name, value) =
+            row.map_err(|error| format!("Could not parse MBTiles metadata: {error}"))?;
+        metadata.insert(name.to_ascii_lowercase(), value);
+    }
+    Ok(metadata)
+}
+
+fn read_metadata_value(connection: &Connection, name: &str) -> Result<Option<String>, String> {
+    connection
+        .query_row(
+            "SELECT value FROM metadata WHERE lower(name) = lower(?1)",
+            [name],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(|error| format!("Could not read MBTiles metadata: {error}"))
+}
+
+fn read_vector_source_layers(json: Option<&String>) -> Vec<String> {
+    let Some(json) = json else {
+        return Vec::new();
+    };
+    let Ok(value) = serde_json::from_str::<Value>(json) else {
+        return Vec::new();
+    };
+    value
+        .get("vector_layers")
+        .and_then(Value::as_array)
+        .map(|layers| {
+            layers
+                .iter()
+                .filter_map(|layer| layer.get("id").and_then(Value::as_str))
+                .map(ToString::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn parse_bounds(value: &str) -> Option<[f64; 4]> {
+    let values = parse_number_list(value);
+    if values.len() != 4 {
+        return None;
+    }
+    Some([values[0], values[1], values[2], values[3]])
+}
+
+fn parse_center(value: &str) -> Option<[f64; 3]> {
+    let values = parse_number_list(value);
+    if values.len() < 2 {
+        return None;
+    }
+    Some([values[0], values[1], values.get(2).copied().unwrap_or(0.0)])
+}
+
+fn parse_number_list(value: &str) -> Vec<f64> {
+    value
+        .split(',')
+        .filter_map(|part| part.trim().parse::<f64>().ok())
+        .collect()
+}
+
+fn decompress_tile_data(data: Vec<u8>) -> Result<Vec<u8>, String> {
+    if data.starts_with(&[0x1f, 0x8b]) {
+        let mut decoder = GzDecoder::new(data.as_slice());
+        let mut decoded = Vec::new();
+        decoder
+            .read_to_end(&mut decoded)
+            .map_err(|error| format!("Could not decompress gzip tile: {error}"))?;
+        return Ok(decoded);
+    }
+
+    if data.len() > 2 && data[0] == 0x78 {
+        let mut decoder = ZlibDecoder::new(data.as_slice());
+        let mut decoded = Vec::new();
+        if decoder.read_to_end(&mut decoded).is_ok() {
+            return Ok(decoded);
+        }
+    }
+
+    Ok(data)
 }
 
 fn create_main_window(app: &mut tauri::App) -> tauri::Result<()> {

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -32,8 +32,14 @@ import {
   openVectorFileWithFallback,
 } from "../../lib/tauri-io";
 import { createAppAPI } from "../../hooks/usePlugins";
+import {
+  mbtilesTileUrl,
+  readMbtilesMetadata,
+  registerMbtilesProtocol,
+  type MbtilesMetadata,
+} from "../../lib/mbtiles";
 
-export type AddDataKind = "xyz" | "wms" | "vector" | "raster";
+export type AddDataKind = "xyz" | "wms" | "vector" | "raster" | "mbtiles";
 
 interface AddDataDialogProps {
   kind: AddDataKind | null;
@@ -50,6 +56,7 @@ const KIND_LABELS: Record<AddDataKind, string> = {
   wms: "Add WMS Layer",
   vector: "Add Vector Layer",
   raster: "Add Raster Layer",
+  mbtiles: "Add MBTiles Layer",
 };
 
 const SELECT_CLASS =
@@ -101,7 +108,10 @@ function createBaseLayer(
   };
 }
 
-function appendQuery(endpoint: string, params: Array<[string, string]>): string {
+function appendQuery(
+  endpoint: string,
+  params: Array<[string, string]>,
+): string {
   const separator = endpoint.includes("?")
     ? endpoint.endsWith("?") || endpoint.endsWith("&")
       ? ""
@@ -198,14 +208,18 @@ export function AddDataDialog({
   const [rasterUrl, setRasterUrl] = useState(DEFAULT_RASTER_URL);
   const [rasterTileSize, setRasterTileSize] = useState("256");
   const [rasterBands, setRasterBands] = useState("1");
-  const [rasterColormap, setRasterColormap] =
-    useState<RasterColormap>("none");
+  const [rasterColormap, setRasterColormap] = useState<RasterColormap>("none");
   const [rasterMin, setRasterMin] = useState("0");
   const [rasterMax, setRasterMax] = useState("255");
   const [rasterNodata, setRasterNodata] = useState("");
   const [selectedRasterPath, setSelectedRasterPath] = useState<string | null>(
     null,
   );
+  const [selectedMbtiles, setSelectedMbtiles] = useState<{
+    metadata: MbtilesMetadata;
+    path: string;
+  } | null>(null);
+  const [mbtilesSourceLayers, setMbtilesSourceLayers] = useState("");
 
   useEffect(() => {
     if (!kind) return;
@@ -217,6 +231,7 @@ export function AddDataDialog({
         wms: "WMS Layer",
         vector: "Vector Layer",
         raster: "Raster Layer",
+        mbtiles: "MBTiles Layer",
       }[kind],
     );
     setBeforeLayerId("");
@@ -241,6 +256,8 @@ export function AddDataDialog({
     setRasterMax("255");
     setRasterNodata("");
     setSelectedRasterPath(null);
+    setSelectedMbtiles(null);
+    setMbtilesSourceLayers("");
   }, [kind]);
 
   const description = useMemo(() => {
@@ -255,6 +272,9 @@ export function AddDataDialog({
     }
     if (kind === "raster") {
       return "Add a Cloud Optimized GeoTIFF or raster URL, or use a raster tile template.";
+    }
+    if (kind === "mbtiles") {
+      return "Add a local MBTiles file as a raster or vector tile layer.";
     }
     return "";
   }, [kind]);
@@ -307,6 +327,34 @@ export function AddDataDialog({
         ? current
         : layerNameFromPath(result.path, "Raster Layer"),
     );
+  };
+
+  const handleChooseMbtilesFile = async () => {
+    setError(null);
+    try {
+      const result = await openLocalDataFileWithFallback({
+        filters: [
+          {
+            name: "MBTiles",
+            extensions: ["mbtiles"],
+          },
+        ],
+        accept: ".mbtiles",
+      });
+      if (!result) return;
+      const metadata = await readMbtilesMetadata(result.path);
+      setSelectedMbtiles({ metadata, path: result.path });
+      setMbtilesSourceLayers(metadata.sourceLayers.join(", "));
+      setLayerName((current) =>
+        current.trim() && current !== "MBTiles Layer"
+          ? current
+          : metadata.name || layerNameFromPath(result.path, "MBTiles Layer"),
+      );
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Could not read MBTiles file.",
+      );
+    }
   };
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
@@ -389,7 +437,8 @@ export function AddDataDialog({
           return;
         }
 
-        if (!vectorUrl.trim()) throw new Error("Enter a vector tile source URL.");
+        if (!vectorUrl.trim())
+          throw new Error("Enter a vector tile source URL.");
         if (!vectorSourceLayer.trim()) {
           throw new Error("Enter the vector tile source layer name.");
         }
@@ -399,6 +448,50 @@ export function AddDataDialog({
             url: vectorUrl.trim(),
             sourceLayer: vectorSourceLayer.trim(),
           }),
+        );
+        return;
+      }
+
+      if (kind === "mbtiles") {
+        if (!selectedMbtiles) throw new Error("Choose an MBTiles file.");
+        registerMbtilesProtocol();
+
+        const { metadata, path } = selectedMbtiles;
+        const sourceLayers = mbtilesSourceLayers
+          .split(",")
+          .map((sourceLayer) => sourceLayer.trim())
+          .filter(Boolean);
+        if (metadata.tileType === "vector" && sourceLayers.length === 0) {
+          throw new Error("Enter at least one vector source layer.");
+        }
+
+        const minzoom = metadata.minZoom ?? undefined;
+        const maxzoom = metadata.maxZoom ?? undefined;
+        addAndClose(
+          createBaseLayer(
+            name,
+            "mbtiles",
+            {
+              bounds: metadata.bounds ?? undefined,
+              maxzoom,
+              minzoom,
+              sourceLayers,
+              tileSize: 256,
+              tiles: [mbtilesTileUrl(path)],
+              type: metadata.tileType,
+            },
+            {
+              bounds: metadata.bounds,
+              center: metadata.center,
+              format: metadata.format,
+              maxzoom,
+              minzoom,
+              scheme: metadata.scheme,
+              sourceKind: "mbtiles-file",
+              sourceLayers,
+              tileType: metadata.tileType,
+            },
+          ),
         );
         return;
       }
@@ -638,7 +731,58 @@ export function AddDataDialog({
                   <Input
                     id="vector-source-layer"
                     value={vectorSourceLayer}
-                    onChange={(event) => setVectorSourceLayer(event.target.value)}
+                    onChange={(event) =>
+                      setVectorSourceLayer(event.target.value)
+                    }
+                  />
+                </div>
+              )}
+            </div>
+          )}
+
+          {kind === "mbtiles" && (
+            <div className="space-y-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handleChooseMbtilesFile}
+                >
+                  <FileUp className="mr-2 h-3.5 w-3.5" />
+                  Choose file
+                </Button>
+                <span className="min-w-0 truncate text-xs text-muted-foreground">
+                  {selectedMbtiles
+                    ? fileNameFromPath(selectedMbtiles.path)
+                    : "No file selected"}
+                </span>
+              </div>
+              {selectedMbtiles && (
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="space-y-1.5">
+                    <Label>Tile type</Label>
+                    <div className="rounded-md border bg-muted/30 px-3 py-2 text-sm">
+                      {selectedMbtiles.metadata.tileType}
+                    </div>
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label>Format</Label>
+                    <div className="rounded-md border bg-muted/30 px-3 py-2 text-sm">
+                      {selectedMbtiles.metadata.format}
+                    </div>
+                  </div>
+                </div>
+              )}
+              {selectedMbtiles?.metadata.tileType === "vector" && (
+                <div className="space-y-1.5">
+                  <Label htmlFor="mbtiles-source-layers">Source layers</Label>
+                  <Input
+                    id="mbtiles-source-layers"
+                    placeholder="building, place, water"
+                    value={mbtilesSourceLayers}
+                    onChange={(event) =>
+                      setMbtilesSourceLayers(event.target.value)
+                    }
                   />
                 </div>
               )}
@@ -730,9 +874,7 @@ export function AddDataDialog({
                       className={SELECT_CLASS}
                       value={rasterColormap}
                       onChange={(event) =>
-                        setRasterColormap(
-                          event.target.value as RasterColormap,
-                        )
+                        setRasterColormap(event.target.value as RasterColormap)
                       }
                     >
                       {COG_COLORMAPS.map((colormap) => (

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -15,6 +15,7 @@ import {
   loadDroppedVectorFiles,
   loadDroppedVectorPaths,
 } from "../../lib/tauri-io";
+import { registerMbtilesProtocol } from "../../lib/mbtiles";
 import { AttributeTable } from "../panels/AttributeTable";
 import { LayerPanel } from "../panels/LayerPanel";
 import { StylePanel } from "../panels/StylePanel";
@@ -91,6 +92,10 @@ export function DesktopShell({
       setDropMessage(null);
       setDropError(null);
     }, 4000);
+  }, []);
+
+  useEffect(() => {
+    if (isTauri()) registerMbtilesProtocol();
   }, []);
 
   useEffect(() => {
@@ -243,7 +248,8 @@ export function DesktopShell({
 
       const startX = event.clientX;
       const startWidth = layerPanelWidth;
-      const panelRect = event.currentTarget.parentElement?.getBoundingClientRect();
+      const panelRect =
+        event.currentTarget.parentElement?.getBoundingClientRect();
       let nextWidth = startWidth;
       let resizeFrame: number | null = null;
       const previousCursor = document.body.style.cursor;
@@ -308,7 +314,8 @@ export function DesktopShell({
 
       const startX = event.clientX;
       const startWidth = stylePanelWidth;
-      const panelRect = event.currentTarget.parentElement?.getBoundingClientRect();
+      const panelRect =
+        event.currentTarget.parentElement?.getBoundingClientRect();
       let nextWidth = startWidth;
       let resizeFrame: number | null = null;
       const previousCursor = document.body.style.cursor;
@@ -389,9 +396,7 @@ export function DesktopShell({
         <main className="relative min-h-72 min-w-0 flex-1 md:min-h-0">
           <MapCanvas controllerRef={mapControllerRef} />
         </main>
-        <StylePanel
-          onResizeStart={startStylePanelResize}
-        />
+        <StylePanel onResizeStart={startStylePanelResize} />
       </div>
       <AttributeTable />
       <StatusBar />

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -1,4 +1,8 @@
-import { projectFromStore, serializeProject, useAppStore } from "@geolibre/core";
+import {
+  projectFromStore,
+  serializeProject,
+  useAppStore,
+} from "@geolibre/core";
 import {
   type BuiltInMapControl,
   DEFAULT_BUILT_IN_CONTROL_VISIBILITY,
@@ -204,6 +208,9 @@ export function TopToolbar({
           <DropdownMenuItem onSelect={handleAddPMTilesLayer}>
             Add PMTiles Layer
           </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setAddDataKind("mbtiles")}>
+            Add MBTiles Layer
+          </DropdownMenuItem>
           <DropdownMenuItem onSelect={handleAddZarrLayer}>
             Add Zarr Layer
           </DropdownMenuItem>
@@ -315,13 +322,17 @@ export function TopToolbar({
       <div className="ml-auto flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
         <Button
           aria-label={
-            themeMode === "dark" ? "Switch to light mode" : "Switch to dark mode"
+            themeMode === "dark"
+              ? "Switch to light mode"
+              : "Switch to dark mode"
           }
           className="h-7 w-7 shrink-0"
           onClick={onToggleThemeMode}
           size="icon"
           title={
-            themeMode === "dark" ? "Switch to light mode" : "Switch to dark mode"
+            themeMode === "dark"
+              ? "Switch to light mode"
+              : "Switch to dark mode"
           }
           variant="ghost"
         >

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -82,7 +82,9 @@ export function LayerPanel({
   const reorderLayer = useAppStore((s) => s.reorderLayer);
   const moveLayer = useAppStore((s) => s.moveLayer);
   const removeLayer = useAppStore((s) => s.removeLayer);
-  const [metadataLayer, setMetadataLayer] = useState<GeoLibreLayer | null>(null);
+  const [metadataLayer, setMetadataLayer] = useState<GeoLibreLayer | null>(
+    null,
+  );
   const [layerPendingRemoval, setLayerPendingRemoval] =
     useState<GeoLibreLayer | null>(null);
   const [isCollapsed, setIsCollapsed] = useState(isMobileViewport);
@@ -170,9 +172,7 @@ export function LayerPanel({
   }
 
   return (
-    <aside
-      className="relative flex max-h-56 w-full shrink-0 flex-col border-b bg-card md:max-h-none md:w-[var(--layer-panel-width)] md:border-b-0 md:border-r"
-    >
+    <aside className="relative flex max-h-56 w-full shrink-0 flex-col border-b bg-card md:max-h-none md:w-[var(--layer-panel-width)] md:border-b-0 md:border-r">
       <div
         role="separator"
         aria-orientation="vertical"
@@ -222,6 +222,8 @@ export function LayerPanel({
             const canIdentify =
               layer.type === "geojson" ||
               layer.type === "vector-tiles" ||
+              (layer.type === "mbtiles" &&
+                layer.metadata.tileType === "vector") ||
               hasNativeIdentifyLayers(layer);
             const identifyActive = identifyLayerId === layer.id;
             return (
@@ -231,9 +233,7 @@ export function LayerPanel({
                   selectedLayerId === layer.id
                     ? "border-primary bg-primary/5"
                     : "border-border bg-background hover:border-muted-foreground/40 hover:bg-muted/20"
-                } ${
-                  draggedLayerId === layer.id ? "opacity-50" : ""
-                }`}
+                } ${draggedLayerId === layer.id ? "opacity-50" : ""}`}
                 onDragOver={(e) => handleLayerDragOver(e, layer.id)}
                 onDrop={(e) => handleLayerDrop(e, layer.id, displayIndex)}
                 onDragEnd={resetDragState}
@@ -293,7 +293,9 @@ export function LayerPanel({
                   </p>
                 )}
                 <div className="mt-2 flex items-center gap-1">
-                  <span className="text-[10px] text-muted-foreground">Opacity</span>
+                  <span className="text-[10px] text-muted-foreground">
+                    Opacity
+                  </span>
                   <Slider
                     className="flex-1"
                     min={0}
@@ -419,9 +421,7 @@ export function LayerPanel({
               <button
                 type="button"
                 className="rounded p-0.5 hover:bg-muted"
-                title={
-                  basemapVisible ? "Hide background" : "Show background"
-                }
+                title={basemapVisible ? "Hide background" : "Show background"}
                 aria-label={
                   basemapVisible ? "Hide background" : "Show background"
                 }
@@ -445,18 +445,14 @@ export function LayerPanel({
               </span>
             </div>
             <div className="mt-2 flex items-center gap-1">
-              <span className="text-[10px] text-muted-foreground">
-                Opacity
-              </span>
+              <span className="text-[10px] text-muted-foreground">Opacity</span>
               <Slider
                 className="flex-1"
                 min={0}
                 max={1}
                 step={0.05}
                 value={[basemapOpacity]}
-                onValueChange={([v]) =>
-                  setBasemapOpacity(v ?? basemapOpacity)
-                }
+                onValueChange={([v]) => setBasemapOpacity(v ?? basemapOpacity)}
                 onClick={(e) => e.stopPropagation()}
               />
             </div>

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -4,7 +4,14 @@ import {
   type LayerType,
   useAppStore,
 } from "@geolibre/core";
-import { Button, Input, Label, ScrollArea, Separator, Slider } from "@geolibre/ui";
+import {
+  Button,
+  Input,
+  Label,
+  ScrollArea,
+  Separator,
+  Slider,
+} from "@geolibre/ui";
 import {
   ChevronDown,
   ChevronUp,
@@ -12,10 +19,7 @@ import {
   PanelRightOpen,
   SlidersHorizontal,
 } from "lucide-react";
-import {
-  type MouseEvent as ReactMouseEvent,
-  useState,
-} from "react";
+import { type MouseEvent as ReactMouseEvent, useState } from "react";
 
 interface StylePanelProps {
   onResizeStart: (event: ReactMouseEvent<HTMLDivElement>) => void;
@@ -205,9 +209,7 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
 
   if (!layer) {
     return (
-      <aside
-        className="relative flex max-h-56 w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0"
-      >
+      <aside className="relative flex max-h-56 w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0">
         {resizeHandle}
         <div className="flex items-center justify-between border-b px-3 py-1.5">
           <span className="text-sm font-semibold">Style</span>
@@ -238,15 +240,14 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
     !isRasterTileLayer &&
     (layer.type === "geojson" ||
       layer.type === "vector-tiles" ||
+      layer.type === "mbtiles" ||
       hasExternalNativeLayers(layer));
   const hasRasterPaintControls =
     isRasterPaintLayer(layer.type) || isRasterTileLayer;
 
   if (hasRasterPaintControls) {
     return (
-      <aside
-        className="relative flex max-h-56 w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0"
-      >
+      <aside className="relative flex max-h-56 w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0">
         {resizeHandle}
         <div className="flex items-center justify-between gap-2 border-b px-3 py-1.5">
           <span className="truncate text-sm font-semibold">
@@ -342,9 +343,7 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
 
   if (!hasVectorPaintControls) {
     return (
-      <aside
-        className="relative flex max-h-56 w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0"
-      >
+      <aside className="relative flex max-h-56 w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0">
         {resizeHandle}
         <div className="flex items-center justify-between gap-2 border-b px-3 py-1.5">
           <span className="truncate text-sm font-semibold">
@@ -373,9 +372,7 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
   }
 
   return (
-    <aside
-      className="relative flex max-h-56 w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0"
-    >
+    <aside className="relative flex max-h-56 w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0">
       {resizeHandle}
       <div className="flex items-center justify-between gap-2 border-b px-3 py-1.5">
         <span className="truncate text-sm font-semibold">
@@ -423,9 +420,7 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
             max={20}
             step={0.5}
             value={style.strokeWidth}
-            onChange={(strokeWidth) =>
-              setLayerStyle(layer.id, { strokeWidth })
-            }
+            onChange={(strokeWidth) => setLayerStyle(layer.id, { strokeWidth })}
           />
           <NumericStyleInput
             id="fillOpacity"
@@ -434,9 +429,7 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
             max={1}
             step={0.05}
             value={style.fillOpacity}
-            onChange={(fillOpacity) =>
-              setLayerStyle(layer.id, { fillOpacity })
-            }
+            onChange={(fillOpacity) => setLayerStyle(layer.id, { fillOpacity })}
           />
           <NumericStyleInput
             id="circleRadius"

--- a/apps/geolibre-desktop/src/lib/mbtiles.ts
+++ b/apps/geolibre-desktop/src/lib/mbtiles.ts
@@ -1,0 +1,86 @@
+import { isTauri } from "./tauri-io";
+import { addProtocol, type RequestParameters } from "maplibre-gl";
+
+const MBTILES_PROTOCOL = "geolibre-mbtiles";
+
+let protocolRegistered = false;
+
+export interface MbtilesMetadata {
+  name: string;
+  format: string;
+  tileType: "raster" | "vector";
+  sourceLayers: string[];
+  minZoom?: number | null;
+  maxZoom?: number | null;
+  bounds?: [number, number, number, number] | null;
+  center?: [number, number, number] | null;
+  scheme: string;
+}
+
+export function mbtilesTileUrl(path: string): string {
+  return `${MBTILES_PROTOCOL}://tile/{z}/{x}/{y}?path=${encodeURIComponent(path)}`;
+}
+
+export async function readMbtilesMetadata(
+  path: string,
+): Promise<MbtilesMetadata> {
+  if (!isTauri()) {
+    throw new Error("MBTiles files require GeoLibre Desktop.");
+  }
+
+  const { invoke } = await import("@tauri-apps/api/core");
+  return invoke<MbtilesMetadata>("read_mbtiles_metadata", { path });
+}
+
+export function registerMbtilesProtocol(): void {
+  if (protocolRegistered) return;
+
+  addProtocol(MBTILES_PROTOCOL, async (request) => {
+    const params = parseMbtilesTileRequest(request);
+    const { invoke } = await import("@tauri-apps/api/core");
+    const bytes = await invoke<number[] | Uint8Array>(
+      "read_mbtiles_tile",
+      params,
+    );
+    const array = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return {
+      data: array.buffer.slice(
+        array.byteOffset,
+        array.byteOffset + array.byteLength,
+      ),
+    };
+  });
+  protocolRegistered = true;
+}
+
+function parseMbtilesTileRequest(request: RequestParameters): {
+  path: string;
+  z: number;
+  x: number;
+  y: number;
+} {
+  const url = new URL(request.url);
+  const parts = url.pathname.split("/").filter(Boolean);
+  if (parts.length !== 3) {
+    throw new Error("Invalid MBTiles tile URL.");
+  }
+  const path = url.searchParams.get("path");
+  if (!path) {
+    throw new Error("Invalid MBTiles tile path.");
+  }
+
+  return {
+    path,
+    z: parseTileCoordinate(parts[0], "z"),
+    x: parseTileCoordinate(parts[1], "x"),
+    y: parseTileCoordinate(parts[2], "y"),
+  };
+}
+
+function parseTileCoordinate(value: string, label: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`Invalid MBTiles ${label} coordinate.`);
+  }
+  return parsed;
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -33,8 +33,7 @@ export const OPENFREEMAP_BASEMAPS = [
   },
 ] as const;
 
-export const DEFAULT_BASEMAP =
-  "https://tiles.openfreemap.org/styles/liberty";
+export const DEFAULT_BASEMAP = "https://tiles.openfreemap.org/styles/liberty";
 
 export const BLANK_BASEMAP = "";
 
@@ -47,6 +46,7 @@ export type LayerType =
   | "xyz"
   | "vector-tiles"
   | "pmtiles"
+  | "mbtiles"
   | "zarr"
   | "lidar"
   | "cog"

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -1,11 +1,8 @@
 import { useAppStore, type GeoLibreLayer } from "@geolibre/core";
 import maplibregl from "maplibre-gl";
 import { memo, useEffect, useRef } from "react";
-import {
-  circleLayerId,
-  fillLayerId,
-  lineLayerId,
-} from "./geojson-loader";
+import { circleLayerId, fillLayerId, lineLayerId } from "./geojson-loader";
+import { mbtilesStyleLayerIds } from "./layer-sync";
 import { createMapController, type MapController } from "./map-controller";
 import "maplibre-gl/dist/maplibre-gl.css";
 import "maplibre-gl-layer-control/style.css";
@@ -44,7 +41,8 @@ function createIdentifyPopupElement(
 
   const appendRow = (key: string, value: unknown) => {
     const row = document.createElement("div");
-    row.className = "grid grid-cols-[minmax(5rem,0.45fr)_1fr] gap-2 border-t py-1";
+    row.className =
+      "grid grid-cols-[minmax(5rem,0.45fr)_1fr] gap-2 border-t py-1";
 
     const keyCell = document.createElement("div");
     keyCell.className = "break-words font-medium text-muted-foreground";
@@ -83,6 +81,7 @@ function nativeIdentifyLayerIds(layer: GeoLibreLayer): string[] {
 function identifyStyleLayerIds(layer: GeoLibreLayer): string[] {
   return [
     ...nativeIdentifyLayerIds(layer),
+    ...mbtilesStyleLayerIds(layer),
     circleLayerId(layer.id),
     lineLayerId(layer.id),
     fillLayerId(layer.id),
@@ -123,9 +122,7 @@ export const MapCanvas = memo(function MapCanvas({
   const selectedLayerId = useAppStore((s) => s.selectedLayerId);
   const selectedFeatureId = useAppStore((s) => s.selectedFeatureId);
   const identifyLayerId = useAppStore((s) => s.identifyLayerId);
-  const zoomToSelectedFeature = useAppStore(
-    (s) => s.ui.zoomToSelectedFeature,
-  );
+  const zoomToSelectedFeature = useAppStore((s) => s.ui.zoomToSelectedFeature);
   const selectFeature = useAppStore((s) => s.selectFeature);
   const setMapView = useAppStore((s) => s.setMapView);
   const setPointerCoords = useAppStore((s) => s.setPointerCoords);
@@ -257,7 +254,8 @@ export const MapCanvas = memo(function MapCanvas({
         : null;
     const shouldFit = Boolean(
       zoomToSelectedFeature &&
-      nextKey && nextKey !== previousSelectedFeatureKey.current,
+      nextKey &&
+      nextKey !== previousSelectedFeatureKey.current,
     );
     previousSelectedFeatureKey.current = nextKey;
     controller.current?.highlightFeature(layer, selectedFeatureId, {

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -28,17 +28,18 @@ export function syncLayer(
     return;
   }
 
-  if (
-    layer.type === "raster" ||
-    layer.type === "wms" ||
-    layer.type === "xyz"
-  ) {
+  if (layer.type === "raster" || layer.type === "wms" || layer.type === "xyz") {
     syncRasterTileLayer(map, layer, beforeId);
     return;
   }
 
   if (layer.type === "vector-tiles") {
     syncVectorTileLayer(map, layer, beforeId);
+    return;
+  }
+
+  if (layer.type === "mbtiles") {
+    syncMbtilesLayer(map, layer, beforeId);
   }
 }
 
@@ -273,6 +274,174 @@ function syncVectorTileLayer(
   );
 }
 
+function syncMbtilesLayer(
+  map: maplibregl.Map,
+  layer: GeoLibreLayer,
+  beforeId?: string,
+): void {
+  if (layer.metadata.tileType === "raster" || layer.source.type === "raster") {
+    syncRasterTileLayer(map, layer, beforeId);
+    return;
+  }
+
+  syncMbtilesVectorLayer(map, layer, beforeId);
+}
+
+function syncMbtilesVectorLayer(
+  map: maplibregl.Map,
+  layer: GeoLibreLayer,
+  beforeId?: string,
+): void {
+  const src = sourceId(layer.id);
+  const tiles = (layer.source.tiles as string[] | undefined) ?? [];
+  if (tiles.length === 0) return;
+
+  if (!map.getSource(src)) {
+    map.addSource(src, {
+      type: "vector",
+      tiles,
+      bounds: layer.source.bounds as
+        | [number, number, number, number]
+        | undefined,
+      maxzoom: layer.source.maxzoom as number | undefined,
+      minzoom: layer.source.minzoom as number | undefined,
+    });
+  }
+
+  const visibility = layer.visible ? "visible" : "none";
+  const sourceLayers = getMbtilesSourceLayers(layer);
+  const currentLayerIds = new Set(mbtilesStyleLayerIds(layer));
+
+  for (const sourceLayer of sourceLayers) {
+    ensureLayer(
+      map,
+      mbtilesFillLayerId(layer.id, sourceLayer),
+      {
+        id: mbtilesFillLayerId(layer.id, sourceLayer),
+        type: "fill",
+        source: src,
+        "source-layer": sourceLayer,
+        filter: [
+          "match",
+          ["geometry-type"],
+          ["Polygon", "MultiPolygon"],
+          true,
+          false,
+        ],
+        paint: fillPaint(layer.style, layer.opacity),
+        layout: { visibility },
+      },
+      beforeId,
+    );
+    ensureLayer(
+      map,
+      mbtilesLineLayerId(layer.id, sourceLayer),
+      {
+        id: mbtilesLineLayerId(layer.id, sourceLayer),
+        type: "line",
+        source: src,
+        "source-layer": sourceLayer,
+        filter: [
+          "match",
+          ["geometry-type"],
+          ["LineString", "MultiLineString", "Polygon", "MultiPolygon"],
+          true,
+          false,
+        ],
+        paint: linePaint(layer.style, layer.opacity),
+        layout: { visibility },
+      },
+      beforeId,
+    );
+    ensureLayer(
+      map,
+      mbtilesCircleLayerId(layer.id, sourceLayer),
+      {
+        id: mbtilesCircleLayerId(layer.id, sourceLayer),
+        type: "circle",
+        source: src,
+        "source-layer": sourceLayer,
+        filter: [
+          "match",
+          ["geometry-type"],
+          ["Point", "MultiPoint"],
+          true,
+          false,
+        ],
+        paint: circlePaint(layer.style, layer.opacity),
+        layout: { visibility },
+      },
+      beforeId,
+    );
+  }
+
+  removeStaleMbtilesLayers(map, layer.id, currentLayerIds);
+}
+
+function getMbtilesSourceLayers(layer: GeoLibreLayer): string[] {
+  const sourceLayers = layer.source.sourceLayers ?? layer.metadata.sourceLayers;
+  return Array.isArray(sourceLayers)
+    ? sourceLayers.filter(
+        (sourceLayer): sourceLayer is string =>
+          typeof sourceLayer === "string" && sourceLayer.length > 0,
+      )
+    : [];
+}
+
+function removeStaleMbtilesLayers(
+  map: maplibregl.Map,
+  layerId: string,
+  currentLayerIds: Set<string>,
+): void {
+  const prefix = `layer-${layerId}-mbtiles-`;
+  for (const styleLayer of map.getStyle().layers ?? []) {
+    if (
+      styleLayer.id.startsWith(prefix) &&
+      !currentLayerIds.has(styleLayer.id)
+    ) {
+      removeIfExists(map, styleLayer.id);
+    }
+  }
+}
+
+function encodeMbtilesLayerPart(value: string): string {
+  return encodeURIComponent(value).replaceAll("%", "_");
+}
+
+export function mbtilesFillLayerId(
+  layerId: string,
+  sourceLayer: string,
+): string {
+  return `layer-${layerId}-mbtiles-${encodeMbtilesLayerPart(sourceLayer)}-fill`;
+}
+
+export function mbtilesLineLayerId(
+  layerId: string,
+  sourceLayer: string,
+): string {
+  return `layer-${layerId}-mbtiles-${encodeMbtilesLayerPart(sourceLayer)}-line`;
+}
+
+export function mbtilesCircleLayerId(
+  layerId: string,
+  sourceLayer: string,
+): string {
+  return `layer-${layerId}-mbtiles-${encodeMbtilesLayerPart(sourceLayer)}-circle`;
+}
+
+export function mbtilesStyleLayerIds(layer: GeoLibreLayer): string[] {
+  if (layer.type !== "mbtiles") return [];
+  if (layer.metadata.tileType === "raster" || layer.source.type === "raster") {
+    return [`layer-${layer.id}-raster`];
+  }
+
+  return getMbtilesSourceLayers(layer).flatMap((sourceLayer) => [
+    mbtilesCircleLayerId(layer.id, sourceLayer),
+    mbtilesLineLayerId(layer.id, sourceLayer),
+    mbtilesFillLayerId(layer.id, sourceLayer),
+  ]);
+}
+
 function ensureLayer(
   map: maplibregl.Map,
   id: string,
@@ -296,7 +465,8 @@ function ensureLayer(
     moveLayer(map, id, beforeId);
     return;
   }
-  const validBeforeId = beforeId && map.getLayer(beforeId) ? beforeId : undefined;
+  const validBeforeId =
+    beforeId && map.getLayer(beforeId) ? beforeId : undefined;
   map.addLayer(spec, validBeforeId);
 }
 
@@ -304,11 +474,7 @@ function removeIfExists(map: maplibregl.Map, id: string): void {
   if (map.getLayer(id)) map.removeLayer(id);
 }
 
-function moveLayer(
-  map: maplibregl.Map,
-  id: string,
-  beforeId?: string,
-): void {
+function moveLayer(map: maplibregl.Map, id: string, beforeId?: string): void {
   try {
     if (beforeId && beforeId !== id && map.getLayer(beforeId)) {
       map.moveLayer(id, beforeId);
@@ -327,6 +493,7 @@ export function removeLayerFromMap(
 ): void {
   for (const id of [
     ...getExternalNativeLayerIds(layer),
+    ...(layer ? mbtilesStyleLayerIds(layer) : []),
     fillLayerId(layerId),
     lineLayerId(layerId),
     circleLayerId(layerId),

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -19,7 +19,11 @@ import {
   lineLayerId,
   sourceId,
 } from "./geojson-loader";
-import { removeLayerFromMap, syncLayer } from "./layer-sync";
+import {
+  mbtilesStyleLayerIds,
+  removeLayerFromMap,
+  syncLayer,
+} from "./layer-sync";
 
 const DEFAULT_PROJECTION: maplibregl.ProjectionSpecification = {
   type: "globe",
@@ -189,7 +193,10 @@ export class MapController {
   private controlVisibility: Record<BuiltInMapControl, boolean> = {
     ...DEFAULT_BUILT_IN_CONTROL_VISIBILITY,
   };
-  private controlPositions: Record<BuiltInMapControl, maplibregl.ControlPosition> = {
+  private controlPositions: Record<
+    BuiltInMapControl,
+    maplibregl.ControlPosition
+  > = {
     ...DEFAULT_BUILT_IN_CONTROL_POSITIONS,
   };
 
@@ -371,12 +378,7 @@ export class MapController {
       zoom: this.map.getZoom(),
       bearing: this.map.getBearing(),
       pitch: this.map.getPitch(),
-      bbox: [
-        b.getWest(),
-        b.getSouth(),
-        b.getEast(),
-        b.getNorth(),
-      ],
+      bbox: [b.getWest(), b.getSouth(), b.getEast(), b.getNorth()],
     };
   }
 
@@ -686,11 +688,7 @@ export class MapController {
   }
 
   private addTerrainSource(): boolean {
-    if (
-      !this.map ||
-      !this.controlVisibility.terrain ||
-      !this.isStyleReady()
-    ) {
+    if (!this.map || !this.controlVisibility.terrain || !this.isStyleReady()) {
       return false;
     }
     if (this.map.getSource(TERRAIN_SOURCE_ID)) return true;
@@ -707,9 +705,8 @@ export class MapController {
       return false;
     }
     const layerControlConfig = this.createLayerControlConfig(this.syncedLayers);
-    this.layerControlSignature = this.createLayerControlSignature(
-      layerControlConfig,
-    );
+    this.layerControlSignature =
+      this.createLayerControlSignature(layerControlConfig);
     this.layerControl = new LayerControl({
       basemapStyleUrl: this.basemapStyleUrl,
       collapsed: true,
@@ -777,7 +774,9 @@ export class MapController {
 
     return {
       excludeLayers,
-      customLayerAdapters: [this.createGeoLibreLayerAdapter(controllableLayers)],
+      customLayerAdapters: [
+        this.createGeoLibreLayerAdapter(controllableLayers),
+      ],
     };
   }
 
@@ -856,10 +855,10 @@ export class MapController {
     const control = this.layerControl as unknown as LayerControlInternalState;
     const items = control.panel?.querySelectorAll(".layer-control-item") ?? [];
     return (
-      Array.from(items).find(
+      (Array.from(items).find(
         (item) => (item as HTMLElement).dataset.layerId === layerId,
-      ) as HTMLElement | undefined
-    ) ?? null;
+      ) as HTMLElement | undefined) ?? null
+    );
   }
 
   private updateLayerControlItem(
@@ -879,7 +878,9 @@ export class MapController {
       opacity.title = `Opacity: ${Math.round(state.opacity * 100)}%`;
     }
 
-    const name = item.querySelector(".layer-control-name") as HTMLElement | null;
+    const name = item.querySelector(
+      ".layer-control-name",
+    ) as HTMLElement | null;
     if (name) {
       name.textContent = state.name;
       name.title = state.name;
@@ -1042,7 +1043,9 @@ export class MapController {
   ): string | undefined {
     if (!this.map || !layer?.beforeId) return undefined;
     if (
-      this.getCandidateStyleLayers(layer).some(({ id }) => id === layer.beforeId)
+      this.getCandidateStyleLayers(layer).some(
+        ({ id }) => id === layer.beforeId,
+      )
     ) {
       return undefined;
     }
@@ -1078,6 +1081,13 @@ export class MapController {
 
     if (layer.type === "vector-tiles") {
       return [{ id: `layer-${layer.id}-vector` }];
+    }
+
+    if (layer.type === "mbtiles") {
+      return mbtilesStyleLayerIds(layer).map((id) => ({
+        id,
+        suffix: nativeLayerSuffix(id),
+      }));
     }
 
     return [];
@@ -1153,10 +1163,7 @@ export class MapController {
       },
       trackUserLocation: true,
     });
-    this.map.addControl(
-      this.geolocateControl,
-      this.controlPositions.geolocate,
-    );
+    this.map.addControl(this.geolocateControl, this.controlPositions.geolocate);
     return true;
   }
 


### PR DESCRIPTION
## Summary
- Add local MBTiles file support to the desktop app via two new Tauri commands: `read_mbtiles_metadata` (name, format, tile type, zoom range, bounds, center, source layers) and `read_mbtiles_tile` (with TMS/XYZ row flipping and gzip/zlib decompression).
- Add a `mbtiles.ts` frontend module that registers a custom MapLibre protocol to stream tiles from the Rust backend, plus a new `"mbtiles"` layer type and supporting UI/map wiring (add-data dialog, layer/style panels, layer sync, map controller).

## Test plan
- [ ] Load a vector MBTiles file and confirm tiles render with correct source layers.
- [ ] Load a raster MBTiles file and confirm tiles render.
- [ ] Verify both TMS and XYZ tile schemes display correctly.
- [ ] Confirm gzip/zlib-compressed tiles decompress and render.