### PR TITLE
fix: ad-hoc sign macOS bundles so Gatekeeper-blocked apps can be opened

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,14 +29,17 @@ jobs:
             args: --no-sign
             rust-targets: ""
 
+          # macOS bundles are ad-hoc signed (bundle > macOS > signingIdentity
+          # in tauri.conf.json) so Gatekeeper lets users open them after
+          # removing the quarantine attribute. Do not pass --no-sign here.
           - name: macOS Apple Silicon
             os: macos-latest
-            args: --target aarch64-apple-darwin --no-sign
+            args: --target aarch64-apple-darwin
             rust-targets: aarch64-apple-darwin
 
           - name: macOS Intel
             os: macos-latest
-            args: --target x86_64-apple-darwin --no-sign
+            args: --target x86_64-apple-darwin
             rust-targets: x86_64-apple-darwin
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,8 @@ jobs:
             rust-targets: ""
 
           # macOS bundles are ad-hoc signed (bundle > macOS > signingIdentity
-          # in tauri.conf.json) so Gatekeeper lets users open them after
-          # removing the quarantine attribute. Do not pass --no-sign here.
+          # in tauri.conf.json); users must still remove the quarantine attribute
+          # to bypass Gatekeeper. Do not pass --no-sign here.
           - name: macOS Apple Silicon
             os: macos-latest
             args: --target aarch64-apple-darwin

--- a/apps/geolibre-desktop/src-tauri/tauri.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.conf.json
@@ -36,6 +36,9 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "macOS": {
+      "signingIdentity": "-"
+    }
   }
 }

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -19,14 +19,16 @@ The Windows build is unsigned and may require a platform-specific trust prompt. 
 ## macOS installation
 
 The macOS builds are not signed with an Apple Developer certificate, so
-Gatekeeper blocks them on first launch. Depending on your macOS version,
-the message is one of:
-
-> "GeoLibre Desktop" is damaged and can't be opened. You should move it to
-> the Bin.
+Gatekeeper blocks them on first launch. Depending on your macOS version and
+which release you downloaded, the message is one of:
 
 > "GeoLibre Desktop" cannot be opened because the developer cannot be
 > verified.
+
+or:
+
+> "GeoLibre Desktop" is damaged and can't be opened. You should move it to
+> the Bin.
 
 The app is not actually damaged. macOS attaches a quarantine attribute to
 files downloaded from the internet and refuses to open apps that are not

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -11,10 +11,35 @@ Release builds are produced for:
 
 - Linux x64: Debian package, RPM package, and AppImage
 - Windows x64: unsigned desktop binary
-- macOS Apple Silicon: unsigned desktop binary
-- macOS Intel: unsigned desktop binary
+- macOS Apple Silicon: ad-hoc signed DMG and app bundle
+- macOS Intel: ad-hoc signed DMG and app bundle
 
 Unsigned builds may require platform-specific trust prompts. Check each release note for the exact assets and platform guidance.
+
+## macOS installation
+
+The macOS builds are not signed with an Apple Developer certificate, so
+Gatekeeper blocks them on first launch with a message like:
+
+> "GeoLibre Desktop" is damaged and can't be opened. You should move it to
+> the Bin.
+
+The app is not actually damaged. macOS attaches a quarantine attribute to
+files downloaded from the internet and refuses to open apps that are not
+notarized by Apple. To install:
+
+1. Download the DMG for your Mac (`aarch64` for Apple Silicon, `x64` for
+   Intel) and drag **GeoLibre Desktop** into **Applications**.
+2. Open **Terminal** and remove the quarantine attribute:
+
+    ```bash
+    xattr -cr "/Applications/GeoLibre Desktop.app"
+    ```
+
+3. Launch GeoLibre Desktop from Applications as usual.
+
+This is a one-time step per installed version. You only need to repeat it
+after installing a new release.
 
 ## Build from source
 

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -19,10 +19,14 @@ The Windows build is unsigned and may require a platform-specific trust prompt. 
 ## macOS installation
 
 The macOS builds are not signed with an Apple Developer certificate, so
-Gatekeeper blocks them on first launch with a message like:
+Gatekeeper blocks them on first launch. Depending on your macOS version,
+the message is one of:
 
 > "GeoLibre Desktop" is damaged and can't be opened. You should move it to
 > the Bin.
+
+> "GeoLibre Desktop" cannot be opened because the developer cannot be
+> verified.
 
 The app is not actually damaged. macOS attaches a quarantine attribute to
 files downloaded from the internet and refuses to open apps that are not

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -14,7 +14,7 @@ Release builds are produced for:
 - macOS Apple Silicon: ad-hoc signed DMG and app bundle
 - macOS Intel: ad-hoc signed DMG and app bundle
 
-Unsigned builds may require platform-specific trust prompts. Check each release note for the exact assets and platform guidance.
+The Windows build is unsigned and may require a platform-specific trust prompt. Check each release note for the exact assets and platform guidance.
 
 ## macOS installation
 


### PR DESCRIPTION
## Summary

Fixes #152.

Users on macOS (both Apple Silicon and Intel) get **"GeoLibre Desktop" is damaged and can't be opened. You should move it to the Bin.** when opening the downloaded app. This is macOS Gatekeeper's standard response to a downloaded app that is unsigned and not notarized, not actual corruption.

The release workflow built macOS bundles with `--no-sign`, so the `.app` bundle had no code signature at all.

## Changes

- Set `bundle.macOS.signingIdentity` to `"-"` in `tauri.conf.json` so Tauri ad-hoc signs the whole bundle, including the bundled `geolibre_server` sidecar. On Apple Silicon a valid (at least ad-hoc) signature is required for the binary to run at all.
- Remove `--no-sign` from the two macOS entries in the release matrix so the signing identity takes effect. Windows keeps `--no-sign`.
- Document the Gatekeeper error and the one-time workaround in `docs/downloads.md`:

  ```bash
  xattr -cr "/Applications/GeoLibre Desktop.app"
  ```

## Notes

Ad-hoc signing does not remove the Gatekeeper prompt entirely; users still need the one-time `xattr -cr` step (now documented). Eliminating the prompt completely requires signing with an Apple Developer ID certificate and notarizing the app, which needs an Apple Developer Program membership. The workflow can be extended later if a certificate becomes available.

## Test plan

- [x] `jq` validates `tauri.conf.json`
- [x] `pre-commit run --all-files` passes
- [ ] Next release: verify `codesign -dv` on the produced `.app` reports an ad-hoc signature and the app launches after `xattr -cr`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated macOS installation guide with Gatekeeper/quarantine explanation and one-time workaround steps to allow launching ad-hoc signed builds.
  * Clarified macOS release asset descriptions to reflect ad-hoc signed DMG and app bundle variants for Apple Silicon and Intel.

* **Chores**
  * Updated macOS build/release configuration to produce ad-hoc signed macOS artifacts and adjusted release workflow notes accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->