### PR TITLE
feat: add Vector processing menu with QGIS-inspired tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS
 - Controls menu with Measure, Bookmark, Minimap, and View State tools, plus a Print menu and a Search panel
 - Conversion menu for Vector to GeoParquet/FlatGeobuf/PMTiles, CSV to GeoParquet, and Raster to COG; GeoParquet and CSV conversions run in the browser with DuckDB-WASM, while FlatGeobuf, PMTiles, and COG require the optional Python sidecar
 - Whitebox toolbox with batch tools run against a selected input directory
-- Vector menu with common geometry tools (buffer, centroids, convex hull, dissolve, bounding box, simplify, clip, intersection, difference, union) that run in the browser with Turf.js, with an optional GeoPandas sidecar engine for buffer and overlay tools
+- Vector menu with common geometry tools (buffer, centroids, convex hull, dissolve, bounding box, simplify, clip, intersection, difference, union) that run in the browser with Turf.js, with an optional GeoPandas sidecar engine for buffer, dissolve, and overlay tools
 - Project menu to create, open, save, and Save As `.geolibre.json` projects
 - Desktop diagnostics panel, update check, and MSIX packaging support
 - Plugin system with basemap, layer control, MapLibre components, swipe, street view, Overture Maps, LiDAR, GeoAgent, and GeoEditor integrations, including configurable control positions and external plugin manifests
@@ -142,7 +142,7 @@ The **Processing → Vector** menu opens a single Vector tools dialog with commo
 
 - **Geometry tools.** **Buffer** (by a distance in kilometers, meters, or miles), **Centroids** (one centroid point per feature), **Convex hull** (a single polygon enclosing all features), **Dissolve** (merge polygons, optionally grouped by an attribute field), **Bounding box** (the rectangular envelope of all features), and **Simplify** (Douglas-Peucker vertex reduction).
 - **Overlay tools.** **Clip** (clip the input to an overlay layer, keeping input attributes), **Intersection**, **Difference**, and **Union** between two polygon layers.
-- **Two engines.** Every tool runs fully in the browser with [Turf.js](https://turfjs.org/), so no sidecar is required. Buffer and the overlay tools can also run on the optional GeoPandas sidecar for projection-aware results; when the sidecar is unavailable the dialog falls back to the client engine.
+- **Two engines.** Every tool runs fully in the browser with [Turf.js](https://turfjs.org/), so no sidecar is required. Buffer, dissolve, and the overlay tools can also run on the optional GeoPandas sidecar for projection-aware results; when the sidecar is unavailable the dialog falls back to the client engine.
 
 To enable the sidecar engine, install the optional `vector` extra (it is not bundled by default to keep the sidecar small):
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS
 - Controls menu with Measure, Bookmark, Minimap, and View State tools, plus a Print menu and a Search panel
 - Conversion menu for Vector to GeoParquet/FlatGeobuf/PMTiles, CSV to GeoParquet, and Raster to COG; GeoParquet and CSV conversions run in the browser with DuckDB-WASM, while FlatGeobuf, PMTiles, and COG require the optional Python sidecar
 - Whitebox toolbox with batch tools run against a selected input directory
+- Vector menu with common geometry tools (buffer, centroids, convex hull, dissolve, bounding box, simplify, clip, intersection, difference, union) that run in the browser with Turf.js, with an optional GeoPandas sidecar engine for buffer and overlay tools
 - Project menu to create, open, save, and Save As `.geolibre.json` projects
 - Desktop diagnostics panel, update check, and MSIX packaging support
 - Plugin system with basemap, layer control, MapLibre components, swipe, street view, Overture Maps, LiDAR, GeoAgent, and GeoEditor integrations, including configurable control positions and external plugin manifests
@@ -134,6 +135,23 @@ ORDER BY POP_EST DESC;
 ```
 
 Only a single statement is supported per run; remote `s3://` URLs are not read directly, so use the HTTPS form instead.
+
+## Vector tools
+
+The **Processing → Vector** menu opens a single Vector tools dialog with common geometry operations that run against your loaded GeoJSON layers. Pick a tool, choose the input layer (and an overlay layer for the two-layer tools), set the parameters, and the result is added to the map as a new layer.
+
+- **Geometry tools.** **Buffer** (by a distance in kilometers, meters, or miles), **Centroids** (one centroid point per feature), **Convex hull** (a single polygon enclosing all features), **Dissolve** (merge polygons, optionally grouped by an attribute field), **Bounding box** (the rectangular envelope of all features), and **Simplify** (Douglas-Peucker vertex reduction).
+- **Overlay tools.** **Clip** (clip the input to an overlay layer, keeping input attributes), **Intersection**, **Difference**, and **Union** between two polygon layers.
+- **Two engines.** Every tool runs fully in the browser with [Turf.js](https://turfjs.org/), so no sidecar is required. Buffer and the overlay tools can also run on the optional GeoPandas sidecar for projection-aware results; when the sidecar is unavailable the dialog falls back to the client engine.
+
+To enable the sidecar engine, install the optional `vector` extra (it is not bundled by default to keep the sidecar small):
+
+```bash
+# install the vector extras (GeoPandas, Shapely)
+pip install -e "backend/geolibre_server[vector]"
+# run it
+geolibre-server   # or: uvicorn geolibre_server.app.main:app --host 127.0.0.1 --port 8765
+```
 
 ## Embed the demo
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS
 - Controls menu with Measure, Bookmark, Minimap, and View State tools, plus a Print menu and a Search panel
 - Conversion menu for Vector to GeoParquet/FlatGeobuf/PMTiles, CSV to GeoParquet, and Raster to COG; GeoParquet and CSV conversions run in the browser with DuckDB-WASM, while FlatGeobuf, PMTiles, and COG require the optional Python sidecar
 - Whitebox toolbox with batch tools run against a selected input directory
-- Vector menu with common geometry tools (buffer, centroids, convex hull, dissolve, bounding box, simplify, clip, intersection, difference, union) that run in the browser with Turf.js, with an optional GeoPandas sidecar engine for buffer, dissolve, and overlay tools
+- Vector menu with common geometry tools (buffer, centroids, convex hull, dissolve, bounding box, simplify, clip, intersection, difference, union) that run in the browser with Turf.js, with an optional GeoPandas sidecar engine for every tool
 - Project menu to create, open, save, and Save As `.geolibre.json` projects
 - Desktop diagnostics panel, update check, and MSIX packaging support
 - Plugin system with basemap, layer control, MapLibre components, swipe, street view, Overture Maps, LiDAR, GeoAgent, and GeoEditor integrations, including configurable control positions and external plugin manifests
@@ -142,7 +142,7 @@ The **Processing → Vector** menu opens a single Vector tools dialog with commo
 
 - **Geometry tools.** **Buffer** (by a distance in kilometers, meters, or miles), **Centroids** (one centroid point per feature), **Convex hull** (a single polygon enclosing all features), **Dissolve** (merge polygons, optionally grouped by an attribute field), **Bounding box** (the rectangular envelope of all features), and **Simplify** (Douglas-Peucker vertex reduction).
 - **Overlay tools.** **Clip** (clip the input to an overlay layer, keeping input attributes), **Intersection**, **Difference**, and **Union** between two polygon layers.
-- **Two engines.** Every tool runs fully in the browser with [Turf.js](https://turfjs.org/), so no sidecar is required. Buffer, dissolve, and the overlay tools can also run on the optional GeoPandas sidecar for projection-aware results; when the sidecar is unavailable the dialog falls back to the client engine.
+- **Two engines.** Every tool runs fully in the browser with [Turf.js](https://turfjs.org/), so no sidecar is required. Every tool can also run on the optional GeoPandas sidecar for projection-aware results; when the sidecar is unavailable the dialog falls back to the client engine.
 
 To enable the sidecar engine, install the optional `vector` extra (it is not bundled by default to keep the sidecar small):
 

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -80,6 +80,20 @@ const ConversionDialog = lazy(() =>
     }),
 );
 
+const VectorToolsDialog = lazy(() =>
+  import("../processing/VectorToolsDialog")
+    .then((module) => ({
+      default: module.VectorToolsDialog,
+    }))
+    .catch((error) => {
+      // Same chunk-load fallback rationale as ProcessingDialog above.
+      console.error("Failed to load VectorToolsDialog", error);
+      const Fallback = (() =>
+        null) as unknown as typeof import("../processing/VectorToolsDialog").VectorToolsDialog;
+      return { default: Fallback };
+    }),
+);
+
 const SqlWorkspaceDialog = lazy(() =>
   import("../processing/SqlWorkspaceDialog")
     .then((module) => ({
@@ -701,6 +715,9 @@ export function DesktopShell({
       </Suspense>
       <Suspense fallback={null}>
         <ConversionDialog />
+      </Suspense>
+      <Suspense fallback={null}>
+        <VectorToolsDialog mapControllerRef={mapControllerRef} />
       </Suspense>
       <Suspense fallback={null}>
         <SqlWorkspaceDialog />

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -248,6 +248,7 @@ export function TopToolbar({
   const loadProject = useAppStore((s) => s.loadProject);
   const setProcessingOpen = useAppStore((s) => s.setProcessingOpen);
   const setConversionOpen = useAppStore((s) => s.setConversionOpen);
+  const setVectorToolOpen = useAppStore((s) => s.setVectorToolOpen);
   const setSqlWorkspaceOpen = useAppStore((s) => s.setSqlWorkspaceOpen);
   const projectName = useAppStore((s) => s.projectName);
   const projectPath = useAppStore((s) => s.projectPath);
@@ -948,6 +949,56 @@ export function TopToolbar({
                 onSelect={() => setConversionOpen("raster-to-cog")}
               >
                 Raster to COG
+              </DropdownMenuItem>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>Vector</DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              <DropdownMenuLabel className="text-xs text-muted-foreground">
+                Geometry
+              </DropdownMenuLabel>
+              <DropdownMenuItem onSelect={() => setVectorToolOpen("buffer")}>
+                Buffer
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => setVectorToolOpen("centroids")}>
+                Centroids
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onSelect={() => setVectorToolOpen("convex-hull")}
+              >
+                Convex hull
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => setVectorToolOpen("dissolve")}>
+                Dissolve
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onSelect={() => setVectorToolOpen("bounding-box")}
+              >
+                Bounding box
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => setVectorToolOpen("simplify")}>
+                Simplify
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel className="text-xs text-muted-foreground">
+                Overlay
+              </DropdownMenuLabel>
+              <DropdownMenuItem onSelect={() => setVectorToolOpen("clip")}>
+                Clip
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onSelect={() => setVectorToolOpen("intersection")}
+              >
+                Intersection
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onSelect={() => setVectorToolOpen("difference")}
+              >
+                Difference
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => setVectorToolOpen("union")}>
+                Union
               </DropdownMenuItem>
             </DropdownMenuSubContent>
           </DropdownMenuSub>

--- a/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
@@ -182,23 +182,30 @@ export function VectorToolsDialog({
         const overlayLayer = layers.find((l) => l.id === params.overlay);
         // A layer may have been removed from the project after the dialog
         // opened; bail out with a clear message instead of sending null GeoJSON.
-        if (!inputLayer) {
+        if (!inputLayer?.geojson) {
           appendLog("Error: input layer no longer exists in the project");
           return;
         }
-        if (params.overlay && !overlayLayer) {
+        if (params.overlay && !overlayLayer?.geojson) {
           appendLog("Error: overlay layer no longer exists in the project");
           return;
         }
         appendLog(`Running "${tool.name}" on the Python sidecar...`);
         const result = await runVectorTool({
           tool_id: tool.id,
-          geojson: inputLayer?.geojson,
+          geojson: inputLayer.geojson,
           overlay: overlayLayer?.geojson,
           parameters: params,
         });
         for (const message of result.messages) appendLog(message);
-        addResultLayer(tool.name, result.geojson as FeatureCollection);
+        // The sidecar response is untyped JSON; verify it is a FeatureCollection
+        // before handing it to the map.
+        const sidecarResult = result.geojson as { type?: string } | null;
+        if (sidecarResult?.type === "FeatureCollection") {
+          addResultLayer(tool.name, sidecarResult as unknown as FeatureCollection);
+        } else {
+          appendLog("Error: sidecar returned invalid GeoJSON");
+        }
       } else {
         const ctx: ProcessingContext = {
           layers,
@@ -434,7 +441,9 @@ function ParameterField({
           max={param.max}
           step={param.step}
           onChange={(e) =>
-            onChange(e.target.value === "" ? "" : Number(e.target.value))
+            onChange(
+              e.target.value === "" ? undefined : Number(e.target.value),
+            )
           }
         />
       </div>

--- a/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
@@ -309,6 +309,11 @@ export function VectorToolsDialog({
                   <option value="client">Client (Turf.js)</option>
                   <option value="sidecar">Sidecar (GeoPandas)</option>
                 </Select>
+                {engine === "sidecar" && sidecarAvailable === null ? (
+                  <p className="text-xs text-muted-foreground">
+                    Checking sidecar availability...
+                  </p>
+                ) : null}
                 {engine === "sidecar" && sidecarAvailable === false ? (
                   <p className="text-xs text-destructive">
                     The GeoPandas sidecar is not available. Start the sidecar
@@ -323,7 +328,7 @@ export function VectorToolsDialog({
                 onClick={handleRun}
                 disabled={
                   running ||
-                  (engine === "sidecar" && sidecarAvailable === false)
+                  (engine === "sidecar" && sidecarAvailable !== true)
                 }
                 className="gap-2"
               >

--- a/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
@@ -164,7 +164,12 @@ export function VectorToolsDialog({
     for (const param of tool.parameters) {
       if (!param.required) continue;
       const value = params[param.id];
-      if (value === undefined || value === "" || value === null) {
+      if (
+        value === undefined ||
+        value === "" ||
+        value === null ||
+        (param.type === "number" && Number.isNaN(value))
+      ) {
         appendLog(`Error: "${param.label}" is required`);
         return;
       }
@@ -175,6 +180,16 @@ export function VectorToolsDialog({
       if (engine === "sidecar") {
         const inputLayer = layers.find((l) => l.id === params.layer);
         const overlayLayer = layers.find((l) => l.id === params.overlay);
+        // A layer may have been removed from the project after the dialog
+        // opened; bail out with a clear message instead of sending null GeoJSON.
+        if (!inputLayer) {
+          appendLog("Error: input layer no longer exists in the project");
+          return;
+        }
+        if (params.overlay && !overlayLayer) {
+          appendLog("Error: overlay layer no longer exists in the project");
+          return;
+        }
         appendLog(`Running "${tool.name}" on the Python sidecar...`);
         const result = await runVectorTool({
           tool_id: tool.id,
@@ -294,7 +309,10 @@ export function VectorToolsDialog({
             <div>
               <Button
                 onClick={handleRun}
-                disabled={running}
+                disabled={
+                  running ||
+                  (engine === "sidecar" && sidecarAvailable === false)
+                }
                 className="gap-2"
               >
                 {running ? (

--- a/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
@@ -200,8 +200,13 @@ export function VectorToolsDialog({
         for (const message of result.messages) appendLog(message);
         // The sidecar response is untyped JSON; verify it is a FeatureCollection
         // before handing it to the map.
-        const sidecarResult = result.geojson as { type?: string } | null;
-        if (sidecarResult?.type === "FeatureCollection") {
+        const sidecarResult = result.geojson as
+          | { type?: string; features?: unknown }
+          | null;
+        if (
+          sidecarResult?.type === "FeatureCollection" &&
+          Array.isArray(sidecarResult.features)
+        ) {
           addResultLayer(tool.name, sidecarResult as unknown as FeatureCollection);
         } else {
           appendLog("Error: sidecar returned invalid GeoJSON");

--- a/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
@@ -1,0 +1,441 @@
+import { useAppStore } from "@geolibre/core";
+import { detectGeometryProfile, type MapController } from "@geolibre/map";
+import {
+  VECTOR_TOOLS,
+  getVectorTool,
+  runVectorTool,
+  fetchVectorStatus,
+  type AlgorithmParameter,
+  type GeometryFamily,
+  type ProcessingAlgorithm,
+  type ProcessingContext,
+} from "@geolibre/processing";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+  ScrollArea,
+  Select,
+  cn,
+} from "@geolibre/ui";
+import { Loader2, Play, Server } from "lucide-react";
+import type { FeatureCollection } from "geojson";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactElement,
+} from "react";
+
+interface VectorToolsDialogProps {
+  mapControllerRef: React.RefObject<MapController | null>;
+}
+
+type Engine = "client" | "sidecar";
+
+/** Tools grouped by their `group` label, preserving registry order. */
+function groupedTools(): { group: string; tools: ProcessingAlgorithm[] }[] {
+  const groups: { group: string; tools: ProcessingAlgorithm[] }[] = [];
+  for (const tool of VECTOR_TOOLS) {
+    const label = tool.group ?? "Tools";
+    let entry = groups.find((g) => g.group === label);
+    if (!entry) {
+      entry = { group: label, tools: [] };
+      groups.push(entry);
+    }
+    entry.tools.push(tool);
+  }
+  return groups;
+}
+
+export function VectorToolsDialog({
+  mapControllerRef,
+}: VectorToolsDialogProps): ReactElement {
+  const openTool = useAppStore((s) => s.ui.vectorToolOpen);
+  const setVectorToolOpen = useAppStore((s) => s.setVectorToolOpen);
+  const layers = useAppStore((s) => s.layers);
+  const addGeoJsonLayer = useAppStore((s) => s.addGeoJsonLayer);
+
+  const open = openTool !== null;
+  const [selectedId, setSelectedId] = useState<string>(
+    openTool ?? VECTOR_TOOLS[0].id,
+  );
+  const [params, setParams] = useState<Record<string, unknown>>({});
+  const [engine, setEngine] = useState<Engine>("client");
+  const [log, setLog] = useState<string[]>([]);
+  const [running, setRunning] = useState(false);
+  const [sidecarAvailable, setSidecarAvailable] = useState<boolean | null>(null);
+  const logEndRef = useRef<HTMLDivElement>(null);
+
+  const tool = useMemo(
+    () => getVectorTool(selectedId) ?? VECTOR_TOOLS[0],
+    [selectedId],
+  );
+
+  // When the menu opens the dialog with a specific tool, preselect it.
+  useEffect(() => {
+    if (openTool) setSelectedId(openTool);
+  }, [openTool]);
+
+  // Reset parameters to the selected tool's defaults whenever it changes.
+  useEffect(() => {
+    const defaults: Record<string, unknown> = {};
+    for (const param of tool.parameters) {
+      if (param.default !== undefined) defaults[param.id] = param.default;
+    }
+    setParams(defaults);
+    setLog([]);
+    if (!tool.supportsSidecar) setEngine("client");
+  }, [tool]);
+
+  // Probe the sidecar's vector capability when the dialog opens.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    fetchVectorStatus()
+      .then((status) => {
+        if (!cancelled) setSidecarAvailable(status.available);
+      })
+      .catch(() => {
+        if (!cancelled) setSidecarAvailable(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  // Keep the newest log lines in view as they stream in.
+  useEffect(() => {
+    logEndRef.current?.scrollIntoView({ block: "end" });
+  }, [log]);
+
+  const appendLog = useCallback(
+    (message: string) => setLog((prev) => [...prev, message]),
+    [],
+  );
+
+  const setParam = useCallback(
+    (id: string, value: unknown) =>
+      setParams((prev) => ({ ...prev, [id]: value })),
+    [],
+  );
+
+  const layerOptions = useCallback(
+    (filter?: GeometryFamily[]) =>
+      layers.filter((layer) => {
+        if (layer.type !== "geojson" || !layer.geojson) return false;
+        if (!filter?.length) return true;
+        const profile = detectGeometryProfile(layer.geojson);
+        return filter.some(
+          (family) =>
+            (family === "point" && profile.hasPoint) ||
+            (family === "line" && profile.hasLine) ||
+            (family === "polygon" && profile.hasPolygon),
+        );
+      }),
+    [layers],
+  );
+
+  const addResultLayer = useCallback(
+    (name: string, fc: FeatureCollection) => {
+      if (!fc.features.length) {
+        appendLog(`No features produced for "${name}"`);
+        return;
+      }
+      const layerId = addGeoJsonLayer(name, fc);
+      const layer = useAppStore
+        .getState()
+        .layers.find((item) => item.id === layerId);
+      if (layer) mapControllerRef.current?.fitLayer(layer);
+    },
+    [addGeoJsonLayer, appendLog, mapControllerRef],
+  );
+
+  const handleRun = useCallback(async () => {
+    setLog([]);
+    // Validate required parameters before doing any work.
+    for (const param of tool.parameters) {
+      if (!param.required) continue;
+      const value = params[param.id];
+      if (value === undefined || value === "" || value === null) {
+        appendLog(`Error: "${param.label}" is required`);
+        return;
+      }
+    }
+
+    setRunning(true);
+    try {
+      if (engine === "sidecar") {
+        const inputLayer = layers.find((l) => l.id === params.layer);
+        const overlayLayer = layers.find((l) => l.id === params.overlay);
+        appendLog(`Running "${tool.name}" on the Python sidecar...`);
+        const result = await runVectorTool({
+          tool_id: tool.id,
+          geojson: inputLayer?.geojson,
+          overlay: overlayLayer?.geojson,
+          parameters: params,
+        });
+        for (const message of result.messages) appendLog(message);
+        addResultLayer(tool.name, result.geojson as FeatureCollection);
+      } else {
+        const ctx: ProcessingContext = {
+          layers,
+          parameters: params,
+          log: appendLog,
+          fitBounds: (bounds) => mapControllerRef.current?.fitBounds(bounds),
+          addResultLayer,
+        };
+        await tool.run(ctx);
+      }
+    } catch (error) {
+      appendLog(`Error: ${(error as Error).message}`);
+    } finally {
+      setRunning(false);
+    }
+  }, [
+    tool,
+    params,
+    engine,
+    layers,
+    appendLog,
+    addResultLayer,
+    mapControllerRef,
+  ]);
+
+  const groups = useMemo(groupedTools, []);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) setVectorToolOpen(null);
+      }}
+    >
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Vector tools</DialogTitle>
+          <DialogDescription>
+            Run common vector geometry operations on your GeoJSON layers.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex gap-4">
+          {/* Tool list */}
+          <ScrollArea className="h-[22rem] w-48 shrink-0 rounded-md border">
+            <div className="p-1">
+              {groups.map((group) => (
+                <div key={group.group} className="mb-1">
+                  <div className="px-2 py-1 text-xs font-medium text-muted-foreground">
+                    {group.group}
+                  </div>
+                  {group.tools.map((entry) => (
+                    <button
+                      key={entry.id}
+                      type="button"
+                      onClick={() => setSelectedId(entry.id)}
+                      className={cn(
+                        "w-full rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent",
+                        entry.id === selectedId &&
+                          "bg-accent font-medium text-accent-foreground",
+                      )}
+                    >
+                      {entry.name}
+                    </button>
+                  ))}
+                </div>
+              ))}
+            </div>
+          </ScrollArea>
+
+          {/* Parameter form + run + log */}
+          <div className="flex min-w-0 flex-1 flex-col gap-3">
+            <p className="text-sm text-muted-foreground">{tool.description}</p>
+
+            <div className="flex flex-col gap-3">
+              {tool.parameters.map((param) => (
+                <ParameterField
+                  key={param.id}
+                  param={param}
+                  value={params[param.id]}
+                  layerOptions={layerOptions(param.geometryFilter)}
+                  onChange={(value) => setParam(param.id, value)}
+                />
+              ))}
+            </div>
+
+            {tool.supportsSidecar ? (
+              <div className="flex flex-col gap-1">
+                <Label className="flex items-center gap-1.5 text-xs">
+                  <Server className="h-3.5 w-3.5" /> Engine
+                </Label>
+                <Select
+                  value={engine}
+                  onChange={(e) => setEngine(e.target.value as Engine)}
+                >
+                  <option value="client">Client (Turf.js)</option>
+                  <option value="sidecar">Sidecar (GeoPandas)</option>
+                </Select>
+                {engine === "sidecar" && sidecarAvailable === false ? (
+                  <p className="text-xs text-destructive">
+                    The GeoPandas sidecar is not available. Start the sidecar
+                    with the vector extra, or switch to the client engine.
+                  </p>
+                ) : null}
+              </div>
+            ) : null}
+
+            <div>
+              <Button
+                onClick={handleRun}
+                disabled={running}
+                className="gap-2"
+              >
+                {running ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Play className="h-4 w-4" />
+                )}
+                Run
+              </Button>
+            </div>
+
+            <ScrollArea className="h-24 rounded-md border bg-muted/30 p-2 font-mono text-xs">
+              {log.length === 0 ? (
+                <span className="text-muted-foreground">
+                  Output will appear here.
+                </span>
+              ) : (
+                log.map((line, index) => (
+                  <div key={index} className="whitespace-pre-wrap">
+                    {line}
+                  </div>
+                ))
+              )}
+              <div ref={logEndRef} />
+            </ScrollArea>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface ParameterFieldProps {
+  param: AlgorithmParameter;
+  value: unknown;
+  layerOptions: { id: string; name: string }[];
+  onChange: (value: unknown) => void;
+}
+
+function ParameterField({
+  param,
+  value,
+  layerOptions,
+  onChange,
+}: ParameterFieldProps): ReactElement {
+  const label = (
+    <Label htmlFor={param.id} className="text-xs">
+      {param.label}
+      {param.required ? <span className="text-destructive"> *</span> : null}
+    </Label>
+  );
+
+  if (param.type === "layer") {
+    return (
+      <div className="flex flex-col gap-1">
+        {label}
+        <Select
+          id={param.id}
+          value={(value as string) ?? ""}
+          onChange={(e) => onChange(e.target.value)}
+        >
+          <option value="">Select a layer...</option>
+          {layerOptions.map((layer) => (
+            <option key={layer.id} value={layer.id}>
+              {layer.name}
+            </option>
+          ))}
+        </Select>
+        {param.description ? (
+          <p className="text-xs text-muted-foreground">{param.description}</p>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (param.type === "select") {
+    return (
+      <div className="flex flex-col gap-1">
+        {label}
+        <Select
+          id={param.id}
+          value={(value as string) ?? ""}
+          onChange={(e) => onChange(e.target.value)}
+        >
+          {param.options?.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </Select>
+      </div>
+    );
+  }
+
+  if (param.type === "boolean") {
+    return (
+      <label className="flex items-center gap-2 text-sm" htmlFor={param.id}>
+        <input
+          id={param.id}
+          type="checkbox"
+          checked={Boolean(value)}
+          onChange={(e) => onChange(e.target.checked)}
+          className="h-4 w-4 rounded border-input"
+        />
+        {param.label}
+      </label>
+    );
+  }
+
+  if (param.type === "number") {
+    return (
+      <div className="flex flex-col gap-1">
+        {label}
+        <Input
+          id={param.id}
+          type="number"
+          value={value === undefined || value === null ? "" : String(value)}
+          min={param.min}
+          max={param.max}
+          step={param.step}
+          onChange={(e) =>
+            onChange(e.target.value === "" ? "" : Number(e.target.value))
+          }
+        />
+      </div>
+    );
+  }
+
+  // string
+  return (
+    <div className="flex flex-col gap-1">
+      {label}
+      <Input
+        id={param.id}
+        type="text"
+        value={(value as string) ?? ""}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      {param.description ? (
+        <p className="text-xs text-muted-foreground">{param.description}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/backend/geolibre_server/geolibre_server/app/main.py
+++ b/backend/geolibre_server/geolibre_server/app/main.py
@@ -21,6 +21,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from .conversion import router as conversion_router
+from .vector import router as vector_router
 from .whitebox import router as whitebox_router
 
 app = FastAPI(title="GeoLibre Server", version="0.8.0")
@@ -39,6 +40,7 @@ app.add_middleware(
 )
 app.include_router(whitebox_router)
 app.include_router(conversion_router)
+app.include_router(vector_router)
 
 
 class RunRequest(BaseModel):

--- a/backend/geolibre_server/geolibre_server/app/vector.py
+++ b/backend/geolibre_server/geolibre_server/app/vector.py
@@ -21,6 +21,10 @@ logger = logging.getLogger(__name__)
 
 WGS84 = "EPSG:4326"
 
+# Cap the input size so a very large layer cannot block the event loop or
+# exhaust memory (GeoPandas runs synchronously on the main thread).
+MAX_FEATURES = 50_000
+
 # Conversion factors from the requested unit to meters.
 _DISTANCE_UNITS = {
     "kilometers": 1000.0,
@@ -41,6 +45,15 @@ def _import_geopandas():
     import geopandas as gpd  # noqa: PLC0415
 
     return gpd
+
+
+def _check_size(geojson: Optional[dict], label: str) -> None:
+    """Reject payloads with more than ``MAX_FEATURES`` features."""
+    if geojson and len(geojson.get("features", [])) > MAX_FEATURES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"{label} exceeds the {MAX_FEATURES}-feature limit",
+        )
 
 
 def _load_gdf(geojson: Optional[dict], label: str):
@@ -68,6 +81,10 @@ def _buffer(request: VectorToolRequest) -> tuple[dict, list[str]]:
     distance = float(params.get("distance", 1) or 0)
     units = str(params.get("units", "kilometers"))
     meters = distance * _DISTANCE_UNITS.get(units, 1000.0)
+    if meters < 0:
+        # The UI enforces a non-negative distance; keep the server consistent
+        # rather than silently performing an inward (erosion) buffer.
+        raise HTTPException(status_code=400, detail="Buffer distance must be >= 0")
     # Buffer in a local metric CRS so the distance is in real-world meters,
     # then reproject the result back to WGS84.
     metric_crs = gdf.estimate_utm_crs()
@@ -82,6 +99,7 @@ def _buffer(request: VectorToolRequest) -> tuple[dict, list[str]]:
 def _centroids(request: VectorToolRequest) -> tuple[dict, list[str]]:
     gdf = _load_gdf(request.geojson, "Input layer")
     result = gdf.copy()
+    # Computed on geographic (WGS84) coordinates, matching the client engine.
     result["geometry"] = gdf.geometry.centroid
     return _to_feature_collection(result), [f"Computed {len(result)} centroid(s)"]
 
@@ -119,6 +137,9 @@ def _bounding_box(request: VectorToolRequest) -> tuple[dict, list[str]]:
 
 def _simplify(request: VectorToolRequest) -> tuple[dict, list[str]]:
     gdf = _load_gdf(request.geojson, "Input layer")
+    # Tolerance is in degrees (the geometry stays in WGS84), matching the UI
+    # label and the client engine. Do not introduce a metric-projected path
+    # here without also reinterpreting the tolerance unit.
     tolerance = float(request.parameters.get("tolerance", 0.01) or 0)
     result = gdf.copy()
     result["geometry"] = gdf.geometry.simplify(tolerance)
@@ -132,7 +153,11 @@ def _overlay(request: VectorToolRequest, how: str) -> tuple[dict, list[str]]:
     gpd = _import_geopandas()
     left = _load_gdf(request.geojson, "Input layer")
     right = _load_gdf(request.overlay, "Overlay layer")
-    result = gpd.overlay(left, right, how=how, keep_geom_type=False)
+    # Keep only polygonal output for difference so degenerate boundary slivers
+    # (lines/points at shared edges) are dropped, per GIS convention.
+    result = gpd.overlay(
+        left, right, how=how, keep_geom_type=(how == "difference")
+    )
     return (
         _to_feature_collection(result),
         [f"{how.capitalize()}: produced {len(result)} feature(s)"],
@@ -195,6 +220,9 @@ def vector_run(request: VectorToolRequest):
         raise HTTPException(
             status_code=400, detail=f"Unknown vector tool: {request.tool_id}"
         )
+
+    _check_size(request.geojson, "Input layer")
+    _check_size(request.overlay, "Overlay layer")
 
     try:
         geojson, messages = handler(request)

--- a/backend/geolibre_server/geolibre_server/app/vector.py
+++ b/backend/geolibre_server/geolibre_server/app/vector.py
@@ -187,6 +187,20 @@ def _clip(request: VectorToolRequest) -> tuple[dict, list[str]]:
     return _to_feature_collection(clipped), [f"Clip: produced {len(clipped)} feature(s)"]
 
 
+def _union(request: VectorToolRequest) -> tuple[dict, list[str]]:
+    gpd = _import_geopandas()
+    left = _load_gdf(request.geojson, "Input layer")
+    right = _load_gdf(request.overlay, "Overlay layer")
+    # Match the client engine: dissolve both layers into a single merged
+    # geometry rather than gpd.overlay(how="union")'s full-outer-join, which
+    # would return many attributed parts and diverge from the Turf.js result.
+    merged = gpd.GeoSeries(
+        [left.geometry.union_all(), right.geometry.union_all()], crs=WGS84
+    ).union_all()
+    result = gpd.GeoDataFrame(geometry=[merged], crs=WGS84)
+    return _to_feature_collection(result), ["Union: produced 1 feature"]
+
+
 _DISPATCH = {
     "buffer": _buffer,
     "centroids": _centroids,
@@ -197,7 +211,7 @@ _DISPATCH = {
     "clip": _clip,
     "intersection": lambda r: _overlay(r, "intersection"),
     "difference": lambda r: _overlay(r, "difference"),
-    "union": lambda r: _overlay(r, "union"),
+    "union": _union,
 }
 
 
@@ -220,7 +234,14 @@ def vector_status():
 
 @router.post("/run")
 def vector_run(request: VectorToolRequest):
-    """Run a single vector geometry operation and return the result GeoJSON."""
+    """Run a single vector geometry operation and return the result GeoJSON.
+
+    Intentionally a plain ``def``: GeoPandas/Shapely are CPU-bound and
+    synchronous, so FastAPI dispatches this to its thread pool and the event
+    loop is not blocked. Do not convert this (or the handlers it calls) to
+    ``async def`` without moving the work to an executor. The ``MAX_FEATURES``
+    cap bounds the per-request cost.
+    """
     try:
         _import_geopandas()
     except Exception as exc:  # noqa: BLE001

--- a/backend/geolibre_server/geolibre_server/app/vector.py
+++ b/backend/geolibre_server/geolibre_server/app/vector.py
@@ -1,0 +1,209 @@
+"""Vector geometry processing sidecar endpoints (GeoPandas).
+
+These endpoints mirror the client-side Turf.js tools in ``@geolibre/processing``
+but run on GeoPandas/Shapely, giving projection-aware results (notably buffers
+in real-world distance units). GeoPandas is an optional dependency: when it is
+not installed, ``/vector/status`` reports ``available: false`` and the desktop
+app falls back to the client engine.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/vector", tags=["vector"])
+logger = logging.getLogger(__name__)
+
+WGS84 = "EPSG:4326"
+
+# Conversion factors from the requested unit to meters.
+_DISTANCE_UNITS = {
+    "kilometers": 1000.0,
+    "meters": 1.0,
+    "miles": 1609.344,
+}
+
+
+class VectorToolRequest(BaseModel):
+    tool_id: str
+    geojson: Optional[dict] = None
+    overlay: Optional[dict] = None
+    parameters: dict[str, Any] = {}
+
+
+def _import_geopandas():
+    """Import GeoPandas, raising if the optional dependency is missing."""
+    import geopandas as gpd  # noqa: PLC0415
+
+    return gpd
+
+
+def _load_gdf(geojson: Optional[dict], label: str):
+    """Build a WGS84 GeoDataFrame from a GeoJSON FeatureCollection."""
+    gpd = _import_geopandas()
+    if not geojson or not geojson.get("features"):
+        raise HTTPException(status_code=400, detail=f"{label} has no features")
+    gdf = gpd.GeoDataFrame.from_features(geojson["features"], crs=WGS84)
+    if gdf.empty:
+        raise HTTPException(status_code=400, detail=f"{label} has no features")
+    return gdf
+
+
+def _to_feature_collection(gdf) -> dict:
+    """Serialize a GeoDataFrame back to a GeoJSON FeatureCollection dict."""
+    # GeoPandas only emits valid GeoJSON in WGS84; reproject if needed.
+    if gdf.crs is not None and gdf.crs.to_epsg() != 4326:
+        gdf = gdf.to_crs(WGS84)
+    return json.loads(gdf.to_json())
+
+
+def _buffer(request: VectorToolRequest) -> tuple[dict, list[str]]:
+    gdf = _load_gdf(request.geojson, "Input layer")
+    params = request.parameters
+    distance = float(params.get("distance", 1) or 0)
+    units = str(params.get("units", "kilometers"))
+    meters = distance * _DISTANCE_UNITS.get(units, 1000.0)
+    # Buffer in a local metric CRS so the distance is in real-world meters,
+    # then reproject the result back to WGS84.
+    metric_crs = gdf.estimate_utm_crs()
+    projected = gdf.to_crs(metric_crs)
+    projected["geometry"] = projected.geometry.buffer(meters)
+    return (
+        _to_feature_collection(projected),
+        [f"Buffered {len(gdf)} feature(s) by {distance} {units}"],
+    )
+
+
+def _centroids(request: VectorToolRequest) -> tuple[dict, list[str]]:
+    gdf = _load_gdf(request.geojson, "Input layer")
+    result = gdf.copy()
+    result["geometry"] = gdf.geometry.centroid
+    return _to_feature_collection(result), [f"Computed {len(result)} centroid(s)"]
+
+
+def _convex_hull(request: VectorToolRequest) -> tuple[dict, list[str]]:
+    gpd = _import_geopandas()
+    gdf = _load_gdf(request.geojson, "Input layer")
+    hull = gdf.geometry.union_all().convex_hull
+    result = gpd.GeoDataFrame(geometry=[hull], crs=WGS84)
+    return _to_feature_collection(result), ["Computed convex hull"]
+
+
+def _dissolve(request: VectorToolRequest) -> tuple[dict, list[str]]:
+    gdf = _load_gdf(request.geojson, "Input layer")
+    field = str(request.parameters.get("field", "") or "").strip()
+    if field and field in gdf.columns:
+        dissolved = gdf.dissolve(by=field).reset_index()
+    else:
+        dissolved = gdf.dissolve()
+    return (
+        _to_feature_collection(dissolved),
+        [f"Dissolved {len(gdf)} feature(s) into {len(dissolved)} feature(s)"],
+    )
+
+
+def _bounding_box(request: VectorToolRequest) -> tuple[dict, list[str]]:
+    gpd = _import_geopandas()
+    from shapely.geometry import box  # noqa: PLC0415
+
+    gdf = _load_gdf(request.geojson, "Input layer")
+    minx, miny, maxx, maxy = gdf.total_bounds
+    result = gpd.GeoDataFrame(geometry=[box(minx, miny, maxx, maxy)], crs=WGS84)
+    return _to_feature_collection(result), ["Computed bounding box"]
+
+
+def _simplify(request: VectorToolRequest) -> tuple[dict, list[str]]:
+    gdf = _load_gdf(request.geojson, "Input layer")
+    tolerance = float(request.parameters.get("tolerance", 0.01) or 0)
+    result = gdf.copy()
+    result["geometry"] = gdf.geometry.simplify(tolerance)
+    return (
+        _to_feature_collection(result),
+        [f"Simplified {len(result)} feature(s) (tolerance {tolerance})"],
+    )
+
+
+def _overlay(request: VectorToolRequest, how: str) -> tuple[dict, list[str]]:
+    gpd = _import_geopandas()
+    left = _load_gdf(request.geojson, "Input layer")
+    right = _load_gdf(request.overlay, "Overlay layer")
+    result = gpd.overlay(left, right, how=how, keep_geom_type=False)
+    return (
+        _to_feature_collection(result),
+        [f"{how.capitalize()}: produced {len(result)} feature(s)"],
+    )
+
+
+def _clip(request: VectorToolRequest) -> tuple[dict, list[str]]:
+    gpd = _import_geopandas()
+    left = _load_gdf(request.geojson, "Input layer")
+    right = _load_gdf(request.overlay, "Overlay layer")
+    clipped = gpd.clip(left, right)
+    return _to_feature_collection(clipped), [f"Clip: produced {len(clipped)} feature(s)"]
+
+
+_DISPATCH = {
+    "buffer": _buffer,
+    "centroids": _centroids,
+    "convex-hull": _convex_hull,
+    "dissolve": _dissolve,
+    "bounding-box": _bounding_box,
+    "simplify": _simplify,
+    "clip": _clip,
+    "intersection": lambda r: _overlay(r, "intersection"),
+    "difference": lambda r: _overlay(r, "difference"),
+    "union": lambda r: _overlay(r, "union"),
+}
+
+
+@router.get("/status")
+def vector_status():
+    """Return vector (GeoPandas) runtime availability."""
+    try:
+        _import_geopandas()
+        return {
+            "available": True,
+            "message": "Vector runtime (GeoPandas) is available.",
+        }
+    except Exception as exc:  # noqa: BLE001 - report any import failure as unavailable
+        logger.info("GeoPandas runtime unavailable: %s", exc)
+        return {
+            "available": False,
+            "message": "Vector runtime (GeoPandas) is not installed.",
+        }
+
+
+@router.post("/run")
+def vector_run(request: VectorToolRequest):
+    """Run a single vector geometry operation and return the result GeoJSON."""
+    try:
+        _import_geopandas()
+    except Exception as exc:  # noqa: BLE001
+        logger.info("GeoPandas runtime unavailable: %s", exc)
+        raise HTTPException(
+            status_code=503,
+            detail="GeoPandas is not installed in the sidecar.",
+        ) from exc
+
+    handler = _DISPATCH.get(request.tool_id)
+    if handler is None:
+        raise HTTPException(
+            status_code=400, detail=f"Unknown vector tool: {request.tool_id}"
+        )
+
+    try:
+        geojson, messages = handler(request)
+    except HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001 - surface a stable error to the client
+        logger.exception("Vector tool %s failed", request.tool_id)
+        raise HTTPException(
+            status_code=400, detail=f"Vector tool failed: {exc}"
+        ) from exc
+
+    return {"geojson": geojson, "messages": messages}

--- a/backend/geolibre_server/geolibre_server/app/vector.py
+++ b/backend/geolibre_server/geolibre_server/app/vector.py
@@ -80,7 +80,13 @@ def _buffer(request: VectorToolRequest) -> tuple[dict, list[str]]:
     params = request.parameters
     distance = float(params.get("distance", 1) or 0)
     units = str(params.get("units", "kilometers"))
-    meters = distance * _DISTANCE_UNITS.get(units, 1000.0)
+    factor = _DISTANCE_UNITS.get(units)
+    if factor is None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown unit '{units}'. Accepted: {list(_DISTANCE_UNITS)}",
+        )
+    meters = distance * factor
     if meters < 0:
         # The UI enforces a non-negative distance; keep the server consistent
         # rather than silently performing an inward (erosion) buffer.
@@ -98,9 +104,13 @@ def _buffer(request: VectorToolRequest) -> tuple[dict, list[str]]:
 
 def _centroids(request: VectorToolRequest) -> tuple[dict, list[str]]:
     gdf = _load_gdf(request.geojson, "Input layer")
-    result = gdf.copy()
-    # Computed on geographic (WGS84) coordinates, matching the client engine.
-    result["geometry"] = gdf.geometry.centroid
+    # Compute centroids in a local metric CRS (like _buffer) so the result is
+    # accurate for large or elongated features, then reproject back to WGS84.
+    metric_crs = gdf.estimate_utm_crs()
+    projected = gdf.to_crs(metric_crs)
+    result = projected.copy()
+    result["geometry"] = projected.geometry.centroid
+    result = result.to_crs(WGS84)
     return _to_feature_collection(result), [f"Computed {len(result)} centroid(s)"]
 
 
@@ -115,7 +125,12 @@ def _convex_hull(request: VectorToolRequest) -> tuple[dict, list[str]]:
 def _dissolve(request: VectorToolRequest) -> tuple[dict, list[str]]:
     gdf = _load_gdf(request.geojson, "Input layer")
     field = str(request.parameters.get("field", "") or "").strip()
-    if field and field in gdf.columns:
+    if field and field not in gdf.columns:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Dissolve field '{field}' not found in layer attributes.",
+        )
+    if field:
         dissolved = gdf.dissolve(by=field).reset_index()
     else:
         dissolved = gdf.dissolve()

--- a/backend/geolibre_server/geolibre_server/app/vector.py
+++ b/backend/geolibre_server/geolibre_server/app/vector.py
@@ -40,7 +40,7 @@ class VectorToolRequest(BaseModel):
     parameters: dict[str, Any] = {}
 
 
-def _import_geopandas():
+def _import_geopandas() -> Any:
     """Import GeoPandas, raising if the optional dependency is missing."""
     import geopandas as gpd  # noqa: PLC0415
 
@@ -56,7 +56,7 @@ def _check_size(geojson: Optional[dict], label: str) -> None:
         )
 
 
-def _load_gdf(geojson: Optional[dict], label: str):
+def _load_gdf(geojson: Optional[dict], label: str) -> Any:
     """Build a WGS84 GeoDataFrame from a GeoJSON FeatureCollection."""
     gpd = _import_geopandas()
     if not geojson or not geojson.get("features"):

--- a/backend/geolibre_server/pyproject.toml
+++ b/backend/geolibre_server/pyproject.toml
@@ -21,6 +21,13 @@ conversion = [
   "rio-cogeo>=5.0.0",
   "freestiler>=0.1.0",
 ]
+# Optional GeoPandas engine for the Vector processing tools. Not installed by
+# default to keep the bundled sidecar small; the desktop app falls back to the
+# client-side (Turf.js) engine when this is absent.
+vector = [
+  "geopandas>=1.0",
+  "shapely>=2.0",
+]
 # Future geospatial stack (not required for MVP UI):
 # geo = [
 #   "gdal",

--- a/backend/geolibre_server/tests/test_vector.py
+++ b/backend/geolibre_server/tests/test_vector.py
@@ -1,3 +1,5 @@
+from typing import NoReturn
+
 import pytest
 from fastapi import HTTPException
 
@@ -74,7 +76,7 @@ def test_status_returns_availability_shape() -> None:
 
 
 def test_run_without_geopandas_raises_503(monkeypatch: pytest.MonkeyPatch) -> None:
-    def _boom():
+    def _boom() -> NoReturn:
         raise ImportError("geopandas missing")
 
     monkeypatch.setattr(vector, "_import_geopandas", _boom)

--- a/backend/geolibre_server/tests/test_vector.py
+++ b/backend/geolibre_server/tests/test_vector.py
@@ -115,3 +115,79 @@ def test_unknown_tool_returns_400() -> None:
     with pytest.raises(HTTPException) as exc:
         vector_run(VectorToolRequest(tool_id="nonsense", geojson=SQUARE))
     assert exc.value.status_code == 400
+
+
+@requires_geopandas
+@pytest.mark.parametrize(
+    "tool_id",
+    ["centroids", "convex-hull", "dissolve", "bounding-box", "simplify"],
+)
+def test_single_layer_tools_return_feature_collection(tool_id: str) -> None:
+    result = vector_run(VectorToolRequest(tool_id=tool_id, geojson=SQUARE))
+    fc = result["geojson"]
+    assert fc["type"] == "FeatureCollection"
+    assert len(fc["features"]) >= 1
+
+
+@requires_geopandas
+@pytest.mark.parametrize("tool_id", ["clip", "difference", "union"])
+def test_overlay_tools_return_feature_collection(tool_id: str) -> None:
+    result = vector_run(
+        VectorToolRequest(tool_id=tool_id, geojson=SQUARE, overlay=OVERLAP)
+    )
+    fc = result["geojson"]
+    assert fc["type"] == "FeatureCollection"
+    assert len(fc["features"]) >= 1
+
+
+@requires_geopandas
+def test_union_dissolves_to_single_feature() -> None:
+    # The sidecar union must match the client engine (one merged geometry).
+    result = vector_run(
+        VectorToolRequest(tool_id="union", geojson=SQUARE, overlay=OVERLAP)
+    )
+    assert len(result["geojson"]["features"]) == 1
+
+
+@requires_geopandas
+def test_buffer_rejects_negative_distance() -> None:
+    with pytest.raises(HTTPException) as exc:
+        vector_run(
+            VectorToolRequest(
+                tool_id="buffer", geojson=SQUARE, parameters={"distance": -1}
+            )
+        )
+    assert exc.value.status_code == 400
+
+
+@requires_geopandas
+def test_buffer_rejects_unknown_unit() -> None:
+    with pytest.raises(HTTPException) as exc:
+        vector_run(
+            VectorToolRequest(
+                tool_id="buffer",
+                geojson=SQUARE,
+                parameters={"distance": 1, "units": "furlongs"},
+            )
+        )
+    assert exc.value.status_code == 400
+
+
+@requires_geopandas
+def test_dissolve_rejects_unknown_field() -> None:
+    with pytest.raises(HTTPException) as exc:
+        vector_run(
+            VectorToolRequest(
+                tool_id="dissolve", geojson=SQUARE, parameters={"field": "missing"}
+            )
+        )
+    assert exc.value.status_code == 400
+
+
+@requires_geopandas
+def test_run_rejects_oversized_input(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(vector, "MAX_FEATURES", 2)
+    big = {"type": "FeatureCollection", "features": [{}, {}, {}]}
+    with pytest.raises(HTTPException) as exc:
+        vector_run(VectorToolRequest(tool_id="buffer", geojson=big))
+    assert exc.value.status_code == 413

--- a/backend/geolibre_server/tests/test_vector.py
+++ b/backend/geolibre_server/tests/test_vector.py
@@ -1,0 +1,115 @@
+import pytest
+from fastapi import HTTPException
+
+from geolibre_server.app import vector
+from geolibre_server.app.vector import (
+    _DISPATCH,
+    VectorToolRequest,
+    vector_run,
+    vector_status,
+)
+
+try:
+    import geopandas  # noqa: F401
+
+    HAS_GEOPANDAS = True
+except Exception:  # pragma: no cover - depends on the optional extra
+    HAS_GEOPANDAS = False
+
+requires_geopandas = pytest.mark.skipif(
+    not HAS_GEOPANDAS, reason="geopandas optional extra not installed"
+)
+
+
+def _square(name: str, x: float = 0.0, y: float = 0.0) -> dict:
+    return {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"name": name},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [x, y],
+                            [x, y + 1],
+                            [x + 1, y + 1],
+                            [x + 1, y],
+                            [x, y],
+                        ]
+                    ],
+                },
+            }
+        ],
+    }
+
+
+SQUARE = _square("a")
+OVERLAP = _square("b", x=0.5, y=0.5)
+
+
+def test_dispatch_covers_all_tools() -> None:
+    """The backend must implement every client-side vector tool id."""
+    expected = {
+        "buffer",
+        "centroids",
+        "convex-hull",
+        "dissolve",
+        "bounding-box",
+        "simplify",
+        "clip",
+        "intersection",
+        "difference",
+        "union",
+    }
+    assert set(_DISPATCH) == expected
+
+
+def test_status_returns_availability_shape() -> None:
+    status = vector_status()
+    assert set(status) == {"available", "message"}
+    assert isinstance(status["available"], bool)
+    assert isinstance(status["message"], str)
+
+
+def test_run_without_geopandas_raises_503(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom():
+        raise ImportError("geopandas missing")
+
+    monkeypatch.setattr(vector, "_import_geopandas", _boom)
+    with pytest.raises(HTTPException) as exc:
+        vector_run(VectorToolRequest(tool_id="buffer", geojson=SQUARE))
+    assert exc.value.status_code == 503
+
+
+@requires_geopandas
+def test_buffer_returns_feature_collection() -> None:
+    result = vector_run(
+        VectorToolRequest(
+            tool_id="buffer",
+            geojson=SQUARE,
+            parameters={"distance": 1, "units": "kilometers"},
+        )
+    )
+    fc = result["geojson"]
+    assert fc["type"] == "FeatureCollection"
+    assert len(fc["features"]) == 1
+    assert result["messages"]
+
+
+@requires_geopandas
+def test_intersection_overlay() -> None:
+    result = vector_run(
+        VectorToolRequest(tool_id="intersection", geojson=SQUARE, overlay=OVERLAP)
+    )
+    fc = result["geojson"]
+    assert fc["type"] == "FeatureCollection"
+    assert len(fc["features"]) >= 1
+
+
+@requires_geopandas
+def test_unknown_tool_returns_400() -> None:
+    with pytest.raises(HTTPException) as exc:
+        vector_run(VectorToolRequest(tool_id="nonsense", geojson=SQUARE))
+    assert exc.value.status_code == 400

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,9 +57,11 @@ Local MBTiles tiles are read through a custom MapLibre protocol backed by Tauri 
 
 ## Python sidecar
 
-The FastAPI app in `backend/geolibre_server` backs the Whitebox toolbox through a managed local processing sidecar. The desktop app starts the sidecar on demand, communicates over `127.0.0.1`, and keeps the heavier Python processing stack outside the browser bundle.
+The FastAPI app in `backend/geolibre_server` backs the Whitebox toolbox and the format Conversion tools through a managed local processing sidecar. The desktop app starts the sidecar on demand, communicates over `127.0.0.1`, and keeps the heavier Python processing stack outside the browser bundle.
 
-Future processing releases are expected to expand the same sidecar pattern for GDAL, Rasterio, GeoPandas, DuckDB Spatial SQL, Leafmap, GeoAI, and SamGeo workflows.
+The Vector tools (Processing → Vector) run client-side with Turf.js and need no sidecar. Buffer and the overlay tools can optionally run on the sidecar's `/vector` endpoints, backed by GeoPandas and Shapely, for projection-aware results; the sidecar reports availability through `/vector/status`, and the dialog falls back to the client engine when the optional `vector` extra is not installed.
+
+Future processing releases are expected to expand the same sidecar pattern for GDAL, Rasterio, DuckDB Spatial SQL, Leafmap, GeoAI, and SamGeo workflows.
 
 ## Container image
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,7 +59,7 @@ Local MBTiles tiles are read through a custom MapLibre protocol backed by Tauri 
 
 The FastAPI app in `backend/geolibre_server` backs the Whitebox toolbox and the format Conversion tools through a managed local processing sidecar. The desktop app starts the sidecar on demand, communicates over `127.0.0.1`, and keeps the heavier Python processing stack outside the browser bundle.
 
-The Vector tools (Processing → Vector) run client-side with Turf.js and need no sidecar. Buffer and the overlay tools can optionally run on the sidecar's `/vector` endpoints, backed by GeoPandas and Shapely, for projection-aware results; the sidecar reports availability through `/vector/status`, and the dialog falls back to the client engine when the optional `vector` extra is not installed.
+The Vector tools (Processing → Vector) run client-side with Turf.js and need no sidecar. Buffer, dissolve, and the overlay tools can optionally run on the sidecar's `/vector` endpoints, backed by GeoPandas and Shapely, for projection-aware results; the sidecar reports availability through `/vector/status`, and the dialog falls back to the client engine when the optional `vector` extra is not installed.
 
 Future processing releases are expected to expand the same sidecar pattern for GDAL, Rasterio, DuckDB Spatial SQL, Leafmap, GeoAI, and SamGeo workflows.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,7 +59,7 @@ Local MBTiles tiles are read through a custom MapLibre protocol backed by Tauri 
 
 The FastAPI app in `backend/geolibre_server` backs the Whitebox toolbox and the format Conversion tools through a managed local processing sidecar. The desktop app starts the sidecar on demand, communicates over `127.0.0.1`, and keeps the heavier Python processing stack outside the browser bundle.
 
-The Vector tools (Processing → Vector) run client-side with Turf.js and need no sidecar. Buffer, dissolve, and the overlay tools can optionally run on the sidecar's `/vector` endpoints, backed by GeoPandas and Shapely, for projection-aware results; the sidecar reports availability through `/vector/status`, and the dialog falls back to the client engine when the optional `vector` extra is not installed.
+The Vector tools (Processing → Vector) run client-side with Turf.js and need no sidecar. All of the tools can optionally run on the sidecar's `/vector` endpoints, backed by GeoPandas and Shapely, for projection-aware results; the sidecar reports availability through `/vector/status`, and the dialog falls back to the client engine when the optional `vector` extra is not installed.
 
 Future processing releases are expected to expand the same sidecar pattern for GDAL, Rasterio, DuckDB Spatial SQL, Leafmap, GeoAI, and SamGeo workflows.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,7 +68,7 @@ Run DuckDB Spatial SQL in the browser against loaded layers, local files, and re
 <div class="feature-card" markdown>
 ### Vector tools
 
-Common geometry tools under Processing → Vector: buffer, centroids, convex hull, dissolve, bounding box, simplify, clip, intersection, difference, and union. They run in the browser with Turf.js, with an optional GeoPandas sidecar engine for buffer, dissolve, and overlay tools.
+Common geometry tools under Processing → Vector: buffer, centroids, convex hull, dissolve, bounding box, simplify, clip, intersection, difference, and union. They run in the browser with Turf.js, with an optional GeoPandas sidecar engine for every tool.
 </div>
 
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,6 +65,12 @@ The processing toolbox includes client-side algorithms now, with a roadmap towar
 Run DuckDB Spatial SQL in the browser against loaded layers, local files, and remote URLs. Auto-wraps bare URLs into the matching reader and streams remote files over HTTP range requests. Includes sample queries, query history, and adding a result (with an optional layer name) to the map or exporting it as CSV or GeoParquet.
 </div>
 
+<div class="feature-card" markdown>
+### Vector tools
+
+Common geometry tools under Processing → Vector: buffer, centroids, convex hull, dissolve, bounding box, simplify, clip, intersection, difference, and union. They run in the browser with Turf.js, with an optional GeoPandas sidecar engine for buffer and overlay tools.
+</div>
+
 </div>
 
 ## Try it in the browser

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,7 +68,7 @@ Run DuckDB Spatial SQL in the browser against loaded layers, local files, and re
 <div class="feature-card" markdown>
 ### Vector tools
 
-Common geometry tools under Processing → Vector: buffer, centroids, convex hull, dissolve, bounding box, simplify, clip, intersection, difference, and union. They run in the browser with Turf.js, with an optional GeoPandas sidecar engine for buffer and overlay tools.
+Common geometry tools under Processing → Vector: buffer, centroids, convex hull, dissolve, bounding box, simplify, clip, intersection, difference, and union. They run in the browser with Turf.js, with an optional GeoPandas sidecar engine for buffer, dissolve, and overlay tools.
 </div>
 
 </div>

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -95,6 +95,7 @@
 - [x] Add Vector Layer powered by the `maplibre-gl-vector` plugin
 - [x] Identify, selection, and attribute table support for DuckDB layers
 - [x] Conversion menu under Processing for Vector to GeoParquet/FlatGeobuf/PMTiles, CSV to GeoParquet, and Raster to COG, backed by a hardened conversion sidecar with a path allowlist
+- [x] Vector menu under Processing with common geometry tools (buffer, centroids, convex hull, dissolve, bounding box, simplify, clip, intersection, difference, union) running client-side with Turf.js, plus an optional GeoPandas sidecar engine
 - [x] Whitebox batch tools run against a selected input directory
 - [x] Controls menu with Measure, Bookmark, Minimap, and View State tools
 - [x] Print menu backed by `PrintControl`

--- a/package-lock.json
+++ b/package-lock.json
@@ -14780,7 +14780,17 @@
       "version": "0.9.0",
       "dependencies": {
         "@geolibre/core": "*",
-        "@turf/bbox": "^7.2.0"
+        "@turf/bbox": "^7.2.0",
+        "@turf/buffer": "^7.3.5",
+        "@turf/centroid": "^7.3.5",
+        "@turf/convex": "^7.3.5",
+        "@turf/difference": "^7.3.5",
+        "@turf/dissolve": "^7.3.5",
+        "@turf/envelope": "^7.3.5",
+        "@turf/helpers": "^7.3.5",
+        "@turf/intersect": "^7.3.5",
+        "@turf/simplify": "^7.3.5",
+        "@turf/union": "^7.3.5"
       },
       "devDependencies": {
         "@types/geojson": "^7946.0.16",

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -28,6 +28,19 @@ export type ConversionToolKind =
   | "vector-to-pmtiles"
   | "raster-to-cog";
 
+/** Identifiers of the vector processing tools (see `@geolibre/processing`). */
+export type VectorToolKind =
+  | "buffer"
+  | "centroids"
+  | "convex-hull"
+  | "dissolve"
+  | "bounding-box"
+  | "simplify"
+  | "clip"
+  | "intersection"
+  | "difference"
+  | "union";
+
 export interface AppState {
   projectName: string;
   projectPath: string | null;
@@ -50,6 +63,7 @@ export interface AppState {
   ui: {
     processingOpen: boolean;
     conversionOpen: ConversionToolKind | null;
+    vectorToolOpen: VectorToolKind | null;
     sqlWorkspaceOpen: boolean;
     attributeTableOpen: boolean;
     zoomToSelectedFeature: boolean;
@@ -71,6 +85,7 @@ export interface AppState {
   setAttributeFilter: (filter: string) => void;
   setProcessingOpen: (open: boolean) => void;
   setConversionOpen: (kind: ConversionToolKind | null) => void;
+  setVectorToolOpen: (kind: VectorToolKind | null) => void;
   setSqlWorkspaceOpen: (open: boolean) => void;
   setAttributeTableOpen: (open: boolean) => void;
   setZoomToSelectedFeature: (enabled: boolean) => void;
@@ -156,6 +171,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   ui: {
     processingOpen: false,
     conversionOpen: null,
+    vectorToolOpen: null,
     sqlWorkspaceOpen: false,
     attributeTableOpen: false,
     zoomToSelectedFeature: false,
@@ -188,6 +204,8 @@ export const useAppStore = create<AppState>((set, get) => ({
     set((s) => ({ ui: { ...s.ui, processingOpen: open } })),
   setConversionOpen: (kind) =>
     set((s) => ({ ui: { ...s.ui, conversionOpen: kind } })),
+  setVectorToolOpen: (kind) =>
+    set((s) => ({ ui: { ...s.ui, vectorToolOpen: kind } })),
   setSqlWorkspaceOpen: (open) =>
     set((s) => ({ ui: { ...s.ui, sqlWorkspaceOpen: open } })),
   setAttributeTableOpen: (open) =>

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -28,7 +28,11 @@ export type ConversionToolKind =
   | "vector-to-pmtiles"
   | "raster-to-cog";
 
-/** Identifiers of the vector processing tools (see `@geolibre/processing`). */
+/**
+ * Identifiers of the vector processing tools. Kept in sync by hand with the
+ * `id` fields of `VECTOR_TOOLS` in `@geolibre/processing` (`vector-tools.ts`);
+ * deriving the type there would create a core -> processing circular import.
+ */
 export type VectorToolKind =
   | "buffer"
   | "centroids"

--- a/packages/processing/package.json
+++ b/packages/processing/package.json
@@ -10,7 +10,17 @@
   },
   "dependencies": {
     "@geolibre/core": "*",
-    "@turf/bbox": "^7.2.0"
+    "@turf/bbox": "^7.2.0",
+    "@turf/buffer": "^7.3.5",
+    "@turf/centroid": "^7.3.5",
+    "@turf/convex": "^7.3.5",
+    "@turf/difference": "^7.3.5",
+    "@turf/dissolve": "^7.3.5",
+    "@turf/envelope": "^7.3.5",
+    "@turf/helpers": "^7.3.5",
+    "@turf/intersect": "^7.3.5",
+    "@turf/simplify": "^7.3.5",
+    "@turf/union": "^7.3.5"
   },
   "devDependencies": {
     "@types/geojson": "^7946.0.16",

--- a/packages/processing/src/index.ts
+++ b/packages/processing/src/index.ts
@@ -5,6 +5,7 @@ export {
   calculateBoundsAlgorithm,
   countFeaturesAlgorithm,
 } from "./registry";
+export { VECTOR_TOOLS, getVectorTool } from "./vector-tools";
 export {
   checkSidecarHealth,
   clearRemoteWhiteboxCatalogSnapshotCache,
@@ -22,6 +23,8 @@ export {
   runVectorToFlatGeobuf,
   runVectorToGeoParquet,
   runVectorToPmtiles,
+  runVectorTool,
+  fetchVectorStatus,
   runWhiteboxTool,
   WHITEBOX_CATALOG_URL,
   type ConversionJob,
@@ -32,6 +35,9 @@ export {
   type VectorToFlatGeobufRequest,
   type VectorToGeoParquetRequest,
   type VectorToPmtilesRequest,
+  type VectorStatus,
+  type VectorToolRequest,
+  type VectorToolResult,
   type WhiteboxJob,
   type WhiteboxLayerInput,
   type WhiteboxParameterKind,

--- a/packages/processing/src/registry.ts
+++ b/packages/processing/src/registry.ts
@@ -62,20 +62,6 @@ export const exportGeoJsonPlaceholder: ProcessingAlgorithm = {
   },
 };
 
-export const bufferPlaceholder: ProcessingAlgorithm = {
-  id: "buffer",
-  name: "Buffer",
-  description: "Buffer geometries by distance",
-  parameters: [
-    { id: "layer", label: "Layer", type: "layer", required: true },
-    { id: "distance", label: "Distance (m)", type: "number", default: 100 },
-  ],
-  run: (ctx) => {
-    // TODO(v0.5): Buffer via Python sidecar or Turf.js
-    ctx.log("Not implemented — buffer planned for v0.5 (Python sidecar)");
-  },
-};
-
 export const reprojectPlaceholder: ProcessingAlgorithm = {
   id: "reproject",
   name: "Reproject",
@@ -94,7 +80,6 @@ export const ALGORITHMS: ProcessingAlgorithm[] = [
   calculateBoundsAlgorithm,
   countFeaturesAlgorithm,
   exportGeoJsonPlaceholder,
-  bufferPlaceholder,
   reprojectPlaceholder,
 ];
 

--- a/packages/processing/src/sidecar-client.ts
+++ b/packages/processing/src/sidecar-client.ts
@@ -457,6 +457,63 @@ export async function fetchConversionJob(
   return (await res.json()) as ConversionJob;
 }
 
+export interface VectorStatus {
+  available: boolean;
+  message: string;
+}
+
+export interface VectorToolRequest {
+  tool_id: string;
+  /** Primary input layer as a GeoJSON FeatureCollection. */
+  geojson: unknown;
+  /** Optional second layer for overlay operations (clip/intersection/etc.). */
+  overlay?: unknown;
+  /** Tool parameters (distance, units, tolerance, field, ...). */
+  parameters?: Record<string, unknown>;
+}
+
+export interface VectorToolResult {
+  /** Resulting GeoJSON FeatureCollection. */
+  geojson: unknown;
+  /** Human-readable log lines describing what ran. */
+  messages: string[];
+}
+
+export async function fetchVectorStatus(
+  baseUrl = DEFAULT_SIDECAR_URL,
+): Promise<VectorStatus> {
+  let res: Response;
+  try {
+    res = await fetch(`${baseUrl}/vector/status`);
+  } catch (error) {
+    throw sidecarConnectionError(baseUrl, error);
+  }
+  if (!res.ok) {
+    throw new Error(`Vector status failed: HTTP ${res.status}`);
+  }
+  return (await res.json()) as VectorStatus;
+}
+
+export async function runVectorTool(
+  request: VectorToolRequest,
+  baseUrl = DEFAULT_SIDECAR_URL,
+): Promise<VectorToolResult> {
+  let res: Response;
+  try {
+    res = await fetch(`${baseUrl}/vector/run`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(request),
+    });
+  } catch (error) {
+    throw sidecarConnectionError(baseUrl, error);
+  }
+  if (!res.ok) {
+    throw new Error(await responseErrorMessage(res, "Could not run vector tool"));
+  }
+  return (await res.json()) as VectorToolResult;
+}
+
 async function responseErrorMessage(
   response: Response,
   fallback: string,

--- a/packages/processing/src/types.ts
+++ b/packages/processing/src/types.ts
@@ -1,6 +1,15 @@
+import type { FeatureCollection } from "geojson";
 import type { GeoLibreLayer } from "@geolibre/core";
 
-export type ParameterType = "layer" | "number" | "string" | "boolean";
+export type ParameterType = "layer" | "number" | "string" | "boolean" | "select";
+
+/** A single geometry family used to filter layer pickers. */
+export type GeometryFamily = "point" | "line" | "polygon";
+
+export interface ParameterOption {
+  value: string;
+  label: string;
+}
 
 export interface AlgorithmParameter {
   id: string;
@@ -8,6 +17,16 @@ export interface AlgorithmParameter {
   type: ParameterType;
   required?: boolean;
   default?: unknown;
+  /** Help text shown beneath the field. */
+  description?: string;
+  /** Options for `type: "select"`. */
+  options?: ParameterOption[];
+  /** Numeric bounds/step for `type: "number"`. */
+  min?: number;
+  max?: number;
+  step?: number;
+  /** Restrict a `type: "layer"` picker to layers with these geometry families. */
+  geometryFilter?: GeometryFamily[];
 }
 
 export interface ProcessingContext {
@@ -15,6 +34,8 @@ export interface ProcessingContext {
   parameters: Record<string, unknown>;
   log: (message: string) => void;
   fitBounds?: (bounds: [number, number, number, number]) => void;
+  /** Add an algorithm result back to the map as a new GeoJSON layer. */
+  addResultLayer?: (name: string, geojson: FeatureCollection) => void;
 }
 
 export interface ProcessingAlgorithm {
@@ -22,5 +43,9 @@ export interface ProcessingAlgorithm {
   name: string;
   description: string;
   parameters: AlgorithmParameter[];
+  /** Optional grouping label for menus/lists (e.g. "Geometry", "Overlay"). */
+  group?: string;
+  /** Whether this algorithm can also run on the Python (GeoPandas) sidecar. */
+  supportsSidecar?: boolean;
   run: (ctx: ProcessingContext) => Promise<void> | void;
 }

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -199,6 +199,12 @@ export const dissolveTool: ProcessingAlgorithm = {
       ctx.log("Error: Dissolve requires (single-part) Polygon features");
       return;
     }
+    const skipped = fc.features.length - polys.length;
+    if (skipped > 0) {
+      ctx.log(
+        `Warning: skipped ${skipped} MultiPolygon feature(s) — Turf Dissolve requires single-part Polygons`,
+      );
+    }
     const field = (ctx.parameters.field as string)?.trim();
     const dissolved = dissolve(featureCollection(polys), {
       propertyName: field || undefined,

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -19,6 +19,9 @@ import type {
 import type { GeoLibreLayer } from "@geolibre/core";
 import type { GeometryFamily, ProcessingAlgorithm, ProcessingContext } from "./types";
 
+/** Upper bound on input×overlay pairs for the main-thread intersection loop. */
+const MAX_CLIENT_PAIRS = 250_000;
+
 function getLayer(
   ctx: ProcessingContext,
   paramId = "layer",
@@ -68,6 +71,26 @@ function polygonFeatures(
   ) as Feature<Polygon | MultiPolygon>[];
 }
 
+/** Split Polygon/MultiPolygon features into single-part Polygon features. */
+function explodeToPolygons(features: Feature[]): Feature<Polygon>[] {
+  const result: Feature<Polygon>[] = [];
+  for (const feature of features) {
+    const geometry = feature.geometry;
+    if (geometry?.type === "Polygon") {
+      result.push(feature as Feature<Polygon>);
+    } else if (geometry?.type === "MultiPolygon") {
+      for (const coordinates of geometry.coordinates) {
+        result.push({
+          type: "Feature",
+          properties: feature.properties ?? {},
+          geometry: { type: "Polygon", coordinates },
+        });
+      }
+    }
+  }
+  return result;
+}
+
 /** Merge all polygons of a collection into a single (multi)polygon feature. */
 function mergePolygons(
   fc: FeatureCollection,
@@ -77,6 +100,8 @@ function mergePolygons(
   let merged: Feature<Polygon | MultiPolygon> = polys[0];
   for (let i = 1; i < polys.length; i += 1) {
     const next = union(featureCollection([merged, polys[i]]));
+    // Turf can return null for degenerate/self-intersecting geometry; keep the
+    // last good accumulation rather than aborting the whole merge.
     if (next) merged = next as Feature<Polygon | MultiPolygon>;
   }
   return merged;
@@ -94,6 +119,7 @@ export const bufferTool: ProcessingAlgorithm = {
       id: "distance",
       label: "Distance",
       type: "number",
+      required: true,
       default: 1,
       min: 0,
       step: 0.1,
@@ -131,6 +157,7 @@ export const centroidsTool: ProcessingAlgorithm = {
   name: "Centroids",
   description: "Compute the centroid point of each feature",
   group: "Geometry",
+  supportsSidecar: true,
   parameters: [
     { id: "layer", label: "Input layer", type: "layer", required: true },
   ],
@@ -150,6 +177,7 @@ export const convexHullTool: ProcessingAlgorithm = {
   name: "Convex hull",
   description: "Compute the convex hull enclosing all features",
   group: "Geometry",
+  supportsSidecar: true,
   parameters: [
     { id: "layer", label: "Input layer", type: "layer", required: true },
   ],
@@ -191,19 +219,13 @@ export const dissolveTool: ProcessingAlgorithm = {
   run: (ctx) => {
     const fc = requireFeatures(ctx);
     if (!fc) return;
-    // Turf's dissolve only accepts single Polygon features (not MultiPolygon).
-    const polys = fc.features.filter(
-      (f) => f.geometry?.type === "Polygon",
-    ) as Feature<Polygon>[];
+    // Turf's dissolve only accepts single Polygon features, so explode any
+    // MultiPolygon into its constituent Polygons first (mirroring the sidecar,
+    // which handles both through GeoPandas) rather than dropping them.
+    const polys = explodeToPolygons(fc.features);
     if (!polys.length) {
-      ctx.log("Error: Dissolve requires (single-part) Polygon features");
+      ctx.log("Error: Dissolve requires polygon features");
       return;
-    }
-    const skipped = fc.features.length - polys.length;
-    if (skipped > 0) {
-      ctx.log(
-        `Warning: skipped ${skipped} MultiPolygon feature(s) — Turf Dissolve requires single-part Polygons`,
-      );
     }
     const field = (ctx.parameters.field as string)?.trim();
     const dissolved = dissolve(featureCollection(polys), {
@@ -221,6 +243,7 @@ export const boundingBoxTool: ProcessingAlgorithm = {
   name: "Bounding box",
   description: "Compute the rectangular envelope of all features",
   group: "Geometry",
+  supportsSidecar: true,
   parameters: [
     { id: "layer", label: "Input layer", type: "layer", required: true },
   ],
@@ -238,6 +261,7 @@ export const simplifyTool: ProcessingAlgorithm = {
   name: "Simplify",
   description: "Reduce the number of vertices using Douglas-Peucker",
   group: "Geometry",
+  supportsSidecar: true,
   parameters: [
     { id: "layer", label: "Input layer", type: "layer", required: true },
     {
@@ -368,6 +392,15 @@ export const intersectionTool: ProcessingAlgorithm = {
     const overlayPolys = polygonFeatures(overlayFc);
     if (!inputPolys.length || !overlayPolys.length) {
       ctx.log("Error: both layers must contain polygon features");
+      return;
+    }
+    // This pairwise loop runs on the main thread; cap it so very large layers
+    // cannot freeze the browser tab. Use the sidecar engine for bigger jobs.
+    const pairs = inputPolys.length * overlayPolys.length;
+    if (pairs > MAX_CLIENT_PAIRS) {
+      ctx.log(
+        `Error: intersection needs ${pairs} comparisons (limit ${MAX_CLIENT_PAIRS}); use the Sidecar engine for large layers`,
+      );
       return;
     }
     // Unlike Clip (which keeps only input attributes), Intersection carries

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -1,0 +1,464 @@
+import buffer from "@turf/buffer";
+import centroid from "@turf/centroid";
+import convex from "@turf/convex";
+import dissolve from "@turf/dissolve";
+import envelope from "@turf/envelope";
+import simplify from "@turf/simplify";
+import intersect from "@turf/intersect";
+import difference from "@turf/difference";
+import union from "@turf/union";
+import { featureCollection } from "@turf/helpers";
+import type {
+  Feature,
+  FeatureCollection,
+  GeoJsonProperties,
+  Geometry,
+  Polygon,
+  MultiPolygon,
+} from "geojson";
+import type { GeoLibreLayer } from "@geolibre/core";
+import type { GeometryFamily, ProcessingAlgorithm, ProcessingContext } from "./types";
+
+function getLayer(
+  ctx: ProcessingContext,
+  paramId = "layer",
+): GeoLibreLayer | undefined {
+  const layerId = ctx.parameters[paramId] as string | undefined;
+  return ctx.layers.find((l) => l.id === layerId);
+}
+
+function requireFeatures(
+  ctx: ProcessingContext,
+  paramId = "layer",
+): FeatureCollection | undefined {
+  const layer = getLayer(ctx, paramId);
+  if (!layer?.geojson?.features?.length) {
+    ctx.log(`Error: parameter "${paramId}" has no GeoJSON features`);
+    return undefined;
+  }
+  return layer.geojson;
+}
+
+function numberParam(
+  ctx: ProcessingContext,
+  id: string,
+  fallback: number,
+): number {
+  const raw = ctx.parameters[id];
+  const value = typeof raw === "string" ? Number(raw) : (raw as number);
+  return Number.isFinite(value) ? value : fallback;
+}
+
+/** True when a feature's geometry belongs to the given family. */
+function isFamily(geometry: Geometry | null, family: GeometryFamily): boolean {
+  const type = geometry?.type;
+  if (!type) return false;
+  if (family === "point") return type === "Point" || type === "MultiPoint";
+  if (family === "line")
+    return type === "LineString" || type === "MultiLineString";
+  return type === "Polygon" || type === "MultiPolygon";
+}
+
+/** Collect every polygon/multipolygon feature from a collection. */
+function polygonFeatures(
+  fc: FeatureCollection,
+): Feature<Polygon | MultiPolygon>[] {
+  return fc.features.filter((f) =>
+    isFamily(f.geometry, "polygon"),
+  ) as Feature<Polygon | MultiPolygon>[];
+}
+
+/** Merge all polygons of a collection into a single (multi)polygon feature. */
+function mergePolygons(
+  fc: FeatureCollection,
+): Feature<Polygon | MultiPolygon> | null {
+  const polys = polygonFeatures(fc);
+  if (!polys.length) return null;
+  let merged: Feature<Polygon | MultiPolygon> = polys[0];
+  for (let i = 1; i < polys.length; i += 1) {
+    const next = union(featureCollection([merged, polys[i]]));
+    if (next) merged = next as Feature<Polygon | MultiPolygon>;
+  }
+  return merged;
+}
+
+export const bufferTool: ProcessingAlgorithm = {
+  id: "buffer",
+  name: "Buffer",
+  description: "Create a buffer polygon around each feature by a fixed distance",
+  group: "Geometry",
+  supportsSidecar: true,
+  parameters: [
+    { id: "layer", label: "Input layer", type: "layer", required: true },
+    {
+      id: "distance",
+      label: "Distance",
+      type: "number",
+      default: 1,
+      min: 0,
+      step: 0.1,
+    },
+    {
+      id: "units",
+      label: "Units",
+      type: "select",
+      default: "kilometers",
+      options: [
+        { value: "kilometers", label: "Kilometers" },
+        { value: "meters", label: "Meters" },
+        { value: "miles", label: "Miles" },
+      ],
+    },
+  ],
+  run: (ctx) => {
+    const fc = requireFeatures(ctx);
+    if (!fc) return;
+    const distance = numberParam(ctx, "distance", 1);
+    const units = (ctx.parameters.units as string) || "kilometers";
+    const buffered = buffer(fc, distance, {
+      units: units as "kilometers" | "meters" | "miles",
+    });
+    const features = ((buffered?.features ?? []) as Feature[]).filter((f) =>
+      Boolean(f?.geometry),
+    );
+    ctx.log(`Buffered ${features.length} feature(s) by ${distance} ${units}`);
+    ctx.addResultLayer?.("Buffer", featureCollection(features));
+  },
+};
+
+export const centroidsTool: ProcessingAlgorithm = {
+  id: "centroids",
+  name: "Centroids",
+  description: "Compute the centroid point of each feature",
+  group: "Geometry",
+  parameters: [
+    { id: "layer", label: "Input layer", type: "layer", required: true },
+  ],
+  run: (ctx) => {
+    const fc = requireFeatures(ctx);
+    if (!fc) return;
+    const features = fc.features
+      .filter((f) => f.geometry)
+      .map((f) => centroid(f, { properties: f.properties ?? {} }));
+    ctx.log(`Computed ${features.length} centroid(s)`);
+    ctx.addResultLayer?.("Centroids", featureCollection(features));
+  },
+};
+
+export const convexHullTool: ProcessingAlgorithm = {
+  id: "convex-hull",
+  name: "Convex hull",
+  description: "Compute the convex hull enclosing all features",
+  group: "Geometry",
+  parameters: [
+    { id: "layer", label: "Input layer", type: "layer", required: true },
+  ],
+  run: (ctx) => {
+    const fc = requireFeatures(ctx);
+    if (!fc) return;
+    const hull = convex(fc);
+    if (!hull) {
+      ctx.log("Error: unable to compute a convex hull for this layer");
+      return;
+    }
+    ctx.log("Computed convex hull");
+    ctx.addResultLayer?.("Convex hull", featureCollection([hull]));
+  },
+};
+
+export const dissolveTool: ProcessingAlgorithm = {
+  id: "dissolve",
+  name: "Dissolve",
+  description:
+    "Merge polygon features into a single geometry, optionally grouped by a field",
+  group: "Geometry",
+  supportsSidecar: true,
+  parameters: [
+    {
+      id: "layer",
+      label: "Input layer",
+      type: "layer",
+      required: true,
+      geometryFilter: ["polygon"],
+    },
+    {
+      id: "field",
+      label: "Dissolve field (optional)",
+      type: "string",
+      description: "Property name to group features by before dissolving",
+    },
+  ],
+  run: (ctx) => {
+    const fc = requireFeatures(ctx);
+    if (!fc) return;
+    // Turf's dissolve only accepts single Polygon features (not MultiPolygon).
+    const polys = fc.features.filter(
+      (f) => f.geometry?.type === "Polygon",
+    ) as Feature<Polygon>[];
+    if (!polys.length) {
+      ctx.log("Error: Dissolve requires (single-part) Polygon features");
+      return;
+    }
+    const field = (ctx.parameters.field as string)?.trim();
+    const dissolved = dissolve(featureCollection(polys), {
+      propertyName: field || undefined,
+    });
+    ctx.log(
+      `Dissolved ${polys.length} polygon(s) into ${dissolved.features.length} feature(s)`,
+    );
+    ctx.addResultLayer?.("Dissolve", dissolved);
+  },
+};
+
+export const boundingBoxTool: ProcessingAlgorithm = {
+  id: "bounding-box",
+  name: "Bounding box",
+  description: "Compute the rectangular envelope of all features",
+  group: "Geometry",
+  parameters: [
+    { id: "layer", label: "Input layer", type: "layer", required: true },
+  ],
+  run: (ctx) => {
+    const fc = requireFeatures(ctx);
+    if (!fc) return;
+    const box = envelope(fc);
+    ctx.log("Computed bounding box");
+    ctx.addResultLayer?.("Bounding box", featureCollection([box]));
+  },
+};
+
+export const simplifyTool: ProcessingAlgorithm = {
+  id: "simplify",
+  name: "Simplify",
+  description: "Reduce the number of vertices using Douglas-Peucker",
+  group: "Geometry",
+  parameters: [
+    { id: "layer", label: "Input layer", type: "layer", required: true },
+    {
+      id: "tolerance",
+      label: "Tolerance (degrees)",
+      type: "number",
+      default: 0.01,
+      min: 0,
+      step: 0.001,
+    },
+    {
+      id: "highQuality",
+      label: "High quality",
+      type: "boolean",
+      default: false,
+    },
+  ],
+  run: (ctx) => {
+    const fc = requireFeatures(ctx);
+    if (!fc) return;
+    const tolerance = numberParam(ctx, "tolerance", 0.01);
+    const highQuality = Boolean(ctx.parameters.highQuality);
+    const simplified = simplify(fc, { tolerance, highQuality, mutate: false });
+    ctx.log(
+      `Simplified ${simplified.features.length} feature(s) (tolerance ${tolerance})`,
+    );
+    ctx.addResultLayer?.("Simplify", simplified);
+  },
+};
+
+/**
+ * Shared engine for two-layer polygon overlay operations
+ * (clip, intersection, difference). Each input feature is combined with the
+ * merged overlay geometry via the supplied Turf operation.
+ */
+function overlay(
+  ctx: ProcessingContext,
+  op: (
+    a: Feature<Polygon | MultiPolygon>,
+    b: Feature<Polygon | MultiPolygon>,
+  ) => Feature<Polygon | MultiPolygon> | null,
+  resultName: string,
+  keepProperties: boolean,
+): void {
+  const input = requireFeatures(ctx, "layer");
+  const overlayFc = requireFeatures(ctx, "overlay");
+  if (!input || !overlayFc) return;
+  const inputPolys = polygonFeatures(input);
+  const overlayGeom = mergePolygons(overlayFc);
+  if (!inputPolys.length || !overlayGeom) {
+    ctx.log("Error: both layers must contain polygon features");
+    return;
+  }
+  const results: Feature[] = [];
+  for (const feature of inputPolys) {
+    const result = op(feature, overlayGeom);
+    if (result?.geometry) {
+      result.properties = keepProperties ? (feature.properties ?? {}) : {};
+      results.push(result);
+    }
+  }
+  ctx.log(`${resultName}: produced ${results.length} feature(s)`);
+  ctx.addResultLayer?.(resultName, featureCollection(results));
+}
+
+export const clipTool: ProcessingAlgorithm = {
+  id: "clip",
+  name: "Clip",
+  description:
+    "Clip the input layer to the area covered by an overlay layer (keeps input attributes)",
+  group: "Overlay",
+  supportsSidecar: true,
+  parameters: [
+    {
+      id: "layer",
+      label: "Input layer",
+      type: "layer",
+      required: true,
+      geometryFilter: ["polygon"],
+    },
+    {
+      id: "overlay",
+      label: "Overlay (clip) layer",
+      type: "layer",
+      required: true,
+      geometryFilter: ["polygon"],
+    },
+  ],
+  run: (ctx) =>
+    overlay(
+      ctx,
+      (a, b) =>
+        intersect(featureCollection([a, b])) as Feature<
+          Polygon | MultiPolygon
+        > | null,
+      "Clip",
+      true,
+    ),
+};
+
+export const intersectionTool: ProcessingAlgorithm = {
+  id: "intersection",
+  name: "Intersection",
+  description: "Keep only the areas where both polygon layers overlap",
+  group: "Overlay",
+  supportsSidecar: true,
+  parameters: [
+    {
+      id: "layer",
+      label: "Input layer",
+      type: "layer",
+      required: true,
+      geometryFilter: ["polygon"],
+    },
+    {
+      id: "overlay",
+      label: "Overlay layer",
+      type: "layer",
+      required: true,
+      geometryFilter: ["polygon"],
+    },
+  ],
+  run: (ctx) =>
+    overlay(
+      ctx,
+      (a, b) =>
+        intersect(featureCollection([a, b])) as Feature<
+          Polygon | MultiPolygon
+        > | null,
+      "Intersection",
+      true,
+    ),
+};
+
+export const differenceTool: ProcessingAlgorithm = {
+  id: "difference",
+  name: "Difference",
+  description: "Remove the overlay layer's area from the input layer",
+  group: "Overlay",
+  supportsSidecar: true,
+  parameters: [
+    {
+      id: "layer",
+      label: "Input layer",
+      type: "layer",
+      required: true,
+      geometryFilter: ["polygon"],
+    },
+    {
+      id: "overlay",
+      label: "Overlay layer",
+      type: "layer",
+      required: true,
+      geometryFilter: ["polygon"],
+    },
+  ],
+  run: (ctx) =>
+    overlay(
+      ctx,
+      (a, b) =>
+        difference(featureCollection([a, b])) as Feature<
+          Polygon | MultiPolygon
+        > | null,
+      "Difference",
+      true,
+    ),
+};
+
+export const unionTool: ProcessingAlgorithm = {
+  id: "union",
+  name: "Union",
+  description: "Merge two polygon layers into a single combined geometry",
+  group: "Overlay",
+  supportsSidecar: true,
+  parameters: [
+    {
+      id: "layer",
+      label: "Input layer",
+      type: "layer",
+      required: true,
+      geometryFilter: ["polygon"],
+    },
+    {
+      id: "overlay",
+      label: "Overlay layer",
+      type: "layer",
+      required: true,
+      geometryFilter: ["polygon"],
+    },
+  ],
+  run: (ctx) => {
+    const input = requireFeatures(ctx, "layer");
+    const overlayFc = requireFeatures(ctx, "overlay");
+    if (!input || !overlayFc) return;
+    const a = mergePolygons(input);
+    const b = mergePolygons(overlayFc);
+    if (!a || !b) {
+      ctx.log("Error: both layers must contain polygon features");
+      return;
+    }
+    const merged = union(featureCollection([a, b]));
+    if (!merged) {
+      ctx.log("Error: unable to compute union");
+      return;
+    }
+    const result: Feature<Polygon | MultiPolygon, GeoJsonProperties> = {
+      ...merged,
+      properties: {},
+    };
+    ctx.log("Union: produced 1 feature");
+    ctx.addResultLayer?.("Union", featureCollection([result]));
+  },
+};
+
+export const VECTOR_TOOLS: ProcessingAlgorithm[] = [
+  bufferTool,
+  centroidsTool,
+  convexHullTool,
+  dissolveTool,
+  boundingBoxTool,
+  simplifyTool,
+  clipTool,
+  intersectionTool,
+  differenceTool,
+  unionTool,
+];
+
+export function getVectorTool(id: string): ProcessingAlgorithm | undefined {
+  return VECTOR_TOOLS.find((tool) => tool.id === id);
+}

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -354,16 +354,38 @@ export const intersectionTool: ProcessingAlgorithm = {
       geometryFilter: ["polygon"],
     },
   ],
-  run: (ctx) =>
-    overlay(
-      ctx,
-      (a, b) =>
-        intersect(featureCollection([a, b])) as Feature<
+  run: (ctx) => {
+    const input = requireFeatures(ctx, "layer");
+    const overlayFc = requireFeatures(ctx, "overlay");
+    if (!input || !overlayFc) return;
+    const inputPolys = polygonFeatures(input);
+    const overlayPolys = polygonFeatures(overlayFc);
+    if (!inputPolys.length || !overlayPolys.length) {
+      ctx.log("Error: both layers must contain polygon features");
+      return;
+    }
+    // Unlike Clip (which keeps only input attributes), Intersection carries
+    // merged attributes from both layers, so pair each input feature with each
+    // overlay feature rather than a dissolved overlay geometry. This mirrors
+    // the sidecar's gpd.overlay(how="intersection").
+    const results: Feature[] = [];
+    for (const a of inputPolys) {
+      for (const b of overlayPolys) {
+        const piece = intersect(featureCollection([a, b])) as Feature<
           Polygon | MultiPolygon
-        > | null,
-      "Intersection",
-      true,
-    ),
+        > | null;
+        if (piece?.geometry) {
+          piece.properties = {
+            ...(a.properties ?? {}),
+            ...(b.properties ?? {}),
+          };
+          results.push(piece);
+        }
+      }
+    }
+    ctx.log(`Intersection: produced ${results.length} feature(s)`);
+    ctx.addResultLayer?.("Intersection", featureCollection(results));
+  },
 };
 
 export const differenceTool: ProcessingAlgorithm = {


### PR DESCRIPTION
## Summary
- Add a Processing > Vector submenu and a single Vector tools dialog with 10 QGIS-inspired tools: buffer, centroids, convex hull, dissolve, bounding box, simplify, clip, intersection, difference, and union.
- Tools run client-side with Turf.js by default. An optional GeoPandas sidecar engine provides projection-aware results and degrades gracefully (the dialog falls back to the client engine when the sidecar lacks the vector extra).
- Give the previously unused `@geolibre/processing` algorithm registry a real purpose, and add a `/vector` sidecar router with a `vector` optional dependency group that is not bundled by default to keep the sidecar small.

## Test plan
- [x] `npm run build` (tsc -b + vite) passes; the Vector tools dialog is lazy-loaded into its own chunk
- [x] Frontend tests pass (`npm run test:frontend`)
- [x] Backend tests pass, including new `tests/test_vector.py` (`pytest backend/geolibre_server`)
- [x] `pre-commit run --all-files` passes
- [x] All 10 client-side tools verified end-to-end against sample GeoJSON
- [ ] Manual check in the desktop app: load a GeoJSON layer, run Buffer/Dissolve/Clip, confirm results render and the map zooms to them
- [ ] Manual check: with no sidecar running, the client engine works and the Sidecar option degrades gracefully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Processing → Vector menu and toolbar entry with geometry & overlay operations (buffer, centroids, convex hull, dissolve, bounding box, simplify, clip, intersection, difference, union).
  * Vector Tools dialog to configure/run tools on loaded layers and add results to the map; client-side Turf.js engine with optional projection-aware server sidecar.

* **Documentation**
  * README, docs, architecture, index, and roadmap updated for Vector tools and sidecar usage.

* **Tests**
  * Expanded unit tests for vector endpoints and tools.

* **Chores**
  * Added Turf client deps and optional server extras for GeoPandas/Shapely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->