### PR TITLE
Fix GeoParquet panel DuckDB startup

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -20,7 +20,7 @@
     "@deck.gl/mesh-layers": "^9.3.2",
     "@developmentseed/deck.gl-geotiff": "^0.7.0",
     "@developmentseed/deck.gl-raster": "^0.7.0",
-    "@duckdb/duckdb-wasm": "^1.29.0",
+    "@duckdb/duckdb-wasm": "^1.33.1-dev45.0",
     "@dvt3d/maplibre-three-plugin": "^1.6.0",
     "@geolibre/core": "*",
     "@geolibre/map": "*",

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -20,7 +20,7 @@
     "@deck.gl/mesh-layers": "^9.3.2",
     "@developmentseed/deck.gl-geotiff": "^0.7.0",
     "@developmentseed/deck.gl-raster": "^0.7.0",
-    "@duckdb/duckdb-wasm": "^1.33.1-dev45.0",
+    "@duckdb/duckdb-wasm": "1.33.1-dev45.0",
     "@dvt3d/maplibre-three-plugin": "^1.6.0",
     "@geolibre/core": "*",
     "@geolibre/map": "*",

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -333,11 +333,15 @@ export function TopToolbar({
     openDuckDBLayerPanel(appApi);
   };
   const handleAddGeoParquetLayer = async () => {
-    const { configureGeoParquetDuckDBRuntime } = await import(
-      "../../lib/geoparquet-duckdb-runtime"
-    );
-    configureGeoParquetDuckDBRuntime();
-    openGeoParquetLayerPanel(appApi);
+    try {
+      const { configureGeoParquetDuckDBRuntime } = await import(
+        "../../lib/geoparquet-duckdb-runtime"
+      );
+      configureGeoParquetDuckDBRuntime();
+      openGeoParquetLayerPanel(appApi);
+    } catch (error) {
+      console.error("Failed to initialise GeoParquet DuckDB runtime", error);
+    }
   };
   const handleAddPMTilesLayer = () => {
     openPMTilesLayerPanel(appApi);

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -13,7 +13,6 @@ import {
   closeSearchPlacesPanel,
   openFlatGeobufAddVectorLayerPanel,
   openDuckDBLayerPanel,
-  openGeoParquetLayerPanel,
   isSearchPlacesPanelVisible,
   openLidarLayerPanel,
   openPMTilesLayerPanel,
@@ -334,12 +333,12 @@ export function TopToolbar({
   };
   const handleAddGeoParquetLayer = async () => {
     try {
-      const { configureGeoParquetDuckDBRuntime } = await import(
+      const { openGeoParquetPanel } = await import(
         "../../lib/geoparquet-duckdb-runtime"
       );
-      configureGeoParquetDuckDBRuntime();
-      openGeoParquetLayerPanel(appApi);
+      openGeoParquetPanel(appApi);
     } catch (error) {
+      console.error("Failed to open the GeoParquet panel", error);
       setActionError(
         error instanceof Error
           ? error.message

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -340,7 +340,11 @@ export function TopToolbar({
       configureGeoParquetDuckDBRuntime();
       openGeoParquetLayerPanel(appApi);
     } catch (error) {
-      console.error("Failed to initialise GeoParquet DuckDB runtime", error);
+      setActionError(
+        error instanceof Error
+          ? error.message
+          : "Failed to open GeoParquet panel",
+      );
     }
   };
   const handleAddPMTilesLayer = () => {

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -332,7 +332,11 @@ export function TopToolbar({
   const handleAddDuckDBLayer = () => {
     openDuckDBLayerPanel(appApi);
   };
-  const handleAddGeoParquetLayer = () => {
+  const handleAddGeoParquetLayer = async () => {
+    const { configureGeoParquetDuckDBRuntime } = await import(
+      "../../lib/geoparquet-duckdb-runtime"
+    );
+    configureGeoParquetDuckDBRuntime();
     openGeoParquetLayerPanel(appApi);
   };
   const handleAddPMTilesLayer = () => {
@@ -522,7 +526,7 @@ export function TopToolbar({
           <DropdownMenuItem onSelect={() => setAddDataKind("raster")}>
             Add Raster Layer
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleAddGeoParquetLayer}>
+          <DropdownMenuItem onSelect={() => void handleAddGeoParquetLayer()}>
             Add GeoParquet Layer
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={handleAddFlatGeobufLayer}>

--- a/apps/geolibre-desktop/src/lib/geoparquet-duckdb-runtime.ts
+++ b/apps/geolibre-desktop/src/lib/geoparquet-duckdb-runtime.ts
@@ -1,0 +1,31 @@
+import type { DuckDBBundles } from "@duckdb/duckdb-wasm";
+import duckdbWasmEh from "@duckdb/duckdb-wasm/dist/duckdb-eh.wasm?url";
+import ehWorker from "@duckdb/duckdb-wasm/dist/duckdb-browser-eh.worker.js?url";
+import duckdbWasmMvp from "@duckdb/duckdb-wasm/dist/duckdb-mvp.wasm?url";
+import mvpWorker from "@duckdb/duckdb-wasm/dist/duckdb-browser-mvp.worker.js?url";
+import { configureDuckDB } from "maplibre-gl-geoparquet";
+
+let configured = false;
+
+const GEOPARQUET_DUCKDB_BUNDLES = {
+  mvp: {
+    mainModule: absoluteAssetUrl(duckdbWasmMvp),
+    mainWorker: absoluteAssetUrl(mvpWorker),
+  },
+  eh: {
+    mainModule: absoluteAssetUrl(duckdbWasmEh),
+    mainWorker: absoluteAssetUrl(ehWorker),
+  },
+} satisfies DuckDBBundles;
+
+function absoluteAssetUrl(url: string): string {
+  return new URL(url, globalThis.location.href).href;
+}
+
+export function configureGeoParquetDuckDBRuntime(): void {
+  if (configured) return;
+  configureDuckDB({
+    bundles: GEOPARQUET_DUCKDB_BUNDLES,
+  });
+  configured = true;
+}

--- a/apps/geolibre-desktop/src/lib/geoparquet-duckdb-runtime.ts
+++ b/apps/geolibre-desktop/src/lib/geoparquet-duckdb-runtime.ts
@@ -4,15 +4,18 @@ import ehWorker from "@duckdb/duckdb-wasm/dist/duckdb-browser-eh.worker.js?url";
 import duckdbWasmMvp from "@duckdb/duckdb-wasm/dist/duckdb-mvp.wasm?url";
 import mvpWorker from "@duckdb/duckdb-wasm/dist/duckdb-browser-mvp.worker.js?url";
 import { configureDuckDB } from "maplibre-gl-geoparquet";
-
-let configured = false;
+import {
+  type GeoLibreAppAPI,
+  openGeoParquetLayerPanel,
+} from "@geolibre/plugins";
 
 function absoluteAssetUrl(url: string): string {
-  return new URL(url, globalThis.location.href).href;
+  return new URL(url, globalThis.location?.href ?? "http://localhost/").href;
 }
 
 export function configureGeoParquetDuckDBRuntime(): void {
-  if (configured) return;
+  // configureDuckDB is an idempotent synchronous setter, so repeated calls
+  // are harmless (and DuckDB ignores config changes once initialized).
   configureDuckDB({
     bundles: {
       mvp: {
@@ -25,5 +28,9 @@ export function configureGeoParquetDuckDBRuntime(): void {
       },
     } satisfies DuckDBBundles,
   });
-  configured = true;
+}
+
+export function openGeoParquetPanel(app: GeoLibreAppAPI): void {
+  configureGeoParquetDuckDBRuntime();
+  openGeoParquetLayerPanel(app);
 }

--- a/apps/geolibre-desktop/src/lib/geoparquet-duckdb-runtime.ts
+++ b/apps/geolibre-desktop/src/lib/geoparquet-duckdb-runtime.ts
@@ -7,17 +7,6 @@ import { configureDuckDB } from "maplibre-gl-geoparquet";
 
 let configured = false;
 
-const GEOPARQUET_DUCKDB_BUNDLES = {
-  mvp: {
-    mainModule: absoluteAssetUrl(duckdbWasmMvp),
-    mainWorker: absoluteAssetUrl(mvpWorker),
-  },
-  eh: {
-    mainModule: absoluteAssetUrl(duckdbWasmEh),
-    mainWorker: absoluteAssetUrl(ehWorker),
-  },
-} satisfies DuckDBBundles;
-
 function absoluteAssetUrl(url: string): string {
   return new URL(url, globalThis.location.href).href;
 }
@@ -25,7 +14,16 @@ function absoluteAssetUrl(url: string): string {
 export function configureGeoParquetDuckDBRuntime(): void {
   if (configured) return;
   configureDuckDB({
-    bundles: GEOPARQUET_DUCKDB_BUNDLES,
+    bundles: {
+      mvp: {
+        mainModule: absoluteAssetUrl(duckdbWasmMvp),
+        mainWorker: absoluteAssetUrl(mvpWorker),
+      },
+      eh: {
+        mainModule: absoluteAssetUrl(duckdbWasmEh),
+        mainWorker: absoluteAssetUrl(ehWorker),
+      },
+    } satisfies DuckDBBundles,
   });
   configured = true;
 }

--- a/apps/geolibre-desktop/src/lib/geoparquet-duckdb-runtime.ts
+++ b/apps/geolibre-desktop/src/lib/geoparquet-duckdb-runtime.ts
@@ -9,6 +9,9 @@ import {
   openGeoParquetLayerPanel,
 } from "@geolibre/plugins";
 
+// Blob workers created by DuckDB-WASM require absolute base URLs; Tauri's
+// origin (tauri://localhost/) won't resolve root-relative ?url imports
+// without this normalisation.
 function absoluteAssetUrl(url: string): string {
   return new URL(url, globalThis.location?.href ?? "http://localhost/").href;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@deck.gl/mesh-layers": "^9.3.2",
         "@developmentseed/deck.gl-geotiff": "^0.7.0",
         "@developmentseed/deck.gl-raster": "^0.7.0",
-        "@duckdb/duckdb-wasm": "^1.29.0",
+        "@duckdb/duckdb-wasm": "^1.33.1-dev45.0",
         "@dvt3d/maplibre-three-plugin": "^1.6.0",
         "@geolibre/core": "*",
         "@geolibre/map": "*",
@@ -1310,12 +1310,13 @@
       "license": "MIT"
     },
     "node_modules/@duckdb/duckdb-wasm": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.32.0.tgz",
-      "integrity": "sha512-IewXTNYEjsZCPE9weUWgtjGxUlMRo7qhX0GF6tq/KjK8bnY+RAl4cyUdYUfcdzbyb4b9ZxPC+FOsCcxgaKFWMg==",
+      "version": "1.33.1-dev45.0",
+      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.33.1-dev45.0.tgz",
+      "integrity": "sha512-ETlrjhiGQzNdaOhpro/Y9u/RCcK+iyuczLy7uOn0kG5Mqlj8C+gTuhBXjs4JpK9ocdUgr3oT8zYYIbUnFD9AYA==",
       "license": "MIT",
       "dependencies": {
-        "apache-arrow": "^17.0.0"
+        "apache-arrow": "^17.0.0",
+        "qs": "^6.14.1"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -9737,36 +9738,6 @@
         }
       }
     },
-    "node_modules/maplibre-gl-duckdb/node_modules/@duckdb/duckdb-wasm": {
-      "version": "1.33.1-dev45.0",
-      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.33.1-dev45.0.tgz",
-      "integrity": "sha512-ETlrjhiGQzNdaOhpro/Y9u/RCcK+iyuczLy7uOn0kG5Mqlj8C+gTuhBXjs4JpK9ocdUgr3oT8zYYIbUnFD9AYA==",
-      "license": "MIT",
-      "dependencies": {
-        "apache-arrow": "^17.0.0",
-        "qs": "^6.14.1"
-      }
-    },
-    "node_modules/maplibre-gl-duckdb/node_modules/@duckdb/duckdb-wasm/node_modules/apache-arrow": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-17.0.0.tgz",
-      "integrity": "sha512-X0p7auzdnGuhYMVKYINdQssS4EcKec9TCXyez/qtJt32DrIMGbzqiaMiQ0X6fQlQpw8Fl0Qygcv4dfRAr5Gu9Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.11",
-        "@types/command-line-args": "^5.2.3",
-        "@types/command-line-usage": "^5.0.4",
-        "@types/node": "^20.13.0",
-        "command-line-args": "^5.2.1",
-        "command-line-usage": "^7.0.1",
-        "flatbuffers": "^24.3.25",
-        "json-bignum": "^0.0.3",
-        "tslib": "^2.6.2"
-      },
-      "bin": {
-        "arrow2csv": "bin/arrow2csv.cjs"
-      }
-    },
     "node_modules/maplibre-gl-duckdb/node_modules/apache-arrow": {
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-21.1.0.tgz",
@@ -9978,36 +9949,6 @@
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/maplibre-gl-geoparquet/node_modules/@duckdb/duckdb-wasm": {
-      "version": "1.33.1-dev45.0",
-      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.33.1-dev45.0.tgz",
-      "integrity": "sha512-ETlrjhiGQzNdaOhpro/Y9u/RCcK+iyuczLy7uOn0kG5Mqlj8C+gTuhBXjs4JpK9ocdUgr3oT8zYYIbUnFD9AYA==",
-      "license": "MIT",
-      "dependencies": {
-        "apache-arrow": "^17.0.0",
-        "qs": "^6.14.1"
-      }
-    },
-    "node_modules/maplibre-gl-geoparquet/node_modules/@duckdb/duckdb-wasm/node_modules/apache-arrow": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-17.0.0.tgz",
-      "integrity": "sha512-X0p7auzdnGuhYMVKYINdQssS4EcKec9TCXyez/qtJt32DrIMGbzqiaMiQ0X6fQlQpw8Fl0Qygcv4dfRAr5Gu9Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.11",
-        "@types/command-line-args": "^5.2.3",
-        "@types/command-line-usage": "^5.0.4",
-        "@types/node": "^20.13.0",
-        "command-line-args": "^5.2.1",
-        "command-line-usage": "^7.0.1",
-        "flatbuffers": "^24.3.25",
-        "json-bignum": "^0.0.3",
-        "tslib": "^2.6.2"
-      },
-      "bin": {
-        "arrow2csv": "bin/arrow2csv.cjs"
       }
     },
     "node_modules/maplibre-gl-geoparquet/node_modules/@geoarrow/deck.gl-layers": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@deck.gl/mesh-layers": "^9.3.2",
         "@developmentseed/deck.gl-geotiff": "^0.7.0",
         "@developmentseed/deck.gl-raster": "^0.7.0",
-        "@duckdb/duckdb-wasm": "^1.33.1-dev45.0",
+        "@duckdb/duckdb-wasm": "1.33.1-dev45.0",
         "@dvt3d/maplibre-three-plugin": "^1.6.0",
         "@geolibre/core": "*",
         "@geolibre/map": "*",

--- a/packages/plugins/src/plugins/map-projection-utils.ts
+++ b/packages/plugins/src/plugins/map-projection-utils.ts
@@ -1,0 +1,12 @@
+import type { Map as MapLibreMap } from "maplibre-gl";
+
+export function ensureMercatorProjection(
+  map: MapLibreMap | null | undefined,
+): void {
+  try {
+    if (!map || map.getProjection()?.type === "mercator") return;
+    map.setProjection({ type: "mercator" });
+  } catch {
+    // MapLibre can reject projection changes while the style is still settling.
+  }
+}

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -52,6 +52,7 @@ import type {
   GeoLibreMapControlPosition,
   GeoLibrePlugin,
 } from "../types";
+import { ensureMercatorProjection } from "./map-projection-utils";
 
 type ControlGridConstructor =
   (typeof import("maplibre-gl-components"))["ControlGrid"];
@@ -754,7 +755,7 @@ export async function addCogRasterLayer(
     return addGeoTiffRasterLayer(app, options);
   }
 
-  ensureCogRasterMercatorProjection(app);
+  ensureMercatorProjection(app.getMap?.());
   const control = await ensureCogRasterControl(app);
   if (!control) {
     throw new Error("The COG raster layer control could not be added to the map.");
@@ -2104,16 +2105,6 @@ function configureCogRasterControl(
   mutableControl._render?.();
 }
 
-function ensureCogRasterMercatorProjection(app: GeoLibreAppAPI): void {
-  try {
-    const map = app.getMap?.();
-    if (!map || map.getProjection()?.type === "mercator") return;
-    map.setProjection({ type: "mercator" });
-  } catch {
-    // MapLibre can reject projection changes while the style is still settling.
-  }
-}
-
 function createFlatGeobufStoreLayer(
   id: string,
   layerInfo: AddVectorLayerInfo,
@@ -2586,7 +2577,7 @@ function patchStacSearchCogLayer(control: StacSearchControl): void {
     item: StacSearchItem,
     assetKey: string,
   ) => {
-    ensureStacSearchMercatorProjection(mutableControl);
+    ensureMercatorProjection(mutableControl._map);
     await mutableControl._ensureOverlay?.();
     const selectedAsset = getStacSearchSelectedAsset(mutableControl, item, {
       key: assetKey,
@@ -2956,17 +2947,6 @@ function getAlphaValue(
 
 function getStacCogShaderNoData(): number | null {
   return null;
-}
-
-function ensureStacSearchMercatorProjection(
-  control: MutableStacSearchControl,
-): void {
-  try {
-    if (control._map?.getProjection()?.type === "mercator") return;
-    control._map?.setProjection({ type: "mercator" });
-  } catch {
-    // MapLibre may reject projection changes while the style is still settling.
-  }
 }
 
 async function patchStacSearchCOGLayerClass(

--- a/packages/plugins/src/plugins/maplibre-geoparquet.ts
+++ b/packages/plugins/src/plugins/maplibre-geoparquet.ts
@@ -97,10 +97,12 @@ export function openGeoParquetLayerPanel(app: GeoLibreAppAPI): void {
 async function openStandaloneGeoParquetControl(
   app: GeoLibreAppAPI,
 ): Promise<boolean> {
+  ensureGeoParquetMercatorProjection(app);
+
   const { GeoParquetControl: GeoParquetControlClass } =
     await getGeoParquetConstructors();
 
-  geoparquetControl ??= createGeoParquetControl(GeoParquetControlClass);
+  geoparquetControl ??= createGeoParquetControl(GeoParquetControlClass, app);
 
   if (!geoparquetControlMounted) {
     const added = app.addMapControl(
@@ -122,6 +124,16 @@ async function openStandaloneGeoParquetControl(
   return true;
 }
 
+function ensureGeoParquetMercatorProjection(app: GeoLibreAppAPI): void {
+  try {
+    const map = app.getMap?.();
+    if (!map || map.getProjection()?.type === "mercator") return;
+    map.setProjection({ type: "mercator" });
+  } catch {
+    // MapLibre can reject projection changes while the style is still settling.
+  }
+}
+
 function getGeoParquetConstructors(): Promise<{
   GeoParquetControl: GeoParquetControlConstructor;
 }> {
@@ -135,10 +147,12 @@ function getGeoParquetConstructors(): Promise<{
 
 function createGeoParquetControl(
   GeoParquetControlClass: GeoParquetControlConstructor,
+  app: GeoLibreAppAPI,
 ): GeoParquetControl {
   const control = new GeoParquetControlClass(GEOPARQUET_OPTIONS);
   patchGeoParquetControlOnRemove(control);
   control.on("collapse", () => hideGeoParquetControl(control));
+  control.on("loadstart", () => ensureGeoParquetMercatorProjection(app));
   control.on("load", createGeoParquetStateChangeHandler(control));
   control.on("statechange", createGeoParquetStateChangeHandler(control));
 

--- a/packages/plugins/src/plugins/maplibre-geoparquet.ts
+++ b/packages/plugins/src/plugins/maplibre-geoparquet.ts
@@ -17,6 +17,7 @@ import {
   pointRadiusMaxPixels,
   type StyledDeckLayerLike,
 } from "./deck-style-utils";
+import { ensureMercatorProjection } from "./map-projection-utils";
 
 type GeoParquetControlConstructor =
   (typeof import("maplibre-gl-geoparquet"))["GeoParquetControl"];
@@ -97,7 +98,7 @@ export function openGeoParquetLayerPanel(app: GeoLibreAppAPI): void {
 async function openStandaloneGeoParquetControl(
   app: GeoLibreAppAPI,
 ): Promise<boolean> {
-  ensureGeoParquetMercatorProjection(app);
+  ensureMercatorProjection(app.getMap?.());
 
   const { GeoParquetControl: GeoParquetControlClass } =
     await getGeoParquetConstructors();
@@ -124,16 +125,6 @@ async function openStandaloneGeoParquetControl(
   return true;
 }
 
-function ensureGeoParquetMercatorProjection(app: GeoLibreAppAPI): void {
-  try {
-    const map = app.getMap?.();
-    if (!map || map.getProjection()?.type === "mercator") return;
-    map.setProjection({ type: "mercator" });
-  } catch {
-    // MapLibre can reject projection changes while the style is still settling.
-  }
-}
-
 function getGeoParquetConstructors(): Promise<{
   GeoParquetControl: GeoParquetControlConstructor;
 }> {
@@ -152,7 +143,7 @@ function createGeoParquetControl(
   const control = new GeoParquetControlClass(GEOPARQUET_OPTIONS);
   patchGeoParquetControlOnRemove(control);
   control.on("collapse", () => hideGeoParquetControl(control));
-  control.on("loadstart", () => ensureGeoParquetMercatorProjection(app));
+  control.on("loadstart", () => ensureMercatorProjection(app.getMap?.()));
   control.on("load", createGeoParquetStateChangeHandler(control));
   control.on("statechange", createGeoParquetStateChangeHandler(control));
 


### PR DESCRIPTION
## Summary
- Configure the GeoParquet control with bundled DuckDB-WASM runtime assets before opening the panel
- Normalize DuckDB worker and WASM asset URLs so the plugin blob worker can load them in Vite and Tauri contexts
- Align the desktop DuckDB-WASM dependency with the version required by the GeoParquet control

Closes #113

## Tests
- npm run build
- pre-commit run --all-files
- Browser smoke test: Add Data -> Add GeoParquet Layer -> load sample URL
- Browser smoke test: Add Data -> Add GeoParquet Layer -> Choose File -> local GeoParquet file