### PR TITLE
feat: add WMS GetFeatureInfo identify support

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -221,7 +221,8 @@ export function LayerPanel({
           {visibleLayers.map((layer, displayIndex) => {
             const canIdentify =
               layer.type === "geojson" ||
-              layer.type === "wms" ||
+              (layer.type === "wms" &&
+                Boolean(layer.source.url || layer.sourcePath)) ||
               layer.type === "vector-tiles" ||
               (layer.type === "mbtiles" &&
                 layer.metadata.tileType === "vector") ||

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -222,7 +222,11 @@ export function LayerPanel({
             const canIdentify =
               layer.type === "geojson" ||
               (layer.type === "wms" &&
-                Boolean(layer.source.url || layer.sourcePath)) ||
+                Boolean(
+                  (typeof layer.source.url === "string" &&
+                    layer.source.url.trim()) ||
+                    layer.sourcePath,
+                )) ||
               layer.type === "vector-tiles" ||
               (layer.type === "mbtiles" &&
                 layer.metadata.tileType === "vector") ||

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -222,6 +222,8 @@ export function LayerPanel({
             const canIdentify =
               layer.type === "geojson" ||
               (layer.type === "wms" &&
+                typeof layer.source.layers === "string" &&
+                Boolean(layer.source.layers.trim()) &&
                 Boolean(
                   (typeof layer.source.url === "string" &&
                     layer.source.url.trim()) ||

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -221,6 +221,7 @@ export function LayerPanel({
           {visibleLayers.map((layer, displayIndex) => {
             const canIdentify =
               layer.type === "geojson" ||
+              layer.type === "wms" ||
               layer.type === "vector-tiles" ||
               (layer.type === "mbtiles" &&
                 layer.metadata.tileType === "vector") ||
@@ -363,14 +364,14 @@ export function LayerPanel({
                         ? identifyActive
                           ? "Deactivate identify"
                           : "Identify features"
-                        : "Identify is only available for vector layers"
+                        : "Identify is only available for vector and WMS layers"
                     }
                     aria-label={
                       canIdentify
                         ? identifyActive
                           ? "Deactivate identify"
                           : "Identify features"
-                        : "Identify is only available for vector layers"
+                        : "Identify is only available for vector and WMS layers"
                     }
                     disabled={!canIdentify}
                     onClick={(e) => {

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -22,6 +22,10 @@ const PANEL_RESIZE_END_EVENT = "geolibre:panel-resize-end";
 const WMS_PROXY_PATH = "/__geolibre_wms_proxy";
 const WEB_MERCATOR_MAX_LATITUDE = 85.0511287798066;
 const WEB_MERCATOR_EARTH_RADIUS = 6378137;
+const WEB_MERCATOR_WORLD_SIZE = 2 * Math.PI * WEB_MERCATOR_EARTH_RADIUS;
+const MAPLIBRE_TILE_SIZE = 512;
+const WMS_IDENTIFY_QUERY_SIZE = 101;
+const WMS_IDENTIFY_QUERY_CENTER = Math.floor(WMS_IDENTIFY_QUERY_SIZE / 2);
 const WMS_IDENTIFY_INFO_FORMATS = [
   "application/json",
   "text/html",
@@ -136,21 +140,11 @@ function findFeatureId(
 }
 
 function isWmsLayer(layer: GeoLibreLayer): boolean {
-  return layer.type === "wms" || layer.metadata.service === "wms";
+  return layer.type === "wms";
 }
 
 function stringSource(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value : undefined;
-}
-
-function numberSource(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value)
-    ? value
-    : undefined;
-}
-
-function encodeWmsParamValue(value: string): string {
-  return value === "{bbox-epsg-3857}" ? value : encodeURIComponent(value);
 }
 
 function appendWmsQuery(
@@ -165,7 +159,7 @@ function appendWmsQuery(
   const query = params
     .map(
       ([key, value]) =>
-        `${encodeURIComponent(key)}=${encodeWmsParamValue(value)}`,
+        `${encodeURIComponent(key)}=${encodeURIComponent(value)}`,
     )
     .join("&");
   return `${endpoint}${separator}${query}`;
@@ -183,13 +177,24 @@ function lngLatToWebMercator(lng: number, lat: number): [number, number] {
   return [x, y];
 }
 
-function mapBbox3857(map: maplibregl.Map): string {
-  const bounds = map.getBounds();
-  const sw = bounds.getSouthWest();
-  const ne = bounds.getNorthEast();
-  const [minX, minY] = lngLatToWebMercator(sw.lng, sw.lat);
-  const [maxX, maxY] = lngLatToWebMercator(ne.lng, ne.lat);
-  return [minX, minY, maxX, maxY].join(",");
+function wmsIdentifyResolution(zoom: number): number {
+  const normalizedZoom = Number.isFinite(zoom) ? Math.max(0, zoom) : 0;
+  return WEB_MERCATOR_WORLD_SIZE / (MAPLIBRE_TILE_SIZE * 2 ** normalizedZoom);
+}
+
+function wmsIdentifyBbox3857(
+  map: maplibregl.Map,
+  lngLat: maplibregl.LngLat,
+): string {
+  const [centerX, centerY] = lngLatToWebMercator(lngLat.lng, lngLat.lat);
+  const halfSpan =
+    (WMS_IDENTIFY_QUERY_SIZE * wmsIdentifyResolution(map.getZoom())) / 2;
+  return [
+    centerX - halfSpan,
+    centerY - halfSpan,
+    centerX + halfSpan,
+    centerY + halfSpan,
+  ].join(",");
 }
 
 function isViteDevServer(): boolean {
@@ -202,6 +207,11 @@ function isViteDevServer(): boolean {
   );
 }
 
+// Only the Vite dev server proxies GetFeatureInfo requests (to dodge CORS in
+// the browser). Production builds target the Tauri webview, which does not
+// enforce same-origin restrictions, so the raw URL is used directly. A WMS
+// server lacking CORS headers would fail if this app were ever hosted as a
+// plain web page; such a deployment would need its own proxy.
 function proxyWmsRequestUrl(url: string): string {
   return isViteDevServer()
     ? `${WMS_PROXY_PATH}?url=${encodeURIComponent(url)}`
@@ -218,32 +228,30 @@ function createWmsGetFeatureInfoUrl(
   const layers = stringSource(layer.source.layers);
   if (!endpoint || !layers) return null;
 
-  const canvas = map.getCanvas();
-  const width = Math.max(1, Math.round(canvas.clientWidth));
-  const height = Math.max(1, Math.round(canvas.clientHeight));
-  const x = Math.max(0, Math.min(width - 1, Math.round(event.point.x)));
-  const y = Math.max(0, Math.min(height - 1, Math.round(event.point.y)));
-  const tileSize = numberSource(layer.source.tileSize) ?? 256;
   const styles = stringSource(layer.source.styles) ?? "";
   const format = stringSource(layer.source.format) ?? "image/png";
+  // WMS 1.3.0 renames the SRS parameter to CRS. EPSG:3857 keeps easting/
+  // northing axis order across both versions, so the BBOX layout is unchanged.
+  const version = stringSource(layer.source.version) ?? "1.1.1";
+  const crsParam = version.startsWith("1.3") ? "CRS" : "SRS";
 
   return appendWmsQuery(endpoint, [
     ["SERVICE", "WMS"],
     ["REQUEST", "GetFeatureInfo"],
-    ["VERSION", "1.1.1"],
+    ["VERSION", version],
     ["LAYERS", layers],
     ["QUERY_LAYERS", layers],
     ["STYLES", styles],
     ["FORMAT", format],
     ["TRANSPARENT", layer.source.transparent === false ? "FALSE" : "TRUE"],
-    ["SRS", "EPSG:3857"],
-    ["BBOX", mapBbox3857(map)],
-    ["WIDTH", String(width || tileSize)],
-    ["HEIGHT", String(height || tileSize)],
-    ["X", String(x)],
-    ["Y", String(y)],
+    [crsParam, "EPSG:3857"],
+    ["BBOX", wmsIdentifyBbox3857(map, event.lngLat)],
+    ["WIDTH", String(WMS_IDENTIFY_QUERY_SIZE)],
+    ["HEIGHT", String(WMS_IDENTIFY_QUERY_SIZE)],
+    ["X", String(WMS_IDENTIFY_QUERY_CENTER)],
+    ["Y", String(WMS_IDENTIFY_QUERY_CENTER)],
     ["INFO_FORMAT", infoFormat],
-    ["FEATURE_COUNT", "10"],
+    ["FEATURE_COUNT", "1"],
   ]);
 }
 
@@ -298,7 +306,14 @@ async function fetchWmsIdentifyProperties(
 } | null> {
   let fallbackText = "";
 
-  for (const infoFormat of WMS_IDENTIFY_INFO_FORMATS) {
+  // Honor an explicitly configured INFO_FORMAT so we issue a single request
+  // instead of probing JSON/HTML/plain-text in sequence.
+  const configuredFormat = stringSource(layer.source.infoFormat);
+  const infoFormats = configuredFormat
+    ? [configuredFormat]
+    : WMS_IDENTIFY_INFO_FORMATS;
+
+  for (const infoFormat of infoFormats) {
     const targetUrl = createWmsGetFeatureInfoUrl(layer, map, event, infoFormat);
     if (!targetUrl) return null;
 
@@ -339,7 +354,10 @@ async function fetchWmsIdentifyProperties(
 }
 
 function isAbortError(error: unknown): boolean {
-  return error instanceof Error && error.name === "AbortError";
+  return (
+    (error instanceof DOMException || error instanceof Error) &&
+    error.name === "AbortError"
+  );
 }
 
 export const MapCanvas = memo(function MapCanvas({

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -19,6 +19,14 @@ import "./layer-control-overrides.css";
 
 const PANEL_RESIZE_START_EVENT = "geolibre:panel-resize-start";
 const PANEL_RESIZE_END_EVENT = "geolibre:panel-resize-end";
+const WMS_PROXY_PATH = "/__geolibre_wms_proxy";
+const WEB_MERCATOR_MAX_LATITUDE = 85.0511287798066;
+const WEB_MERCATOR_EARTH_RADIUS = 6378137;
+const WMS_IDENTIFY_INFO_FORMATS = [
+  "application/json",
+  "text/html",
+  "text/plain",
+];
 
 export interface MapCanvasProps {
   controllerRef?: React.MutableRefObject<MapController | null>;
@@ -81,6 +89,13 @@ function createIdentifyPopupElement(
   return root;
 }
 
+function createIdentifyMessagePopupElement(
+  layerName: string,
+  message: string,
+): HTMLElement {
+  return createIdentifyPopupElement(layerName, { status: message });
+}
+
 function nativeIdentifyLayerIds(layer: GeoLibreLayer): string[] {
   const nativeLayerIds = layer.metadata.nativeLayerIds;
   return Array.isArray(nativeLayerIds)
@@ -118,6 +133,213 @@ function findFeatureId(
   });
 
   return index >= 0 ? String(layer.geojson.features[index].id ?? index) : null;
+}
+
+function isWmsLayer(layer: GeoLibreLayer): boolean {
+  return layer.type === "wms" || layer.metadata.service === "wms";
+}
+
+function stringSource(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function numberSource(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function encodeWmsParamValue(value: string): string {
+  return value === "{bbox-epsg-3857}" ? value : encodeURIComponent(value);
+}
+
+function appendWmsQuery(
+  endpoint: string,
+  params: Array<[string, string]>,
+): string {
+  const separator = endpoint.includes("?")
+    ? endpoint.endsWith("?") || endpoint.endsWith("&")
+      ? ""
+      : "&"
+    : "?";
+  const query = params
+    .map(
+      ([key, value]) =>
+        `${encodeURIComponent(key)}=${encodeWmsParamValue(value)}`,
+    )
+    .join("&");
+  return `${endpoint}${separator}${query}`;
+}
+
+function lngLatToWebMercator(lng: number, lat: number): [number, number] {
+  const clampedLat = Math.max(
+    -WEB_MERCATOR_MAX_LATITUDE,
+    Math.min(WEB_MERCATOR_MAX_LATITUDE, lat),
+  );
+  const x = WEB_MERCATOR_EARTH_RADIUS * (lng * Math.PI) / 180;
+  const y =
+    WEB_MERCATOR_EARTH_RADIUS *
+    Math.log(Math.tan(Math.PI / 4 + (clampedLat * Math.PI) / 360));
+  return [x, y];
+}
+
+function mapBbox3857(map: maplibregl.Map): string {
+  const bounds = map.getBounds();
+  const sw = bounds.getSouthWest();
+  const ne = bounds.getNorthEast();
+  const [minX, minY] = lngLatToWebMercator(sw.lng, sw.lat);
+  const [maxX, maxY] = lngLatToWebMercator(ne.lng, ne.lat);
+  return [minX, minY, maxX, maxY].join(",");
+}
+
+function isViteDevServer(): boolean {
+  return Boolean(
+    (
+      import.meta as ImportMeta & {
+        env?: { DEV?: boolean };
+      }
+    ).env?.DEV,
+  );
+}
+
+function proxyWmsRequestUrl(url: string): string {
+  return isViteDevServer()
+    ? `${WMS_PROXY_PATH}?url=${encodeURIComponent(url)}`
+    : url;
+}
+
+function createWmsGetFeatureInfoUrl(
+  layer: GeoLibreLayer,
+  map: maplibregl.Map,
+  event: maplibregl.MapMouseEvent,
+  infoFormat: string,
+): string | null {
+  const endpoint = stringSource(layer.source.url) ?? layer.sourcePath;
+  const layers = stringSource(layer.source.layers);
+  if (!endpoint || !layers) return null;
+
+  const canvas = map.getCanvas();
+  const width = Math.max(1, Math.round(canvas.clientWidth));
+  const height = Math.max(1, Math.round(canvas.clientHeight));
+  const x = Math.max(0, Math.min(width - 1, Math.round(event.point.x)));
+  const y = Math.max(0, Math.min(height - 1, Math.round(event.point.y)));
+  const tileSize = numberSource(layer.source.tileSize) ?? 256;
+  const styles = stringSource(layer.source.styles) ?? "";
+  const format = stringSource(layer.source.format) ?? "image/png";
+
+  return appendWmsQuery(endpoint, [
+    ["SERVICE", "WMS"],
+    ["REQUEST", "GetFeatureInfo"],
+    ["VERSION", "1.1.1"],
+    ["LAYERS", layers],
+    ["QUERY_LAYERS", layers],
+    ["STYLES", styles],
+    ["FORMAT", format],
+    ["TRANSPARENT", layer.source.transparent === false ? "FALSE" : "TRUE"],
+    ["SRS", "EPSG:3857"],
+    ["BBOX", mapBbox3857(map)],
+    ["WIDTH", String(width || tileSize)],
+    ["HEIGHT", String(height || tileSize)],
+    ["X", String(x)],
+    ["Y", String(y)],
+    ["INFO_FORMAT", infoFormat],
+    ["FEATURE_COUNT", "10"],
+  ]);
+}
+
+function normalizeText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function textFromHtml(value: string): string {
+  const document = new DOMParser().parseFromString(value, "text/html");
+  return normalizeText(document.body.textContent ?? "");
+}
+
+function isWmsExceptionResponse(value: string): boolean {
+  return /<([\w:]+)?(ServiceException|ExceptionReport)\b/i.test(value);
+}
+
+function parseWmsJsonProperties(value: unknown): {
+  featureId?: string | number;
+  properties: Record<string, unknown>;
+} | null {
+  if (!value || typeof value !== "object") return null;
+
+  if ("features" in value && Array.isArray(value.features)) {
+    const [feature] = value.features;
+    if (!feature || typeof feature !== "object") return null;
+    const properties =
+      "properties" in feature &&
+      feature.properties &&
+      typeof feature.properties === "object" &&
+      !Array.isArray(feature.properties)
+        ? (feature.properties as Record<string, unknown>)
+        : {};
+    const featureId =
+      "id" in feature &&
+      (typeof feature.id === "string" || typeof feature.id === "number")
+        ? feature.id
+        : undefined;
+    return { featureId, properties };
+  }
+
+  return { properties: value as Record<string, unknown> };
+}
+
+async function fetchWmsIdentifyProperties(
+  layer: GeoLibreLayer,
+  map: maplibregl.Map,
+  event: maplibregl.MapMouseEvent,
+  signal: AbortSignal,
+): Promise<{
+  featureId?: string | number;
+  properties: Record<string, unknown>;
+} | null> {
+  let fallbackText = "";
+
+  for (const infoFormat of WMS_IDENTIFY_INFO_FORMATS) {
+    const targetUrl = createWmsGetFeatureInfoUrl(layer, map, event, infoFormat);
+    if (!targetUrl) return null;
+
+    const response = await fetch(proxyWmsRequestUrl(targetUrl), { signal });
+    const contentType =
+      response.headers.get("content-type")?.toLowerCase() ?? infoFormat;
+    const text = await response.text();
+    if (!response.ok) {
+      fallbackText = normalizeText(text) || response.statusText;
+      continue;
+    }
+    if (isWmsExceptionResponse(text)) {
+      fallbackText = normalizeText(text);
+      continue;
+    }
+
+    if (
+      contentType.includes("json") ||
+      infoFormat.includes("json") ||
+      text.trim().startsWith("{")
+    ) {
+      try {
+        const parsed = parseWmsJsonProperties(JSON.parse(text));
+        if (parsed) return parsed;
+      } catch {
+        fallbackText = normalizeText(text);
+      }
+      continue;
+    }
+
+    const resultText = contentType.includes("html")
+      ? textFromHtml(text)
+      : normalizeText(text);
+    if (resultText) return { properties: { result: resultText } };
+  }
+
+  return fallbackText ? { properties: { result: fallbackText } } : null;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
 }
 
 export const MapCanvas = memo(function MapCanvas({
@@ -303,12 +525,68 @@ export const MapCanvas = memo(function MapCanvas({
 
     map.getCanvas().style.cursor = "crosshair";
 
+    let wmsIdentifyAbortController: AbortController | null = null;
+
     const handleIdentifyClick = (event: maplibregl.MapMouseEvent) => {
       const clearIdentifyResult = () => {
+        wmsIdentifyAbortController?.abort();
+        wmsIdentifyAbortController = null;
         selectFeature(null);
         identifyPopup.current?.remove();
         identifyPopup.current = null;
       };
+      const showIdentifyPopup = (content: HTMLElement) => {
+        identifyPopup.current?.remove();
+        identifyPopup.current = new maplibregl.Popup({
+          className: "geolibre-identify-popup",
+          closeButton: true,
+          closeOnClick: false,
+          maxWidth: "560px",
+        })
+          .setLngLat(event.lngLat)
+          .setDOMContent(content)
+          .addTo(map);
+      };
+
+      if (isWmsLayer(layer)) {
+        wmsIdentifyAbortController?.abort();
+        const abortController = new AbortController();
+        wmsIdentifyAbortController = abortController;
+        selectFeature(null);
+        showIdentifyPopup(
+          createIdentifyMessagePopupElement(layer.name, "Loading..."),
+        );
+
+        void fetchWmsIdentifyProperties(
+          layer,
+          map,
+          event,
+          abortController.signal,
+        )
+          .then((result) => {
+            if (abortController.signal.aborted) return;
+            wmsIdentifyAbortController = null;
+            showIdentifyPopup(
+              createIdentifyPopupElement(
+                layer.name,
+                result?.properties ?? {},
+                result?.featureId,
+              ),
+            );
+          })
+          .catch((error: unknown) => {
+            if (isAbortError(error)) return;
+            wmsIdentifyAbortController = null;
+            const message =
+              error instanceof Error
+                ? error.message
+                : "The WMS GetFeatureInfo request failed.";
+            showIdentifyPopup(
+              createIdentifyMessagePopupElement(layer.name, message),
+            );
+          });
+        return;
+      }
 
       const queryLayerIds = identifyStyleLayerIds(layer).filter((id) =>
         map.getLayer(id),
@@ -329,27 +607,19 @@ export const MapCanvas = memo(function MapCanvas({
       const featureId = findFeatureId(layer, feature);
       selectFeature(featureId);
 
-      identifyPopup.current?.remove();
-      identifyPopup.current = new maplibregl.Popup({
-        className: "geolibre-identify-popup",
-        closeButton: true,
-        closeOnClick: false,
-        maxWidth: "560px",
-      })
-        .setLngLat(event.lngLat)
-        .setDOMContent(
-          createIdentifyPopupElement(
-            layer.name,
-            feature.properties ?? {},
-            featureId ?? feature.id,
-          ),
-        )
-        .addTo(map);
+      showIdentifyPopup(
+        createIdentifyPopupElement(
+          layer.name,
+          feature.properties ?? {},
+          featureId ?? feature.id,
+        ),
+      );
     };
 
     map.on("click", handleIdentifyClick);
 
     return () => {
+      wmsIdentifyAbortController?.abort();
       map.off("click", handleIdentifyClick);
       identifyPopup.current?.remove();
       identifyPopup.current = null;

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -271,7 +271,7 @@ function createWmsGetFeatureInfoUrl(
     ["X", String(WMS_IDENTIFY_QUERY_CENTER)],
     ["Y", String(WMS_IDENTIFY_QUERY_CENTER)],
     ["INFO_FORMAT", infoFormat],
-    ["FEATURE_COUNT", "1"],
+    ["FEATURE_COUNT", String(Number(layer.source.featureCount) || 1)],
   ]);
 }
 
@@ -359,7 +359,8 @@ async function fetchWmsIdentifyProperties(
     if (
       contentType.includes("json") ||
       infoFormat.includes("json") ||
-      text.trim().startsWith("{")
+      text.trim().startsWith("{") ||
+      text.trim().startsWith("[")
     ) {
       try {
         const parsed = parseWmsJsonProperties(JSON.parse(text));
@@ -370,10 +371,19 @@ async function fetchWmsIdentifyProperties(
       continue;
     }
 
-    const resultText = contentType.includes("html")
-      ? textFromHtml(text)
-      : normalizeText(text);
-    if (resultText) return { properties: { result: resultText } };
+    if (contentType.includes("html")) {
+      const resultText = textFromHtml(text);
+      if (resultText) return { properties: { result: resultText } };
+      continue;
+    }
+
+    const resultText = normalizeText(text);
+    if (!resultText) continue;
+    // Only treat plain text as the final answer when we actually probed a
+    // text format; a body that arrived in an unexpected format is stashed as
+    // a fallback so the remaining info formats are still tried.
+    if (infoFormat.includes("plain")) return { properties: { result: resultText } };
+    fallbackText = resultText;
   }
 
   return fallbackText ? { properties: { result: fallbackText } } : null;

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -151,18 +151,38 @@ function appendWmsQuery(
   endpoint: string,
   params: Array<[string, string]>,
 ): string {
-  const separator = endpoint.includes("?")
-    ? endpoint.endsWith("?") || endpoint.endsWith("&")
-      ? ""
-      : "&"
-    : "?";
-  const query = params
-    .map(
-      ([key, value]) =>
-        `${encodeURIComponent(key)}=${encodeURIComponent(value)}`,
-    )
-    .join("&");
-  return `${endpoint}${separator}${query}`;
+  // Prefer URL parsing so our control parameters override any duplicates the
+  // endpoint already carries (e.g. a pasted GetMap URL) and land before any
+  // fragment, which the browser would otherwise strip along with the query.
+  try {
+    const url = new URL(endpoint);
+    const controlKeys = new Set(params.map(([key]) => key.toLowerCase()));
+    for (const existing of [...url.searchParams.keys()]) {
+      if (controlKeys.has(existing.toLowerCase())) {
+        url.searchParams.delete(existing);
+      }
+    }
+    for (const [key, value] of params) {
+      url.searchParams.append(key, value);
+    }
+    return url.toString();
+  } catch {
+    // Fall back to plain concatenation for non-absolute endpoints.
+    const fragIdx = endpoint.indexOf("#");
+    const base = fragIdx >= 0 ? endpoint.slice(0, fragIdx) : endpoint;
+    const separator = base.includes("?")
+      ? base.endsWith("?") || base.endsWith("&")
+        ? ""
+        : "&"
+      : "?";
+    const query = params
+      .map(
+        ([key, value]) =>
+          `${encodeURIComponent(key)}=${encodeURIComponent(value)}`,
+      )
+      .join("&");
+    return `${base}${separator}${query}`;
+  }
 }
 
 function lngLatToWebMercator(lng: number, lat: number): [number, number] {
@@ -275,6 +295,9 @@ function parseWmsJsonProperties(value: unknown): {
   if (!value || typeof value !== "object") return null;
 
   if ("features" in value && Array.isArray(value.features)) {
+    // An empty collection is the standard "no hit" response: report success
+    // with no properties rather than null, so we don't probe other formats.
+    if (value.features.length === 0) return { properties: {} };
     const [feature] = value.features;
     if (!feature || typeof feature !== "object") return null;
     const properties =
@@ -320,7 +343,10 @@ async function fetchWmsIdentifyProperties(
     const response = await fetch(proxyWmsRequestUrl(targetUrl), { signal });
     const contentType =
       response.headers.get("content-type")?.toLowerCase() ?? infoFormat;
+    // Response.text() cannot take a signal, so bail out as soon as the read
+    // resolves if the request was aborted meanwhile, skipping parsing.
     const text = await response.text();
+    if (signal.aborted) return null;
     if (!response.ok) {
       fallbackText = normalizeText(text) || response.statusText;
       continue;
@@ -593,7 +619,7 @@ export const MapCanvas = memo(function MapCanvas({
             );
           })
           .catch((error: unknown) => {
-            if (isAbortError(error)) return;
+            if (isAbortError(error) || abortController.signal.aborted) return;
             wmsIdentifyAbortController = null;
             const message =
               error instanceof Error


### PR DESCRIPTION
## Summary
- Enable the identify tool for WMS layers, issuing GetFeatureInfo requests on click and showing the response in the identify popup
- Support JSON, HTML, and plain-text info formats, with graceful fallbacks and exception detection
- Route requests through a dev-server proxy to avoid cross-origin issues, and update the LayerPanel identify availability and tooltip to include WMS layers

## Test plan
- [ ] Add a queryable WMS layer and click a feature with the identify tool active; verify attributes render in the popup
- [ ] Confirm the identify button is enabled for WMS layers and its tooltip mentions WMS
- [ ] Verify loading and error states display correctly, and rapid clicks cancel in-flight requests

<img width="1281" height="709" alt="image" src="https://github.com/user-attachments/assets/93fb1f75-059e-4e08-9716-17d532d4071d" />
