### PR TITLE
Fix raster plugin project restore

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1099,6 +1099,7 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
   const isDeckRasterLayer =
     layer.metadata.sourceKind === "cog-url" ||
     layer.metadata.sourceKind === "geotiff-url" ||
+    layer.metadata.sourceKind === "maplibre-gl-raster" ||
     layer.metadata.sourceKind === "stac-search-cog";
   const isDeckVectorLayer = hasExternalDeckLayer(layer);
   const isRasterTileLayer = layer.metadata.tileType === "raster";
@@ -1106,6 +1107,7 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
   const hasVectorPaintControls =
     !isThreeDTilesLayer &&
     !isRasterTileLayer &&
+    !isDeckRasterLayer &&
     (layer.type === "geojson" ||
       layer.type === "vector-tiles" ||
       layer.type === "mbtiles" ||
@@ -1114,9 +1116,10 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
   const hasExtrusionControls =
     !isThreeDTilesLayer &&
     !isRasterTileLayer &&
+    !isDeckRasterLayer &&
     supportsExtrusionControls(layer);
   const hasRasterPaintControls =
-    isRasterPaintLayer(layer.type) || isRasterTileLayer;
+    isRasterPaintLayer(layer.type) || isRasterTileLayer || isDeckRasterLayer;
   const hasTextMarkerControls =
     layer.type === "geojson" && hasTextMarkerFeatures(layer);
   const extrusionEnabled = styleValue(style, "extrusionEnabled");

--- a/packages/plugins/src/plugins/map-projection-utils.ts
+++ b/packages/plugins/src/plugins/map-projection-utils.ts
@@ -19,6 +19,10 @@ function setMercatorProjection(map: MapLibreMap): void {
   }
 }
 
+// Scheduled even when the projection already reads mercator: while the
+// style is settling, getProjection() can report a value the settled style
+// will overwrite (and setMercatorProjection swallows rejections in that
+// window), so the cheap re-check on idle covers both cases.
 function scheduleMercatorIdleGuard(map: MapLibreMap): void {
   if (pendingMercatorIdleGuards.has(map)) return;
   pendingMercatorIdleGuards.add(map);

--- a/packages/plugins/src/plugins/map-projection-utils.ts
+++ b/packages/plugins/src/plugins/map-projection-utils.ts
@@ -1,12 +1,29 @@
 import type { Map as MapLibreMap } from "maplibre-gl";
 
+const pendingMercatorIdleGuards = new WeakSet<MapLibreMap>();
+
 export function ensureMercatorProjection(
   map: MapLibreMap | null | undefined,
 ): void {
+  if (!map) return;
+  setMercatorProjection(map);
+  scheduleMercatorIdleGuard(map);
+}
+
+function setMercatorProjection(map: MapLibreMap): void {
   try {
-    if (!map || map.getProjection()?.type === "mercator") return;
+    if (map.getProjection()?.type === "mercator") return;
     map.setProjection({ type: "mercator" });
   } catch {
     // MapLibre can reject projection changes while the style is still settling.
   }
+}
+
+function scheduleMercatorIdleGuard(map: MapLibreMap): void {
+  if (pendingMercatorIdleGuards.has(map)) return;
+  pendingMercatorIdleGuards.add(map);
+  map.once("idle", () => {
+    pendingMercatorIdleGuards.delete(map);
+    setMercatorProjection(map);
+  });
 }

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -48,8 +48,25 @@ type RasterLayerManagerInternals = {
       map: MapControlHost,
       options: OverlayFactoryOptions,
     ) => OverlayLike;
+    loadGeoTIFF?: (url: string) => Promise<unknown>;
     geolibreTransparentOverlayPatched?: boolean;
+    geolibreTauriNodataPatched?: boolean;
   };
+};
+type RasterTileArray = {
+  bands?: unknown[];
+  data?: unknown;
+  nodata?: number | null;
+};
+type RasterTile = {
+  array?: RasterTileArray;
+};
+type TiledRasterSource = {
+  fetchTile?: (...args: unknown[]) => Promise<RasterTile>;
+  geolibreNodataPatched?: boolean;
+};
+type GeoTiffWithOverviews = TiledRasterSource & {
+  overviews?: TiledRasterSource[];
 };
 
 let rasterControlClassPromise: Promise<RasterControlConstructor> | null = null;
@@ -317,29 +334,88 @@ async function patchTauriRasterOverlayFactory(
 
   const manager = (control as unknown as RasterControlInternals)._layerManager;
   const deps = manager?._deps;
-  if (!deps?.createOverlay || deps.geolibreTransparentOverlayPatched) return;
+  if (!deps) return;
 
-  const MapboxOverlayClass = await getMapboxOverlayClass();
-  deps.createOverlay = (map, options) => {
-    const overlay = new MapboxOverlayClass({
-      deviceProps: {
-        createCanvasContext: { alphaMode: "premultiplied" },
-        webgl: {
-          alpha: true,
-          premultipliedAlpha: true,
+  if (deps.createOverlay && !deps.geolibreTransparentOverlayPatched) {
+    const MapboxOverlayClass = await getMapboxOverlayClass();
+    deps.createOverlay = (map, options) => {
+      const overlay = new MapboxOverlayClass({
+        deviceProps: {
+          createCanvasContext: { alphaMode: "premultiplied" },
+          webgl: {
+            alpha: true,
+            premultipliedAlpha: true,
+          },
         },
-      },
-      interleaved: false,
-      layers: [],
-      onDeviceInitialized: options.onDeviceInitialized,
-      parameters: {
-        clearColor: [0, 0, 0, 0],
-      },
-    });
-    map.addControl(overlay);
-    return overlay;
+        interleaved: false,
+        layers: [],
+        onDeviceInitialized: options.onDeviceInitialized,
+        parameters: {
+          clearColor: [0, 0, 0, 0],
+        },
+      });
+      map.addControl(overlay);
+      return overlay;
+    };
+    deps.geolibreTransparentOverlayPatched = true;
+  }
+
+  if (deps.loadGeoTIFF && !deps.geolibreTauriNodataPatched) {
+    const loadGeoTIFF = deps.loadGeoTIFF;
+    deps.loadGeoTIFF = async (url) => patchGeoTiffNumericNodata(await loadGeoTIFF(url));
+    deps.geolibreTauriNodataPatched = true;
+  }
+}
+
+function patchGeoTiffNumericNodata(tiff: unknown): unknown {
+  patchTiledRasterSource(tiff);
+  for (const overview of (tiff as GeoTiffWithOverviews).overviews ?? []) {
+    patchTiledRasterSource(overview);
+  }
+  return tiff;
+}
+
+function patchTiledRasterSource(source: unknown): void {
+  const tiledSource = source as TiledRasterSource;
+  if (!tiledSource.fetchTile || tiledSource.geolibreNodataPatched) return;
+
+  const fetchTile = tiledSource.fetchTile.bind(source);
+  tiledSource.fetchTile = async (...args) => {
+    const tile = await fetchTile(...args);
+    normalizeTileNumericNodata(tile);
+    return tile;
   };
-  deps.geolibreTransparentOverlayPatched = true;
+  tiledSource.geolibreNodataPatched = true;
+}
+
+function normalizeTileNumericNodata(tile: RasterTile): void {
+  const array = tile.array;
+  const nodata = array?.nodata;
+  if (typeof nodata !== "number" || !Number.isFinite(nodata)) return;
+
+  let replaced = false;
+  if (Array.isArray(array.bands)) {
+    for (const band of array.bands) {
+      replaced = replaceFloat32NodataWithNaN(band, nodata) || replaced;
+    }
+  } else {
+    replaced = replaceFloat32NodataWithNaN(array.data, nodata);
+  }
+
+  if (replaced) array.nodata = Number.NaN;
+}
+
+function replaceFloat32NodataWithNaN(data: unknown, nodata: number): boolean {
+  if (!(data instanceof Float32Array)) return false;
+
+  let replaced = false;
+  for (let index = 0; index < data.length; index += 1) {
+    if (data[index] === nodata) {
+      data[index] = Number.NaN;
+      replaced = true;
+    }
+  }
+  return replaced;
 }
 
 function isTauriRuntime(): boolean {

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -390,7 +390,8 @@ function patchTiledRasterSource(source: unknown): void {
 
 function normalizeTileNumericNodata(tile: RasterTile): void {
   const array = tile.array;
-  const nodata = array?.nodata;
+  if (!array) return;
+  const nodata = array.nodata;
   if (typeof nodata !== "number" || !Number.isFinite(nodata)) return;
 
   let replaced = false;

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -1,5 +1,5 @@
 import { useAppStore } from "@geolibre/core";
-import type { RasterControl } from "maplibre-gl-raster";
+import type { RasterControl, RasterControlEventHandler } from "maplibre-gl-raster";
 import type { GeoLibreAppAPI, GeoLibreMapControlPosition } from "../types";
 import { ensureMercatorProjection } from "./map-projection-utils";
 import {
@@ -102,6 +102,9 @@ export function restoreRasterLayers(app: GeoLibreAppAPI): void {
     );
 
     const pending: Promise<unknown>[] = [];
+    const panelCollapsed = rasterPanelCollapsedFromLayers(
+      useAppStore.getState().layers,
+    );
     // The suspension covers the synchronous events fired inside this block:
     // removeRaster's rasterremove, and the rasteradd each addRaster emits
     // before it awaits the GeoTIFF header (without it, the first rasteradd
@@ -109,6 +112,8 @@ export function restoreRasterLayers(app: GeoLibreAppAPI): void {
     // events that follow header loads land after this window and sync
     // incrementally; the Promise.allSettled pass below settles the rest.
     runWithRasterStoreSyncSuspended(() => {
+      applyRestoredRasterPanelState(control, panelCollapsed);
+
       for (const info of control.getRasters()) {
         if (!storeLayerIds.has(info.id)) control.removeRaster(info.id);
       }
@@ -230,6 +235,10 @@ function createRasterControl(
   for (const event of ["rasteradd", "rasterchange", "rasterremove"] as const) {
     control.on(event, () => syncRasterLayersToStore(control));
   }
+  const panelStateSyncHandler: RasterControlEventHandler = () =>
+    syncRasterLayersToStore(control);
+  control.on("expand", panelStateSyncHandler);
+  control.on("collapse", panelStateSyncHandler);
   wireRasterStoreSync(control);
   patchRasterControlOnRemove(control);
 
@@ -262,6 +271,33 @@ function hideRasterControl(control: RasterControl): void {
   control.collapse();
   const container = control.getContainer();
   if (container) container.style.display = "none";
+}
+
+function applyRestoredRasterPanelState(
+  control: RasterControl,
+  panelCollapsed: boolean,
+): void {
+  if (panelCollapsed) {
+    hideRasterControl(control);
+    return;
+  }
+
+  showRasterControl(control);
+  control.expand();
+  wireRasterCloseButton(control);
+  applyRasterPanelClass(control);
+  disableRasterClickOutsideCollapse(control);
+}
+
+function rasterPanelCollapsedFromLayers(layers: ReturnType<typeof useAppStore.getState>["layers"]): boolean {
+  const panelCollapsed = layers.find(
+    (layer) =>
+      isRasterControlStoreLayer(layer) &&
+      typeof layer.metadata.panelCollapsed === "boolean",
+  )?.metadata.panelCollapsed;
+  // Older projects did not persist this UI state. Keep them collapsed so
+  // loading a raster project does not unexpectedly open the Add Data panel.
+  return typeof panelCollapsed === "boolean" ? panelCollapsed : true;
 }
 
 // The control collapses its panel when the user clicks anywhere else on the

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -32,6 +32,7 @@ type RasterControlConstructor = typeof RasterControl;
 let rasterControlClassPromise: Promise<RasterControlConstructor> | null = null;
 let rasterControl: RasterControl | null = null;
 let rasterControlMounted = false;
+let restorePanelExpandTimeout: number | null = null;
 
 /**
  * Opens the maplibre-gl-raster panel, mounting the control on first use.
@@ -174,10 +175,16 @@ export function restoreRasterLayers(app: GeoLibreAppAPI): void {
     // restores may still be loading; this final pass settles the store once
     // every raster has either loaded or failed.
     void Promise.allSettled(pending).then(() => {
-      // A control torn down mid-restore (map reinitialisation) must not let
-      // this stale callback rewrite layers owned by its successor.
-      if (control !== rasterControl) return;
-      syncRasterLayersToStore(control);
+      // Defer one task so this sync runs after the deferred panel expand in
+      // applyRestoredRasterPanelState: with no pending rasters, allSettled
+      // resolves as a microtask, and syncing then would briefly write the
+      // pre-expand collapsed state to the store.
+      window.setTimeout(() => {
+        // A control torn down mid-restore (map reinitialisation) must not
+        // let this stale callback rewrite layers owned by its successor.
+        if (control !== rasterControl) return;
+        syncRasterLayersToStore(control);
+      }, 0);
     });
   })().catch((error) => {
     console.error("[GeoLibre] Failed to restore raster layers", error);
@@ -297,6 +304,13 @@ function applyRestoredRasterPanelState(
   control: RasterControl,
   panelCollapsed: boolean,
 ): void {
+  // A restore queued by an earlier project load must not fire after this
+  // one has applied a different panel state to the same control.
+  if (restorePanelExpandTimeout !== null) {
+    window.clearTimeout(restorePanelExpandTimeout);
+    restorePanelExpandTimeout = null;
+  }
+
   if (panelCollapsed) {
     hideRasterControl(control);
     return;
@@ -306,7 +320,8 @@ function applyRestoredRasterPanelState(
   // Defer the expand like openRasterLayerPanel does: on a first-mount
   // restore this runs in the same task as addControl, and expanding before
   // MapLibre has laid the control out can measure the panel at zero size.
-  window.setTimeout(() => {
+  restorePanelExpandTimeout = window.setTimeout(() => {
+    restorePanelExpandTimeout = null;
     // A control torn down before this task runs (map reinitialisation)
     // must not expand or fire panel-state syncs against its successor.
     if (control !== rasterControl) return;

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -178,7 +178,11 @@ export function restoreRasterLayers(app: GeoLibreAppAPI): void {
       // Defer one task so this sync runs after the deferred panel expand in
       // applyRestoredRasterPanelState: with no pending rasters, allSettled
       // resolves as a microtask, and syncing then would briefly write the
-      // pre-expand collapsed state to the store.
+      // pre-expand collapsed state to the store. Ordering invariant: the
+      // expand timer is registered synchronously inside the suspension
+      // block above, this one from a microtask after it, and same-delay
+      // timers fire FIFO -- revisit if applyRestoredRasterPanelState ever
+      // becomes async.
       window.setTimeout(() => {
         // A control torn down mid-restore (map reinitialisation) must not
         // let this stale callback rewrite layers owned by its successor.
@@ -277,6 +281,10 @@ function patchRasterControlOnRemove(
     // not keep syncing panel state if a stale reference toggles it.
     control.off("expand", panelStateSyncHandler);
     control.off("collapse", panelStateSyncHandler);
+    if (restorePanelExpandTimeout !== null) {
+      window.clearTimeout(restorePanelExpandTimeout);
+      restorePanelExpandTimeout = null;
+    }
     unwireRasterStoreSync();
     // A control torn down mid-restore must not leave its successor
     // permanently suppressing store sync events.

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -18,7 +18,7 @@ const DEFAULT_RASTER_URL =
   "https://data.source.coop/giswqs/opengeos/nlcd_2021_land_cover_30m.tif";
 
 // These types mirror undocumented private members of RasterControl from
-// maplibre-gl-raster (verified against v0.1.2). All access is optional (?.)
+// maplibre-gl-raster (verified against v0.1.3). All access is optional (?.)
 // so a rename in a future release degrades to a no-op rather than a crash --
 // re-verify these names AND the .mlr-control-close selector in
 // wireRasterCloseButton when bumping the dependency.
@@ -112,7 +112,16 @@ export function restoreRasterLayers(app: GeoLibreAppAPI): void {
     // events that follow header loads land after this window and sync
     // incrementally; the Promise.allSettled pass below settles the rest.
     runWithRasterStoreSyncSuspended(() => {
-      applyRestoredRasterPanelState(control, panelCollapsed);
+      // Isolated so a DOM error from the panel-state restore cannot abort
+      // the raster replay below.
+      try {
+        applyRestoredRasterPanelState(control, panelCollapsed);
+      } catch (error) {
+        console.error(
+          "[GeoLibre] Failed to restore raster panel state",
+          error,
+        );
+      }
 
       for (const info of control.getRasters()) {
         if (!storeLayerIds.has(info.id)) control.removeRaster(info.id);
@@ -235,21 +244,32 @@ function createRasterControl(
   for (const event of ["rasteradd", "rasterchange", "rasterremove"] as const) {
     control.on(event, () => syncRasterLayersToStore(control));
   }
+  // syncRasterLayersToStore re-reads getState().collapsed when these fire.
+  // Safe: expand()/collapse() delegate to toggle(), which flips
+  // _state.collapsed BEFORE emitting the event (verified against v0.1.3) --
+  // re-verify that ordering when bumping the dependency.
   const panelStateSyncHandler: RasterControlEventHandler = () =>
     syncRasterLayersToStore(control);
   control.on("expand", panelStateSyncHandler);
   control.on("collapse", panelStateSyncHandler);
   wireRasterStoreSync(control);
-  patchRasterControlOnRemove(control);
+  patchRasterControlOnRemove(control, panelStateSyncHandler);
 
   return control;
 }
 
-function patchRasterControlOnRemove(control: RasterControl): void {
+function patchRasterControlOnRemove(
+  control: RasterControl,
+  panelStateSyncHandler: RasterControlEventHandler,
+): void {
   const originalOnRemove = control.onRemove.bind(control);
   control.onRemove = () => {
     originalOnRemove();
     if (rasterControl !== control) return;
+    // Symmetric with unwireRasterStoreSync below: a removed control must
+    // not keep syncing panel state if a stale reference toggles it.
+    control.off("expand", panelStateSyncHandler);
+    control.off("collapse", panelStateSyncHandler);
     unwireRasterStoreSync();
     // A control torn down mid-restore must not leave its successor
     // permanently suppressing store sync events.
@@ -283,13 +303,30 @@ function applyRestoredRasterPanelState(
   }
 
   showRasterControl(control);
-  control.expand();
-  wireRasterCloseButton(control);
-  applyRasterPanelClass(control);
-  disableRasterClickOutsideCollapse(control);
+  // Defer the expand like openRasterLayerPanel does: on a first-mount
+  // restore this runs in the same task as addControl, and expanding before
+  // MapLibre has laid the control out can measure the panel at zero size.
+  window.setTimeout(() => {
+    // A control torn down before this task runs (map reinitialisation)
+    // must not expand or fire panel-state syncs against its successor.
+    if (control !== rasterControl) return;
+    try {
+      control.expand();
+      wireRasterCloseButton(control);
+      applyRasterPanelClass(control);
+      disableRasterClickOutsideCollapse(control);
+    } catch (error) {
+      console.error(
+        "[GeoLibre] Failed to restore raster panel state",
+        error,
+      );
+    }
+  }, 0);
 }
 
-function rasterPanelCollapsedFromLayers(layers: ReturnType<typeof useAppStore.getState>["layers"]): boolean {
+function rasterPanelCollapsedFromLayers(
+  layers: ReturnType<typeof useAppStore.getState>["layers"],
+): boolean {
   const panelCollapsed = layers.find(
     (layer) =>
       isRasterControlStoreLayer(layer) &&

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -7,7 +7,7 @@ import {
   resetRasterStoreSyncSuspension,
   runWithRasterStoreSyncSuspended,
   savedRasterState,
-  syncRasterLayersToStore,
+  syncRasterLayersToStoreWithOptions,
   unwireRasterStoreSync,
   wireRasterStoreSync,
 } from "./raster-layer-sync";
@@ -24,15 +24,40 @@ const DEFAULT_RASTER_URL =
 // wireRasterCloseButton when bumping the dependency.
 type RasterControlInternals = {
   _clickOutsideHandler?: ((event: MouseEvent) => void) | null;
+  _layerManager?: RasterLayerManagerInternals;
   _panel?: HTMLElement;
 };
 
 type RasterControlConstructor = typeof RasterControl;
+type OverlayFactoryOptions = {
+  interleaved: boolean;
+  onDeviceInitialized: (device: unknown) => void;
+};
+type OverlayLike = {
+  setProps: (props: { layers?: unknown[] }) => void;
+};
+type MapControlHost = {
+  addControl: (control: unknown) => void;
+};
+type MapboxOverlayConstructor = new (
+  props: Record<string, unknown>,
+) => OverlayLike;
+type RasterLayerManagerInternals = {
+  _deps?: {
+    createOverlay?: (
+      map: MapControlHost,
+      options: OverlayFactoryOptions,
+    ) => OverlayLike;
+    geolibreTransparentOverlayPatched?: boolean;
+  };
+};
 
 let rasterControlClassPromise: Promise<RasterControlConstructor> | null = null;
+let mapboxOverlayClassPromise: Promise<MapboxOverlayConstructor> | null = null;
 let rasterControl: RasterControl | null = null;
 let rasterControlMounted = false;
 let restorePanelExpandTimeout: number | null = null;
+let rasterControlInterleaved = true;
 
 /**
  * Opens the maplibre-gl-raster panel, mounting the control on first use.
@@ -187,7 +212,7 @@ export function restoreRasterLayers(app: GeoLibreAppAPI): void {
         // A control torn down mid-restore (map reinitialisation) must not
         // let this stale callback rewrite layers owned by its successor.
         if (control !== rasterControl) return;
-        syncRasterLayersToStore(control);
+        syncRasterLayersToStoreForRuntime(control);
       }, 0);
     });
   })().catch((error) => {
@@ -212,6 +237,7 @@ async function ensureRasterControl(
     rasterControlMounted = true;
     // The control mounts hidden: project restore must not surface a map
     // button the user never asked for. openRasterLayerPanel shows it.
+    await patchTauriRasterOverlayFactory(rasterControl);
     hideRasterControl(rasterControl);
     disableRasterClickOutsideCollapse(rasterControl);
     wireRasterCloseButton(rasterControl);
@@ -237,13 +263,22 @@ function getRasterControlClass(): Promise<RasterControlConstructor> {
   return rasterControlClassPromise;
 }
 
+function getMapboxOverlayClass(): Promise<MapboxOverlayConstructor> {
+  mapboxOverlayClassPromise ??= import("@deck.gl/mapbox").then(
+    (module) => module.MapboxOverlay as unknown as MapboxOverlayConstructor,
+  );
+  return mapboxOverlayClassPromise;
+}
+
 function createRasterControl(
   RasterControlClass: RasterControlConstructor,
 ): RasterControl {
+  rasterControlInterleaved = !isTauriRuntime();
   const control = new RasterControlClass({
     className: "geolibre-raster-control",
     collapsed: true,
     defaultUrl: DEFAULT_RASTER_URL,
+    interleaved: rasterControlInterleaved,
     panelWidth: 380,
     title: "Add Raster Layer",
   });
@@ -253,20 +288,65 @@ function createRasterControl(
   // switches the map to mercator, like the other deck.gl-backed plugins.
   control.on("rasteradd", () => ensureMercatorProjection(control.getMap()));
   for (const event of ["rasteradd", "rasterchange", "rasterremove"] as const) {
-    control.on(event, () => syncRasterLayersToStore(control));
+    control.on(event, () => syncRasterLayersToStoreForRuntime(control));
   }
   // syncRasterLayersToStore re-reads getState().collapsed when these fire.
   // Safe: expand()/collapse() delegate to toggle(), which flips
   // _state.collapsed BEFORE emitting the event (verified against v0.1.3) --
   // re-verify that ordering when bumping the dependency.
   const panelStateSyncHandler: RasterControlEventHandler = () =>
-    syncRasterLayersToStore(control);
+    syncRasterLayersToStoreForRuntime(control);
   control.on("expand", panelStateSyncHandler);
   control.on("collapse", panelStateSyncHandler);
   wireRasterStoreSync(control);
   patchRasterControlOnRemove(control, panelStateSyncHandler);
 
   return control;
+}
+
+function syncRasterLayersToStoreForRuntime(control: RasterControl): void {
+  syncRasterLayersToStoreWithOptions(control, {
+    interleaved: rasterControlInterleaved,
+  });
+}
+
+async function patchTauriRasterOverlayFactory(
+  control: RasterControl,
+): Promise<void> {
+  if (!isTauriRuntime()) return;
+
+  const manager = (control as unknown as RasterControlInternals)._layerManager;
+  const deps = manager?._deps;
+  if (!deps?.createOverlay || deps.geolibreTransparentOverlayPatched) return;
+
+  const MapboxOverlayClass = await getMapboxOverlayClass();
+  deps.createOverlay = (map, options) => {
+    const overlay = new MapboxOverlayClass({
+      deviceProps: {
+        createCanvasContext: { alphaMode: "premultiplied" },
+        webgl: {
+          alpha: true,
+          premultipliedAlpha: true,
+        },
+      },
+      interleaved: false,
+      layers: [],
+      onDeviceInitialized: options.onDeviceInitialized,
+      parameters: {
+        clearColor: [0, 0, 0, 0],
+      },
+    });
+    map.addControl(overlay);
+    return overlay;
+  };
+  deps.geolibreTransparentOverlayPatched = true;
+}
+
+function isTauriRuntime(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    "__TAURI_INTERNALS__" in window
+  );
 }
 
 function patchRasterControlOnRemove(

--- a/packages/plugins/src/plugins/raster-layer-sync.ts
+++ b/packages/plugins/src/plugins/raster-layer-sync.ts
@@ -13,6 +13,7 @@ export const RASTER_SOURCE_KIND = "maplibre-gl-raster";
  * fakes without touching deck.gl or a real map.
  */
 export type RasterSyncableControl = {
+  getState?: () => { collapsed: boolean };
   getRasters: () => RasterLayerInfo[];
   removeRaster: (id: string) => void;
   setRasterState: (id: string, patch: Partial<RasterLayerState>) => void;
@@ -54,9 +55,13 @@ export function isRasterControlStoreLayer(layer: GeoLibreLayer): boolean {
  * back through the control API.
  *
  * @param info - Public raster snapshot from RasterControl.getRasters().
+ * @param panelCollapsed - Whether the Add Raster Layer panel is collapsed.
  * @returns The corresponding GeoLibre store layer.
  */
-export function createRasterStoreLayer(info: RasterLayerInfo): GeoLibreLayer {
+export function createRasterStoreLayer(
+  info: RasterLayerInfo,
+  panelCollapsed = true,
+): GeoLibreLayer {
   const url = info.source.kind === "url" ? info.source.url : undefined;
   const sourcePath =
     url ?? (info.source.kind === "file" ? info.source.fileName : info.id);
@@ -78,6 +83,7 @@ export function createRasterStoreLayer(info: RasterLayerInfo): GeoLibreLayer {
       // In interleaved mode the deck.gl overlay inserts one custom style
       // layer per raster, keyed by the raster id, so ordering moves reach it.
       nativeLayerIds: [info.id],
+      panelCollapsed,
       // The visualization state is persisted so restoreRasterLayers can
       // replay URL-backed rasters when a saved project is reopened.
       rasterSource: info.source.kind,
@@ -113,6 +119,7 @@ export function syncRasterLayersToStore(control: RasterSyncableControl): void {
 
   const infos = control.getRasters();
   const infoIds = new Set(infos.map((info) => info.id));
+  const panelCollapsed = rasterPanelCollapsedFromControl(control);
 
   syncingLayersToStore = true;
   try {
@@ -124,7 +131,7 @@ export function syncRasterLayersToStore(control: RasterSyncableControl): void {
     }
 
     for (const info of infos) {
-      const layer = createRasterStoreLayer(info);
+      const layer = createRasterStoreLayer(info, panelCollapsed);
       const existing = useAppStore
         .getState()
         .layers.find((current) => current.id === layer.id);
@@ -350,6 +357,17 @@ export function savedRasterState(
   }
 
   return state;
+}
+
+function rasterPanelCollapsedFromControl(
+  control: RasterSyncableControl,
+): boolean {
+  try {
+    const collapsed = control.getState?.().collapsed;
+    return typeof collapsed === "boolean" ? collapsed : true;
+  } catch {
+    return true;
+  }
 }
 
 // Key-order-insensitive deep equality for source/metadata records, matching

--- a/packages/plugins/src/plugins/raster-layer-sync.ts
+++ b/packages/plugins/src/plugins/raster-layer-sync.ts
@@ -20,6 +20,10 @@ export type RasterSyncableControl = {
   setVisible: (id: string, visible: boolean) => void;
 };
 
+export type RasterSyncOptions = {
+  interleaved?: boolean;
+};
+
 let syncedControl: RasterSyncableControl | null = null;
 let storeUnsubscribe: (() => void) | null = null;
 // Guards the store subscriber against re-entrancy: store mutations made by
@@ -61,7 +65,9 @@ export function isRasterControlStoreLayer(layer: GeoLibreLayer): boolean {
 export function createRasterStoreLayer(
   info: RasterLayerInfo,
   panelCollapsed = true,
+  options: RasterSyncOptions = {},
 ): GeoLibreLayer {
+  const interleaved = options.interleaved ?? true;
   const url = info.source.kind === "url" ? info.source.url : undefined;
   const sourcePath =
     url ?? (info.source.kind === "file" ? info.source.fileName : info.id);
@@ -78,12 +84,16 @@ export function createRasterStoreLayer(
     style: { ...DEFAULT_LAYER_STYLE },
     metadata: {
       customLayerType: "raster",
+      externalDeckLayer: true,
       externalNativeLayer: true,
       identifiable: false,
       // In interleaved mode the deck.gl overlay inserts one custom style
       // layer per raster, keyed by the raster id, so ordering moves reach it.
-      nativeLayerIds: [info.id],
+      // The Tauri/WebKit fallback uses a separate deck.gl canvas, so there is
+      // no MapLibre style layer id to sync.
+      nativeLayerIds: interleaved ? [info.id] : [],
       panelCollapsed,
+      rasterOverlayMode: interleaved ? "interleaved" : "overlaid",
       // The visualization state is persisted so restoreRasterLayers can
       // replay URL-backed rasters when a saved project is reopened.
       rasterSource: info.source.kind,
@@ -115,6 +125,13 @@ export function createRasterStoreLayer(
  * @param control - The raster control to mirror.
  */
 export function syncRasterLayersToStore(control: RasterSyncableControl): void {
+  syncRasterLayersToStoreWithOptions(control);
+}
+
+export function syncRasterLayersToStoreWithOptions(
+  control: RasterSyncableControl,
+  options: RasterSyncOptions = {},
+): void {
   if (isRasterStoreSyncSuspended()) return;
 
   const infos = control.getRasters();
@@ -131,7 +148,7 @@ export function syncRasterLayersToStore(control: RasterSyncableControl): void {
     }
 
     for (const info of infos) {
-      const layer = createRasterStoreLayer(info, panelCollapsed);
+      const layer = createRasterStoreLayer(info, panelCollapsed, options);
       const existing = useAppStore
         .getState()
         .layers.find((current) => current.id === layer.id);

--- a/packages/plugins/src/plugins/raster-layer-sync.ts
+++ b/packages/plugins/src/plugins/raster-layer-sync.ts
@@ -365,7 +365,13 @@ function rasterPanelCollapsedFromControl(
   try {
     const collapsed = control.getState?.().collapsed;
     return typeof collapsed === "boolean" ? collapsed : true;
-  } catch {
+  } catch (error) {
+    // getState is optional, so only a throwing implementation lands here;
+    // surface it instead of letting it look like the method being absent.
+    console.warn(
+      "[GeoLibre] rasterPanelCollapsedFromControl: getState threw",
+      error,
+    );
     return true;
   }
 }

--- a/tests/map-projection-utils.test.ts
+++ b/tests/map-projection-utils.test.ts
@@ -40,6 +40,11 @@ function fakeProjectionMap(initialProjection: ProjectionType) {
 }
 
 describe("ensureMercatorProjection", () => {
+  it("is a no-op for nullish map values", () => {
+    assert.doesNotThrow(() => ensureMercatorProjection(undefined));
+    assert.doesNotThrow(() => ensureMercatorProjection(null));
+  });
+
   it("restores mercator on idle if the map is flipped back to globe", () => {
     const fake = fakeProjectionMap("globe");
 
@@ -60,6 +65,15 @@ describe("ensureMercatorProjection", () => {
     ensureMercatorProjection(fake.map);
     ensureMercatorProjection(fake.map);
 
+    assert.equal(fake.idleHandlers.length, 1);
+  });
+
+  it("does not call setProjection when already mercator", () => {
+    const fake = fakeProjectionMap("mercator");
+
+    ensureMercatorProjection(fake.map);
+
+    assert.deepEqual(fake.setProjectionCalls, []);
     assert.equal(fake.idleHandlers.length, 1);
   });
 });

--- a/tests/map-projection-utils.test.ts
+++ b/tests/map-projection-utils.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Map as MapLibreMap } from "maplibre-gl";
+import { ensureMercatorProjection } from "../packages/plugins/src/plugins/map-projection-utils";
+
+type ProjectionType = "globe" | "mercator";
+
+function fakeProjectionMap(initialProjection: ProjectionType) {
+  let projection = initialProjection;
+  const idleHandlers: Array<() => void> = [];
+  const setProjectionCalls: ProjectionType[] = [];
+
+  const map = {
+    getProjection: () => ({ type: projection }),
+    once: (event: string, handler: () => void) => {
+      if (event === "idle") idleHandlers.push(handler);
+      return map;
+    },
+    setProjection: (next: { type: ProjectionType }) => {
+      projection = next.type;
+      setProjectionCalls.push(next.type);
+      return map;
+    },
+  };
+
+  return {
+    emitIdle: () => {
+      for (const handler of idleHandlers.splice(0)) handler();
+    },
+    flipToGlobe: () => {
+      projection = "globe";
+    },
+    get projection() {
+      return projection;
+    },
+    idleHandlers,
+    map: map as unknown as MapLibreMap,
+    setProjectionCalls,
+  };
+}
+
+describe("ensureMercatorProjection", () => {
+  it("restores mercator on idle if the map is flipped back to globe", () => {
+    const fake = fakeProjectionMap("globe");
+
+    ensureMercatorProjection(fake.map);
+    assert.equal(fake.projection, "mercator");
+    assert.equal(fake.idleHandlers.length, 1);
+
+    fake.flipToGlobe();
+    fake.emitIdle();
+
+    assert.equal(fake.projection, "mercator");
+    assert.deepEqual(fake.setProjectionCalls, ["mercator", "mercator"]);
+  });
+
+  it("registers only one pending idle guard per map", () => {
+    const fake = fakeProjectionMap("globe");
+
+    ensureMercatorProjection(fake.map);
+    ensureMercatorProjection(fake.map);
+
+    assert.equal(fake.idleHandlers.length, 1);
+  });
+});

--- a/tests/map-projection-utils.test.ts
+++ b/tests/map-projection-utils.test.ts
@@ -75,5 +75,9 @@ describe("ensureMercatorProjection", () => {
 
     assert.deepEqual(fake.setProjectionCalls, []);
     assert.equal(fake.idleHandlers.length, 1);
+
+    fake.emitIdle();
+
+    assert.deepEqual(fake.setProjectionCalls, []);
   });
 });

--- a/tests/raster-layer-sync.test.ts
+++ b/tests/raster-layer-sync.test.ts
@@ -49,7 +49,11 @@ function rasterInfo(patch: Partial<RasterLayerInfo> = {}): RasterLayerInfo {
   };
 }
 
-/** Recorder fake standing in for RasterControl in store->control tests. */
+/**
+ * Recorder fake standing in for RasterControl in store->control tests.
+ * getState is a static snapshot of options.collapsed: tests exercising
+ * event-driven expand/collapse transitions need a stateful fake instead.
+ */
 function fakeControl(
   infos: RasterLayerInfo[] = [],
   options: { collapsed?: boolean } = {},

--- a/tests/raster-layer-sync.test.ts
+++ b/tests/raster-layer-sync.test.ts
@@ -227,6 +227,40 @@ describe("syncRasterLayersToStore", () => {
     );
   });
 
+  it("flips panelCollapsed on store layers when an expand event syncs", () => {
+    // Stateful stand-in for the production expand/collapse wiring: the
+    // handler mirrors panelStateSyncHandler in maplibre-raster.ts, and
+    // expand() flips the state before notifying, matching the verified
+    // maplibre-gl-raster event ordering.
+    let collapsed = true;
+    const handlers: Array<() => void> = [];
+    const control: RasterSyncableControl = {
+      getState: () => ({ collapsed }),
+      getRasters: () => [rasterInfo()],
+      removeRaster: () => {},
+      setRasterState: () => {},
+      setVisible: () => {},
+    };
+    handlers.push(() => syncRasterLayersToStore(control));
+    const expand = () => {
+      collapsed = false;
+      for (const handler of handlers) handler();
+    };
+
+    syncRasterLayersToStore(control);
+    assert.equal(
+      useAppStore.getState().layers[0].metadata.panelCollapsed,
+      true,
+    );
+
+    expand();
+
+    assert.equal(
+      useAppStore.getState().layers[0].metadata.panelCollapsed,
+      false,
+    );
+  });
+
   it("does not touch an existing layer when nothing changed", () => {
     const { control } = fakeControl([rasterInfo()]);
     syncRasterLayersToStore(control);

--- a/tests/raster-layer-sync.test.ts
+++ b/tests/raster-layer-sync.test.ts
@@ -13,6 +13,7 @@ import {
   runWithRasterStoreSyncSuspended,
   savedRasterState,
   syncRasterLayersToStore,
+  syncRasterLayersToStoreWithOptions,
   unwireRasterStoreSync,
   wireRasterStoreSync,
   type RasterSyncableControl,
@@ -101,9 +102,11 @@ describe("createRasterStoreLayer", () => {
     assert.equal(layer.source.url, "https://example.com/dem.tif");
     assert.equal(layer.sourcePath, "https://example.com/dem.tif");
     assert.equal(layer.metadata.externalNativeLayer, true);
+    assert.equal(layer.metadata.externalDeckLayer, true);
     assert.equal(layer.metadata.customLayerType, "raster");
     assert.equal(layer.metadata.identifiable, false);
     assert.equal(layer.metadata.panelCollapsed, true);
+    assert.equal(layer.metadata.rasterOverlayMode, "interleaved");
     assert.equal(layer.metadata.sourceKind, "maplibre-gl-raster");
     assert.deepEqual(layer.metadata.nativeLayerIds, ["raster-1"]);
     // fitLayer falls back to metadata.bounds for zoom-to-layer.
@@ -157,6 +160,16 @@ describe("createRasterStoreLayer", () => {
 
     assert.equal(layer.metadata.panelCollapsed, false);
   });
+
+  it("marks overlaid deck rasters without MapLibre native layer ids", () => {
+    const layer = createRasterStoreLayer(rasterInfo(), true, {
+      interleaved: false,
+    });
+
+    assert.equal(layer.metadata.externalDeckLayer, true);
+    assert.equal(layer.metadata.rasterOverlayMode, "overlaid");
+    assert.deepEqual(layer.metadata.nativeLayerIds, []);
+  });
 });
 
 describe("syncRasterLayersToStore", () => {
@@ -178,6 +191,16 @@ describe("syncRasterLayersToStore", () => {
     assert.ok(layers.some((layer) => layer.id === "raster-1"));
     assert.ok(layers.some((layer) => layer.id === "raster-2"));
     assert.ok(layers.some((layer) => layer.id === "unrelated"));
+  });
+
+  it("can sync non-interleaved rasters without native layer ids", () => {
+    syncRasterLayersToStoreWithOptions(fakeControl([rasterInfo()]).control, {
+      interleaved: false,
+    });
+
+    const layer = useAppStore.getState().layers[0];
+    assert.equal(layer.metadata.rasterOverlayMode, "overlaid");
+    assert.deepEqual(layer.metadata.nativeLayerIds, []);
   });
 
   it("removes store layers whose rasters are gone", () => {

--- a/tests/raster-layer-sync.test.ts
+++ b/tests/raster-layer-sync.test.ts
@@ -50,9 +50,13 @@ function rasterInfo(patch: Partial<RasterLayerInfo> = {}): RasterLayerInfo {
 }
 
 /** Recorder fake standing in for RasterControl in store->control tests. */
-function fakeControl(infos: RasterLayerInfo[] = []) {
+function fakeControl(
+  infos: RasterLayerInfo[] = [],
+  options: { collapsed?: boolean } = {},
+) {
   const calls: { method: string; args: unknown[] }[] = [];
   const control: RasterSyncableControl = {
+    getState: () => ({ collapsed: options.collapsed ?? true }),
     getRasters: () => infos,
     removeRaster: (id) => calls.push({ method: "removeRaster", args: [id] }),
     setRasterState: (id, patch) =>
@@ -95,6 +99,7 @@ describe("createRasterStoreLayer", () => {
     assert.equal(layer.metadata.externalNativeLayer, true);
     assert.equal(layer.metadata.customLayerType, "raster");
     assert.equal(layer.metadata.identifiable, false);
+    assert.equal(layer.metadata.panelCollapsed, true);
     assert.equal(layer.metadata.sourceKind, "maplibre-gl-raster");
     assert.deepEqual(layer.metadata.nativeLayerIds, ["raster-1"]);
     // fitLayer falls back to metadata.bounds for zoom-to-layer.
@@ -141,6 +146,12 @@ describe("createRasterStoreLayer", () => {
       gamma: 1,
       stretch: "sqrt",
     });
+  });
+
+  it("persists the raster panel collapsed state", () => {
+    const layer = createRasterStoreLayer(rasterInfo(), false);
+
+    assert.equal(layer.metadata.panelCollapsed, false);
   });
 });
 
@@ -192,6 +203,24 @@ describe("syncRasterLayersToStore", () => {
     assert.equal(layer.name, "My DEM");
     assert.equal(layer.opacity, 0.4);
     assert.deepEqual(layer.metadata.bounds, [0, 0, 1, 1]);
+  });
+
+  it("refreshes the saved panel collapsed state", () => {
+    const { control } = fakeControl([rasterInfo()]);
+    syncRasterLayersToStore(control);
+    assert.equal(
+      useAppStore.getState().layers[0].metadata.panelCollapsed,
+      true,
+    );
+
+    syncRasterLayersToStore(
+      fakeControl([rasterInfo()], { collapsed: false }).control,
+    );
+
+    assert.equal(
+      useAppStore.getState().layers[0].metadata.panelCollapsed,
+      false,
+    );
   });
 
   it("does not touch an existing layer when nothing changed", () => {


### PR DESCRIPTION
## Summary
- Persist Add Raster Layer panel collapsed state on raster-backed project layers.
- Restore the raster plugin panel state after project load without pruning replayed rasters.
- Keep deck-backed rasters in mercator after initial map idle so globe projection does not break raster rendering.

## Validation
- npm run test:frontend
- npm run build
- pre-commit run --all-files
- Browser smoke test with restored raster project and expanded raster panel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Raster panel collapsed/expanded state is persisted and restored (defaults collapsed for older projects); control expand/collapse now syncs reliably. Deck raster layers now show appropriate paint controls; raster control runtime options better respected.

* **Bug Fixes**
  * More robust map projection handling tolerant of style transitions and avoids duplicate idle listeners. UI restore defers writes to prevent brief incorrect store state and guards against stale control listeners.

* **Tests**
  * Added tests for projection recovery and raster panel state persistence/synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->