### PR TITLE
fix(map): let external controls keep their own native layer paint

### DIFF
--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -236,7 +236,9 @@ function syncExternalNativeLayer(
       layer.visible ? "visible" : "none",
     );
 
-    setExternalNativeLayerPaint(map, nativeLayerId, nativeLayer.type, layer);
+    if (!controlOwnsPaint(layer)) {
+      setExternalNativeLayerPaint(map, nativeLayerId, nativeLayer.type, layer);
+    }
     // External layers carry their own zoom range from the control or tile
     // service that registered them, so we leave a pristine layer's native range
     // alone. Once the user moves off the defaults GeoLibre owns the range and
@@ -393,6 +395,17 @@ function isPMTilesExternalLayer(layer: GeoLibreLayer): boolean {
 
 function isExternalCustomLayer(layer: GeoLibreLayer): boolean {
   return typeof layer.metadata.customLayerType === "string";
+}
+
+// External controls that paint their native layers with data-driven MapLibre
+// expressions (selection-based color, radius, opacity, ...) cannot express that
+// paint through GeoLibre's flat per-layer style. They opt in with this flag so
+// the sync below keeps managing visibility, zoom range, and ordering while
+// leaving the control's own paint untouched. Unlike `customLayerType`, which
+// drops the layer onto an ordering-only path, these layers still respond to the
+// panel's show/hide and reorder controls.
+function controlOwnsPaint(layer: GeoLibreLayer): boolean {
+  return layer.metadata.controlOwnsPaint === true;
 }
 
 function ensurePMTilesExternalLayer(

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -196,7 +196,11 @@ function syncExternalNativeLayer(
     .map((nativeLayerId) => getStyleLayerSpec(map, nativeLayerId))
     .filter(isFillStyleLayerSpec);
 
-  if (layer.style.extrusionEnabled && nativeFillLayerSpecs.length > 0) {
+  if (
+    layer.style.extrusionEnabled &&
+    nativeFillLayerSpecs.length > 0 &&
+    !controlOwnsPaint(layer)
+  ) {
     for (const nativeLayerId of nativeLayerIds) {
       setNativeLayerVisibility(map, nativeLayerId, "none");
     }

--- a/python/src/geolibre/_extension.py
+++ b/python/src/geolibre/_extension.py
@@ -46,8 +46,18 @@ def load_jupyter_server_extension(serverapp: Any) -> None:
         serverapp: The ``jupyter_server.serverapp.ServerApp`` instance passed by
             Jupyter Server when it loads the extension.
     """
+    import mimetypes
+
     from jupyter_server.utils import url_path_join
     from tornado.web import StaticFileHandler
+
+    # Guarantee the WebAssembly MIME type. The bundled app loads DuckDB-WASM
+    # (and others) via WebAssembly.instantiateStreaming, which requires an
+    # `application/wasm` Content-Type -- and the nosniff header below makes the
+    # browser enforce it strictly. Python 3.11+ ships this mapping, but a host
+    # whose mimetypes DB overrides it would otherwise serve `.wasm` as
+    # octet-stream and break spatial queries.
+    mimetypes.add_type("application/wasm", ".wasm")
 
     class _AppStaticHandler(StaticFileHandler):
         """Serve the bundled app's static files.

--- a/python/src/geolibre/_extension.py
+++ b/python/src/geolibre/_extension.py
@@ -61,10 +61,18 @@ def load_jupyter_server_extension(serverapp: Any) -> None:
         ``default_filename`` kwarg passed below.
         """
 
+        def set_extra_headers(self, path: str) -> None:
+            # Defense in depth: the bundle is served from the Jupyter Server's
+            # authenticated origin, so block MIME sniffing that could coax a
+            # browser into executing a mistyped asset in that origin.
+            self.set_header("X-Content-Type-Options", "nosniff")
+
     web_app = serverapp.web_app
     base_url = web_app.settings["base_url"]
     route = url_path_join(base_url, APP_ROUTE, "(.*)")
-    bundle_present = _STATIC_APP.is_dir()
+    # Match ensure_bundle()'s index.html check (not a bare is_dir) so an empty
+    # bundle dir reports as missing rather than logging a misleading success.
+    bundle_present = (_STATIC_APP / "index.html").is_file()
     web_app.add_handlers(
         ".*$",
         [

--- a/tests/control-owns-paint.test.ts
+++ b/tests/control-owns-paint.test.ts
@@ -24,6 +24,7 @@ function makeMapStub(nativeLayerId: string, nativeType: string) {
     getSource: () => undefined,
     setLayoutProperty: record("setLayoutProperty"),
     setPaintProperty: record("setPaintProperty"),
+    setLayerZoomRange: record("setLayerZoomRange"),
     moveLayer: record("moveLayer"),
     removeLayer: record("removeLayer"),
     addLayer: record("addLayer"),
@@ -78,6 +79,33 @@ describe("controlOwnsPaint external native layers", () => {
     );
 
     // The control owns the paint, so the host must not touch it.
+    assert.ok(
+      !calls.some((c) => c.method === "setPaintProperty"),
+      "expected paint to be left untouched",
+    );
+  });
+
+  it("still manages a non-default zoom range without touching paint", () => {
+    // A distinct id keeps this layer out of the module-level
+    // managedZoomRangeLayerIds set the other tests touch.
+    const { map, calls } = makeMapStub("mub-zoomed", "circle");
+    const layer = externalNativeLayer({
+      id: "mub-zoomed",
+      style: { ...DEFAULT_LAYER_STYLE, minZoom: 5 },
+      metadata: {
+        externalNativeLayer: true,
+        nativeLayerIds: ["mub-zoomed"],
+        sourceIds: ["mub-zoomed"],
+        controlOwnsPaint: true,
+      },
+    });
+
+    syncLayer(map as never, layer);
+
+    assert.ok(
+      calls.some((c) => c.method === "setLayerZoomRange"),
+      "expected the non-default zoom range to be applied",
+    );
     assert.ok(
       !calls.some((c) => c.method === "setPaintProperty"),
       "expected paint to be left untouched",

--- a/tests/control-owns-paint.test.ts
+++ b/tests/control-owns-paint.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { DEFAULT_LAYER_STYLE, type GeoLibreLayer } from "@geolibre/core";
+import { syncLayer } from "../packages/map/src/layer-sync";
+
+// Records the maplibre calls a layer sync makes so a test can assert which
+// native operations ran (visibility/ordering) versus which were skipped (paint).
+interface MapCall {
+  method: string;
+  args: unknown[];
+}
+
+function makeMapStub(nativeLayerId: string, nativeType: string) {
+  const calls: MapCall[] = [];
+  const record =
+    (method: string) =>
+    (...args: unknown[]) => {
+      calls.push({ method, args });
+    };
+  const map = {
+    getStyle: () => ({ layers: [{ id: nativeLayerId, type: nativeType }] }),
+    getLayer: (id: string) =>
+      id === nativeLayerId ? { id, type: nativeType } : undefined,
+    getSource: () => undefined,
+    setLayoutProperty: record("setLayoutProperty"),
+    setPaintProperty: record("setPaintProperty"),
+    moveLayer: record("moveLayer"),
+    removeLayer: record("removeLayer"),
+    addLayer: record("addLayer"),
+    addSource: record("addSource"),
+  };
+  return { map, calls };
+}
+
+function externalNativeLayer(patch: Partial<GeoLibreLayer> = {}): GeoLibreLayer {
+  return {
+    id: "mub-deliveries",
+    name: "Deliveries",
+    type: "geojson",
+    source: { type: "geojson" },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {
+      externalNativeLayer: true,
+      nativeLayerIds: ["mub-deliveries"],
+      sourceIds: ["mub-deliveries"],
+    },
+    ...patch,
+  };
+}
+
+describe("controlOwnsPaint external native layers", () => {
+  it("syncs visibility and ordering but never overwrites the control's paint", () => {
+    const { map, calls } = makeMapStub("mub-deliveries", "circle");
+    const layer = externalNativeLayer({
+      visible: false,
+      metadata: {
+        externalNativeLayer: true,
+        nativeLayerIds: ["mub-deliveries"],
+        sourceIds: ["mub-deliveries"],
+        controlOwnsPaint: true,
+      },
+    });
+
+    syncLayer(map as never, layer);
+
+    // Visibility is a layout property and must still be applied so the panel's
+    // show/hide toggle works.
+    const visibility = calls.find((c) => c.method === "setLayoutProperty");
+    assert.ok(visibility, "expected visibility to be synced");
+    assert.deepEqual(visibility.args, ["mub-deliveries", "visibility", "none"]);
+
+    // Ordering must still be applied so the panel's reorder works.
+    assert.ok(
+      calls.some((c) => c.method === "moveLayer"),
+      "expected layer ordering to be synced",
+    );
+
+    // The control owns the paint, so the host must not touch it.
+    assert.ok(
+      !calls.some((c) => c.method === "setPaintProperty"),
+      "expected paint to be left untouched",
+    );
+  });
+
+  it("still rebuilds paint for ordinary external native layers", () => {
+    const { map, calls } = makeMapStub("mub-deliveries", "circle");
+
+    syncLayer(map as never, externalNativeLayer());
+
+    assert.ok(
+      calls.some((c) => c.method === "setPaintProperty"),
+      "expected the host to apply paint when the control does not own it",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds an opt-in `controlOwnsPaint` metadata flag for external native layers. When set, `layer-sync` still manages the layer's visibility, zoom range, and ordering, but skips the paint rebuild that derives a flat paint from the layer's per-layer style.
- This lets a control that paints its native layers with data-driven MapLibre expressions (selection-based color, radius, opacity) keep its own styling while the layer stays fully controllable from the layers panel (show/hide, reorder).
- Without the flag, behavior is unchanged: the host keeps owning the paint, as it does for existing external layers.

## Motivation
- The MUB Visualization plugin registers native layers whose paint uses data-driven expressions. The previous options were all-or-nothing: let the host own paint (which flattened the visualization) or use `customLayerType` (which dropped the layers onto an ordering-only path, leaving the panel controls inert). This flag is the missing middle ground.

## Test plan
- [x] New `tests/control-owns-paint.test.ts`: a `controlOwnsPaint` layer syncs visibility and ordering but never calls `setPaintProperty`; an ordinary external native layer still has its paint applied.
- [x] Existing external-layer sync tests pass (geoagent, web-service, raster, vector): 92/92.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External controls can now claim ownership of paint styling, preventing styling overrides while preserving visibility, zoom-range, and layer ordering sync.

* **Bug Fixes**
  * Ensured WebAssembly assets are served with the correct MIME type.
  * Improved bundle presence detection to avoid false positives.
  * Added X-Content-Type-Options: nosniff header for bundled responses.

* **Tests**
  * Added tests verifying paint-ownership behavior and related sync interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->