### PR TITLE
feat: add per-layer min/max zoom controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Lightweight, cloud-native desktop GIS prototype built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS**, **DuckDB-WASM Spatial**, and **deck.gl**.
 
+[![](https://files.opengeos.org/GeoLibre-OPERA-demo.webp)](https://geolibre.app/demo/?url=https://data.geolibre.app/opera-dswx.geolibre.json)
+
 ## Features (v0.5.0)
 
 - MapLibre map workspace with OpenFreeMap basemaps, blank background support, and toggleable navigation, fullscreen, geolocation, globe, terrain, scale, attribution, and logo controls

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1,7 +1,7 @@
 import {
   DEFAULT_LAYER_STYLE,
-  type LayerStyle,
   type LayerType,
+  styleValue,
   useAppStore,
 } from "@geolibre/core";
 import {
@@ -204,13 +204,6 @@ function removeTrailingJsonCommas(value: string): string {
   }
 
   return result;
-}
-
-function styleValue<K extends keyof LayerStyle>(
-  style: LayerStyle,
-  key: K,
-): LayerStyle[K] {
-  return style[key] ?? DEFAULT_LAYER_STYLE[key];
 }
 
 function clampNumber(value: number, min: number, max: number): number {
@@ -714,10 +707,7 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
             <PanelRightClose className="h-4 w-4" />
           </Button>
         </div>
-        <div className="space-y-4 p-3">
-          {beforeIdControl}
-          {zoomRangeControls}
-        </div>
+        <div className="space-y-4 p-3">{beforeIdControl}</div>
         <p className="p-4 text-xs text-muted-foreground">
           Style controls are not available for this layer type yet.
         </p>

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -557,16 +557,20 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
   );
   const minZoom = styleValue(style, "minZoom");
   const maxZoom = styleValue(style, "maxZoom");
-  const setMinZoom = (value: number) =>
+  const setMinZoom = (value: number) => {
+    const next = clampNumber(value, MIN_LAYER_ZOOM, MAX_LAYER_ZOOM);
     setLayerStyle(layer.id, {
-      minZoom: value,
-      maxZoom: Math.max(value, maxZoom),
+      minZoom: next,
+      maxZoom: Math.max(next, maxZoom),
     });
-  const setMaxZoom = (value: number) =>
+  };
+  const setMaxZoom = (value: number) => {
+    const next = clampNumber(value, MIN_LAYER_ZOOM, MAX_LAYER_ZOOM);
     setLayerStyle(layer.id, {
-      minZoom: Math.min(value, minZoom),
-      maxZoom: value,
+      minZoom: Math.min(next, minZoom),
+      maxZoom: next,
     });
+  };
   const zoomRangeControls = (
     <div className="grid grid-cols-2 gap-3">
       <NumericStyleInput

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -577,18 +577,18 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
   const zoomRangeControls = (
     <div className="grid grid-cols-2 gap-3">
       <NumericStyleInput
-        id="minZoom"
+        id={`${layer.id}-minZoom`}
         label="Min zoom"
         min={MIN_LAYER_ZOOM}
-        max={MAX_LAYER_ZOOM}
+        max={maxZoom}
         step={1}
         value={minZoom}
         onChange={setMinZoom}
       />
       <NumericStyleInput
-        id="maxZoom"
+        id={`${layer.id}-maxZoom`}
         label="Max zoom"
-        min={MIN_LAYER_ZOOM}
+        min={minZoom}
         max={MAX_LAYER_ZOOM}
         step={1}
         value={maxZoom}

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -217,8 +217,8 @@ function clampNumber(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
 
-const MIN_LAYER_ZOOM = 0;
-const MAX_LAYER_ZOOM = 24;
+const MIN_LAYER_ZOOM = DEFAULT_LAYER_STYLE.minZoom;
+const MAX_LAYER_ZOOM = DEFAULT_LAYER_STYLE.maxZoom;
 
 function stepPrecision(step: number): number {
   const [, decimals = ""] = String(step).split(".");

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -20,11 +20,7 @@ import {
   PanelRightOpen,
   SlidersHorizontal,
 } from "lucide-react";
-import {
-  type MouseEvent as ReactMouseEvent,
-  useEffect,
-  useState,
-} from "react";
+import { type MouseEvent as ReactMouseEvent, useEffect, useState } from "react";
 
 interface StylePanelProps {
   onResizeStart: (event: ReactMouseEvent<HTMLDivElement>) => void;
@@ -39,10 +35,7 @@ function isMobileViewport(): boolean {
 
 function isRasterPaintLayer(type: LayerType): boolean {
   return (
-    type === "raster" ||
-    type === "wms" ||
-    type === "wmts" ||
-    type === "xyz"
+    type === "raster" || type === "wms" || type === "wmts" || type === "xyz"
   );
 }
 
@@ -223,6 +216,9 @@ function styleValue<K extends keyof LayerStyle>(
 function clampNumber(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
+
+const MIN_LAYER_ZOOM = 0;
+const MAX_LAYER_ZOOM = 24;
 
 function stepPrecision(step: number): number {
   const [, decimals = ""] = String(step).split(".");
@@ -489,8 +485,7 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
       hasExternalNativeLayers(layer) ||
       hasExternalDeckLayer(layer));
   const hasExtrusionControls =
-    !isRasterTileLayer &&
-    supportsExtrusionControls(layer);
+    !isRasterTileLayer && supportsExtrusionControls(layer);
   const hasRasterPaintControls =
     isRasterPaintLayer(layer.type) || isRasterTileLayer;
   const extrusionEnabled = styleValue(style, "extrusionEnabled");
@@ -499,10 +494,9 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
     draftExtrusionHeightProperty,
   )
     ? extrusionHeightPropertyOptions
-    : [
-        draftExtrusionHeightProperty,
-        ...extrusionHeightPropertyOptions,
-      ].filter(Boolean);
+    : [draftExtrusionHeightProperty, ...extrusionHeightPropertyOptions].filter(
+        Boolean,
+      );
   const extrusionSettingsChanged =
     draftExtrusionColor !== styleValue(style, "extrusionColor") ||
     draftExtrusionOpacity !== styleValue(style, "extrusionOpacity") ||
@@ -568,6 +562,40 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
       />
     </div>
   );
+  const minZoom = styleValue(style, "minZoom");
+  const maxZoom = styleValue(style, "maxZoom");
+  const setMinZoom = (value: number) =>
+    setLayerStyle(layer.id, {
+      minZoom: value,
+      maxZoom: Math.max(value, maxZoom),
+    });
+  const setMaxZoom = (value: number) =>
+    setLayerStyle(layer.id, {
+      minZoom: Math.min(value, minZoom),
+      maxZoom: value,
+    });
+  const zoomRangeControls = (
+    <div className="grid grid-cols-2 gap-3">
+      <NumericStyleInput
+        id="minZoom"
+        label="Min zoom"
+        min={MIN_LAYER_ZOOM}
+        max={MAX_LAYER_ZOOM}
+        step={1}
+        value={minZoom}
+        onChange={setMinZoom}
+      />
+      <NumericStyleInput
+        id="maxZoom"
+        label="Max zoom"
+        min={MIN_LAYER_ZOOM}
+        max={MAX_LAYER_ZOOM}
+        step={1}
+        value={maxZoom}
+        onChange={setMaxZoom}
+      />
+    </div>
+  );
 
   if (hasRasterPaintControls) {
     return (
@@ -591,6 +619,7 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
         <ScrollArea className="flex-1 p-3">
           <div className="space-y-4">
             {beforeIdControl}
+            {zoomRangeControls}
             <RasterStyleSlider
               label="Opacity"
               value={layer.opacity}
@@ -685,7 +714,10 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
             <PanelRightClose className="h-4 w-4" />
           </Button>
         </div>
-        <div className="p-3">{beforeIdControl}</div>
+        <div className="space-y-4 p-3">
+          {beforeIdControl}
+          {zoomRangeControls}
+        </div>
         <p className="p-4 text-xs text-muted-foreground">
           Style controls are not available for this layer type yet.
         </p>
@@ -718,6 +750,7 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
       <ScrollArea className="flex-1 p-3">
         <div className="space-y-4">
           {beforeIdControl}
+          {zoomRangeControls}
           {hasExtrusionControls && (
             <div className="space-y-2">
               <Label>Visualization</Label>
@@ -747,7 +780,7 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
               </div>
             </div>
           )}
-          {(!hasExtrusionControls || !extrusionEnabled) ? (
+          {!hasExtrusionControls || !extrusionEnabled ? (
             <>
               <div className="space-y-2">
                 <Label htmlFor="fillColor">Fill color</Label>

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ hide:
     </div>
   </div>
   <figure class="hero__media">
-    <img src="assets/geolibre-app.png" alt="GeoLibre map interface showing the desktop GIS workspace">
+    <img src="https://files.opengeos.org/GeoLibre-OPERA-demo.webp" alt="GeoLibre map interface showing the desktop GIS workspace">
   </figure>
 </section>
 

--- a/docs/project-format.md
+++ b/docs/project-format.md
@@ -27,6 +27,8 @@ Projects are saved as **`.geolibre.json`** files.
   "visible": true,
   "opacity": 1,
   "style": {
+    "minZoom": 0,
+    "maxZoom": 24,
     "fillColor": "#3b82f6",
     "strokeColor": "#1e40af",
     "strokeWidth": 2,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -58,6 +58,8 @@ export type LayerType =
   | "duckdb-query";
 
 export interface LayerStyle {
+  minZoom: number;
+  maxZoom: number;
   fillColor: string;
   strokeColor: string;
   strokeWidth: number;
@@ -80,6 +82,8 @@ export interface LayerStyle {
 }
 
 export const DEFAULT_LAYER_STYLE: LayerStyle = {
+  minZoom: 0,
+  maxZoom: 24,
   fillColor: "#3b82f6",
   strokeColor: "#1e40af",
   strokeWidth: 2,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -105,6 +105,18 @@ export const DEFAULT_LAYER_STYLE: LayerStyle = {
   rasterHueRotate: 0,
 };
 
+/**
+ * Read a layer style property, falling back to the shared default when the
+ * layer does not define it. Shared by `@geolibre/map` and the desktop app so
+ * the two consumers cannot drift.
+ */
+export function styleValue<K extends keyof LayerStyle>(
+  style: LayerStyle,
+  key: K,
+): LayerStyle[K] {
+  return style[key] ?? DEFAULT_LAYER_STYLE[key];
+}
+
 export interface GeoLibreLayer {
   id: string;
   name: string;

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -30,6 +30,12 @@ const PMTILES_PROTOCOL_GLOBAL_KEY = "__geolibrePMTilesProtocol";
 const MIN_LAYER_ZOOM = DEFAULT_LAYER_STYLE.minZoom;
 const MAX_LAYER_ZOOM = DEFAULT_LAYER_STYLE.maxZoom;
 
+// Native layer ids whose zoom range GeoLibre has taken over. A pristine external
+// layer keeps its source-declared range, but once the user sets a non-default
+// range we keep applying the style range on every sync, including a later reset
+// back to the full [0, 24] window.
+const managedZoomRangeLayerIds = new Set<string>();
+
 function clampLayerZoom(value: number, fallback: number): number {
   if (!Number.isFinite(value)) return fallback;
   return Math.min(MAX_LAYER_ZOOM, Math.max(MIN_LAYER_ZOOM, value));
@@ -47,18 +53,27 @@ function styleLayerZoomRange(style: LayerStyle): {
   };
 }
 
-// Combine a native layer's source-declared zoom range with the user-configured
+// Intersect a native layer's source-declared zoom range with the user-configured
 // style range, taking the tighter bound on each end. This keeps a tile
 // service's zoom floor/ceiling intact while still letting the user narrow the
-// window from the Style panel.
-function unionZoomRange(
+// window from the Style panel. When the two ranges do not overlap the bounds
+// are swapped so MapLibre never receives an inverted (minzoom > maxzoom) range.
+function intersectZoomRange(
   nativeSpec: { minzoom?: number; maxzoom?: number },
   style: LayerStyle,
 ): { minzoom: number; maxzoom: number } {
   const styleRange = styleLayerZoomRange(style);
+  const minzoom = Math.max(
+    nativeSpec.minzoom ?? MIN_LAYER_ZOOM,
+    styleRange.minzoom,
+  );
+  const maxzoom = Math.min(
+    nativeSpec.maxzoom ?? MAX_LAYER_ZOOM,
+    styleRange.maxzoom,
+  );
   return {
-    minzoom: Math.max(nativeSpec.minzoom ?? MIN_LAYER_ZOOM, styleRange.minzoom),
-    maxzoom: Math.min(nativeSpec.maxzoom ?? MAX_LAYER_ZOOM, styleRange.maxzoom),
+    minzoom: Math.min(minzoom, maxzoom),
+    maxzoom: Math.max(minzoom, maxzoom),
   };
 }
 
@@ -138,7 +153,7 @@ function syncExternalNativeLayer(
           source: fillLayerSpec.source,
           "source-layer": fillLayerSpec["source-layer"],
           filter: fillLayerSpec.filter,
-          ...unionZoomRange(fillLayerSpec, layer.style),
+          ...intersectZoomRange(fillLayerSpec, layer.style),
           paint: fillExtrusionPaint(layer.style, layer.opacity),
           layout: { visibility: layer.visible ? "visible" : "none" },
         },
@@ -164,14 +179,18 @@ function syncExternalNativeLayer(
 
     setExternalNativeLayerPaint(map, nativeLayerId, nativeLayer.type, layer);
     // External layers carry their own zoom range from the control or tile
-    // service that registered them. Only override it once the user has
-    // tightened the window, so we don't reset a source's native zoom range to
-    // the full [0, 24] default on every sync pass.
+    // service that registered them, so we leave a pristine layer's native range
+    // alone. Once the user moves off the defaults GeoLibre owns the range and
+    // keeps applying it, so a later reset to the full [0, 24] window still takes
+    // effect rather than stranding the layer at the narrowed range.
     const zoomRange = styleLayerZoomRange(layer.style);
-    if (
-      zoomRange.minzoom !== MIN_LAYER_ZOOM ||
-      zoomRange.maxzoom !== MAX_LAYER_ZOOM
-    ) {
+    const isDefaultRange =
+      zoomRange.minzoom === MIN_LAYER_ZOOM &&
+      zoomRange.maxzoom === MAX_LAYER_ZOOM;
+    if (!isDefaultRange) {
+      managedZoomRangeLayerIds.add(nativeLayerId);
+    }
+    if (managedZoomRangeLayerIds.has(nativeLayerId)) {
       setLayerZoomRange(map, nativeLayerId, zoomRange);
     }
 

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -2,6 +2,7 @@ import {
   DEFAULT_LAYER_STYLE,
   type GeoLibreLayer,
   type LayerStyle,
+  styleValue,
 } from "@geolibre/core";
 import { addProtocol, config } from "maplibre-gl";
 import type maplibregl from "maplibre-gl";
@@ -28,13 +29,6 @@ const PMTILES_PROTOCOL = "pmtiles";
 const PMTILES_PROTOCOL_GLOBAL_KEY = "__geolibrePMTilesProtocol";
 const MIN_LAYER_ZOOM = DEFAULT_LAYER_STYLE.minZoom;
 const MAX_LAYER_ZOOM = DEFAULT_LAYER_STYLE.maxZoom;
-
-function styleValue<K extends keyof LayerStyle>(
-  style: LayerStyle,
-  key: K,
-): LayerStyle[K] {
-  return style[key] ?? DEFAULT_LAYER_STYLE[key];
-}
 
 function clampLayerZoom(value: number, fallback: number): number {
   if (!Number.isFinite(value)) return fallback;
@@ -1212,12 +1206,18 @@ function setLayerZoomRange(
   id: string,
   range: { minzoom?: number; maxzoom?: number },
 ): void {
+  const minzoom = range.minzoom ?? MIN_LAYER_ZOOM;
+  const maxzoom = range.maxzoom ?? MAX_LAYER_ZOOM;
+  const current = map.getLayer(id) as
+    | { minzoom?: number; maxzoom?: number }
+    | undefined;
+  // setLayerZoomRange invalidates MapLibre's style internally, so skip no-op
+  // calls. syncLayer runs this for every layer on every pass.
+  if (current?.minzoom === minzoom && current?.maxzoom === maxzoom) {
+    return;
+  }
   try {
-    map.setLayerZoomRange(
-      id,
-      range.minzoom ?? MIN_LAYER_ZOOM,
-      range.maxzoom ?? MAX_LAYER_ZOOM,
-    );
+    map.setLayerZoomRange(id, minzoom, maxzoom);
   } catch (error) {
     // Custom layers from external controls do not support zoom range updates,
     // so that failure is expected and ignored. Surface anything else (e.g. an

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -1,4 +1,8 @@
-import type { GeoLibreLayer } from "@geolibre/core";
+import {
+  DEFAULT_LAYER_STYLE,
+  type GeoLibreLayer,
+  type LayerStyle,
+} from "@geolibre/core";
 import { addProtocol, config } from "maplibre-gl";
 import type maplibregl from "maplibre-gl";
 import { PMTiles, Protocol } from "pmtiles";
@@ -22,6 +26,31 @@ import {
 const WMS_PROXY_PATH = "/__geolibre_wms_proxy";
 const PMTILES_PROTOCOL = "pmtiles";
 const PMTILES_PROTOCOL_GLOBAL_KEY = "__geolibrePMTilesProtocol";
+const MIN_LAYER_ZOOM = 0;
+const MAX_LAYER_ZOOM = 24;
+
+function styleValue<K extends keyof LayerStyle>(
+  style: LayerStyle,
+  key: K,
+): LayerStyle[K] {
+  return style[key] ?? DEFAULT_LAYER_STYLE[key];
+}
+
+function clampLayerZoom(value: number): number {
+  return Math.min(MAX_LAYER_ZOOM, Math.max(MIN_LAYER_ZOOM, value));
+}
+
+function styleLayerZoomRange(style: LayerStyle): {
+  maxzoom: number;
+  minzoom: number;
+} {
+  const minzoom = clampLayerZoom(styleValue(style, "minZoom"));
+  const maxzoom = clampLayerZoom(styleValue(style, "maxZoom"));
+  return {
+    minzoom: Math.min(minzoom, maxzoom),
+    maxzoom: Math.max(minzoom, maxzoom),
+  };
+}
 
 export function syncLayer(
   map: maplibregl.Map,
@@ -99,8 +128,7 @@ function syncExternalNativeLayer(
           source: fillLayerSpec.source,
           "source-layer": fillLayerSpec["source-layer"],
           filter: fillLayerSpec.filter,
-          minzoom: fillLayerSpec.minzoom,
-          maxzoom: fillLayerSpec.maxzoom,
+          ...styleLayerZoomRange(layer.style),
           paint: fillExtrusionPaint(layer.style, layer.opacity),
           layout: { visibility: layer.visible ? "visible" : "none" },
         },
@@ -125,6 +153,7 @@ function syncExternalNativeLayer(
     );
 
     setExternalNativeLayerPaint(map, nativeLayerId, nativeLayer.type, layer);
+    setLayerZoomRange(map, nativeLayerId, styleLayerZoomRange(layer.style));
 
     moveLayer(map, nativeLayerId, beforeId);
   }
@@ -174,6 +203,7 @@ function ensurePMTilesExternalLayer(
         id: nativeLayerIds[0] ?? `${sourceId}-raster`,
         type: "raster",
         source: sourceId,
+        ...styleLayerZoomRange(layer.style),
         paint: rasterPaint(layer.style, layer.opacity),
         layout: { visibility: layer.visible ? "visible" : "none" },
       },
@@ -217,6 +247,7 @@ function ensurePMTilesExternalLayer(
         type: "fill",
         source: sourceId,
         "source-layer": sourceLayer,
+        ...styleLayerZoomRange(layer.style),
         filter: ["==", ["geometry-type"], "Polygon"],
         paint: fillPaint(layer.style, layer.opacity),
         layout: { visibility: layer.visible ? "visible" : "none" },
@@ -232,6 +263,7 @@ function ensurePMTilesExternalLayer(
         type: "line",
         source: sourceId,
         "source-layer": sourceLayer,
+        ...styleLayerZoomRange(layer.style),
         filter: [
           "any",
           ["==", ["geometry-type"], "LineString"],
@@ -251,6 +283,7 @@ function ensurePMTilesExternalLayer(
         type: "circle",
         source: sourceId,
         "source-layer": sourceLayer,
+        ...styleLayerZoomRange(layer.style),
         filter: ["==", ["geometry-type"], "Point"],
         paint: circlePaint(layer.style, layer.opacity),
         layout: { visibility: layer.visible ? "visible" : "none" },
@@ -406,6 +439,7 @@ function syncWaybackExternalRasterLayer(
       id: nativeLayerId,
       type: "raster",
       source: sourceId,
+      ...styleLayerZoomRange(layer.style),
       paint: rasterPaint(layer.style, layer.opacity),
       layout: { visibility: layer.visible ? "visible" : "none" },
     },
@@ -449,9 +483,7 @@ function getStyleLayerSpec(
   map: maplibregl.Map,
   layerId: string,
 ): maplibregl.LayerSpecification | null {
-  return (
-    map.getStyle().layers?.find((layer) => layer.id === layerId) ?? null
-  );
+  return map.getStyle().layers?.find((layer) => layer.id === layerId) ?? null;
 }
 
 function isFillStyleLayerSpec(
@@ -523,6 +555,7 @@ function syncGeoJsonLayer(
           id: fillExtrusionLayerId(layer.id),
           type: "fill-extrusion",
           source: src,
+          ...styleLayerZoomRange(layer.style),
           filter: [
             "match",
             ["geometry-type"],
@@ -544,6 +577,7 @@ function syncGeoJsonLayer(
           id: fillLayerId(layer.id),
           type: "fill",
           source: src,
+          ...styleLayerZoomRange(layer.style),
           filter: [
             "match",
             ["geometry-type"],
@@ -573,6 +607,7 @@ function syncGeoJsonLayer(
         id: lineLayerId(layer.id),
         type: "line",
         source: src,
+        ...styleLayerZoomRange(layer.style),
         filter: [
           "match",
           ["geometry-type"],
@@ -597,6 +632,7 @@ function syncGeoJsonLayer(
         id: circleLayerId(layer.id),
         type: "circle",
         source: src,
+        ...styleLayerZoomRange(layer.style),
         filter: [
           "match",
           ["geometry-type"],
@@ -634,6 +670,7 @@ function syncRasterTileLayer(
       id: lid,
       type: "raster",
       source: src,
+      ...styleLayerZoomRange(layer.style),
       paint: rasterPaint(layer.style, layer.opacity),
       layout: { visibility: layer.visible ? "visible" : "none" },
     },
@@ -694,6 +731,7 @@ function syncVectorTileLayer(
           type: "fill-extrusion",
           source: src,
           "source-layer": sourceLayer,
+          ...styleLayerZoomRange(layer.style),
           filter: [
             "match",
             ["geometry-type"],
@@ -716,6 +754,7 @@ function syncVectorTileLayer(
           type: "fill",
           source: src,
           "source-layer": sourceLayer,
+          ...styleLayerZoomRange(layer.style),
           filter: [
             "match",
             ["geometry-type"],
@@ -736,6 +775,7 @@ function syncVectorTileLayer(
           type: "line",
           source: src,
           "source-layer": sourceLayer,
+          ...styleLayerZoomRange(layer.style),
           filter: [
             "match",
             ["geometry-type"],
@@ -756,6 +796,7 @@ function syncVectorTileLayer(
           type: "circle",
           source: src,
           "source-layer": sourceLayer,
+          ...styleLayerZoomRange(layer.style),
           filter: [
             "match",
             ["geometry-type"],
@@ -826,6 +867,7 @@ function syncMbtilesVectorLayer(
           type: "fill-extrusion",
           source: src,
           "source-layer": sourceLayer,
+          ...styleLayerZoomRange(layer.style),
           filter: [
             "match",
             ["geometry-type"],
@@ -848,6 +890,7 @@ function syncMbtilesVectorLayer(
           type: "fill",
           source: src,
           "source-layer": sourceLayer,
+          ...styleLayerZoomRange(layer.style),
           filter: [
             "match",
             ["geometry-type"],
@@ -873,6 +916,7 @@ function syncMbtilesVectorLayer(
           type: "line",
           source: src,
           "source-layer": sourceLayer,
+          ...styleLayerZoomRange(layer.style),
           filter: [
             "match",
             ["geometry-type"],
@@ -893,6 +937,7 @@ function syncMbtilesVectorLayer(
           type: "circle",
           source: src,
           "source-layer": sourceLayer,
+          ...styleLayerZoomRange(layer.style),
           filter: [
             "match",
             ["geometry-type"],
@@ -1103,6 +1148,8 @@ function ensureLayer(
   map: maplibregl.Map,
   id: string,
   spec: maplibregl.AddLayerObject & {
+    maxzoom?: number;
+    minzoom?: number;
     paint?: Record<string, unknown>;
     layout?: Record<string, unknown>;
   },
@@ -1119,12 +1166,32 @@ function ensureLayer(
         map.setLayoutProperty(id, key, value);
       }
     }
+    setLayerZoomRange(map, id, {
+      minzoom: spec.minzoom,
+      maxzoom: spec.maxzoom,
+    });
     moveLayer(map, id, beforeId);
     return;
   }
   const validBeforeId =
     beforeId && map.getLayer(beforeId) ? beforeId : undefined;
   map.addLayer(spec, validBeforeId);
+}
+
+function setLayerZoomRange(
+  map: maplibregl.Map,
+  id: string,
+  range: { minzoom?: number; maxzoom?: number },
+): void {
+  try {
+    map.setLayerZoomRange(
+      id,
+      range.minzoom ?? MIN_LAYER_ZOOM,
+      range.maxzoom ?? MAX_LAYER_ZOOM,
+    );
+  } catch {
+    // External controls can create custom layers that do not support zoom range updates.
+  }
 }
 
 function removeIfExists(map: maplibregl.Map, id: string): void {

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -53,6 +53,21 @@ function styleLayerZoomRange(style: LayerStyle): {
   };
 }
 
+// Combine a native layer's source-declared zoom range with the user-configured
+// style range, taking the tighter bound on each end. This keeps a tile
+// service's zoom floor/ceiling intact while still letting the user narrow the
+// window from the Style panel.
+function unionZoomRange(
+  nativeSpec: { minzoom?: number; maxzoom?: number },
+  style: LayerStyle,
+): { minzoom: number; maxzoom: number } {
+  const styleRange = styleLayerZoomRange(style);
+  return {
+    minzoom: Math.max(nativeSpec.minzoom ?? MIN_LAYER_ZOOM, styleRange.minzoom),
+    maxzoom: Math.min(nativeSpec.maxzoom ?? MAX_LAYER_ZOOM, styleRange.maxzoom),
+  };
+}
+
 export function syncLayer(
   map: maplibregl.Map,
   layer: GeoLibreLayer,
@@ -129,7 +144,7 @@ function syncExternalNativeLayer(
           source: fillLayerSpec.source,
           "source-layer": fillLayerSpec["source-layer"],
           filter: fillLayerSpec.filter,
-          ...styleLayerZoomRange(layer.style),
+          ...unionZoomRange(fillLayerSpec, layer.style),
           paint: fillExtrusionPaint(layer.style, layer.opacity),
           layout: { visibility: layer.visible ? "visible" : "none" },
         },
@@ -154,7 +169,17 @@ function syncExternalNativeLayer(
     );
 
     setExternalNativeLayerPaint(map, nativeLayerId, nativeLayer.type, layer);
-    setLayerZoomRange(map, nativeLayerId, styleLayerZoomRange(layer.style));
+    // External layers carry their own zoom range from the control or tile
+    // service that registered them. Only override it once the user has
+    // tightened the window, so we don't reset a source's native zoom range to
+    // the full [0, 24] default on every sync pass.
+    const zoomRange = styleLayerZoomRange(layer.style);
+    if (
+      zoomRange.minzoom !== MIN_LAYER_ZOOM ||
+      zoomRange.maxzoom !== MAX_LAYER_ZOOM
+    ) {
+      setLayerZoomRange(map, nativeLayerId, zoomRange);
+    }
 
     moveLayer(map, nativeLayerId, beforeId);
   }
@@ -1149,8 +1174,11 @@ function ensureLayer(
   map: maplibregl.Map,
   id: string,
   spec: maplibregl.AddLayerObject & {
-    maxzoom?: number;
-    minzoom?: number;
+    // Required so every caller supplies an explicit zoom range; omitting it
+    // would silently reset an existing layer's range to the full [0, 24]
+    // window on the next sync.
+    maxzoom: number;
+    minzoom: number;
     paint?: Record<string, unknown>;
     layout?: Record<string, unknown>;
   },
@@ -1190,8 +1218,14 @@ function setLayerZoomRange(
       range.minzoom ?? MIN_LAYER_ZOOM,
       range.maxzoom ?? MAX_LAYER_ZOOM,
     );
-  } catch {
-    // External controls can create custom layers that do not support zoom range updates.
+  } catch (error) {
+    // Custom layers from external controls do not support zoom range updates,
+    // so that failure is expected and ignored. Surface anything else (e.g. an
+    // error on a GeoLibre-owned layer) so a real invariant violation is not
+    // silently swallowed.
+    if (map.getLayer(id)?.type !== "custom") {
+      console.warn("[GeoLibre] setLayerZoomRange failed for layer", id, error);
+    }
   }
 }
 

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -26,8 +26,8 @@ import {
 const WMS_PROXY_PATH = "/__geolibre_wms_proxy";
 const PMTILES_PROTOCOL = "pmtiles";
 const PMTILES_PROTOCOL_GLOBAL_KEY = "__geolibrePMTilesProtocol";
-const MIN_LAYER_ZOOM = 0;
-const MAX_LAYER_ZOOM = 24;
+const MIN_LAYER_ZOOM = DEFAULT_LAYER_STYLE.minZoom;
+const MAX_LAYER_ZOOM = DEFAULT_LAYER_STYLE.maxZoom;
 
 function styleValue<K extends keyof LayerStyle>(
   style: LayerStyle,
@@ -36,7 +36,8 @@ function styleValue<K extends keyof LayerStyle>(
   return style[key] ?? DEFAULT_LAYER_STYLE[key];
 }
 
-function clampLayerZoom(value: number): number {
+function clampLayerZoom(value: number, fallback: number): number {
+  if (!Number.isFinite(value)) return fallback;
   return Math.min(MAX_LAYER_ZOOM, Math.max(MIN_LAYER_ZOOM, value));
 }
 
@@ -44,8 +45,8 @@ function styleLayerZoomRange(style: LayerStyle): {
   maxzoom: number;
   minzoom: number;
 } {
-  const minzoom = clampLayerZoom(styleValue(style, "minZoom"));
-  const maxzoom = clampLayerZoom(styleValue(style, "maxZoom"));
+  const minzoom = clampLayerZoom(styleValue(style, "minZoom"), MIN_LAYER_ZOOM);
+  const maxzoom = clampLayerZoom(styleValue(style, "maxZoom"), MAX_LAYER_ZOOM);
   return {
     minzoom: Math.min(minzoom, maxzoom),
     maxzoom: Math.max(minzoom, maxzoom),


### PR DESCRIPTION
## Summary
- Add `minZoom` / `maxZoom` to the layer style model (with defaults of 0 and 24) and persist them in the project format.
- Surface min/max zoom inputs in the Style panel for raster, vector, and unsupported layer types, keeping the two values consistent as the user edits them.
- Apply the zoom range to every native MapLibre layer created by the layer sync, clamping values and tolerating layers that do not support zoom range updates.

## Test plan
- [ ] `pre-commit run --all-files` passes (includes the npm build).
- [ ] In the desktop app, set a min/max zoom on a layer and confirm it hides/shows at the expected zoom levels.
- [ ] Save and reload a project and confirm the zoom range round-trips.