### PR TITLE
fix: safe fallback for crypto.randomUUID in non-secure contexts

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -175,7 +175,9 @@ const DELIMITED_TEXT_DELIMITERS: Record<
 };
 
 function createLayerId(): string {
-  return crypto.randomUUID();
+  return typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
 
 function fileNameFromPath(path: string): string {


### PR DESCRIPTION
## Problem

`crypto.randomUUID()` is only available in [secure contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) (HTTPS or `localhost`). When GeoLibre is served over plain HTTP — for example, an internal intranet deployment — `createLayerId()` in `AddDataDialog` throws:

`TypeError: crypto.randomUUID is not a function`

This error surfaces immediately when a user attempts to add any data layer.

## Fix

Apply the same guard already used in `SettingsDialog.createDraftId()`:

``` 
return typeof crypto !== 'undefined' && 'randomUUID' in crypto
  ? crypto.randomUUID()
  : \\-\\;
```

The fallback produces a sufficiently unique ID for layer identity purposes.