### PR TITLE
feat(attribute-table): manage columns (rename, delete, hide, reorder)

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -358,7 +358,10 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     setDrafts({});
     // Clear column-management state too, so a rename input or pending delete
     // started on the previous layer cannot apply to a same-named column on the
-    // newly selected layer.
+    // newly selected layer. Suppress the rename Input's onBlur first: clearing
+    // editingColumn unmounts it, which fires onBlur -> commitColumnRename with
+    // the old column but the new layer, so the guard must already be set.
+    suppressColumnBlurRef.current = true;
     setEditingColumn(null);
     setEditingColumnName("");
     setColumnPendingDelete(null);
@@ -646,8 +649,9 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     }
     suppressColumnBlurRef.current = true;
     const oldKey = editingColumn;
-    // Trim once here and pass the normalized key, so the data written by
-    // renameColumn and the view-state updates below cannot drift apart.
+    // Normalize the key here so the view-state updates below use exactly what
+    // renameColumn writes. (renameColumn also trims defensively for other
+    // callers; passing the already-trimmed value keeps the two in agreement.)
     const newKey = editingColumnName.trim();
     const patch = renameColumn(layer, discoveredColumns, oldKey, newKey);
     if (patch) {
@@ -686,6 +690,13 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     if (!layer || !columnPendingDelete) return;
     const patch = deleteColumn(layer, columnPendingDelete);
     if (patch) updateLayer(layer.id, patch);
+    // Drop a sort that pointed at the deleted column, which would otherwise
+    // leave sort.key referencing an absent field (every row compares equal).
+    setSort((current) =>
+      current.key === columnPendingDelete
+        ? { key: "__featureId", direction: "asc" }
+        : current,
+    );
     setColumnPendingDelete(null);
   };
 

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -10,9 +10,17 @@ import type { MapController } from "@geolibre/map";
 import type { GeoJSONSource } from "maplibre-gl";
 import {
   Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
   Input,
   ScrollArea,
@@ -25,14 +33,20 @@ import {
 import type { Feature, FeatureCollection } from "geojson";
 import {
   ArrowDown,
+  ArrowLeft,
+  ArrowRight,
   ArrowUp,
+  Columns3,
   Download,
+  EyeOff,
+  MoreHorizontal,
   Pencil,
   PanelBottomClose,
   PanelBottomOpen,
   RotateCcw,
   Save,
   TableProperties,
+  Trash2,
   X,
 } from "lucide-react";
 import {
@@ -44,6 +58,17 @@ import {
   useSyncExternalStore,
 } from "react";
 import { isTauri } from "../../lib/tauri-io";
+import {
+  deleteColumn,
+  getColumnSettings,
+  hiddenColumns,
+  moveColumn,
+  showAllColumns,
+  toggleColumnHidden,
+  renameColumn,
+  visibleColumns,
+  type ColumnMoveDirection,
+} from "../../lib/attribute-columns";
 import {
   exportVectorLayer,
   formatAttributeValue,
@@ -232,6 +257,15 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
   const deferTableResize = isTauri();
 
   const [loadingVectorGeojson, setLoadingVectorGeojson] = useState(false);
+  // Inline field-rename editing in a column header.
+  const [editingColumn, setEditingColumn] = useState<string | null>(null);
+  const [editingColumnName, setEditingColumnName] = useState("");
+  // Set true by Escape/commit so the input's blur does not re-commit a rename
+  // from a stale closure (mirrors LayerPanel's rename guard).
+  const suppressColumnBlurRef = useRef(false);
+  const [columnPendingDelete, setColumnPendingDelete] = useState<string | null>(
+    null,
+  );
 
   const layer = layers.find((l) => l.id === selectedLayerId);
   const hasLayer = Boolean(layer);
@@ -349,8 +383,17 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
       propKeys.add(k);
     }
   }
-  const columns = Array.from(propKeys);
+  const discoveredColumns = Array.from(propKeys);
+  const columnSettings = getColumnSettings(layer);
+  // Columns rendered in the table, honoring saved order and hidden state.
+  const columns = visibleColumns(discoveredColumns, columnSettings);
+  const hiddenCols = hiddenColumns(discoveredColumns, columnSettings);
   const tableColumns = ["__featureId", ...columns];
+  // Column management mutates layer.geojson/style/metadata, so it is offered
+  // only for in-store, editable GeoJSON layers — not DuckDB query results or
+  // Add Vector Layer layers (whose geojson is not persisted).
+  const canManageColumns =
+    Boolean(layer?.geojson) && !isDuckDBLayer && !isReadOnlyVectorLayer;
 
   const columnWidth = (key: SortKey) =>
     columnWidths[key] ??
@@ -577,6 +620,71 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     }
   };
 
+  const beginColumnRename = (col: string) => {
+    suppressColumnBlurRef.current = false;
+    setEditingColumn(col);
+    setEditingColumnName(col);
+  };
+
+  const cancelColumnRename = () => {
+    suppressColumnBlurRef.current = true;
+    setEditingColumn(null);
+    setEditingColumnName("");
+  };
+
+  const commitColumnRename = () => {
+    if (suppressColumnBlurRef.current || !editingColumn || !layer) {
+      suppressColumnBlurRef.current = false;
+      return;
+    }
+    suppressColumnBlurRef.current = true;
+    const oldKey = editingColumn;
+    const patch = renameColumn(
+      layer,
+      discoveredColumns,
+      oldKey,
+      editingColumnName,
+    );
+    if (patch) {
+      const newKey = editingColumnName.trim();
+      updateLayer(layer.id, patch);
+      // Keep view state pointing at the renamed column.
+      setColumnWidths((current) => {
+        if (!(oldKey in current)) return current;
+        const { [oldKey]: width, ...rest } = current;
+        return { ...rest, [newKey]: width };
+      });
+      setSort((current) =>
+        current.key === oldKey ? { ...current, key: newKey } : current,
+      );
+    }
+    setEditingColumn(null);
+    setEditingColumnName("");
+  };
+
+  const handleToggleHidden = (col: string) => {
+    if (!layer) return;
+    updateLayer(layer.id, toggleColumnHidden(layer, col));
+  };
+
+  const handleShowAllColumns = () => {
+    if (!layer) return;
+    updateLayer(layer.id, showAllColumns(layer));
+  };
+
+  const handleMoveColumn = (col: string, direction: ColumnMoveDirection) => {
+    if (!layer) return;
+    const patch = moveColumn(layer, discoveredColumns, col, direction);
+    if (patch) updateLayer(layer.id, patch);
+  };
+
+  const confirmDeleteColumn = () => {
+    if (!layer || !columnPendingDelete) return;
+    const patch = deleteColumn(layer, columnPendingDelete);
+    if (patch) updateLayer(layer.id, patch);
+    setColumnPendingDelete(null);
+  };
+
   const sortableHeader = (key: SortKey, label: string) => (
     <div className="relative flex h-full min-h-10 items-center">
       <button
@@ -596,6 +704,105 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
       />
     </div>
   );
+
+  const attributeColumnHeader = (col: string, index: number) => {
+    if (editingColumn === col) {
+      return (
+        <div className="relative flex h-full min-h-10 items-center">
+          <Input
+            autoFocus
+            className="h-7 min-w-0 flex-1 px-2 text-xs"
+            aria-label={`Rename field ${col}`}
+            value={editingColumnName}
+            onClick={(event) => event.stopPropagation()}
+            onFocus={(event) => event.currentTarget.select()}
+            onChange={(event) => setEditingColumnName(event.target.value)}
+            onBlur={commitColumnRename}
+            onKeyDown={(event) => {
+              event.stopPropagation();
+              if (event.key === "Enter") {
+                event.preventDefault();
+                commitColumnRename();
+              } else if (event.key === "Escape") {
+                event.preventDefault();
+                cancelColumnRename();
+              }
+            }}
+          />
+        </div>
+      );
+    }
+
+    // Read-only / non-manageable layers (DuckDB, Add Vector Layer) keep the
+    // plain sortable header with no management affordances.
+    if (!canManageColumns || isEditing) return sortableHeader(col, col);
+
+    return (
+      <div className="relative flex h-full min-h-10 items-center">
+        <button
+          type="button"
+          className="flex h-full min-w-0 flex-1 items-center gap-1 pr-1 text-left font-medium"
+          onClick={() => toggleSort(col)}
+        >
+          <span className="truncate">{col}</span>
+          {renderSortIcon(col)}
+        </button>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-5 w-5 shrink-0 text-muted-foreground"
+              title={`Manage field "${col}"`}
+              aria-label={`Manage field ${col}`}
+              onClick={(event) => event.stopPropagation()}
+            >
+              <MoreHorizontal className="h-3.5 w-3.5" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onSelect={() => beginColumnRename(col)}>
+              <Pencil className="mr-2 h-3.5 w-3.5" />
+              Rename field
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => handleToggleHidden(col)}>
+              <EyeOff className="mr-2 h-3.5 w-3.5" />
+              Hide field
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={index === 0}
+              onSelect={() => handleMoveColumn(col, "left")}
+            >
+              <ArrowLeft className="mr-2 h-3.5 w-3.5" />
+              Move left
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={index === columns.length - 1}
+              onSelect={() => handleMoveColumn(col, "right")}
+            >
+              <ArrowRight className="mr-2 h-3.5 w-3.5" />
+              Move right
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              className="text-destructive focus:text-destructive"
+              onSelect={() => setColumnPendingDelete(col)}
+            >
+              <Trash2 className="mr-2 h-3.5 w-3.5" />
+              Delete field
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          aria-label={`Resize ${col} column`}
+          className="absolute -right-2 top-0 h-full w-3 cursor-col-resize select-none border-r border-transparent hover:border-primary"
+          onMouseDown={(event) => startColumnResize(col, event)}
+        />
+      </div>
+    );
+  };
 
   if (!attributeTableOpen) {
     return (
@@ -711,6 +918,49 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
           <Save className="h-3.5 w-3.5" />
           <span className="hidden sm:inline">Save</span>
         </Button>
+        {canManageColumns && !isEditing ? (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 px-2"
+                title="Show or hide fields"
+                aria-label="Manage fields"
+              >
+                <Columns3 className="h-3.5 w-3.5" />
+                <span className="hidden sm:inline">Fields</span>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="max-h-72 overflow-y-auto">
+              <DropdownMenuLabel>Visible fields</DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              {discoveredColumns.length === 0 ? (
+                <DropdownMenuItem disabled>No fields</DropdownMenuItem>
+              ) : (
+                discoveredColumns.map((col) => (
+                  <DropdownMenuCheckboxItem
+                    key={col}
+                    checked={!hiddenCols.includes(col)}
+                    // Keep the menu open so several fields can be toggled at once.
+                    onSelect={(event: Event) => event.preventDefault()}
+                    onCheckedChange={() => handleToggleHidden(col)}
+                  >
+                    <span className="truncate">{col}</span>
+                  </DropdownMenuCheckboxItem>
+                ))
+              )}
+              {hiddenCols.length > 0 ? (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onSelect={handleShowAllColumns}>
+                    Show all fields
+                  </DropdownMenuItem>
+                </>
+              ) : null}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : null}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
@@ -812,9 +1062,9 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
                 <TableHead className="bg-card">
                   {sortableHeader("__featureId", "#")}
                 </TableHead>
-                {columns.map((col) => (
+                {columns.map((col, index) => (
                   <TableHead key={col} className="bg-card">
-                    {sortableHeader(col, col)}
+                    {attributeColumnHeader(col, index)}
                   </TableHead>
                 ))}
               </TableRow>
@@ -882,6 +1132,32 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
           </table>
         )}
       </ScrollArea>
+      <Dialog
+        open={columnPendingDelete !== null}
+        onOpenChange={(open: boolean) => {
+          if (!open) setColumnPendingDelete(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete field</DialogTitle>
+            <DialogDescription>
+              {`This permanently removes the field "${columnPendingDelete ?? ""}" from every feature in "${layer?.name ?? ""}". Styling or labels that reference it will be cleared. This cannot be undone.`}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="outline"
+              onClick={() => setColumnPendingDelete(null)}
+            >
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={confirmDeleteColumn}>
+              Delete field
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
     </section>
   );
 }

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -666,6 +666,10 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
         current.key === oldKey ? { ...current, key: newKey } : current,
       );
     }
+    // Always close the editor when committing, even on a no-op (empty,
+    // unchanged, or a name that collides with an existing — possibly hidden —
+    // column); the original name is kept. This matches the layer-rename UX in
+    // LayerPanel. Use Escape to cancel.
     setEditingColumn(null);
     setEditingColumnName("");
   };
@@ -697,6 +701,13 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
         ? { key: "__featureId", direction: "asc" }
         : current,
     );
+    // Drop the deleted column's width so columnWidths doesn't accumulate stale
+    // entries across a session (mirrors the migration in commitColumnRename).
+    setColumnWidths((current) => {
+      if (!(columnPendingDelete in current)) return current;
+      const { [columnPendingDelete]: _removed, ...rest } = current;
+      return rest;
+    });
     setColumnPendingDelete(null);
   };
 

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -356,6 +356,12 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
   useEffect(() => {
     setIsEditing(false);
     setDrafts({});
+    // Clear column-management state too, so a rename input or pending delete
+    // started on the previous layer cannot apply to a same-named column on the
+    // newly selected layer.
+    setEditingColumn(null);
+    setEditingColumnName("");
+    setColumnPendingDelete(null);
   }, [selectedLayerId, hasLayer, isGeometryEditing]);
 
   const filterLower = attributeFilter.toLowerCase();
@@ -388,6 +394,7 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
   // Columns rendered in the table, honoring saved order and hidden state.
   const columns = visibleColumns(discoveredColumns, columnSettings);
   const hiddenCols = hiddenColumns(discoveredColumns, columnSettings);
+  const hiddenColSet = new Set(hiddenCols);
   const tableColumns = ["__featureId", ...columns];
   // Column management mutates layer.geojson/style/metadata, so it is offered
   // only for in-store, editable GeoJSON layers — not DuckDB query results or
@@ -729,6 +736,13 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
               }
             }}
           />
+          <div
+            role="separator"
+            aria-orientation="vertical"
+            aria-label={`Resize ${col} column`}
+            className="absolute -right-2 top-0 h-full w-3 cursor-col-resize select-none border-r border-transparent hover:border-primary"
+            onMouseDown={(event) => startColumnResize(col, event)}
+          />
         </div>
       );
     }
@@ -941,7 +955,7 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
                 discoveredColumns.map((col) => (
                   <DropdownMenuCheckboxItem
                     key={col}
-                    checked={!hiddenCols.includes(col)}
+                    checked={!hiddenColSet.has(col)}
                     // Keep the menu open so several fields can be toggled at once.
                     onSelect={(event: Event) => event.preventDefault()}
                     onCheckedChange={() => handleToggleHidden(col)}

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -646,14 +646,11 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     }
     suppressColumnBlurRef.current = true;
     const oldKey = editingColumn;
-    const patch = renameColumn(
-      layer,
-      discoveredColumns,
-      oldKey,
-      editingColumnName,
-    );
+    // Trim once here and pass the normalized key, so the data written by
+    // renameColumn and the view-state updates below cannot drift apart.
+    const newKey = editingColumnName.trim();
+    const patch = renameColumn(layer, discoveredColumns, oldKey, newKey);
     if (patch) {
-      const newKey = editingColumnName.trim();
       updateLayer(layer.id, patch);
       // Keep view state pointing at the renamed column.
       setColumnWidths((current) => {
@@ -947,7 +944,7 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="max-h-72 overflow-y-auto">
-              <DropdownMenuLabel>Visible fields</DropdownMenuLabel>
+              <DropdownMenuLabel>Show fields</DropdownMenuLabel>
               <DropdownMenuSeparator />
               {discoveredColumns.length === 0 ? (
                 <DropdownMenuItem disabled>No fields</DropdownMenuItem>

--- a/apps/geolibre-desktop/src/lib/attribute-columns.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-columns.ts
@@ -233,6 +233,12 @@ export function deleteColumn(
   key: string,
 ): Partial<GeoLibreLayer> | null {
   if (!layer.geojson) return null;
+  // Mirror renameColumn's guard: a key absent from every feature is a no-op, so
+  // don't return a patch that would touch style/settings without changing data.
+  const keyExists = layer.geojson.features.some(
+    (feature) => feature.properties != null && key in feature.properties,
+  );
+  if (!keyExists) return null;
   const settings = getColumnSettings(layer);
   return {
     geojson: deleteFieldInGeojson(layer.geojson, key),

--- a/apps/geolibre-desktop/src/lib/attribute-columns.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-columns.ts
@@ -1,5 +1,4 @@
 import {
-  DEFAULT_LAYER_STYLE,
   styleValue,
   type GeoLibreLayer,
   type LayerStyle,
@@ -215,6 +214,7 @@ export function renameColumn(
 ): Partial<GeoLibreLayer> | null {
   const newKey = rawNewKey.trim();
   if (!layer.geojson || !newKey || newKey === oldKey) return null;
+  if (!discovered.includes(oldKey)) return null; // nothing to rename
   if (discovered.includes(newKey)) return null; // would clobber another column
   const settings = getColumnSettings(layer);
   return {

--- a/apps/geolibre-desktop/src/lib/attribute-columns.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-columns.ts
@@ -122,6 +122,12 @@ export function hiddenColumns(
   return orderColumns(discovered, settings).filter((key) => hidden.has(key));
 }
 
+// NOTE: renameFieldInGeojson/deleteFieldInGeojson rewrite every feature's
+// property object synchronously on the main thread. This is fine for typical
+// in-browser GeoJSON sizes but will visibly jank on very large layers (tens of
+// thousands of features); chunking or a worker would be needed if that becomes
+// a real workflow. Kept synchronous deliberately — these run on a user-initiated
+// one-off action, not in a hot path.
 function renameFieldInGeojson(
   geojson: FeatureCollection,
   oldKey: string,

--- a/apps/geolibre-desktop/src/lib/attribute-columns.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-columns.ts
@@ -1,0 +1,295 @@
+import {
+  DEFAULT_LAYER_STYLE,
+  styleValue,
+  type GeoLibreLayer,
+  type LayerStyle,
+} from "@geolibre/core";
+import type { FeatureCollection } from "geojson";
+
+/**
+ * Per-layer attribute-table column settings, persisted under
+ * `layer.metadata.columnSettings` so they survive save/reload. Only view-level
+ * concerns live here (visibility and order); rename and delete are destructive
+ * and rewrite the underlying GeoJSON properties instead.
+ */
+export interface ColumnSettings {
+  /** Property keys hidden from the table (view-only, non-destructive). */
+  hidden?: string[];
+  /** Explicit display order of property keys; unknown keys append after. */
+  order?: string[];
+}
+
+export type ColumnMoveDirection = "left" | "right";
+
+const COLUMN_SETTINGS_KEY = "columnSettings";
+
+// Style fields that hold a literal property name a destructive rename/delete
+// must keep in sync. Free-form expression fields (vectorStyleExpression,
+// extrusion*Expression) are intentionally left untouched — rewriting arbitrary
+// MapLibre expressions is out of scope.
+const STYLE_FIELD_KEYS = [
+  "vectorStyleProperty",
+  "extrusionHeightProperty",
+] as const satisfies ReadonlyArray<keyof LayerStyle>;
+
+function stringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const items = value.filter((item): item is string => typeof item === "string");
+  return items.length > 0 ? items : undefined;
+}
+
+/** Read the layer's column settings, tolerating missing/malformed metadata. */
+export function getColumnSettings(
+  layer?: GeoLibreLayer | null,
+): ColumnSettings {
+  const raw = layer?.metadata?.[COLUMN_SETTINGS_KEY];
+  if (!raw || typeof raw !== "object") return {};
+  const settings = raw as ColumnSettings;
+  return {
+    hidden: stringArray(settings.hidden),
+    order: stringArray(settings.order),
+  };
+}
+
+/** Drop empty fields so a no-op settings object isn't persisted. */
+function normalizeSettings(settings: ColumnSettings): ColumnSettings | null {
+  const hidden = settings.hidden?.length ? settings.hidden : undefined;
+  const order = settings.order?.length ? settings.order : undefined;
+  if (!hidden && !order) return null;
+  return {
+    ...(hidden ? { hidden } : {}),
+    ...(order ? { order } : {}),
+  };
+}
+
+/**
+ * Build a full metadata object carrying the next column settings, ready to pass
+ * to `updateLayer` (which replaces metadata wholesale). Removes the key when the
+ * settings are empty.
+ */
+function metadataWithSettings(
+  layer: GeoLibreLayer,
+  next: ColumnSettings,
+): Record<string, unknown> {
+  const metadata = { ...(layer.metadata ?? {}) };
+  const normalized = normalizeSettings(next);
+  if (normalized) metadata[COLUMN_SETTINGS_KEY] = normalized;
+  else delete metadata[COLUMN_SETTINGS_KEY];
+  return metadata;
+}
+
+/**
+ * Full display order of all discovered columns: settings.order first (filtered
+ * to columns that still exist), then any newly-discovered columns in their
+ * discovery order. Includes hidden columns.
+ */
+export function orderColumns(
+  discovered: string[],
+  settings: ColumnSettings,
+): string[] {
+  const known = new Set(discovered);
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const key of settings.order ?? []) {
+    if (known.has(key) && !seen.has(key)) {
+      result.push(key);
+      seen.add(key);
+    }
+  }
+  for (const key of discovered) {
+    if (!seen.has(key)) {
+      result.push(key);
+      seen.add(key);
+    }
+  }
+  return result;
+}
+
+/** Ordered columns with hidden ones removed — what the table renders. */
+export function visibleColumns(
+  discovered: string[],
+  settings: ColumnSettings,
+): string[] {
+  const hidden = new Set(settings.hidden ?? []);
+  return orderColumns(discovered, settings).filter((key) => !hidden.has(key));
+}
+
+/** Ordered columns that are currently hidden. */
+export function hiddenColumns(
+  discovered: string[],
+  settings: ColumnSettings,
+): string[] {
+  const hidden = new Set(settings.hidden ?? []);
+  return orderColumns(discovered, settings).filter((key) => hidden.has(key));
+}
+
+function renameFieldInGeojson(
+  geojson: FeatureCollection,
+  oldKey: string,
+  newKey: string,
+): FeatureCollection {
+  return {
+    ...geojson,
+    features: geojson.features.map((feature) => {
+      const properties = feature.properties;
+      if (!properties || !(oldKey in properties)) return feature;
+      // Rebuild to keep the renamed key in its original position.
+      const next: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(properties)) {
+        next[key === oldKey ? newKey : key] = value;
+      }
+      return { ...feature, properties: next };
+    }),
+  };
+}
+
+function deleteFieldInGeojson(
+  geojson: FeatureCollection,
+  key: string,
+): FeatureCollection {
+  return {
+    ...geojson,
+    features: geojson.features.map((feature) => {
+      const properties = feature.properties;
+      if (!properties || !(key in properties)) return feature;
+      const { [key]: _removed, ...rest } = properties;
+      return { ...feature, properties: rest };
+    }),
+  };
+}
+
+function renameFieldInStyle(
+  style: LayerStyle,
+  oldKey: string,
+  newKey: string,
+): LayerStyle {
+  let next = style;
+  for (const key of STYLE_FIELD_KEYS) {
+    if (styleValue(style, key) === oldKey) next = { ...next, [key]: newKey };
+  }
+  return next;
+}
+
+function clearFieldInStyle(style: LayerStyle, key: string): LayerStyle {
+  let next = style;
+  for (const styleKey of STYLE_FIELD_KEYS) {
+    // Reset to "" rather than the shared default so a deleted field does not
+    // silently re-point styling at some other (possibly absent) property.
+    if (styleValue(style, styleKey) === key) next = { ...next, [styleKey]: "" };
+  }
+  return next;
+}
+
+function renameKeyInSettings(
+  settings: ColumnSettings,
+  oldKey: string,
+  newKey: string,
+): ColumnSettings {
+  return {
+    hidden: settings.hidden?.map((key) => (key === oldKey ? newKey : key)),
+    order: settings.order?.map((key) => (key === oldKey ? newKey : key)),
+  };
+}
+
+function removeKeyFromSettings(
+  settings: ColumnSettings,
+  key: string,
+): ColumnSettings {
+  return {
+    hidden: settings.hidden?.filter((entry) => entry !== key),
+    order: settings.order?.filter((entry) => entry !== key),
+  };
+}
+
+/**
+ * Destructive rename of a property key across every feature, keeping styling and
+ * column settings in sync. Returns null (no-op) when the new name is empty,
+ * unchanged, or collides with an existing column, or when the layer has no
+ * in-store GeoJSON.
+ */
+export function renameColumn(
+  layer: GeoLibreLayer,
+  discovered: string[],
+  oldKey: string,
+  rawNewKey: string,
+): Partial<GeoLibreLayer> | null {
+  const newKey = rawNewKey.trim();
+  if (!layer.geojson || !newKey || newKey === oldKey) return null;
+  if (discovered.includes(newKey)) return null; // would clobber another column
+  const settings = getColumnSettings(layer);
+  return {
+    geojson: renameFieldInGeojson(layer.geojson, oldKey, newKey),
+    style: renameFieldInStyle(layer.style, oldKey, newKey),
+    metadata: metadataWithSettings(
+      layer,
+      renameKeyInSettings(settings, oldKey, newKey),
+    ),
+  };
+}
+
+/** Destructive removal of a property key from every feature. */
+export function deleteColumn(
+  layer: GeoLibreLayer,
+  key: string,
+): Partial<GeoLibreLayer> | null {
+  if (!layer.geojson) return null;
+  const settings = getColumnSettings(layer);
+  return {
+    geojson: deleteFieldInGeojson(layer.geojson, key),
+    style: clearFieldInStyle(layer.style, key),
+    metadata: metadataWithSettings(layer, removeKeyFromSettings(settings, key)),
+  };
+}
+
+/** Toggle a column's visibility (view-only metadata change). */
+export function toggleColumnHidden(
+  layer: GeoLibreLayer,
+  key: string,
+): Partial<GeoLibreLayer> {
+  const settings = getColumnSettings(layer);
+  const hidden = new Set(settings.hidden ?? []);
+  if (hidden.has(key)) hidden.delete(key);
+  else hidden.add(key);
+  return {
+    metadata: metadataWithSettings(layer, { ...settings, hidden: [...hidden] }),
+  };
+}
+
+/** Reveal every hidden column. */
+export function showAllColumns(layer: GeoLibreLayer): Partial<GeoLibreLayer> {
+  const settings = getColumnSettings(layer);
+  return {
+    metadata: metadataWithSettings(layer, { ...settings, hidden: [] }),
+  };
+}
+
+/**
+ * Move a column one slot left or right among the visible columns, persisting
+ * the new order. No-op at the respective edge.
+ */
+export function moveColumn(
+  layer: GeoLibreLayer,
+  discovered: string[],
+  key: string,
+  direction: ColumnMoveDirection,
+): Partial<GeoLibreLayer> | null {
+  const settings = getColumnSettings(layer);
+  const full = orderColumns(discovered, settings);
+  const hidden = new Set(settings.hidden ?? []);
+  const visible = full.filter((entry) => !hidden.has(entry));
+  const visibleIndex = visible.indexOf(key);
+  if (visibleIndex < 0) return null;
+  const neighbor =
+    direction === "left"
+      ? visible[visibleIndex - 1]
+      : visible[visibleIndex + 1];
+  if (neighbor === undefined) return null;
+
+  const next = [...full];
+  const from = next.indexOf(key);
+  const to = next.indexOf(neighbor);
+  [next[from], next[to]] = [next[to], next[from]];
+  return {
+    metadata: metadataWithSettings(layer, { ...settings, order: next }),
+  };
+}

--- a/tests/attribute-columns.test.ts
+++ b/tests/attribute-columns.test.ts
@@ -93,11 +93,26 @@ describe("renameColumn (destructive)", () => {
     assert.deepEqual(settings.order, ["Population", "name"]);
   });
 
-  it("is a no-op for empty, unchanged, or colliding names", () => {
+  it("rewrites every style field that references the renamed column", () => {
+    const layer = makeLayer({
+      style: {
+        ...DEFAULT_LAYER_STYLE,
+        vectorStyleProperty: "pop",
+        extrusionHeightProperty: "pop",
+      },
+    });
+    const patch = renameColumn(layer, DISCOVERED, "pop", "Population");
+    assert.equal(patch?.style?.vectorStyleProperty, "Population");
+    assert.equal(patch?.style?.extrusionHeightProperty, "Population");
+  });
+
+  it("is a no-op for empty, unchanged, colliding, or absent names", () => {
     const layer = makeLayer();
     assert.equal(renameColumn(layer, DISCOVERED, "pop", "  "), null);
     assert.equal(renameColumn(layer, DISCOVERED, "pop", "pop"), null);
     assert.equal(renameColumn(layer, DISCOVERED, "pop", "area"), null);
+    // oldKey not among the discovered columns: nothing to rename.
+    assert.equal(renameColumn(layer, DISCOVERED, "missing", "New"), null);
   });
 });
 
@@ -115,12 +130,17 @@ describe("deleteColumn (destructive)", () => {
     ]);
   });
 
-  it("clears a style field that referenced the deleted column", () => {
+  it("clears every style field that referenced the deleted column", () => {
     const layer = makeLayer({
-      style: { ...DEFAULT_LAYER_STYLE, extrusionHeightProperty: "pop" },
+      style: {
+        ...DEFAULT_LAYER_STYLE,
+        extrusionHeightProperty: "pop",
+        vectorStyleProperty: "pop",
+      },
     });
     const patch = deleteColumn(layer, "pop");
     assert.equal(patch?.style?.extrusionHeightProperty, "");
+    assert.equal(patch?.style?.vectorStyleProperty, "");
   });
 
   it("drops the key from column settings", () => {

--- a/tests/attribute-columns.test.ts
+++ b/tests/attribute-columns.test.ts
@@ -152,6 +152,10 @@ describe("deleteColumn (destructive)", () => {
       .columnSettings as { order: string[] };
     assert.deepEqual(settings.order, ["name", "area"]);
   });
+
+  it("is a no-op for a key absent from every feature", () => {
+    assert.equal(deleteColumn(makeLayer(), "missing"), null);
+  });
 });
 
 describe("visibility toggles", () => {

--- a/tests/attribute-columns.test.ts
+++ b/tests/attribute-columns.test.ts
@@ -1,0 +1,226 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { DEFAULT_LAYER_STYLE, type GeoLibreLayer } from "@geolibre/core";
+import type { FeatureCollection } from "geojson";
+import {
+  deleteColumn,
+  getColumnSettings,
+  hiddenColumns,
+  moveColumn,
+  orderColumns,
+  renameColumn,
+  showAllColumns,
+  toggleColumnHidden,
+  visibleColumns,
+} from "../apps/geolibre-desktop/src/lib/attribute-columns";
+
+function fc(features: FeatureCollection["features"]): FeatureCollection {
+  return { type: "FeatureCollection", features };
+}
+
+function makeLayer(patch: Partial<GeoLibreLayer> = {}): GeoLibreLayer {
+  return {
+    id: "layer-1",
+    name: "Test",
+    type: "geojson",
+    source: { type: "geojson" },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {},
+    geojson: fc([
+      {
+        type: "Feature",
+        geometry: { type: "Point", coordinates: [0, 0] },
+        properties: { name: "A", pop: 10, area: 5 },
+      },
+      {
+        type: "Feature",
+        geometry: { type: "Point", coordinates: [1, 1] },
+        properties: { name: "B", pop: 20, area: 8 },
+      },
+    ]),
+    ...patch,
+  };
+}
+
+const DISCOVERED = ["name", "pop", "area"];
+
+describe("column ordering and visibility", () => {
+  it("orders by settings.order then appends newly discovered keys", () => {
+    const settings = { order: ["pop", "name"] };
+    assert.deepEqual(orderColumns(DISCOVERED, settings), ["pop", "name", "area"]);
+  });
+
+  it("drops stale keys from order that no longer exist", () => {
+    const settings = { order: ["gone", "area", "name"] };
+    assert.deepEqual(orderColumns(DISCOVERED, settings), ["area", "name", "pop"]);
+  });
+
+  it("filters hidden columns out of the visible list", () => {
+    const settings = { hidden: ["pop"] };
+    assert.deepEqual(visibleColumns(DISCOVERED, settings), ["name", "area"]);
+    assert.deepEqual(hiddenColumns(DISCOVERED, settings), ["pop"]);
+  });
+});
+
+describe("renameColumn (destructive)", () => {
+  it("renames the key in every feature, preserving position and other keys", () => {
+    const layer = makeLayer();
+    const patch = renameColumn(layer, DISCOVERED, "pop", "Population");
+    assert.ok(patch);
+    const props = patch.geojson!.features.map((f) => f.properties);
+    assert.deepEqual(props[0], { name: "A", Population: 10, area: 5 });
+    assert.deepEqual(props[1], { name: "B", Population: 20, area: 8 });
+  });
+
+  it("rewrites a matching style field reference", () => {
+    const layer = makeLayer({
+      style: { ...DEFAULT_LAYER_STYLE, vectorStyleProperty: "pop" },
+    });
+    const patch = renameColumn(layer, DISCOVERED, "pop", "Population");
+    assert.equal(patch?.style?.vectorStyleProperty, "Population");
+  });
+
+  it("renames the key inside persisted column settings", () => {
+    const layer = makeLayer({
+      metadata: { columnSettings: { hidden: ["pop"], order: ["pop", "name"] } },
+    });
+    const patch = renameColumn(layer, DISCOVERED, "pop", "Population");
+    const settings = (patch?.metadata as Record<string, unknown>)
+      .columnSettings as { hidden: string[]; order: string[] };
+    assert.deepEqual(settings.hidden, ["Population"]);
+    assert.deepEqual(settings.order, ["Population", "name"]);
+  });
+
+  it("is a no-op for empty, unchanged, or colliding names", () => {
+    const layer = makeLayer();
+    assert.equal(renameColumn(layer, DISCOVERED, "pop", "  "), null);
+    assert.equal(renameColumn(layer, DISCOVERED, "pop", "pop"), null);
+    assert.equal(renameColumn(layer, DISCOVERED, "pop", "area"), null);
+  });
+});
+
+describe("deleteColumn (destructive)", () => {
+  it("removes the key from every feature", () => {
+    const layer = makeLayer();
+    const patch = deleteColumn(layer, "pop");
+    assert.ok(patch);
+    for (const feature of patch.geojson!.features) {
+      assert.ok(!("pop" in (feature.properties ?? {})));
+    }
+    assert.deepEqual(Object.keys(patch.geojson!.features[0].properties ?? {}), [
+      "name",
+      "area",
+    ]);
+  });
+
+  it("clears a style field that referenced the deleted column", () => {
+    const layer = makeLayer({
+      style: { ...DEFAULT_LAYER_STYLE, extrusionHeightProperty: "pop" },
+    });
+    const patch = deleteColumn(layer, "pop");
+    assert.equal(patch?.style?.extrusionHeightProperty, "");
+  });
+
+  it("drops the key from column settings", () => {
+    const layer = makeLayer({
+      metadata: { columnSettings: { order: ["pop", "name", "area"] } },
+    });
+    const patch = deleteColumn(layer, "pop");
+    const settings = (patch?.metadata as Record<string, unknown>)
+      .columnSettings as { order: string[] };
+    assert.deepEqual(settings.order, ["name", "area"]);
+  });
+});
+
+describe("visibility toggles", () => {
+  it("hides then shows a column, clearing empty settings", () => {
+    const layer = makeLayer();
+    const hide = toggleColumnHidden(layer, "pop");
+    assert.deepEqual(
+      (
+        (hide.metadata as Record<string, unknown>).columnSettings as {
+          hidden: string[];
+        }
+      ).hidden,
+      ["pop"],
+    );
+
+    const hiddenLayer = makeLayer({ metadata: hide.metadata });
+    const show = toggleColumnHidden(hiddenLayer, "pop");
+    // Settings became empty, so the key is dropped entirely.
+    assert.equal(
+      (show.metadata as Record<string, unknown>).columnSettings,
+      undefined,
+    );
+  });
+
+  it("showAllColumns clears the hidden list", () => {
+    const layer = makeLayer({
+      metadata: { columnSettings: { hidden: ["pop", "area"] } },
+    });
+    const patch = showAllColumns(layer);
+    assert.equal(
+      (patch.metadata as Record<string, unknown>).columnSettings,
+      undefined,
+    );
+  });
+});
+
+describe("moveColumn", () => {
+  it("moves a column left among visible columns", () => {
+    const layer = makeLayer();
+    const patch = moveColumn(layer, DISCOVERED, "pop", "left");
+    const order = (
+      (patch?.metadata as Record<string, unknown>).columnSettings as {
+        order: string[];
+      }
+    ).order;
+    assert.deepEqual(order, ["pop", "name", "area"]);
+  });
+
+  it("moves a column right among visible columns", () => {
+    const layer = makeLayer();
+    const patch = moveColumn(layer, DISCOVERED, "name", "right");
+    const order = (
+      (patch?.metadata as Record<string, unknown>).columnSettings as {
+        order: string[];
+      }
+    ).order;
+    assert.deepEqual(order, ["pop", "name", "area"]);
+  });
+
+  it("is a no-op at the edges", () => {
+    const layer = makeLayer();
+    assert.equal(moveColumn(layer, DISCOVERED, "name", "left"), null);
+    assert.equal(moveColumn(layer, DISCOVERED, "area", "right"), null);
+  });
+
+  it("skips over hidden neighbors when swapping order", () => {
+    const layer = makeLayer({
+      metadata: { columnSettings: { hidden: ["pop"] } },
+    });
+    // Visible order is [name, area]; moving area left swaps it past hidden pop.
+    const patch = moveColumn(layer, DISCOVERED, "area", "left");
+    const order = (
+      (patch?.metadata as Record<string, unknown>).columnSettings as {
+        order: string[];
+      }
+    ).order;
+    assert.deepEqual(order, ["area", "pop", "name"]);
+  });
+});
+
+describe("getColumnSettings", () => {
+  it("returns empty settings for missing or malformed metadata", () => {
+    assert.deepEqual(getColumnSettings(undefined), {});
+    assert.deepEqual(getColumnSettings(makeLayer({ metadata: {} })), {});
+    assert.deepEqual(
+      getColumnSettings(
+        makeLayer({ metadata: { columnSettings: { hidden: "nope" } } }),
+      ),
+      { hidden: undefined, order: undefined },
+    );
+  });
+});


### PR DESCRIPTION
Adds column management to the attribute table for in-store GeoJSON/vector layers.

### What you can do
- **Per-column header menu** (⋯ on each field header): **Rename**, **Hide**, **Move left/right**, **Delete**.
- **"Fields" toolbar menu**: toggle each field's visibility with a checkmark, plus **Show all fields** (the way to bring back hidden fields).

### Behavior (per the agreed scope)
- **Rename is a real, destructive rename** — rewrites the property key in every feature (keeping it in place), updates the style references that point at a field (`vectorStyleProperty`, `extrusionHeightProperty`), and migrates the column's width/sort/visibility/order to the new key. No-op on empty/unchanged/colliding names.
- **Delete is destructive** — drops the property from every feature and clears style refs that pointed at it. Guarded by a **confirm dialog**.
- **Hide & reorder are non-destructive** view settings persisted under `layer.metadata.columnSettings`, so they survive save/reload.
- Management is offered **only for editable in-store GeoJSON layers** — hidden for DuckDB query results and Add Vector Layer (read-only) layers, and while row-editing is active.

### Implementation
- New `apps/geolibre-desktop/src/lib/attribute-columns.ts`: pure helpers + `Partial<GeoLibreLayer>` patch builders (rename/delete/hide/show-all/move, ordering/visibility derivation). Fully unit-tested (`tests/attribute-columns.test.ts`, 17 tests).
- `AttributeTable.tsx`: renders visible/ordered columns, per-column header dropdown + inline rename (mirrors LayerPanel's rename guard), Fields visibility dropdown, and the delete-confirm dialog.

### Verification
- `npm run build` + **217 frontend tests** pass; pre-commit (`npm-build`) passes.
- **Playwright** end-to-end: rename (`pop_2020`→`Population`), hide + Show-all, reorder (move right), delete (confirm → property removed), and confirmed the menu is hidden for a read-only Add Vector Layer layer. No console errors.

### Notes
- Free-form style **expressions** (`vectorStyleExpression`, `extrusion*Expression`) are intentionally **not** rewritten on rename/delete — rewriting arbitrary MapLibre expressions is out of scope; only the simple field-name style props are kept in sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-field column management for persisted editable GeoJSON layers: inline rename, hide/show, move left/right, delete with confirmation, and column resizing.
  * "Fields" dropdown to toggle fields and a "Show all fields" action; management disabled for query/read-only layers.
* **Bug Fixes**
  * Renames/deletes reliably update underlying data and style references; transient edit state clears on layer switch.
* **Tests**
  * Expanded tests for ordering, visibility, rename/delete, move, and settings parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->