### PR TITLE
feat: add Search places panel from Controls menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ manager.registerAll([
 
 Plugins can use the app API to change basemaps, add GeoJSON layers, or attach MapLibre controls. For a MapLibre control plugin, add the package dependency, import its CSS in `apps/geolibre-desktop/src/main.tsx`, then call `app.addMapControl(control, "top-left")` in `activate()` and `app.removeMapControl(control)` in `deactivate()`.
 
-Built-in MapLibre controls such as Navigation, Fullscreen, Geolocate, Globe, Terrain, Scale, Attribution, and Logo are toggled from the desktop app's Controls menu. Keep project-specific controls such as Layer Control and Components in the plugin menu when they use the plugin API or need plugin lifecycle behavior.
+Built-in MapLibre controls such as Navigation, Fullscreen, Geolocate, Globe, Terrain, Scale, Attribution, and Logo are toggled from the desktop app's Controls menu. The same menu also opens Search, a standalone place search panel backed by the Components plugin. Keep project-specific controls such as Layer Control and Components in the plugin menu when they use the plugin API or need plugin lifecycle behavior.
 
 The v0.5.0 Components plugin wraps `maplibre-gl-components` controls and wires their layer events into the GeoLibre store. It provides Add Data shortcuts for FlatGeobuf, PMTiles, Zarr, LiDAR, and Gaussian splats, while raster COG and GeoTIFF layers can also be added through the standard Add Raster Layer dialog.
 

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -9,15 +9,18 @@ import {
   type MapController,
 } from "@geolibre/map";
 import {
+  closeSearchPlacesPanel,
   openFlatGeobufAddVectorLayerPanel,
   openDuckDBLayerPanel,
   openGeoParquetLayerPanel,
+  isSearchPlacesPanelVisible,
   openLidarLayerPanel,
   openPMTilesLayerPanel,
   openSearchPlacesPanel,
   openSplattingLayerPanel,
   openStacSearchLayerPanel,
   openZarrLayerPanel,
+  subscribeSearchPlacesPanel,
   type GeoLibreMapControlPosition,
 } from "@geolibre/plugins";
 import {
@@ -47,7 +50,7 @@ import {
   Sun,
   Wrench,
 } from "lucide-react";
-import { useState } from "react";
+import { useState, useSyncExternalStore } from "react";
 import { createAppAPI, usePluginRegistry } from "../../hooks/usePlugins";
 import type { ThemeMode } from "../../hooks/useThemeMode";
 import { openProjectFile, saveProjectFile } from "../../lib/tauri-io";
@@ -163,7 +166,16 @@ export function TopToolbar({
   const handleAddStacLayer = () => {
     openStacSearchLayerPanel(appApi);
   };
-  const handleSearchPlaces = () => {
+  const searchPlacesVisible = useSyncExternalStore(
+    subscribeSearchPlacesPanel,
+    isSearchPlacesPanelVisible,
+    isSearchPlacesPanelVisible,
+  );
+  const handleToggleSearchPlaces = () => {
+    if (searchPlacesVisible) {
+      closeSearchPlacesPanel();
+      return;
+    }
     openSearchPlacesPanel(appApi);
   };
   const handleAddZarrLayer = () => {
@@ -283,8 +295,9 @@ export function TopToolbar({
             </DropdownMenuItem>
           ))}
           <DropdownMenuSeparator />
-          <DropdownMenuItem onSelect={handleSearchPlaces}>
+          <DropdownMenuItem onSelect={handleToggleSearchPlaces}>
             Search
+            {searchPlacesVisible ? " ✓" : ""}
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -14,6 +14,7 @@ import {
   openGeoParquetLayerPanel,
   openLidarLayerPanel,
   openPMTilesLayerPanel,
+  openSearchPlacesPanel,
   openSplattingLayerPanel,
   openStacSearchLayerPanel,
   openZarrLayerPanel,
@@ -162,6 +163,9 @@ export function TopToolbar({
   const handleAddStacLayer = () => {
     openStacSearchLayerPanel(appApi);
   };
+  const handleSearchPlaces = () => {
+    openSearchPlacesPanel(appApi);
+  };
   const handleAddZarrLayer = () => {
     openZarrLayerPanel(appApi);
   };
@@ -278,6 +282,10 @@ export function TopToolbar({
               {controlsVisible[control.id] ? " ✓" : ""}
             </DropdownMenuItem>
           ))}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={handleSearchPlaces}>
+            Search
+          </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
       <DropdownMenu>

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -697,6 +697,98 @@ body,
   accent-color: hsl(var(--primary));
 }
 
+.geolibre-search-control {
+  background-color: hsl(var(--card)) !important;
+  box-shadow: 0 12px 32px rgb(0 0 0 / 0.28);
+  color: hsl(var(--foreground)) !important;
+  max-width: min(320px, calc(100vw - 32px));
+  overflow: visible;
+  position: relative;
+  z-index: 3;
+}
+
+.geolibre-search-control .maplibre-gl-search-input-wrapper {
+  background-color: hsl(var(--card)) !important;
+  border-bottom: 1px solid hsl(var(--border)) !important;
+  box-sizing: border-box;
+  width: 100% !important;
+}
+
+.geolibre-search-control .maplibre-gl-search-input {
+  background-color: hsl(var(--card)) !important;
+  caret-color: hsl(var(--foreground));
+  color: hsl(var(--foreground)) !important;
+}
+
+.geolibre-search-control .maplibre-gl-search-input::placeholder {
+  color: hsl(var(--foreground)) !important;
+  opacity: 0.82;
+}
+
+.geolibre-search-control .maplibre-gl-search-input:focus {
+  outline: none;
+}
+
+.geolibre-search-control .maplibre-gl-search-toggle {
+  background: #fff !important;
+  border-radius: 4px;
+  color: #333 !important;
+  height: 29px !important;
+  opacity: 1;
+  width: 29px !important;
+}
+
+.geolibre-search-control .maplibre-gl-search-toggle svg {
+  height: 16px;
+  width: 16px;
+}
+
+.geolibre-search-control .maplibre-gl-search-toggle:hover {
+  background: #f2f2f2 !important;
+  color: #000 !important;
+  opacity: 1;
+}
+
+.geolibre-search-control .maplibre-gl-search-icon,
+.geolibre-search-control .maplibre-gl-search-clear,
+.geolibre-search-control .maplibre-gl-search-collapse {
+  color: hsl(var(--foreground)) !important;
+  opacity: 0.84;
+}
+
+.geolibre-search-control .maplibre-gl-search-clear:hover,
+.geolibre-search-control .maplibre-gl-search-collapse:hover {
+  color: hsl(var(--foreground)) !important;
+  opacity: 1;
+}
+
+.geolibre-search-control .maplibre-gl-search-results {
+  background-color: hsl(var(--card)) !important;
+  border: 1px solid hsl(var(--border));
+  border-top: 0;
+  color: hsl(var(--foreground)) !important;
+  max-width: min(320px, calc(100vw - 32px));
+}
+
+.geolibre-search-control .maplibre-gl-search-result {
+  border-bottom-color: hsl(var(--border)) !important;
+  color: hsl(var(--foreground)) !important;
+}
+
+.geolibre-search-control .maplibre-gl-search-result:hover {
+  background-color: hsl(var(--accent)) !important;
+  color: hsl(var(--accent-foreground)) !important;
+}
+
+.geolibre-search-control .maplibre-gl-search-result:hover * {
+  color: hsl(var(--accent-foreground)) !important;
+}
+
+.geolibre-search-control .maplibre-gl-search-result-detail {
+  color: hsl(var(--foreground)) !important;
+  opacity: 0.78;
+}
+
 .geolibre-stac-search-control {
   background-color: hsl(var(--popover)) !important;
   color: hsl(var(--popover-foreground)) !important;

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -698,9 +698,9 @@ body,
 }
 
 .geolibre-search-control {
-  background-color: hsl(var(--card)) !important;
+  background-color: #fff !important;
   box-shadow: 0 12px 32px rgb(0 0 0 / 0.28);
-  color: hsl(var(--foreground)) !important;
+  color: #333 !important;
   max-width: min(320px, calc(100vw - 32px));
   overflow: visible;
   position: relative;
@@ -708,21 +708,21 @@ body,
 }
 
 .geolibre-search-control .maplibre-gl-search-input-wrapper {
-  background-color: hsl(var(--card)) !important;
-  border-bottom: 1px solid hsl(var(--border)) !important;
+  background-color: #fff !important;
+  border-bottom: 1px solid #d9d9d9 !important;
   box-sizing: border-box;
   width: 100% !important;
 }
 
 .geolibre-search-control .maplibre-gl-search-input {
-  background-color: hsl(var(--card)) !important;
-  caret-color: hsl(var(--foreground));
-  color: hsl(var(--foreground)) !important;
+  background-color: #fff !important;
+  caret-color: #111;
+  color: #111 !important;
 }
 
 .geolibre-search-control .maplibre-gl-search-input::placeholder {
-  color: hsl(var(--foreground)) !important;
-  opacity: 0.82;
+  color: #333 !important;
+  opacity: 1;
 }
 
 .geolibre-search-control .maplibre-gl-search-input:focus {
@@ -752,41 +752,41 @@ body,
 .geolibre-search-control .maplibre-gl-search-icon,
 .geolibre-search-control .maplibre-gl-search-clear,
 .geolibre-search-control .maplibre-gl-search-collapse {
-  color: hsl(var(--foreground)) !important;
-  opacity: 0.84;
+  color: #333 !important;
+  opacity: 1;
 }
 
 .geolibre-search-control .maplibre-gl-search-clear:hover,
 .geolibre-search-control .maplibre-gl-search-collapse:hover {
-  color: hsl(var(--foreground)) !important;
+  color: #000 !important;
   opacity: 1;
 }
 
 .geolibre-search-control .maplibre-gl-search-results {
-  background-color: hsl(var(--card)) !important;
-  border: 1px solid hsl(var(--border));
+  background-color: #fff !important;
+  border: 1px solid #d9d9d9;
   border-top: 0;
-  color: hsl(var(--foreground)) !important;
+  color: #111 !important;
   max-width: min(320px, calc(100vw - 32px));
 }
 
 .geolibre-search-control .maplibre-gl-search-result {
-  border-bottom-color: hsl(var(--border)) !important;
-  color: hsl(var(--foreground)) !important;
+  border-bottom-color: #e5e5e5 !important;
+  color: #111 !important;
 }
 
 .geolibre-search-control .maplibre-gl-search-result:hover {
-  background-color: hsl(var(--accent)) !important;
-  color: hsl(var(--accent-foreground)) !important;
+  background-color: #f2f2f2 !important;
+  color: #000 !important;
 }
 
 .geolibre-search-control .maplibre-gl-search-result:hover * {
-  color: hsl(var(--accent-foreground)) !important;
+  color: #000 !important;
 }
 
 .geolibre-search-control .maplibre-gl-search-result-detail {
-  color: hsl(var(--foreground)) !important;
-  opacity: 0.78;
+  color: #555 !important;
+  opacity: 1;
 }
 
 .geolibre-stac-search-control {

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -698,9 +698,9 @@ body,
 }
 
 .geolibre-search-control {
-  background-color: #fff !important;
+  background-color: hsl(var(--card)) !important;
   box-shadow: 0 12px 32px rgb(0 0 0 / 0.28);
-  color: #333 !important;
+  color: hsl(var(--foreground)) !important;
   max-width: min(320px, calc(100vw - 32px));
   overflow: visible;
   position: relative;
@@ -708,20 +708,20 @@ body,
 }
 
 .geolibre-search-control .maplibre-gl-search-input-wrapper {
-  background-color: #fff !important;
-  border-bottom: 1px solid #d9d9d9 !important;
+  background-color: hsl(var(--card)) !important;
+  border-bottom: 1px solid hsl(var(--border)) !important;
   box-sizing: border-box;
   width: 100% !important;
 }
 
 .geolibre-search-control .maplibre-gl-search-input {
-  background-color: #fff !important;
-  caret-color: #111;
-  color: #111 !important;
+  background-color: hsl(var(--card)) !important;
+  caret-color: hsl(var(--foreground));
+  color: hsl(var(--foreground)) !important;
 }
 
 .geolibre-search-control .maplibre-gl-search-input::placeholder {
-  color: #333 !important;
+  color: hsl(var(--foreground)) !important;
   opacity: 1;
 }
 
@@ -730,9 +730,9 @@ body,
 }
 
 .geolibre-search-control .maplibre-gl-search-toggle {
-  background: #fff !important;
+  background: hsl(var(--card)) !important;
   border-radius: 4px;
-  color: #333 !important;
+  color: hsl(var(--foreground)) !important;
   height: 29px !important;
   opacity: 1;
   width: 29px !important;
@@ -744,48 +744,48 @@ body,
 }
 
 .geolibre-search-control .maplibre-gl-search-toggle:hover {
-  background: #f2f2f2 !important;
-  color: #000 !important;
+  background: hsl(var(--accent)) !important;
+  color: hsl(var(--accent-foreground)) !important;
   opacity: 1;
 }
 
 .geolibre-search-control .maplibre-gl-search-icon,
 .geolibre-search-control .maplibre-gl-search-clear,
 .geolibre-search-control .maplibre-gl-search-collapse {
-  color: #333 !important;
+  color: hsl(var(--foreground)) !important;
   opacity: 1;
 }
 
 .geolibre-search-control .maplibre-gl-search-clear:hover,
 .geolibre-search-control .maplibre-gl-search-collapse:hover {
-  color: #000 !important;
+  color: hsl(var(--accent-foreground)) !important;
   opacity: 1;
 }
 
 .geolibre-search-control .maplibre-gl-search-results {
-  background-color: #fff !important;
-  border: 1px solid #d9d9d9;
+  background-color: hsl(var(--card)) !important;
+  border: 1px solid hsl(var(--border));
   border-top: 0;
-  color: #111 !important;
+  color: hsl(var(--foreground)) !important;
   max-width: min(320px, calc(100vw - 32px));
 }
 
 .geolibre-search-control .maplibre-gl-search-result {
-  border-bottom-color: #e5e5e5 !important;
-  color: #111 !important;
+  border-bottom-color: hsl(var(--border)) !important;
+  color: hsl(var(--foreground)) !important;
 }
 
 .geolibre-search-control .maplibre-gl-search-result:hover {
-  background-color: #f2f2f2 !important;
-  color: #000 !important;
+  background-color: hsl(var(--accent)) !important;
+  color: hsl(var(--accent-foreground)) !important;
 }
 
 .geolibre-search-control .maplibre-gl-search-result:hover * {
-  color: #000 !important;
+  color: hsl(var(--accent-foreground)) !important;
 }
 
 .geolibre-search-control .maplibre-gl-search-result-detail {
-  color: #555 !important;
+  color: hsl(var(--muted-foreground)) !important;
   opacity: 1;
 }
 

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -698,9 +698,9 @@ body,
 }
 
 .geolibre-search-control {
-  background-color: hsl(var(--card)) !important;
+  background-color: #fff !important;
   box-shadow: 0 12px 32px rgb(0 0 0 / 0.28);
-  color: hsl(var(--foreground)) !important;
+  color: #333 !important;
   max-width: min(320px, calc(100vw - 32px));
   overflow: visible;
   position: relative;
@@ -708,20 +708,20 @@ body,
 }
 
 .geolibre-search-control .maplibre-gl-search-input-wrapper {
-  background-color: hsl(var(--card)) !important;
-  border-bottom: 1px solid hsl(var(--border)) !important;
+  background-color: #fff !important;
+  border-bottom: 1px solid #d9d9d9 !important;
   box-sizing: border-box;
   width: 100% !important;
 }
 
 .geolibre-search-control .maplibre-gl-search-input {
-  background-color: hsl(var(--card)) !important;
-  caret-color: hsl(var(--foreground));
-  color: hsl(var(--foreground)) !important;
+  background-color: #fff !important;
+  caret-color: #111;
+  color: #111 !important;
 }
 
 .geolibre-search-control .maplibre-gl-search-input::placeholder {
-  color: hsl(var(--foreground)) !important;
+  color: #333 !important;
   opacity: 1;
 }
 
@@ -730,9 +730,9 @@ body,
 }
 
 .geolibre-search-control .maplibre-gl-search-toggle {
-  background: hsl(var(--card)) !important;
+  background: #fff !important;
   border-radius: 4px;
-  color: hsl(var(--foreground)) !important;
+  color: #333 !important;
   height: 29px !important;
   opacity: 1;
   width: 29px !important;
@@ -744,48 +744,48 @@ body,
 }
 
 .geolibre-search-control .maplibre-gl-search-toggle:hover {
-  background: hsl(var(--accent)) !important;
-  color: hsl(var(--accent-foreground)) !important;
+  background: #f2f2f2 !important;
+  color: #000 !important;
   opacity: 1;
 }
 
 .geolibre-search-control .maplibre-gl-search-icon,
 .geolibre-search-control .maplibre-gl-search-clear,
 .geolibre-search-control .maplibre-gl-search-collapse {
-  color: hsl(var(--foreground)) !important;
+  color: #333 !important;
   opacity: 1;
 }
 
 .geolibre-search-control .maplibre-gl-search-clear:hover,
 .geolibre-search-control .maplibre-gl-search-collapse:hover {
-  color: hsl(var(--accent-foreground)) !important;
+  color: #000 !important;
   opacity: 1;
 }
 
 .geolibre-search-control .maplibre-gl-search-results {
-  background-color: hsl(var(--card)) !important;
-  border: 1px solid hsl(var(--border));
+  background-color: #fff !important;
+  border: 1px solid #d9d9d9;
   border-top: 0;
-  color: hsl(var(--foreground)) !important;
+  color: #111 !important;
   max-width: min(320px, calc(100vw - 32px));
 }
 
 .geolibre-search-control .maplibre-gl-search-result {
-  border-bottom-color: hsl(var(--border)) !important;
-  color: hsl(var(--foreground)) !important;
+  border-bottom-color: #e5e5e5 !important;
+  color: #111 !important;
 }
 
 .geolibre-search-control .maplibre-gl-search-result:hover {
-  background-color: hsl(var(--accent)) !important;
-  color: hsl(var(--accent-foreground)) !important;
+  background-color: #f2f2f2 !important;
+  color: #000 !important;
 }
 
 .geolibre-search-control .maplibre-gl-search-result:hover * {
-  color: hsl(var(--accent-foreground)) !important;
+  color: #000 !important;
 }
 
 .geolibre-search-control .maplibre-gl-search-result-detail {
-  color: hsl(var(--muted-foreground)) !important;
+  color: #555 !important;
   opacity: 1;
 }
 

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -16,6 +16,7 @@ export {
   openFlatGeobufAddVectorLayerPanel,
   openLidarLayerPanel,
   openPMTilesLayerPanel,
+  openSearchPlacesPanel,
   openSplattingLayerPanel,
   openStacSearchLayerPanel,
   openZarrLayerPanel,

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -12,6 +12,8 @@ export {
 } from "./plugins/arcgis-layer";
 export {
   addCogRasterLayer,
+  closeSearchPlacesPanel,
+  isSearchPlacesPanelVisible,
   maplibreComponentsPlugin,
   openFlatGeobufAddVectorLayerPanel,
   openLidarLayerPanel,
@@ -20,6 +22,7 @@ export {
   openSplattingLayerPanel,
   openStacSearchLayerPanel,
   openZarrLayerPanel,
+  subscribeSearchPlacesPanel,
   type CogRasterLayerOptions,
 } from "./plugins/maplibre-components";
 export { openDuckDBLayerPanel } from "./plugins/maplibre-duckdb";

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -32,6 +32,8 @@ import type {
   PMTilesLayerControlOptions,
   PMTilesLayerEventHandler,
   PMTilesLayerInfo,
+  SearchControl,
+  SearchControlOptions,
   StacSearchControl,
   StacSearchControlOptions,
   StacSearchEventHandler,
@@ -59,6 +61,8 @@ type CogLayerControlConstructor =
   (typeof import("maplibre-gl-components"))["CogLayerControl"];
 type PMTilesLayerControlConstructor =
   (typeof import("maplibre-gl-components"))["PMTilesLayerControl"];
+type SearchControlConstructor =
+  (typeof import("maplibre-gl-components"))["SearchControl"];
 type StacSearchControlConstructor =
   (typeof import("maplibre-gl-components"))["StacSearchControl"];
 type ZarrLayerControlConstructor =
@@ -89,6 +93,7 @@ interface ComponentsConstructors {
   LidarControl: LidarControlConstructor;
   LidarLayerAdapter: LidarLayerAdapterConstructor;
   PMTilesLayerControl: PMTilesLayerControlConstructor;
+  SearchControl: SearchControlConstructor;
   StacSearchControl: StacSearchControlConstructor;
   ZarrLayerControl: ZarrLayerControlConstructor;
 }
@@ -97,6 +102,7 @@ let componentsControlPosition: GeoLibreMapControlPosition = "top-right";
 const cogRasterControlPosition: GeoLibreMapControlPosition = "top-left";
 const flatGeobufControlPosition: GeoLibreMapControlPosition = "top-left";
 const pmtilesControlPosition: GeoLibreMapControlPosition = "top-left";
+const searchControlPosition: GeoLibreMapControlPosition = "top-right";
 const stacSearchControlPosition: GeoLibreMapControlPosition = "top-left";
 const zarrControlPosition: GeoLibreMapControlPosition = "top-left";
 const lidarControlPosition: GeoLibreMapControlPosition = "top-left";
@@ -197,6 +203,16 @@ const PMTILES_OPTIONS = {
   defaultUrl: PMTILES_SAMPLE_URL,
   fontColor: "hsl(var(--popover-foreground))",
 } satisfies PMTilesLayerControlOptions;
+
+const SEARCH_OPTIONS = {
+  backgroundColor: "hsl(var(--popover))",
+  className: "geolibre-search-control",
+  collapsed: false,
+  fontColor: "hsl(var(--popover-foreground))",
+  maxResults: 8,
+  placeholder: "Search places...",
+  width: 320,
+} satisfies SearchControlOptions;
 
 const STAC_SEARCH_OPTIONS = {
   backgroundColor: "hsl(var(--popover))",
@@ -389,6 +405,7 @@ let componentsControl: ControlGrid | null = null;
 let cogRasterControl: CogLayerControl | null = null;
 let flatGeobufControl: AddVectorControl | null = null;
 let pmtilesControl: PMTilesLayerControl | null = null;
+let searchControl: SearchControl | null = null;
 let stacSearchControl: StacSearchControl | null = null;
 let zarrControl: ZarrLayerControl | null = null;
 let lidarControl: LidarControl | null = null;
@@ -400,6 +417,7 @@ let flatGeobufControlMounted = false;
 let cogRasterControlMounted = false;
 let geoTiffRasterOverlayMounted = false;
 let pmtilesControlMounted = false;
+let searchControlMounted = false;
 let stacSearchControlMounted = false;
 let zarrControlMounted = false;
 let lidarControlMounted = false;
@@ -623,6 +641,7 @@ const getComponentsConstructors = (): Promise<ComponentsConstructors> => {
       LidarControl: LidarControlClass,
       LidarLayerAdapter: LidarLayerAdapterClass,
       PMTilesLayerControl: PMTilesLayerControlClass,
+      SearchControl: SearchControlClass,
       StacSearchControl: StacSearchControlClass,
       ZarrLayerControl: ZarrLayerControlClass,
     }) => ({
@@ -634,6 +653,7 @@ const getComponentsConstructors = (): Promise<ComponentsConstructors> => {
       LidarControl: LidarControlClass,
       LidarLayerAdapter: LidarLayerAdapterClass,
       PMTilesLayerControl: PMTilesLayerControlClass,
+      SearchControl: SearchControlClass,
       StacSearchControl: StacSearchControlClass,
       ZarrLayerControl: ZarrLayerControlClass,
     }),
@@ -695,6 +715,7 @@ export const maplibreComponentsPlugin: GeoLibrePlugin = {
     teardownGeoTiffRasterOverlay(app);
     teardownFlatGeobufControl(app);
     teardownPMTilesControl(app);
+    teardownSearchControl(app);
     teardownStacSearchControl(app);
     teardownZarrControl(app);
     teardownLidarControl(app);
@@ -744,6 +765,10 @@ export async function addCogRasterLayer(
 
 export function openPMTilesLayerPanel(app: GeoLibreAppAPI): void {
   void openStandalonePMTilesControl(app);
+}
+
+export function openSearchPlacesPanel(app: GeoLibreAppAPI): void {
+  void openStandaloneSearchControl(app);
 }
 
 export function openStacSearchLayerPanel(app: GeoLibreAppAPI): void {
@@ -843,6 +868,29 @@ async function openStandalonePMTilesControl(
   setTimeout(() => {
     pmtilesControl?.show();
     pmtilesControl?.expand();
+  }, 0);
+  return true;
+}
+
+async function openStandaloneSearchControl(
+  app: GeoLibreAppAPI,
+): Promise<boolean> {
+  const { SearchControl: SearchControlClass } = await getComponentsConstructors();
+
+  searchControl ??= new SearchControlClass(SEARCH_OPTIONS);
+
+  if (!searchControlMounted) {
+    const added = app.addMapControl(searchControl, searchControlPosition);
+    if (!added) {
+      searchControl = null;
+      return false;
+    }
+    searchControlMounted = true;
+  }
+
+  setTimeout(() => {
+    searchControl?.show();
+    searchControl?.expand();
   }, 0);
   return true;
 }
@@ -1286,6 +1334,14 @@ function teardownPMTilesControl(app: GeoLibreAppAPI): void {
   }
   pmtilesControl = null;
   pmtilesControlMounted = false;
+}
+
+function teardownSearchControl(app: GeoLibreAppAPI): void {
+  if (searchControl && searchControlMounted) {
+    app.removeMapControl(searchControl);
+  }
+  searchControl = null;
+  searchControlMounted = false;
 }
 
 function teardownStacSearchControl(app: GeoLibreAppAPI): void {

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -434,6 +434,8 @@ let pluginActive = false;
 let componentsControlRevision = 0;
 let componentsConstructorsPromise: Promise<ComponentsConstructors> | null =
   null;
+let searchPlacesPanelVisible = false;
+const searchPlacesPanelListeners = new Set<() => void>();
 
 export interface CogRasterLayerOptions {
   url: string;
@@ -767,8 +769,25 @@ export function openPMTilesLayerPanel(app: GeoLibreAppAPI): void {
   void openStandalonePMTilesControl(app);
 }
 
+// The standalone Search panel is intentionally independent from the
+// ControlGrid search sub-control so it can be used from the Controls menu.
 export function openSearchPlacesPanel(app: GeoLibreAppAPI): void {
   void openStandaloneSearchControl(app);
+}
+
+export function closeSearchPlacesPanel(): void {
+  hideSearchControl();
+}
+
+export function isSearchPlacesPanelVisible(): boolean {
+  return searchPlacesPanelVisible;
+}
+
+export function subscribeSearchPlacesPanel(
+  listener: () => void,
+): () => void {
+  searchPlacesPanelListeners.add(listener);
+  return () => searchPlacesPanelListeners.delete(listener);
 }
 
 export function openStacSearchLayerPanel(app: GeoLibreAppAPI): void {
@@ -877,7 +896,7 @@ async function openStandaloneSearchControl(
 ): Promise<boolean> {
   const { SearchControl: SearchControlClass } = await getComponentsConstructors();
 
-  searchControl ??= new SearchControlClass(SEARCH_OPTIONS);
+  searchControl ??= createSearchControl(SearchControlClass);
 
   if (!searchControlMounted) {
     const added = app.addMapControl(searchControl, searchControlPosition);
@@ -891,6 +910,7 @@ async function openStandaloneSearchControl(
   setTimeout(() => {
     searchControl?.show();
     searchControl?.expand();
+    setSearchPlacesPanelVisible(true);
   }, 0);
   return true;
 }
@@ -1255,6 +1275,14 @@ function createPMTilesControl(
   return control;
 }
 
+function createSearchControl(
+  SearchControlClass: SearchControlConstructor,
+): SearchControl {
+  const control = new SearchControlClass(SEARCH_OPTIONS);
+  control.on("collapse", hideSearchControl);
+  return control;
+}
+
 function createStacSearchControl(
   StacSearchControlClass: StacSearchControlConstructor,
 ): StacSearchControl {
@@ -1342,6 +1370,7 @@ function teardownSearchControl(app: GeoLibreAppAPI): void {
   }
   searchControl = null;
   searchControlMounted = false;
+  setSearchPlacesPanelVisible(false);
 }
 
 function teardownStacSearchControl(app: GeoLibreAppAPI): void {
@@ -1352,6 +1381,19 @@ function teardownStacSearchControl(app: GeoLibreAppAPI): void {
   }
   stacSearchControl = null;
   stacSearchControlMounted = false;
+}
+
+function hideSearchControl(): void {
+  searchControl?.hide();
+  setSearchPlacesPanelVisible(false);
+}
+
+function setSearchPlacesPanelVisible(visible: boolean): void {
+  if (searchPlacesPanelVisible === visible) return;
+  searchPlacesPanelVisible = visible;
+  for (const listener of searchPlacesPanelListeners) {
+    listener();
+  }
 }
 
 function teardownZarrControl(app: GeoLibreAppAPI): void {


### PR DESCRIPTION
## Summary
- Add a standalone place search panel backed by the Components plugin, opened from the desktop app's Controls menu via a new Search item.
- Wire up `openSearchPlacesPanel` through the plugins package and the `SearchControl` lifecycle (mount, show/expand, teardown) in the MapLibre Components plugin.
- Add themed CSS so the search input and results match the GeoLibre UI in both light and dark modes.

## Test plan
- [ ] Open the desktop app and select Controls > Search.
- [ ] Confirm the search panel appears, expands, and accepts input.
- [ ] Search for a place and verify results render with correct theming and hover styles.
- [ ] Toggle the panel off and confirm the control is torn down cleanly.