### PR TITLE
fix: address diagnostics review follow-ups from #154

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DiagnosticsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DiagnosticsDialog.tsx
@@ -68,6 +68,15 @@ export function DiagnosticsDialog({
     [diagnostics.records, levelFilter],
   );
   const listIsFiltered = levelFilter !== "all";
+  // Derived here rather than assumed from networkCount so the badge label
+  // and count cannot diverge if non-error network levels are introduced.
+  const networkErrorCount = useMemo(
+    () =>
+      diagnostics.records.filter(
+        (record) => record.category === "network" && record.level === "error",
+      ).length,
+    [diagnostics.records],
+  );
 
   useEffect(
     () => () => {
@@ -150,12 +159,13 @@ export function DiagnosticsDialog({
               {diagnostics.warningCount} warnings
             </button>
             <span className="rounded bg-muted px-2 py-1 text-muted-foreground">
-              {diagnostics.networkCount}{" "}
-              {diagnostics.captureNetworkInfo ? "network" : "network errors"}
+              {diagnostics.captureNetworkInfo
+                ? `${diagnostics.networkCount} network`
+                : `${networkErrorCount} network errors`}
             </span>
             <label
               className="flex items-center gap-1.5 rounded border px-2 py-1 text-muted-foreground"
-              title="Record successful and aborted network requests. Off by default because logging every request slows the app down."
+              title="Record successful and aborted network requests from now on; requests made while logging was off are not backfilled. Off by default because logging every request slows the app down."
             >
               <input
                 className="h-3.5 w-3.5"

--- a/apps/geolibre-desktop/src/lib/diagnostics.ts
+++ b/apps/geolibre-desktop/src/lib/diagnostics.ts
@@ -229,7 +229,7 @@ export function useDiagnosticsSnapshot(): DiagnosticsSnapshot {
 /**
  * Returns the current diagnostics snapshot outside of React (e.g. in tests).
  *
- * @returns The latest immutable diagnostics snapshot.
+ * @returns The current diagnostics snapshot (treat as read-only).
  */
 export function getDiagnosticsSnapshot(): DiagnosticsSnapshot {
   return snapshot;

--- a/apps/geolibre-desktop/src/lib/diagnostics.ts
+++ b/apps/geolibre-desktop/src/lib/diagnostics.ts
@@ -227,6 +227,15 @@ export function useDiagnosticsSnapshot(): DiagnosticsSnapshot {
 }
 
 /**
+ * Returns the current diagnostics snapshot outside of React (e.g. in tests).
+ *
+ * @returns The latest immutable diagnostics snapshot.
+ */
+export function getDiagnosticsSnapshot(): DiagnosticsSnapshot {
+  return snapshot;
+}
+
+/**
  * Installs the fetch/console/window interceptors and returns a cleanup
  * function. Ref-counted so concurrent callers share one installation; the
  * interceptors are only removed once every returned cleanup has been called.

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -32,6 +32,9 @@ before(async () => {
   } = await import("../apps/geolibre-desktop/src/lib/diagnostics"));
 });
 
+// Intentionally duplicated from diagnostics.ts: the key is a persistence
+// contract with users' localStorage, so an accidental rename in the source
+// should fail this test rather than be silently mirrored by an import.
 const CAPTURE_NETWORK_INFO_STORAGE_KEY =
   "geolibre.diagnostics.captureNetworkInfo";
 

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { before, beforeEach, describe, it } from "node:test";
+
+// diagnostics.ts reads localStorage at import time, so the window stub must
+// be installed before the module is loaded; hence the dynamic import below.
+const storage = new Map<string, string>();
+(globalThis as { window?: unknown }).window = {
+  localStorage: {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      storage.set(key, value);
+    },
+    removeItem: (key: string) => {
+      storage.delete(key);
+    },
+  },
+};
+
+type DiagnosticsModule =
+  typeof import("../apps/geolibre-desktop/src/lib/diagnostics");
+let appendDiagnostic: DiagnosticsModule["appendDiagnostic"];
+let clearDiagnostics: DiagnosticsModule["clearDiagnostics"];
+let getDiagnosticsSnapshot: DiagnosticsModule["getDiagnosticsSnapshot"];
+let setCaptureNetworkInfo: DiagnosticsModule["setCaptureNetworkInfo"];
+
+before(async () => {
+  ({
+    appendDiagnostic,
+    clearDiagnostics,
+    getDiagnosticsSnapshot,
+    setCaptureNetworkInfo,
+  } = await import("../apps/geolibre-desktop/src/lib/diagnostics"));
+});
+
+const CAPTURE_NETWORK_INFO_STORAGE_KEY =
+  "geolibre.diagnostics.captureNetworkInfo";
+
+describe("diagnostics network info capture", () => {
+  beforeEach(() => {
+    setCaptureNetworkInfo(false);
+    clearDiagnostics();
+    storage.clear();
+  });
+
+  it("drops info-level network entries by default", () => {
+    appendDiagnostic({
+      category: "network",
+      level: "info",
+      message: "GET 200 OK",
+    });
+    assert.equal(getDiagnosticsSnapshot().totalCount, 0);
+    assert.equal(getDiagnosticsSnapshot().networkCount, 0);
+  });
+
+  it("keeps error-level network entries by default", () => {
+    appendDiagnostic({
+      category: "network",
+      level: "error",
+      message: "GET 500 Internal Server Error",
+    });
+    const snapshot = getDiagnosticsSnapshot();
+    assert.equal(snapshot.totalCount, 1);
+    assert.equal(snapshot.networkCount, 1);
+    assert.equal(snapshot.errorCount, 1);
+  });
+
+  it("does not filter info-level entries from other categories", () => {
+    appendDiagnostic({
+      category: "console",
+      level: "info",
+      message: "informational",
+    });
+    assert.equal(getDiagnosticsSnapshot().totalCount, 1);
+  });
+
+  it("records info-level network entries once enabled", () => {
+    setCaptureNetworkInfo(true);
+    appendDiagnostic({
+      category: "network",
+      level: "info",
+      message: "GET 200 OK",
+    });
+    const snapshot = getDiagnosticsSnapshot();
+    assert.equal(snapshot.totalCount, 1);
+    assert.equal(snapshot.networkCount, 1);
+    assert.equal(snapshot.captureNetworkInfo, true);
+  });
+
+  it("persists opt-in to localStorage and clears the key on opt-out", () => {
+    setCaptureNetworkInfo(true);
+    assert.equal(storage.get(CAPTURE_NETWORK_INFO_STORAGE_KEY), "true");
+    setCaptureNetworkInfo(false);
+    assert.equal(storage.has(CAPTURE_NETWORK_INFO_STORAGE_KEY), false);
+  });
+
+  it("exposes the capture flag through the snapshot", () => {
+    assert.equal(getDiagnosticsSnapshot().captureNetworkInfo, false);
+    setCaptureNetworkInfo(true);
+    assert.equal(getDiagnosticsSnapshot().captureNetworkInfo, true);
+  });
+});

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -64,6 +64,18 @@ describe("diagnostics network info capture", () => {
     assert.equal(snapshot.errorCount, 1);
   });
 
+  it("keeps warning-level network entries even when capture is off", () => {
+    appendDiagnostic({
+      category: "network",
+      level: "warning",
+      message: "GET 301 Moved Permanently",
+    });
+    const snapshot = getDiagnosticsSnapshot();
+    assert.equal(snapshot.totalCount, 1);
+    assert.equal(snapshot.networkCount, 1);
+    assert.equal(snapshot.warningCount, 1);
+  });
+
   it("does not filter info-level entries from other categories", () => {
     appendDiagnostic({
       category: "console",


### PR DESCRIPTION
## Summary
- Follow-up to the review comments on #154, which was merged before the second review round could be addressed there
- Derive the "network errors" badge count from records (category network and level error) so the label and count cannot diverge if non-error network levels are introduced later
- Clarify the checkbox tooltip that enabling only applies to requests made from then on; earlier requests are not backfilled
- Add unit tests for the info-level network filter, opt-in toggle, localStorage persistence, and snapshot flag, plus a non-hook getDiagnosticsSnapshot accessor for tests

## Test plan
- [x] npm run test:frontend passes (49 tests, 6 new)
- [x] tsc -b passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Diagnostics panel now shows network error counts based on actual recorded network-error records for more accurate labels.

* **New Features**
  * Capture setting for detailed network info persists and correctly toggles whether network-level info is recorded.

* **Tests**
  * Added tests validating network-info recording, persistence behavior, filtering, and reset/cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->