### PR TITLE
fix: skip info-level network diagnostics by default

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DiagnosticsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DiagnosticsDialog.tsx
@@ -12,6 +12,7 @@ import { Clipboard, Trash2 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
   clearDiagnostics,
+  setCaptureNetworkInfo,
   type DiagnosticRecord,
   type DiagnosticLevel,
   type DiagnosticsSnapshot,
@@ -151,6 +152,20 @@ export function DiagnosticsDialog({
             <span className="rounded bg-muted px-2 py-1 text-muted-foreground">
               {diagnostics.networkCount} network
             </span>
+            <label
+              className="flex items-center gap-1.5 rounded border px-2 py-1 text-muted-foreground"
+              title="Record successful and aborted network requests. Off by default because logging every request slows the app down."
+            >
+              <input
+                className="h-3.5 w-3.5"
+                type="checkbox"
+                checked={diagnostics.captureNetworkInfo}
+                onChange={(event) =>
+                  setCaptureNetworkInfo(event.target.checked)
+                }
+              />
+              Log all network requests
+            </label>
           </div>
           <div className="flex gap-2">
             <Button

--- a/apps/geolibre-desktop/src/components/layout/DiagnosticsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DiagnosticsDialog.tsx
@@ -150,7 +150,8 @@ export function DiagnosticsDialog({
               {diagnostics.warningCount} warnings
             </button>
             <span className="rounded bg-muted px-2 py-1 text-muted-foreground">
-              {diagnostics.networkCount} network
+              {diagnostics.networkCount}{" "}
+              {diagnostics.captureNetworkInfo ? "network" : "network errors"}
             </span>
             <label
               className="flex items-center gap-1.5 rounded border px-2 py-1 text-muted-foreground"

--- a/apps/geolibre-desktop/src/lib/diagnostics.ts
+++ b/apps/geolibre-desktop/src/lib/diagnostics.ts
@@ -28,14 +28,28 @@ export interface DiagnosticsSnapshot {
   errorCount: number;
   warningCount: number;
   networkCount: number;
+  captureNetworkInfo: boolean;
 }
 
 const MAX_DIAGNOSTIC_RECORDS = 500;
 const MAX_FIELD_LENGTH = 3000;
+const CAPTURE_NETWORK_INFO_STORAGE_KEY =
+  "geolibre.diagnostics.captureNetworkInfo";
+
+function readStoredCaptureNetworkInfo(): boolean {
+  try {
+    return window.localStorage.getItem(CAPTURE_NETWORK_INFO_STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
 
 const listeners = new Set<() => void>();
 let records: DiagnosticRecord[] = [];
 let sequence = 0;
+// Capturing every successful request floods the store and re-renders
+// subscribers on each fetch, so info-level network entries are opt-in.
+let captureNetworkInfo = readStoredCaptureNetworkInfo();
 let snapshot = createSnapshot(records);
 let captureRefCount = 0;
 let captureCleanup: (() => void) | null = null;
@@ -55,6 +69,7 @@ function createSnapshot(nextRecords: DiagnosticRecord[]): DiagnosticsSnapshot {
     errorCount,
     warningCount,
     networkCount,
+    captureNetworkInfo,
   };
 }
 
@@ -152,6 +167,14 @@ function getSnapshot(): DiagnosticsSnapshot {
 }
 
 export function appendDiagnostic(input: DiagnosticInput): void {
+  if (
+    input.category === "network" &&
+    input.level === "info" &&
+    !captureNetworkInfo
+  ) {
+    return;
+  }
+
   const record: DiagnosticRecord = {
     ...input,
     id: `diagnostic-${Date.now()}-${sequence++}`,
@@ -168,6 +191,27 @@ export function appendDiagnostic(input: DiagnosticInput): void {
 
 export function clearDiagnostics(): void {
   records = [];
+  emitChange();
+}
+
+/**
+ * Enables or disables capturing info-level network diagnostics (successful
+ * and aborted requests). Disabled by default to avoid the overhead of
+ * recording every request; the choice persists across sessions.
+ *
+ * @param enabled - Whether info-level network entries should be recorded.
+ */
+export function setCaptureNetworkInfo(enabled: boolean): void {
+  if (captureNetworkInfo === enabled) return;
+  captureNetworkInfo = enabled;
+  try {
+    window.localStorage.setItem(
+      CAPTURE_NETWORK_INFO_STORAGE_KEY,
+      String(enabled),
+    );
+  } catch {
+    // Persistence is best-effort; the in-memory flag still applies.
+  }
   emitChange();
 }
 

--- a/apps/geolibre-desktop/src/lib/diagnostics.ts
+++ b/apps/geolibre-desktop/src/lib/diagnostics.ts
@@ -36,6 +36,10 @@ const MAX_FIELD_LENGTH = 3000;
 const CAPTURE_NETWORK_INFO_STORAGE_KEY =
   "geolibre.diagnostics.captureNetworkInfo";
 
+// Note: called once at module import, so the initial value is frozen for the
+// lifetime of the module. Tests that need a different starting state must
+// mock localStorage before importing this module, or call
+// setCaptureNetworkInfo() to change it afterwards.
 function readStoredCaptureNetworkInfo(): boolean {
   try {
     return window.localStorage.getItem(CAPTURE_NETWORK_INFO_STORAGE_KEY) === "true";
@@ -205,10 +209,13 @@ export function setCaptureNetworkInfo(enabled: boolean): void {
   if (captureNetworkInfo === enabled) return;
   captureNetworkInfo = enabled;
   try {
-    window.localStorage.setItem(
-      CAPTURE_NETWORK_INFO_STORAGE_KEY,
-      String(enabled),
-    );
+    // The key is only present when the user has explicitly opted in; the
+    // default-off state matches a pristine localStorage.
+    if (enabled) {
+      window.localStorage.setItem(CAPTURE_NETWORK_INFO_STORAGE_KEY, "true");
+    } else {
+      window.localStorage.removeItem(CAPTURE_NETWORK_INFO_STORAGE_KEY);
+    }
   } catch {
     // Persistence is best-effort; the in-memory flag still applies.
   }


### PR DESCRIPTION
## Summary
- Streaming every successful network request into the Diagnostics store triggered a snapshot rebuild and shell re-render on each fetch, causing performance issues; info-level network entries (successful responses and aborts) are now skipped by default
- Warnings and errors are still captured as before
- Added a "Log all network requests" checkbox in the Diagnostics dialog to opt back in, persisted via localStorage across sessions

## Test plan
- [ ] Open the Diagnostics dialog and confirm successful requests are no longer logged by default while failed requests still appear as errors
- [ ] Tick "Log all network requests" and confirm info-level network entries start streaming in
- [ ] Reload the app and confirm the checkbox state persists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Log all network requests" toggle in the diagnostics dialog so users can choose whether successful network requests are recorded.
  * When disabled, informational network entries are hidden; when enabled, they are shown and the diagnostics summary text updates accordingly.
  * The setting is persisted across sessions so your preference is retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->