### PR TITLE
feat(data): add Deck.gl Layer builder for uploaded files and URLs

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@carbonplan/zarr-layer": "^0.5.0",
+    "@deck.gl/aggregation-layers": "9.3.3",
     "@deck.gl/core": "^9.3.3",
     "@deck.gl/geo-layers": "^9.3.3",
     "@deck.gl/layers": "^9.3.3",

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -865,6 +865,10 @@ export function AddDataDialog({
       );
     }
 
+    const bounds =
+      parsed.format === "geojson"
+        ? undefined
+        : (computeDeckVizBounds(parsed.rows ?? [], mapping) ?? undefined);
     const layer = createDeckVizStoreLayer({
       name: layerName.trim() || def.label,
       config: {
@@ -876,13 +880,15 @@ export function AddDataDialog({
       rows: parsed.format === "geojson" ? undefined : parsed.rows,
       geojson: parsed.geojson,
       sourcePath,
+      bounds,
     });
     addLayer(layer, beforeLayer);
+    // GeoJSON fits from its geometry; row-based layers fit from the stored
+    // bounds (also used by the layer panel's "Zoom to layer").
     if (def.format === "geojson") {
       mapControllerRef.current?.fitLayer(layer);
-    } else {
-      const bounds = computeDeckVizBounds(parsed.rows ?? [], mapping);
-      if (bounds) mapControllerRef.current?.fitBounds(bounds);
+    } else if (bounds) {
+      mapControllerRef.current?.fitBounds(bounds);
     }
     closeDialog();
   };

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -1835,7 +1835,9 @@ export function AddDataDialog({
                           setDeckVizRole(role.key, event.target.value)
                         }
                       >
-                        {!role.required ? <option value="">(none)</option> : null}
+                        <option value="">
+                          {role.required ? "— select —" : "(none)"}
+                        </option>
                         {deckVizParsed.columns.map((column) => (
                           <option
                             key={String(column.value)}
@@ -1879,7 +1881,9 @@ export function AddDataDialog({
                         onChange={(event) =>
                           setDeckVizStyle((style) => ({
                             ...style,
-                            radius: Number(event.target.value) || 0,
+                            radius: Number.isFinite(Number(event.target.value))
+                              ? Number(event.target.value)
+                              : style.radius,
                           }))
                         }
                       />
@@ -1895,7 +1899,9 @@ export function AddDataDialog({
                         onChange={(event) =>
                           setDeckVizStyle((style) => ({
                             ...style,
-                            cellSize: Number(event.target.value) || 0,
+                            cellSize: Number.isFinite(Number(event.target.value))
+                              ? Number(event.target.value)
+                              : style.cellSize,
                           }))
                         }
                       />
@@ -1911,7 +1917,9 @@ export function AddDataDialog({
                         onChange={(event) =>
                           setDeckVizStyle((style) => ({
                             ...style,
-                            lineWidth: Number(event.target.value) || 0,
+                            lineWidth: Number.isFinite(Number(event.target.value))
+                              ? Number(event.target.value)
+                              : style.lineWidth,
                           }))
                         }
                       />

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -1697,6 +1697,7 @@ export function AddDataDialog({
                 <Select
                   id="deckviz-kind"
                   value={deckVizKind}
+                  disabled={isLoadingDeckViz}
                   onChange={(event) =>
                     handleDeckVizKindChange(event.target.value)
                   }
@@ -1740,10 +1741,12 @@ export function AddDataDialog({
                 <Select
                   id="deckviz-mode"
                   value={deckVizMode}
+                  disabled={isLoadingDeckViz}
                   onChange={(event) => {
                     setDeckVizMode(event.target.value as "url" | "file");
                     setDeckVizParsed(null);
                     setDeckVizStatus(null);
+                    setIsLoadingDeckViz(false);
                   }}
                 >
                   <option value="url">Data URL</option>

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -8,6 +8,14 @@ import {
   addArcGISLayer,
   type ArcGISLayerType,
   type ArcGISSourceType,
+  createDeckVizStoreLayer,
+  DECK_VIZ_CATEGORY_LABELS,
+  DEFAULT_DECK_VIZ_STYLE,
+  getDeckVizLayerDef,
+  listDeckVizLayerDefs,
+  type DeckVizCategory,
+  type DeckVizFieldMapping,
+  type DeckVizStyle,
 } from "@geolibre/plugins";
 import {
   Button,
@@ -42,6 +50,12 @@ import {
   parseDelimitedTextFields,
   parseDelimitedTextLayer,
 } from "../../lib/delimited-text";
+import {
+  autoDetectFieldMapping,
+  computeDeckVizBounds,
+  type DeckVizParsedInput,
+  detectAndParseDeckVizInput,
+} from "../../lib/deck-viz-input";
 import { parseGpxLayer } from "../../lib/gpx";
 import {
   createWfsGetFeatureUrl,
@@ -80,6 +94,7 @@ export type AddDataKind =
   | "mbtiles"
   | "arcgis"
   | "postgres"
+  | "deckgl-viz"
   | "video";
 
 interface AddDataDialogProps {
@@ -103,6 +118,7 @@ const KIND_LABELS: Record<AddDataKind, string> = {
   mbtiles: "Add MBTiles Layer",
   arcgis: "Add ArcGIS Layer",
   postgres: "Add PostgreSQL Layer",
+  "deckgl-viz": "Add Deck.gl Layer",
   video: "Add Video Layer",
 };
 
@@ -464,6 +480,20 @@ export function AddDataDialog({
   const [martinStatus, setMartinStatus] = useState<string | null>(null);
   const martinLayerAddedRef = useRef(false);
 
+  const [deckVizKind, setDeckVizKind] = useState("scatterplot");
+  const [deckVizMode, setDeckVizMode] = useState<"url" | "file">("url");
+  const [deckVizUrl, setDeckVizUrl] = useState("");
+  const [deckVizSourcePath, setDeckVizSourcePath] = useState("");
+  const [deckVizParsed, setDeckVizParsed] = useState<DeckVizParsedInput | null>(
+    null,
+  );
+  const [deckVizMapping, setDeckVizMapping] = useState<DeckVizFieldMapping>({});
+  const [deckVizStyle, setDeckVizStyle] = useState<DeckVizStyle>({
+    ...DEFAULT_DECK_VIZ_STYLE,
+  });
+  const [deckVizStatus, setDeckVizStatus] = useState<string | null>(null);
+  const [isLoadingDeckViz, setIsLoadingDeckViz] = useState(false);
+
   useEffect(() => {
     if (!kind) return;
     if (kind === "postgres" && !martinServer) martinLayerAddedRef.current = false;
@@ -480,6 +510,7 @@ export function AddDataDialog({
         mbtiles: "MBTiles Layer",
         arcgis: "ArcGIS Layer",
         postgres: "PostgreSQL Layer",
+        "deckgl-viz": getDeckVizLayerDef(deckVizKind)?.label ?? "Deck.gl Layer",
         video: "Video Layer",
       }[kind],
     );
@@ -545,6 +576,14 @@ export function AddDataDialog({
       setSelectedMartinSourceId("");
       setMartinStatus(null);
     }
+    setDeckVizMode("url");
+    setDeckVizUrl("");
+    setDeckVizSourcePath("");
+    setDeckVizParsed(null);
+    setDeckVizMapping({});
+    setDeckVizStyle({ ...DEFAULT_DECK_VIZ_STYLE });
+    setDeckVizStatus(null);
+    setIsLoadingDeckViz(false);
   }, [kind]);
 
   const description = useMemo(() => {
@@ -577,6 +616,9 @@ export function AddDataDialog({
     }
     if (kind === "video") {
       return "Add a georeferenced video overlay by supplying an MP4 URL and four corner coordinates.";
+    }
+    if (kind === "deckgl-viz") {
+      return "Pick a deck.gl layer type, then load the example data or upload a CSV/JSON/GeoJSON file or URL.";
     }
     return "";
   }, [kind]);
@@ -730,6 +772,175 @@ export function AddDataDialog({
   };
 
   const beforeLayer = beforeLayerId.trim() || null;
+
+  const deckVizDef = getDeckVizLayerDef(deckVizKind);
+
+  const handleDeckVizKindChange = (nextKind: string) => {
+    setDeckVizKind(nextKind);
+    setDeckVizParsed(null);
+    setDeckVizMapping({});
+    setDeckVizStatus(null);
+    setError(null);
+    setDeckVizStyle({ ...DEFAULT_DECK_VIZ_STYLE });
+    setLayerName(getDeckVizLayerDef(nextKind)?.label ?? "Deck.gl Layer");
+  };
+
+  const readDeckVizSource = async (): Promise<{
+    sourcePath: string;
+    text: string;
+  }> => {
+    if (deckVizMode === "file") {
+      const selected = await openLocalDataFileWithFallback({
+        filters: [
+          {
+            name: "Data",
+            extensions: ["csv", "tsv", "txt", "json", "geojson"],
+          },
+        ],
+        accept: ".csv,.tsv,.txt,.json,.geojson",
+        readText: true,
+      });
+      if (!selected?.text) throw new Error("Choose a CSV, JSON, or GeoJSON file.");
+      return { sourcePath: selected.path, text: selected.text };
+    }
+    const sourcePath = deckVizUrl.trim();
+    if (!sourcePath) throw new Error("Enter a data URL.");
+    const response = await fetch(sourcePath);
+    if (!response.ok) {
+      throw new Error(`Request failed with status ${response.status}`);
+    }
+    return { sourcePath, text: await response.text() };
+  };
+
+  // Validates format/role completeness, then writes the deck-viz store layer
+  // and fits the map. Shared by the "Use example data" and submit paths.
+  const finalizeDeckVizLayer = (params: {
+    parsed: DeckVizParsedInput;
+    mapping: DeckVizFieldMapping;
+    style: DeckVizStyle;
+    sourcePath: string;
+  }) => {
+    const def = getDeckVizLayerDef(deckVizKind);
+    if (!def) throw new Error("Unknown layer type.");
+    const { parsed, mapping, style, sourcePath } = params;
+
+    if (def.format === "geojson" && parsed.format !== "geojson") {
+      throw new Error(`${def.label} needs a GeoJSON file.`);
+    }
+    if (def.format !== "geojson" && parsed.format === "geojson") {
+      throw new Error(`${def.label} needs tabular CSV/JSON data, not GeoJSON.`);
+    }
+    const missing = def.roles.filter(
+      (role) =>
+        role.required &&
+        (mapping[role.key] === undefined || mapping[role.key] === ""),
+    );
+    if (missing.length > 0) {
+      throw new Error(
+        `Map the required field${missing.length > 1 ? "s" : ""}: ${missing
+          .map((role) => role.label)
+          .join(", ")}.`,
+      );
+    }
+
+    const layer = createDeckVizStoreLayer({
+      name: layerName.trim() || def.label,
+      config: {
+        layerKind: def.kind,
+        format: parsed.format,
+        fieldMapping: mapping,
+        style,
+      },
+      rows: parsed.format === "geojson" ? undefined : parsed.rows,
+      geojson: parsed.geojson,
+      sourcePath,
+    });
+    addLayer(layer, beforeLayer);
+    if (def.format === "geojson") {
+      mapControllerRef.current?.fitLayer(layer);
+    } else {
+      const bounds = computeDeckVizBounds(parsed.rows ?? [], mapping);
+      if (bounds) mapControllerRef.current?.fitBounds(bounds);
+    }
+    closeDialog();
+  };
+
+  const handleUseDeckVizExample = async () => {
+    const def = getDeckVizLayerDef(deckVizKind);
+    if (!def) return;
+    setError(null);
+    setDeckVizStatus(null);
+    setIsLoadingDeckViz(true);
+    try {
+      const response = await fetch(def.example.url);
+      if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`);
+      }
+      const parsed = detectAndParseDeckVizInput(await response.text());
+      finalizeDeckVizLayer({
+        parsed,
+        mapping: def.example.fieldMapping,
+        style: { ...DEFAULT_DECK_VIZ_STYLE, ...(def.example.style ?? {}) },
+        sourcePath: def.example.url,
+      });
+    } catch (err) {
+      setError(errorMessage(err, "Could not load the example data."));
+    } finally {
+      setIsLoadingDeckViz(false);
+    }
+  };
+
+  const handleRetrieveDeckVizColumns = async () => {
+    const def = getDeckVizLayerDef(deckVizKind);
+    if (!def) return;
+    setError(null);
+    setDeckVizStatus(null);
+    setIsLoadingDeckViz(true);
+    try {
+      const { sourcePath, text } = await readDeckVizSource();
+      const parsed = detectAndParseDeckVizInput(text);
+      if (def.format === "geojson" && parsed.format !== "geojson") {
+        throw new Error(`${def.label} needs a GeoJSON file.`);
+      }
+      if (def.format !== "geojson" && parsed.format === "geojson") {
+        throw new Error(`${def.label} needs tabular CSV/JSON data, not GeoJSON.`);
+      }
+      setDeckVizParsed(parsed);
+      setDeckVizSourcePath(sourcePath);
+      setDeckVizMapping(autoDetectFieldMapping(def.roles, parsed.columns));
+      setDeckVizStatus(
+        parsed.format === "geojson"
+          ? `Loaded ${parsed.rowCount} feature${parsed.rowCount === 1 ? "" : "s"}.`
+          : `Loaded ${parsed.rowCount} row${
+              parsed.rowCount === 1 ? "" : "s"
+            } · ${parsed.columns.length} column${
+              parsed.columns.length === 1 ? "" : "s"
+            }.`,
+      );
+    } catch (err) {
+      setError(errorMessage(err, "Could not load the data."));
+      setDeckVizParsed(null);
+    } finally {
+      setIsLoadingDeckViz(false);
+    }
+  };
+
+  const setDeckVizRole = (roleKey: string, value: string) => {
+    setDeckVizMapping((current) => {
+      const next = { ...current };
+      if (value === "") {
+        delete next[roleKey];
+        return next;
+      }
+      // Numeric columns (JSON tuple arrays) are stored as indices.
+      const numeric = Number(value);
+      next[roleKey] =
+        deckVizParsed?.format === "json-array" && Number.isFinite(numeric)
+          ? numeric
+          : value;
+      return next;
+    });
+  };
 
   // Computed during render (not memoized) so the list picks up the map
   // controller once it finishes initialising; the call is a cheap filter.
@@ -959,6 +1170,19 @@ export function AddDataDialog({
 
     try {
       const name = layerName.trim() || KIND_LABELS[kind].replace("Add ", "");
+
+      if (kind === "deckgl-viz") {
+        if (!deckVizParsed) {
+          throw new Error("Load the example data, or a file/URL, first.");
+        }
+        finalizeDeckVizLayer({
+          parsed: deckVizParsed,
+          mapping: deckVizMapping,
+          style: deckVizStyle,
+          sourcePath: deckVizSourcePath,
+        });
+        return;
+      }
 
       if (kind === "xyz") {
         if (!xyzUrl.trim()) throw new Error("Enter an XYZ tile URL template.");
@@ -1373,8 +1597,10 @@ export function AddDataDialog({
   const addLayerDisabled =
     isSubmitting ||
     isRetrievingDelimitedTextColumns ||
+    isLoadingDeckViz ||
     (kind === "gpx" && !hasSelectedGpxLayerKind) ||
     (kind === "delimited-text" && missingCustomDelimiter) ||
+    (kind === "deckgl-viz" && !deckVizParsed) ||
     (kind === "postgres" && (!martinServer || !selectedMartinSourceId));
 
   return (
@@ -1461,6 +1687,222 @@ export function AddDataDialog({
                 />
                 Short URL
               </label>
+            </div>
+          )}
+
+          {kind === "deckgl-viz" && (
+            <div className="space-y-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="deckviz-kind">Layer type</Label>
+                <Select
+                  id="deckviz-kind"
+                  value={deckVizKind}
+                  onChange={(event) =>
+                    handleDeckVizKindChange(event.target.value)
+                  }
+                >
+                  {(
+                    Object.keys(DECK_VIZ_CATEGORY_LABELS) as DeckVizCategory[]
+                  ).map((category) => (
+                    <optgroup
+                      key={category}
+                      label={DECK_VIZ_CATEGORY_LABELS[category]}
+                    >
+                      {listDeckVizLayerDefs()
+                        .filter((def) => def.category === category)
+                        .map((def) => (
+                          <option key={def.kind} value={def.kind}>
+                            {def.label}
+                          </option>
+                        ))}
+                    </optgroup>
+                  ))}
+                </Select>
+                {deckVizDef ? (
+                  <p className="text-xs text-muted-foreground">
+                    {deckVizDef.description}
+                  </p>
+                ) : null}
+              </div>
+
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleUseDeckVizExample}
+                disabled={isLoadingDeckViz}
+              >
+                <Globe2 className="mr-2 h-3.5 w-3.5" />
+                {isLoadingDeckViz ? "Loading..." : "Use example data"}
+              </Button>
+
+              <div className="space-y-1.5">
+                <Label htmlFor="deckviz-mode">Or load your own</Label>
+                <Select
+                  id="deckviz-mode"
+                  value={deckVizMode}
+                  onChange={(event) => {
+                    setDeckVizMode(event.target.value as "url" | "file");
+                    setDeckVizParsed(null);
+                    setDeckVizStatus(null);
+                  }}
+                >
+                  <option value="url">Data URL</option>
+                  <option value="file">Local file</option>
+                </Select>
+              </div>
+
+              {deckVizMode === "url" ? (
+                <div className="space-y-1.5">
+                  <Label htmlFor="deckviz-url">Data URL</Label>
+                  <Input
+                    id="deckviz-url"
+                    placeholder="https://example.com/data.csv"
+                    value={deckVizUrl}
+                    onChange={(event) => {
+                      setDeckVizUrl(event.target.value);
+                      setDeckVizParsed(null);
+                    }}
+                  />
+                </div>
+              ) : null}
+
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleRetrieveDeckVizColumns}
+                disabled={
+                  isLoadingDeckViz ||
+                  (deckVizMode === "url" && !deckVizUrl.trim())
+                }
+              >
+                {deckVizMode === "file" ? (
+                  <FileUp className="mr-2 h-3.5 w-3.5" />
+                ) : (
+                  <Columns3 className="mr-2 h-3.5 w-3.5" />
+                )}
+                {isLoadingDeckViz
+                  ? "Loading..."
+                  : deckVizMode === "file"
+                    ? "Choose file & load"
+                    : "Load data"}
+              </Button>
+              {deckVizStatus ? (
+                <p className="text-xs text-muted-foreground">{deckVizStatus}</p>
+              ) : null}
+
+              {deckVizParsed && deckVizDef && deckVizDef.roles.length > 0 ? (
+                <div className="grid gap-3 sm:grid-cols-2">
+                  {deckVizDef.roles.map((role) => (
+                    <div key={role.key} className="space-y-1.5">
+                      <Label htmlFor={`deckviz-role-${role.key}`}>
+                        {role.label}
+                      </Label>
+                      <Select
+                        id={`deckviz-role-${role.key}`}
+                        value={String(deckVizMapping[role.key] ?? "")}
+                        onChange={(event) =>
+                          setDeckVizRole(role.key, event.target.value)
+                        }
+                      >
+                        {!role.required ? <option value="">(none)</option> : null}
+                        {deckVizParsed.columns.map((column) => (
+                          <option
+                            key={String(column.value)}
+                            value={String(column.value)}
+                          >
+                            {column.label}
+                          </option>
+                        ))}
+                      </Select>
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+
+              {deckVizDef ? (
+                <div className="grid gap-3 sm:grid-cols-2">
+                  {deckVizDef.styleControls.includes("color") ? (
+                    <div className="space-y-1.5">
+                      <Label htmlFor="deckviz-color">Color</Label>
+                      <input
+                        id="deckviz-color"
+                        type="color"
+                        className="h-9 w-full rounded-md border border-input bg-background"
+                        value={deckVizStyle.color}
+                        onChange={(event) =>
+                          setDeckVizStyle((style) => ({
+                            ...style,
+                            color: event.target.value,
+                          }))
+                        }
+                      />
+                    </div>
+                  ) : null}
+                  {deckVizDef.styleControls.includes("radius") ? (
+                    <div className="space-y-1.5">
+                      <Label htmlFor="deckviz-radius">Point size</Label>
+                      <Input
+                        id="deckviz-radius"
+                        inputMode="numeric"
+                        value={String(deckVizStyle.radius)}
+                        onChange={(event) =>
+                          setDeckVizStyle((style) => ({
+                            ...style,
+                            radius: Number(event.target.value) || 0,
+                          }))
+                        }
+                      />
+                    </div>
+                  ) : null}
+                  {deckVizDef.styleControls.includes("cellSize") ? (
+                    <div className="space-y-1.5">
+                      <Label htmlFor="deckviz-cellsize">Cell size</Label>
+                      <Input
+                        id="deckviz-cellsize"
+                        inputMode="numeric"
+                        value={String(deckVizStyle.cellSize)}
+                        onChange={(event) =>
+                          setDeckVizStyle((style) => ({
+                            ...style,
+                            cellSize: Number(event.target.value) || 0,
+                          }))
+                        }
+                      />
+                    </div>
+                  ) : null}
+                  {deckVizDef.styleControls.includes("lineWidth") ? (
+                    <div className="space-y-1.5">
+                      <Label htmlFor="deckviz-linewidth">Line width</Label>
+                      <Input
+                        id="deckviz-linewidth"
+                        inputMode="numeric"
+                        value={String(deckVizStyle.lineWidth)}
+                        onChange={(event) =>
+                          setDeckVizStyle((style) => ({
+                            ...style,
+                            lineWidth: Number(event.target.value) || 0,
+                          }))
+                        }
+                      />
+                    </div>
+                  ) : null}
+                  {deckVizDef.styleControls.includes("extruded") ? (
+                    <label className="flex items-center gap-2 self-end pb-2 text-sm">
+                      <input
+                        type="checkbox"
+                        checked={deckVizStyle.extruded}
+                        onChange={(event) =>
+                          setDeckVizStyle((style) => ({
+                            ...style,
+                            extruded: event.target.checked,
+                          }))
+                        }
+                      />
+                      3D extrusion
+                    </label>
+                  ) : null}
+                </div>
+              ) : null}
             </div>
           )}
 

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -11,6 +11,7 @@ import {
   createDeckVizStoreLayer,
   DECK_VIZ_CATEGORY_LABELS,
   DEFAULT_DECK_VIZ_STYLE,
+  ensureMercatorProjection,
   getDeckVizLayerDef,
   listDeckVizLayerDefs,
   type DeckVizCategory,
@@ -576,6 +577,11 @@ export function AddDataDialog({
       setMartinSources([]);
       setSelectedMartinSourceId("");
       setMartinStatus(null);
+    }
+    // The deck.gl overlay only aligns in a Mercator viewport, so switch away
+    // from globe as soon as the Deck.gl Layer dialog opens.
+    if (kind === "deckgl-viz") {
+      ensureMercatorProjection(mapControllerRef.current?.getMap());
     }
     setDeckVizKind("scatterplot");
     setDeckVizMode("url");

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -510,7 +510,8 @@ export function AddDataDialog({
         mbtiles: "MBTiles Layer",
         arcgis: "ArcGIS Layer",
         postgres: "PostgreSQL Layer",
-        "deckgl-viz": getDeckVizLayerDef(deckVizKind)?.label ?? "Deck.gl Layer",
+        // Matches the deckVizKind reset to "scatterplot" below.
+        "deckgl-viz": getDeckVizLayerDef("scatterplot")?.label ?? "Deck.gl Layer",
         video: "Video Layer",
       }[kind],
     );
@@ -576,6 +577,7 @@ export function AddDataDialog({
       setSelectedMartinSourceId("");
       setMartinStatus(null);
     }
+    setDeckVizKind("scatterplot");
     setDeckVizMode("url");
     setDeckVizUrl("");
     setDeckVizSourcePath("");
@@ -785,10 +787,15 @@ export function AddDataDialog({
     setLayerName(getDeckVizLayerDef(nextKind)?.label ?? "Deck.gl Layer");
   };
 
+  // ~10 MB; deck-viz data is stored inline in the project file, so warn (but
+  // do not block) when a very large payload would bloat saved projects.
+  const DECK_VIZ_SIZE_WARN_BYTES = 10 * 1024 * 1024;
+
   const readDeckVizSource = async (): Promise<{
     sourcePath: string;
     text: string;
   }> => {
+    let source: { sourcePath: string; text: string };
     if (deckVizMode === "file") {
       const selected = await openLocalDataFileWithFallback({
         filters: [
@@ -801,15 +808,24 @@ export function AddDataDialog({
         readText: true,
       });
       if (!selected?.text) throw new Error("Choose a CSV, JSON, or GeoJSON file.");
-      return { sourcePath: selected.path, text: selected.text };
+      source = { sourcePath: selected.path, text: selected.text };
+    } else {
+      const sourcePath = deckVizUrl.trim();
+      if (!sourcePath) throw new Error("Enter a data URL.");
+      const response = await fetch(sourcePath);
+      if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`);
+      }
+      source = { sourcePath, text: await response.text() };
     }
-    const sourcePath = deckVizUrl.trim();
-    if (!sourcePath) throw new Error("Enter a data URL.");
-    const response = await fetch(sourcePath);
-    if (!response.ok) {
-      throw new Error(`Request failed with status ${response.status}`);
+    if (source.text.length > DECK_VIZ_SIZE_WARN_BYTES) {
+      console.warn(
+        "[GeoLibre] deck-viz: large payload stored inline in the project",
+        source.text.length,
+        "bytes",
+      );
     }
-    return { sourcePath, text: await response.text() };
+    return source;
   };
 
   // Validates format/role completeness, then writes the deck-viz store layer

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -109,6 +109,10 @@ type GpxLayerKind = "waypoints" | "tracks" | "routes";
 type DelimitedTextMode = "url" | "file";
 type DelimitedTextDelimiter = "comma" | "tab" | "semicolon" | "pipe" | "custom";
 
+// ~10 MB; deck-viz data is stored inline in the project file, so warn (but do
+// not block) when a very large payload would bloat saved projects.
+const DECK_VIZ_SIZE_WARN_BYTES = 10 * 1024 * 1024;
+
 const KIND_LABELS: Record<AddDataKind, string> = {
   xyz: "Add XYZ Layer",
   wms: "Add WMS Layer",
@@ -792,10 +796,6 @@ export function AddDataDialog({
     setDeckVizStyle({ ...DEFAULT_DECK_VIZ_STYLE });
     setLayerName(getDeckVizLayerDef(nextKind)?.label ?? "Deck.gl Layer");
   };
-
-  // ~10 MB; deck-viz data is stored inline in the project file, so warn (but
-  // do not block) when a very large payload would bloat saved projects.
-  const DECK_VIZ_SIZE_WARN_BYTES = 10 * 1024 * 1024;
 
   const readDeckVizSource = async (): Promise<{
     sourcePath: string;

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -4,10 +4,12 @@ import type { MapController, MapDiagnosticEvent } from "@geolibre/map";
 import { MapCanvas } from "@geolibre/map";
 import {
   addRasterToMap,
+  DECK_VIZ_PLUGIN_ID,
   DIRECTIONS_PLUGIN_ID,
   EFFECTS_PLUGIN_ID,
   endLayerGeometryEdit,
   getGeometryEditTargetLayerId,
+  restoreDeckViz,
   restoreDirections,
   restoreEffects,
   restoreRasterLayers,
@@ -382,6 +384,9 @@ export function DesktopShell({
     // Rebind the directions tool to the (possibly new) map instance after a
     // map re-init, since restoreProjectState skips an already-active plugin.
     restoreDirections(appAPI, pluginManager.isActive(DIRECTIONS_PLUGIN_ID));
+    // Same contract for the deck.gl overlay: re-attach it to the current map
+    // and re-render any deckgl-viz layers a restored project carries.
+    restoreDeckViz(appAPI, pluginManager.isActive(DECK_VIZ_PLUGIN_ID));
     const search = window.location.search;
     void pluginManager
       .handleUrlParameters(

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -1038,6 +1038,9 @@ export function TopToolbar({
           <DropdownMenuItem onSelect={() => setAddDataKind("video")}>
             Video Layer
           </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setAddDataKind("deckgl-viz")}>
+            Deck.gl Layer
+          </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuLabel className="text-xs text-muted-foreground">
             Cloud formats

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -6,6 +6,7 @@ import {
 import {
   maplibreBasemapControlPlugin,
   maplibreComponentsPlugin,
+  maplibreDeckGlVizPlugin,
   maplibreDirectionsPlugin,
   maplibreEffectsPlugin,
   maplibreEnviroAtlasPlugin,
@@ -75,6 +76,7 @@ manager.registerAll([
   maplibreSwipePlugin,
   maplibreEffectsPlugin,
   maplibreDirectionsPlugin,
+  maplibreDeckGlVizPlugin,
   maplibreComponentsPlugin,
 ]);
 
@@ -412,16 +414,20 @@ export function createAppAPI(
         (cached ??= Promise.all([
           import("@deck.gl/core"),
           import("@deck.gl/layers"),
+          import("@deck.gl/aggregation-layers"),
           import("@deck.gl/geo-layers"),
           import("@deck.gl/mesh-layers"),
           import("@deck.gl/mapbox"),
-        ]).then(([core, layers, geoLayers, meshLayers, mapbox]) => ({
-          core,
-          layers,
-          geoLayers,
-          meshLayers,
-          mapbox,
-        })));
+        ]).then(
+          ([core, layers, aggregationLayers, geoLayers, meshLayers, mapbox]) => ({
+            core,
+            layers,
+            aggregationLayers,
+            geoLayers,
+            meshLayers,
+            mapbox,
+          }),
+        ));
     })(),
   };
 }

--- a/apps/geolibre-desktop/src/lib/deck-viz-input.ts
+++ b/apps/geolibre-desktop/src/lib/deck-viz-input.ts
@@ -87,7 +87,13 @@ function parseJsonInput(parsed: unknown): DeckVizParsedInput {
 
   const first = parsed[0];
   if (Array.isArray(first)) {
-    const width = Math.max(...parsed.slice(0, 1).map((row) => row.length));
+    // Scan the first few rows so optional trailing columns on later rows are
+    // still offered in the field-mapping picker.
+    const width = Math.max(
+      ...parsed
+        .slice(0, 10)
+        .map((row) => (Array.isArray(row) ? row.length : 0)),
+    );
     return {
       format: "json-array",
       columns: Array.from({ length: width }, (_, index) => ({

--- a/apps/geolibre-desktop/src/lib/deck-viz-input.ts
+++ b/apps/geolibre-desktop/src/lib/deck-viz-input.ts
@@ -35,12 +35,13 @@ const SAMPLE_FEATURE_LIMIT = 50;
  * can map. Throws a user-facing Error when the payload is empty or unsupported.
  *
  * @param text - The raw file/URL contents.
- * @param delimiter - Delimiter to use when the payload is delimited text.
+ * @param delimiter - Delimiter for delimited text; sniffed from the header
+ *   (comma/tab/semicolon/pipe) when omitted, so .tsv/.txt files parse correctly.
  * @returns The detected format, columns, and parsed data.
  */
 export function detectAndParseDeckVizInput(
   text: string,
-  delimiter = ",",
+  delimiter?: string,
 ): DeckVizParsedInput {
   const trimmed = text.replace(/^﻿/, "").trimStart();
   if (!trimmed) throw new Error("The file is empty.");
@@ -55,7 +56,10 @@ export function detectAndParseDeckVizInput(
     return parseJsonInput(parsed);
   }
 
-  const { fields, rows } = parseDelimitedTextRows(text, delimiter);
+  const { fields, rows } = parseDelimitedTextRows(
+    text,
+    delimiter ?? sniffDelimiter(trimmed),
+  );
   const sample = rows[0];
   return {
     format: "csv-rows",
@@ -245,6 +249,26 @@ export function computeDeckVizBounds(
 
   if (west > east || south > north) return null;
   return [west, south, east, north];
+}
+
+/**
+ * Picks the most likely delimiter for tabular text by counting candidates in
+ * the header line. Lets `.tsv`/`.txt`/semicolon files parse without the caller
+ * knowing the format up front; defaults to a comma.
+ */
+export function sniffDelimiter(text: string): string {
+  const header = text.split(/\r?\n/, 1)[0] ?? "";
+  const candidates = [",", "\t", ";", "|"];
+  let best = ",";
+  let bestCount = 0;
+  for (const candidate of candidates) {
+    const count = header.split(candidate).length - 1;
+    if (count > bestCount) {
+      bestCount = count;
+      best = candidate;
+    }
+  }
+  return best;
 }
 
 function sampleLabel(name: string, sample: unknown): string {

--- a/apps/geolibre-desktop/src/lib/deck-viz-input.ts
+++ b/apps/geolibre-desktop/src/lib/deck-viz-input.ts
@@ -27,7 +27,7 @@ export interface DeckVizParsedInput {
   rowCount: number;
 }
 
-const SAMPLE_FEATURE_LIMIT = 50;
+const SAMPLE_FEATURE_LIMIT = 500;
 
 /**
  * Detects the format of a text payload (CSV, JSON tuple array, JSON object
@@ -296,12 +296,19 @@ function normalizeFeatureCollection(value: {
 }
 
 function collectFeatureProperties(geojson: FeatureCollection): DeckVizColumn[] {
-  const keys = new Set<string>();
+  // Keep the first value seen per key so the picker can show a sample preview,
+  // matching the CSV/JSON-object columns.
+  const firstValues = new Map<string, unknown>();
   for (const feature of geojson.features.slice(0, SAMPLE_FEATURE_LIMIT)) {
     const properties = feature.properties;
     if (properties && typeof properties === "object") {
-      for (const key of Object.keys(properties)) keys.add(key);
+      for (const [key, value] of Object.entries(properties)) {
+        if (!firstValues.has(key)) firstValues.set(key, value);
+      }
     }
   }
-  return Array.from(keys, (key) => ({ value: key, label: key }));
+  return Array.from(firstValues, ([key, value]) => ({
+    value: key,
+    label: sampleLabel(key, value),
+  }));
 }

--- a/apps/geolibre-desktop/src/lib/deck-viz-input.ts
+++ b/apps/geolibre-desktop/src/lib/deck-viz-input.ts
@@ -1,0 +1,277 @@
+import type {
+  DeckVizFieldMapping,
+  DeckVizFormat,
+  DeckVizRole,
+} from "@geolibre/plugins";
+import type { FeatureCollection } from "geojson";
+import { parseDelimitedTextRows } from "./delimited-text";
+
+/**
+ * A column the user can map to a layer role. `value` is what gets written into
+ * the field mapping: a string key for CSV/object data, or a numeric index for
+ * JSON tuple arrays.
+ */
+export interface DeckVizColumn {
+  value: string | number;
+  label: string;
+}
+
+/** Result of detecting and parsing a deck.gl visualization input source. */
+export interface DeckVizParsedInput {
+  format: DeckVizFormat;
+  columns: DeckVizColumn[];
+  /** Parsed rows/tuples/objects for non-GeoJSON formats. */
+  rows?: unknown[];
+  /** Parsed FeatureCollection for the `geojson` format. */
+  geojson?: FeatureCollection;
+  rowCount: number;
+}
+
+const SAMPLE_FEATURE_LIMIT = 50;
+
+/**
+ * Detects the format of a text payload (CSV, JSON tuple array, JSON object
+ * array, or GeoJSON) and parses it into rows/columns the Deck.gl Layer dialog
+ * can map. Throws a user-facing Error when the payload is empty or unsupported.
+ *
+ * @param text - The raw file/URL contents.
+ * @param delimiter - Delimiter to use when the payload is delimited text.
+ * @returns The detected format, columns, and parsed data.
+ */
+export function detectAndParseDeckVizInput(
+  text: string,
+  delimiter = ",",
+): DeckVizParsedInput {
+  const trimmed = text.replace(/^﻿/, "").trimStart();
+  if (!trimmed) throw new Error("The file is empty.");
+
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      throw new Error("The file is not valid JSON.");
+    }
+    return parseJsonInput(parsed);
+  }
+
+  const { fields, rows } = parseDelimitedTextRows(text, delimiter);
+  const sample = rows[0];
+  return {
+    format: "csv-rows",
+    columns: fields.map((field) => ({
+      value: field,
+      label: sampleLabel(field, sample?.[field]),
+    })),
+    rows,
+    rowCount: rows.length,
+  };
+}
+
+function parseJsonInput(parsed: unknown): DeckVizParsedInput {
+  if (isFeatureCollectionLike(parsed)) {
+    const geojson = normalizeFeatureCollection(parsed);
+    return {
+      format: "geojson",
+      columns: collectFeatureProperties(geojson),
+      geojson,
+      rowCount: geojson.features.length,
+    };
+  }
+
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    throw new Error(
+      "Unsupported JSON. Provide a GeoJSON FeatureCollection or a JSON array.",
+    );
+  }
+
+  const first = parsed[0];
+  if (Array.isArray(first)) {
+    const width = Math.max(...parsed.slice(0, 1).map((row) => row.length));
+    return {
+      format: "json-array",
+      columns: Array.from({ length: width }, (_, index) => ({
+        value: index,
+        label: sampleLabel(`Column ${index}`, first[index]),
+      })),
+      rows: parsed,
+      rowCount: parsed.length,
+    };
+  }
+
+  if (first && typeof first === "object") {
+    const keys = Object.keys(first as Record<string, unknown>);
+    return {
+      format: "json-objects",
+      columns: keys.map((key) => ({
+        value: key,
+        label: sampleLabel(key, (first as Record<string, unknown>)[key]),
+      })),
+      rows: parsed,
+      rowCount: parsed.length,
+    };
+  }
+
+  throw new Error(
+    "Unsupported JSON array. Expected an array of objects or [lng, lat] tuples.",
+  );
+}
+
+/**
+ * Auto-maps each layer role to the most likely column. Named columns
+ * (CSV/objects) match on the role's detection hints; numeric columns (JSON
+ * tuples) fall back to positional assignment. Never assigns one column to two
+ * roles.
+ *
+ * @param roles - The roles declared by the chosen layer type.
+ * @param columns - The available columns.
+ * @returns A best-effort field mapping (may omit roles with no match).
+ */
+export function autoDetectFieldMapping(
+  roles: DeckVizRole[],
+  columns: DeckVizColumn[],
+): DeckVizFieldMapping {
+  const mapping: DeckVizFieldMapping = {};
+  if (columns.length === 0) return mapping;
+
+  const numeric = typeof columns[0].value === "number";
+  const used = new Set<string | number>();
+
+  roles.forEach((role, roleIndex) => {
+    if (numeric) {
+      const column = columns[roleIndex];
+      if (column && !used.has(column.value)) {
+        mapping[role.key] = column.value;
+        used.add(column.value);
+      }
+      return;
+    }
+
+    const match = matchNamedColumn(role, columns, used);
+    if (match !== undefined) {
+      mapping[role.key] = match;
+      used.add(match);
+    }
+  });
+
+  return mapping;
+}
+
+function matchNamedColumn(
+  role: DeckVizRole,
+  columns: DeckVizColumn[],
+  used: Set<string | number>,
+): string | undefined {
+  const candidates = columns
+    .filter((column) => !used.has(column.value))
+    .map((column) => ({
+      value: String(column.value),
+      lower: String(column.value).toLowerCase(),
+    }));
+
+  // Exact match wins, including short tokens like "x"/"y".
+  for (const detect of role.detect) {
+    const exact = candidates.find((candidate) => candidate.lower === detect);
+    if (exact) return exact.value;
+  }
+
+  // Prefix match only for multi-character tokens, so "y" cannot grab "city".
+  for (const detect of role.detect) {
+    if (detect.length < 3) continue;
+    const prefix = candidates.find((candidate) =>
+      candidate.lower.startsWith(detect),
+    );
+    if (prefix) return prefix.value;
+  }
+
+  return undefined;
+}
+
+/**
+ * Computes a `[west, south, east, north]` bounding box from inline row data so
+ * the map can fit a freshly added deck.gl layer (GeoJSON layers fit via the
+ * store layer's geometry instead). Scans whichever position roles are mapped:
+ * point (`lng`/`lat`), origin-destination, and Trips `path` arrays.
+ *
+ * @param rows - The parsed rows/tuples/objects.
+ * @param mapping - The role→column mapping.
+ * @returns The bounding box, or null when no finite coordinates are found.
+ */
+export function computeDeckVizBounds(
+  rows: unknown[],
+  mapping: DeckVizFieldMapping,
+): [number, number, number, number] | null {
+  let west = Infinity;
+  let south = Infinity;
+  let east = -Infinity;
+  let north = -Infinity;
+
+  const extend = (lng: unknown, lat: unknown): void => {
+    const x = Number(lng);
+    const y = Number(lat);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) return;
+    if (x < west) west = x;
+    if (x > east) east = x;
+    if (y < south) south = y;
+    if (y > north) north = y;
+  };
+
+  for (const row of rows) {
+    const record = row as Record<string | number, unknown>;
+    if (mapping.lng !== undefined && mapping.lat !== undefined) {
+      extend(record[mapping.lng], record[mapping.lat]);
+    }
+    if (mapping.sourceLng !== undefined && mapping.sourceLat !== undefined) {
+      extend(record[mapping.sourceLng], record[mapping.sourceLat]);
+    }
+    if (mapping.targetLng !== undefined && mapping.targetLat !== undefined) {
+      extend(record[mapping.targetLng], record[mapping.targetLat]);
+    }
+    if (mapping.path !== undefined) {
+      const path = record[mapping.path];
+      if (Array.isArray(path)) {
+        for (const point of path) {
+          if (Array.isArray(point)) extend(point[0], point[1]);
+        }
+      }
+    }
+  }
+
+  if (west > east || south > north) return null;
+  return [west, south, east, north];
+}
+
+function sampleLabel(name: string, sample: unknown): string {
+  if (sample === undefined || sample === null || sample === "") return name;
+  const text = String(sample);
+  const preview = text.length > 16 ? `${text.slice(0, 16)}…` : text;
+  return `${name} (${preview})`;
+}
+
+function isFeatureCollectionLike(
+  value: unknown,
+): value is { type: string; features?: unknown } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { type?: unknown }).type === "FeatureCollection"
+  );
+}
+
+function normalizeFeatureCollection(value: {
+  features?: unknown;
+}): FeatureCollection {
+  const features = Array.isArray(value.features) ? value.features : [];
+  return { type: "FeatureCollection", features } as FeatureCollection;
+}
+
+function collectFeatureProperties(geojson: FeatureCollection): DeckVizColumn[] {
+  const keys = new Set<string>();
+  for (const feature of geojson.features.slice(0, SAMPLE_FEATURE_LIMIT)) {
+    const properties = feature.properties;
+    if (properties && typeof properties === "object") {
+      for (const key of Object.keys(properties)) keys.add(key);
+    }
+  }
+  return Array.from(keys, (key) => ({ value: key, label: key }));
+}

--- a/apps/geolibre-desktop/src/lib/delimited-text.ts
+++ b/apps/geolibre-desktop/src/lib/delimited-text.ts
@@ -104,6 +104,41 @@ export function parseDelimitedTextLayer(
   };
 }
 
+/**
+ * Parses delimited text into row objects keyed by the (de-duplicated) header
+ * names. Unlike {@link parseDelimitedTextLayer}, this keeps every column as a
+ * raw string and does not build GeoJSON, so callers (e.g. the Deck.gl Layer
+ * builder) can map arbitrary columns to layer roles themselves.
+ *
+ * @param text - The delimited text, optionally starting with a BOM.
+ * @param delimiter - The field delimiter, e.g. ",", "\t", or ";".
+ * @returns The header names and one record per data row.
+ */
+export function parseDelimitedTextRows(
+  text: string,
+  delimiter: string,
+): { fields: string[]; rows: Record<string, string>[] } {
+  if (!delimiter) throw new Error("Enter a delimiter.");
+
+  const rawRows = parseDelimitedRows(text, delimiter).filter((row) =>
+    row.some((value) => value.trim()),
+  );
+  if (rawRows.length < 2) {
+    throw new Error("The delimited text must include a header and data rows.");
+  }
+
+  const fields = uniqueFieldNames(rawRows[0].map((field) => field.trim()));
+  const rows = rawRows.slice(1).map((row) => {
+    const record: Record<string, string> = {};
+    fields.forEach((field, index) => {
+      record[field] = (row[index] ?? "").trim();
+    });
+    return record;
+  });
+
+  return { fields, rows };
+}
+
 function parseDelimitedRows(text: string, delimiter: string): string[][] {
   const rows: string[][] = [];
   let field = "";

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
       "version": "1.1.0",
       "dependencies": {
         "@carbonplan/zarr-layer": "^0.5.0",
+        "@deck.gl/aggregation-layers": "9.3.3",
         "@deck.gl/core": "^9.3.3",
         "@deck.gl/geo-layers": "^9.3.3",
         "@deck.gl/layers": "^9.3.3",
@@ -1256,9 +1257,9 @@
       }
     },
     "node_modules/@deck.gl/aggregation-layers": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-9.3.2.tgz",
-      "integrity": "sha512-aOzCmJHPYM95aFEW7s3lyFibTSP+T/fYqCP2RxHyi/IxQwROwJTDrKyn/qPw5GvzZOIgFVxlR1Qc9RY8qYRFBw==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-9.3.3.tgz",
+      "integrity": "sha512-TeCFcNioTNTsoNR09Ee9sAWRQ995wvbida3t0n6cP4HW30u3iX+pW1vLE35ftxsKcV7C+wUbd4dtOHqUtg8pBw==",
       "license": "MIT",
       "dependencies": {
         "@luma.gl/shadertools": "^9.3.3",
@@ -17790,6 +17791,7 @@
       "version": "1.1.0",
       "dependencies": {
         "@carbonplan/zarr-layer": "^0.5.0",
+        "@deck.gl/aggregation-layers": "9.3.3",
         "@deck.gl/core": "^9.3.3",
         "@deck.gl/geo-layers": "^9.3.3",
         "@deck.gl/layers": "^9.3.3",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -57,6 +57,7 @@ export type LayerType =
   | "flatgeobuf"
   | "geoparquet"
   | "duckdb-query"
+  | "deckgl-viz"
   | "video";
 
 export type VectorStyleMode =

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@carbonplan/zarr-layer": "^0.5.0",
+    "@deck.gl/aggregation-layers": "9.3.3",
     "@deck.gl/core": "^9.3.3",
     "@deck.gl/geo-layers": "^9.3.3",
     "@deck.gl/layers": "^9.3.3",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -115,6 +115,7 @@ export {
   maplibreDeckGlVizPlugin,
 } from "./plugins/maplibre-deckgl-viz";
 export { restoreDeckViz } from "./plugins/deckgl-viz/overlay";
+export { ensureMercatorProjection } from "./plugins/map-projection-utils";
 export {
   DECK_VIZ_CATEGORY_LABELS,
   DEFAULT_DECK_VIZ_STYLE,

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -110,6 +110,31 @@ export {
   maplibreEffectsPlugin,
   restoreEffects,
 } from "./plugins/maplibre-effects";
+export {
+  DECK_VIZ_PLUGIN_ID,
+  maplibreDeckGlVizPlugin,
+} from "./plugins/maplibre-deckgl-viz";
+export { restoreDeckViz } from "./plugins/deckgl-viz/overlay";
+export {
+  DECK_VIZ_CATEGORY_LABELS,
+  DEFAULT_DECK_VIZ_STYLE,
+  getDeckVizLayerDef,
+  listDeckVizLayerDefs,
+  type DeckVizCategory,
+  type DeckVizConfig,
+  type DeckVizFieldMapping,
+  type DeckVizFormat,
+  type DeckVizInputKind,
+  type DeckVizLayerDef,
+  type DeckVizRole,
+  type DeckVizStyle,
+  type DeckVizStyleControl,
+} from "./plugins/deckgl-viz/registry";
+export {
+  createDeckVizStoreLayer,
+  DECK_VIZ_SOURCE_KIND,
+  isDeckVizLayer,
+} from "./plugins/deckgl-viz/store-layer";
 export { maplibreEnviroAtlasPlugin } from "./plugins/maplibre-enviroatlas";
 export { maplibreEsriWaybackPlugin } from "./plugins/maplibre-esri-wayback";
 export { maplibreFemaWmsPlugin } from "./plugins/maplibre-fema-wms";

--- a/packages/plugins/src/plugins/deckgl-viz/overlay.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/overlay.ts
@@ -29,6 +29,12 @@ let appRef: GeoLibreAppAPI | null = null;
 // created and re-attached, mirroring restoreDirections.
 let boundMap: unknown;
 
+// Bounds the lazy-mount retry so a restore that races map init still mounts
+// (the store subscription only fires on layer-set changes), without spinning
+// forever if the map never becomes ready.
+const MAX_MOUNT_RETRIES = 120;
+let mountRetries = 0;
+
 let rafHandle: number | null = null;
 // Signature of the current animated-layer set; when it changes the loop length
 // is recomputed and the clock restarts so the animation stays in range.
@@ -129,11 +135,23 @@ function renderDeckVizLayers(): void {
     ensureMercatorProjection(appRef.getMap?.());
   }
 
-  // Mount lazily: the map must be ready for addMapControl to succeed, so retry
-  // on the next store change until it does.
+  // Mount lazily: the map must be ready for addMapControl to succeed. Retry on
+  // the next animation frame so a project restore that races map init does not
+  // depend on a later store change to mount.
   if (!overlayMounted) {
     if (vizLayers.length === 0) return;
-    if (!appRef.addMapControl(overlay)) return;
+    // Add at top-left: MapboxOverlay's overlaid canvas is positioned `left:0`
+    // to fill the map, which only aligns when its control container is the
+    // left corner. The host's addControl otherwise defaults to top-right,
+    // pushing the canvas a full map-width to the right (off screen).
+    if (!appRef.addMapControl(overlay, "top-left")) {
+      if (mountRetries < MAX_MOUNT_RETRIES) {
+        mountRetries += 1;
+        requestAnimationFrame(() => renderDeckVizLayers());
+      }
+      return;
+    }
+    mountRetries = 0;
     overlayMounted = true;
   }
 

--- a/packages/plugins/src/plugins/deckgl-viz/overlay.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/overlay.ts
@@ -1,0 +1,222 @@
+import { type GeoLibreLayer, useAppStore } from "@geolibre/core";
+import type { Layer } from "@deck.gl/core";
+import type { MapboxOverlay } from "@deck.gl/mapbox";
+import type { GeoLibreAppAPI, GeoLibreDeckGL } from "../../types";
+import {
+  type DeckVizBuildContext,
+  getDeckVizLayerDef,
+} from "./registry";
+import { deckVizRows, isDeckVizLayer, readDeckVizConfig } from "./store-layer";
+
+/**
+ * Owns the single deck.gl overlay that renders every Deck.gl Layer in the
+ * store. Mirrors the store-subscription pattern of the raster overlay: the
+ * store is the source of truth, this module rebuilds the overlay's layer list
+ * whenever the layer set, visibility, or opacity changes, and drives an
+ * animation clock for animated layer types (Trips).
+ */
+
+// Data-time units advanced per real second for animated layers.
+const ANIMATION_SPEED = 60;
+
+let overlay: MapboxOverlay | null = null;
+let overlayMounted = false;
+let storeUnsubscribe: (() => void) | null = null;
+let deckGL: GeoLibreDeckGL | null = null;
+let appRef: GeoLibreAppAPI | null = null;
+// The map the current overlay is bound to; on map re-init a new overlay is
+// created and re-attached, mirroring restoreDirections.
+let boundMap: unknown;
+
+let rafHandle: number | null = null;
+// Signature of the current animated-layer set; when it changes the loop length
+// is recomputed and the clock restarts so the animation stays in range.
+let animatedSignature = "";
+let animationRange = 0;
+let animationEpoch = 0;
+
+/**
+ * Activates the deck.gl visualization overlay: resolves the host's deck.gl
+ * modules, creates the overlay, subscribes to the store, and renders any
+ * layers already present (e.g. from a project opened before activation).
+ * Called from the plugin's activate() (manual toggle); also reachable via
+ * {@link restoreDeckViz}.
+ *
+ * @param app - The host application API.
+ */
+export async function activateDeckViz(app: GeoLibreAppAPI): Promise<void> {
+  await ensureDeckVizOverlay(app);
+}
+
+/**
+ * Idempotent startup/restore hook. `activeByDefault` plugins are marked active
+ * without their activate() being called, so the desktop shell must kick this
+ * after restoreProjectState (and on map re-init) — the same contract as
+ * restoreDirections/restoreEffects.
+ *
+ * @param app - The host application API.
+ * @param active - Whether the plugin is currently active.
+ */
+export function restoreDeckViz(app: GeoLibreAppAPI, active: boolean): void {
+  if (!active) {
+    deactivateDeckViz(app);
+    return;
+  }
+  void ensureDeckVizOverlay(app);
+}
+
+async function ensureDeckVizOverlay(app: GeoLibreAppAPI): Promise<void> {
+  appRef = app;
+  if (!app.getDeckGL) return;
+  deckGL ??= await app.getDeckGL();
+
+  const map = app.getMap?.() ?? null;
+  if (overlay && boundMap === map) {
+    // Already bound to this map; just refresh the rendered layers.
+    renderDeckVizLayers();
+    return;
+  }
+
+  // First attach, or the map was reinitialised (e.g. a projection/globe
+  // toggle). Drop the stale overlay before building a fresh one so its widget
+  // container cannot leak onto the new map.
+  if (overlay && overlayMounted) {
+    try {
+      app.removeMapControl(overlay);
+    } catch {
+      // The old map may already be gone; nothing to remove.
+    }
+  }
+  boundMap = map;
+  overlay = new deckGL.mapbox.MapboxOverlay({ interleaved: false, layers: [] });
+  overlayMounted = false;
+  storeUnsubscribe ??= useAppStore.subscribe((state, previous) => {
+    if (state.layers !== previous.layers) renderDeckVizLayers();
+  });
+  renderDeckVizLayers();
+}
+
+/**
+ * Tears down the overlay and store subscription. Store layers are left intact
+ * so re-activation (or a project still holding them) re-renders.
+ *
+ * @param app - The host application API.
+ */
+export function deactivateDeckViz(app: GeoLibreAppAPI): void {
+  storeUnsubscribe?.();
+  storeUnsubscribe = null;
+  stopAnimation();
+  overlay?.setProps({ layers: [] });
+  if (overlay && overlayMounted) {
+    app.removeMapControl(overlay);
+  }
+  overlay = null;
+  overlayMounted = false;
+  boundMap = undefined;
+}
+
+function renderDeckVizLayers(): void {
+  if (!overlay || !deckGL || !appRef) return;
+
+  const vizLayers = useAppStore.getState().layers.filter(isDeckVizLayer);
+
+  // Mount lazily: the map must be ready for addMapControl to succeed, so retry
+  // on the next store change until it does.
+  if (!overlayMounted) {
+    if (vizLayers.length === 0) return;
+    if (!appRef.addMapControl(overlay)) return;
+    overlayMounted = true;
+  }
+
+  const contexts = vizLayers
+    .filter((layer) => layer.visible)
+    .map((layer) => buildContext(layer))
+    .filter((entry): entry is RenderEntry => entry !== null);
+
+  const currentTime = updateAnimationClock(contexts);
+
+  const deckLayers: Layer[] = [];
+  for (const entry of contexts) {
+    try {
+      deckLayers.push(
+        entry.def.build(deckGL, entry.id, {
+          ...entry.ctx,
+          currentTime,
+        }),
+      );
+    } catch (error) {
+      console.warn("[GeoLibre] deckgl-viz: failed to build layer", error);
+    }
+  }
+
+  // Reverse so the topmost layer in the panel draws last (on top), matching the
+  // store's first-is-top ordering.
+  deckLayers.reverse();
+  overlay.setProps({ layers: deckLayers });
+
+  if (animationRange > 0) startAnimation();
+  else stopAnimation();
+}
+
+interface RenderEntry {
+  id: string;
+  def: NonNullable<ReturnType<typeof getDeckVizLayerDef>>;
+  ctx: DeckVizBuildContext;
+}
+
+function buildContext(layer: GeoLibreLayer): RenderEntry | null {
+  const config = readDeckVizConfig(layer);
+  if (!config) return null;
+  const def = getDeckVizLayerDef(config.layerKind);
+  if (!def) return null;
+  const isGeoJson = def.format === "geojson";
+  const ctx: DeckVizBuildContext = {
+    rows: isGeoJson
+      ? undefined
+      : (deckVizRows(layer) as DeckVizBuildContext["rows"]),
+    geojson: isGeoJson ? layer.geojson : undefined,
+    fieldMapping: config.fieldMapping,
+    style: config.style,
+    opacity: layer.opacity,
+  };
+  return { id: layer.id, def, ctx };
+}
+
+/**
+ * Recomputes the animation loop length when the animated-layer set changes and
+ * returns the current clock value (data-time units). Caches the loop length so
+ * the per-frame path does not rescan timestamps.
+ */
+function updateAnimationClock(entries: RenderEntry[]): number {
+  const animated = entries.filter((entry) => entry.def.animated);
+  const signature = animated.map((entry) => entry.id).join("|");
+
+  if (signature !== animatedSignature) {
+    animatedSignature = signature;
+    animationEpoch = performance.now();
+    animationRange = 0;
+    for (const entry of animated) {
+      const range = entry.def.getTimeRange?.(entry.ctx) ?? 0;
+      if (range > animationRange) animationRange = range;
+    }
+  }
+
+  if (animationRange <= 0) return 0;
+  const elapsedSeconds = (performance.now() - animationEpoch) / 1000;
+  return (elapsedSeconds * ANIMATION_SPEED) % animationRange;
+}
+
+function startAnimation(): void {
+  if (rafHandle !== null) return;
+  const tick = (): void => {
+    rafHandle = requestAnimationFrame(tick);
+    renderDeckVizLayers();
+  };
+  rafHandle = requestAnimationFrame(tick);
+}
+
+function stopAnimation(): void {
+  if (rafHandle === null) return;
+  cancelAnimationFrame(rafHandle);
+  rafHandle = null;
+}

--- a/packages/plugins/src/plugins/deckgl-viz/overlay.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/overlay.ts
@@ -121,6 +121,9 @@ export function deactivateDeckViz(app: GeoLibreAppAPI): void {
   overlay = null;
   overlayMounted = false;
   boundMap = undefined;
+  // Reset so a session that exhausted the retries can re-mount after
+  // reactivation.
+  mountRetries = 0;
 }
 
 function renderDeckVizLayers(): void {
@@ -203,8 +206,14 @@ function buildContext(layer: GeoLibreLayer): RenderEntry | null {
   const style: DeckVizBuildContext["style"] = {
     ...config.style,
     color: layer.style.fillColor || config.style.color,
-    radius: layer.style.circleRadius || config.style.radius,
-    lineWidth: layer.style.strokeWidth || config.style.lineWidth,
+    // Number fields use a finite check (not `||`) so an explicit 0 from the
+    // panel (e.g. hiding points) is honored rather than treated as unset.
+    radius: Number.isFinite(layer.style.circleRadius)
+      ? layer.style.circleRadius
+      : config.style.radius,
+    lineWidth: Number.isFinite(layer.style.strokeWidth)
+      ? layer.style.strokeWidth
+      : config.style.lineWidth,
   };
   const ctx: DeckVizBuildContext = {
     rows: isGeoJson

--- a/packages/plugins/src/plugins/deckgl-viz/overlay.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/overlay.ts
@@ -197,14 +197,23 @@ function buildContext(layer: GeoLibreLayer): RenderEntry | null {
   const def = getDeckVizLayerDef(config.layerKind);
   if (!def) return null;
   const isGeoJson = def.format === "geojson";
+  // Bridge the Style panel: color/radius/line width come from the live
+  // LayerStyle (which the panel edits) while deck-specific props (cellSize,
+  // extrusion) stay on the viz config. Fill opacity folds into deck opacity.
+  const style: DeckVizBuildContext["style"] = {
+    ...config.style,
+    color: layer.style.fillColor || config.style.color,
+    radius: layer.style.circleRadius || config.style.radius,
+    lineWidth: layer.style.strokeWidth || config.style.lineWidth,
+  };
   const ctx: DeckVizBuildContext = {
     rows: isGeoJson
       ? undefined
       : (deckVizRows(layer) as DeckVizBuildContext["rows"]),
     geojson: isGeoJson ? layer.geojson : undefined,
     fieldMapping: config.fieldMapping,
-    style: config.style,
-    opacity: layer.opacity,
+    style,
+    opacity: layer.opacity * layer.style.fillOpacity,
   };
   return { id: layer.id, def, ctx };
 }

--- a/packages/plugins/src/plugins/deckgl-viz/overlay.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/overlay.ts
@@ -83,8 +83,9 @@ async function ensureDeckVizOverlay(app: GeoLibreAppAPI): Promise<void> {
   if (overlay && overlayMounted) {
     try {
       app.removeMapControl(overlay);
-    } catch {
-      // The old map may already be gone; nothing to remove.
+    } catch (error) {
+      // The old map may already be gone; surface anything unexpected.
+      console.debug("[GeoLibre] deckgl-viz: overlay cleanup", error);
     }
   }
   boundMap = map;

--- a/packages/plugins/src/plugins/deckgl-viz/overlay.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/overlay.ts
@@ -72,7 +72,20 @@ export function restoreDeckViz(app: GeoLibreAppAPI, active: boolean): void {
   void ensureDeckVizOverlay(app);
 }
 
-async function ensureDeckVizOverlay(app: GeoLibreAppAPI): Promise<void> {
+// Serialises concurrent setup calls (plugin activate() and the shell's restore
+// hook can both fire before the first getDeckGL() resolves) so two overlays are
+// never created for the same map.
+let ensureInFlight: Promise<void> | null = null;
+
+function ensureDeckVizOverlay(app: GeoLibreAppAPI): Promise<void> {
+  if (ensureInFlight) return ensureInFlight;
+  ensureInFlight = runEnsureDeckVizOverlay(app).finally(() => {
+    ensureInFlight = null;
+  });
+  return ensureInFlight;
+}
+
+async function runEnsureDeckVizOverlay(app: GeoLibreAppAPI): Promise<void> {
   appRef = app;
   if (!app.getDeckGL) return;
   deckGL ??= await app.getDeckGL();

--- a/packages/plugins/src/plugins/deckgl-viz/overlay.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/overlay.ts
@@ -2,6 +2,7 @@ import { type GeoLibreLayer, useAppStore } from "@geolibre/core";
 import type { Layer } from "@deck.gl/core";
 import type { MapboxOverlay } from "@deck.gl/mapbox";
 import type { GeoLibreAppAPI, GeoLibreDeckGL } from "../../types";
+import { ensureMercatorProjection } from "../map-projection-utils";
 import {
   type DeckVizBuildContext,
   getDeckVizLayerDef,
@@ -120,6 +121,13 @@ function renderDeckVizLayers(): void {
   if (!overlay || !deckGL || !appRef) return;
 
   const vizLayers = useAppStore.getState().layers.filter(isDeckVizLayer);
+
+  // The deck.gl overlay renders in a Mercator viewport and does not align with
+  // MapLibre's globe projection, so force Mercator while deck layers are shown
+  // (same contract as the DuckDB deck overlay).
+  if (vizLayers.length > 0) {
+    ensureMercatorProjection(appRef.getMap?.());
+  }
 
   // Mount lazily: the map must be ready for addMapControl to succeed, so retry
   // on the next store change until it does.

--- a/packages/plugins/src/plugins/deckgl-viz/registry.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/registry.ts
@@ -241,6 +241,24 @@ function weightAccessor(
   return (record) => readNumber(record, key);
 }
 
+/** Min/max of all timestamp values across the mapped `timestamps` arrays. */
+function timestampBounds(ctx: DeckVizBuildContext): { min: number; max: number } {
+  const tsKey = ctx.fieldMapping.timestamps;
+  let min = Infinity;
+  let max = -Infinity;
+  for (const record of rowsOf(ctx)) {
+    const stamps = (record as Record<string | number, unknown>)[tsKey];
+    if (!Array.isArray(stamps)) continue;
+    for (const value of stamps) {
+      const num = Number(value);
+      if (!Number.isFinite(num)) continue;
+      if (num < min) min = num;
+      if (num > max) max = num;
+    }
+  }
+  return min === Infinity ? { min: 0, max: 0 } : { min, max };
+}
+
 const DEFINITIONS: DeckVizLayerDef[] = [
   // ---- Point & aggregation -------------------------------------------------
   {
@@ -695,6 +713,9 @@ const DEFINITIONS: DeckVizLayerDef[] = [
     build: (deckGL, id, ctx) => {
       const pathKey = ctx.fieldMapping.path;
       const tsKey = ctx.fieldMapping.timestamps;
+      // Normalise timestamps to start at 0 so the loop (which runs from 0)
+      // works for data whose timestamps begin far above 0.
+      const { min: minTs } = timestampBounds(ctx);
       return new deckGL.geoLayers.TripsLayer({
         id,
         data: rowsOf(ctx),
@@ -704,8 +725,12 @@ const DEFINITIONS: DeckVizLayerDef[] = [
           (record as Record<string | number, unknown>)[
             pathKey
           ] as unknown as number[],
-        getTimestamps: (record: AnyRecord) =>
-          (record as Record<string | number, unknown>)[tsKey] as number[],
+        getTimestamps: (record: AnyRecord) => {
+          const stamps = (record as Record<string | number, unknown>)[tsKey];
+          return Array.isArray(stamps)
+            ? stamps.map((value) => Number(value) - minTs)
+            : [];
+        },
         getColor: fillColor(ctx.style),
         widthMinPixels: Math.max(ctx.style.lineWidth, 1),
         rounded: true,
@@ -715,18 +740,8 @@ const DEFINITIONS: DeckVizLayerDef[] = [
       });
     },
     getTimeRange: (ctx) => {
-      const tsKey = ctx.fieldMapping.timestamps;
-      let max = 0;
-      for (const record of rowsOf(ctx)) {
-        const stamps = (record as Record<string | number, unknown>)[tsKey];
-        if (Array.isArray(stamps)) {
-          for (const value of stamps) {
-            const num = Number(value);
-            if (Number.isFinite(num) && num > max) max = num;
-          }
-        }
-      }
-      return max;
+      const { min, max } = timestampBounds(ctx);
+      return max - min;
     },
     example: {
       url: `${DATA_BASE}/trips/trips-v7.json`,

--- a/packages/plugins/src/plugins/deckgl-viz/registry.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/registry.ts
@@ -153,7 +153,12 @@ function readNumber(record: AnyRecord, key: string | number): number {
  */
 function readCoordinate(record: AnyRecord, key: string | number): number {
   const value = (record as Record<string | number, unknown>)[key];
-  return typeof value === "number" ? value : Number(value);
+  // Number("") and Number(null) are 0; treat blank/missing cells as invalid
+  // (NaN) so deck.gl skips the record instead of plotting it at [0, 0].
+  if (value === null || value === undefined) return Number.NaN;
+  if (typeof value === "string" && value.trim() === "") return Number.NaN;
+  const num = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(num) ? num : Number.NaN;
 }
 
 /** A `[lng, lat]` accessor from two mapped roles. */
@@ -241,8 +246,17 @@ function weightAccessor(
   return (record) => readNumber(record, key);
 }
 
+// Cached per data array so the per-frame Trips animation does not rescan every
+// row/timestamp; the array identity is stable until the layer's data changes.
+const timestampBoundsCache = new WeakMap<object, { min: number; max: number }>();
+
 /** Min/max of all timestamp values across the mapped `timestamps` arrays. */
 function timestampBounds(ctx: DeckVizBuildContext): { min: number; max: number } {
+  const rows = ctx.rows;
+  if (rows) {
+    const cached = timestampBoundsCache.get(rows);
+    if (cached) return cached;
+  }
   const tsKey = ctx.fieldMapping.timestamps;
   let min = Infinity;
   let max = -Infinity;
@@ -256,7 +270,9 @@ function timestampBounds(ctx: DeckVizBuildContext): { min: number; max: number }
       if (num > max) max = num;
     }
   }
-  return min === Infinity ? { min: 0, max: 0 } : { min, max };
+  const result = min === Infinity ? { min: 0, max: 0 } : { min, max };
+  if (rows) timestampBoundsCache.set(rows, result);
+  return result;
 }
 
 const DEFINITIONS: DeckVizLayerDef[] = [

--- a/packages/plugins/src/plugins/deckgl-viz/registry.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/registry.ts
@@ -1,0 +1,746 @@
+import type { Layer } from "@deck.gl/core";
+import type { FeatureCollection } from "geojson";
+import { colorToRgba } from "../deck-style-utils";
+import type { GeoLibreDeckGL } from "../../types";
+
+/**
+ * Registry of deck.gl layer types a user can build from an uploaded file or a
+ * URL. Each entry declares the input it expects, the field roles the dialog
+ * must collect, a `build` function that turns parsed data + a field mapping
+ * into a deck.gl layer, and a bundled example (the real deck.gl-data file) so
+ * "Use example data" renders with zero configuration.
+ */
+
+/** Visual grouping shown in the layer-type picker. */
+export type DeckVizCategory = "point" | "flow" | "geojson" | "advanced";
+
+/**
+ * How the source data is shaped. Drives both the dialog (file picker vs URL
+ * fields, CSV vs JSON parsing) and the accessors used by `build`.
+ */
+export type DeckVizInputKind =
+  | "point-csv" // CSV rows with lng/lat columns
+  | "json-array" // JSON array of [lng, lat, weight?] tuples
+  | "od-csv" // CSV rows with source/target lng/lat columns
+  | "geojson" // GeoJSON FeatureCollection
+  | "json-objects"; // JSON array of objects (e.g. trips paths)
+
+/** How parsed data is persisted on the store layer. */
+export type DeckVizFormat = "csv-rows" | "json-array" | "json-objects" | "geojson";
+
+/**
+ * A single field the user maps to a data column (named CSV/object key) or a
+ * tuple index (JSON array). Accessors read `record[key]`, which works for both
+ * an object (`record["lng"]`) and an array (`record[0]`).
+ */
+export interface DeckVizRole {
+  key: string;
+  label: string;
+  required: boolean;
+  /** Lowercased substrings used to auto-detect the matching column. */
+  detect: string[];
+}
+
+/** Optional styling control the dialog renders for a layer. */
+export type DeckVizStyleControl =
+  | "color"
+  | "radius"
+  | "cellSize"
+  | "lineWidth"
+  | "extruded";
+
+/** User-tunable visual style, persisted in the layer's vizConfig. */
+export interface DeckVizStyle {
+  color: string;
+  radius: number;
+  cellSize: number;
+  lineWidth: number;
+  extruded: boolean;
+  elevationScale: number;
+}
+
+export const DEFAULT_DECK_VIZ_STYLE: DeckVizStyle = {
+  color: "#3b82f6",
+  radius: 40,
+  cellSize: 1000,
+  lineWidth: 2,
+  extruded: false,
+  elevationScale: 30,
+};
+
+/** Maps a role key to a column name (string) or tuple index (number). */
+export type DeckVizFieldMapping = Record<string, string | number>;
+
+/** The serialisable description of a built visualization (stored in metadata). */
+export interface DeckVizConfig {
+  layerKind: string;
+  format: DeckVizFormat;
+  fieldMapping: DeckVizFieldMapping;
+  style: DeckVizStyle;
+}
+
+/** Inputs handed to a registry `build` function. */
+export interface DeckVizBuildContext {
+  /** Parsed rows / tuples / objects (`csv-rows`, `json-array`, `json-objects`). */
+  rows?: ReadonlyArray<Record<string, unknown> | ReadonlyArray<unknown>>;
+  /** Parsed FeatureCollection (`geojson`). */
+  geojson?: FeatureCollection;
+  fieldMapping: DeckVizFieldMapping;
+  style: DeckVizStyle;
+  /** Store layer opacity (0..1), multiplied into the deck layer opacity. */
+  opacity: number;
+  /** Animation clock for animated layers (same units as the data timestamps). */
+  currentTime?: number;
+}
+
+export interface DeckVizExample {
+  url: string;
+  fieldMapping: DeckVizFieldMapping;
+  style?: Partial<DeckVizStyle>;
+}
+
+export interface DeckVizLayerDef {
+  kind: string;
+  label: string;
+  category: DeckVizCategory;
+  description: string;
+  inputKind: DeckVizInputKind;
+  format: DeckVizFormat;
+  roles: DeckVizRole[];
+  styleControls: DeckVizStyleControl[];
+  animated?: boolean;
+  build: (
+    deckGL: GeoLibreDeckGL,
+    layerId: string,
+    ctx: DeckVizBuildContext,
+  ) => Layer;
+  example: DeckVizExample;
+  /** Largest timestamp in the data, used to size the animation loop. */
+  getTimeRange?: (ctx: DeckVizBuildContext) => number;
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+const DATA_BASE =
+  "https://raw.githubusercontent.com/visgl/deck.gl-data/master/examples";
+
+// Yellow→red sequential ramp shared by the aggregation layers (matches the
+// deck.gl website examples), typed as deck.gl's RGB/RGBA color tuple list.
+const COLOR_RANGE: [number, number, number][] = [
+  [255, 255, 178],
+  [254, 217, 118],
+  [254, 178, 76],
+  [253, 141, 60],
+  [240, 59, 32],
+  [189, 0, 38],
+];
+
+type AnyRecord = Record<string, unknown> | ReadonlyArray<unknown>;
+
+/** Reads `record[key]` as a finite number (NaN-safe, returns 0 on failure). */
+function readNumber(record: AnyRecord, key: string | number): number {
+  const value = (record as Record<string | number, unknown>)[key];
+  const num = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(num) ? num : 0;
+}
+
+/** A `[lng, lat]` accessor from two mapped roles. */
+function positionAccessor(
+  mapping: DeckVizFieldMapping,
+  lngRole = "lng",
+  latRole = "lat",
+): (record: AnyRecord) => [number, number] {
+  const lngKey = mapping[lngRole];
+  const latKey = mapping[latRole];
+  return (record) => [readNumber(record, lngKey), readNumber(record, latKey)];
+}
+
+function rowsOf(ctx: DeckVizBuildContext): AnyRecord[] {
+  return (ctx.rows ?? []) as AnyRecord[];
+}
+
+function fillColor(style: DeckVizStyle): [number, number, number, number] {
+  return colorToRgba(style.color, 1);
+}
+
+// ---------------------------------------------------------------------------
+// Layer definitions
+// ---------------------------------------------------------------------------
+
+const LNG_ROLE: DeckVizRole = {
+  key: "lng",
+  label: "Longitude",
+  required: true,
+  detect: ["lng", "lon", "long", "longitude", "x"],
+};
+const LAT_ROLE: DeckVizRole = {
+  key: "lat",
+  label: "Latitude",
+  required: true,
+  detect: ["lat", "latitude", "y"],
+};
+const WEIGHT_ROLE: DeckVizRole = {
+  key: "weight",
+  label: "Weight (optional)",
+  required: false,
+  detect: ["weight", "value", "count", "magnitude", "mag"],
+};
+const SOURCE_LNG_ROLE: DeckVizRole = {
+  key: "sourceLng",
+  label: "Source longitude",
+  required: true,
+  detect: ["lon1", "lng1", "source_lng", "from_lng", "origin_lng", "start_lng"],
+};
+const SOURCE_LAT_ROLE: DeckVizRole = {
+  key: "sourceLat",
+  label: "Source latitude",
+  required: true,
+  detect: ["lat1", "source_lat", "from_lat", "origin_lat", "start_lat"],
+};
+const TARGET_LNG_ROLE: DeckVizRole = {
+  key: "targetLng",
+  label: "Target longitude",
+  required: true,
+  detect: ["lon2", "lng2", "target_lng", "to_lng", "dest_lng", "end_lng"],
+};
+const TARGET_LAT_ROLE: DeckVizRole = {
+  key: "targetLat",
+  label: "Target latitude",
+  required: true,
+  detect: ["lat2", "target_lat", "to_lat", "dest_lat", "end_lat"],
+};
+
+const POINT_ROLES: DeckVizRole[] = [LNG_ROLE, LAT_ROLE, WEIGHT_ROLE];
+const OD_ROLES: DeckVizRole[] = [
+  SOURCE_LNG_ROLE,
+  SOURCE_LAT_ROLE,
+  TARGET_LNG_ROLE,
+  TARGET_LAT_ROLE,
+];
+
+function weightAccessor(
+  mapping: DeckVizFieldMapping,
+): ((record: AnyRecord) => number) | undefined {
+  if (mapping.weight === undefined || mapping.weight === "") return undefined;
+  const key = mapping.weight;
+  return (record) => readNumber(record, key);
+}
+
+const DEFINITIONS: DeckVizLayerDef[] = [
+  // ---- Point & aggregation -------------------------------------------------
+  {
+    kind: "scatterplot",
+    label: "Scatterplot",
+    category: "point",
+    description: "Circles at each point. CSV/JSON with longitude & latitude.",
+    inputKind: "json-array",
+    format: "json-array",
+    roles: POINT_ROLES,
+    styleControls: ["color", "radius"],
+    build: (deckGL, id, ctx) =>
+      new deckGL.layers.ScatterplotLayer({
+        id,
+        data: rowsOf(ctx),
+        getPosition: positionAccessor(ctx.fieldMapping),
+        getRadius: ctx.style.radius,
+        getFillColor: fillColor(ctx.style),
+        radiusUnits: "meters",
+        radiusMinPixels: 1,
+        radiusMaxPixels: 100,
+        opacity: ctx.opacity,
+        pickable: true,
+      }),
+    example: {
+      url: `${DATA_BASE}/scatterplot/manhattan.json`,
+      fieldMapping: { lng: 0, lat: 1 },
+      style: { radius: 20 },
+    },
+  },
+  {
+    kind: "heatmap",
+    label: "Heatmap",
+    category: "point",
+    description: "Smooth density heatmap from weighted points.",
+    inputKind: "json-array",
+    format: "json-array",
+    roles: POINT_ROLES,
+    styleControls: ["radius"],
+    build: (deckGL, id, ctx) => {
+      const weight = weightAccessor(ctx.fieldMapping);
+      return new deckGL.aggregationLayers.HeatmapLayer({
+        id,
+        data: rowsOf(ctx),
+        getPosition: positionAccessor(ctx.fieldMapping),
+        ...(weight ? { getWeight: weight } : {}),
+        radiusPixels: Math.max(ctx.style.radius, 10),
+        colorRange: COLOR_RANGE,
+        opacity: ctx.opacity,
+      });
+    },
+    example: {
+      url: `${DATA_BASE}/screen-grid/uber-pickup-locations.json`,
+      fieldMapping: { lng: 0, lat: 1, weight: 2 },
+      style: { radius: 30 },
+    },
+  },
+  {
+    kind: "hexagon",
+    label: "Hexagon (3D)",
+    category: "point",
+    description: "Aggregates points into extruded hexagonal bins.",
+    inputKind: "point-csv",
+    format: "csv-rows",
+    roles: POINT_ROLES,
+    styleControls: ["cellSize", "extruded"],
+    build: (deckGL, id, ctx) => {
+      const weight = weightAccessor(ctx.fieldMapping);
+      return new deckGL.aggregationLayers.HexagonLayer({
+        id,
+        data: rowsOf(ctx),
+        getPosition: positionAccessor(ctx.fieldMapping),
+        // Omit the weight accessors with no weight column so deck.gl uses its
+        // count-based default; a constant accessor breaks GPU aggregation.
+        ...(weight
+          ? { getColorWeight: weight, getElevationWeight: weight }
+          : {}),
+        radius: ctx.style.cellSize,
+        extruded: ctx.style.extruded,
+        elevationScale: ctx.style.extruded ? ctx.style.elevationScale : 0,
+        colorRange: COLOR_RANGE,
+        opacity: ctx.opacity,
+        pickable: true,
+      });
+    },
+    example: {
+      url: `${DATA_BASE}/3d-heatmap/heatmap-data.csv`,
+      fieldMapping: { lng: "lng", lat: "lat" },
+      style: { cellSize: 6000, extruded: true, elevationScale: 50 },
+    },
+  },
+  {
+    kind: "grid",
+    label: "Grid (3D)",
+    category: "point",
+    description: "Aggregates points into extruded square bins.",
+    inputKind: "point-csv",
+    format: "csv-rows",
+    roles: POINT_ROLES,
+    styleControls: ["cellSize", "extruded"],
+    build: (deckGL, id, ctx) => {
+      const weight = weightAccessor(ctx.fieldMapping);
+      return new deckGL.aggregationLayers.GridLayer({
+        id,
+        data: rowsOf(ctx),
+        getPosition: positionAccessor(ctx.fieldMapping),
+        ...(weight
+          ? { getColorWeight: weight, getElevationWeight: weight }
+          : {}),
+        cellSize: ctx.style.cellSize,
+        extruded: ctx.style.extruded,
+        elevationScale: ctx.style.extruded ? ctx.style.elevationScale : 0,
+        colorRange: COLOR_RANGE,
+        opacity: ctx.opacity,
+        pickable: true,
+      });
+    },
+    example: {
+      url: `${DATA_BASE}/3d-heatmap/heatmap-data.csv`,
+      fieldMapping: { lng: "lng", lat: "lat" },
+      style: { cellSize: 6000, extruded: true, elevationScale: 50 },
+    },
+  },
+  {
+    kind: "screen-grid",
+    label: "Screen grid",
+    category: "point",
+    description: "Aggregates points into fixed-pixel screen cells.",
+    inputKind: "json-array",
+    format: "json-array",
+    roles: POINT_ROLES,
+    styleControls: ["cellSize"],
+    build: (deckGL, id, ctx) => {
+      const weight = weightAccessor(ctx.fieldMapping);
+      return new deckGL.aggregationLayers.ScreenGridLayer({
+        id,
+        data: rowsOf(ctx),
+        getPosition: positionAccessor(ctx.fieldMapping),
+        ...(weight ? { getWeight: weight } : {}),
+        cellSizePixels: Math.max(Math.round(ctx.style.cellSize), 5),
+        colorRange: COLOR_RANGE,
+        opacity: ctx.opacity,
+      });
+    },
+    example: {
+      url: `${DATA_BASE}/screen-grid/uber-pickup-locations.json`,
+      fieldMapping: { lng: 0, lat: 1, weight: 2 },
+      style: { cellSize: 20 },
+    },
+  },
+  {
+    kind: "contour",
+    label: "Contour",
+    category: "point",
+    description: "Isoline bands over point density.",
+    inputKind: "point-csv",
+    format: "csv-rows",
+    roles: POINT_ROLES,
+    styleControls: ["cellSize"],
+    build: (deckGL, id, ctx) => {
+      const weight = weightAccessor(ctx.fieldMapping);
+      return new deckGL.aggregationLayers.ContourLayer({
+        id,
+        data: rowsOf(ctx),
+        getPosition: positionAccessor(ctx.fieldMapping),
+        ...(weight ? { getWeight: weight } : {}),
+        cellSize: ctx.style.cellSize,
+        contours: [
+          { threshold: 1, color: [255, 255, 178], strokeWidth: 2 },
+          { threshold: 5, color: [253, 141, 60], strokeWidth: 3 },
+          { threshold: 15, color: [189, 0, 38], strokeWidth: 4 },
+        ],
+        opacity: ctx.opacity,
+      });
+    },
+    example: {
+      url: `${DATA_BASE}/3d-heatmap/heatmap-data.csv`,
+      fieldMapping: { lng: "lng", lat: "lat" },
+      style: { cellSize: 4000 },
+    },
+  },
+  // ---- Flow / OD -----------------------------------------------------------
+  {
+    kind: "arc",
+    label: "Arc",
+    category: "flow",
+    description: "Curved arcs between source and target points.",
+    inputKind: "od-csv",
+    format: "csv-rows",
+    roles: OD_ROLES,
+    styleControls: ["color", "lineWidth"],
+    build: (deckGL, id, ctx) =>
+      new deckGL.layers.ArcLayer({
+        id,
+        data: rowsOf(ctx),
+        getSourcePosition: positionAccessor(
+          ctx.fieldMapping,
+          "sourceLng",
+          "sourceLat",
+        ),
+        getTargetPosition: positionAccessor(
+          ctx.fieldMapping,
+          "targetLng",
+          "targetLat",
+        ),
+        getSourceColor: fillColor(ctx.style),
+        getTargetColor: colorToRgba(ctx.style.color, 0.4),
+        getWidth: ctx.style.lineWidth,
+        opacity: ctx.opacity,
+        pickable: true,
+      }),
+    example: {
+      url: `${DATA_BASE}/globe/2020-01-14.csv`,
+      fieldMapping: {
+        sourceLng: "lon1",
+        sourceLat: "lat1",
+        targetLng: "lon2",
+        targetLat: "lat2",
+      },
+      style: { lineWidth: 1 },
+    },
+  },
+  {
+    kind: "line",
+    label: "Line",
+    category: "flow",
+    description: "Straight lines between source and target points.",
+    inputKind: "od-csv",
+    format: "csv-rows",
+    roles: OD_ROLES,
+    styleControls: ["color", "lineWidth"],
+    build: (deckGL, id, ctx) =>
+      new deckGL.layers.LineLayer({
+        id,
+        data: rowsOf(ctx),
+        getSourcePosition: positionAccessor(
+          ctx.fieldMapping,
+          "sourceLng",
+          "sourceLat",
+        ),
+        getTargetPosition: positionAccessor(
+          ctx.fieldMapping,
+          "targetLng",
+          "targetLat",
+        ),
+        getColor: fillColor(ctx.style),
+        getWidth: ctx.style.lineWidth,
+        opacity: ctx.opacity,
+        pickable: true,
+      }),
+    example: {
+      url: `${DATA_BASE}/globe/2020-01-14.csv`,
+      fieldMapping: {
+        sourceLng: "lon1",
+        sourceLat: "lat1",
+        targetLng: "lon2",
+        targetLat: "lat2",
+      },
+      style: { lineWidth: 2 },
+    },
+  },
+  {
+    kind: "great-circle",
+    label: "Great circle",
+    category: "flow",
+    description: "Geodesic great-circle paths between points.",
+    inputKind: "od-csv",
+    format: "csv-rows",
+    roles: OD_ROLES,
+    styleControls: ["color", "lineWidth"],
+    build: (deckGL, id, ctx) =>
+      new deckGL.geoLayers.GreatCircleLayer({
+        id,
+        data: rowsOf(ctx),
+        getSourcePosition: positionAccessor(
+          ctx.fieldMapping,
+          "sourceLng",
+          "sourceLat",
+        ),
+        getTargetPosition: positionAccessor(
+          ctx.fieldMapping,
+          "targetLng",
+          "targetLat",
+        ),
+        getSourceColor: fillColor(ctx.style),
+        getTargetColor: colorToRgba(ctx.style.color, 0.4),
+        getWidth: ctx.style.lineWidth,
+        opacity: ctx.opacity,
+        pickable: true,
+      }),
+    example: {
+      url: `${DATA_BASE}/globe/2020-01-14.csv`,
+      fieldMapping: {
+        sourceLng: "lon1",
+        sourceLat: "lat1",
+        targetLng: "lon2",
+        targetLat: "lat2",
+      },
+      style: { lineWidth: 2 },
+    },
+  },
+  // ---- GeoJSON -------------------------------------------------------------
+  {
+    kind: "geojson",
+    label: "GeoJSON (with extrusion)",
+    category: "geojson",
+    description: "Render a GeoJSON file; optionally extrude polygons by a property.",
+    inputKind: "geojson",
+    format: "geojson",
+    roles: [
+      {
+        key: "elevation",
+        label: "Extrusion height property (optional)",
+        required: false,
+        detect: ["height", "elevation", "value", "valuepersqm"],
+      },
+    ],
+    styleControls: ["color", "extruded"],
+    build: (deckGL, id, ctx) => {
+      const elevationKey = ctx.fieldMapping.elevation;
+      const extruded = ctx.style.extruded && elevationKey !== undefined;
+      return new deckGL.layers.GeoJsonLayer({
+        id,
+        data: (ctx.geojson ?? {
+          type: "FeatureCollection",
+          features: [],
+        }) as FeatureCollection,
+        filled: true,
+        stroked: true,
+        extruded,
+        getFillColor: colorToRgba(ctx.style.color, 0.7),
+        getLineColor: colorToRgba(ctx.style.color, 1),
+        getLineWidth: ctx.style.lineWidth,
+        lineWidthMinPixels: 1,
+        getPointRadius: ctx.style.radius,
+        pointRadiusUnits: "meters",
+        pointRadiusMinPixels: 2,
+        getElevation: extruded
+          ? (feature: { properties?: Record<string, unknown> | null }) =>
+              readNumber(
+                (feature.properties ?? {}) as Record<string, unknown>,
+                elevationKey as string,
+              )
+          : 0,
+        opacity: ctx.opacity,
+        pickable: true,
+      });
+    },
+    example: {
+      url: `${DATA_BASE}/geojson/vancouver-blocks.json`,
+      fieldMapping: { elevation: "valuePerSqm" },
+      style: { extruded: true },
+    },
+  },
+  // ---- Advanced / animated -------------------------------------------------
+  {
+    kind: "icon",
+    label: "Icon markers",
+    category: "advanced",
+    description: "A marker icon at each point. CSV/JSON with longitude & latitude.",
+    inputKind: "point-csv",
+    format: "csv-rows",
+    roles: [LNG_ROLE, LAT_ROLE],
+    styleControls: ["color", "radius"],
+    build: (deckGL, id, ctx) =>
+      new deckGL.layers.IconLayer({
+        id,
+        data: rowsOf(ctx),
+        getPosition: positionAccessor(ctx.fieldMapping),
+        getIcon: () => "marker",
+        iconAtlas:
+          "https://raw.githubusercontent.com/visgl/deck.gl-data/master/website/icon-atlas.png",
+        iconMapping: {
+          marker: { x: 0, y: 0, width: 128, height: 128, mask: true, anchorY: 128 },
+        },
+        getColor: fillColor(ctx.style),
+        getSize: Math.max(ctx.style.radius, 12),
+        sizeUnits: "pixels",
+        pickable: true,
+        opacity: ctx.opacity,
+      }),
+    example: {
+      url: `${DATA_BASE}/text-layer/cities-1000.csv`,
+      fieldMapping: { lng: "longitude", lat: "latitude" },
+      style: { radius: 24 },
+    },
+  },
+  {
+    kind: "text",
+    label: "Text labels",
+    category: "advanced",
+    description: "A text label at each point. CSV/JSON with a label column.",
+    inputKind: "point-csv",
+    format: "csv-rows",
+    roles: [
+      LNG_ROLE,
+      LAT_ROLE,
+      {
+        key: "text",
+        label: "Label text",
+        required: true,
+        detect: ["name", "label", "text", "title"],
+      },
+    ],
+    styleControls: ["color"],
+    build: (deckGL, id, ctx) => {
+      const textKey = ctx.fieldMapping.text;
+      return new deckGL.layers.TextLayer({
+        id,
+        data: rowsOf(ctx),
+        getPosition: positionAccessor(ctx.fieldMapping),
+        getText: (record: AnyRecord) =>
+          String((record as Record<string | number, unknown>)[textKey] ?? ""),
+        getColor: fillColor(ctx.style),
+        getSize: 16,
+        sizeUnits: "pixels",
+        background: true,
+        getBackgroundColor: [255, 255, 255, 200],
+        pickable: true,
+        opacity: ctx.opacity,
+      });
+    },
+    example: {
+      url: `${DATA_BASE}/text-layer/cities-1000.csv`,
+      fieldMapping: { lng: "longitude", lat: "latitude", text: "name" },
+    },
+  },
+  {
+    kind: "trips",
+    label: "Trips (animated)",
+    category: "advanced",
+    description:
+      "Animated trails along paths. JSON array of objects with path & timestamps.",
+    inputKind: "json-objects",
+    format: "json-objects",
+    roles: [
+      {
+        key: "path",
+        label: "Path property",
+        required: true,
+        detect: ["path", "coordinates", "geometry"],
+      },
+      {
+        key: "timestamps",
+        label: "Timestamps property",
+        required: true,
+        detect: ["timestamps", "time", "times"],
+      },
+    ],
+    styleControls: ["color", "lineWidth"],
+    animated: true,
+    build: (deckGL, id, ctx) => {
+      const pathKey = ctx.fieldMapping.path;
+      const tsKey = ctx.fieldMapping.timestamps;
+      return new deckGL.geoLayers.TripsLayer({
+        id,
+        data: rowsOf(ctx),
+        // deck.gl types PathGeometry as a flat number[], but PathLayer accepts
+        // the nested [[lng,lat],...] arrays our data uses; cast to satisfy it.
+        getPath: (record: AnyRecord) =>
+          (record as Record<string | number, unknown>)[
+            pathKey
+          ] as unknown as number[],
+        getTimestamps: (record: AnyRecord) =>
+          (record as Record<string | number, unknown>)[tsKey] as number[],
+        getColor: fillColor(ctx.style),
+        widthMinPixels: Math.max(ctx.style.lineWidth, 1),
+        rounded: true,
+        trailLength: 180,
+        currentTime: ctx.currentTime ?? 0,
+        opacity: ctx.opacity,
+      });
+    },
+    getTimeRange: (ctx) => {
+      const tsKey = ctx.fieldMapping.timestamps;
+      let max = 0;
+      for (const record of rowsOf(ctx)) {
+        const stamps = (record as Record<string | number, unknown>)[tsKey];
+        if (Array.isArray(stamps)) {
+          for (const value of stamps) {
+            const num = Number(value);
+            if (Number.isFinite(num) && num > max) max = num;
+          }
+        }
+      }
+      return max;
+    },
+    example: {
+      url: `${DATA_BASE}/trips/trips-v7.json`,
+      fieldMapping: { path: "path", timestamps: "timestamps" },
+      style: { lineWidth: 2, color: "#f97316" },
+    },
+  },
+];
+
+const REGISTRY = new Map<string, DeckVizLayerDef>(
+  DEFINITIONS.map((def) => [def.kind, def]),
+);
+
+/** All layer definitions, in registration (display) order. */
+export function listDeckVizLayerDefs(): DeckVizLayerDef[] {
+  return DEFINITIONS;
+}
+
+/** Look up a layer definition by its registry kind. */
+export function getDeckVizLayerDef(kind: string): DeckVizLayerDef | undefined {
+  return REGISTRY.get(kind);
+}
+
+/** Human-readable category labels for the picker, in display order. */
+export const DECK_VIZ_CATEGORY_LABELS: Record<DeckVizCategory, string> = {
+  point: "Point & aggregation",
+  flow: "Flow / origin-destination",
+  geojson: "GeoJSON",
+  advanced: "Advanced / animated",
+};

--- a/packages/plugins/src/plugins/deckgl-viz/registry.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/registry.ts
@@ -139,11 +139,21 @@ const COLOR_RANGE: [number, number, number][] = [
 
 type AnyRecord = Record<string, unknown> | ReadonlyArray<unknown>;
 
-/** Reads `record[key]` as a finite number (NaN-safe, returns 0 on failure). */
+/** Reads `record[key]` as a number, falling back to 0 for non-finite values. */
 function readNumber(record: AnyRecord, key: string | number): number {
   const value = (record as Record<string | number, unknown>)[key];
   const num = typeof value === "number" ? value : Number(value);
   return Number.isFinite(num) ? num : 0;
+}
+
+/**
+ * Reads `record[key]` as a coordinate, returning NaN (not 0) for
+ * missing/invalid values so deck.gl skips the record instead of plotting it at
+ * null-island (0°N, 0°E).
+ */
+function readCoordinate(record: AnyRecord, key: string | number): number {
+  const value = (record as Record<string | number, unknown>)[key];
+  return typeof value === "number" ? value : Number(value);
 }
 
 /** A `[lng, lat]` accessor from two mapped roles. */
@@ -154,7 +164,10 @@ function positionAccessor(
 ): (record: AnyRecord) => [number, number] {
   const lngKey = mapping[lngRole];
   const latKey = mapping[latRole];
-  return (record) => [readNumber(record, lngKey), readNumber(record, latKey)];
+  return (record) => [
+    readCoordinate(record, lngKey),
+    readCoordinate(record, latKey),
+  ];
 }
 
 function rowsOf(ctx: DeckVizBuildContext): AnyRecord[] {

--- a/packages/plugins/src/plugins/deckgl-viz/store-layer.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/store-layer.ts
@@ -39,6 +39,24 @@ export interface CreateDeckVizLayerParams {
   geojson?: FeatureCollection;
   /** Origin URL or file name, shown in the layer panel. */
   sourcePath?: string;
+  /** `[west, south, east, north]` extent, so "Zoom to layer" works. */
+  bounds?: [number, number, number, number];
+}
+
+/**
+ * Seeds the standard LayerStyle from the viz config so the Style panel opens on
+ * the values chosen in the dialog (and editing them flows back into rendering,
+ * since the overlay reads these fields).
+ */
+function deckVizLayerStyle(config: DeckVizConfig) {
+  return {
+    ...DEFAULT_LAYER_STYLE,
+    fillColor: config.style.color,
+    strokeColor: config.style.color,
+    circleRadius: config.style.radius,
+    strokeWidth: config.style.lineWidth,
+    fillOpacity: 1,
+  };
 }
 
 /**
@@ -82,7 +100,7 @@ export function createDeckVizStoreLayer(
     },
     visible: true,
     opacity: 1,
-    style: { ...DEFAULT_LAYER_STYLE },
+    style: deckVizLayerStyle(params.config),
     metadata: {
       sourceKind: DECK_VIZ_SOURCE_KIND,
       // The picker/identify code keys off customLayerType for deck overlays;
@@ -91,6 +109,7 @@ export function createDeckVizStoreLayer(
       externalDeckLayer: true,
       identifiable: false,
       vizConfig: params.config,
+      ...(params.bounds ? { bounds: params.bounds } : {}),
     },
     geojson: params.geojson,
     sourcePath: params.sourcePath,

--- a/packages/plugins/src/plugins/deckgl-viz/store-layer.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/store-layer.ts
@@ -53,10 +53,25 @@ export interface CreateDeckVizLayerParams {
  * @param params - Layer name, viz config, and inline data.
  * @returns The corresponding GeoLibre store layer.
  */
+/**
+ * Row count above which the inline data noticeably bloats the saved project
+ * file. Surfaced as a warning, not a hard cap, so large datasets still work.
+ */
+const DECK_VIZ_ROW_WARN_COUNT = 50_000;
+
 export function createDeckVizStoreLayer(
   params: CreateDeckVizLayerParams,
 ): GeoLibreLayer {
   const id = params.id ?? crypto.randomUUID();
+  const rowCount =
+    params.rows?.length ?? params.geojson?.features.length ?? 0;
+  if (rowCount > DECK_VIZ_ROW_WARN_COUNT) {
+    console.warn(
+      "[GeoLibre] deck-viz: storing",
+      rowCount,
+      "rows inline; this will enlarge the saved project file",
+    );
+  }
   return {
     id,
     name: params.name,

--- a/packages/plugins/src/plugins/deckgl-viz/store-layer.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/store-layer.ts
@@ -111,8 +111,9 @@ export function readDeckVizConfig(layer: GeoLibreLayer): DeckVizConfig | null {
     def &&
     def.roles.some((role) => {
       if (!role.required) return false;
-      const value = fieldMapping[role.key];
-      return value === undefined || value === "";
+      // Typed string | number, but a hand-edited JSON file may carry null.
+      const value: unknown = fieldMapping[role.key];
+      return value === undefined || value === null || value === "";
     })
   ) {
     return null;

--- a/packages/plugins/src/plugins/deckgl-viz/store-layer.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/store-layer.ts
@@ -8,6 +8,7 @@ import {
   type DeckVizConfig,
   type DeckVizFieldMapping,
   type DeckVizStyle,
+  getDeckVizLayerDef,
 } from "./registry";
 
 /** Marks store layers owned by the Deck.gl Layer builder. */
@@ -102,6 +103,20 @@ export function readDeckVizConfig(layer: GeoLibreLayer): DeckVizConfig | null {
   if (!candidate.fieldMapping || typeof candidate.fieldMapping !== "object") {
     return null;
   }
+  const fieldMapping = candidate.fieldMapping as DeckVizFieldMapping;
+  // Reject a corrupt/hand-edited config missing a required role mapping rather
+  // than letting an accessor silently read `undefined` and render at [0, 0].
+  const def = getDeckVizLayerDef(candidate.layerKind);
+  if (
+    def &&
+    def.roles.some((role) => {
+      if (!role.required) return false;
+      const value = fieldMapping[role.key];
+      return value === undefined || value === "";
+    })
+  ) {
+    return null;
+  }
   const style: DeckVizStyle = {
     ...DEFAULT_DECK_VIZ_STYLE,
     ...(candidate.style ?? {}),
@@ -109,7 +124,7 @@ export function readDeckVizConfig(layer: GeoLibreLayer): DeckVizConfig | null {
   return {
     layerKind: candidate.layerKind,
     format: candidate.format ?? "csv-rows",
-    fieldMapping: candidate.fieldMapping as DeckVizFieldMapping,
+    fieldMapping,
     style,
   };
 }

--- a/packages/plugins/src/plugins/deckgl-viz/store-layer.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/store-layer.ts
@@ -1,0 +1,115 @@
+import {
+  DEFAULT_LAYER_STYLE,
+  type GeoLibreLayer,
+} from "@geolibre/core";
+import type { FeatureCollection } from "geojson";
+import {
+  DEFAULT_DECK_VIZ_STYLE,
+  type DeckVizConfig,
+  type DeckVizFieldMapping,
+  type DeckVizStyle,
+} from "./registry";
+
+/** Marks store layers owned by the Deck.gl Layer builder. */
+export const DECK_VIZ_SOURCE_KIND = "deckgl-viz";
+
+/**
+ * Detects a store layer rendered through the deck.gl visualization overlay.
+ *
+ * @param layer - A store layer.
+ * @returns True when the layer was created by the Deck.gl Layer builder.
+ */
+export function isDeckVizLayer(layer: GeoLibreLayer): boolean {
+  return (
+    layer.type === "deckgl-viz" &&
+    layer.metadata.sourceKind === DECK_VIZ_SOURCE_KIND
+  );
+}
+
+/** Inputs for {@link createDeckVizStoreLayer}. */
+export interface CreateDeckVizLayerParams {
+  /** Layer id; a uuid is generated when omitted. */
+  id?: string;
+  name: string;
+  config: DeckVizConfig;
+  /** Parsed rows/tuples/objects for non-GeoJSON layers (stored inline). */
+  rows?: ReadonlyArray<unknown>;
+  /** Parsed FeatureCollection for GeoJSON layers (stored inline). */
+  geojson?: FeatureCollection;
+  /** Origin URL or file name, shown in the layer panel. */
+  sourcePath?: string;
+}
+
+/**
+ * Builds the store layer for a deck.gl visualization.
+ *
+ * The deck.gl layer renders through the plugin's shared overlay, so the record
+ * registers as an external custom layer: layer-sync skips paint/source sync
+ * (`externalDeckLayer` + `customLayerType`), and the overlay manager applies
+ * visibility/opacity from the store. All data and configuration is inlined so a
+ * saved project re-renders without re-fetching.
+ *
+ * @param params - Layer name, viz config, and inline data.
+ * @returns The corresponding GeoLibre store layer.
+ */
+export function createDeckVizStoreLayer(
+  params: CreateDeckVizLayerParams,
+): GeoLibreLayer {
+  const id = params.id ?? crypto.randomUUID();
+  return {
+    id,
+    name: params.name,
+    type: "deckgl-viz",
+    source: {
+      type: "deckgl-viz",
+      ...(params.rows ? { data: params.rows } : {}),
+    },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {
+      sourceKind: DECK_VIZ_SOURCE_KIND,
+      // The picker/identify code keys off customLayerType for deck overlays;
+      // identify is disabled because there is no MapLibre source to query.
+      customLayerType: params.config.layerKind,
+      externalDeckLayer: true,
+      identifiable: false,
+      vizConfig: params.config,
+    },
+    geojson: params.geojson,
+    sourcePath: params.sourcePath,
+  };
+}
+
+/** Reads the inline row data from a deck-viz store layer. */
+export function deckVizRows(layer: GeoLibreLayer): ReadonlyArray<unknown> {
+  const data = (layer.source as { data?: unknown }).data;
+  return Array.isArray(data) ? data : [];
+}
+
+/**
+ * Reads and normalises the persisted viz config from a store layer, tolerating
+ * partial/hand-edited style so older or malformed projects still render.
+ *
+ * @param layer - A deck-viz store layer.
+ * @returns The viz config, or null when it is missing/invalid.
+ */
+export function readDeckVizConfig(layer: GeoLibreLayer): DeckVizConfig | null {
+  const raw = layer.metadata.vizConfig;
+  if (!raw || typeof raw !== "object") return null;
+  const candidate = raw as Partial<DeckVizConfig>;
+  if (typeof candidate.layerKind !== "string") return null;
+  if (!candidate.fieldMapping || typeof candidate.fieldMapping !== "object") {
+    return null;
+  }
+  const style: DeckVizStyle = {
+    ...DEFAULT_DECK_VIZ_STYLE,
+    ...(candidate.style ?? {}),
+  };
+  return {
+    layerKind: candidate.layerKind,
+    format: candidate.format ?? "csv-rows",
+    fieldMapping: candidate.fieldMapping as DeckVizFieldMapping,
+    style,
+  };
+}

--- a/packages/plugins/src/plugins/deckgl-viz/store-layer.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/store-layer.ts
@@ -60,6 +60,12 @@ function deckVizLayerStyle(config: DeckVizConfig) {
 }
 
 /**
+ * Row count above which the inline data noticeably bloats the saved project
+ * file. Surfaced as a warning, not a hard cap, so large datasets still work.
+ */
+const DECK_VIZ_ROW_WARN_COUNT = 50_000;
+
+/**
  * Builds the store layer for a deck.gl visualization.
  *
  * The deck.gl layer renders through the plugin's shared overlay, so the record
@@ -71,12 +77,6 @@ function deckVizLayerStyle(config: DeckVizConfig) {
  * @param params - Layer name, viz config, and inline data.
  * @returns The corresponding GeoLibre store layer.
  */
-/**
- * Row count above which the inline data noticeably bloats the saved project
- * file. Surfaced as a warning, not a hard cap, so large datasets still work.
- */
-const DECK_VIZ_ROW_WARN_COUNT = 50_000;
-
 export function createDeckVizStoreLayer(
   params: CreateDeckVizLayerParams,
 ): GeoLibreLayer {

--- a/packages/plugins/src/plugins/maplibre-deckgl-viz.ts
+++ b/packages/plugins/src/plugins/maplibre-deckgl-viz.ts
@@ -1,0 +1,30 @@
+import type { GeoLibrePlugin } from "../types";
+import {
+  activateDeckViz,
+  deactivateDeckViz,
+} from "./deckgl-viz/overlay";
+
+export const DECK_VIZ_PLUGIN_ID = "maplibre-deckgl-viz";
+
+/**
+ * Renders user-built deck.gl visualizations (created through the Add Data →
+ * "Deck.gl Layer" dialog) on a shared deck.gl overlay. The dialog writes
+ * `deckgl-viz` layers into the store; this plugin owns the overlay that draws
+ * them and keeps it in sync with the store.
+ *
+ * Like the other `activeByDefault` overlay plugins, its initial activation is
+ * driven idempotently from the desktop shell via `restoreDeckViz`, because the
+ * plugin manager marks default plugins active without calling activate().
+ */
+export const maplibreDeckGlVizPlugin: GeoLibrePlugin = {
+  id: DECK_VIZ_PLUGIN_ID,
+  name: "Deck.gl Layer",
+  version: "0.1.0",
+  activeByDefault: true,
+  activate: (app) => {
+    void activateDeckViz(app);
+  },
+  deactivate: (app) => {
+    deactivateDeckViz(app);
+  },
+};

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -59,6 +59,8 @@ export interface GeoLibreDeckGL {
   core: typeof import("@deck.gl/core");
   /** `@deck.gl/layers` (ArcLayer, ScatterplotLayer, GeoJsonLayer, ...). */
   layers: typeof import("@deck.gl/layers");
+  /** `@deck.gl/aggregation-layers` (HexagonLayer, HeatmapLayer, GridLayer, ScreenGridLayer, ContourLayer). */
+  aggregationLayers: typeof import("@deck.gl/aggregation-layers");
   /** `@deck.gl/geo-layers` (TileLayer, H3HexagonLayer, S2Layer, ...). */
   geoLayers: typeof import("@deck.gl/geo-layers");
   /** `@deck.gl/mesh-layers` (SimpleMeshLayer, ScenegraphLayer). */

--- a/tests/deck-viz.test.ts
+++ b/tests/deck-viz.test.ts
@@ -1,0 +1,261 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { parseDelimitedTextRows } from "../apps/geolibre-desktop/src/lib/delimited-text";
+import {
+  autoDetectFieldMapping,
+  computeDeckVizBounds,
+  detectAndParseDeckVizInput,
+} from "../apps/geolibre-desktop/src/lib/deck-viz-input";
+import {
+  getDeckVizLayerDef,
+  listDeckVizLayerDefs,
+} from "../packages/plugins/src/plugins/deckgl-viz/registry";
+import {
+  createDeckVizStoreLayer,
+  isDeckVizLayer,
+  readDeckVizConfig,
+} from "../packages/plugins/src/plugins/deckgl-viz/store-layer";
+
+describe("parseDelimitedTextRows", () => {
+  it("returns header fields and one record per data row", () => {
+    const { fields, rows } = parseDelimitedTextRows(
+      "lng,lat,value\n-73.9,40.7,5\n-74.0,40.6,9\n",
+      ",",
+    );
+    assert.deepEqual(fields, ["lng", "lat", "value"]);
+    assert.equal(rows.length, 2);
+    assert.deepEqual(rows[0], { lng: "-73.9", lat: "40.7", value: "5" });
+    assert.equal(rows[1].value, "9");
+  });
+
+  it("honours quoted fields and a tab delimiter", () => {
+    const { fields, rows } = parseDelimitedTextRows(
+      'name\tlng\n"Smith, John"\t-1.5\n',
+      "\t",
+    );
+    assert.deepEqual(fields, ["name", "lng"]);
+    assert.equal(rows[0].name, "Smith, John");
+  });
+
+  it("throws without a header and data row", () => {
+    assert.throws(() => parseDelimitedTextRows("lng,lat\n", ","));
+  });
+});
+
+describe("detectAndParseDeckVizInput", () => {
+  it("detects CSV rows with sampled column labels", () => {
+    const parsed = detectAndParseDeckVizInput("lng,lat\n-1,2\n-3,4\n");
+    assert.equal(parsed.format, "csv-rows");
+    assert.equal(parsed.rowCount, 2);
+    assert.deepEqual(
+      parsed.columns.map((column) => column.value),
+      ["lng", "lat"],
+    );
+  });
+
+  it("detects a JSON array of tuples with numeric column indices", () => {
+    const parsed = detectAndParseDeckVizInput("[[-73.9,40.7,1],[-74,40.6,2]]");
+    assert.equal(parsed.format, "json-array");
+    assert.deepEqual(
+      parsed.columns.map((column) => column.value),
+      [0, 1, 2],
+    );
+    assert.equal(parsed.rowCount, 2);
+  });
+
+  it("detects a JSON array of objects with key columns", () => {
+    const parsed = detectAndParseDeckVizInput(
+      '[{"path":[[0,0]],"timestamps":[1,2]}]',
+    );
+    assert.equal(parsed.format, "json-objects");
+    assert.deepEqual(
+      parsed.columns.map((column) => column.value),
+      ["path", "timestamps"],
+    );
+  });
+
+  it("detects a GeoJSON FeatureCollection and collects property keys", () => {
+    const parsed = detectAndParseDeckVizInput(
+      JSON.stringify({
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            geometry: { type: "Point", coordinates: [0, 0] },
+            properties: { height: 12, growth: 0.1 },
+          },
+        ],
+      }),
+    );
+    assert.equal(parsed.format, "geojson");
+    assert.ok(parsed.geojson);
+    assert.deepEqual(
+      parsed.columns.map((column) => column.value).sort(),
+      ["growth", "height"],
+    );
+  });
+
+  it("throws on empty or unsupported input", () => {
+    assert.throws(() => detectAndParseDeckVizInput("   "));
+    assert.throws(() => detectAndParseDeckVizInput("[1, 2, 3]"));
+  });
+});
+
+describe("autoDetectFieldMapping", () => {
+  const pointRoles = getDeckVizLayerDef("scatterplot")!.roles;
+  const odRoles = getDeckVizLayerDef("arc")!.roles;
+
+  it("maps named columns by detection hints", () => {
+    const parsed = detectAndParseDeckVizInput(
+      "Longitude,Latitude,Magnitude\n-1,2,3\n",
+    );
+    const mapping = autoDetectFieldMapping(pointRoles, parsed.columns);
+    assert.equal(mapping.lng, "Longitude");
+    assert.equal(mapping.lat, "Latitude");
+    assert.equal(mapping.weight, "Magnitude");
+  });
+
+  it("does not let the short 'y' token grab an unrelated column", () => {
+    const parsed = detectAndParseDeckVizInput("city,lng,lat\nNY,-1,2\n");
+    const mapping = autoDetectFieldMapping(pointRoles, parsed.columns);
+    assert.equal(mapping.lat, "lat");
+    assert.equal(mapping.lng, "lng");
+  });
+
+  it("falls back to positional mapping for tuple arrays", () => {
+    const parsed = detectAndParseDeckVizInput("[[-1,2,9]]");
+    const mapping = autoDetectFieldMapping(pointRoles, parsed.columns);
+    assert.equal(mapping.lng, 0);
+    assert.equal(mapping.lat, 1);
+    assert.equal(mapping.weight, 2);
+  });
+
+  it("maps origin-destination columns without reusing a column", () => {
+    const parsed = detectAndParseDeckVizInput(
+      "lon1,lat1,lon2,lat2\n-1,2,-3,4\n",
+    );
+    const mapping = autoDetectFieldMapping(odRoles, parsed.columns);
+    assert.deepEqual(mapping, {
+      sourceLng: "lon1",
+      sourceLat: "lat1",
+      targetLng: "lon2",
+      targetLat: "lat2",
+    });
+  });
+});
+
+describe("computeDeckVizBounds", () => {
+  it("bounds point rows by lng/lat keys", () => {
+    const bounds = computeDeckVizBounds(
+      [
+        { lng: -10, lat: 5 },
+        { lng: 20, lat: -3 },
+      ],
+      { lng: "lng", lat: "lat" },
+    );
+    assert.deepEqual(bounds, [-10, -3, 20, 5]);
+  });
+
+  it("includes both endpoints for origin-destination rows", () => {
+    const bounds = computeDeckVizBounds([[-5, 0, 30, 40]], {
+      sourceLng: 0,
+      sourceLat: 1,
+      targetLng: 2,
+      targetLat: 3,
+    });
+    assert.deepEqual(bounds, [-5, 0, 30, 40]);
+  });
+
+  it("walks Trips path arrays", () => {
+    const bounds = computeDeckVizBounds(
+      [{ path: [[-2, 1], [4, 9]] }],
+      { path: "path" },
+    );
+    assert.deepEqual(bounds, [-2, 1, 4, 9]);
+  });
+
+  it("returns null when no finite coordinates are present", () => {
+    assert.equal(computeDeckVizBounds([{ lng: "x", lat: "y" }], {
+      lng: "lng",
+      lat: "lat",
+    }), null);
+  });
+});
+
+describe("deck-viz registry & store layer", () => {
+  it("exposes every layer with an example url and required roles", () => {
+    const defs = listDeckVizLayerDefs();
+    assert.ok(defs.length >= 12);
+    for (const def of defs) {
+      assert.match(def.example.url, /^https:\/\//);
+      assert.ok(typeof def.build === "function");
+      // Required roles in the example mapping must be present.
+      for (const role of def.roles) {
+        if (role.required) {
+          assert.notEqual(
+            def.example.fieldMapping[role.key],
+            undefined,
+            `${def.kind} example must map required role ${role.key}`,
+          );
+        }
+      }
+    }
+  });
+
+  it("creates a detectable store layer carrying the viz config", () => {
+    const layer = createDeckVizStoreLayer({
+      name: "Test",
+      config: {
+        layerKind: "scatterplot",
+        format: "json-array",
+        fieldMapping: { lng: 0, lat: 1 },
+        style: getDeckVizLayerDef("scatterplot")!.example.style
+          ? { ...defaultStyle(), ...getDeckVizLayerDef("scatterplot")!.example.style }
+          : defaultStyle(),
+      },
+      rows: [[-1, 2]],
+      sourcePath: "memory://test",
+    });
+    assert.equal(layer.type, "deckgl-viz");
+    assert.equal(layer.metadata.externalDeckLayer, true);
+    assert.equal(layer.metadata.customLayerType, "scatterplot");
+    assert.ok(isDeckVizLayer(layer));
+
+    const config = readDeckVizConfig(layer);
+    assert.ok(config);
+    assert.equal(config.layerKind, "scatterplot");
+    assert.equal(config.fieldMapping.lat, 1);
+  });
+
+  it("readDeckVizConfig fills missing style with defaults and rejects junk", () => {
+    const layer = createDeckVizStoreLayer({
+      name: "Partial",
+      config: {
+        layerKind: "heatmap",
+        format: "json-array",
+        fieldMapping: { lng: 0, lat: 1 },
+        // deliberately partial style
+        style: { color: "#ff0000" } as never,
+      },
+      rows: [],
+    });
+    const config = readDeckVizConfig(layer);
+    assert.ok(config);
+    assert.equal(config.style.color, "#ff0000");
+    assert.equal(typeof config.style.radius, "number");
+
+    const broken = { ...layer, metadata: { ...layer.metadata, vizConfig: {} } };
+    assert.equal(readDeckVizConfig(broken), null);
+  });
+});
+
+function defaultStyle() {
+  return {
+    color: "#3b82f6",
+    radius: 40,
+    cellSize: 1000,
+    lineWidth: 2,
+    extruded: false,
+    elevationScale: 30,
+  };
+}

--- a/tests/deck-viz.test.ts
+++ b/tests/deck-viz.test.ts
@@ -247,6 +247,32 @@ describe("deck-viz registry & store layer", () => {
     const broken = { ...layer, metadata: { ...layer.metadata, vizConfig: {} } };
     assert.equal(readDeckVizConfig(broken), null);
   });
+
+  it("readDeckVizConfig rejects a config missing a required role mapping", () => {
+    const layer = createDeckVizStoreLayer({
+      name: "Corrupt",
+      config: {
+        layerKind: "scatterplot",
+        format: "json-array",
+        // lat is required but absent (e.g. a hand-edited project file)
+        fieldMapping: { lng: 0 },
+        style: defaultStyle(),
+      },
+      rows: [],
+    });
+    assert.equal(readDeckVizConfig(layer), null);
+  });
+});
+
+describe("detectAndParseDeckVizInput tuple width", () => {
+  it("offers columns from a later, wider tuple row", () => {
+    const parsed = detectAndParseDeckVizInput("[[-1,2],[-3,4,9]]");
+    assert.equal(parsed.format, "json-array");
+    assert.deepEqual(
+      parsed.columns.map((column) => column.value),
+      [0, 1, 2],
+    );
+  });
 });
 
 function defaultStyle() {

--- a/tests/deck-viz.test.ts
+++ b/tests/deck-viz.test.ts
@@ -7,6 +7,7 @@ import {
   detectAndParseDeckVizInput,
 } from "../apps/geolibre-desktop/src/lib/deck-viz-input";
 import {
+  DEFAULT_DECK_VIZ_STYLE,
   getDeckVizLayerDef,
   listDeckVizLayerDefs,
 } from "../packages/plugins/src/plugins/deckgl-viz/registry";
@@ -203,15 +204,14 @@ describe("deck-viz registry & store layer", () => {
   });
 
   it("creates a detectable store layer carrying the viz config", () => {
+    const scatterplotDef = getDeckVizLayerDef("scatterplot")!;
     const layer = createDeckVizStoreLayer({
       name: "Test",
       config: {
         layerKind: "scatterplot",
         format: "json-array",
         fieldMapping: { lng: 0, lat: 1 },
-        style: getDeckVizLayerDef("scatterplot")!.example.style
-          ? { ...defaultStyle(), ...getDeckVizLayerDef("scatterplot")!.example.style }
-          : defaultStyle(),
+        style: { ...DEFAULT_DECK_VIZ_STYLE, ...(scatterplotDef.example.style ?? {}) },
       },
       rows: [[-1, 2]],
       sourcePath: "memory://test",
@@ -256,7 +256,7 @@ describe("deck-viz registry & store layer", () => {
         format: "json-array",
         // lat is required but absent (e.g. a hand-edited project file)
         fieldMapping: { lng: 0 },
-        style: defaultStyle(),
+        style: DEFAULT_DECK_VIZ_STYLE,
       },
       rows: [],
     });
@@ -273,15 +273,13 @@ describe("detectAndParseDeckVizInput tuple width", () => {
       [0, 1, 2],
     );
   });
-});
 
-function defaultStyle() {
-  return {
-    color: "#3b82f6",
-    radius: 40,
-    cellSize: 1000,
-    lineWidth: 2,
-    extruded: false,
-    elevationScale: 30,
-  };
-}
+  it("sniffs a tab delimiter for TSV content", () => {
+    const parsed = detectAndParseDeckVizInput("lng\tlat\n-1\t2\n");
+    assert.equal(parsed.format, "csv-rows");
+    assert.deepEqual(
+      parsed.columns.map((column) => column.value),
+      ["lng", "lat"],
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add a "Deck.gl Layer" entry to the Add Data menu that turns a CSV, JSON, or GeoJSON file or URL into a deck.gl visualization. Users pick a layer type first, then either load bundled example data (one click, zero config) or upload a file / paste a URL and map fields in a guided form.
- Ships 13 layer types across four categories: Scatterplot, Heatmap, Hexagon, Grid, Screen-grid, Contour, Arc, Line, Great-circle, GeoJSON (3D extrusion), Icon, Text, and animated Trips.
- Layers render on a single shared deck.gl overlay (MapboxOverlay) driven by the store, appear in the layer panel like any other layer (toggle, opacity, remove), and persist in the project file with their config and inline data so they re-render on reload.

## Details
- New built-in plugin `maplibre-deckgl-viz` with a layer-type registry, an overlay manager modeled on the existing raster overlay sync, and a `restoreDeckViz` startup hook wired into the desktop shell.
- New `deckgl-viz` layer type in the core domain model; parsing helpers detect CSV vs JSON-array-of-tuples vs JSON-objects vs GeoJSON and auto-map columns to layer roles.
- Adds `@deck.gl/aggregation-layers` pinned to 9.3.3 to match the existing deck.gl core and luma.gl versions.

## Test plan
- [x] `npm run build` passes
- [x] `npm run test:frontend` passes (adds tests/deck-viz.test.ts)
- [x] Verified in a browser: Scatterplot, GeoJSON 3D, Arc, Line, Great-circle, Icon, Text, and animated Trips render, fit to data, toggle, and remove
- [ ] Verify the aggregation layers (Heatmap, Hexagon, Grid, Screen-grid, Contour) render on a hardware GPU; they build correctly but do not render under the headless software WebGL renderer used in CI
- [ ] Save a project with deck.gl layers and reload to confirm they re-render from inline data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deck.gl visualizations: new "Deck.gl Layer" in Add Data with picker for layer type, example-or-upload data, per-role field mapping, style controls, and auto-fit-to-data. Layers persist with projects and re-attach on load so visualizations restore correctly.

* **Tests**
  * Added unit tests for input parsing, field mapping, bounds, registry, and layer persistence/validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->