### PR TITLE
feat: resolve short and redirect XYZ tile URLs

### DIFF
--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -56,6 +56,7 @@ pub fn run() {
             close_oauth_popups,
             ensure_martin_binary,
             fetch_url_bytes,
+            resolve_url_redirect,
             read_mbtiles_metadata,
             read_mbtiles_tile,
             start_martin_server,
@@ -99,6 +100,96 @@ fn fetch_url_bytes(url: String) -> Result<Vec<u8>, String> {
         .bytes()
         .map(|bytes| bytes.to_vec())
         .map_err(|error| format!("Could not read response body: {error}"))
+}
+
+#[tauri::command]
+fn resolve_url_redirect(url: String) -> Result<String, String> {
+    if !url.starts_with("https://") && !url.starts_with("http://") {
+        return Err("Only HTTP and HTTPS URLs can be resolved".to_string());
+    }
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .map_err(|error| format!("Could not create HTTP client: {error}"))?;
+
+    if let Ok(head_response) = client.head(&url).send() {
+        if has_xyz_placeholders(head_response.url().as_str()) {
+            return Ok(head_response.url().to_string());
+        }
+    }
+
+    let response = client
+        .get(&url)
+        .header(
+            "accept",
+            "application/json, text/plain;q=0.9, */*;q=0.8",
+        )
+        .send()
+        .map_err(|error| format!("Request failed: {error}"))?;
+    if has_xyz_placeholders(response.url().as_str()) {
+        return Ok(response.url().to_string());
+    }
+
+    let response_url = response.url().to_string();
+    let body = response
+        .text()
+        .map_err(|error| format!("Could not read response body: {error}"))?;
+
+    resolved_url_from_body(&body)
+        .or_else(|| {
+            if response_url.starts_with("https://") || response_url.starts_with("http://") {
+                Some(response_url)
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| "Could not resolve URL".to_string())
+}
+
+fn has_xyz_placeholders(url: &str) -> bool {
+    let normalized = url.to_ascii_lowercase();
+    (normalized.contains("{z}") || normalized.contains("%7bz%7d"))
+        && (normalized.contains("{x}") || normalized.contains("%7bx%7d"))
+        && (normalized.contains("{y}") || normalized.contains("%7by%7d"))
+}
+
+fn resolved_url_from_body(body: &str) -> Option<String> {
+    let trimmed = body.trim();
+    if trimmed.starts_with("https://") || trimmed.starts_with("http://") {
+        return Some(trimmed.to_string());
+    }
+
+    let value: Value = serde_json::from_str(trimmed).ok()?;
+    resolved_url_from_json(&value)
+}
+
+fn resolved_url_from_json(value: &Value) -> Option<String> {
+    if let Some(url) = value.as_str() {
+        return http_url(url);
+    }
+
+    let object = value.as_object()?;
+    for key in ["url", "tileUrl", "tile_url"] {
+        if let Some(url) = object.get(key).and_then(Value::as_str).and_then(http_url) {
+            return Some(url);
+        }
+    }
+
+    object
+        .get("tiles")
+        .and_then(Value::as_array)
+        .and_then(|tiles| tiles.first())
+        .and_then(Value::as_str)
+        .and_then(http_url)
+}
+
+fn http_url(url: &str) -> Option<String> {
+    if url.starts_with("https://") || url.starts_with("http://") {
+        Some(url.to_string())
+    } else {
+        None
+    }
 }
 
 #[derive(Serialize)]

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -121,30 +121,18 @@ fn resolve_url_redirect(url: String) -> Result<String, String> {
 
     let response = client
         .get(&url)
-        .header(
-            "accept",
-            "application/json, text/plain;q=0.9, */*;q=0.8",
-        )
+        .header("accept", "application/json, text/plain;q=0.9, */*;q=0.8")
         .send()
         .map_err(|error| format!("Request failed: {error}"))?;
     if has_xyz_placeholders(response.url().as_str()) {
         return Ok(response.url().to_string());
     }
 
-    let response_url = response.url().to_string();
     let body = response
         .text()
         .map_err(|error| format!("Could not read response body: {error}"))?;
 
-    resolved_url_from_body(&body)
-        .or_else(|| {
-            if response_url.starts_with("https://") || response_url.starts_with("http://") {
-                Some(response_url)
-            } else {
-                None
-            }
-        })
-        .ok_or_else(|| "Could not resolve URL".to_string())
+    resolved_url_from_body(&body).ok_or_else(|| "Could not resolve URL".to_string())
 }
 
 fn has_xyz_placeholders(url: &str) -> bool {

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -53,6 +53,11 @@ import {
   type MartinSourceSummary,
 } from "../../lib/martin";
 import { isTauri } from "../../lib/tauri-io";
+import {
+  createXyzTileUrlTemplate,
+  registerXyzTileProtocol,
+  resolveXyzTileUrlTemplate,
+} from "../../lib/xyz-url";
 
 export type AddDataKind =
   | "xyz"
@@ -286,6 +291,7 @@ export function AddDataDialog({
 
   const [xyzUrl, setXyzUrl] = useState(DEFAULT_XYZ_URL);
   const [xyzTileSize, setXyzTileSize] = useState("256");
+  const [xyzShortUrl, setXyzShortUrl] = useState(false);
 
   const [wmsEndpoint, setWmsEndpoint] = useState(DEFAULT_WMS_ENDPOINT);
   const [wmsLayers, setWmsLayers] = useState(DEFAULT_WMS_LAYERS);
@@ -361,6 +367,7 @@ export function AddDataDialog({
     setBeforeLayerId("");
     setXyzUrl(DEFAULT_XYZ_URL);
     setXyzTileSize("256");
+    setXyzShortUrl(false);
     setWmsEndpoint(DEFAULT_WMS_ENDPOINT);
     setWmsLayers(DEFAULT_WMS_LAYERS);
     setWmsStyles("");
@@ -655,12 +662,26 @@ export function AddDataDialog({
 
       if (kind === "xyz") {
         if (!xyzUrl.trim()) throw new Error("Enter an XYZ tile URL template.");
+        if (xyzShortUrl) registerXyzTileProtocol();
+        const tileUrl = xyzShortUrl
+          ? await resolveXyzTileUrlTemplate(xyzUrl)
+          : createXyzTileUrlTemplate(xyzUrl);
         addAndClose(
-          createBaseLayer(name, "xyz", {
-            type: "raster",
-            tiles: [xyzUrl.trim()],
-            tileSize: Number(xyzTileSize) || 256,
-          }),
+          createBaseLayer(
+            name,
+            "xyz",
+            {
+              type: "raster",
+              tiles: [tileUrl.renderUrl],
+              tileSize: Number(xyzTileSize) || 256,
+              url: tileUrl.originalUrl,
+            },
+            {
+              originalUrl: xyzShortUrl ? tileUrl.originalUrl : undefined,
+              resolvedUrl: tileUrl.redirected ? tileUrl.url : undefined,
+              sourceKind: "xyz-url",
+            },
+          ),
         );
         return;
       }
@@ -926,25 +947,39 @@ export function AddDataDialog({
           </div>
 
           {kind === "xyz" && (
-            <div className="grid gap-3 sm:grid-cols-[1fr_7rem]">
-              <div className="space-y-1.5">
-                <Label htmlFor="xyz-url">Tile URL template</Label>
-                <Input
-                  id="xyz-url"
-                  placeholder="https://example.com/{z}/{x}/{y}.png"
-                  value={xyzUrl}
-                  onChange={(event) => setXyzUrl(event.target.value)}
-                />
+            <div className="space-y-3">
+              <div className="grid gap-3 sm:grid-cols-[1fr_7rem]">
+                <div className="space-y-1.5">
+                  <Label htmlFor="xyz-url">Tile URL template</Label>
+                  <Input
+                    id="xyz-url"
+                    placeholder={
+                      xyzShortUrl
+                        ? "https://go.example.com/layer"
+                        : "https://example.com/{z}/{x}/{y}.png"
+                    }
+                    value={xyzUrl}
+                    onChange={(event) => setXyzUrl(event.target.value)}
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="xyz-tile-size">Tile size</Label>
+                  <Input
+                    id="xyz-tile-size"
+                    inputMode="numeric"
+                    value={xyzTileSize}
+                    onChange={(event) => setXyzTileSize(event.target.value)}
+                  />
+                </div>
               </div>
-              <div className="space-y-1.5">
-                <Label htmlFor="xyz-tile-size">Tile size</Label>
-                <Input
-                  id="xyz-tile-size"
-                  inputMode="numeric"
-                  value={xyzTileSize}
-                  onChange={(event) => setXyzTileSize(event.target.value)}
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={xyzShortUrl}
+                  onChange={(event) => setXyzShortUrl(event.target.checked)}
                 />
-              </div>
+                Short URL
+              </label>
             </div>
           )}
 

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -16,6 +16,7 @@ import {
   loadDroppedVectorPaths,
 } from "../../lib/tauri-io";
 import { registerMbtilesProtocol } from "../../lib/mbtiles";
+import { registerXyzTileProtocol } from "../../lib/xyz-url";
 import { AttributeTable } from "../panels/AttributeTable";
 import { LayerPanel } from "../panels/LayerPanel";
 import { StylePanel } from "../panels/StylePanel";
@@ -98,7 +99,10 @@ export function DesktopShell({
   }, []);
 
   useEffect(() => {
-    if (isTauri()) registerMbtilesProtocol();
+    if (isTauri()) {
+      registerMbtilesProtocol();
+      registerXyzTileProtocol();
+    }
   }, []);
 
   useEffect(() => {

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -119,7 +119,17 @@ export function TopToolbar({
   const handleOpen = async () => {
     const result = await openProjectFile();
     if (result) {
-      loadProject(await resolveProjectXyzLayers(result.project), result.path);
+      try {
+        loadProject(
+          await resolveProjectXyzLayers(result.project),
+          result.path,
+        );
+      } catch (error) {
+        console.error("Failed to open project", error);
+        window.alert(
+          error instanceof Error ? error.message : "Could not open project.",
+        );
+      }
     }
   };
 

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -54,6 +54,7 @@ import { useState, useSyncExternalStore } from "react";
 import { createAppAPI, usePluginRegistry } from "../../hooks/usePlugins";
 import type { ThemeMode } from "../../hooks/useThemeMode";
 import { openProjectFile, saveProjectFile } from "../../lib/tauri-io";
+import { resolveProjectXyzLayers } from "../../lib/xyz-url";
 import { AddDataDialog, type AddDataKind } from "./AddDataDialog";
 import { AboutDialog } from "./AboutDialog";
 import { NewProjectDialog } from "./NewProjectDialog";
@@ -117,7 +118,9 @@ export function TopToolbar({
 
   const handleOpen = async () => {
     const result = await openProjectFile();
-    if (result) loadProject(result.project, result.path);
+    if (result) {
+      loadProject(await resolveProjectXyzLayers(result.project), result.path);
+    }
   };
 
   const handleSave = async (): Promise<boolean> => {

--- a/apps/geolibre-desktop/src/hooks/useProjectUrlLoader.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectUrlLoader.ts
@@ -1,5 +1,6 @@
 import { parseProject, useAppStore } from "@geolibre/core";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { resolveProjectXyzLayers } from "../lib/xyz-url";
 
 export type ProjectUrlLoadState =
   | { error: null; message: null; status: "idle" }
@@ -29,6 +30,7 @@ export function useProjectUrlLoader(): ProjectUrlLoadState {
     });
 
     void loadProjectFromUrl(projectUrl, abortController.signal)
+      .then(resolveProjectXyzLayers)
       .then((project) => {
         loadProject(project, projectUrl);
         setState({

--- a/apps/geolibre-desktop/src/hooks/useProjectUrlLoader.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectUrlLoader.ts
@@ -30,8 +30,11 @@ export function useProjectUrlLoader(): ProjectUrlLoadState {
     });
 
     void loadProjectFromUrl(projectUrl, abortController.signal)
-      .then(resolveProjectXyzLayers)
+      .then((project) =>
+        resolveProjectXyzLayers(project, abortController.signal),
+      )
       .then((project) => {
+        if (abortController.signal.aborted) return;
         loadProject(project, projectUrl);
         setState({
           error: null,

--- a/apps/geolibre-desktop/src/lib/xyz-url.ts
+++ b/apps/geolibre-desktop/src/lib/xyz-url.ts
@@ -1,0 +1,264 @@
+import type { GeoLibreLayer, GeoLibreProject } from "@geolibre/core";
+import { addProtocol, type RequestParameters } from "maplibre-gl";
+import { isTauri } from "./tauri-io";
+
+const XYZ_TILE_PROTOCOL = "geolibre-xyz";
+
+let protocolRegistered = false;
+
+export interface ResolvedXyzTileUrl {
+  originalUrl: string;
+  redirected: boolean;
+  renderUrl: string;
+  url: string;
+}
+
+export function normalizeTileUrlTemplate(url: string): string {
+  return url
+    .replace(/%7B([xyz])%7D/gi, (_, placeholder: string) => {
+      return `{${placeholder.toLowerCase()}}`;
+    })
+    .replace(/\{([xyz])\}/gi, (_, placeholder: string) => {
+      return `{${placeholder.toLowerCase()}}`;
+    });
+}
+
+export function hasXyzTilePlaceholders(url: string): boolean {
+  return ["x", "y", "z"].every((placeholder) =>
+    url.includes(`{${placeholder}}`),
+  );
+}
+
+export function createXyzTileUrlTemplate(url: string): ResolvedXyzTileUrl {
+  const originalUrl = normalizeTileUrlTemplate(url.trim());
+  if (!hasXyzTilePlaceholders(originalUrl)) {
+    throw new Error(
+      "Enter an XYZ tile URL template with {z}, {x}, and {y} placeholders.",
+    );
+  }
+
+  return {
+    originalUrl,
+    redirected: false,
+    renderUrl: originalUrl,
+    url: originalUrl,
+  };
+}
+
+export async function resolveXyzTileUrlTemplate(
+  url: string,
+): Promise<ResolvedXyzTileUrl> {
+  const originalUrl = normalizeTileUrlTemplate(url.trim());
+  if (hasXyzTilePlaceholders(originalUrl)) {
+    return {
+      originalUrl,
+      redirected: false,
+      renderUrl: renderableXyzTileUrl(originalUrl),
+      url: originalUrl,
+    };
+  }
+
+  const resolvedUrl = normalizeTileUrlTemplate(
+    await resolveShortXyzUrl(originalUrl),
+  );
+  if (!hasXyzTilePlaceholders(resolvedUrl)) {
+    throw new Error(
+      "Enter an XYZ tile URL template with {z}, {x}, and {y} placeholders.",
+    );
+  }
+
+  return {
+    originalUrl,
+    redirected: resolvedUrl !== originalUrl,
+    renderUrl: renderableXyzTileUrl(resolvedUrl),
+    url: resolvedUrl,
+  };
+}
+
+export function registerXyzTileProtocol(): void {
+  if (protocolRegistered || !isTauri()) return;
+
+  addProtocol(XYZ_TILE_PROTOCOL, async (request) => {
+    const url = parseXyzTileRequest(request);
+    const { invoke } = await import("@tauri-apps/api/core");
+    const bytes = await invoke<number[] | Uint8Array>("fetch_url_bytes", {
+      url,
+    });
+    const array = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    return {
+      data: array.buffer.slice(
+        array.byteOffset,
+        array.byteOffset + array.byteLength,
+      ),
+    };
+  });
+  protocolRegistered = true;
+}
+
+export async function resolveProjectXyzLayers(
+  project: GeoLibreProject,
+): Promise<GeoLibreProject> {
+  const layers = await Promise.all(project.layers.map(resolveProjectXyzLayer));
+  return { ...project, layers };
+}
+
+async function resolveProjectXyzLayer(
+  layer: GeoLibreLayer,
+): Promise<GeoLibreLayer> {
+  if (layer.type !== "xyz") return layer;
+
+  const url = getSavedXyzUrl(layer);
+  if (!url) {
+    return layer;
+  }
+
+  const hasShortUrlMetadata =
+    typeof layer.metadata.originalUrl === "string" &&
+    layer.metadata.originalUrl.trim().length > 0;
+  const normalizedUrl = normalizeTileUrlTemplate(url);
+  const tileUrl =
+    hasShortUrlMetadata || !hasXyzTilePlaceholders(normalizedUrl)
+      ? await resolveXyzTileUrlTemplate(url)
+      : createXyzTileUrlTemplate(url);
+  return {
+    ...layer,
+    source: {
+      ...layer.source,
+      tiles: [tileUrl.renderUrl],
+      url: tileUrl.originalUrl,
+    },
+    metadata: {
+      ...layer.metadata,
+      originalUrl:
+        tileUrl.redirected || layer.metadata.originalUrl
+          ? tileUrl.originalUrl
+          : undefined,
+      resolvedUrl: tileUrl.redirected ? tileUrl.url : undefined,
+      sourceKind: layer.metadata.sourceKind ?? "xyz-url",
+    },
+  };
+}
+
+function getSavedXyzUrl(layer: GeoLibreLayer): string | null {
+  const originalUrl = layer.metadata.originalUrl;
+  if (typeof originalUrl === "string" && originalUrl.trim()) {
+    return originalUrl;
+  }
+
+  const sourceUrl = layer.source.url;
+  if (typeof sourceUrl === "string" && sourceUrl.trim()) {
+    return sourceUrl;
+  }
+
+  const tiles = layer.source.tiles;
+  if (Array.isArray(tiles) && typeof tiles[0] === "string") {
+    return tiles[0];
+  }
+
+  return null;
+}
+
+function renderableXyzTileUrl(url: string): string {
+  if (!isTauri() || !isHttpUrl(url)) return url;
+
+  registerXyzTileProtocol();
+  return `${XYZ_TILE_PROTOCOL}://tile/{z}/{x}/{y}?url=${encodeURIComponent(
+    url,
+  )}`;
+}
+
+function parseXyzTileRequest(request: RequestParameters): string {
+  const url = new URL(request.url);
+  const template = url.searchParams.get("url");
+  if (!template) {
+    throw new Error("Invalid XYZ tile URL.");
+  }
+
+  const parts = url.pathname.split("/").filter(Boolean);
+  if (parts.length !== 3) {
+    throw new Error("Invalid XYZ tile coordinates.");
+  }
+
+  return template
+    .replace(/\{z\}/g, parts[0])
+    .replace(/\{x\}/g, parts[1])
+    .replace(/\{y\}/g, parts[2]);
+}
+
+function isHttpUrl(url: string): boolean {
+  return /^https?:\/\//i.test(url);
+}
+
+async function resolveShortXyzUrl(url: string): Promise<string> {
+  if (!isHttpUrl(url)) return url;
+
+  if (isTauri()) {
+    const { invoke } = await import("@tauri-apps/api/core");
+    return invoke<string>("resolve_url_redirect", { url });
+  }
+
+  const response = await fetch(url, {
+    headers: { Accept: "application/json, text/plain;q=0.9, */*;q=0.8" },
+    redirect: "follow",
+  });
+  const resolvedUrl = urlFromResolverResponse(response);
+  if (resolvedUrl) return resolvedUrl;
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.startsWith("image/")) {
+    const bodyUrl = await urlFromResolverBody(response);
+    if (bodyUrl) return bodyUrl;
+  }
+
+  return response.url || url;
+}
+
+function urlFromResolverResponse(response: Response): string | null {
+  const resolvedUrl = normalizeTileUrlTemplate(response.url);
+  return resolvedUrl && hasXyzTilePlaceholders(resolvedUrl)
+    ? resolvedUrl
+    : null;
+}
+
+async function urlFromResolverBody(response: Response): Promise<string | null> {
+  const text = (await response.text()).trim();
+  if (!text) return null;
+
+  const jsonUrl = urlFromResolverJson(text);
+  if (jsonUrl) return jsonUrl;
+
+  return isHttpUrl(text) ? text : null;
+}
+
+function urlFromResolverJson(text: string): string | null {
+  try {
+    const value = JSON.parse(text) as unknown;
+    return urlFromJsonValue(value);
+  } catch {
+    return null;
+  }
+}
+
+function urlFromJsonValue(value: unknown): string | null {
+  if (typeof value === "string" && isHttpUrl(value)) return value;
+  if (!value || typeof value !== "object") return null;
+
+  const record = value as Record<string, unknown>;
+  for (const key of ["url", "tileUrl", "tile_url"]) {
+    const candidate = record[key];
+    if (typeof candidate === "string" && isHttpUrl(candidate)) {
+      return candidate;
+    }
+  }
+
+  const tiles = record.tiles;
+  if (
+    Array.isArray(tiles) &&
+    typeof tiles[0] === "string" &&
+    isHttpUrl(tiles[0])
+  ) {
+    return tiles[0];
+  }
+
+  return null;
+}

--- a/apps/geolibre-desktop/src/lib/xyz-url.ts
+++ b/apps/geolibre-desktop/src/lib/xyz-url.ts
@@ -47,6 +47,7 @@ export function createXyzTileUrlTemplate(url: string): ResolvedXyzTileUrl {
 
 export async function resolveXyzTileUrlTemplate(
   url: string,
+  signal?: AbortSignal,
 ): Promise<ResolvedXyzTileUrl> {
   const originalUrl = normalizeTileUrlTemplate(url.trim());
   if (hasXyzTilePlaceholders(originalUrl)) {
@@ -59,7 +60,7 @@ export async function resolveXyzTileUrlTemplate(
   }
 
   const resolvedUrl = normalizeTileUrlTemplate(
-    await resolveShortXyzUrl(originalUrl),
+    await resolveShortXyzUrl(originalUrl, signal),
   );
   if (!hasXyzTilePlaceholders(resolvedUrl)) {
     throw new Error(
@@ -97,13 +98,24 @@ export function registerXyzTileProtocol(): void {
 
 export async function resolveProjectXyzLayers(
   project: GeoLibreProject,
+  signal?: AbortSignal,
 ): Promise<GeoLibreProject> {
-  const layers = await Promise.all(project.layers.map(resolveProjectXyzLayer));
+  const results = await Promise.allSettled(
+    project.layers.map((layer) => resolveProjectXyzLayer(layer, signal)),
+  );
+  const layers = results.map((result, index) => {
+    if (result.status === "fulfilled") return result.value;
+    if (!signal?.aborted) {
+      console.warn("Could not resolve XYZ layer URL", result.reason);
+    }
+    return project.layers[index];
+  });
   return { ...project, layers };
 }
 
 async function resolveProjectXyzLayer(
   layer: GeoLibreLayer,
+  signal?: AbortSignal,
 ): Promise<GeoLibreLayer> {
   if (layer.type !== "xyz") return layer;
 
@@ -118,7 +130,7 @@ async function resolveProjectXyzLayer(
   const normalizedUrl = normalizeTileUrlTemplate(url);
   const tileUrl =
     hasShortUrlMetadata || !hasXyzTilePlaceholders(normalizedUrl)
-      ? await resolveXyzTileUrlTemplate(url)
+      ? await resolveXyzTileUrlTemplate(url, signal)
       : createXyzTileUrlTemplate(url);
   return {
     ...layer,
@@ -189,7 +201,10 @@ function isHttpUrl(url: string): boolean {
   return /^https?:\/\//i.test(url);
 }
 
-async function resolveShortXyzUrl(url: string): Promise<string> {
+async function resolveShortXyzUrl(
+  url: string,
+  signal?: AbortSignal,
+): Promise<string> {
   if (!isHttpUrl(url)) return url;
 
   if (isTauri()) {
@@ -200,6 +215,7 @@ async function resolveShortXyzUrl(url: string): Promise<string> {
   const response = await fetch(url, {
     headers: { Accept: "application/json, text/plain;q=0.9, */*;q=0.8" },
     redirect: "follow",
+    signal,
   });
   const resolvedUrl = urlFromResolverResponse(response);
   if (resolvedUrl) return resolvedUrl;

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -92,9 +92,35 @@ export function projectFromStore(state: {
     basemapStyleUrl: state.basemapStyleUrl,
     basemapVisible: state.basemapVisible,
     basemapOpacity: state.basemapOpacity,
-    layers: state.layers,
+    layers: state.layers.map(prepareLayerForSave),
     styles,
     metadata: state.metadata,
+  };
+}
+
+function prepareLayerForSave(layer: GeoLibreLayer): GeoLibreLayer {
+  if (layer.type !== "xyz") return layer;
+
+  const originalUrl =
+    typeof layer.metadata.originalUrl === "string" &&
+    layer.metadata.originalUrl.trim()
+      ? layer.metadata.originalUrl
+      : typeof layer.source.url === "string" && layer.source.url.trim()
+        ? layer.source.url
+        : null;
+  if (!originalUrl) return layer;
+
+  const metadata = { ...layer.metadata };
+  delete metadata.resolvedUrl;
+
+  return {
+    ...layer,
+    source: {
+      ...layer.source,
+      tiles: [originalUrl],
+      url: originalUrl,
+    },
+    metadata,
   };
 }
 


### PR DESCRIPTION
## Summary
- Add a "Short URL" option for XYZ layers so short links and JSON resolver endpoints can be added directly; the app follows redirects and parses resolver responses to recover the underlying `{z}/{x}/{y}` template.
- Add a Tauri `resolve_url_redirect` command (and a browser fetch fallback) that resolves the final tile URL from redirects or response bodies.
- Re-resolve XYZ layers when opening a saved project or loading one from a URL, while persisting only the original short URL.

## Test plan
- [ ] Add an XYZ layer using a normal `{z}/{x}/{y}` template (renders as before).
- [ ] Add an XYZ layer with the Short URL option using a redirecting/short link and a JSON resolver endpoint.
- [ ] Save and reopen a project containing a short-URL XYZ layer; confirm tiles render and only the short URL is saved.
- [ ] `npm run build` passes.