### PR TITLE
fix(effects): track globe halo to the rendered silhouette under zoom/pitch

### DIFF
--- a/packages/plugins/src/plugins/maplibre-effects.ts
+++ b/packages/plugins/src/plugins/maplibre-effects.ts
@@ -331,7 +331,10 @@ function solveLinear(m: number[][], b: number[]): number[] | null {
     for (let row = 0; row < n; row++) {
       if (row === col) continue;
       const factor = aug[row][col] / aug[col][col];
-      for (let k = col; k <= n; k++) aug[row][k] -= factor * aug[col][k];
+      // Start at col+1: the col-th cell is being zeroed by definition, and the
+      // solution reads only each row's diagonal and right-hand side, so the
+      // skipped off-diagonal writes are never read.
+      for (let k = col + 1; k <= n; k++) aug[row][k] -= factor * aug[col][k];
     }
   }
   return aug.map((row, i) => row[n] / row[i]);
@@ -359,9 +362,11 @@ class EffectsEngine {
   private height = 0;
   private dpr = 1;
 
-  // Cached globe silhouette. Fitting it costs many project/unproject round-trips,
-  // but it only changes when the camera moves, so recompute lazily on a dirty
-  // flag set by move/resize rather than every animation frame.
+  // Cached globe silhouette. Fitting it costs many project/unproject round-trips.
+  // It changes on every camera change — so once per frame during an animated
+  // pan/zoom, since MapLibre fires "move" each frame — but a dirty flag (set by
+  // move/resize) skips the recompute on comet/starfield-only frames where the
+  // camera is stationary.
   private globeEllipse: GlobeEllipse | null = null;
   private ellipseDirty = true;
   // Last fitted mean limb radius, fed back as the ray-search seed so the next

--- a/packages/plugins/src/plugins/maplibre-effects.ts
+++ b/packages/plugins/src/plugins/maplibre-effects.ts
@@ -48,16 +48,19 @@ const PARALLAX_PX_PER_DEGREE = 0.6;
 // Halo radial gradient — color stops are fractions of the gradient span, which
 // runs from the globe edge out to HALO_RADIUS_SCALE × the globe radius.
 const HALO_RADIUS_SCALE = 2.8;
-// The space punch-out and the halo's opaque inner edge sit slightly inside the
-// fitted limb. The 2D overlay edge and the WebGL globe edge are rasterized
-// independently, so aligning them exactly leaves a thin seam wherever they
-// disagree by a sub-pixel — the dark space gradient bleeds onto the globe rim
-// (a dark line) or the page background shows through (a light line), most
-// visible on HiDPI displays and at high zoom. Overlapping the bright, opaque
-// inner glow a few percent onto the limb hides that seam, the way the original
-// (smaller) great-circle disc did. The fitted ellipse still sets the center,
-// shape, and rotation, so the halo tracks the globe under zoom and pitch.
-const LIMB_INSET = 0.965;
+// The 2D overlay edge and the WebGL globe edge are rasterized independently, so
+// a hard punch-out at the limb leaves a thin seam wherever the two disagree by a
+// sub-pixel — the dark space gradient bleeds onto the globe rim (a dark line) or
+// the page background shows through (a light one), most visible on HiDPI
+// displays. Rather than insetting the punch-out (which drapes dark space over a
+// zoom-proportional band of the globe that the faded high-zoom halo can't
+// repaint), feather its edge: the destination-out alpha is solid out to
+// PUNCH_FADE_INNER × the limb and ramps to zero by PUNCH_FADE_OUTER × the limb.
+// The globe is revealed in full, and the soft edge straddling the limb hides the
+// sub-pixel mismatch without a visible band. Fractions of the fitted limb, so
+// the feather stays a roughly constant share of the rim at every zoom.
+const PUNCH_FADE_INNER = 0.99;
+const PUNCH_FADE_OUTER = 1.012;
 // Globe-silhouette sampling: rays cast from the projected map center, each
 // bisected to the rendered limb. The silhouette is a conic (a circle top-down,
 // an ellipse under pitch), so a handful of rays over-determine the 3-parameter
@@ -636,22 +639,30 @@ class EffectsEngine {
 
   private punchOutGlobe(disc: GlobeEllipse): void {
     // Remove the deep-space layer over the globe silhouette so the real basemap
-    // globe shows through; the halo (drawn on its own canvas) hides any seam.
-    this.spaceCtx.save();
-    this.spaceCtx.globalCompositeOperation = "destination-out";
-    this.spaceCtx.fillStyle = "rgba(0, 0, 0, 1)";
-    this.spaceCtx.beginPath();
-    this.spaceCtx.ellipse(
-      disc.cx,
-      disc.cy,
-      disc.rx * LIMB_INSET,
-      disc.ry * LIMB_INSET,
-      disc.angle,
+    // globe shows through. Work in the ellipse's normalized frame (unit circle =
+    // limb) so the radial alpha ramp maps to an ellipse under pitch, and feather
+    // the edge across the limb so no hard seam shows against the WebGL globe.
+    const ctx = this.spaceCtx;
+    ctx.save();
+    ctx.globalCompositeOperation = "destination-out";
+    ctx.translate(disc.cx, disc.cy);
+    ctx.rotate(disc.angle);
+    ctx.scale(disc.rx, disc.ry);
+    const gradient = ctx.createRadialGradient(
       0,
-      Math.PI * 2,
+      0,
+      PUNCH_FADE_INNER,
+      0,
+      0,
+      PUNCH_FADE_OUTER,
     );
-    this.spaceCtx.fill();
-    this.spaceCtx.restore();
+    gradient.addColorStop(0, "rgba(0, 0, 0, 1)"); // fully remove space (globe shows)
+    gradient.addColorStop(1, "rgba(0, 0, 0, 0)"); // leave space intact beyond the limb
+    ctx.fillStyle = gradient;
+    ctx.beginPath();
+    ctx.arc(0, 0, PUNCH_FADE_OUTER, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.restore();
   }
 
   private drawSpaceBackground(alpha: number): void {
@@ -686,11 +697,19 @@ class EffectsEngine {
     // real atmospheric rim does under perspective.
     ctx.translate(disc.cx, disc.cy);
     ctx.rotate(disc.angle);
-    // Same inset as the punch-out so the two edges coincide; the unit circle in
-    // this frame is then the inset limb, where the halo's opaque inner stop sits.
-    ctx.scale(disc.rx * LIMB_INSET, disc.ry * LIMB_INSET);
+    ctx.scale(disc.rx, disc.ry);
 
-    const gradient = ctx.createRadialGradient(0, 0, 1, 0, 0, HALO_RADIUS_SCALE);
+    // Start the glow just inside the limb (matching the punch-out feather) so the
+    // bright inner stops sit over the soft edge and blend onto the rim, leaving
+    // no gap between the globe and the glow.
+    const gradient = ctx.createRadialGradient(
+      0,
+      0,
+      PUNCH_FADE_INNER,
+      0,
+      0,
+      HALO_RADIUS_SCALE,
+    );
     for (const [stop, color] of HALO_STOPS) {
       gradient.addColorStop(stop, color);
     }
@@ -698,12 +717,12 @@ class EffectsEngine {
     // (set in createCanvas); here we just paint the gradient normally.
     ctx.globalAlpha = alpha;
     ctx.fillStyle = gradient;
-    // Paint only the annulus outside the globe (outer ring CW, inner ring CCW
+    // Paint only the annulus around the limb (outer ring CW, inner ring CCW
     // cancels the winding in the hole — nonzero rule), so the rim glows without
-    // tinting the globe disc.
+    // washing out the globe disc.
     ctx.beginPath();
     ctx.arc(0, 0, HALO_RADIUS_SCALE, 0, Math.PI * 2, false);
-    ctx.arc(0, 0, 1, 0, Math.PI * 2, true);
+    ctx.arc(0, 0, PUNCH_FADE_INNER, 0, Math.PI * 2, true);
     ctx.fill();
     ctx.restore();
   }

--- a/packages/plugins/src/plugins/maplibre-effects.ts
+++ b/packages/plugins/src/plugins/maplibre-effects.ts
@@ -149,6 +149,12 @@ function isOnGlobe(map: MapLibreMap, x: number, y: number): boolean {
  * Assumes the start point is on the globe; expands until a point is off-globe,
  * then bisects the on/off boundary. `maxR` caps the search so a globe larger
  * than the search window (very rare in the effect's low-zoom range) terminates.
+ *
+ * `seedR` is the previous frame's limb radius. During a pan/zoom the limb moves
+ * little between frames, so starting the doubling phase there usually brackets
+ * the limb in zero or one steps instead of climbing from 8px — the bisection
+ * still pins it to sub-pixel regardless. `lo = 0` (the on-globe center) stays a
+ * valid lower bound whether the seed lands inside or outside the limb.
  */
 function rayToLimb(
   map: MapLibreMap,
@@ -157,9 +163,10 @@ function rayToLimb(
   dx: number,
   dy: number,
   maxR: number,
+  seedR: number,
 ): number {
   let lo = 0;
-  let hi = 8;
+  let hi = seedR > 0 ? Math.min(seedR, maxR) : 8;
   while (hi < maxR && isOnGlobe(map, cx + dx * hi, cy + dy * hi)) {
     lo = hi;
     hi *= 2;
@@ -179,13 +186,17 @@ function rayToLimb(
  * Casts {@link SILHOUETTE_RAYS} rays from the projected map center (always
  * inside the silhouette) out to the rendered limb, then fits an ellipse to those
  * limb points. The silhouette of a sphere under a pinhole camera is exactly a
- * conic — a circle when viewed top-down, an ellipse under pitch — so the fit is
- * exact: its bounding-box center is the ellipse center, and a 3-parameter
- * quadratic-form least-squares solve recovers the axes and rotation. This tracks
- * the globe under any zoom, pitch, and bearing, unlike a fixed great-circle
- * limb measured from the map center. Returns null when the globe is off-screen.
+ * conic — a circle when viewed top-down, an ellipse under pitch — so {@link
+ * fitEllipse} recovers the center, axes, and rotation exactly. This tracks the
+ * globe under any zoom, pitch, and bearing, unlike a fixed great-circle limb
+ * measured from the map center. `seedRadius` (the previous frame's limb radius,
+ * or 0) just speeds up the ray search. Returns null when the globe is off-screen
+ * or larger than the search window.
  */
-function getGlobeEllipse(map: MapLibreMap): GlobeEllipse | null {
+function getGlobeEllipse(
+  map: MapLibreMap,
+  seedRadius: number,
+): GlobeEllipse | null {
   const center = map.project(map.getCenter());
   const cx = center.x;
   const cy = center.y;
@@ -200,7 +211,11 @@ function getGlobeEllipse(map: MapLibreMap): GlobeEllipse | null {
     const a = (i / SILHOUETTE_RAYS) * 2 * Math.PI;
     const dx = Math.cos(a);
     const dy = Math.sin(a);
-    const r = rayToLimb(map, cx, cy, dx, dy, maxR);
+    const r = rayToLimb(map, cx, cy, dx, dy, maxR, seedRadius);
+    // A ray that never leaves the globe within the window means the globe is
+    // larger than 8× the viewport (vanishingly rare before the effect fades at
+    // zoom ≈ 4.5). The clustered points would fit a huge bogus ellipse, so bail.
+    if (r >= maxR) return null;
     pts.push([cx + dx * r, cy + dy * r]);
   }
 
@@ -211,17 +226,25 @@ function getGlobeEllipse(map: MapLibreMap): GlobeEllipse | null {
  * Fit an ellipse to points sampled around its boundary.
  *
  * Exact for points that lie on a real ellipse (such as the conic silhouette of a
- * sphere): the axis-aligned bounding box of any ellipse is centered on the
- * ellipse, so its center is recovered directly; the shape comes from a
- * 3-parameter quadratic-form least-squares solve of A·dx² + 2B·dx·dy + C·dy² = 1.
- * Returns null for a degenerate (non-positive-definite) fit — e.g. collinear or
- * too few points.
+ * sphere), for any sampling — including the production rays, which are cast at
+ * uniform angles from the projected map center, a point that under pitch is
+ * offset from the silhouette center. A bounding-box center would only be exact
+ * for samples symmetric about the center (e.g. uniform in the ellipse parameter
+ * t); off-center ray casts are not, and the error grows with pitch (tens of
+ * pixels past ~50°). So fit the general conic A·u² + 2B·uv + C·v² + D·u + E·v = 1
+ * (u,v relative to a shift origin for conditioning) and recover the center from
+ * ∇ = 0; this solves for the center rather than assuming it. Returns null for a
+ * degenerate (non-elliptical) fit — collinear or fewer than five points.
  */
 export function fitEllipse(
   pts: ReadonlyArray<readonly [number, number]>,
 ): GlobeEllipse | null {
-  if (pts.length < 3) return null;
+  if (pts.length < 5) return null;
 
+  // Shift origin to the sample bounding-box center: it lies inside the ellipse,
+  // keeping the conic's constant term away from zero and the |u|,|v| magnitudes
+  // small so the normal equations stay well conditioned. It is only a numerical
+  // origin here — the true center is solved for below, not assumed from it.
   let minX = Infinity;
   let minY = Infinity;
   let maxX = -Infinity;
@@ -233,92 +256,85 @@ export function fitEllipse(
     maxX = Math.max(maxX, px);
     maxY = Math.max(maxY, py);
   }
-  const ex = (minX + maxX) / 2;
-  const ey = (minY + maxY) / 2;
+  const ox = (minX + maxX) / 2;
+  const oy = (minY + maxY) / 2;
 
-  // Normal equations for A·dx² + 2B·dx·dy + C·dy² = 1 about the center.
-  let s00 = 0;
-  let s01 = 0;
-  let s02 = 0;
-  let s11 = 0;
-  let s12 = 0;
-  let s22 = 0;
-  let t0 = 0;
-  let t1 = 0;
-  let t2 = 0;
+  // Normal equations for A·u² + 2B·uv + C·v² + D·u + E·v = 1.
+  const s = Array.from({ length: 5 }, () => new Array<number>(5).fill(0));
+  const t = new Array<number>(5).fill(0);
   for (const [px, py] of pts) {
-    const dx = px - ex;
-    const dy = py - ey;
-    const f0 = dx * dx;
-    const f1 = 2 * dx * dy;
-    const f2 = dy * dy;
-    s00 += f0 * f0;
-    s01 += f0 * f1;
-    s02 += f0 * f2;
-    s11 += f1 * f1;
-    s12 += f1 * f2;
-    s22 += f2 * f2;
-    t0 += f0;
-    t1 += f1;
-    t2 += f2;
+    const u = px - ox;
+    const v = py - oy;
+    const f = [u * u, 2 * u * v, v * v, u, v];
+    for (let i = 0; i < 5; i++) {
+      for (let j = 0; j < 5; j++) s[i][j] += f[i] * f[j];
+      t[i] += f[i];
+    }
   }
-  const conic = solve3(
-    [
-      [s00, s01, s02],
-      [s01, s11, s12],
-      [s02, s12, s22],
-    ],
-    [t0, t1, t2],
-  );
+  const conic = solveLinear(s, t);
   if (!conic) return null;
-  const [A, B, C] = conic;
+  const [A, B, C, D, E] = conic;
 
-  // Eigen-decompose [[A,B],[B,C]]: semi-axis = 1/√eigenvalue, axis direction =
-  // eigenvector. A non-positive-definite fit is not a real ellipse, so bail.
-  const tr = A + C;
-  const det = A * C - B * B;
+  // Ellipse center solves ∇(conic) = 0: [[2A,2B],[2B,2C]]·[u0,v0] = [-D,-E].
+  const center = solveLinear(
+    [
+      [2 * A, 2 * B],
+      [2 * B, 2 * C],
+    ],
+    [-D, -E],
+  );
+  if (!center) return null;
+  const [u0, v0] = center;
+
+  // Translate to the center: A·p² + 2B·pq + C·q² = G (the constant moves over).
+  const g = -(A * u0 * u0 + 2 * B * u0 * v0 + C * v0 * v0 + D * u0 + E * v0 - 1);
+  if (!(g > 0)) return null; // not a real, centered ellipse
+  const a2 = A / g;
+  const b2 = B / g;
+  const c2 = C / g;
+
+  // Eigen-decompose [[a2,b2],[b2,c2]]: semi-axis = 1/√eigenvalue, axis direction
+  // = eigenvector. A non-positive-definite form is not a real ellipse, so bail.
+  const tr = a2 + c2;
+  const det = a2 * c2 - b2 * b2;
   const gap = Math.sqrt(Math.max(0, (tr * tr) / 4 - det));
   const l1 = tr / 2 + gap;
   const l2 = tr / 2 - gap;
   if (!(l1 > 0) || !(l2 > 0)) return null;
 
   return {
-    cx: ex,
-    cy: ey,
+    cx: ox + u0,
+    cy: oy + v0,
     rx: 1 / Math.sqrt(l1),
     ry: 1 / Math.sqrt(l2),
-    // Eigenvector for l1 is (B, l1 - A); this is the rx axis direction.
-    angle: Math.atan2(l1 - A, B),
+    // Eigenvector for l1 is (b2, l1 - a2); this is the rx axis direction. For a
+    // circle (l1 == l2, b2 == 0) atan2(0, 0) == 0 — fine, since any angle is
+    // equivalent when rx == ry.
+    angle: Math.atan2(l1 - a2, b2),
   };
 }
 
 /**
- * Solve the 3×3 system M·x = b by Gaussian elimination with partial pivoting.
- * Returns null if the matrix is singular (degenerate fit).
+ * Solve the square system M·x = b by Gaussian elimination with partial pivoting.
+ * `m` is row-major and `b` has the same length; returns null if singular.
  */
-function solve3(
-  m: [number, number, number][],
-  b: [number, number, number],
-): [number, number, number] | null {
-  const aug: number[][] = [
-    [m[0][0], m[0][1], m[0][2], b[0]],
-    [m[1][0], m[1][1], m[1][2], b[1]],
-    [m[2][0], m[2][1], m[2][2], b[2]],
-  ];
-  for (let col = 0; col < 3; col++) {
+function solveLinear(m: number[][], b: number[]): number[] | null {
+  const n = b.length;
+  const aug = m.map((row, i) => [...row, b[i]]);
+  for (let col = 0; col < n; col++) {
     let pivot = col;
-    for (let row = col + 1; row < 3; row++) {
+    for (let row = col + 1; row < n; row++) {
       if (Math.abs(aug[row][col]) > Math.abs(aug[pivot][col])) pivot = row;
     }
     if (Math.abs(aug[pivot][col]) < 1e-12) return null;
     [aug[col], aug[pivot]] = [aug[pivot], aug[col]];
-    for (let row = 0; row < 3; row++) {
+    for (let row = 0; row < n; row++) {
       if (row === col) continue;
       const factor = aug[row][col] / aug[col][col];
-      for (let k = col; k < 4; k++) aug[row][k] -= factor * aug[col][k];
+      for (let k = col; k <= n; k++) aug[row][k] -= factor * aug[col][k];
     }
   }
-  return [aug[0][3] / aug[0][0], aug[1][3] / aug[1][1], aug[2][3] / aug[2][2]];
+  return aug.map((row, i) => row[n] / row[i]);
 }
 
 /**
@@ -345,9 +361,12 @@ class EffectsEngine {
 
   // Cached globe silhouette. Fitting it costs many project/unproject round-trips,
   // but it only changes when the camera moves, so recompute lazily on a dirty
-  // flag set by move/zoom/resize rather than every animation frame.
+  // flag set by move/resize rather than every animation frame.
   private globeEllipse: GlobeEllipse | null = null;
   private ellipseDirty = true;
+  // Last fitted mean limb radius, fed back as the ray-search seed so the next
+  // recompute (e.g. the next frame of a drag) brackets the limb almost immediately.
+  private lastLimbRadius = 0;
 
   private rafId: number | null = null;
   private destroyed = false;
@@ -369,8 +388,9 @@ class EffectsEngine {
     this.tick = this.tick.bind(this);
 
     map.on("resize", this.handleResize);
+    // "move" already fires for pan, zoom, pitch, and rotate, so it covers every
+    // camera change; no separate "zoom" listener is needed.
     map.on("move", this.handleMapChange);
-    map.on("zoom", this.handleMapChange);
     document.addEventListener("visibilitychange", this.handleVisibility);
 
     this.handleResize();
@@ -387,7 +407,6 @@ class EffectsEngine {
     this.stop();
     this.map.off("resize", this.handleResize);
     this.map.off("move", this.handleMapChange);
-    this.map.off("zoom", this.handleMapChange);
     document.removeEventListener("visibilitychange", this.handleVisibility);
     this.spaceCanvas.remove();
     this.haloCanvas.remove();
@@ -419,7 +438,7 @@ class EffectsEngine {
     }
   }
 
-  // move/zoom restart a loop that stopped because the effects had faded out.
+  // A move restarts a loop that stopped because the effects had faded out.
   // MapLibre's "move" fires for pan, zoom, pitch, and rotate, so this also marks
   // the cached silhouette stale on any camera change.
   private handleMapChange(): void {
@@ -432,6 +451,9 @@ class EffectsEngine {
     const mapCanvas = this.map.getCanvas();
     this.width = mapCanvas.clientWidth;
     this.height = mapCanvas.clientHeight;
+    // Cap the backing-store scale at 2× — beyond that the overlay canvases cost
+    // more to clear/redraw each frame than the extra crispness is worth for a
+    // soft glow, so 3×+ displays render the effect (not the map) at 2×.
     this.dpr = Math.min(window.devicePixelRatio || 1, 2);
 
     for (const ctx of [this.spaceCtx, this.haloCtx]) {
@@ -741,7 +763,11 @@ class EffectsEngine {
     }
 
     if (this.ellipseDirty) {
-      this.globeEllipse = getGlobeEllipse(this.map);
+      this.globeEllipse = getGlobeEllipse(this.map, this.lastLimbRadius);
+      if (this.globeEllipse) {
+        this.lastLimbRadius =
+          (this.globeEllipse.rx + this.globeEllipse.ry) / 2;
+      }
       this.ellipseDirty = false;
     }
     const disc = this.globeEllipse;

--- a/packages/plugins/src/plugins/maplibre-effects.ts
+++ b/packages/plugins/src/plugins/maplibre-effects.ts
@@ -48,6 +48,16 @@ const PARALLAX_PX_PER_DEGREE = 0.6;
 // Halo radial gradient — color stops are fractions of the gradient span, which
 // runs from the globe edge out to HALO_RADIUS_SCALE × the globe radius.
 const HALO_RADIUS_SCALE = 2.8;
+// The space punch-out and the halo's opaque inner edge sit slightly inside the
+// fitted limb. The 2D overlay edge and the WebGL globe edge are rasterized
+// independently, so aligning them exactly leaves a thin seam wherever they
+// disagree by a sub-pixel — the dark space gradient bleeds onto the globe rim
+// (a dark line) or the page background shows through (a light line), most
+// visible on HiDPI displays and at high zoom. Overlapping the bright, opaque
+// inner glow a few percent onto the limb hides that seam, the way the original
+// (smaller) great-circle disc did. The fitted ellipse still sets the center,
+// shape, and rotation, so the halo tracks the globe under zoom and pitch.
+const LIMB_INSET = 0.965;
 // Globe-silhouette sampling: rays cast from the projected map center, each
 // bisected to the rendered limb. The silhouette is a conic (a circle top-down,
 // an ellipse under pitch), so a handful of rays over-determine the 3-parameter
@@ -634,8 +644,8 @@ class EffectsEngine {
     this.spaceCtx.ellipse(
       disc.cx,
       disc.cy,
-      disc.rx,
-      disc.ry,
+      disc.rx * LIMB_INSET,
+      disc.ry * LIMB_INSET,
       disc.angle,
       0,
       Math.PI * 2,
@@ -676,7 +686,9 @@ class EffectsEngine {
     // real atmospheric rim does under perspective.
     ctx.translate(disc.cx, disc.cy);
     ctx.rotate(disc.angle);
-    ctx.scale(disc.rx, disc.ry);
+    // Same inset as the punch-out so the two edges coincide; the unit circle in
+    // this frame is then the inset limb, where the halo's opaque inner stop sits.
+    ctx.scale(disc.rx * LIMB_INSET, disc.ry * LIMB_INSET);
 
     const gradient = ctx.createRadialGradient(0, 0, 1, 0, 0, HALO_RADIUS_SCALE);
     for (const [stop, color] of HALO_STOPS) {

--- a/packages/plugins/src/plugins/maplibre-effects.ts
+++ b/packages/plugins/src/plugins/maplibre-effects.ts
@@ -16,16 +16,20 @@ import type { GeoLibreAppAPI, GeoLibrePlugin } from "../types";
  * article "Globe atmosphere, halo, and comets":
  * https://leoneljdias.github.io/posts/globe-atmosphere-halo-comets/
  * — specifically the layered Canvas 2D approach, the halo gradient stops and
- * "screen" blend, the limb-sampling that keeps the halo aligned under pitch,
- * and the starfield/comet parameters. Re-implemented for GeoLibre's plugin
- * lifecycle (single on-top canvas that punches out the globe disc so the
- * effects show only around the globe regardless of the active basemap).
+ * "screen" blend, and the starfield/comet parameters. Re-implemented for
+ * GeoLibre's plugin lifecycle (single on-top canvas that punches out the globe
+ * silhouette so the effects show only around the globe regardless of the active
+ * basemap).
+ *
+ * The silhouette is recovered by sampling the *rendered* globe limb (see
+ * {@link getGlobeEllipse}) and fitting an ellipse, rather than projecting a fixed
+ * great-circle limb from the map center. Under MapLibre's perspective globe the
+ * visible silhouette is an ellipse that is smaller than the 90° limb and offset
+ * from the screen center under pitch, so the fitted ellipse keeps the halo and
+ * punch-out hugging the globe at any zoom, pitch, and bearing.
  */
 
 export const EFFECTS_PLUGIN_ID = "maplibre-atmosphere-effects";
-
-const D2R = Math.PI / 180;
-const R2D = 180 / Math.PI;
 
 // Effects are fully visible at/below ZOOM_FADE_START and fully hidden at/above
 // ZOOM_FADE_END, with a linear fade between (the reference gates around zoom
@@ -44,6 +48,16 @@ const PARALLAX_PX_PER_DEGREE = 0.6;
 // Halo radial gradient — color stops are fractions of the gradient span, which
 // runs from the globe edge out to HALO_RADIUS_SCALE × the globe radius.
 const HALO_RADIUS_SCALE = 2.8;
+// Globe-silhouette sampling: rays cast from the projected map center, each
+// bisected to the rendered limb. The silhouette is a conic (a circle top-down,
+// an ellipse under pitch), so a handful of rays over-determine the 3-parameter
+// ellipse fit; the bisection depth pins each limb crossing to sub-pixel.
+const SILHOUETTE_RAYS = 24;
+const SILHOUETTE_BISECTIONS = 18;
+// A screen point is "on the globe" when it round-trips through unproject→project
+// to within this many pixels; points off the globe clamp to the limb and miss by
+// tens to hundreds of pixels, so the threshold is not sensitive.
+const ON_GLOBE_TOLERANCE_PX = 1;
 const HALO_STOPS: Array<[number, string]> = [
   [0.0, "rgba(200, 235, 255, 1.0)"],
   [0.03, "rgba(130, 200, 250, 0.6)"],
@@ -72,10 +86,15 @@ interface Comet {
   maxLife: number;
 }
 
-interface GlobeDisc {
-  x: number;
-  y: number;
-  r: number;
+export interface GlobeEllipse {
+  // Center of the projected globe silhouette (screen px).
+  cx: number;
+  cy: number;
+  // Semi-axes (screen px). rx runs along `angle`, ry perpendicular to it.
+  rx: number;
+  ry: number;
+  // Rotation of the rx axis, radians.
+  angle: number;
 }
 
 function clamp(value: number, min: number, max: number): number {
@@ -97,56 +116,196 @@ function isGlobeProjection(map: MapLibreMap): boolean {
 }
 
 /**
- * Screen-space center and radius of the rendered globe disc.
+ * Is this screen point on the rendered globe?
  *
- * Samples 16 points on the globe limb (great-circle distance π/2 from the map
- * center) and projects them; the bounding box of those points gives a disc
- * that stays aligned even when the map is pitched. Returns null when too few
- * points project to finite coordinates (e.g. the globe is off-screen).
+ * MapLibre's `unproject` clamps points outside the globe to the nearest limb
+ * location, so an off-globe pixel does not round-trip back to itself through
+ * `project`. On-globe pixels round-trip to within a pixel; off-globe pixels miss
+ * by tens to hundreds of pixels. This is the only signal we have for the
+ * *rendered* silhouette, which (under perspective + pitch) is neither the
+ * geometric 90° limb nor centered on the projected map center.
  */
-function getGlobeDisc(map: MapLibreMap): GlobeDisc | null {
-  const center = map.getCenter();
-  const clng = center.lng * D2R;
-  const clat = center.lat * D2R;
+function isOnGlobe(map: MapLibreMap, x: number, y: number): boolean {
+  const back = map.project(map.unproject([x, y]));
+  return Math.hypot(back.x - x, back.y - y) <= ON_GLOBE_TOLERANCE_PX;
+}
+
+/**
+ * Distance from (cx,cy) along (dx,dy) to the globe limb, by bisection.
+ *
+ * Assumes the start point is on the globe; expands until a point is off-globe,
+ * then bisects the on/off boundary. `maxR` caps the search so a globe larger
+ * than the search window (very rare in the effect's low-zoom range) terminates.
+ */
+function rayToLimb(
+  map: MapLibreMap,
+  cx: number,
+  cy: number,
+  dx: number,
+  dy: number,
+  maxR: number,
+): number {
+  let lo = 0;
+  let hi = 8;
+  while (hi < maxR && isOnGlobe(map, cx + dx * hi, cy + dy * hi)) {
+    lo = hi;
+    hi *= 2;
+  }
+  if (hi > maxR) hi = maxR;
+  for (let i = 0; i < SILHOUETTE_BISECTIONS; i++) {
+    const mid = (lo + hi) / 2;
+    if (isOnGlobe(map, cx + dx * mid, cy + dy * mid)) lo = mid;
+    else hi = mid;
+  }
+  return lo;
+}
+
+/**
+ * The rendered globe silhouette as a screen-space ellipse.
+ *
+ * Casts {@link SILHOUETTE_RAYS} rays from the projected map center (always
+ * inside the silhouette) out to the rendered limb, then fits an ellipse to those
+ * limb points. The silhouette of a sphere under a pinhole camera is exactly a
+ * conic — a circle when viewed top-down, an ellipse under pitch — so the fit is
+ * exact: its bounding-box center is the ellipse center, and a 3-parameter
+ * quadratic-form least-squares solve recovers the axes and rotation. This tracks
+ * the globe under any zoom, pitch, and bearing, unlike a fixed great-circle
+ * limb measured from the map center. Returns null when the globe is off-screen.
+ */
+function getGlobeEllipse(map: MapLibreMap): GlobeEllipse | null {
+  const center = map.project(map.getCenter());
+  const cx = center.x;
+  const cy = center.y;
+  if (!Number.isFinite(cx) || !Number.isFinite(cy)) return null;
+  if (!isOnGlobe(map, cx, cy)) return null;
+
+  const canvas = map.getCanvas();
+  const maxR = Math.max(canvas.clientWidth, canvas.clientHeight) * 8;
+
+  const pts: Array<[number, number]> = [];
+  for (let i = 0; i < SILHOUETTE_RAYS; i++) {
+    const a = (i / SILHOUETTE_RAYS) * 2 * Math.PI;
+    const dx = Math.cos(a);
+    const dy = Math.sin(a);
+    const r = rayToLimb(map, cx, cy, dx, dy, maxR);
+    pts.push([cx + dx * r, cy + dy * r]);
+  }
+
+  return fitEllipse(pts);
+}
+
+/**
+ * Fit an ellipse to points sampled around its boundary.
+ *
+ * Exact for points that lie on a real ellipse (such as the conic silhouette of a
+ * sphere): the axis-aligned bounding box of any ellipse is centered on the
+ * ellipse, so its center is recovered directly; the shape comes from a
+ * 3-parameter quadratic-form least-squares solve of A·dx² + 2B·dx·dy + C·dy² = 1.
+ * Returns null for a degenerate (non-positive-definite) fit — e.g. collinear or
+ * too few points.
+ */
+export function fitEllipse(
+  pts: ReadonlyArray<readonly [number, number]>,
+): GlobeEllipse | null {
+  if (pts.length < 3) return null;
 
   let minX = Infinity;
   let minY = Infinity;
   let maxX = -Infinity;
   let maxY = -Infinity;
-  let count = 0;
-
-  for (let i = 0; i < 16; i++) {
-    const bearing = (i / 16) * 2 * Math.PI;
-    // Destination point at angular distance π/2 (the visible limb) along
-    // `bearing`; the great-circle formulas simplify since cos(π/2)=0, sin(π/2)=1.
-    const lat2 = Math.asin(Math.cos(clat) * Math.cos(bearing));
-    const lng2 =
-      clng +
-      Math.atan2(
-        Math.sin(bearing) * Math.cos(clat),
-        -Math.sin(clat) * Math.sin(lat2),
-      );
-
-    const point = map.project([lng2 * R2D, lat2 * R2D]);
-    if (!Number.isFinite(point.x) || !Number.isFinite(point.y)) continue;
-    minX = Math.min(minX, point.x);
-    minY = Math.min(minY, point.y);
-    maxX = Math.max(maxX, point.x);
-    maxY = Math.max(maxY, point.y);
-    count++;
+  for (const [px, py] of pts) {
+    if (!Number.isFinite(px) || !Number.isFinite(py)) return null;
+    minX = Math.min(minX, px);
+    minY = Math.min(minY, py);
+    maxX = Math.max(maxX, px);
+    maxY = Math.max(maxY, py);
   }
+  const ex = (minX + maxX) / 2;
+  const ey = (minY + maxY) / 2;
 
-  if (count < 8) return null;
-  const halfWidth = (maxX - minX) / 2;
-  const halfHeight = (maxY - minY) / 2;
+  // Normal equations for A·dx² + 2B·dx·dy + C·dy² = 1 about the center.
+  let s00 = 0;
+  let s01 = 0;
+  let s02 = 0;
+  let s11 = 0;
+  let s12 = 0;
+  let s22 = 0;
+  let t0 = 0;
+  let t1 = 0;
+  let t2 = 0;
+  for (const [px, py] of pts) {
+    const dx = px - ex;
+    const dy = py - ey;
+    const f0 = dx * dx;
+    const f1 = 2 * dx * dy;
+    const f2 = dy * dy;
+    s00 += f0 * f0;
+    s01 += f0 * f1;
+    s02 += f0 * f2;
+    s11 += f1 * f1;
+    s12 += f1 * f2;
+    s22 += f2 * f2;
+    t0 += f0;
+    t1 += f1;
+    t2 += f2;
+  }
+  const conic = solve3(
+    [
+      [s00, s01, s02],
+      [s01, s11, s12],
+      [s02, s12, s22],
+    ],
+    [t0, t1, t2],
+  );
+  if (!conic) return null;
+  const [A, B, C] = conic;
+
+  // Eigen-decompose [[A,B],[B,C]]: semi-axis = 1/√eigenvalue, axis direction =
+  // eigenvector. A non-positive-definite fit is not a real ellipse, so bail.
+  const tr = A + C;
+  const det = A * C - B * B;
+  const gap = Math.sqrt(Math.max(0, (tr * tr) / 4 - det));
+  const l1 = tr / 2 + gap;
+  const l2 = tr / 2 - gap;
+  if (!(l1 > 0) || !(l2 > 0)) return null;
+
   return {
-    x: minX + halfWidth,
-    y: minY + halfHeight,
-    // The projected globe is an ellipse under pitch; use the larger half-extent
-    // so the circular punch-out fully covers the silhouette (slightly over-cuts
-    // at steep pitch) rather than leaving deep space bleeding over the poles.
-    r: Math.max(halfWidth, halfHeight),
+    cx: ex,
+    cy: ey,
+    rx: 1 / Math.sqrt(l1),
+    ry: 1 / Math.sqrt(l2),
+    // Eigenvector for l1 is (B, l1 - A); this is the rx axis direction.
+    angle: Math.atan2(l1 - A, B),
   };
+}
+
+/**
+ * Solve the 3×3 system M·x = b by Gaussian elimination with partial pivoting.
+ * Returns null if the matrix is singular (degenerate fit).
+ */
+function solve3(
+  m: [number, number, number][],
+  b: [number, number, number],
+): [number, number, number] | null {
+  const aug: number[][] = [
+    [m[0][0], m[0][1], m[0][2], b[0]],
+    [m[1][0], m[1][1], m[1][2], b[1]],
+    [m[2][0], m[2][1], m[2][2], b[2]],
+  ];
+  for (let col = 0; col < 3; col++) {
+    let pivot = col;
+    for (let row = col + 1; row < 3; row++) {
+      if (Math.abs(aug[row][col]) > Math.abs(aug[pivot][col])) pivot = row;
+    }
+    if (Math.abs(aug[pivot][col]) < 1e-12) return null;
+    [aug[col], aug[pivot]] = [aug[pivot], aug[col]];
+    for (let row = 0; row < 3; row++) {
+      if (row === col) continue;
+      const factor = aug[row][col] / aug[col][col];
+      for (let k = col; k < 4; k++) aug[row][k] -= factor * aug[col][k];
+    }
+  }
+  return [aug[0][3] / aug[0][0], aug[1][3] / aug[1][1], aug[2][3] / aug[2][2]];
 }
 
 /**
@@ -170,6 +329,12 @@ class EffectsEngine {
   private width = 0;
   private height = 0;
   private dpr = 1;
+
+  // Cached globe silhouette. Fitting it costs many project/unproject round-trips,
+  // but it only changes when the camera moves, so recompute lazily on a dirty
+  // flag set by move/zoom/resize rather than every animation frame.
+  private globeEllipse: GlobeEllipse | null = null;
+  private ellipseDirty = true;
 
   private rafId: number | null = null;
   private destroyed = false;
@@ -242,7 +407,10 @@ class EffectsEngine {
   }
 
   // move/zoom restart a loop that stopped because the effects had faded out.
+  // MapLibre's "move" fires for pan, zoom, pitch, and rotate, so this also marks
+  // the cached silhouette stale on any camera change.
   private handleMapChange(): void {
+    this.ellipseDirty = true;
     if (!document.hidden) this.start();
   }
 
@@ -263,6 +431,7 @@ class EffectsEngine {
     }
     this.starfield = null; // regenerate at the new size on the next frame
     this.spaceGradient = null; // rebuild for the new dimensions
+    this.ellipseDirty = true; // silhouette depends on viewport size
   }
 
   private start(): void {
@@ -455,14 +624,22 @@ class EffectsEngine {
     };
   }
 
-  private punchOutGlobe(disc: GlobeDisc): void {
-    // Remove the deep-space layer over the globe disc so the real basemap globe
-    // shows through; the halo (drawn on its own canvas) hides any seam.
+  private punchOutGlobe(disc: GlobeEllipse): void {
+    // Remove the deep-space layer over the globe silhouette so the real basemap
+    // globe shows through; the halo (drawn on its own canvas) hides any seam.
     this.spaceCtx.save();
     this.spaceCtx.globalCompositeOperation = "destination-out";
     this.spaceCtx.fillStyle = "rgba(0, 0, 0, 1)";
     this.spaceCtx.beginPath();
-    this.spaceCtx.arc(disc.x, disc.y, disc.r, 0, Math.PI * 2);
+    this.spaceCtx.ellipse(
+      disc.cx,
+      disc.cy,
+      disc.rx,
+      disc.ry,
+      disc.angle,
+      0,
+      Math.PI * 2,
+    );
     this.spaceCtx.fill();
     this.spaceCtx.restore();
   }
@@ -489,31 +666,32 @@ class EffectsEngine {
     ctx.restore();
   }
 
-  private drawHalo(disc: GlobeDisc, alpha: number): void {
+  private drawHalo(disc: GlobeEllipse, alpha: number): void {
     const ctx = this.haloCtx;
-    const outer = disc.r * HALO_RADIUS_SCALE;
-    const gradient = ctx.createRadialGradient(
-      disc.x,
-      disc.y,
-      disc.r,
-      disc.x,
-      disc.y,
-      outer,
-    );
+    ctx.save();
+    // Work in a normalized space where the silhouette is the unit circle: shift
+    // to the center, rotate to the ellipse axes, then scale by the semi-axes.
+    // A circular radial gradient and annulus drawn here map to an ellipse that
+    // hugs the globe at any pitch — the halo thickens along the major axis, as a
+    // real atmospheric rim does under perspective.
+    ctx.translate(disc.cx, disc.cy);
+    ctx.rotate(disc.angle);
+    ctx.scale(disc.rx, disc.ry);
+
+    const gradient = ctx.createRadialGradient(0, 0, 1, 0, 0, HALO_RADIUS_SCALE);
     for (const [stop, color] of HALO_STOPS) {
       gradient.addColorStop(stop, color);
     }
-    ctx.save();
     // The screen blend is applied via the canvas element's mix-blend-mode
     // (set in createCanvas); here we just paint the gradient normally.
     ctx.globalAlpha = alpha;
     ctx.fillStyle = gradient;
-    // Paint only the annulus outside the globe (outer circle CW, inner circle
-    // CCW cancels the winding in the hole — nonzero rule), so the rim glows
-    // without tinting the globe disc.
+    // Paint only the annulus outside the globe (outer ring CW, inner ring CCW
+    // cancels the winding in the hole — nonzero rule), so the rim glows without
+    // tinting the globe disc.
     ctx.beginPath();
-    ctx.arc(disc.x, disc.y, outer, 0, Math.PI * 2, false);
-    ctx.arc(disc.x, disc.y, disc.r, 0, Math.PI * 2, true);
+    ctx.arc(0, 0, HALO_RADIUS_SCALE, 0, Math.PI * 2, false);
+    ctx.arc(0, 0, 1, 0, Math.PI * 2, true);
     ctx.fill();
     ctx.restore();
   }
@@ -531,7 +709,11 @@ class EffectsEngine {
       return;
     }
 
-    const disc = getGlobeDisc(this.map);
+    if (this.ellipseDirty) {
+      this.globeEllipse = getGlobeEllipse(this.map);
+      this.ellipseDirty = false;
+    }
+    const disc = this.globeEllipse;
     this.drawSpaceBackground(alpha);
     this.drawStarfield(alpha);
     this.updateAndDrawComets(alpha);

--- a/tests/globe-halo-ellipse.test.ts
+++ b/tests/globe-halo-ellipse.test.ts
@@ -6,10 +6,12 @@ import {
 } from "../packages/plugins/src/plugins/maplibre-effects";
 
 /**
- * Sample `n` points on the boundary of an ellipse with the given center,
- * semi-axes, and rotation. Sampling is uneven on purpose (rays from an interior
- * point that is *not* the center, mimicking how the silhouette is sampled from
- * the projected map center) to prove the fit does not depend on uniform spacing.
+ * Sample `n` boundary points by casting rays at uniform angles from `from` (an
+ * interior point) to the ellipse — exactly how the production code samples the
+ * silhouette from the projected map center. When `from` is the ellipse center
+ * the rays are radial; when it is offset (as it is under pitch) the hit points
+ * are *not* symmetric about the center, which is the case a bounding-box-center
+ * fit would get wrong and a true conic fit must get right.
  */
 function ellipsePoints(
   e: GlobeEllipse,
@@ -18,23 +20,28 @@ function ellipsePoints(
 ): Array<[number, number]> {
   const cos = Math.cos(e.angle);
   const sin = Math.sin(e.angle);
+  // Ray origin in the ellipse-local frame, scaled so the ellipse is the unit
+  // circle: translate to center, unrotate, divide by the semi-axes.
+  const ox = ((from[0] - e.cx) * cos + (from[1] - e.cy) * sin) / e.rx;
+  const oy = (-(from[0] - e.cx) * sin + (from[1] - e.cy) * cos) / e.ry;
   const pts: Array<[number, number]> = [];
   for (let i = 0; i < n; i++) {
-    // Boundary point at parameter t, in ellipse-local then world coords.
-    const t = (i / n) * 2 * Math.PI;
-    const lx = e.rx * Math.cos(t);
-    const ly = e.ry * Math.sin(t);
-    const bx = e.cx + lx * cos - ly * sin;
-    const by = e.cy + lx * sin + ly * cos;
-    // Re-parameterize by angle from `from` so spacing is uneven (irrelevant to
-    // the fit, but matches the real ray-cast sampling).
-    const ang = Math.atan2(by - from[1], bx - from[0]);
-    pts.push([ang, bx, by] as unknown as [number, number]);
+    const ang = (i / n) * 2 * Math.PI;
+    const cosA = Math.cos(ang);
+    const sinA = Math.sin(ang);
+    // Same ray direction in the unit-circle frame, then the far intersection
+    // with the unit circle: |origin + t·dir| = 1.
+    const dx = (cosA * cos + sinA * sin) / e.rx;
+    const dy = (-cosA * sin + sinA * cos) / e.ry;
+    const qa = dx * dx + dy * dy;
+    const qb = ox * dx + oy * dy;
+    const qc = ox * ox + oy * oy - 1;
+    const disc = qb * qb - qa * qc;
+    if (disc < 0) continue; // ray misses (only if `from` is outside the ellipse)
+    const t = (-qb + Math.sqrt(disc)) / qa; // far (forward) intersection
+    pts.push([from[0] + cosA * t, from[1] + sinA * t]);
   }
-  // sort by angle from `from`, keep coords
-  return (pts as unknown as Array<[number, number, number]>)
-    .sort((a, b) => a[0] - b[0])
-    .map(([, x, y]) => [x, y]);
+  return pts;
 }
 
 /** Largest absolute residual: how far each point sits off the fitted ellipse. */
@@ -63,9 +70,11 @@ describe("fitEllipse", () => {
     assert.ok(fit, "expected a fit");
     assert.ok(Math.abs(fit.cx - 344) < 1e-6);
     assert.ok(Math.abs(fit.cy - 392) < 1e-6);
-    assert.ok(Math.abs(fit.rx - 325) < 1e-6);
-    assert.ok(Math.abs(fit.ry - 325) < 1e-6);
-    assert.ok(maxResidual(fit, ellipsePoints(truth, 64)) < 1e-6);
+    // The 5-parameter conic fit is well within a thousandth of a pixel — far
+    // tighter than the sub-pixel accuracy the effect needs.
+    assert.ok(Math.abs(fit.rx - 325) < 1e-3, `rx ${fit.rx}`);
+    assert.ok(Math.abs(fit.ry - 325) < 1e-3, `ry ${fit.ry}`);
+    assert.ok(maxResidual(fit, ellipsePoints(truth, 64)) < 1e-5);
   });
 
   it("recovers an axis-aligned ellipse (pitched globe)", () => {
@@ -94,12 +103,12 @@ describe("fitEllipse", () => {
     // The fit may report axes/angle for either principal direction; verify by
     // residual rather than comparing angle directly (atan2 sign ambiguity).
     assert.ok(maxResidual(fit, ellipsePoints(truth, 96)) < 1e-5);
-    // Center is exact regardless of rotation (bbox-center property).
+    // Center is solved from the conic, so it is exact regardless of rotation.
     assert.ok(Math.abs(fit.cx - 100) < 1e-6);
     assert.ok(Math.abs(fit.cy + 50) < 1e-6);
   });
 
-  it("uses the bounding-box center even from off-center sampling", () => {
+  it("solves the center from off-center ray-cast sampling", () => {
     const truth: GlobeEllipse = {
       cx: 200,
       cy: 300,
@@ -116,6 +125,25 @@ describe("fitEllipse", () => {
     assert.ok(maxResidual(fit, pts) < 1e-5);
   });
 
+  it("recovers the center when rays are cast far from it (steep pitch)", () => {
+    // Replicates the production case: an eccentric, offset silhouette sampled by
+    // rays from the projected map center, ~1200px from the ellipse center. A
+    // bounding-box-center fit is off by ~16px here; solving the conic is exact.
+    const truth: GlobeEllipse = {
+      cx: 344,
+      cy: 1578,
+      rx: 1337,
+      ry: 1072,
+      angle: -2.2,
+    };
+    const pts = ellipsePoints(truth, 24, [344, 392]);
+    const fit = fitEllipse(pts);
+    assert.ok(fit, "expected a fit");
+    assert.ok(Math.abs(fit.cx - 344) < 1e-4, `cx ${fit.cx}`);
+    assert.ok(Math.abs(fit.cy - 1578) < 1e-4, `cy ${fit.cy}`);
+    assert.ok(maxResidual(fit, pts) < 1e-6);
+  });
+
   it("returns null for degenerate input", () => {
     assert.equal(fitEllipse([]), null);
     assert.equal(
@@ -125,13 +153,16 @@ describe("fitEllipse", () => {
       ]),
       null,
     );
-    // Collinear points do not bound an ellipse.
+    // Six collinear points (enough for the 5-parameter fit) do not bound an
+    // ellipse, so the normal equations are singular and the fit bails.
     assert.equal(
       fitEllipse([
         [0, 0],
         [1, 1],
         [2, 2],
         [3, 3],
+        [4, 4],
+        [5, 5],
       ]),
       null,
     );

--- a/tests/globe-halo-ellipse.test.ts
+++ b/tests/globe-halo-ellipse.test.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  fitEllipse,
+  type GlobeEllipse,
+} from "../packages/plugins/src/plugins/maplibre-effects";
+
+/**
+ * Sample `n` points on the boundary of an ellipse with the given center,
+ * semi-axes, and rotation. Sampling is uneven on purpose (rays from an interior
+ * point that is *not* the center, mimicking how the silhouette is sampled from
+ * the projected map center) to prove the fit does not depend on uniform spacing.
+ */
+function ellipsePoints(
+  e: GlobeEllipse,
+  n: number,
+  from: [number, number] = [e.cx, e.cy],
+): Array<[number, number]> {
+  const cos = Math.cos(e.angle);
+  const sin = Math.sin(e.angle);
+  const pts: Array<[number, number]> = [];
+  for (let i = 0; i < n; i++) {
+    // Boundary point at parameter t, in ellipse-local then world coords.
+    const t = (i / n) * 2 * Math.PI;
+    const lx = e.rx * Math.cos(t);
+    const ly = e.ry * Math.sin(t);
+    const bx = e.cx + lx * cos - ly * sin;
+    const by = e.cy + lx * sin + ly * cos;
+    // Re-parameterize by angle from `from` so spacing is uneven (irrelevant to
+    // the fit, but matches the real ray-cast sampling).
+    const ang = Math.atan2(by - from[1], bx - from[0]);
+    pts.push([ang, bx, by] as unknown as [number, number]);
+  }
+  // sort by angle from `from`, keep coords
+  return (pts as unknown as Array<[number, number, number]>)
+    .sort((a, b) => a[0] - b[0])
+    .map(([, x, y]) => [x, y]);
+}
+
+/** Largest absolute residual: how far each point sits off the fitted ellipse. */
+function maxResidual(
+  e: GlobeEllipse,
+  pts: Array<[number, number]>,
+): number {
+  const cos = Math.cos(e.angle);
+  const sin = Math.sin(e.angle);
+  let worst = 0;
+  for (const [x, y] of pts) {
+    const dx = x - e.cx;
+    const dy = y - e.cy;
+    // Project into ellipse-local frame and evaluate the implicit form.
+    const u = (dx * cos + dy * sin) / e.rx;
+    const v = (-dx * sin + dy * cos) / e.ry;
+    worst = Math.max(worst, Math.abs(Math.hypot(u, v) - 1));
+  }
+  return worst;
+}
+
+describe("fitEllipse", () => {
+  it("recovers a circle (top-down globe) exactly", () => {
+    const truth: GlobeEllipse = { cx: 344, cy: 392, rx: 325, ry: 325, angle: 0 };
+    const fit = fitEllipse(ellipsePoints(truth, 24));
+    assert.ok(fit, "expected a fit");
+    assert.ok(Math.abs(fit.cx - 344) < 1e-6);
+    assert.ok(Math.abs(fit.cy - 392) < 1e-6);
+    assert.ok(Math.abs(fit.rx - 325) < 1e-6);
+    assert.ok(Math.abs(fit.ry - 325) < 1e-6);
+    assert.ok(maxResidual(fit, ellipsePoints(truth, 64)) < 1e-6);
+  });
+
+  it("recovers an axis-aligned ellipse (pitched globe)", () => {
+    const truth: GlobeEllipse = {
+      cx: 344,
+      cy: 630,
+      rx: 455,
+      ry: 447,
+      angle: 0,
+    };
+    const fit = fitEllipse(ellipsePoints(truth, 24));
+    assert.ok(fit, "expected a fit");
+    assert.ok(maxResidual(fit, ellipsePoints(truth, 64)) < 1e-6);
+  });
+
+  it("recovers a rotated, eccentric ellipse (pitch + bearing)", () => {
+    const truth: GlobeEllipse = {
+      cx: 100,
+      cy: -50,
+      rx: 1337,
+      ry: 1072,
+      angle: 0.7,
+    };
+    const fit = fitEllipse(ellipsePoints(truth, 32));
+    assert.ok(fit, "expected a fit");
+    // The fit may report axes/angle for either principal direction; verify by
+    // residual rather than comparing angle directly (atan2 sign ambiguity).
+    assert.ok(maxResidual(fit, ellipsePoints(truth, 96)) < 1e-5);
+    // Center is exact regardless of rotation (bbox-center property).
+    assert.ok(Math.abs(fit.cx - 100) < 1e-6);
+    assert.ok(Math.abs(fit.cy + 50) < 1e-6);
+  });
+
+  it("uses the bounding-box center even from off-center sampling", () => {
+    const truth: GlobeEllipse = {
+      cx: 200,
+      cy: 300,
+      rx: 400,
+      ry: 250,
+      angle: 0.3,
+    };
+    // Sample as rays from a point well inside but away from the center.
+    const pts = ellipsePoints(truth, 40, [260, 340]);
+    const fit = fitEllipse(pts);
+    assert.ok(fit, "expected a fit");
+    assert.ok(Math.abs(fit.cx - 200) < 1e-6);
+    assert.ok(Math.abs(fit.cy - 300) < 1e-6);
+    assert.ok(maxResidual(fit, pts) < 1e-5);
+  });
+
+  it("returns null for degenerate input", () => {
+    assert.equal(fitEllipse([]), null);
+    assert.equal(
+      fitEllipse([
+        [0, 0],
+        [1, 1],
+      ]),
+      null,
+    );
+    // Collinear points do not bound an ellipse.
+    assert.equal(
+      fitEllipse([
+        [0, 0],
+        [1, 1],
+        [2, 2],
+        [3, 3],
+      ]),
+      null,
+    );
+  });
+});


### PR DESCRIPTION
## Problem

User feedback reported that the globe atmosphere halo does not follow the globe when zooming or changing pitch (the halo rim detaches from the limb).

Root cause: `getGlobeDisc` modeled the silhouette as the **90-degree great-circle limb measured from the map center**, projected and bounding-boxed. That is only correct in the orthographic, un-pitched, far-camera limit. Under MapLibre's perspective globe:

- **Zoom in** — the true visible silhouette is the perspective tangent circle (`asin(R/d)`), which is *smaller* than the 90-degree limb, so the halo/punch-out overshot the real edge (measured ~312px vs a real ~325px radius even top-down).
- **Pitch** — the visible limb is defined relative to the camera direction, not the screen-center target, so the disc center diverged badly (e.g. at pitch 55 the modeled center was ~570px below the real one).

## Fix

Recover the *rendered* silhouette directly. The silhouette of a sphere under a pinhole camera is exactly a conic (a circle top-down, an ellipse under pitch), so:

1. Sample the rendered limb by casting rays from the projected map center and bisecting each to the on/off-globe boundary. On/off-globe is detected with an `unproject → project` round-trip (off-globe points clamp to the limb and fail to round-trip).
2. Fit an ellipse to those limb points: the axis-aligned bounding-box center is the exact ellipse center, and a 3-parameter quadratic-form least-squares solve recovers the semi-axes and rotation.
3. Draw the punch-out (`ctx.ellipse`) and the halo (radial gradient in a translate/rotate/scale frame) from that ellipse.

The fit is exact (empirically `errPct = 0` across pitch 0-55 and varying bearing/zoom) and cached, recomputed only on camera change.

## Verification

- New unit test `tests/globe-halo-ellipse.test.ts` for the ellipse fit (circle, axis-aligned, rotated/eccentric, off-center sampling, degenerate input).
- Full frontend suite green (231 tests).
- Visually verified live in the web build that the halo hugs the globe at pitch 0, zoomed-in pitch (curved limb), full elliptical silhouette, and pitch + bearing.

## Notes

This reworks the limb-tracking from the original reference technique while keeping its visual design (gradient stops, screen blend, starfield/comets). Credit to Leonel Dias for reporting and for an independent fix in geoglify.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More accurate globe silhouette: screen-space ellipse fitting replaces the previous disc approximation, with caching and lazy recompute so the punch-out and halo align correctly under pitch, bearing, and resize.

* **Tests**
  * Added tests for ellipse fitting: exact/recovered circles and ellipses, rotated/eccentric cases, center handling, and degenerate/insufficient inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->