### PR TITLE
fix: persist external native layer geojson when there is no restorable source URL

### DIFF
--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -321,11 +321,32 @@ export function projectFromStore(state: {
   };
 }
 
+// An external native layer can drop its persisted `geojson` only if its
+// features can be reconstructed on reopen, i.e. it has a fetchable source URL
+// (the Add Vector Layer / WFS / geojson-url cases). Layers loaded from local
+// files or built in-memory (e.g. the Annotate Geocodes control) have no such
+// URL, so the persisted `geojson` is their ONLY copy and must be kept.
+function hasRestorableSourceUrl(layer: GeoLibreLayer): boolean {
+  const sourceUrl = layer.source.url;
+  const originalUrl = layer.metadata.originalUrl;
+  return (
+    (typeof sourceUrl === "string" && sourceUrl.trim() !== "") ||
+    (typeof originalUrl === "string" && originalUrl.trim() !== "")
+  );
+}
+
 function prepareLayerForSave(layer: GeoLibreLayer): GeoLibreLayer {
-  // Vector layers owned by the Add Vector Layer control restore their features
-  // from their source URL/file, so any `geojson` read back from the map for the
-  // attribute table is redundant in a saved project and would only bloat it.
-  if (layer.metadata.externalNativeLayer === true && layer.geojson) {
+  // External native layers that restore their features from a source URL keep
+  // a `geojson` copy on the map only for the attribute table; it is redundant
+  // in a saved project and would only bloat it, so strip it. Layers without a
+  // restorable URL (local-file or in-memory) keep their `geojson` because it is
+  // the sole copy GeoLibre's restore path (`ensureExternalGeoJsonNativeLayer`)
+  // re-renders from.
+  if (
+    layer.metadata.externalNativeLayer === true &&
+    layer.geojson &&
+    hasRestorableSourceUrl(layer)
+  ) {
     const { geojson: _geojson, ...rest } = layer;
     layer = rest;
   }

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -6,6 +6,7 @@ import {
   createEmptyProject,
   parseProject,
   projectFromStore,
+  serializeProject,
   useAppStore,
   type GeoLibreLayer,
 } from "@geolibre/core";
@@ -127,6 +128,80 @@ describe("project parsing", () => {
     ]);
     assert.equal(project.layers[0].source.url, "https://tiles.example.com/{z}/{x}/{y}.png");
     assert.equal("resolvedUrl" in project.layers[0].metadata, false);
+  });
+
+  it("drops redundant geojson for external native layers restorable from a source URL", () => {
+    const project = projectFromStore({
+      projectName: "Native URL",
+      mapView: { center: [0, 0], zoom: 2, bearing: 0, pitch: 0 },
+      basemapStyleUrl: DEFAULT_BASEMAP,
+      basemapVisible: true,
+      basemapOpacity: 1,
+      layers: [
+        geojsonLayer({
+          id: "native-url",
+          source: { type: "geojson", url: "https://example.com/data.geojson" },
+          metadata: { externalNativeLayer: true },
+          geojson: {
+            type: "FeatureCollection",
+            features: [
+              {
+                type: "Feature",
+                properties: {},
+                geometry: { type: "Point", coordinates: [1, 2] },
+              },
+            ],
+          },
+        }),
+      ],
+      preferences: createEmptyProject().preferences,
+      metadata: {},
+    });
+
+    assert.equal(project.layers[0].geojson, undefined);
+  });
+
+  it("keeps geojson for external native layers without a restorable source URL", () => {
+    const project = projectFromStore({
+      projectName: "Native File",
+      mapView: { center: [0, 0], zoom: 2, bearing: 0, pitch: 0 },
+      basemapStyleUrl: DEFAULT_BASEMAP,
+      basemapVisible: true,
+      basemapOpacity: 1,
+      layers: [
+        geojsonLayer({
+          id: "native-file",
+          source: { type: "geojson" },
+          metadata: {
+            externalNativeLayer: true,
+            sourceKind: "annotate-geocodes",
+          },
+          geojson: {
+            type: "FeatureCollection",
+            features: [
+              {
+                type: "Feature",
+                properties: {},
+                geometry: { type: "Point", coordinates: [1, 2] },
+              },
+            ],
+          },
+        }),
+      ],
+      preferences: createEmptyProject().preferences,
+      metadata: {},
+    });
+
+    assert.ok(
+      project.layers[0].geojson,
+      "geojson is the only copy for a source-less native layer and must be retained",
+    );
+    assert.equal(project.layers[0].geojson?.features.length, 1);
+
+    // The features must survive the full on-disk round-trip so the restore
+    // path (ensureExternalGeoJsonNativeLayer) can re-render them on reopen.
+    const reopened = parseProject(serializeProject(project));
+    assert.equal(reopened.layers[0].geojson?.features.length, 1);
   });
 });
 


### PR DESCRIPTION
## Problem

Layers added by external-native-layer plugins (e.g. loading a dataset from a local directory) are listed in the Layers panel after reopening a saved project, but they do not render on the map.

## Root cause

`prepareLayerForSave` strips `geojson` from **every** layer tagged `metadata.externalNativeLayer === true`, on the assumption that the owning control restores its features from a source URL/file:

```ts
if (layer.metadata.externalNativeLayer === true && layer.geojson) {
  const { geojson: _geojson, ...rest } = layer;
  layer = rest;
}
```

But the restore path, `ensureExternalGeoJsonNativeLayer` (`packages/map/src/layer-sync.ts`), re-renders these layers **from** `layer.geojson` and bails immediately when it is missing:

```ts
if (!layer.geojson) return;
```

Layers loaded from local files or built in-memory have no fetchable source URL, so the persisted `geojson` is their **only** copy. Stripping it restores the layer entry to the store (hence the panel row) but leaves no data for the map → nothing renders. The Add Vector Layer control's `serializableVectorState` does not embed feature data either, so file-backed vector layers had the same latent data loss.

## Fix

Strip `geojson` only when the layer has a restorable source URL (`source.url` or `metadata.originalUrl`); otherwise keep it. This preserves the size optimization for URL/WFS-backed layers while retaining the sole data copy for source-less ones.

## Tests

- `drops redundant geojson for external native layers restorable from a source URL` — locks the optimization.
- `keeps geojson for external native layers without a restorable source URL` — the fix, including a full `serializeProject` → `parseProject` round-trip proving features survive to disk and back.
- Full frontend suite: 139/139 passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed layer data handling during project saves for external native layers. The system now intelligently preserves GeoJSON data when source URLs are unavailable, while removing redundant data when sources are restorable.

* **Tests**
  * Added comprehensive test coverage for GeoJSON retention and removal behavior during project serialization and parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->