### PR TITLE
feat: load project from URL query parameter

### DIFF
--- a/apps/geolibre-desktop/src/App.tsx
+++ b/apps/geolibre-desktop/src/App.tsx
@@ -1,13 +1,16 @@
 import { DesktopShell } from "./components/layout/DesktopShell";
 import { usePlugins } from "./hooks/usePlugins";
+import { useProjectUrlLoader } from "./hooks/useProjectUrlLoader";
 import { useThemeMode } from "./hooks/useThemeMode";
 
 export default function App() {
   const { themeMode, toggleThemeMode } = useThemeMode();
+  const projectUrlLoadState = useProjectUrlLoader();
 
   usePlugins();
   return (
     <DesktopShell
+      projectUrlLoadState={projectUrlLoadState}
       themeMode={themeMode}
       onToggleThemeMode={toggleThemeMode}
     />

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -23,8 +23,10 @@ import { ProcessingDialog } from "../processing/ProcessingDialog";
 import { StatusBar } from "./StatusBar";
 import { TopToolbar } from "./TopToolbar";
 import type { ThemeMode } from "../../hooks/useThemeMode";
+import type { ProjectUrlLoadState } from "../../hooks/useProjectUrlLoader";
 
 interface DesktopShellProps {
+  projectUrlLoadState?: ProjectUrlLoadState;
   themeMode: ThemeMode;
   onToggleThemeMode: () => void;
 }
@@ -59,6 +61,7 @@ type ShellStyle = CSSProperties &
   Record<"--layer-panel-width" | "--style-panel-width", string>;
 
 export function DesktopShell({
+  projectUrlLoadState,
   themeMode,
   onToggleThemeMode,
 }: DesktopShellProps) {
@@ -410,6 +413,15 @@ export function DesktopShell({
           <div className="rounded-md border bg-background px-4 py-3 text-sm font-medium shadow-lg">
             Drop vector files to add layers
           </div>
+        </div>
+      ) : null}
+      {projectUrlLoadState?.message || projectUrlLoadState?.error ? (
+        <div
+          className={`pointer-events-none absolute left-1/2 top-14 z-50 max-w-[min(90vw,32rem)] -translate-x-1/2 rounded-md border bg-background px-3 py-2 text-center text-sm shadow-lg ${
+            projectUrlLoadState.error ? "text-destructive" : "text-foreground"
+          }`}
+        >
+          {projectUrlLoadState.error ?? projectUrlLoadState.message}
         </div>
       ) : null}
       {dropMessage || dropError ? (

--- a/apps/geolibre-desktop/src/hooks/useProjectUrlLoader.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectUrlLoader.ts
@@ -1,0 +1,121 @@
+import { parseProject, useAppStore } from "@geolibre/core";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+export type ProjectUrlLoadState =
+  | { error: null; message: null; status: "idle" }
+  | { error: null; message: string; status: "loading" | "loaded" }
+  | { error: string; message: null; status: "error" };
+
+const PROJECT_URL_PARAMS = ["url", "project", "projectUrl", "project_url"];
+
+export function useProjectUrlLoader(): ProjectUrlLoadState {
+  const loadProject = useAppStore((state) => state.loadProject);
+  const projectUrl = useMemo(() => projectUrlFromLocation(), []);
+  const clearMessageTimeoutRef = useRef<number | null>(null);
+  const [state, setState] = useState<ProjectUrlLoadState>({
+    error: null,
+    message: null,
+    status: "idle",
+  });
+
+  useEffect(() => {
+    if (!projectUrl) return;
+
+    const abortController = new AbortController();
+    setState({
+      error: null,
+      message: "Loading project from URL...",
+      status: "loading",
+    });
+
+    void loadProjectFromUrl(projectUrl, abortController.signal)
+      .then((project) => {
+        loadProject(project, projectUrl);
+        setState({
+          error: null,
+          message: `Loaded ${project.name}`,
+          status: "loaded",
+        });
+        clearMessageTimeoutRef.current = window.setTimeout(() => {
+          clearMessageTimeoutRef.current = null;
+          setState({ error: null, message: null, status: "idle" });
+        }, 4000);
+      })
+      .catch((error: unknown) => {
+        if (abortController.signal.aborted) return;
+        setState({
+          error:
+            error instanceof Error
+              ? error.message
+              : "Could not load the project URL.",
+          message: null,
+          status: "error",
+        });
+      });
+
+    return () => {
+      abortController.abort();
+      if (clearMessageTimeoutRef.current !== null) {
+        window.clearTimeout(clearMessageTimeoutRef.current);
+        clearMessageTimeoutRef.current = null;
+      }
+    };
+  }, [loadProject, projectUrl]);
+
+  return state;
+}
+
+async function loadProjectFromUrl(projectUrl: string, signal: AbortSignal) {
+  const response = await fetch(projectUrl, {
+    headers: { Accept: "application/json, text/plain;q=0.9, */*;q=0.8" },
+    signal,
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Could not load project URL: HTTP ${response.status} ${response.statusText}`,
+    );
+  }
+
+  return parseProject(await response.text());
+}
+
+function projectUrlFromLocation(): string | null {
+  if (typeof window === "undefined") return null;
+
+  const search = window.location.search;
+  const params = new URLSearchParams(search);
+  for (const key of PROJECT_URL_PARAMS) {
+    const value = params.get(key);
+    const url = normalizeProjectUrl(value);
+    if (url) return url;
+  }
+
+  const bareQuery = search.startsWith("?")
+    ? safeDecodeURIComponent(search.slice(1)).trim()
+    : "";
+  return /^https?:\/\//i.test(bareQuery)
+    ? normalizeProjectUrl(bareQuery)
+    : null;
+}
+
+function normalizeProjectUrl(value: string | null): string | null {
+  if (!value?.trim()) return null;
+
+  try {
+    const url = new URL(value.trim(), window.location.href);
+    return url.protocol === "http:" || url.protocol === "https:"
+      ? url.href
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function safeDecodeURIComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -93,6 +93,49 @@ function wmsProxyPlugin(): Plugin {
   };
 }
 
+function projectUrlQueryPlugin(): Plugin {
+  return {
+    name: "geolibre-project-url-query",
+    configureServer(server) {
+      server.middlewares.use((req, _res, next) => {
+        if (isProjectUrlDocumentRequest(req)) {
+          const requestUrl = new URL(req.url ?? "/", "http://localhost");
+          req.url = requestUrl.pathname;
+        }
+        next();
+      });
+    },
+  };
+}
+
+function isProjectUrlDocumentRequest(req: IncomingMessage): boolean {
+  if (req.method !== "GET" && req.method !== "HEAD") return false;
+
+  const accept = req.headers.accept ?? "";
+  if (!accept.includes("text/html") && accept !== "*/*") return false;
+
+  const requestUrl = new URL(req.url ?? "/", "http://localhost");
+  if (requestUrl.pathname !== "/" && requestUrl.pathname !== "/index.html") {
+    return false;
+  }
+
+  return (
+    requestUrl.searchParams.has("url") ||
+    requestUrl.searchParams.has("project") ||
+    requestUrl.searchParams.has("projectUrl") ||
+    requestUrl.searchParams.has("project_url") ||
+    /^https?:\/\//i.test(safeDecodeURIComponent(requestUrl.search.slice(1)))
+  );
+}
+
+function safeDecodeURIComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
 async function proxyWmsRequest(
   req: IncomingMessage,
   res: ServerResponse,
@@ -136,7 +179,7 @@ async function proxyBinaryRequest(
 
 export default defineConfig({
   base: APP_BASE,
-  plugins: [react(), wmsProxyPlugin()],
+  plugins: [projectUrlQueryPlugin(), react(), wmsProxyPlugin()],
   clearScreen: false,
   define: {
     __GEOLIBRE_VERSION__: JSON.stringify(APP_VERSION),


### PR DESCRIPTION
## Summary
- Add a `useProjectUrlLoader` hook that opens a project directly from a shareable link, reading `url`, `project`, `projectUrl`, `project_url`, or a bare `https://` query parameter and loading it into the app store.
- Show a status banner in `DesktopShell` for loading, loaded, and error states.
- Add a dev-server middleware in `vite.config.ts` that strips the query before serving `index.html` so the SPA still resolves on first load while preserving the original query for the hook to read.

## Test plan
- [ ] Run the desktop app and open it with `?url=<project-json-url>` and confirm the project loads with a "Loading project from URL..." then "Loaded <name>" banner.
- [ ] Open with an invalid or unreachable URL and confirm the error banner appears.
- [ ] Open the app with no query parameters and confirm normal startup is unaffected.