### PR TITLE
feat(data): add Cloud-Optimized NetCDF/HDF layers via kerchunk references

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -43,7 +43,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.4.0",
     "maplibre-gl-basemap-control": "^0.3.0",
-    "maplibre-gl-components": "^0.20.3",
+    "maplibre-gl-components": "^0.20.4",
     "maplibre-gl-duckdb": "^0.2.0",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",

--- a/apps/geolibre-desktop/src/components/layout/AddNetcdfDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddNetcdfDialog.tsx
@@ -1,0 +1,261 @@
+import { useState, type FormEvent } from "react";
+import {
+  addCloudNetcdfLayer,
+  listKerchunkVariables,
+  loadKerchunkReference,
+  type GeoLibreAppAPI,
+  type KerchunkVariable,
+} from "@geolibre/plugins";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+  Select,
+} from "@geolibre/ui";
+import { Boxes } from "lucide-react";
+
+// A real sample: NOAA NCEP/NCAR Reanalysis surface air temperature, stored as a
+// Cloud-Optimized NetCDF and served from Source Cooperative (CORS-enabled,
+// range-request capable). The reference uses a relative chunk URL, so it
+// resolves against the manifest's own location.
+const SAMPLE_URL =
+  "https://data.source.coop/giswqs/opengeos/netcdf/air-temperature.kerchunk.json";
+
+interface AddNetcdfDialogProps {
+  open: boolean;
+  appApi: GeoLibreAppAPI;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Dialog for adding a Cloud-Optimized NetCDF/HDF5 layer via a kerchunk
+ * reference. The user supplies the reference URL, loads its renderable
+ * variables, picks one (and any leading dimension index), and the layer is
+ * rendered through the shared Zarr control with a kerchunk reference store.
+ */
+export function AddNetcdfDialog({
+  open,
+  appApi,
+  onOpenChange,
+}: AddNetcdfDialogProps) {
+  const [url, setUrl] = useState(SAMPLE_URL);
+  const [variables, setVariables] = useState<KerchunkVariable[]>([]);
+  const [variable, setVariable] = useState("");
+  const [dimIndex, setDimIndex] = useState<Record<string, string>>({});
+  const [climMin, setClimMin] = useState("");
+  const [climMax, setClimMax] = useState("");
+  const [loadingVars, setLoadingVars] = useState(false);
+  const [adding, setAdding] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+
+  const selectedVar = variables.find((v) => v.name === variable);
+  // Dimensions other than the trailing two (lat/lon) need a fixed index.
+  const leadingDims = selectedVar
+    ? selectedVar.dims.slice(0, Math.max(0, selectedVar.dims.length - 2))
+    : [];
+
+  const reset = () => {
+    setUrl(SAMPLE_URL);
+    setVariables([]);
+    setVariable("");
+    setDimIndex({});
+    setClimMin("");
+    setClimMax("");
+    setError(null);
+    setStatus(null);
+    setLoadingVars(false);
+    setAdding(false);
+  };
+
+  const handleLoadVariables = async () => {
+    setError(null);
+    setStatus(null);
+    setLoadingVars(true);
+    try {
+      const refs = await loadKerchunkReference(url.trim());
+      const vars = listKerchunkVariables(refs);
+      if (vars.length === 0) {
+        throw new Error(
+          "No renderable (2-D or higher) variables found in the reference."
+        );
+      }
+      setVariables(vars);
+      setVariable(vars[0].name);
+      setStatus(`Found ${vars.length} variable${vars.length > 1 ? "s" : ""}.`);
+    } catch (err) {
+      setVariables([]);
+      setVariable("");
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoadingVars(false);
+    }
+  };
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!variable) return;
+    setError(null);
+    setAdding(true);
+    try {
+      const selector: Record<string, number> = {};
+      for (const dim of leadingDims) {
+        selector[dim] = Number(dimIndex[dim] ?? "0") || 0;
+      }
+      const min = climMin.trim() === "" ? undefined : Number(climMin);
+      const max = climMax.trim() === "" ? undefined : Number(climMax);
+      const clim =
+        min !== undefined &&
+        max !== undefined &&
+        !Number.isNaN(min) &&
+        !Number.isNaN(max)
+          ? ([min, max] as [number, number])
+          : undefined;
+
+      await addCloudNetcdfLayer(appApi, {
+        url: url.trim(),
+        variable,
+        selector: leadingDims.length > 0 ? selector : undefined,
+        clim,
+      });
+      onOpenChange(false);
+      reset();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next: boolean) => {
+        if (!next) reset();
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Boxes className="h-4 w-4" />
+            Add Cloud-Optimized NetCDF / HDF
+          </DialogTitle>
+          <DialogDescription>
+            Render a NetCDF or HDF5 dataset through a kerchunk reference. The
+            data is read directly over HTTP range requests, with no conversion.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="space-y-1.5">
+            <Label htmlFor="netcdf-url">Kerchunk reference URL</Label>
+            <div className="grid gap-2 sm:grid-cols-[1fr_auto]">
+              <Input
+                id="netcdf-url"
+                placeholder="https://example.com/data.kerchunk.json"
+                value={url}
+                onChange={(event) => setUrl(event.target.value)}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleLoadVariables}
+                disabled={!url.trim() || loadingVars}
+              >
+                {loadingVars ? "Loading..." : "Load variables"}
+              </Button>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Pre-filled with a sample NOAA air-temperature dataset. Click Load
+              variables to try it, or paste your own kerchunk reference URL.
+            </p>
+          </div>
+
+          {variables.length > 0 && (
+            <div className="space-y-1.5">
+              <Label htmlFor="netcdf-variable">Variable</Label>
+              <Select
+                id="netcdf-variable"
+                value={variable}
+                onChange={(event) => setVariable(event.target.value)}
+              >
+                {variables.map((item) => (
+                  <option key={item.name} value={item.name}>
+                    {item.dims.length > 0
+                      ? `${item.name} (${item.dims.join(", ")})`
+                      : `${item.name} [${item.shape.join("×")}]`}
+                  </option>
+                ))}
+              </Select>
+            </div>
+          )}
+
+          {leadingDims.map((dim) => (
+            <div className="space-y-1.5" key={dim}>
+              <Label htmlFor={`netcdf-dim-${dim}`}>{dim} index</Label>
+              <Input
+                id={`netcdf-dim-${dim}`}
+                inputMode="numeric"
+                placeholder="0"
+                value={dimIndex[dim] ?? ""}
+                onChange={(event) =>
+                  setDimIndex((prev) => ({
+                    ...prev,
+                    [dim]: event.target.value,
+                  }))
+                }
+              />
+            </div>
+          ))}
+
+          {variables.length > 0 && (
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="space-y-1.5">
+                <Label htmlFor="netcdf-clim-min">Color min (optional)</Label>
+                <Input
+                  id="netcdf-clim-min"
+                  inputMode="decimal"
+                  value={climMin}
+                  onChange={(event) => setClimMin(event.target.value)}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="netcdf-clim-max">Color max (optional)</Label>
+                <Input
+                  id="netcdf-clim-max"
+                  inputMode="decimal"
+                  value={climMax}
+                  onChange={(event) => setClimMax(event.target.value)}
+                />
+              </div>
+            </div>
+          )}
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          {status && !error && (
+            <p className="text-sm text-muted-foreground">{status}</p>
+          )}
+
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!variable || adding}>
+              {adding ? "Adding..." : "Add layer"}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/AddNetcdfDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddNetcdfDialog.tsx
@@ -124,8 +124,9 @@ export function AddNetcdfDialog({
     try {
       const selector: Record<string, number> = {};
       for (const dim of leadingDims) {
+        // Zarr indices are non-negative integers; clamp/truncate user input.
         const parsed = Number(dimIndex[dim] ?? "0");
-        selector[dim] = Number.isFinite(parsed) ? parsed : 0;
+        selector[dim] = Number.isFinite(parsed) ? Math.max(0, Math.trunc(parsed)) : 0;
       }
       const min = climMin.trim() === "" ? undefined : Number(climMin);
       const max = climMax.trim() === "" ? undefined : Number(climMax);
@@ -191,6 +192,7 @@ export function AddNetcdfDialog({
                   setVariable("");
                   setLoadedRefs(null);
                   setStatus(null);
+                  setError(null);
                 }}
               />
               <Button

--- a/apps/geolibre-desktop/src/components/layout/AddNetcdfDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddNetcdfDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent } from "react";
+import { useRef, useState, type FormEvent } from "react";
 import {
   addCloudNetcdfLayer,
   listKerchunkVariables,
@@ -53,6 +53,9 @@ export function AddNetcdfDialog({
   const [adding, setAdding] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState<string | null>(null);
+  // Incremented on every reset; lets in-flight async handlers detect that the
+  // dialog was closed/reopened and bail out before stomping fresh state.
+  const opGen = useRef(0);
 
   const selectedVar = variables.find((v) => v.name === variable);
   // Dimensions other than the trailing two (lat/lon) need a fixed index.
@@ -61,6 +64,7 @@ export function AddNetcdfDialog({
     : [];
 
   const reset = () => {
+    opGen.current += 1;
     setUrl(SAMPLE_URL);
     setVariables([]);
     setVariable("");
@@ -74,12 +78,14 @@ export function AddNetcdfDialog({
   };
 
   const handleLoadVariables = async () => {
+    const gen = opGen.current;
     setError(null);
     setStatus(null);
     setLoadingVars(true);
     try {
       const refs = await loadKerchunkReference(url.trim());
       const vars = listKerchunkVariables(refs);
+      if (gen !== opGen.current) return; // dialog was closed/reopened
       if (vars.length === 0) {
         throw new Error(
           "No renderable (2-D or higher) variables found in the reference."
@@ -89,17 +95,19 @@ export function AddNetcdfDialog({
       setVariable(vars[0].name);
       setStatus(`Found ${vars.length} variable${vars.length > 1 ? "s" : ""}.`);
     } catch (err) {
+      if (gen !== opGen.current) return;
       setVariables([]);
       setVariable("");
       setError(err instanceof Error ? err.message : String(err));
     } finally {
-      setLoadingVars(false);
+      if (gen === opGen.current) setLoadingVars(false);
     }
   };
 
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
     if (!variable) return;
+    const gen = opGen.current;
     setError(null);
     setAdding(true);
     try {
@@ -113,8 +121,8 @@ export function AddNetcdfDialog({
       const clim =
         min !== undefined &&
         max !== undefined &&
-        !Number.isNaN(min) &&
-        !Number.isNaN(max)
+        Number.isFinite(min) &&
+        Number.isFinite(max)
           ? ([min, max] as [number, number])
           : undefined;
 
@@ -124,12 +132,14 @@ export function AddNetcdfDialog({
         selector: leadingDims.length > 0 ? selector : undefined,
         clim,
       });
+      if (gen !== opGen.current) return; // dialog was closed/reopened
       onOpenChange(false);
       reset();
     } catch (err) {
+      if (gen !== opGen.current) return;
       setError(err instanceof Error ? err.message : String(err));
     } finally {
-      setAdding(false);
+      if (gen === opGen.current) setAdding(false);
     }
   };
 
@@ -247,7 +257,10 @@ export function AddNetcdfDialog({
             <Button
               type="button"
               variant="outline"
-              onClick={() => onOpenChange(false)}
+              onClick={() => {
+                reset();
+                onOpenChange(false);
+              }}
             >
               Cancel
             </Button>

--- a/apps/geolibre-desktop/src/components/layout/AddNetcdfDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddNetcdfDialog.tsx
@@ -4,6 +4,7 @@ import {
   listKerchunkVariables,
   loadKerchunkReference,
   type GeoLibreAppAPI,
+  type KerchunkRefs,
   type KerchunkVariable,
 } from "@geolibre/plugins";
 import {
@@ -46,6 +47,9 @@ export function AddNetcdfDialog({
   const [url, setUrl] = useState(SAMPLE_URL);
   const [variables, setVariables] = useState<KerchunkVariable[]>([]);
   const [variable, setVariable] = useState("");
+  // The normalized reference from the last successful load, reused on submit so
+  // the (potentially large) manifest is not fetched a second time.
+  const [loadedRefs, setLoadedRefs] = useState<KerchunkRefs | null>(null);
   const [dimIndex, setDimIndex] = useState<Record<string, string>>({});
   const [climMin, setClimMin] = useState("");
   const [climMax, setClimMax] = useState("");
@@ -68,6 +72,7 @@ export function AddNetcdfDialog({
     setUrl(SAMPLE_URL);
     setVariables([]);
     setVariable("");
+    setLoadedRefs(null);
     setDimIndex({});
     setClimMin("");
     setClimMax("");
@@ -81,6 +86,11 @@ export function AddNetcdfDialog({
     const gen = opGen.current;
     setError(null);
     setStatus(null);
+    // Clear any prior result so the picker hides and "Add layer" disables while
+    // a new URL is loading (avoids submitting a variable from the old manifest).
+    setVariables([]);
+    setVariable("");
+    setLoadedRefs(null);
     setLoadingVars(true);
     try {
       const refs = await loadKerchunkReference(url.trim());
@@ -93,6 +103,7 @@ export function AddNetcdfDialog({
       }
       setVariables(vars);
       setVariable(vars[0].name);
+      setLoadedRefs(refs);
       setStatus(`Found ${vars.length} variable${vars.length > 1 ? "s" : ""}.`);
     } catch (err) {
       if (gen !== opGen.current) return;
@@ -122,12 +133,14 @@ export function AddNetcdfDialog({
         min !== undefined &&
         max !== undefined &&
         Number.isFinite(min) &&
-        Number.isFinite(max)
+        Number.isFinite(max) &&
+        min < max
           ? ([min, max] as [number, number])
           : undefined;
 
       await addCloudNetcdfLayer(appApi, {
         url: url.trim(),
+        refs: loadedRefs ?? undefined,
         variable,
         selector: leadingDims.length > 0 ? selector : undefined,
         clim,
@@ -171,7 +184,14 @@ export function AddNetcdfDialog({
                 id="netcdf-url"
                 placeholder="https://example.com/data.kerchunk.json"
                 value={url}
-                onChange={(event) => setUrl(event.target.value)}
+                onChange={(event) => {
+                  setUrl(event.target.value);
+                  // Invalidate variables loaded from a different URL.
+                  setVariables([]);
+                  setVariable("");
+                  setLoadedRefs(null);
+                  setStatus(null);
+                }}
               />
               <Button
                 type="button"

--- a/apps/geolibre-desktop/src/components/layout/AddNetcdfDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddNetcdfDialog.tsx
@@ -105,7 +105,8 @@ export function AddNetcdfDialog({
     try {
       const selector: Record<string, number> = {};
       for (const dim of leadingDims) {
-        selector[dim] = Number(dimIndex[dim] ?? "0") || 0;
+        const parsed = Number(dimIndex[dim] ?? "0");
+        selector[dim] = Number.isFinite(parsed) ? parsed : 0;
       }
       const min = climMin.trim() === "" ? undefined : Number(climMin);
       const max = climMax.trim() === "" ? undefined : Number(climMax);

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -150,6 +150,7 @@ import { mergeStringLists } from "../../lib/string-lists";
 import { normalizeProjectUrl } from "../../lib/urls";
 import { resolveProjectXyzLayers } from "../../lib/xyz-url";
 import { AddDataDialog, type AddDataKind } from "./AddDataDialog";
+import { AddNetcdfDialog } from "./AddNetcdfDialog";
 import { AboutDialog } from "./AboutDialog";
 import { NewProjectDialog } from "./NewProjectDialog";
 import { ManagePluginsDialog } from "./ManagePluginsDialog";
@@ -285,6 +286,7 @@ export function TopToolbar({
     ),
   );
   const [addDataKind, setAddDataKind] = useState<AddDataKind | null>(null);
+  const [netcdfDialogOpen, setNetcdfDialogOpen] = useState(false);
   const [newProjectDialogOpen, setNewProjectDialogOpen] = useState(false);
   const [projectUrlDialogOpen, setProjectUrlDialogOpen] = useState(false);
   const [managePluginsOpen, setManagePluginsOpen] = useState(false);
@@ -796,6 +798,9 @@ export function TopToolbar({
   const handleAddZarrLayer = () => {
     openZarrLayerPanel(appApi);
   };
+  const handleAddNetcdfLayer = () => {
+    setNetcdfDialogOpen(true);
+  };
   const handleAddLidarLayer = () => {
     openLidarLayerPanel(appApi);
   };
@@ -1053,6 +1058,9 @@ export function TopToolbar({
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={handleAddZarrLayer}>
             Zarr Layer
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={handleAddNetcdfLayer}>
+            NetCDF / HDF
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuLabel className="text-xs text-muted-foreground">
@@ -1497,6 +1505,11 @@ export function TopToolbar({
         onOpenChange={(open: boolean) => {
           if (!open) setAddDataKind(null);
         }}
+      />
+      <AddNetcdfDialog
+        open={netcdfDialogOpen}
+        appApi={appApi}
+        onOpenChange={setNetcdfDialogOpen}
       />
       <Dialog
         open={projectUrlDialogOpen}

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.4.0",
         "maplibre-gl-basemap-control": "^0.3.0",
-        "maplibre-gl-components": "^0.20.3",
+        "maplibre-gl-components": "^0.20.4",
         "maplibre-gl-duckdb": "^0.2.0",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -160,9 +160,9 @@
       "license": "MIT"
     },
     "apps/geolibre-desktop/node_modules/maplibre-gl-components": {
-      "version": "0.20.3",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.20.3.tgz",
-      "integrity": "sha512-BccuYY4zw9l3bOFn8EF/Rb1ylvvuxGcPmpdn3gGfZo8uc8jp5uLJLSoo9nENPHv1lp/iXbjE8cbKmamprOWi8g==",
+      "version": "0.20.4",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.20.4.tgz",
+      "integrity": "sha512-19ppFw9uCT58TjqujiqHwuyHi02eC/CCTD3XGKrAklQ+wxJz/tvelENxyS8Lt9C/q6cT/QTSFqyt3e3aHSMICg==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",
@@ -17810,7 +17810,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.4.0",
         "maplibre-gl-basemap-control": "^0.3.0",
-        "maplibre-gl-components": "^0.20.3",
+        "maplibre-gl-components": "^0.20.4",
         "maplibre-gl-duckdb": "^0.2.0",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -17847,9 +17847,9 @@
       }
     },
     "packages/plugins/node_modules/maplibre-gl-components": {
-      "version": "0.20.3",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.20.3.tgz",
-      "integrity": "sha512-BccuYY4zw9l3bOFn8EF/Rb1ylvvuxGcPmpdn3gGfZo8uc8jp5uLJLSoo9nENPHv1lp/iXbjE8cbKmamprOWi8g==",
+      "version": "0.20.4",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.20.4.tgz",
+      "integrity": "sha512-19ppFw9uCT58TjqujiqHwuyHi02eC/CCTD3XGKrAklQ+wxJz/tvelENxyS8Lt9C/q6cT/QTSFqyt3e3aHSMICg==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -30,7 +30,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.4.0",
     "maplibre-gl-basemap-control": "^0.3.0",
-    "maplibre-gl-components": "^0.20.3",
+    "maplibre-gl-components": "^0.20.4",
     "maplibre-gl-duckdb": "^0.2.0",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -47,6 +47,8 @@ export {
   openStacSearchLayerPanel,
   openViewStatePanel,
   openZarrLayerPanel,
+  addCloudNetcdfLayer,
+  type CloudNetcdfLayerOptions,
   subscribeBookmarkPanel,
   subscribeColorbarPanel,
   subscribeHtmlPanel,
@@ -58,6 +60,14 @@ export {
   subscribeViewStatePanel,
   type CogRasterLayerOptions,
 } from "./plugins/maplibre-components";
+export {
+  KerchunkReferenceStore,
+  loadKerchunkReference,
+  listKerchunkVariables,
+  normalizeKerchunkReference,
+  type KerchunkRefs,
+  type KerchunkVariable,
+} from "./plugins/kerchunk-reference-store";
 export {
   closeDuckDBLayerPanel,
   getDuckDBFeatureBounds,

--- a/packages/plugins/src/plugins/kerchunk-reference-store.ts
+++ b/packages/plugins/src/plugins/kerchunk-reference-store.ts
@@ -70,7 +70,10 @@ export function normalizeKerchunkReference(
   if (!refs) {
     throw new Error("Invalid kerchunk reference: no `refs` found.");
   }
-  if (doc.templates || (Array.isArray(doc.gen) && doc.gen.length > 0)) {
+  if (
+    (doc.templates && Object.keys(doc.templates).length > 0) ||
+    (Array.isArray(doc.gen) && doc.gen.length > 0)
+  ) {
     throw new Error(
       "Templated kerchunk references (templates/gen) are not supported."
     );
@@ -92,11 +95,13 @@ export function normalizeKerchunkReference(
 }
 
 function looksLikeFlatRefs(doc: KerchunkDocument): boolean {
-  // A flat v0 map has Zarr metadata keys directly (e.g. ".zgroup").
+  // Sufficient heuristic: real v0 manifests always include at least one Zarr
+  // metadata key at the root. A manifest with only chunk keys would fail here.
   return ".zgroup" in doc || ".zattrs" in doc || ".zarray" in doc;
 }
 
 function resolveUrl(url: string, base?: string): string {
+  if (!url) return url; // empty URL: don't resolve to the manifest itself
   if (/^[a-z][a-z0-9+.-]*:\/\//i.test(url)) return url; // already absolute
   if (!base) return url;
   try {

--- a/packages/plugins/src/plugins/kerchunk-reference-store.ts
+++ b/packages/plugins/src/plugins/kerchunk-reference-store.ts
@@ -33,9 +33,14 @@ type FetchImpl = (
 ) => Promise<{
   status: number;
   arrayBuffer(): Promise<ArrayBuffer>;
+  headers?: { get(name: string): string | null };
 }>;
 
 const BASE64_PREFIX = "base64:";
+
+// Best-effort guard against a user-supplied URL pointing at an oversized
+// manifest exhausting memory. Honored only when Content-Length is present.
+const MAX_MANIFEST_BYTES = 256 * 1024 * 1024;
 
 function decodeBase64(b64: string): Uint8Array {
   const binary = atob(b64);
@@ -82,19 +87,24 @@ export function normalizeKerchunkReference(
   const resolved: KerchunkRefs = {};
   for (const [key, value] of Object.entries(refs)) {
     if (Array.isArray(value) && typeof value[0] === "string") {
-      const url = resolveUrl(value[0], referenceUrl);
+      // The declared type is a lie for untrusted input; validate the raw array.
+      const arr = value as unknown[];
+      const url = resolveUrl(arr[0] as string, referenceUrl);
+      if (arr.length === 2) {
+        throw new Error(
+          `Invalid kerchunk reference for key "${key}": array refs must have 1 element (whole file) or 3 (url, offset, length), got 2.`
+        );
+      }
       if (
-        value.length >= 3 &&
-        (typeof value[1] !== "number" || typeof value[2] !== "number")
+        arr.length >= 3 &&
+        (typeof arr[1] !== "number" || typeof arr[2] !== "number")
       ) {
         throw new Error(
           `Invalid kerchunk reference for key "${key}": offset and length must be numbers.`
         );
       }
       resolved[key] =
-        value.length >= 3
-          ? [url, value[1] as number, value[2] as number]
-          : [url];
+        arr.length >= 3 ? [url, arr[1] as number, arr[2] as number] : [url];
     } else {
       resolved[key] = value;
     }
@@ -254,6 +264,12 @@ export async function loadKerchunkReference(
   );
   if (res.status !== 200) {
     throw new Error(`Failed to fetch kerchunk reference: HTTP ${res.status}`);
+  }
+  const contentLength = Number(res.headers?.get?.("content-length") ?? 0);
+  if (contentLength > MAX_MANIFEST_BYTES) {
+    throw new Error(
+      `Kerchunk manifest too large: ${contentLength} bytes (limit ${MAX_MANIFEST_BYTES}).`
+    );
   }
   const text = new TextDecoder().decode(await res.arrayBuffer());
   const doc = JSON.parse(text) as KerchunkDocument;

--- a/packages/plugins/src/plugins/kerchunk-reference-store.ts
+++ b/packages/plugins/src/plugins/kerchunk-reference-store.ts
@@ -1,0 +1,238 @@
+// A kerchunk-reference store for rendering Cloud-Optimized NetCDF/HDF5 through
+// the Zarr layer pipeline. A kerchunk reference manifest maps Zarr keys to
+// either inline metadata/data or an [url, offset, length] byte range inside the
+// original HDF5/NetCDF file. This store implements the minimal zarrita
+// `Readable` interface (`get(key)`) so it can be handed to
+// `ZarrLayerControl.addLayer(url, variable, { store })`, letting the existing
+// Zarr renderer draw HDF5/NetCDF data over HTTP range requests with no rewrite.
+//
+// Reference: https://guide.cloudnativegeo.org/cloud-optimized-netcdf4-hdf5/
+
+/** A single kerchunk reference value. */
+export type KerchunkRef =
+  | string // inline: JSON metadata, raw text, or "base64:<...>" binary
+  | [string] // whole referenced file
+  | [string, number, number]; // [url, offset, length] byte range
+
+/** The `refs` map of a kerchunk manifest: Zarr key -> reference value. */
+export type KerchunkRefs = Record<string, KerchunkRef>;
+
+/** A parsed kerchunk document (v1 `{ version, refs }` or a flat v0 map). */
+export interface KerchunkDocument {
+  version?: number;
+  refs?: KerchunkRefs;
+  // v1 may include templates/gen for parametrized URLs (unsupported here).
+  templates?: Record<string, string>;
+  gen?: unknown[];
+  [key: string]: unknown;
+}
+
+type FetchImpl = (
+  input: string,
+  init?: { headers?: Record<string, string> }
+) => Promise<{
+  status: number;
+  arrayBuffer(): Promise<ArrayBuffer>;
+}>;
+
+const BASE64_PREFIX = "base64:";
+
+function decodeBase64(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+  return out;
+}
+
+/**
+ * Normalize a parsed kerchunk document into a flat `refs` map with every
+ * referenced chunk URL resolved to an absolute URL.
+ *
+ * Handles both the v1 `{ version, refs }` envelope and the v0 flat map. Chunk
+ * URLs that are relative are resolved against `referenceUrl` (the location the
+ * manifest was loaded from), matching how cloud-native references are shipped
+ * alongside, or pointing at, the original data file. Inline values are left
+ * untouched.
+ *
+ * @param doc Parsed kerchunk JSON.
+ * @param referenceUrl URL the manifest was fetched from; used to resolve
+ *   relative chunk URLs.
+ * @returns A flat `refs` map ready to back a {@link KerchunkReferenceStore}.
+ * @throws If the document uses unsupported `templates`/`gen` URL generation, or
+ *   has no `refs`.
+ */
+export function normalizeKerchunkReference(
+  doc: KerchunkDocument,
+  referenceUrl?: string
+): KerchunkRefs {
+  const refs: KerchunkRefs | undefined =
+    doc.refs ?? (looksLikeFlatRefs(doc) ? (doc as KerchunkRefs) : undefined);
+  if (!refs) {
+    throw new Error("Invalid kerchunk reference: no `refs` found.");
+  }
+  if (doc.templates || (Array.isArray(doc.gen) && doc.gen.length > 0)) {
+    throw new Error(
+      "Templated kerchunk references (templates/gen) are not supported."
+    );
+  }
+
+  const resolved: KerchunkRefs = {};
+  for (const [key, value] of Object.entries(refs)) {
+    if (Array.isArray(value) && typeof value[0] === "string") {
+      const url = resolveUrl(value[0], referenceUrl);
+      resolved[key] =
+        value.length >= 3
+          ? [url, value[1] as number, value[2] as number]
+          : [url];
+    } else {
+      resolved[key] = value;
+    }
+  }
+  return resolved;
+}
+
+function looksLikeFlatRefs(doc: KerchunkDocument): boolean {
+  // A flat v0 map has Zarr metadata keys directly (e.g. ".zgroup").
+  return ".zgroup" in doc || ".zattrs" in doc || ".zarray" in doc;
+}
+
+function resolveUrl(url: string, base?: string): string {
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(url)) return url; // already absolute
+  if (!base) return url;
+  try {
+    return new URL(url, base).toString();
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * A zarrita-compatible `Readable` backed by a kerchunk reference map. Resolves
+ * each Zarr key to inline bytes (metadata or `base64:` data) or an HTTP byte
+ * range read into the referenced HDF5/NetCDF file.
+ */
+export class KerchunkReferenceStore {
+  private readonly refs: KerchunkRefs;
+  private readonly fetchImpl: FetchImpl;
+  private readonly headers?: Record<string, string>;
+
+  constructor(
+    refs: KerchunkRefs,
+    options: { fetchImpl?: FetchImpl; headers?: Record<string, string> } = {}
+  ) {
+    this.refs = refs;
+    this.fetchImpl =
+      options.fetchImpl ?? (globalThis.fetch as unknown as FetchImpl);
+    this.headers = options.headers;
+  }
+
+  /**
+   * Resolve a Zarr key to its bytes.
+   *
+   * @param key Zarr key, with or without a leading slash (e.g. `/air/0.0.0`).
+   * @returns The bytes for the key, or `undefined` if the key is not present.
+   */
+  async get(key: string): Promise<Uint8Array | undefined> {
+    const normalized = key.startsWith("/") ? key.slice(1) : key;
+    const value = this.refs[normalized];
+    if (value === undefined) return undefined;
+
+    if (typeof value === "string") {
+      return value.startsWith(BASE64_PREFIX)
+        ? decodeBase64(value.slice(BASE64_PREFIX.length))
+        : new TextEncoder().encode(value);
+    }
+
+    const [url, offset, length] = value;
+    const init =
+      value.length >= 3
+        ? {
+            headers: {
+              ...this.headers,
+              Range: `bytes=${offset}-${
+                (offset as number) + (length as number) - 1
+              }`,
+            },
+          }
+        : this.headers
+        ? { headers: { ...this.headers } }
+        : undefined;
+    const res = await this.fetchImpl(url, init);
+    if (res.status !== 206 && res.status !== 200) {
+      throw new Error(
+        `Kerchunk range read failed: ${url} -> HTTP ${res.status}`
+      );
+    }
+    return new Uint8Array(await res.arrayBuffer());
+  }
+}
+
+/** A renderable array discovered in a kerchunk reference. */
+export interface KerchunkVariable {
+  /** Array name (Zarr path, e.g. `air` or `group/temperature`). */
+  name: string;
+  /** Dimension names in order, when present (`_ARRAY_DIMENSIONS`). */
+  dims: string[];
+  /** Array shape. */
+  shape: number[];
+}
+
+/**
+ * List the renderable variables in a kerchunk reference: arrays with at least
+ * two dimensions (gridded data), excluding 1-D coordinate arrays such as
+ * lat/lon/time. Used to populate the variable picker.
+ *
+ * @param refs A normalized kerchunk `refs` map.
+ * @returns The renderable variables, sorted by name.
+ */
+export function listKerchunkVariables(refs: KerchunkRefs): KerchunkVariable[] {
+  const out: KerchunkVariable[] = [];
+  for (const [key, value] of Object.entries(refs)) {
+    if (!key.endsWith("/.zarray") || typeof value !== "string") continue;
+    const name = key.slice(0, -"/.zarray".length);
+    let shape: number[] = [];
+    try {
+      shape = (JSON.parse(value).shape as number[]) ?? [];
+    } catch {
+      continue;
+    }
+    if (shape.length < 2) continue; // skip coordinate / scalar arrays
+
+    let dims: string[] = [];
+    const attrs = refs[`${name}/.zattrs`];
+    if (typeof attrs === "string") {
+      try {
+        dims = (JSON.parse(attrs)._ARRAY_DIMENSIONS as string[]) ?? [];
+      } catch {
+        dims = [];
+      }
+    }
+    out.push({ name, dims, shape });
+  }
+  return out.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Fetch and normalize a kerchunk reference manifest from a URL.
+ *
+ * @param url URL of the kerchunk reference JSON.
+ * @param options Optional `fetchImpl` (for testing) and request `headers`.
+ * @returns The normalized `refs` map.
+ */
+export async function loadKerchunkReference(
+  url: string,
+  options: { fetchImpl?: FetchImpl; headers?: Record<string, string> } = {}
+): Promise<KerchunkRefs> {
+  const fetchImpl =
+    options.fetchImpl ?? (globalThis.fetch as unknown as FetchImpl);
+  const res = await fetchImpl(
+    url,
+    options.headers ? { headers: options.headers } : undefined
+  );
+  if (res.status !== 200) {
+    throw new Error(`Failed to fetch kerchunk reference: HTTP ${res.status}`);
+  }
+  const text = new TextDecoder().decode(await res.arrayBuffer());
+  const doc = JSON.parse(text) as KerchunkDocument;
+  return normalizeKerchunkReference(doc, url);
+}

--- a/packages/plugins/src/plugins/kerchunk-reference-store.ts
+++ b/packages/plugins/src/plugins/kerchunk-reference-store.ts
@@ -34,6 +34,7 @@ type FetchImpl = (
   status: number;
   arrayBuffer(): Promise<ArrayBuffer>;
   headers?: { get(name: string): string | null };
+  body?: ReadableStream<Uint8Array> | null;
 }>;
 
 const BASE64_PREFIX = "base64:";
@@ -105,8 +106,12 @@ export function normalizeKerchunkReference(
       }
       resolved[key] =
         arr.length >= 3 ? [url, arr[1] as number, arr[2] as number] : [url];
-    } else {
+    } else if (typeof value === "string") {
       resolved[key] = value;
+    } else {
+      throw new Error(
+        `Invalid kerchunk reference for key "${key}": unexpected value type "${typeof value}".`
+      );
     }
   }
   return resolved;
@@ -245,6 +250,45 @@ export function listKerchunkVariables(refs: KerchunkRefs): KerchunkVariable[] {
   return out.sort((a, b) => a.name.localeCompare(b.name));
 }
 
+/** Read a response body into bytes, rejecting once it exceeds the size cap. */
+async function readCappedBody(res: {
+  arrayBuffer(): Promise<ArrayBuffer>;
+  body?: ReadableStream<Uint8Array> | null;
+}): Promise<Uint8Array> {
+  const reader = res.body?.getReader?.();
+  if (!reader) {
+    // No streamable body (e.g. a mocked fetch): buffer, then size-check.
+    const buf = new Uint8Array(await res.arrayBuffer());
+    if (buf.byteLength > MAX_MANIFEST_BYTES) throw manifestTooLargeError();
+    return buf;
+  }
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > MAX_MANIFEST_BYTES) {
+      await reader.cancel();
+      throw manifestTooLargeError();
+    }
+    chunks.push(value);
+  }
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out;
+}
+
+function manifestTooLargeError(): Error {
+  return new Error(
+    `Kerchunk manifest too large (limit ${MAX_MANIFEST_BYTES} bytes).`
+  );
+}
+
 /**
  * Fetch and normalize a kerchunk reference manifest from a URL.
  *
@@ -265,13 +309,16 @@ export async function loadKerchunkReference(
   if (res.status !== 200) {
     throw new Error(`Failed to fetch kerchunk reference: HTTP ${res.status}`);
   }
+  // Fast reject when the server advertises a too-large body...
   const contentLength = Number(res.headers?.get?.("content-length") ?? 0);
   if (contentLength > MAX_MANIFEST_BYTES) {
     throw new Error(
       `Kerchunk manifest too large: ${contentLength} bytes (limit ${MAX_MANIFEST_BYTES}).`
     );
   }
-  const text = new TextDecoder().decode(await res.arrayBuffer());
+  // ...and cap the actual bytes read, so chunked/compressed/header-less
+  // responses can't buffer an unbounded body into memory.
+  const text = new TextDecoder().decode(await readCappedBody(res));
   const doc = JSON.parse(text) as KerchunkDocument;
   return normalizeKerchunkReference(doc, url);
 }

--- a/packages/plugins/src/plugins/kerchunk-reference-store.ts
+++ b/packages/plugins/src/plugins/kerchunk-reference-store.ts
@@ -83,6 +83,14 @@ export function normalizeKerchunkReference(
   for (const [key, value] of Object.entries(refs)) {
     if (Array.isArray(value) && typeof value[0] === "string") {
       const url = resolveUrl(value[0], referenceUrl);
+      if (
+        value.length >= 3 &&
+        (typeof value[1] !== "number" || typeof value[2] !== "number")
+      ) {
+        throw new Error(
+          `Invalid kerchunk reference for key "${key}": offset and length must be numbers.`
+        );
+      }
       resolved[key] =
         value.length >= 3
           ? [url, value[1] as number, value[2] as number]
@@ -96,7 +104,9 @@ export function normalizeKerchunkReference(
 
 function looksLikeFlatRefs(doc: KerchunkDocument): boolean {
   // Sufficient heuristic: real v0 manifests always include at least one Zarr
-  // metadata key at the root. A manifest with only chunk keys would fail here.
+  // metadata key at the root. A chunk-keys-only manifest would fall through to
+  // the "no `refs` found" error, which is acceptable since real stores always
+  // include `.zgroup`.
   return ".zgroup" in doc || ".zattrs" in doc || ".zarray" in doc;
 }
 
@@ -197,7 +207,11 @@ export function listKerchunkVariables(refs: KerchunkRefs): KerchunkVariable[] {
     const name = key.slice(0, -"/.zarray".length);
     let shape: number[] = [];
     try {
-      shape = (JSON.parse(value).shape as number[]) ?? [];
+      const parsed = JSON.parse(value).shape;
+      shape =
+        Array.isArray(parsed) && parsed.every((n) => typeof n === "number")
+          ? parsed
+          : [];
     } catch {
       continue;
     }
@@ -207,7 +221,11 @@ export function listKerchunkVariables(refs: KerchunkRefs): KerchunkVariable[] {
     const attrs = refs[`${name}/.zattrs`];
     if (typeof attrs === "string") {
       try {
-        dims = (JSON.parse(attrs)._ARRAY_DIMENSIONS as string[]) ?? [];
+        const parsed = JSON.parse(attrs)._ARRAY_DIMENSIONS;
+        dims =
+          Array.isArray(parsed) && parsed.every((d) => typeof d === "string")
+            ? parsed
+            : [];
       } catch {
         dims = [];
       }

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -1723,6 +1723,11 @@ export async function addCloudNetcdfLayer(
     colormap: options.colormap,
     opacity: options.opacity,
   });
+
+  // Unlike openZarrLayerPanel, the dialog-based flow intentionally leaves the
+  // Zarr control collapsed/hidden: the layer is managed from the layer and
+  // style panels. Users can still open the Zarr panel from the menu to tweak
+  // colormap/clim.
 }
 
 export function openLidarLayerPanel(app: GeoLibreAppAPI): void {

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -74,6 +74,7 @@ import { ensureMercatorProjection } from "./map-projection-utils";
 import {
   KerchunkReferenceStore,
   loadKerchunkReference,
+  type KerchunkRefs,
 } from "./kerchunk-reference-store";
 
 type ControlGridConstructor =
@@ -1647,6 +1648,11 @@ export function openZarrLayerPanel(app: GeoLibreAppAPI): void {
 export interface CloudNetcdfLayerOptions {
   /** URL of the kerchunk reference manifest (JSON) for the NetCDF/HDF file. */
   url: string;
+  /**
+   * Pre-loaded, normalized reference map. When provided, the manifest is not
+   * fetched again (avoids a second download of a potentially large manifest).
+   */
+  refs?: KerchunkRefs;
   /** Variable (array) to render. */
   variable: string;
   /** Dimension selector for non-spatial dims, e.g. `{ time: 0 }`. */
@@ -1694,9 +1700,9 @@ export async function addCloudNetcdfLayer(
   // (matching the COG raster flow) so the layer paints.
   ensureMercatorProjection(app.getMap?.());
 
-  const refs = await loadKerchunkReference(options.url, {
-    headers: options.headers,
-  });
+  const refs =
+    options.refs ??
+    (await loadKerchunkReference(options.url, { headers: options.headers }));
   const store = new KerchunkReferenceStore(refs, { headers: options.headers });
 
   // The control is a module-level singleton and may have been torn down (set to

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -71,6 +71,10 @@ import type {
   GeoLibrePlugin,
 } from "../types";
 import { ensureMercatorProjection } from "./map-projection-utils";
+import {
+  KerchunkReferenceStore,
+  loadKerchunkReference,
+} from "./kerchunk-reference-store";
 
 type ControlGridConstructor =
   (typeof import("maplibre-gl-components"))["ControlGrid"];
@@ -1637,6 +1641,77 @@ export function openStacSearchLayerPanel(app: GeoLibreAppAPI): void {
 
 export function openZarrLayerPanel(app: GeoLibreAppAPI): void {
   void openStandaloneZarrControl(app);
+}
+
+/** Options for {@link addCloudNetcdfLayer}. */
+export interface CloudNetcdfLayerOptions {
+  /** URL of the kerchunk reference manifest (JSON) for the NetCDF/HDF file. */
+  url: string;
+  /** Variable (array) to render. */
+  variable: string;
+  /** Dimension selector for non-spatial dims, e.g. `{ time: 0 }`. */
+  selector?: Record<string, number | string>;
+  /** Color limits `[min, max]`. */
+  clim?: [number, number];
+  /** Colormap (array of hex colors). */
+  colormap?: string[];
+  /** Layer opacity (0-1). */
+  opacity?: number;
+  /** Optional request headers (e.g. for authenticated stores). */
+  headers?: Record<string, string>;
+}
+
+/**
+ * Add a Cloud-Optimized NetCDF/HDF5 layer by rendering it through the shared
+ * Zarr control with a kerchunk reference store. The reference manifest is
+ * fetched and normalized, a {@link KerchunkReferenceStore} resolves each chunk
+ * to an HTTP byte range inside the original file, and the store is handed to
+ * `ZarrLayerControl.addLayer(url, variable, { store })`. The resulting layer is
+ * tracked in the store like any other Zarr layer.
+ *
+ * @param app The GeoLibre app API.
+ * @param options Reference URL, variable, and optional styling/selector.
+ * @throws If the Zarr control cannot be mounted or the reference fails to load.
+ */
+export async function addCloudNetcdfLayer(
+  app: GeoLibreAppAPI,
+  options: CloudNetcdfLayerOptions,
+): Promise<void> {
+  const { ZarrLayerControl: ZarrLayerControlClass } =
+    await getComponentsConstructors();
+
+  zarrControl ??= createZarrControl(ZarrLayerControlClass);
+  if (!zarrControlMounted) {
+    const added = app.addMapControl(zarrControl, zarrControlPosition);
+    if (!added) {
+      zarrControl = null;
+      throw new Error("Could not add the Zarr control to the map.");
+    }
+    zarrControlMounted = true;
+  }
+
+  // The untiled Zarr renderer draws in Web Mercator; switch off globe first
+  // (matching the COG raster flow) so the layer paints.
+  ensureMercatorProjection(app.getMap?.());
+
+  const refs = await loadKerchunkReference(options.url, {
+    headers: options.headers,
+  });
+  const store = new KerchunkReferenceStore(refs, { headers: options.headers });
+
+  await zarrControl.addLayer(options.url, options.variable, {
+    store,
+    zarrVersion: 2,
+    selector: options.selector,
+    clim: options.clim,
+    colormap: options.colormap,
+    opacity: options.opacity,
+  });
+
+  const state = zarrControl.getState();
+  if (state.error) {
+    throw new Error(state.error);
+  }
 }
 
 export function openLidarLayerPanel(app: GeoLibreAppAPI): void {

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -1699,6 +1699,16 @@ export async function addCloudNetcdfLayer(
   });
   const store = new KerchunkReferenceStore(refs, { headers: options.headers });
 
+  // The control is a module-level singleton and may have been torn down (set to
+  // null on plugin deactivation) during the await above.
+  if (!zarrControl) {
+    throw new Error("The Zarr control was removed while loading the reference.");
+  }
+
+  // Success is tracked by the control's "layeradd" event (see createZarrControl),
+  // which adds the layer to the store. We intentionally do not read
+  // getState().error here: the control is shared, so the error may be stale from
+  // a prior operation, and addLayer resolves before async chunk loading finishes.
   await zarrControl.addLayer(options.url, options.variable, {
     store,
     zarrVersion: 2,
@@ -1707,11 +1717,6 @@ export async function addCloudNetcdfLayer(
     colormap: options.colormap,
     opacity: options.opacity,
   });
-
-  const state = zarrControl.getState();
-  if (state.error) {
-    throw new Error(state.error);
-  }
 }
 
 export function openLidarLayerPanel(app: GeoLibreAppAPI): void {

--- a/tests/kerchunk-reference-store.test.ts
+++ b/tests/kerchunk-reference-store.test.ts
@@ -207,6 +207,17 @@ describe("normalizeKerchunkReference", () => {
     );
   });
 
+  it("rejects a ref value that is neither a string nor an array", () => {
+    assert.throws(
+      () =>
+        normalizeKerchunkReference({
+          version: 1,
+          refs: { "air/.zattrs": 42 as unknown as string },
+        }),
+      /unexpected value type/
+    );
+  });
+
   it("throws when there are no refs", () => {
     assert.throws(
       () => normalizeKerchunkReference({ version: 1 }),

--- a/tests/kerchunk-reference-store.test.ts
+++ b/tests/kerchunk-reference-store.test.ts
@@ -179,6 +179,34 @@ describe("normalizeKerchunkReference", () => {
     assert.equal((refs["air/0.0.0"] as [string, number, number])[0], "");
   });
 
+  it("rejects a length-2 array ref (ambiguous: not whole-file or range)", () => {
+    assert.throws(
+      () =>
+        normalizeKerchunkReference({
+          version: 1,
+          refs: { "air/0.0.0": ["air.nc", 10] as unknown as [string] },
+        }),
+      /got 2/
+    );
+  });
+
+  it("rejects an array ref with non-numeric offset/length", () => {
+    assert.throws(
+      () =>
+        normalizeKerchunkReference({
+          version: 1,
+          refs: {
+            "air/0.0.0": ["air.nc", "x", 5] as unknown as [
+              string,
+              number,
+              number,
+            ],
+          },
+        }),
+      /must be numbers/
+    );
+  });
+
   it("throws when there are no refs", () => {
     assert.throws(
       () => normalizeKerchunkReference({ version: 1 }),

--- a/tests/kerchunk-reference-store.test.ts
+++ b/tests/kerchunk-reference-store.test.ts
@@ -147,6 +147,23 @@ describe("normalizeKerchunkReference", () => {
     );
   });
 
+  it("accepts an empty templates object (a no-op)", () => {
+    const refs = normalizeKerchunkReference({
+      version: 1,
+      refs: { ".zgroup": '{"zarr_format":2}' },
+      templates: {},
+    });
+    assert.equal(refs[".zgroup"], '{"zarr_format":2}');
+  });
+
+  it("does not resolve an empty chunk URL to the manifest itself", () => {
+    const refs = normalizeKerchunkReference(
+      { version: 1, refs: { "air/0.0.0": ["", 0, 5] } },
+      "https://host.example/ref.json"
+    );
+    assert.equal((refs["air/0.0.0"] as [string, number, number])[0], "");
+  });
+
   it("throws when there are no refs", () => {
     assert.throws(
       () => normalizeKerchunkReference({ version: 1 }),

--- a/tests/kerchunk-reference-store.test.ts
+++ b/tests/kerchunk-reference-store.test.ts
@@ -77,6 +77,21 @@ describe("KerchunkReferenceStore.get", () => {
     assert.equal(calls[0].range, "bytes=2-4");
   });
 
+  it("throws when range fetch returns an unexpected HTTP status", async () => {
+    const fetchImpl = async () => ({
+      status: 416,
+      arrayBuffer: async () => new ArrayBuffer(0),
+    });
+    const store = new KerchunkReferenceStore(
+      { "air/0.0.0": ["http://data/air.nc", 2, 3] },
+      { fetchImpl }
+    );
+    await assert.rejects(
+      () => store.get("air/0.0.0"),
+      /Kerchunk range read failed/
+    );
+  });
+
   it("merges custom headers into range requests", async () => {
     const { fetchImpl, calls } = fakeRangeFetch(new Uint8Array([0, 0, 0, 0]));
     const captured: Record<string, string>[] = [];
@@ -214,6 +229,27 @@ describe("loadKerchunkReference", () => {
     assert.deepEqual(refs["air/0.0.0"], ["https://h.example/d/air.nc", 0, 4]);
   });
 
+  it("forwards custom headers to the manifest fetch", async () => {
+    const seen: Array<Record<string, string> | undefined> = [];
+    const fetchImpl = async (
+      _url: string,
+      init?: { headers?: Record<string, string> }
+    ) => {
+      seen.push(init?.headers);
+      return {
+        status: 200,
+        arrayBuffer: async () =>
+          new TextEncoder().encode(JSON.stringify({ version: 1, refs: {} }))
+            .buffer as ArrayBuffer,
+      };
+    };
+    await loadKerchunkReference("https://h.example/d/ref.json", {
+      fetchImpl,
+      headers: { Authorization: "Bearer t" },
+    });
+    assert.equal(seen[0]?.Authorization, "Bearer t");
+  });
+
   it("throws on a non-200 response", async () => {
     const fetchImpl = async () => ({
       status: 404,
@@ -222,6 +258,18 @@ describe("loadKerchunkReference", () => {
     await assert.rejects(
       () => loadKerchunkReference("https://h/ref.json", { fetchImpl }),
       /HTTP 404/
+    );
+  });
+
+  it("rejects when the response body is not valid JSON", async () => {
+    const fetchImpl = async () => ({
+      status: 200,
+      arrayBuffer: async () =>
+        new TextEncoder().encode("not json").buffer as ArrayBuffer,
+    });
+    await assert.rejects(
+      () => loadKerchunkReference("https://h/ref.json", { fetchImpl }),
+      SyntaxError
     );
   });
 });

--- a/tests/kerchunk-reference-store.test.ts
+++ b/tests/kerchunk-reference-store.test.ts
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  KerchunkReferenceStore,
+  normalizeKerchunkReference,
+  listKerchunkVariables,
+  loadKerchunkReference,
+  type KerchunkRefs,
+} from "../packages/plugins/src/plugins/kerchunk-reference-store";
+
+function utf8(bytes: Uint8Array | undefined): string {
+  return new TextDecoder().decode(bytes);
+}
+
+// A minimal fake fetch returning a 206 over a fixed buffer, recording the Range.
+function fakeRangeFetch(buffer: Uint8Array) {
+  const calls: { url: string; range?: string }[] = [];
+  const fetchImpl = async (
+    url: string,
+    init?: { headers?: Record<string, string> }
+  ) => {
+    const range = init?.headers?.Range;
+    calls.push({ url, range });
+    let slice = buffer;
+    if (range) {
+      const m = /bytes=(\d+)-(\d+)/.exec(range)!;
+      slice = buffer.slice(Number(m[1]), Number(m[2]) + 1);
+    }
+    return {
+      status: range ? 206 : 200,
+      arrayBuffer: async () =>
+        slice.buffer.slice(
+          slice.byteOffset,
+          slice.byteOffset + slice.byteLength
+        ),
+    };
+  };
+  return { fetchImpl, calls };
+}
+
+describe("KerchunkReferenceStore.get", () => {
+  it("returns inline JSON metadata as UTF-8 bytes", async () => {
+    const refs: KerchunkRefs = { ".zgroup": '{"zarr_format":2}' };
+    const store = new KerchunkReferenceStore(refs);
+    assert.equal(utf8(await store.get(".zgroup")), '{"zarr_format":2}');
+  });
+
+  it("decodes base64 inline binary", async () => {
+    const raw = new Uint8Array([1, 2, 3, 250]);
+    const b64 = Buffer.from(raw).toString("base64");
+    const store = new KerchunkReferenceStore({ "lat/0": `base64:${b64}` });
+    assert.deepEqual([...(await store.get("lat/0"))!], [1, 2, 3, 250]);
+  });
+
+  it("normalizes a leading slash in the key", async () => {
+    const store = new KerchunkReferenceStore({
+      "air/.zarray": '{"shape":[2,2]}',
+    });
+    assert.equal(utf8(await store.get("/air/.zarray")), '{"shape":[2,2]}');
+  });
+
+  it("returns undefined for a missing key", async () => {
+    const store = new KerchunkReferenceStore({});
+    assert.equal(await store.get("/nope"), undefined);
+  });
+
+  it("does an HTTP byte-range read for chunk refs", async () => {
+    const file = new Uint8Array([10, 11, 12, 13, 14, 15, 16, 17]);
+    const { fetchImpl, calls } = fakeRangeFetch(file);
+    const store = new KerchunkReferenceStore(
+      { "air/0.0.0": ["http://data/air.nc", 2, 3] },
+      { fetchImpl }
+    );
+    const bytes = await store.get("air/0.0.0");
+    assert.deepEqual([...bytes!], [12, 13, 14]);
+    assert.equal(calls[0].url, "http://data/air.nc");
+    assert.equal(calls[0].range, "bytes=2-4");
+  });
+
+  it("merges custom headers into range requests", async () => {
+    const { fetchImpl, calls } = fakeRangeFetch(new Uint8Array([0, 0, 0, 0]));
+    const captured: Record<string, string>[] = [];
+    const wrapped = async (
+      url: string,
+      init?: { headers?: Record<string, string> }
+    ) => {
+      captured.push(init?.headers ?? {});
+      return fetchImpl(url, init);
+    };
+    const store = new KerchunkReferenceStore(
+      { "v/0": ["http://d/x", 0, 2] },
+      { fetchImpl: wrapped, headers: { Authorization: "Bearer t" } }
+    );
+    await store.get("v/0");
+    assert.equal(captured[0].Authorization, "Bearer t");
+    assert.match(captured[0].Range, /^bytes=/);
+    assert.ok(calls.length === 1);
+  });
+});
+
+describe("normalizeKerchunkReference", () => {
+  it("unwraps the v1 { version, refs } envelope", () => {
+    const refs = normalizeKerchunkReference({
+      version: 1,
+      refs: { ".zgroup": '{"zarr_format":2}' },
+    });
+    assert.equal(refs[".zgroup"], '{"zarr_format":2}');
+  });
+
+  it("accepts a flat v0 reference map", () => {
+    const refs = normalizeKerchunkReference({
+      ".zgroup": '{"zarr_format":2}',
+      "air/0.0.0": ["http://d/air.nc", 0, 5],
+    });
+    assert.deepEqual(refs["air/0.0.0"], ["http://d/air.nc", 0, 5]);
+  });
+
+  it("resolves relative chunk URLs against the reference URL", () => {
+    const refs = normalizeKerchunkReference(
+      { version: 1, refs: { "air/0.0.0": ["air.nc", 10, 20] } },
+      "https://host.example/data/air.kerchunk.json"
+    );
+    assert.deepEqual(refs["air/0.0.0"], [
+      "https://host.example/data/air.nc",
+      10,
+      20,
+    ]);
+  });
+
+  it("leaves absolute chunk URLs unchanged", () => {
+    const refs = normalizeKerchunkReference(
+      { version: 1, refs: { "air/0.0.0": ["s3://bucket/air.nc", 1, 2] } },
+      "https://host.example/ref.json"
+    );
+    assert.equal((refs["air/0.0.0"] as string[])[0], "s3://bucket/air.nc");
+  });
+
+  it("rejects templated references", () => {
+    assert.throws(
+      () =>
+        normalizeKerchunkReference({
+          version: 1,
+          refs: {},
+          templates: { u: "http://d/{}" },
+        }),
+      /templated/i
+    );
+  });
+
+  it("throws when there are no refs", () => {
+    assert.throws(
+      () => normalizeKerchunkReference({ version: 1 }),
+      /no `refs`/
+    );
+  });
+});
+
+describe("listKerchunkVariables", () => {
+  const refs: KerchunkRefs = {
+    ".zgroup": '{"zarr_format":2}',
+    "air/.zarray": '{"shape":[200,25,53],"dtype":"<f8"}',
+    "air/.zattrs": '{"_ARRAY_DIMENSIONS":["time","lat","lon"]}',
+    "lat/.zarray": '{"shape":[25],"dtype":"<f4"}',
+    "lat/0": "base64:AAA=",
+    "lon/.zarray": '{"shape":[53],"dtype":"<f4"}',
+  };
+
+  it("returns gridded arrays (>=2 dims) and excludes 1-D coordinates", () => {
+    const vars = listKerchunkVariables(refs);
+    assert.deepEqual(
+      vars.map((v) => v.name),
+      ["air"]
+    );
+  });
+
+  it("reports dimension names and shape", () => {
+    const [air] = listKerchunkVariables(refs);
+    assert.deepEqual(air.dims, ["time", "lat", "lon"]);
+    assert.deepEqual(air.shape, [200, 25, 53]);
+  });
+});
+
+describe("loadKerchunkReference", () => {
+  it("fetches, parses, and normalizes a manifest", async () => {
+    const doc = JSON.stringify({
+      version: 1,
+      refs: { "air/0.0.0": ["air.nc", 0, 4] },
+    });
+    const fetchImpl = async () => ({
+      status: 200,
+      arrayBuffer: async () =>
+        new TextEncoder().encode(doc).buffer as ArrayBuffer,
+    });
+    const refs = await loadKerchunkReference("https://h.example/d/ref.json", {
+      fetchImpl,
+    });
+    assert.deepEqual(refs["air/0.0.0"], ["https://h.example/d/air.nc", 0, 4]);
+  });
+
+  it("throws on a non-200 response", async () => {
+    const fetchImpl = async () => ({
+      status: 404,
+      arrayBuffer: async () => new ArrayBuffer(0),
+    });
+    await assert.rejects(
+      () => loadKerchunkReference("https://h/ref.json", { fetchImpl }),
+      /HTTP 404/
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds support for **Cloud-Optimized NetCDF/HDF5** datasets. The data is rendered through the existing Zarr pipeline by backing the Zarr layer with a **kerchunk reference store**: a kerchunk manifest maps each Zarr chunk key to an HTTP byte range inside the original HDF5/NetCDF file, so chunks are read over range requests with no conversion or rewrite.

Reference: [Cloud-Optimized NetCDF/HDF5 guide](https://guide.cloudnativegeo.org/cloud-optimized-netcdf4-hdf5/).

## What's included

- **`KerchunkReferenceStore`** (`packages/plugins/src/plugins/kerchunk-reference-store.ts`): a zarrita-compatible `Readable` that resolves a key to inline JSON metadata, `base64:` inline data, or an `[url, offset, length]` byte-range read. Plus:
  - `loadKerchunkReference` — fetch + normalize (v0 flat and v1 `{ version, refs }`), resolving relative chunk URLs against the manifest location.
  - `listKerchunkVariables` — renderable 2-D+ arrays (excludes 1-D coordinates).
  - Covered by **16 unit tests** (`tests/kerchunk-reference-store.test.ts`).
- **`addCloudNetcdfLayer`** (`maplibre-components`): mounts the shared Zarr control, switches to Web Mercator (matching the COG flow), builds the store, and calls `ZarrLayerControl.addLayer(url, variable, { store })`.
- **UI**: Add Data → Cloud formats → **"NetCDF / HDF"** opens a dialog to enter a kerchunk reference URL, load its variables, pick a variable / dimension index / color range, and add the layer. A real sample (NOAA NCEP reanalysis air temperature) is pre-filled.

## Dependency

Bumps `maplibre-gl-components` to **^0.20.4**, which exposes the custom `store` passthrough on `ZarrLayerControl.addLayer` (opengeos/maplibre-gl-components#97). No CSP changes needed — both the Tauri and nginx `connect-src` already allow `https:`.

## Sample data

The sample dataset is hosted externally on Source Cooperative (CORS-enabled, range-capable) and is **not bundled** in the repo:
`https://data.source.coop/giswqs/opengeos/netcdf/air-temperature.kerchunk.json`

## Verification

- Built end-to-end and tested in the running app with playwright: Add Data → NetCDF / HDF (sample pre-filled) → Load variables (`air (time, lat, lon)`) → Add layer. Network log shows `air-temperature.kerchunk.json => 200` and `air-temperature.nc => 206 Partial Content` range reads to Source Cooperative, and the temperature field renders over North America.
- Gates: full build (tsc + vite) clean, 266/266 frontend tests pass, pre-commit (incl. npm-build) green.

## Known limitations (follow-ups)

- Project-reload restore matches existing Zarr-layer behavior (no auto re-render yet); a kerchunk-aware restore is a follow-up.
- Swath/curvilinear grids and HDF4 are deferred (need server-side regridding / GDAL).
- A sidecar `/raster/virtualize` endpoint to generate references from raw `.nc`/`.h5` is a planned follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for Cloud-Optimized NetCDF/HDF5 layers via kerchunk manifest URLs.
  * New "NetCDF / HDF" Add Data dialog to load a manifest, pick variables, set leading-dimension indices, and configure color range/colormap/opacity; includes sample prefill and status/error feedback.

* **Chores**
  * Bumped maplibre-gl-components dependency.

* **Tests**
  * Added tests for manifest loading, variable discovery, and range fetch handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->