### PR TITLE
feat(routing): one-time privacy notice before enabling Directions

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -293,6 +293,7 @@ export function TopToolbar({
   const [projectUrlError, setProjectUrlError] = useState<string | null>(null);
   const [projectUrlLoading, setProjectUrlLoading] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [directionsNoticeOpen, setDirectionsNoticeOpen] = useState(false);
   const [osmPbfLoading, setOsmPbfLoading] = useState(false);
   const osmPbfAbortRef = useRef<AbortController | null>(null);
   const [osmPbfDialogOpen, setOsmPbfDialogOpen] = useState(false);
@@ -499,6 +500,33 @@ export function TopToolbar({
     setMapControlPosition,
   } = usePluginRegistry();
   const appApi = createAppAPI(mapControllerRef);
+  // Show a one-time consent notice the first time routing is enabled, since it
+  // sends the user's waypoints to a public third-party server. A hover-only
+  // tooltip is invisible on touch, so this is the real disclosure.
+  const handleToggleDirections = () => {
+    if (isActive(DIRECTIONS_PLUGIN_ID)) {
+      toggle(DIRECTIONS_PLUGIN_ID, appApi);
+      return;
+    }
+    let acknowledged = false;
+    try {
+      acknowledged =
+        localStorage.getItem("geolibre:directions-osrm-notice") === "1";
+    } catch {
+      // localStorage unavailable (private mode): fall back to showing the notice.
+    }
+    if (acknowledged) toggle(DIRECTIONS_PLUGIN_ID, appApi);
+    else setDirectionsNoticeOpen(true);
+  };
+  const confirmEnableDirections = () => {
+    try {
+      localStorage.setItem("geolibre:directions-osrm-notice", "1");
+    } catch {
+      // Ignore: the notice will simply show again next time.
+    }
+    setDirectionsNoticeOpen(false);
+    toggle(DIRECTIONS_PLUGIN_ID, appApi);
+  };
   const resetRuntimeControlsForNewProject = () => {
     closeMaplibreComponentControls(appApi);
     closeRasterLayerPanel(appApi);
@@ -1241,7 +1269,7 @@ export function TopToolbar({
           </DropdownMenuItem>
           <DropdownMenuItem
             title="Routing sends your waypoints to the public OSRM demo server (router.project-osrm.org)."
-            onClick={() => toggle(DIRECTIONS_PLUGIN_ID, appApi)}
+            onClick={handleToggleDirections}
           >
             Directions
             {isActive(DIRECTIONS_PLUGIN_ID) ? " ✓" : ""}
@@ -1532,6 +1560,31 @@ export function TopToolbar({
           </DialogHeader>
           <div className="flex justify-end">
             <Button onClick={() => setActionError(null)}>Dismiss</Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+      <Dialog
+        open={directionsNoticeOpen}
+        onOpenChange={setDirectionsNoticeOpen}
+      >
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Directions uses a public routing server</DialogTitle>
+            <DialogDescription>
+              Turning on Directions sends the waypoints you place to the public
+              OSRM demo server (router.project-osrm.org) to calculate routes —
+              your coordinates leave your device for those requests. The demo
+              server is rate-limited and supports driving only.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="outline"
+              onClick={() => setDirectionsNoticeOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button onClick={confirmEnableDirections}>Continue</Button>
           </div>
         </DialogContent>
       </Dialog>

--- a/packages/plugins/src/plugins/maplibre-directions.ts
+++ b/packages/plugins/src/plugins/maplibre-directions.ts
@@ -36,11 +36,16 @@ function attach(app: GeoLibreAppAPI): void {
   const token = ++loadToken;
   void import("@maplibre/maplibre-gl-directions")
     .then(({ default: DirectionsClass, LoadingIndicatorControl }) => {
-      // Stale (toggled off/on during import) or already attached — discard.
+      // Stale token means a newer attach()/teardown() superseded this import, so
+      // discard it. The `|| directions` check is a defensive belt-and-braces:
+      // every attach() bumps loadToken first, so a surviving token implies
+      // directions is still null — but it guards against ever double-creating.
       if (token !== loadToken || directions) return;
       const currentMap = app.getMap?.();
       if (!currentMap) return;
       directions = new DirectionsClass(currentMap);
+      // `interactive` is an instance setter, not a constructor config option in
+      // this library version (it's absent from MapLibreGlDirectionsConfiguration).
       directions.interactive = true;
       directionsMap = currentMap;
       loadingControl = new LoadingIndicatorControl(directions);
@@ -56,7 +61,7 @@ function attach(app: GeoLibreAppAPI): void {
 
 function teardown(app: GeoLibreAppAPI): void {
   // Invalidate any in-flight import so it doesn't reattach after teardown.
-  loadToken += 1;
+  ++loadToken;
   if (loadingControl) {
     app.removeMapControl(loadingControl);
     loadingControl = null;


### PR DESCRIPTION
Follow-up to #233, which **merged before this round of Claude review feedback landed**. These changes were verified on the #233 branch but didn't make it into the merge.

### Changes
- **One-time consent dialog** (localStorage-gated) the first time **Directions** is enabled, disclosing that the waypoints you place are sent to the public OSRM demo server (`router.project-osrm.org`) to compute routes. The hover-only `title` tooltip added in #233 is invisible on touch devices, so this is the real disclosure for a feature that sends coordinates to a third party — in keeping with GeoLibre's privacy-by-design stance.
- `maplibre-directions`: documented why the load-token `|| directions` guard exists, unified the `loadToken` increment style, and clarified that `interactive` is set via the instance setter (it is **not** a constructor config option in `@maplibre/maplibre-gl-directions@0.9.1` — the suggested constructor form fails `tsc`).

### Verification
- `npm run build` + pre-commit pass.
- **Playwright**: first enabling Directions shows the consent dialog; **Continue** sets the localStorage flag and activates the tool; toggling off then on again does **not** re-prompt; **Cancel** leaves it off. No console errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a consent dialog for the Directions feature that informs users their waypoints will be sent to a public OSRM demo server, requiring explicit acknowledgment before enabling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->