### PR TITLE
fix: cross-compile Docker build stage to speed up multi-arch CI builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM node:22-alpine AS build
+# Run the build stage on the builder's native platform: the output is
+# arch-independent static files, so emulating arm64 with QEMU here only
+# slows down multi-arch builds without changing the result.
+FROM --platform=$BUILDPLATFORM node:22-alpine AS build
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # Run the build stage on the builder's native platform: the output is
 # arch-independent static files, so emulating arm64 with QEMU here only
 # slows down multi-arch builds without changing the result.
+# ($BUILDPLATFORM is a Docker-provided automatic ARG, set by BuildKit.)
 FROM --platform=$BUILDPLATFORM node:22-alpine AS build
 
 WORKDIR /app


### PR DESCRIPTION
## Summary

The first push-to-main container build (run 27023827687) ran for 35+ minutes because the `linux/arm64` half of the multi-arch build executes `npm ci` and `npm run build` under QEMU emulation, which is 10-20x slower than native and can stall. PR builds only target `linux/amd64`, so the GHA cache had no arm64 layers to reuse.

The build stage only produces arch-independent static files served by nginx, so it never needs to run on the target architecture. This pins the build stage to the builder's native platform with `--platform=$BUILDPLATFORM`; only the `nginx:1.27-alpine` runtime stage remains per-arch.

## Changes

- `Dockerfile`: build stage now uses `FROM --platform=$BUILDPLATFORM node:22-alpine`, with a comment explaining why.

## Testing

- `docker build` succeeds locally.
- `pre-commit run --all-files` passes.