### PR TITLE
refactor: replace Whitebox submenu with a direct menu item

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -686,14 +686,9 @@ export function TopToolbar({
         <DropdownMenuContent align="start">
           <DropdownMenuLabel>Processing</DropdownMenuLabel>
           <DropdownMenuSeparator />
-          <DropdownMenuSub>
-            <DropdownMenuSubTrigger>Whitebox</DropdownMenuSubTrigger>
-            <DropdownMenuSubContent>
-              <DropdownMenuItem onSelect={() => setProcessingOpen(true)}>
-                Toolbox
-              </DropdownMenuItem>
-            </DropdownMenuSubContent>
-          </DropdownMenuSub>
+          <DropdownMenuItem onSelect={() => setProcessingOpen(true)}>
+            Whitebox
+          </DropdownMenuItem>
           <DropdownMenuItem onSelect={handleOpenPlanetaryComputerPanel}>
             Planetary Computer
           </DropdownMenuItem>


### PR DESCRIPTION
## Summary
- Flatten the Processing menu by replacing the Whitebox submenu, which held only a single Toolbox entry, with a direct Whitebox menu item that opens the toolbox panel.

## Test plan
- [ ] Open the Processing menu and confirm Whitebox appears as a single item (no submenu).
- [ ] Click Whitebox and verify the Whitebox toolbox panel opens.
- [ ] Confirm the Planetary Computer item still works as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the Processing dropdown menu structure by consolidating the Whitebox submenu, streamlining access to processing tools with fewer navigation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->