### PR TITLE
chore: release v0.7.0

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolibre-desktop",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/geolibre-desktop/src-tauri/Cargo.lock
+++ b/apps/geolibre-desktop/src-tauri/Cargo.lock
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-desktop"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "flate2",
  "reqwest 0.12.28",

--- a/apps/geolibre-desktop/src-tauri/Cargo.toml
+++ b/apps/geolibre-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-desktop"
-version = "0.6.0"
+version = "0.7.0"
 description = "GeoLibre Desktop — lightweight cloud-native desktop GIS"
 authors = ["GeoLibre Contributors"]
 edition = "2021"

--- a/apps/geolibre-desktop/src-tauri/tauri.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "GeoLibre Desktop",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "identifier": "org.geolibre.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/backend/geolibre_server/geolibre_server/app/main.py
+++ b/backend/geolibre_server/geolibre_server/app/main.py
@@ -1,7 +1,7 @@
 """
 GeoLibre processing sidecar (FastAPI).
 
-Future integrations (v0.5+):
+Future integrations (v0.8+):
 - GDAL / Rasterio — raster I/O, warping, COG
 - GeoPandas — vector operations, reproject, buffer
 - DuckDB Spatial — SQL on GeoParquet, spatial joins
@@ -22,7 +22,7 @@ from pydantic import BaseModel
 
 from .whitebox import router as whitebox_router
 
-app = FastAPI(title="GeoLibre Server", version="0.6.0")
+app = FastAPI(title="GeoLibre Server", version="0.7.0")
 # Restrict CORS to the Tauri webview origins and the pinned Vite dev server
 # (vite.config.ts sets strictPort on 5173) rather than any localhost port, so a
 # stray local web app cannot reach the Whitebox endpoints from a browser.

--- a/backend/geolibre_server/geolibre_server/app/whitebox.py
+++ b/backend/geolibre_server/geolibre_server/app/whitebox.py
@@ -193,7 +193,7 @@ def _download_to_temp(url: str, suffix: str) -> Path:
     )
     request = urllib.request.Request(
         url,
-        headers={"User-Agent": "GeoLibre/0.6 uv-bootstrap"},
+        headers={"User-Agent": "GeoLibre/0.7 uv-bootstrap"},
     )
     try:
         with urllib.request.urlopen(request, timeout=60) as response:

--- a/backend/geolibre_server/pyproject.toml
+++ b/backend/geolibre_server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolibre-server"
-version = "0.6.0"
+version = "0.7.0"
 description = "Optional Python processing sidecar for GeoLibre Desktop"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,19 +51,15 @@ GeoParquet is read with DuckDB's Parquet reader after loading Spatial. Other loc
 
 ## Advanced Add Data workflows
 
-The v0.6.0 Add Data surface includes native dialogs for XYZ, WMS, vector files, GeoJSON URLs, vector tile sources, raster tile templates, COG and GeoTIFF rasters, MBTiles, and ArcGIS FeatureServer or VectorTileServer layers. The Components plugin wraps `maplibre-gl-components` panels for FlatGeobuf, PMTiles, Zarr, LiDAR, and Gaussian splats, then mirrors added layers into the GeoLibre store so the Layer panel, project format, and layer control can reason about them.
+The v0.7.0 Add Data surface includes native dialogs for XYZ, WMS, WFS, vector files, GeoJSON URLs, vector tile sources, delimited text, raster tile templates, COG and GeoTIFF rasters, MBTiles, ArcGIS FeatureServer or VectorTileServer layers, and GPX waypoints, tracks, and routes. The Components plugin wraps `maplibre-gl-components` panels for FlatGeobuf, PMTiles, Zarr, LiDAR, and Gaussian splats, then mirrors added layers into the GeoLibre store so the Layer panel, project format, and layer control can reason about them.
 
 Local MBTiles tiles are read through a custom MapLibre protocol backed by Tauri commands. Remote rasters are fetched through the desktop backend when needed, and the local development server includes a raster proxy for selected release assets that need CORS handling.
 
 ## Python sidecar
 
-The FastAPI app in `backend/geolibre_server` is reserved for heavier processing workflows and is planned to run as a Tauri **external binary**:
+The FastAPI app in `backend/geolibre_server` backs the v0.7 Whitebox toolbox through a managed local processing sidecar. The desktop app starts the sidecar on demand, communicates over `127.0.0.1`, and keeps the heavier Python processing stack outside the browser bundle.
 
-1. Bundle `geolibre-server` in `src-tauri/bin/`.
-2. Spawn on first processing request needing GDAL/GeoPandas.
-3. Communicate via HTTP on `127.0.0.1:8765`.
-
-Not required for the MVP UI.
+Future processing releases are expected to expand the same sidecar pattern for GDAL, Rasterio, GeoPandas, DuckDB Spatial SQL, Leafmap, GeoAI, and SamGeo workflows.
 
 ## Security
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,4 +97,4 @@ Use `toolbar=icons` when you only want icon-only toolbar buttons. `panels=hidden
 
 ## Project status
 
-GeoLibre is an active prototype. Version 0.6.0 includes the map workspace, project format, plugin API, browser vector import, DuckDB-WASM Spatial loading, advanced Add Data workflows, MBTiles desktop support, ArcGIS layers, COG and GeoTIFF raster rendering, PMTiles, Zarr, LiDAR, Gaussian splats, and persisted recent projects. See the [roadmap](roadmap.md) for planned work on SQL workflows, the Python processing sidecar, and external plugin loading.
+GeoLibre is an active prototype. Version 0.7.0 includes the map workspace, project format, plugin API, browser vector import, DuckDB-WASM Spatial loading, advanced Add Data workflows, MBTiles desktop support, ArcGIS layers, COG and GeoTIFF raster rendering, PMTiles, Zarr, LiDAR, Gaussian splats, WFS layers, delimited text layers, GPX layers, WMS GetFeatureInfo identify, plugin-state persistence, map settings, runtime environment variables, inline attribute editing, and the Whitebox toolbox. See the [roadmap](roadmap.md) for planned work on SQL workflows, expanded processing pipelines, and external plugin loading.

--- a/docs/project-format.md
+++ b/docs/project-format.md
@@ -73,7 +73,7 @@ Projects without a `plugins` section open with the built-in default plugin state
 
 ## Layer types
 
-| Type | v0.6.0 status |
+| Type | v0.7.0 status |
 |------|---------------|
 | `geojson` | Supported for imported files and GeoJSON URLs |
 | `xyz` | Supported for raster tile templates |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -38,7 +38,7 @@
 - [x] Plugin control position controls in the Plugins menu
 - [x] Layer control integration for GeoLibre-managed layers
 
-## v0.6: Project access, web embeds, and expanded integrations (current)
+## v0.6: Project access, web embeds, and expanded integrations
 
 - [x] Persistent recent projects with desktop file recents and URL-backed web recents
 - [x] Separate Open Project from File and Open Project from URL flows
@@ -47,15 +47,28 @@
 - [x] STAC search workflow for adding catalog-backed raster layers
 - [x] Esri Wayback, GeoAgent, GeoEditor, Street View, and Swipe plugin integrations
 
-## v0.7: SQL and processing sidecar
+## v0.7: Add Data expansion, identify, settings, and processing (current)
 
-- [ ] Bundle FastAPI server as Tauri external bin
+- [x] GPX loading from URL or local file, with selectable waypoint, track, and route layers
+- [x] Delimited text loading from URL or local file using longitude and latitude fields
+- [x] WFS GetFeature loading through the Add Data dialog
+- [x] WMS GetFeatureInfo identify support with hardened popup handling
+- [x] Whitebox toolbox backed by a managed Python sidecar
+- [x] Inline attribute editing, horizontal table scrolling, and scrollable identify popups
+- [x] Settings dialog for map preferences and runtime environment variables
+- [x] Plugin state persistence in project files
+- [x] Default GeoJSON sample URL and larger identify popup
+- [x] Local raster file loading fix
+- [x] Large-file pre-commit guard
+
+## v0.8: SQL and processing sidecar
+
 - [ ] GDAL / Rasterio / GeoPandas pipelines
 - [ ] Buffer, reproject, export GeoJSON
-- [ ] WhiteboxTools, Leafmap, GeoAI, SamGeo (selective)
+- [ ] Expanded WhiteboxTools coverage, Leafmap, GeoAI, SamGeo (selective)
 - [ ] SQL panel and query-result layers
 
-## v0.8: External plugin system
+## v0.9: External plugin system
 
 - [ ] External plugin packages
 - [ ] Plugin marketplace / registry (design)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolibre",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolibre",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -16,7 +16,7 @@
       }
     },
     "apps/geolibre-desktop": {
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "@carbonplan/zarr-layer": "^0.3.1",
         "@deck.gl/core": "^9.3.2",
@@ -6964,7 +6964,7 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/raf": {
@@ -6984,7 +6984,7 @@
       "version": "18.3.29",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.29.tgz",
       "integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -6995,7 +6995,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -7859,7 +7859,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -12546,7 +12546,7 @@
     },
     "packages/core": {
       "name": "@geolibre/core",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "uuid": "^11.1.0",
         "zustand": "^5.0.3"
@@ -12558,7 +12558,7 @@
     },
     "packages/map": {
       "name": "@geolibre/map",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "@geolibre/core": "*",
         "@turf/bbox": "^7.2.0",
@@ -12582,7 +12582,7 @@
     },
     "packages/plugins": {
       "name": "@geolibre/plugins",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "@carbonplan/zarr-layer": "^0.3.1",
         "@deck.gl/core": "^9.3.2",
@@ -12707,7 +12707,7 @@
     },
     "packages/processing": {
       "name": "@geolibre/processing",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "@geolibre/core": "*",
         "@turf/bbox": "^7.2.0"
@@ -12719,7 +12719,7 @@
     },
     "packages/ui": {
       "name": "@geolibre/ui",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-dropdown-menu": "^2.1.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geolibre",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "GeoLibre Desktop — lightweight cloud-native desktop GIS",
   "workspaces": [
     "apps/*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/core",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/map",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/plugins",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/processing/package.json
+++ b/packages/processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/processing",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/ui",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",


### PR DESCRIPTION
## Summary
- Bump all workspace packages, the desktop app, and the Python sidecar from 0.6.0 to 0.7.0.
- Refresh docs (architecture, index, project format, roadmap) to cover the WFS, delimited text, and GPX Add Data workflows, WMS GetFeatureInfo identify, settings dialog, plugin-state persistence, and the Whitebox toolbox shipped this cycle.
- Re-target the SQL/processing sidecar and external plugin milestones to v0.8 and v0.9.

## Test plan
- [x] pre-commit run --all-files passes (includes npm build)