### PR TITLE
chore: bump to v0.9.0 and align platform messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A lightweight, cloud-native GIS platform for visualizing, exploring, and analyzi
 
 GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS**, **DuckDB-WASM Spatial**, and **deck.gl**. The same workspace runs as a native desktop app, in any modern web browser, and adapts responsively to mobile and small screens.
 
-[![](https://files.opengeos.org/GeoLibre-demo.webp)](https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json)
+[![GeoLibre demo showing 3D Tiles rendered on a MapLibre map](https://files.opengeos.org/GeoLibre-demo.webp)](https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json)
 
 ## Features (v0.9.0)
 
@@ -21,7 +21,7 @@ GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS
 - SQL Workspace for running DuckDB Spatial SQL against loaded layers, local files, and remote URLs, with sample queries, query history, and adding results to the map or exporting them
 - Multiple DuckDB SQL query-result layers with identify, selection, and attribute table support
 - Controls menu with Measure, Bookmark, Minimap, and View State tools, plus a Print menu and a Search panel
-- Conversion menu for Vector to GeoParquet/FlatGeobuf/PMTiles, CSV to GeoParquet, and Raster to COG, with browser DuckDB-WASM and an optional sidecar
+- Conversion menu for Vector to GeoParquet/FlatGeobuf/PMTiles, CSV to GeoParquet, and Raster to COG; GeoParquet and CSV conversions run in the browser with DuckDB-WASM, while FlatGeobuf, PMTiles, and COG require the optional Python sidecar
 - Whitebox toolbox with batch tools run against a selected input directory
 - Project menu to create, open, save, and Save As `.geolibre.json` projects
 - Desktop diagnostics panel, update check, and MSIX packaging support

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS
 
 ## Features (v0.9.0)
 
-- Runs across desktop (Tauri), web (browser), and mobile or small screens, with a responsive layout that adapts menus, dialogs, and panels and per-panel visibility through Layout settings
+- Runs across desktop (Tauri), web (browser), and mobile or small screens, with a responsive layout that adapts menus, dialogs, and panels, plus per-panel visibility through Layout settings
 - MapLibre map workspace with OpenFreeMap basemaps, blank background support, and toggleable navigation, fullscreen, geolocation, globe, terrain, scale, attribution, and logo controls
 - Load local vector layers supported by DuckDB-WASM Spatial, including common formats such as GeoJSON, GeoParquet, GeoPackage, Shapefile, FlatGeobuf, KML/KMZ, GML, delimited text, and GPX
 - Reproject vector layers to EPSG:4326 on load and split dragged GPX files into named waypoint, track, and route layers
@@ -25,7 +25,7 @@ GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS
 - Whitebox toolbox with batch tools run against a selected input directory
 - Project menu to create, open, save, and Save As `.geolibre.json` projects
 - Desktop diagnostics panel, update check, and MSIX packaging support
-- Plugin system with basemap, layer control, MapLibre components, swipe, street view, Time Slider, Overture Maps, LiDAR, GeoAgent, and GeoEditor integrations, including configurable control positions and external plugin manifests
+- Plugin system with basemap, layer control, MapLibre components, swipe, street view, Overture Maps, LiDAR, GeoAgent, and GeoEditor integrations, including configurable control positions and external plugin manifests
 - Time Slider plugin for animating time series raster and vector data
 - External plugin zip loading from the app data plugins directory and local development plugin directories
 - Browser deployment with Docker, embed-friendly URL parameters, and a `maponly` chrome-free mode

--- a/README.md
+++ b/README.md
@@ -1,25 +1,34 @@
-# GeoLibre Desktop
+# GeoLibre
 
-Lightweight, cloud-native desktop GIS prototype built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS**, **DuckDB-WASM Spatial**, and **deck.gl**.
+A lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data across desktop, mobile, and web environments.
+
+GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS**, **DuckDB-WASM Spatial**, and **deck.gl**. The same workspace runs as a native desktop app, in any modern web browser, and adapts responsively to mobile and small screens.
 
 [![](https://files.opengeos.org/GeoLibre-demo.webp)](https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json)
 
 ## Features (v0.9.0)
 
+- Runs across desktop (Tauri), web (browser), and mobile or small screens, with a responsive layout that adapts menus, dialogs, and panels and per-panel visibility through Layout settings
 - MapLibre map workspace with OpenFreeMap basemaps, blank background support, and toggleable navigation, fullscreen, geolocation, globe, terrain, scale, attribution, and logo controls
 - Load local vector layers supported by DuckDB-WASM Spatial, including common formats such as GeoJSON, GeoParquet, GeoPackage, Shapefile, FlatGeobuf, KML/KMZ, GML, delimited text, and GPX
 - Reproject vector layers to EPSG:4326 on load and split dragged GPX files into named waypoint, track, and route layers
 - Add Data menu for XYZ tiles, WMS, WFS, GeoJSON URLs, vector tiles, COG and GeoTIFF rasters, MBTiles, ArcGIS FeatureServer and VectorTileServer layers, PMTiles, Zarr, LiDAR, 3D Tiles, and Gaussian splats
+- Cloud data integrations through the Planetary Computer and Earth Engine panels, the Overture Maps plugin, and federal Web Services plugins
 - Manual and automatic refresh for WFS and GeoJSON URL layers
 - Layer panel for visibility, opacity, reordering, zoom-to-layer, identify, labels, and remove actions
 - Live style panel (fill, stroke, opacity, circle radius)
 - Attribute table with filtering, sorting, resize controls, feature highlighting, and optional zoom to selected features
-- SQL Workspace for running DuckDB SQL against loaded layers, local files, and remote URLs, with sample queries, query history, and adding results to the map
-- Multiple DuckDB SQL query-result layers
-- Save/open `.geolibre.json` projects
+- SQL Workspace for running DuckDB Spatial SQL against loaded layers, local files, and remote URLs, with sample queries, query history, and adding results to the map or exporting them
+- Multiple DuckDB SQL query-result layers with identify, selection, and attribute table support
+- Controls menu with Measure, Bookmark, Minimap, and View State tools, plus a Print menu and a Search panel
+- Conversion menu for Vector to GeoParquet/FlatGeobuf/PMTiles, CSV to GeoParquet, and Raster to COG, with browser DuckDB-WASM and an optional sidecar
+- Whitebox toolbox with batch tools run against a selected input directory
+- Project menu to create, open, save, and Save As `.geolibre.json` projects
 - Desktop diagnostics panel, update check, and MSIX packaging support
-- Plugin system with basemap, layer control, MapLibre components, swipe, street view, LiDAR, GeoAgent, and GeoEditor integrations, including configurable control positions and external plugin manifests
+- Plugin system with basemap, layer control, MapLibre components, swipe, street view, Time Slider, Overture Maps, LiDAR, GeoAgent, and GeoEditor integrations, including configurable control positions and external plugin manifests
+- Time Slider plugin for animating time series raster and vector data
 - External plugin zip loading from the app data plugins directory and local development plugin directories
+- Browser deployment with Docker, embed-friendly URL parameters, and a `maponly` chrome-free mode
 - Optional Python FastAPI sidecar for heavier processing workflows
 
 ## Prerequisites

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolibre-desktop",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/geolibre-desktop/src-tauri/Cargo.lock
+++ b/apps/geolibre-desktop/src-tauri/Cargo.lock
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-desktop"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "flate2",
  "reqwest 0.12.28",

--- a/apps/geolibre-desktop/src-tauri/Cargo.toml
+++ b/apps/geolibre-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-desktop"
-version = "0.8.0"
+version = "0.9.0"
 description = "GeoLibre Desktop — lightweight cloud-native desktop GIS"
 authors = ["GeoLibre Contributors"]
 edition = "2021"

--- a/apps/geolibre-desktop/src-tauri/tauri.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "GeoLibre Desktop",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "identifier": "org.geolibre.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/backend/geolibre_server/pyproject.toml
+++ b/backend/geolibre_server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geolibre-server"
-version = "0.8.0"
+version = "0.9.0"
 description = "Optional Python processing sidecar for GeoLibre Desktop"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,8 +1,8 @@
-# GeoLibre Desktop Architecture
+# GeoLibre Architecture
 
 ## Overview
 
-GeoLibre Desktop is an npm workspaces monorepo. The UI is a React app hosted by Tauri v2. Map rendering uses MapLibre GL JS in the browser webview, with deck.gl used for advanced raster, point cloud, and 3D overlays. Application state lives in a Zustand store (`@geolibre/core`).
+GeoLibre is a lightweight, cloud-native GIS platform that runs across desktop, mobile, and web environments from a single npm workspaces monorepo. The UI is a React app that ships as a native desktop app hosted by Tauri v2 and as a browser-based web app, adapting responsively to mobile and small screens. Map rendering uses MapLibre GL JS in the browser webview, with deck.gl used for advanced raster, point cloud, and 3D overlays. Application state lives in a Zustand store (`@geolibre/core`).
 
 ```mermaid
 flowchart LR

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-GeoLibre Desktop is an npm workspaces monorepo. The main app lives in `apps/geolibre-desktop` and is built with Tauri, React, TypeScript, and MapLibre GL JS.
+GeoLibre is a lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data across desktop, mobile, and web environments. It is an npm workspaces monorepo: the main app lives in `apps/geolibre-desktop` and is built with Tauri, React, TypeScript, and MapLibre GL JS. The same workspace runs as a native desktop app and as a browser-based web app, and adapts responsively to mobile and small screens.
 
 ## Prerequisites
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,13 +5,13 @@ hide:
 
 <section class="hero">
   <div class="hero__content">
-    <p class="eyebrow">Cloud-native desktop GIS</p>
-    <h1>MapLibre-powered GIS for local projects and modern geospatial workflows.</h1>
+    <p class="eyebrow">Cloud-native GIS platform</p>
+    <h1>A lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data.</h1>
     <p class="hero__lead">
-      GeoLibre is a lightweight desktop GIS prototype built with Tauri, React,
-      TypeScript, MapLibre GL JS, DuckDB-WASM Spatial, and deck.gl. It focuses
-      on fast local data work, project files, styling, plugins, and a practical
-      path toward cloud-native geospatial workflows.
+      GeoLibre is built with Tauri, React, TypeScript, MapLibre GL JS,
+      DuckDB-WASM Spatial, and deck.gl. The same workspace runs across desktop,
+      mobile, and web environments, with fast local and cloud-native data work,
+      project files, styling, plugins, and modern geospatial workflows.
     </p>
     <div class="hero__actions">
       <a class="md-button md-button--primary" href="https://viewer.geolibre.app/">Open live demo</a>
@@ -20,7 +20,7 @@ hide:
     </div>
   </div>
   <figure class="hero__media">
-    <img src="https://files.opengeos.org/GeoLibre-demo.webp" alt="GeoLibre map interface showing the desktop GIS workspace">
+    <img src="https://files.opengeos.org/GeoLibre-demo.webp" alt="GeoLibre map interface showing the GIS workspace">
   </figure>
 </section>
 
@@ -43,7 +43,7 @@ Load local vector data supported by DuckDB-WASM Spatial, add web tile and servic
 <div class="feature-card" markdown>
 ### Plugin-ready UI
 
-Built-in plugins cover basemaps, sample data, layer control, MapLibre components, swipe, street view, time slider, LiDAR, GeoAgent, and GeoEditor integrations.
+Built-in plugins cover basemaps, sample data, layer control, MapLibre components, swipe, street view, time slider, Overture Maps, LiDAR, GeoAgent, and GeoEditor integrations.
 </div>
 
 <div class="feature-card" markdown>

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,4 +1,4 @@
-# GeoLibre Desktop Roadmap
+# GeoLibre Roadmap
 
 ## v0.1: Map viewer and GeoJSON
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: GeoLibre
-site_description: Lightweight, cloud-native desktop GIS built with Tauri, React, TypeScript, and MapLibre GL JS.
+site_description: A lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data across desktop, mobile, and web environments.
 site_url: https://geolibre.app
 repo_name: opengeos/GeoLibre
 repo_url: https://github.com/opengeos/GeoLibre

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolibre",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolibre",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "workspaces": [
         "apps/*",
         "packages/*",
@@ -21,7 +21,7 @@
       }
     },
     "apps/geolibre-desktop": {
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "@carbonplan/zarr-layer": "^0.5.0",
         "@deck.gl/core": "^9.3.2",
@@ -14604,7 +14604,7 @@
     },
     "packages/core": {
       "name": "@geolibre/core",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "uuid": "^11.1.0",
         "zustand": "^5.0.3"
@@ -14616,7 +14616,7 @@
     },
     "packages/map": {
       "name": "@geolibre/map",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "@geolibre/core": "*",
         "@turf/bbox": "^7.2.0",
@@ -14640,7 +14640,7 @@
     },
     "packages/plugins": {
       "name": "@geolibre/plugins",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "@carbonplan/zarr-layer": "^0.5.0",
         "@deck.gl/core": "^9.3.2",
@@ -14777,7 +14777,7 @@
     },
     "packages/processing": {
       "name": "@geolibre/processing",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "@geolibre/core": "*",
         "@turf/bbox": "^7.2.0"
@@ -14789,7 +14789,7 @@
     },
     "packages/ui": {
       "name": "@geolibre/ui",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-dropdown-menu": "^2.1.6",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "geolibre",
   "private": true,
-  "version": "0.8.0",
-  "description": "GeoLibre Desktop — lightweight cloud-native desktop GIS",
+  "version": "0.9.0",
+  "description": "GeoLibre: a lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data across desktop, mobile, and web environments",
   "workspaces": [
     "apps/*",
     "packages/*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/core",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/map",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/plugins",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/processing/package.json
+++ b/packages/processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/processing",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/ui",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",


### PR DESCRIPTION
## Summary
- Bump every workspace manifest and lockfile (root, desktop app, Tauri crate, backend, and packages) from 0.8.0 to 0.9.0 so the app version matches the documented v0.9.0 release
- Reframe the README and docs around the cloud-native GIS platform positioning for visualizing, exploring, and analyzing geospatial data across desktop, mobile, and web environments
- Refresh the README feature list to cover current v0.9.0 capabilities (cloud data integrations, SQL Workspace, Controls/Print/Project menus, Conversion, Time Slider, responsive layout, browser deployment)

## Test plan
- [x] pre-commit run --all-files passes (including npm build)
- [ ] Confirm the version shows as 0.9.0 in the desktop About dialog
- [ ] Confirm docs render correctly with the updated messaging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released version 0.9.0 across the product and packages.

* **Documentation**
  * Rebranded to “GeoLibre” and repositioned as a cloud-native GIS platform for desktop, web, and mobile.
  * Consolidated and expanded feature docs: responsive UI/panels, richer map controls and layer interactions, improved data loading/refresh and SQL Workspace result behavior, enhanced conversion/tooling options, expanded plugin system (Time Slider noted), and clearer browser deployment/embed guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->