### PR TITLE
fix: pass --comment so Claude Code review posts its findings

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,6 +38,6 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## Problem

After granting write permissions (#60), the `Claude Code Review` workflow runs to completion (`subtype: success`) but still posts no comment on the PR. The run log shows `No buffered inline comments` and the review output is discarded.

## Root cause

The `code-review` plugin command is **print-only by default**. Its instructions are explicit (`commands/code-review.md`):

> Step 7: "If `--comment` argument was NOT provided, stop here. Do not post any GitHub comments."

The workflow invoked it without `--comment`:

```
prompt: '/code-review:code-review .../pull/<n>'
```

so the review was generated, printed to the (security-hidden) SDK output, and intentionally never posted.

## Fix

Append `--comment` to the prompt so the command posts inline review comments (via `mcp__github_inline_comment__create_inline_comment`), or a summary comment when no issues are found:

```
prompt: '/code-review:code-review .../pull/<n> --comment'
```

## Note

Like #60, this must land on `main` to take effect: on `pull_request` events the Claude GitHub App requires the PR-branch workflow file to be byte-identical to the default-branch copy before it will mint its token.