### PR TITLE
fix(jupyter): harden the bundled-app server extension (follow-up to #250)

### DIFF
--- a/python/src/geolibre/_extension.py
+++ b/python/src/geolibre/_extension.py
@@ -46,8 +46,18 @@ def load_jupyter_server_extension(serverapp: Any) -> None:
         serverapp: The ``jupyter_server.serverapp.ServerApp`` instance passed by
             Jupyter Server when it loads the extension.
     """
+    import mimetypes
+
     from jupyter_server.utils import url_path_join
     from tornado.web import StaticFileHandler
+
+    # Guarantee the WebAssembly MIME type. The bundled app loads DuckDB-WASM
+    # (and others) via WebAssembly.instantiateStreaming, which requires an
+    # `application/wasm` Content-Type -- and the nosniff header below makes the
+    # browser enforce it strictly. Python 3.11+ ships this mapping, but a host
+    # whose mimetypes DB overrides it would otherwise serve `.wasm` as
+    # octet-stream and break spatial queries.
+    mimetypes.add_type("application/wasm", ".wasm")
 
     class _AppStaticHandler(StaticFileHandler):
         """Serve the bundled app's static files.

--- a/python/src/geolibre/_extension.py
+++ b/python/src/geolibre/_extension.py
@@ -61,10 +61,18 @@ def load_jupyter_server_extension(serverapp: Any) -> None:
         ``default_filename`` kwarg passed below.
         """
 
+        def set_extra_headers(self, path: str) -> None:
+            # Defense in depth: the bundle is served from the Jupyter Server's
+            # authenticated origin, so block MIME sniffing that could coax a
+            # browser into executing a mistyped asset in that origin.
+            self.set_header("X-Content-Type-Options", "nosniff")
+
     web_app = serverapp.web_app
     base_url = web_app.settings["base_url"]
     route = url_path_join(base_url, APP_ROUTE, "(.*)")
-    bundle_present = _STATIC_APP.is_dir()
+    # Match ensure_bundle()'s index.html check (not a bare is_dir) so an empty
+    # bundle dir reports as missing rather than logging a misleading success.
+    bundle_present = (_STATIC_APP / "index.html").is_file()
     web_app.add_handlers(
         ".*$",
         [


### PR DESCRIPTION
Follow-up to #250. PR #250 was squash-merged while the last review round was being addressed; these valid review items landed just after the merge, so they go here.

## Changes

1. **`X-Content-Type-Options: nosniff` on the app route.** The bundle is served from the Jupyter Server's authenticated origin via a plain `StaticFileHandler`. An explicit `set_extra_headers` override blocks MIME sniffing that could coax a browser into executing a mistyped asset in that origin.
2. **Guarantee `application/wasm` MIME.** The app loads DuckDB-WASM and other `.wasm` modules via `WebAssembly.instantiateStreaming`, which requires `application/wasm` — and the nosniff header above makes the browser enforce it strictly. `mimetypes.add_type("application/wasm", ".wasm")` at extension load keeps `.wasm` correct even on a host whose mimetypes DB lacks/overrides the entry, so nosniff can't break spatial queries.
3. **Diagnostic-accuracy fix.** The "Serving the bundled app at …" info log was gated on `_STATIC_APP.is_dir()`, `True` even for an empty directory. It now checks `index.html` is present (matching `ensure_bundle`), so an empty bundle dir reports as missing instead of logging a misleading success.

## Verification

- `pytest python/tests`: 30 passed.
- End-to-end against a real Jupyter Server (`base_url=/user/eve/`, extension auto-enabled): `index.html` and `assets/*.wasm` return `200`; the `.wasm` response carries `Content-Type: application/wasm` **and** `X-Content-Type-Options: nosniff`.
- `pre-commit` (incl. `npm build`) passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Sets X-Content-Type-Options: nosniff on served static files to protect against MIME sniffing attacks.

* **Bug Fixes**
  * Tightens bundle presence checks so incomplete or empty bundles are treated as missing and trigger appropriate warnings/404s.

* **Compatibility**
  * Ensures WebAssembly files are served with the correct MIME type for proper browser handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->