### PR TITLE
fix(a11y): labels, live regions, and loading feedback

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -1490,14 +1490,16 @@ export function AddDataDialog({
               Cancel
             </Button>
             <Button type="submit" disabled={addLayerDisabled}>
-              {kind === "wms" || kind === "wmts" ? (
-                <Globe2 className="mr-2 h-3.5 w-3.5" />
-              ) : kind === "raster" ? (
-                <Image className="mr-2 h-3.5 w-3.5" />
-              ) : (
-                <MapIcon className="mr-2 h-3.5 w-3.5" />
-              )}
-              Add layer
+              {!isSubmitting ? (
+                kind === "wms" || kind === "wmts" ? (
+                  <Globe2 className="mr-2 h-3.5 w-3.5" />
+                ) : kind === "raster" ? (
+                  <Image className="mr-2 h-3.5 w-3.5" />
+                ) : (
+                  <MapIcon className="mr-2 h-3.5 w-3.5" />
+                )
+              ) : null}
+              {isSubmitting ? "Adding…" : "Add layer"}
             </Button>
           </div>
         </form>

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -417,6 +417,7 @@ export function DesktopShell({
       ) : null}
       {projectUrlLoadState?.message || projectUrlLoadState?.error ? (
         <div
+          aria-live="polite"
           className={`pointer-events-none absolute left-1/2 top-14 z-50 max-w-[min(90vw,32rem)] -translate-x-1/2 rounded-md border bg-background px-3 py-2 text-center text-sm shadow-lg ${
             projectUrlLoadState.error ? "text-destructive" : "text-foreground"
           }`}
@@ -426,6 +427,7 @@ export function DesktopShell({
       ) : null}
       {dropMessage || dropError ? (
         <div
+          aria-live="polite"
           className={`pointer-events-none absolute bottom-10 left-1/2 z-50 -translate-x-1/2 rounded-md border bg-background px-3 py-2 text-sm shadow-lg ${
             dropError ? "text-destructive" : "text-foreground"
           }`}

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -329,6 +329,7 @@ export function AttributeTable() {
         <Input
           className="ml-auto h-7 max-w-xs text-xs"
           placeholder="Search attributes…"
+          aria-label="Search attributes"
           value={attributeFilter}
           onChange={(e) => setAttributeFilter(e.target.value)}
         />

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -269,6 +269,8 @@ export function LayerPanel({
                   <button
                     type="button"
                     className="rounded p-0.5 hover:bg-muted"
+                    title={layer.visible ? "Hide layer" : "Show layer"}
+                    aria-label={layer.visible ? "Hide layer" : "Show layer"}
                     onClick={(e) => {
                       e.stopPropagation();
                       setLayerVisibility(layer.id, !layer.visible);
@@ -314,6 +316,7 @@ export function LayerPanel({
                     size="icon"
                     className="h-7 w-7"
                     title="Move up"
+                    aria-label="Move up"
                     onClick={(e) => {
                       e.stopPropagation();
                       reorderLayer(layer.id, "up");
@@ -326,6 +329,7 @@ export function LayerPanel({
                     size="icon"
                     className="h-7 w-7"
                     title="Move down"
+                    aria-label="Move down"
                     onClick={(e) => {
                       e.stopPropagation();
                       reorderLayer(layer.id, "down");
@@ -338,6 +342,7 @@ export function LayerPanel({
                     size="icon"
                     className="h-7 w-7"
                     title="Zoom to layer"
+                    aria-label="Zoom to layer"
                     onClick={(e) => {
                       e.stopPropagation();
                       mapControllerRef.current?.fitLayer(layer);
@@ -360,6 +365,13 @@ export function LayerPanel({
                           : "Identify features"
                         : "Identify is only available for vector layers"
                     }
+                    aria-label={
+                      canIdentify
+                        ? identifyActive
+                          ? "Deactivate identify"
+                          : "Identify features"
+                        : "Identify is only available for vector layers"
+                    }
                     disabled={!canIdentify}
                     onClick={(e) => {
                       e.stopPropagation();
@@ -375,6 +387,7 @@ export function LayerPanel({
                     size="icon"
                     className="h-7 w-7"
                     title="Metadata"
+                    aria-label="Metadata"
                     onClick={(e) => {
                       e.stopPropagation();
                       setMetadataLayer(layer);
@@ -387,6 +400,7 @@ export function LayerPanel({
                     size="icon"
                     className="h-7 w-7 text-destructive"
                     title="Remove layer"
+                    aria-label="Remove layer"
                     onClick={(e) => {
                       e.stopPropagation();
                       setLayerPendingRemoval(layer);

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -61,8 +61,9 @@ export function ProcessingDialog({
         </DialogHeader>
         <div className="space-y-3">
           <div>
-            <Label>Algorithm</Label>
+            <Label htmlFor="processing-algorithm">Algorithm</Label>
             <select
+              id="processing-algorithm"
               className="mt-1 flex h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
               value={algorithmId}
               onChange={(e) => setAlgorithmId(e.target.value)}
@@ -80,8 +81,9 @@ export function ProcessingDialog({
             )}
           </div>
           <div>
-            <Label>Layer</Label>
+            <Label htmlFor="processing-layer">Layer</Label>
             <select
+              id="processing-layer"
               className="mt-1 flex h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
               value={layerId || geojsonLayers[0]?.id || ""}
               onChange={(e) => setLayerId(e.target.value)}


### PR DESCRIPTION
## Summary

- Add `aria-label` to layer panel icon buttons (visibility, reorder, zoom, identify, metadata, remove)
- Associate Processing dialog Algorithm/Layer labels with their selects via `htmlFor` / `id`
- Show "Adding…" on Add Data submit while async add is in progress
- Label attribute table search input for screen readers
- Announce drop/import and URL load status toasts with `aria-live="polite"`

Sorry to open a second PR so soon — just wanted to help anywhere I can.

## Test plan

- [x] Layer panel: tab to row actions; screen reader announces each icon button (move up/down, zoom, identify, metadata, remove, show/hide) *(verified via browser testing on fork)*
- [x] Processing toolbox: click Algorithm/Layer labels; focus moves to the matching select *(verified via browser testing on fork)*
- [x] Add Data: submit any layer type; button shows "Adding…" and stays disabled until complete *(verified via browser testing on fork)*
- [x] Attribute table: search field exposes "Search attributes" to assistive tech *(verified via browser testing on fork)*
- [x] Drop a vector file or load project from URL; status toast is announced without stealing focus *(verified via browser testing on fork — drop toast showed `aria-live="polite"` with "Added 1 vector layer.")*