### PR TITLE
feat: default GeoJSON URL and resize identify popup

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -117,6 +117,8 @@ const DEFAULT_WMTS_URL =
   "https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/MapServer/tile/119/{z}/{y}/{x}";
 const DEFAULT_RASTER_URL =
   "https://data.source.coop/giswqs/opengeos/nlcd_2021_land_cover_30m.tif";
+const DEFAULT_GEOJSON_URL =
+  "https://data.source.coop/giswqs/opengeos/countries.geojson";
 const DEFAULT_ARCGIS_FEATURE_URL =
   "https://services3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/USA_Major_Cities/FeatureServer/0";
 const DEFAULT_ARCGIS_VECTOR_TILE_URL =
@@ -304,8 +306,8 @@ export function AddDataDialog({
   const [wmtsUrl, setWmtsUrl] = useState(DEFAULT_WMTS_URL);
   const [wmtsTileSize, setWmtsTileSize] = useState("256");
 
-  const [vectorMode, setVectorMode] = useState<VectorMode>("vector-file");
-  const [vectorUrl, setVectorUrl] = useState("");
+  const [vectorMode, setVectorMode] = useState<VectorMode>("geojson-url");
+  const [vectorUrl, setVectorUrl] = useState(DEFAULT_GEOJSON_URL);
   const [vectorSourceLayer, setVectorSourceLayer] = useState("");
   const [selectedVector, setSelectedVector] = useState<{
     data: FeatureCollection;
@@ -377,8 +379,8 @@ export function AddDataDialog({
     setWmsTileSize("256");
     setWmtsUrl(DEFAULT_WMTS_URL);
     setWmtsTileSize("256");
-    setVectorMode("vector-file");
-    setVectorUrl("");
+    setVectorMode("geojson-url");
+    setVectorUrl(DEFAULT_GEOJSON_URL);
     setVectorSourceLayer("");
     setSelectedVector(null);
     setRasterMode("cog-url");
@@ -458,6 +460,13 @@ export function AddDataDialog({
     if (!next && isSubmitting) return;
     if (!next) stopTransientMartinServer();
     onOpenChange(next);
+  };
+
+  const handleVectorModeChange = (mode: VectorMode) => {
+    setVectorMode(mode);
+    setVectorSourceLayer("");
+    setSelectedVector(null);
+    setVectorUrl(mode === "geojson-url" ? DEFAULT_GEOJSON_URL : "");
   };
 
   const beforeLayer = beforeLayerId.trim() || null;
@@ -1086,7 +1095,7 @@ export function AddDataDialog({
                   id="vector-mode"
                   value={vectorMode}
                   onChange={(event) =>
-                    setVectorMode(event.target.value as VectorMode)
+                    handleVectorModeChange(event.target.value as VectorMode)
                   }
                 >
                   <option value="vector-file">Vector file</option>

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -463,10 +463,15 @@ export function AddDataDialog({
   };
 
   const handleVectorModeChange = (mode: VectorMode) => {
+    const currentUrl = vectorUrl.trim();
     setVectorMode(mode);
     setVectorSourceLayer("");
     setSelectedVector(null);
-    setVectorUrl(mode === "geojson-url" ? DEFAULT_GEOJSON_URL : "");
+    if (mode === "geojson-url" && !currentUrl) {
+      setVectorUrl(DEFAULT_GEOJSON_URL);
+    } else if (mode !== "geojson-url" && currentUrl === DEFAULT_GEOJSON_URL) {
+      setVectorUrl("");
+    }
   };
 
   const beforeLayer = beforeLayerId.trim() || null;

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1281,10 +1281,22 @@ body,
     0 10px 15px -3px rgb(0 0 0 / 0.18),
     0 4px 6px -4px rgb(0 0 0 / 0.18);
   color: hsl(var(--popover-foreground));
-  /* Keep in sync with the popup root max-height in MapCanvas.tsx
-     (createIdentifyPopupElement). */
-  max-height: min(380px, calc(100vh - 128px));
+  max-height: calc(100vh - 96px);
+  overflow: visible;
+}
+
+.geolibre-identify-popup-root {
+  max-height: min(640px, calc(100vh - 128px));
   overflow: hidden;
+}
+
+.geolibre-identify-popup-rows {
+  flex: 1 1 auto;
+  min-height: 0;
+  max-height: min(560px, calc(100vh - 184px));
+  overflow-y: scroll;
+  scrollbar-gutter: stable;
+  scrollbar-width: thin;
 }
 
 .geolibre-identify-popup .maplibregl-popup-close-button {

--- a/apps/geolibre-desktop/tailwind.config.js
+++ b/apps/geolibre-desktop/tailwind.config.js
@@ -5,6 +5,7 @@ export default {
     "./index.html",
     "./src/**/*.{ts,tsx}",
     "../../packages/ui/src/**/*.{ts,tsx}",
+    "../../packages/map/src/**/*.{ts,tsx}",
   ],
   theme: {
     extend: {

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -19,7 +19,6 @@ import "./layer-control-overrides.css";
 
 const PANEL_RESIZE_START_EVENT = "geolibre:panel-resize-start";
 const PANEL_RESIZE_END_EVENT = "geolibre:panel-resize-end";
-const MAX_IDENTIFY_PROPERTIES = 24;
 
 export interface MapCanvasProps {
   controllerRef?: React.MutableRefObject<MapController | null>;
@@ -38,7 +37,7 @@ function createIdentifyPopupElement(
 ): HTMLElement {
   const root = document.createElement("div");
   root.className =
-    "flex max-h-[min(380px,calc(100vh-128px))] min-w-48 max-w-80 flex-col text-xs";
+    "geolibre-identify-popup-root flex min-w-72 max-w-[min(520px,calc(100vw-48px))] flex-col text-xs";
 
   const title = document.createElement("div");
   title.className = "mb-2 font-semibold text-foreground";
@@ -46,7 +45,7 @@ function createIdentifyPopupElement(
   root.appendChild(title);
 
   const rows = document.createElement("div");
-  rows.className = "min-h-0 flex-1 overflow-y-auto";
+  rows.className = "geolibre-identify-popup-rows pr-2";
   root.appendChild(rows);
 
   const appendRow = (key: string, value: unknown) => {
@@ -68,7 +67,7 @@ function createIdentifyPopupElement(
 
   if (featureId != null) appendRow("id", featureId);
 
-  const entries = Object.entries(properties).slice(0, MAX_IDENTIFY_PROPERTIES);
+  const entries = Object.entries(properties);
   if (entries.length === 0 && featureId == null) {
     const empty = document.createElement("div");
     empty.className = "text-muted-foreground";
@@ -318,7 +317,7 @@ export const MapCanvas = memo(function MapCanvas({
         className: "geolibre-identify-popup",
         closeButton: true,
         closeOnClick: false,
-        maxWidth: "360px",
+        maxWidth: "560px",
       })
         .setLngLat(event.lngLat)
         .setDOMContent(

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -37,7 +37,7 @@ function createIdentifyPopupElement(
 ): HTMLElement {
   const root = document.createElement("div");
   root.className =
-    "geolibre-identify-popup-root flex min-w-72 max-w-[min(520px,calc(100vw-48px))] flex-col text-xs";
+    "geolibre-identify-popup-root flex min-w-[min(18rem,calc(100vw-48px))] max-w-[min(520px,calc(100vw-48px))] flex-col text-xs";
 
   const title = document.createElement("div");
   title.className = "mb-2 font-semibold text-foreground";


### PR DESCRIPTION
## Summary
- Default the Add Data dialog's vector input to a sample GeoJSON URL so the dialog opens ready to load data, and reset to that default when switching vector modes.
- Let the identify popup grow taller and wider with a scrollable property list, removing the previous 24-property cap so all feature attributes are visible.

## Test plan
- [ ] Open the Add Data dialog and confirm the vector tab defaults to the GeoJSON URL mode with the sample URL prefilled.
- [ ] Switch between vector modes and confirm the URL field resets appropriately.
- [ ] Identify a feature with more than 24 properties and confirm all properties are listed and the popup scrolls.