### PR TITLE
fix(web): recover from stale lazy chunks after a redeploy

### DIFF
--- a/apps/geolibre-desktop/src/lib/is-tauri.ts
+++ b/apps/geolibre-desktop/src/lib/is-tauri.ts
@@ -1,0 +1,9 @@
+/**
+ * Whether the app runs inside the Tauri desktop webview. Kept in its own tiny,
+ * side-effect-free module so it can be used from the eager entry (e.g.
+ * stale-chunk-reload) without pulling the heavier tauri-io module — which
+ * imports shpjs/fflate/Tauri plugins — into the initial bundle.
+ */
+export function isTauri(): boolean {
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}

--- a/apps/geolibre-desktop/src/lib/stale-chunk-reload.ts
+++ b/apps/geolibre-desktop/src/lib/stale-chunk-reload.ts
@@ -83,18 +83,27 @@ export function installStaleChunkReload(options?: {
   }
 
   const handler = (event: Event) => {
-    const reloaded = reloadForStaleChunk({
-      now: () => Date.now(),
-      getLastReloadAt: () => {
-        const raw = window.sessionStorage.getItem(RELOAD_TIMESTAMP_KEY);
-        if (raw === null) return null;
-        const parsed = Number(raw);
-        return Number.isFinite(parsed) ? parsed : null;
-      },
-      setLastReloadAt: (value) =>
-        window.sessionStorage.setItem(RELOAD_TIMESTAMP_KEY, String(value)),
-      reload: () => window.location.reload(),
-    });
+    let reloaded = false;
+    try {
+      reloaded = reloadForStaleChunk({
+        now: () => Date.now(),
+        getLastReloadAt: () => {
+          const raw = window.sessionStorage.getItem(RELOAD_TIMESTAMP_KEY);
+          if (raw === null) return null;
+          const parsed = Number(raw);
+          return Number.isFinite(parsed) ? parsed : null;
+        },
+        setLastReloadAt: (value) =>
+          window.sessionStorage.setItem(RELOAD_TIMESTAMP_KEY, String(value)),
+        reload: () => window.location.reload(),
+      });
+    } catch {
+      // sessionStorage can throw when storage is blocked (private modes,
+      // Safari ITP, sandboxed iframes), mirroring the guard in diagnostics.ts.
+      // The cooldown loop-guard needs that persistence, so without it skip the
+      // reload and let Vite surface the original error rather than risk a
+      // refresh loop.
+    }
     // Only suppress Vite's rethrow when we are recovering by reloading; a
     // cooldown-suppressed (broken-build) error should still surface.
     if (reloaded) event.preventDefault();

--- a/apps/geolibre-desktop/src/lib/stale-chunk-reload.ts
+++ b/apps/geolibre-desktop/src/lib/stale-chunk-reload.ts
@@ -1,0 +1,105 @@
+/**
+ * Recovery for stale lazy-loaded chunks after a redeploy.
+ *
+ * On a static host (the GitHub Pages web demo behind viewer.geolibre.app), each
+ * deployment writes content-hashed JS chunks and deletes the previous build's
+ * chunks. Browsers cache hashed assets for hours, so a tab that loaded an
+ * earlier build keeps a cached lazy chunk whose dynamic `import()` targets a
+ * now-deleted chunk. Opening the panel that chunk backs (e.g. Add Raster Layer)
+ * then fetches the missing chunk and 404s, surfacing as
+ * "Failed to fetch dynamically imported module".
+ *
+ * Vite dispatches a cancelable `vite:preloadError` event on `window` for exactly
+ * this case. Reloading the page re-evaluates the current build's import graph,
+ * so the lazy import resolves to a chunk that still exists. A short cooldown
+ * guards against a reload loop when the failure is a genuinely broken build
+ * rather than a stale chunk.
+ */
+
+const RELOAD_TIMESTAMP_KEY = "geolibre:stale-chunk-reload-at";
+
+/**
+ * If a reload just happened and a chunk still fails to load, the build is
+ * broken rather than stale, so further reloads are suppressed to avoid a
+ * refresh loop. Long enough to cover a reload's network round-trip.
+ */
+export const STALE_CHUNK_RELOAD_COOLDOWN_MS = 15_000;
+
+/**
+ * Whether the app runs inside the Tauri desktop webview. Checked inline (rather
+ * than importing the heavier tauri-io module) so this can run in the eager
+ * entry without pulling extra code into the initial bundle.
+ */
+function isTauriRuntime(): boolean {
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
+export interface StaleChunkReloadDeps {
+  /** Current epoch milliseconds. */
+  now: () => number;
+  /** Last reload timestamp this session, or null if none. */
+  getLastReloadAt: () => number | null;
+  /** Persist the reload timestamp for the cooldown guard. */
+  setLastReloadAt: (value: number) => void;
+  /** Reload the page. */
+  reload: () => void;
+}
+
+/**
+ * Reloads the page to recover from a stale chunk, unless a reload happened
+ * within the cooldown (in which case the failure is treated as a broken build
+ * and left to surface).
+ *
+ * @param deps - Injected clock, persistence, and reload, for testability.
+ * @returns True when a reload was triggered, false when suppressed.
+ */
+export function reloadForStaleChunk(deps: StaleChunkReloadDeps): boolean {
+  const last = deps.getLastReloadAt();
+  const current = deps.now();
+  if (last !== null && current - last < STALE_CHUNK_RELOAD_COOLDOWN_MS) {
+    return false;
+  }
+  deps.setLastReloadAt(current);
+  deps.reload();
+  return true;
+}
+
+/**
+ * Registers a `vite:preloadError` handler that reloads once (cooldown-guarded)
+ * to recover from chunks orphaned by a redeploy. A no-op when disabled or
+ * outside a browser (e.g. the Tauri desktop build, whose local chunks never go
+ * stale). When it reloads it calls `preventDefault()` so Vite does not also
+ * rethrow the error.
+ *
+ * @param options.enabled - Pass false to skip installation (e.g. in Tauri).
+ * @returns A cleanup function that removes the listener.
+ */
+export function installStaleChunkReload(options?: {
+  enabled?: boolean;
+}): () => void {
+  const enabled = options?.enabled ?? !isTauriRuntime();
+  if (!enabled || typeof window === "undefined") {
+    return () => {};
+  }
+
+  const handler = (event: Event) => {
+    const reloaded = reloadForStaleChunk({
+      now: () => Date.now(),
+      getLastReloadAt: () => {
+        const raw = window.sessionStorage.getItem(RELOAD_TIMESTAMP_KEY);
+        if (raw === null) return null;
+        const parsed = Number(raw);
+        return Number.isFinite(parsed) ? parsed : null;
+      },
+      setLastReloadAt: (value) =>
+        window.sessionStorage.setItem(RELOAD_TIMESTAMP_KEY, String(value)),
+      reload: () => window.location.reload(),
+    });
+    // Only suppress Vite's rethrow when we are recovering by reloading; a
+    // cooldown-suppressed (broken-build) error should still surface.
+    if (reloaded) event.preventDefault();
+  };
+
+  window.addEventListener("vite:preloadError", handler);
+  return () => window.removeEventListener("vite:preloadError", handler);
+}

--- a/apps/geolibre-desktop/src/lib/stale-chunk-reload.ts
+++ b/apps/geolibre-desktop/src/lib/stale-chunk-reload.ts
@@ -16,6 +16,8 @@
  * rather than a stale chunk.
  */
 
+import { isTauri } from "./is-tauri";
+
 const RELOAD_TIMESTAMP_KEY = "geolibre:stale-chunk-reload-at";
 
 /**
@@ -24,15 +26,6 @@ const RELOAD_TIMESTAMP_KEY = "geolibre:stale-chunk-reload-at";
  * refresh loop. Long enough to cover a reload's network round-trip.
  */
 export const STALE_CHUNK_RELOAD_COOLDOWN_MS = 15_000;
-
-/**
- * Whether the app runs inside the Tauri desktop webview. Checked inline (rather
- * than importing the heavier tauri-io module) so this can run in the eager
- * entry without pulling extra code into the initial bundle.
- */
-function isTauriRuntime(): boolean {
-  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
-}
 
 export interface StaleChunkReloadDeps {
   /** Current epoch milliseconds. */
@@ -77,12 +70,15 @@ export function reloadForStaleChunk(deps: StaleChunkReloadDeps): boolean {
 export function installStaleChunkReload(options?: {
   enabled?: boolean;
 }): () => void {
-  const enabled = options?.enabled ?? !isTauriRuntime();
+  const enabled = options?.enabled ?? !isTauri();
   if (!enabled || typeof window === "undefined") {
     return () => {};
   }
 
   const handler = (event: Event) => {
+    // Vite dispatches a plain Event with the underlying error on `.payload`
+    // (not a CustomEvent `.detail`); surface it so a recovery is visible.
+    const payload = (event as Event & { payload?: unknown }).payload;
     let reloaded = false;
     try {
       reloaded = reloadForStaleChunk({
@@ -103,10 +99,17 @@ export function installStaleChunkReload(options?: {
       // The cooldown loop-guard needs that persistence, so without it skip the
       // reload and let Vite surface the original error rather than risk a
       // refresh loop.
+      console.warn(
+        "[GeoLibre] Stale-chunk reload guard unavailable (storage blocked); leaving the preload error to surface.",
+        payload,
+      );
     }
-    // Only suppress Vite's rethrow when we are recovering by reloading; a
-    // cooldown-suppressed (broken-build) error should still surface.
-    if (reloaded) event.preventDefault();
+    if (reloaded) {
+      // Only suppress Vite's rethrow when we are recovering by reloading; a
+      // cooldown-suppressed (broken-build) error should still surface.
+      console.warn("[GeoLibre] Reloading to recover from a stale chunk.", payload);
+      event.preventDefault();
+    }
   };
 
   window.addEventListener("vite:preloadError", handler);

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -14,10 +14,11 @@ import shp from "shpjs";
 import { parseDelimitedTextFields } from "./delimited-text";
 import type { DuckDbVectorFile } from "./duckdb-vector-loader";
 import { parseGpxLayer } from "./gpx";
+import { isTauri } from "./is-tauri";
 
-export function isTauri(): boolean {
-  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
-}
+// Re-exported so existing `import { isTauri } from "./tauri-io"` consumers keep
+// working; the implementation lives in the lightweight ./is-tauri module.
+export { isTauri };
 
 function browserSafeFileName(path: string): string {
   return path.split(/[/\\]/).pop() || "project.geolibre.json";

--- a/apps/geolibre-desktop/src/main.tsx
+++ b/apps/geolibre-desktop/src/main.tsx
@@ -28,8 +28,12 @@ import "./lib/geoagent-style";
 import "./lib/lidar-style";
 import "./lib/swipe-style";
 import { installDiagnosticsCapture } from "./lib/diagnostics";
+import { installStaleChunkReload } from "./lib/stale-chunk-reload";
 
 installDiagnosticsCapture();
+// Recover from chunks orphaned by a web redeploy (stale lazy import → 404). A
+// no-op in the desktop build, whose chunks are bundled locally.
+installStaleChunkReload();
 
 void import("./App")
   .then(({ default: App }) => {

--- a/tests/stale-chunk-reload.test.ts
+++ b/tests/stale-chunk-reload.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  reloadForStaleChunk,
+  STALE_CHUNK_RELOAD_COOLDOWN_MS,
+} from "../apps/geolibre-desktop/src/lib/stale-chunk-reload";
+
+function makeDeps(initial: { now: number; lastReloadAt: number | null }) {
+  const state = {
+    now: initial.now,
+    lastReloadAt: initial.lastReloadAt,
+    reloads: 0,
+  };
+  return {
+    state,
+    deps: {
+      now: () => state.now,
+      getLastReloadAt: () => state.lastReloadAt,
+      setLastReloadAt: (value: number) => {
+        state.lastReloadAt = value;
+      },
+      reload: () => {
+        state.reloads += 1;
+      },
+    },
+  };
+}
+
+describe("reloadForStaleChunk", () => {
+  it("reloads on the first stale-chunk error and records the timestamp", () => {
+    const { state, deps } = makeDeps({ now: 1000, lastReloadAt: null });
+
+    assert.equal(reloadForStaleChunk(deps), true);
+    assert.equal(state.reloads, 1);
+    assert.equal(state.lastReloadAt, 1000);
+  });
+
+  it("suppresses a reload that fires within the cooldown", () => {
+    const { state, deps } = makeDeps({ now: 5000, lastReloadAt: null });
+
+    assert.equal(reloadForStaleChunk(deps), true);
+    state.now += STALE_CHUNK_RELOAD_COOLDOWN_MS - 1;
+
+    // A second error right after the reload means the build is broken, not
+    // merely stale, so it must not loop.
+    assert.equal(reloadForStaleChunk(deps), false);
+    assert.equal(state.reloads, 1);
+  });
+
+  it("reloads again once the cooldown has elapsed", () => {
+    const { state, deps } = makeDeps({ now: 0, lastReloadAt: null });
+
+    assert.equal(reloadForStaleChunk(deps), true);
+    state.now += STALE_CHUNK_RELOAD_COOLDOWN_MS;
+
+    // A later redeploy in a long-lived session should recover too.
+    assert.equal(reloadForStaleChunk(deps), true);
+    assert.equal(state.reloads, 2);
+    assert.equal(state.lastReloadAt, STALE_CHUNK_RELOAD_COOLDOWN_MS);
+  });
+});

--- a/tests/stale-chunk-reload.test.ts
+++ b/tests/stale-chunk-reload.test.ts
@@ -51,6 +51,8 @@ describe("reloadForStaleChunk", () => {
     const { state, deps } = makeDeps({ now: 0, lastReloadAt: null });
 
     assert.equal(reloadForStaleChunk(deps), true);
+    // The guard is strict `< cooldown`, so a diff of exactly the cooldown is
+    // already past it (the just-expired edge) and reloads again.
     state.now += STALE_CHUNK_RELOAD_COOLDOWN_MS;
 
     // A later redeploy in a long-lived session should recover too.


### PR DESCRIPTION
## Problem
On the deployed web viewer (viewer.geolibre.app), opening a lazily-loaded panel such as **Add Raster Layer** could fail with:

```
[GeoLibre] Failed to open the raster layer panel
TypeError: Failed to fetch dynamically imported module: .../assets/dist-F8oYpeI2.js
```

It worked in incognito mode (no cache).

## Root cause
The web viewer is a Vite SPA served from GitHub Pages (proxied by the `workers/viewer` Cloudflare Worker). Each redeploy writes new content-hashed JS chunks and **deletes the previous build's chunks**. Browsers cache hashed assets for hours, so a tab that loaded an earlier build keeps a cached lazy chunk whose dynamic `import()` targets a chunk a later deploy removed. Opening the panel that chunk backs fetches the missing chunk and 404s. The app had no recovery, so it surfaced a hard error.

Verified:
- The chunk 404s directly on the Pages origin and is **not referenced by the current build** (it is an orphan from a prior deploy).
- A locally-served production build and the current live deploy both open the raster panel fine.
- Incognito works (no stale cache) — confirmed by the reporter.
- The build dispatches a cancelable `vite:preloadError` event on import failure, but nothing listened for it.

## Fix
Register a `vite:preloadError` handler (Vite's documented hook for this case) that reloads the page once to pull the current build's import graph, with a cooldown guard so a genuinely broken build does not loop. It is wired into the eager entry (`main.tsx`) so it is active before any lazy import can fail, and is a no-op in the desktop (Tauri) build, whose chunks are bundled locally. This covers every lazy panel, not just raster.

## Test plan
- [x] `npm run test:frontend` (226 passing, incl. new cooldown-logic tests)
- [x] `npm run build`
- [x] Verified in a served production build: dispatching `vite:preloadError` reloads the page; a second dispatch within the cooldown does not (no reload loop)

## Note (optional follow-up)
GitHub Pages serves `index.html` with `max-age=600`. The `workers/viewer` proxy could override HTML responses to `no-cache` so users pick up a fresh chunk graph sooner, shrinking the stale window. Not required for this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic recovery for stale lazy-loaded chunk errors that triggers a controlled page reload with a session-level cooldown to prevent repeated reloads.

* **Behavior**
  * Recovery is disabled when running in the desktop/webview build so it no-ops where chunks are locally bundled.

* **Tests**
  * Added tests covering initial reload, suppression during cooldown, and reload after cooldown.

* **Refactor**
  * Introduced a lightweight runtime check to detect desktop/webview environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->