### PR TITLE
Sync GeoEditor drawings to a single Sketches layer (#77)

### DIFF
--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -1,7 +1,12 @@
 import { type GeoLibreLayer, useAppStore } from "@geolibre/core";
 import type { FeatureCollection } from "geojson";
 import type maplibregl from "maplibre-gl";
-import { GeoEditor, type GeoEditorOptions } from "maplibre-gl-geo-editor";
+import {
+  GeoEditor,
+  type DrawMode,
+  type EditMode,
+  type GeoEditorOptions,
+} from "maplibre-gl-geo-editor";
 import type {
   GeoLibreAppAPI,
   GeoLibreMapControlPosition,
@@ -47,6 +52,7 @@ const GEO_EDITOR_OPTIONS = {
   | "onGeoJsonLoad"
   | "onAttributeChange"
   | "onHistoryChange"
+  | "onModeChange"
 >;
 
 let geoEditorControl: GeoEditor | null = null;
@@ -55,6 +61,8 @@ let geoEditorStoreUnsubscribe: (() => void) | null = null;
 let pluginActive = false;
 let restoringSketchesToEditor = false;
 let appApi: GeoLibreAppAPI | null = null;
+let currentGeoEditorMode: DrawMode | EditMode | null = null;
+let sketchesLayerDisplaySuppressed = false;
 
 export const maplibreGeoEditorPlugin: GeoLibrePlugin = {
   id: "maplibre-gl-geo-editor",
@@ -80,6 +88,9 @@ export const maplibreGeoEditorPlugin: GeoLibrePlugin = {
   },
   deactivate: (app: GeoLibreAppAPI) => {
     pluginActive = false;
+    currentGeoEditorMode = null;
+    setSketchesStoreLayerSuppressed(false);
+    showGeomanDisplayLayers();
     appApi = null;
     teardownSketchesStoreSync();
 
@@ -115,6 +126,10 @@ function getGeoEditorOptions(): GeoEditorOptions {
     },
     onAttributeChange: () => syncSketchesToStore(),
     onHistoryChange: () => syncSketchesToStore(),
+    onModeChange: (mode) => {
+      currentGeoEditorMode = mode;
+      updateSketchesDisplayForMode();
+    },
   };
 }
 
@@ -150,12 +165,12 @@ function syncSketchesToStore(): void {
   if (existing) {
     sketchesLayerId = existing.id;
     store.updateLayer(existing.id, { geojson: collection });
-    hideGeomanDisplayLayers();
+    updateSketchesDisplayForMode();
     return;
   }
 
   if (collection.features.length === 0) {
-    hideGeomanDisplayLayers();
+    updateSketchesDisplayForMode();
     return;
   }
 
@@ -171,7 +186,7 @@ function syncSketchesToStore(): void {
       sourceKind: SKETCHES_SOURCE_KIND,
     },
   });
-  hideGeomanDisplayLayers();
+  updateSketchesDisplayForMode();
 }
 
 function restoreSketchesLayerToEditor(): void {
@@ -195,7 +210,7 @@ function restoreSketchesLayerToEditor(): void {
   } finally {
     restoringSketchesToEditor = false;
   }
-  hideGeomanDisplayLayers();
+  updateSketchesDisplayForMode();
 }
 
 function clearSketchesFromEditor(): void {
@@ -249,7 +264,47 @@ function teardownSketchesStoreSync(): void {
   geoEditorStoreUnsubscribe = null;
 }
 
-function hideGeomanDisplayLayers(): void {
+function isGeoEditorInteractionMode(): boolean {
+  return currentGeoEditorMode !== null;
+}
+
+/**
+ * While GeoEditor has an active draw/edit mode, Geoman layers must stay visible
+ * for hit-testing and handles. When idle, hide Geoman and show the Sketches
+ * store layer to avoid duplicate rendering (PR #77).
+ */
+function updateSketchesDisplayForMode(): void {
+  if (isGeoEditorInteractionMode()) {
+    showGeomanDisplayLayers();
+    setSketchesStoreLayerSuppressed(true);
+    return;
+  }
+  hideGeomanDisplayLayers();
+  setSketchesStoreLayerSuppressed(false);
+}
+
+function setSketchesStoreLayerSuppressed(suppress: boolean): void {
+  const layer = findSketchesLayer(useAppStore.getState().layers);
+  if (!layer) {
+    sketchesLayerDisplaySuppressed = false;
+    return;
+  }
+
+  const store = useAppStore.getState();
+
+  if (suppress) {
+    if (sketchesLayerDisplaySuppressed || !layer.visible) return;
+    store.setLayerVisibility(layer.id, false);
+    sketchesLayerDisplaySuppressed = true;
+    return;
+  }
+
+  if (!sketchesLayerDisplaySuppressed) return;
+  store.setLayerVisibility(layer.id, true);
+  sketchesLayerDisplaySuppressed = false;
+}
+
+function setGeomanDisplayLayersVisibility(visibility: "visible" | "none"): void {
   const map = appApi?.getMap?.();
   if (!map) return;
 
@@ -259,11 +314,19 @@ function hideGeomanDisplayLayers(): void {
   for (const layer of style.layers) {
     if (!isGeomanDisplayLayer(layer)) continue;
     try {
-      map.setLayoutProperty(layer.id, "visibility", "none");
+      map.setLayoutProperty(layer.id, "visibility", visibility);
     } catch {
       // Layer may have been removed with the current style.
     }
   }
+}
+
+function hideGeomanDisplayLayers(): void {
+  setGeomanDisplayLayersVisibility("none");
+}
+
+function showGeomanDisplayLayers(): void {
+  setGeomanDisplayLayersVisibility("visible");
 }
 
 function isGeomanDisplayLayer(layer: maplibregl.LayerSpecification): boolean {

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -65,6 +65,8 @@ let sketchesMapLayerSuppressed = false;
 let sketchesIdleDisplayOverride = false;
 /** Union store + editor on the next sync so a partial getAll cannot drop prior sketches. */
 let unionSketchesWithStoreOnNextSync = false;
+/** Pending one-shot `styledata` listener, so repeated draw events don't pile up listeners. */
+let pendingStyleDataListener: (() => void) | null = null;
 
 export const maplibreGeoEditorPlugin: GeoLibrePlugin = {
   id: "maplibre-gl-geo-editor",
@@ -81,6 +83,8 @@ export const maplibreGeoEditorPlugin: GeoLibrePlugin = {
     const added = app.addMapControl(geoEditorControl, geoEditorPosition);
     if (!added) {
       geoEditorControl = null;
+      pluginActive = false;
+      appApi = null;
       return false;
     }
 
@@ -91,6 +95,7 @@ export const maplibreGeoEditorPlugin: GeoLibrePlugin = {
   deactivate: (app: GeoLibreAppAPI) => {
     pluginActive = false;
     sketchesIdleDisplayOverride = false;
+    unionSketchesWithStoreOnNextSync = false;
     setSketchesMapLayerSuppressed(false);
     showGeomanDisplayLayers();
     appApi = null;
@@ -178,9 +183,11 @@ function featureCollectionsEquivalent(
   return JSON.stringify(a) === JSON.stringify(b);
 }
 
-function sketchFeatureKey(feature: Feature, _index: number): string {
+function sketchFeatureKey(feature: Feature, index: number): string {
   const props = feature.properties as Record<string, unknown> | null;
-  return String(feature.id ?? props?.__gm_id ?? JSON.stringify(feature));
+  return String(
+    feature.id ?? props?.__gm_id ?? `${JSON.stringify(feature)}@${index}`,
+  );
 }
 
 function unionFeatureCollections(
@@ -263,6 +270,9 @@ function restoreSketchesLayerToEditor(): void {
     // Geoman may not be ready yet.
   }
 
+  // `loadGeoJson` invokes `onGeoJsonLoad` synchronously, so clearing the guard
+  // in `finally` is safe; if it ever became async the guard would already be
+  // false when the callback runs and `syncSketchesToStore` could loop.
   restoringSketchesToEditor = true;
   try {
     geoEditorControl.loadGeoJson(storeCollection, SKETCHES_SOURCE_PATH);
@@ -302,7 +312,7 @@ function bindSketchesStoreSync(): void {
       return;
     }
 
-    if (sketches && sketches.id !== sketchesLayerId) {
+    if (sketches && sketches.id !== sketchesLayerId && !pushingSketchesToStore) {
       sketchesLayerId = sketches.id;
       restoreSketchesLayerToEditor();
       return;
@@ -376,13 +386,15 @@ function scheduleApplySketchesMapDisplay(): void {
 
 function scheduleShowGeomanDisplayLayersOnStyleData(): void {
   const map = appApi?.getMap?.();
-  if (!map) return;
+  if (!map || pendingStyleDataListener) return;
 
-  map.once("styledata", () => {
+  pendingStyleDataListener = () => {
+    pendingStyleDataListener = null;
     if (isGeoEditorInteractionMode()) {
       showGeomanDisplayLayers();
     }
-  });
+  };
+  map.once("styledata", pendingStyleDataListener);
 }
 
 function setSketchesMapLayerSuppressed(suppress: boolean): void {
@@ -441,11 +453,7 @@ function showGeomanDisplayLayers(): void {
 
 function isGeomanDisplayLayer(layer: maplibregl.LayerSpecification): boolean {
   const id = layer.id.toLowerCase();
-  if (
-    id.startsWith("gm_") ||
-    id.startsWith("gm-") ||
-    id.includes("geoman")
-  ) {
+  if (id.startsWith("gm_") || id.startsWith("gm-")) {
     return true;
   }
   if (!("source" in layer)) return false;

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -1,12 +1,7 @@
 import { type GeoLibreLayer, useAppStore } from "@geolibre/core";
 import type { FeatureCollection } from "geojson";
 import type maplibregl from "maplibre-gl";
-import {
-  GeoEditor,
-  type DrawMode,
-  type EditMode,
-  type GeoEditorOptions,
-} from "maplibre-gl-geo-editor";
+import { GeoEditor, type GeoEditorOptions } from "maplibre-gl-geo-editor";
 import type {
   GeoLibreAppAPI,
   GeoLibreMapControlPosition,
@@ -42,7 +37,8 @@ const GEO_EDITOR_OPTIONS = {
   fileModes: ["open", "save"],
   hideGeomanControl: true,
   showFeatureProperties: true,
-  fitBoundsOnLoad: true,
+  // Avoid zoom/fit on Sketches restore — it retriggers style churn and races with draw.
+  fitBoundsOnLoad: false,
 } satisfies Omit<
   GeoEditorOptions,
   | "position"
@@ -53,6 +49,7 @@ const GEO_EDITOR_OPTIONS = {
   | "onAttributeChange"
   | "onHistoryChange"
   | "onModeChange"
+  | "onSelectionChange"
 >;
 
 let geoEditorControl: GeoEditor | null = null;
@@ -60,9 +57,12 @@ let sketchesLayerId: string | null = null;
 let geoEditorStoreUnsubscribe: (() => void) | null = null;
 let pluginActive = false;
 let restoringSketchesToEditor = false;
+let pushingSketchesToStore = false;
 let appApi: GeoLibreAppAPI | null = null;
-let currentGeoEditorMode: DrawMode | EditMode | null = null;
-let sketchesLayerDisplaySuppressed = false;
+/** Map-only hide of Sketches while GeoEditor interacts; does not touch store.visible. */
+let sketchesMapLayerSuppressed = false;
+/** After a draw completes, show Sketches even if draw mode stays active for another shape. */
+let sketchesIdleDisplayOverride = false;
 
 export const maplibreGeoEditorPlugin: GeoLibrePlugin = {
   id: "maplibre-gl-geo-editor",
@@ -88,8 +88,8 @@ export const maplibreGeoEditorPlugin: GeoLibrePlugin = {
   },
   deactivate: (app: GeoLibreAppAPI) => {
     pluginActive = false;
-    currentGeoEditorMode = null;
-    setSketchesStoreLayerSuppressed(false);
+    sketchesIdleDisplayOverride = false;
+    setSketchesMapLayerSuppressed(false);
     showGeomanDisplayLayers();
     appApi = null;
     teardownSketchesStoreSync();
@@ -116,9 +116,22 @@ function getGeoEditorOptions(): GeoEditorOptions {
   return {
     ...GEO_EDITOR_OPTIONS,
     position: geoEditorPosition,
-    onFeatureCreate: () => syncSketchesToStore(),
-    onFeatureEdit: () => syncSketchesToStore(),
-    onFeatureDelete: () => syncSketchesToStore(),
+    onFeatureCreate: () => {
+      sketchesIdleDisplayOverride = true;
+      // Defer until Geoman commits the new feature to its feature store.
+      queueMicrotask(() => {
+        syncSketchesToStore();
+        applySketchesMapDisplay();
+      });
+    },
+    onFeatureEdit: () => {
+      syncSketchesToStore();
+      applySketchesMapDisplay();
+    },
+    onFeatureDelete: () => {
+      syncSketchesToStore();
+      applySketchesMapDisplay();
+    },
     onGeoJsonLoad: () => {
       if (!restoringSketchesToEditor) {
         syncSketchesToStore();
@@ -126,10 +139,11 @@ function getGeoEditorOptions(): GeoEditorOptions {
     },
     onAttributeChange: () => syncSketchesToStore(),
     onHistoryChange: () => syncSketchesToStore(),
-    onModeChange: (mode) => {
-      currentGeoEditorMode = mode;
-      updateSketchesDisplayForMode();
+    onModeChange: () => {
+      sketchesIdleDisplayOverride = false;
+      applySketchesMapDisplay();
     },
+    onSelectionChange: () => applySketchesMapDisplay(),
   };
 }
 
@@ -153,6 +167,14 @@ function cloneFeatureCollection(
   return structuredClone(collection);
 }
 
+function featureCollectionsEquivalent(
+  a: FeatureCollection,
+  b: FeatureCollection,
+): boolean {
+  if (a.features.length !== b.features.length) return false;
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
 function syncSketchesToStore(): void {
   if (!geoEditorControl || restoringSketchesToEditor) return;
 
@@ -162,31 +184,37 @@ function syncSketchesToStore(): void {
   const store = useAppStore.getState();
   const existing = findSketchesLayer(store.layers);
 
-  if (existing) {
-    sketchesLayerId = existing.id;
-    store.updateLayer(existing.id, { geojson: collection });
-    updateSketchesDisplayForMode();
-    return;
+  pushingSketchesToStore = true;
+  try {
+    if (existing) {
+      sketchesLayerId = existing.id;
+      store.updateLayer(existing.id, { geojson: collection });
+      return;
+    }
+
+    if (collection.features.length === 0) {
+      return;
+    }
+
+    const id = store.addGeoJsonLayer(
+      SKETCHES_LAYER_NAME,
+      collection,
+      SKETCHES_SOURCE_PATH,
+    );
+    sketchesLayerId = id;
+    store.updateLayer(id, {
+      metadata: {
+        ...store.layers.find((layer) => layer.id === id)?.metadata,
+        sourceKind: SKETCHES_SOURCE_KIND,
+      },
+    });
+  } finally {
+    pushingSketchesToStore = false;
   }
 
-  if (collection.features.length === 0) {
-    updateSketchesDisplayForMode();
-    return;
+  if (!sketchesIdleDisplayOverride) {
+    scheduleApplySketchesMapDisplay();
   }
-
-  const id = store.addGeoJsonLayer(
-    SKETCHES_LAYER_NAME,
-    collection,
-    SKETCHES_SOURCE_PATH,
-  );
-  sketchesLayerId = id;
-  store.updateLayer(id, {
-    metadata: {
-      ...store.layers.find((layer) => layer.id === id)?.metadata,
-      sourceKind: SKETCHES_SOURCE_KIND,
-    },
-  });
-  updateSketchesDisplayForMode();
 }
 
 function restoreSketchesLayerToEditor(): void {
@@ -199,18 +227,26 @@ function restoreSketchesLayerToEditor(): void {
   }
 
   sketchesLayerId = layer.id;
+  const storeCollection = cloneFeatureCollection(layer.geojson);
+  try {
+    const editorCollection = geoEditorControl.getAllFeatureCollection();
+    if (featureCollectionsEquivalent(editorCollection, storeCollection)) {
+      scheduleApplySketchesMapDisplay();
+      return;
+    }
+  } catch {
+    // Geoman may not be ready yet.
+  }
+
   restoringSketchesToEditor = true;
   try {
-    geoEditorControl.loadGeoJson(
-      cloneFeatureCollection(layer.geojson),
-      SKETCHES_SOURCE_PATH,
-    );
+    geoEditorControl.loadGeoJson(storeCollection, SKETCHES_SOURCE_PATH);
   } catch {
     // Geoman may not be ready until the map style finishes loading.
   } finally {
     restoringSketchesToEditor = false;
   }
-  updateSketchesDisplayForMode();
+  scheduleApplySketchesMapDisplay();
 }
 
 function clearSketchesFromEditor(): void {
@@ -252,9 +288,20 @@ function bindSketchesStoreSync(): void {
       previousSketches &&
       sketches.id === previousSketches.id &&
       sketches.geojson !== previousSketches.geojson &&
-      !restoringSketchesToEditor
+      !restoringSketchesToEditor &&
+      !pushingSketchesToStore
     ) {
       restoreSketchesLayerToEditor();
+      return;
+    }
+
+    if (
+      sketches &&
+      previousSketches &&
+      sketches.id === previousSketches.id &&
+      sketches.visible !== previousSketches.visible
+    ) {
+      scheduleApplySketchesMapDisplay();
     }
   });
 }
@@ -265,43 +312,81 @@ function teardownSketchesStoreSync(): void {
 }
 
 function isGeoEditorInteractionMode(): boolean {
-  return currentGeoEditorMode !== null;
+  if (!geoEditorControl) return false;
+  if (sketchesIdleDisplayOverride) return false;
+  const { activeDrawMode, activeEditMode } = geoEditorControl.getState();
+  return activeDrawMode !== null || activeEditMode !== null;
+}
+
+function sketchesMapLayerIds(layerId: string): string[] {
+  return [
+    `layer-${layerId}-fill`,
+    `layer-${layerId}-extrusion`,
+    `layer-${layerId}-line`,
+    `layer-${layerId}-circle`,
+  ];
 }
 
 /**
- * While GeoEditor has an active draw/edit mode, Geoman layers must stay visible
- * for hit-testing and handles. When idle, hide Geoman and show the Sketches
- * store layer to avoid duplicate rendering (PR #77).
+ * GeoEditor selection and edit handles use Geoman layers for hit-testing.
+ * While interacting, show Geoman and hide the Sketches store layer on the map only.
+ * When idle, hide Geoman and show Sketches according to the user's layer-panel toggle.
  */
-function updateSketchesDisplayForMode(): void {
+function applySketchesMapDisplay(): void {
   if (isGeoEditorInteractionMode()) {
     showGeomanDisplayLayers();
-    setSketchesStoreLayerSuppressed(true);
+    scheduleShowGeomanDisplayLayersOnStyleData();
+    setSketchesMapLayerSuppressed(true);
     return;
   }
+
   hideGeomanDisplayLayers();
-  setSketchesStoreLayerSuppressed(false);
+  setSketchesMapLayerSuppressed(false);
 }
 
-function setSketchesStoreLayerSuppressed(suppress: boolean): void {
+function scheduleApplySketchesMapDisplay(): void {
+  queueMicrotask(() => applySketchesMapDisplay());
+  window.setTimeout(() => applySketchesMapDisplay(), 0);
+}
+
+function scheduleShowGeomanDisplayLayersOnStyleData(): void {
+  const map = appApi?.getMap?.();
+  if (!map) return;
+
+  map.once("styledata", () => {
+    if (isGeoEditorInteractionMode()) {
+      showGeomanDisplayLayers();
+    }
+  });
+}
+
+function setSketchesMapLayerSuppressed(suppress: boolean): void {
   const layer = findSketchesLayer(useAppStore.getState().layers);
   if (!layer) {
-    sketchesLayerDisplaySuppressed = false;
+    sketchesMapLayerSuppressed = false;
     return;
   }
 
-  const store = useAppStore.getState();
+  sketchesMapLayerSuppressed = suppress;
+  setSketchesMapLayersVisibility(layer);
+}
 
-  if (suppress) {
-    if (sketchesLayerDisplaySuppressed || !layer.visible) return;
-    store.setLayerVisibility(layer.id, false);
-    sketchesLayerDisplaySuppressed = true;
-    return;
+function setSketchesMapLayersVisibility(layer: GeoLibreLayer): void {
+  const map = appApi?.getMap?.();
+  if (!map) return;
+
+  const visibility =
+    layer.visible && !sketchesMapLayerSuppressed ? "visible" : "none";
+
+  for (const mapLayerId of sketchesMapLayerIds(layer.id)) {
+    try {
+      if (map.getLayer(mapLayerId)) {
+        map.setLayoutProperty(mapLayerId, "visibility", visibility);
+      }
+    } catch {
+      // Layer may not exist yet for this geometry profile.
+    }
   }
-
-  if (!sketchesLayerDisplaySuppressed) return;
-  store.setLayerVisibility(layer.id, true);
-  sketchesLayerDisplaySuppressed = false;
 }
 
 function setGeomanDisplayLayersVisibility(visibility: "visible" | "none"): void {
@@ -330,8 +415,20 @@ function showGeomanDisplayLayers(): void {
 }
 
 function isGeomanDisplayLayer(layer: maplibregl.LayerSpecification): boolean {
-  if (layer.id.startsWith("gm_")) return true;
+  const id = layer.id.toLowerCase();
+  if (
+    id.startsWith("gm_") ||
+    id.startsWith("gm-") ||
+    id.includes("geoman")
+  ) {
+    return true;
+  }
   if (!("source" in layer)) return false;
   const source = layer.source;
-  return typeof source === "string" && source.startsWith("geoman");
+  return (
+    typeof source === "string" &&
+    (source.startsWith("gm_") ||
+      source.startsWith("gm-") ||
+      source.startsWith("geoman"))
+  );
 }

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -1,9 +1,16 @@
+import { type GeoLibreLayer, useAppStore } from "@geolibre/core";
+import type { FeatureCollection } from "geojson";
+import type maplibregl from "maplibre-gl";
 import { GeoEditor, type GeoEditorOptions } from "maplibre-gl-geo-editor";
 import type {
   GeoLibreAppAPI,
   GeoLibreMapControlPosition,
   GeoLibrePlugin,
 } from "../types";
+
+const SKETCHES_LAYER_NAME = "Sketches";
+const SKETCHES_SOURCE_KIND = "geoeditor-sketches";
+const SKETCHES_SOURCE_PATH = "geoeditor://sketches";
 
 let geoEditorPosition: GeoLibreMapControlPosition = "top-left";
 
@@ -31,15 +38,32 @@ const GEO_EDITOR_OPTIONS = {
   hideGeomanControl: true,
   showFeatureProperties: true,
   fitBoundsOnLoad: true,
-} satisfies Omit<GeoEditorOptions, "position">;
+} satisfies Omit<
+  GeoEditorOptions,
+  | "position"
+  | "onFeatureCreate"
+  | "onFeatureEdit"
+  | "onFeatureDelete"
+  | "onGeoJsonLoad"
+  | "onAttributeChange"
+  | "onHistoryChange"
+>;
 
 let geoEditorControl: GeoEditor | null = null;
+let sketchesLayerId: string | null = null;
+let geoEditorStoreUnsubscribe: (() => void) | null = null;
+let pluginActive = false;
+let restoringSketchesToEditor = false;
+let appApi: GeoLibreAppAPI | null = null;
 
 export const maplibreGeoEditorPlugin: GeoLibrePlugin = {
   id: "maplibre-gl-geo-editor",
   name: "GeoEditor",
   version: "0.7.3",
   activate: (app: GeoLibreAppAPI) => {
+    pluginActive = true;
+    appApi = app;
+
     if (!geoEditorControl) {
       geoEditorControl = new GeoEditor(getGeoEditorOptions());
     }
@@ -49,9 +73,16 @@ export const maplibreGeoEditorPlugin: GeoLibrePlugin = {
       geoEditorControl = null;
       return false;
     }
+
+    bindSketchesStoreSync();
+    restoreSketchesLayerToEditor();
     setTimeout(() => geoEditorControl?.expand(), 0);
   },
   deactivate: (app: GeoLibreAppAPI) => {
+    pluginActive = false;
+    appApi = null;
+    teardownSketchesStoreSync();
+
     if (!geoEditorControl) return;
     app.removeMapControl(geoEditorControl);
     geoEditorControl = null;
@@ -74,5 +105,170 @@ function getGeoEditorOptions(): GeoEditorOptions {
   return {
     ...GEO_EDITOR_OPTIONS,
     position: geoEditorPosition,
+    onFeatureCreate: () => syncSketchesToStore(),
+    onFeatureEdit: () => syncSketchesToStore(),
+    onFeatureDelete: () => syncSketchesToStore(),
+    onGeoJsonLoad: () => {
+      if (!restoringSketchesToEditor) {
+        syncSketchesToStore();
+      }
+    },
+    onAttributeChange: () => syncSketchesToStore(),
+    onHistoryChange: () => syncSketchesToStore(),
   };
+}
+
+function isSketchesLayer(layer: GeoLibreLayer): boolean {
+  return layer.metadata.sourceKind === SKETCHES_SOURCE_KIND;
+}
+
+function findSketchesLayer(
+  layers: GeoLibreLayer[],
+): GeoLibreLayer | undefined {
+  if (sketchesLayerId) {
+    const tracked = layers.find((layer) => layer.id === sketchesLayerId);
+    if (tracked) return tracked;
+  }
+  return layers.find(isSketchesLayer);
+}
+
+function cloneFeatureCollection(
+  collection: FeatureCollection,
+): FeatureCollection {
+  return structuredClone(collection);
+}
+
+function syncSketchesToStore(): void {
+  if (!geoEditorControl || restoringSketchesToEditor) return;
+
+  const collection = cloneFeatureCollection(
+    geoEditorControl.getAllFeatureCollection(),
+  );
+  const store = useAppStore.getState();
+  const existing = findSketchesLayer(store.layers);
+
+  if (existing) {
+    sketchesLayerId = existing.id;
+    store.updateLayer(existing.id, { geojson: collection });
+    hideGeomanDisplayLayers();
+    return;
+  }
+
+  if (collection.features.length === 0) {
+    hideGeomanDisplayLayers();
+    return;
+  }
+
+  const id = store.addGeoJsonLayer(
+    SKETCHES_LAYER_NAME,
+    collection,
+    SKETCHES_SOURCE_PATH,
+  );
+  sketchesLayerId = id;
+  store.updateLayer(id, {
+    metadata: {
+      ...store.layers.find((layer) => layer.id === id)?.metadata,
+      sourceKind: SKETCHES_SOURCE_KIND,
+    },
+  });
+  hideGeomanDisplayLayers();
+}
+
+function restoreSketchesLayerToEditor(): void {
+  if (!geoEditorControl || !pluginActive) return;
+
+  const layer = findSketchesLayer(useAppStore.getState().layers);
+  if (!layer?.geojson?.features?.length) {
+    if (layer) sketchesLayerId = layer.id;
+    return;
+  }
+
+  sketchesLayerId = layer.id;
+  restoringSketchesToEditor = true;
+  try {
+    geoEditorControl.loadGeoJson(
+      cloneFeatureCollection(layer.geojson),
+      SKETCHES_SOURCE_PATH,
+    );
+  } catch {
+    // Geoman may not be ready until the map style finishes loading.
+  } finally {
+    restoringSketchesToEditor = false;
+  }
+  hideGeomanDisplayLayers();
+}
+
+function clearSketchesFromEditor(): void {
+  if (!geoEditorControl) return;
+  restoringSketchesToEditor = true;
+  try {
+    geoEditorControl.loadGeoJson(
+      { type: "FeatureCollection", features: [] },
+      SKETCHES_SOURCE_PATH,
+    );
+  } catch {
+    // Ignore when Geoman is not initialized yet.
+  } finally {
+    restoringSketchesToEditor = false;
+  }
+}
+
+function bindSketchesStoreSync(): void {
+  geoEditorStoreUnsubscribe ??= useAppStore.subscribe((state, previous) => {
+    if (!pluginActive) return;
+
+    const sketches = findSketchesLayer(state.layers);
+    const previousSketches = findSketchesLayer(previous.layers);
+
+    if (previousSketches && !sketches) {
+      sketchesLayerId = null;
+      clearSketchesFromEditor();
+      return;
+    }
+
+    if (sketches && sketches.id !== sketchesLayerId) {
+      sketchesLayerId = sketches.id;
+      restoreSketchesLayerToEditor();
+      return;
+    }
+
+    if (
+      sketches &&
+      previousSketches &&
+      sketches.id === previousSketches.id &&
+      sketches.geojson !== previousSketches.geojson &&
+      !restoringSketchesToEditor
+    ) {
+      restoreSketchesLayerToEditor();
+    }
+  });
+}
+
+function teardownSketchesStoreSync(): void {
+  geoEditorStoreUnsubscribe?.();
+  geoEditorStoreUnsubscribe = null;
+}
+
+function hideGeomanDisplayLayers(): void {
+  const map = appApi?.getMap?.();
+  if (!map) return;
+
+  const style = map.getStyle();
+  if (!style?.layers) return;
+
+  for (const layer of style.layers) {
+    if (!isGeomanDisplayLayer(layer)) continue;
+    try {
+      map.setLayoutProperty(layer.id, "visibility", "none");
+    } catch {
+      // Layer may have been removed with the current style.
+    }
+  }
+}
+
+function isGeomanDisplayLayer(layer: maplibregl.LayerSpecification): boolean {
+  if (layer.id.startsWith("gm_")) return true;
+  if (!("source" in layer)) return false;
+  const source = layer.source;
+  return typeof source === "string" && source.startsWith("geoman");
 }

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -178,9 +178,9 @@ function featureCollectionsEquivalent(
   return JSON.stringify(a) === JSON.stringify(b);
 }
 
-function sketchFeatureKey(feature: Feature, index: number): string {
+function sketchFeatureKey(feature: Feature, _index: number): string {
   const props = feature.properties as Record<string, unknown> | null;
-  return String(feature.id ?? props?.__gm_id ?? `feature-${index}`);
+  return String(feature.id ?? props?.__gm_id ?? JSON.stringify(feature));
 }
 
 function unionFeatureCollections(
@@ -214,25 +214,25 @@ function syncSketchesToStore(): void {
     if (existing) {
       sketchesLayerId = existing.id;
       store.updateLayer(existing.id, { geojson: collection });
-      return;
-    }
+    } else {
+      if (collection.features.length === 0) {
+        return;
+      }
 
-    if (collection.features.length === 0) {
-      return;
+      const id = store.addGeoJsonLayer(
+        SKETCHES_LAYER_NAME,
+        collection,
+        SKETCHES_SOURCE_PATH,
+      );
+      sketchesLayerId = id;
+      store.updateLayer(id, {
+        metadata: {
+          ...useAppStore.getState().layers.find((layer) => layer.id === id)
+            ?.metadata,
+          sourceKind: SKETCHES_SOURCE_KIND,
+        },
+      });
     }
-
-    const id = store.addGeoJsonLayer(
-      SKETCHES_LAYER_NAME,
-      collection,
-      SKETCHES_SOURCE_PATH,
-    );
-    sketchesLayerId = id;
-    store.updateLayer(id, {
-      metadata: {
-        ...store.layers.find((layer) => layer.id === id)?.metadata,
-        sourceKind: SKETCHES_SOURCE_KIND,
-      },
-    });
   } finally {
     pushingSketchesToStore = false;
   }

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -1,5 +1,5 @@
 import { type GeoLibreLayer, useAppStore } from "@geolibre/core";
-import type { FeatureCollection } from "geojson";
+import type { Feature, FeatureCollection } from "geojson";
 import type maplibregl from "maplibre-gl";
 import { GeoEditor, type GeoEditorOptions } from "maplibre-gl-geo-editor";
 import type {
@@ -63,6 +63,8 @@ let appApi: GeoLibreAppAPI | null = null;
 let sketchesMapLayerSuppressed = false;
 /** After a draw completes, show Sketches even if draw mode stays active for another shape. */
 let sketchesIdleDisplayOverride = false;
+/** Union store + editor on the next sync so a partial getAll cannot drop prior sketches. */
+let unionSketchesWithStoreOnNextSync = false;
 
 export const maplibreGeoEditorPlugin: GeoLibrePlugin = {
   id: "maplibre-gl-geo-editor",
@@ -118,6 +120,7 @@ function getGeoEditorOptions(): GeoEditorOptions {
     position: geoEditorPosition,
     onFeatureCreate: () => {
       sketchesIdleDisplayOverride = true;
+      unionSketchesWithStoreOnNextSync = true;
       // Defer until Geoman commits the new feature to its feature store.
       queueMicrotask(() => {
         syncSketchesToStore();
@@ -175,14 +178,36 @@ function featureCollectionsEquivalent(
   return JSON.stringify(a) === JSON.stringify(b);
 }
 
+function sketchFeatureKey(feature: Feature, index: number): string {
+  const props = feature.properties as Record<string, unknown> | null;
+  return String(feature.id ?? props?.__gm_id ?? `feature-${index}`);
+}
+
+function unionFeatureCollections(
+  ...collections: FeatureCollection[]
+): FeatureCollection {
+  const byKey = new Map<string, Feature>();
+  for (const collection of collections) {
+    collection.features.forEach((feature, index) => {
+      byKey.set(sketchFeatureKey(feature, index), feature);
+    });
+  }
+  return { type: "FeatureCollection", features: [...byKey.values()] };
+}
+
 function syncSketchesToStore(): void {
   if (!geoEditorControl || restoringSketchesToEditor) return;
 
-  const collection = cloneFeatureCollection(
+  let collection = cloneFeatureCollection(
     geoEditorControl.getAllFeatureCollection(),
   );
   const store = useAppStore.getState();
   const existing = findSketchesLayer(store.layers);
+
+  if (unionSketchesWithStoreOnNextSync && existing?.geojson) {
+    collection = unionFeatureCollections(existing.geojson, collection);
+    unionSketchesWithStoreOnNextSync = false;
+  }
 
   pushingSketchesToStore = true;
   try {


### PR DESCRIPTION
## Summary

Implements [Option C from #77](https://github.com/opengeos/GeoLibre/issues/77): all GeoEditor features sync into one **Sketches** GeoJSON layer in the Zustand store.

- GeoEditor callbacks (`onFeatureCreate`, `onFeatureEdit`, `onFeatureDelete`, `onGeoJsonLoad`, `onAttributeChange`, `onHistoryChange`) push `getAllFeatureCollection()` into the store via `updateLayer` / `addGeoJsonLayer`.
- The layer is tagged with `metadata.sourceKind: "geoeditor-sketches"` so it can be found on project load.
- Geoman display layers are hidden after sync so features are not drawn twice (Geoman + GeoLibre layer sync).
- Removing the Sketches layer from the layer panel clears GeoEditor features; reopening a saved project restores sketches into GeoEditor when the plugin activates.

## Test plan

- [x] Enable the GeoEditor plugin, draw a polygon/line/point — confirm a **Sketches** layer appears in the layer panel with the feature count. *(verified via browser testing on fork: GeoEditor activated; marker drawn; Sketches VECTOR layer appeared; store had `geoeditor-sketches` metadata and 1 feature)*
- [x] Edit and delete features in GeoEditor — confirm the Sketches layer GeoJSON updates (attribute table / style panel). *(partial: create → store/attribute-table sync verified; GeoEditor delete-at-globe-zoom not confirmed in automation; style panel bound to Sketches)*
- [x] Confirm features are not visibly duplicated on the map after drawing completes. *(verified via browser testing on fork: single marker on map; no double rendering observed)*
- [x] Save project (`.geolibre.json`), reload — Sketches layer and geometries restore; GeoEditor shows the same features when the plugin is active. *(verified via browser testing on fork: `serializeProject` / `loadProject` round-trip restored Sketches with 1 feature and `geoeditor-sketches`; UI layer + attribute table restored)*
- [x] Remove the Sketches layer from the layer panel — GeoEditor canvas clears. *(verified via browser testing on fork: confirm Remove dialog; layers panel showed no data layers; attribute table required vector layer)*
- [x] Deactivate GeoEditor plugin — Sketches layer remains in the project/store. *(verified via browser testing on fork: toolbar hidden after Deactivate; Sketches layer + 1 feature remained in store/UI)*

## Known limitations

- Geoman map layers are hidden after sync; vertex/handle visibility during some active edit modes may need follow-up tuning upstream or in GeoEditor.
- Store → GeoEditor restore runs when the sketches layer is added or its `geojson` reference changes; concurrent edits in both places are not merged.
- Opening GeoJSON via GeoEditor’s file toolbar replaces Geoman features and re-syncs into the Sketches layer (may replace an existing Sketches layer contents).