### PR TITLE
feat: add Time Slider plugin under the Plugins menu

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -53,7 +53,7 @@
     "maplibre-gl-raster": "^0.2.0",
     "maplibre-gl-streetview": "^0.4.0",
     "maplibre-gl-swipe": "^0.7.1",
-    "maplibre-gl-time-slider": "^1.0.1",
+    "maplibre-gl-time-slider": "^1.0.2",
     "maplibre-gl-vector": "^0.2.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -53,6 +53,7 @@
     "maplibre-gl-raster": "^0.2.0",
     "maplibre-gl-streetview": "^0.4.0",
     "maplibre-gl-swipe": "^0.7.1",
+    "maplibre-gl-time-slider": "^1.0.1",
     "maplibre-gl-vector": "^0.2.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -18,6 +18,7 @@ import {
   maplibreOvertureMapsPlugin,
   maplibreStreetViewPlugin,
   maplibreSwipePlugin,
+  maplibreTimeSliderPlugin,
   PluginManager,
 } from "@geolibre/plugins";
 import type { MapController } from "@geolibre/map";
@@ -56,6 +57,7 @@ manager.registerAll([
   maplibreEnviroAtlasPlugin,
   maplibreNationalMapPlugin,
   maplibreEsriWaybackPlugin,
+  maplibreTimeSliderPlugin,
   maplibreOvertureMapsPlugin,
   maplibreGeoAgentPlugin,
   maplibreGeoEditorPlugin,

--- a/apps/geolibre-desktop/src/main.tsx
+++ b/apps/geolibre-desktop/src/main.tsx
@@ -19,6 +19,7 @@ import "maplibre-gl-planetary-computer/style.css";
 import "maplibre-gl-raster/style.css";
 import "maplibre-gl-streetview/style.css";
 import "maplibre-gl-swipe/style.css";
+import "maplibre-gl-time-slider/style.css";
 import "maplibre-gl-vector/style.css";
 import "mapillary-js/dist/mapillary.css";
 import "./index.css";

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -89,6 +89,7 @@
 - [x] Planetary Computer panel for browsing and loading STAC data
 - [x] Earth Engine panel for browsing and loading datasets
 - [x] Overture Maps plugin for loading Overture data themes
+- [x] Time Slider plugin for animating time series raster and vector data, powered by `maplibre-gl-time-slider`
 - [x] Web Services menu with four federal data plugins
 - [x] Add Raster Layer powered by the `maplibre-gl-raster` plugin
 - [x] Add Vector Layer powered by the `maplibre-gl-vector` plugin

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "maplibre-gl-raster": "^0.2.0",
         "maplibre-gl-streetview": "^0.4.0",
         "maplibre-gl-swipe": "^0.7.1",
-        "maplibre-gl-time-slider": "^1.0.1",
+        "maplibre-gl-time-slider": "^1.0.2",
         "maplibre-gl-vector": "^0.2.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -11050,9 +11050,9 @@
       }
     },
     "node_modules/maplibre-gl-time-slider": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-time-slider/-/maplibre-gl-time-slider-1.0.1.tgz",
-      "integrity": "sha512-0n/pitD3DIYFYaG0c/RcptlKjgzhFq0TjVYlfUO2IK9UHSJh7WZje/LL/sY2xp0OFhFiG4Fqrpy/FWko3rvI3w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-time-slider/-/maplibre-gl-time-slider-1.0.2.tgz",
+      "integrity": "sha512-mT3s+p4A2UeMRvjr27GeP12gV80Na63/orhsb2Ov9FXI1QEu9blHXhM1kaJKycBX04Ly1GRqHh9DJbWIhTz1IQ==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=5.14.0",
@@ -14678,7 +14678,7 @@
         "maplibre-gl-raster": "^0.2.0",
         "maplibre-gl-streetview": "^0.4.0",
         "maplibre-gl-swipe": "^0.7.1",
-        "maplibre-gl-time-slider": "^1.0.1",
+        "maplibre-gl-time-slider": "^1.0.2",
         "maplibre-gl-vector": "^0.2.1",
         "proj4": "^2.20.8",
         "shpjs": "^6.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "maplibre-gl-raster": "^0.2.0",
         "maplibre-gl-streetview": "^0.4.0",
         "maplibre-gl-swipe": "^0.7.1",
+        "maplibre-gl-time-slider": "^1.0.1",
         "maplibre-gl-vector": "^0.2.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -7699,7 +7700,7 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/raf": {
@@ -7719,7 +7720,7 @@
       "version": "18.3.29",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.29.tgz",
       "integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -7730,7 +7731,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -8599,7 +8600,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -11036,6 +11037,25 @@
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/maplibre-gl-time-slider": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-time-slider/-/maplibre-gl-time-slider-1.0.1.tgz",
+      "integrity": "sha512-0n/pitD3DIYFYaG0c/RcptlKjgzhFq0TjVYlfUO2IK9UHSJh7WZje/LL/sY2xp0OFhFiG4Fqrpy/FWko3rvI3w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "maplibre-gl": ">=5.14.0",
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"
       },
@@ -14658,6 +14678,7 @@
         "maplibre-gl-raster": "^0.2.0",
         "maplibre-gl-streetview": "^0.4.0",
         "maplibre-gl-swipe": "^0.7.1",
+        "maplibre-gl-time-slider": "^1.0.1",
         "maplibre-gl-vector": "^0.2.1",
         "proj4": "^2.20.8",
         "shpjs": "^6.2.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -45,6 +45,7 @@
     "maplibre-gl-raster": "^0.2.0",
     "maplibre-gl-streetview": "^0.4.0",
     "maplibre-gl-swipe": "^0.7.1",
+    "maplibre-gl-time-slider": "^1.0.1",
     "maplibre-gl-vector": "^0.2.1",
     "proj4": "^2.20.8",
     "shpjs": "^6.2.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -45,7 +45,7 @@
     "maplibre-gl-raster": "^0.2.0",
     "maplibre-gl-streetview": "^0.4.0",
     "maplibre-gl-swipe": "^0.7.1",
-    "maplibre-gl-time-slider": "^1.0.1",
+    "maplibre-gl-time-slider": "^1.0.2",
     "maplibre-gl-vector": "^0.2.1",
     "proj4": "^2.20.8",
     "shpjs": "^6.2.0",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -109,6 +109,7 @@ export { maplibreNationalMapPlugin } from "./plugins/maplibre-national-map";
 export { maplibreOvertureMapsPlugin } from "./plugins/maplibre-overture-maps";
 export { maplibreStreetViewPlugin } from "./plugins/maplibre-streetview";
 export { maplibreSwipePlugin } from "./plugins/maplibre-swipe";
+export { maplibreTimeSliderPlugin } from "./plugins/maplibre-time-slider";
 export {
   sampleGeoJsonPlugin,
   setSampleGeoJson,

--- a/packages/plugins/src/plugins/maplibre-time-slider.ts
+++ b/packages/plugins/src/plugins/maplibre-time-slider.ts
@@ -24,16 +24,23 @@ import type {
 const STORE_LAYER_SOURCE_KIND = "time-slider";
 
 /**
- * Seed configuration applied on first activation: the opengeos Landsat annual
- * composite COG (1984-2013) served via TiTiler, so a layer appears immediately.
- * The source has a stable explicit `id` so the maplibre layer id and the
- * GeoLibre store-layer id stay constant across save/load.
+ * Seed configuration applied on first activation. It mirrors the four bundled
+ * "Add data" examples from maplibre-gl-time-slider, one per source type (COG,
+ * XYZ, GeoJSON, WMS), so every supported type is demonstrated out of the box.
+ *
+ * The examples cover different periods, so a single timeline cannot show all of
+ * them at once: the active timeline defaults to the Landsat COG (yearly,
+ * 1984-2013), which renders immediately. The other sources appear in the Layers
+ * panel and render once the user moves the timeline into their range via the
+ * dock (year/month/day granularity pills are all offered). Each source has a
+ * stable explicit `id` so its maplibre layer id and GeoLibre store-layer id
+ * stay constant across save/load.
  */
 const SEED_OPTIONS: TimeSliderOptions = {
   startDate: "1984-01-01",
   endDate: "2013-01-01",
   granularity: "year",
-  granularities: ["year"],
+  granularities: ["year", "month", "day"],
   speed: 800,
   collapsible: true,
   collapsed: false,
@@ -52,6 +59,39 @@ const SEED_OPTIONS: TimeSliderOptions = {
         -74.72222465917544, -8.586918476798596, -74.15951996520296,
         -8.282218213133522,
       ],
+    },
+    // The remaining examples cover other periods, so they are seeded hidden to
+    // avoid requesting out-of-range tiles under the default Landsat timeline.
+    // They appear in the Layers panel; toggle them on after moving the timeline
+    // into their range (MODIS: Aug 2023 daily; earthquakes: 2015 monthly).
+    {
+      type: "xyz",
+      id: "time-slider-modis-truecolor",
+      name: "MODIS Terra True Color (XYZ)",
+      visible: false,
+      tiles:
+        "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Terra_CorrectedReflectance_TrueColor" +
+        "/default/{date:YYYY-MM-DD}/GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg",
+    },
+    {
+      type: "geojson",
+      id: "time-slider-earthquakes",
+      name: "Significant Earthquakes 2015",
+      visible: false,
+      data: "https://maplibre.org/maplibre-gl-js/docs/assets/significant-earthquakes-2015.geojson",
+      timeProperty: "time",
+      window: { unit: "month", before: 0, after: 1 },
+    },
+    {
+      type: "wms",
+      id: "time-slider-modis-wms",
+      name: "MODIS Terra True Color (WMS)",
+      visible: false,
+      baseUrl:
+        "https://gibs.earthdata.nasa.gov/wms/epsg3857/best/wms.cgi?version=1.3.0&service=WMS" +
+        "&request=GetMap&format=image/png&transparent=true&CRS=EPSG:3857" +
+        "&width=256&height=256&bbox={bbox-epsg-3857}",
+      layers: "MODIS_Terra_CorrectedReflectance_TrueColor",
     },
   ],
 };

--- a/packages/plugins/src/plugins/maplibre-time-slider.ts
+++ b/packages/plugins/src/plugins/maplibre-time-slider.ts
@@ -1,0 +1,290 @@
+import {
+  DEFAULT_LAYER_STYLE,
+  useAppStore,
+  type GeoLibreLayer,
+} from "@geolibre/core";
+import {
+  TimeSliderControl,
+  type SourceSpec,
+  type TimeSliderConfig,
+  type TimeSliderEventHandler,
+  type TimeSliderOptions,
+} from "maplibre-gl-time-slider";
+import type {
+  GeoLibreAppAPI,
+  GeoLibreMapControlPosition,
+  GeoLibrePlugin,
+} from "../types";
+
+/**
+ * Marker placed on every GeoLibre store layer that mirrors a time-slider
+ * source, used to reconcile and prune the plugin's layers without touching any
+ * others (mirrors the Esri Wayback `sourceKind` convention).
+ */
+const STORE_LAYER_SOURCE_KIND = "time-slider";
+
+/**
+ * Seed configuration applied on first activation: the opengeos Landsat annual
+ * composite COG (1984-2013) served via TiTiler, so a layer appears immediately.
+ * The source has a stable explicit `id` so the maplibre layer id and the
+ * GeoLibre store-layer id stay constant across save/load.
+ */
+const SEED_OPTIONS: TimeSliderOptions = {
+  startDate: "1984-01-01",
+  endDate: "2013-01-01",
+  granularity: "year",
+  granularities: ["year"],
+  speed: 800,
+  collapsible: true,
+  collapsed: false,
+  sources: [
+    {
+      type: "cog",
+      id: "time-slider-landsat",
+      name: "Landsat Annual Composite",
+      url: "https://data.source.coop/giswqs/opengeos/landsat_ts/{date:YYYY}.tif",
+      rescale: [0, 110],
+      nodata: 0,
+      bidx: [1, 2, 3],
+    },
+  ],
+};
+
+let timeSliderPosition: GeoLibreMapControlPosition = "bottom-left";
+let timeSliderControl: TimeSliderControl | null = null;
+// Last known config, kept so deactivating/reactivating (or restoring a saved
+// project) rebuilds the timeline and its layers exactly.
+let savedConfig: TimeSliderConfig | null = null;
+let sourceAddHandler: TimeSliderEventHandler | null = null;
+let sourceRemoveHandler: TimeSliderEventHandler | null = null;
+let stateChangeHandler: TimeSliderEventHandler | null = null;
+
+export const maplibreTimeSliderPlugin: GeoLibrePlugin = {
+  id: "maplibre-gl-time-slider",
+  name: "Time Slider",
+  version: "1.0.1",
+  activate: (app: GeoLibreAppAPI) => {
+    timeSliderControl = new TimeSliderControl(
+      savedConfig ? configToOptions(savedConfig) : SEED_OPTIONS,
+    );
+    attachStoreSync(timeSliderControl);
+
+    const added = app.addMapControl(timeSliderControl, timeSliderPosition);
+    if (!added) {
+      detachStoreSync(timeSliderControl);
+      timeSliderControl = null;
+      return false;
+    }
+    // Layers (especially the async COG) only exist a tick after the control is
+    // added, so reconcile the store once they have been created.
+    setTimeout(() => syncStoreLayers(timeSliderControl), 0);
+  },
+  deactivate: (app: GeoLibreAppAPI) => {
+    if (!timeSliderControl) return;
+    savedConfig = timeSliderControl.getConfig();
+    detachStoreSync(timeSliderControl);
+    app.removeMapControl(timeSliderControl);
+    timeSliderControl = null;
+    removeAllTimeSliderStoreLayers();
+  },
+  getMapControlPosition: () => timeSliderPosition,
+  setMapControlPosition: (
+    app: GeoLibreAppAPI,
+    position: GeoLibreMapControlPosition,
+  ) => {
+    timeSliderPosition = position;
+    if (!timeSliderControl) return;
+    // The library's onRemove destroys all adapters/layers and clears event
+    // handlers, so capture the full config first and rebuild a fresh control
+    // at the new position to preserve user-added layers.
+    const config = timeSliderControl.getConfig();
+    detachStoreSync(timeSliderControl);
+    app.removeMapControl(timeSliderControl);
+    timeSliderControl = new TimeSliderControl(configToOptions(config));
+    attachStoreSync(timeSliderControl);
+    const added = app.addMapControl(timeSliderControl, timeSliderPosition);
+    if (!added) {
+      detachStoreSync(timeSliderControl);
+      timeSliderControl = null;
+      return false;
+    }
+    setTimeout(() => syncStoreLayers(timeSliderControl), 0);
+  },
+  getProjectState: () =>
+    timeSliderControl?.getConfig() ?? savedConfig ?? undefined,
+  applyProjectState: (app: GeoLibreAppAPI, state: unknown) => {
+    const nextConfig = normalizeConfig(state);
+    if (!nextConfig) return false;
+
+    savedConfig = nextConfig;
+    if (!timeSliderControl) return true;
+
+    // setConfig replaces every layer with those in the saved config; the
+    // resulting `change`/`statechange` events drive the store reconcile.
+    timeSliderControl.setConfig(nextConfig);
+    setTimeout(() => syncStoreLayers(timeSliderControl), 0);
+  },
+};
+
+/**
+ * Builds constructor options from a serialized config so a fresh control
+ * restores the full timeline state and all of its sources.
+ *
+ * @param config - A config produced by `TimeSliderControl.getConfig()`.
+ * @returns Options for a new `TimeSliderControl`.
+ */
+function configToOptions(config: TimeSliderConfig): TimeSliderOptions {
+  return {
+    startDate: config.startDate,
+    endDate: config.endDate,
+    interval: config.interval,
+    granularity: config.granularity,
+    granularities: config.granularities,
+    initialDate: config.currentDate,
+    speed: config.speed,
+    loop: config.loop,
+    autoPlay: config.autoPlay,
+    theme: config.theme,
+    dateFormat: config.dateFormat,
+    collapsed: config.collapsed,
+    beforeId: config.beforeId,
+    sources: config.sources,
+    collapsible: true,
+  };
+}
+
+/**
+ * Minimal validation of a restored project value before treating it as a
+ * `TimeSliderConfig` (it arrives untyped from the saved project file).
+ *
+ * @param state - The raw value from the saved project.
+ * @returns The config when it looks valid, otherwise null.
+ */
+function normalizeConfig(state: unknown): TimeSliderConfig | null {
+  if (!state || typeof state !== "object") return null;
+  const candidate = state as Partial<TimeSliderConfig>;
+  if (
+    typeof candidate.startDate !== "string" ||
+    typeof candidate.endDate !== "string" ||
+    !Array.isArray(candidate.sources)
+  ) {
+    return null;
+  }
+  return candidate as TimeSliderConfig;
+}
+
+function attachStoreSync(control: TimeSliderControl): void {
+  sourceAddHandler = () => syncStoreLayers(control);
+  sourceRemoveHandler = () => syncStoreLayers(control);
+  stateChangeHandler = () => syncStoreLayers(control);
+  control.on("sourceadd", sourceAddHandler);
+  control.on("sourceremove", sourceRemoveHandler);
+  control.on("statechange", stateChangeHandler);
+}
+
+function detachStoreSync(control: TimeSliderControl): void {
+  if (sourceAddHandler) {
+    control.off("sourceadd", sourceAddHandler);
+    sourceAddHandler = null;
+  }
+  if (sourceRemoveHandler) {
+    control.off("sourceremove", sourceRemoveHandler);
+    sourceRemoveHandler = null;
+  }
+  if (stateChangeHandler) {
+    control.off("statechange", stateChangeHandler);
+    stateChangeHandler = null;
+  }
+}
+
+/**
+ * Reconciles the GeoLibre layer store with the control's current sources: each
+ * source becomes (or updates) an external-native store layer, and store layers
+ * whose source no longer exists are pruned. The maplibre layer id equals the
+ * source id for every adapter type, so `nativeLayerIds` lets the Layers panel
+ * and the on-map layer control drive the underlying layer.
+ */
+function syncStoreLayers(control: TimeSliderControl | null): void {
+  if (!control) return;
+  const activeIds = new Set<string>();
+  for (const spec of control.getSources()) {
+    if (!spec.id) continue;
+    activeIds.add(spec.id);
+    addOrUpdateStoreLayer(createStoreLayer(spec));
+  }
+
+  const store = useAppStore.getState();
+  const staleIds = store.layers
+    .filter(
+      (layer) =>
+        layer.metadata.sourceKind === STORE_LAYER_SOURCE_KIND &&
+        !activeIds.has(layer.id),
+    )
+    .map((layer) => layer.id);
+  for (const id of staleIds) {
+    store.removeLayer(id);
+  }
+}
+
+function addOrUpdateStoreLayer(layer: GeoLibreLayer): void {
+  const store = useAppStore.getState();
+  const existingLayer = store.layers.find((item) => item.id === layer.id);
+  if (!existingLayer) {
+    store.addLayer(layer);
+    return;
+  }
+
+  if (!shouldUpdateStoreLayer(existingLayer, layer)) return;
+
+  // Only sync identity/source/metadata; visibility and opacity are left to the
+  // user via the Layers panel so a dock-side state change cannot clobber them.
+  store.updateLayer(layer.id, {
+    metadata: layer.metadata,
+    name: layer.name,
+    source: layer.source,
+  });
+}
+
+function shouldUpdateStoreLayer(
+  existingLayer: GeoLibreLayer,
+  nextLayer: GeoLibreLayer,
+): boolean {
+  return (
+    existingLayer.name !== nextLayer.name ||
+    JSON.stringify(existingLayer.metadata) !==
+      JSON.stringify(nextLayer.metadata) ||
+    JSON.stringify(existingLayer.source) !== JSON.stringify(nextLayer.source)
+  );
+}
+
+function createStoreLayer(spec: SourceSpec): GeoLibreLayer {
+  const sourceId = spec.id as string;
+  const layerType = spec.type === "geojson" ? "geojson" : "raster";
+  return {
+    id: sourceId,
+    name: spec.name ?? sourceId,
+    type: layerType,
+    source: { type: layerType, sourceId },
+    visible: spec.visible !== false,
+    opacity: spec.opacity ?? 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {
+      externalNativeLayer: true,
+      identifiable: false,
+      nativeLayerIds: [sourceId],
+      sourceId,
+      sourceIds: [sourceId],
+      sourceKind: STORE_LAYER_SOURCE_KIND,
+    },
+  };
+}
+
+function removeAllTimeSliderStoreLayers(): void {
+  const store = useAppStore.getState();
+  const ids = store.layers
+    .filter((layer) => layer.metadata.sourceKind === STORE_LAYER_SOURCE_KIND)
+    .map((layer) => layer.id);
+  for (const id of ids) {
+    store.removeLayer(id);
+  }
+}

--- a/packages/plugins/src/plugins/maplibre-time-slider.ts
+++ b/packages/plugins/src/plugins/maplibre-time-slider.ts
@@ -46,6 +46,12 @@ const SEED_OPTIONS: TimeSliderOptions = {
       rescale: [0, 110],
       nodata: 0,
       bidx: [1, 2, 3],
+      // Footprint of the COG so MapLibre only requests in-bounds tiles
+      // (out-of-bounds tiles 404 at TiTiler and would flood the console).
+      bounds: [
+        -74.72222465917544, -8.586918476798596, -74.15951996520296,
+        -8.282218213133522,
+      ],
     },
   ],
 };

--- a/packages/plugins/src/plugins/maplibre-time-slider.ts
+++ b/packages/plugins/src/plugins/maplibre-time-slider.ts
@@ -156,8 +156,16 @@ export const maplibreTimeSliderPlugin: GeoLibrePlugin = {
     }
     setTimeout(() => syncStoreLayers(timeSliderControl), 0);
   },
-  getProjectState: () =>
-    timeSliderControl?.getConfig() ?? savedConfig ?? undefined,
+  getProjectState: () => {
+    const config = timeSliderControl?.getConfig() ?? savedConfig;
+    // getConfig() includes optional keys (e.g. dateFormat/beforeId) with
+    // `undefined` values. The host drops plugin settings that are not strictly
+    // JSON-compatible, and `undefined` fails that check, so round-trip through
+    // JSON to strip those keys before persisting.
+    return config
+      ? (JSON.parse(JSON.stringify(config)) as TimeSliderConfig)
+      : undefined;
+  },
   applyProjectState: (app: GeoLibreAppAPI, state: unknown) => {
     const nextConfig = normalizeConfig(state);
     if (!nextConfig) {

--- a/packages/plugins/src/plugins/maplibre-time-slider.ts
+++ b/packages/plugins/src/plugins/maplibre-time-slider.ts
@@ -152,6 +152,11 @@ export const maplibreTimeSliderPlugin: GeoLibrePlugin = {
     if (!added) {
       detachStoreSync(timeSliderControl);
       timeSliderControl = null;
+      // Preserve the captured config so a later activate() restores the user's
+      // layers, and drop the now-orphaned store layers (the previous control's
+      // map layers were already removed above).
+      savedConfig = config;
+      removeAllTimeSliderStoreLayers();
       return false;
     }
     setTimeout(() => syncStoreLayers(timeSliderControl), 0);
@@ -170,16 +175,27 @@ export const maplibreTimeSliderPlugin: GeoLibrePlugin = {
     const nextConfig = normalizeConfig(state);
     if (!nextConfig) {
       // A reset/new project (or an invalid value) clears the cached config so
-      // the next activation seeds fresh instead of restoring stale state.
+      // the next activation seeds fresh. If a control is still live (e.g. an
+      // invalid settings entry arrives while the plugin stays active across a
+      // project switch), tear it down and re-seed so the previous project's
+      // timeline cannot linger on screen.
       savedConfig = null;
+      if (timeSliderControl) {
+        detachStoreSync(timeSliderControl);
+        app.removeMapControl(timeSliderControl);
+        timeSliderControl = null;
+        removeAllTimeSliderStoreLayers();
+        return maplibreTimeSliderPlugin.activate(app) !== false;
+      }
       return false;
     }
 
     savedConfig = nextConfig;
     if (!timeSliderControl) return true;
 
-    // setConfig replaces every layer with those in the saved config; the
-    // resulting `change`/`statechange` events drive the store reconcile.
+    // setConfig replaces the sources in place without firing
+    // sourceadd/sourceremove, so reconcile the store via the setTimeout below
+    // once the new layers exist.
     timeSliderControl.setConfig(nextConfig);
     setTimeout(() => syncStoreLayers(timeSliderControl), 0);
     return true;
@@ -208,7 +224,8 @@ function configToOptions(config: TimeSliderConfig): TimeSliderOptions {
     dateFormat: config.dateFormat,
     collapsed: config.collapsed,
     beforeId: config.beforeId,
-    sources: [...config.sources],
+    // Copy each source so the rebuilt control cannot mutate the cached config.
+    sources: config.sources.map((source) => ({ ...source })),
     collapsible: true,
   };
 }
@@ -226,6 +243,9 @@ function normalizeConfig(state: unknown): TimeSliderConfig | null {
   if (
     typeof candidate.startDate !== "string" ||
     typeof candidate.endDate !== "string" ||
+    typeof candidate.granularity !== "string" ||
+    (candidate.currentDate !== undefined &&
+      typeof candidate.currentDate !== "string") ||
     !Array.isArray(candidate.sources) ||
     (candidate.sources as unknown[]).some(
       (source) =>

--- a/packages/plugins/src/plugins/maplibre-time-slider.ts
+++ b/packages/plugins/src/plugins/maplibre-time-slider.ts
@@ -63,13 +63,13 @@ let timeSliderControl: TimeSliderControl | null = null;
 let savedConfig: TimeSliderConfig | null = null;
 let sourceAddHandler: TimeSliderEventHandler | null = null;
 let sourceRemoveHandler: TimeSliderEventHandler | null = null;
-let stateChangeHandler: TimeSliderEventHandler | null = null;
 
 export const maplibreTimeSliderPlugin: GeoLibrePlugin = {
   id: "maplibre-gl-time-slider",
   name: "Time Slider",
   version: "1.0.1",
   activate: (app: GeoLibreAppAPI) => {
+    if (timeSliderControl) return;
     timeSliderControl = new TimeSliderControl(
       savedConfig ? configToOptions(savedConfig) : SEED_OPTIONS,
     );
@@ -120,7 +120,12 @@ export const maplibreTimeSliderPlugin: GeoLibrePlugin = {
     timeSliderControl?.getConfig() ?? savedConfig ?? undefined,
   applyProjectState: (app: GeoLibreAppAPI, state: unknown) => {
     const nextConfig = normalizeConfig(state);
-    if (!nextConfig) return false;
+    if (!nextConfig) {
+      // A reset/new project (or an invalid value) clears the cached config so
+      // the next activation seeds fresh instead of restoring stale state.
+      savedConfig = null;
+      return false;
+    }
 
     savedConfig = nextConfig;
     if (!timeSliderControl) return true;
@@ -129,6 +134,7 @@ export const maplibreTimeSliderPlugin: GeoLibrePlugin = {
     // resulting `change`/`statechange` events drive the store reconcile.
     timeSliderControl.setConfig(nextConfig);
     setTimeout(() => syncStoreLayers(timeSliderControl), 0);
+    return true;
   },
 };
 
@@ -154,7 +160,7 @@ function configToOptions(config: TimeSliderConfig): TimeSliderOptions {
     dateFormat: config.dateFormat,
     collapsed: config.collapsed,
     beforeId: config.beforeId,
-    sources: config.sources,
+    sources: [...config.sources],
     collapsible: true,
   };
 }
@@ -172,20 +178,28 @@ function normalizeConfig(state: unknown): TimeSliderConfig | null {
   if (
     typeof candidate.startDate !== "string" ||
     typeof candidate.endDate !== "string" ||
-    !Array.isArray(candidate.sources)
+    !Array.isArray(candidate.sources) ||
+    (candidate.sources as unknown[]).some(
+      (source) =>
+        !source ||
+        typeof source !== "object" ||
+        typeof (source as { id?: unknown }).id !== "string",
+    )
   ) {
     return null;
   }
   return candidate as TimeSliderConfig;
 }
 
+// Only sourceadd/sourceremove change the store's layer set. statechange also
+// fires on every playback tick (goTo emits it), so subscribing it to a store
+// reconcile would run at animation speed for no benefit; opacity and
+// visibility are intentionally left to the Layers panel.
 function attachStoreSync(control: TimeSliderControl): void {
   sourceAddHandler = () => syncStoreLayers(control);
   sourceRemoveHandler = () => syncStoreLayers(control);
-  stateChangeHandler = () => syncStoreLayers(control);
   control.on("sourceadd", sourceAddHandler);
   control.on("sourceremove", sourceRemoveHandler);
-  control.on("statechange", stateChangeHandler);
 }
 
 function detachStoreSync(control: TimeSliderControl): void {
@@ -196,10 +210,6 @@ function detachStoreSync(control: TimeSliderControl): void {
   if (sourceRemoveHandler) {
     control.off("sourceremove", sourceRemoveHandler);
     sourceRemoveHandler = null;
-  }
-  if (stateChangeHandler) {
-    control.off("statechange", stateChangeHandler);
-    stateChangeHandler = null;
   }
 }
 

--- a/packages/plugins/src/plugins/maplibre-time-slider.ts
+++ b/packages/plugins/src/plugins/maplibre-time-slider.ts
@@ -7,7 +7,6 @@ import {
   TimeSliderControl,
   type SourceSpec,
   type TimeSliderConfig,
-  type TimeSliderEventHandler,
   type TimeSliderOptions,
 } from "maplibre-gl-time-slider";
 import type {
@@ -101,34 +100,37 @@ let timeSliderControl: TimeSliderControl | null = null;
 // Last known config, kept so deactivating/reactivating (or restoring a saved
 // project) rebuilds the timeline and its layers exactly.
 let savedConfig: TimeSliderConfig | null = null;
-let sourceAddHandler: TimeSliderEventHandler | null = null;
-let sourceRemoveHandler: TimeSliderEventHandler | null = null;
+// Detaches the active control's store-sync listeners; set by attachStoreSync,
+// cleared when invoked. Bound to a specific control so handlers cannot leak.
+let detachStoreSync: (() => void) | null = null;
 
 export const maplibreTimeSliderPlugin: GeoLibrePlugin = {
   id: "maplibre-gl-time-slider",
   name: "Time Slider",
-  version: "1.0.1",
+  version: "1.0.2",
   activate: (app: GeoLibreAppAPI) => {
     if (timeSliderControl) return;
-    timeSliderControl = new TimeSliderControl(
+    const control = new TimeSliderControl(
       savedConfig ? configToOptions(savedConfig) : SEED_OPTIONS,
     );
-    attachStoreSync(timeSliderControl);
+    timeSliderControl = control;
+    attachStoreSync(control);
 
-    const added = app.addMapControl(timeSliderControl, timeSliderPosition);
+    const added = app.addMapControl(control, timeSliderPosition);
     if (!added) {
-      detachStoreSync(timeSliderControl);
+      detachStoreSync?.();
       timeSliderControl = null;
       return false;
     }
     // Layers (especially the async COG) only exist a tick after the control is
-    // added, so reconcile the store once they have been created.
-    setTimeout(() => syncStoreLayers(timeSliderControl), 0);
+    // added, so reconcile the store once they have been created. Capture the
+    // control locally so a later reassignment cannot redirect this callback.
+    setTimeout(() => syncStoreLayers(control), 0);
   },
   deactivate: (app: GeoLibreAppAPI) => {
     if (!timeSliderControl) return;
     savedConfig = timeSliderControl.getConfig();
-    detachStoreSync(timeSliderControl);
+    detachStoreSync?.();
     app.removeMapControl(timeSliderControl);
     timeSliderControl = null;
     removeAllTimeSliderStoreLayers();
@@ -144,13 +146,14 @@ export const maplibreTimeSliderPlugin: GeoLibrePlugin = {
     // handlers, so capture the full config first and rebuild a fresh control
     // at the new position to preserve user-added layers.
     const config = timeSliderControl.getConfig();
-    detachStoreSync(timeSliderControl);
+    detachStoreSync?.();
     app.removeMapControl(timeSliderControl);
-    timeSliderControl = new TimeSliderControl(configToOptions(config));
-    attachStoreSync(timeSliderControl);
-    const added = app.addMapControl(timeSliderControl, timeSliderPosition);
+    const control = new TimeSliderControl(configToOptions(config));
+    timeSliderControl = control;
+    attachStoreSync(control);
+    const added = app.addMapControl(control, timeSliderPosition);
     if (!added) {
-      detachStoreSync(timeSliderControl);
+      detachStoreSync?.();
       timeSliderControl = null;
       // Preserve the captured config so a later activate() restores the user's
       // layers, and drop the now-orphaned store layers (the previous control's
@@ -159,7 +162,7 @@ export const maplibreTimeSliderPlugin: GeoLibrePlugin = {
       removeAllTimeSliderStoreLayers();
       return false;
     }
-    setTimeout(() => syncStoreLayers(timeSliderControl), 0);
+    setTimeout(() => syncStoreLayers(control), 0);
   },
   getProjectState: () => {
     const config = timeSliderControl?.getConfig() ?? savedConfig;
@@ -181,7 +184,7 @@ export const maplibreTimeSliderPlugin: GeoLibrePlugin = {
       // timeline cannot linger on screen.
       savedConfig = null;
       if (timeSliderControl) {
-        detachStoreSync(timeSliderControl);
+        detachStoreSync?.();
         app.removeMapControl(timeSliderControl);
         timeSliderControl = null;
         removeAllTimeSliderStoreLayers();
@@ -195,9 +198,11 @@ export const maplibreTimeSliderPlugin: GeoLibrePlugin = {
 
     // setConfig replaces the sources in place without firing
     // sourceadd/sourceremove, so reconcile the store via the setTimeout below
-    // once the new layers exist.
-    timeSliderControl.setConfig(nextConfig);
-    setTimeout(() => syncStoreLayers(timeSliderControl), 0);
+    // once the new layers exist. Capture the control so a later reassignment
+    // cannot redirect this callback.
+    const control = timeSliderControl;
+    control.setConfig(nextConfig);
+    setTimeout(() => syncStoreLayers(control), 0);
     return true;
   },
 };
@@ -231,6 +236,19 @@ function configToOptions(config: TimeSliderConfig): TimeSliderOptions {
 }
 
 /**
+ * Returns true when a source URL-bearing field is safe to hand to the library:
+ * absent/empty, a non-string (e.g. inline GeoJSON data objects), or a plain
+ * http(s) URL. Other schemes (javascript:/data:/file:) are rejected.
+ *
+ * @param value - A candidate `url`/`tiles`/`data`/`baseUrl` value.
+ * @returns Whether the value is safe.
+ */
+function isSafeSourceUrl(value: unknown): boolean {
+  if (typeof value !== "string" || value === "") return true;
+  return /^https?:\/\//i.test(value);
+}
+
+/**
  * Minimal validation of a restored project value before treating it as a
  * `TimeSliderConfig` (it arrives untyped from the saved project file).
  *
@@ -247,12 +265,27 @@ function normalizeConfig(state: unknown): TimeSliderConfig | null {
     (candidate.currentDate !== undefined &&
       typeof candidate.currentDate !== "string") ||
     !Array.isArray(candidate.sources) ||
-    (candidate.sources as unknown[]).some(
-      (source) =>
-        !source ||
-        typeof source !== "object" ||
-        typeof (source as { id?: unknown }).id !== "string",
-    )
+    (candidate.sources as unknown[]).some((source) => {
+      if (!source || typeof source !== "object") return true;
+      const spec = source as {
+        id?: unknown;
+        url?: unknown;
+        tiles?: unknown;
+        data?: unknown;
+        baseUrl?: unknown;
+      };
+      // Reject malformed ids and any URL-bearing field that is not a plain
+      // http(s) URL. A crafted project file could otherwise smuggle a
+      // javascript:/data:/file: URI that MapLibre would fetch, which matters
+      // under the Tauri desktop target.
+      return (
+        typeof spec.id !== "string" ||
+        !isSafeSourceUrl(spec.url) ||
+        !isSafeSourceUrl(spec.tiles) ||
+        !isSafeSourceUrl(spec.data) ||
+        !isSafeSourceUrl(spec.baseUrl)
+      );
+    })
   ) {
     return null;
   }
@@ -264,21 +297,17 @@ function normalizeConfig(state: unknown): TimeSliderConfig | null {
 // reconcile would run at animation speed for no benefit; opacity and
 // visibility are intentionally left to the Layers panel.
 function attachStoreSync(control: TimeSliderControl): void {
-  sourceAddHandler = () => syncStoreLayers(control);
-  sourceRemoveHandler = () => syncStoreLayers(control);
-  control.on("sourceadd", sourceAddHandler);
-  control.on("sourceremove", sourceRemoveHandler);
-}
-
-function detachStoreSync(control: TimeSliderControl): void {
-  if (sourceAddHandler) {
-    control.off("sourceadd", sourceAddHandler);
-    sourceAddHandler = null;
-  }
-  if (sourceRemoveHandler) {
-    control.off("sourceremove", sourceRemoveHandler);
-    sourceRemoveHandler = null;
-  }
+  const onSourceAdd = () => syncStoreLayers(control);
+  const onSourceRemove = () => syncStoreLayers(control);
+  control.on("sourceadd", onSourceAdd);
+  control.on("sourceremove", onSourceRemove);
+  // Bind the detacher to this specific control and its own handler closures so
+  // a second attach can never orphan the previous control's listeners.
+  detachStoreSync = () => {
+    control.off("sourceadd", onSourceAdd);
+    control.off("sourceremove", onSourceRemove);
+    detachStoreSync = null;
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary
Adds a **Time Slider** plugin to the Plugins menu, placed right after **Esri Wayback**, wrapping the [`maplibre-gl-time-slider`](https://www.npmjs.com/package/maplibre-gl-time-slider) package (a NASA-Worldview-style, bottom-docked timeline for animating time series raster/vector data).

- The plugin's toggle (clock) icon defaults to **bottom-left**; the timeline itself stays **bottom-docked** (the library hardcodes the full-width dock, so only the corner toggle honors position).
- Seeds the **opengeos Landsat annual composite COG** (1984-2013) on activation so a layer appears immediately. Users can add more time series sources (COG / XYZ / GeoJSON / WMS) via the dock's built-in "+ Add data" panel.
- **Layers panel + on-map layer control:** the control's sources are mirrored into the GeoLibre layer store as external native layers (`metadata.sourceKind = "time-slider"`), reconciled on `sourceadd` / `sourceremove` / `statechange`, with stale-layer pruning, mirroring the Esri Wayback pattern.
- **Persistence:** the plugin and its layers persist in saved projects via `getConfig()` / `setConfig()`; the icon position persists through the plugin manager. Restored layers are recreated on load.
- Changing the icon position rebuilds a fresh control from the captured config, preserving user-added layers (the library's `onRemove` drops layers and event handlers).

## Upstream
Depends on `maplibre-gl-time-slider@^1.0.1`, released from [opengeos/maplibre-gl-time-slider#18](https://github.com/opengeos/maplibre-gl-time-slider/pull/18) (fixes the published types path so it resolves under strict TS, and adds a `statechange` event on live source-property changes).

## Verification
- `npm run build -w geolibre-desktop` (tsc -b + vite build): passes, no type errors.
- `npm run test:frontend`: 122 passing (incl. plugin-manager).
- `pre-commit run --all-files`: all hooks pass.
- Manual: Plugins menu shows "Time Slider" after "Esri Wayback"; enabling it docks the timeline at the bottom with the toggle bottom-left; the seeded Landsat layer appears in the Layers panel and on-map control; save/reload restores the plugin, position, timeline, and layers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Time Slider plugin added and enabled by default for animating temporal raster and vector layers with interactive playback, timeline controls, and persistent project state
  * Plugin UI styles now load at app startup for consistent appearance

* **Documentation**
  * Roadmap updated to mark Time Slider plugin as completed in v0.9
<!-- end of auto-generated comment: release notes by coderabbit.ai -->