### PR TITLE
feat: run Whitebox batch tools from a selected input directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ The browser demo supports URL parameters for iframe-friendly layouts.
 
 Open a project by URL:
 
-<https://viewer.geolibre.app/?url=https://data.geolibre.app/opera-dswx.geolibre.json>
+<https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json>
 
 Supported query parameters:
 
 | Parameter    | Example                                                  | Description                                                                                                                 |
 | ------------ | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `url`        | `url=https://data.geolibre.app/opera-dswx.geolibre.json` | Loads a `.geolibre.json` project from a public URL.                                                                         |
+| `url`        | `url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json` | Loads a `.geolibre.json` project from a public URL.                                                                         |
 | `layout`     | `layout=compact`                                         | Uses the compact embed layout with icon-only toolbar buttons and hidden project metadata. `embed` and `iframe` are aliases. |
 | `toolbar`    | `toolbar=icons`                                          | Shows icon-only toolbar buttons without enabling the full compact layout.                                                   |
 | `panels`     | `panels=none`                                            | Hides the Layers, Style, and Attribute table panels. `hidden`, `hide`, and `off` are aliases.                               |
@@ -92,13 +92,13 @@ Supported query parameters:
 Use compact mode for narrow embeds. This shows icon-only toolbar buttons and hides project metadata:
 
 ```text
-https://viewer.geolibre.app/?url=https://data.geolibre.app/opera-dswx.geolibre.json&layout=compact
+https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json&layout=compact
 ```
 
 Hide the Layers, Style, and Attribute table panels for map-focused embeds:
 
 ```text
-https://viewer.geolibre.app/?url=https://data.geolibre.app/opera-dswx.geolibre.json&layout=compact&panels=none
+https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json&layout=compact&panels=none
 ```
 
 Use `toolbar=icons` when you only want icon-only toolbar buttons. `panels=hidden`, `panels=hide`, `panels=off`, and `hidePanels=true` are accepted aliases for hiding panels.

--- a/backend/geolibre_server/geolibre_server/app/whitebox.py
+++ b/backend/geolibre_server/geolibre_server/app/whitebox.py
@@ -720,6 +720,13 @@ def _coerce_value(value: Any, kind: str) -> Any:
     return value
 
 
+# Catalog wording that marks a dataset input as batch-capable. Whitebox tool
+# descriptions read "... If omitted, runs in batch mode over all ... files in
+# current directory." If a catalog release rephrases this, directory values
+# fall through to normal argument coercion instead of enabling batch mode.
+_BATCH_DESCRIPTION_PHRASES = ("batch mode", "current directory", "omitted")
+
+
 def _is_batch_directory_input(param: dict[str, Any]) -> bool:
     """Return whether a parameter supports directory-backed batch mode.
 
@@ -732,11 +739,8 @@ def _is_batch_directory_input(param: dict[str, Any]) -> bool:
     """
     kind = str(param.get("kind") or "")
     description = str(param.get("description") or "").lower()
-    return (
-        kind.endswith("_in")
-        and "batch mode" in description
-        and "current directory" in description
-        and "omitted" in description
+    return kind.endswith("_in") and all(
+        phrase in description for phrase in _BATCH_DESCRIPTION_PHRASES
     )
 
 
@@ -748,15 +752,19 @@ def _batch_working_directory(value: Any, param: dict[str, Any]) -> str | None:
         param: Normalized Whitebox parameter metadata.
 
     Returns:
-        The selected directory path when the value should trigger batch mode,
-        otherwise None.
+        The normalized directory path when the value should trigger batch
+        mode, otherwise None.
     """
     if not _is_batch_directory_input(param) or not isinstance(value, str):
         return None
     path = Path(value).expanduser()
-    if path.is_dir():
-        return str(path)
-    return None
+    # Require an absolute, non-symlinked directory (matching the symlink
+    # policy of whitebox_output) and normalize it so the single-directory
+    # comparison in _prepare_arguments is not defeated by lexical variants
+    # such as /data/./a.
+    if not path.is_absolute() or path.is_symlink() or not path.is_dir():
+        return None
+    return str(path.resolve())
 
 
 def _write_layer_input(param_name: str, layer: dict[str, Any], temp_paths: list[Path]) -> str:

--- a/backend/geolibre_server/geolibre_server/app/whitebox.py
+++ b/backend/geolibre_server/geolibre_server/app/whitebox.py
@@ -451,6 +451,7 @@ class ExternalRuntimeSession:
         tool_id: str,
         args_json: str,
         callback: Callable[[Any], None] | None = None,
+        working_directory: str | None = None,
     ) -> str:
         """Run a Whitebox tool and stream progress events to a callback."""
         payload = {
@@ -500,6 +501,7 @@ class ExternalRuntimeSession:
             encoding="utf-8",
             errors="replace",
             env=_clean_env(),
+            cwd=working_directory,
             bufsize=1,
             **_subprocess_startup_kwargs(),
         )
@@ -718,6 +720,45 @@ def _coerce_value(value: Any, kind: str) -> Any:
     return value
 
 
+def _is_batch_directory_input(param: dict[str, Any]) -> bool:
+    """Return whether a parameter supports directory-backed batch mode.
+
+    Args:
+        param: Normalized Whitebox parameter metadata.
+
+    Returns:
+        True when the parameter is an input dataset that the catalog documents
+        as batch-capable when omitted.
+    """
+    kind = str(param.get("kind") or "")
+    description = str(param.get("description") or "").lower()
+    return (
+        kind.endswith("_in")
+        and "batch mode" in description
+        and "current directory" in description
+        and "omitted" in description
+    )
+
+
+def _batch_working_directory(value: Any, param: dict[str, Any]) -> str | None:
+    """Return the working directory for a batch-mode input value.
+
+    Args:
+        value: Frontend parameter value.
+        param: Normalized Whitebox parameter metadata.
+
+    Returns:
+        The selected directory path when the value should trigger batch mode,
+        otherwise None.
+    """
+    if not _is_batch_directory_input(param) or not isinstance(value, str):
+        return None
+    path = Path(value).expanduser()
+    if path.is_dir():
+        return str(path)
+    return None
+
+
 def _write_layer_input(param_name: str, layer: dict[str, Any], temp_paths: list[Path]) -> str:
     """Write an embedded layer input to a temporary file.
 
@@ -739,28 +780,47 @@ def _write_layer_input(param_name: str, layer: dict[str, Any], temp_paths: list[
     return str(path)
 
 
-def _prepare_arguments(request: WhiteboxRunRequest, temp_paths: list[Path]) -> dict[str, Any]:
-    """Prepare a Whitebox JSON argument payload from a run request."""
+def _prepare_arguments(
+    request: WhiteboxRunRequest,
+    temp_paths: list[Path],
+) -> tuple[dict[str, Any], str | None]:
+    """Prepare a Whitebox JSON argument payload from a run request.
+
+    Args:
+        request: Tool run request from the frontend.
+        temp_paths: Collection of temporary paths to remove after execution.
+
+    Returns:
+        A tuple containing the argument payload and an optional subprocess
+        working directory for directory-backed batch tools.
+    """
     specs = {
         str(param.get("name")): param
         for param in (request.tool or {}).get("params", [])
         if isinstance(param, dict)
     }
     args: dict[str, Any] = {}
+    working_directory: str | None = None
     for name, value in request.parameters.items():
         spec = specs.get(str(name), {})
         kind = str(spec.get("kind") or "")
         if name in request.layer_inputs:
             value = _write_layer_input(name, request.layer_inputs[name], temp_paths)
+        batch_directory = _batch_working_directory(value, spec)
+        if batch_directory:
+            if working_directory and working_directory != batch_directory:
+                raise ValueError("Only one Whitebox batch input directory is supported.")
+            working_directory = batch_directory
+            continue
         coerced = _coerce_value(value, kind)
         if coerced is not None:
             args[name] = coerced
 
     for name, spec in specs.items():
         kind = str(spec.get("kind") or "")
-        if kind.endswith("_out") and not args.get(name):
+        if kind.endswith("_out") and not args.get(name) and not working_directory:
             args[name] = _default_output_path(request.tool_id, name, kind)
-    return args
+    return args, working_directory
 
 
 def _extract_outputs(result: Any, args: dict[str, Any], tool: dict[str, Any] | None) -> dict[str, Any]:
@@ -822,7 +882,7 @@ def _run_job(job_id: str, request: WhiteboxRunRequest) -> None:
     temp_paths: list[Path] = []
     try:
         _job_update(job_id, status="running")
-        args = _prepare_arguments(request, temp_paths)
+        args, working_directory = _prepare_arguments(request, temp_paths)
         session = create_runtime_session(
             include_pro=request.include_pro,
             tier=request.tier or "open",
@@ -831,6 +891,7 @@ def _run_job(job_id: str, request: WhiteboxRunRequest) -> None:
             request.tool_id,
             json.dumps(args),
             lambda event: _append_job_message(job_id, event),
+            working_directory=working_directory,
         )
         result = _parse_json_maybe(raw_result)
         _job_update(

--- a/backend/geolibre_server/tests/test_whitebox_arguments.py
+++ b/backend/geolibre_server/tests/test_whitebox_arguments.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+
+from geolibre_server.app.whitebox import WhiteboxRunRequest, _prepare_arguments
+
+
+def _classify_lidar_tool() -> dict:
+    """Return minimal Classify LiDAR metadata for argument tests.
+
+    Returns:
+        Tool metadata with one batch-capable LiDAR input and one LiDAR output.
+    """
+    return {
+        "id": "classify_lidar",
+        "params": [
+            {
+                "data_kind": "lidar",
+                "description": (
+                    "Input LiDAR path or typed LiDAR object. If omitted, runs "
+                    "in batch mode over LiDAR files in current directory."
+                ),
+                "io_role": "input",
+                "kind": "lidar_in",
+                "name": "input",
+                "required": False,
+            },
+            {
+                "data_kind": "lidar",
+                "description": "Optional output LiDAR path.",
+                "io_role": "output",
+                "kind": "lidar_out",
+                "name": "output",
+                "required": False,
+            },
+        ],
+    }
+
+
+def test_prepare_arguments_uses_lidar_directory_as_batch_workdir(
+    tmp_path: Path,
+) -> None:
+    """Verify directory LiDAR inputs trigger Whitebox batch mode.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    request = WhiteboxRunRequest(
+        tool_id="classify_lidar",
+        parameters={"input": str(tmp_path), "output": ""},
+        tool=_classify_lidar_tool(),
+    )
+
+    args, working_directory = _prepare_arguments(request, [])
+
+    assert args == {}
+    assert working_directory == str(tmp_path)
+
+
+def test_prepare_arguments_keeps_lidar_file_input(tmp_path: Path) -> None:
+    """Verify file LiDAR inputs keep the normal JSON input argument.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    lidar_path = tmp_path / "sample.las"
+    lidar_path.touch()
+    request = WhiteboxRunRequest(
+        tool_id="classify_lidar",
+        parameters={"input": str(lidar_path), "output": ""},
+        tool=_classify_lidar_tool(),
+    )
+
+    args, working_directory = _prepare_arguments(request, [])
+
+    assert args["input"] == str(lidar_path)
+    assert args["output"].endswith(".laz")
+    assert working_directory is None

--- a/backend/geolibre_server/tests/test_whitebox_arguments.py
+++ b/backend/geolibre_server/tests/test_whitebox_arguments.py
@@ -1,6 +1,37 @@
 from pathlib import Path
 
-from geolibre_server.app.whitebox import WhiteboxRunRequest, _prepare_arguments
+import pytest
+
+from geolibre_server.app.whitebox import (
+    WhiteboxRunRequest,
+    _is_batch_directory_input,
+    _prepare_arguments,
+)
+
+_BATCH_DESCRIPTION = (
+    "Input LiDAR path or typed LiDAR object. If omitted, runs "
+    "in batch mode over LiDAR files in current directory."
+)
+
+
+def _lidar_input_param(name: str, description: str = _BATCH_DESCRIPTION) -> dict:
+    """Return minimal LiDAR input parameter metadata.
+
+    Args:
+        name: Parameter name.
+        description: Catalog description controlling batch detection.
+
+    Returns:
+        Normalized Whitebox parameter metadata for a LiDAR input.
+    """
+    return {
+        "data_kind": "lidar",
+        "description": description,
+        "io_role": "input",
+        "kind": "lidar_in",
+        "name": name,
+        "required": False,
+    }
 
 
 def _classify_lidar_tool() -> dict:
@@ -12,17 +43,7 @@ def _classify_lidar_tool() -> dict:
     return {
         "id": "classify_lidar",
         "params": [
-            {
-                "data_kind": "lidar",
-                "description": (
-                    "Input LiDAR path or typed LiDAR object. If omitted, runs "
-                    "in batch mode over LiDAR files in current directory."
-                ),
-                "io_role": "input",
-                "kind": "lidar_in",
-                "name": "input",
-                "required": False,
-            },
+            _lidar_input_param("input"),
             {
                 "data_kind": "lidar",
                 "description": "Optional output LiDAR path.",
@@ -51,8 +72,10 @@ def test_prepare_arguments_uses_lidar_directory_as_batch_workdir(
 
     args, working_directory = _prepare_arguments(request, [])
 
+    # The empty output value coerces away and batch mode suppresses the
+    # default output path, so args carries no "output" key either.
     assert args == {}
-    assert working_directory == str(tmp_path)
+    assert working_directory == str(tmp_path.resolve())
 
 
 def test_prepare_arguments_keeps_lidar_file_input(tmp_path: Path) -> None:
@@ -74,3 +97,121 @@ def test_prepare_arguments_keeps_lidar_file_input(tmp_path: Path) -> None:
     assert args["input"] == str(lidar_path)
     assert args["output"].endswith(".laz")
     assert working_directory is None
+
+
+def test_prepare_arguments_keeps_missing_path_as_input(tmp_path: Path) -> None:
+    """Verify nonexistent paths fall through to normal argument handling.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    missing = tmp_path / "missing.las"
+    request = WhiteboxRunRequest(
+        tool_id="classify_lidar",
+        parameters={"input": str(missing), "output": ""},
+        tool=_classify_lidar_tool(),
+    )
+
+    args, working_directory = _prepare_arguments(request, [])
+
+    assert args["input"] == str(missing)
+    assert working_directory is None
+
+
+def test_prepare_arguments_rejects_relative_batch_directory() -> None:
+    """Verify relative directory values do not trigger batch mode."""
+    request = WhiteboxRunRequest(
+        tool_id="classify_lidar",
+        parameters={"input": ".", "output": ""},
+        tool=_classify_lidar_tool(),
+    )
+
+    args, working_directory = _prepare_arguments(request, [])
+
+    assert args["input"] == "."
+    assert working_directory is None
+
+
+def test_prepare_arguments_rejects_conflicting_batch_directories(
+    tmp_path: Path,
+) -> None:
+    """Verify two different batch directories raise a ValueError.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    tool = {
+        "id": "classify_lidar",
+        "params": [_lidar_input_param("input"), _lidar_input_param("polygons")],
+    }
+    request = WhiteboxRunRequest(
+        tool_id="classify_lidar",
+        parameters={"input": str(first), "polygons": str(second)},
+        tool=tool,
+    )
+
+    with pytest.raises(ValueError, match="batch input directory"):
+        _prepare_arguments(request, [])
+
+
+def test_prepare_arguments_accepts_equivalent_batch_directories(
+    tmp_path: Path,
+) -> None:
+    """Verify lexical variants of the same directory do not conflict.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    tool = {
+        "id": "classify_lidar",
+        "params": [_lidar_input_param("input"), _lidar_input_param("polygons")],
+    }
+    request = WhiteboxRunRequest(
+        tool_id="classify_lidar",
+        parameters={
+            "input": str(tmp_path),
+            "polygons": str(sub / ".."),
+        },
+        tool=tool,
+    )
+
+    args, working_directory = _prepare_arguments(request, [])
+
+    assert args == {}
+    assert working_directory == str(tmp_path.resolve())
+
+
+def test_prepare_arguments_without_tool_metadata(tmp_path: Path) -> None:
+    """Verify missing tool metadata never triggers batch mode.
+
+    Args:
+        tmp_path: Pytest temporary directory fixture.
+    """
+    request = WhiteboxRunRequest(
+        tool_id="classify_lidar",
+        parameters={"input": str(tmp_path)},
+        tool=None,
+    )
+
+    args, working_directory = _prepare_arguments(request, [])
+
+    assert args["input"] == str(tmp_path)
+    assert working_directory is None
+
+
+def test_is_batch_directory_input_requires_batch_wording() -> None:
+    """Verify non-batch descriptions never enable batch mode."""
+    assert _is_batch_directory_input(_lidar_input_param("input"))
+    assert not _is_batch_directory_input(
+        _lidar_input_param("input", description="Input LiDAR file.")
+    )
+    # Output parameters never enable batch mode even with batch wording.
+    output_param = _lidar_input_param("output")
+    output_param["kind"] = "lidar_out"
+    assert not _is_batch_directory_input(output_param)

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,26 +67,26 @@ The live demo is the browser-capable version of the GeoLibre desktop UI. It is u
 Open a project by passing a public `.geolibre.json` URL with the `url` query parameter:
 
 ```text
-https://viewer.geolibre.app/?url=https://data.geolibre.app/opera-dswx.geolibre.json
+https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json
 ```
 
 For narrow embeds, add `?layout=compact` to the demo URL to use icon-only toolbar buttons and hide project metadata:
 
 ```text
-https://viewer.geolibre.app/?url=https://data.geolibre.app/opera-dswx.geolibre.json&layout=compact
+https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json&layout=compact
 ```
 
 For map-focused embeds, add `&panels=none` to hide the Layers, Style, and Attribute table panels:
 
 ```text
-https://viewer.geolibre.app/?url=https://data.geolibre.app/opera-dswx.geolibre.json&layout=compact&panels=none
+https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json&layout=compact&panels=none
 ```
 
 Use `toolbar=icons` when you only want icon-only toolbar buttons. `panels=hidden`, `panels=hide`, `panels=off`, and `hidePanels=true` are accepted aliases for hiding panels.
 
 | Parameter | Example | Description |
 | --- | --- | --- |
-| `url` | `url=https://data.geolibre.app/opera-dswx.geolibre.json` | Loads a `.geolibre.json` project from a public URL. |
+| `url` | `url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json` | Loads a `.geolibre.json` project from a public URL. |
 | `layout` | `layout=compact` | Uses the compact embed layout with icon-only toolbar buttons and hidden project metadata. `embed` and `iframe` are aliases. |
 | `toolbar` | `toolbar=icons` | Shows icon-only toolbar buttons without enabling the full compact layout. |
 | `panels` | `panels=none` | Hides the Layers, Style, and Attribute table panels. `hidden`, `hide`, and `off` are aliases. |


### PR DESCRIPTION
## Summary
- Whitebox LiDAR tools document a batch mode that processes all files in the current directory when the input is omitted. When the user selects a directory as the input, the input argument is now omitted and the tool subprocess runs with that directory as its working directory, enabling batch processing from the UI.
- Default output paths are skipped in batch mode so Whitebox writes outputs next to the inputs.
- Update the demo project URL in the README and docs to a share.geolibre.app example.

## Test plan
- [x] Added unit tests covering directory inputs (batch working directory, no input arg) and file inputs (unchanged behavior, default output path)
- [x] `pytest backend/geolibre_server/tests/` passes
- [x] `pre-commit run --all-files` passes
- [ ] Run a batch-capable Whitebox LiDAR tool with a directory input from the UI and verify outputs are written alongside the inputs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batch-mode support for Whitebox tools, allowing runs to use a selected working directory for tool execution.

* **Documentation**
  * Updated embedded demo examples and browser instructions with a new example project URL and revised parameter examples.

* **Tests**
  * Added tests covering batch-mode argument preparation, detection, conflict handling, and related edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->