### PR TITLE
feat: add Planetary Computer panel for browsing and loading STAC data

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -45,6 +45,7 @@
     "maplibre-gl-geoagent": "^0.4.2",
     "maplibre-gl-geoparquet": "^0.2.1",
     "maplibre-gl-lidar": "^0.14.1",
+    "maplibre-gl-planetary-computer": "^0.3.0",
     "maplibre-gl-streetview": "^0.4.0",
     "maplibre-gl-swipe": "^0.7.1",
     "react": "^18.3.1",

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -24,6 +24,7 @@ import {
   openHtmlPanel,
   openLegendPanel,
   openLidarLayerPanel,
+  openPlanetaryComputerPanel,
   openPMTilesLayerPanel,
   openSearchPlacesPanel,
   openSplattingLayerPanel,
@@ -446,6 +447,9 @@ export function TopToolbar({
   const handleAddThreeDTilesLayer = () => {
     openThreeDTilesLayerPanel(appApi);
   };
+  const handleOpenPlanetaryComputerPanel = () => {
+    openPlanetaryComputerPanel(appApi);
+  };
   const toggleMapControl = (control: ToolbarMapControl) => {
     setControlsVisible((current) => {
       const visible = !current[control];
@@ -690,6 +694,9 @@ export function TopToolbar({
               </DropdownMenuItem>
             </DropdownMenuSubContent>
           </DropdownMenuSub>
+          <DropdownMenuItem onSelect={handleOpenPlanetaryComputerPanel}>
+            Planetary Computer
+          </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
       <DropdownMenu>

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -630,9 +630,6 @@ export function TopToolbar({
           <DropdownMenuItem onSelect={handleAddStacLayer}>
             STAC Layer
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleOpenPlanetaryComputerPanel}>
-            Planetary Computer
-          </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuLabel className="text-xs text-muted-foreground">
             Cloud formats
@@ -697,6 +694,9 @@ export function TopToolbar({
               </DropdownMenuItem>
             </DropdownMenuSubContent>
           </DropdownMenuSub>
+          <DropdownMenuItem onSelect={handleOpenPlanetaryComputerPanel}>
+            Planetary Computer
+          </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
       <DropdownMenu>

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -630,6 +630,9 @@ export function TopToolbar({
           <DropdownMenuItem onSelect={handleAddStacLayer}>
             STAC Layer
           </DropdownMenuItem>
+          <DropdownMenuItem onSelect={handleOpenPlanetaryComputerPanel}>
+            Planetary Computer
+          </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuLabel className="text-xs text-muted-foreground">
             Cloud formats
@@ -694,9 +697,6 @@ export function TopToolbar({
               </DropdownMenuItem>
             </DropdownMenuSubContent>
           </DropdownMenuSub>
-          <DropdownMenuItem onSelect={handleOpenPlanetaryComputerPanel}>
-            Planetary Computer
-          </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
       <DropdownMenu>

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1530,6 +1530,7 @@ body,
   .geolibre-components-control .maplibre-gl-control-grid-relocated,
   .geolibre-pmtiles-control .maplibre-gl-pmtiles-layer-panel,
   .geolibre-zarr-control .maplibre-gl-zarr-layer-panel,
+  .pc-control-panel,
   .duckdb-control-panel,
   .geoparquet-control-panel {
     box-sizing: border-box;
@@ -1586,4 +1587,198 @@ body,
   min-height: 0;
   padding-bottom: 0;
   padding-top: 0;
+}
+
+.dark .pc-control-toggle {
+  background: hsl(var(--popover));
+  color: hsl(var(--popover-foreground));
+}
+
+.dark .pc-control-toggle:hover {
+  background: hsl(var(--muted));
+}
+
+.dark .pc-control-icon svg {
+  fill: none;
+  stroke: hsl(var(--popover-foreground));
+}
+
+.dark .pc-control-panel {
+  background: hsl(var(--popover));
+  border: 1px solid hsl(var(--border));
+  box-shadow: 0 12px 32px rgb(0 0 0 / 0.45);
+  color: hsl(var(--popover-foreground));
+}
+
+.dark .pc-control-header,
+.dark .pc-control-nav {
+  background: hsl(var(--muted));
+  border-color: hsl(var(--border));
+}
+
+.dark .pc-control-title,
+.dark .pc-collection-title,
+.dark .pc-result-title,
+.dark .pc-details-title,
+.dark .pc-section-title,
+.dark .pc-meta-item .pc-value,
+.dark .pc-stats-grid > div > strong,
+.dark .pc-point-values > div > strong,
+.dark .pc-stats-title,
+.dark .pc-legend-title,
+.dark .pc-tilejson-card > div > strong,
+.dark .pc-layer-name,
+.dark .pc-inspector-title,
+.dark .pc-opacity-value,
+.dark .pc-cloud-value,
+.dark .pc-advanced-render summary,
+.dark .pc-checkbox-group label,
+.dark .pc-asset-name {
+  color: hsl(var(--popover-foreground));
+}
+
+.dark .pc-control-close,
+.dark .pc-nav-btn,
+.dark .pc-loading,
+.dark .pc-collection-description,
+.dark .pc-label,
+.dark .pc-bbox-text,
+.dark .pc-date-separator,
+.dark .pc-results-count,
+.dark .pc-results-empty,
+.dark .pc-result-date,
+.dark .pc-result-cloud,
+.dark .pc-asset-type,
+.dark .pc-stats-grid > div > span,
+.dark .pc-point-values > div > span,
+.dark .pc-legend-labels,
+.dark .pc-tilejson-card > div > span,
+.dark .pc-layers-empty,
+.dark .pc-inspector-hint,
+.dark .pc-inspector-coords,
+.dark .pc-opacity-label,
+.dark .pc-rescale-separator {
+  color: hsl(var(--muted-foreground));
+}
+
+.dark .pc-control-close:hover,
+.dark .pc-btn-icon:hover {
+  background: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
+}
+
+.dark .pc-search-box,
+.dark .pc-selected-collection,
+.dark .pc-bbox-display,
+.dark .pc-details-meta,
+.dark .pc-asset-item,
+.dark .pc-tool-loading,
+.dark .pc-custom-viz,
+.dark .pc-point-json,
+.dark .pc-result-thumbnail {
+  background: hsl(var(--muted));
+}
+
+.dark .pc-collection-item,
+.dark .pc-result-item,
+.dark .pc-stats-card,
+.dark .pc-legend-card,
+.dark .pc-tilejson-card,
+.dark .pc-layer-item,
+.dark .pc-inspector-panel,
+.dark .pc-custom-viz {
+  border-color: hsl(var(--border));
+}
+
+.dark .pc-collection-item:hover,
+.dark .pc-result-item:hover {
+  background: hsl(var(--accent));
+  border-color: hsl(var(--ring));
+}
+
+.dark .pc-result-selected,
+.dark .pc-result-selected:hover {
+  background: hsl(var(--accent));
+  border-color: #f59e0b;
+}
+
+.dark .pc-tag,
+.dark .pc-btn-active,
+.dark .pc-layer-controls-active {
+  background: rgb(14 116 144 / 0.22);
+  color: #67e8f9;
+}
+
+.dark .pc-search-input,
+.dark .pc-input {
+  background: hsl(var(--background));
+  border-color: hsl(var(--border));
+  color: hsl(var(--foreground));
+}
+
+.dark .pc-search-input::placeholder,
+.dark .pc-input::placeholder {
+  color: hsl(var(--muted-foreground));
+}
+
+.dark .pc-search-input:focus,
+.dark .pc-input:focus {
+  border-color: hsl(var(--ring));
+  box-shadow: inset 0 0 0 1px hsl(var(--ring));
+}
+
+.dark .pc-btn,
+.dark .pc-nav-btn {
+  background: hsl(var(--background));
+  border-color: hsl(var(--border));
+  color: hsl(var(--foreground));
+}
+
+.dark .pc-btn:hover,
+.dark .pc-nav-btn:hover {
+  background: hsl(var(--accent));
+}
+
+.dark .pc-btn:disabled:hover {
+  background: hsl(var(--background));
+}
+
+.dark .pc-btn-primary,
+.dark .pc-nav-btn.active,
+.dark .pc-search-btn-loading,
+.dark .pc-search-btn-loading:disabled,
+.dark .pc-search-btn-loading:disabled:hover,
+.dark .pc-inspect-active,
+.dark .pc-inspect-active:hover {
+  background: #0891b2;
+  border-color: #0891b2;
+  color: #ecfeff;
+}
+
+.dark .pc-btn-back {
+  color: #67e8f9;
+}
+
+.dark .pc-error,
+.dark .pc-tool-error {
+  background: rgb(127 29 29 / 0.35);
+  color: #fecaca;
+}
+
+.dark .pc-tool-success {
+  background: rgb(20 83 45 / 0.35);
+  color: #bbf7d0;
+}
+
+.dark .pc-spinner {
+  border-color: hsl(var(--border));
+  border-top-color: #67e8f9;
+}
+
+.dark .pc-control-content::-webkit-scrollbar-track {
+  background: hsl(var(--muted));
+}
+
+.dark .pc-control-content::-webkit-scrollbar-thumb {
+  background: hsl(var(--border));
 }

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1530,7 +1530,7 @@ body,
   .geolibre-components-control .maplibre-gl-control-grid-relocated,
   .geolibre-pmtiles-control .maplibre-gl-pmtiles-layer-panel,
   .geolibre-zarr-control .maplibre-gl-zarr-layer-panel,
-  .pc-control-panel,
+  .maplibregl-map .pc-control-panel,
   .duckdb-control-panel,
   .geoparquet-control-panel {
     box-sizing: border-box;

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1589,6 +1589,17 @@ body,
   padding-top: 0;
 }
 
+/* The library caps the panel with an inline max-height (500px), which
+   overflows short windows: the panel sits ~50px from the top of the map
+   with overflow hidden, so the bottom is cut off and only the inner
+   content area scrolls within the 500px cap. Clamp the panel to the map
+   height instead so the content scrollbar always reaches the bottom.
+   !important is needed to beat the inline style, and this rule sits
+   after the small-screen media query above so it wins there too. */
+.maplibregl-map .pc-control-panel {
+  max-height: min(500px, calc(100% - 60px)) !important;
+}
+
 .dark .pc-control-toggle {
   background: hsl(var(--popover));
   color: hsl(var(--popover-foreground));

--- a/apps/geolibre-desktop/src/main.tsx
+++ b/apps/geolibre-desktop/src/main.tsx
@@ -10,6 +10,7 @@ import "maplibre-gl-esri-wayback/style.css";
 import "maplibre-gl-geo-editor/style.css";
 import "maplibre-gl-geoagent/style.css";
 import "maplibre-gl-geoparquet/style.css";
+import "maplibre-gl-planetary-computer/style.css";
 import "maplibre-gl-streetview/style.css";
 import "maplibre-gl-swipe/style.css";
 import "mapillary-js/dist/mapillary.css";

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "maplibre-gl-geoagent": "^0.4.2",
         "maplibre-gl-geoparquet": "^0.2.1",
         "maplibre-gl-lidar": "^0.14.1",
+        "maplibre-gl-planetary-computer": "^0.3.0",
         "maplibre-gl-streetview": "^0.4.0",
         "maplibre-gl-swipe": "^0.7.1",
         "react": "^18.3.1",
@@ -10903,9 +10904,9 @@
       }
     },
     "node_modules/maplibre-gl-planetary-computer": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-planetary-computer/-/maplibre-gl-planetary-computer-0.2.2.tgz",
-      "integrity": "sha512-9QPkuEH8sMcQsINMcmhXXEpTF1uDykKb3OeQ1fXQyHkSVmV4YOVh0+bJrQGZhRq84OBpHqQarF0cirzKBo1S8g==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-planetary-computer/-/maplibre-gl-planetary-computer-0.3.0.tgz",
+      "integrity": "sha512-QPdBfeJ6PE2/JxwDVdBMC7L6g04SlcGdw4Z9LqJ5LmPsPP826b0H4gjv45vCt2NopX8IijfXqA6Xts7f4gcaSQ==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -14602,6 +14603,7 @@
         "maplibre-gl-geoagent": "^0.4.2",
         "maplibre-gl-geoparquet": "^0.2.1",
         "maplibre-gl-lidar": "^0.14.1",
+        "maplibre-gl-planetary-computer": "^0.3.0",
         "maplibre-gl-streetview": "^0.4.0",
         "maplibre-gl-swipe": "^0.7.1",
         "proj4": "^2.20.8",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -35,6 +35,7 @@
     "maplibre-gl-geoagent": "^0.4.2",
     "maplibre-gl-geoparquet": "^0.2.1",
     "maplibre-gl-lidar": "^0.14.1",
+    "maplibre-gl-planetary-computer": "^0.3.0",
     "maplibre-gl-streetview": "^0.4.0",
     "maplibre-gl-swipe": "^0.7.1",
     "proj4": "^2.20.8",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -39,6 +39,7 @@ export {
 } from "./plugins/maplibre-components";
 export { openDuckDBLayerPanel } from "./plugins/maplibre-duckdb";
 export { openGeoParquetLayerPanel } from "./plugins/maplibre-geoparquet";
+export { openPlanetaryComputerPanel } from "./plugins/maplibre-planetary-computer";
 export {
   openThreeDTilesLayerPanel,
   restoreThreeDTilesLayers,

--- a/packages/plugins/src/plugins/maplibre-planetary-computer.ts
+++ b/packages/plugins/src/plugins/maplibre-planetary-computer.ts
@@ -29,6 +29,7 @@ let planetaryComputerConstructorsPromise: Promise<{
   PlanetaryComputerControl: PlanetaryComputerControlConstructor;
 }> | null = null;
 let planetaryComputerStoreUnsubscribe: (() => void) | null = null;
+let planetaryComputerCollapseHandler: (() => void) | null = null;
 
 export function openPlanetaryComputerPanel(app: GeoLibreAppAPI): void {
   void openStandalonePlanetaryComputerControl(app);
@@ -37,6 +38,9 @@ export function openPlanetaryComputerPanel(app: GeoLibreAppAPI): void {
 async function openStandalonePlanetaryComputerControl(
   app: GeoLibreAppAPI,
 ): Promise<boolean> {
+  // Unlike the deck.gl-based plugins (GeoParquet, DuckDB), no
+  // ensureMercatorProjection call is needed: the control adds native
+  // MapLibre raster layers, which render correctly on the globe projection.
   const { PlanetaryComputerControl: PlanetaryComputerControlClass } =
     await getPlanetaryComputerConstructors();
 
@@ -79,7 +83,9 @@ function createPlanetaryComputerControl(
 ): PlanetaryComputerControl {
   const control = new PlanetaryComputerControlClass(PLANETARY_COMPUTER_OPTIONS);
   patchPlanetaryComputerControlOnRemove(control);
-  control.on("collapse", () => hidePlanetaryComputerControl(control));
+  planetaryComputerCollapseHandler = () =>
+    hidePlanetaryComputerControl(control);
+  control.on("collapse", planetaryComputerCollapseHandler);
   control.on("layer:add", syncPlanetaryComputerLayersToStore);
   control.on("layer:remove", syncPlanetaryComputerLayersToStore);
   control.on("layer:update", syncPlanetaryComputerLayersToStore);
@@ -88,7 +94,10 @@ function createPlanetaryComputerControl(
   // re-emitting "layer:update" (verified against
   // maplibre-gl-planetary-computer 0.3.0), so the equality checks here and
   // in syncPlanetaryComputerLayersToStore break the store <-> control
-  // feedback cycle.
+  // feedback cycle. When upgrading the library, re-verify that updateLayer
+  // does not coerce or round these values; if it ever does, toggling
+  // visibility/opacity in the layer list would loop updateLayer <->
+  // layer:update indefinitely.
   planetaryComputerStoreUnsubscribe ??= useAppStore.subscribe(
     (state, previous) => {
       const currentById = new Map(state.layers.map((layer) => [layer.id, layer]));
@@ -223,6 +232,10 @@ function resetPlanetaryComputerControl(
 ): void {
   if (planetaryComputerControl !== control) return;
 
+  if (control && planetaryComputerCollapseHandler) {
+    control.off("collapse", planetaryComputerCollapseHandler);
+  }
+  planetaryComputerCollapseHandler = null;
   control?.off("layer:add", syncPlanetaryComputerLayersToStore);
   control?.off("layer:remove", syncPlanetaryComputerLayersToStore);
   control?.off("layer:update", syncPlanetaryComputerLayersToStore);

--- a/packages/plugins/src/plugins/maplibre-planetary-computer.ts
+++ b/packages/plugins/src/plugins/maplibre-planetary-computer.ts
@@ -1,0 +1,228 @@
+import {
+  DEFAULT_LAYER_STYLE,
+  type GeoLibreLayer,
+  useAppStore,
+} from "@geolibre/core";
+import type {
+  ActiveLayer,
+  PlanetaryComputerControl,
+  PlanetaryComputerEventData,
+  PlanetaryComputerOptions,
+} from "maplibre-gl-planetary-computer";
+import type { GeoLibreAppAPI, GeoLibreMapControlPosition } from "../types";
+
+type PlanetaryComputerControlConstructor =
+  (typeof import("maplibre-gl-planetary-computer"))["PlanetaryComputerControl"];
+
+const planetaryComputerControlPosition: GeoLibreMapControlPosition = "top-left";
+
+const PLANETARY_COMPUTER_OPTIONS = {
+  className: "geolibre-planetary-computer-control",
+  collapsed: false,
+  panelWidth: 380,
+  title: "Planetary Computer",
+} satisfies PlanetaryComputerOptions;
+
+let planetaryComputerControl: PlanetaryComputerControl | null = null;
+let planetaryComputerControlMounted = false;
+let planetaryComputerConstructorsPromise: Promise<{
+  PlanetaryComputerControl: PlanetaryComputerControlConstructor;
+}> | null = null;
+let planetaryComputerStoreUnsubscribe: (() => void) | null = null;
+
+export function openPlanetaryComputerPanel(app: GeoLibreAppAPI): void {
+  void openStandalonePlanetaryComputerControl(app);
+}
+
+async function openStandalonePlanetaryComputerControl(
+  app: GeoLibreAppAPI,
+): Promise<boolean> {
+  const { PlanetaryComputerControl: PlanetaryComputerControlClass } =
+    await getPlanetaryComputerConstructors();
+
+  planetaryComputerControl ??= createPlanetaryComputerControl(
+    PlanetaryComputerControlClass,
+  );
+
+  if (!planetaryComputerControlMounted) {
+    const added = app.addMapControl(
+      planetaryComputerControl,
+      planetaryComputerControlPosition,
+    );
+    if (!added) {
+      planetaryComputerControl = null;
+      return false;
+    }
+    planetaryComputerControlMounted = true;
+  }
+
+  setTimeout(() => {
+    showPlanetaryComputerControl(planetaryComputerControl);
+    planetaryComputerControl?.expand();
+  }, 0);
+  return true;
+}
+
+function getPlanetaryComputerConstructors(): Promise<{
+  PlanetaryComputerControl: PlanetaryComputerControlConstructor;
+}> {
+  planetaryComputerConstructorsPromise ??= import(
+    "maplibre-gl-planetary-computer"
+  ).then(({ PlanetaryComputerControl: PlanetaryComputerControlClass }) => ({
+    PlanetaryComputerControl: PlanetaryComputerControlClass,
+  }));
+  return planetaryComputerConstructorsPromise;
+}
+
+function createPlanetaryComputerControl(
+  PlanetaryComputerControlClass: PlanetaryComputerControlConstructor,
+): PlanetaryComputerControl {
+  const control = new PlanetaryComputerControlClass(PLANETARY_COMPUTER_OPTIONS);
+  control.on("collapse", () => hidePlanetaryComputerControl(control));
+  control.on("layer:add", syncPlanetaryComputerLayersToStore);
+  control.on("layer:remove", syncPlanetaryComputerLayersToStore);
+  control.on("layer:update", syncPlanetaryComputerLayersToStore);
+
+  planetaryComputerStoreUnsubscribe ??= useAppStore.subscribe(
+    (state, previous) => {
+      const currentById = new Map(state.layers.map((layer) => [layer.id, layer]));
+
+      for (const layer of previous.layers) {
+        if (!isPlanetaryComputerLayer(layer)) continue;
+
+        const currentLayer = currentById.get(layer.id);
+        if (!currentLayer) {
+          planetaryComputerControl?.removeLayer(layer.id);
+          continue;
+        }
+
+        if (!isPlanetaryComputerLayer(currentLayer)) continue;
+
+        if (
+          currentLayer.visible !== layer.visible ||
+          currentLayer.opacity !== layer.opacity
+        ) {
+          planetaryComputerControl?.updateLayer(currentLayer.id, {
+            opacity: currentLayer.opacity,
+            visible: currentLayer.visible,
+          });
+        }
+      }
+    },
+  );
+
+  return control;
+}
+
+function syncPlanetaryComputerLayersToStore(
+  event: PlanetaryComputerEventData,
+): void {
+  const store = useAppStore.getState();
+  const activeLayers = event.state.activeLayers;
+  const activeLayerIds = new Set(activeLayers.map((layer) => layer.id));
+
+  for (const storeLayer of store.layers) {
+    if (!isPlanetaryComputerLayer(storeLayer)) continue;
+    if (!activeLayerIds.has(storeLayer.id)) {
+      store.removeLayer(storeLayer.id);
+    }
+  }
+
+  for (const activeLayer of activeLayers) {
+    const layer = createPlanetaryComputerStoreLayer(activeLayer);
+    const existing = useAppStore
+      .getState()
+      .layers.find((current) => current.id === layer.id);
+
+    if (existing) {
+      if (
+        existing.visible !== layer.visible ||
+        existing.opacity !== layer.opacity ||
+        existing.name !== layer.name
+      ) {
+        useAppStore.getState().updateLayer(layer.id, {
+          name: layer.name,
+          opacity: layer.opacity,
+          visible: layer.visible,
+        });
+      }
+      continue;
+    }
+
+    useAppStore.getState().addLayer(layer);
+  }
+}
+
+function createPlanetaryComputerStoreLayer(
+  activeLayer: ActiveLayer,
+): GeoLibreLayer {
+  const bbox =
+    activeLayer.item?.bbox ?? activeLayer.collection?.extent?.spatial?.bbox?.[0];
+  const collectionId =
+    activeLayer.item?.collection ?? activeLayer.collection?.id ?? "";
+
+  return {
+    id: activeLayer.id,
+    name: planetaryComputerLayerName(activeLayer),
+    type: "raster",
+    source: {
+      collectionId,
+      sourceId: activeLayer.sourceId,
+      type: "raster",
+    },
+    visible: activeLayer.visible,
+    opacity: activeLayer.opacity,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {
+      assets: activeLayer.assets,
+      externalNativeLayer: true,
+      identifiable: false,
+      nativeLayerIds: [activeLayer.id],
+      planetaryComputerLayerType: activeLayer.type,
+      presetName: activeLayer.presetName,
+      renderParams: activeLayer.renderParams,
+      sourceId: activeLayer.sourceId,
+      sourceIds: [activeLayer.sourceId],
+      sourceKind: "planetary-computer-raster",
+      stacCollectionId: collectionId,
+      stacItemId: activeLayer.item?.id,
+      tileType: "raster",
+      ...(bbox ? { bounds: bbox } : {}),
+    },
+    sourcePath: collectionId || activeLayer.item?.id || activeLayer.id,
+  };
+}
+
+function planetaryComputerLayerName(activeLayer: ActiveLayer): string {
+  if (activeLayer.item) return activeLayer.item.id;
+  if (activeLayer.collection) {
+    return activeLayer.collection.title || activeLayer.collection.id;
+  }
+  return activeLayer.id;
+}
+
+function hidePlanetaryComputerControl(
+  control: PlanetaryComputerControl | null,
+): void {
+  const container = control?.getContainer();
+  const panel = control?.getPanelElement();
+  if (container) container.style.display = "none";
+  if (panel) panel.style.display = "none";
+}
+
+function showPlanetaryComputerControl(
+  control: PlanetaryComputerControl | null,
+): void {
+  const container = control?.getContainer();
+  const panel = control?.getPanelElement();
+  if (container) container.style.display = "";
+  if (panel) panel.style.display = "";
+}
+
+function isPlanetaryComputerLayer(layer: GeoLibreLayer): boolean {
+  return (
+    layer.type === "raster" &&
+    layer.metadata.sourceKind === "planetary-computer-raster" &&
+    layer.metadata.externalNativeLayer === true
+  );
+}

--- a/packages/plugins/src/plugins/maplibre-planetary-computer.ts
+++ b/packages/plugins/src/plugins/maplibre-planetary-computer.ts
@@ -50,7 +50,7 @@ async function openStandalonePlanetaryComputerControl(
       planetaryComputerControlPosition,
     );
     if (!added) {
-      planetaryComputerControl = null;
+      resetPlanetaryComputerControl(planetaryComputerControl);
       return false;
     }
     planetaryComputerControlMounted = true;
@@ -78,11 +78,17 @@ function createPlanetaryComputerControl(
   PlanetaryComputerControlClass: PlanetaryComputerControlConstructor,
 ): PlanetaryComputerControl {
   const control = new PlanetaryComputerControlClass(PLANETARY_COMPUTER_OPTIONS);
+  patchPlanetaryComputerControlOnRemove(control);
   control.on("collapse", () => hidePlanetaryComputerControl(control));
   control.on("layer:add", syncPlanetaryComputerLayersToStore);
   control.on("layer:remove", syncPlanetaryComputerLayersToStore);
   control.on("layer:update", syncPlanetaryComputerLayersToStore);
 
+  // updateLayer stores the passed visible/opacity values verbatim before
+  // re-emitting "layer:update" (verified against
+  // maplibre-gl-planetary-computer 0.3.0), so the equality checks here and
+  // in syncPlanetaryComputerLayersToStore break the store <-> control
+  // feedback cycle.
   planetaryComputerStoreUnsubscribe ??= useAppStore.subscribe(
     (state, previous) => {
       const currentById = new Map(state.layers.map((layer) => [layer.id, layer]));
@@ -199,6 +205,27 @@ function planetaryComputerLayerName(activeLayer: ActiveLayer): string {
     return activeLayer.collection.title || activeLayer.collection.id;
   }
   return activeLayer.id;
+}
+
+function patchPlanetaryComputerControlOnRemove(
+  control: PlanetaryComputerControl,
+): void {
+  const originalOnRemove = control.onRemove.bind(control);
+  control.onRemove = () => {
+    originalOnRemove();
+    resetPlanetaryComputerControl(control);
+  };
+}
+
+function resetPlanetaryComputerControl(
+  control: PlanetaryComputerControl | null,
+): void {
+  if (planetaryComputerControl !== control) return;
+
+  planetaryComputerStoreUnsubscribe?.();
+  planetaryComputerStoreUnsubscribe = null;
+  planetaryComputerControlMounted = false;
+  planetaryComputerControl = null;
 }
 
 function hidePlanetaryComputerControl(

--- a/packages/plugins/src/plugins/maplibre-planetary-computer.ts
+++ b/packages/plugins/src/plugins/maplibre-planetary-computer.ts
@@ -141,13 +141,14 @@ function syncPlanetaryComputerLayersToStore(
       .layers.find((current) => current.id === layer.id);
 
     if (existing) {
+      // Only sync visible/opacity (the same fields the store -> control path
+      // syncs). The name is derived from STAC metadata, so re-syncing it here
+      // would clobber a user rename on every panel event.
       if (
         existing.visible !== layer.visible ||
-        existing.opacity !== layer.opacity ||
-        existing.name !== layer.name
+        existing.opacity !== layer.opacity
       ) {
         useAppStore.getState().updateLayer(layer.id, {
-          name: layer.name,
           opacity: layer.opacity,
           visible: layer.visible,
         });
@@ -222,6 +223,9 @@ function resetPlanetaryComputerControl(
 ): void {
   if (planetaryComputerControl !== control) return;
 
+  control?.off("layer:add", syncPlanetaryComputerLayersToStore);
+  control?.off("layer:remove", syncPlanetaryComputerLayersToStore);
+  control?.off("layer:update", syncPlanetaryComputerLayersToStore);
   planetaryComputerStoreUnsubscribe?.();
   planetaryComputerStoreUnsubscribe = null;
   planetaryComputerControlMounted = false;

--- a/packages/plugins/src/plugins/maplibre-planetary-computer.ts
+++ b/packages/plugins/src/plugins/maplibre-planetary-computer.ts
@@ -29,7 +29,6 @@ let planetaryComputerConstructorsPromise: Promise<{
   PlanetaryComputerControl: PlanetaryComputerControlConstructor;
 }> | null = null;
 let planetaryComputerStoreUnsubscribe: (() => void) | null = null;
-let planetaryComputerCollapseHandler: (() => void) | null = null;
 
 export function openPlanetaryComputerPanel(app: GeoLibreAppAPI): void {
   void openStandalonePlanetaryComputerControl(app);
@@ -63,8 +62,29 @@ async function openStandalonePlanetaryComputerControl(
   setTimeout(() => {
     showPlanetaryComputerControl(planetaryComputerControl);
     planetaryComputerControl?.expand();
+    wirePlanetaryComputerCloseButton(planetaryComputerControl);
   }, 0);
   return true;
+}
+
+// The library fires the same "collapse" event for the toggle icon and the
+// panel's X button, so the two cannot be told apart through events. Clicking
+// the toggle icon keeps the library's default behavior (collapse the panel,
+// leave the icon on the map); only a direct click on the X button hides the
+// whole control until it is reopened from the Processing menu.
+function wirePlanetaryComputerCloseButton(
+  control: PlanetaryComputerControl | null,
+): void {
+  const closeButton = control
+    ?.getPanelElement()
+    ?.querySelector<HTMLElement>(".pc-control-close");
+  if (!closeButton || closeButton.dataset.geolibreCloseWired === "true") {
+    return;
+  }
+  closeButton.dataset.geolibreCloseWired = "true";
+  closeButton.addEventListener("click", () =>
+    hidePlanetaryComputerControl(control),
+  );
 }
 
 function getPlanetaryComputerConstructors(): Promise<{
@@ -83,9 +103,6 @@ function createPlanetaryComputerControl(
 ): PlanetaryComputerControl {
   const control = new PlanetaryComputerControlClass(PLANETARY_COMPUTER_OPTIONS);
   patchPlanetaryComputerControlOnRemove(control);
-  planetaryComputerCollapseHandler = () =>
-    hidePlanetaryComputerControl(control);
-  control.on("collapse", planetaryComputerCollapseHandler);
   control.on("layer:add", syncPlanetaryComputerLayersToStore);
   control.on("layer:remove", syncPlanetaryComputerLayersToStore);
   control.on("layer:update", syncPlanetaryComputerLayersToStore);
@@ -232,10 +249,6 @@ function resetPlanetaryComputerControl(
 ): void {
   if (planetaryComputerControl !== control) return;
 
-  if (control && planetaryComputerCollapseHandler) {
-    control.off("collapse", planetaryComputerCollapseHandler);
-  }
-  planetaryComputerCollapseHandler = null;
   control?.off("layer:add", syncPlanetaryComputerLayersToStore);
   control?.off("layer:remove", syncPlanetaryComputerLayersToStore);
   control?.off("layer:update", syncPlanetaryComputerLayersToStore);


### PR DESCRIPTION
## Summary
- Add a Planetary Computer entry to the Processing menu that opens the maplibre-gl-planetary-computer control for searching Microsoft Planetary Computer STAC collections and adding raster layers
- Sync layers added from the panel with the app layer store so visibility and opacity changes work from the layer list in both directions
- Add dark mode styling for the panel consistent with other plugin panels

## Test plan
- [ ] Open Processing > Planetary Computer and confirm the panel opens
- [ ] Search a collection (e.g. Sentinel-2), select an item, and add it to the map
- [ ] Toggle visibility and adjust opacity from the layer list and confirm the map layer updates
- [ ] Remove the layer from the layer list and confirm it is removed from the panel
- [ ] Verify panel styling in dark mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated Planetary Computer satellite data access.
  * Added a Planetary Computer panel reachable from the main toolbar’s Processing menu.
  * Automatic synchronization of Planetary Computer layers with the map workspace (two‑way visibility/opacity sync).

* **Improvements**
  * Responsive mobile support for the Planetary Computer control panel.
  * Comprehensive dark‑mode styling for the Planetary Computer interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->