### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Lightweight, cloud-native desktop GIS prototype built with **Tauri v2**, **React
 
 [![](https://files.opengeos.org/GeoLibre-OPERA-demo.webp)](https://geolibre.app/demo/?url=https://data.geolibre.app/opera-dswx.geolibre.json)
 
-## Features (v0.5.0)
+## Features (v0.6.0)
 
 - MapLibre map workspace with OpenFreeMap basemaps, blank background support, and toggleable navigation, fullscreen, geolocation, globe, terrain, scale, attribution, and logo controls
 - Load local vector layers supported by DuckDB-WASM Spatial, including common formats such as GeoJSON, GeoParquet, GeoPackage, Shapefile, FlatGeobuf, KML/KMZ, and GML
@@ -165,7 +165,7 @@ Plugins can use the app API to change basemaps, add GeoJSON layers, or attach Ma
 
 Built-in MapLibre controls such as Navigation, Fullscreen, Geolocate, Globe, Terrain, Scale, Attribution, and Logo are toggled from the desktop app's Controls menu. The same menu also opens Search, a standalone place search panel backed by the Components plugin. Keep project-specific controls such as Layer Control and Components in the plugin menu when they use the plugin API or need plugin lifecycle behavior.
 
-The v0.5.0 Components plugin wraps `maplibre-gl-components` controls and wires their layer events into the GeoLibre store. It provides Add Data shortcuts for FlatGeobuf, PMTiles, Zarr, LiDAR, and Gaussian splats, while raster COG and GeoTIFF layers can also be added through the standard Add Raster Layer dialog.
+The v0.6.0 Components plugin wraps `maplibre-gl-components` controls and wires their layer events into the GeoLibre store. It provides Add Data shortcuts for FlatGeobuf, PMTiles, Zarr, LiDAR, and Gaussian splats, while raster COG and GeoTIFF layers can also be added through the standard Add Raster Layer dialog.
 
 If a third-party MapLibre control needs app-specific styling fixes, add scoped overrides in `apps/geolibre-desktop/src/index.css` instead of editing files in `node_modules`. Keep selectors limited to the plugin control class. For example, GeoEditor toolbar buttons need a local override because MapLibre's default control button CSS can override their flex centering:
 

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolibre-desktop",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/geolibre-desktop/src-tauri/Cargo.lock
+++ b/apps/geolibre-desktop/src-tauri/Cargo.lock
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-desktop"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "flate2",
  "reqwest 0.12.28",

--- a/apps/geolibre-desktop/src-tauri/Cargo.toml
+++ b/apps/geolibre-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-desktop"
-version = "0.5.0"
+version = "0.6.0"
 description = "GeoLibre Desktop — lightweight cloud-native desktop GIS"
 authors = ["GeoLibre Contributors"]
 edition = "2021"

--- a/apps/geolibre-desktop/src-tauri/tauri.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "GeoLibre Desktop",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "identifier": "org.geolibre.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/backend/geolibre_server/geolibre_server/app/main.py
+++ b/backend/geolibre_server/geolibre_server/app/main.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
-app = FastAPI(title="GeoLibre Server", version="0.1.0")
+app = FastAPI(title="GeoLibre Server", version="0.6.0")
 
 
 class RunRequest(BaseModel):

--- a/backend/geolibre_server/pyproject.toml
+++ b/backend/geolibre_server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolibre-server"
-version = "0.5.0"
+version = "0.6.0"
 description = "Optional Python processing sidecar for GeoLibre Desktop"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,7 +51,7 @@ GeoParquet is read with DuckDB's Parquet reader after loading Spatial. Other loc
 
 ## Advanced Add Data workflows
 
-The v0.5.0 Add Data surface includes native dialogs for XYZ, WMS, vector files, GeoJSON URLs, vector tile sources, raster tile templates, COG and GeoTIFF rasters, MBTiles, and ArcGIS FeatureServer or VectorTileServer layers. The Components plugin wraps `maplibre-gl-components` panels for FlatGeobuf, PMTiles, Zarr, LiDAR, and Gaussian splats, then mirrors added layers into the GeoLibre store so the Layer panel, project format, and layer control can reason about them.
+The v0.6.0 Add Data surface includes native dialogs for XYZ, WMS, vector files, GeoJSON URLs, vector tile sources, raster tile templates, COG and GeoTIFF rasters, MBTiles, and ArcGIS FeatureServer or VectorTileServer layers. The Components plugin wraps `maplibre-gl-components` panels for FlatGeobuf, PMTiles, Zarr, LiDAR, and Gaussian splats, then mirrors added layers into the GeoLibre store so the Layer panel, project format, and layer control can reason about them.
 
 Local MBTiles tiles are read through a custom MapLibre protocol backed by Tauri commands. Remote rasters are fetched through the desktop backend when needed, and the local development server includes a raster proxy for selected release assets that need CORS handling.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,4 +97,4 @@ Use `toolbar=icons` when you only want icon-only toolbar buttons. `panels=hidden
 
 ## Project status
 
-GeoLibre is an active prototype. Version 0.5.0 includes the map workspace, project format, plugin API, browser vector import, DuckDB-WASM Spatial loading, advanced Add Data workflows, MBTiles desktop support, ArcGIS layers, COG and GeoTIFF raster rendering, PMTiles, Zarr, LiDAR, Gaussian splats, and persisted recent projects. See the [roadmap](roadmap.md) for planned work on SQL workflows, the Python processing sidecar, and external plugin loading.
+GeoLibre is an active prototype. Version 0.6.0 includes the map workspace, project format, plugin API, browser vector import, DuckDB-WASM Spatial loading, advanced Add Data workflows, MBTiles desktop support, ArcGIS layers, COG and GeoTIFF raster rendering, PMTiles, Zarr, LiDAR, Gaussian splats, and persisted recent projects. See the [roadmap](roadmap.md) for planned work on SQL workflows, the Python processing sidecar, and external plugin loading.

--- a/docs/project-format.md
+++ b/docs/project-format.md
@@ -48,7 +48,7 @@ Projects are saved as **`.geolibre.json`** files.
 
 ## Layer types
 
-| Type | v0.5.0 status |
+| Type | v0.6.0 status |
 |------|---------------|
 | `geojson` | Supported for imported files and GeoJSON URLs |
 | `xyz` | Supported for raster tile templates |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,22 @@
 {
   "name": "geolibre",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolibre",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "workspaces": [
         "apps/*",
         "packages/*"
       ],
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "apps/geolibre-desktop": {
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@carbonplan/zarr-layer": "^0.3.1",
         "@deck.gl/core": "^9.3.2",
@@ -12545,7 +12545,7 @@
     },
     "packages/core": {
       "name": "@geolibre/core",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "uuid": "^11.1.0",
         "zustand": "^5.0.3"
@@ -12557,7 +12557,7 @@
     },
     "packages/map": {
       "name": "@geolibre/map",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@geolibre/core": "*",
         "@turf/bbox": "^7.2.0",
@@ -12581,7 +12581,7 @@
     },
     "packages/plugins": {
       "name": "@geolibre/plugins",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@carbonplan/zarr-layer": "^0.3.1",
         "@deck.gl/core": "^9.3.2",
@@ -12705,7 +12705,7 @@
     },
     "packages/processing": {
       "name": "@geolibre/processing",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@geolibre/core": "*",
         "@turf/bbox": "^7.2.0"
@@ -12717,7 +12717,7 @@
     },
     "packages/ui": {
       "name": "@geolibre/ui",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-dropdown-menu": "^2.1.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geolibre",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "GeoLibre Desktop — lightweight cloud-native desktop GIS",
   "workspaces": [
     "apps/*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/core",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/map",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/plugins",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/processing/package.json
+++ b/packages/processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/processing",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/ui",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",


### PR DESCRIPTION
## Summary
- Bump version from 0.5.0 to 0.6.0 across the npm workspaces, the Tauri desktop crate, and the Python processing sidecar
- Update docs (README, architecture, index, project-format) to reference 0.6.0

## Test plan
- [x] `pre-commit run --all-files` passes (includes npm build)