### PR TITLE
feat: replace Before Id inputs with an Insert before dropdown

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -335,6 +335,7 @@ export function AddDataDialog({
 }: AddDataDialogProps) {
   const open = kind !== null;
   const addLayer = useAppStore((s) => s.addLayer);
+  const existingLayers = useAppStore((s) => s.layers);
   const title = kind ? KIND_LABELS[kind] : "Add Data";
 
   const [layerName, setLayerName] = useState("");
@@ -680,6 +681,12 @@ export function AddDataDialog({
   };
 
   const beforeLayer = beforeLayerId.trim() || null;
+
+  const basemapStyleLayerIds = useMemo(
+    () =>
+      open ? (mapControllerRef.current?.getBasemapStyleLayerIds() ?? []) : [],
+    [open, mapControllerRef],
+  );
 
   const handleArcgisLayerTypeChange = (nextLayerType: ArcGISLayerType) => {
     const currentUrl = arcgisUrl.trim();
@@ -1289,13 +1296,32 @@ export function AddDataDialog({
           </div>
 
           <div className="space-y-1.5">
-            <Label htmlFor="add-data-before-id">Before Id</Label>
-            <Input
+            <Label htmlFor="add-data-before-id">Insert before</Label>
+            <Select
               id="add-data-before-id"
-              placeholder="Optional layer id"
               value={beforeLayerId}
               onChange={(event) => setBeforeLayerId(event.target.value)}
-            />
+            >
+              <option value="">Top of layer list (default)</option>
+              {existingLayers.length > 0 && (
+                <optgroup label="Layers">
+                  {[...existingLayers].reverse().map((existingLayer) => (
+                    <option key={existingLayer.id} value={existingLayer.id}>
+                      {existingLayer.name}
+                    </option>
+                  ))}
+                </optgroup>
+              )}
+              {basemapStyleLayerIds.length > 0 && (
+                <optgroup label="Basemap layers">
+                  {basemapStyleLayerIds.map((styleLayerId) => (
+                    <option key={styleLayerId} value={styleLayerId}>
+                      {styleLayerId}
+                    </option>
+                  ))}
+                </optgroup>
+              )}
+            </Select>
           </div>
 
           {kind === "xyz" && (

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -682,11 +682,11 @@ export function AddDataDialog({
 
   const beforeLayer = beforeLayerId.trim() || null;
 
-  const basemapStyleLayerIds = useMemo(
-    () =>
-      open ? (mapControllerRef.current?.getBasemapStyleLayerIds() ?? []) : [],
-    [open, mapControllerRef],
-  );
+  // Computed during render (not memoized) so the list picks up the map
+  // controller once it finishes initialising; the call is a cheap filter.
+  const basemapStyleLayerIds = open
+    ? (mapControllerRef.current?.getBasemapStyleLayerIds() ?? [])
+    : [];
 
   const handleArcgisLayerTypeChange = (nextLayerType: ArcGISLayerType) => {
     const currentUrl = arcgisUrl.trim();

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -519,7 +519,10 @@ export function DesktopShell({
           />
         </main>
         {layoutOptions.stylePanelVisible ? (
-          <StylePanel onResizeStart={startStylePanelResize} />
+          <StylePanel
+            mapControllerRef={mapControllerRef}
+            onResizeStart={startStylePanelResize}
+          />
         ) : null}
       </div>
       {layoutOptions.attributePanelVisible ? <AttributeTable /> : null}

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -15,6 +15,7 @@ import {
   Separator,
   Slider,
 } from "@geolibre/ui";
+import type { MapController } from "@geolibre/map";
 import {
   ChevronDown,
   ChevronUp,
@@ -24,9 +25,15 @@ import {
   SlidersHorizontal,
   Trash2,
 } from "lucide-react";
-import { type MouseEvent as ReactMouseEvent, useEffect, useState } from "react";
+import {
+  type MouseEvent as ReactMouseEvent,
+  type RefObject,
+  useEffect,
+  useState,
+} from "react";
 
 interface StylePanelProps {
+  mapControllerRef: RefObject<MapController | null>;
   onResizeStart: (event: ReactMouseEvent<HTMLDivElement>) => void;
 }
 
@@ -892,7 +899,10 @@ function RasterStyleSlider({
   );
 }
 
-export function StylePanel({ onResizeStart }: StylePanelProps) {
+export function StylePanel({
+  mapControllerRef,
+  onResizeStart,
+}: StylePanelProps) {
   const selectedLayerId = useAppStore((s) => s.selectedLayerId);
   const layers = useAppStore((s) => s.layers);
   const setLayerOpacity = useAppStore((s) => s.setLayerOpacity);
@@ -1321,9 +1331,10 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
       vectorStyleExpression: draftVectorStyleExpression.trim(),
     });
   };
-  const applyBeforeId = () => {
+  const applyBeforeId = (value: string) => {
+    setDraftBeforeId(value);
     updateLayer(layer.id, {
-      beforeId: draftBeforeId.trim() || undefined,
+      beforeId: value.trim() || undefined,
     });
   };
   const applyExtrusionSettings = () => {
@@ -1359,20 +1370,27 @@ export function StylePanel({ onResizeStart }: StylePanelProps) {
       extrusionHeightExpression: draftHeightExpression.trim(),
     });
   };
+  const basemapStyleLayerIds =
+    mapControllerRef.current?.getBasemapStyleLayerIds() ?? [];
+  const beforeIdOptions =
+    draftBeforeId && !basemapStyleLayerIds.includes(draftBeforeId)
+      ? [draftBeforeId, ...basemapStyleLayerIds]
+      : basemapStyleLayerIds;
   const beforeIdControl = (
     <div className="space-y-2">
-      <Label htmlFor="beforeId">Before ID</Label>
-      <Input
+      <Label htmlFor="beforeId">Insert before</Label>
+      <Select
         id="beforeId"
         value={draftBeforeId}
-        placeholder="MapLibre layer ID"
-        onChange={(event) => setDraftBeforeId(event.target.value)}
-        onKeyDown={(event) => {
-          if (event.key !== "Enter") return;
-          event.preventDefault();
-          applyBeforeId();
-        }}
-      />
+        onChange={(event) => applyBeforeId(event.target.value)}
+      >
+        <option value="">Layer order (default)</option>
+        {beforeIdOptions.map((styleLayerId) => (
+          <option key={styleLayerId} value={styleLayerId}>
+            {styleLayerId}
+          </option>
+        ))}
+      </Select>
     </div>
   );
   const minZoom = styleValue(style, "minZoom");

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1344,9 +1344,10 @@ export function StylePanel({
       return;
     }
     setDraftBeforeId(value);
-    updateLayer(layer.id, {
-      beforeId: value.trim() || undefined,
-    });
+    const nextBeforeId = value.trim() || undefined;
+    if (nextBeforeId !== layer.beforeId) {
+      updateLayer(layer.id, { beforeId: nextBeforeId });
+    }
   };
   const applyExtrusionSettings = () => {
     if (draftAdvancedExtrusionEnabled) {
@@ -1384,12 +1385,12 @@ export function StylePanel({
   const basemapStyleLayerIds =
     mapControllerRef.current?.getBasemapStyleLayerIds() ?? [];
   const otherLayers = layers.filter((l) => l.id !== layer.id);
-  const beforeIdOptions =
+  const orphanedBeforeId =
     draftBeforeId &&
     !basemapStyleLayerIds.includes(draftBeforeId) &&
     !otherLayers.some((l) => l.id === draftBeforeId)
-      ? [draftBeforeId, ...basemapStyleLayerIds]
-      : basemapStyleLayerIds;
+      ? draftBeforeId
+      : null;
   const beforeIdControl = (
     <div className="space-y-2">
       <Label htmlFor="beforeId">Insert before</Label>
@@ -1399,6 +1400,11 @@ export function StylePanel({
         onChange={(event) => applyBeforeId(event.target.value)}
       >
         <option value="">Layer order (default)</option>
+        {orphanedBeforeId && (
+          <optgroup label="Saved (unavailable)">
+            <option value={orphanedBeforeId}>{orphanedBeforeId}</option>
+          </optgroup>
+        )}
         {otherLayers.length > 0 && (
           <optgroup label="Layers">
             {[...otherLayers].reverse().map((otherLayer) => (
@@ -1408,9 +1414,9 @@ export function StylePanel({
             ))}
           </optgroup>
         )}
-        {beforeIdOptions.length > 0 && (
+        {basemapStyleLayerIds.length > 0 && (
           <optgroup label="Basemap layers">
-            {beforeIdOptions.map((styleLayerId) => (
+            {basemapStyleLayerIds.map((styleLayerId) => (
               <option key={styleLayerId} value={styleLayerId}>
                 {styleLayerId}
               </option>

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -908,6 +908,7 @@ export function StylePanel({
   const setLayerOpacity = useAppStore((s) => s.setLayerOpacity);
   const setLayerStyle = useAppStore((s) => s.setLayerStyle);
   const updateLayer = useAppStore((s) => s.updateLayer);
+  const moveLayer = useAppStore((s) => s.moveLayer);
   const [isCollapsed, setIsCollapsed] = useState(isMobileViewport);
   const [draftBeforeId, setDraftBeforeId] = useState("");
   const [draftColorExpression, setDraftColorExpression] = useState("");
@@ -1332,6 +1333,16 @@ export function StylePanel({
     });
   };
   const applyBeforeId = (value: string) => {
+    // Picking another user layer is a one-shot reorder in the layer list;
+    // beforeId metadata only works for raw MapLibre (basemap) layer ids.
+    const otherLayers = layers.filter((l) => l.id !== layer.id);
+    const targetIndex = otherLayers.findIndex((l) => l.id === value);
+    if (targetIndex >= 0) {
+      setDraftBeforeId("");
+      if (layer.beforeId) updateLayer(layer.id, { beforeId: undefined });
+      moveLayer(layer.id, targetIndex);
+      return;
+    }
     setDraftBeforeId(value);
     updateLayer(layer.id, {
       beforeId: value.trim() || undefined,
@@ -1372,8 +1383,11 @@ export function StylePanel({
   };
   const basemapStyleLayerIds =
     mapControllerRef.current?.getBasemapStyleLayerIds() ?? [];
+  const otherLayers = layers.filter((l) => l.id !== layer.id);
   const beforeIdOptions =
-    draftBeforeId && !basemapStyleLayerIds.includes(draftBeforeId)
+    draftBeforeId &&
+    !basemapStyleLayerIds.includes(draftBeforeId) &&
+    !otherLayers.some((l) => l.id === draftBeforeId)
       ? [draftBeforeId, ...basemapStyleLayerIds]
       : basemapStyleLayerIds;
   const beforeIdControl = (
@@ -1385,11 +1399,24 @@ export function StylePanel({
         onChange={(event) => applyBeforeId(event.target.value)}
       >
         <option value="">Layer order (default)</option>
-        {beforeIdOptions.map((styleLayerId) => (
-          <option key={styleLayerId} value={styleLayerId}>
-            {styleLayerId}
-          </option>
-        ))}
+        {otherLayers.length > 0 && (
+          <optgroup label="Layers">
+            {[...otherLayers].reverse().map((otherLayer) => (
+              <option key={otherLayer.id} value={otherLayer.id}>
+                {otherLayer.name}
+              </option>
+            ))}
+          </optgroup>
+        )}
+        {beforeIdOptions.length > 0 && (
+          <optgroup label="Basemap layers">
+            {beforeIdOptions.map((styleLayerId) => (
+              <option key={styleLayerId} value={styleLayerId}>
+                {styleLayerId}
+              </option>
+            ))}
+          </optgroup>
+        )}
       </Select>
     </div>
   );

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1339,8 +1339,10 @@ export function StylePanel({
     const targetIndex = otherLayers.findIndex((l) => l.id === value);
     if (targetIndex >= 0) {
       setDraftBeforeId("");
-      if (layer.beforeId) updateLayer(layer.id, { beforeId: undefined });
+      // Move first so the sync triggered by each store update already sees
+      // the correct array position.
       moveLayer(layer.id, targetIndex);
+      if (layer.beforeId) updateLayer(layer.id, { beforeId: undefined });
       return;
     }
     setDraftBeforeId(value);
@@ -1382,6 +1384,8 @@ export function StylePanel({
       extrusionHeightExpression: draftHeightExpression.trim(),
     });
   };
+  // NOTE: not reactive to basemap switches — the ref does not trigger a
+  // re-render, so the list refreshes on the next store-driven render.
   const basemapStyleLayerIds =
     mapControllerRef.current?.getBasemapStyleLayerIds() ?? [];
   const otherLayers = layers.filter((l) => l.id !== layer.id);

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -522,6 +522,10 @@ export class MapController {
     }
   }
 
+  getBasemapStyleLayerIds(): string[] {
+    return this.getBasemapStyleLayers().map((layer) => layer.id);
+  }
+
   private getBasemapStyleLayers(): maplibregl.LayerSpecification[] {
     if (!this.isStyleReady() || !this.map) return [];
     const map = this.map;


### PR DESCRIPTION
## Summary
- Replace the free-text "Before Id" input in the Add Data dialog with an "Insert before" dropdown listing existing map layers (by name) and basemap style layers, so users no longer need to type raw MapLibre layer ids
- Replace the "Before ID" input in the Style panel with the same dropdown; the selection now applies immediately instead of requiring Enter, and an out-of-style saved beforeId is kept as a visible option
- Add a public MapController.getBasemapStyleLayerIds() helper and pass mapControllerRef into StylePanel to populate the options

## Test plan
- [x] npm run build passes
- [x] All 99 frontend tests pass (npm run test:frontend)
- [ ] Open Add Data dialog, confirm the dropdown lists current layers and basemap layers, and a new layer added with "Insert before" lands beneath the chosen layer
- [ ] Select a layer, open the Style panel, choose a basemap layer under "Insert before", and confirm the layer moves beneath it immediately
- [ ] Load a saved project with a custom beforeId and confirm the value still shows in the dropdown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced free-text "Before Id" input with an "Insert before" dropdown in layer dialogs and the style panel; includes a default "Top of layer list" option, grouped existing user layers (insert-before order), and basemap-style layer entries.
  * Shows a "Saved (unavailable)" group when a saved target is no longer present.

* **Refactor**
  * Streamlined layer-insertion and ordering behavior so selecting an existing layer performs an immediate reorder and unavailable targets are handled gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->