### PR TITLE
feat: bake-in drop-in plugins for web and desktop builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS
 - Plugin system with basemap, layer control, MapLibre components, swipe, street view, Overture Maps, LiDAR, GeoAgent, and GeoEditor integrations, including configurable control positions and external plugin manifests
 - Time Slider plugin for animating time series raster and vector data
 - External plugin zip loading from the app data plugins directory and local development plugin directories
+- Bundled drop-in plugins under `public/plugins/<id>/` that bake into both the web and desktop builds and load automatically with no manifest URL
 - Browser deployment with Docker, embed-friendly URL parameters, and a `maponly` chrome-free mode
 - Optional Python FastAPI sidecar for heavier processing workflows
 
@@ -265,7 +266,7 @@ Built-in plugins live in `packages/plugins/src/plugins/` and are registered by t
 
 For external plugin development, start from the [GeoLibre plugin template](https://github.com/opengeos/geolibre-plugin-template). It includes a `plugin.json` manifest, a GeoLibre plugin wrapper entry point, and a `package:geolibre` script that creates a zip file for the desktop app data `plugins/` directory. During development, Settings > Plugins can scan an additional local plugin directory, including an unpacked bundle folder such as the template's `geolibre-plugin/` directory, or a hosted `plugin.json` manifest URL. See the [Plugin API](docs/plugin-api.md) for the external plugin contract.
 
-For web builds, an external plugin can be bundled by placing its built folder under `apps/geolibre-desktop/public/plugins/<plugin-id>/` and loading `/plugins/<plugin-id>/plugin.json` as a manifest URL. Browsers cannot scan plugin folders at runtime, so bundled web plugins still need explicit manifest URLs unless they are registered as built-in plugins.
+To bake an external plugin into the build so it loads automatically — with no Settings entry and no manifest URL — drop its built folder into `apps/geolibre-desktop/public/plugins/<plugin-id>/` (the same `plugin.json` + `dist/` a manifest URL would serve). The `bundledPlugins()` Vite plugin discovers it at build time and the app loads it through the normal external-plugin path. The same folder serves both the web build and the desktop build (which ships the same frontend), so one drop-in covers both. Private plugin bundles are git-ignored under that folder and copied in at build/deploy time. See the [Plugin API](docs/plugin-api.md#bundled-plugins-baked-into-the-build) for details and the security model.
 
 1. Create a plugin file in `packages/plugins/src/plugins/`.
 

--- a/apps/geolibre-desktop/public/plugins/.gitignore
+++ b/apps/geolibre-desktop/public/plugins/.gitignore
@@ -1,0 +1,6 @@
+# Plugins baked into the build are dropped here as public/plugins/<id>/.
+# The plugin bundles themselves are not committed (they may be private and are
+# copied in at build/deploy time); only this folder's convention docs are.
+*
+!.gitignore
+!README.md

--- a/apps/geolibre-desktop/public/plugins/README.md
+++ b/apps/geolibre-desktop/public/plugins/README.md
@@ -1,0 +1,44 @@
+# Bundled plugins (drop-in folder)
+
+Drop a plugin here to **bake it into the GeoLibre build**. It loads
+automatically on startup with no Settings entry and no manifest URL — on both
+the **web** build and the **desktop** build (the desktop app ships the same
+frontend, so one folder serves both).
+
+## Layout
+
+One folder per plugin, named by its plugin id, with a `plugin.json` at its root
+(the exact same content a manifest URL would serve):
+
+```
+public/plugins/
+  my-plugin/
+    plugin.json        # { "id", "name", "version", "entry", "style"? }
+    dist/
+      index.js         # the "entry" referenced by plugin.json
+      style.css        # the optional "style" referenced by plugin.json
+```
+
+`entry` and `style` in `plugin.json` are resolved relative to the manifest, so
+keep them inside the plugin's own folder.
+
+## How it works
+
+The `bundledPlugins()` Vite plugin
+(`apps/geolibre-desktop/vite-plugins/bundled-plugins.ts`) scans this directory
+at build and dev-server start and exposes the discovered manifest paths via the
+`virtual:bundled-plugins` module. `usePlugins.ts` turns those into origin-absolute
+URLs and loads them through the normal external-plugin path (fetch → blob import
+→ register). Adding or removing a plugin is just adding or removing a folder —
+no code changes.
+
+Discovery happens at **build time**, so a dev server or production build must be
+(re)started after adding, updating, or removing a plugin folder.
+
+## Private plugins
+
+The bundles are **git-ignored** (see `.gitignore`) so private plugin code stays
+out of this repo's history. Copy the plugin folder in at build/deploy time (for
+example, in CI before `npm run build`, or with a plugin repo's own install
+script). The discovery code is generic and committed; only the plugin payload
+is excluded.

--- a/apps/geolibre-desktop/public/plugins/README.md
+++ b/apps/geolibre-desktop/public/plugins/README.md
@@ -10,7 +10,7 @@ frontend, so one folder serves both).
 One folder per plugin, named by its plugin id, with a `plugin.json` at its root
 (the exact same content a manifest URL would serve):
 
-```
+```text
 public/plugins/
   my-plugin/
     plugin.json        # { "id", "name", "version", "entry", "style"? }

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -184,8 +184,13 @@ export function useExternalPluginsReady(): boolean {
 // applied to user/project URLs, so the desktop tauri:// origin is accepted.
 function bundledPluginManifestUrls(): string[] {
   if (typeof window === "undefined") return [];
+  // Resolve against a base that always ends in "/" so a non-trailing-slash
+  // BASE_URL (e.g. "/geolibre") cannot mangle the path into "/geolibreplugins".
+  const base = import.meta.env.BASE_URL.endsWith("/")
+    ? import.meta.env.BASE_URL
+    : `${import.meta.env.BASE_URL}/`;
   return bundledPluginManifestPaths.map(
-    (path) => new URL(import.meta.env.BASE_URL + path, window.location.href).href,
+    (path) => new URL(path, new URL(base, window.location.href)).href,
   );
 }
 

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -32,6 +32,7 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { readDir, readFile } from "@tauri-apps/plugin-fs";
 import type { RefObject } from "react";
 import { useEffect, useSyncExternalStore } from "react";
+import { bundledPluginManifestPaths } from "virtual:bundled-plugins";
 import { loadExternalPlugins } from "../lib/external-plugins";
 import { mergeStringLists } from "../lib/string-lists";
 import {
@@ -174,6 +175,20 @@ export function useExternalPluginsReady(): boolean {
   );
 }
 
+// Manifest URLs for plugins baked into the build under public/plugins/<id>/.
+// Resolved against the app origin and base so they fetch same-origin on both
+// the web build and the desktop build (which serves the same frontend from
+// tauri://localhost, allowed by `connect-src 'self'`). These are injected at
+// load time rather than stored in Settings, so a baked-in plugin always loads
+// and cannot be removed by the user. The URL loader skips the scheme allow-list
+// applied to user/project URLs, so the desktop tauri:// origin is accepted.
+function bundledPluginManifestUrls(): string[] {
+  if (typeof window === "undefined") return [];
+  return bundledPluginManifestPaths.map(
+    (path) => new URL(import.meta.env.BASE_URL + path, window.location.href).href,
+  );
+}
+
 function ensureExternalPluginsLoadedWithSettings(
   desktopSettings: ReturnType<
     typeof useDesktopSettingsStore.getState
@@ -181,6 +196,7 @@ function ensureExternalPluginsLoadedWithSettings(
   projectPluginManifestUrls: string[],
 ): Promise<void> {
   const pluginManifestUrls = mergeStringLists(
+    bundledPluginManifestUrls(),
     desktopSettings.pluginManifestUrls,
     projectPluginManifestUrls,
   );

--- a/apps/geolibre-desktop/src/vite-env.d.ts
+++ b/apps/geolibre-desktop/src/vite-env.d.ts
@@ -2,6 +2,13 @@
 
 declare const __GEOLIBRE_VERSION__: string;
 
+declare module "virtual:bundled-plugins" {
+  // Manifest paths (base-relative, no leading slash) for plugins dropped into
+  // public/plugins/<id>/, discovered at build time by the bundledPlugins() Vite
+  // plugin. See apps/geolibre-desktop/vite-plugins/bundled-plugins.ts.
+  export const bundledPluginManifestPaths: string[];
+}
+
 declare module "*.geojson?url" {
   const url: string;
   export default url;

--- a/apps/geolibre-desktop/vite-plugins/bundled-plugins.ts
+++ b/apps/geolibre-desktop/vite-plugins/bundled-plugins.ts
@@ -1,0 +1,46 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import type { Plugin } from "vite";
+
+const VIRTUAL_ID = "virtual:bundled-plugins";
+const RESOLVED_ID = "\0" + VIRTUAL_ID;
+
+// Discovers plugins dropped into public/plugins/<id>/ at build and dev-server
+// start, exposing their manifest paths (base-relative, no leading slash) as the
+// virtual module `virtual:bundled-plugins`. Adding or removing a plugin folder
+// changes the list with no code edit. Because the desktop app bundles the same
+// frontend (tauri.conf.json `frontendDist`), one folder serves both the web and
+// desktop builds; the frontend loads them through the normal URL-plugin path.
+export function bundledPlugins(pluginsDir: string): Plugin {
+  const discover = (): string[] => {
+    if (!existsSync(pluginsDir)) return [];
+    return readdirSync(pluginsDir)
+      .filter((name) => {
+        const manifest = join(pluginsDir, name, "plugin.json");
+        return existsSync(manifest) && statSync(manifest).isFile();
+      })
+      .map((name) => `plugins/${name}/plugin.json`)
+      .sort();
+  };
+
+  return {
+    name: "geolibre:bundled-plugins",
+    resolveId: (id) => (id === VIRTUAL_ID ? RESOLVED_ID : undefined),
+    load(id) {
+      if (id !== RESOLVED_ID) return;
+      return `export const bundledPluginManifestPaths = ${JSON.stringify(
+        discover(),
+      )};`;
+    },
+    configureServer(server) {
+      server.watcher.add(pluginsDir);
+      const reload = () => {
+        const mod = server.moduleGraph.getModuleById(RESOLVED_ID);
+        if (mod) server.moduleGraph.invalidateModule(mod);
+        server.ws.send({ type: "full-reload" });
+      };
+      server.watcher.on("addDir", reload);
+      server.watcher.on("unlinkDir", reload);
+    },
+  };
+}

--- a/apps/geolibre-desktop/vite-plugins/bundled-plugins.ts
+++ b/apps/geolibre-desktop/vite-plugins/bundled-plugins.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import type { Plugin } from "vite";
 
 const VIRTUAL_ID = "virtual:bundled-plugins";
@@ -16,8 +16,17 @@ export function bundledPlugins(pluginsDir: string): Plugin {
     if (!existsSync(pluginsDir)) return [];
     return readdirSync(pluginsDir)
       .filter((name) => {
-        const manifest = join(pluginsDir, name, "plugin.json");
-        return existsSync(manifest) && statSync(manifest).isFile();
+        // statSync with throwIfNoEntry:false avoids a TOCTOU race between an
+        // existsSync check and the stat, and the isDirectory guard makes the
+        // "folder containing plugin.json" intent explicit.
+        const entry = statSync(join(pluginsDir, name), {
+          throwIfNoEntry: false,
+        });
+        if (!entry?.isDirectory()) return false;
+        const manifest = statSync(join(pluginsDir, name, "plugin.json"), {
+          throwIfNoEntry: false,
+        });
+        return manifest?.isFile() ?? false;
       })
       .map((name) => `plugins/${name}/plugin.json`)
       .sort();
@@ -34,7 +43,11 @@ export function bundledPlugins(pluginsDir: string): Plugin {
     },
     configureServer(server) {
       server.watcher.add(pluginsDir);
-      const reload = () => {
+      // chokidar watches recursively, so reload only for direct children of
+      // pluginsDir; a plugin's own dist/ subdir would otherwise fire extra
+      // reloads.
+      const reload = (dirPath: string) => {
+        if (dirname(dirPath) !== pluginsDir) return;
         const mod = server.moduleGraph.getModuleById(RESOLVED_ID);
         if (mod) server.moduleGraph.invalidateModule(mod);
         server.ws.send({ type: "full-reload" });

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -8,6 +8,7 @@ import type {
   WarningHandlerWithDefault,
 } from "rollup";
 import { defineConfig, type Plugin } from "vite";
+import { bundledPlugins } from "./vite-plugins/bundled-plugins";
 
 const GEOAGENT_BROWSER_BUNDLE = "maplibre-gl-geoagent/dist/browser-";
 const EARTH_ENGINE_CONTROL_BUNDLE = "maplibre-gl-earth-engine/dist/";
@@ -303,6 +304,7 @@ export default defineConfig({
   plugins: [
     stripDuckDbWorkerSourcemapPlugin(),
     projectUrlQueryPlugin(),
+    bundledPlugins(path.resolve(__dirname, "public/plugins")),
     react(),
     wmsProxyPlugin(),
     selectiveJsMinifyPlugin(),

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -185,7 +185,9 @@ The Plugins settings section can also add local development directories outside 
 
 For the web app, use manifest URLs. GeoLibre fetches the manifest, resolves `entry` and `style` relative to the manifest URL, then loads the bundled ESM entry. Browser loading requires HTTPS except for `localhost` and depends on the host allowing CORS.
 
-To include an external plugin folder in a GeoLibre web build, place the built plugin bundle under the Vite public directory:
+### Bundled plugins (baked into the build)
+
+To ship an external plugin as part of GeoLibre — loaded automatically, with no Settings entry and no manifest URL — drop its built bundle into the Vite public directory, one folder per plugin id:
 
 ```text
 apps/geolibre-desktop/public/plugins/example-plugin/
@@ -194,13 +196,13 @@ apps/geolibre-desktop/public/plugins/example-plugin/
   dist/style.css
 ```
 
-Vite copies files from `public/` into the final web build, so the manifest URL becomes:
+This is the **same content a manifest URL would serve**. A drop-in is all that is required — no source edits per plugin. The `bundledPlugins()` Vite plugin (`apps/geolibre-desktop/vite-plugins/bundled-plugins.ts`) scans `public/plugins/` at build and dev-server start, exposes the discovered manifest paths through the `virtual:bundled-plugins` module, and `usePlugins.ts` loads them through the normal external-plugin path (fetch → blob import → register). Discovery happens at build time, so restart the dev server or rebuild after adding, updating, or removing a plugin folder.
 
-```text
-/plugins/example-plugin/plugin.json
-```
+The same folder serves **both** the web and desktop builds: the desktop app bundles the identical frontend (`frontendDist` in `tauri.conf.json`) and serves it from `tauri://localhost`, which is same-origin and allowed by the desktop CSP (`connect-src 'self'`, `script-src ... blob:`). Bundled manifest URLs are injected at load time rather than stored in Settings, so a baked-in plugin always loads and cannot be removed by a user; they are deduplicated by plugin id against any user/project plugin of the same id.
 
-This works in both development and production web builds. The browser still cannot scan `/plugins/` at runtime, so each bundled plugin must be loaded by an explicit manifest URL, such as one entered in Settings > Plugins. Manifest URLs are saved in the project `plugins.manifestUrls` array so reloading a shared project can fetch its external plugins before restoring active plugin state. For plugins that should always ship as part of GeoLibre without user configuration, prefer registering them as built-in plugins.
+Private plugins should be git-ignored under `public/plugins/` (see that folder's `.gitignore`) and copied in at build/deploy time (for example in CI before `npm run build`, or by a plugin repo's own install script) so their code stays out of GeoLibre's history. The discovery code is generic and committed; only the plugin payload is excluded.
+
+If instead you want a plugin compiled into the main JS bundle (no `plugin.json`, no fetch), register it as a built-in plugin (see "Add a plugin" in the repository README).
 
 ```json
 {


### PR DESCRIPTION
## Summary
- Add a single drop-in folder, `apps/geolibre-desktop/public/plugins/<id>/`, that bundles external plugins into the build and loads them automatically with no Settings entry, no manifest URL, and no per-plugin source edits.
- A new `bundledPlugins()` Vite plugin discovers dropped folders at build time via the `virtual:bundled-plugins` module; `usePlugins.ts` resolves them to origin- and base-aware URLs and loads them through the normal external-plugin path. URLs are injected at load time (not stored in Settings) and dedupe by plugin id.
- One folder serves both the web build and the desktop build, which ships the same frontend and serves it from `tauri://localhost` (allowed by the existing CSP). Private plugin bundles are git-ignored and copied in at build/deploy time.

## Test plan
- [x] `tsc -b` passes
- [x] Production `vite build` succeeds
- [x] Dropped plugin folder is copied into `dist/plugins/<id>/` and the discovered manifest path is baked into the built app chunk
- [ ] Run the app (web and desktop) and confirm a dropped-in plugin loads on startup with no manifest URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for bundled drop-in plugins: drop built plugin folders into public/plugins/<plugin-id>/ to have them automatically discovered and loaded in both web and desktop builds (no manifest URL needed).

* **Documentation**
  * Updated docs explaining folder layout, resolution rules, restart requirement after changes, deduplication, and that bundled payloads should be git-ignored.

* **Chores**
  * Added .gitignore to keep bundled plugin payloads out of version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->