### PR TITLE
feat: add DuckDB query layer with deck.gl rendering

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -38,6 +38,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-basemap-control": "^0.2.1",
     "maplibre-gl-components": "^0.17.3",
+    "maplibre-gl-duckdb": "^0.2.0",
     "maplibre-gl-geo-editor": "^0.7.3",
     "maplibre-gl-geoagent": "^0.4.2",
     "maplibre-gl-lidar": "^0.14.1",

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -10,6 +10,7 @@ import {
 } from "@geolibre/map";
 import {
   openFlatGeobufAddVectorLayerPanel,
+  openDuckDBLayerPanel,
   openLidarLayerPanel,
   openPMTilesLayerPanel,
   openSplattingLayerPanel,
@@ -148,6 +149,9 @@ export function TopToolbar({
   const handleAddFlatGeobufLayer = () => {
     openFlatGeobufAddVectorLayerPanel(appApi);
   };
+  const handleAddDuckDBLayer = () => {
+    openDuckDBLayerPanel(appApi);
+  };
   const handleAddPMTilesLayer = () => {
     openPMTilesLayerPanel(appApi);
   };
@@ -233,6 +237,9 @@ export function TopToolbar({
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={handleAddStacLayer}>
             Add STAC Layer
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={handleAddDuckDBLayer}>
+            Add DuckDB Layer
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -47,6 +47,10 @@ function hasExternalNativeLayers(layer: { metadata: Record<string, unknown> }) {
   );
 }
 
+function hasExternalDeckLayer(layer: { metadata: Record<string, unknown> }) {
+  return layer.metadata.externalDeckLayer === true;
+}
+
 function supportsExtrusionControls(layer: {
   type: LayerType;
   source: Record<string, unknown>;
@@ -465,13 +469,15 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
     layer.metadata.sourceKind === "cog-url" ||
     layer.metadata.sourceKind === "geotiff-url" ||
     layer.metadata.sourceKind === "stac-search-cog";
+  const isDeckVectorLayer = hasExternalDeckLayer(layer);
   const isRasterTileLayer = layer.metadata.tileType === "raster";
   const hasVectorPaintControls =
     !isRasterTileLayer &&
     (layer.type === "geojson" ||
       layer.type === "vector-tiles" ||
       layer.type === "mbtiles" ||
-      hasExternalNativeLayers(layer));
+      hasExternalNativeLayers(layer) ||
+      hasExternalDeckLayer(layer));
   const hasExtrusionControls =
     !isRasterTileLayer &&
     supportsExtrusionControls(layer);
@@ -923,7 +929,9 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
       <p className="p-2 text-[10px] text-muted-foreground">
         {extrusionEnabled
           ? "3D extrusion settings apply when saved."
-          : "Changes apply live to MapLibre paint properties."}
+          : isDeckVectorLayer
+            ? "Changes apply live to DuckDB deck.gl layer styling."
+            : "Changes apply live to MapLibre paint properties."}
       </p>
     </aside>
   );

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -198,6 +198,117 @@ body,
   display: none !important;
 }
 
+.geolibre-duckdb-control {
+  background-color: transparent !important;
+  box-shadow: none !important;
+  color: hsl(var(--popover-foreground)) !important;
+  height: 0 !important;
+  margin: 0 !important;
+  pointer-events: none;
+}
+
+.geolibre-duckdb-control .duckdb-control-toggle {
+  pointer-events: none;
+  visibility: hidden;
+}
+
+.duckdb-control-panel:has(+ .geolibre-duckdb-control),
+.duckdb-control-panel {
+  box-sizing: border-box;
+  max-height: min(620px, calc(100% - 20px));
+  max-width: min(365px, calc(100vw - 32px));
+}
+
+.duckdb-control-panel {
+  background-color: hsl(var(--popover)) !important;
+  border: 1px solid hsl(var(--border));
+  color: hsl(var(--popover-foreground)) !important;
+  left: 10px !important;
+  top: 10px !important;
+}
+
+.duckdb-control-content {
+  max-height: min(560px, calc(100vh - 220px));
+}
+
+.duckdb-control-header {
+  background-color: hsl(var(--card)) !important;
+  border-bottom-color: hsl(var(--border)) !important;
+  color: hsl(var(--foreground)) !important;
+}
+
+.duckdb-control-title,
+.duckdb-control-label,
+.duckdb-control-section-title,
+.duckdb-control-summary-row strong,
+.duckdb-control-properties dd {
+  color: hsl(var(--foreground)) !important;
+}
+
+.duckdb-control-summary-row span,
+.duckdb-control-properties dt,
+.duckdb-control-placeholder {
+  color: hsl(var(--muted-foreground)) !important;
+}
+
+.duckdb-control-section,
+.duckdb-control-properties th,
+.duckdb-control-properties td {
+  border-color: hsl(var(--border)) !important;
+}
+
+.duckdb-control-input,
+.duckdb-control-file,
+.duckdb-control-textarea {
+  background-color: hsl(var(--background)) !important;
+  border-color: hsl(var(--input)) !important;
+  color: hsl(var(--foreground)) !important;
+}
+
+.duckdb-control-input:focus,
+.duckdb-control-file:focus,
+.duckdb-control-textarea:focus {
+  border-color: hsl(var(--ring)) !important;
+  box-shadow: 0 0 0 1px hsl(var(--ring));
+}
+
+.duckdb-control-button {
+  background-color: hsl(var(--primary)) !important;
+  color: hsl(var(--primary-foreground)) !important;
+}
+
+.duckdb-control-button:hover {
+  background-color: hsl(var(--primary) / 0.9) !important;
+}
+
+.duckdb-control-secondary-button {
+  background-color: hsl(var(--secondary)) !important;
+  color: hsl(var(--secondary-foreground)) !important;
+}
+
+.duckdb-control-secondary-button:hover {
+  background-color: hsl(var(--accent)) !important;
+  color: hsl(var(--accent-foreground)) !important;
+}
+
+.duckdb-control-status {
+  background-color: hsl(var(--accent)) !important;
+  color: hsl(var(--accent-foreground)) !important;
+}
+
+.duckdb-control-error {
+  background-color: hsl(var(--destructive) / 0.12) !important;
+  color: hsl(var(--destructive)) !important;
+}
+
+.duckdb-control-close {
+  color: hsl(var(--muted-foreground)) !important;
+}
+
+.duckdb-control-close:hover {
+  color: hsl(var(--foreground)) !important;
+}
+
 .geolibre-pmtiles-control .maplibre-gl-pmtiles-layer-panel {
   background-color: hsl(var(--popover)) !important;
   border: 1px solid hsl(var(--border));

--- a/apps/geolibre-desktop/src/main.tsx
+++ b/apps/geolibre-desktop/src/main.tsx
@@ -5,6 +5,7 @@ import App from "./App";
 import "@geoman-io/maplibre-geoman-free/dist/maplibre-geoman.css";
 import "maplibre-gl-basemap-control/style.css";
 import "maplibre-gl-components/style.css";
+import "maplibre-gl-duckdb/style.css";
 import "maplibre-gl-geo-editor/style.css";
 import "maplibre-gl-geoagent/style.css";
 import "maplibre-gl-streetview/style.css";

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-basemap-control": "^0.2.1",
         "maplibre-gl-components": "^0.17.3",
+        "maplibre-gl-duckdb": "^0.2.0",
         "maplibre-gl-geo-editor": "^0.7.3",
         "maplibre-gl-geoagent": "^0.4.2",
         "maplibre-gl-lidar": "^0.14.1",
@@ -1020,6 +1021,24 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/@deck.gl/aggregation-layers": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-9.3.2.tgz",
+      "integrity": "sha512-aOzCmJHPYM95aFEW7s3lyFibTSP+T/fYqCP2RxHyi/IxQwROwJTDrKyn/qPw5GvzZOIgFVxlR1Qc9RY8qYRFBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@luma.gl/shadertools": "^9.3.3",
+        "@math.gl/core": "^4.1.0",
+        "@math.gl/web-mercator": "^4.1.0",
+        "d3-hexbin": "^0.2.1"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "~9.3.0",
+        "@deck.gl/layers": "~9.3.0",
+        "@luma.gl/core": "~9.3.3",
+        "@luma.gl/engine": "~9.3.3"
+      }
+    },
     "node_modules/@deck.gl/core": {
       "version": "9.3.2",
       "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-9.3.2.tgz",
@@ -1872,6 +1891,38 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@geoarrow/deck.gl-geoarrow": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@geoarrow/deck.gl-geoarrow/-/deck.gl-geoarrow-0.4.1.tgz",
+      "integrity": "sha512-WYRuN1UnDkudOivyXwa6vPRCfiZmfax2NvQf99vbGyrN1EiY+UzuB2XHdZvEGUScUg2xo30iei91CvwTetH6AA==",
+      "license": "MIT",
+      "dependencies": {
+        "@geoarrow/geoarrow-js": "^0.3.0",
+        "threads": "^1.7.0"
+      },
+      "peerDependencies": {
+        "@deck.gl/aggregation-layers": "^9.0.0",
+        "@deck.gl/core": "^9.0.0",
+        "@deck.gl/geo-layers": "^9.0.0",
+        "@deck.gl/layers": "^9.0.0",
+        "@math.gl/polygon": "^4.1.0",
+        "apache-arrow": ">=15"
+      }
+    },
+    "node_modules/@geoarrow/geoarrow-js": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@geoarrow/geoarrow-js/-/geoarrow-js-0.3.3.tgz",
+      "integrity": "sha512-mtVzYisEqa0FbxgybFut/1w3tu7Ay2L8LwyGGVFo2l0Q3iDQgop7dgEaFFfdxpoManHML6Nm0r3HQJ3EncS2ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@math.gl/polygon": "^4.0.0",
+        "proj4": "^2.9.2",
+        "threads": "^1.7.0"
+      },
+      "peerDependencies": {
+        "apache-arrow": ">=15"
+      }
     },
     "node_modules/@geolibre/core": {
       "resolved": "packages/core",
@@ -6996,6 +7047,32 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@walkthru-earth/objex-utils": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@walkthru-earth/objex-utils/-/objex-utils-1.5.0.tgz",
+      "integrity": "sha512-ReKbw/OhNbJEtjiz84ggubNeOSBtOspXi7GYmmXFwlokXAeM3BpBjwBnh/XbJupEg3cvXHgqmXX+Nn0jEza1+w==",
+      "license": "CC-BY-4.0",
+      "peerDependencies": {
+        "apache-arrow": ">=14",
+        "hyparquet": ">=1.25",
+        "hyparquet-compressors": ">=1.1",
+        "yaml": ">=2"
+      },
+      "peerDependenciesMeta": {
+        "apache-arrow": {
+          "optional": true
+        },
+        "hyparquet": {
+          "optional": true
+        },
+        "hyparquet-compressors": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@zarrita/storage": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.2.0.tgz",
@@ -7392,6 +7469,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -7782,6 +7868,12 @@
         "d3-array": "1"
       }
     },
+    "node_modules/d3-hexbin": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/d3-hexbin/-/d3-hexbin-0.2.2.tgz",
+      "integrity": "sha512-KS3fUT2ReD4RlGCjvCEm1RgMtp2NFZumdMu4DBzQK8AZv3fXRM6Xm8I4fSU07UXvH4xxg03NwWKWdvxfS/yc4w==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/d3-voronoi": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
@@ -8005,6 +8097,16 @@
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -9065,6 +9167,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-observable": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-2.1.0.tgz",
+      "integrity": "sha512-DailKdLb0WU+xX8K5w7VsJhapwHLZ9jjmazqCJq4X12CTgqq73TKnbRcnSLuXYPOoLQgV5IrD7ePiX/h1vnkBw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -9506,6 +9620,166 @@
           "optional": true
         }
       }
+    },
+    "node_modules/maplibre-gl-duckdb": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-duckdb/-/maplibre-gl-duckdb-0.2.0.tgz",
+      "integrity": "sha512-0UlrpBfD82Hj4WJZcGdyXG123V6YjUTQblmaBma0nGUh/1fslZcE0WtQjHshoTf9vrcZ9sX/WCIp5JUAzK3Ryw==",
+      "license": "MIT",
+      "dependencies": {
+        "@deck.gl/aggregation-layers": ">=9.3.2",
+        "@deck.gl/core": ">=9.3.2",
+        "@deck.gl/geo-layers": ">=9.3.2",
+        "@deck.gl/layers": ">=9.3.2",
+        "@deck.gl/mapbox": ">=9.3.2",
+        "@duckdb/duckdb-wasm": ">=1.33.1-dev45.0",
+        "@geoarrow/deck.gl-geoarrow": ">=0.4.1",
+        "@math.gl/polygon": ">=4.1.0",
+        "@walkthru-earth/objex-utils": ">=1.5.0",
+        "apache-arrow": ">=21.1.0"
+      },
+      "peerDependencies": {
+        "maplibre-gl": ">=3.0.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/maplibre-gl-duckdb/node_modules/@duckdb/duckdb-wasm": {
+      "version": "1.33.1-dev45.0",
+      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.33.1-dev45.0.tgz",
+      "integrity": "sha512-ETlrjhiGQzNdaOhpro/Y9u/RCcK+iyuczLy7uOn0kG5Mqlj8C+gTuhBXjs4JpK9ocdUgr3oT8zYYIbUnFD9AYA==",
+      "license": "MIT",
+      "dependencies": {
+        "apache-arrow": "^17.0.0",
+        "qs": "^6.14.1"
+      }
+    },
+    "node_modules/maplibre-gl-duckdb/node_modules/@duckdb/duckdb-wasm/node_modules/apache-arrow": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-17.0.0.tgz",
+      "integrity": "sha512-X0p7auzdnGuhYMVKYINdQssS4EcKec9TCXyez/qtJt32DrIMGbzqiaMiQ0X6fQlQpw8Fl0Qygcv4dfRAr5Gu9Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/command-line-args": "^5.2.3",
+        "@types/command-line-usage": "^5.0.4",
+        "@types/node": "^20.13.0",
+        "command-line-args": "^5.2.1",
+        "command-line-usage": "^7.0.1",
+        "flatbuffers": "^24.3.25",
+        "json-bignum": "^0.0.3",
+        "tslib": "^2.6.2"
+      },
+      "bin": {
+        "arrow2csv": "bin/arrow2csv.cjs"
+      }
+    },
+    "node_modules/maplibre-gl-duckdb/node_modules/apache-arrow": {
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-21.1.0.tgz",
+      "integrity": "sha512-kQrYLxhC+NTVVZ4CCzGF6L/uPVOzJmD1T3XgbiUnP7oTeVFOFgEUu6IKNwCDkpFoBVqDKQivlX4RUFqqnWFlEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/command-line-args": "^5.2.3",
+        "@types/command-line-usage": "^5.0.4",
+        "@types/node": "^24.0.3",
+        "command-line-args": "^6.0.1",
+        "command-line-usage": "^7.0.1",
+        "flatbuffers": "^25.1.24",
+        "json-bignum": "^0.0.3",
+        "tslib": "^2.6.2"
+      },
+      "bin": {
+        "arrow2csv": "bin/arrow2csv.js"
+      }
+    },
+    "node_modules/maplibre-gl-duckdb/node_modules/apache-arrow/node_modules/@types/node": {
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/maplibre-gl-duckdb/node_modules/apache-arrow/node_modules/command-line-args": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.2.tgz",
+      "integrity": "sha512-AIjYVxrV9X752LmPDLbVYv8aMCuHPSLZJXEo2qo/xJfv+NYhaZ4sMSF01rM+gHPaMgvPM0l5D/F+Qx+i2WfSmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.3",
+        "find-replace": "^5.0.2",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/maplibre-gl-duckdb/node_modules/apache-arrow/node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/maplibre-gl-duckdb/node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/maplibre-gl-duckdb/node_modules/find-replace": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
+      "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/maplibre-gl-duckdb/node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/maplibre-gl-duckdb/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
     },
     "node_modules/maplibre-gl-geo-editor": {
       "version": "0.7.3",
@@ -10085,6 +10359,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/observable-fns": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/observable-fns/-/observable-fns-0.6.1.tgz",
+      "integrity": "sha512-9gRK4+sRWzeN6AOewNBTLXir7Zl/i3GB6Yl26gK4flxz8BXVpD3kt8amREmWNb0mxYOGDotvE5a4N+PtGGKdkg==",
+      "license": "MIT"
     },
     "node_modules/ol": {
       "version": "10.9.0",
@@ -11395,11 +11675,39 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/threads": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/threads/-/threads-1.7.0.tgz",
+      "integrity": "sha512-Mx5NBSHX3sQYR6iI9VYbgHKBLisyB+xROCBGjjWm1O9wb9vfLxdaGtmT/KCjUqMsSNW6nERzCW3T6H43LqjDZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.1.0",
+        "debug": "^4.2.0",
+        "is-observable": "^2.1.0",
+        "observable-fns": "^0.6.1"
+      },
+      "funding": {
+        "url": "https://github.com/andywer/threads.js?sponsor=1"
+      },
+      "optionalDependencies": {
+        "tiny-worker": ">= 2"
+      }
+    },
     "node_modules/three": {
       "version": "0.134.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.134.0.tgz",
       "integrity": "sha512-LbBerg7GaSPjYtTOnu41AMp7tV6efUNR3p4Wk5NzkSsNTBuA5mDGOfwwZL1jhhVMLx9V20HolIUo0+U3AXehbg==",
       "license": "MIT"
+    },
+    "node_modules/tiny-worker": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tiny-worker/-/tiny-worker-2.3.0.tgz",
+      "integrity": "sha512-pJ70wq5EAqTAEl9IkGzA+fN0836rycEuz2Cn6yeZ6FRzlVS5IDOkFHpIoEsksPRQV34GDqXm65+OlnZqUSyK2g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "esm": "^3.2.25"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
@@ -12082,6 +12390,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-basemap-control": "^0.2.1",
         "maplibre-gl-components": "^0.17.3",
+        "maplibre-gl-duckdb": "^0.2.0",
         "maplibre-gl-geo-editor": "^0.7.3",
         "maplibre-gl-geoagent": "^0.4.2",
         "maplibre-gl-lidar": "^0.14.1",

--- a/packages/map/src/placeholders.ts
+++ b/packages/map/src/placeholders.ts
@@ -17,6 +17,8 @@ export function isPlaceholderLayer(layer: GeoLibreLayer): boolean {
     return false;
   }
 
+  if (layer.metadata.externalDeckLayer === true) return false;
+
   return (
     PLACEHOLDER_LAYER_TYPES.has(layer.type) ||
     layer.metadata.placeholder === true

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -27,6 +27,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-basemap-control": "^0.2.1",
     "maplibre-gl-components": "^0.17.3",
+    "maplibre-gl-duckdb": "^0.2.0",
     "maplibre-gl-geo-editor": "^0.7.3",
     "maplibre-gl-geoagent": "^0.4.2",
     "maplibre-gl-lidar": "^0.14.1",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -21,6 +21,7 @@ export {
   openZarrLayerPanel,
   type CogRasterLayerOptions,
 } from "./plugins/maplibre-components";
+export { openDuckDBLayerPanel } from "./plugins/maplibre-duckdb";
 export { maplibreGeoEditorPlugin } from "./plugins/maplibre-geo-editor";
 export { maplibreGeoAgentPlugin } from "./plugins/maplibre-geoagent";
 export { maplibreLidarPlugin } from "./plugins/maplibre-lidar";

--- a/packages/plugins/src/plugins/maplibre-duckdb.ts
+++ b/packages/plugins/src/plugins/maplibre-duckdb.ts
@@ -1,0 +1,415 @@
+import {
+  DEFAULT_LAYER_STYLE,
+  type GeoLibreLayer,
+  type LayerStyle,
+  useAppStore,
+} from "@geolibre/core";
+import type {
+  DuckDBControl,
+  DuckDBControlEventHandler,
+  DuckDBControlOptions,
+  DuckDBLayerState,
+  DuckDBState,
+} from "maplibre-gl-duckdb";
+import type { GeoLibreAppAPI, GeoLibreMapControlPosition } from "../types";
+
+type DuckDBControlConstructor =
+  (typeof import("maplibre-gl-duckdb"))["DuckDBControl"];
+
+type DuckDBRendererLike = {
+  clear?: () => void;
+  createLayers?: (
+    layerId: string,
+    result: { geometryType?: string },
+    index: number,
+  ) => StyledDeckLayerLike[];
+  __geolibreStylePatched?: boolean;
+  __geolibreOriginalCreateLayers?: DuckDBRendererLike["createLayers"];
+};
+
+type MutableDuckDBControl = {
+  beforeId?: string;
+  layer?: {
+    beforeId: string | null;
+  } | null;
+  renderLayer?: () => Promise<void>;
+  renderer?: DuckDBRendererLike | null;
+};
+
+type StyledDeckLayerLike = {
+  id?: string;
+  clone?: (props: Record<string, unknown>) => StyledDeckLayerLike;
+  props?: Record<string, unknown>;
+};
+
+interface DuckDBRenderedStyle {
+  opacity: number;
+  style: LayerStyle;
+}
+
+const duckdbControlPosition: GeoLibreMapControlPosition = "top-left";
+const DUCKDB_SAMPLE_DATABASE_URL =
+  "https://data.source.coop/giswqs/opengeos/nyc_data.db";
+const DUCKDB_SAMPLE_QUERY = `SELECT BORONAME, NAME, ST_Transform(geom, 'EPSG:32618', 'EPSG:4326', true) AS geom
+FROM data.main.nyc_neighborhoods
+LIMIT 1000`;
+
+const DUCKDB_OPTIONS = {
+  className: "geolibre-duckdb-control",
+  collapsed: false,
+  geometryColumn: "geom",
+  initialQuery: DUCKDB_SAMPLE_QUERY,
+  layerName: "DuckDB query",
+  panelWidth: 365,
+  pickable: true,
+  sampleDatabaseUrl: DUCKDB_SAMPLE_DATABASE_URL,
+  sourceCrs: "EPSG:32618",
+  title: "Add DuckDB Layer",
+} satisfies DuckDBControlOptions;
+
+let duckdbControl: DuckDBControl | null = null;
+let duckdbControlMounted = false;
+let duckdbStoreUnsubscribe: (() => void) | null = null;
+let duckdbConstructorsPromise: Promise<{
+  DuckDBControl: DuckDBControlConstructor;
+}> | null = null;
+const duckdbRenderedStyles = new Map<string, DuckDBRenderedStyle>();
+
+export function openDuckDBLayerPanel(app: GeoLibreAppAPI): void {
+  void openStandaloneDuckDBControl(app);
+}
+
+async function openStandaloneDuckDBControl(
+  app: GeoLibreAppAPI,
+): Promise<boolean> {
+  const { DuckDBControl: DuckDBControlClass } = await getDuckDBConstructors();
+
+  duckdbControl ??= createDuckDBControl(DuckDBControlClass);
+
+  if (!duckdbControlMounted) {
+    const added = app.addMapControl(duckdbControl, duckdbControlPosition);
+    if (!added) {
+      duckdbControl = null;
+      return false;
+    }
+    duckdbControlMounted = true;
+  }
+
+  setTimeout(() => {
+    showDuckDBControl(duckdbControl);
+    duckdbControl?.expand();
+  }, 0);
+  return true;
+}
+
+function getDuckDBConstructors(): Promise<{
+  DuckDBControl: DuckDBControlConstructor;
+}> {
+  duckdbConstructorsPromise ??= import("maplibre-gl-duckdb").then(
+    ({ DuckDBControl: DuckDBControlClass }) => ({
+      DuckDBControl: DuckDBControlClass,
+    }),
+  );
+  return duckdbConstructorsPromise;
+}
+
+function createDuckDBControl(
+  DuckDBControlClass: DuckDBControlConstructor,
+): DuckDBControl {
+  const control = new DuckDBControlClass(DUCKDB_OPTIONS);
+  control.on("collapse", () => hideDuckDBControl(control));
+  control.on("query", createDuckDBQueryHandler());
+  control.on("statechange", createDuckDBStateChangeHandler());
+
+  duckdbStoreUnsubscribe ??= useAppStore.subscribe((state, previous) => {
+    const currentById = new Map(state.layers.map((layer) => [layer.id, layer]));
+
+    for (const layer of previous.layers) {
+      if (!isDuckDBControlLayer(layer)) continue;
+
+      const currentLayer = currentById.get(layer.id);
+      if (!currentLayer) {
+        removeDuckDBRenderedLayer(layer.id);
+        continue;
+      }
+
+      if (!isDuckDBControlLayer(currentLayer)) continue;
+
+      if (currentLayer.visible !== layer.visible) {
+        setDuckDBRenderedLayerVisible(currentLayer.visible);
+      }
+
+      if (
+        currentLayer.opacity !== layer.opacity ||
+        currentLayer.style !== layer.style
+      ) {
+        setDuckDBRenderedLayerStyle(currentLayer);
+      }
+
+      if (currentLayer.beforeId !== layer.beforeId) {
+        setDuckDBRenderedLayerBeforeId(currentLayer.beforeId ?? null);
+      }
+    }
+  });
+
+  return control;
+}
+
+function createDuckDBQueryHandler(): DuckDBControlEventHandler {
+  return (event) => {
+    const layerState = event.state.layer;
+    if (!layerState) return;
+
+    const store = useAppStore.getState();
+    const existingLayer = store.layers.find((layer) => layer.id === layerState.id);
+    const layer = createDuckDBStoreLayer(event.state, layerState, existingLayer);
+
+    if (existingLayer) {
+      store.updateLayer(layer.id, {
+        metadata: layer.metadata,
+        name: layer.name,
+        source: layer.source,
+        sourcePath: layer.sourcePath,
+        style: layer.style,
+      });
+      setDuckDBRenderedLayerVisible(layer.visible);
+      setDuckDBRenderedLayerBeforeId(layer.beforeId ?? null);
+      setDuckDBRenderedLayerStyle(layer);
+      return;
+    }
+
+    store.addLayer(layer);
+    setDuckDBRenderedLayerVisible(layer.visible);
+    setDuckDBRenderedLayerBeforeId(layer.beforeId ?? null);
+    setDuckDBRenderedLayerStyle(layer);
+  };
+}
+
+function createDuckDBStateChangeHandler(): DuckDBControlEventHandler {
+  return (event) => {
+    if (event.state.layer) return;
+
+    const store = useAppStore.getState();
+    for (const layer of store.layers) {
+      if (isDuckDBControlLayer(layer)) {
+        store.removeLayer(layer.id);
+      }
+    }
+  };
+}
+
+function createDuckDBStoreLayer(
+  state: DuckDBState,
+  layerState: DuckDBLayerState,
+  existingLayer?: GeoLibreLayer,
+): GeoLibreLayer {
+  return {
+    id: layerState.id,
+    name: layerState.name,
+    type: "duckdb-query",
+    source: {
+      databaseSource: state.databaseSource,
+      displaySource: state.displaySource,
+      query: layerState.query,
+      type: "duckdb",
+    },
+    visible: existingLayer?.visible ?? true,
+    opacity: existingLayer?.opacity ?? 1,
+    style: existingLayer?.style ?? { ...DEFAULT_LAYER_STYLE },
+    beforeId: layerState.beforeId ?? existingLayer?.beforeId,
+    metadata: {
+      columns: layerState.schema,
+      databaseSource: state.databaseSource,
+      deckLayerId: layerState.id,
+      displaySource: state.displaySource,
+      externalDeckLayer: true,
+      externalNativeLayer: true,
+      geometryColumn: layerState.geometryColumn,
+      geometryFormat: layerState.geometryFormat,
+      identifiable: false,
+      loadedRows: layerState.loadedRows,
+      pageSize: state.pageSize,
+      query: layerState.query,
+      sourceKind: "duckdb-query",
+      totalRows: layerState.totalRows,
+    },
+    sourcePath: state.databaseSource ?? state.displaySource,
+  };
+}
+
+function removeDuckDBRenderedLayer(layerId: string): void {
+  const stateLayerId = duckdbControl?.getState().layer?.id;
+  if (stateLayerId !== layerId) return;
+  duckdbRenderedStyles.delete(layerId);
+  duckdbControl?.clear();
+}
+
+function setDuckDBRenderedLayerVisible(visible: boolean): void {
+  const control = duckdbControl as unknown as MutableDuckDBControl | null;
+  if (!control) return;
+
+  if (!visible) {
+    control.renderer?.clear?.();
+    return;
+  }
+
+  void control.renderLayer?.();
+}
+
+function setDuckDBRenderedLayerStyle(layer: GeoLibreLayer): void {
+  duckdbRenderedStyles.set(layer.id, {
+    opacity: layer.opacity,
+    style: layer.style,
+  });
+  void renderStyledDuckDBLayer();
+}
+
+async function renderStyledDuckDBLayer(): Promise<void> {
+  const control = duckdbControl as unknown as MutableDuckDBControl | null;
+  if (!control) return;
+
+  if (!control.renderer) {
+    await control.renderLayer?.();
+  }
+  patchDuckDBRenderer(control.renderer);
+  await control.renderLayer?.();
+}
+
+function patchDuckDBRenderer(renderer: DuckDBRendererLike | null | undefined) {
+  if (!renderer?.createLayers || renderer.__geolibreStylePatched) return;
+
+  renderer.__geolibreOriginalCreateLayers = renderer.createLayers.bind(
+    renderer,
+  );
+  renderer.createLayers = (
+    layerId: string,
+    result: { geometryType?: string },
+    index: number,
+  ) => {
+    const originalLayers = renderer.__geolibreOriginalCreateLayers?.(
+      layerId,
+      result,
+      index,
+    );
+    if (!originalLayers) return [];
+
+    const renderedStyle = duckdbRenderedStyles.get(layerId);
+    if (!renderedStyle) return originalLayers;
+
+    return originalLayers.map((deckLayer) =>
+      cloneStyledDeckLayer(deckLayer, result.geometryType, renderedStyle),
+    );
+  };
+  renderer.__geolibreStylePatched = true;
+}
+
+function cloneStyledDeckLayer(
+  deckLayer: StyledDeckLayerLike,
+  geometryType: string | undefined,
+  renderedStyle: DuckDBRenderedStyle,
+): StyledDeckLayerLike {
+  if (!deckLayer.clone) return deckLayer;
+
+  const { style, opacity } = renderedStyle;
+  const fillColor = colorToRgba(
+    style.fillColor,
+    opacity * style.fillOpacity,
+  );
+  const strokeColor = colorToRgba(style.strokeColor, opacity);
+  const geometry = geometryType?.toLowerCase() ?? "";
+
+  if (geometry.includes("point")) {
+    return deckLayer.clone({
+      getFillColor: fillColor,
+      getRadius: style.circleRadius,
+      radiusMaxPixels: Math.max(style.circleRadius * 2, style.circleRadius),
+      radiusMinPixels: Math.max(1, Math.min(style.circleRadius, 4)),
+      updateTriggers: {
+        ...asRecord(deckLayer.props?.updateTriggers),
+        getFillColor: [style.fillColor, style.fillOpacity, opacity],
+        getRadius: [style.circleRadius],
+      },
+    });
+  }
+
+  if (geometry.includes("line")) {
+    return deckLayer.clone({
+      getColor: strokeColor,
+      getWidth: style.strokeWidth,
+      widthMinPixels: Math.max(1, style.strokeWidth),
+      updateTriggers: {
+        ...asRecord(deckLayer.props?.updateTriggers),
+        getColor: [style.strokeColor, opacity],
+        getWidth: [style.strokeWidth],
+      },
+    });
+  }
+
+  return deckLayer.clone({
+    getFillColor: fillColor,
+    getLineColor: strokeColor,
+    getLineWidth: style.strokeWidth,
+    lineWidthMinPixels: Math.max(1, style.strokeWidth),
+    updateTriggers: {
+      ...asRecord(deckLayer.props?.updateTriggers),
+      getFillColor: [style.fillColor, style.fillOpacity, opacity],
+      getLineColor: [style.strokeColor, opacity],
+      getLineWidth: [style.strokeWidth],
+    },
+  });
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function colorToRgba(color: string, alpha: number): [number, number, number, number] {
+  const normalized = color.trim();
+  const hex =
+    normalized.length === 4 && normalized.startsWith("#")
+      ? `#${normalized[1]}${normalized[1]}${normalized[2]}${normalized[2]}${normalized[3]}${normalized[3]}`
+      : normalized;
+  const match = /^#([0-9a-f]{6})$/i.exec(hex);
+  if (!match) return [59, 130, 246, Math.round(clamp(alpha, 0, 1) * 255)];
+
+  const value = Number.parseInt(match[1], 16);
+  return [
+    (value >> 16) & 255,
+    (value >> 8) & 255,
+    value & 255,
+    Math.round(clamp(alpha, 0, 1) * 255),
+  ];
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function setDuckDBRenderedLayerBeforeId(beforeId: string | null): void {
+  const control = duckdbControl as unknown as MutableDuckDBControl | null;
+  if (!control) return;
+
+  control.beforeId = beforeId ?? "";
+  if (control.layer) control.layer.beforeId = beforeId;
+  void control.renderLayer?.();
+}
+
+function hideDuckDBControl(control: DuckDBControl | null): void {
+  const container = control?.getContainer();
+  if (container) container.style.display = "none";
+}
+
+function showDuckDBControl(control: DuckDBControl | null): void {
+  const container = control?.getContainer();
+  if (container) container.style.display = "";
+}
+
+function isDuckDBControlLayer(layer: GeoLibreLayer): boolean {
+  return (
+    layer.type === "duckdb-query" &&
+    layer.metadata.sourceKind === "duckdb-query" &&
+    layer.metadata.externalDeckLayer === true
+  );
+}


### PR DESCRIPTION
## Summary
- Add an "Add DuckDB Layer" option that runs SQL against DuckDB-WASM and renders the result as a deck.gl vector layer via maplibre-gl-duckdb.
- Wire the DuckDB layer into the Style panel so fill, stroke, radius, and opacity changes apply live to the deck.gl layer, and keep it out of the placeholder-layer path.
- Add theme-aware CSS for the DuckDB control panel so it matches the app's light/dark themes.

## Test plan
- [ ] Open the Add Data menu and choose "Add DuckDB Layer"
- [ ] Run the sample query and confirm the result renders on the map
- [ ] Adjust fill/stroke/radius/opacity in the Style panel and confirm live updates
- [ ] Toggle layer visibility and reorder, confirming the deck.gl layer follows