### PR TITLE
fix: show GeoAgent layers in the layer panel

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -40,7 +40,7 @@
     "maplibre-gl-basemap-control": "^0.3.0",
     "maplibre-gl-components": "^0.18.1",
     "maplibre-gl-duckdb": "^0.2.0",
-    "maplibre-gl-earth-engine": "^0.4.0",
+    "maplibre-gl-earth-engine": "^0.4.1",
     "maplibre-gl-esri-wayback": "^0.1.0",
     "maplibre-gl-geo-editor": "^0.7.3",
     "maplibre-gl-geoagent": "^0.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "maplibre-gl-basemap-control": "^0.3.0",
         "maplibre-gl-components": "^0.18.1",
         "maplibre-gl-duckdb": "^0.2.0",
-        "maplibre-gl-earth-engine": "^0.4.0",
+        "maplibre-gl-earth-engine": "^0.4.1",
         "maplibre-gl-esri-wayback": "^0.1.0",
         "maplibre-gl-geo-editor": "^0.7.3",
         "maplibre-gl-geoagent": "^0.4.2",
@@ -10632,9 +10632,9 @@
       "license": "MIT"
     },
     "node_modules/maplibre-gl-earth-engine": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-earth-engine/-/maplibre-gl-earth-engine-0.4.0.tgz",
-      "integrity": "sha512-BboKkAFvkA8Urs0AkGToADcJyYbOgvk6P6J76U9M9xYx6yhb6wyzPyU3DcXJb4AJuet9B/rKeYwMesaMG5fatQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-earth-engine/-/maplibre-gl-earth-engine-0.4.1.tgz",
+      "integrity": "sha512-F2mv23adJY8K3H3XMGxbDad9fw87x79kcoeJyG5xKW8ps/y77z+9bgT6qo9EMxkmJgPo+9feQxOTNIzRgfYxwA==",
       "license": "MIT",
       "dependencies": {
         "@google/earthengine": "^1.7.29",
@@ -14635,7 +14635,7 @@
         "maplibre-gl-basemap-control": "^0.3.0",
         "maplibre-gl-components": "^0.18.1",
         "maplibre-gl-duckdb": "^0.2.0",
-        "maplibre-gl-earth-engine": "^0.4.0",
+        "maplibre-gl-earth-engine": "^0.4.1",
         "maplibre-gl-esri-wayback": "^0.1.0",
         "maplibre-gl-geo-editor": "^0.7.3",
         "maplibre-gl-geoagent": "^0.4.2",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -31,7 +31,7 @@
     "maplibre-gl-basemap-control": "^0.3.0",
     "maplibre-gl-components": "^0.18.1",
     "maplibre-gl-duckdb": "^0.2.0",
-    "maplibre-gl-earth-engine": "^0.4.0",
+    "maplibre-gl-earth-engine": "^0.4.1",
     "maplibre-gl-esri-wayback": "^0.1.0",
     "maplibre-gl-geo-editor": "^0.7.3",
     "maplibre-gl-geoagent": "^0.4.2",

--- a/packages/plugins/src/plugins/geoagent-layer-sync.ts
+++ b/packages/plugins/src/plugins/geoagent-layer-sync.ts
@@ -199,18 +199,25 @@ export function syncGeoAgentOverlaysToStore(
 
       // Only structural fields are refreshed here. Name, visibility, opacity,
       // and style are user-editable in the layer panel, so re-syncing them
-      // would clobber edits on every agent command.
+      // would clobber edits on every agent command. The geojson comparison is
+      // by reference: unchanged overlays keep the same record (and data
+      // object) between commands, while a removeOverlay-then-add cycle swaps
+      // it out even when the freed ids are reused.
       if (
         JSON.stringify(existing.metadata.nativeLayerIds) !==
           JSON.stringify(layer.metadata.nativeLayerIds) ||
         JSON.stringify(existing.metadata.sourceIds) !==
           JSON.stringify(layer.metadata.sourceIds) ||
-        existing.metadata.tileUrl !== layer.metadata.tileUrl
+        JSON.stringify(existing.source) !== JSON.stringify(layer.source) ||
+        existing.metadata.tileUrl !== layer.metadata.tileUrl ||
+        existing.sourcePath !== layer.sourcePath ||
+        existing.geojson !== layer.geojson
       ) {
         useAppStore.getState().updateLayer(layer.id, {
+          geojson: layer.geojson,
           metadata: { ...existing.metadata, ...layer.metadata },
           source: layer.source,
-          ...(layer.geojson ? { geojson: layer.geojson } : {}),
+          sourcePath: layer.sourcePath,
         });
       }
     }
@@ -357,8 +364,13 @@ function rasterOverlayOpacity(overlay: GeoAgentOverlayRecord): number {
 
 function nativeOverlayOpacity(overlay: GeoAgentOverlayRecord): number {
   for (const spec of overlay.layerSpecs ?? []) {
-    const opacity = numberValue(spec.layer.paint?.[`${spec.layer.type}-opacity`]);
-    if (opacity !== undefined) return clamp01(opacity);
+    const properties = NATIVE_OPACITY_PROPERTIES[spec.layer.type] ?? [
+      `${spec.layer.type}-opacity`,
+    ];
+    for (const property of properties) {
+      const opacity = numberValue(spec.layer.paint?.[property]);
+      if (opacity !== undefined) return clamp01(opacity);
+    }
   }
   return 1;
 }

--- a/packages/plugins/src/plugins/geoagent-layer-sync.ts
+++ b/packages/plugins/src/plugins/geoagent-layer-sync.ts
@@ -21,7 +21,12 @@ export type GeoAgentOverlayRecord = {
   style?: Record<string, unknown>;
   attribution?: string;
   layerSpecs?: Array<{
-    layer: { id: string; type: string; paint?: Record<string, unknown> };
+    layer: {
+      id: string;
+      type: string;
+      paint?: Record<string, unknown>;
+      [key: string]: unknown;
+    };
     beforeId?: string;
   }>;
   geeLayerName?: string;
@@ -90,13 +95,19 @@ function isSyncableOverlay(overlay: GeoAgentOverlayRecord): boolean {
 export function createGeoAgentStoreLayer(
   overlay: GeoAgentOverlayRecord,
 ): GeoLibreLayer {
+  // Native overlays may only reference sources that already exist on the
+  // map, so sourceIds can legitimately be empty; omit sourceId rather than
+  // leaking `undefined` into the layer.
+  const sourceId = overlay.sourceIds[0]
+    ? { sourceId: overlay.sourceIds[0] }
+    : {};
   const base: GeoLibreLayer = {
     id: geoAgentStoreLayerId(overlay.name),
     name: overlay.name,
     type: "raster",
     source: {
       type: "raster",
-      sourceId: overlay.sourceIds[0],
+      ...sourceId,
       ...(overlay.url ? { tiles: [overlay.url] } : {}),
       ...(overlay.attribution ? { attribution: overlay.attribution } : {}),
     },
@@ -108,7 +119,7 @@ export function createGeoAgentStoreLayer(
       geoAgentOverlayKind: overlay.kind,
       geoAgentOverlayName: overlay.name,
       nativeLayerIds: [...overlay.layerIds],
-      sourceId: overlay.sourceIds[0],
+      ...sourceId,
       sourceIds: [...overlay.sourceIds],
       sourceKind: GEOAGENT_SOURCE_KIND,
     },
@@ -121,7 +132,7 @@ export function createGeoAgentStoreLayer(
       type: "geojson",
       source: {
         type: "geojson",
-        sourceId: overlay.sourceIds[0],
+        ...sourceId,
         ...(overlay.url ? { url: overlay.url } : {}),
       },
       ...(isFeatureCollection(overlay.data) ? { geojson: overlay.data } : {}),
@@ -134,7 +145,9 @@ export function createGeoAgentStoreLayer(
     // 3D buildings, ...) whose paint is agent-authored, often with data-driven
     // expressions. customLayerType makes layer-sync manage ordering only, so
     // the store's generic style never clobbers that paint; the GeoAgent
-    // plugin applies visibility/opacity itself.
+    // plugin applies visibility/opacity itself. Beyond gating that behavior,
+    // the value feeds map-controller's getLayerSymbolType fallback for the
+    // layer control's symbol when no native layer is on the map.
     return {
       ...base,
       opacity: nativeOverlayOpacity(overlay),
@@ -218,6 +231,7 @@ export function syncGeoAgentOverlaysToStore(
           metadata: { ...existing.metadata, ...layer.metadata },
           source: layer.source,
           sourcePath: layer.sourcePath,
+          type: layer.type,
         });
       }
     }
@@ -232,10 +246,15 @@ export function syncGeoAgentOverlaysToStore(
  * from the map.
  */
 export function removeGeoAgentStoreLayers(): void {
-  for (const layer of useAppStore.getState().layers) {
-    if (isGeoAgentStoreLayer(layer)) {
-      useAppStore.getState().removeLayer(layer.id);
+  syncingOverlaysToStore = true;
+  try {
+    for (const layer of useAppStore.getState().layers) {
+      if (isGeoAgentStoreLayer(layer)) {
+        useAppStore.getState().removeLayer(layer.id);
+      }
     }
+  } finally {
+    syncingOverlaysToStore = false;
   }
 }
 
@@ -351,10 +370,14 @@ function geoJsonOverlayStyle(
     fillColor,
     strokeColor,
     fillOpacity,
-    strokeWidth:
+    strokeWidth: Math.max(
+      0,
       numberValue(style["line-width"]) ?? numberValue(style.lineWidth) ?? 2,
-    circleRadius:
+    ),
+    circleRadius: Math.max(
+      0,
       numberValue(style["circle-radius"]) ?? numberValue(style.radius) ?? 6,
+    ),
   };
 }
 
@@ -362,12 +385,12 @@ function rasterOverlayOpacity(overlay: GeoAgentOverlayRecord): number {
   return clamp01(numberValue(overlay.style?.opacity) ?? 1);
 }
 
+// Uses the same NATIVE_OPACITY_PROPERTIES lookup (and no-op for unlisted
+// types) as applyGeoAgentCustomLayerState, so the panel never seeds an
+// opacity it cannot later apply back to the map.
 function nativeOverlayOpacity(overlay: GeoAgentOverlayRecord): number {
   for (const spec of overlay.layerSpecs ?? []) {
-    const properties = NATIVE_OPACITY_PROPERTIES[spec.layer.type] ?? [
-      `${spec.layer.type}-opacity`,
-    ];
-    for (const property of properties) {
+    for (const property of NATIVE_OPACITY_PROPERTIES[spec.layer.type] ?? []) {
       const opacity = numberValue(spec.layer.paint?.[property]);
       if (opacity !== undefined) return clamp01(opacity);
     }
@@ -382,14 +405,16 @@ function isFeatureCollection(
 }
 
 function stringValue(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
 }
 
 function numberValue(value: unknown): number | undefined {
-  const numeric =
-    typeof value === "number" || typeof value === "string"
-      ? Number(value)
-      : Number.NaN;
+  if (typeof value !== "number" && typeof value !== "string") return undefined;
+  // Number("") is 0; treat blank strings as absent rather than zero.
+  if (typeof value === "string" && !value.trim()) return undefined;
+  const numeric = Number(value);
   return Number.isFinite(numeric) ? numeric : undefined;
 }
 

--- a/packages/plugins/src/plugins/geoagent-layer-sync.ts
+++ b/packages/plugins/src/plugins/geoagent-layer-sync.ts
@@ -89,7 +89,11 @@ export function geoAgentOverlayName(layer: GeoLibreLayer): string {
  * "__sky") are map state rather than layers, so both are excluded.
  */
 function isSyncableOverlay(overlay: GeoAgentOverlayRecord): boolean {
-  return !overlay.name.startsWith("__") && overlay.layerIds.length > 0;
+  return (
+    overlay.kind !== "marker" &&
+    !overlay.name.startsWith("__") &&
+    overlay.layerIds.length > 0
+  );
 }
 
 export function createGeoAgentStoreLayer(
@@ -206,7 +210,13 @@ export function syncGeoAgentOverlaysToStore(
         .layers.find((current) => current.id === layer.id);
 
       if (!existing) {
+        // addLayer selects the new layer; agent-driven adds happen in the
+        // background and must not steal the user's panel selection.
+        const selectedLayerId = useAppStore.getState().selectedLayerId;
         useAppStore.getState().addLayer(layer);
+        if (useAppStore.getState().selectedLayerId !== selectedLayerId) {
+          useAppStore.setState({ selectedLayerId });
+        }
         continue;
       }
 
@@ -230,7 +240,10 @@ export function syncGeoAgentOverlaysToStore(
       ) {
         useAppStore.getState().updateLayer(layer.id, {
           geojson: layer.geojson,
-          metadata: { ...existing.metadata, ...layer.metadata },
+          // Replace metadata wholesale (like the Earth Engine plugin does):
+          // merging would let kind-specific keys (customLayerType, tileUrl,
+          // identifiable) survive a kind change and misroute layer-sync.
+          metadata: layer.metadata,
           source: layer.source,
           sourcePath: layer.sourcePath,
           type: layer.type,
@@ -287,6 +300,10 @@ export function wireGeoAgentStoreSync(tools: GeoAgentSyncableTools): void {
     ) {
       return;
     }
+
+    // The subscriber fires on every layers change; skip the per-layer scan
+    // when the previous snapshot held no GeoAgent layers at all.
+    if (!previous.layers.some(isGeoAgentStoreLayer)) return;
 
     const currentById = new Map(state.layers.map((layer) => [layer.id, layer]));
     for (const layer of previous.layers) {
@@ -393,7 +410,10 @@ function rasterOverlayOpacity(overlay: GeoAgentOverlayRecord): number {
 
 // Uses the same NATIVE_OPACITY_PROPERTIES lookup (and no-op for unlisted
 // types) as applyGeoAgentCustomLayerState, so the panel never seeds an
-// opacity it cannot later apply back to the map.
+// opacity it cannot later apply back to the map. First match wins: the panel
+// models a single opacity per layer, so a heterogeneous multi-spec overlay is
+// seeded from its first recognised spec and homogenised on the first slider
+// change — keep both functions on the same lookup and first-match contract.
 function nativeOverlayOpacity(overlay: GeoAgentOverlayRecord): number {
   for (const spec of overlay.layerSpecs ?? []) {
     for (const property of NATIVE_OPACITY_PROPERTIES[spec.layer.type] ?? []) {

--- a/packages/plugins/src/plugins/geoagent-layer-sync.ts
+++ b/packages/plugins/src/plugins/geoagent-layer-sync.ts
@@ -1,0 +1,365 @@
+import {
+  DEFAULT_LAYER_STYLE,
+  type GeoLibreLayer,
+  useAppStore,
+} from "@geolibre/core";
+import type { FeatureCollection } from "geojson";
+
+/**
+ * Mirrors the private `Overlay` record kept by MapLibreAgentTools in
+ * maplibre-gl-geoagent (verified against v0.4.2). The tools instance exposes
+ * these through its `overlays` Map; re-verify the shape when bumping the
+ * dependency.
+ */
+export type GeoAgentOverlayRecord = {
+  kind: "geojson" | "raster" | "basemap" | "marker" | "native" | "gee";
+  name: string;
+  sourceIds: string[];
+  layerIds: string[];
+  data?: GeoJSON.GeoJSON;
+  url?: string;
+  style?: Record<string, unknown>;
+  attribution?: string;
+  layerSpecs?: Array<{
+    layer: { id: string; type: string; paint?: Record<string, unknown> };
+    beforeId?: string;
+  }>;
+  geeLayerName?: string;
+};
+
+/**
+ * The slice of the GeoAgent tools surface the store -> GeoAgent sync needs.
+ * Structural (rather than maplibre-gl types) so tests can pass fakes.
+ */
+export type GeoAgentSyncableTools = {
+  map?: {
+    getLayer: (id: string) => { type: string } | undefined;
+    setLayoutProperty: (id: string, property: string, value: unknown) => unknown;
+    setPaintProperty: (id: string, property: string, value: unknown) => unknown;
+  };
+  removeOverlay?: (name: string) => boolean;
+};
+
+const GEOAGENT_SOURCE_KIND = "geoagent-overlay";
+
+const NATIVE_OPACITY_PROPERTIES: Record<string, string[]> = {
+  background: ["background-opacity"],
+  circle: ["circle-opacity"],
+  fill: ["fill-opacity"],
+  "fill-extrusion": ["fill-extrusion-opacity"],
+  heatmap: ["heatmap-opacity"],
+  line: ["line-opacity"],
+  raster: ["raster-opacity"],
+  symbol: ["icon-opacity", "text-opacity"],
+};
+
+let syncedTools: GeoAgentSyncableTools | null = null;
+let storeUnsubscribe: (() => void) | null = null;
+
+export function geoAgentStoreLayerId(overlayName: string): string {
+  return `geoagent:${overlayName}`;
+}
+
+export function isGeoAgentStoreLayer(layer: GeoLibreLayer): boolean {
+  return (
+    layer.metadata.sourceKind === GEOAGENT_SOURCE_KIND &&
+    layer.metadata.externalNativeLayer === true
+  );
+}
+
+export function geoAgentOverlayName(layer: GeoLibreLayer): string {
+  return typeof layer.metadata.geoAgentOverlayName === "string"
+    ? layer.metadata.geoAgentOverlayName
+    : layer.name;
+}
+
+/**
+ * Overlays the GeoAgent tools track that should appear in GeoLibre's layer
+ * panel. Markers carry no style layers and internal records ("__terrain",
+ * "__sky") are map state rather than layers, so both are excluded.
+ */
+function isSyncableOverlay(overlay: GeoAgentOverlayRecord): boolean {
+  return !overlay.name.startsWith("__") && overlay.layerIds.length > 0;
+}
+
+export function createGeoAgentStoreLayer(
+  overlay: GeoAgentOverlayRecord,
+): GeoLibreLayer {
+  const base: GeoLibreLayer = {
+    id: geoAgentStoreLayerId(overlay.name),
+    name: overlay.name,
+    type: "raster",
+    source: {
+      type: "raster",
+      sourceId: overlay.sourceIds[0],
+      ...(overlay.url ? { tiles: [overlay.url] } : {}),
+      ...(overlay.attribution ? { attribution: overlay.attribution } : {}),
+    },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {
+      externalNativeLayer: true,
+      geoAgentOverlayKind: overlay.kind,
+      geoAgentOverlayName: overlay.name,
+      nativeLayerIds: [...overlay.layerIds],
+      sourceId: overlay.sourceIds[0],
+      sourceIds: [...overlay.sourceIds],
+      sourceKind: GEOAGENT_SOURCE_KIND,
+    },
+    sourcePath: overlay.url ?? overlay.name,
+  };
+
+  if (overlay.kind === "geojson") {
+    return {
+      ...base,
+      type: "geojson",
+      source: {
+        type: "geojson",
+        sourceId: overlay.sourceIds[0],
+        ...(overlay.url ? { url: overlay.url } : {}),
+      },
+      ...(isFeatureCollection(overlay.data) ? { geojson: overlay.data } : {}),
+      style: geoJsonOverlayStyle(overlay.style ?? {}),
+    };
+  }
+
+  if (overlay.kind === "native") {
+    // Native overlays replay arbitrary layer specs (clusters, choropleths,
+    // 3D buildings, ...) whose paint is agent-authored, often with data-driven
+    // expressions. customLayerType makes layer-sync manage ordering only, so
+    // the store's generic style never clobbers that paint; the GeoAgent
+    // plugin applies visibility/opacity itself.
+    return {
+      ...base,
+      opacity: nativeOverlayOpacity(overlay),
+      metadata: {
+        ...base.metadata,
+        customLayerType: overlay.layerSpecs?.[0]?.layer.type ?? "custom",
+        identifiable: false,
+      },
+    };
+  }
+
+  // raster, basemap, and gee overlays are all single raster tile layers.
+  return {
+    ...base,
+    opacity: rasterOverlayOpacity(overlay),
+    metadata: {
+      ...base.metadata,
+      identifiable: false,
+      tileType: "raster",
+      ...(overlay.url ? { tileUrl: overlay.url } : {}),
+      ...(overlay.attribution ? { attribution: overlay.attribution } : {}),
+    },
+  };
+}
+
+/**
+ * Diff the GeoAgent tools' overlay registry into the app store so the layer
+ * panel lists agent-added layers. Adds new overlays, drops store layers whose
+ * overlays are gone, and refreshes native ids when an overlay is re-added,
+ * while leaving user-editable fields (name, visibility, opacity, style)
+ * untouched on existing layers.
+ */
+export function syncGeoAgentOverlaysToStore(
+  overlays: ReadonlyMap<string, GeoAgentOverlayRecord> | undefined,
+): void {
+  if (!overlays) return;
+
+  const syncable = Array.from(overlays.values()).filter(isSyncableOverlay);
+  const syncableIds = new Set(
+    syncable.map((overlay) => geoAgentStoreLayerId(overlay.name)),
+  );
+
+  for (const storeLayer of useAppStore.getState().layers) {
+    if (!isGeoAgentStoreLayer(storeLayer)) continue;
+    if (!syncableIds.has(storeLayer.id)) {
+      useAppStore.getState().removeLayer(storeLayer.id);
+    }
+  }
+
+  for (const overlay of syncable) {
+    const layer = createGeoAgentStoreLayer(overlay);
+    const existing = useAppStore
+      .getState()
+      .layers.find((current) => current.id === layer.id);
+
+    if (!existing) {
+      useAppStore.getState().addLayer(layer);
+      continue;
+    }
+
+    // Only structural fields are refreshed here. Name, visibility, opacity,
+    // and style are user-editable in the layer panel, so re-syncing them
+    // would clobber edits on every agent command.
+    if (
+      JSON.stringify(existing.metadata.nativeLayerIds) !==
+        JSON.stringify(layer.metadata.nativeLayerIds) ||
+      JSON.stringify(existing.metadata.sourceIds) !==
+        JSON.stringify(layer.metadata.sourceIds) ||
+      existing.metadata.tileUrl !== layer.metadata.tileUrl
+    ) {
+      useAppStore.getState().updateLayer(layer.id, {
+        metadata: { ...existing.metadata, ...layer.metadata },
+        source: layer.source,
+        ...(layer.geojson ? { geojson: layer.geojson } : {}),
+      });
+    }
+  }
+}
+
+/**
+ * Remove every GeoAgent-registered layer from the store. Used when the plugin
+ * deactivates, after the control's teardown has already cleared the overlays
+ * from the map.
+ */
+export function removeGeoAgentStoreLayers(): void {
+  for (const layer of useAppStore.getState().layers) {
+    if (isGeoAgentStoreLayer(layer)) {
+      useAppStore.getState().removeLayer(layer.id);
+    }
+  }
+}
+
+/**
+ * Watch the store for panel-side changes to GeoAgent layers. Removing a layer
+ * in the panel drops GeoAgent's overlay record (the native layers and sources
+ * are already torn down by removeLayerFromMap), so the overlay is not
+ * resurrected on the agent's next basemap change and list_layers stays
+ * accurate. Custom native layers (clusters, choropleths, 3D buildings) skip
+ * the generic visibility/paint sync in layer-sync, so visibility and opacity
+ * are applied here directly.
+ *
+ * Subscribes once; later calls just point the sync at the latest tools
+ * instance (the control recreates tools on every onAdd).
+ */
+export function wireGeoAgentStoreSync(tools: GeoAgentSyncableTools): void {
+  syncedTools = tools;
+  storeUnsubscribe ??= useAppStore.subscribe((state, previous) => {
+    const activeTools = syncedTools;
+    if (!activeTools || state.layers === previous.layers) return;
+
+    const currentById = new Map(state.layers.map((layer) => [layer.id, layer]));
+    for (const layer of previous.layers) {
+      if (!isGeoAgentStoreLayer(layer)) continue;
+
+      const current = currentById.get(layer.id);
+      if (!current) {
+        activeTools.removeOverlay?.(geoAgentOverlayName(layer));
+        continue;
+      }
+
+      if (
+        typeof current.metadata.customLayerType === "string" &&
+        (current.visible !== layer.visible ||
+          current.opacity !== layer.opacity)
+      ) {
+        applyGeoAgentCustomLayerState(activeTools.map, current);
+      }
+    }
+  });
+}
+
+export function unwireGeoAgentStoreSync(): void {
+  storeUnsubscribe?.();
+  storeUnsubscribe = null;
+  syncedTools = null;
+}
+
+function applyGeoAgentCustomLayerState(
+  map: GeoAgentSyncableTools["map"],
+  layer: GeoLibreLayer,
+): void {
+  if (!map) return;
+
+  const nativeLayerIds = Array.isArray(layer.metadata.nativeLayerIds)
+    ? layer.metadata.nativeLayerIds
+    : [];
+  for (const nativeLayerId of nativeLayerIds) {
+    if (typeof nativeLayerId !== "string") continue;
+    const nativeLayer = map.getLayer(nativeLayerId);
+    if (!nativeLayer) continue;
+
+    try {
+      map.setLayoutProperty(
+        nativeLayerId,
+        "visibility",
+        layer.visible ? "visible" : "none",
+      );
+    } catch {
+      // Custom layers from external controls may not accept layout updates.
+    }
+    for (const property of NATIVE_OPACITY_PROPERTIES[nativeLayer.type] ?? []) {
+      try {
+        map.setPaintProperty(nativeLayerId, property, layer.opacity);
+      } catch {
+        // Ignore paint properties a heterogeneous native layer rejects.
+      }
+    }
+  }
+}
+
+/**
+ * Map a GeoAgent geojson overlay style onto GeoLibre's LayerStyle using the
+ * same keys and defaults as geojsonLayerPaint in maplibre-gl-geoagent, so the
+ * store-driven repaint reproduces what the agent drew.
+ */
+function geoJsonOverlayStyle(
+  style: Record<string, unknown>,
+): GeoLibreLayer["style"] {
+  const color =
+    stringValue(style.color) ?? stringValue(style["line-color"]) ?? "#1c7ed6";
+  const fillColor =
+    stringValue(style["fill-color"]) ?? stringValue(style.fillColor) ?? color;
+  const strokeColor =
+    stringValue(style["line-color"]) ?? stringValue(style.lineColor) ?? color;
+  const fillOpacity = clamp01(
+    numberValue(style.opacity) ?? numberValue(style["fill-opacity"]) ?? 0.35,
+  );
+
+  return {
+    ...DEFAULT_LAYER_STYLE,
+    fillColor,
+    strokeColor,
+    fillOpacity,
+    strokeWidth:
+      numberValue(style["line-width"]) ?? numberValue(style.lineWidth) ?? 2,
+    circleRadius:
+      numberValue(style["circle-radius"]) ?? numberValue(style.radius) ?? 6,
+  };
+}
+
+function rasterOverlayOpacity(overlay: GeoAgentOverlayRecord): number {
+  return clamp01(numberValue(overlay.style?.opacity) ?? 1);
+}
+
+function nativeOverlayOpacity(overlay: GeoAgentOverlayRecord): number {
+  for (const spec of overlay.layerSpecs ?? []) {
+    const opacity = numberValue(spec.layer.paint?.[`${spec.layer.type}-opacity`]);
+    if (opacity !== undefined) return clamp01(opacity);
+  }
+  return 1;
+}
+
+function isFeatureCollection(
+  data: GeoJSON.GeoJSON | undefined,
+): data is FeatureCollection {
+  return data?.type === "FeatureCollection";
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  const numeric =
+    typeof value === "number" || typeof value === "string"
+      ? Number(value)
+      : Number.NaN;
+  return Number.isFinite(numeric) ? numeric : undefined;
+}
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}

--- a/packages/plugins/src/plugins/geoagent-layer-sync.ts
+++ b/packages/plugins/src/plugins/geoagent-layer-sync.ts
@@ -55,6 +55,11 @@ const NATIVE_OPACITY_PROPERTIES: Record<string, string[]> = {
 
 let syncedTools: GeoAgentSyncableTools | null = null;
 let storeUnsubscribe: (() => void) | null = null;
+// Guards the store subscriber against re-entrancy: store mutations made by
+// syncGeoAgentOverlaysToStore fire the subscriber synchronously, which would
+// otherwise echo removeOverlay calls back at GeoAgent for overlays it already
+// dropped from its own registry.
+let syncingOverlaysToStore = false;
 
 export function geoAgentStoreLayerId(overlayName: string): string {
   return `geoagent:${overlayName}`;
@@ -172,40 +177,45 @@ export function syncGeoAgentOverlaysToStore(
     syncable.map((overlay) => geoAgentStoreLayerId(overlay.name)),
   );
 
-  for (const storeLayer of useAppStore.getState().layers) {
-    if (!isGeoAgentStoreLayer(storeLayer)) continue;
-    if (!syncableIds.has(storeLayer.id)) {
-      useAppStore.getState().removeLayer(storeLayer.id);
-    }
-  }
-
-  for (const overlay of syncable) {
-    const layer = createGeoAgentStoreLayer(overlay);
-    const existing = useAppStore
-      .getState()
-      .layers.find((current) => current.id === layer.id);
-
-    if (!existing) {
-      useAppStore.getState().addLayer(layer);
-      continue;
+  syncingOverlaysToStore = true;
+  try {
+    for (const storeLayer of useAppStore.getState().layers) {
+      if (!isGeoAgentStoreLayer(storeLayer)) continue;
+      if (!syncableIds.has(storeLayer.id)) {
+        useAppStore.getState().removeLayer(storeLayer.id);
+      }
     }
 
-    // Only structural fields are refreshed here. Name, visibility, opacity,
-    // and style are user-editable in the layer panel, so re-syncing them
-    // would clobber edits on every agent command.
-    if (
-      JSON.stringify(existing.metadata.nativeLayerIds) !==
-        JSON.stringify(layer.metadata.nativeLayerIds) ||
-      JSON.stringify(existing.metadata.sourceIds) !==
-        JSON.stringify(layer.metadata.sourceIds) ||
-      existing.metadata.tileUrl !== layer.metadata.tileUrl
-    ) {
-      useAppStore.getState().updateLayer(layer.id, {
-        metadata: { ...existing.metadata, ...layer.metadata },
-        source: layer.source,
-        ...(layer.geojson ? { geojson: layer.geojson } : {}),
-      });
+    for (const overlay of syncable) {
+      const layer = createGeoAgentStoreLayer(overlay);
+      const existing = useAppStore
+        .getState()
+        .layers.find((current) => current.id === layer.id);
+
+      if (!existing) {
+        useAppStore.getState().addLayer(layer);
+        continue;
+      }
+
+      // Only structural fields are refreshed here. Name, visibility, opacity,
+      // and style are user-editable in the layer panel, so re-syncing them
+      // would clobber edits on every agent command.
+      if (
+        JSON.stringify(existing.metadata.nativeLayerIds) !==
+          JSON.stringify(layer.metadata.nativeLayerIds) ||
+        JSON.stringify(existing.metadata.sourceIds) !==
+          JSON.stringify(layer.metadata.sourceIds) ||
+        existing.metadata.tileUrl !== layer.metadata.tileUrl
+      ) {
+        useAppStore.getState().updateLayer(layer.id, {
+          metadata: { ...existing.metadata, ...layer.metadata },
+          source: layer.source,
+          ...(layer.geojson ? { geojson: layer.geojson } : {}),
+        });
+      }
     }
+  } finally {
+    syncingOverlaysToStore = false;
   }
 }
 
@@ -238,7 +248,13 @@ export function wireGeoAgentStoreSync(tools: GeoAgentSyncableTools): void {
   syncedTools = tools;
   storeUnsubscribe ??= useAppStore.subscribe((state, previous) => {
     const activeTools = syncedTools;
-    if (!activeTools || state.layers === previous.layers) return;
+    if (
+      !activeTools ||
+      syncingOverlaysToStore ||
+      state.layers === previous.layers
+    ) {
+      return;
+    }
 
     const currentById = new Map(state.layers.map((layer) => [layer.id, layer]));
     for (const layer of previous.layers) {
@@ -250,12 +266,11 @@ export function wireGeoAgentStoreSync(tools: GeoAgentSyncableTools): void {
         continue;
       }
 
-      if (
-        typeof current.metadata.customLayerType === "string" &&
-        (current.visible !== layer.visible ||
-          current.opacity !== layer.opacity)
-      ) {
-        applyGeoAgentCustomLayerState(activeTools.map, current);
+      if (typeof current.metadata.customLayerType === "string") {
+        applyGeoAgentCustomLayerState(activeTools.map, current, {
+          opacity: current.opacity !== layer.opacity,
+          visibility: current.visible !== layer.visible,
+        });
       }
     }
   });
@@ -270,8 +285,9 @@ export function unwireGeoAgentStoreSync(): void {
 function applyGeoAgentCustomLayerState(
   map: GeoAgentSyncableTools["map"],
   layer: GeoLibreLayer,
+  changed: { opacity: boolean; visibility: boolean },
 ): void {
-  if (!map) return;
+  if (!map || (!changed.opacity && !changed.visibility)) return;
 
   const nativeLayerIds = Array.isArray(layer.metadata.nativeLayerIds)
     ? layer.metadata.nativeLayerIds
@@ -281,15 +297,18 @@ function applyGeoAgentCustomLayerState(
     const nativeLayer = map.getLayer(nativeLayerId);
     if (!nativeLayer) continue;
 
-    try {
-      map.setLayoutProperty(
-        nativeLayerId,
-        "visibility",
-        layer.visible ? "visible" : "none",
-      );
-    } catch {
-      // Custom layers from external controls may not accept layout updates.
+    if (changed.visibility) {
+      try {
+        map.setLayoutProperty(
+          nativeLayerId,
+          "visibility",
+          layer.visible ? "visible" : "none",
+        );
+      } catch {
+        // Custom layers from external controls may not accept layout updates.
+      }
     }
+    if (!changed.opacity) continue;
     for (const property of NATIVE_OPACITY_PROPERTIES[nativeLayer.type] ?? []) {
       try {
         map.setPaintProperty(nativeLayerId, property, layer.opacity);
@@ -314,6 +333,8 @@ function geoJsonOverlayStyle(
     stringValue(style["fill-color"]) ?? stringValue(style.fillColor) ?? color;
   const strokeColor =
     stringValue(style["line-color"]) ?? stringValue(style.lineColor) ?? color;
+  // GeoAgent's geojsonLayerPaint uses `opacity` (not `fill-opacity`) as its
+  // primary fill-opacity parameter; `fill-opacity` is an alternate key.
   const fillOpacity = clamp01(
     numberValue(style.opacity) ?? numberValue(style["fill-opacity"]) ?? 0.35,
   );

--- a/packages/plugins/src/plugins/geoagent-layer-sync.ts
+++ b/packages/plugins/src/plugins/geoagent-layer-sync.ts
@@ -216,7 +216,9 @@ export function syncGeoAgentOverlaysToStore(
       // by reference: unchanged overlays keep the same record (and data
       // object) between commands, while a removeOverlay-then-add cycle swaps
       // it out even when the freed ids are reused.
+      const typeChanged = existing.type !== layer.type;
       if (
+        typeChanged ||
         JSON.stringify(existing.metadata.nativeLayerIds) !==
           JSON.stringify(layer.metadata.nativeLayerIds) ||
         JSON.stringify(existing.metadata.sourceIds) !==
@@ -232,6 +234,10 @@ export function syncGeoAgentOverlaysToStore(
           source: layer.source,
           sourcePath: layer.sourcePath,
           type: layer.type,
+          // User style edits do not carry meaning across a kind switch;
+          // reseed from the overlay so e.g. a geojson re-add paints with the
+          // agent's style instead of the old kind's.
+          ...(typeChanged ? { style: layer.style } : {}),
         });
       }
     }

--- a/packages/plugins/src/plugins/maplibre-geoagent.ts
+++ b/packages/plugins/src/plugins/maplibre-geoagent.ts
@@ -16,6 +16,13 @@ import type {
   GeoLibrePlugin,
 } from "../types";
 import {
+  removeGeoAgentStoreLayers,
+  syncGeoAgentOverlaysToStore,
+  unwireGeoAgentStoreSync,
+  wireGeoAgentStoreSync,
+  type GeoAgentOverlayRecord,
+} from "./geoagent-layer-sync";
+import {
   authenticateEarthEngine as authenticateEarthEngineForGeoLibre,
   captureEarthEngineFunctionInfo,
   clearEarthEngineFunctionInfo,
@@ -34,13 +41,13 @@ const STORAGE_PREFIX = "geolibre.geoagent";
 type GeoAgentControlInternals = {
   options?: GeoAgentControlOptions;
   tools?: {
-    __geolibreEarthEngineFallbackPatched?: boolean;
+    __geolibreToolRunnerPatched?: boolean;
     addGeeRasterOverlay?: (overlay: {
       name: string;
       url: string;
     }) => Promise<void>;
     map?: MapLibreMap;
-    overlays?: Map<string, unknown>;
+    overlays?: Map<string, GeoAgentOverlayRecord>;
     publishEarthEngineState?: () => void;
     removeOverlay?: (name: string) => boolean;
     requireEarthEngine?: () => {
@@ -91,9 +98,14 @@ export const maplibreGeoAgentPlugin: GeoLibrePlugin = {
   },
   deactivate: (app: GeoLibreAppAPI) => {
     geoAgentActive = false;
-    if (!geoAgentControl) return;
-    app.removeMapControl(geoAgentControl);
-    geoAgentControl = null;
+    unwireGeoAgentStoreSync();
+    if (geoAgentControl) {
+      app.removeMapControl(geoAgentControl);
+      geoAgentControl = null;
+    }
+    // The control's teardown already cleared its overlays from the map; drop
+    // the matching store entries so the layer panel does not list dead layers.
+    removeGeoAgentStoreLayers();
   },
   getMapControlPosition: () => geoAgentPosition,
   setMapControlPosition: (
@@ -108,7 +120,7 @@ export const maplibreGeoAgentPlugin: GeoLibrePlugin = {
     app.removeMapControl(geoAgentControl);
     const added = app.addMapControl(geoAgentControl, geoAgentPosition);
     if (!added) return false;
-    patchGeoAgentEarthEngineToolRunner(geoAgentControl);
+    patchGeoAgentToolRunner(geoAgentControl);
     setTimeout(() => geoAgentControl?.expand(), 0);
     setTimeout(enhanceEarthEngineSignIn, 0);
   },
@@ -123,7 +135,7 @@ async function mountGeoAgentControl(app: GeoLibreAppAPI): Promise<void> {
     if (geoAgentControl === control) geoAgentControl = null;
     return;
   }
-  patchGeoAgentEarthEngineToolRunner(control);
+  patchGeoAgentToolRunner(control);
   setTimeout(() => geoAgentControl?.expand(), 0);
   setTimeout(enhanceEarthEngineSignIn, 0);
   preloadEarthEngineAuthLibrary();
@@ -150,32 +162,41 @@ function getGeoAgentOptions(): GeoAgentControlOptions {
   };
 }
 
-function patchGeoAgentEarthEngineToolRunner(control: GeoAgentControl): void {
+function patchGeoAgentToolRunner(control: GeoAgentControl): void {
   const tools = (control as unknown as GeoAgentControlInternals).tools;
-  if (
-    !tools?.runCommand ||
-    tools.__geolibreEarthEngineFallbackPatched === true
-  ) {
+  if (!tools?.runCommand || tools.__geolibreToolRunnerPatched === true) {
     return;
   }
 
   const runCommand = tools.runCommand.bind(tools);
   tools.runCommand = async (command, args) => {
-    if (isEarthEngineToolCommand(command)) {
-      if (command === "load_gee_dataset") {
-        return loadGeoAgentDatasetWithGeoLibreEarthEngine(tools, args);
-      }
+    try {
+      if (isEarthEngineToolCommand(command)) {
+        if (command === "load_gee_dataset") {
+          return await loadGeoAgentDatasetWithGeoLibreEarthEngine(tools, args);
+        }
 
-      installEarthEngineFunctionInfoFallback(geoAgentEarthEngineFunctionInfo);
-      try {
-        return await runCommand(command, args);
-      } finally {
-        geoAgentEarthEngineFunctionInfo = captureEarthEngineFunctionInfo();
+        installEarthEngineFunctionInfoFallback(geoAgentEarthEngineFunctionInfo);
+        try {
+          return await runCommand(command, args);
+        } finally {
+          geoAgentEarthEngineFunctionInfo = captureEarthEngineFunctionInfo();
+        }
       }
+      return await runCommand(command, args);
+    } finally {
+      // Any command may add or remove overlays (including scripts run through
+      // run_maplibre_script); mirror the registry into the store so the layer
+      // panel stays in sync.
+      syncGeoAgentOverlaysToStore(tools.overlays);
     }
-    return runCommand(command, args);
   };
-  tools.__geolibreEarthEngineFallbackPatched = true;
+  tools.__geolibreToolRunnerPatched = true;
+
+  wireGeoAgentStoreSync(tools);
+  // The control recreates tools (with an empty overlay registry) on every
+  // onAdd, so prune store entries left over from a previous tools instance.
+  syncGeoAgentOverlaysToStore(tools.overlays);
 }
 
 async function loadGeoAgentDatasetWithGeoLibreEarthEngine(

--- a/packages/plugins/src/plugins/maplibre-geoagent.ts
+++ b/packages/plugins/src/plugins/maplibre-geoagent.ts
@@ -119,7 +119,13 @@ export const maplibreGeoAgentPlugin: GeoLibrePlugin = {
     }
     app.removeMapControl(geoAgentControl);
     const added = app.addMapControl(geoAgentControl, geoAgentPosition);
-    if (!added) return false;
+    if (!added) {
+      // removeMapControl already tore the tools (and their overlays) down;
+      // drop the now-stale sync wiring and store layers with them.
+      unwireGeoAgentStoreSync();
+      removeGeoAgentStoreLayers();
+      return false;
+    }
     patchGeoAgentToolRunner(geoAgentControl);
     setTimeout(() => geoAgentControl?.expand(), 0);
     setTimeout(enhanceEarthEngineSignIn, 0);

--- a/tests/geoagent-layer-sync.test.ts
+++ b/tests/geoagent-layer-sync.test.ts
@@ -1,0 +1,288 @@
+import assert from "node:assert/strict";
+import { beforeEach, describe, it } from "node:test";
+import {
+  DEFAULT_LAYER_STYLE,
+  type GeoLibreLayer,
+  useAppStore,
+} from "@geolibre/core";
+import {
+  createGeoAgentStoreLayer,
+  geoAgentStoreLayerId,
+  isGeoAgentStoreLayer,
+  removeGeoAgentStoreLayers,
+  syncGeoAgentOverlaysToStore,
+  unwireGeoAgentStoreSync,
+  wireGeoAgentStoreSync,
+  type GeoAgentOverlayRecord,
+} from "../packages/plugins/src/plugins/geoagent-layer-sync";
+
+function overlayMap(
+  ...overlays: GeoAgentOverlayRecord[]
+): Map<string, GeoAgentOverlayRecord> {
+  return new Map(overlays.map((overlay) => [overlay.name, overlay]));
+}
+
+function geojsonOverlay(
+  patch: Partial<GeoAgentOverlayRecord> = {},
+): GeoAgentOverlayRecord {
+  return {
+    kind: "geojson",
+    name: "Rivers",
+    sourceIds: ["rivers-source"],
+    layerIds: ["rivers-fill", "rivers-line"],
+    style: { "fill-color": "#ff0000", "line-color": "#00ff00" },
+    data: { type: "FeatureCollection", features: [] },
+    ...patch,
+  };
+}
+
+function geeOverlay(
+  patch: Partial<GeoAgentOverlayRecord> = {},
+): GeoAgentOverlayRecord {
+  return {
+    kind: "gee",
+    name: "NDVI",
+    sourceIds: ["ndvi-source"],
+    layerIds: ["ndvi"],
+    url: "https://earthengine.googleapis.com/tiles/{z}/{x}/{y}",
+    attribution: "Google Earth Engine",
+    ...patch,
+  };
+}
+
+function otherStoreLayer(id = "unrelated"): GeoLibreLayer {
+  return {
+    id,
+    name: "Unrelated",
+    type: "geojson",
+    source: { type: "geojson" },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {},
+  };
+}
+
+describe("syncGeoAgentOverlaysToStore", () => {
+  beforeEach(() => {
+    useAppStore.setState({ layers: [] });
+  });
+
+  it("adds a store layer for a GeoAgent geojson overlay", () => {
+    syncGeoAgentOverlaysToStore(overlayMap(geojsonOverlay()));
+
+    const layers = useAppStore.getState().layers;
+    assert.equal(layers.length, 1);
+
+    const layer = layers[0];
+    assert.equal(layer.id, geoAgentStoreLayerId("Rivers"));
+    assert.equal(layer.name, "Rivers");
+    assert.equal(layer.type, "geojson");
+    assert.equal(layer.visible, true);
+    assert.equal(layer.metadata.externalNativeLayer, true);
+    assert.deepEqual(layer.metadata.nativeLayerIds, [
+      "rivers-fill",
+      "rivers-line",
+    ]);
+    assert.deepEqual(layer.metadata.sourceIds, ["rivers-source"]);
+    assert.equal(layer.metadata.sourceKind, "geoagent-overlay");
+    assert.equal(layer.metadata.geoAgentOverlayName, "Rivers");
+    assert.ok(isGeoAgentStoreLayer(layer));
+  });
+
+  it("maps GeoAgent geojson overlay style onto the store layer style", () => {
+    const layer = createGeoAgentStoreLayer(geojsonOverlay());
+
+    assert.equal(layer.style.fillColor, "#ff0000");
+    assert.equal(layer.style.strokeColor, "#00ff00");
+    // geojsonLayerPaint in maplibre-gl-geoagent defaults fill-opacity to 0.35.
+    assert.equal(layer.style.fillOpacity, 0.35);
+  });
+
+  it("adds a raster store layer for a GeoAgent Earth Engine overlay", () => {
+    syncGeoAgentOverlaysToStore(overlayMap(geeOverlay()));
+
+    const layer = useAppStore.getState().layers[0];
+    assert.equal(layer.type, "raster");
+    assert.equal(layer.opacity, 1);
+    assert.equal(layer.metadata.identifiable, false);
+    assert.equal(
+      layer.metadata.tileUrl,
+      "https://earthengine.googleapis.com/tiles/{z}/{x}/{y}",
+    );
+    assert.deepEqual(layer.metadata.nativeLayerIds, ["ndvi"]);
+  });
+
+  it("removes store layers whose overlays are gone, leaving others alone", () => {
+    useAppStore.getState().addLayer(otherStoreLayer());
+    syncGeoAgentOverlaysToStore(overlayMap(geojsonOverlay(), geeOverlay()));
+    assert.equal(useAppStore.getState().layers.length, 3);
+
+    syncGeoAgentOverlaysToStore(overlayMap(geeOverlay()));
+
+    const layers = useAppStore.getState().layers;
+    assert.equal(layers.length, 2);
+    assert.ok(layers.some((layer) => layer.id === "unrelated"));
+    assert.ok(
+      layers.some((layer) => layer.id === geoAgentStoreLayerId("NDVI")),
+    );
+  });
+
+  it("skips markers and internal overlays", () => {
+    syncGeoAgentOverlaysToStore(
+      overlayMap(
+        {
+          kind: "marker",
+          name: "Pin",
+          sourceIds: [],
+          layerIds: [],
+        },
+        {
+          kind: "native",
+          name: "__terrain",
+          sourceIds: ["terrain-source"],
+          layerIds: ["terrain-hillshade"],
+        },
+      ),
+    );
+
+    assert.equal(useAppStore.getState().layers.length, 0);
+  });
+
+  it("preserves user edits on re-sync but refreshes native ids", () => {
+    syncGeoAgentOverlaysToStore(overlayMap(geojsonOverlay()));
+
+    const id = geoAgentStoreLayerId("Rivers");
+    useAppStore.getState().updateLayer(id, {
+      name: "My Rivers",
+      visible: false,
+      opacity: 0.5,
+    });
+
+    // The agent re-adds the overlay; unique id allocation produces new ids.
+    syncGeoAgentOverlaysToStore(
+      overlayMap(
+        geojsonOverlay({
+          sourceIds: ["rivers-source-2"],
+          layerIds: ["rivers-fill-2", "rivers-line-2"],
+        }),
+      ),
+    );
+
+    const layer = useAppStore.getState().layers[0];
+    assert.equal(layer.name, "My Rivers");
+    assert.equal(layer.visible, false);
+    assert.equal(layer.opacity, 0.5);
+    assert.deepEqual(layer.metadata.nativeLayerIds, [
+      "rivers-fill-2",
+      "rivers-line-2",
+    ]);
+    assert.deepEqual(layer.metadata.sourceIds, ["rivers-source-2"]);
+  });
+
+  it("removes only GeoAgent layers when the plugin deactivates", () => {
+    useAppStore.getState().addLayer(otherStoreLayer());
+    syncGeoAgentOverlaysToStore(overlayMap(geojsonOverlay(), geeOverlay()));
+
+    removeGeoAgentStoreLayers();
+
+    const layers = useAppStore.getState().layers;
+    assert.equal(layers.length, 1);
+    assert.equal(layers[0].id, "unrelated");
+  });
+
+  it("drops GeoAgent's overlay record when the layer is removed in the panel", () => {
+    const removed: string[] = [];
+    wireGeoAgentStoreSync({
+      removeOverlay: (name) => {
+        removed.push(name);
+        return true;
+      },
+    });
+
+    try {
+      syncGeoAgentOverlaysToStore(overlayMap(geojsonOverlay()));
+      useAppStore.getState().removeLayer(geoAgentStoreLayerId("Rivers"));
+
+      assert.deepEqual(removed, ["Rivers"]);
+    } finally {
+      unwireGeoAgentStoreSync();
+    }
+  });
+
+  it("applies visibility and opacity to custom native layers via the map", () => {
+    const layout: Array<[string, string, unknown]> = [];
+    const paint: Array<[string, string, unknown]> = [];
+    wireGeoAgentStoreSync({
+      map: {
+        getLayer: (id: string) =>
+          id === "buildings-3d" ? { type: "fill-extrusion" } : undefined,
+        setLayoutProperty: (id: string, property: string, value: unknown) => {
+          layout.push([id, property, value]);
+        },
+        setPaintProperty: (id: string, property: string, value: unknown) => {
+          paint.push([id, property, value]);
+        },
+      },
+    });
+
+    try {
+      syncGeoAgentOverlaysToStore(
+        overlayMap({
+          kind: "native",
+          name: "3D Buildings",
+          sourceIds: ["buildings-source"],
+          layerIds: ["buildings-3d"],
+          layerSpecs: [
+            {
+              layer: {
+                id: "buildings-3d",
+                type: "fill-extrusion",
+                source: "buildings-source",
+                paint: { "fill-extrusion-opacity": 0.6 },
+              },
+            },
+          ],
+        }),
+      );
+
+      const id = geoAgentStoreLayerId("3D Buildings");
+      useAppStore.getState().setLayerVisibility(id, false);
+      useAppStore.getState().setLayerOpacity(id, 0.25);
+
+      assert.deepEqual(layout, [
+        ["buildings-3d", "visibility", "none"],
+        ["buildings-3d", "visibility", "none"],
+      ]);
+      assert.deepEqual(paint, [
+        ["buildings-3d", "fill-extrusion-opacity", 0.6],
+        ["buildings-3d", "fill-extrusion-opacity", 0.25],
+      ]);
+    } finally {
+      unwireGeoAgentStoreSync();
+    }
+  });
+
+  it("registers native overlays as custom layers with their initial opacity", () => {
+    const layer = createGeoAgentStoreLayer({
+      kind: "native",
+      name: "3D Buildings",
+      sourceIds: ["buildings-source"],
+      layerIds: ["buildings-3d"],
+      layerSpecs: [
+        {
+          layer: {
+            id: "buildings-3d",
+            type: "fill-extrusion",
+            source: "buildings-source",
+            paint: { "fill-extrusion-opacity": 0.6 },
+          },
+        },
+      ],
+    });
+
+    assert.equal(layer.metadata.customLayerType, "fill-extrusion");
+    assert.equal(layer.opacity, 0.6);
+    assert.equal(layer.metadata.geoAgentOverlayKind, "native");
+  });
+});

--- a/tests/geoagent-layer-sync.test.ts
+++ b/tests/geoagent-layer-sync.test.ts
@@ -231,6 +231,17 @@ describe("syncGeoAgentOverlaysToStore", () => {
     assert.equal(layer.type, "raster");
   });
 
+  it("reseeds the style when an overlay changes kind", () => {
+    syncGeoAgentOverlaysToStore(overlayMap(geeOverlay()));
+    syncGeoAgentOverlaysToStore(overlayMap(geojsonOverlay({ name: "NDVI" })));
+
+    const layer = useAppStore.getState().layers[0];
+    assert.equal(layer.type, "geojson");
+    // The old kind's style carries no meaning across the switch; the new
+    // geojson style mapped from the overlay must win.
+    assert.equal(layer.style.fillColor, "#ff0000");
+  });
+
   it("omits sourceId for overlays without their own sources", () => {
     // Native overlays may reference sources that already exist on the map,
     // leaving their own sourceSpecs (and thus sourceIds) empty.

--- a/tests/geoagent-layer-sync.test.ts
+++ b/tests/geoagent-layer-sync.test.ts
@@ -223,6 +223,81 @@ describe("syncGeoAgentOverlaysToStore", () => {
     assert.equal(layer.opacity, 0.4);
   });
 
+  it("refreshes the layer type when an overlay is re-added as another kind", () => {
+    syncGeoAgentOverlaysToStore(overlayMap(geojsonOverlay()));
+    syncGeoAgentOverlaysToStore(overlayMap(geeOverlay({ name: "Rivers" })));
+
+    const layer = useAppStore.getState().layers[0];
+    assert.equal(layer.type, "raster");
+  });
+
+  it("omits sourceId for overlays without their own sources", () => {
+    // Native overlays may reference sources that already exist on the map,
+    // leaving their own sourceSpecs (and thus sourceIds) empty.
+    const layer = createGeoAgentStoreLayer({
+      kind: "native",
+      name: "Sky Layer",
+      sourceIds: [],
+      layerIds: ["sky-fill"],
+    });
+
+    assert.ok(!("sourceId" in layer.source));
+    assert.ok(!("sourceId" in layer.metadata));
+  });
+
+  it("treats empty-string style numbers as absent and clamps negatives", () => {
+    const raster = createGeoAgentStoreLayer(geeOverlay({ style: { opacity: "" } }));
+    assert.equal(raster.opacity, 1);
+
+    const geojson = createGeoAgentStoreLayer(
+      geojsonOverlay({ style: { "line-width": -3, "circle-radius": -1 } }),
+    );
+    assert.equal(geojson.style.strokeWidth, 0);
+    assert.equal(geojson.style.circleRadius, 0);
+  });
+
+  it("seeds opacity only for layer types the panel can later control", () => {
+    // hillshade has no *-opacity paint property; seeding from a made-up key
+    // would desync the panel from what opacity changes can actually affect.
+    const layer = createGeoAgentStoreLayer({
+      kind: "native",
+      name: "Relief",
+      sourceIds: ["relief-source"],
+      layerIds: ["relief"],
+      layerSpecs: [
+        {
+          layer: {
+            id: "relief",
+            type: "hillshade",
+            paint: { "hillshade-opacity": 0.5 },
+          },
+        },
+      ],
+    });
+
+    assert.equal(layer.opacity, 1);
+  });
+
+  it("does not echo removeOverlay during deactivate cleanup", () => {
+    const removed: string[] = [];
+    wireGeoAgentStoreSync({
+      removeOverlay: (name) => {
+        removed.push(name);
+        return true;
+      },
+    });
+
+    try {
+      syncGeoAgentOverlaysToStore(overlayMap(geojsonOverlay()));
+      removeGeoAgentStoreLayers();
+
+      assert.equal(useAppStore.getState().layers.length, 0);
+      assert.deepEqual(removed, []);
+    } finally {
+      unwireGeoAgentStoreSync();
+    }
+  });
+
   it("removes only GeoAgent layers when the plugin deactivates", () => {
     useAppStore.getState().addLayer(otherStoreLayer());
     syncGeoAgentOverlaysToStore(overlayMap(geojsonOverlay(), geeOverlay()));

--- a/tests/geoagent-layer-sync.test.ts
+++ b/tests/geoagent-layer-sync.test.ts
@@ -210,6 +210,28 @@ describe("syncGeoAgentOverlaysToStore", () => {
     }
   });
 
+  it("does not call removeOverlay for sync-driven store removals", () => {
+    const removed: string[] = [];
+    wireGeoAgentStoreSync({
+      removeOverlay: (name) => {
+        removed.push(name);
+        return true;
+      },
+    });
+
+    try {
+      syncGeoAgentOverlaysToStore(overlayMap(geojsonOverlay()));
+      // GeoAgent already dropped the overlay from its registry; the sync
+      // prunes the store layer and must not echo a removeOverlay back.
+      syncGeoAgentOverlaysToStore(overlayMap());
+
+      assert.equal(useAppStore.getState().layers.length, 0);
+      assert.deepEqual(removed, []);
+    } finally {
+      unwireGeoAgentStoreSync();
+    }
+  });
+
   it("applies visibility and opacity to custom native layers via the map", () => {
     const layout: Array<[string, string, unknown]> = [];
     const paint: Array<[string, string, unknown]> = [];
@@ -250,14 +272,9 @@ describe("syncGeoAgentOverlaysToStore", () => {
       useAppStore.getState().setLayerVisibility(id, false);
       useAppStore.getState().setLayerOpacity(id, 0.25);
 
-      assert.deepEqual(layout, [
-        ["buildings-3d", "visibility", "none"],
-        ["buildings-3d", "visibility", "none"],
-      ]);
-      assert.deepEqual(paint, [
-        ["buildings-3d", "fill-extrusion-opacity", 0.6],
-        ["buildings-3d", "fill-extrusion-opacity", 0.25],
-      ]);
+      // Each store mutation applies only the dimension that changed.
+      assert.deepEqual(layout, [["buildings-3d", "visibility", "none"]]);
+      assert.deepEqual(paint, [["buildings-3d", "fill-extrusion-opacity", 0.25]]);
     } finally {
       unwireGeoAgentStoreSync();
     }

--- a/tests/geoagent-layer-sync.test.ts
+++ b/tests/geoagent-layer-sync.test.ts
@@ -180,6 +180,49 @@ describe("syncGeoAgentOverlaysToStore", () => {
     assert.deepEqual(layer.metadata.sourceIds, ["rivers-source-2"]);
   });
 
+  it("refreshes geojson data when an overlay is re-added with the same ids", () => {
+    syncGeoAgentOverlaysToStore(overlayMap(geojsonOverlay()));
+
+    // GeoAgent's removeOverlay-then-add flow frees the old ids, so the re-add
+    // reuses them while the payload changes.
+    const updatedData: GeoJSON.FeatureCollection = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          geometry: { type: "Point", coordinates: [0, 0] },
+          properties: {},
+        },
+      ],
+    };
+    syncGeoAgentOverlaysToStore(
+      overlayMap(geojsonOverlay({ data: updatedData })),
+    );
+
+    const layer = useAppStore.getState().layers[0];
+    assert.equal(layer.geojson, updatedData);
+  });
+
+  it("initializes native symbol overlay opacity from icon/text opacity", () => {
+    const layer = createGeoAgentStoreLayer({
+      kind: "native",
+      name: "Labels",
+      sourceIds: ["labels-source"],
+      layerIds: ["labels"],
+      layerSpecs: [
+        {
+          layer: {
+            id: "labels",
+            type: "symbol",
+            paint: { "text-opacity": 0.4 },
+          },
+        },
+      ],
+    });
+
+    assert.equal(layer.opacity, 0.4);
+  });
+
   it("removes only GeoAgent layers when the plugin deactivates", () => {
     useAppStore.getState().addLayer(otherStoreLayer());
     syncGeoAgentOverlaysToStore(overlayMap(geojsonOverlay(), geeOverlay()));

--- a/tests/geoagent-layer-sync.test.ts
+++ b/tests/geoagent-layer-sync.test.ts
@@ -231,6 +231,37 @@ describe("syncGeoAgentOverlaysToStore", () => {
     assert.equal(layer.type, "raster");
   });
 
+  it("preserves the panel selection when sync adds layers", () => {
+    useAppStore.getState().addLayer(otherStoreLayer());
+    assert.equal(useAppStore.getState().selectedLayerId, "unrelated");
+
+    // Agent-driven adds happen in the background; they must not steal the
+    // user's current layer-panel selection.
+    syncGeoAgentOverlaysToStore(overlayMap(geojsonOverlay()));
+
+    assert.equal(useAppStore.getState().selectedLayerId, "unrelated");
+  });
+
+  it("clears customLayerType when a native overlay is re-added as geojson", () => {
+    syncGeoAgentOverlaysToStore(
+      overlayMap({
+        kind: "native",
+        name: "Rivers",
+        sourceIds: ["rivers-source"],
+        layerIds: ["rivers-fill"],
+        layerSpecs: [{ layer: { id: "rivers-fill", type: "fill" } }],
+      }),
+    );
+    syncGeoAgentOverlaysToStore(overlayMap(geojsonOverlay()));
+
+    const layer = useAppStore.getState().layers[0];
+    assert.equal(layer.type, "geojson");
+    assert.ok(
+      typeof layer.metadata.customLayerType !== "string",
+      "customLayerType must be absent so layer-sync uses the normal geojson path",
+    );
+  });
+
   it("reseeds the style when an overlay changes kind", () => {
     syncGeoAgentOverlaysToStore(overlayMap(geeOverlay()));
     syncGeoAgentOverlaysToStore(overlayMap(geojsonOverlay({ name: "NDVI" })));


### PR DESCRIPTION
## Summary

Layers added via the GeoAgent plugin showed up in the on-map layer control but not in the layer panel.

**Root cause:** the layer panel renders only layers registered in the app store, while GeoAgent's tools add overlays directly to the MapLibre map and track them in a private registry. The on-map layer control lists native style layers, which is why the layers appeared there but nowhere else.

**Fix:** mirror GeoAgent's overlay registry into the app store after every tool command, following the same `externalNativeLayer` pattern used by the Earth Engine, Planetary Computer, and Esri Wayback plugins. All GeoAgent tools route through `tools.runCommand`, which the plugin already wraps for the Earth Engine fallback, so the sync hooks into that existing patch.

## Behavior

- GeoJSON, raster, basemap, and Earth Engine overlays register with `nativeLayerIds`/`sourceIds`, so the existing layer-sync path drives panel visibility, opacity, ordering, and removal with no special casing.
- GeoJSON overlay styles map onto `LayerStyle` with the same keys and defaults the agent painted with (`fill-color`, `line-color`, `opacity`, `line-width`, `circle-radius`), so the store-driven repaint reproduces what the agent drew.
- Native overlays (clusters, choropleths, 3D buildings, `add_map_layer`) register as custom layers so their agent-authored, often data-driven paint is never clobbered by the generic style sync; the plugin applies panel visibility/opacity to them directly, seeding the initial opacity from the layer spec.
- Removing a layer in the panel also drops GeoAgent's overlay record, so the overlay is not resurrected on the agent's next basemap change and `list_layers` stays accurate.
- Markers and internal overlays (`__terrain`, `__sky`) are map state rather than layers and stay out of the panel.
- Deactivating the plugin prunes its store layers after the control tears its overlays down; user edits (rename, visibility, opacity) survive agent re-adds of the same overlay.

## Notes

- The overlay record shape and `runCommand` routing were verified against maplibre-gl-geoagent v0.4.2 sources; the mirrored type carries a comment to re-verify on dependency bumps.
- Point layers adopt GeoLibre's styling convention for circle stroke/opacity once registered, which can differ slightly from GeoAgent's hardcoded white stroke.

## Test plan

- [x] New unit tests in `tests/geoagent-layer-sync.test.ts` (10 cases: add/update/remove diffing, style mapping, marker/internal skipping, user-edit preservation, custom-layer visibility/opacity, deactivate cleanup)
- [x] `npm run test:frontend` (32 pass)
- [x] `npm run build` (tsc + vite)
- [x] `pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GeoAgent overlays sync into the layer panel for geojson, raster/dataset and native/custom types; styles and opacity map into panel-visible layer styles.
* **Behavior Improvements**
  * Resync prunes stale GeoAgent layers, updates structural fields only (preserving user-edited name/visibility/opacity/style), and avoids feedback loops during sync; panel removals propagate back to GeoAgent.
* **Tests**
  * End-to-end tests for sync/pruning, style/opacity mapping, edit preservation, removal semantics, and native layer interactions.
* **Chores**
  * Updated Earth Engine adapter dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->