### PR TITLE
feat: add ArcGIS layer support

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -87,6 +87,14 @@ const COG_COLORMAPS = [
 
 const DEFAULT_RASTER_URL =
   "https://data.source.coop/giswqs/opengeos/nlcd_2021_land_cover_30m.tif";
+const DEFAULT_ARCGIS_FEATURE_URL =
+  "https://services3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/USA_Major_Cities/FeatureServer/0";
+const DEFAULT_ARCGIS_VECTOR_TILE_URL =
+  "https://vectortileservices3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/Santa_Monica_parcels_VTL/VectorTileServer";
+const DEFAULT_ARCGIS_URLS: Record<ArcGISLayerType, string> = {
+  feature: DEFAULT_ARCGIS_FEATURE_URL,
+  "vector-tile": DEFAULT_ARCGIS_VECTOR_TILE_URL,
+};
 
 function createLayerId(): string {
   return crypto.randomUUID();
@@ -234,7 +242,7 @@ export function AddDataDialog({
     useState<ArcGISLayerType>("feature");
   const [arcgisSourceType, setArcgisSourceType] =
     useState<ArcGISSourceType>("url");
-  const [arcgisUrl, setArcgisUrl] = useState("");
+  const [arcgisUrl, setArcgisUrl] = useState(DEFAULT_ARCGIS_FEATURE_URL);
   const [arcgisItemId, setArcgisItemId] = useState("");
   const [arcgisPortalUrl, setArcgisPortalUrl] = useState("");
   const [arcgisAccessToken, setArcgisAccessToken] = useState("");
@@ -279,7 +287,7 @@ export function AddDataDialog({
     setMbtilesSourceLayers("");
     setArcgisLayerType("feature");
     setArcgisSourceType("url");
-    setArcgisUrl("");
+    setArcgisUrl(DEFAULT_ARCGIS_FEATURE_URL);
     setArcgisItemId("");
     setArcgisPortalUrl("");
     setArcgisAccessToken("");
@@ -315,6 +323,17 @@ export function AddDataDialog({
   };
 
   const beforeLayer = beforeLayerId.trim() || null;
+
+  const handleArcgisLayerTypeChange = (nextLayerType: ArcGISLayerType) => {
+    const currentUrl = arcgisUrl.trim();
+    setArcgisLayerType(nextLayerType);
+    if (
+      !currentUrl ||
+      Object.values(DEFAULT_ARCGIS_URLS).includes(currentUrl)
+    ) {
+      setArcgisUrl(DEFAULT_ARCGIS_URLS[nextLayerType]);
+    }
+  };
 
   const addAndClose = (layer: GeoLibreLayer) => {
     addLayer(layer, beforeLayer);
@@ -842,7 +861,9 @@ export function AddDataDialog({
                     className={SELECT_CLASS}
                     value={arcgisLayerType}
                     onChange={(event) =>
-                      setArcgisLayerType(event.target.value as ArcGISLayerType)
+                      handleArcgisLayerTypeChange(
+                        event.target.value as ArcGISLayerType,
+                      )
                     }
                   >
                     <option value="feature">Feature layer</option>

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -5,7 +5,10 @@ import {
 } from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
 import {
+  addArcGISLayer,
   addCogRasterLayer,
+  type ArcGISLayerType,
+  type ArcGISSourceType,
   type CogRasterLayerOptions,
 } from "@geolibre/plugins";
 import {
@@ -39,7 +42,13 @@ import {
   type MbtilesMetadata,
 } from "../../lib/mbtiles";
 
-export type AddDataKind = "xyz" | "wms" | "vector" | "raster" | "mbtiles";
+export type AddDataKind =
+  | "xyz"
+  | "wms"
+  | "vector"
+  | "raster"
+  | "mbtiles"
+  | "arcgis";
 
 interface AddDataDialogProps {
   kind: AddDataKind | null;
@@ -57,6 +66,7 @@ const KIND_LABELS: Record<AddDataKind, string> = {
   vector: "Add Vector Layer",
   raster: "Add Raster Layer",
   mbtiles: "Add MBTiles Layer",
+  arcgis: "Add ArcGIS Layer",
 };
 
 const SELECT_CLASS =
@@ -220,6 +230,14 @@ export function AddDataDialog({
     path: string;
   } | null>(null);
   const [mbtilesSourceLayers, setMbtilesSourceLayers] = useState("");
+  const [arcgisLayerType, setArcgisLayerType] =
+    useState<ArcGISLayerType>("feature");
+  const [arcgisSourceType, setArcgisSourceType] =
+    useState<ArcGISSourceType>("url");
+  const [arcgisUrl, setArcgisUrl] = useState("");
+  const [arcgisItemId, setArcgisItemId] = useState("");
+  const [arcgisPortalUrl, setArcgisPortalUrl] = useState("");
+  const [arcgisAccessToken, setArcgisAccessToken] = useState("");
 
   useEffect(() => {
     if (!kind) return;
@@ -232,6 +250,7 @@ export function AddDataDialog({
         vector: "Vector Layer",
         raster: "Raster Layer",
         mbtiles: "MBTiles Layer",
+        arcgis: "ArcGIS Layer",
       }[kind],
     );
     setBeforeLayerId("");
@@ -258,6 +277,12 @@ export function AddDataDialog({
     setSelectedRasterPath(null);
     setSelectedMbtiles(null);
     setMbtilesSourceLayers("");
+    setArcgisLayerType("feature");
+    setArcgisSourceType("url");
+    setArcgisUrl("");
+    setArcgisItemId("");
+    setArcgisPortalUrl("");
+    setArcgisAccessToken("");
   }, [kind]);
 
   const description = useMemo(() => {
@@ -275,6 +300,9 @@ export function AddDataDialog({
     }
     if (kind === "mbtiles") {
       return "Add a local MBTiles file as a raster or vector tile layer.";
+    }
+    if (kind === "arcgis") {
+      return "Add an ArcGIS FeatureServer layer, VectorTileServer layer, or portal item.";
     }
     return "";
   }, [kind]);
@@ -493,6 +521,21 @@ export function AddDataDialog({
             },
           ),
         );
+        return;
+      }
+
+      if (kind === "arcgis") {
+        await addArcGISLayer(createAppAPI(mapControllerRef), {
+          beforeLayerId: beforeLayer,
+          itemId: arcgisItemId.trim() || undefined,
+          layerType: arcgisLayerType,
+          name,
+          portalUrl: arcgisPortalUrl.trim() || undefined,
+          sourceType: arcgisSourceType,
+          token: arcgisAccessToken.trim() || undefined,
+          url: arcgisUrl.trim() || undefined,
+        });
+        closeDialog();
         return;
       }
 
@@ -786,6 +829,87 @@ export function AddDataDialog({
                   />
                 </div>
               )}
+            </div>
+          )}
+
+          {kind === "arcgis" && (
+            <div className="space-y-3">
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="space-y-1.5">
+                  <Label htmlFor="arcgis-layer-type">Layer type</Label>
+                  <select
+                    id="arcgis-layer-type"
+                    className={SELECT_CLASS}
+                    value={arcgisLayerType}
+                    onChange={(event) =>
+                      setArcgisLayerType(event.target.value as ArcGISLayerType)
+                    }
+                  >
+                    <option value="feature">Feature layer</option>
+                    <option value="vector-tile">Vector tile layer</option>
+                  </select>
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="arcgis-source-type">Source type</Label>
+                  <select
+                    id="arcgis-source-type"
+                    className={SELECT_CLASS}
+                    value={arcgisSourceType}
+                    onChange={(event) =>
+                      setArcgisSourceType(event.target.value as ArcGISSourceType)
+                    }
+                  >
+                    <option value="url">Service URL</option>
+                    <option value="portal-item">Portal item ID</option>
+                  </select>
+                </div>
+              </div>
+              {arcgisSourceType === "url" ? (
+                <div className="space-y-1.5">
+                  <Label htmlFor="arcgis-url">Service URL</Label>
+                  <Input
+                    id="arcgis-url"
+                    placeholder={
+                      arcgisLayerType === "feature"
+                        ? "https://services.arcgis.com/.../FeatureServer/0"
+                        : "https://.../arcgis/rest/services/.../VectorTileServer"
+                    }
+                    value={arcgisUrl}
+                    onChange={(event) => setArcgisUrl(event.target.value)}
+                  />
+                </div>
+              ) : (
+                <div className="space-y-1.5">
+                  <Label htmlFor="arcgis-item-id">Portal item ID</Label>
+                  <Input
+                    id="arcgis-item-id"
+                    value={arcgisItemId}
+                    onChange={(event) => setArcgisItemId(event.target.value)}
+                  />
+                </div>
+              )}
+              <div className="space-y-1.5">
+                <Label htmlFor="arcgis-portal-url">Portal URL</Label>
+                <Input
+                  id="arcgis-portal-url"
+                  placeholder="https://www.arcgis.com/sharing/rest"
+                  value={arcgisPortalUrl}
+                  onChange={(event) => setArcgisPortalUrl(event.target.value)}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="arcgis-access-token">Access token</Label>
+                <Input
+                  id="arcgis-access-token"
+                  type="password"
+                  autoComplete="off"
+                  placeholder="Optional"
+                  value={arcgisAccessToken}
+                  onChange={(event) =>
+                    setArcgisAccessToken(event.target.value)
+                  }
+                />
+              </div>
             </div>
           )}
 

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -215,6 +215,9 @@ export function TopToolbar({
           <DropdownMenuItem onSelect={() => setAddDataKind("mbtiles")}>
             Add MBTiles Layer
           </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setAddDataKind("arcgis")}>
+            Add ArcGIS Layer
+          </DropdownMenuItem>
           <DropdownMenuItem onSelect={handleAddZarrLayer}>
             Add Zarr Layer
           </DropdownMenuItem>

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -87,6 +87,7 @@ export function createAppAPI(
     fetchArrayBuffer: fetchRemoteArrayBuffer,
     fitBounds: (bounds: [number, number, number, number]) =>
       mapControllerRef?.current?.fitBounds(bounds),
+    getMap: () => mapControllerRef?.current?.getMap() ?? null,
     addMapControl: (
       control: Parameters<MapController["addControl"]>[0],
       position?: Parameters<MapController["addControl"]>[1],

--- a/apps/geolibre-desktop/tsconfig.json
+++ b/apps/geolibre-desktop/tsconfig.json
@@ -4,14 +4,7 @@
     "composite": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"],
-      "@esri/maplibre-arcgis": [
-        "../../node_modules/@esri/maplibre-arcgis/dist/esm/types/src/MaplibreArcGIS.d.ts"
-      ],
-      "maplibre-gl-components": [
-        "./node_modules/maplibre-gl-components/dist/types/index.d.ts",
-        "./node_modules/maplibre-gl-components/dist/src/index.d.ts"
-      ]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src"],

--- a/apps/geolibre-desktop/tsconfig.json
+++ b/apps/geolibre-desktop/tsconfig.json
@@ -5,6 +5,9 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
+      "@esri/maplibre-arcgis": [
+        "../../node_modules/@esri/maplibre-arcgis/dist/esm/types/src/MaplibreArcGIS.d.ts"
+      ],
       "maplibre-gl-components": [
         "./node_modules/maplibre-gl-components/dist/types/index.d.ts",
         "./node_modules/maplibre-gl-components/dist/src/index.d.ts"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1678,6 +1678,104 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esri/arcgis-rest-basemap-sessions": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-basemap-sessions/-/arcgis-rest-basemap-sessions-4.10.2.tgz",
+      "integrity": "sha512-5Tfxq4Akk8c8YkNccTW+NJXI5ZVcdl3U4xw+paC1KxW4ePpHUFUVnvgYMy5FL8EKGP8+tGIBw+EkxLnUHzYbxQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@esri/arcgis-rest-request": "^4.0.0"
+      }
+    },
+    "node_modules/@esri/arcgis-rest-feature-service": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-feature-service/-/arcgis-rest-feature-service-4.10.2.tgz",
+      "integrity": "sha512-Lsgqi19hRi5TGvQs2AGCP8eOdylfKvNCL5Z3pM/qjHKQfFmmyiP1y4NngmuNy7l+hdqV/DAHtNWEVnQ+kcs3og==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "pbf": "^4.0.1",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@esri/arcgis-rest-portal": "^4.0.0",
+        "@esri/arcgis-rest-request": "^4.0.0"
+      }
+    },
+    "node_modules/@esri/arcgis-rest-fetch": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-fetch/-/arcgis-rest-fetch-4.10.2.tgz",
+      "integrity": "sha512-v0+PxY5wkMulH27GxxM28KCMU73aHT9rNiIK9dBJq1PwmIzEZc+dKZkKJsLvY839oWydUwgsoOClqAlKzqZkig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-fetch": "^3.2.10"
+      }
+    },
+    "node_modules/@esri/arcgis-rest-form-data": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-form-data/-/arcgis-rest-form-data-4.10.2.tgz",
+      "integrity": "sha512-lyYDZP2vNOu6ueoEEebjOTz0JS9HLnWwqX4J/27O0OfIloEAyIXTZjUn2jyCpe+Mu1Q814tI9pULhaXvC2iMLw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "formdata-node": "^4.1.0"
+      }
+    },
+    "node_modules/@esri/arcgis-rest-portal": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-portal/-/arcgis-rest-portal-4.10.2.tgz",
+      "integrity": "sha512-GtSSjo0wnpmtp0l9P5b/3NT0sODg8f/7+rFQSNYLpuqZqH/oV9W5plC4kv0jHRBZzGwk+D3kwOPd7X0J5poPsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@esri/arcgis-rest-request": "^4.0.0"
+      }
+    },
+    "node_modules/@esri/arcgis-rest-request": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@esri/arcgis-rest-request/-/arcgis-rest-request-4.10.2.tgz",
+      "integrity": "sha512-EKJDKiXI5m1fcaFGx7NGOraiBjVHEBxaQ4PPa07OWhp8s8/xJCiJcYw7CAX9jTZgWPiXqh45zkIQ8e+EoMCwrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@esri/arcgis-rest-fetch": "^4.10.2",
+        "@esri/arcgis-rest-form-data": "^4.10.2",
+        "mitt": "^3.0.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/@esri/maplibre-arcgis": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@esri/maplibre-arcgis/-/maplibre-arcgis-1.2.0.tgz",
+      "integrity": "sha512-q3XDt0kYt/pwaa+MZWjJ+eqmXuWRX2+r2TqWve20vJHi7EY2OkJEp9fSBe8G9JY1JI7v+gFv9BvMnbUVuEUCZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@esri/arcgis-rest-basemap-sessions": "^4.10.1",
+        "@esri/arcgis-rest-feature-service": "^4.10.1",
+        "@esri/arcgis-rest-portal": "^4.10.1",
+        "@esri/arcgis-rest-request": "^4.10.1",
+        "@mapbox/tilebelt": "^2.0.3",
+        "mitt": "3.0.1"
+      },
+      "peerDependencies": {
+        "maplibre-gl": ">=5.11.0"
+      }
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
@@ -2398,6 +2496,12 @@
       "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
       "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
       "license": "ISC"
+    },
+    "node_modules/@mapbox/tilebelt": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/tilebelt/-/tilebelt-2.0.3.tgz",
+      "integrity": "sha512-HSscGw2yBlcm0GdLI3S5i8Xw/ffP2fTT2qmRbR1/AkJ02PnNN52yY+zzfw705LKKjesy8jJ/H1dieuioqN0Slw==",
+      "license": "MIT"
     },
     "node_modules/@mapbox/tiny-sdf": {
       "version": "2.2.0",
@@ -8053,6 +8157,28 @@
       "integrity": "sha512-y1deYaVt+lIc/d2uIcWDNd0CrdQTO5xoCjeFdhX0kSXvm2Acm0o+3bAOiYklTEoRyzwio3sv3/IiBZdusbAe2Q==",
       "license": "ISC"
     },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
+    "node_modules/formdata-node/node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -9719,6 +9845,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
     },
     "node_modules/mjolnir.js": {
       "version": "3.0.0",
@@ -11877,6 +12009,7 @@
         "@developmentseed/deck.gl-raster": "^0.7.0",
         "@developmentseed/morecantile": "^0.7.0",
         "@dvt3d/maplibre-three-plugin": "^1.6.0",
+        "@esri/maplibre-arcgis": "^1.2.0",
         "@geolibre/core": "*",
         "@geoman-io/maplibre-geoman-free": "^0.7.1",
         "geotiff": "^3.0.5",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -45,6 +45,7 @@ export type LayerType =
   | "wms"
   | "xyz"
   | "vector-tiles"
+  | "arcgis"
   | "pmtiles"
   | "mbtiles"
   | "zarr"

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -502,7 +502,7 @@ export function removeLayerFromMap(
   ]) {
     if (map.getLayer(id)) map.removeLayer(id);
   }
-  for (const src of [getExternalSourceId(layer), sourceId(layerId)]) {
+  for (const src of [...getExternalSourceIds(layer), sourceId(layerId)]) {
     if (src && map.getSource(src)) map.removeSource(src);
   }
 }
@@ -514,8 +514,13 @@ function getExternalNativeLayerIds(layer?: GeoLibreLayer): string[] {
     : [];
 }
 
-function getExternalSourceId(layer?: GeoLibreLayer): string | undefined {
+function getExternalSourceIds(layer?: GeoLibreLayer): string[] {
+  const sourceIds = layer?.metadata.sourceIds;
+  if (Array.isArray(sourceIds)) {
+    return sourceIds.filter((id): id is string => typeof id === "string");
+  }
+
   return typeof layer?.metadata.sourceId === "string"
-    ? layer.metadata.sourceId
-    : undefined;
+    ? [layer.metadata.sourceId]
+    : [];
 }

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -970,30 +970,48 @@ export class MapController {
   private getLayerMetadataBounds(
     layer: GeoLibreLayer,
   ): [number, number, number, number] | null {
-    const bounds = layer.source.bounds;
+    return (
+      this.normalizeLayerBounds(layer.source.bounds) ??
+      this.normalizeLayerBounds(layer.metadata.bounds)
+    );
+  }
+
+  private getLayerSourceBounds(
+    layer: GeoLibreLayer,
+  ): [number, number, number, number] | null {
+    for (const id of this.getLayerSourceIds(layer)) {
+      const source = this.map?.getSource(id) as
+        | { bounds?: [number, number, number, number] }
+        | undefined;
+      const bounds = this.normalizeLayerBounds(source?.bounds);
+      if (bounds) return bounds;
+    }
+    return null;
+  }
+
+  private getLayerSourceIds(layer: GeoLibreLayer): string[] {
+    const ids = new Set<string>([sourceId(layer.id)]);
+    const sourceIds = layer.metadata.sourceIds;
+    if (Array.isArray(sourceIds)) {
+      for (const id of sourceIds) {
+        if (typeof id === "string") ids.add(id);
+      }
+    }
+    if (typeof layer.metadata.sourceId === "string") {
+      ids.add(layer.metadata.sourceId);
+    }
+    return Array.from(ids);
+  }
+
+  private normalizeLayerBounds(
+    bounds: unknown,
+  ): [number, number, number, number] | null {
     if (
       Array.isArray(bounds) &&
       bounds.length === 4 &&
       bounds.every((value) => Number.isFinite(value))
     ) {
       return bounds as [number, number, number, number];
-    }
-    return null;
-  }
-
-  private getLayerSourceBounds(
-    layer: GeoLibreLayer,
-  ): [number, number, number, number] | null {
-    const source = this.map?.getSource(sourceId(layer.id)) as
-      | { bounds?: [number, number, number, number] }
-      | undefined;
-    const bounds = source?.bounds;
-    if (
-      Array.isArray(bounds) &&
-      bounds.length === 4 &&
-      bounds.every((value) => Number.isFinite(value))
-    ) {
-      return bounds;
     }
     return null;
   }

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -19,6 +19,7 @@
     "@developmentseed/deck.gl-raster": "^0.7.0",
     "@developmentseed/morecantile": "^0.7.0",
     "@dvt3d/maplibre-three-plugin": "^1.6.0",
+    "@esri/maplibre-arcgis": "^1.2.0",
     "@geolibre/core": "*",
     "@geoman-io/maplibre-geoman-free": "^0.7.1",
     "geotiff": "^3.0.5",

--- a/packages/plugins/src/arcgis-maplibre.d.ts
+++ b/packages/plugins/src/arcgis-maplibre.d.ts
@@ -1,0 +1,49 @@
+declare module "@esri/maplibre-arcgis" {
+  import type maplibregl from "maplibre-gl";
+
+  export interface IHostedLayerOptions {
+    attribution?: string;
+    portalUrl?: string;
+    token?: string;
+  }
+
+  export interface IFeatureLayerOptions extends IHostedLayerOptions {
+    itemId?: string;
+    url?: string;
+  }
+
+  export interface IVectorTileLayerOptions extends IHostedLayerOptions {
+    itemId?: string;
+    url?: string;
+  }
+
+  export abstract class HostedLayer {
+    readonly sourceId?: string;
+    readonly sources: Readonly<Record<string, maplibregl.AnySourceData>>;
+    readonly layers: Readonly<maplibregl.LayerSpecification[]>;
+    addSourcesAndLayersTo(map: maplibregl.Map): HostedLayer;
+    setSourceId(oldId: string, newId: string): void;
+  }
+
+  export class FeatureLayer extends HostedLayer {
+    static fromPortalItem(
+      itemId: string,
+      options?: IFeatureLayerOptions,
+    ): Promise<FeatureLayer>;
+    static fromUrl(
+      serviceUrl: string,
+      options?: IFeatureLayerOptions,
+    ): Promise<FeatureLayer>;
+  }
+
+  export class VectorTileLayer extends HostedLayer {
+    static fromPortalItem(
+      itemId: string,
+      options?: IVectorTileLayerOptions,
+    ): Promise<VectorTileLayer>;
+    static fromUrl(
+      serviceUrl: string,
+      options?: IVectorTileLayerOptions,
+    ): Promise<VectorTileLayer>;
+  }
+}

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -5,6 +5,12 @@ export { osmBasemapPlugin } from "./plugins/osm-basemap";
 export { cartoLightPlugin } from "./plugins/carto-light";
 export { maplibreBasemapControlPlugin } from "./plugins/maplibre-basemap-control";
 export {
+  addArcGISLayer,
+  type ArcGISLayerOptions,
+  type ArcGISLayerType,
+  type ArcGISSourceType,
+} from "./plugins/arcgis-layer";
+export {
   addCogRasterLayer,
   maplibreComponentsPlugin,
   openFlatGeobufAddVectorLayerPanel,

--- a/packages/plugins/src/plugins/arcgis-layer.ts
+++ b/packages/plugins/src/plugins/arcgis-layer.ts
@@ -1,0 +1,434 @@
+import {
+  DEFAULT_LAYER_STYLE,
+  type GeoLibreLayer,
+  useAppStore,
+} from "@geolibre/core";
+import type {
+  HostedLayer,
+  VectorTileLayer,
+} from "@esri/maplibre-arcgis";
+import type maplibregl from "maplibre-gl";
+import type { GeoLibreAppAPI } from "../types";
+
+export type ArcGISLayerType = "feature" | "vector-tile";
+export type ArcGISSourceType = "url" | "portal-item";
+
+export interface ArcGISLayerOptions {
+  beforeLayerId?: string | null;
+  itemId?: string;
+  layerType: ArcGISLayerType;
+  name?: string;
+  portalUrl?: string;
+  sourceType: ArcGISSourceType;
+  token?: string;
+  url?: string;
+}
+
+interface ArcGISFeatureLayerInfo {
+  copyrightText?: string;
+  geometryType?: string;
+  name?: string;
+}
+
+interface ArcGISFeatureServiceInfo {
+  layers?: Array<{
+    id: number;
+    subLayerIds?: number[];
+  }>;
+}
+
+type ArcGISLayerModule = typeof import("@esri/maplibre-arcgis");
+type ArcGISRuntimeLayer = Pick<
+  HostedLayer,
+  "addSourcesAndLayersTo" | "layers" | "setSourceId" | "sources"
+>;
+
+let arcgisLayerSequence = 0;
+const arcgisLayerInstances = new Map<string, ArcGISRuntimeLayer>();
+let arcgisStoreUnsubscribe: (() => void) | null = null;
+
+export async function addArcGISLayer(
+  app: GeoLibreAppAPI,
+  options: ArcGISLayerOptions,
+): Promise<string> {
+  const map = app.getMap?.();
+  if (!map) {
+    throw new Error("The map is not ready.");
+  }
+
+  const input = getArcGISInput(options);
+  const arcgis = await import("@esri/maplibre-arcgis");
+  const hostedLayer = await createArcGISHostedLayer(arcgis, options, input);
+  const id = createArcGISLayerId();
+  const sourceIds = prefixArcGISSourceIds(hostedLayer, id);
+  const nativeLayerIds = prefixArcGISStyleLayerIds(hostedLayer, id);
+
+  hostedLayer.addSourcesAndLayersTo(map);
+  ensureArcGISStoreCleanup();
+  arcgisLayerInstances.set(id, hostedLayer);
+
+  const layer = createArcGISStoreLayer({
+    id,
+    input,
+    nativeLayerIds,
+    options,
+    sourceIds,
+  });
+  const store = useAppStore.getState();
+  store.addLayer(layer, options.beforeLayerId);
+  return id;
+}
+
+function ensureArcGISStoreCleanup(): void {
+  arcgisStoreUnsubscribe ??= useAppStore.subscribe((state, previous) => {
+    for (const layer of previous.layers) {
+      if (
+        layer.type === "arcgis" &&
+        !state.layers.some((current) => current.id === layer.id)
+      ) {
+        arcgisLayerInstances.delete(layer.id);
+      }
+    }
+  });
+}
+
+async function createArcGISHostedLayer(
+  arcgis: ArcGISLayerModule,
+  options: ArcGISLayerOptions,
+  input: string,
+): Promise<ArcGISRuntimeLayer> {
+  const layerOptions = {
+    portalUrl: options.portalUrl?.trim() || undefined,
+    token: options.token?.trim() || undefined,
+  };
+
+  if (options.layerType === "feature") return createFallbackFeatureLayer(input, options);
+
+  return options.sourceType === "url"
+    ? (arcgis.VectorTileLayer as typeof VectorTileLayer).fromUrl(
+        input,
+        layerOptions,
+      )
+    : (arcgis.VectorTileLayer as typeof VectorTileLayer).fromPortalItem(
+        input,
+        layerOptions,
+      );
+}
+
+function getArcGISInput(options: ArcGISLayerOptions): string {
+  const input =
+    options.sourceType === "url" ? options.url?.trim() : options.itemId?.trim();
+  if (!input) {
+    throw new Error(
+      options.sourceType === "url"
+        ? "Enter an ArcGIS service URL."
+        : "Enter an ArcGIS portal item ID.",
+    );
+  }
+  return input;
+}
+
+function prefixArcGISSourceIds(
+  hostedLayer: ArcGISRuntimeLayer,
+  layerId: string,
+): string[] {
+  const originalSourceIds = Object.keys(hostedLayer.sources);
+  return originalSourceIds.map((sourceId, index) => {
+    const nextSourceId = `${layerId}-source-${index}-${sanitizeIdPart(sourceId)}`;
+    hostedLayer.setSourceId(sourceId, nextSourceId);
+    return nextSourceId;
+  });
+}
+
+function prefixArcGISStyleLayerIds(
+  hostedLayer: ArcGISRuntimeLayer,
+  layerId: string,
+): string[] {
+  const mutableLayers = hostedLayer.layers as maplibregl.LayerSpecification[];
+  return mutableLayers.map((styleLayer, index) => {
+    const nextLayerId = `${layerId}-layer-${index}-${sanitizeIdPart(
+      styleLayer.id,
+    )}`;
+    styleLayer.id = nextLayerId;
+    return nextLayerId;
+  });
+}
+
+async function createFallbackFeatureLayer(
+  input: string,
+  options: ArcGISLayerOptions,
+  cause: unknown = undefined,
+): Promise<ArcGISRuntimeLayer> {
+  const layerUrl =
+    options.sourceType === "url"
+      ? await resolveFeatureLayerUrl(input, options, cause)
+      : await resolvePortalFeatureLayerUrl(input, options, cause);
+  const layerInfo = await fetchArcGISJson<ArcGISFeatureLayerInfo>(
+    layerUrl,
+    options,
+    cause,
+  );
+  if (!layerInfo.geometryType) {
+    throw new Error("The ArcGIS feature layer metadata is missing geometry type.", {
+      cause,
+    });
+  }
+
+  const sourceId = layerInfo.name || layerNameFromArcGISInput(layerUrl, "arcgis");
+  const styleLayerType = arcgisGeometryLayerType(layerInfo.geometryType);
+  const styleLayerId = `${sourceId}-layer`;
+  const queryUrl = appendArcGISParams(`${trimTrailingSlash(layerUrl)}/query`, {
+    f: "geojson",
+    outFields: "*",
+    returnGeometry: "true",
+    token: options.token?.trim(),
+    where: "1=1",
+  });
+
+  return createStaticArcGISRuntimeLayer({
+    layers: [
+      {
+        id: styleLayerId,
+        source: sourceId,
+        type: styleLayerType,
+        paint: arcgisFallbackPaint(styleLayerType),
+      } as maplibregl.LayerSpecification,
+    ],
+    sources: {
+      [sourceId]: {
+        type: "geojson",
+        data: queryUrl,
+        attribution: layerInfo.copyrightText || "ArcGIS Feature Service",
+      },
+    },
+  });
+}
+
+async function resolveFeatureLayerUrl(
+  input: string,
+  options: ArcGISLayerOptions,
+  cause: unknown,
+): Promise<string> {
+  if (/\/FeatureServer\/\d+\/?$/i.test(input)) return trimTrailingSlash(input);
+  if (!/\/FeatureServer\/?$/i.test(input)) {
+    throw new Error("Enter an ArcGIS FeatureServer layer URL.", { cause });
+  }
+
+  const serviceInfo = await fetchArcGISJson<ArcGISFeatureServiceInfo>(
+    input,
+    options,
+    cause,
+  );
+  const layerId = serviceInfo.layers?.find((layer) => !layer.subLayerIds)?.id;
+  if (layerId == null) {
+    throw new Error("The ArcGIS feature service does not list a feature layer.", {
+      cause,
+    });
+  }
+  return `${trimTrailingSlash(input)}/${layerId}`;
+}
+
+async function resolvePortalFeatureLayerUrl(
+  itemId: string,
+  options: ArcGISLayerOptions,
+  cause: unknown,
+): Promise<string> {
+  const portalUrl =
+    options.portalUrl?.trim() || "https://www.arcgis.com/sharing/rest";
+  const itemUrl = appendArcGISParams(
+    `${trimTrailingSlash(portalUrl)}/content/items/${itemId}`,
+    { f: "json", token: options.token?.trim() },
+  );
+  const response = await fetch(itemUrl);
+  if (!response.ok) {
+    throw new Error(`ArcGIS portal item request failed with ${response.status}.`, {
+      cause,
+    });
+  }
+  const itemInfo = (await response.json()) as { url?: string };
+  if (!itemInfo.url) {
+    throw new Error("The ArcGIS portal item does not include a service URL.", {
+      cause,
+    });
+  }
+  return resolveFeatureLayerUrl(itemInfo.url, options, cause);
+}
+
+async function fetchArcGISJson<T>(
+  url: string,
+  options: ArcGISLayerOptions,
+  cause: unknown,
+): Promise<T> {
+  const response = await fetch(
+    appendArcGISParams(url, {
+      f: "json",
+      token: options.token?.trim(),
+    }),
+  );
+  if (!response.ok) {
+    throw new Error(`ArcGIS service request failed with ${response.status}.`, {
+      cause,
+    });
+  }
+  const json = (await response.json()) as T & {
+    error?: { message?: string };
+  };
+  if (json.error) {
+    throw new Error(json.error.message || "ArcGIS service request failed.", {
+      cause,
+    });
+  }
+  return json;
+}
+
+function createStaticArcGISRuntimeLayer(args: {
+  layers: maplibregl.LayerSpecification[];
+  sources: Record<string, maplibregl.AnySourceData>;
+}): ArcGISRuntimeLayer {
+  return {
+    get layers() {
+      return args.layers;
+    },
+    get sources() {
+      return args.sources;
+    },
+    setSourceId(oldId: string, newId: string) {
+      args.sources[newId] = args.sources[oldId];
+      delete args.sources[oldId];
+      for (const layer of args.layers) {
+        if ("source" in layer && layer.source === oldId) {
+          layer.source = newId;
+        }
+      }
+    },
+    addSourcesAndLayersTo(map: maplibregl.Map) {
+      for (const [sourceId, source] of Object.entries(args.sources)) {
+        map.addSource(sourceId, source);
+      }
+      for (const layer of args.layers) {
+        map.addLayer(layer);
+      }
+      return this;
+    },
+  };
+}
+
+function arcgisGeometryLayerType(
+  geometryType: string,
+): "circle" | "fill" | "line" {
+  if (geometryType === "esriGeometryPoint") return "circle";
+  if (geometryType === "esriGeometryMultipoint") return "circle";
+  if (geometryType === "esriGeometryPolyline") return "line";
+  return "fill";
+}
+
+function arcgisFallbackPaint(
+  layerType: "circle" | "fill" | "line",
+): maplibregl.LayerSpecification["paint"] {
+  if (layerType === "circle") {
+    return {
+      "circle-color": DEFAULT_LAYER_STYLE.fillColor,
+      "circle-radius": DEFAULT_LAYER_STYLE.circleRadius,
+      "circle-stroke-color": DEFAULT_LAYER_STYLE.strokeColor,
+      "circle-stroke-width": DEFAULT_LAYER_STYLE.strokeWidth,
+    };
+  }
+  if (layerType === "line") {
+    return {
+      "line-color": DEFAULT_LAYER_STYLE.strokeColor,
+      "line-width": DEFAULT_LAYER_STYLE.strokeWidth,
+    };
+  }
+  return {
+    "fill-color": DEFAULT_LAYER_STYLE.fillColor,
+    "fill-opacity": DEFAULT_LAYER_STYLE.fillOpacity,
+    "fill-outline-color": DEFAULT_LAYER_STYLE.strokeColor,
+  };
+}
+
+function appendArcGISParams(
+  url: string,
+  params: Record<string, string | undefined>,
+): string {
+  const parsedUrl = new URL(url);
+  for (const [key, value] of Object.entries(params)) {
+    if (value) parsedUrl.searchParams.set(key, value);
+  }
+  return parsedUrl.toString();
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+function createArcGISStoreLayer(args: {
+  id: string;
+  input: string;
+  nativeLayerIds: string[];
+  options: ArcGISLayerOptions;
+  sourceIds: string[];
+}): GeoLibreLayer {
+  const { id, input, nativeLayerIds, options, sourceIds } = args;
+  const sourceKind = `arcgis-${options.layerType}-${options.sourceType}`;
+  const sourceType = options.layerType === "feature" ? "geojson" : "vector";
+  const name = options.name?.trim() || layerNameFromArcGISInput(input, id);
+
+  return {
+    id,
+    name,
+    type: "arcgis",
+    source: {
+      itemId: options.sourceType === "portal-item" ? input : undefined,
+      layerType: options.layerType,
+      portalUrl: options.portalUrl?.trim() || undefined,
+      sourceId: sourceIds[0],
+      sourceIds,
+      type: sourceType,
+      url: options.sourceType === "url" ? input : undefined,
+    },
+    visible: true,
+    opacity: 1,
+    style: {
+      ...DEFAULT_LAYER_STYLE,
+      fillColor: "#2563eb",
+      fillOpacity: 0.45,
+      strokeColor: "#1d4ed8",
+    },
+    metadata: {
+      arcgisLayerType: options.layerType,
+      arcgisSourceType: options.sourceType,
+      externalNativeLayer: true,
+      hasAccessToken: Boolean(options.token?.trim()),
+      nativeLayerIds,
+      portalUrl: options.portalUrl?.trim() || undefined,
+      sourceId: sourceIds[0],
+      sourceIds,
+      sourceKind,
+    },
+    sourcePath: input,
+  };
+}
+
+function layerNameFromArcGISInput(input: string, fallback: string): string {
+  try {
+    const url = new URL(input);
+    const parts = url.pathname.split("/").filter(Boolean);
+    const serverIndex = parts.findIndex((part) =>
+      /^(FeatureServer|VectorTileServer)$/i.test(part),
+    );
+    const namePart =
+      serverIndex > 0 ? parts[serverIndex - 1] : parts[parts.length - 1];
+    return decodeURIComponent(namePart ?? "").replaceAll("_", " ") || fallback;
+  } catch {
+    return input || fallback;
+  }
+}
+
+function sanitizeIdPart(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_-]+/g, "-").replace(/^-+|-+$/g, "") || "id";
+}
+
+function createArcGISLayerId(): string {
+  arcgisLayerSequence += 1;
+  return `arcgis-layer-${arcgisLayerSequence}`;
+}

--- a/packages/plugins/src/plugins/arcgis-layer.ts
+++ b/packages/plugins/src/plugins/arcgis-layer.ts
@@ -26,6 +26,7 @@ export interface ArcGISLayerOptions {
 
 interface ArcGISFeatureLayerInfo {
   copyrightText?: string;
+  extent?: ArcGISExtent;
   geometryType?: string;
   name?: string;
 }
@@ -37,11 +38,36 @@ interface ArcGISFeatureServiceInfo {
   }>;
 }
 
+interface ArcGISServiceInfo {
+  extent?: ArcGISExtent;
+  fullExtent?: ArcGISExtent;
+  initialExtent?: ArcGISExtent;
+}
+
+interface ArcGISPortalItemInfo {
+  extent?: [[number, number], [number, number]];
+  url?: string;
+}
+
+interface ArcGISExtent {
+  spatialReference?: {
+    latestWkid?: number;
+    wkid?: number;
+  };
+  xmax: number;
+  xmin: number;
+  ymax: number;
+  ymin: number;
+}
+
 type ArcGISLayerModule = typeof import("@esri/maplibre-arcgis");
-type ArcGISRuntimeLayer = Pick<
-  HostedLayer,
-  "addSourcesAndLayersTo" | "layers" | "setSourceId" | "sources"
->;
+interface ArcGISRuntimeLayer {
+  readonly bounds?: [number, number, number, number];
+  readonly layers: Readonly<maplibregl.LayerSpecification[]>;
+  readonly sources: Readonly<Record<string, maplibregl.SourceSpecification>>;
+  addSourcesAndLayersTo(map: maplibregl.Map): ArcGISRuntimeLayer;
+  setSourceId(oldId: string, newId: string): void;
+}
 
 let arcgisLayerSequence = 0;
 const arcgisLayerInstances = new Map<string, ArcGISRuntimeLayer>();
@@ -62,8 +88,9 @@ export async function addArcGISLayer(
   const id = createArcGISLayerId();
   const sourceIds = prefixArcGISSourceIds(hostedLayer, id);
   const nativeLayerIds = prefixArcGISStyleLayerIds(hostedLayer, id);
+  const bounds = await resolveArcGISLayerBounds(input, options, hostedLayer);
 
-  hostedLayer.addSourcesAndLayersTo(map);
+  addArcGISRuntimeLayerToMap(hostedLayer, map);
   ensureArcGISStoreCleanup();
   arcgisLayerInstances.set(id, hostedLayer);
 
@@ -72,10 +99,12 @@ export async function addArcGISLayer(
     input,
     nativeLayerIds,
     options,
+    bounds,
     sourceIds,
   });
   const store = useAppStore.getState();
   store.addLayer(layer, options.beforeLayerId);
+  if (bounds) app.fitBounds?.(bounds);
   return id;
 }
 
@@ -102,7 +131,9 @@ async function createArcGISHostedLayer(
     token: options.token?.trim() || undefined,
   };
 
-  if (options.layerType === "feature") return createFallbackFeatureLayer(input, options);
+  if (options.layerType === "feature") {
+    return createFallbackFeatureLayer(input, options);
+  }
 
   return options.sourceType === "url"
     ? (arcgis.VectorTileLayer as typeof VectorTileLayer).fromUrl(
@@ -154,6 +185,23 @@ function prefixArcGISStyleLayerIds(
   });
 }
 
+function addArcGISRuntimeLayerToMap(
+  hostedLayer: ArcGISRuntimeLayer,
+  map: maplibregl.Map,
+): void {
+  for (const [sourceId, source] of Object.entries(hostedLayer.sources)) {
+    if (!map.getSource(sourceId)) {
+      map.addSource(sourceId, source);
+    }
+  }
+
+  for (const layer of hostedLayer.layers) {
+    if (!map.getLayer(layer.id)) {
+      map.addLayer(layer);
+    }
+  }
+}
+
 async function createFallbackFeatureLayer(
   input: string,
   options: ArcGISLayerOptions,
@@ -186,6 +234,7 @@ async function createFallbackFeatureLayer(
   });
 
   return createStaticArcGISRuntimeLayer({
+    bounds: arcgisExtentToBounds(layerInfo.extent),
     layers: [
       {
         id: styleLayerId,
@@ -233,6 +282,20 @@ async function resolvePortalFeatureLayerUrl(
   options: ArcGISLayerOptions,
   cause: unknown,
 ): Promise<string> {
+  const itemInfo = await fetchArcGISPortalItemInfo(itemId, options, cause);
+  if (!itemInfo.url) {
+    throw new Error("The ArcGIS portal item does not include a service URL.", {
+      cause,
+    });
+  }
+  return resolveFeatureLayerUrl(itemInfo.url, options, cause);
+}
+
+async function fetchArcGISPortalItemInfo(
+  itemId: string,
+  options: ArcGISLayerOptions,
+  cause: unknown,
+): Promise<ArcGISPortalItemInfo> {
   const portalUrl =
     options.portalUrl?.trim() || "https://www.arcgis.com/sharing/rest";
   const itemUrl = appendArcGISParams(
@@ -245,13 +308,7 @@ async function resolvePortalFeatureLayerUrl(
       cause,
     });
   }
-  const itemInfo = (await response.json()) as { url?: string };
-  if (!itemInfo.url) {
-    throw new Error("The ArcGIS portal item does not include a service URL.", {
-      cause,
-    });
-  }
-  return resolveFeatureLayerUrl(itemInfo.url, options, cause);
+  return (await response.json()) as ArcGISPortalItemInfo;
 }
 
 async function fetchArcGISJson<T>(
@@ -282,10 +339,14 @@ async function fetchArcGISJson<T>(
 }
 
 function createStaticArcGISRuntimeLayer(args: {
+  bounds?: [number, number, number, number];
   layers: maplibregl.LayerSpecification[];
-  sources: Record<string, maplibregl.AnySourceData>;
+  sources: Record<string, maplibregl.SourceSpecification>;
 }): ArcGISRuntimeLayer {
   return {
+    get bounds() {
+      return args.bounds;
+    },
     get layers() {
       return args.layers;
     },
@@ -311,6 +372,115 @@ function createStaticArcGISRuntimeLayer(args: {
       return this;
     },
   };
+}
+
+async function resolveArcGISLayerBounds(
+  input: string,
+  options: ArcGISLayerOptions,
+  hostedLayer: ArcGISRuntimeLayer,
+): Promise<[number, number, number, number] | undefined> {
+  const sourceBounds = getArcGISSourceBounds(hostedLayer);
+  if (sourceBounds) return sourceBounds;
+  if (hostedLayer.bounds) return hostedLayer.bounds;
+
+  try {
+    if (options.sourceType === "portal-item") {
+      const itemInfo = await fetchArcGISPortalItemInfo(input, options, undefined);
+      const itemBounds = arcgisPortalItemExtentToBounds(itemInfo.extent);
+      if (itemBounds) return itemBounds;
+      if (itemInfo.url) {
+        return resolveArcGISServiceBounds(itemInfo.url, options);
+      }
+      return undefined;
+    }
+
+    return resolveArcGISServiceBounds(input, options);
+  } catch {
+    return undefined;
+  }
+}
+
+async function resolveArcGISServiceBounds(
+  url: string,
+  options: ArcGISLayerOptions,
+): Promise<[number, number, number, number] | undefined> {
+  const serviceInfo = await fetchArcGISJson<ArcGISServiceInfo>(
+    url,
+    options,
+    undefined,
+  );
+  return arcgisExtentToBounds(
+    serviceInfo.fullExtent ?? serviceInfo.initialExtent ?? serviceInfo.extent,
+  );
+}
+
+function getArcGISSourceBounds(
+  hostedLayer: ArcGISRuntimeLayer,
+): [number, number, number, number] | undefined {
+  for (const source of Object.values(hostedLayer.sources)) {
+    const bounds = "bounds" in source ? source.bounds : undefined;
+    if (isGeoBounds(bounds)) return bounds;
+  }
+  return undefined;
+}
+
+function arcgisPortalItemExtentToBounds(
+  extent: ArcGISPortalItemInfo["extent"],
+): [number, number, number, number] | undefined {
+  if (!Array.isArray(extent) || extent.length !== 2) return undefined;
+  const [[west, south], [east, north]] = extent;
+  return isGeoBounds([west, south, east, north])
+    ? [west, south, east, north]
+    : undefined;
+}
+
+function arcgisExtentToBounds(
+  extent: ArcGISExtent | undefined,
+): [number, number, number, number] | undefined {
+  if (!extent) return undefined;
+  const wkid = extent.spatialReference?.latestWkid ?? extent.spatialReference?.wkid;
+  if (wkid === 102100 || wkid === 102113 || wkid === 3857) {
+    return [
+      mercatorXToLongitude(extent.xmin),
+      mercatorYToLatitude(extent.ymin),
+      mercatorXToLongitude(extent.xmax),
+      mercatorYToLatitude(extent.ymax),
+    ];
+  }
+
+  const bounds: [number, number, number, number] = [
+    extent.xmin,
+    extent.ymin,
+    extent.xmax,
+    extent.ymax,
+  ];
+  return isGeoBounds(bounds) ? bounds : undefined;
+}
+
+function mercatorXToLongitude(x: number): number {
+  return (x / 20037508.34) * 180;
+}
+
+function mercatorYToLatitude(y: number): number {
+  const latitude = (y / 20037508.34) * 180;
+  return (
+    (180 / Math.PI) *
+    (2 * Math.atan(Math.exp((latitude * Math.PI) / 180)) - Math.PI / 2)
+  );
+}
+
+function isGeoBounds(value: unknown): value is [number, number, number, number] {
+  return (
+    Array.isArray(value) &&
+    value.length === 4 &&
+    value.every((item) => typeof item === "number" && Number.isFinite(item)) &&
+    value[0] >= -180 &&
+    value[2] <= 180 &&
+    value[1] >= -90 &&
+    value[3] <= 90 &&
+    value[0] < value[2] &&
+    value[1] < value[3]
+  );
 }
 
 function arcgisGeometryLayerType(
@@ -362,13 +532,14 @@ function trimTrailingSlash(value: string): string {
 }
 
 function createArcGISStoreLayer(args: {
+  bounds?: [number, number, number, number];
   id: string;
   input: string;
   nativeLayerIds: string[];
   options: ArcGISLayerOptions;
   sourceIds: string[];
 }): GeoLibreLayer {
-  const { id, input, nativeLayerIds, options, sourceIds } = args;
+  const { bounds, id, input, nativeLayerIds, options, sourceIds } = args;
   const sourceKind = `arcgis-${options.layerType}-${options.sourceType}`;
   const sourceType = options.layerType === "feature" ? "geojson" : "vector";
   const name = options.name?.trim() || layerNameFromArcGISInput(input, id);
@@ -379,6 +550,7 @@ function createArcGISStoreLayer(args: {
     type: "arcgis",
     source: {
       itemId: options.sourceType === "portal-item" ? input : undefined,
+      bounds,
       layerType: options.layerType,
       portalUrl: options.portalUrl?.trim() || undefined,
       sourceId: sourceIds[0],
@@ -397,6 +569,7 @@ function createArcGISStoreLayer(args: {
     metadata: {
       arcgisLayerType: options.layerType,
       arcgisSourceType: options.sourceType,
+      bounds,
       externalNativeLayer: true,
       hasAccessToken: Boolean(options.token?.trim()),
       nativeLayerIds,

--- a/packages/plugins/src/plugins/arcgis-layer.ts
+++ b/packages/plugins/src/plugins/arcgis-layer.ts
@@ -1,3 +1,5 @@
+/// <reference path="../arcgis-maplibre.d.ts" />
+
 import {
   DEFAULT_LAYER_STYLE,
   type GeoLibreLayer,

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -1,5 +1,5 @@
 import type { FeatureCollection } from "geojson";
-import type { IControl } from "maplibre-gl";
+import type { IControl, Map as MapLibreMap } from "maplibre-gl";
 
 export type GeoLibreMapControlPosition =
   | "top-left"
@@ -29,6 +29,7 @@ export interface GeoLibreAppAPI {
   onBasemapChange: (callback: (styleUrl: string) => void) => () => void;
   fetchArrayBuffer?: (url: string) => Promise<ArrayBuffer>;
   fitBounds?: (bounds: [number, number, number, number]) => void;
+  getMap?: () => MapLibreMap | null;
   addMapControl: (
     control: IControl,
     position?: GeoLibreMapControlPosition,

--- a/packages/plugins/tsconfig.json
+++ b/packages/plugins/tsconfig.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
+      "@esri/maplibre-arcgis": [
+        "../../node_modules/@esri/maplibre-arcgis/dist/esm/types/src/MaplibreArcGIS.d.ts"
+      ],
       "maplibre-gl-components": [
         "./node_modules/maplibre-gl-components/dist/types/index.d.ts",
         "./node_modules/maplibre-gl-components/dist/src/index.d.ts"

--- a/packages/plugins/tsconfig.json
+++ b/packages/plugins/tsconfig.json
@@ -2,15 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "paths": {
-      "@esri/maplibre-arcgis": [
-        "../../node_modules/@esri/maplibre-arcgis/dist/esm/types/src/MaplibreArcGIS.d.ts"
-      ],
-      "maplibre-gl-components": [
-        "./node_modules/maplibre-gl-components/dist/types/index.d.ts",
-        "./node_modules/maplibre-gl-components/dist/src/index.d.ts"
-      ]
-    }
+    "paths": {}
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- Add ArcGIS layer support (FeatureServer, VectorTileServer, and portal items) via the @esri/maplibre-arcgis package, including an "Add ArcGIS Layer" dialog and toolbar entry.
- Expose a getMap accessor on the app API and a new arcgis layer type so plugins can drive native MapLibre layers.
- Generalize layer cleanup to remove multiple external source IDs per layer.

## Test plan
- [ ] Add a FeatureServer layer by service URL and confirm it renders.
- [ ] Add a VectorTileServer layer and confirm it renders.
- [ ] Add a layer by portal item ID (with optional portal URL and access token).
- [ ] Remove an ArcGIS layer and confirm all sources/layers are cleaned up.