### PR TITLE
feat: persist plugin state in project files

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -15,6 +15,7 @@ import {
   loadDroppedVectorFiles,
   loadDroppedVectorPaths,
 } from "../../lib/tauri-io";
+import { createAppAPI, getPluginManager } from "../../hooks/usePlugins";
 import { registerMbtilesProtocol } from "../../lib/mbtiles";
 import { registerXyzTileProtocol } from "../../lib/xyz-url";
 import { AttributeTable } from "../panels/AttributeTable";
@@ -75,7 +76,10 @@ export function DesktopShell({
   const dragDepthRef = useRef(0);
   const dropMessageTimeoutRef = useRef<number | null>(null);
   const addGeoJsonLayer = useAppStore((s) => s.addGeoJsonLayer);
+  const projectGeneration = useAppStore((s) => s.projectGeneration);
+  const projectPlugins = useAppStore((s) => s.projectPlugins);
   const [isDraggingFiles, setIsDraggingFiles] = useState(false);
+  const [mapReadyGeneration, setMapReadyGeneration] = useState(0);
   const [dropMessage, setDropMessage] = useState<string | null>(null);
   const [dropError, setDropError] = useState<string | null>(null);
   const [layerPanelWidth, setLayerPanelWidth] = useState(
@@ -109,11 +113,23 @@ export function DesktopShell({
   }, []);
 
   useEffect(() => {
+    if (!mapReadyGeneration || !mapControllerRef.current) return;
+    getPluginManager().restoreProjectState(
+      projectPlugins,
+      createAppAPI(mapControllerRef),
+    );
+  }, [mapReadyGeneration, projectGeneration, projectPlugins]);
+
+  useEffect(() => {
     return () => {
       if (dropMessageTimeoutRef.current !== null) {
         window.clearTimeout(dropMessageTimeoutRef.current);
       }
     };
+  }, []);
+
+  const handleMapControllerReady = useCallback(() => {
+    setMapReadyGeneration((generation) => generation + 1);
   }, []);
 
   const addImportedVectorLayers = useCallback(
@@ -413,7 +429,10 @@ export function DesktopShell({
             layoutOptions.compact ? "min-h-0" : "min-h-72 md:min-h-0"
           }`}
         >
-          <MapCanvas controllerRef={mapControllerRef} />
+          <MapCanvas
+            controllerRef={mapControllerRef}
+            onControllerReady={handleMapControllerReady}
+          />
         </main>
         {layoutOptions.panelsVisible ? (
           <StylePanel onResizeStart={startStylePanelResize} />

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -77,7 +77,6 @@ export function DesktopShell({
   const dropMessageTimeoutRef = useRef<number | null>(null);
   const addGeoJsonLayer = useAppStore((s) => s.addGeoJsonLayer);
   const projectGeneration = useAppStore((s) => s.projectGeneration);
-  const projectPlugins = useAppStore((s) => s.projectPlugins);
   const [isDraggingFiles, setIsDraggingFiles] = useState(false);
   const [mapReadyGeneration, setMapReadyGeneration] = useState(0);
   const [dropMessage, setDropMessage] = useState<string | null>(null);
@@ -113,12 +112,16 @@ export function DesktopShell({
   }, []);
 
   useEffect(() => {
+    // Restoration should run only when a project is loaded (projectGeneration)
+    // or the map is reinitialised (mapReadyGeneration), not on every
+    // incremental plugin write-back. projectPlugins is read from the store
+    // snapshot at call time so it is always current without being a dependency.
     if (!mapReadyGeneration || !mapControllerRef.current) return;
     getPluginManager().restoreProjectState(
-      projectPlugins,
+      useAppStore.getState().projectPlugins,
       createAppAPI(mapControllerRef),
     );
-  }, [mapReadyGeneration, projectGeneration, projectPlugins]);
+  }, [mapReadyGeneration, projectGeneration]);
 
   useEffect(() => {
     return () => {

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -67,7 +67,11 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
-import { createAppAPI, usePluginRegistry } from "../../hooks/usePlugins";
+import {
+  createAppAPI,
+  getPluginManager,
+  usePluginRegistry,
+} from "../../hooks/usePlugins";
 import type { ThemeMode } from "../../hooks/useThemeMode";
 import {
   isTauri,
@@ -290,6 +294,7 @@ export function TopToolbar({
       basemapOpacity: state.basemapOpacity,
       layers: state.layers,
       preferences: state.preferences,
+      plugins: getPluginManager().getProjectState(),
       metadata: state.metadata,
     });
     const content = serializeProject(project);

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -50,13 +50,21 @@ export function usePluginRegistry() {
     plugins: manager.list(),
     isActive: (id: string) => manager.isActive(id),
     getMapControlPosition: (id: string) => manager.getMapControlPosition(id),
-    toggle: (id: string, appApi: ReturnType<typeof createAppAPI>) =>
-      manager.toggle(id, appApi),
+    getProjectState: () => manager.getProjectState(),
+    toggle: (id: string, appApi: ReturnType<typeof createAppAPI>) => {
+      const before = JSON.stringify(manager.getProjectState());
+      manager.toggle(id, appApi);
+      persistProjectPluginState(before);
+    },
     setMapControlPosition: (
       id: string,
       appApi: ReturnType<typeof createAppAPI>,
       position: GeoLibreMapControlPosition,
-    ) => manager.setMapControlPosition(id, appApi, position),
+    ) => {
+      const before = JSON.stringify(manager.getProjectState());
+      manager.setMapControlPosition(id, appApi, position);
+      persistProjectPluginState(before);
+    },
   };
 }
 
@@ -197,4 +205,10 @@ function normalizeBytes(bytes: number[] | Uint8Array): ArrayBuffer {
   const copy = new Uint8Array(view.byteLength);
   copy.set(view);
   return copy.buffer;
+}
+
+function persistProjectPluginState(previousJson: string): void {
+  const nextState = manager.getProjectState();
+  if (JSON.stringify(nextState) === previousJson) return;
+  useAppStore.getState().setProjectPlugins(nextState);
 }

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -35,6 +35,11 @@ export interface GeoLibrePlugin {
     app: GeoLibreAppAPI,
     position: GeoLibreMapControlPosition,
   ) => boolean | void;
+  getProjectState?: () => unknown;
+  applyProjectState?: (
+    app: GeoLibreAppAPI,
+    state: unknown,
+  ) => boolean | void;
 }
 
 export interface GeoLibreAppAPI {
@@ -112,6 +117,8 @@ export const myPlugin: GeoLibrePlugin = {
 ```
 
 Map control plugins can optionally expose `getMapControlPosition()` and `setMapControlPosition()` so the desktop Plugins menu can move the control between map corners. Position-aware plugins should remove and recreate or re-add their control when the position changes.
+
+Plugins with serializable runtime settings can expose `getProjectState()` and `applyProjectState()` so GeoLibre can save and restore those settings in the project file. A wrapper should use these hooks to adapt upstream control APIs such as `getState()` without requiring every upstream package to implement a GeoLibre-specific interface.
 
 ## Roadmap (v0.7)
 

--- a/docs/project-format.md
+++ b/docs/project-format.md
@@ -14,7 +14,32 @@ Projects are saved as **`.geolibre.json`** files.
 | `basemapOpacity` | number | Background layer opacity from `0` to `1` |
 | `layers` | array | Layer definitions (see below) |
 | `styles` | object | Map of layer id → `LayerStyle` |
+| `plugins` | object | Optional active plugin IDs, plugin map-control positions, and plugin settings |
 | `metadata` | object | Free-form project metadata |
+
+## Plugin state
+
+```json
+{
+  "activePluginIds": ["maplibre-layer-control", "maplibre-gl-swipe"],
+  "mapControlPositions": {
+    "maplibre-layer-control": "top-right",
+    "maplibre-gl-swipe": "top-left"
+  },
+  "settings": {
+    "maplibre-gl-swipe": {
+      "orientation": "vertical",
+      "position": 50,
+      "collapsed": false,
+      "active": true,
+      "leftLayers": ["layer-a"],
+      "rightLayers": ["layer-b"]
+    }
+  }
+}
+```
+
+Projects without a `plugins` section open with the built-in default plugin state.
 
 ## Layer object
 

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -7,6 +7,8 @@ import {
   type GeoLibreProject,
   type LayerStyle,
   type MapViewState,
+  type ProjectPluginControlPosition,
+  type ProjectPluginState,
   type ProjectPreferences,
   type RuntimeEnvironmentVariable,
 } from "./types";
@@ -62,6 +64,7 @@ export function parseProject(json: string): GeoLibreProject {
     layers: (data.layers ?? []).map(normalizeLayer),
     styles: data.styles ?? {},
     preferences: normalizeProjectPreferences(data.preferences),
+    plugins: normalizeProjectPlugins(data.plugins) ?? undefined,
     metadata: data.metadata ?? {},
   };
 }
@@ -166,6 +169,102 @@ function normalizeEnvironmentVariable(
   };
 }
 
+const PROJECT_PLUGIN_CONTROL_POSITIONS = new Set<ProjectPluginControlPosition>([
+  "top-left",
+  "top-right",
+  "bottom-left",
+  "bottom-right",
+]);
+
+function normalizeProjectPlugins(
+  plugins: unknown,
+): ProjectPluginState | null {
+  if (!plugins || typeof plugins !== "object") return null;
+
+  const candidate = plugins as Partial<ProjectPluginState>;
+  const activePluginIds = Array.isArray(candidate.activePluginIds)
+    ? uniqueStrings(candidate.activePluginIds)
+    : [];
+  const mapControlPositions: Record<string, ProjectPluginControlPosition> = {};
+  const settings: Record<string, unknown> = {};
+
+  if (
+    candidate.mapControlPositions &&
+    typeof candidate.mapControlPositions === "object"
+  ) {
+    for (const [pluginId, position] of Object.entries(
+      candidate.mapControlPositions,
+    )) {
+      if (
+        typeof pluginId === "string" &&
+        pluginId.trim() &&
+        PROJECT_PLUGIN_CONTROL_POSITIONS.has(
+          position as ProjectPluginControlPosition,
+        )
+      ) {
+        mapControlPositions[pluginId.trim()] =
+          position as ProjectPluginControlPosition;
+      }
+    }
+  }
+
+  if (candidate.settings && typeof candidate.settings === "object") {
+    for (const [pluginId, value] of Object.entries(candidate.settings)) {
+      if (
+        typeof pluginId === "string" &&
+        pluginId.trim() &&
+        isJsonCompatible(value)
+      ) {
+        settings[pluginId.trim()] = value;
+      }
+    }
+  }
+
+  return {
+    activePluginIds,
+    mapControlPositions,
+    settings,
+  };
+}
+
+function uniqueStrings(values: unknown[]): string[] {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+
+  for (const value of values) {
+    if (typeof value !== "string") continue;
+    const id = value.trim();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    normalized.push(id);
+  }
+
+  return normalized;
+}
+
+function isJsonCompatible(value: unknown): boolean {
+  if (value === null) return true;
+
+  switch (typeof value) {
+    case "string":
+    case "boolean":
+      return true;
+    case "number":
+      return Number.isFinite(value);
+    case "object":
+      if (Array.isArray(value)) return value.every(isJsonCompatible);
+      if (!isPlainObject(value)) return false;
+      return Object.values(value).every(isJsonCompatible);
+    default:
+      return false;
+  }
+}
+
+function isPlainObject(value: object): boolean {
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
 function normalizeLayer(layer: GeoLibreLayer): GeoLibreLayer {
   return {
     ...layer,
@@ -185,12 +284,14 @@ export function projectFromStore(state: {
   basemapOpacity: number;
   layers: GeoLibreLayer[];
   preferences: ProjectPreferences;
+  plugins?: ProjectPluginState | null;
   metadata: Record<string, unknown>;
 }): GeoLibreProject {
   const styles: Record<string, LayerStyle> = {};
   for (const layer of state.layers) {
     styles[layer.id] = layer.style;
   }
+  const plugins = normalizeProjectPlugins(state.plugins);
   return {
     version: PROJECT_VERSION,
     name: state.projectName,
@@ -201,6 +302,7 @@ export function projectFromStore(state: {
     layers: state.layers.map(prepareLayerForSave),
     styles,
     preferences: state.preferences,
+    ...(plugins ? { plugins } : {}),
     metadata: state.metadata,
   };
 }
@@ -239,6 +341,7 @@ export function applyProjectToStore(project: GeoLibreProject): {
   basemapOpacity: number;
   layers: GeoLibreLayer[];
   preferences: ProjectPreferences;
+  projectPlugins: ProjectPluginState | null;
   metadata: Record<string, unknown>;
 } {
   const layers = project.layers.map((layer) => ({
@@ -255,6 +358,7 @@ export function applyProjectToStore(project: GeoLibreProject): {
     basemapOpacity: project.basemapOpacity ?? 1,
     layers,
     preferences: normalizeProjectPreferences(project.preferences),
+    projectPlugins: normalizeProjectPlugins(project.plugins),
     metadata: project.metadata,
   };
 }

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -15,6 +15,7 @@ import {
   type GeoLibreProject,
   type LayerStyle,
   type MapViewState,
+  type ProjectPluginState,
   type ProjectPreferences,
   type RecentProjectEntry,
 } from "./types";
@@ -22,6 +23,7 @@ import {
 export interface AppState {
   projectName: string;
   projectPath: string | null;
+  projectGeneration: number;
   isDirty: boolean;
   mapView: MapViewState;
   basemapStyleUrl: string;
@@ -29,6 +31,7 @@ export interface AppState {
   basemapOpacity: number;
   layers: GeoLibreLayer[];
   preferences: ProjectPreferences;
+  projectPlugins: ProjectPluginState | null;
   selectedLayerId: string | null;
   selectedFeatureId: string | null;
   identifyLayerId: string | null;
@@ -48,6 +51,10 @@ export interface AppState {
   setBasemapVisible: (visible: boolean) => void;
   setBasemapOpacity: (opacity: number) => void;
   setPreferences: (preferences: ProjectPreferences) => void;
+  setProjectPlugins: (
+    projectPlugins: ProjectPluginState | null,
+    markDirty?: boolean,
+  ) => void;
   selectLayer: (id: string | null) => void;
   selectFeature: (id: string | null) => void;
   setIdentifyLayer: (id: string | null) => void;
@@ -118,6 +125,7 @@ function normalizeRecentProjects(
 export const useAppStore = create<AppState>((set, get) => ({
   projectName: "Untitled Project",
   projectPath: null,
+  projectGeneration: 0,
   isDirty: false,
   mapView: createDefaultMapView(),
   basemapStyleUrl: DEFAULT_BASEMAP,
@@ -125,6 +133,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   basemapOpacity: 1,
   layers: [],
   preferences: DEFAULT_PROJECT_PREFERENCES,
+  projectPlugins: null,
   selectedLayerId: null,
   selectedFeatureId: null,
   identifyLayerId: null,
@@ -150,6 +159,11 @@ export const useAppStore = create<AppState>((set, get) => ({
   setBasemapOpacity: (opacity) =>
     set({ basemapOpacity: opacity, isDirty: true }),
   setPreferences: (preferences) => set({ preferences, isDirty: true }),
+  setProjectPlugins: (projectPlugins, markDirty = true) =>
+    set((s) => ({
+      projectPlugins,
+      isDirty: markDirty || s.isDirty,
+    })),
   selectLayer: (id) => set({ selectedLayerId: id, selectedFeatureId: null }),
   selectFeature: (id) => set({ selectedFeatureId: id }),
   setIdentifyLayer: (id) => set({ identifyLayerId: id }),
@@ -164,28 +178,30 @@ export const useAppStore = create<AppState>((set, get) => ({
   newProject: (options = {}) => {
     const project = createEmptyProject(options.name, options);
     const applied = applyProjectToStore(project);
-    set({
+    set((s) => ({
       ...applied,
       projectPath: null,
+      projectGeneration: s.projectGeneration + 1,
       isDirty: false,
       selectedLayerId: null,
       selectedFeatureId: null,
       identifyLayerId: null,
       pointerCoords: null,
       attributeFilter: "",
-    });
+    }));
   },
 
   loadProject: (project, path = null, options = {}) => {
     const applied = applyProjectToStore(project);
-    set({
+    set((s) => ({
       ...applied,
       projectPath: path,
+      projectGeneration: s.projectGeneration + 1,
       isDirty: false,
       selectedLayerId: applied.layers[0]?.id ?? null,
       selectedFeatureId: null,
       identifyLayerId: null,
-    });
+    }));
     if (path && options.rememberRecent !== false) {
       get().rememberRecentProject({
         path,

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -53,7 +53,7 @@ export interface AppState {
   setPreferences: (preferences: ProjectPreferences) => void;
   setProjectPlugins: (
     projectPlugins: ProjectPluginState | null,
-    markDirty?: boolean,
+    shouldMarkDirty?: boolean,
   ) => void;
   selectLayer: (id: string | null) => void;
   selectFeature: (id: string | null) => void;
@@ -159,10 +159,12 @@ export const useAppStore = create<AppState>((set, get) => ({
   setBasemapOpacity: (opacity) =>
     set({ basemapOpacity: opacity, isDirty: true }),
   setPreferences: (preferences) => set({ preferences, isDirty: true }),
-  setProjectPlugins: (projectPlugins, markDirty = true) =>
+  // When shouldMarkDirty is false the existing dirty flag is preserved rather
+  // than set; it cannot clear the flag (only markSaved() does that).
+  setProjectPlugins: (projectPlugins, shouldMarkDirty = true) =>
     set((s) => ({
       projectPlugins,
-      isDirty: markDirty || s.isDirty,
+      isDirty: shouldMarkDirty || s.isDirty,
     })),
   selectLayer: (id) => set({ selectedLayerId: id, selectedFeatureId: null }),
   selectFeature: (id) => set({ selectedFeatureId: id }),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -196,6 +196,18 @@ export interface ProjectPreferences {
   environmentVariables: RuntimeEnvironmentVariable[];
 }
 
+export type ProjectPluginControlPosition =
+  | "top-left"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-right";
+
+export interface ProjectPluginState {
+  activePluginIds: string[];
+  mapControlPositions: Record<string, ProjectPluginControlPosition>;
+  settings: Record<string, unknown>;
+}
+
 export const DEFAULT_PROJECT_PREFERENCES: ProjectPreferences = {
   map: {
     restrictBounds: false,
@@ -218,6 +230,7 @@ export interface GeoLibreProject {
   layers: GeoLibreLayer[];
   styles: Record<string, LayerStyle>;
   preferences: ProjectPreferences;
+  plugins?: ProjectPluginState;
   metadata: Record<string, unknown>;
 }
 

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -22,6 +22,7 @@ const PANEL_RESIZE_END_EVENT = "geolibre:panel-resize-end";
 
 export interface MapCanvasProps {
   controllerRef?: React.MutableRefObject<MapController | null>;
+  onControllerReady?: () => void;
 }
 
 function stringifyIdentifyValue(value: unknown): string {
@@ -121,6 +122,7 @@ function findFeatureId(
 
 export const MapCanvas = memo(function MapCanvas({
   controllerRef,
+  onControllerReady,
 }: MapCanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const controller = useRef<MapController | null>(null);
@@ -171,6 +173,7 @@ export const MapCanvas = memo(function MapCanvas({
         state.selectedFeatureId,
       );
       updateView();
+      onControllerReady?.();
     });
 
     let resizeFrame: number | null = null;
@@ -223,7 +226,7 @@ export const MapCanvas = memo(function MapCanvas({
       if (controllerRef) controllerRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [onControllerReady]);
 
   const prevBasemap = useRef(basemapStyleUrl);
   useEffect(() => {

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -126,6 +126,12 @@ export const MapCanvas = memo(function MapCanvas({
 }: MapCanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const controller = useRef<MapController | null>(null);
+  // Read the latest callback through a ref so the setup effect can stay
+  // dependency-free. Adding onControllerReady to its deps would tear down and
+  // recreate the entire map (losing layers, plugins, and view) whenever a
+  // caller passes a non-memoized callback.
+  const onControllerReadyRef = useRef(onControllerReady);
+  onControllerReadyRef.current = onControllerReady;
 
   const basemapStyleUrl = useAppStore((s) => s.basemapStyleUrl);
   const basemapVisible = useAppStore((s) => s.basemapVisible);
@@ -173,7 +179,7 @@ export const MapCanvas = memo(function MapCanvas({
         state.selectedFeatureId,
       );
       updateView();
-      onControllerReady?.();
+      onControllerReadyRef.current?.();
     });
 
     let resizeFrame: number | null = null;
@@ -225,8 +231,10 @@ export const MapCanvas = memo(function MapCanvas({
       controller.current = null;
       if (controllerRef) controllerRef.current = null;
     };
+    // The map is initialised exactly once; onControllerReady is read via
+    // onControllerReadyRef so it is intentionally excluded from the deps.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [onControllerReady]);
+  }, []);
 
   const prevBasemap = useRef(basemapStyleUrl);
   useEffect(() => {

--- a/packages/plugins/src/plugin-manager.ts
+++ b/packages/plugins/src/plugin-manager.ts
@@ -1,3 +1,4 @@
+import type { ProjectPluginState } from "@geolibre/core";
 import type {
   GeoLibreAppAPI,
   GeoLibreMapControlPosition,
@@ -7,17 +8,31 @@ import type {
 export class PluginManager {
   private plugins = new Map<string, GeoLibrePlugin>();
   private active = new Set<string>();
+  private defaultActive = new Set<string>();
+  private defaultMapControlPositions = new Map<
+    string,
+    GeoLibreMapControlPosition
+  >();
   private listeners = new Set<() => void>();
   private version = 0;
 
   register(plugin: GeoLibrePlugin): void {
     const previous = this.plugins.get(plugin.id);
     this.plugins.set(plugin.id, plugin);
+    const defaultPosition = plugin.getMapControlPosition?.();
+    if (defaultPosition) {
+      this.defaultMapControlPositions.set(plugin.id, defaultPosition);
+    }
     // activeByDefault only marks the plugin active; activate() is not called
     // here because no app API is available at registration time. Such plugins
     // must apply their initial side effects idempotently elsewhere (e.g. the
     // layer control is added by MapController.init regardless of plugin state).
-    if (plugin.activeByDefault) this.active.add(plugin.id);
+    if (plugin.activeByDefault) {
+      this.defaultActive.add(plugin.id);
+      this.active.add(plugin.id);
+    } else {
+      this.defaultActive.delete(plugin.id);
+    }
     if (previous !== plugin) this.notify();
   }
 
@@ -31,6 +46,25 @@ export class PluginManager {
 
   isActive(id: string): boolean {
     return this.active.has(id);
+  }
+
+  getProjectState(): ProjectPluginState {
+    const mapControlPositions: ProjectPluginState["mapControlPositions"] = {};
+    const settings: ProjectPluginState["settings"] = {};
+    for (const plugin of this.plugins.values()) {
+      const position = plugin.getMapControlPosition?.();
+      if (position) mapControlPositions[plugin.id] = position;
+      const pluginState = plugin.getProjectState?.();
+      if (pluginState !== undefined) settings[plugin.id] = pluginState;
+    }
+
+    return {
+      activePluginIds: Array.from(this.plugins.keys()).filter((id) =>
+        this.active.has(id),
+      ),
+      mapControlPositions,
+      settings,
+    };
   }
 
   getMapControlPosition(
@@ -80,6 +114,54 @@ export class PluginManager {
     const updated = plugin.setMapControlPosition(app, position);
     if (updated === false) return;
     this.notify();
+  }
+
+  restoreProjectState(
+    state: ProjectPluginState | null,
+    app: GeoLibreAppAPI,
+  ): void {
+    const targetActive = new Set(
+      state?.activePluginIds ?? Array.from(this.defaultActive),
+    );
+    let changed = false;
+
+    for (const [id, plugin] of this.plugins) {
+      const defaultPosition = this.defaultMapControlPositions.get(id);
+      const targetPosition = state?.mapControlPositions[id] ?? defaultPosition;
+      if (targetPosition && plugin.setMapControlPosition) {
+        const currentPosition = plugin.getMapControlPosition?.();
+        if (currentPosition !== targetPosition) {
+          const updated = plugin.setMapControlPosition(app, targetPosition);
+          if (updated !== false) changed = true;
+        }
+      }
+
+      if (plugin.applyProjectState) {
+        const updated = plugin.applyProjectState(app, state?.settings[id]);
+        if (updated !== false) changed = true;
+      }
+    }
+
+    for (const id of Array.from(this.active)) {
+      if (targetActive.has(id)) continue;
+      const plugin = this.plugins.get(id);
+      if (!plugin) continue;
+      plugin.deactivate(app);
+      this.active.delete(id);
+      changed = true;
+    }
+
+    for (const id of targetActive) {
+      if (this.active.has(id)) continue;
+      const plugin = this.plugins.get(id);
+      if (!plugin) continue;
+      const activated = plugin.activate(app);
+      if (activated === false) continue;
+      this.active.add(id);
+      changed = true;
+    }
+
+    if (changed) this.notify();
   }
 
   private notify(): void {

--- a/packages/plugins/src/plugin-manager.ts
+++ b/packages/plugins/src/plugin-manager.ts
@@ -125,6 +125,21 @@ export class PluginManager {
     );
     let changed = false;
 
+    // Deactivate first so plugins that should be inactive tear down their live
+    // controls before we touch positions or settings. This keeps the order of
+    // operations from rebuilding a control only to remove it on the next pass.
+    for (const id of Array.from(this.active)) {
+      if (targetActive.has(id)) continue;
+      const plugin = this.plugins.get(id);
+      if (!plugin) continue;
+      plugin.deactivate(app);
+      this.active.delete(id);
+      changed = true;
+    }
+
+    // Restore positions and settings. Plugins that will be (re)activated below
+    // are inactive at this point, so applyProjectState only caches their state
+    // for the upcoming activate() call rather than doing live DOM work.
     for (const [id, plugin] of this.plugins) {
       const defaultPosition = this.defaultMapControlPositions.get(id);
       const targetPosition = state?.mapControlPositions[id] ?? defaultPosition;
@@ -136,19 +151,13 @@ export class PluginManager {
         }
       }
 
-      if (plugin.applyProjectState) {
-        const updated = plugin.applyProjectState(app, state?.settings[id]);
+      // Only apply settings the loaded project actually carries for this
+      // plugin. A missing entry means "no change" rather than "reset", which
+      // avoids clobbering in-memory state for plugins absent from the project.
+      if (plugin.applyProjectState && state?.settings && id in state.settings) {
+        const updated = plugin.applyProjectState(app, state.settings[id]);
         if (updated !== false) changed = true;
       }
-    }
-
-    for (const id of Array.from(this.active)) {
-      if (targetActive.has(id)) continue;
-      const plugin = this.plugins.get(id);
-      if (!plugin) continue;
-      plugin.deactivate(app);
-      this.active.delete(id);
-      changed = true;
     }
 
     for (const id of targetActive) {

--- a/packages/plugins/src/plugins/maplibre-swipe.ts
+++ b/packages/plugins/src/plugins/maplibre-swipe.ts
@@ -12,6 +12,7 @@ import type {
 let swipeControlPosition: GeoLibreMapControlPosition = "top-left";
 
 let swipeControl: SwipeControl | null = null;
+let savedSwipeState: SwipeState | null = null;
 let unsubscribeBasemap: (() => void) | null = null;
 
 export const maplibreSwipePlugin: GeoLibrePlugin = {
@@ -19,14 +20,16 @@ export const maplibreSwipePlugin: GeoLibrePlugin = {
   name: "Layer Swipe",
   version: "0.7.1",
   activate: (app: GeoLibreAppAPI) => {
-    swipeControl = new SwipeControl(getSwipeControlOptions(app));
+    swipeControl = new SwipeControl(
+      getSwipeControlOptions(app, savedSwipeState ?? undefined),
+    );
 
     const added = app.addMapControl(swipeControl, swipeControlPosition);
     if (!added) {
       swipeControl = null;
       return false;
     }
-    setTimeout(() => swipeControl?.expand(), 0);
+    expandSwipeControl(savedSwipeState ?? undefined);
 
     // The control reads the basemap style only on construction, so recreate it
     // when the active basemap changes to keep its basemap-layer grouping in
@@ -34,17 +37,20 @@ export const maplibreSwipePlugin: GeoLibrePlugin = {
     unsubscribeBasemap = app.onBasemapChange(() => {
       if (!swipeControl) return;
       const previousState = swipeControl.getState();
+      savedSwipeState = previousState;
       app.removeMapControl(swipeControl);
       swipeControl = new SwipeControl(
         getSwipeControlOptions(app, previousState),
       );
       app.addMapControl(swipeControl, swipeControlPosition);
+      expandSwipeControl(previousState);
     });
   },
   deactivate: (app: GeoLibreAppAPI) => {
     unsubscribeBasemap?.();
     unsubscribeBasemap = null;
     if (!swipeControl) return;
+    savedSwipeState = swipeControl.getState();
     app.removeMapControl(swipeControl);
     swipeControl = null;
   },
@@ -55,10 +61,32 @@ export const maplibreSwipePlugin: GeoLibrePlugin = {
   ) => {
     swipeControlPosition = position;
     if (!swipeControl) return;
+    const currentState = swipeControl.getState();
+    savedSwipeState = currentState;
     app.removeMapControl(swipeControl);
     const added = app.addMapControl(swipeControl, swipeControlPosition);
     if (!added) return false;
-    setTimeout(() => swipeControl?.expand(), 0);
+    expandSwipeControl(currentState);
+  },
+  getProjectState: () => swipeControl?.getState() ?? savedSwipeState ?? undefined,
+  applyProjectState: (app: GeoLibreAppAPI, state: unknown) => {
+    const nextState = normalizeSwipeProjectState(state);
+    const currentState = swipeControl?.getState() ?? savedSwipeState;
+    if (areSwipeStatesEqual(currentState, nextState)) return false;
+
+    savedSwipeState = nextState;
+    if (!swipeControl) return true;
+
+    app.removeMapControl(swipeControl);
+    swipeControl = new SwipeControl(
+      getSwipeControlOptions(app, savedSwipeState ?? undefined),
+    );
+    const added = app.addMapControl(swipeControl, swipeControlPosition);
+    if (!added) {
+      swipeControl = null;
+      return false;
+    }
+    expandSwipeControl(savedSwipeState ?? undefined);
   },
 };
 
@@ -80,4 +108,46 @@ function getSwipeControlOptions(
     basemapStyle: app.getActiveBasemap(),
     excludeLayers: ["gl-draw-*", "measure-*"],
   };
+}
+
+function expandSwipeControl(state?: SwipeState): void {
+  if (state?.collapsed === true) return;
+  setTimeout(() => swipeControl?.expand(), 0);
+}
+
+function normalizeSwipeProjectState(state: unknown): SwipeState | null {
+  if (!state || typeof state !== "object") return null;
+  const candidate = state as Partial<SwipeState>;
+
+  return {
+    orientation:
+      candidate.orientation === "horizontal" ? "horizontal" : "vertical",
+    position: normalizePosition(candidate.position),
+    collapsed: normalizeBoolean(candidate.collapsed, false),
+    active: normalizeBoolean(candidate.active, true),
+    leftLayers: normalizeLayerIds(candidate.leftLayers),
+    rightLayers: normalizeLayerIds(candidate.rightLayers),
+  };
+}
+
+function normalizePosition(position: unknown): number {
+  if (!Number.isFinite(position)) return 50;
+  return Math.min(100, Math.max(0, Number(position)));
+}
+
+function normalizeBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function normalizeLayerIds(layerIds: unknown): string[] {
+  return Array.isArray(layerIds)
+    ? layerIds.filter((id): id is string => typeof id === "string" && !!id)
+    : [];
+}
+
+function areSwipeStatesEqual(
+  left: SwipeState | null | undefined,
+  right: SwipeState | null | undefined,
+): boolean {
+  return JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
 }

--- a/packages/plugins/src/plugins/maplibre-swipe.ts
+++ b/packages/plugins/src/plugins/maplibre-swipe.ts
@@ -65,7 +65,10 @@ export const maplibreSwipePlugin: GeoLibrePlugin = {
     savedSwipeState = currentState;
     app.removeMapControl(swipeControl);
     const added = app.addMapControl(swipeControl, swipeControlPosition);
-    if (!added) return false;
+    if (!added) {
+      swipeControl = null;
+      return false;
+    }
     expandSwipeControl(currentState);
   },
   getProjectState: () => swipeControl?.getState() ?? savedSwipeState ?? undefined,

--- a/packages/plugins/src/plugins/maplibre-swipe.ts
+++ b/packages/plugins/src/plugins/maplibre-swipe.ts
@@ -127,6 +127,7 @@ function normalizeSwipeProjectState(state: unknown): SwipeState | null {
     active: normalizeBoolean(candidate.active, true),
     leftLayers: normalizeLayerIds(candidate.leftLayers),
     rightLayers: normalizeLayerIds(candidate.rightLayers),
+    isDragging: false,
   };
 }
 

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -60,4 +60,9 @@ export interface GeoLibrePlugin {
     app: GeoLibreAppAPI,
     position: GeoLibreMapControlPosition,
   ) => boolean | void;
+  getProjectState?: () => unknown;
+  applyProjectState?: (
+    app: GeoLibreAppAPI,
+    state: unknown,
+  ) => boolean | void;
 }


### PR DESCRIPTION
## Summary
- Save active plugin IDs, map control positions, and serializable plugin settings into the `.geolibre.json` project format, with validation when parsing.
- Restore plugin state when a project loads, including re-activating plugins, moving controls, and applying per-plugin settings once the map controller is ready.
- Add `getProjectState()` / `applyProjectState()` plugin hooks and wire the layer swipe plugin to persist its orientation, position, collapsed/active flags, and selected layers.

## Test plan
- [ ] `npm run build` passes (verified via pre-commit)
- [ ] Save a project with plugins enabled and custom control positions, reopen it, and confirm the plugins, positions, and swipe settings are restored
- [ ] Open a legacy project without a `plugins` section and confirm it loads with default plugin state