### PR TITLE
feat: add manual and auto refresh for WFS and GeoJSON URL layers

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -1180,25 +1180,24 @@ export function AddDataDialog({
 
         if (vectorMode === "geojson-url") {
           if (!vectorUrl.trim()) throw new Error("Enter a GeoJSON URL.");
-          const data = await fetchGeoJsonFeatureCollection(vectorUrl.trim());
-          const id = addGeoJsonLayer(name, data, vectorUrl.trim(), beforeLayer);
-          const state = useAppStore.getState();
-          const layer = state.layers.find((l) => l.id === id);
-          if (layer) {
-            state.updateLayer(id, {
-              source: {
-                ...layer.source,
-                url: vectorUrl.trim(),
-              },
-              metadata: {
-                ...layer.metadata,
-                featureCount: data.features.length,
-                sourceKind: "geojson-url",
-              },
-            });
-          }
-          if (layer) mapControllerRef.current?.fitLayer(layer);
-          closeDialog();
+          const url = vectorUrl.trim();
+          const data = await fetchGeoJsonFeatureCollection(url);
+          addAndClose(
+            {
+              ...createBaseLayer(
+                name,
+                "geojson",
+                { type: "geojson", url },
+                {
+                  featureCount: data.features.length,
+                  sourceKind: "geojson-url",
+                },
+              ),
+              geojson: data,
+              sourcePath: url,
+            },
+            { fit: true },
+          );
           return;
         }
 

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -50,6 +50,10 @@ import {
 } from "../../lib/delimited-text";
 import { parseGpxLayer } from "../../lib/gpx";
 import {
+  createWfsGetFeatureUrl,
+  fetchGeoJsonFeatureCollection,
+} from "../../lib/layer-refresh";
+import {
   mbtilesTileUrl,
   readMbtilesMetadata,
   registerMbtilesProtocol,
@@ -157,8 +161,6 @@ const DEFAULT_ARCGIS_URLS: Record<ArcGISLayerType, string> = {
   feature: DEFAULT_ARCGIS_FEATURE_URL,
   "vector-tile": DEFAULT_ARCGIS_VECTOR_TILE_URL,
 };
-// Keep in sync with WFS_PROXY_PATH in vite.config.ts (the dev proxy binds it there).
-const WFS_PROXY_PATH = "/__geolibre_wfs_proxy";
 // Keep in sync with GPX_PROXY_PATH in vite.config.ts (the dev proxy binds it there).
 const GPX_PROXY_PATH = "/__geolibre_gpx_proxy";
 const POSTGRES_CONNECTIONS_STORAGE_KEY =
@@ -248,31 +250,6 @@ function createWmsTileUrl(options: {
   ]);
 }
 
-function createWfsGetFeatureUrl(options: {
-  endpoint: string;
-  typeName: string;
-  version: string;
-  outputFormat: string;
-  srsName: string;
-  maxFeatures?: string;
-}): string {
-  const isWfs2 = options.version.startsWith("2");
-  const params: Array<[string, string]> = [
-    ["service", "WFS"],
-    ["request", "GetFeature"],
-    ["version", options.version],
-    [isWfs2 ? "typeNames" : "typeName", options.typeName],
-    ["outputFormat", options.outputFormat],
-  ];
-
-  if (options.srsName) params.push(["srsName", options.srsName]);
-  if (options.maxFeatures) {
-    params.push([isWfs2 ? "count" : "maxFeatures", options.maxFeatures]);
-  }
-
-  return appendQuery(options.endpoint, params);
-}
-
 function parseRequiredNumber(value: string, label: string): number {
   const parsed = Number(value);
   if (!Number.isFinite(parsed)) {
@@ -350,31 +327,10 @@ function isViteDevServer(): boolean {
   );
 }
 
-function proxyWfsRequestUrl(url: string): string {
-  return isViteDevServer()
-    ? `${WFS_PROXY_PATH}?url=${encodeURIComponent(url)}`
-    : url;
-}
-
 function proxyGpxRequestUrl(url: string): string {
   return isViteDevServer()
     ? `${GPX_PROXY_PATH}?url=${encodeURIComponent(url)}`
     : url;
-}
-
-function parseGeoJsonFeatureCollection(value: unknown): FeatureCollection {
-  if (
-    !value ||
-    typeof value !== "object" ||
-    !("type" in value) ||
-    value.type !== "FeatureCollection" ||
-    !("features" in value) ||
-    !Array.isArray(value.features)
-  ) {
-    throw new Error("The response is not a GeoJSON FeatureCollection.");
-  }
-
-  return value as FeatureCollection;
 }
 
 function resolveDelimitedTextDelimiter(
@@ -404,24 +360,6 @@ function inferDelimitedTextField(
   }
 
   return fields[0] ?? currentField;
-}
-
-async function fetchGeoJson(url: string): Promise<FeatureCollection> {
-  const response = await fetch(url);
-  const text = await response.text();
-  if (!response.ok && !/^\s*</.test(text)) {
-    throw new Error(`Request failed with status ${response.status}`);
-  }
-  try {
-    return parseGeoJsonFeatureCollection(JSON.parse(text));
-  } catch (error) {
-    if (/^\s*</.test(text)) {
-      throw new Error(
-        "The service returned XML instead of GeoJSON. Check the layer name and output format.",
-      );
-    }
-    throw error;
-  }
 }
 
 export function AddDataDialog({
@@ -1173,7 +1111,9 @@ export function AddDataDialog({
           srsName: wfsSrsName.trim(),
           maxFeatures: wfsMaxFeatures.trim() || undefined,
         });
-        const data = await fetchGeoJson(proxyWfsRequestUrl(featureUrl));
+        const data = await fetchGeoJsonFeatureCollection(featureUrl, {
+          useWfsProxy: true,
+        });
         addAndClose(
           {
             ...createBaseLayer(
@@ -1240,9 +1180,23 @@ export function AddDataDialog({
 
         if (vectorMode === "geojson-url") {
           if (!vectorUrl.trim()) throw new Error("Enter a GeoJSON URL.");
-          const data = await fetchGeoJson(vectorUrl.trim());
+          const data = await fetchGeoJsonFeatureCollection(vectorUrl.trim());
           const id = addGeoJsonLayer(name, data, vectorUrl.trim(), beforeLayer);
-          const layer = useAppStore.getState().layers.find((l) => l.id === id);
+          const state = useAppStore.getState();
+          const layer = state.layers.find((l) => l.id === id);
+          if (layer) {
+            state.updateLayer(id, {
+              source: {
+                ...layer.source,
+                url: vectorUrl.trim(),
+              },
+              metadata: {
+                ...layer.metadata,
+                featureCount: data.features.length,
+                sourceKind: "geojson-url",
+              },
+            });
+          }
           if (layer) mapControllerRef.current?.fitLayer(layer);
           closeDialog();
           return;

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -50,6 +50,7 @@ import {
 import {
   getLayerRefreshConfig,
   isRefreshableLayer,
+  MIN_REFRESH_INTERVAL_MS,
   refreshGeoJsonLayer,
   setLayerRefreshConfig,
 } from "../../lib/layer-refresh";
@@ -70,7 +71,6 @@ const REFRESH_INTERVAL_OPTIONS = [
   { label: "15 minutes", intervalMs: 15 * 60_000 },
 ];
 const CUSTOM_REFRESH_INTERVAL_VALUE = "custom";
-const CUSTOM_REFRESH_INTERVAL_MIN_MS = 1_000;
 const REFRESH_SUCCESS_STATUS_DURATION_MS = 4_000;
 
 type LayerRefreshStatus = {
@@ -107,7 +107,7 @@ function customRefreshIntervalSeconds(intervalMs: number): string {
 function parseCustomRefreshIntervalMs(value: string): number | null {
   const seconds = Number(value);
   if (!Number.isFinite(seconds) || seconds <= 0) return null;
-  return Math.max(CUSTOM_REFRESH_INTERVAL_MIN_MS, Math.round(seconds * 1000));
+  return Math.max(MIN_REFRESH_INTERVAL_MS, Math.round(seconds * 1000));
 }
 
 function hasNativeIdentifyLayers(layer: GeoLibreLayer): boolean {
@@ -281,6 +281,13 @@ export function LayerPanel({
     [clearRefreshStatusTimer, scheduleSuccessStatusClear, updateLayer],
   );
 
+  // Read through a ref inside interval callbacks so long-lived timers never
+  // capture a stale handleRefreshLayer closure.
+  const handleRefreshLayerRef = useRef(handleRefreshLayer);
+  useEffect(() => {
+    handleRefreshLayerRef.current = handleRefreshLayer;
+  }, [handleRefreshLayer]);
+
   useEffect(() => {
     if (
       refreshSettingsLayerId &&
@@ -304,7 +311,7 @@ export function LayerPanel({
       }
       return changed ? next : current;
     });
-  }, [layers, refreshSettingsLayerId]);
+  }, [clearRefreshStatusTimer, layers, refreshSettingsLayerId]);
 
   useEffect(() => {
     if (refreshSettingsIntervalMs === null) {
@@ -344,7 +351,7 @@ export function LayerPanel({
 
         const latestConfig = getLayerRefreshConfig(latest);
         if (!latestConfig.enabled || !isRefreshableLayer(latest)) return;
-        void handleRefreshLayer(latest, true);
+        void handleRefreshLayerRef.current(latest, true);
       }, config.intervalMs);
 
       refreshTimersRef.current.set(layer.id, {
@@ -358,7 +365,7 @@ export function LayerPanel({
       window.clearInterval(entry.timer);
       refreshTimersRef.current.delete(id);
     }
-  }, [handleRefreshLayer, layers]);
+  }, [layers]);
 
   useEffect(() => {
     return () => {

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -104,7 +104,7 @@ function customRefreshIntervalSeconds(intervalMs: number): string {
   return String(Math.round(intervalMs / 1000));
 }
 
-function parseCustomRefreshIntervalSeconds(value: string): number | null {
+function parseCustomRefreshIntervalMs(value: string): number | null {
   const seconds = Number(value);
   if (!Number.isFinite(seconds) || seconds <= 0) return null;
   return Math.max(CUSTOM_REFRESH_INTERVAL_MIN_MS, Math.round(seconds * 1000));
@@ -170,6 +170,14 @@ export function LayerPanel({
   const refreshSettingsLayer = refreshSettingsLayerId
     ? (layers.find((layer) => layer.id === refreshSettingsLayerId) ?? null)
     : null;
+  const refreshSettingsConfig = refreshSettingsLayer
+    ? getLayerRefreshConfig(refreshSettingsLayer)
+    : null;
+  const refreshSettingsIntervalMs = refreshSettingsConfig
+    ? refreshSettingsConfig.enabled
+      ? refreshSettingsConfig.intervalMs
+      : 0
+    : null;
   const backgroundSelected = selectedLayerId === BACKGROUND_SELECTION_ID;
   const allLayersVisible =
     basemapVisible && layers.every((layer) => layer.visible);
@@ -183,7 +191,7 @@ export function LayerPanel({
   const draggedDisplayIndex = draggedLayerId
     ? visibleLayers.findIndex((layer) => layer.id === draggedLayerId)
     : -1;
-  const customRefreshIntervalMs = parseCustomRefreshIntervalSeconds(
+  const customRefreshIntervalMs = parseCustomRefreshIntervalMs(
     customRefreshSeconds,
   );
 
@@ -294,12 +302,14 @@ export function LayerPanel({
     }
 
     const layerIds = new Set(layers.map((layer) => layer.id));
+    for (const id of refreshStatusTimersRef.current.keys()) {
+      if (!layerIds.has(id)) clearRefreshStatusTimer(id);
+    }
     setRefreshStatuses((current) => {
       let changed = false;
       const next = { ...current };
       for (const id of Object.keys(next)) {
         if (!layerIds.has(id)) {
-          clearRefreshStatusTimer(id);
           delete next[id];
           changed = true;
         }
@@ -309,21 +319,22 @@ export function LayerPanel({
   }, [layers, refreshSettingsLayerId]);
 
   useEffect(() => {
-    if (!refreshSettingsLayer) {
+    if (refreshSettingsIntervalMs === null) {
       setRefreshIntervalChoice("0");
       setCustomRefreshSeconds("");
       return;
     }
 
-    const config = getLayerRefreshConfig(refreshSettingsLayer);
-    const intervalMs = config.enabled ? config.intervalMs : 0;
-    setRefreshIntervalChoice(refreshIntervalOptionValue(intervalMs));
+    setRefreshIntervalChoice(
+      refreshIntervalOptionValue(refreshSettingsIntervalMs),
+    );
     setCustomRefreshSeconds(
-      refreshIntervalOptionValue(intervalMs) === CUSTOM_REFRESH_INTERVAL_VALUE
-        ? customRefreshIntervalSeconds(intervalMs)
+      refreshIntervalOptionValue(refreshSettingsIntervalMs) ===
+        CUSTOM_REFRESH_INTERVAL_VALUE
+        ? customRefreshIntervalSeconds(refreshSettingsIntervalMs)
         : "",
     );
-  }, [refreshSettingsLayer]);
+  }, [refreshSettingsLayerId, refreshSettingsIntervalMs]);
 
   useEffect(() => {
     const activeLayerIds = new Set<string>();
@@ -375,9 +386,15 @@ export function LayerPanel({
   }, []);
 
   const setRefreshInterval = (layer: GeoLibreLayer, intervalMs: number) => {
+    // Read the latest layer from the store so a concurrent refresh's metadata
+    // (e.g. featureCount) is not overwritten by a stale render snapshot.
+    const latest =
+      useAppStore
+        .getState()
+        .layers.find((candidate) => candidate.id === layer.id) ?? layer;
     updateLayer(
       layer.id,
-      setLayerRefreshConfig(layer, {
+      setLayerRefreshConfig(latest, {
         enabled: intervalMs > 0,
         intervalMs,
       }),

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -2,6 +2,9 @@ import {
   type DragEvent as ReactDragEvent,
   type MouseEvent as ReactMouseEvent,
   type RefObject,
+  useCallback,
+  useEffect,
+  useRef,
   useState,
 } from "react";
 import { useAppStore } from "@geolibre/core";
@@ -15,8 +18,16 @@ import {
   DialogHeader,
   DialogTitle,
   DialogDescription,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Input,
+  Label,
   ScrollArea,
   Separator,
+  Select,
   Slider,
 } from "@geolibre/ui";
 import {
@@ -27,12 +38,21 @@ import {
   GripVertical,
   Info,
   Layers,
+  MoreHorizontal,
   MousePointerClick,
   PanelLeftClose,
   PanelLeftOpen,
+  RefreshCw,
+  Timer,
   Trash2,
   ZoomIn,
 } from "lucide-react";
+import {
+  getLayerRefreshConfig,
+  isRefreshableLayer,
+  refreshGeoJsonLayer,
+  setLayerRefreshConfig,
+} from "../../lib/layer-refresh";
 
 interface LayerPanelProps {
   mapControllerRef: RefObject<MapController | null>;
@@ -41,11 +61,53 @@ interface LayerPanelProps {
 
 const BACKGROUND_SELECTION_ID = "__geolibre-background__";
 
+const REFRESH_INTERVAL_OPTIONS = [
+  { label: "Off", intervalMs: 0 },
+  { label: "15 seconds", intervalMs: 15_000 },
+  { label: "30 seconds", intervalMs: 30_000 },
+  { label: "1 minute", intervalMs: 60_000 },
+  { label: "5 minutes", intervalMs: 5 * 60_000 },
+  { label: "15 minutes", intervalMs: 15 * 60_000 },
+];
+const CUSTOM_REFRESH_INTERVAL_VALUE = "custom";
+const CUSTOM_REFRESH_INTERVAL_MIN_MS = 1_000;
+const REFRESH_SUCCESS_STATUS_DURATION_MS = 4_000;
+
+type LayerRefreshStatus = {
+  type: "refreshing" | "success" | "error";
+  message: string;
+};
+
+type LayerRefreshTimer = {
+  intervalMs: number;
+  timer: number;
+};
+
 function layerTypeLabel(layer: GeoLibreLayer): string {
   if (layer.type === "geojson" || layer.type === "vector-tiles") {
     return "vector";
   }
   return layer.type;
+}
+
+function refreshIntervalOptionValue(intervalMs: number): string {
+  if (
+    REFRESH_INTERVAL_OPTIONS.some((option) => option.intervalMs === intervalMs)
+  ) {
+    return String(intervalMs);
+  }
+  return CUSTOM_REFRESH_INTERVAL_VALUE;
+}
+
+function customRefreshIntervalSeconds(intervalMs: number): string {
+  if (intervalMs <= 0) return "";
+  return String(Math.round(intervalMs / 1000));
+}
+
+function parseCustomRefreshIntervalSeconds(value: string): number | null {
+  const seconds = Number(value);
+  if (!Number.isFinite(seconds) || seconds <= 0) return null;
+  return Math.max(CUSTOM_REFRESH_INTERVAL_MIN_MS, Math.round(seconds * 1000));
 }
 
 function hasNativeIdentifyLayers(layer: GeoLibreLayer): boolean {
@@ -82,17 +144,32 @@ export function LayerPanel({
   const reorderLayer = useAppStore((s) => s.reorderLayer);
   const moveLayer = useAppStore((s) => s.moveLayer);
   const removeLayer = useAppStore((s) => s.removeLayer);
+  const updateLayer = useAppStore((s) => s.updateLayer);
   const [metadataLayer, setMetadataLayer] = useState<GeoLibreLayer | null>(
     null,
   );
   const [layerPendingRemoval, setLayerPendingRemoval] =
     useState<GeoLibreLayer | null>(null);
+  const [refreshSettingsLayerId, setRefreshSettingsLayerId] = useState<
+    string | null
+  >(null);
+  const [refreshStatuses, setRefreshStatuses] = useState<
+    Record<string, LayerRefreshStatus>
+  >({});
+  const [refreshIntervalChoice, setRefreshIntervalChoice] = useState("0");
+  const [customRefreshSeconds, setCustomRefreshSeconds] = useState("");
   const [isCollapsed, setIsCollapsed] = useState(isMobileViewport);
   const [draggedLayerId, setDraggedLayerId] = useState<string | null>(null);
   const [dropTargetLayerId, setDropTargetLayerId] = useState<string | null>(
     null,
   );
+  const refreshingLayerIdsRef = useRef(new Set<string>());
+  const refreshTimersRef = useRef(new Map<string, LayerRefreshTimer>());
+  const refreshStatusTimersRef = useRef(new Map<string, number>());
   const visibleLayers = [...layers].reverse();
+  const refreshSettingsLayer = refreshSettingsLayerId
+    ? (layers.find((layer) => layer.id === refreshSettingsLayerId) ?? null)
+    : null;
   const backgroundSelected = selectedLayerId === BACKGROUND_SELECTION_ID;
   const allLayersVisible =
     basemapVisible && layers.every((layer) => layer.visible);
@@ -106,10 +183,205 @@ export function LayerPanel({
   const draggedDisplayIndex = draggedLayerId
     ? visibleLayers.findIndex((layer) => layer.id === draggedLayerId)
     : -1;
+  const customRefreshIntervalMs = parseCustomRefreshIntervalSeconds(
+    customRefreshSeconds,
+  );
 
   const resetDragState = () => {
     setDraggedLayerId(null);
     setDropTargetLayerId(null);
+  };
+
+  const clearRefreshStatusTimer = (layerId: string) => {
+    const timer = refreshStatusTimersRef.current.get(layerId);
+    if (!timer) return;
+    window.clearTimeout(timer);
+    refreshStatusTimersRef.current.delete(layerId);
+  };
+
+  const scheduleSuccessStatusClear = (layerId: string) => {
+    clearRefreshStatusTimer(layerId);
+    const timer = window.setTimeout(() => {
+      refreshStatusTimersRef.current.delete(layerId);
+      setRefreshStatuses((current) => {
+        if (current[layerId]?.type !== "success") return current;
+        const next = { ...current };
+        delete next[layerId];
+        return next;
+      });
+    }, REFRESH_SUCCESS_STATUS_DURATION_MS);
+    refreshStatusTimersRef.current.set(layerId, timer);
+  };
+
+  const handleRefreshLayer = useCallback(
+    async (layer: GeoLibreLayer, automatic = false) => {
+      if (refreshingLayerIdsRef.current.has(layer.id)) return;
+
+      if (!isRefreshableLayer(layer)) {
+        setRefreshStatuses((current) => ({
+          ...current,
+          [layer.id]: {
+            type: "error",
+            message: "Refresh is only available for WFS and GeoJSON URL layers.",
+          },
+        }));
+        return;
+      }
+
+      refreshingLayerIdsRef.current.add(layer.id);
+      clearRefreshStatusTimer(layer.id);
+      setRefreshStatuses((current) => ({
+        ...current,
+        [layer.id]: {
+          type: "refreshing",
+          message: automatic ? "Auto refreshing..." : "Refreshing...",
+        },
+      }));
+
+      try {
+        const patch = await refreshGeoJsonLayer(layer);
+        const latest = useAppStore
+          .getState()
+          .layers.find((candidate) => candidate.id === layer.id);
+        if (!latest) return;
+
+        updateLayer(layer.id, {
+          ...patch,
+          metadata: {
+            ...latest.metadata,
+            ...(patch.metadata ?? {}),
+          },
+        });
+
+        const featureCount = patch.metadata?.featureCount;
+        setRefreshStatuses((current) => ({
+          ...current,
+          [layer.id]: {
+            type: "success",
+            message:
+              typeof featureCount === "number"
+                ? `Refreshed ${featureCount.toLocaleString()} features.`
+                : "Layer refreshed.",
+          },
+        }));
+        scheduleSuccessStatusClear(layer.id);
+      } catch (error) {
+        clearRefreshStatusTimer(layer.id);
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Could not refresh this layer.";
+        setRefreshStatuses((current) => ({
+          ...current,
+          [layer.id]: {
+            type: "error",
+            message,
+          },
+        }));
+      } finally {
+        refreshingLayerIdsRef.current.delete(layer.id);
+      }
+    },
+    [updateLayer],
+  );
+
+  useEffect(() => {
+    if (
+      refreshSettingsLayerId &&
+      !layers.some((layer) => layer.id === refreshSettingsLayerId)
+    ) {
+      setRefreshSettingsLayerId(null);
+    }
+
+    const layerIds = new Set(layers.map((layer) => layer.id));
+    setRefreshStatuses((current) => {
+      let changed = false;
+      const next = { ...current };
+      for (const id of Object.keys(next)) {
+        if (!layerIds.has(id)) {
+          clearRefreshStatusTimer(id);
+          delete next[id];
+          changed = true;
+        }
+      }
+      return changed ? next : current;
+    });
+  }, [layers, refreshSettingsLayerId]);
+
+  useEffect(() => {
+    if (!refreshSettingsLayer) {
+      setRefreshIntervalChoice("0");
+      setCustomRefreshSeconds("");
+      return;
+    }
+
+    const config = getLayerRefreshConfig(refreshSettingsLayer);
+    const intervalMs = config.enabled ? config.intervalMs : 0;
+    setRefreshIntervalChoice(refreshIntervalOptionValue(intervalMs));
+    setCustomRefreshSeconds(
+      refreshIntervalOptionValue(intervalMs) === CUSTOM_REFRESH_INTERVAL_VALUE
+        ? customRefreshIntervalSeconds(intervalMs)
+        : "",
+    );
+  }, [refreshSettingsLayer]);
+
+  useEffect(() => {
+    const activeLayerIds = new Set<string>();
+
+    for (const layer of layers) {
+      const config = getLayerRefreshConfig(layer);
+      if (!config.enabled || !isRefreshableLayer(layer)) continue;
+
+      activeLayerIds.add(layer.id);
+      const existing = refreshTimersRef.current.get(layer.id);
+      if (existing?.intervalMs === config.intervalMs) continue;
+
+      if (existing) window.clearInterval(existing.timer);
+      const timer = window.setInterval(() => {
+        const latest = useAppStore
+          .getState()
+          .layers.find((candidate) => candidate.id === layer.id);
+        if (!latest) return;
+
+        const latestConfig = getLayerRefreshConfig(latest);
+        if (!latestConfig.enabled || !isRefreshableLayer(latest)) return;
+        void handleRefreshLayer(latest, true);
+      }, config.intervalMs);
+
+      refreshTimersRef.current.set(layer.id, {
+        intervalMs: config.intervalMs,
+        timer,
+      });
+    }
+
+    for (const [id, entry] of refreshTimersRef.current) {
+      if (activeLayerIds.has(id)) continue;
+      window.clearInterval(entry.timer);
+      refreshTimersRef.current.delete(id);
+    }
+  }, [handleRefreshLayer, layers]);
+
+  useEffect(() => {
+    return () => {
+      for (const entry of refreshTimersRef.current.values()) {
+        window.clearInterval(entry.timer);
+      }
+      refreshTimersRef.current.clear();
+      for (const timer of refreshStatusTimersRef.current.values()) {
+        window.clearTimeout(timer);
+      }
+      refreshStatusTimersRef.current.clear();
+    };
+  }, []);
+
+  const setRefreshInterval = (layer: GeoLibreLayer, intervalMs: number) => {
+    updateLayer(
+      layer.id,
+      setLayerRefreshConfig(layer, {
+        enabled: intervalMs > 0,
+        intervalMs,
+      }),
+    );
   };
 
   const handleLayerDragStart = (
@@ -234,6 +506,10 @@ export function LayerPanel({
                 layer.metadata.tileType === "vector") ||
               hasNativeIdentifyLayers(layer);
             const identifyActive = identifyLayerId === layer.id;
+            const canRefresh = isRefreshableLayer(layer);
+            const refreshConfig = getLayerRefreshConfig(layer);
+            const refreshStatus = refreshStatuses[layer.id];
+            const isRefreshing = refreshStatus?.type === "refreshing";
             return (
               <div
                 key={layer.id}
@@ -300,6 +576,19 @@ export function LayerPanel({
                 {isPlaceholderLayer(layer) && (
                   <p className="mt-1 text-[10px] text-amber-600">
                     {placeholderMessage(layer)}
+                  </p>
+                )}
+                {refreshStatus && (
+                  <p
+                    className={`mt-1 text-[10px] ${
+                      refreshStatus.type === "error"
+                        ? "text-destructive"
+                        : refreshStatus.type === "success"
+                          ? "text-emerald-600"
+                          : "text-muted-foreground"
+                    }`}
+                  >
+                    {refreshStatus.message}
                   </p>
                 )}
                 <div className="mt-2 flex items-center gap-1">
@@ -390,6 +679,63 @@ export function LayerPanel({
                   >
                     <MousePointerClick className="h-3.5 w-3.5" />
                   </Button>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className={`h-7 w-7 ${
+                          refreshConfig.enabled
+                            ? "border border-primary text-primary"
+                            : ""
+                        }`}
+                        title="Layer actions"
+                        aria-label="Layer actions"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <MoreHorizontal className="h-3.5 w-3.5" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent
+                      align="end"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <DropdownMenuItem
+                        disabled={!canRefresh || isRefreshing}
+                        onSelect={(e) => {
+                          e.preventDefault();
+                          void handleRefreshLayer(layer);
+                        }}
+                      >
+                        <RefreshCw
+                          className={`mr-2 h-3.5 w-3.5 ${
+                            isRefreshing ? "animate-spin" : ""
+                          }`}
+                        />
+                        Refresh
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        disabled={!canRefresh}
+                        onSelect={(e) => {
+                          e.preventDefault();
+                          setRefreshSettingsLayerId(layer.id);
+                        }}
+                      >
+                        <Timer className="mr-2 h-3.5 w-3.5" />
+                        {refreshConfig.enabled
+                          ? "Auto refresh on"
+                          : "Auto refresh"}
+                      </DropdownMenuItem>
+                      {!canRefresh && (
+                        <>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem disabled>
+                            WFS and GeoJSON URLs only
+                          </DropdownMenuItem>
+                        </>
+                      )}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
                   <Button
                     variant="ghost"
                     size="icon"
@@ -486,6 +832,111 @@ export function LayerPanel({
         {/* TODO(v0.3): Add native PMTiles, COG, and FlatGeobuf layer types */}
         Advanced formats: see docs/roadmap.md
       </p>
+      <Dialog
+        open={!!refreshSettingsLayerId}
+        onOpenChange={(open) => {
+          if (!open) setRefreshSettingsLayerId(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {refreshSettingsLayer?.name ?? "Layer"} Auto Refresh
+            </DialogTitle>
+            <DialogDescription>
+              Reload this layer from its source on a fixed interval.
+            </DialogDescription>
+          </DialogHeader>
+          {refreshSettingsLayer && (
+            <div className="space-y-3">
+              <Label htmlFor="layer-refresh-interval">Interval</Label>
+              <Select
+                id="layer-refresh-interval"
+                value={refreshIntervalChoice}
+                onChange={(event) => {
+                  const value = event.target.value;
+                  setRefreshIntervalChoice(value);
+                  if (value === CUSTOM_REFRESH_INTERVAL_VALUE) {
+                    const current = getLayerRefreshConfig(refreshSettingsLayer);
+                    setCustomRefreshSeconds(
+                      customRefreshIntervalSeconds(current.intervalMs),
+                    );
+                    return;
+                  }
+                  setCustomRefreshSeconds("");
+                  setRefreshInterval(refreshSettingsLayer, Number(value));
+                }}
+              >
+                {REFRESH_INTERVAL_OPTIONS.map((option) => (
+                  <option key={option.intervalMs} value={option.intervalMs}>
+                    {option.label}
+                  </option>
+                ))}
+                <option value={CUSTOM_REFRESH_INTERVAL_VALUE}>Custom</option>
+              </Select>
+              {refreshIntervalChoice === CUSTOM_REFRESH_INTERVAL_VALUE && (
+                <div className="space-y-2">
+                  <Label htmlFor="layer-refresh-custom-seconds">
+                    Custom interval (seconds)
+                  </Label>
+                  <div className="flex gap-2">
+                    <Input
+                      id="layer-refresh-custom-seconds"
+                      type="number"
+                      min="1"
+                      step="1"
+                      value={customRefreshSeconds}
+                      onChange={(event) =>
+                        setCustomRefreshSeconds(event.target.value)
+                      }
+                      onKeyDown={(event) => {
+                        if (
+                          event.key !== "Enter" ||
+                          !refreshSettingsLayer ||
+                          !customRefreshIntervalMs
+                        ) {
+                          return;
+                        }
+                        setRefreshInterval(
+                          refreshSettingsLayer,
+                          customRefreshIntervalMs,
+                        );
+                      }}
+                    />
+                    <Button
+                      type="button"
+                      disabled={!customRefreshIntervalMs}
+                      onClick={() => {
+                        if (!customRefreshIntervalMs) return;
+                        setRefreshInterval(
+                          refreshSettingsLayer,
+                          customRefreshIntervalMs,
+                        );
+                      }}
+                    >
+                      Apply
+                    </Button>
+                  </div>
+                  {!customRefreshIntervalMs && customRefreshSeconds.trim() && (
+                    <p className="text-xs text-destructive">
+                      Enter a positive number of seconds.
+                    </p>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+          <div className="flex justify-end">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => setRefreshSettingsLayerId(null)}
+            >
+              Close
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
       <Dialog
         open={!!metadataLayer}
         onOpenChange={(open) => {

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -200,41 +200,33 @@ export function LayerPanel({
     setDropTargetLayerId(null);
   };
 
-  const clearRefreshStatusTimer = (layerId: string) => {
+  const clearRefreshStatusTimer = useCallback((layerId: string) => {
     const timer = refreshStatusTimersRef.current.get(layerId);
     if (!timer) return;
     window.clearTimeout(timer);
     refreshStatusTimersRef.current.delete(layerId);
-  };
+  }, []);
 
-  const scheduleSuccessStatusClear = (layerId: string) => {
-    clearRefreshStatusTimer(layerId);
-    const timer = window.setTimeout(() => {
-      refreshStatusTimersRef.current.delete(layerId);
-      setRefreshStatuses((current) => {
-        if (current[layerId]?.type !== "success") return current;
-        const next = { ...current };
-        delete next[layerId];
-        return next;
-      });
-    }, REFRESH_SUCCESS_STATUS_DURATION_MS);
-    refreshStatusTimersRef.current.set(layerId, timer);
-  };
+  const scheduleSuccessStatusClear = useCallback(
+    (layerId: string) => {
+      clearRefreshStatusTimer(layerId);
+      const timer = window.setTimeout(() => {
+        refreshStatusTimersRef.current.delete(layerId);
+        setRefreshStatuses((current) => {
+          if (current[layerId]?.type !== "success") return current;
+          const next = { ...current };
+          delete next[layerId];
+          return next;
+        });
+      }, REFRESH_SUCCESS_STATUS_DURATION_MS);
+      refreshStatusTimersRef.current.set(layerId, timer);
+    },
+    [clearRefreshStatusTimer],
+  );
 
   const handleRefreshLayer = useCallback(
     async (layer: GeoLibreLayer, automatic = false) => {
       if (refreshingLayerIdsRef.current.has(layer.id)) return;
-
-      if (!isRefreshableLayer(layer)) {
-        setRefreshStatuses((current) => ({
-          ...current,
-          [layer.id]: {
-            type: "error",
-            message: "Refresh is only available for WFS and GeoJSON URL layers.",
-          },
-        }));
-        return;
-      }
 
       refreshingLayerIdsRef.current.add(layer.id);
       clearRefreshStatusTimer(layer.id);
@@ -247,29 +239,25 @@ export function LayerPanel({
       }));
 
       try {
-        const patch = await refreshGeoJsonLayer(layer);
+        const { geojson, featureCount } = await refreshGeoJsonLayer(layer);
         const latest = useAppStore
           .getState()
           .layers.find((candidate) => candidate.id === layer.id);
         if (!latest) return;
 
         updateLayer(layer.id, {
-          ...patch,
+          geojson,
           metadata: {
             ...latest.metadata,
-            ...(patch.metadata ?? {}),
+            featureCount,
           },
         });
 
-        const featureCount = patch.metadata?.featureCount;
         setRefreshStatuses((current) => ({
           ...current,
           [layer.id]: {
             type: "success",
-            message:
-              typeof featureCount === "number"
-                ? `Refreshed ${featureCount.toLocaleString()} features.`
-                : "Layer refreshed.",
+            message: `Refreshed ${featureCount.toLocaleString()} features.`,
           },
         }));
         scheduleSuccessStatusClear(layer.id);
@@ -290,7 +278,7 @@ export function LayerPanel({
         refreshingLayerIdsRef.current.delete(layer.id);
       }
     },
-    [updateLayer],
+    [clearRefreshStatusTimer, scheduleSuccessStatusClear, updateLayer],
   );
 
   useEffect(() => {

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -71,7 +71,7 @@ const REFRESH_INTERVAL_OPTIONS = [
   { label: "15 minutes", intervalMs: 15 * 60_000 },
 ];
 const CUSTOM_REFRESH_INTERVAL_VALUE = "custom";
-const REFRESH_SUCCESS_STATUS_DURATION_MS = 4_000;
+const REFRESH_STATUS_DURATION_MS = 4_000;
 
 type LayerRefreshStatus = {
   type: "refreshing" | "success" | "error";
@@ -207,18 +207,21 @@ export function LayerPanel({
     refreshStatusTimersRef.current.delete(layerId);
   }, []);
 
-  const scheduleSuccessStatusClear = useCallback(
+  const scheduleStatusClear = useCallback(
     (layerId: string) => {
       clearRefreshStatusTimer(layerId);
       const timer = window.setTimeout(() => {
         refreshStatusTimersRef.current.delete(layerId);
         setRefreshStatuses((current) => {
-          if (current[layerId]?.type !== "success") return current;
+          // Keep in-flight statuses; only fade finished success/error notes.
+          if (!current[layerId] || current[layerId].type === "refreshing") {
+            return current;
+          }
           const next = { ...current };
           delete next[layerId];
           return next;
         });
-      }, REFRESH_SUCCESS_STATUS_DURATION_MS);
+      }, REFRESH_STATUS_DURATION_MS);
       refreshStatusTimersRef.current.set(layerId, timer);
     },
     [clearRefreshStatusTimer],
@@ -260,9 +263,8 @@ export function LayerPanel({
             message: `Refreshed ${featureCount.toLocaleString()} features.`,
           },
         }));
-        scheduleSuccessStatusClear(layer.id);
+        scheduleStatusClear(layer.id);
       } catch (error) {
-        clearRefreshStatusTimer(layer.id);
         const message =
           error instanceof Error
             ? error.message
@@ -274,11 +276,12 @@ export function LayerPanel({
             message,
           },
         }));
+        scheduleStatusClear(layer.id);
       } finally {
         refreshingLayerIdsRef.current.delete(layer.id);
       }
     },
-    [clearRefreshStatusTimer, scheduleSuccessStatusClear, updateLayer],
+    [clearRefreshStatusTimer, scheduleStatusClear, updateLayer],
   );
 
   // Read through a ref inside interval callbacks so long-lived timers never
@@ -380,21 +383,24 @@ export function LayerPanel({
     };
   }, []);
 
-  const setRefreshInterval = (layer: GeoLibreLayer, intervalMs: number) => {
-    // Read the latest layer from the store so a concurrent refresh's metadata
-    // (e.g. featureCount) is not overwritten by a stale render snapshot.
-    const latest =
-      useAppStore
-        .getState()
-        .layers.find((candidate) => candidate.id === layer.id) ?? layer;
-    updateLayer(
-      layer.id,
-      setLayerRefreshConfig(latest, {
-        enabled: intervalMs > 0,
-        intervalMs,
-      }),
-    );
-  };
+  const setRefreshInterval = useCallback(
+    (layer: GeoLibreLayer, intervalMs: number) => {
+      // Read the latest layer from the store so a concurrent refresh's
+      // metadata (e.g. featureCount) is not overwritten by a stale snapshot.
+      const latest =
+        useAppStore
+          .getState()
+          .layers.find((candidate) => candidate.id === layer.id) ?? layer;
+      updateLayer(
+        layer.id,
+        setLayerRefreshConfig(latest, {
+          enabled: intervalMs > 0,
+          intervalMs,
+        }),
+      );
+    },
+    [updateLayer],
+  );
 
   const handleLayerDragStart = (
     event: ReactDragEvent<HTMLElement>,

--- a/apps/geolibre-desktop/src/lib/layer-refresh.ts
+++ b/apps/geolibre-desktop/src/lib/layer-refresh.ts
@@ -1,0 +1,212 @@
+import type { FeatureCollection } from "geojson";
+import type { GeoLibreLayer } from "@geolibre/core";
+
+const WFS_PROXY_PATH = "/__geolibre_wfs_proxy";
+const REFRESHABLE_GEOJSON_SOURCE_KINDS = new Set([
+  "wfs-getfeature",
+  "geojson-url",
+]);
+
+export interface LayerRefreshConfig {
+  enabled: boolean;
+  intervalMs: number;
+}
+
+export function createWfsGetFeatureUrl(options: {
+  endpoint: string;
+  typeName: string;
+  version: string;
+  outputFormat: string;
+  srsName: string;
+  maxFeatures?: string;
+}): string {
+  const isWfs2 = options.version.startsWith("2");
+  const params: Array<[string, string]> = [
+    ["service", "WFS"],
+    ["request", "GetFeature"],
+    ["version", options.version],
+    [isWfs2 ? "typeNames" : "typeName", options.typeName],
+    ["outputFormat", options.outputFormat],
+  ];
+
+  if (options.srsName) params.push(["srsName", options.srsName]);
+  if (options.maxFeatures) {
+    params.push([isWfs2 ? "count" : "maxFeatures", options.maxFeatures]);
+  }
+
+  return appendQuery(options.endpoint, params);
+}
+
+export async function fetchGeoJsonFeatureCollection(
+  url: string,
+  options: { useWfsProxy?: boolean } = {},
+): Promise<FeatureCollection> {
+  const response = await fetch(
+    options.useWfsProxy ? proxyWfsRequestUrl(url) : url,
+  );
+  const text = await response.text();
+  if (!response.ok && !/^\s*</.test(text)) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+  try {
+    return parseGeoJsonFeatureCollection(JSON.parse(text));
+  } catch (error) {
+    if (/^\s*</.test(text)) {
+      throw new Error(
+        "The service returned XML instead of GeoJSON. Check the layer name and output format.",
+      );
+    }
+    throw error;
+  }
+}
+
+export async function refreshGeoJsonLayer(
+  layer: GeoLibreLayer,
+): Promise<Partial<GeoLibreLayer>> {
+  const sourceUrl = refreshSourceUrl(layer);
+  if (!sourceUrl) {
+    throw new Error("This layer does not have a refreshable GeoJSON URL.");
+  }
+
+  const data = await fetchGeoJsonFeatureCollection(sourceUrl, {
+    useWfsProxy: isWfsLayer(layer),
+  });
+
+  return {
+    geojson: data,
+    metadata: {
+      featureCount: data.features.length,
+    },
+  };
+}
+
+export function isRefreshableLayer(layer: GeoLibreLayer): boolean {
+  return Boolean(refreshSourceUrl(layer));
+}
+
+export function getLayerRefreshConfig(
+  layer: GeoLibreLayer,
+): LayerRefreshConfig {
+  const refresh = layer.metadata.refresh;
+  if (!refresh || typeof refresh !== "object" || Array.isArray(refresh)) {
+    return { enabled: false, intervalMs: 0 };
+  }
+
+  const candidate = refresh as Partial<LayerRefreshConfig>;
+  const intervalMs =
+    typeof candidate.intervalMs === "number" &&
+    Number.isFinite(candidate.intervalMs) &&
+    candidate.intervalMs > 0
+      ? candidate.intervalMs
+      : 0;
+
+  return {
+    enabled: candidate.enabled === true && intervalMs > 0,
+    intervalMs,
+  };
+}
+
+export function setLayerRefreshConfig(
+  layer: GeoLibreLayer,
+  config: LayerRefreshConfig,
+): Partial<GeoLibreLayer> {
+  return {
+    metadata: {
+      ...layer.metadata,
+      refresh: {
+        enabled: config.enabled && config.intervalMs > 0,
+        intervalMs: config.intervalMs,
+      },
+    },
+  };
+}
+
+function appendQuery(
+  endpoint: string,
+  params: Array<[string, string]>,
+): string {
+  const separator = endpoint.includes("?")
+    ? endpoint.endsWith("?") || endpoint.endsWith("&")
+      ? ""
+      : "&"
+    : "?";
+  const query = params
+    .map(
+      ([key, value]) =>
+        `${encodeURIComponent(key)}=${encodeURIComponent(value)}`,
+    )
+    .join("&");
+  return `${endpoint}${separator}${query}`;
+}
+
+function parseGeoJsonFeatureCollection(value: unknown): FeatureCollection {
+  if (
+    !value ||
+    typeof value !== "object" ||
+    !("type" in value) ||
+    value.type !== "FeatureCollection" ||
+    !("features" in value) ||
+    !Array.isArray(value.features)
+  ) {
+    throw new Error("The response is not a GeoJSON FeatureCollection.");
+  }
+
+  return value as FeatureCollection;
+}
+
+function refreshSourceUrl(layer: GeoLibreLayer): string | null {
+  if (layer.type !== "geojson") return null;
+
+  const sourcePath =
+    typeof layer.sourcePath === "string" ? layer.sourcePath.trim() : "";
+  const sourceUrl =
+    typeof layer.source.url === "string" ? layer.source.url.trim() : "";
+  const url = sourceUrl || sourcePath;
+  if (!isHttpUrl(url)) return null;
+
+  if (isWfsLayer(layer)) return url;
+  if (layer.metadata.externalNativeLayer === true) return null;
+
+  const sourceKind =
+    typeof layer.metadata.sourceKind === "string"
+      ? layer.metadata.sourceKind
+      : undefined;
+  if (sourceKind && !REFRESHABLE_GEOJSON_SOURCE_KINDS.has(sourceKind)) {
+    return null;
+  }
+
+  return url;
+}
+
+function isWfsLayer(layer: GeoLibreLayer): boolean {
+  return (
+    layer.metadata.sourceKind === "wfs-getfeature" ||
+    layer.metadata.service === "wfs" ||
+    layer.source.service === "wfs"
+  );
+}
+
+function isViteDevServer(): boolean {
+  return Boolean(
+    (
+      import.meta as ImportMeta & {
+        env?: { DEV?: boolean };
+      }
+    ).env?.DEV,
+  );
+}
+
+function proxyWfsRequestUrl(url: string): string {
+  return isViteDevServer()
+    ? `${WFS_PROXY_PATH}?url=${encodeURIComponent(url)}`
+    : url;
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}

--- a/apps/geolibre-desktop/src/lib/layer-refresh.ts
+++ b/apps/geolibre-desktop/src/lib/layer-refresh.ts
@@ -1,7 +1,9 @@
 import type { FeatureCollection } from "geojson";
 import type { GeoLibreLayer } from "@geolibre/core";
 
+// Keep in sync with WFS_PROXY_PATH in vite.config.ts (the dev proxy binds it there).
 const WFS_PROXY_PATH = "/__geolibre_wfs_proxy";
+const FETCH_TIMEOUT_MS = 30_000;
 const REFRESHABLE_GEOJSON_SOURCE_KINDS = new Set([
   "wfs-getfeature",
   "geojson-url",
@@ -39,11 +41,19 @@ export function createWfsGetFeatureUrl(options: {
 
 export async function fetchGeoJsonFeatureCollection(
   url: string,
-  options: { useWfsProxy?: boolean } = {},
+  options: { useWfsProxy?: boolean; signal?: AbortSignal } = {},
 ): Promise<FeatureCollection> {
-  const response = await fetch(
-    options.useWfsProxy ? proxyWfsRequestUrl(url) : url,
-  );
+  let response: Response;
+  try {
+    response = await fetch(options.useWfsProxy ? proxyWfsRequestUrl(url) : url, {
+      signal: options.signal ?? AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "TimeoutError") {
+      throw new Error("The request timed out.");
+    }
+    throw error;
+  }
   const text = await response.text();
   if (!response.ok && !/^\s*</.test(text)) {
     throw new Error(`Request failed with status ${response.status}`);
@@ -62,7 +72,7 @@ export async function fetchGeoJsonFeatureCollection(
 
 export async function refreshGeoJsonLayer(
   layer: GeoLibreLayer,
-): Promise<Partial<GeoLibreLayer>> {
+): Promise<{ geojson: FeatureCollection; featureCount: number }> {
   const sourceUrl = refreshSourceUrl(layer);
   if (!sourceUrl) {
     throw new Error("This layer does not have a refreshable GeoJSON URL.");
@@ -74,9 +84,7 @@ export async function refreshGeoJsonLayer(
 
   return {
     geojson: data,
-    metadata: {
-      featureCount: data.features.length,
-    },
+    featureCount: data.features.length,
   };
 }
 
@@ -167,6 +175,9 @@ function refreshSourceUrl(layer: GeoLibreLayer): string | null {
   if (isWfsLayer(layer)) return url;
   if (layer.metadata.externalNativeLayer === true) return null;
 
+  // Layers added before sourceKind existed have no tag; treat any GeoJSON
+  // layer with an HTTP URL as refreshable unless it is explicitly tagged
+  // with a non-refreshable kind.
   const sourceKind =
     typeof layer.metadata.sourceKind === "string"
       ? layer.metadata.sourceKind

--- a/apps/geolibre-desktop/src/lib/layer-refresh.ts
+++ b/apps/geolibre-desktop/src/lib/layer-refresh.ts
@@ -4,6 +4,7 @@ import type { GeoLibreLayer } from "@geolibre/core";
 // Keep in sync with WFS_PROXY_PATH in vite.config.ts (the dev proxy binds it there).
 const WFS_PROXY_PATH = "/__geolibre_wfs_proxy";
 const FETCH_TIMEOUT_MS = 30_000;
+export const MIN_REFRESH_INTERVAL_MS = 1_000;
 const REFRESHABLE_GEOJSON_SOURCE_KINDS = new Set([
   "wfs-getfeature",
   "geojson-url",
@@ -101,11 +102,13 @@ export function getLayerRefreshConfig(
   }
 
   const candidate = refresh as Partial<LayerRefreshConfig>;
+  // Clamp persisted values so a hand-edited project file cannot schedule
+  // sub-second refresh intervals.
   const intervalMs =
     typeof candidate.intervalMs === "number" &&
     Number.isFinite(candidate.intervalMs) &&
     candidate.intervalMs > 0
-      ? candidate.intervalMs
+      ? Math.max(MIN_REFRESH_INTERVAL_MS, candidate.intervalMs)
       : 0;
 
   return {

--- a/apps/geolibre-desktop/src/lib/layer-refresh.ts
+++ b/apps/geolibre-desktop/src/lib/layer-refresh.ts
@@ -47,7 +47,13 @@ export async function fetchGeoJsonFeatureCollection(
   let response: Response;
   try {
     response = await fetch(options.useWfsProxy ? proxyWfsRequestUrl(url) : url, {
-      signal: options.signal ?? AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      // Combine signals so a caller-supplied signal does not drop the timeout.
+      signal: options.signal
+        ? AbortSignal.any([
+            options.signal,
+            AbortSignal.timeout(FETCH_TIMEOUT_MS),
+          ])
+        : AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
   } catch (error) {
     if (error instanceof DOMException && error.name === "TimeoutError") {
@@ -121,14 +127,17 @@ export function setLayerRefreshConfig(
   layer: GeoLibreLayer,
   config: LayerRefreshConfig,
 ): Partial<GeoLibreLayer> {
+  const enabled = config.enabled && config.intervalMs > 0;
+  // Omit the refresh key entirely when disabled so saved projects do not
+  // accumulate meaningless { enabled: false, intervalMs: 0 } entries.
+  const { refresh: _refresh, ...restMetadata } = layer.metadata;
   return {
-    metadata: {
-      ...layer.metadata,
-      refresh: {
-        enabled: config.enabled && config.intervalMs > 0,
-        intervalMs: config.intervalMs,
-      },
-    },
+    metadata: enabled
+      ? {
+          ...restMetadata,
+          refresh: { enabled: true, intervalMs: config.intervalMs },
+        }
+      : restMetadata,
   };
 }
 

--- a/docs/project-format.md
+++ b/docs/project-format.md
@@ -72,6 +72,20 @@ Projects without a `plugins` section open with the built-in default plugin state
 }
 ```
 
+For WFS GetFeature and GeoJSON URL layers, `metadata.refresh` can persist an
+optional auto-refresh interval. `intervalMs` can be any positive interval in
+milliseconds:
+
+```json
+{
+  "metadata": {
+    "refresh": { "enabled": true, "intervalMs": 60000 }
+  }
+}
+```
+
+Manual refresh uses the same saved source URL without requiring this metadata.
+
 ## Layer types
 
 | Type             | v0.7.0 status                                                                                      |


### PR DESCRIPTION
Fix #130

## Summary
- Add a layer actions menu in the layer panel with manual refresh for WFS GetFeature and GeoJSON URL layers, reloading features from the saved source URL
- Add configurable auto refresh (preset or custom interval) persisted in layer metadata via `metadata.refresh`, so projects restore the setting on reopen
- Extract shared WFS/GeoJSON fetch helpers from AddDataDialog into `lib/layer-refresh.ts` and document the new metadata field in `docs/project-format.md`

## Test plan
- [ ] Add a WFS layer, use Refresh from the layer actions menu, and confirm the feature count status message appears
- [ ] Add a GeoJSON URL layer and verify both manual and auto refresh update the layer
- [ ] Enable auto refresh with a preset and a custom interval, save the project, reopen it, and confirm the interval is restored
- [ ] Confirm refresh options are disabled for non-refreshable layers (local files, external native layers)
- [ ] Remove a layer with auto refresh enabled and confirm no further requests fire

<img width="368" height="280" alt="image" src="https://github.com/user-attachments/assets/fcce97f9-75f1-4e20-bcb4-e0e0547e8738" />

<img width="708" height="499" alt="image" src="https://github.com/user-attachments/assets/5a9558e1-6eb1-4922-bf2a-40a038a3eb4e" />
