### PR TITLE
feat: add inline attribute editing and scrollable identify popup

### DIFF
--- a/apps/geolibre-desktop/src-tauri/capabilities/default.json
+++ b/apps/geolibre-desktop/src-tauri/capabilities/default.json
@@ -9,6 +9,7 @@
     "fs:default",
     "fs:allow-read-file",
     "fs:allow-read-text-file",
+    "fs:allow-write-file",
     "fs:allow-write-text-file",
     {
       "identifier": "opener:allow-open-url",

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -85,6 +85,9 @@ function formatAttributeValue(value: unknown): string {
 function parseAttributeDraft(draft: string, previousValue: unknown): unknown {
   if (draft.trim() === "") return null;
 
+  // A null/undefined cell carries no original type to infer from, so the raw
+  // string is kept as-is: editing a previously-empty cell does not coerce to
+  // number/boolean/object.
   if (previousValue == null) return draft;
 
   if (typeof previousValue === "number") {
@@ -127,6 +130,28 @@ function hasDraftEdits(drafts: AttributeDrafts): boolean {
   );
 }
 
+function applyDraftsToFeatures(
+  features: Feature[],
+  drafts: AttributeDrafts,
+): Feature[] {
+  return features.map((feature, index) => {
+    const featureId = String(feature.id ?? index);
+    const rowDrafts = drafts[featureId];
+    if (!rowDrafts) return feature;
+
+    const properties = { ...(feature.properties ?? {}) };
+    for (const [column, draft] of Object.entries(rowDrafts)) {
+      const previousValue = feature.properties?.[column];
+      // Skip drafts that are invalid JSON for an object-typed cell so we never
+      // persist or export a type-corrupted value; the existing value is kept.
+      if (isInvalidObjectDraft(draft, previousValue)) continue;
+      properties[column] = parseAttributeDraft(draft, previousValue);
+    }
+
+    return { ...feature, properties };
+  });
+}
+
 function sanitizeExportFileName(name: string): string {
   const sanitized = name
     .trim()
@@ -142,16 +167,25 @@ function csvCell(value: unknown): string {
   return /[",\r\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
 }
 
-function exportFormatLabel(_format: BinaryVectorExportFormat): string {
-  return "GeoParquet";
+function exportFormatLabel(format: BinaryVectorExportFormat): string {
+  switch (format) {
+    case "geoparquet":
+      return "GeoParquet";
+  }
 }
 
-function exportFileExtension(_format: BinaryVectorExportFormat): string {
-  return "parquet";
+function exportFileExtension(format: BinaryVectorExportFormat): string {
+  switch (format) {
+    case "geoparquet":
+      return "parquet";
+  }
 }
 
-function exportMimeType(_format: BinaryVectorExportFormat): string {
-  return "application/vnd.apache.parquet";
+function exportMimeType(format: BinaryVectorExportFormat): string {
+  switch (format) {
+    case "geoparquet":
+      return "application/vnd.apache.parquet";
+  }
 }
 
 export function AttributeTable() {
@@ -397,7 +431,9 @@ export function AttributeTable() {
       return;
     }
 
-    setIsEditing(true);
+    if (!isEditing) {
+      setIsEditing(true);
+    }
   };
 
   const saveDrafts = () => {
@@ -405,24 +441,7 @@ export function AttributeTable() {
 
     const geojson = {
       ...layer.geojson,
-      features: layer.geojson.features.map((feature, index) => {
-        const featureId = String(feature.id ?? index);
-        const rowDrafts = drafts[featureId];
-        if (!rowDrafts) return feature;
-
-        const properties = { ...(feature.properties ?? {}) };
-        for (const [column, draft] of Object.entries(rowDrafts)) {
-          properties[column] = parseAttributeDraft(
-            draft,
-            feature.properties?.[column],
-          );
-        }
-
-        return {
-          ...feature,
-          properties,
-        };
-      }),
+      features: applyDraftsToFeatures(layer.geojson.features, drafts),
     };
 
     updateLayer(layer.id, { geojson });
@@ -435,24 +454,7 @@ export function AttributeTable() {
 
     return {
       ...layer.geojson,
-      features: layer.geojson.features.map((feature, index) => {
-        const featureId = String(feature.id ?? index);
-        const rowDrafts = drafts[featureId];
-        if (!rowDrafts) return feature;
-
-        const properties = { ...(feature.properties ?? {}) };
-        for (const [column, draft] of Object.entries(rowDrafts)) {
-          properties[column] = parseAttributeDraft(
-            draft,
-            feature.properties?.[column],
-          );
-        }
-
-        return {
-          ...feature,
-          properties,
-        };
-      }),
+      features: applyDraftsToFeatures(layer.geojson.features, drafts),
     };
   };
 
@@ -649,12 +651,16 @@ export function AttributeTable() {
           size="sm"
           className="ml-auto h-7 px-2"
           title={
-            isEditing && !hasEdits ? "Exit edit mode" : "Edit attribute values"
+            isEditing
+              ? hasEdits
+                ? "Use Save or Cancel to finish editing"
+                : "Exit edit mode"
+              : "Edit attribute values"
           }
           aria-label={
             isEditing && !hasEdits ? "Exit edit mode" : "Edit attribute values"
           }
-          disabled={!layer?.geojson}
+          disabled={!layer?.geojson || (isEditing && hasEdits)}
           onClick={toggleEditing}
         >
           <Pencil className="h-3.5 w-3.5" />
@@ -698,7 +704,7 @@ export function AttributeTable() {
               GeoParquet
             </DropdownMenuItem>
             <DropdownMenuItem onSelect={() => void exportLayer("csv")}>
-              CSV
+              CSV (attributes only)
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -1,6 +1,10 @@
 import { useAppStore } from "@geolibre/core";
 import {
   Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   Input,
   ScrollArea,
   TableBody,
@@ -13,6 +17,7 @@ import type { Feature } from "geojson";
 import {
   ArrowDown,
   ArrowUp,
+  Download,
   Pencil,
   PanelBottomClose,
   PanelBottomOpen,
@@ -27,12 +32,18 @@ import {
   useRef,
   useState,
 } from "react";
-import { isTauri } from "../../lib/tauri-io";
+import {
+  isTauri,
+  saveBinaryFileWithFallback,
+  saveTextFileWithFallback,
+} from "../../lib/tauri-io";
+import type { BinaryVectorExportFormat } from "../../lib/vector-exporter";
 
 type SortDirection = "asc" | "desc";
 type SortKey = "__featureId" | string;
 type ColumnWidths = Record<string, number>;
 type AttributeDrafts = Record<string, Record<string, string>>;
+type ExportFormat = "geojson" | "csv" | BinaryVectorExportFormat;
 
 const DEFAULT_FEATURE_ID_COLUMN_WIDTH = 72;
 const DEFAULT_ATTRIBUTE_COLUMN_WIDTH = 160;
@@ -72,13 +83,13 @@ function formatAttributeValue(value: unknown): string {
 }
 
 function parseAttributeDraft(draft: string, previousValue: unknown): unknown {
-  if (previousValue == null) return draft === "" ? null : draft;
+  if (draft.trim() === "") return null;
+
+  if (previousValue == null) return draft;
 
   if (typeof previousValue === "number") {
     const nextValue = Number(draft);
-    return draft.trim() === "" || !Number.isFinite(nextValue)
-      ? draft
-      : nextValue;
+    return Number.isFinite(nextValue) ? nextValue : draft;
   }
 
   if (typeof previousValue === "boolean") {
@@ -99,8 +110,48 @@ function parseAttributeDraft(draft: string, previousValue: unknown): unknown {
   return draft;
 }
 
+function isInvalidObjectDraft(draft: string, previousValue: unknown): boolean {
+  if (typeof previousValue !== "object" || previousValue == null) return false;
+  if (draft.trim() === "") return false;
+  try {
+    JSON.parse(draft);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
 function hasDraftEdits(drafts: AttributeDrafts): boolean {
-  return Object.values(drafts).some((columns) => Object.keys(columns).length > 0);
+  return Object.values(drafts).some(
+    (columns) => Object.keys(columns).length > 0,
+  );
+}
+
+function sanitizeExportFileName(name: string): string {
+  const sanitized = name
+    .trim()
+    .replace(/[<>:"/\\|?*\u0000-\u001f]/g, "-")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+  return sanitized || "layer";
+}
+
+function csvCell(value: unknown): string {
+  const text = formatAttributeValue(value);
+  return /[",\r\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+}
+
+function exportFormatLabel(_format: BinaryVectorExportFormat): string {
+  return "GeoParquet";
+}
+
+function exportFileExtension(_format: BinaryVectorExportFormat): string {
+  return "parquet";
+}
+
+function exportMimeType(_format: BinaryVectorExportFormat): string {
+  return "application/vnd.apache.parquet";
 }
 
 export function AttributeTable() {
@@ -132,16 +183,25 @@ export function AttributeTable() {
   const [tableHeight, setTableHeight] = useState(DEFAULT_TABLE_HEIGHT);
   const [isEditing, setIsEditing] = useState(false);
   const [drafts, setDrafts] = useState<AttributeDrafts>({});
+  const [exportError, setExportError] = useState<string | null>(null);
   const deferTableResize = isTauri();
 
   const layer = layers.find((l) => l.id === selectedLayerId);
+  const hasLayer = Boolean(layer);
   const features = layer?.geojson?.features ?? [];
   const hasEdits = hasDraftEdits(drafts);
+  const hasInvalidDrafts = features.some((feature, index) => {
+    const rowDrafts = drafts[String(feature.id ?? index)];
+    if (!rowDrafts) return false;
+    return Object.entries(rowDrafts).some(([column, draft]) =>
+      isInvalidObjectDraft(draft, feature.properties?.[column]),
+    );
+  });
 
   useEffect(() => {
     setIsEditing(false);
     setDrafts({});
-  }, [selectedLayerId]);
+  }, [selectedLayerId, hasLayer]);
 
   const filterLower = attributeFilter.toLowerCase();
   const indexedFeatures = features.map((feature, index) => ({
@@ -331,8 +391,17 @@ export function AttributeTable() {
     setDrafts({});
   };
 
+  const toggleEditing = () => {
+    if (isEditing && !hasEdits) {
+      setIsEditing(false);
+      return;
+    }
+
+    setIsEditing(true);
+  };
+
   const saveDrafts = () => {
-    if (!layer?.geojson || !hasEdits) return;
+    if (!layer?.geojson || !hasEdits || hasInvalidDrafts) return;
 
     const geojson = {
       ...layer.geojson,
@@ -359,6 +428,137 @@ export function AttributeTable() {
     updateLayer(layer.id, { geojson });
     setIsEditing(false);
     setDrafts({});
+  };
+
+  const geojsonWithDrafts = () => {
+    if (!layer?.geojson) return null;
+
+    return {
+      ...layer.geojson,
+      features: layer.geojson.features.map((feature, index) => {
+        const featureId = String(feature.id ?? index);
+        const rowDrafts = drafts[featureId];
+        if (!rowDrafts) return feature;
+
+        const properties = { ...(feature.properties ?? {}) };
+        for (const [column, draft] of Object.entries(rowDrafts)) {
+          properties[column] = parseAttributeDraft(
+            draft,
+            feature.properties?.[column],
+          );
+        }
+
+        return {
+          ...feature,
+          properties,
+        };
+      }),
+    };
+  };
+
+  const geojsonToCsv = (
+    geojson: NonNullable<ReturnType<typeof geojsonWithDrafts>>,
+  ) => {
+    const propertyKeys = new Set<string>();
+    for (const feature of geojson.features) {
+      for (const key of Object.keys(feature.properties ?? {})) {
+        propertyKeys.add(key);
+      }
+    }
+
+    const headers = ["feature_id", ...propertyKeys];
+    const rows = geojson.features.map((feature, index) => {
+      const featureId = String(feature.id ?? index);
+      const properties = feature.properties ?? {};
+      const values = [
+        featureId,
+        ...Array.from(propertyKeys).map((key) => properties[key]),
+      ];
+      return values
+        .map(csvCell)
+        .join(",");
+    });
+
+    return [headers.map(csvCell).join(","), ...rows].join("\n");
+  };
+
+  const exportTextLayer = async (
+    format: Extract<ExportFormat, "geojson" | "csv">,
+    exportGeojson: NonNullable<ReturnType<typeof geojsonWithDrafts>>,
+    baseName: string,
+  ) => {
+    const isCsv = format === "csv";
+    const content = isCsv
+      ? geojsonToCsv(exportGeojson)
+      : JSON.stringify(exportGeojson, null, 2);
+    await saveTextFileWithFallback(content, {
+      defaultName: `${baseName}.${isCsv ? "csv" : "geojson"}`,
+      filters: [
+        isCsv
+          ? { name: "CSV", extensions: ["csv"] }
+          : { name: "GeoJSON", extensions: ["geojson", "json"] },
+      ],
+      browserTypes: [
+        {
+          description: isCsv ? "CSV" : "GeoJSON",
+          accept: isCsv
+            ? { "text/csv": [".csv"] }
+            : { "application/geo+json": [".geojson", ".json"] },
+        },
+      ],
+      mimeType: isCsv ? "text/csv" : "application/geo+json",
+    });
+  };
+
+  const exportBinaryLayer = async (
+    format: BinaryVectorExportFormat,
+    exportGeojson: NonNullable<ReturnType<typeof geojsonWithDrafts>>,
+    baseName: string,
+  ) => {
+    const { exportBinaryVectorLayer } = await import("../../lib/vector-exporter");
+    const result = await exportBinaryVectorLayer(
+      exportGeojson,
+      format,
+      baseName,
+    );
+    const label = exportFormatLabel(format);
+    const extension = exportFileExtension(format);
+    await saveBinaryFileWithFallback(result.data, {
+      defaultName: `${baseName}.${extension}`,
+      filters: [{ name: label, extensions: [extension] }],
+      browserTypes: [
+        {
+          description: label,
+          accept: { [exportMimeType(format)]: [`.${extension}`] },
+        },
+      ],
+      mimeType: result.mimeType,
+    });
+  };
+
+  const exportLayer = async (format: ExportFormat) => {
+    if (!layer?.geojson) return;
+
+    try {
+      setExportError(null);
+      const exportGeojson = geojsonWithDrafts();
+      if (!exportGeojson) return;
+
+      const baseName = sanitizeExportFileName(layer.name);
+      if (format === "geojson" || format === "csv") {
+        await exportTextLayer(format, exportGeojson, baseName);
+        return;
+      }
+
+      await exportBinaryLayer(format, exportGeojson, baseName);
+    } catch (error) {
+      console.error("Failed to export attribute table", error);
+      setExportError(
+        error instanceof Error
+          ? error.message
+          : "Could not export the selected layer.",
+      );
+    }
   };
 
   const sortableHeader = (key: SortKey, label: string) => (
@@ -439,14 +639,23 @@ export function AttributeTable() {
             — select a vector layer
           </span>
         )}
+        {exportError ? (
+          <span className="max-w-48 truncate text-xs text-destructive">
+            {exportError}
+          </span>
+        ) : null}
         <Button
           variant={isEditing ? "secondary" : "outline"}
           size="sm"
           className="ml-auto h-7 px-2"
-          title="Edit attribute values"
-          aria-label="Edit attribute values"
+          title={
+            isEditing && !hasEdits ? "Exit edit mode" : "Edit attribute values"
+          }
+          aria-label={
+            isEditing && !hasEdits ? "Exit edit mode" : "Edit attribute values"
+          }
           disabled={!layer?.geojson}
-          onClick={() => setIsEditing(true)}
+          onClick={toggleEditing}
         >
           <Pencil className="h-3.5 w-3.5" />
           Edit
@@ -455,14 +664,44 @@ export function AttributeTable() {
           variant="default"
           size="sm"
           className="h-7 px-2"
-          title="Save attribute edits"
+          title={
+            hasInvalidDrafts
+              ? "Fix invalid JSON before saving"
+              : "Save attribute edits"
+          }
           aria-label="Save attribute edits"
-          disabled={!isEditing || !hasEdits}
+          disabled={!isEditing || !hasEdits || hasInvalidDrafts}
           onClick={saveDrafts}
         >
           <Save className="h-3.5 w-3.5" />
           Save
         </Button>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-7 px-2"
+              title="Export selected layer"
+              aria-label="Export selected layer"
+              disabled={!layer?.geojson}
+            >
+              <Download className="h-3.5 w-3.5" />
+              Export
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onSelect={() => void exportLayer("geojson")}>
+              GeoJSON
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => void exportLayer("geoparquet")}>
+              GeoParquet
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => void exportLayer("csv")}>
+              CSV
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
         {isEditing ? (
           <Button
             variant="ghost"
@@ -551,6 +790,14 @@ export function AttributeTable() {
                       const value = feature.properties?.[col];
                       const draft = drafts[featureId]?.[col];
                       const changed = draft !== undefined;
+                      const invalid =
+                        draft !== undefined &&
+                        isInvalidObjectDraft(draft, value);
+                      const inputClassName = invalid
+                        ? "h-7 min-w-0 border-destructive bg-destructive/10 px-2 text-xs"
+                        : changed
+                          ? "h-7 min-w-0 border-primary/60 bg-primary/10 px-2 text-xs"
+                          : "h-7 min-w-0 px-2 text-xs";
                       return (
                         <TableCell
                           key={col}
@@ -559,10 +806,10 @@ export function AttributeTable() {
                         >
                           {isEditing ? (
                             <Input
-                              className={
-                                changed
-                                  ? "h-7 min-w-0 border-primary/60 bg-primary/10 px-2 text-xs"
-                                  : "h-7 min-w-0 px-2 text-xs"
+                              className={inputClassName}
+                              aria-invalid={invalid || undefined}
+                              title={
+                                invalid ? "Invalid JSON" : undefined
                               }
                               aria-label={`Edit ${col} for feature ${featureId}`}
                               value={draft ?? formatAttributeValue(value)}

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -13,13 +13,17 @@ import type { Feature } from "geojson";
 import {
   ArrowDown,
   ArrowUp,
+  Pencil,
   PanelBottomClose,
   PanelBottomOpen,
+  RotateCcw,
+  Save,
   TableProperties,
   X,
 } from "lucide-react";
 import {
   type MouseEvent as ReactMouseEvent,
+  useEffect,
   useRef,
   useState,
 } from "react";
@@ -28,6 +32,7 @@ import { isTauri } from "../../lib/tauri-io";
 type SortDirection = "asc" | "desc";
 type SortKey = "__featureId" | string;
 type ColumnWidths = Record<string, number>;
+type AttributeDrafts = Record<string, Record<string, string>>;
 
 const DEFAULT_FEATURE_ID_COLUMN_WIDTH = 72;
 const DEFAULT_ATTRIBUTE_COLUMN_WIDTH = 160;
@@ -60,6 +65,44 @@ function compareAttributeValues(a: unknown, b: unknown): number {
   });
 }
 
+function formatAttributeValue(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+function parseAttributeDraft(draft: string, previousValue: unknown): unknown {
+  if (previousValue == null) return draft === "" ? null : draft;
+
+  if (typeof previousValue === "number") {
+    const nextValue = Number(draft);
+    return draft.trim() === "" || !Number.isFinite(nextValue)
+      ? draft
+      : nextValue;
+  }
+
+  if (typeof previousValue === "boolean") {
+    const normalized = draft.trim().toLowerCase();
+    if (normalized === "true") return true;
+    if (normalized === "false") return false;
+    return draft;
+  }
+
+  if (typeof previousValue === "object") {
+    try {
+      return JSON.parse(draft);
+    } catch {
+      return draft;
+    }
+  }
+
+  return draft;
+}
+
+function hasDraftEdits(drafts: AttributeDrafts): boolean {
+  return Object.values(drafts).some((columns) => Object.keys(columns).length > 0);
+}
+
 export function AttributeTable() {
   const tableSectionRef = useRef<HTMLElement>(null);
   const tableResizeGuideRef = useRef<HTMLDivElement>(null);
@@ -71,6 +114,7 @@ export function AttributeTable() {
   const selectFeature = useAppStore((s) => s.selectFeature);
   const attributeTableOpen = useAppStore((s) => s.ui.attributeTableOpen);
   const setAttributeTableOpen = useAppStore((s) => s.setAttributeTableOpen);
+  const updateLayer = useAppStore((s) => s.updateLayer);
   const zoomToSelectedFeature = useAppStore(
     (s) => s.ui.zoomToSelectedFeature,
   );
@@ -86,10 +130,18 @@ export function AttributeTable() {
   });
   const [columnWidths, setColumnWidths] = useState<ColumnWidths>({});
   const [tableHeight, setTableHeight] = useState(DEFAULT_TABLE_HEIGHT);
+  const [isEditing, setIsEditing] = useState(false);
+  const [drafts, setDrafts] = useState<AttributeDrafts>({});
   const deferTableResize = isTauri();
 
   const layer = layers.find((l) => l.id === selectedLayerId);
   const features = layer?.geojson?.features ?? [];
+  const hasEdits = hasDraftEdits(drafts);
+
+  useEffect(() => {
+    setIsEditing(false);
+    setDrafts({});
+  }, [selectedLayerId]);
 
   const filterLower = attributeFilter.toLowerCase();
   const indexedFeatures = features.map((feature, index) => ({
@@ -248,6 +300,67 @@ export function AttributeTable() {
     );
   };
 
+  const updateCellDraft = (
+    featureId: string,
+    column: string,
+    value: string,
+    previousValue: unknown,
+  ) => {
+    setDrafts((current) => {
+      const next = { ...current };
+      const row = { ...(next[featureId] ?? {}) };
+
+      if (value === formatAttributeValue(previousValue)) {
+        delete row[column];
+      } else {
+        row[column] = value;
+      }
+
+      if (Object.keys(row).length === 0) {
+        delete next[featureId];
+      } else {
+        next[featureId] = row;
+      }
+
+      return next;
+    });
+  };
+
+  const cancelEditing = () => {
+    setIsEditing(false);
+    setDrafts({});
+  };
+
+  const saveDrafts = () => {
+    if (!layer?.geojson || !hasEdits) return;
+
+    const geojson = {
+      ...layer.geojson,
+      features: layer.geojson.features.map((feature, index) => {
+        const featureId = String(feature.id ?? index);
+        const rowDrafts = drafts[featureId];
+        if (!rowDrafts) return feature;
+
+        const properties = { ...(feature.properties ?? {}) };
+        for (const [column, draft] of Object.entries(rowDrafts)) {
+          properties[column] = parseAttributeDraft(
+            draft,
+            feature.properties?.[column],
+          );
+        }
+
+        return {
+          ...feature,
+          properties,
+        };
+      }),
+    };
+
+    updateLayer(layer.id, { geojson });
+    setIsEditing(false);
+    setDrafts({});
+  };
+
   const sortableHeader = (key: SortKey, label: string) => (
     <div className="relative flex h-full min-h-10 items-center">
       <button
@@ -326,8 +439,44 @@ export function AttributeTable() {
             — select a vector layer
           </span>
         )}
+        <Button
+          variant={isEditing ? "secondary" : "outline"}
+          size="sm"
+          className="ml-auto h-7 px-2"
+          title="Edit attribute values"
+          aria-label="Edit attribute values"
+          disabled={!layer?.geojson}
+          onClick={() => setIsEditing(true)}
+        >
+          <Pencil className="h-3.5 w-3.5" />
+          Edit
+        </Button>
+        <Button
+          variant="default"
+          size="sm"
+          className="h-7 px-2"
+          title="Save attribute edits"
+          aria-label="Save attribute edits"
+          disabled={!isEditing || !hasEdits}
+          onClick={saveDrafts}
+        >
+          <Save className="h-3.5 w-3.5" />
+          Save
+        </Button>
+        {isEditing ? (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            title="Cancel attribute edits"
+            aria-label="Cancel attribute edits"
+            onClick={cancelEditing}
+          >
+            <RotateCcw className="h-4 w-4" />
+          </Button>
+        ) : null}
         <Input
-          className="ml-auto h-7 max-w-xs text-xs"
+          className="h-7 max-w-xs text-xs"
           placeholder="Search attributes…"
           aria-label="Search attributes"
           value={attributeFilter}
@@ -398,11 +547,41 @@ export function AttributeTable() {
                     }}
                   >
                     <TableCell>{featureId}</TableCell>
-                    {columns.map((col) => (
-                      <TableCell key={col}>
-                        {String(feature.properties?.[col] ?? "")}
-                      </TableCell>
-                    ))}
+                    {columns.map((col) => {
+                      const value = feature.properties?.[col];
+                      const draft = drafts[featureId]?.[col];
+                      const changed = draft !== undefined;
+                      return (
+                        <TableCell
+                          key={col}
+                          data-state={changed ? "edited" : undefined}
+                          className="data-[state=edited]:bg-primary/10 data-[state=edited]:shadow-[inset_3px_0_0_hsl(var(--primary))]"
+                        >
+                          {isEditing ? (
+                            <Input
+                              className={
+                                changed
+                                  ? "h-7 min-w-0 border-primary/60 bg-primary/10 px-2 text-xs"
+                                  : "h-7 min-w-0 px-2 text-xs"
+                              }
+                              aria-label={`Edit ${col} for feature ${featureId}`}
+                              value={draft ?? formatAttributeValue(value)}
+                              onClick={(event) => event.stopPropagation()}
+                              onChange={(event) =>
+                                updateCellDraft(
+                                  featureId,
+                                  col,
+                                  event.target.value,
+                                  value,
+                                )
+                              }
+                            />
+                          ) : (
+                            formatAttributeValue(value)
+                          )}
+                        </TableCell>
+                      );
+                    })}
                   </TableRow>
                 );
               })}

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1281,6 +1281,20 @@ body,
     0 10px 15px -3px rgb(0 0 0 / 0.18),
     0 4px 6px -4px rgb(0 0 0 / 0.18);
   color: hsl(var(--popover-foreground));
+  max-height: min(420px, calc(100vh - 96px));
+  overflow: hidden;
+}
+
+.geolibre-identify-popup-root {
+  display: flex;
+  flex-direction: column;
+  max-height: min(380px, calc(100vh - 128px));
+}
+
+.geolibre-identify-popup-rows {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .geolibre-identify-popup .maplibregl-popup-close-button {

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1281,7 +1281,9 @@ body,
     0 10px 15px -3px rgb(0 0 0 / 0.18),
     0 4px 6px -4px rgb(0 0 0 / 0.18);
   color: hsl(var(--popover-foreground));
-  max-height: min(420px, calc(100vh - 96px));
+  /* Keep in sync with the popup root max-height in MapCanvas.tsx
+     (createIdentifyPopupElement). */
+  max-height: min(380px, calc(100vh - 128px));
   overflow: hidden;
 }
 

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1285,18 +1285,6 @@ body,
   overflow: hidden;
 }
 
-.geolibre-identify-popup-root {
-  display: flex;
-  flex-direction: column;
-  max-height: min(380px, calc(100vh - 128px));
-}
-
-.geolibre-identify-popup-rows {
-  flex: 1 1 auto;
-  min-height: 0;
-  overflow-y: auto;
-}
-
 .geolibre-identify-popup .maplibregl-popup-close-button {
   color: hsl(var(--muted-foreground));
 }

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -39,6 +39,22 @@ function getDatabase(): Promise<duckdb.AsyncDuckDB> {
   return dbPromise;
 }
 
+let spatialExtensionLoaded = false;
+
+/**
+ * Install and load the DuckDB spatial extension once per database instance.
+ * `getDatabase` returns a memoized singleton, so the extension persists across
+ * connections and the redundant INSTALL/LOAD queries are skipped on reuse.
+ */
+async function ensureSpatialExtension(
+  connection: duckdb.AsyncDuckDBConnection,
+): Promise<void> {
+  if (spatialExtensionLoaded) return;
+  await connection.query("INSTALL spatial");
+  await connection.query("LOAD spatial");
+  spatialExtensionLoaded = true;
+}
+
 async function createDatabase(): Promise<duckdb.AsyncDuckDB> {
   const bundle = await duckdb.selectBundle(MANUAL_BUNDLES);
   const worker = new Worker(bundle.mainWorker!, { type: "module" });
@@ -135,8 +151,7 @@ export async function loadDuckDbVectorFile(
     for (const sibling of file.siblingFiles ?? []) {
       await db.registerFileBuffer(sibling.name, sibling.data);
     }
-    await connection.query("INSTALL spatial");
-    await connection.query("LOAD spatial");
+    await ensureSpatialExtension(connection);
 
     const sql = sourceSql(file.name, file.extension);
     const description = rowsFromResult(
@@ -195,8 +210,7 @@ export async function exportDuckDbGeoParquet(
 
   try {
     await registerGeoJsonExportSource(db, geojson, sourceFile);
-    await connection.query("INSTALL spatial");
-    await connection.query("LOAD spatial");
+    await ensureSpatialExtension(connection);
     await connection.query(
       `COPY (SELECT * FROM ST_Read(${quoteSqlString(
         sourceFile,

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -6,6 +6,8 @@ import mvpWorker from "@duckdb/duckdb-wasm/dist/duckdb-browser-mvp.worker.js?url
 import type { Feature, FeatureCollection, Geometry } from "geojson";
 
 const GEOMETRY_JSON_COLUMN = "__geolibre_geometry_geojson";
+const EXPORT_GEOJSON_EXTENSION = "geojson";
+const EXPORT_GEOPARQUET_EXTENSION = "parquet";
 
 const MANUAL_BUNDLES: duckdb.DuckDBBundles = {
   mvp: {
@@ -52,6 +54,11 @@ function quoteSqlString(value: string): string {
 
 function quoteIdentifier(value: string): string {
   return `"${value.replaceAll('"', '""')}"`;
+}
+
+function exportBaseName(): string {
+  const suffix = Math.random().toString(36).slice(2);
+  return `__geolibre_export_${Date.now()}_${suffix}`;
 }
 
 function rowsFromResult(result: { toArray: () => DuckDbRow[] }) {
@@ -155,5 +162,50 @@ export async function loadDuckDbVectorFile(
     return toFeatureCollection(rowsFromResult(result)) as FeatureCollection;
   } finally {
     await connection.close();
+  }
+}
+
+async function dropFilesIfPresent(
+  db: duckdb.AsyncDuckDB,
+  fileNames: string[],
+): Promise<void> {
+  try {
+    await db.dropFiles(fileNames);
+  } catch {
+    // Some files are optional or may not have been created yet.
+  }
+}
+
+async function registerGeoJsonExportSource(
+  db: duckdb.AsyncDuckDB,
+  geojson: FeatureCollection,
+  sourceFile: string,
+): Promise<void> {
+  await db.registerFileText(sourceFile, JSON.stringify(geojson));
+}
+
+export async function exportDuckDbGeoParquet(
+  geojson: FeatureCollection,
+): Promise<Uint8Array> {
+  const db = await getDatabase();
+  const connection = await db.connect();
+  const baseName = exportBaseName();
+  const sourceFile = `${baseName}.${EXPORT_GEOJSON_EXTENSION}`;
+  const outputFile = `${baseName}.${EXPORT_GEOPARQUET_EXTENSION}`;
+
+  try {
+    await registerGeoJsonExportSource(db, geojson, sourceFile);
+    await connection.query("INSTALL spatial");
+    await connection.query("LOAD spatial");
+    await connection.query(
+      `COPY (SELECT * FROM ST_Read(${quoteSqlString(
+        sourceFile,
+      )})) TO ${quoteSqlString(outputFile)} (FORMAT PARQUET)`,
+    );
+    await db.flushFiles();
+    return await db.copyFileToBuffer(outputFile);
+  } finally {
+    await connection.close();
+    await dropFilesIfPresent(db, [sourceFile, outputFile]);
   }
 }

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -1,6 +1,11 @@
 import { parseProject, type GeoLibreProject } from "@geolibre/core";
 import { open, save } from "@tauri-apps/plugin-dialog";
-import { readFile, readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
+import {
+  readFile,
+  readTextFile,
+  writeFile,
+  writeTextFile,
+} from "@tauri-apps/plugin-fs";
 import { unzip } from "fflate";
 import type { FeatureCollection } from "geojson";
 import shp from "shpjs";
@@ -67,6 +72,15 @@ const GEOLIBRE_PROJECT_FILE_TYPES: BrowserFilePickerType[] = [
   },
 ];
 
+interface SaveTextFileOptions {
+  defaultName: string;
+  filters: FileDialogFilter[];
+  browserTypes: BrowserFilePickerType[];
+  mimeType: string;
+}
+
+interface SaveBinaryFileOptions extends SaveTextFileOptions {}
+
 const SHAPEFILE_SIDECAR_EXTENSIONS = ["dbf", "shx", "prj", "cpg"];
 
 // Auxiliary files that accompany Shapefiles (spatial indexes, metadata, etc.)
@@ -131,6 +145,12 @@ function assertFeatureCollection(value: unknown): FeatureCollection {
     return value as FeatureCollection;
   }
   throw new Error("The selected file did not produce a GeoJSON FeatureCollection.");
+}
+
+function toArrayBuffer(data: Uint8Array): ArrayBuffer {
+  const buffer = new ArrayBuffer(data.byteLength);
+  new Uint8Array(buffer).set(data);
+  return buffer;
 }
 
 function mergeFeatureCollections(
@@ -472,6 +492,80 @@ async function saveProjectFileBrowser(
   return fileName;
 }
 
+async function saveTextFileBrowser(
+  content: string,
+  options: SaveTextFileOptions,
+): Promise<string | null> {
+  const fileName = browserSafeFileName(options.defaultName);
+  const pickerWindow = window as BrowserFilePickerWindow;
+
+  if (pickerWindow.showSaveFilePicker) {
+    try {
+      const handle = await pickerWindow.showSaveFilePicker({
+        suggestedName: fileName,
+        types: options.browserTypes,
+        excludeAcceptAllOption: false,
+      });
+      const writable = await handle.createWritable();
+      await writable.write(content);
+      await writable.close();
+      return handle.name || fileName;
+    } catch (error) {
+      if (isAbortError(error)) return null;
+      console.warn("Browser file save picker failed", error);
+    }
+  }
+
+  const blob = new Blob([content], { type: options.mimeType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = fileName;
+  link.style.display = "none";
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+  return fileName;
+}
+
+async function saveBinaryFileBrowser(
+  content: Uint8Array,
+  options: SaveBinaryFileOptions,
+): Promise<string | null> {
+  const fileName = browserSafeFileName(options.defaultName);
+  const pickerWindow = window as BrowserFilePickerWindow;
+  const blob = new Blob([toArrayBuffer(content)], { type: options.mimeType });
+
+  if (pickerWindow.showSaveFilePicker) {
+    try {
+      const handle = await pickerWindow.showSaveFilePicker({
+        suggestedName: fileName,
+        types: options.browserTypes,
+        excludeAcceptAllOption: false,
+      });
+      const writable = await handle.createWritable();
+      await writable.write(blob);
+      await writable.close();
+      return handle.name || fileName;
+    } catch (error) {
+      if (isAbortError(error)) return null;
+      console.warn("Browser binary file save picker failed", error);
+    }
+  }
+
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = fileName;
+  link.style.display = "none";
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+  return fileName;
+}
+
 export async function openLocalDataFileWithFallback(
   options: LocalDataFileOptions,
 ): Promise<{
@@ -637,6 +731,40 @@ export async function saveProjectFile(
   });
   if (!path) return null;
   await writeTextFile(path, content);
+  return path;
+}
+
+export async function saveTextFileWithFallback(
+  content: string,
+  options: SaveTextFileOptions,
+): Promise<string | null> {
+  if (!isTauri()) {
+    return saveTextFileBrowser(content, options);
+  }
+
+  const path = await save({
+    filters: options.filters,
+    defaultPath: options.defaultName,
+  });
+  if (!path) return null;
+  await writeTextFile(path, content);
+  return path;
+}
+
+export async function saveBinaryFileWithFallback(
+  content: Uint8Array,
+  options: SaveBinaryFileOptions,
+): Promise<string | null> {
+  if (!isTauri()) {
+    return saveBinaryFileBrowser(content, options);
+  }
+
+  const path = await save({
+    filters: options.filters,
+    defaultPath: options.defaultName,
+  });
+  if (!path) return null;
+  await writeFile(path, content);
   return path;
 }
 

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -147,6 +147,9 @@ function assertFeatureCollection(value: unknown): FeatureCollection {
   throw new Error("The selected file did not produce a GeoJSON FeatureCollection.");
 }
 
+// DuckDB-wasm (pthreads build) can hand back a Uint8Array backed by a
+// SharedArrayBuffer, which `Blob`'s BlobPart type rejects. Copy into a plain
+// ArrayBuffer so the binary save path type-checks and stays portable.
 function toArrayBuffer(data: Uint8Array): ArrayBuffer {
   const buffer = new ArrayBuffer(data.byteLength);
   new Uint8Array(buffer).set(data);

--- a/apps/geolibre-desktop/src/lib/vector-exporter.ts
+++ b/apps/geolibre-desktop/src/lib/vector-exporter.ts
@@ -1,0 +1,28 @@
+import type { FeatureCollection } from "geojson";
+
+export type BinaryVectorExportFormat = "geoparquet";
+
+export interface BinaryVectorExportResult {
+  data: Uint8Array;
+  extension: string;
+  mimeType: string;
+}
+
+async function exportGeoParquet(
+  geojson: FeatureCollection,
+): Promise<Uint8Array> {
+  const { exportDuckDbGeoParquet } = await import("./duckdb-vector-loader");
+  return exportDuckDbGeoParquet(geojson);
+}
+
+export async function exportBinaryVectorLayer(
+  geojson: FeatureCollection,
+  _format: BinaryVectorExportFormat,
+  _layerName: string,
+): Promise<BinaryVectorExportResult> {
+  return {
+    data: await exportGeoParquet(geojson),
+    extension: "parquet",
+    mimeType: "application/vnd.apache.parquet",
+  };
+}

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -18,6 +18,9 @@ const APP_VERSION = JSON.parse(
 ).version as string;
 const WMS_PROXY_PATH = "/__geolibre_wms_proxy";
 const RASTER_PROXY_PATH = "/__geolibre_raster_proxy";
+const DUCKDB_WORKER_PATH_PART = "/@duckdb/duckdb-wasm/dist/";
+const DUCKDB_WORKER_SOURCE_MAP_RE =
+  /\n?\/\/# sourceMappingURL=duckdb-browser-(?:eh|mvp)\.worker\.js\.map\s*$/;
 const RADIX_OPTIMIZE_EXCLUDES = [
   "@developmentseed/geotiff",
   "@developmentseed/lzw-tiff-decoder",
@@ -91,6 +94,56 @@ function wmsProxyPlugin(): Plugin {
       });
     },
   };
+}
+
+function stripDuckDbWorkerSourcemapPlugin(): Plugin {
+  return {
+    name: "geolibre-strip-duckdb-worker-sourcemap",
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const requestUrl = new URL(req.url ?? "/", "http://localhost");
+        const decodedPath = safeDecodeURIComponent(requestUrl.pathname);
+        if (!isDuckDbWorkerRequest(decodedPath)) {
+          next();
+          return;
+        }
+
+        const workerFile = path.join(
+          __dirname,
+          "../../node_modules",
+          decodedPath.slice(decodedPath.indexOf(DUCKDB_WORKER_PATH_PART) + 1),
+        );
+        const source = readFileSync(workerFile, "utf8").replace(
+          DUCKDB_WORKER_SOURCE_MAP_RE,
+          "",
+        );
+        res.statusCode = 200;
+        res.setHeader("content-type", "application/javascript");
+        res.end(source);
+      });
+    },
+    generateBundle(_, bundle) {
+      for (const asset of Object.values(bundle)) {
+        if (
+          asset.type === "asset" &&
+          /duckdb-browser-(?:eh|mvp)\.worker-[\w-]+\.js$/.test(asset.fileName)
+        ) {
+          const source =
+            typeof asset.source === "string"
+              ? asset.source
+              : Buffer.from(asset.source).toString("utf8");
+          asset.source = source.replace(DUCKDB_WORKER_SOURCE_MAP_RE, "");
+        }
+      }
+    },
+  };
+}
+
+function isDuckDbWorkerRequest(pathname: string): boolean {
+  return (
+    pathname.includes(DUCKDB_WORKER_PATH_PART) &&
+    /duckdb-browser-(?:eh|mvp)\.worker\.js$/.test(pathname)
+  );
 }
 
 function projectUrlQueryPlugin(): Plugin {
@@ -179,7 +232,12 @@ async function proxyBinaryRequest(
 
 export default defineConfig({
   base: APP_BASE,
-  plugins: [projectUrlQueryPlugin(), react(), wmsProxyPlugin()],
+  plugins: [
+    stripDuckDbWorkerSourcemapPlugin(),
+    projectUrlQueryPlugin(),
+    react(),
+    wmsProxyPlugin(),
+  ],
   clearScreen: false,
   define: {
     __GEOLIBRE_VERSION__: JSON.stringify(APP_VERSION),

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -103,7 +103,7 @@ function stripDuckDbWorkerSourcemapPlugin(): Plugin {
       server.middlewares.use((req, res, next) => {
         const requestUrl = new URL(req.url ?? "/", "http://localhost");
         const decodedPath = safeDecodeURIComponent(requestUrl.pathname);
-        if (!isDuckDbWorkerRequest(decodedPath)) {
+        if (requestUrl.search || !isDuckDbWorkerRequest(decodedPath)) {
           next();
           return;
         }

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -37,7 +37,7 @@ function createIdentifyPopupElement(
   featureId?: string | number,
 ): HTMLElement {
   const root = document.createElement("div");
-  root.className = "min-w-48 max-w-80 text-xs";
+  root.className = "geolibre-identify-popup-root min-w-48 max-w-80 text-xs";
 
   const title = document.createElement("div");
   title.className = "mb-2 font-semibold text-foreground";
@@ -45,7 +45,7 @@ function createIdentifyPopupElement(
   root.appendChild(title);
 
   const rows = document.createElement("div");
-  rows.className = "max-h-64 overflow-auto";
+  rows.className = "geolibre-identify-popup-rows";
   root.appendChild(rows);
 
   const appendRow = (key: string, value: unknown) => {

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -37,7 +37,8 @@ function createIdentifyPopupElement(
   featureId?: string | number,
 ): HTMLElement {
   const root = document.createElement("div");
-  root.className = "geolibre-identify-popup-root min-w-48 max-w-80 text-xs";
+  root.className =
+    "flex max-h-[min(380px,calc(100vh-128px))] min-w-48 max-w-80 flex-col text-xs";
 
   const title = document.createElement("div");
   title.className = "mb-2 font-semibold text-foreground";
@@ -45,7 +46,7 @@ function createIdentifyPopupElement(
   root.appendChild(title);
 
   const rows = document.createElement("div");
-  rows.className = "geolibre-identify-popup-rows";
+  rows.className = "min-h-0 flex-1 overflow-y-auto";
   root.appendChild(rows);
 
   const appendRow = (key: string, value: unknown) => {


### PR DESCRIPTION
## Summary
- Add inline editing to the attribute table: an Edit/Save/Cancel toolbar, per-cell drafts with type-aware parsing (numbers, booleans, JSON), and visual highlighting of edited cells before saving back to the layer.
- Constrain the identify popup height so long attribute lists scroll within the popup instead of overflowing the viewport.

## Test plan
- [ ] Open a vector layer's attribute table, click Edit, modify values, and confirm Save writes them back and Cancel discards drafts.
- [ ] Edit numeric, boolean, and object-valued fields and confirm values are parsed to the correct types.
- [ ] Switch layers mid-edit and confirm drafts reset.
- [ ] Identify a feature with many attributes and confirm the popup scrolls instead of overflowing.