### PR TITLE
feat: set initial light/dark theme via a theme query param

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Supported query parameters:
 | `panels`     | `panels=none`                                            | Hides the Layers, Style, and Attribute table panels. `hidden`, `hide`, and `off` are aliases.                               |
 | `hidePanels` | `hidePanels=true`                                        | Alternative way to hide the Layers, Style, and Attribute table panels.                                                      |
 | `maponly`    | `maponly`                                                | Hides all chrome (toolbar menu, Layers/Style/Attribute panels, and status bar), leaving only the map. The bare flag or any of `true`, `1`, `yes`, `on` enable it. |
+| `theme`      | `theme=dark`                                             | Sets the initial color theme on load, overriding the OS preference. Accepts `dark` or `light`; the in-app toggle still works afterwards. |
 
 Use compact mode for narrow embeds. This shows icon-only toolbar buttons and hides project metadata:
 

--- a/apps/geolibre-desktop/src/hooks/useThemeMode.ts
+++ b/apps/geolibre-desktop/src/hooks/useThemeMode.ts
@@ -2,9 +2,19 @@ import { useCallback, useLayoutEffect, useState } from "react";
 
 export type ThemeMode = "light" | "dark";
 
-function getInitialThemeMode(): ThemeMode {
+export function getInitialThemeMode(): ThemeMode {
   if (typeof window === "undefined") {
     return "light";
+  }
+
+  // An explicit `?theme=dark` / `?theme=light` overrides the OS preference on
+  // load (handy for embeds); the in-app toggle still works afterwards.
+  const themeParam = new URLSearchParams(window.location.search)
+    .get("theme")
+    ?.trim()
+    .toLowerCase();
+  if (themeParam === "dark" || themeParam === "light") {
+    return themeParam;
   }
 
   return window.matchMedia("(prefers-color-scheme: dark)").matches

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,6 +117,7 @@ https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geol
 | `panels` | `panels=none` | Hides the Layers, Style, and Attribute table panels. `hidden`, `hide`, and `off` are aliases. |
 | `hidePanels` | `hidePanels=true` | Alternative way to hide the Layers, Style, and Attribute table panels. |
 | `maponly` | `maponly` | Hides all chrome (toolbar menu, Layers/Style/Attribute panels, and status bar), leaving only the map. The bare flag or any of `true`, `1`, `yes`, `on` enable it. |
+| `theme` | `theme=dark` | Sets the initial color theme on load, overriding the OS preference. Accepts `dark` or `light`; the in-app toggle still works afterwards. |
 
 [Open the live demo](https://viewer.geolibre.app/){ .md-button .md-button--primary }
 [Read the architecture](architecture.md){ .md-button }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -107,6 +107,7 @@
 - [x] Component panels persisted and controls reset on new project
 - [x] Plugins can declare and handle URL query parameters
 - [x] `maponly` query parameter for chrome-free map embeds
+- [x] `theme` query parameter to set the initial light/dark theme for embeds
 - [x] Docker support for the browser app
 - [x] `VITE_DUCKDB_SPATIAL_EXTENSION_PATH` for offline spatial extension loading
 

--- a/tests/theme-mode.test.ts
+++ b/tests/theme-mode.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { getInitialThemeMode } from "../apps/geolibre-desktop/src/hooks/useThemeMode";
+
+const originalWindow = (globalThis as { window?: unknown }).window;
+
+/** Mock `window` with a search string and an OS dark-mode preference. */
+function withWindow(search: string, prefersDark: boolean): void {
+  (globalThis as { window?: unknown }).window = {
+    location: { search },
+    matchMedia: (query: string) => ({
+      matches: query.includes("dark") ? prefersDark : false,
+    }),
+  };
+}
+
+afterEach(() => {
+  if (originalWindow === undefined) {
+    delete (globalThis as { window?: unknown }).window;
+  } else {
+    (globalThis as { window?: unknown }).window = originalWindow;
+  }
+});
+
+describe("getInitialThemeMode", () => {
+  it("falls back to the OS preference without a theme param", () => {
+    withWindow("", true);
+    assert.equal(getInitialThemeMode(), "dark");
+    withWindow("", false);
+    assert.equal(getInitialThemeMode(), "light");
+  });
+
+  it("honors ?theme=dark and ?theme=light over the OS preference", () => {
+    withWindow("?theme=dark", false);
+    assert.equal(getInitialThemeMode(), "dark");
+    withWindow("?theme=light", true);
+    assert.equal(getInitialThemeMode(), "light");
+  });
+
+  it("is case-insensitive and tolerates surrounding whitespace", () => {
+    withWindow("?theme=DARK", false);
+    assert.equal(getInitialThemeMode(), "dark");
+    withWindow("?theme=%20Light%20", true);
+    assert.equal(getInitialThemeMode(), "light");
+  });
+
+  it("ignores an unrecognized theme value and uses the OS preference", () => {
+    withWindow("?theme=neon", true);
+    assert.equal(getInitialThemeMode(), "dark");
+    withWindow("?theme=neon", false);
+    assert.equal(getInitialThemeMode(), "light");
+  });
+
+  it("returns light when window is undefined (SSR)", () => {
+    delete (globalThis as { window?: unknown }).window;
+    assert.equal(getInitialThemeMode(), "light");
+  });
+});

--- a/tests/theme-mode.test.ts
+++ b/tests/theme-mode.test.ts
@@ -44,10 +44,15 @@ describe("getInitialThemeMode", () => {
     assert.equal(getInitialThemeMode(), "light");
   });
 
-  it("ignores an unrecognized theme value and uses the OS preference", () => {
+  it("ignores an unrecognized or empty theme value and uses the OS preference", () => {
     withWindow("?theme=neon", true);
     assert.equal(getInitialThemeMode(), "dark");
     withWindow("?theme=neon", false);
+    assert.equal(getInitialThemeMode(), "light");
+    // A bare `?theme=` yields "" and should also fall back to the OS preference.
+    withWindow("?theme=", true);
+    assert.equal(getInitialThemeMode(), "dark");
+    withWindow("?theme=", false);
     assert.equal(getInitialThemeMode(), "light");
   });
 


### PR DESCRIPTION
## Summary
- Read a `theme` query parameter (`?theme=dark` / `?theme=light`) on load to set the initial color theme, overriding the OS `prefers-color-scheme` preference. The in-app toggle still works afterwards.
- Parsing is case-insensitive, trims whitespace, and ignores unrecognized values (falls back to the OS preference).
- Documented in the embed query-parameter tables (README and docs/index.md) and the roadmap.

## Test plan
- [x] `npm run test:frontend` (173 pass, includes 5 new getInitialThemeMode tests: param override, OS fallback, case-insensitivity, unknown value, SSR)
- [x] `npm run build` succeeds
- [x] pre-commit clean
- [ ] Manual: load `?theme=dark` and `?theme=light` and confirm the initial theme and that the toolbar toggle still flips it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `theme` query parameter for embeds to set the initial light/dark theme on load (accepts `dark` or `light`); it overrides OS preference on first load while the in-app theme toggle still works.

* **Documentation**
  * Updated docs and roadmap to describe the new `theme` parameter and its behavior.

* **Tests**
  * Added tests covering initial theme selection, SSR default, OS-prefallback, query-override precedence, and robust parsing of the `theme` value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->