### PR TITLE
fix(vector): apply categorized/graduated styles to Add Vector Layer layers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10675,9 +10675,9 @@
       }
     },
     "node_modules/maplibre-gl-vector": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.2.4.tgz",
-      "integrity": "sha512-Q1d7jOwxb6Zz0+zcN2P7IOWqh29ztmb2V8bGwAz0DK+oc+eJIrenSQ0Jp1+Jv7Ev2zzN4RGo8+rnQlsB3fKKoA==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.2.5.tgz",
+      "integrity": "sha512-aGSLrle87mUBWjOKkCpvo525lOODOoG0O0CjzwAHyreZ3OpNuQ4xtuI51h0RbNWvQfg9d9By338CqG0vLlQUtA==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"
@@ -13177,7 +13177,7 @@
         "maplibre-gl-streetview": "^0.5.0",
         "maplibre-gl-swipe": "^0.7.1",
         "maplibre-gl-time-slider": "^1.0.3",
-        "maplibre-gl-vector": "^0.2.4",
+        "maplibre-gl-vector": "^0.2.5",
         "proj4": "^2.20.9",
         "shpjs": "^6.2.0",
         "three": "^0.184.0"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./types";
+export * from "./vector-color";
 export * from "./project";
 export {
   projectPathLabel,

--- a/packages/core/src/vector-color.ts
+++ b/packages/core/src/vector-color.ts
@@ -149,7 +149,13 @@ export function vectorFillColorValue(style: LayerStyle): VectorColorValue {
   return vectorColorExpression(style, styleValue(style, "fillColor"));
 }
 
-/** Circle color value for a point layer (fallback: the layer fill color). */
+/**
+ * Circle color value for a point layer. Intentionally identical to
+ * `vectorFillColorValue`: GeoLibre has no separate point-fill color, so point
+ * circles share the polygon fill color (matching `circlePaint` in the map
+ * package). Kept as its own function so the per-geometry callers read in
+ * parallel and a future dedicated circle color stays a one-line change here.
+ */
 export function vectorCircleColorValue(style: LayerStyle): VectorColorValue {
   return vectorColorExpression(style, styleValue(style, "fillColor"));
 }

--- a/packages/core/src/vector-color.ts
+++ b/packages/core/src/vector-color.ts
@@ -1,0 +1,171 @@
+import { DEFAULT_LAYER_STYLE, type LayerStyle } from "./types";
+
+/**
+ * A data-driven color value for a vector paint property: either a plain CSS
+ * color string, or a MapLibre expression array (e.g. a categorized `match` or
+ * graduated `interpolate`). Typed maplibre-agnostically so `@geolibre/core`
+ * stays free of a maplibre-gl dependency; consumers cast to the concrete
+ * `PropertyValueSpecification<string>` where the MapLibre types are in scope.
+ */
+export type VectorColorValue = string | unknown[];
+
+/** Whether a color value is a data-driven expression rather than a flat color. */
+export function isVectorColorExpression(
+  value: VectorColorValue,
+): value is unknown[] {
+  return Array.isArray(value);
+}
+
+function styleValue<K extends keyof LayerStyle>(
+  style: LayerStyle,
+  key: K,
+): LayerStyle[K] {
+  return style[key] ?? DEFAULT_LAYER_STYLE[key];
+}
+
+function isColor(value: string): boolean {
+  return /^#[0-9a-f]{6}$/i.test(value.trim());
+}
+
+/**
+ * Parses a user-entered MapLibre expression string into an expression array,
+ * tolerating trailing commas. Returns null when the text is empty or not a
+ * JSON array.
+ */
+export function parseJsonExpression(expression: string): unknown[] | null {
+  const trimmed = expression.trim();
+  if (!trimmed) return null;
+
+  try {
+    const parsed = JSON.parse(removeTrailingJsonCommas(trimmed));
+    if (!Array.isArray(parsed)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function removeTrailingJsonCommas(value: string): string {
+  let result = "";
+  let inString = false;
+  let escaped = false;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+
+    if (inString) {
+      result += char;
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      result += char;
+      continue;
+    }
+
+    if (char === ",") {
+      const nextSignificant = value.slice(index + 1).match(/\S/)?.[0];
+      if (nextSignificant === "]" || nextSignificant === "}") continue;
+    }
+
+    result += char;
+  }
+
+  return result;
+}
+
+/**
+ * Builds the data-driven color value for a vector layer's current style mode.
+ * `single` (or any mode that cannot produce a valid expression) returns the
+ * flat fallback color; `categorized` returns a `match` expression, `graduated`
+ * an `interpolate` expression, and `expression` the parsed user expression.
+ *
+ * @param style - The layer style.
+ * @param fallbackColor - The flat color used for `single` mode and as the
+ *   expression fallback.
+ * @returns A flat color string or a MapLibre color expression.
+ */
+export function vectorColorExpression(
+  style: LayerStyle,
+  fallbackColor: string,
+): VectorColorValue {
+  const mode = styleValue(style, "vectorStyleMode");
+  if (mode === "single") return fallbackColor;
+
+  if (mode === "expression") {
+    return (
+      parseJsonExpression(styleValue(style, "vectorStyleExpression")) ??
+      fallbackColor
+    );
+  }
+
+  const property = styleValue(style, "vectorStyleProperty").trim();
+  if (!property) return fallbackColor;
+
+  if (mode === "categorized") {
+    const stops = styleValue(style, "vectorStyleStops").filter(
+      (stop) => String(stop.value).trim().length > 0 && isColor(stop.color),
+    );
+    if (stops.length === 0) return fallbackColor;
+
+    return [
+      "match",
+      ["to-string", ["get", property]],
+      ...stops.flatMap((stop) => [String(stop.value).trim(), stop.color]),
+      fallbackColor,
+    ];
+  }
+
+  const stops = styleValue(style, "vectorStyleStops")
+    .map((stop) => ({
+      color: stop.color,
+      value:
+        typeof stop.value === "number"
+          ? stop.value
+          : Number.parseFloat(stop.value),
+    }))
+    .filter((stop) => Number.isFinite(stop.value) && isColor(stop.color))
+    .sort((a, b) => a.value - b.value);
+  if (stops.length < 2) return fallbackColor;
+
+  return [
+    "interpolate",
+    ["linear"],
+    ["to-number", ["get", property], stops[0].value],
+    ...stops.flatMap((stop) => [stop.value, stop.color]),
+  ];
+}
+
+/** Fill color value for a polygon layer (fallback: the layer fill color). */
+export function vectorFillColorValue(style: LayerStyle): VectorColorValue {
+  return vectorColorExpression(style, styleValue(style, "fillColor"));
+}
+
+/** Circle color value for a point layer (fallback: the layer fill color). */
+export function vectorCircleColorValue(style: LayerStyle): VectorColorValue {
+  return vectorColorExpression(style, styleValue(style, "fillColor"));
+}
+
+/**
+ * Line color value for line geometry and polygon outlines (fallback: the
+ * layer stroke color). For non-`expression` modes the data-driven color is
+ * applied to line geometry only, while polygon outlines keep the flat stroke
+ * color, matching the polygon-fill-only behavior of categorized/graduated
+ * styling.
+ */
+export function vectorLineColorValue(style: LayerStyle): VectorColorValue {
+  const strokeColor = styleValue(style, "strokeColor");
+  const vectorColor = vectorColorExpression(style, strokeColor);
+  if (vectorColor === strokeColor) return strokeColor;
+  return styleValue(style, "vectorStyleMode") === "expression"
+    ? vectorColor
+    : ["case", ["==", ["geometry-type"], "Polygon"], strokeColor, vectorColor];
+}

--- a/packages/core/src/vector-color.ts
+++ b/packages/core/src/vector-color.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_LAYER_STYLE, type LayerStyle } from "./types";
+import { styleValue, type LayerStyle } from "./types";
 
 /**
  * A data-driven color value for a vector paint property: either a plain CSS
@@ -14,13 +14,6 @@ export function isVectorColorExpression(
   value: VectorColorValue,
 ): value is unknown[] {
   return Array.isArray(value);
-}
-
-function styleValue<K extends keyof LayerStyle>(
-  style: LayerStyle,
-  key: K,
-): LayerStyle[K] {
-  return style[key] ?? DEFAULT_LAYER_STYLE[key];
 }
 
 function isColor(value: string): boolean {

--- a/packages/map/src/style-mapper.ts
+++ b/packages/map/src/style-mapper.ts
@@ -1,4 +1,12 @@
-import { DEFAULT_LAYER_STYLE, type LayerStyle } from "@geolibre/core";
+import {
+  DEFAULT_LAYER_STYLE,
+  parseJsonExpression,
+  vectorCircleColorValue,
+  vectorColorExpression,
+  vectorFillColorValue,
+  vectorLineColorValue,
+  type LayerStyle,
+} from "@geolibre/core";
 import type { PropertyValueSpecification } from "maplibre-gl";
 
 function styleValue<K extends keyof LayerStyle>(
@@ -10,10 +18,9 @@ function styleValue<K extends keyof LayerStyle>(
 
 export function fillPaint(style: LayerStyle, opacity: number) {
   return {
-    "fill-color": vectorColorPaintValue(
+    "fill-color": vectorFillColorValue(
       style,
-      styleValue(style, "fillColor"),
-    ),
+    ) as PropertyValueSpecification<string>,
     "fill-opacity": styleValue(style, "fillOpacity") * opacity,
     "fill-outline-color": styleValue(style, "strokeColor"),
   };
@@ -22,11 +29,11 @@ export function fillPaint(style: LayerStyle, opacity: number) {
 function extrusionHeightPaintValue(
   style: LayerStyle,
 ): PropertyValueSpecification<number> {
-  const advancedExpression = parseJsonExpression<number>(
+  const advancedExpression = parseJsonExpression(
     styleValue(style, "extrusionAdvancedStyleEnabled")
       ? styleValue(style, "extrusionHeightExpression")
       : "",
-  );
+  ) as PropertyValueSpecification<number> | null;
   if (advancedExpression) return advancedExpression;
 
   const property = styleValue(style, "extrusionHeightProperty").trim();
@@ -38,127 +45,20 @@ function extrusionHeightPaintValue(
 function extrusionColorPaintValue(
   style: LayerStyle,
 ): PropertyValueSpecification<string> {
-  const vectorExpression = vectorColorPaintValue(
+  const vectorExpression = vectorColorExpression(
     style,
     styleValue(style, "extrusionColor"),
-  );
+  ) as PropertyValueSpecification<string>;
   if (vectorExpression !== styleValue(style, "extrusionColor")) {
     return vectorExpression;
   }
 
-  const advancedExpression = parseJsonExpression<string>(
+  const advancedExpression = parseJsonExpression(
     styleValue(style, "extrusionAdvancedStyleEnabled")
       ? styleValue(style, "extrusionColorExpression")
       : "",
-  );
+  ) as PropertyValueSpecification<string> | null;
   return advancedExpression ?? styleValue(style, "extrusionColor");
-}
-
-function vectorColorPaintValue(
-  style: LayerStyle,
-  fallbackColor: string,
-): PropertyValueSpecification<string> {
-  const mode = styleValue(style, "vectorStyleMode");
-  if (mode === "single") return fallbackColor;
-
-  if (mode === "expression") {
-    return (
-      parseJsonExpression<string>(styleValue(style, "vectorStyleExpression")) ??
-      fallbackColor
-    );
-  }
-
-  const property = styleValue(style, "vectorStyleProperty").trim();
-  if (!property) return fallbackColor;
-
-  if (mode === "categorized") {
-    const stops = styleValue(style, "vectorStyleStops").filter(
-      (stop) => String(stop.value).trim().length > 0 && isColor(stop.color),
-    );
-    if (stops.length === 0) return fallbackColor;
-
-    return [
-      "match",
-      ["to-string", ["get", property]],
-      ...stops.flatMap((stop) => [String(stop.value).trim(), stop.color]),
-      fallbackColor,
-    ] as PropertyValueSpecification<string>;
-  }
-
-  const stops = styleValue(style, "vectorStyleStops")
-    .map((stop) => ({
-      color: stop.color,
-      value:
-        typeof stop.value === "number"
-          ? stop.value
-          : Number.parseFloat(stop.value),
-    }))
-    .filter((stop) => Number.isFinite(stop.value) && isColor(stop.color))
-    .sort((a, b) => a.value - b.value);
-  if (stops.length < 2) return fallbackColor;
-
-  return [
-    "interpolate",
-    ["linear"],
-    ["to-number", ["get", property], stops[0].value],
-    ...stops.flatMap((stop) => [stop.value, stop.color]),
-  ] as PropertyValueSpecification<string>;
-}
-
-function isColor(value: string): boolean {
-  return /^#[0-9a-f]{6}$/i.test(value.trim());
-}
-
-function parseJsonExpression<T>(
-  expression: string,
-): PropertyValueSpecification<T> | null {
-  const trimmed = expression.trim();
-  if (!trimmed) return null;
-
-  try {
-    const parsed = JSON.parse(removeTrailingJsonCommas(trimmed));
-    if (!Array.isArray(parsed)) return null;
-    return parsed as PropertyValueSpecification<T>;
-  } catch {
-    return null;
-  }
-}
-
-function removeTrailingJsonCommas(value: string): string {
-  let result = "";
-  let inString = false;
-  let escaped = false;
-
-  for (let index = 0; index < value.length; index += 1) {
-    const char = value[index];
-
-    if (inString) {
-      result += char;
-      if (escaped) {
-        escaped = false;
-      } else if (char === "\\") {
-        escaped = true;
-      } else if (char === '"') {
-        inString = false;
-      }
-      continue;
-    }
-
-    if (char === '"') {
-      inString = true;
-      result += char;
-      continue;
-    }
-
-    if (char === ",") {
-      const nextSignificant = value.slice(index + 1).match(/\S/)?.[0];
-      if (nextSignificant === "]" || nextSignificant === "}") continue;
-    }
-
-    result += char;
-  }
-
-  return result;
 }
 
 export function fillExtrusionPaint(style: LayerStyle, opacity: number) {
@@ -172,22 +72,10 @@ export function fillExtrusionPaint(style: LayerStyle, opacity: number) {
 }
 
 export function linePaint(style: LayerStyle, opacity: number) {
-  const strokeColor = styleValue(style, "strokeColor");
-  const vectorColor = vectorColorPaintValue(style, strokeColor);
-  const lineColor =
-    vectorColor === strokeColor
-      ? strokeColor
-      : styleValue(style, "vectorStyleMode") === "expression"
-        ? vectorColor
-        : ([
-            "case",
-            ["==", ["geometry-type"], "Polygon"],
-            strokeColor,
-            vectorColor,
-          ] as PropertyValueSpecification<string>);
-
   return {
-    "line-color": lineColor,
+    "line-color": vectorLineColorValue(
+      style,
+    ) as PropertyValueSpecification<string>,
     "line-width": styleValue(style, "strokeWidth"),
     "line-opacity": opacity,
   };
@@ -195,10 +83,9 @@ export function linePaint(style: LayerStyle, opacity: number) {
 
 export function circlePaint(style: LayerStyle, opacity: number) {
   return {
-    "circle-color": vectorColorPaintValue(
+    "circle-color": vectorCircleColorValue(
       style,
-      styleValue(style, "fillColor"),
-    ),
+    ) as PropertyValueSpecification<string>,
     "circle-radius": styleValue(style, "circleRadius"),
     "circle-opacity": styleValue(style, "fillOpacity") * opacity,
     "circle-stroke-color": styleValue(style, "strokeColor"),

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -46,7 +46,7 @@
     "maplibre-gl-streetview": "^0.5.0",
     "maplibre-gl-swipe": "^0.7.1",
     "maplibre-gl-time-slider": "^1.0.3",
-    "maplibre-gl-vector": "^0.2.4",
+    "maplibre-gl-vector": "^0.2.5",
     "proj4": "^2.20.9",
     "shpjs": "^6.2.0",
     "three": "^0.184.0"

--- a/packages/plugins/src/plugins/vector-layer-sync.ts
+++ b/packages/plugins/src/plugins/vector-layer-sync.ts
@@ -1,9 +1,15 @@
 import {
   DEFAULT_LAYER_STYLE,
+  isVectorColorExpression,
+  vectorCircleColorValue,
+  vectorFillColorValue,
+  vectorLineColorValue,
   type GeoLibreLayer,
   type LayerStyle,
+  type VectorColorValue,
   useAppStore,
 } from "@geolibre/core";
+import type { PropertyValueSpecification } from "maplibre-gl";
 import type {
   VectorLayerInfo,
   VectorLayerOptions,
@@ -437,6 +443,13 @@ function savedVectorStyle(raw: unknown): Partial<VectorLayerStyle> | null {
  * layer's point circles unify with its fill from the first panel edit onward,
  * since GeoLibre has no separate point-fill control.
  *
+ * Categorized/graduated/expression style modes produce a data-driven MapLibre
+ * color expression that a flat color cannot represent, so it is carried in the
+ * control's optional *ColorExpression fields (the flat colors remain the
+ * fallback). The expression fields are always set — to the expression in a
+ * data-driven mode, or to undefined in `single` mode — so reverting to a single
+ * color clears any previously pushed expression on the control.
+ *
  * @param style - The GeoLibre layer style.
  * @returns The equivalent control style patch.
  */
@@ -453,7 +466,26 @@ function layerStyleToVectorStyle(style: LayerStyle): VectorLayerStyle {
     circleColor: style.fillColor,
     circleOpacity: style.fillOpacity,
     circleRadius: style.circleRadius,
+    fillColorExpression: colorExpressionField(vectorFillColorValue(style)),
+    lineColorExpression: colorExpressionField(vectorLineColorValue(style)),
+    circleColorExpression: colorExpressionField(vectorCircleColorValue(style)),
   };
+}
+
+/**
+ * Narrows a computed vector color to the control's expression field: the
+ * expression when the style mode is data-driven, or undefined when it resolves
+ * to a flat color (so the control falls back to fillColor/lineColor/circleColor).
+ *
+ * @param value - A color value from the @geolibre/core color builders.
+ * @returns The expression, or undefined for a flat color.
+ */
+function colorExpressionField(
+  value: VectorColorValue,
+): PropertyValueSpecification<string> | undefined {
+  return isVectorColorExpression(value)
+    ? (value as PropertyValueSpecification<string>)
+    : undefined;
 }
 
 /**
@@ -505,7 +537,13 @@ function vectorStylesEqual(
     left.lineWidth === right.lineWidth &&
     left.circleColor === right.circleColor &&
     left.circleOpacity === right.circleOpacity &&
-    left.circleRadius === right.circleRadius
+    left.circleRadius === right.circleRadius &&
+    // Color expressions are arrays (or undefined), so compare them deeply: a
+    // categorized/graduated stop change reuses the same flat colors but yields
+    // a different expression, which must still register as a style change.
+    valuesEqual(left.fillColorExpression, right.fillColorExpression) &&
+    valuesEqual(left.lineColorExpression, right.lineColorExpression) &&
+    valuesEqual(left.circleColorExpression, right.circleColorExpression)
   );
 }
 

--- a/packages/plugins/src/plugins/vector-layer-sync.ts
+++ b/packages/plugins/src/plugins/vector-layer-sync.ts
@@ -446,6 +446,7 @@ function savedVectorStyle(raw: unknown): Partial<VectorLayerStyle> | null {
     value: unknown,
   ): value is PropertyValueSpecification<string> =>
     Array.isArray(value) &&
+    value.length > 0 &&
     JSON.stringify(value).length <= MAX_COLOR_EXPRESSION_CHARS;
   if (colorExpression(candidate.fillColorExpression)) {
     style.fillColorExpression = candidate.fillColorExpression;

--- a/packages/plugins/src/plugins/vector-layer-sync.ts
+++ b/packages/plugins/src/plugins/vector-layer-sync.ts
@@ -444,10 +444,16 @@ function savedVectorStyle(raw: unknown): Partial<VectorLayerStyle> | null {
   // are far under this cap, and MapLibre validates the expression contents.
   const colorExpression = (
     value: unknown,
-  ): value is PropertyValueSpecification<string> =>
-    Array.isArray(value) &&
-    value.length > 0 &&
-    JSON.stringify(value).length <= MAX_COLOR_EXPRESSION_CHARS;
+  ): value is PropertyValueSpecification<string> => {
+    if (!Array.isArray(value) || value.length === 0) return false;
+    try {
+      return JSON.stringify(value).length <= MAX_COLOR_EXPRESSION_CHARS;
+    } catch {
+      // A circular or pathologically deep array makes JSON.stringify throw;
+      // reject it so a hand-edited project file cannot break restore.
+      return false;
+    }
+  };
   if (colorExpression(candidate.fillColorExpression)) {
     style.fillColorExpression = candidate.fillColorExpression;
   }

--- a/packages/plugins/src/plugins/vector-layer-sync.ts
+++ b/packages/plugins/src/plugins/vector-layer-sync.ts
@@ -18,6 +18,12 @@ import type {
 
 export const VECTOR_SOURCE_KIND = "maplibre-gl-vector";
 
+// Upper bound on a restored color expression's serialized size. Generous for a
+// real categorized/graduated style (hundreds of stops are well under this) but
+// blocks a hand-edited project file from smuggling a large blob into a paint
+// property, matching the length caps on restored color strings.
+const MAX_COLOR_EXPRESSION_CHARS = 20_000;
+
 /**
  * The slice of the maplibre-gl-vector VectorControl surface the store sync
  * drives. Structural (rather than the concrete class) so tests can pass
@@ -431,11 +437,16 @@ function savedVectorStyle(raw: unknown): Partial<VectorLayerStyle> | null {
   // Restore the data-driven color expressions so a saved categorized/graduated/
   // expression style renders on reload: restoreVectorLayers seeds the control's
   // addData from this style, and the post-load sync does not re-push (the
-  // recomputed expression matches the persisted one). Like the colors above,
-  // these are validated by MapLibre itself rather than parsed here.
+  // recomputed expression matches the persisted one). Bounded like the color
+  // strings above: an array passes only when its serialized form stays small,
+  // so a hand-edited project file cannot smuggle a multi-kilobyte (or deeply
+  // nested) blob into a paint property. Real categorized/graduated expressions
+  // are far under this cap, and MapLibre validates the expression contents.
   const colorExpression = (
     value: unknown,
-  ): value is PropertyValueSpecification<string> => Array.isArray(value);
+  ): value is PropertyValueSpecification<string> =>
+    Array.isArray(value) &&
+    JSON.stringify(value).length <= MAX_COLOR_EXPRESSION_CHARS;
   if (colorExpression(candidate.fillColorExpression)) {
     style.fillColorExpression = candidate.fillColorExpression;
   }

--- a/packages/plugins/src/plugins/vector-layer-sync.ts
+++ b/packages/plugins/src/plugins/vector-layer-sync.ts
@@ -428,6 +428,24 @@ function savedVectorStyle(raw: unknown): Partial<VectorLayerStyle> | null {
     style.circleOpacity = candidate.circleOpacity;
   }
 
+  // Restore the data-driven color expressions so a saved categorized/graduated/
+  // expression style renders on reload: restoreVectorLayers seeds the control's
+  // addData from this style, and the post-load sync does not re-push (the
+  // recomputed expression matches the persisted one). Like the colors above,
+  // these are validated by MapLibre itself rather than parsed here.
+  const colorExpression = (
+    value: unknown,
+  ): value is PropertyValueSpecification<string> => Array.isArray(value);
+  if (colorExpression(candidate.fillColorExpression)) {
+    style.fillColorExpression = candidate.fillColorExpression;
+  }
+  if (colorExpression(candidate.lineColorExpression)) {
+    style.lineColorExpression = candidate.lineColorExpression;
+  }
+  if (colorExpression(candidate.circleColorExpression)) {
+    style.circleColorExpression = candidate.circleColorExpression;
+  }
+
   return Object.keys(style).length > 0 ? style : null;
 }
 

--- a/tests/vector-layer-sync.test.ts
+++ b/tests/vector-layer-sync.test.ts
@@ -613,6 +613,31 @@ describe("savedVectorState", () => {
     });
   });
 
+  it("restores data-driven color expressions from the persisted style", () => {
+    // A saved categorized/graduated style persists a color expression in
+    // vectorState.style; restore must hand it back so the control seeds the
+    // expression and the reopened project renders the data-driven colors.
+    const matchExpr = [
+      "match",
+      ["to-string", ["get", "continent"]],
+      "Asia",
+      "#ff0000",
+      "#3388ff",
+    ];
+    const layer = createVectorStoreLayer(vectorInfo());
+    (layer.metadata.vectorState as Record<string, unknown>).style = {
+      ...vectorStyle(),
+      fillColorExpression: matchExpr,
+      circleColorExpression: matchExpr,
+    };
+
+    const restored = savedVectorState(layer).style;
+    assert.deepEqual(restored?.fillColorExpression, matchExpr);
+    assert.deepEqual(restored?.circleColorExpression, matchExpr);
+    // No lineColorExpression was persisted, so none is restored.
+    assert.equal(restored != null && "lineColorExpression" in restored, false);
+  });
+
   it("drops malformed fields from hand-edited project files", () => {
     const layer = createVectorStoreLayer(vectorInfo());
     layer.metadata.vectorState = {

--- a/tests/vector-layer-sync.test.ts
+++ b/tests/vector-layer-sync.test.ts
@@ -450,7 +450,8 @@ describe("wireVectorStoreSync", () => {
 
     // GeoLibre's shared fillColor/strokeColor/fillOpacity/strokeWidth map onto
     // the control's per-geometry fill/line/circle style; the unedited fields
-    // come from the style seeded off the control's own style.
+    // come from the style seeded off the control's own style. The color
+    // expression fields are undefined for a single-color (non-data-driven) edit.
     const expectedStyle = {
       fillColor: "#ff0000",
       fillOpacity: 0.4,
@@ -459,6 +460,9 @@ describe("wireVectorStoreSync", () => {
       circleColor: "#ff0000",
       circleOpacity: 0.4,
       circleRadius: 5,
+      fillColorExpression: undefined,
+      lineColorExpression: undefined,
+      circleColorExpression: undefined,
     };
     assert.deepEqual(calls, [
       { method: "setLayerStyle", args: ["vector-1", expectedStyle] },
@@ -471,6 +475,47 @@ describe("wireVectorStoreSync", () => {
       (stored.metadata.vectorState as { style: unknown }).style,
       expectedStyle,
     );
+  });
+
+  it("pushes a categorized color expression through the control", () => {
+    const { control, calls } = fakeControl([vectorInfo()]);
+    syncVectorLayersToStore(control);
+    wireVectorStoreSync(control);
+
+    useAppStore.getState().setLayerStyle("vector-1", {
+      vectorStyleMode: "categorized",
+      vectorStyleProperty: "continent",
+      vectorStyleStops: [
+        { value: "Asia", color: "#ff0000" },
+        { value: "Europe", color: "#00ff00" },
+      ],
+    });
+
+    assert.equal(calls.length, 1);
+    const [method, args] = [calls[0].method, calls[0].args];
+    assert.equal(method, "setLayerStyle");
+    const pushed = args[1] as VectorLayerStyle;
+    // The fill (and circle) color becomes a MapLibre `match` expression on the
+    // chosen attribute, with the flat fillColor as the fallback.
+    const matchExpr = [
+      "match",
+      ["to-string", ["get", "continent"]],
+      "Asia",
+      "#ff0000",
+      "Europe",
+      "#00ff00",
+      "#3388ff",
+    ];
+    assert.deepEqual(pushed.fillColorExpression, matchExpr);
+    assert.deepEqual(pushed.circleColorExpression, matchExpr);
+    // Polygon outlines keep the flat stroke color; only line geometry takes the
+    // categorized color, expressed via a geometry-type case.
+    assert.deepEqual(pushed.lineColorExpression, [
+      "case",
+      ["==", ["geometry-type"], "Polygon"],
+      "#3388ff",
+      matchExpr,
+    ]);
   });
 
   it("does not touch the control for GeoLibre-only style fields", () => {

--- a/tests/vector-layer-sync.test.ts
+++ b/tests/vector-layer-sync.test.ts
@@ -661,6 +661,27 @@ describe("savedVectorState", () => {
     assert.equal("lineColorExpression" in restored, false);
   });
 
+  it("drops a malformed color expression without throwing", () => {
+    // A circular (or pathologically deep) array from a hand-edited project file
+    // would make JSON.stringify throw; the guard must reject it and keep the
+    // rest of the restore working rather than aborting it. Empty arrays are
+    // rejected too, since [] is not a valid MapLibre expression.
+    const circular: unknown[] = [];
+    circular.push(circular);
+    const layer = createVectorStoreLayer(vectorInfo());
+    (layer.metadata.vectorState as Record<string, unknown>).style = {
+      fillColor: "#123456",
+      fillColorExpression: circular,
+      lineColorExpression: [],
+    };
+
+    const restored = savedVectorState(layer).style;
+    assert.ok(restored != null);
+    assert.equal(restored.fillColor, "#123456");
+    assert.equal("fillColorExpression" in restored, false);
+    assert.equal("lineColorExpression" in restored, false);
+  });
+
   it("drops malformed fields from hand-edited project files", () => {
     const layer = createVectorStoreLayer(vectorInfo());
     layer.metadata.vectorState = {

--- a/tests/vector-layer-sync.test.ts
+++ b/tests/vector-layer-sync.test.ts
@@ -518,6 +518,28 @@ describe("wireVectorStoreSync", () => {
     ]);
   });
 
+  it("clears the color expression when reverting to a single color", () => {
+    const { control, calls } = fakeControl([vectorInfo()]);
+    syncVectorLayersToStore(control);
+    wireVectorStoreSync(control);
+
+    useAppStore.getState().setLayerStyle("vector-1", {
+      vectorStyleMode: "categorized",
+      vectorStyleProperty: "continent",
+      vectorStyleStops: [{ value: "Asia", color: "#ff0000" }],
+    });
+    useAppStore.getState().setLayerStyle("vector-1", {
+      vectorStyleMode: "single",
+    });
+
+    // Two pushes: one applying the expression, one reverting to flat color.
+    assert.equal(calls.length, 2);
+    const reverted = calls[1].args[1] as VectorLayerStyle;
+    assert.equal(reverted.fillColorExpression, undefined);
+    assert.equal(reverted.lineColorExpression, undefined);
+    assert.equal(reverted.circleColorExpression, undefined);
+  });
+
   it("does not touch the control for GeoLibre-only style fields", () => {
     const { control, calls } = fakeControl([vectorInfo()]);
     syncVectorLayersToStore(control);
@@ -632,10 +654,11 @@ describe("savedVectorState", () => {
     };
 
     const restored = savedVectorState(layer).style;
-    assert.deepEqual(restored?.fillColorExpression, matchExpr);
-    assert.deepEqual(restored?.circleColorExpression, matchExpr);
+    assert.ok(restored != null);
+    assert.deepEqual(restored.fillColorExpression, matchExpr);
+    assert.deepEqual(restored.circleColorExpression, matchExpr);
     // No lineColorExpression was persisted, so none is restored.
-    assert.equal(restored != null && "lineColorExpression" in restored, false);
+    assert.equal("lineColorExpression" in restored, false);
   });
 
   it("drops malformed fields from hand-edited project files", () => {


### PR DESCRIPTION
## Summary
Categorized, graduated, and expression style modes had no effect on "Add Vector Layer" layers: only single-color edits applied. These layers are rendered by the `maplibre-gl-vector` control, and the bridge into `control.setLayerStyle` collapsed GeoLibre's style into the control's flat `VectorLayerStyle`, dropping the data-driven `match`/`interpolate` color expression. (Normal in-browser GeoJSON layers were never affected; they style through `@geolibre/map`'s paint path.)

- Move the vector color-expression builder into `@geolibre/core` (`vector-color.ts`), reused by `@geolibre/map`'s `style-mapper` (no behavior change) so `@geolibre/plugins` can use it without depending on `@geolibre/map`.
- The control bridge now computes and pushes fill/line/circle color expressions through the control's new `*ColorExpression` fields; `vectorStylesEqual` deep-compares them. The fields are always set, so reverting to a single color clears a previously pushed expression.
- Requires `maplibre-gl-vector@0.2.5`, which adds the data-driven color fields (opengeos/maplibre-gl-vector#11).

## Test plan
- [x] `npm run typecheck` (full build) green against published `maplibre-gl-vector@0.2.5`
- [x] `npm run test:frontend` (201 passing, incl. new categorized-expression bridge test)
- [x] Verified end-to-end in the running app: loaded the default countries layer, applied Categorized -> CONTINENT, and the map recolors per continent (was uniform before)

Fixes #220

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Data-driven color expressions for vector layers (categorized, graduated, expression modes)
  * New public helpers for vector color handling and robust expression parsing with safe fallbacks

* **Bug Fixes / Improvements**
  * Sync preserves, compares and restores expression-based vector styles so edits reliably propagate
  * Geometry-aware color behavior refined for fills, lines and circles; invalid/oversized expressions are ignored

* **Tests**
  * Extended vector layer sync tests covering expression round-trips and restoration

* **Chores**
  * Dependency version bump
<!-- end of auto-generated comment: release notes by coderabbit.ai -->