### PR TITLE
Fix local raster file loading

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -37,7 +37,7 @@
     "mapillary-js": "^4.1.2",
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-basemap-control": "^0.2.1",
-    "maplibre-gl-components": "^0.17.3",
+    "maplibre-gl-components": "^0.17.4",
     "maplibre-gl-duckdb": "^0.2.0",
     "maplibre-gl-esri-wayback": "^0.1.0",
     "maplibre-gl-geo-editor": "^0.7.3",

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -80,7 +80,7 @@ type VectorMode = "vector-file" | "geojson-url" | "vector-tiles";
 type RasterMode = "tiles" | "cog-url" | "file";
 type RasterColormap = NonNullable<CogRasterLayerOptions["colormap"]>;
 type SelectedRasterFile = {
-  data?: ArrayBuffer;
+  data: ArrayBuffer;
   path: string;
 };
 
@@ -608,26 +608,31 @@ export function AddDataDialog({
 
   const handleChooseRasterFile = async () => {
     setError(null);
-    const result = await openLocalDataFileWithFallback({
-      filters: [
-        {
-          name: "GeoTIFF raster",
-          extensions: ["tif", "tiff"],
-        },
-      ],
-      accept: ".tif,.tiff",
-      readBinary: true,
-    });
-    if (!result) return;
-    setSelectedRasterFile({
-      data: result.data,
-      path: result.path,
-    });
-    setLayerName((current) =>
-      current.trim() && current !== "Raster Layer"
-        ? current
-        : layerNameFromPath(result.path, "Raster Layer"),
-    );
+    try {
+      const result = await openLocalDataFileWithFallback({
+        filters: [
+          {
+            name: "GeoTIFF raster",
+            extensions: ["tif", "tiff"],
+          },
+        ],
+        accept: ".tif,.tiff",
+        readBinary: true,
+      });
+      if (!result) return;
+      if (!result.data) throw new Error("Raster file data is missing.");
+      setSelectedRasterFile({
+        data: result.data,
+        path: result.path,
+      });
+      setLayerName((current) =>
+        current.trim() && current !== "Raster Layer"
+          ? current
+          : layerNameFromPath(result.path, "Raster Layer"),
+      );
+    } catch (err) {
+      setError(errorMessage(err, "Could not read raster file."));
+    }
   };
 
   const handleChooseMbtilesFile = async () => {

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -79,6 +79,10 @@ interface AddDataDialogProps {
 type VectorMode = "vector-file" | "geojson-url" | "vector-tiles";
 type RasterMode = "tiles" | "cog-url" | "file";
 type RasterColormap = NonNullable<CogRasterLayerOptions["colormap"]>;
+type SelectedRasterFile = {
+  data?: ArrayBuffer;
+  path: string;
+};
 
 const KIND_LABELS: Record<AddDataKind, string> = {
   xyz: "Add XYZ Layer",
@@ -316,9 +320,8 @@ export function AddDataDialog({
   const [rasterMin, setRasterMin] = useState("0");
   const [rasterMax, setRasterMax] = useState("255");
   const [rasterNodata, setRasterNodata] = useState("");
-  const [selectedRasterPath, setSelectedRasterPath] = useState<string | null>(
-    null,
-  );
+  const [selectedRasterFile, setSelectedRasterFile] =
+    useState<SelectedRasterFile | null>(null);
   const [selectedMbtiles, setSelectedMbtiles] = useState<{
     metadata: MbtilesMetadata;
     path: string;
@@ -386,7 +389,7 @@ export function AddDataDialog({
     setRasterMin("0");
     setRasterMax("255");
     setRasterNodata("");
-    setSelectedRasterPath(null);
+    setSelectedRasterFile(null);
     setSelectedMbtiles(null);
     setMbtilesSourceLayers("");
     setArcgisLayerType("feature");
@@ -613,9 +616,13 @@ export function AddDataDialog({
         },
       ],
       accept: ".tif,.tiff",
+      readBinary: true,
     });
     if (!result) return;
-    setSelectedRasterPath(result.path);
+    setSelectedRasterFile({
+      data: result.data,
+      path: result.path,
+    });
     setLayerName((current) =>
       current.trim() && current !== "Raster Layer"
         ? current
@@ -884,7 +891,7 @@ export function AddDataDialog({
         return;
       }
 
-      if (!selectedRasterPath) throw new Error("Choose a raster file.");
+      if (!selectedRasterFile) throw new Error("Choose a raster file.");
       const rescaleMin = parseRequiredNumber(rasterMin, "minimum value");
       const rescaleMax = parseRequiredNumber(rasterMax, "maximum value");
       if (rescaleMax <= rescaleMin) {
@@ -894,12 +901,13 @@ export function AddDataDialog({
         bands: rasterBands.trim() || "1",
         beforeLayerId: beforeLayer,
         colormap: rasterColormap,
+        data: selectedRasterFile.data,
         name,
         nodata: parseOptionalNumber(rasterNodata, "nodata value"),
         opacity: 1,
         rescaleMax,
         rescaleMin,
-        url: selectedRasterPath,
+        url: selectedRasterFile.path,
       });
       closeDialog();
     } catch (err) {
@@ -1404,8 +1412,8 @@ export function AddDataDialog({
                     Choose file
                   </Button>
                   <span className="min-w-0 truncate text-xs text-muted-foreground">
-                    {selectedRasterPath
-                      ? fileNameFromPath(selectedRasterPath)
+                    {selectedRasterFile
+                      ? fileNameFromPath(selectedRasterFile.path)
                       : "No file selected"}
                   </span>
                 </div>

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -27,6 +27,7 @@ interface FileDialogFilter {
 interface LocalDataFileOptions {
   filters: FileDialogFilter[];
   accept: string;
+  readBinary?: boolean;
   readText?: boolean;
 }
 
@@ -572,6 +573,7 @@ async function saveBinaryFileBrowser(
 export async function openLocalDataFileWithFallback(
   options: LocalDataFileOptions,
 ): Promise<{
+  data?: ArrayBuffer;
   path: string;
   text?: string;
 } | null> {
@@ -581,8 +583,11 @@ export async function openLocalDataFileWithFallback(
       filters: options.filters,
     });
     if (!selected || typeof selected !== "string") return null;
+    const data = options.readBinary
+      ? toArrayBuffer(await readFile(selected))
+      : undefined;
     const text = options.readText ? await readTextFile(selected) : undefined;
-    return { path: selected, text };
+    return { data, path: selected, text };
   }
 
   return new Promise((resolve) => {
@@ -595,8 +600,9 @@ export async function openLocalDataFileWithFallback(
         resolve(null);
         return;
       }
+      const data = options.readBinary ? await file.arrayBuffer() : undefined;
       const text = options.readText ? await file.text() : undefined;
-      resolve({ path: file.name, text });
+      resolve({ data, path: file.name, text });
     };
     input.click();
   });

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -590,19 +590,23 @@ export async function openLocalDataFileWithFallback(
     return { data, path: selected, text };
   }
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const input = document.createElement("input");
     input.type = "file";
     input.accept = options.accept;
     input.onchange = async () => {
-      const file = input.files?.[0];
-      if (!file) {
-        resolve(null);
-        return;
+      try {
+        const file = input.files?.[0];
+        if (!file) {
+          resolve(null);
+          return;
+        }
+        const data = options.readBinary ? await file.arrayBuffer() : undefined;
+        const text = options.readText ? await file.text() : undefined;
+        resolve({ data, path: file.name, text });
+      } catch (error) {
+        reject(error);
       }
-      const data = options.readBinary ? await file.arrayBuffer() : undefined;
-      const text = options.readText ? await file.text() : undefined;
-      resolve({ data, path: file.name, text });
     };
     input.click();
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "mapillary-js": "^4.1.2",
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-basemap-control": "^0.2.1",
-        "maplibre-gl-components": "^0.17.3",
+        "maplibre-gl-components": "^0.17.4",
         "maplibre-gl-duckdb": "^0.2.0",
         "maplibre-gl-esri-wayback": "^0.1.0",
         "maplibre-gl-geo-editor": "^0.7.3",
@@ -87,12 +87,13 @@
       "license": "MIT"
     },
     "apps/geolibre-desktop/node_modules/maplibre-gl-components": {
-      "version": "0.17.3",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.17.3.tgz",
-      "integrity": "sha512-u/3FX/Rw19HodsvfZbhtg+KD+tg5PthvE+1cwWClNcL9rTNWoj6mkoxd+DcCRT28jAqE77OCuOxjBbM64fw20w==",
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.17.4.tgz",
+      "integrity": "sha512-n9l78bdTtMIsa0+sYerjRliQPYj6c1mxAsrELVztI38nv1gkR8SStrIQonpnHSf4rCtdh3z0LB244bZ2zVzx1g==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",
+        "@developmentseed/geotiff": ">=0.7.0",
         "flatgeobuf": ">=4.4.0",
         "geotiff": ">=3.0.5",
         "geotiff-geokeys-to-proj4": ">=2024.4.13",
@@ -6963,7 +6964,7 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/raf": {
@@ -6983,7 +6984,7 @@
       "version": "18.3.29",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.29.tgz",
       "integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -6994,7 +6995,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -7858,7 +7859,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -12600,7 +12601,7 @@
         "jspdf": "^2.5.2",
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-basemap-control": "^0.2.1",
-        "maplibre-gl-components": "^0.17.3",
+        "maplibre-gl-components": "^0.17.4",
         "maplibre-gl-duckdb": "^0.2.0",
         "maplibre-gl-esri-wayback": "^0.1.0",
         "maplibre-gl-geo-editor": "^0.7.3",
@@ -12628,12 +12629,13 @@
       }
     },
     "packages/plugins/node_modules/maplibre-gl-components": {
-      "version": "0.17.3",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.17.3.tgz",
-      "integrity": "sha512-u/3FX/Rw19HodsvfZbhtg+KD+tg5PthvE+1cwWClNcL9rTNWoj6mkoxd+DcCRT28jAqE77OCuOxjBbM64fw20w==",
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.17.4.tgz",
+      "integrity": "sha512-n9l78bdTtMIsa0+sYerjRliQPYj6c1mxAsrELVztI38nv1gkR8SStrIQonpnHSf4rCtdh3z0LB244bZ2zVzx1g==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",
+        "@developmentseed/geotiff": ">=0.7.0",
         "flatgeobuf": ">=4.4.0",
         "geotiff": ">=3.0.5",
         "geotiff-geokeys-to-proj4": ">=2024.4.13",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -26,7 +26,7 @@
     "jspdf": "^2.5.2",
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-basemap-control": "^0.2.1",
-    "maplibre-gl-components": "^0.17.3",
+    "maplibre-gl-components": "^0.17.4",
     "maplibre-gl-duckdb": "^0.2.0",
     "maplibre-gl-esri-wayback": "^0.1.0",
     "maplibre-gl-geo-editor": "^0.7.3",

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -1699,14 +1699,18 @@ async function addGeoTiffRasterLayer(
   const id = createGeoTiffRasterLayerId();
   const url = options.url.trim();
   const name = options.name?.trim() || layerNameFromUrl(url, id);
-  const rasterInput = await fetchGeoTiffRasterInput(app, options, cause);
+  const rasterInput = await fetchGeoTiffRasterInput(app, options, url, cause);
   const { bounds, raster } = await loadGeoTiffRasterData(rasterInput, options);
+  const { data: _data, ...stateOptions } = options;
   const state: GeoTiffRasterLayerState = {
     bounds,
     id,
     name,
     opacity: options.opacity ?? 1,
-    options,
+    options: {
+      ...stateOptions,
+      url,
+    },
     raster,
     url,
     visible: true,
@@ -1783,11 +1787,11 @@ async function ensureGeoTiffRasterOverlay(
 async function fetchGeoTiffRasterInput(
   app: GeoLibreAppAPI,
   options: CogRasterLayerOptions,
+  url: string,
   cause: unknown,
 ): Promise<ArrayBuffer> {
   if (options.data) return options.data;
 
-  const url = options.url;
   if (app.fetchArrayBuffer) {
     try {
       return await app.fetchArrayBuffer(url);

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -1872,18 +1872,16 @@ function createGeoTiffReprojectionFns(
 ): RasterLayerProps["reprojectionFns"] {
   const [originX, originY] = image.getOrigin();
   const [resolutionX, resolutionY] = image.getResolution();
-  const width = image.getWidth();
-  const height = image.getHeight();
   const converter = proj4(sourceProjection, "EPSG:4326");
 
   return {
     forwardTransform: (x, y) => [
-      originX + x * width * resolutionX,
-      originY + y * height * resolutionY,
+      originX + x * resolutionX,
+      originY + y * resolutionY,
     ],
     inverseTransform: (x, y) => [
-      (x - originX) / (width * resolutionX),
-      (y - originY) / (height * resolutionY),
+      (x - originX) / resolutionX,
+      (y - originY) / resolutionY,
     ],
     forwardReproject: (x, y) => converter.forward([x, y]),
     inverseReproject: (x, y) => converter.inverse([x, y]),
@@ -3176,11 +3174,8 @@ function shouldUseGenericGeoTiffRenderer(url: string): boolean {
 
   try {
     const parsedUrl = new URL(url);
-    const isGitHubRelease =
-      parsedUrl.hostname === "github.com" &&
-      parsedUrl.pathname.includes("/releases/download/");
     const isTiff = /\.tiff?$/i.test(parsedUrl.pathname);
-    return isTiff && (isGitHubRelease || parsedUrl.protocol === "file:");
+    return isTiff;
   } catch {
     return isTiffPath;
   }

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -754,6 +754,7 @@ export async function addCogRasterLayer(
     return addGeoTiffRasterLayer(app, options);
   }
 
+  ensureCogRasterMercatorProjection(app);
   const control = await ensureCogRasterControl(app);
   if (!control) {
     throw new Error("The COG raster layer control could not be added to the map.");
@@ -762,6 +763,7 @@ export async function addCogRasterLayer(
   try {
     return await addLayerWithCogRasterControl(control, options);
   } catch (error) {
+    if (isRemoteHttpUrl(options.url)) throw error;
     return addGeoTiffRasterLayer(app, options, error);
   }
 }
@@ -2102,6 +2104,16 @@ function configureCogRasterControl(
   mutableControl._render?.();
 }
 
+function ensureCogRasterMercatorProjection(app: GeoLibreAppAPI): void {
+  try {
+    const map = app.getMap?.();
+    if (!map || map.getProjection()?.type === "mercator") return;
+    map.setProjection({ type: "mercator" });
+  } catch {
+    // MapLibre can reject projection changes while the style is still settling.
+  }
+}
+
 function createFlatGeobufStoreLayer(
   id: string,
   layerInfo: AddVectorLayerInfo,
@@ -3175,7 +3187,7 @@ function shouldUseGenericGeoTiffRenderer(url: string): boolean {
   try {
     const parsedUrl = new URL(url);
     const isTiff = /\.tiff?$/i.test(parsedUrl.pathname);
-    return isTiff;
+    return isTiff && parsedUrl.protocol === "file:";
   } catch {
     return isTiffPath;
   }

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -439,6 +439,7 @@ const searchPlacesPanelListeners = new Set<() => void>();
 
 export interface CogRasterLayerOptions {
   url: string;
+  data?: ArrayBuffer;
   name?: string;
   bands?: string;
   colormap?: CogLayerControlOptions["defaultColormap"];
@@ -749,7 +750,7 @@ export async function addCogRasterLayer(
   app: GeoLibreAppAPI,
   options: CogRasterLayerOptions,
 ): Promise<string> {
-  if (shouldUseGenericGeoTiffRenderer(options.url)) {
+  if (options.data || shouldUseGenericGeoTiffRenderer(options.url)) {
     return addGeoTiffRasterLayer(app, options);
   }
 
@@ -1698,7 +1699,7 @@ async function addGeoTiffRasterLayer(
   const id = createGeoTiffRasterLayerId();
   const url = options.url.trim();
   const name = options.name?.trim() || layerNameFromUrl(url, id);
-  const rasterInput = await fetchGeoTiffRasterInput(app, url, cause);
+  const rasterInput = await fetchGeoTiffRasterInput(app, options, cause);
   const { bounds, raster } = await loadGeoTiffRasterData(rasterInput, options);
   const state: GeoTiffRasterLayerState = {
     bounds,
@@ -1781,9 +1782,12 @@ async function ensureGeoTiffRasterOverlay(
 
 async function fetchGeoTiffRasterInput(
   app: GeoLibreAppAPI,
-  url: string,
+  options: CogRasterLayerOptions,
   cause: unknown,
 ): Promise<ArrayBuffer> {
+  if (options.data) return options.data;
+
+  const url = options.url;
   if (app.fetchArrayBuffer) {
     try {
       return await app.fetchArrayBuffer(url);


### PR DESCRIPTION
## Summary
- keep selected local raster bytes from the file picker
- pass local raster data into the GeoTIFF renderer instead of fetching by filename
- preserve existing URL and tile raster paths

## Tests
- npm run build
- pre-commit run --all-files
- browser smoke test with /home/qiusheng/Downloads/dem.tif