### PR TITLE
feat: add maponly query param for chrome-free map embeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Supported query parameters:
 | `toolbar`    | `toolbar=icons`                                          | Shows icon-only toolbar buttons without enabling the full compact layout.                                                   |
 | `panels`     | `panels=none`                                            | Hides the Layers, Style, and Attribute table panels. `hidden`, `hide`, and `off` are aliases.                               |
 | `hidePanels` | `hidePanels=true`                                        | Alternative way to hide the Layers, Style, and Attribute table panels.                                                      |
+| `maponly`    | `maponly`                                                | Hides all chrome (toolbar menu, Layers/Style/Attribute panels, and status bar), leaving only the map. The bare flag or any of `true`, `1`, `yes`, `on` enable it. |
 
 Use compact mode for narrow embeds. This shows icon-only toolbar buttons and hides project metadata:
 
@@ -136,6 +137,12 @@ https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geol
 ```
 
 Use `toolbar=icons` when you only want icon-only toolbar buttons. `panels=hidden`, `panels=hide`, `panels=off`, and `hidePanels=true` are accepted aliases for hiding panels.
+
+For a fully chrome-free, map-only embed, use `maponly`. It hides the toolbar menu, all panels, and the status bar:
+
+```text
+https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json&maponly
+```
 
 ## Environment variables
 

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -490,16 +490,18 @@ export function DesktopShell({
       onDragOver={handleDragOver}
       onDrop={handleDrop}
     >
-      <TopToolbar
-        compact={layoutOptions.compact}
-        diagnosticsErrorCount={diagnostics.errorCount}
-        mapControllerRef={mapControllerRef}
-        showLabels={layoutOptions.toolbarLabels}
-        showProjectInfo={layoutOptions.showProjectInfo}
-        themeMode={themeMode}
-        onOpenDiagnostics={() => setDiagnosticsOpen(true)}
-        onToggleThemeMode={onToggleThemeMode}
-      />
+      {layoutOptions.toolbarVisible ? (
+        <TopToolbar
+          compact={layoutOptions.compact}
+          diagnosticsErrorCount={diagnostics.errorCount}
+          mapControllerRef={mapControllerRef}
+          showLabels={layoutOptions.toolbarLabels}
+          showProjectInfo={layoutOptions.showProjectInfo}
+          themeMode={themeMode}
+          onOpenDiagnostics={() => setDiagnosticsOpen(true)}
+          onToggleThemeMode={onToggleThemeMode}
+        />
+      ) : null}
       <div className="flex min-h-0 flex-1 flex-col md:flex-row">
         {layoutOptions.layerPanelVisible ? (
           <LayerPanel
@@ -526,12 +528,14 @@ export function DesktopShell({
         ) : null}
       </div>
       {layoutOptions.attributePanelVisible ? <AttributeTable /> : null}
-      <StatusBar
-        compact={layoutOptions.compact}
-        diagnosticsErrorCount={diagnostics.errorCount}
-        diagnosticsWarningCount={diagnostics.warningCount}
-        onOpenDiagnostics={() => setDiagnosticsOpen(true)}
-      />
+      {layoutOptions.statusBarVisible ? (
+        <StatusBar
+          compact={layoutOptions.compact}
+          diagnosticsErrorCount={diagnostics.errorCount}
+          diagnosticsWarningCount={diagnostics.warningCount}
+          onOpenDiagnostics={() => setDiagnosticsOpen(true)}
+        />
+      ) : null}
       <DiagnosticsDialog
         diagnostics={diagnostics}
         open={diagnosticsOpen}

--- a/apps/geolibre-desktop/src/hooks/useLayoutOptions.ts
+++ b/apps/geolibre-desktop/src/hooks/useLayoutOptions.ts
@@ -55,6 +55,10 @@ export function layoutOptionsFromLocation(
   const mapOnly =
     params.has("maponly") &&
     MAP_ONLY_VALUES.has(normalizedParam(params.get("maponly")));
+  // `maponly` implies `compact` so the map fills its container (the `<main>`
+  // element gets `min-h-0`). This also forces `toolbarLabels` and
+  // `showProjectInfo` to false below, which is harmless since the toolbar is
+  // hidden, but any other consumer of `compact` sees `true` in map-only mode.
   const compact = mapOnly || COMPACT_LAYOUT_VALUES.has(layout);
   const panelsHidden =
     mapOnly ||

--- a/apps/geolibre-desktop/src/hooks/useLayoutOptions.ts
+++ b/apps/geolibre-desktop/src/hooks/useLayoutOptions.ts
@@ -10,13 +10,16 @@ export interface LayoutOptions {
   compact: boolean;
   layerPanelVisible: boolean;
   showProjectInfo: boolean;
+  statusBarVisible: boolean;
   stylePanelVisible: boolean;
   toolbarLabels: boolean;
+  toolbarVisible: boolean;
 }
 
 const COMPACT_LAYOUT_VALUES = new Set(["compact", "embed", "iframe"]);
 const ICON_TOOLBAR_VALUES = new Set(["icon", "icons", "icon-only"]);
 const HIDDEN_PANEL_VALUES = new Set(["hidden", "hide", "none", "off"]);
+const MAP_ONLY_VALUES = new Set(["", "true", "1", "yes", "on"]);
 
 export function useLayoutOptions(): LayoutOptions {
   // Shallow equality keeps unrelated desktop-settings updates (which always
@@ -30,19 +33,31 @@ export function useLayoutOptions(): LayoutOptions {
   );
 }
 
-function layoutOptionsFromLocation(
+export function layoutOptionsFromLocation(
   layoutSettings: DesktopLayoutSettings,
 ): LayoutOptions {
   if (typeof window === "undefined") {
-    return { compact: false, ...layoutSettings };
+    return {
+      compact: false,
+      statusBarVisible: true,
+      toolbarVisible: true,
+      ...layoutSettings,
+    };
   }
 
   const params = new URLSearchParams(window.location.search);
   const layout = normalizedParam(params.get("layout"));
   const panels = normalizedParam(params.get("panels"));
   const toolbar = normalizedParam(params.get("toolbar"));
-  const compact = COMPACT_LAYOUT_VALUES.has(layout);
+  // `maponly` hides the entire chrome (toolbar, panels, status bar), leaving
+  // only the map. The param can be a bare flag (`?maponly`) or an explicit
+  // truthy value (`?maponly=true`).
+  const mapOnly =
+    params.has("maponly") &&
+    MAP_ONLY_VALUES.has(normalizedParam(params.get("maponly")));
+  const compact = mapOnly || COMPACT_LAYOUT_VALUES.has(layout);
   const panelsHidden =
+    mapOnly ||
     HIDDEN_PANEL_VALUES.has(panels) ||
     normalizedParam(params.get("hidePanels")) === "true";
   const toolbarLabels =
@@ -65,8 +80,10 @@ function layoutOptionsFromLocation(
     compact,
     layerPanelVisible,
     showProjectInfo,
+    statusBarVisible: !mapOnly,
     stylePanelVisible,
     toolbarLabels,
+    toolbarVisible: !mapOnly,
   };
 }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,6 +84,12 @@ https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geol
 
 Use `toolbar=icons` when you only want icon-only toolbar buttons. `panels=hidden`, `panels=hide`, `panels=off`, and `hidePanels=true` are accepted aliases for hiding panels.
 
+For a fully chrome-free, map-only embed, add `&maponly` to hide the toolbar menu, all panels, and the status bar:
+
+```text
+https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json&maponly
+```
+
 | Parameter | Example | Description |
 | --- | --- | --- |
 | `url` | `url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json` | Loads a `.geolibre.json` project from a public URL. |
@@ -91,6 +97,7 @@ Use `toolbar=icons` when you only want icon-only toolbar buttons. `panels=hidden
 | `toolbar` | `toolbar=icons` | Shows icon-only toolbar buttons without enabling the full compact layout. |
 | `panels` | `panels=none` | Hides the Layers, Style, and Attribute table panels. `hidden`, `hide`, and `off` are aliases. |
 | `hidePanels` | `hidePanels=true` | Alternative way to hide the Layers, Style, and Attribute table panels. |
+| `maponly` | `maponly` | Hides all chrome (toolbar menu, Layers/Style/Attribute panels, and status bar), leaving only the map. The bare flag or any of `true`, `1`, `yes`, `on` enable it. |
 
 [Open the live demo](https://viewer.geolibre.app/){ .md-button .md-button--primary }
 [Read the architecture](architecture.md){ .md-button }

--- a/tests/layout-options.test.ts
+++ b/tests/layout-options.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { DEFAULT_DESKTOP_LAYOUT_SETTINGS } from "../apps/geolibre-desktop/src/hooks/useDesktopSettings";
+import { layoutOptionsFromLocation } from "../apps/geolibre-desktop/src/hooks/useLayoutOptions";
+
+const originalWindow = (globalThis as { window?: unknown }).window;
+
+function withSearch(search: string): void {
+  (globalThis as { window?: unknown }).window = {
+    location: { search },
+  };
+}
+
+afterEach(() => {
+  if (originalWindow === undefined) {
+    delete (globalThis as { window?: unknown }).window;
+  } else {
+    (globalThis as { window?: unknown }).window = originalWindow;
+  }
+});
+
+describe("layoutOptionsFromLocation", () => {
+  it("keeps all chrome visible without query params", () => {
+    withSearch("");
+    const options = layoutOptionsFromLocation(DEFAULT_DESKTOP_LAYOUT_SETTINGS);
+    assert.equal(options.toolbarVisible, true);
+    assert.equal(options.statusBarVisible, true);
+    assert.equal(options.layerPanelVisible, true);
+    assert.equal(options.stylePanelVisible, true);
+    assert.equal(options.attributePanelVisible, true);
+  });
+
+  it("hides every chrome element when maponly is set as a bare flag", () => {
+    withSearch("?maponly");
+    const options = layoutOptionsFromLocation(DEFAULT_DESKTOP_LAYOUT_SETTINGS);
+    assert.equal(options.toolbarVisible, false);
+    assert.equal(options.statusBarVisible, false);
+    assert.equal(options.layerPanelVisible, false);
+    assert.equal(options.stylePanelVisible, false);
+    assert.equal(options.attributePanelVisible, false);
+  });
+
+  it("accepts truthy maponly values", () => {
+    for (const value of ["true", "1", "yes", "on"]) {
+      withSearch(`?maponly=${value}`);
+      const options = layoutOptionsFromLocation(DEFAULT_DESKTOP_LAYOUT_SETTINGS);
+      assert.equal(options.toolbarVisible, false, `maponly=${value}`);
+      assert.equal(options.statusBarVisible, false, `maponly=${value}`);
+    }
+  });
+
+  it("ignores maponly with a non-truthy value", () => {
+    withSearch("?maponly=false");
+    const options = layoutOptionsFromLocation(DEFAULT_DESKTOP_LAYOUT_SETTINGS);
+    assert.equal(options.toolbarVisible, true);
+    assert.equal(options.statusBarVisible, true);
+    assert.equal(options.layerPanelVisible, true);
+  });
+
+  it("leaves the toolbar and status bar visible for panels=none", () => {
+    withSearch("?panels=none");
+    const options = layoutOptionsFromLocation(DEFAULT_DESKTOP_LAYOUT_SETTINGS);
+    assert.equal(options.toolbarVisible, true);
+    assert.equal(options.statusBarVisible, true);
+    assert.equal(options.layerPanelVisible, false);
+    assert.equal(options.stylePanelVisible, false);
+    assert.equal(options.attributePanelVisible, false);
+  });
+});

--- a/tests/layout-options.test.ts
+++ b/tests/layout-options.test.ts
@@ -46,7 +46,21 @@ describe("layoutOptionsFromLocation", () => {
       const options = layoutOptionsFromLocation(DEFAULT_DESKTOP_LAYOUT_SETTINGS);
       assert.equal(options.toolbarVisible, false, `maponly=${value}`);
       assert.equal(options.statusBarVisible, false, `maponly=${value}`);
+      assert.equal(options.layerPanelVisible, false, `maponly=${value}`);
+      assert.equal(options.stylePanelVisible, false, `maponly=${value}`);
+      assert.equal(options.attributePanelVisible, false, `maponly=${value}`);
     }
+  });
+
+  it("returns defaults when window is undefined (SSR)", () => {
+    delete (globalThis as { window?: unknown }).window;
+    const options = layoutOptionsFromLocation(DEFAULT_DESKTOP_LAYOUT_SETTINGS);
+    assert.equal(options.toolbarVisible, true);
+    assert.equal(options.statusBarVisible, true);
+    assert.equal(options.compact, false);
+    assert.equal(options.layerPanelVisible, true);
+    assert.equal(options.stylePanelVisible, true);
+    assert.equal(options.attributePanelVisible, true);
   });
 
   it("ignores maponly with a non-truthy value", () => {


### PR DESCRIPTION
## Summary
- Add a `maponly` URL query parameter that hides all UI chrome (toolbar menu, Layers/Style/Attribute panels, and status bar), leaving only the map for clean embeds.
- Accepts a bare flag (`?maponly`) or a truthy value (`true`, `1`, `yes`, `on`); non-truthy values are ignored.
- Document the parameter in the README and docs embed tables, and cover the layout logic with unit tests.

## Test plan
- [x] `node --import tsx --test tests/layout-options.test.ts` (5/5 pass)
- [x] `npm run test:frontend` (118/118 pass)
- [x] `npx tsc -b apps/geolibre-desktop` (clean)
- [ ] Open the viewer with `?maponly` and confirm only the map is visible
- [ ] Confirm `?maponly=false` leaves the full UI intact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `maponly` query parameter to enable minimalist, chrome-free embeds that hide the toolbar, status bar, and all panels so only the map displays.

* **Documentation**
  * Updated docs and README with `maponly` details, supported truthy values, and iframe usage examples.

* **Tests**
  * Added tests covering `maponly` behavior, truthy/false values, and server-side default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->