### PR TITLE
feat: support identify, selection, and attribute table for DuckDB layers

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -1,7 +1,6 @@
-import { useAppStore } from "@geolibre/core";
+import { isDuckDBQueryLayer, useAppStore } from "@geolibre/core";
 import {
   getDuckDBLayerRows,
-  setDuckDBSelectedFeature,
   updateDuckDBLayerRows,
   type DuckDBAttributeRow,
 } from "@geolibre/plugins";
@@ -51,7 +50,6 @@ type ColumnWidths = Record<string, number>;
 type AttributeDrafts = Record<string, Record<string, string>>;
 type ExportFormat = "geojson" | "csv" | BinaryVectorExportFormat;
 type AttributeTableRow = {
-  feature?: Feature;
   featureId: string;
   properties: Record<string, unknown>;
 };
@@ -163,14 +161,6 @@ function applyDraftsToFeatures(
   });
 }
 
-function isDuckDBQueryLayer(layer: { metadata: Record<string, unknown>; type: string } | undefined): boolean {
-  return (
-    layer?.type === "duckdb-query" &&
-    layer.metadata.sourceKind === "duckdb-query" &&
-    layer.metadata.externalDeckLayer === true
-  );
-}
-
 function duckDBRowsToAttributeRows(
   rows: DuckDBAttributeRow[],
 ): AttributeTableRow[] {
@@ -277,13 +267,12 @@ export function AttributeTable() {
   const features = layer?.geojson?.features ?? [];
   const isDuckDBLayer = isDuckDBQueryLayer(layer);
   const duckdbRows = layer && isDuckDBLayer ? getDuckDBLayerRows(layer.id) : [];
-  const attributeRows: AttributeTableRow[] = layer?.geojson
-    ? features.map((feature, index) => ({
-        feature,
+  const attributeRows: AttributeTableRow[] = isDuckDBLayer
+    ? duckDBRowsToAttributeRows(duckdbRows)
+    : features.map((feature, index) => ({
         featureId: String(feature.id ?? index),
         properties: (feature.properties ?? {}) as Record<string, unknown>,
-      }))
-    : duckDBRowsToAttributeRows(duckdbRows);
+      }));
   const hasAttributeSource = Boolean(layer?.geojson || isDuckDBLayer);
   const hasEdits = hasDraftEdits(drafts);
   const hasInvalidDrafts = attributeRows.some((row) => {
@@ -828,10 +817,7 @@ export function AttributeTable() {
           title="Clear selected feature"
           aria-label="Clear selected feature"
           disabled={!selectedFeatureId}
-          onClick={() => {
-            if (layer && isDuckDBLayer) setDuckDBSelectedFeature(layer.id, null);
-            selectFeature(null);
-          }}
+          onClick={() => selectFeature(null)}
         >
           <X className="h-4 w-4" />
         </Button>
@@ -880,9 +866,6 @@ export function AttributeTable() {
                     data-state={selected ? "selected" : undefined}
                     className="cursor-pointer"
                     onClick={() => {
-                      if (layer && isDuckDBLayer) {
-                        setDuckDBSelectedFeature(layer.id, featureId);
-                      }
                       selectFeature(featureId);
                     }}
                   >

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -1,5 +1,11 @@
 import { useAppStore } from "@geolibre/core";
 import {
+  getDuckDBLayerRows,
+  setDuckDBSelectedFeature,
+  updateDuckDBLayerRows,
+  type DuckDBAttributeRow,
+} from "@geolibre/plugins";
+import {
   Button,
   DropdownMenu,
   DropdownMenuContent,
@@ -44,6 +50,11 @@ type SortKey = "__featureId" | string;
 type ColumnWidths = Record<string, number>;
 type AttributeDrafts = Record<string, Record<string, string>>;
 type ExportFormat = "geojson" | "csv" | BinaryVectorExportFormat;
+type AttributeTableRow = {
+  feature?: Feature;
+  featureId: string;
+  properties: Record<string, unknown>;
+};
 
 const DEFAULT_FEATURE_ID_COLUMN_WIDTH = 72;
 const DEFAULT_ATTRIBUTE_COLUMN_WIDTH = 160;
@@ -152,6 +163,47 @@ function applyDraftsToFeatures(
   });
 }
 
+function isDuckDBQueryLayer(layer: { metadata: Record<string, unknown>; type: string } | undefined): boolean {
+  return (
+    layer?.type === "duckdb-query" &&
+    layer.metadata.sourceKind === "duckdb-query" &&
+    layer.metadata.externalDeckLayer === true
+  );
+}
+
+function duckDBRowsToAttributeRows(
+  rows: DuckDBAttributeRow[],
+): AttributeTableRow[] {
+  return rows.map((row) => ({
+    featureId: row.featureId,
+    properties: row.properties,
+  }));
+}
+
+function applyDraftsToDuckDBRows(
+  rows: AttributeTableRow[],
+  drafts: AttributeDrafts,
+): Record<string, Record<string, unknown>> {
+  const rowById = new Map(rows.map((row) => [row.featureId, row]));
+  const updates: Record<string, Record<string, unknown>> = {};
+
+  for (const [featureId, rowDrafts] of Object.entries(drafts)) {
+    const row = rowById.get(featureId);
+    if (!row) continue;
+
+    const properties: Record<string, unknown> = {};
+    for (const [column, draft] of Object.entries(rowDrafts)) {
+      const previousValue = row.properties[column];
+      if (isInvalidObjectDraft(draft, previousValue)) continue;
+      properties[column] = parseAttributeDraft(draft, previousValue);
+    }
+
+    if (Object.keys(properties).length > 0) updates[featureId] = properties;
+  }
+
+  return updates;
+}
+
 function sanitizeExportFileName(name: string): string {
   const sanitized = name
     .trim()
@@ -223,12 +275,22 @@ export function AttributeTable() {
   const layer = layers.find((l) => l.id === selectedLayerId);
   const hasLayer = Boolean(layer);
   const features = layer?.geojson?.features ?? [];
+  const isDuckDBLayer = isDuckDBQueryLayer(layer);
+  const duckdbRows = layer && isDuckDBLayer ? getDuckDBLayerRows(layer.id) : [];
+  const attributeRows: AttributeTableRow[] = layer?.geojson
+    ? features.map((feature, index) => ({
+        feature,
+        featureId: String(feature.id ?? index),
+        properties: (feature.properties ?? {}) as Record<string, unknown>,
+      }))
+    : duckDBRowsToAttributeRows(duckdbRows);
+  const hasAttributeSource = Boolean(layer?.geojson || isDuckDBLayer);
   const hasEdits = hasDraftEdits(drafts);
-  const hasInvalidDrafts = features.some((feature, index) => {
-    const rowDrafts = drafts[String(feature.id ?? index)];
+  const hasInvalidDrafts = attributeRows.some((row) => {
+    const rowDrafts = drafts[row.featureId];
     if (!rowDrafts) return false;
     return Object.entries(rowDrafts).some(([column, draft]) =>
-      isInvalidObjectDraft(draft, feature.properties?.[column]),
+      isInvalidObjectDraft(draft, row.properties[column]),
     );
   });
 
@@ -238,32 +300,28 @@ export function AttributeTable() {
   }, [selectedLayerId, hasLayer]);
 
   const filterLower = attributeFilter.toLowerCase();
-  const indexedFeatures = features.map((feature, index) => ({
-    feature,
-    featureId: String(feature.id ?? index),
-  }));
-  const filtered = indexedFeatures.filter(({ feature, featureId }) => {
+  const filtered = attributeRows.filter(({ properties, featureId }) => {
     if (!filterLower) return true;
-    const props = JSON.stringify(feature.properties ?? {}).toLowerCase();
+    const props = JSON.stringify(properties).toLowerCase();
     return featureId.includes(filterLower) || props.includes(filterLower);
   });
   const sorted = [...filtered].sort((a, b) => {
     const aValue =
       sort.key === "__featureId"
         ? a.featureId
-        : a.feature.properties?.[sort.key];
+        : a.properties[sort.key];
     const bValue =
       sort.key === "__featureId"
         ? b.featureId
-        : b.feature.properties?.[sort.key];
+        : b.properties[sort.key];
     const result = compareAttributeValues(aValue, bValue);
     return sort.direction === "asc" ? result : -result;
   });
 
   const propKeys = new Set<string>();
-  for (const f of features) {
-    if (f.properties) {
-      for (const k of Object.keys(f.properties)) propKeys.add(k);
+  for (const row of attributeRows) {
+    for (const k of Object.keys(row.properties)) {
+      propKeys.add(k);
     }
   }
   const columns = Array.from(propKeys);
@@ -441,7 +499,19 @@ export function AttributeTable() {
   };
 
   const saveDrafts = () => {
-    if (!layer?.geojson || !hasEdits || hasInvalidDrafts) return;
+    if (!layer || !hasEdits || hasInvalidDrafts) return;
+
+    if (isDuckDBLayer) {
+      updateDuckDBLayerRows(
+        layer.id,
+        applyDraftsToDuckDBRows(attributeRows, drafts),
+      );
+      setIsEditing(false);
+      setDrafts({});
+      return;
+    }
+
+    if (!layer.geojson) return;
 
     const geojson = {
       ...layer.geojson,
@@ -644,7 +714,7 @@ export function AttributeTable() {
           </span>
         ) : (
           <span className="min-w-0 max-w-full truncate text-xs text-muted-foreground md:max-w-56">
-            - select a vector layer
+            - select a layer with attributes
           </span>
         )}
         {exportError ? (
@@ -661,12 +731,14 @@ export function AttributeTable() {
               ? hasEdits
                 ? "Use Save or Cancel to finish editing"
                 : "Exit edit mode"
-              : "Edit attribute values"
+              : isDuckDBLayer
+                ? "Edit displayed DuckDB query attributes in memory"
+                : "Edit attribute values"
           }
           aria-label={
             isEditing && !hasEdits ? "Exit edit mode" : "Edit attribute values"
           }
-          disabled={!layer?.geojson || (isEditing && hasEdits)}
+          disabled={!hasAttributeSource || (isEditing && hasEdits)}
           onClick={toggleEditing}
         >
           <Pencil className="h-3.5 w-3.5" />
@@ -679,7 +751,9 @@ export function AttributeTable() {
           title={
             hasInvalidDrafts
               ? "Fix invalid JSON before saving"
-              : "Save attribute edits"
+              : isDuckDBLayer
+                ? "Save in-memory DuckDB attribute edits"
+                : "Save attribute edits"
           }
           aria-label="Save attribute edits"
           disabled={!isEditing || !hasEdits || hasInvalidDrafts}
@@ -694,7 +768,11 @@ export function AttributeTable() {
               variant="outline"
               size="sm"
               className="h-7 px-2"
-              title="Export selected layer"
+              title={
+                layer?.geojson
+                  ? "Export selected layer"
+                  : "Export requires a GeoJSON-backed layer"
+              }
               aria-label="Export selected layer"
               disabled={!layer?.geojson}
             >
@@ -750,7 +828,10 @@ export function AttributeTable() {
           title="Clear selected feature"
           aria-label="Clear selected feature"
           disabled={!selectedFeatureId}
-          onClick={() => selectFeature(null)}
+          onClick={() => {
+            if (layer && isDuckDBLayer) setDuckDBSelectedFeature(layer.id, null);
+            selectFeature(null);
+          }}
         >
           <X className="h-4 w-4" />
         </Button>
@@ -764,9 +845,9 @@ export function AttributeTable() {
         type="always"
         className="flex-1 [&_[data-orientation=vertical]]:!top-11 [&_[data-orientation=vertical]]:!h-[calc(100%-3.625rem)]"
       >
-        {!layer?.geojson ? (
+        {!hasAttributeSource ? (
           <p className="p-4 text-xs text-muted-foreground">
-            Attribute table requires a vector layer.
+            Attribute table requires a vector or DuckDB query layer.
           </p>
         ) : (
           <table
@@ -791,10 +872,7 @@ export function AttributeTable() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {sorted.map(({ feature, featureId }: {
-                feature: Feature;
-                featureId: string;
-              }) => {
+              {sorted.map(({ featureId, properties }) => {
                 const selected = selectedFeatureId === featureId;
                 return (
                   <TableRow
@@ -802,12 +880,15 @@ export function AttributeTable() {
                     data-state={selected ? "selected" : undefined}
                     className="cursor-pointer"
                     onClick={() => {
+                      if (layer && isDuckDBLayer) {
+                        setDuckDBSelectedFeature(layer.id, featureId);
+                      }
                       selectFeature(featureId);
                     }}
                   >
                     <TableCell>{featureId}</TableCell>
                     {columns.map((col) => {
-                      const value = feature.properties?.[col];
+                      const value = properties[col];
                       const draft = drafts[featureId]?.[col];
                       const changed = draft !== undefined;
                       const invalid =

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -7,7 +7,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { useAppStore } from "@geolibre/core";
+import { isDuckDBQueryLayer, useAppStore } from "@geolibre/core";
 import type { GeoLibreLayer } from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
 import { isPlaceholderLayer, placeholderMessage } from "@geolibre/map";
@@ -116,14 +116,6 @@ function hasNativeIdentifyLayers(layer: GeoLibreLayer): boolean {
   return (
     Array.isArray(layer.metadata.nativeLayerIds) &&
     layer.metadata.nativeLayerIds.length > 0
-  );
-}
-
-function isDuckDBQueryLayer(layer: GeoLibreLayer): boolean {
-  return (
-    layer.type === "duckdb-query" &&
-    layer.metadata.sourceKind === "duckdb-query" &&
-    layer.metadata.externalDeckLayer === true
   );
 }
 

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -119,6 +119,14 @@ function hasNativeIdentifyLayers(layer: GeoLibreLayer): boolean {
   );
 }
 
+function isDuckDBQueryLayer(layer: GeoLibreLayer): boolean {
+  return (
+    layer.type === "duckdb-query" &&
+    layer.metadata.sourceKind === "duckdb-query" &&
+    layer.metadata.externalDeckLayer === true
+  );
+}
+
 function isMobileViewport(): boolean {
   return (
     typeof window !== "undefined" &&
@@ -511,6 +519,7 @@ export function LayerPanel({
           {visibleLayers.map((layer, displayIndex) => {
             const canIdentify =
               layer.type === "geojson" ||
+              isDuckDBQueryLayer(layer) ||
               (layer.type === "wms" &&
                 typeof layer.source.layers === "string" &&
                 Boolean(layer.source.layers.trim()) &&

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -169,6 +169,21 @@ export interface GeoLibreLayer {
   sourcePath?: string;
 }
 
+/**
+ * Detect a DuckDB query layer rendered through the plugin's external deck.gl
+ * overlay. Shared by `@geolibre/map`, `@geolibre/plugins`, and the desktop
+ * app so the detection criteria cannot drift.
+ */
+export function isDuckDBQueryLayer(
+  layer: Pick<GeoLibreLayer, "metadata" | "type"> | undefined,
+): boolean {
+  return (
+    layer?.type === "duckdb-query" &&
+    layer.metadata.sourceKind === "duckdb-query" &&
+    layer.metadata.externalDeckLayer === true
+  );
+}
+
 export interface MapViewState {
   center: [number, number];
   zoom: number;

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -46,6 +46,24 @@ export interface MapDiagnosticEvent {
   url?: string;
 }
 
+interface DuckDBIdentifyBridgeResult {
+  coordinate: [number, number] | null;
+  featureId: string;
+  properties: Record<string, unknown>;
+}
+
+interface GeoLibreDuckDBBridge {
+  getFeatureBounds?: (
+    layerId: string,
+    featureId: string,
+  ) => [number, number, number, number] | null;
+  identifyLayerAtPoint?: (
+    layerId: string,
+    point: { x: number; y: number },
+  ) => DuckDBIdentifyBridgeResult | null;
+  setSelectedFeature?: (layerId: string, featureId: string | null) => void;
+}
+
 function stringifyIdentifyValue(value: unknown): string {
   if (value == null) return "";
   if (typeof value === "object") return JSON.stringify(value);
@@ -150,6 +168,21 @@ function findFeatureId(
 
 function isWmsLayer(layer: GeoLibreLayer): boolean {
   return layer.type === "wms";
+}
+
+function isDuckDBQueryLayer(layer: GeoLibreLayer): boolean {
+  return (
+    layer.type === "duckdb-query" &&
+    layer.metadata.sourceKind === "duckdb-query" &&
+    layer.metadata.externalDeckLayer === true
+  );
+}
+
+function duckDBBridge(): GeoLibreDuckDBBridge | undefined {
+  return typeof window === "undefined"
+    ? undefined
+    : (window as Window & { __GEOLIBRE_DUCKDB__?: GeoLibreDuckDBBridge })
+        .__GEOLIBRE_DUCKDB__;
 }
 
 function stringSource(value: unknown): string | undefined {
@@ -570,6 +603,7 @@ export const MapCanvas = memo(function MapCanvas({
   const setMapView = useAppStore((s) => s.setMapView);
   const setPointerCoords = useAppStore((s) => s.setPointerCoords);
   const previousSelectedFeatureKey = useRef<string | null>(null);
+  const previousDuckDBSelectionLayerId = useRef<string | null>(null);
   const identifyPopup = useRef<maplibregl.Popup | null>(null);
 
   useEffect(() => {
@@ -719,6 +753,23 @@ export const MapCanvas = memo(function MapCanvas({
     controller.current?.highlightFeature(layer, selectedFeatureId, {
       fit: shouldFit,
     });
+    if (layer && isDuckDBQueryLayer(layer)) {
+      duckDBBridge()?.setSelectedFeature?.(layer.id, selectedFeatureId);
+      if (shouldFit && selectedFeatureId) {
+        const bounds = duckDBBridge()?.getFeatureBounds?.(
+          layer.id,
+          selectedFeatureId,
+        );
+        if (bounds) controller.current?.fitBounds(bounds);
+      }
+      previousDuckDBSelectionLayerId.current = layer.id;
+    } else if (previousDuckDBSelectionLayerId.current) {
+      duckDBBridge()?.setSelectedFeature?.(
+        previousDuckDBSelectionLayerId.current,
+        null,
+      );
+      previousDuckDBSelectionLayerId.current = null;
+    }
   }, [layers, selectedLayerId, selectedFeatureId, zoomToSelectedFeature]);
 
   useEffect(() => {
@@ -815,6 +866,27 @@ export const MapCanvas = memo(function MapCanvas({
               createIdentifyMessagePopupElement(layer.name, message),
             );
           });
+        return;
+      }
+
+      if (isDuckDBQueryLayer(layer)) {
+        const result = duckDBBridge()?.identifyLayerAtPoint?.(layer.id, {
+          x: event.point.x,
+          y: event.point.y,
+        });
+        if (!result) {
+          clearIdentifyResult();
+          return;
+        }
+
+        selectFeature(result.featureId);
+        showIdentifyPopup(
+          createIdentifyPopupElement(
+            layer.name,
+            result.properties,
+            result.featureId,
+          ),
+        );
         return;
       }
 

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -1,4 +1,8 @@
-import { useAppStore, type GeoLibreLayer } from "@geolibre/core";
+import {
+  isDuckDBQueryLayer,
+  useAppStore,
+  type GeoLibreLayer,
+} from "@geolibre/core";
 import maplibregl from "maplibre-gl";
 import { memo, useEffect, useRef } from "react";
 import {
@@ -168,14 +172,6 @@ function findFeatureId(
 
 function isWmsLayer(layer: GeoLibreLayer): boolean {
   return layer.type === "wms";
-}
-
-function isDuckDBQueryLayer(layer: GeoLibreLayer): boolean {
-  return (
-    layer.type === "duckdb-query" &&
-    layer.metadata.sourceKind === "duckdb-query" &&
-    layer.metadata.externalDeckLayer === true
-  );
 }
 
 function duckDBBridge(): GeoLibreDuckDBBridge | undefined {

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -608,6 +608,14 @@ export class MapController {
 
   fitBounds(bounds: [number, number, number, number]): void {
     if (!this.map) return;
+    if (bounds[0] === bounds[2] && bounds[1] === bounds[3]) {
+      this.map.flyTo({
+        center: [bounds[0], bounds[1]],
+        zoom: Math.max(this.map.getZoom(), 14),
+        duration: 800,
+      });
+      return;
+    }
     this.map.fitBounds(
       [
         [bounds[0], bounds[1]],

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -608,6 +608,8 @@ export class MapController {
 
   fitBounds(bounds: [number, number, number, number]): void {
     if (!this.map) return;
+    if (bounds.some((value) => !Number.isFinite(value))) return;
+    // A degenerate point-sized box cannot be fit; fly to the point instead.
     if (bounds[0] === bounds[2] && bounds[1] === bounds[3]) {
       this.map.flyTo({
         center: [bounds[0], bounds[1]],
@@ -680,17 +682,7 @@ export class MapController {
   private fitFeature(featureCollection: FeatureCollection): void {
     if (!this.map || featureCollection.features.length === 0) return;
     const box = bbox(featureCollection) as [number, number, number, number];
-    if (box.some((value) => !Number.isFinite(value))) return;
-
-    if (box[0] === box[2] && box[1] === box[3]) {
-      this.map.flyTo({
-        center: [box[0], box[1]],
-        zoom: Math.max(this.map.getZoom(), 14),
-        duration: 800,
-      });
-      return;
-    }
-
+    // fitBounds validates the box and handles point-sized boxes.
     this.fitBounds(box);
   }
 

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -37,7 +37,16 @@ export {
   subscribeSearchPlacesPanel,
   type CogRasterLayerOptions,
 } from "./plugins/maplibre-components";
-export { openDuckDBLayerPanel } from "./plugins/maplibre-duckdb";
+export {
+  getDuckDBFeatureBounds,
+  getDuckDBLayerRows,
+  identifyDuckDBLayerAtPoint,
+  openDuckDBLayerPanel,
+  setDuckDBSelectedFeature,
+  updateDuckDBLayerRows,
+  type DuckDBAttributeRow,
+  type DuckDBIdentifyResult,
+} from "./plugins/maplibre-duckdb";
 export { openGeoParquetLayerPanel } from "./plugins/maplibre-geoparquet";
 export { openPlanetaryComputerPanel } from "./plugins/maplibre-planetary-computer";
 export {

--- a/packages/plugins/src/plugins/maplibre-duckdb.ts
+++ b/packages/plugins/src/plugins/maplibre-duckdb.ts
@@ -201,13 +201,16 @@ declare global {
 }
 
 if (typeof window !== "undefined") {
-  window.__GEOLIBRE_DUCKDB__ = {
+  // Bridge consumed only by @geolibre/map (MapCanvas), which cannot import
+  // this package directly. Do not widen this API; frozen so its members
+  // cannot be swapped out by other scripts after construction.
+  window.__GEOLIBRE_DUCKDB__ = Object.freeze({
     getFeatureBounds: getDuckDBFeatureBounds,
     getLayerRows: getDuckDBLayerRows,
     identifyLayerAtPoint: identifyDuckDBLayerAtPoint,
     setSelectedFeature: setDuckDBSelectedFeature,
     updateLayerRows: updateDuckDBLayerRows,
-  };
+  });
 }
 
 export function openDuckDBLayerPanel(app: GeoLibreAppAPI): void {
@@ -934,7 +937,9 @@ function getGeoArrowRowIndex(objectInfo: {
     return rawIndex;
   }
   if (typeof rawIndex === "bigint") {
-    return rawIndex <= BigInt(Number.MAX_SAFE_INTEGER) ? Number(rawIndex) : index;
+    return rawIndex >= BigInt(0) && rawIndex <= BigInt(Number.MAX_SAFE_INTEGER)
+      ? Number(rawIndex)
+      : index;
   }
   return index;
 }
@@ -998,11 +1003,20 @@ function getDuckDBCustomLayerType(geometryTypes: string[]): string {
 
 function getDuckDBDeckLayerIds(layerId: string): string[] {
   const renderedLayer = duckdbRenderedLayers.get(layerId);
-  return (renderedLayer?.results ?? [])
+  const results = renderedLayer?.results ?? [];
+  // Mirrors the deck layer naming scheme of maplibre-gl-duckdb 0.2.0
+  // (`duckdb-<layerId>-<geometryType>-<resultIndex>`); revisit on upgrades.
+  const ids = results
     .map((result, index) =>
       result.geometryType ? `duckdb-${layerId}-${result.geometryType}-${index}` : null,
     )
     .filter((id): id is string => typeof id === "string");
+  if (ids.length === 0 && results.length > 0 && import.meta.env.DEV) {
+    console.warn(
+      `DuckDB layer ${layerId} has results without geometry types; identify picking may match nothing.`,
+    );
+  }
+  return ids;
 }
 
 function getDuckDBResultLocalRowIndex(
@@ -1129,7 +1143,11 @@ function getRowIndexFromProperties(
 ): number | null {
   const rawIndex = properties?.__index;
   if (typeof rawIndex === "number" && Number.isFinite(rawIndex)) return rawIndex;
-  if (typeof rawIndex === "bigint" && rawIndex <= BigInt(Number.MAX_SAFE_INTEGER)) {
+  if (
+    typeof rawIndex === "bigint" &&
+    rawIndex >= BigInt(0) &&
+    rawIndex <= BigInt(Number.MAX_SAFE_INTEGER)
+  ) {
     return Number(rawIndex);
   }
   return null;

--- a/packages/plugins/src/plugins/maplibre-duckdb.ts
+++ b/packages/plugins/src/plugins/maplibre-duckdb.ts
@@ -181,6 +181,12 @@ const duckdbRenderedLayers = new Map<string, DuckDBRenderedLayerLike>();
 const duckdbRenderedRows = new Map<string, Record<number, Record<string, unknown>>>();
 const duckdbRenderedStyles = new Map<string, DuckDBRenderedStyle>();
 const warnedMissingRowsLayerIds = new Set<string>();
+// Global row index → local Arrow row index, built lazily per result chunk.
+// Keyed weakly so replaced query results release their maps automatically.
+const duckdbResultRowIndexMaps = new WeakMap<
+  DuckDBResultLike,
+  Map<number, number>
+>();
 const DUCKDB_SELECTED_FILL_COLOR: [number, number, number, number] = [
   250, 204, 21, 230,
 ];
@@ -255,7 +261,11 @@ export function getDuckDBFeatureBounds(
   if (!renderedLayer) return null;
 
   for (const result of renderedLayer.results) {
-    const localRowIndex = getDuckDBResultLocalRowIndex(result, index);
+    const localRowIndex = getDuckDBResultLocalRowIndex(
+      result,
+      index,
+      renderedLayer.results.length === 1,
+    );
     if (localRowIndex === null) continue;
 
     const geometry = result.table?.getChild?.("geometry")?.get?.(localRowIndex);
@@ -597,19 +607,26 @@ function patchDuckDBControlSelection(control: DuckDBControl): void {
   // so future patches can inspect or restore the library behavior.
   mutableControl.__geolibreOriginalShowAttributePopup =
     mutableControl.showAttributePopup?.bind(mutableControl);
-  mutableControl.showAttributePopup = () => {};
+  // While identify mode targets a DuckDB layer, MapCanvas already handles the
+  // click via identifyDuckDBLayerAtPoint and the selection store; letting the
+  // control's own callbacks run too would process the same click twice and
+  // show a duplicate popup. The control is only pickable in that mode (see
+  // syncDuckDBPickableFromStore), so outside it the originals run unchanged.
+  mutableControl.showAttributePopup = (coordinate) => {
+    if (isDuckDBIdentifyModeActive()) return;
+    mutableControl.__geolibreOriginalShowAttributePopup?.(coordinate);
+  };
   mutableControl.handleMapSelect = (selection) => {
-    // The control is only pickable while identify mode targets a DuckDB layer
-    // (see syncDuckDBPickableFromStore), and in that mode MapCanvas already
-    // handles the click via identifyDuckDBLayerAtPoint and the selection
-    // store; letting the overlay's own callback run too would process the
-    // same click twice.
-    const { identifyLayerId, layers } = useAppStore.getState();
-    const identifyLayer = layers.find((layer) => layer.id === identifyLayerId);
-    if (identifyLayer && isDuckDBQueryLayer(identifyLayer)) return;
+    if (isDuckDBIdentifyModeActive()) return;
     originalHandleMapSelect?.(selection);
   };
   mutableControl.__geolibreSelectionPatched = true;
+}
+
+function isDuckDBIdentifyModeActive(): boolean {
+  const { identifyLayerId, layers } = useAppStore.getState();
+  const identifyLayer = layers.find((layer) => layer.id === identifyLayerId);
+  return Boolean(identifyLayer && isDuckDBQueryLayer(identifyLayer));
 }
 
 // Mirror the store-driven selection into the control's own attribute pane so
@@ -991,6 +1008,7 @@ function getDuckDBDeckLayerIds(layerId: string): string[] {
 function getDuckDBResultLocalRowIndex(
   result: DuckDBResultLike,
   rowIndex: number,
+  isOnlyResult: boolean,
 ): number | null {
   const indexVector = result.table?.getChild?.("__index");
   const rowCount =
@@ -999,20 +1017,33 @@ function getDuckDBResultLocalRowIndex(
       : indexVector?.length;
   if (typeof rowCount !== "number" || rowCount <= 0) return null;
 
-  // Without an __index column the rows are stored in natural order, so the
-  // global row index addresses the chunk directly — no scan needed.
   if (!indexVector?.get) {
+    // Without an __index column a global row index cannot be attributed to
+    // one chunk among several; only a lone chunk, whose rows are stored in
+    // natural order, can be addressed directly.
+    if (!isOnlyResult) return null;
     return rowIndex >= 0 && rowIndex < rowCount ? rowIndex : null;
   }
 
-  for (let localIndex = 0; localIndex < rowCount; localIndex += 1) {
-    const value = indexVector.get(localIndex);
-    if (value === rowIndex) return localIndex;
-    if (typeof value === "bigint" && value === BigInt(rowIndex)) {
-      return localIndex;
+  let indexMap = duckdbResultRowIndexMaps.get(result);
+  if (!indexMap) {
+    // Build the global → local index map once per result so repeated lookups
+    // (one per zoom-to-feature) do not rescan the Arrow column.
+    indexMap = new Map();
+    for (let localIndex = 0; localIndex < rowCount; localIndex += 1) {
+      const value = indexVector.get(localIndex);
+      if (typeof value === "number" && Number.isFinite(value)) {
+        indexMap.set(value, localIndex);
+      } else if (
+        typeof value === "bigint" &&
+        value <= BigInt(Number.MAX_SAFE_INTEGER)
+      ) {
+        indexMap.set(Number(value), localIndex);
+      }
     }
+    duckdbResultRowIndexMaps.set(result, indexMap);
   }
-  return null;
+  return indexMap.get(rowIndex) ?? null;
 }
 
 function boundsFromDuckDBGeometryValue(

--- a/packages/plugins/src/plugins/maplibre-duckdb.ts
+++ b/packages/plugins/src/plugins/maplibre-duckdb.ts
@@ -34,11 +34,14 @@ type DuckDBRendererLike = {
   __geolibreOriginalSetData?: DuckDBRendererLike["setData"];
   __geolibreStylePatched?: boolean;
   __geolibreOriginalCreateLayers?: DuckDBRendererLike["createLayers"];
+  overlay?: DuckDBDeckOverlayLike;
+  setSelectedFeature?: (layerId: string | null, index: number | null) => void;
 };
 
 type DuckDBResultLike = {
   bounds?: [number, number, number, number];
   geometryType?: string;
+  table?: DuckDBArrowTableLike;
 };
 
 type DuckDBRenderedLayerLike = {
@@ -61,11 +64,32 @@ type DuckDBInternalLayer = Omit<DuckDBRenderedLayerLike, "results"> & {
   totalRows?: number;
 };
 
+type DuckDBPickInfo = {
+  coordinate: [number, number] | null;
+  index: number;
+  layerId: string;
+};
+
+type DuckDBSelection = {
+  index: number;
+  layerId: string;
+  layerName: string;
+  properties: Record<string, unknown>;
+};
+
 type MutableDuckDBControl = {
   beforeId?: string;
+  emit?: (event: string, data?: Record<string, unknown>) => void;
+  handleMapSelect?: (selection: DuckDBPickInfo | null) => void;
   layer?: DuckDBInternalLayer | null;
+  popup?: { remove?: () => void } | null;
   renderLayer?: () => Promise<void>;
+  renderContent?: () => void;
   renderer?: DuckDBRendererLike | null;
+  selectedFeature?: DuckDBSelection | null;
+  setPickable?: (pickable: boolean) => void;
+  showAttributePopup?: (coordinate: [number, number] | null) => void;
+  __geolibreSelectionPatched?: boolean;
 };
 
 interface DuckDBRenderedStyle {
@@ -73,6 +97,61 @@ interface DuckDBRenderedStyle {
   style: LayerStyle;
   visible: boolean;
 }
+
+export interface DuckDBAttributeRow {
+  featureId: string;
+  index: number;
+  properties: Record<string, unknown>;
+}
+
+export interface DuckDBIdentifyResult {
+  coordinate: [number, number] | null;
+  featureId: string;
+  index: number;
+  properties: Record<string, unknown>;
+}
+
+type DuckDBPickingInfo = {
+  coordinate?: number[];
+  index?: number;
+  layer?: { id?: string };
+  object?: Record<string, unknown>;
+  picked?: boolean;
+};
+
+type DuckDBDeckOverlayLike = {
+  pickObject?: (options: {
+    layerIds?: string[];
+    radius?: number;
+    x: number;
+    y: number;
+  }) => DuckDBPickingInfo | null;
+};
+
+type DuckDBArrowFieldLike = {
+  name?: string;
+};
+
+type DuckDBArrowVectorLike = {
+  get?: (index: number) => unknown;
+  length?: number;
+};
+
+type DuckDBArrowTableLike = {
+  getChild?: (name: string) => DuckDBArrowVectorLike | null;
+  numRows?: number;
+  schema?: {
+    fields?: DuckDBArrowFieldLike[];
+  };
+};
+
+type DuckDBGlobalBridge = {
+  getFeatureBounds: typeof getDuckDBFeatureBounds;
+  getLayerRows: typeof getDuckDBLayerRows;
+  identifyLayerAtPoint: typeof identifyDuckDBLayerAtPoint;
+  setSelectedFeature: typeof setDuckDBSelectedFeature;
+  updateLayerRows: typeof updateDuckDBLayerRows;
+};
 
 const duckdbControlPosition: GeoLibreMapControlPosition = "top-left";
 const DUCKDB_SAMPLE_DATABASE_URL =
@@ -101,9 +180,166 @@ const duckdbRenderedLayers = new Map<string, DuckDBRenderedLayerLike>();
 const duckdbRenderedRows = new Map<string, Record<number, Record<string, unknown>>>();
 const duckdbRenderedStyles = new Map<string, DuckDBRenderedStyle>();
 const warnedMissingRowsLayerIds = new Set<string>();
+const DUCKDB_SELECTED_FILL_COLOR: [number, number, number, number] = [
+  250, 204, 21, 230,
+];
+const DUCKDB_SELECTED_STROKE_COLOR: [number, number, number, number] = [
+  17, 24, 39, 255,
+];
+
+declare global {
+  interface Window {
+    __GEOLIBRE_DUCKDB__?: DuckDBGlobalBridge;
+  }
+}
+
+if (typeof window !== "undefined") {
+  window.__GEOLIBRE_DUCKDB__ = {
+    getFeatureBounds: getDuckDBFeatureBounds,
+    getLayerRows: getDuckDBLayerRows,
+    identifyLayerAtPoint: identifyDuckDBLayerAtPoint,
+    setSelectedFeature: setDuckDBSelectedFeature,
+    updateLayerRows: updateDuckDBLayerRows,
+  };
+}
 
 export function openDuckDBLayerPanel(app: GeoLibreAppAPI): void {
   void openStandaloneDuckDBControl(app);
+}
+
+export function getDuckDBLayerRows(layerId: string): DuckDBAttributeRow[] {
+  return Object.entries(getDuckDBRenderedRows(layerId))
+    .map(([key, properties]) => {
+      const numericKey = Number(key);
+      const rowIndex =
+        Number.isFinite(numericKey) && Number.isInteger(numericKey)
+          ? numericKey
+          : getRowIndexFromProperties(properties) ?? 0;
+      return {
+        featureId: String(rowIndex),
+        index: rowIndex,
+        properties: publicDuckDBProperties(properties),
+      };
+    })
+    .sort((first, second) => first.index - second.index);
+}
+
+export function setDuckDBSelectedFeature(
+  layerId: string,
+  featureId: string | null,
+): void {
+  if (!isKnownDuckDBLayer(layerId)) return;
+
+  const index =
+    featureId === null
+      ? null
+      : Number.isFinite(Number(featureId))
+        ? Number(featureId)
+        : null;
+  getMutableDuckDBControl()?.renderer?.setSelectedFeature?.(
+    index === null ? null : layerId,
+    index,
+  );
+  renderDuckDBCachedLayers();
+}
+
+export function getDuckDBFeatureBounds(
+  layerId: string,
+  featureId: string,
+): [number, number, number, number] | null {
+  const index = Number(featureId);
+  if (!Number.isFinite(index)) return null;
+
+  const renderedLayer = duckdbRenderedLayers.get(layerId);
+  if (!renderedLayer) return null;
+
+  for (const result of renderedLayer.results) {
+    const localRowIndex = getDuckDBResultLocalRowIndex(result, index);
+    if (localRowIndex === null) continue;
+
+    const geometry = result.table?.getChild?.("geometry")?.get?.(localRowIndex);
+    const bounds = boundsFromDuckDBGeometryValue(geometry);
+    if (bounds) return bounds;
+  }
+
+  return null;
+}
+
+export function updateDuckDBLayerRows(
+  layerId: string,
+  updates: Record<string, Record<string, unknown>>,
+): void {
+  const rows = getDuckDBRenderedRows(layerId);
+  if (Object.keys(rows).length === 0) return;
+
+  for (const [featureId, properties] of Object.entries(updates)) {
+    const index = Number(featureId);
+    if (!Number.isFinite(index)) continue;
+
+    const current = rows[index];
+    if (!current) continue;
+
+    rows[index] = {
+      ...current,
+      ...properties,
+    };
+  }
+
+  const control = getMutableDuckDBControl();
+  if (control?.layer?.id === layerId) {
+    control.layer.rows = rows;
+    if (
+      control.selectedFeature?.layerId === layerId &&
+      rows[control.selectedFeature.index]
+    ) {
+      control.selectedFeature = {
+        ...control.selectedFeature,
+        properties: rows[control.selectedFeature.index],
+      };
+    }
+    control.renderContent?.();
+  }
+
+  renderDuckDBCachedLayers();
+}
+
+export function identifyDuckDBLayerAtPoint(
+  layerId: string,
+  point: { x: number; y: number },
+): DuckDBIdentifyResult | null {
+  if (!isKnownDuckDBLayer(layerId)) return null;
+
+  const overlay = getMutableDuckDBControl()?.renderer?.overlay;
+  const deckLayerIds = getDuckDBDeckLayerIds(layerId);
+  const picked = overlay?.pickObject?.({
+    x: point.x,
+    y: point.y,
+    radius: 5,
+    layerIds: deckLayerIds.length > 0 ? deckLayerIds : undefined,
+  });
+  if (!picked?.picked || !isDuckDBDeckLayerId(layerId, picked.layer?.id)) {
+    return null;
+  }
+
+  const index =
+    getRowIndexFromProperties(picked.object) ??
+    (typeof picked.index === "number" && Number.isFinite(picked.index)
+      ? picked.index
+      : null);
+  if (index === null) return null;
+
+  const properties = getDuckDBRenderedRows(layerId)[index] ?? picked.object ?? {};
+  setDuckDBSelectedFeature(layerId, String(index));
+
+  return {
+    coordinate:
+      picked.coordinate && picked.coordinate.length >= 2
+        ? [picked.coordinate[0], picked.coordinate[1]]
+        : null,
+    featureId: String(index),
+    index,
+    properties: publicDuckDBProperties(properties),
+  };
 }
 
 async function openStandaloneDuckDBControl(
@@ -146,6 +382,8 @@ function createDuckDBControl(
   DuckDBControlClass: DuckDBControlConstructor,
 ): DuckDBControl {
   const control = new DuckDBControlClass(DUCKDB_OPTIONS);
+  patchDuckDBControlSelection(control);
+  syncDuckDBPickableFromStore();
   control.on("collapse", () => hideDuckDBControl(control));
   control.on("query", createDuckDBQueryHandler());
   control.on("statechange", createDuckDBStateChangeHandler());
@@ -183,6 +421,10 @@ function createDuckDBControl(
         duckdbLayerOrderSignature(previous.layers)
     ) {
       shouldSyncControl = true;
+    }
+
+    if (state.identifyLayerId !== previous.identifyLayerId) {
+      syncDuckDBPickableFromStore(state.layers, state.identifyLayerId);
     }
 
     if (shouldSyncControl) {
@@ -271,11 +513,17 @@ function createDuckDBStoreLayer(
   state: DuckDBState,
   layerState: DuckDBLayerState,
 ): GeoLibreLayer {
+  const controlLayer = getMutableDuckDBControl()?.layer;
+  const results = controlLayer?.results ?? controlLayer?.geoArrowResults ?? [];
+  const bounds = combineResultBounds(results);
+  const geometryTypes = getDuckDBGeometryTypes(results);
+
   return {
     id: layerState.id,
     name: layerState.name,
     type: "duckdb-query",
     source: {
+      bounds,
       databaseSource: state.databaseSource,
       displaySource: state.displaySource,
       query: layerState.query,
@@ -286,7 +534,9 @@ function createDuckDBStoreLayer(
     style: { ...DEFAULT_LAYER_STYLE },
     beforeId: layerState.beforeId ?? undefined,
     metadata: {
+      bounds,
       columns: layerState.schema,
+      customLayerType: getDuckDBCustomLayerType(geometryTypes),
       databaseSource: state.databaseSource,
       deckLayerId: layerState.id,
       displaySource: state.displaySource,
@@ -294,7 +544,8 @@ function createDuckDBStoreLayer(
       externalNativeLayer: true,
       geometryColumn: layerState.geometryColumn,
       geometryFormat: layerState.geometryFormat,
-      identifiable: false,
+      geometryTypes,
+      identifiable: true,
       loadedRows: layerState.loadedRows,
       pageSize: state.pageSize,
       query: layerState.query,
@@ -323,6 +574,59 @@ function clearDuckDBRenderedLayers(): void {
   duckdbRenderedStyles.clear();
   warnedMissingRowsLayerIds.clear();
   getMutableDuckDBControl()?.renderer?.clear?.();
+}
+
+function syncDuckDBPickableFromStore(
+  layers = useAppStore.getState().layers,
+  identifyLayerId = useAppStore.getState().identifyLayerId,
+): void {
+  const identifyLayer = layers.find((layer) => layer.id === identifyLayerId);
+  getMutableDuckDBControl()?.setPickable?.(
+    Boolean(identifyLayer && isDuckDBControlLayer(identifyLayer)),
+  );
+}
+
+function patchDuckDBControlSelection(control: DuckDBControl): void {
+  const mutableControl = getMutableDuckDBControl(control);
+  if (!mutableControl || mutableControl.__geolibreSelectionPatched) return;
+
+  const originalHandleMapSelect = mutableControl.handleMapSelect?.bind(
+    mutableControl,
+  );
+  mutableControl.showAttributePopup = () => {};
+  mutableControl.handleMapSelect = (selection) => {
+    if (!selection) {
+      originalHandleMapSelect?.(selection);
+      useAppStore.getState().selectFeature(null);
+      return;
+    }
+
+    const layer = useAppStore
+      .getState()
+      .layers.find((item) => item.id === selection.layerId);
+    const rows = getDuckDBRenderedRows(selection.layerId);
+    const properties = rows[selection.index] ?? { __index: selection.index };
+    const selectedFeature = {
+      index: selection.index,
+      layerId: selection.layerId,
+      layerName: layer?.name ?? selection.layerId,
+      properties,
+    };
+
+    mutableControl.selectedFeature = selectedFeature;
+    mutableControl.popup?.remove?.();
+    mutableControl.popup = null;
+    mutableControl.renderer?.setSelectedFeature?.(
+      selection.layerId,
+      selection.index,
+    );
+    renderDuckDBCachedLayers();
+    mutableControl.renderContent?.();
+    mutableControl.emit?.("select", { selection: selectedFeature });
+    mutableControl.emit?.("statechange");
+    useAppStore.getState().selectFeature(String(selection.index));
+  };
+  mutableControl.__geolibreSelectionPatched = true;
 }
 
 function syncDuckDBRenderedLayersFromStore(layers: GeoLibreLayer[]): void {
@@ -441,28 +745,34 @@ function cloneStyledDeckLayer(
   const geometry = geometryType?.toLowerCase() ?? "";
 
   if (geometry.includes("point")) {
+    const selectedRadius = selectedDuckDBPointRadius(style.circleRadius);
     return deckLayer.clone({
-      getFillColor: fillColor,
-      getRadius: style.circleRadius,
-      radiusMaxPixels: pointRadiusMaxPixels(style),
+      getFillColor: createDuckDBColorAccessor(layerId, fillColor),
+      getRadius: createDuckDBRadiusAccessor(layerId, style.circleRadius),
+      radiusMaxPixels: Math.max(pointRadiusMaxPixels(style), selectedRadius),
       radiusMinPixels: Math.max(1, Math.min(style.circleRadius, 4)),
       updateTriggers: {
         ...asRecord(deckLayer.props?.updateTriggers),
-        getFillColor: [style.fillColor, style.fillOpacity, opacity],
-        getRadius: [style.circleRadius],
+        getFillColor: [
+          style.fillColor,
+          style.fillOpacity,
+          opacity,
+          getSelectedDuckDBFeatureId(layerId),
+        ],
+        getRadius: [style.circleRadius, getSelectedDuckDBFeatureId(layerId)],
       },
     });
   }
 
   if (geometry.includes("line")) {
     return deckLayer.clone({
-      getColor: strokeColor,
-      getWidth: style.strokeWidth,
+      getColor: createDuckDBColorAccessor(layerId, strokeColor),
+      getWidth: createDuckDBLineWidthAccessor(layerId, style.strokeWidth),
       widthMinPixels: Math.max(1, style.strokeWidth),
       updateTriggers: {
         ...asRecord(deckLayer.props?.updateTriggers),
-        getColor: [style.strokeColor, opacity],
-        getWidth: [style.strokeWidth],
+        getColor: [style.strokeColor, opacity, getSelectedDuckDBFeatureId(layerId)],
+        getWidth: [style.strokeWidth, getSelectedDuckDBFeatureId(layerId)],
       },
     });
   }
@@ -470,10 +780,10 @@ function cloneStyledDeckLayer(
   return deckLayer.clone({
     elevationScale: style.extrusionHeightScale,
     extruded: style.extrusionEnabled,
-    getFillColor: fillColor,
+    getFillColor: createDuckDBColorAccessor(layerId, fillColor),
     getElevation: createDuckDBElevationAccessor(layerId, renderedStyle),
-    getLineColor: strokeColor,
-    getLineWidth: style.strokeWidth,
+    getLineColor: createDuckDBLineColorAccessor(layerId, strokeColor),
+    getLineWidth: createDuckDBLineWidthAccessor(layerId, style.strokeWidth),
     lineWidthMinPixels: Math.max(1, style.strokeWidth),
     updateTriggers: {
       ...asRecord(deckLayer.props?.updateTriggers),
@@ -482,11 +792,74 @@ function cloneStyledDeckLayer(
         style.extrusionHeightProperty,
         style.extrusionHeightScale,
       ],
-      getFillColor: [style.fillColor, style.fillOpacity, opacity],
-      getLineColor: [style.strokeColor, opacity],
-      getLineWidth: [style.strokeWidth],
+      getFillColor: [
+        style.fillColor,
+        style.fillOpacity,
+        opacity,
+        getSelectedDuckDBFeatureId(layerId),
+      ],
+      getLineColor: [
+        style.strokeColor,
+        opacity,
+        getSelectedDuckDBFeatureId(layerId),
+      ],
+      getLineWidth: [style.strokeWidth, getSelectedDuckDBFeatureId(layerId)],
     },
   });
+}
+
+function createDuckDBColorAccessor(
+  layerId: string,
+  fallbackColor: [number, number, number, number],
+) {
+  return (objectInfo: { data?: unknown; index?: number }) =>
+    isSelectedDuckDBObject(layerId, objectInfo)
+      ? DUCKDB_SELECTED_FILL_COLOR
+      : fallbackColor;
+}
+
+function createDuckDBLineColorAccessor(
+  layerId: string,
+  fallbackColor: [number, number, number, number],
+) {
+  return (objectInfo: { data?: unknown; index?: number }) =>
+    isSelectedDuckDBObject(layerId, objectInfo)
+      ? DUCKDB_SELECTED_STROKE_COLOR
+      : fallbackColor;
+}
+
+function createDuckDBRadiusAccessor(layerId: string, fallbackRadius: number) {
+  return (objectInfo: { data?: unknown; index?: number }) =>
+    isSelectedDuckDBObject(layerId, objectInfo)
+      ? selectedDuckDBPointRadius(fallbackRadius)
+      : fallbackRadius;
+}
+
+function selectedDuckDBPointRadius(fallbackRadius: number): number {
+  return Math.max(fallbackRadius + 3, fallbackRadius * 1.6);
+}
+
+function createDuckDBLineWidthAccessor(layerId: string, fallbackWidth: number) {
+  return (objectInfo: { data?: unknown; index?: number }) =>
+    isSelectedDuckDBObject(layerId, objectInfo)
+      ? Math.max(fallbackWidth + 3, fallbackWidth * 2)
+      : fallbackWidth;
+}
+
+function isSelectedDuckDBObject(
+  layerId: string,
+  objectInfo: { data?: unknown; index?: number },
+): boolean {
+  const selectedFeatureId = getSelectedDuckDBFeatureId(layerId);
+  if (selectedFeatureId === null) return false;
+
+  const rowIndex = getGeoArrowRowIndex(objectInfo);
+  return rowIndex !== null && String(rowIndex) === selectedFeatureId;
+}
+
+function getSelectedDuckDBFeatureId(layerId: string): string | null {
+  const state = useAppStore.getState();
+  return state.selectedLayerId === layerId ? state.selectedFeatureId : null;
 }
 
 function createDuckDBElevationAccessor(
@@ -549,6 +922,175 @@ function getDuckDBRenderedRows(layerId: string): Record<number, Record<string, u
     return {};
   }
   return rows;
+}
+
+function combineResultBounds(
+  results: DuckDBResultLike[] | undefined,
+): [number, number, number, number] | undefined {
+  const bounds = (results ?? [])
+    .map((result) => result.bounds)
+    .filter(isBounds);
+  if (bounds.length === 0) return undefined;
+
+  return [
+    Math.min(...bounds.map((item) => item[0])),
+    Math.min(...bounds.map((item) => item[1])),
+    Math.max(...bounds.map((item) => item[2])),
+    Math.max(...bounds.map((item) => item[3])),
+  ];
+}
+
+function isBounds(value: unknown): value is [number, number, number, number] {
+  return (
+    Array.isArray(value) &&
+    value.length === 4 &&
+    value.every((item) => typeof item === "number" && Number.isFinite(item))
+  );
+}
+
+function getDuckDBGeometryTypes(results: DuckDBResultLike[]): string[] {
+  return Array.from(
+    new Set(
+      results
+        .map((result) => result.geometryType)
+        .filter((item): item is string => typeof item === "string"),
+    ),
+  );
+}
+
+function getDuckDBCustomLayerType(geometryTypes: string[]): string {
+  const normalized = geometryTypes.map((type) => type.toLowerCase());
+  if (normalized.some((type) => type.includes("point"))) return "circle";
+  if (normalized.some((type) => type.includes("line"))) return "line";
+  if (normalized.some((type) => type.includes("polygon"))) return "fill";
+  return "custom";
+}
+
+function getDuckDBDeckLayerIds(layerId: string): string[] {
+  const renderedLayer = duckdbRenderedLayers.get(layerId);
+  return (renderedLayer?.results ?? [])
+    .map((result, index) =>
+      result.geometryType ? `duckdb-${layerId}-${result.geometryType}-${index}` : null,
+    )
+    .filter((id): id is string => typeof id === "string");
+}
+
+function getDuckDBResultLocalRowIndex(
+  result: DuckDBResultLike,
+  rowIndex: number,
+): number | null {
+  const indexVector = result.table?.getChild?.("__index");
+  const rowCount =
+    typeof result.table?.numRows === "number"
+      ? result.table.numRows
+      : indexVector?.length;
+  if (typeof rowCount !== "number" || rowCount <= 0) return null;
+
+  for (let localIndex = 0; localIndex < rowCount; localIndex += 1) {
+    const value = indexVector?.get?.(localIndex);
+    if (value === rowIndex) return localIndex;
+    if (typeof value === "bigint" && value === BigInt(rowIndex)) {
+      return localIndex;
+    }
+  }
+  return null;
+}
+
+function boundsFromDuckDBGeometryValue(
+  value: unknown,
+): [number, number, number, number] | null {
+  const bounds = createEmptyBounds();
+  collectGeometryBounds(value, bounds);
+  return isFiniteBounds(bounds) ? bounds : null;
+}
+
+function collectGeometryBounds(
+  value: unknown,
+  bounds: [number, number, number, number],
+): void {
+  if (!value) return;
+
+  if (Array.isArray(value)) {
+    if (value.length >= 2 && isFiniteNumber(value[0]) && isFiniteNumber(value[1])) {
+      extendBounds(bounds, value[0], value[1]);
+      return;
+    }
+    for (const item of value) collectGeometryBounds(item, bounds);
+    return;
+  }
+
+  const vector = value as DuckDBArrowVectorLike;
+  if (typeof vector.get !== "function" || typeof vector.length !== "number") {
+    return;
+  }
+
+  if (
+    vector.length >= 2 &&
+    isFiniteNumber(vector.get(0)) &&
+    isFiniteNumber(vector.get(1))
+  ) {
+    extendBounds(bounds, vector.get(0) as number, vector.get(1) as number);
+    return;
+  }
+
+  for (let index = 0; index < vector.length; index += 1) {
+    collectGeometryBounds(vector.get(index), bounds);
+  }
+}
+
+function createEmptyBounds(): [number, number, number, number] {
+  return [Infinity, Infinity, -Infinity, -Infinity];
+}
+
+function extendBounds(
+  bounds: [number, number, number, number],
+  x: number,
+  y: number,
+): void {
+  bounds[0] = Math.min(bounds[0], x);
+  bounds[1] = Math.min(bounds[1], y);
+  bounds[2] = Math.max(bounds[2], x);
+  bounds[3] = Math.max(bounds[3], y);
+}
+
+function isFiniteBounds(
+  bounds: [number, number, number, number],
+): bounds is [number, number, number, number] {
+  return bounds.every((value) => Number.isFinite(value));
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isDuckDBDeckLayerId(
+  layerId: string,
+  deckLayerId: string | undefined,
+): boolean {
+  return typeof deckLayerId === "string" && deckLayerId.startsWith(`duckdb-${layerId}-`);
+}
+
+function isKnownDuckDBLayer(layerId: string): boolean {
+  return duckdbRenderedLayers.has(layerId) || duckdbRenderedRows.has(layerId);
+}
+
+function getRowIndexFromProperties(
+  properties: Record<string, unknown> | undefined,
+): number | null {
+  const rawIndex = properties?.__index;
+  if (typeof rawIndex === "number" && Number.isFinite(rawIndex)) return rawIndex;
+  if (typeof rawIndex === "bigint" && rawIndex <= BigInt(Number.MAX_SAFE_INTEGER)) {
+    return Number(rawIndex);
+  }
+  return null;
+}
+
+function publicDuckDBProperties(
+  properties: Record<string, unknown>,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(properties).filter(([key]) => !key.startsWith("__")),
+  );
 }
 
 function warnMissingDuckDBRows(layerId: string): void {

--- a/packages/plugins/src/plugins/maplibre-duckdb.ts
+++ b/packages/plugins/src/plugins/maplibre-duckdb.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_LAYER_STYLE,
+  isDuckDBQueryLayer,
   type GeoLibreLayer,
   type LayerStyle,
   useAppStore,
@@ -79,7 +80,6 @@ type DuckDBSelection = {
 
 type MutableDuckDBControl = {
   beforeId?: string;
-  emit?: (event: string, data?: Record<string, unknown>) => void;
   handleMapSelect?: (selection: DuckDBPickInfo | null) => void;
   layer?: DuckDBInternalLayer | null;
   popup?: { remove?: () => void } | null;
@@ -89,6 +89,7 @@ type MutableDuckDBControl = {
   selectedFeature?: DuckDBSelection | null;
   setPickable?: (pickable: boolean) => void;
   showAttributePopup?: (coordinate: [number, number] | null) => void;
+  __geolibreOriginalShowAttributePopup?: MutableDuckDBControl["showAttributePopup"];
   __geolibreSelectionPatched?: boolean;
 };
 
@@ -230,16 +231,16 @@ export function setDuckDBSelectedFeature(
 ): void {
   if (!isKnownDuckDBLayer(layerId)) return;
 
+  // Row indices are integers; reject fractional or non-numeric ids outright
+  // so a bad id clears the selection instead of silently matching nothing.
+  const numericId = featureId === null ? null : Number(featureId);
   const index =
-    featureId === null
-      ? null
-      : Number.isFinite(Number(featureId))
-        ? Number(featureId)
-        : null;
+    numericId !== null && Number.isInteger(numericId) ? numericId : null;
   getMutableDuckDBControl()?.renderer?.setSelectedFeature?.(
     index === null ? null : layerId,
     index,
   );
+  syncDuckDBControlSelection(layerId, index);
   renderDuckDBCachedLayers();
 }
 
@@ -329,7 +330,6 @@ export function identifyDuckDBLayerAtPoint(
   if (index === null) return null;
 
   const properties = getDuckDBRenderedRows(layerId)[index] ?? picked.object ?? {};
-  setDuckDBSelectedFeature(layerId, String(index));
 
   return {
     coordinate:
@@ -394,7 +394,7 @@ function createDuckDBControl(
     let shouldSyncControl = false;
 
     for (const layer of previous.layers) {
-      if (!isDuckDBControlLayer(layer)) continue;
+      if (!isDuckDBQueryLayer(layer)) continue;
 
       const currentLayer = currentById.get(layer.id);
       if (!currentLayer) {
@@ -402,7 +402,7 @@ function createDuckDBControl(
         continue;
       }
 
-      if (!isDuckDBControlLayer(currentLayer)) continue;
+      if (!isDuckDBQueryLayer(currentLayer)) continue;
 
       if (
         currentLayer.opacity !== layer.opacity ||
@@ -502,7 +502,7 @@ function createDuckDBStateChangeHandler(): DuckDBControlEventHandler {
     // an empty set instead of flashing the remaining layers n-1 times.
     clearDuckDBRenderedLayers();
     for (const layer of store.layers) {
-      if (isDuckDBControlLayer(layer)) {
+      if (isDuckDBQueryLayer(layer)) {
         store.removeLayer(layer.id);
       }
     }
@@ -582,7 +582,7 @@ function syncDuckDBPickableFromStore(
 ): void {
   const identifyLayer = layers.find((layer) => layer.id === identifyLayerId);
   getMutableDuckDBControl()?.setPickable?.(
-    Boolean(identifyLayer && isDuckDBControlLayer(identifyLayer)),
+    Boolean(identifyLayer && isDuckDBQueryLayer(identifyLayer)),
   );
 }
 
@@ -593,50 +593,63 @@ function patchDuckDBControlSelection(control: DuckDBControl): void {
   const originalHandleMapSelect = mutableControl.handleMapSelect?.bind(
     mutableControl,
   );
+  // Keep the original around (matching the __geolibreOriginalSetData pattern)
+  // so future patches can inspect or restore the library behavior.
+  mutableControl.__geolibreOriginalShowAttributePopup =
+    mutableControl.showAttributePopup?.bind(mutableControl);
   mutableControl.showAttributePopup = () => {};
   mutableControl.handleMapSelect = (selection) => {
-    if (!selection) {
-      originalHandleMapSelect?.(selection);
-      useAppStore.getState().selectFeature(null);
-      return;
-    }
-
-    const layer = useAppStore
-      .getState()
-      .layers.find((item) => item.id === selection.layerId);
-    const rows = getDuckDBRenderedRows(selection.layerId);
-    const properties = rows[selection.index] ?? { __index: selection.index };
-    const selectedFeature = {
-      index: selection.index,
-      layerId: selection.layerId,
-      layerName: layer?.name ?? selection.layerId,
-      properties,
-    };
-
-    mutableControl.selectedFeature = selectedFeature;
-    mutableControl.popup?.remove?.();
-    mutableControl.popup = null;
-    mutableControl.renderer?.setSelectedFeature?.(
-      selection.layerId,
-      selection.index,
-    );
-    renderDuckDBCachedLayers();
-    mutableControl.renderContent?.();
-    mutableControl.emit?.("select", { selection: selectedFeature });
-    mutableControl.emit?.("statechange");
-    useAppStore.getState().selectFeature(String(selection.index));
+    // The control is only pickable while identify mode targets a DuckDB layer
+    // (see syncDuckDBPickableFromStore), and in that mode MapCanvas already
+    // handles the click via identifyDuckDBLayerAtPoint and the selection
+    // store; letting the overlay's own callback run too would process the
+    // same click twice.
+    const { identifyLayerId, layers } = useAppStore.getState();
+    const identifyLayer = layers.find((layer) => layer.id === identifyLayerId);
+    if (identifyLayer && isDuckDBQueryLayer(identifyLayer)) return;
+    originalHandleMapSelect?.(selection);
   };
   mutableControl.__geolibreSelectionPatched = true;
+}
+
+// Mirror the store-driven selection into the control's own attribute pane so
+// it stays consistent with the map highlight and the attribute table.
+function syncDuckDBControlSelection(
+  layerId: string,
+  index: number | null,
+): void {
+  const control = getMutableDuckDBControl();
+  if (!control) return;
+
+  if (index === null) {
+    if (control.selectedFeature?.layerId !== layerId) return;
+    control.selectedFeature = null;
+    control.renderContent?.();
+    return;
+  }
+
+  const layer = useAppStore
+    .getState()
+    .layers.find((item) => item.id === layerId);
+  control.selectedFeature = {
+    index,
+    layerId,
+    layerName: layer?.name ?? layerId,
+    properties: getDuckDBRenderedRows(layerId)[index] ?? { __index: index },
+  };
+  control.popup?.remove?.();
+  control.popup = null;
+  control.renderContent?.();
 }
 
 function syncDuckDBRenderedLayersFromStore(layers: GeoLibreLayer[]): void {
   duckdbLayerOrder.clear();
   layers
-    .filter(isDuckDBControlLayer)
+    .filter(isDuckDBQueryLayer)
     .forEach((layer, index) => duckdbLayerOrder.set(layer.id, index));
 
   for (const layer of layers) {
-    if (!isDuckDBControlLayer(layer)) continue;
+    if (!isDuckDBQueryLayer(layer)) continue;
 
     const renderedLayer = duckdbRenderedLayers.get(layer.id);
     if (!renderedLayer) continue;
@@ -986,8 +999,14 @@ function getDuckDBResultLocalRowIndex(
       : indexVector?.length;
   if (typeof rowCount !== "number" || rowCount <= 0) return null;
 
+  // Without an __index column the rows are stored in natural order, so the
+  // global row index addresses the chunk directly — no scan needed.
+  if (!indexVector?.get) {
+    return rowIndex >= 0 && rowIndex < rowCount ? rowIndex : null;
+  }
+
   for (let localIndex = 0; localIndex < rowCount; localIndex += 1) {
-    const value = indexVector?.get?.(localIndex);
+    const value = indexVector.get(localIndex);
     if (value === rowIndex) return localIndex;
     if (typeof value === "bigint" && value === BigInt(rowIndex)) {
       return localIndex;
@@ -1114,14 +1133,6 @@ function showDuckDBControl(control: DuckDBControl | null): void {
   if (container) container.style.display = "";
 }
 
-function isDuckDBControlLayer(layer: GeoLibreLayer): boolean {
-  return (
-    layer.type === "duckdb-query" &&
-    layer.metadata.sourceKind === "duckdb-query" &&
-    layer.metadata.externalDeckLayer === true
-  );
-}
-
 function getMutableDuckDBControl(
   control = duckdbControl,
 ): MutableDuckDBControl | null {
@@ -1147,5 +1158,5 @@ function createUniqueDuckDBLayerName(
 }
 
 function duckdbLayerOrderSignature(layers: GeoLibreLayer[]): string {
-  return layers.filter(isDuckDBControlLayer).map((layer) => layer.id).join("|");
+  return layers.filter(isDuckDBQueryLayer).map((layer) => layer.id).join("|");
 }

--- a/packages/plugins/src/plugins/maplibre-duckdb.ts
+++ b/packages/plugins/src/plugins/maplibre-duckdb.ts
@@ -337,7 +337,9 @@ export function identifyDuckDBLayerAtPoint(
 
   const index =
     getRowIndexFromProperties(picked.object) ??
-    (typeof picked.index === "number" && Number.isFinite(picked.index)
+    (typeof picked.index === "number" &&
+    Number.isFinite(picked.index) &&
+    picked.index >= 0
       ? picked.index
       : null);
   if (index === null) return null;
@@ -776,12 +778,16 @@ function cloneStyledDeckLayer(
   );
   const strokeColor = colorToRgba(style.strokeColor, opacity);
   const geometry = geometryType?.toLowerCase() ?? "";
+  // Captured once per clone; updateTriggers below include it, so deck.gl
+  // re-creates the accessors on selection changes and the closures never
+  // read the store per object.
+  const selectedFeatureId = getSelectedDuckDBFeatureId(layerId);
 
   if (geometry.includes("point")) {
     const selectedRadius = selectedDuckDBPointRadius(style.circleRadius);
     return deckLayer.clone({
-      getFillColor: createDuckDBColorAccessor(layerId, fillColor),
-      getRadius: createDuckDBRadiusAccessor(layerId, style.circleRadius),
+      getFillColor: createDuckDBColorAccessor(selectedFeatureId, fillColor),
+      getRadius: createDuckDBRadiusAccessor(selectedFeatureId, style.circleRadius),
       radiusMaxPixels: Math.max(pointRadiusMaxPixels(style), selectedRadius),
       radiusMinPixels: Math.max(1, Math.min(style.circleRadius, 4)),
       updateTriggers: {
@@ -790,22 +796,22 @@ function cloneStyledDeckLayer(
           style.fillColor,
           style.fillOpacity,
           opacity,
-          getSelectedDuckDBFeatureId(layerId),
+          selectedFeatureId,
         ],
-        getRadius: [style.circleRadius, getSelectedDuckDBFeatureId(layerId)],
+        getRadius: [style.circleRadius, selectedFeatureId],
       },
     });
   }
 
   if (geometry.includes("line")) {
     return deckLayer.clone({
-      getColor: createDuckDBColorAccessor(layerId, strokeColor),
-      getWidth: createDuckDBLineWidthAccessor(layerId, style.strokeWidth),
+      getColor: createDuckDBColorAccessor(selectedFeatureId, strokeColor),
+      getWidth: createDuckDBLineWidthAccessor(selectedFeatureId, style.strokeWidth),
       widthMinPixels: Math.max(1, style.strokeWidth),
       updateTriggers: {
         ...asRecord(deckLayer.props?.updateTriggers),
-        getColor: [style.strokeColor, opacity, getSelectedDuckDBFeatureId(layerId)],
-        getWidth: [style.strokeWidth, getSelectedDuckDBFeatureId(layerId)],
+        getColor: [style.strokeColor, opacity, selectedFeatureId],
+        getWidth: [style.strokeWidth, selectedFeatureId],
       },
     });
   }
@@ -813,10 +819,10 @@ function cloneStyledDeckLayer(
   return deckLayer.clone({
     elevationScale: style.extrusionHeightScale,
     extruded: style.extrusionEnabled,
-    getFillColor: createDuckDBColorAccessor(layerId, fillColor),
+    getFillColor: createDuckDBColorAccessor(selectedFeatureId, fillColor),
     getElevation: createDuckDBElevationAccessor(layerId, renderedStyle),
-    getLineColor: createDuckDBLineColorAccessor(layerId, strokeColor),
-    getLineWidth: createDuckDBLineWidthAccessor(layerId, style.strokeWidth),
+    getLineColor: createDuckDBLineColorAccessor(selectedFeatureId, strokeColor),
+    getLineWidth: createDuckDBLineWidthAccessor(selectedFeatureId, style.strokeWidth),
     lineWidthMinPixels: Math.max(1, style.strokeWidth),
     updateTriggers: {
       ...asRecord(deckLayer.props?.updateTriggers),
@@ -829,41 +835,44 @@ function cloneStyledDeckLayer(
         style.fillColor,
         style.fillOpacity,
         opacity,
-        getSelectedDuckDBFeatureId(layerId),
+        selectedFeatureId,
       ],
       getLineColor: [
         style.strokeColor,
         opacity,
-        getSelectedDuckDBFeatureId(layerId),
+        selectedFeatureId,
       ],
-      getLineWidth: [style.strokeWidth, getSelectedDuckDBFeatureId(layerId)],
+      getLineWidth: [style.strokeWidth, selectedFeatureId],
     },
   });
 }
 
 function createDuckDBColorAccessor(
-  layerId: string,
+  selectedFeatureId: string | null,
   fallbackColor: [number, number, number, number],
 ) {
   return (objectInfo: { data?: unknown; index?: number }) =>
-    isSelectedDuckDBObject(layerId, objectInfo)
+    isSelectedDuckDBObject(selectedFeatureId, objectInfo)
       ? DUCKDB_SELECTED_FILL_COLOR
       : fallbackColor;
 }
 
 function createDuckDBLineColorAccessor(
-  layerId: string,
+  selectedFeatureId: string | null,
   fallbackColor: [number, number, number, number],
 ) {
   return (objectInfo: { data?: unknown; index?: number }) =>
-    isSelectedDuckDBObject(layerId, objectInfo)
+    isSelectedDuckDBObject(selectedFeatureId, objectInfo)
       ? DUCKDB_SELECTED_STROKE_COLOR
       : fallbackColor;
 }
 
-function createDuckDBRadiusAccessor(layerId: string, fallbackRadius: number) {
+function createDuckDBRadiusAccessor(
+  selectedFeatureId: string | null,
+  fallbackRadius: number,
+) {
   return (objectInfo: { data?: unknown; index?: number }) =>
-    isSelectedDuckDBObject(layerId, objectInfo)
+    isSelectedDuckDBObject(selectedFeatureId, objectInfo)
       ? selectedDuckDBPointRadius(fallbackRadius)
       : fallbackRadius;
 }
@@ -872,18 +881,20 @@ function selectedDuckDBPointRadius(fallbackRadius: number): number {
   return Math.max(fallbackRadius + 3, fallbackRadius * 1.6);
 }
 
-function createDuckDBLineWidthAccessor(layerId: string, fallbackWidth: number) {
+function createDuckDBLineWidthAccessor(
+  selectedFeatureId: string | null,
+  fallbackWidth: number,
+) {
   return (objectInfo: { data?: unknown; index?: number }) =>
-    isSelectedDuckDBObject(layerId, objectInfo)
+    isSelectedDuckDBObject(selectedFeatureId, objectInfo)
       ? Math.max(fallbackWidth + 3, fallbackWidth * 2)
       : fallbackWidth;
 }
 
 function isSelectedDuckDBObject(
-  layerId: string,
+  selectedFeatureId: string | null,
   objectInfo: { data?: unknown; index?: number },
 ): boolean {
-  const selectedFeatureId = getSelectedDuckDBFeatureId(layerId);
   if (selectedFeatureId === null) return false;
 
   const rowIndex = getGeoArrowRowIndex(objectInfo);
@@ -1071,15 +1082,18 @@ function boundsFromDuckDBGeometryValue(
 function collectGeometryBounds(
   value: unknown,
   bounds: [number, number, number, number],
+  depth = 0,
 ): void {
-  if (!value) return;
+  // Well-formed GeoArrow geometries nest a handful of levels at most; the
+  // cap keeps malformed data from recursing unboundedly.
+  if (!value || depth > 10) return;
 
   if (Array.isArray(value)) {
     if (value.length >= 2 && isFiniteNumber(value[0]) && isFiniteNumber(value[1])) {
       extendBounds(bounds, value[0], value[1]);
       return;
     }
-    for (const item of value) collectGeometryBounds(item, bounds);
+    for (const item of value) collectGeometryBounds(item, bounds, depth + 1);
     return;
   }
 
@@ -1098,7 +1112,7 @@ function collectGeometryBounds(
   }
 
   for (let index = 0; index < vector.length; index += 1) {
-    collectGeometryBounds(vector.get(index), bounds);
+    collectGeometryBounds(vector.get(index), bounds, depth + 1);
   }
 }
 


### PR DESCRIPTION
## Summary
- Add a bridge between the DuckDB plugin and the map so DuckDB query layers support identify clicks, feature selection highlighting on the deck.gl overlay, and zoom-to-feature via per-feature bounds computed from the Arrow geometry data.
- Show DuckDB query rows in the attribute table with filtering, sorting, and in-memory editing of the displayed attributes.
- Handle degenerate point bounds in MapController.fitBounds by flying to the point instead of fitting a zero-area box.

## Test plan
- [x] `npm run build` passes
- [x] `npm run test:frontend` passes (22 tests)
- [ ] Load the sample DuckDB database, run a query, and click features on the map to verify identify popup and selection highlight
- [ ] Open the attribute table for a DuckDB query layer, select rows, edit values, and verify zoom-to-feature works for points, lines, and polygons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attribute table now supports DuckDB query layers alongside GeoJSON, including editing, saving, and exporting per layer type.
  * Map identify/pick works for DuckDB query layers and shows attribute popups.

* **User Experience**
  * Selected DuckDB features are highlighted, can be cleared, and selection-driven map zoom works.
  * Edit/Save/Export buttons, empty-state messages, and tooltips reflect DuckDB support.

* **Bug Fixes**
  * Zoom-to-selection correctly handles single-point features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->