### PR TITLE
feat: add STAC search layer with COG rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ __pycache__/
 *.tsbuildinfo
 **/src-tauri/gen/
 .playwright-cli/
+.claude/

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -18,7 +18,7 @@
     "@deck.gl/layers": "^9.3.2",
     "@deck.gl/mapbox": "^9.3.2",
     "@deck.gl/mesh-layers": "^9.3.2",
-    "@developmentseed/deck.gl-geotiff": "^0.2.0",
+    "@developmentseed/deck.gl-geotiff": "^0.7.0",
     "@developmentseed/deck.gl-raster": "^0.7.0",
     "@duckdb/duckdb-wasm": "^1.29.0",
     "@dvt3d/maplibre-three-plugin": "^1.6.0",

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -216,9 +216,6 @@ export function TopToolbar({
           <DropdownMenuItem onSelect={handleAddPMTilesLayer}>
             Add PMTiles Layer
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleAddStacLayer}>
-            Add STAC Layer
-          </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => setAddDataKind("mbtiles")}>
             Add MBTiles Layer
           </DropdownMenuItem>
@@ -233,6 +230,9 @@ export function TopToolbar({
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={handleAddSplattingLayer}>
             Add Splatting Layer
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={handleAddStacLayer}>
+            Add STAC Layer
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -13,6 +13,7 @@ import {
   openLidarLayerPanel,
   openPMTilesLayerPanel,
   openSplattingLayerPanel,
+  openStacSearchLayerPanel,
   openZarrLayerPanel,
   type GeoLibreMapControlPosition,
 } from "@geolibre/plugins";
@@ -150,6 +151,9 @@ export function TopToolbar({
   const handleAddPMTilesLayer = () => {
     openPMTilesLayerPanel(appApi);
   };
+  const handleAddStacLayer = () => {
+    openStacSearchLayerPanel(appApi);
+  };
   const handleAddZarrLayer = () => {
     openZarrLayerPanel(appApi);
   };
@@ -211,6 +215,9 @@ export function TopToolbar({
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={handleAddPMTilesLayer}>
             Add PMTiles Layer
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={handleAddStacLayer}>
+            Add STAC Layer
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => setAddDataKind("mbtiles")}>
             Add MBTiles Layer

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -463,7 +463,8 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
   const { style } = layer;
   const isDeckRasterLayer =
     layer.metadata.sourceKind === "cog-url" ||
-    layer.metadata.sourceKind === "geotiff-url";
+    layer.metadata.sourceKind === "geotiff-url" ||
+    layer.metadata.sourceKind === "stac-search-cog";
   const isRasterTileLayer = layer.metadata.tileType === "raster";
   const hasVectorPaintControls =
     !isRasterTileLayer &&

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -452,6 +452,147 @@ body,
   accent-color: hsl(var(--primary));
 }
 
+.geolibre-stac-search-control {
+  background-color: hsl(var(--popover)) !important;
+  color: hsl(var(--popover-foreground)) !important;
+  overflow: visible;
+  position: relative;
+  z-index: 3;
+}
+
+.maplibregl-control-container {
+  position: relative;
+  z-index: 2;
+}
+
+#deckgl-overlay {
+  z-index: 1;
+}
+
+.geolibre-stac-search-control .maplibre-gl-stac-search-button {
+  display: none !important;
+}
+
+.geolibre-stac-search-control .maplibre-gl-stac-search-panel {
+  background-color: hsl(var(--popover)) !important;
+  border: 1px solid hsl(var(--border));
+  box-shadow: 0 12px 32px rgb(0 0 0 / 0.28);
+  color: hsl(var(--popover-foreground)) !important;
+  max-width: min(365px, calc(100vw - 32px));
+}
+
+.geolibre-stac-search-control .maplibre-gl-stac-search-header {
+  background-color: hsl(var(--card)) !important;
+  border-bottom-color: hsl(var(--border)) !important;
+  color: hsl(var(--foreground)) !important;
+}
+
+.geolibre-stac-search-control .maplibre-gl-stac-search-title,
+.geolibre-stac-search-control .maplibre-gl-stac-search-form-group > label,
+.geolibre-stac-search-control .maplibre-gl-stac-search-hint,
+.geolibre-stac-search-control .maplibre-gl-stac-search-list-header,
+.geolibre-stac-search-control .maplibre-gl-stac-search-list-label,
+.geolibre-stac-search-control .maplibre-gl-stac-search-rgb-label {
+  color: hsl(var(--foreground)) !important;
+}
+
+.geolibre-stac-search-control .maplibre-gl-stac-search-close,
+.geolibre-stac-search-control .maplibre-gl-stac-search-list-remove {
+  color: hsl(var(--muted-foreground)) !important;
+}
+
+.geolibre-stac-search-control .maplibre-gl-stac-search-close:hover,
+.geolibre-stac-search-control .maplibre-gl-stac-search-list-remove:hover {
+  background-color: hsl(var(--accent)) !important;
+  color: hsl(var(--accent-foreground)) !important;
+}
+
+.geolibre-stac-search-control .maplibre-gl-stac-search-input,
+.geolibre-stac-search-control .maplibre-gl-stac-search-select {
+  background-color: hsl(var(--background)) !important;
+  border: 1px solid hsl(var(--input)) !important;
+  color: hsl(var(--foreground)) !important;
+}
+
+.geolibre-stac-search-control .maplibre-gl-stac-search-input::placeholder {
+  color: hsl(var(--muted-foreground)) !important;
+}
+
+.geolibre-stac-search-control .maplibre-gl-stac-search-input:focus,
+.geolibre-stac-search-control .maplibre-gl-stac-search-select:focus {
+  border-color: hsl(var(--ring)) !important;
+  box-shadow: 0 0 0 1px hsl(var(--ring)) !important;
+  outline: none;
+}
+
+.geolibre-stac-search-control .maplibre-gl-stac-search-select option {
+  background-color: hsl(var(--popover));
+  color: hsl(var(--popover-foreground));
+}
+
+.geolibre-stac-search-control .maplibre-gl-stac-search-btn,
+.geolibre-stac-search-control .maplibre-gl-stac-search-btn-clear,
+.geolibre-stac-search-control .maplibre-gl-stac-search-btn-clear-footprints {
+  background-color: hsl(var(--card)) !important;
+  border: 1px solid hsl(var(--border)) !important;
+  color: hsl(var(--foreground)) !important;
+}
+
+.geolibre-stac-search-control
+  .maplibre-gl-stac-search-btn:hover:not(:disabled),
+.geolibre-stac-search-control .maplibre-gl-stac-search-btn-clear:hover,
+.geolibre-stac-search-control
+  .maplibre-gl-stac-search-btn-clear-footprints:hover {
+  background-color: hsl(var(--accent)) !important;
+  color: hsl(var(--accent-foreground)) !important;
+}
+
+.geolibre-stac-search-control .maplibre-gl-stac-search-btn:disabled {
+  color: hsl(var(--muted-foreground)) !important;
+  opacity: 0.65;
+}
+
+.geolibre-stac-search-control .maplibre-gl-stac-search-btn--primary,
+.geolibre-stac-search-control
+  .maplibre-gl-stac-search-btn--toggle.active {
+  background-color: hsl(var(--primary)) !important;
+  border-color: hsl(var(--primary)) !important;
+  color: hsl(var(--primary-foreground)) !important;
+}
+
+.geolibre-stac-search-control .maplibre-gl-stac-search-list {
+  background-color: hsl(var(--card)) !important;
+  border-color: hsl(var(--border)) !important;
+  color: hsl(var(--foreground)) !important;
+}
+
+.geolibre-stac-search-control .maplibre-gl-stac-search-list-item {
+  background-color: hsl(var(--background)) !important;
+  border-bottom-color: hsl(var(--border)) !important;
+  color: hsl(var(--foreground)) !important;
+}
+
+.geolibre-stac-search-control .maplibre-gl-stac-search-list-item:hover {
+  background-color: hsl(var(--accent)) !important;
+  color: hsl(var(--accent-foreground)) !important;
+}
+
+.geolibre-stac-search-control
+  .maplibre-gl-stac-search-list-item:hover
+  .maplibre-gl-stac-search-list-label {
+  color: hsl(var(--accent-foreground)) !important;
+}
+
+.geolibre-stac-search-control
+  .maplibre-gl-stac-search-list-item:hover
+  .maplibre-gl-stac-search-list-remove {
+  color: hsl(var(--accent-foreground)) !important;
+}
+
+.geolibre-stac-search-control .maplibre-gl-stac-search-status--error {
+  color: hsl(var(--destructive)) !important;
+}
+
 .geolibre-flatgeobuf-control .maplibre-gl-add-vector-panel {
   background-color: hsl(var(--popover)) !important;
   border: 1px solid hsl(var(--border));

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -19,6 +19,8 @@ const APP_VERSION = JSON.parse(
 const WMS_PROXY_PATH = "/__geolibre_wms_proxy";
 const RASTER_PROXY_PATH = "/__geolibre_raster_proxy";
 const RADIX_OPTIMIZE_EXCLUDES = [
+  "@developmentseed/geotiff",
+  "@developmentseed/lzw-tiff-decoder",
   "@radix-ui/react-dialog",
   "@radix-ui/react-dropdown-menu",
   "@radix-ui/react-label",
@@ -112,7 +114,11 @@ async function proxyBinaryRequest(
     return;
   }
 
-  const response = await fetch(target);
+  const headers = new Headers();
+  const range = req.headers.range;
+  if (range) headers.set("range", range);
+
+  const response = await fetch(target, { headers });
   const contentType =
     response.headers.get("content-type") ?? "application/octet-stream";
   const body = Buffer.from(await response.arrayBuffer());
@@ -121,6 +127,10 @@ async function proxyBinaryRequest(
   res.setHeader("access-control-allow-origin", "*");
   res.setHeader("cache-control", "public, max-age=3600");
   res.setHeader("content-type", contentType);
+  for (const header of ["accept-ranges", "content-length", "content-range"]) {
+    const value = response.headers.get(header);
+    if (value) res.setHeader(header, value);
+  }
   res.end(body);
 }
 
@@ -135,8 +145,14 @@ export default defineConfig({
     port: 5173,
     strictPort: true,
   },
+  worker: {
+    format: "es",
+  },
   envPrefix: ["VITE_", "TAURI_"],
   optimizeDeps: {
+    esbuildOptions: {
+      target: "esnext",
+    },
     exclude: RADIX_OPTIMIZE_EXCLUDES,
   },
   build: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@deck.gl/layers": "^9.3.2",
         "@deck.gl/mapbox": "^9.3.2",
         "@deck.gl/mesh-layers": "^9.3.2",
-        "@developmentseed/deck.gl-geotiff": "^0.2.0",
+        "@developmentseed/deck.gl-geotiff": "^0.7.0",
         "@developmentseed/deck.gl-raster": "^0.7.0",
         "@duckdb/duckdb-wasm": "^1.29.0",
         "@dvt3d/maplibre-three-plugin": "^1.6.0",
@@ -966,6 +966,60 @@
         "numcodecs": "^0.3.2"
       }
     },
+    "node_modules/@chunkd/middleware": {
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/@chunkd/middleware/-/middleware-11.3.1.tgz",
+      "integrity": "sha512-BMvxd2Zfb0zhcZUjLera/9ozt1CKcpS71LjekNtJwOxeMN4AJ4DJK8gev9erHX5ZnwBsjbq1VnZSm2TxEFhv1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@chunkd/source": "^11.4.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@chunkd/source": {
+      "version": "11.4.1",
+      "resolved": "https://registry.npmjs.org/@chunkd/source/-/source-11.4.1.tgz",
+      "integrity": "sha512-R4/gIKbx059Am4UOYplEjKkE6g9jhDQF4M7jKNkMZR8Toeudr9vQl0z9ppb9fkTQIuvW8oKjO0Hc5/s4RCCCzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@chunkd/source-http": {
+      "version": "11.4.1",
+      "resolved": "https://registry.npmjs.org/@chunkd/source-http/-/source-http-11.4.1.tgz",
+      "integrity": "sha512-h/7tWxFh6EUh5k/pcYh66WSwiVbIWM6mCCLH0TZpBSWzgekjOXqXkEMRUBXrhekqrmtPQdTPro5e7tnknIdESg==",
+      "license": "MIT",
+      "dependencies": {
+        "@chunkd/source": "^11.4.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@chunkd/source-memory": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@chunkd/source-memory/-/source-memory-11.2.1.tgz",
+      "integrity": "sha512-+WDp5x71OqfFm2AbX4ev9xn+HhP8SAfUAdTsDQtiO8sR65abZAkZ6GK0laOK5p24tA72dhCaUIVrFC8swVgFiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chunkd/source": "^11.4.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@cogeotiff/core": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/@cogeotiff/core/-/core-9.5.0.tgz",
+      "integrity": "sha512-BsBlk8UGq9b8aIlUliKweS2V48KK8O3xORjd+IZLBxErr0kHP1WmWnqBRG+JcmNGoPMaE4lUHl/YVbY9UHLr+A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/@deck.gl/core": {
       "version": "9.3.2",
       "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-9.3.2.tgz",
@@ -1117,75 +1171,28 @@
       "license": "MIT"
     },
     "node_modules/@developmentseed/deck.gl-geotiff": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@developmentseed/deck.gl-geotiff/-/deck.gl-geotiff-0.2.0.tgz",
-      "integrity": "sha512-X44JtDP7SjOhKGC/ynkTsdphURE87v4rKVcf81DzPxE7rnPZmEtidQFBYsyqYV+aVYFvfvQfX4CZgnDnZV54dw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@developmentseed/deck.gl-geotiff/-/deck.gl-geotiff-0.7.0.tgz",
+      "integrity": "sha512-HfeXC14btr1P0SsN9yFhNKCA4j9ZDNfSUa6LaZKFeTQB739C6t1Bxn1OM5wDHrHv6wdcq4CcdYPI0ZiClI9bSA==",
       "license": "MIT",
       "dependencies": {
-        "@developmentseed/deck.gl-raster": "^0.2.0",
-        "@developmentseed/raster-reproject": "^0.2.0",
-        "flatbush": "^4.5.0",
-        "geotiff": "2.1.3",
-        "proj4": "^2.20.2"
+        "@cogeotiff/core": "^9.5.0",
+        "@developmentseed/affine": "^0.7.0",
+        "@developmentseed/deck.gl-raster": "^0.7.0",
+        "@developmentseed/geotiff": "^0.7.0",
+        "@developmentseed/morecantile": "^0.7.0",
+        "@developmentseed/proj": "^0.7.0",
+        "@developmentseed/raster-reproject": "^0.7.0",
+        "flatbush": "^4.5.1",
+        "proj4": "^2.20.8"
       },
       "peerDependencies": {
-        "@deck.gl/core": "^9.2.6",
-        "@deck.gl/geo-layers": "^9.2.6",
-        "@deck.gl/layers": "^9.2.6",
-        "@deck.gl/mesh-layers": "^9.2.6",
-        "@luma.gl/core": "^9.2.6"
+        "@deck.gl/core": "^9.3.0",
+        "@deck.gl/geo-layers": "^9.3.0",
+        "@deck.gl/layers": "^9.3.0",
+        "@deck.gl/mesh-layers": "^9.3.0",
+        "@luma.gl/core": "^9.3.2"
       }
-    },
-    "node_modules/@developmentseed/deck.gl-geotiff/node_modules/@developmentseed/deck.gl-raster": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@developmentseed/deck.gl-raster/-/deck.gl-raster-0.2.0.tgz",
-      "integrity": "sha512-+D2me1CR5BDyYPjXL6cZsG5r8BAa+KgDftErRZikY1hBqiFOdWi4iwm2oJNxdVc+YpaPOLc54o9CXTvSD48VaA==",
-      "license": "MIT",
-      "dependencies": {
-        "@developmentseed/raster-reproject": "^0.2.0",
-        "@math.gl/core": "^4.1.0",
-        "@math.gl/culling": "^4.1.0",
-        "@math.gl/web-mercator": "^4.1.0"
-      },
-      "peerDependencies": {
-        "@deck.gl/core": "^9.2.6",
-        "@deck.gl/geo-layers": "^9.2.6",
-        "@deck.gl/layers": "^9.2.6",
-        "@deck.gl/mesh-layers": "^9.2.6",
-        "@luma.gl/core": "^9.2.6",
-        "@luma.gl/shadertools": "^9.2.6"
-      }
-    },
-    "node_modules/@developmentseed/deck.gl-geotiff/node_modules/@developmentseed/raster-reproject": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@developmentseed/raster-reproject/-/raster-reproject-0.2.0.tgz",
-      "integrity": "sha512-jr8UeDLFqTsqxMcJwe+iOabBi5LpPL9ZKCXVwXdLDk2gvTs8T8WY0PtR8gMfeUFFECzFSuKFlslh1nbuK5eAzA==",
-      "license": "MIT"
-    },
-    "node_modules/@developmentseed/deck.gl-geotiff/node_modules/geotiff": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.3.tgz",
-      "integrity": "sha512-PT6uoF5a1+kbC3tHmZSUsLHBp2QJlHasxxxxPW47QIY1VBKpFB+FcDvX+MxER6UzgLQZ0xDzJ9s48B9JbOCTqA==",
-      "license": "MIT",
-      "dependencies": {
-        "@petamoriken/float16": "^3.4.7",
-        "lerc": "^3.0.0",
-        "pako": "^2.0.4",
-        "parse-headers": "^2.0.2",
-        "quick-lru": "^6.1.1",
-        "web-worker": "^1.2.0",
-        "xml-utils": "^1.0.2",
-        "zstddec": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10.19"
-      }
-    },
-    "node_modules/@developmentseed/deck.gl-geotiff/node_modules/zstddec": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
-      "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg==",
-      "license": "MIT AND BSD-3-Clause"
     },
     "node_modules/@developmentseed/deck.gl-raster": {
       "version": "0.7.0",
@@ -1209,6 +1216,51 @@
         "@luma.gl/core": "^9.3.2",
         "@luma.gl/shadertools": "^9.3.2"
       }
+    },
+    "node_modules/@developmentseed/geotiff": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@developmentseed/geotiff/-/geotiff-0.7.0.tgz",
+      "integrity": "sha512-KnTJ7ZRzg7laiNRlfuslNN4EmM8lvOp4h7Y/RTyojCmiDycJxT0tbo7gMDjFPSvys5tWxoR/9WGPLKyipkzRiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@chunkd/middleware": "^11.3.0",
+        "@chunkd/source": "^11.4.0",
+        "@chunkd/source-http": "^11.4.0",
+        "@chunkd/source-memory": "^11.2.0",
+        "@cogeotiff/core": "^9.5.0",
+        "@developmentseed/affine": "^0.7.0",
+        "@developmentseed/lzw-tiff-decoder": "^0.2.2",
+        "@developmentseed/morecantile": "^0.7.0",
+        "@developmentseed/proj": "^0.7.0",
+        "fzstd": "^0.1.1",
+        "lerc": "^4.1.1",
+        "uuid": "^14.0.0"
+      }
+    },
+    "node_modules/@developmentseed/geotiff/node_modules/lerc": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-4.1.1.tgz",
+      "integrity": "sha512-rgMqdHK4+gIUnF80OkWyfRae2u1B96BT8ZAjbLB4xfxIdfCHQ9GOf17haZVCag+5X9WC+40hLNZPbwctFs2FPQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@developmentseed/geotiff/node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/@developmentseed/lzw-tiff-decoder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@developmentseed/lzw-tiff-decoder/-/lzw-tiff-decoder-0.2.2.tgz",
+      "integrity": "sha512-bsBIdV1LyqcrtnYtIYu3C/297X2wxeYkmmhHzR02OOX823sGxT8GLGdenTmwoXvNWkozk3b+ptXtJeSUmNPaTA==",
+      "license": "MIT"
     },
     "node_modules/@developmentseed/morecantile": {
       "version": "0.7.0",
@@ -8236,6 +8288,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fzstd": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/fzstd/-/fzstd-0.1.1.tgz",
+      "integrity": "sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA==",
+      "license": "MIT"
+    },
     "node_modules/gaxios": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
@@ -12012,7 +12070,7 @@
         "@deck.gl/layers": "^9.3.2",
         "@deck.gl/mapbox": "^9.3.2",
         "@deck.gl/mesh-layers": "^9.3.2",
-        "@developmentseed/deck.gl-geotiff": "^0.2.0",
+        "@developmentseed/deck.gl-geotiff": "^0.7.0",
         "@developmentseed/deck.gl-raster": "^0.7.0",
         "@developmentseed/morecantile": "^0.7.0",
         "@dvt3d/maplibre-three-plugin": "^1.6.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -15,7 +15,7 @@
     "@deck.gl/layers": "^9.3.2",
     "@deck.gl/mapbox": "^9.3.2",
     "@deck.gl/mesh-layers": "^9.3.2",
-    "@developmentseed/deck.gl-geotiff": "^0.2.0",
+    "@developmentseed/deck.gl-geotiff": "^0.7.0",
     "@developmentseed/deck.gl-raster": "^0.7.0",
     "@developmentseed/morecantile": "^0.7.0",
     "@dvt3d/maplibre-three-plugin": "^1.6.0",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -17,6 +17,7 @@ export {
   openLidarLayerPanel,
   openPMTilesLayerPanel,
   openSplattingLayerPanel,
+  openStacSearchLayerPanel,
   openZarrLayerPanel,
   type CogRasterLayerOptions,
 } from "./plugins/maplibre-components";

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -604,6 +604,14 @@ interface StacCogRenderOptions {
   rescaleMin: number;
 }
 
+interface StacCogTextureHelper {
+  inferTextureFormat?: (
+    samplesPerPixel: number,
+    bitsPerSample: unknown,
+    sampleFormat: unknown,
+  ) => string;
+}
+
 const getComponentsConstructors = (): Promise<ComponentsConstructors> => {
   componentsConstructorsPromise ??= import("maplibre-gl-components").then(
     ({
@@ -2483,7 +2491,10 @@ function patchStacSearchCogLayer(control: StacSearchControl): void {
     const layerCounter = mutableControl._layerCounter ?? 0;
     mutableControl._layerCounter = layerCounter + 1;
     const id = `stac-search-${item.id}-${selectedAsset.key}-${layerCounter}`;
-    const layer = new COGLayerClass({
+    const CogLayerConstructor = COGLayerClass as unknown as {
+      new (props: Record<string, unknown>): Layer;
+    };
+    const layer = new CogLayerConstructor({
       geotiff: layerUrl,
       id,
       opacity: 1,
@@ -2491,7 +2502,7 @@ function patchStacSearchCogLayer(control: StacSearchControl): void {
     });
     mutableControl._cogLayers?.set(id, layer as unknown as Layer);
     mutableControl._deckOverlay?.setProps({
-      layers: Array.from(mutableControl._cogLayers?.values() ?? []),
+      layers: Array.from(mutableControl._cogLayers?.values() ?? []) as Layer[],
     });
     if (mutableControl._state) {
       mutableControl._state.hasLayer = true;
@@ -2543,13 +2554,7 @@ function getStacSearchRenderOptions(
   };
 }
 
-async function createStacCogRenderProps(texture: {
-  inferTextureFormat?: (
-    samplesPerPixel: number,
-    bitsPerSample: ArrayLike<number>,
-    sampleFormat: ArrayLike<number>,
-  ) => string;
-}, renderOptions: StacCogRenderOptions): Promise<{
+async function createStacCogRenderProps(texture: unknown, renderOptions: StacCogRenderOptions): Promise<{
   getTileData: (
     image: StacCogImageLike,
     options: StacCogTileOptions,
@@ -2567,7 +2572,8 @@ async function createStacCogRenderProps(texture: {
   const { getColormap } = (await import("maplibre-gl-components")) as {
     getColormap?: (name: string) => StacColorStop[];
   };
-  const inferTextureFormat = texture.inferTextureFormat;
+  const inferTextureFormat = (texture as StacCogTextureHelper)
+    .inferTextureFormat;
 
   return {
     getTileData: async (image, options) => {
@@ -2855,8 +2861,12 @@ async function patchStacSearchCOGLayerClass(
     CogLayerControl: CogLayerControlClass,
     StacLayerControl: StacLayerControlClass,
   } = await import("maplibre-gl-components");
-  const stacPatcher = new StacLayerControlClass({}) as StacLayerControlPatcher;
-  const cogPatcher = new CogLayerControlClass({}) as StacLayerControlPatcher;
+  const stacPatcher = new StacLayerControlClass(
+    {},
+  ) as unknown as StacLayerControlPatcher;
+  const cogPatcher = new CogLayerControlClass(
+    {},
+  ) as unknown as StacLayerControlPatcher;
   stacPatcher._patchCOGLayer?.(COGLayerClass);
   cogPatcher._patchCOGLayerForFloat?.(COGLayerClass);
   cogPatcher._patchCOGLayerForOpacity?.(COGLayerClass);

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -6,14 +6,11 @@ import {
 import type { Layer } from "@deck.gl/core";
 import type { MapboxOverlay } from "@deck.gl/mapbox";
 import {
-  extractGeotiffReprojectors,
-  proj,
-} from "@developmentseed/deck.gl-geotiff";
-import {
   RasterLayer,
   type RasterLayerProps,
 } from "@developmentseed/deck.gl-raster";
 import { fromArrayBuffer } from "geotiff";
+import type maplibregl from "maplibre-gl";
 import proj4 from "proj4";
 import type {
   AddVectorControl,
@@ -35,6 +32,10 @@ import type {
   PMTilesLayerControlOptions,
   PMTilesLayerEventHandler,
   PMTilesLayerInfo,
+  StacSearchControl,
+  StacSearchControlOptions,
+  StacSearchEventHandler,
+  StacSearchItem,
   ZarrLayerControl,
   ZarrLayerControlOptions,
   ZarrLayerEventHandler,
@@ -58,6 +59,8 @@ type CogLayerControlConstructor =
   (typeof import("maplibre-gl-components"))["CogLayerControl"];
 type PMTilesLayerControlConstructor =
   (typeof import("maplibre-gl-components"))["PMTilesLayerControl"];
+type StacSearchControlConstructor =
+  (typeof import("maplibre-gl-components"))["StacSearchControl"];
 type ZarrLayerControlConstructor =
   (typeof import("maplibre-gl-components"))["ZarrLayerControl"];
 type LidarControlConstructor =
@@ -86,6 +89,7 @@ interface ComponentsConstructors {
   LidarControl: LidarControlConstructor;
   LidarLayerAdapter: LidarLayerAdapterConstructor;
   PMTilesLayerControl: PMTilesLayerControlConstructor;
+  StacSearchControl: StacSearchControlConstructor;
   ZarrLayerControl: ZarrLayerControlConstructor;
 }
 
@@ -93,6 +97,7 @@ let componentsControlPosition: GeoLibreMapControlPosition = "top-right";
 const cogRasterControlPosition: GeoLibreMapControlPosition = "top-left";
 const flatGeobufControlPosition: GeoLibreMapControlPosition = "top-left";
 const pmtilesControlPosition: GeoLibreMapControlPosition = "top-left";
+const stacSearchControlPosition: GeoLibreMapControlPosition = "top-left";
 const zarrControlPosition: GeoLibreMapControlPosition = "top-left";
 const lidarControlPosition: GeoLibreMapControlPosition = "top-left";
 const splattingControlPosition: GeoLibreMapControlPosition = "top-left";
@@ -107,6 +112,7 @@ const LIDAR_SAMPLE_URL =
   "https://s3.amazonaws.com/hobu-lidar/autzen-classified.copc.laz";
 const SPLATTING_SAMPLE_URL =
   "https://maplibre.org/maplibre-gl-js/docs/assets/34M_17/34M_17.gltf";
+const RASTER_PROXY_PATH = "/__geolibre_raster_proxy";
 
 const COMPONENT_CONTROL_NAMES = [
   "spinGlobe",
@@ -192,6 +198,142 @@ const PMTILES_OPTIONS = {
   fontColor: "hsl(var(--popover-foreground))",
 } satisfies PMTilesLayerControlOptions;
 
+const STAC_SEARCH_OPTIONS = {
+  backgroundColor: "hsl(var(--popover))",
+  className: "geolibre-stac-search-control",
+  collapsed: false,
+  defaultColormap: "viridis",
+  defaultRescaleMax: 10000,
+  defaultRescaleMin: 0,
+  defaultRgbMode: true,
+  fontColor: "hsl(var(--popover-foreground))",
+  maxHeight: 560,
+  panelWidth: 365,
+  showFootprints: true,
+} satisfies StacSearchControlOptions;
+
+const STAC_COLOR_RAMP_MODULE = {
+  name: "geolibre-stac-color-ramp",
+  inject: {
+    "fs:DECKGL_FILTER_COLOR": `
+      float v = clamp(color.r, 0.0, 1.0);
+      vec3 c0 = vec3(0.267, 0.005, 0.329);
+      vec3 c1 = vec3(0.283, 0.141, 0.458);
+      vec3 c2 = vec3(0.254, 0.265, 0.530);
+      vec3 c3 = vec3(0.207, 0.372, 0.553);
+      vec3 c4 = vec3(0.164, 0.471, 0.558);
+      vec3 c5 = vec3(0.128, 0.567, 0.551);
+      vec3 c6 = vec3(0.135, 0.659, 0.518);
+      vec3 c7 = vec3(0.267, 0.749, 0.441);
+      vec3 c8 = vec3(0.478, 0.821, 0.318);
+      vec3 c9 = vec3(0.741, 0.873, 0.150);
+      vec3 c10 = vec3(0.993, 0.906, 0.144);
+      vec3 rgb = mix(c0, c1, smoothstep(0.0, 0.1, v));
+      rgb = mix(rgb, c2, smoothstep(0.1, 0.2, v));
+      rgb = mix(rgb, c3, smoothstep(0.2, 0.3, v));
+      rgb = mix(rgb, c4, smoothstep(0.3, 0.4, v));
+      rgb = mix(rgb, c5, smoothstep(0.4, 0.5, v));
+      rgb = mix(rgb, c6, smoothstep(0.5, 0.6, v));
+      rgb = mix(rgb, c7, smoothstep(0.6, 0.7, v));
+      rgb = mix(rgb, c8, smoothstep(0.7, 0.8, v));
+      rgb = mix(rgb, c9, smoothstep(0.8, 0.9, v));
+      rgb = mix(rgb, c10, smoothstep(0.9, 1.0, v));
+      color = vec4(rgb, color.a);
+    `,
+  },
+};
+
+const STAC_COLOR_RAMP_COLORS: Record<string, string[]> = {
+  cividis: [
+    "vec3(0.000, 0.126, 0.302)",
+    "vec3(0.188, 0.243, 0.416)",
+    "vec3(0.337, 0.372, 0.431)",
+    "vec3(0.505, 0.504, 0.375)",
+    "vec3(0.735, 0.680, 0.308)",
+    "vec3(0.996, 0.909, 0.218)",
+  ],
+  hot: [
+    "vec3(0.041, 0.000, 0.000)",
+    "vec3(0.365, 0.000, 0.000)",
+    "vec3(0.729, 0.000, 0.000)",
+    "vec3(1.000, 0.318, 0.000)",
+    "vec3(1.000, 0.729, 0.000)",
+    "vec3(1.000, 1.000, 0.700)",
+  ],
+  inferno: [
+    "vec3(0.001, 0.000, 0.014)",
+    "vec3(0.197, 0.038, 0.368)",
+    "vec3(0.472, 0.111, 0.428)",
+    "vec3(0.730, 0.212, 0.333)",
+    "vec3(0.929, 0.472, 0.178)",
+    "vec3(0.988, 0.998, 0.645)",
+  ],
+  magma: [
+    "vec3(0.001, 0.000, 0.014)",
+    "vec3(0.172, 0.067, 0.372)",
+    "vec3(0.445, 0.123, 0.507)",
+    "vec3(0.716, 0.215, 0.475)",
+    "vec3(0.945, 0.464, 0.365)",
+    "vec3(0.987, 0.991, 0.749)",
+  ],
+  plasma: [
+    "vec3(0.050, 0.030, 0.528)",
+    "vec3(0.363, 0.003, 0.649)",
+    "vec3(0.611, 0.090, 0.620)",
+    "vec3(0.798, 0.280, 0.470)",
+    "vec3(0.929, 0.512, 0.298)",
+    "vec3(0.940, 0.975, 0.131)",
+  ],
+  terrain: [
+    "vec3(0.200, 0.200, 0.600)",
+    "vec3(0.000, 0.600, 0.450)",
+    "vec3(0.450, 0.700, 0.300)",
+    "vec3(0.750, 0.650, 0.350)",
+    "vec3(0.600, 0.450, 0.300)",
+    "vec3(1.000, 1.000, 1.000)",
+  ],
+  turbo: [
+    "vec3(0.190, 0.072, 0.232)",
+    "vec3(0.252, 0.357, 0.813)",
+    "vec3(0.276, 0.718, 0.650)",
+    "vec3(0.663, 0.864, 0.196)",
+    "vec3(0.974, 0.573, 0.040)",
+    "vec3(0.480, 0.016, 0.011)",
+  ],
+  viridis: [
+    "vec3(0.267, 0.005, 0.329)",
+    "vec3(0.254, 0.265, 0.530)",
+    "vec3(0.164, 0.471, 0.558)",
+    "vec3(0.135, 0.659, 0.518)",
+    "vec3(0.478, 0.821, 0.318)",
+    "vec3(0.993, 0.906, 0.144)",
+  ],
+};
+
+function getStacColorRampModule(colormap: string): typeof STAC_COLOR_RAMP_MODULE {
+  const colors = STAC_COLOR_RAMP_COLORS[colormap.toLowerCase()];
+  if (!colors) return STAC_COLOR_RAMP_MODULE;
+
+  const step = 1 / (colors.length - 1);
+  const mixes = colors.slice(1).map((color, index) => {
+    const lower = (index * step).toFixed(3);
+    const upper = ((index + 1) * step).toFixed(3);
+    return `rgb = mix(rgb, ${color}, smoothstep(${lower}, ${upper}, v));`;
+  });
+
+  return {
+    name: `geolibre-stac-color-ramp-${colormap.toLowerCase()}`,
+    inject: {
+      "fs:DECKGL_FILTER_COLOR": `
+        float v = clamp(color.r, 0.0, 1.0);
+        vec3 rgb = ${colors[0]};
+        ${mixes.join("\n")}
+        color = vec4(rgb, color.a);
+      `,
+    },
+  };
+}
+
 const ZARR_OPTIONS = {
   backgroundColor: "hsl(var(--popover))",
   className: "geolibre-zarr-control",
@@ -247,6 +389,7 @@ let componentsControl: ControlGrid | null = null;
 let cogRasterControl: CogLayerControl | null = null;
 let flatGeobufControl: AddVectorControl | null = null;
 let pmtilesControl: PMTilesLayerControl | null = null;
+let stacSearchControl: StacSearchControl | null = null;
 let zarrControl: ZarrLayerControl | null = null;
 let lidarControl: LidarControl | null = null;
 let lidarLayerAdapter: LidarLayerAdapter | null = null;
@@ -257,6 +400,7 @@ let flatGeobufControlMounted = false;
 let cogRasterControlMounted = false;
 let geoTiffRasterOverlayMounted = false;
 let pmtilesControlMounted = false;
+let stacSearchControlMounted = false;
 let zarrControlMounted = false;
 let lidarControlMounted = false;
 let splattingControlMounted = false;
@@ -264,6 +408,7 @@ let flatGeobufStoreUnsubscribe: (() => void) | null = null;
 let cogRasterStoreUnsubscribe: (() => void) | null = null;
 let geoTiffRasterStoreUnsubscribe: (() => void) | null = null;
 let pmtilesStoreUnsubscribe: (() => void) | null = null;
+let stacSearchStoreUnsubscribe: (() => void) | null = null;
 let zarrStoreUnsubscribe: (() => void) | null = null;
 let lidarStoreUnsubscribe: (() => void) | null = null;
 let splattingStoreUnsubscribe: (() => void) | null = null;
@@ -305,6 +450,8 @@ const ignoredCogRasterLayerUrls = new Set<string>();
 const geoTiffRasterLayerProps = new Map<string, GeoTiffRasterLayerState>();
 const geoTiffRasterLayers = new Map<string, Layer>();
 let geoTiffRasterLayerSequence = 0;
+let stacCogLayerPatched = false;
+let stacGeoKeysParserPromise: Promise<StacGeoKeysParser> | null = null;
 
 interface GeoTiffRasterLayerState {
   bounds?: [number, number, number, number];
@@ -324,6 +471,70 @@ interface GeoTiffRasterData {
   width: number;
 }
 
+interface GeoTiffImageLike {
+  getHeight: () => number;
+  getOrigin: () => number[];
+  getResolution: () => number[];
+  getWidth: () => number;
+}
+
+interface MutableStacSearchControl {
+  _addCogLayer?: (
+    url: string,
+    item: StacSearchItem,
+    assetKey: string,
+  ) => Promise<void>;
+  _cogLayers?: Map<string, StacSearchRenderableLayer>;
+  _convertS3ToHttps?: (url: string) => string;
+  _deckOverlay?: MapboxOverlay | null;
+  _ensureOverlay?: () => Promise<void>;
+  _emit?: (type: string, detail?: Record<string, unknown>) => void;
+  _layerCounter?: number;
+  _map?: maplibregl.Map;
+  _removeLayer?: (id?: string) => void;
+  _render?: () => void;
+  _state?: {
+    colormap?: string;
+    hasLayer?: boolean;
+    isRgbMode?: boolean;
+    layerCount?: number;
+    rescaleMax?: number;
+    rescaleMin?: number;
+    rgbBands?: {
+      b?: string | null;
+      g?: string | null;
+      r?: string | null;
+    };
+    selectedBand?: string | null;
+    status?: string | null;
+  };
+}
+
+type StacSearchRenderableLayer =
+  | Layer
+  | {
+      layerId?: string;
+      sourceId?: string;
+      type?: string;
+    };
+
+interface StacSearchLayerSnapshot {
+  id: string;
+  layer: StacSearchRenderableLayer;
+}
+
+interface StacLayerControlPatcher {
+  _patchCOGLayer?: (COGLayerClass: unknown) => void;
+  _patchCOGLayerForFloat?: (COGLayerClass: unknown) => void;
+  _patchCOGLayerForOpacity?: (COGLayerClass: unknown) => void;
+}
+
+type StacGeoKeysParser = (geoKeys: Record<string, unknown>) => Promise<{
+  coordinatesUnits: string;
+  def: string;
+  parsed: Record<string, unknown>;
+} | null>;
+
 type RasterBandValues =
   | Float32Array
   | Float64Array
@@ -334,6 +545,64 @@ type RasterBandValues =
   | Uint8ClampedArray
   | Uint16Array
   | Uint32Array;
+
+interface StacCogImageLike {
+  cachedTags?: {
+    bitsPerSample?: ArrayLike<number>;
+    nodata?: number | null;
+    photometric?: number;
+    sampleFormat?: ArrayLike<number>;
+    samplesPerPixel?: number;
+  };
+  fetchTile: (
+    x: number,
+    y: number,
+    options: {
+      boundless: boolean;
+      pool?: unknown;
+      signal?: AbortSignal;
+    },
+  ) => Promise<{
+    array: {
+      data: RasterBandValues;
+      height: number;
+      layout?: string;
+      mask?: Uint8Array | null;
+      nodata?: number | null;
+      width: number;
+    };
+  }>;
+}
+
+interface StacCogTileOptions {
+  device: {
+    createTexture: (props: Record<string, unknown>) => unknown;
+  };
+  pool?: unknown;
+  signal?: AbortSignal;
+  x: number;
+  y: number;
+}
+
+interface StacCogTileData {
+  byteLength: number;
+  height: number;
+  isRgb: boolean;
+  texture: unknown;
+  width: number;
+}
+
+interface StacColorStop {
+  color: string;
+  position: number;
+}
+
+interface StacCogRenderOptions {
+  colormap: string;
+  isRgbMode: boolean;
+  rescaleMax: number;
+  rescaleMin: number;
+}
 
 const getComponentsConstructors = (): Promise<ComponentsConstructors> => {
   componentsConstructorsPromise ??= import("maplibre-gl-components").then(
@@ -346,6 +615,7 @@ const getComponentsConstructors = (): Promise<ComponentsConstructors> => {
       LidarControl: LidarControlClass,
       LidarLayerAdapter: LidarLayerAdapterClass,
       PMTilesLayerControl: PMTilesLayerControlClass,
+      StacSearchControl: StacSearchControlClass,
       ZarrLayerControl: ZarrLayerControlClass,
     }) => ({
       AddVectorControl: AddVectorControlClass,
@@ -356,6 +626,7 @@ const getComponentsConstructors = (): Promise<ComponentsConstructors> => {
       LidarControl: LidarControlClass,
       LidarLayerAdapter: LidarLayerAdapterClass,
       PMTilesLayerControl: PMTilesLayerControlClass,
+      StacSearchControl: StacSearchControlClass,
       ZarrLayerControl: ZarrLayerControlClass,
     }),
   );
@@ -416,6 +687,7 @@ export const maplibreComponentsPlugin: GeoLibrePlugin = {
     teardownGeoTiffRasterOverlay(app);
     teardownFlatGeobufControl(app);
     teardownPMTilesControl(app);
+    teardownStacSearchControl(app);
     teardownZarrControl(app);
     teardownLidarControl(app);
     teardownSplattingControl(app);
@@ -464,6 +736,10 @@ export async function addCogRasterLayer(
 
 export function openPMTilesLayerPanel(app: GeoLibreAppAPI): void {
   void openStandalonePMTilesControl(app);
+}
+
+export function openStacSearchLayerPanel(app: GeoLibreAppAPI): void {
+  void openStandaloneStacSearchControl(app);
 }
 
 export function openZarrLayerPanel(app: GeoLibreAppAPI): void {
@@ -559,6 +835,30 @@ async function openStandalonePMTilesControl(
   setTimeout(() => {
     pmtilesControl?.show();
     pmtilesControl?.expand();
+  }, 0);
+  return true;
+}
+
+async function openStandaloneStacSearchControl(
+  app: GeoLibreAppAPI,
+): Promise<boolean> {
+  const { StacSearchControl: StacSearchControlClass } =
+    await getComponentsConstructors();
+
+  stacSearchControl ??= createStacSearchControl(StacSearchControlClass);
+
+  if (!stacSearchControlMounted) {
+    const added = app.addMapControl(stacSearchControl, stacSearchControlPosition);
+    if (!added) {
+      stacSearchControl = null;
+      return false;
+    }
+    stacSearchControlMounted = true;
+  }
+
+  setTimeout(() => {
+    stacSearchControl?.show();
+    stacSearchControl?.expand();
   }, 0);
   return true;
 }
@@ -899,6 +1199,44 @@ function createPMTilesControl(
   return control;
 }
 
+function createStacSearchControl(
+  StacSearchControlClass: StacSearchControlConstructor,
+): StacSearchControl {
+  const control = new StacSearchControlClass(STAC_SEARCH_OPTIONS);
+  control.on("collapse", () => control.hide());
+  control.on("display", createStacSearchDisplayHandler(control));
+  patchStacSearchCogLayer(control);
+  patchStacSearchRasterUrls(control);
+  patchStacSearchRemoveLayer(control);
+  stacSearchStoreUnsubscribe ??= useAppStore.subscribe((state, previous) => {
+    const currentById = new Map(state.layers.map((layer) => [layer.id, layer]));
+
+    for (const layer of previous.layers) {
+      if (!isStacSearchControlLayer(layer)) continue;
+
+      const currentLayer = currentById.get(layer.id);
+      if (!currentLayer) {
+        removeStacSearchControlLayer(layer.id);
+        continue;
+      }
+
+      if (!isStacSearchControlLayer(currentLayer)) continue;
+
+      if (
+        currentLayer.visible !== layer.visible ||
+        currentLayer.opacity !== layer.opacity
+      ) {
+        setStacSearchControlLayerState(
+          currentLayer.id,
+          currentLayer.visible,
+          currentLayer.opacity,
+        );
+      }
+    }
+  });
+  return control;
+}
+
 function teardownFlatGeobufControl(app: GeoLibreAppAPI): void {
   flatGeobufStoreUnsubscribe?.();
   flatGeobufStoreUnsubscribe = null;
@@ -940,6 +1278,16 @@ function teardownPMTilesControl(app: GeoLibreAppAPI): void {
   }
   pmtilesControl = null;
   pmtilesControlMounted = false;
+}
+
+function teardownStacSearchControl(app: GeoLibreAppAPI): void {
+  stacSearchStoreUnsubscribe?.();
+  stacSearchStoreUnsubscribe = null;
+  if (stacSearchControl && stacSearchControlMounted) {
+    app.removeMapControl(stacSearchControl);
+  }
+  stacSearchControl = null;
+  stacSearchControlMounted = false;
 }
 
 function teardownZarrControl(app: GeoLibreAppAPI): void {
@@ -1153,6 +1501,25 @@ function createPMTilesLayerAddHandler(): PMTilesLayerEventHandler {
   };
 }
 
+function createStacSearchDisplayHandler(
+  control: StacSearchControl,
+): StacSearchEventHandler {
+  return (event) => {
+    const store = useAppStore.getState();
+    for (const snapshot of getStacSearchLayerSnapshots(control)) {
+      if (store.layers.some((item) => item.id === snapshot.id)) continue;
+
+      const layer = createStacSearchStoreLayer(
+        snapshot,
+        event.item ?? event.state.selectedItem,
+        event.state.selectedCollection?.id,
+        event.state.selectedCatalog?.url,
+      );
+      store.addLayer(layer);
+    }
+  };
+}
+
 function addLayerWithCogRasterControl(
   control: CogLayerControl,
   options: CogRasterLayerOptions,
@@ -1343,7 +1710,7 @@ async function loadGeoTiffRasterData(
 }> {
   const tiff = await fromArrayBuffer(input);
   const image = await tiff.getImage();
-  const projection = await proj.epsgIoGeoKeyParser(image.getGeoKeys() ?? {});
+  const projection = await parseGeoTiffProjection(image.getGeoKeys() ?? {});
   if (!projection) {
     throw new Error("Could not determine the GeoTIFF projection.");
   }
@@ -1356,10 +1723,7 @@ async function loadGeoTiffRasterData(
     imageBounds as [number, number, number, number],
     projection.def,
   );
-  const reprojectionFns = await extractGeotiffReprojectors(
-    tiff as never,
-    projection.def,
-  );
+  const reprojectionFns = createGeoTiffReprojectionFns(image, projection.def);
   const sampleCount = image.getSamplesPerPixel();
   const sample = Math.min(getFirstRasterBand(options.bands), sampleCount - 1);
   const bandValues = (await image.readRasters({
@@ -1378,6 +1742,37 @@ async function loadGeoTiffRasterData(
       reprojectionFns,
       width,
     },
+  };
+}
+
+async function parseGeoTiffProjection(
+  geoKeys: Record<string, unknown>,
+): Promise<Awaited<ReturnType<StacGeoKeysParser>>> {
+  const parser = await getStacGeoKeysParser();
+  return parser(geoKeys);
+}
+
+function createGeoTiffReprojectionFns(
+  image: GeoTiffImageLike,
+  sourceProjection: Parameters<typeof proj4>[0],
+): RasterLayerProps["reprojectionFns"] {
+  const [originX, originY] = image.getOrigin();
+  const [resolutionX, resolutionY] = image.getResolution();
+  const width = image.getWidth();
+  const height = image.getHeight();
+  const converter = proj4(sourceProjection, "EPSG:4326");
+
+  return {
+    forwardTransform: (x, y) => [
+      originX + x * width * resolutionX,
+      originY + y * height * resolutionY,
+    ],
+    inverseTransform: (x, y) => [
+      (x - originX) / (width * resolutionX),
+      (y - originY) / (height * resolutionY),
+    ],
+    forwardReproject: (x, y) => converter.forward([x, y]),
+    inverseReproject: (x, y) => converter.inverse([x, y]),
   };
 }
 
@@ -1821,6 +2216,66 @@ function createZarrStoreLayer(
   };
 }
 
+function createStacSearchStoreLayer(
+  snapshot: StacSearchLayerSnapshot,
+  item?: StacSearchItem | null,
+  collectionId?: string,
+  catalogUrl?: string,
+): GeoLibreLayer {
+  const rasterLayerInfo = getStacSearchRasterLayerInfo(snapshot.layer);
+  const deckLayerProps = "props" in snapshot.layer ? snapshot.layer.props : {};
+  const sourceKind = rasterLayerInfo
+    ? "stac-search-raster"
+    : "stac-search-cog";
+  const url = rasterLayerInfo?.tileUrl ?? getDeckLayerSourceUrl(snapshot.layer);
+  const nativeLayerIds = rasterLayerInfo
+    ? [rasterLayerInfo.layerId]
+    : [snapshot.id];
+  const sourceId = rasterLayerInfo?.sourceId ?? snapshot.id;
+
+  return {
+    id: snapshot.id,
+    name: stacSearchLayerName(snapshot.id, item, collectionId),
+    type: rasterLayerInfo ? "raster" : "cog",
+    source: {
+      bounds: item?.bbox,
+      catalogUrl,
+      collectionId,
+      itemId: item?.id,
+      sourceId,
+      type: "raster",
+      url,
+    },
+    visible: true,
+    opacity: getStacSearchLayerOpacity(snapshot.layer),
+    style: {
+      ...DEFAULT_LAYER_STYLE,
+      fillOpacity: 1,
+    },
+    metadata: {
+      collectionId,
+      customLayerType: "raster",
+      externalNativeLayer: true,
+      identifiable: false,
+      nativeLayerIds,
+      sourceId,
+      sourceIds: [sourceId],
+      sourceKind,
+      stacAsset: stacAssetFromLayerId(snapshot.id),
+      stacCatalogUrl: catalogUrl,
+      stacItemId: item?.id,
+      tileType: "raster",
+      ...(item?.bbox ? { bounds: item.bbox } : {}),
+      ...(deckLayerProps &&
+      typeof deckLayerProps === "object" &&
+      "_colormap" in deckLayerProps
+        ? { colormap: deckLayerProps._colormap }
+        : {}),
+    },
+    sourcePath: url,
+  };
+}
+
 function createLidarStoreLayer(pointCloud: PointCloudInfo): GeoLibreLayer {
   return {
     id: pointCloud.id,
@@ -1926,6 +2381,15 @@ function isZarrControlLayer(layer: GeoLibreLayer): boolean {
   );
 }
 
+function isStacSearchControlLayer(layer: GeoLibreLayer): boolean {
+  return (
+    (layer.type === "cog" || layer.type === "raster") &&
+    (layer.metadata.sourceKind === "stac-search-cog" ||
+      layer.metadata.sourceKind === "stac-search-raster") &&
+    layer.metadata.externalNativeLayer === true
+  );
+}
+
 function isLidarControlLayer(layer: GeoLibreLayer): boolean {
   return (
     layer.type === "lidar" &&
@@ -1940,6 +2404,639 @@ function isSplattingControlLayer(layer: GeoLibreLayer): boolean {
     layer.metadata.sourceKind === "splatting-url" &&
     layer.metadata.externalNativeLayer === true
   );
+}
+
+function getStacSearchLayerSnapshots(
+  control: StacSearchControl,
+): StacSearchLayerSnapshot[] {
+  const mutableControl = control as unknown as MutableStacSearchControl;
+  return Array.from(mutableControl._cogLayers?.entries() ?? []).map(
+    ([id, layer]) => ({
+      id,
+      layer,
+    }),
+  );
+}
+
+function patchStacSearchRemoveLayer(control: StacSearchControl): void {
+  const mutableControl = control as unknown as MutableStacSearchControl;
+  const removeLayer = mutableControl._removeLayer?.bind(control);
+  if (!removeLayer) return;
+
+  mutableControl._removeLayer = (id?: string) => {
+    const layerIds = id
+      ? [id]
+      : Array.from(mutableControl._cogLayers?.keys() ?? []);
+    removeLayer(id);
+    const store = useAppStore.getState();
+    for (const layerId of layerIds) {
+      const layer = store.layers.find((item) => item.id === layerId);
+      if (layer && isStacSearchControlLayer(layer)) {
+        store.removeLayer(layerId);
+      }
+    }
+  };
+}
+
+function patchStacSearchRasterUrls(control: StacSearchControl): void {
+  const mutableControl = control as unknown as MutableStacSearchControl;
+  const convertS3ToHttps = mutableControl._convertS3ToHttps?.bind(control);
+  if (!convertS3ToHttps) return;
+
+  mutableControl._convertS3ToHttps = (url: string) =>
+    proxyDevRasterUrl(normalizeStacRasterUrl(convertS3ToHttps(url)));
+}
+
+function patchStacSearchCogLayer(control: StacSearchControl): void {
+  const mutableControl = control as unknown as MutableStacSearchControl;
+  if (
+    !mutableControl._ensureOverlay ||
+    !mutableControl._convertS3ToHttps ||
+    !mutableControl._cogLayers
+  ) {
+    return;
+  }
+
+  mutableControl._addCogLayer = async (
+    url: string,
+    item: StacSearchItem,
+    assetKey: string,
+  ) => {
+    ensureStacSearchMercatorProjection(mutableControl);
+    await mutableControl._ensureOverlay?.();
+    const selectedAsset = getStacSearchSelectedAsset(mutableControl, item, {
+      key: assetKey,
+      url,
+    });
+    const layerUrl = normalizeStacRasterUrl(
+      mutableControl._convertS3ToHttps?.(selectedAsset.url) ??
+        selectedAsset.url,
+    );
+    const { COGLayer: COGLayerClass, texture } = await import(
+      "@developmentseed/deck.gl-geotiff"
+    );
+    const renderProps = await createStacCogRenderProps(
+      texture,
+      getStacSearchRenderOptions(mutableControl),
+    );
+    await patchStacSearchCOGLayerClass(COGLayerClass);
+    const layerCounter = mutableControl._layerCounter ?? 0;
+    mutableControl._layerCounter = layerCounter + 1;
+    const id = `stac-search-${item.id}-${selectedAsset.key}-${layerCounter}`;
+    const layer = new COGLayerClass({
+      geotiff: layerUrl,
+      id,
+      opacity: 1,
+      ...renderProps,
+    });
+    mutableControl._cogLayers?.set(id, layer as unknown as Layer);
+    mutableControl._deckOverlay?.setProps({
+      layers: Array.from(mutableControl._cogLayers?.values() ?? []),
+    });
+    if (mutableControl._state) {
+      mutableControl._state.hasLayer = true;
+      mutableControl._state.layerCount = mutableControl._cogLayers?.size ?? 0;
+      mutableControl._state.status = `Displayed: ${id}`;
+    }
+    mutableControl._render?.();
+    mutableControl._emit?.("display", {
+      assetKey: selectedAsset.key,
+      item,
+      layerId: id,
+      url: selectedAsset.url,
+    });
+  };
+}
+
+function getStacSearchSelectedAsset(
+  control: MutableStacSearchControl,
+  item: StacSearchItem,
+  fallback: { key: string; url: string },
+): { key: string; url: string } {
+  const state = control._state;
+  if (state?.isRgbMode !== false) return fallback;
+  const selectedBand = state.selectedBand;
+  if (!selectedBand) return fallback;
+  const asset = getStacAsset(item, selectedBand);
+  return asset?.href ? { key: selectedBand, url: asset.href } : fallback;
+}
+
+function getStacAsset(
+  item: StacSearchItem,
+  key: string,
+): { href?: string } | null {
+  const assets = (item as { assets?: Record<string, unknown> }).assets;
+  const asset = assets?.[key];
+  if (!asset || typeof asset !== "object") return null;
+  return asset as { href?: string };
+}
+
+function getStacSearchRenderOptions(
+  control: MutableStacSearchControl,
+): StacCogRenderOptions {
+  const state = control._state;
+  return {
+    colormap: state?.colormap ?? STAC_SEARCH_OPTIONS.defaultColormap,
+    isRgbMode: state?.isRgbMode ?? STAC_SEARCH_OPTIONS.defaultRgbMode,
+    rescaleMax: state?.rescaleMax ?? STAC_SEARCH_OPTIONS.defaultRescaleMax,
+    rescaleMin: state?.rescaleMin ?? STAC_SEARCH_OPTIONS.defaultRescaleMin,
+  };
+}
+
+async function createStacCogRenderProps(texture: {
+  inferTextureFormat?: (
+    samplesPerPixel: number,
+    bitsPerSample: ArrayLike<number>,
+    sampleFormat: ArrayLike<number>,
+  ) => string;
+}, renderOptions: StacCogRenderOptions): Promise<{
+  getTileData: (
+    image: StacCogImageLike,
+    options: StacCogTileOptions,
+  ) => Promise<StacCogTileData>;
+  renderTile: (tileData: StacCogTileData) => {
+    renderPipeline: Array<{ module: unknown; props?: Record<string, unknown> }>;
+  };
+}> {
+  const {
+    BlackIsZero,
+    CreateTexture,
+    FilterNoDataVal,
+    LinearRescale,
+  } = await import("@developmentseed/deck.gl-raster/gpu-modules");
+  const { getColormap } = (await import("maplibre-gl-components")) as {
+    getColormap?: (name: string) => StacColorStop[];
+  };
+  const inferTextureFormat = texture.inferTextureFormat;
+
+  return {
+    getTileData: async (image, options) => {
+      const { x, y, device, pool, signal } = options;
+      const tile = await image.fetchTile(x, y, {
+        boundless: false,
+        pool,
+        signal,
+      });
+      const { data, height, layout, mask, nodata, width } = tile.array;
+      if (layout === "band-separate") {
+        throw new Error("Band-separate GeoTIFF tiles are not supported.");
+      }
+      const tags = image.cachedTags;
+      let samplesPerPixel = tags?.samplesPerPixel ?? 1;
+      const bitsPerSample = tags?.bitsPerSample ?? [8];
+      const sampleFormat = tags?.sampleFormat ?? [1];
+      let textureData: RasterBandValues;
+      let textureBitsPerSample = bitsPerSample;
+      let textureSampleFormat = sampleFormat;
+      let textureFormat: string | undefined;
+
+      if (samplesPerPixel === 1) {
+        textureData = createStacSingleBandRgba(data, width, height, {
+          colormap: renderOptions.colormap,
+          getColormap,
+          mask,
+          nodata: nodata ?? tags?.nodata ?? null,
+          rescaleMax: renderOptions.rescaleMax,
+          rescaleMin: renderOptions.rescaleMin,
+        });
+        samplesPerPixel = 4;
+        textureBitsPerSample = [8, 8, 8, 8];
+        textureSampleFormat = [1, 1, 1, 1];
+        textureFormat = "rgba8unorm";
+      } else if (samplesPerPixel === 3) {
+        textureData = addOpaqueAlphaChannel(data, width, height, bitsPerSample);
+        samplesPerPixel = 4;
+      } else {
+        textureData = data;
+      }
+
+      const format =
+        textureFormat ??
+        inferTextureFormat?.(
+          samplesPerPixel,
+          textureBitsPerSample,
+          textureSampleFormat,
+        ) ??
+        "r8unorm";
+      const textureObject = device.createTexture({
+        data: textureData,
+        format,
+        height,
+        sampler: {
+          magFilter: "linear",
+          minFilter: "linear",
+        },
+        width,
+      });
+
+      return {
+        byteLength: textureData.byteLength,
+        height,
+        isRgb: samplesPerPixel >= 3,
+        texture: textureObject,
+        width,
+      };
+    },
+    renderTile: (tileData) => {
+      const renderPipeline: Array<{
+        module: unknown;
+        props?: Record<string, unknown>;
+      }> = [
+        {
+          module: CreateTexture,
+          props: { textureName: tileData.texture },
+        },
+      ];
+      if (tileData.isRgb) {
+        return { renderPipeline };
+      }
+      const nodata = getStacCogShaderNoData();
+      if (nodata !== null) {
+        renderPipeline.push({
+          module: FilterNoDataVal,
+          props: { value: nodata },
+        });
+      }
+      renderPipeline.push({
+        module: LinearRescale,
+        props: {
+          rescaleMax: renderOptions.rescaleMax,
+          rescaleMin: renderOptions.rescaleMin,
+        },
+      });
+      renderPipeline.push(
+        renderOptions.colormap === "none"
+          ? { module: BlackIsZero }
+          : { module: getStacColorRampModule(renderOptions.colormap) },
+      );
+      return { renderPipeline };
+    },
+  };
+}
+
+function createStacSingleBandRgba(
+  data: RasterBandValues,
+  width: number,
+  height: number,
+  options: {
+    colormap: string;
+    getColormap?: (name: string) => StacColorStop[];
+    mask?: Uint8Array | null;
+    nodata?: number | null;
+    rescaleMax: number;
+    rescaleMin: number;
+  },
+): Uint8Array {
+  const pixelCount = width * height;
+  const output = new Uint8Array(pixelCount * 4);
+  const range = options.rescaleMax - options.rescaleMin || 1;
+  const stops = getStacColormapStops(options.colormap, options.getColormap);
+
+  for (let index = 0; index < pixelCount; index += 1) {
+    const rawValue = Number(data[index]);
+    const target = index * 4;
+    if (
+      options.mask?.[index] === 0 ||
+      !Number.isFinite(rawValue) ||
+      (options.nodata !== null &&
+        options.nodata !== undefined &&
+        rawValue === options.nodata)
+    ) {
+      output[target] = 0;
+      output[target + 1] = 0;
+      output[target + 2] = 0;
+      output[target + 3] = 0;
+      continue;
+    }
+
+    const normalized = Math.max(
+      0,
+      Math.min(1, (rawValue - options.rescaleMin) / range),
+    );
+    const color = stops
+      ? interpolateStacColormap(stops, normalized)
+      : [normalized * 255, normalized * 255, normalized * 255];
+
+    output[target] = Math.round(color[0]);
+    output[target + 1] = Math.round(color[1]);
+    output[target + 2] = Math.round(color[2]);
+    output[target + 3] = 255;
+  }
+
+  return output;
+}
+
+function getStacColormapStops(
+  colormap: string,
+  getColormap?: (name: string) => StacColorStop[],
+): StacColorStop[] | null {
+  if (colormap === "none") return null;
+  try {
+    const stops = getColormap?.(colormap);
+    if (stops?.length) return stops;
+  } catch {
+    // Fall back to the local shader ramp approximations below.
+  }
+
+  const colors = STAC_COLOR_RAMP_COLORS[colormap.toLowerCase()];
+  if (!colors) return null;
+  return colors.map((color, index) => ({
+    color,
+    position: colors.length === 1 ? 0 : index / (colors.length - 1),
+  }));
+}
+
+function interpolateStacColormap(
+  stops: StacColorStop[],
+  value: number,
+): [number, number, number] {
+  const sortedStops = stops
+    .slice()
+    .sort((left, right) => left.position - right.position);
+  const first = sortedStops[0];
+  const last = sortedStops[sortedStops.length - 1];
+  if (!first || !last) return [0, 0, 0];
+  if (value <= first.position) return parseStacColor(first.color);
+  if (value >= last.position) return parseStacColor(last.color);
+
+  for (let index = 1; index < sortedStops.length; index += 1) {
+    const upper = sortedStops[index];
+    const lower = sortedStops[index - 1];
+    if (!upper || !lower || value > upper.position) continue;
+    const span = upper.position - lower.position || 1;
+    const amount = (value - lower.position) / span;
+    const lowerColor = parseStacColor(lower.color);
+    const upperColor = parseStacColor(upper.color);
+    return [
+      lowerColor[0] + (upperColor[0] - lowerColor[0]) * amount,
+      lowerColor[1] + (upperColor[1] - lowerColor[1]) * amount,
+      lowerColor[2] + (upperColor[2] - lowerColor[2]) * amount,
+    ];
+  }
+
+  return parseStacColor(last.color);
+}
+
+function parseStacColor(color: string): [number, number, number] {
+  const hex = color.trim().match(/^#?([0-9a-f]{6})$/i)?.[1];
+  if (hex) {
+    return [
+      Number.parseInt(hex.slice(0, 2), 16),
+      Number.parseInt(hex.slice(2, 4), 16),
+      Number.parseInt(hex.slice(4, 6), 16),
+    ];
+  }
+
+  const rgb = color.match(
+    /(?:rgb|vec3)\(([\d.]+),\s*([\d.]+),\s*([\d.]+)\)/i,
+  );
+  if (!rgb) return [0, 0, 0];
+  const values = rgb.slice(1, 4).map(Number);
+  const scale = values.some((value) => value > 1) ? 1 : 255;
+  return [
+    Math.round((values[0] ?? 0) * scale),
+    Math.round((values[1] ?? 0) * scale),
+    Math.round((values[2] ?? 0) * scale),
+  ];
+}
+
+function addOpaqueAlphaChannel(
+  data: RasterBandValues,
+  width: number,
+  height: number,
+  bitsPerSample: ArrayLike<number>,
+): RasterBandValues {
+  const pixelCount = width * height;
+  const Constructor = data.constructor as {
+    new (length: number): RasterBandValues;
+  };
+  const output = new Constructor(pixelCount * 4);
+  const alpha = getAlphaValue(data, bitsPerSample);
+  for (let index = 0; index < pixelCount; index += 1) {
+    const source = index * 3;
+    const target = index * 4;
+    output[target] = data[source];
+    output[target + 1] = data[source + 1];
+    output[target + 2] = data[source + 2];
+    output[target + 3] = alpha;
+  }
+  return output;
+}
+
+function getAlphaValue(
+  data: RasterBandValues,
+  bitsPerSample: ArrayLike<number>,
+): number {
+  if (data instanceof Float32Array || data instanceof Float64Array) return 1;
+  const bits = bitsPerSample[0] ?? 8;
+  return bits >= 16 ? 65535 : 255;
+}
+
+function getStacCogShaderNoData(): number | null {
+  return null;
+}
+
+function ensureStacSearchMercatorProjection(
+  control: MutableStacSearchControl,
+): void {
+  try {
+    if (control._map?.getProjection()?.type === "mercator") return;
+    control._map?.setProjection({ type: "mercator" });
+  } catch {
+    // MapLibre may reject projection changes while the style is still settling.
+  }
+}
+
+async function patchStacSearchCOGLayerClass(
+  COGLayerClass: unknown,
+): Promise<void> {
+  if (stacCogLayerPatched) return;
+  const {
+    CogLayerControl: CogLayerControlClass,
+    StacLayerControl: StacLayerControlClass,
+  } = await import("maplibre-gl-components");
+  const stacPatcher = new StacLayerControlClass({}) as StacLayerControlPatcher;
+  const cogPatcher = new CogLayerControlClass({}) as StacLayerControlPatcher;
+  stacPatcher._patchCOGLayer?.(COGLayerClass);
+  cogPatcher._patchCOGLayerForFloat?.(COGLayerClass);
+  cogPatcher._patchCOGLayerForOpacity?.(COGLayerClass);
+  stacCogLayerPatched = true;
+}
+
+function removeStacSearchControlLayer(id: string): void {
+  const mutableControl = stacSearchControl as unknown as
+    | MutableStacSearchControl
+    | null;
+  mutableControl?._removeLayer?.(id);
+}
+
+function setStacSearchControlLayerState(
+  id: string,
+  visible: boolean,
+  opacity: number,
+): void {
+  const mutableControl = stacSearchControl as unknown as
+    | MutableStacSearchControl
+    | null;
+  const layer = mutableControl?._cogLayers?.get(id);
+  if (!layer) return;
+
+  const appliedOpacity = visible ? opacity : 0;
+  const rasterLayerInfo = getStacSearchRasterLayerInfo(layer);
+  if (rasterLayerInfo) {
+    const map = (stacSearchControl as unknown as MutableStacSearchControl | null)
+      ?._map;
+    try {
+      map?.setLayoutProperty(
+        rasterLayerInfo.layerId,
+        "visibility",
+        visible ? "visible" : "none",
+      );
+      map?.setPaintProperty(
+        rasterLayerInfo.layerId,
+        "raster-opacity",
+        appliedOpacity,
+      );
+    } catch {
+      // The layer may have been removed by the upstream control.
+    }
+    return;
+  }
+
+  if (!("clone" in layer) || typeof layer.clone !== "function") return;
+
+  mutableControl?._cogLayers?.set(
+    id,
+    layer.clone({ opacity: appliedOpacity }) as StacSearchRenderableLayer,
+  );
+  mutableControl?._deckOverlay?.setProps({
+    layers: getStacSearchDeckLayers(mutableControl),
+  });
+}
+
+function getStacSearchDeckLayers(
+  control: MutableStacSearchControl,
+): Layer[] {
+  return Array.from(control._cogLayers?.values() ?? []).filter(
+    (layer): layer is Layer => !getStacSearchRasterLayerInfo(layer),
+  );
+}
+
+function getStacSearchRasterLayerInfo(
+  layer: StacSearchRenderableLayer,
+): { layerId: string; sourceId: string; tileUrl?: string } | null {
+  if (!("type" in layer) || layer.type !== "raster") return null;
+  if (typeof layer.layerId !== "string" || typeof layer.sourceId !== "string") {
+    return null;
+  }
+  const map = (stacSearchControl as unknown as MutableStacSearchControl | null)
+    ?._map;
+  const source = map?.getSource(layer.sourceId) as
+    | { tiles?: string[] }
+    | undefined;
+  return {
+    layerId: layer.layerId,
+    sourceId: layer.sourceId,
+    tileUrl: source?.tiles?.[0],
+  };
+}
+
+function getDeckLayerSourceUrl(layer: StacSearchRenderableLayer): string {
+  if (!("props" in layer)) return "";
+  const props = layer.props as Record<string, unknown> | undefined;
+  const geotiff = props?.geotiff;
+  if (typeof geotiff === "string") return geotiff;
+  const sourceUrl = props?.sourceUrl;
+  return typeof sourceUrl === "string" ? sourceUrl : "";
+}
+
+function normalizeStacRasterUrl(url: string): string {
+  return url.replace(
+    "copernicus-dem-30m.s3.us-east-1.amazonaws.com",
+    "copernicus-dem-30m.s3.eu-central-1.amazonaws.com",
+  );
+}
+
+function proxyDevRasterUrl(url: string): string {
+  if (!isLocalDevHost() || !isRemoteHttpUrl(url)) return url;
+  return `${RASTER_PROXY_PATH}?url=${encodeURIComponent(url)}`;
+}
+
+function getStacGeoKeysParser(): Promise<StacGeoKeysParser> {
+  stacGeoKeysParserPromise ??= createStacGeoKeysParser();
+  return stacGeoKeysParserPromise;
+}
+
+async function createStacGeoKeysParser(): Promise<StacGeoKeysParser> {
+  const geokeysToProj4 = await import("geotiff-geokeys-to-proj4");
+  registerStacCommonProjections();
+
+  return async (geoKeys) => {
+    try {
+      const projection = geokeysToProj4.toProj4(geoKeys as never);
+      if (!projection?.proj4) return null;
+      const def = projection.proj4.replace(/\+axis=\w+\s*/g, "");
+      proj4.defs("custom", def);
+      return {
+        coordinatesUnits: projection.coordinatesUnits || "metre",
+        def,
+        parsed: (proj4.defs("custom") as Record<string, unknown>) ?? {},
+      };
+    } catch {
+      return null;
+    }
+  };
+}
+
+function registerStacCommonProjections(): void {
+  proj4.defs(
+    "EPSG:4326",
+    "+proj=longlat +datum=WGS84 +no_defs +type=crs",
+  );
+  proj4.defs(
+    "EPSG:3857",
+    "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 " +
+      "+x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext " +
+      "+no_defs +type=crs",
+  );
+}
+
+function isLocalDevHost(): boolean {
+  if (typeof window === "undefined") return false;
+  return ["localhost", "127.0.0.1", "::1"].includes(window.location.hostname);
+}
+
+function isRemoteHttpUrl(url: string): boolean {
+  try {
+    const parsedUrl = new URL(url);
+    return parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function getStacSearchLayerOpacity(layer: StacSearchRenderableLayer): number {
+  if ("props" in layer && typeof layer.props?.opacity === "number") {
+    return layer.props.opacity;
+  }
+  return 1;
+}
+
+function stacSearchLayerName(
+  id: string,
+  item?: StacSearchItem | null,
+  collectionId?: string,
+): string {
+  return [collectionId, item?.id, stacAssetFromLayerId(id)]
+    .filter(Boolean)
+    .join(" - ") || id;
+}
+
+function stacAssetFromLayerId(id: string): string | undefined {
+  if (id.startsWith("stac-search-pc-")) return undefined;
+  const parts = id.split("-");
+  if (parts.length < 4) return undefined;
+  return parts[parts.length - 2];
 }
 
 function layerNameFromUrl(url: string, fallback: string): string {


### PR DESCRIPTION
## Summary
- Add a "Add STAC Layer" entry to the Add Data menu, backed by a new STAC search control that searches catalogs, draws item footprints, and renders selected COG assets on the map.
- Render single-band COGs with selectable colormaps (viridis, plasma, inferno, magma, cividis, turbo, hot, terrain) and support RGB band compositing, with rescale and opacity wired into the Style panel.
- Upgrade `@developmentseed/deck.gl-geotiff` to 0.7.0 and adapt the GeoTIFF reprojection path to the new API.
- Add HTTP range request forwarding to the dev raster proxy so remote COGs stream correctly, plus ESM worker and esbuild target config for the new decoder dependencies.

## Test plan
- [ ] Open the Add Data menu and choose "Add STAC Layer"; search a catalog and confirm footprints render.
- [ ] Display a single-band COG asset and verify colormap, rescale, and opacity controls work in the Style panel.
- [ ] Display an RGB asset and verify band compositing renders correctly.
- [ ] Toggle visibility and remove layers from both the control and the layer list and confirm they stay in sync.
- [ ] Confirm `npm run build` passes.