### PR TITLE
chore(deps): update maplibre-gl-components to 0.20.3 and maplibre-gl-usgs-lidar to 0.9.0

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -46,7 +46,7 @@
     "maplibre-gl-fema-wms": "^0.1.2",
     "maplibre-gl-geo-editor": "^0.8.0",
     "maplibre-gl-geoagent": "^0.4.2",
-    "maplibre-gl-lidar": "^0.14.1",
+    "maplibre-gl-lidar": "^0.15.0",
     "maplibre-gl-nasa-earthdata": "^0.1.2",
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-planetary-computer": "^0.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7690,12 +7690,6 @@
       "integrity": "sha512-9Zw2KoDpi+T4PZz2G6pO2xArE0m/GSMTW1MIxF2s8ZY8x9XDO6fv9um0ydRGvcbkFLlaq8yNK6eZxnmMZtDgWQ==",
       "license": "MIT"
     },
-    "node_modules/@types/proj4": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@types/proj4/-/proj4-2.5.6.tgz",
-      "integrity": "sha512-zfMrPy9fx+8DchqM0kIUGeu2tTVB5ApO1KGAYcSGFS8GoqRIkyL41xq2yCx/iV3sOLzo7v4hEgViSLTiPI1L0w==",
-      "license": "MIT"
-    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -10466,47 +10460,6 @@
         }
       }
     },
-    "node_modules/maplibre-gl-components": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.5.0.tgz",
-      "integrity": "sha512-Cj0fA65IxsFkggko1LSXxAmNUygyI/NdLj5bFO6FrtU6i3XhPH983PNrFf0aV77Q4H9BNM6f01gp+T8+DWmvAg==",
-      "license": "MIT",
-      "dependencies": {
-        "maplibre-gl-layer-control": "^0.8.2"
-      },
-      "peerDependencies": {
-        "maplibre-gl": ">=5.14.0",
-        "react": ">=18.0.0",
-        "react-dom": ">=18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/maplibre-gl-components/node_modules/maplibre-gl-layer-control": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-layer-control/-/maplibre-gl-layer-control-0.8.2.tgz",
-      "integrity": "sha512-0AKia2bkrLWQSDVFbMtNpODt3EraZ/Dfr3c8VFHSevq9NDZ6wOHz0GpfVYCw1UbIarrMspyRLAlvLOjPDLA1jQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "maplibre-gl": ">=3.0.0",
-        "react": ">=18.0.0",
-        "react-dom": ">=18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/maplibre-gl-duckdb": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/maplibre-gl-duckdb/-/maplibre-gl-duckdb-0.2.0.tgz",
@@ -11069,35 +11022,15 @@
       }
     },
     "node_modules/maplibre-gl-usgs-lidar": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-usgs-lidar/-/maplibre-gl-usgs-lidar-0.7.3.tgz",
-      "integrity": "sha512-jG/HntYbIx3ZjvZfpYjFpo/HaLuScMWsGQcCTprq2PK7xrs4kb5OQKmf3MFuE+z8JiE6kM3D/rQTCrhtU/AeXw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-usgs-lidar/-/maplibre-gl-usgs-lidar-0.9.0.tgz",
+      "integrity": "sha512-3HqDHDuD7KRjrV3Nr5k2TjVFdryt1mHOKqHJ19j/hg+oDEXGfVTfxH7t/CKaIGmZl94GdLfMY4DlUkYY39cUEA==",
       "license": "MIT",
       "dependencies": {
-        "maplibre-gl-components": "^0.5.0",
-        "maplibre-gl-layer-control": "^0.11.0",
-        "maplibre-gl-lidar": "^0.11.0",
-        "topojson-client": "^3.1.0"
+        "maplibre-gl-layer-control": ">=0.14.1",
+        "maplibre-gl-lidar": ">=0.15.0",
+        "topojson-client": ">=3.1.0"
       },
-      "peerDependencies": {
-        "maplibre-gl": ">=3.0.0",
-        "react": ">=18.0.0",
-        "react-dom": ">=18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/maplibre-gl-usgs-lidar/node_modules/maplibre-gl-layer-control": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-layer-control/-/maplibre-gl-layer-control-0.11.0.tgz",
-      "integrity": "sha512-OFAIuAhc64rzBW5VGl2DZ8rmPb2sz3z/Dn04Yc8YQn+vyuIN5S0Cfp+ojPD1SMiXTm7W/BAfmfr/JQpwm+nerQ==",
-      "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
         "react": ">=18.0.0",
@@ -11113,21 +11046,20 @@
       }
     },
     "node_modules/maplibre-gl-usgs-lidar/node_modules/maplibre-gl-lidar": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-lidar/-/maplibre-gl-lidar-0.11.1.tgz",
-      "integrity": "sha512-Z/4VdlZZu1KQ2q8OwAs9uNvHuhffh6JqP7nCiS4u/Zbk+oA1SRR3WOi2HsbvGzc/d41FfgS32BTVkI49CEBI4g==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-lidar/-/maplibre-gl-lidar-0.15.0.tgz",
+      "integrity": "sha512-5KbFuuhS647JuNfsu2hzuqqa3cpDhKNeBhcFPJCtUo3tYiE20tPrdANVZP40nFmFNAGLZvU2obk5Ftojdjp1ig==",
       "license": "MIT",
       "dependencies": {
-        "@deck.gl/core": "^9.0.0",
-        "@deck.gl/extensions": "^9.0.0",
-        "@deck.gl/layers": "^9.0.0",
-        "@deck.gl/mapbox": "^9.0.0",
-        "@loaders.gl/core": "^4.3.4",
-        "@loaders.gl/las": "^4.3.4",
-        "@types/proj4": "^2.5.6",
-        "copc": "^0.0.8",
-        "maplibre-gl-layer-control": "^0.11.0",
-        "proj4": "^2.20.2"
+        "@deck.gl/core": ">=9.3.2",
+        "@deck.gl/extensions": ">=9.3.2",
+        "@deck.gl/layers": ">=9.3.2",
+        "@deck.gl/mapbox": ">=9.3.2",
+        "@loaders.gl/core": ">=4.4.2",
+        "@loaders.gl/las": ">=4.4.2",
+        "copc": ">=0.0.8",
+        "maplibre-gl-layer-control": ">=0.14.1",
+        "proj4": ">=2.20.8"
       },
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,9 +101,9 @@
       "license": "MIT"
     },
     "apps/geolibre-desktop/node_modules/maplibre-gl-components": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.20.2.tgz",
-      "integrity": "sha512-OBPy43jj+f0y5XYq1edGDuCiK9NoV1T6mI5Snp2Zmi2/kWrKkRFZyY5/sbp2VmQviqmFG56Bc8YW+3p7LACilg==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.20.3.tgz",
+      "integrity": "sha512-BccuYY4zw9l3bOFn8EF/Rb1ylvvuxGcPmpdn3gGfZo8uc8jp5uLJLSoo9nENPHv1lp/iXbjE8cbKmamprOWi8g==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",
@@ -14631,9 +14631,9 @@
       }
     },
     "packages/plugins/node_modules/maplibre-gl-components": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.20.2.tgz",
-      "integrity": "sha512-OBPy43jj+f0y5XYq1edGDuCiK9NoV1T6mI5Snp2Zmi2/kWrKkRFZyY5/sbp2VmQviqmFG56Bc8YW+3p7LACilg==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.20.3.tgz",
+      "integrity": "sha512-BccuYY4zw9l3bOFn8EF/Rb1ylvvuxGcPmpdn3gGfZo8uc8jp5uLJLSoo9nENPHv1lp/iXbjE8cbKmamprOWi8g==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "maplibre-gl-fema-wms": "^0.1.2",
         "maplibre-gl-geo-editor": "^0.8.0",
         "maplibre-gl-geoagent": "^0.4.2",
-        "maplibre-gl-lidar": "^0.14.1",
+        "maplibre-gl-lidar": "^0.15.0",
         "maplibre-gl-nasa-earthdata": "^0.1.2",
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
@@ -10757,9 +10757,9 @@
       }
     },
     "node_modules/maplibre-gl-lidar": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-lidar/-/maplibre-gl-lidar-0.14.1.tgz",
-      "integrity": "sha512-4qBh08g97c/mtxFKgyMhT/nIrTId+g4+OdFUCCL/mkowCGZ/IvAHxHulYJ2jdLYopV/fP7iGI3ei9bJffpmh2w==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-lidar/-/maplibre-gl-lidar-0.15.0.tgz",
+      "integrity": "sha512-5KbFuuhS647JuNfsu2hzuqqa3cpDhKNeBhcFPJCtUo3tYiE20tPrdANVZP40nFmFNAGLZvU2obk5Ftojdjp1ig==",
       "license": "MIT",
       "dependencies": {
         "@deck.gl/core": ">=9.3.2",
@@ -11030,36 +11030,6 @@
         "maplibre-gl-layer-control": ">=0.14.1",
         "maplibre-gl-lidar": ">=0.15.0",
         "topojson-client": ">=3.1.0"
-      },
-      "peerDependencies": {
-        "maplibre-gl": ">=3.0.0",
-        "react": ">=18.0.0",
-        "react-dom": ">=18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/maplibre-gl-usgs-lidar/node_modules/maplibre-gl-lidar": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-lidar/-/maplibre-gl-lidar-0.15.0.tgz",
-      "integrity": "sha512-5KbFuuhS647JuNfsu2hzuqqa3cpDhKNeBhcFPJCtUo3tYiE20tPrdANVZP40nFmFNAGLZvU2obk5Ftojdjp1ig==",
-      "license": "MIT",
-      "dependencies": {
-        "@deck.gl/core": ">=9.3.2",
-        "@deck.gl/extensions": ">=9.3.2",
-        "@deck.gl/layers": ">=9.3.2",
-        "@deck.gl/mapbox": ">=9.3.2",
-        "@loaders.gl/core": ">=4.4.2",
-        "@loaders.gl/las": ">=4.4.2",
-        "copc": ">=0.0.8",
-        "maplibre-gl-layer-control": ">=0.14.1",
-        "proj4": ">=2.20.8"
       },
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -14602,7 +14572,7 @@
         "maplibre-gl-fema-wms": "^0.1.2",
         "maplibre-gl-geo-editor": "^0.8.0",
         "maplibre-gl-geoagent": "^0.4.2",
-        "maplibre-gl-lidar": "^0.14.1",
+        "maplibre-gl-lidar": "^0.15.0",
         "maplibre-gl-nasa-earthdata": "^0.1.2",
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-overture-maps": "^0.3.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -37,7 +37,7 @@
     "maplibre-gl-fema-wms": "^0.1.2",
     "maplibre-gl-geo-editor": "^0.8.0",
     "maplibre-gl-geoagent": "^0.4.2",
-    "maplibre-gl-lidar": "^0.14.1",
+    "maplibre-gl-lidar": "^0.15.0",
     "maplibre-gl-nasa-earthdata": "^0.1.2",
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-overture-maps": "^0.3.0",


### PR DESCRIPTION
Updates two maplibre dependencies in the lockfile.

### `maplibre-gl-components` 0.20.2 -> 0.20.3
Pulls in the PMTiles null-island fix (opengeos/maplibre-gl-components#96, released as 0.20.3) via the existing `^0.20.2` range. Adding a PMTiles layer whose archive leaves the center at `0,0` (e.g. the **Overture buildings** example) now fits the archive bounds instead of zooming to null island in the Gulf of Guinea.

### `maplibre-gl-usgs-lidar` 0.7.3 -> 0.9.0
Bumps the transitive `maplibre-gl-usgs-lidar` (pulled in by `maplibre-gl-components`) to latest. `0.9.0` dropped its dependency on `maplibre-gl-components`, which removes the duplicate `maplibre-gl-components@0.5.0` previously hoisted to the repo root.

Verified: `npm run build` succeeds; only `package-lock.json` changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to the latest compatible versions to improve stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->