### PR TITLE
docs: update documentation for v0.5.0 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 # GeoLibre Desktop
 
-Lightweight, cloud-native desktop GIS prototype built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS**, and **DuckDB-WASM Spatial**.
+Lightweight, cloud-native desktop GIS prototype built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS**, **DuckDB-WASM Spatial**, and **deck.gl**.
 
-## Features (v0.4.0)
+## Features (v0.5.0)
 
-- MapLibre map with OpenFreeMap Liberty basemap
+- MapLibre map workspace with OpenFreeMap basemaps, blank background support, and toggleable navigation, fullscreen, geolocation, globe, terrain, scale, attribution, and logo controls
 - Load local vector layers supported by DuckDB-WASM Spatial, including common formats such as GeoJSON, GeoParquet, GeoPackage, Shapefile, FlatGeobuf, KML/KMZ, and GML
-- Layer panel (visibility, opacity, reorder, remove)
+- Add Data menu for XYZ tiles, WMS, GeoJSON URLs, vector tiles, COG and GeoTIFF rasters, MBTiles, ArcGIS FeatureServer and VectorTileServer layers, PMTiles, Zarr, LiDAR, and Gaussian splats
+- Layer panel for visibility, opacity, reordering, zoom-to-layer, identify, and remove actions
 - Live style panel (fill, stroke, opacity, circle radius)
-- Attribute table for imported vector layers
+- Attribute table with filtering, sorting, resize controls, feature highlighting, and optional zoom to selected features
 - Save/open `.geolibre.json` projects
 - Processing toolbox with local bounds and feature count algorithms
-- Plugin system with basemap, layer control, swipe, street view, lidar, GeoAgent, and GeoEditor integrations
+- Plugin system with basemap, layer control, MapLibre components, swipe, street view, LiDAR, GeoAgent, and GeoEditor integrations, including configurable control positions
 - Optional Python FastAPI sidecar for heavier processing workflows
 
 ## Prerequisites
@@ -30,13 +31,13 @@ npm install
 
 Bun users can run `bun install`. The root `trustedDependencies` list allows the known install scripts for `core-js`, `@google/genai`, and `protobufjs`.
 
-## Run (web dev — map in browser)
+## Run (web dev, map in browser)
 
 ```bash
 npm run dev
 ```
 
-Open http://localhost:5173. The map and browser vector import support local vector files that DuckDB-WASM Spatial can read, including common formats such as GeoJSON, GeoParquet, GeoPackage, Shapefile, FlatGeobuf, KML/KMZ, and GML, with direct handling for GeoJSON, zipped Shapefiles, and KMZ archives. You can choose files from Add Vector Layer or drag them onto the app. Desktop filesystem dialogs require Tauri.
+Open http://localhost:5173. The map and browser vector import support local vector files that DuckDB-WASM Spatial can read, including common formats such as GeoJSON, GeoParquet, GeoPackage, Shapefile, FlatGeobuf, KML/KMZ, and GML, with direct handling for GeoJSON, zipped Shapefiles, and KMZ archives. You can choose files from Add Vector Layer or drag them onto the app. Desktop filesystem dialogs, local MBTiles, and local raster file reads require Tauri.
 
 ## Environment variables
 
@@ -89,7 +90,7 @@ docs/                   # Architecture & API docs
 
 ## Add a plugin
 
-Built-in plugins live in `packages/plugins/src/plugins/` and are registered by the desktop app in `apps/geolibre-desktop/src/hooks/usePlugins.ts`.
+Built-in plugins live in `packages/plugins/src/plugins/` and are registered by the desktop app in `apps/geolibre-desktop/src/hooks/usePlugins.ts`. Map control plugins can expose a control position through `getMapControlPosition()` and `setMapControlPosition()` so the Plugins menu can move them between map corners.
 
 1. Create a plugin file in `packages/plugins/src/plugins/`.
 
@@ -128,7 +129,9 @@ manager.registerAll([
 
 Plugins can use the app API to change basemaps, add GeoJSON layers, or attach MapLibre controls. For a MapLibre control plugin, add the package dependency, import its CSS in `apps/geolibre-desktop/src/main.tsx`, then call `app.addMapControl(control, "top-left")` in `activate()` and `app.removeMapControl(control)` in `deactivate()`.
 
-Built-in MapLibre controls such as Navigation, Fullscreen, Geolocate, Globe, Terrain, Scale, Attribution, and Logo are toggled from the desktop app's Controls menu. Keep project-specific controls such as Layer Control in the plugin menu when they use the plugin API or need plugin lifecycle behavior.
+Built-in MapLibre controls such as Navigation, Fullscreen, Geolocate, Globe, Terrain, Scale, Attribution, and Logo are toggled from the desktop app's Controls menu. Keep project-specific controls such as Layer Control and Components in the plugin menu when they use the plugin API or need plugin lifecycle behavior.
+
+The v0.5.0 Components plugin wraps `maplibre-gl-components` controls and wires their layer events into the GeoLibre store. It provides Add Data shortcuts for FlatGeobuf, PMTiles, Zarr, LiDAR, and Gaussian splats, while raster COG and GeoTIFF layers can also be added through the standard Add Raster Layer dialog.
 
 If a third-party MapLibre control needs app-specific styling fixes, add scoped overrides in `apps/geolibre-desktop/src/index.css` instead of editing files in `node_modules`. Keep selectors limited to the plugin control class. For example, GeoEditor toolbar buttons need a local override because MapLibre's default control button CSS can override their flex centering:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,13 +2,15 @@
 
 ## Overview
 
-GeoLibre Desktop is an npm workspaces monorepo. The UI is a React app hosted by Tauri v2. Map rendering uses MapLibre GL JS in the browser webview. Application state lives in a Zustand store (`@geolibre/core`).
+GeoLibre Desktop is an npm workspaces monorepo. The UI is a React app hosted by Tauri v2. Map rendering uses MapLibre GL JS in the browser webview, with deck.gl used for advanced raster, point cloud, and 3D overlays. Application state lives in a Zustand store (`@geolibre/core`).
 
 ```mermaid
 flowchart LR
   UI[React UI] --> Store[Zustand Store]
   Store --> MapPkg[MapController]
   MapPkg --> ML[MapLibre GL JS]
+  Plugins[Built-in plugins] --> Store
+  Plugins --> ML
   UI --> Tauri[Tauri Plugins]
   Tauri --> FS[File System]
   Proc[Processing] --> Store
@@ -20,7 +22,7 @@ flowchart LR
 | Package | Responsibility |
 |---------|----------------|
 | `@geolibre/core` | Domain types, project JSON schema, global store |
-| `@geolibre/map` | MapLibre lifecycle, layer sync, GeoJSON styling |
+| `@geolibre/map` | MapLibre lifecycle, layer sync, GeoJSON, raster, tile, MBTiles, control, and selection styling |
 | `@geolibre/ui` | Shared UI primitives (shadcn-style) |
 | `@geolibre/processing` | Client-side algorithm registry |
 | `@geolibre/plugins` | Plugin interface and built-in plugins |
@@ -28,11 +30,13 @@ flowchart LR
 
 ## State flow
 
-1. User adds local vector data supported by DuckDB-WASM Spatial through the Tauri dialog, browser file picker, or drag and drop.
-2. The selected vector data is parsed directly or converted to GeoJSON with DuckDB-WASM Spatial, then passed to `addGeoJsonLayer` in the store.
-3. `MapCanvas` subscribes to `layers`, then `MapController.syncLayers` updates MapLibre sources and layers.
-4. Style panel updates `layer.style`, then sync updates paint properties.
-5. Desktop save uses `projectFromStore` and writes `.geolibre.json` to disk.
+1. User adds data through the Add Data menu, the Tauri dialog, browser file picker, drag and drop, or a built-in plugin control.
+2. Local vector data is parsed directly or converted to GeoJSON with DuckDB-WASM Spatial, then passed to `addGeoJsonLayer` in the store.
+3. Tile, service, raster, ArcGIS, MBTiles, and plugin-backed layers create `GeoLibreLayer` records with source metadata and native MapLibre layer ids when applicable.
+4. `MapCanvas` subscribes to `layers`, then `MapController.syncLayers` updates MapLibre sources and layers and keeps the layer control in sync.
+5. Style panel and layer panel updates change layer state, then map sync updates paint, visibility, opacity, ordering, and removal.
+6. Attribute table selections update the highlighted feature source and can zoom the map to the selected feature.
+7. Desktop save uses `projectFromStore` and writes `.geolibre.json` to disk.
 
 ## DuckDB-WASM
 
@@ -45,9 +49,15 @@ LOAD spatial;
 
 GeoParquet is read with DuckDB's Parquet reader after loading Spatial. Other local vector formats are passed to Spatial `ST_Read` when the WebAssembly extension can load the GDAL-backed reader. Zipped Shapefiles are parsed with `shpjs` first, then DuckDB Spatial is tried if that parser cannot read the file. KMZ archives are unzipped in the browser and their KML files are passed through the same DuckDB Spatial KML reader.
 
-## Python sidecar (v0.5)
+## Advanced Add Data workflows
 
-The FastAPI app in `backend/geolibre_server` is planned to run as a Tauri **external binary**:
+The v0.5.0 Add Data surface includes native dialogs for XYZ, WMS, vector files, GeoJSON URLs, vector tile sources, raster tile templates, COG and GeoTIFF rasters, MBTiles, and ArcGIS FeatureServer or VectorTileServer layers. The Components plugin wraps `maplibre-gl-components` panels for FlatGeobuf, PMTiles, Zarr, LiDAR, and Gaussian splats, then mirrors added layers into the GeoLibre store so the Layer panel, project format, and layer control can reason about them.
+
+Local MBTiles tiles are read through a custom MapLibre protocol backed by Tauri commands. Remote rasters are fetched through the desktop backend when needed, and the local development server includes a raster proxy for selected release assets that need CORS handling.
+
+## Python sidecar
+
+The FastAPI app in `backend/geolibre_server` is reserved for heavier processing workflows and is planned to run as a Tauri **external binary**:
 
 1. Bundle `geolibre-server` in `src-tauri/bin/`.
 2. Spawn on first processing request needing GDAL/GeoPandas.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,7 +24,9 @@ Bun users can run `bun install`. The root `trustedDependencies` list allows the 
 npm run dev
 ```
 
-Open `http://localhost:5173`. The map and browser vector import support local vector files that DuckDB-WASM Spatial can read, with direct handling for GeoJSON, zipped Shapefiles, and KMZ archives. Use Add Vector Layer or drag files onto the app. Desktop filesystem dialogs require Tauri.
+Open `http://localhost:5173`. The map and browser vector import support local vector files that DuckDB-WASM Spatial can read, with direct handling for GeoJSON, zipped Shapefiles, and KMZ archives. Use Add Vector Layer or drag files onto the app. The browser UI can also add URL-based services and datasets such as XYZ, WMS, GeoJSON URLs, vector tiles, COG rasters, ArcGIS services, FlatGeobuf, PMTiles, Zarr, LiDAR, and Gaussian splats.
+
+Desktop filesystem dialogs, local MBTiles, local raster file reads, project save/open, and other filesystem operations require Tauri.
 
 ## Run the desktop app
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,8 +9,8 @@ hide:
     <h1>MapLibre-powered GIS for local projects and modern geospatial workflows.</h1>
     <p class="hero__lead">
       GeoLibre is a lightweight desktop GIS prototype built with Tauri, React,
-      TypeScript, MapLibre GL JS, and DuckDB-WASM Spatial. It focuses on fast
-      local vector data work, project files, styling, plugins, and a practical
+      TypeScript, MapLibre GL JS, DuckDB-WASM Spatial, and deck.gl. It focuses
+      on fast local data work, project files, styling, plugins, and a practical
       path toward cloud-native geospatial workflows.
     </p>
     <div class="hero__actions">
@@ -31,19 +31,25 @@ hide:
 <div class="feature-card" markdown>
 ### MapLibre map workspace
 
-Use an OpenFreeMap basemap, pan and zoom smoothly, and toggle built-in map controls for navigation, terrain, globe view, geolocation, scale, attribution, and logo display.
+Use OpenFreeMap basemaps, a blank background, smooth pan and zoom, and toggle built-in map controls for navigation, terrain, globe view, geolocation, scale, attribution, and logo display.
 </div>
 
 <div class="feature-card" markdown>
-### Local vector projects
+### Local and remote data
 
-Load local vector data supported by DuckDB-WASM Spatial, inspect attributes, style layers, reorder visibility, and save or reopen `.geolibre.json` projects from the desktop app.
+Load local vector data supported by DuckDB-WASM Spatial, add web tile and service layers, inspect attributes, style layers, reorder visibility, and save or reopen `.geolibre.json` projects from the desktop app.
 </div>
 
 <div class="feature-card" markdown>
 ### Plugin-ready UI
 
-Built-in plugins cover basemaps, sample data, layer control, swipe, street view, lidar, GeoAgent, and GeoEditor integrations.
+Built-in plugins cover basemaps, sample data, layer control, MapLibre components, swipe, street view, LiDAR, GeoAgent, and GeoEditor integrations.
+</div>
+
+<div class="feature-card" markdown>
+### Advanced layer formats
+
+Add Data supports XYZ, WMS, GeoJSON URLs, vector tiles, COG and GeoTIFF rasters, MBTiles, ArcGIS layers, FlatGeobuf, PMTiles, Zarr, LiDAR, and Gaussian splats.
 </div>
 
 <div class="feature-card" markdown>
@@ -56,11 +62,11 @@ The processing toolbox includes client-side algorithms now, with a roadmap towar
 
 ## Try it in the browser
 
-The live demo is the browser-capable version of the GeoLibre desktop UI. It is useful for exploring the map, loading browser-selected vector data supported by DuckDB-WASM Spatial, styling layers, and testing plugins. Desktop-only file dialogs and filesystem save/open operations still require the installed Tauri app.
+The live demo is the browser-capable version of the GeoLibre desktop UI. It is useful for exploring the map, loading browser-selected vector data supported by DuckDB-WASM Spatial, adding URL-based layers, styling layers, and testing plugins. Desktop-only file dialogs, local MBTiles, local raster reads, and filesystem save/open operations still require the installed Tauri app.
 
 [Open the live demo](/demo/){ .md-button .md-button--primary }
 [Read the architecture](architecture.md){ .md-button }
 
 ## Project status
 
-GeoLibre is an active prototype. Version 0.4.0 includes the map workspace, project format, plugin API, browser vector import, DuckDB-WASM Spatial loading, and core UI patterns. See the [roadmap](roadmap.md) for planned work on PMTiles, COGs, SQL workflows, the Python processing sidecar, and external plugin loading.
+GeoLibre is an active prototype. Version 0.5.0 includes the map workspace, project format, plugin API, browser vector import, DuckDB-WASM Spatial loading, advanced Add Data workflows, MBTiles desktop support, ArcGIS layers, COG and GeoTIFF raster rendering, PMTiles, Zarr, LiDAR, and Gaussian splats. See the [roadmap](roadmap.md) for planned work on SQL workflows, persisted recent projects, the Python processing sidecar, and external plugin loading.

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -46,6 +46,9 @@ export interface GeoLibreAppAPI {
   ) => void;
   getActiveBasemap: () => string;
   onBasemapChange: (callback: (styleUrl: string) => void) => () => void;
+  fetchArrayBuffer?: (url: string) => Promise<ArrayBuffer>;
+  fitBounds?: (bounds: [number, number, number, number]) => void;
+  getMap?: () => import("maplibre-gl").Map | null;
   addMapControl: (
     control: IControl,
     position?: GeoLibreMapControlPosition,
@@ -83,9 +86,10 @@ manager.activate("my-plugin", appApi);
 | `carto-light` | CARTO Positron GL style |
 | `sample-geojson` | Loads `sample-data/sample.geojson` |
 | `maplibre-gl-basemap-control` | Adds a MapLibre basemap picker |
+| `maplibre-gl-components` | Adds the MapLibre Components control grid and panels for FlatGeobuf, COG, PMTiles, Zarr, LiDAR, and Gaussian splats |
 | `maplibre-gl-geo-editor` | Adds GeoEditor drawing controls |
 | `maplibre-gl-geoagent` | Adds GeoAgent map assistant controls |
-| `maplibre-gl-lidar` | Adds lidar controls |
+| `maplibre-gl-lidar` | Adds LiDAR controls |
 | `maplibre-gl-streetview` | Adds street view controls |
 | `maplibre-gl-swipe` | Adds map swipe controls |
 
@@ -107,8 +111,10 @@ export const myPlugin: GeoLibrePlugin = {
 };
 ```
 
-## Roadmap (v0.6)
+Map control plugins can optionally expose `getMapControlPosition()` and `setMapControlPosition()` so the desktop Plugins menu can move the control between map corners. Position-aware plugins should remove and recreate or re-add their control when the position changes.
 
-- Dynamic plugin loading from `plugins/` directory
+## Roadmap (v0.7)
+
+- Dynamic plugin loading from a `plugins/` directory
 - Plugin manifest (`plugin.json`)
 - Sandboxed worker plugins

--- a/docs/project-format.md
+++ b/docs/project-format.md
@@ -31,7 +31,12 @@ Projects are saved as **`.geolibre.json`** files.
     "strokeColor": "#1e40af",
     "strokeWidth": 2,
     "fillOpacity": 0.6,
-    "circleRadius": 6
+    "circleRadius": 6,
+    "rasterBrightnessMin": 0,
+    "rasterBrightnessMax": 1,
+    "rasterSaturation": 0,
+    "rasterContrast": 0,
+    "rasterHueRotate": 0
   },
   "metadata": {},
   "geojson": { "type": "FeatureCollection", "features": [] },
@@ -41,16 +46,23 @@ Projects are saved as **`.geolibre.json`** files.
 
 ## Layer types
 
-| Type | MVP status |
-|------|------------|
-| `geojson` | Supported |
-| `xyz` | Partial (raster tiles) |
-| `vector-tiles` | Partial |
-| `pmtiles` | Placeholder (v0.3) |
-| `cog` | Placeholder (v0.3) |
-| `flatgeobuf` | Placeholder (v0.3) |
+| Type | v0.5.0 status |
+|------|---------------|
+| `geojson` | Supported for imported files and GeoJSON URLs |
+| `xyz` | Supported for raster tile templates |
+| `wms` | Supported as tiled WMS GetMap layers |
+| `raster` | Supported for raster tile templates |
+| `vector-tiles` | Supported for MapLibre vector tile sources |
+| `mbtiles` | Supported in the desktop app through a local MapLibre protocol |
+| `arcgis` | Supported for ArcGIS FeatureServer and VectorTileServer layers |
+| `pmtiles` | Supported through the Components plugin |
+| `cog` | Supported for COG and GeoTIFF raster layers |
+| `flatgeobuf` | Supported through the Components plugin and imported as GeoJSON when loaded as a local vector file |
+| `zarr` | Supported through the Components plugin |
+| `lidar` | Supported through the Components plugin |
+| `gaussian-splat` | Supported through the Components plugin |
 | `geoparquet` | Imported as GeoJSON via DuckDB-WASM |
-| `duckdb-query` | Placeholder (v0.4) |
+| `duckdb-query` | Reserved for SQL query-result layers |
 
 ## Example
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # GeoLibre Desktop Roadmap
 
-## v0.1: Map viewer and GeoJSON (current)
+## v0.1: Map viewer and GeoJSON
 
 - [x] Tauri + React + MapLibre shell
 - [x] GeoJSON load, layer panel, style panel
@@ -11,34 +11,48 @@
 ## v0.2: Project persistence
 
 - [x] `.geolibre.json` save/open
-- [ ] Recent projects list (persistence)
-- [ ] Feature highlight from attribute table
+- [x] In-session recent project tracking
+- [x] Feature highlight from attribute table
+- [x] Optional zoom to selected feature
+- [ ] Recent projects UI and persistence
 
 ## v0.3: Cloud-native formats
 
-- [ ] PMTiles
-- [ ] FlatGeobuf
-- [ ] GeoParquet
-- [ ] COG (raster)
-- [ ] Zoom to layer for all types
+- [x] GeoParquet import through DuckDB-WASM
+- [x] FlatGeobuf import through DuckDB-WASM and URL-based Components plugin panel
+- [x] PMTiles through Components plugin
+- [x] COG and GeoTIFF raster rendering
+- [x] Zoom to layer for GeoJSON and source-bounds-aware layer types
 
 ## v0.4: DuckDB Spatial
 
-- [ ] DuckDB-WASM integration
-- [ ] `INSTALL spatial` / `LOAD spatial`
-- [ ] SQL panel and query-result layers
+- [x] DuckDB-WASM integration
+- [x] `INSTALL spatial` / `LOAD spatial`
+- [x] Shapefile, KMZ/KML, GeoPackage, GeoParquet, FlatGeobuf, GML, and related vector import paths
 
-## v0.5: Python processing sidecar
+## v0.5: Advanced Add Data and plugin-backed layers (current)
+
+- [x] Add Data dialogs for XYZ, WMS, vector files, GeoJSON URLs, vector tiles, raster tile templates, COG and GeoTIFF rasters, MBTiles, and ArcGIS layers
+- [x] MapLibre Components plugin with FlatGeobuf, PMTiles, Zarr, LiDAR, and Gaussian splat panels
+- [x] Desktop MBTiles metadata and tile reads through Tauri commands
+- [x] Plugin control position controls in the Plugins menu
+- [x] Layer control integration for GeoLibre-managed layers
+
+## v0.6: SQL and processing sidecar
 
 - [ ] Bundle FastAPI server as Tauri external bin
 - [ ] GDAL / Rasterio / GeoPandas pipelines
 - [ ] Buffer, reproject, export GeoJSON
 - [ ] WhiteboxTools, Leafmap, GeoAI, SamGeo (selective)
+- [ ] SQL panel and query-result layers
 
-## v0.6: Plugin system
+## v0.7: Plugin system
 
 - [ ] External plugin packages
 - [ ] Plugin marketplace / registry (design)
+- [ ] Dynamic plugin loading from a `plugins/` directory
+- [ ] Plugin manifest (`plugin.json`)
+- [ ] Sandboxed worker plugins
 
 ## v1.0: Stable prototype
 


### PR DESCRIPTION
## Summary
- Refresh README and docs to describe the v0.5.0 Add Data workflows, plugin-backed layers (FlatGeobuf, PMTiles, Zarr, LiDAR, Gaussian splats), MBTiles desktop support, ArcGIS layers, and COG/GeoTIFF raster rendering.
- Update the layer type table, project format, plugin API, and architecture notes to match shipped capabilities.
- Revise the roadmap to mark completed v0.1-v0.5 work and re-sequence upcoming SQL, processing sidecar, and plugin system milestones.

## Test plan
- [x] `pre-commit run --all-files` passes (includes npm build)
- [ ] Review rendered docs for accuracy