### PR TITLE
feat: add VITE_DUCKDB_SPATIAL_EXTENSION_PATH for offline spatial extension loading

### DIFF
--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -4,6 +4,7 @@ import ehWorker from "@duckdb/duckdb-wasm/dist/duckdb-browser-eh.worker.js?url";
 import duckdbWasmMvp from "@duckdb/duckdb-wasm/dist/duckdb-mvp.wasm?url";
 import mvpWorker from "@duckdb/duckdb-wasm/dist/duckdb-browser-mvp.worker.js?url";
 import type { Feature, FeatureCollection, Geometry } from "geojson";
+import { getSpatialExtensionPath } from "./spatial-extension-config";
 
 const GEOMETRY_JSON_COLUMN = "__geolibre_geometry_geojson";
 const EXPORT_GEOJSON_EXTENSION = "geojson";
@@ -42,6 +43,16 @@ export function getDatabase(): Promise<duckdb.AsyncDuckDB> {
 
 let spatialExtensionPromise: Promise<void> | null = null;
 
+function configuredSpatialExtensionPath(): string | undefined {
+  try {
+    const env = (import.meta as { env?: Record<string, string | undefined> })
+      .env;
+    return getSpatialExtensionPath(env);
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Install and load the DuckDB spatial extension once per database instance.
  * `getDatabase` returns a memoized singleton, so the extension persists across
@@ -50,12 +61,23 @@ let spatialExtensionPromise: Promise<void> | null = null;
  * The load is memoized as a promise rather than a boolean so concurrent callers
  * (the function is exported and reused) share a single INSTALL/LOAD instead of
  * each racing to run it. On failure the memo is cleared so a later call retries.
+ *
+ * When `VITE_DUCKDB_SPATIAL_EXTENSION_PATH` is set, INSTALL is skipped and
+ * the extension is loaded from the provided local path (useful for offline or
+ * sandboxed environments where the remote extension repository is unreachable).
  */
 export async function ensureSpatialExtension(
   connection: duckdb.AsyncDuckDBConnection,
   beforeLoad?: () => Promise<void>,
 ): Promise<void> {
   spatialExtensionPromise ??= (async () => {
+    const customPath = configuredSpatialExtensionPath();
+    if (customPath) {
+      const normalizedPath = customPath.replace(/\\/g, "/");
+      await connection.query(`LOAD ${quoteSqlString(normalizedPath)}`);
+      return;
+    }
+
     // duckdb-wasm 1.33.1-dev45 breaks remote read_parquet if the spatial
     // extension is loaded before the first remote HTTP read on the database.
     // `beforeLoad` lets the caller warm up that path (a pre-spatial remote read)

--- a/apps/geolibre-desktop/src/lib/spatial-extension-config.ts
+++ b/apps/geolibre-desktop/src/lib/spatial-extension-config.ts
@@ -1,0 +1,6 @@
+export function getSpatialExtensionPath(
+  env?: Record<string, string | undefined>,
+): string | undefined {
+  const value = env?.VITE_DUCKDB_SPATIAL_EXTENSION_PATH;
+  return value && value.trim() ? value.trim() : undefined;
+}

--- a/tests/spatial-extension-config.test.ts
+++ b/tests/spatial-extension-config.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  getSpatialExtensionPath,
+} from "../apps/geolibre-desktop/src/lib/spatial-extension-config";
+
+describe("getSpatialExtensionPath", () => {
+  it("returns undefined when env is missing or empty", () => {
+    assert.equal(getSpatialExtensionPath(undefined), undefined);
+    assert.equal(getSpatialExtensionPath({}), undefined);
+    assert.equal(
+      getSpatialExtensionPath({ VITE_DUCKDB_SPATIAL_EXTENSION_PATH: "" }),
+      undefined,
+    );
+    assert.equal(
+      getSpatialExtensionPath({ VITE_DUCKDB_SPATIAL_EXTENSION_PATH: "   " }),
+      undefined,
+    );
+  });
+
+  it("returns the path when env is set", () => {
+    assert.equal(
+      getSpatialExtensionPath({
+        VITE_DUCKDB_SPATIAL_EXTENSION_PATH: "C:/test.duckdb_extension",
+      }),
+      "C:/test.duckdb_extension",
+    );
+  });
+
+  it("trims whitespace from the env value", () => {
+    assert.equal(
+      getSpatialExtensionPath({
+        VITE_DUCKDB_SPATIAL_EXTENSION_PATH: "  C:/test.duckdb_extension  ",
+      }),
+      "C:/test.duckdb_extension",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

GeoLibre's DuckDB-WASM integration always runs `INSTALL spatial; LOAD spatial`, which attempts to download the spatial extension from DuckDB's remote extension repository. This fails in sandboxed, air-gapped, or firewalled environments.

## Solution

Introduce an optional `VITE_DUCKDB_SPATIAL_EXTENSION_PATH` environment variable. When set, `INSTALL spatial` is skipped and the extension is loaded directly from the provided local file path. Default behavior is fully preserved when the variable is unset.

## Files Changed

- `apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts` — branches inside `ensureSpatialExtension` to skip `INSTALL` when the env var is set
- `apps/geolibre-desktop/src/lib/spatial-extension-config.ts` *(new)* — extracted pure env-parsing helper for testability
- `tests/spatial-extension-config.test.ts` *(new)* — unit tests for env parsing logic

## Usage

```cmd
set VITE_DUCKDB_SPATIAL_EXTENSION_PATH=C:\path\to\spatial.duckdb_extension
npm run dev
Or add to apps/geolibre-desktop/.env.local:
VITE_DUCKDB_SPATIAL_EXTENSION_PATH=C:/path/to/spatial.duckdb_extension
Closes #170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DuckDB spatial extension now supports environment-based configuration, enabling custom paths for flexible deployment scenarios.

* **Tests**
  * Added comprehensive test coverage for spatial extension configuration, validating path resolution and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->