### PR TITLE
feat: load external plugin zips from app data plugins directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ Open a project by URL:
 
 Supported query parameters:
 
-| Parameter | Example | Description |
-| --- | --- | --- |
-| `url` | `url=https://data.geolibre.app/opera-dswx.geolibre.json` | Loads a `.geolibre.json` project from a public URL. |
-| `layout` | `layout=compact` | Uses the compact embed layout with icon-only toolbar buttons and hidden project metadata. `embed` and `iframe` are aliases. |
-| `toolbar` | `toolbar=icons` | Shows icon-only toolbar buttons without enabling the full compact layout. |
-| `panels` | `panels=none` | Hides the Layers, Style, and Attribute table panels. `hidden`, `hide`, and `off` are aliases. |
-| `hidePanels` | `hidePanels=true` | Alternative way to hide the Layers, Style, and Attribute table panels. |
+| Parameter    | Example                                                  | Description                                                                                                                 |
+| ------------ | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `url`        | `url=https://data.geolibre.app/opera-dswx.geolibre.json` | Loads a `.geolibre.json` project from a public URL.                                                                         |
+| `layout`     | `layout=compact`                                         | Uses the compact embed layout with icon-only toolbar buttons and hidden project metadata. `embed` and `iframe` are aliases. |
+| `toolbar`    | `toolbar=icons`                                          | Shows icon-only toolbar buttons without enabling the full compact layout.                                                   |
+| `panels`     | `panels=none`                                            | Hides the Layers, Style, and Attribute table panels. `hidden`, `hide`, and `off` are aliases.                               |
+| `hidePanels` | `hidePanels=true`                                        | Alternative way to hide the Layers, Style, and Attribute table panels.                                                      |
 
 Use compact mode for narrow embeds. This shows icon-only toolbar buttons and hides project metadata:
 
@@ -125,6 +125,8 @@ docs/                   # Architecture & API docs
 ## Add a plugin
 
 Built-in plugins live in `packages/plugins/src/plugins/` and are registered by the desktop app in `apps/geolibre-desktop/src/hooks/usePlugins.ts`. Map control plugins can expose a control position through `getMapControlPosition()` and `setMapControlPosition()` so the Plugins menu can move them between map corners.
+
+For external plugin development, start from the [GeoLibre plugin template](https://github.com/giswqs/geolibre-plugin-template). It includes a `plugin.json` manifest, a GeoLibre plugin wrapper entry point, and a `package:geolibre` script that creates a zip file for the desktop app data `plugins/` directory. See the [Plugin API](docs/plugin-api.md) for the external zip contract.
 
 1. Create a plugin file in `packages/plugins/src/plugins/`.
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ docs/                   # Architecture & API docs
 
 Built-in plugins live in `packages/plugins/src/plugins/` and are registered by the desktop app in `apps/geolibre-desktop/src/hooks/usePlugins.ts`. Map control plugins can expose a control position through `getMapControlPosition()` and `setMapControlPosition()` so the Plugins menu can move them between map corners.
 
-For external plugin development, start from the [GeoLibre plugin template](https://github.com/giswqs/geolibre-plugin-template). It includes a `plugin.json` manifest, a GeoLibre plugin wrapper entry point, and a `package:geolibre` script that creates a zip file for the desktop app data `plugins/` directory. See the [Plugin API](docs/plugin-api.md) for the external zip contract.
+For external plugin development, start from the [GeoLibre plugin template](https://github.com/giswqs/geolibre-plugin-template). It includes a `plugin.json` manifest, a GeoLibre plugin wrapper entry point, and a `package:geolibre` script that creates a zip file for the desktop app data `plugins/` directory. During development, Settings > Plugins can scan an additional local plugin directory, including an unpacked bundle folder such as the template's `geolibre-plugin/` directory. See the [Plugin API](docs/plugin-api.md) for the external plugin contract.
 
 1. Create a plugin file in `packages/plugins/src/plugins/`.
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ docs/                   # Architecture & API docs
 
 Built-in plugins live in `packages/plugins/src/plugins/` and are registered by the desktop app in `apps/geolibre-desktop/src/hooks/usePlugins.ts`. Map control plugins can expose a control position through `getMapControlPosition()` and `setMapControlPosition()` so the Plugins menu can move them between map corners.
 
-For external plugin development, start from the [GeoLibre plugin template](https://github.com/giswqs/geolibre-plugin-template). It includes a `plugin.json` manifest, a GeoLibre plugin wrapper entry point, and a `package:geolibre` script that creates a zip file for the desktop app data `plugins/` directory. During development, Settings > Plugins can scan an additional local plugin directory, including an unpacked bundle folder such as the template's `geolibre-plugin/` directory. See the [Plugin API](docs/plugin-api.md) for the external plugin contract.
+For external plugin development, start from the [GeoLibre plugin template](https://github.com/opengeos/geolibre-plugin-template). It includes a `plugin.json` manifest, a GeoLibre plugin wrapper entry point, and a `package:geolibre` script that creates a zip file for the desktop app data `plugins/` directory. During development, Settings > Plugins can scan an additional local plugin directory, including an unpacked bundle folder such as the template's `geolibre-plugin/` directory. See the [Plugin API](docs/plugin-api.md) for the external plugin contract.
 
 1. Create a plugin file in `packages/plugins/src/plugins/`.
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ docs/                   # Architecture & API docs
 
 Built-in plugins live in `packages/plugins/src/plugins/` and are registered by the desktop app in `apps/geolibre-desktop/src/hooks/usePlugins.ts`. Map control plugins can expose a control position through `getMapControlPosition()` and `setMapControlPosition()` so the Plugins menu can move them between map corners.
 
-For external plugin development, start from the [GeoLibre plugin template](https://github.com/opengeos/geolibre-plugin-template). It includes a `plugin.json` manifest, a GeoLibre plugin wrapper entry point, and a `package:geolibre` script that creates a zip file for the desktop app data `plugins/` directory. During development, Settings > Plugins can scan an additional local plugin directory, including an unpacked bundle folder such as the template's `geolibre-plugin/` directory. See the [Plugin API](docs/plugin-api.md) for the external plugin contract.
+For external plugin development, start from the [GeoLibre plugin template](https://github.com/opengeos/geolibre-plugin-template). It includes a `plugin.json` manifest, a GeoLibre plugin wrapper entry point, and a `package:geolibre` script that creates a zip file for the desktop app data `plugins/` directory. During development, Settings > Plugins can scan an additional local plugin directory, including an unpacked bundle folder such as the template's `geolibre-plugin/` directory, or a hosted `plugin.json` manifest URL. See the [Plugin API](docs/plugin-api.md) for the external plugin contract.
+
+For web builds, an external plugin can be bundled by placing its built folder under `apps/geolibre-desktop/public/plugins/<plugin-id>/` and loading `/plugins/<plugin-id>/plugin.json` as a manifest URL. Browsers cannot scan plugin folders at runtime, so bundled web plugins still need explicit manifest URLs unless they are registered as built-in plugins.
 
 1. Create a plugin file in `packages/plugins/src/plugins/`.
 

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -255,7 +255,11 @@ fn load_external_plugin_bundles_blocking(
 }
 
 fn normalize_path_key(path: &Path) -> String {
-    path.to_string_lossy().replace('\\', "/")
+    // Canonicalize so symlinks and case differences on case-insensitive file
+    // systems (Windows, macOS) dedupe to one key; fall back to the raw path
+    // when it does not exist yet.
+    let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    canonical.to_string_lossy().replace('\\', "/")
 }
 
 fn scan_external_plugin_directory(

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -402,17 +402,27 @@ fn read_zip_text_entry<R: Read + std::io::Seek>(
     entry_name: &str,
     label: &str,
 ) -> Result<String, String> {
-    let mut entry = archive
+    const MAX_ENTRY_BYTES: u64 = 50 * 1024 * 1024;
+    let entry = archive
         .by_name(entry_name)
         .map_err(|error| format!("Could not read {label} '{entry_name}': {error}"))?;
     if entry.is_dir() {
         return Err(format!("{label} '{entry_name}' must be a file"));
     }
 
+    // Cap the actual bytes read instead of trusting the zip header size,
+    // which a hand-crafted archive can spoof.
     let mut text = String::new();
     entry
+        .take(MAX_ENTRY_BYTES + 1)
         .read_to_string(&mut text)
         .map_err(|error| format!("Could not read {label} '{entry_name}' as UTF-8: {error}"))?;
+    if text.len() as u64 > MAX_ENTRY_BYTES {
+        return Err(format!(
+            "{label} '{entry_name}' exceeds the {}-MB size limit",
+            MAX_ENTRY_BYTES / (1024 * 1024)
+        ));
+    }
     Ok(text)
 }
 
@@ -462,11 +472,16 @@ fn validate_optional_manifest_string(field: &str, value: &str) -> Result<(), Str
 }
 
 fn validate_external_plugin_path(field: &str, value: &str) -> Result<(), String> {
-    if value.starts_with('/') || value.starts_with('\\') {
+    if value.starts_with('/') {
         return Err(format!("{field} must be a relative path"));
     }
     if value.contains('\\') {
         return Err(format!("{field} must use forward slashes"));
+    }
+    if value.contains(':') {
+        return Err(format!(
+            "{field} must not contain drive letters or ':' characters"
+        ));
     }
     if value
         .split('/')

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -91,7 +91,7 @@ struct ExternalPluginBundleError {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct ExternalPluginBundleLoadResult {
-    plugins_directory: String,
+    plugins_directories: Vec<String>,
     bundles: Vec<ExternalPluginBundle>,
     errors: Vec<ExternalPluginBundleError>,
 }
@@ -199,14 +199,18 @@ fn fetch_url_bytes_blocking(url: String) -> Result<Vec<u8>, String> {
 #[tauri::command]
 async fn load_external_plugin_bundles(
     app: tauri::AppHandle,
+    additional_plugin_directories: Vec<String>,
 ) -> Result<ExternalPluginBundleLoadResult, String> {
-    tauri::async_runtime::spawn_blocking(move || load_external_plugin_bundles_blocking(&app))
-        .await
-        .map_err(|error| format!("External plugin scan task failed: {error}"))?
+    tauri::async_runtime::spawn_blocking(move || {
+        load_external_plugin_bundles_blocking(&app, additional_plugin_directories)
+    })
+    .await
+    .map_err(|error| format!("External plugin scan task failed: {error}"))?
 }
 
 fn load_external_plugin_bundles_blocking(
     app: &tauri::AppHandle,
+    additional_plugin_directories: Vec<String>,
 ) -> Result<ExternalPluginBundleLoadResult, String> {
     let plugins_dir = app
         .path()
@@ -217,43 +221,119 @@ fn load_external_plugin_bundles_blocking(
     fs::create_dir_all(&plugins_dir)
         .map_err(|error| format!("Could not create plugins directory: {error}"))?;
 
-    let mut archives = fs::read_dir(&plugins_dir)
-        .map_err(|error| format!("Could not read plugins directory: {error}"))?
-        .filter_map(Result::ok)
-        .filter(|entry| {
-            entry
-                .file_type()
-                .map(|file_type| file_type.is_file())
-                .unwrap_or(false)
-        })
-        .filter(|entry| {
-            entry
-                .path()
-                .extension()
-                .and_then(|extension| extension.to_str())
-                .is_some_and(|extension| extension.eq_ignore_ascii_case("zip"))
-        })
-        .collect::<Vec<_>>();
-    archives.sort_by_key(|entry| entry.file_name().to_string_lossy().to_string());
+    let mut plugin_dirs = Vec::new();
+    let mut seen_dirs = HashSet::new();
+    for directory in additional_plugin_directories {
+        let directory = directory.trim();
+        if directory.is_empty() {
+            continue;
+        }
+        let path = PathBuf::from(directory);
+        let key = normalize_path_key(&path);
+        if seen_dirs.insert(key) {
+            plugin_dirs.push(path);
+        }
+    }
+    if seen_dirs.insert(normalize_path_key(&plugins_dir)) {
+        plugin_dirs.push(plugins_dir);
+    }
 
     let mut bundles = Vec::new();
     let mut errors = Vec::new();
-    for archive in archives {
-        let archive_name = archive.file_name().to_string_lossy().to_string();
-        match load_external_plugin_archive(&archive.path(), &archive_name) {
-            Ok(bundle) => bundles.push(bundle),
-            Err(message) => errors.push(ExternalPluginBundleError {
-                archive_name,
-                message,
-            }),
-        }
+    for plugin_dir in &plugin_dirs {
+        scan_external_plugin_directory(plugin_dir, &mut bundles, &mut errors);
     }
 
     Ok(ExternalPluginBundleLoadResult {
-        plugins_directory: plugins_dir.to_string_lossy().to_string(),
+        plugins_directories: plugin_dirs
+            .iter()
+            .map(|path| path.to_string_lossy().to_string())
+            .collect(),
         bundles,
         errors,
     })
+}
+
+fn normalize_path_key(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn scan_external_plugin_directory(
+    plugin_dir: &Path,
+    bundles: &mut Vec<ExternalPluginBundle>,
+    errors: &mut Vec<ExternalPluginBundleError>,
+) {
+    if !plugin_dir.exists() {
+        errors.push(ExternalPluginBundleError {
+            archive_name: plugin_dir.to_string_lossy().to_string(),
+            message: "Plugin directory does not exist.".to_string(),
+        });
+        return;
+    }
+
+    if plugin_dir.join("plugin.json").is_file() {
+        let bundle_name = plugin_dir.to_string_lossy().to_string();
+        match load_external_plugin_directory(plugin_dir, &bundle_name) {
+            Ok(bundle) => bundles.push(bundle),
+            Err(message) => errors.push(ExternalPluginBundleError {
+                archive_name: bundle_name,
+                message,
+            }),
+        }
+        return;
+    }
+
+    let mut entries = match fs::read_dir(plugin_dir) {
+        Ok(entries) => entries.filter_map(Result::ok).collect::<Vec<_>>(),
+        Err(error) => {
+            errors.push(ExternalPluginBundleError {
+                archive_name: plugin_dir.to_string_lossy().to_string(),
+                message: format!("Could not read plugins directory: {error}"),
+            });
+            return;
+        }
+    };
+    entries.sort_by_key(|entry| entry.file_name().to_string_lossy().to_string());
+
+    for entry in entries {
+        let path = entry.path();
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(error) => {
+                errors.push(ExternalPluginBundleError {
+                    archive_name: path.to_string_lossy().to_string(),
+                    message: format!("Could not inspect plugin entry: {error}"),
+                });
+                continue;
+            }
+        };
+
+        if file_type.is_file() && is_zip_path(&path) {
+            let bundle_name = path.to_string_lossy().to_string();
+            match load_external_plugin_archive(&path, &bundle_name) {
+                Ok(bundle) => bundles.push(bundle),
+                Err(message) => errors.push(ExternalPluginBundleError {
+                    archive_name: bundle_name,
+                    message,
+                }),
+            }
+        } else if file_type.is_dir() && path.join("plugin.json").is_file() {
+            let bundle_name = path.to_string_lossy().to_string();
+            match load_external_plugin_directory(&path, &bundle_name) {
+                Ok(bundle) => bundles.push(bundle),
+                Err(message) => errors.push(ExternalPluginBundleError {
+                    archive_name: bundle_name,
+                    message,
+                }),
+            }
+        }
+    }
+}
+
+fn is_zip_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("zip"))
 }
 
 fn load_external_plugin_archive(
@@ -280,6 +360,41 @@ fn load_external_plugin_archive(
         entry_source,
         style_source,
     })
+}
+
+fn load_external_plugin_directory(
+    path: &Path,
+    archive_name: &str,
+) -> Result<ExternalPluginBundle, String> {
+    let manifest_text = read_fs_text_entry(path, "plugin.json", "plugin manifest")?;
+    let manifest: ExternalPluginManifest = serde_json::from_str(&manifest_text)
+        .map_err(|error| format!("Could not parse plugin.json: {error}"))?;
+    validate_external_plugin_manifest(&manifest)?;
+
+    let entry_source = read_fs_text_entry(path, &manifest.entry, "plugin entry")?;
+    let style_source = match manifest.style.as_deref() {
+        Some(style) => Some(read_fs_text_entry(path, style, "plugin style")?),
+        None => None,
+    };
+
+    Ok(ExternalPluginBundle {
+        archive_name: archive_name.to_string(),
+        manifest,
+        entry_source,
+        style_source,
+    })
+}
+
+fn read_fs_text_entry(root: &Path, entry_name: &str, label: &str) -> Result<String, String> {
+    let entry_path = root.join(entry_name);
+    if !entry_path.is_file() {
+        return Err(format!(
+            "Could not read {label} '{entry_name}': file does not exist"
+        ));
+    }
+
+    fs::read_to_string(&entry_path)
+        .map_err(|error| format!("Could not read {label} '{entry_name}' as UTF-8: {error}"))
 }
 
 fn read_zip_text_entry<R: Read + std::io::Seek>(

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -5,7 +5,7 @@ use earth_engine_oauth::{
 };
 use flate2::read::{GzDecoder, ZlibDecoder};
 use rusqlite::{params, Connection, OpenFlags, OptionalExtension};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashSet;
 use std::env;
@@ -59,6 +59,43 @@ struct SidecarProcess {
     child: Child,
 }
 
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ExternalPluginManifest {
+    id: String,
+    name: String,
+    version: String,
+    entry: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    style: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ExternalPluginBundle {
+    archive_name: String,
+    manifest: ExternalPluginManifest,
+    entry_source: String,
+    style_source: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ExternalPluginBundleError {
+    archive_name: String,
+    message: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ExternalPluginBundleLoadResult {
+    plugins_directory: String,
+    bundles: Vec<ExternalPluginBundle>,
+    errors: Vec<ExternalPluginBundleError>,
+}
+
 impl SidecarProcess {
     fn terminate(&mut self) {
         terminate_sidecar_child(&mut self.child);
@@ -97,6 +134,7 @@ pub fn run() {
             close_oauth_popups,
             ensure_martin_binary,
             fetch_url_bytes,
+            load_external_plugin_bundles,
             resolve_url_redirect,
             read_mbtiles_metadata,
             read_mbtiles_tile,
@@ -156,6 +194,174 @@ fn fetch_url_bytes_blocking(url: String) -> Result<Vec<u8>, String> {
         .bytes()
         .map(|bytes| bytes.to_vec())
         .map_err(|error| format!("Could not read response body: {error}"))
+}
+
+#[tauri::command]
+async fn load_external_plugin_bundles(
+    app: tauri::AppHandle,
+) -> Result<ExternalPluginBundleLoadResult, String> {
+    tauri::async_runtime::spawn_blocking(move || load_external_plugin_bundles_blocking(&app))
+        .await
+        .map_err(|error| format!("External plugin scan task failed: {error}"))?
+}
+
+fn load_external_plugin_bundles_blocking(
+    app: &tauri::AppHandle,
+) -> Result<ExternalPluginBundleLoadResult, String> {
+    let plugins_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|error| format!("Could not resolve app data directory: {error}"))?
+        .join("plugins");
+
+    fs::create_dir_all(&plugins_dir)
+        .map_err(|error| format!("Could not create plugins directory: {error}"))?;
+
+    let mut archives = fs::read_dir(&plugins_dir)
+        .map_err(|error| format!("Could not read plugins directory: {error}"))?
+        .filter_map(Result::ok)
+        .filter(|entry| {
+            entry
+                .file_type()
+                .map(|file_type| file_type.is_file())
+                .unwrap_or(false)
+        })
+        .filter(|entry| {
+            entry
+                .path()
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("zip"))
+        })
+        .collect::<Vec<_>>();
+    archives.sort_by_key(|entry| entry.file_name().to_string_lossy().to_string());
+
+    let mut bundles = Vec::new();
+    let mut errors = Vec::new();
+    for archive in archives {
+        let archive_name = archive.file_name().to_string_lossy().to_string();
+        match load_external_plugin_archive(&archive.path(), &archive_name) {
+            Ok(bundle) => bundles.push(bundle),
+            Err(message) => errors.push(ExternalPluginBundleError {
+                archive_name,
+                message,
+            }),
+        }
+    }
+
+    Ok(ExternalPluginBundleLoadResult {
+        plugins_directory: plugins_dir.to_string_lossy().to_string(),
+        bundles,
+        errors,
+    })
+}
+
+fn load_external_plugin_archive(
+    path: &Path,
+    archive_name: &str,
+) -> Result<ExternalPluginBundle, String> {
+    let file = File::open(path).map_err(|error| format!("Could not open zip: {error}"))?;
+    let mut archive =
+        zip::ZipArchive::new(file).map_err(|error| format!("Could not read zip: {error}"))?;
+    let manifest_text = read_zip_text_entry(&mut archive, "plugin.json", "plugin manifest")?;
+    let manifest: ExternalPluginManifest = serde_json::from_str(&manifest_text)
+        .map_err(|error| format!("Could not parse plugin.json: {error}"))?;
+    validate_external_plugin_manifest(&manifest)?;
+
+    let entry_source = read_zip_text_entry(&mut archive, &manifest.entry, "plugin entry")?;
+    let style_source = match manifest.style.as_deref() {
+        Some(style) => Some(read_zip_text_entry(&mut archive, style, "plugin style")?),
+        None => None,
+    };
+
+    Ok(ExternalPluginBundle {
+        archive_name: archive_name.to_string(),
+        manifest,
+        entry_source,
+        style_source,
+    })
+}
+
+fn read_zip_text_entry<R: Read + std::io::Seek>(
+    archive: &mut zip::ZipArchive<R>,
+    entry_name: &str,
+    label: &str,
+) -> Result<String, String> {
+    let mut entry = archive
+        .by_name(entry_name)
+        .map_err(|error| format!("Could not read {label} '{entry_name}': {error}"))?;
+    if entry.is_dir() {
+        return Err(format!("{label} '{entry_name}' must be a file"));
+    }
+
+    let mut text = String::new();
+    entry
+        .read_to_string(&mut text)
+        .map_err(|error| format!("Could not read {label} '{entry_name}' as UTF-8: {error}"))?;
+    Ok(text)
+}
+
+fn validate_external_plugin_manifest(manifest: &ExternalPluginManifest) -> Result<(), String> {
+    validate_required_manifest_string("id", &manifest.id)?;
+    validate_required_manifest_string("name", &manifest.name)?;
+    validate_required_manifest_string("version", &manifest.version)?;
+    validate_required_manifest_string("entry", &manifest.entry)?;
+    validate_external_plugin_path("entry", &manifest.entry)?;
+    if !manifest.entry.ends_with(".js") && !manifest.entry.ends_with(".mjs") {
+        return Err("entry must point to a .js or .mjs file".to_string());
+    }
+
+    if let Some(description) = manifest.description.as_deref() {
+        validate_optional_manifest_string("description", description)?;
+    }
+    if let Some(style) = manifest.style.as_deref() {
+        validate_optional_manifest_string("style", style)?;
+        validate_external_plugin_path("style", style)?;
+        if !style.ends_with(".css") {
+            return Err("style must point to a .css file".to_string());
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_required_manifest_string(field: &str, value: &str) -> Result<(), String> {
+    if value.trim().is_empty() {
+        return Err(format!("{field} must not be empty"));
+    }
+    if value.trim() != value {
+        return Err(format!(
+            "{field} must not have leading or trailing whitespace"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_optional_manifest_string(field: &str, value: &str) -> Result<(), String> {
+    if value.trim() != value {
+        return Err(format!(
+            "{field} must not have leading or trailing whitespace"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_external_plugin_path(field: &str, value: &str) -> Result<(), String> {
+    if value.starts_with('/') || value.starts_with('\\') {
+        return Err(format!("{field} must be a relative path"));
+    }
+    if value.contains('\\') {
+        return Err(format!("{field} must use forward slashes"));
+    }
+    if value
+        .split('/')
+        .any(|part| part.is_empty() || part == "." || part == "..")
+    {
+        return Err(format!(
+            "{field} must not contain empty, '.', or '..' segments"
+        ));
+    }
+    Ok(())
 }
 
 #[tauri::command]

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -296,8 +296,10 @@ fn scan_external_plugin_directory(
 
     for entry in entries {
         let path = entry.path();
-        let file_type = match entry.file_type() {
-            Ok(file_type) => file_type,
+        // Resolve through path metadata rather than the directory entry so
+        // symlinked zips and plugin directories are followed, not skipped.
+        let metadata = match path.metadata() {
+            Ok(metadata) => metadata,
             Err(error) => {
                 errors.push(ExternalPluginBundleError {
                     archive_name: path.to_string_lossy().to_string(),
@@ -307,7 +309,7 @@ fn scan_external_plugin_directory(
             }
         };
 
-        if file_type.is_file() && is_zip_path(&path) {
+        if metadata.is_file() && is_zip_path(&path) {
             let bundle_name = path.to_string_lossy().to_string();
             match load_external_plugin_archive(&path, &bundle_name) {
                 Ok(bundle) => bundles.push(bundle),
@@ -316,7 +318,7 @@ fn scan_external_plugin_directory(
                     message,
                 }),
             }
-        } else if file_type.is_dir() && path.join("plugin.json").is_file() {
+        } else if metadata.is_dir() && path.join("plugin.json").is_file() {
             let bundle_name = path.to_string_lossy().to_string();
             match load_external_plugin_directory(&path, &bundle_name) {
                 Ok(bundle) => bundles.push(bundle),

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -264,10 +264,9 @@ fn scan_external_plugin_directory(
     errors: &mut Vec<ExternalPluginBundleError>,
 ) {
     if !plugin_dir.exists() {
-        errors.push(ExternalPluginBundleError {
-            archive_name: plugin_dir.to_string_lossy().to_string(),
-            message: "Plugin directory does not exist.".to_string(),
-        });
+        // User-configured development directories may not exist yet; the app
+        // data plugins directory is always created before scanning. Skip
+        // silently instead of warning on every startup.
         return;
     }
 
@@ -393,16 +392,28 @@ fn read_fs_text_entry(root: &Path, entry_name: &str, label: &str) -> Result<Stri
         ));
     }
 
-    fs::read_to_string(&entry_path)
-        .map_err(|error| format!("Could not read {label} '{entry_name}' as UTF-8: {error}"))
+    let file = File::open(&entry_path)
+        .map_err(|error| format!("Could not read {label} '{entry_name}': {error}"))?;
+    let mut text = String::new();
+    file.take(MAX_PLUGIN_ENTRY_BYTES + 1)
+        .read_to_string(&mut text)
+        .map_err(|error| format!("Could not read {label} '{entry_name}' as UTF-8: {error}"))?;
+    if text.len() as u64 > MAX_PLUGIN_ENTRY_BYTES {
+        return Err(format!(
+            "{label} '{entry_name}' exceeds the {}-MB size limit",
+            MAX_PLUGIN_ENTRY_BYTES / (1024 * 1024)
+        ));
+    }
+    Ok(text)
 }
+
+const MAX_PLUGIN_ENTRY_BYTES: u64 = 50 * 1024 * 1024;
 
 fn read_zip_text_entry<R: Read + std::io::Seek>(
     archive: &mut zip::ZipArchive<R>,
     entry_name: &str,
     label: &str,
 ) -> Result<String, String> {
-    const MAX_ENTRY_BYTES: u64 = 50 * 1024 * 1024;
     let entry = archive
         .by_name(entry_name)
         .map_err(|error| format!("Could not read {label} '{entry_name}': {error}"))?;
@@ -414,13 +425,13 @@ fn read_zip_text_entry<R: Read + std::io::Seek>(
     // which a hand-crafted archive can spoof.
     let mut text = String::new();
     entry
-        .take(MAX_ENTRY_BYTES + 1)
+        .take(MAX_PLUGIN_ENTRY_BYTES + 1)
         .read_to_string(&mut text)
         .map_err(|error| format!("Could not read {label} '{entry_name}' as UTF-8: {error}"))?;
-    if text.len() as u64 > MAX_ENTRY_BYTES {
+    if text.len() as u64 > MAX_PLUGIN_ENTRY_BYTES {
         return Err(format!(
             "{label} '{entry_name}' exceeds the {}-MB size limit",
-            MAX_ENTRY_BYTES / (1024 * 1024)
+            MAX_PLUGIN_ENTRY_BYTES / (1024 * 1024)
         ));
     }
     Ok(text)

--- a/apps/geolibre-desktop/src-tauri/tauri.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' https: http://127.0.0.1:*; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval' https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'",
+      "csp": "default-src 'self'; connect-src 'self' https: http://127.0.0.1:*; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'",
       "capabilities": ["default"]
     }
   },

--- a/apps/geolibre-desktop/src/App.tsx
+++ b/apps/geolibre-desktop/src/App.tsx
@@ -1,4 +1,5 @@
 import { DesktopShell } from "./components/layout/DesktopShell";
+import { useDesktopSettingsPersistence } from "./hooks/useDesktopSettings";
 import { useLayoutOptions } from "./hooks/useLayoutOptions";
 import { usePlugins } from "./hooks/usePlugins";
 import { useProjectUrlLoader } from "./hooks/useProjectUrlLoader";
@@ -11,6 +12,7 @@ export default function App() {
   const { themeMode, toggleThemeMode } = useThemeMode();
   const projectUrlLoadState = useProjectUrlLoader();
 
+  useDesktopSettingsPersistence();
   usePlugins();
   useRecentProjectsPersistence();
   useRuntimeEnvironmentVariables();

--- a/apps/geolibre-desktop/src/App.tsx
+++ b/apps/geolibre-desktop/src/App.tsx
@@ -1,7 +1,7 @@
 import { DesktopShell } from "./components/layout/DesktopShell";
 import { useDesktopSettingsPersistence } from "./hooks/useDesktopSettings";
 import { useLayoutOptions } from "./hooks/useLayoutOptions";
-import { usePlugins } from "./hooks/usePlugins";
+import { useExternalPluginsReady } from "./hooks/usePlugins";
 import { useProjectUrlLoader } from "./hooks/useProjectUrlLoader";
 import { useRecentProjectsPersistence } from "./hooks/useRecentProjectsPersistence";
 import { useRuntimeEnvironmentVariables } from "./hooks/useRuntimeEnvironmentVariables";
@@ -13,7 +13,9 @@ export default function App() {
   const projectUrlLoadState = useProjectUrlLoader();
 
   useDesktopSettingsPersistence();
-  usePlugins();
+  // Triggers the external plugin scan; the readiness flag is consumed in
+  // DesktopShell to gate project plugin state restoration.
+  useExternalPluginsReady();
   useRecentProjectsPersistence();
   useRuntimeEnvironmentVariables();
   return (

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -17,7 +17,11 @@ import {
   loadDroppedVectorFiles,
   loadDroppedVectorPaths,
 } from "../../lib/tauri-io";
-import { createAppAPI, getPluginManager } from "../../hooks/usePlugins";
+import {
+  createAppAPI,
+  getPluginManager,
+  useExternalPluginsReady,
+} from "../../hooks/usePlugins";
 import { registerMbtilesProtocol } from "../../lib/mbtiles";
 import { registerXyzTileProtocol } from "../../lib/xyz-url";
 import { AttributeTable } from "../panels/AttributeTable";
@@ -39,7 +43,8 @@ const ProcessingDialog = lazy(() =>
       // throw during render and unmount the whole shell. Fall back to a
       // no-op component so the rest of the app stays interactive.
       console.error("Failed to load ProcessingDialog", error);
-      const Fallback = (() => null) as unknown as typeof import("../processing/ProcessingDialog").ProcessingDialog;
+      const Fallback = (() =>
+        null) as unknown as typeof import("../processing/ProcessingDialog").ProcessingDialog;
       return { default: Fallback };
     }),
 );
@@ -97,6 +102,7 @@ export function DesktopShell({
   const [mapReadyGeneration, setMapReadyGeneration] = useState(0);
   const [dropMessage, setDropMessage] = useState<string | null>(null);
   const [dropError, setDropError] = useState<string | null>(null);
+  const externalPluginsReady = useExternalPluginsReady();
   const [layerPanelWidth, setLayerPanelWidth] = useState(
     DEFAULT_SIDE_PANEL_WIDTH,
   );
@@ -132,12 +138,17 @@ export function DesktopShell({
     // or the map is reinitialised (mapReadyGeneration), not on every
     // incremental plugin write-back. projectPlugins is read from the store
     // snapshot at call time so it is always current without being a dependency.
-    if (!mapReadyGeneration || !mapControllerRef.current) return;
+    if (
+      !externalPluginsReady ||
+      !mapReadyGeneration ||
+      !mapControllerRef.current
+    )
+      return;
     getPluginManager().restoreProjectState(
       useAppStore.getState().projectPlugins,
       createAppAPI(mapControllerRef),
     );
-  }, [mapReadyGeneration, projectGeneration]);
+  }, [externalPluginsReady, mapReadyGeneration, projectGeneration]);
 
   useEffect(() => {
     return () => {

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -1,5 +1,6 @@
 import {
   DEFAULT_PROJECT_PREFERENCES,
+  isAllowedPluginManifestUrl,
   PROJECT_VERSION,
   useAppStore,
   type MapPreferences,
@@ -199,16 +200,12 @@ function validatePluginManifestUrls(urls: string[]): string | null {
   for (const url of urls) {
     if (!url.trim()) continue;
     try {
-      const parsed = new URL(url.trim());
-      const isHttps = parsed.protocol === "https:";
-      const isLocalHttp =
-        parsed.protocol === "http:" &&
-        ["localhost", "127.0.0.1", "[::1]"].includes(parsed.hostname);
-      if (!isHttps && !isLocalHttp) {
-        return "Plugin manifest URLs must use HTTPS, or HTTP on localhost, 127.0.0.1, or [::1].";
-      }
+      new URL(url.trim());
     } catch {
       return "Plugin manifest URLs must be valid absolute URLs.";
+    }
+    if (!isAllowedPluginManifestUrl(url.trim())) {
+      return "Plugin manifest URLs must use HTTPS, or HTTP on localhost, 127.0.0.1, or [::1].";
     }
   }
   return null;

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -99,17 +99,18 @@ function clonePreferences(preferences: ProjectPreferences): DraftPreferences {
 function cloneDesktopSettings(settings: DesktopSettings): DesktopSettings {
   return {
     additionalPluginDirectories: [...settings.additionalPluginDirectories],
+    pluginManifestUrls: [...settings.pluginManifestUrls],
   };
 }
 
-function normalizePluginDirectories(paths: string[]): string[] {
+function normalizeStringList(values: string[]): string[] {
   const seen = new Set<string>();
   const normalized: string[] = [];
-  for (const value of paths) {
-    const path = value.trim();
-    if (!path || seen.has(path)) continue;
-    seen.add(path);
-    normalized.push(path);
+  for (const value of values) {
+    const normalizedValue = value.trim();
+    if (!normalizedValue || seen.has(normalizedValue)) continue;
+    seen.add(normalizedValue);
+    normalized.push(normalizedValue);
   }
   return normalized;
 }
@@ -176,6 +177,25 @@ function validateEnvironmentVariables(
     keys.add(variable.key.trim());
   }
 
+  return null;
+}
+
+function validatePluginManifestUrls(urls: string[]): string | null {
+  for (const url of urls) {
+    if (!url.trim()) continue;
+    try {
+      const parsed = new URL(url.trim());
+      if (
+        parsed.protocol !== "https:" &&
+        parsed.hostname !== "localhost" &&
+        parsed.hostname !== "127.0.0.1"
+      ) {
+        return "Plugin manifest URLs must use HTTPS, localhost, or 127.0.0.1.";
+      }
+    } catch {
+      return "Plugin manifest URLs must be valid absolute URLs.";
+    }
+  }
   return null;
 }
 
@@ -336,6 +356,35 @@ export function SettingsDialog({
     setError(null);
   };
 
+  const updatePluginManifestUrl = (index: number, url: string) => {
+    setDraftDesktopSettings((current) => ({
+      ...current,
+      pluginManifestUrls: current.pluginManifestUrls.map((currentUrl, i) =>
+        i === index ? url : currentUrl,
+      ),
+    }));
+    setError(null);
+  };
+
+  const addPluginManifestUrl = () => {
+    setDraftDesktopSettings((current) => ({
+      ...current,
+      pluginManifestUrls: [...current.pluginManifestUrls, ""],
+    }));
+    setSection("plugins");
+    setError(null);
+  };
+
+  const removePluginManifestUrl = (index: number) => {
+    setDraftDesktopSettings((current) => ({
+      ...current,
+      pluginManifestUrls: current.pluginManifestUrls.filter(
+        (_, i) => i !== index,
+      ),
+    }));
+    setError(null);
+  };
+
   const applyCurrentViewBounds = () => {
     const bounds = mapControllerRef.current?.readView().bbox;
     if (!bounds) {
@@ -368,13 +417,25 @@ export function SettingsDialog({
       return;
     }
 
+    const pluginManifestUrls = normalizeStringList(
+      draftDesktopSettings.pluginManifestUrls,
+    );
+    const manifestUrlValidationError =
+      validatePluginManifestUrls(pluginManifestUrls);
+    if (manifestUrlValidationError) {
+      setError(manifestUrlValidationError);
+      setSection("plugins");
+      return;
+    }
+
     const nextProjectName = draftProjectName.trim() || "Untitled Project";
     if (nextProjectName !== projectName) setProjectName(nextProjectName);
     setPreferences(normalized);
     setDesktopSettings({
-      additionalPluginDirectories: normalizePluginDirectories(
+      additionalPluginDirectories: normalizeStringList(
         draftDesktopSettings.additionalPluginDirectories,
       ),
+      pluginManifestUrls,
     });
     setOpen(false);
   };
@@ -721,77 +782,143 @@ export function SettingsDialog({
                 <div className="space-y-5">
                   <div className="flex items-center justify-between gap-3">
                     <div>
-                      <h3 className="text-sm font-semibold">
-                        Plugin directories
-                      </h3>
+                      <h3 className="text-sm font-semibold">Plugin sources</h3>
                       <p className="text-xs text-muted-foreground">
-                        Extra local directories scanned for plugin zips or
-                        unpacked plugin bundles.
+                        Extra local directories and web manifest URLs scanned
+                        for external plugins.
                       </p>
                     </div>
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="outline"
-                      onClick={addPluginDirectory}
-                    >
-                      <Plus className="h-3.5 w-3.5" />
-                      Add
-                    </Button>
                   </div>
                   <div className="rounded-md border bg-muted/40 p-3 text-xs text-muted-foreground">
                     GeoLibre always scans its app data plugins directory. These
-                    additional paths are local desktop settings and are not
-                    saved into project files. Each directory can contain `.zip`
-                    plugin bundles, unpacked plugin bundle folders, or be an
-                    unpacked plugin bundle with a root `plugin.json`.
+                    additional sources are local settings and are not saved into
+                    project files. Desktop directories can contain `.zip` plugin
+                    bundles, unpacked plugin bundle folders, or be an unpacked
+                    plugin bundle with a root `plugin.json`. Manifest URLs also
+                    work in the web app by resolving `entry` and `style`
+                    relative to `plugin.json`.
                   </div>
-                  {draftDesktopSettings.additionalPluginDirectories.length ===
-                  0 ? (
-                    <div className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
-                      No additional plugin directories configured.
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between gap-3">
+                      <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        Local directories
+                      </h4>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        onClick={addPluginDirectory}
+                      >
+                        <Plus className="h-3.5 w-3.5" />
+                        Add
+                      </Button>
                     </div>
-                  ) : (
-                    <div className="space-y-2">
-                      {draftDesktopSettings.additionalPluginDirectories.map(
-                        (directory, index) => (
-                          <div
-                            key={index}
-                            className="grid grid-cols-[minmax(10rem,1fr)_2rem_2rem] items-center gap-2"
-                          >
-                            <Input
-                              aria-label="Plugin directory"
-                              placeholder="/path/to/geolibre-plugin"
-                              value={directory}
-                              onChange={(event) =>
-                                updatePluginDirectory(index, event.target.value)
-                              }
-                            />
-                            <Button
-                              aria-label="Browse plugin directory"
-                              className="h-8 w-8"
-                              type="button"
-                              size="icon"
-                              variant="ghost"
-                              onClick={() => void browsePluginDirectory(index)}
+                    {draftDesktopSettings.additionalPluginDirectories.length ===
+                    0 ? (
+                      <div className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+                        No additional plugin directories configured.
+                      </div>
+                    ) : (
+                      <div className="space-y-2">
+                        {draftDesktopSettings.additionalPluginDirectories.map(
+                          (directory, index) => (
+                            <div
+                              key={index}
+                              className="grid grid-cols-[minmax(10rem,1fr)_2rem_2rem] items-center gap-2"
                             >
-                              <FolderOpen className="h-3.5 w-3.5" />
-                            </Button>
-                            <Button
-                              aria-label="Remove plugin directory"
-                              className="h-8 w-8"
-                              type="button"
-                              size="icon"
-                              variant="ghost"
-                              onClick={() => removePluginDirectory(index)}
-                            >
-                              <Trash2 className="h-3.5 w-3.5" />
-                            </Button>
-                          </div>
-                        ),
-                      )}
+                              <Input
+                                aria-label="Plugin directory"
+                                placeholder="/path/to/geolibre-plugin"
+                                value={directory}
+                                onChange={(event) =>
+                                  updatePluginDirectory(
+                                    index,
+                                    event.target.value,
+                                  )
+                                }
+                              />
+                              <Button
+                                aria-label="Browse plugin directory"
+                                className="h-8 w-8"
+                                type="button"
+                                size="icon"
+                                variant="ghost"
+                                onClick={() =>
+                                  void browsePluginDirectory(index)
+                                }
+                              >
+                                <FolderOpen className="h-3.5 w-3.5" />
+                              </Button>
+                              <Button
+                                aria-label="Remove plugin directory"
+                                className="h-8 w-8"
+                                type="button"
+                                size="icon"
+                                variant="ghost"
+                                onClick={() => removePluginDirectory(index)}
+                              >
+                                <Trash2 className="h-3.5 w-3.5" />
+                              </Button>
+                            </div>
+                          ),
+                        )}
+                      </div>
+                    )}
+                  </div>
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between gap-3">
+                      <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        Manifest URLs
+                      </h4>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        onClick={addPluginManifestUrl}
+                      >
+                        <Plus className="h-3.5 w-3.5" />
+                        Add
+                      </Button>
                     </div>
-                  )}
+                    {draftDesktopSettings.pluginManifestUrls.length === 0 ? (
+                      <div className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+                        No plugin manifest URLs configured.
+                      </div>
+                    ) : (
+                      <div className="space-y-2">
+                        {draftDesktopSettings.pluginManifestUrls.map(
+                          (url, index) => (
+                            <div
+                              key={index}
+                              className="grid grid-cols-[minmax(10rem,1fr)_2rem] items-center gap-2"
+                            >
+                              <Input
+                                aria-label="Plugin manifest URL"
+                                placeholder="https://example.com/plugin/plugin.json"
+                                value={url}
+                                onChange={(event) =>
+                                  updatePluginManifestUrl(
+                                    index,
+                                    event.target.value,
+                                  )
+                                }
+                              />
+                              <Button
+                                aria-label="Remove plugin manifest URL"
+                                className="h-8 w-8"
+                                type="button"
+                                size="icon"
+                                variant="ghost"
+                                onClick={() => removePluginManifestUrl(index)}
+                              >
+                                <Trash2 className="h-3.5 w-3.5" />
+                              </Button>
+                            </div>
+                          ),
+                        )}
+                      </div>
+                    )}
+                  </div>
                 </div>
               ) : null}
               {section === "project" ? (

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -756,7 +756,7 @@ export function SettingsDialog({
                       {draftDesktopSettings.additionalPluginDirectories.map(
                         (directory, index) => (
                           <div
-                            key={`${index}-${directory}`}
+                            key={index}
                             className="grid grid-cols-[minmax(10rem,1fr)_2rem_2rem] items-center gap-2"
                           >
                             <Input

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -3,6 +3,7 @@ import {
   PROJECT_VERSION,
   useAppStore,
   type MapPreferences,
+  type ProjectPluginState,
   type ProjectPreferences,
   type RuntimeEnvironmentVariable,
 } from "@geolibre/core";
@@ -44,6 +45,7 @@ import {
   useDesktopSettingsStore,
   type DesktopSettings,
 } from "../../hooks/useDesktopSettings";
+import { getPluginManager } from "../../hooks/usePlugins";
 import { pickLocalPathWithFallback } from "../../lib/tauri-io";
 
 type SettingsSection = "map" | "environment" | "plugins" | "project";
@@ -97,11 +99,21 @@ function clonePreferences(preferences: ProjectPreferences): DraftPreferences {
   };
 }
 
-function cloneDesktopSettings(settings: DesktopSettings): DesktopSettings {
+function cloneDesktopSettings(
+  settings: DesktopSettings,
+  projectPlugins: ProjectPluginState | null,
+): DesktopSettings {
   return {
     additionalPluginDirectories: [...settings.additionalPluginDirectories],
-    pluginManifestUrls: [...settings.pluginManifestUrls],
+    pluginManifestUrls: mergeStringLists(
+      projectPlugins?.manifestUrls ?? [],
+      settings.pluginManifestUrls,
+    ),
   };
+}
+
+function mergeStringLists(...lists: string[][]): string[] {
+  return normalizeStringList(lists.flat());
 }
 
 function normalizeBounds(
@@ -201,6 +213,8 @@ export function SettingsDialog({
   const setDesktopSettings = useDesktopSettingsStore(
     (s) => s.setDesktopSettings,
   );
+  const projectPlugins = useAppStore((s) => s.projectPlugins);
+  const setProjectPlugins = useAppStore((s) => s.setProjectPlugins);
   const projectName = useAppStore((s) => s.projectName);
   const projectPath = useAppStore((s) => s.projectPath);
   const setProjectName = useAppStore((s) => s.setProjectName);
@@ -210,7 +224,9 @@ export function SettingsDialog({
     () => clonePreferences(preferences),
   );
   const [draftDesktopSettings, setDraftDesktopSettings] =
-    useState<DesktopSettings>(() => cloneDesktopSettings(desktopSettings));
+    useState<DesktopSettings>(() =>
+      cloneDesktopSettings(desktopSettings, projectPlugins),
+    );
   const [draftProjectName, setDraftProjectName] = useState(projectName);
   const [error, setError] = useState<string | null>(null);
   // Ids of variables whose value is temporarily revealed; values are masked
@@ -233,7 +249,10 @@ export function SettingsDialog({
     if (!open) return;
     setDraftPreferences(clonePreferences(useAppStore.getState().preferences));
     setDraftDesktopSettings(
-      cloneDesktopSettings(useDesktopSettingsStore.getState().desktopSettings),
+      cloneDesktopSettings(
+        useDesktopSettingsStore.getState().desktopSettings,
+        useAppStore.getState().projectPlugins,
+      ),
     );
     setDraftProjectName(useAppStore.getState().projectName);
     setRevealedValueIds(new Set());
@@ -433,6 +452,10 @@ export function SettingsDialog({
         draftDesktopSettings.additionalPluginDirectories,
       ),
       pluginManifestUrls,
+    });
+    setProjectPlugins({
+      ...getPluginManager().getProjectState(),
+      manifestUrls: pluginManifestUrls,
     });
     setOpen(false);
   };
@@ -788,12 +811,13 @@ export function SettingsDialog({
                   </div>
                   <div className="rounded-md border bg-muted/40 p-3 text-xs text-muted-foreground">
                     GeoLibre always scans its app data plugins directory. These
-                    additional sources are local settings and are not saved into
-                    project files. Desktop directories can contain `.zip` plugin
-                    bundles, unpacked plugin bundle folders, or be an unpacked
-                    plugin bundle with a root `plugin.json`. Manifest URLs also
-                    work in the web app by resolving `entry` and `style`
-                    relative to `plugin.json`.
+                    local directories are desktop-only settings and are not
+                    saved into project files. Manifest URLs are saved with the
+                    project so reloading a project can fetch its external
+                    plugins before restoring active plugin state. Desktop
+                    directories can contain `.zip` plugin bundles, unpacked
+                    plugin bundle folders, or be an unpacked plugin bundle with
+                    a root `plugin.json`.
                   </div>
                   <div className="space-y-3">
                     <div className="flex items-center justify-between gap-3">

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -40,6 +40,7 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useState, type RefObject } from "react";
 import {
+  normalizeStringList,
   useDesktopSettingsStore,
   type DesktopSettings,
 } from "../../hooks/useDesktopSettings";
@@ -101,18 +102,6 @@ function cloneDesktopSettings(settings: DesktopSettings): DesktopSettings {
     additionalPluginDirectories: [...settings.additionalPluginDirectories],
     pluginManifestUrls: [...settings.pluginManifestUrls],
   };
-}
-
-function normalizeStringList(values: string[]): string[] {
-  const seen = new Set<string>();
-  const normalized: string[] = [];
-  for (const value of values) {
-    const normalizedValue = value.trim();
-    if (!normalizedValue || seen.has(normalizedValue)) continue;
-    seen.add(normalizedValue);
-    normalized.push(normalizedValue);
-  }
-  return normalized;
 }
 
 function normalizeBounds(
@@ -185,12 +174,12 @@ function validatePluginManifestUrls(urls: string[]): string | null {
     if (!url.trim()) continue;
     try {
       const parsed = new URL(url.trim());
-      if (
-        parsed.protocol !== "https:" &&
-        parsed.hostname !== "localhost" &&
-        parsed.hostname !== "127.0.0.1"
-      ) {
-        return "Plugin manifest URLs must use HTTPS, localhost, or 127.0.0.1.";
+      const isHttps = parsed.protocol === "https:";
+      const isLocalHttp =
+        parsed.protocol === "http:" &&
+        (parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1");
+      if (!isHttps && !isLocalHttp) {
+        return "Plugin manifest URLs must use HTTPS, or HTTP on localhost or 127.0.0.1.";
       }
     } catch {
       return "Plugin manifest URLs must be valid absolute URLs.";
@@ -341,9 +330,17 @@ export function SettingsDialog({
   };
 
   const browsePluginDirectory = async (index: number) => {
-    const path = await pickLocalPathWithFallback({ directory: true });
-    if (!path) return;
-    updatePluginDirectory(index, path);
+    try {
+      const path = await pickLocalPathWithFallback({ directory: true });
+      if (!path) return;
+      updatePluginDirectory(index, path);
+    } catch (error) {
+      setError(
+        error instanceof Error
+          ? error.message
+          : "Could not open the directory picker.",
+      );
+    }
   };
 
   const removePluginDirectory = (index: number) => {

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -35,10 +35,17 @@ import {
   Settings,
   Trash2,
   TriangleAlert,
+  Puzzle,
+  FolderOpen,
 } from "lucide-react";
 import { useEffect, useMemo, useState, type RefObject } from "react";
+import {
+  useDesktopSettingsStore,
+  type DesktopSettings,
+} from "../../hooks/useDesktopSettings";
+import { pickLocalPathWithFallback } from "../../lib/tauri-io";
 
-type SettingsSection = "map" | "environment" | "project";
+type SettingsSection = "map" | "environment" | "plugins" | "project";
 
 interface SettingsDialogProps {
   buttonClassName?: string;
@@ -55,6 +62,7 @@ const SECTION_ITEMS: Array<{
 }> = [
   { id: "map", label: "Map", icon: MapPinned },
   { id: "environment", label: "Environment", icon: Braces },
+  { id: "plugins", label: "Plugins", icon: Puzzle },
   { id: "project", label: "Project", icon: FolderCog },
 ];
 
@@ -88,7 +96,27 @@ function clonePreferences(preferences: ProjectPreferences): DraftPreferences {
   };
 }
 
-function normalizeBounds(bounds: MapPreferences["bounds"]): MapPreferences["bounds"] {
+function cloneDesktopSettings(settings: DesktopSettings): DesktopSettings {
+  return {
+    additionalPluginDirectories: [...settings.additionalPluginDirectories],
+  };
+}
+
+function normalizePluginDirectories(paths: string[]): string[] {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const value of paths) {
+    const path = value.trim();
+    if (!path || seen.has(path)) continue;
+    seen.add(path);
+    normalized.push(path);
+  }
+  return normalized;
+}
+
+function normalizeBounds(
+  bounds: MapPreferences["bounds"],
+): MapPreferences["bounds"] {
   const west = clamp(bounds[0], -180, 180);
   const south = clamp(bounds[1], -85, 85);
   const east = clamp(bounds[2], -180, 180);
@@ -160,6 +188,10 @@ export function SettingsDialog({
 }: SettingsDialogProps) {
   const preferences = useAppStore((s) => s.preferences);
   const setPreferences = useAppStore((s) => s.setPreferences);
+  const desktopSettings = useDesktopSettingsStore((s) => s.desktopSettings);
+  const setDesktopSettings = useDesktopSettingsStore(
+    (s) => s.setDesktopSettings,
+  );
   const projectName = useAppStore((s) => s.projectName);
   const projectPath = useAppStore((s) => s.projectPath);
   const setProjectName = useAppStore((s) => s.setProjectName);
@@ -168,6 +200,8 @@ export function SettingsDialog({
   const [draftPreferences, setDraftPreferences] = useState<DraftPreferences>(
     () => clonePreferences(preferences),
   );
+  const [draftDesktopSettings, setDraftDesktopSettings] =
+    useState<DesktopSettings>(() => cloneDesktopSettings(desktopSettings));
   const [draftProjectName, setDraftProjectName] = useState(projectName);
   const [error, setError] = useState<string | null>(null);
   // Ids of variables whose value is temporarily revealed; values are masked
@@ -189,6 +223,9 @@ export function SettingsDialog({
   useEffect(() => {
     if (!open) return;
     setDraftPreferences(clonePreferences(useAppStore.getState().preferences));
+    setDraftDesktopSettings(
+      cloneDesktopSettings(useDesktopSettingsStore.getState().desktopSettings),
+    );
     setDraftProjectName(useAppStore.getState().projectName);
     setRevealedValueIds(new Set());
     setError(null);
@@ -214,10 +251,7 @@ export function SettingsDialog({
     setError(null);
   };
 
-  const updateBoundsValue = (
-    index: number,
-    value: number,
-  ) => {
+  const updateBoundsValue = (index: number, value: number) => {
     // Ignore a cleared field (valueAsNumber is NaN) so it does not silently
     // become an edge-of-range value on save; the last valid value is kept.
     if (!Number.isFinite(value)) return;
@@ -267,6 +301,41 @@ export function SettingsDialog({
     setError(null);
   };
 
+  const updatePluginDirectory = (index: number, path: string) => {
+    setDraftDesktopSettings((current) => ({
+      ...current,
+      additionalPluginDirectories: current.additionalPluginDirectories.map(
+        (directory, i) => (i === index ? path : directory),
+      ),
+    }));
+    setError(null);
+  };
+
+  const addPluginDirectory = () => {
+    setDraftDesktopSettings((current) => ({
+      ...current,
+      additionalPluginDirectories: [...current.additionalPluginDirectories, ""],
+    }));
+    setSection("plugins");
+    setError(null);
+  };
+
+  const browsePluginDirectory = async (index: number) => {
+    const path = await pickLocalPathWithFallback({ directory: true });
+    if (!path) return;
+    updatePluginDirectory(index, path);
+  };
+
+  const removePluginDirectory = (index: number) => {
+    setDraftDesktopSettings((current) => ({
+      ...current,
+      additionalPluginDirectories: current.additionalPluginDirectories.filter(
+        (_, i) => i !== index,
+      ),
+    }));
+    setError(null);
+  };
+
   const applyCurrentViewBounds = () => {
     const bounds = mapControllerRef.current?.readView().bbox;
     if (!bounds) {
@@ -302,6 +371,11 @@ export function SettingsDialog({
     const nextProjectName = draftProjectName.trim() || "Untitled Project";
     if (nextProjectName !== projectName) setProjectName(nextProjectName);
     setPreferences(normalized);
+    setDesktopSettings({
+      additionalPluginDirectories: normalizePluginDirectories(
+        draftDesktopSettings.additionalPluginDirectories,
+      ),
+    });
     setOpen(false);
   };
 
@@ -361,6 +435,15 @@ export function SettingsDialog({
           >
             <Braces className="mr-2 h-3.5 w-3.5" />
             Environment Variables
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={() => {
+              setSection("plugins");
+              setOpen(true);
+            }}
+          >
+            <Puzzle className="mr-2 h-3.5 w-3.5" />
+            Plugin Directories
           </DropdownMenuItem>
           <DropdownMenuItem
             onSelect={() => {
@@ -624,6 +707,83 @@ export function SettingsDialog({
                               size="icon"
                               variant="ghost"
                               onClick={() => removeEnvironmentVariable(index)}
+                            >
+                              <Trash2 className="h-3.5 w-3.5" />
+                            </Button>
+                          </div>
+                        ),
+                      )}
+                    </div>
+                  )}
+                </div>
+              ) : null}
+              {section === "plugins" ? (
+                <div className="space-y-5">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <h3 className="text-sm font-semibold">
+                        Plugin directories
+                      </h3>
+                      <p className="text-xs text-muted-foreground">
+                        Extra local directories scanned for plugin zips or
+                        unpacked plugin bundles.
+                      </p>
+                    </div>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={addPluginDirectory}
+                    >
+                      <Plus className="h-3.5 w-3.5" />
+                      Add
+                    </Button>
+                  </div>
+                  <div className="rounded-md border bg-muted/40 p-3 text-xs text-muted-foreground">
+                    GeoLibre always scans its app data plugins directory. These
+                    additional paths are local desktop settings and are not
+                    saved into project files. Each directory can contain `.zip`
+                    plugin bundles, unpacked plugin bundle folders, or be an
+                    unpacked plugin bundle with a root `plugin.json`.
+                  </div>
+                  {draftDesktopSettings.additionalPluginDirectories.length ===
+                  0 ? (
+                    <div className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+                      No additional plugin directories configured.
+                    </div>
+                  ) : (
+                    <div className="space-y-2">
+                      {draftDesktopSettings.additionalPluginDirectories.map(
+                        (directory, index) => (
+                          <div
+                            key={`${index}-${directory}`}
+                            className="grid grid-cols-[minmax(10rem,1fr)_2rem_2rem] items-center gap-2"
+                          >
+                            <Input
+                              aria-label="Plugin directory"
+                              placeholder="/path/to/geolibre-plugin"
+                              value={directory}
+                              onChange={(event) =>
+                                updatePluginDirectory(index, event.target.value)
+                              }
+                            />
+                            <Button
+                              aria-label="Browse plugin directory"
+                              className="h-8 w-8"
+                              type="button"
+                              size="icon"
+                              variant="ghost"
+                              onClick={() => void browsePluginDirectory(index)}
+                            >
+                              <FolderOpen className="h-3.5 w-3.5" />
+                            </Button>
+                            <Button
+                              aria-label="Remove plugin directory"
+                              className="h-8 w-8"
+                              type="button"
+                              size="icon"
+                              variant="ghost"
+                              onClick={() => removePluginDirectory(index)}
                             >
                               <Trash2 className="h-3.5 w-3.5" />
                             </Button>

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -41,11 +41,11 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useState, type RefObject } from "react";
 import {
-  normalizeStringList,
   useDesktopSettingsStore,
   type DesktopSettings,
 } from "../../hooks/useDesktopSettings";
 import { getPluginManager } from "../../hooks/usePlugins";
+import { mergeStringLists, normalizeStringList } from "../../lib/string-lists";
 import { pickLocalPathWithFallback } from "../../lib/tauri-io";
 
 type SettingsSection = "map" | "environment" | "plugins" | "project";
@@ -83,6 +83,23 @@ interface DraftPreferences {
   environmentVariables: DraftEnvironmentVariable[];
 }
 
+// Draft plugin-source rows carry the same stable client-side id as draft env
+// vars so React keys survive mid-list deletes instead of reusing input DOM
+// state across the wrong row.
+interface DraftListEntry {
+  id: string;
+  value: string;
+}
+
+interface DraftDesktopSettings {
+  additionalPluginDirectories: DraftListEntry[];
+  pluginManifestUrls: DraftListEntry[];
+}
+
+function toDraftListEntry(value: string): DraftListEntry {
+  return { id: createDraftId(), value };
+}
+
 function createDraftId(): string {
   return typeof crypto !== "undefined" && "randomUUID" in crypto
     ? crypto.randomUUID()
@@ -102,18 +119,15 @@ function clonePreferences(preferences: ProjectPreferences): DraftPreferences {
 function cloneDesktopSettings(
   settings: DesktopSettings,
   projectPlugins: ProjectPluginState | null,
-): DesktopSettings {
+): DraftDesktopSettings {
   return {
-    additionalPluginDirectories: [...settings.additionalPluginDirectories],
+    additionalPluginDirectories:
+      settings.additionalPluginDirectories.map(toDraftListEntry),
     pluginManifestUrls: mergeStringLists(
       projectPlugins?.manifestUrls ?? [],
       settings.pluginManifestUrls,
-    ),
+    ).map(toDraftListEntry),
   };
-}
-
-function mergeStringLists(...lists: string[][]): string[] {
-  return normalizeStringList(lists.flat());
 }
 
 function normalizeBounds(
@@ -189,9 +203,9 @@ function validatePluginManifestUrls(urls: string[]): string | null {
       const isHttps = parsed.protocol === "https:";
       const isLocalHttp =
         parsed.protocol === "http:" &&
-        (parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1");
+        ["localhost", "127.0.0.1", "[::1]"].includes(parsed.hostname);
       if (!isHttps && !isLocalHttp) {
-        return "Plugin manifest URLs must use HTTPS, or HTTP on localhost or 127.0.0.1.";
+        return "Plugin manifest URLs must use HTTPS, or HTTP on localhost, 127.0.0.1, or [::1].";
       }
     } catch {
       return "Plugin manifest URLs must be valid absolute URLs.";
@@ -224,7 +238,7 @@ export function SettingsDialog({
     () => clonePreferences(preferences),
   );
   const [draftDesktopSettings, setDraftDesktopSettings] =
-    useState<DesktopSettings>(() =>
+    useState<DraftDesktopSettings>(() =>
       cloneDesktopSettings(desktopSettings, projectPlugins),
     );
   const [draftProjectName, setDraftProjectName] = useState(projectName);
@@ -333,7 +347,7 @@ export function SettingsDialog({
     setDraftDesktopSettings((current) => ({
       ...current,
       additionalPluginDirectories: current.additionalPluginDirectories.map(
-        (directory, i) => (i === index ? path : directory),
+        (entry, i) => (i === index ? { ...entry, value: path } : entry),
       ),
     }));
     setError(null);
@@ -342,7 +356,10 @@ export function SettingsDialog({
   const addPluginDirectory = () => {
     setDraftDesktopSettings((current) => ({
       ...current,
-      additionalPluginDirectories: [...current.additionalPluginDirectories, ""],
+      additionalPluginDirectories: [
+        ...current.additionalPluginDirectories,
+        toDraftListEntry(""),
+      ],
     }));
     setSection("plugins");
     setError(null);
@@ -375,8 +392,8 @@ export function SettingsDialog({
   const updatePluginManifestUrl = (index: number, url: string) => {
     setDraftDesktopSettings((current) => ({
       ...current,
-      pluginManifestUrls: current.pluginManifestUrls.map((currentUrl, i) =>
-        i === index ? url : currentUrl,
+      pluginManifestUrls: current.pluginManifestUrls.map((entry, i) =>
+        i === index ? { ...entry, value: url } : entry,
       ),
     }));
     setError(null);
@@ -385,7 +402,7 @@ export function SettingsDialog({
   const addPluginManifestUrl = () => {
     setDraftDesktopSettings((current) => ({
       ...current,
-      pluginManifestUrls: [...current.pluginManifestUrls, ""],
+      pluginManifestUrls: [...current.pluginManifestUrls, toDraftListEntry("")],
     }));
     setSection("plugins");
     setError(null);
@@ -434,7 +451,7 @@ export function SettingsDialog({
     }
 
     const pluginManifestUrls = normalizeStringList(
-      draftDesktopSettings.pluginManifestUrls,
+      draftDesktopSettings.pluginManifestUrls.map((entry) => entry.value),
     );
     const manifestUrlValidationError =
       validatePluginManifestUrls(pluginManifestUrls);
@@ -449,7 +466,9 @@ export function SettingsDialog({
     setPreferences(normalized);
     setDesktopSettings({
       additionalPluginDirectories: normalizeStringList(
-        draftDesktopSettings.additionalPluginDirectories,
+        draftDesktopSettings.additionalPluginDirectories.map(
+          (entry) => entry.value,
+        ),
       ),
       pluginManifestUrls,
     });
@@ -842,15 +861,15 @@ export function SettingsDialog({
                     ) : (
                       <div className="space-y-2">
                         {draftDesktopSettings.additionalPluginDirectories.map(
-                          (directory, index) => (
+                          (entry, index) => (
                             <div
-                              key={index}
+                              key={entry.id}
                               className="grid grid-cols-[minmax(10rem,1fr)_2rem_2rem] items-center gap-2"
                             >
                               <Input
                                 aria-label="Plugin directory"
                                 placeholder="/path/to/geolibre-plugin"
-                                value={directory}
+                                value={entry.value}
                                 onChange={(event) =>
                                   updatePluginDirectory(
                                     index,
@@ -908,15 +927,15 @@ export function SettingsDialog({
                     ) : (
                       <div className="space-y-2">
                         {draftDesktopSettings.pluginManifestUrls.map(
-                          (url, index) => (
+                          (entry, index) => (
                             <div
-                              key={index}
+                              key={entry.id}
                               className="grid grid-cols-[minmax(10rem,1fr)_2rem] items-center gap-2"
                             >
                               <Input
                                 aria-label="Plugin manifest URL"
                                 placeholder="https://example.com/plugin/plugin.json"
-                                value={url}
+                                value={entry.value}
                                 onChange={(event) =>
                                   updatePluginManifestUrl(
                                     index,

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -61,17 +61,13 @@ import {
   Wrench,
   X,
 } from "lucide-react";
-import {
-  type FormEvent,
-  useRef,
-  useState,
-  useSyncExternalStore,
-} from "react";
+import { type FormEvent, useRef, useState, useSyncExternalStore } from "react";
 import {
   createAppAPI,
   getPluginManager,
   usePluginRegistry,
 } from "../../hooks/usePlugins";
+import { useDesktopSettingsStore } from "../../hooks/useDesktopSettings";
 import type { ThemeMode } from "../../hooks/useThemeMode";
 import {
   isTauri,
@@ -286,6 +282,10 @@ export function TopToolbar({
   const handleSave = async (): Promise<boolean> => {
     const state = useAppStore.getState();
     const defaultProjectName = state.projectName.trim() || "Untitled Project";
+    const pluginManifestUrls = mergeStringLists(
+      state.projectPlugins?.manifestUrls ?? [],
+      useDesktopSettingsStore.getState().desktopSettings.pluginManifestUrls,
+    );
     const project = projectFromStore({
       projectName: defaultProjectName,
       mapView: mapControllerRef.current?.readView() ?? state.mapView,
@@ -294,7 +294,10 @@ export function TopToolbar({
       basemapOpacity: state.basemapOpacity,
       layers: state.layers,
       preferences: state.preferences,
-      plugins: getPluginManager().getProjectState(),
+      plugins: {
+        ...getPluginManager().getProjectState(),
+        manifestUrls: pluginManifestUrls,
+      },
       metadata: state.metadata,
     });
     const content = serializeProject(project);
@@ -810,4 +813,18 @@ export function TopToolbar({
       </div>
     </header>
   );
+}
+
+function mergeStringLists(...lists: string[][]): string[] {
+  const seen = new Set<string>();
+  const merged: string[] = [];
+  for (const list of lists) {
+    for (const value of list) {
+      const normalized = value.trim();
+      if (!normalized || seen.has(normalized)) continue;
+      seen.add(normalized);
+      merged.push(normalized);
+    }
+  }
+  return merged;
 }

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -76,6 +76,7 @@ import {
   RecentProjectGoneError,
   saveProjectFile,
 } from "../../lib/tauri-io";
+import { mergeStringLists } from "../../lib/string-lists";
 import { normalizeProjectUrl } from "../../lib/urls";
 import { resolveProjectXyzLayers } from "../../lib/xyz-url";
 import { AddDataDialog, type AddDataKind } from "./AddDataDialog";
@@ -813,18 +814,4 @@ export function TopToolbar({
       </div>
     </header>
   );
-}
-
-function mergeStringLists(...lists: string[][]): string[] {
-  const seen = new Set<string>();
-  const merged: string[] = [];
-  for (const list of lists) {
-    for (const value of list) {
-      const normalized = value.trim();
-      if (!normalized || seen.has(normalized)) continue;
-      seen.add(normalized);
-      merged.push(normalized);
-    }
-  }
-  return merged;
 }

--- a/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
+++ b/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import { create } from "zustand";
+import { normalizeStringList } from "../lib/string-lists";
 
 const DESKTOP_SETTINGS_STORAGE_KEY = "geolibre.desktopSettings";
 
@@ -17,21 +18,6 @@ const DEFAULT_DESKTOP_SETTINGS: DesktopSettings = {
   additionalPluginDirectories: [],
   pluginManifestUrls: [],
 };
-
-export function normalizeStringList(values: unknown): string[] {
-  if (!Array.isArray(values)) return [];
-
-  const seen = new Set<string>();
-  const normalized: string[] = [];
-  for (const value of values) {
-    if (typeof value !== "string") continue;
-    const normalizedValue = value.trim();
-    if (!normalizedValue || seen.has(normalizedValue)) continue;
-    seen.add(normalizedValue);
-    normalized.push(normalizedValue);
-  }
-  return normalized;
-}
 
 function normalizeDesktopSettings(settings: unknown): DesktopSettings {
   if (!settings || typeof settings !== "object") {

--- a/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
+++ b/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
@@ -1,0 +1,92 @@
+import { useEffect } from "react";
+import { create } from "zustand";
+
+const DESKTOP_SETTINGS_STORAGE_KEY = "geolibre.desktopSettings";
+
+export interface DesktopSettings {
+  additionalPluginDirectories: string[];
+}
+
+interface DesktopSettingsState {
+  desktopSettings: DesktopSettings;
+  setDesktopSettings: (settings: DesktopSettings) => void;
+}
+
+const DEFAULT_DESKTOP_SETTINGS: DesktopSettings = {
+  additionalPluginDirectories: [],
+};
+
+function normalizePathList(paths: unknown): string[] {
+  if (!Array.isArray(paths)) return [];
+
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const value of paths) {
+    if (typeof value !== "string") continue;
+    const path = value.trim();
+    if (!path || seen.has(path)) continue;
+    seen.add(path);
+    normalized.push(path);
+  }
+  return normalized;
+}
+
+function normalizeDesktopSettings(settings: unknown): DesktopSettings {
+  if (!settings || typeof settings !== "object") {
+    return DEFAULT_DESKTOP_SETTINGS;
+  }
+
+  const candidate = settings as Partial<DesktopSettings>;
+  return {
+    additionalPluginDirectories: normalizePathList(
+      candidate.additionalPluginDirectories,
+    ),
+  };
+}
+
+function loadDesktopSettings(): DesktopSettings {
+  if (typeof window === "undefined") return DEFAULT_DESKTOP_SETTINGS;
+
+  try {
+    const stored = window.localStorage.getItem(DESKTOP_SETTINGS_STORAGE_KEY);
+    if (!stored) return DEFAULT_DESKTOP_SETTINGS;
+    return normalizeDesktopSettings(JSON.parse(stored) as unknown);
+  } catch {
+    return DEFAULT_DESKTOP_SETTINGS;
+  }
+}
+
+function saveDesktopSettings(settings: DesktopSettings): void {
+  if (typeof window === "undefined") return;
+
+  try {
+    window.localStorage.setItem(
+      DESKTOP_SETTINGS_STORAGE_KEY,
+      JSON.stringify(settings),
+    );
+  } catch {
+    // Persistence is best-effort; ignore quota or disabled-storage errors.
+  }
+}
+
+export const useDesktopSettingsStore = create<DesktopSettingsState>((set) => ({
+  desktopSettings: loadDesktopSettings(),
+  setDesktopSettings: (settings) =>
+    set({ desktopSettings: normalizeDesktopSettings(settings) }),
+}));
+
+export function useDesktopSettingsPersistence() {
+  const setDesktopSettings = useDesktopSettingsStore(
+    (state) => state.setDesktopSettings,
+  );
+
+  useEffect(() => {
+    saveDesktopSettings(useDesktopSettingsStore.getState().desktopSettings);
+
+    return useDesktopSettingsStore.subscribe((state, previous) => {
+      if (state.desktopSettings !== previous.desktopSettings) {
+        saveDesktopSettings(state.desktopSettings);
+      }
+    });
+  }, [setDesktopSettings]);
+}

--- a/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
+++ b/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
@@ -76,10 +76,6 @@ export const useDesktopSettingsStore = create<DesktopSettingsState>((set) => ({
 }));
 
 export function useDesktopSettingsPersistence() {
-  const setDesktopSettings = useDesktopSettingsStore(
-    (state) => state.setDesktopSettings,
-  );
-
   useEffect(() => {
     saveDesktopSettings(useDesktopSettingsStore.getState().desktopSettings);
 
@@ -88,5 +84,5 @@ export function useDesktopSettingsPersistence() {
         saveDesktopSettings(state.desktopSettings);
       }
     });
-  }, [setDesktopSettings]);
+  }, []);
 }

--- a/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
+++ b/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
@@ -5,6 +5,7 @@ const DESKTOP_SETTINGS_STORAGE_KEY = "geolibre.desktopSettings";
 
 export interface DesktopSettings {
   additionalPluginDirectories: string[];
+  pluginManifestUrls: string[];
 }
 
 interface DesktopSettingsState {
@@ -14,19 +15,20 @@ interface DesktopSettingsState {
 
 const DEFAULT_DESKTOP_SETTINGS: DesktopSettings = {
   additionalPluginDirectories: [],
+  pluginManifestUrls: [],
 };
 
-function normalizePathList(paths: unknown): string[] {
-  if (!Array.isArray(paths)) return [];
+function normalizeStringList(values: unknown): string[] {
+  if (!Array.isArray(values)) return [];
 
   const seen = new Set<string>();
   const normalized: string[] = [];
-  for (const value of paths) {
+  for (const value of values) {
     if (typeof value !== "string") continue;
-    const path = value.trim();
-    if (!path || seen.has(path)) continue;
-    seen.add(path);
-    normalized.push(path);
+    const normalizedValue = value.trim();
+    if (!normalizedValue || seen.has(normalizedValue)) continue;
+    seen.add(normalizedValue);
+    normalized.push(normalizedValue);
   }
   return normalized;
 }
@@ -38,9 +40,10 @@ function normalizeDesktopSettings(settings: unknown): DesktopSettings {
 
   const candidate = settings as Partial<DesktopSettings>;
   return {
-    additionalPluginDirectories: normalizePathList(
+    additionalPluginDirectories: normalizeStringList(
       candidate.additionalPluginDirectories,
     ),
+    pluginManifestUrls: normalizeStringList(candidate.pluginManifestUrls),
   };
 }
 

--- a/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
+++ b/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
@@ -18,7 +18,7 @@ const DEFAULT_DESKTOP_SETTINGS: DesktopSettings = {
   pluginManifestUrls: [],
 };
 
-function normalizeStringList(values: unknown): string[] {
+export function normalizeStringList(values: unknown): string[] {
   if (!Array.isArray(values)) return [];
 
   const seen = new Set<string>();

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -16,6 +16,7 @@ import type { GeoLibreMapControlPosition } from "@geolibre/plugins";
 import type { RefObject } from "react";
 import { useEffect, useSyncExternalStore } from "react";
 import { loadExternalPlugins } from "../lib/external-plugins";
+import { mergeStringLists } from "../lib/string-lists";
 import { useDesktopSettingsStore } from "./useDesktopSettings";
 
 const RASTER_PROXY_PATH = "/__geolibre_raster_proxy";
@@ -127,11 +128,19 @@ function ensureExternalPluginsLoadedWithSettings(
 
   setExternalPluginsLoaded(false);
   externalPluginsLoadKey = loadKey;
-  const loadPromise = loadExternalPlugins(
-    manager,
-    desktopSettings.additionalPluginDirectories,
-    pluginManifestUrls,
-  )
+  // Serialize scans: loadExternalPlugins reads and writes module-level state
+  // (the loaded-plugin map) across awaits, so two in-flight scans could both
+  // pass the dedup check and double-register the same plugin. Waiting for the
+  // previous scan (which never rejects) keeps at most one scan running.
+  const previousLoad = externalPluginsLoadPromise ?? Promise.resolve();
+  const loadPromise = previousLoad
+    .then(() =>
+      loadExternalPlugins(
+        manager,
+        desktopSettings.additionalPluginDirectories,
+        pluginManifestUrls,
+      ),
+    )
     .then((result) => {
       if (result.loadedPluginIds.length) {
         console.info(
@@ -311,18 +320,4 @@ function persistProjectPluginState(previousJson: string): void {
   };
   if (JSON.stringify(nextState) === previousJson) return;
   useAppStore.getState().setProjectPlugins(nextState);
-}
-
-function mergeStringLists(...lists: string[][]): string[] {
-  const seen = new Set<string>();
-  const merged: string[] = [];
-  for (const list of lists) {
-    for (const value of list) {
-      const normalized = value.trim();
-      if (!normalized || seen.has(normalized)) continue;
-      seen.add(normalized);
-      merged.push(normalized);
-    }
-  }
-  return merged;
 }

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -41,6 +41,7 @@ let externalPluginsLoaded = false;
 let externalPluginsLoadPromise: Promise<void> | null = null;
 let externalPluginsLoadKey: string | null = null;
 const externalPluginsListeners = new Set<() => void>();
+const EMPTY_PLUGIN_MANIFEST_URLS: string[] = [];
 
 export function getPluginManager(): PluginManager {
   return manager;
@@ -82,10 +83,16 @@ export function useExternalPluginsReady(): boolean {
   const desktopSettings = useDesktopSettingsStore(
     (state) => state.desktopSettings,
   );
+  const projectPluginManifestUrls = useAppStore(
+    (state) => state.projectPlugins?.manifestUrls ?? EMPTY_PLUGIN_MANIFEST_URLS,
+  );
 
   useEffect(() => {
-    void ensureExternalPluginsLoadedWithSettings(desktopSettings);
-  }, [desktopSettings]);
+    void ensureExternalPluginsLoadedWithSettings(
+      desktopSettings,
+      projectPluginManifestUrls,
+    );
+  }, [desktopSettings, projectPluginManifestUrls]);
 
   return useSyncExternalStore(
     (listener) => {
@@ -101,8 +108,16 @@ function ensureExternalPluginsLoadedWithSettings(
   desktopSettings: ReturnType<
     typeof useDesktopSettingsStore.getState
   >["desktopSettings"],
+  projectPluginManifestUrls: string[],
 ): Promise<void> {
-  const loadKey = JSON.stringify(desktopSettings);
+  const pluginManifestUrls = mergeStringLists(
+    desktopSettings.pluginManifestUrls,
+    projectPluginManifestUrls,
+  );
+  const loadKey = JSON.stringify({
+    additionalPluginDirectories: desktopSettings.additionalPluginDirectories,
+    pluginManifestUrls,
+  });
   if (externalPluginsLoaded && externalPluginsLoadKey === loadKey) {
     return Promise.resolve();
   }
@@ -115,7 +130,7 @@ function ensureExternalPluginsLoadedWithSettings(
   const loadPromise = loadExternalPlugins(
     manager,
     desktopSettings.additionalPluginDirectories,
-    desktopSettings.pluginManifestUrls,
+    pluginManifestUrls,
   )
     .then((result) => {
       if (result.loadedPluginIds.length) {
@@ -288,7 +303,26 @@ function normalizeBytes(bytes: number[] | Uint8Array): ArrayBuffer {
 }
 
 function persistProjectPluginState(previousJson: string): void {
-  const nextState = manager.getProjectState();
+  const nextState = {
+    ...manager.getProjectState(),
+    manifestUrls:
+      useAppStore.getState().projectPlugins?.manifestUrls ??
+      EMPTY_PLUGIN_MANIFEST_URLS,
+  };
   if (JSON.stringify(nextState) === previousJson) return;
   useAppStore.getState().setProjectPlugins(nextState);
+}
+
+function mergeStringLists(...lists: string[][]): string[] {
+  const seen = new Set<string>();
+  const merged: string[] = [];
+  for (const list of lists) {
+    for (const value of list) {
+      const normalized = value.trim();
+      if (!normalized || seen.has(normalized)) continue;
+      seen.add(normalized);
+      merged.push(normalized);
+    }
+  }
+  return merged;
 }

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -100,10 +100,6 @@ export function useExternalPluginsReady(): boolean {
   );
 }
 
-export function ensureExternalPluginsLoaded(): Promise<void> {
-  return ensureExternalPluginsLoadedWithDirectories([]);
-}
-
 function ensureExternalPluginsLoadedWithDirectories(
   additionalPluginDirectories: string[],
 ): Promise<void> {
@@ -122,10 +118,7 @@ function ensureExternalPluginsLoadedWithDirectories(
 
   setExternalPluginsLoaded(false);
   externalPluginsLoadKey = loadKey;
-  externalPluginsLoadPromise = loadExternalPlugins(
-    manager,
-    additionalPluginDirectories,
-  )
+  const loadPromise = loadExternalPlugins(manager, additionalPluginDirectories)
     .then((result) => {
       if (result.loadedPluginIds.length) {
         console.info(
@@ -144,11 +137,15 @@ function ensureExternalPluginsLoadedWithDirectories(
       console.warn("Could not load external GeoLibre plugins.", error);
     })
     .finally(() => {
+      // A settings change can start a new load while this one is in flight.
+      // Only the load that still owns the current key may mark plugins ready.
+      if (externalPluginsLoadKey !== loadKey) return;
       externalPluginsLoadPromise = null;
       setExternalPluginsLoaded(true);
     });
 
-  return externalPluginsLoadPromise;
+  externalPluginsLoadPromise = loadPromise;
+  return loadPromise;
 }
 
 export function createAppAPI(

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -75,10 +75,9 @@ export function usePluginRegistry() {
   };
 }
 
-export function usePlugins() {
-  return useExternalPluginsReady();
-}
-
+// Built-in plugins are registered at module load so the toolbar can render
+// plugin menu items on the first pass. This hook additionally kicks off the
+// external plugin scan and reports whether it has finished.
 export function useExternalPluginsReady(): boolean {
   const desktopSettings = useDesktopSettingsStore(
     (state) => state.desktopSettings,

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -80,15 +80,13 @@ export function usePlugins() {
 }
 
 export function useExternalPluginsReady(): boolean {
-  const additionalPluginDirectories = useDesktopSettingsStore(
-    (state) => state.desktopSettings.additionalPluginDirectories,
+  const desktopSettings = useDesktopSettingsStore(
+    (state) => state.desktopSettings,
   );
 
   useEffect(() => {
-    void ensureExternalPluginsLoadedWithDirectories(
-      additionalPluginDirectories,
-    );
-  }, [additionalPluginDirectories]);
+    void ensureExternalPluginsLoadedWithSettings(desktopSettings);
+  }, [desktopSettings]);
 
   return useSyncExternalStore(
     (listener) => {
@@ -100,15 +98,12 @@ export function useExternalPluginsReady(): boolean {
   );
 }
 
-function ensureExternalPluginsLoadedWithDirectories(
-  additionalPluginDirectories: string[],
+function ensureExternalPluginsLoadedWithSettings(
+  desktopSettings: ReturnType<
+    typeof useDesktopSettingsStore.getState
+  >["desktopSettings"],
 ): Promise<void> {
-  if (!isTauriRuntime()) {
-    setExternalPluginsLoaded(true);
-    return Promise.resolve();
-  }
-
-  const loadKey = JSON.stringify(additionalPluginDirectories);
+  const loadKey = JSON.stringify(desktopSettings);
   if (externalPluginsLoaded && externalPluginsLoadKey === loadKey) {
     return Promise.resolve();
   }
@@ -118,11 +113,15 @@ function ensureExternalPluginsLoadedWithDirectories(
 
   setExternalPluginsLoaded(false);
   externalPluginsLoadKey = loadKey;
-  const loadPromise = loadExternalPlugins(manager, additionalPluginDirectories)
+  const loadPromise = loadExternalPlugins(
+    manager,
+    desktopSettings.additionalPluginDirectories,
+    desktopSettings.pluginManifestUrls,
+  )
     .then((result) => {
       if (result.loadedPluginIds.length) {
         console.info(
-          `Loaded external GeoLibre plugins from ${result.pluginsDirectories.join(
+          `Loaded external GeoLibre plugins from ${result.pluginSources.join(
             ", ",
           )}: ${result.loadedPluginIds.join(", ")}`,
         );

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -16,6 +16,7 @@ import type { GeoLibreMapControlPosition } from "@geolibre/plugins";
 import type { RefObject } from "react";
 import { useEffect, useSyncExternalStore } from "react";
 import { loadExternalPlugins } from "../lib/external-plugins";
+import { useDesktopSettingsStore } from "./useDesktopSettings";
 
 const RASTER_PROXY_PATH = "/__geolibre_raster_proxy";
 
@@ -38,6 +39,7 @@ manager.registerAll([
 
 let externalPluginsLoaded = false;
 let externalPluginsLoadPromise: Promise<void> | null = null;
+let externalPluginsLoadKey: string | null = null;
 let externalPluginsVersion = 0;
 const externalPluginsListeners = new Set<() => void>();
 
@@ -79,9 +81,15 @@ export function usePlugins() {
 }
 
 export function useExternalPluginsReady(): boolean {
+  const additionalPluginDirectories = useDesktopSettingsStore(
+    (state) => state.desktopSettings.additionalPluginDirectories,
+  );
+
   useEffect(() => {
-    void ensureExternalPluginsLoaded();
-  }, []);
+    void ensureExternalPluginsLoadedWithDirectories(
+      additionalPluginDirectories,
+    );
+  }, [additionalPluginDirectories]);
 
   useSyncExternalStore(
     (listener) => {
@@ -96,18 +104,37 @@ export function useExternalPluginsReady(): boolean {
 }
 
 export function ensureExternalPluginsLoaded(): Promise<void> {
+  return ensureExternalPluginsLoadedWithDirectories([]);
+}
+
+function ensureExternalPluginsLoadedWithDirectories(
+  additionalPluginDirectories: string[],
+): Promise<void> {
   if (!isTauriRuntime()) {
     markExternalPluginsLoaded();
     return Promise.resolve();
   }
 
-  externalPluginsLoadPromise ??= loadExternalPlugins(manager)
+  const loadKey = JSON.stringify(additionalPluginDirectories);
+  if (externalPluginsLoaded && externalPluginsLoadKey === loadKey) {
+    return Promise.resolve();
+  }
+  if (externalPluginsLoadPromise && externalPluginsLoadKey === loadKey) {
+    return externalPluginsLoadPromise;
+  }
+
+  externalPluginsLoaded = false;
+  externalPluginsLoadKey = loadKey;
+  externalPluginsLoadPromise = loadExternalPlugins(
+    manager,
+    additionalPluginDirectories,
+  )
     .then((result) => {
       if (result.loadedPluginIds.length) {
         console.info(
-          `Loaded external GeoLibre plugins from ${result.pluginsDirectory}: ${result.loadedPluginIds.join(
+          `Loaded external GeoLibre plugins from ${result.pluginsDirectories.join(
             ", ",
-          )}`,
+          )}: ${result.loadedPluginIds.join(", ")}`,
         );
       }
       for (const issue of result.issues) {
@@ -119,7 +146,10 @@ export function ensureExternalPluginsLoaded(): Promise<void> {
     .catch((error) => {
       console.warn("Could not load external GeoLibre plugins.", error);
     })
-    .finally(markExternalPluginsLoaded);
+    .finally(() => {
+      externalPluginsLoadPromise = null;
+      markExternalPluginsLoaded();
+    });
 
   return externalPluginsLoadPromise;
 }

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -40,7 +40,6 @@ manager.registerAll([
 let externalPluginsLoaded = false;
 let externalPluginsLoadPromise: Promise<void> | null = null;
 let externalPluginsLoadKey: string | null = null;
-let externalPluginsVersion = 0;
 const externalPluginsListeners = new Set<() => void>();
 
 export function getPluginManager(): PluginManager {
@@ -91,16 +90,14 @@ export function useExternalPluginsReady(): boolean {
     );
   }, [additionalPluginDirectories]);
 
-  useSyncExternalStore(
+  return useSyncExternalStore(
     (listener) => {
       externalPluginsListeners.add(listener);
       return () => externalPluginsListeners.delete(listener);
     },
-    () => externalPluginsVersion,
-    () => externalPluginsVersion,
+    () => externalPluginsLoaded,
+    () => externalPluginsLoaded,
   );
-
-  return externalPluginsLoaded;
 }
 
 export function ensureExternalPluginsLoaded(): Promise<void> {
@@ -111,7 +108,7 @@ function ensureExternalPluginsLoadedWithDirectories(
   additionalPluginDirectories: string[],
 ): Promise<void> {
   if (!isTauriRuntime()) {
-    markExternalPluginsLoaded();
+    setExternalPluginsLoaded(true);
     return Promise.resolve();
   }
 
@@ -123,7 +120,7 @@ function ensureExternalPluginsLoadedWithDirectories(
     return externalPluginsLoadPromise;
   }
 
-  externalPluginsLoaded = false;
+  setExternalPluginsLoaded(false);
   externalPluginsLoadKey = loadKey;
   externalPluginsLoadPromise = loadExternalPlugins(
     manager,
@@ -148,7 +145,7 @@ function ensureExternalPluginsLoadedWithDirectories(
     })
     .finally(() => {
       externalPluginsLoadPromise = null;
-      markExternalPluginsLoaded();
+      setExternalPluginsLoaded(true);
     });
 
   return externalPluginsLoadPromise;
@@ -265,10 +262,9 @@ function isTauriRuntime(): boolean {
   return Boolean((window as TauriRuntimeWindow).__TAURI_INTERNALS__);
 }
 
-function markExternalPluginsLoaded(): void {
-  if (externalPluginsLoaded) return;
-  externalPluginsLoaded = true;
-  externalPluginsVersion += 1;
+function setExternalPluginsLoaded(loaded: boolean): void {
+  if (externalPluginsLoaded === loaded) return;
+  externalPluginsLoaded = loaded;
   for (const listener of externalPluginsListeners) listener();
 }
 

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -14,7 +14,8 @@ import {
 import type { MapController } from "@geolibre/map";
 import type { GeoLibreMapControlPosition } from "@geolibre/plugins";
 import type { RefObject } from "react";
-import { useSyncExternalStore } from "react";
+import { useEffect, useSyncExternalStore } from "react";
+import { loadExternalPlugins } from "../lib/external-plugins";
 
 const RASTER_PROXY_PATH = "/__geolibre_raster_proxy";
 
@@ -34,6 +35,11 @@ manager.registerAll([
   maplibreSwipePlugin,
   maplibreComponentsPlugin,
 ]);
+
+let externalPluginsLoaded = false;
+let externalPluginsLoadPromise: Promise<void> | null = null;
+let externalPluginsVersion = 0;
+const externalPluginsListeners = new Set<() => void>();
 
 export function getPluginManager(): PluginManager {
   return manager;
@@ -69,8 +75,53 @@ export function usePluginRegistry() {
 }
 
 export function usePlugins() {
-  // Built-in plugin registration happens at module load so the toolbar can
-  // render plugin menu items on the first pass.
+  return useExternalPluginsReady();
+}
+
+export function useExternalPluginsReady(): boolean {
+  useEffect(() => {
+    void ensureExternalPluginsLoaded();
+  }, []);
+
+  useSyncExternalStore(
+    (listener) => {
+      externalPluginsListeners.add(listener);
+      return () => externalPluginsListeners.delete(listener);
+    },
+    () => externalPluginsVersion,
+    () => externalPluginsVersion,
+  );
+
+  return externalPluginsLoaded;
+}
+
+export function ensureExternalPluginsLoaded(): Promise<void> {
+  if (!isTauriRuntime()) {
+    markExternalPluginsLoaded();
+    return Promise.resolve();
+  }
+
+  externalPluginsLoadPromise ??= loadExternalPlugins(manager)
+    .then((result) => {
+      if (result.loadedPluginIds.length) {
+        console.info(
+          `Loaded external GeoLibre plugins from ${result.pluginsDirectory}: ${result.loadedPluginIds.join(
+            ", ",
+          )}`,
+        );
+      }
+      for (const issue of result.issues) {
+        console.warn(
+          `Skipped external plugin archive '${issue.archiveName}': ${issue.message}`,
+        );
+      }
+    })
+    .catch((error) => {
+      console.warn("Could not load external GeoLibre plugins.", error);
+    })
+    .finally(markExternalPluginsLoaded);
+
+  return externalPluginsLoadPromise;
 }
 
 export function createAppAPI(
@@ -102,8 +153,9 @@ export function createAppAPI(
       control: Parameters<MapController["addControl"]>[0],
       position?: Parameters<MapController["addControl"]>[1],
     ) => mapControllerRef?.current?.addControl(control, position) ?? false,
-    removeMapControl: (control: Parameters<MapController["removeControl"]>[0]) =>
-      mapControllerRef?.current?.removeControl(control),
+    removeMapControl: (
+      control: Parameters<MapController["removeControl"]>[0],
+    ) => mapControllerRef?.current?.removeControl(control),
     setBuiltInMapControlVisible: (
       control: Parameters<MapController["setBuiltInControlVisible"]>[0],
       visible: boolean,
@@ -119,10 +171,8 @@ export function createAppAPI(
       control: Parameters<MapController["setBuiltInControlPosition"]>[0],
       position: Parameters<MapController["setBuiltInControlPosition"]>[1],
     ) =>
-      mapControllerRef?.current?.setBuiltInControlPosition(
-        control,
-        position,
-      ) ?? false,
+      mapControllerRef?.current?.setBuiltInControlPosition(control, position) ??
+      false,
   };
 }
 
@@ -167,7 +217,9 @@ function localPathFromReference(value: string): string {
 }
 
 function fetchDevRasterProxy(url: string): Promise<ArrayBuffer> {
-  return fetchArrayBuffer(`${RASTER_PROXY_PATH}?url=${encodeURIComponent(url)}`);
+  return fetchArrayBuffer(
+    `${RASTER_PROXY_PATH}?url=${encodeURIComponent(url)}`,
+  );
 }
 
 async function fetchArrayBuffer(url: string): Promise<ArrayBuffer> {
@@ -181,6 +233,13 @@ async function fetchArrayBuffer(url: string): Promise<ArrayBuffer> {
 function isTauriRuntime(): boolean {
   if (typeof window === "undefined") return false;
   return Boolean((window as TauriRuntimeWindow).__TAURI_INTERNALS__);
+}
+
+function markExternalPluginsLoaded(): void {
+  if (externalPluginsLoaded) return;
+  externalPluginsLoaded = true;
+  externalPluginsVersion += 1;
+  for (const listener of externalPluginsListeners) listener();
 }
 
 function isLocalDevHost(): boolean {

--- a/apps/geolibre-desktop/src/lib/external-plugins.ts
+++ b/apps/geolibre-desktop/src/lib/external-plugins.ts
@@ -34,6 +34,12 @@ export interface ExternalPluginLoadResult {
   issues: ExternalPluginLoadIssue[];
 }
 
+// IDs registered by previous loadExternalPlugins calls. A settings change
+// triggers a re-scan; plugins already loaded externally are skipped silently
+// instead of being reported as duplicate-ID issues. Removing a plugin
+// directory does not unregister its plugins until the app restarts.
+const externallyLoadedPluginIds = new Set<string>();
+
 export async function loadExternalPlugins(
   manager: PluginManager,
   additionalPluginDirectories: string[] = [],
@@ -64,6 +70,11 @@ export async function loadExternalPlugins(
 
   for (const bundle of result.bundles) {
     try {
+      if (externallyLoadedPluginIds.has(bundle.manifest.id)) {
+        // Already loaded by a previous scan; a settings change re-runs the
+        // scan and should not warn about plugins it loaded itself.
+        continue;
+      }
       if (registeredPluginIds.has(bundle.manifest.id)) {
         issues.push({
           archiveName: bundle.archiveName,
@@ -78,6 +89,7 @@ export async function loadExternalPlugins(
       }
       manager.register(plugin);
       registeredPluginIds.add(plugin.id);
+      externallyLoadedPluginIds.add(plugin.id);
       loadedPluginIds.push(plugin.id);
     } catch (error) {
       issues.push({

--- a/apps/geolibre-desktop/src/lib/external-plugins.ts
+++ b/apps/geolibre-desktop/src/lib/external-plugins.ts
@@ -91,12 +91,15 @@ export async function loadExternalPlugins(
       }
 
       const plugin = await importExternalPlugin(bundle);
-      if (bundle.styleSource) {
-        injectExternalPluginStyle(bundle.manifest.id, bundle.styleSource);
-      }
       manager.register(plugin);
       registeredPluginIds.add(plugin.id);
       externallyLoadedPluginSources.set(plugin.id, bundle.archiveName);
+      // Inject the style only after registration succeeds; an orphaned
+      // <style> element would block re-injection on a later scan because
+      // injectExternalPluginStyle skips existing style ids.
+      if (bundle.styleSource) {
+        injectExternalPluginStyle(bundle.manifest.id, bundle.styleSource);
+      }
       loadedPluginIds.push(plugin.id);
     } catch (error) {
       issues.push({
@@ -185,12 +188,54 @@ async function loadPluginUrlBundle(
   };
 }
 
+// Mirrors MAX_PLUGIN_ENTRY_BYTES in the Rust filesystem loader so URL-loaded
+// plugin assets cannot buffer an unbounded response into memory.
+const MAX_PLUGIN_ASSET_BYTES = 50 * 1024 * 1024;
+
 async function fetchPluginText(url: string, label: string): Promise<string> {
   const response = await fetch(url);
   if (!response.ok) {
     throw new Error(`Could not fetch ${label}: HTTP ${response.status}`);
   }
-  return response.text();
+
+  const contentLength = Number(response.headers.get("content-length"));
+  if (contentLength > MAX_PLUGIN_ASSET_BYTES) {
+    throw new Error(`Could not fetch ${label}: exceeds the 50 MB size limit.`);
+  }
+
+  const reader = response.body?.getReader();
+  if (!reader) {
+    const text = await response.text();
+    if (text.length > MAX_PLUGIN_ASSET_BYTES) {
+      throw new Error(
+        `Could not fetch ${label}: exceeds the 50 MB size limit.`,
+      );
+    }
+    return text;
+  }
+
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    totalBytes += value.byteLength;
+    if (totalBytes > MAX_PLUGIN_ASSET_BYTES) {
+      await reader.cancel();
+      throw new Error(
+        `Could not fetch ${label}: exceeds the 50 MB size limit.`,
+      );
+    }
+    chunks.push(value);
+  }
+
+  const merged = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(merged);
 }
 
 function resolvePluginAssetUrl(manifestUrl: string, path: string): string {
@@ -205,16 +250,24 @@ function resolvePluginAssetUrl(manifestUrl: string, path: string): string {
   return new URL(path, manifestUrl).toString();
 }
 
+// Matches the Rust validate_required_manifest_string: non-empty with no
+// leading or trailing whitespace.
+function isRequiredManifestString(value: unknown): value is string {
+  return (
+    typeof value === "string" && value.length > 0 && value.trim() === value
+  );
+}
+
 function isExternalPluginManifest(
   value: unknown,
 ): value is GeoLibreExternalPluginManifest {
   if (!value || typeof value !== "object") return false;
   const manifest = value as Partial<GeoLibreExternalPluginManifest>;
   return (
-    typeof manifest.id === "string" &&
-    typeof manifest.name === "string" &&
-    typeof manifest.version === "string" &&
-    typeof manifest.entry === "string" &&
+    isRequiredManifestString(manifest.id) &&
+    isRequiredManifestString(manifest.name) &&
+    isRequiredManifestString(manifest.version) &&
+    isRequiredManifestString(manifest.entry) &&
     (manifest.entry.endsWith(".js") || manifest.entry.endsWith(".mjs")) &&
     (manifest.description === undefined ||
       typeof manifest.description === "string") &&

--- a/apps/geolibre-desktop/src/lib/external-plugins.ts
+++ b/apps/geolibre-desktop/src/lib/external-plugins.ts
@@ -30,6 +30,7 @@ export interface ExternalPluginLoadIssue {
 
 export interface ExternalPluginLoadResult {
   pluginsDirectories: string[];
+  pluginSources: string[];
   loadedPluginIds: string[];
   issues: ExternalPluginLoadIssue[];
 }
@@ -43,32 +44,28 @@ const externallyLoadedPluginIds = new Set<string>();
 export async function loadExternalPlugins(
   manager: PluginManager,
   additionalPluginDirectories: string[] = [],
+  pluginManifestUrls: string[] = [],
 ): Promise<ExternalPluginLoadResult> {
-  if (!isTauri()) {
-    return {
-      pluginsDirectories: [],
-      loadedPluginIds: [],
-      issues: [],
-    };
-  }
-
-  const { invoke } = await import("@tauri-apps/api/core");
-  const result = await invoke<ExternalPluginBundleLoadResult>(
-    "load_external_plugin_bundles",
-    {
-      additionalPluginDirectories,
-    },
+  const filesystemResult = isTauri()
+    ? await loadFilesystemPluginBundles(additionalPluginDirectories)
+    : {
+        pluginsDirectories: [],
+        bundles: [],
+        errors: [],
+      };
+  const issues: ExternalPluginLoadIssue[] = filesystemResult.errors.map(
+    (error) => ({
+      archiveName: error.archiveName,
+      message: error.message,
+    }),
   );
-  const issues: ExternalPluginLoadIssue[] = result.errors.map((error) => ({
-    archiveName: error.archiveName,
-    message: error.message,
-  }));
+  const urlBundles = await loadPluginUrlBundles(pluginManifestUrls, issues);
   const loadedPluginIds: string[] = [];
   const registeredPluginIds = new Set(
     manager.list().map((plugin) => plugin.id),
   );
 
-  for (const bundle of result.bundles) {
+  for (const bundle of [...urlBundles, ...filesystemResult.bundles]) {
     try {
       if (externallyLoadedPluginIds.has(bundle.manifest.id)) {
         // Already loaded by a previous scan; a settings change re-runs the
@@ -103,10 +100,117 @@ export async function loadExternalPlugins(
   }
 
   return {
-    pluginsDirectories: result.pluginsDirectories,
+    pluginsDirectories: filesystemResult.pluginsDirectories,
+    pluginSources: [
+      ...pluginManifestUrls,
+      ...filesystemResult.pluginsDirectories,
+    ],
     loadedPluginIds,
     issues,
   };
+}
+
+async function loadFilesystemPluginBundles(
+  additionalPluginDirectories: string[],
+): Promise<ExternalPluginBundleLoadResult> {
+  const { invoke } = await import("@tauri-apps/api/core");
+  return invoke<ExternalPluginBundleLoadResult>(
+    "load_external_plugin_bundles",
+    {
+      additionalPluginDirectories,
+    },
+  );
+}
+
+async function loadPluginUrlBundles(
+  manifestUrls: string[],
+  issues: ExternalPluginLoadIssue[],
+): Promise<ExternalPluginBundle[]> {
+  const bundles: ExternalPluginBundle[] = [];
+  for (const manifestUrl of manifestUrls) {
+    try {
+      bundles.push(await loadPluginUrlBundle(manifestUrl));
+    } catch (error) {
+      issues.push({
+        archiveName: manifestUrl,
+        message:
+          error instanceof Error
+            ? error.message
+            : "Could not load plugin manifest URL.",
+      });
+    }
+  }
+  return bundles;
+}
+
+async function loadPluginUrlBundle(
+  manifestUrl: string,
+): Promise<ExternalPluginBundle> {
+  const manifestResponse = await fetch(manifestUrl);
+  if (!manifestResponse.ok) {
+    throw new Error(
+      `Could not fetch plugin manifest: HTTP ${manifestResponse.status}`,
+    );
+  }
+
+  const manifest = (await manifestResponse.json()) as unknown;
+  if (!isExternalPluginManifest(manifest)) {
+    throw new Error("Plugin manifest is invalid.");
+  }
+
+  const entryUrl = resolvePluginAssetUrl(manifestUrl, manifest.entry);
+  const entrySource = await fetchPluginText(entryUrl, "plugin entry");
+  const styleSource = manifest.style
+    ? await fetchPluginText(
+        resolvePluginAssetUrl(manifestUrl, manifest.style),
+        "plugin style",
+      )
+    : null;
+
+  return {
+    archiveName: manifestUrl,
+    manifest,
+    entrySource,
+    styleSource,
+  };
+}
+
+async function fetchPluginText(url: string, label: string): Promise<string> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Could not fetch ${label}: HTTP ${response.status}`);
+  }
+  return response.text();
+}
+
+function resolvePluginAssetUrl(manifestUrl: string, path: string): string {
+  if (
+    path.startsWith("/") ||
+    path.includes("\\") ||
+    /^[a-z][a-z\d+.-]*:/i.test(path) ||
+    path.split("/").some((part) => !part || part === "." || part === "..")
+  ) {
+    throw new Error("Plugin manifest paths must be relative safe paths.");
+  }
+  return new URL(path, manifestUrl).toString();
+}
+
+function isExternalPluginManifest(
+  value: unknown,
+): value is GeoLibreExternalPluginManifest {
+  if (!value || typeof value !== "object") return false;
+  const manifest = value as Partial<GeoLibreExternalPluginManifest>;
+  return (
+    typeof manifest.id === "string" &&
+    typeof manifest.name === "string" &&
+    typeof manifest.version === "string" &&
+    typeof manifest.entry === "string" &&
+    (manifest.entry.endsWith(".js") || manifest.entry.endsWith(".mjs")) &&
+    (manifest.description === undefined ||
+      typeof manifest.description === "string") &&
+    (manifest.style === undefined ||
+      (typeof manifest.style === "string" && manifest.style.endsWith(".css")))
+  );
 }
 
 async function importExternalPlugin(

--- a/apps/geolibre-desktop/src/lib/external-plugins.ts
+++ b/apps/geolibre-desktop/src/lib/external-plugins.ts
@@ -140,15 +140,18 @@ async function loadPluginUrlBundles(
   issues: ExternalPluginLoadIssue[],
 ): Promise<ExternalPluginBundle[]> {
   const bundles: ExternalPluginBundle[] = [];
-  for (const manifestUrl of manifestUrls) {
-    try {
-      bundles.push(await loadPluginUrlBundle(manifestUrl));
-    } catch (error) {
+  const results = await Promise.allSettled(
+    manifestUrls.map((manifestUrl) => loadPluginUrlBundle(manifestUrl)),
+  );
+  for (const [index, result] of results.entries()) {
+    if (result.status === "fulfilled") {
+      bundles.push(result.value);
+    } else {
       issues.push({
-        archiveName: manifestUrl,
+        archiveName: manifestUrls[index],
         message:
-          error instanceof Error
-            ? error.message
+          result.reason instanceof Error
+            ? result.reason.message
             : "Could not load plugin manifest URL.",
       });
     }

--- a/apps/geolibre-desktop/src/lib/external-plugins.ts
+++ b/apps/geolibre-desktop/src/lib/external-plugins.ts
@@ -201,15 +201,20 @@ async function fetchPluginText(url: string, label: string): Promise<string> {
     throw new Error(`Could not fetch ${label}: HTTP ${response.status}`);
   }
 
-  const contentLength = Number(response.headers.get("content-length"));
-  if (contentLength > MAX_PLUGIN_ASSET_BYTES) {
+  // Fast-fail when the server declares the size; the streaming reader below
+  // is the real enforcement for responses without a content-length header.
+  const contentLengthHeader = response.headers.get("content-length");
+  if (
+    contentLengthHeader !== null &&
+    Number(contentLengthHeader) > MAX_PLUGIN_ASSET_BYTES
+  ) {
     throw new Error(`Could not fetch ${label}: exceeds the 50 MB size limit.`);
   }
 
   const reader = response.body?.getReader();
   if (!reader) {
     const text = await response.text();
-    if (text.length > MAX_PLUGIN_ASSET_BYTES) {
+    if (new TextEncoder().encode(text).byteLength > MAX_PLUGIN_ASSET_BYTES) {
       throw new Error(
         `Could not fetch ${label}: exceeds the 50 MB size limit.`,
       );
@@ -250,7 +255,15 @@ function resolvePluginAssetUrl(manifestUrl: string, path: string): string {
   ) {
     throw new Error("Plugin manifest paths must be relative safe paths.");
   }
-  return new URL(path, manifestUrl).toString();
+  // Percent-encoded dot segments ("%2e%2e") pass the textual check above but
+  // the URL parser still normalizes them, so confirm the resolved URL stays
+  // under the manifest directory.
+  const resolved = new URL(path, manifestUrl);
+  const manifestDirectory = new URL(".", manifestUrl);
+  if (!resolved.href.startsWith(manifestDirectory.href)) {
+    throw new Error("Plugin manifest paths must be relative safe paths.");
+  }
+  return resolved.toString();
 }
 
 // Matches the Rust validate_required_manifest_string: non-empty with no

--- a/apps/geolibre-desktop/src/lib/external-plugins.ts
+++ b/apps/geolibre-desktop/src/lib/external-plugins.ts
@@ -18,7 +18,7 @@ interface ExternalPluginBundleError {
 }
 
 interface ExternalPluginBundleLoadResult {
-  pluginsDirectory: string;
+  pluginsDirectories: string[];
   bundles: ExternalPluginBundle[];
   errors: ExternalPluginBundleError[];
 }
@@ -29,16 +29,18 @@ export interface ExternalPluginLoadIssue {
 }
 
 export interface ExternalPluginLoadResult {
-  pluginsDirectory?: string;
+  pluginsDirectories: string[];
   loadedPluginIds: string[];
   issues: ExternalPluginLoadIssue[];
 }
 
 export async function loadExternalPlugins(
   manager: PluginManager,
+  additionalPluginDirectories: string[] = [],
 ): Promise<ExternalPluginLoadResult> {
   if (!isTauri()) {
     return {
+      pluginsDirectories: [],
       loadedPluginIds: [],
       issues: [],
     };
@@ -47,6 +49,9 @@ export async function loadExternalPlugins(
   const { invoke } = await import("@tauri-apps/api/core");
   const result = await invoke<ExternalPluginBundleLoadResult>(
     "load_external_plugin_bundles",
+    {
+      additionalPluginDirectories,
+    },
   );
   const issues: ExternalPluginLoadIssue[] = result.errors.map((error) => ({
     archiveName: error.archiveName,
@@ -94,7 +99,7 @@ export async function loadExternalPlugins(
   }
 
   return {
-    pluginsDirectory: result.pluginsDirectory,
+    pluginsDirectories: result.pluginsDirectories,
     loadedPluginIds,
     issues,
   };

--- a/apps/geolibre-desktop/src/lib/external-plugins.ts
+++ b/apps/geolibre-desktop/src/lib/external-plugins.ts
@@ -73,14 +73,6 @@ export async function loadExternalPlugins(
       }
 
       const plugin = await importExternalPlugin(bundle);
-      if (registeredPluginIds.has(plugin.id)) {
-        issues.push({
-          archiveName: bundle.archiveName,
-          message: `Plugin id '${plugin.id}' is already registered.`,
-        });
-        continue;
-      }
-
       if (bundle.styleSource) {
         injectExternalPluginStyle(bundle.manifest.id, bundle.styleSource);
       }

--- a/apps/geolibre-desktop/src/lib/external-plugins.ts
+++ b/apps/geolibre-desktop/src/lib/external-plugins.ts
@@ -35,11 +35,13 @@ export interface ExternalPluginLoadResult {
   issues: ExternalPluginLoadIssue[];
 }
 
-// IDs registered by previous loadExternalPlugins calls. A settings change
-// triggers a re-scan; plugins already loaded externally are skipped silently
-// instead of being reported as duplicate-ID issues. Removing a plugin
-// directory does not unregister its plugins until the app restarts.
-const externallyLoadedPluginIds = new Set<string>();
+// Plugin IDs registered by previous loadExternalPlugins calls, mapped to the
+// source that loaded them. A settings change triggers a re-scan; plugins
+// already loaded from the same source are skipped silently, while the same ID
+// arriving from a different source is reported so the user knows a restart is
+// needed to pick it up. Removing a plugin source does not unregister its
+// plugins until the app restarts.
+const externallyLoadedPluginSources = new Map<string, string>();
 
 export async function loadExternalPlugins(
   manager: PluginManager,
@@ -65,11 +67,19 @@ export async function loadExternalPlugins(
     manager.list().map((plugin) => plugin.id),
   );
 
-  for (const bundle of [...urlBundles, ...filesystemResult.bundles]) {
+  for (const bundle of [...filesystemResult.bundles, ...urlBundles]) {
     try {
-      if (externallyLoadedPluginIds.has(bundle.manifest.id)) {
+      const loadedFrom = externallyLoadedPluginSources.get(bundle.manifest.id);
+      if (loadedFrom !== undefined) {
         // Already loaded by a previous scan; a settings change re-runs the
-        // scan and should not warn about plugins it loaded itself.
+        // scan and should not warn about plugins it loaded itself. A copy
+        // from a different source needs a restart to replace the loaded one.
+        if (loadedFrom !== bundle.archiveName) {
+          issues.push({
+            archiveName: bundle.archiveName,
+            message: `Plugin id '${bundle.manifest.id}' is already loaded from '${loadedFrom}'. Restart GeoLibre to load this copy.`,
+          });
+        }
         continue;
       }
       if (registeredPluginIds.has(bundle.manifest.id)) {
@@ -86,7 +96,7 @@ export async function loadExternalPlugins(
       }
       manager.register(plugin);
       registeredPluginIds.add(plugin.id);
-      externallyLoadedPluginIds.add(plugin.id);
+      externallyLoadedPluginSources.set(plugin.id, bundle.archiveName);
       loadedPluginIds.push(plugin.id);
     } catch (error) {
       issues.push({

--- a/apps/geolibre-desktop/src/lib/external-plugins.ts
+++ b/apps/geolibre-desktop/src/lib/external-plugins.ts
@@ -1,0 +1,170 @@
+import type {
+  GeoLibreExternalPluginManifest,
+  GeoLibrePlugin,
+  PluginManager,
+} from "@geolibre/plugins";
+import { isTauri } from "./tauri-io";
+
+interface ExternalPluginBundle {
+  archiveName: string;
+  manifest: GeoLibreExternalPluginManifest;
+  entrySource: string;
+  styleSource?: string | null;
+}
+
+interface ExternalPluginBundleError {
+  archiveName: string;
+  message: string;
+}
+
+interface ExternalPluginBundleLoadResult {
+  pluginsDirectory: string;
+  bundles: ExternalPluginBundle[];
+  errors: ExternalPluginBundleError[];
+}
+
+export interface ExternalPluginLoadIssue {
+  archiveName: string;
+  message: string;
+}
+
+export interface ExternalPluginLoadResult {
+  pluginsDirectory?: string;
+  loadedPluginIds: string[];
+  issues: ExternalPluginLoadIssue[];
+}
+
+export async function loadExternalPlugins(
+  manager: PluginManager,
+): Promise<ExternalPluginLoadResult> {
+  if (!isTauri()) {
+    return {
+      loadedPluginIds: [],
+      issues: [],
+    };
+  }
+
+  const { invoke } = await import("@tauri-apps/api/core");
+  const result = await invoke<ExternalPluginBundleLoadResult>(
+    "load_external_plugin_bundles",
+  );
+  const issues: ExternalPluginLoadIssue[] = result.errors.map((error) => ({
+    archiveName: error.archiveName,
+    message: error.message,
+  }));
+  const loadedPluginIds: string[] = [];
+  const registeredPluginIds = new Set(
+    manager.list().map((plugin) => plugin.id),
+  );
+
+  for (const bundle of result.bundles) {
+    try {
+      if (registeredPluginIds.has(bundle.manifest.id)) {
+        issues.push({
+          archiveName: bundle.archiveName,
+          message: `Plugin id '${bundle.manifest.id}' is already registered.`,
+        });
+        continue;
+      }
+
+      const plugin = await importExternalPlugin(bundle);
+      if (registeredPluginIds.has(plugin.id)) {
+        issues.push({
+          archiveName: bundle.archiveName,
+          message: `Plugin id '${plugin.id}' is already registered.`,
+        });
+        continue;
+      }
+
+      if (bundle.styleSource) {
+        injectExternalPluginStyle(bundle.manifest.id, bundle.styleSource);
+      }
+      manager.register(plugin);
+      registeredPluginIds.add(plugin.id);
+      loadedPluginIds.push(plugin.id);
+    } catch (error) {
+      issues.push({
+        archiveName: bundle.archiveName,
+        message:
+          error instanceof Error
+            ? error.message
+            : "Could not load external plugin.",
+      });
+    }
+  }
+
+  return {
+    pluginsDirectory: result.pluginsDirectory,
+    loadedPluginIds,
+    issues,
+  };
+}
+
+async function importExternalPlugin(
+  bundle: ExternalPluginBundle,
+): Promise<GeoLibrePlugin> {
+  const moduleUrl = URL.createObjectURL(
+    new Blob([bundle.entrySource], { type: "text/javascript" }),
+  );
+
+  try {
+    const module = (await import(/* @vite-ignore */ moduleUrl)) as {
+      default?: unknown;
+      plugin?: unknown;
+    };
+    const candidate = module.default ?? module.plugin;
+    if (!isGeoLibrePlugin(candidate)) {
+      throw new Error(
+        "Entry must export a GeoLibrePlugin as default or plugin.",
+      );
+    }
+    validateManifestMatchesPlugin(bundle.manifest, candidate);
+    if (candidate.activeByDefault) {
+      throw new Error("External plugins cannot use activeByDefault.");
+    }
+    return candidate;
+  } finally {
+    URL.revokeObjectURL(moduleUrl);
+  }
+}
+
+function isGeoLibrePlugin(value: unknown): value is GeoLibrePlugin {
+  if (!value || typeof value !== "object") return false;
+  const plugin = value as Partial<GeoLibrePlugin>;
+  return (
+    typeof plugin.id === "string" &&
+    typeof plugin.name === "string" &&
+    typeof plugin.version === "string" &&
+    typeof plugin.activate === "function" &&
+    typeof plugin.deactivate === "function"
+  );
+}
+
+function validateManifestMatchesPlugin(
+  manifest: GeoLibreExternalPluginManifest,
+  plugin: GeoLibrePlugin,
+): void {
+  if (plugin.id !== manifest.id) {
+    throw new Error("Exported plugin id does not match plugin.json.");
+  }
+  if (plugin.name !== manifest.name) {
+    throw new Error("Exported plugin name does not match plugin.json.");
+  }
+  if (plugin.version !== manifest.version) {
+    throw new Error("Exported plugin version does not match plugin.json.");
+  }
+}
+
+function injectExternalPluginStyle(
+  pluginId: string,
+  styleSource: string,
+): void {
+  const styleId = `geolibre-external-plugin-style:${pluginId}`;
+  if (document.getElementById(styleId)) return;
+
+  const style = document.createElement("style");
+  style.id = styleId;
+  style.dataset.geolibreExternalPlugin = pluginId;
+  style.textContent = styleSource;
+  document.head.append(style);
+}

--- a/apps/geolibre-desktop/src/lib/string-lists.ts
+++ b/apps/geolibre-desktop/src/lib/string-lists.ts
@@ -1,0 +1,21 @@
+// Shared helpers for the trimmed, deduplicated string lists used by the
+// plugin-source settings (directories and manifest URLs).
+
+export function normalizeStringList(values: unknown): string[] {
+  if (!Array.isArray(values)) return [];
+
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const value of values) {
+    if (typeof value !== "string") continue;
+    const normalizedValue = value.trim();
+    if (!normalizedValue || seen.has(normalizedValue)) continue;
+    seen.add(normalizedValue);
+    normalized.push(normalizedValue);
+  }
+  return normalized;
+}
+
+export function mergeStringLists(...lists: string[][]): string[] {
+  return normalizeStringList(lists.flat());
+}

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -165,6 +165,8 @@ External plugin entries are executed with `import(URL.createObjectURL(...))`, wh
 
 Manifest paths must be relative zip paths with forward slashes, no leading slash, no backslashes, and no `..` segments. External plugins cannot use `activeByDefault`; saved project state can still reactivate an external plugin by ID after the zip is loaded.
 
+The optional `style` CSS is injected globally into the host document, not scoped to the plugin. Plugin authors are responsible for scoping their selectors (for example with a plugin-specific class prefix) so broad rules do not restyle the rest of the app.
+
 When using the template, update `geolibre-plugin/plugin.json` and `src/geolibre.ts` together so `id`, `name`, and `version` stay in sync. Run `npm run package:geolibre`, then either copy the generated zip into the desktop app data `plugins/` directory, add the template's `geolibre-plugin/` directory in Settings > Plugins for local development, or host the `geolibre-plugin/` directory and add its `plugin.json` URL.
 
 ## Future plugin work

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -119,7 +119,7 @@ Plugins with serializable runtime settings can expose `getProjectState()` and `a
 
 ## External plugin zip files
 
-Use the [GeoLibre plugin template](https://github.com/giswqs/geolibre-plugin-template) as the recommended starting point for external plugin development. The template includes a MapLibre control wrapper, a `plugin.json` manifest, a GeoLibre plugin entry point, and a `package:geolibre` script that builds the zip layout GeoLibre Desktop expects.
+Use the [GeoLibre plugin template](https://github.com/opengeos/geolibre-plugin-template) as the recommended starting point for external plugin development. The template includes a MapLibre control wrapper, a `plugin.json` manifest, a GeoLibre plugin entry point, and a `package:geolibre` script that builds the zip layout GeoLibre Desktop expects.
 
 GeoLibre Desktop loads external plugins from the app data `plugins/` directory at startup. Browser builds keep built-in plugins only. External plugins are trusted local code and can be installed as either:
 

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -121,7 +121,12 @@ Plugins with serializable runtime settings can expose `getProjectState()` and `a
 
 Use the [GeoLibre plugin template](https://github.com/giswqs/geolibre-plugin-template) as the recommended starting point for external plugin development. The template includes a MapLibre control wrapper, a `plugin.json` manifest, a GeoLibre plugin entry point, and a `package:geolibre` script that builds the zip layout GeoLibre Desktop expects.
 
-GeoLibre Desktop loads external plugin zip files from the app data `plugins/` directory at startup. Browser builds keep built-in plugins only. Each zip is trusted local code and must contain a bundled ESM entry file plus a root `plugin.json` manifest.
+GeoLibre Desktop loads external plugins from the app data `plugins/` directory at startup. Browser builds keep built-in plugins only. External plugins are trusted local code and can be installed as either:
+
+- A `.zip` file with a root `plugin.json`.
+- An unpacked directory with a root `plugin.json`.
+
+The Plugins settings section can also add local development directories outside the app data folder. Each configured directory can contain plugin zips, unpacked plugin bundle folders, or be a single unpacked plugin bundle itself. Configured development directories are scanned before the app data `plugins/` directory, so a development copy can override an installed external plugin with the same ID. Built-in plugins still take precedence over all external plugins.
 
 ```json
 {
@@ -138,7 +143,7 @@ The `entry` file must export a `GeoLibrePlugin` as either the default export or 
 
 Manifest paths must be relative zip paths with forward slashes, no leading slash, no backslashes, and no `..` segments. External plugins cannot use `activeByDefault`; saved project state can still reactivate an external plugin by ID after the zip is loaded.
 
-When using the template, update `geolibre-plugin/plugin.json` and `src/geolibre.ts` together so `id`, `name`, and `version` stay in sync. Run `npm run package:geolibre`, then copy the generated zip into the desktop app data `plugins/` directory and restart GeoLibre.
+When using the template, update `geolibre-plugin/plugin.json` and `src/geolibre.ts` together so `id`, `name`, and `version` stay in sync. Run `npm run package:geolibre`, then either copy the generated zip into the desktop app data `plugins/` directory or add the template's `geolibre-plugin/` directory in Settings > Plugins for local development.
 
 ## Future plugin work
 

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -36,10 +36,7 @@ export interface GeoLibrePlugin {
     position: GeoLibreMapControlPosition,
   ) => boolean | void;
   getProjectState?: () => unknown;
-  applyProjectState?: (
-    app: GeoLibreAppAPI,
-    state: unknown,
-  ) => boolean | void;
+  applyProjectState?: (app: GeoLibreAppAPI, state: unknown) => boolean | void;
 }
 
 export interface GeoLibreAppAPI {
@@ -85,18 +82,18 @@ manager.activate("my-plugin", appApi);
 
 ## Built-in plugins
 
-| ID | Description |
-|----|-------------|
-| `osm-basemap` | OpenFreeMap Liberty style |
-| `carto-light` | CARTO Positron GL style |
-| `sample-geojson` | Loads `sample-data/sample.geojson` |
-| `maplibre-gl-basemap-control` | Adds a MapLibre basemap picker |
-| `maplibre-gl-components` | Adds the MapLibre Components control grid and panels for FlatGeobuf, COG, PMTiles, Zarr, LiDAR, and Gaussian splats |
-| `maplibre-gl-geo-editor` | Adds GeoEditor drawing controls |
-| `maplibre-gl-geoagent` | Adds GeoAgent map assistant controls |
-| `maplibre-gl-lidar` | Adds LiDAR controls |
-| `maplibre-gl-streetview` | Adds street view controls |
-| `maplibre-gl-swipe` | Adds map swipe controls |
+| ID                            | Description                                                                                                         |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `osm-basemap`                 | OpenFreeMap Liberty style                                                                                           |
+| `carto-light`                 | CARTO Positron GL style                                                                                             |
+| `sample-geojson`              | Loads `sample-data/sample.geojson`                                                                                  |
+| `maplibre-gl-basemap-control` | Adds a MapLibre basemap picker                                                                                      |
+| `maplibre-gl-components`      | Adds the MapLibre Components control grid and panels for FlatGeobuf, COG, PMTiles, Zarr, LiDAR, and Gaussian splats |
+| `maplibre-gl-geo-editor`      | Adds GeoEditor drawing controls                                                                                     |
+| `maplibre-gl-geoagent`        | Adds GeoAgent map assistant controls                                                                                |
+| `maplibre-gl-lidar`           | Adds LiDAR controls                                                                                                 |
+| `maplibre-gl-streetview`      | Adds street view controls                                                                                           |
+| `maplibre-gl-swipe`           | Adds map swipe controls                                                                                             |
 
 ## Example plugin
 
@@ -120,8 +117,29 @@ Map control plugins can optionally expose `getMapControlPosition()` and `setMapC
 
 Plugins with serializable runtime settings can expose `getProjectState()` and `applyProjectState()` so GeoLibre can save and restore those settings in the project file. A wrapper should use these hooks to adapt upstream control APIs such as `getState()` without requiring every upstream package to implement a GeoLibre-specific interface.
 
-## Roadmap (v0.7)
+## External plugin zip files
 
-- Dynamic plugin loading from a `plugins/` directory
-- Plugin manifest (`plugin.json`)
+Use the [GeoLibre plugin template](https://github.com/giswqs/geolibre-plugin-template) as the recommended starting point for external plugin development. The template includes a MapLibre control wrapper, a `plugin.json` manifest, a GeoLibre plugin entry point, and a `package:geolibre` script that builds the zip layout GeoLibre Desktop expects.
+
+GeoLibre Desktop loads external plugin zip files from the app data `plugins/` directory at startup. Browser builds keep built-in plugins only. Each zip is trusted local code and must contain a bundled ESM entry file plus a root `plugin.json` manifest.
+
+```json
+{
+  "id": "example-plugin",
+  "name": "Example Plugin",
+  "version": "0.1.0",
+  "entry": "dist/index.js",
+  "description": "Optional short description",
+  "style": "dist/style.css"
+}
+```
+
+The `entry` file must export a `GeoLibrePlugin` as either the default export or a named `plugin` export. The exported plugin `id`, `name`, and `version` must match `plugin.json`. The entry must be a self-contained `.js` or `.mjs` bundle because relative module imports inside the zip are not resolved by this first loader.
+
+Manifest paths must be relative zip paths with forward slashes, no leading slash, no backslashes, and no `..` segments. External plugins cannot use `activeByDefault`; saved project state can still reactivate an external plugin by ID after the zip is loaded.
+
+When using the template, update `geolibre-plugin/plugin.json` and `src/geolibre.ts` together so `id`, `name`, and `version` stay in sync. Run `npm run package:geolibre`, then copy the generated zip into the desktop app data `plugins/` directory and restart GeoLibre.
+
+## Future plugin work
+
 - Sandboxed worker plugins

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -146,7 +146,7 @@ Vite copies files from `public/` into the final web build, so the manifest URL b
 /plugins/example-plugin/plugin.json
 ```
 
-This works in both development and production web builds. The browser still cannot scan `/plugins/` at runtime, so each bundled plugin must be loaded by an explicit manifest URL, such as one entered in Settings > Plugins. For plugins that should always ship as part of GeoLibre without user configuration, prefer registering them as built-in plugins.
+This works in both development and production web builds. The browser still cannot scan `/plugins/` at runtime, so each bundled plugin must be loaded by an explicit manifest URL, such as one entered in Settings > Plugins. Manifest URLs are saved in the project `plugins.manifestUrls` array so reloading a shared project can fetch its external plugins before restoring active plugin state. For plugins that should always ship as part of GeoLibre without user configuration, prefer registering them as built-in plugins.
 
 ```json
 {

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -117,16 +117,36 @@ Map control plugins can optionally expose `getMapControlPosition()` and `setMapC
 
 Plugins with serializable runtime settings can expose `getProjectState()` and `applyProjectState()` so GeoLibre can save and restore those settings in the project file. A wrapper should use these hooks to adapt upstream control APIs such as `getState()` without requiring every upstream package to implement a GeoLibre-specific interface.
 
-## External plugin zip files
+## External plugins
 
 Use the [GeoLibre plugin template](https://github.com/opengeos/geolibre-plugin-template) as the recommended starting point for external plugin development. The template includes a MapLibre control wrapper, a `plugin.json` manifest, a GeoLibre plugin entry point, and a `package:geolibre` script that builds the zip layout GeoLibre Desktop expects.
 
-GeoLibre Desktop loads external plugins from the app data `plugins/` directory at startup. Browser builds keep built-in plugins only. External plugins are trusted local code and can be installed as either:
+GeoLibre Desktop loads external plugins from the app data `plugins/` directory at startup. External plugins are trusted code and can be installed as:
 
 - A `.zip` file with a root `plugin.json`.
 - An unpacked directory with a root `plugin.json`.
+- A HTTPS `plugin.json` manifest URL.
 
 The Plugins settings section can also add local development directories outside the app data folder. Each configured directory can contain plugin zips, unpacked plugin bundle folders, or be a single unpacked plugin bundle itself. Configured development directories are scanned before the app data `plugins/` directory, so a development copy can override an installed external plugin with the same ID. Built-in plugins still take precedence over all external plugins.
+
+For the web app, use manifest URLs. GeoLibre fetches the manifest, resolves `entry` and `style` relative to the manifest URL, then loads the bundled ESM entry. Browser loading requires HTTPS except for `localhost` and depends on the host allowing CORS.
+
+To include an external plugin folder in a GeoLibre web build, place the built plugin bundle under the Vite public directory:
+
+```text
+apps/geolibre-desktop/public/plugins/example-plugin/
+  plugin.json
+  dist/index.js
+  dist/style.css
+```
+
+Vite copies files from `public/` into the final web build, so the manifest URL becomes:
+
+```text
+/plugins/example-plugin/plugin.json
+```
+
+This works in both development and production web builds. The browser still cannot scan `/plugins/` at runtime, so each bundled plugin must be loaded by an explicit manifest URL, such as one entered in Settings > Plugins. For plugins that should always ship as part of GeoLibre without user configuration, prefer registering them as built-in plugins.
 
 ```json
 {
@@ -145,7 +165,7 @@ External plugin entries are executed with `import(URL.createObjectURL(...))`, wh
 
 Manifest paths must be relative zip paths with forward slashes, no leading slash, no backslashes, and no `..` segments. External plugins cannot use `activeByDefault`; saved project state can still reactivate an external plugin by ID after the zip is loaded.
 
-When using the template, update `geolibre-plugin/plugin.json` and `src/geolibre.ts` together so `id`, `name`, and `version` stay in sync. Run `npm run package:geolibre`, then either copy the generated zip into the desktop app data `plugins/` directory or add the template's `geolibre-plugin/` directory in Settings > Plugins for local development.
+When using the template, update `geolibre-plugin/plugin.json` and `src/geolibre.ts` together so `id`, `name`, and `version` stay in sync. Run `npm run package:geolibre`, then either copy the generated zip into the desktop app data `plugins/` directory, add the template's `geolibre-plugin/` directory in Settings > Plugins for local development, or host the `geolibre-plugin/` directory and add its `plugin.json` URL.
 
 ## Future plugin work
 

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -141,6 +141,8 @@ The Plugins settings section can also add local development directories outside 
 
 The `entry` file must export a `GeoLibrePlugin` as either the default export or a named `plugin` export. The exported plugin `id`, `name`, and `version` must match `plugin.json`. The entry must be a self-contained `.js` or `.mjs` bundle because relative module imports inside the zip are not resolved by this first loader.
 
+External plugin entries are executed with `import(URL.createObjectURL(...))`, which is why the desktop CSP in `tauri.conf.json` includes `blob:` in `script-src`. Removing `blob:` from `script-src` breaks external plugin loading. Combined with `'unsafe-eval'`, this means code that can create a blob URL can execute scripts, which is acceptable because external plugins are trusted local files installed by the user.
+
 Manifest paths must be relative zip paths with forward slashes, no leading slash, no backslashes, and no `..` segments. External plugins cannot use `activeByDefault`; saved project state can still reactivate an external plugin by ID after the zip is loaded.
 
 When using the template, update `geolibre-plugin/plugin.json` and `src/geolibre.ts` together so `id`, `name`, and `version` stay in sync. Run `npm run package:geolibre`, then either copy the generated zip into the desktop app data `plugins/` directory or add the template's `geolibre-plugin/` directory in Settings > Plugins for local development.

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -165,7 +165,7 @@ External plugin entries are executed with `import(URL.createObjectURL(...))`, wh
 
 Manifest paths must be relative zip paths with forward slashes, no leading slash, no backslashes, and no `..` segments. External plugins cannot use `activeByDefault`; saved project state can still reactivate an external plugin by ID after the zip is loaded.
 
-The optional `style` CSS is injected globally into the host document, not scoped to the plugin. Plugin authors are responsible for scoping their selectors (for example with a plugin-specific class prefix) so broad rules do not restyle the rest of the app.
+The optional `style` CSS is injected globally into the host document, not scoped to the plugin. Plugin authors are responsible for scoping their selectors (for example with a plugin-specific class prefix) so broad rules do not restyle the rest of the app. Injected CSS can also issue network requests through `url()` references and `@import`, so a plugin stylesheet can load external fonts, images, or additional sheets; treat plugin CSS with the same trust expectations as plugin code.
 
 When using the template, update `geolibre-plugin/plugin.json` and `src/geolibre.ts` together so `id`, `name`, and `version` stay in sync. Run `npm run package:geolibre`, then either copy the generated zip into the desktop app data `plugins/` directory, add the template's `geolibre-plugin/` directory in Settings > Plugins for local development, or host the `geolibre-plugin/` directory and add its `plugin.json` URL.
 

--- a/docs/project-format.md
+++ b/docs/project-format.md
@@ -4,23 +4,24 @@ Projects are saved as **`.geolibre.json`** files.
 
 ## Schema
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `version` | string | Format version (`0.1.0`) |
-| `name` | string | Project display name |
-| `mapView` | object | `center`, `zoom`, `bearing`, `pitch`, optional `bbox` |
-| `basemapStyleUrl` | string | MapLibre style JSON URL, or an empty string for a blank background |
-| `basemapVisible` | boolean | Whether the Background layer is visible |
-| `basemapOpacity` | number | Background layer opacity from `0` to `1` |
-| `layers` | array | Layer definitions (see below) |
-| `styles` | object | Map of layer id → `LayerStyle` |
-| `plugins` | object | Optional active plugin IDs, plugin map-control positions, and plugin settings |
-| `metadata` | object | Free-form project metadata |
+| Field             | Type    | Description                                                                                                  |
+| ----------------- | ------- | ------------------------------------------------------------------------------------------------------------ |
+| `version`         | string  | Format version (`0.1.0`)                                                                                     |
+| `name`            | string  | Project display name                                                                                         |
+| `mapView`         | object  | `center`, `zoom`, `bearing`, `pitch`, optional `bbox`                                                        |
+| `basemapStyleUrl` | string  | MapLibre style JSON URL, or an empty string for a blank background                                           |
+| `basemapVisible`  | boolean | Whether the Background layer is visible                                                                      |
+| `basemapOpacity`  | number  | Background layer opacity from `0` to `1`                                                                     |
+| `layers`          | array   | Layer definitions (see below)                                                                                |
+| `styles`          | object  | Map of layer id → `LayerStyle`                                                                               |
+| `plugins`         | object  | Optional external plugin manifest URLs, active plugin IDs, plugin map-control positions, and plugin settings |
+| `metadata`        | object  | Free-form project metadata                                                                                   |
 
 ## Plugin state
 
 ```json
 {
+  "manifestUrls": ["https://example.com/plugins/example-plugin/plugin.json"],
   "activePluginIds": ["maplibre-layer-control", "maplibre-gl-swipe"],
   "mapControlPositions": {
     "maplibre-layer-control": "top-right",
@@ -73,23 +74,23 @@ Projects without a `plugins` section open with the built-in default plugin state
 
 ## Layer types
 
-| Type | v0.7.0 status |
-|------|---------------|
-| `geojson` | Supported for imported files and GeoJSON URLs |
-| `xyz` | Supported for raster tile templates |
-| `wms` | Supported as tiled WMS GetMap layers |
-| `raster` | Supported for raster tile templates |
-| `vector-tiles` | Supported for MapLibre vector tile sources |
-| `mbtiles` | Supported in the desktop app through a local MapLibre protocol |
-| `arcgis` | Supported for ArcGIS FeatureServer and VectorTileServer layers |
-| `pmtiles` | Supported through the Components plugin |
-| `cog` | Supported for COG and GeoTIFF raster layers |
-| `flatgeobuf` | Supported through the Components plugin and imported as GeoJSON when loaded as a local vector file |
-| `zarr` | Supported through the Components plugin |
-| `lidar` | Supported through the Components plugin |
-| `gaussian-splat` | Supported through the Components plugin |
-| `geoparquet` | Imported as GeoJSON via DuckDB-WASM |
-| `duckdb-query` | Reserved for SQL query-result layers |
+| Type             | v0.7.0 status                                                                                      |
+| ---------------- | -------------------------------------------------------------------------------------------------- |
+| `geojson`        | Supported for imported files and GeoJSON URLs                                                      |
+| `xyz`            | Supported for raster tile templates                                                                |
+| `wms`            | Supported as tiled WMS GetMap layers                                                               |
+| `raster`         | Supported for raster tile templates                                                                |
+| `vector-tiles`   | Supported for MapLibre vector tile sources                                                         |
+| `mbtiles`        | Supported in the desktop app through a local MapLibre protocol                                     |
+| `arcgis`         | Supported for ArcGIS FeatureServer and VectorTileServer layers                                     |
+| `pmtiles`        | Supported through the Components plugin                                                            |
+| `cog`            | Supported for COG and GeoTIFF raster layers                                                        |
+| `flatgeobuf`     | Supported through the Components plugin and imported as GeoJSON when loaded as a local vector file |
+| `zarr`           | Supported through the Components plugin                                                            |
+| `lidar`          | Supported through the Components plugin                                                            |
+| `gaussian-splat` | Supported through the Components plugin                                                            |
+| `geoparquet`     | Imported as GeoJSON via DuckDB-WASM                                                                |
+| `duckdb-query`   | Reserved for SQL query-result layers                                                               |
 
 ## Example
 
@@ -98,5 +99,9 @@ See [`sample-data/example.geolibre.json`](https://github.com/opengeos/GeoLibre/b
 ## API
 
 ```typescript
-import { createEmptyProject, parseProject, serializeProject } from "@geolibre/core";
+import {
+  createEmptyProject,
+  parseProject,
+  serializeProject,
+} from "@geolibre/core";
 ```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -72,8 +72,8 @@
 
 - [ ] External plugin packages
 - [ ] Plugin marketplace / registry (design)
-- [ ] Dynamic plugin loading from a `plugins/` directory
-- [ ] Plugin manifest (`plugin.json`)
+- [x] Dynamic plugin loading from a `plugins/` directory
+- [x] Plugin manifest (`plugin.json`)
 - [ ] Sandboxed worker plugins
 
 ## v1.0: Stable prototype

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -177,7 +177,7 @@ function normalizeProjectPlugins(plugins: unknown): ProjectPluginState | null {
 
   const candidate = plugins as Partial<ProjectPluginState>;
   const manifestUrls = Array.isArray(candidate.manifestUrls)
-    ? uniqueStrings(candidate.manifestUrls)
+    ? uniqueStrings(candidate.manifestUrls).filter(isAllowedPluginManifestUrl)
     : [];
   const activePluginIds = Array.isArray(candidate.activePluginIds)
     ? uniqueStrings(candidate.activePluginIds)
@@ -223,6 +223,22 @@ function normalizeProjectPlugins(plugins: unknown): ProjectPluginState | null {
     mapControlPositions,
     settings,
   };
+}
+
+// Plugin manifest URLs lead to fetched and executed code, so both the
+// Settings dialog and project-file loading enforce the same scheme rule:
+// HTTPS, or HTTP on a loopback host for local development.
+export function isAllowedPluginManifestUrl(url: string): boolean {
+  try {
+    const { protocol, hostname } = new URL(url);
+    return (
+      protocol === "https:" ||
+      (protocol === "http:" &&
+        ["localhost", "127.0.0.1", "[::1]"].includes(hostname))
+    );
+  } catch {
+    return false;
+  }
 }
 
 function uniqueStrings(values: unknown[]): string[] {

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -69,9 +69,7 @@ export function parseProject(json: string): GeoLibreProject {
   };
 }
 
-function normalizeProjectPreferences(
-  preferences: unknown,
-): ProjectPreferences {
+function normalizeProjectPreferences(preferences: unknown): ProjectPreferences {
   if (!preferences || typeof preferences !== "object") {
     return DEFAULT_PROJECT_PREFERENCES;
   }
@@ -117,9 +115,7 @@ function normalizeProjectPreferences(
   };
 }
 
-function normalizeBounds(
-  bounds: unknown,
-): ProjectPreferences["map"]["bounds"] {
+function normalizeBounds(bounds: unknown): ProjectPreferences["map"]["bounds"] {
   if (
     Array.isArray(bounds) &&
     bounds.length === 4 &&
@@ -176,12 +172,13 @@ const PROJECT_PLUGIN_CONTROL_POSITIONS = new Set<ProjectPluginControlPosition>([
   "bottom-right",
 ]);
 
-function normalizeProjectPlugins(
-  plugins: unknown,
-): ProjectPluginState | null {
+function normalizeProjectPlugins(plugins: unknown): ProjectPluginState | null {
   if (!plugins || typeof plugins !== "object") return null;
 
   const candidate = plugins as Partial<ProjectPluginState>;
+  const manifestUrls = Array.isArray(candidate.manifestUrls)
+    ? uniqueStrings(candidate.manifestUrls)
+    : [];
   const activePluginIds = Array.isArray(candidate.activePluginIds)
     ? uniqueStrings(candidate.activePluginIds)
     : [];
@@ -221,6 +218,7 @@ function normalizeProjectPlugins(
   }
 
   return {
+    manifestUrls,
     activePluginIds,
     mapControlPositions,
     settings,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -203,6 +203,7 @@ export type ProjectPluginControlPosition =
   | "bottom-right";
 
 export interface ProjectPluginState {
+  manifestUrls: string[];
   activePluginIds: string[];
   mapControlPositions: Record<string, ProjectPluginControlPosition>;
   settings: Record<string, unknown>;

--- a/packages/plugins/src/plugin-manager.ts
+++ b/packages/plugins/src/plugin-manager.ts
@@ -59,6 +59,9 @@ export class PluginManager {
     }
 
     return {
+      // The manager does not track external plugin sources; callers that
+      // persist project state must overwrite manifestUrls with the real list
+      // (see TopToolbar.handleSave and persistProjectPluginState).
       manifestUrls: [],
       activePluginIds: Array.from(this.plugins.keys()).filter((id) =>
         this.active.has(id),

--- a/packages/plugins/src/plugin-manager.ts
+++ b/packages/plugins/src/plugin-manager.ts
@@ -59,6 +59,7 @@ export class PluginManager {
     }
 
     return {
+      manifestUrls: [],
       activePluginIds: Array.from(this.plugins.keys()).filter((id) =>
         this.active.has(id),
       ),
@@ -67,9 +68,7 @@ export class PluginManager {
     };
   }
 
-  getMapControlPosition(
-    id: string,
-  ): GeoLibreMapControlPosition | undefined {
+  getMapControlPosition(id: string): GeoLibreMapControlPosition | undefined {
     return this.plugins.get(id)?.getMapControlPosition?.();
   }
 

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -61,8 +61,14 @@ export interface GeoLibrePlugin {
     position: GeoLibreMapControlPosition,
   ) => boolean | void;
   getProjectState?: () => unknown;
-  applyProjectState?: (
-    app: GeoLibreAppAPI,
-    state: unknown,
-  ) => boolean | void;
+  applyProjectState?: (app: GeoLibreAppAPI, state: unknown) => boolean | void;
+}
+
+export interface GeoLibreExternalPluginManifest {
+  id: string;
+  name: string;
+  version: string;
+  entry: string;
+  description?: string;
+  style?: string;
 }


### PR DESCRIPTION
## Summary
- GeoLibre Desktop now scans the app data `plugins/` directory at startup, validates each zip's `plugin.json` manifest in Rust, and loads the bundled ESM entry (plus optional CSS) as a plugin.
- Project state restoration in `DesktopShell` waits for external plugins to finish loading so saved project state can reactivate external plugins by ID.
- Documents the external plugin zip contract in `docs/plugin-api.md`, links the plugin template from the README, and checks off dynamic plugin loading and `plugin.json` manifest items on the roadmap.

## Test plan
- [ ] `cargo check` passes for the Tauri backend
- [ ] `npm run build` passes via pre-commit
- [ ] Package a plugin zip with the template, copy it into the app data `plugins/` directory, restart GeoLibre Desktop, and confirm the plugin appears in the Plugins menu
- [ ] Confirm a zip with an invalid manifest is skipped with a console warning instead of breaking startup
- [ ] Confirm browser build still loads built-in plugins only