### PR TITLE
feat(attribute-table): add a field calculator (#238)

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -904,7 +904,8 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
 
   const confirmCalculate = () => {
     if (!layer || !calcCanSubmit) return;
-    const targetName = calcMode === "create" ? calcNewName : calcTargetField;
+    const targetName =
+      calcMode === "create" ? calcNewNameTrimmed : calcTargetField;
     const scope =
       calcSelectedOnly && selectedFeatureId
         ? new Set([selectedFeatureId])

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -819,14 +819,15 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     }
     const start = el.selectionStart ?? el.value.length;
     const end = el.selectionEnd ?? el.value.length;
-    setCalcExpression(
-      (current) => current.slice(0, start) + snippet + current.slice(end),
-    );
+    const next = el.value.slice(0, start) + snippet + el.value.slice(end);
+    // Write the DOM value and caret synchronously, then sync React state. Doing
+    // this in a deferred rAF let a rapid second chip click read a stale caret
+    // (still 0) and splice at the wrong offset.
+    el.value = next;
     const caret = start + (caretOffset ?? snippet.length);
-    window.requestAnimationFrame(() => {
-      el.focus();
-      el.setSelectionRange(caret, caret);
-    });
+    el.focus();
+    el.setSelectionRange(caret, caret);
+    setCalcExpression(next);
   };
 
   const calcNewNameTrimmed = calcNewName.trim();
@@ -854,10 +855,11 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
   // Stable string keys so the memo skips recompiling the expression on renders
   // that don't change the inputs (discoveredColumns / the sample row are rebuilt
   // with fresh identities every render, so they can't be deps directly).
-  const calcColumnsKey = JSON.stringify(discoveredColumns);
-  const calcSampleKey = calcSampleRow
-    ? JSON.stringify(calcSampleRow.properties)
-    : "";
+  // Only serialize while the dialog is open — these exist solely as stable memo
+  // deps, and the memo short-circuits to "empty" when closed anyway.
+  const calcColumnsKey = calcOpen ? JSON.stringify(discoveredColumns) : "";
+  const calcSampleKey =
+    calcOpen && calcSampleRow ? JSON.stringify(calcSampleRow.properties) : "";
   const calcPreview = useMemo<
     | { kind: "empty" }
     | { kind: "ok"; value: unknown }
@@ -930,7 +932,7 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
       // null. Keep the dialog open and report it rather than showing a silent
       // success over a column of nulls.
       setCalcError(
-        `Applied with ${result.errors} of ${result.evaluated} feature(s) errored and written as null.`,
+        `Applied, but ${result.errors} of ${result.evaluated} feature(s) errored and were written as null.`,
       );
       return;
     }

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -854,7 +854,7 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
   // Stable string keys so the memo skips recompiling the expression on renders
   // that don't change the inputs (discoveredColumns / the sample row are rebuilt
   // with fresh identities every render, so they can't be deps directly).
-  const calcColumnsKey = discoveredColumns.join(" ");
+  const calcColumnsKey = JSON.stringify(discoveredColumns);
   const calcSampleKey = calcSampleRow
     ? JSON.stringify(calcSampleRow.properties)
     : "";
@@ -925,6 +925,15 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
       return;
     }
     updateLayer(layer.id, result.patch);
+    if (result.errors > 0) {
+      // The calculation was applied, but some rows threw and were written as
+      // null. Keep the dialog open and report it rather than showing a silent
+      // success over a column of nulls.
+      setCalcError(
+        `Applied with ${result.errors} of ${result.evaluated} feature(s) errored and written as null.`,
+      );
+      return;
+    }
     setCalcError(null);
     setCalcOpen(false);
   };

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -26,6 +26,7 @@ import {
   Label,
   ScrollArea,
   Select,
+  Textarea,
   TableBody,
   TableCell,
   TableHead,
@@ -38,6 +39,7 @@ import {
   ArrowLeft,
   ArrowRight,
   ArrowUp,
+  Calculator,
   Columns3,
   Download,
   EyeOff,
@@ -63,6 +65,7 @@ import {
 import { isTauri } from "../../lib/tauri-io";
 import {
   addColumn,
+  calculateField,
   deleteColumn,
   getColumnSettings,
   hiddenColumns,
@@ -74,6 +77,13 @@ import {
   type ColumnMoveDirection,
   type NewColumnType,
 } from "../../lib/attribute-columns";
+import {
+  coerceComputedValue,
+  compileExpression,
+  EXPRESSION_HELPERS,
+  fieldReference,
+  type CalcOutputType,
+} from "../../lib/attribute-expression";
 import {
   exportVectorLayer,
   formatAttributeValue,
@@ -276,6 +286,16 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
   const [newColumnName, setNewColumnName] = useState("");
   const [newColumnType, setNewColumnType] = useState<NewColumnType>("text");
   const [newColumnDefault, setNewColumnDefault] = useState("");
+  // Field-calculator dialog state.
+  const [calcOpen, setCalcOpen] = useState(false);
+  const [calcMode, setCalcMode] = useState<"update" | "create">("update");
+  const [calcTargetField, setCalcTargetField] = useState("");
+  const [calcNewName, setCalcNewName] = useState("");
+  const [calcOutputType, setCalcOutputType] = useState<CalcOutputType>("auto");
+  const [calcExpression, setCalcExpression] = useState("");
+  const [calcSelectedOnly, setCalcSelectedOnly] = useState(false);
+  const [calcError, setCalcError] = useState<string | null>(null);
+  const calcExpressionRef = useRef<HTMLTextAreaElement>(null);
 
   const layer = layers.find((l) => l.id === selectedLayerId);
   const hasLayer = Boolean(layer);
@@ -379,6 +399,10 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     setNewColumnName("");
     setNewColumnType("text");
     setNewColumnDefault("");
+    setCalcOpen(false);
+    setCalcExpression("");
+    setCalcError(null);
+    setCalcSelectedOnly(false);
   }, [selectedLayerId, hasLayer, isGeometryEditing]);
 
   const filterLower = attributeFilter.toLowerCase();
@@ -763,6 +787,127 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     setAddingColumn(false);
   };
 
+  const openCalculator = () => {
+    const hasColumns = discoveredColumns.length > 0;
+    setCalcMode(hasColumns ? "update" : "create");
+    setCalcTargetField(hasColumns ? discoveredColumns[0] : "");
+    setCalcNewName("");
+    setCalcOutputType("auto");
+    setCalcExpression("");
+    setCalcSelectedOnly(false);
+    setCalcError(null);
+    setCalcOpen(true);
+  };
+
+  // Insert a field reference (or function call) into the expression at the
+  // caret, then restore focus so chips can be clicked without losing position.
+  const insertExpressionSnippet = (snippet: string) => {
+    const el = calcExpressionRef.current;
+    if (!el) {
+      setCalcExpression((current) => current + snippet);
+      return;
+    }
+    const start = el.selectionStart ?? el.value.length;
+    const end = el.selectionEnd ?? el.value.length;
+    setCalcExpression(
+      (current) => current.slice(0, start) + snippet + current.slice(end),
+    );
+    const caret = start + snippet.length;
+    window.requestAnimationFrame(() => {
+      el.focus();
+      el.setSelectionRange(caret, caret);
+    });
+  };
+
+  const calcNewNameTrimmed = calcNewName.trim();
+  const calcNameCollides =
+    calcMode === "create" &&
+    calcNewNameTrimmed !== "" &&
+    discoveredColumns.includes(calcNewNameTrimmed);
+  const calcHasTarget =
+    calcMode === "create"
+      ? calcNewNameTrimmed !== "" && !calcNameCollides
+      : calcTargetField !== "";
+  const calcHasSelection = Boolean(selectedFeatureId);
+
+  // Live preview of the expression against a sample feature: the selected row
+  // when present (and a single feature is targeted), else the first row. A
+  // syntax error blocks submission; a runtime error on the sample does not,
+  // since other features may still evaluate cleanly.
+  const calcSampleRow =
+    (calcSelectedOnly && calcHasSelection
+      ? attributeRows.find((row) => row.featureId === selectedFeatureId)
+      : undefined) ?? attributeRows[0];
+  let calcPreview:
+    | { kind: "empty" }
+    | { kind: "ok"; value: unknown }
+    | { kind: "syntax"; message: string }
+    | { kind: "runtime"; message: string } = { kind: "empty" };
+  if (calcOpen && calcExpression.trim() !== "") {
+    try {
+      const compiled = compileExpression(calcExpression, discoveredColumns);
+      if (calcSampleRow) {
+        try {
+          const raw = compiled.evaluate(
+            calcSampleRow.properties,
+            attributeRows.indexOf(calcSampleRow),
+          );
+          calcPreview = {
+            kind: "ok",
+            value: coerceComputedValue(raw, calcOutputType),
+          };
+        } catch (error) {
+          calcPreview = {
+            kind: "runtime",
+            message:
+              error instanceof Error ? error.message : "Evaluation failed.",
+          };
+        }
+      } else {
+        calcPreview = { kind: "ok", value: null };
+      }
+    } catch (error) {
+      calcPreview = {
+        kind: "syntax",
+        message: error instanceof Error ? error.message : "Invalid expression.",
+      };
+    }
+  }
+  const calcCanSubmit =
+    features.length > 0 &&
+    calcHasTarget &&
+    calcExpression.trim() !== "" &&
+    calcPreview.kind !== "syntax";
+
+  const confirmCalculate = () => {
+    if (!layer || !calcCanSubmit) return;
+    const targetName = calcMode === "create" ? calcNewName : calcTargetField;
+    const scope =
+      calcSelectedOnly && selectedFeatureId
+        ? new Set([selectedFeatureId])
+        : undefined;
+    const result = calculateField(
+      layer,
+      discoveredColumns,
+      targetName,
+      calcMode === "create",
+      calcExpression,
+      calcOutputType,
+      scope,
+    );
+    if (!result) {
+      setCalcError("Could not apply the calculation to this layer.");
+      return;
+    }
+    if ("error" in result) {
+      setCalcError(result.error);
+      return;
+    }
+    updateLayer(layer.id, result.patch);
+    setCalcError(null);
+    setCalcOpen(false);
+  };
+
   const sortableHeader = (key: SortKey, label: string) => (
     <div className="relative flex h-full min-h-10 items-center">
       <button
@@ -1014,6 +1159,19 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
           >
             <Plus className="h-3.5 w-3.5" />
             <span className="hidden sm:inline">Add field</span>
+          </Button>
+        ) : null}
+        {canManageColumns && !isEditing ? (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 px-2"
+            title="Calculate field values from an expression"
+            aria-label="Field calculator"
+            onClick={openCalculator}
+          >
+            <Calculator className="h-3.5 w-3.5" />
+            <span className="hidden sm:inline">Calculate</span>
           </Button>
         ) : null}
         {canManageColumns && !isEditing ? (
@@ -1344,6 +1502,167 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
             </Button>
             <Button disabled={!canSubmitNewColumn} onClick={confirmAddColumn}>
               Add field
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+      <Dialog
+        open={calcOpen}
+        onOpenChange={(open: boolean) => {
+          setCalcOpen(open);
+          if (!open) setCalcError(null);
+        }}
+      >
+        <DialogContent className="sm:max-w-xl">
+          <DialogHeader>
+            <DialogTitle>Field calculator</DialogTitle>
+            <DialogDescription>
+              {`Compute values from a JavaScript expression and write them to a field in "${layer?.name ?? ""}".`}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-3 py-1">
+            <div className="grid gap-1.5">
+              <Label htmlFor="calc-target">Target field</Label>
+              <div className="flex gap-2">
+                <Select
+                  id="calc-target-mode"
+                  className="w-40 shrink-0"
+                  value={calcMode}
+                  onChange={(event) =>
+                    setCalcMode(event.target.value as "update" | "create")
+                  }
+                >
+                  <option
+                    value="update"
+                    disabled={discoveredColumns.length === 0}
+                  >
+                    Update field
+                  </option>
+                  <option value="create">Create field</option>
+                </Select>
+                {calcMode === "create" ? (
+                  <Input
+                    id="calc-target"
+                    className="flex-1"
+                    value={calcNewName}
+                    placeholder="New field name"
+                    aria-invalid={calcNameCollides || undefined}
+                    onChange={(event) => setCalcNewName(event.target.value)}
+                  />
+                ) : (
+                  <Select
+                    id="calc-target"
+                    className="flex-1"
+                    value={calcTargetField}
+                    onChange={(event) => setCalcTargetField(event.target.value)}
+                  >
+                    {discoveredColumns.map((col) => (
+                      <option key={col} value={col}>
+                        {col}
+                      </option>
+                    ))}
+                  </Select>
+                )}
+              </div>
+              {calcNameCollides ? (
+                <span className="text-xs text-destructive">
+                  A field named "{calcNewNameTrimmed}" already exists.
+                </span>
+              ) : null}
+            </div>
+            <div className="grid gap-1.5">
+              <Label htmlFor="calc-output-type">Output type</Label>
+              <Select
+                id="calc-output-type"
+                value={calcOutputType}
+                onChange={(event) =>
+                  setCalcOutputType(event.target.value as CalcOutputType)
+                }
+              >
+                <option value="auto">Auto (keep computed type)</option>
+                <option value="text">Text</option>
+                <option value="number">Number</option>
+                <option value="boolean">Boolean</option>
+              </Select>
+            </div>
+            <div className="grid gap-1.5">
+              <Label htmlFor="calc-expression">Expression</Label>
+              <Textarea
+                id="calc-expression"
+                ref={calcExpressionRef}
+                className="min-h-20 font-mono text-xs"
+                value={calcExpression}
+                placeholder='e.g. pop / area, or upper(name), or pop > 100 ? "big" : "small"'
+                onChange={(event) => setCalcExpression(event.target.value)}
+              />
+              {discoveredColumns.length > 0 ? (
+                <div className="flex flex-wrap items-center gap-1">
+                  <span className="text-xs text-muted-foreground">Fields:</span>
+                  {discoveredColumns.map((col) => (
+                    <button
+                      key={col}
+                      type="button"
+                      className="rounded border border-input bg-muted/40 px-1.5 py-0.5 font-mono text-[11px] hover:bg-muted"
+                      title={`Insert ${col}`}
+                      onClick={() => insertExpressionSnippet(fieldReference(col))}
+                    >
+                      {col}
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+              <div className="flex flex-wrap items-center gap-1">
+                <span className="text-xs text-muted-foreground">
+                  Functions:
+                </span>
+                {Object.keys(EXPRESSION_HELPERS).map((fn) => (
+                  <button
+                    key={fn}
+                    type="button"
+                    className="rounded border border-input bg-muted/40 px-1.5 py-0.5 font-mono text-[11px] hover:bg-muted"
+                    title={`Insert ${fn}()`}
+                    onClick={() => insertExpressionSnippet(`${fn}()`)}
+                  >
+                    {fn}
+                  </button>
+                ))}
+              </div>
+            </div>
+            {calcPreview.kind === "syntax" ? (
+              <span className="text-xs text-destructive">
+                {calcPreview.message}
+              </span>
+            ) : calcPreview.kind === "runtime" ? (
+              <span className="text-xs text-amber-600 dark:text-amber-500">
+                {`Sample row errored (other rows may still compute): ${calcPreview.message}`}
+              </span>
+            ) : calcPreview.kind === "ok" ? (
+              <span className="truncate text-xs text-muted-foreground">
+                Preview:{" "}
+                <span className="font-mono text-foreground">
+                  {formatAttributeValue(calcPreview.value)}
+                </span>
+              </span>
+            ) : null}
+            <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <input
+                type="checkbox"
+                checked={calcSelectedOnly}
+                disabled={!calcHasSelection}
+                onChange={(event) => setCalcSelectedOnly(event.target.checked)}
+              />
+              Only update the selected feature
+            </label>
+            {calcError ? (
+              <span className="text-xs text-destructive">{calcError}</span>
+            ) : null}
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" onClick={() => setCalcOpen(false)}>
+              Cancel
+            </Button>
+            <Button disabled={!calcCanSubmit} onClick={confirmCalculate}>
+              Calculate
             </Button>
           </div>
         </DialogContent>

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -58,6 +58,7 @@ import {
   type MouseEvent as ReactMouseEvent,
   type RefObject,
   useEffect,
+  useMemo,
   useRef,
   useState,
   useSyncExternalStore,
@@ -404,6 +405,13 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     setCalcError(null);
     setCalcSelectedOnly(false);
   }, [selectedLayerId, hasLayer, isGeometryEditing]);
+
+  // If the selected feature is cleared while the calculator is open, drop the
+  // "selected only" flag too: leaving it checked-but-disabled would mislead the
+  // user, and the submit guard would silently widen the scope to all features.
+  useEffect(() => {
+    if (!selectedFeatureId) setCalcSelectedOnly(false);
+  }, [selectedFeatureId]);
 
   const filterLower = attributeFilter.toLowerCase();
   const filtered = attributeRows.filter(({ properties, featureId }) => {
@@ -801,7 +809,9 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
 
   // Insert a field reference (or function call) into the expression at the
   // caret, then restore focus so chips can be clicked without losing position.
-  const insertExpressionSnippet = (snippet: string) => {
+  // `caretOffset` overrides where the caret lands relative to the inserted text
+  // (default: at its end) — function chips use it to land inside the parens.
+  const insertExpressionSnippet = (snippet: string, caretOffset?: number) => {
     const el = calcExpressionRef.current;
     if (!el) {
       setCalcExpression((current) => current + snippet);
@@ -812,7 +822,7 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     setCalcExpression(
       (current) => current.slice(0, start) + snippet + current.slice(end),
     );
-    const caret = start + snippet.length;
+    const caret = start + (caretOffset ?? snippet.length);
     window.requestAnimationFrame(() => {
       el.focus();
       el.setSelectionRange(caret, caret);
@@ -838,41 +848,52 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     (calcSelectedOnly && calcHasSelection
       ? attributeRows.find((row) => row.featureId === selectedFeatureId)
       : undefined) ?? attributeRows[0];
-  let calcPreview:
+  const calcSampleIndex = calcSampleRow
+    ? attributeRows.indexOf(calcSampleRow)
+    : -1;
+  // Stable string keys so the memo skips recompiling the expression on renders
+  // that don't change the inputs (discoveredColumns / the sample row are rebuilt
+  // with fresh identities every render, so they can't be deps directly).
+  const calcColumnsKey = discoveredColumns.join(" ");
+  const calcSampleKey = calcSampleRow
+    ? JSON.stringify(calcSampleRow.properties)
+    : "";
+  const calcPreview = useMemo<
     | { kind: "empty" }
     | { kind: "ok"; value: unknown }
     | { kind: "syntax"; message: string }
-    | { kind: "runtime"; message: string } = { kind: "empty" };
-  if (calcOpen && calcExpression.trim() !== "") {
+    | { kind: "runtime"; message: string }
+  >(() => {
+    if (!calcOpen || calcExpression.trim() === "") return { kind: "empty" };
     try {
       const compiled = compileExpression(calcExpression, discoveredColumns);
-      if (calcSampleRow) {
-        try {
-          const raw = compiled.evaluate(
-            calcSampleRow.properties,
-            attributeRows.indexOf(calcSampleRow),
-          );
-          calcPreview = {
-            kind: "ok",
-            value: coerceComputedValue(raw, calcOutputType),
-          };
-        } catch (error) {
-          calcPreview = {
-            kind: "runtime",
-            message:
-              error instanceof Error ? error.message : "Evaluation failed.",
-          };
-        }
-      } else {
-        calcPreview = { kind: "ok", value: null };
+      if (!calcSampleRow) return { kind: "ok", value: null };
+      try {
+        const raw = compiled.evaluate(calcSampleRow.properties, calcSampleIndex);
+        return { kind: "ok", value: coerceComputedValue(raw, calcOutputType) };
+      } catch (error) {
+        return {
+          kind: "runtime",
+          message:
+            error instanceof Error ? error.message : "Evaluation failed.",
+        };
       }
     } catch (error) {
-      calcPreview = {
+      return {
         kind: "syntax",
         message: error instanceof Error ? error.message : "Invalid expression.",
       };
     }
-  }
+    // Keyed on the stable strings above rather than the rebuilt arrays/objects.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    calcOpen,
+    calcExpression,
+    calcOutputType,
+    calcColumnsKey,
+    calcSampleKey,
+    calcSampleIndex,
+  ]);
   const calcCanSubmit =
     features.length > 0 &&
     calcHasTarget &&
@@ -1621,7 +1642,11 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
                     type="button"
                     className="rounded border border-input bg-muted/40 px-1.5 py-0.5 font-mono text-[11px] hover:bg-muted"
                     title={`Insert ${fn}()`}
-                    onClick={() => insertExpressionSnippet(`${fn}()`)}
+                    onClick={() =>
+                      // Land the caret between the parens so the user can type
+                      // the argument straight away.
+                      insertExpressionSnippet(`${fn}()`, fn.length + 1)
+                    }
                   >
                     {fn}
                   </button>

--- a/apps/geolibre-desktop/src/lib/attribute-columns.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-columns.ts
@@ -4,6 +4,11 @@ import {
   type LayerStyle,
 } from "@geolibre/core";
 import type { FeatureCollection } from "geojson";
+import {
+  coerceComputedValue,
+  compileExpression,
+  type CalcOutputType,
+} from "./attribute-expression";
 
 /**
  * Per-layer attribute-table column settings, persisted under
@@ -281,6 +286,106 @@ export function addColumn(
     geojson: addFieldInGeojson(layer.geojson, name, value),
     metadata: metadataWithSettings(layer, appendKeyToOrder(settings, name)),
   };
+}
+
+/** The id the attribute table uses for a feature: its own id, else its index. */
+function featureKey(
+  feature: FeatureCollection["features"][number],
+  index: number,
+): string {
+  return String(feature.id ?? index);
+}
+
+/** Outcome of a field calculation: a layer patch plus per-run statistics. */
+export interface FieldCalculationResult {
+  patch: Partial<GeoLibreLayer>;
+  /** How many features had the expression evaluated against them. */
+  evaluated: number;
+  /** How many of those threw at runtime and were written as null instead. */
+  errors: number;
+}
+
+/**
+ * Compute a field's values from a JavaScript expression and return a layer patch
+ * that writes them into the GeoJSON. The target is either an existing field or a
+ * new one (`createField: true`), and values can be limited to a subset of
+ * features (`targetFeatureIds`) — e.g. only the selected row.
+ *
+ * A SyntaxError from the expression compiler is returned as a string in
+ * `{ error }` so the caller can surface it without mutating the layer. Features
+ * whose expression throws at runtime keep a null value and are counted in
+ * `errors`. When creating a field while scoped to a subset, out-of-scope
+ * features still receive the field (as null) so the column is consistent.
+ *
+ * Returns null (no-op) when the layer has no in-store GeoJSON or no features,
+ * when a new field's name is empty or collides, or when an existing target is
+ * absent.
+ */
+export function calculateField(
+  layer: GeoLibreLayer,
+  discovered: string[],
+  rawTargetName: string,
+  createField: boolean,
+  expression: string,
+  outputType: CalcOutputType,
+  targetFeatureIds?: ReadonlySet<string>,
+): FieldCalculationResult | { error: string } | null {
+  if (!layer.geojson || layer.geojson.features.length === 0) return null;
+
+  const target = rawTargetName.trim();
+  if (!target) return null;
+  if (createField && discovered.includes(target)) return null; // would clobber
+  if (!createField && !discovered.includes(target)) return null; // nothing to set
+
+  let compiled;
+  try {
+    compiled = compileExpression(expression, discovered);
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error.message : "Invalid expression.",
+    };
+  }
+
+  const scoped = targetFeatureIds ?? null;
+  let evaluated = 0;
+  let errors = 0;
+
+  const features = layer.geojson.features.map((feature, index) => {
+    const inScope =
+      scoped === null || scoped.has(featureKey(feature, index));
+    if (!inScope) {
+      // Out-of-scope feature on a new field: seed null so the column exists for
+      // every feature. An existing field is left exactly as it was.
+      if (!createField) return feature;
+      return {
+        ...feature,
+        properties: { ...(feature.properties ?? {}), [target]: null },
+      };
+    }
+
+    const props = (feature.properties ?? {}) as Record<string, unknown>;
+    let value: unknown;
+    try {
+      value = coerceComputedValue(compiled.evaluate(props, index), outputType);
+      evaluated += 1;
+    } catch {
+      value = null;
+      evaluated += 1;
+      errors += 1;
+    }
+    return { ...feature, properties: { ...props, [target]: value } };
+  });
+
+  const geojson: FeatureCollection = { ...layer.geojson, features };
+  const settings = getColumnSettings(layer);
+  const patch: Partial<GeoLibreLayer> = createField
+    ? {
+        geojson,
+        metadata: metadataWithSettings(layer, appendKeyToOrder(settings, target)),
+      }
+    : { geojson };
+
+  return { patch, evaluated, errors };
 }
 
 /**

--- a/apps/geolibre-desktop/src/lib/attribute-expression.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-expression.ts
@@ -105,13 +105,34 @@ const RESERVED_NAMES = new Set<string>([
 
 const IDENTIFIER_RE = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
 
+// ECMAScript keywords (plus the strict-mode future-reserved words and the
+// strict-mode-restricted `eval`/`arguments`) are illegal as `new Function`
+// parameter names. A field whose name matches one — `class` and `type`-style
+// names are common in OSM data — must fall back to the `props["name"]` path,
+// otherwise compiling ANY expression for that layer throws a SyntaxError.
+const JS_KEYWORDS = new Set([
+  "break", "case", "catch", "class", "const", "continue", "debugger",
+  "default", "delete", "do", "else", "export", "extends", "false", "finally",
+  "for", "function", "if", "import", "in", "instanceof", "new", "null",
+  "return", "super", "switch", "this", "throw", "true", "try", "typeof",
+  "var", "void", "while", "with", "yield",
+  // strict-mode future-reserved words and restricted names
+  "let", "static", "implements", "interface", "package", "private",
+  "protected", "public", "eval", "arguments",
+]);
+
 /**
  * Whether a field name can be exposed as a bare identifier in an expression.
- * Names that collide with a helper/constant fall back to `props["name"]` access
- * so the helper is never shadowed.
+ * Names that collide with a helper/constant, or with a JavaScript keyword that
+ * cannot be a function parameter, fall back to `props["name"]` access — so
+ * neither a helper is shadowed nor the parser is broken.
  */
 export function isBareIdentifier(name: string): boolean {
-  return IDENTIFIER_RE.test(name) && !RESERVED_NAMES.has(name);
+  return (
+    IDENTIFIER_RE.test(name) &&
+    !RESERVED_NAMES.has(name) &&
+    !JS_KEYWORDS.has(name)
+  );
 }
 
 /**

--- a/apps/geolibre-desktop/src/lib/attribute-expression.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-expression.ts
@@ -65,14 +65,23 @@ export const EXPRESSION_HELPERS: Record<string, Helper> = {
   trim: (x) => (x == null ? "" : String(x).trim()),
   length: (x) => (x == null ? 0 : String(x).length),
   concat: (...args) => args.map((a) => (a == null ? "" : String(a))).join(""),
+  // (start, length) with slice semantics, so a negative start counts from the
+  // end (`substr("hello", -3)` → "llo"), matching QGIS / Python / JS slice.
   substr: (x, start, len) => {
     const str = x == null ? "" : String(x);
     const from = Math.trunc(toNumber(start)) || 0;
-    if (len == null) return str.substring(from);
-    return str.substring(from, from + (Math.trunc(toNumber(len)) || 0));
+    if (len == null) return str.slice(from);
+    return str.slice(from, from + (Math.trunc(toNumber(len)) || 0));
   },
-  replace: (x, search, replacement) =>
-    (x == null ? "" : String(x)).split(String(search)).join(String(replacement)),
+  // A null/undefined search is a no-op (returns the input); a null replacement
+  // is treated as the empty string — both avoid coercing to "null"/"undefined".
+  replace: (x, search, replacement) => {
+    const str = x == null ? "" : String(x);
+    if (search == null) return str;
+    return str
+      .split(String(search))
+      .join(replacement == null ? "" : String(replacement));
+  },
   // Logic
   isNull: (x) => isNullish(x),
   // First argument that is neither null nor NaN; null when all are nullish.

--- a/apps/geolibre-desktop/src/lib/attribute-expression.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-expression.ts
@@ -191,8 +191,11 @@ export function compileExpression(
 
   let fn: (...args: unknown[]) => unknown;
   try {
-    // "use strict" disables `with` and silent global creation; the expression
-    // only sees the named arguments we pass in.
+    // "use strict" disables `with` and silent global creation; the named
+    // arguments shadow the field/helper names. It does NOT sandbox: browser
+    // globals (fetch, window, …) stay reachable — see the file-level note. Safe
+    // here only because calculations run immediately and the expression itself
+    // is never persisted or re-evaluated from a project file.
     // eslint-disable-next-line @typescript-eslint/no-implied-eval
     fn = new Function(
       ...argNames,
@@ -248,8 +251,15 @@ export function coerceComputedValue(
   if (type === "boolean") {
     if (typeof value === "boolean") return value;
     const normalized = String(value).trim().toLowerCase();
-    if (normalized === "true") return true;
-    if (normalized === "false") return false;
+    // Recognize the common string spellings so "0"/"no" don't become true via
+    // JS truthiness (every non-empty string is truthy) — surprising to users
+    // coming from SQL / QGIS / pandas.
+    if (normalized === "true" || normalized === "1" || normalized === "yes") {
+      return true;
+    }
+    if (normalized === "false" || normalized === "0" || normalized === "no") {
+      return false;
+    }
     return Boolean(value);
   }
   // text

--- a/apps/geolibre-desktop/src/lib/attribute-expression.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-expression.ts
@@ -1,0 +1,227 @@
+/**
+ * A small, self-contained expression evaluator for the attribute-table Field
+ * Calculator. Expressions are plain JavaScript so familiar arithmetic, string,
+ * and ternary syntax all work (e.g. `pop / area`, `upper(name)`,
+ * `pop > 100 ? "big" : "small"`). They run on the user's own data in the local
+ * webview — analogous to a spreadsheet formula bar — so the evaluator favors
+ * ergonomics over a hardened sandbox. It is NOT a security boundary; it must
+ * never be used to run expressions from an untrusted source.
+ *
+ * Field values are exposed two ways:
+ *  - as bare identifiers when the field name is a valid JS identifier (`pop`),
+ *  - always through the `props` object so fields with spaces/punctuation are
+ *    reachable as `props["my field"]`.
+ * A curated set of helper functions and the `$index` (row position) variable
+ * are also in scope.
+ */
+
+/** A helper exposed to expressions by name. */
+type Helper = (...args: unknown[]) => unknown;
+
+function toNumber(value: unknown): number {
+  if (value == null || value === "") return Number.NaN;
+  const next = Number(value);
+  return next;
+}
+
+function isNullish(value: unknown): boolean {
+  return value == null || (typeof value === "number" && Number.isNaN(value));
+}
+
+/**
+ * Helper functions available inside an expression. Kept small and GIS-flavored;
+ * arithmetic/comparison/ternary come for free from JavaScript itself.
+ */
+export const EXPRESSION_HELPERS: Record<string, Helper> = {
+  // Math
+  abs: (x) => Math.abs(toNumber(x)),
+  ceil: (x) => Math.ceil(toNumber(x)),
+  floor: (x) => Math.floor(toNumber(x)),
+  sqrt: (x) => Math.sqrt(toNumber(x)),
+  exp: (x) => Math.exp(toNumber(x)),
+  ln: (x) => Math.log(toNumber(x)),
+  log10: (x) => Math.log10(toNumber(x)),
+  pow: (x, y) => Math.pow(toNumber(x), toNumber(y)),
+  min: (...args) => Math.min(...args.map(toNumber)),
+  max: (...args) => Math.max(...args.map(toNumber)),
+  // round(x) → nearest integer; round(x, n) → n decimal places.
+  round: (x, digits) => {
+    const value = toNumber(x);
+    const places = digits == null ? 0 : Math.trunc(toNumber(digits));
+    if (!Number.isFinite(value) || !Number.isFinite(places)) return value;
+    const factor = 10 ** places;
+    return Math.round(value * factor) / factor;
+  },
+  // Conversion
+  toNumber: (x) => {
+    const next = toNumber(x);
+    return Number.isNaN(next) ? null : next;
+  },
+  // Param annotated because `toString` collides with Object.prototype's own
+  // signature, which would otherwise win the contextual type over Helper.
+  toString: (x: unknown) => (x == null ? "" : String(x)),
+  // String
+  upper: (x) => (x == null ? "" : String(x).toUpperCase()),
+  lower: (x) => (x == null ? "" : String(x).toLowerCase()),
+  trim: (x) => (x == null ? "" : String(x).trim()),
+  length: (x) => (x == null ? 0 : String(x).length),
+  concat: (...args) => args.map((a) => (a == null ? "" : String(a))).join(""),
+  substr: (x, start, len) => {
+    const str = x == null ? "" : String(x);
+    const from = Math.trunc(toNumber(start)) || 0;
+    if (len == null) return str.substring(from);
+    return str.substring(from, from + (Math.trunc(toNumber(len)) || 0));
+  },
+  replace: (x, search, replacement) =>
+    (x == null ? "" : String(x)).split(String(search)).join(String(replacement)),
+  // Logic
+  isNull: (x) => isNullish(x),
+  // First argument that is neither null nor NaN; null when all are nullish.
+  coalesce: (...args) => {
+    for (const arg of args) {
+      if (!isNullish(arg)) return arg;
+    }
+    return null;
+  },
+  // iif(condition, thenValue, elseValue) — `if` is a reserved word in JS, so it
+  // cannot be a bare identifier; ternaries (`cond ? a : b`) also work directly.
+  iif: (condition, thenValue, elseValue) =>
+    condition ? thenValue : elseValue,
+};
+
+/** Math constants exposed as bare identifiers. */
+const EXPRESSION_CONSTANTS: Record<string, number> = {
+  PI: Math.PI,
+  E: Math.E,
+};
+
+/** Names that are always in scope and therefore cannot be used as field idents. */
+const RESERVED_NAMES = new Set<string>([
+  ...Object.keys(EXPRESSION_HELPERS),
+  ...Object.keys(EXPRESSION_CONSTANTS),
+  "props",
+  "$index",
+]);
+
+const IDENTIFIER_RE = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+/**
+ * Whether a field name can be exposed as a bare identifier in an expression.
+ * Names that collide with a helper/constant fall back to `props["name"]` access
+ * so the helper is never shadowed.
+ */
+export function isBareIdentifier(name: string): boolean {
+  return IDENTIFIER_RE.test(name) && !RESERVED_NAMES.has(name);
+}
+
+/**
+ * The snippet that references a field inside an expression: the bare name when
+ * it is a safe identifier, otherwise a quoted `props[...]` lookup.
+ */
+export function fieldReference(name: string): string {
+  return isBareIdentifier(name) ? name : `props[${JSON.stringify(name)}]`;
+}
+
+/** A compiled expression ready to run against each feature's properties. */
+export interface CompiledExpression {
+  evaluate: (props: Record<string, unknown>, index: number) => unknown;
+}
+
+/**
+ * Compile an expression once for a known set of field names. Throws a
+ * SyntaxError (with a readable message) when the expression cannot be parsed, so
+ * callers can surface the problem before touching any feature.
+ */
+export function compileExpression(
+  expression: string,
+  fieldNames: string[],
+): CompiledExpression {
+  const trimmed = expression.trim();
+  if (trimmed === "") {
+    throw new SyntaxError("Expression is empty.");
+  }
+
+  const bareFields = fieldNames.filter(isBareIdentifier);
+  const helperNames = Object.keys(EXPRESSION_HELPERS);
+  const constantNames = Object.keys(EXPRESSION_CONSTANTS);
+  const argNames = [
+    ...bareFields,
+    ...helperNames,
+    ...constantNames,
+    "props",
+    "$index",
+  ];
+
+  let fn: (...args: unknown[]) => unknown;
+  try {
+    // "use strict" disables `with` and silent global creation; the expression
+    // only sees the named arguments we pass in.
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval
+    fn = new Function(
+      ...argNames,
+      `"use strict"; return (${trimmed});`,
+    ) as (...args: unknown[]) => unknown;
+  } catch (error) {
+    throw new SyntaxError(
+      error instanceof Error ? error.message : "Invalid expression.",
+    );
+  }
+
+  const helperValues = helperNames.map((name) => EXPRESSION_HELPERS[name]);
+  const constantValues = constantNames.map((name) => EXPRESSION_CONSTANTS[name]);
+
+  return {
+    evaluate(props, index) {
+      const fieldValues = bareFields.map((name) => props[name]);
+      return fn(
+        ...fieldValues,
+        ...helperValues,
+        ...constantValues,
+        props,
+        index,
+      );
+    },
+  };
+}
+
+/** Output type for a calculated field. `auto` keeps the raw computed value. */
+export type CalcOutputType = "auto" | "text" | "number" | "boolean";
+
+/**
+ * Coerce a computed value to the chosen output type. `auto` passes the raw value
+ * through (numbers stay numbers, strings stay strings). A value that cannot be
+ * represented in the target type — a non-finite number, an unparseable text →
+ * number — becomes null so a calculation never persists a type-corrupted cell.
+ */
+export function coerceComputedValue(
+  value: unknown,
+  type: CalcOutputType,
+): unknown {
+  if (value === undefined) return null;
+  if (type === "auto") {
+    // Normalize the JS "no result" values to null for a clean cell.
+    if (typeof value === "number" && !Number.isFinite(value)) return null;
+    return value;
+  }
+  if (value === null) return null;
+  if (type === "number") {
+    const next = Number(value);
+    return Number.isFinite(next) ? next : null;
+  }
+  if (type === "boolean") {
+    if (typeof value === "boolean") return value;
+    const normalized = String(value).trim().toLowerCase();
+    if (normalized === "true") return true;
+    if (normalized === "false") return false;
+    return Boolean(value);
+  }
+  // text
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
+}

--- a/apps/geolibre-desktop/src/lib/attribute-expression.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-expression.ts
@@ -20,8 +20,7 @@ type Helper = (...args: unknown[]) => unknown;
 
 function toNumber(value: unknown): number {
   if (value == null || value === "") return Number.NaN;
-  const next = Number(value);
-  return next;
+  return Number(value);
 }
 
 function isNullish(value: unknown): boolean {
@@ -85,6 +84,9 @@ export const EXPRESSION_HELPERS: Record<string, Helper> = {
   },
   // iif(condition, thenValue, elseValue) — `if` is a reserved word in JS, so it
   // cannot be a bare identifier; ternaries (`cond ? a : b`) also work directly.
+  // Note: unlike SQL CASE or a ternary, all three arguments are evaluated before
+  // iif() runs — use a ternary when a branch may throw (e.g. null-property
+  // access: `obj != null ? obj.child : "default"`).
   iif: (condition, thenValue, elseValue) =>
     condition ? thenValue : elseValue,
 };
@@ -119,6 +121,11 @@ const JS_KEYWORDS = new Set([
   // strict-mode future-reserved words and restricted names
   "let", "static", "implements", "interface", "package", "private",
   "protected", "public", "eval", "arguments",
+  // future-reserved in all modes
+  "enum",
+  // global constants — not reserved words, but as bare params they would
+  // silently shadow the JS globals (e.g. a field named `NaN`).
+  "undefined", "NaN", "Infinity",
 ]);
 
 /**

--- a/packages/ui/src/components/textarea.tsx
+++ b/packages/ui/src/components/textarea.tsx
@@ -7,7 +7,7 @@ export const Textarea = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <textarea
     className={cn(
-      "flex min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-colors placeholder:text-muted-foreground focus-visible:border-2 focus-visible:border-ring focus-visible:outline-none focus-visible:ring-0 disabled:cursor-not-allowed disabled:opacity-50",
+      "flex min-h-16 w-full resize-y rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-colors placeholder:text-muted-foreground focus-visible:border-2 focus-visible:border-ring focus-visible:outline-none focus-visible:ring-0 disabled:cursor-not-allowed disabled:opacity-50",
       className,
     )}
     ref={ref}

--- a/packages/ui/src/components/textarea.tsx
+++ b/packages/ui/src/components/textarea.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { cn } from "../lib/utils";
+
+export const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
+>(({ className, ...props }, ref) => (
+  <textarea
+    className={cn(
+      "flex min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-colors placeholder:text-muted-foreground focus-visible:border-2 focus-visible:border-ring focus-visible:outline-none focus-visible:ring-0 disabled:cursor-not-allowed disabled:opacity-50",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+));
+Textarea.displayName = "Textarea";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,6 +1,7 @@
 export { cn } from "./lib/utils";
 export { Button, type ButtonProps } from "./components/button";
 export { Input } from "./components/input";
+export { Textarea } from "./components/textarea";
 export { Select } from "./components/select";
 export { Label } from "./components/label";
 export { Slider } from "./components/slider";

--- a/tests/attribute-calculator.test.ts
+++ b/tests/attribute-calculator.test.ts
@@ -68,6 +68,22 @@ describe("expression compilation", () => {
     );
   });
 
+  it("handles null-ish args in string helpers without coercing to 'null'", () => {
+    // replace: a null search is a no-op; a null replacement is the empty string.
+    assert.equal(
+      compileExpression('replace("a null b", x, "X")', ["x"]).evaluate(
+        { x: null },
+        0,
+      ),
+      "a null b",
+    );
+    // substr uses slice semantics: a negative start counts from the end.
+    assert.equal(
+      compileExpression('substr("hello", -3)', []).evaluate({}, 0),
+      "llo",
+    );
+  });
+
   it("reaches non-identifier fields through props", () => {
     const compiled = compileExpression('props["my field"] + 1', ["my field"]);
     assert.equal(compiled.evaluate({ "my field": 41 }, 0), 42);
@@ -97,7 +113,9 @@ describe("identifier helpers", () => {
     assert.equal(isBareIdentifier("class"), false); // JS keyword
     assert.equal(isBareIdentifier("let"), false); // strict-mode reserved
     assert.equal(isBareIdentifier("enum"), false); // reserved in all modes
+    assert.equal(isBareIdentifier("undefined"), false); // global constant
     assert.equal(isBareIdentifier("NaN"), false); // global constant
+    assert.equal(isBareIdentifier("Infinity"), false); // global constant
     assert.equal(fieldReference("pop"), "pop");
     assert.equal(fieldReference("my field"), 'props["my field"]');
     assert.equal(fieldReference("class"), 'props["class"]');

--- a/tests/attribute-calculator.test.ts
+++ b/tests/attribute-calculator.test.ts
@@ -136,6 +136,15 @@ describe("output coercion", () => {
     assert.equal(coerceComputedValue(1, "text"), "1");
     assert.equal(coerceComputedValue("true", "boolean"), true);
     assert.equal(coerceComputedValue("false", "boolean"), false);
+    // String spellings of 0/1 and yes/no are recognized rather than falling
+    // through to JS truthiness (where every non-empty string would be true).
+    assert.equal(coerceComputedValue("1", "boolean"), true);
+    assert.equal(coerceComputedValue("0", "boolean"), false);
+    assert.equal(coerceComputedValue("yes", "boolean"), true);
+    assert.equal(coerceComputedValue("no", "boolean"), false);
+    // Actual numbers use JS truthiness, which is already correct.
+    assert.equal(coerceComputedValue(1, "boolean"), true);
+    assert.equal(coerceComputedValue(0, "boolean"), false);
   });
 });
 

--- a/tests/attribute-calculator.test.ts
+++ b/tests/attribute-calculator.test.ts
@@ -96,6 +96,8 @@ describe("identifier helpers", () => {
     assert.equal(isBareIdentifier("round"), false); // collides with a helper
     assert.equal(isBareIdentifier("class"), false); // JS keyword
     assert.equal(isBareIdentifier("let"), false); // strict-mode reserved
+    assert.equal(isBareIdentifier("enum"), false); // reserved in all modes
+    assert.equal(isBareIdentifier("NaN"), false); // global constant
     assert.equal(fieldReference("pop"), "pop");
     assert.equal(fieldReference("my field"), 'props["my field"]');
     assert.equal(fieldReference("class"), 'props["class"]');

--- a/tests/attribute-calculator.test.ts
+++ b/tests/attribute-calculator.test.ts
@@ -73,6 +73,16 @@ describe("expression compilation", () => {
     assert.equal(compiled.evaluate({ "my field": 41 }, 0), 42);
   });
 
+  it("compiles when a field name is a JS keyword (e.g. OSM 'class')", () => {
+    // `class` is a reserved word and cannot be a `new Function` parameter, so it
+    // must be reachable only via props — compiling must not throw.
+    const compiled = compileExpression('props["class"]', ["class", "name"]);
+    assert.equal(compiled.evaluate({ class: "road", name: "x" }, 0), "road");
+    assert.doesNotThrow(() =>
+      compileExpression("name", ["class", "let", "name"]),
+    );
+  });
+
   it("throws a SyntaxError for an unparseable or empty expression", () => {
     assert.throws(() => compileExpression("pop +", DISCOVERED), SyntaxError);
     assert.throws(() => compileExpression("   ", DISCOVERED), SyntaxError);
@@ -84,8 +94,11 @@ describe("identifier helpers", () => {
     assert.equal(isBareIdentifier("pop"), true);
     assert.equal(isBareIdentifier("my field"), false);
     assert.equal(isBareIdentifier("round"), false); // collides with a helper
+    assert.equal(isBareIdentifier("class"), false); // JS keyword
+    assert.equal(isBareIdentifier("let"), false); // strict-mode reserved
     assert.equal(fieldReference("pop"), "pop");
     assert.equal(fieldReference("my field"), 'props["my field"]');
+    assert.equal(fieldReference("class"), 'props["class"]');
   });
 });
 

--- a/tests/attribute-calculator.test.ts
+++ b/tests/attribute-calculator.test.ts
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { DEFAULT_LAYER_STYLE, type GeoLibreLayer } from "@geolibre/core";
+import type { FeatureCollection } from "geojson";
+import { calculateField } from "../apps/geolibre-desktop/src/lib/attribute-columns";
+import {
+  coerceComputedValue,
+  compileExpression,
+  fieldReference,
+  isBareIdentifier,
+} from "../apps/geolibre-desktop/src/lib/attribute-expression";
+
+function fc(features: FeatureCollection["features"]): FeatureCollection {
+  return { type: "FeatureCollection", features };
+}
+
+function makeLayer(patch: Partial<GeoLibreLayer> = {}): GeoLibreLayer {
+  return {
+    id: "layer-1",
+    name: "Test",
+    type: "geojson",
+    source: { type: "geojson" },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {},
+    geojson: fc([
+      {
+        type: "Feature",
+        id: "f0",
+        geometry: { type: "Point", coordinates: [0, 0] },
+        properties: { name: "A", pop: 10, area: 5 },
+      },
+      {
+        type: "Feature",
+        id: "f1",
+        geometry: { type: "Point", coordinates: [1, 1] },
+        properties: { name: "B", pop: 20, area: 8 },
+      },
+    ]),
+    ...patch,
+  };
+}
+
+const DISCOVERED = ["name", "pop", "area"];
+
+describe("expression compilation", () => {
+  it("evaluates arithmetic over field identifiers", () => {
+    const compiled = compileExpression("pop / area", DISCOVERED);
+    assert.equal(compiled.evaluate({ pop: 10, area: 5 }, 0), 2);
+  });
+
+  it("exposes helper functions and the $index variable", () => {
+    assert.equal(
+      compileExpression("upper(name)", DISCOVERED).evaluate({ name: "abc" }, 0),
+      "ABC",
+    );
+    assert.equal(
+      compileExpression("round(pop / area, 2)", DISCOVERED).evaluate(
+        { pop: 10, area: 3 },
+        0,
+      ),
+      3.33,
+    );
+    assert.equal(
+      compileExpression("$index", DISCOVERED).evaluate({}, 7),
+      7,
+    );
+  });
+
+  it("reaches non-identifier fields through props", () => {
+    const compiled = compileExpression('props["my field"] + 1', ["my field"]);
+    assert.equal(compiled.evaluate({ "my field": 41 }, 0), 42);
+  });
+
+  it("throws a SyntaxError for an unparseable or empty expression", () => {
+    assert.throws(() => compileExpression("pop +", DISCOVERED), SyntaxError);
+    assert.throws(() => compileExpression("   ", DISCOVERED), SyntaxError);
+  });
+});
+
+describe("identifier helpers", () => {
+  it("treats valid, non-reserved names as bare identifiers", () => {
+    assert.equal(isBareIdentifier("pop"), true);
+    assert.equal(isBareIdentifier("my field"), false);
+    assert.equal(isBareIdentifier("round"), false); // collides with a helper
+    assert.equal(fieldReference("pop"), "pop");
+    assert.equal(fieldReference("my field"), 'props["my field"]');
+  });
+});
+
+describe("output coercion", () => {
+  it("keeps the raw value under auto and normalizes non-finite numbers", () => {
+    assert.equal(coerceComputedValue(3.5, "auto"), 3.5);
+    assert.equal(coerceComputedValue("x", "auto"), "x");
+    assert.equal(coerceComputedValue(Number.NaN, "auto"), null);
+    assert.equal(coerceComputedValue(undefined, "auto"), null);
+  });
+
+  it("coerces to the requested type, nulling unrepresentable values", () => {
+    assert.equal(coerceComputedValue("7", "number"), 7);
+    assert.equal(coerceComputedValue("nope", "number"), null);
+    assert.equal(coerceComputedValue(1, "text"), "1");
+    assert.equal(coerceComputedValue("true", "boolean"), true);
+    assert.equal(coerceComputedValue("false", "boolean"), false);
+  });
+});
+
+describe("calculateField", () => {
+  it("creates a new field from an expression for every feature", () => {
+    const result = calculateField(
+      makeLayer(),
+      DISCOVERED,
+      "density",
+      true,
+      "pop / area",
+      "number",
+    );
+    assert.ok(result && "patch" in result);
+    assert.equal(result.evaluated, 2);
+    assert.equal(result.errors, 0);
+    const props = result.patch.geojson?.features.map((f) => f.properties);
+    assert.equal(props?.[0]?.density, 2);
+    assert.equal(props?.[1]?.density, 2.5);
+    // The new field is appended to the persisted column order.
+    const order = (result.patch.metadata?.columnSettings as { order?: string[] })
+      ?.order;
+    assert.deepEqual(order, undefined); // no prior explicit order → discovery places it
+  });
+
+  it("updates an existing field in place without adding metadata order", () => {
+    const result = calculateField(
+      makeLayer(),
+      DISCOVERED,
+      "pop",
+      false,
+      "pop * 2",
+      "number",
+    );
+    assert.ok(result && "patch" in result);
+    const props = result.patch.geojson?.features.map((f) => f.properties);
+    assert.equal(props?.[0]?.pop, 20);
+    assert.equal(props?.[1]?.pop, 40);
+    assert.equal(result.patch.metadata, undefined);
+  });
+
+  it("limits updates to the targeted feature ids", () => {
+    const result = calculateField(
+      makeLayer(),
+      DISCOVERED,
+      "pop",
+      false,
+      "999",
+      "number",
+      new Set(["f1"]),
+    );
+    assert.ok(result && "patch" in result);
+    assert.equal(result.evaluated, 1);
+    const props = result.patch.geojson?.features.map((f) => f.properties);
+    assert.equal(props?.[0]?.pop, 10); // untouched
+    assert.equal(props?.[1]?.pop, 999);
+  });
+
+  it("seeds out-of-scope features with null when creating a scoped field", () => {
+    const result = calculateField(
+      makeLayer(),
+      DISCOVERED,
+      "flag",
+      true,
+      '"yes"',
+      "text",
+      new Set(["f0"]),
+    );
+    assert.ok(result && "patch" in result);
+    const props = result.patch.geojson?.features.map((f) => f.properties);
+    assert.equal(props?.[0]?.flag, "yes");
+    assert.equal(props?.[1]?.flag, null);
+  });
+
+  it("counts runtime errors and writes null for the failing feature", () => {
+    const result = calculateField(
+      makeLayer(),
+      DISCOVERED,
+      "bad",
+      true,
+      "nope.missing", // ReferenceError on every row
+      "auto",
+    );
+    assert.ok(result && "patch" in result);
+    assert.equal(result.errors, 2);
+    const props = result.patch.geojson?.features.map((f) => f.properties);
+    assert.equal(props?.[0]?.bad, null);
+  });
+
+  it("returns an error for an invalid expression instead of mutating", () => {
+    const result = calculateField(
+      makeLayer(),
+      DISCOVERED,
+      "x",
+      true,
+      "pop +",
+      "auto",
+    );
+    assert.ok(result && "error" in result);
+  });
+
+  it("is a no-op when creating a colliding field or targeting an absent one", () => {
+    assert.equal(
+      calculateField(makeLayer(), DISCOVERED, "pop", true, "1", "number"),
+      null,
+    );
+    assert.equal(
+      calculateField(makeLayer(), DISCOVERED, "ghost", false, "1", "number"),
+      null,
+    );
+  });
+});


### PR DESCRIPTION
Closes #238.

## What

Adds a **Field calculator** to the attribute table: compute values from an expression and write them to a new or existing field — the QGIS-style "Field Calculator" workflow.

A new **Calculate** button sits alongside *Add field* (shown for editable, in-store GeoJSON layers). It opens a dialog where you:

- choose **Update field** (existing) or **Create field** (new name),
- pick an **output type** — Auto (keep computed type) / Text / Number / Boolean,
- write an **expression**, with clickable chips that insert field references and helper functions at the caret,
- see a **live preview** of the result against a sample row (the selected feature when scoped, else the first row),
- optionally **scope to the selected feature only**.

## Expression language

Plain JavaScript, so familiar syntax works: `pop / area`, `upper(name)`, `pop > 100 ? "big" : "small"`. Fields are exposed as bare identifiers when the name is a valid identifier, and always via `props["my field"]`. A small curated helper set is in scope (`abs`, `round`, `min`, `max`, `upper`, `lower`, `concat`, `coalesce`, `iif`, …) plus `$index` and `PI`/`E`.

The evaluator runs on the user's own data in the local webview (analogous to a spreadsheet formula bar). It uses strict-mode `new Function` with only the named field/helper arguments passed in — it is deliberately **not** a security sandbox and is documented as such; it must never run untrusted input.

Per-feature runtime errors write `null` and are counted (a syntax error blocks the whole run and is surfaced instead). Values are coerced to the chosen output type; anything unrepresentable becomes `null` so a calculation never persists a type-corrupted cell. New fields are appended to the persisted column order, consistent with *Add field*.

## Files

- `lib/attribute-expression.ts` — expression compile/evaluate, identifier helpers, output coercion (new)
- `lib/attribute-columns.ts` — `calculateField()` layer-patch producer reusing the existing column/metadata helpers
- `components/panels/AttributeTable.tsx` — the dialog, toolbar button, and live preview
- `packages/ui` — new `Textarea` primitive for the expression editor

## Tests

`tests/attribute-calculator.test.ts` (14 cases): compilation, identifier/`props` access, syntax-error handling, output coercion across types, and `calculateField` create/update/scoped/seed-null/runtime-error/no-op paths. Full frontend suite (323) green; `npm run build` and scoped `pre-commit` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attribute Table: Field Calculator — enter JS-style expressions, live preview with syntax vs runtime error handling, choose output type, create or update fields with name-collision checks, scope to selected features, and detailed reporting for partial failures.
  * UI: Added a new Textarea component.

* **Tests**
  * Added tests for expression compilation, value coercion, and end-to-end field-calculation behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->