### PR TITLE
chore: release v1.1.0 (version bump, README, docs, roadmap)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS
 
 **Video tutorial:** [GeoLibre 1.0: A Free, Open-Source Cloud-Native GIS That Runs Anywhere (Browser, Desktop & Jupyter)](https://youtu.be/87Cm0QagtxI)
 
-## Features (v1.0)
+## Features (v1.1)
 
 - Runs across desktop (Tauri), web (browser), and mobile or small screens, with a responsive layout that adapts menus, dialogs, and panels, plus per-panel visibility through Layout settings
 - MapLibre map workspace with OpenFreeMap basemaps, blank background support, and toggleable navigation, fullscreen, geolocation, globe, terrain, scale, attribution, and logo controls
@@ -28,10 +28,10 @@ GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS
 - Reproject vector layers to EPSG:4326 on load and split dragged GPX files into named waypoint, track, and route layers
 - Add Data menu for XYZ tiles, WMS, WFS, GeoJSON URLs, vector tiles, COG and GeoTIFF rasters, MBTiles, ArcGIS FeatureServer and VectorTileServer layers, PMTiles, Zarr, LiDAR, 3D Tiles, and Gaussian splats
 - Cloud data integrations through the Planetary Computer and Earth Engine panels, the Overture Maps plugin, and federal Web Services plugins
-- Manual and automatic refresh for WFS and GeoJSON URL layers
-- Layer panel for visibility, opacity, reordering, zoom-to-layer, identify, labels, and remove actions
-- Live style panel (fill, stroke, opacity, circle radius)
-- Attribute table with filtering, sorting, resize controls, feature highlighting, and optional zoom to selected features
+- Manual and automatic refresh for WFS, GeoJSON URL, and Add Vector Layer URL layers
+- Layer panel for visibility, opacity, reordering, rename, zoom-to-layer, identify, labels, open attribute table, export, and remove actions
+- Live style panel with single, categorized, graduated, and expression symbology (fill, stroke, opacity, circle radius), including for Add Vector Layer layers
+- Attribute table with filtering, sorting, resize controls, feature highlighting, optional zoom to selected features, column management (rename, delete, hide/show, reorder), and export to GeoJSON/GeoParquet/CSV
 - SQL Workspace for running DuckDB Spatial SQL against loaded layers, local files, and remote URLs, with sample queries, query history, and adding results to the map or exporting them
 - Multiple DuckDB SQL query-result layers with identify, selection, and attribute table support
 - Controls menu with Measure, Bookmark, Minimap, and View State tools, plus a Print menu and a Search panel
@@ -42,7 +42,7 @@ GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS
 - Drag and drop vector and GeoTIFF/COG raster files onto the map to add them as layers
 - Project menu to create, open, save, and Save As `.geolibre.json` projects
 - Desktop diagnostics panel, update check, and MSIX packaging support
-- Plugin system with basemap, layer control, MapLibre components, swipe, street view, Overture Maps, LiDAR, GeoAgent, and GeoEditor integrations, including configurable control positions and external plugin manifests
+- Plugin system with basemap, layer control, MapLibre components, swipe, street view, Overture Maps, LiDAR, GeoAgent, and GeoEditor integrations, including configurable control positions and external plugin manifests; external plugins can render on the host's shared deck.gl instance via `app.getDeckGL()`
 - Time Slider plugin for animating time series raster and vector data
 - Atmosphere Effects plugin that renders a deep-space backdrop, parallax starfield, comets, and an atmospheric halo around the globe at low zoom (technique adapted from [Leonel Dias](https://leoneljdias.github.io/posts/globe-atmosphere-halo-comets/))
 - External plugin zip loading from the app data plugins directory and local development plugin directories

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolibre-desktop",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -61,13 +61,13 @@
     "three": "^0.184.0"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.3.0",
     "@tauri-apps/cli": "^2.11.2",
     "@types/geojson": "^7946.0.16",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
     "esbuild": "^0.28.0",
-    "@tailwindcss/postcss": "^4.3.0",
     "postcss": "^8.5.15",
     "tailwindcss": "^4.3.0",
     "typescript": "^6.0.3",

--- a/apps/geolibre-desktop/src-tauri/Cargo.lock
+++ b/apps/geolibre-desktop/src-tauri/Cargo.lock
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-desktop"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "flate2",
  "reqwest 0.12.28",

--- a/apps/geolibre-desktop/src-tauri/Cargo.toml
+++ b/apps/geolibre-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-desktop"
-version = "1.0.0"
+version = "1.1.0"
 description = "GeoLibre Desktop — lightweight cloud-native desktop GIS"
 authors = ["GeoLibre Contributors"]
 edition = "2021"

--- a/apps/geolibre-desktop/src-tauri/tauri.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "GeoLibre Desktop",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "identifier": "org.geolibre.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,13 +39,13 @@ Pan, zoom, rotate, and tilt a MapLibre map with OpenFreeMap basemaps or a blank 
 <div class="feature-card" markdown>
 ### Local and remote data
 
-Load local and remote vector and raster data, inspect attributes in the table, style layers with data-driven symbology, reorder and refresh layers, and save, reopen, or share `.geolibre.json` projects.
+Load local and remote vector and raster data, inspect and manage attributes in the table (rename, hide, reorder, and delete fields, plus export), style layers with single, categorized, graduated, and expression symbology, reorder, rename, and refresh layers, and save, reopen, or share `.geolibre.json` projects.
 </div>
 
 <div class="feature-card" markdown>
 ### Plugins and marketplace
 
-Activate built-in plugins for layer control, basemaps, MapLibre components, swipe, street view, time slider, Overture Maps, LiDAR, GeoAgent, and GeoEditor, and install, update, or remove external plugins from the built-in marketplace.
+Activate built-in plugins for layer control, basemaps, MapLibre components, swipe, street view, time slider, Overture Maps, LiDAR, GeoAgent, GeoEditor, and atmosphere effects, and install, update, or remove external plugins from the built-in marketplace.
 </div>
 
 <div class="feature-card" markdown>

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -45,6 +45,16 @@ export interface GeoLibrePlugin {
   applyProjectState?: (app: GeoLibreAppAPI, state: unknown) => boolean | void;
 }
 
+// Resolved by app.getDeckGL(): GeoLibre's own deck.gl modules, so a plugin
+// renders on the host's single instance instead of bundling its own copy.
+export interface GeoLibreDeckGL {
+  core: typeof import("@deck.gl/core");
+  layers: typeof import("@deck.gl/layers");
+  geoLayers: typeof import("@deck.gl/geo-layers");
+  meshLayers: typeof import("@deck.gl/mesh-layers");
+  mapbox: typeof import("@deck.gl/mapbox");
+}
+
 export interface GeoLibreAppAPI {
   setBasemap: (styleUrl: string) => void;
   addGeoJsonLayer: (
@@ -74,16 +84,6 @@ export interface GeoLibreAppAPI {
     position: GeoLibreMapControlPosition,
   ) => boolean;
   getDeckGL?: () => Promise<GeoLibreDeckGL>;
-}
-
-// Resolved by app.getDeckGL(): GeoLibre's own deck.gl modules, so a plugin
-// renders on the host's single instance instead of bundling its own copy.
-export interface GeoLibreDeckGL {
-  core: typeof import("@deck.gl/core");
-  layers: typeof import("@deck.gl/layers");
-  geoLayers: typeof import("@deck.gl/geo-layers");
-  meshLayers: typeof import("@deck.gl/mesh-layers");
-  mapbox: typeof import("@deck.gl/mapbox");
 }
 ```
 

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -75,6 +75,16 @@ export interface GeoLibreAppAPI {
   ) => boolean;
   getDeckGL?: () => Promise<GeoLibreDeckGL>;
 }
+
+// Resolved by app.getDeckGL(): GeoLibre's own deck.gl modules, so a plugin
+// renders on the host's single instance instead of bundling its own copy.
+export interface GeoLibreDeckGL {
+  core: typeof import("@deck.gl/core");
+  layers: typeof import("@deck.gl/layers");
+  geoLayers: typeof import("@deck.gl/geo-layers");
+  meshLayers: typeof import("@deck.gl/mesh-layers");
+  mapbox: typeof import("@deck.gl/mapbox");
+}
 ```
 
 ## Register a plugin

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -73,6 +73,7 @@ export interface GeoLibreAppAPI {
     control: GeoLibreBuiltInMapControl,
     position: GeoLibreMapControlPosition,
   ) => boolean;
+  getDeckGL?: () => Promise<GeoLibreDeckGL>;
 }
 ```
 
@@ -122,6 +123,8 @@ export const myPlugin: GeoLibrePlugin = {
 Map control plugins can optionally expose `getMapControlPosition()` and `setMapControlPosition()` so the desktop Plugins menu can move the control between map corners. Position-aware plugins should remove and recreate or re-add their control when the position changes.
 
 Plugins with serializable runtime settings can expose `getProjectState()` and `applyProjectState()` so GeoLibre can save and restore those settings in the project file. A wrapper should use these hooks to adapt upstream control APIs such as `getState()` without requiring every upstream package to implement a GeoLibre-specific interface.
+
+Plugins that render with deck.gl should call `app.getDeckGL()` (returns a promise) to obtain GeoLibre's own deck.gl modules — `core`, `layers`, `geoLayers`, `meshLayers`, and `mapbox` (use `mapbox.MapboxOverlay` for interleaved MapLibre rendering). Render on the host's single deck.gl instance rather than bundling a second copy: deck.gl and luma.gl throw on a version mismatch and share global singletons, so a bundled copy fails to render. Call it with optional chaining (`app.getDeckGL?.()`) since a host variant may not ship deck.gl.
 
 Plugins can also declare URL query parameters and handle them when GeoLibre opens. URL parameter handlers run after the map is ready, external plugins are loaded, and project plugin state has been restored. GeoLibre calls handlers for plugins whose declared parameter names are present in the URL, and it suppresses repeated handling of the same URL context for the same plugin. If a matching plugin is registered (installed) but inactive, GeoLibre first attempts to activate it via `PluginManager.activate`; the handler runs only if activation succeeds (an `activate()` that returns `false` or throws leaves the plugin inactive and skips dispatch). Parameter names are case-sensitive, as URL query parameters are: declaring `exampleGeoJson` will not match `?ExampleGeoJson=…`.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -111,7 +111,7 @@
 - [x] Docker support for the browser app
 - [x] `VITE_DUCKDB_SPATIAL_EXTENSION_PATH` for offline spatial extension loading
 
-## v1.0: Processing pipelines, external plugin system, and stable prototype (current)
+## v1.0: Processing pipelines, external plugin system, and stable prototype
 
 - [x] GDAL / Rasterio / GeoPandas pipelines
 - [x] Buffer, reproject, and export GeoJSON processing tools
@@ -125,6 +125,20 @@
 - [x] Performance tuning and test suite
 - [x] Cross-platform installers
 - [x] Documentation and tutorials
+
+## v1.1: Vector styling, attribute table management, and atmosphere effects (current)
+
+- [x] In-browser GeoPandas engine for the Vector tools via Pyodide (no server, same results as the optional sidecar)
+- [x] Host deck.gl exposed to external plugins via `app.getDeckGL()`, so plugins render on the shared instance instead of bundling their own copy
+- [x] Style panel support for Add Vector Layer (`maplibre-gl-vector`) layers, including single, categorized, graduated, and expression symbology applied to the control's native layers
+- [x] Rename layers from the layer panel by double-clicking the name or from the layer actions menu
+- [x] Open attribute table and Export actions added to the layer actions menu
+- [x] Manual and automatic (timed) refresh extended to Add Vector Layer URL layers
+- [x] Attribute table column management: rename, delete, hide/show, and reorder fields, persisted with the project
+- [x] Atmosphere Effects plugin: deep-space backdrop, parallax starfield, comets, and a globe atmosphere halo at low zoom (toggled from the Controls menu)
+- [x] conda-forge install instructions and a video tutorial in the documentation
+- [x] MIT license
+- [x] CSP allowance for `cdn.jsdelivr.net` so DuckDB-WASM loads its bundles in the browser build
 
 ## Plugin marketplace and registry (design)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolibre",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolibre",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "workspaces": [
         "apps/*",
         "packages/*",
@@ -21,7 +21,7 @@
       }
     },
     "apps/geolibre-desktop": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@carbonplan/zarr-layer": "^0.5.0",
         "@deck.gl/core": "^9.3.3",
@@ -13055,7 +13055,7 @@
     },
     "packages/core": {
       "name": "@geolibre/core",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "uuid": "^14.0.0",
         "zustand": "^5.0.14"
@@ -13067,7 +13067,7 @@
     },
     "packages/map": {
       "name": "@geolibre/map",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@geolibre/core": "*",
         "@turf/bbox": "^7.3.5",
@@ -13075,8 +13075,8 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-layer-control": "^0.14.1",
         "pmtiles": "^4.4.1",
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7"
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       },
       "devDependencies": {
         "@types/geojson": "^7946.0.16",
@@ -13138,7 +13138,7 @@
     },
     "packages/plugins": {
       "name": "@geolibre/plugins",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@carbonplan/zarr-layer": "^0.5.0",
         "@deck.gl/core": "^9.3.3",
@@ -13275,7 +13275,7 @@
     },
     "packages/processing": {
       "name": "@geolibre/processing",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@geolibre/core": "*",
         "@turf/bbox": "^7.3.5",
@@ -13297,7 +13297,7 @@
     },
     "packages/ui": {
       "name": "@geolibre/ui",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.16",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
@@ -13311,8 +13311,8 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.17.0",
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
         "tailwind-merge": "^3.6.0",
         "tw-animate-css": "^1.4.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13075,8 +13075,8 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-layer-control": "^0.14.1",
         "pmtiles": "^4.4.1",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7"
       },
       "devDependencies": {
         "@types/geojson": "^7946.0.16",
@@ -13311,8 +13311,8 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.17.0",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
         "tailwind-merge": "^3.6.0",
         "tw-animate-css": "^1.4.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geolibre",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "GeoLibre: a lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data across desktop and web environments, with a responsive layout for mobile screens",
   "workspaces": [
     "apps/*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/core",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/map",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",
@@ -15,8 +15,8 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-layer-control": "^0.14.1",
     "pmtiles": "^4.4.1",
-    "react": "^19.2.7",
-    "react-dom": "^19.2.7"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@types/geojson": "^7946.0.16",

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -15,8 +15,8 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-layer-control": "^0.14.1",
     "pmtiles": "^4.4.1",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
   },
   "devDependencies": {
     "@types/geojson": "^7946.0.16",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/plugins",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/processing/package.json
+++ b/packages/processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/processing",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -22,8 +22,8 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.17.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
     "tailwind-merge": "^3.6.0",
     "tw-animate-css": "^1.4.0"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/ui",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",
@@ -22,8 +22,8 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.17.0",
-    "react": "^19.2.7",
-    "react-dom": "^19.2.7",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "tailwind-merge": "^3.6.0",
     "tw-animate-css": "^1.4.0"
   },

--- a/python/src/geolibre/__init__.py
+++ b/python/src/geolibre/__init__.py
@@ -2,5 +2,5 @@
 
 from .geolibre import Map
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 __all__ = ["Map", "__version__"]


### PR DESCRIPTION
Prepares the **v1.1.0** release: minor version bump plus README/docs/roadmap updates covering everything shipped since v1.0.

### Version bump (1.0.0 → 1.1.0)
- JS workspaces: root, `@geolibre/{core,map,ui,processing,plugins}`, `geolibre-desktop`, and `package-lock.json`.
- Desktop: `tauri.conf.json`, `Cargo.toml`, `Cargo.lock`.
- Python: `geolibre` package `__version__`.

### README
- Retitled **Features (v1.1)** and updated bullets for: auto-refresh on Add Vector Layer URL layers; layer-panel **rename / open attribute table / export** actions; **single/categorized/graduated/expression** symbology (including for Add Vector Layer layers); attribute-table **column management** (rename, delete, hide/show, reorder) + export; and external-plugin access to the host deck.gl via `app.getDeckGL()`.

### Docs
- **roadmap.md**: new **v1.1** section listing every feature since v1.0; dropped "(current)" from v1.0.
- **plugin-api.md**: documented `app.getDeckGL()`.
- **index.md**: refreshed the feature cards (attribute-table management, symbology modes, atmosphere effects plugin).

### Features since v1.0 captured here
In-browser GeoPandas (Pyodide) vector engine (#201) · `app.getDeckGL()` for plugins (#204) · Add Vector Layer styling incl. categorized/graduated (#211, #221) · layer rename (#213) · Add Vector Layer auto-refresh (#214) · Atmosphere Effects plugin (#218) · open-table/export layer actions (#219) · attribute-table column management (#222) · MIT license (#202) · conda-forge + video tutorial docs (#205) · DuckDB-WASM CSP fix (#209).

Verified: `npm run build` and pre-commit (`npm-build`, JSON/TOML checks) pass; no stray `1.0.0` version fields remain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External plugins can access the host's shared deck.gl instance (via a getDeckGL method) to render without bundling another copy.

* **Documentation**
  * Expanded docs and README: richer layer styling (single/categorized/graduated/expression), more layer actions (opacity/identify/labels/zoom/export/remove/refresh/rename/reorder), and enhanced attribute-table column management and export details; marketplace/plugin guidance updated.

* **Chores**
  * Project version bumped to 1.1.0 across packages; UI package aligned React peer/dependency range.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->