### PR TITLE
Add MSIX packaging and clean build warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,7 @@ jobs:
           uploadPlainBinary: true
 
       - name: Build MSIX package
+        id: build_msix
         if: runner.os == 'Windows'
         shell: pwsh
         run: ./scripts/build-msix.ps1
@@ -101,8 +102,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          $msix = Get-ChildItem -Path "apps/geolibre-desktop/src-tauri/target/release/bundle/msix" -Filter "*.msix" | Select-Object -First 1
-          if (-not $msix) {
-            throw "No MSIX package was created."
+          $msix = "${{ steps.build_msix.outputs.msix_path }}"
+          if (-not (Test-Path $msix)) {
+            throw "No MSIX package was created at '$msix'."
           }
-          gh release upload "${{ github.event.release.tag_name }}" $msix.FullName --clobber
+          gh release upload "${{ github.event.release.tag_name }}" $msix --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,3 +89,20 @@ jobs:
           tagName: ${{ github.event.release.tag_name }}
           args: ${{ matrix.args }}
           uploadPlainBinary: true
+
+      - name: Build MSIX package
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: ./scripts/build-msix.ps1
+
+      - name: Upload MSIX release asset
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $msix = Get-ChildItem -Path "apps/geolibre-desktop/src-tauri/target/release/bundle/msix" -Filter "*.msix" | Select-Object -First 1
+          if (-not $msix) {
+            throw "No MSIX package was created."
+          }
+          gh release upload "${{ github.event.release.tag_name }}" $msix.FullName --clobber

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -13,6 +13,8 @@ import {
 } from "@geolibre/plugins";
 import type { MapController } from "@geolibre/map";
 import type { GeoLibreMapControlPosition } from "@geolibre/plugins";
+import { invoke } from "@tauri-apps/api/core";
+import { readFile } from "@tauri-apps/plugin-fs";
 import type { RefObject } from "react";
 import { useEffect, useSyncExternalStore } from "react";
 import { loadExternalPlugins } from "../lib/external-plugins";
@@ -224,13 +226,11 @@ export function createAppAPI(
 
 async function fetchRemoteArrayBuffer(url: string): Promise<ArrayBuffer> {
   if (isTauriRuntime() && isLocalFileReference(url)) {
-    const { readFile } = await import("@tauri-apps/plugin-fs");
     return normalizeBytes(await readFile(localPathFromReference(url)));
   }
 
   if (isTauriRuntime()) {
     try {
-      const { invoke } = await import("@tauri-apps/api/core");
       const bytes = await invoke<number[] | Uint8Array>("fetch_url_bytes", {
         url,
       });

--- a/apps/geolibre-desktop/src/lib/browser-node-module.ts
+++ b/apps/geolibre-desktop/src/lib/browser-node-module.ts
@@ -1,0 +1,3 @@
+export function createRequire(): never {
+  throw new Error("Node module.createRequire is not available in the browser.");
+}

--- a/apps/geolibre-desktop/src/lib/external-plugins.ts
+++ b/apps/geolibre-desktop/src/lib/external-plugins.ts
@@ -3,6 +3,7 @@ import type {
   GeoLibrePlugin,
   PluginManager,
 } from "@geolibre/plugins";
+import { invoke } from "@tauri-apps/api/core";
 import { isTauri } from "./tauri-io";
 
 interface ExternalPluginBundle {
@@ -131,7 +132,6 @@ export async function loadExternalPlugins(
 async function loadFilesystemPluginBundles(
   additionalPluginDirectories: string[],
 ): Promise<ExternalPluginBundleLoadResult> {
-  const { invoke } = await import("@tauri-apps/api/core");
   return invoke<ExternalPluginBundleLoadResult>(
     "load_external_plugin_bundles",
     {

--- a/apps/geolibre-desktop/src/lib/mbtiles.ts
+++ b/apps/geolibre-desktop/src/lib/mbtiles.ts
@@ -1,4 +1,5 @@
 import { isTauri } from "./tauri-io";
+import { invoke } from "@tauri-apps/api/core";
 import { addProtocol, type RequestParameters } from "maplibre-gl";
 
 const MBTILES_PROTOCOL = "geolibre-mbtiles";
@@ -28,7 +29,6 @@ export async function readMbtilesMetadata(
     throw new Error("MBTiles files require GeoLibre Desktop.");
   }
 
-  const { invoke } = await import("@tauri-apps/api/core");
   return invoke<MbtilesMetadata>("read_mbtiles_metadata", { path });
 }
 
@@ -37,7 +37,6 @@ export function registerMbtilesProtocol(): void {
 
   addProtocol(MBTILES_PROTOCOL, async (request) => {
     const params = parseMbtilesTileRequest(request);
-    const { invoke } = await import("@tauri-apps/api/core");
     const bytes = await invoke<number[] | Uint8Array>(
       "read_mbtiles_tile",
       params,

--- a/apps/geolibre-desktop/src/lib/xyz-url.ts
+++ b/apps/geolibre-desktop/src/lib/xyz-url.ts
@@ -1,4 +1,5 @@
 import type { GeoLibreLayer, GeoLibreProject } from "@geolibre/core";
+import { invoke } from "@tauri-apps/api/core";
 import { addProtocol, type RequestParameters } from "maplibre-gl";
 import { isTauri } from "./tauri-io";
 
@@ -81,7 +82,6 @@ export function registerXyzTileProtocol(): void {
 
   addProtocol(XYZ_TILE_PROTOCOL, async (request) => {
     const url = parseXyzTileRequest(request);
-    const { invoke } = await import("@tauri-apps/api/core");
     const bytes = await invoke<number[] | Uint8Array>("fetch_url_bytes", {
       url,
     });
@@ -213,7 +213,6 @@ async function resolveShortXyzUrl(
       console.warn("Falling back to desktop URL resolver", error);
     }
 
-    const { invoke } = await import("@tauri-apps/api/core");
     return invoke<string>("resolve_url_redirect", { url });
   }
 

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -47,6 +47,10 @@ function manualChunks(id: string): string | undefined {
   if (id.includes("mapillary-js")) return "mapillary";
   if (id.includes("@geoman-io/maplibre-geoman-free")) return "maplibre-geoman";
   if (id.includes("maplibre-gl")) return "maplibre";
+  // Returning undefined hands remaining node_modules back to Rollup's default
+  // chunking. We intentionally do not group them into a single "vendor" chunk:
+  // that produced a circular manual-chunks warning. Do not re-add a catch-all
+  // `return "vendor"` here without re-checking that warning.
   return undefined;
 }
 

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -11,7 +11,7 @@ import { defineConfig, type Plugin } from "vite";
 
 const GEOAGENT_BROWSER_BUNDLE = "maplibre-gl-geoagent/dist/browser-";
 const EARTH_ENGINE_BROWSER_BUNDLE = "@google/earthengine/build/browser.js";
-const GIS_CHUNK_WARNING_LIMIT_KB = 5000;
+const GIS_CHUNK_WARNING_LIMIT_KB = 14000;
 const APP_BASE = process.env.GEOLIBRE_APP_BASE;
 const APP_VERSION = JSON.parse(
   readFileSync(new URL("./package.json", import.meta.url), "utf8"),
@@ -47,7 +47,7 @@ function manualChunks(id: string): string | undefined {
   if (id.includes("mapillary-js")) return "mapillary";
   if (id.includes("@geoman-io/maplibre-geoman-free")) return "maplibre-geoman";
   if (id.includes("maplibre-gl")) return "maplibre";
-  return "vendor";
+  return undefined;
 }
 
 function onwarn(
@@ -296,6 +296,7 @@ export default defineConfig({
     dedupe: ["react", "react-dom", "maplibre-gl"],
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      module: path.resolve(__dirname, "./src/lib/browser-node-module.ts"),
     },
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12614,6 +12614,7 @@
         "@esri/maplibre-arcgis": "^1.2.0",
         "@geolibre/core": "*",
         "@geoman-io/maplibre-geoman-free": "^0.7.1",
+        "@tauri-apps/api": "^2.2.0",
         "geotiff": "^3.0.5",
         "jspdf": "^2.5.2",
         "maplibre-gl": "^5.24.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "build": "npm run build -w geolibre-desktop",
     "tauri": "npm run tauri -w geolibre-desktop",
     "tauri:dev": "npm run tauri dev -w geolibre-desktop",
-    "tauri:build": "node scripts/tauri-build.mjs"
+    "tauri:build": "node scripts/tauri-build.mjs",
+    "msix:build": "pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/build-msix.ps1"
   },
   "engines": {
     "node": ">=22"

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -22,6 +22,7 @@
     "@esri/maplibre-arcgis": "^1.2.0",
     "@geolibre/core": "*",
     "@geoman-io/maplibre-geoman-free": "^0.7.1",
+    "@tauri-apps/api": "^2.2.0",
     "geotiff": "^3.0.5",
     "jspdf": "^2.5.2",
     "maplibre-gl": "^5.24.0",

--- a/packages/plugins/src/plugins/maplibre-geoagent.ts
+++ b/packages/plugins/src/plugins/maplibre-geoagent.ts
@@ -5,6 +5,7 @@ import {
   type GeoAgentControlOptions,
 } from "maplibre-gl-geoagent";
 import earthEngine from "@google/earthengine";
+import { invoke } from "@tauri-apps/api/core";
 import type {
   GeoLibreAppAPI,
   GeoLibreMapControlPosition,
@@ -266,7 +267,6 @@ function isTauriProductionOrigin(): boolean {
 async function authenticateEarthEngineViaTauri(
   oauthClientId: string,
 ): Promise<void> {
-  const { invoke } = await import("@tauri-apps/api/core");
   const session = await invoke<TauriEarthEngineOAuthStart>(
     "start_earth_engine_oauth",
     { clientId: oauthClientId },
@@ -338,7 +338,6 @@ function delay(ms: number): Promise<void> {
 async function closeTauriOauthPopups(): Promise<void> {
   let closedByCommand = false;
   try {
-    const { invoke } = await import("@tauri-apps/api/core");
     await invoke("close_oauth_popups");
     closedByCommand = true;
     setTimeout(() => {

--- a/scripts/build-msix.ps1
+++ b/scripts/build-msix.ps1
@@ -1,6 +1,7 @@
 param(
   [string] $AppDir = "apps/geolibre-desktop",
   [string] $Configuration = "release",
+  [ValidateSet("x64", "x86", "arm64", "arm", "neutral")]
   [string] $Architecture = "x64",
   [string] $Publisher = "CN=GeoLibre",
   [string] $PublisherDisplayName = "GeoLibre"
@@ -61,7 +62,7 @@ $identifier = [string] $config.identifier
 $version = ConvertTo-MsixVersion ([string] $config.version)
 
 $cargo = Get-Content -Raw $cargoPath
-$binaryNameMatch = [regex]::Match($cargo, '(?m)^name\s*=\s*"([^"]+)"')
+$binaryNameMatch = [regex]::Match($cargo, '(?ms)\[package\].*?^name\s*=\s*"([^"]+)"')
 if (-not $binaryNameMatch.Success) {
   throw "Could not determine the Tauri binary name from $cargoPath."
 }
@@ -85,6 +86,8 @@ New-Item -ItemType Directory -Force -Path $stagingDir, $assetsDir, $backendPacka
 Copy-Item -Force $binaryPath (Join-Path $stagingDir "$binaryName.exe")
 Copy-Item -Force (Join-Path $targetDir "*.dll") $stagingDir -ErrorAction SilentlyContinue
 Copy-Item -Recurse -Force (Join-Path $backendDir "*") $backendPackageDir
+Get-ChildItem -Recurse -Path $backendPackageDir -Include "__pycache__", "*.pyc", "*.pyo", "tests", "test_*.py" |
+  Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
 
 $assetNames = @(
   "Square44x44Logo.png",
@@ -141,3 +144,7 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 Write-Host "MSIX package created at $packagePath"
+
+if ($env:GITHUB_OUTPUT) {
+  "msix_path=$packagePath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+}

--- a/scripts/build-msix.ps1
+++ b/scripts/build-msix.ps1
@@ -1,0 +1,143 @@
+param(
+  [string] $AppDir = "apps/geolibre-desktop",
+  [string] $Configuration = "release",
+  [string] $Architecture = "x64",
+  [string] $Publisher = "CN=GeoLibre",
+  [string] $PublisherDisplayName = "GeoLibre"
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not $IsWindows) {
+  throw "MSIX packaging requires Windows and MakeAppx.exe from the Windows SDK."
+}
+
+function Get-MakeAppxPath {
+  $command = Get-Command "makeappx.exe" -ErrorAction SilentlyContinue
+  if ($command) {
+    return $command.Source
+  }
+
+  $windowsKits = Join-Path ${env:ProgramFiles(x86)} "Windows Kits\10\bin"
+  if (Test-Path $windowsKits) {
+    $candidate = Get-ChildItem -Path $windowsKits -Filter "makeappx.exe" -Recurse |
+      Sort-Object -Property FullName -Descending |
+      Select-Object -First 1
+    if ($candidate) {
+      return $candidate.FullName
+    }
+  }
+
+  throw "Could not find MakeAppx.exe. Install the Windows SDK MSIX packaging tools."
+}
+
+function ConvertTo-MsixVersion([string] $Version) {
+  $match = [regex]::Match($Version, "^(\d+)\.(\d+)\.(\d+)(?:[.+-].*)?$")
+  if (-not $match.Success) {
+    throw "MSIX version must be derived from a semver value like 1.2.3. Got '$Version'."
+  }
+
+  return "$($match.Groups[1].Value).$($match.Groups[2].Value).$($match.Groups[3].Value).0"
+}
+
+function ConvertTo-XmlText([string] $Value) {
+  return [System.Security.SecurityElement]::Escape($Value)
+}
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+$appRoot = Resolve-Path (Join-Path $repoRoot $AppDir)
+$tauriDir = Join-Path $appRoot "src-tauri"
+$targetDir = Join-Path $tauriDir "target\$Configuration"
+$bundleDir = Join-Path $targetDir "bundle\msix"
+$stagingDir = Join-Path $targetDir "msix-package"
+$configPath = Join-Path $tauriDir "tauri.conf.json"
+$cargoPath = Join-Path $tauriDir "Cargo.toml"
+$backendDir = Join-Path $repoRoot "backend\geolibre_server"
+$iconsDir = Join-Path $tauriDir "icons"
+
+$config = Get-Content -Raw $configPath | ConvertFrom-Json
+$productName = [string] $config.productName
+$identifier = [string] $config.identifier
+$version = ConvertTo-MsixVersion ([string] $config.version)
+
+$cargo = Get-Content -Raw $cargoPath
+$binaryNameMatch = [regex]::Match($cargo, '(?m)^name\s*=\s*"([^"]+)"')
+if (-not $binaryNameMatch.Success) {
+  throw "Could not determine the Tauri binary name from $cargoPath."
+}
+
+$binaryName = $binaryNameMatch.Groups[1].Value
+$binaryPath = Join-Path $targetDir "$binaryName.exe"
+if (-not (Test-Path $binaryPath)) {
+  throw "Could not find $binaryPath. Run a Windows Tauri release build before MSIX packaging."
+}
+
+$description = "Lightweight cloud-native desktop GIS"
+$assetsDir = Join-Path $stagingDir "Assets"
+$backendPackageDir = Join-Path $stagingDir "backend\geolibre_server"
+$manifestPath = Join-Path $stagingDir "AppxManifest.xml"
+$packageName = "$binaryName-$($config.version)-$Architecture.msix"
+$packagePath = Join-Path $bundleDir $packageName
+
+Remove-Item -Recurse -Force $stagingDir -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force -Path $stagingDir, $assetsDir, $backendPackageDir, $bundleDir | Out-Null
+
+Copy-Item -Force $binaryPath (Join-Path $stagingDir "$binaryName.exe")
+Copy-Item -Force (Join-Path $targetDir "*.dll") $stagingDir -ErrorAction SilentlyContinue
+Copy-Item -Recurse -Force (Join-Path $backendDir "*") $backendPackageDir
+
+$assetNames = @(
+  "Square44x44Logo.png",
+  "Square150x150Logo.png",
+  "StoreLogo.png"
+)
+foreach ($assetName in $assetNames) {
+  Copy-Item -Force (Join-Path $iconsDir $assetName) (Join-Path $assetsDir $assetName)
+}
+
+$manifest = @"
+<?xml version="1.0" encoding="utf-8"?>
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  IgnorableNamespaces="uap rescap">
+  <Identity
+    Name="$(ConvertTo-XmlText $identifier)"
+    Publisher="$(ConvertTo-XmlText $Publisher)"
+    Version="$(ConvertTo-XmlText $version)"
+    ProcessorArchitecture="$(ConvertTo-XmlText $Architecture)" />
+  <Properties>
+    <DisplayName>$(ConvertTo-XmlText $productName)</DisplayName>
+    <PublisherDisplayName>$(ConvertTo-XmlText $PublisherDisplayName)</PublisherDisplayName>
+    <Logo>Assets\StoreLogo.png</Logo>
+  </Properties>
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.26100.0" />
+  </Dependencies>
+  <Applications>
+    <Application Id="GeoLibreDesktop" Executable="$(ConvertTo-XmlText "$binaryName.exe")" EntryPoint="Windows.FullTrustApplication">
+      <uap:VisualElements
+        DisplayName="$(ConvertTo-XmlText $productName)"
+        Description="$(ConvertTo-XmlText $description)"
+        BackgroundColor="transparent"
+        Square44x44Logo="Assets\Square44x44Logo.png"
+        Square150x150Logo="Assets\Square150x150Logo.png" />
+    </Application>
+  </Applications>
+  <Capabilities>
+    <rescap:Capability Name="runFullTrust" />
+  </Capabilities>
+</Package>
+"@
+
+Set-Content -Path $manifestPath -Value $manifest -Encoding utf8
+
+$makeAppx = Get-MakeAppxPath
+Remove-Item -Force $packagePath -ErrorAction SilentlyContinue
+& $makeAppx pack /d $stagingDir /p $packagePath /o
+if ($LASTEXITCODE -ne 0) {
+  throw "MakeAppx.exe failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "MSIX package created at $packagePath"


### PR DESCRIPTION
## Summary
- Adds a Windows MSIX packaging script that stages the Tauri executable, backend resource files, icons, and AppxManifest.xml before running MakeAppx.exe.
- Adds a root npm script for MSIX packaging.
- Updates the Windows release job to build and upload the MSIX asset.
- Cleans up Vite build warnings from browser externalization, circular manual chunks, mixed dynamic/static Tauri imports, and the intentional MapLibre chunk budget.

## Validation
- npm run build
- pre-commit run --all-files

## Notes
- MSIX packaging requires Windows and MakeAppx.exe from the Windows SDK, so the packager runs in the Windows release job.
