### PR TITLE
fix(layers): harden rename blur guard (PR #213 follow-up)

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -181,12 +181,14 @@ export function LayerPanel({
   const [dropTargetLayerId, setDropTargetLayerId] = useState<string | null>(
     null,
   );
-  // Escape cancels a rename by clearing editing state, but the input's onBlur
-  // (fired when React unmounts the focused input) would otherwise run
-  // commitRename with the pre-update closure and commit the edit anyway. This
-  // ref is read synchronously by commitRename, so it reflects the cancel
-  // regardless of which render's closure is executing.
-  const isCancelingRenameRef = useRef(false);
+  // Ending a rename (commit or cancel) clears the editing state, which
+  // unmounts the focused input. React then delivers that input's onBlur (the
+  // browser's native blur on the removed element) to commitRename from the
+  // pre-update closure, which would re-commit the edit. This ref, read
+  // synchronously by commitRename, suppresses that stray blur commit. It is
+  // reset in beginRename so a flag left set by a cancel whose blur never fired
+  // cannot leak into the next rename session.
+  const suppressBlurCommitRef = useRef(false);
   const refreshingLayerIdsRef = useRef(new Set<string>());
   const refreshTimersRef = useRef(new Map<string, LayerRefreshTimer>());
   const refreshStatusTimersRef = useRef(new Map<string, number>());
@@ -225,15 +227,21 @@ export function LayerPanel({
   };
 
   const beginRename = (layer: GeoLibreLayer) => {
+    // Clear any flag left set by a prior cancel/commit whose blur never fired,
+    // so it cannot swallow the first commit of this rename session.
+    suppressBlurCommitRef.current = false;
     setEditingLayerId(layer.id);
     setEditingName(layer.name);
   };
 
   const commitRename = () => {
-    if (isCancelingRenameRef.current || !editingLayerId) {
-      isCancelingRenameRef.current = false;
+    if (suppressBlurCommitRef.current || !editingLayerId) {
+      suppressBlurCommitRef.current = false;
       return;
     }
+    // Suppress the onBlur that fires when clearing editing state unmounts the
+    // input, so the edit is not committed a second time from the stale closure.
+    suppressBlurCommitRef.current = true;
     const trimmed = editingName.trim();
     const current = layers.find((l) => l.id === editingLayerId);
     if (trimmed && current && trimmed !== current.name) {
@@ -244,7 +252,7 @@ export function LayerPanel({
   };
 
   const cancelRename = () => {
-    isCancelingRenameRef.current = true;
+    suppressBlurCommitRef.current = true;
     setEditingLayerId(null);
     setEditingName("");
   };


### PR DESCRIPTION
Follow-up to #213 addressing a Claude review thread left unresolved at merge.

The layer-rename blur guard (`isCancelingRenameRef`) was only cleared inside `commitRename`'s early return, so two edge cases remained:

1. **Stale flag drops the next commit.** After a cancel (or a click-away commit) whose unmount `onBlur` never fires a second time, the ref stays `true`. The next `beginRename` did not reset it, so that session's first commit was silently swallowed.
2. **Enter double-writes.** On Enter, clearing editing state unmounts the input; the resulting `onBlur` re-entered `commitRename` from the pre-update closure and called `updateLayer` a second time with the same name (harmless final state, but a redundant write + dirty flag).

Fix: reset the flag in `beginRename`, set it before clearing state in `commitRename` to suppress the unmount blur, and rename `isCancelingRenameRef` -> `suppressBlurCommitRef` (its role now covers both cancel and commit). `npm run typecheck` and the scoped `pre-commit` (npm build) pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of layer rename operations, particularly when canceling a rename action. Fixes an issue where blur events during rename cancellation could inadvertently commit unintended changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->