### PR TITLE
feat: add update check to desktop About dialog

### DIFF
--- a/apps/geolibre-desktop/src-tauri/capabilities/default.json
+++ b/apps/geolibre-desktop/src-tauri/capabilities/default.json
@@ -15,6 +15,7 @@
       "identifier": "opener:allow-open-url",
       "allow": [
         { "url": "https://geolibre.app" },
+        { "url": "https://geolibre.app/downloads/" },
         { "url": "https://github.com/opengeos/GeoLibre" }
       ]
     }

--- a/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
@@ -10,7 +10,7 @@ import {
 } from "@geolibre/ui";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { CheckCircle2, ExternalLink, Info, Map, RefreshCw } from "lucide-react";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 const LINKS = [
   {
@@ -88,6 +88,14 @@ export function AboutDialog({
   const [updateError, setUpdateError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
 
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  const resetUpdateState = () => {
+    setUpdateStatus("idle");
+    setLatestVersion(null);
+    setUpdateError(null);
+  };
+
   const handleCheckForUpdates = async () => {
     abortRef.current?.abort();
     const controller = new AbortController();
@@ -98,11 +106,22 @@ export function AboutDialog({
 
     try {
       const response = await fetch(LATEST_RELEASE_URL, {
-        headers: { Accept: "application/vnd.github+json" },
+        headers: {
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
         signal: controller.signal,
       });
 
       if (!response.ok) {
+        if (
+          response.status === 403 &&
+          response.headers.get("X-RateLimit-Remaining") === "0"
+        ) {
+          throw new Error(
+            "GitHub rate limit exceeded. Please try again later.",
+          );
+        }
         throw new Error(`GitHub returned ${response.status}.`);
       }
 
@@ -115,7 +134,7 @@ export function AboutDialog({
 
       setLatestVersion(nextLatestVersion);
       setUpdateStatus(
-        compareVersions(APP_VERSION, release.tag_name) < 0
+        compareVersions(APP_VERSION, nextLatestVersion) < 0
           ? "available"
           : "current",
       );
@@ -132,7 +151,11 @@ export function AboutDialog({
   };
 
   return (
-    <Dialog>
+    <Dialog
+      onOpenChange={(open) => {
+        if (open) resetUpdateState();
+      }}
+    >
       <DialogTrigger asChild>
         <Button
           className={buttonClassName}

--- a/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
@@ -9,7 +9,8 @@ import {
   DialogTrigger,
 } from "@geolibre/ui";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { ExternalLink, Info, Map } from "lucide-react";
+import { CheckCircle2, ExternalLink, Info, Map, RefreshCw } from "lucide-react";
+import { useState } from "react";
 
 const LINKS = [
   {
@@ -22,7 +23,16 @@ const LINKS = [
   },
 ];
 
+const UPDATE_URL = "https://geolibre.app/downloads/";
+const LATEST_RELEASE_URL =
+  "https://api.github.com/repos/opengeos/GeoLibre/releases/latest";
 const APP_VERSION = __GEOLIBRE_VERSION__;
+
+type UpdateStatus = "idle" | "checking" | "current" | "available" | "error";
+
+interface GitHubRelease {
+  tag_name?: unknown;
+}
 
 interface AboutDialogProps {
   buttonClassName?: string;
@@ -43,12 +53,82 @@ async function openExternalLink(url: string) {
   window.open(url, "_blank", "noopener,noreferrer");
 }
 
+function parseVersion(version: string): [number, number, number] | null {
+  const match = version.trim().match(/^v?(\d+)(?:\.(\d+))?(?:\.(\d+))?/i);
+  if (!match) return null;
+
+  return [
+    Number(match[1]),
+    Number(match[2] ?? 0),
+    Number(match[3] ?? 0),
+  ];
+}
+
+function compareVersions(currentVersion: string, latestVersion: string): number {
+  const current = parseVersion(currentVersion);
+  const latest = parseVersion(latestVersion);
+  if (!current || !latest) return currentVersion.localeCompare(latestVersion);
+
+  for (let index = 0; index < current.length; index += 1) {
+    if (current[index] !== latest[index]) return current[index] - latest[index];
+  }
+
+  return 0;
+}
+
+function formatVersion(version: string): string {
+  const trimmedVersion = version.trim();
+  return trimmedVersion.startsWith("v") ? trimmedVersion : `v${trimmedVersion}`;
+}
+
 export function AboutDialog({
   buttonClassName,
   buttonSize = "sm",
   iconClassName,
   showLabels = true,
 }: AboutDialogProps) {
+  const [updateStatus, setUpdateStatus] = useState<UpdateStatus>("idle");
+  const [latestVersion, setLatestVersion] = useState<string | null>(null);
+  const [updateError, setUpdateError] = useState<string | null>(null);
+
+  const handleCheckForUpdates = async () => {
+    setUpdateStatus("checking");
+    setLatestVersion(null);
+    setUpdateError(null);
+
+    try {
+      const response = await fetch(LATEST_RELEASE_URL, {
+        headers: { Accept: "application/vnd.github+json" },
+      });
+
+      if (!response.ok) {
+        throw new Error(`GitHub returned ${response.status}.`);
+      }
+
+      const release = (await response.json()) as GitHubRelease;
+      if (typeof release.tag_name !== "string" || !release.tag_name.trim()) {
+        throw new Error("The latest release does not include a version tag.");
+      }
+
+      const nextLatestVersion = formatVersion(release.tag_name);
+
+      setLatestVersion(nextLatestVersion);
+      setUpdateStatus(
+        compareVersions(APP_VERSION, release.tag_name) < 0
+          ? "available"
+          : "current",
+      );
+    } catch (error) {
+      console.error("Failed to check for updates", error);
+      setUpdateStatus("error");
+      setUpdateError(
+        error instanceof Error
+          ? error.message
+          : "Could not check for updates.",
+      );
+    }
+  };
+
   return (
     <Dialog>
       <DialogTrigger asChild>
@@ -77,6 +157,75 @@ export function AboutDialog({
             <span className="text-muted-foreground">Version</span>
             <span className="font-mono text-foreground">v{APP_VERSION}</span>
           </div>
+          <Button
+            className="w-full justify-between"
+            disabled={updateStatus === "checking"}
+            onClick={() => void handleCheckForUpdates()}
+            type="button"
+            variant="outline"
+          >
+            <span className="inline-flex items-center gap-2">
+              <RefreshCw
+                className={`h-3.5 w-3.5 ${
+                  updateStatus === "checking" ? "animate-spin" : ""
+                }`}
+              />
+              {updateStatus === "checking"
+                ? "Checking for updates"
+                : "Check for updates"}
+            </span>
+          </Button>
+          {updateStatus !== "idle" && updateStatus !== "checking" ? (
+            <div className="rounded-md border bg-muted/30 px-3 py-2">
+              {updateStatus === "current" ? (
+                <div className="flex items-center gap-2 text-foreground">
+                  <CheckCircle2 className="h-3.5 w-3.5 text-primary" />
+                  <span>
+                    You are up to date
+                    {latestVersion ? ` (${latestVersion}).` : "."}
+                  </span>
+                </div>
+              ) : null}
+              {updateStatus === "available" ? (
+                <div className="space-y-2">
+                  <div className="text-foreground">
+                    {latestVersion} is available. You are running v
+                    {APP_VERSION}.
+                  </div>
+                  <Button
+                    className="w-full justify-between"
+                    onClick={() => void openExternalLink(UPDATE_URL)}
+                    type="button"
+                    variant="default"
+                  >
+                    <span>Download update</span>
+                    <ExternalLink className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+              ) : null}
+              {updateStatus === "error" ? (
+                <div className="space-y-2">
+                  <div className="text-foreground">
+                    Could not check for updates.
+                  </div>
+                  {updateError ? (
+                    <div className="text-xs text-muted-foreground">
+                      {updateError}
+                    </div>
+                  ) : null}
+                  <Button
+                    className="w-full justify-between"
+                    onClick={() => void openExternalLink(UPDATE_URL)}
+                    type="button"
+                    variant="outline"
+                  >
+                    <span>View downloads</span>
+                    <ExternalLink className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+              ) : null}
+            </div>
+          ) : null}
           {LINKS.map((link) => (
             <a
               key={link.href}

--- a/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
@@ -10,7 +10,7 @@ import {
 } from "@geolibre/ui";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { CheckCircle2, ExternalLink, Info, Map, RefreshCw } from "lucide-react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 const LINKS = [
   {
@@ -54,20 +54,16 @@ async function openExternalLink(url: string) {
 }
 
 function parseVersion(version: string): [number, number, number] | null {
-  const match = version.trim().match(/^v?(\d+)(?:\.(\d+))?(?:\.(\d+))?/i);
+  const match = version.trim().match(/^v?(\d+)\.(\d+)\.(\d+)$/);
   if (!match) return null;
 
-  return [
-    Number(match[1]),
-    Number(match[2] ?? 0),
-    Number(match[3] ?? 0),
-  ];
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
 }
 
 function compareVersions(currentVersion: string, latestVersion: string): number {
   const current = parseVersion(currentVersion);
   const latest = parseVersion(latestVersion);
-  if (!current || !latest) return currentVersion.localeCompare(latestVersion);
+  if (!current || !latest) return 0;
 
   for (let index = 0; index < current.length; index += 1) {
     if (current[index] !== latest[index]) return current[index] - latest[index];
@@ -90,8 +86,12 @@ export function AboutDialog({
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus>("idle");
   const [latestVersion, setLatestVersion] = useState<string | null>(null);
   const [updateError, setUpdateError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
 
   const handleCheckForUpdates = async () => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
     setUpdateStatus("checking");
     setLatestVersion(null);
     setUpdateError(null);
@@ -99,6 +99,7 @@ export function AboutDialog({
     try {
       const response = await fetch(LATEST_RELEASE_URL, {
         headers: { Accept: "application/vnd.github+json" },
+        signal: controller.signal,
       });
 
       if (!response.ok) {
@@ -119,6 +120,7 @@ export function AboutDialog({
           : "current",
       );
     } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") return;
       console.error("Failed to check for updates", error);
       setUpdateStatus("error");
       setUpdateError(
@@ -189,8 +191,8 @@ export function AboutDialog({
               {updateStatus === "available" ? (
                 <div className="space-y-2">
                   <div className="text-foreground">
-                    {latestVersion} is available. You are running v
-                    {APP_VERSION}.
+                    {latestVersion ?? "A new version"} is available. You are
+                    running {`v${APP_VERSION}`}.
                   </div>
                   <Button
                     className="w-full justify-between"


### PR DESCRIPTION
## Summary
- Add a "Check for updates" button to the desktop About dialog that queries the latest GitHub release and compares it against the running app version
- Show up-to-date, update-available (with a download link to https://geolibre.app/downloads/), or error states
- Allow the downloads page URL in the Tauri opener capability

## Test plan
- [ ] Open the About dialog in the desktop app and click "Check for updates"
- [ ] Verify the up-to-date message appears when running the latest version
- [ ] Verify the download button appears and opens the downloads page when an older version is detected
- [ ] Verify a friendly error message appears when the network request fails