### PR TITLE
feat(3d-tiles): support authenticated tilesets via custom request headers

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -41,7 +41,7 @@
     "jspdf": "^4.2.1",
     "mapillary-js": "^4.1.2",
     "maplibre-gl": "^5.24.0",
-    "maplibre-gl-3d-tiles": "^0.3.0",
+    "maplibre-gl-3d-tiles": "^0.4.0",
     "maplibre-gl-basemap-control": "^0.3.0",
     "maplibre-gl-components": "^0.20.3",
     "maplibre-gl-duckdb": "^0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "jspdf": "^4.2.1",
         "mapillary-js": "^4.1.2",
         "maplibre-gl": "^5.24.0",
-        "maplibre-gl-3d-tiles": "^0.3.0",
+        "maplibre-gl-3d-tiles": "^0.4.0",
         "maplibre-gl-basemap-control": "^0.3.0",
         "maplibre-gl-components": "^0.20.3",
         "maplibre-gl-duckdb": "^0.2.0",
@@ -12743,9 +12743,9 @@
       }
     },
     "node_modules/maplibre-gl-3d-tiles": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-3d-tiles/-/maplibre-gl-3d-tiles-0.3.0.tgz",
-      "integrity": "sha512-u/M+L2uywpSfBjGKpbnSSITchqbFGJAOT61iZfozsbBbZuBYPRUvOIzRXpVZLJMPERe++TvDjab4J3hVteg1MQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-3d-tiles/-/maplibre-gl-3d-tiles-0.4.0.tgz",
+      "integrity": "sha512-I9V240lbbpHmpxKAoa2BslYxck9Hp4jRczGo3iq0qJLZG1s27zoQMLQTqeMnzqNNcBmS5rkpY6ZoP06/65qfgQ==",
       "license": "MIT",
       "dependencies": {
         "3d-tiles-renderer": "^0.4.27",
@@ -17808,7 +17808,7 @@
         "geotiff": "^3.0.5",
         "jspdf": "^4.2.1",
         "maplibre-gl": "^5.24.0",
-        "maplibre-gl-3d-tiles": "^0.3.0",
+        "maplibre-gl-3d-tiles": "^0.4.0",
         "maplibre-gl-basemap-control": "^0.3.0",
         "maplibre-gl-components": "^0.20.3",
         "maplibre-gl-duckdb": "^0.2.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -28,7 +28,7 @@
     "geotiff": "^3.0.5",
     "jspdf": "^4.2.1",
     "maplibre-gl": "^5.24.0",
-    "maplibre-gl-3d-tiles": "^0.3.0",
+    "maplibre-gl-3d-tiles": "^0.4.0",
     "maplibre-gl-basemap-control": "^0.3.0",
     "maplibre-gl-components": "^0.20.3",
     "maplibre-gl-duckdb": "^0.2.0",

--- a/packages/plugins/src/plugins/maplibre-3d-tiles.ts
+++ b/packages/plugins/src/plugins/maplibre-3d-tiles.ts
@@ -389,9 +389,9 @@ function createThreeDTilesStoreLayer(
       url: tileset.tilesetUrl,
       // Persisted so a saved project reloads an authenticated tileset; this
       // means any credential in a header is stored in the project file.
-      ...(tileset.requestHeaders
-        ? { requestHeaders: tileset.requestHeaders }
-        : {}),
+      // JSON.stringify drops the key when undefined, so a header-less tileset
+      // is not written to the project file.
+      requestHeaders: tileset.requestHeaders,
     },
     visible: tileset.visible,
     opacity,
@@ -702,8 +702,12 @@ function stringRecordValue(
   value: unknown,
 ): Record<string, string> | undefined {
   if (!isRecord(value)) return undefined;
+  // Keep only valid string-valued headers with a non-empty name (an empty
+  // header name is invalid per RFC 7230); drop malformed entries from a
+  // hand-edited project file rather than discarding the whole set.
   const entries = Object.entries(value).filter(
-    (entry): entry is [string, string] => typeof entry[1] === "string",
+    (entry): entry is [string, string] =>
+      entry[0].trim() !== "" && typeof entry[1] === "string",
   );
   return entries.length > 0 ? Object.fromEntries(entries) : undefined;
 }

--- a/packages/plugins/src/plugins/maplibre-3d-tiles.ts
+++ b/packages/plugins/src/plugins/maplibre-3d-tiles.ts
@@ -248,6 +248,7 @@ function restoreThreeDTilesMapLayer(
   const layerName = layer.name || layerNameFromUrl(url, id);
   const beforeId = validThreeDTilesBeforeId(control, layer.beforeId);
   const altitudeOffset = numberValue(layer.source.altitudeOffset, 0);
+  const requestHeaders = stringRecordValue(layer.source.requestHeaders);
   const existingTilesets = control
     .getState()
     .tilesets.filter((tileset) => tileset.id !== id);
@@ -267,6 +268,7 @@ function restoreThreeDTilesMapLayer(
     status,
     center: savedCenter,
     altitude: savedAltitude,
+    requestHeaders,
   };
 
   runWithThreeDTilesStoreSyncSuspended(() => {
@@ -279,6 +281,7 @@ function restoreThreeDTilesMapLayer(
       error: undefined,
       layerName,
       opacity: layer.opacity,
+      requestHeaders,
       status,
       tilesetUrl: url,
       tilesets: [...existingTilesets, restoredTileset],
@@ -297,6 +300,7 @@ function restoreThreeDTilesMapLayer(
     altitudeOffset,
     opacity: layer.opacity,
     visible: layer.visible,
+    requestHeaders,
     ...getThreeDTilesDecoderOptions(control),
     onLoad: (metadata) => updateThreeDTilesLoaded(control, id, metadata),
     onError: (error) => updateThreeDTilesError(control, id, error),
@@ -383,6 +387,11 @@ function createThreeDTilesStoreLayer(
       sourceId: tileset.id,
       type: "3d-tiles",
       url: tileset.tilesetUrl,
+      // Persisted so a saved project reloads an authenticated tileset; this
+      // means any credential in a header is stored in the project file.
+      ...(tileset.requestHeaders
+        ? { requestHeaders: tileset.requestHeaders }
+        : {}),
     },
     visible: tileset.visible,
     opacity,
@@ -687,6 +696,16 @@ function lngLatPairValue(value: unknown): [number, number] | undefined {
     return [value[0], value[1]];
   }
   return undefined;
+}
+
+function stringRecordValue(
+  value: unknown,
+): Record<string, string> | undefined {
+  if (!isRecord(value)) return undefined;
+  const entries = Object.entries(value).filter(
+    (entry): entry is [string, string] => typeof entry[1] === "string",
+  );
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
 }
 
 function recordsEqual(


### PR DESCRIPTION
Closes #223.

## Summary

Lets users load **authenticated 3D Tiles sources** (e.g. tilesets that require `Authorization: ApiKey <key>`, Bearer tokens, or `X-API-Key`) that previously failed with 401. The 3D Tiles panel gains a **"Request headers"** field (one `Name: Value` per line); the headers are applied to the tileset's fetch options so the tileset JSON and every tile request carry them.

This pairs with the upstream change in [`maplibre-gl-3d-tiles` 0.4.0](https://github.com/opengeos/maplibre-gl-3d-tiles/pull/6), which adds the `requestHeaders` option and the panel field. This PR bumps the dependency and wires persistence through GeoLibre.

## Changes

- **Bump `maplibre-gl-3d-tiles` to `^0.4.0`** (adds `requestHeaders` + the panel "Request headers" field).
- **`maplibre-3d-tiles.ts` plugin:**
  - Persist `source.requestHeaders` on the store layer so a saved project reloads an authenticated tileset.
  - Read `requestHeaders` from the source on restore and pass them to `ThreeDTilesLayer`; thread them through the control item/state.
  - New `stringRecordValue` source-value helper.

## Persistence note

Headers are stored in the layer `source`, so they are written to `.geolibre.json`. This means a saved project reloads the authenticated tileset automatically, but the credential is stored in plaintext in the project file. The panel field shows a hint that headers are saved with the layer.

## Verification

- `npm run build` (tsc + vite) passes against the published `0.4.0`; `npm run test:frontend` — 250 tests pass.
- `pre-commit run --files ...` passes (incl. the npm build hook).
- **End-to-end in a browser (Playwright):** added a tileset against a local logging server with a `X-Geolibre-Test: itworks` header; the server received the header on the `GET /tileset.json` request (after the expected CORS preflight), confirming the header rides on the wire.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dependencies**
  * Bumped maplibre-gl-3d-tiles to v0.4.0 across the apps.

* **Improvements**
  * 3D Tiles layers now preserve and restore authenticated request headers, so credentialed tilesets remain usable when projects are saved and reopened.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->