### PR TITLE
feat: persist recent projects with reopen UI

### DIFF
--- a/apps/geolibre-desktop/src/App.tsx
+++ b/apps/geolibre-desktop/src/App.tsx
@@ -2,6 +2,7 @@ import { DesktopShell } from "./components/layout/DesktopShell";
 import { useLayoutOptions } from "./hooks/useLayoutOptions";
 import { usePlugins } from "./hooks/usePlugins";
 import { useProjectUrlLoader } from "./hooks/useProjectUrlLoader";
+import { useRecentProjectsPersistence } from "./hooks/useRecentProjectsPersistence";
 import { useThemeMode } from "./hooks/useThemeMode";
 
 export default function App() {
@@ -10,6 +11,7 @@ export default function App() {
   const projectUrlLoadState = useProjectUrlLoader();
 
   usePlugins();
+  useRecentProjectsPersistence();
   return (
     <DesktopShell
       layoutOptions={layoutOptions}

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -42,6 +42,7 @@ import {
 import {
   Database,
   FolderOpen,
+  History,
   Layers,
   Map,
   Moon,
@@ -54,7 +55,11 @@ import {
 import { useState, useSyncExternalStore } from "react";
 import { createAppAPI, usePluginRegistry } from "../../hooks/usePlugins";
 import type { ThemeMode } from "../../hooks/useThemeMode";
-import { openProjectFile, saveProjectFile } from "../../lib/tauri-io";
+import {
+  openProjectFile,
+  openRecentProjectFile,
+  saveProjectFile,
+} from "../../lib/tauri-io";
 import { resolveProjectXyzLayers } from "../../lib/xyz-url";
 import { AddDataDialog, type AddDataKind } from "./AddDataDialog";
 import { AboutDialog } from "./AboutDialog";
@@ -95,6 +100,22 @@ const PLUGIN_POSITION_ITEMS: Array<{
   { value: "bottom-right", label: "Bottom right" },
 ];
 
+function projectPathLabel(path: string): string {
+  return path.split(/[/\\]/).pop() || path;
+}
+
+function formatRecentProjectTime(openedAt: string): string {
+  const openedDate = new Date(openedAt);
+  if (Number.isNaN(openedDate.getTime())) return "";
+
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(openedDate);
+}
+
 export function TopToolbar({
   compact = false,
   mapControllerRef,
@@ -107,8 +128,12 @@ export function TopToolbar({
   const setProcessingOpen = useAppStore((s) => s.setProcessingOpen);
   const projectName = useAppStore((s) => s.projectName);
   const projectPath = useAppStore((s) => s.projectPath);
+  const recentProjects = useAppStore((s) => s.recentProjects);
   const setProjectPath = useAppStore((s) => s.setProjectPath);
   const setProjectName = useAppStore((s) => s.setProjectName);
+  const rememberRecentProject = useAppStore((s) => s.rememberRecentProject);
+  const forgetRecentProject = useAppStore((s) => s.forgetRecentProject);
+  const clearRecentProjects = useAppStore((s) => s.clearRecentProjects);
   const markSaved = useAppStore((s) => s.markSaved);
   const [controlsVisible, setControlsVisible] = useState<
     Record<ToolbarMapControl, boolean>
@@ -140,6 +165,34 @@ export function TopToolbar({
     }
   };
 
+  const handleOpenRecent = async (path: string) => {
+    let result: Awaited<ReturnType<typeof openRecentProjectFile>>;
+
+    try {
+      result = await openRecentProjectFile(path);
+    } catch (error) {
+      forgetRecentProject(path);
+      console.error("Failed to open recent project", error);
+      window.alert(
+        error instanceof Error
+          ? error.message
+          : "Could not open the recent project.",
+      );
+      return;
+    }
+
+    try {
+      loadProject(await resolveProjectXyzLayers(result.project), result.path);
+    } catch (error) {
+      console.error("Failed to load recent project", error);
+      window.alert(
+        error instanceof Error
+          ? error.message
+          : "Could not load the recent project.",
+      );
+    }
+  };
+
   const handleSave = async (): Promise<boolean> => {
     const state = useAppStore.getState();
     const defaultProjectName = state.projectName.trim() || "Untitled Project";
@@ -159,6 +212,11 @@ export function TopToolbar({
     );
     if (!path) return false;
     setProjectPath(path);
+    rememberRecentProject({
+      path,
+      name: project.name,
+      openedAt: new Date().toISOString(),
+    });
     markSaved();
     return true;
   };
@@ -244,16 +302,62 @@ export function TopToolbar({
         showLabels={showLabels}
         onSaveCurrentProject={handleSave}
       />
-      <Button
-        className={toolbarButtonClass}
-        variant="ghost"
-        size={toolbarButtonSize}
-        onClick={handleOpen}
-        aria-label="Open"
-      >
-        <FolderOpen className={toolbarIconClassName} />
-        {renderToolbarLabel("Open")}
-      </Button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            className={toolbarButtonClass}
+            variant="ghost"
+            size={toolbarButtonSize}
+            aria-label="Open"
+          >
+            <FolderOpen className={toolbarIconClassName} />
+            {renderToolbarLabel("Open")}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-80">
+          <DropdownMenuLabel>Project</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={() => void handleOpen()}>
+            <FolderOpen className="mr-2 h-3.5 w-3.5" />
+            Open Project...
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuLabel>Recent projects</DropdownMenuLabel>
+          {recentProjects.length === 0 ? (
+            <DropdownMenuItem disabled>No recent projects</DropdownMenuItem>
+          ) : (
+            recentProjects.map((project) => {
+              const openedAt = formatRecentProjectTime(project.openedAt);
+              return (
+                <DropdownMenuItem
+                  key={project.path}
+                  className="flex-col items-start gap-0.5"
+                  onSelect={() => void handleOpenRecent(project.path)}
+                >
+                  <span className="max-w-full truncate font-medium">
+                    {project.name || projectPathLabel(project.path)}
+                  </span>
+                  <span className="flex max-w-full items-center gap-1 text-xs text-muted-foreground">
+                    <History className="h-3 w-3 shrink-0" />
+                    <span className="truncate">
+                      {openedAt
+                        ? `${openedAt} - ${project.path}`
+                        : project.path}
+                    </span>
+                  </span>
+                </DropdownMenuItem>
+              );
+            })
+          )}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            disabled={recentProjects.length === 0}
+            onSelect={clearRecentProjects}
+          >
+            Clear Recent Projects
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
       <Button
         className={toolbarButtonClass}
         variant="ghost"

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -167,6 +167,7 @@ export function TopToolbar({
   const [projectUrlLoading, setProjectUrlLoading] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
   const projectUrlAbortRef = useRef<AbortController | null>(null);
+  const recentAbortRef = useRef<AbortController | null>(null);
 
   const handleOpenFromFile = async () => {
     const result = await openProjectFile();
@@ -229,11 +230,18 @@ export function TopToolbar({
   };
 
   const handleOpenRecent = async (path: string) => {
+    // Cancel any previous in-flight open so rapid clicks cannot race and let a
+    // stale fetch win by resolving last.
+    recentAbortRef.current?.abort();
+    const controller = new AbortController();
+    recentAbortRef.current = controller;
+
     let result: Awaited<ReturnType<typeof openRecentProjectFile>>;
 
     try {
-      result = await openRecentProjectFile(path);
+      result = await openRecentProjectFile(path, controller.signal);
     } catch (error) {
+      if (controller.signal.aborted) return;
       // Only drop the entry when the project is permanently gone; preserve it
       // for transient failures (network timeout, 5xx, momentary IO error).
       if (error instanceof RecentProjectGoneError) {
@@ -249,14 +257,24 @@ export function TopToolbar({
     }
 
     try {
-      loadProject(await resolveProjectXyzLayers(result.project), result.path);
+      const project = await resolveProjectXyzLayers(
+        result.project,
+        controller.signal,
+      );
+      if (controller.signal.aborted) return;
+      loadProject(project, result.path);
     } catch (error) {
+      if (controller.signal.aborted) return;
       console.error("Failed to load recent project", error);
       setActionError(
         error instanceof Error
           ? error.message
           : "Could not load the recent project.",
       );
+    } finally {
+      if (recentAbortRef.current === controller) {
+        recentAbortRef.current = null;
+      }
     }
   };
 

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -26,6 +26,11 @@ import {
 import {
   Button,
   cn,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -38,12 +43,14 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
   Input,
+  Label,
 } from "@geolibre/ui";
 import {
   Database,
   FolderOpen,
   History,
   Layers,
+  Link2,
   Map,
   Moon,
   Puzzle,
@@ -52,10 +59,11 @@ import {
   Sun,
   Wrench,
 } from "lucide-react";
-import { useState, useSyncExternalStore } from "react";
+import { type FormEvent, useState, useSyncExternalStore } from "react";
 import { createAppAPI, usePluginRegistry } from "../../hooks/usePlugins";
 import type { ThemeMode } from "../../hooks/useThemeMode";
 import {
+  isTauri,
   openProjectFile,
   openRecentProjectFile,
   saveProjectFile,
@@ -116,6 +124,19 @@ function formatRecentProjectTime(openedAt: string): string {
   }).format(openedDate);
 }
 
+function normalizeProjectUrl(value: string): string | null {
+  if (!value.trim()) return null;
+
+  try {
+    const url = new URL(value.trim(), window.location.href);
+    return url.protocol === "http:" || url.protocol === "https:"
+      ? url.href
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 export function TopToolbar({
   compact = false,
   mapControllerRef,
@@ -147,14 +168,19 @@ export function TopToolbar({
     ),
   );
   const [addDataKind, setAddDataKind] = useState<AddDataKind | null>(null);
+  const [projectUrlDialogOpen, setProjectUrlDialogOpen] = useState(false);
+  const [projectUrl, setProjectUrl] = useState("");
+  const [projectUrlError, setProjectUrlError] = useState<string | null>(null);
+  const [projectUrlLoading, setProjectUrlLoading] = useState(false);
 
-  const handleOpen = async () => {
+  const handleOpenFromFile = async () => {
     const result = await openProjectFile();
     if (result) {
       try {
         loadProject(
           await resolveProjectXyzLayers(result.project),
           result.path,
+          { rememberRecent: isTauri() },
         );
       } catch (error) {
         console.error("Failed to open project", error);
@@ -162,6 +188,32 @@ export function TopToolbar({
           error instanceof Error ? error.message : "Could not open project.",
         );
       }
+    }
+  };
+
+  const handleOpenFromUrl = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const normalizedUrl = normalizeProjectUrl(projectUrl);
+    if (!normalizedUrl) {
+      setProjectUrlError("Enter a valid HTTP or HTTPS project URL.");
+      return;
+    }
+
+    setProjectUrlLoading(true);
+    setProjectUrlError(null);
+
+    try {
+      const result = await openRecentProjectFile(normalizedUrl);
+      loadProject(await resolveProjectXyzLayers(result.project), result.path);
+      setProjectUrl("");
+      setProjectUrlDialogOpen(false);
+    } catch (error) {
+      console.error("Failed to open project URL", error);
+      setProjectUrlError(
+        error instanceof Error ? error.message : "Could not open project URL.",
+      );
+    } finally {
+      setProjectUrlLoading(false);
     }
   };
 
@@ -317,9 +369,13 @@ export function TopToolbar({
         <DropdownMenuContent align="start" className="w-80">
           <DropdownMenuLabel>Project</DropdownMenuLabel>
           <DropdownMenuSeparator />
-          <DropdownMenuItem onSelect={() => void handleOpen()}>
+          <DropdownMenuItem onSelect={() => void handleOpenFromFile()}>
             <FolderOpen className="mr-2 h-3.5 w-3.5" />
-            Open Project...
+            Open Project from File...
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setProjectUrlDialogOpen(true)}>
+            <Link2 className="mr-2 h-3.5 w-3.5" />
+            Open Project from URL...
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuLabel>Recent projects</DropdownMenuLabel>
@@ -548,6 +604,56 @@ export function TopToolbar({
           if (!open) setAddDataKind(null);
         }}
       />
+      <Dialog
+        open={projectUrlDialogOpen}
+        onOpenChange={(open) => {
+          setProjectUrlDialogOpen(open);
+          if (!open) {
+            setProjectUrl("");
+            setProjectUrlError(null);
+            setProjectUrlLoading(false);
+          }
+        }}
+      >
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Open project from URL</DialogTitle>
+            <DialogDescription>
+              Load a public `.geolibre.json` project and add it to recent
+              projects.
+            </DialogDescription>
+          </DialogHeader>
+          <form className="space-y-4" onSubmit={handleOpenFromUrl}>
+            <div className="space-y-2">
+              <Label htmlFor="project-url">Project URL</Label>
+              <Input
+                id="project-url"
+                placeholder="https://example.com/project.geolibre.json"
+                value={projectUrl}
+                onChange={(event) => {
+                  setProjectUrl(event.target.value);
+                  setProjectUrlError(null);
+                }}
+              />
+              {projectUrlError ? (
+                <p className="text-xs text-destructive">{projectUrlError}</p>
+              ) : null}
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setProjectUrlDialogOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={projectUrlLoading}>
+                {projectUrlLoading ? "Opening..." : "Open"}
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
       <AboutDialog
         buttonClassName={toolbarButtonClass}
         buttonSize={toolbarButtonSize}

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -1,5 +1,6 @@
 import {
   projectFromStore,
+  projectPathLabel,
   serializeProject,
   useAppStore,
 } from "@geolibre/core";
@@ -58,16 +59,24 @@ import {
   SlidersHorizontal,
   Sun,
   Wrench,
+  X,
 } from "lucide-react";
-import { type FormEvent, useState, useSyncExternalStore } from "react";
+import {
+  type FormEvent,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import { createAppAPI, usePluginRegistry } from "../../hooks/usePlugins";
 import type { ThemeMode } from "../../hooks/useThemeMode";
 import {
   isTauri,
   openProjectFile,
   openRecentProjectFile,
+  RecentProjectGoneError,
   saveProjectFile,
 } from "../../lib/tauri-io";
+import { normalizeProjectUrl } from "../../lib/urls";
 import { resolveProjectXyzLayers } from "../../lib/xyz-url";
 import { AddDataDialog, type AddDataKind } from "./AddDataDialog";
 import { AboutDialog } from "./AboutDialog";
@@ -108,33 +117,17 @@ const PLUGIN_POSITION_ITEMS: Array<{
   { value: "bottom-right", label: "Bottom right" },
 ];
 
-function projectPathLabel(path: string): string {
-  return path.split(/[/\\]/).pop() || path;
-}
-
 function formatRecentProjectTime(openedAt: string): string {
   const openedDate = new Date(openedAt);
   if (Number.isNaN(openedDate.getTime())) return "";
 
   return new Intl.DateTimeFormat(undefined, {
+    year: "numeric",
     month: "short",
     day: "numeric",
     hour: "numeric",
     minute: "2-digit",
   }).format(openedDate);
-}
-
-function normalizeProjectUrl(value: string): string | null {
-  if (!value.trim()) return null;
-
-  try {
-    const url = new URL(value.trim(), window.location.href);
-    return url.protocol === "http:" || url.protocol === "https:"
-      ? url.href
-      : null;
-  } catch {
-    return null;
-  }
 }
 
 export function TopToolbar({
@@ -172,6 +165,8 @@ export function TopToolbar({
   const [projectUrl, setProjectUrl] = useState("");
   const [projectUrlError, setProjectUrlError] = useState<string | null>(null);
   const [projectUrlLoading, setProjectUrlLoading] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const projectUrlAbortRef = useRef<AbortController | null>(null);
 
   const handleOpenFromFile = async () => {
     const result = await openProjectFile();
@@ -184,7 +179,7 @@ export function TopToolbar({
         );
       } catch (error) {
         console.error("Failed to open project", error);
-        window.alert(
+        setActionError(
           error instanceof Error ? error.message : "Could not open project.",
         );
       }
@@ -199,20 +194,36 @@ export function TopToolbar({
       return;
     }
 
+    projectUrlAbortRef.current?.abort();
+    const controller = new AbortController();
+    projectUrlAbortRef.current = controller;
+
     setProjectUrlLoading(true);
     setProjectUrlError(null);
 
     try {
-      const result = await openRecentProjectFile(normalizedUrl);
-      loadProject(await resolveProjectXyzLayers(result.project), result.path);
+      const result = await openRecentProjectFile(
+        normalizedUrl,
+        controller.signal,
+      );
+      const project = await resolveProjectXyzLayers(
+        result.project,
+        controller.signal,
+      );
+      if (controller.signal.aborted) return;
+      loadProject(project, result.path);
       setProjectUrl("");
       setProjectUrlDialogOpen(false);
     } catch (error) {
+      if (controller.signal.aborted) return;
       console.error("Failed to open project URL", error);
       setProjectUrlError(
         error instanceof Error ? error.message : "Could not open project URL.",
       );
     } finally {
+      if (projectUrlAbortRef.current === controller) {
+        projectUrlAbortRef.current = null;
+      }
       setProjectUrlLoading(false);
     }
   };
@@ -223,9 +234,13 @@ export function TopToolbar({
     try {
       result = await openRecentProjectFile(path);
     } catch (error) {
-      forgetRecentProject(path);
+      // Only drop the entry when the project is permanently gone; preserve it
+      // for transient failures (network timeout, 5xx, momentary IO error).
+      if (error instanceof RecentProjectGoneError) {
+        forgetRecentProject(path);
+      }
       console.error("Failed to open recent project", error);
-      window.alert(
+      setActionError(
         error instanceof Error
           ? error.message
           : "Could not open the recent project.",
@@ -237,7 +252,7 @@ export function TopToolbar({
       loadProject(await resolveProjectXyzLayers(result.project), result.path);
     } catch (error) {
       console.error("Failed to load recent project", error);
-      window.alert(
+      setActionError(
         error instanceof Error
           ? error.message
           : "Could not load the recent project.",
@@ -384,23 +399,39 @@ export function TopToolbar({
           ) : (
             recentProjects.map((project) => {
               const openedAt = formatRecentProjectTime(project.openedAt);
+              const label = project.name || projectPathLabel(project.path);
               return (
                 <DropdownMenuItem
                   key={project.path}
-                  className="flex-col items-start gap-0.5"
+                  className="flex items-start justify-between gap-2"
                   onSelect={() => void handleOpenRecent(project.path)}
                 >
-                  <span className="max-w-full truncate font-medium">
-                    {project.name || projectPathLabel(project.path)}
-                  </span>
-                  <span className="flex max-w-full items-center gap-1 text-xs text-muted-foreground">
-                    <History className="h-3 w-3 shrink-0" />
-                    <span className="truncate">
-                      {openedAt
-                        ? `${openedAt} - ${project.path}`
-                        : project.path}
+                  <span className="flex min-w-0 flex-col items-start gap-0.5">
+                    <span className="max-w-full truncate font-medium">
+                      {label}
+                    </span>
+                    <span className="flex max-w-full items-center gap-1 text-xs text-muted-foreground">
+                      <History className="h-3 w-3 shrink-0" />
+                      <span className="truncate">
+                        {openedAt
+                          ? `${openedAt} - ${project.path}`
+                          : project.path}
+                      </span>
                     </span>
                   </span>
+                  <button
+                    type="button"
+                    aria-label={`Remove ${label} from recent projects`}
+                    className="mt-0.5 shrink-0 rounded p-0.5 text-muted-foreground hover:text-foreground"
+                    onPointerDown={(event) => event.stopPropagation()}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      event.preventDefault();
+                      forgetRecentProject(project.path);
+                    }}
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
                 </DropdownMenuItem>
               );
             })
@@ -609,6 +640,8 @@ export function TopToolbar({
         onOpenChange={(open) => {
           setProjectUrlDialogOpen(open);
           if (!open) {
+            projectUrlAbortRef.current?.abort();
+            projectUrlAbortRef.current = null;
             setProjectUrl("");
             setProjectUrlError(null);
             setProjectUrlLoading(false);
@@ -652,6 +685,22 @@ export function TopToolbar({
               </Button>
             </div>
           </form>
+        </DialogContent>
+      </Dialog>
+      <Dialog
+        open={actionError !== null}
+        onOpenChange={(open) => {
+          if (!open) setActionError(null);
+        }}
+      >
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Could not open project</DialogTitle>
+            <DialogDescription>{actionError}</DialogDescription>
+          </DialogHeader>
+          <div className="flex justify-end">
+            <Button onClick={() => setActionError(null)}>Dismiss</Button>
+          </div>
         </DialogContent>
       </Dialog>
       <AboutDialog

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -423,8 +423,9 @@ export function TopToolbar({
                     type="button"
                     aria-label={`Remove ${label} from recent projects`}
                     className="mt-0.5 shrink-0 rounded p-0.5 text-muted-foreground hover:text-foreground"
-                    onPointerDown={(event) => event.stopPropagation()}
                     onClick={(event) => {
+                      // Keep the menu open and prevent the row's onSelect (which
+                      // would reopen the project) from firing.
                       event.stopPropagation();
                       event.preventDefault();
                       forgetRecentProject(project.path);

--- a/apps/geolibre-desktop/src/hooks/useProjectUrlLoader.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectUrlLoader.ts
@@ -1,5 +1,6 @@
 import { parseProject, useAppStore } from "@geolibre/core";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { normalizeProjectUrl } from "../lib/urls";
 import { resolveProjectXyzLayers } from "../lib/xyz-url";
 
 export type ProjectUrlLoadState =
@@ -35,7 +36,9 @@ export function useProjectUrlLoader(): ProjectUrlLoadState {
       )
       .then((project) => {
         if (abortController.signal.aborted) return;
-        loadProject(project, projectUrl);
+        // A `?url=` deep link is reloaded on every visit, so treat it as
+        // transient rather than persisting it to the recent-projects list.
+        loadProject(project, projectUrl, { rememberRecent: false });
         setState({
           error: null,
           message: `Loaded ${project.name}`,
@@ -102,19 +105,6 @@ function projectUrlFromLocation(): string | null {
   return /^https?:\/\//i.test(bareQuery)
     ? normalizeProjectUrl(bareQuery)
     : null;
-}
-
-function normalizeProjectUrl(value: string | null): string | null {
-  if (!value?.trim()) return null;
-
-  try {
-    const url = new URL(value.trim(), window.location.href);
-    return url.protocol === "http:" || url.protocol === "https:"
-      ? url.href
-      : null;
-  } catch {
-    return null;
-  }
 }
 
 function safeDecodeURIComponent(value: string): string {

--- a/apps/geolibre-desktop/src/hooks/useRecentProjectsPersistence.ts
+++ b/apps/geolibre-desktop/src/hooks/useRecentProjectsPersistence.ts
@@ -1,0 +1,47 @@
+import { useAppStore, type RecentProjectEntry } from "@geolibre/core";
+import { useEffect } from "react";
+
+const RECENT_PROJECTS_STORAGE_KEY = "geolibre.recentProjects";
+
+function isRecentProjectEntry(value: unknown): value is RecentProjectEntry {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<RecentProjectEntry>;
+  return (
+    typeof candidate.path === "string" &&
+    typeof candidate.name === "string" &&
+    typeof candidate.openedAt === "string"
+  );
+}
+
+function loadRecentProjects(): RecentProjectEntry[] {
+  const stored = window.localStorage.getItem(RECENT_PROJECTS_STORAGE_KEY);
+  if (!stored) return [];
+
+  try {
+    const parsed = JSON.parse(stored) as unknown;
+    return Array.isArray(parsed) ? parsed.filter(isRecentProjectEntry) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveRecentProjects(projects: RecentProjectEntry[]) {
+  window.localStorage.setItem(
+    RECENT_PROJECTS_STORAGE_KEY,
+    JSON.stringify(projects),
+  );
+}
+
+export function useRecentProjectsPersistence() {
+  const setRecentProjects = useAppStore((state) => state.setRecentProjects);
+
+  useEffect(() => {
+    setRecentProjects(loadRecentProjects());
+
+    return useAppStore.subscribe((state, previous) => {
+      if (state.recentProjects !== previous.recentProjects) {
+        saveRecentProjects(state.recentProjects);
+      }
+    });
+  }, [setRecentProjects]);
+}

--- a/apps/geolibre-desktop/src/hooks/useRecentProjectsPersistence.ts
+++ b/apps/geolibre-desktop/src/hooks/useRecentProjectsPersistence.ts
@@ -14,22 +14,30 @@ function isRecentProjectEntry(value: unknown): value is RecentProjectEntry {
 }
 
 function loadRecentProjects(): RecentProjectEntry[] {
-  const stored = window.localStorage.getItem(RECENT_PROJECTS_STORAGE_KEY);
-  if (!stored) return [];
+  if (typeof window === "undefined") return [];
 
   try {
+    const stored = window.localStorage.getItem(RECENT_PROJECTS_STORAGE_KEY);
+    if (!stored) return [];
     const parsed = JSON.parse(stored) as unknown;
     return Array.isArray(parsed) ? parsed.filter(isRecentProjectEntry) : [];
   } catch {
+    // localStorage may be unavailable (SecurityError) or hold invalid JSON.
     return [];
   }
 }
 
 function saveRecentProjects(projects: RecentProjectEntry[]) {
-  window.localStorage.setItem(
-    RECENT_PROJECTS_STORAGE_KEY,
-    JSON.stringify(projects),
-  );
+  if (typeof window === "undefined") return;
+
+  try {
+    window.localStorage.setItem(
+      RECENT_PROJECTS_STORAGE_KEY,
+      JSON.stringify(projects),
+    );
+  } catch {
+    // Persistence is best-effort; ignore quota or disabled-storage errors.
+  }
 }
 
 export function useRecentProjectsPersistence() {
@@ -43,5 +51,7 @@ export function useRecentProjectsPersistence() {
         saveRecentProjects(state.recentProjects);
       }
     });
-  }, [setRecentProjects]);
+    // `setRecentProjects` is a stable Zustand action, so this runs once on mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 }

--- a/apps/geolibre-desktop/src/hooks/useRecentProjectsPersistence.ts
+++ b/apps/geolibre-desktop/src/hooks/useRecentProjectsPersistence.ts
@@ -45,6 +45,10 @@ export function useRecentProjectsPersistence() {
 
   useEffect(() => {
     setRecentProjects(loadRecentProjects());
+    // Persist the normalized form now: the subscriber below is attached after
+    // this first state change, so any dedup/trim done on load would otherwise
+    // never be written back and the raw entries would reappear next load.
+    saveRecentProjects(useAppStore.getState().recentProjects);
 
     return useAppStore.subscribe((state, previous) => {
       if (state.recentProjects !== previous.recentProjects) {

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -559,7 +559,10 @@ const MAX_PROJECT_URL_BYTES = 25 * 1024 * 1024;
 
 function isFileMissingError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
-  return /no such file|os error 2|enoent|cannot find|does not exist|not found/i.test(
+  // Match filesystem "missing file" signals only. Avoid broad substrings like
+  // "not found" / "cannot find" that also appear in transient IPC errors
+  // (e.g. "Command not found", Windows os error 3 for a disconnected drive).
+  return /no such file|os error 2|\benoent\b|cannot find the file|file not found|does not exist/i.test(
     message,
   );
 }
@@ -584,11 +587,11 @@ export async function openRecentProjectFile(
       throw new Error(message);
     }
 
-    const contentLength = Number(response.headers.get("content-length"));
-    if (Number.isFinite(contentLength) && contentLength > MAX_PROJECT_URL_BYTES) {
-      throw new Error(
-        "Project file is too large to load (over 25 MB).",
-      );
+    // Only a present Content-Length lets us guard up front. `Number(null)` is
+    // 0, which would silently pass for chunked/CDN responses that omit it.
+    const contentLength = response.headers.get("content-length");
+    if (contentLength !== null && Number(contentLength) > MAX_PROJECT_URL_BYTES) {
+      throw new Error("Project file is too large to load (over 25 MB).");
     }
 
     const contentType = response.headers.get("content-type") ?? "";

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -91,6 +91,15 @@ function isAbortError(error: unknown): boolean {
   return error instanceof DOMException && error.name === "AbortError";
 }
 
+function isHttpUrl(path: string): boolean {
+  try {
+    const url = new URL(path);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 function fileExtension(path: string): string {
   const name = browserSafeFileName(path).toLowerCase();
   if (name.endsWith(".geoparquet")) return "geoparquet";
@@ -530,6 +539,29 @@ export async function openProjectFile(): Promise<{
   const text = await readTextFile(selected);
   const project = parseProject(text);
   return { project, path: selected };
+}
+
+export async function openRecentProjectFile(path: string): Promise<{
+  project: GeoLibreProject;
+  path: string;
+}> {
+  if (isHttpUrl(path)) {
+    const response = await fetch(path);
+    if (!response.ok) {
+      throw new Error(
+        `Could not load project URL: HTTP ${response.status} ${response.statusText}`,
+      );
+    }
+    return { project: parseProject(await response.text()), path };
+  }
+
+  if (!isTauri()) {
+    throw new Error(
+      "Recent local projects can only be reopened in GeoLibre Desktop.",
+    );
+  }
+
+  return { project: parseProject(await readTextFile(path)), path };
 }
 
 export async function saveProjectFile(

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -541,17 +541,63 @@ export async function openProjectFile(): Promise<{
   return { project, path: selected };
 }
 
-export async function openRecentProjectFile(path: string): Promise<{
+/**
+ * Thrown when a recent project is permanently gone (HTTP 404/410 or a local
+ * file that no longer exists), signalling the caller that the entry can be
+ * safely forgotten. Transient failures throw a plain `Error` instead so the
+ * entry is preserved for a retry.
+ */
+export class RecentProjectGoneError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RecentProjectGoneError";
+  }
+}
+
+// Refuse to buffer absurdly large responses into memory (25 MB).
+const MAX_PROJECT_URL_BYTES = 25 * 1024 * 1024;
+
+function isFileMissingError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /no such file|os error 2|enoent|cannot find|does not exist|not found/i.test(
+    message,
+  );
+}
+
+export async function openRecentProjectFile(
+  path: string,
+  signal?: AbortSignal,
+): Promise<{
   project: GeoLibreProject;
   path: string;
 }> {
   if (isHttpUrl(path)) {
-    const response = await fetch(path);
+    const response = await fetch(path, {
+      headers: { Accept: "application/json, text/plain;q=0.9, */*;q=0.8" },
+      signal,
+    });
     if (!response.ok) {
+      const message = `Could not load project URL: HTTP ${response.status} ${response.statusText}`;
+      if (response.status === 404 || response.status === 410) {
+        throw new RecentProjectGoneError(message);
+      }
+      throw new Error(message);
+    }
+
+    const contentLength = Number(response.headers.get("content-length"));
+    if (Number.isFinite(contentLength) && contentLength > MAX_PROJECT_URL_BYTES) {
       throw new Error(
-        `Could not load project URL: HTTP ${response.status} ${response.statusText}`,
+        "Project file is too large to load (over 25 MB).",
       );
     }
+
+    const contentType = response.headers.get("content-type") ?? "";
+    if (/\bhtml\b/i.test(contentType)) {
+      throw new Error(
+        `Unexpected content type "${contentType}" - the URL does not appear to be a project file.`,
+      );
+    }
+
     return { project: parseProject(await response.text()), path };
   }
 
@@ -561,7 +607,17 @@ export async function openRecentProjectFile(path: string): Promise<{
     );
   }
 
-  return { project: parseProject(await readTextFile(path)), path };
+  let text: string;
+  try {
+    text = await readTextFile(path);
+  } catch (error) {
+    if (isFileMissingError(error)) {
+      throw new RecentProjectGoneError(`Project file no longer exists: ${path}`);
+    }
+    throw error;
+  }
+
+  return { project: parseProject(text), path };
 }
 
 export async function saveProjectFile(

--- a/apps/geolibre-desktop/src/lib/urls.ts
+++ b/apps/geolibre-desktop/src/lib/urls.ts
@@ -2,13 +2,16 @@
  * Normalize a user-provided value into an absolute `http:`/`https:` URL.
  *
  * Returns the normalized href, or `null` when the value is empty, unparseable,
- * or uses a non-HTTP protocol.
+ * or uses a non-HTTP protocol. The value must already carry an absolute
+ * scheme: parsing with no base rejects relative/bare paths (e.g. `/api/x`,
+ * `../secret`) instead of resolving them against the current origin, and
+ * avoids touching `window.location` in non-browser contexts.
  */
 export function normalizeProjectUrl(value: string | null): string | null {
   if (!value?.trim()) return null;
 
   try {
-    const url = new URL(value.trim(), window.location.href);
+    const url = new URL(value.trim());
     return url.protocol === "http:" || url.protocol === "https:"
       ? url.href
       : null;

--- a/apps/geolibre-desktop/src/lib/urls.ts
+++ b/apps/geolibre-desktop/src/lib/urls.ts
@@ -1,0 +1,18 @@
+/**
+ * Normalize a user-provided value into an absolute `http:`/`https:` URL.
+ *
+ * Returns the normalized href, or `null` when the value is empty, unparseable,
+ * or uses a non-HTTP protocol.
+ */
+export function normalizeProjectUrl(value: string | null): string | null {
+  if (!value?.trim()) return null;
+
+  try {
+    const url = new URL(value.trim(), window.location.href);
+    return url.protocol === "http:" || url.protocol === "https:"
+      ? url.href
+      : null;
+  } catch {
+    return null;
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,4 +97,4 @@ Use `toolbar=icons` when you only want icon-only toolbar buttons. `panels=hidden
 
 ## Project status
 
-GeoLibre is an active prototype. Version 0.5.0 includes the map workspace, project format, plugin API, browser vector import, DuckDB-WASM Spatial loading, advanced Add Data workflows, MBTiles desktop support, ArcGIS layers, COG and GeoTIFF raster rendering, PMTiles, Zarr, LiDAR, and Gaussian splats. See the [roadmap](roadmap.md) for planned work on SQL workflows, persisted recent projects, the Python processing sidecar, and external plugin loading.
+GeoLibre is an active prototype. Version 0.5.0 includes the map workspace, project format, plugin API, browser vector import, DuckDB-WASM Spatial loading, advanced Add Data workflows, MBTiles desktop support, ArcGIS layers, COG and GeoTIFF raster rendering, PMTiles, Zarr, LiDAR, Gaussian splats, and persisted recent projects. See the [roadmap](roadmap.md) for planned work on SQL workflows, the Python processing sidecar, and external plugin loading.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -30,7 +30,7 @@
 - [x] `INSTALL spatial` / `LOAD spatial`
 - [x] Shapefile, KMZ/KML, GeoPackage, GeoParquet, FlatGeobuf, GML, and related vector import paths
 
-## v0.5: Advanced Add Data and plugin-backed layers (current)
+## v0.5: Advanced Add Data and plugin-backed layers
 
 - [x] Add Data dialogs for XYZ, WMS, vector files, GeoJSON URLs, vector tiles, raster tile templates, COG and GeoTIFF rasters, MBTiles, and ArcGIS layers
 - [x] MapLibre Components plugin with FlatGeobuf, PMTiles, Zarr, LiDAR, and Gaussian splat panels
@@ -38,7 +38,16 @@
 - [x] Plugin control position controls in the Plugins menu
 - [x] Layer control integration for GeoLibre-managed layers
 
-## v0.6: SQL and processing sidecar
+## v0.6: Project access, web embeds, and expanded integrations (current)
+
+- [x] Persistent recent projects with desktop file recents and URL-backed web recents
+- [x] Separate Open Project from File and Open Project from URL flows
+- [x] Browser demo query options for compact layout, icon-only toolbar, and hidden panels
+- [x] PostgreSQL layer workflow through desktop Martin server integration
+- [x] STAC search workflow for adding catalog-backed raster layers
+- [x] Esri Wayback, GeoAgent, GeoEditor, Street View, and Swipe plugin integrations
+
+## v0.7: SQL and processing sidecar
 
 - [ ] Bundle FastAPI server as Tauri external bin
 - [ ] GDAL / Rasterio / GeoPandas pipelines
@@ -46,7 +55,7 @@
 - [ ] WhiteboxTools, Leafmap, GeoAI, SamGeo (selective)
 - [ ] SQL panel and query-result layers
 
-## v0.7: Plugin system
+## v0.8: External plugin system
 
 - [ ] External plugin packages
 - [ ] Plugin marketplace / registry (design)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -14,7 +14,7 @@
 - [x] In-session recent project tracking
 - [x] Feature highlight from attribute table
 - [x] Optional zoom to selected feature
-- [ ] Recent projects UI and persistence
+- [x] Recent projects UI and persistence
 
 ## v0.3: Cloud-native formats
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,3 @@
 export * from "./types";
 export * from "./project";
-export { useAppStore, type AppState } from "./store";
+export { projectPathLabel, useAppStore, type AppState } from "./store";

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -56,6 +56,10 @@ export interface AppState {
   loadProject: (project: GeoLibreProject, path?: string | null) => void;
   setProjectPath: (path: string | null) => void;
   setProjectName: (name: string) => void;
+  setRecentProjects: (projects: RecentProjectEntry[]) => void;
+  rememberRecentProject: (entry: RecentProjectEntry) => void;
+  forgetRecentProject: (path: string) => void;
+  clearRecentProjects: () => void;
   markSaved: () => void;
 
   addLayer: (layer: GeoLibreLayer, beforeLayerId?: string | null) => void;
@@ -72,6 +76,30 @@ export interface AppState {
     sourcePath?: string,
     beforeLayerId?: string | null,
   ) => string;
+}
+
+const MAX_RECENT_PROJECTS = 10;
+
+function normalizeRecentProjects(
+  projects: RecentProjectEntry[],
+): RecentProjectEntry[] {
+  const seen = new Set<string>();
+  const normalized: RecentProjectEntry[] = [];
+
+  for (const project of projects) {
+    const path = project.path.trim();
+    if (!path || seen.has(path)) continue;
+
+    const name = project.name.trim() || path.split(/[/\\]/).pop() || path;
+    normalized.push({
+      path,
+      name,
+      openedAt: project.openedAt || new Date().toISOString(),
+    });
+    seen.add(path);
+  }
+
+  return normalized.slice(0, MAX_RECENT_PROJECTS);
 }
 
 export const useAppStore = create<AppState>((set, get) => ({
@@ -144,22 +172,27 @@ export const useAppStore = create<AppState>((set, get) => ({
       identifyLayerId: null,
     });
     if (path) {
-      const entry: RecentProjectEntry = {
+      get().rememberRecentProject({
         path,
         name: project.name,
         openedAt: new Date().toISOString(),
-      };
-      set((s) => ({
-        recentProjects: [
-          entry,
-          ...s.recentProjects.filter((r) => r.path !== path),
-        ].slice(0, 10),
-      }));
+      });
     }
   },
 
   setProjectPath: (path) => set({ projectPath: path }),
   setProjectName: (name) => set({ projectName: name, isDirty: true }),
+  setRecentProjects: (projects) =>
+    set({ recentProjects: normalizeRecentProjects(projects) }),
+  rememberRecentProject: (entry) =>
+    set((s) => ({
+      recentProjects: normalizeRecentProjects([entry, ...s.recentProjects]),
+    })),
+  forgetRecentProject: (path) =>
+    set((s) => ({
+      recentProjects: s.recentProjects.filter((project) => project.path !== path),
+    })),
+  clearRecentProjects: () => set({ recentProjects: [] }),
   markSaved: () => set({ isDirty: false }),
 
   addLayer: (layer, beforeLayerId = null) =>

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -197,10 +197,16 @@ export const useAppStore = create<AppState>((set, get) => ({
     set((s) => ({
       recentProjects: normalizeRecentProjects([entry, ...s.recentProjects]),
     })),
-  forgetRecentProject: (path) =>
+  forgetRecentProject: (path) => {
+    // Compare with separators normalized so a backslash/forward-slash mismatch
+    // on Windows does not leave a stale entry behind.
+    const normalized = path.replace(/\\/g, "/");
     set((s) => ({
-      recentProjects: s.recentProjects.filter((project) => project.path !== path),
-    })),
+      recentProjects: s.recentProjects.filter(
+        (project) => project.path.replace(/\\/g, "/") !== normalized,
+      ),
+    }));
+  },
   clearRecentProjects: () => set({ recentProjects: [] }),
   markSaved: () => set({ isDirty: false }),
 

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -53,7 +53,11 @@ export interface AppState {
   setZoomToSelectedFeature: (enabled: boolean) => void;
 
   newProject: (options?: CreateProjectOptions & { name?: string }) => void;
-  loadProject: (project: GeoLibreProject, path?: string | null) => void;
+  loadProject: (
+    project: GeoLibreProject,
+    path?: string | null,
+    options?: { rememberRecent?: boolean },
+  ) => void;
   setProjectPath: (path: string | null) => void;
   setProjectName: (name: string) => void;
   setRecentProjects: (projects: RecentProjectEntry[]) => void;
@@ -161,7 +165,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     });
   },
 
-  loadProject: (project, path = null) => {
+  loadProject: (project, path = null, options = {}) => {
     const applied = applyProjectToStore(project);
     set({
       ...applied,
@@ -171,7 +175,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       selectedFeatureId: null,
       identifyLayerId: null,
     });
-    if (path) {
+    if (path && options.rememberRecent !== false) {
       get().rememberRecentProject({
         path,
         name: project.name,

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -84,6 +84,11 @@ export interface AppState {
 
 const MAX_RECENT_PROJECTS = 10;
 
+/** Derive a human-friendly display name from a file path or URL. */
+export function projectPathLabel(path: string): string {
+  return path.split(/[/\\]/).pop() || path;
+}
+
 function normalizeRecentProjects(
   projects: RecentProjectEntry[],
 ): RecentProjectEntry[] {
@@ -94,7 +99,7 @@ function normalizeRecentProjects(
     const path = project.path.trim();
     if (!path || seen.has(path)) continue;
 
-    const name = project.name.trim() || path.split(/[/\\]/).pop() || path;
+    const name = project.name.trim() || projectPathLabel(path);
     normalized.push({
       path,
       name,


### PR DESCRIPTION
## Summary
- Persist recent projects to localStorage so they survive reloads, restored on startup via a `useRecentProjectsPersistence` hook
- Add an Open dropdown listing recent projects with reopen support for both local files and http(s) project URLs
- Add store helpers (`setRecentProjects`, `rememberRecentProject`, `forgetRecentProject`, `clearRecentProjects`) with dedupe and a 10-entry cap

## Test plan
- [ ] Save a project, reload the app, and confirm it appears under Open > Recent projects
- [ ] Reopen a recent local project and a recent project URL
- [ ] Remove a recent entry and clear all recent projects
- [ ] `pre-commit run --all-files` passes (npm build included)