### PR TITLE
feat: add Esri Wayback imagery layer plugin

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -39,6 +39,7 @@
     "maplibre-gl-basemap-control": "^0.2.1",
     "maplibre-gl-components": "^0.17.3",
     "maplibre-gl-duckdb": "^0.2.0",
+    "maplibre-gl-esri-wayback": "^0.1.0",
     "maplibre-gl-geo-editor": "^0.7.3",
     "maplibre-gl-geoagent": "^0.4.2",
     "maplibre-gl-geoparquet": "^0.2.1",

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -2,6 +2,7 @@ import { useAppStore } from "@geolibre/core";
 import {
   maplibreBasemapControlPlugin,
   maplibreComponentsPlugin,
+  maplibreEsriWaybackPlugin,
   maplibreGeoAgentPlugin,
   maplibreGeoEditorPlugin,
   maplibreLayerControlPlugin,
@@ -25,6 +26,7 @@ const manager = new PluginManager();
 manager.registerAll([
   maplibreLayerControlPlugin,
   maplibreBasemapControlPlugin,
+  maplibreEsriWaybackPlugin,
   maplibreGeoAgentPlugin,
   maplibreGeoEditorPlugin,
   maplibreLidarPlugin,

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -52,6 +52,24 @@ body,
   margin: 0;
 }
 
+.geolibre-esri-wayback-control,
+.esri-wayback-control-panel {
+  color-scheme: light;
+}
+
+.esri-wayback-control-panel .esri-wayback-range {
+  accent-color: #2b7bb9;
+}
+
+.esri-wayback-control-panel .esri-wayback-input {
+  background-color: #fff !important;
+  color: #111827 !important;
+}
+
+.esri-wayback-control-panel .esri-wayback-input::placeholder {
+  color: #6b7280 !important;
+}
+
 .geolibre-components-control .maplibregl-ctrl-group,
 .geolibre-components-control .maplibregl-ctrl {
   align-items: center;

--- a/apps/geolibre-desktop/src/main.tsx
+++ b/apps/geolibre-desktop/src/main.tsx
@@ -6,6 +6,7 @@ import "@geoman-io/maplibre-geoman-free/dist/maplibre-geoman.css";
 import "maplibre-gl-basemap-control/style.css";
 import "maplibre-gl-components/style.css";
 import "maplibre-gl-duckdb/style.css";
+import "maplibre-gl-esri-wayback/style.css";
 import "maplibre-gl-geo-editor/style.css";
 import "maplibre-gl-geoagent/style.css";
 import "maplibre-gl-geoparquet/style.css";

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "maplibre-gl-basemap-control": "^0.2.1",
         "maplibre-gl-components": "^0.17.3",
         "maplibre-gl-duckdb": "^0.2.0",
+        "maplibre-gl-esri-wayback": "^0.1.0",
         "maplibre-gl-geo-editor": "^0.7.3",
         "maplibre-gl-geoagent": "^0.4.2",
         "maplibre-gl-geoparquet": "^0.2.1",
@@ -1854,6 +1855,12 @@
       "peerDependencies": {
         "maplibre-gl": ">=5.11.0"
       }
+    },
+    "node_modules/@esri/wayback-core": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@esri/wayback-core/-/wayback-core-1.0.10.tgz",
+      "integrity": "sha512-gN3p868TRVPEUL2X34yqjvjOux40CpnnGcvMLzKpzePvV19OyAblv0rGHab8oM4bP9HY2IXRyDlkx7EZa8B3TA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
@@ -9782,6 +9789,28 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
+    "node_modules/maplibre-gl-esri-wayback": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-esri-wayback/-/maplibre-gl-esri-wayback-0.1.0.tgz",
+      "integrity": "sha512-lJpqPZBQ0nNpoyAhHbJ5iQ6MOsunGUY2gOsKeHz6EaThzR/y41DkPdJU5VhaKFvIFSSKIEUyWoaZSTgW7B39yQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@esri/wayback-core": ">=1.0.10"
+      },
+      "peerDependencies": {
+        "maplibre-gl": ">=5.24.0",
+        "react": ">=19.2.6",
+        "react-dom": ">=19.2.6"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/maplibre-gl-geo-editor": {
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/maplibre-gl-geo-editor/-/maplibre-gl-geo-editor-0.7.3.tgz",
@@ -9926,35 +9955,6 @@
         "@math.gl/polygon": "^3.6.2",
         "apache-arrow": ">=15"
       }
-    },
-    "node_modules/maplibre-gl-geoparquet/node_modules/@math.gl/core": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@math.gl/core/-/core-3.6.3.tgz",
-      "integrity": "sha512-jBABmDkj5uuuE0dTDmwwss7Cup5ZwQ6Qb7h1pgvtkEutTrhkcv8SuItQNXmF45494yIHeoGue08NlyeY6wxq2A==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.0",
-        "@math.gl/types": "3.6.3",
-        "gl-matrix": "^3.4.0"
-      }
-    },
-    "node_modules/maplibre-gl-geoparquet/node_modules/@math.gl/polygon": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@math.gl/polygon/-/polygon-3.6.3.tgz",
-      "integrity": "sha512-FivQ1ZnYcAss1wVifOkHP/ZnlfQy1IL/769uzNtiHxwUbW0kZG3yyOZ9I7fwyzR5Hvqt3ErJKHjSYZr0uVlz5g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@math.gl/core": "3.6.3"
-      }
-    },
-    "node_modules/maplibre-gl-geoparquet/node_modules/@math.gl/types": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@math.gl/types/-/types-3.6.3.tgz",
-      "integrity": "sha512-3uWLVXHY3jQxsXCr/UCNPSc2BG0hNUljhmOBt9l+lNFDp7zHgm0cK2Tw4kj2XfkJy4TgwZTBGwRDQgWEbLbdTA==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/maplibre-gl-geoparquet/node_modules/apache-arrow": {
       "version": "21.1.0",
@@ -12601,6 +12601,7 @@
         "maplibre-gl-basemap-control": "^0.2.1",
         "maplibre-gl-components": "^0.17.3",
         "maplibre-gl-duckdb": "^0.2.0",
+        "maplibre-gl-esri-wayback": "^0.1.0",
         "maplibre-gl-geo-editor": "^0.7.3",
         "maplibre-gl-geoagent": "^0.4.2",
         "maplibre-gl-geoparquet": "^0.2.1",

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -65,6 +65,11 @@ function syncExternalNativeLayer(
   beforeId?: string,
 ): void {
   const nativeLayerIds = getExternalNativeLayerIds(layer);
+  if (isWaybackExternalRasterLayer(layer)) {
+    syncWaybackExternalRasterLayer(map, layer, nativeLayerIds, beforeId);
+    return;
+  }
+
   const nativeFillLayerSpecs = nativeLayerIds
     .map((nativeLayerId) => getStyleLayerSpec(map, nativeLayerId))
     .filter(isFillStyleLayerSpec);
@@ -114,6 +119,69 @@ function syncExternalNativeLayer(
 
     moveLayer(map, nativeLayerId, beforeId);
   }
+}
+
+function isWaybackExternalRasterLayer(layer: GeoLibreLayer): boolean {
+  return (
+    layer.type === "raster" &&
+    (layer.metadata.sourceKind === "esri-wayback-current" ||
+      layer.metadata.sourceKind === "esri-wayback-persistent") &&
+    layer.metadata.externalNativeLayer === true
+  );
+}
+
+function syncWaybackExternalRasterLayer(
+  map: maplibregl.Map,
+  layer: GeoLibreLayer,
+  nativeLayerIds: string[],
+  beforeId?: string,
+): void {
+  const nativeLayerId = nativeLayerIds[0] ?? layer.id;
+  const sourceId = getExternalSourceIds(layer)[0] ?? `${nativeLayerId}-source`;
+  const tileUrl = getWaybackTileUrl(layer);
+  if (!tileUrl) return;
+
+  if (!map.getSource(sourceId)) {
+    map.addSource(sourceId, {
+      type: "raster",
+      tiles: [tileUrl],
+      tileSize: 256,
+      maxzoom: 23,
+    });
+  }
+
+  ensureLayer(
+    map,
+    nativeLayerId,
+    {
+      id: nativeLayerId,
+      type: "raster",
+      source: sourceId,
+      paint: rasterPaint(layer.style, layer.opacity),
+      layout: { visibility: layer.visible ? "visible" : "none" },
+    },
+    beforeId,
+  );
+}
+
+function getWaybackTileUrl(layer: GeoLibreLayer): string | null {
+  const rawUrl =
+    stringMetadata(layer.metadata.waybackItemUrl) ??
+    stringSource(layer.source.url) ??
+    layer.sourcePath;
+  if (!rawUrl) return null;
+  return rawUrl
+    .replace(/\{level\}/g, "{z}")
+    .replace(/\{row\}/g, "{y}")
+    .replace(/\{col\}/g, "{x}");
+}
+
+function stringMetadata(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function stringSource(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
 }
 
 function setNativeLayerVisibility(

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -28,6 +28,7 @@
     "maplibre-gl-basemap-control": "^0.2.1",
     "maplibre-gl-components": "^0.17.3",
     "maplibre-gl-duckdb": "^0.2.0",
+    "maplibre-gl-esri-wayback": "^0.1.0",
     "maplibre-gl-geo-editor": "^0.7.3",
     "maplibre-gl-geoagent": "^0.4.2",
     "maplibre-gl-geoparquet": "^0.2.1",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -27,6 +27,7 @@ export {
 } from "./plugins/maplibre-components";
 export { openDuckDBLayerPanel } from "./plugins/maplibre-duckdb";
 export { openGeoParquetLayerPanel } from "./plugins/maplibre-geoparquet";
+export { maplibreEsriWaybackPlugin } from "./plugins/maplibre-esri-wayback";
 export { maplibreGeoEditorPlugin } from "./plugins/maplibre-geo-editor";
 export { maplibreGeoAgentPlugin } from "./plugins/maplibre-geoagent";
 export { maplibreLidarPlugin } from "./plugins/maplibre-lidar";

--- a/packages/plugins/src/plugins/maplibre-esri-wayback.ts
+++ b/packages/plugins/src/plugins/maplibre-esri-wayback.ts
@@ -74,7 +74,11 @@ export const maplibreEsriWaybackPlugin: GeoLibrePlugin = {
     if (!esriWaybackControl) return;
     app.removeMapControl(esriWaybackControl);
     const added = app.addMapControl(esriWaybackControl, esriWaybackPosition);
-    if (!added) return false;
+    if (!added) {
+      detachStoreSync(esriWaybackControl);
+      esriWaybackControl = null;
+      return false;
+    }
     setTimeout(() => esriWaybackControl?.expand(), 0);
   },
 };
@@ -120,14 +124,28 @@ function syncPersistentWaybackLayers(
   const state = control?.getState();
   if (!map || !state) return;
 
+  const activePersistentIds = new Set<string>();
   for (const styleLayer of map.getStyle().layers ?? []) {
     if (!styleLayer.id.startsWith(`${PERSISTENT_LAYER_PREFIX}-`)) continue;
+    activePersistentIds.add(styleLayer.id);
     const release = state.releases.find(
       (item) => getPersistentWaybackLayerId(item) === styleLayer.id,
     );
     addOrUpdateWaybackStoreLayer(
       createPersistentWaybackStoreLayer(styleLayer, release),
     );
+  }
+
+  const store = useAppStore.getState();
+  const stalePersistentIds = store.layers
+    .filter(
+      (layer) =>
+        layer.metadata.sourceKind === "esri-wayback-persistent" &&
+        !activePersistentIds.has(layer.id),
+    )
+    .map((layer) => layer.id);
+  for (const id of stalePersistentIds) {
+    store.removeLayer(id);
   }
 }
 
@@ -226,6 +244,7 @@ function createWaybackStoreLayer(options: {
       sourceIds: [options.sourceId],
       sourceKind: options.sourceKind,
       waybackItemId: options.release?.itemID,
+      waybackItemUrl: options.release?.itemURL,
       waybackMetadataLayerUrl: options.release?.metadataLayerUrl,
       waybackReleaseDate: options.release?.releaseDateLabel,
       waybackReleaseNumber: options.release?.releaseNum,

--- a/packages/plugins/src/plugins/maplibre-esri-wayback.ts
+++ b/packages/plugins/src/plugins/maplibre-esri-wayback.ts
@@ -1,0 +1,248 @@
+import {
+  DEFAULT_LAYER_STYLE,
+  useAppStore,
+  type GeoLibreLayer,
+} from "@geolibre/core";
+import {
+  DEFAULT_LAYER_ID,
+  DEFAULT_SOURCE_ID,
+  EsriWaybackControl,
+  PERSISTENT_LAYER_PREFIX,
+  getPersistentWaybackLayerId,
+  type EsriWaybackControlEventHandler,
+  type EsriWaybackControlOptions,
+  type EsriWaybackRelease,
+} from "maplibre-gl-esri-wayback";
+import type { LayerSpecification } from "maplibre-gl";
+import type {
+  GeoLibreAppAPI,
+  GeoLibreMapControlPosition,
+  GeoLibrePlugin,
+} from "../types";
+
+let esriWaybackPosition: GeoLibreMapControlPosition = "top-left";
+
+const ESRI_WAYBACK_OPTIONS = {
+  collapsed: false,
+  title: "Esri Wayback",
+  panelWidth: 340,
+  className: "geolibre-esri-wayback-control",
+  metadataOnClick: true,
+} satisfies Omit<EsriWaybackControlOptions, "position">;
+
+let esriWaybackControl: EsriWaybackControl | null = null;
+let releaseChangeHandler: EsriWaybackControlEventHandler | null = null;
+let stateChangeHandler: EsriWaybackControlEventHandler | null = null;
+
+export const maplibreEsriWaybackPlugin: GeoLibrePlugin = {
+  id: "maplibre-gl-esri-wayback",
+  name: "Esri Wayback",
+  version: "0.1.0",
+  activate: (app: GeoLibreAppAPI) => {
+    if (!esriWaybackControl) {
+      esriWaybackControl = new EsriWaybackControl(
+        getEsriWaybackControlOptions(),
+      );
+      attachStoreSync(esriWaybackControl);
+    }
+
+    const added = app.addMapControl(esriWaybackControl, esriWaybackPosition);
+    if (!added) {
+      detachStoreSync(esriWaybackControl);
+      esriWaybackControl = null;
+      return false;
+    }
+    setTimeout(() => {
+      esriWaybackControl?.expand();
+      syncCurrentWaybackLayer(esriWaybackControl);
+      syncPersistentWaybackLayers(esriWaybackControl);
+    }, 0);
+  },
+  deactivate: (app: GeoLibreAppAPI) => {
+    if (!esriWaybackControl) return;
+    detachStoreSync(esriWaybackControl);
+    app.removeMapControl(esriWaybackControl);
+    esriWaybackControl = null;
+    removeCurrentWaybackStoreLayer();
+  },
+  getMapControlPosition: () => esriWaybackPosition,
+  setMapControlPosition: (
+    app: GeoLibreAppAPI,
+    position: GeoLibreMapControlPosition,
+  ) => {
+    esriWaybackPosition = position;
+    if (!esriWaybackControl) return;
+    app.removeMapControl(esriWaybackControl);
+    const added = app.addMapControl(esriWaybackControl, esriWaybackPosition);
+    if (!added) return false;
+    setTimeout(() => esriWaybackControl?.expand(), 0);
+  },
+};
+
+function getEsriWaybackControlOptions(): EsriWaybackControlOptions {
+  return {
+    ...ESRI_WAYBACK_OPTIONS,
+    position: esriWaybackPosition,
+  };
+}
+
+function attachStoreSync(control: EsriWaybackControl): void {
+  releaseChangeHandler = () => syncCurrentWaybackLayer(control);
+  stateChangeHandler = () => syncPersistentWaybackLayers(control);
+  control.on("releasechange", releaseChangeHandler);
+  control.on("statechange", stateChangeHandler);
+}
+
+function detachStoreSync(control: EsriWaybackControl): void {
+  if (releaseChangeHandler) {
+    control.off("releasechange", releaseChangeHandler);
+    releaseChangeHandler = null;
+  }
+  if (stateChangeHandler) {
+    control.off("statechange", stateChangeHandler);
+    stateChangeHandler = null;
+  }
+}
+
+function syncCurrentWaybackLayer(
+  control: EsriWaybackControl | null,
+): void {
+  const map = control?.getMap();
+  const release = control?.getState().selectedRelease;
+  if (!map?.getLayer(DEFAULT_LAYER_ID) || !release) return;
+  addOrUpdateWaybackStoreLayer(createCurrentWaybackStoreLayer(release));
+}
+
+function syncPersistentWaybackLayers(
+  control: EsriWaybackControl | null,
+): void {
+  const map = control?.getMap();
+  const state = control?.getState();
+  if (!map || !state) return;
+
+  for (const styleLayer of map.getStyle().layers ?? []) {
+    if (!styleLayer.id.startsWith(`${PERSISTENT_LAYER_PREFIX}-`)) continue;
+    const release = state.releases.find(
+      (item) => getPersistentWaybackLayerId(item) === styleLayer.id,
+    );
+    addOrUpdateWaybackStoreLayer(
+      createPersistentWaybackStoreLayer(styleLayer, release),
+    );
+  }
+}
+
+function addOrUpdateWaybackStoreLayer(layer: GeoLibreLayer): void {
+  const store = useAppStore.getState();
+  const existingLayer = store.layers.find((item) => item.id === layer.id);
+  if (!existingLayer) {
+    store.addLayer(layer);
+    return;
+  }
+
+  if (!shouldUpdateWaybackStoreLayer(existingLayer, layer)) return;
+
+  store.updateLayer(layer.id, {
+    metadata: layer.metadata,
+    name: layer.name,
+    source: layer.source,
+    sourcePath: layer.sourcePath,
+  });
+}
+
+function shouldUpdateWaybackStoreLayer(
+  existingLayer: GeoLibreLayer,
+  nextLayer: GeoLibreLayer,
+): boolean {
+  return (
+    existingLayer.name !== nextLayer.name ||
+    existingLayer.sourcePath !== nextLayer.sourcePath ||
+    JSON.stringify(existingLayer.metadata) !==
+      JSON.stringify(nextLayer.metadata) ||
+    JSON.stringify(existingLayer.source) !== JSON.stringify(nextLayer.source)
+  );
+}
+
+function removeCurrentWaybackStoreLayer(): void {
+  const store = useAppStore.getState();
+  if (store.layers.some((layer) => layer.id === DEFAULT_LAYER_ID)) {
+    store.removeLayer(DEFAULT_LAYER_ID);
+  }
+}
+
+function createCurrentWaybackStoreLayer(
+  release: EsriWaybackRelease,
+): GeoLibreLayer {
+  return createWaybackStoreLayer({
+    id: DEFAULT_LAYER_ID,
+    name: `Esri Wayback ${release.releaseDateLabel}`,
+    nativeLayerId: DEFAULT_LAYER_ID,
+    release,
+    sourceId: DEFAULT_SOURCE_ID,
+    sourceKind: "esri-wayback-current",
+  });
+}
+
+function createPersistentWaybackStoreLayer(
+  styleLayer: LayerSpecification,
+  release: EsriWaybackRelease | undefined,
+): GeoLibreLayer {
+  return createWaybackStoreLayer({
+    id: styleLayer.id,
+    name: release
+      ? `Esri Wayback ${release.releaseDateLabel}`
+      : layerNameFromPersistentWaybackId(styleLayer.id),
+    nativeLayerId: styleLayer.id,
+    release,
+    sourceId: getStyleLayerSourceId(styleLayer) ?? `${styleLayer.id}-source`,
+    sourceKind: "esri-wayback-persistent",
+  });
+}
+
+function createWaybackStoreLayer(options: {
+  id: string;
+  name: string;
+  nativeLayerId: string;
+  release?: EsriWaybackRelease;
+  sourceId: string;
+  sourceKind: "esri-wayback-current" | "esri-wayback-persistent";
+}): GeoLibreLayer {
+  return {
+    id: options.id,
+    name: options.name,
+    type: "raster",
+    source: {
+      type: "raster",
+      sourceId: options.sourceId,
+      url: options.release?.itemURL,
+    },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {
+      externalNativeLayer: true,
+      identifiable: false,
+      nativeLayerIds: [options.nativeLayerId],
+      sourceId: options.sourceId,
+      sourceIds: [options.sourceId],
+      sourceKind: options.sourceKind,
+      waybackItemId: options.release?.itemID,
+      waybackMetadataLayerUrl: options.release?.metadataLayerUrl,
+      waybackReleaseDate: options.release?.releaseDateLabel,
+      waybackReleaseNumber: options.release?.releaseNum,
+    },
+    sourcePath: options.release?.itemURL,
+  };
+}
+
+function getStyleLayerSourceId(layer: LayerSpecification): string | undefined {
+  return "source" in layer && typeof layer.source === "string"
+    ? layer.source
+    : undefined;
+}
+
+function layerNameFromPersistentWaybackId(layerId: string): string {
+  const label = layerId
+    .replace(`${PERSISTENT_LAYER_PREFIX}-`, "")
+    .replaceAll("-", " ");
+  return label ? `Esri Wayback ${label}` : "Esri Wayback";
+}


### PR DESCRIPTION
## Summary
- Add the `maplibre-gl-esri-wayback` control as a GeoLibre plugin for browsing historical Esri World Imagery releases.
- Sync the selected and pinned wayback layers into the app layer store so they show up in the layer panel alongside other layers.
- Register the plugin, add its stylesheet, and apply light styling overrides for the control panel.

## Test plan
- [ ] Launch the desktop app and enable the Esri Wayback control from the Controls menu.
- [ ] Select a historical release and confirm the imagery updates on the map and a corresponding entry appears in the layer panel.
- [ ] Pin one or more releases and confirm persistent layers appear in the layer panel.
- [ ] Toggle the plugin off and confirm the wayback layers are removed.