### PR TITLE
feat(layers): rename layers + fix Load button focus ring clipping

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -631,9 +631,40 @@ export function LayerPanel({
                       <EyeOff className="h-3.5 w-3.5 text-muted-foreground" />
                     )}
                   </button>
-                  <span className="flex-1 truncate text-sm font-medium">
-                    {layer.name}
-                  </span>
+                  {editingLayerId === layer.id ? (
+                    <input
+                      autoFocus
+                      type="text"
+                      className="flex-1 min-w-0 rounded border border-input bg-background px-1 py-0.5 text-sm font-medium outline-none focus:ring-1 focus:ring-ring"
+                      value={editingName}
+                      aria-label={`Rename ${layer.name}`}
+                      onChange={(e) => setEditingName(e.target.value)}
+                      onClick={(e: ReactMouseEvent) => e.stopPropagation()}
+                      onFocus={(e) => e.currentTarget.select()}
+                      onBlur={commitRename}
+                      onKeyDown={(e) => {
+                        e.stopPropagation();
+                        if (e.key === "Enter") {
+                          e.preventDefault();
+                          commitRename();
+                        } else if (e.key === "Escape") {
+                          e.preventDefault();
+                          cancelRename();
+                        }
+                      }}
+                    />
+                  ) : (
+                    <span
+                      className="flex-1 truncate text-sm font-medium"
+                      title="Double-click to rename"
+                      onDoubleClick={(e: ReactMouseEvent) => {
+                        e.stopPropagation();
+                        beginRename(layer);
+                      }}
+                    >
+                      {layer.name}
+                    </span>
+                  )}
                   <span className="text-[10px] uppercase text-muted-foreground">
                     {layerTypeLabel(layer)}
                   </span>

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -828,6 +828,16 @@ export function LayerPanel({
                       align="end"
                       onClick={(e: ReactMouseEvent) => e.stopPropagation()}
                     >
+                      <DropdownMenuItem
+                        onSelect={(e: Event) => {
+                          e.preventDefault();
+                          beginRename(layer);
+                        }}
+                      >
+                        <Pencil className="mr-2 h-3.5 w-3.5" />
+                        Rename
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
                       {canMaterializeDuckDB && (
                         <>
                           <DropdownMenuItem

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -181,6 +181,12 @@ export function LayerPanel({
   const [dropTargetLayerId, setDropTargetLayerId] = useState<string | null>(
     null,
   );
+  // Escape cancels a rename by clearing editing state, but the input's onBlur
+  // (fired when React unmounts the focused input) would otherwise run
+  // commitRename with the pre-update closure and commit the edit anyway. This
+  // ref is read synchronously by commitRename, so it reflects the cancel
+  // regardless of which render's closure is executing.
+  const isCancelingRenameRef = useRef(false);
   const refreshingLayerIdsRef = useRef(new Set<string>());
   const refreshTimersRef = useRef(new Map<string, LayerRefreshTimer>());
   const refreshStatusTimersRef = useRef(new Map<string, number>());
@@ -224,7 +230,10 @@ export function LayerPanel({
   };
 
   const commitRename = () => {
-    if (!editingLayerId) return;
+    if (isCancelingRenameRef.current || !editingLayerId) {
+      isCancelingRenameRef.current = false;
+      return;
+    }
     const trimmed = editingName.trim();
     const current = layers.find((l) => l.id === editingLayerId);
     if (trimmed && current && trimmed !== current.name) {
@@ -235,6 +244,7 @@ export function LayerPanel({
   };
 
   const cancelRename = () => {
+    isCancelingRenameRef.current = true;
     setEditingLayerId(null);
     setEditingName("");
   };
@@ -338,6 +348,14 @@ export function LayerPanel({
       setRefreshSettingsLayerId(null);
     }
 
+    if (
+      editingLayerId &&
+      !layers.some((layer) => layer.id === editingLayerId)
+    ) {
+      setEditingLayerId(null);
+      setEditingName("");
+    }
+
     const layerIds = new Set(layers.map((layer) => layer.id));
     for (const id of refreshStatusTimersRef.current.keys()) {
       if (!layerIds.has(id)) clearRefreshStatusTimer(id);
@@ -353,7 +371,7 @@ export function LayerPanel({
       }
       return changed ? next : current;
     });
-  }, [clearRefreshStatusTimer, layers, refreshSettingsLayerId]);
+  }, [clearRefreshStatusTimer, editingLayerId, layers, refreshSettingsLayerId]);
 
   useEffect(() => {
     if (refreshSettingsIntervalMs === null) {
@@ -828,6 +846,10 @@ export function LayerPanel({
                       align="end"
                       onClick={(e: ReactMouseEvent) => e.stopPropagation()}
                     >
+                      {/* Rename is always available — name is a display-only
+                          label, so no per-layer-type guard is needed here.
+                          preventDefault keeps the menu's default close from
+                          racing autoFocus on the rename input. */}
                       <DropdownMenuItem
                         onSelect={(e: Event) => {
                           e.preventDefault();

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -43,6 +43,7 @@ import {
   MousePointerClick,
   PanelLeftClose,
   PanelLeftOpen,
+  Pencil,
   PencilRuler,
   RefreshCw,
   Table2,
@@ -160,6 +161,8 @@ export function LayerPanel({
   const moveLayer = useAppStore((s) => s.moveLayer);
   const removeLayer = useAppStore((s) => s.removeLayer);
   const updateLayer = useAppStore((s) => s.updateLayer);
+  const [editingLayerId, setEditingLayerId] = useState<string | null>(null);
+  const [editingName, setEditingName] = useState("");
   const [metadataLayer, setMetadataLayer] = useState<GeoLibreLayer | null>(
     null,
   );
@@ -213,6 +216,27 @@ export function LayerPanel({
   const resetDragState = () => {
     setDraggedLayerId(null);
     setDropTargetLayerId(null);
+  };
+
+  const beginRename = (layer: GeoLibreLayer) => {
+    setEditingLayerId(layer.id);
+    setEditingName(layer.name);
+  };
+
+  const commitRename = () => {
+    if (!editingLayerId) return;
+    const trimmed = editingName.trim();
+    const current = layers.find((l) => l.id === editingLayerId);
+    if (trimmed && current && trimmed !== current.name) {
+      updateLayer(editingLayerId, { name: trimmed });
+    }
+    setEditingLayerId(null);
+    setEditingName("");
+  };
+
+  const cancelRename = () => {
+    setEditingLayerId(null);
+    setEditingName("");
   };
 
   const clearRefreshStatusTimer = useCallback((layerId: string) => {

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1875,6 +1875,15 @@ html:not(.dark) .vector-control-popup,
   color-scheme: dark;
 }
 
+/* The panel content scrolls vertically (overflow-y: auto), which forces
+   overflow-x to clip and cuts off the Load button's offset focus ring on
+   the right edge. Give the scroll area a little horizontal breathing room
+   so the ring is not clipped. */
+.vector-control-panel.geolibre-vector-panel .vector-control-content {
+  padding-left: 5px;
+  padding-right: 5px;
+}
+
 /* The upstream stylesheet themes the MapLibre popup chrome around the
    picker popup from prefers-color-scheme; re-key it to the app theme. The
    html prefixes also outrank the upstream :has() rules when the OS scheme

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1880,8 +1880,7 @@ html:not(.dark) .vector-control-popup,
    the right edge. Give the scroll area a little horizontal breathing room
    so the ring is not clipped. */
 .vector-control-panel.geolibre-vector-panel .vector-control-content {
-  padding-left: 5px;
-  padding-right: 5px;
+  padding-inline: 5px;
 }
 
 /* The upstream stylesheet themes the MapLibre popup chrome around the

--- a/docs/superpowers/plans/2026-06-11-layer-rename-and-load-button-fix.md
+++ b/docs/superpowers/plans/2026-06-11-layer-rename-and-load-button-fix.md
@@ -1,0 +1,298 @@
+# Layer Rename + Load Button Border Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add inline layer renaming to the Layers panel and stop the Add Vector Layer "Load" button focus ring from being clipped on its right edge.
+
+**Architecture:** Pure GeoLibre frontend change. Renaming reuses the existing `updateLayer(id, patch)` store action driven by new local edit state in `LayerPanel.tsx`; the Load button fix is a scoped CSS override in `index.css`. No store, schema, or map-sync changes.
+
+**Tech Stack:** React + TypeScript, Zustand store (`@geolibre/core`), shadcn-style `@geolibre/ui` primitives, lucide-react icons, Tailwind CSS.
+
+**Scope:** This is GeoLibre PR #1 of the spec at `docs/superpowers/specs/2026-06-11-layer-panel-rename-and-vector-refresh-design.md`. Part 3 (Add-Vector-Layer auto refresh) is deferred to a later upstream release + second PR and is NOT in this plan.
+
+**Testing reality:** The frontend test harness (`npm run test:frontend`, `node --test`) runs logic-level tests with no React component renderer, so these UI/CSS changes are verified by `npm run typecheck` plus manual verification in the running web app (`npm run dev`). There is no meaningful pure-logic unit to TDD beyond the already-covered `updateLayer` store action.
+
+**Branch:** Create a feature branch before the first commit (never commit to `main`). Suggested: `feat/layer-rename-and-load-button-fix`.
+
+---
+
+### Task 0: Create the feature branch
+
+- [ ] **Step 1: Branch off main**
+
+Run:
+```bash
+git checkout -b feat/layer-rename-and-load-button-fix
+```
+Expected: `Switched to a new branch 'feat/layer-rename-and-load-button-fix'`
+
+---
+
+### Task 1: Add `Pencil` icon import and rename edit state
+
+**Files:**
+- Modify: `apps/geolibre-desktop/src/components/panels/LayerPanel.tsx` (imports ~line 34-52; component state ~line 162-180)
+
+- [ ] **Step 1: Add the `Pencil` icon to the lucide-react import block**
+
+In the `lucide-react` import (currently lines 34-52), add `Pencil` in alphabetical order between `PanelLeftOpen` and `PencilRuler`:
+
+```tsx
+  PanelLeftClose,
+  PanelLeftOpen,
+  Pencil,
+  PencilRuler,
+  RefreshCw,
+```
+
+- [ ] **Step 2: Add rename edit state next to the other `useState` hooks**
+
+Immediately after the `updateLayer` selector (line 162) and before `metadataLayer` state, add:
+
+```tsx
+  const [editingLayerId, setEditingLayerId] = useState<string | null>(null);
+  const [editingName, setEditingName] = useState("");
+```
+
+- [ ] **Step 3: Add rename helper callbacks**
+
+After the existing `resetDragState` definition (around line 213-216), add three helpers:
+
+```tsx
+  const beginRename = (layer: GeoLibreLayer) => {
+    setEditingLayerId(layer.id);
+    setEditingName(layer.name);
+  };
+
+  const commitRename = () => {
+    if (!editingLayerId) return;
+    const trimmed = editingName.trim();
+    const current = layers.find((l) => l.id === editingLayerId);
+    if (trimmed && current && trimmed !== current.name) {
+      updateLayer(editingLayerId, { name: trimmed });
+    }
+    setEditingLayerId(null);
+    setEditingName("");
+  };
+
+  const cancelRename = () => {
+    setEditingLayerId(null);
+    setEditingName("");
+  };
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `npm run typecheck`
+Expected: build succeeds with no new type errors (unused `beginRename`/`commitRename`/`cancelRename` are referenced in Task 2, so if typecheck flags them as unused here, proceed to Task 2 before re-checking — or complete Tasks 1 and 2 before the first typecheck).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+git commit -m "feat(layers): add rename edit state and Pencil icon to layer panel"
+```
+
+---
+
+### Task 2: Render the name as an inline editable input + double-click trigger
+
+**Files:**
+- Modify: `apps/geolibre-desktop/src/components/panels/LayerPanel.tsx` (name span ~line 610-612)
+
+- [ ] **Step 1: Replace the static name span with a conditional input/span**
+
+Replace the current name span (lines 610-612):
+
+```tsx
+                  <span className="flex-1 truncate text-sm font-medium">
+                    {layer.name}
+                  </span>
+```
+
+with:
+
+```tsx
+                  {editingLayerId === layer.id ? (
+                    <input
+                      autoFocus
+                      type="text"
+                      className="flex-1 min-w-0 rounded border border-input bg-background px-1 py-0.5 text-sm font-medium outline-none focus:ring-1 focus:ring-ring"
+                      value={editingName}
+                      aria-label={`Rename ${layer.name}`}
+                      onChange={(e) => setEditingName(e.target.value)}
+                      onClick={(e: ReactMouseEvent) => e.stopPropagation()}
+                      onFocus={(e) => e.currentTarget.select()}
+                      onBlur={commitRename}
+                      onKeyDown={(e) => {
+                        e.stopPropagation();
+                        if (e.key === "Enter") {
+                          e.preventDefault();
+                          commitRename();
+                        } else if (e.key === "Escape") {
+                          e.preventDefault();
+                          cancelRename();
+                        }
+                      }}
+                    />
+                  ) : (
+                    <span
+                      className="flex-1 truncate text-sm font-medium"
+                      title="Double-click to rename"
+                      onDoubleClick={(e: ReactMouseEvent) => {
+                        e.stopPropagation();
+                        beginRename(layer);
+                      }}
+                    >
+                      {layer.name}
+                    </span>
+                  )}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+Expected: build succeeds, no type errors. `beginRename`/`commitRename`/`cancelRename` are now all referenced.
+
+- [ ] **Step 3: Manual verification in the running app**
+
+Run: `npm run dev` then open http://localhost:5173. Add any layer (e.g. the sample places plugin). Then verify:
+- Double-click the layer name → it becomes a text input with all text selected.
+- Type a new name, press Enter → the name updates in the panel.
+- Double-click again, change text, press Escape → reverts to the prior name.
+- Double-click, clear the field, click elsewhere (blur) → name stays unchanged (empty no-op).
+- Clicking the input does not toggle layer selection or start a drag.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+git commit -m "feat(layers): rename layer by double-clicking its name"
+```
+
+---
+
+### Task 3: Add a "Rename" item to the per-layer "..." dropdown menu
+
+**Files:**
+- Modify: `apps/geolibre-desktop/src/components/panels/LayerPanel.tsx` (dropdown content ~line 772-776)
+
+- [ ] **Step 1: Add a Rename menu item at the top of the dropdown content**
+
+Inside `<DropdownMenuContent align="end" ...>` (opens at line 772), insert as the FIRST child, before the `{canMaterializeDuckDB && (` block (line 776):
+
+```tsx
+                      <DropdownMenuItem
+                        onSelect={(e: Event) => {
+                          e.preventDefault();
+                          beginRename(layer);
+                        }}
+                      >
+                        <Pencil className="mr-2 h-3.5 w-3.5" />
+                        Rename
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+Expected: build succeeds, no type errors.
+
+- [ ] **Step 3: Manual verification**
+
+In the running app: open a layer's `...` menu → click **Rename** → the name field becomes an editable input focused with text selected. Enter commits, Escape cancels. Confirm the dropdown closes when Rename is chosen.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+git commit -m "feat(layers): add Rename action to layer actions menu"
+```
+
+---
+
+### Task 4: Fix the clipped Load button focus ring in the Add Vector Layer panel
+
+**Files:**
+- Modify: `apps/geolibre-desktop/src/index.css` (append a scoped override near the existing `.geolibre-vector-panel` theming block, after line ~1876)
+
+**Why:** The upstream `.vector-control-button:focus` uses `outline: 2px solid; outline-offset: 2px`. The button sits flush against the right edge of `.vector-control-content`, whose `overflow-y: auto` forces `overflow-x` to clip, cutting off the right side of the ring. The fix gives the ring horizontal room inside the clip box. Never edit `node_modules` (repo convention).
+
+- [ ] **Step 1: Append the scoped override**
+
+After the dark-theme vector block that ends at line 1876 (`}` closing `.dark .vector-control...`), append:
+
+```css
+/* The panel content scrolls vertically (overflow-y: auto), which forces
+   overflow-x to clip and cuts off the Load button's offset focus ring on
+   the right edge. Give the scroll area a little horizontal breathing room
+   so the ring is not clipped. */
+.vector-control-panel.geolibre-vector-panel .vector-control-content {
+  padding-left: 3px;
+  padding-right: 3px;
+}
+```
+
+- [ ] **Step 2: Typecheck/build (CSS is bundled by Vite)**
+
+Run: `npm run typecheck`
+Expected: build succeeds.
+
+- [ ] **Step 3: Manual verification (light and dark)**
+
+In the running app: open Plugins → Add Vector Layer (or the vector control). Click into the URL field, then click/focus the **Load** button. Confirm the full focus ring renders on all four sides, including the right edge, with no clipping. Toggle dark mode (Settings) and re-check. Confirm the URL input and Load button are not visually cramped by the added padding.
+
+- [ ] **Step 4: If 3px padding is insufficient or looks cramped, adjust**
+
+If the right edge is still clipped, increase to `padding-left/right: 4px`. If the row feels cramped, instead reduce the ring offset by adding to the same override block:
+
+```css
+.vector-control-panel.geolibre-vector-panel .vector-control-url-row .vector-control-button:focus {
+  outline-offset: 1px;
+}
+```
+
+Re-verify per Step 3. Keep whichever single approach reads cleanest; do not ship both unless both are needed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/geolibre-desktop/src/index.css
+git commit -m "fix(vector): stop Load button focus ring from being clipped"
+```
+
+---
+
+### Task 5: Pre-push gate and PR
+
+**Files:** none (process)
+
+- [ ] **Step 1: Run the scoped pre-commit hook on the changed files**
+
+Run:
+```bash
+pre-commit run --files apps/geolibre-desktop/src/components/panels/LayerPanel.tsx apps/geolibre-desktop/src/index.css docs/superpowers/specs/2026-06-11-layer-panel-rename-and-vector-refresh-design.md docs/superpowers/plans/2026-06-11-layer-rename-and-load-button-fix.md
+```
+Expected: hooks pass (the local `npm-build` hook compiles the app). Fix any reported issues and re-run.
+
+- [ ] **Step 2: Full typecheck once more**
+
+Run: `npm run typecheck`
+Expected: build succeeds.
+
+- [ ] **Step 3: Push and open the PR**
+
+Run:
+```bash
+git push -u origin feat/layer-rename-and-load-button-fix
+```
+Then open a PR as `giswqs` against `main`. PR body: summarize layer rename (double-click + Rename menu item) and the Load button focus-ring fix; note Part 3 (Add-Vector-Layer auto refresh) is tracked separately and lands after the upstream `reloadLayer()` release.
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** Part 1 (rename) → Tasks 1-3. Part 2 (Load button) → Task 4. Part 3 is explicitly out of scope for this plan (deferred per the split-delivery decision).
+- **Type consistency:** `beginRename(layer)`, `commitRename()`, `cancelRename()`, `editingLayerId`, `editingName` are defined in Task 1 and used in Tasks 2-3 with matching signatures.
+- **No placeholders:** every code step shows the exact code; Task 4 Step 4 is a conditional adjustment with concrete alternatives, not a placeholder.

--- a/docs/superpowers/specs/2026-06-11-layer-panel-rename-and-vector-refresh-design.md
+++ b/docs/superpowers/specs/2026-06-11-layer-panel-rename-and-vector-refresh-design.md
@@ -1,0 +1,95 @@
+# Layer rename, Load button border fix, and Add-Vector-Layer auto refresh
+
+Date: 2026-06-11
+
+## Summary
+
+Three independent changes, two repos:
+
+1. **Rename layers** in the GeoLibre Layers panel (GeoLibre only).
+2. **Fix the clipped "Load" button focus ring** in the Add Vector Layer panel (GeoLibre only).
+3. **Enable Auto Refresh for Add-Vector-Layer GeoJSON-URL layers** via a new upstream `reloadLayer()` API (maplibre-gl-vector + GeoLibre).
+
+Parts 1 and 2 ship together in a GeoLibre PR. Part 3 is upstream-first: add and release `reloadLayer()` in maplibre-gl-vector, then bump the dependency and wire it in GeoLibre.
+
+## Part 1: Rename layers
+
+### Goal
+Let users rename a layer's display label in the Layers panel.
+
+### Background
+- `GeoLibreLayer.name` (`packages/core/src/types.ts`) is a pure display label. MapLibre sync keys off `layer.id`, never `name`, so a rename cannot break rendering (`packages/map/src/layer-sync.ts`, `map-controller.ts`).
+- The store already has a generic `updateLayer(id, patch)` action (`packages/core/src/store.ts`), so renaming is `updateLayer(layer.id, { name })`. No new store action.
+
+### Design (`apps/geolibre-desktop/src/components/panels/LayerPanel.tsx`)
+- Track edit state with component state: `editingLayerId: string | null` and `editingName: string`.
+- The layer name `<span>` (currently `LayerPanel.tsx:610`) renders as a text `<input>` when `editingLayerId === layer.id`, otherwise as the existing span.
+- **Two entry triggers** (per user's choice):
+  - Double-click the name span enters edit mode.
+  - A new **Rename** `DropdownMenuItem` (with a `Pencil` icon) added at the top of the per-layer `...` menu (before "Materialize"/"Refresh").
+- On entering edit mode the input auto-focuses and selects all text.
+- **Commit:** Enter key or input blur calls `updateLayer(layer.id, { name: trimmed })`. No-op when the value is empty or unchanged. **Escape** cancels without committing.
+- `stopPropagation` on the input's mouse/key events so editing does not toggle layer selection or trigger drag.
+- Applies only to real `GeoLibreLayer` entries, not the synthetic "Background" basemap row.
+
+### Testing
+- A `tests/*.test.ts` frontend test asserting `updateLayer` renames and that sync/MapLibre is unaffected (name is not used as a key). Manual verification in the running app for the double-click and menu paths, including Escape-cancel and empty-name no-op.
+
+## Part 2: Load button border clipping
+
+### Goal
+The "Load" button's focus ring in the Add Vector Layer panel is clipped on its right edge. Show the full ring.
+
+### Root cause
+- The button is the upstream `maplibre-gl-vector` `.vector-control-button`. Its `:focus` style is `outline: 2px solid; outline-offset: 2px` (upstream `maplibre-gl-vector.css`).
+- The button sits flush against the right edge of `.vector-control-content`, which has `overflow-y: auto`. Per CSS, that forces `overflow-x` to a clipping value, so the offset focus ring is cut off on the right.
+
+### Design (`apps/geolibre-desktop/src/index.css`)
+- Add a scoped override under `.geolibre-vector-panel` (never edit `node_modules`, per repo convention) that gives the focus ring room so it is not clipped. Preferred approach: a few px of `padding-right` on `.vector-control-content` (and matching left padding to stay symmetric), or reduce the button's `outline-offset` so the ring stays inside the clip box.
+- Choose whichever reads cleanest in the running app and verify visually in both light and dark themes.
+
+### Testing
+- Visual verification in the running web app: focus/click the Load button and confirm the full ring renders, including the right edge, in light and dark mode.
+
+## Part 3: Auto Refresh for Add-Vector-Layer GeoJSON-URL layers
+
+### Goal
+A GeoJSON layer added through the Add Vector Layer panel via an HTTP(S) URL should support manual Refresh and Auto Refresh, matching WFS layers.
+
+### Background / why it is currently excluded
+- WFS layers are added through `addGeoJsonLayer` and are store-rendered GeoJSON; the existing refresh path re-fetches and calls `updateLayer({ geojson })` (`apps/geolibre-desktop/src/lib/layer-refresh.ts`).
+- Add-Vector-Layer URL layers are created by the external maplibre-gl-vector control, which owns native MapLibre sources/layers. Their store layer is tagged `externalNativeLayer: true` and `sourceKind: "maplibre-gl-vector"` (`packages/plugins/src/plugins/vector-layer-sync.ts: createVectorStoreLayer`).
+- `refreshSourceUrl` returns `null` when `externalNativeLayer === true` (`layer-refresh.ts:188`), so these layers are never refreshable. The store-geojson refresh path also cannot drive them, because the control renders the data, not the store.
+- The control exposes only `addData()` and `removeLayer()` (no in-place reload). Remove + re-add would mint a new layer id each refresh, breaking selection, ordering, and the auto-refresh timer config. Hence the upstream-first approach.
+
+### Upstream change (maplibre-gl-vector)
+
+Add an in-place reload that re-fetches a URL-backed layer while preserving its id, source id, style, render mode, and position. Model it on the existing in-place `setRenderMode()` re-render (`src/lib/core/LayerManager.ts`).
+
+`LayerManager.reloadLayer(id)`:
+1. Look up the record; return `undefined` if missing. If `record.source` is not a URL string, return the current info unchanged (files/in-memory GeoJSON are static).
+2. Emit `loading` (`Refreshing <name>...`).
+3. Tear down current presentation: `_detachPicker`, `removeLayersAndSource(map, layerIds, sourceId)`, unregister the tile provider if any, reset `record.info.layerIds = []`.
+4. Drop the stale engine table (`record.tableName`) and clear it, so the next ingest re-fetches fresh data.
+5. Re-run the load pipeline preserving the current render mode/ingest mode/sourceLayer: `_addGeoJSON(record, opts)` for GeoJSON render, else `_addViaEngine(record, opts)`. Passing the resolved `renderMode` ('geojson'/'tiles') keeps the chosen mode stable.
+6. Emit `layerupdated` (same event `setRenderMode` uses) and return the refreshed info.
+
+`VectorControl.reloadLayer(id)` delegates to `this._layerManager?.reloadLayer(id)`. Expose it on the type declarations (`dist/types`) and the React imperative handle (`VectorControlReact` / `react.ts`) for parity with `removeLayer`/`getLayers`.
+
+Add a unit test (vitest) that reloads a URL layer and asserts the id/sourceId are preserved and the data re-fetches. Release a new version (the opengeos packages publish to npm on `gh release create`).
+
+### GeoLibre wiring (after the upstream release)
+- Bump the `maplibre-gl-vector` dependency to the release that includes `reloadLayer()`.
+- `packages/plugins/src/plugins/vector-layer-sync.ts`: add `reloadLayer` to the `VectorSyncableControl` type.
+- `packages/plugins/src/plugins/maplibre-vector.ts`: export an accessor for the active control (or a `refreshVectorLayer(id)` helper) so the refresh handler can reach it.
+- `apps/geolibre-desktop/src/lib/layer-refresh.ts`: treat a vector-control layer (`type === "geojson"`, `externalNativeLayer === true`, `sourceKind === "maplibre-gl-vector"`) with an HTTP(S) URL as refreshable, instead of bailing on the `externalNativeLayer` flag.
+- `apps/geolibre-desktop/src/components/panels/LayerPanel.tsx`: branch `handleRefreshLayer` so vector-control layers refresh through `control.reloadLayer(layer.id)`, while existing store-geojson layers keep the `refreshGeoJsonLayer` + `updateLayer` path. The id is stable across reload, so the existing auto-refresh scheduler (keyed by `layer.id`) keeps working without timer churn. Update the menu hint text accordingly.
+
+### Testing
+- Upstream: vitest for `reloadLayer` (id/source preserved, data re-fetched).
+- GeoLibre: frontend test that `isRefreshableLayer` returns true for a vector-control URL layer; manual verification in the running app that manual Refresh and Auto Refresh both work for an Add-Vector-Layer URL layer and the layer id/selection/position survive a refresh.
+
+## Sequencing
+1. GeoLibre PR: Part 1 + Part 2.
+2. maplibre-gl-vector: implement + test + release `reloadLayer()`.
+3. GeoLibre PR: bump dep + Part 3 wiring.

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -239,6 +239,21 @@ describe("app store", () => {
     assert.equal(useAppStore.getState().selectedLayerId, second);
   });
 
+  it("renames a layer without changing its id (keeps MapLibre sync stable)", () => {
+    const id = useAppStore.getState().addGeoJsonLayer("Original", {
+      type: "FeatureCollection",
+      features: [],
+    });
+
+    useAppStore.getState().updateLayer(id, { name: "Renamed" });
+
+    const layer = useAppStore.getState().layers.find((l) => l.id === id);
+    assert.ok(layer);
+    assert.equal(layer.name, "Renamed");
+    // The id is the MapLibre source/layer key — renaming must not touch it.
+    assert.equal(layer.id, id);
+  });
+
   it("deduplicates recent projects and normalizes empty names", () => {
     useAppStore.getState().setRecentProjects([
       { path: "/tmp/a.geolibre.json", name: "", openedAt: "2026-01-01T00:00:00Z" },


### PR DESCRIPTION
## Summary

Two focused Layers/Add-Vector-Layer improvements:

1. **Rename layers** in the Layers panel. Double-click a layer name to edit it inline, or use the new **Rename** item in the per-layer "..." menu. Enter commits, Escape cancels, blur commits; empty/unchanged names are no-ops. Renaming applies only to real layers, not the Background basemap row.
2. **Fix the clipped "Load" button focus ring** in the Add Vector Layer panel. The panel content scrolls vertically (`overflow-y: auto`), which forces `overflow-x` to clip and cut off the button's offset focus ring on the right edge. A scoped override in `index.css` gives the scroll area a little horizontal breathing room (the upstream `maplibre-gl-vector` stylesheet is left untouched, per repo convention).

## Implementation notes

- `name` is a pure display label; MapLibre sync keys off `layer.id`, so renaming cannot affect rendering. Renaming reuses the existing generic `updateLayer(id, { name })` store action, so there are no store/schema/map-sync changes.
- All changes are frontend-only: `apps/geolibre-desktop/src/components/panels/LayerPanel.tsx` and `apps/geolibre-desktop/src/index.css`.

## Verification

- `npm run typecheck` (full `tsc -b && vite build`) passes.
- `pre-commit run --files` (including the `npm build` hook) passes.
- Pending manual check in the running app: the inline rename interactions (double-click / Enter / Escape / blur) and the Load button focus ring in both light and dark themes.

## Not in this PR

Auto Refresh for Add-Vector-Layer GeoJSON-URL layers is tracked separately. Those layers are owned by the external maplibre-gl-vector control, which has no in-place reload API, so that work lands after an upstream `reloadLayer()` release and a follow-up dependency bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Layers can be renamed inline via double-click or the layer menu; edits commit on Enter/blur and cancel with Escape.

* **Bug Fixes**
  * Fixed focus-ring clipping on the Load button in the Vector Layer panel when the panel content scrolls.

* **Tests**
  * Added a unit test ensuring renaming a layer does not change its internal identifier.

* **Documentation**
  * Added plans and spec documents describing the rename UX and the Load-button fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->