### PR TITLE
fix(jupyter): serve embedded app via Jupyter Server extension on managed JupyterHub (#247)

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -26,8 +26,8 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        # Cover the declared minimum (requires-python >= 3.10) and a current
-        # release so 3.11/3.12-only syntax can't slip in unnoticed.
+        # Cover the declared minimum (requires-python >= 3.11) and current
+        # releases so newer-only syntax can't slip in unnoticed.
         python-version: ["3.11", "3.12", "3.13"]
     steps:
       - name: Checkout repository

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         # Cover the declared minimum (requires-python >= 3.10) and a current
         # release so 3.11/3.12-only syntax can't slip in unnoticed.
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -281,10 +281,10 @@ Map().load_project("my-map.geolibre.json")
 The package source lives in [`python/`](python/), and the bundled web app is
 built into the wheel by `npm run build:embed`. The interactive widget works in
 local Jupyter, VS Code, Google Colab (its built-in port proxy is used
-automatically), and JupyterHub / remote servers (through `jupyter-server-proxy`;
-install with `pip install "geolibre[hub]"`, and pass `Map(server_proxy=True)` on
-non-Hub remote setups). See the [Python package guide](docs/python.md) for the
-full API.
+automatically), and JupyterHub / remote servers (through a Jupyter Server
+extension bundled with the wheel and auto-enabled on install, so managed hubs
+work without `jupyter-server-proxy`; pass `Map(server_proxy=True)` on non-Hub
+remote setups). See the [Python package guide](docs/python.md) for the full API.
 
 ## Environment variables
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -32,8 +32,8 @@ Optional extras for `add_geojson()` from a GeoDataFrame:
 pip install "geolibre[all]"   # adds GeoPandas and Shapely
 ```
 
-The optional extras (`[all]`, `[hub]`) are pip-only. If you installed via conda,
-add them with `pip install "geolibre[all]"` inside the same environment.
+The optional `[all]` extra is pip-only. If you installed via conda, add it with
+`pip install "geolibre[all]"` inside the same environment.
 
 ## Quickstart
 
@@ -127,15 +127,21 @@ UI edits flow back the same way.
     - **Local Jupyter / VS Code** - the app is served directly from localhost.
     - **Google Colab** - routes through Colab's built-in port proxy
       (`google.colab.kernel.proxyPort`) automatically.
-    - **JupyterHub** - routes through
-      [`jupyter-server-proxy`](https://jupyter-server-proxy.readthedocs.io)
-      automatically (detected via `JUPYTERHUB_SERVICE_PREFIX`). Install it in the
-      single-user image with `pip install "geolibre[hub]"` (or
-      `pip install jupyter-server-proxy`).
+    - **JupyterHub** (including managed/shared hubs) - the app is served by a
+      Jupyter Server extension bundled with `geolibre`, mounted at
+      `{base_url}geolibre/app/` on the notebook server's own origin. It is
+      enabled automatically on `pip install geolibre` (detected at runtime via
+      `JUPYTERHUB_SERVICE_PREFIX`) and needs no `jupyter-server-proxy` and no
+      extra port, so it works on locked-down hubs that block raw-port proxying.
     - **Other remote servers** (Binder, remote JupyterLab over SSH/network) -
-      pass `Map(server_proxy=True)`, which also requires `jupyter-server-proxy`.
+      pass `Map(server_proxy=True)` to use that same bundled server-extension
+      route.
 
-    Set `Map(server_proxy=False)` to force the direct localhost path.
+    Set `Map(server_proxy=False)` to force the direct localhost path. If the app
+    fails to load on a hub, confirm the extension is active with
+    `jupyter server extension list` (look for `geolibre`); restart the Jupyter
+    server after installing `geolibre`, or run
+    `jupyter server extension enable geolibre`.
 
 !!! warning "URL fetching"
 

--- a/python/README.md
+++ b/python/README.md
@@ -81,9 +81,11 @@ m.to_project()["mapView"]["center"]
   through its built-in port proxy automatically. **JupyterHub** (including
   managed/shared hubs) is served by a Jupyter Server extension bundled with
   `geolibre` at `{base_url}geolibre/app/`, enabled automatically on
-  `pip install geolibre` with no `jupyter-server-proxy` and no extra port. On
-  other remote servers (Binder, remote JupyterLab), pass `Map(server_proxy=True)`
-  to use that same route; `Map(server_proxy=False)` forces the direct path.
+  `pip install geolibre` with no `jupyter-server-proxy` and no extra port.
+  Because the extension is loaded at server startup, restart an already-running
+  Jupyter server after installing `geolibre` for it to take effect. On other
+  remote servers (Binder, remote JupyterLab), pass `Map(server_proxy=True)` to
+  use that same route; `Map(server_proxy=False)` forces the direct path.
 - Optional extras: `pip install geolibre[all]` adds GeoPandas/Shapely support
   for `add_geojson(geodataframe)`.
 - `add_geojson` inlines file/URL data into the project (up to 50 MB), so a large

--- a/python/README.md
+++ b/python/README.md
@@ -78,11 +78,12 @@ m.to_project()["mapView"]["center"]
 
 - The bundled app is served from a localhost HTTP server, so the interactive
   widget works in local Jupyter and VS Code directly. **Google Colab** routes
-  through its built-in port proxy automatically. **JupyterHub** routes through
-  [`jupyter-server-proxy`](https://jupyter-server-proxy.readthedocs.io)
-  automatically (install it with `pip install "geolibre[hub]"`). On other remote
-  servers (Binder, remote JupyterLab), pass `Map(server_proxy=True)` (also needs
-  `jupyter-server-proxy`); `Map(server_proxy=False)` forces the direct path.
+  through its built-in port proxy automatically. **JupyterHub** (including
+  managed/shared hubs) is served by a Jupyter Server extension bundled with
+  `geolibre` at `{base_url}geolibre/app/`, enabled automatically on
+  `pip install geolibre` with no `jupyter-server-proxy` and no extra port. On
+  other remote servers (Binder, remote JupyterLab), pass `Map(server_proxy=True)`
+  to use that same route; `Map(server_proxy=False)` forces the direct path.
 - Optional extras: `pip install geolibre[all]` adds GeoPandas/Shapely support
   for `add_geojson(geodataframe)`.
 - `add_geojson` inlines file/URL data into the project (up to 50 MB), so a large

--- a/python/jupyter-config/jupyter_server_config.d/geolibre.json
+++ b/python/jupyter-config/jupyter_server_config.d/geolibre.json
@@ -1,0 +1,7 @@
+{
+  "ServerApp": {
+    "jpserver_extensions": {
+      "geolibre": true
+    }
+  }
+}

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -23,8 +23,7 @@ dependencies = ["anywidget>=0.9", "traitlets>=5"]
 
 [project.optional-dependencies]
 all = ["geopandas", "shapely"]
-hub = ["jupyter-server-proxy"]
-dev = ["pytest", "build", "anywidget[dev]"]
+dev = ["pytest", "build", "anywidget[dev]", "jupyter-server"]
 
 [project.urls]
 Homepage = "https://geolibre.app"
@@ -38,6 +37,12 @@ packages = ["src/geolibre"]
 # The bundled app under static/ is produced by the build hook and git-ignored,
 # so it must be re-included explicitly here (VCS file discovery skips it).
 artifacts = ["src/geolibre/static/**"]
+
+# Install the Jupyter Server config drop-in to {sys.prefix}/etc/jupyter so the
+# bundled app-serving extension (geolibre._load_jupyter_server_extension)
+# auto-enables on `pip install geolibre`, including on managed JupyterHubs.
+[tool.hatch.build.targets.wheel.shared-data]
+"jupyter-config/jupyter_server_config.d/geolibre.json" = "etc/jupyter/jupyter_server_config.d/geolibre.json"
 
 [tool.hatch.build.targets.sdist]
 artifacts = ["src/geolibre/static/**"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -7,7 +7,7 @@ name = "geolibre"
 dynamic = ["version"]
 description = "GeoLibre in Jupyter: the full GeoLibre GIS app as an anywidget, with a leafmap-style Python API."
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = "MIT"
 authors = [{ name = "Qiusheng Wu", email = "giswqs@gmail.com" }]
 keywords = ["geolibre", "gis", "maplibre", "jupyter", "anywidget", "mapping"]

--- a/python/src/geolibre/__init__.py
+++ b/python/src/geolibre/__init__.py
@@ -1,6 +1,20 @@
 """GeoLibre for Jupyter: the full GeoLibre GIS app as an anywidget."""
 
+from typing import Any
+
 from .geolibre import Map
 
 __version__ = "1.1.0"
 __all__ = ["Map", "__version__"]
+
+
+def _jupyter_server_extension_points() -> list[dict[str, str]]:
+    """Declare the Jupyter Server extension that serves the bundled app."""
+    return [{"module": "geolibre"}]
+
+
+def _load_jupyter_server_extension(serverapp: Any) -> None:
+    """Entry point called by Jupyter Server when the extension loads."""
+    from ._extension import load_jupyter_server_extension
+
+    load_jupyter_server_extension(serverapp)

--- a/python/src/geolibre/__init__.py
+++ b/python/src/geolibre/__init__.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from .geolibre import Map
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 __all__ = ["Map", "__version__"]
 
 

--- a/python/src/geolibre/_extension.py
+++ b/python/src/geolibre/_extension.py
@@ -19,6 +19,11 @@ The extension auto-enables on install via the
 wheel; the package-level ``_jupyter_server_extension_points`` /
 ``_load_jupyter_server_extension`` hooks (in ``geolibre/__init__.py``) delegate
 to :func:`load_jupyter_server_extension` below.
+
+Note: tornado is imported lazily inside :func:`load_jupyter_server_extension`
+(not at module load) so this module can be imported -- and the package tested --
+without tornado installed. tornado is always present wherever a Jupyter Server
+actually runs the extension.
 """
 
 from __future__ import annotations
@@ -26,24 +31,12 @@ from __future__ import annotations
 import pathlib
 from typing import Any
 
-from tornado.web import StaticFileHandler
-
 # Mount point under the Jupyter Server base URL. Kept in sync with the front-end
 # (_frontend.js), which loads "{base_url}geolibre/app/index.html".
 APP_ROUTE = "geolibre/app"
 
 _HERE = pathlib.Path(__file__).parent
 _STATIC_APP = _HERE / "static" / "app"
-
-
-class _AppStaticHandler(StaticFileHandler):
-    """Serve the bundled app, defaulting a bare directory request to index.html.
-
-    A plain tornado ``StaticFileHandler`` (not a ``JupyterHandler``) is used on
-    purpose: the static app bundle carries no user data, so it is served like any
-    other static asset, and this also keeps Jupyter Server from flagging it as an
-    unauthenticated handler.
-    """
 
 
 def load_jupyter_server_extension(serverapp: Any) -> None:
@@ -54,10 +47,30 @@ def load_jupyter_server_extension(serverapp: Any) -> None:
             Jupyter Server when it loads the extension.
     """
     from jupyter_server.utils import url_path_join
+    from tornado.web import StaticFileHandler
+
+    class _AppStaticHandler(StaticFileHandler):
+        """Serve the bundled app's static files.
+
+        A plain tornado ``StaticFileHandler`` (not a ``JupyterHandler``) is used
+        on purpose: the static app bundle carries no user data, so it is served
+        like any other static asset, and this also keeps Jupyter Server from
+        flagging it as an unauthenticated handler. Bare-directory requests fall
+        back to ``index.html`` via the ``default_filename`` kwarg passed below.
+        """
 
     web_app = serverapp.web_app
     base_url = web_app.settings["base_url"]
     route = url_path_join(base_url, APP_ROUTE, "(.*)")
+    if not _STATIC_APP.is_dir():
+        # A wheel built/installed without running the JS build (e.g. a dev
+        # checkout) would otherwise 404 on every request with no explanation.
+        serverapp.log.warning(
+            "[geolibre] Bundled app not found at %s; the %s/ route will return "
+            "404. Reinstall the geolibre wheel or run `npm run build:embed`.",
+            _STATIC_APP,
+            APP_ROUTE,
+        )
     web_app.add_handlers(
         ".*$",
         [

--- a/python/src/geolibre/_extension.py
+++ b/python/src/geolibre/_extension.py
@@ -64,15 +64,7 @@ def load_jupyter_server_extension(serverapp: Any) -> None:
     web_app = serverapp.web_app
     base_url = web_app.settings["base_url"]
     route = url_path_join(base_url, APP_ROUTE, "(.*)")
-    if not _STATIC_APP.is_dir():
-        # A wheel built/installed without running the JS build (e.g. a dev
-        # checkout) would otherwise 404 on every request with no explanation.
-        serverapp.log.warning(
-            "[geolibre] Bundled app not found at %s; the %s/ route will return "
-            "404. Reinstall the geolibre wheel or run `npm run build:embed`.",
-            _STATIC_APP,
-            APP_ROUTE,
-        )
+    bundle_present = _STATIC_APP.is_dir()
     web_app.add_handlers(
         ".*$",
         [
@@ -83,6 +75,17 @@ def load_jupyter_server_extension(serverapp: Any) -> None:
             )
         ],
     )
-    serverapp.log.info(
-        "[geolibre] Serving the bundled app at %s%s/", base_url, APP_ROUTE
-    )
+    if bundle_present:
+        serverapp.log.info(
+            "[geolibre] Serving the bundled app at %s%s/", base_url, APP_ROUTE
+        )
+    else:
+        # A wheel built/installed without running the JS build (e.g. a dev
+        # checkout) would otherwise 404 on every request with no explanation.
+        # Emit only this warning (not the "Serving …" line) so the log is clear.
+        serverapp.log.warning(
+            "[geolibre] Bundled app not found at %s; the %s/ route will return "
+            "404. Reinstall the geolibre wheel or run `npm run build:embed`.",
+            _STATIC_APP,
+            APP_ROUTE,
+        )

--- a/python/src/geolibre/_extension.py
+++ b/python/src/geolibre/_extension.py
@@ -1,0 +1,73 @@
+"""A Jupyter Server extension that serves the bundled GeoLibre web app.
+
+The widget renders the full GeoLibre single-page app inside an ``<iframe>``. On
+remote deployments (JupyterHub and managed/shared hubs) the browser cannot reach
+the kernel's ``localhost``, and raw-port proxying via ``jupyter-server-proxy`` is
+frequently unavailable or disabled. This extension sidesteps both problems by
+serving the bundled app from the Jupyter Server's own origin at
+``{base_url}geolibre/app/`` -- the same authenticated origin that serves the
+notebook, so it is reachable wherever the notebook itself is.
+
+The files served here are only the static app bundle (the same public app
+published at geolibre.app); no notebook or project data passes through this
+route. Project state is exchanged separately over ``window.postMessage`` between
+the kernel and the iframe. The bundle is therefore served without per-request
+authentication, matching how Jupyter serves its own static assets.
+
+The extension auto-enables on install via the
+``etc/jupyter/jupyter_server_config.d/geolibre.json`` drop-in shipped in the
+wheel; the package-level ``_jupyter_server_extension_points`` /
+``_load_jupyter_server_extension`` hooks (in ``geolibre/__init__.py``) delegate
+to :func:`load_jupyter_server_extension` below.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from typing import Any
+
+from tornado.web import StaticFileHandler
+
+# Mount point under the Jupyter Server base URL. Kept in sync with the front-end
+# (_frontend.js), which loads "{base_url}geolibre/app/index.html".
+APP_ROUTE = "geolibre/app"
+
+_HERE = pathlib.Path(__file__).parent
+_STATIC_APP = _HERE / "static" / "app"
+
+
+class _AppStaticHandler(StaticFileHandler):
+    """Serve the bundled app, defaulting a bare directory request to index.html.
+
+    A plain tornado ``StaticFileHandler`` (not a ``JupyterHandler``) is used on
+    purpose: the static app bundle carries no user data, so it is served like any
+    other static asset, and this also keeps Jupyter Server from flagging it as an
+    unauthenticated handler.
+    """
+
+
+def load_jupyter_server_extension(serverapp: Any) -> None:
+    """Register the static-app route on a running Jupyter Server.
+
+    Args:
+        serverapp: The ``jupyter_server.serverapp.ServerApp`` instance passed by
+            Jupyter Server when it loads the extension.
+    """
+    from jupyter_server.utils import url_path_join
+
+    web_app = serverapp.web_app
+    base_url = web_app.settings["base_url"]
+    route = url_path_join(base_url, APP_ROUTE, "(.*)")
+    web_app.add_handlers(
+        ".*$",
+        [
+            (
+                route,
+                _AppStaticHandler,
+                {"path": str(_STATIC_APP), "default_filename": "index.html"},
+            )
+        ],
+    )
+    serverapp.log.info(
+        "[geolibre] Serving the bundled app at %s%s/", base_url, APP_ROUTE
+    )

--- a/python/src/geolibre/_extension.py
+++ b/python/src/geolibre/_extension.py
@@ -53,10 +53,12 @@ def load_jupyter_server_extension(serverapp: Any) -> None:
         """Serve the bundled app's static files.
 
         A plain tornado ``StaticFileHandler`` (not a ``JupyterHandler``) is used
-        on purpose: the static app bundle carries no user data, so it is served
-        like any other static asset, and this also keeps Jupyter Server from
-        flagging it as an unauthenticated handler. Bare-directory requests fall
-        back to ``index.html`` via the ``default_filename`` kwarg passed below.
+        on purpose: the bundle is the same public app published at geolibre.app
+        and carries no user/project data (project state flows separately over
+        ``window.postMessage``), so it is served unauthenticated like any other
+        static asset, outside Jupyter Server's per-request auth pipeline. Bare-
+        directory requests fall back to ``index.html`` via the
+        ``default_filename`` kwarg passed below.
         """
 
     web_app = serverapp.web_app

--- a/python/src/geolibre/_frontend.js
+++ b/python/src/geolibre/_frontend.js
@@ -62,9 +62,10 @@ async function resolveBase(model) {
 async function appReachable(base) {
   // render() awaits this before the iframe exists, so a stalled request (slow
   // proxy / auth layer) would otherwise hang widget rendering indefinitely.
-  // Abort after a short deadline and treat that as unreachable.
+  // Abort after a generous deadline (cold/loaded hubs can be slow) and treat
+  // that as unreachable; the caller shows a placeholder while this runs.
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 5000);
+  const timer = setTimeout(() => controller.abort(), 15000);
   try {
     const res = await fetch(`${base}index.html`, {
       method: "HEAD",
@@ -96,13 +97,19 @@ async function render({ model, el }) {
     return;
   }
 
-  if (model.get("_remote_mode") === "extension" && !(await appReachable(base))) {
-    el.textContent =
-      "GeoLibre: the bundled app could not be loaded from the Jupyter server. " +
-      "Make sure the geolibre server extension is enabled (restart your Jupyter " +
-      "server after installing geolibre, or run " +
-      "`jupyter server extension enable geolibre`), then re-run this cell.";
-    return;
+  if (model.get("_remote_mode") === "extension") {
+    // Probe the route first so a missing/disabled extension surfaces an
+    // actionable message instead of a bare 404 in the iframe. Show a
+    // placeholder while the probe runs so the cell is not blank on a slow hub.
+    el.textContent = "GeoLibre: connecting to the server extension…";
+    if (!(await appReachable(base))) {
+      el.textContent =
+        "GeoLibre: the bundled app could not be loaded from the Jupyter server. " +
+        "Make sure the geolibre server extension is enabled (restart your Jupyter " +
+        "server after installing geolibre, or run " +
+        "`jupyter server extension enable geolibre`), then re-run this cell.";
+      return;
+    }
   }
 
   const layout = model.get("layout") || "embed";
@@ -113,7 +120,8 @@ async function render({ model, el }) {
     params.set("layout", "embed");
   }
   iframe.src = `${base}index.html?${params.toString()}`;
-  el.appendChild(iframe);
+  // replaceChildren clears any placeholder text set above before mounting.
+  el.replaceChildren(iframe);
 
   let ready = false;
   // The last project object received from the app. onProjectChange compares the

--- a/python/src/geolibre/_frontend.js
+++ b/python/src/geolibre/_frontend.js
@@ -60,15 +60,23 @@ async function resolveBase(model) {
 // missing/disabled server extension surfaces an actionable message instead of a
 // bare 404 page inside the iframe.
 async function appReachable(base) {
+  // render() awaits this before the iframe exists, so a stalled request (slow
+  // proxy / auth layer) would otherwise hang widget rendering indefinitely.
+  // Abort after a short deadline and treat that as unreachable.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5000);
   try {
     const res = await fetch(`${base}index.html`, {
       method: "HEAD",
       credentials: "same-origin",
+      signal: controller.signal,
     });
     return res.ok;
   } catch (error) {
     console.warn("[GeoLibre] App reachability check failed", error);
     return false;
+  } finally {
+    clearTimeout(timer);
   }
 }
 
@@ -93,7 +101,7 @@ async function render({ model, el }) {
       "GeoLibre: the bundled app could not be loaded from the Jupyter server. " +
       "Make sure the geolibre server extension is enabled (restart your Jupyter " +
       "server after installing geolibre, or run " +
-      "`jupyter server extension enable geolibre`).";
+      "`jupyter server extension enable geolibre`), then re-run this cell.";
     return;
   }
 

--- a/python/src/geolibre/_frontend.js
+++ b/python/src/geolibre/_frontend.js
@@ -10,7 +10,7 @@
 // (`lastRemoteProject`) and only pushes Python-initiated changes.
 
 // The Jupyter server's base URL, read from the page config that JupyterLab and
-// Notebook 7 inject. Used to build a jupyter-server-proxy URL. Defaults to "/".
+// Notebook 7 inject. Used to build the server-extension app URL. Defaults to "/".
 function jupyterBaseUrl() {
   try {
     const el = document.getElementById("jupyter-config-data");
@@ -24,10 +24,17 @@ function jupyterBaseUrl() {
   return "/";
 }
 
-// Resolve the base URL of the app server. The kernel serves it on localhost,
-// which the browser reaches directly in local Jupyter / VS Code. On hosts where
-// the browser cannot reach the kernel's localhost, route through a proxy:
-// Google Colab's port proxy, or jupyter-server-proxy (JupyterHub / remote).
+// Base URL of the app served by the GeoLibre Jupyter Server extension
+// (_extension.py), which mounts the bundle at {base_url}geolibre/app/.
+function extensionBase() {
+  return new URL(`${jupyterBaseUrl()}geolibre/app/`, window.location.href).href;
+}
+
+// Resolve the base URL of the app. The kernel serves it on localhost, which the
+// browser reaches directly in local Jupyter / VS Code. On hosts where the
+// browser cannot reach the kernel's localhost, the app comes from elsewhere:
+// Google Colab's port proxy, or the GeoLibre Jupyter Server extension
+// (JupyterHub / remote servers), which serves it from the notebook's own origin.
 async function resolveBase(model) {
   const port = model.get("_app_port");
   const colab =
@@ -43,12 +50,26 @@ async function resolveBase(model) {
       console.warn("[GeoLibre] Colab proxyPort failed; using direct URL", error);
     }
   }
-  if (port && model.get("_use_server_proxy")) {
-    // jupyter-server-proxy serves kernel-side ports at {base_url}proxy/{port}/.
-    return new URL(`${jupyterBaseUrl()}proxy/${port}/`, window.location.href)
-      .href;
+  if (model.get("_remote_mode") === "extension") {
+    return extensionBase();
   }
   return model.get("_app_url");
+}
+
+// Verify the bundle is actually reachable before pointing the iframe at it, so a
+// missing/disabled server extension surfaces an actionable message instead of a
+// bare 404 page inside the iframe.
+async function appReachable(base) {
+  try {
+    const res = await fetch(`${base}index.html`, {
+      method: "HEAD",
+      credentials: "same-origin",
+    });
+    return res.ok;
+  } catch (error) {
+    console.warn("[GeoLibre] App reachability check failed", error);
+    return false;
+  }
 }
 
 async function render({ model, el }) {
@@ -64,6 +85,15 @@ async function render({ model, el }) {
   if (!base) {
     el.textContent =
       "GeoLibre: the local app server is not running. Re-create the Map().";
+    return;
+  }
+
+  if (model.get("_remote_mode") === "extension" && !(await appReachable(base))) {
+    el.textContent =
+      "GeoLibre: the bundled app could not be loaded from the Jupyter server. " +
+      "Make sure the geolibre server extension is enabled (restart your Jupyter " +
+      "server after installing geolibre, or run " +
+      "`jupyter server extension enable geolibre`).";
     return;
   }
 

--- a/python/src/geolibre/_frontend.js
+++ b/python/src/geolibre/_frontend.js
@@ -59,7 +59,15 @@ async function resolveBase(model) {
 // Verify the bundle is actually reachable before pointing the iframe at it, so a
 // missing/disabled server extension surfaces an actionable message instead of a
 // bare 404 page inside the iframe.
+// Base URLs confirmed reachable this session. render() can run again on every
+// re-display, so caching the (stable) positive result skips a redundant HEAD
+// round-trip each time. Only successes are cached: a negative result is left
+// uncached so re-running the cell after enabling the extension re-probes and
+// recovers, matching the "then re-run this cell" hint shown on failure.
+const _reachable = new Set();
+
 async function appReachable(base) {
+  if (_reachable.has(base)) return true;
   // render() awaits this before the iframe exists, so a stalled request (slow
   // proxy / auth layer) would otherwise hang widget rendering indefinitely.
   // Abort after a generous deadline (cold/loaded hubs can be slow) and treat
@@ -72,6 +80,7 @@ async function appReachable(base) {
       credentials: "same-origin",
       signal: controller.signal,
     });
+    if (res.ok) _reachable.add(base);
     return res.ok;
   } catch (error) {
     console.warn("[GeoLibre] App reachability check failed", error);

--- a/python/src/geolibre/_server.py
+++ b/python/src/geolibre/_server.py
@@ -8,7 +8,9 @@ process-wide singleton: every widget instance shares the one origin.
 
 Note: because it binds to 127.0.0.1, the iframe URL is only reachable when the
 browser runs on the same host as the kernel (local Jupyter, VS Code). Remote
-setups (JupyterHub, Colab) would need a proxy; that is a known limitation.
+setups reach the app a different way: Google Colab routes through its port proxy,
+and JupyterHub / remote servers load the bundle from the Jupyter Server extension
+in ``_extension.py`` instead of this localhost server.
 """
 
 from __future__ import annotations
@@ -51,6 +53,24 @@ class _QuietServer(ThreadingHTTPServer):
         super().handle_error(request, client_address)
 
 
+def ensure_bundle(static_dir: Path) -> None:
+    """Verify the bundled app is present, raising a helpful error if not.
+
+    Args:
+        static_dir: Directory expected to contain the built app
+            (``index.html`` and its assets).
+
+    Raises:
+        FileNotFoundError: If ``index.html`` is missing from ``static_dir``.
+    """
+    if not (static_dir / "index.html").is_file():
+        raise FileNotFoundError(
+            f"The bundled GeoLibre app was not found at {static_dir}. "
+            "Reinstall the geolibre wheel, or run `npm run build:embed` from a "
+            "checkout of the GeoLibre repository."
+        )
+
+
 def serve_app(static_dir: Path) -> str:
     """Start (once) the static server for ``static_dir`` and return its base URL.
 
@@ -67,12 +87,7 @@ def serve_app(static_dir: Path) -> str:
     """
     global _server, _base_url, _port
 
-    if not (static_dir / "index.html").is_file():
-        raise FileNotFoundError(
-            f"The bundled GeoLibre app was not found at {static_dir}. "
-            "Reinstall the geolibre wheel, or run `npm run build:embed` from a "
-            "checkout of the GeoLibre repository."
-        )
+    ensure_bundle(static_dir)
 
     with _lock:
         # _base_url, _server, and _port are always set together, so one check

--- a/python/src/geolibre/_server.py
+++ b/python/src/geolibre/_server.py
@@ -89,9 +89,10 @@ def serve_app(static_dir: Path) -> str:
 
     with _lock:
         # _base_url, _server, and _port are always set together, so one check
-        # covers all three. Validate the bundle only when actually booting the
-        # singleton, so a later call with a different/missing path reuses the
-        # running server instead of raising.
+        # covers all three. Validate the bundle only at first boot; later calls
+        # reuse the running server regardless of `static_dir`, so a subsequently
+        # missing/different path 404s rather than raising (acceptable: the
+        # singleton always serves the same `_STATIC_APP` directory).
         if _base_url is None:
             ensure_bundle(static_dir)
             handler = partial(_QuietHandler, directory=str(static_dir))

--- a/python/src/geolibre/_server.py
+++ b/python/src/geolibre/_server.py
@@ -87,12 +87,13 @@ def serve_app(static_dir: Path) -> str:
     """
     global _server, _base_url, _port
 
-    ensure_bundle(static_dir)
-
     with _lock:
         # _base_url, _server, and _port are always set together, so one check
-        # covers all three.
+        # covers all three. Validate the bundle only when actually booting the
+        # singleton, so a later call with a different/missing path reuses the
+        # running server instead of raising.
         if _base_url is None:
+            ensure_bundle(static_dir)
             handler = partial(_QuietHandler, directory=str(static_dir))
             server = _QuietServer(("127.0.0.1", 0), handler)
             thread = threading.Thread(

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -132,6 +132,15 @@ class Map(anywidget.AnyWidget):
         )
 
     @staticmethod
+    def _running_on_colab() -> bool:
+        """Return True when running inside a Google Colab kernel."""
+        try:
+            import google.colab  # noqa: F401
+        except ImportError:
+            return False
+        return True
+
+    @staticmethod
     def _resolve_remote_mode(server_proxy: bool | str) -> str:
         """Decide how the front-end reaches the bundled app.
 
@@ -147,10 +156,18 @@ class Map(anywidget.AnyWidget):
             extension, or ``""`` for the direct localhost path.
         """
         if isinstance(server_proxy, bool):
-            return "extension" if server_proxy else ""
-        if server_proxy == "auto":
-            return "extension" if os.environ.get("JUPYTERHUB_SERVICE_PREFIX") else ""
-        raise ValueError("server_proxy must be True, False, or 'auto'")
+            mode = "extension" if server_proxy else ""
+        elif server_proxy == "auto":
+            mode = "extension" if os.environ.get("JUPYTERHUB_SERVICE_PREFIX") else ""
+        else:
+            raise ValueError("server_proxy must be True, False, or 'auto'")
+        # Google Colab reaches the app through its own port proxy (resolved in
+        # the front-end), which needs the localhost server running and a
+        # populated _app_port. Never route Colab through the server extension,
+        # even when server_proxy=True is passed explicitly.
+        if mode == "extension" and Map._running_on_colab():
+            return ""
+        return mode
 
     # -- internal --------------------------------------------------------
 

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -12,7 +12,7 @@ import anywidget
 import traitlets
 
 from . import project as _project
-from ._server import app_port, serve_app
+from ._server import app_port, ensure_bundle, serve_app
 from .basemaps import resolve_basemap
 
 _HERE = pathlib.Path(__file__).parent
@@ -50,11 +50,13 @@ class Map(anywidget.AnyWidget):
     # google.colab.kernel.proxyPort) when localhost is not reachable from the
     # browser, as on Google Colab.
     _app_port = traitlets.Int(0).tag(sync=True)
-    # When set, the front-end loads the app through jupyter-server-proxy at
-    # `{base_url}proxy/{port}/` instead of localhost, so it works on remote
-    # servers (JupyterHub, Binder, remote JupyterLab) where the browser cannot
-    # reach the kernel's localhost.
-    _use_server_proxy = traitlets.Bool(False).tag(sync=True)
+    # How the front-end reaches the app on a remote server. "" means the direct
+    # localhost path (local Jupyter, VS Code). "extension" means the bundled
+    # Jupyter Server extension at `{base_url}geolibre/app/`, which serves the app
+    # from the notebook server's own origin so it works on JupyterHub and other
+    # remote servers where the browser cannot reach the kernel's localhost.
+    # Google Colab is detected in the front-end and uses its own port proxy.
+    _remote_mode = traitlets.Unicode("").tag(sync=True)
     height = traitlets.Unicode("800px").tag(sync=True)
     # "embed" (compact chrome), "full" (desktop chrome), or "maponly".
     layout = traitlets.Unicode("embed").tag(sync=True)
@@ -86,13 +88,18 @@ class Map(anywidget.AnyWidget):
             layout: ``"embed"`` (compact UI), ``"full"`` (full desktop UI), or
                 ``"maponly"`` (map without chrome).
             theme: ``"light"`` or ``"dark"``.
-            server_proxy: How to reach the app server from the browser.
-                ``"auto"`` (default) serves the app directly from localhost, and
-                switches to ``jupyter-server-proxy`` automatically when running
-                under JupyterHub. Pass ``True`` to force the proxy on any remote
-                server (requires ``jupyter-server-proxy``), or ``False`` to force
-                the direct localhost path. Google Colab is detected separately
-                and always uses its own port proxy.
+            server_proxy: How the browser reaches the bundled app.
+                ``"auto"`` (default) serves the app directly from localhost for
+                local Jupyter and VS Code, and switches automatically to the
+                bundled GeoLibre Jupyter Server extension when running under
+                JupyterHub (detected via ``JUPYTERHUB_SERVICE_PREFIX``). That
+                extension serves the app from the notebook server's own origin at
+                ``{base_url}geolibre/app/``, so it works on managed hubs without
+                ``jupyter-server-proxy``. Pass ``True`` to force the
+                server-extension route on any other remote server (Binder, remote
+                JupyterLab), or ``False`` to force the direct localhost path.
+                Google Colab is detected separately and always uses its own port
+                proxy.
             **kwargs: Forwarded to ``anywidget.AnyWidget``.
         """
         if layout not in _VALID_LAYOUTS:
@@ -107,9 +114,17 @@ class Map(anywidget.AnyWidget):
         self.height = height
         self.layout = layout
         self.theme = theme
-        self._app_url = serve_app(_STATIC_APP)
-        self._app_port = app_port() or 0
-        self._use_server_proxy = self._resolve_server_proxy(server_proxy)
+        self._remote_mode = self._resolve_remote_mode(server_proxy)
+        if self._remote_mode == "extension":
+            # The Jupyter Server extension serves the bundled app over the
+            # notebook's own origin, so no kernel-side localhost server is
+            # needed (and binding an extra port on a shared hub is avoided).
+            ensure_bundle(_STATIC_APP)
+            self._app_url = ""
+            self._app_port = 0
+        else:
+            self._app_url = serve_app(_STATIC_APP)
+            self._app_port = app_port() or 0
         self.project = _project.build_empty_project(
             center=center,
             zoom=zoom,
@@ -117,21 +132,24 @@ class Map(anywidget.AnyWidget):
         )
 
     @staticmethod
-    def _resolve_server_proxy(server_proxy: bool | str) -> bool:
-        """Decide whether to load the app through jupyter-server-proxy.
+    def _resolve_remote_mode(server_proxy: bool | str) -> str:
+        """Decide how the front-end reaches the bundled app.
 
         Args:
-            server_proxy: ``True``/``False`` to force, or ``"auto"`` to enable
-                the proxy only when a JupyterHub single-user server is detected
-                (via the ``JUPYTERHUB_SERVICE_PREFIX`` environment variable).
+            server_proxy: ``True`` to force the server-extension route on any
+                remote server, ``False`` to force the direct localhost path, or
+                ``"auto"`` to use the extension only when a JupyterHub single-user
+                server is detected (via the ``JUPYTERHUB_SERVICE_PREFIX``
+                environment variable).
 
         Returns:
-            True to route through the server proxy, False for direct localhost.
+            ``"extension"`` to load the app through the bundled Jupyter Server
+            extension, or ``""`` for the direct localhost path.
         """
         if isinstance(server_proxy, bool):
-            return server_proxy
+            return "extension" if server_proxy else ""
         if server_proxy == "auto":
-            return bool(os.environ.get("JUPYTERHUB_SERVICE_PREFIX"))
+            return "extension" if os.environ.get("JUPYTERHUB_SERVICE_PREFIX") else ""
         raise ValueError("server_proxy must be True, False, or 'auto'")
 
     # -- internal --------------------------------------------------------

--- a/python/tests/test_extension.py
+++ b/python/tests/test_extension.py
@@ -1,0 +1,61 @@
+"""Tests for the GeoLibre Jupyter Server extension that serves the bundled app."""
+
+from __future__ import annotations
+
+import json
+import logging
+import pathlib
+from types import SimpleNamespace
+
+import pytest
+from tornado.testing import AsyncHTTPTestCase
+from tornado.web import Application
+
+import geolibre
+from geolibre import _extension
+
+_HAS_BUNDLE = (_extension._STATIC_APP / "index.html").is_file()
+_needs_bundle = pytest.mark.skipif(
+    not _HAS_BUNDLE,
+    reason="bundled app not built (run `npm run build:embed`)",
+)
+
+
+def test_extension_points():
+    assert geolibre._jupyter_server_extension_points() == [{"module": "geolibre"}]
+
+
+def test_config_drop_in_enables_extension():
+    config = (
+        pathlib.Path(__file__).resolve().parents[1]
+        / "jupyter-config"
+        / "jupyter_server_config.d"
+        / "geolibre.json"
+    )
+    data = json.loads(config.read_text(encoding="utf-8"))
+    assert data["ServerApp"]["jpserver_extensions"]["geolibre"] is True
+
+
+@_needs_bundle
+class ExtensionRouteTest(AsyncHTTPTestCase):
+    def get_app(self):
+        app = Application(base_url="/")
+        serverapp = SimpleNamespace(
+            web_app=app, log=logging.getLogger("geolibre-test")
+        )
+        _extension.load_jupyter_server_extension(serverapp)
+        return app
+
+    def test_serves_index_html(self):
+        resp = self.fetch("/geolibre/app/index.html")
+        assert resp.code == 200
+        assert b"<!doctype html" in resp.body[:64].lower()
+
+    def test_directory_defaults_to_index(self):
+        resp = self.fetch("/geolibre/app/")
+        assert resp.code == 200
+        assert b"<!doctype html" in resp.body[:64].lower()
+
+    def test_unknown_asset_is_404(self):
+        resp = self.fetch("/geolibre/app/does-not-exist.js")
+        assert resp.code == 404

--- a/python/tests/test_extension.py
+++ b/python/tests/test_extension.py
@@ -1,28 +1,26 @@
-"""Tests for the GeoLibre Jupyter Server extension that serves the bundled app."""
+"""Tornado-free tests for the GeoLibre Jupyter Server extension wiring.
+
+The route-serving tests (which require tornado) live in
+``test_extension_routes.py`` so this module can be collected and run in CI
+environments that install only ``anywidget``/``traitlets``/``pytest``.
+"""
 
 from __future__ import annotations
 
 import json
-import logging
 import pathlib
-from types import SimpleNamespace
-
-import pytest
-from tornado.testing import AsyncHTTPTestCase
-from tornado.web import Application
 
 import geolibre
 from geolibre import _extension
 
-_HAS_BUNDLE = (_extension._STATIC_APP / "index.html").is_file()
-_needs_bundle = pytest.mark.skipif(
-    not _HAS_BUNDLE,
-    reason="bundled app not built (run `npm run build:embed`)",
-)
-
 
 def test_extension_points():
     assert geolibre._jupyter_server_extension_points() == [{"module": "geolibre"}]
+
+
+def test_app_route_matches_frontend():
+    # The front-end (_frontend.js) loads "{base_url}geolibre/app/index.html".
+    assert _extension.APP_ROUTE == "geolibre/app"
 
 
 def test_config_drop_in_enables_extension():
@@ -34,28 +32,3 @@ def test_config_drop_in_enables_extension():
     )
     data = json.loads(config.read_text(encoding="utf-8"))
     assert data["ServerApp"]["jpserver_extensions"]["geolibre"] is True
-
-
-@_needs_bundle
-class ExtensionRouteTest(AsyncHTTPTestCase):
-    def get_app(self):
-        app = Application(base_url="/")
-        serverapp = SimpleNamespace(
-            web_app=app, log=logging.getLogger("geolibre-test")
-        )
-        _extension.load_jupyter_server_extension(serverapp)
-        return app
-
-    def test_serves_index_html(self):
-        resp = self.fetch("/geolibre/app/index.html")
-        assert resp.code == 200
-        assert b"<!doctype html" in resp.body[:64].lower()
-
-    def test_directory_defaults_to_index(self):
-        resp = self.fetch("/geolibre/app/")
-        assert resp.code == 200
-        assert b"<!doctype html" in resp.body[:64].lower()
-
-    def test_unknown_asset_is_404(self):
-        resp = self.fetch("/geolibre/app/does-not-exist.js")
-        assert resp.code == 404

--- a/python/tests/test_extension_routes.py
+++ b/python/tests/test_extension_routes.py
@@ -1,0 +1,72 @@
+"""Route-serving tests for the GeoLibre Jupyter Server extension.
+
+These exercise the bundled app served over a running tornado app, so they need
+both tornado and the built app bundle. tornado is an implicit Jupyter Server
+dependency but is not guaranteed in the minimal CI test environment, so the
+whole module is skipped when it is absent.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("tornado")
+
+from tornado.testing import AsyncHTTPTestCase  # noqa: E402
+from tornado.web import Application  # noqa: E402
+
+from geolibre import _extension  # noqa: E402
+
+pytestmark = pytest.mark.skipif(
+    not (_extension._STATIC_APP / "index.html").is_file(),
+    reason="bundled app not built (run `npm run build:embed`)",
+)
+
+
+def _load_app(base_url: str) -> Application:
+    app = Application(base_url=base_url)
+    serverapp = SimpleNamespace(web_app=app, log=logging.getLogger("geolibre-test"))
+    _extension.load_jupyter_server_extension(serverapp)
+    return app
+
+
+class _RouteCases:
+    """Shared assertions; a mixin (not a TestCase) so it is not collected alone.
+
+    ``PREFIX`` is the Jupyter Server ``base_url``; subclasses pin it to the local
+    ("/") and JupyterHub-style ("/user/alice/") cases.
+    """
+
+    PREFIX = "/"
+
+    def get_app(self):
+        return _load_app(self.PREFIX)
+
+    def test_serves_index_html(self):
+        resp = self.fetch(f"{self.PREFIX}geolibre/app/index.html")
+        assert resp.code == 200
+        assert b"<!doctype html" in resp.body[:64].lower()
+
+    def test_directory_defaults_to_index(self):
+        resp = self.fetch(f"{self.PREFIX}geolibre/app/")
+        assert resp.code == 200
+        assert b"<!doctype html" in resp.body[:64].lower()
+
+    def test_unknown_asset_is_404(self):
+        resp = self.fetch(f"{self.PREFIX}geolibre/app/does-not-exist.js")
+        assert resp.code == 404
+
+
+class TestRootBaseUrlRoute(_RouteCases, AsyncHTTPTestCase):
+    """Default base_url, as on local Jupyter."""
+
+    PREFIX = "/"
+
+
+class TestHubBaseUrlRoute(_RouteCases, AsyncHTTPTestCase):
+    """JupyterHub-style base_url prefix -- the scenario this extension fixes."""
+
+    PREFIX = "/user/alice/"

--- a/python/tests/test_extension_routes.py
+++ b/python/tests/test_extension_routes.py
@@ -50,6 +50,12 @@ class _RouteCases:
         assert resp.code == 200
         assert b"<!doctype html" in resp.body[:64].lower()
 
+    def test_head_probe_reaches_index_html(self):
+        # The front-end gates extension mode on a HEAD probe of index.html; make
+        # sure HEAD is served (a GET-only regression would slip past otherwise).
+        resp = self.fetch(f"{self.PREFIX}geolibre/app/index.html", method="HEAD")
+        assert resp.code == 200
+
     def test_directory_defaults_to_index(self):
         resp = self.fetch(f"{self.PREFIX}geolibre/app/")
         assert resp.code == 200

--- a/python/tests/test_map.py
+++ b/python/tests/test_map.py
@@ -7,21 +7,21 @@ import pytest
 from geolibre.geolibre import Map
 
 
-def test_server_proxy_explicit():
-    assert Map._resolve_server_proxy(True) is True
-    assert Map._resolve_server_proxy(False) is False
+def test_remote_mode_explicit():
+    assert Map._resolve_remote_mode(True) == "extension"
+    assert Map._resolve_remote_mode(False) == ""
 
 
-def test_server_proxy_auto_local(monkeypatch):
+def test_remote_mode_auto_local(monkeypatch):
     monkeypatch.delenv("JUPYTERHUB_SERVICE_PREFIX", raising=False)
-    assert Map._resolve_server_proxy("auto") is False
+    assert Map._resolve_remote_mode("auto") == ""
 
 
-def test_server_proxy_auto_jupyterhub(monkeypatch):
+def test_remote_mode_auto_jupyterhub(monkeypatch):
     monkeypatch.setenv("JUPYTERHUB_SERVICE_PREFIX", "/user/alice/")
-    assert Map._resolve_server_proxy("auto") is True
+    assert Map._resolve_remote_mode("auto") == "extension"
 
 
-def test_server_proxy_invalid():
+def test_remote_mode_invalid():
     with pytest.raises(ValueError):
-        Map._resolve_server_proxy("bogus")
+        Map._resolve_remote_mode("bogus")

--- a/python/tests/test_map.py
+++ b/python/tests/test_map.py
@@ -25,3 +25,15 @@ def test_remote_mode_auto_jupyterhub(monkeypatch):
 def test_remote_mode_invalid():
     with pytest.raises(ValueError):
         Map._resolve_remote_mode("bogus")
+
+
+def test_remote_mode_colab_forces_direct(monkeypatch):
+    # Colab uses its own port proxy (front-end), which needs the localhost
+    # server; an explicit server_proxy=True must not switch it to the extension.
+    monkeypatch.setattr(Map, "_running_on_colab", staticmethod(lambda: True))
+    assert Map._resolve_remote_mode(True) == ""
+
+
+def test_remote_mode_non_colab_uses_extension(monkeypatch):
+    monkeypatch.setattr(Map, "_running_on_colab", staticmethod(lambda: False))
+    assert Map._resolve_remote_mode(True) == "extension"


### PR DESCRIPTION
Fixes #247.

## Problem

On managed JupyterHub (e.g. NSF I-GUIDE), the Jupyter widget rendered a blank iframe with a 404:

```
https://jupyter.i-guide.io/user/iguide-user-12503/proxy/36275/index.html  ->  404
```

The widget reached the kernel's localhost app server through **jupyter-server-proxy's raw-port route** (`{base_url}proxy/{port}/`). On managed/shared hubs that route 404s because jupyter-server-proxy is frequently **not installed**, or raw-port proxying (`/proxy/<port>`) is **disabled for security**. The approach structurally depended on something locked-down hubs don't provide.

## Fix

Stop depending on jupyter-server-proxy. Ship a **Jupyter Server extension** inside the `geolibre` wheel that serves the bundled app from the notebook server's own origin at `{base_url}geolibre/app/`:

- **Auto-enables** on `pip install geolibre` via an `etc/jupyter/jupyter_server_config.d/geolibre.json` drop-in. No extra package, no extra port, no raw-port proxy.
- Works on locked-down managed hubs because it uses the same authenticated origin that already serves the notebook.
- The widget uses this route under JupyterHub automatically (detected via `JUPYTERHUB_SERVICE_PREFIX`) or when `Map(server_proxy=True)` is passed; the **localhost path (local Jupyter / VS Code) and Colab's port proxy are unchanged**.
- The front-end HEAD-probes the route and shows an actionable message if the extension is not active, instead of a bare 404 iframe.
- The bundle is static app code only (no user/project data; project state flows over `window.postMessage`), so it is served like any other static asset.

Drops the now-unused `[hub]` extra (jupyter-server-proxy).

## Verification

- Launched a real Jupyter Server with a JupyterHub-style `base_url=/user/alice/`: `/user/alice/geolibre/app/index.html` -> **200**, relative assets -> **200**, served without a token (works inside the iframe).
- Confirmed the config drop-in **auto-enables** the extension with no explicit flag (`[geolibre] Serving the bundled app at /user/bob/geolibre/app/`).
- Confirmed the wheel packages the drop-in at `…data/data/etc/jupyter/jupyter_server_config.d/geolibre.json`.
- `pytest` (22 passed), including new tests that serve `index.html`/assets through the extension and validate the drop-in.
- `pre-commit run --files …` passes (including the full `npm build`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GeoLibre now bundles and auto-enables a Jupyter Server extension for simpler JupyterHub/remote usage; the widget detects and prefers this route and shows an actionable message if the embedded app is unreachable.

* **Documentation**
  * Clarified pip-only install guidance, JupyterHub/remote routing, and Map(server_proxy=True/False) usage across READMEs and docs.

* **Compatibility**
  * Minimum Python requirement raised to 3.11.

* **Tests**
  * Added and adjusted tests validating extension wiring and routing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->