### PR TITLE
chore(deps): update maplibre-gl-vector to 0.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10675,10 +10675,13 @@
       }
     },
     "node_modules/maplibre-gl-vector": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.2.1.tgz",
-      "integrity": "sha512-ICO29KifY+/Esb2Sg1aqN7sKFnSwPqivYbgsDsYeV8lKqjQxT8Zk/3J60y4nwJtmlbgfu1YjpM5jmwdOKonzhA==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.2.3.tgz",
+      "integrity": "sha512-y8G1YiTxEYNWcFKpCd/gjWJbeVyovYLzd7+Q9Lgj8RKF850fTswCwkRus3tTcO9+MTyzVp/uA0KvXVK2f6wzUw==",
       "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.8.2"
+      },
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
         "react": ">=18.0.0",
@@ -10692,6 +10695,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/maplibre-gl-vector/node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/marked": {
       "version": "18.0.4",


### PR DESCRIPTION
Pulls in the zipped-shapefile fix (opengeos/maplibre-gl-vector#8, released as `0.2.3`) via the existing `^0.2.1` range.

Add Vector Layer now reads **local zipped shapefiles** by unzipping client-side and registering the components (`.shp`/`.dbf`/`.shx`/...), then `ST_Read`-ing the `.shp` directly — instead of GDAL `/vsizip/`, which cannot read a DuckDB-WASM `registerFileBuffer` archive and failed with `Could not open GDAL dataset at /vsizip/...zip`.

Lockfile-only change (the declared `^0.2.1` already permits `0.2.3`). Verified `npm run build` succeeds.