### PR TITLE
chore: enforce large file check in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,8 @@ repos:
     rev: v6.0.0
     hooks:
       - id: check-json
+      - id: check-added-large-files
+        args: ["--maxkb=1024", "--enforce-all"]
       - id: check-merge-conflict
       - id: check-toml
       - id: check-yaml


### PR DESCRIPTION
## Summary
- Add the `check-added-large-files` pre-commit hook with a 1 MB limit (`--maxkb=1024`) and `--enforce-all` so oversized files cannot be committed.

## Test plan
- [x] `pre-commit run --all-files` passes, including the new hook.