### PR TITLE
feat: add GeoParquet layer with deck.gl rendering

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -41,6 +41,7 @@
     "maplibre-gl-duckdb": "^0.2.0",
     "maplibre-gl-geo-editor": "^0.7.3",
     "maplibre-gl-geoagent": "^0.4.2",
+    "maplibre-gl-geoparquet": "^0.2.1",
     "maplibre-gl-lidar": "^0.14.1",
     "maplibre-gl-streetview": "^0.4.0",
     "maplibre-gl-swipe": "^0.7.1",

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -11,6 +11,7 @@ import {
 import {
   openFlatGeobufAddVectorLayerPanel,
   openDuckDBLayerPanel,
+  openGeoParquetLayerPanel,
   openLidarLayerPanel,
   openPMTilesLayerPanel,
   openSplattingLayerPanel,
@@ -152,6 +153,9 @@ export function TopToolbar({
   const handleAddDuckDBLayer = () => {
     openDuckDBLayerPanel(appApi);
   };
+  const handleAddGeoParquetLayer = () => {
+    openGeoParquetLayerPanel(appApi);
+  };
   const handleAddPMTilesLayer = () => {
     openPMTilesLayerPanel(appApi);
   };
@@ -213,6 +217,9 @@ export function TopToolbar({
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => setAddDataKind("raster")}>
             Add Raster Layer
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={handleAddGeoParquetLayer}>
+            Add GeoParquet Layer
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={handleAddFlatGeobufLayer}>
             Add FlatGeobuf Layer

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -461,7 +461,7 @@ export function LayerPanel({
       </ScrollArea>
       <Separator />
       <p className="p-2 text-[10px] text-muted-foreground">
-        {/* TODO(v0.3): Add PMTiles, COG, FlatGeobuf, GeoParquet layer types */}
+        {/* TODO(v0.3): Add native PMTiles, COG, and FlatGeobuf layer types */}
         Advanced formats: see docs/roadmap.md
       </p>
       <Dialog

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -227,6 +227,140 @@ body,
   top: 10px !important;
 }
 
+.geolibre-geoparquet-control {
+  background-color: transparent !important;
+  box-shadow: none !important;
+  color: hsl(var(--popover-foreground)) !important;
+  height: 0 !important;
+  margin: 0 !important;
+  pointer-events: none;
+}
+
+.geolibre-geoparquet-control .geoparquet-control-toggle {
+  pointer-events: none;
+  visibility: hidden;
+}
+
+.geoparquet-control-panel {
+  background-color: hsl(var(--popover)) !important;
+  border: 1px solid hsl(var(--border));
+  box-sizing: border-box;
+  color: hsl(var(--popover-foreground)) !important;
+  max-height: min(620px, calc(100% - 20px));
+  max-width: min(365px, calc(100vw - 32px));
+}
+
+.geoparquet-control-content {
+  max-height: min(560px, calc(100vh - 220px));
+}
+
+.geoparquet-control-header {
+  background-color: hsl(var(--card)) !important;
+  border-bottom-color: hsl(var(--border)) !important;
+  color: hsl(var(--foreground)) !important;
+}
+
+.geoparquet-control-title,
+.geoparquet-control-section-title,
+.geoparquet-control-label,
+.geoparquet-control-check,
+.geoparquet-control-summary-row strong,
+.geoparquet-control-properties dd {
+  color: hsl(var(--popover-foreground)) !important;
+}
+
+.geoparquet-control-close,
+.geoparquet-control-summary-row span,
+.geoparquet-control-properties dt {
+  color: hsl(var(--muted-foreground)) !important;
+}
+
+.geoparquet-control-close:hover {
+  color: hsl(var(--foreground)) !important;
+}
+
+.geoparquet-control-section {
+  border-bottom-color: hsl(var(--border)) !important;
+}
+
+.geoparquet-control-input,
+.geoparquet-control-file {
+  background-color: hsl(var(--background)) !important;
+  border-color: hsl(var(--input)) !important;
+  color: hsl(var(--foreground)) !important;
+}
+
+.geoparquet-control-input::placeholder {
+  color: hsl(var(--muted-foreground)) !important;
+}
+
+.geoparquet-control-input:focus {
+  border-color: hsl(var(--ring)) !important;
+  box-shadow: 0 0 0 1px hsl(var(--ring));
+  outline: none;
+}
+
+.geoparquet-control-button {
+  background-color: hsl(var(--primary)) !important;
+  color: hsl(var(--primary-foreground)) !important;
+}
+
+.geoparquet-control-button:hover {
+  background-color: hsl(var(--primary) / 0.9) !important;
+}
+
+.geoparquet-control-secondary-button,
+.geoparquet-control-mini-button {
+  background-color: hsl(var(--secondary)) !important;
+  border-color: hsl(var(--border)) !important;
+  color: hsl(var(--secondary-foreground)) !important;
+}
+
+.geoparquet-control-secondary-button:hover,
+.geoparquet-control-mini-button:hover {
+  background-color: hsl(var(--accent)) !important;
+  color: hsl(var(--accent-foreground)) !important;
+}
+
+.geoparquet-control-layer-list,
+.geoparquet-control-column-list {
+  border-color: hsl(var(--border)) !important;
+}
+
+.geoparquet-control-status {
+  background-color: hsl(var(--accent)) !important;
+  color: hsl(var(--accent-foreground)) !important;
+}
+
+.geoparquet-control-error {
+  background-color: hsl(var(--destructive) / 0.12) !important;
+  color: hsl(var(--destructive)) !important;
+}
+
+.geoparquet-control-warning {
+  background-color: hsl(45 90% 55% / 0.14) !important;
+  color: hsl(var(--foreground)) !important;
+}
+
+.geoparquet-popup {
+  color: hsl(var(--popover-foreground)) !important;
+}
+
+.maplibregl-popup.geoparquet-attribute-popup .maplibregl-popup-content {
+  background-color: hsl(var(--popover)) !important;
+  border: 1px solid hsl(var(--border));
+  color: hsl(var(--popover-foreground)) !important;
+}
+
+.geoparquet-popup th,
+.geoparquet-popup td {
+  border-top-color: hsl(var(--border)) !important;
+}
+
+.geoparquet-popup th {
+  color: hsl(var(--muted-foreground)) !important;
+}
+
 .duckdb-control-content {
   max-height: min(560px, calc(100vh - 220px));
 }

--- a/apps/geolibre-desktop/src/main.tsx
+++ b/apps/geolibre-desktop/src/main.tsx
@@ -8,6 +8,7 @@ import "maplibre-gl-components/style.css";
 import "maplibre-gl-duckdb/style.css";
 import "maplibre-gl-geo-editor/style.css";
 import "maplibre-gl-geoagent/style.css";
+import "maplibre-gl-geoparquet/style.css";
 import "maplibre-gl-streetview/style.css";
 import "maplibre-gl-swipe/style.css";
 import "mapillary-js/dist/mapillary.css";

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "maplibre-gl-duckdb": "^0.2.0",
         "maplibre-gl-geo-editor": "^0.7.3",
         "maplibre-gl-geoagent": "^0.4.2",
+        "maplibre-gl-geoparquet": "^0.2.1",
         "maplibre-gl-lidar": "^0.14.1",
         "maplibre-gl-streetview": "^0.4.0",
         "maplibre-gl-swipe": "^0.7.1",
@@ -9845,6 +9846,215 @@
         }
       }
     },
+    "node_modules/maplibre-gl-geoparquet": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-geoparquet/-/maplibre-gl-geoparquet-0.2.1.tgz",
+      "integrity": "sha512-Nb8OqwFox312zGko3NSvbLkPq3nMzGsCwHHrFqs/Gqwz1VgfZPOZZB9HgZPSRcUDgc9Bwk0nyRR6o0Pl+a1G4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@deck.gl/core": "^9.3.2",
+        "@deck.gl/layers": "^9.3.2",
+        "@deck.gl/mapbox": "^9.3.2",
+        "@duckdb/duckdb-wasm": "^1.33.1-dev45.0",
+        "@geoarrow/deck.gl-layers": "^0.3.2",
+        "@walkthru-earth/objex-utils": "^1.5.0",
+        "apache-arrow": "^21.1.0"
+      },
+      "peerDependencies": {
+        "maplibre-gl": ">=3.0.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/maplibre-gl-geoparquet/node_modules/@duckdb/duckdb-wasm": {
+      "version": "1.33.1-dev45.0",
+      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.33.1-dev45.0.tgz",
+      "integrity": "sha512-ETlrjhiGQzNdaOhpro/Y9u/RCcK+iyuczLy7uOn0kG5Mqlj8C+gTuhBXjs4JpK9ocdUgr3oT8zYYIbUnFD9AYA==",
+      "license": "MIT",
+      "dependencies": {
+        "apache-arrow": "^17.0.0",
+        "qs": "^6.14.1"
+      }
+    },
+    "node_modules/maplibre-gl-geoparquet/node_modules/@duckdb/duckdb-wasm/node_modules/apache-arrow": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-17.0.0.tgz",
+      "integrity": "sha512-X0p7auzdnGuhYMVKYINdQssS4EcKec9TCXyez/qtJt32DrIMGbzqiaMiQ0X6fQlQpw8Fl0Qygcv4dfRAr5Gu9Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/command-line-args": "^5.2.3",
+        "@types/command-line-usage": "^5.0.4",
+        "@types/node": "^20.13.0",
+        "command-line-args": "^5.2.1",
+        "command-line-usage": "^7.0.1",
+        "flatbuffers": "^24.3.25",
+        "json-bignum": "^0.0.3",
+        "tslib": "^2.6.2"
+      },
+      "bin": {
+        "arrow2csv": "bin/arrow2csv.cjs"
+      }
+    },
+    "node_modules/maplibre-gl-geoparquet/node_modules/@geoarrow/deck.gl-layers": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@geoarrow/deck.gl-layers/-/deck.gl-layers-0.3.2.tgz",
+      "integrity": "sha512-GWepG0iNSU1X1rdkcuYIR6ZQaUJ67XesLjzk2gUxvbxuQgKZBFra7goOh53ziyMercy0hVRrXEqE0M+DJmYDDA==",
+      "deprecated": "This package has been renamed to @geoarrow/deck.gl-geoarrow",
+      "license": "MIT",
+      "workspaces": [
+        ".",
+        "examples/*"
+      ],
+      "dependencies": {
+        "@geoarrow/geoarrow-js": "^0.3.0",
+        "threads": "^1.7.0"
+      },
+      "peerDependencies": {
+        "@deck.gl/aggregation-layers": "^9.0.12",
+        "@deck.gl/core": "^9.0.12",
+        "@deck.gl/geo-layers": "^9.0.12",
+        "@deck.gl/layers": "^9.0.12",
+        "@math.gl/polygon": "^3.6.2",
+        "apache-arrow": ">=15"
+      }
+    },
+    "node_modules/maplibre-gl-geoparquet/node_modules/@math.gl/core": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@math.gl/core/-/core-3.6.3.tgz",
+      "integrity": "sha512-jBABmDkj5uuuE0dTDmwwss7Cup5ZwQ6Qb7h1pgvtkEutTrhkcv8SuItQNXmF45494yIHeoGue08NlyeY6wxq2A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "@math.gl/types": "3.6.3",
+        "gl-matrix": "^3.4.0"
+      }
+    },
+    "node_modules/maplibre-gl-geoparquet/node_modules/@math.gl/polygon": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@math.gl/polygon/-/polygon-3.6.3.tgz",
+      "integrity": "sha512-FivQ1ZnYcAss1wVifOkHP/ZnlfQy1IL/769uzNtiHxwUbW0kZG3yyOZ9I7fwyzR5Hvqt3ErJKHjSYZr0uVlz5g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@math.gl/core": "3.6.3"
+      }
+    },
+    "node_modules/maplibre-gl-geoparquet/node_modules/@math.gl/types": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@math.gl/types/-/types-3.6.3.tgz",
+      "integrity": "sha512-3uWLVXHY3jQxsXCr/UCNPSc2BG0hNUljhmOBt9l+lNFDp7zHgm0cK2Tw4kj2XfkJy4TgwZTBGwRDQgWEbLbdTA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/maplibre-gl-geoparquet/node_modules/apache-arrow": {
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-21.1.0.tgz",
+      "integrity": "sha512-kQrYLxhC+NTVVZ4CCzGF6L/uPVOzJmD1T3XgbiUnP7oTeVFOFgEUu6IKNwCDkpFoBVqDKQivlX4RUFqqnWFlEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/command-line-args": "^5.2.3",
+        "@types/command-line-usage": "^5.0.4",
+        "@types/node": "^24.0.3",
+        "command-line-args": "^6.0.1",
+        "command-line-usage": "^7.0.1",
+        "flatbuffers": "^25.1.24",
+        "json-bignum": "^0.0.3",
+        "tslib": "^2.6.2"
+      },
+      "bin": {
+        "arrow2csv": "bin/arrow2csv.js"
+      }
+    },
+    "node_modules/maplibre-gl-geoparquet/node_modules/apache-arrow/node_modules/@types/node": {
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/maplibre-gl-geoparquet/node_modules/apache-arrow/node_modules/command-line-args": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.2.tgz",
+      "integrity": "sha512-AIjYVxrV9X752LmPDLbVYv8aMCuHPSLZJXEo2qo/xJfv+NYhaZ4sMSF01rM+gHPaMgvPM0l5D/F+Qx+i2WfSmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.3",
+        "find-replace": "^5.0.2",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/maplibre-gl-geoparquet/node_modules/apache-arrow/node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/maplibre-gl-geoparquet/node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/maplibre-gl-geoparquet/node_modules/find-replace": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
+      "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/maplibre-gl-geoparquet/node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/maplibre-gl-geoparquet/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
+    },
     "node_modules/maplibre-gl-layer-control": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/maplibre-gl-layer-control/-/maplibre-gl-layer-control-0.14.1.tgz",
@@ -12393,6 +12603,7 @@
         "maplibre-gl-duckdb": "^0.2.0",
         "maplibre-gl-geo-editor": "^0.7.3",
         "maplibre-gl-geoagent": "^0.4.2",
+        "maplibre-gl-geoparquet": "^0.2.1",
         "maplibre-gl-lidar": "^0.14.1",
         "maplibre-gl-streetview": "^0.4.0",
         "maplibre-gl-swipe": "^0.7.1",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -30,6 +30,7 @@
     "maplibre-gl-duckdb": "^0.2.0",
     "maplibre-gl-geo-editor": "^0.7.3",
     "maplibre-gl-geoagent": "^0.4.2",
+    "maplibre-gl-geoparquet": "^0.2.1",
     "maplibre-gl-lidar": "^0.14.1",
     "maplibre-gl-streetview": "^0.4.0",
     "maplibre-gl-swipe": "^0.7.1",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -22,6 +22,7 @@ export {
   type CogRasterLayerOptions,
 } from "./plugins/maplibre-components";
 export { openDuckDBLayerPanel } from "./plugins/maplibre-duckdb";
+export { openGeoParquetLayerPanel } from "./plugins/maplibre-geoparquet";
 export { maplibreGeoEditorPlugin } from "./plugins/maplibre-geo-editor";
 export { maplibreGeoAgentPlugin } from "./plugins/maplibre-geoagent";
 export { maplibreLidarPlugin } from "./plugins/maplibre-lidar";

--- a/packages/plugins/src/plugins/deck-style-utils.ts
+++ b/packages/plugins/src/plugins/deck-style-utils.ts
@@ -1,0 +1,41 @@
+import type { LayerStyle } from "@geolibre/core";
+
+export type StyledDeckLayerLike = {
+  clone?: (props: Record<string, unknown>) => StyledDeckLayerLike;
+  props?: Record<string, unknown>;
+};
+
+export function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+export function colorToRgba(
+  color: string,
+  alpha: number,
+): [number, number, number, number] {
+  const normalized = color.trim();
+  const hex =
+    normalized.length === 4 && normalized.startsWith("#")
+      ? `#${normalized[1]}${normalized[1]}${normalized[2]}${normalized[2]}${normalized[3]}${normalized[3]}`
+      : normalized;
+  const match = /^#([0-9a-f]{6})$/i.exec(hex);
+  if (!match) return [59, 130, 246, Math.round(clamp(alpha, 0, 1) * 255)];
+
+  const value = Number.parseInt(match[1], 16);
+  return [
+    (value >> 16) & 255,
+    (value >> 8) & 255,
+    value & 255,
+    Math.round(clamp(alpha, 0, 1) * 255),
+  ];
+}
+
+export function pointRadiusMaxPixels(style: LayerStyle): number {
+  return style.circleRadius * 2;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}

--- a/packages/plugins/src/plugins/maplibre-duckdb.ts
+++ b/packages/plugins/src/plugins/maplibre-duckdb.ts
@@ -12,6 +12,12 @@ import type {
   DuckDBState,
 } from "maplibre-gl-duckdb";
 import type { GeoLibreAppAPI, GeoLibreMapControlPosition } from "../types";
+import {
+  asRecord,
+  colorToRgba,
+  pointRadiusMaxPixels,
+  type StyledDeckLayerLike,
+} from "./deck-style-utils";
 
 type DuckDBControlConstructor =
   (typeof import("maplibre-gl-duckdb"))["DuckDBControl"];
@@ -35,12 +41,6 @@ type MutableDuckDBControl = {
   } | null;
   renderLayer?: () => Promise<void>;
   renderer?: DuckDBRendererLike | null;
-};
-
-type StyledDeckLayerLike = {
-  id?: string;
-  clone?: (props: Record<string, unknown>) => StyledDeckLayerLike;
-  props?: Record<string, unknown>;
 };
 
 interface DuckDBRenderedStyle {
@@ -325,7 +325,7 @@ function cloneStyledDeckLayer(
     return deckLayer.clone({
       getFillColor: fillColor,
       getRadius: style.circleRadius,
-      radiusMaxPixels: Math.max(style.circleRadius * 2, style.circleRadius),
+      radiusMaxPixels: pointRadiusMaxPixels(style),
       radiusMinPixels: Math.max(1, Math.min(style.circleRadius, 4)),
       updateTriggers: {
         ...asRecord(deckLayer.props?.updateTriggers),
@@ -438,34 +438,6 @@ function warnMissingDuckDBRows(layerId: string): void {
       `DuckDB layer ${layerId} did not expose row data for extrusion heights.`,
     );
   }
-}
-
-function asRecord(value: unknown): Record<string, unknown> {
-  return value && typeof value === "object"
-    ? (value as Record<string, unknown>)
-    : {};
-}
-
-function colorToRgba(color: string, alpha: number): [number, number, number, number] {
-  const normalized = color.trim();
-  const hex =
-    normalized.length === 4 && normalized.startsWith("#")
-      ? `#${normalized[1]}${normalized[1]}${normalized[2]}${normalized[2]}${normalized[3]}${normalized[3]}`
-      : normalized;
-  const match = /^#([0-9a-f]{6})$/i.exec(hex);
-  if (!match) return [59, 130, 246, Math.round(clamp(alpha, 0, 1) * 255)];
-
-  const value = Number.parseInt(match[1], 16);
-  return [
-    (value >> 16) & 255,
-    (value >> 8) & 255,
-    value & 255,
-    Math.round(clamp(alpha, 0, 1) * 255),
-  ];
-}
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(max, Math.max(min, value));
 }
 
 function setDuckDBRenderedLayerBeforeId(beforeId: string | null): void {

--- a/packages/plugins/src/plugins/maplibre-geoparquet.ts
+++ b/packages/plugins/src/plugins/maplibre-geoparquet.ts
@@ -11,6 +11,12 @@ import type {
   GeoParquetLayerState,
 } from "maplibre-gl-geoparquet";
 import type { GeoLibreAppAPI, GeoLibreMapControlPosition } from "../types";
+import {
+  asRecord,
+  colorToRgba,
+  pointRadiusMaxPixels,
+  type StyledDeckLayerLike,
+} from "./deck-style-utils";
 
 type GeoParquetControlConstructor =
   (typeof import("maplibre-gl-geoparquet"))["GeoParquetControl"];
@@ -44,17 +50,21 @@ type MutableGeoParquetControl = {
 
 type GeoParquetRendererLike = {
   __geolibreOriginalCreateLayers?: GeoParquetRendererLike["createLayers"];
+  __geolibreOriginalSetData?: GeoParquetRendererLike["setData"];
   __geolibreStylePatched?: boolean;
   createLayers?: (
     layerId: string,
     result: GeoParquetResultLike,
     index: number,
   ) => StyledDeckLayerLike[];
+  setData?: (layers: GeoParquetRenderedLayerLike[]) => void;
 };
 
-type StyledDeckLayerLike = {
-  clone?: (props: Record<string, unknown>) => StyledDeckLayerLike;
-  props?: Record<string, unknown>;
+type GeoParquetRenderedLayerLike = {
+  beforeId?: string | null;
+  id: string;
+  name?: string;
+  results?: GeoParquetResultLike[];
 };
 
 const geoparquetControlPosition: GeoLibreMapControlPosition = "top-left";
@@ -75,6 +85,7 @@ let geoparquetConstructorsPromise: Promise<{
 }> | null = null;
 let geoparquetStoreUnsubscribe: (() => void) | null = null;
 const geoparquetRenderedStyles = new Map<string, GeoParquetRenderedStyle>();
+let geoparquetLayerOrder = new Map<string, number>();
 
 export function openGeoParquetLayerPanel(app: GeoLibreAppAPI): void {
   void openStandaloneGeoParquetControl(app);
@@ -98,7 +109,6 @@ async function openStandaloneGeoParquetControl(
       return false;
     }
     geoparquetControlMounted = true;
-    patchGeoParquetRenderer(getMutableGeoParquetControl().renderer);
   }
 
   setTimeout(() => {
@@ -124,12 +134,14 @@ function createGeoParquetControl(
   GeoParquetControlClass: GeoParquetControlConstructor,
 ): GeoParquetControl {
   const control = new GeoParquetControlClass(GEOPARQUET_OPTIONS);
+  patchGeoParquetControlOnRemove(control);
   control.on("collapse", () => hideGeoParquetControl(control));
   control.on("load", createGeoParquetStateChangeHandler(control));
   control.on("statechange", createGeoParquetStateChangeHandler(control));
 
   geoparquetStoreUnsubscribe ??= useAppStore.subscribe((state, previous) => {
     const currentById = new Map(state.layers.map((layer) => [layer.id, layer]));
+    let shouldSyncControl = false;
 
     for (const layer of previous.layers) {
       if (!isGeoParquetControlLayer(layer)) continue;
@@ -150,12 +162,16 @@ function createGeoParquetControl(
         currentLayer.beforeId !== layer.beforeId ||
         currentLayer.name !== layer.name
       ) {
-        syncGeoParquetControlFromStore(state.layers);
+        shouldSyncControl = true;
       }
     }
 
     if (geoparquetLayerOrderSignature(state.layers) !==
       geoparquetLayerOrderSignature(previous.layers)) {
+      shouldSyncControl = true;
+    }
+
+    if (shouldSyncControl) {
       syncGeoParquetControlFromStore(state.layers);
     }
   });
@@ -260,10 +276,12 @@ function createGeoParquetLayerPatch(
   if (existingLayer.beforeId !== nextLayer.beforeId) {
     patch.beforeId = nextLayer.beforeId;
   }
-  if (!shallowEqualRecord(existingLayer.source, nextLayer.source)) {
+  if (hasGeoParquetSourceChanged(existingLayer.source, nextLayer.source)) {
     patch.source = nextLayer.source;
   }
-  if (!shallowEqualRecord(existingLayer.metadata, nextLayer.metadata)) {
+  if (
+    hasGeoParquetMetadataChanged(existingLayer.metadata, nextLayer.metadata)
+  ) {
     patch.metadata = nextLayer.metadata;
   }
   if (existingLayer.sourcePath !== nextLayer.sourcePath) {
@@ -279,12 +297,10 @@ function syncGeoParquetControlFromStore(layers: GeoLibreLayer[]): void {
   if (!controlLayers) return;
 
   const storeLayerById = new Map(layers.map((layer) => [layer.id, layer]));
-  const storeOrder = new Map(layers.map((layer, index) => [layer.id, index]));
-
-  controlLayers.sort(
-    (a, b) =>
-      (storeOrder.get(a.id) ?? Number.MAX_SAFE_INTEGER) -
-      (storeOrder.get(b.id) ?? Number.MAX_SAFE_INTEGER),
+  geoparquetLayerOrder = new Map(
+    layers
+      .filter(isGeoParquetControlLayer)
+      .map((layer, index) => [layer.id, index]),
   );
 
   for (const controlLayer of controlLayers) {
@@ -306,7 +322,25 @@ function syncGeoParquetControlFromStore(layers: GeoLibreLayer[]): void {
 function patchGeoParquetRenderer(
   renderer: GeoParquetRendererLike | null | undefined,
 ): void {
-  if (!renderer?.createLayers || renderer.__geolibreStylePatched) return;
+  if (!renderer || renderer.__geolibreStylePatched) return;
+
+  if (renderer.setData) {
+    renderer.__geolibreOriginalSetData = renderer.setData.bind(renderer);
+    renderer.setData = (layers: GeoParquetRenderedLayerLike[]) => {
+      renderer.__geolibreOriginalSetData?.(
+        [...layers].sort(
+          (first, second) =>
+            (geoparquetLayerOrder.get(first.id) ?? Number.MAX_SAFE_INTEGER) -
+            (geoparquetLayerOrder.get(second.id) ?? Number.MAX_SAFE_INTEGER),
+        ),
+      );
+    };
+  }
+
+  if (!renderer.createLayers) {
+    renderer.__geolibreStylePatched = true;
+    return;
+  }
 
   renderer.__geolibreOriginalCreateLayers = renderer.createLayers.bind(
     renderer,
@@ -353,7 +387,7 @@ function cloneStyledDeckLayer(
     return deckLayer.clone({
       getFillColor: fillColor,
       getRadius: style.circleRadius,
-      radiusMaxPixels: Math.max(style.circleRadius * 2, style.circleRadius),
+      radiusMaxPixels: pointRadiusMaxPixels(style),
       radiusMinPixels: Math.max(1, Math.min(style.circleRadius, 4)),
       updateTriggers: {
         ...asRecord(deckLayer.props?.updateTriggers),
@@ -450,6 +484,25 @@ function getMutableGeoParquetControl(
   return control as unknown as MutableGeoParquetControl;
 }
 
+function patchGeoParquetControlOnRemove(control: GeoParquetControl): void {
+  const originalOnRemove = control.onRemove.bind(control);
+  control.onRemove = () => {
+    originalOnRemove();
+    resetGeoParquetControl(control);
+  };
+}
+
+function resetGeoParquetControl(control: GeoParquetControl): void {
+  if (geoparquetControl !== control) return;
+
+  geoparquetStoreUnsubscribe?.();
+  geoparquetStoreUnsubscribe = null;
+  geoparquetRenderedStyles.clear();
+  geoparquetLayerOrder.clear();
+  geoparquetControlMounted = false;
+  geoparquetControl = null;
+}
+
 function getGeoParquetLayerBounds(
   layer: GeoParquetLayerState,
 ): [number, number, number, number] | undefined {
@@ -542,39 +595,70 @@ function layerNameFromUrl(url: string, fallback: string): string {
   }
 }
 
-function shallowEqualRecord(
-  first: Record<string, unknown>,
-  second: Record<string, unknown>,
+function hasGeoParquetSourceChanged(
+  current: Record<string, unknown>,
+  next: Record<string, unknown>,
 ): boolean {
-  return JSON.stringify(first) === JSON.stringify(second);
+  return (
+    current.displaySource !== next.displaySource ||
+    current.sourceId !== next.sourceId ||
+    current.type !== next.type ||
+    current.url !== next.url ||
+    !boundsEqual(current.bounds, next.bounds)
+  );
 }
 
-function asRecord(value: unknown): Record<string, unknown> {
-  return value && typeof value === "object"
-    ? (value as Record<string, unknown>)
-    : {};
+function hasGeoParquetMetadataChanged(
+  current: Record<string, unknown>,
+  next: Record<string, unknown>,
+): boolean {
+  return (
+    current.customLayerType !== next.customLayerType ||
+    current.deckLayerId !== next.deckLayerId ||
+    current.externalDeckLayer !== next.externalDeckLayer ||
+    current.fileInfo !== next.fileInfo ||
+    current.geoMetadata !== next.geoMetadata ||
+    current.identifiable !== next.identifiable ||
+    current.loadedRows !== next.loadedRows ||
+    current.pageSize !== next.pageSize ||
+    current.primaryGeoColumn !== next.primaryGeoColumn ||
+    current.sourceId !== next.sourceId ||
+    current.sourceKind !== next.sourceKind ||
+    current.totalRows !== next.totalRows ||
+    !boundsEqual(current.bounds, next.bounds) ||
+    !stringArrayEqual(current.geometryTypes, next.geometryTypes) ||
+    !stringArrayEqual(current.selectedColumns, next.selectedColumns) ||
+    !schemaEqual(current.columns, next.columns)
+  );
 }
 
-function colorToRgba(color: string, alpha: number): [number, number, number, number] {
-  const normalized = color.trim();
-  const hex =
-    normalized.length === 4 && normalized.startsWith("#")
-      ? `#${normalized[1]}${normalized[1]}${normalized[2]}${normalized[2]}${normalized[3]}${normalized[3]}`
-      : normalized;
-  const match = /^#([0-9a-f]{6})$/i.exec(hex);
-  if (!match) return [59, 130, 246, Math.round(clamp(alpha, 0, 1) * 255)];
-
-  const value = Number.parseInt(match[1], 16);
-  return [
-    (value >> 16) & 255,
-    (value >> 8) & 255,
-    value & 255,
-    Math.round(clamp(alpha, 0, 1) * 255),
-  ];
+function boundsEqual(first: unknown, second: unknown): boolean {
+  if (first === second) return true;
+  if (!isBounds(first) || !isBounds(second)) return false;
+  return first.every((value, index) => value === second[index]);
 }
 
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(max, Math.max(min, value));
+function stringArrayEqual(first: unknown, second: unknown): boolean {
+  if (first === second) return true;
+  if (!Array.isArray(first) || !Array.isArray(second)) return false;
+  if (first.length !== second.length) return false;
+  return first.every((value, index) => value === second[index]);
+}
+
+function schemaEqual(first: unknown, second: unknown): boolean {
+  if (first === second) return true;
+  if (!Array.isArray(first) || !Array.isArray(second)) return false;
+  if (first.length !== second.length) return false;
+
+  return first.every((value, index) => {
+    const currentColumn = value as Record<string, unknown>;
+    const nextColumn = second[index] as Record<string, unknown>;
+    return (
+      currentColumn.name === nextColumn.name &&
+      currentColumn.nullable === nextColumn.nullable &&
+      currentColumn.type === nextColumn.type
+    );
+  });
 }
 
 function hideGeoParquetControl(control: GeoParquetControl | null): void {

--- a/packages/plugins/src/plugins/maplibre-geoparquet.ts
+++ b/packages/plugins/src/plugins/maplibre-geoparquet.ts
@@ -1,0 +1,588 @@
+import {
+  DEFAULT_LAYER_STYLE,
+  type GeoLibreLayer,
+  type LayerStyle,
+  useAppStore,
+} from "@geolibre/core";
+import type {
+  GeoParquetControl,
+  GeoParquetControlEventHandler,
+  GeoParquetControlOptions,
+  GeoParquetLayerState,
+} from "maplibre-gl-geoparquet";
+import type { GeoLibreAppAPI, GeoLibreMapControlPosition } from "../types";
+
+type GeoParquetControlConstructor =
+  (typeof import("maplibre-gl-geoparquet"))["GeoParquetControl"];
+
+type GeoParquetRenderedStyle = {
+  opacity: number;
+  style: LayerStyle;
+  visible: boolean;
+};
+
+type GeoParquetResultLike = {
+  bounds?: [number, number, number, number];
+  geometryType?: string;
+};
+
+type GeoParquetInternalLayer = {
+  beforeId?: string | null;
+  displaySource: string;
+  geoArrowResults?: GeoParquetResultLike[];
+  id: string;
+  name: string;
+  rows?: Record<number, Record<string, unknown>>;
+};
+
+type MutableGeoParquetControl = {
+  activeLayerId?: string | null;
+  layers?: GeoParquetInternalLayer[];
+  renderAllLayers?: () => void;
+  renderer?: GeoParquetRendererLike | null;
+};
+
+type GeoParquetRendererLike = {
+  __geolibreOriginalCreateLayers?: GeoParquetRendererLike["createLayers"];
+  __geolibreStylePatched?: boolean;
+  createLayers?: (
+    layerId: string,
+    result: GeoParquetResultLike,
+    index: number,
+  ) => StyledDeckLayerLike[];
+};
+
+type StyledDeckLayerLike = {
+  clone?: (props: Record<string, unknown>) => StyledDeckLayerLike;
+  props?: Record<string, unknown>;
+};
+
+const geoparquetControlPosition: GeoLibreMapControlPosition = "top-left";
+
+const GEOPARQUET_OPTIONS = {
+  className: "geolibre-geoparquet-control",
+  collapsed: false,
+  interleaved: true,
+  panelWidth: 365,
+  pickable: true,
+  title: "Add GeoParquet Layer",
+} satisfies GeoParquetControlOptions;
+
+let geoparquetControl: GeoParquetControl | null = null;
+let geoparquetControlMounted = false;
+let geoparquetConstructorsPromise: Promise<{
+  GeoParquetControl: GeoParquetControlConstructor;
+}> | null = null;
+let geoparquetStoreUnsubscribe: (() => void) | null = null;
+const geoparquetRenderedStyles = new Map<string, GeoParquetRenderedStyle>();
+
+export function openGeoParquetLayerPanel(app: GeoLibreAppAPI): void {
+  void openStandaloneGeoParquetControl(app);
+}
+
+async function openStandaloneGeoParquetControl(
+  app: GeoLibreAppAPI,
+): Promise<boolean> {
+  const { GeoParquetControl: GeoParquetControlClass } =
+    await getGeoParquetConstructors();
+
+  geoparquetControl ??= createGeoParquetControl(GeoParquetControlClass);
+
+  if (!geoparquetControlMounted) {
+    const added = app.addMapControl(
+      geoparquetControl,
+      geoparquetControlPosition,
+    );
+    if (!added) {
+      geoparquetControl = null;
+      return false;
+    }
+    geoparquetControlMounted = true;
+    patchGeoParquetRenderer(getMutableGeoParquetControl().renderer);
+  }
+
+  setTimeout(() => {
+    showGeoParquetControl(geoparquetControl);
+    geoparquetControl?.expand();
+    patchGeoParquetRenderer(getMutableGeoParquetControl().renderer);
+  }, 0);
+  return true;
+}
+
+function getGeoParquetConstructors(): Promise<{
+  GeoParquetControl: GeoParquetControlConstructor;
+}> {
+  geoparquetConstructorsPromise ??= import("maplibre-gl-geoparquet").then(
+    ({ GeoParquetControl: GeoParquetControlClass }) => ({
+      GeoParquetControl: GeoParquetControlClass,
+    }),
+  );
+  return geoparquetConstructorsPromise;
+}
+
+function createGeoParquetControl(
+  GeoParquetControlClass: GeoParquetControlConstructor,
+): GeoParquetControl {
+  const control = new GeoParquetControlClass(GEOPARQUET_OPTIONS);
+  control.on("collapse", () => hideGeoParquetControl(control));
+  control.on("load", createGeoParquetStateChangeHandler(control));
+  control.on("statechange", createGeoParquetStateChangeHandler(control));
+
+  geoparquetStoreUnsubscribe ??= useAppStore.subscribe((state, previous) => {
+    const currentById = new Map(state.layers.map((layer) => [layer.id, layer]));
+
+    for (const layer of previous.layers) {
+      if (!isGeoParquetControlLayer(layer)) continue;
+
+      const currentLayer = currentById.get(layer.id);
+      if (!currentLayer) {
+        geoparquetControl?.removeLayer(layer.id);
+        geoparquetRenderedStyles.delete(layer.id);
+        continue;
+      }
+
+      if (!isGeoParquetControlLayer(currentLayer)) continue;
+
+      if (
+        currentLayer.visible !== layer.visible ||
+        currentLayer.opacity !== layer.opacity ||
+        currentLayer.style !== layer.style ||
+        currentLayer.beforeId !== layer.beforeId ||
+        currentLayer.name !== layer.name
+      ) {
+        syncGeoParquetControlFromStore(state.layers);
+      }
+    }
+
+    if (geoparquetLayerOrderSignature(state.layers) !==
+      geoparquetLayerOrderSignature(previous.layers)) {
+      syncGeoParquetControlFromStore(state.layers);
+    }
+  });
+
+  return control;
+}
+
+function createGeoParquetStateChangeHandler(
+  control: GeoParquetControl,
+): GeoParquetControlEventHandler {
+  return (event) => {
+    patchGeoParquetRenderer(getMutableGeoParquetControl(control).renderer);
+
+    const store = useAppStore.getState();
+    const controlLayerIds = new Set(
+      event.state.layers.map((layer) => layer.id),
+    );
+
+    for (const existingLayer of store.layers) {
+      if (!isGeoParquetControlLayer(existingLayer)) continue;
+      if (!controlLayerIds.has(existingLayer.id)) {
+        store.removeLayer(existingLayer.id);
+      }
+    }
+
+    for (const layerState of event.state.layers) {
+      const existingLayer = store.layers.find(
+        (layer) => layer.id === layerState.id,
+      );
+      const layer = createGeoParquetStoreLayer(layerState, existingLayer);
+      geoparquetRenderedStyles.set(layer.id, {
+        opacity: layer.opacity,
+        style: layer.style,
+        visible: layer.visible,
+      });
+
+      if (existingLayer) {
+        const patch = createGeoParquetLayerPatch(existingLayer, layer);
+        if (patch) store.updateLayer(layer.id, patch);
+        continue;
+      }
+
+      store.addLayer(layer);
+    }
+
+    syncGeoParquetControlFromStore(useAppStore.getState().layers);
+  };
+}
+
+function createGeoParquetStoreLayer(
+  layerState: GeoParquetLayerState,
+  existingLayer?: GeoLibreLayer,
+): GeoLibreLayer {
+  const bounds = getGeoParquetLayerBounds(layerState);
+  const geometryTypes = getGeoParquetGeometryTypes(layerState);
+  const sourcePath = layerState.displaySource || layerState.source;
+
+  return {
+    id: layerState.id,
+    name: layerState.name || layerNameFromUrl(sourcePath, layerState.id),
+    type: "geoparquet",
+    source: {
+      bounds,
+      displaySource: layerState.displaySource,
+      sourceId: layerState.id,
+      type: "geoparquet",
+      url: layerState.source,
+    },
+    visible: existingLayer?.visible ?? true,
+    opacity: existingLayer?.opacity ?? 1,
+    style: existingLayer?.style ?? { ...DEFAULT_LAYER_STYLE },
+    beforeId: existingLayer?.beforeId ?? layerState.beforeId ?? undefined,
+    metadata: {
+      bounds,
+      columns: layerState.schema,
+      customLayerType: getGeoParquetCustomLayerType(geometryTypes),
+      deckLayerId: layerState.id,
+      externalDeckLayer: true,
+      fileInfo: layerState.metadata?.fileInfo ?? null,
+      geoMetadata: layerState.metadata?.geoMetadata ?? null,
+      geometryTypes,
+      identifiable: false,
+      loadedRows: layerState.loadedRows,
+      pageSize: layerState.pageSize,
+      primaryGeoColumn: layerState.primaryGeoColumn,
+      selectedColumns: layerState.selectedColumns,
+      sourceId: layerState.id,
+      sourceKind: "geoparquet-url",
+      totalRows: layerState.totalRows,
+    },
+    sourcePath,
+  };
+}
+
+function createGeoParquetLayerPatch(
+  existingLayer: GeoLibreLayer,
+  nextLayer: GeoLibreLayer,
+): Partial<GeoLibreLayer> | null {
+  const patch: Partial<GeoLibreLayer> = {};
+
+  if (existingLayer.name !== nextLayer.name) patch.name = nextLayer.name;
+  if (existingLayer.beforeId !== nextLayer.beforeId) {
+    patch.beforeId = nextLayer.beforeId;
+  }
+  if (!shallowEqualRecord(existingLayer.source, nextLayer.source)) {
+    patch.source = nextLayer.source;
+  }
+  if (!shallowEqualRecord(existingLayer.metadata, nextLayer.metadata)) {
+    patch.metadata = nextLayer.metadata;
+  }
+  if (existingLayer.sourcePath !== nextLayer.sourcePath) {
+    patch.sourcePath = nextLayer.sourcePath;
+  }
+
+  return Object.keys(patch).length > 0 ? patch : null;
+}
+
+function syncGeoParquetControlFromStore(layers: GeoLibreLayer[]): void {
+  const mutableControl = getMutableGeoParquetControl();
+  const controlLayers = mutableControl.layers;
+  if (!controlLayers) return;
+
+  const storeLayerById = new Map(layers.map((layer) => [layer.id, layer]));
+  const storeOrder = new Map(layers.map((layer, index) => [layer.id, index]));
+
+  controlLayers.sort(
+    (a, b) =>
+      (storeOrder.get(a.id) ?? Number.MAX_SAFE_INTEGER) -
+      (storeOrder.get(b.id) ?? Number.MAX_SAFE_INTEGER),
+  );
+
+  for (const controlLayer of controlLayers) {
+    const storeLayer = storeLayerById.get(controlLayer.id);
+    if (!storeLayer || !isGeoParquetControlLayer(storeLayer)) continue;
+    controlLayer.name = storeLayer.name;
+    controlLayer.beforeId = storeLayer.beforeId ?? null;
+    geoparquetRenderedStyles.set(storeLayer.id, {
+      opacity: storeLayer.opacity,
+      style: storeLayer.style,
+      visible: storeLayer.visible,
+    });
+  }
+
+  patchGeoParquetRenderer(mutableControl.renderer);
+  mutableControl.renderAllLayers?.();
+}
+
+function patchGeoParquetRenderer(
+  renderer: GeoParquetRendererLike | null | undefined,
+): void {
+  if (!renderer?.createLayers || renderer.__geolibreStylePatched) return;
+
+  renderer.__geolibreOriginalCreateLayers = renderer.createLayers.bind(
+    renderer,
+  );
+  renderer.createLayers = (
+    layerId: string,
+    result: GeoParquetResultLike,
+    index: number,
+  ) => {
+    const renderedStyle = geoparquetRenderedStyles.get(layerId);
+    if (renderedStyle && !renderedStyle.visible) return [];
+
+    const originalLayers = renderer.__geolibreOriginalCreateLayers?.(
+      layerId,
+      result,
+      index,
+    );
+    if (!originalLayers || !renderedStyle) return originalLayers ?? [];
+
+    return originalLayers.map((deckLayer) =>
+      cloneStyledDeckLayer(layerId, deckLayer, result.geometryType, renderedStyle),
+    );
+  };
+  renderer.__geolibreStylePatched = true;
+}
+
+function cloneStyledDeckLayer(
+  layerId: string,
+  deckLayer: StyledDeckLayerLike,
+  geometryType: string | undefined,
+  renderedStyle: GeoParquetRenderedStyle,
+): StyledDeckLayerLike {
+  if (!deckLayer.clone) return deckLayer;
+
+  const { style, opacity } = renderedStyle;
+  const fillColor = colorToRgba(
+    style.fillColor,
+    opacity * style.fillOpacity,
+  );
+  const strokeColor = colorToRgba(style.strokeColor, opacity);
+  const geometry = geometryType?.toLowerCase() ?? "";
+
+  if (geometry.includes("point")) {
+    return deckLayer.clone({
+      getFillColor: fillColor,
+      getRadius: style.circleRadius,
+      radiusMaxPixels: Math.max(style.circleRadius * 2, style.circleRadius),
+      radiusMinPixels: Math.max(1, Math.min(style.circleRadius, 4)),
+      updateTriggers: {
+        ...asRecord(deckLayer.props?.updateTriggers),
+        getFillColor: [style.fillColor, style.fillOpacity, opacity],
+        getRadius: [style.circleRadius],
+      },
+    });
+  }
+
+  if (geometry.includes("line")) {
+    return deckLayer.clone({
+      getColor: strokeColor,
+      getWidth: style.strokeWidth,
+      widthMinPixels: Math.max(1, style.strokeWidth),
+      updateTriggers: {
+        ...asRecord(deckLayer.props?.updateTriggers),
+        getColor: [style.strokeColor, opacity],
+        getWidth: [style.strokeWidth],
+      },
+    });
+  }
+
+  return deckLayer.clone({
+    elevationScale: style.extrusionHeightScale,
+    extruded: style.extrusionEnabled,
+    getElevation: createGeoParquetElevationAccessor(layerId, renderedStyle),
+    getFillColor: fillColor,
+    getLineColor: strokeColor,
+    getLineWidth: style.strokeWidth,
+    lineWidthMinPixels: Math.max(1, style.strokeWidth),
+    updateTriggers: {
+      ...asRecord(deckLayer.props?.updateTriggers),
+      getElevation: [
+        style.extrusionBase,
+        style.extrusionHeightProperty,
+        style.extrusionHeightScale,
+      ],
+      getFillColor: [style.fillColor, style.fillOpacity, opacity],
+      getLineColor: [style.strokeColor, opacity],
+      getLineWidth: [style.strokeWidth],
+    },
+  });
+}
+
+function createGeoParquetElevationAccessor(
+  layerId: string,
+  renderedStyle: GeoParquetRenderedStyle,
+) {
+  return (objectInfo: { index?: number; object?: Record<string, unknown> }): number => {
+    const { style } = renderedStyle;
+    const fallbackHeight = style.extrusionBase ?? 100;
+    const rowIndex = getGeoParquetRowIndex(objectInfo);
+    const rows = getGeoParquetRenderedRows(layerId);
+    const row = rowIndex === null ? undefined : rows[rowIndex];
+    const rawValue =
+      row && style.extrusionHeightProperty
+        ? row[style.extrusionHeightProperty]
+        : undefined;
+    const value = Number(rawValue);
+
+    if (!Number.isFinite(value)) return fallbackHeight;
+    return Math.max(0, value + style.extrusionBase);
+  };
+}
+
+function getGeoParquetRowIndex(objectInfo: {
+  index?: number;
+  object?: Record<string, unknown>;
+}): number | null {
+  const rawIndex = objectInfo.object?.__index;
+  if (typeof rawIndex === "number" && Number.isFinite(rawIndex)) {
+    return rawIndex;
+  }
+  if (typeof rawIndex === "bigint") {
+    return rawIndex <= BigInt(Number.MAX_SAFE_INTEGER)
+      ? Number(rawIndex)
+      : (objectInfo.index ?? null);
+  }
+  return typeof objectInfo.index === "number" ? objectInfo.index : null;
+}
+
+function getGeoParquetRenderedRows(
+  layerId: string,
+): Record<number, Record<string, unknown>> {
+  const controlLayer = getMutableGeoParquetControl().layers?.find(
+    (layer) => layer.id === layerId,
+  );
+  return controlLayer?.rows ?? {};
+}
+
+function getMutableGeoParquetControl(
+  control = geoparquetControl,
+): MutableGeoParquetControl {
+  return control as unknown as MutableGeoParquetControl;
+}
+
+function getGeoParquetLayerBounds(
+  layer: GeoParquetLayerState,
+): [number, number, number, number] | undefined {
+  const primaryColumn = layer.primaryGeoColumn;
+  const bounds =
+    primaryColumn && layer.metadata?.geoMetadata?.columns?.[primaryColumn]?.bbox;
+  if (isBounds(bounds)) return bounds;
+
+  const mutableLayer = getMutableGeoParquetControl().layers?.find(
+    (item) => item.id === layer.id,
+  );
+  return combineResultBounds(mutableLayer?.geoArrowResults);
+}
+
+function combineResultBounds(
+  results: GeoParquetResultLike[] | undefined,
+): [number, number, number, number] | undefined {
+  const bounds = (results ?? [])
+    .map((result) => result.bounds)
+    .filter(isBounds);
+  if (bounds.length === 0) return undefined;
+
+  return [
+    Math.min(...bounds.map((item) => item[0])),
+    Math.min(...bounds.map((item) => item[1])),
+    Math.max(...bounds.map((item) => item[2])),
+    Math.max(...bounds.map((item) => item[3])),
+  ];
+}
+
+function isBounds(value: unknown): value is [number, number, number, number] {
+  return (
+    Array.isArray(value) &&
+    value.length === 4 &&
+    value.every((item) => typeof item === "number" && Number.isFinite(item))
+  );
+}
+
+function getGeoParquetGeometryTypes(layer: GeoParquetLayerState): string[] {
+  const primaryColumn = layer.primaryGeoColumn;
+  const types =
+    primaryColumn &&
+    layer.metadata?.geoMetadata?.columns?.[primaryColumn]?.geometry_types;
+  if (Array.isArray(types) && types.length > 0) {
+    return types.filter((item): item is string => typeof item === "string");
+  }
+
+  const mutableLayer = getMutableGeoParquetControl().layers?.find(
+    (item) => item.id === layer.id,
+  );
+  return Array.from(
+    new Set(
+      (mutableLayer?.geoArrowResults ?? [])
+        .map((result) => result.geometryType)
+        .filter((item): item is string => typeof item === "string"),
+    ),
+  );
+}
+
+function getGeoParquetCustomLayerType(geometryTypes: string[]): string {
+  const normalized = geometryTypes.map((type) => type.toLowerCase());
+  if (normalized.some((type) => type.includes("point"))) return "circle";
+  if (normalized.some((type) => type.includes("line"))) return "line";
+  if (normalized.some((type) => type.includes("polygon"))) return "fill";
+  return "custom";
+}
+
+function geoparquetLayerOrderSignature(layers: GeoLibreLayer[]): string {
+  return layers
+    .filter(isGeoParquetControlLayer)
+    .map((layer) => layer.id)
+    .join("|");
+}
+
+function isGeoParquetControlLayer(layer: GeoLibreLayer): boolean {
+  return (
+    layer.type === "geoparquet" &&
+    layer.metadata.sourceKind === "geoparquet-url" &&
+    layer.metadata.externalDeckLayer === true
+  );
+}
+
+function layerNameFromUrl(url: string, fallback: string): string {
+  try {
+    const pathname = new URL(url).pathname;
+    const name = pathname.split("/").filter(Boolean).pop();
+    return name || fallback;
+  } catch {
+    return url.split("/").filter(Boolean).pop() || fallback;
+  }
+}
+
+function shallowEqualRecord(
+  first: Record<string, unknown>,
+  second: Record<string, unknown>,
+): boolean {
+  return JSON.stringify(first) === JSON.stringify(second);
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function colorToRgba(color: string, alpha: number): [number, number, number, number] {
+  const normalized = color.trim();
+  const hex =
+    normalized.length === 4 && normalized.startsWith("#")
+      ? `#${normalized[1]}${normalized[1]}${normalized[2]}${normalized[2]}${normalized[3]}${normalized[3]}`
+      : normalized;
+  const match = /^#([0-9a-f]{6})$/i.exec(hex);
+  if (!match) return [59, 130, 246, Math.round(clamp(alpha, 0, 1) * 255)];
+
+  const value = Number.parseInt(match[1], 16);
+  return [
+    (value >> 16) & 255,
+    (value >> 8) & 255,
+    value & 255,
+    Math.round(clamp(alpha, 0, 1) * 255),
+  ];
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function hideGeoParquetControl(control: GeoParquetControl | null): void {
+  const container = control?.getContainer();
+  if (container) container.style.display = "none";
+}
+
+function showGeoParquetControl(control: GeoParquetControl | null): void {
+  const container = control?.getContainer();
+  if (container) container.style.display = "";
+}


### PR DESCRIPTION
## Summary
- Add a GeoParquet layer type backed by `maplibre-gl-geoparquet`, rendered with deck.gl
- Wire an "Add GeoParquet Layer" entry into the Add Data menu and register the control
- Sync control layers with the app store so style, opacity, visibility, and ordering stay consistent with the layer panel, including 3D extrusion styling

## Test plan
- [ ] `pre-commit run --all-files` passes (build included)
- [ ] Add a GeoParquet layer from the Add Data menu and confirm it renders
- [ ] Toggle visibility, opacity, and ordering and confirm the map updates
- [ ] Adjust fill/stroke style and extrusion and confirm rendering reflects it