### PR TITLE
fix(csp): allow cdn.jsdelivr.net in script-src for DuckDB-WASM

### DIFF
--- a/apps/geolibre-desktop/src-tauri/tauri.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' https: http://127.0.0.1:*; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net/pyodide/ https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'",
+      "csp": "default-src 'self'; connect-src 'self' https: http://127.0.0.1:*; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'",
       "capabilities": ["default"]
     }
   },

--- a/apps/geolibre-desktop/src-tauri/tauri.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' https: http://127.0.0.1:*; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'",
+      "csp": "default-src 'self'; connect-src 'self' https: http://127.0.0.1:*; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net/npm/ https://cdn.jsdelivr.net/pyodide/ https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'",
       "capabilities": ["default"]
     }
   },

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -32,7 +32,10 @@ server {
         # Mirrors the Tauri desktop CSP. 'unsafe-eval' is required by the
         # @google/earthengine and maplibre-gl-geoagent bundles; connect-src
         # stays broad because users connect to arbitrary tile/WMS endpoints.
-        add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https: data: blob:; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'" always;
+        # cdn.jsdelivr.net is in script-src because maplibre-gl-vector loads
+        # DuckDB-WASM (Add Vector Layer) and the Pyodide vector engine via
+        # dynamic import()/importScripts() from that CDN.
+        add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https: data: blob:; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' https://cdn.jsdelivr.net https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'" always;
     }
 
     location ~* \.(?:css|js|mjs|png|jpg|jpeg|gif|ico|svg|webp|avif|wasm|woff2?|ttf|otf)$ {

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -32,10 +32,11 @@ server {
         # Mirrors the Tauri desktop CSP. 'unsafe-eval' is required by the
         # @google/earthengine and maplibre-gl-geoagent bundles; connect-src
         # stays broad because users connect to arbitrary tile/WMS endpoints.
-        # cdn.jsdelivr.net is in script-src because maplibre-gl-vector loads
-        # DuckDB-WASM (Add Vector Layer) and the Pyodide vector engine via
-        # dynamic import()/importScripts() from that CDN.
-        add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https: data: blob:; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' https://cdn.jsdelivr.net https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'" always;
+        # The jsDelivr script-src allowances are path-scoped: /npm/ covers
+        # maplibre-gl-vector's DuckDB-WASM + geojson-vt/vt-pbf (Add Vector
+        # Layer) loaded via dynamic import()/importScripts(), and /pyodide/
+        # covers the Pyodide vector engine.
+        add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https: data: blob:; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net/npm/ https://cdn.jsdelivr.net/pyodide/ https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'" always;
     }
 
     location ~* \.(?:css|js|mjs|png|jpg|jpeg|gif|ico|svg|webp|avif|wasm|woff2?|ttf|otf)$ {


### PR DESCRIPTION
## Problem

In the Docker/nginx web build, **Add Vector Layer** fails with:

```
Failed to fetch dynamically imported module:
https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@1.31.0/+esm
```

Local `npm run dev` works fine.

## Root cause

`maplibre-gl-vector` loads DuckDB-WASM on first use via a dynamic `import()` from `cdn.jsdelivr.net` (`VectorControl`: `DUCKDB_CDN_BASE = https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@1.31.0`), and also pulls `geojson-vt`/`vt-pbf` from the same CDN. ES-module `import()` (and the `importScripts()` inside its blob worker) are governed by the CSP **`script-src`** directive.

The nginx CSP `script-src` listed only `'self' blob: 'unsafe-eval' https://accounts.google.com` — no `cdn.jsdelivr.net` — so the browser blocked the import. The Vite dev server sets no CSP, which is why dev worked.

The Tauri desktop CSP had the same latent gap: it allowed only `https://cdn.jsdelivr.net/pyodide/`, not the `/npm/` path DuckDB uses.

## Fix

- **`docker/nginx.conf`**: add `https://cdn.jsdelivr.net` to `script-src`.
- **`tauri.conf.json`**: broaden `https://cdn.jsdelivr.net/pyodide/` to the whole `https://cdn.jsdelivr.net` host.

`connect-src https:` already covers the WASM bundle + `extensions.duckdb.org` spatial-extension fetches; `worker-src blob:` covers the blob worker; `'unsafe-eval'` covers the `new Function` dynamic import and WASM compilation.

## Verification

Ran nginx with the updated config: `nginx -t` passes and the served `Content-Security-Policy` header now contains `script-src ... https://cdn.jsdelivr.net ...`. Full confirmation: rebuild the Docker image and exercise Add Vector Layer.

> Note (out of scope): `maplibre-gl-vector` hard-codes DuckDB-WASM `1.31.0` from the CDN while GeoLibre bundles `1.33.1-dev45.0`. A future upstream improvement could load the bundled copy (offline-capable) instead of the CDN.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Updates**
  * Updated Content Security Policy to refine third-party script allowances: broadened approved CDN script sources for dynamic bundles and adjusted handling for WebAssembly/Pyodide-related resources to improve loading reliability while maintaining security controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->