### PR TITLE
feat: add GPX layer support to Add Data dialog

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -3,7 +3,7 @@ import {
   type GeoLibreLayer,
   useAppStore,
 } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import { getLayerBounds, type MapController } from "@geolibre/map";
 import {
   addArcGISLayer,
   addCogRasterLayer,
@@ -643,7 +643,7 @@ export function AddDataDialog({
       return "Add local vector files supported by DuckDB Spatial, GeoJSON URLs, or MapLibre vector tile sources.";
     }
     if (kind === "gpx") {
-      return "Add GPX waypoints, routes, and tracks as a GeoJSON layer.";
+      return "Add GPX waypoints, routes, and tracks as one or more vector layers.";
     }
     if (kind === "delimited-text") {
       return "Add a delimited text file or URL as a point layer using longitude and latitude fields.";
@@ -1322,7 +1322,24 @@ export function AddDataDialog({
         for (const layer of layers) {
           addLayer(layer, beforeLayer);
         }
-        mapControllerRef.current?.fitLayer(layers[0]);
+        const combinedBounds = layers.reduce<
+          [number, number, number, number] | null
+        >((merged, layer) => {
+          const bounds = getLayerBounds(layer);
+          if (!bounds) return merged;
+          if (!merged) return [...bounds];
+          return [
+            Math.min(merged[0], bounds[0]),
+            Math.min(merged[1], bounds[1]),
+            Math.max(merged[2], bounds[2]),
+            Math.max(merged[3], bounds[3]),
+          ];
+        }, null);
+        if (combinedBounds) {
+          mapControllerRef.current?.fitBounds(combinedBounds);
+        } else {
+          mapControllerRef.current?.fitLayer(layers[0]);
+        }
         closeDialog();
         return;
       }

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -1327,7 +1327,7 @@ export function AddDataDialog({
         >((merged, layer) => {
           const bounds = getLayerBounds(layer);
           if (!bounds) return merged;
-          if (!merged) return [...bounds];
+          if (!merged) return bounds;
           return [
             Math.min(merged[0], bounds[0]),
             Math.min(merged[1], bounds[1]),

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -143,7 +143,8 @@ const DEFAULT_RASTER_URL =
   "https://data.source.coop/giswqs/opengeos/nlcd_2021_land_cover_30m.tif";
 const DEFAULT_GEOJSON_URL =
   "https://data.source.coop/giswqs/opengeos/countries.geojson";
-const DEFAULT_GPX_URL = "https://www.topografix.com/fells_loop.gpx";
+const DEFAULT_GPX_URL =
+  "https://data.source.coop/giswqs/opengeos/fells_loop.gpx";
 const DEFAULT_DELIMITED_TEXT_URL =
   "https://data.source.coop/giswqs/opengeos/us_cities.csv";
 const DEFAULT_DELIMITED_TEXT_LATITUDE_FIELD = "latitude";

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -48,6 +48,7 @@ import {
   parseDelimitedTextFields,
   parseDelimitedTextLayer,
 } from "../../lib/delimited-text";
+import { parseGpxLayer } from "../../lib/gpx";
 import {
   mbtilesTileUrl,
   readMbtilesMetadata,
@@ -77,6 +78,7 @@ export type AddDataKind =
   | "wfs"
   | "wmts"
   | "vector"
+  | "gpx"
   | "delimited-text"
   | "raster"
   | "mbtiles"
@@ -90,6 +92,8 @@ interface AddDataDialogProps {
 }
 
 type VectorMode = "vector-file" | "geojson-url" | "vector-tiles";
+type GpxMode = "url" | "file";
+type GpxLayerKind = "waypoints" | "tracks" | "routes";
 type DelimitedTextMode = "url" | "file";
 type DelimitedTextDelimiter = "comma" | "tab" | "semicolon" | "pipe" | "custom";
 type RasterMode = "tiles" | "cog-url" | "file";
@@ -105,6 +109,7 @@ const KIND_LABELS: Record<AddDataKind, string> = {
   wfs: "Add WFS Layer",
   wmts: "Add WMTS Layer",
   vector: "Add Vector Layer",
+  gpx: "Add GPX Layer",
   "delimited-text": "Add Delimited Text Layer",
   raster: "Add Raster Layer",
   mbtiles: "Add MBTiles Layer",
@@ -138,6 +143,7 @@ const DEFAULT_RASTER_URL =
   "https://data.source.coop/giswqs/opengeos/nlcd_2021_land_cover_30m.tif";
 const DEFAULT_GEOJSON_URL =
   "https://data.source.coop/giswqs/opengeos/countries.geojson";
+const DEFAULT_GPX_URL = "https://www.topografix.com/fells_loop.gpx";
 const DEFAULT_DELIMITED_TEXT_URL =
   "https://data.source.coop/giswqs/opengeos/us_cities.csv";
 const DEFAULT_DELIMITED_TEXT_LATITUDE_FIELD = "latitude";
@@ -152,6 +158,8 @@ const DEFAULT_ARCGIS_URLS: Record<ArcGISLayerType, string> = {
 };
 // Keep in sync with WFS_PROXY_PATH in vite.config.ts (the dev proxy binds it there).
 const WFS_PROXY_PATH = "/__geolibre_wfs_proxy";
+// Keep in sync with GPX_PROXY_PATH in vite.config.ts (the dev proxy binds it there).
+const GPX_PROXY_PATH = "/__geolibre_gpx_proxy";
 const POSTGRES_CONNECTIONS_STORAGE_KEY =
   "geolibre.postgres.connectionStrings";
 const MAX_SAVED_POSTGRES_CONNECTIONS = 10;
@@ -345,6 +353,12 @@ function proxyWfsRequestUrl(url: string): string {
     : url;
 }
 
+function proxyGpxRequestUrl(url: string): string {
+  return isViteDevServer()
+    ? `${GPX_PROXY_PATH}?url=${encodeURIComponent(url)}`
+    : url;
+}
+
 function parseGeoJsonFeatureCollection(value: unknown): FeatureCollection {
   if (
     !value ||
@@ -448,6 +462,19 @@ export function AddDataDialog({
     data: FeatureCollection;
     path: string;
   } | null>(null);
+  const [gpxMode, setGpxMode] = useState<GpxMode>("url");
+  const [gpxUrl, setGpxUrl] = useState(DEFAULT_GPX_URL);
+  const [selectedGpx, setSelectedGpx] = useState<{
+    path: string;
+    text: string;
+  } | null>(null);
+  const [selectedGpxLayerKinds, setSelectedGpxLayerKinds] = useState<
+    Record<GpxLayerKind, boolean>
+  >({
+    routes: true,
+    tracks: true,
+    waypoints: true,
+  });
   const [delimitedTextMode, setDelimitedTextMode] =
     useState<DelimitedTextMode>("url");
   const [delimitedTextUrl, setDelimitedTextUrl] = useState(
@@ -520,6 +547,7 @@ export function AddDataDialog({
         wfs: "WFS Layer",
         wmts: "WMTS Layer",
         vector: "Vector Layer",
+        gpx: "GPX Layer",
         "delimited-text": "Delimited Text Layer",
         raster: "Raster Layer",
         mbtiles: "MBTiles Layer",
@@ -549,6 +577,14 @@ export function AddDataDialog({
     setVectorUrl(DEFAULT_GEOJSON_URL);
     setVectorSourceLayer("");
     setSelectedVector(null);
+    setGpxMode("url");
+    setGpxUrl(DEFAULT_GPX_URL);
+    setSelectedGpx(null);
+    setSelectedGpxLayerKinds({
+      routes: true,
+      tracks: true,
+      waypoints: true,
+    });
     setDelimitedTextMode("url");
     setDelimitedTextUrl(DEFAULT_DELIMITED_TEXT_URL);
     setDelimitedTextDelimiter("comma");
@@ -606,6 +642,9 @@ export function AddDataDialog({
     if (kind === "vector") {
       return "Add local vector files supported by DuckDB Spatial, GeoJSON URLs, or MapLibre vector tile sources.";
     }
+    if (kind === "gpx") {
+      return "Add GPX waypoints, routes, and tracks as a GeoJSON layer.";
+    }
     if (kind === "delimited-text") {
       return "Add a delimited text file or URL as a point layer using longitude and latitude fields.";
     }
@@ -656,6 +695,24 @@ export function AddDataDialog({
     }
   };
 
+  const handleGpxModeChange = (mode: GpxMode) => {
+    setGpxMode(mode);
+    setSelectedGpx(null);
+    if (mode === "url" && !gpxUrl.trim()) {
+      setGpxUrl(DEFAULT_GPX_URL);
+    }
+  };
+
+  const setGpxLayerKindSelected = (
+    layerKind: GpxLayerKind,
+    selected: boolean,
+  ) => {
+    setSelectedGpxLayerKinds((current) => ({
+      ...current,
+      [layerKind]: selected,
+    }));
+  };
+
   const resetDelimitedTextColumns = () => {
     setDelimitedTextFields([]);
     setDelimitedTextColumnsStatus(null);
@@ -688,6 +745,31 @@ export function AddDataDialog({
     if (!sourcePath) throw new Error("Enter a delimited text URL.");
 
     const response = await fetch(sourcePath);
+    if (!response.ok) {
+      throw new Error(`Request failed with status ${response.status}`);
+    }
+    return {
+      sourcePath,
+      text: await response.text(),
+    };
+  };
+
+  const readGpxSource = async (): Promise<{
+    sourcePath: string;
+    text: string;
+  }> => {
+    if (gpxMode === "file") {
+      if (!selectedGpx) throw new Error("Choose a GPX file.");
+      return {
+        sourcePath: selectedGpx.path,
+        text: selectedGpx.text,
+      };
+    }
+
+    const sourcePath = gpxUrl.trim();
+    if (!sourcePath) throw new Error("Enter a GPX URL.");
+
+    const response = await fetch(proxyGpxRequestUrl(sourcePath));
     if (!response.ok) {
       throw new Error(`Request failed with status ${response.status}`);
     }
@@ -914,6 +996,35 @@ export function AddDataDialog({
       );
     } catch (err) {
       setError(errorMessage(err, "Could not read delimited text file."));
+    }
+  };
+
+  const handleChooseGpx = async () => {
+    setError(null);
+    try {
+      const result = await openLocalDataFileWithFallback({
+        filters: [
+          {
+            name: "GPX",
+            extensions: ["gpx"],
+          },
+        ],
+        accept: ".gpx",
+        readText: true,
+      });
+      if (!result) return;
+      if (!result.text) throw new Error("GPX file data is missing.");
+      setSelectedGpx({
+        path: result.path,
+        text: result.text,
+      });
+      setLayerName((current) =>
+        current.trim() && current !== "GPX Layer"
+          ? current
+          : layerNameFromPath(result.path, "GPX Layer"),
+      );
+    } catch (err) {
+      setError(errorMessage(err, "Could not read GPX file."));
     }
   };
 
@@ -1149,6 +1260,73 @@ export function AddDataDialog({
         return;
       }
 
+      if (kind === "gpx") {
+        if (!hasSelectedGpxLayerKind) {
+          throw new Error("Select at least one GPX layer type.");
+        }
+
+        const { sourcePath, text } = await readGpxSource();
+        const result = parseGpxLayer(text);
+        const gpxLayerGroups: Array<{
+          featureCollection: FeatureCollection;
+          kind: GpxLayerKind;
+          label: string;
+        }> = [
+          {
+            featureCollection: result.waypoints,
+            kind: "waypoints",
+            label: "Waypoints",
+          },
+          {
+            featureCollection: result.tracks,
+            kind: "tracks",
+            label: "Tracks",
+          },
+          {
+            featureCollection: result.routes,
+            kind: "routes",
+            label: "Routes",
+          },
+        ];
+        const layers = gpxLayerGroups
+          .filter(
+            (group) =>
+              selectedGpxLayerKinds[group.kind] &&
+              group.featureCollection.features.length > 0,
+          )
+          .map((group) => ({
+            ...createBaseLayer(
+              `${name} ${group.label}`,
+              "geojson",
+              {
+                type: "geojson",
+                url: sourcePath,
+              },
+              {
+                featureCount: group.featureCollection.features.length,
+                gpxLayerKind: group.kind,
+                routeCount: result.routeCount,
+                sourceKind: "gpx",
+                trackCount: result.trackCount,
+                waypointCount: result.waypointCount,
+              },
+            ),
+            geojson: group.featureCollection,
+            sourcePath,
+          }));
+
+        if (layers.length === 0) {
+          throw new Error("The selected GPX layer types were not found.");
+        }
+
+        for (const layer of layers) {
+          addLayer(layer, beforeLayer);
+        }
+        mapControllerRef.current?.fitLayer(layers[0]);
+        closeDialog();
+        return;
+      }
+
       if (kind === "delimited-text") {
         const delimiter = resolveDelimitedTextDelimiter(
           delimitedTextDelimiter,
@@ -1343,10 +1521,14 @@ export function AddDataDialog({
   const missingCustomDelimiter =
     delimitedTextDelimiter === "custom" &&
     !delimitedTextCustomDelimiter.trim();
+  const hasSelectedGpxLayerKind = Object.values(selectedGpxLayerKinds).some(
+    Boolean,
+  );
 
   const addLayerDisabled =
     isSubmitting ||
     isRetrievingDelimitedTextColumns ||
+    (kind === "gpx" && !hasSelectedGpxLayerKind) ||
     (kind === "delimited-text" && missingCustomDelimiter) ||
     (kind === "postgres" && (!martinServer || !selectedMartinSourceId));
 
@@ -1631,6 +1813,91 @@ export function AddDataDialog({
                   />
                 </div>
               )}
+            </div>
+          )}
+
+          {kind === "gpx" && (
+            <div className="space-y-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="gpx-mode">Source type</Label>
+                <Select
+                  id="gpx-mode"
+                  value={gpxMode}
+                  onChange={(event) =>
+                    handleGpxModeChange(event.target.value as GpxMode)
+                  }
+                >
+                  <option value="url">GPX URL</option>
+                  <option value="file">GPX file</option>
+                </Select>
+              </div>
+
+              {gpxMode === "file" ? (
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={handleChooseGpx}
+                  >
+                    <FileUp className="mr-2 h-3.5 w-3.5" />
+                    Choose file
+                  </Button>
+                  <span className="min-w-0 truncate text-xs text-muted-foreground">
+                    {selectedGpx
+                      ? fileNameFromPath(selectedGpx.path)
+                      : "No file selected"}
+                  </span>
+                </div>
+              ) : (
+                <div className="space-y-1.5">
+                  <Label htmlFor="gpx-url">GPX URL</Label>
+                  <Input
+                    id="gpx-url"
+                    placeholder="https://example.com/route.gpx"
+                    value={gpxUrl}
+                    onChange={(event) => setGpxUrl(event.target.value)}
+                  />
+                </div>
+              )}
+
+              <div className="space-y-2">
+                <Label>Layer types</Label>
+                <div className="grid gap-2 sm:grid-cols-3">
+                  <label className="flex items-center gap-2 text-sm">
+                    <input
+                      type="checkbox"
+                      checked={selectedGpxLayerKinds.waypoints}
+                      onChange={(event) =>
+                        setGpxLayerKindSelected(
+                          "waypoints",
+                          event.target.checked,
+                        )
+                      }
+                    />
+                    Waypoints
+                  </label>
+                  <label className="flex items-center gap-2 text-sm">
+                    <input
+                      type="checkbox"
+                      checked={selectedGpxLayerKinds.tracks}
+                      onChange={(event) =>
+                        setGpxLayerKindSelected("tracks", event.target.checked)
+                      }
+                    />
+                    Tracks
+                  </label>
+                  <label className="flex items-center gap-2 text-sm">
+                    <input
+                      type="checkbox"
+                      checked={selectedGpxLayerKinds.routes}
+                      onChange={(event) =>
+                        setGpxLayerKindSelected("routes", event.target.checked)
+                      }
+                    />
+                    Routes
+                  </label>
+                </div>
+              </div>
             </div>
           )}
 

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -511,9 +511,6 @@ export function TopToolbar({
           <DropdownMenuItem onSelect={() => setAddDataKind("vector")}>
             Add Vector Layer
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setAddDataKind("gpx")}>
-            Add GPX Layer
-          </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => setAddDataKind("raster")}>
             Add Raster Layer
           </DropdownMenuItem>
@@ -552,6 +549,9 @@ export function TopToolbar({
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => setAddDataKind("delimited-text")}>
             Add Delimited Text Layer
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setAddDataKind("gpx")}>
+            Add GPX Layer
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -511,6 +511,9 @@ export function TopToolbar({
           <DropdownMenuItem onSelect={() => setAddDataKind("vector")}>
             Add Vector Layer
           </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setAddDataKind("gpx")}>
+            Add GPX Layer
+          </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => setAddDataKind("raster")}>
             Add Raster Layer
           </DropdownMenuItem>
@@ -549,9 +552,6 @@ export function TopToolbar({
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => setAddDataKind("delimited-text")}>
             Add Delimited Text Layer
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setAddDataKind("gpx")}>
-            Add GPX Layer
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -550,6 +550,9 @@ export function TopToolbar({
           <DropdownMenuItem onSelect={() => setAddDataKind("delimited-text")}>
             Add Delimited Text Layer
           </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setAddDataKind("gpx")}>
+            Add GPX Layer
+          </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
       <DropdownMenu>

--- a/apps/geolibre-desktop/src/lib/gpx.ts
+++ b/apps/geolibre-desktop/src/lib/gpx.ts
@@ -1,0 +1,219 @@
+import type {
+  Feature,
+  FeatureCollection,
+  GeoJsonProperties,
+  LineString,
+  Point,
+  Position,
+} from "geojson";
+
+export interface GpxLayerResult {
+  data: FeatureCollection;
+  routes: FeatureCollection<LineString>;
+  routeCount: number;
+  tracks: FeatureCollection<LineString>;
+  trackCount: number;
+  waypoints: FeatureCollection<Point>;
+  waypointCount: number;
+}
+
+type GpxPointElement = Element;
+
+const GPX_POINT_PROPERTY_NAMES = [
+  "ele",
+  "time",
+  "name",
+  "cmt",
+  "desc",
+  "src",
+  "sym",
+  "type",
+  "fix",
+  "sat",
+  "hdop",
+  "vdop",
+  "pdop",
+  "ageofdgpsdata",
+  "dgpsid",
+];
+
+const GPX_CONTAINER_PROPERTY_NAMES = [
+  "name",
+  "cmt",
+  "desc",
+  "src",
+  "number",
+  "type",
+];
+
+export function parseGpxLayer(text: string): GpxLayerResult {
+  const document = new DOMParser().parseFromString(text, "application/xml");
+  const parserError = document.querySelector("parsererror");
+  if (parserError) {
+    throw new Error("The GPX file is not valid XML.");
+  }
+
+  const gpx = document.documentElement;
+  if (!gpx || gpx.localName.toLowerCase() !== "gpx") {
+    throw new Error("The file does not contain a GPX document.");
+  }
+
+  const waypointFeatures: Feature<Point, GeoJsonProperties>[] = [];
+  const routeFeatures: Feature<LineString, GeoJsonProperties>[] = [];
+  const trackFeatures: Feature<LineString, GeoJsonProperties>[] = [];
+  const waypoints = directChildren(gpx, "wpt");
+  const routes = directChildren(gpx, "rte");
+  const tracks = directChildren(gpx, "trk");
+
+  for (const [index, waypoint] of waypoints.entries()) {
+    const coordinate = coordinateFromPoint(waypoint);
+    if (!coordinate) continue;
+    waypointFeatures.push({
+      type: "Feature",
+      geometry: {
+        type: "Point",
+        coordinates: coordinate,
+      },
+      properties: {
+        ...pointProperties(waypoint),
+        gpx_index: index + 1,
+        gpx_kind: "waypoint",
+      },
+    } satisfies Feature<Point, GeoJsonProperties>);
+  }
+
+  for (const [index, route] of routes.entries()) {
+    const routePoints = directChildren(route, "rtept");
+    const coordinates = coordinatesFromPoints(routePoints);
+    if (coordinates.length < 2) continue;
+    routeFeatures.push({
+      type: "Feature",
+      geometry: {
+        type: "LineString",
+        coordinates,
+      },
+      properties: {
+        ...containerProperties(route),
+        gpx_index: index + 1,
+        gpx_kind: "route",
+        point_count: coordinates.length,
+      },
+    } satisfies Feature<LineString, GeoJsonProperties>);
+  }
+
+  for (const [trackIndex, track] of tracks.entries()) {
+    const segments = directChildren(track, "trkseg");
+    for (const [segmentIndex, segment] of segments.entries()) {
+      const trackPoints = directChildren(segment, "trkpt");
+      const coordinates = coordinatesFromPoints(trackPoints);
+      if (coordinates.length < 2) continue;
+      trackFeatures.push({
+        type: "Feature",
+        geometry: {
+          type: "LineString",
+          coordinates,
+        },
+        properties: {
+          ...containerProperties(track),
+          gpx_index: trackIndex + 1,
+          gpx_kind: "track",
+          point_count: coordinates.length,
+          segment_count: segments.length,
+          segment_index: segmentIndex + 1,
+        },
+      } satisfies Feature<LineString, GeoJsonProperties>);
+    }
+  }
+
+  const features: Feature[] = [
+    ...waypointFeatures,
+    ...routeFeatures,
+    ...trackFeatures,
+  ];
+
+  if (features.length === 0) {
+    throw new Error("No valid GPX waypoints, routes, or tracks were found.");
+  }
+
+  return {
+    data: {
+      type: "FeatureCollection",
+      features,
+    },
+    routes: {
+      type: "FeatureCollection",
+      features: routeFeatures,
+    },
+    routeCount: routes.length,
+    tracks: {
+      type: "FeatureCollection",
+      features: trackFeatures,
+    },
+    trackCount: tracks.length,
+    waypoints: {
+      type: "FeatureCollection",
+      features: waypointFeatures,
+    },
+    waypointCount: waypoints.length,
+  };
+}
+
+function directChildren(parent: Element, localName: string): Element[] {
+  return Array.from(parent.children).filter(
+    (child) => child.localName.toLowerCase() === localName,
+  );
+}
+
+function childText(parent: Element, localName: string): string | undefined {
+  const child = directChildren(parent, localName)[0];
+  const value = child?.textContent?.trim();
+  return value || undefined;
+}
+
+function pointProperties(point: Element): GeoJsonProperties {
+  const properties: GeoJsonProperties = {};
+  for (const name of GPX_POINT_PROPERTY_NAMES) {
+    const value = childText(point, name);
+    if (value !== undefined) properties[name] = numericValue(value);
+  }
+  return properties;
+}
+
+function containerProperties(container: Element): GeoJsonProperties {
+  const properties: GeoJsonProperties = {};
+  for (const name of GPX_CONTAINER_PROPERTY_NAMES) {
+    const value = childText(container, name);
+    if (value !== undefined) properties[name] = numericValue(value);
+  }
+  return properties;
+}
+
+function coordinateFromPoint(point: GpxPointElement): Position | null {
+  const latitude = Number(point.getAttribute("lat"));
+  const longitude = Number(point.getAttribute("lon"));
+  if (
+    !Number.isFinite(latitude) ||
+    !Number.isFinite(longitude) ||
+    latitude < -90 ||
+    latitude > 90 ||
+    longitude < -180 ||
+    longitude > 180
+  ) {
+    return null;
+  }
+
+  const elevation = Number(childText(point, "ele"));
+  if (Number.isFinite(elevation)) return [longitude, latitude, elevation];
+  return [longitude, latitude];
+}
+
+function coordinatesFromPoints(points: GpxPointElement[]): Position[] {
+  return points
+    .map(coordinateFromPoint)
+    .filter((coordinate): coordinate is Position => coordinate !== null);
+}
+
+function numericValue(value: string): string | number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && value.trim() !== "" ? parsed : value;
+}

--- a/apps/geolibre-desktop/src/lib/gpx.ts
+++ b/apps/geolibre-desktop/src/lib/gpx.ts
@@ -46,6 +46,20 @@ const GPX_CONTAINER_PROPERTY_NAMES = [
   "type",
 ];
 
+// GPX fields defined as numeric types in the schema. Every other tag (name,
+// cmt, desc, src, sym, type, fix, time, ...) is textual and must stay a string
+// so values like a name of "0012" are not coerced into the number 12.
+const GPX_NUMERIC_PROPERTY_NAMES = new Set([
+  "ele",
+  "sat",
+  "hdop",
+  "vdop",
+  "pdop",
+  "ageofdgpsdata",
+  "dgpsid",
+  "number",
+]);
+
 export function parseGpxLayer(text: string): GpxLayerResult {
   const document = new DOMParser().parseFromString(text, "application/xml");
   const parserError = document.querySelector("parsererror");
@@ -144,17 +158,17 @@ export function parseGpxLayer(text: string): GpxLayerResult {
       type: "FeatureCollection",
       features: routeFeatures,
     },
-    routeCount: routes.length,
+    routeCount: routeFeatures.length,
     tracks: {
       type: "FeatureCollection",
       features: trackFeatures,
     },
-    trackCount: tracks.length,
+    trackCount: trackFeatures.length,
     waypoints: {
       type: "FeatureCollection",
       features: waypointFeatures,
     },
-    waypointCount: waypoints.length,
+    waypointCount: waypointFeatures.length,
   };
 }
 
@@ -174,7 +188,7 @@ function pointProperties(point: Element): GeoJsonProperties {
   const properties: GeoJsonProperties = {};
   for (const name of GPX_POINT_PROPERTY_NAMES) {
     const value = childText(point, name);
-    if (value !== undefined) properties[name] = numericValue(value);
+    if (value !== undefined) properties[name] = propertyValue(name, value);
   }
   return properties;
 }
@@ -183,14 +197,21 @@ function containerProperties(container: Element): GeoJsonProperties {
   const properties: GeoJsonProperties = {};
   for (const name of GPX_CONTAINER_PROPERTY_NAMES) {
     const value = childText(container, name);
-    if (value !== undefined) properties[name] = numericValue(value);
+    if (value !== undefined) properties[name] = propertyValue(name, value);
   }
   return properties;
 }
 
+function propertyValue(name: string, value: string): string | number {
+  return GPX_NUMERIC_PROPERTY_NAMES.has(name) ? numericValue(value) : value;
+}
+
 function coordinateFromPoint(point: GpxPointElement): Position | null {
-  const latitude = Number(point.getAttribute("lat"));
-  const longitude = Number(point.getAttribute("lon"));
+  const latitudeAttribute = point.getAttribute("lat");
+  const longitudeAttribute = point.getAttribute("lon");
+  if (!latitudeAttribute?.trim() || !longitudeAttribute?.trim()) return null;
+  const latitude = Number(latitudeAttribute);
+  const longitude = Number(longitudeAttribute);
   if (
     !Number.isFinite(latitude) ||
     !Number.isFinite(longitude) ||

--- a/apps/geolibre-desktop/src/lib/gpx.ts
+++ b/apps/geolibre-desktop/src/lib/gpx.ts
@@ -8,12 +8,18 @@ import type {
 } from "geojson";
 
 export interface GpxLayerResult {
-  data: FeatureCollection;
   routes: FeatureCollection<LineString>;
+  /** Number of route features produced (routes with at least 2 valid points). */
   routeCount: number;
   tracks: FeatureCollection<LineString>;
+  /**
+   * Number of track features produced. Each `<trkseg>` becomes its own
+   * LineString, so a single `<trk>` with multiple segments contributes more
+   * than one to this count.
+   */
   trackCount: number;
   waypoints: FeatureCollection<Point>;
+  /** Number of waypoint features produced (waypoints with valid coordinates). */
   waypointCount: number;
 }
 
@@ -139,21 +145,15 @@ export function parseGpxLayer(text: string): GpxLayerResult {
     }
   }
 
-  const features: Feature[] = [
-    ...waypointFeatures,
-    ...routeFeatures,
-    ...trackFeatures,
-  ];
-
-  if (features.length === 0) {
+  if (
+    waypointFeatures.length === 0 &&
+    routeFeatures.length === 0 &&
+    trackFeatures.length === 0
+  ) {
     throw new Error("No valid GPX waypoints, routes, or tracks were found.");
   }
 
   return {
-    data: {
-      type: "FeatureCollection",
-      features,
-    },
     routes: {
       type: "FeatureCollection",
       features: routeFeatures,

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -18,6 +18,7 @@ const APP_VERSION = JSON.parse(
 ).version as string;
 const WMS_PROXY_PATH = "/__geolibre_wms_proxy";
 const WFS_PROXY_PATH = "/__geolibre_wfs_proxy";
+const GPX_PROXY_PATH = "/__geolibre_gpx_proxy";
 const RASTER_PROXY_PATH = "/__geolibre_raster_proxy";
 const DUCKDB_WORKER_PATH_PART = "/@duckdb/duckdb-wasm/dist/";
 const DUCKDB_WORKER_SOURCE_MAP_RE =
@@ -86,6 +87,17 @@ function wmsProxyPlugin(): Plugin {
         } catch (error) {
           const message =
             error instanceof Error ? error.message : "WFS proxy request failed";
+          res.statusCode = 502;
+          res.setHeader("content-type", "text/plain");
+          res.end(message);
+        }
+      });
+      server.middlewares.use(GPX_PROXY_PATH, async (req, res) => {
+        try {
+          await proxyBinaryRequest(req, res, GPX_PROXY_PATH);
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : "GPX proxy request failed";
           res.statusCode = 502;
           res.setHeader("content-type", "text/plain");
           res.end(message);


### PR DESCRIPTION
## Summary
- Add a GPX option to the Add Data dialog that parses waypoints, routes, and tracks from a GPX file or URL into GeoJSON layers.
- Let users pick which GPX layer types to load and add each as a separate layer.
- Add a dev server proxy path for remote GPX URLs to avoid CORS issues, matching the existing WMS/WFS proxy pattern.

## Test plan
- [ ] Load a remote GPX URL (default sample) and confirm waypoints, routes, and tracks render.
- [ ] Load a local GPX file and confirm the same.
- [ ] Toggle layer type checkboxes and confirm only selected types are added.
- [ ] Confirm an invalid or non-GPX file surfaces a clear error.