### PR TITLE
feat: replace the Add Raster Layer dialog with the maplibre-gl-raster plugin

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -47,6 +47,7 @@
     "maplibre-gl-geoparquet": "^0.2.1",
     "maplibre-gl-lidar": "^0.14.1",
     "maplibre-gl-planetary-computer": "^0.3.0",
+    "maplibre-gl-raster": "^0.1.1",
     "maplibre-gl-streetview": "^0.4.0",
     "maplibre-gl-swipe": "^0.7.1",
     "react": "^18.3.1",

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -47,7 +47,7 @@
     "maplibre-gl-geoparquet": "^0.2.1",
     "maplibre-gl-lidar": "^0.14.1",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.1.1",
+    "maplibre-gl-raster": "^0.1.2",
     "maplibre-gl-streetview": "^0.4.0",
     "maplibre-gl-swipe": "^0.7.1",
     "react": "^18.3.1",

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -47,7 +47,7 @@
     "maplibre-gl-geoparquet": "^0.2.1",
     "maplibre-gl-lidar": "^0.14.1",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.1.2",
+    "maplibre-gl-raster": "^0.1.3",
     "maplibre-gl-streetview": "^0.4.0",
     "maplibre-gl-swipe": "^0.7.1",
     "react": "^18.3.1",

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -6,10 +6,8 @@ import {
 import { getLayerBounds, type MapController } from "@geolibre/map";
 import {
   addArcGISLayer,
-  addCogRasterLayer,
   type ArcGISLayerType,
   type ArcGISSourceType,
-  type CogRasterLayerOptions,
 } from "@geolibre/plugins";
 import {
   Button,
@@ -28,7 +26,6 @@ import {
   Database,
   FileUp,
   Globe2,
-  Image,
   Map as MapIcon,
 } from "lucide-react";
 import {
@@ -84,7 +81,6 @@ export type AddDataKind =
   | "vector"
   | "gpx"
   | "delimited-text"
-  | "raster"
   | "mbtiles"
   | "arcgis"
   | "postgres";
@@ -100,12 +96,6 @@ type GpxMode = "url" | "file";
 type GpxLayerKind = "waypoints" | "tracks" | "routes";
 type DelimitedTextMode = "url" | "file";
 type DelimitedTextDelimiter = "comma" | "tab" | "semicolon" | "pipe" | "custom";
-type RasterMode = "tiles" | "cog-url" | "file";
-type RasterColormap = NonNullable<CogRasterLayerOptions["colormap"]>;
-type SelectedRasterFile = {
-  data: ArrayBuffer;
-  path: string;
-};
 
 const KIND_LABELS: Record<AddDataKind, string> = {
   xyz: "Add XYZ Layer",
@@ -115,24 +105,10 @@ const KIND_LABELS: Record<AddDataKind, string> = {
   vector: "Add Vector Layer",
   gpx: "Add GPX Layer",
   "delimited-text": "Add Delimited Text Layer",
-  raster: "Add Raster Layer",
   mbtiles: "Add MBTiles Layer",
   arcgis: "Add ArcGIS Layer",
   postgres: "Add PostgreSQL Layer",
 };
-
-const COG_COLORMAPS = [
-  "none",
-  "viridis",
-  "plasma",
-  "inferno",
-  "magma",
-  "cividis",
-  "terrain",
-  "turbo",
-  "jet",
-  "gray",
-] satisfies RasterColormap[];
 
 const DEFAULT_XYZ_URL =
   "https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryOnly/MapServer/tile/{z}/{y}/{x}";
@@ -143,8 +119,6 @@ const DEFAULT_WFS_ENDPOINT = "https://ahocevar.com/geoserver/wfs";
 const DEFAULT_WFS_TYPE_NAME = "topp:states";
 const DEFAULT_WMTS_URL =
   "https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/MapServer/tile/119/{z}/{y}/{x}";
-const DEFAULT_RASTER_URL =
-  "https://data.source.coop/giswqs/opengeos/nlcd_2021_land_cover_30m.tif";
 const DEFAULT_GEOJSON_URL =
   "https://data.source.coop/giswqs/opengeos/countries.geojson";
 const DEFAULT_GPX_URL =
@@ -440,16 +414,6 @@ export function AddDataDialog({
     text: string;
   } | null>(null);
 
-  const [rasterMode, setRasterMode] = useState<RasterMode>("cog-url");
-  const [rasterUrl, setRasterUrl] = useState(DEFAULT_RASTER_URL);
-  const [rasterTileSize, setRasterTileSize] = useState("256");
-  const [rasterBands, setRasterBands] = useState("1");
-  const [rasterColormap, setRasterColormap] = useState<RasterColormap>("none");
-  const [rasterMin, setRasterMin] = useState("0");
-  const [rasterMax, setRasterMax] = useState("255");
-  const [rasterNodata, setRasterNodata] = useState("");
-  const [selectedRasterFile, setSelectedRasterFile] =
-    useState<SelectedRasterFile | null>(null);
   const [selectedMbtiles, setSelectedMbtiles] = useState<{
     metadata: MbtilesMetadata;
     path: string;
@@ -490,7 +454,6 @@ export function AddDataDialog({
         vector: "Vector Layer",
         gpx: "GPX Layer",
         "delimited-text": "Delimited Text Layer",
-        raster: "Raster Layer",
         mbtiles: "MBTiles Layer",
         arcgis: "ArcGIS Layer",
         postgres: "PostgreSQL Layer",
@@ -536,15 +499,6 @@ export function AddDataDialog({
     setDelimitedTextColumnsStatus(null);
     setIsRetrievingDelimitedTextColumns(false);
     setSelectedDelimitedText(null);
-    setRasterMode("cog-url");
-    setRasterUrl(DEFAULT_RASTER_URL);
-    setRasterTileSize("256");
-    setRasterBands("1");
-    setRasterColormap("none");
-    setRasterMin("0");
-    setRasterMax("255");
-    setRasterNodata("");
-    setSelectedRasterFile(null);
     setSelectedMbtiles(null);
     setMbtilesSourceLayers("");
     setArcgisLayerType("feature");
@@ -588,9 +542,6 @@ export function AddDataDialog({
     }
     if (kind === "delimited-text") {
       return "Add a delimited text file or URL as a point layer using longitude and latitude fields.";
-    }
-    if (kind === "raster") {
-      return "Add a Cloud Optimized GeoTIFF or raster URL, or use a raster tile template.";
     }
     if (kind === "mbtiles") {
       return "Add a local MBTiles file as a raster or vector tile layer.";
@@ -966,35 +917,6 @@ export function AddDataDialog({
       );
     } catch (err) {
       setError(errorMessage(err, "Could not read GPX file."));
-    }
-  };
-
-  const handleChooseRasterFile = async () => {
-    setError(null);
-    try {
-      const result = await openLocalDataFileWithFallback({
-        filters: [
-          {
-            name: "GeoTIFF raster",
-            extensions: ["tif", "tiff"],
-          },
-        ],
-        accept: ".tif,.tiff",
-        readBinary: true,
-      });
-      if (!result) return;
-      if (!result.data) throw new Error("Raster file data is missing.");
-      setSelectedRasterFile({
-        data: result.data,
-        path: result.path,
-      });
-      setLayerName((current) =>
-        current.trim() && current !== "Raster Layer"
-          ? current
-          : layerNameFromPath(result.path, "Raster Layer"),
-      );
-    } catch (err) {
-      setError(errorMessage(err, "Could not read raster file."));
     }
   };
 
@@ -1410,62 +1332,6 @@ export function AddDataDialog({
         await addMartinSource(selectedMartinSourceId);
         return;
       }
-
-      if (rasterMode === "tiles") {
-        if (!rasterUrl.trim()) {
-          throw new Error("Enter a raster tile URL template.");
-        }
-        addAndClose(
-          createBaseLayer(name, "raster", {
-            type: "raster",
-            tiles: [rasterUrl.trim()],
-            tileSize: Number(rasterTileSize) || 256,
-          }),
-        );
-        return;
-      }
-
-      if (rasterMode === "cog-url") {
-        if (!rasterUrl.trim()) throw new Error("Enter a raster URL.");
-        const rescaleMin = parseRequiredNumber(rasterMin, "minimum value");
-        const rescaleMax = parseRequiredNumber(rasterMax, "maximum value");
-        if (rescaleMax <= rescaleMin) {
-          throw new Error("Maximum value must be greater than minimum value.");
-        }
-        await addCogRasterLayer(createAppAPI(mapControllerRef), {
-          bands: rasterBands.trim() || "1",
-          beforeLayerId: beforeLayer,
-          colormap: rasterColormap,
-          name,
-          nodata: parseOptionalNumber(rasterNodata, "nodata value"),
-          opacity: 1,
-          rescaleMax,
-          rescaleMin,
-          url: rasterUrl.trim(),
-        });
-        closeDialog();
-        return;
-      }
-
-      if (!selectedRasterFile) throw new Error("Choose a raster file.");
-      const rescaleMin = parseRequiredNumber(rasterMin, "minimum value");
-      const rescaleMax = parseRequiredNumber(rasterMax, "maximum value");
-      if (rescaleMax <= rescaleMin) {
-        throw new Error("Maximum value must be greater than minimum value.");
-      }
-      await addCogRasterLayer(createAppAPI(mapControllerRef), {
-        bands: rasterBands.trim() || "1",
-        beforeLayerId: beforeLayer,
-        colormap: rasterColormap,
-        data: selectedRasterFile.data,
-        name,
-        nodata: parseOptionalNumber(rasterNodata, "nodata value"),
-        opacity: 1,
-        rescaleMax,
-        rescaleMin,
-        url: selectedRasterFile.path,
-      });
-      closeDialog();
     } catch (err) {
       setError(errorMessage(err, "Could not add layer."));
     } finally {
@@ -2272,132 +2138,6 @@ export function AddDataDialog({
             </div>
           )}
 
-          {kind === "raster" && (
-            <div className="space-y-3">
-              <div className="space-y-1.5">
-                <Label htmlFor="raster-mode">Source type</Label>
-                <Select
-                  id="raster-mode"
-                  value={rasterMode}
-                  onChange={(event) =>
-                    setRasterMode(event.target.value as RasterMode)
-                  }
-                >
-                  <option value="cog-url">COG or raster URL</option>
-                  <option value="tiles">Raster tile URL template</option>
-                  <option value="file">Raster file</option>
-                </Select>
-              </div>
-              {rasterMode === "file" ? (
-                <div className="flex flex-wrap items-center gap-2">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={handleChooseRasterFile}
-                  >
-                    <Image className="mr-2 h-3.5 w-3.5" />
-                    Choose file
-                  </Button>
-                  <span className="min-w-0 truncate text-xs text-muted-foreground">
-                    {selectedRasterFile
-                      ? fileNameFromPath(selectedRasterFile.path)
-                      : "No file selected"}
-                  </span>
-                </div>
-              ) : (
-                <div className="grid gap-3 sm:grid-cols-[1fr_7rem]">
-                  <div className="space-y-1.5">
-                    <Label htmlFor="raster-url">
-                      {rasterMode === "tiles"
-                        ? "Tile URL template"
-                        : "Raster URL"}
-                    </Label>
-                    <Input
-                      id="raster-url"
-                      placeholder={
-                        rasterMode === "tiles"
-                          ? "https://example.com/{z}/{x}/{y}.png"
-                          : "https://example.com/image.tif"
-                      }
-                      value={rasterUrl}
-                      onChange={(event) => setRasterUrl(event.target.value)}
-                    />
-                  </div>
-                  {rasterMode === "tiles" && (
-                    <div className="space-y-1.5">
-                      <Label htmlFor="raster-tile-size">Tile size</Label>
-                      <Input
-                        id="raster-tile-size"
-                        inputMode="numeric"
-                        value={rasterTileSize}
-                        onChange={(event) =>
-                          setRasterTileSize(event.target.value)
-                        }
-                      />
-                    </div>
-                  )}
-                </div>
-              )}
-              {rasterMode !== "tiles" && (
-                <div className="grid gap-3 sm:grid-cols-4">
-                  <div className="space-y-1.5">
-                    <Label htmlFor="raster-bands">Bands</Label>
-                    <Input
-                      id="raster-bands"
-                      placeholder="1 or 1,2,3"
-                      value={rasterBands}
-                      onChange={(event) => setRasterBands(event.target.value)}
-                    />
-                  </div>
-                  <div className="space-y-1.5">
-                    <Label htmlFor="raster-colormap">Colormap</Label>
-                    <Select
-                      id="raster-colormap"
-                      value={rasterColormap}
-                      onChange={(event) =>
-                        setRasterColormap(event.target.value as RasterColormap)
-                      }
-                    >
-                      {COG_COLORMAPS.map((colormap) => (
-                        <option key={colormap} value={colormap}>
-                          {colormap}
-                        </option>
-                      ))}
-                    </Select>
-                  </div>
-                  <div className="space-y-1.5">
-                    <Label htmlFor="raster-min">Min</Label>
-                    <Input
-                      id="raster-min"
-                      inputMode="decimal"
-                      value={rasterMin}
-                      onChange={(event) => setRasterMin(event.target.value)}
-                    />
-                  </div>
-                  <div className="space-y-1.5">
-                    <Label htmlFor="raster-max">Max</Label>
-                    <Input
-                      id="raster-max"
-                      inputMode="decimal"
-                      value={rasterMax}
-                      onChange={(event) => setRasterMax(event.target.value)}
-                    />
-                  </div>
-                  <div className="space-y-1.5 sm:col-span-2">
-                    <Label htmlFor="raster-nodata">Nodata</Label>
-                    <Input
-                      id="raster-nodata"
-                      inputMode="decimal"
-                      placeholder="Optional"
-                      value={rasterNodata}
-                      onChange={(event) => setRasterNodata(event.target.value)}
-                    />
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
-
           {error ? <p className="text-sm text-destructive">{error}</p> : null}
 
           <div className="flex justify-end gap-2">
@@ -2413,8 +2153,6 @@ export function AddDataDialog({
               {!isSubmitting ? (
                 kind === "wms" || kind === "wfs" || kind === "wmts" ? (
                   <Globe2 className="mr-2 h-3.5 w-3.5" />
-                ) : kind === "raster" ? (
-                  <Image className="mr-2 h-3.5 w-3.5" />
                 ) : (
                   <MapIcon className="mr-2 h-3.5 w-3.5" />
                 )

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -1,7 +1,10 @@
 import { useAppStore } from "@geolibre/core";
 import type { MapController, MapDiagnosticEvent } from "@geolibre/map";
 import { MapCanvas } from "@geolibre/map";
-import { restoreThreeDTilesLayers } from "@geolibre/plugins";
+import {
+  restoreRasterLayers,
+  restoreThreeDTilesLayers,
+} from "@geolibre/plugins";
 import {
   type CSSProperties,
   type DragEvent,
@@ -159,6 +162,7 @@ export function DesktopShell({
       appAPI,
     );
     restoreThreeDTilesLayers(appAPI);
+    restoreRasterLayers(appAPI);
     const search = window.location.search;
     void pluginManager
       .handleUrlParameters(

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -27,6 +27,7 @@ import {
   openLidarLayerPanel,
   openPlanetaryComputerPanel,
   openPMTilesLayerPanel,
+  openRasterLayerPanel,
   openSearchPlacesPanel,
   openSplattingLayerPanel,
   openStacSearchLayerPanel,
@@ -390,6 +391,9 @@ export function TopToolbar({
   const handleAddStacLayer = () => {
     openStacSearchLayerPanel(appApi);
   };
+  const handleAddRasterLayer = () => {
+    openRasterLayerPanel(appApi);
+  };
   const searchPlacesVisible = useSyncExternalStore(
     subscribeSearchPlacesPanel,
     isSearchPlacesPanelVisible,
@@ -607,7 +611,7 @@ export function TopToolbar({
           <DropdownMenuItem onSelect={() => setAddDataKind("vector")}>
             Vector Layer
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setAddDataKind("raster")}>
+          <DropdownMenuItem onSelect={handleAddRasterLayer}>
             Raster Layer
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => setAddDataKind("delimited-text")}>

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1845,3 +1845,45 @@ body,
   box-shadow: inset 0 0 0 1px hsl(var(--ring));
   outline: none;
 }
+
+/* maplibre-gl-raster themes its panel from prefers-color-scheme (the OS
+   setting), while GeoLibre themes from the .dark class on <html>. All of
+   the panel's colors flow through --mlr-* custom properties, so remapping
+   them onto the app theme tokens keeps the panel in sync with the in-app
+   light/dark toggle. The doubled selectors outrank the upstream
+   prefers-color-scheme block regardless of stylesheet order. */
+.plugin-control.geolibre-raster-control,
+.plugin-control-panel.geolibre-raster-panel {
+  --mlr-bg: hsl(var(--popover));
+  --mlr-surface-muted: hsl(var(--muted));
+  --mlr-surface-soft: hsl(var(--card));
+  --mlr-text: hsl(var(--popover-foreground));
+  --mlr-text-strong: hsl(var(--foreground));
+  --mlr-text-soft: hsl(var(--popover-foreground) / 0.8);
+  --mlr-text-muted: hsl(var(--muted-foreground));
+  --mlr-text-faint: hsl(var(--muted-foreground) / 0.75);
+  --mlr-border: hsl(var(--border));
+  --mlr-border-soft: hsl(var(--border) / 0.8);
+  --mlr-border-faint: hsl(var(--border) / 0.6);
+  --mlr-border-strong: hsl(var(--input));
+  --mlr-accent: hsl(var(--primary));
+  --mlr-accent-strong: hsl(var(--primary) / 0.85);
+  --mlr-accent-soft: hsl(var(--primary) / 0.12);
+  --mlr-hover: hsl(var(--foreground) / 0.06);
+  --mlr-error: hsl(var(--destructive));
+  --mlr-disabled-bg: hsl(var(--muted));
+  --mlr-disabled-text: hsl(var(--muted-foreground) / 0.5);
+  --mlr-scrollbar: hsl(var(--border));
+  --mlr-scrollbar-hover: hsl(var(--input));
+  --mlr-shadow: hsl(var(--foreground) / 0.12);
+  --mlr-histogram-neutral: hsl(var(--foreground));
+
+  color-scheme: light;
+}
+
+.dark .plugin-control.geolibre-raster-control,
+.dark .plugin-control-panel.geolibre-raster-panel {
+  --mlr-shadow: hsl(0 0% 0% / 0.4);
+
+  color-scheme: dark;
+}

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1852,8 +1852,8 @@ body,
    them onto the app theme tokens keeps the panel in sync with the in-app
    light/dark toggle. The doubled selectors outrank the upstream
    prefers-color-scheme block regardless of stylesheet order. */
-.plugin-control.geolibre-raster-control,
-.plugin-control-panel.geolibre-raster-panel {
+.mlr-control.geolibre-raster-control,
+.mlr-control-panel.geolibre-raster-panel {
   --mlr-bg: hsl(var(--popover));
   --mlr-surface-muted: hsl(var(--muted));
   --mlr-surface-soft: hsl(var(--card));
@@ -1881,8 +1881,8 @@ body,
   color-scheme: light;
 }
 
-.dark .plugin-control.geolibre-raster-control,
-.dark .plugin-control-panel.geolibre-raster-panel {
+.dark .mlr-control.geolibre-raster-control,
+.dark .mlr-control-panel.geolibre-raster-panel {
   --mlr-shadow: hsl(0 0% 0% / 0.4);
 
   color-scheme: dark;

--- a/apps/geolibre-desktop/src/main.tsx
+++ b/apps/geolibre-desktop/src/main.tsx
@@ -12,6 +12,7 @@ import "maplibre-gl-geo-editor/style.css";
 import "maplibre-gl-geoagent/style.css";
 import "maplibre-gl-geoparquet/style.css";
 import "maplibre-gl-planetary-computer/style.css";
+import "maplibre-gl-raster/style.css";
 import "maplibre-gl-streetview/style.css";
 import "maplibre-gl-swipe/style.css";
 import "mapillary-js/dist/mapillary.css";

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "maplibre-gl-geoparquet": "^0.2.1",
         "maplibre-gl-lidar": "^0.14.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.1.1",
+        "maplibre-gl-raster": "^0.1.2",
         "maplibre-gl-streetview": "^0.4.0",
         "maplibre-gl-swipe": "^0.7.1",
         "react": "^18.3.1",
@@ -10960,9 +10960,9 @@
       }
     },
     "node_modules/maplibre-gl-raster": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.1.1.tgz",
-      "integrity": "sha512-+tqBVIv30vQmIcqyrBP24ABtB0ylLi/1sHuOnC90J2ktzf2qWiiBDop8XOYSS3kdsZsI2ie0Km5htSbmdOvsrw==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.1.2.tgz",
+      "integrity": "sha512-zOFQpVeEsXYoDByLiK9gMDn7ra1/OAF6LrdJObeoPd7Xvu3u1hFMg3vZ2G/S9KhhG4Sx69cwXq6tNZzhWHxvBg==",
       "license": "MIT",
       "dependencies": {
         "@chunkd/middleware": "^11.3.0",
@@ -14794,7 +14794,7 @@
         "maplibre-gl-geoparquet": "^0.2.1",
         "maplibre-gl-lidar": "^0.14.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.1.1",
+        "maplibre-gl-raster": "^0.1.2",
         "maplibre-gl-streetview": "^0.4.0",
         "maplibre-gl-swipe": "^0.7.1",
         "proj4": "^2.20.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "maplibre-gl-geoparquet": "^0.2.1",
         "maplibre-gl-lidar": "^0.14.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
+        "maplibre-gl-raster": "^0.1.1",
         "maplibre-gl-streetview": "^0.4.0",
         "maplibre-gl-swipe": "^0.7.1",
         "react": "^18.3.1",
@@ -10958,6 +10959,157 @@
         }
       }
     },
+    "node_modules/maplibre-gl-raster": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.1.1.tgz",
+      "integrity": "sha512-+tqBVIv30vQmIcqyrBP24ABtB0ylLi/1sHuOnC90J2ktzf2qWiiBDop8XOYSS3kdsZsI2ie0Km5htSbmdOvsrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chunkd/middleware": "^11.3.0",
+        "@chunkd/source": "^11.4.0",
+        "@chunkd/source-http": "^11.4.0",
+        "@cogeotiff/core": "^9.5.0",
+        "@developmentseed/deck.gl-geotiff": "^0.6.1",
+        "@developmentseed/deck.gl-raster": "0.6.1",
+        "@developmentseed/geotiff": "^0.6.1"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "^9.3.2",
+        "@deck.gl/geo-layers": "^9.3.2",
+        "@deck.gl/layers": "^9.3.2",
+        "@deck.gl/mapbox": "^9.3.2",
+        "@deck.gl/mesh-layers": "^9.3.2",
+        "@luma.gl/core": "^9.3.3",
+        "@luma.gl/shadertools": "^9.3.3",
+        "maplibre-gl": ">=3.0.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/maplibre-gl-raster/node_modules/@developmentseed/affine": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@developmentseed/affine/-/affine-0.6.1.tgz",
+      "integrity": "sha512-RSywOfmKAUxib61vXOYFoobIZS/vZWvaAHgUlTTwejlgAU7tK9VvViz0xTqwHF9K3BLDD12EdNB1yS/ZDpBlWQ==",
+      "license": "MIT"
+    },
+    "node_modules/maplibre-gl-raster/node_modules/@developmentseed/deck.gl-geotiff": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@developmentseed/deck.gl-geotiff/-/deck.gl-geotiff-0.6.1.tgz",
+      "integrity": "sha512-xPK/ZIf332xCOn9U+Of7CxW1+VKKi6DSSAao6oXRIRk7E82oeJAInWHnnpPmIkKYykdkog0pgQhymNb+MbAYhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@cogeotiff/core": "^9.5.0",
+        "@developmentseed/affine": "^0.6.1",
+        "@developmentseed/deck.gl-raster": "^0.6.1",
+        "@developmentseed/geotiff": "^0.6.1",
+        "@developmentseed/morecantile": "^0.6.1",
+        "@developmentseed/proj": "^0.6.1",
+        "@developmentseed/raster-reproject": "^0.6.1",
+        "flatbush": "^4.5.0",
+        "proj4": "^2.20.4"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "^9.3.0",
+        "@deck.gl/geo-layers": "^9.3.0",
+        "@deck.gl/layers": "^9.3.0",
+        "@deck.gl/mesh-layers": "^9.3.0",
+        "@luma.gl/core": "^9.3.2"
+      }
+    },
+    "node_modules/maplibre-gl-raster/node_modules/@developmentseed/deck.gl-raster": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@developmentseed/deck.gl-raster/-/deck.gl-raster-0.6.1.tgz",
+      "integrity": "sha512-0ODeinL6G7awL8l3wa3tzdgX+CvzELaxG67qIrj6wZRIMea8qRCvXgpmhSeB41VBqbAayH8Jbl6nRYziFwbgPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@developmentseed/affine": "^0.6.1",
+        "@developmentseed/proj": "^0.6.1",
+        "@developmentseed/raster-reproject": "^0.6.1",
+        "@math.gl/core": "^4.1.0",
+        "@math.gl/culling": "^4.1.0",
+        "@math.gl/web-mercator": "^4.1.0"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "^9.3.0",
+        "@deck.gl/geo-layers": "^9.3.0",
+        "@deck.gl/layers": "^9.3.0",
+        "@deck.gl/mesh-layers": "^9.3.0",
+        "@developmentseed/morecantile": "^0.6.1",
+        "@luma.gl/core": "^9.3.2",
+        "@luma.gl/shadertools": "^9.3.2"
+      }
+    },
+    "node_modules/maplibre-gl-raster/node_modules/@developmentseed/geotiff": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@developmentseed/geotiff/-/geotiff-0.6.1.tgz",
+      "integrity": "sha512-gAqVglVP+2w7LMODaKNXMbWEyOQjaBwVibLzog1EY+N2S9r7eh1KT27k/VLS3ksf+Rqn3PZnUkJ/cGHumSHFEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@chunkd/middleware": "^11.2.0",
+        "@chunkd/source": "^11.2.0",
+        "@chunkd/source-http": "^11.2.0",
+        "@chunkd/source-memory": "^11.0.3",
+        "@cogeotiff/core": "^9.5.0",
+        "@developmentseed/affine": "^0.6.1",
+        "@developmentseed/lzw-tiff-decoder": "^0.2.2",
+        "@developmentseed/morecantile": "^0.6.1",
+        "@developmentseed/proj": "^0.6.1",
+        "fzstd": "^0.1.1",
+        "lerc": "^4.1.1",
+        "uuid": "^14.0.0"
+      }
+    },
+    "node_modules/maplibre-gl-raster/node_modules/@developmentseed/morecantile": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@developmentseed/morecantile/-/morecantile-0.6.1.tgz",
+      "integrity": "sha512-65icLFsLYThYIINsii95g0gnL4enmBstTdHxmAue66UBtrOXBGm6+PccbRLhGSyrYQHXTg4YZNl7zCetdh6PYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@developmentseed/affine": "^0.6.1"
+      }
+    },
+    "node_modules/maplibre-gl-raster/node_modules/@developmentseed/proj": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@developmentseed/proj/-/proj-0.6.1.tgz",
+      "integrity": "sha512-2FjoFt06pcvQrgZeXbK68mixIpiUrnnGwasQqJGCzTnnATWx3f5clhGqJEpP0MPx36g1oyZLaA7qoTryx5Ggow==",
+      "license": "MIT",
+      "dependencies": {
+        "wkt-parser": "1.5.5"
+      }
+    },
+    "node_modules/maplibre-gl-raster/node_modules/@developmentseed/raster-reproject": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@developmentseed/raster-reproject/-/raster-reproject-0.6.1.tgz",
+      "integrity": "sha512-1/xyCW5dpfsoiphCto7UVoV1k4Br9XOYU1K5gGtJy50gbmyjag7sOpFHrtc/Cjn/ZMKSe9DJT2XF8J25N+MDbw==",
+      "license": "MIT"
+    },
+    "node_modules/maplibre-gl-raster/node_modules/lerc": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-4.1.1.tgz",
+      "integrity": "sha512-rgMqdHK4+gIUnF80OkWyfRae2u1B96BT8ZAjbLB4xfxIdfCHQ9GOf17haZVCag+5X9WC+40hLNZPbwctFs2FPQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/maplibre-gl-raster/node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
     "node_modules/maplibre-gl-splat": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/maplibre-gl-splat/-/maplibre-gl-splat-0.2.2.tgz",
@@ -14642,6 +14794,7 @@
         "maplibre-gl-geoparquet": "^0.2.1",
         "maplibre-gl-lidar": "^0.14.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
+        "maplibre-gl-raster": "^0.1.1",
         "maplibre-gl-streetview": "^0.4.0",
         "maplibre-gl-swipe": "^0.7.1",
         "proj4": "^2.20.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "maplibre-gl-geoparquet": "^0.2.1",
         "maplibre-gl-lidar": "^0.14.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.1.2",
+        "maplibre-gl-raster": "^0.1.3",
         "maplibre-gl-streetview": "^0.4.0",
         "maplibre-gl-swipe": "^0.7.1",
         "react": "^18.3.1",
@@ -10960,9 +10960,9 @@
       }
     },
     "node_modules/maplibre-gl-raster": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.1.2.tgz",
-      "integrity": "sha512-zOFQpVeEsXYoDByLiK9gMDn7ra1/OAF6LrdJObeoPd7Xvu3u1hFMg3vZ2G/S9KhhG4Sx69cwXq6tNZzhWHxvBg==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.1.3.tgz",
+      "integrity": "sha512-Ao2eXmjSM6FIZE68EXxoctqFbs1EUdrPaMZCOxHw6ChY/6A5PRnJVmTlH/5m+ZpHUODQhtQxfKlsbcOigCq2pw==",
       "license": "MIT",
       "dependencies": {
         "@chunkd/middleware": "^11.3.0",
@@ -14794,7 +14794,7 @@
         "maplibre-gl-geoparquet": "^0.2.1",
         "maplibre-gl-lidar": "^0.14.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.1.2",
+        "maplibre-gl-raster": "^0.1.3",
         "maplibre-gl-streetview": "^0.4.0",
         "maplibre-gl-swipe": "^0.7.1",
         "proj4": "^2.20.8",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -38,7 +38,7 @@
     "maplibre-gl-geoparquet": "^0.2.1",
     "maplibre-gl-lidar": "^0.14.1",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.1.1",
+    "maplibre-gl-raster": "^0.1.2",
     "maplibre-gl-streetview": "^0.4.0",
     "maplibre-gl-swipe": "^0.7.1",
     "proj4": "^2.20.8",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -38,6 +38,7 @@
     "maplibre-gl-geoparquet": "^0.2.1",
     "maplibre-gl-lidar": "^0.14.1",
     "maplibre-gl-planetary-computer": "^0.3.0",
+    "maplibre-gl-raster": "^0.1.1",
     "maplibre-gl-streetview": "^0.4.0",
     "maplibre-gl-swipe": "^0.7.1",
     "proj4": "^2.20.8",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -38,7 +38,7 @@
     "maplibre-gl-geoparquet": "^0.2.1",
     "maplibre-gl-lidar": "^0.14.1",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.1.2",
+    "maplibre-gl-raster": "^0.1.3",
     "maplibre-gl-streetview": "^0.4.0",
     "maplibre-gl-swipe": "^0.7.1",
     "proj4": "^2.20.8",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -59,6 +59,20 @@ export {
   openThreeDTilesLayerPanel,
   restoreThreeDTilesLayers,
 } from "./plugins/maplibre-3d-tiles";
+export {
+  openRasterLayerPanel,
+  restoreRasterLayers,
+} from "./plugins/maplibre-raster";
+export {
+  createRasterStoreLayer,
+  isRasterControlStoreLayer,
+  removeRasterStoreLayers,
+  savedRasterState,
+  syncRasterLayersToStore,
+  unwireRasterStoreSync,
+  wireRasterStoreSync,
+  type RasterSyncableControl,
+} from "./plugins/raster-layer-sync";
 export { maplibreEsriWaybackPlugin } from "./plugins/maplibre-esri-wayback";
 export { maplibreGeoEditorPlugin } from "./plugins/maplibre-geo-editor";
 export { maplibreGeoAgentPlugin } from "./plugins/maplibre-geoagent";

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -63,16 +63,9 @@ export {
   openRasterLayerPanel,
   restoreRasterLayers,
 } from "./plugins/maplibre-raster";
-export {
-  createRasterStoreLayer,
-  isRasterControlStoreLayer,
-  removeRasterStoreLayers,
-  savedRasterState,
-  syncRasterLayersToStore,
-  unwireRasterStoreSync,
-  wireRasterStoreSync,
-  type RasterSyncableControl,
-} from "./plugins/raster-layer-sync";
+// The raster-layer-sync internals are not re-exported: the app drives the
+// panel through the two functions above, and the tests import the sync
+// helpers from the module path directly.
 export { maplibreEsriWaybackPlugin } from "./plugins/maplibre-esri-wayback";
 export { maplibreGeoEditorPlugin } from "./plugins/maplibre-geo-editor";
 export { maplibreGeoAgentPlugin } from "./plugins/maplibre-geoagent";

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -12,6 +12,9 @@ import {
 } from "./raster-layer-sync";
 
 const rasterControlPosition: GeoLibreMapControlPosition = "top-left";
+const RASTER_PANEL_CLASS = "geolibre-raster-panel";
+const DEFAULT_RASTER_URL =
+  "https://data.source.coop/giswqs/opengeos/nlcd_2021_land_cover_30m.tif";
 
 // These types mirror undocumented private members of RasterControl from
 // maplibre-gl-raster (verified against v0.1.1). All access is optional (?.)
@@ -148,6 +151,7 @@ async function ensureRasterControl(
     hideRasterControl(rasterControl);
     disableRasterClickOutsideCollapse(rasterControl);
     wireRasterCloseButton(rasterControl);
+    applyRasterPanelClass(rasterControl);
   }
 
   return rasterControl;
@@ -168,6 +172,7 @@ function createRasterControl(
   const control = new RasterControlClass({
     className: "geolibre-raster-control",
     collapsed: true,
+    defaultUrl: DEFAULT_RASTER_URL,
     panelWidth: 380,
     title: "Add Raster Layer",
   });
@@ -217,6 +222,15 @@ function disableRasterClickOutsideCollapse(control: RasterControl): void {
   if (!handler) return;
   document.removeEventListener("click", handler);
   internals._clickOutsideHandler = null;
+}
+
+// The upstream stylesheet themes the panel from prefers-color-scheme (the
+// OS setting), while GeoLibre themes from the .dark class on <html>. The
+// app maps the panel's --mlr-* custom properties onto its own theme tokens
+// under this class (see index.css), so the panel follows the app theme.
+function applyRasterPanelClass(control: RasterControl): void {
+  const internals = control as unknown as RasterControlInternals;
+  internals._panel?.classList.add(RASTER_PANEL_CLASS);
 }
 
 // The upstream close button only collapses the panel, leaving the map

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -1,0 +1,236 @@
+import { useAppStore } from "@geolibre/core";
+import type { RasterControl } from "maplibre-gl-raster";
+import type { GeoLibreAppAPI, GeoLibreMapControlPosition } from "../types";
+import { ensureMercatorProjection } from "./map-projection-utils";
+import {
+  isRasterControlStoreLayer,
+  runWithRasterStoreSyncSuspended,
+  savedRasterState,
+  syncRasterLayersToStore,
+  unwireRasterStoreSync,
+  wireRasterStoreSync,
+} from "./raster-layer-sync";
+
+const rasterControlPosition: GeoLibreMapControlPosition = "top-left";
+
+// These types mirror undocumented private members of RasterControl from
+// maplibre-gl-raster (verified against v0.1.1). All access is optional (?.)
+// so a rename in a future release degrades to a no-op rather than a crash --
+// re-verify these names when bumping the dependency.
+type RasterControlInternals = {
+  _clickOutsideHandler?: ((event: MouseEvent) => void) | null;
+  _panel?: HTMLElement;
+};
+
+type RasterControlConstructor = typeof RasterControl;
+
+let rasterControlClassPromise: Promise<RasterControlConstructor> | null = null;
+let rasterControl: RasterControl | null = null;
+let rasterControlMounted = false;
+
+/**
+ * Opens the maplibre-gl-raster panel, mounting the control on first use.
+ * Replaces the former Add Raster Layer dialog: the panel loads COGs and
+ * GeoTIFFs from URLs or local files and edits bands, rescale, colormaps,
+ * nodata, stretch, gamma, and opacity per layer.
+ *
+ * @param app - The GeoLibre app API.
+ */
+export function openRasterLayerPanel(app: GeoLibreAppAPI): void {
+  void (async () => {
+    const control = await ensureRasterControl(app);
+    if (!control) return;
+    window.setTimeout(() => {
+      showRasterControl(control);
+      control.expand();
+    }, 0);
+  })();
+}
+
+/**
+ * Replays URL-backed rasters from the loaded project into the control and
+ * drops control rasters the project does not contain. Called by the desktop
+ * shell whenever a project is loaded or the map is reinitialised, mirroring
+ * restoreThreeDTilesLayers. Local-file rasters cannot be reloaded from a
+ * saved project, so their panel entries are removed with a notice.
+ *
+ * @param app - The GeoLibre app API.
+ */
+export function restoreRasterLayers(app: GeoLibreAppAPI): void {
+  const hasRasterLayers = useAppStore
+    .getState()
+    .layers.some(isRasterControlStoreLayer);
+  if (!hasRasterLayers && !rasterControl) return;
+
+  void (async () => {
+    const control = await ensureRasterControl(app);
+    if (!control) return;
+
+    // Re-read the store after the await: the project may have changed while
+    // the control class was loading.
+    const storeLayerIds = new Set(
+      useAppStore
+        .getState()
+        .layers.filter(isRasterControlStoreLayer)
+        .map((layer) => layer.id),
+    );
+
+    const pending: Promise<unknown>[] = [];
+    runWithRasterStoreSyncSuspended(() => {
+      for (const info of control.getRasters()) {
+        if (!storeLayerIds.has(info.id)) control.removeRaster(info.id);
+      }
+
+      for (const layer of useAppStore.getState().layers) {
+        if (!isRasterControlStoreLayer(layer)) continue;
+        if (control.getRaster(layer.id)) continue;
+
+        const url =
+          typeof layer.source.url === "string" && layer.source.url
+            ? layer.source.url
+            : undefined;
+        if (!url) {
+          console.info(
+            `[GeoLibre] Raster layer "${layer.name}" came from a local file and cannot be restored from the saved project.`,
+          );
+          useAppStore.getState().removeLayer(layer.id);
+          continue;
+        }
+
+        pending.push(
+          control
+            .addRaster(url, {
+              id: layer.id,
+              name: layer.name,
+              state: {
+                ...savedRasterState(layer),
+                opacity: layer.opacity,
+                visible: layer.visible,
+              },
+              zoomTo: false,
+            })
+            .catch((error) => {
+              console.error(
+                `[GeoLibre] Failed to restore raster layer "${layer.name}"`,
+                error,
+              );
+            }),
+        );
+      }
+    });
+
+    // Each addRaster syncs on its own events too, but those run while other
+    // restores may still be loading; this final pass settles the store once
+    // every raster has either loaded or failed.
+    void Promise.allSettled(pending).then(() => {
+      syncRasterLayersToStore(control);
+    });
+  })();
+}
+
+async function ensureRasterControl(
+  app: GeoLibreAppAPI,
+): Promise<RasterControl | null> {
+  const RasterControlClass = await getRasterControlClass();
+
+  rasterControl ??= createRasterControl(RasterControlClass);
+
+  if (!rasterControlMounted) {
+    const added = app.addMapControl(rasterControl, rasterControlPosition);
+    if (!added) {
+      unwireRasterStoreSync();
+      rasterControl = null;
+      return null;
+    }
+    rasterControlMounted = true;
+    // The control mounts hidden: project restore must not surface a map
+    // button the user never asked for. openRasterLayerPanel shows it.
+    hideRasterControl(rasterControl);
+    disableRasterClickOutsideCollapse(rasterControl);
+    wireRasterCloseButton(rasterControl);
+  }
+
+  return rasterControl;
+}
+
+function getRasterControlClass(): Promise<RasterControlConstructor> {
+  // Defer the maplibre-gl-raster import (and its deck.gl GeoTIFF pipeline)
+  // until the user first opens the panel or a project restores a raster.
+  rasterControlClassPromise ??= import("maplibre-gl-raster").then(
+    (module) => module.RasterControl,
+  );
+  return rasterControlClassPromise;
+}
+
+function createRasterControl(
+  RasterControlClass: RasterControlConstructor,
+): RasterControl {
+  const control = new RasterControlClass({
+    className: "geolibre-raster-control",
+    collapsed: true,
+    panelWidth: 380,
+    title: "Add Raster Layer",
+  });
+
+  // deck.gl's COG tile traversal does not support MapLibre's globe view
+  // ("TODO: implement getBoundingVolume in Globe view"), so adding a raster
+  // switches the map to mercator, like the other deck.gl-backed plugins.
+  control.on("rasteradd", () => ensureMercatorProjection(control.getMap()));
+  for (const event of ["rasteradd", "rasterchange", "rasterremove"] as const) {
+    control.on(event, () => syncRasterLayersToStore(control));
+  }
+  wireRasterStoreSync(control);
+  patchRasterControlOnRemove(control);
+
+  return control;
+}
+
+function patchRasterControlOnRemove(control: RasterControl): void {
+  const originalOnRemove = control.onRemove.bind(control);
+  control.onRemove = () => {
+    originalOnRemove();
+    if (rasterControl !== control) return;
+    unwireRasterStoreSync();
+    rasterControl = null;
+    rasterControlMounted = false;
+  };
+}
+
+function showRasterControl(control: RasterControl): void {
+  const container = control.getContainer();
+  if (container) container.style.display = "";
+}
+
+function hideRasterControl(control: RasterControl): void {
+  control.collapse();
+  const container = control.getContainer();
+  if (container) container.style.display = "none";
+}
+
+// The control collapses its panel when the user clicks anywhere else on the
+// page, which fights the panel's role as the Add Raster Layer dialog (e.g.
+// panning the map to inspect a loaded COG would close it). Removing the
+// handler keeps the panel open until the user closes it explicitly.
+function disableRasterClickOutsideCollapse(control: RasterControl): void {
+  const internals = control as unknown as RasterControlInternals;
+  const handler = internals._clickOutsideHandler;
+  if (!handler) return;
+  document.removeEventListener("click", handler);
+  internals._clickOutsideHandler = null;
+}
+
+// The upstream close button only collapses the panel, leaving the map
+// button visible. Hide the whole control too so closing the panel restores
+// the pre-open map, like dismissing the dialog it replaces. Loaded rasters
+// keep rendering; the layer panel still manages them.
+function wireRasterCloseButton(control: RasterControl): void {
+  const panel = (control as unknown as RasterControlInternals)._panel;
+  const closeButton = panel?.querySelector<HTMLElement>(
+    ".plugin-control-close",
+  );
+  if (!closeButton || closeButton.dataset.geolibreCloseWired === "true") {
+    return;
+  }
+  closeButton.dataset.geolibreCloseWired = "true";
+  closeButton.addEventListener("click", () => hideRasterControl(control));
+}

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -56,9 +56,11 @@ export function openRasterLayerPanel(app: GeoLibreAppAPI): void {
         control.expand();
         // Idempotent (guarded by a dataset flag / null checks): retried on
         // every open so the panel chrome stays wired even if a future
-        // upstream release builds the panel DOM lazily on first expand.
+        // upstream release builds the panel DOM (or registers the
+        // click-outside handler) lazily on first expand.
         wireRasterCloseButton(control);
         applyRasterPanelClass(control);
+        disableRasterClickOutsideCollapse(control);
       } catch (error) {
         console.error(
           "[GeoLibre] Failed to open the raster layer panel",
@@ -126,6 +128,8 @@ export function restoreRasterLayers(app: GeoLibreAppAPI): void {
           console.info(
             `[GeoLibre] Raster layer "${layer.name}" came from a local file and cannot be restored from the saved project.`,
           );
+          // removeLayer fires the store subscriber synchronously; the
+          // suspension guard keeps it from echoing back at the control.
           useAppStore.getState().removeLayer(layer.id);
           continue;
         }
@@ -241,6 +245,9 @@ function patchRasterControlOnRemove(control: RasterControl): void {
     // A control torn down mid-restore must not leave its successor
     // permanently suppressing store sync events.
     resetRasterStoreSyncSuspension();
+    // Store layers are intentionally NOT pruned here: the control is
+    // removed on map reinitialisation, where they must survive so
+    // restoreRasterLayers can replay them into the successor control.
     rasterControl = null;
     rasterControlMounted = false;
   };

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -45,13 +45,21 @@ export function openRasterLayerPanel(app: GeoLibreAppAPI): void {
     const control = await ensureRasterControl(app);
     if (!control) return;
     window.setTimeout(() => {
-      showRasterControl(control);
-      control.expand();
-      // Idempotent (guarded by a dataset flag / null checks): retried on
-      // every open so the panel chrome stays wired even if a future
-      // upstream release builds the panel DOM lazily on first expand.
-      wireRasterCloseButton(control);
-      applyRasterPanelClass(control);
+      // The IIFE's catch cannot see exceptions thrown in this later task.
+      try {
+        showRasterControl(control);
+        control.expand();
+        // Idempotent (guarded by a dataset flag / null checks): retried on
+        // every open so the panel chrome stays wired even if a future
+        // upstream release builds the panel DOM lazily on first expand.
+        wireRasterCloseButton(control);
+        applyRasterPanelClass(control);
+      } catch (error) {
+        console.error(
+          "[GeoLibre] Failed to open the raster layer panel",
+          error,
+        );
+      }
     }, 0);
   })().catch((error) => {
     console.error("[GeoLibre] Failed to open the raster layer panel", error);
@@ -101,6 +109,9 @@ export function restoreRasterLayers(app: GeoLibreAppAPI): void {
             ? layer.source.url
             : undefined;
         if (!url) {
+          // Console-only on purpose for this first pass: the plugin layer has
+          // no toast/notification API today. Surface this through an in-app
+          // notification once one is exposed to plugins.
           console.info(
             `[GeoLibre] Raster layer "${layer.name}" came from a local file and cannot be restored from the saved project.`,
           );
@@ -134,6 +145,9 @@ export function restoreRasterLayers(app: GeoLibreAppAPI): void {
     // restores may still be loading; this final pass settles the store once
     // every raster has either loaded or failed.
     void Promise.allSettled(pending).then(() => {
+      // A control torn down mid-restore (map reinitialisation) must not let
+      // this stale callback rewrite layers owned by its successor.
+      if (control !== rasterControl) return;
       syncRasterLayersToStore(control);
     });
   })().catch((error) => {
@@ -260,7 +274,7 @@ function applyRasterPanelClass(control: RasterControl): void {
 function wireRasterCloseButton(control: RasterControl): void {
   const panel = (control as unknown as RasterControlInternals)._panel;
   const closeButton = panel?.querySelector<HTMLElement>(
-    ".plugin-control-close",
+    ".mlr-control-close",
   );
   if (!closeButton || closeButton.dataset.geolibreCloseWired === "true") {
     return;

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -18,9 +18,10 @@ const DEFAULT_RASTER_URL =
   "https://data.source.coop/giswqs/opengeos/nlcd_2021_land_cover_30m.tif";
 
 // These types mirror undocumented private members of RasterControl from
-// maplibre-gl-raster (verified against v0.1.1). All access is optional (?.)
+// maplibre-gl-raster (verified against v0.1.2). All access is optional (?.)
 // so a rename in a future release degrades to a no-op rather than a crash --
-// re-verify these names when bumping the dependency.
+// re-verify these names AND the .mlr-control-close selector in
+// wireRasterCloseButton when bumping the dependency.
 type RasterControlInternals = {
   _clickOutsideHandler?: ((event: MouseEvent) => void) | null;
   _panel?: HTMLElement;
@@ -44,6 +45,10 @@ export function openRasterLayerPanel(app: GeoLibreAppAPI): void {
   void (async () => {
     const control = await ensureRasterControl(app);
     if (!control) return;
+    // Defer by one task so the control finishes its mount cycle before the
+    // panel is shown and expanded, matching the other standalone panels
+    // (Earth Engine, 3D Tiles); expanding in the same task as addControl can
+    // measure the panel before MapLibre has laid the control out.
     window.setTimeout(() => {
       // The IIFE's catch cannot see exceptions thrown in this later task.
       try {
@@ -95,6 +100,12 @@ export function restoreRasterLayers(app: GeoLibreAppAPI): void {
     );
 
     const pending: Promise<unknown>[] = [];
+    // The suspension covers the synchronous events fired inside this block:
+    // removeRaster's rasterremove, and the rasteradd each addRaster emits
+    // before it awaits the GeoTIFF header (without it, the first rasteradd
+    // sync would prune store layers not yet replayed). The rasterchange
+    // events that follow header loads land after this window and sync
+    // incrementally; the Promise.allSettled pass below settles the rest.
     runWithRasterStoreSyncSuspended(() => {
       for (const info of control.getRasters()) {
         if (!storeLayerIds.has(info.id)) control.removeRaster(info.id);

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -4,6 +4,7 @@ import type { GeoLibreAppAPI, GeoLibreMapControlPosition } from "../types";
 import { ensureMercatorProjection } from "./map-projection-utils";
 import {
   isRasterControlStoreLayer,
+  resetRasterStoreSyncSuspension,
   runWithRasterStoreSyncSuspended,
   savedRasterState,
   syncRasterLayersToStore,
@@ -46,8 +47,15 @@ export function openRasterLayerPanel(app: GeoLibreAppAPI): void {
     window.setTimeout(() => {
       showRasterControl(control);
       control.expand();
+      // Idempotent (guarded by a dataset flag / null checks): retried on
+      // every open so the panel chrome stays wired even if a future
+      // upstream release builds the panel DOM lazily on first expand.
+      wireRasterCloseButton(control);
+      applyRasterPanelClass(control);
     }, 0);
-  })();
+  })().catch((error) => {
+    console.error("[GeoLibre] Failed to open the raster layer panel", error);
+  });
 }
 
 /**
@@ -128,7 +136,9 @@ export function restoreRasterLayers(app: GeoLibreAppAPI): void {
     void Promise.allSettled(pending).then(() => {
       syncRasterLayersToStore(control);
     });
-  })();
+  })().catch((error) => {
+    console.error("[GeoLibre] Failed to restore raster layers", error);
+  });
 }
 
 async function ensureRasterControl(
@@ -162,6 +172,13 @@ function getRasterControlClass(): Promise<RasterControlConstructor> {
   // until the user first opens the panel or a project restores a raster.
   rasterControlClassPromise ??= import("maplibre-gl-raster").then(
     (module) => module.RasterControl,
+    (error: unknown) => {
+      // Do not cache the rejection: a transient failure (e.g. the dev
+      // server restarting) would otherwise make every later open re-throw
+      // until the page reloads.
+      rasterControlClassPromise = null;
+      throw error;
+    },
   );
   return rasterControlClassPromise;
 }
@@ -196,6 +213,9 @@ function patchRasterControlOnRemove(control: RasterControl): void {
     originalOnRemove();
     if (rasterControl !== control) return;
     unwireRasterStoreSync();
+    // A control torn down mid-restore must not leave its successor
+    // permanently suppressing store sync events.
+    resetRasterStoreSyncSuspension();
     rasterControl = null;
     rasterControlMounted = false;
   };

--- a/packages/plugins/src/plugins/raster-layer-sync.ts
+++ b/packages/plugins/src/plugins/raster-layer-sync.ts
@@ -138,8 +138,8 @@ export function syncRasterLayersToStore(control: RasterSyncableControl): void {
         existing.visible !== layer.visible ||
         existing.opacity !== layer.opacity ||
         existing.sourcePath !== layer.sourcePath ||
-        JSON.stringify(existing.source) !== JSON.stringify(layer.source) ||
-        JSON.stringify(existing.metadata) !== JSON.stringify(layer.metadata)
+        !recordsEqual(existing.source, layer.source) ||
+        !recordsEqual(existing.metadata, layer.metadata)
       ) {
         useAppStore.getState().updateLayer(layer.id, {
           // Replace metadata wholesale so stale keys (error, bounds) cannot
@@ -220,6 +220,10 @@ export function unwireRasterStoreSync(): void {
 /**
  * Removes every control-managed raster layer from the store, without
  * echoing the removals back at the control.
+ *
+ * Deliberately NOT called from the control's onRemove teardown: the control
+ * is removed on map reinitialisation, where the store layers must survive
+ * so restoreRasterLayers can replay them into the successor control.
  */
 export function removeRasterStoreLayers(): void {
   syncingLayersToStore = true;
@@ -314,6 +318,10 @@ export function savedRasterState(
   ) {
     state.rescale = candidate.rescale as [number, number][] | null;
   }
+  // The valid names are a runtime property of maplibre-gl-raster (90+
+  // colormaps), so no allowlist here; the control tolerates unknown names
+  // (addRaster does not validate them and rendering falls back) rather
+  // than throwing on restore.
   if (typeof candidate.colormap === "string" && candidate.colormap) {
     state.colormap = candidate.colormap;
   }
@@ -324,7 +332,13 @@ export function savedRasterState(
   ) {
     state.nodata = candidate.nodata;
   }
-  if (typeof candidate.gamma === "number" && Number.isFinite(candidate.gamma)) {
+  // Gamma is a power-law exponent; zero and negative values are physically
+  // meaningless and could misbehave in the shader.
+  if (
+    typeof candidate.gamma === "number" &&
+    Number.isFinite(candidate.gamma) &&
+    candidate.gamma > 0
+  ) {
     state.gamma = candidate.gamma;
   }
   if (
@@ -336,6 +350,39 @@ export function savedRasterState(
   }
 
   return state;
+}
+
+// Key-order-insensitive deep equality for source/metadata records, matching
+// the helper of the same name in maplibre-3d-tiles.ts. JSON.stringify would
+// report a difference for semantically equal objects whose keys were built
+// in a different order, forcing a spurious updateLayer on every event.
+function recordsEqual(
+  left: Record<string, unknown>,
+  right: Record<string, unknown>,
+): boolean {
+  const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
+  for (const key of keys) {
+    if (!valuesEqual(left[key], right[key])) return false;
+  }
+  return true;
+}
+
+function valuesEqual(left: unknown, right: unknown): boolean {
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right)) return false;
+    if (left.length !== right.length) return false;
+    return left.every((value, index) => valuesEqual(value, right[index]));
+  }
+
+  if (isRecord(left) || isRecord(right)) {
+    return isRecord(left) && isRecord(right) && recordsEqual(left, right);
+  }
+
+  return Object.is(left, right);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function serializableRasterState(

--- a/packages/plugins/src/plugins/raster-layer-sync.ts
+++ b/packages/plugins/src/plugins/raster-layer-sync.ts
@@ -58,7 +58,8 @@ export function isRasterControlStoreLayer(layer: GeoLibreLayer): boolean {
  */
 export function createRasterStoreLayer(info: RasterLayerInfo): GeoLibreLayer {
   const url = info.source.kind === "url" ? info.source.url : undefined;
-  const sourcePath = url ?? (info.source.kind === "file" ? info.source.fileName : info.id);
+  const sourcePath =
+    url ?? (info.source.kind === "file" ? info.source.fileName : info.id);
   return {
     id: info.id,
     name: info.name,
@@ -296,16 +297,22 @@ export function savedRasterState(
   ) {
     state.bands = candidate.bands as number[];
   }
+  // null is the control's "auto rescale from stats" state and round-trips
+  // explicitly; an empty array is not a meaningful rescale value.
   if (
-    Array.isArray(candidate.rescale) &&
-    candidate.rescale.every(
-      (range) =>
-        Array.isArray(range) &&
-        range.length === 2 &&
-        range.every((value) => typeof value === "number" && Number.isFinite(value)),
-    )
+    candidate.rescale === null ||
+    (Array.isArray(candidate.rescale) &&
+      candidate.rescale.length > 0 &&
+      candidate.rescale.every(
+        (range) =>
+          Array.isArray(range) &&
+          range.length === 2 &&
+          range.every(
+            (value) => typeof value === "number" && Number.isFinite(value),
+          ),
+      ))
   ) {
-    state.rescale = candidate.rescale as [number, number][];
+    state.rescale = candidate.rescale as [number, number][] | null;
   }
   if (typeof candidate.colormap === "string" && candidate.colormap) {
     state.colormap = candidate.colormap;

--- a/packages/plugins/src/plugins/raster-layer-sync.ts
+++ b/packages/plugins/src/plugins/raster-layer-sync.ts
@@ -260,6 +260,15 @@ export function isRasterStoreSyncSuspended(): boolean {
 }
 
 /**
+ * Clears the suspension counter. Called on control teardown so a control
+ * torn down mid-restore cannot leave its successor permanently suppressing
+ * store sync events.
+ */
+export function resetRasterStoreSyncSuspension(): void {
+  storeSyncSuspended = 0;
+}
+
+/**
  * Reads the persisted visualization state from a store layer's metadata,
  * keeping only well-formed fields so a hand-edited project file cannot
  * crash the control.

--- a/packages/plugins/src/plugins/raster-layer-sync.ts
+++ b/packages/plugins/src/plugins/raster-layer-sync.ts
@@ -341,8 +341,12 @@ export function savedRasterState(
 function serializableRasterState(
   state: RasterLayerState,
 ): Record<string, unknown> {
+  // visible and opacity live on the top-level layer fields (the panel edits
+  // them there); persisting copies here would leave two competing values in
+  // a saved project file, so they are omitted.
+  const { visible: _visible, opacity: _opacity, ...vizState } = state;
   return {
-    ...state,
+    ...vizState,
     bands: [...state.bands],
     rescale: state.rescale?.map((range) => [...range]) ?? null,
   };

--- a/packages/plugins/src/plugins/raster-layer-sync.ts
+++ b/packages/plugins/src/plugins/raster-layer-sync.ts
@@ -1,0 +1,333 @@
+import {
+  DEFAULT_LAYER_STYLE,
+  type GeoLibreLayer,
+  useAppStore,
+} from "@geolibre/core";
+import type { RasterLayerInfo, RasterLayerState } from "maplibre-gl-raster";
+
+export const RASTER_SOURCE_KIND = "maplibre-gl-raster";
+
+/**
+ * The slice of the maplibre-gl-raster RasterControl surface the store sync
+ * drives. Structural (rather than the concrete class) so tests can pass
+ * fakes without touching deck.gl or a real map.
+ */
+export type RasterSyncableControl = {
+  getRasters: () => RasterLayerInfo[];
+  removeRaster: (id: string) => void;
+  setRasterState: (id: string, patch: Partial<RasterLayerState>) => void;
+  setVisible: (id: string, visible: boolean) => void;
+};
+
+let syncedControl: RasterSyncableControl | null = null;
+let storeUnsubscribe: (() => void) | null = null;
+// Guards the store subscriber against re-entrancy: store mutations made by
+// syncRasterLayersToStore fire the subscriber synchronously, which would
+// otherwise echo removeRaster calls back at the control for layers it
+// already dropped from its own list.
+let syncingLayersToStore = false;
+// Suspends event-driven control->store syncs while this module itself is
+// mutating the control (store->control pushes, project restore). The
+// control emits raster* events synchronously from those calls, and syncing
+// mid-mutation would observe a partially updated layer list.
+let storeSyncSuspended = 0;
+
+/**
+ * Detects a layer panel entry owned by the maplibre-gl-raster control.
+ *
+ * @param layer - A store layer.
+ * @returns True when the layer mirrors a control-managed raster.
+ */
+export function isRasterControlStoreLayer(layer: GeoLibreLayer): boolean {
+  return (
+    layer.metadata.sourceKind === RASTER_SOURCE_KIND &&
+    layer.metadata.externalNativeLayer === true
+  );
+}
+
+/**
+ * Builds the store layer mirroring a control raster snapshot.
+ *
+ * The deck.gl COGLayer renders through the control's shared overlay, so the
+ * store layer registers as an external custom layer: layer-sync manages
+ * ordering only, and wireRasterStoreSync applies panel visibility/opacity
+ * back through the control API.
+ *
+ * @param info - Public raster snapshot from RasterControl.getRasters().
+ * @returns The corresponding GeoLibre store layer.
+ */
+export function createRasterStoreLayer(info: RasterLayerInfo): GeoLibreLayer {
+  const url = info.source.kind === "url" ? info.source.url : undefined;
+  const sourcePath = url ?? (info.source.kind === "file" ? info.source.fileName : info.id);
+  return {
+    id: info.id,
+    name: info.name,
+    type: "cog",
+    source: {
+      type: "raster",
+      ...(url ? { url } : {}),
+    },
+    visible: info.state.visible,
+    opacity: info.state.opacity,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {
+      customLayerType: "raster",
+      externalNativeLayer: true,
+      identifiable: false,
+      // In interleaved mode the deck.gl overlay inserts one custom style
+      // layer per raster, keyed by the raster id, so ordering moves reach it.
+      nativeLayerIds: [info.id],
+      // The visualization state is persisted so restoreRasterLayers can
+      // replay URL-backed rasters when a saved project is reopened.
+      rasterSource: info.source.kind,
+      rasterState: serializableRasterState(info.state),
+      sourceIds: [],
+      sourceKind: RASTER_SOURCE_KIND,
+      ...(info.bounds
+        ? {
+            bounds: [
+              info.bounds.west,
+              info.bounds.south,
+              info.bounds.east,
+              info.bounds.north,
+            ],
+          }
+        : {}),
+      ...(info.error ? { error: info.error.message } : {}),
+    },
+    sourcePath,
+  };
+}
+
+/**
+ * Diffs the control's raster list into the app store so the layer panel
+ * lists control-managed rasters. Adds new rasters, drops store layers whose
+ * rasters are gone, and refreshes changed fields on existing layers. The
+ * name is only seeded on creation so panel renames survive later syncs.
+ *
+ * @param control - The raster control to mirror.
+ */
+export function syncRasterLayersToStore(control: RasterSyncableControl): void {
+  if (isRasterStoreSyncSuspended()) return;
+
+  const infos = control.getRasters();
+  const infoIds = new Set(infos.map((info) => info.id));
+
+  syncingLayersToStore = true;
+  try {
+    for (const storeLayer of useAppStore.getState().layers) {
+      if (!isRasterControlStoreLayer(storeLayer)) continue;
+      if (!infoIds.has(storeLayer.id)) {
+        useAppStore.getState().removeLayer(storeLayer.id);
+      }
+    }
+
+    for (const info of infos) {
+      const layer = createRasterStoreLayer(info);
+      const existing = useAppStore
+        .getState()
+        .layers.find((current) => current.id === layer.id);
+
+      if (!existing) {
+        useAppStore.getState().addLayer(layer);
+        continue;
+      }
+
+      if (
+        existing.visible !== layer.visible ||
+        existing.opacity !== layer.opacity ||
+        existing.sourcePath !== layer.sourcePath ||
+        JSON.stringify(existing.source) !== JSON.stringify(layer.source) ||
+        JSON.stringify(existing.metadata) !== JSON.stringify(layer.metadata)
+      ) {
+        useAppStore.getState().updateLayer(layer.id, {
+          // Replace metadata wholesale so stale keys (error, bounds) cannot
+          // survive a raster being swapped out under the same id.
+          metadata: layer.metadata,
+          opacity: layer.opacity,
+          source: layer.source,
+          sourcePath: layer.sourcePath,
+          visible: layer.visible,
+        });
+      }
+    }
+  } finally {
+    syncingLayersToStore = false;
+  }
+}
+
+/**
+ * Watches the store for panel-side changes to control-managed rasters.
+ * Removing a layer in the panel drops the control's raster, and visibility
+ * and opacity edits are applied through the control API because the deck.gl
+ * custom layers skip the generic paint sync in layer-sync.
+ *
+ * Subscribes once; later calls point the sync at the latest control
+ * instance.
+ *
+ * @param control - The raster control to receive store changes.
+ */
+export function wireRasterStoreSync(control: RasterSyncableControl): void {
+  syncedControl = control;
+  storeUnsubscribe ??= useAppStore.subscribe((state, previous) => {
+    const activeControl = syncedControl;
+    if (
+      !activeControl ||
+      syncingLayersToStore ||
+      isRasterStoreSyncSuspended() ||
+      state.layers === previous.layers
+    ) {
+      return;
+    }
+
+    // The subscriber fires on every layers change; skip the per-layer scan
+    // when the previous snapshot held no control-managed rasters at all.
+    if (!previous.layers.some(isRasterControlStoreLayer)) return;
+
+    const currentById = new Map(state.layers.map((layer) => [layer.id, layer]));
+    runWithRasterStoreSyncSuspended(() => {
+      for (const layer of previous.layers) {
+        if (!isRasterControlStoreLayer(layer)) continue;
+
+        const current = currentById.get(layer.id);
+        if (!current) {
+          activeControl.removeRaster(layer.id);
+          continue;
+        }
+
+        if (current.visible !== layer.visible) {
+          activeControl.setVisible(layer.id, current.visible);
+        }
+        if (current.opacity !== layer.opacity) {
+          activeControl.setRasterState(layer.id, { opacity: current.opacity });
+        }
+      }
+    });
+  });
+}
+
+/**
+ * Stops the store subscription and forgets the synced control. Used when
+ * the control is removed from the map.
+ */
+export function unwireRasterStoreSync(): void {
+  storeUnsubscribe?.();
+  storeUnsubscribe = null;
+  syncedControl = null;
+}
+
+/**
+ * Removes every control-managed raster layer from the store, without
+ * echoing the removals back at the control.
+ */
+export function removeRasterStoreLayers(): void {
+  syncingLayersToStore = true;
+  try {
+    for (const layer of useAppStore.getState().layers) {
+      if (isRasterControlStoreLayer(layer)) {
+        useAppStore.getState().removeLayer(layer.id);
+      }
+    }
+  } finally {
+    syncingLayersToStore = false;
+  }
+}
+
+/**
+ * Runs a callback with event-driven control->store syncing (and the
+ * store->control subscriber) suspended. Used around control mutations whose
+ * intermediate states must not be mirrored.
+ *
+ * @param callback - The mutation to run while suspended.
+ * @returns The callback's return value.
+ */
+export function runWithRasterStoreSyncSuspended<T>(callback: () => T): T {
+  storeSyncSuspended += 1;
+  try {
+    return callback();
+  } finally {
+    storeSyncSuspended -= 1;
+  }
+}
+
+/**
+ * Whether sync suppression is currently active.
+ *
+ * @returns True while runWithRasterStoreSyncSuspended is executing.
+ */
+export function isRasterStoreSyncSuspended(): boolean {
+  return storeSyncSuspended > 0;
+}
+
+/**
+ * Reads the persisted visualization state from a store layer's metadata,
+ * keeping only well-formed fields so a hand-edited project file cannot
+ * crash the control.
+ *
+ * @param layer - A store layer created by createRasterStoreLayer.
+ * @returns The state overrides to replay through RasterControl.addRaster.
+ */
+export function savedRasterState(
+  layer: GeoLibreLayer,
+): Partial<RasterLayerState> {
+  const raw = layer.metadata.rasterState;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+  const candidate = raw as Record<string, unknown>;
+  const state: Partial<RasterLayerState> = {};
+
+  if (candidate.mode === "rgb" || candidate.mode === "single") {
+    state.mode = candidate.mode;
+  }
+  if (
+    Array.isArray(candidate.bands) &&
+    candidate.bands.length > 0 &&
+    candidate.bands.every(
+      (band) => typeof band === "number" && Number.isInteger(band) && band > 0,
+    )
+  ) {
+    state.bands = candidate.bands as number[];
+  }
+  if (
+    Array.isArray(candidate.rescale) &&
+    candidate.rescale.every(
+      (range) =>
+        Array.isArray(range) &&
+        range.length === 2 &&
+        range.every((value) => typeof value === "number" && Number.isFinite(value)),
+    )
+  ) {
+    state.rescale = candidate.rescale as [number, number][];
+  }
+  if (typeof candidate.colormap === "string" && candidate.colormap) {
+    state.colormap = candidate.colormap;
+  }
+  if (
+    candidate.nodata === "off" ||
+    candidate.nodata === "auto" ||
+    (typeof candidate.nodata === "number" && Number.isFinite(candidate.nodata))
+  ) {
+    state.nodata = candidate.nodata;
+  }
+  if (typeof candidate.gamma === "number" && Number.isFinite(candidate.gamma)) {
+    state.gamma = candidate.gamma;
+  }
+  if (
+    candidate.stretch === "linear" ||
+    candidate.stretch === "log" ||
+    candidate.stretch === "sqrt"
+  ) {
+    state.stretch = candidate.stretch;
+  }
+
+  return state;
+}
+
+function serializableRasterState(
+  state: RasterLayerState,
+): Record<string, unknown> {
+  return {
+    ...state,
+    bands: [...state.bands],
+    rescale: state.rescale?.map((range) => [...range]) ?? null,
+  };
+}

--- a/tests/raster-layer-sync.test.ts
+++ b/tests/raster-layer-sync.test.ts
@@ -131,16 +131,15 @@ describe("createRasterStoreLayer", () => {
     );
 
     assert.equal(layer.metadata.error, "CORS blocked");
+    // visible and opacity live on the top-level layer fields, not here.
     assert.deepEqual(layer.metadata.rasterState, {
       mode: "single",
       bands: [2],
       rescale: [[0, 4000]],
       colormap: "viridis",
       nodata: 0,
-      opacity: 1,
       gamma: 1,
       stretch: "sqrt",
-      visible: true,
     });
   });
 });

--- a/tests/raster-layer-sync.test.ts
+++ b/tests/raster-layer-sync.test.ts
@@ -1,0 +1,335 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import {
+  DEFAULT_LAYER_STYLE,
+  type GeoLibreLayer,
+  useAppStore,
+} from "@geolibre/core";
+import type { RasterLayerInfo, RasterLayerState } from "maplibre-gl-raster";
+import {
+  createRasterStoreLayer,
+  isRasterControlStoreLayer,
+  removeRasterStoreLayers,
+  runWithRasterStoreSyncSuspended,
+  savedRasterState,
+  syncRasterLayersToStore,
+  unwireRasterStoreSync,
+  wireRasterStoreSync,
+  type RasterSyncableControl,
+} from "../packages/plugins/src/plugins/raster-layer-sync";
+
+function rasterState(patch: Partial<RasterLayerState> = {}): RasterLayerState {
+  return {
+    mode: "rgb",
+    bands: [1, 2, 3],
+    rescale: null,
+    colormap: "gray",
+    nodata: "auto",
+    opacity: 1,
+    gamma: 1,
+    stretch: "linear",
+    visible: true,
+    ...patch,
+  };
+}
+
+function rasterInfo(patch: Partial<RasterLayerInfo> = {}): RasterLayerInfo {
+  return {
+    id: "raster-1",
+    name: "dem.tif",
+    source: { kind: "url", url: "https://example.com/dem.tif" },
+    bandCount: 3,
+    bandNames: null,
+    beforeId: null,
+    bounds: null,
+    loading: false,
+    error: null,
+    state: rasterState(),
+    ...patch,
+  };
+}
+
+/** Recorder fake standing in for RasterControl in store->control tests. */
+function fakeControl(infos: RasterLayerInfo[] = []) {
+  const calls: { method: string; args: unknown[] }[] = [];
+  const control: RasterSyncableControl = {
+    getRasters: () => infos,
+    removeRaster: (id) => calls.push({ method: "removeRaster", args: [id] }),
+    setRasterState: (id, patch) =>
+      calls.push({ method: "setRasterState", args: [id, patch] }),
+    setVisible: (id, visible) =>
+      calls.push({ method: "setVisible", args: [id, visible] }),
+  };
+  return { control, calls };
+}
+
+function otherStoreLayer(id = "unrelated"): GeoLibreLayer {
+  return {
+    id,
+    name: "Unrelated",
+    type: "geojson",
+    source: { type: "geojson" },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {},
+  };
+}
+
+describe("createRasterStoreLayer", () => {
+  it("mirrors a URL raster as an external custom cog layer", () => {
+    const layer = createRasterStoreLayer(
+      rasterInfo({
+        bounds: { west: -10, south: -5, east: 10, north: 5 },
+        state: rasterState({ opacity: 0.5, visible: false }),
+      }),
+    );
+
+    assert.equal(layer.id, "raster-1");
+    assert.equal(layer.name, "dem.tif");
+    assert.equal(layer.type, "cog");
+    assert.equal(layer.visible, false);
+    assert.equal(layer.opacity, 0.5);
+    assert.equal(layer.source.url, "https://example.com/dem.tif");
+    assert.equal(layer.sourcePath, "https://example.com/dem.tif");
+    assert.equal(layer.metadata.externalNativeLayer, true);
+    assert.equal(layer.metadata.customLayerType, "raster");
+    assert.equal(layer.metadata.identifiable, false);
+    assert.equal(layer.metadata.sourceKind, "maplibre-gl-raster");
+    assert.deepEqual(layer.metadata.nativeLayerIds, ["raster-1"]);
+    // fitLayer falls back to metadata.bounds for zoom-to-layer.
+    assert.deepEqual(layer.metadata.bounds, [-10, -5, 10, 5]);
+    assert.ok(isRasterControlStoreLayer(layer));
+  });
+
+  it("uses the file name for local files and omits bounds until known", () => {
+    const layer = createRasterStoreLayer(
+      rasterInfo({
+        source: { kind: "file", fileName: "local.tif", objectUrl: "blob:x" },
+      }),
+    );
+
+    assert.equal(layer.source.url, undefined);
+    assert.equal(layer.sourcePath, "local.tif");
+    assert.equal(layer.metadata.rasterSource, "file");
+    assert.equal("bounds" in layer.metadata, false);
+  });
+
+  it("persists the visualization state and surfaces load errors", () => {
+    const layer = createRasterStoreLayer(
+      rasterInfo({
+        error: new Error("CORS blocked"),
+        state: rasterState({
+          mode: "single",
+          bands: [2],
+          rescale: [[0, 4000]],
+          colormap: "viridis",
+          nodata: 0,
+          stretch: "sqrt",
+        }),
+      }),
+    );
+
+    assert.equal(layer.metadata.error, "CORS blocked");
+    assert.deepEqual(layer.metadata.rasterState, {
+      mode: "single",
+      bands: [2],
+      rescale: [[0, 4000]],
+      colormap: "viridis",
+      nodata: 0,
+      opacity: 1,
+      gamma: 1,
+      stretch: "sqrt",
+      visible: true,
+    });
+  });
+});
+
+describe("syncRasterLayersToStore", () => {
+  beforeEach(() => {
+    useAppStore.setState({ layers: [] });
+  });
+
+  it("adds store layers for control rasters, leaving others alone", () => {
+    useAppStore.getState().addLayer(otherStoreLayer());
+    const { control } = fakeControl([
+      rasterInfo(),
+      rasterInfo({ id: "raster-2", name: "landcover.tif" }),
+    ]);
+
+    syncRasterLayersToStore(control);
+
+    const layers = useAppStore.getState().layers;
+    assert.equal(layers.length, 3);
+    assert.ok(layers.some((layer) => layer.id === "raster-1"));
+    assert.ok(layers.some((layer) => layer.id === "raster-2"));
+    assert.ok(layers.some((layer) => layer.id === "unrelated"));
+  });
+
+  it("removes store layers whose rasters are gone", () => {
+    const { control } = fakeControl([rasterInfo()]);
+    syncRasterLayersToStore(control);
+    assert.equal(useAppStore.getState().layers.length, 1);
+
+    syncRasterLayersToStore(fakeControl([]).control);
+    assert.equal(useAppStore.getState().layers.length, 0);
+  });
+
+  it("refreshes changed fields but preserves panel renames", () => {
+    const { control } = fakeControl([rasterInfo()]);
+    syncRasterLayersToStore(control);
+    useAppStore.getState().updateLayer("raster-1", { name: "My DEM" });
+
+    syncRasterLayersToStore(
+      fakeControl([
+        rasterInfo({
+          bounds: { west: 0, south: 0, east: 1, north: 1 },
+          state: rasterState({ opacity: 0.4 }),
+        }),
+      ]).control,
+    );
+
+    const layer = useAppStore.getState().layers[0];
+    assert.equal(layer.name, "My DEM");
+    assert.equal(layer.opacity, 0.4);
+    assert.deepEqual(layer.metadata.bounds, [0, 0, 1, 1]);
+  });
+
+  it("does nothing while sync is suspended", () => {
+    const { control } = fakeControl([rasterInfo()]);
+    runWithRasterStoreSyncSuspended(() => {
+      syncRasterLayersToStore(control);
+    });
+    assert.equal(useAppStore.getState().layers.length, 0);
+  });
+});
+
+describe("wireRasterStoreSync", () => {
+  beforeEach(() => {
+    useAppStore.setState({ layers: [] });
+  });
+
+  afterEach(() => {
+    unwireRasterStoreSync();
+  });
+
+  it("applies panel visibility and opacity changes through the control", () => {
+    const { control, calls } = fakeControl([rasterInfo()]);
+    syncRasterLayersToStore(control);
+    wireRasterStoreSync(control);
+
+    useAppStore.getState().updateLayer("raster-1", { visible: false });
+    useAppStore.getState().updateLayer("raster-1", { opacity: 0.25 });
+
+    assert.deepEqual(calls, [
+      { method: "setVisible", args: ["raster-1", false] },
+      { method: "setRasterState", args: ["raster-1", { opacity: 0.25 }] },
+    ]);
+  });
+
+  it("drops the control raster when the panel removes the layer", () => {
+    const { control, calls } = fakeControl([rasterInfo()]);
+    syncRasterLayersToStore(control);
+    wireRasterStoreSync(control);
+
+    useAppStore.getState().removeLayer("raster-1");
+
+    assert.deepEqual(calls, [
+      { method: "removeRaster", args: ["raster-1"] },
+    ]);
+  });
+
+  it("does not echo control-driven syncs back at the control", () => {
+    const { control, calls } = fakeControl([rasterInfo()]);
+    syncRasterLayersToStore(control);
+    wireRasterStoreSync(control);
+
+    // A raster removed in the control's own panel: the event-driven sync
+    // removes the store layer, which must not bounce a removeRaster back.
+    syncRasterLayersToStore(fakeControl([]).control);
+
+    assert.equal(useAppStore.getState().layers.length, 0);
+    assert.deepEqual(calls, []);
+  });
+
+  it("ignores store changes that touch no raster layers", () => {
+    const { control, calls } = fakeControl([rasterInfo()]);
+    syncRasterLayersToStore(control);
+    wireRasterStoreSync(control);
+
+    useAppStore.getState().addLayer(otherStoreLayer());
+    useAppStore.getState().updateLayer("unrelated", { opacity: 0.5 });
+
+    assert.deepEqual(calls, []);
+  });
+});
+
+describe("removeRasterStoreLayers", () => {
+  beforeEach(() => {
+    useAppStore.setState({ layers: [] });
+  });
+
+  afterEach(() => {
+    unwireRasterStoreSync();
+  });
+
+  it("prunes raster layers without echoing removals at the control", () => {
+    const { control, calls } = fakeControl([rasterInfo()]);
+    syncRasterLayersToStore(control);
+    useAppStore.getState().addLayer(otherStoreLayer());
+    wireRasterStoreSync(control);
+
+    removeRasterStoreLayers();
+
+    const layers = useAppStore.getState().layers;
+    assert.equal(layers.length, 1);
+    assert.equal(layers[0].id, "unrelated");
+    assert.deepEqual(calls, []);
+  });
+});
+
+describe("savedRasterState", () => {
+  it("round-trips the state persisted by createRasterStoreLayer", () => {
+    const state = rasterState({
+      mode: "single",
+      bands: [4],
+      rescale: [[100, 2000]],
+      colormap: "terrain",
+      nodata: "off",
+      gamma: 1.4,
+      stretch: "log",
+    });
+    const layer = createRasterStoreLayer(rasterInfo({ state }));
+
+    assert.deepEqual(savedRasterState(layer), {
+      mode: "single",
+      bands: [4],
+      rescale: [[100, 2000]],
+      colormap: "terrain",
+      nodata: "off",
+      gamma: 1.4,
+      stretch: "log",
+    });
+  });
+
+  it("drops malformed fields from hand-edited project files", () => {
+    const layer = createRasterStoreLayer(rasterInfo());
+    layer.metadata.rasterState = {
+      mode: "sepia",
+      bands: [0, -1],
+      rescale: [[0]],
+      colormap: 42,
+      nodata: "sometimes",
+      gamma: Number.NaN,
+      stretch: "cubic",
+    };
+
+    assert.deepEqual(savedRasterState(layer), {});
+  });
+
+  it("returns no overrides when the metadata is missing", () => {
+    const layer = createRasterStoreLayer(rasterInfo());
+    delete layer.metadata.rasterState;
+    assert.deepEqual(savedRasterState(layer), {});
+  });
+});

--- a/tests/raster-layer-sync.test.ts
+++ b/tests/raster-layer-sync.test.ts
@@ -194,6 +194,18 @@ describe("syncRasterLayersToStore", () => {
     assert.deepEqual(layer.metadata.bounds, [0, 0, 1, 1]);
   });
 
+  it("does not touch an existing layer when nothing changed", () => {
+    const { control } = fakeControl([rasterInfo()]);
+    syncRasterLayersToStore(control);
+    const before = useAppStore.getState().layers[0];
+
+    // A second sync with an identical snapshot builds fresh source/metadata
+    // objects; the deep comparison must not report them as changed.
+    syncRasterLayersToStore(fakeControl([rasterInfo()]).control);
+
+    assert.equal(useAppStore.getState().layers[0], before);
+  });
+
   it("does nothing while sync is suspended", () => {
     const { control } = fakeControl([rasterInfo()]);
     runWithRasterStoreSyncSuspended(() => {
@@ -327,7 +339,7 @@ describe("savedRasterState", () => {
       rescale: [],
       colormap: 42,
       nodata: "sometimes",
-      gamma: Number.NaN,
+      gamma: 0,
       stretch: "cubic",
     };
 

--- a/tests/raster-layer-sync.test.ts
+++ b/tests/raster-layer-sync.test.ts
@@ -312,12 +312,20 @@ describe("savedRasterState", () => {
     });
   });
 
+  it("round-trips the auto-rescale (null) state explicitly", () => {
+    const layer = createRasterStoreLayer(
+      rasterInfo({ state: rasterState({ rescale: null }) }),
+    );
+
+    assert.equal(savedRasterState(layer).rescale, null);
+  });
+
   it("drops malformed fields from hand-edited project files", () => {
     const layer = createRasterStoreLayer(rasterInfo());
     layer.metadata.rasterState = {
       mode: "sepia",
       bands: [0, -1],
-      rescale: [[0]],
+      rescale: [],
       colormap: 42,
       nodata: "sometimes",
       gamma: Number.NaN,


### PR DESCRIPTION
## Summary

Replaces the **Add Data > Raster Layer** form dialog with the [maplibre-gl-raster](https://www.npmjs.com/package/maplibre-gl-raster) plugin panel, integrated as an internal plugin in `@geolibre/plugins`.

The panel loads COGs and GeoTIFFs from URLs or local files (drag-and-drop) directly in the browser and edits bands, rescale histograms, 90+ colormaps, nodata, stretch, gamma, and opacity per layer, superseding the dialog's static band/colormap/min-max fields. Raster tile URL templates remain available through the XYZ Layer dialog.

## Changes

- **`packages/plugins/src/plugins/maplibre-raster.ts`** mounts a hidden `RasterControl` on demand; `openRasterLayerPanel` shows and expands it from the toolbar, and the close button hides the whole control again like dismissing the dialog it replaces. Adding a raster switches the map to mercator (deck.gl's COG tile traversal does not support globe view, matching the other deck.gl-backed plugins).
- **`packages/plugins/src/plugins/raster-layer-sync.ts`** mirrors the control's rasters into the app store via the control's public events, following the external custom layer pattern: layer-sync manages ordering only, while panel visibility, opacity, and removal apply back through the control API, with re-entrancy guards in both directions.
- **`restoreRasterLayers`** replays URL-backed rasters (with their persisted visualization state) when a project is reopened, mirroring `restoreThreeDTilesLayers`; local-file rasters cannot be reloaded from a saved project and are pruned with a notice.
- **`AddDataDialog`** drops the raster kind (form, submit path, file picker, state); the toolbar menu item now opens the plugin panel.
- Zoom-to-layer works through `metadata.bounds`, populated from the `RasterLayerInfo.bounds` field added in maplibre-gl-raster 0.1.1 (which also emits `rasterchange` once bounds are known).

## Testing

- `tests/raster-layer-sync.test.ts` (15 new cases): store mirroring (add/remove/update, rename preservation, bounds/error metadata), store→control visibility/opacity/removal, re-entrancy guards, suspension, and persisted-state round-trip/validation.
- `npm run test:frontend`: 65/65 pass; `npm run build` clean; `pre-commit run --all-files` passes.
- Verified end-to-end in the browser with Playwright: panel opens from Add Data > Raster Layer, an NLCD COG loads and renders, the layer appears in the layer panel as `cog`, visibility toggles sync in both directions, zoom-to-layer fits the raster bounds, and removal (with confirm) clears both panels with zero console errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Raster Layer panel for adding and managing raster layers.

* **Improvements**
  * Raster layers now persist with projects and are restored on reopen.
  * Raster inputs removed from the general Add Data dialog to centralize raster workflows.
  * Raster panel styling matches the app's light/dark theme for visual consistency.

* **Tests**
  * Added automated tests covering raster sync and persistence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->