### PR TITLE
perf(embed): CDN-load PGlite/PostGIS to halve the Jupyter wheel

### DIFF
--- a/apps/geolibre-desktop/src/lib/pglite-loader.cdn.ts
+++ b/apps/geolibre-desktop/src/lib/pglite-loader.cdn.ts
@@ -27,6 +27,7 @@ export async function loadPgliteModules(): Promise<PgliteModules> {
         "embed build (GEOLIBRE_PGLITE_CDN=1).",
     );
   }
+  let modules: { PGlite: unknown; postgis: unknown };
   try {
     // Version-pinned but not integrity-checked: dynamic import() has no
     // `integrity` option, so there is no Subresource Integrity guard on the
@@ -37,13 +38,32 @@ export async function loadPgliteModules(): Promise<PgliteModules> {
       import(/* @vite-ignore */ __PGLITE_CDN_URL__),
       import(/* @vite-ignore */ __PGLITE_POSTGIS_CDN_URL__),
     ]);
-    return { PGlite: PGlite as PgliteModules["PGlite"], postgis };
+    modules = { PGlite, postgis };
   } catch (err) {
+    // The import itself failed: no network, jsDelivr unreachable, or a strict
+    // JupyterHub CSP blocking script-src cdn.jsdelivr.net. Name all three so the
+    // failure is diagnosable.
     throw new Error(
       "Could not load the PostGIS SQL engine from the CDN. The embedded " +
         "GeoLibre app fetches PGlite from jsDelivr on first use, so this " +
-        "feature needs network access.",
+        "feature needs network access and a Content-Security-Policy that " +
+        "allows loading scripts from cdn.jsdelivr.net.",
       { cause: err },
     );
   }
+  // Validate the export shape outside the catch (so this specific message is not
+  // rewrapped as the network error above). If the pinned CDN bundle ever ships
+  // an incompatible module (e.g. a CJS shim that nests everything under
+  // `default`), these would be undefined and otherwise surface later as an
+  // opaque "PGlite is not a constructor" in pglite-workspace.ts.
+  if (typeof modules.PGlite !== "function" || !modules.postgis) {
+    throw new Error(
+      "The CDN module did not export the expected PGlite/postgis symbols; " +
+        "the pinned jsDelivr URL may point to an incompatible bundle.",
+    );
+  }
+  return {
+    PGlite: modules.PGlite as PgliteModules["PGlite"],
+    postgis: modules.postgis,
+  };
 }

--- a/apps/geolibre-desktop/src/lib/pglite-loader.cdn.ts
+++ b/apps/geolibre-desktop/src/lib/pglite-loader.cdn.ts
@@ -17,8 +17,10 @@ export type { PgliteModules };
 export async function loadPgliteModules(): Promise<PgliteModules> {
   try {
     const [{ PGlite }, { postgis }] = await Promise.all([
-      import(/* @vite-ignore */ __PGLITE_CDN_URL__),
-      import(/* @vite-ignore */ __PGLITE_POSTGIS_CDN_URL__),
+      // Non-null assertions: this module is only resolved in the embed build
+      // (GEOLIBRE_PGLITE_CDN=1), where vite.config.ts injects real URL strings.
+      import(/* @vite-ignore */ __PGLITE_CDN_URL__!),
+      import(/* @vite-ignore */ __PGLITE_POSTGIS_CDN_URL__!),
     ]);
     return { PGlite: PGlite as PgliteModules["PGlite"], postgis };
   } catch (err) {

--- a/apps/geolibre-desktop/src/lib/pglite-loader.cdn.ts
+++ b/apps/geolibre-desktop/src/lib/pglite-loader.cdn.ts
@@ -28,6 +28,11 @@ export async function loadPgliteModules(): Promise<PgliteModules> {
     );
   }
   try {
+    // Version-pinned but not integrity-checked: dynamic import() has no
+    // `integrity` option, so there is no Subresource Integrity guard on the
+    // CDN code/WASM. Accepted risk for this optional, CDN-only embed feature
+    // (non-sandboxed iframe, no CSP) — see
+    // docs/superpowers/specs/2026-06-12-embed-build-cdn-pglite-design.md.
     const [{ PGlite }, { postgis }] = await Promise.all([
       import(/* @vite-ignore */ __PGLITE_CDN_URL__),
       import(/* @vite-ignore */ __PGLITE_POSTGIS_CDN_URL__),

--- a/apps/geolibre-desktop/src/lib/pglite-loader.cdn.ts
+++ b/apps/geolibre-desktop/src/lib/pglite-loader.cdn.ts
@@ -1,0 +1,32 @@
+// CDN PGlite loader: used only by the embed (Jupyter wheel) build, which aliases
+// `./pglite-loader` to this module when GEOLIBRE_PGLITE_CDN=1 (see vite.config.ts).
+// It fetches PGlite and its PostGIS extension from jsDelivr at runtime instead of
+// vendoring their ~25 MB of WASM/data/postgis.tar into the wheel. PGlite resolves
+// its own .wasm/.data/postgis.tar relative to the loaded module URL, so the pinned
+// jsDelivr URL transparently pulls those companion files from the CDN too.
+//
+// The URLs come from `define` constants injected by vite.config.ts, pinned to the
+// installed package versions so they cannot drift from the lockfile. The
+// `@vite-ignore` comments keep Vite from trying to resolve/bundle the CDN URLs.
+
+import type { PgliteModules } from "./pglite-loader";
+
+export type { PgliteModules };
+
+/** Load PGlite and the PostGIS extension from the CDN (embed build only). */
+export async function loadPgliteModules(): Promise<PgliteModules> {
+  try {
+    const [{ PGlite }, { postgis }] = await Promise.all([
+      import(/* @vite-ignore */ __PGLITE_CDN_URL__),
+      import(/* @vite-ignore */ __PGLITE_POSTGIS_CDN_URL__),
+    ]);
+    return { PGlite: PGlite as PgliteModules["PGlite"], postgis };
+  } catch (err) {
+    throw new Error(
+      "Could not load the PostGIS SQL engine from the CDN. The embedded " +
+        "GeoLibre app fetches PGlite from jsDelivr on first use, so this " +
+        "feature needs network access.",
+      { cause: err },
+    );
+  }
+}

--- a/apps/geolibre-desktop/src/lib/pglite-loader.cdn.ts
+++ b/apps/geolibre-desktop/src/lib/pglite-loader.cdn.ts
@@ -15,12 +15,22 @@ export type { PgliteModules };
 
 /** Load PGlite and the PostGIS extension from the CDN (embed build only). */
 export async function loadPgliteModules(): Promise<PgliteModules> {
+  // The URLs are only injected (non-null) in the embed build that swaps this
+  // module in via pgliteCdnLoaderPlugin. Fail fast with a clear message if this
+  // loader is somehow reached without them, rather than rewrapping a cryptic
+  // `import(null)` failure as the generic "needs network access" error below.
+  // The guard also narrows the `string | null` defines to `string` for the
+  // dynamic imports.
+  if (!__PGLITE_CDN_URL__ || !__PGLITE_POSTGIS_CDN_URL__) {
+    throw new Error(
+      "PGlite CDN URLs were not injected. This loader is only meant for the " +
+        "embed build (GEOLIBRE_PGLITE_CDN=1).",
+    );
+  }
   try {
     const [{ PGlite }, { postgis }] = await Promise.all([
-      // Non-null assertions: this module is only resolved in the embed build
-      // (GEOLIBRE_PGLITE_CDN=1), where vite.config.ts injects real URL strings.
-      import(/* @vite-ignore */ __PGLITE_CDN_URL__!),
-      import(/* @vite-ignore */ __PGLITE_POSTGIS_CDN_URL__!),
+      import(/* @vite-ignore */ __PGLITE_CDN_URL__),
+      import(/* @vite-ignore */ __PGLITE_POSTGIS_CDN_URL__),
     ]);
     return { PGlite: PGlite as PgliteModules["PGlite"], postgis };
   } catch (err) {

--- a/apps/geolibre-desktop/src/lib/pglite-loader.ts
+++ b/apps/geolibre-desktop/src/lib/pglite-loader.ts
@@ -1,0 +1,24 @@
+// Default PGlite loader: dynamically import the bundled PGlite engine and its
+// PostGIS extension. These are heavy (~25 MB including the PostGIS WASM bundle),
+// so the import is lazy and lives in its own Vite chunk; it only loads when the
+// user first opens the PostGIS SQL workspace.
+//
+// The embed (Jupyter wheel) build swaps this module for `pglite-loader.cdn.ts`
+// via a Vite alias (see vite.config.ts, gated on GEOLIBRE_PGLITE_CDN) so the
+// bundled packages are removed from the graph entirely and never vendored into
+// the wheel. A bundler emits a chunk for every `import()` it parses regardless
+// of dead-code reachability, so the CDN/bundled choice must be made by swapping
+// modules, not by an `if` branch inside one module.
+
+/** Loaded PGlite constructor and PostGIS extension factory. */
+export interface PgliteModules {
+  PGlite: new (options: { extensions: { postgis: unknown } }) => unknown;
+  postgis: unknown;
+}
+
+/** Load the bundled PGlite engine and PostGIS extension. */
+export async function loadPgliteModules(): Promise<PgliteModules> {
+  const { PGlite } = await import("@electric-sql/pglite");
+  const { postgis } = await import("@electric-sql/pglite-postgis");
+  return { PGlite: PGlite as PgliteModules["PGlite"], postgis };
+}

--- a/apps/geolibre-desktop/src/lib/pglite-loader.ts
+++ b/apps/geolibre-desktop/src/lib/pglite-loader.ts
@@ -18,7 +18,9 @@ export interface PgliteModules {
 
 /** Load the bundled PGlite engine and PostGIS extension. */
 export async function loadPgliteModules(): Promise<PgliteModules> {
-  const { PGlite } = await import("@electric-sql/pglite");
-  const { postgis } = await import("@electric-sql/pglite-postgis");
+  const [{ PGlite }, { postgis }] = await Promise.all([
+    import("@electric-sql/pglite"),
+    import("@electric-sql/pglite-postgis"),
+  ]);
   return { PGlite: PGlite as PgliteModules["PGlite"], postgis };
 }

--- a/apps/geolibre-desktop/src/lib/pglite-workspace.ts
+++ b/apps/geolibre-desktop/src/lib/pglite-workspace.ts
@@ -1,5 +1,6 @@
 import type { GeoLibreLayer } from "@geolibre/core";
 import type { FeatureCollection } from "geojson";
+import { loadPgliteModules } from "./pglite-loader";
 import {
   buildCreateTableStatement,
   buildInsertChunk,
@@ -75,8 +76,7 @@ function runExclusive<T>(task: () => Promise<T>): Promise<T> {
 async function getState(): Promise<PgliteState> {
   if (!statePromise) {
     statePromise = (async () => {
-      const { PGlite } = await import("@electric-sql/pglite");
-      const { postgis } = await import("@electric-sql/pglite-postgis");
+      const { PGlite, postgis } = await loadPgliteModules();
       const pg = new PGlite({
         extensions: { postgis },
       }) as unknown as PgliteLike;

--- a/apps/geolibre-desktop/src/vite-env.d.ts
+++ b/apps/geolibre-desktop/src/vite-env.d.ts
@@ -2,6 +2,13 @@
 
 declare const __GEOLIBRE_VERSION__: string;
 
+// jsDelivr URLs for the PGlite engine and its PostGIS extension, injected by
+// vite.config.ts. Only the embed (Jupyter wheel) build reads them, from
+// pglite-loader.cdn.ts; web/desktop builds bundle PGlite and never reference
+// these (the define values are null there).
+declare const __PGLITE_CDN_URL__: string;
+declare const __PGLITE_POSTGIS_CDN_URL__: string;
+
 declare module "virtual:bundled-plugins" {
   // Manifest paths (base-relative, no leading slash) for plugins dropped into
   // public/plugins/<id>/, discovered at build time by the bundledPlugins() Vite

--- a/apps/geolibre-desktop/src/vite-env.d.ts
+++ b/apps/geolibre-desktop/src/vite-env.d.ts
@@ -6,8 +6,8 @@ declare const __GEOLIBRE_VERSION__: string;
 // vite.config.ts. Only the embed (Jupyter wheel) build reads them, from
 // pglite-loader.cdn.ts; web/desktop builds bundle PGlite and never reference
 // these (the define values are null there).
-declare const __PGLITE_CDN_URL__: string;
-declare const __PGLITE_POSTGIS_CDN_URL__: string;
+declare const __PGLITE_CDN_URL__: string | null;
+declare const __PGLITE_POSTGIS_CDN_URL__: string | null;
 
 declare module "virtual:bundled-plugins" {
   // Manifest paths (base-relative, no leading slash) for plugins dropped into

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -28,16 +28,38 @@ const APP_VERSION = JSON.parse(
 // lockfile; PGlite resolves its own .wasm/.data/postgis.tar relative to these.
 const PGLITE_CDN = process.env.GEOLIBRE_PGLITE_CDN === "1";
 const pgliteCdnRequire = createRequire(import.meta.url);
+// The ESM entry of a package's manifest. Prefer the `module` field and the
+// `import` condition of `exports` (both point at the ESM build); never fall back
+// to `main`, which is the CJS entry (`dist/index.cjs` for PGlite) and would
+// break the jsDelivr `import()` at runtime. Falls back to `dist/index.js`, the
+// historical PGlite layout, if neither is declared.
+function esmEntry(manifest: Record<string, unknown>): string {
+  if (typeof manifest.module === "string") return manifest.module;
+  const exportsRoot = (manifest.exports as Record<string, unknown> | undefined)?.[
+    "."
+  ];
+  const importEntry = (exportsRoot as Record<string, unknown> | undefined)
+    ?.import;
+  const importDefault =
+    typeof importEntry === "string"
+      ? importEntry
+      : (importEntry as Record<string, unknown> | undefined)?.default;
+  if (typeof importDefault === "string") return importDefault;
+  return "dist/index.js";
+}
 // The PGlite packages do not expose "./package.json" via their `exports`, so
 // resolve the package entry and walk up to its package.json to read the
-// installed version.
-function installedVersion(pkg: string): string {
+// installed version and ESM entry path (so the CDN URL tracks the lockfile and
+// any future dist restructuring instead of hardcoding `/dist/index.js`).
+function installedPackage(pkg: string): { version: string; entry: string } {
   let dir = path.dirname(pgliteCdnRequire.resolve(pkg));
   while (dir !== path.dirname(dir)) {
     const manifest = path.join(dir, "package.json");
     try {
       const parsed = JSON.parse(readFileSync(manifest, "utf8"));
-      if (parsed.name === pkg) return parsed.version as string;
+      if (parsed.name === pkg) {
+        return { version: parsed.version as string, entry: esmEntry(parsed) };
+      }
     } catch {
       // Not this directory's package.json; keep walking up.
     }
@@ -47,7 +69,10 @@ function installedVersion(pkg: string): string {
 }
 function pgliteCdnUrl(pkg: string): string | null {
   if (!PGLITE_CDN) return null;
-  return `https://cdn.jsdelivr.net/npm/${pkg}@${installedVersion(pkg)}/dist/index.js`;
+  const { version, entry } = installedPackage(pkg);
+  // Normalize a leading "./" from the manifest entry into the jsDelivr path.
+  const entryPath = entry.replace(/^\.?\//, "");
+  return `https://cdn.jsdelivr.net/npm/${pkg}@${version}/${entryPath}`;
 }
 const PGLITE_CDN_URL = pgliteCdnUrl("@electric-sql/pglite");
 const PGLITE_POSTGIS_CDN_URL = pgliteCdnUrl("@electric-sql/pglite-postgis");

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -1,6 +1,7 @@
 import react from "@vitejs/plugin-react";
 import { readFileSync } from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { createRequire } from "node:module";
 import path from "node:path";
 import type {
   RollupLog,
@@ -19,6 +20,37 @@ const APP_BASE = process.env.GEOLIBRE_APP_BASE;
 const APP_VERSION = JSON.parse(
   readFileSync(new URL("./package.json", import.meta.url), "utf8"),
 ).version as string;
+
+// The embedded (Jupyter wheel) build sets GEOLIBRE_PGLITE_CDN=1 so the ~25 MB
+// PGlite + PostGIS bundle is fetched from jsDelivr at runtime instead of vendored
+// into the wheel. Web and desktop builds keep bundling it (offline-capable). The
+// CDN URLs are pinned to the installed versions so they cannot drift from the
+// lockfile; PGlite resolves its own .wasm/.data/postgis.tar relative to these.
+const PGLITE_CDN = process.env.GEOLIBRE_PGLITE_CDN === "1";
+const pgliteCdnRequire = createRequire(import.meta.url);
+// The PGlite packages do not expose "./package.json" via their `exports`, so
+// resolve the package entry and walk up to its package.json to read the
+// installed version.
+function installedVersion(pkg: string): string {
+  let dir = path.dirname(pgliteCdnRequire.resolve(pkg));
+  while (dir !== path.dirname(dir)) {
+    const manifest = path.join(dir, "package.json");
+    try {
+      const parsed = JSON.parse(readFileSync(manifest, "utf8"));
+      if (parsed.name === pkg) return parsed.version as string;
+    } catch {
+      // Not this directory's package.json; keep walking up.
+    }
+    dir = path.dirname(dir);
+  }
+  throw new Error(`Could not resolve installed version of ${pkg}`);
+}
+function pgliteCdnUrl(pkg: string): string | null {
+  if (!PGLITE_CDN) return null;
+  return `https://cdn.jsdelivr.net/npm/${pkg}@${installedVersion(pkg)}/dist/index.js`;
+}
+const PGLITE_CDN_URL = pgliteCdnUrl("@electric-sql/pglite");
+const PGLITE_POSTGIS_CDN_URL = pgliteCdnUrl("@electric-sql/pglite-postgis");
 const WMS_PROXY_PATH = "/__geolibre_wms_proxy";
 const WFS_PROXY_PATH = "/__geolibre_wfs_proxy";
 const GPX_PROXY_PATH = "/__geolibre_gpx_proxy";
@@ -234,6 +266,23 @@ function isDuckDbWorkerRequest(pathname: string): boolean {
   );
 }
 
+// Embed build only: redirect imports of `./pglite-loader` to the CDN variant so
+// the bundled PGlite/PostGIS packages (and their ~25 MB of WASM/data/postgis.tar)
+// are removed from the graph entirely. A bundler emits a chunk for every parsed
+// `import()` regardless of dead-code reachability, so swapping the whole module
+// is the only reliable way to keep those assets out of the wheel.
+function pgliteCdnLoaderPlugin(): Plugin {
+  const cdnLoader = path.resolve(__dirname, "src/lib/pglite-loader.cdn.ts");
+  return {
+    name: "geolibre-pglite-cdn-loader",
+    enforce: "pre",
+    resolveId(source) {
+      // Match `./pglite-loader` (and `.ts`) but never `pglite-loader.cdn`.
+      return /(?:^|\/)pglite-loader(?:\.ts)?$/.test(source) ? cdnLoader : null;
+    },
+  };
+}
+
 function projectUrlQueryPlugin(): Plugin {
   return {
     name: "geolibre-project-url-query",
@@ -321,6 +370,7 @@ async function proxyBinaryRequest(
 export default defineConfig({
   base: APP_BASE,
   plugins: [
+    ...(PGLITE_CDN ? [pgliteCdnLoaderPlugin()] : []),
     stripDuckDbWorkerSourcemapPlugin(),
     projectUrlQueryPlugin(),
     bundledPlugins(path.resolve(__dirname, "public/plugins")),
@@ -338,6 +388,8 @@ export default defineConfig({
   clearScreen: false,
   define: {
     __GEOLIBRE_VERSION__: JSON.stringify(APP_VERSION),
+    __PGLITE_CDN_URL__: JSON.stringify(PGLITE_CDN_URL),
+    __PGLITE_POSTGIS_CDN_URL__: JSON.stringify(PGLITE_POSTGIS_CDN_URL),
   },
   server: {
     port: 5173,

--- a/docs/superpowers/specs/2026-06-12-embed-build-cdn-pglite-design.md
+++ b/docs/superpowers/specs/2026-06-12-embed-build-cdn-pglite-design.md
@@ -55,10 +55,18 @@ wheel embeds the whole `dist-embed/` tree, so those lazy chunks plus the 19.6 MB
 
 ## Approach
 
-A build-time flag, set only by the embed build, flips the dynamic `import()` in
-`pglite-workspace.ts` from the bundled package to a version-pinned jsDelivr URL.
-The bundled branch is dead-code-eliminated in embed mode, so Vite never emits the
-pglite chunk, `.wasm`, `.data`, or `postgis.tar`.
+A build-time flag, set only by the embed build, swaps the entire PGlite **loader
+module** for a CDN variant at Rollup's `resolveId` stage. Because the bundled
+loader is no longer in the module graph, Vite never emits the pglite chunk,
+`.wasm`, `.data`, or `postgis.tar`.
+
+> **Note:** an earlier draft of this design used a single loader module with an
+> `if (__PGLITE_CDN__) { ... } else { ... }` branch, relying on Rollup to
+> tree-shake the dead bundled branch. That approach was **not** shipped: a
+> bundler emits a chunk for every `import()` it parses regardless of dead-code
+> reachability, so the dead branch would still vendor the pglite chunk into the
+> wheel. Sections 2 and 3 below describe the module-swap design that was
+> actually built.
 
 ### 1. Flag plumbing
 
@@ -69,41 +77,39 @@ alongside the existing `GEOLIBRE_APP_BASE=./`.
 
 Read the env var. Using `createRequire`, read the **installed** versions of
 `@electric-sql/pglite` and `@electric-sql/pglite-postgis` from their
-`package.json` so the CDN URLs cannot drift from the lockfile. Inject three
+`package.json` so the CDN URLs cannot drift from the lockfile. Inject two
 `define` constants:
 
-- `__PGLITE_CDN__`: `true` / `false`
 - `__PGLITE_CDN_URL__`:
   `"https://cdn.jsdelivr.net/npm/@electric-sql/pglite@<ver>/dist/index.js"`
   (or `null` when not in embed mode)
 - `__PGLITE_POSTGIS_CDN_URL__`: the same for `pglite-postgis` (or `null`)
 
-### 3. Runtime branch (`apps/geolibre-desktop/src/lib/pglite-workspace.ts`)
+Also register `pgliteCdnLoaderPlugin()` (only when `GEOLIBRE_PGLITE_CDN=1`): a
+Vite/Rollup plugin whose `resolveId` redirects any import of `./pglite-loader`
+(but never `pglite-loader.cdn`) to `src/lib/pglite-loader.cdn.ts`.
 
-In `getState()`:
+### 3. Loader modules (`apps/geolibre-desktop/src/lib/pglite-loader*.ts`)
 
-```js
-let pgliteMod, postgisMod;
-if (__PGLITE_CDN__) {
-  pgliteMod  = await import(/* @vite-ignore */ __PGLITE_CDN_URL__);
-  postgisMod = await import(/* @vite-ignore */ __PGLITE_POSTGIS_CDN_URL__);
-} else {
-  pgliteMod  = await import("@electric-sql/pglite");
-  postgisMod = await import("@electric-sql/pglite-postgis");
-}
-const { PGlite } = pgliteMod;
-const { postgis } = postgisMod;
-```
+`pglite-workspace.ts` is left unchanged except for importing
+`loadPgliteModules()` from `./pglite-loader`. There is **no** `if` branch in the
+workspace code.
 
-`if (false) { ... }` is reliably tree-shaken by Rollup, so the bundled imports
-(and their assets) vanish from the embed build while staying intact everywhere
-else. A TypeScript ambient declaration (e.g. in a `*.d.ts`) declares the three
-`__PGLITE_*__` globals so the source typechecks.
+- `pglite-loader.ts` (default): dynamically imports the bundled
+  `@electric-sql/pglite` and `@electric-sql/pglite-postgis`.
+- `pglite-loader.cdn.ts` (embed only): dynamically imports the injected
+  `__PGLITE_CDN_URL__` / `__PGLITE_POSTGIS_CDN_URL__` jsDelivr URLs with
+  `/* @vite-ignore */` so Vite does not try to resolve/bundle them.
+
+The plugin swaps `pglite-loader` → `pglite-loader.cdn` only in embed mode, so the
+bundled imports (and their assets) vanish from the embed build while staying
+intact everywhere else. A TypeScript ambient declaration (in `vite-env.d.ts`)
+declares the two `__PGLITE_*_URL__` globals so the source typechecks.
 
 The CDN error path reuses the existing `getState()` behavior: on failure it
 resets `statePromise` so the load is retryable, and the dialog surfaces the
-error. The thrown message is adjusted to mention that the PostGIS engine is
-fetched from a CDN and needs network access, so a failure is diagnosable.
+error. The thrown message mentions that the PostGIS engine is fetched from a CDN
+and needs network access, so a failure is diagnosable.
 
 ### 4. Build guard
 
@@ -137,3 +143,11 @@ the dead-code-elimination ever stops working.
   Accepted per the chosen direction.
 - **Version drift.** CDN URLs are pinned from the installed package versions at
   build time, so they cannot diverge from the lockfile.
+- **No Subresource Integrity / tamper protection.** The URLs are version-pinned
+  but unhashed. Dynamic `import()` has no `integrity` option, so a compromised
+  jsDelivr or a tampered package version that reached the registry would be
+  served from the pinned URL with no integrity signal. A fetch-then-SHA-256-then-
+  `URL.createObjectURL` step could add verification, but at the cost of
+  complexity for an optional, opt-in feature in a non-sandboxed iframe with no
+  CSP. **Accepted risk** for CDN loading in the embed build; revisit if the embed
+  path ever handles untrusted data or gains a CSP.

--- a/docs/superpowers/specs/2026-06-12-embed-build-cdn-pglite-design.md
+++ b/docs/superpowers/specs/2026-06-12-embed-build-cdn-pglite-design.md
@@ -1,0 +1,139 @@
+# Embed-build CDN loading for PGlite/PostGIS
+
+Date: 2026-06-12
+
+## Problem
+
+The `geolibre` Python wheel grew from ~24 MB (v1.1.0) to ~47 MB (v1.1.1). The
+entire increase comes from the in-browser PostGIS SQL engine added in PR #234
+(`feat(sql): add in-browser PostGIS SQL engine via PGlite`). The wheel bundles
+the built web app (`geolibre/static/app`), which now includes the lazily-loaded
+PGlite assets:
+
+| File | Compressed |
+|------|-----------|
+| `postgis.tar.gz` (PostGIS extension bundle) | 19.58 MB |
+| `pglite.wasm` (PostgreSQL compiled to WASM) | 3.40 MB |
+| `pglite.data` | 1.85 MB |
+| `initdb.wasm` | 0.14 MB |
+| `pglite.js` | 0.14 MB |
+| **PGlite subtotal** | **25.1 MB** |
+
+PGlite is already lazy-loaded at runtime (the `SqlWorkspaceDialog` is `lazy()`,
+and `pglite-workspace.ts` uses dynamic `import()`), so on the web/desktop it only
+downloads when a user opens the SQL workspace. The problem is purely that the
+wheel embeds the whole `dist-embed/` tree, so those lazy chunks plus the 19.6 MB
+`postgis.tar.gz` ship inside the wheel regardless of whether the feature is used.
+
+## Goals
+
+- Shrink the Jupyter wheel back to ~24 MB.
+- Keep the in-browser PostGIS SQL workspace working in Jupyter, loading PGlite
+  and the PostGIS extension from a CDN (jsDelivr) on first use.
+- Leave the regular web build and the Tauri desktop build unchanged (they keep
+  bundling PGlite so they work fully offline / vendored).
+
+## Non-goals
+
+- No change to web or desktop bundling behavior.
+- No offline support for the PostGIS SQL feature inside the Jupyter wheel. It is
+  an optional feature; needing internet on first use is acceptable. The app
+  already loads basemap tiles from the network.
+- No change to the SQL-building logic or the dialog UI.
+
+## Constraints verified
+
+- The embedded app is served by the Jupyter Server extension
+  (`python/src/geolibre/_extension.py`) and rendered in a **non-sandboxed**
+  iframe via `iframe.src` (`python/src/geolibre/_frontend.js`).
+- The server sets only `X-Content-Type-Options: nosniff` (for WASM MIME). There
+  is **no Content-Security-Policy** anywhere in the embed/web path, so a
+  cross-origin script/WASM/data fetch from jsDelivr is not blocked.
+- `@electric-sql/pglite` (0.5.2) and `@electric-sql/pglite-postgis` (0.2.2) are
+  pure ESM and support CDN loading: they resolve their own `.wasm`, `.data`, and
+  `postgis.tar` relative to their module URL, which becomes the jsDelivr path.
+
+## Approach
+
+A build-time flag, set only by the embed build, flips the dynamic `import()` in
+`pglite-workspace.ts` from the bundled package to a version-pinned jsDelivr URL.
+The bundled branch is dead-code-eliminated in embed mode, so Vite never emits the
+pglite chunk, `.wasm`, `.data`, or `postgis.tar`.
+
+### 1. Flag plumbing
+
+`scripts/build-embed.mjs` adds `GEOLIBRE_PGLITE_CDN: "1"` to the build env,
+alongside the existing `GEOLIBRE_APP_BASE=./`.
+
+### 2. Vite config (`apps/geolibre-desktop/vite.config.ts`)
+
+Read the env var. Using `createRequire`, read the **installed** versions of
+`@electric-sql/pglite` and `@electric-sql/pglite-postgis` from their
+`package.json` so the CDN URLs cannot drift from the lockfile. Inject three
+`define` constants:
+
+- `__PGLITE_CDN__`: `true` / `false`
+- `__PGLITE_CDN_URL__`:
+  `"https://cdn.jsdelivr.net/npm/@electric-sql/pglite@<ver>/dist/index.js"`
+  (or `null` when not in embed mode)
+- `__PGLITE_POSTGIS_CDN_URL__`: the same for `pglite-postgis` (or `null`)
+
+### 3. Runtime branch (`apps/geolibre-desktop/src/lib/pglite-workspace.ts`)
+
+In `getState()`:
+
+```js
+let pgliteMod, postgisMod;
+if (__PGLITE_CDN__) {
+  pgliteMod  = await import(/* @vite-ignore */ __PGLITE_CDN_URL__);
+  postgisMod = await import(/* @vite-ignore */ __PGLITE_POSTGIS_CDN_URL__);
+} else {
+  pgliteMod  = await import("@electric-sql/pglite");
+  postgisMod = await import("@electric-sql/pglite-postgis");
+}
+const { PGlite } = pgliteMod;
+const { postgis } = postgisMod;
+```
+
+`if (false) { ... }` is reliably tree-shaken by Rollup, so the bundled imports
+(and their assets) vanish from the embed build while staying intact everywhere
+else. A TypeScript ambient declaration (e.g. in a `*.d.ts`) declares the three
+`__PGLITE_*__` globals so the source typechecks.
+
+The CDN error path reuses the existing `getState()` behavior: on failure it
+resets `statePromise` so the load is retryable, and the dialog surfaces the
+error. The thrown message is adjusted to mention that the PostGIS engine is
+fetched from a CDN and needs network access, so a failure is diagnosable.
+
+### 4. Build guard
+
+`scripts/build-embed.mjs` already guards against absolute asset paths in
+`index.html`. Add a second guard: after the build, fail if any `postgis.tar*`
+file exists under `dist-embed/assets/`, so the wheel cannot silently regrow if
+the dead-code-elimination ever stops working.
+
+## Verification
+
+1. `npm run build:embed`, then assert `dist-embed/assets/` contains **no**
+   `postgis.tar*`, `pglite*.wasm`, `pglite*.data`, `initdb*.wasm`, or pglite JS
+   chunk.
+2. Confirm the staged `python/src/geolibre/static/app` tree shrinks by ~25 MB and
+   a freshly built wheel is back to ~24 MB.
+3. Run the regular `npm run build` and confirm it **still** bundles the PGlite
+   assets (web/desktop unchanged).
+4. `npm run test:frontend` (the `pglite-sql.ts` unit tests are unaffected, but
+   confirm nothing regressed) and `npm run typecheck`.
+5. Manual: build the wheel, open the embedded app in Jupyter, open the SQL
+   workspace, pick the PostGIS engine, and confirm it loads from jsDelivr and
+   runs a query.
+
+## Risks
+
+- **Tree-shaking the bundled import in embed mode** is the load-bearing
+  assumption. Verified empirically in step 1 of Verification before declaring
+  done; the build guard (step 4 of Approach) is the backstop.
+- **CDN availability at runtime.** The Jupyter PostGIS SQL feature now needs
+  internet on first use. jsDelivr CORS is permissive and no CSP blocks it.
+  Accepted per the chosen direction.
+- **Version drift.** CDN URLs are pinned from the installed package versions at
+  build time, so they cannot diverge from the lockfile.

--- a/scripts/build-embed.mjs
+++ b/scripts/build-embed.mjs
@@ -48,18 +48,23 @@ if (result.status !== 0) {
 // 19.6 MB postgis.tar (and PGlite wasm/data) would silently re-inflate the wheel.
 const assetsDir = resolve(distDir, "assets");
 // Matches the content-hashed PGlite assets, e.g. postgis.tar-<hash>.gz,
-// pglite-<hash>.wasm, pglite-<hash>.data, initdb-<hash>.wasm. Also catches a
-// leaked pglite-<hash>.js chunk: manualChunks() names any @electric-sql/pglite
-// import "pglite", so if the loader module-swap stops excluding the package,
-// Rollup would emit that JS chunk and the wheel would regrow even without the
-// WASM/data assets.
-const pgliteAssetRe = /^(?:postgis\.tar|pglite|initdb).*\.(?:gz|wasm|data|js)$/;
+// pglite-<hash>.wasm, pglite-<hash>.data, initdb-<hash>.wasm. The second arm
+// also catches a leaked pglite-<hash>.js chunk: manualChunks() names any
+// @electric-sql/pglite import exactly "pglite", so if the loader module-swap
+// stops excluding the package, Rollup emits `pglite-<hash>.js` and the wheel
+// would regrow even without the WASM/data assets. The JS arm is anchored to
+// `pglite-<alnum-hash>.js` so it does not spuriously match a `pglite-loader-*`
+// chunk (the `-` in `loader` breaks the `\w+` run) should Rollup ever split the
+// statically-imported loader module into its own chunk.
+const pgliteAssetRe =
+  /^(?:postgis\.tar|pglite|initdb).*\.(?:gz|wasm|data)$|^pglite-\w+\.js$/;
 const leaked = readdirSync(assetsDir).filter((name) => pgliteAssetRe.test(name));
 if (leaked.length > 0) {
   console.error(
     "[build-embed] PGlite assets leaked into the embed build despite " +
       `GEOLIBRE_PGLITE_CDN=1: ${leaked.join(", ")}. These should load from a ` +
-      "CDN at runtime; check the tree-shaken import branch in pglite-workspace.ts.",
+      "CDN at runtime; check `pgliteCdnLoaderPlugin` in vite.config.ts and the " +
+      "pglite-loader.cdn.ts / pglite-loader.ts module pair.",
   );
   process.exit(1);
 }

--- a/scripts/build-embed.mjs
+++ b/scripts/build-embed.mjs
@@ -1,17 +1,26 @@
 // Build the GeoLibre web app for embedding (Jupyter widget / standalone HTML)
 // and stage it into the Python package.
 //
-// The embed build differs from the normal web build in one load-bearing way:
-// it sets `GEOLIBRE_APP_BASE=./` so every asset, favicon, and bundled-plugin
-// URL in the emitted index.html is relative. That lets the app load from
-// inside a Python wheel (served from an arbitrary, content-hashed location)
-// instead of the site root.
+// The embed build differs from the normal web build in two load-bearing ways:
+//  1. `GEOLIBRE_APP_BASE=./` makes every asset, favicon, and bundled-plugin URL
+//     in the emitted index.html relative, so the app can load from inside a
+//     Python wheel (served from an arbitrary, content-hashed location) instead
+//     of the site root.
+//  2. `GEOLIBRE_PGLITE_CDN=1` makes the PostGIS SQL engine fetch PGlite and its
+//     ~25 MB PostGIS bundle from jsDelivr at runtime instead of vendoring them
+//     into the wheel. Web/desktop builds keep bundling PGlite (offline-capable).
 //
 // Output: apps/geolibre-desktop/dist-embed/ -> copied to
 // python/src/geolibre/static/app/.
 
 import { spawnSync } from "node:child_process";
-import { cpSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import {
+  cpSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -26,12 +35,29 @@ const result = spawnSync(
     cwd: repoRoot,
     shell: process.platform === "win32",
     stdio: "inherit",
-    env: { ...process.env, GEOLIBRE_APP_BASE: "./" },
+    env: { ...process.env, GEOLIBRE_APP_BASE: "./", GEOLIBRE_PGLITE_CDN: "1" },
   },
 );
 
 if (result.status !== 0) {
   process.exit(result.status ?? 1);
+}
+
+// Guard the wheel size: GEOLIBRE_PGLITE_CDN should keep the PGlite/PostGIS bundle
+// out of the embed build. If the dead-code elimination ever stops working, the
+// 19.6 MB postgis.tar (and PGlite wasm/data) would silently re-inflate the wheel.
+const assetsDir = resolve(distDir, "assets");
+// Matches the content-hashed PGlite assets, e.g. postgis.tar-<hash>.gz,
+// pglite-<hash>.wasm, pglite-<hash>.data, initdb-<hash>.wasm.
+const pgliteAssetRe = /^(?:postgis\.tar|pglite|initdb).*\.(?:gz|wasm|data)$/;
+const leaked = readdirSync(assetsDir).filter((name) => pgliteAssetRe.test(name));
+if (leaked.length > 0) {
+  console.error(
+    "[build-embed] PGlite assets leaked into the embed build despite " +
+      `GEOLIBRE_PGLITE_CDN=1: ${leaked.join(", ")}. These should load from a ` +
+      "CDN at runtime; check the tree-shaken import branch in pglite-workspace.ts.",
+  );
+  process.exit(1);
 }
 
 // Guard the one thing that silently breaks the wheel: if the base path was not

--- a/scripts/build-embed.mjs
+++ b/scripts/build-embed.mjs
@@ -48,8 +48,12 @@ if (result.status !== 0) {
 // 19.6 MB postgis.tar (and PGlite wasm/data) would silently re-inflate the wheel.
 const assetsDir = resolve(distDir, "assets");
 // Matches the content-hashed PGlite assets, e.g. postgis.tar-<hash>.gz,
-// pglite-<hash>.wasm, pglite-<hash>.data, initdb-<hash>.wasm.
-const pgliteAssetRe = /^(?:postgis\.tar|pglite|initdb).*\.(?:gz|wasm|data)$/;
+// pglite-<hash>.wasm, pglite-<hash>.data, initdb-<hash>.wasm. Also catches a
+// leaked pglite-<hash>.js chunk: manualChunks() names any @electric-sql/pglite
+// import "pglite", so if the loader module-swap stops excluding the package,
+// Rollup would emit that JS chunk and the wheel would regrow even without the
+// WASM/data assets.
+const pgliteAssetRe = /^(?:postgis\.tar|pglite|initdb).*\.(?:gz|wasm|data|js)$/;
 const leaked = readdirSync(assetsDir).filter((name) => pgliteAssetRe.test(name));
 if (leaked.length > 0) {
   console.error(


### PR DESCRIPTION
## Summary
- The in-browser PostGIS SQL engine (PGlite) vendored ~25 MB of WASM/data/postgis.tar into the Jupyter wheel, growing it from ~24 MB to ~47 MB. The embed build now loads PGlite and the PostGIS extension from version-pinned jsDelivr URLs at first use instead of bundling them, bringing the wheel back to 24.5 MB.
- Selection is done by swapping the loader module (`./pglite-loader` to `pglite-loader.cdn.ts`) via a pre-resolve Vite plugin gated on `GEOLIBRE_PGLITE_CDN=1`, because a bundler emits a chunk for every parsed `import()` and dead-code branches alone do not exclude the assets. A build guard fails if the assets ever leak back in.
- Web and desktop builds are unchanged and keep bundling PGlite for fully offline use. Only the Jupyter wheel now needs network access on first use of the PostGIS SQL workspace; failures surface through the existing retryable error path.

## Test plan
- [x] `npm run build:embed` produces no `postgis.tar` / `pglite*.wasm` / `pglite*.data`; lazy SQL chunk carries pinned `pglite@0.5.2` and `pglite-postgis@0.2.2` URLs
- [x] Built wheel is 24.5 MB (down from 47 MB)
- [x] `npm run typecheck` (full build) clean; regular build still bundles PGlite with no CDN URL
- [x] `npm run test:frontend` (306 pass) and Python suite (30 pass)
- [x] `pre-commit` passes including the npm-build hook
- [ ] Manual: open the embedded app in Jupyter, run a PostGIS query, confirm it loads from jsDelivr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CDN-based runtime loading of the database engine and PostGIS for the embedded (wheel) build.
  * Lazy-loading of those libraries with fail-fast checks and clearer, network-focused error messages; runtime validation of expected exports.
  * Build-time flag and injected CDN URLs to toggle/configure embed behavior.

* **Chores**
  * Post-build verification that fails if database assets are accidentally bundled into the embed distribution.

* **Documentation**
  * Added design spec describing the CDN-based embed approach and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->