### PR TITLE
feat: let external plugins resolve their own bundled asset URLs

### DIFF
--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -36,6 +36,7 @@ import { bundledPluginManifestPaths } from "virtual:bundled-plugins";
 import {
   loadExternalPlugins,
   reloadExternalUrlPlugin,
+  resolvePluginAssetUrlForLoadedPlugin,
   unloadRemovedUrlPlugins,
 } from "../lib/external-plugins";
 import { mergeStringLists } from "../lib/string-lists";
@@ -317,6 +318,8 @@ export function createAppAPI(
         }
       }),
     fetchArrayBuffer: fetchRemoteArrayBuffer,
+    resolvePluginAssetUrl: (pluginId: string, relativePath: string) =>
+      resolvePluginAssetUrlForLoadedPlugin(pluginId, relativePath),
     fitBounds: (bounds: [number, number, number, number]) =>
       mapControllerRef?.current?.fitBounds(bounds),
     getMap: () => mapControllerRef?.current?.getMap() ?? null,

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -318,8 +318,7 @@ export function createAppAPI(
         }
       }),
     fetchArrayBuffer: fetchRemoteArrayBuffer,
-    resolvePluginAssetUrl: (pluginId: string, relativePath: string) =>
-      resolvePluginAssetUrlForLoadedPlugin(pluginId, relativePath),
+    resolvePluginAssetUrl: resolvePluginAssetUrlForLoadedPlugin,
     fitBounds: (bounds: [number, number, number, number]) =>
       mapControllerRef?.current?.fitBounds(bounds),
     getMap: () => mapControllerRef?.current?.getMap() ?? null,

--- a/apps/geolibre-desktop/src/lib/external-plugins.ts
+++ b/apps/geolibre-desktop/src/lib/external-plugins.ts
@@ -5,6 +5,11 @@ import type {
   PluginManager,
 } from "@geolibre/plugins";
 import { invoke } from "@tauri-apps/api/core";
+import {
+  isManagedUrlSource,
+  pluginAssetUrlFromSource,
+  resolvePluginAssetUrl,
+} from "./plugin-asset-url";
 import { isTauri } from "./tauri-io";
 
 interface ExternalPluginBundle {
@@ -263,26 +268,6 @@ async function fetchPluginText(
   return new TextDecoder().decode(merged);
 }
 
-function resolvePluginAssetUrl(manifestUrl: string, path: string): string {
-  if (
-    path.startsWith("/") ||
-    path.includes("\\") ||
-    /^[a-z][a-z\d+.-]*:/i.test(path) ||
-    path.split("/").some((part) => !part || part === "." || part === "..")
-  ) {
-    throw new Error("Plugin manifest paths must be relative safe paths.");
-  }
-  // Percent-encoded dot segments ("%2e%2e") pass the textual check above but
-  // the URL parser still normalizes them, so confirm the resolved URL stays
-  // under the manifest directory.
-  const resolved = new URL(path, manifestUrl);
-  const manifestDirectory = new URL(".", manifestUrl);
-  if (!resolved.href.startsWith(manifestDirectory.href)) {
-    throw new Error("Plugin manifest paths must be relative safe paths.");
-  }
-  return resolved.toString();
-}
-
 // Matches the Rust validate_required_manifest_string: non-empty with no
 // leading or trailing whitespace.
 function isRequiredManifestString(value: unknown): value is string {
@@ -384,10 +369,24 @@ function removeExternalPluginStyle(pluginId: string): void {
     ?.remove();
 }
 
-// A loaded plugin came from a manifest URL (web/desktop) rather than the
-// desktop filesystem scan, whose source is an absolute path with no scheme.
-function isManagedUrlSource(source: string): boolean {
-  return /^(https?|tauri):\/\//.test(source);
+/**
+ * Resolve a fetchable URL for an asset shipped alongside a loaded plugin's
+ * manifest (e.g. sample data bundled in the plugin folder). The plugin's
+ * recorded source is its manifest URL, so `relativePath` resolves against the
+ * plugin's own directory. Returns null when the plugin is unknown, was loaded
+ * from the desktop filesystem (no URL base), or when `relativePath` would
+ * escape the plugin directory. This is exposed to plugins via the app API so a
+ * plugin can locate its own bundled assets without GeoLibre knowing anything
+ * about that specific plugin.
+ */
+export function resolvePluginAssetUrlForLoadedPlugin(
+  pluginId: string,
+  relativePath: string,
+): string | null {
+  return pluginAssetUrlFromSource(
+    externallyLoadedPluginSources.get(pluginId),
+    relativePath,
+  );
 }
 
 /**

--- a/apps/geolibre-desktop/src/lib/plugin-asset-url.ts
+++ b/apps/geolibre-desktop/src/lib/plugin-asset-url.ts
@@ -1,0 +1,52 @@
+// Pure helpers for resolving plugin asset URLs. Kept free of Tauri and
+// browser imports so they stay unit-testable in Node and reusable by both the
+// external-plugin loader and the app API exposed to plugins.
+
+// A loaded plugin's source is a URL (a web/desktop bundled plugin or a
+// manifest-URL install) rather than a desktop filesystem path (an absolute
+// path with no scheme). Only URL sources have a fetchable asset base.
+export function isManagedUrlSource(source: string): boolean {
+  return /^(https?|tauri):\/\//.test(source);
+}
+
+// Resolve `path` against a plugin manifest URL, rejecting anything absolute,
+// scheme-qualified, or that escapes the manifest's own directory. Mirrors the
+// safety checks GeoLibre applies to a manifest's `entry`/`style` paths so a
+// plugin can only reach assets shipped inside its own folder.
+export function resolvePluginAssetUrl(
+  manifestUrl: string,
+  path: string,
+): string {
+  if (
+    path.startsWith("/") ||
+    path.includes("\\") ||
+    /^[a-z][a-z\d+.-]*:/i.test(path) ||
+    path.split("/").some((part) => !part || part === "." || part === "..")
+  ) {
+    throw new Error("Plugin manifest paths must be relative safe paths.");
+  }
+  // Percent-encoded dot segments ("%2e%2e") pass the textual check above but
+  // the URL parser still normalizes them, so confirm the resolved URL stays
+  // under the manifest directory.
+  const resolved = new URL(path, manifestUrl);
+  const manifestDirectory = new URL(".", manifestUrl);
+  if (!resolved.href.startsWith(manifestDirectory.href)) {
+    throw new Error("Plugin manifest paths must be relative safe paths.");
+  }
+  return resolved.toString();
+}
+
+// Resolve a plugin asset URL from the plugin's loaded source. Returns null for
+// a missing source, a desktop filesystem source (no URL base), or an unsafe
+// relative path, so callers can treat null as "no bundled asset URL".
+export function pluginAssetUrlFromSource(
+  source: string | undefined,
+  relativePath: string,
+): string | null {
+  if (!source || !isManagedUrlSource(source)) return null;
+  try {
+    return resolvePluginAssetUrl(source, relativePath);
+  } catch {
+    return null;
+  }
+}

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -327,8 +327,9 @@ export function projectFromStore(state: {
 // An external native layer can drop its persisted `geojson` only if its
 // features can be reconstructed on reopen, i.e. it has a fetchable source URL
 // (the Add Vector Layer / WFS / geojson-url cases). Layers loaded from local
-// files or built in-memory (e.g. the Annotate Geocodes control) have no such
-// URL, so the persisted `geojson` is their ONLY copy and must be kept.
+// files or built in-memory (e.g. by a plugin's drawing/annotation control)
+// have no such URL, so the persisted `geojson` is their ONLY copy and must be
+// kept.
 function hasRestorableSourceUrl(layer: GeoLibreLayer): boolean {
   const sourceUrl = layer.source.url;
   const originalUrl = layer.metadata.originalUrl;

--- a/packages/plugins/src/plugin-manager.ts
+++ b/packages/plugins/src/plugin-manager.ts
@@ -213,8 +213,9 @@ export class PluginManager {
 
         // A deep link to a parameter a plugin owns implies the user wants that
         // plugin: activate it if it is installed (registered) but inactive, so
-        // e.g. ?annotate-data=... brings up its plugin. Only already-registered
-        // (trusted) plugins are activated here; nothing is loaded from the URL.
+        // a parameter a plugin declares brings up that plugin. Only
+        // already-registered (trusted) plugins are activated here; nothing is
+        // loaded from the URL.
         // If activation is refused or throws, skip dispatch and isolate the
         // failure to this plugin instead of aborting the whole loop.
         if (!this.active.has(id)) {

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -59,6 +59,18 @@ export interface GeoLibreAppAPI {
   getActiveBasemap: () => string;
   onBasemapChange: (callback: (styleUrl: string) => void) => () => void;
   fetchArrayBuffer?: (url: string) => Promise<ArrayBuffer>;
+  /**
+   * Resolve a fetchable URL for an asset shipped alongside an external
+   * plugin's manifest (e.g. sample data bundled in the plugin folder). The
+   * host resolves `relativePath` against the plugin's own directory. Returns
+   * null for built-in plugins, for plugins installed from the desktop
+   * filesystem (which have no URL base), or when `relativePath` escapes the
+   * plugin directory. `pluginId` must be the calling plugin's own id.
+   */
+  resolvePluginAssetUrl?: (
+    pluginId: string,
+    relativePath: string,
+  ) => string | null;
   fitBounds?: (bounds: [number, number, number, number]) => void;
   getMap?: () => MapLibreMap | null;
   pickLocalDirectoryFiles?: () => Promise<File[] | null>;

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -65,7 +65,11 @@ export interface GeoLibreAppAPI {
    * host resolves `relativePath` against the plugin's own directory. Returns
    * null for built-in plugins, for plugins installed from the desktop
    * filesystem (which have no URL base), or when `relativePath` escapes the
-   * plugin directory. `pluginId` must be the calling plugin's own id.
+   * plugin directory. `pluginId` should be the calling plugin's own id; since
+   * all plugins share one JS context the host cannot verify the caller, so this
+   * is a convention rather than an enforced boundary. It is not a privilege
+   * boundary: the resolved URL grants no access a plugin does not already have,
+   * since any plugin can fetch any same-origin URL directly.
    */
   resolvePluginAssetUrl?: (
     pluginId: string,

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -174,7 +174,7 @@ describe("project parsing", () => {
           source: { type: "geojson" },
           metadata: {
             externalNativeLayer: true,
-            sourceKind: "annotate-geocodes",
+            sourceKind: "plugin-control",
           },
           geojson: {
             type: "FeatureCollection",

--- a/tests/external-plugin-assets.test.ts
+++ b/tests/external-plugin-assets.test.ts
@@ -66,4 +66,17 @@ describe("pluginAssetUrlFromSource", () => {
       null,
     );
   });
+
+  it("rejects percent-encoded path traversal (%2e%2e)", () => {
+    // The literal-segment checks pass "%2e%2e", but URL normalization decodes
+    // it to ".." and the resolved URL lands outside the plugin directory, so
+    // the directory-containment guard still rejects it.
+    assert.equal(
+      pluginAssetUrlFromSource(
+        "https://geolibre.app/plugins/x/plugin.json",
+        "%2e%2e/secrets",
+      ),
+      null,
+    );
+  });
 });

--- a/tests/external-plugin-assets.test.ts
+++ b/tests/external-plugin-assets.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { pluginAssetUrlFromSource } from "../apps/geolibre-desktop/src/lib/plugin-asset-url";
+
+describe("pluginAssetUrlFromSource", () => {
+  it("resolves an asset against a bundled plugin's manifest URL", () => {
+    assert.equal(
+      pluginAssetUrlFromSource(
+        "https://geolibre.app/plugins/demo-plugin/plugin.json",
+        "dist/sample-data",
+      ),
+      "https://geolibre.app/plugins/demo-plugin/dist/sample-data",
+    );
+  });
+
+  it("respects a non-root app base in the manifest URL", () => {
+    assert.equal(
+      pluginAssetUrlFromSource(
+        "https://example.com/geolibre/plugins/x/plugin.json",
+        "dist/sample-data",
+      ),
+      "https://example.com/geolibre/plugins/x/dist/sample-data",
+    );
+  });
+
+  it("resolves against a tauri:// manifest URL (desktop bundled build)", () => {
+    assert.equal(
+      pluginAssetUrlFromSource(
+        "tauri://localhost/plugins/x/plugin.json",
+        "dist/sample-data",
+      ),
+      "tauri://localhost/plugins/x/dist/sample-data",
+    );
+  });
+
+  it("returns null for a desktop filesystem source (no URL base)", () => {
+    assert.equal(
+      pluginAssetUrlFromSource(
+        "/home/user/.local/share/org.geolibre.desktop/plugins/x",
+        "dist/sample-data",
+      ),
+      null,
+    );
+  });
+
+  it("returns null when the source is missing", () => {
+    assert.equal(pluginAssetUrlFromSource(undefined, "dist/sample-data"), null);
+  });
+
+  it("rejects paths that escape the plugin directory", () => {
+    assert.equal(
+      pluginAssetUrlFromSource(
+        "https://geolibre.app/plugins/x/plugin.json",
+        "../secrets",
+      ),
+      null,
+    );
+  });
+
+  it("rejects absolute paths", () => {
+    assert.equal(
+      pluginAssetUrlFromSource(
+        "https://geolibre.app/plugins/x/plugin.json",
+        "/etc/passwd",
+      ),
+      null,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds an optional `resolvePluginAssetUrl(pluginId, relativePath)` method to the GeoLibre app API so a bundled or URL-installed external plugin can locate assets shipped inside its own folder (for example, sample data) without GeoLibre needing any knowledge of that specific plugin.

External plugins are loaded from a Blob URL, so `import.meta.url` cannot reveal where the plugin is served from. GeoLibre already records each plugin's source (its manifest URL), so the host resolves a relative asset path against that and returns a fetchable URL, or `null` for built-in plugins, desktop filesystem installs (no URL base), or unsafe paths that would escape the plugin directory.

## Changes

- New `apps/geolibre-desktop/src/lib/plugin-asset-url.ts`: dependency-free URL helpers (`isManagedUrlSource`, `resolvePluginAssetUrl`, `pluginAssetUrlFromSource`), now shared by the external-plugin loader instead of being duplicated inside it.
- `external-plugins.ts`: reuses those helpers and adds `resolvePluginAssetUrlForLoadedPlugin`, keyed off the recorded plugin source.
- `usePlugins.ts`: exposes `resolvePluginAssetUrl` on the app API returned by `createAppAPI`.
- `packages/plugins/src/types.ts`: documents the new optional method on `GeoLibreAppAPI`.
- New `tests/external-plugin-assets.test.ts`: unit tests for the resolver (bundled URL, non-root base, `tauri://`, filesystem source, missing source, path-escape, absolute path).
- Minor: removed a few incidental plugin-specific examples from comments/tests in favor of generic wording.

## Testing

- `npm run test:frontend` — 180 pass
- `tsc -b apps/geolibre-desktop` — clean
- Verified live in the browser with a bundled plugin: the plugin resolved its own `dist/sample-data`, loaded a dataset, and rendered its layers with no console errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hosts now expose an optional API to resolve URLs for assets bundled with external plugins, with safety checks to prevent directory traversal and unsafe paths.

* **Tests**
  * Added comprehensive tests covering asset URL resolution for various manifest sources, managed schemes, and unsafe-path rejection.

* **Chores**
  * Minor comment and documentation clarifications in core and plugin modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->