### PR TITLE
feat: add 3D Tiles layer support via maplibre-gl-3d-tiles

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -36,6 +36,7 @@
     "jspdf": "^2.5.2",
     "mapillary-js": "^4.1.2",
     "maplibre-gl": "^5.24.0",
+    "maplibre-gl-3d-tiles": "^0.3.0",
     "maplibre-gl-basemap-control": "^0.2.1",
     "maplibre-gl-components": "^0.17.4",
     "maplibre-gl-duckdb": "^0.2.0",

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -20,6 +20,7 @@ import {
   openSearchPlacesPanel,
   openSplattingLayerPanel,
   openStacSearchLayerPanel,
+  openThreeDTilesLayerPanel,
   openZarrLayerPanel,
   subscribeSearchPlacesPanel,
   type GeoLibreMapControlPosition,
@@ -361,6 +362,9 @@ export function TopToolbar({
   const handleAddSplattingLayer = () => {
     openSplattingLayerPanel(appApi);
   };
+  const handleAddThreeDTilesLayer = () => {
+    openThreeDTilesLayerPanel(appApi);
+  };
   const toggleMapControl = (control: ToolbarMapControl) => {
     setControlsVisible((current) => {
       const visible = !current[control];
@@ -541,6 +545,9 @@ export function TopToolbar({
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={handleAddSplattingLayer}>
             Add Splatting Layer
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={handleAddThreeDTilesLayer}>
+            Add 3D Tiles Layer
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={handleAddStacLayer}>
             Add STAC Layer

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1077,7 +1077,9 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
     layer.metadata.sourceKind === "stac-search-cog";
   const isDeckVectorLayer = hasExternalDeckLayer(layer);
   const isRasterTileLayer = layer.metadata.tileType === "raster";
+  const isThreeDTilesLayer = layer.type === "3d-tiles";
   const hasVectorPaintControls =
+    !isThreeDTilesLayer &&
     !isRasterTileLayer &&
     (layer.type === "geojson" ||
       layer.type === "vector-tiles" ||
@@ -1085,7 +1087,9 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
       hasExternalNativeLayers(layer) ||
       hasExternalDeckLayer(layer));
   const hasExtrusionControls =
-    !isRasterTileLayer && supportsExtrusionControls(layer);
+    !isThreeDTilesLayer &&
+    !isRasterTileLayer &&
+    supportsExtrusionControls(layer);
   const hasRasterPaintControls =
     isRasterPaintLayer(layer.type) || isRasterTileLayer;
   const extrusionEnabled = styleValue(style, "extrusionEnabled");

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1280,6 +1280,7 @@ body,
 }
 
 .geolibre-3d-tiles-panel {
+  --geolibre-3d-tiles-status-success: #0f9f6e;
   background: hsl(var(--popover)) !important;
   border: 1px solid hsl(var(--border)) !important;
   box-shadow:
@@ -1333,29 +1334,32 @@ body,
 }
 
 .geolibre-3d-tiles-panel .three-d-tiles-input:focus {
-  border-color: #2f8f85 !important;
-  box-shadow: 0 0 0 2px rgba(47, 143, 133, 0.16) !important;
+  border-color: hsl(var(--ring)) !important;
+  box-shadow: 0 0 0 2px hsl(var(--ring) / 0.16) !important;
 }
 
 .geolibre-3d-tiles-panel .three-d-tiles-checkbox input,
 .geolibre-3d-tiles-panel .three-d-tiles-list-actions input[type="checkbox"],
 .geolibre-3d-tiles-panel .three-d-tiles-opacity {
-  accent-color: #2f8f85;
+  accent-color: hsl(var(--primary));
 }
 
-.geolibre-3d-tiles-panel .three-d-tiles-button {
+.geolibre-3d-tiles-panel .three-d-tiles-button,
+.geolibre-3d-tiles-panel .three-d-tiles-small-button {
   background: hsl(var(--secondary)) !important;
   border-color: hsl(var(--border)) !important;
   color: hsl(var(--secondary-foreground)) !important;
 }
 
-.geolibre-3d-tiles-panel .three-d-tiles-button:hover:not(:disabled) {
+.geolibre-3d-tiles-panel .three-d-tiles-button:hover:not(:disabled),
+.geolibre-3d-tiles-panel .three-d-tiles-small-button:hover:not(:disabled) {
   background: hsl(var(--accent)) !important;
   border-color: hsl(var(--border)) !important;
   color: hsl(var(--accent-foreground)) !important;
 }
 
-.geolibre-3d-tiles-panel .three-d-tiles-button:disabled {
+.geolibre-3d-tiles-panel .three-d-tiles-button:disabled,
+.geolibre-3d-tiles-panel .three-d-tiles-small-button:disabled {
   background: hsl(var(--muted)) !important;
   border-color: hsl(var(--border)) !important;
   color: hsl(var(--muted-foreground)) !important;
@@ -1364,25 +1368,6 @@ body,
 
 .geolibre-3d-tiles-panel .three-d-tiles-opacity {
   width: 58px;
-}
-
-.geolibre-3d-tiles-panel .three-d-tiles-small-button {
-  background: hsl(var(--secondary)) !important;
-  border-color: hsl(var(--border)) !important;
-  color: hsl(var(--secondary-foreground)) !important;
-}
-
-.geolibre-3d-tiles-panel .three-d-tiles-small-button:hover:not(:disabled) {
-  background: hsl(var(--accent)) !important;
-  border-color: hsl(var(--border)) !important;
-  color: hsl(var(--accent-foreground)) !important;
-}
-
-.geolibre-3d-tiles-panel .three-d-tiles-small-button:disabled {
-  background: hsl(var(--muted)) !important;
-  border-color: hsl(var(--border)) !important;
-  color: hsl(var(--muted-foreground)) !important;
-  opacity: 0.75;
 }
 
 .geolibre-3d-tiles-panel .three-d-tiles-list-actions {
@@ -1396,17 +1381,17 @@ body,
 
 .geolibre-3d-tiles-panel .three-d-tiles-list-item.active {
   background: hsl(var(--accent)) !important;
-  border-color: #2f8f85 !important;
+  border-color: hsl(var(--ring)) !important;
 }
 
 .geolibre-3d-tiles-panel .three-d-tiles-status[data-status="loaded"],
 .geolibre-3d-tiles-panel .three-d-tiles-list-status[data-status="loaded"] {
-  color: #0f9f6e !important;
+  color: var(--geolibre-3d-tiles-status-success) !important;
 }
 
 .geolibre-3d-tiles-panel .three-d-tiles-status[data-status="error"],
 .geolibre-3d-tiles-panel .three-d-tiles-list-status[data-status="error"] {
-  color: #ef4444 !important;
+  color: hsl(var(--destructive)) !important;
 }
 
 .geolibre-components-control input:not([type="checkbox"]):not([type="radio"]):not(

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -264,8 +264,14 @@ body,
   border: 1px solid hsl(var(--border));
   box-sizing: border-box;
   color: hsl(var(--popover-foreground)) !important;
+  --geolibre-geoparquet-panel-left: 10px;
+  left: var(--geolibre-geoparquet-panel-left) !important;
   max-height: min(620px, calc(100% - 20px));
-  max-width: min(365px, calc(100vw - 32px));
+  max-width: min(
+    365px,
+    calc(100vw - var(--geolibre-geoparquet-panel-left) - 22px)
+  );
+  top: 10px !important;
 }
 
 .geoparquet-control-content {
@@ -1258,6 +1264,149 @@ body,
   justify-content: center !important;
   line-height: 1 !important;
   min-height: 30px;
+}
+
+.geolibre-3d-tiles-control {
+  background: hsl(var(--popover)) !important;
+  color: hsl(var(--popover-foreground)) !important;
+}
+
+.geolibre-3d-tiles-control .three-d-tiles-control-toggle {
+  color: hsl(var(--popover-foreground)) !important;
+}
+
+.geolibre-3d-tiles-control .three-d-tiles-control-toggle:hover {
+  background-color: hsl(var(--accent)) !important;
+}
+
+.geolibre-3d-tiles-panel {
+  background: hsl(var(--popover)) !important;
+  border: 1px solid hsl(var(--border)) !important;
+  box-shadow:
+    0 10px 15px -3px rgb(0 0 0 / 0.18),
+    0 4px 6px -4px rgb(0 0 0 / 0.18) !important;
+  color: hsl(var(--popover-foreground)) !important;
+  color-scheme: light dark;
+}
+
+.geolibre-3d-tiles-panel .three-d-tiles-control-header {
+  border-bottom-color: hsl(var(--border)) !important;
+  color: hsl(var(--popover-foreground)) !important;
+}
+
+.geolibre-3d-tiles-panel .three-d-tiles-control-close,
+.geolibre-3d-tiles-panel .three-d-tiles-empty,
+.geolibre-3d-tiles-panel .three-d-tiles-list-status,
+.geolibre-3d-tiles-panel .three-d-tiles-list-url,
+.geolibre-3d-tiles-panel .three-d-tiles-status {
+  color: hsl(var(--muted-foreground)) !important;
+}
+
+.geolibre-3d-tiles-panel .three-d-tiles-control-close:hover {
+  color: hsl(var(--popover-foreground)) !important;
+}
+
+.geolibre-3d-tiles-panel .three-d-tiles-field,
+.geolibre-3d-tiles-panel .three-d-tiles-checkbox,
+.geolibre-3d-tiles-panel .three-d-tiles-list-title {
+  color: hsl(var(--popover-foreground)) !important;
+}
+
+.geolibre-3d-tiles-panel .three-d-tiles-input {
+  background: hsl(var(--background)) !important;
+  border-color: hsl(var(--input)) !important;
+  color: hsl(var(--foreground)) !important;
+}
+
+.geolibre-3d-tiles-panel .three-d-tiles-input[type="number"] {
+  min-height: 36px;
+  padding-right: 4px;
+}
+
+.geolibre-3d-tiles-panel
+  .three-d-tiles-input[type="number"]::-webkit-inner-spin-button,
+.geolibre-3d-tiles-panel
+  .three-d-tiles-input[type="number"]::-webkit-outer-spin-button {
+  min-height: 30px;
+  opacity: 1;
+  width: 22px;
+}
+
+.geolibre-3d-tiles-panel .three-d-tiles-input:focus {
+  border-color: #2f8f85 !important;
+  box-shadow: 0 0 0 2px rgba(47, 143, 133, 0.16) !important;
+}
+
+.geolibre-3d-tiles-panel .three-d-tiles-checkbox input,
+.geolibre-3d-tiles-panel .three-d-tiles-list-actions input[type="checkbox"],
+.geolibre-3d-tiles-panel .three-d-tiles-opacity {
+  accent-color: #2f8f85;
+}
+
+.geolibre-3d-tiles-panel .three-d-tiles-button {
+  background: hsl(var(--secondary)) !important;
+  border-color: hsl(var(--border)) !important;
+  color: hsl(var(--secondary-foreground)) !important;
+}
+
+.geolibre-3d-tiles-panel .three-d-tiles-button:hover:not(:disabled) {
+  background: hsl(var(--accent)) !important;
+  border-color: hsl(var(--border)) !important;
+  color: hsl(var(--accent-foreground)) !important;
+}
+
+.geolibre-3d-tiles-panel .three-d-tiles-button:disabled {
+  background: hsl(var(--muted)) !important;
+  border-color: hsl(var(--border)) !important;
+  color: hsl(var(--muted-foreground)) !important;
+  opacity: 0.75;
+}
+
+.geolibre-3d-tiles-panel .three-d-tiles-opacity {
+  width: 58px;
+}
+
+.geolibre-3d-tiles-panel .three-d-tiles-small-button {
+  background: hsl(var(--secondary)) !important;
+  border-color: hsl(var(--border)) !important;
+  color: hsl(var(--secondary-foreground)) !important;
+}
+
+.geolibre-3d-tiles-panel .three-d-tiles-small-button:hover:not(:disabled) {
+  background: hsl(var(--accent)) !important;
+  border-color: hsl(var(--border)) !important;
+  color: hsl(var(--accent-foreground)) !important;
+}
+
+.geolibre-3d-tiles-panel .three-d-tiles-small-button:disabled {
+  background: hsl(var(--muted)) !important;
+  border-color: hsl(var(--border)) !important;
+  color: hsl(var(--muted-foreground)) !important;
+  opacity: 0.75;
+}
+
+.geolibre-3d-tiles-panel .three-d-tiles-list-actions {
+  color: hsl(var(--popover-foreground)) !important;
+}
+
+.geolibre-3d-tiles-panel .three-d-tiles-status,
+.geolibre-3d-tiles-panel .three-d-tiles-list-item {
+  border-color: hsl(var(--border)) !important;
+}
+
+.geolibre-3d-tiles-panel .three-d-tiles-list-item.active {
+  background: hsl(var(--accent)) !important;
+  border-color: #2f8f85 !important;
+}
+
+.geolibre-3d-tiles-panel .three-d-tiles-status[data-status="loaded"],
+.geolibre-3d-tiles-panel .three-d-tiles-list-status[data-status="loaded"] {
+  color: #0f9f6e !important;
+}
+
+.geolibre-3d-tiles-panel .three-d-tiles-status[data-status="error"],
+.geolibre-3d-tiles-panel .three-d-tiles-list-status[data-status="error"] {
+  color: #ef4444 !important;
 }
 
 .geolibre-components-control input:not([type="checkbox"]):not([type="radio"]):not(

--- a/apps/geolibre-desktop/src/main.tsx
+++ b/apps/geolibre-desktop/src/main.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "@geoman-io/maplibre-geoman-free/dist/maplibre-geoman.css";
+import "maplibre-gl-3d-tiles/style.css";
 import "maplibre-gl-basemap-control/style.css";
 import "maplibre-gl-components/style.css";
 import "maplibre-gl-duckdb/style.css";

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "jspdf": "^2.5.2",
         "mapillary-js": "^4.1.2",
         "maplibre-gl": "^5.24.0",
+        "maplibre-gl-3d-tiles": "^0.3.0",
         "maplibre-gl-basemap-control": "^0.2.1",
         "maplibre-gl-components": "^0.17.4",
         "maplibre-gl-duckdb": "^0.2.0",
@@ -9570,6 +9571,81 @@
         "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
       }
     },
+    "node_modules/maplibre-gl-3d-tiles": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-3d-tiles/-/maplibre-gl-3d-tiles-0.3.0.tgz",
+      "integrity": "sha512-u/M+L2uywpSfBjGKpbnSSITchqbFGJAOT61iZfozsbBbZuBYPRUvOIzRXpVZLJMPERe++TvDjab4J3hVteg1MQ==",
+      "license": "MIT",
+      "dependencies": {
+        "3d-tiles-renderer": "^0.4.27",
+        "three": "^0.184.0"
+      },
+      "peerDependencies": {
+        "maplibre-gl": ">=3.0.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/maplibre-gl-3d-tiles/node_modules/3d-tiles-renderer": {
+      "version": "0.4.27",
+      "resolved": "https://registry.npmjs.org/3d-tiles-renderer/-/3d-tiles-renderer-0.4.27.tgz",
+      "integrity": "sha512-6LjbyYvwyJSfHSuX4t3rvZh6LW67LNmXzIY83zrEPYQv1nra2UQ9rV/ibYlj7OAO1Fy49WYX7gp5RyaJNSzdAA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@babylonjs/core": ">=8.0.0",
+        "@babylonjs/loaders": ">=8.0.0",
+        "@mapbox/vector-tile": "^2.0.3",
+        "@react-three/fiber": "^8.17.9 || ^9.0.0",
+        "pbf": "^4.0.1",
+        "pmtiles": "^4.3.2",
+        "react": "^18.3.1 || ^19.0.0",
+        "react-dom": "^18.3.1 || ^19.0.0",
+        "three": ">=0.167.0"
+      },
+      "peerDependenciesMeta": {
+        "@babylonjs/core": {
+          "optional": true
+        },
+        "@babylonjs/loaders": {
+          "optional": true
+        },
+        "@mapbox/vector-tile": {
+          "optional": true
+        },
+        "@react-three/fiber": {
+          "optional": true
+        },
+        "pbf": {
+          "optional": true
+        },
+        "pmtiles": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "three": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/maplibre-gl-3d-tiles/node_modules/three": {
+      "version": "0.184.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
+      "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
+      "license": "MIT"
+    },
     "node_modules/maplibre-gl-basemap-control": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/maplibre-gl-basemap-control/-/maplibre-gl-basemap-control-0.2.1.tgz",
@@ -12600,6 +12676,7 @@
         "geotiff": "^3.0.5",
         "jspdf": "^2.5.2",
         "maplibre-gl": "^5.24.0",
+        "maplibre-gl-3d-tiles": "^0.3.0",
         "maplibre-gl-basemap-control": "^0.2.1",
         "maplibre-gl-components": "^0.17.4",
         "maplibre-gl-duckdb": "^0.2.0",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -52,6 +52,7 @@ export type LayerType =
   | "zarr"
   | "lidar"
   | "gaussian-splat"
+  | "3d-tiles"
   | "cog"
   | "flatgeobuf"
   | "geoparquet"

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -128,6 +128,13 @@ function syncExternalNativeLayer(
     ensurePMTilesExternalLayer(map, layer, nativeLayerIds, beforeId);
   }
 
+  if (isExternalCustomLayer(map, nativeLayerIds)) {
+    for (const nativeLayerId of nativeLayerIds) {
+      moveLayer(map, nativeLayerId, beforeId);
+    }
+    return;
+  }
+
   if (isWaybackExternalRasterLayer(layer)) {
     syncWaybackExternalRasterLayer(map, layer, nativeLayerIds, beforeId);
     return;
@@ -203,6 +210,15 @@ function isPMTilesExternalLayer(layer: GeoLibreLayer): boolean {
     layer.type === "pmtiles" &&
     layer.metadata.sourceKind === "pmtiles-url" &&
     layer.metadata.externalNativeLayer === true
+  );
+}
+
+function isExternalCustomLayer(
+  map: maplibregl.Map,
+  nativeLayerIds: string[],
+): boolean {
+  return nativeLayerIds.some(
+    (nativeLayerId) => map.getLayer(nativeLayerId)?.type === "custom",
   );
 }
 

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -128,7 +128,11 @@ function syncExternalNativeLayer(
     ensurePMTilesExternalLayer(map, layer, nativeLayerIds, beforeId);
   }
 
-  if (isExternalCustomLayer(map, nativeLayerIds)) {
+  // Custom render layers (e.g. 3D Tiles) manage their own visibility, opacity,
+  // and zoom behavior through the control that registered them, so the standard
+  // visibility/paint/zoom-range sync below must be skipped — only ordering is
+  // handled here.
+  if (isExternalCustomLayer(layer)) {
     for (const nativeLayerId of nativeLayerIds) {
       moveLayer(map, nativeLayerId, beforeId);
     }
@@ -213,13 +217,8 @@ function isPMTilesExternalLayer(layer: GeoLibreLayer): boolean {
   );
 }
 
-function isExternalCustomLayer(
-  map: maplibregl.Map,
-  nativeLayerIds: string[],
-): boolean {
-  return nativeLayerIds.some(
-    (nativeLayerId) => map.getLayer(nativeLayerId)?.type === "custom",
-  );
+function isExternalCustomLayer(layer: GeoLibreLayer): boolean {
+  return typeof layer.metadata.customLayerType === "string";
 }
 
 function ensurePMTilesExternalLayer(

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -570,6 +570,23 @@ export class MapController {
   }
 
   fitLayer(layer: GeoLibreLayer): void {
+    if (layer.type === "3d-tiles" && this.map) {
+      const center = layer.metadata.center;
+      if (
+        Array.isArray(center) &&
+        typeof center[0] === "number" &&
+        typeof center[1] === "number"
+      ) {
+        this.map.flyTo({
+          center: [center[0], center[1]],
+          duration: 800,
+          pitch: Math.max(this.map.getPitch(), 60),
+          zoom: Math.max(this.map.getZoom(), 18),
+        });
+        return;
+      }
+    }
+
     const bounds =
       getLayerBounds(layer) ??
       this.getLayerMetadataBounds(layer) ??

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -577,11 +577,14 @@ export class MapController {
         typeof center[0] === "number" &&
         typeof center[1] === "number"
       ) {
+        // Tilesets only expose their center, not a native zoom range. Use a
+        // conservative floor so city-scale tilesets that render below zoom 18
+        // are not flown past into an empty viewport.
         this.map.flyTo({
           center: [center[0], center[1]],
           duration: 800,
           pitch: Math.max(this.map.getPitch(), 60),
-          zoom: Math.max(this.map.getZoom(), 18),
+          zoom: Math.max(this.map.getZoom(), 14),
         });
         return;
       }

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -575,7 +575,9 @@ export class MapController {
       if (
         Array.isArray(center) &&
         typeof center[0] === "number" &&
-        typeof center[1] === "number"
+        typeof center[1] === "number" &&
+        Number.isFinite(center[0]) &&
+        Number.isFinite(center[1])
       ) {
         // Tilesets only expose their center, not a native zoom range. Use a
         // conservative floor so city-scale tilesets that render below zoom 18

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -25,6 +25,7 @@
     "geotiff": "^3.0.5",
     "jspdf": "^2.5.2",
     "maplibre-gl": "^5.24.0",
+    "maplibre-gl-3d-tiles": "^0.3.0",
     "maplibre-gl-basemap-control": "^0.2.1",
     "maplibre-gl-components": "^0.17.4",
     "maplibre-gl-duckdb": "^0.2.0",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -27,6 +27,7 @@ export {
 } from "./plugins/maplibre-components";
 export { openDuckDBLayerPanel } from "./plugins/maplibre-duckdb";
 export { openGeoParquetLayerPanel } from "./plugins/maplibre-geoparquet";
+export { openThreeDTilesLayerPanel } from "./plugins/maplibre-3d-tiles";
 export { maplibreEsriWaybackPlugin } from "./plugins/maplibre-esri-wayback";
 export { maplibreGeoEditorPlugin } from "./plugins/maplibre-geo-editor";
 export { maplibreGeoAgentPlugin } from "./plugins/maplibre-geoagent";

--- a/packages/plugins/src/plugins/maplibre-3d-tiles.ts
+++ b/packages/plugins/src/plugins/maplibre-3d-tiles.ts
@@ -46,7 +46,7 @@ function openStandaloneThreeDTilesControl(app: GeoLibreAppAPI): boolean {
       threeDTilesControlPosition,
     );
     if (!added) {
-      threeDTilesControl = null;
+      resetThreeDTilesControl(threeDTilesControl);
       return false;
     }
     threeDTilesControlMounted = true;
@@ -73,6 +73,7 @@ function createThreeDTilesControl(): ThreeDTilesControl {
   };
 
   control.on("statechange", syncHandler);
+  patchThreeDTilesControlOnRemove(control);
   threeDTilesStoreUnsubscribe ??= useAppStore.subscribe((state, previous) => {
     const currentById = new Map(state.layers.map((layer) => [layer.id, layer]));
 
@@ -218,6 +219,24 @@ function createThreeDTilesLayerUpdate(
   }
 
   return Object.keys(update).length > 0 ? update : null;
+}
+
+function patchThreeDTilesControlOnRemove(control: ThreeDTilesControl): void {
+  const originalOnRemove = control.onRemove.bind(control);
+  control.onRemove = () => {
+    originalOnRemove();
+    resetThreeDTilesControl(control);
+  };
+}
+
+function resetThreeDTilesControl(control: ThreeDTilesControl | null): void {
+  if (threeDTilesControl !== control) return;
+
+  threeDTilesStoreUnsubscribe?.();
+  threeDTilesStoreUnsubscribe = null;
+  threeDTilesPanelPinned = false;
+  threeDTilesControlMounted = false;
+  threeDTilesControl = null;
 }
 
 function isThreeDTilesControlLayer(layer: GeoLibreLayer): boolean {

--- a/packages/plugins/src/plugins/maplibre-3d-tiles.ts
+++ b/packages/plugins/src/plugins/maplibre-3d-tiles.ts
@@ -267,7 +267,7 @@ function installThreeDTilesToggleHandler(
 
   const toggleButton = control
     .getContainer()
-    .querySelector<HTMLButtonElement>(".three-d-tiles-control-toggle");
+    ?.querySelector<HTMLButtonElement>(".three-d-tiles-control-toggle");
   if (!toggleButton || toggleButton.dataset.geolibreToggleHandler === "true") {
     return;
   }

--- a/packages/plugins/src/plugins/maplibre-3d-tiles.ts
+++ b/packages/plugins/src/plugins/maplibre-3d-tiles.ts
@@ -70,6 +70,9 @@ function createThreeDTilesControl(): ThreeDTilesControl {
   const syncHandler: ThreeDTilesControlEventHandler = () => {
     syncThreeDTilesStoreFromControl(control);
     keepThreeDTilesPanelExpanded(control);
+    // The panel may render after showThreeDTilesControl ran, so retry the
+    // (idempotent) handler installation whenever the control state changes.
+    installThreeDTilesPanelHandlers(control);
   };
 
   control.on("statechange", syncHandler);
@@ -114,7 +117,11 @@ function syncThreeDTilesStoreFromControl(control: ThreeDTilesControl): void {
     }
   }
 
-  const layersById = new Map(store.layers.map((layer) => [layer.id, layer]));
+  // Re-read state: the removals above produce a new store snapshot, so the
+  // captured `store.layers` would still include the just-removed layers.
+  const layersById = new Map(
+    useAppStore.getState().layers.map((layer) => [layer.id, layer]),
+  );
   for (const tileset of state.tilesets) {
     const existingLayer = layersById.get(tileset.id);
     const layer = createThreeDTilesStoreLayer(tileset, tileset.opacity);
@@ -262,10 +269,18 @@ function hideThreeDTilesControl(control: ThreeDTilesControl | null): void {
 function showThreeDTilesControl(control: ThreeDTilesControl | null): void {
   const container = control?.getContainer();
   if (container) container.style.display = "";
+  installThreeDTilesPanelHandlers(control);
+}
+
+function installThreeDTilesPanelHandlers(
+  control: ThreeDTilesControl | null,
+): void {
   const panel = getThreeDTilesPanel(control);
-  panel?.classList.add("geolibre-3d-tiles-panel");
+  if (panel) {
+    panel.classList.add("geolibre-3d-tiles-panel");
+    installThreeDTilesCloseHandler(control, panel);
+  }
   installThreeDTilesToggleHandler(control);
-  installThreeDTilesCloseHandler(control, panel);
 }
 
 function getThreeDTilesPanel(

--- a/packages/plugins/src/plugins/maplibre-3d-tiles.ts
+++ b/packages/plugins/src/plugins/maplibre-3d-tiles.ts
@@ -1,0 +1,379 @@
+import {
+  DEFAULT_LAYER_STYLE,
+  type GeoLibreLayer,
+  useAppStore,
+} from "@geolibre/core";
+import {
+  DEFAULT_TILESET_URL,
+  ThreeDTilesControl,
+  type ThreeDTilesControlEventHandler,
+  type ThreeDTilesControlOptions,
+  type ThreeDTilesItemState,
+} from "maplibre-gl-3d-tiles";
+import type {
+  GeoLibreAppAPI,
+  GeoLibreMapControlPosition,
+} from "../types";
+
+const threeDTilesControlPosition: GeoLibreMapControlPosition = "top-left";
+const THREE_D_TILES_LAYER_ID = "geolibre-3d-tiles";
+
+const THREE_D_TILES_OPTIONS = {
+  className: "geolibre-3d-tiles-control",
+  collapsed: true,
+  collapseOnClickOutside: false,
+  layerId: THREE_D_TILES_LAYER_ID,
+  panelWidth: 365,
+  title: "Add 3D Tiles Layer",
+  tilesetUrl: DEFAULT_TILESET_URL,
+} satisfies ThreeDTilesControlOptions;
+
+let threeDTilesControl: ThreeDTilesControl | null = null;
+let threeDTilesControlMounted = false;
+let threeDTilesPanelPinned = false;
+let threeDTilesStoreUnsubscribe: (() => void) | null = null;
+
+export function openThreeDTilesLayerPanel(app: GeoLibreAppAPI): void {
+  openStandaloneThreeDTilesControl(app);
+}
+
+function openStandaloneThreeDTilesControl(app: GeoLibreAppAPI): boolean {
+  threeDTilesControl ??= createThreeDTilesControl();
+
+  if (!threeDTilesControlMounted) {
+    const added = app.addMapControl(
+      threeDTilesControl,
+      threeDTilesControlPosition,
+    );
+    if (!added) {
+      threeDTilesControl = null;
+      return false;
+    }
+    threeDTilesControlMounted = true;
+  }
+
+  const control = threeDTilesControl;
+  window.setTimeout(() => {
+    threeDTilesPanelPinned = true;
+    showThreeDTilesControl(control);
+    control.expand();
+    void hydrateThreeDTilesControlFromStore(control).then(() => {
+      syncThreeDTilesStoreFromControl(control);
+    });
+  }, 0);
+
+  return true;
+}
+
+function createThreeDTilesControl(): ThreeDTilesControl {
+  const control = new ThreeDTilesControl(THREE_D_TILES_OPTIONS);
+  const syncHandler: ThreeDTilesControlEventHandler = () => {
+    syncThreeDTilesStoreFromControl(control);
+    keepThreeDTilesPanelExpanded(control);
+  };
+
+  control.on("statechange", syncHandler);
+  threeDTilesStoreUnsubscribe ??= useAppStore.subscribe((state, previous) => {
+    const currentById = new Map(state.layers.map((layer) => [layer.id, layer]));
+
+    for (const layer of previous.layers) {
+      if (!isThreeDTilesControlLayer(layer)) continue;
+
+      const currentLayer = currentById.get(layer.id);
+      if (!currentLayer) {
+        if (hasThreeDTilesTileset(control, layer.id)) {
+          control.removeTileset(layer.id);
+        }
+        continue;
+      }
+
+      if (!isThreeDTilesControlLayer(currentLayer)) continue;
+
+      if (currentLayer.visible !== layer.visible) {
+        control.setVisible(currentLayer.visible, currentLayer.id);
+      }
+
+      if (currentLayer.opacity !== layer.opacity) {
+        setThreeDTilesOpacity(control, currentLayer.id, currentLayer.opacity);
+      }
+    }
+  });
+
+  return control;
+}
+
+function syncThreeDTilesStoreFromControl(control: ThreeDTilesControl): void {
+  const store = useAppStore.getState();
+  const state = control.getState();
+  const tilesetIds = new Set(state.tilesets.map((tileset) => tileset.id));
+
+  for (const layer of store.layers) {
+    if (isThreeDTilesControlLayer(layer) && !tilesetIds.has(layer.id)) {
+      store.removeLayer(layer.id);
+    }
+  }
+
+  const layersById = new Map(store.layers.map((layer) => [layer.id, layer]));
+  for (const tileset of state.tilesets) {
+    const existingLayer = layersById.get(tileset.id);
+    const layer = createThreeDTilesStoreLayer(tileset, tileset.opacity);
+
+    if (existingLayer) {
+      const update = createThreeDTilesLayerUpdate(existingLayer, layer);
+      if (update) store.updateLayer(layer.id, update);
+      continue;
+    }
+
+    store.addLayer(layer);
+  }
+}
+
+async function hydrateThreeDTilesControlFromStore(
+  control: ThreeDTilesControl,
+): Promise<void> {
+  if (control.getState().tilesets.length > 0) return;
+
+  const layers = useAppStore
+    .getState()
+    .layers.filter(isThreeDTilesControlLayer);
+  for (const layer of layers) {
+    const url = stringValue(layer.source.url) ?? layer.sourcePath;
+    if (!url) continue;
+
+    const layerValues = {
+      beforeId: layer.beforeId,
+      layerName: layer.name,
+    };
+    const id = await control.loadTileset(url, {
+      altitudeOffset: numberValue(layer.source.altitudeOffset, 0),
+      beforeId: layerValues.beforeId,
+      flyToOnLoad: false,
+      layerName: layerValues.layerName,
+      opacity: layer.opacity,
+      visible: layer.visible,
+    });
+    if (id) setThreeDTilesOpacity(control, id, layer.opacity);
+  }
+}
+
+function createThreeDTilesStoreLayer(
+  tileset: ThreeDTilesItemState,
+  opacity = 1,
+): GeoLibreLayer {
+  const layerName = tileset.layerName || layerNameFromUrl(tileset.tilesetUrl, tileset.id);
+  const beforeId = tileset.beforeId;
+
+  return {
+    id: tileset.id,
+    name: layerName,
+    type: "3d-tiles",
+    source: {
+      altitudeOffset: tileset.altitudeOffset,
+      sourceId: tileset.id,
+      type: "3d-tiles",
+      url: tileset.tilesetUrl,
+    },
+    visible: tileset.visible,
+    opacity,
+    style: { ...DEFAULT_LAYER_STYLE },
+    beforeId,
+    metadata: {
+      altitude: tileset.altitude,
+      altitudeOffset: tileset.altitudeOffset,
+      beforeId,
+      center: tileset.center,
+      customLayerType: "3d-tiles",
+      error: tileset.error,
+      externalNativeLayer: true,
+      identifiable: false,
+      layerName,
+      nativeLayerIds: [tileset.layerId],
+      sourceId: tileset.id,
+      sourceKind: "3d-tiles-url",
+      status: tileset.status,
+    },
+    sourcePath: tileset.tilesetUrl,
+  };
+}
+
+function createThreeDTilesLayerUpdate(
+  existingLayer: GeoLibreLayer,
+  layer: GeoLibreLayer,
+): Partial<GeoLibreLayer> | null {
+  const update: Partial<GeoLibreLayer> = {};
+  const name = existingLayer.name || layer.name;
+
+  if (existingLayer.name !== name) update.name = name;
+  if (existingLayer.beforeId !== layer.beforeId) update.beforeId = layer.beforeId;
+  if (existingLayer.opacity !== layer.opacity) update.opacity = layer.opacity;
+  if (existingLayer.visible !== layer.visible) update.visible = layer.visible;
+  if (existingLayer.sourcePath !== layer.sourcePath) {
+    update.sourcePath = layer.sourcePath;
+  }
+  if (!recordsEqual(existingLayer.source, layer.source)) {
+    update.source = layer.source;
+  }
+  if (!recordsEqual(existingLayer.metadata, layer.metadata)) {
+    update.metadata = layer.metadata;
+  }
+
+  return Object.keys(update).length > 0 ? update : null;
+}
+
+function isThreeDTilesControlLayer(layer: GeoLibreLayer): boolean {
+  return (
+    layer.type === "3d-tiles" &&
+    layer.metadata.sourceKind === "3d-tiles-url" &&
+    layer.metadata.externalNativeLayer === true
+  );
+}
+
+function hasThreeDTilesTileset(
+  control: ThreeDTilesControl,
+  id: string,
+): boolean {
+  return control.getState().tilesets.some((tileset) => tileset.id === id);
+}
+
+function hideThreeDTilesControl(control: ThreeDTilesControl | null): void {
+  const container = control?.getContainer();
+  if (container) container.style.display = "none";
+}
+
+function showThreeDTilesControl(control: ThreeDTilesControl | null): void {
+  const container = control?.getContainer();
+  if (container) container.style.display = "";
+  const panel = getThreeDTilesPanel(control);
+  panel?.classList.add("geolibre-3d-tiles-panel");
+  installThreeDTilesToggleHandler(control);
+  installThreeDTilesCloseHandler(control, panel);
+}
+
+function getThreeDTilesPanel(
+  control: ThreeDTilesControl | null,
+): HTMLElement | null {
+  return (
+    control
+      ?.getMap()
+      ?.getContainer()
+      .querySelector<HTMLElement>(".three-d-tiles-control-panel") ?? null
+  );
+}
+
+function installThreeDTilesToggleHandler(
+  control: ThreeDTilesControl | null,
+): void {
+  if (!control) return;
+
+  const toggleButton = control
+    .getContainer()
+    .querySelector<HTMLButtonElement>(".three-d-tiles-control-toggle");
+  if (!toggleButton || toggleButton.dataset.geolibreToggleHandler === "true") {
+    return;
+  }
+
+  toggleButton.dataset.geolibreToggleHandler = "true";
+  toggleButton.addEventListener(
+    "click",
+    () => {
+      threeDTilesPanelPinned = false;
+      window.setTimeout(() => {
+        threeDTilesPanelPinned = !control.getState().collapsed;
+      }, 0);
+    },
+    { capture: true },
+  );
+}
+
+function installThreeDTilesCloseHandler(
+  control: ThreeDTilesControl | null,
+  panel: HTMLElement | null,
+): void {
+  const closeButton = panel?.querySelector<HTMLButtonElement>(
+    ".three-d-tiles-control-close",
+  );
+  if (!closeButton || closeButton.dataset.geolibreCloseHandler === "true") {
+    return;
+  }
+
+  closeButton.dataset.geolibreCloseHandler = "true";
+  closeButton.addEventListener("click", () => {
+    threeDTilesPanelPinned = false;
+    window.setTimeout(() => hideThreeDTilesControl(control), 0);
+  });
+}
+
+function keepThreeDTilesPanelExpanded(control: ThreeDTilesControl): void {
+  if (!threeDTilesPanelPinned || !control.getState().collapsed) return;
+
+  window.setTimeout(() => {
+    if (threeDTilesPanelPinned && control.getState().collapsed) {
+      control.expand();
+    }
+  }, 0);
+}
+
+function setThreeDTilesOpacity(
+  control: ThreeDTilesControl,
+  id: string,
+  opacity: number,
+): void {
+  control.setOpacity(opacity, id, false);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function numberValue(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : fallback;
+}
+
+function recordsEqual(
+  left: Record<string, unknown>,
+  right: Record<string, unknown>,
+): boolean {
+  const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
+  for (const key of keys) {
+    if (!valuesEqual(left[key], right[key])) return false;
+  }
+  return true;
+}
+
+function valuesEqual(left: unknown, right: unknown): boolean {
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right)) return false;
+    if (left.length !== right.length) return false;
+    return left.every((value, index) => valuesEqual(value, right[index]));
+  }
+
+  if (isRecord(left) || isRecord(right)) {
+    return isRecord(left) && isRecord(right) && recordsEqual(left, right);
+  }
+
+  return Object.is(left, right);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value)
+  );
+}
+
+function layerNameFromUrl(url: string, fallback: string): string {
+  try {
+    const parsed = new URL(url);
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    const fileName = segments.at(-1);
+    const parentName = segments.at(-2);
+    return parentName && fileName
+      ? `${parentName}/${fileName}`
+      : (fileName ?? parsed.hostname);
+  } catch {
+    return fallback;
+  }
+}

--- a/packages/plugins/src/plugins/maplibre-geoparquet.ts
+++ b/packages/plugins/src/plugins/maplibre-geoparquet.ts
@@ -699,24 +699,33 @@ function updateGeoParquetPanelInset(
 ): void {
   panel.style.setProperty(
     "--geolibre-geoparquet-panel-left",
-    hasVisibleTopLeftMapControls(control) ? "48px" : "10px",
+    geoParquetPanelLeftOffset(control),
   );
 }
 
-function hasVisibleTopLeftMapControls(
-  control: GeoParquetControl | null,
-): boolean {
-  const topLeftControls = control
-    ?.getMap()
-    ?.getContainer()
-    .querySelector<HTMLElement>(".maplibregl-ctrl-top-left");
-  if (!topLeftControls) return false;
+function geoParquetPanelLeftOffset(control: GeoParquetControl | null): string {
+  const mapContainer = control?.getMap()?.getContainer();
+  const topLeftControls = mapContainer?.querySelector<HTMLElement>(
+    ".maplibregl-ctrl-top-left",
+  );
+  if (!mapContainer || !topLeftControls) return "10px";
 
-  return [...topLeftControls.querySelectorAll<HTMLElement>(".maplibregl-ctrl")]
+  // Measure the actual right edge of the other visible top-left controls
+  // instead of assuming a fixed control width.
+  const visibleControls = [
+    ...topLeftControls.querySelectorAll<HTMLElement>(".maplibregl-ctrl"),
+  ]
     .filter(
       (element) => !element.classList.contains("geolibre-geoparquet-control"),
     )
-    .some(isVisibleElement);
+    .filter(isVisibleElement);
+  if (visibleControls.length === 0) return "10px";
+
+  const rightEdge = Math.max(
+    ...visibleControls.map((element) => element.getBoundingClientRect().right),
+  );
+  const left = rightEdge - mapContainer.getBoundingClientRect().left + 10;
+  return `${Math.max(Math.round(left), 10)}px`;
 }
 
 function isVisibleElement(element: HTMLElement): boolean {

--- a/packages/plugins/src/plugins/maplibre-geoparquet.ts
+++ b/packages/plugins/src/plugins/maplibre-geoparquet.ts
@@ -68,6 +68,8 @@ type GeoParquetRenderedLayerLike = {
 };
 
 const geoparquetControlPosition: GeoLibreMapControlPosition = "top-left";
+const DEFAULT_GEOPARQUET_URL =
+  "https://data.source.coop/giswqs/opengeos/countries.parquet";
 
 const GEOPARQUET_OPTIONS = {
   className: "geolibre-geoparquet-control",
@@ -75,6 +77,7 @@ const GEOPARQUET_OPTIONS = {
   interleaved: true,
   panelWidth: 365,
   pickable: true,
+  sampleUrl: DEFAULT_GEOPARQUET_URL,
   title: "Add GeoParquet Layer",
 } satisfies GeoParquetControlOptions;
 
@@ -669,4 +672,60 @@ function hideGeoParquetControl(control: GeoParquetControl | null): void {
 function showGeoParquetControl(control: GeoParquetControl | null): void {
   const container = control?.getContainer();
   if (container) container.style.display = "";
+
+  const panel = getGeoParquetPanel(control);
+  if (!panel) return;
+
+  updateGeoParquetPanelInset(control, panel);
+  window.requestAnimationFrame(() => {
+    updateGeoParquetPanelInset(control, panel);
+  });
+}
+
+function getGeoParquetPanel(
+  control: GeoParquetControl | null,
+): HTMLElement | null {
+  return (
+    control
+      ?.getMap()
+      ?.getContainer()
+      .querySelector<HTMLElement>(".geoparquet-control-panel") ?? null
+  );
+}
+
+function updateGeoParquetPanelInset(
+  control: GeoParquetControl | null,
+  panel: HTMLElement,
+): void {
+  panel.style.setProperty(
+    "--geolibre-geoparquet-panel-left",
+    hasVisibleTopLeftMapControls(control) ? "48px" : "10px",
+  );
+}
+
+function hasVisibleTopLeftMapControls(
+  control: GeoParquetControl | null,
+): boolean {
+  const topLeftControls = control
+    ?.getMap()
+    ?.getContainer()
+    .querySelector<HTMLElement>(".maplibregl-ctrl-top-left");
+  if (!topLeftControls) return false;
+
+  return [...topLeftControls.querySelectorAll<HTMLElement>(".maplibregl-ctrl")]
+    .filter(
+      (element) => !element.classList.contains("geolibre-geoparquet-control"),
+    )
+    .some(isVisibleElement);
+}
+
+function isVisibleElement(element: HTMLElement): boolean {
+  const style = window.getComputedStyle(element);
+  const rect = element.getBoundingClientRect();
+  return (
+    style.display !== "none" &&
+    style.visibility !== "hidden" &&
+    rect.width > 0 &&
+    rect.height > 0
+  );
 }


### PR DESCRIPTION
## Summary
- Add a new 3D Tiles plugin built on maplibre-gl-3d-tiles with a map control panel for loading Cesium 3D Tiles tilesets, including two-way sync between the control and the layer store (visibility, opacity, removal)
- Wire an "Add 3D Tiles Layer" entry into the toolbar, add themed panel styles, register the new "3d-tiles" layer type, support custom-layer reordering in layer sync, and fly to the tileset center on fit
- Set a default sample URL for the GeoParquet panel and offset its panel when other top-left map controls are visible

## Test plan
- [ ] Add a 3D Tiles layer from the toolbar and confirm the tileset renders
- [ ] Toggle visibility and adjust opacity from the layer list and confirm the tileset updates
- [ ] Remove the layer from the layer list and confirm the tileset is removed from the map
- [ ] Use zoom-to-layer on a 3D Tiles layer and confirm the camera flies to the tileset
- [ ] Open the GeoParquet panel with and without other top-left controls visible and confirm it is not overlapped