### PR TITLE
feat: add PostgreSQL/PostGIS layers via Martin tile server

### DIFF
--- a/apps/geolibre-desktop/src-tauri/Cargo.lock
+++ b/apps/geolibre-desktop/src-tauri/Cargo.lock
@@ -60,6 +60,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,6 +699,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,6 +1006,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1258,11 +1288,13 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "tar",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-opener",
+ "zip",
 ]
 
 [[package]]
@@ -3647,6 +3679,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5400,6 +5443,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5564,10 +5617,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zvariant"

--- a/apps/geolibre-desktop/src-tauri/Cargo.toml
+++ b/apps/geolibre-desktop/src-tauri/Cargo.toml
@@ -19,6 +19,8 @@ tauri-plugin-fs = "2"
 tauri-plugin-opener = "2"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 flate2 = "1"
+tar = "0.4"
+zip = { version = "2", default-features = false, features = ["deflate"] }
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -7,12 +7,36 @@ use flate2::read::{GzDecoder, ZlibDecoder};
 use rusqlite::{params, Connection, OpenFlags, OptionalExtension};
 use serde::Serialize;
 use serde_json::Value;
-use std::io::Read;
-use std::path::Path;
+use std::fs::{self, File};
+use std::io::{Cursor, Read};
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+use std::thread;
+use std::time::Duration;
 use tauri::Manager;
 
 static POPUP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+const MARTIN_LATEST_BASE_URL: &str = "https://github.com/maplibre/martin/releases/latest/download";
+const MARTIN_CACHE_VERSION: &str = "latest";
+
+struct MartinServerState {
+    process: Mutex<Option<MartinProcess>>,
+}
+
+struct MartinProcess {
+    child: Child,
+}
+
+impl Drop for MartinProcess {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -23,11 +47,17 @@ pub fn run() {
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_opener::init())
         .manage(EarthEngineOAuthState::default())
+        .manage(MartinServerState {
+            process: Mutex::new(None),
+        })
         .invoke_handler(tauri::generate_handler![
             close_oauth_popups,
+            ensure_martin_binary,
             fetch_url_bytes,
             read_mbtiles_metadata,
             read_mbtiles_tile,
+            start_martin_server,
+            stop_martin_server,
             start_earth_engine_oauth,
             poll_earth_engine_oauth
         ])
@@ -67,6 +97,291 @@ fn fetch_url_bytes(url: String) -> Result<Vec<u8>, String> {
         .bytes()
         .map(|bytes| bytes.to_vec())
         .map_err(|error| format!("Could not read response body: {error}"))
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MartinBinaryInfo {
+    path: String,
+    downloaded: bool,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MartinServerInfo {
+    base_url: String,
+    binary_path: String,
+    port: u16,
+}
+
+#[tauri::command]
+fn ensure_martin_binary(app: tauri::AppHandle) -> Result<MartinBinaryInfo, String> {
+    ensure_martin_binary_path(&app)
+}
+
+#[tauri::command]
+fn start_martin_server(
+    app: tauri::AppHandle,
+    state: tauri::State<MartinServerState>,
+    connection_string: String,
+    default_srid: Option<String>,
+) -> Result<MartinServerInfo, String> {
+    if connection_string.trim().is_empty() {
+        return Err("Enter a PostgreSQL connection string.".to_string());
+    }
+
+    let binary = ensure_martin_binary_path(&app)?;
+    let port = reserve_local_port()?;
+    let listen_address = format!("127.0.0.1:{port}");
+    let base_url = format!("http://127.0.0.1:{port}");
+    let mut command = Command::new(&binary.path);
+    command
+        .arg("-l")
+        .arg(&listen_address)
+        .env("DATABASE_URL", connection_string.trim())
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    if let Some(default_srid) = default_srid
+        .as_ref()
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+    {
+        command.env("DEFAULT_SRID", default_srid);
+    }
+
+    let mut child = command
+        .spawn()
+        .map_err(|error| format!("Could not start Martin: {error}"))?;
+
+    if let Err(error) = wait_for_martin_health(&base_url, &mut child) {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(error);
+    }
+
+    let mut process = state
+        .process
+        .lock()
+        .map_err(|_| "Could not lock Martin process state.".to_string())?;
+    *process = Some(MartinProcess { child });
+
+    Ok(MartinServerInfo {
+        base_url,
+        binary_path: binary.path,
+        port,
+    })
+}
+
+#[tauri::command]
+fn stop_martin_server(state: tauri::State<MartinServerState>) -> Result<(), String> {
+    let mut process = state
+        .process
+        .lock()
+        .map_err(|_| "Could not lock Martin process state.".to_string())?;
+    *process = None;
+    Ok(())
+}
+
+fn ensure_martin_binary_path(app: &tauri::AppHandle) -> Result<MartinBinaryInfo, String> {
+    let asset_name = martin_asset_name()?;
+    let executable_name = martin_executable_name();
+    let martin_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|error| format!("Could not resolve app data directory: {error}"))?
+        .join("martin")
+        .join(MARTIN_CACHE_VERSION)
+        .join(
+            asset_name
+                .trim_end_matches(".tar.gz")
+                .trim_end_matches(".zip"),
+        );
+    let binary_path = martin_dir.join(executable_name);
+
+    if binary_path.exists() {
+        return Ok(MartinBinaryInfo {
+            path: binary_path.to_string_lossy().to_string(),
+            downloaded: false,
+        });
+    }
+
+    fs::create_dir_all(&martin_dir)
+        .map_err(|error| format!("Could not create Martin cache directory: {error}"))?;
+    let archive = download_martin_asset(asset_name)?;
+    extract_martin_binary(&archive, asset_name, &binary_path)?;
+    make_executable(&binary_path)?;
+
+    Ok(MartinBinaryInfo {
+        path: binary_path.to_string_lossy().to_string(),
+        downloaded: true,
+    })
+}
+
+fn martin_asset_name() -> Result<&'static str, String> {
+    if cfg!(target_os = "linux") && cfg!(target_arch = "x86_64") {
+        return Ok("martin-x86_64-unknown-linux-musl.tar.gz");
+    }
+    if cfg!(target_os = "linux") && cfg!(target_arch = "aarch64") {
+        return Ok("martin-aarch64-unknown-linux-musl.tar.gz");
+    }
+    if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
+        return Ok("martin-aarch64-apple-darwin.tar.gz");
+    }
+    if cfg!(target_os = "windows") && cfg!(target_arch = "x86_64") {
+        return Ok("martin-x86_64-pc-windows-msvc.zip");
+    }
+
+    Err("No Martin binary release is available for this platform.".to_string())
+}
+
+fn martin_executable_name() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "martin.exe"
+    } else {
+        "martin"
+    }
+}
+
+fn download_martin_asset(asset_name: &str) -> Result<Vec<u8>, String> {
+    let url = format!("{MARTIN_LATEST_BASE_URL}/{asset_name}");
+    let response = reqwest::blocking::Client::builder()
+        .user_agent("GeoLibre Desktop")
+        .build()
+        .map_err(|error| format!("Could not create HTTP client: {error}"))?
+        .get(url)
+        .send()
+        .map_err(|error| format!("Could not download Martin: {error}"))?;
+    let status = response.status();
+    if !status.is_success() {
+        return Err(format!("Martin download failed with status {status}"));
+    }
+
+    response
+        .bytes()
+        .map(|bytes| bytes.to_vec())
+        .map_err(|error| format!("Could not read Martin download: {error}"))
+}
+
+fn extract_martin_binary(
+    archive: &[u8],
+    asset_name: &str,
+    binary_path: &Path,
+) -> Result<(), String> {
+    if asset_name.ends_with(".zip") {
+        extract_martin_binary_from_zip(archive, binary_path)
+    } else {
+        extract_martin_binary_from_tar_gz(archive, binary_path)
+    }
+}
+
+fn extract_martin_binary_from_tar_gz(archive: &[u8], binary_path: &Path) -> Result<(), String> {
+    let decoder = GzDecoder::new(Cursor::new(archive));
+    let mut archive = tar::Archive::new(decoder);
+    let executable_name = martin_executable_name();
+    let entries = archive
+        .entries()
+        .map_err(|error| format!("Could not read Martin archive: {error}"))?;
+
+    for entry in entries {
+        let mut entry = entry.map_err(|error| format!("Could not read Martin archive: {error}"))?;
+        let path = entry
+            .path()
+            .map_err(|error| format!("Could not read Martin archive path: {error}"))?;
+        if path.file_name().and_then(|name| name.to_str()) != Some(executable_name) {
+            continue;
+        }
+
+        let mut output = File::create(binary_path)
+            .map_err(|error| format!("Could not create Martin binary: {error}"))?;
+        std::io::copy(&mut entry, &mut output)
+            .map_err(|error| format!("Could not extract Martin binary: {error}"))?;
+        return Ok(());
+    }
+
+    Err("Martin archive did not contain the expected executable.".to_string())
+}
+
+fn extract_martin_binary_from_zip(archive: &[u8], binary_path: &Path) -> Result<(), String> {
+    let reader = Cursor::new(archive);
+    let mut archive = zip::ZipArchive::new(reader)
+        .map_err(|error| format!("Could not read Martin zip: {error}"))?;
+    let executable_name = martin_executable_name();
+
+    for index in 0..archive.len() {
+        let mut file = archive
+            .by_index(index)
+            .map_err(|error| format!("Could not read Martin zip entry: {error}"))?;
+        let path = PathBuf::from(file.name());
+        if path.file_name().and_then(|name| name.to_str()) != Some(executable_name) {
+            continue;
+        }
+
+        let mut output = File::create(binary_path)
+            .map_err(|error| format!("Could not create Martin binary: {error}"))?;
+        std::io::copy(&mut file, &mut output)
+            .map_err(|error| format!("Could not extract Martin binary: {error}"))?;
+        return Ok(());
+    }
+
+    Err("Martin zip did not contain the expected executable.".to_string())
+}
+
+#[cfg(unix)]
+fn make_executable(path: &Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = fs::metadata(path)
+        .map_err(|error| format!("Could not read Martin binary permissions: {error}"))?
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions)
+        .map_err(|error| format!("Could not mark Martin executable: {error}"))
+}
+
+#[cfg(not(unix))]
+fn make_executable(_path: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+fn reserve_local_port() -> Result<u16, String> {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .map_err(|error| format!("Could not reserve a local Martin port: {error}"))?;
+    listener
+        .local_addr()
+        .map(|address| address.port())
+        .map_err(|error| format!("Could not read local Martin port: {error}"))
+}
+
+fn wait_for_martin_health(base_url: &str, child: &mut Child) -> Result<(), String> {
+    let health_url = format!("{base_url}/health");
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_millis(750))
+        .build()
+        .map_err(|error| format!("Could not create HTTP client: {error}"))?;
+
+    for _ in 0..80 {
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|error| format!("Could not inspect Martin process: {error}"))?
+        {
+            return Err(format!("Martin exited before it was ready: {status}"));
+        }
+
+        if client
+            .get(&health_url)
+            .send()
+            .map(|response| response.status().is_success())
+            .unwrap_or(false)
+        {
+            return Ok(());
+        }
+
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    Err("Martin did not become ready in time.".to_string())
 }
 
 #[derive(Serialize)]

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -20,8 +20,10 @@ use tauri::Manager;
 
 static POPUP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
-const MARTIN_LATEST_BASE_URL: &str = "https://github.com/maplibre/martin/releases/latest/download";
-const MARTIN_CACHE_VERSION: &str = "latest";
+const MARTIN_VERSION: &str = "martin-v1.10.1";
+const MARTIN_RELEASE_BASE_URL: &str = "https://github.com/maplibre/martin/releases/download";
+const MARTIN_START_ATTEMPTS: usize = 3;
+const MARTIN_HEALTH_ATTEMPTS: usize = 30;
 
 struct MartinServerState {
     process: Mutex<Option<MartinProcess>>,
@@ -120,9 +122,20 @@ fn ensure_martin_binary(app: tauri::AppHandle) -> Result<MartinBinaryInfo, Strin
 }
 
 #[tauri::command]
-fn start_martin_server(
+async fn start_martin_server(
     app: tauri::AppHandle,
-    state: tauri::State<MartinServerState>,
+    connection_string: String,
+    default_srid: Option<String>,
+) -> Result<MartinServerInfo, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        start_martin_server_blocking(app, connection_string, default_srid)
+    })
+    .await
+    .map_err(|error| format!("Could not join Martin startup task: {error}"))?
+}
+
+fn start_martin_server_blocking(
+    app: tauri::AppHandle,
     connection_string: String,
     default_srid: Option<String>,
 ) -> Result<MartinServerInfo, String> {
@@ -131,47 +144,53 @@ fn start_martin_server(
     }
 
     let binary = ensure_martin_binary_path(&app)?;
-    let port = reserve_local_port()?;
-    let listen_address = format!("127.0.0.1:{port}");
-    let base_url = format!("http://127.0.0.1:{port}");
-    let mut command = Command::new(&binary.path);
-    command
-        .arg("-l")
-        .arg(&listen_address)
-        .env("DATABASE_URL", connection_string.trim())
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null());
-
-    if let Some(default_srid) = default_srid
-        .as_ref()
-        .map(|value| value.trim())
-        .filter(|value| !value.is_empty())
+    let state = app.state::<MartinServerState>();
     {
-        command.env("DEFAULT_SRID", default_srid);
+        let process = state
+            .process
+            .lock()
+            .map_err(|_| "Could not lock Martin process state.".to_string())?;
+        if process.is_some() {
+            return Err(
+                "A Martin server is already running. Stop it before starting a new one."
+                    .to_string(),
+            );
+        }
     }
 
-    let mut child = command
-        .spawn()
-        .map_err(|error| format!("Could not start Martin: {error}"))?;
-
-    if let Err(error) = wait_for_martin_health(&base_url, &mut child) {
-        let _ = child.kill();
-        let _ = child.wait();
-        return Err(error);
+    let mut last_error = "Could not start Martin.".to_string();
+    for _ in 0..MARTIN_START_ATTEMPTS {
+        match spawn_martin_server(
+            &binary.path,
+            connection_string.trim(),
+            default_srid.as_deref(),
+        ) {
+            Ok(info) => {
+                let mut process = state
+                    .process
+                    .lock()
+                    .map_err(|_| "Could not lock Martin process state.".to_string())?;
+                if process.is_some() {
+                    drop(info.process);
+                    return Err(
+                        "A Martin server is already running. Stop it before starting a new one."
+                            .to_string(),
+                    );
+                }
+                *process = Some(info.process);
+                return Ok(MartinServerInfo {
+                    base_url: info.base_url,
+                    binary_path: binary.path,
+                    port: info.port,
+                });
+            }
+            Err(error) => {
+                last_error = error;
+            }
+        }
     }
 
-    let mut process = state
-        .process
-        .lock()
-        .map_err(|_| "Could not lock Martin process state.".to_string())?;
-    *process = Some(MartinProcess { child });
-
-    Ok(MartinServerInfo {
-        base_url,
-        binary_path: binary.path,
-        port,
-    })
+    Err(last_error)
 }
 
 #[tauri::command]
@@ -192,13 +211,14 @@ fn ensure_martin_binary_path(app: &tauri::AppHandle) -> Result<MartinBinaryInfo,
         .app_data_dir()
         .map_err(|error| format!("Could not resolve app data directory: {error}"))?
         .join("martin")
-        .join(MARTIN_CACHE_VERSION)
+        .join(MARTIN_VERSION)
         .join(
             asset_name
                 .trim_end_matches(".tar.gz")
                 .trim_end_matches(".zip"),
         );
     let binary_path = martin_dir.join(executable_name);
+    let temp_binary_path = martin_dir.join(format!("{executable_name}.download"));
 
     if binary_path.exists() {
         return Ok(MartinBinaryInfo {
@@ -209,9 +229,18 @@ fn ensure_martin_binary_path(app: &tauri::AppHandle) -> Result<MartinBinaryInfo,
 
     fs::create_dir_all(&martin_dir)
         .map_err(|error| format!("Could not create Martin cache directory: {error}"))?;
+    let _ = fs::remove_file(&temp_binary_path);
     let archive = download_martin_asset(asset_name)?;
-    extract_martin_binary(&archive, asset_name, &binary_path)?;
-    make_executable(&binary_path)?;
+    if let Err(error) = extract_martin_binary(&archive, asset_name, &temp_binary_path)
+        .and_then(|_| make_executable(&temp_binary_path))
+        .and_then(|_| {
+            fs::rename(&temp_binary_path, &binary_path)
+                .map_err(|error| format!("Could not install Martin binary: {error}"))
+        })
+    {
+        let _ = fs::remove_file(&temp_binary_path);
+        return Err(error);
+    }
 
     Ok(MartinBinaryInfo {
         path: binary_path.to_string_lossy().to_string(),
@@ -229,6 +258,9 @@ fn martin_asset_name() -> Result<&'static str, String> {
     if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
         return Ok("martin-aarch64-apple-darwin.tar.gz");
     }
+    if cfg!(target_os = "macos") && cfg!(target_arch = "x86_64") {
+        return Ok("martin-x86_64-apple-darwin.tar.gz");
+    }
     if cfg!(target_os = "windows") && cfg!(target_arch = "x86_64") {
         return Ok("martin-x86_64-pc-windows-msvc.zip");
     }
@@ -245,7 +277,7 @@ fn martin_executable_name() -> &'static str {
 }
 
 fn download_martin_asset(asset_name: &str) -> Result<Vec<u8>, String> {
-    let url = format!("{MARTIN_LATEST_BASE_URL}/{asset_name}");
+    let url = format!("{MARTIN_RELEASE_BASE_URL}/{MARTIN_VERSION}/{asset_name}");
     let response = reqwest::blocking::Client::builder()
         .user_agent("GeoLibre Desktop")
         .build()
@@ -293,10 +325,7 @@ fn extract_martin_binary_from_tar_gz(archive: &[u8], binary_path: &Path) -> Resu
             continue;
         }
 
-        let mut output = File::create(binary_path)
-            .map_err(|error| format!("Could not create Martin binary: {error}"))?;
-        std::io::copy(&mut entry, &mut output)
-            .map_err(|error| format!("Could not extract Martin binary: {error}"))?;
+        copy_archive_entry_to_path(&mut entry, binary_path)?;
         return Ok(());
     }
 
@@ -318,14 +347,21 @@ fn extract_martin_binary_from_zip(archive: &[u8], binary_path: &Path) -> Result<
             continue;
         }
 
-        let mut output = File::create(binary_path)
-            .map_err(|error| format!("Could not create Martin binary: {error}"))?;
-        std::io::copy(&mut file, &mut output)
-            .map_err(|error| format!("Could not extract Martin binary: {error}"))?;
+        copy_archive_entry_to_path(&mut file, binary_path)?;
         return Ok(());
     }
 
     Err("Martin zip did not contain the expected executable.".to_string())
+}
+
+fn copy_archive_entry_to_path<R: Read>(reader: &mut R, path: &Path) -> Result<(), String> {
+    let mut output =
+        File::create(path).map_err(|error| format!("Could not create Martin binary: {error}"))?;
+    if let Err(error) = std::io::copy(reader, &mut output) {
+        let _ = fs::remove_file(path);
+        return Err(format!("Could not extract Martin binary: {error}"));
+    }
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -345,28 +381,80 @@ fn make_executable(_path: &Path) -> Result<(), String> {
     Ok(())
 }
 
-fn reserve_local_port() -> Result<u16, String> {
+struct SpawnedMartinServer {
+    base_url: String,
+    port: u16,
+    process: MartinProcess,
+}
+
+fn spawn_martin_server(
+    binary_path: &str,
+    connection_string: &str,
+    default_srid: Option<&str>,
+) -> Result<SpawnedMartinServer, String> {
     let listener = TcpListener::bind("127.0.0.1:0")
         .map_err(|error| format!("Could not reserve a local Martin port: {error}"))?;
-    listener
+    let port = listener
         .local_addr()
         .map(|address| address.port())
-        .map_err(|error| format!("Could not read local Martin port: {error}"))
+        .map_err(|error| format!("Could not read local Martin port: {error}"))?;
+    let listen_address = format!("127.0.0.1:{port}");
+    let base_url = format!("http://127.0.0.1:{port}");
+    let mut command = Command::new(binary_path);
+    command
+        .arg("-l")
+        .arg(&listen_address)
+        .env("DATABASE_URL", connection_string)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    if let Some(default_srid) = default_srid
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        command.env("DEFAULT_SRID", default_srid);
+    }
+
+    drop(listener);
+    let mut child = command
+        .spawn()
+        .map_err(|error| format!("Could not start Martin: {error}"))?;
+
+    if let Err(error) = wait_for_martin_health(&base_url, &mut child) {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(error);
+    }
+
+    let _ = child.stdout.take();
+    let _ = child.stderr.take();
+
+    Ok(SpawnedMartinServer {
+        base_url,
+        port,
+        process: MartinProcess { child },
+    })
 }
 
 fn wait_for_martin_health(base_url: &str, child: &mut Child) -> Result<(), String> {
     let health_url = format!("{base_url}/health");
     let client = reqwest::blocking::Client::builder()
-        .timeout(Duration::from_millis(750))
+        .timeout(Duration::from_millis(500))
         .build()
         .map_err(|error| format!("Could not create HTTP client: {error}"))?;
 
-    for _ in 0..80 {
+    for _ in 0..MARTIN_HEALTH_ATTEMPTS {
         if let Some(status) = child
             .try_wait()
             .map_err(|error| format!("Could not inspect Martin process: {error}"))?
         {
-            return Err(format!("Martin exited before it was ready: {status}"));
+            let output = read_child_output(child);
+            return Err(if output.trim().is_empty() {
+                format!("Martin exited before it was ready: {status}")
+            } else {
+                format!("Martin exited before it was ready: {output}")
+            });
         }
 
         if client
@@ -382,6 +470,17 @@ fn wait_for_martin_health(base_url: &str, child: &mut Child) -> Result<(), Strin
     }
 
     Err("Martin did not become ready in time.".to_string())
+}
+
+fn read_child_output(child: &mut Child) -> String {
+    let mut output = String::new();
+    if let Some(mut stdout) = child.stdout.take() {
+        let _ = stdout.read_to_string(&mut output);
+    }
+    if let Some(mut stderr) = child.stderr.take() {
+        let _ = stderr.read_to_string(&mut output);
+    }
+    output
 }
 
 #[derive(Serialize)]

--- a/apps/geolibre-desktop/src-tauri/tauri.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' https:; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval' https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'",
+      "csp": "default-src 'self'; connect-src 'self' https: http://127.0.0.1:* http://localhost:*; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval' https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'",
       "capabilities": ["default"]
     }
   },

--- a/apps/geolibre-desktop/src-tauri/tauri.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' https: http://127.0.0.1:* http://localhost:*; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval' https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'",
+      "csp": "default-src 'self'; connect-src 'self' https: http://127.0.0.1:*; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval' https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'",
       "capabilities": ["default"]
     }
   },

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -1142,6 +1142,13 @@ export function AddDataDialog({
 
           {kind === "postgres" && (
             <div className="space-y-3">
+              {!isTauri() ? (
+                <p className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
+                  PostgreSQL layers are only available in GeoLibre Desktop. This
+                  feature runs a local Martin tile server, which the web app
+                  cannot launch.
+                </p>
+              ) : null}
               {savedPostgresConnections.length > 0 ? (
                 <div className="space-y-1.5">
                   <Label htmlFor="postgres-saved-connection">
@@ -1212,7 +1219,7 @@ export function AddDataDialog({
                       type="button"
                       variant="outline"
                       onClick={handleConnectPostgres}
-                      disabled={isSubmitting}
+                      disabled={isSubmitting || !isTauri()}
                     >
                       Connect
                     </Button>

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -41,6 +41,17 @@ import {
   registerMbtilesProtocol,
   type MbtilesMetadata,
 } from "../../lib/mbtiles";
+import {
+  ensureMartinBinary,
+  fetchMartinCatalog,
+  fetchMartinTileJson,
+  martinTileJsonUrl,
+  startMartinServer,
+  stopMartinServer,
+  type MartinServerInfo,
+  type MartinSourceSummary,
+} from "../../lib/martin";
+import { isTauri } from "../../lib/tauri-io";
 
 export type AddDataKind =
   | "xyz"
@@ -48,7 +59,8 @@ export type AddDataKind =
   | "vector"
   | "raster"
   | "mbtiles"
-  | "arcgis";
+  | "arcgis"
+  | "postgres";
 
 interface AddDataDialogProps {
   kind: AddDataKind | null;
@@ -67,6 +79,7 @@ const KIND_LABELS: Record<AddDataKind, string> = {
   raster: "Add Raster Layer",
   mbtiles: "Add MBTiles Layer",
   arcgis: "Add ArcGIS Layer",
+  postgres: "Add PostgreSQL Layer",
 };
 
 const SELECT_CLASS =
@@ -100,6 +113,9 @@ const DEFAULT_ARCGIS_URLS: Record<ArcGISLayerType, string> = {
   feature: DEFAULT_ARCGIS_FEATURE_URL,
   "vector-tile": DEFAULT_ARCGIS_VECTOR_TILE_URL,
 };
+const POSTGRES_CONNECTIONS_STORAGE_KEY =
+  "geolibre.postgres.connectionStrings";
+const MAX_SAVED_POSTGRES_CONNECTIONS = 10;
 
 function createLayerId(): string {
   return crypto.randomUUID();
@@ -186,6 +202,52 @@ function parseOptionalNumber(value: string, label: string): number | undefined {
   return parseRequiredNumber(value, label);
 }
 
+function readSavedPostgresConnections(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const value = window.localStorage.getItem(POSTGRES_CONNECTIONS_STORAGE_KEY);
+    if (!value) return [];
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed)
+      ? parsed.filter((item): item is string => typeof item === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function rememberPostgresConnection(connectionString: string): string[] {
+  const trimmed = connectionString.trim();
+  if (!trimmed || typeof window === "undefined") return [];
+
+  const connections = [
+    trimmed,
+    ...readSavedPostgresConnections().filter((value) => value !== trimmed),
+  ].slice(0, MAX_SAVED_POSTGRES_CONNECTIONS);
+
+  window.localStorage.setItem(
+    POSTGRES_CONNECTIONS_STORAGE_KEY,
+    JSON.stringify(connections),
+  );
+  return connections;
+}
+
+function savedPostgresConnectionLabel(connectionString: string): string {
+  try {
+    const url = new URL(connectionString);
+    if (url.password) url.password = "****";
+    return url.toString();
+  } catch {
+    return connectionString.replace(/(:\/\/[^:\s/@]+:)[^@\s]+@/, "$1****@");
+  }
+}
+
+function errorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string" && error.trim()) return error;
+  return fallback;
+}
+
 async function fetchGeoJson(url: string): Promise<FeatureCollection> {
   const response = await fetch(url);
   if (!response.ok) {
@@ -251,6 +313,17 @@ export function AddDataDialog({
   const [arcgisItemId, setArcgisItemId] = useState("");
   const [arcgisPortalUrl, setArcgisPortalUrl] = useState("");
   const [arcgisAccessToken, setArcgisAccessToken] = useState("");
+  const [postgresConnectionString, setPostgresConnectionString] = useState("");
+  const [savedPostgresConnections, setSavedPostgresConnections] = useState<
+    string[]
+  >(() => readSavedPostgresConnections());
+  const [postgresDefaultSrid, setPostgresDefaultSrid] = useState("");
+  const [martinServer, setMartinServer] = useState<MartinServerInfo | null>(
+    null,
+  );
+  const [martinSources, setMartinSources] = useState<MartinSourceSummary[]>([]);
+  const [selectedMartinSourceId, setSelectedMartinSourceId] = useState("");
+  const [martinStatus, setMartinStatus] = useState<string | null>(null);
 
   useEffect(() => {
     if (!kind) return;
@@ -264,6 +337,7 @@ export function AddDataDialog({
         raster: "Raster Layer",
         mbtiles: "MBTiles Layer",
         arcgis: "ArcGIS Layer",
+        postgres: "PostgreSQL Layer",
       }[kind],
     );
     setBeforeLayerId("");
@@ -296,6 +370,16 @@ export function AddDataDialog({
     setArcgisItemId("");
     setArcgisPortalUrl("");
     setArcgisAccessToken("");
+    const savedConnections = readSavedPostgresConnections();
+    setSavedPostgresConnections(savedConnections);
+    setPostgresConnectionString(
+      kind === "postgres" ? (savedConnections[0] ?? "") : "",
+    );
+    setPostgresDefaultSrid("");
+    setMartinServer(null);
+    setMartinSources([]);
+    setSelectedMartinSourceId("");
+    setMartinStatus(null);
   }, [kind]);
 
   const description = useMemo(() => {
@@ -316,6 +400,9 @@ export function AddDataDialog({
     }
     if (kind === "arcgis") {
       return "Add an ArcGIS FeatureServer layer, VectorTileServer layer, or portal item.";
+    }
+    if (kind === "postgres") {
+      return "Start Martin locally, discover PostGIS sources, and add a source as vector tiles.";
     }
     return "";
   }, [kind]);
@@ -340,9 +427,117 @@ export function AddDataDialog({
     }
   };
 
-  const addAndClose = (layer: GeoLibreLayer) => {
+  const addAndClose = (
+    layer: GeoLibreLayer,
+    options: { fit?: boolean } = {},
+  ) => {
     addLayer(layer, beforeLayer);
+    if (options.fit) mapControllerRef.current?.fitLayer(layer);
     closeDialog();
+  };
+
+  const handleConnectPostgres = async () => {
+    setError(null);
+    setMartinStatus(null);
+    setIsSubmitting(true);
+    setMartinSources([]);
+    setSelectedMartinSourceId("");
+
+    try {
+      if (!isTauri()) {
+        throw new Error("PostgreSQL layers require GeoLibre Desktop.");
+      }
+      if (!postgresConnectionString.trim()) {
+        throw new Error("Enter a PostgreSQL connection string.");
+      }
+
+      setMartinStatus("Checking Martin binary...");
+      const binary = await ensureMartinBinary();
+      setMartinStatus(
+        binary.downloaded
+          ? "Martin downloaded. Starting local server..."
+          : "Starting local Martin server...",
+      );
+      const server = await startMartinServer({
+        connectionString: postgresConnectionString,
+        defaultSrid: postgresDefaultSrid,
+      });
+      setSavedPostgresConnections(
+        rememberPostgresConnection(postgresConnectionString),
+      );
+      setMartinServer(server);
+      setMartinStatus("Reading Martin catalog...");
+
+      const sources = await fetchMartinCatalog(server);
+      setMartinSources(sources);
+      setSelectedMartinSourceId(sources[0]?.id ?? "");
+      setMartinStatus(
+        sources.length > 0
+          ? `Found ${sources.length} source${sources.length === 1 ? "" : "s"}.`
+          : "Martin is running, but no compatible PostGIS sources were found.",
+      );
+    } catch (err) {
+      setMartinServer(null);
+      setError(errorMessage(err, "Could not connect to PostgreSQL."));
+      setMartinStatus(null);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleStopMartin = async () => {
+    setError(null);
+    setIsSubmitting(true);
+    try {
+      await stopMartinServer();
+      setMartinServer(null);
+      setMartinSources([]);
+      setSelectedMartinSourceId("");
+      setMartinStatus("Martin stopped.");
+    } catch (err) {
+      setError(errorMessage(err, "Could not stop Martin."));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const addMartinSource = async (sourceId: string) => {
+    if (!martinServer) throw new Error("Connect to PostgreSQL first.");
+    const tilejson = await fetchMartinTileJson(martinServer, sourceId);
+    const vectorLayers = tilejson.vector_layers ?? tilejson.vectorLayers ?? [];
+    const sourceLayer = vectorLayers[0]?.id;
+    if (!sourceLayer) {
+      throw new Error("The selected Martin source has no vector layers.");
+    }
+
+    const source = martinSources.find((candidate) => candidate.id === sourceId);
+    const tilejsonUrl = martinTileJsonUrl(martinServer, sourceId);
+    addAndClose(
+      createBaseLayer(
+        layerName.trim() || tilejson.name || source?.name || sourceId,
+        "vector-tiles",
+        {
+          type: "vector",
+          url: tilejsonUrl,
+          sourceLayer,
+          bounds: tilejson.bounds,
+          minzoom: tilejson.minzoom,
+          maxzoom: tilejson.maxzoom,
+        },
+        {
+          bounds: tilejson.bounds,
+          center: tilejson.center,
+          maxzoom: tilejson.maxzoom,
+          minzoom: tilejson.minzoom,
+          martinPort: martinServer.port,
+          martinSourceId: sourceId,
+          sourceKind: "martin-postgis",
+          sourceLayers: vectorLayers.map((vectorLayer) => vectorLayer.id),
+          tilejsonUrl,
+        },
+      ),
+      { fit: true },
+    );
   };
 
   const handleChooseVector = async () => {
@@ -357,7 +552,7 @@ export function AddDataDialog({
           : layerNameFromPath(result.path, "Vector Layer"),
       );
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Could not read file.");
+      setError(errorMessage(err, "Could not read file."));
     }
   };
 
@@ -403,9 +598,7 @@ export function AddDataDialog({
           : metadata.name || layerNameFromPath(result.path, "MBTiles Layer"),
       );
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Could not read MBTiles file.",
-      );
+      setError(errorMessage(err, "Could not read MBTiles file."));
     }
   };
 
@@ -563,6 +756,14 @@ export function AddDataDialog({
         return;
       }
 
+      if (kind === "postgres") {
+        if (!selectedMartinSourceId) {
+          throw new Error("Select a Martin source to add.");
+        }
+        await addMartinSource(selectedMartinSourceId);
+        return;
+      }
+
       if (rasterMode === "tiles") {
         if (!rasterUrl.trim()) {
           throw new Error("Enter a raster tile URL template.");
@@ -618,7 +819,7 @@ export function AddDataDialog({
       });
       closeDialog();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Could not add layer.");
+      setError(errorMessage(err, "Could not add layer."));
     } finally {
       setIsSubmitting(false);
     }
@@ -936,6 +1137,125 @@ export function AddDataDialog({
                   }
                 />
               </div>
+            </div>
+          )}
+
+          {kind === "postgres" && (
+            <div className="space-y-3">
+              {savedPostgresConnections.length > 0 ? (
+                <div className="space-y-1.5">
+                  <Label htmlFor="postgres-saved-connection">
+                    Saved connection
+                  </Label>
+                  <select
+                    id="postgres-saved-connection"
+                    className={SELECT_CLASS}
+                    value={
+                      savedPostgresConnections.includes(
+                        postgresConnectionString,
+                      )
+                        ? postgresConnectionString
+                        : ""
+                    }
+                    onChange={(event) =>
+                      setPostgresConnectionString(event.target.value)
+                    }
+                  >
+                    <option value="">Select saved connection</option>
+                    {savedPostgresConnections.map((connection) => (
+                      <option key={connection} value={connection}>
+                        {savedPostgresConnectionLabel(connection)}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              ) : null}
+              <div className="space-y-1.5">
+                <Label htmlFor="postgres-connection">
+                  PostgreSQL connection string
+                </Label>
+                <Input
+                  id="postgres-connection"
+                  type="password"
+                  autoComplete="off"
+                  list="postgres-saved-connections"
+                  placeholder="postgres://user:password@host:5432/database"
+                  value={postgresConnectionString}
+                  onChange={(event) =>
+                    setPostgresConnectionString(event.target.value)
+                  }
+                />
+                {savedPostgresConnections.length > 0 ? (
+                  <datalist id="postgres-saved-connections">
+                    {savedPostgresConnections.map((connection) => (
+                      <option key={connection} value={connection} />
+                    ))}
+                  </datalist>
+                ) : null}
+              </div>
+              <div className="grid gap-3 sm:grid-cols-[1fr_auto]">
+                <div className="space-y-1.5">
+                  <Label htmlFor="postgres-default-srid">Default SRID</Label>
+                  <Input
+                    id="postgres-default-srid"
+                    inputMode="numeric"
+                    placeholder="Optional"
+                    value={postgresDefaultSrid}
+                    onChange={(event) =>
+                      setPostgresDefaultSrid(event.target.value)
+                    }
+                  />
+                </div>
+                <div className="flex items-end">
+                  <div className="flex gap-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={handleConnectPostgres}
+                      disabled={isSubmitting}
+                    >
+                      Connect
+                    </Button>
+                    {martinServer ? (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={handleStopMartin}
+                        disabled={isSubmitting}
+                      >
+                        Stop
+                      </Button>
+                    ) : null}
+                  </div>
+                </div>
+              </div>
+              {martinStatus ? (
+                <p className="text-xs text-muted-foreground">{martinStatus}</p>
+              ) : null}
+              {martinSources.length > 0 ? (
+                <div className="space-y-1.5">
+                  <Label htmlFor="martin-source">Martin source</Label>
+                  <select
+                    id="martin-source"
+                    className={SELECT_CLASS}
+                    value={selectedMartinSourceId}
+                    onChange={(event) =>
+                      setSelectedMartinSourceId(event.target.value)
+                    }
+                  >
+                    {martinSources.map((source) => (
+                      <option key={source.id} value={source.id}>
+                        {source.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              ) : null}
+              {martinServer ? (
+                <p className="text-xs text-muted-foreground">
+                  Martin is running on port {martinServer.port}.
+                </p>
+              ) : null}
             </div>
           )}
 

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -28,6 +28,7 @@ import {
   type RefObject,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import {
@@ -209,7 +210,9 @@ function readSavedPostgresConnections(): string[] {
     if (!value) return [];
     const parsed = JSON.parse(value);
     return Array.isArray(parsed)
-      ? parsed.filter((item): item is string => typeof item === "string")
+      ? uniquePostgresConnections(
+          parsed.filter((item): item is string => typeof item === "string"),
+        )
       : [];
   } catch {
     return [];
@@ -220,10 +223,10 @@ function rememberPostgresConnection(connectionString: string): string[] {
   const trimmed = connectionString.trim();
   if (!trimmed || typeof window === "undefined") return [];
 
-  const connections = [
+  const connections = uniquePostgresConnections([
     trimmed,
     ...readSavedPostgresConnections().filter((value) => value !== trimmed),
-  ].slice(0, MAX_SAVED_POSTGRES_CONNECTIONS);
+  ]).slice(0, MAX_SAVED_POSTGRES_CONNECTIONS);
 
   window.localStorage.setItem(
     POSTGRES_CONNECTIONS_STORAGE_KEY,
@@ -232,13 +235,19 @@ function rememberPostgresConnection(connectionString: string): string[] {
   return connections;
 }
 
+function uniquePostgresConnections(connections: string[]): string[] {
+  return Array.from(new Set(connections));
+}
+
 function savedPostgresConnectionLabel(connectionString: string): string {
   try {
     const url = new URL(connectionString);
     if (url.password) url.password = "****";
     return url.toString();
   } catch {
-    return connectionString.replace(/(:\/\/[^:\s/@]+:)[^@\s]+@/, "$1****@");
+    return connectionString
+      .replace(/(:\/\/[^:\s/@]+:)[^@\s]+@/, "$1****@")
+      .replace(/(password\s*=\s*)('[^']*'|[^\s]+)/i, "$1****");
   }
 }
 
@@ -324,9 +333,11 @@ export function AddDataDialog({
   const [martinSources, setMartinSources] = useState<MartinSourceSummary[]>([]);
   const [selectedMartinSourceId, setSelectedMartinSourceId] = useState("");
   const [martinStatus, setMartinStatus] = useState<string | null>(null);
+  const martinLayerAddedRef = useRef(false);
 
   useEffect(() => {
     if (!kind) return;
+    if (kind === "postgres" && !martinServer) martinLayerAddedRef.current = false;
     setError(null);
     setIsSubmitting(false);
     setLayerName(
@@ -376,10 +387,12 @@ export function AddDataDialog({
       kind === "postgres" ? (savedConnections[0] ?? "") : "",
     );
     setPostgresDefaultSrid("");
-    setMartinServer(null);
-    setMartinSources([]);
-    setSelectedMartinSourceId("");
-    setMartinStatus(null);
+    if (!martinLayerAddedRef.current) {
+      setMartinServer(null);
+      setMartinSources([]);
+      setSelectedMartinSourceId("");
+      setMartinStatus(null);
+    }
   }, [kind]);
 
   const description = useMemo(() => {
@@ -407,10 +420,23 @@ export function AddDataDialog({
     return "";
   }, [kind]);
 
-  const closeDialog = () => onOpenChange(false);
+  const stopTransientMartinServer = () => {
+    if (!martinServer || martinLayerAddedRef.current) return;
+    void stopMartinServer();
+    setMartinServer(null);
+    setMartinSources([]);
+    setSelectedMartinSourceId("");
+    setMartinStatus(null);
+  };
+
+  const closeDialog = () => {
+    stopTransientMartinServer();
+    onOpenChange(false);
+  };
 
   const handleOpenChange = (next: boolean) => {
     if (!next && isSubmitting) return;
+    if (!next) stopTransientMartinServer();
     onOpenChange(next);
   };
 
@@ -450,6 +476,7 @@ export function AddDataDialog({
       if (!postgresConnectionString.trim()) {
         throw new Error("Enter a PostgreSQL connection string.");
       }
+      const connectionString = postgresConnectionString.trim();
 
       setMartinStatus("Checking Martin binary...");
       const binary = await ensureMartinBinary();
@@ -459,11 +486,11 @@ export function AddDataDialog({
           : "Starting local Martin server...",
       );
       const server = await startMartinServer({
-        connectionString: postgresConnectionString,
+        connectionString,
         defaultSrid: postgresDefaultSrid,
       });
       setSavedPostgresConnections(
-        rememberPostgresConnection(postgresConnectionString),
+        rememberPostgresConnection(connectionString),
       );
       setMartinServer(server);
       setMartinStatus("Reading Martin catalog...");
@@ -490,6 +517,7 @@ export function AddDataDialog({
     setIsSubmitting(true);
     try {
       await stopMartinServer();
+      martinLayerAddedRef.current = false;
       setMartinServer(null);
       setMartinSources([]);
       setSelectedMartinSourceId("");
@@ -512,6 +540,7 @@ export function AddDataDialog({
 
     const source = martinSources.find((candidate) => candidate.id === sourceId);
     const tilejsonUrl = martinTileJsonUrl(martinServer, sourceId);
+    martinLayerAddedRef.current = true;
     addAndClose(
       createBaseLayer(
         layerName.trim() || tilejson.name || source?.name || sourceId,
@@ -520,6 +549,7 @@ export function AddDataDialog({
           type: "vector",
           url: tilejsonUrl,
           sourceLayer,
+          sourceLayers: vectorLayers.map((vectorLayer) => vectorLayer.id),
           bounds: tilejson.bounds,
           minzoom: tilejson.minzoom,
           maxzoom: tilejson.maxzoom,
@@ -757,6 +787,9 @@ export function AddDataDialog({
       }
 
       if (kind === "postgres") {
+        if (!martinServer) {
+          throw new Error("Connect to PostgreSQL first.");
+        }
         if (!selectedMartinSourceId) {
           throw new Error("Select a Martin source to add.");
         }
@@ -824,6 +857,10 @@ export function AddDataDialog({
       setIsSubmitting(false);
     }
   };
+
+  const addLayerDisabled =
+    isSubmitting ||
+    (kind === "postgres" && (!martinServer || !selectedMartinSourceId));
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -1185,20 +1222,12 @@ export function AddDataDialog({
                   id="postgres-connection"
                   type="password"
                   autoComplete="off"
-                  list="postgres-saved-connections"
                   placeholder="postgres://user:password@host:5432/database"
                   value={postgresConnectionString}
                   onChange={(event) =>
                     setPostgresConnectionString(event.target.value)
                   }
                 />
-                {savedPostgresConnections.length > 0 ? (
-                  <datalist id="postgres-saved-connections">
-                    {savedPostgresConnections.map((connection) => (
-                      <option key={connection} value={connection} />
-                    ))}
-                  </datalist>
-                ) : null}
               </div>
               <div className="grid gap-3 sm:grid-cols-[1fr_auto]">
                 <div className="space-y-1.5">
@@ -1405,7 +1434,7 @@ export function AddDataDialog({
             >
               Cancel
             </Button>
-            <Button type="submit" disabled={isSubmitting}>
+            <Button type="submit" disabled={addLayerDisabled}>
               {kind === "wms" ? (
                 <Globe2 className="mr-2 h-3.5 w-3.5" />
               ) : kind === "raster" ? (

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -264,6 +264,9 @@ export function TopToolbar({
           <DropdownMenuItem onSelect={handleAddDuckDBLayer}>
             Add DuckDB Layer
           </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setAddDataKind("postgres")}>
+            Add PostgreSQL Layer
+          </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
       <Button

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -53,7 +53,7 @@ import {
 import { useState, useSyncExternalStore } from "react";
 import { createAppAPI, usePluginRegistry } from "../../hooks/usePlugins";
 import type { ThemeMode } from "../../hooks/useThemeMode";
-import { openProjectFile, saveProjectFile } from "../../lib/tauri-io";
+import { isTauri, openProjectFile, saveProjectFile } from "../../lib/tauri-io";
 import { AddDataDialog, type AddDataKind } from "./AddDataDialog";
 import { AboutDialog } from "./AboutDialog";
 import { NewProjectDialog } from "./NewProjectDialog";
@@ -264,9 +264,11 @@ export function TopToolbar({
           <DropdownMenuItem onSelect={handleAddDuckDBLayer}>
             Add DuckDB Layer
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setAddDataKind("postgres")}>
-            Add PostgreSQL Layer
-          </DropdownMenuItem>
+          {isTauri() && (
+            <DropdownMenuItem onSelect={() => setAddDataKind("postgres")}>
+              Add PostgreSQL Layer
+            </DropdownMenuItem>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
       <Button

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -53,7 +53,7 @@ import {
 import { useState, useSyncExternalStore } from "react";
 import { createAppAPI, usePluginRegistry } from "../../hooks/usePlugins";
 import type { ThemeMode } from "../../hooks/useThemeMode";
-import { isTauri, openProjectFile, saveProjectFile } from "../../lib/tauri-io";
+import { openProjectFile, saveProjectFile } from "../../lib/tauri-io";
 import { AddDataDialog, type AddDataKind } from "./AddDataDialog";
 import { AboutDialog } from "./AboutDialog";
 import { NewProjectDialog } from "./NewProjectDialog";
@@ -264,11 +264,9 @@ export function TopToolbar({
           <DropdownMenuItem onSelect={handleAddDuckDBLayer}>
             Add DuckDB Layer
           </DropdownMenuItem>
-          {isTauri() && (
-            <DropdownMenuItem onSelect={() => setAddDataKind("postgres")}>
-              Add PostgreSQL Layer
-            </DropdownMenuItem>
-          )}
+          <DropdownMenuItem onSelect={() => setAddDataKind("postgres")}>
+            Add PostgreSQL Layer
+          </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
       <Button

--- a/apps/geolibre-desktop/src/lib/martin.ts
+++ b/apps/geolibre-desktop/src/lib/martin.ts
@@ -1,0 +1,111 @@
+import { invoke } from "@tauri-apps/api/core";
+import { isTauri } from "./tauri-io";
+
+export interface MartinBinaryInfo {
+  path: string;
+  downloaded: boolean;
+}
+
+export interface MartinServerInfo {
+  baseUrl: string;
+  binaryPath: string;
+  port: number;
+}
+
+export interface MartinCatalogTile {
+  name?: string;
+  content_type?: string;
+  contentType?: string;
+}
+
+export interface MartinCatalog {
+  tiles?: Record<string, MartinCatalogTile>;
+}
+
+export interface MartinVectorLayer {
+  id: string;
+  fields?: Record<string, string>;
+  description?: string;
+  minzoom?: number;
+  maxzoom?: number;
+}
+
+export interface MartinTileJson {
+  name?: string;
+  description?: string;
+  bounds?: [number, number, number, number];
+  center?: [number, number, number];
+  minzoom?: number;
+  maxzoom?: number;
+  vector_layers?: MartinVectorLayer[];
+  vectorLayers?: MartinVectorLayer[];
+}
+
+export interface MartinSourceSummary {
+  id: string;
+  name: string;
+  contentType: string;
+}
+
+export async function ensureMartinBinary(): Promise<MartinBinaryInfo> {
+  assertTauri();
+  return invoke<MartinBinaryInfo>("ensure_martin_binary");
+}
+
+export async function startMartinServer(options: {
+  connectionString: string;
+  defaultSrid?: string;
+}): Promise<MartinServerInfo> {
+  assertTauri();
+  return invoke<MartinServerInfo>("start_martin_server", {
+    connectionString: options.connectionString,
+    defaultSrid: options.defaultSrid?.trim() || null,
+  });
+}
+
+export async function stopMartinServer(): Promise<void> {
+  assertTauri();
+  await invoke("stop_martin_server");
+}
+
+export async function fetchMartinCatalog(
+  server: MartinServerInfo,
+): Promise<MartinSourceSummary[]> {
+  const response = await fetch(`${server.baseUrl}/catalog`);
+  if (!response.ok) {
+    throw new Error(`Martin catalog request failed with status ${response.status}.`);
+  }
+
+  const catalog = (await response.json()) as MartinCatalog;
+  return Object.entries(catalog.tiles ?? {})
+    .map(([id, tile]) => ({
+      id,
+      name: tile.name?.trim() || id,
+      contentType: tile.contentType ?? tile.content_type ?? "",
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function fetchMartinTileJson(
+  server: MartinServerInfo,
+  sourceId: string,
+): Promise<MartinTileJson> {
+  const response = await fetch(martinTileJsonUrl(server, sourceId));
+  if (!response.ok) {
+    throw new Error(`Martin TileJSON request failed with status ${response.status}.`);
+  }
+  return (await response.json()) as MartinTileJson;
+}
+
+export function martinTileJsonUrl(
+  server: MartinServerInfo,
+  sourceId: string,
+): string {
+  return `${server.baseUrl}/${encodeURIComponent(sourceId)}`;
+}
+
+function assertTauri(): void {
+  if (!isTauri()) {
+    throw new Error("PostgreSQL layers require GeoLibre Desktop.");
+  }
+}

--- a/apps/geolibre-desktop/src/lib/martin.ts
+++ b/apps/geolibre-desktop/src/lib/martin.ts
@@ -83,6 +83,7 @@ export async function fetchMartinCatalog(
       name: tile.name?.trim() || id,
       contentType: tile.contentType ?? tile.content_type ?? "",
     }))
+    .filter((source) => isVectorTileContentType(source.contentType))
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 
@@ -108,4 +109,12 @@ function assertTauri(): void {
   if (!isTauri()) {
     throw new Error("PostgreSQL layers require GeoLibre Desktop.");
   }
+}
+
+function isVectorTileContentType(contentType: string): boolean {
+  const normalized = contentType.toLowerCase();
+  return (
+    normalized.includes("protobuf") ||
+    normalized.includes("mapbox-vector-tile")
+  );
 }

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -10,7 +10,7 @@ import {
 import {
   externalExtrusionLayerId,
   mbtilesStyleLayerIds,
-  vectorTileLayerId,
+  vectorTileStyleLayerIds,
 } from "./layer-sync";
 import { createMapController, type MapController } from "./map-controller";
 import "maplibre-gl/dist/maplibre-gl.css";
@@ -96,8 +96,7 @@ function identifyStyleLayerIds(layer: GeoLibreLayer): string[] {
     lineLayerId(layer.id),
     fillExtrusionLayerId(layer.id),
     fillLayerId(layer.id),
-    vectorTileLayerId(layer.id, true),
-    vectorTileLayerId(layer.id),
+    ...vectorTileStyleLayerIds(layer),
   ];
 }
 

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -358,6 +358,8 @@ function syncVectorTileLayer(
   const visibility = layer.visible ? "visible" : "none";
   if (layer.style.extrusionEnabled) {
     removeIfExists(map, vectorTileLayerId(layer.id));
+    removeIfExists(map, vectorTileLineLayerId(layer.id));
+    removeIfExists(map, vectorTileCircleLayerId(layer.id));
     ensureLayer(
       map,
       vectorTileLayerId(layer.id, true),
@@ -366,6 +368,13 @@ function syncVectorTileLayer(
         type: "fill-extrusion",
         source: src,
         "source-layer": sourceLayer,
+        filter: [
+          "match",
+          ["geometry-type"],
+          ["Polygon", "MultiPolygon"],
+          true,
+          false,
+        ],
         paint: fillExtrusionPaint(layer.style, layer.opacity),
         layout: { visibility },
       },
@@ -381,7 +390,54 @@ function syncVectorTileLayer(
         type: "fill",
         source: src,
         "source-layer": sourceLayer,
+        filter: [
+          "match",
+          ["geometry-type"],
+          ["Polygon", "MultiPolygon"],
+          true,
+          false,
+        ],
         paint: fillPaint(layer.style, layer.opacity),
+        layout: { visibility },
+      },
+      beforeId,
+    );
+    ensureLayer(
+      map,
+      vectorTileLineLayerId(layer.id),
+      {
+        id: vectorTileLineLayerId(layer.id),
+        type: "line",
+        source: src,
+        "source-layer": sourceLayer,
+        filter: [
+          "match",
+          ["geometry-type"],
+          ["LineString", "MultiLineString", "Polygon", "MultiPolygon"],
+          true,
+          false,
+        ],
+        paint: linePaint(layer.style, layer.opacity),
+        layout: { visibility },
+      },
+      beforeId,
+    );
+    ensureLayer(
+      map,
+      vectorTileCircleLayerId(layer.id),
+      {
+        id: vectorTileCircleLayerId(layer.id),
+        type: "circle",
+        source: src,
+        "source-layer": sourceLayer,
+        filter: [
+          "match",
+          ["geometry-type"],
+          ["Point", "MultiPoint"],
+          true,
+          false,
+        ],
+        paint: circlePaint(layer.style, layer.opacity),
         layout: { visibility },
       },
       beforeId,
@@ -620,6 +676,26 @@ export function vectorTileLayerId(
   return `layer-${layerId}-${extrusionEnabled ? "vector-extrusion" : "vector"}`;
 }
 
+export function vectorTileLineLayerId(layerId: string): string {
+  return `layer-${layerId}-vector-line`;
+}
+
+export function vectorTileCircleLayerId(layerId: string): string {
+  return `layer-${layerId}-vector-circle`;
+}
+
+export function vectorTileStyleLayerIds(layer: GeoLibreLayer): string[] {
+  if (layer.type !== "vector-tiles") return [];
+  if (layer.style.extrusionEnabled) {
+    return [vectorTileLayerId(layer.id, true)];
+  }
+  return [
+    vectorTileCircleLayerId(layer.id),
+    vectorTileLineLayerId(layer.id),
+    vectorTileLayerId(layer.id),
+  ];
+}
+
 function ensureLayer(
   map: maplibregl.Map,
   id: string,
@@ -678,6 +754,8 @@ export function removeLayerFromMap(
     lineLayerId(layerId),
     circleLayerId(layerId),
     `layer-${layerId}-raster`,
+    vectorTileCircleLayerId(layerId),
+    vectorTileLineLayerId(layerId),
     vectorTileLayerId(layerId),
     vectorTileLayerId(layerId, true),
   ]) {

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -354,95 +354,102 @@ function syncVectorTileLayer(
   if (!map.getSource(src)) {
     map.addSource(src, { type: "vector", url });
   }
-  const sourceLayer = (layer.source.sourceLayer as string) ?? "";
   const visibility = layer.visible ? "visible" : "none";
-  if (layer.style.extrusionEnabled) {
-    removeIfExists(map, vectorTileLayerId(layer.id));
-    removeIfExists(map, vectorTileLineLayerId(layer.id));
-    removeIfExists(map, vectorTileCircleLayerId(layer.id));
-    ensureLayer(
-      map,
-      vectorTileLayerId(layer.id, true),
-      {
-        id: vectorTileLayerId(layer.id, true),
-        type: "fill-extrusion",
-        source: src,
-        "source-layer": sourceLayer,
-        filter: [
-          "match",
-          ["geometry-type"],
-          ["Polygon", "MultiPolygon"],
-          true,
-          false,
-        ],
-        paint: fillExtrusionPaint(layer.style, layer.opacity),
-        layout: { visibility },
-      },
-      beforeId,
-    );
-  } else {
-    removeIfExists(map, vectorTileLayerId(layer.id, true));
-    ensureLayer(
-      map,
-      vectorTileLayerId(layer.id),
-      {
-        id: vectorTileLayerId(layer.id),
-        type: "fill",
-        source: src,
-        "source-layer": sourceLayer,
-        filter: [
-          "match",
-          ["geometry-type"],
-          ["Polygon", "MultiPolygon"],
-          true,
-          false,
-        ],
-        paint: fillPaint(layer.style, layer.opacity),
-        layout: { visibility },
-      },
-      beforeId,
-    );
-    ensureLayer(
-      map,
-      vectorTileLineLayerId(layer.id),
-      {
-        id: vectorTileLineLayerId(layer.id),
-        type: "line",
-        source: src,
-        "source-layer": sourceLayer,
-        filter: [
-          "match",
-          ["geometry-type"],
-          ["LineString", "MultiLineString", "Polygon", "MultiPolygon"],
-          true,
-          false,
-        ],
-        paint: linePaint(layer.style, layer.opacity),
-        layout: { visibility },
-      },
-      beforeId,
-    );
-    ensureLayer(
-      map,
-      vectorTileCircleLayerId(layer.id),
-      {
-        id: vectorTileCircleLayerId(layer.id),
-        type: "circle",
-        source: src,
-        "source-layer": sourceLayer,
-        filter: [
-          "match",
-          ["geometry-type"],
-          ["Point", "MultiPoint"],
-          true,
-          false,
-        ],
-        paint: circlePaint(layer.style, layer.opacity),
-        layout: { visibility },
-      },
-      beforeId,
-    );
+  const sourceLayers = getVectorTileSourceLayers(layer);
+  const currentLayerIds = new Set(vectorTileStyleLayerIds(layer));
+
+  for (const sourceLayer of sourceLayers) {
+    const layerPart = vectorTileScopedSourceLayer(layer, sourceLayer);
+    if (layer.style.extrusionEnabled) {
+      removeIfExists(map, vectorTileLayerId(layer.id, false, layerPart));
+      removeIfExists(map, vectorTileLineLayerId(layer.id, layerPart));
+      removeIfExists(map, vectorTileCircleLayerId(layer.id, layerPart));
+      ensureLayer(
+        map,
+        vectorTileLayerId(layer.id, true, layerPart),
+        {
+          id: vectorTileLayerId(layer.id, true, layerPart),
+          type: "fill-extrusion",
+          source: src,
+          "source-layer": sourceLayer,
+          filter: [
+            "match",
+            ["geometry-type"],
+            ["Polygon", "MultiPolygon"],
+            true,
+            false,
+          ],
+          paint: fillExtrusionPaint(layer.style, layer.opacity),
+          layout: { visibility },
+        },
+        beforeId,
+      );
+    } else {
+      removeIfExists(map, vectorTileLayerId(layer.id, true, layerPart));
+      ensureLayer(
+        map,
+        vectorTileLayerId(layer.id, false, layerPart),
+        {
+          id: vectorTileLayerId(layer.id, false, layerPart),
+          type: "fill",
+          source: src,
+          "source-layer": sourceLayer,
+          filter: [
+            "match",
+            ["geometry-type"],
+            ["Polygon", "MultiPolygon"],
+            true,
+            false,
+          ],
+          paint: fillPaint(layer.style, layer.opacity),
+          layout: { visibility },
+        },
+        beforeId,
+      );
+      ensureLayer(
+        map,
+        vectorTileLineLayerId(layer.id, layerPart),
+        {
+          id: vectorTileLineLayerId(layer.id, layerPart),
+          type: "line",
+          source: src,
+          "source-layer": sourceLayer,
+          filter: [
+            "match",
+            ["geometry-type"],
+            ["LineString", "MultiLineString", "Polygon", "MultiPolygon"],
+            true,
+            false,
+          ],
+          paint: linePaint(layer.style, layer.opacity),
+          layout: { visibility },
+        },
+        beforeId,
+      );
+      ensureLayer(
+        map,
+        vectorTileCircleLayerId(layer.id, layerPart),
+        {
+          id: vectorTileCircleLayerId(layer.id, layerPart),
+          type: "circle",
+          source: src,
+          "source-layer": sourceLayer,
+          filter: [
+            "match",
+            ["geometry-type"],
+            ["Point", "MultiPoint"],
+            true,
+            false,
+          ],
+          paint: circlePaint(layer.style, layer.opacity),
+          layout: { visibility },
+        },
+        beforeId,
+      );
+    }
   }
+
+  removeStaleVectorTileLayers(map, layer.id, currentLayerIds);
 }
 
 function syncMbtilesLayer(
@@ -612,6 +619,10 @@ function encodeMbtilesLayerPart(value: string): string {
   return encodeURIComponent(value).replaceAll("%", "_");
 }
 
+function encodeVectorTileLayerPart(value: string): string {
+  return encodeURIComponent(value).replaceAll("%", "_");
+}
+
 export function mbtilesFillLayerId(
   layerId: string,
   sourceLayer: string,
@@ -672,28 +683,98 @@ export function mbtilesAllStyleLayerIds(layer: GeoLibreLayer): string[] {
 export function vectorTileLayerId(
   layerId: string,
   extrusionEnabled = false,
+  sourceLayer?: string,
 ): string {
+  if (sourceLayer) {
+    return `layer-${layerId}-vector-${encodeVectorTileLayerPart(sourceLayer)}-${extrusionEnabled ? "extrusion" : "fill"}`;
+  }
   return `layer-${layerId}-${extrusionEnabled ? "vector-extrusion" : "vector"}`;
 }
 
-export function vectorTileLineLayerId(layerId: string): string {
+export function vectorTileLineLayerId(
+  layerId: string,
+  sourceLayer?: string,
+): string {
+  if (sourceLayer) {
+    return `layer-${layerId}-vector-${encodeVectorTileLayerPart(sourceLayer)}-line`;
+  }
   return `layer-${layerId}-vector-line`;
 }
 
-export function vectorTileCircleLayerId(layerId: string): string {
+export function vectorTileCircleLayerId(
+  layerId: string,
+  sourceLayer?: string,
+): string {
+  if (sourceLayer) {
+    return `layer-${layerId}-vector-${encodeVectorTileLayerPart(sourceLayer)}-circle`;
+  }
   return `layer-${layerId}-vector-circle`;
 }
 
 export function vectorTileStyleLayerIds(layer: GeoLibreLayer): string[] {
   if (layer.type !== "vector-tiles") return [];
-  if (layer.style.extrusionEnabled) {
-    return [vectorTileLayerId(layer.id, true)];
+  return getVectorTileSourceLayers(layer).flatMap((sourceLayer) => {
+    const layerPart = vectorTileScopedSourceLayer(layer, sourceLayer);
+    if (layer.style.extrusionEnabled) {
+      return [vectorTileLayerId(layer.id, true, layerPart)];
+    }
+    return [
+      vectorTileCircleLayerId(layer.id, layerPart),
+      vectorTileLineLayerId(layer.id, layerPart),
+      vectorTileLayerId(layer.id, false, layerPart),
+    ];
+  });
+}
+
+function vectorTileAllStyleLayerIds(layer: GeoLibreLayer): string[] {
+  if (layer.type !== "vector-tiles") return [];
+  return getVectorTileSourceLayers(layer).flatMap((sourceLayer) => {
+    const layerPart = vectorTileScopedSourceLayer(layer, sourceLayer);
+    return [
+      vectorTileCircleLayerId(layer.id, layerPart),
+      vectorTileLineLayerId(layer.id, layerPart),
+      vectorTileLayerId(layer.id, false, layerPart),
+      vectorTileLayerId(layer.id, true, layerPart),
+    ];
+  });
+}
+
+function getVectorTileSourceLayers(layer: GeoLibreLayer): string[] {
+  const sourceLayers = layer.source.sourceLayers ?? layer.metadata.sourceLayers;
+  if (Array.isArray(sourceLayers)) {
+    return sourceLayers.filter(
+      (sourceLayer): sourceLayer is string =>
+        typeof sourceLayer === "string" && sourceLayer.length > 0,
+    );
   }
-  return [
-    vectorTileCircleLayerId(layer.id),
-    vectorTileLineLayerId(layer.id),
-    vectorTileLayerId(layer.id),
-  ];
+
+  const sourceLayer = layer.source.sourceLayer;
+  return typeof sourceLayer === "string" && sourceLayer.length > 0
+    ? [sourceLayer]
+    : [];
+}
+
+function vectorTileScopedSourceLayer(
+  layer: GeoLibreLayer,
+  sourceLayer: string,
+): string | undefined {
+  return getVectorTileSourceLayers(layer).length > 1 ? sourceLayer : undefined;
+}
+
+function removeStaleVectorTileLayers(
+  map: maplibregl.Map,
+  layerId: string,
+  currentLayerIds: Set<string>,
+): void {
+  const prefix = `layer-${layerId}-vector`;
+  for (const styleLayer of map.getStyle().layers ?? []) {
+    if (
+      styleLayer.id.startsWith(prefix) &&
+      !currentLayerIds.has(styleLayer.id)
+    ) {
+      removeIfExists(map, styleLayer.id);
+    }
+  }
 }
 
 function ensureLayer(
@@ -754,6 +835,7 @@ export function removeLayerFromMap(
     lineLayerId(layerId),
     circleLayerId(layerId),
     `layer-${layerId}-raster`,
+    ...(layer ? vectorTileAllStyleLayerIds(layer) : []),
     vectorTileCircleLayerId(layerId),
     vectorTileLineLayerId(layerId),
     vectorTileLayerId(layerId),

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -24,7 +24,7 @@ import {
   mbtilesStyleLayerIds,
   removeLayerFromMap,
   syncLayer,
-  vectorTileLayerId,
+  vectorTileStyleLayerIds,
 } from "./layer-sync";
 
 const DEFAULT_PROJECTION: maplibregl.ProjectionSpecification = {
@@ -1101,10 +1101,10 @@ export class MapController {
     }
 
     if (layer.type === "vector-tiles") {
-      return [
-        { id: vectorTileLayerId(layer.id, true), suffix: "Extrusions" },
-        { id: vectorTileLayerId(layer.id), suffix: "Polygons" },
-      ];
+      return vectorTileStyleLayerIds(layer).map((id) => ({
+        id,
+        suffix: nativeLayerSuffix(id),
+      }));
     }
 
     if (layer.type === "mbtiles") {

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -86,6 +86,18 @@ function nativeLayerSuffix(layerId: string): string | undefined {
   return suffix.charAt(0).toUpperCase() + suffix.slice(1);
 }
 
+function vectorTileLayerSuffix(layerId: string): string | undefined {
+  if (layerId.endsWith("-vector") || layerId.endsWith("-fill")) {
+    return "Polygons";
+  }
+  if (layerId.endsWith("-vector-extrusion") || layerId.endsWith("-extrusion")) {
+    return "Extrusions";
+  }
+  if (layerId.endsWith("-line")) return "Lines";
+  if (layerId.endsWith("-circle")) return "Points";
+  return nativeLayerSuffix(layerId);
+}
+
 function createBlankMapStyle(): maplibregl.StyleSpecification {
   return {
     version: 8,
@@ -1103,7 +1115,7 @@ export class MapController {
     if (layer.type === "vector-tiles") {
       return vectorTileStyleLayerIds(layer).map((id) => ({
         id,
-        suffix: nativeLayerSuffix(id),
+        suffix: vectorTileLayerSuffix(id),
       }));
     }
 


### PR DESCRIPTION
## Summary
- Add PostgreSQL/PostGIS support by auto-downloading the Martin tile server binary, spawning a local server bound to a free loopback port, and waiting on its health endpoint before use.
- Fetch the Martin catalog and per-source TileJSON, and surface PostGIS tables as vector tile layers through the Add Data dialog and map sync.
- Allow loopback connections in the Tauri CSP so the webview can reach the local Martin server.

## Test plan
- [ ] Launch the desktop app and open Add Data, connect to a PostGIS database, and confirm tables appear as selectable sources.
- [ ] Add a PostGIS source and verify the vector tiles render on the map.
- [ ] Confirm the Martin binary downloads once and is reused on subsequent runs, and that the server process stops cleanly on exit.