### PR TITLE
feat: add Docker support for the browser app

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,8 +5,11 @@
 node_modules
 **/node_modules
 apps/geolibre-desktop/dist
-apps/geolibre-desktop/src-tauri/target
-backend/geolibre_server/.venv
+apps/geolibre-desktop/src-tauri
+backend
+workers
+docs
+sample-data
 coverage
 dist
 build

--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,5 @@ dist
 build
 *.log
 .DS_Store
+.env
+.env.*

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+.vscode
+.idea
+node_modules
+**/node_modules
+apps/geolibre-desktop/dist
+apps/geolibre-desktop/src-tauri/target
+backend/geolibre_server/.venv
+coverage
+dist
+build
+*.log
+.DS_Store

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -14,7 +14,7 @@ permissions:
 
 concurrency:
   group: container-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -28,6 +28,10 @@ jobs:
         id: image
         run: echo "name=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
 
+      - name: Set up QEMU
+        if: github.event_name != 'pull_request'
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -56,6 +60,7 @@ jobs:
           context: .
           file: Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -1,0 +1,62 @@
+name: Publish Container Image
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: container-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build and publish container image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set image name
+        id: image
+        run: echo "name=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.image.outputs.name }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and publish image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,7 @@ COPY --from=build /app/apps/geolibre-desktop/dist /usr/share/nginx/html
 
 EXPOSE 80
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+  CMD wget -q -O /dev/null http://127.0.0.1/ || exit 1
+
 CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM node:22-alpine AS build
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+COPY apps/geolibre-desktop/package.json apps/geolibre-desktop/package.json
+COPY packages/core/package.json packages/core/package.json
+COPY packages/map/package.json packages/map/package.json
+COPY packages/plugins/package.json packages/plugins/package.json
+COPY packages/processing/package.json packages/processing/package.json
+COPY packages/ui/package.json packages/ui/package.json
+
+RUN npm ci
+
+COPY . .
+
+ARG GEOLIBRE_APP_BASE=/
+ENV GEOLIBRE_APP_BASE=${GEOLIBRE_APP_BASE}
+
+RUN npm run build
+
+FROM nginx:1.27-alpine AS runtime
+
+COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/apps/geolibre-desktop/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM node:22-alpine AS build
 
 WORKDIR /app
 
+# Copy every workspace member's package.json before npm ci so the install
+# layer is cached. Adding a new package under apps/ or packages/ requires
+# adding its package.json here, or npm ci fails with a missing workspace.
 COPY package.json package-lock.json ./
 COPY apps/geolibre-desktop/package.json apps/geolibre-desktop/package.json
 COPY packages/core/package.json packages/core/package.json

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ For deployments under a URL subpath, pass `GEOLIBRE_APP_BASE` at build time:
 docker build --build-arg GEOLIBRE_APP_BASE=/geolibre/ -t geolibre .
 ```
 
+The container always serves the app from its root path. The build argument only sets the URL prefix that the app expects, so subpath deployments also require a reverse proxy in front of the container that strips the prefix before forwarding requests (for example, nginx `proxy_pass http://geolibre/;` with a trailing slash).
+
 ## Embed the demo
 
 The browser demo supports URL parameters for iframe-friendly layouts.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,30 @@ npm run dev
 
 Open http://localhost:5173. The map and browser vector import support local vector files that DuckDB-WASM Spatial can read, including common formats such as GeoJSON, GeoParquet, GeoPackage, Shapefile, FlatGeobuf, KML/KMZ, and GML, with direct handling for GeoJSON, zipped Shapefiles, and KMZ archives. You can choose files from Add Vector Layer or drag them onto the app. Desktop filesystem dialogs, local MBTiles, and local raster file reads require Tauri.
 
+## Run with Docker
+
+Build and run the browser version of GeoLibre:
+
+```bash
+docker build -t geolibre .
+docker run --rm -p 8080:80 geolibre
+```
+
+Open http://localhost:8080. The Docker image serves the production Vite build with nginx. Desktop-only features such as Tauri filesystem dialogs, local MBTiles, local raster file reads, and project save/open require the desktop app.
+
+The published image is available from GitHub Container Registry:
+
+```bash
+docker pull ghcr.io/opengeos/geolibre:latest
+docker run --rm -p 8080:80 ghcr.io/opengeos/geolibre:latest
+```
+
+For deployments under a URL subpath, pass `GEOLIBRE_APP_BASE` at build time:
+
+```bash
+docker build --build-arg GEOLIBRE_APP_BASE=/geolibre/ -t geolibre .
+```
+
 ## Embed the demo
 
 The browser demo supports URL parameters for iframe-friendly layouts.

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,16 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location ~* \.(?:css|js|mjs|json|png|jpg|jpeg|gif|ico|svg|webp|wasm|woff2?)$ {
+        try_files $uri =404;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+}

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -22,7 +22,7 @@ server {
         add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https: data: blob:; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'" always;
     }
 
-    location ~* \.(?:css|js|mjs|png|jpg|jpeg|gif|ico|svg|webp|wasm|woff2?)$ {
+    location ~* \.(?:css|js|mjs|png|jpg|jpeg|gif|ico|svg|webp|avif|wasm|woff2?|ttf|otf)$ {
         try_files $uri =404;
         add_header Cache-Control "public, max-age=31536000, immutable";
         add_header X-Content-Type-Options "nosniff" always;

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -6,17 +6,19 @@ server {
     index index.html;
 
     gzip on;
+    gzip_vary on;
     gzip_types text/css application/javascript application/json application/wasm image/svg+xml;
     gzip_min_length 1024;
 
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-
     location / {
         try_files $uri $uri/ /index.html;
+        add_header Cache-Control "no-cache, must-revalidate" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https: data: blob:; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'" always;
     }
 
-    location ~* \.(?:css|js|mjs|json|png|jpg|jpeg|gif|ico|svg|webp|wasm|woff2?)$ {
+    location ~* \.(?:css|js|mjs|png|jpg|jpeg|gif|ico|svg|webp|wasm|woff2?)$ {
         try_files $uri =404;
         add_header Cache-Control "public, max-age=31536000, immutable";
         add_header X-Content-Type-Options "nosniff" always;

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -5,6 +5,13 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    gzip on;
+    gzip_types text/css application/javascript application/json application/wasm image/svg+xml;
+    gzip_min_length 1024;
+
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
     location / {
         try_files $uri $uri/ /index.html;
     }
@@ -12,5 +19,7 @@ server {
     location ~* \.(?:css|js|mjs|json|png|jpg|jpeg|gif|ico|svg|webp|wasm|woff2?)$ {
         try_files $uri =404;
         add_header Cache-Control "public, max-age=31536000, immutable";
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     }
 }

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -7,6 +7,7 @@ server {
 
     gzip on;
     gzip_vary on;
+    gzip_proxied any;
     gzip_types text/css application/javascript application/json application/wasm image/svg+xml;
     gzip_min_length 1024;
 

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -12,10 +12,13 @@ server {
     gzip_min_length 1024;
 
     location / {
-        try_files $uri $uri/ /index.html;
+        try_files $uri /index.html;
         add_header Cache-Control "no-cache, must-revalidate" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        # Mirrors the Tauri desktop CSP. 'unsafe-eval' is required by the
+        # @google/earthengine and maplibre-gl-geoagent bundles; connect-src
+        # stays broad because users connect to arbitrary tile/WMS endpoints.
         add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https: data: blob:; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'" always;
     }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,6 +61,14 @@ The FastAPI app in `backend/geolibre_server` backs the Whitebox toolbox through 
 
 Future processing releases are expected to expand the same sidecar pattern for GDAL, Rasterio, GeoPandas, DuckDB Spatial SQL, Leafmap, GeoAI, and SamGeo workflows.
 
+## Container image
+
+The root Dockerfile packages the browser version of the app. It uses a Node build stage to run the workspace build for `geolibre-desktop`, then copies `apps/geolibre-desktop/dist` into an nginx runtime image. The nginx config serves static assets and falls back to `index.html` for browser-entry URLs.
+
+The `Publish Container Image` GitHub Actions workflow builds the image for pull requests and publishes it to GitHub Container Registry for pushes to `main`, version tags, and manual runs. The upstream image name is `ghcr.io/opengeos/geolibre`.
+
+The container does not run the Tauri desktop shell or the optional Python sidecar. Workflows that depend on desktop filesystem access still require the installed desktop app.
+
 ## Security
 
 - Tauri CSP allowlists tile and style hosts (OpenFreeMap, CARTO).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,6 +52,8 @@ For deployments under a URL subpath, pass the app base at build time:
 docker build --build-arg GEOLIBRE_APP_BASE=/geolibre/ -t geolibre .
 ```
 
+The container always serves the app from its root path. The build argument only sets the URL prefix that the app expects, so subpath deployments also require a reverse proxy in front of the container that strips the prefix before forwarding requests (for example, nginx `proxy_pass http://geolibre/;` with a trailing slash).
+
 ## Run the desktop app
 
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,6 +28,30 @@ Open `http://localhost:5173`. The map and browser vector import support local ve
 
 Desktop filesystem dialogs, local MBTiles, local raster file reads, project save/open, and other filesystem operations require Tauri.
 
+## Run with Docker
+
+The repository includes a Dockerfile for the browser version of GeoLibre. It builds the Vite app and serves the production files with nginx:
+
+```bash
+docker build -t geolibre .
+docker run --rm -p 8080:80 geolibre
+```
+
+Open `http://localhost:8080`. The containerized browser UI supports web-capable workflows, but desktop filesystem dialogs, local MBTiles, local raster file reads, project save/open, and other Tauri-only features require the desktop app.
+
+The published image is available from GitHub Container Registry:
+
+```bash
+docker pull ghcr.io/opengeos/geolibre:latest
+docker run --rm -p 8080:80 ghcr.io/opengeos/geolibre:latest
+```
+
+For deployments under a URL subpath, pass the app base at build time:
+
+```bash
+docker build --build-arg GEOLIBRE_APP_BASE=/geolibre/ -t geolibre .
+```
+
 ## Run the desktop app
 
 ```bash


### PR DESCRIPTION
## Summary
- Add a multi-stage Dockerfile that builds the browser version of GeoLibre with Node and serves the production Vite build with nginx, including an SPA fallback and long-lived caching for static assets
- Add a Publish Container Image workflow that builds the image on pull requests and publishes it to GitHub Container Registry (ghcr.io/opengeos/geolibre) on pushes to main, version tags, and manual runs
- Document Docker usage in the README, getting started guide, and architecture docs, including the GEOLIBRE_APP_BASE build argument for subpath deployments

## Test plan
- [ ] `docker build -t geolibre .` completes successfully
- [ ] `docker run --rm -p 8080:80 geolibre` serves the app at http://localhost:8080
- [ ] Browser-entry URLs fall back to index.html (deep links load)
- [ ] PR CI builds the image without pushing; merge to main publishes to GHCR