### PR TITLE
chore: bump version to 0.5.0 and show app version in About dialog

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolibre-desktop",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/geolibre-desktop/src-tauri/Cargo.lock
+++ b/apps/geolibre-desktop/src-tauri/Cargo.lock
@@ -1251,7 +1251,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-desktop"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "flate2",
  "reqwest 0.12.28",

--- a/apps/geolibre-desktop/src-tauri/Cargo.toml
+++ b/apps/geolibre-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-desktop"
-version = "0.4.0"
+version = "0.5.0"
 description = "GeoLibre Desktop — lightweight cloud-native desktop GIS"
 authors = ["GeoLibre Contributors"]
 edition = "2021"

--- a/apps/geolibre-desktop/src-tauri/tauri.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "GeoLibre Desktop",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "identifier": "org.geolibre.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
@@ -21,6 +21,8 @@ const LINKS = [
   },
 ];
 
+const APP_VERSION = __GEOLIBRE_VERSION__;
+
 function isTauri(): boolean {
   return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 }
@@ -53,6 +55,10 @@ export function AboutDialog() {
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-3 text-sm">
+          <div className="flex items-center justify-between rounded-md border bg-muted/30 px-3 py-2">
+            <span className="text-muted-foreground">Version</span>
+            <span className="font-mono text-foreground">v{APP_VERSION}</span>
+          </div>
           {LINKS.map((link) => (
             <a
               key={link.href}

--- a/apps/geolibre-desktop/src/vite-env.d.ts
+++ b/apps/geolibre-desktop/src/vite-env.d.ts
@@ -1,5 +1,7 @@
 /// <reference types="vite/client" />
 
+declare const __GEOLIBRE_VERSION__: string;
+
 declare module "*.geojson?url" {
   const url: string;
   export default url;

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -1,4 +1,5 @@
 import react from "@vitejs/plugin-react";
+import { readFileSync } from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
 import type {
@@ -12,6 +13,9 @@ const GEOAGENT_BROWSER_BUNDLE = "maplibre-gl-geoagent/dist/browser-";
 const EARTH_ENGINE_BROWSER_BUNDLE = "@google/earthengine/build/browser.js";
 const GIS_CHUNK_WARNING_LIMIT_KB = 5000;
 const APP_BASE = process.env.GEOLIBRE_APP_BASE;
+const APP_VERSION = JSON.parse(
+  readFileSync(new URL("./package.json", import.meta.url), "utf8"),
+).version as string;
 const WMS_PROXY_PATH = "/__geolibre_wms_proxy";
 const RASTER_PROXY_PATH = "/__geolibre_raster_proxy";
 const RADIX_OPTIMIZE_EXCLUDES = [
@@ -124,6 +128,9 @@ export default defineConfig({
   base: APP_BASE,
   plugins: [react(), wmsProxyPlugin()],
   clearScreen: false,
+  define: {
+    __GEOLIBRE_VERSION__: JSON.stringify(APP_VERSION),
+  },
   server: {
     port: 5173,
     strictPort: true,

--- a/backend/geolibre_server/pyproject.toml
+++ b/backend/geolibre_server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolibre-server"
-version = "0.4.0"
+version = "0.5.0"
 description = "Optional Python processing sidecar for GeoLibre Desktop"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolibre",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolibre",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -16,7 +16,7 @@
       }
     },
     "apps/geolibre-desktop": {
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@carbonplan/zarr-layer": "^0.3.1",
         "@deck.gl/core": "^9.3.2",
@@ -11969,7 +11969,7 @@
     },
     "packages/core": {
       "name": "@geolibre/core",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "uuid": "^11.1.0",
         "zustand": "^5.0.3"
@@ -11981,7 +11981,7 @@
     },
     "packages/map": {
       "name": "@geolibre/map",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@geolibre/core": "*",
         "@turf/bbox": "^7.2.0",
@@ -12004,7 +12004,7 @@
     },
     "packages/plugins": {
       "name": "@geolibre/plugins",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@carbonplan/zarr-layer": "^0.3.1",
         "@deck.gl/core": "^9.3.2",
@@ -12125,7 +12125,7 @@
     },
     "packages/processing": {
       "name": "@geolibre/processing",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@geolibre/core": "*",
         "@turf/bbox": "^7.2.0"
@@ -12137,7 +12137,7 @@
     },
     "packages/ui": {
       "name": "@geolibre/ui",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-dropdown-menu": "^2.1.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geolibre",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "GeoLibre Desktop — lightweight cloud-native desktop GIS",
   "workspaces": [
     "apps/*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/core",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/map",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/plugins",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/processing/package.json
+++ b/packages/processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/processing",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/ui",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",


### PR DESCRIPTION
## Summary
- Bump all workspace packages, the Tauri app, and the Python sidecar from 0.4.0 to 0.5.0
- Display the running app version in the About dialog, injected at build time from package.json

## Test plan
- [x] pre-commit run --all-files (includes npm build) passes
- [ ] Open the About dialog and confirm it shows v0.5.0