### PR TITLE
fix: address follow-up review feedback on external plugin loading

### DIFF
--- a/apps/geolibre-desktop/src/App.tsx
+++ b/apps/geolibre-desktop/src/App.tsx
@@ -1,7 +1,6 @@
 import { DesktopShell } from "./components/layout/DesktopShell";
 import { useDesktopSettingsPersistence } from "./hooks/useDesktopSettings";
 import { useLayoutOptions } from "./hooks/useLayoutOptions";
-import { useExternalPluginsReady } from "./hooks/usePlugins";
 import { useProjectUrlLoader } from "./hooks/useProjectUrlLoader";
 import { useRecentProjectsPersistence } from "./hooks/useRecentProjectsPersistence";
 import { useRuntimeEnvironmentVariables } from "./hooks/useRuntimeEnvironmentVariables";
@@ -13,9 +12,6 @@ export default function App() {
   const projectUrlLoadState = useProjectUrlLoader();
 
   useDesktopSettingsPersistence();
-  // Triggers the external plugin scan; the readiness flag is consumed in
-  // DesktopShell to gate project plugin state restoration.
-  useExternalPluginsReady();
   useRecentProjectsPersistence();
   useRuntimeEnvironmentVariables();
   return (

--- a/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
+++ b/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
@@ -1,3 +1,4 @@
+import { isAllowedPluginManifestUrl } from "@geolibre/core";
 import { useEffect } from "react";
 import { create } from "zustand";
 import { normalizeStringList } from "../lib/string-lists";
@@ -29,7 +30,11 @@ function normalizeDesktopSettings(settings: unknown): DesktopSettings {
     additionalPluginDirectories: normalizeStringList(
       candidate.additionalPluginDirectories,
     ),
-    pluginManifestUrls: normalizeStringList(candidate.pluginManifestUrls),
+    // Apply the same scheme rule as project-file loading so stale or edited
+    // localStorage values cannot smuggle in disallowed URL schemes.
+    pluginManifestUrls: normalizeStringList(candidate.pluginManifestUrls).filter(
+      isAllowedPluginManifestUrl,
+    ),
   };
 }
 

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -61,7 +61,7 @@ export function usePluginRegistry() {
     getMapControlPosition: (id: string) => manager.getMapControlPosition(id),
     getProjectState: () => manager.getProjectState(),
     toggle: (id: string, appApi: ReturnType<typeof createAppAPI>) => {
-      const before = JSON.stringify(manager.getProjectState());
+      const before = JSON.stringify(projectPluginStateSnapshot());
       manager.toggle(id, appApi);
       persistProjectPluginState(before);
     },
@@ -70,7 +70,7 @@ export function usePluginRegistry() {
       appApi: ReturnType<typeof createAppAPI>,
       position: GeoLibreMapControlPosition,
     ) => {
-      const before = JSON.stringify(manager.getProjectState());
+      const before = JSON.stringify(projectPluginStateSnapshot());
       manager.setMapControlPosition(id, appApi, position);
       persistProjectPluginState(before);
     },
@@ -311,13 +311,20 @@ function normalizeBytes(bytes: number[] | Uint8Array): ArrayBuffer {
   return copy.buffer;
 }
 
-function persistProjectPluginState(previousJson: string): void {
-  const nextState = {
+// The manager's getProjectState always returns an empty manifestUrls list,
+// so the before/after snapshots both graft on the store's real list to keep
+// the no-change comparison meaningful.
+function projectPluginStateSnapshot() {
+  return {
     ...manager.getProjectState(),
     manifestUrls:
       useAppStore.getState().projectPlugins?.manifestUrls ??
       EMPTY_PLUGIN_MANIFEST_URLS,
   };
+}
+
+function persistProjectPluginState(previousJson: string): void {
+  const nextState = projectPluginStateSnapshot();
   if (JSON.stringify(nextState) === previousJson) return;
   useAppStore.getState().setProjectPlugins(nextState);
 }

--- a/apps/geolibre-desktop/src/lib/external-plugins.ts
+++ b/apps/geolibre-desktop/src/lib/external-plugins.ts
@@ -48,20 +48,25 @@ export async function loadExternalPlugins(
   additionalPluginDirectories: string[] = [],
   pluginManifestUrls: string[] = [],
 ): Promise<ExternalPluginLoadResult> {
-  const filesystemResult = isTauri()
-    ? await loadFilesystemPluginBundles(additionalPluginDirectories)
-    : {
-        pluginsDirectories: [],
-        bundles: [],
-        errors: [],
-      };
-  const issues: ExternalPluginLoadIssue[] = filesystemResult.errors.map(
-    (error) => ({
+  const issues: ExternalPluginLoadIssue[] = [];
+  // The filesystem scan (Tauri IPC + disk) and the manifest URL fetches
+  // (network) are independent, so overlap them.
+  const [filesystemResult, urlBundles] = await Promise.all([
+    isTauri()
+      ? loadFilesystemPluginBundles(additionalPluginDirectories)
+      : Promise.resolve<ExternalPluginBundleLoadResult>({
+          pluginsDirectories: [],
+          bundles: [],
+          errors: [],
+        }),
+    loadPluginUrlBundles(pluginManifestUrls, issues),
+  ]);
+  for (const error of filesystemResult.errors) {
+    issues.push({
       archiveName: error.archiveName,
       message: error.message,
-    }),
-  );
-  const urlBundles = await loadPluginUrlBundles(pluginManifestUrls, issues);
+    });
+  }
   const loadedPluginIds: string[] = [];
   const registeredPluginIds = new Set(
     manager.list().map((plugin) => plugin.id),
@@ -175,13 +180,15 @@ async function loadPluginUrlBundle(
   }
 
   const entryUrl = resolvePluginAssetUrl(manifestUrl, manifest.entry);
-  const entrySource = await fetchPluginText(entryUrl, "plugin entry");
-  const styleSource = manifest.style
-    ? await fetchPluginText(
-        resolvePluginAssetUrl(manifestUrl, manifest.style),
-        "plugin style",
-      )
+  const styleUrl = manifest.style
+    ? resolvePluginAssetUrl(manifestUrl, manifest.style)
     : null;
+  const [entrySource, styleSource] = await Promise.all([
+    fetchPluginText(entryUrl, "plugin entry"),
+    styleUrl
+      ? fetchPluginText(styleUrl, "plugin style")
+      : Promise.resolve(null),
+  ]);
 
   return {
     archiveName: manifestUrl,
@@ -203,11 +210,8 @@ async function fetchPluginText(url: string, label: string): Promise<string> {
 
   // Fast-fail when the server declares the size; the streaming reader below
   // is the real enforcement for responses without a content-length header.
-  const contentLengthHeader = response.headers.get("content-length");
-  if (
-    contentLengthHeader !== null &&
-    Number(contentLengthHeader) > MAX_PLUGIN_ASSET_BYTES
-  ) {
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_PLUGIN_ASSET_BYTES) {
     throw new Error(`Could not fetch ${label}: exceeds the 50 MB size limit.`);
   }
 

--- a/apps/geolibre-desktop/src/lib/string-lists.ts
+++ b/apps/geolibre-desktop/src/lib/string-lists.ts
@@ -1,5 +1,7 @@
 // Shared helpers for the trimmed, deduplicated string lists used by the
-// plugin-source settings (directories and manifest URLs).
+// plugin-source settings (directories and manifest URLs). normalizeStringList
+// intentionally mirrors uniqueStrings in packages/core/src/project.ts, which
+// stays private to core's project parsing; update both if the rules change.
 
 export function normalizeStringList(values: unknown): string[] {
   if (!Array.isArray(values)) return [];


### PR DESCRIPTION
## Summary

Addresses the final round of Claude review comments on #116, which was merged while the round was in flight.

- Compare plugin-state snapshots that include the real manifest URLs on both sides so `persistProjectPluginState`'s no-change guard works again (previously `setProjectPlugins` fired on every plugin toggle whenever a project had manifest URLs)
- Filter localStorage plugin manifest URLs through `isAllowedPluginManifestUrl`, matching the project-file loading path
- Overlap the filesystem plugin scan with manifest URL fetches, and fetch a plugin's entry and style files concurrently
- Remove the redundant `useExternalPluginsReady` call in `App`; `DesktopShell` is the consumer and already triggers the scan
- Guard the content-length fast-fail with `Number.isFinite` and note that `normalizeStringList` intentionally mirrors core's private `uniqueStrings`