### PR TITLE
fix: restore 3D Tiles layers when reopening a project

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -1,6 +1,7 @@
 import { useAppStore } from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
 import { MapCanvas } from "@geolibre/map";
+import { restoreThreeDTilesLayers } from "@geolibre/plugins";
 import {
   type CSSProperties,
   type DragEvent,
@@ -148,6 +149,7 @@ export function DesktopShell({
       useAppStore.getState().projectPlugins,
       createAppAPI(mapControllerRef),
     );
+    restoreThreeDTilesLayers(createAppAPI(mapControllerRef));
   }, [externalPluginsReady, mapReadyGeneration, projectGeneration]);
 
   useEffect(() => {

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -145,11 +145,12 @@ export function DesktopShell({
       !mapControllerRef.current
     )
       return;
+    const appAPI = createAppAPI(mapControllerRef);
     getPluginManager().restoreProjectState(
       useAppStore.getState().projectPlugins,
-      createAppAPI(mapControllerRef),
+      appAPI,
     );
-    restoreThreeDTilesLayers(createAppAPI(mapControllerRef));
+    restoreThreeDTilesLayers(appAPI);
   }, [externalPluginsReady, mapReadyGeneration, projectGeneration]);
 
   useEffect(() => {

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -575,6 +575,7 @@ export const MapCanvas = memo(function MapCanvas({
         state.layers.find((layer) => layer.id === state.selectedLayerId),
         state.selectedFeatureId,
       );
+      onControllerReadyRef.current?.();
     });
     controller.current?.setStyle(basemapStyleUrl);
   }, [basemapStyleUrl]);

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -1268,6 +1268,8 @@ function removeIfExists(map: maplibregl.Map, id: string): void {
 }
 
 function moveLayer(map: maplibregl.Map, id: string, beforeId?: string): void {
+  if (!map.getLayer(id)) return;
+
   try {
     if (beforeId && beforeId !== id && map.getLayer(beforeId)) {
       map.moveLayer(id, beforeId);

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -27,7 +27,10 @@ export {
 } from "./plugins/maplibre-components";
 export { openDuckDBLayerPanel } from "./plugins/maplibre-duckdb";
 export { openGeoParquetLayerPanel } from "./plugins/maplibre-geoparquet";
-export { openThreeDTilesLayerPanel } from "./plugins/maplibre-3d-tiles";
+export {
+  openThreeDTilesLayerPanel,
+  restoreThreeDTilesLayers,
+} from "./plugins/maplibre-3d-tiles";
 export { maplibreEsriWaybackPlugin } from "./plugins/maplibre-esri-wayback";
 export { maplibreGeoEditorPlugin } from "./plugins/maplibre-geo-editor";
 export { maplibreGeoAgentPlugin } from "./plugins/maplibre-geoagent";

--- a/packages/plugins/src/plugins/maplibre-3d-tiles.ts
+++ b/packages/plugins/src/plugins/maplibre-3d-tiles.ts
@@ -579,7 +579,8 @@ function restoredThreeDTilesLayerId(layer: GeoLibreLayer): string {
   const nativeLayerIds = layer.metadata.nativeLayerIds;
   if (Array.isArray(nativeLayerIds)) {
     const layerId = nativeLayerIds.find(
-      (value): value is string => typeof value === "string" && value.trim(),
+      (value): value is string =>
+        typeof value === "string" && value.trim().length > 0,
     );
     if (layerId) return layerId;
   }

--- a/packages/plugins/src/plugins/maplibre-3d-tiles.ts
+++ b/packages/plugins/src/plugins/maplibre-3d-tiles.ts
@@ -6,6 +6,8 @@ import {
 import {
   DEFAULT_TILESET_URL,
   ThreeDTilesControl,
+  ThreeDTilesLayer,
+  type LoadedTilesetMetadata,
   type ThreeDTilesControlEventHandler,
   type ThreeDTilesControlOptions,
   type ThreeDTilesItemState,
@@ -17,6 +19,9 @@ import type {
 
 const threeDTilesControlPosition: GeoLibreMapControlPosition = "top-left";
 const THREE_D_TILES_LAYER_ID = "geolibre-3d-tiles";
+const THREE_VERSION = "0.184.0";
+const DEFAULT_DRACO_DECODER_PATH = `https://unpkg.com/three@${THREE_VERSION}/examples/jsm/libs/draco/`;
+const DEFAULT_KTX2_TRANSCODER_PATH = `https://unpkg.com/three@${THREE_VERSION}/examples/jsm/libs/basis/`;
 
 const THREE_D_TILES_OPTIONS = {
   className: "geolibre-3d-tiles-control",
@@ -34,6 +39,16 @@ let threeDTilesPanelPinned = false;
 let threeDTilesStoreUnsubscribe: (() => void) | null = null;
 let threeDTilesStoreSyncSuspended = 0;
 
+type ThreeDTilesLayerInstance = InstanceType<typeof ThreeDTilesLayer>;
+
+interface ThreeDTilesControlInternals {
+  _layers?: Map<string, ThreeDTilesLayerInstance>;
+  _options?: {
+    dracoDecoderPath?: string;
+    ktx2TranscoderPath?: string;
+  };
+}
+
 export function openThreeDTilesLayerPanel(app: GeoLibreAppAPI): void {
   openStandaloneThreeDTilesControl(app);
 }
@@ -49,7 +64,16 @@ export function restoreThreeDTilesLayers(app: GeoLibreAppAPI): void {
   );
   if (!control) return;
 
-  hideThreeDTilesControl(control);
+  const panelCollapsed = threeDTilesPanelCollapsedFromLayers(layers);
+  runWithThreeDTilesStoreSyncSuspended(() => {
+    showThreeDTilesControl(control);
+    threeDTilesPanelPinned = !panelCollapsed;
+    if (panelCollapsed) {
+      control.collapse();
+    } else {
+      control.expand();
+    }
+  });
   void hydrateThreeDTilesControlFromStore(control, {
     replaceExisting: true,
   }).then(() => {
@@ -154,7 +178,11 @@ function syncThreeDTilesStoreFromControl(control: ThreeDTilesControl): void {
   );
   for (const tileset of state.tilesets) {
     const existingLayer = layersById.get(tileset.id);
-    const layer = createThreeDTilesStoreLayer(tileset, tileset.opacity);
+    const layer = createThreeDTilesStoreLayer(
+      tileset,
+      tileset.opacity,
+      state.collapsed,
+    );
 
     if (existingLayer) {
       const update = createThreeDTilesLayerUpdate(existingLayer, layer);
@@ -190,27 +218,142 @@ async function hydrateThreeDTilesControlFromStore(
     const url = stringValue(layer.source.url) ?? layer.sourcePath;
     if (!url) continue;
 
-    const layerValues = {
-      beforeId: layer.beforeId,
-      layerName: layer.name,
-    };
-    const id = await runWithThreeDTilesStoreSyncSuspended(() => {
-      return control.loadTileset(url, {
-        altitudeOffset: numberValue(layer.source.altitudeOffset, 0),
-        beforeId: layerValues.beforeId,
-        flyToOnLoad: false,
-        layerName: layerValues.layerName,
-        opacity: layer.opacity,
-        visible: layer.visible,
-      });
-    });
-    if (id) setThreeDTilesOpacity(control, id, layer.opacity);
+    restoreThreeDTilesMapLayer(control, layer, url);
   }
+}
+
+function restoreThreeDTilesMapLayer(
+  control: ThreeDTilesControl,
+  layer: GeoLibreLayer,
+  url: string,
+): void {
+  const map = control.getMap();
+  const controlLayers = getThreeDTilesControlLayers(control);
+  if (!map || !controlLayers) return;
+
+  const id = layer.id;
+  const layerId = restoredThreeDTilesLayerId(layer);
+  const layerName = layer.name || layerNameFromUrl(url, id);
+  const beforeId = validThreeDTilesBeforeId(control, layer.beforeId);
+  const altitudeOffset = numberValue(layer.source.altitudeOffset, 0);
+  const existingTilesets = control
+    .getState()
+    .tilesets.filter((tileset) => tileset.id !== id);
+  const savedCenter = lngLatPairValue(layer.metadata.center);
+  const savedAltitude = optionalNumberValue(layer.metadata.altitude);
+  const status = savedCenter ? "loaded" : "loading";
+
+  const restoredTileset: ThreeDTilesItemState = {
+    id,
+    layerId,
+    layerName,
+    beforeId,
+    tilesetUrl: url,
+    altitudeOffset,
+    opacity: layer.opacity,
+    visible: layer.visible,
+    status,
+    center: savedCenter,
+    altitude: savedAltitude,
+  };
+
+  runWithThreeDTilesStoreSyncSuspended(() => {
+    control.setState({
+      activeTilesetId: id,
+      altitude: restoredTileset.altitude,
+      altitudeOffset,
+      beforeId,
+      center: restoredTileset.center,
+      error: undefined,
+      layerName,
+      opacity: layer.opacity,
+      status,
+      tilesetUrl: url,
+      tilesets: [...existingTilesets, restoredTileset],
+      visible: layer.visible,
+    });
+  });
+
+  if (map.getLayer(layerId)) {
+    moveThreeDTilesMapLayer(map, layerId, beforeId);
+    return;
+  }
+
+  const restoredLayer = new ThreeDTilesLayer({
+    id: layerId,
+    tilesetUrl: url,
+    altitudeOffset,
+    opacity: layer.opacity,
+    visible: layer.visible,
+    ...getThreeDTilesDecoderOptions(control),
+    onLoad: (metadata) => updateThreeDTilesLoaded(control, id, metadata),
+    onError: (error) => updateThreeDTilesError(control, id, error),
+  });
+  controlLayers.set(id, restoredLayer);
+  map.addLayer(restoredLayer, beforeId);
+}
+
+function updateThreeDTilesLoaded(
+  control: ThreeDTilesControl,
+  id: string,
+  metadata: LoadedTilesetMetadata,
+): void {
+  const state = control.getState();
+  const tilesets = state.tilesets.map((tileset) =>
+    tileset.id === id
+      ? {
+          ...tileset,
+          altitude: metadata.altitude,
+          center: metadata.center,
+          error: undefined,
+          status: "loaded" as const,
+        }
+      : tileset,
+  );
+  const activeTileset =
+    tilesets.find((tileset) => tileset.id === state.activeTilesetId) ??
+    tilesets.at(-1);
+
+  control.setState({
+    altitude: activeTileset?.altitude,
+    center: activeTileset?.center,
+    error: activeTileset?.error,
+    status: activeTileset?.status ?? "idle",
+    tilesets,
+  });
+}
+
+function updateThreeDTilesError(
+  control: ThreeDTilesControl,
+  id: string,
+  error: Error,
+): void {
+  const state = control.getState();
+  const message = error.message || "Unable to load 3D Tiles layer.";
+  const tilesets = state.tilesets.map((tileset) =>
+    tileset.id === id
+      ? {
+          ...tileset,
+          error: message,
+          status: "error" as const,
+        }
+      : tileset,
+  );
+  const activeTileset =
+    tilesets.find((tileset) => tileset.id === state.activeTilesetId) ??
+    tilesets.at(-1);
+
+  control.setState({
+    error: activeTileset?.error,
+    status: activeTileset?.status ?? "idle",
+    tilesets,
+  });
 }
 
 function createThreeDTilesStoreLayer(
   tileset: ThreeDTilesItemState,
   opacity = 1,
+  panelCollapsed = true,
 ): GeoLibreLayer {
   const layerName = tileset.layerName || layerNameFromUrl(tileset.tilesetUrl, tileset.id);
   const beforeId = tileset.beforeId;
@@ -240,6 +383,7 @@ function createThreeDTilesStoreLayer(
       identifiable: false,
       layerName,
       nativeLayerIds: [tileset.layerId],
+      panelCollapsed,
       sourceId: tileset.id,
       sourceKind: "3d-tiles-url",
       status: tileset.status,
@@ -414,6 +558,74 @@ function isThreeDTilesStoreSyncSuspended(): boolean {
   return threeDTilesStoreSyncSuspended > 0;
 }
 
+function threeDTilesPanelCollapsedFromLayers(
+  layers: GeoLibreLayer[],
+): boolean {
+  const panelCollapsed = layers.find(
+    (layer) => typeof layer.metadata.panelCollapsed === "boolean",
+  )?.metadata.panelCollapsed;
+  return typeof panelCollapsed === "boolean" ? panelCollapsed : false;
+}
+
+function validThreeDTilesBeforeId(
+  control: ThreeDTilesControl,
+  beforeId: string | undefined,
+): string | undefined {
+  if (!beforeId) return undefined;
+  return control.getMap()?.getLayer(beforeId) ? beforeId : undefined;
+}
+
+function restoredThreeDTilesLayerId(layer: GeoLibreLayer): string {
+  const nativeLayerIds = layer.metadata.nativeLayerIds;
+  if (Array.isArray(nativeLayerIds)) {
+    const layerId = nativeLayerIds.find(
+      (value): value is string => typeof value === "string" && value.trim(),
+    );
+    if (layerId) return layerId;
+  }
+  return `${THREE_D_TILES_LAYER_ID}-${layer.id}`;
+}
+
+function getThreeDTilesControlLayers(
+  control: ThreeDTilesControl,
+): Map<string, ThreeDTilesLayerInstance> | null {
+  const layers = (control as unknown as ThreeDTilesControlInternals)._layers;
+  return layers instanceof Map ? layers : null;
+}
+
+function getThreeDTilesDecoderOptions(
+  control: ThreeDTilesControl,
+): {
+  dracoDecoderPath: string;
+  ktx2TranscoderPath: string;
+} {
+  const options = (control as unknown as ThreeDTilesControlInternals)._options;
+  return {
+    dracoDecoderPath:
+      options?.dracoDecoderPath ?? DEFAULT_DRACO_DECODER_PATH,
+    ktx2TranscoderPath:
+      options?.ktx2TranscoderPath ?? DEFAULT_KTX2_TRANSCODER_PATH,
+  };
+}
+
+function moveThreeDTilesMapLayer(
+  map: ReturnType<ThreeDTilesControl["getMap"]>,
+  layerId: string,
+  beforeId: string | undefined,
+): void {
+  if (!map?.getLayer(layerId)) return;
+  try {
+    if (beforeId && beforeId !== layerId && map.getLayer(beforeId)) {
+      map.moveLayer(layerId, beforeId);
+      return;
+    }
+    map.moveLayer(layerId);
+  } catch {
+    // Style reloads can make ordering transiently unavailable. The next
+    // restore/sync pass will retry with the same saved layer metadata.
+  }
+}
+
 function stringValue(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value : undefined;
 }
@@ -422,6 +634,26 @@ function numberValue(value: unknown, fallback: number): number {
   return typeof value === "number" && Number.isFinite(value)
     ? value
     : fallback;
+}
+
+function optionalNumberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function lngLatPairValue(value: unknown): [number, number] | undefined {
+  if (
+    Array.isArray(value) &&
+    value.length >= 2 &&
+    typeof value[0] === "number" &&
+    typeof value[1] === "number" &&
+    Number.isFinite(value[0]) &&
+    Number.isFinite(value[1])
+  ) {
+    return [value[0], value[1]];
+  }
+  return undefined;
 }
 
 function recordsEqual(

--- a/packages/plugins/src/plugins/maplibre-3d-tiles.ts
+++ b/packages/plugins/src/plugins/maplibre-3d-tiles.ts
@@ -19,6 +19,9 @@ import type {
 
 const threeDTilesControlPosition: GeoLibreMapControlPosition = "top-left";
 const THREE_D_TILES_LAYER_ID = "geolibre-3d-tiles";
+// Keep in sync with the three.js version maplibre-gl-3d-tiles is built
+// against. Only used as a fallback when the control does not expose its own
+// decoder paths (see getThreeDTilesDecoderOptions).
 const THREE_VERSION = "0.184.0";
 const DEFAULT_DRACO_DECODER_PATH = `https://unpkg.com/three@${THREE_VERSION}/examples/jsm/libs/draco/`;
 const DEFAULT_KTX2_TRANSCODER_PATH = `https://unpkg.com/three@${THREE_VERSION}/examples/jsm/libs/basis/`;
@@ -74,11 +77,12 @@ export function restoreThreeDTilesLayers(app: GeoLibreAppAPI): void {
       control.expand();
     }
   });
-  void hydrateThreeDTilesControlFromStore(control, {
-    replaceExisting: true,
-  }).then(() => {
+  try {
+    hydrateThreeDTilesControlFromStore(control, { replaceExisting: true });
     syncThreeDTilesStoreFromControl(control);
-  });
+  } catch (error) {
+    console.error("[GeoLibre] Failed to restore 3D Tiles layers", error);
+  }
 }
 
 function openStandaloneThreeDTilesControl(app: GeoLibreAppAPI): boolean {
@@ -89,9 +93,12 @@ function openStandaloneThreeDTilesControl(app: GeoLibreAppAPI): boolean {
     threeDTilesPanelPinned = true;
     showThreeDTilesControl(control);
     control.expand();
-    void hydrateThreeDTilesControlFromStore(control).then(() => {
+    try {
+      hydrateThreeDTilesControlFromStore(control);
       syncThreeDTilesStoreFromControl(control);
-    });
+    } catch (error) {
+      console.error("[GeoLibre] Failed to open 3D Tiles layer panel", error);
+    }
   }, 0);
 
   return true;
@@ -194,10 +201,10 @@ function syncThreeDTilesStoreFromControl(control: ThreeDTilesControl): void {
   }
 }
 
-async function hydrateThreeDTilesControlFromStore(
+function hydrateThreeDTilesControlFromStore(
   control: ThreeDTilesControl,
   options: { replaceExisting?: boolean } = {},
-): Promise<void> {
+): void {
   const layers = useAppStore
     .getState()
     .layers.filter(isThreeDTilesControlLayer);
@@ -289,6 +296,9 @@ function restoreThreeDTilesMapLayer(
     onLoad: (metadata) => updateThreeDTilesLoaded(control, id, metadata),
     onError: (error) => updateThreeDTilesError(control, id, error),
   });
+  // ThreeDTilesControl keys its internal `_layers` map by tileset id (see
+  // loadTileset/removeTileset in the library), so removeTileset(id) reaches
+  // this entry. The ThreeDTilesLayer itself carries the native map layer id.
   controlLayers.set(id, restoredLayer);
   map.addLayer(restoredLayer, beforeId);
 }
@@ -432,6 +442,9 @@ function resetThreeDTilesControl(control: ThreeDTilesControl | null): void {
   threeDTilesPanelPinned = false;
   threeDTilesControlMounted = false;
   threeDTilesControl = null;
+  // Clear the suspension counter so a control torn down mid-hydration cannot
+  // leave its successor permanently suppressing store sync events.
+  threeDTilesStoreSyncSuspended = 0;
 }
 
 function isThreeDTilesControlLayer(layer: GeoLibreLayer): boolean {
@@ -564,7 +577,9 @@ function threeDTilesPanelCollapsedFromLayers(
   const panelCollapsed = layers.find(
     (layer) => typeof layer.metadata.panelCollapsed === "boolean",
   )?.metadata.panelCollapsed;
-  return typeof panelCollapsed === "boolean" ? panelCollapsed : false;
+  // Default to collapsed to match the control's initial state, so projects
+  // saved before panelCollapsed existed do not pop the panel open on load.
+  return typeof panelCollapsed === "boolean" ? panelCollapsed : true;
 }
 
 function validThreeDTilesBeforeId(
@@ -591,7 +606,13 @@ function getThreeDTilesControlLayers(
   control: ThreeDTilesControl,
 ): Map<string, ThreeDTilesLayerInstance> | null {
   const layers = (control as unknown as ThreeDTilesControlInternals)._layers;
-  return layers instanceof Map ? layers : null;
+  if (!(layers instanceof Map)) {
+    console.warn(
+      "[GeoLibre] ThreeDTilesControl._layers unavailable; skipping 3D Tiles restore. The library internals may have changed.",
+    );
+    return null;
+  }
+  return layers;
 }
 
 function getThreeDTilesDecoderOptions(
@@ -601,6 +622,15 @@ function getThreeDTilesDecoderOptions(
   ktx2TranscoderPath: string;
 } {
   const options = (control as unknown as ThreeDTilesControlInternals)._options;
+  if (!options?.dracoDecoderPath || !options?.ktx2TranscoderPath) {
+    // The control normally exposes its configured decoder paths via _options.
+    // When it does not, fall back to a CDN build of three pinned to the
+    // version maplibre-gl-3d-tiles depends on (THREE_VERSION). This is a
+    // network-dependent supply-chain fallback, so surface it for diagnosis.
+    console.warn(
+      `[GeoLibre] ThreeDTilesControl decoder paths unavailable; falling back to unpkg three@${THREE_VERSION}. Compressed tilesets will fail offline.`,
+    );
+  }
   return {
     dracoDecoderPath:
       options?.dracoDecoderPath ?? DEFAULT_DRACO_DECODER_PATH,
@@ -650,7 +680,9 @@ function lngLatPairValue(value: unknown): [number, number] | undefined {
     typeof value[0] === "number" &&
     typeof value[1] === "number" &&
     Number.isFinite(value[0]) &&
-    Number.isFinite(value[1])
+    Number.isFinite(value[1]) &&
+    Math.abs(value[0]) <= 180 &&
+    Math.abs(value[1]) <= 90
   ) {
     return [value[0], value[1]];
   }

--- a/packages/plugins/src/plugins/maplibre-3d-tiles.ts
+++ b/packages/plugins/src/plugins/maplibre-3d-tiles.ts
@@ -32,27 +32,35 @@ let threeDTilesControl: ThreeDTilesControl | null = null;
 let threeDTilesControlMounted = false;
 let threeDTilesPanelPinned = false;
 let threeDTilesStoreUnsubscribe: (() => void) | null = null;
+let threeDTilesStoreSyncSuspended = 0;
 
 export function openThreeDTilesLayerPanel(app: GeoLibreAppAPI): void {
   openStandaloneThreeDTilesControl(app);
 }
 
+export function restoreThreeDTilesLayers(app: GeoLibreAppAPI): void {
+  const layers = useAppStore
+    .getState()
+    .layers.filter(isThreeDTilesControlLayer);
+  if (layers.length === 0) return;
+
+  const control = runWithThreeDTilesStoreSyncSuspended(() =>
+    ensureThreeDTilesControl(app),
+  );
+  if (!control) return;
+
+  hideThreeDTilesControl(control);
+  void hydrateThreeDTilesControlFromStore(control, {
+    replaceExisting: true,
+  }).then(() => {
+    syncThreeDTilesStoreFromControl(control);
+  });
+}
+
 function openStandaloneThreeDTilesControl(app: GeoLibreAppAPI): boolean {
-  threeDTilesControl ??= createThreeDTilesControl();
+  const control = ensureThreeDTilesControl(app);
+  if (!control) return false;
 
-  if (!threeDTilesControlMounted) {
-    const added = app.addMapControl(
-      threeDTilesControl,
-      threeDTilesControlPosition,
-    );
-    if (!added) {
-      resetThreeDTilesControl(threeDTilesControl);
-      return false;
-    }
-    threeDTilesControlMounted = true;
-  }
-
-  const control = threeDTilesControl;
   window.setTimeout(() => {
     threeDTilesPanelPinned = true;
     showThreeDTilesControl(control);
@@ -65,10 +73,32 @@ function openStandaloneThreeDTilesControl(app: GeoLibreAppAPI): boolean {
   return true;
 }
 
+function ensureThreeDTilesControl(
+  app: GeoLibreAppAPI,
+): ThreeDTilesControl | null {
+  threeDTilesControl ??= createThreeDTilesControl();
+
+  if (!threeDTilesControlMounted) {
+    const added = app.addMapControl(
+      threeDTilesControl,
+      threeDTilesControlPosition,
+    );
+    if (!added) {
+      resetThreeDTilesControl(threeDTilesControl);
+      return null;
+    }
+    threeDTilesControlMounted = true;
+  }
+
+  return threeDTilesControl;
+}
+
 function createThreeDTilesControl(): ThreeDTilesControl {
   const control = new ThreeDTilesControl(THREE_D_TILES_OPTIONS);
   const syncHandler: ThreeDTilesControlEventHandler = () => {
-    syncThreeDTilesStoreFromControl(control);
+    if (!isThreeDTilesStoreSyncSuspended()) {
+      syncThreeDTilesStoreFromControl(control);
+    }
     keepThreeDTilesPanelExpanded(control);
     // The panel may render after showThreeDTilesControl ran, so retry the
     // (idempotent) handler installation whenever the control state changes.
@@ -138,12 +168,24 @@ function syncThreeDTilesStoreFromControl(control: ThreeDTilesControl): void {
 
 async function hydrateThreeDTilesControlFromStore(
   control: ThreeDTilesControl,
+  options: { replaceExisting?: boolean } = {},
 ): Promise<void> {
-  if (control.getState().tilesets.length > 0) return;
-
   const layers = useAppStore
     .getState()
     .layers.filter(isThreeDTilesControlLayer);
+  if (layers.length === 0) return;
+
+  const tilesets = control.getState().tilesets;
+  if (tilesets.length > 0) {
+    if (!options.replaceExisting) return;
+
+    runWithThreeDTilesStoreSyncSuspended(() => {
+      for (const tileset of tilesets) {
+        control.removeTileset(tileset.id);
+      }
+    });
+  }
+
   for (const layer of layers) {
     const url = stringValue(layer.source.url) ?? layer.sourcePath;
     if (!url) continue;
@@ -152,13 +194,15 @@ async function hydrateThreeDTilesControlFromStore(
       beforeId: layer.beforeId,
       layerName: layer.name,
     };
-    const id = await control.loadTileset(url, {
-      altitudeOffset: numberValue(layer.source.altitudeOffset, 0),
-      beforeId: layerValues.beforeId,
-      flyToOnLoad: false,
-      layerName: layerValues.layerName,
-      opacity: layer.opacity,
-      visible: layer.visible,
+    const id = await runWithThreeDTilesStoreSyncSuspended(() => {
+      return control.loadTileset(url, {
+        altitudeOffset: numberValue(layer.source.altitudeOffset, 0),
+        beforeId: layerValues.beforeId,
+        flyToOnLoad: false,
+        layerName: layerValues.layerName,
+        opacity: layer.opacity,
+        visible: layer.visible,
+      });
     });
     if (id) setThreeDTilesOpacity(control, id, layer.opacity);
   }
@@ -352,7 +396,22 @@ function setThreeDTilesOpacity(
   id: string,
   opacity: number,
 ): void {
-  control.setOpacity(opacity, id, false);
+  runWithThreeDTilesStoreSyncSuspended(() => {
+    control.setOpacity(opacity, id, false);
+  });
+}
+
+function runWithThreeDTilesStoreSyncSuspended<T>(callback: () => T): T {
+  threeDTilesStoreSyncSuspended += 1;
+  try {
+    return callback();
+  } finally {
+    threeDTilesStoreSyncSuspended -= 1;
+  }
+}
+
+function isThreeDTilesStoreSyncSuspended(): boolean {
+  return threeDTilesStoreSyncSuspended > 0;
 }
 
 function stringValue(value: unknown): string | undefined {


### PR DESCRIPTION
## Summary
- Restore persisted 3D Tiles layers on map ready when a project loads, instead of only when the panel is opened
- Suspend store sync during hydration so intermediate control events do not clobber the persisted layer state (opacity, visibility, order)
- Guard moveLayer in layer-sync against layers not managed by the MapLibre style (3D Tiles layers are rendered by the control)

## Test plan
- [ ] Add a 3D Tiles layer, save the project, reopen it, and verify the layer is re-added to the map with the saved opacity and visibility
- [ ] Open the 3D Tiles panel after project load and verify it lists the restored tilesets without duplicates
- [ ] Reorder layers with a 3D Tiles layer present and verify no moveLayer console errors