### PR TITLE
feat: add settings dialog for map preferences and runtime env vars

### DIFF
--- a/apps/geolibre-desktop/src/App.tsx
+++ b/apps/geolibre-desktop/src/App.tsx
@@ -3,6 +3,7 @@ import { useLayoutOptions } from "./hooks/useLayoutOptions";
 import { usePlugins } from "./hooks/usePlugins";
 import { useProjectUrlLoader } from "./hooks/useProjectUrlLoader";
 import { useRecentProjectsPersistence } from "./hooks/useRecentProjectsPersistence";
+import { useRuntimeEnvironmentVariables } from "./hooks/useRuntimeEnvironmentVariables";
 import { useThemeMode } from "./hooks/useThemeMode";
 
 export default function App() {
@@ -12,6 +13,7 @@ export default function App() {
 
   usePlugins();
   useRecentProjectsPersistence();
+  useRuntimeEnvironmentVariables();
   return (
     <DesktopShell
       layoutOptions={layoutOptions}

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -314,7 +314,10 @@ export function SettingsDialog({
         size="sm"
         type="button"
         variant={section === item.id ? "secondary" : "ghost"}
-        onClick={() => setSection(item.id)}
+        onClick={() => {
+          setSection(item.id);
+          setError(null);
+        }}
       >
         <Icon className="h-4 w-4" />
         {item.label}

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -32,6 +32,7 @@ import {
   RotateCcw,
   Settings,
   Trash2,
+  TriangleAlert,
 } from "lucide-react";
 import { useEffect, useMemo, useState, type RefObject } from "react";
 
@@ -514,6 +515,14 @@ export function SettingsDialog({
                       <Plus className="h-3.5 w-3.5" />
                       Add
                     </Button>
+                  </div>
+                  <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-700 dark:text-amber-300">
+                    <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0" />
+                    <span>
+                      Values are stored in plain text in the project file and
+                      may be exposed when the project is shared. Avoid putting
+                      secrets here unless the project file stays private.
+                    </span>
                   </div>
                   {draftPreferences.environmentVariables.length === 0 ? (
                     <div className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -1,0 +1,613 @@
+import {
+  DEFAULT_PROJECT_PREFERENCES,
+  PROJECT_VERSION,
+  useAppStore,
+  type MapPreferences,
+  type ProjectPreferences,
+  type RuntimeEnvironmentVariable,
+} from "@geolibre/core";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Input,
+  Label,
+} from "@geolibre/ui";
+import type { MapController } from "@geolibre/map";
+import {
+  Braces,
+  Crosshair,
+  FolderCog,
+  MapPinned,
+  Plus,
+  RotateCcw,
+  Settings,
+  Trash2,
+} from "lucide-react";
+import { useEffect, useMemo, useState, type RefObject } from "react";
+
+type SettingsSection = "map" | "environment" | "project";
+
+interface SettingsDialogProps {
+  buttonClassName?: string;
+  buttonSize?: "default" | "sm" | "lg" | "icon" | null;
+  iconClassName?: string;
+  mapControllerRef: RefObject<MapController | null>;
+  showLabels?: boolean;
+}
+
+const SECTION_ITEMS: Array<{
+  id: SettingsSection;
+  label: string;
+  icon: typeof MapPinned;
+}> = [
+  { id: "map", label: "Map", icon: MapPinned },
+  { id: "environment", label: "Environment", icon: Braces },
+  { id: "project", label: "Project", icon: FolderCog },
+];
+
+const VARIABLE_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function clonePreferences(preferences: ProjectPreferences): ProjectPreferences {
+  return {
+    map: { ...preferences.map },
+    environmentVariables: preferences.environmentVariables.map((variable) => ({
+      ...variable,
+    })),
+  };
+}
+
+function normalizeBounds(bounds: MapPreferences["bounds"]): MapPreferences["bounds"] {
+  const west = clamp(bounds[0], -180, 180);
+  const south = clamp(bounds[1], -85, 85);
+  const east = clamp(bounds[2], -180, 180);
+  const north = clamp(bounds[3], -85, 85);
+  if (west >= east || south >= north) {
+    return DEFAULT_PROJECT_PREFERENCES.map.bounds;
+  }
+
+  return [west, south, east, north];
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(max, Math.max(min, value));
+}
+
+function roundCoordinate(value: number): number {
+  return Number(value.toFixed(6));
+}
+
+function normalizePreferences(
+  preferences: ProjectPreferences,
+): ProjectPreferences {
+  const minZoom = clamp(preferences.map.minZoom, 0, 24);
+  const maxZoom = Math.max(minZoom, clamp(preferences.map.maxZoom, 0, 24));
+  return {
+    map: {
+      ...preferences.map,
+      bounds: normalizeBounds(preferences.map.bounds),
+      minZoom,
+      maxZoom,
+      maxPitch: clamp(preferences.map.maxPitch, 0, 85),
+    },
+    environmentVariables: preferences.environmentVariables
+      .map((variable) => ({
+        key: variable.key.trim(),
+        value: variable.value,
+        enabled: variable.enabled,
+      }))
+      .filter((variable) => variable.key.length > 0),
+  };
+}
+
+function validateEnvironmentVariables(
+  variables: RuntimeEnvironmentVariable[],
+): string | null {
+  const keys = new Set<string>();
+
+  for (const variable of variables) {
+    if (!variable.key.trim()) continue;
+    if (!VARIABLE_NAME_PATTERN.test(variable.key.trim())) {
+      return "Environment variable names must start with a letter or underscore and contain only letters, numbers, and underscores.";
+    }
+    if (keys.has(variable.key.trim())) {
+      return `Environment variable "${variable.key.trim()}" is duplicated.`;
+    }
+    keys.add(variable.key.trim());
+  }
+
+  return null;
+}
+
+export function SettingsDialog({
+  buttonClassName,
+  buttonSize = "sm",
+  iconClassName,
+  mapControllerRef,
+  showLabels = true,
+}: SettingsDialogProps) {
+  const preferences = useAppStore((s) => s.preferences);
+  const setPreferences = useAppStore((s) => s.setPreferences);
+  const projectName = useAppStore((s) => s.projectName);
+  const projectPath = useAppStore((s) => s.projectPath);
+  const setProjectName = useAppStore((s) => s.setProjectName);
+  const [open, setOpen] = useState(false);
+  const [section, setSection] = useState<SettingsSection>("map");
+  const [draftPreferences, setDraftPreferences] = useState<ProjectPreferences>(
+    () => clonePreferences(preferences),
+  );
+  const [draftProjectName, setDraftProjectName] = useState(projectName);
+  const [error, setError] = useState<string | null>(null);
+  const enabledVariableCount = useMemo(
+    () =>
+      draftPreferences.environmentVariables.filter(
+        (variable) => variable.enabled && variable.key.trim(),
+      ).length,
+    [draftPreferences.environmentVariables],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    setDraftPreferences(clonePreferences(preferences));
+    setDraftProjectName(projectName);
+    setError(null);
+  }, [open, preferences, projectName]);
+
+  const updateMapPreferences = (patch: Partial<MapPreferences>) => {
+    setDraftPreferences((current) => ({
+      ...current,
+      map: { ...current.map, ...patch },
+    }));
+    setError(null);
+  };
+
+  const updateBoundsValue = (
+    index: number,
+    value: number,
+  ) => {
+    setDraftPreferences((current) => {
+      const bounds: MapPreferences["bounds"] = [...current.map.bounds];
+      bounds[index] = value;
+      return {
+        ...current,
+        map: { ...current.map, bounds },
+      };
+    });
+    setError(null);
+  };
+
+  const updateEnvironmentVariable = (
+    index: number,
+    patch: Partial<RuntimeEnvironmentVariable>,
+  ) => {
+    setDraftPreferences((current) => ({
+      ...current,
+      environmentVariables: current.environmentVariables.map((variable, i) =>
+        i === index ? { ...variable, ...patch } : variable,
+      ),
+    }));
+    setError(null);
+  };
+
+  const addEnvironmentVariable = () => {
+    setDraftPreferences((current) => ({
+      ...current,
+      environmentVariables: [
+        ...current.environmentVariables,
+        { key: "", value: "", enabled: true },
+      ],
+    }));
+    setSection("environment");
+    setError(null);
+  };
+
+  const removeEnvironmentVariable = (index: number) => {
+    setDraftPreferences((current) => ({
+      ...current,
+      environmentVariables: current.environmentVariables.filter(
+        (_, i) => i !== index,
+      ),
+    }));
+    setError(null);
+  };
+
+  const useCurrentViewBounds = () => {
+    const bounds = mapControllerRef.current?.readView().bbox;
+    if (!bounds) {
+      setError("The map bounds are not available yet.");
+      return;
+    }
+    updateMapPreferences({
+      restrictBounds: true,
+      bounds: [
+        roundCoordinate(bounds[0]),
+        roundCoordinate(bounds[1]),
+        roundCoordinate(bounds[2]),
+        roundCoordinate(bounds[3]),
+      ],
+    });
+  };
+
+  const resetMapPreferences = () => {
+    updateMapPreferences(DEFAULT_PROJECT_PREFERENCES.map);
+  };
+
+  const saveSettings = () => {
+    const normalized = normalizePreferences(draftPreferences);
+    const validationError = validateEnvironmentVariables(
+      normalized.environmentVariables,
+    );
+    if (validationError) {
+      setError(validationError);
+      setSection("environment");
+      return;
+    }
+
+    const nextProjectName = draftProjectName.trim() || "Untitled Project";
+    if (nextProjectName !== projectName) setProjectName(nextProjectName);
+    setPreferences(normalized);
+    setOpen(false);
+  };
+
+  const renderSectionButton = (item: (typeof SECTION_ITEMS)[number]) => {
+    const Icon = item.icon;
+    return (
+      <Button
+        key={item.id}
+        className="justify-start"
+        size="sm"
+        type="button"
+        variant={section === item.id ? "secondary" : "ghost"}
+        onClick={() => setSection(item.id)}
+      >
+        <Icon className="h-4 w-4" />
+        {item.label}
+      </Button>
+    );
+  };
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            className={buttonClassName}
+            variant="ghost"
+            size={buttonSize}
+            aria-label="Settings"
+          >
+            <Settings className={iconClassName} />
+            {showLabels ? (
+              <span className="hidden sm:inline">Settings</span>
+            ) : null}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          <DropdownMenuLabel>Settings</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onSelect={() => {
+              setSection("map");
+              setOpen(true);
+            }}
+          >
+            <MapPinned className="mr-2 h-3.5 w-3.5" />
+            Map Preferences
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={() => {
+              setSection("environment");
+              setOpen(true);
+            }}
+          >
+            <Braces className="mr-2 h-3.5 w-3.5" />
+            Environment Variables
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={() => {
+              setSection("project");
+              setOpen(true);
+            }}
+          >
+            <FolderCog className="mr-2 h-3.5 w-3.5" />
+            Project Settings
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-h-[min(88vh,760px)] max-w-3xl overflow-hidden p-0">
+          <DialogHeader className="border-b px-6 pb-4 pt-6">
+            <DialogTitle>Settings</DialogTitle>
+            <DialogDescription>
+              Configure project preferences and runtime settings.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid min-h-0 grid-cols-1 md:grid-cols-[12rem_1fr]">
+            <nav className="flex gap-1 border-b p-3 md:flex-col md:border-b-0 md:border-r">
+              {SECTION_ITEMS.map(renderSectionButton)}
+            </nav>
+            <div className="min-h-0 overflow-y-auto p-6">
+              {section === "map" ? (
+                <div className="space-y-5">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <h3 className="text-sm font-semibold">Map constraints</h3>
+                      <p className="text-xs text-muted-foreground">
+                        Limits apply while the project is open.
+                      </p>
+                    </div>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={resetMapPreferences}
+                    >
+                      <RotateCcw className="h-3.5 w-3.5" />
+                      Reset
+                    </Button>
+                  </div>
+                  <label className="flex items-center gap-2 text-sm">
+                    <input
+                      className="h-4 w-4"
+                      type="checkbox"
+                      checked={draftPreferences.map.restrictBounds}
+                      onChange={(event) =>
+                        updateMapPreferences({
+                          restrictBounds: event.target.checked,
+                        })
+                      }
+                    />
+                    Restrict map bounds
+                  </label>
+                  <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+                    {[
+                      ["West", 0, -180, 180],
+                      ["South", 1, -85, 85],
+                      ["East", 2, -180, 180],
+                      ["North", 3, -85, 85],
+                    ].map(([label, index, min, max]) => (
+                      <div key={label} className="space-y-1.5">
+                        <Label htmlFor={`settings-bounds-${index}`}>
+                          {label}
+                        </Label>
+                        <Input
+                          id={`settings-bounds-${index}`}
+                          type="number"
+                          min={min}
+                          max={max}
+                          step="0.000001"
+                          value={draftPreferences.map.bounds[index as number]}
+                          onChange={(event) =>
+                            updateBoundsValue(
+                              index as number,
+                              event.target.valueAsNumber,
+                            )
+                          }
+                        />
+                      </div>
+                    ))}
+                  </div>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={useCurrentViewBounds}
+                  >
+                    <Crosshair className="h-3.5 w-3.5" />
+                    Use Current View
+                  </Button>
+                  <div className="grid gap-3 sm:grid-cols-3">
+                    <div className="space-y-1.5">
+                      <Label htmlFor="settings-min-zoom">Min zoom</Label>
+                      <Input
+                        id="settings-min-zoom"
+                        type="number"
+                        min={0}
+                        max={24}
+                        step={0.25}
+                        value={draftPreferences.map.minZoom}
+                        onChange={(event) =>
+                          updateMapPreferences({
+                            minZoom: event.target.valueAsNumber,
+                          })
+                        }
+                      />
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="settings-max-zoom">Max zoom</Label>
+                      <Input
+                        id="settings-max-zoom"
+                        type="number"
+                        min={0}
+                        max={24}
+                        step={0.25}
+                        value={draftPreferences.map.maxZoom}
+                        onChange={(event) =>
+                          updateMapPreferences({
+                            maxZoom: event.target.valueAsNumber,
+                          })
+                        }
+                      />
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="settings-max-pitch">Max pitch</Label>
+                      <Input
+                        id="settings-max-pitch"
+                        type="number"
+                        min={0}
+                        max={85}
+                        step={1}
+                        value={draftPreferences.map.maxPitch}
+                        onChange={(event) =>
+                          updateMapPreferences({
+                            maxPitch: event.target.valueAsNumber,
+                          })
+                        }
+                      />
+                    </div>
+                  </div>
+                  <label className="flex items-center gap-2 text-sm">
+                    <input
+                      className="h-4 w-4"
+                      type="checkbox"
+                      checked={draftPreferences.map.renderWorldCopies}
+                      onChange={(event) =>
+                        updateMapPreferences({
+                          renderWorldCopies: event.target.checked,
+                        })
+                      }
+                    />
+                    Render world copies
+                  </label>
+                </div>
+              ) : null}
+              {section === "environment" ? (
+                <div className="space-y-5">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <h3 className="text-sm font-semibold">
+                        Environment variables
+                      </h3>
+                      <p className="text-xs text-muted-foreground">
+                        {enabledVariableCount} enabled runtime variable
+                        {enabledVariableCount === 1 ? "" : "s"}.
+                      </p>
+                    </div>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={addEnvironmentVariable}
+                    >
+                      <Plus className="h-3.5 w-3.5" />
+                      Add
+                    </Button>
+                  </div>
+                  {draftPreferences.environmentVariables.length === 0 ? (
+                    <div className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+                      No environment variables configured.
+                    </div>
+                  ) : (
+                    <div className="space-y-2">
+                      {draftPreferences.environmentVariables.map(
+                        (variable, index) => (
+                          <div
+                            key={index}
+                            className="grid grid-cols-[1.25rem_minmax(7rem,1fr)_minmax(7rem,1fr)_2rem] items-center gap-2"
+                          >
+                            <input
+                              aria-label={`Enable ${variable.key || "variable"}`}
+                              className="h-4 w-4"
+                              type="checkbox"
+                              checked={variable.enabled}
+                              onChange={(event) =>
+                                updateEnvironmentVariable(index, {
+                                  enabled: event.target.checked,
+                                })
+                              }
+                            />
+                            <Input
+                              aria-label="Variable name"
+                              placeholder="VITE_EXAMPLE_KEY"
+                              value={variable.key}
+                              onChange={(event) =>
+                                updateEnvironmentVariable(index, {
+                                  key: event.target.value,
+                                })
+                              }
+                            />
+                            <Input
+                              aria-label="Variable value"
+                              placeholder="Value"
+                              value={variable.value}
+                              onChange={(event) =>
+                                updateEnvironmentVariable(index, {
+                                  value: event.target.value,
+                                })
+                              }
+                            />
+                            <Button
+                              aria-label={`Remove ${variable.key || "variable"}`}
+                              className="h-8 w-8"
+                              type="button"
+                              size="icon"
+                              variant="ghost"
+                              onClick={() => removeEnvironmentVariable(index)}
+                            >
+                              <Trash2 className="h-3.5 w-3.5" />
+                            </Button>
+                          </div>
+                        ),
+                      )}
+                    </div>
+                  )}
+                </div>
+              ) : null}
+              {section === "project" ? (
+                <div className="space-y-5">
+                  <div>
+                    <h3 className="text-sm font-semibold">Project</h3>
+                    <p className="text-xs text-muted-foreground">
+                      Settings are saved with the `.geolibre.json` project.
+                    </p>
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="settings-project-name">Name</Label>
+                    <Input
+                      id="settings-project-name"
+                      value={draftProjectName}
+                      onChange={(event) =>
+                        setDraftProjectName(event.target.value)
+                      }
+                    />
+                  </div>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <div className="space-y-1.5">
+                      <Label>Project file</Label>
+                      <div className="min-h-9 truncate rounded-md border bg-muted px-3 py-2 text-sm text-muted-foreground">
+                        {projectPath ?? "Not saved"}
+                      </div>
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label>Project format</Label>
+                      <div className="min-h-9 rounded-md border bg-muted px-3 py-2 text-sm text-muted-foreground">
+                        {PROJECT_VERSION}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          </div>
+          {error ? (
+            <div className="border-t px-6 py-2 text-sm text-destructive">
+              {error}
+            </div>
+          ) : null}
+          <div className="flex justify-end gap-2 border-t px-6 py-4">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="button" onClick={saveSettings}>
+              Save Settings
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -240,7 +240,7 @@ export function SettingsDialog({
     setError(null);
   };
 
-  const useCurrentViewBounds = () => {
+  const applyCurrentViewBounds = () => {
     const bounds = mapControllerRef.current?.readView().bbox;
     if (!bounds) {
       setError("The map bounds are not available yet.");
@@ -420,7 +420,7 @@ export function SettingsDialog({
                     type="button"
                     size="sm"
                     variant="outline"
-                    onClick={useCurrentViewBounds}
+                    onClick={applyCurrentViewBounds}
                   >
                     <Crosshair className="h-3.5 w-3.5" />
                     Use Current View

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -57,11 +57,30 @@ const SECTION_ITEMS: Array<{
 
 const VARIABLE_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
-function clonePreferences(preferences: ProjectPreferences): ProjectPreferences {
+// Draft env vars carry a stable client-side id so React can key the rows by
+// identity. Keying by array index reuses input DOM state (focus, cursor)
+// across the wrong item after a mid-list delete.
+interface DraftEnvironmentVariable extends RuntimeEnvironmentVariable {
+  id: string;
+}
+
+interface DraftPreferences {
+  map: MapPreferences;
+  environmentVariables: DraftEnvironmentVariable[];
+}
+
+function createDraftId(): string {
+  return typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function clonePreferences(preferences: ProjectPreferences): DraftPreferences {
   return {
     map: { ...preferences.map },
     environmentVariables: preferences.environmentVariables.map((variable) => ({
       ...variable,
+      id: createDraftId(),
     })),
   };
 }
@@ -143,7 +162,7 @@ export function SettingsDialog({
   const setProjectName = useAppStore((s) => s.setProjectName);
   const [open, setOpen] = useState(false);
   const [section, setSection] = useState<SettingsSection>("map");
-  const [draftPreferences, setDraftPreferences] = useState<ProjectPreferences>(
+  const [draftPreferences, setDraftPreferences] = useState<DraftPreferences>(
     () => clonePreferences(preferences),
   );
   const [draftProjectName, setDraftProjectName] = useState(projectName);
@@ -204,7 +223,7 @@ export function SettingsDialog({
       ...current,
       environmentVariables: [
         ...current.environmentVariables,
-        { key: "", value: "", enabled: true },
+        { id: createDraftId(), key: "", value: "", enabled: true },
       ],
     }));
     setSection("environment");
@@ -502,7 +521,7 @@ export function SettingsDialog({
                       {draftPreferences.environmentVariables.map(
                         (variable, index) => (
                           <div
-                            key={index}
+                            key={variable.id}
                             className="grid grid-cols-[1.25rem_minmax(7rem,1fr)_minmax(7rem,1fr)_2rem] items-center gap-2"
                           >
                             <input

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -175,12 +175,15 @@ export function SettingsDialog({
     [draftPreferences.environmentVariables],
   );
 
+  // Seed the draft from the store only when the dialog opens. Depending on
+  // preferences/projectName would reset in-progress edits if the store changed
+  // while the dialog is open (e.g. a slow ?url= project finishes loading).
   useEffect(() => {
     if (!open) return;
-    setDraftPreferences(clonePreferences(preferences));
-    setDraftProjectName(projectName);
+    setDraftPreferences(clonePreferences(useAppStore.getState().preferences));
+    setDraftProjectName(useAppStore.getState().projectName);
     setError(null);
-  }, [open, preferences, projectName]);
+  }, [open]);
 
   const updateMapPreferences = (patch: Partial<MapPreferences>) => {
     setDraftPreferences((current) => ({

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -26,6 +26,8 @@ import type { MapController } from "@geolibre/map";
 import {
   Braces,
   Crosshair,
+  Eye,
+  EyeOff,
   FolderCog,
   MapPinned,
   Plus,
@@ -168,6 +170,11 @@ export function SettingsDialog({
   );
   const [draftProjectName, setDraftProjectName] = useState(projectName);
   const [error, setError] = useState<string | null>(null);
+  // Ids of variables whose value is temporarily revealed; values are masked
+  // by default so secrets are not shown on screen.
+  const [revealedValueIds, setRevealedValueIds] = useState<Set<string>>(
+    () => new Set(),
+  );
   const enabledVariableCount = useMemo(
     () =>
       draftPreferences.environmentVariables.filter(
@@ -183,8 +190,21 @@ export function SettingsDialog({
     if (!open) return;
     setDraftPreferences(clonePreferences(useAppStore.getState().preferences));
     setDraftProjectName(useAppStore.getState().projectName);
+    setRevealedValueIds(new Set());
     setError(null);
   }, [open]);
+
+  const toggleValueVisibility = (id: string) => {
+    setRevealedValueIds((current) => {
+      const next = new Set(current);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
 
   const updateMapPreferences = (patch: Partial<MapPreferences>) => {
     setDraftPreferences((current) => ({
@@ -198,6 +218,9 @@ export function SettingsDialog({
     index: number,
     value: number,
   ) => {
+    // Ignore a cleared field (valueAsNumber is NaN) so it does not silently
+    // become an edge-of-range value on save; the last valid value is kept.
+    if (!Number.isFinite(value)) return;
     setDraftPreferences((current) => {
       const bounds: MapPreferences["bounds"] = [...current.map.bounds];
       bounds[index] = value;
@@ -534,7 +557,7 @@ export function SettingsDialog({
                         (variable, index) => (
                           <div
                             key={variable.id}
-                            className="grid grid-cols-[1.25rem_minmax(7rem,1fr)_minmax(7rem,1fr)_2rem] items-center gap-2"
+                            className="grid grid-cols-[1.25rem_minmax(7rem,1fr)_minmax(7rem,1fr)_2rem_2rem] items-center gap-2"
                           >
                             <input
                               aria-label={`Enable ${variable.key || "variable"}`}
@@ -560,6 +583,12 @@ export function SettingsDialog({
                             <Input
                               aria-label="Variable value"
                               placeholder="Value"
+                              type={
+                                revealedValueIds.has(variable.id)
+                                  ? "text"
+                                  : "password"
+                              }
+                              autoComplete="off"
                               value={variable.value}
                               onChange={(event) =>
                                 updateEnvironmentVariable(index, {
@@ -567,6 +596,24 @@ export function SettingsDialog({
                                 })
                               }
                             />
+                            <Button
+                              aria-label={
+                                revealedValueIds.has(variable.id)
+                                  ? `Hide value for ${variable.key || "variable"}`
+                                  : `Show value for ${variable.key || "variable"}`
+                              }
+                              className="h-8 w-8"
+                              type="button"
+                              size="icon"
+                              variant="ghost"
+                              onClick={() => toggleValueVisibility(variable.id)}
+                            >
+                              {revealedValueIds.has(variable.id) ? (
+                                <EyeOff className="h-3.5 w-3.5" />
+                              ) : (
+                                <Eye className="h-3.5 w-3.5" />
+                              )}
+                            </Button>
                             <Button
                               aria-label={`Remove ${variable.key || "variable"}`}
                               className="h-8 w-8"

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -81,6 +81,7 @@ import { resolveProjectXyzLayers } from "../../lib/xyz-url";
 import { AddDataDialog, type AddDataKind } from "./AddDataDialog";
 import { AboutDialog } from "./AboutDialog";
 import { NewProjectDialog } from "./NewProjectDialog";
+import { SettingsDialog } from "./SettingsDialog";
 
 interface TopToolbarProps {
   compact?: boolean;
@@ -288,6 +289,7 @@ export function TopToolbar({
       basemapVisible: state.basemapVisible,
       basemapOpacity: state.basemapOpacity,
       layers: state.layers,
+      preferences: state.preferences,
       metadata: state.metadata,
     });
     const content = serializeProject(project);
@@ -647,6 +649,13 @@ export function TopToolbar({
           })}
         </DropdownMenuContent>
       </DropdownMenu>
+      <SettingsDialog
+        buttonClassName={toolbarButtonClass}
+        buttonSize={toolbarButtonSize}
+        iconClassName={toolbarIconClassName}
+        mapControllerRef={mapControllerRef}
+        showLabels={showLabels}
+      />
       <AddDataDialog
         kind={addDataKind}
         mapControllerRef={mapControllerRef}

--- a/apps/geolibre-desktop/src/hooks/useRuntimeEnvironmentVariables.ts
+++ b/apps/geolibre-desktop/src/hooks/useRuntimeEnvironmentVariables.ts
@@ -6,6 +6,7 @@ export function useRuntimeEnvironmentVariables() {
     (s) => s.preferences.environmentVariables,
   );
   const lastSerializedEnv = useRef<string | null>(null);
+  const isFirstRender = useRef(true);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -16,15 +17,27 @@ export function useRuntimeEnvironmentVariables() {
         .map((variable) => [variable.key.trim(), variable.value]),
     );
 
-    // Skip the update when the derived env is unchanged. Saving unrelated
+    // Always keep the global env in sync so plugins can read it when they
+    // activate, even before the first change event.
+    window.__GEOLIBRE_RUNTIME_ENV__ = runtimeEnv;
+
+    // Skip the change event on the initial mount: plugins read the global
+    // directly when they activate, so dispatching here would only trigger a
+    // spurious Street View control remove/re-add on startup.
+    const serializedEnv = JSON.stringify(runtimeEnv);
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      lastSerializedEnv.current = serializedEnv;
+      return;
+    }
+
+    // Skip the dispatch when the derived env is unchanged. Saving unrelated
     // settings (e.g. map preferences) recreates the array reference without
     // changing its contents, and a redundant dispatch needlessly reinitializes
     // plugins such as Street View.
-    const serializedEnv = JSON.stringify(runtimeEnv);
     if (serializedEnv === lastSerializedEnv.current) return;
     lastSerializedEnv.current = serializedEnv;
 
-    window.__GEOLIBRE_RUNTIME_ENV__ = runtimeEnv;
     window.dispatchEvent(
       new CustomEvent("geolibre:runtime-env-change", { detail: runtimeEnv }),
     );

--- a/apps/geolibre-desktop/src/hooks/useRuntimeEnvironmentVariables.ts
+++ b/apps/geolibre-desktop/src/hooks/useRuntimeEnvironmentVariables.ts
@@ -1,10 +1,11 @@
 import { useAppStore } from "@geolibre/core";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 export function useRuntimeEnvironmentVariables() {
   const environmentVariables = useAppStore(
     (s) => s.preferences.environmentVariables,
   );
+  const lastSerializedEnv = useRef<string | null>(null);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -14,6 +15,15 @@ export function useRuntimeEnvironmentVariables() {
         .filter((variable) => variable.enabled && variable.key.trim())
         .map((variable) => [variable.key.trim(), variable.value]),
     );
+
+    // Skip the update when the derived env is unchanged. Saving unrelated
+    // settings (e.g. map preferences) recreates the array reference without
+    // changing its contents, and a redundant dispatch needlessly reinitializes
+    // plugins such as Street View.
+    const serializedEnv = JSON.stringify(runtimeEnv);
+    if (serializedEnv === lastSerializedEnv.current) return;
+    lastSerializedEnv.current = serializedEnv;
+
     window.__GEOLIBRE_RUNTIME_ENV__ = runtimeEnv;
     window.dispatchEvent(
       new CustomEvent("geolibre:runtime-env-change", { detail: runtimeEnv }),

--- a/apps/geolibre-desktop/src/hooks/useRuntimeEnvironmentVariables.ts
+++ b/apps/geolibre-desktop/src/hooks/useRuntimeEnvironmentVariables.ts
@@ -1,0 +1,22 @@
+import { useAppStore } from "@geolibre/core";
+import { useEffect } from "react";
+
+export function useRuntimeEnvironmentVariables() {
+  const environmentVariables = useAppStore(
+    (s) => s.preferences.environmentVariables,
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const runtimeEnv = Object.fromEntries(
+      environmentVariables
+        .filter((variable) => variable.enabled && variable.key.trim())
+        .map((variable) => [variable.key.trim(), variable.value]),
+    );
+    window.__GEOLIBRE_RUNTIME_ENV__ = runtimeEnv;
+    window.dispatchEvent(
+      new CustomEvent("geolibre:runtime-env-change", { detail: runtimeEnv }),
+    );
+  }, [environmentVariables]);
+}

--- a/apps/geolibre-desktop/src/vite-env.d.ts
+++ b/apps/geolibre-desktop/src/vite-env.d.ts
@@ -2,6 +2,10 @@
 
 declare const __GEOLIBRE_VERSION__: string;
 
+interface Window {
+  __GEOLIBRE_RUNTIME_ENV__?: Record<string, string>;
+}
+
 declare module "*.geojson?url" {
   const url: string;
   export default url;

--- a/apps/geolibre-desktop/src/vite-env.d.ts
+++ b/apps/geolibre-desktop/src/vite-env.d.ts
@@ -2,10 +2,6 @@
 
 declare const __GEOLIBRE_VERSION__: string;
 
-interface Window {
-  __GEOLIBRE_RUNTIME_ENV__?: Record<string, string>;
-}
-
 declare module "*.geojson?url" {
   const url: string;
   export default url;

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -1,11 +1,14 @@
 import {
   DEFAULT_BASEMAP,
   DEFAULT_LAYER_STYLE,
+  DEFAULT_PROJECT_PREFERENCES,
   PROJECT_VERSION,
   type GeoLibreLayer,
   type GeoLibreProject,
   type LayerStyle,
   type MapViewState,
+  type ProjectPreferences,
+  type RuntimeEnvironmentVariable,
 } from "./types";
 
 export interface CreateProjectOptions {
@@ -35,6 +38,7 @@ export function createEmptyProject(
     basemapOpacity: 1,
     layers: [],
     styles: {},
+    preferences: DEFAULT_PROJECT_PREFERENCES,
     metadata: {},
   };
 }
@@ -57,7 +61,85 @@ export function parseProject(json: string): GeoLibreProject {
     basemapOpacity: data.basemapOpacity ?? 1,
     layers: (data.layers ?? []).map(normalizeLayer),
     styles: data.styles ?? {},
+    preferences: normalizeProjectPreferences(data.preferences),
     metadata: data.metadata ?? {},
+  };
+}
+
+function normalizeProjectPreferences(
+  preferences: unknown,
+): ProjectPreferences {
+  if (!preferences || typeof preferences !== "object") {
+    return DEFAULT_PROJECT_PREFERENCES;
+  }
+
+  const candidate = preferences as Partial<ProjectPreferences>;
+  const map = candidate.map ?? {};
+  return {
+    map: {
+      ...DEFAULT_PROJECT_PREFERENCES.map,
+      ...map,
+      bounds: normalizeBounds(
+        (map as Partial<ProjectPreferences["map"]>).bounds,
+      ),
+      minZoom: normalizeNumber(
+        (map as Partial<ProjectPreferences["map"]>).minZoom,
+        DEFAULT_PROJECT_PREFERENCES.map.minZoom,
+      ),
+      maxZoom: normalizeNumber(
+        (map as Partial<ProjectPreferences["map"]>).maxZoom,
+        DEFAULT_PROJECT_PREFERENCES.map.maxZoom,
+      ),
+      maxPitch: normalizeNumber(
+        (map as Partial<ProjectPreferences["map"]>).maxPitch,
+        DEFAULT_PROJECT_PREFERENCES.map.maxPitch,
+      ),
+      restrictBounds: Boolean(
+        (map as Partial<ProjectPreferences["map"]>).restrictBounds,
+      ),
+      renderWorldCopies:
+        (map as Partial<ProjectPreferences["map"]>).renderWorldCopies ?? true,
+    },
+    environmentVariables: Array.isArray(candidate.environmentVariables)
+      ? candidate.environmentVariables
+          .map(normalizeEnvironmentVariable)
+          .filter((variable): variable is RuntimeEnvironmentVariable =>
+            Boolean(variable),
+          )
+      : [],
+  };
+}
+
+function normalizeBounds(
+  bounds: unknown,
+): ProjectPreferences["map"]["bounds"] {
+  if (
+    Array.isArray(bounds) &&
+    bounds.length === 4 &&
+    bounds.every((value) => Number.isFinite(value))
+  ) {
+    return bounds as ProjectPreferences["map"]["bounds"];
+  }
+
+  return DEFAULT_PROJECT_PREFERENCES.map.bounds;
+}
+
+function normalizeNumber(value: unknown, fallback: number): number {
+  return Number.isFinite(value) ? Number(value) : fallback;
+}
+
+function normalizeEnvironmentVariable(
+  variable: unknown,
+): RuntimeEnvironmentVariable | null {
+  if (!variable || typeof variable !== "object") return null;
+  const candidate = variable as Partial<RuntimeEnvironmentVariable>;
+  const key = typeof candidate.key === "string" ? candidate.key.trim() : "";
+  if (!key) return null;
+
+  return {
+    key,
+    value: typeof candidate.value === "string" ? candidate.value : "",
+    enabled: candidate.enabled ?? true,
   };
 }
 
@@ -79,6 +161,7 @@ export function projectFromStore(state: {
   basemapVisible: boolean;
   basemapOpacity: number;
   layers: GeoLibreLayer[];
+  preferences: ProjectPreferences;
   metadata: Record<string, unknown>;
 }): GeoLibreProject {
   const styles: Record<string, LayerStyle> = {};
@@ -94,6 +177,7 @@ export function projectFromStore(state: {
     basemapOpacity: state.basemapOpacity,
     layers: state.layers.map(prepareLayerForSave),
     styles,
+    preferences: state.preferences,
     metadata: state.metadata,
   };
 }
@@ -131,6 +215,7 @@ export function applyProjectToStore(project: GeoLibreProject): {
   basemapVisible: boolean;
   basemapOpacity: number;
   layers: GeoLibreLayer[];
+  preferences: ProjectPreferences;
   metadata: Record<string, unknown>;
 } {
   const layers = project.layers.map((layer) => ({
@@ -146,6 +231,7 @@ export function applyProjectToStore(project: GeoLibreProject): {
     basemapVisible: project.basemapVisible ?? true,
     basemapOpacity: project.basemapOpacity ?? 1,
     layers,
+    preferences: normalizeProjectPreferences(project.preferences),
     metadata: project.metadata,
   };
 }

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -97,8 +97,10 @@ function normalizeProjectPreferences(
       restrictBounds: Boolean(
         (map as Partial<ProjectPreferences["map"]>).restrictBounds,
       ),
-      renderWorldCopies:
-        (map as Partial<ProjectPreferences["map"]>).renderWorldCopies ?? true,
+      renderWorldCopies: normalizeBoolean(
+        (map as Partial<ProjectPreferences["map"]>).renderWorldCopies,
+        true,
+      ),
     },
     environmentVariables: Array.isArray(candidate.environmentVariables)
       ? candidate.environmentVariables
@@ -128,18 +130,24 @@ function normalizeNumber(value: unknown, fallback: number): number {
   return Number.isFinite(value) ? Number(value) : fallback;
 }
 
+function normalizeBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+const ENVIRONMENT_VARIABLE_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
 function normalizeEnvironmentVariable(
   variable: unknown,
 ): RuntimeEnvironmentVariable | null {
   if (!variable || typeof variable !== "object") return null;
   const candidate = variable as Partial<RuntimeEnvironmentVariable>;
   const key = typeof candidate.key === "string" ? candidate.key.trim() : "";
-  if (!key) return null;
+  if (!key || !ENVIRONMENT_VARIABLE_NAME_PATTERN.test(key)) return null;
 
   return {
     key,
     value: typeof candidate.value === "string" ? candidate.value : "",
-    enabled: candidate.enabled ?? true,
+    enabled: normalizeBoolean(candidate.enabled, true),
   };
 }
 

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -118,11 +118,18 @@ function normalizeBounds(
   if (
     Array.isArray(bounds) &&
     bounds.length === 4 &&
-    bounds.every((value) => Number.isFinite(value)) &&
-    bounds[0] < bounds[2] &&
-    bounds[1] < bounds[3]
+    bounds.every((value) => Number.isFinite(value))
   ) {
-    return bounds as ProjectPreferences["map"]["bounds"];
+    // Clamp to valid lng/lat ranges so the stored bounds match what the map
+    // controller applies, then keep the ordering check so an empty or
+    // inverted region falls back to the default instead of being persisted.
+    const west = clampCoordinate(Number(bounds[0]), -180, 180);
+    const south = clampCoordinate(Number(bounds[1]), -85, 85);
+    const east = clampCoordinate(Number(bounds[2]), -180, 180);
+    const north = clampCoordinate(Number(bounds[3]), -85, 85);
+    if (west < east && south < north) {
+      return [west, south, east, north];
+    }
   }
 
   return DEFAULT_PROJECT_PREFERENCES.map.bounds;
@@ -130,6 +137,10 @@ function normalizeBounds(
 
 function normalizeNumber(value: unknown, fallback: number): number {
   return Number.isFinite(value) ? Number(value) : fallback;
+}
+
+function clampCoordinate(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
 }
 
 function normalizeBoolean(value: unknown, fallback: boolean): boolean {

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -75,10 +75,12 @@ function normalizeProjectPreferences(
 
   const candidate = preferences as Partial<ProjectPreferences>;
   const map = candidate.map ?? {};
+  // Every MapPreferences field is normalized explicitly below, so the map
+  // object is not spread in: that would forward unknown keys from a
+  // hand-edited project file straight into app state.
   return {
     map: {
       ...DEFAULT_PROJECT_PREFERENCES.map,
-      ...map,
       bounds: normalizeBounds(
         (map as Partial<ProjectPreferences["map"]>).bounds,
       ),

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -118,7 +118,9 @@ function normalizeBounds(
   if (
     Array.isArray(bounds) &&
     bounds.length === 4 &&
-    bounds.every((value) => Number.isFinite(value))
+    bounds.every((value) => Number.isFinite(value)) &&
+    bounds[0] < bounds[2] &&
+    bounds[1] < bounds[3]
   ) {
     return bounds as ProjectPreferences["map"]["bounds"];
   }

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -10,10 +10,12 @@ import {
 import {
   DEFAULT_BASEMAP,
   DEFAULT_LAYER_STYLE,
+  DEFAULT_PROJECT_PREFERENCES,
   type GeoLibreLayer,
   type GeoLibreProject,
   type LayerStyle,
   type MapViewState,
+  type ProjectPreferences,
   type RecentProjectEntry,
 } from "./types";
 
@@ -26,6 +28,7 @@ export interface AppState {
   basemapVisible: boolean;
   basemapOpacity: number;
   layers: GeoLibreLayer[];
+  preferences: ProjectPreferences;
   selectedLayerId: string | null;
   selectedFeatureId: string | null;
   identifyLayerId: string | null;
@@ -44,6 +47,7 @@ export interface AppState {
   setBasemapStyleUrl: (url: string) => void;
   setBasemapVisible: (visible: boolean) => void;
   setBasemapOpacity: (opacity: number) => void;
+  setPreferences: (preferences: ProjectPreferences) => void;
   selectLayer: (id: string | null) => void;
   selectFeature: (id: string | null) => void;
   setIdentifyLayer: (id: string | null) => void;
@@ -120,6 +124,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   basemapVisible: true,
   basemapOpacity: 1,
   layers: [],
+  preferences: DEFAULT_PROJECT_PREFERENCES,
   selectedLayerId: null,
   selectedFeatureId: null,
   identifyLayerId: null,
@@ -144,6 +149,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     set({ basemapVisible: visible, isDirty: true }),
   setBasemapOpacity: (opacity) =>
     set({ basemapOpacity: opacity, isDirty: true }),
+  setPreferences: (preferences) => set({ preferences, isDirty: true }),
   selectLayer: (id) => set({ selectedLayerId: id, selectedFeatureId: null }),
   selectFeature: (id) => set({ selectedFeatureId: id }),
   setIdentifyLayer: (id) => set({ identifyLayerId: id }),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -183,6 +183,14 @@ export interface RuntimeEnvironmentVariable {
   enabled: boolean;
 }
 
+declare global {
+  interface Window {
+    // Runtime environment variables published from project preferences. Shared
+    // here so the desktop app and plugins type the global from one source.
+    __GEOLIBRE_RUNTIME_ENV__?: Record<string, string>;
+  }
+}
+
 export interface ProjectPreferences {
   map: MapPreferences;
   environmentVariables: RuntimeEnvironmentVariable[];

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -168,6 +168,38 @@ export interface MapViewState {
   bbox?: [number, number, number, number];
 }
 
+export interface MapPreferences {
+  restrictBounds: boolean;
+  bounds: [number, number, number, number];
+  minZoom: number;
+  maxZoom: number;
+  maxPitch: number;
+  renderWorldCopies: boolean;
+}
+
+export interface RuntimeEnvironmentVariable {
+  key: string;
+  value: string;
+  enabled: boolean;
+}
+
+export interface ProjectPreferences {
+  map: MapPreferences;
+  environmentVariables: RuntimeEnvironmentVariable[];
+}
+
+export const DEFAULT_PROJECT_PREFERENCES: ProjectPreferences = {
+  map: {
+    restrictBounds: false,
+    bounds: [-180, -85, 180, 85],
+    minZoom: 0,
+    maxZoom: 24,
+    maxPitch: 85,
+    renderWorldCopies: true,
+  },
+  environmentVariables: [],
+};
+
 export interface GeoLibreProject {
   version: string;
   name: string;
@@ -177,6 +209,7 @@ export interface GeoLibreProject {
   basemapOpacity: number;
   layers: GeoLibreLayer[];
   styles: Record<string, LayerStyle>;
+  preferences: ProjectPreferences;
   metadata: Record<string, unknown>;
 }
 

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -128,6 +128,7 @@ export const MapCanvas = memo(function MapCanvas({
   const basemapStyleUrl = useAppStore((s) => s.basemapStyleUrl);
   const basemapVisible = useAppStore((s) => s.basemapVisible);
   const basemapOpacity = useAppStore((s) => s.basemapOpacity);
+  const mapPreferences = useAppStore((s) => s.preferences.map);
   const mapView = useAppStore((s) => s.mapView);
   const layers = useAppStore((s) => s.layers);
   const selectedLayerId = useAppStore((s) => s.selectedLayerId);
@@ -147,6 +148,7 @@ export const MapCanvas = memo(function MapCanvas({
     const map = mc.init(containerRef.current, {
       styleUrl: basemapStyleUrl,
       mapView,
+      mapPreferences,
     });
     controller.current = mc;
     if (controllerRef) controllerRef.current = mc;
@@ -252,6 +254,10 @@ export const MapCanvas = memo(function MapCanvas({
   useEffect(() => {
     controller.current?.setBasemapOpacity(basemapOpacity);
   }, [basemapOpacity]);
+
+  useEffect(() => {
+    controller.current?.applyMapPreferences(mapPreferences);
+  }, [mapPreferences]);
 
   useEffect(() => {
     controller.current?.waitAndSyncLayers(layers);

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -250,7 +250,10 @@ export class MapController {
       attributionControl: false,
       maplibreLogo: false,
     });
-    this.applyMapPreferences(mapPreferences);
+    // The constructor options above already apply the static constraints.
+    // The transform constraint is installed by the MapCanvas effect that
+    // fires on mount, so calling applyMapPreferences here would only add a
+    // redundant jumpTo that can interrupt the initial camera.
     const handleStyleReady = () => {
       this.styleReady = true;
       this.enforceDefaultProjection();

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -407,8 +407,11 @@ export class MapController {
     );
     const maxPitch = clampNumber(preferences.maxPitch, 0, DEFAULT_MAX_PITCH);
 
-    // Set maxZoom before minZoom so the new minZoom never exceeds the
-    // current maxZoom, which MapLibre would otherwise reject.
+    // Lower minZoom to an intermediate value first so neither setter ever
+    // violates the live min <= max relationship MapLibre validates: this
+    // covers both new minZoom > current maxZoom and new maxZoom < current
+    // minZoom. Then raise maxZoom and finally apply the real minZoom.
+    this.map.setMinZoom(Math.min(minZoom, this.map.getMinZoom()));
     this.map.setMaxZoom(maxZoom);
     this.map.setMinZoom(minZoom);
     this.map.setMaxPitch(maxPitch);

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -388,7 +388,7 @@ export class MapController {
 
   applyView(view: MapViewState): void {
     if (!this.map) return;
-    this.map.jumpTo(constrainMapView(view, this.mapPreferences));
+    this.map.jumpTo(constrainMapView(view, this.mapPreferences, this.map));
   }
 
   applyMapPreferences(preferences: MapPreferences): void {
@@ -1412,8 +1412,15 @@ function createMapTransformConstraint(
 function constrainMapView(
   view: MapViewState,
   preferences: MapPreferences,
+  map: maplibregl.Map | null,
 ): maplibregl.JumpToOptions {
-  const minZoom = clampNumber(preferences.minZoom, 0, 24);
+  const requestedMinZoom = clampNumber(preferences.minZoom, 0, 24);
+  // Use the same effective floor the transform constraint enforces so the
+  // jumpTo does not land at a zoom the constraint would immediately correct,
+  // which would show as a snap when bounds are restricted.
+  const minZoom = map
+    ? effectiveMinZoomForPreferences(preferences, map, requestedMinZoom)
+    : requestedMinZoom;
   const maxZoom = Math.max(
     minZoom,
     clampNumber(preferences.maxZoom, 0, 24),

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -404,9 +404,8 @@ export class MapController {
     );
     const maxPitch = clampNumber(preferences.maxPitch, 0, DEFAULT_MAX_PITCH);
 
-    if (minZoom <= this.map.getMaxZoom()) {
-      this.map.setMinZoom(minZoom);
-    }
+    // Set maxZoom before minZoom so the new minZoom never exceeds the
+    // current maxZoom, which MapLibre would otherwise reject.
     this.map.setMaxZoom(maxZoom);
     this.map.setMinZoom(minZoom);
     this.map.setMaxPitch(maxPitch);

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -1,5 +1,10 @@
-import { BLANK_BASEMAP, DEFAULT_BASEMAP, useAppStore } from "@geolibre/core";
-import type { GeoLibreLayer, MapViewState } from "@geolibre/core";
+import {
+  BLANK_BASEMAP,
+  DEFAULT_BASEMAP,
+  DEFAULT_PROJECT_PREFERENCES,
+  useAppStore,
+} from "@geolibre/core";
+import type { GeoLibreLayer, MapPreferences, MapViewState } from "@geolibre/core";
 import bbox from "@turf/bbox";
 import type { Feature, FeatureCollection, Geometry } from "geojson";
 import maplibregl from "maplibre-gl";
@@ -200,6 +205,7 @@ export class MapController {
   private basemapStyleUrl = DEFAULT_BASEMAP;
   private basemapVisible = true;
   private basemapOpacity = 1;
+  private mapPreferences: MapPreferences = DEFAULT_PROJECT_PREFERENCES.map;
   private basemapOriginalPaintValues = new Map<string, Map<string, unknown>>();
   private syncedLayers: GeoLibreLayer[] = [];
   private layerIds: string[] = [];
@@ -219,9 +225,15 @@ export class MapController {
     options: {
       styleUrl?: string;
       mapView?: MapViewState;
+      mapPreferences?: MapPreferences;
     },
   ): maplibregl.Map {
     const view = options.mapView;
+    const mapPreferences = options.mapPreferences ?? this.mapPreferences;
+    const minZoom = clampNumber(mapPreferences.minZoom, 0, 24);
+    const maxZoom = Math.max(minZoom, clampNumber(mapPreferences.maxZoom, 0, 24));
+    const maxPitch = clampNumber(mapPreferences.maxPitch, 0, DEFAULT_MAX_PITCH);
+    this.mapPreferences = mapPreferences;
     this.basemapStyleUrl = options.styleUrl ?? DEFAULT_BASEMAP;
     this.map = new maplibregl.Map({
       container,
@@ -230,10 +242,15 @@ export class MapController {
       zoom: view?.zoom ?? 2,
       bearing: view?.bearing ?? 0,
       pitch: view?.pitch ?? 0,
-      maxPitch: DEFAULT_MAX_PITCH,
+      minZoom,
+      maxZoom,
+      maxPitch,
+      maxBounds: mapBoundsForPreferences(mapPreferences) ?? undefined,
+      renderWorldCopies: mapPreferences.renderWorldCopies,
       attributionControl: false,
       maplibreLogo: false,
     });
+    this.applyMapPreferences(mapPreferences);
     const handleStyleReady = () => {
       this.styleReady = true;
       this.enforceDefaultProjection();
@@ -368,12 +385,37 @@ export class MapController {
 
   applyView(view: MapViewState): void {
     if (!this.map) return;
-    this.map.jumpTo({
-      center: view.center,
-      zoom: view.zoom,
-      bearing: view.bearing,
-      pitch: view.pitch,
-    });
+    this.map.jumpTo(constrainMapView(view, this.mapPreferences));
+  }
+
+  applyMapPreferences(preferences: MapPreferences): void {
+    if (!this.map) return;
+    this.mapPreferences = preferences;
+
+    const requestedMinZoom = clampNumber(preferences.minZoom, 0, 24);
+    const minZoom = effectiveMinZoomForPreferences(
+      preferences,
+      this.map,
+      requestedMinZoom,
+    );
+    const maxZoom = Math.max(
+      minZoom,
+      clampNumber(preferences.maxZoom, 0, 24),
+    );
+    const maxPitch = clampNumber(preferences.maxPitch, 0, DEFAULT_MAX_PITCH);
+
+    if (minZoom <= this.map.getMaxZoom()) {
+      this.map.setMinZoom(minZoom);
+    }
+    this.map.setMaxZoom(maxZoom);
+    this.map.setMinZoom(minZoom);
+    this.map.setMaxPitch(maxPitch);
+    this.map.setRenderWorldCopies(preferences.renderWorldCopies);
+    this.map.setMaxBounds(mapBoundsForPreferences(preferences));
+    this.map.setTransformConstrain(
+      createMapTransformConstraint(preferences, this.map, minZoom, maxZoom),
+    );
+    this.applyView(this.readView());
   }
 
   readView(): MapViewState {
@@ -1324,6 +1366,194 @@ export class MapController {
     else if (control === "logo") this.removeLogoControl();
     else this.removeLayerControl();
   }
+}
+
+function clampNumber(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(max, Math.max(min, value));
+}
+
+function createMapTransformConstraint(
+  preferences: MapPreferences,
+  map: maplibregl.Map,
+  minZoom: number,
+  maxZoom: number,
+): Parameters<maplibregl.Map["setTransformConstrain"]>[0] {
+  return (lngLat, zoom) => {
+    const constrainedZoom = clampNumber(zoom, minZoom, maxZoom);
+    const bounds =
+      preferences.restrictBounds && normalizeMapBounds(preferences.bounds);
+    if (!bounds) {
+      return {
+        center: new maplibregl.LngLat(
+          preferences.renderWorldCopies
+            ? lngLat.lng
+            : clampNumber(lngLat.lng, -180, 180),
+          clampNumber(lngLat.lat, -85, 85),
+        ),
+        zoom: constrainedZoom,
+      };
+    }
+
+    return {
+      center: constrainCenterToVisibleBounds(
+        [lngLat.lng, lngLat.lat],
+        bounds,
+        map,
+        constrainedZoom,
+      ),
+      zoom: constrainedZoom,
+    };
+  };
+}
+
+function constrainMapView(
+  view: MapViewState,
+  preferences: MapPreferences,
+): maplibregl.JumpToOptions {
+  const minZoom = clampNumber(preferences.minZoom, 0, 24);
+  const maxZoom = Math.max(
+    minZoom,
+    clampNumber(preferences.maxZoom, 0, 24),
+  );
+
+  return {
+    center: [
+      preferences.renderWorldCopies
+        ? view.center[0]
+        : clampNumber(view.center[0], -180, 180),
+      clampNumber(view.center[1], -85, 85),
+    ],
+    zoom: clampNumber(view.zoom, minZoom, maxZoom),
+    bearing: view.bearing,
+    pitch: clampNumber(
+      view.pitch,
+      0,
+      clampNumber(preferences.maxPitch, 0, DEFAULT_MAX_PITCH),
+    ),
+  };
+}
+
+function effectiveMinZoomForPreferences(
+  preferences: MapPreferences,
+  map: maplibregl.Map,
+  requestedMinZoom: number,
+): number {
+  const bounds =
+    preferences.restrictBounds && normalizeMapBounds(preferences.bounds);
+  if (!bounds) return requestedMinZoom;
+
+  const mercatorBounds = mercatorBoundsForLngLatBounds(bounds);
+  const widthRatio = Math.abs(mercatorBounds.east - mercatorBounds.west);
+  const heightRatio = Math.abs(mercatorBounds.south - mercatorBounds.north);
+  if (widthRatio <= 0 || heightRatio <= 0) return requestedMinZoom;
+
+  const canvas = map.getCanvas();
+  const minZoomForWidth = Math.log2(canvas.clientWidth / (512 * widthRatio));
+  const minZoomForHeight = Math.log2(canvas.clientHeight / (512 * heightRatio));
+
+  return clampNumber(
+    Math.max(requestedMinZoom, minZoomForWidth, minZoomForHeight),
+    0,
+    24,
+  );
+}
+
+function constrainCenterToVisibleBounds(
+  center: [number, number],
+  bounds: MapPreferences["bounds"],
+  map: maplibregl.Map,
+  zoom: number,
+): maplibregl.LngLat {
+  const mercatorBounds = mercatorBoundsForLngLatBounds(bounds);
+  const worldSize = 512 * 2 ** zoom;
+  const halfWidth = map.getCanvas().clientWidth / (2 * worldSize);
+  const halfHeight = map.getCanvas().clientHeight / (2 * worldSize);
+  const centerMercator = {
+    x: mercatorXFromLng(center[0]),
+    y: mercatorYFromLat(center[1]),
+  };
+  const minX = mercatorBounds.west + halfWidth;
+  const maxX = mercatorBounds.east - halfWidth;
+  const minY = mercatorBounds.north + halfHeight;
+  const maxY = mercatorBounds.south - halfHeight;
+
+  return new maplibregl.LngLat(
+    lngFromMercatorX(
+      minX <= maxX
+        ? clampNumber(centerMercator.x, minX, maxX)
+        : (mercatorBounds.west + mercatorBounds.east) / 2,
+    ),
+    latFromMercatorY(
+      minY <= maxY
+        ? clampNumber(centerMercator.y, minY, maxY)
+        : (mercatorBounds.north + mercatorBounds.south) / 2,
+    ),
+  );
+}
+
+function mercatorBoundsForLngLatBounds(bounds: MapPreferences["bounds"]): {
+  west: number;
+  south: number;
+  east: number;
+  north: number;
+} {
+  return {
+    west: mercatorXFromLng(bounds[0]),
+    south: mercatorYFromLat(bounds[1]),
+    east: mercatorXFromLng(bounds[2]),
+    north: mercatorYFromLat(bounds[3]),
+  };
+}
+
+function mercatorXFromLng(lng: number): number {
+  return (lng + 180) / 360;
+}
+
+function lngFromMercatorX(x: number): number {
+  return x * 360 - 180;
+}
+
+function mercatorYFromLat(lat: number): number {
+  const radians = (clampNumber(lat, -85, 85) * Math.PI) / 180;
+  return (
+    (1 - Math.log(Math.tan(radians) + 1 / Math.cos(radians)) / Math.PI) / 2
+  );
+}
+
+function latFromMercatorY(y: number): number {
+  return (Math.atan(Math.sinh(Math.PI * (1 - 2 * y))) * 180) / Math.PI;
+}
+
+function normalizeMapBounds(
+  bounds: MapPreferences["bounds"],
+): MapPreferences["bounds"] | null {
+  const [west, south, east, north] = bounds;
+  if (![west, south, east, north].every(Number.isFinite)) return null;
+  const normalized: MapPreferences["bounds"] = [
+    clampNumber(west, -180, 180),
+    clampNumber(south, -85, 85),
+    clampNumber(east, -180, 180),
+    clampNumber(north, -85, 85),
+  ];
+  if (normalized[0] >= normalized[2] || normalized[1] >= normalized[3]) {
+    return null;
+  }
+
+  return normalized;
+}
+
+function mapBoundsForPreferences(
+  preferences: MapPreferences,
+): maplibregl.LngLatBoundsLike | null {
+  const bounds =
+    preferences.restrictBounds && normalizeMapBounds(preferences.bounds);
+  if (!bounds) return null;
+
+  return [
+    [bounds[0], bounds[1]],
+    [bounds[2], bounds[3]],
+  ];
 }
 
 export function createMapController(): MapController {

--- a/packages/plugins/src/plugins/maplibre-streetview.ts
+++ b/packages/plugins/src/plugins/maplibre-streetview.ts
@@ -14,16 +14,13 @@ const streetViewEnv = (
   }
 ).env;
 
-interface StreetViewRuntimeWindow extends Window {
-  __GEOLIBRE_RUNTIME_ENV__?: Record<string, string>;
-}
-
 function getRuntimeEnvironment(): Record<string, string | undefined> {
   if (typeof window === "undefined") return streetViewEnv ?? {};
 
+  // __GEOLIBRE_RUNTIME_ENV__ is declared globally in @geolibre/core.
   return {
     ...(streetViewEnv ?? {}),
-    ...((window as StreetViewRuntimeWindow).__GEOLIBRE_RUNTIME_ENV__ ?? {}),
+    ...(window.__GEOLIBRE_RUNTIME_ENV__ ?? {}),
   };
 }
 

--- a/packages/plugins/src/plugins/maplibre-streetview.ts
+++ b/packages/plugins/src/plugins/maplibre-streetview.ts
@@ -120,6 +120,10 @@ function addRuntimeEnvListener(): void {
     const added = activeApp.addMapControl(streetViewControl, streetViewPosition);
     if (!added) {
       streetViewControl = null;
+      // Tear down the listener too, otherwise it stays registered while
+      // streetViewControl is null and every later event short-circuits,
+      // silently breaking credential updates for the rest of the session.
+      cleanupRuntimeEnvListener();
       return;
     }
     setTimeout(() => streetViewControl?.expand(), 0);

--- a/packages/plugins/src/plugins/maplibre-streetview.ts
+++ b/packages/plugins/src/plugins/maplibre-streetview.ts
@@ -14,16 +14,39 @@ const streetViewEnv = (
   }
 ).env;
 
-const googleApiKey = streetViewEnv?.VITE_GOOGLE_MAPS_API_KEY;
-const mapillaryAccessToken = streetViewEnv?.VITE_MAPILLARY_ACCESS_TOKEN;
+interface StreetViewRuntimeWindow extends Window {
+  __GEOLIBRE_RUNTIME_ENV__?: Record<string, string>;
+}
 
-// Pick a default provider that actually has credentials so the panel does not
-// open onto a provider it cannot authenticate. Google wins when both are set.
-const defaultProvider: StreetViewControlOptions["defaultProvider"] = googleApiKey
-  ? "google"
-  : mapillaryAccessToken
-    ? "mapillary"
-    : "google";
+function getRuntimeEnvironment(): Record<string, string | undefined> {
+  if (typeof window === "undefined") return streetViewEnv ?? {};
+
+  return {
+    ...(streetViewEnv ?? {}),
+    ...((window as StreetViewRuntimeWindow).__GEOLIBRE_RUNTIME_ENV__ ?? {}),
+  };
+}
+
+function getStreetViewCredentials(): Pick<
+  StreetViewControlOptions,
+  "defaultProvider" | "googleApiKey" | "mapillaryAccessToken"
+> {
+  const env = getRuntimeEnvironment();
+  const googleApiKey = env.VITE_GOOGLE_MAPS_API_KEY?.trim() || undefined;
+  const mapillaryAccessToken =
+    env.VITE_MAPILLARY_ACCESS_TOKEN?.trim() || undefined;
+
+  // Pick a default provider that actually has credentials so the panel does not
+  // open onto a provider it cannot authenticate. Google wins when both are set.
+  const defaultProvider: StreetViewControlOptions["defaultProvider"] =
+    googleApiKey ? "google" : mapillaryAccessToken ? "mapillary" : "google";
+
+  return {
+    defaultProvider,
+    googleApiKey,
+    mapillaryAccessToken,
+  };
+}
 
 let streetViewPosition: GeoLibreMapControlPosition = "top-right";
 
@@ -32,18 +55,22 @@ const STREET_VIEW_OPTIONS = {
   title: "Street View",
   panelWidth: 420,
   panelHeight: 320,
-  defaultProvider,
-  googleApiKey,
-  mapillaryAccessToken,
-} satisfies Omit<StreetViewControlOptions, "position">;
+} satisfies Omit<
+  StreetViewControlOptions,
+  "defaultProvider" | "googleApiKey" | "mapillaryAccessToken" | "position"
+>;
 
 let streetViewControl: StreetViewControl | null = null;
+let activeApp: GeoLibreAppAPI | null = null;
+let removeRuntimeEnvListener: (() => void) | null = null;
 
 export const maplibreStreetViewPlugin: GeoLibrePlugin = {
   id: "maplibre-gl-streetview",
   name: "Street View",
   version: "0.4.0",
   activate: (app: GeoLibreAppAPI) => {
+    activeApp = app;
+    addRuntimeEnvListener();
     if (!streetViewControl) {
       streetViewControl = new StreetViewControl(getStreetViewOptions());
     }
@@ -51,14 +78,15 @@ export const maplibreStreetViewPlugin: GeoLibrePlugin = {
     const added = app.addMapControl(streetViewControl, streetViewPosition);
     if (!added) {
       streetViewControl = null;
+      cleanupRuntimeEnvListener();
       return false;
     }
     setTimeout(() => streetViewControl?.expand(), 0);
   },
   deactivate: (app: GeoLibreAppAPI) => {
-    if (!streetViewControl) return;
-    app.removeMapControl(streetViewControl);
+    if (streetViewControl) app.removeMapControl(streetViewControl);
     streetViewControl = null;
+    cleanupRuntimeEnvListener();
   },
   getMapControlPosition: () => streetViewPosition,
   setMapControlPosition: (
@@ -77,6 +105,40 @@ export const maplibreStreetViewPlugin: GeoLibrePlugin = {
 function getStreetViewOptions(): StreetViewControlOptions {
   return {
     ...STREET_VIEW_OPTIONS,
+    ...getStreetViewCredentials(),
     position: streetViewPosition,
   };
+}
+
+function addRuntimeEnvListener(): void {
+  if (removeRuntimeEnvListener || typeof window === "undefined") return;
+
+  const handleRuntimeEnvChange = () => {
+    if (!activeApp || !streetViewControl) return;
+    activeApp.removeMapControl(streetViewControl);
+    streetViewControl = new StreetViewControl(getStreetViewOptions());
+    const added = activeApp.addMapControl(streetViewControl, streetViewPosition);
+    if (!added) {
+      streetViewControl = null;
+      return;
+    }
+    setTimeout(() => streetViewControl?.expand(), 0);
+  };
+
+  window.addEventListener(
+    "geolibre:runtime-env-change",
+    handleRuntimeEnvChange,
+  );
+  removeRuntimeEnvListener = () => {
+    window.removeEventListener(
+      "geolibre:runtime-env-change",
+      handleRuntimeEnvChange,
+    );
+  };
+}
+
+function cleanupRuntimeEnvListener(): void {
+  activeApp = null;
+  removeRuntimeEnvListener?.();
+  removeRuntimeEnvListener = null;
 }

--- a/packages/plugins/src/plugins/maplibre-streetview.ts
+++ b/packages/plugins/src/plugins/maplibre-streetview.ts
@@ -111,16 +111,19 @@ function addRuntimeEnvListener(): void {
   if (removeRuntimeEnvListener || typeof window === "undefined") return;
 
   const handleRuntimeEnvChange = () => {
-    if (!activeApp || !streetViewControl) return;
-    activeApp.removeMapControl(streetViewControl);
+    if (!activeApp) return;
+    if (streetViewControl) activeApp.removeMapControl(streetViewControl);
     streetViewControl = new StreetViewControl(getStreetViewOptions());
     const added = activeApp.addMapControl(streetViewControl, streetViewPosition);
     if (!added) {
+      // Keep the listener registered so a later credential change can retry.
+      // addMapControl failures here are typically transient (e.g. the map is
+      // not fully initialized yet); the guard above only requires activeApp,
+      // so the next event re-attempts the add.
       streetViewControl = null;
-      // Tear down the listener too, otherwise it stays registered while
-      // streetViewControl is null and every later event short-circuits,
-      // silently breaking credential updates for the rest of the session.
-      cleanupRuntimeEnvListener();
+      console.warn(
+        "[maplibre-streetview] addMapControl failed during credential update; will retry on next env change.",
+      );
       return;
     }
     setTimeout(() => streetViewControl?.expand(), 0);


### PR DESCRIPTION
## Summary
- Add a Settings dialog with Map, Environment, and Project sections for configuring per-project map constraints (bounds, min/max zoom, max pitch, world copies) and runtime environment variables.
- Persist preferences with the project file and apply map constraints live through the map controller.
- Expose enabled runtime variables to plugins (e.g. Street View) so credentials can be set at runtime without a rebuild.

## Test plan
- [ ] Open Settings, set map bounds/zoom/pitch limits, and confirm the map respects them.
- [ ] Add a runtime environment variable, enable Street View, and confirm credentials are picked up without a rebuild.
- [ ] Save and reload a project, confirming preferences persist.
- [ ] `pre-commit run --all-files` passes (includes npm build).