### PR TITLE
feat: render PMTiles URLs as external native layers

### DIFF
--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -24,6 +24,9 @@ const MARTIN_VERSION: &str = "martin-v1.10.1";
 const MARTIN_RELEASE_BASE_URL: &str = "https://github.com/maplibre/martin/releases/download";
 const MARTIN_START_ATTEMPTS: usize = 3;
 const MARTIN_HEALTH_ATTEMPTS: usize = 30;
+const REMOTE_TILE_TIMEOUT_SECS: u64 = 8;
+const REMOTE_TILE_CONNECT_TIMEOUT_SECS: u64 = 4;
+const URL_RESOLVE_TIMEOUT_SECS: u64 = 15;
 
 struct MartinServerState {
     process: Mutex<Option<MartinProcess>>,
@@ -82,12 +85,25 @@ fn close_oauth_popups(app: tauri::AppHandle) {
 }
 
 #[tauri::command]
-fn fetch_url_bytes(url: String) -> Result<Vec<u8>, String> {
+async fn fetch_url_bytes(url: String) -> Result<Vec<u8>, String> {
+    tauri::async_runtime::spawn_blocking(move || fetch_url_bytes_blocking(url))
+        .await
+        .map_err(|error| format!("Tile fetch task failed: {error}"))?
+}
+
+fn fetch_url_bytes_blocking(url: String) -> Result<Vec<u8>, String> {
     if !url.starts_with("https://") && !url.starts_with("http://") {
         return Err("Only HTTP and HTTPS URLs can be fetched".to_string());
     }
 
-    let response = reqwest::blocking::Client::new()
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(REMOTE_TILE_TIMEOUT_SECS))
+        .connect_timeout(Duration::from_secs(REMOTE_TILE_CONNECT_TIMEOUT_SECS))
+        .user_agent("GeoLibre Desktop")
+        .build()
+        .map_err(|error| format!("Could not create HTTP client: {error}"))?;
+
+    let response = client
         .get(&url)
         .send()
         .map_err(|error| format!("Request failed: {error}"))?;
@@ -103,13 +119,21 @@ fn fetch_url_bytes(url: String) -> Result<Vec<u8>, String> {
 }
 
 #[tauri::command]
-fn resolve_url_redirect(url: String) -> Result<String, String> {
+async fn resolve_url_redirect(url: String) -> Result<String, String> {
+    tauri::async_runtime::spawn_blocking(move || resolve_url_redirect_blocking(url))
+        .await
+        .map_err(|error| format!("URL resolve task failed: {error}"))?
+}
+
+fn resolve_url_redirect_blocking(url: String) -> Result<String, String> {
     if !url.starts_with("https://") && !url.starts_with("http://") {
         return Err("Only HTTP and HTTPS URLs can be resolved".to_string());
     }
 
     let client = reqwest::blocking::Client::builder()
-        .timeout(Duration::from_secs(15))
+        .timeout(Duration::from_secs(URL_RESOLVE_TIMEOUT_SECS))
+        .connect_timeout(Duration::from_secs(REMOTE_TILE_CONNECT_TIMEOUT_SECS))
+        .user_agent("GeoLibre Desktop")
         .build()
         .map_err(|error| format!("Could not create HTTP client: {error}"))?;
 

--- a/apps/geolibre-desktop/src/lib/xyz-url.ts
+++ b/apps/geolibre-desktop/src/lib/xyz-url.ts
@@ -171,12 +171,10 @@ function getSavedXyzUrl(layer: GeoLibreLayer): string | null {
 }
 
 function renderableXyzTileUrl(url: string): string {
-  if (!isTauri() || !isHttpUrl(url)) return url;
-
-  registerXyzTileProtocol();
-  return `${XYZ_TILE_PROTOCOL}://tile/{z}/{x}/{y}?url=${encodeURIComponent(
-    url,
-  )}`;
+  // Tauri allows HTTPS image tiles via CSP, so keep the browser/WebView tile
+  // path. Routing every XYZ tile through IPC makes slow tile servers affect
+  // desktop responsiveness.
+  return url;
 }
 
 function parseXyzTileRequest(request: RequestParameters): string {
@@ -208,10 +206,24 @@ async function resolveShortXyzUrl(
   if (!isHttpUrl(url)) return url;
 
   if (isTauri()) {
+    try {
+      return await resolveShortXyzUrlWithFetch(url, signal);
+    } catch (error) {
+      if (isAbortError(error)) throw error;
+      console.warn("Falling back to desktop URL resolver", error);
+    }
+
     const { invoke } = await import("@tauri-apps/api/core");
     return invoke<string>("resolve_url_redirect", { url });
   }
 
+  return resolveShortXyzUrlWithFetch(url, signal);
+}
+
+async function resolveShortXyzUrlWithFetch(
+  url: string,
+  signal?: AbortSignal,
+): Promise<string> {
   const response = await fetch(url, {
     headers: { Accept: "application/json, text/plain;q=0.9, */*;q=0.8" },
     redirect: "follow",
@@ -227,6 +239,10 @@ async function resolveShortXyzUrl(
   }
 
   return response.url || url;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
 }
 
 function urlFromResolverResponse(response: Response): string | null {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12564,6 +12564,7 @@
         "@turf/helpers": "^7.2.0",
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-layer-control": "^0.14.1",
+        "pmtiles": "^4.4.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -14,6 +14,7 @@
     "@turf/helpers": "^7.2.0",
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-layer-control": "^0.14.1",
+    "pmtiles": "^4.4.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -21,8 +21,7 @@ import {
 
 const WMS_PROXY_PATH = "/__geolibre_wms_proxy";
 const PMTILES_PROTOCOL = "pmtiles";
-let pmtilesProtocol: Protocol | null = null;
-let pmtilesProtocolRegistered = false;
+const PMTILES_PROTOCOL_GLOBAL_KEY = "__geolibrePMTilesProtocol";
 
 export function syncLayer(
   map: maplibregl.Map,
@@ -190,22 +189,9 @@ function ensurePMTilesExternalLayer(
   );
 
   if (sourceLayers.length === 0) {
-    const genericLayerId = getPMTilesNativeLayerId(
-      nativeLayerIds,
-      `${sourceId}-generic`,
-    );
-    ensureLayer(
-      map,
-      genericLayerId,
-      {
-        id: genericLayerId,
-        type: "fill",
-        source: sourceId,
-        paint: fillPaint(layer.style, layer.opacity),
-        layout: { visibility: layer.visible ? "visible" : "none" },
-      },
-      beforeId,
-    );
+    // Vector tile sources require a `source-layer` on every layer. With no
+    // known source layer there is nothing valid to render, so skip rather
+    // than add a layer MapLibre would reject at runtime.
     return;
   }
 
@@ -275,20 +261,26 @@ function ensurePMTilesExternalLayer(
 }
 
 function ensurePMTilesProtocol(url: string): void {
-  if (!pmtilesProtocol) {
-    pmtilesProtocol = new Protocol();
+  const protocol = getSharedPMTilesProtocol();
+
+  // Register the same instance we add archives to so MapLibre routes tile
+  // requests through it. isMapLibreProtocolRegistered() reflects MapLibre's
+  // live state, so this also re-registers after setStyle() clears protocols.
+  if (!isMapLibreProtocolRegistered()) {
+    addProtocol(PMTILES_PROTOCOL, protocol.tile);
   }
 
-  if (!pmtilesProtocolRegistered && !isMapLibreProtocolRegistered()) {
-    try {
-      addProtocol(PMTILES_PROTOCOL, pmtilesProtocol.tile);
-    } catch {
-      // Another PMTiles control may have registered the protocol first.
-    }
-  }
+  protocol.add(new PMTiles(stripPMTilesProtocol(url)));
+}
 
-  pmtilesProtocol.add(new PMTiles(stripPMTilesProtocol(url)));
-  pmtilesProtocolRegistered = true;
+function getSharedPMTilesProtocol(): Protocol {
+  const globalScope = globalThis as typeof globalThis & {
+    [PMTILES_PROTOCOL_GLOBAL_KEY]?: Protocol;
+  };
+  if (!globalScope[PMTILES_PROTOCOL_GLOBAL_KEY]) {
+    globalScope[PMTILES_PROTOCOL_GLOBAL_KEY] = new Protocol();
+  }
+  return globalScope[PMTILES_PROTOCOL_GLOBAL_KEY];
 }
 
 function isMapLibreProtocolRegistered(): boolean {
@@ -355,7 +347,7 @@ function pmtilesVectorLayerId(
   sourceLayer: string,
   kind: string,
 ): string {
-  return `${sourceId}-${sourceLayer}-${kind}`;
+  return `${sourceId}-${encodeVectorTileLayerPart(sourceLayer)}-${kind}`;
 }
 
 function getPMTilesSourceLayers(layer: GeoLibreLayer): string[] {

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -1,5 +1,7 @@
 import type { GeoLibreLayer } from "@geolibre/core";
+import { addProtocol, config } from "maplibre-gl";
 import type maplibregl from "maplibre-gl";
+import { PMTiles, Protocol } from "pmtiles";
 import {
   circleLayerId,
   detectGeometryProfile,
@@ -18,6 +20,10 @@ import {
 } from "./style-mapper";
 
 const WMS_PROXY_PATH = "/__geolibre_wms_proxy";
+const PMTILES_PROTOCOL = "pmtiles";
+let pmtilesProtocol: Protocol | null = null;
+let pmtilesProtocolRegistered = false;
+
 export function syncLayer(
   map: maplibregl.Map,
   layer: GeoLibreLayer,
@@ -65,6 +71,10 @@ function syncExternalNativeLayer(
   beforeId?: string,
 ): void {
   const nativeLayerIds = getExternalNativeLayerIds(layer);
+  if (isPMTilesExternalLayer(layer)) {
+    ensurePMTilesExternalLayer(map, layer, nativeLayerIds, beforeId);
+  }
+
   if (isWaybackExternalRasterLayer(layer)) {
     syncWaybackExternalRasterLayer(map, layer, nativeLayerIds, beforeId);
     return;
@@ -119,6 +129,253 @@ function syncExternalNativeLayer(
 
     moveLayer(map, nativeLayerId, beforeId);
   }
+}
+
+function isPMTilesExternalLayer(layer: GeoLibreLayer): boolean {
+  return (
+    layer.type === "pmtiles" &&
+    layer.metadata.sourceKind === "pmtiles-url" &&
+    layer.metadata.externalNativeLayer === true
+  );
+}
+
+function ensurePMTilesExternalLayer(
+  map: maplibregl.Map,
+  layer: GeoLibreLayer,
+  nativeLayerIds: string[],
+  beforeId?: string,
+): void {
+  const rawUrl = stringSource(layer.source.url) ?? layer.sourcePath;
+  const sourceId = getPMTilesSourceId(layer);
+  if (!rawUrl || !sourceId) return;
+
+  ensurePMTilesProtocol(rawUrl);
+
+  if (!map.getSource(sourceId)) {
+    const tileUrl = normalizePMTilesUrl(rawUrl);
+    if (getPMTilesTileType(layer) === "raster") {
+      map.addSource(sourceId, {
+        type: "raster",
+        url: tileUrl,
+        tileSize: 256,
+      });
+    } else {
+      map.addSource(sourceId, {
+        type: "vector",
+        url: tileUrl,
+      });
+    }
+  }
+
+  if (getPMTilesTileType(layer) === "raster") {
+    ensureLayer(
+      map,
+      nativeLayerIds[0] ?? `${sourceId}-raster`,
+      {
+        id: nativeLayerIds[0] ?? `${sourceId}-raster`,
+        type: "raster",
+        source: sourceId,
+        paint: rasterPaint(layer.style, layer.opacity),
+        layout: { visibility: layer.visible ? "visible" : "none" },
+      },
+      beforeId,
+    );
+    return;
+  }
+
+  const sourceLayers = getPMTilesRenderableSourceLayers(
+    layer,
+    sourceId,
+    nativeLayerIds,
+  );
+
+  if (sourceLayers.length === 0) {
+    const genericLayerId = getPMTilesNativeLayerId(
+      nativeLayerIds,
+      `${sourceId}-generic`,
+    );
+    ensureLayer(
+      map,
+      genericLayerId,
+      {
+        id: genericLayerId,
+        type: "fill",
+        source: sourceId,
+        paint: fillPaint(layer.style, layer.opacity),
+        layout: { visibility: layer.visible ? "visible" : "none" },
+      },
+      beforeId,
+    );
+    return;
+  }
+
+  for (const sourceLayer of sourceLayers) {
+    const fillId = getPMTilesNativeLayerId(
+      nativeLayerIds,
+      pmtilesVectorLayerId(sourceId, sourceLayer, "fill"),
+    );
+    const lineId = getPMTilesNativeLayerId(
+      nativeLayerIds,
+      pmtilesVectorLayerId(sourceId, sourceLayer, "line"),
+    );
+    const circleId = getPMTilesNativeLayerId(
+      nativeLayerIds,
+      pmtilesVectorLayerId(sourceId, sourceLayer, "circle"),
+    );
+
+    ensureLayer(
+      map,
+      fillId,
+      {
+        id: fillId,
+        type: "fill",
+        source: sourceId,
+        "source-layer": sourceLayer,
+        filter: ["==", ["geometry-type"], "Polygon"],
+        paint: fillPaint(layer.style, layer.opacity),
+        layout: { visibility: layer.visible ? "visible" : "none" },
+      },
+      beforeId,
+    );
+
+    ensureLayer(
+      map,
+      lineId,
+      {
+        id: lineId,
+        type: "line",
+        source: sourceId,
+        "source-layer": sourceLayer,
+        filter: [
+          "any",
+          ["==", ["geometry-type"], "LineString"],
+          ["==", ["geometry-type"], "Polygon"],
+        ],
+        paint: linePaint(layer.style, layer.opacity),
+        layout: { visibility: layer.visible ? "visible" : "none" },
+      },
+      beforeId,
+    );
+
+    ensureLayer(
+      map,
+      circleId,
+      {
+        id: circleId,
+        type: "circle",
+        source: sourceId,
+        "source-layer": sourceLayer,
+        filter: ["==", ["geometry-type"], "Point"],
+        paint: circlePaint(layer.style, layer.opacity),
+        layout: { visibility: layer.visible ? "visible" : "none" },
+      },
+      beforeId,
+    );
+  }
+}
+
+function ensurePMTilesProtocol(url: string): void {
+  if (!pmtilesProtocol) {
+    pmtilesProtocol = new Protocol();
+  }
+
+  if (!pmtilesProtocolRegistered && !isMapLibreProtocolRegistered()) {
+    try {
+      addProtocol(PMTILES_PROTOCOL, pmtilesProtocol.tile);
+    } catch {
+      // Another PMTiles control may have registered the protocol first.
+    }
+  }
+
+  pmtilesProtocol.add(new PMTiles(stripPMTilesProtocol(url)));
+  pmtilesProtocolRegistered = true;
+}
+
+function isMapLibreProtocolRegistered(): boolean {
+  return Boolean(
+    (
+      config as {
+        REGISTERED_PROTOCOLS?: Record<string, unknown>;
+      }
+    ).REGISTERED_PROTOCOLS?.[PMTILES_PROTOCOL],
+  );
+}
+
+function normalizePMTilesUrl(url: string): string {
+  return url.startsWith(`${PMTILES_PROTOCOL}://`)
+    ? url
+    : `${PMTILES_PROTOCOL}://${url}`;
+}
+
+function stripPMTilesProtocol(url: string): string {
+  return url.startsWith(`${PMTILES_PROTOCOL}://`)
+    ? url.slice(`${PMTILES_PROTOCOL}://`.length)
+    : url;
+}
+
+function getPMTilesSourceId(layer: GeoLibreLayer): string | undefined {
+  return (
+    stringMetadata(layer.metadata.sourceId) ??
+    stringSource(layer.source.sourceId) ??
+    layer.id
+  );
+}
+
+function getPMTilesTileType(layer: GeoLibreLayer): "raster" | "vector" {
+  return layer.metadata.tileType === "raster" || layer.source.type === "raster"
+    ? "raster"
+    : "vector";
+}
+
+function getPMTilesRenderableSourceLayers(
+  layer: GeoLibreLayer,
+  sourceId: string,
+  nativeLayerIds: string[],
+): string[] {
+  const sourceLayers = getPMTilesSourceLayers(layer);
+  const savedSourceLayers = sourceLayers.filter((sourceLayer) =>
+    hasPMTilesNativeSourceLayer(nativeLayerIds, sourceId, sourceLayer),
+  );
+
+  return savedSourceLayers.length > 0 ? savedSourceLayers : sourceLayers;
+}
+
+function hasPMTilesNativeSourceLayer(
+  nativeLayerIds: string[],
+  sourceId: string,
+  sourceLayer: string,
+): boolean {
+  return ["fill", "line", "circle"].some((kind) =>
+    nativeLayerIds.includes(pmtilesVectorLayerId(sourceId, sourceLayer, kind)),
+  );
+}
+
+function pmtilesVectorLayerId(
+  sourceId: string,
+  sourceLayer: string,
+  kind: string,
+): string {
+  return `${sourceId}-${sourceLayer}-${kind}`;
+}
+
+function getPMTilesSourceLayers(layer: GeoLibreLayer): string[] {
+  const sourceLayers = layer.source.sourceLayers ?? layer.metadata.sourceLayers;
+  return Array.isArray(sourceLayers)
+    ? sourceLayers.filter(
+        (sourceLayer): sourceLayer is string =>
+          typeof sourceLayer === "string" && sourceLayer.length > 0,
+      )
+    : [];
+}
+
+function getPMTilesNativeLayerId(
+  nativeLayerIds: string[],
+  fallbackId: string,
+): string {
+  return (
+    nativeLayerIds.find((nativeLayerId) => nativeLayerId === fallbackId) ??
+    fallbackId
+  );
 }
 
 function isWaybackExternalRasterLayer(layer: GeoLibreLayer): boolean {


### PR DESCRIPTION
## Summary
- Add the `pmtiles` dependency and register the `pmtiles://` protocol so PMTiles sources can be added directly to MapLibre.
- Render PMTiles vector sources by fanning each source layer out into fill, line, and circle layers (geometry-filtered), and PMTiles raster sources through a single raster layer.

## Test plan
- [ ] `pre-commit run --all-files` passes (includes `npm run build`)
- [ ] Load a PMTiles vector URL and confirm polygons, lines, and points render
- [ ] Load a PMTiles raster URL and confirm tiles render with correct opacity
- [ ] Toggle layer visibility and opacity and confirm they propagate