### PR TITLE
Add desktop diagnostics panel

### DIFF
--- a/apps/geolibre-desktop/src/App.tsx
+++ b/apps/geolibre-desktop/src/App.tsx
@@ -5,7 +5,6 @@ import { useProjectUrlLoader } from "./hooks/useProjectUrlLoader";
 import { useRecentProjectsPersistence } from "./hooks/useRecentProjectsPersistence";
 import { useRuntimeEnvironmentVariables } from "./hooks/useRuntimeEnvironmentVariables";
 import { useThemeMode } from "./hooks/useThemeMode";
-import { useDiagnosticsCapture } from "./lib/diagnostics";
 
 export default function App() {
   const layoutOptions = useLayoutOptions();
@@ -13,7 +12,6 @@ export default function App() {
   const projectUrlLoadState = useProjectUrlLoader();
 
   useDesktopSettingsPersistence();
-  useDiagnosticsCapture();
   useRecentProjectsPersistence();
   useRuntimeEnvironmentVariables();
   return (

--- a/apps/geolibre-desktop/src/App.tsx
+++ b/apps/geolibre-desktop/src/App.tsx
@@ -5,6 +5,7 @@ import { useProjectUrlLoader } from "./hooks/useProjectUrlLoader";
 import { useRecentProjectsPersistence } from "./hooks/useRecentProjectsPersistence";
 import { useRuntimeEnvironmentVariables } from "./hooks/useRuntimeEnvironmentVariables";
 import { useThemeMode } from "./hooks/useThemeMode";
+import { useDiagnosticsCapture } from "./lib/diagnostics";
 
 export default function App() {
   const layoutOptions = useLayoutOptions();
@@ -12,6 +13,7 @@ export default function App() {
   const projectUrlLoadState = useProjectUrlLoader();
 
   useDesktopSettingsPersistence();
+  useDiagnosticsCapture();
   useRecentProjectsPersistence();
   useRuntimeEnvironmentVariables();
   return (

--- a/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
@@ -166,6 +166,12 @@ export function AboutDialog({
     wasOpenRef.current = dialogOpen;
   }, [dialogOpen]);
 
+  // Read the latest handler through a ref so the effect can depend only on
+  // the command counter; the update check should run exactly once for each
+  // increment.
+  const handleCheckForUpdatesRef = useRef(handleCheckForUpdates);
+  handleCheckForUpdatesRef.current = handleCheckForUpdates;
+
   useEffect(() => {
     if (
       !dialogOpen ||
@@ -175,10 +181,7 @@ export function AboutDialog({
       return;
     }
     handledCheckForUpdatesRequestRef.current = checkForUpdatesRequest;
-    void handleCheckForUpdates();
-    // checkForUpdatesRequest is an explicit command counter; the update check
-    // should run exactly once for each increment.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    void handleCheckForUpdatesRef.current();
   }, [checkForUpdatesRequest, dialogOpen]);
 
   const handleOpenChange = (nextOpen: boolean) => {

--- a/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
@@ -169,7 +169,9 @@ export function AboutDialog({
 
   // Read the latest handler through a ref so the effect can depend only on
   // the command counter; the update check should run exactly once for each
-  // increment.
+  // increment. Invariant: call sites must increment checkForUpdatesRequest
+  // only while also opening the dialog; an increment made while the dialog
+  // stays closed would fire the check on the next open instead.
   const handleCheckForUpdatesRef = useRef(handleCheckForUpdates);
   handleCheckForUpdatesRef.current = handleCheckForUpdates;
 

--- a/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
@@ -6,7 +6,6 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from "@geolibre/ui";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { CheckCircle2, ExternalLink, Info, Map, RefreshCw } from "lucide-react";
@@ -35,6 +34,10 @@ interface GitHubRelease {
 }
 
 interface AboutDialogProps {
+  checkForUpdatesRequest?: number;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  renderTrigger?: boolean;
   buttonClassName?: string;
   buttonSize?: ButtonProps["size"];
   iconClassName?: string;
@@ -78,15 +81,23 @@ function formatVersion(version: string): string {
 }
 
 export function AboutDialog({
+  checkForUpdatesRequest = 0,
+  open,
+  onOpenChange,
+  renderTrigger = true,
   buttonClassName,
   buttonSize = "sm",
   iconClassName,
   showLabels = true,
 }: AboutDialogProps) {
+  const [internalOpen, setInternalOpen] = useState(false);
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus>("idle");
   const [latestVersion, setLatestVersion] = useState<string | null>(null);
   const [updateError, setUpdateError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const handledCheckForUpdatesRequestRef = useRef(0);
+  const wasOpenRef = useRef(false);
+  const dialogOpen = open ?? internalOpen;
 
   useEffect(() => () => abortRef.current?.abort(), []);
 
@@ -150,23 +161,45 @@ export function AboutDialog({
     }
   };
 
+  useEffect(() => {
+    if (dialogOpen && !wasOpenRef.current) resetUpdateState();
+    wasOpenRef.current = dialogOpen;
+  }, [dialogOpen]);
+
+  useEffect(() => {
+    if (
+      !dialogOpen ||
+      checkForUpdatesRequest === 0 ||
+      checkForUpdatesRequest === handledCheckForUpdatesRequestRef.current
+    ) {
+      return;
+    }
+    handledCheckForUpdatesRequestRef.current = checkForUpdatesRequest;
+    void handleCheckForUpdates();
+    // checkForUpdatesRequest is an explicit command counter; the update check
+    // should run exactly once for each increment.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [checkForUpdatesRequest, dialogOpen]);
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setInternalOpen(nextOpen);
+    onOpenChange?.(nextOpen);
+  };
+
   return (
-    <Dialog
-      onOpenChange={(open) => {
-        if (open) resetUpdateState();
-      }}
-    >
-      <DialogTrigger asChild>
+    <Dialog open={dialogOpen} onOpenChange={handleOpenChange}>
+      {renderTrigger ? (
         <Button
           className={buttonClassName}
           variant="ghost"
           size={buttonSize}
           aria-label="About"
+          onClick={() => handleOpenChange(true)}
         >
           <Info className={iconClassName ?? "h-3.5 w-3.5 sm:mr-1"} />
           {showLabels ? <span className="hidden sm:inline">About</span> : null}
         </Button>
-      </DialogTrigger>
+      ) : null}
       <DialogContent className="max-w-md">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">

--- a/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
@@ -6,10 +6,11 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
+  DialogTrigger,
 } from "@geolibre/ui";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { CheckCircle2, ExternalLink, Info, Map, RefreshCw } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 const LINKS = [
   {
@@ -101,11 +102,11 @@ export function AboutDialog({
 
   useEffect(() => () => abortRef.current?.abort(), []);
 
-  const resetUpdateState = () => {
+  const resetUpdateState = useCallback(() => {
     setUpdateStatus("idle");
     setLatestVersion(null);
     setUpdateError(null);
-  };
+  }, []);
 
   const handleCheckForUpdates = async () => {
     abortRef.current?.abort();
@@ -164,7 +165,7 @@ export function AboutDialog({
   useEffect(() => {
     if (dialogOpen && !wasOpenRef.current) resetUpdateState();
     wasOpenRef.current = dialogOpen;
-  }, [dialogOpen]);
+  }, [dialogOpen, resetUpdateState]);
 
   // Read the latest handler through a ref so the effect can depend only on
   // the command counter; the update check should run exactly once for each
@@ -192,16 +193,19 @@ export function AboutDialog({
   return (
     <Dialog open={dialogOpen} onOpenChange={handleOpenChange}>
       {renderTrigger ? (
-        <Button
-          className={buttonClassName}
-          variant="ghost"
-          size={buttonSize}
-          aria-label="About"
-          onClick={() => handleOpenChange(true)}
-        >
-          <Info className={iconClassName ?? "h-3.5 w-3.5 sm:mr-1"} />
-          {showLabels ? <span className="hidden sm:inline">About</span> : null}
-        </Button>
+        <DialogTrigger asChild>
+          <Button
+            className={buttonClassName}
+            variant="ghost"
+            size={buttonSize}
+            aria-label="About"
+          >
+            <Info className={iconClassName ?? "h-3.5 w-3.5 sm:mr-1"} />
+            {showLabels ? (
+              <span className="hidden sm:inline">About</span>
+            ) : null}
+          </Button>
+        </DialogTrigger>
       ) : null}
       <DialogContent className="max-w-md">
         <DialogHeader>

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -501,6 +501,7 @@ export function DesktopShell({
         onOpenDiagnostics={() => setDiagnosticsOpen(true)}
       />
       <DiagnosticsDialog
+        diagnostics={diagnostics}
         open={diagnosticsOpen}
         onOpenChange={setDiagnosticsOpen}
       />

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -1,5 +1,5 @@
 import { useAppStore } from "@geolibre/core";
-import type { MapController } from "@geolibre/map";
+import type { MapController, MapDiagnosticEvent } from "@geolibre/map";
 import { MapCanvas } from "@geolibre/map";
 import { restoreThreeDTilesLayers } from "@geolibre/plugins";
 import {
@@ -25,9 +25,14 @@ import {
 } from "../../hooks/usePlugins";
 import { registerMbtilesProtocol } from "../../lib/mbtiles";
 import { registerXyzTileProtocol } from "../../lib/xyz-url";
+import {
+  appendDiagnostic,
+  useDiagnosticsSnapshot,
+} from "../../lib/diagnostics";
 import { AttributeTable } from "../panels/AttributeTable";
 import { LayerPanel } from "../panels/LayerPanel";
 import { StylePanel } from "../panels/StylePanel";
+import { DiagnosticsDialog } from "./DiagnosticsDialog";
 import { StatusBar } from "./StatusBar";
 import { TopToolbar } from "./TopToolbar";
 import type { LayoutOptions } from "../../hooks/useLayoutOptions";
@@ -103,6 +108,8 @@ export function DesktopShell({
   const [mapReadyGeneration, setMapReadyGeneration] = useState(0);
   const [dropMessage, setDropMessage] = useState<string | null>(null);
   const [dropError, setDropError] = useState<string | null>(null);
+  const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
+  const diagnostics = useDiagnosticsSnapshot();
   const externalPluginsReady = useExternalPluginsReady();
   const [layerPanelWidth, setLayerPanelWidth] = useState(
     DEFAULT_SIDE_PANEL_WIDTH,
@@ -163,6 +170,18 @@ export function DesktopShell({
 
   const handleMapControllerReady = useCallback(() => {
     setMapReadyGeneration((generation) => generation + 1);
+  }, []);
+
+  const handleMapDiagnosticEvent = useCallback((event: MapDiagnosticEvent) => {
+    appendDiagnostic({
+      category: "map",
+      level: "error",
+      message: event.message,
+      detail: event.detail,
+      source: event.source,
+      status: event.status,
+      url: event.url,
+    });
   }, []);
 
   const addImportedVectorLayers = useCallback(
@@ -444,10 +463,13 @@ export function DesktopShell({
     >
       <TopToolbar
         compact={layoutOptions.compact}
+        diagnosticsErrorCount={diagnostics.errorCount}
+        diagnosticsTotalCount={diagnostics.totalCount}
         mapControllerRef={mapControllerRef}
         showLabels={layoutOptions.toolbarLabels}
         showProjectInfo={layoutOptions.showProjectInfo}
         themeMode={themeMode}
+        onOpenDiagnostics={() => setDiagnosticsOpen(true)}
         onToggleThemeMode={onToggleThemeMode}
       />
       <div className="flex min-h-0 flex-1 flex-col md:flex-row">
@@ -464,6 +486,7 @@ export function DesktopShell({
         >
           <MapCanvas
             controllerRef={mapControllerRef}
+            onMapDiagnosticEvent={handleMapDiagnosticEvent}
             onControllerReady={handleMapControllerReady}
           />
         </main>
@@ -472,7 +495,16 @@ export function DesktopShell({
         ) : null}
       </div>
       {layoutOptions.panelsVisible ? <AttributeTable /> : null}
-      <StatusBar compact={layoutOptions.compact} />
+      <StatusBar
+        compact={layoutOptions.compact}
+        diagnosticsErrorCount={diagnostics.errorCount}
+        diagnosticsWarningCount={diagnostics.warningCount}
+        onOpenDiagnostics={() => setDiagnosticsOpen(true)}
+      />
+      <DiagnosticsDialog
+        open={diagnosticsOpen}
+        onOpenChange={setDiagnosticsOpen}
+      />
       <Suspense fallback={null}>
         <ProcessingDialog mapControllerRef={mapControllerRef} />
       </Suspense>

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -464,7 +464,6 @@ export function DesktopShell({
       <TopToolbar
         compact={layoutOptions.compact}
         diagnosticsErrorCount={diagnostics.errorCount}
-        diagnosticsTotalCount={diagnostics.totalCount}
         mapControllerRef={mapControllerRef}
         showLabels={layoutOptions.toolbarLabels}
         showProjectInfo={layoutOptions.showProjectInfo}

--- a/apps/geolibre-desktop/src/components/layout/DiagnosticsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DiagnosticsDialog.tsx
@@ -1,0 +1,177 @@
+import {
+  Button,
+  cn,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  ScrollArea,
+} from "@geolibre/ui";
+import { Clipboard, Trash2 } from "lucide-react";
+import { useMemo, useState } from "react";
+import {
+  clearDiagnostics,
+  type DiagnosticRecord,
+  useDiagnosticsSnapshot,
+} from "../../lib/diagnostics";
+
+interface DiagnosticsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function formatTime(timestamp: string): string {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return timestamp;
+  return new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+  }).format(date);
+}
+
+function recordAccent(record: DiagnosticRecord): string {
+  if (record.level === "error") return "border-l-destructive";
+  if (record.level === "warning") return "border-l-amber-500";
+  return "border-l-primary";
+}
+
+function recordLevelClass(record: DiagnosticRecord): string {
+  if (record.level === "error") {
+    return "bg-destructive/10 text-destructive";
+  }
+  if (record.level === "warning") {
+    return "bg-amber-500/10 text-amber-700 dark:text-amber-300";
+  }
+  return "bg-muted text-muted-foreground";
+}
+
+export function DiagnosticsDialog({
+  open,
+  onOpenChange,
+}: DiagnosticsDialogProps) {
+  const diagnostics = useDiagnosticsSnapshot();
+  const [copyState, setCopyState] = useState<"copied" | "idle">("idle");
+  const serializedRecords = useMemo(
+    () => JSON.stringify(diagnostics.records, null, 2),
+    [diagnostics.records],
+  );
+
+  const copyDiagnostics = async () => {
+    if (!navigator.clipboard || diagnostics.records.length === 0) return;
+    await navigator.clipboard.writeText(serializedRecords);
+    setCopyState("copied");
+    window.setTimeout(() => setCopyState("idle"), 1500);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[min(760px,92vh)] max-w-5xl grid-rows-[auto_auto_minmax(0,1fr)] p-0">
+        <DialogHeader className="border-b px-6 py-4 pr-12">
+          <DialogTitle>Diagnostics</DialogTitle>
+          <DialogDescription>
+            Recent network requests, MapLibre errors, console warnings, and
+            runtime exceptions.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-wrap items-center justify-between gap-3 px-6">
+          <div className="flex flex-wrap gap-2 text-xs">
+            <span className="rounded border px-2 py-1">
+              {diagnostics.totalCount} total
+            </span>
+            <span
+              className={cn(
+                "rounded border px-2 py-1",
+                diagnostics.errorCount > 0 &&
+                  "border-destructive/30 text-destructive",
+              )}
+            >
+              {diagnostics.errorCount} errors
+            </span>
+            <span className="rounded border px-2 py-1">
+              {diagnostics.warningCount} warnings
+            </span>
+            <span className="rounded border px-2 py-1">
+              {diagnostics.networkCount} network
+            </span>
+          </div>
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={diagnostics.records.length === 0}
+              onClick={() => void copyDiagnostics()}
+            >
+              <Clipboard className="h-3.5 w-3.5" />
+              {copyState === "copied" ? "Copied" : "Copy JSON"}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={diagnostics.records.length === 0}
+              onClick={clearDiagnostics}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              Clear
+            </Button>
+          </div>
+        </div>
+        <ScrollArea className="min-h-0 border-t">
+          {diagnostics.records.length === 0 ? (
+            <div className="flex min-h-48 items-center justify-center px-6 py-12 text-sm text-muted-foreground">
+              No diagnostics captured.
+            </div>
+          ) : (
+            <ol className="divide-y">
+              {diagnostics.records.map((record) => (
+                <li
+                  key={record.id}
+                  className={cn("border-l-2 px-6 py-3", recordAccent(record))}
+                >
+                  <div className="mb-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                    <span
+                      className={cn(
+                        "rounded px-1.5 py-0.5 font-medium uppercase",
+                        recordLevelClass(record),
+                      )}
+                    >
+                      {record.level}
+                    </span>
+                    <span className="rounded bg-muted px-1.5 py-0.5 uppercase">
+                      {record.category}
+                    </span>
+                    <time>{formatTime(record.timestamp)}</time>
+                    {record.method ? <span>{record.method}</span> : null}
+                    {record.status ? <span>HTTP {record.status}</span> : null}
+                    {record.durationMs != null ? (
+                      <span>{record.durationMs} ms</span>
+                    ) : null}
+                  </div>
+                  <div className="break-words text-sm">{record.message}</div>
+                  {record.url ? (
+                    <div className="mt-1 break-all font-mono text-xs text-muted-foreground">
+                      {record.url}
+                    </div>
+                  ) : null}
+                  {record.source ? (
+                    <div className="mt-1 break-all font-mono text-xs text-muted-foreground">
+                      {record.source}
+                    </div>
+                  ) : null}
+                  {record.detail ? (
+                    <pre className="mt-2 max-h-44 overflow-auto whitespace-pre-wrap rounded border bg-muted/40 p-2 text-xs">
+                      {record.detail}
+                    </pre>
+                  ) : null}
+                </li>
+              ))}
+            </ol>
+          )}
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/DiagnosticsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DiagnosticsDialog.tsx
@@ -102,10 +102,11 @@ export function DiagnosticsDialog({
             <button
               type="button"
               className={cn(
-                "rounded border px-2 py-1 hover:bg-accent hover:text-accent-foreground",
-                levelFilter === "error" && "bg-accent text-accent-foreground",
+                "rounded border px-2 py-1 hover:bg-destructive/10 hover:text-destructive dark:hover:text-red-200",
                 diagnostics.errorCount > 0 &&
-                  "border-destructive/30 text-destructive",
+                  "border-destructive/50 text-destructive dark:border-red-400/60 dark:text-red-300",
+                levelFilter === "error" &&
+                  "border-destructive bg-destructive text-destructive-foreground hover:bg-destructive hover:text-destructive-foreground dark:border-red-500 dark:bg-red-600 dark:text-white dark:hover:bg-red-600 dark:hover:text-white",
               )}
               onClick={() => setLevelFilter("error")}
             >

--- a/apps/geolibre-desktop/src/components/layout/DiagnosticsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DiagnosticsDialog.tsx
@@ -66,10 +66,6 @@ export function DiagnosticsDialog({
         : diagnostics.records.filter((record) => record.level === levelFilter),
     [diagnostics.records, levelFilter],
   );
-  const serializedRecords = useMemo(
-    () => JSON.stringify(filteredRecords, null, 2),
-    [filteredRecords],
-  );
   const listIsFiltered = levelFilter !== "all";
 
   useEffect(
@@ -84,7 +80,9 @@ export function DiagnosticsDialog({
   const copyDiagnostics = async () => {
     if (!navigator.clipboard || filteredRecords.length === 0) return;
     try {
-      await navigator.clipboard.writeText(serializedRecords);
+      await navigator.clipboard.writeText(
+        JSON.stringify(filteredRecords, null, 2),
+      );
     } catch {
       // Clipboard access denied or unavailable.
       return;
@@ -113,6 +111,7 @@ export function DiagnosticsDialog({
           <div className="flex flex-wrap gap-2 text-xs">
             <button
               type="button"
+              aria-pressed={levelFilter === "all"}
               className={cn(
                 "rounded border px-2 py-1 hover:bg-accent hover:text-accent-foreground",
                 levelFilter === "all" && "bg-accent text-accent-foreground",
@@ -123,6 +122,7 @@ export function DiagnosticsDialog({
             </button>
             <button
               type="button"
+              aria-pressed={levelFilter === "error"}
               className={cn(
                 "rounded border px-2 py-1 hover:bg-destructive/10 hover:text-destructive dark:hover:text-red-200",
                 diagnostics.errorCount > 0 &&
@@ -136,6 +136,7 @@ export function DiagnosticsDialog({
             </button>
             <button
               type="button"
+              aria-pressed={levelFilter === "warning"}
               className={cn(
                 "rounded border px-2 py-1 hover:bg-accent hover:text-accent-foreground",
                 levelFilter === "warning" && "bg-accent text-accent-foreground",

--- a/apps/geolibre-desktop/src/components/layout/DiagnosticsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DiagnosticsDialog.tsx
@@ -13,6 +13,7 @@ import { useMemo, useState } from "react";
 import {
   clearDiagnostics,
   type DiagnosticRecord,
+  type DiagnosticLevel,
   useDiagnosticsSnapshot,
 } from "../../lib/diagnostics";
 
@@ -53,13 +54,24 @@ export function DiagnosticsDialog({
 }: DiagnosticsDialogProps) {
   const diagnostics = useDiagnosticsSnapshot();
   const [copyState, setCopyState] = useState<"copied" | "idle">("idle");
-  const serializedRecords = useMemo(
-    () => JSON.stringify(diagnostics.records, null, 2),
-    [diagnostics.records],
+  const [levelFilter, setLevelFilter] = useState<DiagnosticLevel | "all">(
+    "all",
   );
+  const filteredRecords = useMemo(
+    () =>
+      levelFilter === "all"
+        ? diagnostics.records
+        : diagnostics.records.filter((record) => record.level === levelFilter),
+    [diagnostics.records, levelFilter],
+  );
+  const serializedRecords = useMemo(
+    () => JSON.stringify(filteredRecords, null, 2),
+    [filteredRecords],
+  );
+  const listIsFiltered = levelFilter !== "all";
 
   const copyDiagnostics = async () => {
-    if (!navigator.clipboard || diagnostics.records.length === 0) return;
+    if (!navigator.clipboard || filteredRecords.length === 0) return;
     await navigator.clipboard.writeText(serializedRecords);
     setCopyState("copied");
     window.setTimeout(() => setCopyState("idle"), 1500);
@@ -77,21 +89,38 @@ export function DiagnosticsDialog({
         </DialogHeader>
         <div className="flex flex-wrap items-center justify-between gap-3 px-6">
           <div className="flex flex-wrap gap-2 text-xs">
-            <span className="rounded border px-2 py-1">
-              {diagnostics.totalCount} total
-            </span>
-            <span
+            <button
+              type="button"
               className={cn(
-                "rounded border px-2 py-1",
+                "rounded border px-2 py-1 hover:bg-accent hover:text-accent-foreground",
+                levelFilter === "all" && "bg-accent text-accent-foreground",
+              )}
+              onClick={() => setLevelFilter("all")}
+            >
+              {diagnostics.totalCount} total
+            </button>
+            <button
+              type="button"
+              className={cn(
+                "rounded border px-2 py-1 hover:bg-accent hover:text-accent-foreground",
+                levelFilter === "error" && "bg-accent text-accent-foreground",
                 diagnostics.errorCount > 0 &&
                   "border-destructive/30 text-destructive",
               )}
+              onClick={() => setLevelFilter("error")}
             >
               {diagnostics.errorCount} errors
-            </span>
-            <span className="rounded border px-2 py-1">
+            </button>
+            <button
+              type="button"
+              className={cn(
+                "rounded border px-2 py-1 hover:bg-accent hover:text-accent-foreground",
+                levelFilter === "warning" && "bg-accent text-accent-foreground",
+              )}
+              onClick={() => setLevelFilter("warning")}
+            >
               {diagnostics.warningCount} warnings
-            </span>
+            </button>
             <span className="rounded border px-2 py-1">
               {diagnostics.networkCount} network
             </span>
@@ -101,7 +130,7 @@ export function DiagnosticsDialog({
               type="button"
               variant="outline"
               size="sm"
-              disabled={diagnostics.records.length === 0}
+              disabled={filteredRecords.length === 0}
               onClick={() => void copyDiagnostics()}
             >
               <Clipboard className="h-3.5 w-3.5" />
@@ -112,7 +141,10 @@ export function DiagnosticsDialog({
               variant="outline"
               size="sm"
               disabled={diagnostics.records.length === 0}
-              onClick={clearDiagnostics}
+              onClick={() => {
+                setLevelFilter("all");
+                clearDiagnostics();
+              }}
             >
               <Trash2 className="h-3.5 w-3.5" />
               Clear
@@ -120,13 +152,15 @@ export function DiagnosticsDialog({
           </div>
         </div>
         <ScrollArea className="min-h-0 border-t">
-          {diagnostics.records.length === 0 ? (
+          {filteredRecords.length === 0 ? (
             <div className="flex min-h-48 items-center justify-center px-6 py-12 text-sm text-muted-foreground">
-              No diagnostics captured.
+              {listIsFiltered
+                ? `No ${levelFilter} diagnostics captured.`
+                : "No diagnostics captured."}
             </div>
           ) : (
             <ol className="divide-y">
-              {diagnostics.records.map((record) => (
+              {filteredRecords.map((record) => (
                 <li
                   key={record.id}
                   className={cn("border-l-2 px-6 py-3", recordAccent(record))}

--- a/apps/geolibre-desktop/src/components/layout/DiagnosticsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DiagnosticsDialog.tsx
@@ -9,15 +9,16 @@ import {
   ScrollArea,
 } from "@geolibre/ui";
 import { Clipboard, Trash2 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   clearDiagnostics,
   type DiagnosticRecord,
   type DiagnosticLevel,
-  useDiagnosticsSnapshot,
+  type DiagnosticsSnapshot,
 } from "../../lib/diagnostics";
 
 interface DiagnosticsDialogProps {
+  diagnostics: DiagnosticsSnapshot;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
@@ -49,11 +50,12 @@ function recordLevelClass(record: DiagnosticRecord): string {
 }
 
 export function DiagnosticsDialog({
+  diagnostics,
   open,
   onOpenChange,
 }: DiagnosticsDialogProps) {
-  const diagnostics = useDiagnosticsSnapshot();
   const [copyState, setCopyState] = useState<"copied" | "idle">("idle");
+  const copyResetTimerRef = useRef<number | null>(null);
   const [levelFilter, setLevelFilter] = useState<DiagnosticLevel | "all">(
     "all",
   );
@@ -70,11 +72,31 @@ export function DiagnosticsDialog({
   );
   const listIsFiltered = levelFilter !== "all";
 
+  useEffect(
+    () => () => {
+      if (copyResetTimerRef.current !== null) {
+        window.clearTimeout(copyResetTimerRef.current);
+      }
+    },
+    [],
+  );
+
   const copyDiagnostics = async () => {
     if (!navigator.clipboard || filteredRecords.length === 0) return;
-    await navigator.clipboard.writeText(serializedRecords);
+    try {
+      await navigator.clipboard.writeText(serializedRecords);
+    } catch {
+      // Clipboard access denied or unavailable.
+      return;
+    }
     setCopyState("copied");
-    window.setTimeout(() => setCopyState("idle"), 1500);
+    if (copyResetTimerRef.current !== null) {
+      window.clearTimeout(copyResetTimerRef.current);
+    }
+    copyResetTimerRef.current = window.setTimeout(
+      () => setCopyState("idle"),
+      1500,
+    );
   };
 
   return (
@@ -122,7 +144,7 @@ export function DiagnosticsDialog({
             >
               {diagnostics.warningCount} warnings
             </button>
-            <span className="rounded border px-2 py-1">
+            <span className="rounded bg-muted px-2 py-1 text-muted-foreground">
               {diagnostics.networkCount} network
             </span>
           </div>
@@ -178,7 +200,9 @@ export function DiagnosticsDialog({
                     <span className="rounded bg-muted px-1.5 py-0.5 uppercase">
                       {record.category}
                     </span>
-                    <time>{formatTime(record.timestamp)}</time>
+                    <time dateTime={record.timestamp}>
+                      {formatTime(record.timestamp)}
+                    </time>
                     {record.method ? <span>{record.method}</span> : null}
                     {record.status ? <span>HTTP {record.status}</span> : null}
                     {record.durationMs != null ? (

--- a/apps/geolibre-desktop/src/components/layout/StatusBar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/StatusBar.tsx
@@ -1,13 +1,23 @@
 import { useAppStore } from "@geolibre/core";
 import { cn } from "@geolibre/ui";
+import { Bug } from "lucide-react";
 
 interface StatusBarProps {
   compact?: boolean;
+  diagnosticsErrorCount: number;
+  diagnosticsWarningCount: number;
+  onOpenDiagnostics: () => void;
 }
 
-export function StatusBar({ compact = false }: StatusBarProps) {
+export function StatusBar({
+  compact = false,
+  diagnosticsErrorCount,
+  diagnosticsWarningCount,
+  onOpenDiagnostics,
+}: StatusBarProps) {
   const pointerCoords = useAppStore((s) => s.pointerCoords);
   const mapView = useAppStore((s) => s.mapView);
+  const diagnosticsCount = diagnosticsErrorCount + diagnosticsWarningCount;
 
   const coordText = pointerCoords
     ? `${pointerCoords[0].toFixed(5)}, ${pointerCoords[1].toFixed(5)}`
@@ -32,6 +42,20 @@ export function StatusBar({ compact = false }: StatusBarProps) {
         Bearing: {mapView.bearing.toFixed(1)}°
       </span>
       <span className="shrink-0">Pitch: {mapView.pitch.toFixed(1)}°</span>
+      <button
+        type="button"
+        className={cn(
+          "inline-flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 hover:bg-accent hover:text-accent-foreground",
+          diagnosticsErrorCount > 0 && "text-destructive",
+          diagnosticsErrorCount === 0 &&
+            diagnosticsWarningCount > 0 &&
+            "text-amber-700 dark:text-amber-300",
+        )}
+        onClick={onOpenDiagnostics}
+      >
+        <Bug className="h-3 w-3" />
+        {compact ? "Diag" : "Diagnostics"}: {diagnosticsCount}
+      </button>
       {compact ? null : <span className="min-w-0 truncate">BBox: {bboxText}</span>}
     </footer>
   );

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -47,6 +47,7 @@ import {
   Label,
 } from "@geolibre/ui";
 import {
+  Bug,
   Database,
   FolderOpen,
   History,
@@ -86,10 +87,13 @@ import { SettingsDialog } from "./SettingsDialog";
 
 interface TopToolbarProps {
   compact?: boolean;
+  diagnosticsErrorCount: number;
+  diagnosticsTotalCount: number;
   mapControllerRef: React.RefObject<MapController | null>;
   showLabels?: boolean;
   showProjectInfo?: boolean;
   themeMode: ThemeMode;
+  onOpenDiagnostics: () => void;
   onToggleThemeMode: () => void;
 }
 
@@ -134,10 +138,13 @@ function formatRecentProjectTime(openedAt: string): string {
 
 export function TopToolbar({
   compact = false,
+  diagnosticsErrorCount,
+  diagnosticsTotalCount,
   mapControllerRef,
   showLabels = true,
   showProjectInfo = true,
   themeMode,
+  onOpenDiagnostics,
   onToggleThemeMode,
 }: TopToolbarProps) {
   const loadProject = useAppStore((s) => s.loadProject);
@@ -577,6 +584,23 @@ export function TopToolbar({
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
+      <Button
+        className={cn(toolbarButtonClass, "relative")}
+        variant="ghost"
+        size={toolbarButtonSize}
+        onClick={onOpenDiagnostics}
+        aria-label="Diagnostics"
+      >
+        <Bug className={toolbarIconClassName} />
+        {renderToolbarLabel("Diagnostics")}
+        {diagnosticsErrorCount > 0 ? (
+          <span className="ml-1 rounded bg-destructive px-1.5 py-0.5 text-[10px] leading-none text-destructive-foreground">
+            {diagnosticsErrorCount}
+          </span>
+        ) : diagnosticsTotalCount > 0 && !showLabels ? (
+          <span className="absolute right-1 top-1 h-1.5 w-1.5 rounded-full bg-primary" />
+        ) : null}
+      </Button>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -48,14 +48,17 @@ import {
 } from "@geolibre/ui";
 import {
   Bug,
+  CircleHelp,
   Database,
   FolderOpen,
   History,
+  Info,
   Layers,
   Link2,
   Map,
   Moon,
   Puzzle,
+  RefreshCw,
   Save,
   SlidersHorizontal,
   Sun,
@@ -175,6 +178,8 @@ export function TopToolbar({
   const [projectUrlError, setProjectUrlError] = useState<string | null>(null);
   const [projectUrlLoading, setProjectUrlLoading] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [aboutOpen, setAboutOpen] = useState(false);
+  const [checkForUpdatesRequest, setCheckForUpdatesRequest] = useState(0);
   const projectUrlAbortRef = useRef<AbortController | null>(null);
   const recentAbortRef = useRef<AbortController | null>(null);
 
@@ -584,23 +589,6 @@ export function TopToolbar({
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
-      <Button
-        className={cn(toolbarButtonClass, "relative")}
-        variant="ghost"
-        size={toolbarButtonSize}
-        onClick={onOpenDiagnostics}
-        aria-label="Diagnostics"
-      >
-        <Bug className={toolbarIconClassName} />
-        {renderToolbarLabel("Diagnostics")}
-        {diagnosticsErrorCount > 0 ? (
-          <span className="ml-1 rounded bg-destructive px-1.5 py-0.5 text-[10px] leading-none text-destructive-foreground">
-            {diagnosticsErrorCount}
-          </span>
-        ) : diagnosticsTotalCount > 0 && !showLabels ? (
-          <span className="absolute right-1 top-1 h-1.5 w-1.5 rounded-full bg-primary" />
-        ) : null}
-      </Button>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button
@@ -731,6 +719,48 @@ export function TopToolbar({
         mapControllerRef={mapControllerRef}
         showLabels={showLabels}
       />
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            className={cn(toolbarButtonClass, "relative")}
+            variant="ghost"
+            size={toolbarButtonSize}
+            aria-label="Help"
+          >
+            <CircleHelp className={toolbarIconClassName} />
+            {renderToolbarLabel("Help")}
+            {diagnosticsErrorCount > 0 ? (
+              <span className="ml-1 rounded bg-destructive px-1.5 py-0.5 text-[10px] leading-none text-destructive-foreground">
+                {diagnosticsErrorCount}
+              </span>
+            ) : diagnosticsTotalCount > 0 && !showLabels ? (
+              <span className="absolute right-1 top-1 h-1.5 w-1.5 rounded-full bg-primary" />
+            ) : null}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          <DropdownMenuLabel>Help</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={onOpenDiagnostics}>
+            <Bug className="mr-2 h-3.5 w-3.5" />
+            Diagnostics
+            {diagnosticsErrorCount > 0 ? ` (${diagnosticsErrorCount})` : ""}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={() => {
+              setAboutOpen(true);
+              setCheckForUpdatesRequest((value) => value + 1);
+            }}
+          >
+            <RefreshCw className="mr-2 h-3.5 w-3.5" />
+            Check for updates
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setAboutOpen(true)}>
+            <Info className="mr-2 h-3.5 w-3.5" />
+            About
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
       <AddDataDialog
         kind={addDataKind}
         mapControllerRef={mapControllerRef}
@@ -807,10 +837,10 @@ export function TopToolbar({
         </DialogContent>
       </Dialog>
       <AboutDialog
-        buttonClassName={toolbarButtonClass}
-        buttonSize={toolbarButtonSize}
-        iconClassName={toolbarIconClassName}
-        showLabels={showLabels}
+        checkForUpdatesRequest={checkForUpdatesRequest}
+        open={aboutOpen}
+        renderTrigger={false}
+        onOpenChange={setAboutOpen}
       />
       <div className="ml-auto flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
         <Button

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -56,6 +56,7 @@ import {
   Layers,
   Link2,
   Map,
+  MessageSquare,
   Moon,
   Puzzle,
   RefreshCw,
@@ -65,6 +66,7 @@ import {
   Wrench,
   X,
 } from "lucide-react";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import { type FormEvent, useRef, useState, useSyncExternalStore } from "react";
 import {
   createAppAPI,
@@ -124,6 +126,16 @@ const PLUGIN_POSITION_ITEMS: Array<{
   { value: "bottom-left", label: "Bottom left" },
   { value: "bottom-right", label: "Bottom right" },
 ];
+
+const FEEDBACK_URL = "https://github.com/opengeos/GeoLibre/issues";
+
+async function openExternalLink(url: string): Promise<void> {
+  if (isTauri()) {
+    await openUrl(url);
+    return;
+  }
+  window.open(url, "_blank", "noopener,noreferrer");
+}
 
 function formatRecentProjectTime(openedAt: string): string {
   const openedDate = new Date(openedAt);
@@ -740,6 +752,12 @@ export function TopToolbar({
                 {diagnosticsErrorCount}
               </span>
             ) : null}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={() => void openExternalLink(FEEDBACK_URL)}
+          >
+            <MessageSquare className="mr-2 h-3.5 w-3.5" />
+            Give feedback
           </DropdownMenuItem>
           <DropdownMenuItem
             onSelect={() => {

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -91,7 +91,6 @@ import { SettingsDialog } from "./SettingsDialog";
 interface TopToolbarProps {
   compact?: boolean;
   diagnosticsErrorCount: number;
-  diagnosticsTotalCount: number;
   mapControllerRef: React.RefObject<MapController | null>;
   showLabels?: boolean;
   showProjectInfo?: boolean;
@@ -142,7 +141,6 @@ function formatRecentProjectTime(openedAt: string): string {
 export function TopToolbar({
   compact = false,
   diagnosticsErrorCount,
-  diagnosticsTotalCount,
   mapControllerRef,
   showLabels = true,
   showProjectInfo = true,
@@ -722,20 +720,13 @@ export function TopToolbar({
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button
-            className={cn(toolbarButtonClass, "relative")}
+            className={toolbarButtonClass}
             variant="ghost"
             size={toolbarButtonSize}
             aria-label="Help"
           >
             <CircleHelp className={toolbarIconClassName} />
             {renderToolbarLabel("Help")}
-            {diagnosticsErrorCount > 0 ? (
-              <span className="ml-1 rounded bg-destructive px-1.5 py-0.5 text-[10px] leading-none text-destructive-foreground">
-                {diagnosticsErrorCount}
-              </span>
-            ) : diagnosticsTotalCount > 0 && !showLabels ? (
-              <span className="absolute right-1 top-1 h-1.5 w-1.5 rounded-full bg-primary" />
-            ) : null}
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start">
@@ -744,7 +735,11 @@ export function TopToolbar({
           <DropdownMenuItem onSelect={onOpenDiagnostics}>
             <Bug className="mr-2 h-3.5 w-3.5" />
             Diagnostics
-            {diagnosticsErrorCount > 0 ? ` (${diagnosticsErrorCount})` : ""}
+            {diagnosticsErrorCount > 0 ? (
+              <span className="ml-2 rounded bg-destructive px-1.5 py-0.5 text-[10px] leading-none text-destructive-foreground">
+                {diagnosticsErrorCount}
+              </span>
+            ) : null}
           </DropdownMenuItem>
           <DropdownMenuItem
             onSelect={() => {

--- a/apps/geolibre-desktop/src/lib/diagnostics.ts
+++ b/apps/geolibre-desktop/src/lib/diagnostics.ts
@@ -22,7 +22,7 @@ export interface DiagnosticInput
   timestamp?: string;
 }
 
-interface DiagnosticsSnapshot {
+export interface DiagnosticsSnapshot {
   records: DiagnosticRecord[];
   totalCount: number;
   errorCount: number;
@@ -41,14 +41,20 @@ let captureRefCount = 0;
 let captureCleanup: (() => void) | null = null;
 
 function createSnapshot(nextRecords: DiagnosticRecord[]): DiagnosticsSnapshot {
+  let errorCount = 0;
+  let warningCount = 0;
+  let networkCount = 0;
+  for (const record of nextRecords) {
+    if (record.level === "error") errorCount += 1;
+    else if (record.level === "warning") warningCount += 1;
+    if (record.category === "network") networkCount += 1;
+  }
   return {
     records: nextRecords,
     totalCount: nextRecords.length,
-    errorCount: nextRecords.filter((record) => record.level === "error").length,
-    warningCount: nextRecords.filter((record) => record.level === "warning")
-      .length,
-    networkCount: nextRecords.filter((record) => record.category === "network")
-      .length,
+    errorCount,
+    warningCount,
+    networkCount,
   };
 }
 
@@ -183,11 +189,14 @@ export function installDiagnosticsCapture(): () => void {
       });
       return response;
     } catch (error) {
+      const isAbort =
+        (error instanceof DOMException || error instanceof Error) &&
+        error.name === "AbortError";
       appendDiagnostic({
         category: "network",
-        level: "error",
-        message: `${method} request failed`,
-        detail: formatUnknown(error),
+        level: isAbort ? "info" : "error",
+        message: isAbort ? `${method} aborted` : `${method} request failed`,
+        detail: isAbort ? undefined : formatUnknown(error),
         durationMs: Math.round(performance.now() - startedAt),
         method,
         url,

--- a/apps/geolibre-desktop/src/lib/diagnostics.ts
+++ b/apps/geolibre-desktop/src/lib/diagnostics.ts
@@ -115,8 +115,8 @@ const REDACTED_URL_PARAMS = new Set([
 function redactUrl(raw: string): string {
   try {
     const url = new URL(raw);
-    for (const param of REDACTED_URL_PARAMS) {
-      if (url.searchParams.has(param)) {
+    for (const param of [...url.searchParams.keys()]) {
+      if (REDACTED_URL_PARAMS.has(param.toLowerCase())) {
         url.searchParams.set(param, "[REDACTED]");
       }
     }

--- a/apps/geolibre-desktop/src/lib/diagnostics.ts
+++ b/apps/geolibre-desktop/src/lib/diagnostics.ts
@@ -86,7 +86,9 @@ function safeStringify(value: unknown): string {
         return nestedValue;
       },
       2,
-    );
+      // JSON.stringify returns undefined for undefined, functions, and
+      // symbols; fall back to String() so the field is never dropped.
+    ) ?? String(value);
   } catch {
     return String(value);
   }
@@ -100,6 +102,28 @@ function formatUnknown(value: unknown): string {
 
 function formatConsoleArgs(args: unknown[]): string {
   return args.map(formatUnknown).filter(Boolean).join(" ");
+}
+
+const REDACTED_URL_PARAMS = new Set([
+  "access_token",
+  "api_key",
+  "apikey",
+  "key",
+  "token",
+]);
+
+function redactUrl(raw: string): string {
+  try {
+    const url = new URL(raw);
+    for (const param of REDACTED_URL_PARAMS) {
+      if (url.searchParams.has(param)) {
+        url.searchParams.set(param, "[REDACTED]");
+      }
+    }
+    return url.toString();
+  } catch {
+    return raw;
+  }
 }
 
 function requestUrl(input: Parameters<typeof fetch>[0]): string {
@@ -135,7 +159,7 @@ export function appendDiagnostic(input: DiagnosticInput): void {
     message: truncate(input.message),
     detail: input.detail ? truncate(input.detail) : undefined,
     source: input.source ? truncate(input.source) : undefined,
-    url: input.url ? truncate(input.url) : undefined,
+    url: input.url ? truncate(redactUrl(input.url)) : undefined,
   };
 
   records = [record, ...records].slice(0, MAX_DIAGNOSTIC_RECORDS);
@@ -155,6 +179,13 @@ export function useDiagnosticsCapture(): void {
   useEffect(() => installDiagnosticsCapture(), []);
 }
 
+/**
+ * Installs the fetch/console/window interceptors and returns a cleanup
+ * function. Ref-counted so concurrent callers share one installation; the
+ * interceptors are only removed once every returned cleanup has been called.
+ * Each caller must therefore invoke its cleanup exactly once (guaranteed when
+ * used via useDiagnosticsCapture's effect).
+ */
 export function installDiagnosticsCapture(): () => void {
   captureRefCount += 1;
   if (captureCleanup) {

--- a/apps/geolibre-desktop/src/lib/diagnostics.ts
+++ b/apps/geolibre-desktop/src/lib/diagnostics.ts
@@ -206,21 +206,27 @@ export function installDiagnosticsCapture(): () => void {
   };
 
   console.error = (...args: unknown[]) => {
-    appendDiagnostic({
-      category: "console",
-      level: "error",
-      message: formatConsoleArgs(args) || "console.error",
-    });
-    originalConsoleError(...args);
+    try {
+      appendDiagnostic({
+        category: "console",
+        level: "error",
+        message: formatConsoleArgs(args) || "console.error",
+      });
+    } finally {
+      originalConsoleError(...args);
+    }
   };
 
   console.warn = (...args: unknown[]) => {
-    appendDiagnostic({
-      category: "console",
-      level: "warning",
-      message: formatConsoleArgs(args) || "console.warn",
-    });
-    originalConsoleWarn(...args);
+    try {
+      appendDiagnostic({
+        category: "console",
+        level: "warning",
+        message: formatConsoleArgs(args) || "console.warn",
+      });
+    } finally {
+      originalConsoleWarn(...args);
+    }
   };
 
   const handleWindowError = (event: ErrorEvent) => {

--- a/apps/geolibre-desktop/src/lib/diagnostics.ts
+++ b/apps/geolibre-desktop/src/lib/diagnostics.ts
@@ -1,0 +1,257 @@
+import { useEffect, useSyncExternalStore } from "react";
+
+export type DiagnosticCategory = "console" | "map" | "network" | "runtime";
+export type DiagnosticLevel = "error" | "info" | "warning";
+
+export interface DiagnosticRecord {
+  id: string;
+  timestamp: string;
+  category: DiagnosticCategory;
+  level: DiagnosticLevel;
+  message: string;
+  detail?: string;
+  durationMs?: number;
+  method?: string;
+  source?: string;
+  status?: number;
+  url?: string;
+}
+
+export interface DiagnosticInput
+  extends Omit<DiagnosticRecord, "id" | "timestamp"> {
+  timestamp?: string;
+}
+
+interface DiagnosticsSnapshot {
+  records: DiagnosticRecord[];
+  totalCount: number;
+  errorCount: number;
+  warningCount: number;
+  networkCount: number;
+}
+
+const MAX_DIAGNOSTIC_RECORDS = 500;
+const MAX_FIELD_LENGTH = 3000;
+
+const listeners = new Set<() => void>();
+let records: DiagnosticRecord[] = [];
+let sequence = 0;
+let snapshot = createSnapshot(records);
+let captureRefCount = 0;
+let captureCleanup: (() => void) | null = null;
+
+function createSnapshot(nextRecords: DiagnosticRecord[]): DiagnosticsSnapshot {
+  return {
+    records: nextRecords,
+    totalCount: nextRecords.length,
+    errorCount: nextRecords.filter((record) => record.level === "error").length,
+    warningCount: nextRecords.filter((record) => record.level === "warning")
+      .length,
+    networkCount: nextRecords.filter((record) => record.category === "network")
+      .length,
+  };
+}
+
+function emitChange(): void {
+  snapshot = createSnapshot(records);
+  for (const listener of listeners) listener();
+}
+
+function truncate(value: string): string {
+  return value.length > MAX_FIELD_LENGTH
+    ? `${value.slice(0, MAX_FIELD_LENGTH)}...`
+    : value;
+}
+
+function safeStringify(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value instanceof Error) return value.stack ?? value.message;
+
+  const seen = new WeakSet<object>();
+  try {
+    return JSON.stringify(
+      value,
+      (_key, nestedValue: unknown) => {
+        if (typeof nestedValue !== "object" || nestedValue === null) {
+          return nestedValue;
+        }
+        if (seen.has(nestedValue)) return "[Circular]";
+        seen.add(nestedValue);
+        return nestedValue;
+      },
+      2,
+    );
+  } catch {
+    return String(value);
+  }
+}
+
+function formatUnknown(value: unknown): string {
+  if (value instanceof Error) return value.stack ?? value.message;
+  if (typeof value === "string") return value;
+  return safeStringify(value);
+}
+
+function formatConsoleArgs(args: unknown[]): string {
+  return args.map(formatUnknown).filter(Boolean).join(" ");
+}
+
+function requestUrl(input: Parameters<typeof fetch>[0]): string {
+  if (input instanceof Request) return input.url;
+  if (input instanceof URL) return input.toString();
+  return String(input);
+}
+
+function requestMethod(
+  input: Parameters<typeof fetch>[0],
+  init?: Parameters<typeof fetch>[1],
+): string {
+  return (
+    init?.method ??
+    (input instanceof Request && input.method ? input.method : "GET")
+  ).toUpperCase();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function getSnapshot(): DiagnosticsSnapshot {
+  return snapshot;
+}
+
+export function appendDiagnostic(input: DiagnosticInput): void {
+  const record: DiagnosticRecord = {
+    ...input,
+    id: `diagnostic-${Date.now()}-${sequence++}`,
+    timestamp: input.timestamp ?? new Date().toISOString(),
+    message: truncate(input.message),
+    detail: input.detail ? truncate(input.detail) : undefined,
+    source: input.source ? truncate(input.source) : undefined,
+    url: input.url ? truncate(input.url) : undefined,
+  };
+
+  records = [record, ...records].slice(0, MAX_DIAGNOSTIC_RECORDS);
+  emitChange();
+}
+
+export function clearDiagnostics(): void {
+  records = [];
+  emitChange();
+}
+
+export function useDiagnosticsSnapshot(): DiagnosticsSnapshot {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+export function useDiagnosticsCapture(): void {
+  useEffect(() => installDiagnosticsCapture(), []);
+}
+
+export function installDiagnosticsCapture(): () => void {
+  captureRefCount += 1;
+  if (captureCleanup) {
+    return () => {
+      captureRefCount -= 1;
+      if (captureRefCount === 0) {
+        captureCleanup?.();
+        captureCleanup = null;
+      }
+    };
+  }
+
+  const originalFetch = window.fetch.bind(window);
+  const originalConsoleError = console.error;
+  const originalConsoleWarn = console.warn;
+
+  const patchedFetch: typeof fetch = async (input, init) => {
+    const startedAt = performance.now();
+    const method = requestMethod(input, init);
+    const url = requestUrl(input);
+
+    try {
+      const response = await originalFetch(input, init);
+      appendDiagnostic({
+        category: "network",
+        level: response.ok ? "info" : "error",
+        message: `${method} ${response.status} ${response.statusText}`.trim(),
+        durationMs: Math.round(performance.now() - startedAt),
+        method,
+        status: response.status,
+        url,
+      });
+      return response;
+    } catch (error) {
+      appendDiagnostic({
+        category: "network",
+        level: "error",
+        message: `${method} request failed`,
+        detail: formatUnknown(error),
+        durationMs: Math.round(performance.now() - startedAt),
+        method,
+        url,
+      });
+      throw error;
+    }
+  };
+
+  console.error = (...args: unknown[]) => {
+    appendDiagnostic({
+      category: "console",
+      level: "error",
+      message: formatConsoleArgs(args) || "console.error",
+    });
+    originalConsoleError(...args);
+  };
+
+  console.warn = (...args: unknown[]) => {
+    appendDiagnostic({
+      category: "console",
+      level: "warning",
+      message: formatConsoleArgs(args) || "console.warn",
+    });
+    originalConsoleWarn(...args);
+  };
+
+  const handleWindowError = (event: ErrorEvent) => {
+    appendDiagnostic({
+      category: "runtime",
+      level: "error",
+      message: event.message || "Unhandled runtime error",
+      detail: event.error ? formatUnknown(event.error) : undefined,
+      source: event.filename
+        ? `${event.filename}:${event.lineno}:${event.colno}`
+        : undefined,
+    });
+  };
+
+  const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
+    appendDiagnostic({
+      category: "runtime",
+      level: "error",
+      message: "Unhandled promise rejection",
+      detail: formatUnknown(event.reason),
+    });
+  };
+
+  window.fetch = patchedFetch;
+  window.addEventListener("error", handleWindowError);
+  window.addEventListener("unhandledrejection", handleUnhandledRejection);
+
+  captureCleanup = () => {
+    window.fetch = originalFetch;
+    console.error = originalConsoleError;
+    console.warn = originalConsoleWarn;
+    window.removeEventListener("error", handleWindowError);
+    window.removeEventListener("unhandledrejection", handleUnhandledRejection);
+  };
+
+  return () => {
+    captureRefCount -= 1;
+    if (captureRefCount === 0) {
+      captureCleanup?.();
+      captureCleanup = null;
+    }
+  };
+}

--- a/apps/geolibre-desktop/src/lib/diagnostics.ts
+++ b/apps/geolibre-desktop/src/lib/diagnostics.ts
@@ -1,4 +1,4 @@
-import { useEffect, useSyncExternalStore } from "react";
+import { useSyncExternalStore } from "react";
 
 export type DiagnosticCategory = "console" | "map" | "network" | "runtime";
 export type DiagnosticLevel = "error" | "info" | "warning";
@@ -175,16 +175,12 @@ export function useDiagnosticsSnapshot(): DiagnosticsSnapshot {
   return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }
 
-export function useDiagnosticsCapture(): void {
-  useEffect(() => installDiagnosticsCapture(), []);
-}
-
 /**
  * Installs the fetch/console/window interceptors and returns a cleanup
  * function. Ref-counted so concurrent callers share one installation; the
  * interceptors are only removed once every returned cleanup has been called.
- * Each caller must therefore invoke its cleanup exactly once (guaranteed when
- * used via useDiagnosticsCapture's effect).
+ * Each caller must therefore invoke its cleanup exactly once (e.g. from a
+ * useEffect cleanup or a single entry-point install as in main.tsx).
  */
 export function installDiagnosticsCapture(): () => void {
   captureRefCount += 1;

--- a/apps/geolibre-desktop/src/main.tsx
+++ b/apps/geolibre-desktop/src/main.tsx
@@ -1,7 +1,6 @@
 import "./lib/symbol-dispose-polyfill";
 import React from "react";
 import ReactDOM from "react-dom/client";
-import App from "./App";
 import "@geoman-io/maplibre-geoman-free/dist/maplibre-geoman.css";
 import "maplibre-gl-3d-tiles/style.css";
 import "maplibre-gl-basemap-control/style.css";
@@ -19,9 +18,18 @@ import "./lib/basemap-style";
 import "./lib/geoagent-style";
 import "./lib/lidar-style";
 import "./lib/swipe-style";
+import { installDiagnosticsCapture } from "./lib/diagnostics";
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-);
+installDiagnosticsCapture();
+
+void import("./App")
+  .then(({ default: App }) => {
+    ReactDOM.createRoot(document.getElementById("root")!).render(
+      <React.StrictMode>
+        <App />
+      </React.StrictMode>,
+    );
+  })
+  .catch((error: unknown) => {
+    console.error("Failed to start GeoLibre", error);
+  });

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -486,7 +486,15 @@ function stringifyDiagnosticDetail(value: unknown): string | undefined {
     return JSON.stringify(
       value,
       (key, nestedValue: unknown) => {
-        if (key === "target") return "[Map]";
+        // Only clamp object-valued targets (Map, XHR, DOM nodes) that risk
+        // circular or huge output; keep string targets such as tile URLs.
+        if (
+          key === "target" &&
+          typeof nestedValue === "object" &&
+          nestedValue !== null
+        ) {
+          return "[Map]";
+        }
         if (typeof nestedValue !== "object" || nestedValue === null) {
           return nestedValue;
         }

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -34,7 +34,16 @@ const WMS_IDENTIFY_INFO_FORMATS = [
 
 export interface MapCanvasProps {
   controllerRef?: React.MutableRefObject<MapController | null>;
+  onMapDiagnosticEvent?: (event: MapDiagnosticEvent) => void;
   onControllerReady?: () => void;
+}
+
+export interface MapDiagnosticEvent {
+  message: string;
+  detail?: string;
+  source?: string;
+  status?: number;
+  url?: string;
 }
 
 function stringifyIdentifyValue(value: unknown): string {
@@ -441,8 +450,91 @@ function isAbortError(error: unknown): boolean {
   );
 }
 
+function recordFromUnknown(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function stringProperty(
+  record: Record<string, unknown> | null,
+  key: string,
+): string | undefined {
+  const value = record?.[key];
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function numberProperty(
+  record: Record<string, unknown> | null,
+  key: string,
+): number | undefined {
+  const value = record?.[key];
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  const record = recordFromUnknown(error);
+  return stringProperty(record, "message") ?? "MapLibre reported an error.";
+}
+
+function stringifyDiagnosticDetail(value: unknown): string | undefined {
+  const seen = new WeakSet<object>();
+  try {
+    return JSON.stringify(
+      value,
+      (key, nestedValue: unknown) => {
+        if (key === "target") return "[Map]";
+        if (typeof nestedValue !== "object" || nestedValue === null) {
+          return nestedValue;
+        }
+        if (seen.has(nestedValue)) return "[Circular]";
+        seen.add(nestedValue);
+        return nestedValue;
+      },
+      2,
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+function mapErrorDiagnosticEvent(event: maplibregl.ErrorEvent): MapDiagnosticEvent {
+  const eventRecord = recordFromUnknown(event);
+  const errorRecord = recordFromUnknown(event.error);
+  const source =
+    stringProperty(eventRecord, "sourceId") ??
+    stringProperty(errorRecord, "sourceId");
+  const url =
+    stringProperty(eventRecord, "url") ??
+    stringProperty(errorRecord, "url") ??
+    stringProperty(errorRecord, "resource");
+  const status =
+    numberProperty(eventRecord, "status") ?? numberProperty(errorRecord, "status");
+
+  return {
+    message: errorMessage(event.error),
+    detail: stringifyDiagnosticDetail({
+      type: event.type,
+      source,
+      status,
+      url,
+      dataType: eventRecord?.dataType,
+      sourceDataType: eventRecord?.sourceDataType,
+      tile: eventRecord?.tile,
+      error: event.error,
+    }),
+    source,
+    status,
+    url,
+  };
+}
+
 export const MapCanvas = memo(function MapCanvas({
   controllerRef,
+  onMapDiagnosticEvent,
   onControllerReady,
 }: MapCanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -453,6 +545,8 @@ export const MapCanvas = memo(function MapCanvas({
   // caller passes a non-memoized callback.
   const onControllerReadyRef = useRef(onControllerReady);
   onControllerReadyRef.current = onControllerReady;
+  const onMapDiagnosticEventRef = useRef(onMapDiagnosticEvent);
+  onMapDiagnosticEventRef.current = onMapDiagnosticEvent;
 
   const basemapStyleUrl = useAppStore((s) => s.basemapStyleUrl);
   const basemapVisible = useAppStore((s) => s.basemapVisible);
@@ -486,6 +580,9 @@ export const MapCanvas = memo(function MapCanvas({
       setPointerCoords([e.lngLat.lng, e.lngLat.lat]);
     });
     map.on("mouseout", () => setPointerCoords(null));
+    map.on("error", (event) => {
+      onMapDiagnosticEventRef.current?.(mapErrorDiagnosticEvent(event));
+    });
 
     const updateView = (event?: { originalEvent?: unknown }) =>
       setMapView(mc.readView(), Boolean(event?.originalEvent));

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -581,6 +581,9 @@ export const MapCanvas = memo(function MapCanvas({
     });
     map.on("mouseout", () => setPointerCoords(null));
     map.on("error", (event) => {
+      // Cancelled tile fetches are already surfaced (as info) by the
+      // network capture; logging them here would double-count aborts.
+      if (isAbortError(event.error)) return;
       onMapDiagnosticEventRef.current?.(mapErrorDiagnosticEvent(event));
     });
 

--- a/packages/map/src/index.ts
+++ b/packages/map/src/index.ts
@@ -1,4 +1,8 @@
-export { MapCanvas, type MapCanvasProps } from "./MapCanvas";
+export {
+  MapCanvas,
+  type MapCanvasProps,
+  type MapDiagnosticEvent,
+} from "./MapCanvas";
 export {
   MapController,
   createMapController,


### PR DESCRIPTION
## Summary
- add an in-app Diagnostics dialog for recent network requests, MapLibre errors, console warnings, and runtime exceptions
- expose diagnostics from the toolbar and status bar with error counts
- forward MapLibre error events from the map canvas with source, URL, status, and detail context

Addresses https://github.com/opengeos/GeoLibre/discussions/129

## Tests
- npm run build
- pre-commit run --all-files
- Playwright screenshot smoke check with system Chrome at http://127.0.0.1:5173/

<img width="1019" height="693" alt="image" src="https://github.com/user-attachments/assets/23549696-6400-4cd5-831c-3efdb8e7c46e" />
