### PR TITLE
feat: consolidate New/Open/Save into a Project menu with Save As

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
@@ -7,18 +7,15 @@ import {
 } from "@geolibre/core";
 import {
   Button,
-  type ButtonProps,
   cn,
   Dialog,
   DialogContent,
   DialogDescription,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
   Input,
   Label,
 } from "@geolibre/ui";
-import { FilePlus2 } from "lucide-react";
 import type { FormEvent } from "react";
 import { useMemo, useState } from "react";
 
@@ -41,25 +38,20 @@ type BasemapChoice =
   | typeof BLANK_BASEMAP_ID;
 
 interface NewProjectDialogProps {
-  buttonClassName?: string;
-  buttonSize?: ButtonProps["size"];
-  iconClassName?: string;
-  showLabels?: boolean;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   onSaveCurrentProject: () => Promise<boolean>;
   onProjectCreated?: () => void;
 }
 
 export function NewProjectDialog({
-  buttonClassName,
-  buttonSize = "sm",
-  iconClassName,
-  showLabels = true,
+  open,
+  onOpenChange,
   onSaveCurrentProject,
   onProjectCreated,
 }: NewProjectDialogProps) {
   const newProject = useAppStore((s) => s.newProject);
   const isDirty = useAppStore((s) => s.isDirty);
-  const [open, setOpen] = useState(false);
   const [selectedBasemapId, setSelectedBasemapId] =
     useState<BasemapChoice>(DEFAULT_BASEMAP_ID);
   const [projectName, setProjectName] = useState(DEFAULT_PROJECT_NAME);
@@ -95,7 +87,7 @@ export function NewProjectDialog({
   };
 
   const handleOpenChange = (nextOpen: boolean) => {
-    setOpen(nextOpen);
+    onOpenChange(nextOpen);
     if (!nextOpen) resetForm();
   };
 
@@ -118,7 +110,7 @@ export function NewProjectDialog({
           : createDefaultMapView(),
     });
     onProjectCreated?.();
-    setOpen(false);
+    onOpenChange(false);
     resetForm();
   };
 
@@ -148,17 +140,6 @@ export function NewProjectDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogTrigger asChild>
-        <Button
-          className={buttonClassName}
-          variant="ghost"
-          size={buttonSize}
-          aria-label="New project"
-        >
-          <FilePlus2 className={iconClassName ?? "h-3.5 w-3.5 sm:mr-1"} />
-          {showLabels ? <span className="hidden sm:inline">New</span> : null}
-        </Button>
-      </DialogTrigger>
       <DialogContent className="max-w-xl">
         {showSavePrompt ? (
           <>

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -75,6 +75,8 @@ import {
   Bug,
   CircleHelp,
   Database,
+  FilePlus2,
+  Folder,
   FolderOpen,
   History,
   Info,
@@ -86,6 +88,7 @@ import {
   Puzzle,
   RefreshCw,
   Save,
+  SaveAll,
   SlidersHorizontal,
   Sun,
   Wrench,
@@ -101,11 +104,13 @@ import {
 import { useDesktopSettingsStore } from "../../hooks/useDesktopSettings";
 import type { ThemeMode } from "../../hooks/useThemeMode";
 import {
+  isHttpUrl,
   isTauri,
   openProjectFile,
   openRecentProjectFile,
   RecentProjectGoneError,
   saveProjectFile,
+  saveProjectFileToPath,
 } from "../../lib/tauri-io";
 import { mergeStringLists } from "../../lib/string-lists";
 import { normalizeProjectUrl } from "../../lib/urls";
@@ -234,6 +239,7 @@ export function TopToolbar({
     ),
   );
   const [addDataKind, setAddDataKind] = useState<AddDataKind | null>(null);
+  const [newProjectDialogOpen, setNewProjectDialogOpen] = useState(false);
   const [projectUrlDialogOpen, setProjectUrlDialogOpen] = useState(false);
   const [projectUrl, setProjectUrl] = useState("");
   const [projectUrlError, setProjectUrlError] = useState<string | null>(null);
@@ -353,7 +359,9 @@ export function TopToolbar({
     }
   };
 
-  const handleSave = async (): Promise<boolean> => {
+  const saveProject = async (options?: {
+    saveAs?: boolean;
+  }): Promise<boolean> => {
     const state = useAppStore.getState();
     const defaultProjectName = state.projectName.trim() || "Untitled Project";
     const pluginManifestUrls = mergeStringLists(
@@ -375,10 +383,19 @@ export function TopToolbar({
       metadata: state.metadata,
     });
     const content = serializeProject(project);
-    const path = await saveProjectFile(
-      content,
-      state.projectPath ?? `${defaultProjectName}.geolibre.json`,
-    );
+    // Projects opened from a URL have no writable path, so both Save and
+    // Save As fall back to the save dialog for them.
+    const existingLocalPath =
+      state.projectPath && !isHttpUrl(state.projectPath)
+        ? state.projectPath
+        : null;
+    const path =
+      !options?.saveAs && existingLocalPath
+        ? await saveProjectFileToPath(content, existingLocalPath)
+        : await saveProjectFile(
+            content,
+            existingLocalPath ?? `${defaultProjectName}.geolibre.json`,
+          );
     if (!path) return false;
     setProjectPath(path);
     rememberRecentProject({
@@ -389,6 +406,9 @@ export function TopToolbar({
     markSaved();
     return true;
   };
+
+  const handleSave = () => saveProject();
+  const handleSaveAs = () => saveProject({ saveAs: true });
 
   const {
     plugins,
@@ -541,108 +561,123 @@ export function TopToolbar({
           <span className="hidden sm:inline">{appTitle}</span>
         ) : null}
       </span>
-      <NewProjectDialog
-        buttonClassName={toolbarButtonClass}
-        buttonSize={toolbarButtonSize}
-        iconClassName={toolbarIconClassName}
-        showLabels={showLabels}
-        onSaveCurrentProject={handleSave}
-        onProjectCreated={resetRuntimeControlsForNewProject}
-      />
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button
             className={toolbarButtonClass}
             variant="ghost"
             size={toolbarButtonSize}
-            aria-label="Open"
+            aria-label="Project"
           >
-            <FolderOpen className={toolbarIconClassName} />
-            {renderToolbarLabel("Open")}
+            <Folder className={toolbarIconClassName} />
+            {renderToolbarLabel("Project")}
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="w-80">
+        <DropdownMenuContent align="start" className="w-64">
           <DropdownMenuLabel>Project</DropdownMenuLabel>
           <DropdownMenuSeparator />
-          <DropdownMenuItem onSelect={() => void handleOpenFromFile()}>
-            <FolderOpen className="mr-2 h-3.5 w-3.5" />
-            Open Project from File...
+          <DropdownMenuItem onSelect={() => setNewProjectDialogOpen(true)}>
+            <FilePlus2 className="mr-2 h-3.5 w-3.5" />
+            New...
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setProjectUrlDialogOpen(true)}>
-            <Link2 className="mr-2 h-3.5 w-3.5" />
-            Open Project from URL...
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuLabel>Recent projects</DropdownMenuLabel>
-          {recentProjects.length === 0 ? (
-            <DropdownMenuItem disabled>No recent projects</DropdownMenuItem>
-          ) : (
-            recentProjects.map((project) => {
-              const openedAt = formatRecentProjectTime(project.openedAt);
-              const label = project.name || projectPathLabel(project.path);
-              return (
-                <DropdownMenuItem
-                  key={project.path}
-                  className="flex items-start justify-between gap-2"
-                  onSelect={() => void handleOpenRecent(project.path)}
-                  title={project.path}
-                >
-                  <span className="flex min-w-0 flex-col items-start gap-0.5">
-                    <span
-                      className="max-w-full truncate font-medium"
-                      title={label}
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              <FolderOpen className="mr-2 h-3.5 w-3.5" />
+              Open From
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              <DropdownMenuItem onSelect={() => void handleOpenFromFile()}>
+                <FolderOpen className="mr-2 h-3.5 w-3.5" />
+                File...
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => setProjectUrlDialogOpen(true)}>
+                <Link2 className="mr-2 h-3.5 w-3.5" />
+                URL...
+              </DropdownMenuItem>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              <History className="mr-2 h-3.5 w-3.5" />
+              Open Recent
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent className="w-80">
+              {recentProjects.length === 0 ? (
+                <DropdownMenuItem disabled>No recent projects</DropdownMenuItem>
+              ) : (
+                recentProjects.map((project) => {
+                  const openedAt = formatRecentProjectTime(project.openedAt);
+                  const label = project.name || projectPathLabel(project.path);
+                  return (
+                    <DropdownMenuItem
+                      key={project.path}
+                      className="flex items-start justify-between gap-2"
+                      onSelect={() => void handleOpenRecent(project.path)}
+                      title={project.path}
                     >
-                      {label}
-                    </span>
-                    <span className="flex max-w-full items-start gap-1 text-xs text-muted-foreground">
-                      <History className="h-3 w-3 shrink-0" />
-                      <span
-                        className="break-all text-left leading-snug"
-                        title={project.path}
-                      >
-                        {openedAt
-                          ? `${openedAt} - ${project.path}`
-                          : project.path}
+                      <span className="flex min-w-0 flex-col items-start gap-0.5">
+                        <span
+                          className="max-w-full truncate font-medium"
+                          title={label}
+                        >
+                          {label}
+                        </span>
+                        <span className="flex max-w-full items-start gap-1 text-xs text-muted-foreground">
+                          <History className="h-3 w-3 shrink-0" />
+                          <span
+                            className="break-all text-left leading-snug"
+                            title={project.path}
+                          >
+                            {openedAt
+                              ? `${openedAt} - ${project.path}`
+                              : project.path}
+                          </span>
+                        </span>
                       </span>
-                    </span>
-                  </span>
-                  <button
-                    type="button"
-                    aria-label={`Remove ${label} from recent projects`}
-                    className="mt-0.5 shrink-0 rounded p-0.5 text-muted-foreground hover:text-foreground"
-                    onClick={(event) => {
-                      // Keep the menu open and prevent the row's onSelect (which
-                      // would reopen the project) from firing.
-                      event.stopPropagation();
-                      event.preventDefault();
-                      forgetRecentProject(project.path);
-                    }}
-                  >
-                    <X className="h-3.5 w-3.5" />
-                  </button>
-                </DropdownMenuItem>
-              );
-            })
-          )}
+                      <button
+                        type="button"
+                        aria-label={`Remove ${label} from recent projects`}
+                        className="mt-0.5 shrink-0 rounded p-0.5 text-muted-foreground hover:text-foreground"
+                        onClick={(event) => {
+                          // Keep the menu open and prevent the row's onSelect
+                          // (which would reopen the project) from firing.
+                          event.stopPropagation();
+                          event.preventDefault();
+                          forgetRecentProject(project.path);
+                        }}
+                      >
+                        <X className="h-3.5 w-3.5" />
+                      </button>
+                    </DropdownMenuItem>
+                  );
+                })
+              )}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                disabled={recentProjects.length === 0}
+                onSelect={clearRecentProjects}
+              >
+                Clear Recent Projects
+              </DropdownMenuItem>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
           <DropdownMenuSeparator />
-          <DropdownMenuItem
-            disabled={recentProjects.length === 0}
-            onSelect={clearRecentProjects}
-          >
-            Clear Recent Projects
+          <DropdownMenuItem onSelect={() => void handleSave()}>
+            <Save className="mr-2 h-3.5 w-3.5" />
+            Save
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => void handleSaveAs()}>
+            <SaveAll className="mr-2 h-3.5 w-3.5" />
+            Save As...
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
-      <Button
-        className={toolbarButtonClass}
-        variant="ghost"
-        size={toolbarButtonSize}
-        onClick={handleSave}
-        aria-label="Save"
-      >
-        <Save className={toolbarIconClassName} />
-        {renderToolbarLabel("Save")}
-      </Button>
+      <NewProjectDialog
+        open={newProjectDialogOpen}
+        onOpenChange={setNewProjectDialogOpen}
+        onSaveCurrentProject={handleSave}
+        onProjectCreated={resetRuntimeControlsForNewProject}
+      />
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -77,6 +77,7 @@ import {
   Database,
   FilePen,
   FilePlus2,
+  FileText,
   Folder,
   FolderOpen,
   History,
@@ -596,7 +597,7 @@ export function TopToolbar({
             </DropdownMenuSubTrigger>
             <DropdownMenuSubContent>
               <DropdownMenuItem onSelect={() => void handleOpenFromFile()}>
-                <FolderOpen className="mr-2 h-3.5 w-3.5" />
+                <FileText className="mr-2 h-3.5 w-3.5" />
                 File...
               </DropdownMenuItem>
               <DropdownMenuItem onSelect={() => setProjectUrlDialogOpen(true)}>

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -75,6 +75,7 @@ import {
   Bug,
   CircleHelp,
   Database,
+  FilePen,
   FilePlus2,
   Folder,
   FolderOpen,
@@ -88,7 +89,6 @@ import {
   Puzzle,
   RefreshCw,
   Save,
-  SaveAll,
   SlidersHorizontal,
   Sun,
   Wrench,
@@ -389,13 +389,22 @@ export function TopToolbar({
       state.projectPath && !isHttpUrl(state.projectPath)
         ? state.projectPath
         : null;
-    const path =
-      !options?.saveAs && existingLocalPath
-        ? await saveProjectFileToPath(content, existingLocalPath)
-        : await saveProjectFile(
-            content,
-            existingLocalPath ?? `${defaultProjectName}.geolibre.json`,
-          );
+    let path: string | null;
+    try {
+      path =
+        !options?.saveAs && existingLocalPath
+          ? await saveProjectFileToPath(content, existingLocalPath)
+          : await saveProjectFile(
+              content,
+              existingLocalPath ?? `${defaultProjectName}.geolibre.json`,
+            );
+    } catch (error) {
+      console.error("Failed to save project", error);
+      setActionError(
+        error instanceof Error ? error.message : "Could not save the project.",
+      );
+      return false;
+    }
     if (!path) return false;
     setProjectPath(path);
     rememberRecentProject({
@@ -597,7 +606,7 @@ export function TopToolbar({
             </DropdownMenuSubContent>
           </DropdownMenuSub>
           <DropdownMenuSub>
-            <DropdownMenuSubTrigger>
+            <DropdownMenuSubTrigger disabled={recentProjects.length === 0}>
               <History className="mr-2 h-3.5 w-3.5" />
               Open Recent
             </DropdownMenuSubTrigger>
@@ -667,7 +676,7 @@ export function TopToolbar({
             Save
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => void handleSaveAs()}>
-            <SaveAll className="mr-2 h-3.5 w-3.5" />
+            <FilePen className="mr-2 h-3.5 w-3.5" />
             Save As...
           </DropdownMenuItem>
         </DropdownMenuContent>
@@ -1060,7 +1069,7 @@ export function TopToolbar({
       >
         <DialogContent className="max-w-lg">
           <DialogHeader>
-            <DialogTitle>Could not open project</DialogTitle>
+            <DialogTitle>Something went wrong</DialogTitle>
             <DialogDescription>{actionError}</DialogDescription>
           </DialogHeader>
           <div className="flex justify-end">

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -128,7 +128,7 @@ function isAbortError(error: unknown): boolean {
   return error instanceof DOMException && error.name === "AbortError";
 }
 
-function isHttpUrl(path: string): boolean {
+export function isHttpUrl(path: string): boolean {
   try {
     const url = new URL(path);
     return url.protocol === "http:" || url.protocol === "https:";
@@ -860,6 +860,22 @@ export async function saveProjectFile(
     defaultPath: defaultName ?? "project.geolibre.json",
   });
   if (!path) return null;
+  await writeTextFile(path, content);
+  return path;
+}
+
+/**
+ * Save a project directly to an already-known local path without prompting.
+ * Falls back to the save dialog when not running in Tauri (the browser never
+ * has a writable filesystem path) or when the path is an HTTP(S) URL.
+ */
+export async function saveProjectFileToPath(
+  content: string,
+  path: string,
+): Promise<string | null> {
+  if (!isTauri() || isHttpUrl(path)) {
+    return saveProjectFile(content, path);
+  }
   await writeTextFile(path, content);
   return path;
 }


### PR DESCRIPTION
## Summary
- Add a new Project dropdown as the first toolbar menu, containing New..., Open From (File/URL), Open Recent (with per-item remove and Clear Recent Projects), Save, and Save As...
- Remove the standalone New, Open, and Save entries from the top toolbar
- Save now writes directly to the project's existing local path without prompting; Save As (and projects opened from a URL or running in the browser) always open the save dialog
- NewProjectDialog is now a controlled dialog triggered from the Project menu instead of rendering its own toolbar button

## Test plan
- [x] `npm run build` (tsc + vite) passes
- [x] `npm run test:frontend` passes (99 tests)
- [x] Verified in the browser: toolbar shows Project as the first menu; New... opens the New map dialog; Open From shows File.../URL...; Open Recent shows the recent list and Clear Recent Projects; Save and Save As... are present
- [ ] Verify in Tauri desktop that Save writes in place for an opened project and Save As prompts for a new path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Project actions (New, Open, Open Recent, Save, Save As) consolidated into a single Project dropdown; the New dialog is now controlled by the toolbar.
* **New Features**
  * Save flow improved to write directly to a known local file when available, otherwise opens a Save dialog.
* **Bug Fixes**
  * Generic error dialog language clarified to be less specific.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->