### PR TITLE
fix(ci): use GITHUB_TOKEN for Claude review on fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -43,6 +43,15 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
+          # Use the workflow's GITHUB_TOKEN for GitHub API calls instead of the
+          # default OIDC -> Claude GitHub App token exchange. That exchange
+          # returns "401 Invalid OIDC token" for OIDC tokens minted in a
+          # pull_request_target context, which broke review on fork PRs. Under
+          # pull_request_target GITHUB_TOKEN already carries the pull-requests
+          # and issues write scopes this job declares, so it can post the review
+          # (as github-actions[bot]). claude_code_oauth_token still authenticates
+          # Claude to the model.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             Perform a thorough code review of pull request ${{ github.repository }}/pull/${{ github.event.pull_request.number }}.


### PR DESCRIPTION
## Problem

The `claude-review` job fails on fork PRs (e.g. #79) at the auth step, before any review happens:

```
App token exchange failed: 401 Unauthorized - Invalid OIDC token
Action failed with error: Invalid OIDC token
```

## Cause

`claude-code-action` authenticates to GitHub in two stages: (1) fetch a GitHub OIDC token, then (2) exchange it with Anthropic's endpoint for an installation token of the official Claude GitHub App. Switching this workflow to `pull_request_target` + `id-token: write` (#78) fixed stage 1, but stage 2 rejects OIDC tokens minted in a `pull_request_target` context with `401 Invalid OIDC token`.

## Fix

Pass the workflow `GITHUB_TOKEN` as `github_token`, which makes the action skip the OIDC -> app-token exchange and use that token for GitHub API calls. Under `pull_request_target` it already carries the `pull-requests: write` and `issues: write` scopes this job declares, so it can post the review. `claude_code_oauth_token` still authenticates Claude to the model.

Tradeoff: review comments post as `github-actions[bot]` instead of `claude[bot]`.