### PR TITLE
fix: make menus, dialogs, and panels usable on small screens

### DIFF
--- a/apps/geolibre-desktop/index.html
+++ b/apps/geolibre-desktop/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/png" href="%BASE_URL%favicon.png" sizes="32x32" />
     <link rel="icon" href="%BASE_URL%favicon.ico" sizes="any" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>GeoLibre Desktop</title>
+    <title>GeoLibre</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/geolibre-desktop/src/components/layout/DiagnosticsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DiagnosticsDialog.tsx
@@ -101,7 +101,7 @@ export function DiagnosticsDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         className="max-h-[min(760px,92vh)] max-w-5xl"
-        bodyClassName="grid-rows-[auto_auto_minmax(0,1fr)] p-0"
+        bodyClassName="grid-rows-[auto_auto_minmax(0,1fr)] overflow-hidden p-0"
       >
         <DialogHeader className="border-b px-6 py-4 pr-12">
           <DialogTitle>Diagnostics</DialogTitle>

--- a/apps/geolibre-desktop/src/components/layout/DiagnosticsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DiagnosticsDialog.tsx
@@ -99,7 +99,10 @@ export function DiagnosticsDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[min(760px,92vh)] max-w-5xl grid-rows-[auto_auto_minmax(0,1fr)] p-0">
+      <DialogContent
+        className="max-h-[min(760px,92vh)] max-w-5xl"
+        bodyClassName="grid-rows-[auto_auto_minmax(0,1fr)] p-0"
+      >
         <DialogHeader className="border-b px-6 py-4 pr-12">
           <DialogTitle>Diagnostics</DialogTitle>
           <DialogDescription>

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -636,9 +636,9 @@ export function SettingsDialog({
                 Layout Settings
               </DropdownMenuItem>
               <DropdownMenuSeparator />
-              <p className="px-2 py-1 text-xs text-muted-foreground">
+              <DropdownMenuLabel className="px-2 py-1 text-xs font-normal text-muted-foreground">
                 URL layout parameters override saved settings.
-              </p>
+              </DropdownMenuLabel>
             </DropdownMenuSubContent>
           </DropdownMenuSub>
           <DropdownMenuItem

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -21,9 +21,6 @@ import {
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
   Input,
   Label,
@@ -554,7 +551,7 @@ export function SettingsDialog({
             ) : null}
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start">
+        <DropdownMenuContent align="start" className="w-72">
           <DropdownMenuLabel>Settings</DropdownMenuLabel>
           <DropdownMenuSeparator />
           <DropdownMenuItem
@@ -566,79 +563,76 @@ export function SettingsDialog({
             <MapPinned className="mr-2 h-3.5 w-3.5" />
             Map Preferences
           </DropdownMenuItem>
-          <DropdownMenuSub>
-            <DropdownMenuSubTrigger>
-              <LayoutPanelTop className="mr-2 h-3.5 w-3.5" />
-              Layout
-            </DropdownMenuSubTrigger>
-            <DropdownMenuSubContent className="min-w-56">
-              <DropdownMenuCheckboxItem
-                checked={desktopSettings.layout.toolbarLabels}
-                onCheckedChange={(checked) =>
-                  updateSavedLayoutSettings({ toolbarLabels: checked === true })
-                }
-                onSelect={(event) => event.preventDefault()}
-              >
-                Show toolbar labels
-              </DropdownMenuCheckboxItem>
-              <DropdownMenuCheckboxItem
-                checked={desktopSettings.layout.showProjectInfo}
-                onCheckedChange={(checked) =>
-                  updateSavedLayoutSettings({ showProjectInfo: checked === true })
-                }
-                onSelect={(event) => event.preventDefault()}
-              >
-                Show project info
-              </DropdownMenuCheckboxItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuCheckboxItem
-                checked={desktopSettings.layout.layerPanelVisible}
-                onCheckedChange={(checked) =>
-                  updateSavedLayoutSettings({
-                    layerPanelVisible: checked === true,
-                  })
-                }
-                onSelect={(event) => event.preventDefault()}
-              >
-                Show Layers panel
-              </DropdownMenuCheckboxItem>
-              <DropdownMenuCheckboxItem
-                checked={desktopSettings.layout.stylePanelVisible}
-                onCheckedChange={(checked) =>
-                  updateSavedLayoutSettings({
-                    stylePanelVisible: checked === true,
-                  })
-                }
-                onSelect={(event) => event.preventDefault()}
-              >
-                Show Style panel
-              </DropdownMenuCheckboxItem>
-              <DropdownMenuCheckboxItem
-                checked={desktopSettings.layout.attributePanelVisible}
-                onCheckedChange={(checked) =>
-                  updateSavedLayoutSettings({
-                    attributePanelVisible: checked === true,
-                  })
-                }
-                onSelect={(event) => event.preventDefault()}
-              >
-                Show Attribute panel
-              </DropdownMenuCheckboxItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                onSelect={() => {
-                  setSection("layout");
-                  setOpen(true);
-                }}
-              >
-                Layout Settings
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <p className="px-2 py-1 text-xs text-muted-foreground">
-                URL layout parameters override saved settings.
-              </p>
-            </DropdownMenuSubContent>
-          </DropdownMenuSub>
+          <DropdownMenuSeparator />
+          <DropdownMenuLabel className="flex items-center gap-2 text-xs text-muted-foreground">
+            <LayoutPanelTop className="h-3.5 w-3.5" />
+            Layout
+          </DropdownMenuLabel>
+          <DropdownMenuCheckboxItem
+            checked={desktopSettings.layout.toolbarLabels}
+            onCheckedChange={(checked) =>
+              updateSavedLayoutSettings({ toolbarLabels: checked === true })
+            }
+            onSelect={(event) => event.preventDefault()}
+          >
+            Show toolbar labels
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem
+            checked={desktopSettings.layout.showProjectInfo}
+            onCheckedChange={(checked) =>
+              updateSavedLayoutSettings({ showProjectInfo: checked === true })
+            }
+            onSelect={(event) => event.preventDefault()}
+          >
+            Show project info
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuCheckboxItem
+            checked={desktopSettings.layout.layerPanelVisible}
+            onCheckedChange={(checked) =>
+              updateSavedLayoutSettings({
+                layerPanelVisible: checked === true,
+              })
+            }
+            onSelect={(event) => event.preventDefault()}
+          >
+            Show Layers panel
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem
+            checked={desktopSettings.layout.stylePanelVisible}
+            onCheckedChange={(checked) =>
+              updateSavedLayoutSettings({
+                stylePanelVisible: checked === true,
+              })
+            }
+            onSelect={(event) => event.preventDefault()}
+          >
+            Show Style panel
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem
+            checked={desktopSettings.layout.attributePanelVisible}
+            onCheckedChange={(checked) =>
+              updateSavedLayoutSettings({
+                attributePanelVisible: checked === true,
+              })
+            }
+            onSelect={(event) => event.preventDefault()}
+          >
+            Show Attribute panel
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onSelect={() => {
+              setSection("layout");
+              setOpen(true);
+            }}
+          >
+            Layout Settings
+          </DropdownMenuItem>
+          <p className="px-2 py-1 text-xs text-muted-foreground">
+            URL layout parameters override saved settings.
+          </p>
+          <DropdownMenuSeparator />
           <DropdownMenuItem
             onSelect={() => {
               setSection("environment");

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -669,7 +669,10 @@ export function SettingsDialog({
         </DropdownMenuContent>
       </DropdownMenu>
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-h-[min(88vh,760px)] max-w-3xl overflow-hidden p-0">
+        <DialogContent
+          className="max-h-[min(88vh,760px)] max-w-3xl"
+          bodyClassName="overflow-hidden p-0"
+        >
           <DialogHeader className="border-b px-6 pb-4 pt-6">
             <DialogTitle>Settings</DialogTitle>
             <DialogDescription>

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -21,6 +21,9 @@ import {
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
   Input,
   Label,
@@ -551,7 +554,7 @@ export function SettingsDialog({
             ) : null}
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="w-72">
+        <DropdownMenuContent align="start" className="w-56">
           <DropdownMenuLabel>Settings</DropdownMenuLabel>
           <DropdownMenuSeparator />
           <DropdownMenuItem
@@ -563,76 +566,81 @@ export function SettingsDialog({
             <MapPinned className="mr-2 h-3.5 w-3.5" />
             Map Preferences
           </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuLabel className="flex items-center gap-2 text-xs text-muted-foreground">
-            <LayoutPanelTop className="h-3.5 w-3.5" />
-            Layout
-          </DropdownMenuLabel>
-          <DropdownMenuCheckboxItem
-            checked={desktopSettings.layout.toolbarLabels}
-            onCheckedChange={(checked) =>
-              updateSavedLayoutSettings({ toolbarLabels: checked === true })
-            }
-            onSelect={(event) => event.preventDefault()}
-          >
-            Show toolbar labels
-          </DropdownMenuCheckboxItem>
-          <DropdownMenuCheckboxItem
-            checked={desktopSettings.layout.showProjectInfo}
-            onCheckedChange={(checked) =>
-              updateSavedLayoutSettings({ showProjectInfo: checked === true })
-            }
-            onSelect={(event) => event.preventDefault()}
-          >
-            Show project info
-          </DropdownMenuCheckboxItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuCheckboxItem
-            checked={desktopSettings.layout.layerPanelVisible}
-            onCheckedChange={(checked) =>
-              updateSavedLayoutSettings({
-                layerPanelVisible: checked === true,
-              })
-            }
-            onSelect={(event) => event.preventDefault()}
-          >
-            Show Layers panel
-          </DropdownMenuCheckboxItem>
-          <DropdownMenuCheckboxItem
-            checked={desktopSettings.layout.stylePanelVisible}
-            onCheckedChange={(checked) =>
-              updateSavedLayoutSettings({
-                stylePanelVisible: checked === true,
-              })
-            }
-            onSelect={(event) => event.preventDefault()}
-          >
-            Show Style panel
-          </DropdownMenuCheckboxItem>
-          <DropdownMenuCheckboxItem
-            checked={desktopSettings.layout.attributePanelVisible}
-            onCheckedChange={(checked) =>
-              updateSavedLayoutSettings({
-                attributePanelVisible: checked === true,
-              })
-            }
-            onSelect={(event) => event.preventDefault()}
-          >
-            Show Attribute panel
-          </DropdownMenuCheckboxItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem
-            onSelect={() => {
-              setSection("layout");
-              setOpen(true);
-            }}
-          >
-            Layout Settings
-          </DropdownMenuItem>
-          <p className="px-2 py-1 text-xs text-muted-foreground">
-            URL layout parameters override saved settings.
-          </p>
-          <DropdownMenuSeparator />
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              <LayoutPanelTop className="mr-2 h-3.5 w-3.5" />
+              Layout
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent className="geolibre-layout-submenu w-40 sm:w-72">
+              <DropdownMenuCheckboxItem
+                checked={desktopSettings.layout.toolbarLabels}
+                onCheckedChange={(checked) =>
+                  updateSavedLayoutSettings({ toolbarLabels: checked === true })
+                }
+                onSelect={(event) => event.preventDefault()}
+              >
+                Show toolbar labels
+              </DropdownMenuCheckboxItem>
+              <DropdownMenuCheckboxItem
+                checked={desktopSettings.layout.showProjectInfo}
+                onCheckedChange={(checked) =>
+                  updateSavedLayoutSettings({
+                    showProjectInfo: checked === true,
+                  })
+                }
+                onSelect={(event) => event.preventDefault()}
+              >
+                Show project info
+              </DropdownMenuCheckboxItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuCheckboxItem
+                checked={desktopSettings.layout.layerPanelVisible}
+                onCheckedChange={(checked) =>
+                  updateSavedLayoutSettings({
+                    layerPanelVisible: checked === true,
+                  })
+                }
+                onSelect={(event) => event.preventDefault()}
+              >
+                Show Layers panel
+              </DropdownMenuCheckboxItem>
+              <DropdownMenuCheckboxItem
+                checked={desktopSettings.layout.stylePanelVisible}
+                onCheckedChange={(checked) =>
+                  updateSavedLayoutSettings({
+                    stylePanelVisible: checked === true,
+                  })
+                }
+                onSelect={(event) => event.preventDefault()}
+              >
+                Show Style panel
+              </DropdownMenuCheckboxItem>
+              <DropdownMenuCheckboxItem
+                checked={desktopSettings.layout.attributePanelVisible}
+                onCheckedChange={(checked) =>
+                  updateSavedLayoutSettings({
+                    attributePanelVisible: checked === true,
+                  })
+                }
+                onSelect={(event) => event.preventDefault()}
+              >
+                Show Attribute panel
+              </DropdownMenuCheckboxItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onSelect={() => {
+                  setSection("layout");
+                  setOpen(true);
+                }}
+              >
+                Layout Settings
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <p className="px-2 py-1 text-xs text-muted-foreground">
+                URL layout parameters override saved settings.
+              </p>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
           <DropdownMenuItem
             onSelect={() => {
               setSection("environment");

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -458,6 +458,7 @@ export function TopToolbar({
   const toolbarButtonSize = compact ? "icon" : "sm";
   const toolbarButtonClass = compact ? "h-8 w-8 shrink-0" : "shrink-0";
   const toolbarIconClassName = cn("h-3.5 w-3.5", showLabels && "sm:mr-1");
+  const appTitle = isTauri() ? "GeoLibre Desktop" : "GeoLibre";
   const renderToolbarLabel = (label: string) =>
     showLabels ? <span className="hidden sm:inline">{label}</span> : null;
 
@@ -473,7 +474,7 @@ export function TopToolbar({
       <span className="mr-1 flex shrink-0 items-center gap-1.5 text-sm font-semibold text-primary md:mr-2">
         <Map className="h-4 w-4" />
         {showProjectInfo ? (
-          <span className="hidden sm:inline">GeoLibre Desktop</span>
+          <span className="hidden sm:inline">{appTitle}</span>
         ) : null}
       </span>
       <NewProjectDialog

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -582,68 +582,87 @@ export function TopToolbar({
             {renderToolbarLabel("Add Data")}
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start">
+        <DropdownMenuContent align="start" className="w-64">
           <DropdownMenuLabel>Add data</DropdownMenuLabel>
           <DropdownMenuSeparator />
-          <DropdownMenuItem onSelect={() => setAddDataKind("xyz")}>
-            Add XYZ Layer
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setAddDataKind("wms")}>
-            Add WMS Layer
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setAddDataKind("wfs")}>
-            Add WFS Layer
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setAddDataKind("wmts")}>
-            Add WMTS Layer
-          </DropdownMenuItem>
+          <DropdownMenuLabel className="text-xs text-muted-foreground">
+            Files
+          </DropdownMenuLabel>
           <DropdownMenuItem onSelect={() => setAddDataKind("vector")}>
-            Add Vector Layer
+            Vector Layer
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => setAddDataKind("raster")}>
-            Add Raster Layer
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => void handleAddGeoParquetLayer()}>
-            Add GeoParquet Layer
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleAddFlatGeobufLayer}>
-            Add FlatGeobuf Layer
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleAddPMTilesLayer}>
-            Add PMTiles Layer
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setAddDataKind("mbtiles")}>
-            Add MBTiles Layer
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setAddDataKind("arcgis")}>
-            Add ArcGIS Layer
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleAddZarrLayer}>
-            Add Zarr Layer
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleAddLidarLayer}>
-            Add LiDAR Layer
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleAddSplattingLayer}>
-            Add Splatting Layer
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleAddThreeDTilesLayer}>
-            Add 3D Tiles Layer
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleAddStacLayer}>
-            Add STAC Layer
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleAddDuckDBLayer}>
-            Add DuckDB Layer
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setAddDataKind("postgres")}>
-            Add PostgreSQL Layer
+            Raster Layer
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => setAddDataKind("delimited-text")}>
-            Add Delimited Text Layer
+            Delimited Text Layer
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => setAddDataKind("gpx")}>
-            Add GPX Layer
+            GPX Layer
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setAddDataKind("mbtiles")}>
+            MBTiles Layer
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuLabel className="text-xs text-muted-foreground">
+            Web services
+          </DropdownMenuLabel>
+          <DropdownMenuItem onSelect={() => setAddDataKind("xyz")}>
+            XYZ Layer
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setAddDataKind("wms")}>
+            WMS Layer
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setAddDataKind("wfs")}>
+            WFS Layer
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setAddDataKind("wmts")}>
+            WMTS Layer
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setAddDataKind("arcgis")}>
+            ArcGIS Layer
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={handleAddStacLayer}>
+            STAC Layer
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuLabel className="text-xs text-muted-foreground">
+            Cloud formats
+          </DropdownMenuLabel>
+          <DropdownMenuItem onSelect={() => void handleAddGeoParquetLayer()}>
+            GeoParquet Layer
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={handleAddFlatGeobufLayer}>
+            FlatGeobuf Layer
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={handleAddPMTilesLayer}>
+            PMTiles Layer
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={handleAddZarrLayer}>
+            Zarr Layer
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuLabel className="text-xs text-muted-foreground">
+            3D layers
+          </DropdownMenuLabel>
+          <DropdownMenuItem onSelect={handleAddLidarLayer}>
+            LiDAR Layer
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={handleAddSplattingLayer}>
+            Splatting Layer
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={handleAddThreeDTilesLayer}>
+            3D Tiles Layer
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuLabel className="text-xs text-muted-foreground">
+            Databases
+          </DropdownMenuLabel>
+          <DropdownMenuItem onSelect={handleAddDuckDBLayer}>
+            DuckDB Layer
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setAddDataKind("postgres")}>
+            PostgreSQL Layer
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -625,7 +625,7 @@ export function AttributeTable() {
         ref={tableResizeGuideRef}
         className="pointer-events-none fixed left-0 right-0 z-50 hidden h-px bg-primary shadow-[0_0_0_1px_hsl(var(--primary)/0.25)]"
       />
-      <div className="flex items-center gap-2 border-b px-3 py-1.5">
+      <div className="flex flex-wrap items-center gap-2 border-b px-3 py-1.5 md:flex-nowrap">
         <Button
           variant="ghost"
           size="icon"
@@ -639,10 +639,12 @@ export function AttributeTable() {
         <TableProperties className="h-4 w-4 text-muted-foreground" />
         <span className="text-sm font-semibold">Attribute table</span>
         {layer ? (
-          <span className="text-xs text-muted-foreground">— {layer.name}</span>
+          <span className="min-w-0 max-w-full truncate text-xs text-muted-foreground md:max-w-56">
+            - {layer.name}
+          </span>
         ) : (
-          <span className="text-xs text-muted-foreground">
-            — select a vector layer
+          <span className="min-w-0 max-w-full truncate text-xs text-muted-foreground md:max-w-56">
+            - select a vector layer
           </span>
         )}
         {exportError ? (
@@ -668,7 +670,7 @@ export function AttributeTable() {
           onClick={toggleEditing}
         >
           <Pencil className="h-3.5 w-3.5" />
-          Edit
+          <span className="hidden sm:inline">Edit</span>
         </Button>
         <Button
           variant="default"
@@ -684,7 +686,7 @@ export function AttributeTable() {
           onClick={saveDrafts}
         >
           <Save className="h-3.5 w-3.5" />
-          Save
+          <span className="hidden sm:inline">Save</span>
         </Button>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
@@ -697,7 +699,7 @@ export function AttributeTable() {
               disabled={!layer?.geojson}
             >
               <Download className="h-3.5 w-3.5" />
-              Export
+              <span className="hidden sm:inline">Export</span>
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
@@ -725,8 +727,8 @@ export function AttributeTable() {
           </Button>
         ) : null}
         <Input
-          className="h-7 max-w-xs text-xs"
-          placeholder="Search attributes…"
+          className="h-7 min-w-36 flex-1 text-xs md:max-w-xs"
+          placeholder="Search attributes..."
           aria-label="Search attributes"
           value={attributeFilter}
           onChange={(e) => setAttributeFilter(e.target.value)}

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -462,7 +462,7 @@ export function LayerPanel({
   }
 
   return (
-    <aside className="relative flex max-h-56 w-full shrink-0 flex-col border-b bg-card md:max-h-none md:w-[var(--layer-panel-width)] md:border-b-0 md:border-r">
+    <aside className="relative flex max-h-[min(24rem,42dvh)] w-full shrink-0 flex-col border-b bg-card md:max-h-none md:w-[var(--layer-panel-width)] md:border-b-0 md:border-r">
       <div
         role="separator"
         aria-orientation="vertical"

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -462,7 +462,7 @@ export function LayerPanel({
   }
 
   return (
-    <aside className="relative flex max-h-[min(24rem,42dvh)] w-full shrink-0 flex-col border-b bg-card md:max-h-none md:w-[var(--layer-panel-width)] md:border-b-0 md:border-r">
+    <aside className="relative flex max-h-[min(24rem,42vh)] supports-[max-height:1dvh]:max-h-[min(24rem,42dvh)] w-full shrink-0 flex-col border-b bg-card md:max-h-none md:w-[var(--layer-panel-width)] md:border-b-0 md:border-r">
       <div
         role="separator"
         aria-orientation="vertical"

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -710,6 +710,10 @@ function clampNumber(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
 
+// Shared shell classes for every StylePanel return branch.
+const STYLE_PANEL_ASIDE_CLASS =
+  "relative flex max-h-[min(24rem,42vh)] supports-[max-height:1dvh]:max-h-[min(24rem,42dvh)] w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0";
+
 const MIN_LAYER_ZOOM = DEFAULT_LAYER_STYLE.minZoom;
 const MAX_LAYER_ZOOM = DEFAULT_LAYER_STYLE.maxZoom;
 
@@ -1069,7 +1073,7 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
 
   if (!layer) {
     return (
-      <aside className="relative flex max-h-[min(24rem,42vh)] supports-[max-height:1dvh]:max-h-[min(24rem,42dvh)] w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0">
+      <aside className={STYLE_PANEL_ASIDE_CLASS}>
         {resizeHandle}
         <div className="flex items-center justify-between border-b px-3 py-1.5">
           <span className="text-sm font-semibold">Style</span>
@@ -1824,7 +1828,7 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
 
   if (hasRasterPaintControls) {
     return (
-      <aside className="relative flex max-h-[min(24rem,42vh)] supports-[max-height:1dvh]:max-h-[min(24rem,42dvh)] w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0">
+      <aside className={STYLE_PANEL_ASIDE_CLASS}>
         {resizeHandle}
         <div className="flex items-center justify-between gap-2 border-b px-3 py-1.5">
           <span className="truncate text-sm font-semibold">
@@ -1922,7 +1926,7 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
 
   if (!hasVectorPaintControls) {
     return (
-      <aside className="relative flex max-h-[min(24rem,42vh)] supports-[max-height:1dvh]:max-h-[min(24rem,42dvh)] w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0">
+      <aside className={STYLE_PANEL_ASIDE_CLASS}>
         {resizeHandle}
         <div className="flex items-center justify-between gap-2 border-b px-3 py-1.5">
           <span className="truncate text-sm font-semibold">
@@ -1952,7 +1956,7 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
   }
 
   return (
-    <aside className="relative flex max-h-[min(24rem,42vh)] supports-[max-height:1dvh]:max-h-[min(24rem,42dvh)] w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0">
+    <aside className={STYLE_PANEL_ASIDE_CLASS}>
       {resizeHandle}
       <div className="flex items-center justify-between gap-2 border-b px-3 py-1.5">
         <span className="truncate text-sm font-semibold">

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1069,7 +1069,7 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
 
   if (!layer) {
     return (
-      <aside className="relative flex max-h-56 w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0">
+      <aside className="relative flex max-h-[min(24rem,42dvh)] w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0">
         {resizeHandle}
         <div className="flex items-center justify-between border-b px-3 py-1.5">
           <span className="text-sm font-semibold">Style</span>
@@ -1824,7 +1824,7 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
 
   if (hasRasterPaintControls) {
     return (
-      <aside className="relative flex max-h-56 w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0">
+      <aside className="relative flex max-h-[min(24rem,42dvh)] w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0">
         {resizeHandle}
         <div className="flex items-center justify-between gap-2 border-b px-3 py-1.5">
           <span className="truncate text-sm font-semibold">
@@ -1922,7 +1922,7 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
 
   if (!hasVectorPaintControls) {
     return (
-      <aside className="relative flex max-h-56 w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0">
+      <aside className="relative flex max-h-[min(24rem,42dvh)] w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0">
         {resizeHandle}
         <div className="flex items-center justify-between gap-2 border-b px-3 py-1.5">
           <span className="truncate text-sm font-semibold">
@@ -1952,7 +1952,7 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
   }
 
   return (
-    <aside className="relative flex max-h-56 w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0">
+    <aside className="relative flex max-h-[min(24rem,42dvh)] w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0">
       {resizeHandle}
       <div className="flex items-center justify-between gap-2 border-b px-3 py-1.5">
         <span className="truncate text-sm font-semibold">

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1069,7 +1069,7 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
 
   if (!layer) {
     return (
-      <aside className="relative flex max-h-[min(24rem,42dvh)] w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0">
+      <aside className="relative flex max-h-[min(24rem,42vh)] supports-[max-height:1dvh]:max-h-[min(24rem,42dvh)] w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0">
         {resizeHandle}
         <div className="flex items-center justify-between border-b px-3 py-1.5">
           <span className="text-sm font-semibold">Style</span>
@@ -1824,7 +1824,7 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
 
   if (hasRasterPaintControls) {
     return (
-      <aside className="relative flex max-h-[min(24rem,42dvh)] w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0">
+      <aside className="relative flex max-h-[min(24rem,42vh)] supports-[max-height:1dvh]:max-h-[min(24rem,42dvh)] w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0">
         {resizeHandle}
         <div className="flex items-center justify-between gap-2 border-b px-3 py-1.5">
           <span className="truncate text-sm font-semibold">
@@ -1922,7 +1922,7 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
 
   if (!hasVectorPaintControls) {
     return (
-      <aside className="relative flex max-h-[min(24rem,42dvh)] w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0">
+      <aside className="relative flex max-h-[min(24rem,42vh)] supports-[max-height:1dvh]:max-h-[min(24rem,42dvh)] w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0">
         {resizeHandle}
         <div className="flex items-center justify-between gap-2 border-b px-3 py-1.5">
           <span className="truncate text-sm font-semibold">
@@ -1952,7 +1952,7 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
   }
 
   return (
-    <aside className="relative flex max-h-[min(24rem,42dvh)] w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0">
+    <aside className="relative flex max-h-[min(24rem,42vh)] supports-[max-height:1dvh]:max-h-[min(24rem,42dvh)] w-full shrink-0 flex-col border-t bg-card md:max-h-none md:w-[var(--style-panel-width)] md:border-l md:border-t-0">
       {resizeHandle}
       <div className="flex items-center justify-between gap-2 border-b px-3 py-1.5">
         <span className="truncate text-sm font-semibold">

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -627,7 +627,7 @@ export function ProcessingDialog({
     <Dialog open={open} onOpenChange={setProcessingOpen}>
       <DialogContent
         className="h-[min(760px,92vh)] max-w-6xl"
-        bodyClassName="grid-rows-[auto_minmax(0,1fr)] gap-3 p-5"
+        bodyClassName="grid-rows-[auto_minmax(0,1fr)] gap-3 overflow-hidden p-5"
       >
         <DialogHeader>
           <DialogTitle>Whitebox toolbox</DialogTitle>

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -625,7 +625,10 @@ export function ProcessingDialog({
 
   return (
     <Dialog open={open} onOpenChange={setProcessingOpen}>
-      <DialogContent className="h-[min(760px,92vh)] max-w-6xl grid-rows-[auto_minmax(0,1fr)] gap-3 p-5">
+      <DialogContent
+        className="h-[min(760px,92vh)] max-w-6xl"
+        bodyClassName="grid-rows-[auto_minmax(0,1fr)] gap-3 p-5"
+      >
         <DialogHeader>
           <DialogTitle>Whitebox toolbox</DialogTitle>
           <DialogDescription>

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1533,6 +1533,7 @@ body,
   .duckdb-control-panel,
   .geoparquet-control-panel {
     box-sizing: border-box;
+    /* 96px clears the mobile top toolbar plus the panel's own top offset */
     max-height: calc(100vh - 96px) !important;
     max-height: calc(100dvh - 96px) !important;
     max-width: calc(100vw - 20px) !important;
@@ -1548,6 +1549,7 @@ body,
 
   .duckdb-control-content,
   .geoparquet-control-content {
+    /* 170px = the 96px panel offset above plus the panel header height */
     max-height: calc(100vh - 170px);
     max-height: calc(100dvh - 170px);
   }

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1557,6 +1557,15 @@ body,
   }
 }
 
+@media (max-width: 639px) {
+  .geolibre-layout-submenu {
+    margin-left: max(
+      0px,
+      calc(100% - var(--radix-dropdown-menu-content-available-width) + 8px)
+    );
+  }
+}
+
 .geolibre-identify-popup.maplibregl-popup-anchor-left .maplibregl-popup-tip {
   border-right-color: hsl(var(--popover));
 }

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1525,6 +1525,36 @@ body,
   border-top-color: hsl(var(--popover));
 }
 
+@media (max-width: 767px) {
+  .geolibre-components-control .maplibre-gl-control-grid-floating-panel,
+  .geolibre-components-control .maplibre-gl-control-grid-relocated,
+  .geolibre-pmtiles-control .maplibre-gl-pmtiles-layer-panel,
+  .geolibre-zarr-control .maplibre-gl-zarr-layer-panel,
+  .duckdb-control-panel,
+  .geoparquet-control-panel {
+    box-sizing: border-box;
+    max-height: calc(100dvh - 96px) !important;
+    max-width: calc(100vw - 20px) !important;
+    overflow-y: auto;
+  }
+
+  .duckdb-control-panel,
+  .geoparquet-control-panel {
+    left: 10px !important;
+    right: auto !important;
+    width: calc(100vw - 20px) !important;
+  }
+
+  .duckdb-control-content,
+  .geoparquet-control-content {
+    max-height: calc(100dvh - 170px);
+  }
+
+  .geolibre-identify-popup .maplibregl-popup-content {
+    max-width: calc(100vw - 24px);
+  }
+}
+
 .geolibre-identify-popup.maplibregl-popup-anchor-left .maplibregl-popup-tip {
   border-right-color: hsl(var(--popover));
 }

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1533,6 +1533,7 @@ body,
   .duckdb-control-panel,
   .geoparquet-control-panel {
     box-sizing: border-box;
+    max-height: calc(100vh - 96px) !important;
     max-height: calc(100dvh - 96px) !important;
     max-width: calc(100vw - 20px) !important;
     overflow-y: auto;
@@ -1547,6 +1548,7 @@ body,
 
   .duckdb-control-content,
   .geoparquet-control-content {
+    max-height: calc(100vh - 170px);
     max-height: calc(100dvh - 170px);
   }
 

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1560,6 +1560,10 @@ body,
 }
 
 @media (max-width: 639px) {
+  /* On narrow screens the Layout submenu can be wider than the space Radix
+     has between the trigger and the viewport edge. Shift it left by the
+     shortfall (Radix reports it via the available-width variable) plus an
+     8px edge buffer so the submenu stays fully visible. */
   .geolibre-layout-submenu {
     margin-left: max(
       0px,

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -32,7 +32,7 @@ export const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid max-h-[calc(100dvh-1rem)] w-[calc(100vw-1rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background p-4 shadow-lg duration-200 sm:rounded-lg sm:p-6",
         className,
       )}
       {...props}

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -34,7 +34,7 @@ export const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 flex max-h-[calc(100dvh-1rem)] w-[calc(100vw-1rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] flex-col overflow-hidden border bg-background shadow-lg duration-200 sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 flex max-h-[calc(100dvh-1rem)] w-[calc(100vw-1rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] flex-col overflow-hidden border bg-background shadow-lg duration-200 supports-[not_(max-height:1dvh)]:max-h-[calc(100vh-1rem)] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -41,8 +41,8 @@ export const DialogContent = React.forwardRef<
     >
       <div
         className={cn(
-          "grid min-h-0 flex-1 gap-4 overflow-y-auto p-4 sm:p-6",
-          bodyClassName,
+          "grid min-h-0 flex-1 gap-4 overflow-auto",
+          bodyClassName ?? "p-4 sm:p-6",
         )}
       >
         {children}

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -25,19 +25,28 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 export const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+    bodyClassName?: string;
+  }
+>(({ className, bodyClassName, children, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid max-h-[calc(100dvh-1rem)] w-[calc(100vw-1rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background p-4 shadow-lg duration-200 sm:rounded-lg sm:p-6",
+        "fixed left-[50%] top-[50%] z-50 flex max-h-[calc(100dvh-1rem)] w-[calc(100vw-1rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] flex-col overflow-hidden border bg-background shadow-lg duration-200 sm:rounded-lg",
         className,
       )}
       {...props}
     >
-      {children}
+      <div
+        className={cn(
+          "grid min-h-0 flex-1 gap-4 overflow-y-auto p-4 sm:p-6",
+          bodyClassName,
+        )}
+      >
+        {children}
+      </div>
       <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -19,14 +19,14 @@ export const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent",
+      "flex min-w-0 cursor-default select-none items-center gap-2 overflow-hidden rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent",
       inset && "pl-8",
       className,
     )}
     {...props}
   >
     {children}
-    <ChevronRight className="ml-auto h-4 w-4" />
+    <ChevronRight className="ml-auto h-4 w-4 shrink-0" />
   </DropdownMenuPrimitive.SubTrigger>
 ));
 DropdownMenuSubTrigger.displayName =
@@ -35,13 +35,18 @@ DropdownMenuSubTrigger.displayName =
 export const DropdownMenuSubContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
->(({ className, ...props }, ref) => (
+>(({ className, style, ...props }, ref) => (
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg",
+      "z-50 max-w-[calc(100vw-1rem)] min-w-[8rem] overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-lg",
       className,
     )}
+    style={{
+      maxHeight:
+        "min(var(--radix-dropdown-menu-content-available-height, calc(100vh - 1rem)), calc(100vh - 1rem))",
+      ...style,
+    }}
     {...props}
   />
 ));
@@ -51,15 +56,20 @@ DropdownMenuSubContent.displayName =
 export const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
+>(({ className, sideOffset = 4, style, ...props }, ref) => (
   <DropdownMenuPrimitive.Portal>
     <DropdownMenuPrimitive.Content
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+        "z-50 max-w-[calc(100vw-1rem)] min-w-[8rem] overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
         className,
       )}
+      style={{
+        maxHeight:
+          "min(var(--radix-dropdown-menu-content-available-height, calc(100vh - 1rem)), calc(100vh - 1rem))",
+        ...style,
+      }}
       {...props}
     />
   </DropdownMenuPrimitive.Portal>
@@ -75,7 +85,7 @@ export const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex min-w-0 cursor-default select-none items-center overflow-hidden rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
       className,
     )}

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -44,7 +44,7 @@ export const DropdownMenuSubContent = React.forwardRef<
     )}
     style={{
       maxHeight:
-        "min(var(--radix-dropdown-menu-content-available-height, calc(100vh - 1rem)), calc(100vh - 1rem))",
+        "min(var(--radix-dropdown-menu-content-available-height, 100vh), calc(100vh - 1rem))",
       ...style,
     }}
     {...props}
@@ -67,7 +67,7 @@ export const DropdownMenuContent = React.forwardRef<
       )}
       style={{
         maxHeight:
-          "min(var(--radix-dropdown-menu-content-available-height, calc(100vh - 1rem)), calc(100vh - 1rem))",
+          "min(var(--radix-dropdown-menu-content-available-height, 100vh), calc(100vh - 1rem))",
         ...style,
       }}
       {...props}


### PR DESCRIPTION
## Summary
- Constrain dropdown menus and dialogs to the visible viewport with scrolling so they no longer overflow on small screens
- Group the Add Data menu into Files, Web services, Cloud formats, 3D layers, and Databases sections for easier scanning
- Let the attribute table header wrap on narrow layouts, cap mobile heights for the Layer and Style panels, and keep floating map control panels within the viewport

## Test plan
- [ ] Open the app at a narrow viewport (e.g. 375px wide) and verify the Add Data menu fits on screen and scrolls
- [ ] Open dialogs (Add XYZ/WMS/PostgreSQL layer) on mobile width and confirm they fit and scroll
- [ ] Open the attribute table on mobile width and verify the header wraps without overflowing
- [ ] Verify the Layer and Style panels do not take over the screen on mobile
- [ ] Confirm desktop layout is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reorganized "Add Data" menu into labeled sections (Files, Web services, Cloud formats, 3D layers, Databases) with clearer item labels and improved panel width.
  * Settings layout options now appear inline for easier toggling.

* **Style**
  * Improved mobile responsiveness: toolbars, panels, attribute table, and identify popup adapt better (flex-wrapping, truncated labels, icon-only buttons).
  * Dialogs and dropdowns have refined sizing and scrollbar behavior.

* **UX**
  * Attribute search placeholder updated to "Search attributes..."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->