### PR TITLE
feat: add COMTiles vector tile layer support

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -42,6 +42,7 @@
     "maplibre-gl-lidar": "^0.14.1",
     "maplibre-gl-streetview": "^0.4.0",
     "maplibre-gl-swipe": "^0.7.1",
+    "pako": "^2.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "shpjs": "^6.2.0",
@@ -50,6 +51,7 @@
   "devDependencies": {
     "@tauri-apps/cli": "^2.2.7",
     "@types/geojson": "^7946.0.16",
+    "@types/pako": "^2.0.4",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react": "^4.3.4",

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -38,8 +38,15 @@ import {
   registerMbtilesProtocol,
   type MbtilesMetadata,
 } from "../../lib/mbtiles";
+import { comtilesTileUrl, registerComtilesProtocol } from "../../lib/comtiles";
 
-export type AddDataKind = "xyz" | "wms" | "vector" | "raster" | "mbtiles";
+export type AddDataKind =
+  | "xyz"
+  | "wms"
+  | "vector"
+  | "raster"
+  | "mbtiles"
+  | "comtiles";
 
 interface AddDataDialogProps {
   kind: AddDataKind | null;
@@ -57,6 +64,7 @@ const KIND_LABELS: Record<AddDataKind, string> = {
   vector: "Add Vector Layer",
   raster: "Add Raster Layer",
   mbtiles: "Add MBTiles Layer",
+  comtiles: "Add COMTiles Layer",
 };
 
 const SELECT_CLASS =
@@ -163,6 +171,15 @@ function parseOptionalNumber(value: string, label: string): number | undefined {
   return parseRequiredNumber(value, label);
 }
 
+function parseOptionalInteger(value: string, label: string): number | undefined {
+  if (!value.trim()) return undefined;
+  const parsed = parseRequiredNumber(value, label);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`Enter a non-negative integer ${label}.`);
+  }
+  return parsed;
+}
+
 async function fetchGeoJson(url: string): Promise<FeatureCollection> {
   const response = await fetch(url);
   if (!response.ok) {
@@ -220,6 +237,10 @@ export function AddDataDialog({
     path: string;
   } | null>(null);
   const [mbtilesSourceLayers, setMbtilesSourceLayers] = useState("");
+  const [comtilesUrl, setComtilesUrl] = useState("");
+  const [comtilesSourceLayers, setComtilesSourceLayers] = useState("");
+  const [comtilesMinZoom, setComtilesMinZoom] = useState("");
+  const [comtilesMaxZoom, setComtilesMaxZoom] = useState("14");
 
   useEffect(() => {
     if (!kind) return;
@@ -232,6 +253,7 @@ export function AddDataDialog({
         vector: "Vector Layer",
         raster: "Raster Layer",
         mbtiles: "MBTiles Layer",
+        comtiles: "COMTiles Layer",
       }[kind],
     );
     setBeforeLayerId("");
@@ -258,6 +280,10 @@ export function AddDataDialog({
     setSelectedRasterPath(null);
     setSelectedMbtiles(null);
     setMbtilesSourceLayers("");
+    setComtilesUrl("");
+    setComtilesSourceLayers("");
+    setComtilesMinZoom("");
+    setComtilesMaxZoom("14");
   }, [kind]);
 
   const description = useMemo(() => {
@@ -275,6 +301,9 @@ export function AddDataDialog({
     }
     if (kind === "mbtiles") {
       return "Add a local MBTiles file as a raster or vector tile layer.";
+    }
+    if (kind === "comtiles") {
+      return "Add a cloud-hosted COMTiles archive as a vector tile layer.";
     }
     return "";
   }, [kind]);
@@ -490,6 +519,47 @@ export function AddDataDialog({
               sourceKind: "mbtiles-file",
               sourceLayers,
               tileType: metadata.tileType,
+            },
+          ),
+        );
+        return;
+      }
+
+      if (kind === "comtiles") {
+        const url = comtilesUrl.trim();
+        if (!url) throw new Error("Enter a COMTiles archive URL.");
+        const sourceLayers = comtilesSourceLayers
+          .split(",")
+          .map((sourceLayer) => sourceLayer.trim())
+          .filter(Boolean);
+        if (sourceLayers.length === 0) {
+          throw new Error("Enter at least one vector source layer.");
+        }
+        const minzoom = parseOptionalInteger(comtilesMinZoom, "minimum zoom");
+        const maxzoom = parseOptionalInteger(comtilesMaxZoom, "maximum zoom");
+        if (minzoom !== undefined && maxzoom !== undefined && maxzoom < minzoom) {
+          throw new Error("Maximum zoom must be greater than or equal to minimum zoom.");
+        }
+
+        registerComtilesProtocol();
+        addAndClose(
+          createBaseLayer(
+            name,
+            "comtiles",
+            {
+              maxzoom,
+              minzoom,
+              sourceLayers,
+              tiles: [comtilesTileUrl(url)],
+              type: "vector",
+            },
+            {
+              format: "comt",
+              maxzoom,
+              minzoom,
+              sourceKind: "comtiles-url",
+              sourceLayers,
+              tileType: "vector",
             },
           ),
         );
@@ -786,6 +856,52 @@ export function AddDataDialog({
                   />
                 </div>
               )}
+            </div>
+          )}
+
+          {kind === "comtiles" && (
+            <div className="space-y-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="comtiles-url">Archive URL</Label>
+                <Input
+                  id="comtiles-url"
+                  placeholder="https://example.com/tiles.comt"
+                  value={comtilesUrl}
+                  onChange={(event) => setComtilesUrl(event.target.value)}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="comtiles-source-layers">Source layers</Label>
+                <Input
+                  id="comtiles-source-layers"
+                  placeholder="building, place, water"
+                  value={comtilesSourceLayers}
+                  onChange={(event) =>
+                    setComtilesSourceLayers(event.target.value)
+                  }
+                />
+              </div>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="space-y-1.5">
+                  <Label htmlFor="comtiles-minzoom">Min zoom</Label>
+                  <Input
+                    id="comtiles-minzoom"
+                    inputMode="numeric"
+                    placeholder="Optional"
+                    value={comtilesMinZoom}
+                    onChange={(event) => setComtilesMinZoom(event.target.value)}
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="comtiles-maxzoom">Max zoom</Label>
+                  <Input
+                    id="comtiles-maxzoom"
+                    inputMode="numeric"
+                    value={comtilesMaxZoom}
+                    onChange={(event) => setComtilesMaxZoom(event.target.value)}
+                  />
+                </div>
+              </div>
             </div>
           )}
 

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -15,6 +15,7 @@ import {
   loadDroppedVectorFiles,
   loadDroppedVectorPaths,
 } from "../../lib/tauri-io";
+import { registerComtilesProtocol } from "../../lib/comtiles";
 import { registerMbtilesProtocol } from "../../lib/mbtiles";
 import { AttributeTable } from "../panels/AttributeTable";
 import { LayerPanel } from "../panels/LayerPanel";
@@ -96,6 +97,7 @@ export function DesktopShell({
 
   useEffect(() => {
     if (isTauri()) registerMbtilesProtocol();
+    registerComtilesProtocol();
   }, []);
 
   useEffect(() => {

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -211,6 +211,9 @@ export function TopToolbar({
           <DropdownMenuItem onSelect={() => setAddDataKind("mbtiles")}>
             Add MBTiles Layer
           </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setAddDataKind("comtiles")}>
+            Add COMTiles Layer
+          </DropdownMenuItem>
           <DropdownMenuItem onSelect={handleAddZarrLayer}>
             Add Zarr Layer
           </DropdownMenuItem>

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -45,6 +45,9 @@ function layerTypeLabel(layer: GeoLibreLayer): string {
   if (layer.type === "geojson" || layer.type === "vector-tiles") {
     return "vector";
   }
+  if (layer.type === "comtiles") {
+    return "COMTiles";
+  }
   return layer.type;
 }
 
@@ -222,6 +225,7 @@ export function LayerPanel({
             const canIdentify =
               layer.type === "geojson" ||
               layer.type === "vector-tiles" ||
+              layer.type === "comtiles" ||
               (layer.type === "mbtiles" &&
                 layer.metadata.tileType === "vector") ||
               hasNativeIdentifyLayers(layer);

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -241,6 +241,7 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
     (layer.type === "geojson" ||
       layer.type === "vector-tiles" ||
       layer.type === "mbtiles" ||
+      layer.type === "comtiles" ||
       hasExternalNativeLayers(layer));
   const hasRasterPaintControls =
     isRasterPaintLayer(layer.type) || isRasterTileLayer;

--- a/apps/geolibre-desktop/src/lib/comtiles.ts
+++ b/apps/geolibre-desktop/src/lib/comtiles.ts
@@ -1,0 +1,584 @@
+import { addProtocol, type RequestParameters } from "maplibre-gl";
+import { ungzip } from "pako";
+
+const COMTILES_PROTOCOL = "comt";
+const INITIAL_CHUNK_SIZE = 2 ** 19;
+const METADATA_OFFSET_INDEX = 17;
+const DEFAULT_TILE_OFFSET_BYTES = 5;
+const TILE_SIZE_BYTES = 4;
+const SUPPORTED_TILE_MATRIX_CRS = "WebMercatorQuad";
+const SUPPORTED_ORDERING = "RowMajor";
+
+let protocolRegistered = false;
+const archiveCaches = new Map<string, ComtilesArchive>();
+
+interface TileMatrixLimits {
+  maxTileCol: number;
+  maxTileRow: number;
+  minTileCol: number;
+  minTileRow: number;
+}
+
+interface TileMatrix {
+  aggregationCoefficient: number;
+  tileMatrixLimits: TileMatrixLimits;
+  zoom: number;
+}
+
+interface ComtilesMetadata {
+  tileFormat: string;
+  tileOffsetBytes?: number;
+  tileMatrixSet: {
+    fragmentOrdering?: string;
+    tileMatrix: TileMatrix[];
+    tileMatrixCRS?: string;
+    tileOrdering?: string;
+  };
+}
+
+interface Header {
+  dataOffset: number;
+  indexOffset: number;
+  metadata: ComtilesMetadata;
+  partialIndex: ArrayBuffer;
+}
+
+interface IndexEntry {
+  offset: number;
+  size: number;
+}
+
+interface FragmentRange {
+  endOffset: number;
+  index: number;
+  startOffset: number;
+}
+
+interface TileIndex {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export function comtilesTileUrl(url: string): string {
+  const trimmedUrl = url.trim();
+  if (!trimmedUrl) return "";
+  if (trimmedUrl.startsWith(`${COMTILES_PROTOCOL}://`)) return trimmedUrl;
+  return `${COMTILES_PROTOCOL}://tile/{z}/{x}/{y}?url=${encodeURIComponent(
+    trimmedUrl,
+  )}`;
+}
+
+export function registerComtilesProtocol(): void {
+  if (protocolRegistered) return;
+
+  addProtocol(COMTILES_PROTOCOL, async (request, abortController) => {
+    const { archiveUrl, x, y, z } = parseComtilesTileRequest(request);
+    let archive = archiveCaches.get(archiveUrl);
+    if (!archive) {
+      archive = new ComtilesArchive(archiveUrl);
+      archiveCaches.set(archiveUrl, archive);
+    }
+
+    return {
+      data: await archive.getTile({ x, y, z }, abortController.signal),
+    };
+  });
+
+  protocolRegistered = true;
+}
+
+function parseComtilesTileRequest(request: RequestParameters): {
+  archiveUrl: string;
+  x: number;
+  y: number;
+  z: number;
+} {
+  const url = new URL(request.url);
+  const encodedArchiveUrl = url.searchParams.get("url");
+  if (encodedArchiveUrl) {
+    const parts = url.pathname.split("/").filter(Boolean);
+    if (parts.length !== 3) {
+      throw new Error("Invalid COMTiles tile URL.");
+    }
+    return {
+      archiveUrl: encodedArchiveUrl,
+      z: parseTileCoordinate(parts[0], "z"),
+      x: parseTileCoordinate(parts[1], "x"),
+      y: parseTileCoordinate(parts[2], "y"),
+    };
+  }
+
+  const match = request.url.match(
+    /^comt:\/\/(.+)\/(\d+)\/(\d+)\/(\d+)(?:[?#].*)?$/,
+  );
+  if (!match) {
+    throw new Error("Invalid COMTiles tile URL.");
+  }
+
+  return {
+    archiveUrl: match[1],
+    z: parseTileCoordinate(match[2], "z"),
+    x: parseTileCoordinate(match[3], "x"),
+    y: parseTileCoordinate(match[4], "y"),
+  };
+}
+
+function parseTileCoordinate(value: string, label: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`Invalid COMTiles ${label} coordinate.`);
+  }
+  return parsed;
+}
+
+class ComtilesArchive {
+  private header: Header | null = null;
+  private headerLoad: Promise<Header> | null = null;
+  private indexCache: ComtilesIndexCache | null = null;
+  private index: ComtilesIndex | null = null;
+  private readonly requestCache = new Map<number, Promise<ArrayBuffer>>();
+
+  constructor(private readonly url: string) {}
+
+  async getTile(tile: TileIndex, signal?: AbortSignal): Promise<ArrayBuffer> {
+    const entry = await this.getIndexEntry(tile, signal);
+    if (!entry || entry.indexEntry.size === 0) {
+      return new Uint8Array(0).buffer;
+    }
+
+    const compressedTile = await fetchBinaryRange(
+      this.url,
+      entry.absoluteTileOffset,
+      entry.absoluteTileOffset + entry.indexEntry.size - 1,
+      signal,
+    );
+    return uint8ArrayToArrayBuffer(ungzip(new Uint8Array(compressedTile)));
+  }
+
+  private async getIndexEntry(
+    tile: TileIndex,
+    signal?: AbortSignal,
+  ): Promise<
+    | {
+        absoluteTileOffset: number;
+        indexEntry: IndexEntry;
+      }
+    | undefined
+  > {
+    const header = await this.ensureHeader(signal);
+    const matrix = header.metadata.tileMatrixSet.tileMatrix.find(
+      (item) => item.zoom === tile.z,
+    );
+    if (!matrix) return undefined;
+
+    const tmsY = (1 << tile.z) - tile.y - 1;
+    const limit = matrix.tileMatrixLimits;
+    if (
+      tile.x < limit.minTileCol ||
+      tile.x > limit.maxTileCol ||
+      tmsY < limit.minTileRow ||
+      tmsY > limit.maxTileRow
+    ) {
+      return undefined;
+    }
+
+    const tmsTile = { x: tile.x, y: tmsY, z: tile.z };
+    const indexEntry =
+      this.indexCache?.get(tmsTile) ?? (await this.fetchIndexEntry(tmsTile, signal));
+    return {
+      absoluteTileOffset: header.dataOffset + indexEntry.offset,
+      indexEntry,
+    };
+  }
+
+  private async fetchIndexEntry(
+    tile: TileIndex,
+    signal?: AbortSignal,
+  ): Promise<IndexEntry> {
+    if (!this.header || !this.index || !this.indexCache) {
+      throw new Error("COMTiles archive header is not loaded.");
+    }
+
+    const fragmentRange = this.index.getFragmentRangeForTile(tile.z, tile.x, tile.y);
+    let indexFragment = this.requestCache.get(fragmentRange.startOffset);
+    if (!indexFragment) {
+      indexFragment = fetchBinaryRange(
+        this.url,
+        this.header.indexOffset + fragmentRange.startOffset,
+        this.header.indexOffset + fragmentRange.endOffset,
+        signal,
+      );
+      this.requestCache.set(fragmentRange.startOffset, indexFragment);
+      indexFragment.finally(() => {
+        this.requestCache.delete(fragmentRange.startOffset);
+      });
+    }
+
+    this.indexCache.setIndexFragment(
+      fragmentRange,
+      new Uint8Array(await indexFragment),
+    );
+    const entry = this.indexCache.get(tile);
+    if (!entry) {
+      throw new Error("COMTiles index entry could not be read.");
+    }
+    return entry;
+  }
+
+  private async ensureHeader(signal?: AbortSignal): Promise<Header> {
+    if (this.header) return this.header;
+    this.headerLoad ??= loadHeader(this.url, signal);
+    this.header = await this.headerLoad;
+    this.indexCache = new ComtilesIndexCache(
+      this.header.metadata,
+      new Uint8Array(this.header.partialIndex),
+    );
+    this.index = new ComtilesIndex(this.header.metadata);
+    return this.header;
+  }
+}
+
+class ComtilesIndexCache {
+  private readonly fragmentedIndex = new LruCache<
+    number,
+    { fragmentRange: FragmentRange; indexEntries: Uint8Array }
+  >(28);
+  private readonly index: ComtilesIndex;
+  private readonly indexEntryByteLength: number;
+
+  constructor(
+    private readonly metadata: ComtilesMetadata,
+    private readonly partialIndex = new Uint8Array(0),
+  ) {
+    this.index = new ComtilesIndex(metadata);
+    this.indexEntryByteLength = getIndexEntryByteLength(metadata);
+  }
+
+  get(tile: TileIndex): IndexEntry | undefined {
+    const { index } = this.index.calculateIndexOffsetForTile(
+      tile.z,
+      tile.x,
+      tile.y,
+    );
+    const { startOffset } = this.index.getFragmentRangeForTile(
+      tile.z,
+      tile.x,
+      tile.y,
+    );
+    const indexOffset = index * this.indexEntryByteLength;
+    if (indexOffset <= this.partialIndex.byteLength - this.indexEntryByteLength) {
+      return this.createIndexEntry(indexOffset, this.partialIndex);
+    }
+
+    const indexFragment = this.fragmentedIndex.get(startOffset);
+    if (!indexFragment) return undefined;
+
+    const relativeFragmentOffset =
+      (index - indexFragment.fragmentRange.index) * this.indexEntryByteLength;
+    return this.createIndexEntry(relativeFragmentOffset, indexFragment.indexEntries);
+  }
+
+  setIndexFragment(fragmentRange: FragmentRange, indexEntries: Uint8Array): void {
+    this.fragmentedIndex.put(fragmentRange.startOffset, {
+      fragmentRange,
+      indexEntries,
+    });
+  }
+
+  private createIndexEntry(
+    indexOffset: number,
+    indexEntries: Uint8Array,
+  ): IndexEntry {
+    const offsetBytes = this.metadata.tileOffsetBytes ?? DEFAULT_TILE_OFFSET_BYTES;
+    return {
+      offset: readUnsignedLittleEndian(indexEntries.buffer, indexOffset, offsetBytes),
+      size: new DataView(indexEntries.buffer).getUint32(
+        indexOffset + offsetBytes,
+        true,
+      ),
+    };
+  }
+}
+
+class ComtilesIndex {
+  private readonly indexEntryByteLength: number;
+  private readonly tileMatrixSet: ComtilesMetadata["tileMatrixSet"];
+
+  constructor(private readonly metadata: ComtilesMetadata) {
+    this.tileMatrixSet = metadata.tileMatrixSet;
+    this.indexEntryByteLength = getIndexEntryByteLength(metadata);
+  }
+
+  getFragmentRangeForTile(zoom: number, x: number, y: number): FragmentRange {
+    const tileMatrices = this.tileMatrixSet.tileMatrix.filter(
+      (tileMatrix) => tileMatrix.zoom <= zoom,
+    );
+
+    let startIndex = 0;
+    let endIndex = 0;
+    for (const tileMatrix of tileMatrices) {
+      const limit = tileMatrix.tileMatrixLimits;
+      if (tileMatrix.zoom === zoom && !isInRange(x, y, limit)) {
+        throw new Error("Specified tile index is not part of the COMTiles archive.");
+      }
+
+      if (tileMatrix.zoom < zoom) {
+        startIndex += countTiles(limit);
+        continue;
+      }
+
+      const fragmentBounds = calculateFragmentBounds(
+        x,
+        y,
+        tileMatrix.aggregationCoefficient,
+        limit,
+      );
+      startIndex += countIndexEntriesBeforeFragment(fragmentBounds, limit);
+      endIndex = startIndex + countTiles(fragmentBounds) - 1;
+    }
+
+    return {
+      endOffset: (endIndex + 1) * this.indexEntryByteLength,
+      index: startIndex,
+      startOffset: startIndex * this.indexEntryByteLength,
+    };
+  }
+
+  calculateIndexOffsetForTile(
+    zoom: number,
+    x: number,
+    y: number,
+  ): { index: number; offset: number } {
+    const offset = this.tileMatrixSet.tileMatrix
+      .filter((tileMatrix) => tileMatrix.zoom <= zoom)
+      .reduce((currentOffset, tileMatrix) => {
+        const limit = tileMatrix.tileMatrixLimits;
+        if (tileMatrix.zoom === zoom && !isInRange(x, y, limit)) {
+          throw new Error("Specified tile index is not part of the COMTiles archive.");
+        }
+
+        if (tileMatrix.zoom < zoom) {
+          return currentOffset + countTiles(limit) * this.indexEntryByteLength;
+        }
+
+        if (tileMatrix.aggregationCoefficient === -1) {
+          const rowCount = y - limit.minTileRow;
+          const columnCount = limit.maxTileCol - limit.minTileCol + 1;
+          const columnDelta = x - limit.minTileCol;
+          return (
+            currentOffset +
+            (rowCount > 0 ? rowCount * columnCount + columnDelta : columnDelta) *
+              this.indexEntryByteLength
+          );
+        }
+
+        const fragmentBounds = calculateFragmentBounds(
+          x,
+          y,
+          tileMatrix.aggregationCoefficient,
+          limit,
+        );
+        const entriesBeforeFragment = countIndexEntriesBeforeFragment(
+          fragmentBounds,
+          limit,
+        );
+        const fullRows =
+          (y - fragmentBounds.minTileRow) *
+          (fragmentBounds.maxTileCol - fragmentBounds.minTileCol + 1);
+        const partialRow = x - fragmentBounds.minTileCol;
+        return (
+          currentOffset +
+          (entriesBeforeFragment + fullRows + partialRow) *
+            this.indexEntryByteLength
+        );
+      }, 0);
+
+    return {
+      index: offset / this.indexEntryByteLength,
+      offset,
+    };
+  }
+}
+
+class LruCache<K, V> {
+  private readonly values = new Map<K, V>();
+
+  constructor(private readonly maxEntries: number) {}
+
+  get(key: K): V | undefined {
+    if (!this.values.has(key)) return undefined;
+    const value = this.values.get(key);
+    this.values.delete(key);
+    if (value !== undefined) this.values.set(key, value);
+    return value;
+  }
+
+  put(key: K, value: V): void {
+    if (this.values.size >= this.maxEntries) {
+      const keyToDelete = this.values.keys().next().value;
+      if (keyToDelete !== undefined) this.values.delete(keyToDelete);
+    }
+    this.values.set(key, value);
+  }
+}
+
+async function loadHeader(url: string, signal?: AbortSignal): Promise<Header> {
+  const buffer = await fetchBinaryRange(url, 0, INITIAL_CHUNK_SIZE - 1, signal);
+  const view = new DataView(buffer);
+  const version = view.getUint32(4, true);
+  if (version !== 1) {
+    throw new Error("The specified COMTiles archive version is not supported.");
+  }
+
+  const metadataSize = view.getUint32(8, true);
+  const indexSize = readUnsignedLittleEndian(buffer, 12, DEFAULT_TILE_OFFSET_BYTES);
+  const indexOffset = METADATA_OFFSET_INDEX + metadataSize;
+  const metadataDocument = new TextDecoder().decode(
+    buffer.slice(METADATA_OFFSET_INDEX, indexOffset),
+  );
+  const metadata = JSON.parse(metadataDocument) as ComtilesMetadata;
+  const indexEntryByteLength = getIndexEntryByteLength(metadata);
+  const completeIndexEntries = Math.floor(
+    (INITIAL_CHUNK_SIZE - indexOffset) / indexEntryByteLength,
+  );
+  validateMetadata(metadata, completeIndexEntries);
+
+  const partialIndexEnd = Math.min(
+    buffer.byteLength,
+    indexOffset + completeIndexEntries * indexEntryByteLength,
+  );
+  return {
+    dataOffset: indexOffset + indexSize,
+    indexOffset,
+    metadata,
+    partialIndex: buffer.slice(indexOffset, partialIndexEnd),
+  };
+}
+
+function validateMetadata(
+  metadata: ComtilesMetadata,
+  downloadedUnfragmentedIndexEntries: number,
+): void {
+  if (metadata.tileFormat !== "pbf") {
+    throw new Error("Only COMTiles archives with pbf vector tiles are supported.");
+  }
+
+  const tileMatrixSet = metadata.tileMatrixSet;
+  for (const ordering of [
+    tileMatrixSet.fragmentOrdering,
+    tileMatrixSet.tileOrdering,
+  ]) {
+    if (ordering !== undefined && ordering !== SUPPORTED_ORDERING) {
+      throw new Error(`Only ${SUPPORTED_ORDERING} COMTiles ordering is supported.`);
+    }
+  }
+
+  if (
+    tileMatrixSet.tileMatrixCRS !== undefined &&
+    tileMatrixSet.tileMatrixCRS.trim().toLowerCase() !==
+      SUPPORTED_TILE_MATRIX_CRS.toLowerCase()
+  ) {
+    throw new Error(`Only ${SUPPORTED_TILE_MATRIX_CRS} COMTiles are supported.`);
+  }
+
+  const unfragmentedIndexEntries = tileMatrixSet.tileMatrix
+    .filter((tileMatrix) => tileMatrix.aggregationCoefficient === -1)
+    .reduce(
+      (total, tileMatrix) => total + countTiles(tileMatrix.tileMatrixLimits),
+      0,
+    );
+  if (unfragmentedIndexEntries > downloadedUnfragmentedIndexEntries) {
+    throw new Error(
+      "The COMTiles unfragmented index is larger than the initial chunk.",
+    );
+  }
+}
+
+async function fetchBinaryRange(
+  url: string,
+  start: number,
+  end: number,
+  signal?: AbortSignal,
+): Promise<ArrayBuffer> {
+  const response = await fetch(url, {
+    headers: { range: `bytes=${start}-${end}` },
+    signal,
+  });
+  if (!response.ok) {
+    throw new Error(`COMTiles request failed with status ${response.status}`);
+  }
+
+  const buffer = await response.arrayBuffer();
+  if (response.status === 200 && buffer.byteLength > end - start + 1) {
+    return buffer.slice(start, end + 1);
+  }
+  return buffer;
+}
+
+function calculateFragmentBounds(
+  x: number,
+  y: number,
+  aggregationCoefficient: number,
+  limit: TileMatrixLimits,
+): TileMatrixLimits {
+  if (aggregationCoefficient === -1) return limit;
+
+  const tilesPerSide = 2 ** aggregationCoefficient;
+  const minTileCol = Math.floor(x / tilesPerSide) * tilesPerSide;
+  const minTileRow = Math.floor(y / tilesPerSide) * tilesPerSide;
+  return {
+    maxTileCol: Math.min(limit.maxTileCol, minTileCol + tilesPerSide - 1),
+    maxTileRow: Math.min(limit.maxTileRow, minTileRow + tilesPerSide - 1),
+    minTileCol: Math.max(limit.minTileCol, minTileCol),
+    minTileRow: Math.max(limit.minTileRow, minTileRow),
+  };
+}
+
+function countIndexEntriesBeforeFragment(
+  fragmentBounds: TileMatrixLimits,
+  limit: TileMatrixLimits,
+): number {
+  const left =
+    (fragmentBounds.minTileCol - limit.minTileCol) *
+    (fragmentBounds.maxTileRow - limit.minTileRow + 1);
+  const lower =
+    (limit.maxTileCol - fragmentBounds.minTileCol + 1) *
+    (fragmentBounds.minTileRow - limit.minTileRow);
+  return left + lower;
+}
+
+function countTiles(limit: TileMatrixLimits): number {
+  return (
+    (limit.maxTileCol - limit.minTileCol + 1) *
+    (limit.maxTileRow - limit.minTileRow + 1)
+  );
+}
+
+function getIndexEntryByteLength(metadata: ComtilesMetadata): number {
+  return (metadata.tileOffsetBytes ?? DEFAULT_TILE_OFFSET_BYTES) + TILE_SIZE_BYTES;
+}
+
+function isInRange(x: number, y: number, limit: TileMatrixLimits): boolean {
+  return (
+    x >= limit.minTileCol &&
+    x <= limit.maxTileCol &&
+    y >= limit.minTileRow &&
+    y <= limit.maxTileRow
+  );
+}
+
+function readUnsignedLittleEndian(
+  buffer: ArrayBufferLike,
+  offset: number,
+  byteLength: number,
+): number {
+  const bytes = new Uint8Array(buffer, offset, byteLength);
+  return bytes.reduceRight((value, byte) => value * 256 + byte, 0);
+}
+
+function uint8ArrayToArrayBuffer(array: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(array.byteLength);
+  copy.set(array);
+  return copy.buffer;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "maplibre-gl-lidar": "^0.14.1",
         "maplibre-gl-streetview": "^0.4.0",
         "maplibre-gl-swipe": "^0.7.1",
+        "pako": "^2.1.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "shpjs": "^6.2.0",
@@ -56,6 +57,7 @@
       "devDependencies": {
         "@tauri-apps/cli": "^2.2.7",
         "@types/geojson": "^7946.0.16",
+        "@types/pako": "^2.0.4",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
         "@vitejs/plugin-react": "^4.3.4",
@@ -75,6 +77,13 @@
       "peerDependencies": {
         "three": "^0.178.0"
       }
+    },
+    "apps/geolibre-desktop/node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "dev": true,
+      "license": "MIT"
     },
     "apps/geolibre-desktop/node_modules/maplibre-gl-components": {
       "version": "0.17.3",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -47,6 +47,7 @@ export type LayerType =
   | "vector-tiles"
   | "pmtiles"
   | "mbtiles"
+  | "comtiles"
   | "zarr"
   | "lidar"
   | "cog"

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -2,7 +2,7 @@ import { useAppStore, type GeoLibreLayer } from "@geolibre/core";
 import maplibregl from "maplibre-gl";
 import { memo, useEffect, useRef } from "react";
 import { circleLayerId, fillLayerId, lineLayerId } from "./geojson-loader";
-import { mbtilesStyleLayerIds } from "./layer-sync";
+import { comtilesStyleLayerIds, mbtilesStyleLayerIds } from "./layer-sync";
 import { createMapController, type MapController } from "./map-controller";
 import "maplibre-gl/dist/maplibre-gl.css";
 import "maplibre-gl-layer-control/style.css";
@@ -82,6 +82,7 @@ function identifyStyleLayerIds(layer: GeoLibreLayer): string[] {
   return [
     ...nativeIdentifyLayerIds(layer),
     ...mbtilesStyleLayerIds(layer),
+    ...comtilesStyleLayerIds(layer),
     circleLayerId(layer.id),
     lineLayerId(layer.id),
     fillLayerId(layer.id),

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -40,6 +40,11 @@ export function syncLayer(
 
   if (layer.type === "mbtiles") {
     syncMbtilesLayer(map, layer, beforeId);
+    return;
+  }
+
+  if (layer.type === "comtiles") {
+    syncComtilesLayer(map, layer, beforeId);
   }
 }
 
@@ -292,6 +297,23 @@ function syncMbtilesVectorLayer(
   layer: GeoLibreLayer,
   beforeId?: string,
 ): void {
+  syncTiledVectorLayer(map, layer, "mbtiles", beforeId);
+}
+
+function syncComtilesLayer(
+  map: maplibregl.Map,
+  layer: GeoLibreLayer,
+  beforeId?: string,
+): void {
+  syncTiledVectorLayer(map, layer, "comtiles", beforeId);
+}
+
+function syncTiledVectorLayer(
+  map: maplibregl.Map,
+  layer: GeoLibreLayer,
+  kind: "mbtiles" | "comtiles",
+  beforeId?: string,
+): void {
   const src = sourceId(layer.id);
   const tiles = (layer.source.tiles as string[] | undefined) ?? [];
   if (tiles.length === 0) return;
@@ -309,15 +331,15 @@ function syncMbtilesVectorLayer(
   }
 
   const visibility = layer.visible ? "visible" : "none";
-  const sourceLayers = getMbtilesSourceLayers(layer);
-  const currentLayerIds = new Set(mbtilesStyleLayerIds(layer));
+  const sourceLayers = getTiledVectorSourceLayers(layer);
+  const currentLayerIds = new Set(tiledVectorStyleLayerIds(layer, kind));
 
   for (const sourceLayer of sourceLayers) {
     ensureLayer(
       map,
-      mbtilesFillLayerId(layer.id, sourceLayer),
+      tiledVectorFillLayerId(layer.id, kind, sourceLayer),
       {
-        id: mbtilesFillLayerId(layer.id, sourceLayer),
+        id: tiledVectorFillLayerId(layer.id, kind, sourceLayer),
         type: "fill",
         source: src,
         "source-layer": sourceLayer,
@@ -335,9 +357,9 @@ function syncMbtilesVectorLayer(
     );
     ensureLayer(
       map,
-      mbtilesLineLayerId(layer.id, sourceLayer),
+      tiledVectorLineLayerId(layer.id, kind, sourceLayer),
       {
-        id: mbtilesLineLayerId(layer.id, sourceLayer),
+        id: tiledVectorLineLayerId(layer.id, kind, sourceLayer),
         type: "line",
         source: src,
         "source-layer": sourceLayer,
@@ -355,9 +377,9 @@ function syncMbtilesVectorLayer(
     );
     ensureLayer(
       map,
-      mbtilesCircleLayerId(layer.id, sourceLayer),
+      tiledVectorCircleLayerId(layer.id, kind, sourceLayer),
       {
-        id: mbtilesCircleLayerId(layer.id, sourceLayer),
+        id: tiledVectorCircleLayerId(layer.id, kind, sourceLayer),
         type: "circle",
         source: src,
         "source-layer": sourceLayer,
@@ -375,10 +397,10 @@ function syncMbtilesVectorLayer(
     );
   }
 
-  removeStaleMbtilesLayers(map, layer.id, currentLayerIds);
+  removeStaleTiledVectorLayers(map, layer.id, kind, currentLayerIds);
 }
 
-function getMbtilesSourceLayers(layer: GeoLibreLayer): string[] {
+function getTiledVectorSourceLayers(layer: GeoLibreLayer): string[] {
   const sourceLayers = layer.source.sourceLayers ?? layer.metadata.sourceLayers;
   return Array.isArray(sourceLayers)
     ? sourceLayers.filter(
@@ -388,12 +410,13 @@ function getMbtilesSourceLayers(layer: GeoLibreLayer): string[] {
     : [];
 }
 
-function removeStaleMbtilesLayers(
+function removeStaleTiledVectorLayers(
   map: maplibregl.Map,
   layerId: string,
+  kind: "mbtiles" | "comtiles",
   currentLayerIds: Set<string>,
 ): void {
-  const prefix = `layer-${layerId}-mbtiles-`;
+  const prefix = `layer-${layerId}-${kind}-`;
   for (const styleLayer of map.getStyle().layers ?? []) {
     if (
       styleLayer.id.startsWith(prefix) &&
@@ -404,7 +427,7 @@ function removeStaleMbtilesLayers(
   }
 }
 
-function encodeMbtilesLayerPart(value: string): string {
+function encodeTiledVectorLayerPart(value: string): string {
   return encodeURIComponent(value).replaceAll("%", "_");
 }
 
@@ -412,21 +435,21 @@ export function mbtilesFillLayerId(
   layerId: string,
   sourceLayer: string,
 ): string {
-  return `layer-${layerId}-mbtiles-${encodeMbtilesLayerPart(sourceLayer)}-fill`;
+  return tiledVectorFillLayerId(layerId, "mbtiles", sourceLayer);
 }
 
 export function mbtilesLineLayerId(
   layerId: string,
   sourceLayer: string,
 ): string {
-  return `layer-${layerId}-mbtiles-${encodeMbtilesLayerPart(sourceLayer)}-line`;
+  return tiledVectorLineLayerId(layerId, "mbtiles", sourceLayer);
 }
 
 export function mbtilesCircleLayerId(
   layerId: string,
   sourceLayer: string,
 ): string {
-  return `layer-${layerId}-mbtiles-${encodeMbtilesLayerPart(sourceLayer)}-circle`;
+  return tiledVectorCircleLayerId(layerId, "mbtiles", sourceLayer);
 }
 
 export function mbtilesStyleLayerIds(layer: GeoLibreLayer): string[] {
@@ -435,10 +458,46 @@ export function mbtilesStyleLayerIds(layer: GeoLibreLayer): string[] {
     return [`layer-${layer.id}-raster`];
   }
 
-  return getMbtilesSourceLayers(layer).flatMap((sourceLayer) => [
-    mbtilesCircleLayerId(layer.id, sourceLayer),
-    mbtilesLineLayerId(layer.id, sourceLayer),
-    mbtilesFillLayerId(layer.id, sourceLayer),
+  return tiledVectorStyleLayerIds(layer, "mbtiles");
+}
+
+export function comtilesStyleLayerIds(layer: GeoLibreLayer): string[] {
+  if (layer.type !== "comtiles") return [];
+  return tiledVectorStyleLayerIds(layer, "comtiles");
+}
+
+function tiledVectorFillLayerId(
+  layerId: string,
+  kind: "mbtiles" | "comtiles",
+  sourceLayer: string,
+): string {
+  return `layer-${layerId}-${kind}-${encodeTiledVectorLayerPart(sourceLayer)}-fill`;
+}
+
+function tiledVectorLineLayerId(
+  layerId: string,
+  kind: "mbtiles" | "comtiles",
+  sourceLayer: string,
+): string {
+  return `layer-${layerId}-${kind}-${encodeTiledVectorLayerPart(sourceLayer)}-line`;
+}
+
+function tiledVectorCircleLayerId(
+  layerId: string,
+  kind: "mbtiles" | "comtiles",
+  sourceLayer: string,
+): string {
+  return `layer-${layerId}-${kind}-${encodeTiledVectorLayerPart(sourceLayer)}-circle`;
+}
+
+function tiledVectorStyleLayerIds(
+  layer: GeoLibreLayer,
+  kind: "mbtiles" | "comtiles",
+): string[] {
+  return getTiledVectorSourceLayers(layer).flatMap((sourceLayer) => [
+    tiledVectorCircleLayerId(layer.id, kind, sourceLayer),
+    tiledVectorLineLayerId(layer.id, kind, sourceLayer),
+    tiledVectorFillLayerId(layer.id, kind, sourceLayer),
   ]);
 }
 
@@ -494,6 +553,7 @@ export function removeLayerFromMap(
   for (const id of [
     ...getExternalNativeLayerIds(layer),
     ...(layer ? mbtilesStyleLayerIds(layer) : []),
+    ...(layer ? comtilesStyleLayerIds(layer) : []),
     fillLayerId(layerId),
     lineLayerId(layerId),
     circleLayerId(layerId),

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -20,6 +20,7 @@ import {
   sourceId,
 } from "./geojson-loader";
 import {
+  comtilesStyleLayerIds,
   mbtilesStyleLayerIds,
   removeLayerFromMap,
   syncLayer,
@@ -1085,6 +1086,13 @@ export class MapController {
 
     if (layer.type === "mbtiles") {
       return mbtilesStyleLayerIds(layer).map((id) => ({
+        id,
+        suffix: nativeLayerSuffix(id),
+      }));
+    }
+
+    if (layer.type === "comtiles") {
+      return comtilesStyleLayerIds(layer).map((id) => ({
         id,
         suffix: nativeLayerSuffix(id),
       }));


### PR DESCRIPTION
## Summary
- Add a COMTiles archive reader (`comtiles.ts`) that streams remote vector tiles over HTTP range requests, with header/index parsing, fragment caching, and gzip decoding via pako.
- Introduce a `comtiles` layer type wired through the Add Data dialog, toolbar, layer/style panels, and core types.
- Refactor MBTiles vector styling into shared tiled-vector helpers reused by both MBTiles and COMTiles layers.

## Test plan
- [ ] `npm run build` passes (verified via pre-commit gate)
- [ ] Add a COMTiles layer from a remote archive URL and confirm vector tiles render
- [ ] Confirm identify and style controls work on COMTiles layers
- [ ] Confirm existing MBTiles layers still render and identify correctly