### PR TITLE
Expose the host deck.gl to external plugins via app.getDeckGL

### DIFF
--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -397,6 +397,15 @@ export function createAppAPI(
     ) =>
       mapControllerRef?.current?.setBuiltInControlPosition(control, position) ??
       false,
+    // Hand external plugins GeoLibre's own deck.gl modules so they render on the
+    // host's single deck.gl instance (a bundled second copy throws on the
+    // deck.gl/luma.gl version guards and fails to render).
+    getDeckGL: () =>
+      Promise.all([
+        import("@deck.gl/core"),
+        import("@deck.gl/layers"),
+        import("@deck.gl/mapbox"),
+      ]).then(([core, layers, mapbox]) => ({ core, layers, mapbox })),
   };
 }
 

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -23,6 +23,7 @@ import {
 } from "@geolibre/plugins";
 import type { MapController } from "@geolibre/map";
 import type {
+  GeoLibreDeckGL,
   GeoLibreExternalNativeLayerRegistration,
   GeoLibreFileDialogOptions,
   GeoLibreMapControlPosition,
@@ -399,13 +400,25 @@ export function createAppAPI(
       false,
     // Hand external plugins GeoLibre's own deck.gl modules so they render on the
     // host's single deck.gl instance (a bundled second copy throws on the
-    // deck.gl/luma.gl version guards and fails to render).
-    getDeckGL: () =>
-      Promise.all([
-        import("@deck.gl/core"),
-        import("@deck.gl/layers"),
-        import("@deck.gl/mapbox"),
-      ]).then(([core, layers, mapbox]) => ({ core, layers, mapbox })),
+    // deck.gl/luma.gl version guards and fails to render). Memoized so repeated
+    // calls reuse one resolved module set.
+    getDeckGL: (() => {
+      let cached: Promise<GeoLibreDeckGL> | undefined;
+      return () =>
+        (cached ??= Promise.all([
+          import("@deck.gl/core"),
+          import("@deck.gl/layers"),
+          import("@deck.gl/geo-layers"),
+          import("@deck.gl/mesh-layers"),
+          import("@deck.gl/mapbox"),
+        ]).then(([core, layers, geoLayers, meshLayers, mapbox]) => ({
+          core,
+          layers,
+          geoLayers,
+          meshLayers,
+          mapbox,
+        })));
+    })(),
   };
 }
 

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -49,6 +49,17 @@ export interface GeoLibreFileDialogOptions {
   mimeType?: string;
 }
 
+/**
+ * GeoLibre's own deck.gl modules, handed to a plugin via
+ * {@link GeoLibreAppAPI.getDeckGL}. Lets an external plugin render deck.gl
+ * layers using the host's single deck.gl instance instead of bundling its own.
+ */
+export interface GeoLibreDeckGL {
+  core: typeof import("@deck.gl/core");
+  layers: typeof import("@deck.gl/layers");
+  mapbox: typeof import("@deck.gl/mapbox");
+}
+
 export interface GeoLibreAppAPI {
   setBasemap: (styleUrl: string) => void;
   addGeoJsonLayer: (
@@ -123,6 +134,14 @@ export interface GeoLibreAppAPI {
     control: GeoLibreBuiltInMapControl,
     position: GeoLibreMapControlPosition,
   ) => boolean;
+  /**
+   * Resolve GeoLibre's own deck.gl modules so an external plugin can render
+   * deck.gl layers (e.g. an `ArcLayer`) on the host's single deck.gl instance.
+   * Bundling a second copy is not viable: deck.gl and luma.gl throw on a
+   * version mismatch and share global singletons, so a plugin's own copy fails
+   * to render. Present only on hosts that ship deck.gl.
+   */
+  getDeckGL?: () => Promise<GeoLibreDeckGL>;
 }
 
 export interface GeoLibrePlugin {

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -55,8 +55,15 @@ export interface GeoLibreFileDialogOptions {
  * layers using the host's single deck.gl instance instead of bundling its own.
  */
 export interface GeoLibreDeckGL {
+  /** `@deck.gl/core` (Deck, the Layer base classes, view/state helpers). */
   core: typeof import("@deck.gl/core");
+  /** `@deck.gl/layers` (ArcLayer, ScatterplotLayer, GeoJsonLayer, ...). */
   layers: typeof import("@deck.gl/layers");
+  /** `@deck.gl/geo-layers` (TileLayer, H3HexagonLayer, S2Layer, ...). */
+  geoLayers: typeof import("@deck.gl/geo-layers");
+  /** `@deck.gl/mesh-layers` (SimpleMeshLayer, ScenegraphLayer). */
+  meshLayers: typeof import("@deck.gl/mesh-layers");
+  /** `@deck.gl/mapbox` - use `mapbox.MapboxOverlay` for interleaved MapLibre rendering. */
   mapbox: typeof import("@deck.gl/mapbox");
 }
 
@@ -139,7 +146,9 @@ export interface GeoLibreAppAPI {
    * deck.gl layers (e.g. an `ArcLayer`) on the host's single deck.gl instance.
    * Bundling a second copy is not viable: deck.gl and luma.gl throw on a
    * version mismatch and share global singletons, so a plugin's own copy fails
-   * to render. Present only on hosts that ship deck.gl.
+   * to render. Always present on the GeoLibre desktop and web hosts; typed
+   * optional for forward-compatibility with host variants that may not ship
+   * deck.gl, so plugins should still call it with optional chaining.
    */
   getDeckGL?: () => Promise<GeoLibreDeckGL>;
 }


### PR DESCRIPTION
## Summary
External plugins cannot safely bundle their own deck.gl. deck.gl and luma.gl each throw on a version mismatch with the host and share global singletons (`globalThis.deck` / `globalThis.luma`), so a plugin's second copy either aborts at load or silently fails to render.

This adds an optional `getDeckGL()` to the plugin app API so an external plugin can render deck.gl layers on the host's single deck.gl instance instead of bundling its own.

## Changes
- `packages/plugins/src/types.ts`: add `GeoLibreDeckGL` and an optional `getDeckGL?(): Promise<GeoLibreDeckGL>` on `GeoLibreAppAPI`, resolving the host's `@deck.gl/core`, `@deck.gl/layers`, and `@deck.gl/mapbox` namespaces.
- `apps/geolibre-desktop/src/hooks/usePlugins.ts`: implement it by dynamically importing the host's deck.gl modules.

## Notes
- Backward compatible: the method is optional, so plugins call it with optional chaining and degrade gracefully on hosts without it.
- A plugin that uses this should create its deck overlay in interleaved mode so it renders within MapLibre's pipeline and tracks the active projection.

## Test plan
- [ ] An external plugin can call `app.getDeckGL()` and render a deck.gl layer (e.g. an ArcLayer) that appears on the map.
- [ ] No "deck.gl/luma.gl multiple versions detected" errors when the plugin uses the returned modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin API now exposes a getDeckGL method so external plugins can asynchronously reuse the host’s single deck.gl bundle (core, layers, geo-layers, mesh-layers, mapbox), avoiding duplicate copies and ensuring consistent shared instances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->