### PR TITLE
feat(sql): add in-browser PostGIS SQL engine via PGlite

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -22,6 +22,8 @@
     "@developmentseed/deck.gl-raster": "^0.7.0",
     "@duckdb/duckdb-wasm": "1.33.1-dev45.0",
     "@dvt3d/maplibre-three-plugin": "^1.6.0",
+    "@electric-sql/pglite": "^0.5.2",
+    "@electric-sql/pglite-postgis": "^0.2.2",
     "@geolibre/core": "*",
     "@geolibre/map": "*",
     "@geolibre/plugins": "*",

--- a/apps/geolibre-desktop/src/components/processing/SqlWorkspaceDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SqlWorkspaceDialog.tsx
@@ -31,9 +31,33 @@ import {
   SAMPLE_DATASET_URL,
   type SqlQueryResult,
 } from "../../lib/sql-workspace";
+import { runPostgisQuery } from "../../lib/pglite-workspace";
 import { saveBinaryFileWithFallback } from "../../lib/tauri-io";
 
 const CSV_MIME_TYPE = "text/csv";
+
+/** SQL engine backing the workspace. */
+type SqlEngine = "duckdb" | "postgis";
+
+const ENGINE_STORAGE_KEY = "geolibre.sqlWorkspace.engine";
+
+/** Load the last-used engine from localStorage, defaulting to DuckDB. */
+function loadEngine(): SqlEngine {
+  if (typeof window === "undefined") return "duckdb";
+  return window.localStorage.getItem(ENGINE_STORAGE_KEY) === "postgis"
+    ? "postgis"
+    : "duckdb";
+}
+
+/** Persist the chosen engine; ignore storage failures (quota/privacy mode). */
+function saveEngine(engine: SqlEngine): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(ENGINE_STORAGE_KEY, engine);
+  } catch {
+    // Best-effort persistence only.
+  }
+}
 
 // Cap how many result rows are rendered so a large result set cannot freeze the
 // UI; the full result is still used for export and add-as-layer.
@@ -68,6 +92,41 @@ const SAMPLE_QUERIES: ReadonlyArray<{ label: string; sql: string }> = [
   {
     label: "Largest countries by area (spatial)",
     sql: `SELECT NAME, ST_Area(geom) AS area\nFROM ${SAMPLE_DATASET_URL}\nORDER BY area DESC\nLIMIT 10;`,
+  },
+];
+
+// PostGIS examples. PGlite cannot read remote files, so these target registered
+// layer tables (replace `your_layer` with a name from "Queryable layers") plus a
+// couple of table-free spatial constructors. Every table query uses the `geom`
+// column the workspace creates on each registered layer.
+const POSTGIS_SAMPLE_QUERIES: ReadonlyArray<{ label: string; sql: string }> = [
+  {
+    label: "PostGIS version",
+    sql: "SELECT PostGIS_Full_Version() AS version;",
+  },
+  {
+    label: "Make a point (geometry)",
+    sql: "SELECT ST_SetSRID(ST_MakePoint(-115.1398, 36.1699), 4326) AS geom;",
+  },
+  {
+    label: "First rows of a layer",
+    sql: `SELECT *\nFROM your_layer\nLIMIT 10;`,
+  },
+  {
+    label: "Feature count",
+    sql: `SELECT COUNT(*) AS features\nFROM your_layer;`,
+  },
+  {
+    label: "Centroids of a layer (spatial)",
+    sql: `SELECT ST_Centroid(geom) AS geom\nFROM your_layer;`,
+  },
+  {
+    label: "Buffer features by 0.01 deg (spatial)",
+    sql: `SELECT ST_Buffer(geom, 0.01) AS geom\nFROM your_layer;`,
+  },
+  {
+    label: "Bounding box of a layer (spatial)",
+    sql: `SELECT ST_Envelope(ST_Collect(geom)) AS geom\nFROM your_layer;`,
   },
 ];
 
@@ -141,6 +200,7 @@ export function SqlWorkspaceDialog() {
   const layers = useAppStore((s) => s.layers);
   const addGeoJsonLayer = useAppStore((s) => s.addGeoJsonLayer);
 
+  const [engine, setEngine] = useState<SqlEngine>(loadEngine);
   const [sql, setSql] = useState(SAMPLE_QUERY);
   const [running, setRunning] = useState(false);
   const [exporting, setExporting] = useState(false);
@@ -151,6 +211,8 @@ export function SqlWorkspaceDialog() {
   const [layerName, setLayerName] = useState("");
 
   const tables = useMemo(() => previewLayerTables(layers), [layers]);
+  const sampleQueries =
+    engine === "postgis" ? POSTGIS_SAMPLE_QUERIES : SAMPLE_QUERIES;
 
   // `running` state lags a render behind, so a rapid second Ctrl+Enter could
   // read the stale `false` and fire a concurrent query. A ref is updated
@@ -172,7 +234,10 @@ export function SqlWorkspaceDialog() {
     setError(null);
     setNotice(null);
     try {
-      const queryResult = await runSqlQuery(trimmed, layers);
+      const queryResult =
+        engine === "postgis"
+          ? await runPostgisQuery(trimmed, layers)
+          : await runSqlQuery(trimmed, layers);
       setResult(queryResult);
     } catch (err) {
       setResult(null);
@@ -276,8 +341,18 @@ export function SqlWorkspaceDialog() {
         <DialogHeader>
           <DialogTitle>SQL Workspace</DialogTitle>
           <DialogDescription>
-            Run DuckDB SQL against loaded layers, files, and URLs. The spatial
-            extension is loaded, so {"ST_*"} functions are available.
+            {engine === "postgis" ? (
+              <>
+                Run PostGIS SQL against loaded layers. The PostGIS extension is
+                loaded, so {"ST_*"} functions are available. The first run loads
+                a ~19 MB database engine.
+              </>
+            ) : (
+              <>
+                Run DuckDB SQL against loaded layers, files, and URLs. The spatial
+                extension is loaded, so {"ST_*"} functions are available.
+              </>
+            )}
           </DialogDescription>
         </DialogHeader>
 
@@ -295,6 +370,11 @@ export function SqlWorkspaceDialog() {
                   </span>
                 ))}
               </p>
+            ) : engine === "postgis" ? (
+              <p className="text-xs text-muted-foreground">
+                No vector layers are loaded as tables yet. Load a vector layer to
+                query it with PostGIS.
+              </p>
             ) : (
               <p className="text-xs text-muted-foreground">
                 No vector layers are loaded as tables yet. You can still read
@@ -303,6 +383,20 @@ export function SqlWorkspaceDialog() {
               </p>
             )}
             <div className="ml-auto flex items-center gap-2">
+              <Select
+                aria-label="SQL engine"
+                className="h-8 w-auto text-xs"
+                value={engine}
+                onChange={(event) => {
+                  const next =
+                    event.target.value === "postgis" ? "postgis" : "duckdb";
+                  setEngine(next);
+                  saveEngine(next);
+                }}
+              >
+                <option value="duckdb">Engine: DuckDB</option>
+                <option value="postgis">Engine: PostGIS</option>
+              </Select>
               {history.length > 0 ? (
                 <Select
                   aria-label="Reuse a query from history"
@@ -329,14 +423,14 @@ export function SqlWorkspaceDialog() {
                 value=""
                 onChange={(event) => {
                   const index = Number(event.target.value);
-                  const sample = SAMPLE_QUERIES[index];
+                  const sample = sampleQueries[index];
                   if (sample) setSql(sample.sql);
                 }}
               >
                 <option value="" disabled>
                   Sample queries…
                 </option>
-                {SAMPLE_QUERIES.map((sample, index) => (
+                {sampleQueries.map((sample, index) => (
                   <option key={sample.label} value={index}>
                     {sample.label}
                   </option>

--- a/apps/geolibre-desktop/src/lib/pglite-sql.ts
+++ b/apps/geolibre-desktop/src/lib/pglite-sql.ts
@@ -1,0 +1,180 @@
+import type { Feature } from "geojson";
+
+// Pure SQL-building helpers for the PGlite + PostGIS workspace. This module has
+// no heavy/Vite-only imports (no DuckDB `?url` assets), so it can be unit-tested
+// under `node --test` directly. The runtime engine lives in pglite-workspace.ts.
+
+// Geometry column name created on every registered table. PostGIS geometry is
+// kept separate from feature properties, so a `geom` collision is rare; when a
+// property is already named `geom`, a non-colliding fallback is chosen.
+const DEFAULT_GEOMETRY_COLUMN = "geom";
+
+/** Quote a Postgres identifier (double quotes, doubling embedded quotes). */
+export function quoteIdentifier(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`;
+}
+
+/** Postgres column type chosen for a flattened GeoJSON property. */
+export type PgColumnType = "double precision" | "boolean" | "jsonb" | "text";
+
+/** A property flattened to a Postgres table column. */
+export interface PgColumn {
+  /** Property key, used verbatim as the column name. */
+  name: string;
+  /** Inferred Postgres column type. */
+  type: PgColumnType;
+}
+
+/**
+ * Choose a Postgres column type for a single property given every value it takes
+ * across a layer's features. The rule favours the most specific type that fits
+ * all non-null values: numeric -> double precision, boolean -> boolean, anything
+ * containing an object/array -> jsonb, otherwise text. An all-null property
+ * defaults to text.
+ *
+ * @param values Non-null/undefined values are considered; null/undefined skipped.
+ * @returns The inferred Postgres column type.
+ */
+export function classifyColumnType(values: unknown[]): PgColumnType {
+  const present = values.filter(
+    (value) => value !== null && value !== undefined,
+  );
+  if (present.length === 0) return "text";
+  if (present.some((value) => typeof value === "object")) return "jsonb";
+  if (
+    present.every(
+      (value) => typeof value === "number" && Number.isFinite(value),
+    )
+  ) {
+    return "double precision";
+  }
+  if (present.every((value) => typeof value === "boolean")) return "boolean";
+  return "text";
+}
+
+/**
+ * Infer the flattened property columns for a layer's features. Keys are taken in
+ * first-seen order across all features so the column order is stable, and each
+ * key's type is inferred from every value it takes via {@link classifyColumnType}.
+ *
+ * @param features GeoJSON features whose `properties` are flattened to columns.
+ * @returns The columns in stable order; never includes a geometry column.
+ */
+export function inferPropertyColumns(features: Feature[]): PgColumn[] {
+  const order: string[] = [];
+  const valuesByKey = new Map<string, unknown[]>();
+  for (const feature of features) {
+    const properties = feature.properties;
+    if (!properties) continue;
+    for (const [key, value] of Object.entries(properties)) {
+      let bucket = valuesByKey.get(key);
+      if (!bucket) {
+        bucket = [];
+        valuesByKey.set(key, bucket);
+        order.push(key);
+      }
+      bucket.push(value);
+    }
+  }
+  return order.map((name) => ({
+    name,
+    type: classifyColumnType(valuesByKey.get(name) ?? []),
+  }));
+}
+
+/**
+ * Pick a geometry column name that does not collide with any property column.
+ * Prefers `geom`, then `geometry`, then `geom_2`, `geom_3`, ... so the generated
+ * tables use a predictable, query-friendly name in the common (no-collision) case.
+ *
+ * @param propertyNames Names already used by flattened property columns.
+ * @returns A geometry column name guaranteed not to be in `propertyNames`.
+ */
+export function pickGeometryColumnName(
+  propertyNames: Iterable<string>,
+): string {
+  const used = new Set(propertyNames);
+  if (!used.has(DEFAULT_GEOMETRY_COLUMN)) return DEFAULT_GEOMETRY_COLUMN;
+  if (!used.has("geometry")) return "geometry";
+  let suffix = 2;
+  while (used.has(`${DEFAULT_GEOMETRY_COLUMN}_${suffix}`)) suffix += 1;
+  return `${DEFAULT_GEOMETRY_COLUMN}_${suffix}`;
+}
+
+/**
+ * Build the `CREATE TABLE` statement for a registered layer: one column per
+ * inferred property plus a `geometry(Geometry, 4326)` geometry column.
+ *
+ * @param qualifiedTable Schema-qualified, already-quoted table name.
+ * @param columns Inferred property columns.
+ * @param geometryColumn Name of the geometry column to append.
+ * @returns A single `CREATE TABLE` SQL statement.
+ */
+export function buildCreateTableStatement(
+  qualifiedTable: string,
+  columns: PgColumn[],
+  geometryColumn: string,
+): string {
+  const columnDefs = columns.map(
+    (column) => `${quoteIdentifier(column.name)} ${column.type}`,
+  );
+  columnDefs.push(
+    `${quoteIdentifier(geometryColumn)} geometry(Geometry, 4326)`,
+  );
+  return `CREATE TABLE ${qualifiedTable} (${columnDefs.join(", ")})`;
+}
+
+/** Coerce a property value into a bind parameter matching its column type. */
+function toBindValue(value: unknown, type: PgColumnType): unknown {
+  if (value === null || value === undefined) return null;
+  if (type === "jsonb") return JSON.stringify(value);
+  if (type === "text") {
+    if (typeof value === "string") return value;
+    return typeof value === "object" ? JSON.stringify(value) : String(value);
+  }
+  // double precision / boolean values are already primitives PGlite serializes.
+  return value;
+}
+
+/**
+ * Build one batched, parameterized `INSERT` for a slice of features. Property
+ * values bind as plain parameters; the geometry binds through
+ * `ST_SetSRID(ST_GeomFromGeoJSON($n), 4326)` so each feature's GeoJSON geometry
+ * becomes a 4326 PostGIS geometry (a null geometry yields a null cell).
+ *
+ * @param qualifiedTable Schema-qualified, already-quoted table name.
+ * @param columns Inferred property columns, in insert order.
+ * @param geometryColumn Name of the geometry column.
+ * @param features Features to insert (one row each).
+ * @returns The statement text and its ordered bind parameters.
+ */
+export function buildInsertChunk(
+  qualifiedTable: string,
+  columns: PgColumn[],
+  geometryColumn: string,
+  features: Feature[],
+): { text: string; params: unknown[] } {
+  const columnList = [
+    ...columns.map((column) => quoteIdentifier(column.name)),
+    quoteIdentifier(geometryColumn),
+  ].join(", ");
+  const params: unknown[] = [];
+  const rows: string[] = [];
+  for (const feature of features) {
+    const placeholders: string[] = [];
+    const properties = feature.properties ?? {};
+    for (const column of columns) {
+      params.push(toBindValue(properties[column.name], column.type));
+      placeholders.push(`$${params.length}`);
+    }
+    params.push(feature.geometry ? JSON.stringify(feature.geometry) : null);
+    placeholders.push(
+      `ST_SetSRID(ST_GeomFromGeoJSON($${params.length}), 4326)`,
+    );
+    rows.push(`(${placeholders.join(", ")})`);
+  }
+  return {
+    text: `INSERT INTO ${qualifiedTable} (${columnList}) VALUES ${rows.join(", ")}`,
+    params,
+  };
+}

--- a/apps/geolibre-desktop/src/lib/pglite-workspace.ts
+++ b/apps/geolibre-desktop/src/lib/pglite-workspace.ts
@@ -1,0 +1,254 @@
+import type { GeoLibreLayer } from "@geolibre/core";
+import type { FeatureCollection } from "geojson";
+import {
+  buildCreateTableStatement,
+  buildInsertChunk,
+  inferPropertyColumns,
+  pickGeometryColumnName,
+  quoteIdentifier,
+} from "./pglite-sql";
+import {
+  assignTableNames,
+  cleanStatement,
+  containsMultipleStatements,
+  GEOMETRY_JSON_COLUMN,
+  normalizeRow,
+  rowsToFeatureCollection,
+  type SqlQueryResult,
+  type SqlWorkspaceTable,
+} from "./sql-workspace";
+
+// Schema that holds every layer table. It is dropped and recreated on each run
+// so the exposed tables always match the current layers (and tables for removed
+// layers never linger), mirroring how the DuckDB engine rebuilds TEMP tables.
+const WORKSPACE_SCHEMA = "geolibre";
+
+// Rows are inserted in batches so a layer with many features does not build one
+// enormous parameterized statement. Postgres caps bind parameters at 65535, so a
+// wide table also needs a smaller batch: the effective size is the lesser of this
+// row cap and the per-statement parameter budget.
+const INSERT_CHUNK_ROWS = 500;
+const MAX_BIND_PARAMS = 65535;
+
+/** Rows per INSERT batch, shrinking for wide tables to stay under the param cap. */
+function insertChunkRows(columnCount: number): number {
+  // Each row binds one parameter per property column plus one for the geometry.
+  const paramsPerRow = columnCount + 1;
+  return Math.max(1, Math.min(INSERT_CHUNK_ROWS, Math.floor(MAX_BIND_PARAMS / paramsPerRow)));
+}
+
+// Minimal structural view of the PGlite instance this module relies on, so the
+// dynamic import does not force the whole app to depend on PGlite's types.
+interface PgliteLike {
+  query: (
+    sql: string,
+    params?: unknown[],
+  ) => Promise<{
+    rows: Record<string, unknown>[];
+    fields: { name: string; dataTypeID: number }[];
+  }>;
+  exec: (sql: string) => Promise<unknown>;
+}
+
+interface PgliteState {
+  pg: PgliteLike;
+  /** OID of the PostGIS `geometry` type, used to detect geometry columns. */
+  geometryOid: number | null;
+}
+
+// Memoized singleton: the ~18.8 MB PostGIS WASM bundle loads only on first use.
+let statePromise: Promise<PgliteState> | null = null;
+
+// PGlite executes statements on a single instance; chain whole register+run
+// operations so concurrent dialog runs cannot interleave schema resets.
+let queue: Promise<unknown> = Promise.resolve();
+
+function runExclusive<T>(task: () => Promise<T>): Promise<T> {
+  const result = queue.then(task, task);
+  queue = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
+}
+
+async function getState(): Promise<PgliteState> {
+  if (!statePromise) {
+    statePromise = (async () => {
+      const { PGlite } = await import("@electric-sql/pglite");
+      const { postgis } = await import("@electric-sql/pglite-postgis");
+      const pg = new PGlite({
+        extensions: { postgis },
+      }) as unknown as PgliteLike;
+      await pg.exec("CREATE EXTENSION IF NOT EXISTS postgis;");
+      const oidResult = await pg.query(
+        "SELECT oid FROM pg_type WHERE typname = 'geometry'",
+      );
+      const oid = oidResult.rows[0]?.oid;
+      return {
+        pg,
+        geometryOid: typeof oid === "number" ? oid : Number(oid) || null,
+      };
+    })().catch((err) => {
+      // Reset so a failed load (e.g. an aborted bundle fetch) can be retried.
+      statePromise = null;
+      throw err;
+    });
+  }
+  return statePromise;
+}
+
+/**
+ * Drop and recreate the workspace schema, then register every layer that carries
+ * an in-memory GeoJSON FeatureCollection as a table inside it, and point the
+ * search path at the schema so the user can reference tables by bare name.
+ *
+ * @param pg The PGlite instance.
+ * @param layers Current app layers; those without `geojson` are skipped.
+ * @returns The registered tables, in the same naming as the DuckDB engine.
+ */
+async function registerLayerTables(
+  pg: PgliteLike,
+  layers: GeoLibreLayer[],
+): Promise<SqlWorkspaceTable[]> {
+  await pg.exec(
+    `DROP SCHEMA IF EXISTS ${quoteIdentifier(WORKSPACE_SCHEMA)} CASCADE; ` +
+      `CREATE SCHEMA ${quoteIdentifier(WORKSPACE_SCHEMA)}; ` +
+      `SET search_path TO ${quoteIdentifier(WORKSPACE_SCHEMA)}, public;`,
+  );
+
+  const registered: SqlWorkspaceTable[] = [];
+  for (const { layer, tableName } of assignTableNames(layers)) {
+    const collection = layer.geojson as FeatureCollection | undefined;
+    const features = collection?.features ?? [];
+    const qualifiedTable = `${quoteIdentifier(WORKSPACE_SCHEMA)}.${quoteIdentifier(tableName)}`;
+    const columns = inferPropertyColumns(features);
+    const geometryColumn = pickGeometryColumnName(columns.map((c) => c.name));
+    await pg.query(
+      buildCreateTableStatement(qualifiedTable, columns, geometryColumn),
+    );
+    const chunkRows = insertChunkRows(columns.length);
+    for (let i = 0; i < features.length; i += chunkRows) {
+      const chunk = buildInsertChunk(
+        qualifiedTable,
+        columns,
+        geometryColumn,
+        features.slice(i, i + chunkRows),
+      );
+      await pg.query(chunk.text, chunk.params);
+    }
+    registered.push({ tableName, layerName: layer.name });
+  }
+  return registered;
+}
+
+interface DescribedQuery {
+  columnNames: string[];
+  geometryColumn: string | null;
+}
+
+/**
+ * Describe the user's statement to learn its result columns and find the geometry
+ * column (the first whose type OID matches PostGIS `geometry`). Returns null when
+ * the statement is not a query that can be wrapped in a FROM subquery (e.g. DDL),
+ * which the caller then runs directly without geometry handling.
+ */
+async function describeQuery(
+  pg: PgliteLike,
+  geometryOid: number | null,
+  statement: string,
+): Promise<DescribedQuery | null> {
+  try {
+    const described = await pg.query(
+      `SELECT * FROM (${statement}) AS ${quoteIdentifier("__geolibre_sql_subquery")} LIMIT 0`,
+    );
+    const columnNames = described.fields.map((field) => field.name);
+    const geometryColumn =
+      geometryOid === null
+        ? null
+        : (described.fields.find((field) => field.dataTypeID === geometryOid)
+            ?.name ?? null);
+    return { columnNames, geometryColumn };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Run a single SQL statement against the embedded PGlite + PostGIS engine with
+ * every GeoJSON-backed layer registered as a table.
+ *
+ * When the result has a PostGIS geometry column, geometry is rendered as WKT in
+ * the grid rows and a GeoJSON FeatureCollection is built (via `ST_AsGeoJSON`) for
+ * the add-as-layer and export paths. Coordinates are assumed/declared as WGS84
+ * (EPSG:4326). The returned shape matches the DuckDB engine's {@link SqlQueryResult}
+ * so the dialog renders both engines identically.
+ *
+ * @param sql The SQL statement to execute.
+ * @param layers Current app layers exposed as queryable tables.
+ * @returns Columns, rows, row count, geometry column name, and GeoJSON result.
+ * @throws Whatever PostGIS throws for invalid SQL (surfaced to the caller).
+ */
+export async function runPostgisQuery(
+  sql: string,
+  layers: GeoLibreLayer[],
+): Promise<SqlQueryResult> {
+  const cleaned = cleanStatement(sql);
+  if (containsMultipleStatements(cleaned)) {
+    throw new Error(
+      "Only a single SQL statement is supported. Remove any intermediate semicolons.",
+    );
+  }
+
+  return runExclusive(async () => {
+    const { pg, geometryOid } = await getState();
+    await registerLayerTables(pg, layers);
+
+    const described = await describeQuery(pg, geometryOid, cleaned);
+    const geometryColumn = described?.geometryColumn ?? null;
+
+    if (described && geometryColumn) {
+      const geomId = quoteIdentifier(geometryColumn);
+      const sub = quoteIdentifier("__geolibre_sql_subquery");
+      const hiddenId = quoteIdentifier(GEOMETRY_JSON_COLUMN);
+      // Build an explicit projection (Postgres has no DuckDB `SELECT * REPLACE`):
+      // pass each column through, but render the geometry column as WKT text for
+      // the grid, and append the hidden GeoJSON column for the layer/export path.
+      const projection = described.columnNames
+        .filter((name) => name !== GEOMETRY_JSON_COLUMN)
+        .map((name) => {
+          const id = quoteIdentifier(name);
+          return name === geometryColumn
+            ? `ST_AsText(${sub}.${geomId}) AS ${geomId}`
+            : `${sub}.${id} AS ${id}`;
+        });
+      projection.push(`ST_AsGeoJSON(${sub}.${geomId}) AS ${hiddenId}`);
+      const result = await pg.query(
+        `SELECT ${projection.join(", ")} FROM (${cleaned}) AS ${sub}`,
+      );
+      const columns = result.fields
+        .map((field) => field.name)
+        .filter((name) => name !== GEOMETRY_JSON_COLUMN);
+      const geojson = rowsToFeatureCollection(result.rows, geometryColumn);
+      const rows = result.rows.map((row) => normalizeRow(row, columns));
+      return {
+        columns,
+        rows,
+        rowCount: rows.length,
+        geometryColumn,
+        geojson,
+      } satisfies SqlQueryResult;
+    }
+
+    const result = await pg.query(cleaned);
+    const columns = result.fields.map((field) => field.name);
+    const rows = result.rows.map((row) => normalizeRow(row, columns));
+    return {
+      columns,
+      rows,
+      rowCount: rows.length,
+      geometryColumn: null,
+      geojson: null,
+    } satisfies SqlQueryResult;
+  });
+}

--- a/apps/geolibre-desktop/src/lib/sql-workspace.ts
+++ b/apps/geolibre-desktop/src/lib/sql-workspace.ts
@@ -18,7 +18,7 @@ import {
 // GeoJSON for the "Add as layer" / export paths without disturbing the columns
 // the user sees in the results grid. This is a reserved name: a user column of
 // the same name is filtered out of both the grid and the GeoJSON properties.
-const GEOMETRY_JSON_COLUMN = "__geolibre_sql_geometry_geojson";
+export const GEOMETRY_JSON_COLUMN = "__geolibre_sql_geometry_geojson";
 
 // Reserved alias wrapping the user's statement when geometry is detected; kept
 // deliberately obscure so it does not collide with a user's own CTE/subquery.
@@ -126,7 +126,7 @@ function sanitizeTableName(layerName: string, layerId: string): string {
  * numeric suffix on collision. Shared by registration and the UI preview so the
  * names cannot drift.
  */
-function assignTableNames(
+export function assignTableNames(
   layers: GeoLibreLayer[],
 ): Array<{ layer: GeoLibreLayer; tableName: string }> {
   const assigned: Array<{ layer: GeoLibreLayer; tableName: string }> = [];
@@ -222,7 +222,7 @@ function columnNamesFromResult(result: {
  * matching the loader's `normalizePropertyValue`; otherwise a nested bigint
  * would make `JSON.stringify` throw during CSV/GeoJSON export.
  */
-function normalizeValue(value: unknown): unknown {
+export function normalizeValue(value: unknown): unknown {
   if (typeof value === "bigint") {
     const asNumber = Number(value);
     return Number.isSafeInteger(asNumber) ? asNumber : value.toString();
@@ -238,7 +238,7 @@ function normalizeValue(value: unknown): unknown {
   return value;
 }
 
-function normalizeRow(
+export function normalizeRow(
   row: Record<string, unknown>,
   columns: string[],
 ): Record<string, unknown> {
@@ -310,7 +310,7 @@ async function describeQuery(
  * (e.g. `cleanStatement`) pass `false` so a trailing string literal is not
  * mistaken for trailing whitespace.
  */
-function maskSqlLiterals(sql: string, blankLiterals = true): string {
+export function maskSqlLiterals(sql: string, blankLiterals = true): string {
   const out = sql.split("");
   const blank = (start: number, end: number): void => {
     for (let k = start; k < end && k < out.length; k += 1) {
@@ -370,7 +370,7 @@ function maskSqlLiterals(sql: string, blankLiterals = true): string {
  * geometry detection. Operates via {@link maskSqlLiterals} so a semicolon or
  * comment inside a literal is never mistaken for the terminator.
  */
-function cleanStatement(sql: string): string {
+export function cleanStatement(sql: string): string {
   const src = sql.trim();
   // Blank comments only (keep string literals): trimming the mask then drops a
   // trailing comment without mistaking a trailing string literal — e.g. the
@@ -388,7 +388,7 @@ function cleanStatement(sql: string): string {
  * so the caller rejects multi-statement input instead of discarding earlier
  * results. Expects a statement already cleaned of its trailing semicolon.
  */
-function containsMultipleStatements(sql: string): boolean {
+export function containsMultipleStatements(sql: string): boolean {
   const masked = maskSqlLiterals(sql);
   const semicolon = masked.indexOf(";");
   // A semicolon is only a statement separator when real content follows it;
@@ -510,7 +510,7 @@ async function registerRemoteSources(
   return { statement: rewritten, readerCalls };
 }
 
-function rowsToFeatureCollection(
+export function rowsToFeatureCollection(
   rows: Record<string, unknown>[],
   geometryColumn: string,
 ): FeatureCollection {

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -42,6 +42,9 @@ const RADIX_OPTIMIZE_EXCLUDES = [
 function manualChunks(id: string): string | undefined {
   if (!id.includes("node_modules")) return undefined;
   if (id.includes("@duckdb/duckdb-wasm")) return "duckdb";
+  // PGlite + the ~18.8 MB PostGIS extension only load when the user picks the
+  // PostGIS SQL engine; keep them in their own lazily-fetched chunk.
+  if (id.includes("@electric-sql/pglite")) return "pglite";
   if (id.includes("maplibre-gl-earth-engine")) {
     return "maplibre-earth-engine";
   }
@@ -345,7 +348,13 @@ export default defineConfig({
   },
   envPrefix: ["VITE_", "TAURI_"],
   optimizeDeps: {
-    exclude: RADIX_OPTIMIZE_EXCLUDES,
+    // PGlite ships its own WASM + filesystem bundles and must not be pre-bundled
+    // by esbuild, which mangles those asset references (per PGlite's Vite guide).
+    exclude: [
+      ...RADIX_OPTIMIZE_EXCLUDES,
+      "@electric-sql/pglite",
+      "@electric-sql/pglite-postgis",
+    ],
   },
   build: {
     target: "esnext",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,8 @@
         "@developmentseed/deck.gl-raster": "^0.7.0",
         "@duckdb/duckdb-wasm": "1.33.1-dev45.0",
         "@dvt3d/maplibre-three-plugin": "^1.6.0",
+        "@electric-sql/pglite": "^0.5.2",
+        "@electric-sql/pglite-postgis": "^0.2.2",
         "@geolibre/core": "*",
         "@geolibre/map": "*",
         "@geolibre/plugins": "*",
@@ -1303,6 +1305,21 @@
       "dependencies": {
         "apache-arrow": "^17.0.0",
         "qs": "^6.14.1"
+      }
+    },
+    "node_modules/@electric-sql/pglite": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.5.2.tgz",
+      "integrity": "sha512-y6ySdFE7FQB7BkVaSNaPINgY7mXCyvi+3GQB5ySX9WGwgrdh31WXMP5RM40oAyYff47lIr7xdcW8UbCW5NHDmw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@electric-sql/pglite-postgis": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-postgis/-/pglite-postgis-0.2.2.tgz",
+      "integrity": "sha512-AS/gYwM/bnYzhXEoGhncXNvErf6a4NcMs2RXUw8rbp2FXRP2QNx0y5KHH3ArEKQ60SY9259Vp2gvwKh5479+1A==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@electric-sql/pglite": "0.5.2"
       }
     },
     "node_modules/@emnapi/core": {

--- a/tests/pglite-workspace.test.ts
+++ b/tests/pglite-workspace.test.ts
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Feature } from "geojson";
+import {
+  buildCreateTableStatement,
+  buildInsertChunk,
+  classifyColumnType,
+  inferPropertyColumns,
+  pickGeometryColumnName,
+} from "../apps/geolibre-desktop/src/lib/pglite-sql";
+
+function feature(
+  properties: Record<string, unknown> | null,
+  geometry: Feature["geometry"] = { type: "Point", coordinates: [0, 0] },
+): Feature {
+  return { type: "Feature", properties, geometry };
+}
+
+describe("classifyColumnType", () => {
+  it("defaults an all-null property to text", () => {
+    assert.equal(classifyColumnType([null, undefined]), "text");
+    assert.equal(classifyColumnType([]), "text");
+  });
+
+  it("picks double precision only when every value is a finite number", () => {
+    assert.equal(classifyColumnType([1, 2.5, null]), "double precision");
+    assert.equal(classifyColumnType([1, "2"]), "text");
+    assert.equal(classifyColumnType([1, Number.NaN]), "text");
+  });
+
+  it("picks boolean only when every value is boolean", () => {
+    assert.equal(classifyColumnType([true, false, null]), "boolean");
+    assert.equal(classifyColumnType([true, 1]), "text");
+  });
+
+  it("picks jsonb when any value is an object or array", () => {
+    assert.equal(classifyColumnType([{ a: 1 }, null]), "jsonb");
+    assert.equal(classifyColumnType([[1, 2], "x"]), "jsonb");
+  });
+});
+
+describe("inferPropertyColumns", () => {
+  it("keeps first-seen key order across features and infers per-key types", () => {
+    const columns = inferPropertyColumns([
+      feature({ name: "a", pop: 10, active: true }),
+      feature({ name: "b", pop: 20, active: false, extra: { nested: 1 } }),
+    ]);
+    assert.deepEqual(columns, [
+      { name: "name", type: "text" },
+      { name: "pop", type: "double precision" },
+      { name: "active", type: "boolean" },
+      { name: "extra", type: "jsonb" },
+    ]);
+  });
+
+  it("ignores features with null properties", () => {
+    const columns = inferPropertyColumns([feature(null), feature({ id: 1 })]);
+    assert.deepEqual(columns, [{ name: "id", type: "double precision" }]);
+  });
+});
+
+describe("pickGeometryColumnName", () => {
+  it("prefers geom when free", () => {
+    assert.equal(pickGeometryColumnName(["name", "pop"]), "geom");
+  });
+
+  it("falls back when geom (and geometry) are taken", () => {
+    assert.equal(pickGeometryColumnName(["geom"]), "geometry");
+    assert.equal(pickGeometryColumnName(["geom", "geometry"]), "geom_2");
+    assert.equal(
+      pickGeometryColumnName(["geom", "geometry", "geom_2"]),
+      "geom_3",
+    );
+  });
+});
+
+describe("buildCreateTableStatement", () => {
+  it("quotes identifiers and appends a 4326 geometry column", () => {
+    const sql = buildCreateTableStatement(
+      '"geolibre"."cities"',
+      [
+        { name: "name", type: "text" },
+        { name: "pop", type: "double precision" },
+      ],
+      "geom",
+    );
+    assert.equal(
+      sql,
+      'CREATE TABLE "geolibre"."cities" ("name" text, "pop" double precision, ' +
+        '"geom" geometry(Geometry, 4326))',
+    );
+  });
+
+  it("escapes embedded double quotes in column names", () => {
+    const sql = buildCreateTableStatement(
+      '"t"',
+      [{ name: 'we"ird', type: "text" }],
+      "geom",
+    );
+    assert.match(sql, /"we""ird" text/);
+  });
+});
+
+describe("buildInsertChunk", () => {
+  it("binds property values and wraps geometry in ST_GeomFromGeoJSON", () => {
+    const point = { type: "Point", coordinates: [1, 2] } as const;
+    const { text, params } = buildInsertChunk(
+      '"t"',
+      [
+        { name: "name", type: "text" },
+        { name: "pop", type: "double precision" },
+        { name: "tags", type: "jsonb" },
+      ],
+      "geom",
+      [feature({ name: "a", pop: 5, tags: { x: 1 } }, point)],
+    );
+    assert.equal(
+      text,
+      'INSERT INTO "t" ("name", "pop", "tags", "geom") VALUES ' +
+        "($1, $2, $3, ST_SetSRID(ST_GeomFromGeoJSON($4), 4326))",
+    );
+    assert.deepEqual(params, ["a", 5, '{"x":1}', JSON.stringify(point)]);
+  });
+
+  it("emits a null geometry parameter when a feature has no geometry", () => {
+    const { params } = buildInsertChunk(
+      '"t"',
+      [{ name: "id", type: "double precision" }],
+      "geom",
+      [feature({ id: 1 }, null)],
+    );
+    assert.deepEqual(params, [1, null]);
+  });
+
+  it("renumbers placeholders across multiple rows", () => {
+    const { text, params } = buildInsertChunk(
+      '"t"',
+      [{ name: "id", type: "double precision" }],
+      "geom",
+      [
+        feature({ id: 1 }, { type: "Point", coordinates: [0, 0] }),
+        feature({ id: 2 }, { type: "Point", coordinates: [1, 1] }),
+      ],
+    );
+    assert.equal(
+      text,
+      'INSERT INTO "t" ("id", "geom") VALUES ' +
+        "($1, ST_SetSRID(ST_GeomFromGeoJSON($2), 4326)), " +
+        "($3, ST_SetSRID(ST_GeomFromGeoJSON($4), 4326))",
+    );
+    assert.equal(params.length, 4);
+  });
+
+  it("stringifies non-string scalars for text columns", () => {
+    const { params } = buildInsertChunk(
+      '"t"',
+      [{ name: "mixed", type: "text" }],
+      "geom",
+      [feature({ mixed: 42 }, null)],
+    );
+    assert.deepEqual(params, ["42", null]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an in-browser **PostGIS SQL engine** (PGlite + `@electric-sql/pglite-postgis`) alongside the existing DuckDB engine in the SQL Workspace, selectable via an **Engine** dropdown. Users can now run real PostGIS `ST_*` SQL entirely client-side, with no server or Martin detour. Works in both the web build and the Tauri desktop app (shared React app).

The engine reuses the same `SqlQueryResult` contract as the DuckDB path, so the results grid, CSV/GeoParquet export, and "Add as layer" work unchanged.

The PostGIS extension is experimental and ships a ~19 MB bundle, so it is **lazy-loaded** only when the user first selects the PostGIS engine and runs a query. PGlite cannot read remote files/URLs (no `read_parquet`/`ST_Read` httpfs), so this engine targets the loaded layer tables.

## Changes

**Added**
- `apps/geolibre-desktop/src/lib/pglite-sql.ts` — dependency-free SQL builders (column type inference, `CREATE TABLE`/`INSERT` generation). Split out so they are unit-testable without DuckDB's Vite-only `?url` imports.
- `apps/geolibre-desktop/src/lib/pglite-workspace.ts` — `runPostgisQuery`: singleton PGlite + PostGIS, per-run schema reset + layer registration, geometry-column detection by type OID, GeoJSON round-trip.
- `tests/pglite-workspace.test.ts` — 14 unit tests for the SQL builders.

**Edited**
- `sql-workspace.ts` — export the engine-agnostic helpers (`cleanStatement`, `normalizeRow`, `rowsToFeatureCollection`, `assignTableNames`, etc.) for reuse.
- `SqlWorkspaceDialog.tsx` — engine selector (persisted to localStorage), dispatch, engine-aware description/hint and PostGIS sample queries.
- `vite.config.ts` — `pglite` manual chunk + `optimizeDeps.exclude`.
- `package.json` — adds `@electric-sql/pglite` and `@electric-sql/pglite-postgis`.

## How it works

- Each layer with in-memory GeoJSON is registered as a table in a `geolibre` schema that is dropped/recreated per run (so tables track current layers). Properties are flattened to typed columns (numeric → `double precision`, boolean → `boolean`, nested → `jsonb`, else `text`) plus a `geom geometry(Geometry, 4326)` column built via `ST_SetSRID(ST_GeomFromGeoJSON(...), 4326)`.
- The geometry column is detected by matching result field type OIDs against the PostGIS `geometry` type OID; when present, geometry renders as WKT in the grid and as GeoJSON (`ST_AsGeoJSON`) for the layer/export paths.

## CSP

No CSP change needed: the existing Tauri CSP already grants `'wasm-unsafe-eval'`, `blob:` script/worker sources, and `worker-src blob: 'self'`. PGlite assets are bundled (same-origin, resolved via `import.meta.url`).

## Verification

- `npm run test:frontend` — 240 existing + 14 new tests pass.
- `npm run build` (tsc + vite) — type-checks and bundles; PGlite WASM/data + the 19 MB `postgis.tar.gz` emit as lazy-loaded, same-origin assets.
- `pre-commit run --files ...` — passes including the full `npm build` hook.
- Real PGlite+PostGIS round-trip validated in Node (geometry OID detection, `ST_GeomFromGeoJSON` insert, `ST_Centroid` spatial query, `ST_AsText`/`ST_AsGeoJSON` output, and the no-geometry aggregate path).

Remaining: live in-app/desktop click-through E2E (first-run bundle load, on-map rendering) is still worth a manual pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added PostGIS as an alternative SQL engine in the SQL Workspace—users can now switch between DuckDB and PostGIS for spatial queries
* Engine selection is automatically saved and restored between sessions
* PostGIS-specific sample queries included for quick reference

**Chores**
* Added spatial database dependencies and optimized application bundling for improved performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->