### PR TITLE
feat: add SQL Workspace under the Processing menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Lightweight, cloud-native desktop GIS prototype built with **Tauri v2**, **React
 - Layer panel for visibility, opacity, reordering, zoom-to-layer, identify, labels, and remove actions
 - Live style panel (fill, stroke, opacity, circle radius)
 - Attribute table with filtering, sorting, resize controls, feature highlighting, and optional zoom to selected features
+- SQL Workspace for running DuckDB SQL against loaded layers, local files, and remote URLs, with sample queries, query history, and adding results to the map
 - Multiple DuckDB SQL query-result layers
 - Save/open `.geolibre.json` projects
 - Desktop diagnostics panel, update check, and MSIX packaging support
@@ -104,6 +105,25 @@ docker build --build-arg GEOLIBRE_APP_BASE=/geolibre/ -t geolibre .
 ```
 
 The container always serves the app from its root path. The build argument only sets the URL prefix that the app expects, so subpath deployments also require a reverse proxy in front of the container that strips the prefix before forwarding requests (for example, nginx `proxy_pass http://geolibre/;` with a trailing slash).
+
+## SQL Workspace
+
+The SQL Workspace runs DuckDB SQL (with the Spatial extension loaded, so `ST_*` functions are available) directly in the browser against your loaded layers and remote data. Open it from the Processing menu.
+
+- **Query loaded layers.** Every vector layer with in-memory features is exposed as a table; the queryable table names are listed at the top of the dialog.
+- **Read files and URLs.** Use `read_parquet()`, `read_csv_auto()`, `read_json_auto()`, or `ST_Read()`. A bare URL or path after `FROM`/`JOIN` (for example `SELECT * FROM https://host/data.parquet`) is auto-wrapped in the matching reader. Remote files are streamed over HTTP range requests, so large datasets are not downloaded in full.
+- **Sample queries.** A dropdown of ready-to-run examples (attribute-only, aggregate, and spatial queries) against a public sample dataset, plus a per-layer "sample query for layer" dropdown.
+- **Query history.** Recently run queries are saved (in `localStorage`) and can be reloaded from the History dropdown.
+- **Results and export.** Results show in a grid (capped for display; the full result is kept for export). When a query returns a geometry column, you can add the result to the map as a new layer (with an optional custom **layer name**) or export it as CSV or GeoParquet.
+
+```sql
+SELECT NAME, CONTINENT, POP_EST, geom
+FROM https://data.source.coop/giswqs/opengeos/countries.parquet
+WHERE POP_EST > 50000000
+ORDER BY POP_EST DESC;
+```
+
+Only a single statement is supported per run; remote `s3://` URLs are not read directly, so use the HTTPS form instead.
 
 ## Embed the demo
 

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -541,7 +541,9 @@ export function DesktopShell({
           />
         ) : null}
       </div>
-      {layoutOptions.attributePanelVisible ? <AttributeTable /> : null}
+      {layoutOptions.attributePanelVisible ? (
+        <AttributeTable mapControllerRef={mapControllerRef} />
+      ) : null}
       {layoutOptions.statusBarVisible ? (
         <StatusBar
           compact={layoutOptions.compact}

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -73,6 +73,20 @@ const ConversionDialog = lazy(() =>
     }),
 );
 
+const SqlWorkspaceDialog = lazy(() =>
+  import("../processing/SqlWorkspaceDialog")
+    .then((module) => ({
+      default: module.SqlWorkspaceDialog,
+    }))
+    .catch((error) => {
+      // Same chunk-load fallback rationale as ProcessingDialog above.
+      console.error("Failed to load SqlWorkspaceDialog", error);
+      const Fallback = (() =>
+        null) as unknown as typeof import("../processing/SqlWorkspaceDialog").SqlWorkspaceDialog;
+      return { default: Fallback };
+    }),
+);
+
 interface DesktopShellProps {
   layoutOptions: LayoutOptions;
   projectUrlLoadState?: ProjectUrlLoadState;
@@ -546,6 +560,9 @@ export function DesktopShell({
       </Suspense>
       <Suspense fallback={null}>
         <ConversionDialog />
+      </Suspense>
+      <Suspense fallback={null}>
+        <SqlWorkspaceDialog />
       </Suspense>
       <div
         ref={verticalResizeGuideRef}

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -244,6 +244,7 @@ export function TopToolbar({
   const loadProject = useAppStore((s) => s.loadProject);
   const setProcessingOpen = useAppStore((s) => s.setProcessingOpen);
   const setConversionOpen = useAppStore((s) => s.setConversionOpen);
+  const setSqlWorkspaceOpen = useAppStore((s) => s.setSqlWorkspaceOpen);
   const projectName = useAppStore((s) => s.projectName);
   const projectPath = useAppStore((s) => s.projectPath);
   const recentProjects = useAppStore((s) => s.recentProjects);
@@ -892,6 +893,9 @@ export function TopToolbar({
           <DropdownMenuSeparator />
           <DropdownMenuItem onSelect={() => setProcessingOpen(true)}>
             Whitebox
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setSqlWorkspaceOpen(true)}>
+            SQL Workspace
           </DropdownMenuItem>
           <DropdownMenuSub>
             <DropdownMenuSubTrigger>Conversion</DropdownMenuSubTrigger>

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -307,6 +307,11 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
         properties: (feature.properties ?? {}) as Record<string, unknown>,
       }));
   const hasAttributeSource = Boolean(layer?.geojson || isDuckDBLayer);
+  // Add Vector Layer (geojson-mode) layers render from a MapLibre source the
+  // control owns, and their `layer.geojson` is dropped when a project is saved.
+  // Edits made here would neither redraw on the map nor survive a save, so the
+  // attribute table is read-only for them.
+  const isReadOnlyVectorLayer = geojsonVectorSourceId(layer) !== null;
 
   // Vector layers added via the Add Vector Layer control keep their features in
   // a MapLibre GeoJSON source rather than in `layer.geojson`. Read the data back
@@ -801,18 +806,24 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
           size="sm"
           className="ml-auto h-7 px-2"
           title={
-            isEditing
-              ? hasEdits
-                ? "Use Save or Cancel to finish editing"
-                : "Exit edit mode"
-              : isDuckDBLayer
-                ? "Edit displayed DuckDB query attributes in memory"
-                : "Edit attribute values"
+            isReadOnlyVectorLayer
+              ? "Editing is not available for Add Vector Layer layers"
+              : isEditing
+                ? hasEdits
+                  ? "Use Save or Cancel to finish editing"
+                  : "Exit edit mode"
+                : isDuckDBLayer
+                  ? "Edit displayed DuckDB query attributes in memory"
+                  : "Edit attribute values"
           }
           aria-label={
             isEditing && !hasEdits ? "Exit edit mode" : "Edit attribute values"
           }
-          disabled={!hasAttributeSource || (isEditing && hasEdits)}
+          disabled={
+            !hasAttributeSource ||
+            isReadOnlyVectorLayer ||
+            (isEditing && hasEdits)
+          }
           onClick={toggleEditing}
         >
           <Pencil className="h-3.5 w-3.5" />

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -1,9 +1,15 @@
-import { isDuckDBQueryLayer, useAppStore } from "@geolibre/core";
+import {
+  isDuckDBQueryLayer,
+  useAppStore,
+  type GeoLibreLayer,
+} from "@geolibre/core";
 import {
   getDuckDBLayerRows,
   updateDuckDBLayerRows,
   type DuckDBAttributeRow,
 } from "@geolibre/plugins";
+import type { MapController } from "@geolibre/map";
+import type { GeoJSONSource } from "maplibre-gl";
 import {
   Button,
   DropdownMenu,
@@ -18,7 +24,7 @@ import {
   TableHeader,
   TableRow,
 } from "@geolibre/ui";
-import type { Feature } from "geojson";
+import type { Feature, FeatureCollection } from "geojson";
 import {
   ArrowDown,
   ArrowUp,
@@ -33,6 +39,7 @@ import {
 } from "lucide-react";
 import {
   type MouseEvent as ReactMouseEvent,
+  type RefObject,
   useEffect,
   useRef,
   useState,
@@ -230,7 +237,31 @@ function exportMimeType(format: BinaryVectorExportFormat): string {
   }
 }
 
-export function AttributeTable() {
+/**
+ * Source id of a geojson-render-mode vector layer created by the Add Vector
+ * Layer control, or null. These layers hold their features in a MapLibre
+ * GeoJSON source rather than in `layer.geojson`, so the attribute table reads
+ * the data back from the map. Tiles-mode (DuckDB) vector layers are excluded.
+ */
+function geojsonVectorSourceId(layer: GeoLibreLayer | undefined): string | null {
+  if (
+    !layer ||
+    layer.type !== "geojson" ||
+    layer.metadata.sourceKind !== "maplibre-gl-vector" ||
+    layer.metadata.externalNativeLayer !== true
+  ) {
+    return null;
+  }
+  const sourceIds = layer.metadata.sourceIds;
+  const sourceId = Array.isArray(sourceIds) ? sourceIds[0] : undefined;
+  return typeof sourceId === "string" ? sourceId : null;
+}
+
+interface AttributeTableProps {
+  mapControllerRef: RefObject<MapController | null>;
+}
+
+export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
   const tableSectionRef = useRef<HTMLElement>(null);
   const tableResizeGuideRef = useRef<HTMLDivElement>(null);
   const selectedLayerId = useAppStore((s) => s.selectedLayerId);
@@ -262,6 +293,8 @@ export function AttributeTable() {
   const [exportError, setExportError] = useState<string | null>(null);
   const deferTableResize = isTauri();
 
+  const [loadingVectorGeojson, setLoadingVectorGeojson] = useState(false);
+
   const layer = layers.find((l) => l.id === selectedLayerId);
   const hasLayer = Boolean(layer);
   const features = layer?.geojson?.features ?? [];
@@ -274,6 +307,53 @@ export function AttributeTable() {
         properties: (feature.properties ?? {}) as Record<string, unknown>,
       }));
   const hasAttributeSource = Boolean(layer?.geojson || isDuckDBLayer);
+
+  // Vector layers added via the Add Vector Layer control keep their features in
+  // a MapLibre GeoJSON source rather than in `layer.geojson`. Read the data back
+  // from the map once so the table (and export) can use it like any other
+  // vector layer. Tiles-mode vector layers are not handled here.
+  useEffect(() => {
+    if (!layer || layer.geojson) {
+      setLoadingVectorGeojson(false);
+      return;
+    }
+    const sourceId = geojsonVectorSourceId(layer);
+    if (!sourceId) {
+      setLoadingVectorGeojson(false);
+      return;
+    }
+    const source = mapControllerRef.current?.getMap()?.getSource(sourceId) as
+      | GeoJSONSource
+      | undefined;
+    if (!source || typeof source.getData !== "function") return;
+
+    let cancelled = false;
+    const layerId = layer.id;
+    setLoadingVectorGeojson(true);
+    source
+      .getData()
+      .then((data) => {
+        if (cancelled) return;
+        if (
+          data &&
+          typeof data === "object" &&
+          (data as { type?: string }).type === "FeatureCollection"
+        ) {
+          updateLayer(layerId, { geojson: data as FeatureCollection });
+        }
+      })
+      .catch(() => {
+        // Best-effort: a source that cannot return data leaves the table in its
+        // existing "requires a vector layer" empty state.
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingVectorGeojson(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [layer, mapControllerRef, updateLayer]);
   const hasEdits = hasDraftEdits(drafts);
   const hasInvalidDrafts = attributeRows.some((row) => {
     const rowDrafts = drafts[row.featureId];
@@ -833,7 +913,9 @@ export function AttributeTable() {
       >
         {!hasAttributeSource ? (
           <p className="p-4 text-xs text-muted-foreground">
-            Attribute table requires a vector or DuckDB query layer.
+            {loadingVectorGeojson
+              ? "Loading layer attributes…"
+              : "Attribute table requires a vector or DuckDB query layer."}
           </p>
         ) : (
           <table

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -325,7 +325,12 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     const source = mapControllerRef.current?.getMap()?.getSource(sourceId) as
       | GeoJSONSource
       | undefined;
-    if (!source || typeof source.getData !== "function") return;
+    if (!source || typeof source.getData !== "function") {
+      // Reset here too: a prior run may have left the indicator true, and this
+      // early return would otherwise leave it stuck after a layer switch.
+      setLoadingVectorGeojson(false);
+      return;
+    }
 
     let cancelled = false;
     const layerId = layer.id;

--- a/apps/geolibre-desktop/src/components/processing/SqlWorkspaceDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SqlWorkspaceDialog.tsx
@@ -80,6 +80,48 @@ function sampleQueryForTable(tableName: string): string {
   return `SELECT *\nFROM ${tableName}\nLIMIT 10;`;
 }
 
+const HISTORY_STORAGE_KEY = "geolibre.sqlWorkspace.history";
+const MAX_HISTORY_ENTRIES = 25;
+
+/** Load saved query history from localStorage, newest first. */
+function loadQueryHistory(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const parsed = JSON.parse(
+      window.localStorage.getItem(HISTORY_STORAGE_KEY) ?? "[]",
+    );
+    return Array.isArray(parsed)
+      ? parsed.filter((entry): entry is string => typeof entry === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Prepend a query to history (deduped, newest first, capped) and persist it. */
+function saveQueryToHistory(history: string[], query: string): string[] {
+  const trimmed = query.trim();
+  if (!trimmed) return history;
+  const next = [
+    trimmed,
+    ...history.filter((entry) => entry !== trimmed),
+  ].slice(0, MAX_HISTORY_ENTRIES);
+  if (typeof window !== "undefined") {
+    try {
+      window.localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(next));
+    } catch {
+      // Best-effort: ignore quota or privacy-mode storage failures.
+    }
+  }
+  return next;
+}
+
+/** One-line, length-capped label for a history entry. */
+function historyLabel(query: string): string {
+  const oneLine = query.replace(/\s+/g, " ").trim();
+  return oneLine.length > 80 ? `${oneLine.slice(0, 80)}…` : oneLine;
+}
+
 /** Format a result cell for display, keeping the grid compact and readable. */
 function formatCell(value: unknown): string {
   if (value === null || value === undefined) return "";
@@ -105,6 +147,7 @@ export function SqlWorkspaceDialog() {
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<SqlQueryResult | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
+  const [history, setHistory] = useState<string[]>(loadQueryHistory);
 
   const tables = useMemo(() => previewLayerTables(layers), [layers]);
 
@@ -116,6 +159,7 @@ export function SqlWorkspaceDialog() {
   const runQuery = async () => {
     const trimmed = sql.trim();
     if (!trimmed || runningRef.current) return;
+    setHistory((current) => saveQueryToHistory(current, trimmed));
     runningRef.current = true;
     setRunning(true);
     setError(null);
@@ -243,6 +287,26 @@ export function SqlWorkspaceDialog() {
               </p>
             )}
             <div className="ml-auto flex items-center gap-2">
+              {history.length > 0 ? (
+                <Select
+                  aria-label="Reuse a query from history"
+                  className="h-8 w-auto max-w-[12rem] text-xs"
+                  value=""
+                  onChange={(event) => {
+                    const entry = history[Number(event.target.value)];
+                    if (entry) setSql(entry);
+                  }}
+                >
+                  <option value="" disabled>
+                    History…
+                  </option>
+                  {history.map((entry, index) => (
+                    <option key={entry} value={index}>
+                      {historyLabel(entry)}
+                    </option>
+                  ))}
+                </Select>
+              ) : null}
               <Select
                 aria-label="Insert a sample query"
                 className="h-8 w-auto text-xs"

--- a/apps/geolibre-desktop/src/components/processing/SqlWorkspaceDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SqlWorkspaceDialog.tsx
@@ -1,5 +1,4 @@
-import { DEFAULT_LAYER_STYLE, useAppStore } from "@geolibre/core";
-import type { GeoLibreLayer } from "@geolibre/core";
+import { useAppStore } from "@geolibre/core";
 import {
   Button,
   Dialog,
@@ -33,16 +32,16 @@ const MAX_DISPLAYED_ROWS = 500;
 
 const SAMPLE_QUERY = "SELECT 1 AS hello;";
 
-function createLayerId(): string {
-  return typeof crypto !== "undefined" && "randomUUID" in crypto
-    ? crypto.randomUUID()
-    : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
-}
-
 /** Format a result cell for display, keeping the grid compact and readable. */
 function formatCell(value: unknown): string {
   if (value === null || value === undefined) return "";
-  if (typeof value === "object") return JSON.stringify(value);
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return "[object]";
+    }
+  }
   return String(value);
 }
 
@@ -50,7 +49,7 @@ export function SqlWorkspaceDialog() {
   const open = useAppStore((s) => s.ui.sqlWorkspaceOpen);
   const setSqlWorkspaceOpen = useAppStore((s) => s.setSqlWorkspaceOpen);
   const layers = useAppStore((s) => s.layers);
-  const addLayer = useAppStore((s) => s.addLayer);
+  const addGeoJsonLayer = useAppStore((s) => s.addGeoJsonLayer);
 
   const [sql, setSql] = useState(SAMPLE_QUERY);
   const [running, setRunning] = useState(false);
@@ -79,24 +78,10 @@ export function SqlWorkspaceDialog() {
 
   const handleAddAsLayer = () => {
     if (!result?.geojson) return;
-    const layer: GeoLibreLayer = {
-      id: createLayerId(),
-      name: "SQL result",
-      type: "geojson",
-      source: { type: "geojson" },
-      visible: true,
-      opacity: 1,
-      style: { ...DEFAULT_LAYER_STYLE },
-      metadata: {
-        featureCount: result.geojson.features.length,
-        sourceKind: "sql-workspace",
-      },
-      geojson: result.geojson,
-    };
-    addLayer(layer);
-    setNotice(
-      `Added ${result.geojson.features.length} features to the map as "SQL result".`,
-    );
+    const featureCount = result.geojson.features.length;
+    const name = `SQL result ${new Date().toLocaleTimeString()}`;
+    addGeoJsonLayer(name, result.geojson);
+    setNotice(`Added ${featureCount} features to the map as "${name}".`);
   };
 
   const saveBinary = async (

--- a/apps/geolibre-desktop/src/components/processing/SqlWorkspaceDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SqlWorkspaceDialog.tsx
@@ -6,6 +6,7 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
+  Input,
   ScrollArea,
   Select,
   cn,
@@ -143,6 +144,7 @@ export function SqlWorkspaceDialog() {
   const [result, setResult] = useState<SqlQueryResult | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [history, setHistory] = useState<string[]>(loadQueryHistory);
+  const [layerName, setLayerName] = useState("");
 
   const tables = useMemo(() => previewLayerTables(layers), [layers]);
 
@@ -179,13 +181,15 @@ export function SqlWorkspaceDialog() {
     setResult(null);
     setError(null);
     setNotice(null);
+    setLayerName("");
   };
 
   const handleAddAsLayer = () => {
     if (!result?.geojson) return;
     setError(null);
     const featureCount = result.geojson.features.length;
-    const name = `SQL result ${new Date().toLocaleTimeString()}`;
+    const name =
+      layerName.trim() || `SQL result ${new Date().toLocaleTimeString()}`;
     addGeoJsonLayer(name, result.geojson);
     setNotice(`Added ${featureCount} features to the map as "${name}".`);
   };
@@ -418,6 +422,15 @@ export function SqlWorkspaceDialog() {
           {result ? (
             <div className="grid gap-2">
               <div className="flex flex-wrap items-center gap-2">
+                {result.geojson ? (
+                  <Input
+                    aria-label="Layer name"
+                    className="h-8 w-48 text-sm"
+                    value={layerName}
+                    onChange={(event) => setLayerName(event.target.value)}
+                    placeholder="Layer name (optional)"
+                  />
+                ) : null}
                 <Button
                   variant="outline"
                   size="sm"

--- a/apps/geolibre-desktop/src/components/processing/SqlWorkspaceDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SqlWorkspaceDialog.tsx
@@ -53,6 +53,7 @@ export function SqlWorkspaceDialog() {
 
   const [sql, setSql] = useState(SAMPLE_QUERY);
   const [running, setRunning] = useState(false);
+  const [exporting, setExporting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<SqlQueryResult | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
@@ -78,6 +79,7 @@ export function SqlWorkspaceDialog() {
 
   const handleAddAsLayer = () => {
     if (!result?.geojson) return;
+    setError(null);
     const featureCount = result.geojson.features.length;
     const name = `SQL result ${new Date().toLocaleTimeString()}`;
     addGeoJsonLayer(name, result.geojson);
@@ -103,8 +105,10 @@ export function SqlWorkspaceDialog() {
   };
 
   const handleExportCsv = async () => {
-    if (!result) return;
+    if (!result || exporting) return;
     setError(null);
+    setNotice(null);
+    setExporting(true);
     try {
       const csv = resultToCsv(result.columns, result.rows);
       await saveBinary(
@@ -117,12 +121,16 @@ export function SqlWorkspaceDialog() {
       );
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setExporting(false);
     }
   };
 
   const handleExportGeoParquet = async () => {
-    if (!result?.geojson) return;
+    if (!result?.geojson || exporting) return;
     setError(null);
+    setNotice(null);
+    setExporting(true);
     try {
       const exported = await exportBinaryVectorLayer(
         result.geojson,
@@ -132,6 +140,8 @@ export function SqlWorkspaceDialog() {
       await saveBinary({ ...exported, mimeType: GEOPARQUET_MIME_TYPE }, "GeoParquet");
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setExporting(false);
     }
   };
 
@@ -231,7 +241,7 @@ export function SqlWorkspaceDialog() {
                   variant="outline"
                   size="sm"
                   onClick={handleAddAsLayer}
-                  disabled={!result.geojson}
+                  disabled={!result.geojson || exporting}
                 >
                   <MapPlus className="h-4 w-4" />
                   Add as layer
@@ -240,7 +250,7 @@ export function SqlWorkspaceDialog() {
                   variant="outline"
                   size="sm"
                   onClick={handleExportCsv}
-                  disabled={result.columns.length === 0}
+                  disabled={result.columns.length === 0 || exporting}
                 >
                   <Download className="h-4 w-4" />
                   Export CSV
@@ -249,7 +259,7 @@ export function SqlWorkspaceDialog() {
                   variant="outline"
                   size="sm"
                   onClick={handleExportGeoParquet}
-                  disabled={!result.geojson}
+                  disabled={!result.geojson || exporting}
                 >
                   <Download className="h-4 w-4" />
                   Export GeoParquet

--- a/apps/geolibre-desktop/src/components/processing/SqlWorkspaceDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SqlWorkspaceDialog.tsx
@@ -1,0 +1,314 @@
+import { DEFAULT_LAYER_STYLE, useAppStore } from "@geolibre/core";
+import type { GeoLibreLayer } from "@geolibre/core";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  ScrollArea,
+  cn,
+} from "@geolibre/ui";
+import { AlertCircle, Download, Loader2, MapPlus, Play } from "lucide-react";
+import { useMemo, useState } from "react";
+import {
+  exportBinaryVectorLayer,
+  type BinaryVectorExportResult,
+} from "../../lib/vector-exporter";
+import {
+  previewLayerTables,
+  resultToCsv,
+  runSqlQuery,
+  type SqlQueryResult,
+} from "../../lib/sql-workspace";
+import { saveBinaryFileWithFallback } from "../../lib/tauri-io";
+
+const CSV_MIME_TYPE = "text/csv";
+const GEOPARQUET_MIME_TYPE = "application/vnd.apache.parquet";
+
+// Cap how many result rows are rendered so a large result set cannot freeze the
+// UI; the full result is still used for export and add-as-layer.
+const MAX_DISPLAYED_ROWS = 500;
+
+const SAMPLE_QUERY = "SELECT 1 AS hello;";
+
+function createLayerId(): string {
+  return typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+/** Format a result cell for display, keeping the grid compact and readable. */
+function formatCell(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+export function SqlWorkspaceDialog() {
+  const open = useAppStore((s) => s.ui.sqlWorkspaceOpen);
+  const setSqlWorkspaceOpen = useAppStore((s) => s.setSqlWorkspaceOpen);
+  const layers = useAppStore((s) => s.layers);
+  const addLayer = useAppStore((s) => s.addLayer);
+
+  const [sql, setSql] = useState(SAMPLE_QUERY);
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<SqlQueryResult | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const tables = useMemo(() => previewLayerTables(layers), [layers]);
+
+  const runQuery = async () => {
+    const trimmed = sql.trim();
+    if (!trimmed || running) return;
+    setRunning(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const queryResult = await runSqlQuery(trimmed, layers);
+      setResult(queryResult);
+    } catch (err) {
+      setResult(null);
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  const handleAddAsLayer = () => {
+    if (!result?.geojson) return;
+    const layer: GeoLibreLayer = {
+      id: createLayerId(),
+      name: "SQL result",
+      type: "geojson",
+      source: { type: "geojson" },
+      visible: true,
+      opacity: 1,
+      style: { ...DEFAULT_LAYER_STYLE },
+      metadata: {
+        featureCount: result.geojson.features.length,
+        sourceKind: "sql-workspace",
+      },
+      geojson: result.geojson,
+    };
+    addLayer(layer);
+    setNotice(
+      `Added ${result.geojson.features.length} features to the map as "SQL result".`,
+    );
+  };
+
+  const saveBinary = async (
+    payload: BinaryVectorExportResult,
+    label: string,
+  ) => {
+    const savedName = await saveBinaryFileWithFallback(payload.data, {
+      defaultName: `sql-result.${payload.extension}`,
+      filters: [{ name: label, extensions: [payload.extension] }],
+      browserTypes: [
+        {
+          description: label,
+          accept: { [payload.mimeType]: [`.${payload.extension}`] },
+        },
+      ],
+      mimeType: payload.mimeType,
+    });
+    if (savedName) setNotice(`Saved ${label} as ${savedName}.`);
+  };
+
+  const handleExportCsv = async () => {
+    if (!result) return;
+    setError(null);
+    try {
+      const csv = resultToCsv(result.columns, result.rows);
+      await saveBinary(
+        {
+          data: new TextEncoder().encode(csv),
+          extension: "csv",
+          mimeType: CSV_MIME_TYPE,
+        },
+        "CSV",
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const handleExportGeoParquet = async () => {
+    if (!result?.geojson) return;
+    setError(null);
+    try {
+      const exported = await exportBinaryVectorLayer(
+        result.geojson,
+        "geoparquet",
+        "SQL result",
+      );
+      await saveBinary({ ...exported, mimeType: GEOPARQUET_MIME_TYPE }, "GeoParquet");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const displayedRows = result?.rows.slice(0, MAX_DISPLAYED_ROWS) ?? [];
+  const hiddenRowCount = result ? result.rowCount - displayedRows.length : 0;
+
+  return (
+    <Dialog open={open} onOpenChange={setSqlWorkspaceOpen}>
+      <DialogContent className="max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>SQL Workspace</DialogTitle>
+          <DialogDescription>
+            Run DuckDB SQL against loaded layers, files, and URLs. The spatial
+            extension is loaded, so {"ST_*"} functions are available.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4">
+          {tables.length > 0 ? (
+            <p className="text-xs text-muted-foreground">
+              Queryable layers:{" "}
+              {tables.map((table, index) => (
+                <span key={table.tableName}>
+                  {index > 0 ? ", " : ""}
+                  <code className="rounded bg-muted px-1 py-0.5 font-mono">
+                    {table.tableName}
+                  </code>
+                </span>
+              ))}
+            </p>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              No vector layers are loaded as tables yet. You can still read files
+              and URLs with {"read_parquet()"}, {"read_csv_auto()"}, or {"ST_Read()"}.
+            </p>
+          )}
+
+          <textarea
+            value={sql}
+            onChange={(event) => setSql(event.target.value)}
+            spellCheck={false}
+            rows={6}
+            className={cn(
+              "w-full rounded-md border border-input bg-transparent px-3 py-2",
+              "font-mono text-sm shadow-sm transition-colors",
+              "placeholder:text-muted-foreground focus-visible:border-2",
+              "focus-visible:border-ring focus-visible:outline-none",
+            )}
+            placeholder="SELECT * FROM your_layer LIMIT 10;"
+          />
+
+          <div className="flex items-center gap-2">
+            <Button onClick={runQuery} disabled={running || !sql.trim()}>
+              {running ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Play className="h-4 w-4" />
+              )}
+              Run
+            </Button>
+            {result ? (
+              <span className="text-sm text-muted-foreground">
+                {result.rowCount} row{result.rowCount === 1 ? "" : "s"} ·{" "}
+                {result.columns.length} column
+                {result.columns.length === 1 ? "" : "s"}
+              </span>
+            ) : null}
+          </div>
+
+          {error ? (
+            <div className="grid gap-2 rounded-md border border-destructive/40 bg-destructive/5 p-3">
+              <p className="flex items-start gap-2 text-sm text-destructive">
+                <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                <span className="font-mono">{error}</span>
+              </p>
+            </div>
+          ) : null}
+
+          {notice ? (
+            <p className="text-sm text-muted-foreground">{notice}</p>
+          ) : null}
+
+          {result ? (
+            <div className="grid gap-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleAddAsLayer}
+                  disabled={!result.geojson}
+                >
+                  <MapPlus className="h-4 w-4" />
+                  Add as layer
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleExportCsv}
+                  disabled={result.columns.length === 0}
+                >
+                  <Download className="h-4 w-4" />
+                  Export CSV
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleExportGeoParquet}
+                  disabled={!result.geojson}
+                >
+                  <Download className="h-4 w-4" />
+                  Export GeoParquet
+                </Button>
+              </div>
+
+              {result.columns.length > 0 ? (
+                <ScrollArea className="max-h-80 rounded-md border">
+                  <table className="w-full border-collapse text-sm">
+                    <thead className="sticky top-0 bg-muted">
+                      <tr>
+                        {result.columns.map((column) => (
+                          <th
+                            key={column}
+                            className="border-b px-2 py-1.5 text-left font-medium"
+                          >
+                            {column}
+                          </th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {displayedRows.map((row, rowIndex) => (
+                        <tr key={rowIndex} className="even:bg-muted/40">
+                          {result.columns.map((column) => (
+                            <td
+                              key={column}
+                              className="max-w-xs truncate border-b px-2 py-1 font-mono"
+                              title={formatCell(row[column])}
+                            >
+                              {formatCell(row[column])}
+                            </td>
+                          ))}
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </ScrollArea>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  Statement executed. No rows returned.
+                </p>
+              )}
+
+              {hiddenRowCount > 0 ? (
+                <p className="text-xs text-muted-foreground">
+                  Showing first {displayedRows.length} of {result.rowCount} rows.
+                  Export to see them all.
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/geolibre-desktop/src/components/processing/SqlWorkspaceDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SqlWorkspaceDialog.tsx
@@ -7,9 +7,17 @@ import {
   DialogHeader,
   DialogTitle,
   ScrollArea,
+  Select,
   cn,
 } from "@geolibre/ui";
-import { AlertCircle, Download, Loader2, MapPlus, Play } from "lucide-react";
+import {
+  AlertCircle,
+  Download,
+  Eraser,
+  Loader2,
+  MapPlus,
+  Play,
+} from "lucide-react";
 import { useMemo, useRef, useState } from "react";
 import {
   exportBinaryVectorLayer,
@@ -31,6 +39,11 @@ const GEOPARQUET_MIME_TYPE = "application/vnd.apache.parquet";
 const MAX_DISPLAYED_ROWS = 500;
 
 const SAMPLE_QUERY = "SELECT 1 AS hello;";
+
+/** Build a starter query that selects the first rows of a layer table. */
+function sampleQueryForTable(tableName: string): string {
+  return `SELECT *\nFROM ${tableName}\nLIMIT 10;`;
+}
 
 /** Format a result cell for display, keeping the grid compact and readable. */
 function formatCell(value: unknown): string {
@@ -82,6 +95,13 @@ export function SqlWorkspaceDialog() {
       runningRef.current = false;
       setRunning(false);
     }
+  };
+
+  const clearWorkspace = () => {
+    setSql("");
+    setResult(null);
+    setError(null);
+    setNotice(null);
   };
 
   const handleAddAsLayer = () => {
@@ -168,17 +188,37 @@ export function SqlWorkspaceDialog() {
 
         <div className="grid gap-4">
           {tables.length > 0 ? (
-            <p className="text-xs text-muted-foreground">
-              Queryable layers:{" "}
-              {tables.map((table, index) => (
-                <span key={table.tableName}>
-                  {index > 0 ? ", " : ""}
-                  <code className="rounded bg-muted px-1 py-0.5 font-mono">
+            <div className="flex flex-wrap items-center gap-2">
+              <p className="text-xs text-muted-foreground">
+                Queryable layers:{" "}
+                {tables.map((table, index) => (
+                  <span key={table.tableName}>
+                    {index > 0 ? ", " : ""}
+                    <code className="rounded bg-muted px-1 py-0.5 font-mono">
+                      {table.tableName}
+                    </code>
+                  </span>
+                ))}
+              </p>
+              <Select
+                aria-label="Insert a sample query for a layer"
+                className="ml-auto h-8 w-auto text-xs"
+                value=""
+                onChange={(event) => {
+                  const tableName = event.target.value;
+                  if (tableName) setSql(sampleQueryForTable(tableName));
+                }}
+              >
+                <option value="" disabled>
+                  Sample query for layer…
+                </option>
+                {tables.map((table) => (
+                  <option key={table.tableName} value={table.tableName}>
                     {table.tableName}
-                  </code>
-                </span>
-              ))}
-            </p>
+                  </option>
+                ))}
+              </Select>
+            </div>
           ) : (
             <p className="text-xs text-muted-foreground">
               No vector layers are loaded as tables yet. You can still read files
@@ -218,6 +258,14 @@ export function SqlWorkspaceDialog() {
                 <Play className="h-4 w-4" />
               )}
               Run
+            </Button>
+            <Button
+              variant="outline"
+              onClick={clearWorkspace}
+              disabled={running || (!sql && !result && !error)}
+            >
+              <Eraser className="h-4 w-4" />
+              Clear
             </Button>
             {result ? (
               <span className="text-sm text-muted-foreground">

--- a/apps/geolibre-desktop/src/components/processing/SqlWorkspaceDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SqlWorkspaceDialog.tsx
@@ -10,7 +10,7 @@ import {
   cn,
 } from "@geolibre/ui";
 import { AlertCircle, Download, Loader2, MapPlus, Play } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import {
   exportBinaryVectorLayer,
   type BinaryVectorExportResult,
@@ -60,9 +60,15 @@ export function SqlWorkspaceDialog() {
 
   const tables = useMemo(() => previewLayerTables(layers), [layers]);
 
+  // `running` state lags a render behind, so a rapid second Ctrl+Enter could
+  // read the stale `false` and fire a concurrent query. A ref is updated
+  // synchronously and guards against that race; `running` only drives the UI.
+  const runningRef = useRef(false);
+
   const runQuery = async () => {
     const trimmed = sql.trim();
-    if (!trimmed || running) return;
+    if (!trimmed || runningRef.current) return;
+    runningRef.current = true;
     setRunning(true);
     setError(null);
     setNotice(null);
@@ -73,6 +79,7 @@ export function SqlWorkspaceDialog() {
       setResult(null);
       setError(err instanceof Error ? err.message : String(err));
     } finally {
+      runningRef.current = false;
       setRunning(false);
     }
   };

--- a/apps/geolibre-desktop/src/components/processing/SqlWorkspaceDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SqlWorkspaceDialog.tsx
@@ -73,7 +73,9 @@ const SAMPLE_QUERIES: ReadonlyArray<{ label: string; sql: string }> = [
 
 /** Build a starter query that selects the first rows of a layer table. */
 function sampleQueryForTable(tableName: string): string {
-  return `SELECT *\nFROM ${tableName}\nLIMIT 10;`;
+  // Quote the identifier so the generated query stays valid even if the table
+  // name ever contains characters the sanitizer does not currently produce.
+  return `SELECT *\nFROM "${tableName.replaceAll('"', '""')}"\nLIMIT 10;`;
 }
 
 const HISTORY_STORAGE_KEY = "geolibre.sqlWorkspace.history";
@@ -87,7 +89,9 @@ function loadQueryHistory(): string[] {
       window.localStorage.getItem(HISTORY_STORAGE_KEY) ?? "[]",
     );
     return Array.isArray(parsed)
-      ? parsed.filter((entry): entry is string => typeof entry === "string")
+      ? parsed
+          .filter((entry): entry is string => typeof entry === "string")
+          .slice(0, MAX_HISTORY_ENTRIES)
       : [];
   } catch {
     return [];
@@ -155,6 +159,9 @@ export function SqlWorkspaceDialog() {
   // Same race for exports: the disabled buttons lag a render, so a fast double
   // click could open two save dialogs. The ref guards synchronously.
   const exportingRef = useRef(false);
+  // handleAddAsLayer is synchronous, so a rapid double-click could add the same
+  // result as two layers before React re-renders. The ref guards synchronously.
+  const addingLayerRef = useRef(false);
 
   const runQuery = async () => {
     const trimmed = sql.trim();
@@ -185,13 +192,15 @@ export function SqlWorkspaceDialog() {
   };
 
   const handleAddAsLayer = () => {
-    if (!result?.geojson) return;
+    if (!result?.geojson || addingLayerRef.current) return;
+    addingLayerRef.current = true;
     setError(null);
     const featureCount = result.geojson.features.length;
     const name =
       layerName.trim() || `SQL result ${new Date().toLocaleTimeString()}`;
     addGeoJsonLayer(name, result.geojson);
     setNotice(`Added ${featureCount} features to the map as "${name}".`);
+    addingLayerRef.current = false;
   };
 
   const saveBinary = async (
@@ -308,7 +317,7 @@ export function SqlWorkspaceDialog() {
                     History…
                   </option>
                   {history.map((entry, index) => (
-                    <option key={entry} value={index}>
+                    <option key={index} value={index}>
                       {historyLabel(entry)}
                     </option>
                   ))}

--- a/apps/geolibre-desktop/src/components/processing/SqlWorkspaceDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SqlWorkspaceDialog.tsx
@@ -27,6 +27,7 @@ import {
   previewLayerTables,
   resultToCsv,
   runSqlQuery,
+  SAMPLE_DATASET_URL,
   type SqlQueryResult,
 } from "../../lib/sql-workspace";
 import { saveBinaryFileWithFallback } from "../../lib/tauri-io";
@@ -38,11 +39,6 @@ const CSV_MIME_TYPE = "text/csv";
 const MAX_DISPLAYED_ROWS = 500;
 
 const SAMPLE_QUERY = "SELECT 1 AS hello;";
-
-// Public sample dataset (Natural Earth countries, GeoParquet) used by the
-// example queries so users can try the workspace without loading data first.
-const SAMPLE_DATASET_URL =
-  "https://data.source.coop/giswqs/opengeos/countries.parquet";
 
 // Curated examples covering plain attribute tables, aggregates, and spatial
 // queries that return a geometry column (so "Add as layer" / export work). All

--- a/apps/geolibre-desktop/src/components/processing/SqlWorkspaceDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SqlWorkspaceDialog.tsx
@@ -32,7 +32,6 @@ import {
 import { saveBinaryFileWithFallback } from "../../lib/tauri-io";
 
 const CSV_MIME_TYPE = "text/csv";
-const GEOPARQUET_MIME_TYPE = "application/vnd.apache.parquet";
 
 // Cap how many result rows are rendered so a large result set cannot freeze the
 // UI; the full result is still used for export and add-as-layer.
@@ -155,6 +154,9 @@ export function SqlWorkspaceDialog() {
   // read the stale `false` and fire a concurrent query. A ref is updated
   // synchronously and guards against that race; `running` only drives the UI.
   const runningRef = useRef(false);
+  // Same race for exports: the disabled buttons lag a render, so a fast double
+  // click could open two save dialogs. The ref guards synchronously.
+  const exportingRef = useRef(false);
 
   const runQuery = async () => {
     const trimmed = sql.trim();
@@ -211,7 +213,8 @@ export function SqlWorkspaceDialog() {
   };
 
   const handleExportCsv = async () => {
-    if (!result || exporting) return;
+    if (!result || exportingRef.current) return;
+    exportingRef.current = true;
     setError(null);
     setNotice(null);
     setExporting(true);
@@ -228,12 +231,14 @@ export function SqlWorkspaceDialog() {
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
+      exportingRef.current = false;
       setExporting(false);
     }
   };
 
   const handleExportGeoParquet = async () => {
-    if (!result?.geojson || exporting) return;
+    if (!result?.geojson || exportingRef.current) return;
+    exportingRef.current = true;
     setError(null);
     setNotice(null);
     setExporting(true);
@@ -243,10 +248,12 @@ export function SqlWorkspaceDialog() {
         "geoparquet",
         "SQL result",
       );
-      await saveBinary({ ...exported, mimeType: GEOPARQUET_MIME_TYPE }, "GeoParquet");
+      // exportBinaryVectorLayer already sets the GeoParquet mimeType.
+      await saveBinary(exported, "GeoParquet");
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
+      exportingRef.current = false;
       setExporting(false);
     }
   };
@@ -385,7 +392,7 @@ export function SqlWorkspaceDialog() {
             <Button
               variant="outline"
               onClick={clearWorkspace}
-              disabled={running || (!sql && !result && !error)}
+              disabled={running || (!sql && !result && !error && !notice)}
             >
               <Eraser className="h-4 w-4" />
               Clear

--- a/apps/geolibre-desktop/src/components/processing/SqlWorkspaceDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SqlWorkspaceDialog.tsx
@@ -169,9 +169,19 @@ export function SqlWorkspaceDialog() {
             </p>
           )}
 
+          <label htmlFor="sql-workspace-editor" className="sr-only">
+            SQL query
+          </label>
           <textarea
+            id="sql-workspace-editor"
             value={sql}
             onChange={(event) => setSql(event.target.value)}
+            onKeyDown={(event) => {
+              if ((event.ctrlKey || event.metaKey) && event.key === "Enter") {
+                event.preventDefault();
+                void runQuery();
+              }
+            }}
             spellCheck={false}
             rows={6}
             className={cn(

--- a/apps/geolibre-desktop/src/components/processing/SqlWorkspaceDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SqlWorkspaceDialog.tsx
@@ -40,6 +40,41 @@ const MAX_DISPLAYED_ROWS = 500;
 
 const SAMPLE_QUERY = "SELECT 1 AS hello;";
 
+// Public sample dataset (Natural Earth countries, GeoParquet) used by the
+// example queries so users can try the workspace without loading data first.
+const SAMPLE_DATASET_URL =
+  "https://data.source.coop/giswqs/opengeos/countries.parquet";
+
+// Curated examples covering plain attribute tables, aggregates, and spatial
+// queries that return a geometry column (so "Add as layer" / export work). All
+// were validated against the dataset above.
+const SAMPLE_QUERIES: ReadonlyArray<{ label: string; sql: string }> = [
+  {
+    label: "Countries with geometry",
+    sql: `SELECT NAME, CONTINENT, POP_EST, geom\nFROM ${SAMPLE_DATASET_URL}\nLIMIT 100;`,
+  },
+  {
+    label: "Attributes only (no geometry)",
+    sql: `SELECT NAME, CONTINENT, POP_EST, GDP_MD_EST\nFROM ${SAMPLE_DATASET_URL}\nORDER BY POP_EST DESC\nLIMIT 10;`,
+  },
+  {
+    label: "Population by continent (aggregate)",
+    sql: `SELECT CONTINENT, COUNT(*) AS countries, SUM(POP_EST) AS population\nFROM ${SAMPLE_DATASET_URL}\nGROUP BY CONTINENT\nORDER BY population DESC;`,
+  },
+  {
+    label: "Most populous countries (geometry)",
+    sql: `SELECT NAME, POP_EST, geom\nFROM ${SAMPLE_DATASET_URL}\nWHERE POP_EST > 50000000\nORDER BY POP_EST DESC;`,
+  },
+  {
+    label: "Country centroids (spatial)",
+    sql: `SELECT NAME, CONTINENT, ST_Centroid(geom) AS geom\nFROM ${SAMPLE_DATASET_URL}\nWHERE CONTINENT = 'Africa';`,
+  },
+  {
+    label: "Largest countries by area (spatial)",
+    sql: `SELECT NAME, ST_Area(geom) AS area\nFROM ${SAMPLE_DATASET_URL}\nORDER BY area DESC\nLIMIT 10;`,
+  },
+];
+
 /** Build a starter query that selects the first rows of a layer table. */
 function sampleQueryForTable(tableName: string): string {
   return `SELECT *\nFROM ${tableName}\nLIMIT 10;`;
@@ -187,8 +222,8 @@ export function SqlWorkspaceDialog() {
         </DialogHeader>
 
         <div className="grid gap-4">
-          {tables.length > 0 ? (
-            <div className="flex flex-wrap items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            {tables.length > 0 ? (
               <p className="text-xs text-muted-foreground">
                 Queryable layers:{" "}
                 {tables.map((table, index) => (
@@ -200,31 +235,55 @@ export function SqlWorkspaceDialog() {
                   </span>
                 ))}
               </p>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                No vector layers are loaded as tables yet. You can still read
+                files and URLs with {"read_parquet()"}, {"read_csv_auto()"}, or{" "}
+                {"ST_Read()"}.
+              </p>
+            )}
+            <div className="ml-auto flex items-center gap-2">
               <Select
-                aria-label="Insert a sample query for a layer"
-                className="ml-auto h-8 w-auto text-xs"
+                aria-label="Insert a sample query"
+                className="h-8 w-auto text-xs"
                 value=""
                 onChange={(event) => {
-                  const tableName = event.target.value;
-                  if (tableName) setSql(sampleQueryForTable(tableName));
+                  const index = Number(event.target.value);
+                  const sample = SAMPLE_QUERIES[index];
+                  if (sample) setSql(sample.sql);
                 }}
               >
                 <option value="" disabled>
-                  Sample query for layer…
+                  Sample queries…
                 </option>
-                {tables.map((table) => (
-                  <option key={table.tableName} value={table.tableName}>
-                    {table.tableName}
+                {SAMPLE_QUERIES.map((sample, index) => (
+                  <option key={sample.label} value={index}>
+                    {sample.label}
                   </option>
                 ))}
               </Select>
+              {tables.length > 0 ? (
+                <Select
+                  aria-label="Insert a sample query for a layer"
+                  className="h-8 w-auto text-xs"
+                  value=""
+                  onChange={(event) => {
+                    const tableName = event.target.value;
+                    if (tableName) setSql(sampleQueryForTable(tableName));
+                  }}
+                >
+                  <option value="" disabled>
+                    Sample query for layer…
+                  </option>
+                  {tables.map((table) => (
+                    <option key={table.tableName} value={table.tableName}>
+                      {table.tableName}
+                    </option>
+                  ))}
+                </Select>
+              ) : null}
             </div>
-          ) : (
-            <p className="text-xs text-muted-foreground">
-              No vector layers are loaded as tables yet. You can still read files
-              and URLs with {"read_parquet()"}, {"read_csv_auto()"}, or {"ST_Read()"}.
-            </p>
-          )}
+          </div>
 
           <label htmlFor="sql-workspace-editor" className="sr-only">
             SQL query

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -35,7 +35,7 @@ export interface DuckDbVectorFile {
   siblingFiles?: DuckDbVectorFile[];
 }
 
-function getDatabase(): Promise<duckdb.AsyncDuckDB> {
+export function getDatabase(): Promise<duckdb.AsyncDuckDB> {
   dbPromise ??= createDatabase();
   return dbPromise;
 }
@@ -47,7 +47,7 @@ let spatialExtensionLoaded = false;
  * `getDatabase` returns a memoized singleton, so the extension persists across
  * connections and the redundant INSTALL/LOAD queries are skipped on reuse.
  */
-async function ensureSpatialExtension(
+export async function ensureSpatialExtension(
   connection: duckdb.AsyncDuckDBConnection,
 ): Promise<void> {
   if (spatialExtensionLoaded) return;
@@ -78,7 +78,7 @@ function exportBaseName(): string {
   return `__geolibre_export_${Date.now()}_${suffix}`;
 }
 
-function rowsFromResult(result: { toArray: () => DuckDbRow[] }) {
+export function rowsFromResult(result: { toArray: () => DuckDbRow[] }) {
   return result.toArray().map((row) =>
     typeof row.toJSON === "function" ? row.toJSON() : { ...row },
   );
@@ -86,7 +86,7 @@ function rowsFromResult(result: { toArray: () => DuckDbRow[] }) {
 
 // DuckDB Spatial reports CRS-annotated geometry types such as
 // GEOMETRY('EPSG:4326'), so match on the prefix rather than equality.
-function isGeometryColumnType(columnType: unknown): boolean {
+export function isGeometryColumnType(columnType: unknown): boolean {
   return (
     typeof columnType === "string" &&
     columnType.toUpperCase().startsWith("GEOMETRY")

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -62,6 +62,11 @@ async function createDatabase(): Promise<duckdb.AsyncDuckDB> {
   const logger = new duckdb.ConsoleLogger(duckdb.LogLevel.WARNING);
   const db = new duckdb.AsyncDuckDB(logger, worker);
   await db.instantiate(bundle.mainModule, bundle.pthreadWorker);
+  // Open the database so its runtime/filesystem config is initialised. Without
+  // this, locally registered buffers still read, but remote HTTP reads fail
+  // (e.g. read_parquet over https throws "stoi: no conversion"). This mirrors
+  // how maplibre-gl-duckdb initialises the engine that reads remote files.
+  await db.open({});
   return db;
 }
 

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -40,32 +40,42 @@ export function getDatabase(): Promise<duckdb.AsyncDuckDB> {
   return dbPromise;
 }
 
-let spatialExtensionLoaded = false;
+let spatialExtensionPromise: Promise<void> | null = null;
 
 /**
  * Install and load the DuckDB spatial extension once per database instance.
  * `getDatabase` returns a memoized singleton, so the extension persists across
  * connections and the redundant INSTALL/LOAD queries are skipped on reuse.
+ *
+ * The load is memoized as a promise rather than a boolean so concurrent callers
+ * (the function is exported and reused) share a single INSTALL/LOAD instead of
+ * each racing to run it. On failure the memo is cleared so a later call retries.
  */
 export async function ensureSpatialExtension(
   connection: duckdb.AsyncDuckDBConnection,
   beforeLoad?: () => Promise<void>,
 ): Promise<void> {
-  if (spatialExtensionLoaded) return;
-  // duckdb-wasm 1.33.1-dev45 breaks remote read_parquet if the spatial
-  // extension is loaded before the first remote HTTP read on the database.
-  // `beforeLoad` lets the caller warm up that path (a pre-spatial remote read)
-  // before INSTALL/LOAD, which is the only thing that initialises it.
-  if (beforeLoad) {
-    try {
-      await beforeLoad();
-    } catch {
-      // Warm-up is best-effort; a failure here must not block spatial loading.
+  spatialExtensionPromise ??= (async () => {
+    // duckdb-wasm 1.33.1-dev45 breaks remote read_parquet if the spatial
+    // extension is loaded before the first remote HTTP read on the database.
+    // `beforeLoad` lets the caller warm up that path (a pre-spatial remote read)
+    // before INSTALL/LOAD, which is the only thing that initialises it.
+    if (beforeLoad) {
+      try {
+        await beforeLoad();
+      } catch {
+        // Warm-up is best-effort; a failure here must not block spatial loading.
+      }
     }
+    await connection.query("INSTALL spatial");
+    await connection.query("LOAD spatial");
+  })();
+  try {
+    await spatialExtensionPromise;
+  } catch (error) {
+    spatialExtensionPromise = null;
+    throw error;
   }
-  await connection.query("INSTALL spatial");
-  await connection.query("LOAD spatial");
-  spatialExtensionLoaded = true;
 }
 
 async function createDatabase(): Promise<duckdb.AsyncDuckDB> {

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -49,8 +49,20 @@ let spatialExtensionLoaded = false;
  */
 export async function ensureSpatialExtension(
   connection: duckdb.AsyncDuckDBConnection,
+  beforeLoad?: () => Promise<void>,
 ): Promise<void> {
   if (spatialExtensionLoaded) return;
+  // duckdb-wasm 1.33.1-dev45 breaks remote read_parquet if the spatial
+  // extension is loaded before the first remote HTTP read on the database.
+  // `beforeLoad` lets the caller warm up that path (a pre-spatial remote read)
+  // before INSTALL/LOAD, which is the only thing that initialises it.
+  if (beforeLoad) {
+    try {
+      await beforeLoad();
+    } catch {
+      // Warm-up is best-effort; a failure here must not block spatial loading.
+    }
+  }
   await connection.query("INSTALL spatial");
   await connection.query("LOAD spatial");
   spatialExtensionLoaded = true;

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -65,11 +65,11 @@ async function createDatabase(): Promise<duckdb.AsyncDuckDB> {
   return db;
 }
 
-function quoteSqlString(value: string): string {
+export function quoteSqlString(value: string): string {
   return `'${value.replaceAll("'", "''")}'`;
 }
 
-function quoteIdentifier(value: string): string {
+export function quoteIdentifier(value: string): string {
   return `"${value.replaceAll('"', '""')}"`;
 }
 

--- a/apps/geolibre-desktop/src/lib/sql-workspace.ts
+++ b/apps/geolibre-desktop/src/lib/sql-workspace.ts
@@ -23,6 +23,38 @@ const GEOMETRY_JSON_COLUMN = "__geolibre_sql_geometry_geojson";
 // deliberately obscure so it does not collide with a user's own CTE/subquery.
 const SQL_SUBQUERY_ALIAS = "__geolibre_sql_subquery";
 
+// DuckDB reserved keywords cannot be used as unquoted identifiers, so a layer
+// named e.g. "Group" would sanitize to `group` and break `SELECT * FROM group`.
+// Such names are prefixed with `t_` to stay valid in the SQL the user types.
+const RESERVED_TABLE_NAMES = new Set([
+  "all", "analyse", "analyze", "and", "any", "array", "as", "asc",
+  "asymmetric", "both", "case", "cast", "check", "collate", "column",
+  "constraint", "create", "default", "deferrable", "desc", "describe",
+  "distinct", "do", "else", "end", "except", "false", "fetch", "for",
+  "foreign", "from", "grant", "group", "having", "in", "initially",
+  "intersect", "into", "lateral", "leading", "limit", "not", "null", "offset",
+  "on", "only", "or", "order", "pivot", "placing", "primary", "qualify",
+  "references", "returning", "select", "show", "some", "symmetric", "table",
+  "then", "to", "trailing", "true", "union", "unique", "using", "variadic",
+  "when", "where", "window", "with",
+]);
+
+// Bare URLs and file paths after FROM/JOIN are auto-wrapped in a matching
+// DuckDB table function so the convenient `SELECT * FROM https://…/x.parquet`
+// form works (DuckDB itself rejects unquoted URLs/paths). Quoted sources,
+// subqueries, and plain table names are left untouched.
+const DATA_SOURCE_READERS: Array<{ extensions: string[]; reader: string }> = [
+  { extensions: ["parquet", "geoparquet", "pq"], reader: "read_parquet" },
+  { extensions: ["csv", "tsv", "txt"], reader: "read_csv_auto" },
+  { extensions: ["json", "ndjson"], reader: "read_json_auto" },
+  {
+    extensions: ["geojson", "fgb", "shp", "gpkg", "kml", "gml"],
+    reader: "ST_Read",
+  },
+];
+const BARE_SOURCE_PATTERN =
+  /\b(from|join)\s+((?:https?:\/\/|\/|\.\/|\.\.\/|~\/|[A-Za-z]:[\\/])[^\s,;()]+)/gi;
+
 /** A loaded layer exposed to the workspace as a DuckDB table. */
 export interface SqlWorkspaceTable {
   /** SQL identifier the user references in queries. */
@@ -58,7 +90,11 @@ function sanitizeTableName(layerName: string, layerId: string): string {
     .replace(/^_+|_+$/g, "");
   // Keep `normalized` empty when `base` is empty so the layer_<id> fallback is
   // reached; prefixing an empty base would yield "t_" and bypass the fallback.
-  const normalized = base ? (/^[a-z_]/.test(base) ? base : `t_${base}`) : "";
+  // A leading digit or a reserved keyword is prefixed with `t_` so the name is
+  // a usable bare identifier in the SQL the user writes.
+  const needsPrefix =
+    !!base && (!/^[a-z_]/.test(base) || RESERVED_TABLE_NAMES.has(base));
+  const normalized = base ? (needsPrefix ? `t_${base}` : base) : "";
   return normalized || `layer_${layerId.replace(/[^a-z0-9]+/gi, "_")}`;
 }
 
@@ -114,21 +150,33 @@ export function previewLayerTables(
  * from the current layers, which keeps the tables in sync with edits and avoids
  * leaking tables for layers that were since removed.
  *
+ * The registered GeoJSON file names are namespaced with `filePrefix` so that
+ * concurrent `runSqlQuery` calls against the shared database instance cannot
+ * overwrite or drop each other's files while a query is still reading them.
+ *
  * @param db Shared DuckDB-WASM database instance.
  * @param connection Open connection used to create the tables.
  * @param layers Current app layers; those without `geojson` are skipped.
+ * @param filePrefix Per-run prefix applied to every registered VFS file name.
+ * @param registeredFiles Optional accumulator; each created file name is pushed
+ *   as it is registered so the caller can clean up even if a later layer throws.
  * @returns The registered tables in registration order.
  */
 export async function registerLayerTables(
   db: AsyncDuckDB,
   connection: AsyncDuckDBConnection,
   layers: GeoLibreLayer[],
+  filePrefix: string,
+  registeredFiles?: string[],
 ): Promise<SqlWorkspaceTable[]> {
   const registered: SqlWorkspaceTable[] = [];
 
   for (const { layer, tableName } of assignTableNames(layers)) {
-    const fileName = `${tableName}.geojson`;
+    const fileName = `${filePrefix}__${tableName}.geojson`;
     await db.registerFileText(fileName, JSON.stringify(layer.geojson));
+    // Track immediately after registration so a failure in the CREATE TABLE
+    // below still leaves this file in the cleanup list.
+    registeredFiles?.push(fileName);
     await connection.query(
       `CREATE OR REPLACE TEMP TABLE ${quoteIdentifier(tableName)} AS ` +
         `SELECT * FROM ST_Read(${quoteSqlString(fileName)})`,
@@ -179,21 +227,115 @@ function normalizeRow(
   return out;
 }
 
-/** Find the first GEOMETRY-typed column in the user's query, if any. */
-async function detectGeometryColumn(
+interface DescribedQuery {
+  /** Column names the query returns, in select order. */
+  columnNames: string[];
+  /** Name of the first GEOMETRY-typed column, or null when there is none. */
+  geometryColumn: string | null;
+}
+
+/**
+ * Describe the user's query to learn its columns and detect a GEOMETRY column.
+ *
+ * The statement is wrapped in a `SELECT * FROM (...)` subquery so the probe also
+ * works for CTE (`WITH`) and set-operation (`UNION`) queries, which a bare
+ * `DESCRIBE <statement>` rejects. Because DDL/DML cannot appear inside a FROM
+ * subquery, this also avoids ever executing a mutating statement (e.g. a
+ * `DELETE ... RETURNING`) during description: such statements simply throw here
+ * and fall through to being run once, normally. Returns null when the statement
+ * cannot be described as a query result.
+ */
+async function describeQuery(
   connection: AsyncDuckDBConnection,
-  sql: string,
-): Promise<string | null> {
+  statement: string,
+): Promise<DescribedQuery | null> {
   try {
-    const described = rowsFromResult(await connection.query(`DESCRIBE ${sql}`));
-    const match = described.find((row) =>
+    const described = rowsFromResult(
+      await connection.query(
+        `DESCRIBE SELECT * FROM (${statement}) AS ` +
+          quoteIdentifier(SQL_SUBQUERY_ALIAS),
+      ),
+    );
+    const columnNames = described
+      .map((row) => row.column_name)
+      .filter((name): name is string => typeof name === "string");
+    const geometryColumn = described.find((row) =>
       isGeometryColumnType(row.column_type),
     )?.column_name;
-    return typeof match === "string" ? match : null;
+    return {
+      columnNames,
+      geometryColumn:
+        typeof geometryColumn === "string" ? geometryColumn : null,
+    };
   } catch {
-    // DESCRIBE fails for DDL or multi-statement input; those have no geometry.
     return null;
   }
+}
+
+/**
+ * Detect whether `sql` contains more than one statement (an interior semicolon
+ * outside of string literals, quoted identifiers, and comments). DuckDB-WASM
+ * silently runs every statement but only returns the last result, so the caller
+ * rejects multi-statement input instead of discarding earlier results.
+ */
+function containsMultipleStatements(sql: string): boolean {
+  let index = 0;
+  while (index < sql.length) {
+    const char = sql[index];
+    if (char === "'" || char === '"') {
+      index += 1;
+      while (index < sql.length) {
+        if (sql[index] === char) {
+          // A doubled quote is an escaped quote, not the end of the literal.
+          if (sql[index + 1] === char) {
+            index += 2;
+            continue;
+          }
+          break;
+        }
+        index += 1;
+      }
+    } else if (char === "-" && sql[index + 1] === "-") {
+      while (index < sql.length && sql[index] !== "\n") index += 1;
+    } else if (char === "/" && sql[index + 1] === "*") {
+      index += 2;
+      while (index < sql.length && !(sql[index] === "*" && sql[index + 1] === "/"))
+        index += 1;
+      index += 1;
+    } else if (char === ";") {
+      return true;
+    }
+    index += 1;
+  }
+  return false;
+}
+
+/** Pick the DuckDB table function for a data source extension, if recognised. */
+function readerForExtension(extension: string): string | null {
+  return (
+    DATA_SOURCE_READERS.find((entry) => entry.extensions.includes(extension))
+      ?.reader ?? null
+  );
+}
+
+/**
+ * Rewrite a bare URL or file path after FROM/JOIN into the matching DuckDB
+ * reader (`read_parquet`, `read_csv_auto`, `read_json_auto`, or `ST_Read`) by
+ * file extension, so `SELECT * FROM https://host/data.parquet` works. Sources
+ * with an unrecognised extension, and anything already quoted or wrapped in a
+ * function call, are left unchanged.
+ */
+function rewriteBareSources(sql: string): string {
+  return sql.replace(
+    BARE_SOURCE_PATTERN,
+    (whole, keyword: string, source: string) => {
+      const path = source.split(/[?#]/)[0];
+      const dot = path.lastIndexOf(".");
+      const extension = dot >= 0 ? path.slice(dot + 1).toLowerCase() : "";
+      const reader = readerForExtension(extension);
+      return reader ? `${keyword} ${reader}(${quoteSqlString(source)})` : whole;
+    },
+  );
 }
 
 function rowsToFeatureCollection(
@@ -250,28 +392,45 @@ export async function runSqlQuery(
 ): Promise<SqlQueryResult> {
   // A trailing semicolon is valid as a standalone statement but breaks the
   // geometry-detection wrapper `... FROM (<sql>) AS ...`, so strip it once.
-  const statement = sql.trim().replace(/;\s*$/, "");
+  const trimmed = sql.trim().replace(/;\s*$/, "");
+  if (containsMultipleStatements(trimmed)) {
+    throw new Error(
+      "Only a single SQL statement is supported. Remove any intermediate semicolons.",
+    );
+  }
+  // Wrap bare URLs/paths after FROM/JOIN in the matching reader so the
+  // convenient `SELECT * FROM https://…/x.parquet` form runs.
+  const statement = rewriteBareSources(trimmed);
 
   const db = await getDatabase();
   const connection = await db.connect();
-  let registeredFiles: string[] = [];
+  // Per-run prefix so concurrent queries on the shared database do not register
+  // or drop one another's VFS files. Populated by registerLayerTables as it
+  // creates files so cleanup matches exactly what was registered.
+  const filePrefix = `__geolibre_sql_${Date.now()}_${Math.random()
+    .toString(36)
+    .slice(2)}`;
+  const registeredFiles: string[] = [];
 
   try {
     await ensureSpatialExtension(connection);
-    // Pre-compute the file names from the same naming logic so the finally
-    // block can clean up even if registration throws part-way through the loop.
-    registeredFiles = previewLayerTables(layers).map(
-      (table) => `${table.tableName}.geojson`,
-    );
-    await registerLayerTables(db, connection, layers);
+    await registerLayerTables(db, connection, layers, filePrefix, registeredFiles);
 
-    const geometryColumn = await detectGeometryColumn(connection, statement);
+    const described = await describeQuery(connection, statement);
+    const geometryColumn = described?.geometryColumn ?? null;
 
     if (geometryColumn) {
       const geomId = quoteIdentifier(geometryColumn);
       const hiddenId = quoteIdentifier(GEOMETRY_JSON_COLUMN);
+      // Drop a user column that already uses the reserved hidden name from the
+      // wildcard so appending our own alias cannot raise a duplicate-column
+      // error. EXCLUDE only when present, since DuckDB rejects EXCLUDE of a
+      // missing column.
+      const excludeClause = described?.columnNames.includes(GEOMETRY_JSON_COLUMN)
+        ? ` EXCLUDE (${hiddenId})`
+        : "";
       const result = await connection.query(
-        `SELECT * REPLACE (ST_AsText(${geomId}) AS ${geomId}), ` +
+        `SELECT *${excludeClause} REPLACE (ST_AsText(${geomId}) AS ${geomId}), ` +
           `ST_AsGeoJSON(${geomId}) AS ${hiddenId} ` +
           `FROM (${statement}) AS ${quoteIdentifier(SQL_SUBQUERY_ALIAS)}`,
       );

--- a/apps/geolibre-desktop/src/lib/sql-workspace.ts
+++ b/apps/geolibre-desktop/src/lib/sql-workspace.ts
@@ -68,11 +68,13 @@ const BARE_SOURCE_PATTERN =
 const REMOTE_READER_ARG_PATTERN =
   /\b(read_parquet|parquet_scan|read_csv_auto|read_csv|read_json_auto|read_json|read_ndjson_auto|read_ndjson)\s*\(\s*'(https?:\/\/[^']+)'/gi;
 
-// A pre-spatial remote read_parquet is what initialises the HTTP read path (see
-// ensureSpatialExtension). When a query has no remote parquet of its own to warm
-// up with (e.g. a local-only first query that would otherwise load spatial
-// cold), this tiny public parquet is read instead. Only its footer is fetched.
-const HTTP_WARMUP_PARQUET_URL =
+// Public sample dataset used both by the dialog's example queries and as the
+// pre-spatial HTTP warm-up read. A pre-spatial remote read_parquet is what
+// initialises the HTTP read path (see ensureSpatialExtension); when a query has
+// no remote parquet of its own to warm up with (e.g. a local-only first query
+// that would otherwise load spatial cold), this parquet is read instead — only
+// its footer is fetched. Exported so the dialog shares the same single URL.
+export const SAMPLE_DATASET_URL =
   "https://data.source.coop/giswqs/opengeos/countries.parquet";
 
 /** A loaded layer exposed to the workspace as a DuckDB table. */
@@ -482,11 +484,14 @@ async function registerRemoteSources(
   }
   // Replace only the matched reader-call arguments, so a URL that happens to
   // appear elsewhere (e.g. in a WHERE-clause string literal) is left intact.
+  // The pattern matches up to the URL's closing quote but not the call's
+  // closing paren, so the replacement must not add one: the original `)` (and
+  // any trailing arguments) stays in place.
   const rewritten = statement.replace(
     REMOTE_READER_ARG_PATTERN,
     (whole, reader: string, url: string) => {
       const handle = handleByUrl.get(url);
-      return handle ? `${reader}(${quoteSqlString(handle)})` : whole;
+      return handle ? `${reader}(${quoteSqlString(handle)}` : whole;
     },
   );
   return { statement: rewritten, readerCalls };
@@ -585,8 +590,15 @@ export async function runSqlQuery(
     // and guarantee at least one read_parquet runs by falling back to a tiny
     // default parquet when the query has none of its own.
     const warmups = [...readerCalls];
-    if (!warmups.some((call) => call.startsWith("read_parquet"))) {
-      warmups.push(`read_parquet(${quoteSqlString(HTTP_WARMUP_PARQUET_URL)})`);
+    // read_parquet and its alias parquet_scan both initialise the HTTP read
+    // path; only fall back to the default warmup when neither is present.
+    if (
+      !warmups.some(
+        (call) =>
+          call.startsWith("read_parquet") || call.startsWith("parquet_scan"),
+      )
+    ) {
+      warmups.push(`read_parquet(${quoteSqlString(SAMPLE_DATASET_URL)})`);
     }
     await ensureSpatialExtension(connection, async () => {
       for (const readerCall of warmups) {

--- a/apps/geolibre-desktop/src/lib/sql-workspace.ts
+++ b/apps/geolibre-desktop/src/lib/sql-workspace.ts
@@ -15,7 +15,8 @@ import {
 
 // Hidden column appended to the user's query so geometry can be returned as
 // GeoJSON for the "Add as layer" / export paths without disturbing the columns
-// the user sees in the results grid.
+// the user sees in the results grid. This is a reserved name: a user column of
+// the same name is filtered out of both the grid and the GeoJSON properties.
 const GEOMETRY_JSON_COLUMN = "__geolibre_sql_geometry_geojson";
 
 /** A loaded layer exposed to the workspace as a DuckDB table. */
@@ -102,8 +103,10 @@ export function previewLayerTables(
  * Register every loaded layer that carries an in-memory GeoJSON FeatureCollection
  * as a DuckDB table, so user SQL can query the current map data by layer name.
  *
- * Existing tables are replaced so repeated runs stay in sync with edits to the
- * layers.
+ * Tables are created TEMPORARY so they are scoped to the caller's connection and
+ * dropped when it closes. Each query therefore starts from a clean set built
+ * from the current layers, which keeps the tables in sync with edits and avoids
+ * leaking tables for layers that were since removed.
  *
  * @param db Shared DuckDB-WASM database instance.
  * @param connection Open connection used to create the tables.
@@ -121,7 +124,7 @@ export async function registerLayerTables(
     const fileName = `${tableName}.geojson`;
     await db.registerFileText(fileName, JSON.stringify(layer.geojson));
     await connection.query(
-      `CREATE OR REPLACE TABLE ${quoteIdentifier(tableName)} AS ` +
+      `CREATE OR REPLACE TEMP TABLE ${quoteIdentifier(tableName)} AS ` +
         `SELECT * FROM ST_Read(${quoteSqlString(fileName)})`,
     );
     registered.push({ tableName, layerName: layer.name });
@@ -137,7 +140,12 @@ function columnNamesFromResult(result: {
   return result.schema?.fields?.map((field) => field.name) ?? [];
 }
 
-/** Normalise a DuckDB cell value into something JSON/CSV friendly. */
+/**
+ * Normalise a DuckDB cell value into something JSON/CSV friendly. Recurses into
+ * arrays (LIST) and objects (STRUCT) so nested bigint/Date values are coerced,
+ * matching the loader's `normalizePropertyValue`; otherwise a nested bigint
+ * would make `JSON.stringify` throw during CSV/GeoJSON export.
+ */
 function normalizeValue(value: unknown): unknown {
   if (typeof value === "bigint") {
     const asNumber = Number(value);
@@ -145,6 +153,12 @@ function normalizeValue(value: unknown): unknown {
   }
   if (value instanceof Date) return value.toISOString();
   if (value instanceof Uint8Array) return `[binary ${value.length} bytes]`;
+  if (Array.isArray(value)) return value.map(normalizeValue);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, normalizeValue(item)]),
+    );
+  }
   return value;
 }
 
@@ -182,10 +196,16 @@ function rowsToFeatureCollection(
 ): FeatureCollection {
   const features = rows.map((row) => {
     const rawGeometry = row[GEOMETRY_JSON_COLUMN];
-    const geometry =
-      typeof rawGeometry === "string"
-        ? (JSON.parse(rawGeometry) as Geometry)
-        : null;
+    // Parse defensively: a single malformed geometry string should drop that
+    // one feature's geometry, not abort the whole result set.
+    let geometry: Geometry | null = null;
+    if (typeof rawGeometry === "string") {
+      try {
+        geometry = JSON.parse(rawGeometry) as Geometry;
+      } catch {
+        geometry = null;
+      }
+    }
     const properties: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(row)) {
       if (key === GEOMETRY_JSON_COLUMN || key === geometryColumn) continue;
@@ -302,5 +322,6 @@ export function resultToCsv(
   for (const row of rows) {
     lines.push(columns.map((column) => escape(row[column])).join(","));
   }
-  return lines.join("\n");
+  // RFC 4180 specifies CRLF line endings for the broadest spreadsheet support.
+  return lines.join("\r\n");
 }

--- a/apps/geolibre-desktop/src/lib/sql-workspace.ts
+++ b/apps/geolibre-desktop/src/lib/sql-workspace.ts
@@ -1,8 +1,9 @@
 import type { GeoLibreLayer } from "@geolibre/core";
 import type { Feature, FeatureCollection, Geometry } from "geojson";
-import type {
-  AsyncDuckDB,
-  AsyncDuckDBConnection,
+import {
+  DuckDBDataProtocol,
+  type AsyncDuckDB,
+  type AsyncDuckDBConnection,
 } from "@duckdb/duckdb-wasm";
 import {
   ensureSpatialExtension,
@@ -54,6 +55,18 @@ const DATA_SOURCE_READERS: Array<{ extensions: string[]; reader: string }> = [
 ];
 const BARE_SOURCE_PATTERN =
   /\b(from|join)\s+((?:https?:\/\/|\/|\.\/|\.\.\/|~\/|[A-Za-z]:[\\/])[^\s,;()]+)/gi;
+
+// HTTP(S) URLs whose extension feeds a native DuckDB reader (read_parquet /
+// read_csv_auto / read_json_auto) are registered as DuckDB file handles so the
+// JS runtime streams them via range requests. The in-WASM httpfs path used by a
+// bare `read_parquet('https://…')` fails with "stoi: no conversion" on many
+// servers. ST_Read (GDAL/vsicurl) URLs are left bare so GDAL handles them.
+const REMOTE_URL_PATTERN = /https?:\/\/[^\s'");]+/gi;
+const NATIVE_REMOTE_READER_EXTENSIONS = new Set(
+  DATA_SOURCE_READERS.filter((entry) => entry.reader !== "ST_Read").flatMap(
+    (entry) => entry.extensions,
+  ),
+);
 
 /** A loaded layer exposed to the workspace as a DuckDB table. */
 export interface SqlWorkspaceTable {
@@ -338,6 +351,50 @@ function rewriteBareSources(sql: string): string {
   );
 }
 
+/** Derive a stable, VFS-safe handle name from a URL, keeping its extension. */
+function remoteHandleName(filePrefix: string, index: number, url: string): string {
+  const path = url.split(/[?#]/)[0];
+  const base = path.slice(path.lastIndexOf("/") + 1).replace(/[^\w.-]/g, "_");
+  return `${filePrefix}__remote_${index}_${base || "source"}`;
+}
+
+/**
+ * Register each HTTP(S) URL that feeds a native DuckDB reader as a file handle
+ * and rewrite the statement to reference the handle. DuckDB-WASM then reads the
+ * remote file through the JS runtime's HTTP range reader (streaming only the
+ * byte ranges the query needs, so large files work) instead of the in-WASM
+ * httpfs path, which fails with "stoi: no conversion" against many servers.
+ *
+ * @returns The statement with registered URLs replaced by their handle names.
+ */
+async function registerRemoteSources(
+  db: AsyncDuckDB,
+  filePrefix: string,
+  statement: string,
+  registeredFiles: string[],
+): Promise<string> {
+  // Longest first so a URL that is a prefix of another is replaced correctly.
+  const urls = [...new Set(statement.match(REMOTE_URL_PATTERN) ?? [])].sort(
+    (a, b) => b.length - a.length,
+  );
+  let rewritten = statement;
+  let index = 0;
+  for (const url of urls) {
+    const path = url.split(/[?#]/)[0];
+    const dot = path.lastIndexOf(".");
+    const extension = dot >= 0 ? path.slice(dot + 1).toLowerCase() : "";
+    if (!NATIVE_REMOTE_READER_EXTENSIONS.has(extension)) continue;
+    const handle = remoteHandleName(filePrefix, index, url);
+    index += 1;
+    // directIO = true forces range-based reads so the whole file is never
+    // buffered locally.
+    await db.registerFileURL(handle, url, DuckDBDataProtocol.HTTP, true);
+    registeredFiles.push(handle);
+    rewritten = rewritten.split(url).join(handle);
+  }
+  return rewritten;
+}
+
 function rowsToFeatureCollection(
   rows: Record<string, unknown>[],
   geometryColumn: string,
@@ -400,13 +457,14 @@ export async function runSqlQuery(
   }
   // Wrap bare URLs/paths after FROM/JOIN in the matching reader so the
   // convenient `SELECT * FROM https://…/x.parquet` form runs.
-  const statement = rewriteBareSources(trimmed);
+  const rewritten = rewriteBareSources(trimmed);
 
   const db = await getDatabase();
   const connection = await db.connect();
   // Per-run prefix so concurrent queries on the shared database do not register
-  // or drop one another's VFS files. Populated by registerLayerTables as it
-  // creates files so cleanup matches exactly what was registered.
+  // or drop one another's VFS files. Populated by registerLayerTables and
+  // registerRemoteSources as they create handles so cleanup matches exactly
+  // what was registered.
   const filePrefix = `__geolibre_sql_${Date.now()}_${Math.random()
     .toString(36)
     .slice(2)}`;
@@ -415,6 +473,14 @@ export async function runSqlQuery(
   try {
     await ensureSpatialExtension(connection);
     await registerLayerTables(db, connection, layers, filePrefix, registeredFiles);
+    // Register remote URLs as DuckDB file handles so they stream over HTTP
+    // range requests instead of the unreliable in-WASM httpfs path.
+    const statement = await registerRemoteSources(
+      db,
+      filePrefix,
+      rewritten,
+      registeredFiles,
+    );
 
     const described = await describeQuery(connection, statement);
     const geometryColumn = described?.geometryColumn ?? null;

--- a/apps/geolibre-desktop/src/lib/sql-workspace.ts
+++ b/apps/geolibre-desktop/src/lib/sql-workspace.ts
@@ -38,6 +38,9 @@ const RESERVED_TABLE_NAMES = new Set([
   "references", "returning", "select", "show", "some", "symmetric", "table",
   "then", "to", "trailing", "true", "union", "unique", "using", "variadic",
   "when", "where", "window", "with",
+  // DuckDB-specific keywords beyond the ANSI set above.
+  "anti", "asof", "by", "glob", "ilike", "like", "macro", "map", "positional",
+  "semi", "struct", "summarize", "try_cast", "unpivot", "values", "virtual",
 ]);
 
 // Bare URLs and file paths after FROM/JOIN are auto-wrapped in a matching
@@ -56,12 +59,14 @@ const DATA_SOURCE_READERS: Array<{ extensions: string[]; reader: string }> = [
 const BARE_SOURCE_PATTERN =
   /\b(from|join)\s+((?:https?:\/\/|\/|\.\/|\.\.\/|~\/|[A-Za-z]:[\\/])[^\s,;()]+)/gi;
 
-// HTTP(S) URLs whose extension feeds a native DuckDB reader (read_parquet /
-// read_csv_auto / read_json_auto) are registered as DuckDB file handles so the
-// JS runtime streams them via range requests. The in-WASM httpfs path used by a
-// bare `read_parquet('https://…')` fails with "stoi: no conversion" on many
-// servers. ST_Read (GDAL/vsicurl) URLs are left bare so GDAL handles them.
-const REMOTE_URL_PATTERN = /https?:\/\/[^\s'");]+/gi;
+// HTTP(S) URLs that are arguments to a native DuckDB reader are registered as
+// DuckDB file handles so the JS runtime streams them via range requests. The
+// in-WASM httpfs path used by a bare `read_parquet('https://…')` fails with
+// "stoi: no conversion" on many servers. ST_Read (GDAL/vsicurl) URLs are left
+// bare so GDAL handles them. Matching only reader-call arguments (rather than
+// any URL) means a URL inside an unrelated string literal is never rewritten.
+const REMOTE_READER_ARG_PATTERN =
+  /\b(read_parquet|parquet_scan|read_csv_auto|read_csv|read_json_auto|read_json|read_ndjson_auto|read_ndjson)\s*\(\s*'(https?:\/\/[^']+)'/gi;
 
 // A pre-spatial remote read_parquet is what initialises the HTTP read path (see
 // ensureSpatialExtension). When a query has no remote parquet of its own to warm
@@ -296,8 +301,14 @@ async function describeQuery(
  * Running regexes against this mask makes them literal-aware without a full
  * parser: a match's indices are valid against the original string, but the
  * regex can never match text that lives inside a literal or comment.
+ *
+ * The scanner always parses literals and comments (so a `--` inside a string is
+ * not mistaken for a comment), but `blankLiterals` controls whether literal
+ * content is blanked. Callers that need to find the end of the real statement
+ * (e.g. `cleanStatement`) pass `false` so a trailing string literal is not
+ * mistaken for trailing whitespace.
  */
-function maskSqlLiterals(sql: string): string {
+function maskSqlLiterals(sql: string, blankLiterals = true): string {
   const out = sql.split("");
   const blank = (start: number, end: number): void => {
     for (let k = start; k < end && k < out.length; k += 1) {
@@ -320,7 +331,7 @@ function maskSqlLiterals(sql: string): string {
         }
         j += 1;
       }
-      blank(i, j + 1);
+      if (blankLiterals) blank(i, j + 1);
       i = j + 1;
     } else if (char === "-" && sql[i + 1] === "-") {
       let j = i;
@@ -339,7 +350,7 @@ function maskSqlLiterals(sql: string): string {
         const tag = tagMatch[0];
         const closeAt = sql.indexOf(tag, i + tag.length);
         const end = closeAt === -1 ? sql.length : closeAt + tag.length;
-        blank(i, end);
+        if (blankLiterals) blank(i, end);
         i = end;
       } else {
         i += 1;
@@ -359,9 +370,10 @@ function maskSqlLiterals(sql: string): string {
  */
 function cleanStatement(sql: string): string {
   const src = sql.trim();
-  const masked = maskSqlLiterals(src);
-  // maskSqlLiterals blanks comments to spaces, so trimming the mask drops any
-  // trailing comment; the matching slice of the original is the real content.
+  // Blank comments only (keep string literals): trimming the mask then drops a
+  // trailing comment without mistaking a trailing string literal — e.g. the
+  // `'a;b'` in `SELECT 'a;b'` — for trailing whitespace.
+  const masked = maskSqlLiterals(src, false);
   let end = masked.replace(/\s+$/, "").length;
   if (end > 0 && masked[end - 1] === ";") end -= 1;
   return src.slice(0, end).trimEnd();
@@ -382,22 +394,6 @@ function containsMultipleStatements(sql: string): boolean {
   return semicolon !== -1 && masked.slice(semicolon + 1).trim().length > 0;
 }
 
-/** Names of layer tables referenced (as bare identifiers) in the statement. */
-function referencedTableNames(
-  statement: string,
-  candidates: Iterable<string>,
-): Set<string> {
-  const masked = maskSqlLiterals(statement);
-  const referenced = new Set<string>();
-  for (const name of candidates) {
-    // Table names are sanitized lower-case identifiers, so a word-boundary
-    // match against the masked (literal-free) statement is reliable.
-    const pattern = new RegExp(`(?<![\\w.])${name}\\b`, "i");
-    if (pattern.test(masked)) referenced.add(name);
-  }
-  return referenced;
-}
-
 /** Pick the DuckDB table function for a data source extension, if recognised. */
 function readerForExtension(extension: string): string | null {
   return (
@@ -414,16 +410,29 @@ function readerForExtension(extension: string): string | null {
  * function call, are left unchanged.
  */
 function rewriteBareSources(sql: string): string {
-  return sql.replace(
-    BARE_SOURCE_PATTERN,
-    (whole, keyword: string, source: string) => {
-      const path = source.split(/[?#]/)[0];
-      const dot = path.lastIndexOf(".");
-      const extension = dot >= 0 ? path.slice(dot + 1).toLowerCase() : "";
-      const reader = readerForExtension(extension);
-      return reader ? `${keyword} ${reader}(${quoteSqlString(source)})` : whole;
-    },
-  );
+  // Match against the masked SQL so a `FROM`/`JOIN` that appears inside a string
+  // literal or comment is never rewritten; the match indices are valid against
+  // the original string, and the matched source text is code (never masked).
+  const masked = maskSqlLiterals(sql);
+  let result = "";
+  let lastIndex = 0;
+  for (const match of masked.matchAll(BARE_SOURCE_PATTERN)) {
+    const index = match.index ?? 0;
+    const whole = sql.slice(index, index + match[0].length);
+    const keyword = match[1];
+    const source = match[2];
+    const path = source.split(/[?#]/)[0];
+    const dot = path.lastIndexOf(".");
+    const extension = dot >= 0 ? path.slice(dot + 1).toLowerCase() : "";
+    const reader = readerForExtension(extension);
+    result += sql.slice(lastIndex, index);
+    result += reader
+      ? `${keyword} ${reader}(${quoteSqlString(source)})`
+      : whole;
+    lastIndex = index + match[0].length;
+  }
+  result += sql.slice(lastIndex);
+  return result;
 }
 
 /** Derive a stable, VFS-safe handle name from a URL, keeping its extension. */
@@ -448,28 +457,38 @@ async function registerRemoteSources(
   statement: string,
   registeredFiles: string[],
 ): Promise<{ statement: string; readerCalls: string[] }> {
-  // Longest first so a URL that is a prefix of another is replaced correctly.
-  const urls = [...new Set(statement.match(REMOTE_URL_PATTERN) ?? [])].sort(
-    (a, b) => b.length - a.length,
-  );
-  let rewritten = statement;
-  let index = 0;
+  // Collect each distinct URL that is a native reader's argument, keeping the
+  // first reader function it appears with (used to warm up the HTTP path).
+  const readerByUrl = new Map<string, string>();
+  for (const match of statement.matchAll(REMOTE_READER_ARG_PATTERN)) {
+    const reader = match[1].toLowerCase();
+    const url = match[2];
+    if (!readerByUrl.has(url)) readerByUrl.set(url, reader);
+  }
+  if (readerByUrl.size === 0) return { statement, readerCalls: [] };
+
+  const handleByUrl = new Map<string, string>();
   const readerCalls: string[] = [];
-  for (const url of urls) {
-    const path = url.split(/[?#]/)[0];
-    const dot = path.lastIndexOf(".");
-    const extension = dot >= 0 ? path.slice(dot + 1).toLowerCase() : "";
-    const reader = readerForExtension(extension);
-    if (!reader || reader === "ST_Read") continue;
+  let index = 0;
+  for (const [url, reader] of readerByUrl) {
     const handle = remoteHandleName(filePrefix, index, url);
     index += 1;
     // directIO = true forces range-based reads so the whole file is never
     // buffered locally.
     await db.registerFileURL(handle, url, DuckDBDataProtocol.HTTP, true);
     registeredFiles.push(handle);
+    handleByUrl.set(url, handle);
     readerCalls.push(`${reader}(${quoteSqlString(handle)})`);
-    rewritten = rewritten.split(url).join(handle);
   }
+  // Replace only the matched reader-call arguments, so a URL that happens to
+  // appear elsewhere (e.g. in a WHERE-clause string literal) is left intact.
+  const rewritten = statement.replace(
+    REMOTE_READER_ARG_PATTERN,
+    (whole, reader: string, url: string) => {
+      const handle = handleByUrl.get(url);
+      return handle ? `${reader}(${quoteSqlString(handle)})` : whole;
+    },
+  );
   return { statement: rewritten, readerCalls };
 }
 
@@ -525,17 +544,18 @@ export async function runSqlQuery(
   sql: string,
   layers: GeoLibreLayer[],
 ): Promise<SqlQueryResult> {
-  // A trailing semicolon is valid as a standalone statement but breaks the
-  // geometry-detection wrapper `... FROM (<sql>) AS ...`, so strip it once.
-  const trimmed = sql.trim().replace(/;\s*$/, "");
-  if (containsMultipleStatements(trimmed)) {
+  // Strip a trailing semicolon and any trailing comment (literal-aware) so the
+  // statement can be wrapped in the geometry-detection subquery `... FROM
+  // (<sql>) AS ...` without the terminator or a line comment breaking it.
+  const cleaned = cleanStatement(sql);
+  if (containsMultipleStatements(cleaned)) {
     throw new Error(
       "Only a single SQL statement is supported. Remove any intermediate semicolons.",
     );
   }
   // Wrap bare URLs/paths after FROM/JOIN in the matching reader so the
   // convenient `SELECT * FROM https://…/x.parquet` form runs.
-  const rewritten = rewriteBareSources(trimmed);
+  const rewritten = rewriteBareSources(cleaned);
 
   const db = await getDatabase();
   const connection = await db.connect();

--- a/apps/geolibre-desktop/src/lib/sql-workspace.ts
+++ b/apps/geolibre-desktop/src/lib/sql-workspace.ts
@@ -62,11 +62,13 @@ const BARE_SOURCE_PATTERN =
 // bare `read_parquet('https://…')` fails with "stoi: no conversion" on many
 // servers. ST_Read (GDAL/vsicurl) URLs are left bare so GDAL handles them.
 const REMOTE_URL_PATTERN = /https?:\/\/[^\s'");]+/gi;
-const NATIVE_REMOTE_READER_EXTENSIONS = new Set(
-  DATA_SOURCE_READERS.filter((entry) => entry.reader !== "ST_Read").flatMap(
-    (entry) => entry.extensions,
-  ),
-);
+
+// A pre-spatial remote read_parquet is what initialises the HTTP read path (see
+// ensureSpatialExtension). When a query has no remote parquet of its own to warm
+// up with (e.g. a local-only first query that would otherwise load spatial
+// cold), this tiny public parquet is read instead. Only its footer is fetched.
+const HTTP_WARMUP_PARQUET_URL =
+  "https://data.source.coop/giswqs/opengeos/countries.parquet";
 
 /** A loaded layer exposed to the workspace as a DuckDB table. */
 export interface SqlWorkspaceTable {
@@ -286,41 +288,114 @@ async function describeQuery(
 }
 
 /**
- * Detect whether `sql` contains more than one statement (an interior semicolon
- * outside of string literals, quoted identifiers, and comments). DuckDB-WASM
- * silently runs every statement but only returns the last result, so the caller
- * rejects multi-statement input instead of discarding earlier results.
+ * Return a copy of `sql` in which every character inside a string literal,
+ * quoted identifier, line/block comment, or dollar-quoted string (`$$…$$`,
+ * `$tag$…$tag$`) is replaced with a space, while newlines and all "code"
+ * characters keep their original position.
+ *
+ * Running regexes against this mask makes them literal-aware without a full
+ * parser: a match's indices are valid against the original string, but the
+ * regex can never match text that lives inside a literal or comment.
  */
-function containsMultipleStatements(sql: string): boolean {
-  let index = 0;
-  while (index < sql.length) {
-    const char = sql[index];
+function maskSqlLiterals(sql: string): string {
+  const out = sql.split("");
+  const blank = (start: number, end: number): void => {
+    for (let k = start; k < end && k < out.length; k += 1) {
+      if (out[k] !== "\n") out[k] = " ";
+    }
+  };
+  let i = 0;
+  while (i < sql.length) {
+    const char = sql[i];
     if (char === "'" || char === '"') {
-      index += 1;
-      while (index < sql.length) {
-        if (sql[index] === char) {
+      let j = i + 1;
+      while (j < sql.length) {
+        if (sql[j] === char) {
           // A doubled quote is an escaped quote, not the end of the literal.
-          if (sql[index + 1] === char) {
-            index += 2;
+          if (sql[j + 1] === char) {
+            j += 2;
             continue;
           }
           break;
         }
-        index += 1;
+        j += 1;
       }
-    } else if (char === "-" && sql[index + 1] === "-") {
-      while (index < sql.length && sql[index] !== "\n") index += 1;
-    } else if (char === "/" && sql[index + 1] === "*") {
-      index += 2;
-      while (index < sql.length && !(sql[index] === "*" && sql[index + 1] === "/"))
-        index += 1;
-      index += 1;
-    } else if (char === ";") {
-      return true;
+      blank(i, j + 1);
+      i = j + 1;
+    } else if (char === "-" && sql[i + 1] === "-") {
+      let j = i;
+      while (j < sql.length && sql[j] !== "\n") j += 1;
+      blank(i, j);
+      i = j;
+    } else if (char === "/" && sql[i + 1] === "*") {
+      let j = i + 2;
+      while (j < sql.length && !(sql[j] === "*" && sql[j + 1] === "/")) j += 1;
+      blank(i, j + 2);
+      i = j + 2;
+    } else if (char === "$") {
+      // Dollar-quote tag: $tag$ where tag is empty or [A-Za-z0-9_]+.
+      const tagMatch = /^\$[A-Za-z0-9_]*\$/.exec(sql.slice(i));
+      if (tagMatch) {
+        const tag = tagMatch[0];
+        const closeAt = sql.indexOf(tag, i + tag.length);
+        const end = closeAt === -1 ? sql.length : closeAt + tag.length;
+        blank(i, end);
+        i = end;
+      } else {
+        i += 1;
+      }
+    } else {
+      i += 1;
     }
-    index += 1;
   }
-  return false;
+  return out.join("");
+}
+
+/**
+ * Trim the statement and strip a single trailing semicolon and any trailing
+ * comment, so it can be safely wrapped in `... FROM (<statement>) AS …` for
+ * geometry detection. Operates via {@link maskSqlLiterals} so a semicolon or
+ * comment inside a literal is never mistaken for the terminator.
+ */
+function cleanStatement(sql: string): string {
+  const src = sql.trim();
+  const masked = maskSqlLiterals(src);
+  // maskSqlLiterals blanks comments to spaces, so trimming the mask drops any
+  // trailing comment; the matching slice of the original is the real content.
+  let end = masked.replace(/\s+$/, "").length;
+  if (end > 0 && masked[end - 1] === ";") end -= 1;
+  return src.slice(0, end).trimEnd();
+}
+
+/**
+ * Detect whether `sql` contains more than one statement (an interior semicolon
+ * outside of string literals, quoted identifiers, comments, and dollar-quotes).
+ * DuckDB-WASM silently runs every statement but only returns the last result,
+ * so the caller rejects multi-statement input instead of discarding earlier
+ * results. Expects a statement already cleaned of its trailing semicolon.
+ */
+function containsMultipleStatements(sql: string): boolean {
+  const masked = maskSqlLiterals(sql);
+  const semicolon = masked.indexOf(";");
+  // A semicolon is only a statement separator when real content follows it;
+  // trailing comments/whitespace have already been blanked by the mask.
+  return semicolon !== -1 && masked.slice(semicolon + 1).trim().length > 0;
+}
+
+/** Names of layer tables referenced (as bare identifiers) in the statement. */
+function referencedTableNames(
+  statement: string,
+  candidates: Iterable<string>,
+): Set<string> {
+  const masked = maskSqlLiterals(statement);
+  const referenced = new Set<string>();
+  for (const name of candidates) {
+    // Table names are sanitized lower-case identifiers, so a word-boundary
+    // match against the masked (literal-free) statement is reliable.
+    const pattern = new RegExp(`(?<![\\w.])${name}\\b`, "i");
+    if (pattern.test(masked)) referenced.add(name);
+  }
+  return referenced;
 }
 
 /** Pick the DuckDB table function for a data source extension, if recognised. */
@@ -372,27 +447,30 @@ async function registerRemoteSources(
   filePrefix: string,
   statement: string,
   registeredFiles: string[],
-): Promise<string> {
+): Promise<{ statement: string; readerCalls: string[] }> {
   // Longest first so a URL that is a prefix of another is replaced correctly.
   const urls = [...new Set(statement.match(REMOTE_URL_PATTERN) ?? [])].sort(
     (a, b) => b.length - a.length,
   );
   let rewritten = statement;
   let index = 0;
+  const readerCalls: string[] = [];
   for (const url of urls) {
     const path = url.split(/[?#]/)[0];
     const dot = path.lastIndexOf(".");
     const extension = dot >= 0 ? path.slice(dot + 1).toLowerCase() : "";
-    if (!NATIVE_REMOTE_READER_EXTENSIONS.has(extension)) continue;
+    const reader = readerForExtension(extension);
+    if (!reader || reader === "ST_Read") continue;
     const handle = remoteHandleName(filePrefix, index, url);
     index += 1;
     // directIO = true forces range-based reads so the whole file is never
     // buffered locally.
     await db.registerFileURL(handle, url, DuckDBDataProtocol.HTTP, true);
     registeredFiles.push(handle);
+    readerCalls.push(`${reader}(${quoteSqlString(handle)})`);
     rewritten = rewritten.split(url).join(handle);
   }
-  return rewritten;
+  return { statement: rewritten, readerCalls };
 }
 
 function rowsToFeatureCollection(
@@ -471,16 +549,31 @@ export async function runSqlQuery(
   const registeredFiles: string[] = [];
 
   try {
-    await ensureSpatialExtension(connection);
-    await registerLayerTables(db, connection, layers, filePrefix, registeredFiles);
     // Register remote URLs as DuckDB file handles so they stream over HTTP
-    // range requests instead of the unreliable in-WASM httpfs path.
-    const statement = await registerRemoteSources(
+    // range requests instead of the unreliable in-WASM httpfs path. Done before
+    // loading spatial so the handles can warm up the HTTP read path first.
+    const { statement, readerCalls } = await registerRemoteSources(
       db,
       filePrefix,
       rewritten,
       registeredFiles,
     );
+    // Load spatial, warming up the HTTP read path first: duckdb-wasm breaks
+    // remote read_parquet if spatial is loaded before the first remote read. A
+    // single pre-spatial read_parquet initialises the path for all later remote
+    // reads. Warm up with the query's own remote readers (no extra request),
+    // and guarantee at least one read_parquet runs by falling back to a tiny
+    // default parquet when the query has none of its own.
+    const warmups = [...readerCalls];
+    if (!warmups.some((call) => call.startsWith("read_parquet"))) {
+      warmups.push(`read_parquet(${quoteSqlString(HTTP_WARMUP_PARQUET_URL)})`);
+    }
+    await ensureSpatialExtension(connection, async () => {
+      for (const readerCall of warmups) {
+        await connection.query(`SELECT 1 FROM ${readerCall} LIMIT 0`);
+      }
+    });
+    await registerLayerTables(db, connection, layers, filePrefix, registeredFiles);
 
     const described = await describeQuery(connection, statement);
     const geometryColumn = described?.geometryColumn ?? null;

--- a/apps/geolibre-desktop/src/lib/sql-workspace.ts
+++ b/apps/geolibre-desktop/src/lib/sql-workspace.ts
@@ -1,0 +1,301 @@
+import type { GeoLibreLayer } from "@geolibre/core";
+import type { Feature, FeatureCollection, Geometry } from "geojson";
+import type {
+  AsyncDuckDB,
+  AsyncDuckDBConnection,
+} from "@duckdb/duckdb-wasm";
+import {
+  ensureSpatialExtension,
+  getDatabase,
+  isGeometryColumnType,
+  rowsFromResult,
+} from "./duckdb-vector-loader";
+
+// Hidden column appended to the user's query so geometry can be returned as
+// GeoJSON for the "Add as layer" / export paths without disturbing the columns
+// the user sees in the results grid.
+const GEOMETRY_JSON_COLUMN = "__geolibre_sql_geometry_geojson";
+
+/** A loaded layer exposed to the workspace as a DuckDB table. */
+export interface SqlWorkspaceTable {
+  /** SQL identifier the user references in queries. */
+  tableName: string;
+  /** Human-readable layer name the table was derived from. */
+  layerName: string;
+}
+
+/** Result of running a single SQL statement in the workspace. */
+export interface SqlQueryResult {
+  /** Column names in select order (the hidden geometry column is excluded). */
+  columns: string[];
+  /** Result rows keyed by column name; geometry is rendered as WKT text. */
+  rows: Record<string, unknown>[];
+  /** Total rows returned (equals `rows.length`). */
+  rowCount: number;
+  /** Name of the detected GEOMETRY column, or null when the result has none. */
+  geometryColumn: string | null;
+  /** Result as GeoJSON when a geometry column is present, otherwise null. */
+  geojson: FeatureCollection | null;
+}
+
+function quoteIdentifier(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`;
+}
+
+function quoteSqlString(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+/**
+ * Turn a layer name into a valid, lower-case SQL identifier. Non-alphanumeric
+ * runs collapse to underscores and a leading digit is prefixed so the result is
+ * always a usable bare identifier; an empty result falls back to `layer_<id>`.
+ */
+function sanitizeTableName(layerName: string, layerId: string): string {
+  const base = layerName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  const normalized = /^[a-z_]/.test(base) ? base : `t_${base}`;
+  return normalized || `layer_${layerId.replace(/[^a-z0-9]+/gi, "_")}`;
+}
+
+/**
+ * Assign a unique table name to each layer that carries an in-memory GeoJSON
+ * FeatureCollection. Names are derived from layer names and de-duplicated with a
+ * numeric suffix on collision. Shared by registration and the UI preview so the
+ * names cannot drift.
+ */
+function assignTableNames(
+  layers: GeoLibreLayer[],
+): Array<{ layer: GeoLibreLayer; tableName: string }> {
+  const assigned: Array<{ layer: GeoLibreLayer; tableName: string }> = [];
+  const usedNames = new Set<string>();
+  for (const layer of layers) {
+    if (!layer.geojson) continue;
+    const baseName = sanitizeTableName(layer.name, layer.id);
+    let tableName = baseName;
+    let suffix = 2;
+    while (usedNames.has(tableName)) {
+      tableName = `${baseName}_${suffix}`;
+      suffix += 1;
+    }
+    usedNames.add(tableName);
+    assigned.push({ layer, tableName });
+  }
+  return assigned;
+}
+
+/**
+ * Compute the table names the workspace will expose for the given layers,
+ * without touching DuckDB, so the UI can show queryable table names before a
+ * query runs.
+ *
+ * @param layers Current app layers; those without `geojson` are skipped.
+ * @returns The tables, in the same order and naming as registration.
+ */
+export function previewLayerTables(
+  layers: GeoLibreLayer[],
+): SqlWorkspaceTable[] {
+  return assignTableNames(layers).map(({ layer, tableName }) => ({
+    tableName,
+    layerName: layer.name,
+  }));
+}
+
+/**
+ * Register every loaded layer that carries an in-memory GeoJSON FeatureCollection
+ * as a DuckDB table, so user SQL can query the current map data by layer name.
+ *
+ * Existing tables are replaced so repeated runs stay in sync with edits to the
+ * layers.
+ *
+ * @param db Shared DuckDB-WASM database instance.
+ * @param connection Open connection used to create the tables.
+ * @param layers Current app layers; those without `geojson` are skipped.
+ * @returns The registered tables in registration order.
+ */
+export async function registerLayerTables(
+  db: AsyncDuckDB,
+  connection: AsyncDuckDBConnection,
+  layers: GeoLibreLayer[],
+): Promise<SqlWorkspaceTable[]> {
+  const registered: SqlWorkspaceTable[] = [];
+
+  for (const { layer, tableName } of assignTableNames(layers)) {
+    const fileName = `${tableName}.geojson`;
+    await db.registerFileText(fileName, JSON.stringify(layer.geojson));
+    await connection.query(
+      `CREATE OR REPLACE TABLE ${quoteIdentifier(tableName)} AS ` +
+        `SELECT * FROM ST_Read(${quoteSqlString(fileName)})`,
+    );
+    registered.push({ tableName, layerName: layer.name });
+  }
+
+  return registered;
+}
+
+/** Read the column names from a DuckDB-WASM Arrow result, even when empty. */
+function columnNamesFromResult(result: {
+  schema?: { fields?: ReadonlyArray<{ name: string }> };
+}): string[] {
+  return result.schema?.fields?.map((field) => field.name) ?? [];
+}
+
+/** Normalise a DuckDB cell value into something JSON/CSV friendly. */
+function normalizeValue(value: unknown): unknown {
+  if (typeof value === "bigint") {
+    const asNumber = Number(value);
+    return Number.isSafeInteger(asNumber) ? asNumber : value.toString();
+  }
+  if (value instanceof Date) return value.toISOString();
+  if (value instanceof Uint8Array) return `[binary ${value.length} bytes]`;
+  return value;
+}
+
+function normalizeRow(
+  row: Record<string, unknown>,
+  columns: string[],
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const column of columns) {
+    out[column] = normalizeValue(row[column]);
+  }
+  return out;
+}
+
+/** Find the first GEOMETRY-typed column in the user's query, if any. */
+async function detectGeometryColumn(
+  connection: AsyncDuckDBConnection,
+  sql: string,
+): Promise<string | null> {
+  try {
+    const described = rowsFromResult(await connection.query(`DESCRIBE ${sql}`));
+    const match = described.find((row) =>
+      isGeometryColumnType(row.column_type),
+    )?.column_name;
+    return typeof match === "string" ? match : null;
+  } catch {
+    // DESCRIBE fails for DDL or multi-statement input; those have no geometry.
+    return null;
+  }
+}
+
+function rowsToFeatureCollection(
+  rows: Record<string, unknown>[],
+  geometryColumn: string,
+): FeatureCollection {
+  const features = rows.map((row) => {
+    const rawGeometry = row[GEOMETRY_JSON_COLUMN];
+    const geometry =
+      typeof rawGeometry === "string"
+        ? (JSON.parse(rawGeometry) as Geometry)
+        : null;
+    const properties: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(row)) {
+      if (key === GEOMETRY_JSON_COLUMN || key === geometryColumn) continue;
+      if (value instanceof Uint8Array) continue;
+      properties[key] = normalizeValue(value);
+    }
+    return {
+      type: "Feature",
+      geometry,
+      properties,
+    } satisfies Feature<Geometry | null>;
+  });
+
+  // GeoJSON Features may legally have a null geometry; the app's layer model
+  // treats them as a regular FeatureCollection and the map ignores nulls.
+  return { type: "FeatureCollection", features } as FeatureCollection;
+}
+
+/**
+ * Run a single SQL statement against the shared DuckDB instance with the spatial
+ * extension loaded and all GeoJSON-backed layers registered as tables.
+ *
+ * When the result has a GEOMETRY column, geometry is rendered as WKT in the grid
+ * rows and a GeoJSON FeatureCollection is built for the add-as-layer and export
+ * paths. Coordinates are assumed to be WGS84 (EPSG:4326); reprojection is not
+ * applied here.
+ *
+ * @param sql The SQL statement to execute.
+ * @param layers Current app layers exposed as queryable tables.
+ * @returns Columns, rows, row count, geometry column name, and GeoJSON result.
+ * @throws Whatever DuckDB throws for invalid SQL (surfaced to the caller).
+ */
+export async function runSqlQuery(
+  sql: string,
+  layers: GeoLibreLayer[],
+): Promise<SqlQueryResult> {
+  // A trailing semicolon is valid as a standalone statement but breaks the
+  // geometry-detection wrapper `... FROM (<sql>) AS ...`, so strip it once.
+  const statement = sql.trim().replace(/;\s*$/, "");
+
+  const db = await getDatabase();
+  const connection = await db.connect();
+
+  try {
+    await ensureSpatialExtension(connection);
+    await registerLayerTables(db, connection, layers);
+
+    const geometryColumn = await detectGeometryColumn(connection, statement);
+
+    if (geometryColumn) {
+      const geomId = quoteIdentifier(geometryColumn);
+      const hiddenId = quoteIdentifier(GEOMETRY_JSON_COLUMN);
+      const result = await connection.query(
+        `SELECT * REPLACE (ST_AsText(${geomId}) AS ${geomId}), ` +
+          `ST_AsGeoJSON(${geomId}) AS ${hiddenId} ` +
+          `FROM (${statement}) AS __geolibre_sql_query`,
+      );
+      const allColumns = columnNamesFromResult(result);
+      const columns = allColumns.filter(
+        (column) => column !== GEOMETRY_JSON_COLUMN,
+      );
+      const rawRows = rowsFromResult(result);
+      const geojson = rowsToFeatureCollection(rawRows, geometryColumn);
+      const rows = rawRows.map((row) => normalizeRow(row, columns));
+      return {
+        columns,
+        rows,
+        rowCount: rows.length,
+        geometryColumn,
+        geojson,
+      };
+    }
+
+    const result = await connection.query(statement);
+    const columns = columnNamesFromResult(result);
+    const rows = rowsFromResult(result).map((row) =>
+      normalizeRow(row, columns),
+    );
+    return {
+      columns,
+      rows,
+      rowCount: rows.length,
+      geometryColumn: null,
+      geojson: null,
+    };
+  } finally {
+    await connection.close();
+  }
+}
+
+/** Serialise result rows to CSV text, quoting per RFC 4180. */
+export function resultToCsv(
+  columns: string[],
+  rows: Record<string, unknown>[],
+): string {
+  const escape = (value: unknown): string => {
+    if (value === null || value === undefined) return "";
+    const text =
+      typeof value === "object" ? JSON.stringify(value) : String(value);
+    return /[",\n\r]/.test(text) ? `"${text.replaceAll('"', '""')}"` : text;
+  };
+  const lines = [columns.map(escape).join(",")];
+  for (const row of rows) {
+    lines.push(columns.map((column) => escape(row[column])).join(","));
+  }
+  return lines.join("\n");
+}

--- a/apps/geolibre-desktop/src/lib/sql-workspace.ts
+++ b/apps/geolibre-desktop/src/lib/sql-workspace.ts
@@ -52,7 +52,9 @@ function sanitizeTableName(layerName: string, layerId: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "_")
     .replace(/^_+|_+$/g, "");
-  const normalized = /^[a-z_]/.test(base) ? base : `t_${base}`;
+  // Keep `normalized` empty when `base` is empty so the layer_<id> fallback is
+  // reached; prefixing an empty base would yield "t_" and bypass the fallback.
+  const normalized = base ? (/^[a-z_]/.test(base) ? base : `t_${base}`) : "";
   return normalized || `layer_${layerId.replace(/[^a-z0-9]+/gi, "_")}`;
 }
 
@@ -252,8 +254,12 @@ export async function runSqlQuery(
 
   try {
     await ensureSpatialExtension(connection);
-    const tables = await registerLayerTables(db, connection, layers);
-    registeredFiles = tables.map((table) => `${table.tableName}.geojson`);
+    // Pre-compute the file names from the same naming logic so the finally
+    // block can clean up even if registration throws part-way through the loop.
+    registeredFiles = previewLayerTables(layers).map(
+      (table) => `${table.tableName}.geojson`,
+    );
+    await registerLayerTables(db, connection, layers);
 
     const geometryColumn = await detectGeometryColumn(connection, statement);
 

--- a/apps/geolibre-desktop/src/lib/sql-workspace.ts
+++ b/apps/geolibre-desktop/src/lib/sql-workspace.ts
@@ -19,6 +19,10 @@ import {
 // the same name is filtered out of both the grid and the GeoJSON properties.
 const GEOMETRY_JSON_COLUMN = "__geolibre_sql_geometry_geojson";
 
+// Reserved alias wrapping the user's statement when geometry is detected; kept
+// deliberately obscure so it does not collide with a user's own CTE/subquery.
+const SQL_SUBQUERY_ALIAS = "__geolibre_sql_subquery";
+
 /** A loaded layer exposed to the workspace as a DuckDB table. */
 export interface SqlWorkspaceTable {
   /** SQL identifier the user references in queries. */
@@ -269,7 +273,7 @@ export async function runSqlQuery(
       const result = await connection.query(
         `SELECT * REPLACE (ST_AsText(${geomId}) AS ${geomId}), ` +
           `ST_AsGeoJSON(${geomId}) AS ${hiddenId} ` +
-          `FROM (${statement}) AS __geolibre_sql_query`,
+          `FROM (${statement}) AS ${quoteIdentifier(SQL_SUBQUERY_ALIAS)}`,
       );
       const allColumns = columnNamesFromResult(result);
       const columns = allColumns.filter(

--- a/apps/geolibre-desktop/src/lib/sql-workspace.ts
+++ b/apps/geolibre-desktop/src/lib/sql-workspace.ts
@@ -8,6 +8,8 @@ import {
   ensureSpatialExtension,
   getDatabase,
   isGeometryColumnType,
+  quoteIdentifier,
+  quoteSqlString,
   rowsFromResult,
 } from "./duckdb-vector-loader";
 
@@ -36,14 +38,6 @@ export interface SqlQueryResult {
   geometryColumn: string | null;
   /** Result as GeoJSON when a geometry column is present, otherwise null. */
   geojson: FeatureCollection | null;
-}
-
-function quoteIdentifier(value: string): string {
-  return `"${value.replaceAll('"', '""')}"`;
-}
-
-function quoteSqlString(value: string): string {
-  return `'${value.replaceAll("'", "''")}'`;
 }
 
 /**
@@ -234,10 +228,12 @@ export async function runSqlQuery(
 
   const db = await getDatabase();
   const connection = await db.connect();
+  let registeredFiles: string[] = [];
 
   try {
     await ensureSpatialExtension(connection);
-    await registerLayerTables(db, connection, layers);
+    const tables = await registerLayerTables(db, connection, layers);
+    registeredFiles = tables.map((table) => `${table.tableName}.geojson`);
 
     const geometryColumn = await detectGeometryColumn(connection, statement);
 
@@ -279,6 +275,15 @@ export async function runSqlQuery(
     };
   } finally {
     await connection.close();
+    // The table data is materialised by CREATE TABLE, so the registered GeoJSON
+    // files are no longer needed; drop them to free DuckDB's in-memory VFS.
+    if (registeredFiles.length > 0) {
+      try {
+        await db.dropFiles(registeredFiles);
+      } catch {
+        // Files may already be gone; cleanup is best-effort.
+      }
+    }
   }
 }
 

--- a/apps/geolibre-desktop/src/lib/sql-workspace.ts
+++ b/apps/geolibre-desktop/src/lib/sql-workspace.ts
@@ -275,7 +275,7 @@ async function describeQuery(
     const described = rowsFromResult(
       await connection.query(
         `DESCRIBE SELECT * FROM (${statement}) AS ` +
-          quoteIdentifier(SQL_SUBQUERY_ALIAS),
+          `${quoteIdentifier(SQL_SUBQUERY_ALIAS)} LIMIT 0`,
       ),
     );
     const columnNames = described
@@ -459,13 +459,21 @@ async function registerRemoteSources(
   statement: string,
   registeredFiles: string[],
 ): Promise<{ statement: string; readerCalls: string[] }> {
+  // Match against the masked SQL so a reader call that appears inside a string
+  // literal or comment is ignored: a match whose start is blanked in the mask is
+  // not real code. Match indices are valid against the original string, and the
+  // reader keyword and URL the pattern captures are code (never masked).
+  const masked = maskSqlLiterals(statement);
+  const matches = [...statement.matchAll(REMOTE_READER_ARG_PATTERN)].filter(
+    (match) => masked[match.index ?? 0] !== " ",
+  );
+
   // Collect each distinct URL that is a native reader's argument, keeping the
   // first reader function it appears with (used to warm up the HTTP path).
   const readerByUrl = new Map<string, string>();
-  for (const match of statement.matchAll(REMOTE_READER_ARG_PATTERN)) {
-    const reader = match[1].toLowerCase();
+  for (const match of matches) {
     const url = match[2];
-    if (!readerByUrl.has(url)) readerByUrl.set(url, reader);
+    if (!readerByUrl.has(url)) readerByUrl.set(url, match[1].toLowerCase());
   }
   if (readerByUrl.size === 0) return { statement, readerCalls: [] };
 
@@ -482,18 +490,23 @@ async function registerRemoteSources(
     handleByUrl.set(url, handle);
     readerCalls.push(`${reader}(${quoteSqlString(handle)})`);
   }
-  // Replace only the matched reader-call arguments, so a URL that happens to
-  // appear elsewhere (e.g. in a WHERE-clause string literal) is left intact.
-  // The pattern matches up to the URL's closing quote but not the call's
-  // closing paren, so the replacement must not add one: the original `)` (and
-  // any trailing arguments) stays in place.
-  const rewritten = statement.replace(
-    REMOTE_READER_ARG_PATTERN,
-    (whole, reader: string, url: string) => {
-      const handle = handleByUrl.get(url);
-      return handle ? `${reader}(${quoteSqlString(handle)}` : whole;
-    },
-  );
+
+  // Rebuild the statement replacing only the matched (code) reader-call
+  // arguments via their indices. The pattern matches up to the URL's closing
+  // quote but not the call's closing paren, so the replacement must not add one:
+  // the original `)` and any trailing arguments stay in place.
+  let rewritten = "";
+  let lastIndex = 0;
+  for (const match of matches) {
+    const matchIndex = match.index ?? 0;
+    const handle = handleByUrl.get(match[2]);
+    rewritten += statement.slice(lastIndex, matchIndex);
+    rewritten += handle
+      ? `${match[1]}(${quoteSqlString(handle)}`
+      : match[0];
+    lastIndex = matchIndex + match[0].length;
+  }
+  rewritten += statement.slice(lastIndex);
   return { statement: rewritten, readerCalls };
 }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,12 @@ Add Data supports XYZ, WMS, GeoJSON URLs, vector tiles, COG and GeoTIFF rasters,
 The processing toolbox includes client-side algorithms now, with a roadmap toward DuckDB Spatial and an optional Python sidecar for heavier geoprocessing.
 </div>
 
+<div class="feature-card" markdown>
+### SQL Workspace
+
+Run DuckDB Spatial SQL in the browser against loaded layers, local files, and remote URLs. Auto-wraps bare URLs into the matching reader and streams remote files over HTTP range requests. Includes sample queries, query history, and adding a result (with an optional layer name) to the map or exporting it as CSV or GeoParquet.
+</div>
+
 </div>
 
 ## Try it in the browser

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -85,7 +85,7 @@
 
 ## v0.9: SQL and processing sidecar
 
-- [ ] SQL panel workflow for building and managing queries
+- [x] SQL Workspace for running DuckDB Spatial SQL against loaded layers, local files, and remote URLs, with sample queries, query history, and adding results to the map or exporting them
 - [ ] GDAL / Rasterio / GeoPandas pipelines
 - [ ] Buffer, reproject, and export GeoJSON processing tools
 - [ ] Expanded WhiteboxTools coverage

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -322,6 +322,14 @@ export function projectFromStore(state: {
 }
 
 function prepareLayerForSave(layer: GeoLibreLayer): GeoLibreLayer {
+  // Vector layers owned by the Add Vector Layer control restore their features
+  // from their source URL/file, so any `geojson` read back from the map for the
+  // attribute table is redundant in a saved project and would only bloat it.
+  if (layer.metadata.externalNativeLayer === true && layer.geojson) {
+    const { geojson: _geojson, ...rest } = layer;
+    layer = rest;
+  }
+
   if (layer.type !== "xyz") return layer;
 
   const originalUrl =

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -49,6 +49,7 @@ export interface AppState {
   ui: {
     processingOpen: boolean;
     conversionOpen: ConversionToolKind | null;
+    sqlWorkspaceOpen: boolean;
     attributeTableOpen: boolean;
     zoomToSelectedFeature: boolean;
   };
@@ -69,6 +70,7 @@ export interface AppState {
   setAttributeFilter: (filter: string) => void;
   setProcessingOpen: (open: boolean) => void;
   setConversionOpen: (kind: ConversionToolKind | null) => void;
+  setSqlWorkspaceOpen: (open: boolean) => void;
   setAttributeTableOpen: (open: boolean) => void;
   setZoomToSelectedFeature: (enabled: boolean) => void;
 
@@ -153,6 +155,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   ui: {
     processingOpen: false,
     conversionOpen: null,
+    sqlWorkspaceOpen: false,
     attributeTableOpen: false,
     zoomToSelectedFeature: false,
   },
@@ -184,6 +187,8 @@ export const useAppStore = create<AppState>((set, get) => ({
     set((s) => ({ ui: { ...s.ui, processingOpen: open } })),
   setConversionOpen: (kind) =>
     set((s) => ({ ui: { ...s.ui, conversionOpen: kind } })),
+  setSqlWorkspaceOpen: (open) =>
+    set((s) => ({ ui: { ...s.ui, sqlWorkspaceOpen: open } })),
   setAttributeTableOpen: (open) =>
     set((s) => ({ ui: { ...s.ui, attributeTableOpen: open } })),
   setZoomToSelectedFeature: (enabled) =>


### PR DESCRIPTION
## Summary
- Adds a SQL Workspace modal under the Processing menu: an interactive DuckDB SQL editor that queries loaded layers (registered as tables), files, and URLs, with a results grid.
- Geometry-bearing results can be added to the map as a new layer or exported to CSV or GeoParquet.
- Reuses the existing DuckDB-WASM singleton and spatial extension, so no new dependency is introduced.

## Test plan
- [ ] Processing > SQL Workspace opens the dialog and lists loaded vector layers as queryable tables.
- [ ] Run `SELECT count(*) FROM <layer>;` and a spatial query (e.g. `ST_Area`) and confirm the results grid populates.
- [ ] Run a file reader such as `SELECT * FROM read_csv_auto('<url>') LIMIT 5;`.
- [ ] With a geometry result, click Add as layer (new layer renders on the map) and Export (CSV and GeoParquet download).
- [ ] Trigger an invalid query and confirm the error banner shows while the editor text is retained.
- [ ] Toggle dark mode and confirm the dialog, editor, and grid follow the in-app theme.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SQL Workspace added to the Processing menu — run SQL against loaded layers, preview table names, view results in an interactive table, export to CSV or GeoParquet, and add geometry results as new map layers.

* **Improvements**
  * Workspace lazy-loads with an error fallback, shows row/column counts and truncated previews for responsiveness, supports keyboard Run (Ctrl/Cmd+Enter), prevents concurrent runs, and adds a UI flag to open/close the dialog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->