### PR TITLE
docs: add conda-forge install and video tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,13 @@ ways through a single `.geolibre.json` project, so data you add from Python
 appears in the UI, and edits you make in the UI are readable back from Python.
 
 ```bash
-pip install geolibre          # or: conda install -c conda-forge geolibre
+pip install geolibre
+```
+
+Or with conda:
+
+```bash
+conda install -c conda-forge geolibre
 ```
 
 ```python

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![GeoLibre plugins](https://img.shields.io/badge/GeoLibre-plugins-green.svg)](https://plugins.geolibre.app)
 [![image](https://img.shields.io/pypi/v/geolibre.svg)](https://pypi.python.org/pypi/geolibre)
 [![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/GeoLibre/blob/main/python/examples/getting-started.ipynb)
+[![image](https://img.shields.io/conda/vn/conda-forge/geolibre.svg)](https://anaconda.org/conda-forge/geolibre)
+[![Conda Recipe](https://img.shields.io/badge/recipe-geolibre-green.svg)](https://github.com/conda-forge/geolibre-feedstock)
 [![Open in CodeSandbox](https://img.shields.io/badge/Open%20in-CodeSandbox-blue?logo=codesandbox)](https://codesandbox.io/p/github/opengeos/geolibre)
 [![Open in StackBlitz](https://img.shields.io/badge/Open%20in-StackBlitz-blue?logo=stackblitz)](https://stackblitz.com/github/opengeos/geolibre)
 [![image](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -15,6 +17,8 @@ A lightweight, cloud-native GIS platform for visualizing, exploring, and analyzi
 GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS**, **DuckDB-WASM Spatial**, and **deck.gl**. The same workspace runs as a native desktop app, in any modern web browser, and adapts responsively to mobile and small screens.
 
 [![GeoLibre demo showing 3D Tiles rendered on a MapLibre map](https://files.opengeos.org/GeoLibre-demo.webp)](https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json)
+
+**Video tutorial:** [GeoLibre 1.0: A Free, Open-Source Cloud-Native GIS That Runs Anywhere (Browser, Desktop & Jupyter)](https://youtu.be/87Cm0QagtxI)
 
 ## Features (v1.0)
 
@@ -245,7 +249,7 @@ ways through a single `.geolibre.json` project, so data you add from Python
 appears in the UI, and edits you make in the UI are readable back from Python.
 
 ```bash
-pip install geolibre
+pip install geolibre          # or: conda install -c conda-forge geolibre
 ```
 
 ```python

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,6 +5,8 @@
 [![GeoLibre plugins](https://img.shields.io/badge/GeoLibre-plugins-green.svg)](https://plugins.geolibre.app)
 [![image](https://img.shields.io/pypi/v/geolibre.svg)](https://pypi.python.org/pypi/geolibre)
 [![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/GeoLibre/blob/main/python/examples/getting-started.ipynb)
+[![image](https://img.shields.io/conda/vn/conda-forge/geolibre.svg)](https://anaconda.org/conda-forge/geolibre)
+[![Conda Recipe](https://img.shields.io/badge/recipe-geolibre-green.svg)](https://github.com/conda-forge/geolibre-feedstock)
 [![Open in CodeSandbox](https://img.shields.io/badge/Open%20in-CodeSandbox-blue?logo=codesandbox)](https://codesandbox.io/p/github/opengeos/geolibre)
 [![Open in StackBlitz](https://img.shields.io/badge/Open%20in-StackBlitz-blue?logo=stackblitz)](https://stackblitz.com/github/opengeos/geolibre)
 [![image](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,6 +11,10 @@
 
 GeoLibre is a lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data across desktop and web environments, with a responsive layout for mobile screens. It is an npm workspaces monorepo: the main app lives in `apps/geolibre-desktop` and is built with Tauri, React, TypeScript, and MapLibre GL JS. The same workspace runs as a native desktop app and as a browser-based web app, and adapts responsively to mobile and small screens.
 
+## Video tutorial
+
+Watch the introduction: [GeoLibre 1.0: A Free, Open-Source Cloud-Native GIS That Runs Anywhere (Browser, Desktop & Jupyter)](https://youtu.be/87Cm0QagtxI)
+
 ## Prerequisites
 
 - Node.js 22 or newer

--- a/docs/python.md
+++ b/docs/python.md
@@ -32,6 +32,9 @@ Optional extras for `add_geojson()` from a GeoDataFrame:
 pip install "geolibre[all]"   # adds GeoPandas and Shapely
 ```
 
+The optional extras (`[all]`, `[hub]`) are pip-only. If you installed via conda,
+add them with `pip install "geolibre[all]"` inside the same environment.
+
 ## Quickstart
 
 ```python

--- a/docs/python.md
+++ b/docs/python.md
@@ -1,5 +1,10 @@
 # Python package (Jupyter)
 
+[![image](https://img.shields.io/pypi/v/geolibre.svg)](https://pypi.python.org/pypi/geolibre)
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/GeoLibre/blob/main/python/examples/getting-started.ipynb)
+[![image](https://img.shields.io/conda/vn/conda-forge/geolibre.svg)](https://anaconda.org/conda-forge/geolibre)
+[![Conda Recipe](https://img.shields.io/badge/recipe-geolibre-green.svg)](https://github.com/conda-forge/geolibre-feedstock)
+
 GeoLibre ships a Python package, **`geolibre`**, that embeds the full GeoLibre
 app inside a Jupyter notebook cell as an [anywidget](https://anywidget.dev),
 with a [leafmap](https://leafmap.org)-style API.
@@ -13,6 +18,12 @@ data you add from Python appears in the UI, and edits you make in the UI
 
 ```bash
 pip install geolibre
+```
+
+Or with conda from [conda-forge](https://anaconda.org/conda-forge/geolibre):
+
+```bash
+conda install -c conda-forge geolibre
 ```
 
 Optional extras for `add_geojson()` from a GeoDataFrame:

--- a/python/README.md
+++ b/python/README.md
@@ -1,5 +1,10 @@
 # geolibre
 
+[![image](https://img.shields.io/pypi/v/geolibre.svg)](https://pypi.python.org/pypi/geolibre)
+[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/GeoLibre/blob/main/python/examples/getting-started.ipynb)
+[![image](https://img.shields.io/conda/vn/conda-forge/geolibre.svg)](https://anaconda.org/conda-forge/geolibre)
+[![Conda Recipe](https://img.shields.io/badge/recipe-geolibre-green.svg)](https://github.com/conda-forge/geolibre-feedstock)
+
 GeoLibre in Jupyter: the full [GeoLibre](https://geolibre.app) GIS app as an
 [anywidget](https://anywidget.dev), with a leafmap-style Python API.
 
@@ -12,6 +17,12 @@ edits you make in the UI are readable back from Python.
 
 ```bash
 pip install geolibre
+```
+
+Or with conda from [conda-forge](https://anaconda.org/conda-forge/geolibre):
+
+```bash
+conda install -c conda-forge geolibre
 ```
 
 ## Quickstart


### PR DESCRIPTION
## Summary
- Document conda-forge installation (`conda install -c conda-forge geolibre`) alongside pip in the README, Python docs, and the `python/` package README, and add conda-forge version and recipe badges.
- Link the GeoLibre 1.0 video tutorial in the main README and the Getting Started guide.

## Test plan
- [ ] Verify the rendered Markdown shows the conda-forge install commands and badges.
- [ ] Confirm the video tutorial link resolves to the correct video.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added conda‑forge install option alongside pip across README and Python docs.
  * Inserted PyPI and Conda status badges and a Conda recipe link in top-level docs.
  * Added “Watch the introduction” video tutorial link in introductory and getting‑started pages.
  * Clarified optional extras guidance for pip vs conda installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->