### PR TITLE
chore: upgrade maplibre-gl-geo-editor to 0.8.0 and drop import workaround

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -44,7 +44,7 @@
     "maplibre-gl-enviroatlas": "^0.1.1",
     "maplibre-gl-esri-wayback": "^0.1.0",
     "maplibre-gl-fema-wms": "^0.1.2",
-    "maplibre-gl-geo-editor": "^0.7.3",
+    "maplibre-gl-geo-editor": "^0.8.0",
     "maplibre-gl-geoagent": "^0.4.2",
     "maplibre-gl-lidar": "^0.14.1",
     "maplibre-gl-nasa-earthdata": "^0.1.2",

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -141,6 +141,7 @@ export function DesktopShell({
   const mapControllerRef = useRef<MapController | null>(null);
   const dragDepthRef = useRef(0);
   const dropMessageTimeoutRef = useRef<number | null>(null);
+  const materializingRef = useRef(false);
   const addGeoJsonLayer = useAppStore((s) => s.addGeoJsonLayer);
   const projectGeneration = useAppStore((s) => s.projectGeneration);
   const geometryEditLayerId = useSyncExternalStore(
@@ -219,11 +220,18 @@ export function DesktopShell({
       const manager = getPluginManager();
       if (!manager.isActive("maplibre-gl-geo-editor")) {
         manager.activate("maplibre-gl-geo-editor", appAPI);
+        if (!manager.isActive("maplibre-gl-geo-editor")) {
+          setDropError(
+            "Could not activate the geometry editor. Try again once the map has fully loaded.",
+          );
+          clearDropMessageLater();
+          return;
+        }
       }
       const started = await startLayerGeometryEdit(appAPI, layerId);
       if (!started) {
         setDropError(
-          "Could not start geometry editing. Try again once the map has loaded.",
+          "Could not start geometry editing for this layer. Its data may still be loading.",
         );
         clearDropMessageLater();
       }
@@ -237,6 +245,9 @@ export function DesktopShell({
 
   const handleMaterializeDuckDBLayer = useCallback(
     async (layer: GeoLibreLayer) => {
+      // Guard against concurrent triggers (double-click, or two layers in quick
+      // succession) so we do not add duplicate materialized layers.
+      if (materializingRef.current) return;
       const query =
         typeof layer.metadata.query === "string" ? layer.metadata.query : null;
       if (!query) {
@@ -244,9 +255,12 @@ export function DesktopShell({
         clearDropMessageLater();
         return;
       }
+      materializingRef.current = true;
       setDropError(null);
       setDropMessage("Materializing DuckDB layer...");
       try {
+        // The query is the layer's own stored SQL from the user's project; it is
+        // intentionally run unrestricted against the in-memory DuckDB instance.
         const result = await runSqlQuery(query, useAppStore.getState().layers);
         if (!result.geojson) {
           throw new Error("The query did not return a geometry column.");
@@ -267,6 +281,7 @@ export function DesktopShell({
             : "Could not materialize this layer.",
         );
       } finally {
+        materializingRef.current = false;
         clearDropMessageLater();
       }
     },

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -142,6 +142,7 @@ export function DesktopShell({
   const dragDepthRef = useRef(0);
   const dropMessageTimeoutRef = useRef<number | null>(null);
   const materializingRef = useRef(false);
+  const togglingGeometryEditRef = useRef(false);
   const addGeoJsonLayer = useAppStore((s) => s.addGeoJsonLayer);
   const projectGeneration = useAppStore((s) => s.projectGeneration);
   const geometryEditLayerId = useSyncExternalStore(
@@ -210,37 +211,47 @@ export function DesktopShell({
     async (layerId: string) => {
       const appAPI = createAppAPI(mapControllerRef);
       if (getGeometryEditTargetLayerId() === layerId) {
-        endLayerGeometryEdit(appAPI, { save: true });
+        await endLayerGeometryEdit(appAPI, { save: true });
         return;
       }
-      // Add Vector Layer (geojson-mode) layers keep their features in a MapLibre
-      // source rather than in `layer.geojson`. Read them back once so the editor
-      // has features to load. (Plain geojson layers already have `geojson`.)
-      await ensureLayerGeojsonFromSource(layerId);
-      const manager = getPluginManager();
-      if (!manager.isActive("maplibre-gl-geo-editor")) {
-        manager.activate("maplibre-gl-geo-editor", appAPI);
+      // Guard against concurrent invocations: this handler awaits before it sets
+      // the session target, so two rapid clicks could otherwise both pass the
+      // check above and race into startLayerGeometryEdit for different layers.
+      if (togglingGeometryEditRef.current) return;
+      togglingGeometryEditRef.current = true;
+      try {
+        // Add Vector Layer (geojson-mode) layers keep their features in a
+        // MapLibre source rather than in `layer.geojson`. Read them back once so
+        // the editor has features to load. (Plain geojson layers already have
+        // `geojson`.)
+        await ensureLayerGeojsonFromSource(layerId);
+        const manager = getPluginManager();
         if (!manager.isActive("maplibre-gl-geo-editor")) {
+          manager.activate("maplibre-gl-geo-editor", appAPI);
+          if (!manager.isActive("maplibre-gl-geo-editor")) {
+            setDropError(
+              "Could not activate the geometry editor. Try again once the map has fully loaded.",
+            );
+            clearDropMessageLater();
+            return;
+          }
+        }
+        const started = await startLayerGeometryEdit(appAPI, layerId);
+        if (!started) {
           setDropError(
-            "Could not activate the geometry editor. Try again once the map has fully loaded.",
+            "Could not start geometry editing for this layer. Its data may still be loading.",
           );
           clearDropMessageLater();
-          return;
         }
-      }
-      const started = await startLayerGeometryEdit(appAPI, layerId);
-      if (!started) {
-        setDropError(
-          "Could not start geometry editing for this layer. Its data may still be loading.",
-        );
-        clearDropMessageLater();
+      } finally {
+        togglingGeometryEditRef.current = false;
       }
     },
     [clearDropMessageLater, ensureLayerGeojsonFromSource],
   );
 
   const handleCancelGeometryEdit = useCallback(() => {
-    endLayerGeometryEdit(createAppAPI(mapControllerRef), { save: false });
+    void endLayerGeometryEdit(createAppAPI(mapControllerRef), { save: false });
   }, []);
 
   const handleMaterializeDuckDBLayer = useCallback(

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -220,7 +220,7 @@ export function DesktopShell({
       if (!manager.isActive("maplibre-gl-geo-editor")) {
         manager.activate("maplibre-gl-geo-editor", appAPI);
       }
-      const started = startLayerGeometryEdit(appAPI, layerId);
+      const started = await startLayerGeometryEdit(appAPI, layerId);
       if (!started) {
         setDropError(
           "Could not start geometry editing. Try again once the map has loaded.",

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -186,8 +186,14 @@ export function DesktopShell({
     if (!manager.isActive("maplibre-gl-geo-editor")) {
       manager.activate("maplibre-gl-geo-editor", appAPI);
     }
-    startLayerGeometryEdit(appAPI, layerId);
-  }, []);
+    const started = startLayerGeometryEdit(appAPI, layerId);
+    if (!started) {
+      setDropError(
+        "Could not start geometry editing. Try again once the map has loaded.",
+      );
+      clearDropMessageLater();
+    }
+  }, [clearDropMessageLater]);
 
   const handleCancelGeometryEdit = useCallback(() => {
     endLayerGeometryEdit(createAppAPI(mapControllerRef), { save: false });

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -1,4 +1,5 @@
 import { useAppStore, type GeoLibreLayer } from "@geolibre/core";
+import type { FeatureCollection } from "geojson";
 import type { MapController, MapDiagnosticEvent } from "@geolibre/map";
 import { MapCanvas } from "@geolibre/map";
 import {
@@ -176,24 +177,59 @@ export function DesktopShell({
     }, 4000);
   }, []);
 
-  const handleToggleGeometryEdit = useCallback((layerId: string) => {
-    const appAPI = createAppAPI(mapControllerRef);
-    if (getGeometryEditTargetLayerId() === layerId) {
-      endLayerGeometryEdit(appAPI, { save: true });
-      return;
+  const ensureLayerGeojsonFromSource = useCallback(async (layerId: string) => {
+    const layer = useAppStore
+      .getState()
+      .layers.find((candidate) => candidate.id === layerId);
+    if (!layer || layer.geojson) return;
+    const sourceIds = layer.metadata.sourceIds;
+    const sourceId = Array.isArray(sourceIds) ? sourceIds[0] : undefined;
+    if (typeof sourceId !== "string") return;
+    const source = mapControllerRef.current?.getMap()?.getSource(sourceId) as
+      | { getData?: () => Promise<unknown> }
+      | undefined;
+    if (!source || typeof source.getData !== "function") return;
+    try {
+      const data = await source.getData();
+      if (
+        data &&
+        typeof data === "object" &&
+        (data as { type?: string }).type === "FeatureCollection"
+      ) {
+        useAppStore
+          .getState()
+          .updateLayer(layerId, { geojson: data as FeatureCollection });
+      }
+    } catch {
+      // Best effort; startLayerGeometryEdit will fail and surface an error.
     }
-    const manager = getPluginManager();
-    if (!manager.isActive("maplibre-gl-geo-editor")) {
-      manager.activate("maplibre-gl-geo-editor", appAPI);
-    }
-    const started = startLayerGeometryEdit(appAPI, layerId);
-    if (!started) {
-      setDropError(
-        "Could not start geometry editing. Try again once the map has loaded.",
-      );
-      clearDropMessageLater();
-    }
-  }, [clearDropMessageLater]);
+  }, []);
+
+  const handleToggleGeometryEdit = useCallback(
+    async (layerId: string) => {
+      const appAPI = createAppAPI(mapControllerRef);
+      if (getGeometryEditTargetLayerId() === layerId) {
+        endLayerGeometryEdit(appAPI, { save: true });
+        return;
+      }
+      // Add Vector Layer (geojson-mode) layers keep their features in a MapLibre
+      // source rather than in `layer.geojson`. Read them back once so the editor
+      // has features to load. (Plain geojson layers already have `geojson`.)
+      await ensureLayerGeojsonFromSource(layerId);
+      const manager = getPluginManager();
+      if (!manager.isActive("maplibre-gl-geo-editor")) {
+        manager.activate("maplibre-gl-geo-editor", appAPI);
+      }
+      const started = startLayerGeometryEdit(appAPI, layerId);
+      if (!started) {
+        setDropError(
+          "Could not start geometry editing. Try again once the map has loaded.",
+        );
+        clearDropMessageLater();
+      }
+    },
+    [clearDropMessageLater, ensureLayerGeojsonFromSource],
+  );
 
   const handleCancelGeometryEdit = useCallback(() => {
     endLayerGeometryEdit(createAppAPI(mapControllerRef), { save: false });

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -1,10 +1,14 @@
-import { useAppStore } from "@geolibre/core";
+import { useAppStore, type GeoLibreLayer } from "@geolibre/core";
 import type { MapController, MapDiagnosticEvent } from "@geolibre/map";
 import { MapCanvas } from "@geolibre/map";
 import {
+  endLayerGeometryEdit,
+  getGeometryEditTargetLayerId,
   restoreRasterLayers,
   restoreThreeDTilesLayers,
   restoreVectorLayers,
+  startLayerGeometryEdit,
+  subscribeGeometryEdit,
 } from "@geolibre/plugins";
 import {
   type CSSProperties,
@@ -16,7 +20,9 @@ import {
   useEffect,
   useRef,
   useState,
+  useSyncExternalStore,
 } from "react";
+import { runSqlQuery } from "../../lib/sql-workspace";
 import {
   isTauri,
   loadDroppedVectorFiles,
@@ -136,6 +142,10 @@ export function DesktopShell({
   const dropMessageTimeoutRef = useRef<number | null>(null);
   const addGeoJsonLayer = useAppStore((s) => s.addGeoJsonLayer);
   const projectGeneration = useAppStore((s) => s.projectGeneration);
+  const geometryEditLayerId = useSyncExternalStore(
+    subscribeGeometryEdit,
+    getGeometryEditTargetLayerId,
+  );
   const [isDraggingFiles, setIsDraggingFiles] = useState(false);
   const [mapReadyGeneration, setMapReadyGeneration] = useState(0);
   const [dropMessage, setDropMessage] = useState<string | null>(null);
@@ -165,6 +175,61 @@ export function DesktopShell({
       setDropError(null);
     }, 4000);
   }, []);
+
+  const handleToggleGeometryEdit = useCallback((layerId: string) => {
+    const appAPI = createAppAPI(mapControllerRef);
+    if (getGeometryEditTargetLayerId() === layerId) {
+      endLayerGeometryEdit(appAPI, { save: true });
+      return;
+    }
+    const manager = getPluginManager();
+    if (!manager.isActive("maplibre-gl-geo-editor")) {
+      manager.activate("maplibre-gl-geo-editor", appAPI);
+    }
+    startLayerGeometryEdit(appAPI, layerId);
+  }, []);
+
+  const handleCancelGeometryEdit = useCallback(() => {
+    endLayerGeometryEdit(createAppAPI(mapControllerRef), { save: false });
+  }, []);
+
+  const handleMaterializeDuckDBLayer = useCallback(
+    async (layer: GeoLibreLayer) => {
+      const query =
+        typeof layer.metadata.query === "string" ? layer.metadata.query : null;
+      if (!query) {
+        setDropError("This DuckDB layer has no stored query to materialize.");
+        clearDropMessageLater();
+        return;
+      }
+      setDropError(null);
+      setDropMessage("Materializing DuckDB layer...");
+      try {
+        const result = await runSqlQuery(query, useAppStore.getState().layers);
+        if (!result.geojson) {
+          throw new Error("The query did not return a geometry column.");
+        }
+        const id = addGeoJsonLayer(`${layer.name} (editable)`, result.geojson);
+        const created = useAppStore
+          .getState()
+          .layers.find((candidate) => candidate.id === id);
+        if (created) mapControllerRef.current?.fitLayer(created);
+        setDropMessage(
+          `Materialized ${result.geojson.features.length.toLocaleString()} features.`,
+        );
+      } catch (error) {
+        setDropMessage(null);
+        setDropError(
+          error instanceof Error
+            ? error.message
+            : "Could not materialize this layer.",
+        );
+      } finally {
+        clearDropMessageLater();
+      }
+    },
+    [addGeoJsonLayer, clearDropMessageLater],
+  );
 
   useEffect(() => {
     if (isTauri()) {
@@ -521,6 +586,10 @@ export function DesktopShell({
           <LayerPanel
             mapControllerRef={mapControllerRef}
             onResizeStart={startLayerPanelResize}
+            geometryEditLayerId={geometryEditLayerId}
+            onToggleGeometryEdit={handleToggleGeometryEdit}
+            onCancelGeometryEdit={handleCancelGeometryEdit}
+            onMaterializeDuckDBLayer={handleMaterializeDuckDBLayer}
           />
         ) : null}
         <main

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -219,6 +219,8 @@ export function DesktopShell({
       // check above and race into startLayerGeometryEdit for different layers.
       if (togglingGeometryEditRef.current) return;
       togglingGeometryEditRef.current = true;
+      // Clear any stale error from a previous failed attempt.
+      setDropError(null);
       try {
         // Add Vector Layer (geojson-mode) layers keep their features in a
         // MapLibre source rather than in `layer.geojson`. Read them back once so

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -5,6 +5,8 @@ import {
 } from "@geolibre/core";
 import {
   getDuckDBLayerRows,
+  getGeometryEditTargetLayerId,
+  subscribeGeometryEdit,
   updateDuckDBLayerRows,
   type DuckDBAttributeRow,
 } from "@geolibre/plugins";
@@ -43,6 +45,7 @@ import {
   useEffect,
   useRef,
   useState,
+  useSyncExternalStore,
 } from "react";
 import {
   isTauri,
@@ -312,6 +315,14 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
   // Edits made here would neither redraw on the map nor survive a save, so the
   // attribute table is read-only for them.
   const isReadOnlyVectorLayer = geojsonVectorSourceId(layer) !== null;
+  // While this layer's geometry is being edited in place, attribute edits would
+  // race the editor's geometry write-back, so the inline editor is disabled.
+  const geometryEditLayerId = useSyncExternalStore(
+    subscribeGeometryEdit,
+    getGeometryEditTargetLayerId,
+  );
+  const isGeometryEditing =
+    layer != null && geometryEditLayerId === layer.id;
 
   // Vector layers added via the Add Vector Layer control keep their features in
   // a MapLibre GeoJSON source rather than in `layer.geojson`. Read the data back
@@ -376,7 +387,7 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
   useEffect(() => {
     setIsEditing(false);
     setDrafts({});
-  }, [selectedLayerId, hasLayer]);
+  }, [selectedLayerId, hasLayer, isGeometryEditing]);
 
   const filterLower = attributeFilter.toLowerCase();
   const filtered = attributeRows.filter(({ properties, featureId }) => {
@@ -806,15 +817,17 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
           size="sm"
           className="ml-auto h-7 px-2"
           title={
-            isReadOnlyVectorLayer
-              ? "Editing is not available for Add Vector Layer layers"
-              : isEditing
-                ? hasEdits
-                  ? "Use Save or Cancel to finish editing"
-                  : "Exit edit mode"
-                : isDuckDBLayer
-                  ? "Edit displayed DuckDB query attributes in memory"
-                  : "Edit attribute values"
+            isGeometryEditing
+              ? "Finish geometry editing to edit attributes"
+              : isReadOnlyVectorLayer
+                ? "Editing is not available for Add Vector Layer layers"
+                : isEditing
+                  ? hasEdits
+                    ? "Use Save or Cancel to finish editing"
+                    : "Exit edit mode"
+                  : isDuckDBLayer
+                    ? "Edit displayed DuckDB query attributes in memory"
+                    : "Edit attribute values"
           }
           aria-label={
             isEditing && !hasEdits ? "Exit edit mode" : "Edit attribute values"
@@ -822,6 +835,7 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
           disabled={
             !hasAttributeSource ||
             isReadOnlyVectorLayer ||
+            isGeometryEditing ||
             (isEditing && hasEdits)
           }
           onClick={toggleEditing}

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -752,37 +752,6 @@ export function LayerPanel({
                   >
                     <MousePointerClick className="h-3.5 w-3.5" />
                   </Button>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className={`h-7 w-7 ${
-                      geometryEditActive
-                        ? "border border-primary bg-primary text-primary-foreground shadow-sm hover:bg-primary/90 hover:text-primary-foreground"
-                        : ""
-                    }`}
-                    title={
-                      canEditGeometry
-                        ? geometryEditActive
-                          ? "Finish geometry editing (saves)"
-                          : "Edit geometry"
-                        : "Geometry editing is only available for in-memory vector layers"
-                    }
-                    aria-label={
-                      geometryEditActive
-                        ? "Finish geometry editing"
-                        : "Edit geometry"
-                    }
-                    disabled={!canEditGeometry || geometryEditElsewhere}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      if (!canEditGeometry) return;
-                      selectLayer(layer.id);
-                      if (identifyActive) setIdentifyLayer(null);
-                      onToggleGeometryEdit(layer.id);
-                    }}
-                  >
-                    <PencilRuler className="h-3.5 w-3.5" />
-                  </Button>
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
                       <Button
@@ -817,6 +786,22 @@ export function LayerPanel({
                           </DropdownMenuItem>
                           <DropdownMenuSeparator />
                         </>
+                      )}
+                      {(canEditGeometry || geometryEditActive) && (
+                        <DropdownMenuItem
+                          disabled={geometryEditElsewhere}
+                          onSelect={(e) => {
+                            e.preventDefault();
+                            selectLayer(layer.id);
+                            if (identifyActive) setIdentifyLayer(null);
+                            onToggleGeometryEdit(layer.id);
+                          }}
+                        >
+                          <PencilRuler className="mr-2 h-3.5 w-3.5" />
+                          {geometryEditActive
+                            ? "Finish editing geometry"
+                            : "Edit geometry"}
+                        </DropdownMenuItem>
                       )}
                       <DropdownMenuItem
                         disabled={!canRefresh || isRefreshing}

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import { isDuckDBQueryLayer, useAppStore } from "@geolibre/core";
 import type { GeoLibreLayer } from "@geolibre/core";
+import { canEditLayerGeometry } from "@geolibre/plugins";
 import type { MapController } from "@geolibre/map";
 import { isPlaceholderLayer, placeholderMessage } from "@geolibre/map";
 import {
@@ -42,7 +43,9 @@ import {
   MousePointerClick,
   PanelLeftClose,
   PanelLeftOpen,
+  PencilRuler,
   RefreshCw,
+  Table2,
   Timer,
   Trash2,
   ZoomIn,
@@ -58,6 +61,14 @@ import {
 interface LayerPanelProps {
   mapControllerRef: RefObject<MapController | null>;
   onResizeStart: (event: ReactMouseEvent<HTMLDivElement>) => void;
+  /** Id of the layer currently in a geometry-edit session, or null. */
+  geometryEditLayerId: string | null;
+  /** Toggle in-place geometry editing for a layer (toggling off saves). */
+  onToggleGeometryEdit: (layerId: string) => void;
+  /** Discard the active geometry-edit session without saving. */
+  onCancelGeometryEdit: () => void;
+  /** Materialize a DuckDB query layer into an editable GeoJSON layer. */
+  onMaterializeDuckDBLayer: (layer: GeoLibreLayer) => void;
 }
 
 const BACKGROUND_SELECTION_ID = "__geolibre-background__";
@@ -129,6 +140,10 @@ function isMobileViewport(): boolean {
 export function LayerPanel({
   mapControllerRef,
   onResizeStart,
+  geometryEditLayerId,
+  onToggleGeometryEdit,
+  onCancelGeometryEdit,
+  onMaterializeDuckDBLayer,
 }: LayerPanelProps) {
   const layers = useAppStore((s) => s.layers);
   const selectedLayerId = useAppStore((s) => s.selectedLayerId);
@@ -525,6 +540,13 @@ export function LayerPanel({
                 layer.metadata.tileType === "vector") ||
               hasNativeIdentifyLayers(layer);
             const identifyActive = identifyLayerId === layer.id;
+            const canEditGeometry = canEditLayerGeometry(layer);
+            const geometryEditActive = geometryEditLayerId === layer.id;
+            const geometryEditElsewhere =
+              geometryEditLayerId !== null && !geometryEditActive;
+            const canMaterializeDuckDB =
+              isDuckDBQueryLayer(layer) &&
+              typeof layer.metadata.query === "string";
             const canRefresh = isRefreshableLayer(layer);
             const refreshConfig = getLayerRefreshConfig(layer);
             const refreshStatus = refreshStatuses[layer.id];
@@ -610,6 +632,38 @@ export function LayerPanel({
                     {refreshStatus.message}
                   </p>
                 )}
+                {geometryEditActive && (
+                  <div className="mt-1 flex items-center gap-1 rounded-sm bg-primary/10 px-1.5 py-1">
+                    <PencilRuler className="h-3 w-3 text-primary" />
+                    <span className="flex-1 text-[10px] font-medium text-primary">
+                      Editing geometry
+                    </span>
+                    <Button
+                      variant="default"
+                      size="sm"
+                      className="h-6 px-2 text-[10px]"
+                      title="Save geometry edits"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onToggleGeometryEdit(layer.id);
+                      }}
+                    >
+                      Save
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-6 px-2 text-[10px]"
+                      title="Discard geometry edits"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onCancelGeometryEdit();
+                      }}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                )}
                 <div className="mt-2 flex items-center gap-1">
                   <span className="text-[10px] text-muted-foreground">
                     Opacity
@@ -688,7 +742,7 @@ export function LayerPanel({
                           : "Identify features"
                         : "Identify is only available for vector and WMS layers"
                     }
-                    disabled={!canIdentify}
+                    disabled={!canIdentify || geometryEditActive}
                     onClick={(e) => {
                       e.stopPropagation();
                       if (!canIdentify) return;
@@ -697,6 +751,37 @@ export function LayerPanel({
                     }}
                   >
                     <MousePointerClick className="h-3.5 w-3.5" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className={`h-7 w-7 ${
+                      geometryEditActive
+                        ? "border border-primary bg-primary text-primary-foreground shadow-sm hover:bg-primary/90 hover:text-primary-foreground"
+                        : ""
+                    }`}
+                    title={
+                      canEditGeometry
+                        ? geometryEditActive
+                          ? "Finish geometry editing (saves)"
+                          : "Edit geometry"
+                        : "Geometry editing is only available for in-memory vector layers"
+                    }
+                    aria-label={
+                      geometryEditActive
+                        ? "Finish geometry editing"
+                        : "Edit geometry"
+                    }
+                    disabled={!canEditGeometry || geometryEditElsewhere}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (!canEditGeometry) return;
+                      selectLayer(layer.id);
+                      if (identifyActive) setIdentifyLayer(null);
+                      onToggleGeometryEdit(layer.id);
+                    }}
+                  >
+                    <PencilRuler className="h-3.5 w-3.5" />
                   </Button>
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
@@ -719,6 +804,20 @@ export function LayerPanel({
                       align="end"
                       onClick={(e) => e.stopPropagation()}
                     >
+                      {canMaterializeDuckDB && (
+                        <>
+                          <DropdownMenuItem
+                            onSelect={(e) => {
+                              e.preventDefault();
+                              onMaterializeDuckDBLayer(layer);
+                            }}
+                          >
+                            <Table2 className="mr-2 h-3.5 w-3.5" />
+                            Materialize to editable layer
+                          </DropdownMenuItem>
+                          <DropdownMenuSeparator />
+                        </>
+                      )}
                       <DropdownMenuItem
                         disabled={!canRefresh || isRefreshing}
                         onSelect={(e) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "maplibre-gl-enviroatlas": "^0.1.1",
         "maplibre-gl-esri-wayback": "^0.1.0",
         "maplibre-gl-fema-wms": "^0.1.2",
-        "maplibre-gl-geo-editor": "^0.7.3",
+        "maplibre-gl-geo-editor": "^0.8.0",
         "maplibre-gl-geoagent": "^0.4.2",
         "maplibre-gl-lidar": "^0.14.1",
         "maplibre-gl-nasa-earthdata": "^0.1.2",
@@ -10721,9 +10721,9 @@
       }
     },
     "node_modules/maplibre-gl-geo-editor": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-geo-editor/-/maplibre-gl-geo-editor-0.7.3.tgz",
-      "integrity": "sha512-FpHN9MEZOp16iyuSNVFosCQrRxSLyojPlwuAyj/5/8svwcZsZXDfojGEqe16AgMvV76vJM7505mGDmGRNYeidQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-geo-editor/-/maplibre-gl-geo-editor-0.8.0.tgz",
+      "integrity": "sha512-DiMFYZE+94ztPtCvqbfftbBbfvOa5+qaqs7gpKzUjLRenWT8FhCjzjYsQDfUklePzlm8EMKa6BH/2pr8W+MU8A==",
       "license": "MIT",
       "dependencies": {
         "@turf/turf": "^7.3.4",
@@ -14668,7 +14668,7 @@
         "maplibre-gl-enviroatlas": "^0.1.1",
         "maplibre-gl-esri-wayback": "^0.1.0",
         "maplibre-gl-fema-wms": "^0.1.2",
-        "maplibre-gl-geo-editor": "^0.7.3",
+        "maplibre-gl-geo-editor": "^0.8.0",
         "maplibre-gl-geoagent": "^0.4.2",
         "maplibre-gl-lidar": "^0.14.1",
         "maplibre-gl-nasa-earthdata": "^0.1.2",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -35,7 +35,7 @@
     "maplibre-gl-enviroatlas": "^0.1.1",
     "maplibre-gl-esri-wayback": "^0.1.0",
     "maplibre-gl-fema-wms": "^0.1.2",
-    "maplibre-gl-geo-editor": "^0.7.3",
+    "maplibre-gl-geo-editor": "^0.8.0",
     "maplibre-gl-geoagent": "^0.4.2",
     "maplibre-gl-lidar": "^0.14.1",
     "maplibre-gl-nasa-earthdata": "^0.1.2",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -101,7 +101,14 @@ export {
 export { maplibreEnviroAtlasPlugin } from "./plugins/maplibre-enviroatlas";
 export { maplibreEsriWaybackPlugin } from "./plugins/maplibre-esri-wayback";
 export { maplibreFemaWmsPlugin } from "./plugins/maplibre-fema-wms";
-export { maplibreGeoEditorPlugin } from "./plugins/maplibre-geo-editor";
+export {
+  maplibreGeoEditorPlugin,
+  canEditLayerGeometry,
+  startLayerGeometryEdit,
+  endLayerGeometryEdit,
+  getGeometryEditTargetLayerId,
+  subscribeGeometryEdit,
+} from "./plugins/maplibre-geo-editor";
 export { maplibreGeoAgentPlugin } from "./plugins/maplibre-geoagent";
 export { maplibreLidarPlugin } from "./plugins/maplibre-lidar";
 export { maplibreNasaEarthdataPlugin } from "./plugins/maplibre-nasa-earthdata";

--- a/packages/plugins/src/plugins/geo-editor-geometry.ts
+++ b/packages/plugins/src/plugins/geo-editor-geometry.ts
@@ -37,11 +37,22 @@ export function canEditLayerGeometry(
   layer: GeoLibreLayer | undefined,
 ): boolean {
   if (!layer) return false;
+  // Only geojson-mode vector layers; "vector-tiles" (DuckDB tiles) are excluded.
   if (layer.type !== "geojson") return false;
   if (isDuckDBQueryLayer(layer)) return false;
   if (layer.metadata.sourceKind === SKETCHES_SOURCE_KIND) return false;
-  if (layer.metadata.sourceKind === "maplibre-gl-vector") return false;
-  if (layer.metadata.externalNativeLayer === true) return false;
+
+  if (layer.metadata.externalNativeLayer === true) {
+    // Externally-rendered layers are only editable when they are Add-Vector-Layer
+    // geojson-mode layers, whose features live in a MapLibre GeoJSON source that
+    // can be read and written back. Other external layers are not editable.
+    return (
+      layer.metadata.sourceKind === "maplibre-gl-vector" &&
+      Array.isArray(layer.metadata.sourceIds)
+    );
+  }
+
+  // Plain in-memory geojson layers carry their features in `layer.geojson`.
   return Array.isArray(layer.geojson?.features);
 }
 

--- a/packages/plugins/src/plugins/geo-editor-geometry.ts
+++ b/packages/plugins/src/plugins/geo-editor-geometry.ts
@@ -24,6 +24,49 @@ export const SKETCHES_SOURCE_KIND = "geoeditor-sketches";
 export const GEOMETRY_EDIT_FID_PROPERTY = "__geolibre_fid";
 
 /**
+ * Id of a throwaway feature prepended to the collection loaded into the editor.
+ * Geoman's batch `importGeoJson` silently drops the FIRST feature of every batch
+ * (confirmed empirically: the loss is position-based, not geometry-based), so a
+ * sacrificial first feature absorbs that loss and every real feature is loaded.
+ * It is filtered out again on write-back in case it survives.
+ */
+export const GEOMETRY_EDIT_SACRIFICE_ID = "__geolibre_sacrifice__";
+
+/**
+ * Prepend a sacrificial placeholder feature so Geoman's drop-the-first-feature
+ * batch-import bug consumes the placeholder instead of a real feature.
+ *
+ * @param collection The tagged feature collection about to be loaded.
+ * @returns A collection with the placeholder as its first feature.
+ */
+export function withSacrificialFirstFeature(
+  collection: FeatureCollection,
+): FeatureCollection {
+  const placeholder = {
+    type: "Feature" as const,
+    id: GEOMETRY_EDIT_SACRIFICE_ID,
+    properties: { [GEOMETRY_EDIT_FID_PROPERTY]: GEOMETRY_EDIT_SACRIFICE_ID },
+    // A tiny polygon at null island; same geometry family as typical layers so
+    // Geoman treats it as an ordinary first feature.
+    geometry: {
+      type: "Polygon" as const,
+      coordinates: [
+        [
+          [0, 0],
+          [0, 0.0001],
+          [0.0001, 0.0001],
+          [0, 0],
+        ],
+      ],
+    },
+  };
+  return {
+    type: "FeatureCollection",
+    features: [placeholder, ...collection.features],
+  };
+}
+
+/**
  * Whether a layer's geometry can be edited in place. Mirrors the exclusions the
  * attribute table already applies so the two rules cannot drift: only in-memory
  * geojson vector layers qualify. DuckDB query layers and Add-Vector-Layer
@@ -123,14 +166,25 @@ export function reconcileEditedFeatures(
   const ids = makeIdAllocator();
   return {
     type: "FeatureCollection",
-    features: collection.features.map((feature) => {
-      const properties = {
-        ...(feature.properties ?? {}),
-      } as Record<string, unknown>;
-      const tag = properties[GEOMETRY_EDIT_FID_PROPERTY];
-      delete properties[GEOMETRY_EDIT_FID_PROPERTY];
-      const id = ids.take(tag);
-      return { ...feature, id, properties };
-    }),
+    features: collection.features
+      // Drop the sacrificial placeholder if it survived the import.
+      .filter((feature) => {
+        const tag = (feature.properties as Record<string, unknown> | null)?.[
+          GEOMETRY_EDIT_FID_PROPERTY
+        ];
+        return (
+          tag !== GEOMETRY_EDIT_SACRIFICE_ID &&
+          feature.id !== GEOMETRY_EDIT_SACRIFICE_ID
+        );
+      })
+      .map((feature) => {
+        const properties = {
+          ...(feature.properties ?? {}),
+        } as Record<string, unknown>;
+        const tag = properties[GEOMETRY_EDIT_FID_PROPERTY];
+        delete properties[GEOMETRY_EDIT_FID_PROPERTY];
+        const id = ids.take(tag);
+        return { ...feature, id, properties };
+      }),
   };
 }

--- a/packages/plugins/src/plugins/geo-editor-geometry.ts
+++ b/packages/plugins/src/plugins/geo-editor-geometry.ts
@@ -24,49 +24,6 @@ export const SKETCHES_SOURCE_KIND = "geoeditor-sketches";
 export const GEOMETRY_EDIT_FID_PROPERTY = "__geolibre_fid";
 
 /**
- * Id of a throwaway feature prepended to the collection loaded into the editor.
- * Geoman's batch `importGeoJson` silently drops the FIRST feature of every batch
- * (confirmed empirically: the loss is position-based, not geometry-based), so a
- * sacrificial first feature absorbs that loss and every real feature is loaded.
- * It is filtered out again on write-back in case it survives.
- */
-export const GEOMETRY_EDIT_SACRIFICE_ID = "__geolibre_sacrifice__";
-
-/**
- * Prepend a sacrificial placeholder feature so Geoman's drop-the-first-feature
- * batch-import bug consumes the placeholder instead of a real feature.
- *
- * @param collection The tagged feature collection about to be loaded.
- * @returns A collection with the placeholder as its first feature.
- */
-export function withSacrificialFirstFeature(
-  collection: FeatureCollection,
-): FeatureCollection {
-  const placeholder = {
-    type: "Feature" as const,
-    id: GEOMETRY_EDIT_SACRIFICE_ID,
-    properties: { [GEOMETRY_EDIT_FID_PROPERTY]: GEOMETRY_EDIT_SACRIFICE_ID },
-    // A tiny polygon at null island; same geometry family as typical layers so
-    // Geoman treats it as an ordinary first feature.
-    geometry: {
-      type: "Polygon" as const,
-      coordinates: [
-        [
-          [0, 0],
-          [0, 0.0001],
-          [0.0001, 0.0001],
-          [0, 0],
-        ],
-      ],
-    },
-  };
-  return {
-    type: "FeatureCollection",
-    features: [placeholder, ...collection.features],
-  };
-}
-
-/**
  * Whether a layer's geometry can be edited in place. Only geojson-mode vector
  * layers qualify ("vector-tiles" / DuckDB-tiles layers do not). DuckDB query
  * layers are excluded and must be materialized to an editable GeoJSON copy
@@ -182,25 +139,14 @@ export function reconcileEditedFeatures(
   const ids = makeIdAllocator();
   return {
     type: "FeatureCollection",
-    features: collection.features
-      // Drop the sacrificial placeholder if it survived the import.
-      .filter((feature) => {
-        const tag = (feature.properties as Record<string, unknown> | null)?.[
-          GEOMETRY_EDIT_FID_PROPERTY
-        ];
-        return (
-          tag !== GEOMETRY_EDIT_SACRIFICE_ID &&
-          feature.id !== GEOMETRY_EDIT_SACRIFICE_ID
-        );
-      })
-      .map((feature) => {
-        const properties = {
-          ...(feature.properties ?? {}),
-        } as Record<string, unknown>;
-        const tag = properties[GEOMETRY_EDIT_FID_PROPERTY];
-        delete properties[GEOMETRY_EDIT_FID_PROPERTY];
-        const id = ids.take(tag);
-        return { ...feature, id, properties };
-      }),
+    features: collection.features.map((feature) => {
+      const properties = {
+        ...(feature.properties ?? {}),
+      } as Record<string, unknown>;
+      const tag = properties[GEOMETRY_EDIT_FID_PROPERTY];
+      delete properties[GEOMETRY_EDIT_FID_PROPERTY];
+      const id = ids.take(tag);
+      return { ...feature, id, properties };
+    }),
   };
 }

--- a/packages/plugins/src/plugins/geo-editor-geometry.ts
+++ b/packages/plugins/src/plugins/geo-editor-geometry.ts
@@ -15,6 +15,11 @@ export const SKETCHES_SOURCE_KIND = "geoeditor-sketches";
  * loaded in the editor. Geoman reassigns `feature.id` on load, so the original
  * id is preserved here and restored on write-back, then stripped so it never
  * reaches a saved project or the attribute table.
+ *
+ * The name is deliberately `__`-prefixed and namespaced to avoid colliding with
+ * real user attributes. A feature that already carries a property with this
+ * exact name would have it overwritten for the session and stripped on save, so
+ * this name must stay unusual enough that real data never uses it.
  */
 export const GEOMETRY_EDIT_FID_PROPERTY = "__geolibre_fid";
 

--- a/packages/plugins/src/plugins/geo-editor-geometry.ts
+++ b/packages/plugins/src/plugins/geo-editor-geometry.ts
@@ -46,10 +46,14 @@ export function canEditLayerGeometry(
   if (layer.metadata.externalNativeLayer === true) {
     // Externally-rendered layers are only editable when they are Add-Vector-Layer
     // geojson-mode layers, whose features live in a MapLibre GeoJSON source that
-    // can be read and written back. Other external layers are not editable.
+    // can be read and written back. Require a usable source id (a non-empty
+    // string), otherwise there is nothing to hydrate from or write back to.
+    const sourceIds = layer.metadata.sourceIds;
     return (
       layer.metadata.sourceKind === "maplibre-gl-vector" &&
-      Array.isArray(layer.metadata.sourceIds)
+      Array.isArray(sourceIds) &&
+      typeof sourceIds[0] === "string" &&
+      sourceIds[0].length > 0
     );
   }
 

--- a/packages/plugins/src/plugins/geo-editor-geometry.ts
+++ b/packages/plugins/src/plugins/geo-editor-geometry.ts
@@ -56,56 +56,71 @@ export function canEditLayerGeometry(
   return Array.isArray(layer.geojson?.features);
 }
 
+/** Allocator that hands out unique string ids, skipping ones already taken. */
+function makeIdAllocator(): { take: (preferred?: unknown) => string } {
+  const used = new Set<string>();
+  let next = 0;
+  return {
+    take(preferred?: unknown): string {
+      // Reuse the preferred id only if it is a non-empty, not-yet-taken value;
+      // otherwise allocate a fresh integer id that does not collide.
+      if (preferred != null && preferred !== "" && !used.has(String(preferred))) {
+        const id = String(preferred);
+        used.add(id);
+        return id;
+      }
+      while (used.has(String(next))) next += 1;
+      const id = String(next);
+      used.add(id);
+      return id;
+    },
+  };
+}
+
 /**
- * Tag each feature with its stable original id in `properties` before loading
- * into the editor. Geoman preserves `properties` through geometry operations but
- * reassigns `feature.id`, so this tag is how identity survives the round-trip.
+ * Tag each feature with a stable, UNIQUE id in both `feature.id` and a
+ * `properties` key before loading into the editor. Geoman keys its feature store
+ * by `feature.id`, so duplicate ids would make features overwrite each other on
+ * import (some would silently disappear or become non-editable). The id is also
+ * mirrored into `properties` because Geoman reassigns `feature.id` during edits
+ * but preserves `properties`, so the tag is how identity survives the round-trip.
  *
  * @param collection The layer's feature collection.
- * @returns A new collection with each feature carrying a feature-key tag.
+ * @returns A new collection with unique ids and a feature-key tag per feature.
  */
 export function tagFeatureKeys(
   collection: FeatureCollection,
 ): FeatureCollection {
+  const ids = makeIdAllocator();
   return {
     type: "FeatureCollection",
-    features: collection.features.map((feature, index) => ({
-      ...feature,
-      properties: {
-        ...(feature.properties ?? {}),
-        [GEOMETRY_EDIT_FID_PROPERTY]: String(feature.id ?? index),
-      },
-    })),
+    features: collection.features.map((feature) => {
+      const id = ids.take(feature.id);
+      return {
+        ...feature,
+        id,
+        properties: {
+          ...(feature.properties ?? {}),
+          [GEOMETRY_EDIT_FID_PROPERTY]: id,
+        },
+      };
+    }),
   };
 }
 
 /**
  * Restore stable feature ids from the load-time tag and strip it, so the store
- * layer stays tag-free. Features without a tag are new (drawn during the
- * session) and receive a fresh id that does not collide with a tagged one.
+ * layer stays tag-free. Ids are guaranteed unique: a duplicated tag (e.g. from a
+ * Geoman copy/split that cloned `properties`) and untagged new features each get
+ * a fresh id that does not collide.
  *
  * @param collection The editor's current feature collection (tagged).
- * @returns A new collection with stable ids and the tag removed.
+ * @returns A new collection with unique stable ids and the tag removed.
  */
 export function reconcileEditedFeatures(
   collection: FeatureCollection,
 ): FeatureCollection {
-  const usedIds = new Set<string>();
-  for (const feature of collection.features) {
-    const tag = (feature.properties as Record<string, unknown> | null)?.[
-      GEOMETRY_EDIT_FID_PROPERTY
-    ];
-    if (tag != null) usedIds.add(String(tag));
-  }
-
-  let nextId = 0;
-  const allocateId = (): string => {
-    while (usedIds.has(String(nextId))) nextId += 1;
-    const id = String(nextId);
-    usedIds.add(id);
-    return id;
-  };
-
+  const ids = makeIdAllocator();
   return {
     type: "FeatureCollection",
     features: collection.features.map((feature) => {
@@ -114,7 +129,7 @@ export function reconcileEditedFeatures(
       } as Record<string, unknown>;
       const tag = properties[GEOMETRY_EDIT_FID_PROPERTY];
       delete properties[GEOMETRY_EDIT_FID_PROPERTY];
-      const id = tag != null ? String(tag) : allocateId();
+      const id = ids.take(tag);
       return { ...feature, id, properties };
     }),
   };

--- a/packages/plugins/src/plugins/geo-editor-geometry.ts
+++ b/packages/plugins/src/plugins/geo-editor-geometry.ts
@@ -1,0 +1,105 @@
+import { isDuckDBQueryLayer, type GeoLibreLayer } from "@geolibre/core";
+import type { FeatureCollection } from "geojson";
+
+/**
+ * Pure helpers for in-place geometry editing of vector layers. Kept free of the
+ * Geoman/MapLibre runtime imports in `maplibre-geo-editor.ts` so they can be
+ * unit-tested under Node without a browser environment.
+ */
+
+/** Metadata `sourceKind` marking the GeoEditor's own "Sketches" layer. */
+export const SKETCHES_SOURCE_KIND = "geoeditor-sketches";
+
+/**
+ * Transient feature-key tag written into a feature's `properties` while it is
+ * loaded in the editor. Geoman reassigns `feature.id` on load, so the original
+ * id is preserved here and restored on write-back, then stripped so it never
+ * reaches a saved project or the attribute table.
+ */
+export const GEOMETRY_EDIT_FID_PROPERTY = "__geolibre_fid";
+
+/**
+ * Whether a layer's geometry can be edited in place. Mirrors the exclusions the
+ * attribute table already applies so the two rules cannot drift: only in-memory
+ * geojson vector layers qualify. DuckDB query layers and Add-Vector-Layer
+ * control layers keep their features outside `layer.geojson`, so they are
+ * excluded (DuckDB layers are materialized to an editable copy first).
+ *
+ * @param layer The candidate layer, or undefined.
+ * @returns True when the layer's geometry can be edited in place.
+ */
+export function canEditLayerGeometry(
+  layer: GeoLibreLayer | undefined,
+): boolean {
+  if (!layer) return false;
+  if (layer.type !== "geojson") return false;
+  if (isDuckDBQueryLayer(layer)) return false;
+  if (layer.metadata.sourceKind === SKETCHES_SOURCE_KIND) return false;
+  if (layer.metadata.sourceKind === "maplibre-gl-vector") return false;
+  if (layer.metadata.externalNativeLayer === true) return false;
+  return Array.isArray(layer.geojson?.features);
+}
+
+/**
+ * Tag each feature with its stable original id in `properties` before loading
+ * into the editor. Geoman preserves `properties` through geometry operations but
+ * reassigns `feature.id`, so this tag is how identity survives the round-trip.
+ *
+ * @param collection The layer's feature collection.
+ * @returns A new collection with each feature carrying a feature-key tag.
+ */
+export function tagFeatureKeys(
+  collection: FeatureCollection,
+): FeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: collection.features.map((feature, index) => ({
+      ...feature,
+      properties: {
+        ...(feature.properties ?? {}),
+        [GEOMETRY_EDIT_FID_PROPERTY]: String(feature.id ?? index),
+      },
+    })),
+  };
+}
+
+/**
+ * Restore stable feature ids from the load-time tag and strip it, so the store
+ * layer stays tag-free. Features without a tag are new (drawn during the
+ * session) and receive a fresh id that does not collide with a tagged one.
+ *
+ * @param collection The editor's current feature collection (tagged).
+ * @returns A new collection with stable ids and the tag removed.
+ */
+export function reconcileEditedFeatures(
+  collection: FeatureCollection,
+): FeatureCollection {
+  const usedIds = new Set<string>();
+  for (const feature of collection.features) {
+    const tag = (feature.properties as Record<string, unknown> | null)?.[
+      GEOMETRY_EDIT_FID_PROPERTY
+    ];
+    if (tag != null) usedIds.add(String(tag));
+  }
+
+  let nextId = 0;
+  const allocateId = (): string => {
+    while (usedIds.has(String(nextId))) nextId += 1;
+    const id = String(nextId);
+    usedIds.add(id);
+    return id;
+  };
+
+  return {
+    type: "FeatureCollection",
+    features: collection.features.map((feature) => {
+      const properties = {
+        ...(feature.properties ?? {}),
+      } as Record<string, unknown>;
+      const tag = properties[GEOMETRY_EDIT_FID_PROPERTY];
+      delete properties[GEOMETRY_EDIT_FID_PROPERTY];
+      const id = tag != null ? String(tag) : allocateId();
+      return { ...feature, id, properties };
+    }),
+  };
+}

--- a/packages/plugins/src/plugins/geo-editor-geometry.ts
+++ b/packages/plugins/src/plugins/geo-editor-geometry.ts
@@ -67,11 +67,12 @@ export function withSacrificialFirstFeature(
 }
 
 /**
- * Whether a layer's geometry can be edited in place. Mirrors the exclusions the
- * attribute table already applies so the two rules cannot drift: only in-memory
- * geojson vector layers qualify. DuckDB query layers and Add-Vector-Layer
- * control layers keep their features outside `layer.geojson`, so they are
- * excluded (DuckDB layers are materialized to an editable copy first).
+ * Whether a layer's geometry can be edited in place. Only geojson-mode vector
+ * layers qualify ("vector-tiles" / DuckDB-tiles layers do not). DuckDB query
+ * layers are excluded and must be materialized to an editable GeoJSON copy
+ * first. Add-Vector-Layer geojson-mode layers ARE included: their features live
+ * in a MapLibre GeoJSON source and are read back (via the caller's
+ * `ensureLayerGeojsonFromSource`) before editing begins.
  *
  * @param layer The candidate layer, or undefined.
  * @returns True when the layer's geometry can be edited in place.
@@ -135,9 +136,24 @@ export function tagFeatureKeys(
   collection: FeatureCollection,
 ): FeatureCollection {
   const ids = makeIdAllocator();
+  let warnedCollision = false;
   return {
     type: "FeatureCollection",
     features: collection.features.map((feature) => {
+      // Warn once if real data already uses the reserved tag key: that value is
+      // overwritten for the session and stripped on save, so the user would
+      // otherwise silently lose it.
+      if (
+        !warnedCollision &&
+        feature.properties != null &&
+        GEOMETRY_EDIT_FID_PROPERTY in feature.properties
+      ) {
+        warnedCollision = true;
+        console.warn(
+          `Geometry edit: features already contain a "${GEOMETRY_EDIT_FID_PROPERTY}" ` +
+            "property; it will be overwritten for the edit session and removed on save.",
+        );
+      }
       const id = ids.take(feature.id);
       return {
         ...feature,

--- a/packages/plugins/src/plugins/geo-editor-geometry.ts
+++ b/packages/plugins/src/plugins/geo-editor-geometry.ts
@@ -144,11 +144,17 @@ export function reconcileEditedFeatures(
   return {
     type: "FeatureCollection",
     features: collection.features.map((feature) => {
-      const properties = {
-        ...(feature.properties ?? {}),
-      } as Record<string, unknown>;
-      const tag = properties[GEOMETRY_EDIT_FID_PROPERTY];
-      delete properties[GEOMETRY_EDIT_FID_PROPERTY];
+      const rawProps = feature.properties;
+      const tag = rawProps?.[GEOMETRY_EDIT_FID_PROPERTY];
+      // Preserve null properties as null (GeoJSON allows it, and a feature drawn
+      // during the session may have null); only strip the tag from real objects.
+      let properties: Record<string, unknown> | null;
+      if (rawProps == null) {
+        properties = null;
+      } else {
+        properties = { ...rawProps };
+        delete properties[GEOMETRY_EDIT_FID_PROPERTY];
+      }
       const id = ids.take(tag);
       return { ...feature, id, properties };
     }),

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -616,11 +616,11 @@ function setEditTargetStoreVisible(layerId: string, visible: boolean): void {
 
 /** Exit any active Geoman draw/edit mode so temporary edit features are cleared. */
 function disableActiveEditModes(): void {
-  try {
-    void geomanInstance?.disableAllModes();
-  } catch {
+  // disableAllModes() is async; attach a catch so a rejection (e.g. Geoman
+  // already torn down) does not surface as an unhandled promise rejection.
+  geomanInstance?.disableAllModes()?.catch(() => {
     // Geoman may already be torn down.
-  }
+  });
 }
 
 /**

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -95,8 +95,6 @@ let geomanEditSyncMap: maplibregl.Map | null = null;
 let editTargetLayerId: string | null = null;
 /** Sketches stashed out of the editor for the duration of an edit session. */
 let savedSketchesCollection: FeatureCollection | null = null;
-/** Target layer's geojson captured at session start, restored on Cancel. */
-let originalTargetGeojson: FeatureCollection | null = null;
 /** Listeners notified when a geometry edit session starts or ends. */
 const geometryEditListeners = new Set<() => void>();
 
@@ -360,10 +358,11 @@ function unionFeatureCollections(
 function syncSketchesToStore(): void {
   if (!geoEditorControl || restoringSketchesToEditor) return;
 
-  if (editTargetLayerId) {
-    syncEditTargetToStore();
-    return;
-  }
+  // During a geometry-edit session edits live in the editor and are written
+  // back only on save. Writing per operation would rebuild the target layer's
+  // map source on every drag and disrupt Geoman's in-progress vertex editing,
+  // so skip store writes here; `endLayerGeometryEdit` flushes the final state.
+  if (editTargetLayerId) return;
 
   let collection = cloneFeatureCollection(
     geoEditorControl.getAllFeatureCollection(),
@@ -430,6 +429,11 @@ function notifyGeometryEdit(): void {
   for (const listener of geometryEditListeners) listener();
 }
 
+/**
+ * Write the editor's current features back to the target layer. Called only
+ * when a session ends with save, so the target's map source is rebuilt once
+ * rather than on every edit operation.
+ */
 function syncEditTargetToStore(): void {
   if (!geoEditorControl || !editTargetLayerId) return;
 
@@ -439,19 +443,12 @@ function syncEditTargetToStore(): void {
   const edited = reconcileEditedFeatures(
     cloneFeatureCollection(geoEditorControl.getAllFeatureCollection()),
   );
-  // The union path is a Sketches-only safeguard; in edit mode the editor's full
-  // collection is the source of truth.
-  unionSketchesWithStoreOnNextSync = false;
 
   pushingSketchesToStore = true;
   try {
     store.updateLayer(editTargetLayerId, { geojson: edited });
   } finally {
     pushingSketchesToStore = false;
-  }
-
-  if (!sketchesIdleDisplayOverride) {
-    scheduleApplySketchesMapDisplay();
   }
 }
 
@@ -489,7 +486,8 @@ export function startLayerGeometryEdit(
   clearSketchesFromEditor();
   setSketchesMapLayerSuppressed(false);
 
-  originalTargetGeojson = cloneFeatureCollection(layer.geojson);
+  // The store layer is left untouched until save, so Cancel simply discards the
+  // editor's copy and the original geojson is still in the store.
   editTargetLayerId = layerId;
   sketchesIdleDisplayOverride = false;
   unionSketchesWithStoreOnNextSync = false;
@@ -512,9 +510,10 @@ export function startLayerGeometryEdit(
 }
 
 /**
- * Finish the active geometry edit session. With `save`, the latest edits are
- * written to the target layer; otherwise the layer is reverted to its
- * session-start snapshot. The editor is returned to Sketches mode either way.
+ * Finish the active geometry edit session. With `save`, the editor's features
+ * are written back to the target layer; otherwise they are discarded and the
+ * layer keeps the geojson it had at session start (it was never modified). The
+ * editor is returned to Sketches mode either way.
  */
 export function endLayerGeometryEdit(
   _app: GeoLibreAppAPI,
@@ -522,25 +521,12 @@ export function endLayerGeometryEdit(
 ): void {
   if (!editTargetLayerId || !geoEditorControl) return;
 
-  const targetId = editTargetLayerId;
-  if (save) {
-    syncEditTargetToStore();
-  } else if (originalTargetGeojson) {
-    pushingSketchesToStore = true;
-    try {
-      useAppStore
-        .getState()
-        .updateLayer(targetId, { geojson: originalTargetGeojson });
-    } finally {
-      pushingSketchesToStore = false;
-    }
-  }
+  if (save) syncEditTargetToStore();
 
   // Restore the target layer's normal map rendering while it is still the
   // active layer, then switch back to Sketches mode.
   setSketchesMapLayerSuppressed(false);
   editTargetLayerId = null;
-  originalTargetGeojson = null;
   sketchesIdleDisplayOverride = false;
   unionSketchesWithStoreOnNextSync = false;
 
@@ -556,7 +542,6 @@ export function endLayerGeometryEdit(
  */
 function abortGeometryEditSession(): void {
   editTargetLayerId = null;
-  originalTargetGeojson = null;
   sketchesIdleDisplayOverride = false;
   unionSketchesWithStoreOnNextSync = false;
   restoreSketchesAfterSession();
@@ -729,9 +714,13 @@ function sketchesMapLayerIds(layerId: string): string[] {
  * GeoEditor selection and edit handles use Geoman layers for hit-testing.
  * While interacting, show Geoman and hide the Sketches store layer on the map only.
  * When idle, hide Geoman and show Sketches according to the user's layer-panel toggle.
+ *
+ * During a geometry-edit session the target layer is shown exclusively through
+ * Geoman for the whole session: its normal rendering stays suppressed even when
+ * idle, so the layer's edits are not also drawn by the (stale) store source.
  */
 function applySketchesMapDisplay(): void {
-  if (isGeoEditorInteractionMode()) {
+  if (editTargetLayerId || isGeoEditorInteractionMode()) {
     showGeomanDisplayLayers();
     scheduleShowGeomanDisplayLayersOnStyleData();
     setSketchesMapLayerSuppressed(true);
@@ -753,7 +742,7 @@ function scheduleShowGeomanDisplayLayersOnStyleData(): void {
 
   pendingStyleDataListener = () => {
     pendingStyleDataListener = null;
-    if (isGeoEditorInteractionMode()) {
+    if (editTargetLayerId || isGeoEditorInteractionMode()) {
       showGeomanDisplayLayers();
     }
   };

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -95,6 +95,10 @@ let geomanEditSyncMap: maplibregl.Map | null = null;
 let editTargetLayerId: string | null = null;
 /** Sketches stashed out of the editor for the duration of an edit session. */
 let savedSketchesCollection: FeatureCollection | null = null;
+/** The live Geoman instance backing the editor, used for clean teardown. */
+let geomanInstance: Geoman | null = null;
+/** Target layer's store visibility captured at session start, restored on end. */
+let editTargetOriginalVisible: boolean | null = null;
 /** Listeners notified when a geometry edit session starts or ends. */
 const geometryEditListeners = new Set<() => void>();
 
@@ -116,12 +120,11 @@ export const maplibreGeoEditorPlugin: GeoLibrePlugin = {
       geoEditorControl = new GeoEditor(getGeoEditorOptions());
       const map = app.getMap?.();
       if (map) {
-        geoEditorControl.setGeoman(
-          new Geoman(map, {
-            layerStyles: geomanLayerStylesForMap(map),
-            settings: { useControlsUi: false },
-          }),
-        );
+        geomanInstance = new Geoman(map, {
+          layerStyles: geomanLayerStylesForMap(map),
+          settings: { useControlsUi: false },
+        });
+        geoEditorControl.setGeoman(geomanInstance);
         bindGeomanEditSync(map);
       }
     }
@@ -155,6 +158,8 @@ export const maplibreGeoEditorPlugin: GeoLibrePlugin = {
     if (!geoEditorControl) return;
     app.removeMapControl(geoEditorControl);
     geoEditorControl = null;
+    void geomanInstance?.destroy({ removeSources: true });
+    geomanInstance = null;
   },
   getMapControlPosition: () => geoEditorPosition,
   setMapControlPosition: (
@@ -438,7 +443,8 @@ function syncEditTargetToStore(): void {
   if (!geoEditorControl || !editTargetLayerId) return;
 
   const store = useAppStore.getState();
-  if (!store.layers.some((layer) => layer.id === editTargetLayerId)) return;
+  const layer = store.layers.find((l) => l.id === editTargetLayerId);
+  if (!layer) return;
 
   const edited = reconcileEditedFeatures(
     cloneFeatureCollection(geoEditorControl.getAllFeatureCollection()),
@@ -449,6 +455,33 @@ function syncEditTargetToStore(): void {
     store.updateLayer(editTargetLayerId, { geojson: edited });
   } finally {
     pushingSketchesToStore = false;
+  }
+
+  // Add Vector Layer control layers render from a MapLibre GeoJSON source they
+  // own rather than from `layer.geojson`, so push the edits there too or the map
+  // would keep showing the pre-edit geometry.
+  writeBackToVectorSource(layer, edited);
+}
+
+/** Source id of an Add-Vector-Layer geojson-mode layer, or null. */
+function vectorSourceIdForLayer(layer: GeoLibreLayer): string | null {
+  if (layer.metadata.sourceKind !== "maplibre-gl-vector") return null;
+  const sourceIds = layer.metadata.sourceIds;
+  const sourceId = Array.isArray(sourceIds) ? sourceIds[0] : undefined;
+  return typeof sourceId === "string" ? sourceId : null;
+}
+
+function writeBackToVectorSource(
+  layer: GeoLibreLayer,
+  collection: FeatureCollection,
+): void {
+  const sourceId = vectorSourceIdForLayer(layer);
+  if (!sourceId) return;
+  const source = appApi?.getMap?.()?.getSource(sourceId) as
+    | { setData?: (data: FeatureCollection) => void }
+    | undefined;
+  if (source && typeof source.setData === "function") {
+    source.setData(collection);
   }
 }
 
@@ -492,6 +525,14 @@ export function startLayerGeometryEdit(
   sketchesIdleDisplayOverride = false;
   unionSketchesWithStoreOnNextSync = false;
 
+  // Hide the target's normal rendering through the store, not via a map-layer
+  // visibility toggle: the store value is authoritative for the layer sync, so
+  // it survives any re-render and the editable features are shown only once
+  // (through Geoman), avoiding the double-render that left some features
+  // appearing editable but not interactive.
+  editTargetOriginalVisible = layer.visible;
+  setEditTargetStoreVisible(layerId, false);
+
   let loaded = false;
   restoringSketchesToEditor = true;
   try {
@@ -508,8 +549,10 @@ export function startLayerGeometryEdit(
 
   // If the load failed the editor is empty; do NOT keep the session active or a
   // later Save would overwrite the layer with an empty collection. Roll back:
-  // restore the stashed sketches and report failure so the caller can retry.
+  // restore visibility and the stashed sketches and report failure.
   if (!loaded) {
+    setEditTargetStoreVisible(layerId, editTargetOriginalVisible ?? true);
+    editTargetOriginalVisible = null;
     editTargetLayerId = null;
     restoreSketchesAfterSession();
     applySketchesMapDisplay();
@@ -519,6 +562,22 @@ export function startLayerGeometryEdit(
   applySketchesMapDisplay();
   notifyGeometryEdit();
   return true;
+}
+
+/** Set the target layer's store visibility without provoking a sketches sync. */
+function setEditTargetStoreVisible(layerId: string, visible: boolean): void {
+  const state = useAppStore.getState();
+  if (!state.layers.some((layer) => layer.id === layerId)) return;
+  state.setLayerVisibility(layerId, visible);
+}
+
+/** Exit any active Geoman draw/edit mode so temporary edit features are cleared. */
+function disableActiveEditModes(): void {
+  try {
+    void geomanInstance?.disableAllModes();
+  } catch {
+    // Geoman may already be torn down.
+  }
 }
 
 /**
@@ -533,14 +592,21 @@ export function endLayerGeometryEdit(
 ): void {
   if (!editTargetLayerId || !geoEditorControl) return;
 
+  const targetId = editTargetLayerId;
   if (save) syncEditTargetToStore();
 
-  // Restore the target layer's normal map rendering while it is still the
-  // active layer, then switch back to Sketches mode.
-  setSketchesMapLayerSuppressed(false);
+  // Exit edit modes and clear the editor before restoring Sketches, so Geoman's
+  // temporary edit features do not linger on the map.
+  disableActiveEditModes();
+
   editTargetLayerId = null;
   sketchesIdleDisplayOverride = false;
   unionSketchesWithStoreOnNextSync = false;
+
+  // Restore the target layer's normal rendering (it now reflects the saved
+  // edits, or the untouched original on cancel).
+  setEditTargetStoreVisible(targetId, editTargetOriginalVisible ?? true);
+  editTargetOriginalVisible = null;
 
   restoreSketchesAfterSession();
   applySketchesMapDisplay();
@@ -557,6 +623,9 @@ function abortGeometryEditSession(): void {
     "Geometry edit session aborted: the target layer was removed; " +
       "in-progress geometry edits were discarded.",
   );
+  disableActiveEditModes();
+  // The layer is gone, so there is no visibility to restore; just drop the flag.
+  editTargetOriginalVisible = null;
   editTargetLayerId = null;
   sketchesIdleDisplayOverride = false;
   unionSketchesWithStoreOnNextSync = false;
@@ -571,6 +640,7 @@ function restoreSketchesAfterSession(): void {
     savedSketchesCollection = null;
     return;
   }
+  disableActiveEditModes();
   clearSketchesFromEditor();
   if (savedSketchesCollection?.features.length) {
     restoringSketchesToEditor = true;
@@ -736,7 +806,16 @@ function sketchesMapLayerIds(layerId: string): string[] {
  * idle, so the layer's edits are not also drawn by the (stale) store source.
  */
 function applySketchesMapDisplay(): void {
-  if (editTargetLayerId || isGeoEditorInteractionMode()) {
+  // During a geometry-edit session the target's normal rendering is hidden via
+  // store visibility, so only Geoman needs to be shown here; toggling map-layer
+  // visibility for the target is unnecessary and would race the layer sync.
+  if (editTargetLayerId) {
+    showGeomanDisplayLayers();
+    scheduleShowGeomanDisplayLayersOnStyleData();
+    return;
+  }
+
+  if (isGeoEditorInteractionMode()) {
     showGeomanDisplayLayers();
     scheduleShowGeomanDisplayLayersOnStyleData();
     setSketchesMapLayerSuppressed(true);
@@ -798,8 +877,13 @@ function setGeomanDisplayLayersVisibility(visibility: "visible" | "none"): void 
   const map = appApi?.getMap?.();
   if (!map) return;
   const sketchesLayer = activeEditableLayer(useAppStore.getState().layers);
+  // In a session the target is intentionally store-hidden, so its `visible`
+  // flag must not also hide the Geoman display layers that present the features
+  // being edited.
   const effectiveVisibility =
-    visibility === "visible" && sketchesLayer?.visible === false
+    visibility === "visible" &&
+    !editTargetLayerId &&
+    sketchesLayer?.visible === false
       ? "none"
       : visibility;
 

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -3,14 +3,21 @@ import { Geoman, defaultLayerStyles } from "@geoman-io/maplibre-geoman-free";
 import type { Feature, FeatureCollection } from "geojson";
 import type maplibregl from "maplibre-gl";
 import { GeoEditor, type GeoEditorOptions } from "maplibre-gl-geo-editor";
+import {
+  SKETCHES_SOURCE_KIND,
+  canEditLayerGeometry,
+  reconcileEditedFeatures,
+  tagFeatureKeys,
+} from "./geo-editor-geometry";
 import type {
   GeoLibreAppAPI,
   GeoLibreMapControlPosition,
   GeoLibrePlugin,
 } from "../types";
 
+export { canEditLayerGeometry } from "./geo-editor-geometry";
+
 const SKETCHES_LAYER_NAME = "Sketches";
-const SKETCHES_SOURCE_KIND = "geoeditor-sketches";
 const SKETCHES_SOURCE_PATH = "geoeditor://sketches";
 const GEOMAN_TEXT_PROPERTY = "__gm_text";
 
@@ -79,6 +86,20 @@ let unionSketchesWithStoreOnNextSync = false;
 let pendingStyleDataListener: (() => void) | null = null;
 let geomanEditSyncMap: maplibregl.Map | null = null;
 
+/**
+ * Id of the store layer currently being geometry-edited in place, or null when
+ * the editor is in its default "Sketches" mode. While set, the shared editor is
+ * re-targeted at this layer: the sync/display helpers resolve to it instead of
+ * the Sketches layer (see `activeEditableLayer`).
+ */
+let editTargetLayerId: string | null = null;
+/** Sketches stashed out of the editor for the duration of an edit session. */
+let savedSketchesCollection: FeatureCollection | null = null;
+/** Target layer's geojson captured at session start, restored on Cancel. */
+let originalTargetGeojson: FeatureCollection | null = null;
+/** Listeners notified when a geometry edit session starts or ends. */
+const geometryEditListeners = new Set<() => void>();
+
 const GEOMAN_EDIT_SYNC_EVENTS = [
   "gm:dragend",
   "gm:editend",
@@ -120,6 +141,10 @@ export const maplibreGeoEditorPlugin: GeoLibrePlugin = {
     setTimeout(() => geoEditorControl?.expand(), 0);
   },
   deactivate: (app: GeoLibreAppAPI) => {
+    // Persist any in-progress geometry edit and restore the editor to Sketches
+    // mode before tearing the control down, so map rendering and store state
+    // stay consistent.
+    if (editTargetLayerId) endLayerGeometryEdit(app, { save: true });
     pluginActive = false;
     sketchesIdleDisplayOverride = false;
     unionSketchesWithStoreOnNextSync = false;
@@ -284,6 +309,21 @@ function findSketchesLayer(
   return layers.find(isSketchesLayer);
 }
 
+/**
+ * The store layer the shared editor is currently bound to: the geometry-edit
+ * target when a session is active, otherwise the Sketches layer. The map-display
+ * helpers resolve through this so they suppress/style whichever layer the editor
+ * is showing, without duplicating the suppression logic per mode.
+ */
+function activeEditableLayer(
+  layers: GeoLibreLayer[],
+): GeoLibreLayer | undefined {
+  if (editTargetLayerId) {
+    return layers.find((layer) => layer.id === editTargetLayerId);
+  }
+  return findSketchesLayer(layers);
+}
+
 function cloneFeatureCollection(
   collection: FeatureCollection,
 ): FeatureCollection {
@@ -319,6 +359,11 @@ function unionFeatureCollections(
 
 function syncSketchesToStore(): void {
   if (!geoEditorControl || restoringSketchesToEditor) return;
+
+  if (editTargetLayerId) {
+    syncEditTargetToStore();
+    return;
+  }
 
   let collection = cloneFeatureCollection(
     geoEditorControl.getAllFeatureCollection(),
@@ -362,6 +407,181 @@ function syncSketchesToStore(): void {
   if (!sketchesIdleDisplayOverride) {
     scheduleApplySketchesMapDisplay();
   }
+}
+
+// ---------------------------------------------------------------------------
+// In-place geometry editing of an existing vector layer
+// ---------------------------------------------------------------------------
+
+/** Id of the layer being geometry-edited, or null when no session is active. */
+export function getGeometryEditTargetLayerId(): string | null {
+  return editTargetLayerId;
+}
+
+/** Subscribe to geometry-edit session changes (for `useSyncExternalStore`). */
+export function subscribeGeometryEdit(listener: () => void): () => void {
+  geometryEditListeners.add(listener);
+  return () => {
+    geometryEditListeners.delete(listener);
+  };
+}
+
+function notifyGeometryEdit(): void {
+  for (const listener of geometryEditListeners) listener();
+}
+
+function syncEditTargetToStore(): void {
+  if (!geoEditorControl || !editTargetLayerId) return;
+
+  const store = useAppStore.getState();
+  if (!store.layers.some((layer) => layer.id === editTargetLayerId)) return;
+
+  const edited = reconcileEditedFeatures(
+    cloneFeatureCollection(geoEditorControl.getAllFeatureCollection()),
+  );
+  // The union path is a Sketches-only safeguard; in edit mode the editor's full
+  // collection is the source of truth.
+  unionSketchesWithStoreOnNextSync = false;
+
+  pushingSketchesToStore = true;
+  try {
+    store.updateLayer(editTargetLayerId, { geojson: edited });
+  } finally {
+    pushingSketchesToStore = false;
+  }
+
+  if (!sketchesIdleDisplayOverride) {
+    scheduleApplySketchesMapDisplay();
+  }
+}
+
+/**
+ * Begin editing the geometry of an existing vector layer in place, reusing the
+ * shared Geoman editor. Stashes any current sketches out of the editor, loads
+ * the target layer's features (id-tagged), and re-targets the sync/display
+ * helpers at the target layer. Returns false when the plugin is not active or
+ * the layer is not editable.
+ */
+export function startLayerGeometryEdit(
+  _app: GeoLibreAppAPI,
+  layerId: string,
+): boolean {
+  if (!pluginActive || !geoEditorControl) return false;
+
+  // Only one session at a time; finish any open one first (saving its work).
+  if (editTargetLayerId && editTargetLayerId !== layerId) {
+    endLayerGeometryEdit(_app, { save: true });
+  }
+  if (editTargetLayerId === layerId) return true;
+
+  const layer = useAppStore
+    .getState()
+    .layers.find((candidate) => candidate.id === layerId);
+  if (!layer || !canEditLayerGeometry(layer) || !layer.geojson) return false;
+
+  // Flush sketches to the store, stash them out of the editor, and restore the
+  // Sketches store layer's normal rendering (it stays visible as a plain layer
+  // during the target edit).
+  syncSketchesToStore();
+  savedSketchesCollection = cloneFeatureCollection(
+    geoEditorControl.getAllFeatureCollection(),
+  );
+  clearSketchesFromEditor();
+  setSketchesMapLayerSuppressed(false);
+
+  originalTargetGeojson = cloneFeatureCollection(layer.geojson);
+  editTargetLayerId = layerId;
+  sketchesIdleDisplayOverride = false;
+  unionSketchesWithStoreOnNextSync = false;
+
+  restoringSketchesToEditor = true;
+  try {
+    geoEditorControl.loadGeoJson(
+      tagFeatureKeys(cloneFeatureCollection(layer.geojson)),
+      SKETCHES_SOURCE_PATH,
+    );
+  } catch {
+    // Geoman may not be ready until the map style finishes loading.
+  } finally {
+    restoringSketchesToEditor = false;
+  }
+
+  applySketchesMapDisplay();
+  notifyGeometryEdit();
+  return true;
+}
+
+/**
+ * Finish the active geometry edit session. With `save`, the latest edits are
+ * written to the target layer; otherwise the layer is reverted to its
+ * session-start snapshot. The editor is returned to Sketches mode either way.
+ */
+export function endLayerGeometryEdit(
+  _app: GeoLibreAppAPI,
+  { save }: { save: boolean },
+): void {
+  if (!editTargetLayerId || !geoEditorControl) return;
+
+  const targetId = editTargetLayerId;
+  if (save) {
+    syncEditTargetToStore();
+  } else if (originalTargetGeojson) {
+    pushingSketchesToStore = true;
+    try {
+      useAppStore
+        .getState()
+        .updateLayer(targetId, { geojson: originalTargetGeojson });
+    } finally {
+      pushingSketchesToStore = false;
+    }
+  }
+
+  // Restore the target layer's normal map rendering while it is still the
+  // active layer, then switch back to Sketches mode.
+  setSketchesMapLayerSuppressed(false);
+  editTargetLayerId = null;
+  originalTargetGeojson = null;
+  sketchesIdleDisplayOverride = false;
+  unionSketchesWithStoreOnNextSync = false;
+
+  restoreSketchesAfterSession();
+  applySketchesMapDisplay();
+  notifyGeometryEdit();
+}
+
+/**
+ * Tear down a session whose target layer was removed from the store mid-edit:
+ * drop the editor's copy and restore Sketches without writing back to the gone
+ * layer.
+ */
+function abortGeometryEditSession(): void {
+  editTargetLayerId = null;
+  originalTargetGeojson = null;
+  sketchesIdleDisplayOverride = false;
+  unionSketchesWithStoreOnNextSync = false;
+  restoreSketchesAfterSession();
+  applySketchesMapDisplay();
+  notifyGeometryEdit();
+}
+
+/** Clear the editor and reload the sketches stashed at session start. */
+function restoreSketchesAfterSession(): void {
+  if (!geoEditorControl) {
+    savedSketchesCollection = null;
+    return;
+  }
+  clearSketchesFromEditor();
+  if (savedSketchesCollection?.features.length) {
+    restoringSketchesToEditor = true;
+    try {
+      geoEditorControl.loadGeoJson(savedSketchesCollection, SKETCHES_SOURCE_PATH);
+    } catch {
+      // Geoman may not be ready; the store subscription will re-restore.
+    } finally {
+      restoringSketchesToEditor = false;
+    }
+  }
+  savedSketchesCollection = null;
 }
 
 function restoreSketchesLayerToEditor(): void {
@@ -417,6 +637,31 @@ function clearSketchesFromEditor(): void {
 function bindSketchesStoreSync(): void {
   geoEditorStoreUnsubscribe ??= useAppStore.subscribe((state, previous) => {
     if (!pluginActive) return;
+
+    // During a geometry-edit session the editor holds the target layer's
+    // features, not sketches. Skip the Sketches reconciliation entirely and
+    // only watch the target: abort if it was removed, reflect display changes.
+    if (editTargetLayerId) {
+      const target = state.layers.find(
+        (layer) => layer.id === editTargetLayerId,
+      );
+      if (!target) {
+        abortGeometryEditSession();
+        return;
+      }
+      const previousTarget = previous.layers.find(
+        (layer) => layer.id === editTargetLayerId,
+      );
+      if (
+        previousTarget &&
+        (target.visible !== previousTarget.visible ||
+          target.opacity !== previousTarget.opacity ||
+          target.style !== previousTarget.style)
+      ) {
+        scheduleApplySketchesMapDisplay();
+      }
+      return;
+    }
 
     const sketches = findSketchesLayer(state.layers);
     const previousSketches = findSketchesLayer(previous.layers);
@@ -516,7 +761,7 @@ function scheduleShowGeomanDisplayLayersOnStyleData(): void {
 }
 
 function setSketchesMapLayerSuppressed(suppress: boolean): void {
-  const layer = findSketchesLayer(useAppStore.getState().layers);
+  const layer = activeEditableLayer(useAppStore.getState().layers);
   if (!layer) {
     sketchesMapLayerSuppressed = false;
     return;
@@ -547,7 +792,7 @@ function setSketchesMapLayersVisibility(layer: GeoLibreLayer): void {
 function setGeomanDisplayLayersVisibility(visibility: "visible" | "none"): void {
   const map = appApi?.getMap?.();
   if (!map) return;
-  const sketchesLayer = findSketchesLayer(useAppStore.getState().layers);
+  const sketchesLayer = activeEditableLayer(useAppStore.getState().layers);
   const effectiveVisibility =
     visibility === "visible" && sketchesLayer?.visible === false
       ? "none"

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -536,11 +536,21 @@ export function startLayerGeometryEdit(
   let loaded = false;
   restoringSketchesToEditor = true;
   try {
-    geoEditorControl.loadGeoJson(
-      tagFeatureKeys(cloneFeatureCollection(layer.geojson)),
-      SKETCHES_SOURCE_PATH,
-    );
+    const tagged = tagFeatureKeys(cloneFeatureCollection(layer.geojson));
+    const result = geoEditorControl.loadGeoJson(tagged, SKETCHES_SOURCE_PATH);
     loaded = true;
+    // Geoman skips features whose geometry shape it cannot map (e.g. some
+    // MultiPolygon/GeometryCollection inputs); those render but are not editable.
+    // Surface the count so the cause is visible instead of looking like a bug.
+    const importedCount = result?.count ?? tagged.features.length;
+    if (importedCount < tagged.features.length) {
+      console.warn(
+        `Geometry edit: ${
+          tagged.features.length - importedCount
+        } of ${tagged.features.length} features could not be loaded into the ` +
+          "editor and will not be editable (unsupported geometry shape).",
+      );
+    }
   } catch {
     // Geoman may not be ready until the map style finishes loading.
   } finally {

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -111,7 +111,7 @@ const GEOMAN_EDIT_SYNC_EVENTS = [
 export const maplibreGeoEditorPlugin: GeoLibrePlugin = {
   id: "maplibre-gl-geo-editor",
   name: "GeoEditor",
-  version: "0.7.3",
+  version: "0.8.0",
   activate: (app: GeoLibreAppAPI) => {
     pluginActive = true;
     appApi = app;
@@ -143,9 +143,10 @@ export const maplibreGeoEditorPlugin: GeoLibrePlugin = {
   },
   deactivate: (app: GeoLibreAppAPI) => {
     // Persist any in-progress geometry edit and restore the editor to Sketches
-    // mode before tearing the control down, so map rendering and store state
-    // stay consistent.
-    if (editTargetLayerId) endLayerGeometryEdit(app, { save: true });
+    // mode before tearing the control down. The write-back is synchronous; only
+    // the sketches restore is async, which is moot since the control is removed
+    // below, so this need not be awaited.
+    if (editTargetLayerId) void endLayerGeometryEdit(app, { save: true });
     pluginActive = false;
     sketchesIdleDisplayOverride = false;
     unionSketchesWithStoreOnNextSync = false;
@@ -508,6 +509,12 @@ async function ensureGeomanReady(): Promise<void> {
  * helpers at the target layer. Returns false when the plugin is not active or
  * the layer is not editable.
  *
+ * The target's features must already be in `layer.geojson`. Add-Vector-Layer
+ * (`maplibre-gl-vector`) layers keep their features in a MapLibre source, so the
+ * caller must hydrate `layer.geojson` from that source first (otherwise this
+ * returns false); `canEditLayerGeometry` deliberately reports them editable
+ * because that hydration is the caller's responsibility.
+ *
  * `_app` is accepted for API symmetry with the other plugin entry points but is
  * not used: this function operates through the module-level `appApi`/store.
  */
@@ -518,8 +525,9 @@ export async function startLayerGeometryEdit(
   if (!pluginActive || !geoEditorControl) return false;
 
   // Only one session at a time; finish any open one first (saving its work).
+  // Await it so its sketches restore completes before the new session starts.
   if (editTargetLayerId && editTargetLayerId !== layerId) {
-    endLayerGeometryEdit(_app, { save: true });
+    await endLayerGeometryEdit(_app, { save: true });
   }
   if (editTargetLayerId === layerId) return true;
 
@@ -577,6 +585,11 @@ export async function startLayerGeometryEdit(
     restoringSketchesToEditor = false;
   }
 
+  // The target layer may have been removed while `loadGeoJson` was awaited; the
+  // store subscription's `abortGeometryEditSession` then already tore the session
+  // down (and restored sketches). Bail out without a second teardown.
+  if (editTargetLayerId !== layerId) return false;
+
   // If the load failed the editor is empty; do NOT keep the session active or a
   // later Save would overwrite the layer with an empty collection. Roll back:
   // restore visibility and the stashed sketches and report failure.
@@ -616,10 +629,10 @@ function disableActiveEditModes(): void {
  * layer keeps the geojson it had at session start (it was never modified). The
  * editor is returned to Sketches mode either way.
  */
-export function endLayerGeometryEdit(
+export async function endLayerGeometryEdit(
   _app: GeoLibreAppAPI,
   { save }: { save: boolean },
-): void {
+): Promise<void> {
   if (!editTargetLayerId) return;
 
   // Defensive: if the control was torn down while a session id lingered, clear
@@ -647,10 +660,9 @@ export function endLayerGeometryEdit(
     // edits, or the untouched original on cancel).
     setEditTargetStoreVisible(targetId, editTargetOriginalVisible ?? true);
     editTargetOriginalVisible = null;
-    // restoreSketchesAfterSession() exits Geoman edit modes and clears the
-    // editor before reloading sketches. It is async (it awaits Geoman); the
-    // internal awaits keep its own steps ordered, so it is fire-and-forget here.
-    void restoreSketchesAfterSession();
+    // Await the sketches restore so a caller switching sessions does not start a
+    // new edit while the previous restore is still clearing/loading the editor.
+    await restoreSketchesAfterSession();
     applySketchesMapDisplay();
     notifyGeometryEdit();
   }

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -8,7 +8,6 @@ import {
   canEditLayerGeometry,
   reconcileEditedFeatures,
   tagFeatureKeys,
-  withSacrificialFirstFeature,
 } from "./geo-editor-geometry";
 import type {
   GeoLibreAppAPI,
@@ -139,7 +138,7 @@ export const maplibreGeoEditorPlugin: GeoLibrePlugin = {
     }
 
     bindSketchesStoreSync();
-    restoreSketchesLayerToEditor();
+    void restoreSketchesLayerToEditor();
     setTimeout(() => geoEditorControl?.expand(), 0);
   },
   deactivate: (app: GeoLibreAppAPI) => {
@@ -541,7 +540,7 @@ export async function startLayerGeometryEdit(
   savedSketchesCollection = cloneFeatureCollection(
     geoEditorControl.getAllFeatureCollection(),
   );
-  clearSketchesFromEditor();
+  await clearSketchesFromEditor();
   setSketchesMapLayerSuppressed(false);
 
   // The store layer is left untouched until save, so Cancel simply discards the
@@ -562,10 +561,7 @@ export async function startLayerGeometryEdit(
   restoringSketchesToEditor = true;
   try {
     const tagged = tagFeatureKeys(cloneFeatureCollection(layer.geojson));
-    geoEditorControl.loadGeoJson(
-      withSacrificialFirstFeature(tagged),
-      SKETCHES_SOURCE_PATH,
-    );
+    await geoEditorControl.loadGeoJson(tagged, SKETCHES_SOURCE_PATH);
     loaded = true;
   } catch (error) {
     // A "Missing source" failure means Geoman is not ready yet (handled by the
@@ -588,7 +584,7 @@ export async function startLayerGeometryEdit(
     setEditTargetStoreVisible(layerId, editTargetOriginalVisible ?? true);
     editTargetOriginalVisible = null;
     editTargetLayerId = null;
-    restoreSketchesAfterSession();
+    await restoreSketchesAfterSession();
     applySketchesMapDisplay();
     return false;
   }
@@ -652,8 +648,9 @@ export function endLayerGeometryEdit(
     setEditTargetStoreVisible(targetId, editTargetOriginalVisible ?? true);
     editTargetOriginalVisible = null;
     // restoreSketchesAfterSession() exits Geoman edit modes and clears the
-    // editor before reloading sketches.
-    restoreSketchesAfterSession();
+    // editor before reloading sketches. It is async (it awaits Geoman); the
+    // internal awaits keep its own steps ordered, so it is fire-and-forget here.
+    void restoreSketchesAfterSession();
     applySketchesMapDisplay();
     notifyGeometryEdit();
   }
@@ -675,23 +672,26 @@ function abortGeometryEditSession(): void {
   editTargetLayerId = null;
   sketchesIdleDisplayOverride = false;
   unionSketchesWithStoreOnNextSync = false;
-  restoreSketchesAfterSession();
+  void restoreSketchesAfterSession();
   applySketchesMapDisplay();
   notifyGeometryEdit();
 }
 
 /** Clear the editor and reload the sketches stashed at session start. */
-function restoreSketchesAfterSession(): void {
+async function restoreSketchesAfterSession(): Promise<void> {
   if (!geoEditorControl) {
     savedSketchesCollection = null;
     return;
   }
   disableActiveEditModes();
-  clearSketchesFromEditor();
+  await clearSketchesFromEditor();
   if (savedSketchesCollection?.features.length) {
     restoringSketchesToEditor = true;
     try {
-      geoEditorControl.loadGeoJson(savedSketchesCollection, SKETCHES_SOURCE_PATH);
+      await geoEditorControl.loadGeoJson(
+        savedSketchesCollection,
+        SKETCHES_SOURCE_PATH,
+      );
     } catch {
       // Geoman may not be ready; the store subscription will re-restore.
     } finally {
@@ -701,7 +701,7 @@ function restoreSketchesAfterSession(): void {
   savedSketchesCollection = null;
 }
 
-function restoreSketchesLayerToEditor(): void {
+async function restoreSketchesLayerToEditor(): Promise<void> {
   if (!geoEditorControl || !pluginActive) return;
 
   const layer = findSketchesLayer(useAppStore.getState().layers);
@@ -722,12 +722,12 @@ function restoreSketchesLayerToEditor(): void {
     // Geoman may not be ready yet.
   }
 
-  // `loadGeoJson` invokes `onGeoJsonLoad` synchronously, so clearing the guard
-  // in `finally` is safe; if it ever became async the guard would already be
-  // false when the callback runs and `syncSketchesToStore` could loop.
+  // `loadGeoJson` is async, so the guard is awaited through the load: it stays
+  // set while Geoman imports and fires onGeoJsonLoad, then is cleared in
+  // `finally`, preventing `syncSketchesToStore` from looping.
   restoringSketchesToEditor = true;
   try {
-    geoEditorControl.loadGeoJson(storeCollection, SKETCHES_SOURCE_PATH);
+    await geoEditorControl.loadGeoJson(storeCollection, SKETCHES_SOURCE_PATH);
   } catch {
     // Geoman may not be ready until the map style finishes loading.
   } finally {
@@ -736,11 +736,13 @@ function restoreSketchesLayerToEditor(): void {
   scheduleApplySketchesMapDisplay();
 }
 
-function clearSketchesFromEditor(): void {
+async function clearSketchesFromEditor(): Promise<void> {
   if (!geoEditorControl) return;
+  // loadGeoJson is async (it awaits Geoman's import); keep the guard set for the
+  // whole load so the onGeoJsonLoad callback it fires cannot re-enter the sync.
   restoringSketchesToEditor = true;
   try {
-    geoEditorControl.loadGeoJson(
+    await geoEditorControl.loadGeoJson(
       { type: "FeatureCollection", features: [] },
       SKETCHES_SOURCE_PATH,
     );
@@ -790,13 +792,13 @@ function bindSketchesStoreSync(): void {
 
     if (previousSketches && !sketches) {
       sketchesLayerId = null;
-      clearSketchesFromEditor();
+      void clearSketchesFromEditor();
       return;
     }
 
     if (sketches && sketches.id !== sketchesLayerId && !pushingSketchesToStore) {
       sketchesLayerId = sketches.id;
-      restoreSketchesLayerToEditor();
+      void restoreSketchesLayerToEditor();
       return;
     }
 
@@ -808,7 +810,7 @@ function bindSketchesStoreSync(): void {
       !restoringSketchesToEditor &&
       !pushingSketchesToStore
     ) {
-      restoreSketchesLayerToEditor();
+      void restoreSketchesLayerToEditor();
       return;
     }
 

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -508,6 +508,9 @@ async function ensureGeomanReady(): Promise<void> {
  * the target layer's features (id-tagged), and re-targets the sync/display
  * helpers at the target layer. Returns false when the plugin is not active or
  * the layer is not editable.
+ *
+ * `_app` is accepted for API symmetry with the other plugin entry points but is
+ * not used: this function operates through the module-level `appApi`/store.
  */
 export async function startLayerGeometryEdit(
   _app: GeoLibreAppAPI,
@@ -564,8 +567,16 @@ export async function startLayerGeometryEdit(
       SKETCHES_SOURCE_PATH,
     );
     loaded = true;
-  } catch {
-    // Geoman may not be ready until the map style finishes loading.
+  } catch (error) {
+    // A "Missing source" failure means Geoman is not ready yet (handled by the
+    // rollback below). Log anything else so unexpected failures (e.g. malformed
+    // geojson) are not silently swallowed.
+    if (
+      !(error instanceof Error) ||
+      !error.message.includes("Missing source")
+    ) {
+      console.warn("startLayerGeometryEdit: loadGeoJson failed", error);
+    }
   } finally {
     restoringSketchesToEditor = false;
   }
@@ -613,27 +624,39 @@ export function endLayerGeometryEdit(
   _app: GeoLibreAppAPI,
   { save }: { save: boolean },
 ): void {
-  if (!editTargetLayerId || !geoEditorControl) return;
+  if (!editTargetLayerId) return;
+
+  // Defensive: if the control was torn down while a session id lingered, clear
+  // the session state so the UI does not get stuck in the "editing" state.
+  if (!geoEditorControl) {
+    editTargetLayerId = null;
+    editTargetOriginalVisible = null;
+    sketchesIdleDisplayOverride = false;
+    unionSketchesWithStoreOnNextSync = false;
+    notifyGeometryEdit();
+    return;
+  }
 
   const targetId = editTargetLayerId;
-  if (save) syncEditTargetToStore();
-
-  // Exit edit modes and clear the editor before restoring Sketches, so Geoman's
-  // temporary edit features do not linger on the map.
-  disableActiveEditModes();
-
-  editTargetLayerId = null;
-  sketchesIdleDisplayOverride = false;
-  unionSketchesWithStoreOnNextSync = false;
-
-  // Restore the target layer's normal rendering (it now reflects the saved
-  // edits, or the untouched original on cancel).
-  setEditTargetStoreVisible(targetId, editTargetOriginalVisible ?? true);
-  editTargetOriginalVisible = null;
-
-  restoreSketchesAfterSession();
-  applySketchesMapDisplay();
-  notifyGeometryEdit();
+  // Run the write-back in try/finally so a throw (e.g. from the store update)
+  // cannot leave the session half-torn-down with the target layer still hidden
+  // and the user unable to exit.
+  try {
+    if (save) syncEditTargetToStore();
+  } finally {
+    editTargetLayerId = null;
+    sketchesIdleDisplayOverride = false;
+    unionSketchesWithStoreOnNextSync = false;
+    // Restore the target layer's normal rendering (it now reflects the saved
+    // edits, or the untouched original on cancel).
+    setEditTargetStoreVisible(targetId, editTargetOriginalVisible ?? true);
+    editTargetOriginalVisible = null;
+    // restoreSketchesAfterSession() exits Geoman edit modes and clears the
+    // editor before reloading sketches.
+    restoreSketchesAfterSession();
+    applySketchesMapDisplay();
+    notifyGeometryEdit();
+  }
 }
 
 /**
@@ -646,8 +669,8 @@ function abortGeometryEditSession(): void {
     "Geometry edit session aborted: the target layer was removed; " +
       "in-progress geometry edits were discarded.",
   );
-  disableActiveEditModes();
   // The layer is gone, so there is no visibility to restore; just drop the flag.
+  // (restoreSketchesAfterSession exits Geoman edit modes.)
   editTargetOriginalVisible = null;
   editTargetLayerId = null;
   sketchesIdleDisplayOverride = false;
@@ -752,6 +775,11 @@ function bindSketchesStoreSync(): void {
           target.opacity !== previousTarget.opacity ||
           target.style !== previousTarget.style)
       ) {
+        // If the user toggled the target layer back on while editing, re-hide it
+        // so its stale normal rendering does not double-draw over Geoman.
+        if (target.visible && !previousTarget.visible) {
+          setEditTargetStoreVisible(editTargetLayerId, false);
+        }
         scheduleApplySketchesMapDisplay();
       }
       return;

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -492,16 +492,28 @@ export function startLayerGeometryEdit(
   sketchesIdleDisplayOverride = false;
   unionSketchesWithStoreOnNextSync = false;
 
+  let loaded = false;
   restoringSketchesToEditor = true;
   try {
     geoEditorControl.loadGeoJson(
       tagFeatureKeys(cloneFeatureCollection(layer.geojson)),
       SKETCHES_SOURCE_PATH,
     );
+    loaded = true;
   } catch {
     // Geoman may not be ready until the map style finishes loading.
   } finally {
     restoringSketchesToEditor = false;
+  }
+
+  // If the load failed the editor is empty; do NOT keep the session active or a
+  // later Save would overwrite the layer with an empty collection. Roll back:
+  // restore the stashed sketches and report failure so the caller can retry.
+  if (!loaded) {
+    editTargetLayerId = null;
+    restoreSketchesAfterSession();
+    applySketchesMapDisplay();
+    return false;
   }
 
   applySketchesMapDisplay();
@@ -541,6 +553,10 @@ export function endLayerGeometryEdit(
  * layer.
  */
 function abortGeometryEditSession(): void {
+  console.warn(
+    "Geometry edit session aborted: the target layer was removed; " +
+      "in-progress geometry edits were discarded.",
+  );
   editTargetLayerId = null;
   sketchesIdleDisplayOverride = false;
   unionSketchesWithStoreOnNextSync = false;

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -8,6 +8,7 @@ import {
   canEditLayerGeometry,
   reconcileEditedFeatures,
   tagFeatureKeys,
+  withSacrificialFirstFeature,
 } from "./geo-editor-geometry";
 import type {
   GeoLibreAppAPI,
@@ -486,16 +487,32 @@ function writeBackToVectorSource(
 }
 
 /**
+ * Wait until Geoman has finished its asynchronous initialization. Geoman creates
+ * its feature sources during an async `init()`, so importing features before it
+ * is loaded fails with "Missing source for feature creation" and the features
+ * are silently dropped (they render but cannot be edited).
+ */
+async function ensureGeomanReady(): Promise<void> {
+  const geoman = geomanInstance;
+  if (!geoman || geoman.loaded) return;
+  try {
+    await geoman.waitForGeomanLoaded();
+  } catch {
+    // If readiness cannot be awaited, the caller's load will no-op safely.
+  }
+}
+
+/**
  * Begin editing the geometry of an existing vector layer in place, reusing the
  * shared Geoman editor. Stashes any current sketches out of the editor, loads
  * the target layer's features (id-tagged), and re-targets the sync/display
  * helpers at the target layer. Returns false when the plugin is not active or
  * the layer is not editable.
  */
-export function startLayerGeometryEdit(
+export async function startLayerGeometryEdit(
   _app: GeoLibreAppAPI,
   layerId: string,
-): boolean {
+): Promise<boolean> {
   if (!pluginActive || !geoEditorControl) return false;
 
   // Only one session at a time; finish any open one first (saving its work).
@@ -508,6 +525,11 @@ export function startLayerGeometryEdit(
     .getState()
     .layers.find((candidate) => candidate.id === layerId);
   if (!layer || !canEditLayerGeometry(layer) || !layer.geojson) return false;
+
+  // Geoman may have only just been created (the plugin was activated for this
+  // edit); wait for it to finish initializing so the import below succeeds.
+  await ensureGeomanReady();
+  if (!pluginActive || !geoEditorControl) return false;
 
   // Flush sketches to the store, stash them out of the editor, and restore the
   // Sketches store layer's normal rendering (it stays visible as a plain layer
@@ -537,20 +559,11 @@ export function startLayerGeometryEdit(
   restoringSketchesToEditor = true;
   try {
     const tagged = tagFeatureKeys(cloneFeatureCollection(layer.geojson));
-    const result = geoEditorControl.loadGeoJson(tagged, SKETCHES_SOURCE_PATH);
+    geoEditorControl.loadGeoJson(
+      withSacrificialFirstFeature(tagged),
+      SKETCHES_SOURCE_PATH,
+    );
     loaded = true;
-    // Geoman skips features whose geometry shape it cannot map (e.g. some
-    // MultiPolygon/GeometryCollection inputs); those render but are not editable.
-    // Surface the count so the cause is visible instead of looking like a bug.
-    const importedCount = result?.count ?? tagged.features.length;
-    if (importedCount < tagged.features.length) {
-      console.warn(
-        `Geometry edit: ${
-          tagged.features.length - importedCount
-        } of ${tagged.features.length} features could not be loaded into the ` +
-          "editor and will not be editable (unsupported geometry shape).",
-      );
-    }
   } catch {
     // Geoman may not be ready until the map style finishes loading.
   } finally {

--- a/tests/geo-editor-geometry.test.ts
+++ b/tests/geo-editor-geometry.test.ts
@@ -110,6 +110,20 @@ describe("canEditLayerGeometry", () => {
       ),
       false,
     );
+    // maplibre-gl-vector with an empty sourceIds array: still no usable source.
+    assert.equal(
+      canEditLayerGeometry(
+        makeLayer({
+          geojson: undefined,
+          metadata: {
+            sourceKind: "maplibre-gl-vector",
+            externalNativeLayer: true,
+            sourceIds: [],
+          },
+        }),
+      ),
+      false,
+    );
   });
 
   it("allows Add-Vector-Layer geojson-mode layers (features in a source)", () => {

--- a/tests/geo-editor-geometry.test.ts
+++ b/tests/geo-editor-geometry.test.ts
@@ -91,23 +91,17 @@ describe("canEditLayerGeometry", () => {
     );
   });
 
-  it("rejects Add-Vector-Layer control layers", () => {
-    // sourceKind alone is enough to reject.
-    assert.equal(
-      canEditLayerGeometry(
-        makeLayer({ metadata: { sourceKind: "maplibre-gl-vector" } }),
-      ),
-      false,
-    );
-    // externalNativeLayer alone is also enough.
+  it("rejects generic external native layers", () => {
+    // externalNativeLayer that is not an Add-Vector-Layer source is not editable.
     assert.equal(
       canEditLayerGeometry(makeLayer({ metadata: { externalNativeLayer: true } })),
       false,
     );
-    // Both together (the original combined case).
+    // maplibre-gl-vector but missing sourceIds: no readable source to edit.
     assert.equal(
       canEditLayerGeometry(
         makeLayer({
+          geojson: undefined,
           metadata: {
             sourceKind: "maplibre-gl-vector",
             externalNativeLayer: true,
@@ -115,6 +109,22 @@ describe("canEditLayerGeometry", () => {
         }),
       ),
       false,
+    );
+  });
+
+  it("allows Add-Vector-Layer geojson-mode layers (features in a source)", () => {
+    assert.equal(
+      canEditLayerGeometry(
+        makeLayer({
+          geojson: undefined,
+          metadata: {
+            sourceKind: "maplibre-gl-vector",
+            externalNativeLayer: true,
+            sourceIds: ["src-1"],
+          },
+        }),
+      ),
+      true,
     );
   });
 });

--- a/tests/geo-editor-geometry.test.ts
+++ b/tests/geo-editor-geometry.test.ts
@@ -1,0 +1,180 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { FeatureCollection } from "geojson";
+import type { GeoLibreLayer } from "../packages/core/src/types";
+import {
+  GEOMETRY_EDIT_FID_PROPERTY,
+  canEditLayerGeometry,
+  reconcileEditedFeatures,
+  tagFeatureKeys,
+} from "../packages/plugins/src/plugins/geo-editor-geometry";
+
+function makeLayer(overrides: Partial<GeoLibreLayer>): GeoLibreLayer {
+  return {
+    id: "layer-1",
+    name: "Layer 1",
+    type: "geojson",
+    source: {},
+    visible: true,
+    opacity: 1,
+    style: {},
+    metadata: {},
+    geojson: { type: "FeatureCollection", features: [] },
+    ...overrides,
+  } as unknown as GeoLibreLayer;
+}
+
+function point(
+  id: string | number | undefined,
+  properties: Record<string, unknown> = {},
+) {
+  return {
+    type: "Feature" as const,
+    id,
+    geometry: { type: "Point" as const, coordinates: [0, 0] },
+    properties,
+  };
+}
+
+describe("canEditLayerGeometry", () => {
+  it("allows an in-memory geojson vector layer", () => {
+    assert.equal(
+      canEditLayerGeometry(
+        makeLayer({
+          geojson: { type: "FeatureCollection", features: [point(0)] },
+        }),
+      ),
+      true,
+    );
+  });
+
+  it("allows an empty-but-present feature collection", () => {
+    assert.equal(canEditLayerGeometry(makeLayer({})), true);
+  });
+
+  it("rejects an undefined layer", () => {
+    assert.equal(canEditLayerGeometry(undefined), false);
+  });
+
+  it("rejects non-vector layer types", () => {
+    assert.equal(
+      canEditLayerGeometry(makeLayer({ type: "raster", geojson: undefined })),
+      false,
+    );
+  });
+
+  it("rejects a layer without an in-memory feature collection", () => {
+    assert.equal(canEditLayerGeometry(makeLayer({ geojson: undefined })), false);
+  });
+
+  it("rejects DuckDB query layers", () => {
+    assert.equal(
+      canEditLayerGeometry(
+        makeLayer({
+          type: "duckdb-query",
+          metadata: {
+            sourceKind: "duckdb-query",
+            externalDeckLayer: true,
+          },
+        }),
+      ),
+      false,
+    );
+  });
+
+  it("rejects the GeoEditor Sketches layer", () => {
+    assert.equal(
+      canEditLayerGeometry(
+        makeLayer({ metadata: { sourceKind: "geoeditor-sketches" } }),
+      ),
+      false,
+    );
+  });
+
+  it("rejects Add-Vector-Layer control layers", () => {
+    assert.equal(
+      canEditLayerGeometry(
+        makeLayer({
+          metadata: {
+            sourceKind: "maplibre-gl-vector",
+            externalNativeLayer: true,
+          },
+        }),
+      ),
+      false,
+    );
+    assert.equal(
+      canEditLayerGeometry(makeLayer({ metadata: { externalNativeLayer: true } })),
+      false,
+    );
+  });
+});
+
+describe("tagFeatureKeys", () => {
+  it("tags each feature with its stable id, falling back to the index", () => {
+    const collection: FeatureCollection = {
+      type: "FeatureCollection",
+      features: [point("a"), point(undefined)],
+    };
+    const tagged = tagFeatureKeys(collection);
+    assert.equal(
+      tagged.features[0].properties?.[GEOMETRY_EDIT_FID_PROPERTY],
+      "a",
+    );
+    assert.equal(
+      tagged.features[1].properties?.[GEOMETRY_EDIT_FID_PROPERTY],
+      "1",
+    );
+    // Original collection is not mutated.
+    assert.equal(
+      collection.features[0].properties?.[GEOMETRY_EDIT_FID_PROPERTY],
+      undefined,
+    );
+  });
+});
+
+describe("reconcileEditedFeatures", () => {
+  it("restores tagged ids and strips the tag", () => {
+    const tagged = tagFeatureKeys({
+      type: "FeatureCollection",
+      features: [point("a", { name: "A" }), point("b", { name: "B" })],
+    });
+    const reconciled = reconcileEditedFeatures(tagged);
+    assert.deepEqual(
+      reconciled.features.map((f) => f.id),
+      ["a", "b"],
+    );
+    for (const feature of reconciled.features) {
+      assert.equal(feature.properties?.[GEOMETRY_EDIT_FID_PROPERTY], undefined);
+    }
+    assert.equal(reconciled.features[0].properties?.name, "A");
+  });
+
+  it("assigns fresh non-colliding ids to new (untagged) features", () => {
+    // Tagged feature keeps id "0"; the untagged new feature must not reuse "0".
+    const collection: FeatureCollection = {
+      type: "FeatureCollection",
+      features: [
+        { ...point(undefined), properties: { [GEOMETRY_EDIT_FID_PROPERTY]: "0" } },
+        point(undefined, { drawn: true }),
+      ],
+    };
+    const reconciled = reconcileEditedFeatures(collection);
+    const ids = reconciled.features.map((f) => String(f.id));
+    assert.equal(ids[0], "0");
+    assert.notEqual(ids[1], "0");
+    assert.equal(new Set(ids).size, ids.length);
+  });
+
+  it("round-trips original ids through tag then reconcile", () => {
+    const original: FeatureCollection = {
+      type: "FeatureCollection",
+      features: [point(5), point(12), point(undefined)],
+    };
+    const reconciled = reconcileEditedFeatures(tagFeatureKeys(original));
+    assert.deepEqual(
+      reconciled.features.map((f) => String(f.id)),
+      ["5", "12", "2"],
+    );
+  });
+});

--- a/tests/geo-editor-geometry.test.ts
+++ b/tests/geo-editor-geometry.test.ts
@@ -130,7 +130,7 @@ describe("canEditLayerGeometry", () => {
 });
 
 describe("tagFeatureKeys", () => {
-  it("tags each feature with its stable id, falling back to the index", () => {
+  it("tags each feature with a unique id mirrored into feature.id", () => {
     const collection: FeatureCollection = {
       type: "FeatureCollection",
       features: [point("a"), point(undefined)],
@@ -140,15 +140,29 @@ describe("tagFeatureKeys", () => {
       tagged.features[0].properties?.[GEOMETRY_EDIT_FID_PROPERTY],
       "a",
     );
+    assert.equal(tagged.features[0].id, "a");
+    // The untagged feature gets a freshly allocated, non-colliding id.
+    const secondId = String(tagged.features[1].id);
     assert.equal(
       tagged.features[1].properties?.[GEOMETRY_EDIT_FID_PROPERTY],
-      "1",
+      secondId,
     );
+    assert.notEqual(secondId, "a");
     // Original collection is not mutated.
     assert.equal(
       collection.features[0].properties?.[GEOMETRY_EDIT_FID_PROPERTY],
       undefined,
     );
+  });
+
+  it("assigns unique ids when the input has duplicate ids", () => {
+    const tagged = tagFeatureKeys({
+      type: "FeatureCollection",
+      features: [point("dup"), point("dup"), point("dup")],
+    });
+    const ids = tagged.features.map((f) => String(f.id));
+    assert.equal(new Set(ids).size, ids.length);
+    assert.equal(ids[0], "dup");
   });
 });
 
@@ -193,7 +207,25 @@ describe("reconcileEditedFeatures", () => {
     const reconciled = reconcileEditedFeatures(tagFeatureKeys(original));
     assert.deepEqual(
       reconciled.features.map((f) => String(f.id)),
-      ["5", "12", "2"],
+      ["5", "12", "0"],
     );
+  });
+
+  it("de-duplicates ids when a tag was cloned (e.g. a copied feature)", () => {
+    // Two features share the same tag, as a Geoman copy that cloned properties
+    // would produce. Reconcile must give them distinct ids so Geoman does not
+    // overwrite one with the other on the next load.
+    const collection: FeatureCollection = {
+      type: "FeatureCollection",
+      features: [
+        { ...point(undefined), properties: { [GEOMETRY_EDIT_FID_PROPERTY]: "7" } },
+        { ...point(undefined), properties: { [GEOMETRY_EDIT_FID_PROPERTY]: "7" } },
+      ],
+    };
+    const reconciled = reconcileEditedFeatures(collection);
+    const ids = reconciled.features.map((f) => String(f.id));
+    assert.equal(ids[0], "7");
+    assert.notEqual(ids[1], "7");
+    assert.equal(new Set(ids).size, ids.length);
   });
 });

--- a/tests/geo-editor-geometry.test.ts
+++ b/tests/geo-editor-geometry.test.ts
@@ -4,11 +4,9 @@ import type { FeatureCollection } from "geojson";
 import type { GeoLibreLayer } from "../packages/core/src/types";
 import {
   GEOMETRY_EDIT_FID_PROPERTY,
-  GEOMETRY_EDIT_SACRIFICE_ID,
   canEditLayerGeometry,
   reconcileEditedFeatures,
   tagFeatureKeys,
-  withSacrificialFirstFeature,
 } from "../packages/plugins/src/plugins/geo-editor-geometry";
 
 function makeLayer(overrides: Partial<GeoLibreLayer>): GeoLibreLayer {
@@ -213,22 +211,6 @@ describe("reconcileEditedFeatures", () => {
     );
   });
 
-  it("drops the sacrificial placeholder if it survived import", () => {
-    const collection: FeatureCollection = {
-      type: "FeatureCollection",
-      features: [
-        {
-          ...point(undefined),
-          properties: { [GEOMETRY_EDIT_FID_PROPERTY]: GEOMETRY_EDIT_SACRIFICE_ID },
-        },
-        { ...point(undefined), properties: { [GEOMETRY_EDIT_FID_PROPERTY]: "3" } },
-      ],
-    };
-    const reconciled = reconcileEditedFeatures(collection);
-    assert.equal(reconciled.features.length, 1);
-    assert.equal(reconciled.features[0].id, "3");
-  });
-
   it("avoids id collision when an index-based fallback could match an explicit id", () => {
     // Feature at index 2 has id undefined; another feature carries explicit id 2.
     // The unique-id allocator must not assign "2" to both.
@@ -258,28 +240,5 @@ describe("reconcileEditedFeatures", () => {
     assert.equal(ids[0], "7");
     assert.notEqual(ids[1], "7");
     assert.equal(new Set(ids).size, ids.length);
-  });
-});
-
-describe("withSacrificialFirstFeature", () => {
-  it("prepends a placeholder so a real feature is not the first imported", () => {
-    const tagged = tagFeatureKeys({
-      type: "FeatureCollection",
-      features: [point("a"), point("b")],
-    });
-    const guarded = withSacrificialFirstFeature(tagged);
-    assert.equal(guarded.features.length, 3);
-    assert.equal(guarded.features[0].id, GEOMETRY_EDIT_SACRIFICE_ID);
-    // The real features follow the placeholder, unchanged and in order.
-    assert.deepEqual(
-      guarded.features.slice(1).map((f) => f.id),
-      ["a", "b"],
-    );
-    // A full round-trip yields exactly the real features (placeholder removed).
-    const reconciled = reconcileEditedFeatures(guarded);
-    assert.deepEqual(
-      reconciled.features.map((f) => f.id),
-      ["a", "b"],
-    );
   });
 });

--- a/tests/geo-editor-geometry.test.ts
+++ b/tests/geo-editor-geometry.test.ts
@@ -229,6 +229,19 @@ describe("reconcileEditedFeatures", () => {
     assert.equal(reconciled.features[0].id, "3");
   });
 
+  it("avoids id collision when an index-based fallback could match an explicit id", () => {
+    // Feature at index 2 has id undefined; another feature carries explicit id 2.
+    // The unique-id allocator must not assign "2" to both.
+    const original: FeatureCollection = {
+      type: "FeatureCollection",
+      features: [point(2), point(5), point(undefined)],
+    };
+    const reconciled = reconcileEditedFeatures(tagFeatureKeys(original));
+    const ids = reconciled.features.map((f) => String(f.id));
+    assert.equal(new Set(ids).size, ids.length, `duplicate ids: ${ids}`);
+    assert.equal(ids[0], "2"); // the explicit id 2 must survive
+  });
+
   it("de-duplicates ids when a tag was cloned (e.g. a copied feature)", () => {
     // Two features share the same tag, as a Geoman copy that cloned properties
     // would produce. Reconcile must give them distinct ids so Geoman does not

--- a/tests/geo-editor-geometry.test.ts
+++ b/tests/geo-editor-geometry.test.ts
@@ -92,6 +92,19 @@ describe("canEditLayerGeometry", () => {
   });
 
   it("rejects Add-Vector-Layer control layers", () => {
+    // sourceKind alone is enough to reject.
+    assert.equal(
+      canEditLayerGeometry(
+        makeLayer({ metadata: { sourceKind: "maplibre-gl-vector" } }),
+      ),
+      false,
+    );
+    // externalNativeLayer alone is also enough.
+    assert.equal(
+      canEditLayerGeometry(makeLayer({ metadata: { externalNativeLayer: true } })),
+      false,
+    );
+    // Both together (the original combined case).
     assert.equal(
       canEditLayerGeometry(
         makeLayer({
@@ -101,10 +114,6 @@ describe("canEditLayerGeometry", () => {
           },
         }),
       ),
-      false,
-    );
-    assert.equal(
-      canEditLayerGeometry(makeLayer({ metadata: { externalNativeLayer: true } })),
       false,
     );
   });

--- a/tests/geo-editor-geometry.test.ts
+++ b/tests/geo-editor-geometry.test.ts
@@ -4,9 +4,11 @@ import type { FeatureCollection } from "geojson";
 import type { GeoLibreLayer } from "../packages/core/src/types";
 import {
   GEOMETRY_EDIT_FID_PROPERTY,
+  GEOMETRY_EDIT_SACRIFICE_ID,
   canEditLayerGeometry,
   reconcileEditedFeatures,
   tagFeatureKeys,
+  withSacrificialFirstFeature,
 } from "../packages/plugins/src/plugins/geo-editor-geometry";
 
 function makeLayer(overrides: Partial<GeoLibreLayer>): GeoLibreLayer {
@@ -211,6 +213,22 @@ describe("reconcileEditedFeatures", () => {
     );
   });
 
+  it("drops the sacrificial placeholder if it survived import", () => {
+    const collection: FeatureCollection = {
+      type: "FeatureCollection",
+      features: [
+        {
+          ...point(undefined),
+          properties: { [GEOMETRY_EDIT_FID_PROPERTY]: GEOMETRY_EDIT_SACRIFICE_ID },
+        },
+        { ...point(undefined), properties: { [GEOMETRY_EDIT_FID_PROPERTY]: "3" } },
+      ],
+    };
+    const reconciled = reconcileEditedFeatures(collection);
+    assert.equal(reconciled.features.length, 1);
+    assert.equal(reconciled.features[0].id, "3");
+  });
+
   it("de-duplicates ids when a tag was cloned (e.g. a copied feature)", () => {
     // Two features share the same tag, as a Geoman copy that cloned properties
     // would produce. Reconcile must give them distinct ids so Geoman does not
@@ -227,5 +245,28 @@ describe("reconcileEditedFeatures", () => {
     assert.equal(ids[0], "7");
     assert.notEqual(ids[1], "7");
     assert.equal(new Set(ids).size, ids.length);
+  });
+});
+
+describe("withSacrificialFirstFeature", () => {
+  it("prepends a placeholder so a real feature is not the first imported", () => {
+    const tagged = tagFeatureKeys({
+      type: "FeatureCollection",
+      features: [point("a"), point("b")],
+    });
+    const guarded = withSacrificialFirstFeature(tagged);
+    assert.equal(guarded.features.length, 3);
+    assert.equal(guarded.features[0].id, GEOMETRY_EDIT_SACRIFICE_ID);
+    // The real features follow the placeholder, unchanged and in order.
+    assert.deepEqual(
+      guarded.features.slice(1).map((f) => f.id),
+      ["a", "b"],
+    );
+    // A full round-trip yields exactly the real features (placeholder removed).
+    const reconciled = reconcileEditedFeatures(guarded);
+    assert.deepEqual(
+      reconciled.features.map((f) => f.id),
+      ["a", "b"],
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Upgrade `maplibre-gl-geo-editor` to `^0.8.0` (app + plugins packages).
- Adapt to the breaking change: `loadGeoJson` is now async. Await it and the now-async sketches helpers (`clearSketchesFromEditor` / `restoreSketchesLayerToEditor` / `restoreSketchesAfterSession`) so the `restoringSketchesToEditor` guard spans the load and `onGeoJsonLoad` cannot re-enter the sync.
- Remove the sacrificial-placeholder workaround and its helper/tests.

## Why the workaround is no longer needed
The "first feature dropped on import" symptom was caused by geo-editor 0.7.x calling `deleteAll()` and `importGeoJson()` without awaiting: `deleteAll()`'s async `featureStore.clear()` ran *after* `importGeoJson()` had already added the first feature, wiping it. 0.8.0 awaits `deleteAll()` before importing, so all features load.

## Verification (live app, Playwright)
- Load a 540-feature layer -> Edit geometry: `Loaded 540 features`, no `Missing source` errors (previously dropped to 539).
- Save -> re-edit: `Loaded 540 features` again; all preserved across the round-trip.
- Confirmed directly that Geoman's store holds 540/540 without the placeholder.

## Test plan
- [x] `npm run test:frontend` (full suite passes; geometry helper tests updated)
- [x] `pre-commit run` on changed files (includes full build)
- [x] Manual: edit / save / re-edit a GeoJSON layer in the running app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-place geometry editing for vector layers with visible Edit/Save/Cancel controls, session gating to prevent conflicts, and UI feedback for errors
  * Materialize query-backed layers into editable GeoJSON with validation, single-run guard, and optional map fit
  * Editor exposes geometry-edit utilities for broader integration

* **Tests**
  * Added unit tests for geometry-edit utilities and reconciliation behavior

* **Chores**
  * Upgraded geometry editor plugin dependency to a newer minor version
<!-- end of auto-generated comment: release notes by coderabbit.ai -->