### PR TITLE
fix: harden WMS GetFeatureInfo identify

### DIFF
--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -302,9 +302,22 @@ function parseWmsJsonProperties(value: unknown): {
   if (Array.isArray(value)) {
     // Some servers return a bare array of features instead of a FeatureCollection.
     if (value.length === 0) return { properties: {} };
+    const first = value[0];
+    // A plain property bag (no "properties"/"features" key) is not a GeoJSON
+    // Feature; delegate so the catch-all below returns its own keys rather than
+    // wrapping it into a feature whose properties resolve to {}.
+    if (
+      first &&
+      typeof first === "object" &&
+      !Array.isArray(first) &&
+      !("properties" in first) &&
+      !("features" in first)
+    ) {
+      return parseWmsJsonProperties(first);
+    }
     return parseWmsJsonProperties({
       type: "FeatureCollection",
-      features: [value[0]],
+      features: [first],
     });
   }
 
@@ -387,6 +400,9 @@ async function fetchWmsIdentifyProperties(
       try {
         const parsed = parseWmsJsonProperties(JSON.parse(text));
         if (parsed) return parsed;
+        // Valid JSON the parser couldn't map: keep the raw text as a fallback
+        // so an unrecognized-but-real response isn't silently discarded.
+        fallbackText = fallbackText || normalizeText(text);
       } catch {
         fallbackText = normalizeText(text);
       }
@@ -634,9 +650,13 @@ export const MapCanvas = memo(function MapCanvas({
         );
         // Closing the loading popup (the × button) must cancel the in-flight
         // request so its result does not reopen a popup the user dismissed.
-        // Guard the shared controller by identity so replacing this popup with
-        // the result popup does not clobber a newer request's controller.
+        // Track user dismissal with a flag rather than the abort signal: the
+        // result swap calls remove() on this popup, which also fires "close",
+        // and we must not treat that programmatic swap as a dismissal. Guard the
+        // shared controller by identity so a newer request is not clobbered.
+        let userDismissed = false;
         identifyPopup.current?.once("close", () => {
+          userDismissed = true;
           abortController.abort();
           if (wmsIdentifyAbortController === abortController) {
             wmsIdentifyAbortController = null;
@@ -650,7 +670,7 @@ export const MapCanvas = memo(function MapCanvas({
           abortController.signal,
         )
           .then((result) => {
-            if (abortController.signal.aborted) return;
+            if (userDismissed || abortController.signal.aborted) return;
             wmsIdentifyAbortController = null;
             showIdentifyPopup(
               createIdentifyPopupElement(
@@ -661,7 +681,8 @@ export const MapCanvas = memo(function MapCanvas({
             );
           })
           .catch((error: unknown) => {
-            if (isAbortError(error) || abortController.signal.aborted) return;
+            if (userDismissed || isAbortError(error) || abortController.signal.aborted)
+              return;
             wmsIdentifyAbortController = null;
             const message =
               error instanceof Error

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -257,10 +257,10 @@ function createWmsGetFeatureInfoUrl(
   const isV13 = version.startsWith("1.3");
   const crsParam = isV13 ? "CRS" : "SRS";
   // Treat a deliberate featureCount of 0 ("all features" on some servers) as
-  // intentional; only fall back to 1 when it is unset (null/undefined) or
-  // non-numeric. Number(null) is 0, so guard null explicitly.
+  // intentional; only fall back to 1 when it is unset (null/undefined), blank,
+  // or non-numeric. Number(null) and Number("") are both 0, so guard those.
   const featureCount =
-    layer.source.featureCount != null
+    layer.source.featureCount != null && layer.source.featureCount !== ""
       ? Number(layer.source.featureCount)
       : NaN;
 
@@ -315,7 +315,10 @@ function parseWmsJsonProperties(value: unknown): {
       typeof first === "object" &&
       !Array.isArray(first) &&
       !("properties" in first) &&
-      !("features" in first)
+      !(
+        "features" in first &&
+        Array.isArray((first as Record<string, unknown>).features)
+      )
     ) {
       return parseWmsJsonProperties(first);
     }
@@ -659,14 +662,16 @@ export const MapCanvas = memo(function MapCanvas({
         // and we must not treat that programmatic swap as a dismissal. Guard the
         // shared controller by identity so a newer request is not clobbered.
         let userDismissed = false;
-        // showIdentifyPopup just assigned identifyPopup.current, so it is set.
-        identifyPopup.current!.once("close", () => {
+        const loadingPopup = identifyPopup.current;
+        const onLoadingClose = () => {
           userDismissed = true;
           abortController.abort();
           if (wmsIdentifyAbortController === abortController) {
             wmsIdentifyAbortController = null;
           }
-        });
+        };
+        // showIdentifyPopup just assigned identifyPopup.current, so it is set.
+        loadingPopup!.once("close", onLoadingClose);
 
         void fetchWmsIdentifyProperties(
           layer,
@@ -677,6 +682,9 @@ export const MapCanvas = memo(function MapCanvas({
           .then((result) => {
             if (userDismissed || abortController.signal.aborted) return;
             wmsIdentifyAbortController = null;
+            // Detach before the swap so remove()'s synchronous "close" does not
+            // spuriously abort the request that just succeeded.
+            loadingPopup?.off("close", onLoadingClose);
             showIdentifyPopup(
               createIdentifyPopupElement(
                 layer.name,
@@ -689,6 +697,7 @@ export const MapCanvas = memo(function MapCanvas({
             if (userDismissed || isAbortError(error) || abortController.signal.aborted)
               return;
             wmsIdentifyAbortController = null;
+            loadingPopup?.off("close", onLoadingClose);
             const message =
               error instanceof Error
                 ? error.message

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -257,8 +257,12 @@ function createWmsGetFeatureInfoUrl(
   const isV13 = version.startsWith("1.3");
   const crsParam = isV13 ? "CRS" : "SRS";
   // Treat a deliberate featureCount of 0 ("all features" on some servers) as
-  // intentional; only fall back to 1 when it is unset or non-numeric.
-  const featureCount = Number(layer.source.featureCount);
+  // intentional; only fall back to 1 when it is unset (null/undefined) or
+  // non-numeric. Number(null) is 0, so guard null explicitly.
+  const featureCount =
+    layer.source.featureCount != null
+      ? Number(layer.source.featureCount)
+      : NaN;
 
   return appendWmsQuery(endpoint, [
     ["SERVICE", "WMS"],
@@ -655,7 +659,8 @@ export const MapCanvas = memo(function MapCanvas({
         // and we must not treat that programmatic swap as a dismissal. Guard the
         // shared controller by identity so a newer request is not clobbered.
         let userDismissed = false;
-        identifyPopup.current?.once("close", () => {
+        // showIdentifyPopup just assigned identifyPopup.current, so it is set.
+        identifyPopup.current!.once("close", () => {
           userDismissed = true;
           abortController.abort();
           if (wmsIdentifyAbortController === abortController) {

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -250,10 +250,15 @@ function createWmsGetFeatureInfoUrl(
 
   const styles = stringSource(layer.source.styles) ?? "";
   const format = stringSource(layer.source.format) ?? "image/png";
-  // WMS 1.3.0 renames the SRS parameter to CRS. EPSG:3857 keeps easting/
-  // northing axis order across both versions, so the BBOX layout is unchanged.
+  // WMS 1.3.0 renames the SRS parameter to CRS and the pixel coordinates from
+  // X/Y to I/J. EPSG:3857 keeps easting/northing axis order across both
+  // versions, so the BBOX layout is unchanged.
   const version = stringSource(layer.source.version) ?? "1.1.1";
-  const crsParam = version.startsWith("1.3") ? "CRS" : "SRS";
+  const isV13 = version.startsWith("1.3");
+  const crsParam = isV13 ? "CRS" : "SRS";
+  // Treat a deliberate featureCount of 0 ("all features" on some servers) as
+  // intentional; only fall back to 1 when it is unset or non-numeric.
+  const featureCount = Number(layer.source.featureCount);
 
   return appendWmsQuery(endpoint, [
     ["SERVICE", "WMS"],
@@ -268,10 +273,10 @@ function createWmsGetFeatureInfoUrl(
     ["BBOX", wmsIdentifyBbox3857(map, event.lngLat)],
     ["WIDTH", String(WMS_IDENTIFY_QUERY_SIZE)],
     ["HEIGHT", String(WMS_IDENTIFY_QUERY_SIZE)],
-    ["X", String(WMS_IDENTIFY_QUERY_CENTER)],
-    ["Y", String(WMS_IDENTIFY_QUERY_CENTER)],
+    [isV13 ? "I" : "X", String(WMS_IDENTIFY_QUERY_CENTER)],
+    [isV13 ? "J" : "Y", String(WMS_IDENTIFY_QUERY_CENTER)],
     ["INFO_FORMAT", infoFormat],
-    ["FEATURE_COUNT", String(Number(layer.source.featureCount) || 1)],
+    ["FEATURE_COUNT", String(Number.isFinite(featureCount) ? featureCount : 1)],
   ]);
 }
 
@@ -293,6 +298,15 @@ function parseWmsJsonProperties(value: unknown): {
   properties: Record<string, unknown>;
 } | null {
   if (!value || typeof value !== "object") return null;
+
+  if (Array.isArray(value)) {
+    // Some servers return a bare array of features instead of a FeatureCollection.
+    if (value.length === 0) return { properties: {} };
+    return parseWmsJsonProperties({
+      type: "FeatureCollection",
+      features: [value[0]],
+    });
+  }
 
   if ("features" in value && Array.isArray(value.features)) {
     // An empty collection is the standard "no hit" response: report success
@@ -348,20 +362,28 @@ async function fetchWmsIdentifyProperties(
     const text = await response.text();
     if (signal.aborted) return null;
     if (!response.ok) {
-      fallbackText = normalizeText(text) || response.statusText;
+      // HTTP/2 drops the reason phrase, so statusText is often "". Fall back to
+      // the status code so a failed request never surfaces as "No attributes".
+      fallbackText =
+        normalizeText(text) || response.statusText || `HTTP ${response.status}`;
       continue;
     }
-    if (isWmsExceptionResponse(text)) {
+
+    const trimmed = text.trim();
+    const looksLikeJson =
+      contentType.includes("json") ||
+      infoFormat.includes("json") ||
+      trimmed.startsWith("{") ||
+      trimmed.startsWith("[");
+
+    // Only run the XML exception check on bodies that are not JSON, so a JSON
+    // response that merely mentions "ServiceException" is not misread as one.
+    if (!looksLikeJson && isWmsExceptionResponse(text)) {
       fallbackText = normalizeText(text);
       continue;
     }
 
-    if (
-      contentType.includes("json") ||
-      infoFormat.includes("json") ||
-      text.trim().startsWith("{") ||
-      text.trim().startsWith("[")
-    ) {
+    if (looksLikeJson) {
       try {
         const parsed = parseWmsJsonProperties(JSON.parse(text));
         if (parsed) return parsed;
@@ -610,6 +632,16 @@ export const MapCanvas = memo(function MapCanvas({
         showIdentifyPopup(
           createIdentifyMessagePopupElement(layer.name, "Loading..."),
         );
+        // Closing the loading popup (the × button) must cancel the in-flight
+        // request so its result does not reopen a popup the user dismissed.
+        // Guard the shared controller by identity so replacing this popup with
+        // the result popup does not clobber a newer request's controller.
+        identifyPopup.current?.once("close", () => {
+          abortController.abort();
+          if (wmsIdentifyAbortController === abortController) {
+            wmsIdentifyAbortController = null;
+          }
+        });
 
         void fetchWmsIdentifyProperties(
           layer,


### PR DESCRIPTION
## Summary
- Follow-up to #97, addressing review feedback that arrived after it was merged
- Emit I/J instead of X/Y for WMS 1.3.0 GetFeatureInfo, abort the in-flight request when the loading popup is closed, and parse bare JSON arrays into the first feature
- Fall back to the HTTP status code when statusText is empty (HTTP/2), skip the XML exception check for JSON bodies, and preserve an explicit featureCount of 0

## Test plan
- [ ] Identify a feature on a strict WMS 1.3.0 layer and confirm results return (I/J parameters)
- [ ] Click the loading popup close button mid-request and confirm no result popup reopens
- [ ] Identify against a server returning a bare JSON array and confirm real attribute names show
- [ ] Confirm a failing request over HTTP/2 shows a status-code message rather than an empty popup