### PR TITLE
docs: add Update section for updating from source

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ npm run dev            # web dev server → http://localhost:5173
 npm run tauri:dev      # desktop app (required for filesystem dialogs, local MBTiles, local raster reads)
 npm run build          # production web build → apps/geolibre-desktop/dist/
 npm run tauri:build    # desktop installers → apps/geolibre-desktop/src-tauri/target/release/bundle/
-npm run typecheck      # alias for the build (tsc -b && vite build)
+npm run typecheck      # alias for the full build (tsc -b && vite build) — writes to dist/, not a pure type-check
 npm run ci             # full local gate: build + frontend + worker + backend + rust check
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository shape
+
+GeoLibre is a single **npm workspaces monorepo** (`apps/*`, `packages/*`, `workers/*`) plus two non-npm components: a Python FastAPI sidecar (`backend/geolibre_server`) and a separate Python package (`python/`, the `geolibre` Jupyter anywidget). One `npm install` at the root wires up every JS workspace. Use **npm** (the repo tracks `package-lock.json`), Node **22+**.
+
+The same React app ships three ways: native desktop via **Tauri v2** (`apps/geolibre-desktop/src-tauri`), a browser web build served by nginx (Docker), and embedded in Jupyter (the `python/` package bundles a build of the web app into its wheel).
+
+## Commands
+
+```bash
+npm run dev            # web dev server → http://localhost:5173
+npm run tauri:dev      # desktop app (required for filesystem dialogs, local MBTiles, local raster reads)
+npm run build          # production web build → apps/geolibre-desktop/dist/
+npm run tauri:build    # desktop installers → apps/geolibre-desktop/src-tauri/target/release/bundle/
+npm run typecheck      # alias for the build (tsc -b && vite build)
+npm run ci             # full local gate: build + frontend + worker + backend + rust check
+```
+
+Tests:
+
+```bash
+npm run test:frontend                              # node --test over tests/*.test.ts (tsx loader)
+node --import tsx --test tests/<name>.test.ts      # a single frontend test file
+npm run test:backend                               # pytest backend/geolibre_server/tests
+python -m pytest backend/geolibre_server/tests/test_x.py::test_y   # a single backend test
+npm run test:worker                                # typecheck workers/viewer
+npm run check:rust                                 # cargo check the Tauri crate
+```
+
+The `python/` package has its own pytest suite (`cd python && pytest`) and is built into a wheel via `npm run build:embed` (produces `apps/geolibre-desktop/dist-embed`, consumed by `python/hatch_build.py`). Its version is dynamic, sourced from `python/src/geolibre/__init__.py`.
+
+## Pre-commit
+
+`.pre-commit-config.yaml` includes a **local `npm-build` hook**, so `pre-commit run` compiles the whole app — it is slow and can touch unrelated build state. Scope it to the files you changed: `pre-commit run --files <paths>`. Run it before pushing.
+
+## Architecture (the parts that span files)
+
+The app is **store-driven**. `@geolibre/core` holds the Zustand store, domain types, and the `.geolibre.json` project schema — it is the single source of truth. Data flows one way:
+
+1. Data enters through the Add Data menus, Tauri dialogs, the browser file picker, drag-and-drop, or a plugin control.
+2. Local vector files that MapLibre can't render directly are converted to GeoJSON in-browser by **DuckDB-WASM Spatial** (`INSTALL spatial; LOAD spatial;` → `ST_Read`; GeoParquet via the Parquet reader; zipped Shapefiles via `shpjs` with a DuckDB fallback; KMZ unzipped client-side). The result calls `addGeoJsonLayer`.
+3. Tile/service/raster/ArcGIS/MBTiles/plugin layers become `GeoLibreLayer` records.
+4. `MapCanvas` subscribes to `layers`; `MapController.syncLayers` (`@geolibre/map`) reconciles MapLibre sources/layers and the layer control. **You don't mutate MapLibre directly from UI** — you change store state and let sync apply it.
+
+Rendering is MapLibre GL JS in the webview, with **deck.gl** for raster/point-cloud/3D overlays.
+
+**Packages:** `@geolibre/core` (types, project format, store) · `@geolibre/map` (MapLibre lifecycle + layer sync) · `@geolibre/ui` (shadcn-style primitives) · `@geolibre/processing` (client-side algorithm registry) · `@geolibre/plugins` (plugin interface + built-in plugins) · `geolibre-desktop` (shell layout, Tauri I/O, composition).
+
+**Plugins:** Built-in plugins live in `packages/plugins/src/plugins/`, are exported from that package's `index.ts`, and registered in `apps/geolibre-desktop/src/hooks/usePlugins.ts`. External plugins load from zips or a `plugin.json` manifest; bundled drop-ins under `apps/geolibre-desktop/public/plugins/<id>/` bake into both web and desktop builds. See `docs/plugin-api.md`.
+
+**Python sidecar** (`backend/geolibre_server`, FastAPI on `127.0.0.1:8765`): backs the Whitebox toolbox, format Conversion tools, and Raster tools (rasterio). The desktop app starts it on demand. It is **optional** — Vector tools (Processing → Vector) run client-side with Turf.js and only use the sidecar's `/vector` endpoints (GeoPandas/Shapely) when the optional `vector` extra is installed; the dialog falls back to the client engine via `/vector/status`. Optional extras: `conversion`, `vector`, `raster`. Some conversions (PMTiles, Whitebox) are amd64-only.
+
+The browser build proxies the sidecar at `/sidecar` (same-origin, no CORS); confined to `GEOLIBRE_CONVERSION_ROOTS` (default `/data`). Local MBTiles use a custom MapLibre protocol backed by Tauri commands.
+
+## Conventions
+
+- Never commit directly to `main`; branch and open a PR.
+- Tauri CSP allowlists tile/style hosts (OpenFreeMap, CARTO) — new external map/tile hosts must be added there.
+- Map/tile-host CORS for selected release assets is handled by a dev-server raster proxy.
+- For MapLibre control styling fixes, add scoped overrides in `apps/geolibre-desktop/src/index.css`, never edit `node_modules`.
+- Reference docs: `docs/architecture.md`, `docs/project-format.md`, `docs/plugin-api.md`, `docs/python.md`, `docs/contributing.md`.

--- a/README.md
+++ b/README.md
@@ -291,6 +291,11 @@ npm run build
 npm run tauri:build
 ```
 
+Where to find the output:
+
+- **Web build** — static files in `apps/geolibre-desktop/dist/`. Serve this directory with any static web server (or the Docker image above).
+- **Desktop installers** — `apps/geolibre-desktop/src-tauri/target/release/bundle/`, with per-platform subfolders: `deb/`, `rpm/`, and `appimage/` on Linux; `msi/` and `nsis/` on Windows; `dmg/` and `macos/` on macOS. The unbundled executable is in `apps/geolibre-desktop/src-tauri/target/release/`. On Linux, `npm run tauri:build` builds `deb` and `rpm` by default; pass targets explicitly to build others, for example `npm run tauri:build -- --bundles appimage`.
+
 ## Quality checks
 
 Run the fast TypeScript unit tests:

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ Bun users can run `bun install`. The root `trustedDependencies` list allows the 
 To update an existing source checkout to the latest version, pull the changes, reinstall dependencies (in case `package.json` changed), and rebuild:
 
 ```bash
-cd GeoLibre          # your GeoLibre folder
+cd /path/to/GeoLibre   # your GeoLibre checkout
 git pull origin main
-npm install          # or: bun install
-npm run build        # web build; use npm run tauri:build for the desktop app
+npm install            # or: bun install
+npm run build          # production web build only; use npm run tauri:build for the desktop app. Skip if you run npm run dev / npm run tauri:dev
 ```
 
 The `npm run build` (or `npm run tauri:build`) step is only needed if you run a production build. If you work from the dev servers (`npm run dev` or `npm run tauri:dev`), `git pull` followed by `npm install` is enough — restart the dev server to pick up the changes.
@@ -294,7 +294,7 @@ npm run tauri:build
 Where to find the output:
 
 - **Web build** — static files in `apps/geolibre-desktop/dist/`. Serve this directory with any static web server (or the Docker image above).
-- **Desktop installers** — `apps/geolibre-desktop/src-tauri/target/release/bundle/`, with per-platform subfolders: `deb/`, `rpm/`, and `appimage/` on Linux; `msi/` and `nsis/` on Windows; `dmg/` and `macos/` on macOS. The unbundled executable is in `apps/geolibre-desktop/src-tauri/target/release/`. On Linux, `npm run tauri:build` builds `deb` and `rpm` by default; pass targets explicitly to build others, for example `npm run tauri:build -- --bundles appimage`.
+- **Desktop installers** — `apps/geolibre-desktop/src-tauri/target/release/bundle/`, with per-platform subfolders: `deb/`, `rpm/`, and `appimage/` on Linux; `msi/` and `nsis/` on Windows; `dmg/` and `macos/` on macOS. The unbundled executable is in `apps/geolibre-desktop/src-tauri/target/release/`. On Linux, `npm run tauri:build` builds `deb` and `rpm` by default; passing `--bundles` replaces that default selection rather than adding to it, so list every format you want, for example `npm run tauri:build -- --bundles deb,rpm,appimage` for all three.
 
 ## Quality checks
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To update an existing source checkout to the latest version, pull the changes, r
 ```bash
 cd GeoLibre          # your GeoLibre folder
 git pull origin main
-npm install
+npm install          # or: bun install
 npm run build        # web build; use npm run tauri:build for the desktop app
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,19 @@ npm install
 
 Bun users can run `bun install`. The root `trustedDependencies` list allows the known install scripts for `core-js`, `@google/genai`, and `protobufjs`.
 
+## Update
+
+To update an existing source checkout to the latest version, pull the changes, reinstall dependencies (in case `package.json` changed), and rebuild:
+
+```bash
+cd GeoLibre          # your GeoLibre folder
+git pull origin main
+npm install
+npm run build        # web build; use npm run tauri:build for the desktop app
+```
+
+The `npm run build` (or `npm run tauri:build`) step is only needed if you run a production build. If you work from the dev servers (`npm run dev` or `npm run tauri:dev`), `git pull` followed by `npm install` is enough — restart the dev server to pick up the changes.
+
 ## Run (web dev, map in browser)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -60,10 +60,9 @@ To update an existing source checkout to the latest version, pull the changes, r
 cd /path/to/GeoLibre   # your GeoLibre checkout
 git pull origin main
 npm install            # or: bun install
-npm run build          # production web build only; use npm run tauri:build for the desktop app. Skip if you run npm run dev / npm run tauri:dev
 ```
 
-The `npm run build` (or `npm run tauri:build`) step is only needed if you run a production build. If you work from the dev servers (`npm run dev` or `npm run tauri:dev`), `git pull` followed by `npm install` is enough — restart the dev server to pick up the changes.
+If you run a production build, rebuild afterwards with `npm run build` (web) or `npm run tauri:build` (desktop). If you work from the dev servers (`npm run dev` or `npm run tauri:dev`), the `git pull` and `npm install` above are enough — just restart the dev server to pick up the changes.
 
 ## Run (web dev, map in browser)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -80,6 +80,11 @@ npm run build
 npm run tauri:build
 ```
 
+Where to find the output:
+
+- **Web build** — static files in `apps/geolibre-desktop/dist/`. Serve this directory with any static web server (or the Docker image above).
+- **Desktop installers** — `apps/geolibre-desktop/src-tauri/target/release/bundle/`, with per-platform subfolders: `deb/`, `rpm/`, and `appimage/` on Linux; `msi/` and `nsis/` on Windows; `dmg/` and `macos/` on macOS. The unbundled executable is in `apps/geolibre-desktop/src-tauri/target/release/`. On Linux, `npm run tauri:build` builds `deb` and `rpm` by default; pass targets explicitly to build others, for example `npm run tauri:build -- --bundles appimage`.
+
 ## Optional imagery credentials
 
 The Street View plugin can use Google Street View and Mapillary imagery. Create `apps/geolibre-desktop/.env.local` and set one or both provider credentials:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,10 +23,10 @@ Bun users can run `bun install`. The root `trustedDependencies` list allows the 
 To update an existing source checkout to the latest version, pull the changes, reinstall dependencies (in case `package.json` changed), and rebuild:
 
 ```bash
-cd GeoLibre          # your GeoLibre folder
+cd /path/to/GeoLibre   # your GeoLibre checkout
 git pull origin main
-npm install          # or: bun install
-npm run build        # web build; use npm run tauri:build for the desktop app
+npm install            # or: bun install
+npm run build          # production web build only; use npm run tauri:build for the desktop app. Skip if you run npm run dev / npm run tauri:dev
 ```
 
 The `npm run build` (or `npm run tauri:build`) step is only needed for a production build. If you work from the dev servers (`npm run dev` or `npm run tauri:dev`), `git pull` followed by `npm install` is enough — restart the dev server to pick up the changes.
@@ -83,7 +83,7 @@ npm run tauri:build
 Where to find the output:
 
 - **Web build** — static files in `apps/geolibre-desktop/dist/`. Serve this directory with any static web server (or the Docker image above).
-- **Desktop installers** — `apps/geolibre-desktop/src-tauri/target/release/bundle/`, with per-platform subfolders: `deb/`, `rpm/`, and `appimage/` on Linux; `msi/` and `nsis/` on Windows; `dmg/` and `macos/` on macOS. The unbundled executable is in `apps/geolibre-desktop/src-tauri/target/release/`. On Linux, `npm run tauri:build` builds `deb` and `rpm` by default; pass targets explicitly to build others, for example `npm run tauri:build -- --bundles appimage`.
+- **Desktop installers** — `apps/geolibre-desktop/src-tauri/target/release/bundle/`, with per-platform subfolders: `deb/`, `rpm/`, and `appimage/` on Linux; `msi/` and `nsis/` on Windows; `dmg/` and `macos/` on macOS. The unbundled executable is in `apps/geolibre-desktop/src-tauri/target/release/`. On Linux, `npm run tauri:build` builds `deb` and `rpm` by default; passing `--bundles` replaces that default selection rather than adding to it, so list every format you want, for example `npm run tauri:build -- --bundles deb,rpm,appimage` for all three.
 
 ## Optional imagery credentials
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,6 +18,19 @@ npm install
 
 Bun users can run `bun install`. The root `trustedDependencies` list allows the known install scripts for `core-js`, `@google/genai`, and `protobufjs`.
 
+## Update
+
+To update an existing source checkout to the latest version, pull the changes, reinstall dependencies (in case `package.json` changed), and rebuild:
+
+```bash
+cd GeoLibre          # your GeoLibre folder
+git pull origin main
+npm install
+npm run build        # web build; use npm run tauri:build for the desktop app
+```
+
+The build step is only needed for a production build. If you work from the dev servers (`npm run dev` or `npm run tauri:dev`), `git pull` followed by `npm install` is enough — restart the dev server to pick up the changes.
+
 ## Run the browser UI
 
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,11 +25,11 @@ To update an existing source checkout to the latest version, pull the changes, r
 ```bash
 cd GeoLibre          # your GeoLibre folder
 git pull origin main
-npm install
+npm install          # or: bun install
 npm run build        # web build; use npm run tauri:build for the desktop app
 ```
 
-The build step is only needed for a production build. If you work from the dev servers (`npm run dev` or `npm run tauri:dev`), `git pull` followed by `npm install` is enough — restart the dev server to pick up the changes.
+The `npm run build` (or `npm run tauri:build`) step is only needed for a production build. If you work from the dev servers (`npm run dev` or `npm run tauri:dev`), `git pull` followed by `npm install` is enough — restart the dev server to pick up the changes.
 
 ## Run the browser UI
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,10 +26,9 @@ To update an existing source checkout to the latest version, pull the changes, r
 cd /path/to/GeoLibre   # your GeoLibre checkout
 git pull origin main
 npm install            # or: bun install
-npm run build          # production web build only; use npm run tauri:build for the desktop app. Skip if you run npm run dev / npm run tauri:dev
 ```
 
-The `npm run build` (or `npm run tauri:build`) step is only needed for a production build. If you work from the dev servers (`npm run dev` or `npm run tauri:dev`), `git pull` followed by `npm install` is enough — restart the dev server to pick up the changes.
+If you run a production build, rebuild afterwards with `npm run build` (web) or `npm run tauri:build` (desktop). If you work from the dev servers (`npm run dev` or `npm run tauri:dev`), the `git pull` and `npm install` above are enough — just restart the dev server to pick up the changes.
 
 ## Run the browser UI
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -12,7 +12,7 @@ license = "MIT"
 authors = [{ name = "Qiusheng Wu", email = "giswqs@gmail.com" }]
 keywords = ["geolibre", "gis", "maplibre", "jupyter", "anywidget", "mapping"]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Framework :: Jupyter",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",

--- a/python/src/geolibre/__init__.py
+++ b/python/src/geolibre/__init__.py
@@ -2,5 +2,5 @@
 
 from .geolibre import Map
 
-__version__ = "0.2.0"
+__version__ = "1.0.0"
 __all__ = ["Map", "__version__"]


### PR DESCRIPTION
## Summary

Closes #198.

Adds an **Update** section to both the README and the Getting Started docs explaining how to update an existing source checkout, plus notes on where build output and installers land. Also includes two related maintenance changes (see below).

```bash
cd /path/to/GeoLibre   # your GeoLibre checkout
git pull origin main
npm install            # or: bun install
npm run build          # production web build only; skip if using the dev servers
```

## Files changed

- `README.md` — new `## Update` section; build-output/installer locations
- `docs/getting-started.md` — same additions for the docs site
- `CLAUDE.md` — new repo guide for Claude Code (monorepo commands + architecture)
- `python/src/geolibre/__init__.py` — bump `geolibre` package version `0.2.0 → 1.0.0` to match the app's 1.0.0 release (root `package.json` / `tauri.conf.json` are already `1.0.0`)
- `python/pyproject.toml` — Trove classifier `4 - Beta → 5 - Production/Stable` for the 1.0.0 milestone

## Testing

- `pre-commit run --files <changed files>` — all hooks pass (including the npm build hook)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added update instructions for existing checkouts, clarified when full rebuilds are needed vs. restarting dev servers, and documented locations of web and desktop build outputs and executables.
  * Added a new repository guidance document covering workspace layout, primary commands, architecture notes, build/test flow, and contribution conventions.
* **Chores**
  * Project version advanced to 1.0.0 and package status updated to production/stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->