### PR TITLE
feat: register external native GeoJSON layers from local directories

### DIFF
--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -1,4 +1,8 @@
-import { useAppStore } from "@geolibre/core";
+import {
+  DEFAULT_LAYER_STYLE,
+  type GeoLibreLayer,
+  useAppStore,
+} from "@geolibre/core";
 import {
   maplibreBasemapControlPlugin,
   maplibreComponentsPlugin,
@@ -12,9 +16,13 @@ import {
   PluginManager,
 } from "@geolibre/plugins";
 import type { MapController } from "@geolibre/map";
-import type { GeoLibreMapControlPosition } from "@geolibre/plugins";
+import type {
+  GeoLibreExternalNativeLayerRegistration,
+  GeoLibreMapControlPosition,
+} from "@geolibre/plugins";
 import { invoke } from "@tauri-apps/api/core";
-import { readFile } from "@tauri-apps/plugin-fs";
+import { open } from "@tauri-apps/plugin-dialog";
+import { readDir, readFile } from "@tauri-apps/plugin-fs";
 import type { RefObject } from "react";
 import { useEffect, useSyncExternalStore } from "react";
 import { loadExternalPlugins } from "../lib/external-plugins";
@@ -39,6 +47,45 @@ manager.registerAll([
   maplibreSwipePlugin,
   maplibreComponentsPlugin,
 ]);
+
+function createExternalNativeStoreLayer(
+  registration: GeoLibreExternalNativeLayerRegistration,
+  existing?: GeoLibreLayer,
+): GeoLibreLayer {
+  const sourceIds = registration.sourceIds?.length
+    ? registration.sourceIds
+    : registration.sourceId
+      ? [registration.sourceId]
+      : [];
+  const sourceId = registration.sourceId ?? sourceIds[0];
+
+  return {
+    id: registration.id,
+    name: registration.name,
+    type: "geojson",
+    source: {
+      type: "geojson",
+      ...(sourceId ? { sourceId } : {}),
+    },
+    visible: existing?.visible ?? true,
+    opacity: existing?.opacity ?? registration.opacity ?? 1,
+    style: {
+      ...DEFAULT_LAYER_STYLE,
+      ...(registration.style ?? {}),
+      ...(existing?.style ?? {}),
+    } as GeoLibreLayer["style"],
+    metadata: {
+      ...(existing?.metadata ?? {}),
+      ...(registration.metadata ?? {}),
+      externalNativeLayer: true,
+      nativeLayerIds: registration.nativeLayerIds,
+      sourceIds,
+      ...(sourceId ? { sourceId } : {}),
+    },
+    geojson: registration.geojson ?? existing?.geojson,
+    sourcePath: registration.sourcePath ?? existing?.sourcePath,
+  };
+}
 
 let externalPluginsLoaded = false;
 let externalPluginsLoadPromise: Promise<void> | null = null;
@@ -197,6 +244,27 @@ export function createAppAPI(
     fitBounds: (bounds: [number, number, number, number]) =>
       mapControllerRef?.current?.fitBounds(bounds),
     getMap: () => mapControllerRef?.current?.getMap() ?? null,
+    pickLocalDirectoryFiles,
+    registerExternalNativeLayer: (
+      registration: GeoLibreExternalNativeLayerRegistration,
+    ) => {
+      const state = useAppStore.getState();
+      const existing = state.layers.find(
+        (layer) => layer.id === registration.id,
+      );
+      const layer = createExternalNativeStoreLayer(registration, existing);
+      if (existing) {
+        state.updateLayer(layer.id, layer);
+      } else {
+        state.addLayer(layer);
+      }
+    },
+    unregisterExternalNativeLayer: (id: string) => {
+      const state = useAppStore.getState();
+      if (state.layers.some((layer) => layer.id === id)) {
+        state.removeLayer(id);
+      }
+    },
     addMapControl: (
       control: Parameters<MapController["addControl"]>[0],
       position?: Parameters<MapController["addControl"]>[1],
@@ -250,6 +318,54 @@ async function fetchRemoteArrayBuffer(url: string): Promise<ArrayBuffer> {
     if (!isLocalDevHost()) throw error;
     return fetchDevRasterProxy(url);
   }
+}
+
+async function pickLocalDirectoryFiles(): Promise<File[] | null> {
+  if (!isTauriRuntime()) return null;
+  const selected = await open({
+    directory: true,
+    multiple: false,
+    recursive: true,
+  });
+  if (typeof selected !== "string") return null;
+  return readTauriDirectoryFiles(selected);
+}
+
+async function readTauriDirectoryFiles(rootPath: string): Promise<File[]> {
+  const rootName = localNameFromPath(rootPath) || "dataset";
+  const files: File[] = [];
+
+  async function walk(directoryPath: string, relativePrefix: string): Promise<void> {
+    const entries = await readDir(directoryPath);
+    for (const entry of entries) {
+      const entryPath = joinLocalPath(directoryPath, entry.name);
+      const relativePath = `${relativePrefix}${entry.name}`;
+      if (entry.isDirectory) {
+        await walk(entryPath, `${relativePath}/`);
+        continue;
+      }
+      if (!entry.isFile) continue;
+      const bytes = await readFile(entryPath);
+      const file = new File([bytes], entry.name);
+      Object.defineProperty(file, "webkitRelativePath", {
+        configurable: true,
+        value: `${rootName}/${relativePath}`,
+      });
+      files.push(file);
+    }
+  }
+
+  await walk(rootPath, "");
+  return files;
+}
+
+function joinLocalPath(parent: string, child: string): string {
+  if (parent.endsWith("/") || parent.endsWith("\\")) return `${parent}${child}`;
+  return `${parent}/${child}`;
+}
+
+function localNameFromPath(path: string): string {
+  return path.split(/[/\\]/).filter(Boolean).pop() ?? "";
 }
 
 function isLocalFileReference(value: string): boolean {

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -334,8 +334,11 @@ async function pickLocalDirectoryFiles(): Promise<File[] | null> {
 async function readTauriDirectoryFiles(rootPath: string): Promise<File[]> {
   const rootName = localNameFromPath(rootPath) || "dataset";
   const files: File[] = [];
+  const visited = new Set<string>();
 
   async function walk(directoryPath: string, relativePrefix: string): Promise<void> {
+    if (visited.has(directoryPath)) return;
+    visited.add(directoryPath);
     const entries = await readDir(directoryPath);
     for (const entry of entries) {
       const entryPath = joinLocalPath(directoryPath, entry.name);

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -144,6 +144,8 @@ function syncExternalNativeLayer(
     return;
   }
 
+  ensureExternalGeoJsonNativeLayer(map, layer, nativeLayerIds, beforeId);
+
   const nativeFillLayerSpecs = nativeLayerIds
     .map((nativeLayerId) => getStyleLayerSpec(map, nativeLayerId))
     .filter(isFillStyleLayerSpec);
@@ -207,6 +209,112 @@ function syncExternalNativeLayer(
 
     moveLayer(map, nativeLayerId, beforeId);
   }
+}
+
+function ensureExternalGeoJsonNativeLayer(
+  map: maplibregl.Map,
+  layer: GeoLibreLayer,
+  nativeLayerIds: string[],
+  beforeId?: string,
+): void {
+  if (!layer.geojson || nativeLayerIds.every((id) => map.getLayer(id))) return;
+
+  const nativeSourceId =
+    getExternalSourceIds(layer)[0] ??
+    stringSource(layer.source.sourceId) ??
+    sourceIdFromNativeLayerId(nativeLayerIds[0]) ??
+    sourceId(layer.id);
+
+  if (!map.getSource(nativeSourceId)) {
+    map.addSource(nativeSourceId, {
+      type: "geojson",
+      data: layer.geojson,
+    });
+  } else {
+    (map.getSource(nativeSourceId) as maplibregl.GeoJSONSource).setData(
+      layer.geojson,
+    );
+  }
+
+  const visibility = layer.visible ? "visible" : "none";
+  const zoomRange = styleLayerZoomRange(layer.style);
+  const geometryType = stringMetadata(layer.metadata.geometryType);
+  const symbolLayer = layer.metadata.symbolLayer === true;
+  const profile = detectGeometryProfile(layer.geojson);
+  const primaryLayerId = nativeLayerIds[0] ?? layer.id;
+
+  if (symbolLayer) {
+    ensureLayer(
+      map,
+      primaryLayerId,
+      {
+        id: primaryLayerId,
+        type: "symbol",
+        source: nativeSourceId,
+        ...zoomRange,
+        layout: {
+          "text-allow-overlap": true,
+          "text-field": "*",
+          "text-ignore-placement": true,
+          "text-size": Math.max(8, styleValue(layer.style, "circleRadius") * 2.5),
+          visibility,
+        },
+        paint: {
+          "text-color": styleValue(layer.style, "fillColor"),
+          "text-halo-color": styleValue(layer.style, "strokeColor"),
+          "text-halo-width": styleValue(layer.style, "strokeWidth"),
+          "text-opacity": layer.opacity,
+        },
+      },
+      beforeId,
+    );
+    return;
+  }
+
+  if (geometryType === "point" || profile.hasPoint) {
+    ensureLayer(
+      map,
+      primaryLayerId,
+      {
+        id: primaryLayerId,
+        type: "circle",
+        source: nativeSourceId,
+        ...zoomRange,
+        filter: ["match", ["geometry-type"], ["Point", "MultiPoint"], true, false],
+        paint: circlePaint(layer.style, layer.opacity),
+        layout: { visibility },
+      },
+      beforeId,
+    );
+    return;
+  }
+
+  if (geometryType === "line" || profile.hasLine || profile.hasPolygon) {
+    ensureLayer(
+      map,
+      primaryLayerId,
+      {
+        id: primaryLayerId,
+        type: "line",
+        source: nativeSourceId,
+        ...zoomRange,
+        filter: [
+          "match",
+          ["geometry-type"],
+          ["LineString", "MultiLineString", "Polygon", "MultiPolygon"],
+          true,
+          false,
+        ],
+        paint: linePaint(layer.style, layer.opacity),
+        layout: { visibility },
+      },
+      beforeId,
+    );
+  }
+}
+
+function sourceIdFromNativeLayerId(layerId: string | undefined): string | null {
+  return layerId ? `${layerId}-source` : null;
 }
 
 function isPMTilesExternalLayer(layer: GeoLibreLayer): boolean {

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -217,7 +217,14 @@ function ensureExternalGeoJsonNativeLayer(
   nativeLayerIds: string[],
   beforeId?: string,
 ): void {
-  if (!layer.geojson || nativeLayerIds.every((id) => map.getLayer(id))) return;
+  if (!layer.geojson) return;
+
+  if (nativeLayerIds.length === 0) {
+    console.warn(
+      `[layer-sync] external native GeoJSON layer "${layer.id}" has no nativeLayerIds; skipping native layer creation`,
+    );
+    return;
+  }
 
   const nativeSourceId =
     getExternalSourceIds(layer)[0] ??
@@ -225,6 +232,9 @@ function ensureExternalGeoJsonNativeLayer(
     sourceIdFromNativeLayerId(nativeLayerIds[0]) ??
     sourceId(layer.id);
 
+  // Always refresh the source so re-registration with new geojson data takes
+  // effect, then short-circuit only the layer creation when the native layers
+  // already exist.
   if (!map.getSource(nativeSourceId)) {
     map.addSource(nativeSourceId, {
       type: "geojson",
@@ -236,13 +246,20 @@ function ensureExternalGeoJsonNativeLayer(
     );
   }
 
+  if (nativeLayerIds.every((id) => map.getLayer(id))) return;
+
   const visibility = layer.visible ? "visible" : "none";
   const zoomRange = styleLayerZoomRange(layer.style);
   const geometryType = stringMetadata(layer.metadata.geometryType);
   const symbolLayer = layer.metadata.symbolLayer === true;
   const profile = detectGeometryProfile(layer.geojson);
-  const primaryLayerId = nativeLayerIds[0] ?? layer.id;
+  const primaryLayerId = nativeLayerIds[0];
 
+  // Each registration is rendered with a single representative native layer
+  // (the first nativeLayerId), chosen by the dominant geometry below. A
+  // FeatureCollection mixing geometry types only renders the representative
+  // one; callers that need every type drawn should register one entry per
+  // geometry type (one nativeLayerId each).
   if (symbolLayer) {
     ensureLayer(
       map,
@@ -254,6 +271,9 @@ function ensureExternalGeoJsonNativeLayer(
         ...zoomRange,
         layout: {
           "text-allow-overlap": true,
+          // Literal glyph rendered at every feature as a sprite-free point
+          // marker (an asterisk, not a property lookup). Symbol registrations
+          // here carry no label field, so this is intentional placeholder text.
           "text-field": "*",
           "text-ignore-placement": true,
           "text-size": Math.max(8, styleValue(layer.style, "circleRadius") * 2.5),

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -18,6 +18,19 @@ export type GeoLibreBuiltInMapControl =
   | "logo"
   | "layer-control";
 
+export interface GeoLibreExternalNativeLayerRegistration {
+  id: string;
+  name: string;
+  geojson?: FeatureCollection;
+  nativeLayerIds: string[];
+  sourceIds?: string[];
+  sourceId?: string;
+  opacity?: number;
+  style?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  sourcePath?: string;
+}
+
 export interface GeoLibreAppAPI {
   setBasemap: (styleUrl: string) => void;
   addGeoJsonLayer: (
@@ -30,6 +43,11 @@ export interface GeoLibreAppAPI {
   fetchArrayBuffer?: (url: string) => Promise<ArrayBuffer>;
   fitBounds?: (bounds: [number, number, number, number]) => void;
   getMap?: () => MapLibreMap | null;
+  pickLocalDirectoryFiles?: () => Promise<File[] | null>;
+  registerExternalNativeLayer?: (
+    layer: GeoLibreExternalNativeLayerRegistration,
+  ) => void;
+  unregisterExternalNativeLayer?: (id: string) => void;
   addMapControl: (
     control: IControl,
     position?: GeoLibreMapControlPosition,

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -1,3 +1,4 @@
+import type { LayerStyle } from "@geolibre/core";
 import type { FeatureCollection } from "geojson";
 import type { IControl, Map as MapLibreMap } from "maplibre-gl";
 
@@ -26,7 +27,7 @@ export interface GeoLibreExternalNativeLayerRegistration {
   sourceIds?: string[];
   sourceId?: string;
   opacity?: number;
-  style?: Record<string, unknown>;
+  style?: Partial<LayerStyle>;
   metadata?: Record<string, unknown>;
   sourcePath?: string;
 }


### PR DESCRIPTION
## Summary
- Add app API methods (`pickLocalDirectoryFiles`, `registerExternalNativeLayer`, `unregisterExternalNativeLayer`) so plugins can pick local directory files and register external native GeoJSON layers.
- Build matching native source and style layers (circle/line/symbol) in layer-sync so registered GeoJSON data actually renders on the map.
- Extend plugin types with `GeoLibreExternalNativeLayerRegistration` and the new optional app API methods.

## Test plan
- [ ] `pre-commit run --all-files` passes (includes full `npm run build`)
- [ ] Register an external native GeoJSON layer from a local directory and confirm it renders on the map
- [ ] Toggle visibility and opacity on the registered layer
- [ ] Unregister the layer and confirm it is removed