### PR TITLE
feat: add Layout settings with per-panel visibility toggles

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -472,7 +472,7 @@ export function DesktopShell({
         onToggleThemeMode={onToggleThemeMode}
       />
       <div className="flex min-h-0 flex-1 flex-col md:flex-row">
-        {layoutOptions.panelsVisible ? (
+        {layoutOptions.layerPanelVisible ? (
           <LayerPanel
             mapControllerRef={mapControllerRef}
             onResizeStart={startLayerPanelResize}
@@ -489,11 +489,11 @@ export function DesktopShell({
             onControllerReady={handleMapControllerReady}
           />
         </main>
-        {layoutOptions.panelsVisible ? (
+        {layoutOptions.stylePanelVisible ? (
           <StylePanel onResizeStart={startStylePanelResize} />
         ) : null}
       </div>
-      {layoutOptions.panelsVisible ? <AttributeTable /> : null}
+      {layoutOptions.attributePanelVisible ? <AttributeTable /> : null}
       <StatusBar
         compact={layoutOptions.compact}
         diagnosticsErrorCount={diagnostics.errorCount}

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -16,10 +16,14 @@ import {
   DialogHeader,
   DialogTitle,
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
   Input,
   Label,
@@ -32,9 +36,14 @@ import {
   EyeOff,
   FolderCog,
   MapPinned,
+  LayoutPanelTop,
+  PanelLeft,
+  PanelRight,
   Plus,
   RotateCcw,
   Settings,
+  TableProperties,
+  Type,
   Trash2,
   TriangleAlert,
   Puzzle,
@@ -42,14 +51,21 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useState, type RefObject } from "react";
 import {
+  DEFAULT_DESKTOP_LAYOUT_SETTINGS,
   useDesktopSettingsStore,
   type DesktopSettings,
+  type DesktopLayoutSettings,
 } from "../../hooks/useDesktopSettings";
 import { getPluginManager } from "../../hooks/usePlugins";
 import { mergeStringLists, normalizeStringList } from "../../lib/string-lists";
 import { pickLocalPathWithFallback } from "../../lib/tauri-io";
 
-type SettingsSection = "map" | "environment" | "plugins" | "project";
+type SettingsSection =
+  | "map"
+  | "layout"
+  | "environment"
+  | "plugins"
+  | "project";
 
 interface SettingsDialogProps {
   buttonClassName?: string;
@@ -65,6 +81,7 @@ const SECTION_ITEMS: Array<{
   icon: typeof MapPinned;
 }> = [
   { id: "map", label: "Map", icon: MapPinned },
+  { id: "layout", label: "Layout", icon: LayoutPanelTop },
   { id: "environment", label: "Environment", icon: Braces },
   { id: "plugins", label: "Plugins", icon: Puzzle },
   { id: "project", label: "Project", icon: FolderCog },
@@ -94,6 +111,7 @@ interface DraftListEntry {
 
 interface DraftDesktopSettings {
   additionalPluginDirectories: DraftListEntry[];
+  layout: DesktopLayoutSettings;
   pluginManifestUrls: DraftListEntry[];
 }
 
@@ -124,6 +142,7 @@ function cloneDesktopSettings(
   return {
     additionalPluginDirectories:
       settings.additionalPluginDirectories.map(toDraftListEntry),
+    layout: { ...settings.layout },
     pluginManifestUrls: mergeStringLists(
       projectPlugins?.manifestUrls ?? [],
       settings.pluginManifestUrls,
@@ -436,6 +455,25 @@ export function SettingsDialog({
     updateMapPreferences(DEFAULT_PROJECT_PREFERENCES.map);
   };
 
+  const updateDraftLayoutSettings = (patch: Partial<DesktopLayoutSettings>) => {
+    setDraftDesktopSettings((current) => ({
+      ...current,
+      layout: { ...current.layout, ...patch },
+    }));
+    setError(null);
+  };
+
+  const updateSavedLayoutSettings = (patch: Partial<DesktopLayoutSettings>) => {
+    setDesktopSettings({
+      ...desktopSettings,
+      layout: { ...desktopSettings.layout, ...patch },
+    });
+  };
+
+  const resetLayoutSettings = () => {
+    updateDraftLayoutSettings(DEFAULT_DESKTOP_LAYOUT_SETTINGS);
+  };
+
   const saveSettings = () => {
     const normalized = normalizePreferences(draftPreferences);
     const validationError = validateEnvironmentVariables(
@@ -467,6 +505,7 @@ export function SettingsDialog({
           (entry) => entry.value,
         ),
       ),
+      layout: draftDesktopSettings.layout,
       pluginManifestUrls,
     });
     setProjectPlugins({
@@ -524,6 +563,75 @@ export function SettingsDialog({
             <MapPinned className="mr-2 h-3.5 w-3.5" />
             Map Preferences
           </DropdownMenuItem>
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              <LayoutPanelTop className="mr-2 h-3.5 w-3.5" />
+              Layout
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent className="min-w-56">
+              <DropdownMenuCheckboxItem
+                checked={!desktopSettings.layout.toolbarLabels}
+                onCheckedChange={(checked) =>
+                  updateSavedLayoutSettings({ toolbarLabels: checked !== true })
+                }
+                onSelect={(event) => event.preventDefault()}
+              >
+                Icon-only toolbar buttons
+              </DropdownMenuCheckboxItem>
+              <DropdownMenuCheckboxItem
+                checked={desktopSettings.layout.showProjectInfo}
+                onCheckedChange={(checked) =>
+                  updateSavedLayoutSettings({ showProjectInfo: checked === true })
+                }
+                onSelect={(event) => event.preventDefault()}
+              >
+                Show project info
+              </DropdownMenuCheckboxItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuCheckboxItem
+                checked={desktopSettings.layout.layerPanelVisible}
+                onCheckedChange={(checked) =>
+                  updateSavedLayoutSettings({
+                    layerPanelVisible: checked === true,
+                  })
+                }
+                onSelect={(event) => event.preventDefault()}
+              >
+                Show Layers panel
+              </DropdownMenuCheckboxItem>
+              <DropdownMenuCheckboxItem
+                checked={desktopSettings.layout.stylePanelVisible}
+                onCheckedChange={(checked) =>
+                  updateSavedLayoutSettings({
+                    stylePanelVisible: checked === true,
+                  })
+                }
+                onSelect={(event) => event.preventDefault()}
+              >
+                Show Style panel
+              </DropdownMenuCheckboxItem>
+              <DropdownMenuCheckboxItem
+                checked={desktopSettings.layout.attributePanelVisible}
+                onCheckedChange={(checked) =>
+                  updateSavedLayoutSettings({
+                    attributePanelVisible: checked === true,
+                  })
+                }
+                onSelect={(event) => event.preventDefault()}
+              >
+                Show Attribute panel
+              </DropdownMenuCheckboxItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onSelect={() => {
+                  setSection("layout");
+                  setOpen(true);
+                }}
+              >
+                Layout Settings
+              </DropdownMenuItem>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
           <DropdownMenuItem
             onSelect={() => {
               setSection("environment");
@@ -698,6 +806,113 @@ export function SettingsDialog({
                     />
                     Render world copies
                   </label>
+                </div>
+              ) : null}
+              {section === "layout" ? (
+                <div className="space-y-5">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <h3 className="text-sm font-semibold">Layout</h3>
+                      <p className="text-xs text-muted-foreground">
+                        Workspace visibility and toolbar presentation.
+                      </p>
+                    </div>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={resetLayoutSettings}
+                    >
+                      <RotateCcw className="h-3.5 w-3.5" />
+                      Reset
+                    </Button>
+                  </div>
+                  <div className="space-y-3">
+                    <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Toolbar
+                    </h4>
+                    <label className="flex items-center gap-3 rounded-md border p-3 text-sm">
+                      <input
+                        className="h-4 w-4"
+                        type="checkbox"
+                        checked={!draftDesktopSettings.layout.toolbarLabels}
+                        onChange={(event) =>
+                          updateDraftLayoutSettings({
+                            toolbarLabels: !event.target.checked,
+                          })
+                        }
+                      />
+                      <Type className="h-4 w-4 text-muted-foreground" />
+                      <span>Use icon-only toolbar buttons</span>
+                    </label>
+                    <label className="flex items-center gap-3 rounded-md border p-3 text-sm">
+                      <input
+                        className="h-4 w-4"
+                        type="checkbox"
+                        checked={draftDesktopSettings.layout.showProjectInfo}
+                        onChange={(event) =>
+                          updateDraftLayoutSettings({
+                            showProjectInfo: event.target.checked,
+                          })
+                        }
+                      />
+                      <FolderCog className="h-4 w-4 text-muted-foreground" />
+                      <span>Show project info in the toolbar</span>
+                    </label>
+                  </div>
+                  <div className="space-y-3">
+                    <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Panels
+                    </h4>
+                    <label className="flex items-center gap-3 rounded-md border p-3 text-sm">
+                      <input
+                        className="h-4 w-4"
+                        type="checkbox"
+                        checked={draftDesktopSettings.layout.layerPanelVisible}
+                        onChange={(event) =>
+                          updateDraftLayoutSettings({
+                            layerPanelVisible: event.target.checked,
+                          })
+                        }
+                      />
+                      <PanelLeft className="h-4 w-4 text-muted-foreground" />
+                      <span>Show Layers panel</span>
+                    </label>
+                    <label className="flex items-center gap-3 rounded-md border p-3 text-sm">
+                      <input
+                        className="h-4 w-4"
+                        type="checkbox"
+                        checked={draftDesktopSettings.layout.stylePanelVisible}
+                        onChange={(event) =>
+                          updateDraftLayoutSettings({
+                            stylePanelVisible: event.target.checked,
+                          })
+                        }
+                      />
+                      <PanelRight className="h-4 w-4 text-muted-foreground" />
+                      <span>Show Style panel</span>
+                    </label>
+                    <label className="flex items-center gap-3 rounded-md border p-3 text-sm">
+                      <input
+                        className="h-4 w-4"
+                        type="checkbox"
+                        checked={
+                          draftDesktopSettings.layout.attributePanelVisible
+                        }
+                        onChange={(event) =>
+                          updateDraftLayoutSettings({
+                            attributePanelVisible: event.target.checked,
+                          })
+                        }
+                      />
+                      <TableProperties className="h-4 w-4 text-muted-foreground" />
+                      <span>Show Attribute panel</span>
+                    </label>
+                  </div>
+                  <div className="rounded-md border bg-muted/40 p-3 text-xs text-muted-foreground">
+                    URL layout parameters still apply when present in shared
+                    viewer links.
+                  </div>
                 </div>
               ) : null}
               {section === "environment" ? (

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -633,6 +633,10 @@ export function SettingsDialog({
               >
                 Layout Settings
               </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <p className="px-2 py-1 text-xs text-muted-foreground">
+                URL layout parameters override saved settings.
+              </p>
             </DropdownMenuSubContent>
           </DropdownMenuSub>
           <DropdownMenuItem

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -464,9 +464,12 @@ export function SettingsDialog({
   };
 
   const updateSavedLayoutSettings = (patch: Partial<DesktopLayoutSettings>) => {
+    // Read the latest state synchronously so rapid successive toggles do not
+    // overwrite each other with a stale render-closure snapshot.
+    const current = useDesktopSettingsStore.getState().desktopSettings;
     setDesktopSettings({
-      ...desktopSettings,
-      layout: { ...desktopSettings.layout, ...patch },
+      ...current,
+      layout: { ...current.layout, ...patch },
     });
   };
 
@@ -570,13 +573,13 @@ export function SettingsDialog({
             </DropdownMenuSubTrigger>
             <DropdownMenuSubContent className="min-w-56">
               <DropdownMenuCheckboxItem
-                checked={!desktopSettings.layout.toolbarLabels}
+                checked={desktopSettings.layout.toolbarLabels}
                 onCheckedChange={(checked) =>
-                  updateSavedLayoutSettings({ toolbarLabels: checked !== true })
+                  updateSavedLayoutSettings({ toolbarLabels: checked === true })
                 }
                 onSelect={(event) => event.preventDefault()}
               >
-                Icon-only toolbar buttons
+                Show toolbar labels
               </DropdownMenuCheckboxItem>
               <DropdownMenuCheckboxItem
                 checked={desktopSettings.layout.showProjectInfo}
@@ -835,15 +838,15 @@ export function SettingsDialog({
                       <input
                         className="h-4 w-4"
                         type="checkbox"
-                        checked={!draftDesktopSettings.layout.toolbarLabels}
+                        checked={draftDesktopSettings.layout.toolbarLabels}
                         onChange={(event) =>
                           updateDraftLayoutSettings({
-                            toolbarLabels: !event.target.checked,
+                            toolbarLabels: event.target.checked,
                           })
                         }
                       />
                       <Type className="h-4 w-4 text-muted-foreground" />
-                      <span>Use icon-only toolbar buttons</span>
+                      <span>Show toolbar labels</span>
                     </label>
                     <label className="flex items-center gap-3 rounded-md border p-3 text-sm">
                       <input

--- a/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
+++ b/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
@@ -64,23 +64,30 @@ function normalizeDesktopLayoutSettings(
     return DEFAULT_DESKTOP_LAYOUT_SETTINGS;
   }
 
+  // Require strict booleans so tampered localStorage values (e.g. "yes")
+  // cannot smuggle non-boolean values into the layout settings.
   const candidate = layout as Partial<DesktopLayoutSettings>;
   return {
     attributePanelVisible:
-      candidate.attributePanelVisible ??
-      DEFAULT_DESKTOP_LAYOUT_SETTINGS.attributePanelVisible,
+      typeof candidate.attributePanelVisible === "boolean"
+        ? candidate.attributePanelVisible
+        : DEFAULT_DESKTOP_LAYOUT_SETTINGS.attributePanelVisible,
     layerPanelVisible:
-      candidate.layerPanelVisible ??
-      DEFAULT_DESKTOP_LAYOUT_SETTINGS.layerPanelVisible,
+      typeof candidate.layerPanelVisible === "boolean"
+        ? candidate.layerPanelVisible
+        : DEFAULT_DESKTOP_LAYOUT_SETTINGS.layerPanelVisible,
     showProjectInfo:
-      candidate.showProjectInfo ??
-      DEFAULT_DESKTOP_LAYOUT_SETTINGS.showProjectInfo,
+      typeof candidate.showProjectInfo === "boolean"
+        ? candidate.showProjectInfo
+        : DEFAULT_DESKTOP_LAYOUT_SETTINGS.showProjectInfo,
     stylePanelVisible:
-      candidate.stylePanelVisible ??
-      DEFAULT_DESKTOP_LAYOUT_SETTINGS.stylePanelVisible,
+      typeof candidate.stylePanelVisible === "boolean"
+        ? candidate.stylePanelVisible
+        : DEFAULT_DESKTOP_LAYOUT_SETTINGS.stylePanelVisible,
     toolbarLabels:
-      candidate.toolbarLabels ??
-      DEFAULT_DESKTOP_LAYOUT_SETTINGS.toolbarLabels,
+      typeof candidate.toolbarLabels === "boolean"
+        ? candidate.toolbarLabels
+        : DEFAULT_DESKTOP_LAYOUT_SETTINGS.toolbarLabels,
   };
 }
 

--- a/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
+++ b/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
@@ -7,7 +7,16 @@ const DESKTOP_SETTINGS_STORAGE_KEY = "geolibre.desktopSettings";
 
 export interface DesktopSettings {
   additionalPluginDirectories: string[];
+  layout: DesktopLayoutSettings;
   pluginManifestUrls: string[];
+}
+
+export interface DesktopLayoutSettings {
+  attributePanelVisible: boolean;
+  layerPanelVisible: boolean;
+  showProjectInfo: boolean;
+  stylePanelVisible: boolean;
+  toolbarLabels: boolean;
 }
 
 interface DesktopSettingsState {
@@ -15,8 +24,17 @@ interface DesktopSettingsState {
   setDesktopSettings: (settings: DesktopSettings) => void;
 }
 
+export const DEFAULT_DESKTOP_LAYOUT_SETTINGS: DesktopLayoutSettings = {
+  attributePanelVisible: true,
+  layerPanelVisible: true,
+  showProjectInfo: true,
+  stylePanelVisible: true,
+  toolbarLabels: true,
+};
+
 const DEFAULT_DESKTOP_SETTINGS: DesktopSettings = {
   additionalPluginDirectories: [],
+  layout: DEFAULT_DESKTOP_LAYOUT_SETTINGS,
   pluginManifestUrls: [],
 };
 
@@ -30,11 +48,39 @@ function normalizeDesktopSettings(settings: unknown): DesktopSettings {
     additionalPluginDirectories: normalizeStringList(
       candidate.additionalPluginDirectories,
     ),
+    layout: normalizeDesktopLayoutSettings(candidate.layout),
     // Apply the same scheme rule as project-file loading so stale or edited
     // localStorage values cannot smuggle in disallowed URL schemes.
     pluginManifestUrls: normalizeStringList(candidate.pluginManifestUrls).filter(
       isAllowedPluginManifestUrl,
     ),
+  };
+}
+
+function normalizeDesktopLayoutSettings(
+  layout: unknown,
+): DesktopLayoutSettings {
+  if (!layout || typeof layout !== "object") {
+    return DEFAULT_DESKTOP_LAYOUT_SETTINGS;
+  }
+
+  const candidate = layout as Partial<DesktopLayoutSettings>;
+  return {
+    attributePanelVisible:
+      candidate.attributePanelVisible ??
+      DEFAULT_DESKTOP_LAYOUT_SETTINGS.attributePanelVisible,
+    layerPanelVisible:
+      candidate.layerPanelVisible ??
+      DEFAULT_DESKTOP_LAYOUT_SETTINGS.layerPanelVisible,
+    showProjectInfo:
+      candidate.showProjectInfo ??
+      DEFAULT_DESKTOP_LAYOUT_SETTINGS.showProjectInfo,
+    stylePanelVisible:
+      candidate.stylePanelVisible ??
+      DEFAULT_DESKTOP_LAYOUT_SETTINGS.stylePanelVisible,
+    toolbarLabels:
+      candidate.toolbarLabels ??
+      DEFAULT_DESKTOP_LAYOUT_SETTINGS.toolbarLabels,
   };
 }
 

--- a/apps/geolibre-desktop/src/hooks/useLayoutOptions.ts
+++ b/apps/geolibre-desktop/src/hooks/useLayoutOptions.ts
@@ -1,9 +1,16 @@
 import { useMemo } from "react";
+import {
+  useDesktopSettingsStore,
+  type DesktopLayoutSettings,
+} from "./useDesktopSettings";
 
 export interface LayoutOptions {
+  attributePanelVisible: boolean;
   compact: boolean;
+  layerPanelVisible: boolean;
   panelsVisible: boolean;
   showProjectInfo: boolean;
+  stylePanelVisible: boolean;
   toolbarLabels: boolean;
 }
 
@@ -12,33 +19,68 @@ const ICON_TOOLBAR_VALUES = new Set(["icon", "icons", "icon-only"]);
 const HIDDEN_PANEL_VALUES = new Set(["hidden", "hide", "none", "off"]);
 
 const DEFAULT_LAYOUT_OPTIONS: LayoutOptions = {
+  attributePanelVisible: true,
   compact: false,
+  layerPanelVisible: true,
   panelsVisible: true,
   showProjectInfo: true,
+  stylePanelVisible: true,
   toolbarLabels: true,
 };
 
 export function useLayoutOptions(): LayoutOptions {
-  return useMemo(() => layoutOptionsFromLocation(), []);
+  const layoutSettings = useDesktopSettingsStore((s) => s.desktopSettings.layout);
+  return useMemo(
+    () => layoutOptionsFromLocation(layoutSettings),
+    [layoutSettings],
+  );
 }
 
-function layoutOptionsFromLocation(): LayoutOptions {
-  if (typeof window === "undefined") return DEFAULT_LAYOUT_OPTIONS;
+function layoutOptionsFromLocation(
+  layoutSettings: DesktopLayoutSettings,
+): LayoutOptions {
+  if (typeof window === "undefined") {
+    return {
+      ...DEFAULT_LAYOUT_OPTIONS,
+      ...layoutSettings,
+      panelsVisible:
+        layoutSettings.layerPanelVisible ||
+        layoutSettings.stylePanelVisible ||
+        layoutSettings.attributePanelVisible,
+    };
+  }
 
   const params = new URLSearchParams(window.location.search);
   const layout = normalizedParam(params.get("layout"));
   const panels = normalizedParam(params.get("panels"));
   const toolbar = normalizedParam(params.get("toolbar"));
   const compact = COMPACT_LAYOUT_VALUES.has(layout);
-  const panelsVisible =
-    !HIDDEN_PANEL_VALUES.has(panels) &&
-    normalizedParam(params.get("hidePanels")) !== "true";
-  const toolbarLabels = !compact && !ICON_TOOLBAR_VALUES.has(toolbar);
+  const panelsHidden =
+    HIDDEN_PANEL_VALUES.has(panels) ||
+    normalizedParam(params.get("hidePanels")) === "true";
+  const toolbarLabels =
+    !compact && !ICON_TOOLBAR_VALUES.has(toolbar)
+      ? layoutSettings.toolbarLabels
+      : false;
+  const showProjectInfo = compact ? false : layoutSettings.showProjectInfo;
+  const layerPanelVisible = panelsHidden
+    ? false
+    : layoutSettings.layerPanelVisible;
+  const stylePanelVisible = panelsHidden
+    ? false
+    : layoutSettings.stylePanelVisible;
+  const attributePanelVisible = panelsHidden
+    ? false
+    : layoutSettings.attributePanelVisible;
 
   return {
+    attributePanelVisible,
     compact,
-    panelsVisible,
-    showProjectInfo: !compact,
+    layerPanelVisible,
+    panelsVisible:
+      layerPanelVisible || stylePanelVisible || attributePanelVisible,
+    showProjectInfo,
+    stylePanelVisible,
     toolbarLabels,
   };
 }

--- a/apps/geolibre-desktop/src/hooks/useLayoutOptions.ts
+++ b/apps/geolibre-desktop/src/hooks/useLayoutOptions.ts
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useShallow } from "zustand/react/shallow";
 import {
   useDesktopSettingsStore,
   type DesktopLayoutSettings,
@@ -17,17 +18,12 @@ const COMPACT_LAYOUT_VALUES = new Set(["compact", "embed", "iframe"]);
 const ICON_TOOLBAR_VALUES = new Set(["icon", "icons", "icon-only"]);
 const HIDDEN_PANEL_VALUES = new Set(["hidden", "hide", "none", "off"]);
 
-const DEFAULT_LAYOUT_OPTIONS: LayoutOptions = {
-  attributePanelVisible: true,
-  compact: false,
-  layerPanelVisible: true,
-  showProjectInfo: true,
-  stylePanelVisible: true,
-  toolbarLabels: true,
-};
-
 export function useLayoutOptions(): LayoutOptions {
-  const layoutSettings = useDesktopSettingsStore((s) => s.desktopSettings.layout);
+  // Shallow equality keeps unrelated desktop-settings updates (which always
+  // rebuild the layout object) from re-rendering every layout consumer.
+  const layoutSettings = useDesktopSettingsStore(
+    useShallow((s) => s.desktopSettings.layout),
+  );
   return useMemo(
     () => layoutOptionsFromLocation(layoutSettings),
     [layoutSettings],
@@ -38,7 +34,7 @@ function layoutOptionsFromLocation(
   layoutSettings: DesktopLayoutSettings,
 ): LayoutOptions {
   if (typeof window === "undefined") {
-    return { ...DEFAULT_LAYOUT_OPTIONS, ...layoutSettings };
+    return { compact: false, ...layoutSettings };
   }
 
   const params = new URLSearchParams(window.location.search);

--- a/apps/geolibre-desktop/src/hooks/useLayoutOptions.ts
+++ b/apps/geolibre-desktop/src/hooks/useLayoutOptions.ts
@@ -8,7 +8,6 @@ export interface LayoutOptions {
   attributePanelVisible: boolean;
   compact: boolean;
   layerPanelVisible: boolean;
-  panelsVisible: boolean;
   showProjectInfo: boolean;
   stylePanelVisible: boolean;
   toolbarLabels: boolean;
@@ -22,7 +21,6 @@ const DEFAULT_LAYOUT_OPTIONS: LayoutOptions = {
   attributePanelVisible: true,
   compact: false,
   layerPanelVisible: true,
-  panelsVisible: true,
   showProjectInfo: true,
   stylePanelVisible: true,
   toolbarLabels: true,
@@ -40,14 +38,7 @@ function layoutOptionsFromLocation(
   layoutSettings: DesktopLayoutSettings,
 ): LayoutOptions {
   if (typeof window === "undefined") {
-    return {
-      ...DEFAULT_LAYOUT_OPTIONS,
-      ...layoutSettings,
-      panelsVisible:
-        layoutSettings.layerPanelVisible ||
-        layoutSettings.stylePanelVisible ||
-        layoutSettings.attributePanelVisible,
-    };
+    return { ...DEFAULT_LAYOUT_OPTIONS, ...layoutSettings };
   }
 
   const params = new URLSearchParams(window.location.search);
@@ -77,8 +68,6 @@ function layoutOptionsFromLocation(
     attributePanelVisible,
     compact,
     layerPanelVisible,
-    panelsVisible:
-      layerPanelVisible || stylePanelVisible || attributePanelVisible,
     showProjectInfo,
     stylePanelVisible,
     toolbarLabels,


### PR DESCRIPTION
## Summary
- Add a Layout section to the Settings dialog with persisted toggles for the Layers, Style, and Attribute panels, icon-only toolbar buttons, and project info visibility
- Add a Layout submenu to the settings dropdown for quick toggling without opening the dialog
- Split the single panelsVisible flag into per-panel visibility; URL layout parameters (layout, panels, toolbar, hidePanels) still take precedence in shared viewer links

## Test plan
- [ ] Open Settings > Layout, toggle each panel off, save, and confirm the corresponding panel hides
- [ ] Toggle panels from the settings dropdown Layout submenu and confirm changes apply immediately
- [ ] Reload the app and confirm layout settings persist
- [ ] Open the app with ?hidePanels=true and ?layout=compact and confirm URL parameters still override saved settings
- [ ] Click Reset in the Layout section and confirm defaults are restored after saving

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Layout settings section with per-panel visibility toggles (layer, style, attribute), toolbar label and project-info controls, plus a reset option.
  * Layout preferences persist and can be edited in a draft UI; quick toggles update saved layout immediately. URL layout parameters override saved settings.

* **Refactor**
  * Side panels now respect individual visibility settings and can be shown/hidden independently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->