### PR TITLE
feat(routing): add Directions plugin (maplibre-gl-directions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS
 - Plugin system with basemap, layer control, MapLibre components, swipe, street view, Overture Maps, LiDAR, GeoAgent, and GeoEditor integrations, including configurable control positions and external plugin manifests; external plugins can render on the host's shared deck.gl instance via `app.getDeckGL()`
 - Time Slider plugin for animating time series raster and vector data
 - Atmosphere Effects plugin that renders a deep-space backdrop, parallax starfield, comets, and an atmospheric halo around the globe at low zoom (technique adapted from [Leonel Dias](https://leoneljdias.github.io/posts/globe-atmosphere-halo-comets/))
+- Directions plugin for interactive routing via [maplibre-gl-directions](https://github.com/maplibre/maplibre-gl-directions): click the map to add waypoints, drag to reposition, and click a waypoint to remove it (uses the public OSRM demo server, driving only)
 - External plugin zip loading from the app data plugins directory and local development plugin directories
 - Bundled drop-in plugins under `public/plugins/<id>/` that bake into both the web and desktop builds and load automatically with no manifest URL
 - Browser deployment with Docker, embed-friendly URL parameters, and a `maponly` chrome-free mode

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -4,9 +4,11 @@ import type { MapController, MapDiagnosticEvent } from "@geolibre/map";
 import { MapCanvas } from "@geolibre/map";
 import {
   addRasterToMap,
+  DIRECTIONS_PLUGIN_ID,
   EFFECTS_PLUGIN_ID,
   endLayerGeometryEdit,
   getGeometryEditTargetLayerId,
+  restoreDirections,
   restoreEffects,
   restoreRasterLayers,
   restoreThreeDTilesLayers,
@@ -377,6 +379,9 @@ export function DesktopShell({
     // called, so the effects engine must be kicked explicitly to match the
     // restored active state (idempotent).
     restoreEffects(appAPI, pluginManager.isActive(EFFECTS_PLUGIN_ID));
+    // Rebind the directions tool to the (possibly new) map instance after a
+    // map re-init, since restoreProjectState skips an already-active plugin.
+    restoreDirections(appAPI, pluginManager.isActive(DIRECTIONS_PLUGIN_ID));
     const search = window.location.search;
     void pluginManager
       .handleUrlParameters(

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -68,6 +68,7 @@ import {
   subscribeSearchPlacesPanel,
   subscribeViewStatePanel,
   toggleEarthEnginePanel,
+  DIRECTIONS_PLUGIN_ID,
   EFFECTS_PLUGIN_ID,
   WEB_SERVICE_PLUGIN_IDS,
   type GeoLibreMapControlPosition,
@@ -1238,6 +1239,12 @@ export function TopToolbar({
             Atmosphere Effects
             {isActive(EFFECTS_PLUGIN_ID) ? " ✓" : ""}
           </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => toggle(DIRECTIONS_PLUGIN_ID, appApi)}
+          >
+            Directions
+            {isActive(DIRECTIONS_PLUGIN_ID) ? " ✓" : ""}
+          </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem onSelect={handleToggleSearchPlacesPanel}>
             Search
@@ -1348,9 +1355,12 @@ export function TopToolbar({
             // above Esri Wayback).
             let webServicesRendered = false;
             return plugins.map((p) => {
-              // Atmosphere Effects is toggled from the Controls menu instead, so
-              // it is omitted here to avoid a duplicate toggle.
-              if (p.id === EFFECTS_PLUGIN_ID) return null;
+              // Atmosphere Effects and Directions are toggled from the Controls
+              // menu instead, so they are omitted here to avoid a duplicate
+              // toggle.
+              if (p.id === EFFECTS_PLUGIN_ID || p.id === DIRECTIONS_PLUGIN_ID) {
+                return null;
+              }
               if (!WEB_SERVICE_PLUGIN_ID_SET.has(p.id)) {
                 return renderPluginMenuItem(p);
               }

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -1240,6 +1240,7 @@ export function TopToolbar({
             {isActive(EFFECTS_PLUGIN_ID) ? " ✓" : ""}
           </DropdownMenuItem>
           <DropdownMenuItem
+            title="Routing sends your waypoints to the public OSRM demo server (router.project-osrm.org)."
             onClick={() => toggle(DIRECTIONS_PLUGIN_ID, appApi)}
           >
             Directions

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -6,6 +6,7 @@ import {
 import {
   maplibreBasemapControlPlugin,
   maplibreComponentsPlugin,
+  maplibreDirectionsPlugin,
   maplibreEffectsPlugin,
   maplibreEnviroAtlasPlugin,
   maplibreEsriWaybackPlugin,
@@ -73,6 +74,7 @@ manager.registerAll([
   maplibreStreetViewPlugin,
   maplibreSwipePlugin,
   maplibreEffectsPlugin,
+  maplibreDirectionsPlugin,
   maplibreComponentsPlugin,
 ]);
 

--- a/apps/geolibre-desktop/src/main.tsx
+++ b/apps/geolibre-desktop/src/main.tsx
@@ -2,6 +2,7 @@ import "./lib/symbol-dispose-polyfill";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import "@geoman-io/maplibre-geoman-free/dist/maplibre-geoman.css";
+import "@maplibre/maplibre-gl-directions/dist/style.css";
 import "maplibre-gl-3d-tiles/style.css";
 import "maplibre-gl-basemap-control/style.css";
 import "maplibre-gl-components/style.css";

--- a/package-lock.json
+++ b/package-lock.json
@@ -3667,6 +3667,37 @@
         "kdbush": "^4.0.2"
       }
     },
+    "node_modules/@maplibre/maplibre-gl-directions": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-directions/-/maplibre-gl-directions-0.9.1.tgz",
+      "integrity": "sha512-gV0knkzbknQXvM1TEu/VXNUj71wrR19JlDzGPpmfrCvnPQW1/sVs8lvUPj2IS6yHHnWWxp9IiJ/kBNuUExifpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@placemarkio/polyline": "^1.2.0",
+        "nanoid": "^5.0.6"
+      },
+      "peerDependencies": {
+        "maplibre-gl": "^5.0.0"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-directions/node_modules/nanoid": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
+      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
       "version": "24.8.5",
       "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.8.5.tgz",
@@ -4042,6 +4073,18 @@
       "license": "MIT",
       "dependencies": {
         "@changesets/cli": "^2.29.7"
+      }
+    },
+    "node_modules/@placemarkio/polyline": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@placemarkio/polyline/-/polyline-1.2.0.tgz",
+      "integrity": "sha512-PjXntwUKQFTM/MgXIZHBOtuU2rAkmPgfrIxweOJEf1vyytQJNLDMI4YIRO3LUkt++F4TyAQHjPoRsteYa+gtVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      },
+      "peerDependencies": {
+        "@types/geojson": "*"
       }
     },
     "node_modules/@poppinss/colors": {
@@ -17742,6 +17785,7 @@
         "@esri/maplibre-arcgis": "^1.3.0",
         "@geolibre/core": "*",
         "@geoman-io/maplibre-geoman-free": "^0.7.1",
+        "@maplibre/maplibre-gl-directions": "^0.9.1",
         "@tauri-apps/api": "^2.11.0",
         "@tauri-apps/plugin-opener": "^2.5.4",
         "geotiff": "^3.0.5",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -22,6 +22,7 @@
     "@esri/maplibre-arcgis": "^1.3.0",
     "@geolibre/core": "*",
     "@geoman-io/maplibre-geoman-free": "^0.7.1",
+    "@maplibre/maplibre-gl-directions": "^0.9.1",
     "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-opener": "^2.5.4",
     "geotiff": "^3.0.5",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -103,6 +103,7 @@ export {
 export {
   DIRECTIONS_PLUGIN_ID,
   maplibreDirectionsPlugin,
+  restoreDirections,
 } from "./plugins/maplibre-directions";
 export {
   EFFECTS_PLUGIN_ID,

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -101,6 +101,10 @@ export {
 // re-exported: the app drives the panels through the functions above, and
 // the tests import the sync helpers from the module paths directly.
 export {
+  DIRECTIONS_PLUGIN_ID,
+  maplibreDirectionsPlugin,
+} from "./plugins/maplibre-directions";
+export {
   EFFECTS_PLUGIN_ID,
   maplibreEffectsPlugin,
   restoreEffects,

--- a/packages/plugins/src/plugins/maplibre-directions.ts
+++ b/packages/plugins/src/plugins/maplibre-directions.ts
@@ -1,0 +1,59 @@
+import type MapLibreGlDirections from "@maplibre/maplibre-gl-directions";
+import type { IControl } from "maplibre-gl";
+import type { GeoLibreAppAPI, GeoLibrePlugin } from "../types";
+
+/**
+ * Interactive routing via `@maplibre/maplibre-gl-directions`.
+ *
+ * Toggled from the Controls menu (off by default). When active, the user can
+ * click the map to add waypoints, drag them to reposition, and click a waypoint
+ * to remove it; routes come from the library's default OSRM demo server
+ * (`https://router.project-osrm.org`, driving only). The route is transient — it
+ * is not persisted in the project and is cleared when the tool is toggled off.
+ *
+ * The heavy routing library is lazy-imported on activate so it stays out of the
+ * main bundle.
+ */
+export const DIRECTIONS_PLUGIN_ID = "maplibre-gl-directions";
+
+let directions: MapLibreGlDirections | null = null;
+let loadingControl: IControl | null = null;
+// Bumped on every activate/deactivate. A lazy import that resolves with a stale
+// token (the user toggled off, or off then on, while it loaded) is discarded so
+// it doesn't attach a directions instance to a tool that is no longer active.
+let loadToken = 0;
+
+export const maplibreDirectionsPlugin: GeoLibrePlugin = {
+  id: DIRECTIONS_PLUGIN_ID,
+  name: "Directions",
+  version: "1.0.0",
+  activate: (app: GeoLibreAppAPI) => {
+    const map = app.getMap?.();
+    if (!map) return false;
+    const token = ++loadToken;
+    void import("@maplibre/maplibre-gl-directions")
+      .then(({ default: DirectionsClass, LoadingIndicatorControl }) => {
+        // Stale (toggled off/on during import) or already attached — discard.
+        if (token !== loadToken || directions) return;
+        const currentMap = app.getMap?.();
+        if (!currentMap) return;
+        directions = new DirectionsClass(currentMap);
+        directions.interactive = true;
+        loadingControl = new LoadingIndicatorControl(directions);
+        app.addMapControl(loadingControl, "top-right");
+      })
+      .catch((error) => {
+        console.warn("Could not load the Directions plugin.", error);
+      });
+  },
+  deactivate: (app: GeoLibreAppAPI) => {
+    // Invalidate any in-flight import so it doesn't reattach after teardown.
+    loadToken += 1;
+    if (loadingControl) {
+      app.removeMapControl(loadingControl);
+      loadingControl = null;
+    }
+    directions?.destroy();
+    directions = null;
+  },
+};

--- a/packages/plugins/src/plugins/maplibre-directions.ts
+++ b/packages/plugins/src/plugins/maplibre-directions.ts
@@ -1,5 +1,5 @@
 import type MapLibreGlDirections from "@maplibre/maplibre-gl-directions";
-import type { IControl } from "maplibre-gl";
+import type { IControl, Map as MapLibreMap } from "maplibre-gl";
 import type { GeoLibreAppAPI, GeoLibrePlugin } from "../types";
 
 /**
@@ -11,49 +11,85 @@ import type { GeoLibreAppAPI, GeoLibrePlugin } from "../types";
  * (`https://router.project-osrm.org`, driving only). The route is transient — it
  * is not persisted in the project and is cleared when the tool is toggled off.
  *
+ * Privacy note: waypoints are sent to the public OSRM demo server. This is
+ * surfaced to the user via the Controls menu item's tooltip and the README; a
+ * configurable/self-hosted routing server is a planned follow-up.
+ *
  * The heavy routing library is lazy-imported on activate so it stays out of the
  * main bundle.
  */
 export const DIRECTIONS_PLUGIN_ID = "maplibre-gl-directions";
 
 let directions: MapLibreGlDirections | null = null;
+// The map the current instance is bound to, so restoreDirections can detect a
+// map re-initialization (a brand-new Map object) and rebind.
+let directionsMap: MapLibreMap | null = null;
 let loadingControl: IControl | null = null;
-// Bumped on every activate/deactivate. A lazy import that resolves with a stale
+// Bumped on every attach/teardown. A lazy import that resolves with a stale
 // token (the user toggled off, or off then on, while it loaded) is discarded so
 // it doesn't attach a directions instance to a tool that is no longer active.
 let loadToken = 0;
+
+function attach(app: GeoLibreAppAPI): void {
+  const map = app.getMap?.();
+  if (!map) return;
+  const token = ++loadToken;
+  void import("@maplibre/maplibre-gl-directions")
+    .then(({ default: DirectionsClass, LoadingIndicatorControl }) => {
+      // Stale (toggled off/on during import) or already attached — discard.
+      if (token !== loadToken || directions) return;
+      const currentMap = app.getMap?.();
+      if (!currentMap) return;
+      directions = new DirectionsClass(currentMap);
+      directions.interactive = true;
+      directionsMap = currentMap;
+      loadingControl = new LoadingIndicatorControl(directions);
+      app.addMapControl(loadingControl, "top-right");
+    })
+    .catch((error) => {
+      console.error(
+        "Directions plugin failed to load; it stays toggled on but inactive.",
+        error,
+      );
+    });
+}
+
+function teardown(app: GeoLibreAppAPI): void {
+  // Invalidate any in-flight import so it doesn't reattach after teardown.
+  loadToken += 1;
+  if (loadingControl) {
+    app.removeMapControl(loadingControl);
+    loadingControl = null;
+  }
+  directions?.destroy();
+  directions = null;
+  directionsMap = null;
+}
+
+/**
+ * Keep the directions tool bound to the current map after a map re-init.
+ *
+ * Mirrors `restoreEffects`: the desktop shell calls this after restoring plugin
+ * state. Directions is off by default, so unlike the effects plugin it does not
+ * need a first-load kick — this only matters when it is active and the map
+ * object is replaced (a MapCanvas remount), where the manager would otherwise
+ * leave the instance bound to the destroyed old map. Idempotent.
+ */
+export function restoreDirections(app: GeoLibreAppAPI, active: boolean): void {
+  if (!active) {
+    teardown(app);
+    return;
+  }
+  const map = app.getMap?.();
+  if (directions && directionsMap === map) return; // already bound to this map
+  teardown(app);
+  attach(app);
+}
 
 export const maplibreDirectionsPlugin: GeoLibrePlugin = {
   id: DIRECTIONS_PLUGIN_ID,
   name: "Directions",
   version: "1.0.0",
-  activate: (app: GeoLibreAppAPI) => {
-    const map = app.getMap?.();
-    if (!map) return false;
-    const token = ++loadToken;
-    void import("@maplibre/maplibre-gl-directions")
-      .then(({ default: DirectionsClass, LoadingIndicatorControl }) => {
-        // Stale (toggled off/on during import) or already attached — discard.
-        if (token !== loadToken || directions) return;
-        const currentMap = app.getMap?.();
-        if (!currentMap) return;
-        directions = new DirectionsClass(currentMap);
-        directions.interactive = true;
-        loadingControl = new LoadingIndicatorControl(directions);
-        app.addMapControl(loadingControl, "top-right");
-      })
-      .catch((error) => {
-        console.warn("Could not load the Directions plugin.", error);
-      });
-  },
-  deactivate: (app: GeoLibreAppAPI) => {
-    // Invalidate any in-flight import so it doesn't reattach after teardown.
-    loadToken += 1;
-    if (loadingControl) {
-      app.removeMapControl(loadingControl);
-      loadingControl = null;
-    }
-    directions?.destroy();
-    directions = null;
-  },
+  activate: (app: GeoLibreAppAPI) => attach(app),
+  deactivate: (app: GeoLibreAppAPI) => teardown(app),
 };


### PR DESCRIPTION
Closes #229 — adds interactive routing via the official [`@maplibre/maplibre-gl-directions`](https://github.com/maplibre/maplibre-gl-directions) library.

### What it does
- A **Directions** toggle in the **Controls menu** (checkmark, off by default), like the Atmosphere Effects plugin.
- When active: **click the map to add waypoints, drag to reposition, click a waypoint to remove it**; a loading indicator shows while routing. Routes come from the library's default **OSRM demo server**.

### Implementation
- New `packages/plugins/src/plugins/maplibre-directions.ts`: **lazy-imports** the library on activate (keeping it off the main App bundle — it co-locates into the maplibre vendor chunk that already loads with the map), creates `new MapLibreGlDirections(map)` with `interactive = true` plus a `LoadingIndicatorControl`, and tears both down (`destroy()` + `removeMapControl`) on deactivate. A load token discards a lazy import that resolves after the tool was toggled off.
- Registered in `index.ts` + `usePlugins.ts`; surfaced as a Controls-menu checkmark and **excluded from the Plugins menu** to avoid a duplicate toggle.
- CSS in `main.tsx`. **No CSP change** — `connect-src ... https:` already covers `router.project-osrm.org` (verified).

### Verification
- `npm run build` + **236 frontend tests** + pre-commit pass; the routing library lands in the maplibre vendor chunk, not the App entry bundle.
- **Playwright** end-to-end: toggling Directions adds the ✓ and the control; clicking two map points renders a route (OSRM request to `router.project-osrm.org`, which returns CORS `*`) with waypoint/snappoint markers; toggling off removes the route, markers, and control; no console errors.

### Known limitations (follow-ups)
- The public OSRM demo server is **rate-limited and driving-only** — walking/cycling and production use need a custom OSRM/Mapbox-compatible routing server (a planned follow-up, along with a travel-mode selector).
- The drawn route is **transient** — not persisted in the `.geolibre.json` project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Directions plugin for interactive routing with waypoint add/remove via map clicks/drags.
  * Directions control is available in the Map controls dropdown and can be toggled on/off.
  * Directions state is preserved/restored when the map or project is reinitialized.

* **Documentation**
  * README updated to mention the Directions plugin and that it uses the public OSRM demo server for driving routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->