### PR TITLE
fix(vector): apply Style panel edits to Add Vector Layer layers

### DIFF
--- a/packages/plugins/src/plugins/vector-layer-sync.ts
+++ b/packages/plugins/src/plugins/vector-layer-sync.ts
@@ -410,6 +410,11 @@ function savedVectorStyle(raw: unknown): Partial<VectorLayerStyle> | null {
  * and the stroke fields drive lines and polygon outlines; the control applies
  * only the fields relevant to each layer's actual geometry.
  *
+ * The collapse is intentionally lossy: circleColor/circleOpacity always track
+ * fillColor/fillOpacity. Single-geometry layers round-trip cleanly; a "mixed"
+ * layer's point circles unify with its fill from the first panel edit onward,
+ * since GeoLibre has no separate point-fill control.
+ *
  * @param style - The GeoLibre layer style.
  * @returns The equivalent control style patch.
  */
@@ -437,14 +442,22 @@ function layerStyleToVectorStyle(style: LayerStyle): VectorLayerStyle {
  */
 function vectorStyleToLayerStyle(info: VectorLayerInfo): Partial<LayerStyle> {
   const style = info.style;
-  const shared: Partial<LayerStyle> = {
-    strokeColor: style.lineColor,
-    strokeWidth: style.lineWidth,
-    circleRadius: style.circleRadius,
-  };
-  return info.geometryType === "point"
-    ? { ...shared, fillColor: style.circleColor, fillOpacity: style.circleOpacity }
-    : { ...shared, fillColor: style.fillColor, fillOpacity: style.fillOpacity };
+  // Only emit fields the control actually provided; otherwise a missing value
+  // would spread an explicit `undefined` over DEFAULT_LAYER_STYLE at the seed
+  // site and clobber a valid default.
+  const seed: Partial<LayerStyle> = {};
+  if (style.lineColor !== undefined) seed.strokeColor = style.lineColor;
+  if (style.lineWidth !== undefined) seed.strokeWidth = style.lineWidth;
+  if (style.circleRadius !== undefined) seed.circleRadius = style.circleRadius;
+
+  const [fillColor, fillOpacity] =
+    info.geometryType === "point"
+      ? [style.circleColor, style.circleOpacity]
+      : [style.fillColor, style.fillOpacity];
+  if (fillColor !== undefined) seed.fillColor = fillColor;
+  if (fillOpacity !== undefined) seed.fillOpacity = fillOpacity;
+
+  return seed;
 }
 
 /**

--- a/packages/plugins/src/plugins/vector-layer-sync.ts
+++ b/packages/plugins/src/plugins/vector-layer-sync.ts
@@ -226,6 +226,28 @@ export function wireVectorStoreSync(control: VectorSyncableControl): void {
         const nextStyle = layerStyleToVectorStyle(current.style);
         if (!vectorStylesEqual(layerStyleToVectorStyle(layer.style), nextStyle)) {
           activeControl.setLayerStyle(layer.id, nextStyle);
+          // Keep the persisted control-seed style in sync so a saved project
+          // restores the user-edited colors: restoreVectorLayers seeds the
+          // control's addData from metadata.vectorState.style. (The control's
+          // layerupdated event would normally refresh this via
+          // syncVectorLayersToStore, but the suspension around this push
+          // suppresses it.)
+          const vectorState = current.metadata.vectorState;
+          if (
+            vectorState &&
+            typeof vectorState === "object" &&
+            !Array.isArray(vectorState)
+          ) {
+            useAppStore.getState().updateLayer(layer.id, {
+              metadata: {
+                ...current.metadata,
+                vectorState: {
+                  ...(vectorState as Record<string, unknown>),
+                  style: nextStyle,
+                },
+              },
+            });
+          }
         }
       }
     });
@@ -424,6 +446,10 @@ function layerStyleToVectorStyle(style: LayerStyle): VectorLayerStyle {
     fillOpacity: style.fillOpacity,
     lineColor: style.strokeColor,
     lineWidth: style.strokeWidth,
+    // circleColor/circleOpacity intentionally track fillColor/fillOpacity (see
+    // the doc comment): one fill edit drives both polygon fills and point
+    // circles on mixed layers. Pure polygon/line layers ignore these fields;
+    // pure point layers ignore fillColor/fillOpacity instead.
     circleColor: style.fillColor,
     circleOpacity: style.fillOpacity,
     circleRadius: style.circleRadius,

--- a/packages/plugins/src/plugins/vector-layer-sync.ts
+++ b/packages/plugins/src/plugins/vector-layer-sync.ts
@@ -1,6 +1,7 @@
 import {
   DEFAULT_LAYER_STYLE,
   type GeoLibreLayer,
+  type LayerStyle,
   useAppStore,
 } from "@geolibre/core";
 import type {
@@ -22,6 +23,7 @@ export type VectorSyncableControl = {
   removeLayer: (id: string) => void;
   setLayerOpacity: (id: string, opacity: number) => void;
   setLayerVisibility: (id: string, visible: boolean) => void;
+  setLayerStyle: (id: string, style: Partial<VectorLayerStyle>) => void;
 };
 
 let syncedControl: VectorSyncableControl | null = null;
@@ -80,7 +82,10 @@ export function createVectorStoreLayer(
     },
     visible: info.visible,
     opacity: info.opacity,
-    style: { ...DEFAULT_LAYER_STYLE },
+    // Seed the panel style from the control's own style so the Style panel
+    // reflects what is actually rendered, and so an edit to one field does
+    // not reset the others back to GeoLibre defaults.
+    style: { ...DEFAULT_LAYER_STYLE, ...vectorStyleToLayerStyle(info) },
     metadata: {
       customLayerType: vectorCustomLayerType(info.geometryType),
       externalNativeLayer: true,
@@ -217,6 +222,10 @@ export function wireVectorStoreSync(control: VectorSyncableControl): void {
         }
         if (current.opacity !== layer.opacity) {
           activeControl.setLayerOpacity(layer.id, current.opacity);
+        }
+        const nextStyle = layerStyleToVectorStyle(current.style);
+        if (!vectorStylesEqual(layerStyleToVectorStyle(layer.style), nextStyle)) {
+          activeControl.setLayerStyle(layer.id, nextStyle);
         }
       }
     });
@@ -392,6 +401,73 @@ function savedVectorStyle(raw: unknown): Partial<VectorLayerStyle> | null {
   }
 
   return Object.keys(style).length > 0 ? style : null;
+}
+
+/**
+ * Maps GeoLibre's shared LayerStyle onto the control's per-geometry
+ * VectorLayerStyle. GeoLibre exposes one fillColor/strokeColor/fillOpacity/
+ * strokeWidth for every geometry, so the fill fields also drive point circles
+ * and the stroke fields drive lines and polygon outlines; the control applies
+ * only the fields relevant to each layer's actual geometry.
+ *
+ * @param style - The GeoLibre layer style.
+ * @returns The equivalent control style patch.
+ */
+function layerStyleToVectorStyle(style: LayerStyle): VectorLayerStyle {
+  return {
+    fillColor: style.fillColor,
+    fillOpacity: style.fillOpacity,
+    lineColor: style.strokeColor,
+    lineWidth: style.strokeWidth,
+    circleColor: style.fillColor,
+    circleOpacity: style.fillOpacity,
+    circleRadius: style.circleRadius,
+  };
+}
+
+/**
+ * Seeds a GeoLibre LayerStyle from the control's VectorLayerStyle so the Style
+ * panel reflects what the control actually rendered. Collapses the control's
+ * per-geometry colors onto GeoLibre's shared fields, choosing the fill source
+ * by geometry (point circles use the circle fill; everything else the polygon
+ * fill).
+ *
+ * @param info - The control layer snapshot.
+ * @returns A partial GeoLibre style to overlay on the defaults.
+ */
+function vectorStyleToLayerStyle(info: VectorLayerInfo): Partial<LayerStyle> {
+  const style = info.style;
+  const shared: Partial<LayerStyle> = {
+    strokeColor: style.lineColor,
+    strokeWidth: style.lineWidth,
+    circleRadius: style.circleRadius,
+  };
+  return info.geometryType === "point"
+    ? { ...shared, fillColor: style.circleColor, fillOpacity: style.circleOpacity }
+    : { ...shared, fillColor: style.fillColor, fillOpacity: style.fillOpacity };
+}
+
+/**
+ * Shallow equality over the control style fields, so a no-op style change in
+ * the store does not push a redundant setLayerStyle at the control.
+ *
+ * @param left - First control style.
+ * @param right - Second control style.
+ * @returns True when every field matches.
+ */
+function vectorStylesEqual(
+  left: VectorLayerStyle,
+  right: VectorLayerStyle,
+): boolean {
+  return (
+    left.fillColor === right.fillColor &&
+    left.fillOpacity === right.fillOpacity &&
+    left.lineColor === right.lineColor &&
+    left.lineWidth === right.lineWidth &&
+    left.circleColor === right.circleColor &&
+    left.circleOpacity === right.circleOpacity &&
+    left.circleRadius === right.circleRadius
+  );
 }
 
 function vectorCustomLayerType(

--- a/tests/vector-layer-sync.test.ts
+++ b/tests/vector-layer-sync.test.ts
@@ -73,6 +73,8 @@ function fakeControl(
       calls.push({ method: "setLayerOpacity", args: [id, opacity] }),
     setLayerVisibility: (id, visible) =>
       calls.push({ method: "setLayerVisibility", args: [id, visible] }),
+    setLayerStyle: (id, style) =>
+      calls.push({ method: "setLayerStyle", args: [id, style] }),
   };
   return { control, calls };
 }
@@ -364,6 +366,35 @@ describe("wireVectorStoreSync", () => {
     assert.deepEqual(calls, [
       { method: "setLayerVisibility", args: ["vector-1", false] },
       { method: "setLayerOpacity", args: ["vector-1", 0.25] },
+    ]);
+  });
+
+  it("applies panel style changes through the control", () => {
+    const { control, calls } = fakeControl([vectorInfo()]);
+    syncVectorLayersToStore(control);
+    wireVectorStoreSync(control);
+
+    useAppStore.getState().setLayerStyle("vector-1", { fillColor: "#ff0000" });
+
+    // GeoLibre's shared fillColor/strokeColor/fillOpacity/strokeWidth map onto
+    // the control's per-geometry fill/line/circle style; the unedited fields
+    // come from the style seeded off the control's own style.
+    assert.deepEqual(calls, [
+      {
+        method: "setLayerStyle",
+        args: [
+          "vector-1",
+          {
+            fillColor: "#ff0000",
+            fillOpacity: 0.4,
+            lineColor: "#3388ff",
+            lineWidth: 2,
+            circleColor: "#ff0000",
+            circleOpacity: 0.4,
+            circleRadius: 5,
+          },
+        ],
+      },
     ]);
   });
 

--- a/tests/vector-layer-sync.test.ts
+++ b/tests/vector-layer-sync.test.ts
@@ -188,6 +188,45 @@ describe("createVectorStoreLayer", () => {
 
     assert.equal(layer.metadata.panelCollapsed, false);
   });
+
+  it("seeds the panel style from polygon fill/outline", () => {
+    const layer = createVectorStoreLayer(
+      vectorInfo({
+        geometryType: "polygon",
+        style: vectorStyle({
+          fillColor: "#112233",
+          fillOpacity: 0.3,
+          lineColor: "#445566",
+          lineWidth: 4,
+        }),
+      }),
+    );
+
+    assert.equal(layer.style.fillColor, "#112233");
+    assert.equal(layer.style.fillOpacity, 0.3);
+    assert.equal(layer.style.strokeColor, "#445566");
+    assert.equal(layer.style.strokeWidth, 4);
+  });
+
+  it("seeds the panel fill from the circle style for point layers", () => {
+    const layer = createVectorStoreLayer(
+      vectorInfo({
+        geometryType: "point",
+        style: vectorStyle({
+          fillColor: "#ffffff",
+          circleColor: "#abc123",
+          circleOpacity: 0.7,
+          circleRadius: 9,
+        }),
+      }),
+    );
+
+    // Points fold the circle color/opacity onto GeoLibre's shared fill fields,
+    // not the polygon fillColor.
+    assert.equal(layer.style.fillColor, "#abc123");
+    assert.equal(layer.style.fillOpacity, 0.7);
+    assert.equal(layer.style.circleRadius, 9);
+  });
 });
 
 describe("syncVectorLayersToStore", () => {
@@ -282,6 +321,7 @@ describe("syncVectorLayersToStore", () => {
       removeLayer: () => {},
       setLayerOpacity: () => {},
       setLayerVisibility: () => {},
+      setLayerStyle: () => {},
     };
     handlers.push(() => syncVectorLayersToStore(control));
     const expand = () => {

--- a/tests/vector-layer-sync.test.ts
+++ b/tests/vector-layer-sync.test.ts
@@ -227,6 +227,38 @@ describe("createVectorStoreLayer", () => {
     assert.equal(layer.style.fillOpacity, 0.7);
     assert.equal(layer.style.circleRadius, 9);
   });
+
+  it("seeds a line layer from the line style and keeps default fill", () => {
+    const layer = createVectorStoreLayer(
+      vectorInfo({
+        geometryType: "line",
+        style: vectorStyle({
+          fillColor: "#ffffff",
+          lineColor: "#0a0b0c",
+          lineWidth: 5,
+        }),
+      }),
+    );
+
+    // The non-point branch seeds stroke from lineColor; the shared fillColor
+    // tracks the control's fillColor field (irrelevant to a line, but harmless).
+    assert.equal(layer.style.strokeColor, "#0a0b0c");
+    assert.equal(layer.style.strokeWidth, 5);
+    assert.equal(layer.style.fillColor, "#ffffff");
+  });
+
+  it("seeds a mixed layer from the polygon fill (lossy collapse)", () => {
+    const layer = createVectorStoreLayer(
+      vectorInfo({
+        geometryType: "mixed",
+        style: vectorStyle({ fillColor: "#101112", circleColor: "#dddddd" }),
+      }),
+    );
+
+    // "mixed" takes the non-point branch: the shared fillColor comes from the
+    // polygon fill, so the circle color is unified with it from the first edit.
+    assert.equal(layer.style.fillColor, "#101112");
+  });
 });
 
 describe("syncVectorLayersToStore", () => {
@@ -419,23 +451,38 @@ describe("wireVectorStoreSync", () => {
     // GeoLibre's shared fillColor/strokeColor/fillOpacity/strokeWidth map onto
     // the control's per-geometry fill/line/circle style; the unedited fields
     // come from the style seeded off the control's own style.
+    const expectedStyle = {
+      fillColor: "#ff0000",
+      fillOpacity: 0.4,
+      lineColor: "#3388ff",
+      lineWidth: 2,
+      circleColor: "#ff0000",
+      circleOpacity: 0.4,
+      circleRadius: 5,
+    };
     assert.deepEqual(calls, [
-      {
-        method: "setLayerStyle",
-        args: [
-          "vector-1",
-          {
-            fillColor: "#ff0000",
-            fillOpacity: 0.4,
-            lineColor: "#3388ff",
-            lineWidth: 2,
-            circleColor: "#ff0000",
-            circleOpacity: 0.4,
-            circleRadius: 5,
-          },
-        ],
-      },
+      { method: "setLayerStyle", args: ["vector-1", expectedStyle] },
     ]);
+
+    // The control-seed style is kept in sync so a saved project restores the
+    // edited colors (restoreVectorLayers seeds addData from vectorState.style).
+    const stored = useAppStore.getState().layers[0];
+    assert.deepEqual(
+      (stored.metadata.vectorState as { style: unknown }).style,
+      expectedStyle,
+    );
+  });
+
+  it("does not touch the control for GeoLibre-only style fields", () => {
+    const { control, calls } = fakeControl([vectorInfo()]);
+    syncVectorLayersToStore(control);
+    wireVectorStoreSync(control);
+
+    // textColor has no VectorLayerStyle equivalent, so the mapped style is
+    // unchanged and no setLayerStyle is pushed.
+    useAppStore.getState().setLayerStyle("vector-1", { textColor: "#abcdef" });
+
+    assert.deepEqual(calls, []);
   });
 
   it("drops the control layer when the panel removes the layer", () => {


### PR DESCRIPTION
Fixes #210.

## Problem

Changing a property (Fill color, Outline color, …) in the Style panel for a layer added via **Add Data => Vector** has no effect on the map, even though the panel says "Changes apply live to MapLibre paint properties."

## Root cause

Vector-panel layers are mirrored into the store with `metadata.customLayerType` set (`vector-layer-sync.ts`). In `@geolibre/map`'s `syncExternalNativeLayer`, `isExternalCustomLayer` is true whenever `customLayerType` is a string, which takes the early return that handles **ordering only** and skips `setExternalNativeLayerPaint`. So Style-panel edits updated `layer.style` in the store but never reached the map.

## Fix

The `maplibre-gl-vector` `VectorControl` owns and re-renders its own layers and already exposes `setLayerStyle(id, Partial<VectorLayerStyle>)`. So — consistent with how visibility/opacity already route through the control API in `wireVectorStoreSync` — style edits now route through `control.setLayerStyle`:

- **Map** GeoLibre's shared `LayerStyle` onto the control's per-geometry `VectorLayerStyle` (`fillColor`/`strokeColor`/`fillOpacity`/`strokeWidth` → fill/line/circle). The control applies only the fields relevant to each layer's geometry.
- **Seed** the store layer's style from the control's own style on creation, so the Style panel reflects what's rendered and editing one field doesn't reset the others to GeoLibre defaults.
- Push only when the mapped style actually changed (no redundant calls).

## Tests

New `wireVectorStoreSync` case: a `setLayerStyle` store edit pushes the mapped style through the control. Full suite: **186 passing**; build/typecheck clean.

> Note: a separate issue (zipped-shapefile `/vsizip/` GDAL error in the Docker build) is still under investigation and not part of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Layer styles now seed from the control’s rendered style and synchronize bidirectionally with active vector controls, with smarter reconciliation to avoid redundant updates and to persist edited styles for accurate restores.

* **Tests**
  * Added tests for style seeding (polygon/point/line/mixed), store→control synchronization behavior, persisted style updates, and prevention of unnecessary control updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->