### PR TITLE
fix: keep Colorbar, Legend, and HTML panels within the viewport

### DIFF
--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -138,6 +138,7 @@ const LIDAR_SAMPLE_URL =
 const SPLATTING_SAMPLE_URL =
   "https://maplibre.org/maplibre-gl-js/docs/assets/34M_17/34M_17.gltf";
 const RASTER_PROXY_PATH = "/__geolibre_raster_proxy";
+const GUI_PANEL_VIEWPORT_MARGIN = 16;
 
 const COMPONENT_CONTROL_NAMES = [
   "spinGlobe",
@@ -257,6 +258,7 @@ const COLORBAR_OPTIONS = {
   fontColor: "hsl(var(--popover-foreground))",
   maxHeight: 520,
   panelWidth: 320,
+  position: colorbarControlPosition,
 } satisfies ColorbarGuiControlOptions;
 
 const LEGEND_OPTIONS = {
@@ -266,6 +268,7 @@ const LEGEND_OPTIONS = {
   fontColor: "hsl(var(--popover-foreground))",
   maxHeight: 520,
   panelWidth: 320,
+  position: legendControlPosition,
 } satisfies LegendGuiControlOptions;
 
 const HTML_OPTIONS = {
@@ -275,6 +278,7 @@ const HTML_OPTIONS = {
   fontColor: "hsl(var(--popover-foreground))",
   maxHeight: 520,
   panelWidth: 340,
+  position: htmlControlPosition,
 } satisfies HtmlGuiControlOptions;
 
 const STAC_COLOR_RAMP_MODULE = {
@@ -497,6 +501,26 @@ let legendPanelVisible = false;
 const legendPanelListeners = new Set<() => void>();
 let htmlPanelVisible = false;
 const htmlPanelListeners = new Set<() => void>();
+
+function constrainGuiPanelToViewport(panelSelector: string): void {
+  const panel = document.querySelector<HTMLElement>(panelSelector);
+  if (!panel) return;
+
+  const rect = panel.getBoundingClientRect();
+  const availableHeight = Math.floor(
+    window.innerHeight - rect.top - GUI_PANEL_VIEWPORT_MARGIN,
+  );
+  if (availableHeight > 160 && rect.bottom > window.innerHeight) {
+    panel.style.maxHeight = `${availableHeight}px`;
+  }
+
+  const availableWidth = Math.floor(
+    window.innerWidth - rect.left - GUI_PANEL_VIEWPORT_MARGIN,
+  );
+  if (availableWidth > 220 && rect.right > window.innerWidth) {
+    panel.style.width = `${availableWidth}px`;
+  }
+}
 
 export interface CogRasterLayerOptions {
   url: string;
@@ -1107,6 +1131,9 @@ async function openStandaloneColorbarControl(
   setTimeout(() => {
     colorbarControl?.show();
     colorbarControl?.expand();
+    constrainGuiPanelToViewport(
+      ".geolibre-colorbar-control .colorbar-gui-panel",
+    );
     setColorbarPanelVisible(true);
   }, 0);
   return true;
@@ -1132,6 +1159,9 @@ async function openStandaloneLegendControl(
   setTimeout(() => {
     legendControl?.show();
     legendControl?.expand();
+    constrainGuiPanelToViewport(
+      ".geolibre-legend-control .legend-gui-panel",
+    );
     setLegendPanelVisible(true);
   }, 0);
   return true;
@@ -1157,6 +1187,7 @@ async function openStandaloneHtmlControl(
   setTimeout(() => {
     htmlControl?.show();
     htmlControl?.expand();
+    constrainGuiPanelToViewport(".geolibre-html-control .html-gui-panel");
     setHtmlPanelVisible(true);
   }, 0);
   return true;
@@ -1486,7 +1517,13 @@ function createColorbarControl(
   ColorbarGuiControlClass: ColorbarGuiControlConstructor,
 ): ColorbarGuiControl {
   const control = new ColorbarGuiControlClass(COLORBAR_OPTIONS);
-  control.on("collapse", hideColorbarControl);
+  control.on("collapse", () => setColorbarPanelVisible(false));
+  control.on("expand", () => {
+    constrainGuiPanelToViewport(
+      ".geolibre-colorbar-control .colorbar-gui-panel",
+    );
+    setColorbarPanelVisible(true);
+  });
   return control;
 }
 
@@ -1494,7 +1531,13 @@ function createLegendControl(
   LegendGuiControlClass: LegendGuiControlConstructor,
 ): LegendGuiControl {
   const control = new LegendGuiControlClass(LEGEND_OPTIONS);
-  control.on("collapse", hideLegendControl);
+  control.on("collapse", () => setLegendPanelVisible(false));
+  control.on("expand", () => {
+    constrainGuiPanelToViewport(
+      ".geolibre-legend-control .legend-gui-panel",
+    );
+    setLegendPanelVisible(true);
+  });
   return control;
 }
 
@@ -1502,7 +1545,11 @@ function createHtmlControl(
   HtmlGuiControlClass: HtmlGuiControlConstructor,
 ): HtmlGuiControl {
   const control = new HtmlGuiControlClass(HTML_OPTIONS);
-  control.on("collapse", hideHtmlControl);
+  control.on("collapse", () => setHtmlPanelVisible(false));
+  control.on("expand", () => {
+    constrainGuiPanelToViewport(".geolibre-html-control .html-gui-panel");
+    setHtmlPanelVisible(true);
+  });
   return control;
 }
 
@@ -1638,11 +1685,6 @@ function teardownColorbarControl(app: GeoLibreAppAPI): void {
   setColorbarPanelVisible(false);
 }
 
-function hideColorbarControl(): void {
-  colorbarControl?.hide();
-  setColorbarPanelVisible(false);
-}
-
 function setColorbarPanelVisible(visible: boolean): void {
   if (colorbarPanelVisible === visible) return;
   colorbarPanelVisible = visible;
@@ -1660,11 +1702,6 @@ function teardownLegendControl(app: GeoLibreAppAPI): void {
   setLegendPanelVisible(false);
 }
 
-function hideLegendControl(): void {
-  legendControl?.hide();
-  setLegendPanelVisible(false);
-}
-
 function setLegendPanelVisible(visible: boolean): void {
   if (legendPanelVisible === visible) return;
   legendPanelVisible = visible;
@@ -1679,11 +1716,6 @@ function teardownHtmlControl(app: GeoLibreAppAPI): void {
   }
   htmlControl = null;
   htmlControlMounted = false;
-  setHtmlPanelVisible(false);
-}
-
-function hideHtmlControl(): void {
-  htmlControl?.hide();
   setHtmlPanelVisible(false);
 }
 

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -1517,7 +1517,6 @@ function createColorbarControl(
   ColorbarGuiControlClass: ColorbarGuiControlConstructor,
 ): ColorbarGuiControl {
   const control = new ColorbarGuiControlClass(COLORBAR_OPTIONS);
-  control.on("collapse", () => setColorbarPanelVisible(false));
   control.on("expand", () => {
     constrainGuiPanelToViewport(
       ".geolibre-colorbar-control .colorbar-gui-panel",
@@ -1531,7 +1530,6 @@ function createLegendControl(
   LegendGuiControlClass: LegendGuiControlConstructor,
 ): LegendGuiControl {
   const control = new LegendGuiControlClass(LEGEND_OPTIONS);
-  control.on("collapse", () => setLegendPanelVisible(false));
   control.on("expand", () => {
     constrainGuiPanelToViewport(
       ".geolibre-legend-control .legend-gui-panel",
@@ -1545,7 +1543,6 @@ function createHtmlControl(
   HtmlGuiControlClass: HtmlGuiControlConstructor,
 ): HtmlGuiControl {
   const control = new HtmlGuiControlClass(HTML_OPTIONS);
-  control.on("collapse", () => setHtmlPanelVisible(false));
   control.on("expand", () => {
     constrainGuiPanelToViewport(".geolibre-html-control .html-gui-panel");
     setHtmlPanelVisible(true);

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -503,23 +503,32 @@ let htmlPanelVisible = false;
 const htmlPanelListeners = new Set<() => void>();
 
 function constrainGuiPanelToViewport(panelSelector: string): void {
-  const panel = document.querySelector<HTMLElement>(panelSelector);
-  if (!panel) return;
+  // Defer measurement until after the expanded panel has been laid out so
+  // getBoundingClientRect() reflects the fully expanded dimensions.
+  requestAnimationFrame(() => {
+    const panel = document.querySelector<HTMLElement>(panelSelector);
+    if (!panel) return;
 
-  const rect = panel.getBoundingClientRect();
-  const availableHeight = Math.floor(
-    window.innerHeight - rect.top - GUI_PANEL_VIEWPORT_MARGIN,
-  );
-  if (availableHeight > 160 && rect.bottom > window.innerHeight) {
-    panel.style.maxHeight = `${availableHeight}px`;
-  }
+    // Clear previously-applied inline constraints before re-measuring so
+    // they don't suppress the overflow check on subsequent opens.
+    panel.style.maxHeight = "";
+    panel.style.maxWidth = "";
 
-  const availableWidth = Math.floor(
-    window.innerWidth - rect.left - GUI_PANEL_VIEWPORT_MARGIN,
-  );
-  if (availableWidth > 220 && rect.right > window.innerWidth) {
-    panel.style.width = `${availableWidth}px`;
-  }
+    const rect = panel.getBoundingClientRect();
+    const availableHeight = Math.floor(
+      window.innerHeight - rect.top - GUI_PANEL_VIEWPORT_MARGIN,
+    );
+    if (availableHeight > 160 && rect.bottom > window.innerHeight) {
+      panel.style.maxHeight = `${availableHeight}px`;
+    }
+
+    const availableWidth = Math.floor(
+      window.innerWidth - rect.left - GUI_PANEL_VIEWPORT_MARGIN,
+    );
+    if (availableWidth > 220 && rect.right > window.innerWidth) {
+      panel.style.maxWidth = `${availableWidth}px`;
+    }
+  });
 }
 
 export interface CogRasterLayerOptions {
@@ -1130,10 +1139,9 @@ async function openStandaloneColorbarControl(
 
   setTimeout(() => {
     colorbarControl?.show();
+    // expand() fires the "expand" handler, which applies the viewport
+    // constraint, so no separate constrainGuiPanelToViewport call is needed.
     colorbarControl?.expand();
-    constrainGuiPanelToViewport(
-      ".geolibre-colorbar-control .colorbar-gui-panel",
-    );
     setColorbarPanelVisible(true);
   }, 0);
   return true;
@@ -1159,9 +1167,6 @@ async function openStandaloneLegendControl(
   setTimeout(() => {
     legendControl?.show();
     legendControl?.expand();
-    constrainGuiPanelToViewport(
-      ".geolibre-legend-control .legend-gui-panel",
-    );
     setLegendPanelVisible(true);
   }, 0);
   return true;
@@ -1187,7 +1192,6 @@ async function openStandaloneHtmlControl(
   setTimeout(() => {
     htmlControl?.show();
     htmlControl?.expand();
-    constrainGuiPanelToViewport(".geolibre-html-control .html-gui-panel");
     setHtmlPanelVisible(true);
   }, 0);
   return true;


### PR DESCRIPTION
## Summary
- Constrain the Colorbar, Legend, and HTML GUI panels to the visible viewport on expand so tall or wide panels no longer overflow past the window edges.
- Pass explicit control positions to the panel options and keep the control button visible when a panel is collapsed so it can be reopened from the map.

## Test plan
- [ ] Open the Colorbar, Legend, and HTML panels from the toolbar and confirm each panel stays fully within the window, including on small window sizes.
- [ ] Collapse a panel via its header and confirm the control button remains visible and re-expands the panel.
- [ ] Toggle the panels from the toolbar and confirm the toolbar state stays in sync with panel visibility.