### PR TITLE
feat(layers): add Open attribute table and Export to layer menu

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -1,8 +1,4 @@
-import {
-  isDuckDBQueryLayer,
-  useAppStore,
-  type GeoLibreLayer,
-} from "@geolibre/core";
+import { isDuckDBQueryLayer, useAppStore } from "@geolibre/core";
 import {
   getDuckDBLayerRows,
   getGeometryEditTargetLayerId,
@@ -47,18 +43,19 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
+import { isTauri } from "../../lib/tauri-io";
 import {
-  isTauri,
-  saveBinaryFileWithFallback,
-  saveTextFileWithFallback,
-} from "../../lib/tauri-io";
-import type { BinaryVectorExportFormat } from "../../lib/vector-exporter";
+  exportVectorLayer,
+  formatAttributeValue,
+  geojsonVectorSourceId,
+  sanitizeExportFileName,
+  type VectorExportFormat,
+} from "../../lib/vector-export";
 
 type SortDirection = "asc" | "desc";
 type SortKey = "__featureId" | string;
 type ColumnWidths = Record<string, number>;
 type AttributeDrafts = Record<string, Record<string, string>>;
-type ExportFormat = "geojson" | "csv" | BinaryVectorExportFormat;
 type AttributeTableRow = {
   featureId: string;
   properties: Record<string, unknown>;
@@ -93,12 +90,6 @@ function compareAttributeValues(a: unknown, b: unknown): number {
     numeric: true,
     sensitivity: "base",
   });
-}
-
-function formatAttributeValue(value: unknown): string {
-  if (value == null) return "";
-  if (typeof value === "object") return JSON.stringify(value);
-  return String(value);
 }
 
 function parseAttributeDraft(draft: string, previousValue: unknown): unknown {
@@ -202,62 +193,6 @@ function applyDraftsToDuckDBRows(
   }
 
   return updates;
-}
-
-function sanitizeExportFileName(name: string): string {
-  const sanitized = name
-    .trim()
-    .replace(/[<>:"/\\|?*\u0000-\u001f]/g, "-")
-    .replace(/\s+/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-|-$/g, "");
-  return sanitized || "layer";
-}
-
-function csvCell(value: unknown): string {
-  const text = formatAttributeValue(value);
-  return /[",\r\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
-}
-
-function exportFormatLabel(format: BinaryVectorExportFormat): string {
-  switch (format) {
-    case "geoparquet":
-      return "GeoParquet";
-  }
-}
-
-function exportFileExtension(format: BinaryVectorExportFormat): string {
-  switch (format) {
-    case "geoparquet":
-      return "parquet";
-  }
-}
-
-function exportMimeType(format: BinaryVectorExportFormat): string {
-  switch (format) {
-    case "geoparquet":
-      return "application/vnd.apache.parquet";
-  }
-}
-
-/**
- * Source id of a geojson-render-mode vector layer created by the Add Vector
- * Layer control, or null. These layers hold their features in a MapLibre
- * GeoJSON source rather than in `layer.geojson`, so the attribute table reads
- * the data back from the map. Tiles-mode (DuckDB) vector layers are excluded.
- */
-function geojsonVectorSourceId(layer: GeoLibreLayer | undefined): string | null {
-  if (
-    !layer ||
-    layer.type !== "geojson" ||
-    layer.metadata.sourceKind !== "maplibre-gl-vector" ||
-    layer.metadata.externalNativeLayer !== true
-  ) {
-    return null;
-  }
-  const sourceIds = layer.metadata.sourceIds;
-  const sourceId = Array.isArray(sourceIds) ? sourceIds[0] : undefined;
-  return typeof sourceId === "string" ? sourceId : null;
 }
 
 interface AttributeTableProps {
@@ -622,87 +557,7 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     };
   };
 
-  const geojsonToCsv = (
-    geojson: NonNullable<ReturnType<typeof geojsonWithDrafts>>,
-  ) => {
-    const propertyKeys = new Set<string>();
-    for (const feature of geojson.features) {
-      for (const key of Object.keys(feature.properties ?? {})) {
-        propertyKeys.add(key);
-      }
-    }
-
-    const headers = ["feature_id", ...propertyKeys];
-    const rows = geojson.features.map((feature, index) => {
-      const featureId = String(feature.id ?? index);
-      const properties = feature.properties ?? {};
-      const values = [
-        featureId,
-        ...Array.from(propertyKeys).map((key) => properties[key]),
-      ];
-      return values
-        .map(csvCell)
-        .join(",");
-    });
-
-    return [headers.map(csvCell).join(","), ...rows].join("\n");
-  };
-
-  const exportTextLayer = async (
-    format: Extract<ExportFormat, "geojson" | "csv">,
-    exportGeojson: NonNullable<ReturnType<typeof geojsonWithDrafts>>,
-    baseName: string,
-  ) => {
-    const isCsv = format === "csv";
-    const content = isCsv
-      ? geojsonToCsv(exportGeojson)
-      : JSON.stringify(exportGeojson, null, 2);
-    await saveTextFileWithFallback(content, {
-      defaultName: `${baseName}.${isCsv ? "csv" : "geojson"}`,
-      filters: [
-        isCsv
-          ? { name: "CSV", extensions: ["csv"] }
-          : { name: "GeoJSON", extensions: ["geojson", "json"] },
-      ],
-      browserTypes: [
-        {
-          description: isCsv ? "CSV" : "GeoJSON",
-          accept: isCsv
-            ? { "text/csv": [".csv"] }
-            : { "application/geo+json": [".geojson", ".json"] },
-        },
-      ],
-      mimeType: isCsv ? "text/csv" : "application/geo+json",
-    });
-  };
-
-  const exportBinaryLayer = async (
-    format: BinaryVectorExportFormat,
-    exportGeojson: NonNullable<ReturnType<typeof geojsonWithDrafts>>,
-    baseName: string,
-  ) => {
-    const { exportBinaryVectorLayer } = await import("../../lib/vector-exporter");
-    const result = await exportBinaryVectorLayer(
-      exportGeojson,
-      format,
-      baseName,
-    );
-    const label = exportFormatLabel(format);
-    const extension = exportFileExtension(format);
-    await saveBinaryFileWithFallback(result.data, {
-      defaultName: `${baseName}.${extension}`,
-      filters: [{ name: label, extensions: [extension] }],
-      browserTypes: [
-        {
-          description: label,
-          accept: { [exportMimeType(format)]: [`.${extension}`] },
-        },
-      ],
-      mimeType: result.mimeType,
-    });
-  };
-
-  const exportLayer = async (format: ExportFormat) => {
+  const exportLayer = async (format: VectorExportFormat) => {
     if (!layer?.geojson) return;
 
     try {
@@ -711,12 +566,7 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
       if (!exportGeojson) return;
 
       const baseName = sanitizeExportFileName(layer.name);
-      if (format === "geojson" || format === "csv") {
-        await exportTextLayer(format, exportGeojson, baseName);
-        return;
-      }
-
-      await exportBinaryLayer(format, exportGeojson, baseName);
+      await exportVectorLayer(exportGeojson, format, baseName);
     } catch (error) {
       console.error("Failed to export attribute table", error);
       setExportError(

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -69,6 +69,7 @@ import {
 } from "../../lib/layer-refresh";
 import {
   exportVectorLayer,
+  geojsonVectorSourceId,
   resolveLayerGeojson,
   sanitizeExportFileName,
   type VectorExportFormat,
@@ -408,21 +409,33 @@ export function LayerPanel({
           mapControllerRef.current?.getMap() ?? undefined,
         );
         if (!geojson) {
+          // A source-backed (Add Vector Layer) layer whose features could not be
+          // read is usually a not-yet-ready map source, not a layer that lacks
+          // features, so the two cases get different diagnostics.
+          const message =
+            geojsonVectorSourceId(layer) !== null
+              ? "Layer data is not ready yet. Try again in a moment."
+              : "Export requires a vector layer with features.";
           setRefreshStatuses((current) => ({
             ...current,
-            [layer.id]: {
-              type: "error",
-              message: "Export requires a vector layer with features.",
-            },
+            [layer.id]: { type: "error", message },
           }));
           scheduleStatusClear(layer.id);
           return;
         }
-        await exportVectorLayer(
+        const savedPath = await exportVectorLayer(
           geojson,
           format,
           sanitizeExportFileName(layer.name),
         );
+        // A null path means the user cancelled the save dialog, so no note.
+        if (savedPath !== null) {
+          setRefreshStatuses((current) => ({
+            ...current,
+            [layer.id]: { type: "success", message: "Layer exported." },
+          }));
+          scheduleStatusClear(layer.id);
+        }
       } catch (error) {
         const message =
           error instanceof Error

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -26,6 +26,9 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
   Input,
   Label,
@@ -37,6 +40,7 @@ import {
 import {
   ChevronDown,
   ChevronUp,
+  Download,
   Eye,
   EyeOff,
   GripVertical,
@@ -50,6 +54,7 @@ import {
   PencilRuler,
   RefreshCw,
   Table2,
+  TableProperties,
   Timer,
   Trash2,
   ZoomIn,
@@ -62,6 +67,12 @@ import {
   refreshGeoJsonLayer,
   setLayerRefreshConfig,
 } from "../../lib/layer-refresh";
+import {
+  exportVectorLayer,
+  resolveLayerGeojson,
+  sanitizeExportFileName,
+  type VectorExportFormat,
+} from "../../lib/vector-export";
 
 interface LayerPanelProps {
   mapControllerRef: RefObject<MapController | null>;
@@ -165,6 +176,7 @@ export function LayerPanel({
   const moveLayer = useAppStore((s) => s.moveLayer);
   const removeLayer = useAppStore((s) => s.removeLayer);
   const updateLayer = useAppStore((s) => s.updateLayer);
+  const setAttributeTableOpen = useAppStore((s) => s.setAttributeTableOpen);
   const [editingLayerId, setEditingLayerId] = useState<string | null>(null);
   const [editingName, setEditingName] = useState("");
   const [metadataLayer, setMetadataLayer] = useState<GeoLibreLayer | null>(
@@ -385,6 +397,45 @@ export function LayerPanel({
       }
     },
     [clearRefreshStatusTimer, scheduleStatusClear, updateLayer],
+  );
+
+  const handleExportLayer = useCallback(
+    async (layer: GeoLibreLayer, format: VectorExportFormat) => {
+      clearRefreshStatusTimer(layer.id);
+      try {
+        const geojson = await resolveLayerGeojson(
+          layer,
+          mapControllerRef.current?.getMap() ?? undefined,
+        );
+        if (!geojson) {
+          setRefreshStatuses((current) => ({
+            ...current,
+            [layer.id]: {
+              type: "error",
+              message: "Export requires a vector layer with features.",
+            },
+          }));
+          scheduleStatusClear(layer.id);
+          return;
+        }
+        await exportVectorLayer(
+          geojson,
+          format,
+          sanitizeExportFileName(layer.name),
+        );
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Could not export this layer.";
+        setRefreshStatuses((current) => ({
+          ...current,
+          [layer.id]: { type: "error", message },
+        }));
+        scheduleStatusClear(layer.id);
+      }
+    },
+    [clearRefreshStatusTimer, mapControllerRef, scheduleStatusClear],
   );
 
   // Read through a ref inside interval callbacks so long-lived timers never
@@ -643,6 +694,13 @@ export function LayerPanel({
             const canMaterializeDuckDB =
               isDuckDBQueryLayer(layer) &&
               typeof layer.metadata.query === "string";
+            // The attribute table reads features from geojson layers (including
+            // Add Vector Layer geojson-mode) and DuckDB query layers.
+            const canOpenAttributeTable =
+              layer.type === "geojson" || isDuckDBQueryLayer(layer);
+            // Export writes the layer's GeoJSON features to disk; only
+            // geojson-backed vector layers carry those features.
+            const canExportLayer = layer.type === "geojson";
             const canRefresh = isRefreshableLayer(layer);
             const refreshConfig = getLayerRefreshConfig(layer);
             const refreshStatus = refreshStatuses[layer.id];
@@ -943,6 +1001,52 @@ export function LayerPanel({
                             ? "Finish editing geometry"
                             : "Edit geometry"}
                         </DropdownMenuItem>
+                      )}
+                      {canOpenAttributeTable && (
+                        <DropdownMenuItem
+                          onSelect={(e: Event) => {
+                            e.preventDefault();
+                            selectLayer(layer.id);
+                            setAttributeTableOpen(true);
+                          }}
+                        >
+                          <TableProperties className="mr-2 h-3.5 w-3.5" />
+                          Open attribute table
+                        </DropdownMenuItem>
+                      )}
+                      {canExportLayer && (
+                        <DropdownMenuSub>
+                          <DropdownMenuSubTrigger>
+                            <Download className="h-3.5 w-3.5" />
+                            Export
+                          </DropdownMenuSubTrigger>
+                          <DropdownMenuSubContent>
+                            <DropdownMenuItem
+                              onSelect={(e: Event) => {
+                                e.preventDefault();
+                                void handleExportLayer(layer, "geojson");
+                              }}
+                            >
+                              GeoJSON
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              onSelect={(e: Event) => {
+                                e.preventDefault();
+                                void handleExportLayer(layer, "geoparquet");
+                              }}
+                            >
+                              GeoParquet
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              onSelect={(e: Event) => {
+                                e.preventDefault();
+                                void handleExportLayer(layer, "csv");
+                              }}
+                            >
+                              CSV (attributes only)
+                            </DropdownMenuItem>
+                          </DropdownMenuSubContent>
+                        </DropdownMenuSub>
                       )}
                       <DropdownMenuItem
                         disabled={!canRefresh || isRefreshing}

--- a/apps/geolibre-desktop/src/lib/vector-export.ts
+++ b/apps/geolibre-desktop/src/lib/vector-export.ts
@@ -83,12 +83,12 @@ async function exportTextLayer(
   format: "geojson" | "csv",
   geojson: FeatureCollection,
   baseName: string,
-) {
+): Promise<string | null> {
   const isCsv = format === "csv";
   const content = isCsv
     ? geojsonToCsv(geojson)
     : JSON.stringify(geojson, null, 2);
-  await saveTextFileWithFallback(content, {
+  return saveTextFileWithFallback(content, {
     defaultName: `${baseName}.${isCsv ? "csv" : "geojson"}`,
     filters: [
       isCsv
@@ -111,11 +111,11 @@ async function exportBinaryLayer(
   format: BinaryVectorExportFormat,
   geojson: FeatureCollection,
   baseName: string,
-) {
+): Promise<string | null> {
   const result = await exportBinaryVectorLayer(geojson, format, baseName);
   const label = exportFormatLabel(format);
   const extension = exportFileExtension(format);
-  await saveBinaryFileWithFallback(result.data, {
+  return saveBinaryFileWithFallback(result.data, {
     defaultName: `${baseName}.${extension}`,
     filters: [{ name: label, extensions: [extension] }],
     browserTypes: [
@@ -130,18 +130,18 @@ async function exportBinaryLayer(
 
 /**
  * Save a vector layer's features to disk in the requested format, prompting
- * with the native (Tauri) or browser file-save dialog.
+ * with the native (Tauri) or browser file-save dialog. Returns the saved path
+ * (a name in the browser), or null when the user cancels the save dialog.
  */
 export async function exportVectorLayer(
   geojson: FeatureCollection,
   format: VectorExportFormat,
   baseName: string,
-): Promise<void> {
+): Promise<string | null> {
   if (format === "geojson" || format === "csv") {
-    await exportTextLayer(format, geojson, baseName);
-    return;
+    return exportTextLayer(format, geojson, baseName);
   }
-  await exportBinaryLayer(format, geojson, baseName);
+  return exportBinaryLayer(format, geojson, baseName);
 }
 
 /**
@@ -188,7 +188,8 @@ export async function resolveLayerGeojson(
   if (
     data &&
     typeof data === "object" &&
-    (data as { type?: string }).type === "FeatureCollection"
+    (data as { type?: string }).type === "FeatureCollection" &&
+    Array.isArray((data as { features?: unknown }).features)
   ) {
     return data as FeatureCollection;
   }

--- a/apps/geolibre-desktop/src/lib/vector-export.ts
+++ b/apps/geolibre-desktop/src/lib/vector-export.ts
@@ -1,0 +1,195 @@
+import type { GeoLibreLayer } from "@geolibre/core";
+import type { FeatureCollection } from "geojson";
+import type { GeoJSONSource, Map as MapLibreMap } from "maplibre-gl";
+import {
+  saveBinaryFileWithFallback,
+  saveTextFileWithFallback,
+} from "./tauri-io";
+import {
+  type BinaryVectorExportFormat,
+  exportBinaryVectorLayer,
+} from "./vector-exporter";
+
+export type VectorExportFormat = "geojson" | "csv" | BinaryVectorExportFormat;
+
+/** Render an attribute value as the plain string used in CSV cells and inputs. */
+export function formatAttributeValue(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+/** Turn a layer name into a filesystem-safe export base filename. */
+export function sanitizeExportFileName(name: string): string {
+  const sanitized = name
+    .trim()
+    .replace(/[<>:"/\\|?*\u0000-\u001f]/g, "-")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+  return sanitized || "layer";
+}
+
+function csvCell(value: unknown): string {
+  const text = formatAttributeValue(value);
+  return /[",\r\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+}
+
+function geojsonToCsv(geojson: FeatureCollection): string {
+  const propertyKeys = new Set<string>();
+  for (const feature of geojson.features) {
+    for (const key of Object.keys(feature.properties ?? {})) {
+      propertyKeys.add(key);
+    }
+  }
+
+  const headers = ["feature_id", ...propertyKeys];
+  const rows = geojson.features.map((feature, index) => {
+    const featureId = String(feature.id ?? index);
+    const properties = feature.properties ?? {};
+    const values = [
+      featureId,
+      ...Array.from(propertyKeys).map((key) => properties[key]),
+    ];
+    return values.map(csvCell).join(",");
+  });
+
+  return [headers.map(csvCell).join(","), ...rows].join("\n");
+}
+
+function exportFormatLabel(format: BinaryVectorExportFormat): string {
+  switch (format) {
+    case "geoparquet":
+      return "GeoParquet";
+  }
+}
+
+function exportFileExtension(format: BinaryVectorExportFormat): string {
+  switch (format) {
+    case "geoparquet":
+      return "parquet";
+  }
+}
+
+function exportMimeType(format: BinaryVectorExportFormat): string {
+  switch (format) {
+    case "geoparquet":
+      return "application/vnd.apache.parquet";
+  }
+}
+
+async function exportTextLayer(
+  format: "geojson" | "csv",
+  geojson: FeatureCollection,
+  baseName: string,
+) {
+  const isCsv = format === "csv";
+  const content = isCsv
+    ? geojsonToCsv(geojson)
+    : JSON.stringify(geojson, null, 2);
+  await saveTextFileWithFallback(content, {
+    defaultName: `${baseName}.${isCsv ? "csv" : "geojson"}`,
+    filters: [
+      isCsv
+        ? { name: "CSV", extensions: ["csv"] }
+        : { name: "GeoJSON", extensions: ["geojson", "json"] },
+    ],
+    browserTypes: [
+      {
+        description: isCsv ? "CSV" : "GeoJSON",
+        accept: isCsv
+          ? { "text/csv": [".csv"] }
+          : { "application/geo+json": [".geojson", ".json"] },
+      },
+    ],
+    mimeType: isCsv ? "text/csv" : "application/geo+json",
+  });
+}
+
+async function exportBinaryLayer(
+  format: BinaryVectorExportFormat,
+  geojson: FeatureCollection,
+  baseName: string,
+) {
+  const result = await exportBinaryVectorLayer(geojson, format, baseName);
+  const label = exportFormatLabel(format);
+  const extension = exportFileExtension(format);
+  await saveBinaryFileWithFallback(result.data, {
+    defaultName: `${baseName}.${extension}`,
+    filters: [{ name: label, extensions: [extension] }],
+    browserTypes: [
+      {
+        description: label,
+        accept: { [exportMimeType(format)]: [`.${extension}`] },
+      },
+    ],
+    mimeType: result.mimeType,
+  });
+}
+
+/**
+ * Save a vector layer's features to disk in the requested format, prompting
+ * with the native (Tauri) or browser file-save dialog.
+ */
+export async function exportVectorLayer(
+  geojson: FeatureCollection,
+  format: VectorExportFormat,
+  baseName: string,
+): Promise<void> {
+  if (format === "geojson" || format === "csv") {
+    await exportTextLayer(format, geojson, baseName);
+    return;
+  }
+  await exportBinaryLayer(format, geojson, baseName);
+}
+
+/**
+ * Source id of a geojson-render-mode vector layer created by the Add Vector
+ * Layer control, or null. These layers hold their features in a MapLibre
+ * GeoJSON source rather than in `layer.geojson`, so callers read the data back
+ * from the map. Tiles-mode (DuckDB) vector layers are excluded.
+ */
+export function geojsonVectorSourceId(
+  layer: GeoLibreLayer | undefined,
+): string | null {
+  if (
+    !layer ||
+    layer.type !== "geojson" ||
+    layer.metadata.sourceKind !== "maplibre-gl-vector" ||
+    layer.metadata.externalNativeLayer !== true
+  ) {
+    return null;
+  }
+  const sourceIds = layer.metadata.sourceIds;
+  const sourceId = Array.isArray(sourceIds) ? sourceIds[0] : undefined;
+  return typeof sourceId === "string" ? sourceId : null;
+}
+
+/**
+ * Resolve a layer's features for export. Plain geojson layers carry them in
+ * `layer.geojson`; Add Vector Layer geojson-mode layers keep them in a MapLibre
+ * GeoJSON source, which is read back from the map. Returns null when no feature
+ * data is available (e.g. tile or service layers).
+ */
+export async function resolveLayerGeojson(
+  layer: GeoLibreLayer,
+  map: MapLibreMap | undefined,
+): Promise<FeatureCollection | null> {
+  if (layer.geojson) return layer.geojson;
+
+  const sourceId = geojsonVectorSourceId(layer);
+  if (!sourceId || !map) return null;
+
+  const source = map.getSource(sourceId) as GeoJSONSource | undefined;
+  if (!source || typeof source.getData !== "function") return null;
+
+  const data = await source.getData();
+  if (
+    data &&
+    typeof data === "object" &&
+    (data as { type?: string }).type === "FeatureCollection"
+  ) {
+    return data as FeatureCollection;
+  }
+  return null;
+}

--- a/apps/geolibre-desktop/src/lib/vector-export.ts
+++ b/apps/geolibre-desktop/src/lib/vector-export.ts
@@ -43,13 +43,14 @@ function geojsonToCsv(geojson: FeatureCollection): string {
     }
   }
 
-  const headers = ["feature_id", ...propertyKeys];
+  const orderedKeys = Array.from(propertyKeys);
+  const headers = ["feature_id", ...orderedKeys];
   const rows = geojson.features.map((feature, index) => {
     const featureId = String(feature.id ?? index);
     const properties = feature.properties ?? {};
     const values = [
       featureId,
-      ...Array.from(propertyKeys).map((key) => properties[key]),
+      ...orderedKeys.map((key) => properties[key]),
     ];
     return values.map(csvCell).join(",");
   });


### PR DESCRIPTION
## Summary
- Add "Open attribute table" and "Export" (GeoJSON, GeoParquet, CSV) items to the vector layer actions menu, placed right after "Edit geometry".
- Extract the export logic out of the attribute table panel into a shared `vector-export` module so both the panel and the layer menu reuse it. Export resolves features from `layer.geojson` or reads them back from the MapLibre source for Add Vector Layer geojson-mode layers.
- Menu items are gated to layers that have feature data: the attribute table item shows for GeoJSON and DuckDB query layers; Export shows for GeoJSON-backed layers.

## Test plan
- [x] npm run typecheck (full tsc build) passes
- [x] npm run test:frontend passes (200/200)
- [x] pre-commit run --all-files passes
- [ ] Manually open the attribute table from a vector layer's actions menu
- [ ] Manually export a vector layer to GeoJSON, GeoParquet, and CSV
- [ ] Confirm the menu items do not appear for raster, tile, or service layers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Open attribute table" action for compatible layers.
  * Added Export submenu offering GeoJSON, GeoParquet, and CSV (attributes only) for exportable vector layers.

* **Bug Fixes / Improvements**
  * Exports now reliably resolve layer data, show an error when no exportable features, report success/failure, avoid stale refresh state, produce sanitized filenames, and generate better-formatted CSV output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->