### PR TITLE
fix(ui): balanced padding on native select dropdowns

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -20,6 +20,7 @@ import {
   DialogTitle,
   Input,
   Label,
+  Select,
 } from "@geolibre/ui";
 import type { FeatureCollection } from "geojson";
 import { Database, FileUp, Globe2, Image, Map as MapIcon } from "lucide-react";
@@ -84,9 +85,6 @@ const KIND_LABELS: Record<AddDataKind, string> = {
   arcgis: "Add ArcGIS Layer",
   postgres: "Add PostgreSQL Layer",
 };
-
-const SELECT_CLASS =
-  "flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
 
 const COG_COLORMAPS = [
   "none",
@@ -979,15 +977,14 @@ export function AddDataDialog({
                 </div>
                 <div className="space-y-1.5">
                   <Label htmlFor="wms-format">Format</Label>
-                  <select
+                  <Select
                     id="wms-format"
-                    className={SELECT_CLASS}
                     value={wmsFormat}
                     onChange={(event) => setWmsFormat(event.target.value)}
                   >
                     <option value="image/png">PNG</option>
                     <option value="image/jpeg">JPEG</option>
-                  </select>
+                  </Select>
                 </div>
                 <div className="space-y-1.5">
                   <Label htmlFor="wms-tile-size">Tile size</Label>
@@ -1037,9 +1034,8 @@ export function AddDataDialog({
             <div className="space-y-3">
               <div className="space-y-1.5">
                 <Label htmlFor="vector-mode">Source type</Label>
-                <select
+                <Select
                   id="vector-mode"
-                  className={SELECT_CLASS}
                   value={vectorMode}
                   onChange={(event) =>
                     setVectorMode(event.target.value as VectorMode)
@@ -1048,7 +1044,7 @@ export function AddDataDialog({
                   <option value="vector-file">Vector file</option>
                   <option value="geojson-url">GeoJSON URL</option>
                   <option value="vector-tiles">Vector tile source URL</option>
-                </select>
+                </Select>
               </div>
               {vectorMode === "vector-file" ? (
                 <div className="flex flex-wrap items-center gap-2">
@@ -1154,9 +1150,8 @@ export function AddDataDialog({
               <div className="grid gap-3 sm:grid-cols-2">
                 <div className="space-y-1.5">
                   <Label htmlFor="arcgis-layer-type">Layer type</Label>
-                  <select
+                  <Select
                     id="arcgis-layer-type"
-                    className={SELECT_CLASS}
                     value={arcgisLayerType}
                     onChange={(event) =>
                       handleArcgisLayerTypeChange(
@@ -1166,13 +1161,12 @@ export function AddDataDialog({
                   >
                     <option value="feature">Feature layer</option>
                     <option value="vector-tile">Vector tile layer</option>
-                  </select>
+                  </Select>
                 </div>
                 <div className="space-y-1.5">
                   <Label htmlFor="arcgis-source-type">Source type</Label>
-                  <select
+                  <Select
                     id="arcgis-source-type"
-                    className={SELECT_CLASS}
                     value={arcgisSourceType}
                     onChange={(event) =>
                       setArcgisSourceType(event.target.value as ArcGISSourceType)
@@ -1180,7 +1174,7 @@ export function AddDataDialog({
                   >
                     <option value="url">Service URL</option>
                     <option value="portal-item">Portal item ID</option>
-                  </select>
+                  </Select>
                 </div>
               </div>
               {arcgisSourceType === "url" ? (
@@ -1246,9 +1240,8 @@ export function AddDataDialog({
                   <Label htmlFor="postgres-saved-connection">
                     Saved connection
                   </Label>
-                  <select
+                  <Select
                     id="postgres-saved-connection"
-                    className={SELECT_CLASS}
                     value={
                       savedPostgresConnections.includes(
                         postgresConnectionString,
@@ -1266,7 +1259,7 @@ export function AddDataDialog({
                         {savedPostgresConnectionLabel(connection)}
                       </option>
                     ))}
-                  </select>
+                  </Select>
                 </div>
               ) : null}
               <div className="space-y-1.5">
@@ -1326,9 +1319,8 @@ export function AddDataDialog({
               {martinSources.length > 0 ? (
                 <div className="space-y-1.5">
                   <Label htmlFor="martin-source">Martin source</Label>
-                  <select
+                  <Select
                     id="martin-source"
-                    className={SELECT_CLASS}
                     value={selectedMartinSourceId}
                     onChange={(event) =>
                       setSelectedMartinSourceId(event.target.value)
@@ -1339,7 +1331,7 @@ export function AddDataDialog({
                         {source.name}
                       </option>
                     ))}
-                  </select>
+                  </Select>
                 </div>
               ) : null}
               {martinServer ? (
@@ -1354,9 +1346,8 @@ export function AddDataDialog({
             <div className="space-y-3">
               <div className="space-y-1.5">
                 <Label htmlFor="raster-mode">Source type</Label>
-                <select
+                <Select
                   id="raster-mode"
-                  className={SELECT_CLASS}
                   value={rasterMode}
                   onChange={(event) =>
                     setRasterMode(event.target.value as RasterMode)
@@ -1365,7 +1356,7 @@ export function AddDataDialog({
                   <option value="cog-url">COG or raster URL</option>
                   <option value="tiles">Raster tile URL template</option>
                   <option value="file">Raster file</option>
-                </select>
+                </Select>
               </div>
               {rasterMode === "file" ? (
                 <div className="flex flex-wrap items-center gap-2">
@@ -1430,9 +1421,8 @@ export function AddDataDialog({
                   </div>
                   <div className="space-y-1.5">
                     <Label htmlFor="raster-colormap">Colormap</Label>
-                    <select
+                    <Select
                       id="raster-colormap"
-                      className={SELECT_CLASS}
                       value={rasterColormap}
                       onChange={(event) =>
                         setRasterColormap(event.target.value as RasterColormap)
@@ -1443,7 +1433,7 @@ export function AddDataDialog({
                           {colormap}
                         </option>
                       ))}
-                    </select>
+                    </Select>
                   </div>
                   <div className="space-y-1.5">
                     <Label htmlFor="raster-min">Min</Label>

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -9,6 +9,7 @@ import {
   Input,
   Label,
   ScrollArea,
+  Select,
   Separator,
   Slider,
 } from "@geolibre/ui";
@@ -878,9 +879,8 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
                     <Label htmlFor="extrusionHeightProperty">
                       Height property
                     </Label>
-                    <select
+                    <Select
                       id="extrusionHeightProperty"
-                      className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors focus-visible:border-2 focus-visible:border-ring focus-visible:outline-none focus-visible:ring-0 disabled:cursor-not-allowed disabled:opacity-50"
                       value={draftExtrusionHeightProperty}
                       onChange={(event) =>
                         setDraftExtrusionHeightProperty(event.target.value)
@@ -896,7 +896,7 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
                           </option>
                         ))
                       )}
-                    </select>
+                    </Select>
                   </div>
                   <NumericStyleInput
                     id="extrusionHeightScale"

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -13,6 +13,7 @@ import {
   DialogTitle,
   Label,
   ScrollArea,
+  Select,
 } from "@geolibre/ui";
 import { useState } from "react";
 
@@ -62,8 +63,8 @@ export function ProcessingDialog({
         <div className="space-y-3">
           <div>
             <Label>Algorithm</Label>
-            <select
-              className="mt-1 flex h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
+            <Select
+              className="mt-1"
               value={algorithmId}
               onChange={(e) => setAlgorithmId(e.target.value)}
             >
@@ -72,7 +73,7 @@ export function ProcessingDialog({
                   {a.name}
                 </option>
               ))}
-            </select>
+            </Select>
             {algorithm && (
               <p className="mt-1 text-xs text-muted-foreground">
                 {algorithm.description}
@@ -81,8 +82,8 @@ export function ProcessingDialog({
           </div>
           <div>
             <Label>Layer</Label>
-            <select
-              className="mt-1 flex h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
+            <Select
+              className="mt-1"
               value={layerId || geojsonLayers[0]?.id || ""}
               onChange={(e) => setLayerId(e.target.value)}
             >
@@ -91,7 +92,7 @@ export function ProcessingDialog({
                   {l.name}
                 </option>
               ))}
-            </select>
+            </Select>
           </div>
           <Button onClick={run} disabled={geojsonLayers.length === 0}>
             Run

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -1,0 +1,23 @@
+import { ChevronDown } from "lucide-react";
+import * as React from "react";
+import { cn } from "../lib/utils";
+
+export const Select = React.forwardRef<
+  HTMLSelectElement,
+  React.SelectHTMLAttributes<HTMLSelectElement>
+>(({ className, children, ...props }, ref) => (
+  <div className={cn("relative", className)}>
+    <select
+      ref={ref}
+      className="flex h-9 w-full appearance-none rounded-md border border-input bg-background py-1 pl-3 pr-8 text-sm shadow-sm transition-colors focus-visible:border-2 focus-visible:border-ring focus-visible:outline-none focus-visible:ring-0 disabled:cursor-not-allowed disabled:opacity-50"
+      {...props}
+    >
+      {children}
+    </select>
+    <ChevronDown
+      className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground opacity-50"
+      aria-hidden="true"
+    />
+  </div>
+));
+Select.displayName = "Select";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,6 +1,7 @@
 export { cn } from "./lib/utils";
 export { Button, type ButtonProps } from "./components/button";
 export { Input } from "./components/input";
+export { Select } from "./components/select";
 export { Label } from "./components/label";
 export { Slider } from "./components/slider";
 export { Separator } from "./components/separator";


### PR DESCRIPTION
## Summary

Native `<select>` elements used symmetric horizontal padding while the browser still drew its own caret, so label text looked shifted to the right.

<img width="1046" height="433" alt="Screenshot 2026-05-31 at 3 42 41 PM" src="https://github.com/user-attachments/assets/09fccd29-5763-4493-8805-7e2b5f8c290c" />

This fix adds a shared `Select` component in `@geolibre/ui` with `appearance-none`, extra right padding (`pr-8`), and a positioned chevron so spacing is consistent. Existing selects in Add Data, Style, and Processing dialogs are migrated to use it.

## Test plan

- [x] Verified select dropdowns in the app look visually balanced (user-tested on fork)