### PR TITLE
feat: add WMTS tile layer support

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -57,6 +57,7 @@ import { isTauri } from "../../lib/tauri-io";
 export type AddDataKind =
   | "xyz"
   | "wms"
+  | "wmts"
   | "vector"
   | "raster"
   | "mbtiles"
@@ -76,6 +77,7 @@ type RasterColormap = NonNullable<CogRasterLayerOptions["colormap"]>;
 const KIND_LABELS: Record<AddDataKind, string> = {
   xyz: "Add XYZ Layer",
   wms: "Add WMS Layer",
+  wmts: "Add WMTS Layer",
   vector: "Add Vector Layer",
   raster: "Add Raster Layer",
   mbtiles: "Add MBTiles Layer",
@@ -104,6 +106,8 @@ const DEFAULT_XYZ_URL =
 const DEFAULT_WMS_ENDPOINT =
   "https://imagery.nationalmap.gov/arcgis/services/USGSNAIPImagery/ImageServer/WMSServer";
 const DEFAULT_WMS_LAYERS = "USGSNAIPImagery:FalseColorComposite";
+const DEFAULT_WMTS_URL =
+  "https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/MapServer/tile/119/{z}/{y}/{x}";
 const DEFAULT_RASTER_URL =
   "https://data.source.coop/giswqs/opengeos/nlcd_2021_land_cover_30m.tif";
 const DEFAULT_ARCGIS_FEATURE_URL =
@@ -289,6 +293,8 @@ export function AddDataDialog({
   const [wmsFormat, setWmsFormat] = useState("image/png");
   const [wmsTransparent, setWmsTransparent] = useState(true);
   const [wmsTileSize, setWmsTileSize] = useState("256");
+  const [wmtsUrl, setWmtsUrl] = useState(DEFAULT_WMTS_URL);
+  const [wmtsTileSize, setWmtsTileSize] = useState("256");
 
   const [vectorMode, setVectorMode] = useState<VectorMode>("vector-file");
   const [vectorUrl, setVectorUrl] = useState("");
@@ -344,6 +350,7 @@ export function AddDataDialog({
       {
         xyz: "XYZ Layer",
         wms: "WMS Layer",
+        wmts: "WMTS Layer",
         vector: "Vector Layer",
         raster: "Raster Layer",
         mbtiles: "MBTiles Layer",
@@ -360,6 +367,8 @@ export function AddDataDialog({
     setWmsFormat("image/png");
     setWmsTransparent(true);
     setWmsTileSize("256");
+    setWmtsUrl(DEFAULT_WMTS_URL);
+    setWmtsTileSize("256");
     setVectorMode("vector-file");
     setVectorUrl("");
     setVectorSourceLayer("");
@@ -401,6 +410,9 @@ export function AddDataDialog({
     }
     if (kind === "wms") {
       return "Add a WMS GetMap service as a tiled raster layer.";
+    }
+    if (kind === "wmts") {
+      return "Add a WMTS tile URL template as a raster layer.";
     }
     if (kind === "vector") {
       return "Add local vector files supported by DuckDB Spatial, GeoJSON URLs, or MapLibre vector tile sources.";
@@ -682,6 +694,26 @@ export function AddDataDialog({
               transparent: wmsTransparent,
             },
             { service: "wms" },
+          ),
+        );
+        return;
+      }
+
+      if (kind === "wmts") {
+        if (!wmtsUrl.trim()) {
+          throw new Error("Enter a WMTS tile URL template.");
+        }
+        addAndClose(
+          createBaseLayer(
+            name,
+            "wmts",
+            {
+              type: "raster",
+              tiles: [wmtsUrl.trim()],
+              tileSize: Number(wmtsTileSize) || 256,
+              url: wmtsUrl.trim(),
+            },
+            { service: "wmts" },
           ),
         );
         return;
@@ -975,6 +1007,29 @@ export function AddDataDialog({
                 />
                 Transparent background
               </label>
+            </div>
+          )}
+
+          {kind === "wmts" && (
+            <div className="grid gap-3 sm:grid-cols-[1fr_7rem]">
+              <div className="space-y-1.5">
+                <Label htmlFor="wmts-url">Tile URL template</Label>
+                <Input
+                  id="wmts-url"
+                  placeholder="https://example.com/wmts/{z}/{y}/{x}.png"
+                  value={wmtsUrl}
+                  onChange={(event) => setWmtsUrl(event.target.value)}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="wmts-tile-size">Tile size</Label>
+                <Input
+                  id="wmts-tile-size"
+                  inputMode="numeric"
+                  value={wmtsTileSize}
+                  onChange={(event) => setWmtsTileSize(event.target.value)}
+                />
+              </div>
             </div>
           )}
 
@@ -1435,7 +1490,7 @@ export function AddDataDialog({
               Cancel
             </Button>
             <Button type="submit" disabled={addLayerDisabled}>
-              {kind === "wms" ? (
+              {kind === "wms" || kind === "wmts" ? (
                 <Globe2 className="mr-2 h-3.5 w-3.5" />
               ) : kind === "raster" ? (
                 <Image className="mr-2 h-3.5 w-3.5" />

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -228,6 +228,9 @@ export function TopToolbar({
           <DropdownMenuItem onSelect={() => setAddDataKind("wms")}>
             Add WMS Layer
           </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setAddDataKind("wmts")}>
+            Add WMTS Layer
+          </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => setAddDataKind("vector")}>
             Add Vector Layer
           </DropdownMenuItem>

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -37,7 +37,12 @@ function isMobileViewport(): boolean {
 }
 
 function isRasterPaintLayer(type: LayerType): boolean {
-  return type === "raster" || type === "wms" || type === "xyz";
+  return (
+    type === "raster" ||
+    type === "wms" ||
+    type === "wmts" ||
+    type === "xyz"
+  );
 }
 
 function hasExternalNativeLayers(layer: { metadata: Record<string, unknown> }) {

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -798,7 +798,9 @@ body,
 }
 
 .maplibregl-control-container {
-  position: relative;
+  inset: 0;
+  pointer-events: none;
+  position: absolute;
   z-index: 2;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -43,6 +43,7 @@ export type LayerType =
   | "geojson"
   | "raster"
   | "wms"
+  | "wmts"
   | "xyz"
   | "vector-tiles"
   | "arcgis"

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -35,7 +35,12 @@ export function syncLayer(
     return;
   }
 
-  if (layer.type === "raster" || layer.type === "wms" || layer.type === "xyz") {
+  if (
+    layer.type === "raster" ||
+    layer.type === "wms" ||
+    layer.type === "wmts" ||
+    layer.type === "xyz"
+  ) {
     syncRasterTileLayer(map, layer, beforeId);
     return;
   }

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -1107,6 +1107,7 @@ export class MapController {
     if (
       layer.type === "raster" ||
       layer.type === "wms" ||
+      layer.type === "wmts" ||
       layer.type === "xyz"
     ) {
       return [{ id: `layer-${layer.id}-raster` }];


### PR DESCRIPTION
## Summary
- Add a new WMTS layer type that lets users add a WMTS tile URL template as a raster layer, alongside the existing XYZ and WMS options (menu item, Add Data dialog form, layer sync, and styling support).
- Fix the MapLibre control container so it overlays the map without blocking interaction.

## Test plan
- [ ] Open the Add Data dialog, choose Add WMTS Layer, and confirm a WMTS tile URL template renders on the map.
- [ ] Confirm the Style panel exposes raster paint controls for WMTS layers.
- [ ] Confirm map pan/zoom and clicks still work with the updated control container.