### PR TITLE
feat(layers): Auto Refresh for Add Vector Layer URL layers

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -54,7 +54,7 @@
     "maplibre-gl-streetview": "^0.5.0",
     "maplibre-gl-swipe": "^0.7.1",
     "maplibre-gl-time-slider": "^1.0.3",
-    "maplibre-gl-vector": "^0.2.1",
+    "maplibre-gl-vector": "^0.2.4",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "shpjs": "^6.2.0",

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -9,7 +9,10 @@ import {
 } from "react";
 import { isDuckDBQueryLayer, useAppStore } from "@geolibre/core";
 import type { GeoLibreLayer } from "@geolibre/core";
-import { canEditLayerGeometry } from "@geolibre/plugins";
+import {
+  canEditLayerGeometry,
+  reloadVectorControlLayer,
+} from "@geolibre/plugins";
 import type { MapController } from "@geolibre/map";
 import { isPlaceholderLayer, placeholderMessage } from "@geolibre/map";
 import {
@@ -53,6 +56,7 @@ import {
 import {
   getLayerRefreshConfig,
   isRefreshableLayer,
+  isVectorControlRefreshLayer,
   MIN_REFRESH_INTERVAL_MS,
   refreshGeoJsonLayer,
   setLayerRefreshConfig,
@@ -257,6 +261,28 @@ export function LayerPanel({
       }));
 
       try {
+        if (isVectorControlRefreshLayer(layer)) {
+          const info = await reloadVectorControlLayer(layer.id);
+          if (!info) {
+            throw new Error(
+              "Open the Add Vector Layer panel to refresh this layer.",
+            );
+          }
+          const featureCount =
+            typeof info.featureCount === "number" ? info.featureCount : null;
+          setRefreshStatuses((current) => ({
+            ...current,
+            [layer.id]: {
+              type: "success",
+              message:
+                featureCount === null
+                  ? "Refreshed."
+                  : `Refreshed ${featureCount.toLocaleString()} features.`,
+            },
+          }));
+          scheduleStatusClear(layer.id);
+          return;
+        }
         const { geojson, featureCount } = await refreshGeoJsonLayer(layer);
         const latest = useAppStore
           .getState()

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -264,10 +264,30 @@ export function LayerPanel({
         if (isVectorControlRefreshLayer(layer)) {
           const info = await reloadVectorControlLayer(layer.id);
           if (!info) {
+            // The control is unavailable (panel never opened, or torn down
+            // and not yet replayed) or no longer knows this layer id.
+            // Automatic ticks fire on a timer the user didn't initiate, so
+            // skip silently and clear the transient note instead of surfacing
+            // an error every interval until the control comes back.
+            if (automatic) {
+              setRefreshStatuses((current) => {
+                if (!current[layer.id]) return current;
+                const next = { ...current };
+                delete next[layer.id];
+                return next;
+              });
+              return;
+            }
             throw new Error(
-              "Open the Add Vector Layer panel to refresh this layer.",
+              "Could not refresh this layer. Try re-opening the Add Vector Layer panel.",
             );
           }
+          // reloadLayer fires `layerupdated`, which drives
+          // syncVectorLayersToStore to persist the refreshed featureCount (and
+          // bounds) into the store. We intentionally don't call updateLayer
+          // here: the metadata write is handled by that event, and a second
+          // write would risk clobbering the synced values. `info` feeds only
+          // the toast below.
           const featureCount =
             typeof info.featureCount === "number" ? info.featureCount : null;
           setRefreshStatuses((current) => ({

--- a/apps/geolibre-desktop/src/lib/layer-refresh.ts
+++ b/apps/geolibre-desktop/src/lib/layer-refresh.ts
@@ -10,6 +10,12 @@ const REFRESHABLE_GEOJSON_SOURCE_KINDS = new Set([
   "geojson-url",
 ]);
 
+// Add Vector Layer (maplibre-gl-vector) tags its store layers with this
+// sourceKind. Mirrors VECTOR_SOURCE_KIND in @geolibre/plugins; kept local so
+// this module stays dependency-light (it is exercised in node tests). The
+// same literal is already used in AttributeTable.tsx.
+const VECTOR_CONTROL_SOURCE_KIND = "maplibre-gl-vector";
+
 export interface LayerRefreshConfig {
   enabled: boolean;
   intervalMs: number;
@@ -95,8 +101,25 @@ export async function refreshGeoJsonLayer(
   };
 }
 
+/**
+ * True when the layer is an Add Vector Layer (maplibre-gl-vector) layer
+ * backed by an HTTP(S) URL. These render through the external control's own
+ * native sources, so they refresh via VectorControl.reloadLayer rather than
+ * the store-GeoJSON path. Covers both GeoJSON and tile render modes.
+ *
+ * @param layer - The store layer to test.
+ * @returns Whether the layer refreshes through the vector control.
+ */
+export function isVectorControlRefreshLayer(layer: GeoLibreLayer): boolean {
+  return (
+    layer.metadata.sourceKind === VECTOR_CONTROL_SOURCE_KIND &&
+    layer.metadata.externalNativeLayer === true &&
+    layerHttpUrl(layer) !== null
+  );
+}
+
 export function isRefreshableLayer(layer: GeoLibreLayer): boolean {
-  return Boolean(refreshSourceUrl(layer));
+  return Boolean(refreshSourceUrl(layer)) || isVectorControlRefreshLayer(layer);
 }
 
 export function getLayerRefreshConfig(
@@ -174,15 +197,20 @@ function parseGeoJsonFeatureCollection(value: unknown): FeatureCollection {
   return value as FeatureCollection;
 }
 
-function refreshSourceUrl(layer: GeoLibreLayer): string | null {
-  if (layer.type !== "geojson") return null;
-
+function layerHttpUrl(layer: GeoLibreLayer): string | null {
   const sourcePath =
     typeof layer.sourcePath === "string" ? layer.sourcePath.trim() : "";
   const sourceUrl =
     typeof layer.source.url === "string" ? layer.source.url.trim() : "";
   const url = sourceUrl || sourcePath;
-  if (!isHttpUrl(url)) return null;
+  return isHttpUrl(url) ? url : null;
+}
+
+function refreshSourceUrl(layer: GeoLibreLayer): string | null {
+  if (layer.type !== "geojson") return null;
+
+  const url = layerHttpUrl(layer);
+  if (!url) return null;
 
   if (isWfsLayer(layer)) return url;
   if (layer.metadata.externalNativeLayer === true) return null;

--- a/apps/geolibre-desktop/src/lib/layer-refresh.ts
+++ b/apps/geolibre-desktop/src/lib/layer-refresh.ts
@@ -11,9 +11,11 @@ const REFRESHABLE_GEOJSON_SOURCE_KINDS = new Set([
 ]);
 
 // Add Vector Layer (maplibre-gl-vector) tags its store layers with this
-// sourceKind. Mirrors VECTOR_SOURCE_KIND in @geolibre/plugins; kept local so
-// this module stays dependency-light (it is exercised in node tests). The
-// same literal is already used in AttributeTable.tsx.
+// sourceKind. Canonical source is VECTOR_SOURCE_KIND in
+// packages/plugins/src/plugins/vector-layer-sync.ts; kept local (not imported)
+// so this module stays dependency-light for the node test runner. If the
+// canonical value ever changes, update this copy and the literal in
+// AttributeTable.tsx — there is no compile-time link between them.
 const VECTOR_CONTROL_SOURCE_KIND = "maplibre-gl-vector";
 
 export interface LayerRefreshConfig {

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "maplibre-gl-streetview": "^0.5.0",
         "maplibre-gl-swipe": "^0.7.1",
         "maplibre-gl-time-slider": "^1.0.3",
-        "maplibre-gl-vector": "^0.2.1",
+        "maplibre-gl-vector": "^0.2.4",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "shpjs": "^6.2.0",
@@ -10675,9 +10675,9 @@
       }
     },
     "node_modules/maplibre-gl-vector": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.2.3.tgz",
-      "integrity": "sha512-y8G1YiTxEYNWcFKpCd/gjWJbeVyovYLzd7+Q9Lgj8RKF850fTswCwkRus3tTcO9+MTyzVp/uA0KvXVK2f6wzUw==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.2.4.tgz",
+      "integrity": "sha512-Q1d7jOwxb6Zz0+zcN2P7IOWqh29ztmb2V8bGwAz0DK+oc+eJIrenSQ0Jp1+Jv7Ev2zzN4RGo8+rnQlsB3fKKoA==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"
@@ -13177,7 +13177,7 @@
         "maplibre-gl-streetview": "^0.5.0",
         "maplibre-gl-swipe": "^0.7.1",
         "maplibre-gl-time-slider": "^1.0.3",
-        "maplibre-gl-vector": "^0.2.1",
+        "maplibre-gl-vector": "^0.2.4",
         "proj4": "^2.20.9",
         "shpjs": "^6.2.0",
         "three": "^0.184.0"

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -46,7 +46,7 @@
     "maplibre-gl-streetview": "^0.5.0",
     "maplibre-gl-swipe": "^0.7.1",
     "maplibre-gl-time-slider": "^1.0.3",
-    "maplibre-gl-vector": "^0.2.1",
+    "maplibre-gl-vector": "^0.2.4",
     "proj4": "^2.20.9",
     "shpjs": "^6.2.0",
     "three": "^0.184.0"

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -94,6 +94,7 @@ export {
 export {
   closeVectorLayerPanel,
   openVectorLayerPanel,
+  reloadVectorControlLayer,
   restoreVectorLayers,
 } from "./plugins/maplibre-vector";
 // The raster-layer-sync and vector-layer-sync internals are not

--- a/packages/plugins/src/plugins/maplibre-vector.ts
+++ b/packages/plugins/src/plugins/maplibre-vector.ts
@@ -2,6 +2,7 @@ import { useAppStore } from "@geolibre/core";
 import type {
   VectorControl,
   VectorControlEventHandler,
+  VectorLayerInfo,
 } from "maplibre-gl-vector";
 import type { GeoLibreAppAPI, GeoLibreMapControlPosition } from "../types";
 import {
@@ -103,6 +104,22 @@ export function closeVectorLayerPanel(app: GeoLibreAppAPI): void {
   resetVectorStoreSyncSuspension();
   vectorControl = null;
   vectorControlMounted = false;
+}
+
+/**
+ * Re-fetches a URL-backed Add Vector Layer layer in place through the
+ * control's reloadLayer API, preserving the layer id. Returns the refreshed
+ * layer info, or undefined when the control is not mounted or does not know
+ * the layer (e.g. the panel was fully torn down).
+ *
+ * @param id - The store/control layer id.
+ * @returns The refreshed layer info, or undefined.
+ */
+export async function reloadVectorControlLayer(
+  id: string,
+): Promise<VectorLayerInfo | undefined> {
+  if (!vectorControl) return undefined;
+  return vectorControl.reloadLayer(id);
 }
 
 /**

--- a/packages/plugins/src/plugins/maplibre-vector.ts
+++ b/packages/plugins/src/plugins/maplibre-vector.ts
@@ -109,8 +109,8 @@ export function closeVectorLayerPanel(app: GeoLibreAppAPI): void {
 /**
  * Re-fetches a URL-backed Add Vector Layer layer in place through the
  * control's reloadLayer API, preserving the layer id. Returns the refreshed
- * layer info, or undefined when the control is not mounted or does not know
- * the layer (e.g. the panel was fully torn down).
+ * layer info, or undefined when the control singleton is null (not yet
+ * created or already removed) or the layer id is unknown to the control.
  *
  * @param id - The store/control layer id.
  * @returns The refreshed layer info, or undefined.

--- a/tests/layer-refresh.test.ts
+++ b/tests/layer-refresh.test.ts
@@ -78,6 +78,20 @@ describe("isVectorControlRefreshLayer / isRefreshableLayer", () => {
     assert.equal(isRefreshableLayer(layer), true);
   });
 
+  it("treats a tiles-mode (vector-tiles) vector-control layer as refreshable", () => {
+    const layer = makeLayer({
+      type: "vector-tiles",
+      source: { type: "vector", url: "https://x.com/a.pmtiles" },
+      metadata: {
+        sourceKind: "maplibre-gl-vector",
+        externalNativeLayer: true,
+      },
+    });
+
+    assert.equal(isVectorControlRefreshLayer(layer), true);
+    assert.equal(isRefreshableLayer(layer), true);
+  });
+
   it("does not treat a plain store layer as a vector-control refresh layer", () => {
     const layer = makeLayer({
       type: "geojson",

--- a/tests/layer-refresh.test.ts
+++ b/tests/layer-refresh.test.ts
@@ -67,4 +67,15 @@ describe("isVectorControlRefreshLayer / isRefreshableLayer", () => {
 
     assert.equal(isRefreshableLayer(layer), true);
   });
+
+  it("legacy untagged geojson-url layer is refreshable via the store path", () => {
+    const layer = makeLayer({
+      type: "geojson",
+      source: { type: "geojson", url: "https://example.com/data.geojson" },
+      metadata: {},
+    });
+
+    assert.equal(isRefreshableLayer(layer), true);
+    assert.equal(isVectorControlRefreshLayer(layer), false);
+  });
 });

--- a/tests/layer-refresh.test.ts
+++ b/tests/layer-refresh.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { DEFAULT_LAYER_STYLE, type GeoLibreLayer } from "@geolibre/core";
+import {
+  isRefreshableLayer,
+  isVectorControlRefreshLayer,
+} from "../apps/geolibre-desktop/src/lib/layer-refresh";
+
+function makeLayer(patch: Partial<GeoLibreLayer> = {}): GeoLibreLayer {
+  return {
+    id: "layer-1",
+    name: "Test Layer",
+    type: "geojson",
+    source: { type: "geojson" },
+    visible: true,
+    opacity: 1,
+    style: DEFAULT_LAYER_STYLE,
+    metadata: {},
+    ...patch,
+  };
+}
+
+describe("isVectorControlRefreshLayer / isRefreshableLayer", () => {
+  it("treats a vector-control URL layer as refreshable", () => {
+    const layer = makeLayer({
+      type: "geojson",
+      source: { type: "geojson", url: "https://x.com/a.geojson" },
+      metadata: {
+        sourceKind: "maplibre-gl-vector",
+        externalNativeLayer: true,
+      },
+    });
+
+    assert.equal(isVectorControlRefreshLayer(layer), true);
+    assert.equal(isRefreshableLayer(layer), true);
+  });
+
+  it("does not treat a file-backed vector-control layer (no url) as a vector-control refresh layer", () => {
+    const layer = makeLayer({
+      type: "geojson",
+      source: { type: "geojson" },
+      metadata: {
+        sourceKind: "maplibre-gl-vector",
+        externalNativeLayer: true,
+      },
+    });
+
+    assert.equal(isVectorControlRefreshLayer(layer), false);
+  });
+
+  it("does not treat a plain store layer as a vector-control refresh layer", () => {
+    const layer = makeLayer({
+      type: "geojson",
+      source: { type: "geojson", url: "https://x.com/a.geojson" },
+      metadata: { sourceKind: "geojson-url" },
+    });
+
+    assert.equal(isVectorControlRefreshLayer(layer), false);
+  });
+
+  it("still treats a WFS layer as refreshable (refactor regression guard)", () => {
+    const layer = makeLayer({
+      type: "geojson",
+      source: { type: "geojson", url: "https://x.com/wfs?service=WFS" },
+      metadata: { sourceKind: "wfs-getfeature" },
+    });
+
+    assert.equal(isRefreshableLayer(layer), true);
+  });
+});

--- a/tests/layer-refresh.test.ts
+++ b/tests/layer-refresh.test.ts
@@ -46,6 +46,36 @@ describe("isVectorControlRefreshLayer / isRefreshableLayer", () => {
     });
 
     assert.equal(isVectorControlRefreshLayer(layer), false);
+    assert.equal(isRefreshableLayer(layer), false);
+  });
+
+  it("does not treat a vector-control layer without the externalNativeLayer flag as refreshable", () => {
+    const layer = makeLayer({
+      type: "geojson",
+      source: { type: "geojson", url: "https://x.com/a.geojson" },
+      metadata: {
+        sourceKind: "maplibre-gl-vector",
+        // externalNativeLayer intentionally absent — exercises the three-way AND
+      },
+    });
+
+    assert.equal(isVectorControlRefreshLayer(layer), false);
+    assert.equal(isRefreshableLayer(layer), false);
+  });
+
+  it("treats a vector-control layer whose URL comes from sourcePath as refreshable", () => {
+    const layer = makeLayer({
+      type: "geojson",
+      source: { type: "geojson" },
+      sourcePath: "https://x.com/a.geojson",
+      metadata: {
+        sourceKind: "maplibre-gl-vector",
+        externalNativeLayer: true,
+      },
+    });
+
+    assert.equal(isVectorControlRefreshLayer(layer), true);
+    assert.equal(isRefreshableLayer(layer), true);
   });
 
   it("does not treat a plain store layer as a vector-control refresh layer", () => {


### PR DESCRIPTION
## Summary

Enables manual **Refresh** and **Auto Refresh** for "Add Vector Layer" (maplibre-gl-vector) layers backed by an HTTP(S) URL, matching the behavior WFS layers already have.

These layers render through the external maplibre-gl-vector control's own native sources (tagged `externalNativeLayer: true`, `sourceKind: "maplibre-gl-vector"`), so the store-GeoJSON refresh path (`refreshGeoJsonLayer` + `updateLayer`) cannot drive them. They are refreshed in place through the new upstream `VectorControl.reloadLayer(id)` API, which re-fetches and re-renders while preserving the layer id (so selection, ordering, and the auto-refresh timer survive).

## Changes
- `packages/plugins`: new `reloadVectorControlLayer(id)` helper bridging to the control singleton; exported from the package index.
- `apps/.../lib/layer-refresh.ts`: `isVectorControlRefreshLayer` predicate (covers both GeoJSON and tile render modes); `isRefreshableLayer` now includes vector-control URL layers. `refreshSourceUrl` refactored (behavior-preserving) to share a `layerHttpUrl` helper.
- `apps/.../panels/LayerPanel.tsx`: `handleRefreshLayer` branches to the reload path for vector-control layers; the store-GeoJSON path is unchanged for WFS/others.
- `tests/layer-refresh.test.ts`: new unit tests (vector-control URL refreshable, File-backed not, plain layer not, WFS still refreshable, legacy untagged geojson-url still refreshable).

## ⚠️ DRAFT — blocked on upstream release
This depends on `VectorControl.reloadLayer(id)` from **opengeos/maplibre-gl-vector#9**. CI will be red here until that PR is merged, a new maplibre-gl-vector version is released to npm, and `apps/geolibre-desktop/package.json` + `package-lock.json` are bumped to it. Verified locally against a build of that branch copied into `node_modules` (full `tsc -b && vite build` + 196 frontend tests pass). Marking ready once the dependency is published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vector-control-backed layers (HTTP(S) vector sources) can be refreshed from the Layer Panel.
  * Manual refresh shows success messages (including feature counts); automatic interval refreshes fail silently when source info is missing.

* **Chores**
  * Upgraded maplibre-gl-vector from 0.2.1 to 0.2.4.

* **Tests**
  * Added tests covering detection and refreshable-layer behavior for various layer/source shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->