### PR TITLE
feat: support multiple DuckDB query result layers

### DIFF
--- a/packages/plugins/src/plugins/maplibre-duckdb.ts
+++ b/packages/plugins/src/plugins/maplibre-duckdb.ts
@@ -48,7 +48,10 @@ type DuckDBRenderedLayerLike = {
   results: DuckDBResultLike[];
 };
 
-type DuckDBInternalLayer = DuckDBRenderedLayerLike & {
+type DuckDBInternalLayer = Omit<DuckDBRenderedLayerLike, "results"> & {
+  // The control's internal layer stores its tables as geoArrowResults;
+  // results only exists on the objects passed to the renderer.
+  results?: DuckDBResultLike[];
   geoArrowResults?: DuckDBResultLike[];
   geometryColumn?: string | null;
   geometryFormat?: string | null;
@@ -175,8 +178,9 @@ function createDuckDBControl(
     }
 
     if (
+      !shouldSyncControl &&
       duckdbLayerOrderSignature(state.layers) !==
-      duckdbLayerOrderSignature(previous.layers)
+        duckdbLayerOrderSignature(previous.layers)
     ) {
       shouldSyncControl = true;
     }
@@ -252,12 +256,14 @@ function createDuckDBStateChangeHandler(): DuckDBControlEventHandler {
     if (event.state.layer) return;
 
     const store = useAppStore.getState();
+    // Clear the caches first so the per-removal subscription syncs render
+    // an empty set instead of flashing the remaining layers n-1 times.
+    clearDuckDBRenderedLayers();
     for (const layer of store.layers) {
       if (isDuckDBControlLayer(layer)) {
         store.removeLayer(layer.id);
       }
     }
-    clearDuckDBRenderedLayers();
   };
 }
 

--- a/packages/plugins/src/plugins/maplibre-duckdb.ts
+++ b/packages/plugins/src/plugins/maplibre-duckdb.ts
@@ -270,7 +270,7 @@ function createDuckDBStoreLayer(
     visible: true,
     opacity: 1,
     style: { ...DEFAULT_LAYER_STYLE },
-    beforeId: layerState.beforeId,
+    beforeId: layerState.beforeId ?? undefined,
     metadata: {
       columns: layerState.schema,
       databaseSource: state.databaseSource,
@@ -295,6 +295,7 @@ function removeDuckDBRenderedLayer(layerId: string): void {
   duckdbRenderedLayers.delete(layerId);
   duckdbRenderedRows.delete(layerId);
   duckdbRenderedStyles.delete(layerId);
+  duckdbLayerOrder.delete(layerId);
   warnedMissingRowsLayerIds.delete(layerId);
   renderDuckDBCachedLayers();
 }
@@ -340,7 +341,8 @@ function renderDuckDBCachedLayers(): void {
   if (!renderer) return;
 
   patchDuckDBRenderer(renderer);
-  renderer.setData?.(getOrderedDuckDBRenderedLayers());
+  const orderedLayers = getOrderedDuckDBRenderedLayers();
+  (renderer.__geolibreOriginalSetData ?? renderer.setData)?.(orderedLayers);
 }
 
 function getOrderedDuckDBRenderedLayers(): DuckDBRenderedLayerLike[] {

--- a/packages/plugins/src/plugins/maplibre-duckdb.ts
+++ b/packages/plugins/src/plugins/maplibre-duckdb.ts
@@ -93,7 +93,7 @@ let duckdbStoreUnsubscribe: (() => void) | null = null;
 let duckdbConstructorsPromise: Promise<{
   DuckDBControl: DuckDBControlConstructor;
 }> | null = null;
-let duckdbLayerOrder = new Map<string, number>();
+const duckdbLayerOrder = new Map<string, number>();
 const duckdbRenderedLayers = new Map<string, DuckDBRenderedLayerLike>();
 const duckdbRenderedRows = new Map<string, Record<number, Record<string, unknown>>>();
 const duckdbRenderedStyles = new Map<string, DuckDBRenderedStyle>();
@@ -320,20 +320,19 @@ function clearDuckDBRenderedLayers(): void {
 }
 
 function syncDuckDBRenderedLayersFromStore(layers: GeoLibreLayer[]): void {
-  duckdbLayerOrder = new Map(
-    layers
-      .filter(isDuckDBControlLayer)
-      .map((layer, index) => [layer.id, index]),
-  );
+  duckdbLayerOrder.clear();
+  layers
+    .filter(isDuckDBControlLayer)
+    .forEach((layer, index) => duckdbLayerOrder.set(layer.id, index));
 
   for (const layer of layers) {
     if (!isDuckDBControlLayer(layer)) continue;
 
     const renderedLayer = duckdbRenderedLayers.get(layer.id);
-    if (renderedLayer) {
-      renderedLayer.name = layer.name;
-      renderedLayer.beforeId = layer.beforeId ?? null;
-    }
+    if (!renderedLayer) continue;
+
+    renderedLayer.name = layer.name;
+    renderedLayer.beforeId = layer.beforeId ?? null;
 
     duckdbRenderedStyles.set(layer.id, {
       opacity: layer.opacity,
@@ -375,9 +374,15 @@ function patchDuckDBRenderer(renderer: DuckDBRendererLike | null | undefined) {
   if (renderer.setData && !renderer.__geolibreOriginalSetData) {
     renderer.__geolibreOriginalSetData = renderer.setData.bind(renderer);
     renderer.setData = (layers: DuckDBRenderedLayerLike[]) => {
-      renderer.__geolibreOriginalSetData?.(
-        [...layers].sort(compareDuckDBLayerOrder),
-      );
+      // The control's own follow-up renders (feature select, pickable
+      // toggle) pass only its current layer, which would wipe the other
+      // cached layers. Fold the fresh results into the cache and always
+      // render the full ordered set instead.
+      for (const incoming of layers) {
+        const cached = duckdbRenderedLayers.get(incoming.id);
+        if (cached) cached.results = incoming.results;
+      }
+      renderer.__geolibreOriginalSetData?.(getOrderedDuckDBRenderedLayers());
     };
   }
 

--- a/packages/plugins/src/plugins/maplibre-duckdb.ts
+++ b/packages/plugins/src/plugins/maplibre-duckdb.ts
@@ -209,6 +209,10 @@ function createDuckDBQueryHandler(): DuckDBControlEventHandler {
     const layer = createDuckDBStoreLayer(event.state, nextLayerState);
 
     if (controlLayer) {
+      // Rename the control's internal layer to the unique query layer id so
+      // its own follow-up renders and feature-select calls stay keyed to the
+      // same id as the cached layer below. The renderer rebuilds all deck
+      // layers from scratch on every setData call, so the rename is safe.
       controlLayer.id = queryLayerId;
       controlLayer.name = queryLayerName;
       duckdbRenderedLayers.set(layer.id, {
@@ -218,10 +222,20 @@ function createDuckDBQueryHandler(): DuckDBControlEventHandler {
         results: controlLayer.results ?? controlLayer.geoArrowResults ?? [],
       });
       duckdbRenderedRows.set(layer.id, controlLayer.rows ?? {});
+    } else if (import.meta.env.DEV) {
+      console.warn(
+        `DuckDB query completed before the control layer was ready; layer ${queryLayerId} will not render.`,
+      );
     }
 
+    // Seed the style before addLayer so the store subscription's sync render
+    // already picks it up, avoiding a second back-to-back render.
+    duckdbRenderedStyles.set(layer.id, {
+      opacity: layer.opacity,
+      style: layer.style,
+      visible: layer.visible,
+    });
     store.addLayer(layer);
-    setDuckDBRenderedLayerStyle(layer);
   };
 }
 
@@ -242,7 +256,6 @@ function createDuckDBStateChangeHandler(): DuckDBControlEventHandler {
 function createDuckDBStoreLayer(
   state: DuckDBState,
   layerState: DuckDBLayerState,
-  existingLayer?: GeoLibreLayer,
 ): GeoLibreLayer {
   return {
     id: layerState.id,
@@ -254,10 +267,10 @@ function createDuckDBStoreLayer(
       query: layerState.query,
       type: "duckdb",
     },
-    visible: existingLayer?.visible ?? true,
-    opacity: existingLayer?.opacity ?? 1,
-    style: existingLayer?.style ?? { ...DEFAULT_LAYER_STYLE },
-    beforeId: layerState.beforeId ?? existingLayer?.beforeId,
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    beforeId: layerState.beforeId,
     metadata: {
       columns: layerState.schema,
       databaseSource: state.databaseSource,
@@ -293,15 +306,6 @@ function clearDuckDBRenderedLayers(): void {
   duckdbRenderedStyles.clear();
   warnedMissingRowsLayerIds.clear();
   getMutableDuckDBControl().renderer?.clear?.();
-}
-
-function setDuckDBRenderedLayerStyle(layer: GeoLibreLayer): void {
-  duckdbRenderedStyles.set(layer.id, {
-    opacity: layer.opacity,
-    style: layer.style,
-    visible: layer.visible,
-  });
-  renderDuckDBCachedLayers();
 }
 
 function syncDuckDBRenderedLayersFromStore(layers: GeoLibreLayer[]): void {

--- a/packages/plugins/src/plugins/maplibre-duckdb.ts
+++ b/packages/plugins/src/plugins/maplibre-duckdb.ts
@@ -195,7 +195,16 @@ function createDuckDBQueryHandler(): DuckDBControlEventHandler {
     if (!layerState) return;
 
     const store = useAppStore.getState();
-    const controlLayer = getMutableDuckDBControl().layer;
+    const controlLayer = getMutableDuckDBControl()?.layer;
+    if (!controlLayer) {
+      // Without the control's layer there is no geometry to render; skip
+      // adding a ghost entry to the store.
+      console.warn(
+        "DuckDB query completed before the control layer was ready; the result will not be added to the layer list.",
+      );
+      return;
+    }
+
     const queryLayerId = createDuckDBQueryLayerId(layerState.id);
     const queryLayerName = createUniqueDuckDBLayerName(
       layerState.name,
@@ -208,24 +217,23 @@ function createDuckDBQueryHandler(): DuckDBControlEventHandler {
     };
     const layer = createDuckDBStoreLayer(event.state, nextLayerState);
 
-    if (controlLayer) {
-      // Rename the control's internal layer to the unique query layer id so
-      // its own follow-up renders and feature-select calls stay keyed to the
-      // same id as the cached layer below. The renderer rebuilds all deck
-      // layers from scratch on every setData call, so the rename is safe.
-      controlLayer.id = queryLayerId;
-      controlLayer.name = queryLayerName;
-      duckdbRenderedLayers.set(layer.id, {
-        beforeId: controlLayer.beforeId ?? nextLayerState.beforeId ?? null,
-        id: layer.id,
-        name: layer.name,
-        results: controlLayer.results ?? controlLayer.geoArrowResults ?? [],
-      });
-      duckdbRenderedRows.set(layer.id, controlLayer.rows ?? {});
-    } else if (import.meta.env.DEV) {
-      console.warn(
-        `DuckDB query completed before the control layer was ready; layer ${queryLayerId} will not render.`,
-      );
+    // Rename the control's internal layer to the unique query layer id so
+    // its own follow-up renders and feature-select calls stay keyed to the
+    // same id as the cached layer below. Verified against
+    // maplibre-gl-duckdb 0.2.0: the renderer rebuilds all deck layers from
+    // scratch on every setData call and the control builds a fresh layer
+    // object (with complete rows) before emitting "query", so the rename
+    // and the by-reference caches are safe. Re-check on library upgrades.
+    controlLayer.id = queryLayerId;
+    controlLayer.name = queryLayerName;
+    duckdbRenderedLayers.set(layer.id, {
+      beforeId: controlLayer.beforeId ?? nextLayerState.beforeId ?? null,
+      id: layer.id,
+      name: layer.name,
+      results: controlLayer.results ?? controlLayer.geoArrowResults ?? [],
+    });
+    if (controlLayer.rows) {
+      duckdbRenderedRows.set(layer.id, controlLayer.rows);
     }
 
     // Seed the style before addLayer so the store subscription's sync render
@@ -297,7 +305,9 @@ function removeDuckDBRenderedLayer(layerId: string): void {
   duckdbRenderedStyles.delete(layerId);
   duckdbLayerOrder.delete(layerId);
   warnedMissingRowsLayerIds.delete(layerId);
-  renderDuckDBCachedLayers();
+  // No render here: removals are only observed via the store subscription,
+  // whose layer-order signature check follows up with
+  // syncDuckDBRenderedLayersFromStore and a single render.
 }
 
 function clearDuckDBRenderedLayers(): void {
@@ -306,7 +316,7 @@ function clearDuckDBRenderedLayers(): void {
   duckdbRenderedRows.clear();
   duckdbRenderedStyles.clear();
   warnedMissingRowsLayerIds.clear();
-  getMutableDuckDBControl().renderer?.clear?.();
+  getMutableDuckDBControl()?.renderer?.clear?.();
 }
 
 function syncDuckDBRenderedLayersFromStore(layers: GeoLibreLayer[]): void {
@@ -346,33 +356,35 @@ function renderDuckDBCachedLayers(): void {
 }
 
 function getOrderedDuckDBRenderedLayers(): DuckDBRenderedLayerLike[] {
-  return [...duckdbRenderedLayers.values()].sort(
-    (first, second) =>
-      (duckdbLayerOrder.get(first.id) ?? Number.MAX_SAFE_INTEGER) -
-      (duckdbLayerOrder.get(second.id) ?? Number.MAX_SAFE_INTEGER),
+  return [...duckdbRenderedLayers.values()].sort(compareDuckDBLayerOrder);
+}
+
+function compareDuckDBLayerOrder(
+  first: DuckDBRenderedLayerLike,
+  second: DuckDBRenderedLayerLike,
+): number {
+  return (
+    (duckdbLayerOrder.get(first.id) ?? Number.MAX_SAFE_INTEGER) -
+    (duckdbLayerOrder.get(second.id) ?? Number.MAX_SAFE_INTEGER)
   );
 }
 
 function patchDuckDBRenderer(renderer: DuckDBRendererLike | null | undefined) {
   if (!renderer || renderer.__geolibreStylePatched) return;
 
-  if (renderer.setData) {
+  if (renderer.setData && !renderer.__geolibreOriginalSetData) {
     renderer.__geolibreOriginalSetData = renderer.setData.bind(renderer);
     renderer.setData = (layers: DuckDBRenderedLayerLike[]) => {
       renderer.__geolibreOriginalSetData?.(
-        [...layers].sort(
-          (first, second) =>
-            (duckdbLayerOrder.get(first.id) ?? Number.MAX_SAFE_INTEGER) -
-            (duckdbLayerOrder.get(second.id) ?? Number.MAX_SAFE_INTEGER),
-        ),
+        [...layers].sort(compareDuckDBLayerOrder),
       );
     };
   }
 
-  if (!renderer.createLayers) {
-    renderer.__geolibreStylePatched = true;
-    return;
-  }
+  // Leave the patched flag unset until createLayers is available so a later
+  // call can finish the patch; the setData guard above keeps that retry
+  // idempotent.
+  if (!renderer.createLayers) return;
 
   renderer.__geolibreOriginalCreateLayers = renderer.createLayers.bind(
     renderer,
@@ -559,8 +571,8 @@ function isDuckDBControlLayer(layer: GeoLibreLayer): boolean {
 
 function getMutableDuckDBControl(
   control = duckdbControl,
-): MutableDuckDBControl {
-  return control as unknown as MutableDuckDBControl;
+): MutableDuckDBControl | null {
+  return control as unknown as MutableDuckDBControl | null;
 }
 
 function createDuckDBQueryLayerId(baseId: string): string {

--- a/packages/plugins/src/plugins/maplibre-duckdb.ts
+++ b/packages/plugins/src/plugins/maplibre-duckdb.ts
@@ -18,6 +18,7 @@ import {
   pointRadiusMaxPixels,
   type StyledDeckLayerLike,
 } from "./deck-style-utils";
+import { ensureMercatorProjection } from "./map-projection-utils";
 
 type DuckDBControlConstructor =
   (typeof import("maplibre-gl-duckdb"))["DuckDBControl"];
@@ -26,19 +27,40 @@ type DuckDBRendererLike = {
   clear?: () => void;
   createLayers?: (
     layerId: string,
-    result: { geometryType?: string },
+    result: DuckDBResultLike,
     index: number,
   ) => StyledDeckLayerLike[];
+  setData?: (layers: DuckDBRenderedLayerLike[]) => void;
+  __geolibreOriginalSetData?: DuckDBRendererLike["setData"];
   __geolibreStylePatched?: boolean;
   __geolibreOriginalCreateLayers?: DuckDBRendererLike["createLayers"];
 };
 
+type DuckDBResultLike = {
+  bounds?: [number, number, number, number];
+  geometryType?: string;
+};
+
+type DuckDBRenderedLayerLike = {
+  beforeId?: string | null;
+  id: string;
+  name?: string;
+  results: DuckDBResultLike[];
+};
+
+type DuckDBInternalLayer = DuckDBRenderedLayerLike & {
+  geoArrowResults?: DuckDBResultLike[];
+  geometryColumn?: string | null;
+  geometryFormat?: string | null;
+  query?: string;
+  rows?: Record<number, Record<string, unknown>>;
+  schema?: DuckDBLayerState["schema"];
+  totalRows?: number;
+};
+
 type MutableDuckDBControl = {
   beforeId?: string;
-  layer?: {
-    beforeId: string | null;
-    rows?: Record<number, Record<string, unknown>>;
-  } | null;
+  layer?: DuckDBInternalLayer | null;
   renderLayer?: () => Promise<void>;
   renderer?: DuckDBRendererLike | null;
 };
@@ -46,20 +68,17 @@ type MutableDuckDBControl = {
 interface DuckDBRenderedStyle {
   opacity: number;
   style: LayerStyle;
+  visible: boolean;
 }
 
 const duckdbControlPosition: GeoLibreMapControlPosition = "top-left";
 const DUCKDB_SAMPLE_DATABASE_URL =
   "https://data.source.coop/giswqs/opengeos/nyc_data.db";
-const DUCKDB_SAMPLE_QUERY = `SELECT BORONAME, NAME, ST_Transform(geom, 'EPSG:32618', 'EPSG:4326', true) AS geom
-FROM data.main.nyc_neighborhoods
-LIMIT 1000`;
 
 const DUCKDB_OPTIONS = {
   className: "geolibre-duckdb-control",
   collapsed: false,
   geometryColumn: "geom",
-  initialQuery: DUCKDB_SAMPLE_QUERY,
   layerName: "DuckDB query",
   panelWidth: 365,
   pickable: true,
@@ -74,6 +93,9 @@ let duckdbStoreUnsubscribe: (() => void) | null = null;
 let duckdbConstructorsPromise: Promise<{
   DuckDBControl: DuckDBControlConstructor;
 }> | null = null;
+let duckdbLayerOrder = new Map<string, number>();
+const duckdbRenderedLayers = new Map<string, DuckDBRenderedLayerLike>();
+const duckdbRenderedRows = new Map<string, Record<number, Record<string, unknown>>>();
 const duckdbRenderedStyles = new Map<string, DuckDBRenderedStyle>();
 const warnedMissingRowsLayerIds = new Set<string>();
 
@@ -84,6 +106,8 @@ export function openDuckDBLayerPanel(app: GeoLibreAppAPI): void {
 async function openStandaloneDuckDBControl(
   app: GeoLibreAppAPI,
 ): Promise<boolean> {
+  ensureMercatorProjection(app.getMap?.());
+
   const { DuckDBControl: DuckDBControlClass } = await getDuckDBConstructors();
 
   duckdbControl ??= createDuckDBControl(DuckDBControlClass);
@@ -126,6 +150,8 @@ function createDuckDBControl(
   duckdbStoreUnsubscribe ??= useAppStore.subscribe((state, previous) => {
     const currentById = new Map(state.layers.map((layer) => [layer.id, layer]));
 
+    let shouldSyncControl = false;
+
     for (const layer of previous.layers) {
       if (!isDuckDBControlLayer(layer)) continue;
 
@@ -137,20 +163,26 @@ function createDuckDBControl(
 
       if (!isDuckDBControlLayer(currentLayer)) continue;
 
-      if (currentLayer.visible !== layer.visible) {
-        setDuckDBRenderedLayerVisible(currentLayer.visible);
-      }
-
       if (
         currentLayer.opacity !== layer.opacity ||
-        currentLayer.style !== layer.style
+        currentLayer.style !== layer.style ||
+        currentLayer.visible !== layer.visible ||
+        currentLayer.beforeId !== layer.beforeId ||
+        currentLayer.name !== layer.name
       ) {
-        setDuckDBRenderedLayerStyle(currentLayer);
+        shouldSyncControl = true;
       }
+    }
 
-      if (currentLayer.beforeId !== layer.beforeId) {
-        setDuckDBRenderedLayerBeforeId(currentLayer.beforeId ?? null);
-      }
+    if (
+      duckdbLayerOrderSignature(state.layers) !==
+      duckdbLayerOrderSignature(previous.layers)
+    ) {
+      shouldSyncControl = true;
+    }
+
+    if (shouldSyncControl) {
+      syncDuckDBRenderedLayersFromStore(state.layers);
     }
   });
 
@@ -163,26 +195,32 @@ function createDuckDBQueryHandler(): DuckDBControlEventHandler {
     if (!layerState) return;
 
     const store = useAppStore.getState();
-    const existingLayer = store.layers.find((layer) => layer.id === layerState.id);
-    const layer = createDuckDBStoreLayer(event.state, layerState, existingLayer);
+    const controlLayer = getMutableDuckDBControl().layer;
+    const queryLayerId = createDuckDBQueryLayerId(layerState.id);
+    const queryLayerName = createUniqueDuckDBLayerName(
+      layerState.name,
+      store.layers,
+    );
+    const nextLayerState = {
+      ...layerState,
+      id: queryLayerId,
+      name: queryLayerName,
+    };
+    const layer = createDuckDBStoreLayer(event.state, nextLayerState);
 
-    if (existingLayer) {
-      store.updateLayer(layer.id, {
-        metadata: layer.metadata,
+    if (controlLayer) {
+      controlLayer.id = queryLayerId;
+      controlLayer.name = queryLayerName;
+      duckdbRenderedLayers.set(layer.id, {
+        beforeId: controlLayer.beforeId ?? nextLayerState.beforeId ?? null,
+        id: layer.id,
         name: layer.name,
-        source: layer.source,
-        sourcePath: layer.sourcePath,
-        style: layer.style,
+        results: controlLayer.results ?? controlLayer.geoArrowResults ?? [],
       });
-      setDuckDBRenderedLayerVisible(layer.visible);
-      setDuckDBRenderedLayerBeforeId(layer.beforeId ?? null);
-      setDuckDBRenderedLayerStyle(layer);
-      return;
+      duckdbRenderedRows.set(layer.id, controlLayer.rows ?? {});
     }
 
     store.addLayer(layer);
-    setDuckDBRenderedLayerVisible(layer.visible);
-    setDuckDBRenderedLayerBeforeId(layer.beforeId ?? null);
     setDuckDBRenderedLayerStyle(layer);
   };
 }
@@ -197,6 +235,7 @@ function createDuckDBStateChangeHandler(): DuckDBControlEventHandler {
         store.removeLayer(layer.id);
       }
     }
+    clearDuckDBRenderedLayers();
   };
 }
 
@@ -240,54 +279,106 @@ function createDuckDBStoreLayer(
 }
 
 function removeDuckDBRenderedLayer(layerId: string): void {
-  const stateLayerId = duckdbControl?.getState().layer?.id;
-  if (stateLayerId !== layerId) return;
+  duckdbRenderedLayers.delete(layerId);
+  duckdbRenderedRows.delete(layerId);
   duckdbRenderedStyles.delete(layerId);
-  duckdbControl?.clear();
+  warnedMissingRowsLayerIds.delete(layerId);
+  renderDuckDBCachedLayers();
 }
 
-function setDuckDBRenderedLayerVisible(visible: boolean): void {
-  const control = duckdbControl as unknown as MutableDuckDBControl | null;
-  if (!control) return;
-
-  if (!visible) {
-    control.renderer?.clear?.();
-    return;
-  }
-
-  void control.renderLayer?.();
+function clearDuckDBRenderedLayers(): void {
+  duckdbLayerOrder.clear();
+  duckdbRenderedLayers.clear();
+  duckdbRenderedRows.clear();
+  duckdbRenderedStyles.clear();
+  warnedMissingRowsLayerIds.clear();
+  getMutableDuckDBControl().renderer?.clear?.();
 }
 
 function setDuckDBRenderedLayerStyle(layer: GeoLibreLayer): void {
   duckdbRenderedStyles.set(layer.id, {
     opacity: layer.opacity,
     style: layer.style,
+    visible: layer.visible,
   });
-  void renderStyledDuckDBLayer();
+  renderDuckDBCachedLayers();
 }
 
-async function renderStyledDuckDBLayer(): Promise<void> {
-  const control = duckdbControl as unknown as MutableDuckDBControl | null;
-  if (!control) return;
+function syncDuckDBRenderedLayersFromStore(layers: GeoLibreLayer[]): void {
+  duckdbLayerOrder = new Map(
+    layers
+      .filter(isDuckDBControlLayer)
+      .map((layer, index) => [layer.id, index]),
+  );
 
-  if (!control.renderer) {
-    await control.renderLayer?.();
+  for (const layer of layers) {
+    if (!isDuckDBControlLayer(layer)) continue;
+
+    const renderedLayer = duckdbRenderedLayers.get(layer.id);
+    if (renderedLayer) {
+      renderedLayer.name = layer.name;
+      renderedLayer.beforeId = layer.beforeId ?? null;
+    }
+
+    duckdbRenderedStyles.set(layer.id, {
+      opacity: layer.opacity,
+      style: layer.style,
+      visible: layer.visible,
+    });
   }
-  patchDuckDBRenderer(control.renderer);
-  await control.renderLayer?.();
+
+  renderDuckDBCachedLayers();
+}
+
+function renderDuckDBCachedLayers(): void {
+  const control = duckdbControl as unknown as MutableDuckDBControl | null;
+  const renderer = control?.renderer;
+  if (!renderer) return;
+
+  patchDuckDBRenderer(renderer);
+  renderer.setData?.(getOrderedDuckDBRenderedLayers());
+}
+
+function getOrderedDuckDBRenderedLayers(): DuckDBRenderedLayerLike[] {
+  return [...duckdbRenderedLayers.values()].sort(
+    (first, second) =>
+      (duckdbLayerOrder.get(first.id) ?? Number.MAX_SAFE_INTEGER) -
+      (duckdbLayerOrder.get(second.id) ?? Number.MAX_SAFE_INTEGER),
+  );
 }
 
 function patchDuckDBRenderer(renderer: DuckDBRendererLike | null | undefined) {
-  if (!renderer?.createLayers || renderer.__geolibreStylePatched) return;
+  if (!renderer || renderer.__geolibreStylePatched) return;
+
+  if (renderer.setData) {
+    renderer.__geolibreOriginalSetData = renderer.setData.bind(renderer);
+    renderer.setData = (layers: DuckDBRenderedLayerLike[]) => {
+      renderer.__geolibreOriginalSetData?.(
+        [...layers].sort(
+          (first, second) =>
+            (duckdbLayerOrder.get(first.id) ?? Number.MAX_SAFE_INTEGER) -
+            (duckdbLayerOrder.get(second.id) ?? Number.MAX_SAFE_INTEGER),
+        ),
+      );
+    };
+  }
+
+  if (!renderer.createLayers) {
+    renderer.__geolibreStylePatched = true;
+    return;
+  }
 
   renderer.__geolibreOriginalCreateLayers = renderer.createLayers.bind(
     renderer,
   );
   renderer.createLayers = (
     layerId: string,
-    result: { geometryType?: string },
+    result: DuckDBResultLike,
     index: number,
   ) => {
+    const renderedStyle = duckdbRenderedStyles.get(layerId);
+    if (renderedStyle && !renderedStyle.visible) return [];
+
     const originalLayers = renderer.__geolibreOriginalCreateLayers?.(
       layerId,
       result,
@@ -295,7 +386,6 @@ function patchDuckDBRenderer(renderer: DuckDBRendererLike | null | undefined) {
     );
     if (!originalLayers) return [];
 
-    const renderedStyle = duckdbRenderedStyles.get(layerId);
     if (!renderedStyle) return originalLayers;
 
     return originalLayers.map((deckLayer) =>
@@ -418,6 +508,9 @@ function getGeoArrowRowIndex(objectInfo: {
 }
 
 function getDuckDBRenderedRows(layerId: string): Record<number, Record<string, unknown>> {
+  const cachedRows = duckdbRenderedRows.get(layerId);
+  if (cachedRows) return cachedRows;
+
   const control = duckdbControl as unknown as MutableDuckDBControl | null;
   const stateLayerId = duckdbControl?.getState().layer?.id;
   if (stateLayerId !== layerId) return {};
@@ -440,15 +533,6 @@ function warnMissingDuckDBRows(layerId: string): void {
   }
 }
 
-function setDuckDBRenderedLayerBeforeId(beforeId: string | null): void {
-  const control = duckdbControl as unknown as MutableDuckDBControl | null;
-  if (!control) return;
-
-  control.beforeId = beforeId ?? "";
-  if (control.layer) control.layer.beforeId = beforeId;
-  void control.renderLayer?.();
-}
-
 function hideDuckDBControl(control: DuckDBControl | null): void {
   const container = control?.getContainer();
   if (container) container.style.display = "none";
@@ -465,4 +549,32 @@ function isDuckDBControlLayer(layer: GeoLibreLayer): boolean {
     layer.metadata.sourceKind === "duckdb-query" &&
     layer.metadata.externalDeckLayer === true
   );
+}
+
+function getMutableDuckDBControl(
+  control = duckdbControl,
+): MutableDuckDBControl {
+  return control as unknown as MutableDuckDBControl;
+}
+
+function createDuckDBQueryLayerId(baseId: string): string {
+  return `${baseId}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function createUniqueDuckDBLayerName(
+  baseName: string,
+  existingLayers: GeoLibreLayer[],
+): string {
+  const trimmedBaseName = baseName.trim() || "DuckDB query";
+  const existingNames = new Set(existingLayers.map((layer) => layer.name));
+  if (!existingNames.has(trimmedBaseName)) return trimmedBaseName;
+
+  for (let index = 2; ; index += 1) {
+    const candidate = `${trimmedBaseName} ${index}`;
+    if (!existingNames.has(candidate)) return candidate;
+  }
+}
+
+function duckdbLayerOrderSignature(layers: GeoLibreLayer[]): string {
+  return layers.filter(isDuckDBControlLayer).map((layer) => layer.id).join("|");
 }


### PR DESCRIPTION
## Summary
- Each DuckDB query now creates its own uniquely named store layer instead of replacing the single rendered layer, so multiple query results can coexist on the map
- Rendered layer data, picked rows, ordering, visibility, and styles are cached per layer and re-synced to the renderer whenever the layer list changes
- Removed the prefilled sample query and ensure the map uses a Mercator projection before opening the DuckDB control

## Test plan
- [ ] Run two different DuckDB queries and confirm both result layers appear on the map and in the layer list
- [ ] Toggle visibility, change style and opacity, rename, and reorder each DuckDB layer and confirm the map updates
- [ ] Remove one DuckDB layer and confirm the other keeps rendering with correct tooltips
- [ ] Disconnect the database and confirm all DuckDB layers are removed