### PR TITLE
feat(data): add georeferenced video overlay layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS
 - MapLibre map workspace with OpenFreeMap basemaps, blank background support, and toggleable navigation, fullscreen, geolocation, globe, terrain, scale, attribution, and logo controls
 - Load local vector layers supported by DuckDB-WASM Spatial, including common formats such as GeoJSON, GeoParquet, GeoPackage, Shapefile, FlatGeobuf, KML/KMZ, GML, delimited text, and GPX
 - Reproject vector layers to EPSG:4326 on load and split dragged GPX files into named waypoint, track, and route layers
-- Add Data menu for XYZ tiles, WMS, WFS, GeoJSON URLs, vector tiles, COG and GeoTIFF rasters, MBTiles, ArcGIS FeatureServer and VectorTileServer layers, PMTiles, Zarr, LiDAR, 3D Tiles, and Gaussian splats
+- Add Data menu for XYZ tiles, WMS, WFS, GeoJSON URLs, vector tiles, COG and GeoTIFF rasters, MBTiles, ArcGIS FeatureServer and VectorTileServer layers, PMTiles, Zarr, LiDAR, 3D Tiles, Gaussian splats, and georeferenced video overlays
 - Cloud data integrations through the Planetary Computer and Earth Engine panels, the Overture Maps plugin, and federal Web Services plugins
 - Manual and automatic refresh for WFS, GeoJSON URL, and Add Vector Layer URL layers
 - Layer panel for visibility, opacity, reordering, rename, zoom-to-layer, identify, labels, open attribute table, export, and remove actions

--- a/apps/geolibre-desktop/src-tauri/tauri.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' https: http://127.0.0.1:*; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net/npm/ https://cdn.jsdelivr.net/pyodide/ https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'",
+      "csp": "default-src 'self'; connect-src 'self' https: http://127.0.0.1:*; img-src 'self' data: blob: https:; media-src 'self' blob: https: http://127.0.0.1:*; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net/npm/ https://cdn.jsdelivr.net/pyodide/ https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'",
       "capabilities": ["default"]
     }
   },

--- a/apps/geolibre-desktop/src-tauri/tauri.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' https: http://127.0.0.1:*; img-src 'self' data: blob: https:; media-src 'self' blob: https: http://127.0.0.1:*; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net/npm/ https://cdn.jsdelivr.net/pyodide/ https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'",
+      "csp": "default-src 'self'; connect-src 'self' https: http://127.0.0.1:*; img-src 'self' data: blob: https:; media-src 'self' blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net/npm/ https://cdn.jsdelivr.net/pyodide/ https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'",
       "capabilities": ["default"]
     }
   },

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -994,6 +994,11 @@ export function AddDataDialog({
         const urls = [primary];
         const webm = videoWebmUrl.trim();
         if (webm) urls.push(webm);
+        // The media-src CSP is HTTPS-only, so an http:// URL would be silently
+        // blocked — reject it up front with a clear message.
+        if (urls.some((url) => !/^https:\/\//i.test(url))) {
+          throw new Error("Video URLs must start with https://.");
+        }
         const coordinates: [
           [number, number],
           [number, number],
@@ -1007,11 +1012,15 @@ export function AddDataDialog({
         ];
         const lngs = coordinates.map((corner) => corner[0]);
         const lats = coordinates.map((corner) => corner[1]);
+        const west = Math.min(...lngs);
+        const south = Math.min(...lats);
+        const east = Math.max(...lngs);
+        const north = Math.max(...lats);
         const bounds: [number, number, number, number] = [
-          Math.min(...lngs),
-          Math.min(...lats),
-          Math.max(...lngs),
-          Math.max(...lats),
+          west,
+          south,
+          east,
+          north,
         ];
         const layer = createBaseLayer(
           name,
@@ -1022,7 +1031,11 @@ export function AddDataDialog({
           { sourceKind: "video-url", bounds },
         );
         addLayer(layer, beforeLayer);
-        mapControllerRef.current?.fitBounds(bounds);
+        // Skip the fit for a degenerate (zero-area) bbox, which would otherwise
+        // snap to a single point at max zoom.
+        if (west !== east || south !== north) {
+          mapControllerRef.current?.fitBounds(bounds);
+        }
         closeDialog();
         return;
       }
@@ -1454,7 +1467,7 @@ export function AddDataDialog({
           {kind === "video" && (
             <div className="space-y-3">
               <div className="space-y-1.5">
-                <Label htmlFor="video-mp4-url">Video URL (MP4)</Label>
+                <Label htmlFor="video-mp4-url">Primary video URL</Label>
                 <Input
                   id="video-mp4-url"
                   placeholder="https://example.com/clip.mp4"
@@ -1463,7 +1476,9 @@ export function AddDataDialog({
                 />
               </div>
               <div className="space-y-1.5">
-                <Label htmlFor="video-webm-url">Video URL (WebM, optional)</Label>
+                <Label htmlFor="video-webm-url">
+                  Fallback video URL (optional)
+                </Label>
                 <Input
                   id="video-webm-url"
                   placeholder="https://example.com/clip.webm"

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -247,10 +247,15 @@ function parseVideoCorner(value: string, label: string): [number, number] {
   if (parts.length !== 2) {
     throw new Error(`Enter the ${label} corner as "longitude, latitude".`);
   }
-  return [
-    parseRequiredNumber(parts[0], `${label} longitude`),
-    parseRequiredNumber(parts[1], `${label} latitude`),
-  ];
+  const lng = parseRequiredNumber(parts[0], `${label} longitude`);
+  const lat = parseRequiredNumber(parts[1], `${label} latitude`);
+  if (lng < -180 || lng > 180) {
+    throw new Error(`${label} longitude must be between -180 and 180.`);
+  }
+  if (lat < -90 || lat > 90) {
+    throw new Error(`${label} latitude must be between -90 and 90.`);
+  }
+  return [lng, lat];
 }
 
 function readSavedPostgresConnections(): string[] {

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -1005,21 +1005,24 @@ export function AddDataDialog({
           parseVideoCorner(videoBottomRight, "bottom-right"),
           parseVideoCorner(videoBottomLeft, "bottom-left"),
         ];
-        const layer = createBaseLayer(
-          name,
-          "video",
-          { type: "video", urls, coordinates },
-          { sourceKind: "video-url" },
-        );
-        addLayer(layer, beforeLayer);
         const lngs = coordinates.map((corner) => corner[0]);
         const lats = coordinates.map((corner) => corner[1]);
-        mapControllerRef.current?.fitBounds([
+        const bounds: [number, number, number, number] = [
           Math.min(...lngs),
           Math.min(...lats),
           Math.max(...lngs),
           Math.max(...lats),
-        ]);
+        ];
+        const layer = createBaseLayer(
+          name,
+          "video",
+          { type: "video", urls, coordinates },
+          // Persist the corner bbox so "Zoom to layer" works — a video source
+          // exposes no bounds for fitLayer to fall back on.
+          { sourceKind: "video-url", bounds },
+        );
+        addLayer(layer, beforeLayer);
+        mapControllerRef.current?.fitBounds(bounds);
         closeDialog();
         return;
       }
@@ -1510,8 +1513,8 @@ export function AddDataDialog({
               </div>
               <p className="text-xs text-muted-foreground">
                 The four corners georeference the video on the map. The video
-                host must allow cross-origin requests (CORS) for the frames to
-                render.
+                must be served over HTTPS and the host must allow cross-origin
+                requests (CORS) for the frames to render.
               </p>
             </div>
           )}

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -487,6 +487,12 @@ export function AddDataDialog({
     setXyzUrl(DEFAULT_XYZ_URL);
     setXyzTileSize("256");
     setXyzShortUrl(false);
+    setVideoMp4Url(DEFAULT_VIDEO_MP4_URL);
+    setVideoWebmUrl(DEFAULT_VIDEO_WEBM_URL);
+    setVideoTopLeft(DEFAULT_VIDEO_TOP_LEFT);
+    setVideoTopRight(DEFAULT_VIDEO_TOP_RIGHT);
+    setVideoBottomRight(DEFAULT_VIDEO_BOTTOM_RIGHT);
+    setVideoBottomLeft(DEFAULT_VIDEO_BOTTOM_LEFT);
     setWmsEndpoint(DEFAULT_WMS_ENDPOINT);
     setWmsLayers(DEFAULT_WMS_LAYERS);
     setWmsStyles("");
@@ -568,6 +574,9 @@ export function AddDataDialog({
     }
     if (kind === "postgres") {
       return "Start Martin locally, discover PostGIS sources, and add a source as vector tiles.";
+    }
+    if (kind === "video") {
+      return "Add a georeferenced video overlay by supplying an MP4 URL and four corner coordinates.";
     }
     return "";
   }, [kind]);

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -79,7 +79,8 @@ export type AddDataKind =
   | "delimited-text"
   | "mbtiles"
   | "arcgis"
-  | "postgres";
+  | "postgres"
+  | "video";
 
 interface AddDataDialogProps {
   kind: AddDataKind | null;
@@ -102,6 +103,7 @@ const KIND_LABELS: Record<AddDataKind, string> = {
   mbtiles: "Add MBTiles Layer",
   arcgis: "Add ArcGIS Layer",
   postgres: "Add PostgreSQL Layer",
+  video: "Add Video Layer",
 };
 
 const DEFAULT_XYZ_URL =
@@ -119,6 +121,16 @@ const DEFAULT_DELIMITED_TEXT_URL =
   "https://data.source.coop/giswqs/opengeos/us_cities.csv";
 const DEFAULT_DELIMITED_TEXT_LATITUDE_FIELD = "latitude";
 const DEFAULT_DELIMITED_TEXT_LONGITUDE_FIELD = "longitude";
+// MapLibre's "Add a video" sample (a drone clip over San Francisco), pre-filled
+// so the dialog works out of the box. The corners are [lng, lat] pairs.
+const DEFAULT_VIDEO_MP4_URL =
+  "https://static-assets.mapbox.com/mapbox-gl-js/drone.mp4";
+const DEFAULT_VIDEO_WEBM_URL =
+  "https://static-assets.mapbox.com/mapbox-gl-js/drone.webm";
+const DEFAULT_VIDEO_TOP_LEFT = "-122.51596391201019, 37.56238816766053";
+const DEFAULT_VIDEO_TOP_RIGHT = "-122.51467645168304, 37.56410183312965";
+const DEFAULT_VIDEO_BOTTOM_RIGHT = "-122.51309394836426, 37.563391708549425";
+const DEFAULT_VIDEO_BOTTOM_LEFT = "-122.51423120498657, 37.56161849366671";
 const DEFAULT_ARCGIS_FEATURE_URL =
   "https://services3.arcgis.com/GVgbJbqm8hXASVYi/arcgis/rest/services/USA_Major_Cities/FeatureServer/0";
 const DEFAULT_ARCGIS_VECTOR_TILE_URL =
@@ -227,6 +239,18 @@ function parseRequiredNumber(value: string, label: string): number {
 function parseOptionalNumber(value: string, label: string): number | undefined {
   if (!value.trim()) return undefined;
   return parseRequiredNumber(value, label);
+}
+
+/** Parse a `"longitude, latitude"` corner string into a [lng, lat] pair. */
+function parseVideoCorner(value: string, label: string): [number, number] {
+  const parts = value.split(",").map((part) => part.trim());
+  if (parts.length !== 2) {
+    throw new Error(`Enter the ${label} corner as "longitude, latitude".`);
+  }
+  return [
+    parseRequiredNumber(parts[0], `${label} longitude`),
+    parseRequiredNumber(parts[1], `${label} latitude`),
+  ];
 }
 
 function readSavedPostgresConnections(): string[] {
@@ -346,6 +370,16 @@ export function AddDataDialog({
   const [xyzUrl, setXyzUrl] = useState(DEFAULT_XYZ_URL);
   const [xyzTileSize, setXyzTileSize] = useState("256");
   const [xyzShortUrl, setXyzShortUrl] = useState(false);
+  const [videoMp4Url, setVideoMp4Url] = useState(DEFAULT_VIDEO_MP4_URL);
+  const [videoWebmUrl, setVideoWebmUrl] = useState(DEFAULT_VIDEO_WEBM_URL);
+  const [videoTopLeft, setVideoTopLeft] = useState(DEFAULT_VIDEO_TOP_LEFT);
+  const [videoTopRight, setVideoTopRight] = useState(DEFAULT_VIDEO_TOP_RIGHT);
+  const [videoBottomRight, setVideoBottomRight] = useState(
+    DEFAULT_VIDEO_BOTTOM_RIGHT,
+  );
+  const [videoBottomLeft, setVideoBottomLeft] = useState(
+    DEFAULT_VIDEO_BOTTOM_LEFT,
+  );
 
   const [wmsEndpoint, setWmsEndpoint] = useState(DEFAULT_WMS_ENDPOINT);
   const [wmsLayers, setWmsLayers] = useState(DEFAULT_WMS_LAYERS);
@@ -441,6 +475,7 @@ export function AddDataDialog({
         mbtiles: "MBTiles Layer",
         arcgis: "ArcGIS Layer",
         postgres: "PostgreSQL Layer",
+        video: "Video Layer",
       }[kind],
     );
     setBeforeLayerId("");
@@ -937,6 +972,44 @@ export function AddDataDialog({
         return;
       }
 
+      if (kind === "video") {
+        const primary = videoMp4Url.trim();
+        if (!primary) {
+          throw new Error("Enter a video URL.");
+        }
+        const urls = [primary];
+        const webm = videoWebmUrl.trim();
+        if (webm) urls.push(webm);
+        const coordinates: [
+          [number, number],
+          [number, number],
+          [number, number],
+          [number, number],
+        ] = [
+          parseVideoCorner(videoTopLeft, "top-left"),
+          parseVideoCorner(videoTopRight, "top-right"),
+          parseVideoCorner(videoBottomRight, "bottom-right"),
+          parseVideoCorner(videoBottomLeft, "bottom-left"),
+        ];
+        const layer = createBaseLayer(
+          name,
+          "video",
+          { type: "video", urls, coordinates },
+          { sourceKind: "video-url" },
+        );
+        addLayer(layer, beforeLayer);
+        const lngs = coordinates.map((corner) => corner[0]);
+        const lats = coordinates.map((corner) => corner[1]);
+        mapControllerRef.current?.fitBounds([
+          Math.min(...lngs),
+          Math.min(...lats),
+          Math.max(...lngs),
+          Math.max(...lats),
+        ]);
+        closeDialog();
+        return;
+      }
+
       if (kind === "wms") {
         if (!wmsEndpoint.trim()) throw new Error("Enter a WMS service URL.");
         if (!wmsLayers.trim()) {
@@ -1358,6 +1431,74 @@ export function AddDataDialog({
                 />
                 Short URL
               </label>
+            </div>
+          )}
+
+          {kind === "video" && (
+            <div className="space-y-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="video-mp4-url">Video URL (MP4)</Label>
+                <Input
+                  id="video-mp4-url"
+                  placeholder="https://example.com/clip.mp4"
+                  value={videoMp4Url}
+                  onChange={(event) => setVideoMp4Url(event.target.value)}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="video-webm-url">Video URL (WebM, optional)</Label>
+                <Input
+                  id="video-webm-url"
+                  placeholder="https://example.com/clip.webm"
+                  value={videoWebmUrl}
+                  onChange={(event) => setVideoWebmUrl(event.target.value)}
+                />
+              </div>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="space-y-1.5">
+                  <Label htmlFor="video-top-left">Top-left (lng, lat)</Label>
+                  <Input
+                    id="video-top-left"
+                    value={videoTopLeft}
+                    onChange={(event) => setVideoTopLeft(event.target.value)}
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="video-top-right">Top-right (lng, lat)</Label>
+                  <Input
+                    id="video-top-right"
+                    value={videoTopRight}
+                    onChange={(event) => setVideoTopRight(event.target.value)}
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="video-bottom-right">
+                    Bottom-right (lng, lat)
+                  </Label>
+                  <Input
+                    id="video-bottom-right"
+                    value={videoBottomRight}
+                    onChange={(event) =>
+                      setVideoBottomRight(event.target.value)
+                    }
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="video-bottom-left">
+                    Bottom-left (lng, lat)
+                  </Label>
+                  <Input
+                    id="video-bottom-left"
+                    value={videoBottomLeft}
+                    onChange={(event) => setVideoBottomLeft(event.target.value)}
+                  />
+                </div>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                The four corners georeference the video on the map. The video
+                host must allow cross-origin requests (CORS) for the frames to
+                render.
+              </p>
             </div>
           )}
 

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -1035,6 +1035,9 @@ export function TopToolbar({
           <DropdownMenuItem onSelect={handleAddStacLayer}>
             STAC Layer
           </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setAddDataKind("video")}>
+            Video Layer
+          </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuLabel className="text-xs text-muted-foreground">
             Cloud formats

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -36,7 +36,7 @@ server {
         # maplibre-gl-vector's DuckDB-WASM + geojson-vt/vt-pbf (Add Vector
         # Layer) loaded via dynamic import()/importScripts(), and /pyodide/
         # covers the Pyodide vector engine.
-        add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https: data: blob:; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net/npm/ https://cdn.jsdelivr.net/pyodide/ https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'" always;
+        add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https: data: blob:; img-src 'self' data: blob: https:; media-src 'self' blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net/npm/ https://cdn.jsdelivr.net/pyodide/ https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'" always;
     }
 
     location ~* \.(?:css|js|mjs|png|jpg|jpeg|gif|ico|svg|webp|avif|wasm|woff2?|ttf|otf)$ {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -56,7 +56,8 @@ export type LayerType =
   | "cog"
   | "flatgeobuf"
   | "geoparquet"
-  | "duckdb-query";
+  | "duckdb-query"
+  | "video";
 
 export type VectorStyleMode =
   | "single"

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -141,6 +141,11 @@ export function syncLayer(
 
   if (layer.type === "mbtiles") {
     syncMbtilesLayer(map, layer, beforeId);
+    return;
+  }
+
+  if (layer.type === "video") {
+    syncVideoLayer(map, layer, beforeId);
   }
 }
 
@@ -1190,6 +1195,43 @@ function syncRasterTileLayer(
   );
 }
 
+/**
+ * A georeferenced video overlay (MapLibre `type: "video"` source rendered as a
+ * raster layer). The source carries the media `urls` (format fallbacks) and the
+ * four corner `coordinates` in [lng, lat] order: top-left, top-right,
+ * bottom-right, bottom-left. The video host must send CORS headers so MapLibre
+ * can read its frames into the map texture.
+ */
+function syncVideoLayer(
+  map: maplibregl.Map,
+  layer: GeoLibreLayer,
+  beforeId?: string,
+): void {
+  const src = sourceId(layer.id);
+  const lid = `layer-${layer.id}-video`;
+  const urls = (layer.source.urls as string[] | undefined) ?? [];
+  const coordinates = layer.source.coordinates as
+    | [[number, number], [number, number], [number, number], [number, number]]
+    | undefined;
+  if (urls.length === 0 || !coordinates) return;
+  if (!map.getSource(src)) {
+    map.addSource(src, { type: "video", urls, coordinates });
+  }
+  ensureLayer(
+    map,
+    lid,
+    {
+      id: lid,
+      type: "raster",
+      source: src,
+      ...styleLayerZoomRange(layer.style),
+      paint: rasterPaint(layer.style, layer.opacity),
+      layout: { visibility: layer.visible ? "visible" : "none" },
+    },
+    beforeId,
+  );
+}
+
 function getRenderableRasterTiles(layer: GeoLibreLayer): string[] {
   const tiles = (layer.source.tiles as string[]) ?? [];
   if (layer.type !== "wms" || !isViteDevServer()) return tiles;
@@ -1761,6 +1803,7 @@ export function removeLayerFromMap(
     circleLayerId(layerId),
     textLayerId(layerId),
     `layer-${layerId}-raster`,
+    `layer-${layerId}-video`,
     ...(layer ? vectorTileAllStyleLayerIds(layer) : []),
     vectorTileCircleLayerId(layerId),
     vectorTileLineLayerId(layerId),

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -1246,6 +1246,8 @@ function syncVideoLayer(
   if (urls.length === 0 || !coordinates) return;
   if (!map.getSource(src)) {
     map.addSource(src, { type: "video", urls, coordinates });
+    // MapLibre's VideoSource exposes setCoordinates() but no URL setter, so a
+    // future edit-layer flow would need to remove + re-add to change urls.
   }
   ensureLayer(
     map,

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -1203,7 +1203,7 @@ type VideoCoordinates = [
   [number, number],
 ];
 
-/** Validate persisted video corners: four [lng, lat] pairs of finite numbers. */
+/** Validate persisted video corners: four in-range [lng, lat] pairs. */
 function isVideoCoordinates(value: unknown): value is VideoCoordinates {
   return (
     Array.isArray(value) &&
@@ -1213,7 +1213,11 @@ function isVideoCoordinates(value: unknown): value is VideoCoordinates {
         Array.isArray(corner) &&
         corner.length === 2 &&
         Number.isFinite(corner[0]) &&
-        Number.isFinite(corner[1]),
+        Number.isFinite(corner[1]) &&
+        corner[0] >= -180 &&
+        corner[0] <= 180 &&
+        corner[1] >= -90 &&
+        corner[1] <= 90,
     )
   );
 }

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -146,6 +146,7 @@ export function syncLayer(
 
   if (layer.type === "video") {
     syncVideoLayer(map, layer, beforeId);
+    return;
   }
 }
 

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -1196,6 +1196,28 @@ function syncRasterTileLayer(
   );
 }
 
+type VideoCoordinates = [
+  [number, number],
+  [number, number],
+  [number, number],
+  [number, number],
+];
+
+/** Validate persisted video corners: four [lng, lat] pairs of finite numbers. */
+function isVideoCoordinates(value: unknown): value is VideoCoordinates {
+  return (
+    Array.isArray(value) &&
+    value.length === 4 &&
+    value.every(
+      (corner) =>
+        Array.isArray(corner) &&
+        corner.length === 2 &&
+        Number.isFinite(corner[0]) &&
+        Number.isFinite(corner[1]),
+    )
+  );
+}
+
 /**
  * A georeferenced video overlay (MapLibre `type: "video"` source rendered as a
  * raster layer). The source carries the media `urls` (format fallbacks) and the
@@ -1210,10 +1232,17 @@ function syncVideoLayer(
 ): void {
   const src = sourceId(layer.id);
   const lid = `layer-${layer.id}-video`;
-  const urls = (layer.source.urls as string[] | undefined) ?? [];
-  const coordinates = layer.source.coordinates as
-    | [[number, number], [number, number], [number, number], [number, number]]
-    | undefined;
+  // Validate the persisted source payload — a malformed project must not make
+  // map.addSource throw and abort the rest of the layer-sync pass.
+  const urls = Array.isArray(layer.source.urls)
+    ? layer.source.urls.filter(
+        (value): value is string =>
+          typeof value === "string" && value.trim().length > 0,
+      )
+    : [];
+  const coordinates = isVideoCoordinates(layer.source.coordinates)
+    ? layer.source.coordinates
+    : undefined;
   if (urls.length === 0 || !coordinates) return;
   if (!map.getSource(src)) {
     map.addSource(src, { type: "video", urls, coordinates });

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -1186,6 +1186,10 @@ export class MapController {
       return [{ id: `layer-${layer.id}-raster` }];
     }
 
+    if (layer.type === "video") {
+      return [{ id: `layer-${layer.id}-video` }];
+    }
+
     if (layer.type === "vector-tiles") {
       return vectorTileStyleLayerIds(layer).map((id) => ({
         id,


### PR DESCRIPTION
Adds support for adding a **video layer** to the map, per the [MapLibre "Add a video" example](https://maplibre.org/maplibre-gl-js/docs/examples/add-a-video/).

### What it does
- New **Video Layer** item in **Add Data → Web services**. The dialog takes an MP4 URL (optional WebM fallback) and four corner coordinates (`lng, lat` for top-left, top-right, bottom-right, bottom-left) that georeference the video on the map.
- The dialog is **pre-filled with MapLibre's sample drone clip over San Francisco**, so it works out of the box — just click **Add layer**.
- On add, the map fits to the video's corner extent. The layer participates in the normal layer panel (opacity, visibility, reorder, remove) and persists in the `.geolibre.json` project.

### Implementation
- `core`: add `"video"` to the `LayerType` union.
- `map`: `syncVideoLayer` adds a `type: "video"` source (`urls` + 4 `coordinates`) rendered as a `raster` layer, mirroring the raster path for opacity/zoom-range/teardown. **Mapped the video style layer in `getCandidateStyleLayers`** so the MapLibre layer control excludes/owns it — without this the control reasserted visibility and the hide toggle silently did nothing (caught during Playwright testing).
- `AddDataDialog`: new `video` kind, sample defaults, corner parsing, fit-to-corners.
- **CSP**: added `media-src` (`blob:` + `https:`) to the Tauri and nginx policies so cross-origin video can load.

### Verification
- `npm run build` + **250 frontend tests** + pre-commit pass.
- **Playwright** end-to-end: Add Data → Video Layer → dialog pre-filled → **Add** renders the drone clip as a georeferenced quad over SF and zooms to it; **hide** removes it, **show** restores it, **remove** tears down the layer + source; no console errors.

### Notes / limitations
- The video host must send **CORS** headers for MapLibre to read frames into the map texture (the bundled sample is CORS-enabled).
- The Style panel shows "not available for this layer type yet" for video (opacity is still adjustable from the layer panel) — a reasonable follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add video layer support — georeferenced MP4/WebM overlays with four corner coordinates; map auto-fits to video bounds.
  * New "Video Layer" entry in the Add Data menu for quick access.

* **Bug Fixes**
  * Improved validation, rendering, and cleanup for video overlays.

* **Documentation**
  * Expanded supported data sources list to include additional raster, vector, catalog, and media overlay formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->