### PR TITLE
feat: activate an installed plugin when a URL parameter it owns is present

### DIFF
--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -28,8 +28,14 @@ export interface GeoLibrePlugin {
   name: string;
   version: string;
   activeByDefault?: boolean;
+  /** At least one name is required for handleUrlParameters to be called. */
+  urlParameterNames?: string[];
   activate: (app: GeoLibreAppAPI) => boolean | void;
   deactivate: (app: GeoLibreAppAPI) => void;
+  handleUrlParameters?: (
+    app: GeoLibreAppAPI,
+    params: URLSearchParams,
+  ) => void | Promise<void>;
   getMapControlPosition?: () => GeoLibreMapControlPosition;
   setMapControlPosition?: (
     app: GeoLibreAppAPI,

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -117,7 +117,7 @@ Map control plugins can optionally expose `getMapControlPosition()` and `setMapC
 
 Plugins with serializable runtime settings can expose `getProjectState()` and `applyProjectState()` so GeoLibre can save and restore those settings in the project file. A wrapper should use these hooks to adapt upstream control APIs such as `getState()` without requiring every upstream package to implement a GeoLibre-specific interface.
 
-Plugins can also declare URL query parameters and handle them when GeoLibre opens. URL parameter handlers run after the map is ready, external plugins are loaded, and project plugin state has been restored. GeoLibre calls handlers only for active plugins whose declared parameter names are present in the URL, and it suppresses repeated handling of the same URL context for the same plugin. Parameter names are case-sensitive, as URL query parameters are: declaring `exampleGeoJson` will not match `?ExampleGeoJson=…`.
+Plugins can also declare URL query parameters and handle them when GeoLibre opens. URL parameter handlers run after the map is ready, external plugins are loaded, and project plugin state has been restored. GeoLibre calls handlers for plugins whose declared parameter names are present in the URL, and it suppresses repeated handling of the same URL context for the same plugin. If a matching plugin is registered (installed) but inactive, GeoLibre first attempts to activate it via `PluginManager.activate`; the handler runs only if activation succeeds (an `activate()` that returns `false` or throws leaves the plugin inactive and skips dispatch). Parameter names are case-sensitive, as URL query parameters are: declaring `exampleGeoJson` will not match `?ExampleGeoJson=…`.
 
 ```typescript
 import type { GeoLibreAppAPI, GeoLibrePlugin } from "@geolibre/plugins";
@@ -163,7 +163,7 @@ For example:
 https://viewer.geolibre.app/?url=https://example.com/project.geolibre.json&exampleGeoJson=https://example.com/data.geojson
 ```
 
-A URL parameter does not activate an inactive plugin by itself. For external plugins, include the plugin manifest URL and active plugin ID in the project `plugins` state, or have the user enable the plugin before relying on its URL handler.
+A URL parameter activates only an already-registered (installed) plugin that owns it; it never loads a plugin from the URL. For external plugins, include the plugin manifest URL in the project `plugins` state (so the plugin is registered) before relying on its URL handler — the matching parameter then activates and dispatches it even if it is not in the active set.
 
 ## External plugins
 

--- a/packages/plugins/src/plugin-manager.ts
+++ b/packages/plugins/src/plugin-manager.ts
@@ -173,17 +173,30 @@ export class PluginManager {
           continue;
         }
 
+        // Skip before activating: a context already handled this plugin, so
+        // re-running activation side-effects (e.g. after a manual deactivate)
+        // would reactivate it without ever dispatching the handler again.
+        if (handledPluginIds.has(id)) continue;
+
         // A deep link to a parameter a plugin owns implies the user wants that
         // plugin: activate it if it is installed (registered) but inactive, so
         // e.g. ?annotate-data=... brings up its plugin. Only already-registered
         // (trusted) plugins are activated here; nothing is loaded from the URL.
-        // If activation is refused, skip dispatch.
+        // If activation is refused or throws, skip dispatch and isolate the
+        // failure to this plugin instead of aborting the whole loop.
         if (!this.active.has(id)) {
-          this.activate(id, app);
+          try {
+            this.activate(id, app);
+          } catch (error) {
+            console.warn(
+              `Plugin '${id}' could not be activated from GeoLibre URL parameters.`,
+              error,
+            );
+            continue;
+          }
           if (!this.active.has(id)) continue;
         }
 
-        if (handledPluginIds.has(id)) continue;
         // Mark before awaiting so a concurrent dispatch for the same context
         // cannot double-fire the handler.
         handledPluginIds.add(id);

--- a/packages/plugins/src/plugin-manager.ts
+++ b/packages/plugins/src/plugin-manager.ts
@@ -163,7 +163,7 @@ export class PluginManager {
 
     try {
       for (const [id, plugin] of this.plugins) {
-        if (!this.active.has(id) || !plugin.handleUrlParameters) continue;
+        if (!plugin.handleUrlParameters) continue;
 
         const parameterNames = this.urlParameterNamesById.get(id) ?? [];
         if (
@@ -171,6 +171,16 @@ export class PluginManager {
           !parameterNames.some((name) => params.has(name))
         ) {
           continue;
+        }
+
+        // A deep link to a parameter a plugin owns implies the user wants that
+        // plugin: activate it if it is installed (registered) but inactive, so
+        // e.g. ?annotate-data=... brings up its plugin. Only already-registered
+        // (trusted) plugins are activated here; nothing is loaded from the URL.
+        // If activation is refused, skip dispatch.
+        if (!this.active.has(id)) {
+          this.activate(id, app);
+          if (!this.active.has(id)) continue;
         }
 
         if (handledPluginIds.has(id)) continue;

--- a/packages/plugins/src/plugin-manager.ts
+++ b/packages/plugins/src/plugin-manager.ts
@@ -177,6 +177,11 @@ export class PluginManager {
         // re-running activation side-effects (e.g. after a manual deactivate)
         // would reactivate it without ever dispatching the handler again.
         if (handledPluginIds.has(id)) continue;
+        // Reserve dedup before activating: activate() notifies listeners
+        // synchronously, and a re-entrant URL dispatch for the same context
+        // must not double-run this plugin. Rolled back on every path that
+        // ends without dispatching the handler.
+        handledPluginIds.add(id);
 
         // A deep link to a parameter a plugin owns implies the user wants that
         // plugin: activate it if it is installed (registered) but inactive, so
@@ -188,18 +193,18 @@ export class PluginManager {
           try {
             this.activate(id, app);
           } catch (error) {
+            handledPluginIds.delete(id);
             console.warn(
               `Plugin '${id}' could not be activated from GeoLibre URL parameters.`,
               error,
             );
             continue;
           }
-          if (!this.active.has(id)) continue;
+          if (!this.active.has(id)) {
+            handledPluginIds.delete(id);
+            continue;
+          }
         }
-
-        // Mark before awaiting so a concurrent dispatch for the same context
-        // cannot double-fire the handler.
-        handledPluginIds.add(id);
 
         try {
           await plugin.handleUrlParameters(app, new URLSearchParams(params));

--- a/tests/plugin-manager.test.ts
+++ b/tests/plugin-manager.test.ts
@@ -109,6 +109,16 @@ describe("PluginManager URL parameters", () => {
     assert.deepEqual(calls, ["ds.zip"]);
     // Activated exactly once, with the app passed to handleUrlParameters.
     assert.deepEqual(activateApps, [app]);
+
+    // Second dispatch for the same context: dedup means neither the handler
+    // nor activation re-fires for the auto-activated plugin.
+    await manager.handleUrlParameters(
+      new URLSearchParams("data=ds.zip"),
+      app,
+      "ctx",
+    );
+    assert.deepEqual(calls, ["ds.zip"]);
+    assert.deepEqual(activateApps, [app]);
   });
 
   it("leaves an inactive plugin inactive when its parameter is absent", async () => {

--- a/tests/plugin-manager.test.ts
+++ b/tests/plugin-manager.test.ts
@@ -34,10 +34,10 @@ describe("PluginManager URL parameters", () => {
     );
     manager.register(
       testPlugin({
-        id: "inactive-loader",
-        urlParameterNames: ["data"],
+        id: "unmatched-loader",
+        urlParameterNames: ["missing"],
         handleUrlParameters: () => {
-          calls.push("inactive");
+          calls.push("unmatched");
         },
       }),
     );
@@ -50,6 +50,7 @@ describe("PluginManager URL parameters", () => {
       }),
     );
     manager.activate("url-loader", app);
+    manager.activate("unmatched-loader", app);
     manager.activate("undeclared-loader", app);
 
     await manager.handleUrlParameters(
@@ -77,6 +78,87 @@ describe("PluginManager URL parameters", () => {
       "https://example.com/data.geojson",
       "https://example.com/next.geojson",
     ]);
+  });
+
+  it("activates an installed-but-inactive plugin that owns a present parameter", async () => {
+    const calls: string[] = [];
+    const activateApps: GeoLibreAppAPI[] = [];
+    const manager = new PluginManager();
+
+    manager.register(
+      testPlugin({
+        id: "deep-link-loader",
+        urlParameterNames: ["data"],
+        activate: (a) => {
+          activateApps.push(a);
+        },
+        handleUrlParameters: (_app, params) => {
+          calls.push(params.get("data") ?? "");
+        },
+      }),
+    );
+    assert.equal(manager.isActive("deep-link-loader"), false);
+
+    await manager.handleUrlParameters(
+      new URLSearchParams("data=ds.zip"),
+      app,
+      "ctx",
+    );
+
+    assert.equal(manager.isActive("deep-link-loader"), true);
+    assert.deepEqual(calls, ["ds.zip"]);
+    // Activated exactly once, with the app passed to handleUrlParameters.
+    assert.deepEqual(activateApps, [app]);
+  });
+
+  it("leaves an inactive plugin inactive when its parameter is absent", async () => {
+    const manager = new PluginManager();
+    let activated = false;
+
+    manager.register(
+      testPlugin({
+        id: "deep-link-loader",
+        urlParameterNames: ["data"],
+        activate: () => {
+          activated = true;
+        },
+        handleUrlParameters: () => undefined,
+      }),
+    );
+
+    await manager.handleUrlParameters(
+      new URLSearchParams("other=1"),
+      app,
+      "ctx",
+    );
+
+    assert.equal(activated, false);
+    assert.equal(manager.isActive("deep-link-loader"), false);
+  });
+
+  it("does not run a plugin whose activation is refused", async () => {
+    const calls: string[] = [];
+    const manager = new PluginManager();
+
+    manager.register(
+      testPlugin({
+        id: "refuses-activation",
+        urlParameterNames: ["data"],
+        activate: () => false,
+        handleUrlParameters: () => {
+          calls.push("ran");
+        },
+      }),
+    );
+
+    await manager.handleUrlParameters(
+      new URLSearchParams("data=ds.zip"),
+      app,
+      "ctx",
+    );
+
+    assert.equal(manager.isActive("refuses-activation"), false);
+    assert.deepEqual(calls, []);
   });
 
   it("awaits async handlers in registration order", async () => {


### PR DESCRIPTION
## Problem

`PluginManager.handleUrlParameters` dispatched URL parameters only to **active** plugins (`if (!this.active.has(id) ...) continue`). So a deep link could not bring up an installed-but-inactive plugin: opening with `?data=...` did nothing unless the owning plugin was already active.

## Change

A registered plugin that declares a `urlParameterNames` value present in the URL is now **activated** before its handler runs.

- Only already-registered (trusted) plugins are activated; nothing is fetched or executed from the URL itself.
- Plugins that own no present parameter are untouched.
- No plugin currently declares `urlParameterNames`, so there is no behavior change for existing plugins. The Annotate Geocodes plugin is the first consumer.

This keeps the existing dedup / once-per-URL-context / error-retry semantics intact.

## Tests

Added to `tests/plugin-manager.test.ts`:
- an installed-but-inactive plugin that owns a present parameter is activated and handled,
- an absent parameter leaves the plugin inactive,
- a plugin whose activation is refused is not dispatched.

Updated the existing dispatch test (which assumed inactive owners are skipped) to use a plugin that owns a non-present parameter. Full frontend suite passes (143/143).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deep links for parameters owned by installed-but-inactive plugins now attempt on-demand activation; activation failures or refusals skip that plugin without aborting overall URL handling. Per-context deduplication prevents repeated handling.

* **Tests**
  * Added tests for on-demand activation, deduplication, and skip-on-activation-failure scenarios.

* **Documentation**
  * Updated plugin API docs: parameter handling order, activation semantics for installed vs. unregistered plugins, case-sensitive matching, and new urlParameterNames / handleUrlParameters contract.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->