### PR TITLE
docs: point demo links to viewer.geolibre.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Lightweight, cloud-native desktop GIS prototype built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS**, **DuckDB-WASM Spatial**, and **deck.gl**.
 
-[![](https://files.opengeos.org/GeoLibre-OPERA-demo.webp)](https://geolibre.app/demo/?url=https://data.geolibre.app/opera-dswx.geolibre.json)
+[![](https://files.opengeos.org/GeoLibre-OPERA-demo.webp)](https://viewer.geolibre.app/?url=https://data.geolibre.app/opera-dswx.geolibre.json)
 
 ## Features (v0.6.0)
 
@@ -47,7 +47,7 @@ The browser demo supports URL parameters for iframe-friendly layouts.
 
 Open a project by URL:
 
-<https://geolibre.app/demo/?url=https://data.geolibre.app/opera-dswx.geolibre.json>
+<https://viewer.geolibre.app/?url=https://data.geolibre.app/opera-dswx.geolibre.json>
 
 Supported query parameters:
 
@@ -62,13 +62,13 @@ Supported query parameters:
 Use compact mode for narrow embeds. This shows icon-only toolbar buttons and hides project metadata:
 
 ```text
-https://geolibre.app/demo/?url=https://data.geolibre.app/opera-dswx.geolibre.json&layout=compact
+https://viewer.geolibre.app/?url=https://data.geolibre.app/opera-dswx.geolibre.json&layout=compact
 ```
 
 Hide the Layers, Style, and Attribute table panels for map-focused embeds:
 
 ```text
-https://geolibre.app/demo/?url=https://data.geolibre.app/opera-dswx.geolibre.json&layout=compact&panels=none
+https://viewer.geolibre.app/?url=https://data.geolibre.app/opera-dswx.geolibre.json&layout=compact&panels=none
 ```
 
 Use `toolbar=icons` when you only want icon-only toolbar buttons. `panels=hidden`, `panels=hide`, `panels=off`, and `hidePanels=true` are accepted aliases for hiding panels.

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -3,7 +3,7 @@
 GeoLibre desktop installers are published from GitHub Releases.
 
 [View releases](https://github.com/opengeos/GeoLibre/releases){ .md-button .md-button--primary }
-[Open live demo](/demo/){ .md-button }
+[Open live demo](https://viewer.geolibre.app/){ .md-button }
 
 ## Release assets
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ hide:
       path toward cloud-native geospatial workflows.
     </p>
     <div class="hero__actions">
-      <a class="md-button md-button--primary" href="/demo/">Open live demo</a>
+      <a class="md-button md-button--primary" href="https://viewer.geolibre.app/">Open live demo</a>
       <a class="md-button" href="getting-started/">Get started</a>
       <a class="md-button" href="downloads/">Download app</a>
     </div>
@@ -92,7 +92,7 @@ Use `toolbar=icons` when you only want icon-only toolbar buttons. `panels=hidden
 | `panels` | `panels=none` | Hides the Layers, Style, and Attribute table panels. `hidden`, `hide`, and `off` are aliases. |
 | `hidePanels` | `hidePanels=true` | Alternative way to hide the Layers, Style, and Attribute table panels. |
 
-[Open the live demo](/demo/){ .md-button .md-button--primary }
+[Open the live demo](https://viewer.geolibre.app/){ .md-button .md-button--primary }
 [Read the architecture](architecture.md){ .md-button }
 
 ## Project status

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,19 +67,19 @@ The live demo is the browser-capable version of the GeoLibre desktop UI. It is u
 Open a project by passing a public `.geolibre.json` URL with the `url` query parameter:
 
 ```text
-https://geolibre.app/demo/?url=https://data.geolibre.app/opera-dswx.geolibre.json
+https://viewer.geolibre.app/?url=https://data.geolibre.app/opera-dswx.geolibre.json
 ```
 
 For narrow embeds, add `?layout=compact` to the demo URL to use icon-only toolbar buttons and hide project metadata:
 
 ```text
-https://geolibre.app/demo/?url=https://data.geolibre.app/opera-dswx.geolibre.json&layout=compact
+https://viewer.geolibre.app/?url=https://data.geolibre.app/opera-dswx.geolibre.json&layout=compact
 ```
 
 For map-focused embeds, add `&panels=none` to hide the Layers, Style, and Attribute table panels:
 
 ```text
-https://geolibre.app/demo/?url=https://data.geolibre.app/opera-dswx.geolibre.json&layout=compact&panels=none
+https://viewer.geolibre.app/?url=https://data.geolibre.app/opera-dswx.geolibre.json&layout=compact&panels=none
 ```
 
 Use `toolbar=icons` when you only want icon-only toolbar buttons. `panels=hidden`, `panels=hide`, `panels=off`, and `hidePanels=true` are accepted aliases for hiding panels.


### PR DESCRIPTION
## Summary
- Update the README and docs to link the live demo at `https://viewer.geolibre.app/` instead of `https://geolibre.app/demo/`.
- The dedicated subdomain is now served by the Cloudflare Worker added in #104; the worker proxies to the GitHub Pages build, so the query parameters and paths are unchanged.

## Test plan
- [ ] Confirm the updated links resolve and load a project, e.g. https://viewer.geolibre.app/?url=https://data.geolibre.app/opera-dswx.geolibre.json
- [ ] Verify the compact and panels=none embed examples still work on the new subdomain.