### PR TITLE
feat: add 3D extrusion styling for DuckDB deck.gl layers

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,8 +36,26 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
+          prompt: |
+            Perform a thorough code review of pull request ${{ github.repository }}/pull/${{ github.event.pull_request.number }}.
+
+            Inspect the changes with `gh pr diff` and `gh pr view`. When the diff alone is not enough to judge correctness, read the surrounding source files for context.
+
+            Review the changed code for:
+            - Bugs and logic errors, including edge cases, race conditions, and missing error handling
+            - Security issues such as injection, unsafe input handling, and leaked secrets
+            - Performance problems and obvious inefficiencies
+            - Code quality, readability, naming, and maintainability
+            - Adherence to any CLAUDE.md guidelines that apply to the changed files
+
+            Concentrate on the changed lines, but use repository context to judge whether they are correct. Report findings across a range of confidence levels, not only near-certain ones. It is fine to raise a well-reasoned concern even when you are not fully certain, as long as you state your confidence and reasoning. Skip pre-existing issues unrelated to this change.
+
+            Post specific findings as inline review comments on the relevant lines using the create_inline_comment tool. For each comment, briefly explain the issue and, when the fix is small and self-contained, include a committable suggestion block. Group minor nits together rather than posting many separate inline comments.
+
+            After posting inline comments, post exactly one summary comment with `gh pr comment` that starts with the heading "## Code review" and lists the findings grouped by category (Bugs, Security, Performance, Quality, CLAUDE.md), each with a one-line description and confidence. If you genuinely find nothing worth raising, say so and note what you checked.
+
+            Do not approve, merge, or modify any code. Only review and comment. Do not use web fetch; use the gh CLI for all GitHub interactions.
+          claude_args: |
+            --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -78,6 +78,10 @@ function supportsExtrusionControls(layer: {
     return true;
   }
 
+  if (hasExternalDeckLayer(layer)) {
+    return true;
+  }
+
   return (
     hasExternalNativeLayers(layer) &&
     layer.metadata.tileType !== "raster" &&

--- a/packages/plugins/src/plugins/maplibre-duckdb.ts
+++ b/packages/plugins/src/plugins/maplibre-duckdb.ts
@@ -31,6 +31,7 @@ type MutableDuckDBControl = {
   beforeId?: string;
   layer?: {
     beforeId: string | null;
+    rows?: Record<number, Record<string, unknown>>;
   } | null;
   renderLayer?: () => Promise<void>;
   renderer?: DuckDBRendererLike | null;
@@ -44,6 +45,7 @@ type StyledDeckLayerLike = {
 
 interface DuckDBRenderedStyle {
   opacity: number;
+  rows: Record<number, Record<string, unknown>>;
   style: LayerStyle;
 }
 
@@ -259,6 +261,7 @@ function setDuckDBRenderedLayerVisible(visible: boolean): void {
 function setDuckDBRenderedLayerStyle(layer: GeoLibreLayer): void {
   duckdbRenderedStyles.set(layer.id, {
     opacity: layer.opacity,
+    rows: getDuckDBRenderedRows(layer.id),
     style: layer.style,
   });
   void renderStyledDuckDBLayer();
@@ -346,17 +349,73 @@ function cloneStyledDeckLayer(
   }
 
   return deckLayer.clone({
+    elevationScale: style.extrusionHeightScale,
+    extruded: style.extrusionEnabled,
     getFillColor: fillColor,
+    getElevation: createDuckDBElevationAccessor(renderedStyle),
     getLineColor: strokeColor,
     getLineWidth: style.strokeWidth,
     lineWidthMinPixels: Math.max(1, style.strokeWidth),
     updateTriggers: {
       ...asRecord(deckLayer.props?.updateTriggers),
+      getElevation: [
+        style.extrusionBase,
+        style.extrusionHeightProperty,
+        style.extrusionHeightScale,
+      ],
       getFillColor: [style.fillColor, style.fillOpacity, opacity],
       getLineColor: [style.strokeColor, opacity],
       getLineWidth: [style.strokeWidth],
     },
   });
+}
+
+function createDuckDBElevationAccessor(renderedStyle: DuckDBRenderedStyle) {
+  return (objectInfo: { data?: unknown; index?: number }): number => {
+    const { style, rows } = renderedStyle;
+    const fallbackHeight = style.extrusionBase || 100;
+    const rowIndex = getGeoArrowRowIndex(objectInfo);
+    const row = rowIndex === null ? undefined : rows[rowIndex];
+    const rawValue =
+      row && style.extrusionHeightProperty
+        ? row[style.extrusionHeightProperty]
+        : undefined;
+    const value = Number(rawValue);
+
+    if (!Number.isFinite(value)) return fallbackHeight;
+    return Math.max(0, value + style.extrusionBase);
+  };
+}
+
+function getGeoArrowRowIndex(objectInfo: {
+  data?: unknown;
+  index?: number;
+}): number | null {
+  const table = (
+    objectInfo.data as
+      | {
+          data?: {
+            getChild?: (name: string) => { get?: (index: number) => unknown } | null;
+          };
+        }
+      | undefined
+  )?.data;
+  const index = objectInfo.index;
+  if (typeof index !== "number") return null;
+
+  const rawIndex = table?.getChild?.("__index")?.get?.(index);
+  if (typeof rawIndex === "number" && Number.isFinite(rawIndex)) {
+    return rawIndex;
+  }
+  if (typeof rawIndex === "bigint") return Number(rawIndex);
+  return index;
+}
+
+function getDuckDBRenderedRows(layerId: string): Record<number, Record<string, unknown>> {
+  const control = duckdbControl as unknown as MutableDuckDBControl | null;
+  const stateLayerId = duckdbControl?.getState().layer?.id;
+  if (stateLayerId !== layerId) return {};
+  return control?.layer?.rows ?? {};
 }
 
 function asRecord(value: unknown): Record<string, unknown> {

--- a/packages/plugins/src/plugins/maplibre-duckdb.ts
+++ b/packages/plugins/src/plugins/maplibre-duckdb.ts
@@ -45,7 +45,6 @@ type StyledDeckLayerLike = {
 
 interface DuckDBRenderedStyle {
   opacity: number;
-  rows: Record<number, Record<string, unknown>>;
   style: LayerStyle;
 }
 
@@ -76,6 +75,7 @@ let duckdbConstructorsPromise: Promise<{
   DuckDBControl: DuckDBControlConstructor;
 }> | null = null;
 const duckdbRenderedStyles = new Map<string, DuckDBRenderedStyle>();
+const warnedMissingRowsLayerIds = new Set<string>();
 
 export function openDuckDBLayerPanel(app: GeoLibreAppAPI): void {
   void openStandaloneDuckDBControl(app);
@@ -261,7 +261,6 @@ function setDuckDBRenderedLayerVisible(visible: boolean): void {
 function setDuckDBRenderedLayerStyle(layer: GeoLibreLayer): void {
   duckdbRenderedStyles.set(layer.id, {
     opacity: layer.opacity,
-    rows: getDuckDBRenderedRows(layer.id),
     style: layer.style,
   });
   void renderStyledDuckDBLayer();
@@ -300,13 +299,14 @@ function patchDuckDBRenderer(renderer: DuckDBRendererLike | null | undefined) {
     if (!renderedStyle) return originalLayers;
 
     return originalLayers.map((deckLayer) =>
-      cloneStyledDeckLayer(deckLayer, result.geometryType, renderedStyle),
+      cloneStyledDeckLayer(layerId, deckLayer, result.geometryType, renderedStyle),
     );
   };
   renderer.__geolibreStylePatched = true;
 }
 
 function cloneStyledDeckLayer(
+  layerId: string,
   deckLayer: StyledDeckLayerLike,
   geometryType: string | undefined,
   renderedStyle: DuckDBRenderedStyle,
@@ -352,7 +352,7 @@ function cloneStyledDeckLayer(
     elevationScale: style.extrusionHeightScale,
     extruded: style.extrusionEnabled,
     getFillColor: fillColor,
-    getElevation: createDuckDBElevationAccessor(renderedStyle),
+    getElevation: createDuckDBElevationAccessor(layerId, renderedStyle),
     getLineColor: strokeColor,
     getLineWidth: style.strokeWidth,
     lineWidthMinPixels: Math.max(1, style.strokeWidth),
@@ -370,11 +370,15 @@ function cloneStyledDeckLayer(
   });
 }
 
-function createDuckDBElevationAccessor(renderedStyle: DuckDBRenderedStyle) {
+function createDuckDBElevationAccessor(
+  layerId: string,
+  renderedStyle: DuckDBRenderedStyle,
+) {
   return (objectInfo: { data?: unknown; index?: number }): number => {
-    const { style, rows } = renderedStyle;
-    const fallbackHeight = style.extrusionBase || 100;
+    const { style } = renderedStyle;
+    const fallbackHeight = style.extrusionBase ?? 100;
     const rowIndex = getGeoArrowRowIndex(objectInfo);
+    const rows = getDuckDBRenderedRows(layerId);
     const row = rowIndex === null ? undefined : rows[rowIndex];
     const rawValue =
       row && style.extrusionHeightProperty
@@ -407,7 +411,9 @@ function getGeoArrowRowIndex(objectInfo: {
   if (typeof rawIndex === "number" && Number.isFinite(rawIndex)) {
     return rawIndex;
   }
-  if (typeof rawIndex === "bigint") return Number(rawIndex);
+  if (typeof rawIndex === "bigint") {
+    return rawIndex <= BigInt(Number.MAX_SAFE_INTEGER) ? Number(rawIndex) : index;
+  }
   return index;
 }
 
@@ -415,7 +421,23 @@ function getDuckDBRenderedRows(layerId: string): Record<number, Record<string, u
   const control = duckdbControl as unknown as MutableDuckDBControl | null;
   const stateLayerId = duckdbControl?.getState().layer?.id;
   if (stateLayerId !== layerId) return {};
-  return control?.layer?.rows ?? {};
+  const rows = control?.layer?.rows;
+  if (!rows) {
+    warnMissingDuckDBRows(layerId);
+    return {};
+  }
+  return rows;
+}
+
+function warnMissingDuckDBRows(layerId: string): void {
+  if (warnedMissingRowsLayerIds.has(layerId)) return;
+  warnedMissingRowsLayerIds.add(layerId);
+
+  if (import.meta.env.DEV) {
+    console.warn(
+      `DuckDB layer ${layerId} did not expose row data for extrusion heights.`,
+    );
+  }
 }
 
 function asRecord(value: unknown): Record<string, unknown> {


### PR DESCRIPTION
## Summary
- Enable the extrusion style controls for DuckDB query layers rendered via deck.gl, not just native vector layers.
- Add an elevation accessor in the DuckDB renderer that reads per-row height from a chosen property, with base offset and height scale, and wires the relevant deck.gl update triggers.

## Test plan
- [x] `npm run build` (`tsc -b && vite build`) passes, type-checking the changed code
- [x] `pre-commit run` on changed files passes (build hook + formatting)
- [ ] Manually verify a DuckDB query layer extrudes by a numeric property in the desktop app

Note: the repo currently has no unit-test, lint, or typecheck scripts, so the build is the available verification gate.