### PR TITLE
fix: reposition status bar BBox text and improve diagnostics contrast

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/StatusBar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/StatusBar.tsx
@@ -49,7 +49,7 @@ export function StatusBar({
         type="button"
         className={cn(
           "inline-flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 hover:bg-accent hover:text-accent-foreground",
-          compact && "ml-auto",
+          "ml-auto",
           diagnosticsErrorCount > 0 && "text-red-700 dark:text-red-300",
           diagnosticsErrorCount === 0 &&
             diagnosticsWarningCount > 0 &&

--- a/apps/geolibre-desktop/src/components/layout/StatusBar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/StatusBar.tsx
@@ -42,11 +42,15 @@ export function StatusBar({
         Bearing: {mapView.bearing.toFixed(1)}°
       </span>
       <span className="shrink-0">Pitch: {mapView.pitch.toFixed(1)}°</span>
+      {compact ? null : (
+        <span className="min-w-0 flex-1 truncate">BBox: {bboxText}</span>
+      )}
       <button
         type="button"
         className={cn(
           "inline-flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 hover:bg-accent hover:text-accent-foreground",
-          diagnosticsErrorCount > 0 && "text-destructive",
+          compact && "ml-auto",
+          diagnosticsErrorCount > 0 && "text-red-700 dark:text-red-300",
           diagnosticsErrorCount === 0 &&
             diagnosticsWarningCount > 0 &&
             "text-amber-700 dark:text-amber-300",
@@ -56,7 +60,6 @@ export function StatusBar({
         <Bug className="h-3 w-3" />
         {compact ? "Diag" : "Diagnostics"}: {diagnosticsCount}
       </button>
-      {compact ? null : <span className="min-w-0 truncate">BBox: {bboxText}</span>}
     </footer>
   );
 }


### PR DESCRIPTION
## Summary
- Move the BBox readout before the diagnostics button so the diagnostics button stays right-aligned in the status bar
- Use explicit red shades for the diagnostics error state to keep readable contrast in both light and dark themes

## Test plan
- [ ] Open the desktop app and confirm the BBox text appears between Pitch and the Diagnostics button
- [ ] Narrow the window to compact mode and confirm the Diag button is right-aligned with BBox hidden
- [ ] Trigger a diagnostics error and verify the red text is readable in light and dark themes