### PR TITLE
feat: add KMZ vector layer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Lightweight, cloud-native desktop GIS prototype built with **Tauri v2**, **React
 ## Features (v0.4.0)
 
 - MapLibre map with OpenFreeMap Liberty basemap
-- Load local vector layers supported by DuckDB-WASM Spatial, including common formats such as GeoJSON, GeoParquet, GeoPackage, Shapefile, FlatGeobuf, KML, and GML
+- Load local vector layers supported by DuckDB-WASM Spatial, including common formats such as GeoJSON, GeoParquet, GeoPackage, Shapefile, FlatGeobuf, KML/KMZ, and GML
 - Layer panel (visibility, opacity, reorder, remove)
 - Live style panel (fill, stroke, opacity, circle radius)
 - Attribute table for imported vector layers
@@ -36,7 +36,7 @@ Bun users can run `bun install`. The root `trustedDependencies` list allows the 
 npm run dev
 ```
 
-Open http://localhost:5173. The map and browser vector import support local vector files that DuckDB-WASM Spatial can read, including common formats such as GeoJSON, GeoParquet, GeoPackage, Shapefile, FlatGeobuf, KML, and GML, with direct handling for GeoJSON and zipped Shapefiles. You can choose files from Add Vector Layer or drag them onto the app. Desktop filesystem dialogs require Tauri.
+Open http://localhost:5173. The map and browser vector import support local vector files that DuckDB-WASM Spatial can read, including common formats such as GeoJSON, GeoParquet, GeoPackage, Shapefile, FlatGeobuf, KML/KMZ, and GML, with direct handling for GeoJSON, zipped Shapefiles, and KMZ archives. You can choose files from Add Vector Layer or drag them onto the app. Desktop filesystem dialogs require Tauri.
 
 ## Environment variables
 

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -32,6 +32,7 @@
     "@tauri-apps/plugin-dialog": "^2.2.0",
     "@tauri-apps/plugin-fs": "^2.2.0",
     "@tauri-apps/plugin-opener": "^2.5.4",
+    "fflate": "^0.8.3",
     "jspdf": "^2.5.2",
     "mapillary-js": "^4.1.2",
     "maplibre-gl": "^5.24.0",

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -1,6 +1,7 @@
 import { parseProject, type GeoLibreProject } from "@geolibre/core";
 import { open, save } from "@tauri-apps/plugin-dialog";
 import { readFile, readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
+import { unzip } from "fflate";
 import type { FeatureCollection } from "geojson";
 import shp from "shpjs";
 import type { DuckDbVectorFile } from "./duckdb-vector-loader";
@@ -151,6 +152,63 @@ async function parseShapefileZip(
   return normalizeShapefileResult(await shp(data));
 }
 
+function unzipArchive(
+  data: ArrayBuffer | Uint8Array,
+): Promise<Record<string, Uint8Array>> {
+  const bytes = data instanceof Uint8Array ? data : new Uint8Array(data);
+  return new Promise<Record<string, Uint8Array>>((resolve, reject) => {
+    unzip(bytes, (error, entries) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve(entries);
+    });
+  });
+}
+
+function toDuckDbVectorData(data: Uint8Array): Uint8Array<ArrayBuffer> {
+  return new Uint8Array(data);
+}
+
+async function readKmzKmlFiles(
+  data: ArrayBuffer | Uint8Array,
+): Promise<DuckDbVectorFile[]> {
+  const entries = await unzipArchive(data);
+  const kmlEntries = Object.entries(entries)
+    .filter(([entryName]) => entryName.toLowerCase().endsWith(".kml"))
+    .sort(([leftName], [rightName]) => {
+      if (browserSafeFileName(leftName).toLowerCase() === "doc.kml") return -1;
+      if (browserSafeFileName(rightName).toLowerCase() === "doc.kml") return 1;
+      return leftName.localeCompare(rightName);
+    });
+
+  if (!kmlEntries.length) {
+    throw new Error("The KMZ archive did not contain a KML file.");
+  }
+
+  return kmlEntries.map(([entryName, data], index) => {
+    const entryBaseName =
+      browserSafeFileName(entryName) || `document-${index + 1}.kml`;
+    return {
+      name:
+        kmlEntries.length === 1
+          ? entryBaseName
+          : `${index + 1}-${entryBaseName}`,
+      extension: "kml",
+      data: toDuckDbVectorData(data),
+    };
+  });
+}
+
+async function parseKmz(
+  data: ArrayBuffer | Uint8Array,
+): Promise<FeatureCollection> {
+  const kmlFiles = await readKmzKmlFiles(data);
+  const collections = await Promise.all(kmlFiles.map(loadDuckDbVector));
+  return mergeFeatureCollections(collections);
+}
+
 async function loadDuckDbVector(file: DuckDbVectorFile) {
   const { loadDuckDbVectorFile } = await import("./duckdb-vector-loader");
   return loadDuckDbVectorFile(file);
@@ -193,6 +251,13 @@ async function loadBrowserVectorFile(
     } catch {
       // DuckDB Spatial may be able to read zipped vector data that shpjs cannot.
     }
+  }
+
+  if (extension === "kmz") {
+    return {
+      data: await parseKmz(await file.arrayBuffer()),
+      path: file.name,
+    };
   }
 
   return {
@@ -266,6 +331,18 @@ async function loadTauriVectorFile(path: string): Promise<{
       };
     } catch {
       // DuckDB Spatial may be able to read zipped vector data that shpjs cannot.
+    }
+  }
+
+  if (extension === "kmz") {
+    try {
+      return {
+        data: await parseKmz(await readFile(path)),
+        path,
+      };
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : "Unknown error";
+      throw new Error(`Could not read this KMZ file. ${detail}`);
     }
   }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,7 +43,7 @@ INSTALL spatial;
 LOAD spatial;
 ```
 
-GeoParquet is read with DuckDB's Parquet reader after loading Spatial. Other local vector formats are passed to Spatial `ST_Read` when the WebAssembly extension can load the GDAL-backed reader. Zipped Shapefiles are parsed with `shpjs` first, then DuckDB Spatial is tried if that parser cannot read the file.
+GeoParquet is read with DuckDB's Parquet reader after loading Spatial. Other local vector formats are passed to Spatial `ST_Read` when the WebAssembly extension can load the GDAL-backed reader. Zipped Shapefiles are parsed with `shpjs` first, then DuckDB Spatial is tried if that parser cannot read the file. KMZ archives are unzipped in the browser and their KML files are passed through the same DuckDB Spatial KML reader.
 
 ## Python sidecar (v0.5)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,7 +24,7 @@ Bun users can run `bun install`. The root `trustedDependencies` list allows the 
 npm run dev
 ```
 
-Open `http://localhost:5173`. The map and browser vector import support local vector files that DuckDB-WASM Spatial can read, with direct handling for GeoJSON and zipped Shapefiles. Use Add Vector Layer or drag files onto the app. Desktop filesystem dialogs require Tauri.
+Open `http://localhost:5173`. The map and browser vector import support local vector files that DuckDB-WASM Spatial can read, with direct handling for GeoJSON, zipped Shapefiles, and KMZ archives. Use Add Vector Layer or drag files onto the app. Desktop filesystem dialogs require Tauri.
 
 ## Run the desktop app
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@tauri-apps/plugin-dialog": "^2.2.0",
         "@tauri-apps/plugin-fs": "^2.2.0",
         "@tauri-apps/plugin-opener": "^2.5.4",
+        "fflate": "^0.8.3",
         "jspdf": "^2.5.2",
         "mapillary-js": "^4.1.2",
         "maplibre-gl": "^5.24.0",
@@ -75,6 +76,12 @@
       "peerDependencies": {
         "three": "^0.178.0"
       }
+    },
+    "apps/geolibre-desktop/node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "apps/geolibre-desktop/node_modules/maplibre-gl-components": {
       "version": "0.17.3",


### PR DESCRIPTION
## Summary
- Unzip KMZ archives in the browser with fflate and route their KML contents through the existing DuckDB Spatial KML reader
- Support KMZ import in both the browser file picker/drag-drop path and the Tauri desktop filesystem path
- Update README and docs to list KML/KMZ among supported vector formats

## Test plan
- [ ] Import a single-KML KMZ via Add Vector Layer in the browser
- [ ] Import a multi-KML KMZ and confirm features merge correctly
- [ ] Import a KMZ through the desktop (Tauri) file dialog
- [ ] Confirm an invalid KMZ surfaces a clear error message