### PR TITLE
feat(attribute-table): add new field to a vector layer

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -376,6 +376,9 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     setEditingColumnName("");
     setColumnPendingDelete(null);
     setAddingColumn(false);
+    setNewColumnName("");
+    setNewColumnType("text");
+    setNewColumnDefault("");
   }, [selectedLayerId, hasLayer, isGeometryEditing]);
 
   const filterLower = attributeFilter.toLowerCase();

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -726,7 +726,11 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
   const newColumnCollides =
     newColumnNameTrimmed !== "" &&
     discoveredColumns.includes(newColumnNameTrimmed);
-  const canSubmitNewColumn = newColumnNameTrimmed !== "" && !newColumnCollides;
+  // A field is only discoverable through feature property keys, so a new column
+  // cannot be added to a layer with no features (see addColumn).
+  const canAddColumn = features.length > 0;
+  const canSubmitNewColumn =
+    newColumnNameTrimmed !== "" && !newColumnCollides && canAddColumn;
 
   const openAddColumn = () => {
     setNewColumnName("");
@@ -737,9 +741,10 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
 
   const changeNewColumnType = (type: NewColumnType) => {
     setNewColumnType(type);
-    // Boolean fields default to false; reset the free-form default otherwise so
-    // a value typed for one type does not carry over to an incompatible one.
-    setNewColumnDefault(type === "boolean" ? "false" : "");
+    // Reset the default to blank ("no default" → null) for every type so a value
+    // typed for one type does not carry over to an incompatible one, and so the
+    // user must explicitly choose a value rather than silently persisting one.
+    setNewColumnDefault("");
   };
 
   const confirmAddColumn = () => {
@@ -1301,9 +1306,10 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
               {newColumnType === "boolean" ? (
                 <Select
                   id="new-field-default"
-                  value={newColumnDefault || "false"}
+                  value={newColumnDefault}
                   onChange={(event) => setNewColumnDefault(event.target.value)}
                 >
+                  <option value="">(no default)</option>
                   <option value="false">false</option>
                   <option value="true">true</option>
                 </Select>
@@ -1323,6 +1329,11 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
                 />
               )}
             </div>
+            {!canAddColumn ? (
+              <span className="text-xs text-destructive">
+                This layer has no features to add a field to.
+              </span>
+            ) : null}
           </div>
           <div className="flex justify-end gap-2">
             <Button variant="outline" onClick={() => setAddingColumn(false)}>

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -23,7 +23,9 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
   Input,
+  Label,
   ScrollArea,
+  Select,
   TableBody,
   TableCell,
   TableHead,
@@ -43,6 +45,7 @@ import {
   Pencil,
   PanelBottomClose,
   PanelBottomOpen,
+  Plus,
   RotateCcw,
   Save,
   TableProperties,
@@ -59,6 +62,7 @@ import {
 } from "react";
 import { isTauri } from "../../lib/tauri-io";
 import {
+  addColumn,
   deleteColumn,
   getColumnSettings,
   hiddenColumns,
@@ -68,6 +72,7 @@ import {
   renameColumn,
   visibleColumns,
   type ColumnMoveDirection,
+  type NewColumnType,
 } from "../../lib/attribute-columns";
 import {
   exportVectorLayer,
@@ -266,6 +271,11 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
   const [columnPendingDelete, setColumnPendingDelete] = useState<string | null>(
     null,
   );
+  // New-field creation dialog state.
+  const [addingColumn, setAddingColumn] = useState(false);
+  const [newColumnName, setNewColumnName] = useState("");
+  const [newColumnType, setNewColumnType] = useState<NewColumnType>("text");
+  const [newColumnDefault, setNewColumnDefault] = useState("");
 
   const layer = layers.find((l) => l.id === selectedLayerId);
   const hasLayer = Boolean(layer);
@@ -365,6 +375,7 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     setEditingColumn(null);
     setEditingColumnName("");
     setColumnPendingDelete(null);
+    setAddingColumn(false);
   }, [selectedLayerId, hasLayer, isGeometryEditing]);
 
   const filterLower = attributeFilter.toLowerCase();
@@ -711,6 +722,39 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     setColumnPendingDelete(null);
   };
 
+  const newColumnNameTrimmed = newColumnName.trim();
+  const newColumnCollides =
+    newColumnNameTrimmed !== "" &&
+    discoveredColumns.includes(newColumnNameTrimmed);
+  const canSubmitNewColumn = newColumnNameTrimmed !== "" && !newColumnCollides;
+
+  const openAddColumn = () => {
+    setNewColumnName("");
+    setNewColumnType("text");
+    setNewColumnDefault("");
+    setAddingColumn(true);
+  };
+
+  const changeNewColumnType = (type: NewColumnType) => {
+    setNewColumnType(type);
+    // Boolean fields default to false; reset the free-form default otherwise so
+    // a value typed for one type does not carry over to an incompatible one.
+    setNewColumnDefault(type === "boolean" ? "false" : "");
+  };
+
+  const confirmAddColumn = () => {
+    if (!layer || !canSubmitNewColumn) return;
+    const patch = addColumn(
+      layer,
+      discoveredColumns,
+      newColumnName,
+      newColumnType,
+      newColumnDefault,
+    );
+    if (patch) updateLayer(layer.id, patch);
+    setAddingColumn(false);
+  };
+
   const sortableHeader = (key: SortKey, label: string) => (
     <div className="relative flex h-full min-h-10 items-center">
       <button
@@ -952,6 +996,19 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
           <span className="hidden sm:inline">Save</span>
         </Button>
         {canManageColumns && !isEditing ? (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 px-2"
+            title="Add a new field"
+            aria-label="Add field"
+            onClick={openAddColumn}
+          >
+            <Plus className="h-3.5 w-3.5" />
+            <span className="hidden sm:inline">Add field</span>
+          </Button>
+        ) : null}
+        {canManageColumns && !isEditing ? (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
@@ -1187,6 +1244,92 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
             </Button>
             <Button variant="destructive" onClick={confirmDeleteColumn}>
               Delete field
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+      <Dialog
+        open={addingColumn}
+        onOpenChange={(open: boolean) => setAddingColumn(open)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add field</DialogTitle>
+            <DialogDescription>
+              {`Add a new field to every feature in "${layer?.name ?? ""}".`}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-3 py-1">
+            <div className="grid gap-1.5">
+              <Label htmlFor="new-field-name">Field name</Label>
+              <Input
+                id="new-field-name"
+                autoFocus
+                value={newColumnName}
+                placeholder="e.g. category"
+                aria-invalid={newColumnCollides || undefined}
+                onChange={(event) => setNewColumnName(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" && canSubmitNewColumn) {
+                    event.preventDefault();
+                    confirmAddColumn();
+                  }
+                }}
+              />
+              {newColumnCollides ? (
+                <span className="text-xs text-destructive">
+                  A field named "{newColumnNameTrimmed}" already exists.
+                </span>
+              ) : null}
+            </div>
+            <div className="grid gap-1.5">
+              <Label htmlFor="new-field-type">Type</Label>
+              <Select
+                id="new-field-type"
+                value={newColumnType}
+                onChange={(event) =>
+                  changeNewColumnType(event.target.value as NewColumnType)
+                }
+              >
+                <option value="text">Text</option>
+                <option value="number">Number</option>
+                <option value="boolean">Boolean</option>
+              </Select>
+            </div>
+            <div className="grid gap-1.5">
+              <Label htmlFor="new-field-default">Default value</Label>
+              {newColumnType === "boolean" ? (
+                <Select
+                  id="new-field-default"
+                  value={newColumnDefault || "false"}
+                  onChange={(event) => setNewColumnDefault(event.target.value)}
+                >
+                  <option value="false">false</option>
+                  <option value="true">true</option>
+                </Select>
+              ) : (
+                <Input
+                  id="new-field-default"
+                  type={newColumnType === "number" ? "number" : "text"}
+                  value={newColumnDefault}
+                  placeholder="Leave blank for empty"
+                  onChange={(event) => setNewColumnDefault(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" && canSubmitNewColumn) {
+                      event.preventDefault();
+                      confirmAddColumn();
+                    }
+                  }}
+                />
+              )}
+            </div>
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" onClick={() => setAddingColumn(false)}>
+              Cancel
+            </Button>
+            <Button disabled={!canSubmitNewColumn} onClick={confirmAddColumn}>
+              Add field
             </Button>
           </div>
         </DialogContent>

--- a/apps/geolibre-desktop/src/lib/attribute-columns.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-columns.ts
@@ -258,7 +258,10 @@ function appendKeyToOrder(
 /**
  * Add a new attribute field, seeding every feature with a type-appropriate
  * default value. Returns null (no-op) when the name is empty, collides with an
- * existing column, or when the layer has no in-store GeoJSON.
+ * existing column, when the layer has no in-store GeoJSON, or when it has no
+ * features. A field is only discoverable through feature property keys, so on a
+ * zero-row layer the column would never appear (and the collision guard would
+ * never trip, letting the same name be added repeatedly) — reject it instead.
  */
 export function addColumn(
   layer: GeoLibreLayer,
@@ -268,7 +271,9 @@ export function addColumn(
   rawDefault: string,
 ): Partial<GeoLibreLayer> | null {
   const name = rawName.trim();
-  if (!layer.geojson || !name) return null;
+  if (!layer.geojson || layer.geojson.features.length === 0 || !name) {
+    return null;
+  }
   if (discovered.includes(name)) return null; // would clobber another column
   const value = defaultValueForType(type, rawDefault);
   const settings = getColumnSettings(layer);

--- a/apps/geolibre-desktop/src/lib/attribute-columns.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-columns.ts
@@ -20,6 +20,9 @@ export interface ColumnSettings {
 
 export type ColumnMoveDirection = "left" | "right";
 
+/** Data type chosen when creating a new attribute field. */
+export type NewColumnType = "text" | "number" | "boolean";
+
 const COLUMN_SETTINGS_KEY = "columnSettings";
 
 // Style fields that hold a literal property name a destructive rename/delete
@@ -163,6 +166,39 @@ function deleteFieldInGeojson(
   };
 }
 
+function addFieldInGeojson(
+  geojson: FeatureCollection,
+  key: string,
+  value: unknown,
+): FeatureCollection {
+  return {
+    ...geojson,
+    features: geojson.features.map((feature) => ({
+      ...feature,
+      // Append the new key last so it is discovered (and thus rendered) at the
+      // end of the table. A feature with null properties gains a fresh object.
+      properties: { ...(feature.properties ?? {}), [key]: value },
+    })),
+  };
+}
+
+/**
+ * Coerce the raw default-value string into the value seeded into every feature.
+ * An empty string means "no default" → null, which mirrors how GIS tools leave
+ * a freshly added field unset. A non-null default also lets the inline cell
+ * editor infer the field's type (see parseAttributeDraft in AttributeTable).
+ */
+function defaultValueForType(type: NewColumnType, raw: string): unknown {
+  const trimmed = raw.trim();
+  if (trimmed === "") return null;
+  if (type === "number") {
+    const next = Number(trimmed);
+    return Number.isFinite(next) ? next : null;
+  }
+  if (type === "boolean") return trimmed.toLowerCase() === "true";
+  return trimmed;
+}
+
 function renameFieldInStyle(
   style: LayerStyle,
   oldKey: string,
@@ -203,6 +239,42 @@ function removeKeyFromSettings(
   return {
     hidden: settings.hidden?.filter((entry) => entry !== key),
     order: settings.order?.filter((entry) => entry !== key),
+  };
+}
+
+/**
+ * Append a key to settings.order so a new column lands at the end of an explicit
+ * ordering. When no explicit order exists, return the settings untouched and let
+ * discovery order place the (last-added) key last on its own.
+ */
+function appendKeyToOrder(
+  settings: ColumnSettings,
+  key: string,
+): ColumnSettings {
+  if (!settings.order?.length) return settings;
+  return { ...settings, order: [...settings.order, key] };
+}
+
+/**
+ * Add a new attribute field, seeding every feature with a type-appropriate
+ * default value. Returns null (no-op) when the name is empty, collides with an
+ * existing column, or when the layer has no in-store GeoJSON.
+ */
+export function addColumn(
+  layer: GeoLibreLayer,
+  discovered: string[],
+  rawName: string,
+  type: NewColumnType,
+  rawDefault: string,
+): Partial<GeoLibreLayer> | null {
+  const name = rawName.trim();
+  if (!layer.geojson || !name) return null;
+  if (discovered.includes(name)) return null; // would clobber another column
+  const value = defaultValueForType(type, rawDefault);
+  const settings = getColumnSettings(layer);
+  return {
+    geojson: addFieldInGeojson(layer.geojson, name, value),
+    metadata: metadataWithSettings(layer, appendKeyToOrder(settings, name)),
   };
 }
 

--- a/apps/geolibre-desktop/src/lib/attribute-columns.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-columns.ts
@@ -125,12 +125,12 @@ export function hiddenColumns(
   return orderColumns(discovered, settings).filter((key) => hidden.has(key));
 }
 
-// NOTE: renameFieldInGeojson/deleteFieldInGeojson rewrite every feature's
-// property object synchronously on the main thread. This is fine for typical
-// in-browser GeoJSON sizes but will visibly jank on very large layers (tens of
-// thousands of features); chunking or a worker would be needed if that becomes
-// a real workflow. Kept synchronous deliberately — these run on a user-initiated
-// one-off action, not in a hot path.
+// NOTE: renameFieldInGeojson/deleteFieldInGeojson/addFieldInGeojson rewrite every
+// feature's property object synchronously on the main thread. This is fine for
+// typical in-browser GeoJSON sizes but will visibly jank on very large layers
+// (tens of thousands of features); chunking or a worker would be needed if that
+// becomes a real workflow. Kept synchronous deliberately — these run on a
+// user-initiated one-off action, not in a hot path.
 function renameFieldInGeojson(
   geojson: FeatureCollection,
   oldKey: string,

--- a/tests/attribute-columns.test.ts
+++ b/tests/attribute-columns.test.ts
@@ -131,6 +131,20 @@ describe("addColumn (destructive)", () => {
     const layer = makeLayer({ geojson: fc([]) });
     assert.equal(addColumn(layer, [], "label", "text", "x"), null);
   });
+
+  it("seeds the new key for a feature whose properties are null", () => {
+    const layer = makeLayer({
+      geojson: fc([
+        {
+          type: "Feature",
+          geometry: { type: "Point", coordinates: [0, 0] },
+          properties: null,
+        },
+      ]),
+    });
+    const patch = addColumn(layer, [], "label", "text", "x");
+    assert.deepEqual(patch!.geojson!.features[0].properties, { label: "x" });
+  });
 });
 
 describe("renameColumn (destructive)", () => {

--- a/tests/attribute-columns.test.ts
+++ b/tests/attribute-columns.test.ts
@@ -126,6 +126,11 @@ describe("addColumn (destructive)", () => {
     assert.equal(addColumn(layer, DISCOVERED, "  ", "text", ""), null);
     assert.equal(addColumn(layer, DISCOVERED, "pop", "text", ""), null);
   });
+
+  it("is a no-op on a layer with no features (field would never appear)", () => {
+    const layer = makeLayer({ geojson: fc([]) });
+    assert.equal(addColumn(layer, [], "label", "text", "x"), null);
+  });
 });
 
 describe("renameColumn (destructive)", () => {

--- a/tests/attribute-columns.test.ts
+++ b/tests/attribute-columns.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import { DEFAULT_LAYER_STYLE, type GeoLibreLayer } from "@geolibre/core";
 import type { FeatureCollection } from "geojson";
 import {
+  addColumn,
   deleteColumn,
   getColumnSettings,
   hiddenColumns,
@@ -61,6 +62,69 @@ describe("column ordering and visibility", () => {
     const settings = { hidden: ["pop"] };
     assert.deepEqual(visibleColumns(DISCOVERED, settings), ["name", "area"]);
     assert.deepEqual(hiddenColumns(DISCOVERED, settings), ["pop"]);
+  });
+});
+
+describe("addColumn (destructive)", () => {
+  it("seeds a null default into every feature for an empty text default", () => {
+    const layer = makeLayer();
+    const patch = addColumn(layer, DISCOVERED, "label", "text", "");
+    assert.ok(patch);
+    const props = patch.geojson!.features.map((f) => f.properties);
+    assert.deepEqual(props[0], { name: "A", pop: 10, area: 5, label: null });
+    assert.deepEqual(props[1], { name: "B", pop: 20, area: 8, label: null });
+  });
+
+  it("appends the new key last so it is discovered at the end", () => {
+    const layer = makeLayer();
+    const patch = addColumn(layer, DISCOVERED, "label", "text", "x");
+    const keys = Object.keys(patch!.geojson!.features[0].properties ?? {});
+    assert.deepEqual(keys, ["name", "pop", "area", "label"]);
+  });
+
+  it("coerces a numeric default to a number", () => {
+    const layer = makeLayer();
+    const patch = addColumn(layer, DISCOVERED, "score", "number", "42");
+    assert.equal(patch!.geojson!.features[0].properties!.score, 42);
+  });
+
+  it("coerces a boolean default", () => {
+    const layer = makeLayer();
+    const patch = addColumn(layer, DISCOVERED, "flag", "boolean", "true");
+    assert.equal(patch!.geojson!.features[0].properties!.flag, true);
+    const off = addColumn(layer, DISCOVERED, "flag", "boolean", "false");
+    assert.equal(off!.geojson!.features[0].properties!.flag, false);
+  });
+
+  it("keeps a non-numeric default for a number field as null", () => {
+    const layer = makeLayer();
+    const patch = addColumn(layer, DISCOVERED, "score", "number", "abc");
+    assert.equal(patch!.geojson!.features[0].properties!.score, null);
+  });
+
+  it("appends the new key to an existing explicit order", () => {
+    const layer = makeLayer({
+      metadata: { columnSettings: { order: ["pop", "name", "area"] } },
+    });
+    const patch = addColumn(layer, DISCOVERED, "label", "text", "");
+    const settings = (patch?.metadata as Record<string, unknown>)
+      .columnSettings as { order: string[] };
+    assert.deepEqual(settings.order, ["pop", "name", "area", "label"]);
+  });
+
+  it("leaves order unset when none existed, relying on discovery order", () => {
+    const layer = makeLayer();
+    const patch = addColumn(layer, DISCOVERED, "label", "text", "");
+    assert.equal(
+      (patch?.metadata as Record<string, unknown>).columnSettings,
+      undefined,
+    );
+  });
+
+  it("is a no-op for empty or colliding names", () => {
+    const layer = makeLayer();
+    assert.equal(addColumn(layer, DISCOVERED, "  ", "text", ""), null);
+    assert.equal(addColumn(layer, DISCOVERED, "pop", "text", ""), null);
   });
 });
 


### PR DESCRIPTION
Closes #241

## Summary

Adds an **"Add field"** action to the attribute table toolbar so users can create a new attribute field on a vector layer.

The button appears for editable, in-store GeoJSON layers (same gating as the existing rename/delete-field flow — not shown for DuckDB query results or read-only Add-Vector-Layer layers). It opens a dialog that collects:

- **Field name** — validated against empty/whitespace and collision with an existing field (inline error + disabled submit).
- **Type** — Text / Number / Boolean.
- **Default value** — free-form input for text/number, a true/false select for boolean. Blank → `null` (mirroring how GIS tools leave a freshly added field unset); a non-null default also lets the inline cell editor infer the new field's type.

On confirm, the value is seeded into **every feature** and the new column is discovered at the end of the table.

## Implementation

- `attribute-columns.ts`: new `addColumn()` helper (plus `NewColumnType`, `addFieldInGeojson`, `defaultValueForType`, `appendKeyToOrder`). Same shape as `renameColumn`/`deleteColumn` — returns a `Partial<GeoLibreLayer>` patch or `null` no-op, and keeps `columnSettings` order in sync.
- `AttributeTable.tsx`: toolbar button, dialog UI, state/handlers; dialog state resets on layer switch.
- `tests/attribute-columns.test.ts`: 8 new cases (type coercion, null defaults, ordering, collision/empty no-ops).

## Testing

- `npm run test:frontend` → 304 pass (incl. 27 in attribute-columns)
- `tsc -b` full app build typecheck → clean
- `pre-commit run --files …` → all hooks pass, including the full `npm build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add field flow in the attribute table: create new fields (text/number/boolean) with type-dependent default, inline validation (no empty/duplicate names, requires layer with features), Enter-key submission, and conditional toolbar button visibility when column management is allowed.
  * Preserves field ordering in view settings when a field is added.

* **Tests**
  * Added tests for field creation, default coercion, ordering persistence, and validation/no-op cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->