### PR TITLE
feat: let plugins declare and handle URL query parameters

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -159,11 +159,12 @@ export function DesktopShell({
       appAPI,
     );
     restoreThreeDTilesLayers(appAPI);
+    const search = window.location.search;
     void pluginManager
       .handleUrlParameters(
-        new URLSearchParams(window.location.search),
+        new URLSearchParams(search),
         appAPI,
-        `${projectGeneration}:${window.location.search}`,
+        `${projectGeneration}:${search}`,
       )
       .catch(console.error);
   }, [externalPluginsReady, mapReadyGeneration, projectGeneration]);

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -159,11 +159,13 @@ export function DesktopShell({
       appAPI,
     );
     restoreThreeDTilesLayers(appAPI);
-    void pluginManager.handleUrlParameters(
-      new URLSearchParams(window.location.search),
-      appAPI,
-      `${projectGeneration}:${window.location.search}`,
-    );
+    void pluginManager
+      .handleUrlParameters(
+        new URLSearchParams(window.location.search),
+        appAPI,
+        `${projectGeneration}:${window.location.search}`,
+      )
+      .catch(console.error);
   }, [externalPluginsReady, mapReadyGeneration, projectGeneration]);
 
   useEffect(() => {

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -153,11 +153,17 @@ export function DesktopShell({
     )
       return;
     const appAPI = createAppAPI(mapControllerRef);
-    getPluginManager().restoreProjectState(
+    const pluginManager = getPluginManager();
+    pluginManager.restoreProjectState(
       useAppStore.getState().projectPlugins,
       appAPI,
     );
     restoreThreeDTilesLayers(appAPI);
+    void pluginManager.handleUrlParameters(
+      new URLSearchParams(window.location.search),
+      appAPI,
+      `${projectGeneration}:${window.location.href}`,
+    );
   }, [externalPluginsReady, mapReadyGeneration, projectGeneration]);
 
   useEffect(() => {

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -162,7 +162,7 @@ export function DesktopShell({
     void pluginManager.handleUrlParameters(
       new URLSearchParams(window.location.search),
       appAPI,
-      `${projectGeneration}:${window.location.href}`,
+      `${projectGeneration}:${window.location.search}`,
     );
   }, [externalPluginsReady, mapReadyGeneration, projectGeneration]);
 

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -135,6 +135,9 @@ export const plugin: GeoLibrePlugin = {
   },
   async handleUrlParameters(app: GeoLibreAppAPI, params: URLSearchParams) {
     for (const dataUrl of params.getAll("exampleGeoJson")) {
+      // URL parameter values are attacker-controlled: only fetch HTTPS URLs
+      // so adversarial links cannot reach file://, data:, or loopback hosts.
+      if (!dataUrl.startsWith("https://")) continue;
       const response = await fetch(dataUrl);
       if (!response.ok) continue;
       app.addGeoJsonLayer("Example URL layer", await response.json(), dataUrl);
@@ -142,6 +145,8 @@ export const plugin: GeoLibrePlugin = {
   },
 };
 ```
+
+Validate URL parameter values before acting on them. Anyone can craft a link to GeoLibre, so handlers that fetch a parameter value should reject unexpected schemes (`file://`, `data:`, plain `http://`) and only contact origins they trust.
 
 For example:
 

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -117,6 +117,40 @@ Map control plugins can optionally expose `getMapControlPosition()` and `setMapC
 
 Plugins with serializable runtime settings can expose `getProjectState()` and `applyProjectState()` so GeoLibre can save and restore those settings in the project file. A wrapper should use these hooks to adapt upstream control APIs such as `getState()` without requiring every upstream package to implement a GeoLibre-specific interface.
 
+Plugins can also declare URL query parameters and handle them when GeoLibre opens. URL parameter handlers run after the map is ready, external plugins are loaded, and project plugin state has been restored. GeoLibre calls handlers only for active plugins whose declared parameter names are present in the URL, and it suppresses repeated handling of the same URL context for the same plugin.
+
+```typescript
+import type { GeoLibreAppAPI, GeoLibrePlugin } from "@geolibre/plugins";
+
+export const plugin: GeoLibrePlugin = {
+  id: "example-url-loader",
+  name: "Example URL Loader",
+  version: "0.1.0",
+  urlParameterNames: ["exampleGeoJson"],
+  activate() {
+    // Set up controls or plugin state here.
+  },
+  deactivate() {
+    // Clean up controls, listeners, and plugin state here.
+  },
+  async handleUrlParameters(app: GeoLibreAppAPI, params: URLSearchParams) {
+    for (const dataUrl of params.getAll("exampleGeoJson")) {
+      const response = await fetch(dataUrl);
+      if (!response.ok) continue;
+      app.addGeoJsonLayer("Example URL layer", await response.json(), dataUrl);
+    }
+  },
+};
+```
+
+For example:
+
+```text
+https://viewer.geolibre.app/?url=https://example.com/project.geolibre.json&exampleGeoJson=https://example.com/data.geojson
+```
+
+A URL parameter does not activate an inactive plugin by itself. For external plugins, include the plugin manifest URL and active plugin ID in the project `plugins` state, or have the user enable the plugin before relying on its URL handler.
+
 ## External plugins
 
 Use the [GeoLibre plugin template](https://github.com/opengeos/geolibre-plugin-template) as the recommended starting point for external plugin development. The template includes a MapLibre control wrapper, a `plugin.json` manifest, a GeoLibre plugin entry point, and a `package:geolibre` script that builds the zip layout GeoLibre Desktop expects.

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -136,10 +136,17 @@ export const plugin: GeoLibrePlugin = {
   async handleUrlParameters(app: GeoLibreAppAPI, params: URLSearchParams) {
     for (const dataUrl of params.getAll("exampleGeoJson")) {
       // URL parameter values are attacker-controlled: only fetch HTTPS URLs
-      // and verify the origin is one you trust before loading. This check
-      // only prevents non-HTTPS schemes (file://, data:, http://); it does
-      // not protect against SSRF to loopback or private-network addresses.
-      if (!dataUrl.startsWith("https://")) continue;
+      // and verify the origin is one you trust before loading. Parsing the
+      // value rejects malformed URLs, and the protocol check blocks
+      // non-HTTPS schemes (file://, data:, http://); neither protects
+      // against SSRF to loopback or private-network addresses.
+      let parsedUrl: URL;
+      try {
+        parsedUrl = new URL(dataUrl);
+      } catch {
+        continue;
+      }
+      if (parsedUrl.protocol !== "https:") continue;
       const response = await fetch(dataUrl);
       if (!response.ok) continue;
       app.addGeoJsonLayer("Example URL layer", await response.json(), dataUrl);

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -147,7 +147,7 @@ export const plugin: GeoLibrePlugin = {
         continue;
       }
       if (parsedUrl.protocol !== "https:") continue;
-      const response = await fetch(dataUrl);
+      const response = await fetch(parsedUrl.href);
       if (!response.ok) continue;
       app.addGeoJsonLayer("Example URL layer", await response.json(), dataUrl);
     }

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -136,7 +136,9 @@ export const plugin: GeoLibrePlugin = {
   async handleUrlParameters(app: GeoLibreAppAPI, params: URLSearchParams) {
     for (const dataUrl of params.getAll("exampleGeoJson")) {
       // URL parameter values are attacker-controlled: only fetch HTTPS URLs
-      // so adversarial links cannot reach file://, data:, or loopback hosts.
+      // and verify the origin is one you trust before loading. This check
+      // only prevents non-HTTPS schemes (file://, data:, http://); it does
+      // not protect against SSRF to loopback or private-network addresses.
       if (!dataUrl.startsWith("https://")) continue;
       const response = await fetch(dataUrl);
       if (!response.ok) continue;

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -117,7 +117,7 @@ Map control plugins can optionally expose `getMapControlPosition()` and `setMapC
 
 Plugins with serializable runtime settings can expose `getProjectState()` and `applyProjectState()` so GeoLibre can save and restore those settings in the project file. A wrapper should use these hooks to adapt upstream control APIs such as `getState()` without requiring every upstream package to implement a GeoLibre-specific interface.
 
-Plugins can also declare URL query parameters and handle them when GeoLibre opens. URL parameter handlers run after the map is ready, external plugins are loaded, and project plugin state has been restored. GeoLibre calls handlers only for active plugins whose declared parameter names are present in the URL, and it suppresses repeated handling of the same URL context for the same plugin.
+Plugins can also declare URL query parameters and handle them when GeoLibre opens. URL parameter handlers run after the map is ready, external plugins are loaded, and project plugin state has been restored. GeoLibre calls handlers only for active plugins whose declared parameter names are present in the URL, and it suppresses repeated handling of the same URL context for the same plugin. Parameter names are case-sensitive, as URL query parameters are: declaring `exampleGeoJson` will not match `?ExampleGeoJson=…`.
 
 ```typescript
 import type { GeoLibreAppAPI, GeoLibrePlugin } from "@geolibre/plugins";

--- a/packages/plugins/src/plugin-manager.ts
+++ b/packages/plugins/src/plugin-manager.ts
@@ -124,12 +124,17 @@ export class PluginManager {
     app: GeoLibreAppAPI,
     contextKey = params.toString(),
   ): Promise<void> {
-    if (params.size === 0) return;
+    // An empty serialization means no parameters. params.size would be more
+    // direct but is unavailable in older webviews (pre-Safari 17 WKWebView).
+    if (!params.toString()) return;
 
     // Dedup state is kept per context so overlapping async calls with
     // different context keys cannot clear each other's in-flight entries.
     // Only the most recent contexts matter, so older ones are evicted to keep
-    // the map bounded for the lifetime of the page.
+    // the map bounded for the lifetime of the page. If more than
+    // MAX_HANDLED_URL_CONTEXTS contexts ever overlapped concurrently, the
+    // oldest could be evicted while still in flight and re-run on a repeat
+    // dispatch; that much overlap is not expected in practice.
     let handledPluginIds = this.handledUrlParametersByContext.get(contextKey);
     if (!handledPluginIds) {
       handledPluginIds = new Set();

--- a/packages/plugins/src/plugin-manager.ts
+++ b/packages/plugins/src/plugin-manager.ts
@@ -14,12 +14,18 @@ export class PluginManager {
     GeoLibreMapControlPosition
   >();
   private handledUrlParameterKeys = new Set<string>();
+  private lastHandledContextKey: string | null = null;
+  private urlParameterNamesById = new Map<string, string[]>();
   private listeners = new Set<() => void>();
   private version = 0;
 
   register(plugin: GeoLibrePlugin): void {
     const previous = this.plugins.get(plugin.id);
     this.plugins.set(plugin.id, plugin);
+    this.urlParameterNamesById.set(
+      plugin.id,
+      normalizeUrlParameterNames(plugin.urlParameterNames),
+    );
     const defaultPosition = plugin.getMapControlPosition?.();
     if (defaultPosition) {
       this.defaultMapControlPositions.set(plugin.id, defaultPosition);
@@ -112,14 +118,19 @@ export class PluginManager {
     app: GeoLibreAppAPI,
     contextKey = params.toString(),
   ): Promise<void> {
-    if (!Array.from(params.keys()).length) return;
+    if (!params.toString()) return;
+
+    // Only the latest context matters for dedup, so evict the previous
+    // context's keys instead of accumulating them for the page lifetime.
+    if (contextKey !== this.lastHandledContextKey) {
+      this.handledUrlParameterKeys.clear();
+      this.lastHandledContextKey = contextKey;
+    }
 
     for (const [id, plugin] of this.plugins) {
       if (!this.active.has(id) || !plugin.handleUrlParameters) continue;
 
-      const parameterNames = normalizeUrlParameterNames(
-        plugin.urlParameterNames,
-      );
+      const parameterNames = this.urlParameterNamesById.get(id) ?? [];
       if (
         parameterNames.length === 0 ||
         !parameterNames.some((name) => params.has(name))

--- a/packages/plugins/src/plugin-manager.ts
+++ b/packages/plugins/src/plugin-manager.ts
@@ -22,8 +22,11 @@ export class PluginManager {
   register(plugin: GeoLibrePlugin): void {
     const previous = this.plugins.get(plugin.id);
     if (previous && previous !== plugin) {
-      // Evict dedup entries so a re-registered (e.g. hot-reloaded) plugin can
-      // handle the current URL context again.
+      // Evict the plugin's dedup entries from every retained context so a
+      // re-registered (e.g. hot-reloaded) plugin can handle the current URL
+      // context again. This intentionally also lets it re-handle older
+      // retained contexts if one of those is ever re-dispatched: the new
+      // plugin instance has fresh state and never saw them.
       for (const handled of this.handledUrlParametersByContext.values()) {
         handled.delete(plugin.id);
       }
@@ -123,11 +126,13 @@ export class PluginManager {
   async handleUrlParameters(
     params: URLSearchParams,
     app: GeoLibreAppAPI,
-    contextKey = params.toString(),
+    contextKey?: string,
   ): Promise<void> {
     // An empty serialization means no parameters. params.size would be more
     // direct but is unavailable in older webviews (pre-Safari 17 WKWebView).
-    if (!params.toString()) return;
+    const serialized = params.toString();
+    if (!serialized) return;
+    contextKey ??= serialized;
 
     // Dedup state is kept per context so overlapping async calls with
     // different context keys cannot clear each other's in-flight entries.

--- a/packages/plugins/src/plugin-manager.ts
+++ b/packages/plugins/src/plugin-manager.ts
@@ -14,6 +14,7 @@ export class PluginManager {
     GeoLibreMapControlPosition
   >();
   private handledUrlParametersByContext = new Map<string, Set<string>>();
+  private inFlightUrlContexts = new Map<string, number>();
   private urlParameterNamesById = new Map<string, string[]>();
   private listeners = new Set<() => void>();
   private version = 0;
@@ -131,43 +132,63 @@ export class PluginManager {
     // Dedup state is kept per context so overlapping async calls with
     // different context keys cannot clear each other's in-flight entries.
     // Only the most recent contexts matter, so older ones are evicted to keep
-    // the map bounded for the lifetime of the page. If more than
-    // MAX_HANDLED_URL_CONTEXTS contexts ever overlapped concurrently, the
-    // oldest could be evicted while still in flight and re-run on a repeat
-    // dispatch; that much overlap is not expected in practice.
+    // the map bounded for the lifetime of the page. In-flight contexts are
+    // never evicted, so a suspended dispatch cannot lose its dedup entries
+    // and re-run plugins for the same context; the map can temporarily exceed
+    // MAX_HANDLED_URL_CONTEXTS while that many dispatches overlap.
+    this.inFlightUrlContexts.set(
+      contextKey,
+      (this.inFlightUrlContexts.get(contextKey) ?? 0) + 1,
+    );
+
     let handledPluginIds = this.handledUrlParametersByContext.get(contextKey);
     if (!handledPluginIds) {
       handledPluginIds = new Set();
       this.handledUrlParametersByContext.set(contextKey, handledPluginIds);
-      while (this.handledUrlParametersByContext.size > MAX_HANDLED_URL_CONTEXTS) {
-        const oldest = this.handledUrlParametersByContext.keys().next().value;
-        if (oldest === undefined) break;
-        this.handledUrlParametersByContext.delete(oldest);
+      for (const key of this.handledUrlParametersByContext.keys()) {
+        if (
+          this.handledUrlParametersByContext.size <= MAX_HANDLED_URL_CONTEXTS
+        ) {
+          break;
+        }
+        if (this.inFlightUrlContexts.has(key)) continue;
+        this.handledUrlParametersByContext.delete(key);
       }
     }
 
-    for (const [id, plugin] of this.plugins) {
-      if (!this.active.has(id) || !plugin.handleUrlParameters) continue;
+    try {
+      for (const [id, plugin] of this.plugins) {
+        if (!this.active.has(id) || !plugin.handleUrlParameters) continue;
 
-      const parameterNames = this.urlParameterNamesById.get(id) ?? [];
-      if (
-        parameterNames.length === 0 ||
-        !parameterNames.some((name) => params.has(name))
-      ) {
-        continue;
+        const parameterNames = this.urlParameterNamesById.get(id) ?? [];
+        if (
+          parameterNames.length === 0 ||
+          !parameterNames.some((name) => params.has(name))
+        ) {
+          continue;
+        }
+
+        if (handledPluginIds.has(id)) continue;
+        // Mark before awaiting so a concurrent dispatch for the same context
+        // cannot double-fire the handler.
+        handledPluginIds.add(id);
+
+        try {
+          await plugin.handleUrlParameters(app, new URLSearchParams(params));
+        } catch (error) {
+          // Unmark so a later dispatch for the same context retries the
+          // plugin instead of silently skipping it after a failure.
+          handledPluginIds.delete(id);
+          console.warn(
+            `Plugin '${id}' could not handle GeoLibre URL parameters.`,
+            error,
+          );
+        }
       }
-
-      if (handledPluginIds.has(id)) continue;
-      handledPluginIds.add(id);
-
-      try {
-        await plugin.handleUrlParameters(app, new URLSearchParams(params));
-      } catch (error) {
-        console.warn(
-          `Plugin '${id}' could not handle GeoLibre URL parameters.`,
-          error,
-        );
-      }
+    } finally {
+      const inFlight = this.inFlightUrlContexts.get(contextKey) ?? 0;
+      if (inFlight <= 1) this.inFlightUrlContexts.delete(contextKey);
+      else this.inFlightUrlContexts.set(contextKey, inFlight - 1);
     }
   }
 

--- a/packages/plugins/src/plugin-manager.ts
+++ b/packages/plugins/src/plugin-manager.ts
@@ -13,14 +13,20 @@ export class PluginManager {
     string,
     GeoLibreMapControlPosition
   >();
-  private handledUrlParameterKeys = new Set<string>();
-  private lastHandledContextKey: string | null = null;
+  private handledUrlParametersByContext = new Map<string, Set<string>>();
   private urlParameterNamesById = new Map<string, string[]>();
   private listeners = new Set<() => void>();
   private version = 0;
 
   register(plugin: GeoLibrePlugin): void {
     const previous = this.plugins.get(plugin.id);
+    if (previous && previous !== plugin) {
+      // Evict dedup entries so a re-registered (e.g. hot-reloaded) plugin can
+      // handle the current URL context again.
+      for (const handled of this.handledUrlParametersByContext.values()) {
+        handled.delete(plugin.id);
+      }
+    }
     this.plugins.set(plugin.id, plugin);
     this.urlParameterNamesById.set(
       plugin.id,
@@ -118,13 +124,21 @@ export class PluginManager {
     app: GeoLibreAppAPI,
     contextKey = params.toString(),
   ): Promise<void> {
-    if (!params.toString()) return;
+    if (params.size === 0) return;
 
-    // Only the latest context matters for dedup, so evict the previous
-    // context's keys instead of accumulating them for the page lifetime.
-    if (contextKey !== this.lastHandledContextKey) {
-      this.handledUrlParameterKeys.clear();
-      this.lastHandledContextKey = contextKey;
+    // Dedup state is kept per context so overlapping async calls with
+    // different context keys cannot clear each other's in-flight entries.
+    // Only the most recent contexts matter, so older ones are evicted to keep
+    // the map bounded for the lifetime of the page.
+    let handledPluginIds = this.handledUrlParametersByContext.get(contextKey);
+    if (!handledPluginIds) {
+      handledPluginIds = new Set();
+      this.handledUrlParametersByContext.set(contextKey, handledPluginIds);
+      while (this.handledUrlParametersByContext.size > MAX_HANDLED_URL_CONTEXTS) {
+        const oldest = this.handledUrlParametersByContext.keys().next().value;
+        if (oldest === undefined) break;
+        this.handledUrlParametersByContext.delete(oldest);
+      }
     }
 
     for (const [id, plugin] of this.plugins) {
@@ -138,9 +152,8 @@ export class PluginManager {
         continue;
       }
 
-      const handledKey = `${id}\0${contextKey}`;
-      if (this.handledUrlParameterKeys.has(handledKey)) continue;
-      this.handledUrlParameterKeys.add(handledKey);
+      if (handledPluginIds.has(id)) continue;
+      handledPluginIds.add(id);
 
       try {
         await plugin.handleUrlParameters(app, new URLSearchParams(params));
@@ -227,6 +240,10 @@ export class PluginManager {
     for (const listener of this.listeners) listener();
   }
 }
+
+// Retaining several recent contexts (rather than only the latest) keeps dedup
+// intact when fire-and-forget calls with different context keys overlap.
+const MAX_HANDLED_URL_CONTEXTS = 8;
 
 function normalizeUrlParameterNames(names: string[] | undefined): string[] {
   if (!names) return [];

--- a/packages/plugins/src/plugin-manager.ts
+++ b/packages/plugins/src/plugin-manager.ts
@@ -13,6 +13,7 @@ export class PluginManager {
     string,
     GeoLibreMapControlPosition
   >();
+  private handledUrlParameterKeys = new Set<string>();
   private listeners = new Set<() => void>();
   private version = 0;
 
@@ -106,6 +107,41 @@ export class PluginManager {
     else this.activate(id, app);
   }
 
+  async handleUrlParameters(
+    params: URLSearchParams,
+    app: GeoLibreAppAPI,
+    contextKey = params.toString(),
+  ): Promise<void> {
+    if (!Array.from(params.keys()).length) return;
+
+    for (const [id, plugin] of this.plugins) {
+      if (!this.active.has(id) || !plugin.handleUrlParameters) continue;
+
+      const parameterNames = normalizeUrlParameterNames(
+        plugin.urlParameterNames,
+      );
+      if (
+        parameterNames.length === 0 ||
+        !parameterNames.some((name) => params.has(name))
+      ) {
+        continue;
+      }
+
+      const handledKey = `${id}\0${contextKey}`;
+      if (this.handledUrlParameterKeys.has(handledKey)) continue;
+      this.handledUrlParameterKeys.add(handledKey);
+
+      try {
+        await plugin.handleUrlParameters(app, new URLSearchParams(params));
+      } catch (error) {
+        console.warn(
+          `Plugin '${id}' could not handle GeoLibre URL parameters.`,
+          error,
+        );
+      }
+    }
+  }
+
   setMapControlPosition(
     id: string,
     app: GeoLibreAppAPI,
@@ -179,4 +215,11 @@ export class PluginManager {
     this.version += 1;
     for (const listener of this.listeners) listener();
   }
+}
+
+function normalizeUrlParameterNames(names: string[] | undefined): string[] {
+  if (!names) return [];
+  return Array.from(
+    new Set(names.map((name) => name.trim()).filter((name) => name.length > 0)),
+  );
 }

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -82,7 +82,8 @@ export interface GeoLibrePlugin {
   /**
    * Called once per URL context after the map and plugins are ready.
    * Requires urlParameterNames to be non-empty; otherwise this hook is never
-   * invoked.
+   * invoked. A handler that throws is not counted as handled, so a later
+   * dispatch for the same context retries it.
    */
   handleUrlParameters?: (
     app: GeoLibreAppAPI,

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -75,8 +75,13 @@ export interface GeoLibrePlugin {
   name: string;
   version: string;
   activeByDefault?: boolean;
+  urlParameterNames?: string[];
   activate: (app: GeoLibreAppAPI) => boolean | void;
   deactivate: (app: GeoLibreAppAPI) => void;
+  handleUrlParameters?: (
+    app: GeoLibreAppAPI,
+    params: URLSearchParams,
+  ) => boolean | void | Promise<boolean | void>;
   getMapControlPosition?: () => GeoLibreMapControlPosition;
   setMapControlPosition?: (
     app: GeoLibreAppAPI,

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -75,9 +75,15 @@ export interface GeoLibrePlugin {
   name: string;
   version: string;
   activeByDefault?: boolean;
+  /** At least one name is required for handleUrlParameters to be called. */
   urlParameterNames?: string[];
   activate: (app: GeoLibreAppAPI) => boolean | void;
   deactivate: (app: GeoLibreAppAPI) => void;
+  /**
+   * Called once per URL context after the map and plugins are ready.
+   * Requires urlParameterNames to be non-empty; otherwise this hook is never
+   * invoked.
+   */
   handleUrlParameters?: (
     app: GeoLibreAppAPI,
     params: URLSearchParams,

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -81,7 +81,7 @@ export interface GeoLibrePlugin {
   handleUrlParameters?: (
     app: GeoLibreAppAPI,
     params: URLSearchParams,
-  ) => boolean | void | Promise<boolean | void>;
+  ) => void | Promise<void>;
   getMapControlPosition?: () => GeoLibreMapControlPosition;
   setMapControlPosition?: (
     app: GeoLibreAppAPI,

--- a/tests/plugin-manager.test.ts
+++ b/tests/plugin-manager.test.ts
@@ -148,6 +148,46 @@ describe("PluginManager URL parameters", () => {
     assert.deepEqual(calls, ["working"]);
   });
 
+  it("retries a plugin whose handler failed on a later dispatch", async () => {
+    const calls: string[] = [];
+    let shouldFail = true;
+    const manager = new PluginManager();
+
+    manager.register(
+      testPlugin({
+        urlParameterNames: ["data"],
+        handleUrlParameters: () => {
+          if (shouldFail) {
+            shouldFail = false;
+            throw new Error("boom");
+          }
+          calls.push("handled");
+        },
+      }),
+    );
+    manager.activate("url-loader", app);
+
+    // The first dispatch fails, the second retries and succeeds, and the
+    // third is deduped as handled.
+    await manager.handleUrlParameters(
+      new URLSearchParams("data=value"),
+      app,
+      "project-1",
+    );
+    await manager.handleUrlParameters(
+      new URLSearchParams("data=value"),
+      app,
+      "project-1",
+    );
+    await manager.handleUrlParameters(
+      new URLSearchParams("data=value"),
+      app,
+      "project-1",
+    );
+
+    assert.deepEqual(calls, ["handled"]);
+  });
+
   it("ignores calls without any URL parameters", async () => {
     const calls: string[] = [];
     const manager = new PluginManager();
@@ -214,6 +254,53 @@ describe("PluginManager URL parameters", () => {
       "7",
       "first",
     ]);
+  });
+
+  it("does not evict an in-flight context from the dedup map", async () => {
+    const calls: string[] = [];
+    const resolvers: Array<() => void> = [];
+    const manager = new PluginManager();
+
+    manager.register(
+      testPlugin({
+        urlParameterNames: ["data"],
+        handleUrlParameters: async (_app, params) => {
+          const value = params.get("data") ?? "";
+          if (value === "first") {
+            await new Promise<void>((resolve) => {
+              resolvers.push(resolve);
+            });
+          }
+          calls.push(value);
+        },
+      }),
+    );
+    manager.activate("url-loader", app);
+
+    // Suspend the first context, overflow the dedup map with eight newer
+    // contexts, then settle the first dispatch and re-dispatch its context.
+    // The in-flight context must survive eviction so the repeat is deduped.
+    const firstCall = manager.handleUrlParameters(
+      new URLSearchParams("data=first"),
+      app,
+      "ctx-first",
+    );
+    for (let i = 0; i < 8; i += 1) {
+      await manager.handleUrlParameters(
+        new URLSearchParams(`data=${i}`),
+        app,
+        `ctx-${i}`,
+      );
+    }
+    for (const resolve of resolvers) resolve();
+    await firstCall;
+    await manager.handleUrlParameters(
+      new URLSearchParams("data=first"),
+      app,
+      "ctx-first",
+    );
+
+    assert.deepEqual(calls, ["0", "1", "2", "3", "4", "5", "6", "7", "first"]);
   });
 
   it("keeps dedup state for overlapping calls with different contexts", async () => {

--- a/tests/plugin-manager.test.ts
+++ b/tests/plugin-manager.test.ts
@@ -148,6 +148,74 @@ describe("PluginManager URL parameters", () => {
     assert.deepEqual(calls, ["working"]);
   });
 
+  it("ignores calls without any URL parameters", async () => {
+    const calls: string[] = [];
+    const manager = new PluginManager();
+
+    manager.register(
+      testPlugin({
+        urlParameterNames: ["data"],
+        handleUrlParameters: () => {
+          calls.push("handled");
+        },
+      }),
+    );
+    manager.activate("url-loader", app);
+
+    await manager.handleUrlParameters(new URLSearchParams(""), app, "ctx");
+
+    assert.deepEqual(calls, []);
+  });
+
+  it("evicts the oldest context once the retained context limit is exceeded", async () => {
+    const calls: string[] = [];
+    const manager = new PluginManager();
+
+    manager.register(
+      testPlugin({
+        urlParameterNames: ["data"],
+        handleUrlParameters: (_app, params) => {
+          calls.push(params.get("data") ?? "");
+        },
+      }),
+    );
+    manager.activate("url-loader", app);
+
+    // Handle the first context, then push it out of the bounded dedup map
+    // with eight newer contexts (MAX_HANDLED_URL_CONTEXTS = 8).
+    await manager.handleUrlParameters(
+      new URLSearchParams("data=first"),
+      app,
+      "ctx-first",
+    );
+    for (let i = 0; i < 8; i += 1) {
+      await manager.handleUrlParameters(
+        new URLSearchParams(`data=${i}`),
+        app,
+        `ctx-${i}`,
+      );
+    }
+    // The evicted context is treated as new again and re-runs the handler.
+    await manager.handleUrlParameters(
+      new URLSearchParams("data=first"),
+      app,
+      "ctx-first",
+    );
+
+    assert.deepEqual(calls, [
+      "first",
+      "0",
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "6",
+      "7",
+      "first",
+    ]);
+  });
+
   it("keeps dedup state for overlapping calls with different contexts", async () => {
     const calls: string[] = [];
     const resolvers: Array<() => void> = [];

--- a/tests/plugin-manager.test.ts
+++ b/tests/plugin-manager.test.ts
@@ -78,4 +78,103 @@ describe("PluginManager URL parameters", () => {
       "https://example.com/next.geojson",
     ]);
   });
+
+  it("awaits async handlers in registration order", async () => {
+    const calls: string[] = [];
+    const manager = new PluginManager();
+
+    manager.register(
+      testPlugin({
+        id: "slow-loader",
+        urlParameterNames: ["data"],
+        handleUrlParameters: async () => {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          calls.push("slow");
+        },
+      }),
+    );
+    manager.register(
+      testPlugin({
+        id: "fast-loader",
+        urlParameterNames: ["data"],
+        handleUrlParameters: () => {
+          calls.push("fast");
+        },
+      }),
+    );
+    manager.activate("slow-loader", app);
+    manager.activate("fast-loader", app);
+
+    await manager.handleUrlParameters(
+      new URLSearchParams("data=value"),
+      app,
+      "project-1",
+    );
+
+    assert.deepEqual(calls, ["slow", "fast"]);
+  });
+
+  it("keeps running handlers after one plugin throws", async () => {
+    const calls: string[] = [];
+    const manager = new PluginManager();
+
+    manager.register(
+      testPlugin({
+        id: "broken-loader",
+        urlParameterNames: ["data"],
+        handleUrlParameters: () => {
+          throw new Error("boom");
+        },
+      }),
+    );
+    manager.register(
+      testPlugin({
+        id: "working-loader",
+        urlParameterNames: ["data"],
+        handleUrlParameters: () => {
+          calls.push("working");
+        },
+      }),
+    );
+    manager.activate("broken-loader", app);
+    manager.activate("working-loader", app);
+
+    await manager.handleUrlParameters(
+      new URLSearchParams("data=value"),
+      app,
+      "project-1",
+    );
+
+    assert.deepEqual(calls, ["working"]);
+  });
+
+  it("does not re-run a handled context after deactivate and reactivate", async () => {
+    const calls: string[] = [];
+    const manager = new PluginManager();
+
+    manager.register(
+      testPlugin({
+        urlParameterNames: ["data"],
+        handleUrlParameters: () => {
+          calls.push("handled");
+        },
+      }),
+    );
+    manager.activate("url-loader", app);
+
+    await manager.handleUrlParameters(
+      new URLSearchParams("data=value"),
+      app,
+      "project-1",
+    );
+    manager.deactivate("url-loader", app);
+    manager.activate("url-loader", app);
+    await manager.handleUrlParameters(
+      new URLSearchParams("data=value"),
+      app,
+      "project-1",
+    );
+
+    assert.deepEqual(calls, ["handled"]);
+  });
 });

--- a/tests/plugin-manager.test.ts
+++ b/tests/plugin-manager.test.ts
@@ -148,6 +148,47 @@ describe("PluginManager URL parameters", () => {
     assert.deepEqual(calls, ["working"]);
   });
 
+  it("keeps dedup state for overlapping calls with different contexts", async () => {
+    const calls: string[] = [];
+    const resolvers: Array<() => void> = [];
+    const manager = new PluginManager();
+
+    manager.register(
+      testPlugin({
+        urlParameterNames: ["data"],
+        handleUrlParameters: async (_app, params) => {
+          await new Promise<void>((resolve) => {
+            resolvers.push(resolve);
+          });
+          calls.push(params.get("data") ?? "");
+        },
+      }),
+    );
+    manager.activate("url-loader", app);
+
+    // Start two fire-and-forget calls with different context keys, then
+    // re-dispatch the first context while both handlers are still suspended.
+    const callA = manager.handleUrlParameters(
+      new URLSearchParams("data=a"),
+      app,
+      "ctx-a",
+    );
+    const callB = manager.handleUrlParameters(
+      new URLSearchParams("data=b"),
+      app,
+      "ctx-b",
+    );
+    const callARepeat = manager.handleUrlParameters(
+      new URLSearchParams("data=a"),
+      app,
+      "ctx-a",
+    );
+    for (const resolve of resolvers) resolve();
+    await Promise.all([callA, callB, callARepeat]);
+
+    assert.deepEqual(calls, ["a", "b"]);
+  });
+
   it("does not re-run a handled context after deactivate and reactivate", async () => {
     const calls: string[] = [];
     const manager = new PluginManager();

--- a/tests/plugin-manager.test.ts
+++ b/tests/plugin-manager.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { PluginManager } from "../packages/plugins/src/plugin-manager";
+import type {
+  GeoLibreAppAPI,
+  GeoLibrePlugin,
+} from "../packages/plugins/src/types";
+
+const app = {} as GeoLibreAppAPI;
+
+function testPlugin(patch: Partial<GeoLibrePlugin> = {}): GeoLibrePlugin {
+  return {
+    id: "url-loader",
+    name: "URL Loader",
+    version: "0.1.0",
+    activate: () => undefined,
+    deactivate: () => undefined,
+    ...patch,
+  };
+}
+
+describe("PluginManager URL parameters", () => {
+  it("runs matching active plugin URL parameter handlers once per context", async () => {
+    const calls: string[] = [];
+    const manager = new PluginManager();
+
+    manager.register(
+      testPlugin({
+        urlParameterNames: [" data ", "", "data"],
+        handleUrlParameters: (_app, params) => {
+          calls.push(params.get("data") ?? "");
+        },
+      }),
+    );
+    manager.register(
+      testPlugin({
+        id: "inactive-loader",
+        urlParameterNames: ["data"],
+        handleUrlParameters: () => {
+          calls.push("inactive");
+        },
+      }),
+    );
+    manager.register(
+      testPlugin({
+        id: "undeclared-loader",
+        handleUrlParameters: () => {
+          calls.push("undeclared");
+        },
+      }),
+    );
+    manager.activate("url-loader", app);
+    manager.activate("undeclared-loader", app);
+
+    await manager.handleUrlParameters(
+      new URLSearchParams("data=https%3A%2F%2Fexample.com%2Fdata.geojson"),
+      app,
+      "project-1",
+    );
+    await manager.handleUrlParameters(
+      new URLSearchParams("data=https%3A%2F%2Fexample.com%2Fdata.geojson"),
+      app,
+      "project-1",
+    );
+    await manager.handleUrlParameters(
+      new URLSearchParams("other=value"),
+      app,
+      "project-2",
+    );
+    await manager.handleUrlParameters(
+      new URLSearchParams("data=https%3A%2F%2Fexample.com%2Fnext.geojson"),
+      app,
+      "project-2",
+    );
+
+    assert.deepEqual(calls, [
+      "https://example.com/data.geojson",
+      "https://example.com/next.geojson",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add optional `urlParameterNames` and `handleUrlParameters` to the `GeoLibrePlugin` interface so plugins can respond to URL query parameters
- `PluginManager.handleUrlParameters` dispatches matching parameters to active plugins once per URL context, with per-plugin error isolation
- Wire URL parameter handling into the desktop shell after map readiness, external plugin loading, and project state restore, and document the new hooks in the plugin API guide

## Test plan
- [x] New unit test covers active/inactive plugins, declared vs. undeclared parameter names, name normalization, and once-per-context dedup (`npm run test:frontend`)
- [x] `npm run build` passes
- [ ] Open the viewer with a plugin URL parameter (e.g. `?exampleGeoJson=...`) and confirm the active plugin's handler runs once

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugins can declare and handle URL query parameters; handlers run after map/plugins initialize and after project restoration (desktop app now processes URL params during project restore)

* **Reliability**
  * Handler invocations deduplicated per plugin/context with bounded memory; re-registering a plugin lets it handle current contexts again
  * Async handlers are awaited in registration order; one handler failing won’t stop others and failures allow retries

* **Documentation**
  * Plugin API docs updated with URL-parameter guidance and examples

* **Tests**
  * Added tests for matching, ordering, dedupe, re-registration, eviction, in-flight behavior, and error resilience
<!-- end of auto-generated comment: release notes by coderabbit.ai -->