### PR TITLE
feat: add URL-driven compact embed layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Lightweight, cloud-native desktop GIS prototype built with **Tauri v2**, **React
 
 ## Prerequisites
 
-- **Node.js** 18+
+- **Node.js** 22+
 - **Rust** toolchain ([rustup](https://rustup.rs/)) for Tauri desktop builds
 - Linux: `webkit2gtk`, `libayatana-appindicator` (see [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/))
 
@@ -40,6 +40,38 @@ npm run dev
 ```
 
 Open http://localhost:5173. The map and browser vector import support local vector files that DuckDB-WASM Spatial can read, including common formats such as GeoJSON, GeoParquet, GeoPackage, Shapefile, FlatGeobuf, KML/KMZ, and GML, with direct handling for GeoJSON, zipped Shapefiles, and KMZ archives. You can choose files from Add Vector Layer or drag them onto the app. Desktop filesystem dialogs, local MBTiles, and local raster file reads require Tauri.
+
+## Embed the demo
+
+The browser demo supports URL parameters for iframe-friendly layouts.
+
+Open a project by URL:
+
+<https://geolibre.app/demo/?url=https://data.geolibre.app/opera-dswx.geolibre.json>
+
+Supported query parameters:
+
+| Parameter | Example | Description |
+| --- | --- | --- |
+| `url` | `url=https://data.geolibre.app/opera-dswx.geolibre.json` | Loads a `.geolibre.json` project from a public URL. |
+| `layout` | `layout=compact` | Uses the compact embed layout with icon-only toolbar buttons and hidden project metadata. `embed` and `iframe` are aliases. |
+| `toolbar` | `toolbar=icons` | Shows icon-only toolbar buttons without enabling the full compact layout. |
+| `panels` | `panels=none` | Hides the Layers, Style, and Attribute table panels. `hidden`, `hide`, and `off` are aliases. |
+| `hidePanels` | `hidePanels=true` | Alternative way to hide the Layers, Style, and Attribute table panels. |
+
+Use compact mode for narrow embeds. This shows icon-only toolbar buttons and hides project metadata:
+
+```text
+https://geolibre.app/demo/?url=https://data.geolibre.app/opera-dswx.geolibre.json&layout=compact
+```
+
+Hide the Layers, Style, and Attribute table panels for map-focused embeds:
+
+```text
+https://geolibre.app/demo/?url=https://data.geolibre.app/opera-dswx.geolibre.json&layout=compact&panels=none
+```
+
+Use `toolbar=icons` when you only want icon-only toolbar buttons. `panels=hidden`, `panels=hide`, `panels=off`, and `hidePanels=true` are accepted aliases for hiding panels.
 
 ## Environment variables
 

--- a/apps/geolibre-desktop/src/App.tsx
+++ b/apps/geolibre-desktop/src/App.tsx
@@ -1,15 +1,18 @@
 import { DesktopShell } from "./components/layout/DesktopShell";
+import { useLayoutOptions } from "./hooks/useLayoutOptions";
 import { usePlugins } from "./hooks/usePlugins";
 import { useProjectUrlLoader } from "./hooks/useProjectUrlLoader";
 import { useThemeMode } from "./hooks/useThemeMode";
 
 export default function App() {
+  const layoutOptions = useLayoutOptions();
   const { themeMode, toggleThemeMode } = useThemeMode();
   const projectUrlLoadState = useProjectUrlLoader();
 
   usePlugins();
   return (
     <DesktopShell
+      layoutOptions={layoutOptions}
       projectUrlLoadState={projectUrlLoadState}
       themeMode={themeMode}
       onToggleThemeMode={toggleThemeMode}

--- a/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
@@ -28,7 +28,7 @@ interface AboutDialogProps {
   buttonClassName?: string;
   buttonSize?: ButtonProps["size"];
   iconClassName?: string;
-  showLabel?: boolean;
+  showLabels?: boolean;
 }
 
 function isTauri(): boolean {
@@ -47,7 +47,7 @@ export function AboutDialog({
   buttonClassName,
   buttonSize = "sm",
   iconClassName,
-  showLabel = true,
+  showLabels = true,
 }: AboutDialogProps) {
   return (
     <Dialog>
@@ -59,7 +59,7 @@ export function AboutDialog({
           aria-label="About"
         >
           <Info className={iconClassName ?? "h-3.5 w-3.5 sm:mr-1"} />
-          {showLabel ? <span className="hidden sm:inline">About</span> : null}
+          {showLabels ? <span className="hidden sm:inline">About</span> : null}
         </Button>
       </DialogTrigger>
       <DialogContent className="max-w-md">

--- a/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  type ButtonProps,
   Dialog,
   DialogContent,
   DialogDescription,
@@ -23,6 +24,13 @@ const LINKS = [
 
 const APP_VERSION = __GEOLIBRE_VERSION__;
 
+interface AboutDialogProps {
+  buttonClassName?: string;
+  buttonSize?: ButtonProps["size"];
+  iconClassName?: string;
+  showLabel?: boolean;
+}
+
 function isTauri(): boolean {
   return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 }
@@ -35,13 +43,23 @@ async function openExternalLink(url: string) {
   window.open(url, "_blank", "noopener,noreferrer");
 }
 
-export function AboutDialog() {
+export function AboutDialog({
+  buttonClassName,
+  buttonSize = "sm",
+  iconClassName,
+  showLabel = true,
+}: AboutDialogProps) {
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <Button variant="ghost" size="sm" aria-label="About">
-          <Info className="h-3.5 w-3.5 sm:mr-1" />
-          <span className="hidden sm:inline">About</span>
+        <Button
+          className={buttonClassName}
+          variant="ghost"
+          size={buttonSize}
+          aria-label="About"
+        >
+          <Info className={iconClassName ?? "h-3.5 w-3.5 sm:mr-1"} />
+          {showLabel ? <span className="hidden sm:inline">About</span> : null}
         </Button>
       </DialogTrigger>
       <DialogContent className="max-w-md">

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -23,10 +23,12 @@ import { StylePanel } from "../panels/StylePanel";
 import { ProcessingDialog } from "../processing/ProcessingDialog";
 import { StatusBar } from "./StatusBar";
 import { TopToolbar } from "./TopToolbar";
+import type { LayoutOptions } from "../../hooks/useLayoutOptions";
 import type { ThemeMode } from "../../hooks/useThemeMode";
 import type { ProjectUrlLoadState } from "../../hooks/useProjectUrlLoader";
 
 interface DesktopShellProps {
+  layoutOptions: LayoutOptions;
   projectUrlLoadState?: ProjectUrlLoadState;
   themeMode: ThemeMode;
   onToggleThemeMode: () => void;
@@ -62,6 +64,7 @@ type ShellStyle = CSSProperties &
   Record<"--layer-panel-width" | "--style-panel-width", string>;
 
 export function DesktopShell({
+  layoutOptions,
   projectUrlLoadState,
   themeMode,
   onToggleThemeMode,
@@ -383,7 +386,7 @@ export function DesktopShell({
   return (
     <div
       ref={shellRef}
-      className="relative flex h-full flex-col bg-background"
+      className="relative flex h-full min-w-0 flex-col overflow-hidden bg-background"
       style={shellStyle}
       onDragEnter={handleDragEnter}
       onDragLeave={handleDragLeave}
@@ -391,22 +394,33 @@ export function DesktopShell({
       onDrop={handleDrop}
     >
       <TopToolbar
+        compact={layoutOptions.compact}
         mapControllerRef={mapControllerRef}
+        showLabels={layoutOptions.toolbarLabels}
+        showProjectInfo={layoutOptions.showProjectInfo}
         themeMode={themeMode}
         onToggleThemeMode={onToggleThemeMode}
       />
       <div className="flex min-h-0 flex-1 flex-col md:flex-row">
-        <LayerPanel
-          mapControllerRef={mapControllerRef}
-          onResizeStart={startLayerPanelResize}
-        />
-        <main className="relative min-h-72 min-w-0 flex-1 md:min-h-0">
+        {layoutOptions.panelsVisible ? (
+          <LayerPanel
+            mapControllerRef={mapControllerRef}
+            onResizeStart={startLayerPanelResize}
+          />
+        ) : null}
+        <main
+          className={`relative min-w-0 flex-1 overflow-hidden ${
+            layoutOptions.compact ? "min-h-0" : "min-h-72 md:min-h-0"
+          }`}
+        >
           <MapCanvas controllerRef={mapControllerRef} />
         </main>
-        <StylePanel onResizeStart={startStylePanelResize} />
+        {layoutOptions.panelsVisible ? (
+          <StylePanel onResizeStart={startStylePanelResize} />
+        ) : null}
       </div>
-      <AttributeTable />
-      <StatusBar />
+      {layoutOptions.panelsVisible ? <AttributeTable /> : null}
+      <StatusBar compact={layoutOptions.compact} />
       <ProcessingDialog mapControllerRef={mapControllerRef} />
       <div
         ref={verticalResizeGuideRef}

--- a/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
@@ -44,7 +44,7 @@ interface NewProjectDialogProps {
   buttonClassName?: string;
   buttonSize?: ButtonProps["size"];
   iconClassName?: string;
-  showLabel?: boolean;
+  showLabels?: boolean;
   onSaveCurrentProject: () => Promise<boolean>;
 }
 
@@ -52,7 +52,7 @@ export function NewProjectDialog({
   buttonClassName,
   buttonSize = "sm",
   iconClassName,
-  showLabel = true,
+  showLabels = true,
   onSaveCurrentProject,
 }: NewProjectDialogProps) {
   const newProject = useAppStore((s) => s.newProject);
@@ -153,7 +153,7 @@ export function NewProjectDialog({
           aria-label="New project"
         >
           <FilePlus2 className={iconClassName ?? "h-3.5 w-3.5 sm:mr-1"} />
-          {showLabel ? <span className="hidden sm:inline">New</span> : null}
+          {showLabels ? <span className="hidden sm:inline">New</span> : null}
         </Button>
       </DialogTrigger>
       <DialogContent className="max-w-xl">

--- a/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
@@ -7,6 +7,7 @@ import {
 } from "@geolibre/core";
 import {
   Button,
+  type ButtonProps,
   cn,
   Dialog,
   DialogContent,
@@ -40,10 +41,18 @@ type BasemapChoice =
   | typeof BLANK_BASEMAP_ID;
 
 interface NewProjectDialogProps {
+  buttonClassName?: string;
+  buttonSize?: ButtonProps["size"];
+  iconClassName?: string;
+  showLabel?: boolean;
   onSaveCurrentProject: () => Promise<boolean>;
 }
 
 export function NewProjectDialog({
+  buttonClassName,
+  buttonSize = "sm",
+  iconClassName,
+  showLabel = true,
   onSaveCurrentProject,
 }: NewProjectDialogProps) {
   const newProject = useAppStore((s) => s.newProject);
@@ -137,9 +146,14 @@ export function NewProjectDialog({
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
-        <Button variant="ghost" size="sm" aria-label="New project">
-          <FilePlus2 className="h-3.5 w-3.5 sm:mr-1" />
-          <span className="hidden sm:inline">New</span>
+        <Button
+          className={buttonClassName}
+          variant="ghost"
+          size={buttonSize}
+          aria-label="New project"
+        >
+          <FilePlus2 className={iconClassName ?? "h-3.5 w-3.5 sm:mr-1"} />
+          {showLabel ? <span className="hidden sm:inline">New</span> : null}
         </Button>
       </DialogTrigger>
       <DialogContent className="max-w-xl">

--- a/apps/geolibre-desktop/src/components/layout/StatusBar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/StatusBar.tsx
@@ -1,6 +1,11 @@
 import { useAppStore } from "@geolibre/core";
+import { cn } from "@geolibre/ui";
 
-export function StatusBar() {
+interface StatusBarProps {
+  compact?: boolean;
+}
+
+export function StatusBar({ compact = false }: StatusBarProps) {
   const pointerCoords = useAppStore((s) => s.pointerCoords);
   const mapView = useAppStore((s) => s.mapView);
 
@@ -13,16 +18,21 @@ export function StatusBar() {
     : "—";
 
   return (
-    <footer className="flex h-7 shrink-0 items-center gap-4 overflow-x-auto border-t bg-muted/40 px-3 font-mono text-xs text-muted-foreground">
-      <span>Coords: {coordText}</span>
-      <span className="whitespace-nowrap">Zoom: {mapView.zoom.toFixed(2)}</span>
-      <span className="whitespace-nowrap">
+    <footer
+      className={cn(
+        "flex h-7 shrink-0 items-center gap-4 overflow-y-hidden whitespace-nowrap border-t bg-muted/40 px-3 font-mono text-xs text-muted-foreground",
+        compact ? "overflow-hidden" : "overflow-x-auto",
+      )}
+    >
+      <span className="shrink-0">
+        {compact ? "XY" : "Coords"}: {coordText}
+      </span>
+      <span className="shrink-0">Zoom: {mapView.zoom.toFixed(2)}</span>
+      <span className="shrink-0">
         Bearing: {mapView.bearing.toFixed(1)}°
       </span>
-      <span className="whitespace-nowrap">
-        Pitch: {mapView.pitch.toFixed(1)}°
-      </span>
-      <span className="truncate">BBox: {bboxText}</span>
+      <span className="shrink-0">Pitch: {mapView.pitch.toFixed(1)}°</span>
+      {compact ? null : <span className="min-w-0 truncate">BBox: {bboxText}</span>}
     </footer>
   );
 }

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -233,7 +233,7 @@ export function TopToolbar({
     >
       <span className="mr-1 flex shrink-0 items-center gap-1.5 text-sm font-semibold text-primary md:mr-2">
         <Map className="h-4 w-4" />
-        {showLabels ? (
+        {showProjectInfo ? (
           <span className="hidden sm:inline">GeoLibre Desktop</span>
         ) : null}
       </span>
@@ -241,7 +241,7 @@ export function TopToolbar({
         buttonClassName={toolbarButtonClass}
         buttonSize={toolbarButtonSize}
         iconClassName={toolbarIconClassName}
-        showLabel={showLabels}
+        showLabels={showLabels}
         onSaveCurrentProject={handleSave}
       />
       <Button
@@ -448,7 +448,7 @@ export function TopToolbar({
         buttonClassName={toolbarButtonClass}
         buttonSize={toolbarButtonSize}
         iconClassName={toolbarIconClassName}
-        showLabel={showLabels}
+        showLabels={showLabels}
       />
       <div className="ml-auto flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
         <Button

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -25,6 +25,7 @@ import {
 } from "@geolibre/plugins";
 import {
   Button,
+  cn,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -60,7 +61,10 @@ import { AboutDialog } from "./AboutDialog";
 import { NewProjectDialog } from "./NewProjectDialog";
 
 interface TopToolbarProps {
+  compact?: boolean;
   mapControllerRef: React.RefObject<MapController | null>;
+  showLabels?: boolean;
+  showProjectInfo?: boolean;
   themeMode: ThemeMode;
   onToggleThemeMode: () => void;
 }
@@ -92,7 +96,10 @@ const PLUGIN_POSITION_ITEMS: Array<{
 ];
 
 export function TopToolbar({
+  compact = false,
   mapControllerRef,
+  showLabels = true,
+  showProjectInfo = true,
   themeMode,
   onToggleThemeMode,
 }: TopToolbarProps) {
@@ -209,27 +216,64 @@ export function TopToolbar({
       return updated ? { ...current, [control]: visible } : current;
     });
   };
+  const toolbarButtonSize = compact ? "icon" : "sm";
+  const toolbarButtonClass = compact ? "h-8 w-8 shrink-0" : "shrink-0";
+  const toolbarIconClassName = cn("h-3.5 w-3.5", showLabels && "sm:mr-1");
+  const renderToolbarLabel = (label: string) =>
+    showLabels ? <span className="hidden sm:inline">{label}</span> : null;
 
   return (
-    <header className="flex min-h-11 shrink-0 flex-wrap items-center gap-1 border-b bg-card px-2 py-1 md:flex-nowrap">
+    <header
+      className={cn(
+        "flex min-h-11 min-w-0 shrink-0 items-center gap-1 border-b bg-card py-1",
+        compact
+          ? "flex-nowrap overflow-x-auto px-1.5"
+          : "flex-wrap px-2 md:flex-nowrap",
+      )}
+    >
       <span className="mr-1 flex shrink-0 items-center gap-1.5 text-sm font-semibold text-primary md:mr-2">
         <Map className="h-4 w-4" />
-        <span className="hidden sm:inline">GeoLibre Desktop</span>
+        {showLabels ? (
+          <span className="hidden sm:inline">GeoLibre Desktop</span>
+        ) : null}
       </span>
-      <NewProjectDialog onSaveCurrentProject={handleSave} />
-      <Button variant="ghost" size="sm" onClick={handleOpen} aria-label="Open">
-        <FolderOpen className="h-3.5 w-3.5 sm:mr-1" />
-        <span className="hidden sm:inline">Open</span>
+      <NewProjectDialog
+        buttonClassName={toolbarButtonClass}
+        buttonSize={toolbarButtonSize}
+        iconClassName={toolbarIconClassName}
+        showLabel={showLabels}
+        onSaveCurrentProject={handleSave}
+      />
+      <Button
+        className={toolbarButtonClass}
+        variant="ghost"
+        size={toolbarButtonSize}
+        onClick={handleOpen}
+        aria-label="Open"
+      >
+        <FolderOpen className={toolbarIconClassName} />
+        {renderToolbarLabel("Open")}
       </Button>
-      <Button variant="ghost" size="sm" onClick={handleSave} aria-label="Save">
-        <Save className="h-3.5 w-3.5 sm:mr-1" />
-        <span className="hidden sm:inline">Save</span>
+      <Button
+        className={toolbarButtonClass}
+        variant="ghost"
+        size={toolbarButtonSize}
+        onClick={handleSave}
+        aria-label="Save"
+      >
+        <Save className={toolbarIconClassName} />
+        {renderToolbarLabel("Save")}
       </Button>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button variant="ghost" size="sm" aria-label="Add Data">
-            <Database className="h-3.5 w-3.5 sm:mr-1" />
-            <span className="hidden sm:inline">Add Data</span>
+          <Button
+            className={toolbarButtonClass}
+            variant="ghost"
+            size={toolbarButtonSize}
+            aria-label="Add Data"
+          >
+            <Database className={toolbarIconClassName} />
+            {renderToolbarLabel("Add Data")}
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start">
@@ -286,19 +330,25 @@ export function TopToolbar({
         </DropdownMenuContent>
       </DropdownMenu>
       <Button
+        className={toolbarButtonClass}
         variant="ghost"
-        size="sm"
+        size={toolbarButtonSize}
         onClick={() => setProcessingOpen(true)}
         aria-label="Processing"
       >
-        <Wrench className="h-3.5 w-3.5 sm:mr-1" />
-        <span className="hidden sm:inline">Processing</span>
+        <Wrench className={toolbarIconClassName} />
+        {renderToolbarLabel("Processing")}
       </Button>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button variant="ghost" size="sm" aria-label="Controls">
-            <SlidersHorizontal className="h-3.5 w-3.5 sm:mr-1" />
-            <span className="hidden sm:inline">Controls</span>
+          <Button
+            className={toolbarButtonClass}
+            variant="ghost"
+            size={toolbarButtonSize}
+            aria-label="Controls"
+          >
+            <SlidersHorizontal className={toolbarIconClassName} />
+            {renderToolbarLabel("Controls")}
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start">
@@ -322,9 +372,14 @@ export function TopToolbar({
       </DropdownMenu>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button variant="ghost" size="sm" aria-label="Plugins">
-            <Puzzle className="h-3.5 w-3.5 sm:mr-1" />
-            <span className="hidden sm:inline">Plugins</span>
+          <Button
+            className={toolbarButtonClass}
+            variant="ghost"
+            size={toolbarButtonSize}
+            aria-label="Plugins"
+          >
+            <Puzzle className={toolbarIconClassName} />
+            {renderToolbarLabel("Plugins")}
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start">
@@ -389,7 +444,12 @@ export function TopToolbar({
           if (!open) setAddDataKind(null);
         }}
       />
-      <AboutDialog />
+      <AboutDialog
+        buttonClassName={toolbarButtonClass}
+        buttonSize={toolbarButtonSize}
+        iconClassName={toolbarIconClassName}
+        showLabel={showLabels}
+      />
       <div className="ml-auto flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
         <Button
           aria-label={
@@ -413,19 +473,23 @@ export function TopToolbar({
             <Moon className="h-3.5 w-3.5" />
           )}
         </Button>
-        <Layers className="mr-1 hidden h-3 w-3 md:inline" />
-        <Input
-          aria-label="Project name"
-          className="hidden h-7 w-44 border-transparent px-2 text-xs shadow-none focus-visible:border-input md:block"
-          value={projectName}
-          onChange={(event) => setProjectName(event.target.value)}
-          onBlur={(event) => {
-            const nextName = event.target.value.trim();
-            if (!nextName) setProjectName("Untitled Project");
-          }}
-        />
-        {projectPath ? (
-          <span className="hidden truncate lg:inline">{projectPath}</span>
+        {showProjectInfo ? (
+          <>
+            <Layers className="mr-1 hidden h-3 w-3 md:inline" />
+            <Input
+              aria-label="Project name"
+              className="hidden h-7 w-44 border-transparent px-2 text-xs shadow-none focus-visible:border-input md:block"
+              value={projectName}
+              onChange={(event) => setProjectName(event.target.value)}
+              onBlur={(event) => {
+                const nextName = event.target.value.trim();
+                if (!nextName) setProjectName("Untitled Project");
+              }}
+            />
+            {projectPath ? (
+              <span className="hidden truncate lg:inline">{projectPath}</span>
+            ) : null}
+          </>
         ) : null}
       </div>
     </header>

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -270,7 +270,7 @@ export function AttributeTable() {
 
   if (!attributeTableOpen) {
     return (
-      <section className="flex h-11 shrink-0 items-center gap-2 border-t bg-card px-3">
+      <section className="flex h-11 shrink-0 items-center gap-2 border-t bg-card px-2">
         <Button
           variant="ghost"
           size="icon"

--- a/apps/geolibre-desktop/src/hooks/useLayoutOptions.ts
+++ b/apps/geolibre-desktop/src/hooks/useLayoutOptions.ts
@@ -1,0 +1,48 @@
+import { useMemo } from "react";
+
+export interface LayoutOptions {
+  compact: boolean;
+  panelsVisible: boolean;
+  showProjectInfo: boolean;
+  toolbarLabels: boolean;
+}
+
+const COMPACT_LAYOUT_VALUES = new Set(["compact", "embed", "iframe"]);
+const ICON_TOOLBAR_VALUES = new Set(["icon", "icons", "icon-only"]);
+const HIDDEN_PANEL_VALUES = new Set(["false", "hidden", "hide", "none", "off"]);
+
+const DEFAULT_LAYOUT_OPTIONS: LayoutOptions = {
+  compact: false,
+  panelsVisible: true,
+  showProjectInfo: true,
+  toolbarLabels: true,
+};
+
+export function useLayoutOptions(): LayoutOptions {
+  return useMemo(() => layoutOptionsFromLocation(), []);
+}
+
+function layoutOptionsFromLocation(): LayoutOptions {
+  if (typeof window === "undefined") return DEFAULT_LAYOUT_OPTIONS;
+
+  const params = new URLSearchParams(window.location.search);
+  const layout = normalizedParam(params.get("layout"));
+  const panels = normalizedParam(params.get("panels"));
+  const toolbar = normalizedParam(params.get("toolbar"));
+  const compact = COMPACT_LAYOUT_VALUES.has(layout);
+  const panelsVisible =
+    !HIDDEN_PANEL_VALUES.has(panels) &&
+    normalizedParam(params.get("hidePanels")) !== "true";
+  const toolbarLabels = !compact && !ICON_TOOLBAR_VALUES.has(toolbar);
+
+  return {
+    compact,
+    panelsVisible,
+    showProjectInfo: !compact,
+    toolbarLabels,
+  };
+}
+
+function normalizedParam(value: string | null): string {
+  return value?.trim().toLowerCase() ?? "";
+}

--- a/apps/geolibre-desktop/src/hooks/useLayoutOptions.ts
+++ b/apps/geolibre-desktop/src/hooks/useLayoutOptions.ts
@@ -9,7 +9,7 @@ export interface LayoutOptions {
 
 const COMPACT_LAYOUT_VALUES = new Set(["compact", "embed", "iframe"]);
 const ICON_TOOLBAR_VALUES = new Set(["icon", "icons", "icon-only"]);
-const HIDDEN_PANEL_VALUES = new Set(["false", "hidden", "hide", "none", "off"]);
+const HIDDEN_PANEL_VALUES = new Set(["hidden", "hide", "none", "off"]);
 
 const DEFAULT_LAYOUT_OPTIONS: LayoutOptions = {
   compact: false,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@ GeoLibre Desktop is an npm workspaces monorepo. The main app lives in `apps/geol
 
 ## Prerequisites
 
-- Node.js 18 or newer
+- Node.js 22 or newer
 - Rust toolchain for desktop builds
 - Linux desktop build dependencies from the Tauri v2 prerequisites
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,6 +64,34 @@ The processing toolbox includes client-side algorithms now, with a roadmap towar
 
 The live demo is the browser-capable version of the GeoLibre desktop UI. It is useful for exploring the map, loading browser-selected vector data supported by DuckDB-WASM Spatial, adding URL-based layers, styling layers, and testing plugins. Desktop-only file dialogs, local MBTiles, local raster reads, and filesystem save/open operations still require the installed Tauri app.
 
+Open a project by passing a public `.geolibre.json` URL with the `url` query parameter:
+
+```text
+https://geolibre.app/demo/?url=https://data.geolibre.app/opera-dswx.geolibre.json
+```
+
+For narrow embeds, add `?layout=compact` to the demo URL to use icon-only toolbar buttons and hide project metadata:
+
+```text
+https://geolibre.app/demo/?url=https://data.geolibre.app/opera-dswx.geolibre.json&layout=compact
+```
+
+For map-focused embeds, add `&panels=none` to hide the Layers, Style, and Attribute table panels:
+
+```text
+https://geolibre.app/demo/?url=https://data.geolibre.app/opera-dswx.geolibre.json&layout=compact&panels=none
+```
+
+Use `toolbar=icons` when you only want icon-only toolbar buttons. `panels=hidden`, `panels=hide`, `panels=off`, and `hidePanels=true` are accepted aliases for hiding panels.
+
+| Parameter | Example | Description |
+| --- | --- | --- |
+| `url` | `url=https://data.geolibre.app/opera-dswx.geolibre.json` | Loads a `.geolibre.json` project from a public URL. |
+| `layout` | `layout=compact` | Uses the compact embed layout with icon-only toolbar buttons and hidden project metadata. `embed` and `iframe` are aliases. |
+| `toolbar` | `toolbar=icons` | Shows icon-only toolbar buttons without enabling the full compact layout. |
+| `panels` | `panels=none` | Hides the Layers, Style, and Attribute table panels. `hidden`, `hide`, and `off` are aliases. |
+| `hidePanels` | `hidePanels=true` | Alternative way to hide the Layers, Style, and Attribute table panels. |
+
 [Open the live demo](/demo/){ .md-button .md-button--primary }
 [Read the architecture](architecture.md){ .md-button }
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "tauri:build": "node scripts/tauri-build.mjs"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   }
 }


### PR DESCRIPTION
## Summary
- Add a `useLayoutOptions` hook that reads `layout`, `toolbar`, `panels`, and `hidePanels` query parameters to drive a compact, iframe-friendly layout.
- Wire the options through `DesktopShell`, `TopToolbar`, `StatusBar`, `AboutDialog`, and `NewProjectDialog` for icon-only toolbar buttons, hidden project metadata, and optional panel hiding.
- Document the embed parameters in the README and docs.

## Test plan
- [ ] `npm run dev` and open the demo with `?layout=compact` to confirm icon-only toolbar and hidden project info.
- [ ] Add `&panels=none` (and verify `panels=hidden/hide/off` and `hidePanels=true` aliases) hide the Layers, Style, and Attribute table panels.
- [ ] Confirm `toolbar=icons` shows icon-only buttons without enabling full compact mode.
- [ ] Default load (no params) renders the standard desktop layout.