### PR TITLE
feat: harden conversion sidecar (path allowlist, perf, UX) — follow-up to #161

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,9 +61,15 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     fi
 
 # Point the sidecar at this interpreter so it skips the managed-runtime
-# bootstrap and uses the prebaked packages.
+# bootstrap and uses the prebaked packages. Confine conversion reads/writes to
+# /data by default: the sidecar is reachable same-origin through the nginx
+# proxy, so without this an arbitrary same-origin caller could read or
+# overwrite container paths. Mount input files at /data (read-write for
+# outputs); override GEOLIBRE_CONVERSION_ROOTS to widen or disable.
 ENV GEOLIBRE_CONVERSION_PYTHON=/usr/local/bin/python \
-    WBW_EXTERNAL_PYTHON=/usr/local/bin/python
+    WBW_EXTERNAL_PYTHON=/usr/local/bin/python \
+    GEOLIBRE_CONVERSION_ROOTS=/data
+RUN mkdir -p /data
 
 COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ CORS or separate process to manage. `/conversion/status` is reachable at
   `freestiler` and `whitebox-workflows` publish no linux/arm64 wheels. On arm64
   the other conversions still work; those two report unavailable.
 
+Because the sidecar is reachable same-origin, conversion reads/writes are
+confined to `GEOLIBRE_CONVERSION_ROOTS` (default `/data` in the image). Mount
+your files there:
+
+```bash
+docker run --rm -p 8080:80 -v "$PWD/data:/data" geolibre
+```
+
 Set `GEOLIBRE_DISABLE_SIDECAR=1` to run nginx only (the original web-only
 behavior):
 

--- a/apps/geolibre-desktop/src/components/processing/ConversionDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ConversionDialog.tsx
@@ -405,7 +405,9 @@ export function ConversionDialog() {
   };
 
   const runBrowserConversion = async () => {
-    const toolId = kind ?? "vector-to-geoparquet";
+    // Only reached when usesBrowserRuntime is true, which requires a kind.
+    if (!kind) return;
+    const toolId = kind;
     const { mainFile, siblings } = splitBrowserSelection(browserFiles);
     if (!mainFile) {
       setError("Choose an input file.");
@@ -462,19 +464,20 @@ export function ConversionDialog() {
           mimeType: GEOPARQUET_MIME_TYPE,
         },
       );
+      const sortedLine =
+        result.featureCount === undefined
+          ? `Hilbert-sorted on column ${result.geometryColumn}`
+          : `Hilbert-sorted ${result.featureCount} features on column ${result.geometryColumn}`;
+      // The conversion itself succeeded; cancelling the save dialog is a
+      // deliberate user action, not a failure, so keep the status green.
       setJob(
-        browserConversionJob(
-          toolId,
-          savedName ? "succeeded" : "failed",
-          [
-            `Converting ${mainFile.name} with DuckDB-WASM`,
-            `Hilbert-sorted ${result.featureCount} features on column ${result.geometryColumn}`,
-            savedName
-              ? `Saved GeoParquet as ${savedName}`
-              : "Conversion finished but the file was not saved.",
-          ],
-          savedName ? null : "Save canceled",
-        ),
+        browserConversionJob(toolId, "succeeded", [
+          `Converting ${mainFile.name} with DuckDB-WASM`,
+          sortedLine,
+          savedName
+            ? `Saved GeoParquet as ${savedName}`
+            : "Conversion finished; save was canceled.",
+        ]),
       );
     } catch (err) {
       const detail =

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -281,7 +281,12 @@ export interface GeoParquetConversionOptions {
 
 export interface GeoParquetConversionResult {
   data: Uint8Array;
-  featureCount: number;
+  /**
+   * Number of rows written, or `undefined` — DuckDB-WASM does not surface the
+   * COPY row count, so the count is only populated when a caller opts into the
+   * extra scan. It is left out here to avoid a second full pass over the data.
+   */
+  featureCount?: number;
   geometryColumn: string;
 }
 
@@ -378,17 +383,9 @@ export async function convertDuckDbVectorToGeoParquet(
 
     const geometrySql = quoteIdentifier(geometryColumn);
 
-    // Unlike the Python sidecar, DuckDB-WASM's connection.query does not surface
-    // the COPY row count, so a separate COUNT(*) is required to report the
-    // feature total. This is a second scan; keep it cheap by not materializing
-    // rows. Remove only if the count is dropped from the result.
-    const countRow = rowsFromResult(
-      await connection.query(
-        `SELECT COUNT(*) AS feature_count FROM (${source}) AS src`,
-      ),
-    )[0];
-    const featureCount = Number(countRow?.feature_count ?? 0);
-
+    // DuckDB-WASM's connection.query does not surface the COPY row count, and a
+    // separate COUNT(*) would scan the whole dataset a second time, so the
+    // feature count is left undefined to keep the in-browser path single-pass.
     await connection.query(
       `COPY (
         WITH src AS (${source}),
@@ -401,7 +398,7 @@ export async function convertDuckDbVectorToGeoParquet(
     );
     await db.flushFiles();
     const data = await db.copyFileToBuffer(outputFile);
-    return { data, featureCount, geometryColumn };
+    return { data, geometryColumn };
   } finally {
     await connection.close();
     await dropFilesIfPresent(db, [...registeredFiles, outputFile]);

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -1011,25 +1011,56 @@ export async function loadDroppedVectorPaths(
   return layers;
 }
 
+/**
+ * Split one RFC 4180-style line into fields for a given delimiter, honoring
+ * double-quoted fields (which may contain the delimiter) and "" escapes.
+ */
+function splitCsvLine(line: string, delimiter: string): string[] {
+  const fields: string[] = [];
+  let field = "";
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i += 1) {
+    const char = line[i];
+    if (inQuotes) {
+      if (char === '"') {
+        if (line[i + 1] === '"') {
+          field += '"';
+          i += 1;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += char;
+      }
+    } else if (char === '"') {
+      inQuotes = true;
+    } else if (char === delimiter) {
+      fields.push(field);
+      field = "";
+    } else {
+      field += char;
+    }
+  }
+  fields.push(field);
+  return fields;
+}
+
 /** Split a CSV/TSV header line into trimmed column names. */
 export function parseCsvHeaderLine(line: string): string[] {
   const header = line.replace(/^﻿/, "").replace(/[\r\n]+$/, "");
   if (!header) return [];
-  // Pick the delimiter that yields the most fields (comma, tab, or semicolon).
-  // Strip outer quotes from each token first so a quoted field containing the
-  // candidate delimiter (e.g. "city,state" in a TSV) does not skew the count.
+  // Quote-aware parsing for each candidate delimiter, then pick the one that
+  // yields the most fields. Because quotes are respected, a quoted field
+  // containing the delimiter (e.g. "city,state") no longer skews the count.
   const delimiter = [",", "\t", ";"]
     .map((d) => ({
       d,
-      count: header
-        .split(d)
-        .map((token) => token.trim().replace(/^".*"$/, ""))
-        .filter((token) => token.length > 0).length,
+      count: splitCsvLine(header, d).filter((token) => token.trim().length > 0)
+        .length,
     }))
     .sort((a, b) => b.count - a.count)[0].d;
-  return header
-    .split(delimiter)
-    .map((name) => name.trim().replace(/^"(.*)"$/, "$1").trim())
+  return splitCsvLine(header, delimiter)
+    .map((name) => name.trim())
     .filter((name) => name.length > 0);
 }
 

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -11,6 +11,7 @@ import {
 import { unzip } from "fflate";
 import type { FeatureCollection } from "geojson";
 import shp from "shpjs";
+import { parseDelimitedTextFields } from "./delimited-text";
 import type { DuckDbVectorFile } from "./duckdb-vector-loader";
 import { parseGpxLayer } from "./gpx";
 
@@ -1011,57 +1012,26 @@ export async function loadDroppedVectorPaths(
   return layers;
 }
 
-/**
- * Split one RFC 4180-style line into fields for a given delimiter, honoring
- * double-quoted fields (which may contain the delimiter) and "" escapes.
- */
-function splitCsvLine(line: string, delimiter: string): string[] {
-  const fields: string[] = [];
-  let field = "";
-  let inQuotes = false;
-  for (let i = 0; i < line.length; i += 1) {
-    const char = line[i];
-    if (inQuotes) {
-      if (char === '"') {
-        if (line[i + 1] === '"') {
-          field += '"';
-          i += 1;
-        } else {
-          inQuotes = false;
-        }
-      } else {
-        field += char;
-      }
-    } else if (char === '"') {
-      inQuotes = true;
-    } else if (char === delimiter) {
-      fields.push(field);
-      field = "";
-    } else {
-      field += char;
-    }
-  }
-  fields.push(field);
-  return fields;
-}
-
 /** Split a CSV/TSV header line into trimmed column names. */
 export function parseCsvHeaderLine(line: string): string[] {
   const header = line.replace(/^﻿/, "").replace(/[\r\n]+$/, "");
   if (!header) return [];
-  // Quote-aware parsing for each candidate delimiter, then pick the one that
-  // yields the most fields. Because quotes are respected, a quoted field
-  // containing the delimiter (e.g. "city,state") no longer skews the count.
-  const delimiter = [",", "\t", ";"]
-    .map((d) => ({
-      d,
-      count: splitCsvLine(header, d).filter((token) => token.trim().length > 0)
-        .length,
-    }))
-    .sort((a, b) => b.count - a.count)[0].d;
-  return splitCsvLine(header, delimiter)
-    .map((name) => name.trim())
-    .filter((name) => name.length > 0);
+  // Reuse the project's quote-aware delimited-text parser for each candidate
+  // delimiter (comma, tab, semicolon) and keep the one that yields the most
+  // columns. Quoting is respected, so a quoted field containing the delimiter
+  // (e.g. "city,state") neither skews detection nor splits the header.
+  let best: string[] = [];
+  for (const delimiter of [",", "\t", ";"]) {
+    try {
+      const fields = parseDelimitedTextFields(header, delimiter).filter(
+        (name) => name.trim().length > 0,
+      );
+      if (fields.length > best.length) best = fields;
+    } catch {
+      // No header row for this delimiter; try the next candidate.
+    }
+  }
+  return best.map((name) => name.trim()).filter((name) => name.length > 0);
 }
 
 /**

--- a/backend/geolibre_server/README.md
+++ b/backend/geolibre_server/README.md
@@ -76,7 +76,13 @@ Useful overrides:
 GEOLIBRE_CONVERSION_PYTHON=/path/to/python   # reuse an existing env (skip bootstrap)
 GEOLIBRE_CONVERSION_ENV=/path/to/venv        # managed runtime location
 GEOLIBRE_CONVERSION_PACKAGES='duckdb>=1.1.0 rio-cogeo>=5.0.0 freestiler>=0.1.0'  # whitespace-separated
+GEOLIBRE_CONVERSION_ROOTS=/data:/srv/geo      # confine inputs/outputs to these roots (os.pathsep-separated; unset = no restriction)
 ```
+
+When the sidecar is reachable by untrusted same-origin content (e.g. the
+bundled Docker image), set `GEOLIBRE_CONVERSION_ROOTS` so conversions cannot
+read or overwrite arbitrary filesystem paths. It is unset by default for the
+desktop app, where paths are the user's own filesystem.
 
 ## Endpoints
 

--- a/backend/geolibre_server/geolibre_server/app/conversion.py
+++ b/backend/geolibre_server/geolibre_server/app/conversion.py
@@ -51,6 +51,18 @@ DEFAULT_COG_COMPRESSION = "deflate"
 
 _RESULT_MARKER = "__GEOLIBRE_CONVERSION_RESULT__"
 
+# Optional allowlist of directories that conversion inputs/outputs must live
+# under, set via GEOLIBRE_CONVERSION_ROOTS (os.pathsep-separated). Unset means
+# no restriction (the default for the desktop app, where paths are the user's
+# own filesystem). The bundled Docker image sets this so the sidecar — which is
+# reachable same-origin through the nginx proxy — cannot read or overwrite
+# arbitrary container paths.
+_CONVERSION_ROOTS = [
+    str(Path(root).expanduser().resolve())
+    for root in os.environ.get("GEOLIBRE_CONVERSION_ROOTS", "").split(os.pathsep)
+    if root.strip()
+]
+
 _JOBS: dict[str, JobState] = {}
 _JOBS_LOCK = threading.Lock()
 _RUNTIME_SETUP_LOCK = threading.Lock()
@@ -413,18 +425,43 @@ def _ensure_managed_runtime() -> str:
         return str(python)
 
 
+_CHECKED_RUNTIME_PYTHON: str | None = None
+
+
 def _runtime_python() -> str:
-    """Return the Python executable used for conversions."""
+    """Return the Python executable used for conversions.
+
+    The import check spawns a subprocess, so the verified interpreter is cached
+    to avoid that cost on every status poll and job start. The managed-runtime
+    path does its own (cheaper) re-check under its setup lock.
+    """
+    global _CHECKED_RUNTIME_PYTHON
+    if _CHECKED_RUNTIME_PYTHON is not None:
+        return _CHECKED_RUNTIME_PYTHON
     configured = os.environ.get("GEOLIBRE_CONVERSION_PYTHON")
     if configured:
         resolved = str(Path(configured).expanduser())
         if os.path.isfile(resolved) and os.access(resolved, os.X_OK):
             _check_runtime_import(resolved)
+            _CHECKED_RUNTIME_PYTHON = resolved
             return resolved
         raise RuntimeBootstrapError(
             f"Configured conversion Python is not executable: {configured}"
         )
-    return _ensure_managed_runtime()
+    resolved = _ensure_managed_runtime()
+    _CHECKED_RUNTIME_PYTHON = resolved
+    return resolved
+
+
+def _is_within_roots(path: Path) -> bool:
+    """Return whether a resolved path lives under an allowlisted root."""
+    if not _CONVERSION_ROOTS:
+        return True
+    resolved = str(path.resolve())
+    return any(
+        resolved == root or resolved.startswith(root + os.sep)
+        for root in _CONVERSION_ROOTS
+    )
 
 
 def _validate_paths(input_path: str, output_path: str) -> tuple[str, str]:
@@ -443,6 +480,14 @@ def _validate_paths(input_path: str, output_path: str) -> tuple[str, str]:
         raise HTTPException(
             status_code=400,
             detail=f"Output folder does not exist: {target.parent}",
+        )
+    # When an allowlist is configured, confine reads/writes (and the failure
+    # cleanup unlink) to those roots so a same-origin caller cannot touch
+    # arbitrary files.
+    if not _is_within_roots(source) or not _is_within_roots(target):
+        raise HTTPException(
+            status_code=403,
+            detail="Path is outside the allowed conversion directories",
         )
     # Reading from and writing to the same file would truncate the input.
     if source.resolve() == target.resolve():
@@ -602,6 +647,8 @@ def _start_job(
         daemon=True,
     )
     thread.start()
+    # The worker may have already flipped the job to "running" by the time this
+    # lock is re-acquired, so callers must not assume the response is "pending".
     with _JOBS_LOCK:
         return _JOBS[job_id]
 

--- a/backend/geolibre_server/geolibre_server/app/conversion.py
+++ b/backend/geolibre_server/geolibre_server/app/conversion.py
@@ -426,40 +426,55 @@ def _ensure_managed_runtime() -> str:
 
 
 _CHECKED_RUNTIME_PYTHON: str | None = None
+_CHECKED_RUNTIME_PYTHON_LOCK = threading.Lock()
 
 
 def _runtime_python() -> str:
     """Return the Python executable used for conversions.
 
     The import check spawns a subprocess, so the verified interpreter is cached
-    to avoid that cost on every status poll and job start. The managed-runtime
-    path does its own (cheaper) re-check under its setup lock.
+    to avoid that cost on every status poll and job start. Double-checked
+    locking keeps concurrent cold-start callers (FastAPI runs sync handlers in
+    a thread pool) from each spawning that subprocess.
     """
     global _CHECKED_RUNTIME_PYTHON
-    if _CHECKED_RUNTIME_PYTHON is not None:
-        return _CHECKED_RUNTIME_PYTHON
-    configured = os.environ.get("GEOLIBRE_CONVERSION_PYTHON")
-    if configured:
-        resolved = str(Path(configured).expanduser())
-        if os.path.isfile(resolved) and os.access(resolved, os.X_OK):
-            _check_runtime_import(resolved)
-            _CHECKED_RUNTIME_PYTHON = resolved
-            return resolved
-        raise RuntimeBootstrapError(
-            f"Configured conversion Python is not executable: {configured}"
-        )
-    resolved = _ensure_managed_runtime()
-    _CHECKED_RUNTIME_PYTHON = resolved
-    return resolved
+    cached = _CHECKED_RUNTIME_PYTHON
+    # Drop a cached interpreter whose file has since disappeared (e.g. the
+    # managed venv was wiped) so the next call re-bootstraps cleanly.
+    if cached is not None and os.path.isfile(cached):
+        return cached
+    with _CHECKED_RUNTIME_PYTHON_LOCK:
+        cached = _CHECKED_RUNTIME_PYTHON
+        if cached is not None and os.path.isfile(cached):
+            return cached
+        _CHECKED_RUNTIME_PYTHON = None
+        configured = os.environ.get("GEOLIBRE_CONVERSION_PYTHON")
+        if configured:
+            resolved = str(Path(configured).expanduser())
+            if os.path.isfile(resolved) and os.access(resolved, os.X_OK):
+                _check_runtime_import(resolved)
+                _CHECKED_RUNTIME_PYTHON = resolved
+                return resolved
+            raise RuntimeBootstrapError(
+                f"Configured conversion Python is not executable: {configured}"
+            )
+        resolved = _ensure_managed_runtime()
+        _CHECKED_RUNTIME_PYTHON = resolved
+        return resolved
 
 
 def _is_within_roots(path: Path) -> bool:
-    """Return whether a resolved path lives under an allowlisted root."""
+    """Return whether a resolved path lives under an allowlisted root.
+
+    Uses ``Path.is_relative_to`` so filesystem roots (``/``, a Windows drive)
+    work — naive ``startswith(root + sep)`` would produce ``//`` and reject
+    valid descendants.
+    """
     if not _CONVERSION_ROOTS:
         return True
-    resolved = str(path.resolve())
+    resolved = path.resolve()
     return any(
-        resolved == root or resolved.startswith(root + os.sep)
+        resolved == Path(root) or resolved.is_relative_to(root)
         for root in _CONVERSION_ROOTS
     )
 
@@ -495,7 +510,9 @@ def _validate_paths(input_path: str, output_path: str) -> tuple[str, str]:
             status_code=400,
             detail="input_path and output_path must be different files",
         )
-    return str(source), str(target)
+    # Return canonical paths so the subprocess and the failure-cleanup unlink
+    # operate on the same resolved paths the allowlist check approved.
+    return str(source.resolve()), str(target.resolve())
 
 
 def _job_update(job_id: str, **patch: Any) -> None:

--- a/backend/geolibre_server/geolibre_server/app/runtime.py
+++ b/backend/geolibre_server/geolibre_server/app/runtime.py
@@ -11,6 +11,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import threading
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
@@ -25,6 +26,11 @@ UV_INSTALL_BASE_URL = os.environ.get(
     "GEOLIBRE_UV_INSTALL_BASE_URL",
     "https://astral.sh/uv",
 ).rstrip("/")
+
+# The Whitebox and conversion routers each guard their own runtime setup with
+# their own lock, but both call _install_managed_uv; this shared lock prevents
+# two concurrent cold-start bootstraps from racing on the same uv binary.
+_UV_INSTALL_LOCK = threading.Lock()
 
 
 class RuntimeBootstrapError(RuntimeError):
@@ -135,6 +141,16 @@ def _install_managed_uv() -> str:
     if uv.exists():
         return str(uv)
 
+    with _UV_INSTALL_LOCK:
+        # Re-check inside the lock: another router may have installed uv while
+        # this caller was waiting.
+        if uv.exists():
+            return str(uv)
+        return _install_managed_uv_locked(uv)
+
+
+def _install_managed_uv_locked(uv: Path) -> str:
+    """Download and install uv. The caller must hold ``_UV_INSTALL_LOCK``."""
     install_dir = _managed_uv_dir()
     install_dir.mkdir(parents=True, exist_ok=True)
     script_url = (

--- a/backend/geolibre_server/geolibre_server/app/runtime.py
+++ b/backend/geolibre_server/geolibre_server/app/runtime.py
@@ -135,16 +135,24 @@ def _download_to_temp(url: str, suffix: str) -> Path:
     return target
 
 
+def _is_valid_managed_uv(path: Path) -> bool:
+    """Return whether the managed uv binary is present and runnable."""
+    if not path.is_file():
+        return False
+    # Windows executability is extension-based; POSIX needs the execute bit.
+    return os.name == "nt" or os.access(path, os.X_OK)
+
+
 def _install_managed_uv() -> str:
     """Download and install uv into GeoLibre's managed runtime directory."""
     uv = _managed_uv_executable()
-    if uv.exists():
+    if _is_valid_managed_uv(uv):
         return str(uv)
 
     with _UV_INSTALL_LOCK:
         # Re-check inside the lock: another router may have installed uv while
         # this caller was waiting.
-        if uv.exists():
+        if _is_valid_managed_uv(uv):
             return str(uv)
         return _install_managed_uv_locked(uv)
 
@@ -188,8 +196,10 @@ def _install_managed_uv_locked(uv: Path) -> str:
     if completed.returncode != 0:
         detail = completed.stderr.strip() or completed.stdout.strip()
         raise RuntimeBootstrapError(f"uv installer failed. {detail}")
-    if not uv.exists():
-        raise RuntimeBootstrapError(f"uv installer did not create {uv}")
+    if not _is_valid_managed_uv(uv):
+        raise RuntimeBootstrapError(
+            f"uv installer did not create a runnable binary at {uv}"
+        )
     return str(uv)
 
 

--- a/backend/geolibre_server/tests/test_conversion.py
+++ b/backend/geolibre_server/tests/test_conversion.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 
 import pytest
@@ -72,6 +73,22 @@ def test_validate_paths_rejects_outside_allowed_roots(
     assert excinfo.value.status_code == 403
 
 
+def test_validate_paths_rejects_output_outside_allowed_roots(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """An allowlisted input but out-of-root output is rejected (403)."""
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    source = allowed / "input.geojson"
+    source.write_text("{}", encoding="utf-8")
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    monkeypatch.setattr(conversion, "_CONVERSION_ROOTS", [str(allowed.resolve())])
+    with pytest.raises(HTTPException) as excinfo:
+        _validate_paths(str(source), str(outside_dir / "out.parquet"))
+    assert excinfo.value.status_code == 403
+
+
 def test_validate_paths_allows_within_allowed_roots(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -84,8 +101,25 @@ def test_validate_paths_allows_within_allowed_roots(
     input_path, output_path = _validate_paths(
         str(source), str(allowed / "out.parquet")
     )
-    assert input_path == str(source)
-    assert output_path == str(allowed / "out.parquet")
+    assert input_path == str(source.resolve())
+    assert output_path == str((allowed / "out.parquet").resolve())
+
+
+def test_runtime_python_caches_after_first_call(monkeypatch) -> None:
+    """The import check runs at most once across repeated _runtime_python calls."""
+    import_calls = 0
+
+    def fake_check(python_executable: str) -> None:
+        nonlocal import_calls
+        import_calls += 1
+
+    monkeypatch.setattr(conversion, "_CHECKED_RUNTIME_PYTHON", None)
+    monkeypatch.setenv("GEOLIBRE_CONVERSION_PYTHON", sys.executable)
+    monkeypatch.setattr(conversion, "_check_runtime_import", fake_check)
+
+    assert conversion._runtime_python() == sys.executable
+    conversion._runtime_python()
+    assert import_calls == 1
 
 
 def test_vector_to_geoparquet_rejects_unknown_compression(tmp_path: Path) -> None:

--- a/backend/geolibre_server/tests/test_conversion.py
+++ b/backend/geolibre_server/tests/test_conversion.py
@@ -58,6 +58,36 @@ def test_validate_paths_rejects_missing_output_folder(tmp_path: Path) -> None:
     assert excinfo.value.status_code == 400
 
 
+def test_validate_paths_rejects_outside_allowed_roots(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """With an allowlist set, paths outside the roots are rejected (403)."""
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    outside = tmp_path / "outside.geojson"
+    outside.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(conversion, "_CONVERSION_ROOTS", [str(allowed.resolve())])
+    with pytest.raises(HTTPException) as excinfo:
+        _validate_paths(str(outside), str(allowed / "out.parquet"))
+    assert excinfo.value.status_code == 403
+
+
+def test_validate_paths_allows_within_allowed_roots(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Paths under an allowlisted root pass validation."""
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    source = allowed / "input.geojson"
+    source.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(conversion, "_CONVERSION_ROOTS", [str(allowed.resolve())])
+    input_path, output_path = _validate_paths(
+        str(source), str(allowed / "out.parquet")
+    )
+    assert input_path == str(source)
+    assert output_path == str(allowed / "out.parquet")
+
+
 def test_vector_to_geoparquet_rejects_unknown_compression(tmp_path: Path) -> None:
     """Unsupported Parquet compressions are rejected before starting a job."""
     source = tmp_path / "input.geojson"

--- a/packages/processing/src/sidecar-client.ts
+++ b/packages/processing/src/sidecar-client.ts
@@ -2,22 +2,39 @@ import type { FeatureCollection } from "geojson";
 
 const LOCAL_SIDECAR_URL = "http://127.0.0.1:8765";
 
+/** Build-time override, e.g. `VITE_SIDECAR_URL=http://127.0.0.1:9000`. */
+function explicitSidecarUrl(): string | undefined {
+  try {
+    const env = (import.meta as { env?: Record<string, string | undefined> })
+      .env;
+    const value = env?.VITE_SIDECAR_URL;
+    return value && value.trim() ? value.trim().replace(/\/$/, "") : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Resolve the sidecar base URL for the current runtime.
  *
- * - Desktop (Tauri) and the Vite dev server talk to a local sidecar directly at
- *   {@link LOCAL_SIDECAR_URL}.
+ * - An explicit `VITE_SIDECAR_URL` always wins (useful for non-standard dev
+ *   ports such as `vite --port 3000`).
+ * - Desktop (Tauri) and the default Vite dev server (port 5173) talk to a local
+ *   sidecar directly at {@link LOCAL_SIDECAR_URL}.
  * - When the app is served from any other http(s) origin (e.g. the combined
  *   Docker image), the sidecar is reached through a same-origin `/sidecar`
  *   reverse proxy, which sidesteps CORS entirely.
  */
 function resolveSidecarBaseUrl(): string {
+  const override = explicitSidecarUrl();
+  if (override) return override;
   if (typeof window === "undefined" || !window.location) {
     return LOCAL_SIDECAR_URL;
   }
   const { protocol, hostname, port, origin } = window.location;
-  const isTauri =
-    protocol === "tauri:" || hostname === "tauri.localhost";
+  const isTauri = protocol === "tauri:" || hostname === "tauri.localhost";
+  // 5173 is Vite's default dev port (vite.config.ts pins strictPort). For other
+  // ports set VITE_SIDECAR_URL explicitly.
   const isViteDev = port === "5173";
   if (!isTauri && !isViteDev && (protocol === "http:" || protocol === "https:")) {
     return `${origin}/sidecar`;


### PR DESCRIPTION
Follow-up to #161. Implements the review round that the Claude bot posted **after** #161 was merged, so it lands as a separate PR.

## Security — the bundled Docker sidecar is reachable same-origin
- Add an optional **`GEOLIBRE_CONVERSION_ROOTS`** allowlist. When set, conversion `input_path`/`output_path` (and the failure-cleanup `unlink`) are confined to those roots, so a same-origin caller cannot read or overwrite arbitrary files via DuckDB's `ST_Read`/`COPY` or `cog_translate`.
- The Docker image sets `GEOLIBRE_CONVERSION_ROOTS=/data` by default and creates `/data`; mount your files there (`-v "$PWD/data:/data"`). Unset by default for the desktop app, where paths are the user's own filesystem.

## Backend
- **Cache the verified interpreter** — `/status` polling and each job start no longer spawn an import-check subprocess every call.
- **Shared uv-install lock** in `runtime.py` closes a TOCTOU race when the conversion and Whitebox runtimes bootstrap concurrently on a cold start (they used separate locks but share `_install_managed_uv`).
- Note that a started job may already be `running` when returned.

## Frontend
- **Quote-aware CSV header parsing** (RFC 4180 splitter) so quoted column names containing the delimiter (e.g. `"city,state"`) no longer skew delimiter detection or the lon/lat dropdowns.
- **Cancelled save dialog → succeeded**, not a red "failed" job (the conversion itself succeeded).
- **Drop the second `COUNT(*)` scan** in the DuckDB-WASM path; `featureCount` is now optional, halving work for the common in-browser case.
- Honor a **`VITE_SIDECAR_URL`** override and document the `5173` dev-port assumption.
- Remove an unreachable `toolId` fallback.

## Not changed (with rationale)
- `cog_profiles.get("raw")` was flagged as returning `None` — false positive: this rio-cogeo version has a `"raw"` profile and **no** `"none"` (it raises `KeyError`), so the current code is correct.

## Testing
- `npm run build`, `npm run test:frontend` (99), `npm run test:worker` pass
- Backend `pytest` — 22 pass, including new `GEOLIBRE_CONVERSION_ROOTS` allowlist tests
- `pre-commit run --files …` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Build-time sidecar URL override for flexible deployments
  - Optional conversion root confinement (default /data) to limit conversion read/write scope

* **Bug Fixes**
  - Improved CSV header parsing with quote-aware delimiter selection
  - Conversion dialog reports success when save is canceled
  - Conversion result no longer forces an extra row-count pass

* **Documentation**
  - Docker and runtime docs updated with /data mount and conversion-root guidance

* **Tests**
  - Added tests covering conversion-root allowlist and runtime caching behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->