### PR TITLE
feat: add geolibre Python package for Jupyter notebooks

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -24,6 +24,11 @@ jobs:
   test:
     name: Test Python package
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        # Cover the declared minimum (requires-python >= 3.10) and a current
+        # release so 3.11/3.12-only syntax can't slip in unnoticed.
+        python-version: ["3.10", "3.12"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -33,7 +38,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       # Tests cover the pure-Python builders and do not need the bundled web
       # app, so install only the runtime/test deps and run against the sources.

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -89,6 +89,6 @@ jobs:
           VITE_GEE_OAUTH_CLIENT_ID: ${{ secrets.VITE_GEE_OAUTH_CLIENT_ID }}
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: python/dist

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -1,0 +1,94 @@
+name: Publish Python package
+
+on:
+  release:
+    types: [published]
+  pull_request:
+    branches: [main]
+    paths:
+      - "python/**"
+      - "apps/geolibre-desktop/src/**"
+      - "packages/**"
+      - "scripts/build-embed.mjs"
+      - ".github/workflows/publish-python.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-python-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test Python package
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      # Tests cover the pure-Python builders and do not need the bundled web
+      # app, so install only the runtime/test deps and run against the sources.
+      - name: Install test dependencies
+        run: python -m pip install anywidget traitlets pytest
+
+      - name: Run tests
+        run: python -m pytest python/tests
+        env:
+          PYTHONPATH: python/src
+
+  publish:
+    name: Build wheel and publish
+    runs-on: ubuntu-22.04
+    needs: test
+    if: github.event_name == 'release'
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write # PyPI Trusted Publishing (OIDC)
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Install build backend
+        run: python -m pip install build
+
+      - name: Build wheel and sdist
+        working-directory: python
+        run: python -m build
+        env:
+          # Force a fresh embed build so the published wheel always carries the
+          # current app bundle.
+          GEOLIBRE_FORCE_JS_BUILD: "1"
+          NODE_OPTIONS: --max-old-space-size=4096
+          VITE_GEE_OAUTH_CLIENT_ID: ${{ secrets.VITE_GEE_OAUTH_CLIENT_ID }}
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: python/dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+dist-embed/
 site/
 target/
 .tauri/
@@ -23,3 +24,4 @@ uv.lock
 # Documentation screenshots are hosted on Cloudflare R2 (data.geolibre.app/images),
 # not committed to the repo, to save space.
 docs/assets/screenshots/
+python/examples/my-map.geolibre.json

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS
 - External plugin zip loading from the app data plugins directory and local development plugin directories
 - Bundled drop-in plugins under `public/plugins/<id>/` that bake into both the web and desktop builds and load automatically with no manifest URL
 - Browser deployment with Docker, embed-friendly URL parameters, and a `maponly` chrome-free mode
+- Python package (`geolibre`) that embeds the full app in Jupyter notebooks as an [anywidget](https://anywidget.dev), with a leafmap-style API and two-way project sync
 - Optional Python FastAPI sidecar for heavier processing workflows
 
 ## Prerequisites
@@ -213,6 +214,42 @@ For a fully chrome-free, map-only embed, use `maponly`. It hides the toolbar men
 https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json&maponly
 ```
 
+## Python package (Jupyter)
+
+GeoLibre ships a Python package that embeds the **full** GeoLibre app (menus,
+panels, processing tools) in a Jupyter notebook cell as an
+[anywidget](https://anywidget.dev), with a leafmap-style API. State syncs both
+ways through a single `.geolibre.json` project, so data you add from Python
+appears in the UI, and edits you make in the UI are readable back from Python.
+
+```bash
+pip install geolibre
+```
+
+```python
+from geolibre import Map
+
+m = Map(center=(-100, 40), zoom=4)
+m.add_geojson("https://example.com/data.geojson", name="Data")
+m.add_tile_layer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", name="OpenStreetMap")
+m.add_cog("https://example.com/dem.tif", name="DEM")
+m  # the full GeoLibre UI renders in the cell
+```
+
+Read state edited in the UI, and round-trip projects:
+
+```python
+m.to_project()["mapView"]["center"]   # reflects the live UI view after panning
+m.save_project("my-map.geolibre.json")
+Map().load_project("my-map.geolibre.json")
+```
+
+The package source lives in [`python/`](python/), and the bundled web app is
+built into the wheel by `npm run build:embed`. The interactive widget works in
+local Jupyter and VS Code; remote setups (JupyterHub, Colab) where the browser
+cannot reach the kernel's `localhost` are not yet supported. See the
+[Python package guide](docs/python.md) for the full API.
+
 ## Environment variables
 
 The Street View plugin can use Google Street View and Mapillary imagery. Create `apps/geolibre-desktop/.env.local` and set one or both provider credentials:
@@ -295,6 +332,7 @@ packages/ui             # Tailwind + shadcn/ui
 packages/plugins        # Plugin API
 packages/processing     # Algorithm registry
 backend/geolibre_server # FastAPI sidecar
+python/                 # geolibre Python package (Jupyter anywidget)
 sample-data/            # Sample GeoJSON & project
 docs/                   # Architecture & API docs
 ```
@@ -384,6 +422,7 @@ Full documentation, including the User Guide and Tutorials, is published at
   - [Architecture](docs/architecture.md)
   - [Project format](docs/project-format.md)
   - [Plugin API](docs/plugin-api.md)
+  - [Python package (Jupyter)](docs/python.md)
   - [Roadmap](docs/roadmap.md)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -246,10 +246,10 @@ Map().load_project("my-map.geolibre.json")
 
 The package source lives in [`python/`](python/), and the bundled web app is
 built into the wheel by `npm run build:embed`. The interactive widget works in
-local Jupyter, VS Code, and Google Colab (which routes through its built-in port
-proxy automatically); other remote setups such as JupyterHub or Binder, where
-the browser cannot reach the kernel's `localhost` and no port proxy is wired up,
-are not yet supported. See the [Python package guide](docs/python.md) for the
+local Jupyter, VS Code, Google Colab (its built-in port proxy is used
+automatically), and JupyterHub / remote servers (through `jupyter-server-proxy`;
+install with `pip install "geolibre[hub]"`, and pass `Map(server_proxy=True)` on
+non-Hub remote setups). See the [Python package guide](docs/python.md) for the
 full API.
 
 ## Environment variables

--- a/README.md
+++ b/README.md
@@ -246,9 +246,11 @@ Map().load_project("my-map.geolibre.json")
 
 The package source lives in [`python/`](python/), and the bundled web app is
 built into the wheel by `npm run build:embed`. The interactive widget works in
-local Jupyter and VS Code; remote setups (JupyterHub, Colab) where the browser
-cannot reach the kernel's `localhost` are not yet supported. See the
-[Python package guide](docs/python.md) for the full API.
+local Jupyter, VS Code, and Google Colab (which routes through its built-in port
+proxy automatically); other remote setups such as JupyterHub or Binder, where
+the browser cannot reach the kernel's `localhost` and no port proxy is wired up,
+are not yet supported. See the [Python package guide](docs/python.md) for the
+full API.
 
 ## Environment variables
 

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -40,6 +40,7 @@ import {
 } from "../../hooks/usePlugins";
 import { registerMbtilesProtocol } from "../../lib/mbtiles";
 import { registerXyzTileProtocol } from "../../lib/xyz-url";
+import { useEmbedBridge } from "../../hooks/useEmbedBridge";
 import {
   appendDiagnostic,
   useDiagnosticsSnapshot,
@@ -188,6 +189,9 @@ export function DesktopShell({
   const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
   const diagnostics = useDiagnosticsSnapshot();
   const externalPluginsReady = useExternalPluginsReady(mapControllerRef);
+  // Sync the project with an embedding host (the GeoLibre Jupyter widget) over
+  // postMessage. Inert when the app is not embedded.
+  useEmbedBridge(mapControllerRef);
   const [layerPanelWidth, setLayerPanelWidth] = useState(
     DEFAULT_SIDE_PANEL_WIDTH,
   );

--- a/apps/geolibre-desktop/src/hooks/useEmbedBridge.ts
+++ b/apps/geolibre-desktop/src/hooks/useEmbedBridge.ts
@@ -144,7 +144,9 @@ export function useEmbedBridge(
           typeof message.project === "string"
             ? parseProject(message.project)
             : parseProject(JSON.stringify(message.project));
-        if (typeof message.seq === "number") lastLoadedSeq = message.seq;
+        // Reset (not retain) when a load omits seq, so a later snapshot never
+        // echoes a stale, unrelated sequence number.
+        lastLoadedSeq = typeof message.seq === "number" ? message.seq : 0;
         // Suppress the snapshot this load would otherwise echo: the host
         // already has this project, and re-posting it is wasted traffic.
         lastPostedContent = serializeProject(project);

--- a/apps/geolibre-desktop/src/hooks/useEmbedBridge.ts
+++ b/apps/geolibre-desktop/src/hooks/useEmbedBridge.ts
@@ -71,9 +71,11 @@ export function useEmbedBridge(
 ): void {
   useEffect(() => {
     if (!isEmbedded()) return;
-    // `window.parent` is the host even when the app is the top-level document
-    // (the `?embed=1` self-test case falls back to posting to itself).
-    const host = window.parent ?? window;
+    // The host is the embedding parent (the Jupyter/embed widget). In a browser
+    // `window.parent` is always defined; when the app is the top-level document
+    // (the `?embed=1` self-test) it is `window` itself, so the bridge naturally
+    // posts to and receives from itself.
+    const host = window.parent;
 
     let disposed = false;
     let debounceTimer: number | null = null;
@@ -105,17 +107,21 @@ export function useEmbedBridge(
 
     const postState = () => {
       if (disposed) return;
-      const content = serializeProject(buildProject());
+      const project = buildProject();
+      const content = serializeProject(project);
       // Many store writes (selection, hover) do not change the serialized
       // project; skip posting an identical snapshot to keep the host quiet.
       if (content === lastPostedContent) return;
       lastPostedContent = content;
       try {
+        // Posted to the parent window object directly. "*" is used as the target
+        // origin because the framed app does not know the embedding host's
+        // origin; the message still only reaches that one parent window.
         host.postMessage(
           {
             type: "geolibre:state",
             seq: lastLoadedSeq,
-            project: JSON.parse(content) as GeoLibreProject,
+            project,
           },
           "*",
         );
@@ -157,6 +163,11 @@ export function useEmbedBridge(
     };
 
     const handleMessage = (event: MessageEvent) => {
+      // Only accept messages from the embedding host (the parent window), so an
+      // arbitrary same-page script cannot inject a project. This matters most
+      // for the standalone `?embed=1` (`to_html()`) export, where the app may be
+      // framed by a third-party page.
+      if (event.source !== host) return;
       const data = event.data as Partial<InboundMessage> | null;
       if (!data || typeof data !== "object") return;
       if (data.type === "geolibre:load-project") {

--- a/apps/geolibre-desktop/src/hooks/useEmbedBridge.ts
+++ b/apps/geolibre-desktop/src/hooks/useEmbedBridge.ts
@@ -1,0 +1,186 @@
+import {
+  parseProject,
+  projectFromStore,
+  serializeProject,
+  useAppStore,
+  type GeoLibreProject,
+} from "@geolibre/core";
+import { type RefObject, useEffect } from "react";
+import type { MapController } from "@geolibre/map";
+import { getPluginManager } from "./usePlugins";
+
+// How long to wait after the last store change before posting a fresh project
+// snapshot to the host. Coalesces the burst of store writes a single user
+// action (adding a layer, panning) produces into one message.
+const STATE_DEBOUNCE_MS = 250;
+
+interface LoadProjectMessage {
+  type: "geolibre:load-project";
+  project: GeoLibreProject | string;
+  seq?: number;
+}
+
+interface RequestStateMessage {
+  type: "geolibre:request-state";
+}
+
+type InboundMessage = LoadProjectMessage | RequestStateMessage;
+
+/**
+ * Detects whether the app is running inside the GeoLibre Jupyter/embed host.
+ *
+ * The app is considered embedded when it is framed (a different `window.parent`)
+ * or when it is opened with an explicit `?embed=1` query parameter, which lets
+ * the host force the bridge on for a standalone `to_html()` export.
+ *
+ * @returns True when the postMessage bridge should be active.
+ */
+function isEmbedded(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    if (window.parent && window.parent !== window) return true;
+  } catch {
+    // A cross-origin parent throws on access; being unable to read it at all
+    // still means we are framed.
+    return true;
+  }
+  const embed = new URLSearchParams(window.location.search).get("embed");
+  return embed === "1" || embed === "true";
+}
+
+/**
+ * Bridges the running app with an embedding host (the GeoLibre Python widget)
+ * over `window.postMessage`.
+ *
+ * When embedded, the hook:
+ * - applies a `geolibre:load-project` message by replacing the current project,
+ * - posts a debounced `geolibre:state` snapshot whenever the store changes, so
+ *   the host (and Python) sees map view, layer, and basemap edits,
+ * - answers a `geolibre:request-state` with an immediate snapshot, and
+ * - announces `geolibre:ready` on mount so the host can flush queued messages.
+ *
+ * Loop prevention lives on the host side: the host does not echo a project it
+ * received from the app back into the iframe. Outside an embedding host the
+ * hook is an inert no-op.
+ *
+ * @param mapControllerRef - Ref to the live map controller, read so the emitted
+ *   snapshot captures the current camera (pan/zoom) rather than only the store.
+ */
+export function useEmbedBridge(
+  mapControllerRef: RefObject<MapController | null>,
+): void {
+  useEffect(() => {
+    if (!isEmbedded()) return;
+    // `window.parent` is the host even when the app is the top-level document
+    // (the `?embed=1` self-test case falls back to posting to itself).
+    const host = window.parent ?? window;
+
+    let disposed = false;
+    let debounceTimer: number | null = null;
+    // The seq of the most recent host->app load, echoed back so the host can
+    // correlate a snapshot with the load that triggered it.
+    let lastLoadedSeq = 0;
+    let lastPostedContent: string | null = null;
+
+    const buildProject = (): GeoLibreProject => {
+      const state = useAppStore.getState();
+      return projectFromStore({
+        projectName: state.projectName,
+        // Mirror the Save/Share path: read the live camera from the controller
+        // so pan/zoom round-trips, falling back to the store before the map is
+        // ready.
+        mapView: mapControllerRef.current?.readView() ?? state.mapView,
+        basemapStyleUrl: state.basemapStyleUrl,
+        basemapVisible: state.basemapVisible,
+        basemapOpacity: state.basemapOpacity,
+        layers: state.layers,
+        preferences: state.preferences,
+        plugins: {
+          ...getPluginManager().getProjectState(),
+          manifestUrls: state.projectPlugins?.manifestUrls ?? [],
+        },
+        metadata: state.metadata,
+      });
+    };
+
+    const postState = () => {
+      if (disposed) return;
+      const content = serializeProject(buildProject());
+      // Many store writes (selection, hover) do not change the serialized
+      // project; skip posting an identical snapshot to keep the host quiet.
+      if (content === lastPostedContent) return;
+      lastPostedContent = content;
+      try {
+        host.postMessage(
+          {
+            type: "geolibre:state",
+            seq: lastLoadedSeq,
+            project: JSON.parse(content) as GeoLibreProject,
+          },
+          "*",
+        );
+      } catch (error) {
+        console.error("[GeoLibre] Failed to post embed state", error);
+      }
+    };
+
+    const scheduleState = () => {
+      if (debounceTimer !== null) window.clearTimeout(debounceTimer);
+      debounceTimer = window.setTimeout(() => {
+        debounceTimer = null;
+        postState();
+      }, STATE_DEBOUNCE_MS);
+    };
+
+    const applyLoad = (message: LoadProjectMessage) => {
+      try {
+        const project =
+          typeof message.project === "string"
+            ? parseProject(message.project)
+            : parseProject(JSON.stringify(message.project));
+        if (typeof message.seq === "number") lastLoadedSeq = message.seq;
+        // Suppress the snapshot this load would otherwise echo: the host
+        // already has this project, and re-posting it is wasted traffic.
+        lastPostedContent = serializeProject(project);
+        useAppStore
+          .getState()
+          .loadProject(project, null, { rememberRecent: false });
+      } catch (error) {
+        host.postMessage(
+          {
+            type: "geolibre:error",
+            message: error instanceof Error ? error.message : String(error),
+          },
+          "*",
+        );
+      }
+    };
+
+    const handleMessage = (event: MessageEvent) => {
+      const data = event.data as Partial<InboundMessage> | null;
+      if (!data || typeof data !== "object") return;
+      if (data.type === "geolibre:load-project") {
+        applyLoad(data as LoadProjectMessage);
+      } else if (data.type === "geolibre:request-state") {
+        // Force a snapshot regardless of the dedupe cache.
+        lastPostedContent = null;
+        postState();
+      }
+    };
+
+    window.addEventListener("message", handleMessage);
+    const unsubscribe = useAppStore.subscribe(scheduleState);
+
+    host.postMessage(
+      { type: "geolibre:ready", version: __GEOLIBRE_VERSION__ },
+      "*",
+    );
+
+    return () => {
+      disposed = true;
+      window.removeEventListener("message", handleMessage);
+      unsubscribe();
+      if (debounceTimer !== null) window.clearTimeout(debounceTimer);
+    };
+  }, [mapControllerRef]);
+}

--- a/apps/geolibre-desktop/src/hooks/useEmbedBridge.ts
+++ b/apps/geolibre-desktop/src/hooks/useEmbedBridge.ts
@@ -89,6 +89,12 @@ export function useEmbedBridge(
     // (only the version-only `ready` ping precedes any inbound message) we fall
     // back to "*".
     let hostOrigin: string | null = null;
+    // Whether the host has sent at least one message. Until it has, the bridge
+    // must not proactively broadcast project state: a third-party page that
+    // frames a `?embed=1` export but never speaks would otherwise receive every
+    // snapshot through the "*" fallback below. The version-only `ready` ping is
+    // the sole message sent before the handshake completes.
+    let hostHandshakeComplete = false;
     const targetOrigin = () => hostOrigin ?? "*";
 
     const buildProject = (): GeoLibreProject => {
@@ -114,6 +120,10 @@ export function useEmbedBridge(
 
     const postState = () => {
       if (disposed) return;
+      // Don't broadcast state before the host has identified itself (see
+      // hostHandshakeComplete); otherwise an uncooperative third-party frame
+      // that never speaks would keep receiving snapshots via the "*" fallback.
+      if (!hostHandshakeComplete) return;
       const content = serializeProject(buildProject());
       // Many store writes (selection, hover) do not change the serialized
       // project; skip posting an identical snapshot to keep the host quiet.
@@ -182,6 +192,8 @@ export function useEmbedBridge(
       // for the standalone `?embed=1` (`to_html()`) export, where the app may be
       // framed by a third-party page.
       if (event.source !== host) return;
+      // The host has spoken: proactive state pushes are safe from here on.
+      hostHandshakeComplete = true;
       // Learn the host's origin from its first message and scope outbound
       // messages to it from then on. "null" (opaque/file origins) stays "*".
       if (event.origin && event.origin !== "null") hostOrigin = event.origin;
@@ -210,5 +222,7 @@ export function useEmbedBridge(
       unsubscribe();
       if (debounceTimer !== null) window.clearTimeout(debounceTimer);
     };
-  }, [mapControllerRef]);
+    // Mount-only: mapControllerRef is a stable ref, so the bridge is set up
+    // once and reads the live controller through the ref inside buildProject.
+  }, []);
 }

--- a/apps/geolibre-desktop/src/hooks/useEmbedBridge.ts
+++ b/apps/geolibre-desktop/src/hooks/useEmbedBridge.ts
@@ -37,15 +37,19 @@ type InboundMessage = LoadProjectMessage | RequestStateMessage;
  */
 function isEmbedded(): boolean {
   if (typeof window === "undefined") return false;
-  try {
-    if (window.parent && window.parent !== window) return true;
-  } catch {
-    // A cross-origin parent throws on access; being unable to read it at all
-    // still means we are framed.
-    return true;
-  }
+  // An explicit opt-in always activates the bridge — this is how the Jupyter
+  // widget and `to_html()` exports run (they load the app with `?embed=1`).
   const embed = new URLSearchParams(window.location.search).get("embed");
-  return embed === "1" || embed === "true";
+  if (embed === "1" || embed === "true") return true;
+  try {
+    // A same-origin framing host (readable parent) is trusted, so activate.
+    return Boolean(window.parent && window.parent !== window);
+  } catch {
+    // A cross-origin parent throws on access. Without the explicit `?embed=1`
+    // opt-in, don't activate the bridge — otherwise any third-party page that
+    // iframes a deployed app would start receiving project state.
+    return false;
+  }
 }
 
 /**
@@ -164,6 +168,10 @@ export function useEmbedBridge(
     };
 
     const applyLoad = (message: LoadProjectMessage) => {
+      // Advance the seq before parsing so a later snapshot carries the right
+      // correlation id even when the load fails. Reset (not retain) when a load
+      // omits seq, so a snapshot never echoes a stale, unrelated sequence number.
+      lastLoadedSeq = typeof message.seq === "number" ? message.seq : 0;
       try {
         // parseProject takes a JSON string and runs the schema validation and
         // normalisation the app relies on, so an object payload is re-stringified
@@ -172,9 +180,6 @@ export function useEmbedBridge(
           typeof message.project === "string"
             ? parseProject(message.project)
             : parseProject(JSON.stringify(message.project));
-        // Reset (not retain) when a load omits seq, so a later snapshot never
-        // echoes a stale, unrelated sequence number.
-        lastLoadedSeq = typeof message.seq === "number" ? message.seq : 0;
         useAppStore
           .getState()
           .loadProject(project, null, { rememberRecent: false });

--- a/apps/geolibre-desktop/src/hooks/useEmbedBridge.ts
+++ b/apps/geolibre-desktop/src/hooks/useEmbedBridge.ts
@@ -107,21 +107,23 @@ export function useEmbedBridge(
 
     const postState = () => {
       if (disposed) return;
-      const project = buildProject();
-      const content = serializeProject(project);
+      const content = serializeProject(buildProject());
       // Many store writes (selection, hover) do not change the serialized
       // project; skip posting an identical snapshot to keep the host quiet.
       if (content === lastPostedContent) return;
       lastPostedContent = content;
       try {
-        // Posted to the parent window object directly. "*" is used as the target
-        // origin because the framed app does not know the embedding host's
-        // origin; the message still only reaches that one parent window.
+        // Post the JSON-parsed snapshot (not the raw store object) so the wire
+        // payload exactly matches the serialized `.geolibre.json` form and is
+        // guaranteed structured-clone-safe even if a layer's free-form metadata
+        // ever holds a non-clone value. Posted to the parent window object
+        // directly; "*" is used because the framed app does not know the host's
+        // origin, and the message still only reaches that one parent window.
         host.postMessage(
           {
             type: "geolibre:state",
             seq: lastLoadedSeq,
-            project,
+            project: JSON.parse(content) as GeoLibreProject,
           },
           "*",
         );
@@ -161,7 +163,7 @@ export function useEmbedBridge(
             type: "geolibre:error",
             message: error instanceof Error ? error.message : String(error),
           },
-          "*",
+          "*", // host origin unknown; error text only, no project data
         );
       }
     };

--- a/apps/geolibre-desktop/src/hooks/useEmbedBridge.ts
+++ b/apps/geolibre-desktop/src/hooks/useEmbedBridge.ts
@@ -147,12 +147,14 @@ export function useEmbedBridge(
         // Reset (not retain) when a load omits seq, so a later snapshot never
         // echoes a stale, unrelated sequence number.
         lastLoadedSeq = typeof message.seq === "number" ? message.seq : 0;
-        // Suppress the snapshot this load would otherwise echo: the host
-        // already has this project, and re-posting it is wasted traffic.
-        lastPostedContent = serializeProject(project);
         useAppStore
           .getState()
           .loadProject(project, null, { rememberRecent: false });
+        // Suppress the snapshot this load would otherwise echo. loadProject is
+        // synchronous, so cache the post-normalisation project (merged styles,
+        // computed defaults) rather than the raw input; otherwise the first
+        // snapshot would differ from this string and be re-posted to the host.
+        lastPostedContent = serializeProject(buildProject());
       } catch (error) {
         host.postMessage(
           {

--- a/apps/geolibre-desktop/src/hooks/useEmbedBridge.ts
+++ b/apps/geolibre-desktop/src/hooks/useEmbedBridge.ts
@@ -83,6 +83,13 @@ export function useEmbedBridge(
     // correlate a snapshot with the load that triggered it.
     let lastLoadedSeq = 0;
     let lastPostedContent: string | null = null;
+    // The host's origin, learned from the first message it sends (a lightweight
+    // handshake). Outbound project/error messages are scoped to it once known,
+    // so a project a third party frames can never receive the data. Until then
+    // (only the version-only `ready` ping precedes any inbound message) we fall
+    // back to "*".
+    let hostOrigin: string | null = null;
+    const targetOrigin = () => hostOrigin ?? "*";
 
     const buildProject = (): GeoLibreProject => {
       const state = useAppStore.getState();
@@ -116,16 +123,14 @@ export function useEmbedBridge(
         // Post the JSON-parsed snapshot (not the raw store object) so the wire
         // payload exactly matches the serialized `.geolibre.json` form and is
         // guaranteed structured-clone-safe even if a layer's free-form metadata
-        // ever holds a non-clone value. Posted to the parent window object
-        // directly; "*" is used because the framed app does not know the host's
-        // origin, and the message still only reaches that one parent window.
+        // ever holds a non-clone value. Scoped to the host origin once known.
         host.postMessage(
           {
             type: "geolibre:state",
             seq: lastLoadedSeq,
             project: JSON.parse(content) as GeoLibreProject,
           },
-          "*",
+          targetOrigin(),
         );
       } catch (error) {
         console.error("[GeoLibre] Failed to post embed state", error);
@@ -142,6 +147,9 @@ export function useEmbedBridge(
 
     const applyLoad = (message: LoadProjectMessage) => {
       try {
+        // parseProject takes a JSON string and runs the schema validation and
+        // normalisation the app relies on, so an object payload is re-stringified
+        // to feed it through the same path.
         const project =
           typeof message.project === "string"
             ? parseProject(message.project)
@@ -163,7 +171,7 @@ export function useEmbedBridge(
             type: "geolibre:error",
             message: error instanceof Error ? error.message : String(error),
           },
-          "*", // host origin unknown; error text only, no project data
+          targetOrigin(),
         );
       }
     };
@@ -174,6 +182,9 @@ export function useEmbedBridge(
       // for the standalone `?embed=1` (`to_html()`) export, where the app may be
       // framed by a third-party page.
       if (event.source !== host) return;
+      // Learn the host's origin from its first message and scope outbound
+      // messages to it from then on. "null" (opaque/file origins) stays "*".
+      if (event.origin && event.origin !== "null") hostOrigin = event.origin;
       const data = event.data as Partial<InboundMessage> | null;
       if (!data || typeof data !== "object") return;
       if (data.type === "geolibre:load-project") {

--- a/apps/geolibre-desktop/src/hooks/useEmbedBridge.ts
+++ b/apps/geolibre-desktop/src/hooks/useEmbedBridge.ts
@@ -63,6 +63,14 @@ function isEmbedded(): boolean {
  * received from the app back into the iframe. Outside an embedding host the
  * hook is an inert no-op.
  *
+ * Trust model: the embedding host is fully trusted and receives the entire
+ * project state. Project snapshots are not broadcast until the host sends its
+ * first message (which is also when the bridge learns its origin and scopes
+ * subsequent posts to it); only the version-only `geolibre:ready` ping precedes
+ * the handshake and is the single message sent to `"*"`. Any page that frames
+ * the app (not just the Jupyter widget) therefore becomes that trusted host, so
+ * `?embed=1` standalone exports should only be served from a trusted context.
+ *
  * @param mapControllerRef - Ref to the live map controller, read so the emitted
  *   snapshot captures the current camera (pan/zoom) rather than only the store.
  */

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,6 +78,12 @@ Common geometry tools under Processing → Vector: buffer, centroids, convex hul
 Common raster tools under Processing → Raster: hillshade, slope, aspect, reproject, resample, clip by extent, clip by mask layer, polygonize, and contour. They run on a rasterio Python sidecar with a file path in and a file path out. Drag a GeoTIFF/COG onto the map to add it as a raster layer.
 </div>
 
+<div class="feature-card" markdown>
+### Python and Jupyter
+
+Embed the full GeoLibre app in a Jupyter notebook with the [`geolibre`](python.md) Python package. A leafmap-style API (`add_geojson`, `add_tile_layer`, `add_cog`) drives the map, and the project syncs both ways so UI edits are readable back from Python.
+</div>
+
 </div>
 
 ## Learn GeoLibre

--- a/docs/python.md
+++ b/docs/python.md
@@ -110,6 +110,16 @@ UI edits flow back the same way.
     such as JupyterHub or Google Colab, where the browser cannot reach the
     kernel's `localhost`, are not yet supported.
 
+!!! warning "URL fetching"
+
+    `add_geojson(url)` fetches the URL from the **kernel**, following redirects,
+    so a notebook can reach any host the kernel can (including private and
+    link-local addresses such as cloud metadata endpoints). This is intended for
+    single-user local notebooks, where you already control the kernel. Private
+    and localhost URLs are intentionally allowed so you can load from a local
+    tile server. Do not load untrusted `.geolibre.json` projects or URLs on a
+    shared/multi-tenant kernel.
+
 ## Building from source
 
 The package lives in [`python/`](https://github.com/opengeos/GeoLibre/tree/main/python).

--- a/docs/python.md
+++ b/docs/python.md
@@ -106,9 +106,11 @@ UI edits flow back the same way.
 
 !!! note "Environment support"
 
-    The interactive widget works in **local Jupyter and VS Code**. Remote setups
-    such as JupyterHub or Google Colab, where the browser cannot reach the
-    kernel's `localhost`, are not yet supported.
+    The interactive widget works in **local Jupyter, VS Code, and Google Colab**.
+    On Colab it routes the app through Colab's built-in port proxy
+    (`google.colab.kernel.proxyPort`) automatically. Other remote setups (e.g.
+    JupyterHub or Binder) where the browser cannot reach the kernel's `localhost`
+    and no port proxy is wired up are not yet supported.
 
 !!! warning "URL fetching"
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -72,7 +72,7 @@ Map(
     center=(-100, 40),   # [lng, lat]
     zoom=4,
     basemap="dark",      # a basemap name or a MapLibre style URL
-    height="600px",
+    height="800px",
     layout="embed",      # "embed" (compact UI), "full" (desktop UI), or "maponly"
     theme="light",       # "light" or "dark"
 )

--- a/docs/python.md
+++ b/docs/python.md
@@ -1,0 +1,124 @@
+# Python package (Jupyter)
+
+GeoLibre ships a Python package, **`geolibre`**, that embeds the full GeoLibre
+app inside a Jupyter notebook cell as an [anywidget](https://anywidget.dev),
+with a [leafmap](https://leafmap.org)-style API.
+
+The widget loads the complete GeoLibre app (menus, panels, processing tools) in
+an iframe. State syncs both ways through a single `.geolibre.json` project, so
+data you add from Python appears in the UI, and edits you make in the UI
+(panning, zooming, adding layers) are readable back from Python.
+
+## Install
+
+```bash
+pip install geolibre
+```
+
+Optional extras for `add_geojson()` from a GeoDataFrame:
+
+```bash
+pip install "geolibre[all]"   # adds GeoPandas and Shapely
+```
+
+## Quickstart
+
+```python
+from geolibre import Map
+
+m = Map(center=(-100, 40), zoom=4)
+m.add_geojson("https://example.com/data.geojson", name="Data")
+m
+```
+
+The full GeoLibre UI renders in the cell. Add more data and drive the view:
+
+```python
+m.add_tile_layer(
+    "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
+    name="OpenStreetMap",
+    attribution="(c) OpenStreetMap contributors",
+)
+m.add_cog("https://example.com/dem.tif", name="DEM", colormap="terrain")
+m.add_basemap("dark")
+m.set_center(-120, 47, zoom=8)
+```
+
+## Two-way sync
+
+Because the project syncs both ways, you can pan or zoom the map in the UI and
+then read the live state back from Python:
+
+```python
+proj = m.to_project()
+proj["mapView"]["center"]              # reflects the live UI view
+[layer["name"] for layer in proj["layers"]]
+```
+
+Save and reload projects, fully interchangeable with the desktop and web apps:
+
+```python
+m.save_project("my-map.geolibre.json")
+
+m2 = Map()
+m2.load_project("my-map.geolibre.json")
+m2
+```
+
+## Map options
+
+```python
+Map(
+    center=(-100, 40),   # [lng, lat]
+    zoom=4,
+    basemap="dark",      # a basemap name or a MapLibre style URL
+    height="600px",
+    layout="embed",      # "embed" (compact UI), "full" (desktop UI), or "maponly"
+    theme="light",       # "light" or "dark"
+)
+```
+
+## API reference
+
+| Method | Description |
+| --- | --- |
+| `Map(center, zoom, basemap=, height=, layout=, theme=)` | Create a map. |
+| `add_geojson(data, name=, **style)` | Add GeoJSON from a dict, file path, URL, JSON string, or GeoDataFrame. |
+| `add_tile_layer(url, name=, tile_size=, attribution=)` | Add a raster XYZ tile layer. |
+| `add_cog(url, name=, bands=, colormap=, rescale=)` | Add a Cloud Optimized GeoTIFF. |
+| `add_basemap(basemap)` | Set the background basemap. |
+| `set_center(lng, lat, zoom=None)` | Center (and optionally zoom) the map. |
+| `remove_layer(layer_id)` / `clear_layers()` | Remove layers. |
+| `to_project()` | Return the current project as a dict. |
+| `load_project(src)` | Replace the project from a dict, JSON string, or `.geolibre.json` path. |
+| `save_project(path)` | Write the current project to a `.geolibre.json` file. |
+
+Style keyword arguments (for example `fillColor`, `strokeColor`, `strokeWidth`,
+`circleRadius`) map to the GeoLibre [layer style fields](project-format.md).
+
+## How it works
+
+The wheel bundles the GeoLibre web build. At import time the package starts a
+small localhost static server that serves the bundled app; the widget renders
+that app in an iframe and exchanges the project over `window.postMessage`.
+Adding data from Python rewrites the synced project and pushes it into the app;
+UI edits flow back the same way.
+
+!!! note "Environment support"
+
+    The interactive widget works in **local Jupyter and VS Code**. Remote setups
+    such as JupyterHub or Google Colab, where the browser cannot reach the
+    kernel's `localhost`, are not yet supported.
+
+## Building from source
+
+The package lives in [`python/`](https://github.com/opengeos/GeoLibre/tree/main/python).
+The bundled app is produced from the monorepo with:
+
+```bash
+npm run build:embed      # builds the app and stages it into the wheel
+pip install -e python    # editable install for development
+```
+
+Changes to the Python code are picked up on kernel restart. Changes to the app
+(TypeScript) require re-running `npm run build:embed` and restarting the kernel.

--- a/docs/python.md
+++ b/docs/python.md
@@ -106,11 +106,21 @@ UI edits flow back the same way.
 
 !!! note "Environment support"
 
-    The interactive widget works in **local Jupyter, VS Code, and Google Colab**.
-    On Colab it routes the app through Colab's built-in port proxy
-    (`google.colab.kernel.proxyPort`) automatically. Other remote setups (e.g.
-    JupyterHub or Binder) where the browser cannot reach the kernel's `localhost`
-    and no port proxy is wired up are not yet supported.
+    The interactive widget works in **local Jupyter, VS Code, Google Colab, and
+    JupyterHub / remote servers**:
+
+    - **Local Jupyter / VS Code** - the app is served directly from localhost.
+    - **Google Colab** - routes through Colab's built-in port proxy
+      (`google.colab.kernel.proxyPort`) automatically.
+    - **JupyterHub** - routes through
+      [`jupyter-server-proxy`](https://jupyter-server-proxy.readthedocs.io)
+      automatically (detected via `JUPYTERHUB_SERVICE_PREFIX`). Install it in the
+      single-user image with `pip install "geolibre[hub]"` (or
+      `pip install jupyter-server-proxy`).
+    - **Other remote servers** (Binder, remote JupyterLab over SSH/network) -
+      pass `Map(server_proxy=True)`, which also requires `jupyter-server-proxy`.
+
+    Set `Map(server_proxy=False)` to force the direct localhost path.
 
 !!! warning "URL fetching"
 
@@ -129,6 +139,8 @@ The bundled app is produced from the monorepo with:
 
 ```bash
 npm run build:embed      # builds the app and stages it into the wheel
+python -m build          # builds the wheel
+python -m twine upload dist/*  # upload to PyPI
 pip install -e python    # editable install for development
 ```
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -88,6 +88,7 @@ Map(
 | `add_cog(url, name=, bands=, colormap=, rescale=)` | Add a Cloud Optimized GeoTIFF. |
 | `add_basemap(basemap)` | Set the background basemap. |
 | `set_center(lng, lat, zoom=None)` | Center (and optionally zoom) the map. |
+| `set_center_zoom(lng, lat, zoom=None)` | Alias of `set_center` (leafmap compatibility). |
 | `remove_layer(layer_id)` / `clear_layers()` | Remove layers. |
 | `to_project()` | Return the current project as a dict. |
 | `load_project(src)` | Replace the project from a dict, JSON string, or `.geolibre.json` path. |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -121,6 +121,7 @@
 - [x] Plugin marketplace MVP: curated registry plus browse and install UI
 - [x] Plugin update (in-place re-fetch) and uninstall with confirmation
 - [x] Project menu Share action that uploads to share.geolibre.app using a personal API token
+- [x] Python package (`geolibre`) for Jupyter notebooks: embeds the full app as an [anywidget](https://anywidget.dev) with a leafmap-style API (`add_geojson`, `add_tile_layer`, `add_cog`) and two-way `.geolibre.json` project sync
 - [x] Performance tuning and test suite
 - [x] Cross-platform installers
 - [x] Documentation and tutorials

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,7 @@ nav:
       - Architecture: architecture.md
       - Project Format: project-format.md
       - Plugin API: plugin-api.md
+      - Python Package: python.md
       - Roadmap: roadmap.md
       - Contributing: contributing.md
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "dev": "npm run dev -w geolibre-desktop",
     "build": "npm run build -w geolibre-desktop",
+    "build:embed": "node scripts/build-embed.mjs",
     "typecheck": "npm run build",
     "test": "npm run test:frontend",
     "test:frontend": "node --import tsx --test tests/*.test.ts",

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,0 +1,13 @@
+# Bundled web app, produced by `npm run build:embed` at build time.
+src/geolibre/static/
+
+# Python build artifacts
+dist/
+build/
+*.egg-info/
+__pycache__/
+.pytest_cache/
+
+# Jupyter and example run artifacts
+.ipynb_checkpoints/
+examples/*.geolibre.json

--- a/python/README.md
+++ b/python/README.md
@@ -59,6 +59,7 @@ m.to_project()["mapView"]["center"]
 | `add_cog(url, name=, bands=, colormap=, rescale=)` | Add a Cloud Optimized GeoTIFF. |
 | `add_basemap(basemap)` | Set the background basemap. |
 | `set_center(lng, lat, zoom=None)` | Center (and optionally zoom) the map. |
+| `set_center_zoom(lng, lat, zoom=None)` | Alias of `set_center` (leafmap compatibility). |
 | `remove_layer(layer_id)` / `clear_layers()` | Remove layers. |
 | `to_project()` / `load_project(src)` / `save_project(path)` | Project I/O. |
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,71 @@
+# geolibre
+
+GeoLibre in Jupyter: the full [GeoLibre](https://geolibre.app) GIS app as an
+[anywidget](https://anywidget.dev), with a leafmap-style Python API.
+
+The widget embeds the complete GeoLibre app (menus, panels, processing tools)
+inside a notebook cell. State syncs both ways through a single
+`.geolibre.json` project, so data you add from Python appears in the UI, and
+edits you make in the UI are readable back from Python.
+
+## Install
+
+```bash
+pip install geolibre
+```
+
+## Quickstart
+
+```python
+from geolibre import Map
+
+m = Map(center=(-100, 40), zoom=4)
+m.add_geojson("https://example.com/data.geojson", name="Data")
+m
+```
+
+Add more data and drive the view:
+
+```python
+m.add_tile_layer(
+    "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
+    name="OpenStreetMap",
+    attribution="(c) OpenStreetMap contributors",
+)
+m.add_cog("https://example.com/dem.tif", name="DEM", colormap="terrain")
+m.add_basemap("dark")
+m.set_center(-120, 47, zoom=8)
+```
+
+Round-trip the project:
+
+```python
+m.save_project("my-map.geolibre.json")
+
+m2 = Map()
+m2.load_project("my-map.geolibre.json")
+
+# Read state edited in the UI (e.g. after panning/zooming):
+m.to_project()["mapView"]["center"]
+```
+
+## API
+
+| Method | Description |
+| --- | --- |
+| `Map(center, zoom, basemap=, height=, layout=, theme=)` | Create a map. `layout` is `"embed"`, `"full"`, or `"maponly"`. |
+| `add_geojson(data, name=, **style)` | Add GeoJSON (dict, path, URL, JSON, or GeoDataFrame). |
+| `add_tile_layer(url, name=, tile_size=, attribution=)` | Add a raster XYZ tile layer. |
+| `add_cog(url, name=, bands=, colormap=, rescale=)` | Add a Cloud Optimized GeoTIFF. |
+| `add_basemap(basemap)` | Set the background basemap. |
+| `set_center(lng, lat, zoom=None)` | Center (and optionally zoom) the map. |
+| `remove_layer(layer_id)` / `clear_layers()` | Remove layers. |
+| `to_project()` / `load_project(src)` / `save_project(path)` | Project I/O. |
+
+## Notes
+
+- The bundled app is served from a localhost HTTP server, so the interactive
+  widget works in local Jupyter and VS Code. Remote setups (JupyterHub, Colab)
+  where the browser cannot reach the kernel's `localhost` are not yet supported.
+- Optional extras: `pip install geolibre[all]` adds GeoPandas/Shapely support
+  for `add_geojson(geodataframe)`.

--- a/python/README.md
+++ b/python/README.md
@@ -65,9 +65,11 @@ m.to_project()["mapView"]["center"]
 ## Notes
 
 - The bundled app is served from a localhost HTTP server, so the interactive
-  widget works in local Jupyter, VS Code, and Google Colab (Colab routes through
-  its built-in port proxy automatically). Other remote setups (JupyterHub,
-  Binder) where the browser cannot reach the kernel's `localhost` and no port
-  proxy is configured are not yet supported.
+  widget works in local Jupyter and VS Code directly. **Google Colab** routes
+  through its built-in port proxy automatically. **JupyterHub** routes through
+  [`jupyter-server-proxy`](https://jupyter-server-proxy.readthedocs.io)
+  automatically (install it with `pip install "geolibre[hub]"`). On other remote
+  servers (Binder, remote JupyterLab), pass `Map(server_proxy=True)` (also needs
+  `jupyter-server-proxy`); `Map(server_proxy=False)` forces the direct path.
 - Optional extras: `pip install geolibre[all]` adds GeoPandas/Shapely support
   for `add_geojson(geodataframe)`.

--- a/python/README.md
+++ b/python/README.md
@@ -74,3 +74,7 @@ m.to_project()["mapView"]["center"]
   `jupyter-server-proxy`); `Map(server_proxy=False)` forces the direct path.
 - Optional extras: `pip install geolibre[all]` adds GeoPandas/Shapely support
   for `add_geojson(geodataframe)`.
+- `add_geojson` inlines file/URL data into the project (up to 50 MB), so a large
+  dataset is held in memory and re-synced on every project update. For very large
+  layers, prefer a tile or COG source (`add_tile_layer`/`add_cog`) the app fetches
+  directly.

--- a/python/README.md
+++ b/python/README.md
@@ -65,7 +65,9 @@ m.to_project()["mapView"]["center"]
 ## Notes
 
 - The bundled app is served from a localhost HTTP server, so the interactive
-  widget works in local Jupyter and VS Code. Remote setups (JupyterHub, Colab)
-  where the browser cannot reach the kernel's `localhost` are not yet supported.
+  widget works in local Jupyter, VS Code, and Google Colab (Colab routes through
+  its built-in port proxy automatically). Other remote setups (JupyterHub,
+  Binder) where the browser cannot reach the kernel's `localhost` and no port
+  proxy is configured are not yet supported.
 - Optional extras: `pip install geolibre[all]` adds GeoPandas/Shapely support
   for `add_geojson(geodataframe)`.

--- a/python/examples/getting-started.ipynb
+++ b/python/examples/getting-started.ipynb
@@ -1,0 +1,171 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "dfce5571",
+   "metadata": {},
+   "source": [
+    "# GeoLibre in Jupyter\n",
+    "\n",
+    "The full GeoLibre GIS app, embedded in a notebook cell, with a leafmap-style Python API.\n",
+    "Run the cells below one at a time. After the map renders, edits you make in the UI (panning,\n",
+    "adding layers) are readable back from Python."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3f23332-3285-44c1-b46c-2fe20e9f1c23",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install geolibre"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fabd9a9e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from geolibre import Map\n",
+    "\n",
+    "m = Map(center=(-100, 40), zoom=4, height=\"800px\")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "76cd4556",
+   "metadata": {},
+   "source": [
+    "## Add a GeoJSON layer\n",
+    "\n",
+    "`add_geojson` accepts a dict, a file path, a URL, a JSON string, or a GeoDataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9178dbb3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = (\n",
+    "    \"https://github.com/opengeos/datasets/releases/download/world/world_cities.geojson\"\n",
+    ")\n",
+    "m.add_geojson(url, name=\"World Cities\", circleRadius=4, fillColor=\"#ef4444\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6b73404",
+   "metadata": {},
+   "source": [
+    "## Add a raster XYZ tile layer and move the view"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9babf49d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.add_tile_layer(\n",
+    "    \"https://tile.openstreetmap.org/{z}/{x}/{y}.png\",\n",
+    "    name=\"OpenStreetMap\",\n",
+    "    attribution=\"(c) OpenStreetMap contributors\",\n",
+    ")\n",
+    "m.set_center(-122.4, 37.77, zoom=10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d2917f9",
+   "metadata": {},
+   "source": [
+    "## Add a Cloud Optimized GeoTIFF (COG)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4becb69",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.add_cog(\n",
+    "    \"https://data.source.coop/giswqs/opengeos/nlcd_2021_land_cover_30m.tif\",\n",
+    "    name=\"Raster\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f94bd19",
+   "metadata": {},
+   "source": [
+    "## Read state back from the UI\n",
+    "\n",
+    "Pan or zoom the map above, then run this cell. The center reflects the live UI view."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "87ec3037",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "proj = m.to_project()\n",
+    "print(\"center:\", proj[\"mapView\"][\"center\"], \"zoom:\", round(proj[\"mapView\"][\"zoom\"], 2))\n",
+    "print(\"layers:\", [layer[\"name\"] for layer in proj[\"layers\"]])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33e013cb",
+   "metadata": {},
+   "source": [
+    "## Save and reload a project"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "efa653fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.save_project(\"my-map.geolibre.json\")\n",
+    "\n",
+    "m2 = Map()\n",
+    "m2.load_project(\"my-map.geolibre.json\")\n",
+    "m2"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/hatch_build.py
+++ b/python/hatch_build.py
@@ -46,12 +46,18 @@ class CustomBuildHook(BuildHookInterface):
         self.app.display_info(
             "Building embedded GeoLibre web app (npm run build:embed)..."
         )
-        subprocess.run(
-            ["npm", "run", "build:embed"],
-            cwd=REPO_ROOT,
-            check=True,
-            timeout=600,  # 10 minutes; fail loudly rather than hang pip forever
-        )
+        try:
+            subprocess.run(
+                ["npm", "run", "build:embed"],
+                cwd=REPO_ROOT,
+                check=True,
+                timeout=600,  # 10 minutes; fail loudly rather than hang pip forever
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                "npm was not found. Install Node.js and run `npm ci` from the "
+                "repository root before building the wheel."
+            ) from exc
 
         if not (STATIC_APP / "index.html").is_file():
             raise RuntimeError(

--- a/python/hatch_build.py
+++ b/python/hatch_build.py
@@ -50,6 +50,7 @@ class CustomBuildHook(BuildHookInterface):
             ["npm", "run", "build:embed"],
             cwd=REPO_ROOT,
             check=True,
+            timeout=600,  # 10 minutes; fail loudly rather than hang pip forever
         )
 
         if not (STATIC_APP / "index.html").is_file():

--- a/python/hatch_build.py
+++ b/python/hatch_build.py
@@ -1,0 +1,59 @@
+"""Hatchling build hook that bundles the GeoLibre web app into the wheel.
+
+The Python package serves the built GeoLibre single-page app from
+``geolibre/static/app``. That directory is produced by the JavaScript build
+(``npm run build:embed``) and is intentionally git-ignored, so it must be
+materialized at build time. This hook runs the embed build when the assets are
+missing (or ``GEOLIBRE_FORCE_JS_BUILD=1`` is set) and the JavaScript sources are
+available next to the package (i.e. building from a checkout of the monorepo).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+PACKAGE_ROOT = Path(__file__).parent
+STATIC_APP = PACKAGE_ROOT / "src" / "geolibre" / "static" / "app"
+# The Python package lives at <repo>/python, so the monorepo root is one level up.
+REPO_ROOT = PACKAGE_ROOT.parent
+BUILD_SCRIPT = REPO_ROOT / "scripts" / "build-embed.mjs"
+
+
+class CustomBuildHook(BuildHookInterface):
+    """Build the embedded web app before packaging the wheel/sdist."""
+
+    def initialize(self, version: str, build_data: dict) -> None:
+        force = os.environ.get("GEOLIBRE_FORCE_JS_BUILD") == "1"
+        have_assets = (STATIC_APP / "index.html").is_file()
+
+        if have_assets and not force:
+            return
+
+        if not BUILD_SCRIPT.is_file():
+            if have_assets:
+                return
+            raise RuntimeError(
+                "GeoLibre web assets are missing and the JavaScript build "
+                f"script was not found at {BUILD_SCRIPT}. Build the wheel from "
+                "a full checkout of the GeoLibre monorepo, or run "
+                "`npm run build:embed` first."
+            )
+
+        self.app.display_info(
+            "Building embedded GeoLibre web app (npm run build:embed)..."
+        )
+        subprocess.run(
+            ["npm", "run", "build:embed"],
+            cwd=REPO_ROOT,
+            check=True,
+        )
+
+        if not (STATIC_APP / "index.html").is_file():
+            raise RuntimeError(
+                "The embed build completed but produced no index.html at "
+                f"{STATIC_APP}."
+            )

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,48 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "geolibre"
+dynamic = ["version"]
+description = "GeoLibre in Jupyter: the full GeoLibre GIS app as an anywidget, with a leafmap-style Python API."
+readme = "README.md"
+requires-python = ">=3.10"
+license = "MIT"
+authors = [{ name = "Qiusheng Wu", email = "giswqs@gmail.com" }]
+keywords = ["geolibre", "gis", "maplibre", "jupyter", "anywidget", "mapping"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Framework :: Jupyter",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3 :: Only",
+    "Topic :: Scientific/Engineering :: GIS",
+]
+dependencies = ["anywidget>=0.9", "traitlets>=5"]
+
+[project.optional-dependencies]
+all = ["geopandas", "shapely"]
+dev = ["pytest", "build", "anywidget[dev]"]
+
+[project.urls]
+Homepage = "https://geolibre.app"
+Repository = "https://github.com/opengeos/GeoLibre"
+
+[tool.hatch.version]
+path = "src/geolibre/__init__.py"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/geolibre"]
+# The bundled app under static/ is produced by the build hook and git-ignored,
+# so it must be re-included explicitly here (VCS file discovery skips it).
+artifacts = ["src/geolibre/static/**"]
+
+[tool.hatch.build.targets.sdist]
+artifacts = ["src/geolibre/static/**"]
+
+[tool.hatch.build.targets.wheel.hooks.custom]
+path = "hatch_build.py"
+
+[tool.hatch.build.targets.sdist.hooks.custom]
+path = "hatch_build.py"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = ["anywidget>=0.9", "traitlets>=5"]
 
 [project.optional-dependencies]
 all = ["geopandas", "shapely"]
+hub = ["jupyter-server-proxy"]
 dev = ["pytest", "build", "anywidget[dev]"]
 
 [project.urls]

--- a/python/src/geolibre/__init__.py
+++ b/python/src/geolibre/__init__.py
@@ -2,5 +2,5 @@
 
 from .geolibre import Map
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 __all__ = ["Map", "__version__"]

--- a/python/src/geolibre/__init__.py
+++ b/python/src/geolibre/__init__.py
@@ -1,0 +1,6 @@
+"""GeoLibre for Jupyter: the full GeoLibre GIS app as an anywidget."""
+
+from .geolibre import Map
+
+__version__ = "0.1.0"
+__all__ = ["Map", "__version__"]

--- a/python/src/geolibre/_frontend.js
+++ b/python/src/geolibre/_frontend.js
@@ -134,6 +134,13 @@ async function render({ model, el }) {
     // not re-broadcast the value we just sent (traitlets.Dict change detection
     // is value-based), so the identity check is not defeated by the save round
     // trip.
+    //
+    // Invariant: this relies on anywidget/backbone returning from model.get()
+    // the same JS object reference passed to model.set() on this side (no
+    // serialization round-trip on the front end). If a future anywidget release
+    // ever deep-clones or JSON-normalizes the Dict trait on set, the reference
+    // check would always fail and every app snapshot would be echoed back —
+    // replace this with the primitive `_seq` counter comparison instead.
     if (model.get("project") === lastRemoteProject) return;
     lastRemoteProject = null;
     pushProject();

--- a/python/src/geolibre/_frontend.js
+++ b/python/src/geolibre/_frontend.js
@@ -1,0 +1,90 @@
+// anywidget front-end for the GeoLibre Jupyter widget.
+//
+// Renders the bundled GeoLibre app in an <iframe> and bridges it with the
+// Python model over window.postMessage. The single synced payload is a
+// `.geolibre.json` project object.
+//
+// Loop prevention: a project the app reports back (geolibre:state) is written
+// into the `project` trait but NOT pushed back into the iframe, guarded by
+// `applyingRemoteState`. Only Python-initiated project changes are pushed.
+
+function render({ model, el }) {
+  const iframe = document.createElement("iframe");
+  iframe.style.width = "100%";
+  iframe.style.height = model.get("height") || "600px";
+  iframe.style.border = "0";
+  iframe.style.display = "block";
+  iframe.allow = "fullscreen; clipboard-read; clipboard-write; geolocation";
+  iframe.allowFullscreen = true;
+
+  const base = model.get("_app_url");
+  if (!base) {
+    el.textContent =
+      "GeoLibre: the local app server is not running. Re-create the Map().";
+    return;
+  }
+
+  const layout = model.get("layout") || "embed";
+  const params = new URLSearchParams({ embed: "1", theme: model.get("theme") || "light" });
+  if (layout === "maponly") {
+    params.set("maponly", "1");
+  } else if (layout !== "full") {
+    params.set("layout", "embed");
+  }
+  iframe.src = `${base}index.html?${params.toString()}`;
+  el.appendChild(iframe);
+
+  let ready = false;
+  let applyingRemoteState = false;
+
+  const post = (message) => {
+    const win = iframe.contentWindow;
+    if (win) win.postMessage(message, "*");
+  };
+
+  const pushProject = () => {
+    if (!ready) return;
+    post({
+      type: "geolibre:load-project",
+      seq: model.get("_seq"),
+      project: model.get("project"),
+    });
+  };
+
+  const onMessage = (event) => {
+    if (event.source !== iframe.contentWindow) return;
+    const data = event.data;
+    if (!data || typeof data !== "object") return;
+    if (data.type === "geolibre:ready") {
+      ready = true;
+      pushProject();
+    } else if (data.type === "geolibre:state") {
+      applyingRemoteState = true;
+      model.set("project", data.project);
+      model.save_changes();
+      applyingRemoteState = false;
+    } else if (data.type === "geolibre:error") {
+      model.set("error", String(data.message || ""));
+      model.save_changes();
+    }
+  };
+
+  window.addEventListener("message", onMessage);
+
+  const onProjectChange = () => {
+    if (!applyingRemoteState) pushProject();
+  };
+  const onHeight = () => {
+    iframe.style.height = model.get("height") || "600px";
+  };
+  model.on("change:project", onProjectChange);
+  model.on("change:height", onHeight);
+
+  return () => {
+    window.removeEventListener("message", onMessage);
+    model.off("change:project", onProjectChange);
+    model.off("change:height", onHeight);
+  };
+}
+
+export default { render };

--- a/python/src/geolibre/_frontend.js
+++ b/python/src/geolibre/_frontend.js
@@ -35,7 +35,11 @@ function render({ model, el }) {
   el.appendChild(iframe);
 
   let ready = false;
-  let applyingRemoteState = false;
+  // The last project object received from the app. onProjectChange compares the
+  // current trait value against it by reference to decide whether a change came
+  // from the app (skip) or from Python (push). Reference identity avoids any
+  // dependency on whether anywidget fires change:project synchronously.
+  let lastRemoteProject = null;
 
   // Restrict delivery to the app's own origin (the localhost app server), so a
   // future misconfiguration of `_app_url` cannot leak the project to a third
@@ -66,15 +70,12 @@ function render({ model, el }) {
       ready = true;
       pushProject();
     } else if (data.type === "geolibre:state") {
-      // Set the flag before model.set() and clear it after: anywidget fires
-      // change:project synchronously inside set(), and the flag must be true
-      // during that callback or onProjectChange would echo the app's own state
-      // back into the iframe as a new load. If a future anywidget defers
-      // change events, this guard must be revisited.
-      applyingRemoteState = true;
+      // Record the project object that came from the app, then write it back to
+      // Python. onProjectChange skips pushing whatever value is still identical
+      // to this reference, so the app's own state is never echoed back.
+      lastRemoteProject = data.project;
       model.set("project", data.project);
       model.save_changes();
-      applyingRemoteState = false;
     } else if (data.type === "geolibre:error") {
       model.set("error", String(data.message || ""));
       model.save_changes();
@@ -84,7 +85,12 @@ function render({ model, el }) {
   window.addEventListener("message", onMessage);
 
   const onProjectChange = () => {
-    if (!applyingRemoteState) pushProject();
+    // A project that originated from the app is still the identical object on
+    // the trait; do not echo it back. A Python-initiated change deserializes
+    // into a fresh object, so identity differs and it is pushed.
+    if (model.get("project") === lastRemoteProject) return;
+    lastRemoteProject = null;
+    pushProject();
   };
   const onHeight = () => {
     iframe.style.height = model.get("height") || "800px";

--- a/python/src/geolibre/_frontend.js
+++ b/python/src/geolibre/_frontend.js
@@ -11,7 +11,7 @@
 function render({ model, el }) {
   const iframe = document.createElement("iframe");
   iframe.style.width = "100%";
-  iframe.style.height = model.get("height") || "600px";
+  iframe.style.height = model.get("height") || "800px";
   iframe.style.border = "0";
   iframe.style.display = "block";
   iframe.allow = "fullscreen; clipboard-read; clipboard-write; geolocation";
@@ -37,9 +37,13 @@ function render({ model, el }) {
   let ready = false;
   let applyingRemoteState = false;
 
+  // Restrict delivery to the app's own origin (the localhost app server), so a
+  // future misconfiguration of `_app_url` cannot leak the project to a third
+  // party.
+  const iframeOrigin = new URL(base).origin;
   const post = (message) => {
     const win = iframe.contentWindow;
-    if (win) win.postMessage(message, "*");
+    if (win) win.postMessage(message, iframeOrigin);
   };
 
   const pushProject = () => {
@@ -59,6 +63,11 @@ function render({ model, el }) {
       ready = true;
       pushProject();
     } else if (data.type === "geolibre:state") {
+      // Set the flag before model.set() and clear it after: anywidget fires
+      // change:project synchronously inside set(), and the flag must be true
+      // during that callback or onProjectChange would echo the app's own state
+      // back into the iframe as a new load. If a future anywidget defers
+      // change events, this guard must be revisited.
       applyingRemoteState = true;
       model.set("project", data.project);
       model.save_changes();
@@ -75,7 +84,7 @@ function render({ model, el }) {
     if (!applyingRemoteState) pushProject();
   };
   const onHeight = () => {
-    iframe.style.height = model.get("height") || "600px";
+    iframe.style.height = model.get("height") || "800px";
   };
   model.on("change:project", onProjectChange);
   model.on("change:height", onHeight);

--- a/python/src/geolibre/_frontend.js
+++ b/python/src/geolibre/_frontend.js
@@ -9,10 +9,25 @@
 // compares the current value against the last object received from the app
 // (`lastRemoteProject`) and only pushes Python-initiated changes.
 
+// The Jupyter server's base URL, read from the page config that JupyterLab and
+// Notebook 7 inject. Used to build a jupyter-server-proxy URL. Defaults to "/".
+function jupyterBaseUrl() {
+  try {
+    const el = document.getElementById("jupyter-config-data");
+    if (el && el.textContent) {
+      const base = JSON.parse(el.textContent).baseUrl;
+      if (base) return base.endsWith("/") ? base : `${base}/`;
+    }
+  } catch (error) {
+    console.warn("[GeoLibre] Could not read jupyter-config-data", error);
+  }
+  return "/";
+}
+
 // Resolve the base URL of the app server. The kernel serves it on localhost,
 // which the browser reaches directly in local Jupyter / VS Code. On hosts where
-// the browser cannot reach the kernel's localhost (e.g. Google Colab), route
-// through the host's port proxy instead.
+// the browser cannot reach the kernel's localhost, route through a proxy:
+// Google Colab's port proxy, or jupyter-server-proxy (JupyterHub / remote).
 async function resolveBase(model) {
   const port = model.get("_app_port");
   const colab =
@@ -27,6 +42,11 @@ async function resolveBase(model) {
     } catch (error) {
       console.warn("[GeoLibre] Colab proxyPort failed; using direct URL", error);
     }
+  }
+  if (port && model.get("_use_server_proxy")) {
+    // jupyter-server-proxy serves kernel-side ports at {base_url}proxy/{port}/.
+    return new URL(`${jupyterBaseUrl()}proxy/${port}/`, window.location.href)
+      .href;
   }
   return model.get("_app_url");
 }

--- a/python/src/geolibre/_frontend.js
+++ b/python/src/geolibre/_frontend.js
@@ -128,12 +128,13 @@ async function render({ model, el }) {
   window.addEventListener("message", onMessage);
 
   const onProjectChange = () => {
-    // A project that originated from the app is still the identical object on
-    // the trait; do not echo it back. A Python-initiated change deserializes
-    // into a fresh object, so identity differs and it is pushed. The kernel does
-    // not re-broadcast the value we just sent (traitlets.Dict change detection
-    // is value-based), so the identity check is not defeated by the save round
-    // trip.
+    // Loop guard. The PRIMARY protection is on the Python side: traitlets.Dict
+    // change detection is value-based, so the kernel never re-broadcasts the
+    // value we just sent back to the front end. This identity check is the
+    // SECONDARY fast-path guard that avoids the round-trip entirely: a project
+    // that originated from the app is still the identical object on the trait,
+    // so don't echo it back; a Python-initiated change deserializes into a fresh
+    // object, so identity differs and it is pushed.
     //
     // Invariant: this relies on anywidget/backbone returning from model.get()
     // the same JS object reference passed to model.set() on this side (no

--- a/python/src/geolibre/_frontend.js
+++ b/python/src/geolibre/_frontend.js
@@ -110,7 +110,10 @@ async function render({ model, el }) {
   const onProjectChange = () => {
     // A project that originated from the app is still the identical object on
     // the trait; do not echo it back. A Python-initiated change deserializes
-    // into a fresh object, so identity differs and it is pushed.
+    // into a fresh object, so identity differs and it is pushed. The kernel does
+    // not re-broadcast the value we just sent (traitlets.Dict change detection
+    // is value-based), so the identity check is not defeated by the save round
+    // trip.
     if (model.get("project") === lastRemoteProject) return;
     lastRemoteProject = null;
     pushProject();

--- a/python/src/geolibre/_frontend.js
+++ b/python/src/geolibre/_frontend.js
@@ -57,6 +57,9 @@ function render({ model, el }) {
 
   const onMessage = (event) => {
     if (event.source !== iframe.contentWindow) return;
+    // Defense in depth alongside the source check: reject messages that did not
+    // originate from the app's own origin.
+    if (event.origin !== iframeOrigin) return;
     const data = event.data;
     if (!data || typeof data !== "object") return;
     if (data.type === "geolibre:ready") {

--- a/python/src/geolibre/_frontend.js
+++ b/python/src/geolibre/_frontend.js
@@ -5,10 +5,33 @@
 // `.geolibre.json` project object.
 //
 // Loop prevention: a project the app reports back (geolibre:state) is written
-// into the `project` trait but NOT pushed back into the iframe, guarded by
-// `applyingRemoteState`. Only Python-initiated project changes are pushed.
+// into the `project` trait but NOT pushed back into the iframe. onProjectChange
+// compares the current value against the last object received from the app
+// (`lastRemoteProject`) and only pushes Python-initiated changes.
 
-function render({ model, el }) {
+// Resolve the base URL of the app server. The kernel serves it on localhost,
+// which the browser reaches directly in local Jupyter / VS Code. On hosts where
+// the browser cannot reach the kernel's localhost (e.g. Google Colab), route
+// through the host's port proxy instead.
+async function resolveBase(model) {
+  const port = model.get("_app_port");
+  const colab =
+    typeof window !== "undefined" &&
+    window.google &&
+    window.google.colab &&
+    window.google.colab.kernel;
+  if (port && colab && typeof colab.proxyPort === "function") {
+    try {
+      const url = await colab.proxyPort(port, { cache: true });
+      if (url) return url.endsWith("/") ? url : `${url}/`;
+    } catch (error) {
+      console.warn("[GeoLibre] Colab proxyPort failed; using direct URL", error);
+    }
+  }
+  return model.get("_app_url");
+}
+
+async function render({ model, el }) {
   const iframe = document.createElement("iframe");
   iframe.style.width = "100%";
   iframe.style.height = model.get("height") || "800px";
@@ -17,7 +40,7 @@ function render({ model, el }) {
   iframe.allow = "fullscreen; clipboard-read; clipboard-write; geolocation";
   iframe.allowFullscreen = true;
 
-  const base = model.get("_app_url");
+  const base = await resolveBase(model);
   if (!base) {
     el.textContent =
       "GeoLibre: the local app server is not running. Re-create the Map().";
@@ -41,9 +64,9 @@ function render({ model, el }) {
   // dependency on whether anywidget fires change:project synchronously.
   let lastRemoteProject = null;
 
-  // Restrict delivery to the app's own origin (the localhost app server), so a
-  // future misconfiguration of `_app_url` cannot leak the project to a third
-  // party.
+  // Restrict delivery to the app server's own origin (localhost, or the host
+  // proxy origin on Colab), so a future misconfiguration cannot leak the project
+  // to a third party.
   const iframeOrigin = new URL(base).origin;
   const post = (message) => {
     const win = iframe.contentWindow;

--- a/python/src/geolibre/_server.py
+++ b/python/src/geolibre/_server.py
@@ -13,6 +13,7 @@ setups (JupyterHub, Colab) would need a proxy; that is a known limitation.
 
 from __future__ import annotations
 
+import sys
 import threading
 from functools import partial
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
@@ -40,8 +41,13 @@ class _QuietServer(ThreadingHTTPServer):
     daemon_threads = True
 
     def handle_error(self, request: object, client_address: object) -> None:
-        # Connection resets / broken pipes are expected and not actionable.
-        pass
+        # Silently discard connection resets and broken pipes; these are
+        # expected when browsers abort in-flight asset requests. Any other
+        # exception is a genuine handler bug, so surface it as usual.
+        exc = sys.exc_info()[1]
+        if isinstance(exc, (ConnectionResetError, BrokenPipeError)):
+            return
+        super().handle_error(request, client_address)
 
 
 def serve_app(static_dir: Path) -> str:

--- a/python/src/geolibre/_server.py
+++ b/python/src/geolibre/_server.py
@@ -22,6 +22,7 @@ from pathlib import Path
 _lock = threading.Lock()
 _server: ThreadingHTTPServer | None = None
 _base_url: str | None = None
+_port: int | None = None
 
 
 class _QuietHandler(SimpleHTTPRequestHandler):
@@ -55,6 +56,8 @@ def serve_app(static_dir: Path) -> str:
 
     Args:
         static_dir: Directory containing the built app (``index.html`` etc.).
+            On the second and subsequent calls this argument is ignored; the
+            singleton server started by the first call is reused.
 
     Returns:
         The base URL of the running server, ending with ``/``.
@@ -62,7 +65,7 @@ def serve_app(static_dir: Path) -> str:
     Raises:
         FileNotFoundError: If the bundled app is not present.
     """
-    global _server, _base_url
+    global _server, _base_url, _port
 
     if not (static_dir / "index.html").is_file():
         raise FileNotFoundError(
@@ -72,7 +75,9 @@ def serve_app(static_dir: Path) -> str:
         )
 
     with _lock:
-        if _server is None or _base_url is None:
+        # _base_url, _server, and _port are always set together, so one check
+        # covers all three.
+        if _base_url is None:
             handler = partial(_QuietHandler, directory=str(static_dir))
             server = _QuietServer(("127.0.0.1", 0), handler)
             thread = threading.Thread(
@@ -84,4 +89,15 @@ def serve_app(static_dir: Path) -> str:
             host, port = server.server_address[:2]
             _server = server
             _base_url = f"http://{host}:{port}/"
+            _port = port
         return _base_url
+
+
+def app_port() -> int | None:
+    """Return the port the static app server is listening on, if started.
+
+    The port lets the front-end route through a host proxy (for example
+    ``google.colab.kernel.proxyPort``) when the browser cannot reach the
+    kernel's ``localhost`` directly.
+    """
+    return _port

--- a/python/src/geolibre/_server.py
+++ b/python/src/geolibre/_server.py
@@ -1,0 +1,81 @@
+"""A tiny localhost static server for the bundled GeoLibre web app.
+
+The widget renders the full GeoLibre single-page app inside an ``<iframe>``. A
+multi-chunk Vite SPA needs a real HTTP origin to resolve its dynamically
+imported chunks, so the package serves the bundled ``static/app`` directory from
+a background ``ThreadingHTTPServer`` bound to loopback. The server is a
+process-wide singleton: every widget instance shares the one origin.
+
+Note: because it binds to 127.0.0.1, the iframe URL is only reachable when the
+browser runs on the same host as the kernel (local Jupyter, VS Code). Remote
+setups (JupyterHub, Colab) would need a proxy; that is a known limitation.
+"""
+
+from __future__ import annotations
+
+import threading
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+_lock = threading.Lock()
+_server: ThreadingHTTPServer | None = None
+_base_url: str | None = None
+
+
+class _QuietHandler(SimpleHTTPRequestHandler):
+    """A request handler that does not spam the notebook with access logs."""
+
+    def log_message(self, *args: object) -> None:  # noqa: D401 - silence logs
+        pass
+
+
+class _QuietServer(ThreadingHTTPServer):
+    """A server that swallows the broken-pipe noise of early-closed requests.
+
+    Browsers routinely abort asset requests (e.g. on reload), which would
+    otherwise print connection-reset tracebacks into the notebook/kernel log.
+    """
+
+    daemon_threads = True
+
+    def handle_error(self, request: object, client_address: object) -> None:
+        # Connection resets / broken pipes are expected and not actionable.
+        pass
+
+
+def serve_app(static_dir: Path) -> str:
+    """Start (once) the static server for ``static_dir`` and return its base URL.
+
+    Args:
+        static_dir: Directory containing the built app (``index.html`` etc.).
+
+    Returns:
+        The base URL of the running server, ending with ``/``.
+
+    Raises:
+        FileNotFoundError: If the bundled app is not present.
+    """
+    global _server, _base_url
+
+    if not (static_dir / "index.html").is_file():
+        raise FileNotFoundError(
+            f"The bundled GeoLibre app was not found at {static_dir}. "
+            "Reinstall the geolibre wheel, or run `npm run build:embed` from a "
+            "checkout of the GeoLibre repository."
+        )
+
+    with _lock:
+        if _server is None or _base_url is None:
+            handler = partial(_QuietHandler, directory=str(static_dir))
+            server = _QuietServer(("127.0.0.1", 0), handler)
+            thread = threading.Thread(
+                target=server.serve_forever,
+                name="geolibre-static-server",
+                daemon=True,
+            )
+            thread.start()
+            host, port = server.server_address[:2]
+            _server = server
+            _base_url = f"http://{host}:{port}/"
+        return _base_url

--- a/python/src/geolibre/basemaps.py
+++ b/python/src/geolibre/basemaps.py
@@ -1,0 +1,44 @@
+"""Named MapLibre basemap styles for the GeoLibre Python API."""
+
+from __future__ import annotations
+
+# The app's default basemap (packages/core/src/types.ts: DEFAULT_BASEMAP).
+DEFAULT_BASEMAP = "https://tiles.openfreemap.org/styles/liberty"
+
+# Friendly name -> MapLibre style JSON URL. These are vector basemap styles
+# (set as the project's `basemapStyleUrl`). Raster tile basemaps such as
+# OpenStreetMap are added as layers via `Map.add_tile_layer` instead.
+BASEMAPS: dict[str, str] = {
+    "liberty": "https://tiles.openfreemap.org/styles/liberty",
+    "bright": "https://tiles.openfreemap.org/styles/bright",
+    "positron": "https://tiles.openfreemap.org/styles/positron",
+    "dark": "https://tiles.openfreemap.org/styles/dark",
+    "fiord": "https://tiles.openfreemap.org/styles/fiord",
+}
+
+
+def resolve_basemap(basemap: str) -> str:
+    """Resolve a basemap name or URL to a MapLibre style URL.
+
+    Args:
+        basemap: A known basemap name (e.g. ``"liberty"``, ``"dark"``) or a
+            full MapLibre style JSON URL.
+
+    Returns:
+        The resolved style URL.
+
+    Raises:
+        ValueError: If ``basemap`` is neither a known name nor a URL.
+    """
+    if not isinstance(basemap, str) or not basemap.strip():
+        raise ValueError("basemap must be a non-empty string")
+    value = basemap.strip()
+    if value.startswith(("http://", "https://")):
+        return value
+    key = value.lower()
+    if key in BASEMAPS:
+        return BASEMAPS[key]
+    raise ValueError(
+        f"Unknown basemap {basemap!r}. Pass a style URL or one of: "
+        + ", ".join(sorted(BASEMAPS))
+    )

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -156,6 +156,12 @@ class Map(anywidget.AnyWidget):
 
         Returns:
             The id of the added layer.
+
+        Note:
+            File and URL sources are fetched and inlined into the project (up to
+            the 50 MB GeoJSON limit), so a large dataset is carried in memory and
+            re-synced over the widget bus on every subsequent project update. For
+            very large layers, prefer a tile/COG source the app fetches directly.
         """
         source_url = (
             data
@@ -277,6 +283,7 @@ class Map(anywidget.AnyWidget):
 
         self._update_project(mutate)
 
+    # leafmap compatibility alias for set_center
     set_center_zoom = set_center
 
     # -- project I/O -----------------------------------------------------

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -18,6 +18,11 @@ from .basemaps import resolve_basemap
 _HERE = pathlib.Path(__file__).parent
 _STATIC_APP = _HERE / "static" / "app"
 
+# Accepted values for the constructor's layout/theme args, validated up front so
+# a typo surfaces immediately instead of silently falling back in the front-end.
+_VALID_LAYOUTS = frozenset({"embed", "full", "maponly"})
+_VALID_THEMES = frozenset({"light", "dark"})
+
 
 class Map(anywidget.AnyWidget):
     """An interactive GeoLibre map for Jupyter notebooks.
@@ -90,6 +95,14 @@ class Map(anywidget.AnyWidget):
                 and always uses its own port proxy.
             **kwargs: Forwarded to ``anywidget.AnyWidget``.
         """
+        if layout not in _VALID_LAYOUTS:
+            raise ValueError(
+                f"layout must be one of {sorted(_VALID_LAYOUTS)}, got {layout!r}"
+            )
+        if theme not in _VALID_THEMES:
+            raise ValueError(
+                f"theme must be one of {sorted(_VALID_THEMES)}, got {theme!r}"
+            )
         super().__init__(**kwargs)
         self.height = height
         self.layout = layout
@@ -300,26 +313,38 @@ class Map(anywidget.AnyWidget):
                 ``.geolibre.json`` file.
 
         Raises:
-            ValueError: If the project is not a dict or is missing required
-                top-level keys (``version``, ``name``, ``mapView``).
+            ValueError: If the source is not valid JSON or an existing file, or
+                if the project is not a dict or is missing required top-level
+                keys (``version``, ``name``, ``mapView``).
         """
         if isinstance(source, dict):
             project = copy.deepcopy(source)
         else:
             text = str(source)
+            project = None
             if text.strip().startswith("{"):
                 try:
                     project = json.loads(text)
                 except json.JSONDecodeError:
-                    # Not JSON after all (e.g. a path like `{backup}/map.json`);
-                    # fall back to treating the source as a file path.
-                    project = json.loads(
-                        pathlib.Path(text).expanduser().read_text(encoding="utf-8")
-                    )
-            else:
-                project = json.loads(
-                    pathlib.Path(text).expanduser().read_text(encoding="utf-8")
-                )
+                    # Looks like JSON but isn't; it may be a path that begins
+                    # with "{" (e.g. `{backup}/map.json`), so fall through to
+                    # the file-read branch below.
+                    project = None
+            if project is None:
+                path = pathlib.Path(text).expanduser()
+                try:
+                    project = json.loads(path.read_text(encoding="utf-8"))
+                except FileNotFoundError as exc:
+                    # Honour the documented ValueError contract instead of
+                    # leaking a raw FileNotFoundError/JSONDecodeError.
+                    raise ValueError(
+                        f"Project source is not valid JSON nor an existing "
+                        f"file: {text}"
+                    ) from exc
+                except json.JSONDecodeError as exc:
+                    raise ValueError(
+                        f"Invalid project JSON in file {text}: {exc}"
+                    ) from exc
         # Validate the required keys up front (matching parseProject in
         # @geolibre/core) so an invalid project raises here instead of failing
         # silently in the app and only surfacing through the `error` trait.

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -308,7 +308,14 @@ class Map(anywidget.AnyWidget):
         else:
             text = str(source)
             if text.strip().startswith("{"):
-                project = json.loads(text)
+                try:
+                    project = json.loads(text)
+                except json.JSONDecodeError:
+                    # Not JSON after all (e.g. a path like `{backup}/map.json`);
+                    # fall back to treating the source as a file path.
+                    project = json.loads(
+                        pathlib.Path(text).expanduser().read_text(encoding="utf-8")
+                    )
             else:
                 project = json.loads(
                     pathlib.Path(text).expanduser().read_text(encoding="utf-8")

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import json
+import os
 import pathlib
 from typing import Any, Callable
 
@@ -44,6 +45,11 @@ class Map(anywidget.AnyWidget):
     # google.colab.kernel.proxyPort) when localhost is not reachable from the
     # browser, as on Google Colab.
     _app_port = traitlets.Int(0).tag(sync=True)
+    # When set, the front-end loads the app through jupyter-server-proxy at
+    # `{base_url}proxy/{port}/` instead of localhost, so it works on remote
+    # servers (JupyterHub, Binder, remote JupyterLab) where the browser cannot
+    # reach the kernel's localhost.
+    _use_server_proxy = traitlets.Bool(False).tag(sync=True)
     height = traitlets.Unicode("800px").tag(sync=True)
     # "embed" (compact chrome), "full" (desktop chrome), or "maponly".
     layout = traitlets.Unicode("embed").tag(sync=True)
@@ -62,6 +68,7 @@ class Map(anywidget.AnyWidget):
         height: str = "800px",
         layout: str = "embed",
         theme: str = "light",
+        server_proxy: bool | str = "auto",
         **kwargs: Any,
     ) -> None:
         """Create a GeoLibre map.
@@ -74,6 +81,13 @@ class Map(anywidget.AnyWidget):
             layout: ``"embed"`` (compact UI), ``"full"`` (full desktop UI), or
                 ``"maponly"`` (map without chrome).
             theme: ``"light"`` or ``"dark"``.
+            server_proxy: How to reach the app server from the browser.
+                ``"auto"`` (default) serves the app directly from localhost, and
+                switches to ``jupyter-server-proxy`` automatically when running
+                under JupyterHub. Pass ``True`` to force the proxy on any remote
+                server (requires ``jupyter-server-proxy``), or ``False`` to force
+                the direct localhost path. Google Colab is detected separately
+                and always uses its own port proxy.
             **kwargs: Forwarded to ``anywidget.AnyWidget``.
         """
         super().__init__(**kwargs)
@@ -82,11 +96,30 @@ class Map(anywidget.AnyWidget):
         self.theme = theme
         self._app_url = serve_app(_STATIC_APP)
         self._app_port = app_port() or 0
+        self._use_server_proxy = self._resolve_server_proxy(server_proxy)
         self.project = _project.build_empty_project(
             center=center,
             zoom=zoom,
             basemap_url=resolve_basemap(basemap) if basemap else None,
         )
+
+    @staticmethod
+    def _resolve_server_proxy(server_proxy: bool | str) -> bool:
+        """Decide whether to load the app through jupyter-server-proxy.
+
+        Args:
+            server_proxy: ``True``/``False`` to force, or ``"auto"`` to enable
+                the proxy only when a JupyterHub single-user server is detected
+                (via the ``JUPYTERHUB_SERVICE_PREFIX`` environment variable).
+
+        Returns:
+            True to route through the server proxy, False for direct localhost.
+        """
+        if isinstance(server_proxy, bool):
+            return server_proxy
+        if server_proxy == "auto":
+            return bool(os.environ.get("JUPYTERHUB_SERVICE_PREFIX"))
+        raise ValueError("server_proxy must be True, False, or 'auto'")
 
     # -- internal --------------------------------------------------------
 

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -40,7 +40,7 @@ class Map(anywidget.AnyWidget):
     project = traitlets.Dict().tag(sync=True)
     # Base URL of the localhost server hosting the bundled app.
     _app_url = traitlets.Unicode("").tag(sync=True)
-    height = traitlets.Unicode("600px").tag(sync=True)
+    height = traitlets.Unicode("800px").tag(sync=True)
     # "embed" (compact chrome), "full" (desktop chrome), or "maponly".
     layout = traitlets.Unicode("embed").tag(sync=True)
     theme = traitlets.Unicode("light").tag(sync=True)
@@ -55,7 +55,7 @@ class Map(anywidget.AnyWidget):
         zoom: float | None = None,
         *,
         basemap: str | None = None,
-        height: str = "600px",
+        height: str = "800px",
         layout: str = "embed",
         theme: str = "light",
         **kwargs: Any,
@@ -66,7 +66,7 @@ class Map(anywidget.AnyWidget):
             center: Initial ``[lng, lat]`` map center.
             zoom: Initial zoom level.
             basemap: A basemap name or MapLibre style URL for the background.
-            height: CSS height of the widget (e.g. ``"600px"``).
+            height: CSS height of the widget (e.g. ``"800px"``).
             layout: ``"embed"`` (compact UI), ``"full"`` (full desktop UI), or
                 ``"maponly"`` (map without chrome).
             theme: ``"light"`` or ``"dark"``.
@@ -200,11 +200,12 @@ class Map(anywidget.AnyWidget):
         Args:
             layer_id: The id returned when the layer was added.
         """
-        self._update_project(
-            lambda p: p.__setitem__(
-                "layers", [l for l in p["layers"] if l.get("id") != layer_id]
-            )
-        )
+        def _drop(p: dict[str, Any]) -> None:
+            p["layers"] = [
+                layer for layer in p["layers"] if layer.get("id") != layer_id
+            ]
+
+        self._update_project(_drop)
 
     def clear_layers(self) -> None:
         """Remove all layers from the map."""

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -215,7 +215,7 @@ class Map(anywidget.AnyWidget):
 
     def clear_layers(self) -> None:
         """Remove all layers from the map."""
-        self._update_project(lambda p: p.__setitem__("layers", []))
+        self._update_project(lambda p: p.update({"layers": []}))
 
     # -- view / basemap API ---------------------------------------------
 
@@ -226,7 +226,7 @@ class Map(anywidget.AnyWidget):
             basemap: A basemap name or MapLibre style URL.
         """
         url = resolve_basemap(basemap)
-        self._update_project(lambda p: p.__setitem__("basemapStyleUrl", url))
+        self._update_project(lambda p: p.update({"basemapStyleUrl": url}))
 
     def set_center(self, lng: float, lat: float, zoom: float | None = None) -> None:
         """Center the map, optionally setting the zoom.
@@ -283,6 +283,14 @@ class Map(anywidget.AnyWidget):
             raise ValueError(
                 f"Invalid project: missing required keys {sorted(missing)}"
             )
+        # The app defaults a missing `layers` to [], but the Map API mutates
+        # project["layers"] directly (add_*/remove_layer), so backfill it and
+        # reject a non-list to avoid a later KeyError / type error.
+        layers = project.get("layers")
+        if layers is None:
+            project["layers"] = []
+        elif not isinstance(layers, list):
+            raise ValueError("Invalid project: 'layers' must be a list")
         self._seq += 1
         self.project = project
 

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -1,0 +1,276 @@
+"""The GeoLibre Jupyter widget and its leafmap-style Python API."""
+
+from __future__ import annotations
+
+import copy
+import json
+import pathlib
+from typing import Any, Callable
+
+import anywidget
+import traitlets
+
+from . import project as _project
+from ._server import serve_app
+from .basemaps import resolve_basemap
+
+_HERE = pathlib.Path(__file__).parent
+_STATIC_APP = _HERE / "static" / "app"
+
+
+class Map(anywidget.AnyWidget):
+    """An interactive GeoLibre map for Jupyter notebooks.
+
+    The widget embeds the full GeoLibre GIS app (menus, panels, processing
+    tools) and exposes a small Python API to add data and drive the view. State
+    is synchronized both ways through a single ``.geolibre.json`` project, so
+    edits made in the UI are readable from Python via :meth:`to_project`.
+
+    Example:
+        >>> from geolibre import Map
+        >>> m = Map(center=(-100, 40), zoom=4)
+        >>> m.add_geojson("https://example.com/data.geojson", name="Data")
+        >>> m
+    """
+
+    _esm = _HERE / "_frontend.js"
+
+    # The serialized project is the single source of truth synced over the
+    # bridge. Edits in the UI flow back into this trait.
+    project = traitlets.Dict().tag(sync=True)
+    # Base URL of the localhost server hosting the bundled app.
+    _app_url = traitlets.Unicode("").tag(sync=True)
+    height = traitlets.Unicode("600px").tag(sync=True)
+    # "embed" (compact chrome), "full" (desktop chrome), or "maponly".
+    layout = traitlets.Unicode("embed").tag(sync=True)
+    theme = traitlets.Unicode("light").tag(sync=True)
+    # Bumped on every Python-initiated project change; echoed by the app.
+    _seq = traitlets.Int(0).tag(sync=True)
+    # Last error reported by the app (e.g. an invalid project).
+    error = traitlets.Unicode("").tag(sync=True)
+
+    def __init__(
+        self,
+        center: list[float] | tuple[float, float] | None = None,
+        zoom: float | None = None,
+        *,
+        basemap: str | None = None,
+        height: str = "600px",
+        layout: str = "embed",
+        theme: str = "light",
+        **kwargs: Any,
+    ) -> None:
+        """Create a GeoLibre map.
+
+        Args:
+            center: Initial ``[lng, lat]`` map center.
+            zoom: Initial zoom level.
+            basemap: A basemap name or MapLibre style URL for the background.
+            height: CSS height of the widget (e.g. ``"600px"``).
+            layout: ``"embed"`` (compact UI), ``"full"`` (full desktop UI), or
+                ``"maponly"`` (map without chrome).
+            theme: ``"light"`` or ``"dark"``.
+            **kwargs: Forwarded to ``anywidget.AnyWidget``.
+        """
+        super().__init__(**kwargs)
+        self.height = height
+        self.layout = layout
+        self.theme = theme
+        self._app_url = serve_app(_STATIC_APP)
+        self.project = _project.build_empty_project(
+            center=center,
+            zoom=zoom,
+            basemap_url=resolve_basemap(basemap) if basemap else None,
+        )
+
+    # -- internal --------------------------------------------------------
+
+    def _update_project(self, mutate: Callable[[dict[str, Any]], None]) -> None:
+        """Mutate the project off a deep copy and reassign it.
+
+        traitlets only fires a sync on identity change, so an in-place edit of
+        ``self.project`` would not reach the app. Each mutation works on a copy,
+        bumps the sequence counter, and reassigns the trait.
+
+        Args:
+            mutate: Callback that mutates the project dict in place.
+        """
+        proj = copy.deepcopy(self.project)
+        mutate(proj)
+        self._seq += 1
+        self.project = proj
+
+    def _add_layer(self, layer: dict[str, Any]) -> str:
+        self._update_project(lambda p: p["layers"].append(layer))
+        return layer["id"]
+
+    # -- layer API -------------------------------------------------------
+
+    def add_geojson(self, data: Any, name: str = "GeoJSON", **style: Any) -> str:
+        """Add a GeoJSON layer.
+
+        Args:
+            data: A FeatureCollection/Feature/geometry dict, a file path or URL
+                to a GeoJSON file, a JSON string, or any object with a
+                ``__geo_interface__`` (e.g. a GeoDataFrame).
+            name: Layer display name.
+            **style: Style overrides (e.g. ``fillColor="#ff0000"``).
+
+        Returns:
+            The id of the added layer.
+        """
+        source_url = (
+            data
+            if isinstance(data, str) and data.startswith(("http://", "https://"))
+            else None
+        )
+        fc = _project.load_featurecollection(data)
+        return self._add_layer(
+            _project.geojson_layer(name, fc, source_url=source_url, **style)
+        )
+
+    def add_tile_layer(
+        self,
+        url: str,
+        name: str = "Tile Layer",
+        *,
+        tile_size: int = 256,
+        attribution: str | None = None,
+        **style: Any,
+    ) -> str:
+        """Add a raster XYZ tile layer.
+
+        Args:
+            url: An XYZ tile URL template (``{z}/{x}/{y}``).
+            name: Layer display name.
+            tile_size: Tile size in pixels.
+            attribution: Optional attribution string.
+            **style: Style overrides.
+
+        Returns:
+            The id of the added layer.
+        """
+        return self._add_layer(
+            _project.tile_layer(
+                name,
+                url,
+                tile_size=tile_size,
+                attribution=attribution,
+                **style,
+            )
+        )
+
+    def add_cog(
+        self,
+        url: str,
+        name: str = "COG",
+        *,
+        bands: list[int] | None = None,
+        colormap: str | None = None,
+        rescale: list[list[float]] | None = None,
+        **style: Any,
+    ) -> str:
+        """Add a Cloud Optimized GeoTIFF (COG) layer.
+
+        Args:
+            url: URL of the COG / GeoTIFF.
+            name: Layer display name.
+            bands: Optional 1-based band indices to render.
+            colormap: Optional colormap name (single-band rendering).
+            rescale: Optional ``[[min, max], ...]`` ranges per band.
+            **style: Style overrides.
+
+        Returns:
+            The id of the added layer.
+        """
+        return self._add_layer(
+            _project.cog_layer(
+                name,
+                url,
+                bands=bands,
+                colormap=colormap,
+                rescale=rescale,
+                **style,
+            )
+        )
+
+    def remove_layer(self, layer_id: str) -> None:
+        """Remove a layer by id.
+
+        Args:
+            layer_id: The id returned when the layer was added.
+        """
+        self._update_project(
+            lambda p: p.__setitem__(
+                "layers", [l for l in p["layers"] if l.get("id") != layer_id]
+            )
+        )
+
+    def clear_layers(self) -> None:
+        """Remove all layers from the map."""
+        self._update_project(lambda p: p.__setitem__("layers", []))
+
+    # -- view / basemap API ---------------------------------------------
+
+    def add_basemap(self, basemap: str) -> None:
+        """Set the background basemap style.
+
+        Args:
+            basemap: A basemap name or MapLibre style URL.
+        """
+        url = resolve_basemap(basemap)
+        self._update_project(lambda p: p.__setitem__("basemapStyleUrl", url))
+
+    def set_center(self, lng: float, lat: float, zoom: float | None = None) -> None:
+        """Center the map, optionally setting the zoom.
+
+        Args:
+            lng: Longitude of the new center.
+            lat: Latitude of the new center.
+            zoom: Optional zoom level.
+        """
+
+        def mutate(p: dict[str, Any]) -> None:
+            p["mapView"]["center"] = [float(lng), float(lat)]
+            if zoom is not None:
+                p["mapView"]["zoom"] = float(zoom)
+
+        self._update_project(mutate)
+
+    set_center_zoom = set_center
+
+    # -- project I/O -----------------------------------------------------
+
+    def to_project(self) -> dict[str, Any]:
+        """Return a deep copy of the current project dict."""
+        return copy.deepcopy(self.project)
+
+    def load_project(self, source: Any) -> None:
+        """Replace the current project.
+
+        Args:
+            source: A project dict, a JSON string, or a path to a
+                ``.geolibre.json`` file.
+        """
+        if isinstance(source, dict):
+            project = copy.deepcopy(source)
+        else:
+            text = str(source)
+            if text.strip().startswith("{"):
+                project = json.loads(text)
+            else:
+                project = json.loads(
+                    pathlib.Path(text).expanduser().read_text(encoding="utf-8")
+                )
+        self._seq += 1
+        self.project = project
+
+    def save_project(self, path: str) -> None:
+        """Write the current project to a ``.geolibre.json`` file.
+
+        Args:
+            path: Destination file path.
+        """
+        pathlib.Path(path).expanduser().write_text(
+            json.dumps(self.project, indent=2), encoding="utf-8"
+        )

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -11,7 +11,7 @@ import anywidget
 import traitlets
 
 from . import project as _project
-from ._server import serve_app
+from ._server import app_port, serve_app
 from .basemaps import resolve_basemap
 
 _HERE = pathlib.Path(__file__).parent
@@ -40,6 +40,10 @@ class Map(anywidget.AnyWidget):
     project = traitlets.Dict().tag(sync=True)
     # Base URL of the localhost server hosting the bundled app.
     _app_url = traitlets.Unicode("").tag(sync=True)
+    # Port of that server, so the front-end can route through a host proxy (e.g.
+    # google.colab.kernel.proxyPort) when localhost is not reachable from the
+    # browser, as on Google Colab.
+    _app_port = traitlets.Int(0).tag(sync=True)
     height = traitlets.Unicode("800px").tag(sync=True)
     # "embed" (compact chrome), "full" (desktop chrome), or "maponly".
     layout = traitlets.Unicode("embed").tag(sync=True)
@@ -77,6 +81,7 @@ class Map(anywidget.AnyWidget):
         self.layout = layout
         self.theme = theme
         self._app_url = serve_app(_STATIC_APP)
+        self._app_port = app_port() or 0
         self.project = _project.build_empty_project(
             center=center,
             zoom=zoom,
@@ -200,6 +205,7 @@ class Map(anywidget.AnyWidget):
         Args:
             layer_id: The id returned when the layer was added.
         """
+
         def _drop(p: dict[str, Any]) -> None:
             p["layers"] = [
                 layer for layer in p["layers"] if layer.get("id") != layer_id
@@ -284,8 +290,9 @@ class Map(anywidget.AnyWidget):
         """Write the current project to a ``.geolibre.json`` file.
 
         Args:
-            path: Destination file path.
+            path: Destination file path. Parent directories are created if
+                they do not already exist.
         """
-        pathlib.Path(path).expanduser().write_text(
-            json.dumps(self.project, indent=2), encoding="utf-8"
-        )
+        out = pathlib.Path(path).expanduser()
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(self.project, indent=2), encoding="utf-8")

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -252,6 +252,10 @@ class Map(anywidget.AnyWidget):
         Args:
             source: A project dict, a JSON string, or a path to a
                 ``.geolibre.json`` file.
+
+        Raises:
+            ValueError: If the project is not a dict or is missing required
+                top-level keys (``version``, ``name``, ``mapView``).
         """
         if isinstance(source, dict):
             project = copy.deepcopy(source)
@@ -263,6 +267,16 @@ class Map(anywidget.AnyWidget):
                 project = json.loads(
                     pathlib.Path(text).expanduser().read_text(encoding="utf-8")
                 )
+        # Validate the required keys up front (matching parseProject in
+        # @geolibre/core) so an invalid project raises here instead of failing
+        # silently in the app and only surfacing through the `error` trait.
+        if not isinstance(project, dict):
+            raise ValueError("Project must be a JSON object")
+        missing = {"version", "name", "mapView"} - project.keys()
+        if missing:
+            raise ValueError(
+                f"Invalid project: missing required keys {sorted(missing)}"
+            )
         self._seq += 1
         self.project = project
 

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -355,6 +355,10 @@ class Map(anywidget.AnyWidget):
             raise ValueError(
                 f"Invalid project: missing required keys {sorted(missing)}"
             )
+        # Presence isn't enough: set_center et al. index into mapView, so a
+        # non-dict here would surface as a confusing TypeError later.
+        if not isinstance(project.get("mapView"), dict):
+            raise ValueError("Invalid project: 'mapView' must be an object")
         # The app defaults a missing `layers` to [], but the Map API mutates
         # project["layers"] directly (add_*/remove_layer), so backfill it and
         # reject a non-list to avoid a later KeyError / type error.

--- a/python/src/geolibre/project.py
+++ b/python/src/geolibre/project.py
@@ -1,0 +1,293 @@
+"""Builders for GeoLibre project (`.geolibre.json`) dicts and their layers.
+
+The shapes here mirror the TypeScript interfaces in
+``packages/core/src/types.ts`` and ``packages/core/src/project.ts``. Keeping the
+Python builders faithful to those interfaces is what lets the embedded app load
+a project produced entirely from Python.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+from typing import Any
+from urllib.request import urlopen
+
+from .basemaps import DEFAULT_BASEMAP
+
+PROJECT_VERSION = "0.1.0"
+
+# Mirror of DEFAULT_LAYER_STYLE in packages/core/src/types.ts. The app fills in
+# any missing fields on load, so layers only need to override what differs, but
+# carrying the full default keeps round-tripped projects stable.
+DEFAULT_LAYER_STYLE: dict[str, Any] = {
+    "minZoom": 0,
+    "maxZoom": 24,
+    "fillColor": "#3b82f6",
+    "strokeColor": "#1e40af",
+    "strokeWidth": 2,
+    "fillOpacity": 0.6,
+    "circleRadius": 6,
+    "textColor": "#111827",
+    "textHaloColor": "#ffffff",
+    "textHaloWidth": 2,
+    "textSize": 16,
+    "extrusionEnabled": False,
+    "extrusionColor": "#3b82f6",
+    "extrusionOpacity": 0.8,
+    "extrusionHeightProperty": "height",
+    "extrusionHeightScale": 1,
+    "extrusionBase": 0,
+    "extrusionAdvancedStyleEnabled": False,
+    "extrusionColorExpression": "",
+    "extrusionHeightExpression": "",
+    "vectorStyleMode": "single",
+    "vectorStyleProperty": "",
+    "vectorStyleClassCount": 5,
+    "vectorStyleColorRamp": "viridis",
+    "vectorStyleClassificationScheme": "equal-interval",
+    "vectorStyleStops": [
+        {"value": 0, "color": "#dbeafe"},
+        {"value": 1, "color": "#2563eb"},
+    ],
+    "vectorStyleExpression": "",
+    "rasterBrightnessMin": 0,
+    "rasterBrightnessMax": 1,
+    "rasterSaturation": 0,
+    "rasterContrast": 0,
+    "rasterHueRotate": 0,
+}
+
+# Mirror of DEFAULT_PROJECT_PREFERENCES in packages/core/src/types.ts.
+DEFAULT_PROJECT_PREFERENCES: dict[str, Any] = {
+    "map": {
+        "restrictBounds": False,
+        "bounds": [-180, -85, 180, 85],
+        "minZoom": 0,
+        "maxZoom": 24,
+        "maxPitch": 85,
+        "renderWorldCopies": True,
+    },
+    "environmentVariables": [],
+}
+
+
+def default_map_view() -> dict[str, Any]:
+    """Return the app's default camera (createDefaultMapView in project.ts)."""
+    return {"center": [-100, 40], "zoom": 2, "bearing": 0, "pitch": 0}
+
+
+def build_empty_project(
+    name: str = "Untitled Project",
+    *,
+    center: list[float] | tuple[float, float] | None = None,
+    zoom: float | None = None,
+    basemap_url: str | None = None,
+) -> dict[str, Any]:
+    """Build an empty GeoLibre project dict.
+
+    Args:
+        name: Project display name.
+        center: Optional ``[lng, lat]`` map center.
+        zoom: Optional initial zoom level.
+        basemap_url: Optional MapLibre style URL; defaults to the app default.
+
+    Returns:
+        A project dict ready to be assigned to the widget's ``project`` trait.
+    """
+    map_view = default_map_view()
+    if center is not None:
+        map_view["center"] = [float(center[0]), float(center[1])]
+    if zoom is not None:
+        map_view["zoom"] = float(zoom)
+    return {
+        "version": PROJECT_VERSION,
+        "name": name,
+        "mapView": map_view,
+        "basemapStyleUrl": basemap_url or DEFAULT_BASEMAP,
+        "basemapVisible": True,
+        "basemapOpacity": 1,
+        "layers": [],
+        "styles": {},
+        "preferences": json.loads(json.dumps(DEFAULT_PROJECT_PREFERENCES)),
+        "metadata": {},
+    }
+
+
+def _layer_base(name: str, layer_type: str, **style: Any) -> dict[str, Any]:
+    merged_style = {**DEFAULT_LAYER_STYLE, **style}
+    return {
+        "id": str(uuid.uuid4()),
+        "name": name,
+        "type": layer_type,
+        "visible": True,
+        "opacity": 1,
+        "style": merged_style,
+        "metadata": {},
+    }
+
+
+def geojson_layer(
+    name: str,
+    data: dict[str, Any],
+    *,
+    source_url: str | None = None,
+    **style: Any,
+) -> dict[str, Any]:
+    """Build a GeoJSON layer with an inlined FeatureCollection.
+
+    Args:
+        name: Layer display name.
+        data: A GeoJSON FeatureCollection dict.
+        source_url: Optional URL the data originated from (recorded on the
+            source for restore/refresh).
+        **style: Style overrides merged into the default layer style
+            (e.g. ``fillColor="#ff0000"``).
+
+    Returns:
+        A layer dict for the project's ``layers`` array.
+    """
+    layer = _layer_base(name, "geojson", **style)
+    source: dict[str, Any] = {"type": "geojson"}
+    if source_url:
+        source["url"] = source_url
+        layer["sourcePath"] = source_url
+    layer["source"] = source
+    layer["geojson"] = data
+    return layer
+
+
+def tile_layer(
+    name: str,
+    url: str,
+    *,
+    tile_size: int = 256,
+    attribution: str | None = None,
+    **style: Any,
+) -> dict[str, Any]:
+    """Build a raster XYZ tile layer (e.g. an ``{z}/{x}/{y}`` template).
+
+    Args:
+        name: Layer display name.
+        url: The XYZ tile URL template.
+        tile_size: Tile size in pixels (typically 256).
+        attribution: Optional attribution string.
+        **style: Style overrides merged into the default layer style.
+
+    Returns:
+        A layer dict for the project's ``layers`` array.
+    """
+    layer = _layer_base(name, "xyz", **style)
+    source: dict[str, Any] = {
+        "type": "raster",
+        "tiles": [url],
+        "tileSize": tile_size,
+        "url": url,
+    }
+    if attribution:
+        source["attribution"] = attribution
+    layer["source"] = source
+    layer["metadata"] = {"sourceKind": "xyz-url"}
+    return layer
+
+
+def cog_layer(
+    name: str,
+    url: str,
+    *,
+    bands: list[int] | None = None,
+    colormap: str | None = None,
+    rescale: list[list[float]] | None = None,
+    **style: Any,
+) -> dict[str, Any]:
+    """Build a Cloud Optimized GeoTIFF (COG) layer.
+
+    The shape matches what ``restoreRasterLayers`` replays from a saved project
+    (see packages/plugins/src/plugins/raster-layer-sync.ts), so the app rebuilds
+    the deck.gl raster overlay on load.
+
+    Args:
+        name: Layer display name.
+        url: URL of the COG / GeoTIFF.
+        bands: Optional 1-based band indices to render (e.g. ``[1, 2, 3]``).
+        colormap: Optional colormap name for single-band rendering.
+        rescale: Optional list of ``[min, max]`` ranges, one per rendered band.
+        **style: Style overrides merged into the default layer style.
+
+    Returns:
+        A layer dict for the project's ``layers`` array.
+    """
+    layer = _layer_base(name, "cog", **style)
+    raster_state: dict[str, Any] = {"rescale": rescale}
+    if bands is not None:
+        raster_state["bands"] = bands
+        raster_state["mode"] = "rgb" if len(bands) >= 3 else "single"
+    if colormap is not None:
+        raster_state["colormap"] = colormap
+    layer["source"] = {"type": "raster", "url": url}
+    layer["metadata"] = {
+        "customLayerType": "raster",
+        "externalDeckLayer": True,
+        "externalNativeLayer": True,
+        "identifiable": False,
+        "nativeLayerIds": [layer["id"]],
+        "panelCollapsed": True,
+        "rasterOverlayMode": "interleaved",
+        "rasterSource": "url",
+        "rasterState": raster_state,
+        "sourceIds": [],
+        "sourceKind": "maplibre-gl-raster",
+    }
+    layer["sourcePath"] = url
+    return layer
+
+
+def load_featurecollection(data: Any) -> dict[str, Any]:
+    """Coerce assorted inputs into a GeoJSON FeatureCollection dict.
+
+    Accepts a FeatureCollection/Feature/geometry dict, a file path or URL to a
+    GeoJSON file, a JSON string, or any object exposing ``__geo_interface__``
+    (e.g. a GeoPandas GeoDataFrame/GeoSeries or a Shapely geometry).
+
+    Args:
+        data: The input geometry/collection in one of the supported forms.
+
+    Returns:
+        A GeoJSON FeatureCollection dict.
+
+    Raises:
+        ValueError: If the input cannot be interpreted as GeoJSON.
+    """
+    if hasattr(data, "__geo_interface__"):
+        data = data.__geo_interface__
+
+    if isinstance(data, (bytes, bytearray)):
+        data = data.decode("utf-8")
+
+    if isinstance(data, str):
+        text = data.strip()
+        if text.startswith(("http://", "https://")):
+            with urlopen(text) as response:  # noqa: S310 - user-provided URL
+                data = json.loads(response.read().decode("utf-8"))
+        elif text.startswith(("{", "[")):
+            data = json.loads(text)
+        else:
+            path = Path(text).expanduser()
+            if not path.is_file():
+                raise ValueError(f"GeoJSON file not found: {text}")
+            data = json.loads(path.read_text(encoding="utf-8"))
+
+    if not isinstance(data, dict) or "type" not in data:
+        raise ValueError("Could not interpret input as GeoJSON")
+
+    geom_type = data["type"]
+    if geom_type == "FeatureCollection":
+        return data
+    if geom_type == "Feature":
+        return {"type": "FeatureCollection", "features": [data]}
+    # A bare geometry: wrap it in a feature.
+    return {
+        "type": "FeatureCollection",
+        "features": [{"type": "Feature", "properties": {}, "geometry": data}],
+    }

--- a/python/src/geolibre/project.py
+++ b/python/src/geolibre/project.py
@@ -19,6 +19,10 @@ from .basemaps import DEFAULT_BASEMAP
 
 PROJECT_VERSION = "0.1.0"
 
+# Cap GeoJSON inputs (URL fetches and local files alike) so a huge source cannot
+# silently exhaust kernel memory when inlined into the project.
+_MAX_GEOJSON_BYTES = 50 * 1024 * 1024  # 50 MB
+
 # Mirror of DEFAULT_LAYER_STYLE in packages/core/src/types.ts. The app fills in
 # any missing fields on load, so layers only need to override what differs, but
 # carrying the full default keeps round-tripped projects stable.
@@ -272,17 +276,16 @@ def load_featurecollection(data: Any) -> dict[str, Any]:
             # Bound the request so a slow or oversized response cannot hang the
             # kernel or exhaust memory. read(limit + 1) detects an over-limit
             # body without buffering the whole thing.
-            limit = 50 * 1024 * 1024  # 50 MB
             try:
                 with urlopen(text, timeout=30) as response:  # noqa: S310 - user URL
-                    raw = response.read(limit + 1)
+                    raw = response.read(_MAX_GEOJSON_BYTES + 1)
             except (URLError, TimeoutError) as exc:
                 # Normalize transport failures to the documented ValueError
                 # contract (decode/JSON errors are already ValueError-derived).
                 raise ValueError(
                     f"Could not load GeoJSON from URL: {text}"
                 ) from exc
-            if len(raw) > limit:
+            if len(raw) > _MAX_GEOJSON_BYTES:
                 raise ValueError("GeoJSON response exceeds the 50 MB size limit")
             data = json.loads(raw.decode("utf-8"))
         elif text.startswith(("{", "[")):
@@ -291,6 +294,10 @@ def load_featurecollection(data: Any) -> dict[str, Any]:
             path = Path(text).expanduser()
             if not path.is_file():
                 raise ValueError(f"GeoJSON file not found: {text}")
+            if path.stat().st_size > _MAX_GEOJSON_BYTES:
+                raise ValueError(
+                    f"GeoJSON file exceeds the 50 MB size limit: {text}"
+                )
             data = json.loads(path.read_text(encoding="utf-8"))
 
     if not isinstance(data, dict) or "type" not in data:

--- a/python/src/geolibre/project.py
+++ b/python/src/geolibre/project.py
@@ -12,6 +12,7 @@ import json
 import uuid
 from pathlib import Path
 from typing import Any
+from urllib.error import URLError
 from urllib.request import urlopen
 
 from .basemaps import DEFAULT_BASEMAP
@@ -272,8 +273,15 @@ def load_featurecollection(data: Any) -> dict[str, Any]:
             # kernel or exhaust memory. read(limit + 1) detects an over-limit
             # body without buffering the whole thing.
             limit = 50 * 1024 * 1024  # 50 MB
-            with urlopen(text, timeout=30) as response:  # noqa: S310 - user URL
-                raw = response.read(limit + 1)
+            try:
+                with urlopen(text, timeout=30) as response:  # noqa: S310 - user URL
+                    raw = response.read(limit + 1)
+            except (URLError, TimeoutError) as exc:
+                # Normalize transport failures to the documented ValueError
+                # contract (decode/JSON errors are already ValueError-derived).
+                raise ValueError(
+                    f"Could not load GeoJSON from URL: {text}"
+                ) from exc
             if len(raw) > limit:
                 raise ValueError("GeoJSON response exceeds the 50 MB size limit")
             data = json.loads(raw.decode("utf-8"))

--- a/python/src/geolibre/project.py
+++ b/python/src/geolibre/project.py
@@ -103,6 +103,10 @@ def build_empty_project(
     """
     map_view = default_map_view()
     if center is not None:
+        if len(center) < 2:
+            raise ValueError(
+                "center must be a [lng, lat] sequence with 2 elements"
+            )
         map_view["center"] = [float(center[0]), float(center[1])]
     if zoom is not None:
         map_view["zoom"] = float(zoom)
@@ -282,9 +286,7 @@ def load_featurecollection(data: Any) -> dict[str, Any]:
             except (URLError, TimeoutError) as exc:
                 # Normalize transport failures to the documented ValueError
                 # contract (decode/JSON errors are already ValueError-derived).
-                raise ValueError(
-                    f"Could not load GeoJSON from URL: {text}"
-                ) from exc
+                raise ValueError(f"Could not load GeoJSON from URL: {text}") from exc
             if len(raw) > _MAX_GEOJSON_BYTES:
                 raise ValueError("GeoJSON response exceeds the 50 MB size limit")
             data = json.loads(raw.decode("utf-8"))
@@ -295,9 +297,7 @@ def load_featurecollection(data: Any) -> dict[str, Any]:
             if not path.is_file():
                 raise ValueError(f"GeoJSON file not found: {text}")
             if path.stat().st_size > _MAX_GEOJSON_BYTES:
-                raise ValueError(
-                    f"GeoJSON file exceeds the 50 MB size limit: {text}"
-                )
+                raise ValueError(f"GeoJSON file exceeds the 50 MB size limit: {text}")
             data = json.loads(path.read_text(encoding="utf-8"))
 
     if not isinstance(data, dict) or "type" not in data:

--- a/python/src/geolibre/project.py
+++ b/python/src/geolibre/project.py
@@ -103,9 +103,9 @@ def build_empty_project(
     """
     map_view = default_map_view()
     if center is not None:
-        if len(center) < 2:
+        if len(center) != 2:
             raise ValueError(
-                "center must be a [lng, lat] sequence with 2 elements"
+                "center must be a [lng, lat] sequence with exactly 2 elements"
             )
         map_view["center"] = [float(center[0]), float(center[1])]
     if zoom is not None:
@@ -228,7 +228,9 @@ def cog_layer(
         A layer dict for the project's ``layers`` array.
     """
     layer = _layer_base(name, "cog", **style)
-    raster_state: dict[str, Any] = {"rescale": rescale}
+    raster_state: dict[str, Any] = {}
+    if rescale is not None:
+        raster_state["rescale"] = rescale
     if bands is not None:
         raster_state["bands"] = bands
         raster_state["mode"] = "rgb" if len(bands) >= 3 else "single"
@@ -305,6 +307,8 @@ def load_featurecollection(data: Any) -> dict[str, Any]:
 
     geom_type = data["type"]
     if geom_type == "FeatureCollection":
+        if not isinstance(data.get("features"), list):
+            raise ValueError("FeatureCollection must have a 'features' list")
         return data
     if geom_type == "Feature":
         return {"type": "FeatureCollection", "features": [data]}

--- a/python/src/geolibre/project.py
+++ b/python/src/geolibre/project.py
@@ -268,8 +268,15 @@ def load_featurecollection(data: Any) -> dict[str, Any]:
     if isinstance(data, str):
         text = data.strip()
         if text.startswith(("http://", "https://")):
-            with urlopen(text) as response:  # noqa: S310 - user-provided URL
-                data = json.loads(response.read().decode("utf-8"))
+            # Bound the request so a slow or oversized response cannot hang the
+            # kernel or exhaust memory. read(limit + 1) detects an over-limit
+            # body without buffering the whole thing.
+            limit = 50 * 1024 * 1024  # 50 MB
+            with urlopen(text, timeout=30) as response:  # noqa: S310 - user URL
+                raw = response.read(limit + 1)
+            if len(raw) > limit:
+                raise ValueError("GeoJSON response exceeds the 50 MB size limit")
+            data = json.loads(raw.decode("utf-8"))
         elif text.startswith(("{", "[")):
             data = json.loads(text)
         else:

--- a/python/src/geolibre/project.py
+++ b/python/src/geolibre/project.py
@@ -9,12 +9,15 @@ a project produced entirely from Python.
 from __future__ import annotations
 
 import copy
+import ipaddress
 import json
+import socket
 import uuid
 from pathlib import Path
 from typing import Any
 from urllib.error import URLError
-from urllib.request import urlopen
+from urllib.parse import urlsplit
+from urllib.request import HTTPRedirectHandler, build_opener
 
 from .basemaps import DEFAULT_BASEMAP
 
@@ -23,6 +26,49 @@ PROJECT_VERSION = "0.1.0"
 # Cap GeoJSON inputs (URL fetches and local files alike) so a huge source cannot
 # silently exhaust kernel memory when inlined into the project.
 _MAX_GEOJSON_BYTES = 50 * 1024 * 1024  # 50 MB
+
+
+def _assert_public_url(url: str) -> None:
+    """Reject a URL whose host resolves to a non-public address.
+
+    Guards the kernel-side fetch against SSRF: without this a redirect (or a
+    crafted URL) could reach a private/loopback/link-local address such as a
+    cloud metadata endpoint (``169.254.169.254``) and inline the response into
+    the project. Every address the host resolves to must be globally routable.
+
+    Args:
+        url: The URL about to be fetched (or a redirect target).
+
+    Raises:
+        ValueError: If the host is missing, unresolvable, or maps to any
+            non-public address.
+    """
+    host = urlsplit(url).hostname
+    if not host:
+        raise ValueError(f"URL has no host: {url}")
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror as exc:
+        raise ValueError(f"Could not resolve host for URL: {url}") from exc
+    for info in infos:
+        ip = ipaddress.ip_address(info[4][0])
+        if not ip.is_global:
+            raise ValueError(
+                f"Refusing to fetch from a non-public address ({ip}): {url}"
+            )
+
+
+class _PublicOnlyRedirectHandler(HTTPRedirectHandler):
+    """Redirect handler that re-validates every hop against ``_assert_public_url``."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001, D102
+        _assert_public_url(newurl)
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+# Opener used for all remote GeoJSON fetches: follows redirects but rejects any
+# hop that points at a non-public address (SSRF defence).
+_GEOJSON_OPENER = build_opener(_PublicOnlyRedirectHandler)
 
 # Mirror of DEFAULT_LAYER_STYLE in packages/core/src/types.ts. The app fills in
 # any missing fields on load, so layers only need to override what differs, but
@@ -126,7 +172,10 @@ def build_empty_project(
 
 
 def _layer_base(name: str, layer_type: str, **style: Any) -> dict[str, Any]:
-    merged_style = {**DEFAULT_LAYER_STYLE, **style}
+    # Deep-copy the defaults so nested values (e.g. the vectorStyleStops list)
+    # are not shared with the module constant; a caller mutating a returned
+    # layer's style must not corrupt DEFAULT_LAYER_STYLE for later layers.
+    merged_style = {**copy.deepcopy(DEFAULT_LAYER_STYLE), **style}
     return {
         "id": str(uuid.uuid4()),
         "name": name,
@@ -280,11 +329,15 @@ def load_featurecollection(data: Any) -> dict[str, Any]:
     if isinstance(data, str):
         text = data.strip()
         if text.startswith(("http://", "https://")):
+            # Reject non-public hosts up front, then fetch through an opener that
+            # re-checks every redirect hop, so a redirect to a private/metadata
+            # address cannot be followed (SSRF defence).
+            _assert_public_url(text)
             # Bound the request so a slow or oversized response cannot hang the
             # kernel or exhaust memory. read(limit + 1) detects an over-limit
             # body without buffering the whole thing.
             try:
-                with urlopen(text, timeout=30) as response:  # noqa: S310 - user URL
+                with _GEOJSON_OPENER.open(text, timeout=30) as response:  # noqa: S310 - user URL
                     raw = response.read(_MAX_GEOJSON_BYTES + 1)
             except (URLError, TimeoutError) as exc:
                 # Normalize transport failures to the documented ValueError

--- a/python/src/geolibre/project.py
+++ b/python/src/geolibre/project.py
@@ -8,6 +8,7 @@ a project produced entirely from Python.
 
 from __future__ import annotations
 
+import copy
 import json
 import uuid
 from pathlib import Path
@@ -119,7 +120,7 @@ def build_empty_project(
         "basemapOpacity": 1,
         "layers": [],
         "styles": {},
-        "preferences": json.loads(json.dumps(DEFAULT_PROJECT_PREFERENCES)),
+        "preferences": copy.deepcopy(DEFAULT_PROJECT_PREFERENCES),
         "metadata": {},
     }
 

--- a/python/tests/test_map.py
+++ b/python/tests/test_map.py
@@ -1,0 +1,27 @@
+"""Tests for Map helpers that do not require a running widget/server."""
+
+from __future__ import annotations
+
+import pytest
+
+from geolibre.geolibre import Map
+
+
+def test_server_proxy_explicit():
+    assert Map._resolve_server_proxy(True) is True
+    assert Map._resolve_server_proxy(False) is False
+
+
+def test_server_proxy_auto_local(monkeypatch):
+    monkeypatch.delenv("JUPYTERHUB_SERVICE_PREFIX", raising=False)
+    assert Map._resolve_server_proxy("auto") is False
+
+
+def test_server_proxy_auto_jupyterhub(monkeypatch):
+    monkeypatch.setenv("JUPYTERHUB_SERVICE_PREFIX", "/user/alice/")
+    assert Map._resolve_server_proxy("auto") is True
+
+
+def test_server_proxy_invalid():
+    with pytest.raises(ValueError):
+        Map._resolve_server_proxy("bogus")

--- a/python/tests/test_project.py
+++ b/python/tests/test_project.py
@@ -1,0 +1,121 @@
+"""Unit tests for the project/layer builders.
+
+These exercise the pure-Python layer construction without needing a browser or
+the bundled web app, so they run in plain CI.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from geolibre import project
+
+POINT_FC = {
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {"name": "A"},
+            "geometry": {"type": "Point", "coordinates": [0, 0]},
+        }
+    ],
+}
+
+
+def test_build_empty_project_defaults():
+    proj = project.build_empty_project()
+    assert proj["version"] == project.PROJECT_VERSION
+    assert proj["mapView"]["center"] == [-100, 40]
+    assert proj["layers"] == []
+    # Preferences must be a fresh copy, not the shared default.
+    assert proj["preferences"] is not project.DEFAULT_PROJECT_PREFERENCES
+
+
+def test_build_empty_project_overrides():
+    proj = project.build_empty_project(center=(10, 20), zoom=7, basemap_url="x")
+    assert proj["mapView"]["center"] == [10.0, 20.0]
+    assert proj["mapView"]["zoom"] == 7.0
+    assert proj["basemapStyleUrl"] == "x"
+
+
+def test_geojson_layer_inlines_data():
+    layer = project.geojson_layer("Pts", POINT_FC, fillColor="#ff0000")
+    assert layer["type"] == "geojson"
+    assert layer["source"] == {"type": "geojson"}
+    assert layer["geojson"] == POINT_FC
+    assert layer["style"]["fillColor"] == "#ff0000"
+    # Unspecified style fields fall back to the defaults.
+    assert layer["style"]["strokeWidth"] == project.DEFAULT_LAYER_STYLE["strokeWidth"]
+
+
+def test_geojson_layer_with_source_url():
+    layer = project.geojson_layer("R", POINT_FC, source_url="https://e/x.geojson")
+    assert layer["source"]["url"] == "https://e/x.geojson"
+    assert layer["sourcePath"] == "https://e/x.geojson"
+
+
+def test_tile_layer_shape():
+    layer = project.tile_layer("OSM", "https://t/{z}/{x}/{y}.png")
+    assert layer["type"] == "xyz"
+    assert layer["source"]["type"] == "raster"
+    assert layer["source"]["tiles"] == ["https://t/{z}/{x}/{y}.png"]
+    assert layer["source"]["tileSize"] == 256
+    assert layer["metadata"]["sourceKind"] == "xyz-url"
+
+
+def test_cog_layer_restore_shape():
+    layer = project.cog_layer(
+        "DEM", "https://e/dem.tif", bands=[1, 2, 3], colormap="terrain"
+    )
+    assert layer["type"] == "cog"
+    assert layer["source"] == {"type": "raster", "url": "https://e/dem.tif"}
+    md = layer["metadata"]
+    assert md["sourceKind"] == "maplibre-gl-raster"
+    assert md["rasterSource"] == "url"
+    assert md["externalNativeLayer"] is True
+    assert md["nativeLayerIds"] == [layer["id"]]
+    assert md["rasterState"]["bands"] == [1, 2, 3]
+    assert md["rasterState"]["mode"] == "rgb"
+    assert md["rasterState"]["colormap"] == "terrain"
+
+
+def test_load_featurecollection_passthrough():
+    assert project.load_featurecollection(POINT_FC) is POINT_FC
+
+
+def test_load_featurecollection_wraps_feature():
+    feature = POINT_FC["features"][0]
+    fc = project.load_featurecollection(feature)
+    assert fc["type"] == "FeatureCollection"
+    assert fc["features"] == [feature]
+
+
+def test_load_featurecollection_wraps_geometry():
+    fc = project.load_featurecollection({"type": "Point", "coordinates": [1, 2]})
+    assert fc["features"][0]["geometry"]["coordinates"] == [1, 2]
+
+
+def test_load_featurecollection_from_json_string():
+    fc = project.load_featurecollection(json.dumps(POINT_FC))
+    assert fc["features"][0]["properties"]["name"] == "A"
+
+
+def test_load_featurecollection_from_file(tmp_path):
+    path = tmp_path / "pts.geojson"
+    path.write_text(json.dumps(POINT_FC), encoding="utf-8")
+    fc = project.load_featurecollection(str(path))
+    assert fc == POINT_FC
+
+
+def test_load_featurecollection_geo_interface():
+    class Fake:
+        __geo_interface__ = POINT_FC
+
+    assert project.load_featurecollection(Fake()) == POINT_FC
+
+
+def test_load_featurecollection_invalid():
+    with pytest.raises(ValueError):
+        project.load_featurecollection(42)

--- a/scripts/build-embed.mjs
+++ b/scripts/build-embed.mjs
@@ -1,0 +1,52 @@
+// Build the GeoLibre web app for embedding (Jupyter widget / standalone HTML)
+// and stage it into the Python package.
+//
+// The embed build differs from the normal web build in one load-bearing way:
+// it sets `GEOLIBRE_APP_BASE=./` so every asset, favicon, and bundled-plugin
+// URL in the emitted index.html is relative. That lets the app load from
+// inside a Python wheel (served from an arbitrary, content-hashed location)
+// instead of the site root.
+//
+// Output: apps/geolibre-desktop/dist-embed/ -> copied to
+// python/src/geolibre/static/app/.
+
+import { spawnSync } from "node:child_process";
+import { cpSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const distDir = resolve(repoRoot, "apps/geolibre-desktop/dist-embed");
+const staticDir = resolve(repoRoot, "python/src/geolibre/static/app");
+
+const result = spawnSync(
+  "npm",
+  ["run", "build", "-w", "geolibre-desktop", "--", "--outDir", "dist-embed"],
+  {
+    cwd: repoRoot,
+    shell: process.platform === "win32",
+    stdio: "inherit",
+    env: { ...process.env, GEOLIBRE_APP_BASE: "./" },
+  },
+);
+
+if (result.status !== 0) {
+  process.exit(result.status ?? 1);
+}
+
+// Guard the one thing that silently breaks the wheel: if the base path was not
+// applied, index.html references /assets/... and the iframe loads a blank page.
+const indexHtml = readFileSync(resolve(distDir, "index.html"), "utf8");
+if (/\b(?:src|href)="\/(?!\/)/.test(indexHtml)) {
+  console.error(
+    "[build-embed] dist-embed/index.html has absolute asset paths. " +
+      "GEOLIBRE_APP_BASE=./ was not applied; the embedded app would 404.",
+  );
+  process.exit(1);
+}
+
+rmSync(staticDir, { recursive: true, force: true });
+mkdirSync(staticDir, { recursive: true });
+cpSync(distDir, staticDir, { recursive: true });
+
+console.log(`[build-embed] Staged embed build into ${staticDir}`);


### PR DESCRIPTION
## Summary

Adds **`geolibre`**, a Python package that embeds the full GeoLibre app in a Jupyter notebook cell as an [anywidget](https://anywidget.dev), with a leafmap-style API and two-way `.geolibre.json` project sync.

```python
from geolibre import Map
m = Map(center=(-100, 40), zoom=4)
m.add_geojson("https://example.com/data.geojson", name="Data")
m.add_cog("https://example.com/dem.tif", name="DEM")
m   # the full GeoLibre UI renders in the cell
```

UI edits flow back to Python (`m.to_project()`), and projects round-trip with the desktop/web apps (`save_project` / `load_project`).

## How it works

The wheel bundles the GeoLibre web build. At import the package starts a localhost static server that serves the bundled app; the widget renders it in an `<iframe>` and exchanges the project over `window.postMessage`. Loop prevention lives on the host side (a project received from the app is never echoed back into the iframe).

## Changes

**App side (additive, minimal)**
- New `useEmbedBridge` hook: applies `geolibre:load-project` via the existing `loadProject`, and emits debounced `geolibre:state` snapshots built with the existing `projectFromStore`. Wired into `DesktopShell`.
- New `build:embed` script builds with `GEOLIBRE_APP_BASE=./` so assets resolve from inside the wheel (asserts relative paths).

**Python package (`python/`)**
- `Map` widget + leafmap-style API: `add_geojson`, `add_tile_layer`, `add_cog`, `add_basemap`, `set_center`, `remove_layer`, `clear_layers`, `to_project`/`load_project`/`save_project`.
- Project/layer builders mirroring `packages/core` interfaces, named basemaps, localhost app server, and the postMessage bridge front-end.
- Hatch build hook bundles the web build into the wheel.

**CI / docs**
- `publish-python.yml`: tests on PRs; publishes to PyPI via OIDC trusted publishing on release.
- README section, `docs/python.md` guide, mkdocs nav entry, home feature card, and a v1.0 roadmap item.

## Verification

- Embed build emits relative asset paths (asserted in the build script).
- TypeScript typecheck clean; full `pre-commit run --all-files` (incl. `npm-build`) passes.
- 13 Python unit tests pass.
- Real-browser bridge round-trip (headless Chromium): `geolibre:ready` -> posted a project -> received a `geolibre:state` echo containing the loaded layer and center.
- Wheel builds at ~26 MB (under PyPI's 100 MB limit) and bundles the app.

## Notes / limitations

- The interactive widget works in local Jupyter and VS Code. Remote setups (JupyterHub, Colab) where the browser cannot reach the kernel's `localhost` are not yet supported.
- First-class layer types from project JSON today: `geojson`, XYZ tiles, COG. PMTiles and the vector-tile plugin types are created by runtime plugin panels and were intentionally left out of the initial API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Python package for Jupyter: Map widget with add/remove layers, basemaps, COGs, view control, project I/O, and bidirectional sync with the web app.
  * Embed host↔app postMessage bridge and iframe integration with resize handling.
  * Local bundled static server to serve the embedded app inside notebooks.

* **Documentation**
  * Full Python/Jupyter docs, quickstart, API reference, README updates, and example notebook.

* **Tests**
  * Pytest coverage for project/layer builders and GeoJSON loading.

* **Chores**
  * CI workflow to build/publish the Python package and embed build script; updated ignore rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->