### PR TITLE
docs: refine tagline to position mobile as responsive layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GeoLibre
 
-A lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data across desktop, mobile, and web environments.
+A lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data across desktop and web environments, with a responsive layout for mobile screens.
 
 GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS**, **DuckDB-WASM Spatial**, and **deck.gl**. The same workspace runs as a native desktop app, in any modern web browser, and adapts responsively to mobile and small screens.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-GeoLibre is a lightweight, cloud-native GIS platform that runs across desktop, mobile, and web environments from a single npm workspaces monorepo. The UI is a React app that ships as a native desktop app hosted by Tauri v2 and as a browser-based web app, adapting responsively to mobile and small screens. Map rendering uses MapLibre GL JS in the browser webview, with deck.gl used for advanced raster, point cloud, and 3D overlays. Application state lives in a Zustand store (`@geolibre/core`).
+GeoLibre is a lightweight, cloud-native GIS platform that runs across desktop and web environments, with a responsive layout for mobile screens, from a single npm workspaces monorepo. The UI is a React app that ships as a native desktop app hosted by Tauri v2 and as a browser-based web app, adapting responsively to mobile and small screens. Map rendering uses MapLibre GL JS in the browser webview, with deck.gl used for advanced raster, point cloud, and 3D overlays. Application state lives in a Zustand store (`@geolibre/core`).
 
 ```mermaid
 flowchart LR

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-GeoLibre is a lightweight, cloud-native GIS platform that runs across desktop and web environments, with a responsive layout for mobile screens, from a single npm workspaces monorepo. The UI is a React app that ships as a native desktop app hosted by Tauri v2 and as a browser-based web app, adapting responsively to mobile and small screens. Map rendering uses MapLibre GL JS in the browser webview, with deck.gl used for advanced raster, point cloud, and 3D overlays. Application state lives in a Zustand store (`@geolibre/core`).
+GeoLibre is a lightweight, cloud-native GIS platform that runs across desktop and web environments, with a responsive layout for mobile screens, all from a single npm workspaces monorepo. The UI is a React app that ships as a native desktop app hosted by Tauri v2 and as a browser-based web app, adapting responsively to mobile and small screens. Map rendering uses MapLibre GL JS in the browser webview, with deck.gl used for advanced raster, point cloud, and 3D overlays. Application state lives in a Zustand store (`@geolibre/core`).
 
 ```mermaid
 flowchart LR

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-GeoLibre is a lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data across desktop, mobile, and web environments. It is an npm workspaces monorepo: the main app lives in `apps/geolibre-desktop` and is built with Tauri, React, TypeScript, and MapLibre GL JS. The same workspace runs as a native desktop app and as a browser-based web app, and adapts responsively to mobile and small screens.
+GeoLibre is a lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data across desktop and web environments, with a responsive layout for mobile screens. It is an npm workspaces monorepo: the main app lives in `apps/geolibre-desktop` and is built with Tauri, React, TypeScript, and MapLibre GL JS. The same workspace runs as a native desktop app and as a browser-based web app, and adapts responsively to mobile and small screens.
 
 ## Prerequisites
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ hide:
     <p class="hero__lead">
       GeoLibre is built with Tauri, React, TypeScript, MapLibre GL JS,
       DuckDB-WASM Spatial, and deck.gl. The same workspace runs across desktop
-      and web environments, with a responsive layout for mobile screens, fast
+      and web environments, adapting responsively to mobile screens, with fast
       local and cloud-native data work, project files, styling, plugins, and
       modern geospatial workflows.
     </p>

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,9 +9,10 @@ hide:
     <h1>A lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data.</h1>
     <p class="hero__lead">
       GeoLibre is built with Tauri, React, TypeScript, MapLibre GL JS,
-      DuckDB-WASM Spatial, and deck.gl. The same workspace runs across desktop,
-      mobile, and web environments, with fast local and cloud-native data work,
-      project files, styling, plugins, and modern geospatial workflows.
+      DuckDB-WASM Spatial, and deck.gl. The same workspace runs across desktop
+      and web environments, with a responsive layout for mobile screens, fast
+      local and cloud-native data work, project files, styling, plugins, and
+      modern geospatial workflows.
     </p>
     <div class="hero__actions">
       <a class="md-button md-button--primary" href="https://viewer.geolibre.app/">Open live demo</a>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: GeoLibre
-site_description: A lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data across desktop, mobile, and web environments.
+site_description: A lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data across desktop and web environments, with a responsive layout for mobile screens.
 site_url: https://geolibre.app
 repo_name: opengeos/GeoLibre
 repo_url: https://github.com/opengeos/GeoLibre

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "geolibre",
   "private": true,
   "version": "0.9.0",
-  "description": "GeoLibre: a lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data across desktop, mobile, and web environments",
+  "description": "GeoLibre: a lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data across desktop and web environments, with a responsive layout for mobile screens",
   "workspaces": [
     "apps/*",
     "packages/*",


### PR DESCRIPTION
## Summary
- Refine the project tagline to "across desktop and web environments, with a responsive layout for mobile screens", since mobile is a responsive layout rather than a separate native app
- Apply the wording consistently across the README, getting-started and architecture docs, the docs home hero, the mkdocs site description, and the package description

## Test plan
- [x] pre-commit run on changed files passes (including npm build)
- [ ] Confirm docs render correctly with the updated hero and descriptions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified platform messaging across docs and site metadata: GeoLibre is described as supporting desktop and web environments, with a responsive layout for mobile screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->