### PR TITLE
feat(attribute-table): add a Charts panel (histogram / scatter / bar / line / box) (#240)

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/AttributeChartDialog.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeChartDialog.tsx
@@ -88,6 +88,7 @@ export function AttributeChartDialog({
   const [catField, setCatField] = useState("");
   const [barAgg, setBarAgg] = useState<BarAggregation>("count");
   const [barValueField, setBarValueField] = useState("");
+  const [exportError, setExportError] = useState<string | null>(null);
   const chartRef = useRef<HTMLDivElement>(null);
 
   // Seed the pickers when the dialog opens. Keyed on `open` only: `rows` and
@@ -96,13 +97,10 @@ export function AttributeChartDialog({
   // selections constantly. They are read from the render where `open` flipped.
   useEffect(() => {
     if (!open) return;
-    setChartType(
-      numericCols.length > 0
-        ? "histogram"
-        : categoryCols.length > 0
-          ? "bar"
-          : "histogram",
-    );
+    // No numeric fields → default to bar (the only category-only type). When
+    // there are no chartable fields at all the dialog shows an empty state, so
+    // the chosen type is irrelevant.
+    setChartType(numericCols.length > 0 ? "histogram" : "bar");
     setBins(DEFAULT_HISTOGRAM_BINS);
     setField(numericCols[0] ?? "");
     setXField(numericCols[0] ?? "");
@@ -110,6 +108,7 @@ export function AttributeChartDialog({
     setCatField(categoryCols[0] ?? "");
     setBarAgg("count");
     setBarValueField(numericCols[0] ?? "");
+    setExportError(null);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
@@ -155,11 +154,22 @@ export function AttributeChartDialog({
   const downloadChart = (format: "svg" | "png") => {
     const svg = chartRef.current?.querySelector("svg");
     if (!svg) return;
+    setExportError(null);
     const base = `${sanitizeExportFileName(layerName || "chart")}-${chartType}`;
+    const onError = (error: unknown) =>
+      setExportError(
+        error instanceof Error ? error.message : "Could not export the chart.",
+      );
     if (format === "svg") {
-      downloadChartSvg(svg, CHART_W, CHART_H, `${base}.svg`);
+      try {
+        downloadChartSvg(svg, CHART_W, CHART_H, `${base}.svg`);
+      } catch (error) {
+        onError(error);
+      }
     } else {
-      void downloadChartPng(svg, CHART_W, CHART_H, `${base}.png`);
+      // PNG rasterization is async (image load + canvas), so surface a
+      // rejection rather than letting it become an unhandled promise.
+      downloadChartPng(svg, CHART_W, CHART_H, `${base}.png`).catch(onError);
     }
   };
 
@@ -338,7 +348,12 @@ export function AttributeChartDialog({
           </div>
         )}
 
-        <div className="flex justify-end gap-2">
+        <div className="flex items-center justify-end gap-2">
+          {exportError ? (
+            <span className="mr-auto truncate text-xs text-destructive">
+              {exportError}
+            </span>
+          ) : null}
           {hasChartable ? (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -570,8 +585,16 @@ function ScatterChart({
   return (
     <>
       <ChartFrame label={`Scatter plot of ${yField} versus ${xField}`}>
-        {tickText(MARGIN.left - 6, MARGIN.top, formatAxisValue(yMax), "end", "middle")}
-        {tickText(MARGIN.left - 6, MARGIN.top + INNER_H, formatAxisValue(yMin), "end", "middle")}
+        {/* Single centered tick when an axis is flat (all values identical),
+            mirroring the histogram, rather than the same value at both ends. */}
+        {yMin === yMax ? (
+          tickText(MARGIN.left - 6, MARGIN.top + INNER_H / 2, formatAxisValue(yMin), "end", "middle")
+        ) : (
+          <>
+            {tickText(MARGIN.left - 6, MARGIN.top, formatAxisValue(yMax), "end", "middle")}
+            {tickText(MARGIN.left - 6, MARGIN.top + INNER_H, formatAxisValue(yMin), "end", "middle")}
+          </>
+        )}
         {points.map((point, index) => {
           const cx = MARGIN.left + fraction(point.x, xMin, xMax) * INNER_W;
           const cy =
@@ -582,8 +605,14 @@ function ScatterChart({
             </circle>
           );
         })}
-        {tickText(MARGIN.left, MARGIN.top + INNER_H + 14, formatAxisValue(xMin), "start")}
-        {tickText(MARGIN.left + INNER_W, MARGIN.top + INNER_H + 14, formatAxisValue(xMax), "end")}
+        {xMin === xMax ? (
+          tickText(MARGIN.left + INNER_W / 2, MARGIN.top + INNER_H + 14, formatAxisValue(xMin), "middle")
+        ) : (
+          <>
+            {tickText(MARGIN.left, MARGIN.top + INNER_H + 14, formatAxisValue(xMin), "start")}
+            {tickText(MARGIN.left + INNER_W, MARGIN.top + INNER_H + 14, formatAxisValue(xMax), "end")}
+          </>
+        )}
         {axisTitle(xField)}
         {yAxisTitle(yField)}
       </ChartFrame>
@@ -623,7 +652,11 @@ function BarChart({
   return (
     <>
       <ChartFrame label={`Bar chart of ${aggregation} by ${category}`}>
-        {tickText(MARGIN.left - 6, MARGIN.top, formatAxisValue(domainMax), "end", "middle")}
+        {/* Top tick only when the domain extends above 0; when all bars are
+            <= 0 the domain tops at 0 and the baseline tick already labels it. */}
+        {domainMax > 0
+          ? tickText(MARGIN.left - 6, MARGIN.top, formatAxisValue(domainMax), "end", "middle")
+          : null}
         {tickText(MARGIN.left - 6, baselineY, "0", "end", "middle")}
         {/* Lower-bound tick when bars go negative (sum/mean of negative values). */}
         {minValue < 0

--- a/apps/geolibre-desktop/src/components/panels/AttributeChartDialog.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeChartDialog.tsx
@@ -468,6 +468,22 @@ function axisTitle(text: string) {
   );
 }
 
+function yAxisTitle(text: string) {
+  const cy = MARGIN.top + INNER_H / 2;
+  return (
+    <text
+      x={12}
+      y={cy}
+      textAnchor="middle"
+      fontSize={11}
+      fill={TICK}
+      transform={`rotate(-90 12 ${cy})`}
+    >
+      {text}
+    </text>
+  );
+}
+
 function EmptyChart({ message }: { message: string }) {
   return (
     <p className="py-10 text-center text-sm text-muted-foreground">{message}</p>
@@ -569,6 +585,7 @@ function ScatterChart({
         {tickText(MARGIN.left, MARGIN.top + INNER_H + 14, formatAxisValue(xMin), "start")}
         {tickText(MARGIN.left + INNER_W, MARGIN.top + INNER_H + 14, formatAxisValue(xMax), "end")}
         {axisTitle(xField)}
+        {yAxisTitle(yField)}
       </ChartFrame>
       <Caption>
         {total.toLocaleString()} point{total === 1 ? "" : "s"} · {yField} vs{" "}
@@ -608,6 +625,10 @@ function BarChart({
       <ChartFrame label={`Bar chart of ${aggregation} by ${category}`}>
         {tickText(MARGIN.left - 6, MARGIN.top, formatAxisValue(domainMax), "end", "middle")}
         {tickText(MARGIN.left - 6, baselineY, "0", "end", "middle")}
+        {/* Lower-bound tick when bars go negative (sum/mean of negative values). */}
+        {minValue < 0
+          ? tickText(MARGIN.left - 6, MARGIN.top + INNER_H, formatAxisValue(domainMin), "end", "middle")
+          : null}
         {bars.map((datum, index) => {
           const top = Math.min(baselineY, scaleY(datum.value));
           const height = Math.abs(scaleY(datum.value) - baselineY);
@@ -694,8 +715,16 @@ function LineChart({
               </circle>
             ))
           : null}
-        {tickText(MARGIN.left, MARGIN.top + INNER_H + 14, "0", "start")}
-        {tickText(MARGIN.left + INNER_W, MARGIN.top + INNER_H + 14, String(length - 1), "end")}
+        {/* A single-feature layer has only index 0; show one centered label
+            instead of "0" at both ends. */}
+        {length <= 1 ? (
+          tickText(MARGIN.left + INNER_W / 2, MARGIN.top + INNER_H + 14, "0", "middle")
+        ) : (
+          <>
+            {tickText(MARGIN.left, MARGIN.top + INNER_H + 14, "0", "start")}
+            {tickText(MARGIN.left + INNER_W, MARGIN.top + INNER_H + 14, String(length - 1), "end")}
+          </>
+        )}
         {axisTitle("feature order")}
       </ChartFrame>
       <Caption>
@@ -754,19 +783,31 @@ function BoxChart({
           stroke={SERIES}
           strokeWidth={2}
         />
-        {stats.map(([label, value]) => (
-          <text
-            key={label}
-            x={centerX + boxWidth / 2 + 8}
-            y={scaleY(value)}
-            textAnchor="start"
-            dominantBaseline="middle"
-            fontSize={10}
-            fill={TICK}
-          >
-            {`${label} ${formatAxisValue(value)}`}
-          </text>
-        ))}
+        {/* When every value is identical the five stats share one y position;
+            show a single label instead of five overlapping ones. */}
+        {min === max ? (
+          tickText(
+            centerX + boxWidth / 2 + 8,
+            scaleY(median),
+            `all = ${formatAxisValue(median)}`,
+            "start",
+            "middle",
+          )
+        ) : (
+          stats.map(([label, value]) => (
+            <text
+              key={label}
+              x={centerX + boxWidth / 2 + 8}
+              y={scaleY(value)}
+              textAnchor="start"
+              dominantBaseline="middle"
+              fontSize={10}
+              fill={TICK}
+            >
+              {`${label} ${formatAxisValue(value)}`}
+            </text>
+          ))
+        )}
         {axisTitle(field)}
       </ChartFrame>
       <Caption>

--- a/apps/geolibre-desktop/src/components/panels/AttributeChartDialog.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeChartDialog.tsx
@@ -47,14 +47,6 @@ const AXIS = "hsl(var(--border))";
 const TICK = "hsl(var(--muted-foreground))";
 const SERIES = "hsl(var(--primary))";
 
-/** Chart types that plot one or more numeric fields. */
-const NUMERIC_TYPES: ReadonlySet<ChartType> = new Set([
-  "histogram",
-  "scatter",
-  "line",
-  "box",
-]);
-
 /** Map a value within [min, max] to a 0..1 fraction, centering a flat range. */
 function fraction(value: number, min: number, max: number): number {
   if (max === min) return 0.5;
@@ -558,7 +550,11 @@ function BarChart({
 
   const { bars, maxValue, minValue, truncated } = result;
   const domainMin = Math.min(0, minValue);
-  const domainMax = Math.max(0, maxValue) || 1;
+  // Keep 0 as the top of the scale when every bar is <= 0 (possible for
+  // sum/mean); only fall back to 1 when the domain would otherwise be zero-width
+  // (all bars exactly 0). `Math.max(0, maxValue) || 1` wrongly made an
+  // all-negative domain top out at 1.
+  const domainMax = maxValue > 0 ? maxValue : minValue < 0 ? 0 : 1;
   const slot = INNER_W / bars.length;
   const gap = Math.min(6, slot * 0.2);
   const scaleY = (value: number) =>

--- a/apps/geolibre-desktop/src/components/panels/AttributeChartDialog.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeChartDialog.tsx
@@ -5,11 +5,18 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   Input,
   Label,
   Select,
 } from "@geolibre/ui";
-import { type ReactNode, useEffect, useMemo, useState } from "react";
+import { Download } from "lucide-react";
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { downloadChartPng, downloadChartSvg } from "../../lib/chart-export";
+import { sanitizeExportFileName } from "../../lib/vector-export";
 import {
   categoricalColumns,
   computeBar,
@@ -81,6 +88,7 @@ export function AttributeChartDialog({
   const [catField, setCatField] = useState("");
   const [barAgg, setBarAgg] = useState<BarAggregation>("count");
   const [barValueField, setBarValueField] = useState("");
+  const chartRef = useRef<HTMLDivElement>(null);
 
   // Seed the pickers when the dialog opens. Keyed on `open` only: `rows` and
   // `columns` are rebuilt with fresh identities on every parent render, so
@@ -138,6 +146,22 @@ export function AttributeChartDialog({
   const hasNumeric = numericCols.length > 0;
   const hasCategory = categoryCols.length > 0;
   const hasChartable = hasNumeric || hasCategory;
+  // A chart is only downloadable when the active type produced a result (an SVG
+  // is on screen); empty states render no <svg>.
+  const chartRendered = Boolean(
+    histogram || scatter || bar || line || box,
+  );
+
+  const downloadChart = (format: "svg" | "png") => {
+    const svg = chartRef.current?.querySelector("svg");
+    if (!svg) return;
+    const base = `${sanitizeExportFileName(layerName || "chart")}-${chartType}`;
+    if (format === "svg") {
+      downloadChartSvg(svg, CHART_W, CHART_H, `${base}.svg`);
+    } else {
+      void downloadChartPng(svg, CHART_W, CHART_H, `${base}.png`);
+    }
+  };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -292,7 +316,7 @@ export function AttributeChartDialog({
               )}
             </div>
 
-            <div className="rounded-md border bg-background p-2">
+            <div ref={chartRef} className="rounded-md border bg-background p-2">
               {chartType === "histogram" && (
                 <HistogramChart result={histogram} field={field} />
               )}
@@ -314,7 +338,25 @@ export function AttributeChartDialog({
           </div>
         )}
 
-        <div className="flex justify-end">
+        <div className="flex justify-end gap-2">
+          {hasChartable ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" disabled={!chartRendered}>
+                  <Download className="h-4 w-4" />
+                  Download
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onSelect={() => downloadChart("png")}>
+                  PNG image
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => downloadChart("svg")}>
+                  SVG vector
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : null}
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             Close
           </Button>

--- a/apps/geolibre-desktop/src/components/panels/AttributeChartDialog.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeChartDialog.tsx
@@ -627,7 +627,14 @@ function LineChart({
   const scaleY = (value: number) =>
     MARGIN.top + INNER_H - fraction(value, min, max) * INNER_H;
   const path = points
-    .map((p, i) => `${i === 0 ? "M" : "L"}${scaleX(p.index)} ${scaleY(p.value)}`)
+    .map((p, i) => {
+      // Break the line (start a new subpath) when rows are non-consecutive, so
+      // a gap from skipped (non-numeric) rows shows as a gap rather than a
+      // straight segment across it.
+      const command =
+        i === 0 || p.index !== points[i - 1].index + 1 ? "M" : "L";
+      return `${command}${scaleX(p.index)} ${scaleY(p.value)}`;
+    })
     .join(" ");
 
   return (

--- a/apps/geolibre-desktop/src/components/panels/AttributeChartDialog.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeChartDialog.tsx
@@ -1,0 +1,370 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+  Select,
+} from "@geolibre/ui";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
+import {
+  computeHistogram,
+  computeScatter,
+  DEFAULT_HISTOGRAM_BINS,
+  formatAxisValue,
+  MAX_HISTOGRAM_BINS,
+  MIN_HISTOGRAM_BINS,
+  numericColumns,
+  numericValues,
+  type ChartRow,
+  type ChartType,
+} from "../../lib/attribute-charts";
+
+interface AttributeChartDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  rows: ChartRow[];
+  columns: string[];
+  layerName: string;
+}
+
+// SVG geometry. The chart scales to its container via viewBox/width=100%.
+const CHART_W = 560;
+const CHART_H = 300;
+const MARGIN = { top: 16, right: 16, bottom: 44, left: 52 };
+const INNER_W = CHART_W - MARGIN.left - MARGIN.right;
+const INNER_H = CHART_H - MARGIN.top - MARGIN.bottom;
+
+const AXIS = "hsl(var(--border))";
+const TICK = "hsl(var(--muted-foreground))";
+const SERIES = "hsl(var(--primary))";
+
+/** Map a value within [min, max] to a 0..1 fraction, centering a flat range. */
+function fraction(value: number, min: number, max: number): number {
+  if (max === min) return 0.5;
+  return (value - min) / (max - min);
+}
+
+export function AttributeChartDialog({
+  open,
+  onOpenChange,
+  rows,
+  columns,
+  layerName,
+}: AttributeChartDialogProps) {
+  const numericCols = useMemo(
+    () => numericColumns(rows, columns),
+    [rows, columns],
+  );
+
+  const [chartType, setChartType] = useState<ChartType>("histogram");
+  const [field, setField] = useState("");
+  const [xField, setXField] = useState("");
+  const [yField, setYField] = useState("");
+  const [bins, setBins] = useState(DEFAULT_HISTOGRAM_BINS);
+
+  // Seed the field pickers when the dialog opens. Keyed on `open` only: `rows`
+  // and `columns` are rebuilt with fresh identities on every parent render, so
+  // depending on numericCols here would reset the user's selections constantly.
+  // numericCols is read from the render in which `open` flipped true.
+  useEffect(() => {
+    if (!open) return;
+    setChartType("histogram");
+    setBins(DEFAULT_HISTOGRAM_BINS);
+    setField(numericCols[0] ?? "");
+    setXField(numericCols[0] ?? "");
+    setYField(numericCols[1] ?? numericCols[0] ?? "");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const histogram = useMemo(() => {
+    if (chartType !== "histogram" || !field) return null;
+    return computeHistogram(numericValues(rows, field), bins);
+  }, [chartType, field, rows, bins]);
+
+  const scatter = useMemo(() => {
+    if (chartType !== "scatter" || !xField || !yField) return null;
+    return computeScatter(rows, xField, yField);
+  }, [chartType, xField, yField, rows]);
+
+  const hasNumeric = numericCols.length > 0;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Charts</DialogTitle>
+          <DialogDescription>
+            {`Visualize numeric fields in "${layerName}".`}
+          </DialogDescription>
+        </DialogHeader>
+
+        {!hasNumeric ? (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            This layer has no numeric fields to chart.
+          </p>
+        ) : (
+          <div className="grid gap-3 py-1">
+            <div className="flex flex-wrap items-end gap-3">
+              <div className="grid gap-1.5">
+                <Label htmlFor="chart-type">Chart type</Label>
+                <Select
+                  id="chart-type"
+                  className="w-36"
+                  value={chartType}
+                  onChange={(event) =>
+                    setChartType(event.target.value as ChartType)
+                  }
+                >
+                  <option value="histogram">Histogram</option>
+                  <option value="scatter">Scatter</option>
+                </Select>
+              </div>
+
+              {chartType === "histogram" ? (
+                <>
+                  <div className="grid gap-1.5">
+                    <Label htmlFor="chart-field">Field</Label>
+                    <Select
+                      id="chart-field"
+                      className="w-44"
+                      value={field}
+                      onChange={(event) => setField(event.target.value)}
+                    >
+                      {numericCols.map((col) => (
+                        <option key={col} value={col}>
+                          {col}
+                        </option>
+                      ))}
+                    </Select>
+                  </div>
+                  <div className="grid gap-1.5">
+                    <Label htmlFor="chart-bins">Bins</Label>
+                    <Input
+                      id="chart-bins"
+                      type="number"
+                      className="w-24"
+                      min={MIN_HISTOGRAM_BINS}
+                      max={MAX_HISTOGRAM_BINS}
+                      value={bins}
+                      onChange={(event) => {
+                        const next = Number(event.target.value);
+                        if (Number.isFinite(next)) {
+                          setBins(
+                            Math.max(
+                              MIN_HISTOGRAM_BINS,
+                              Math.min(MAX_HISTOGRAM_BINS, Math.trunc(next)),
+                            ),
+                          );
+                        }
+                      }}
+                    />
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div className="grid gap-1.5">
+                    <Label htmlFor="chart-x">X axis</Label>
+                    <Select
+                      id="chart-x"
+                      className="w-44"
+                      value={xField}
+                      onChange={(event) => setXField(event.target.value)}
+                    >
+                      {numericCols.map((col) => (
+                        <option key={col} value={col}>
+                          {col}
+                        </option>
+                      ))}
+                    </Select>
+                  </div>
+                  <div className="grid gap-1.5">
+                    <Label htmlFor="chart-y">Y axis</Label>
+                    <Select
+                      id="chart-y"
+                      className="w-44"
+                      value={yField}
+                      onChange={(event) => setYField(event.target.value)}
+                    >
+                      {numericCols.map((col) => (
+                        <option key={col} value={col}>
+                          {col}
+                        </option>
+                      ))}
+                    </Select>
+                  </div>
+                </>
+              )}
+            </div>
+
+            <div className="rounded-md border bg-background p-2">
+              {chartType === "histogram" ? (
+                <HistogramChart result={histogram} field={field} />
+              ) : (
+                <ScatterChart
+                  result={scatter}
+                  xField={xField}
+                  yField={yField}
+                />
+              )}
+            </div>
+          </div>
+        )}
+
+        <div className="flex justify-end">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ChartFrame({ children }: { children: ReactNode }) {
+  return (
+    <svg
+      viewBox={`0 0 ${CHART_W} ${CHART_H}`}
+      width="100%"
+      role="img"
+      className="h-auto w-full"
+      preserveAspectRatio="xMidYMid meet"
+    >
+      {/* Axes */}
+      <line
+        x1={MARGIN.left}
+        y1={MARGIN.top}
+        x2={MARGIN.left}
+        y2={MARGIN.top + INNER_H}
+        stroke={AXIS}
+      />
+      <line
+        x1={MARGIN.left}
+        y1={MARGIN.top + INNER_H}
+        x2={MARGIN.left + INNER_W}
+        y2={MARGIN.top + INNER_H}
+        stroke={AXIS}
+      />
+      {children}
+    </svg>
+  );
+}
+
+function EmptyChart({ message }: { message: string }) {
+  return (
+    <p className="py-10 text-center text-sm text-muted-foreground">{message}</p>
+  );
+}
+
+function HistogramChart({
+  result,
+  field,
+}: {
+  result: ReturnType<typeof computeHistogram>;
+  field: string;
+}) {
+  if (!result) return <EmptyChart message="No numeric values to plot." />;
+
+  const { bins, maxCount, min, max, total } = result;
+  const slot = INNER_W / bins.length;
+  const gap = Math.min(4, slot * 0.15);
+
+  return (
+    <>
+      <ChartFrame>
+        {/* y-axis ticks: 0 and the tallest bin count */}
+        <text x={MARGIN.left - 6} y={MARGIN.top + INNER_H} textAnchor="end" dominantBaseline="middle" fontSize={10} fill={TICK}>
+          0
+        </text>
+        <text x={MARGIN.left - 6} y={MARGIN.top} textAnchor="end" dominantBaseline="middle" fontSize={10} fill={TICK}>
+          {maxCount}
+        </text>
+        {bins.map((bin, index) => {
+          const height = maxCount === 0 ? 0 : (bin.count / maxCount) * INNER_H;
+          return (
+            <rect
+              key={index}
+              x={MARGIN.left + index * slot + gap / 2}
+              y={MARGIN.top + INNER_H - height}
+              width={Math.max(1, slot - gap)}
+              height={height}
+              fill={SERIES}
+              opacity={0.85}
+            >
+              <title>{`[${formatAxisValue(bin.x0)}, ${formatAxisValue(bin.x1)}${
+                index === bins.length - 1 ? "]" : ")"
+              }: ${bin.count}`}</title>
+            </rect>
+          );
+        })}
+        {/* x-axis min/max */}
+        <text x={MARGIN.left} y={MARGIN.top + INNER_H + 14} textAnchor="start" fontSize={10} fill={TICK}>
+          {formatAxisValue(min)}
+        </text>
+        <text x={MARGIN.left + INNER_W} y={MARGIN.top + INNER_H + 14} textAnchor="end" fontSize={10} fill={TICK}>
+          {formatAxisValue(max)}
+        </text>
+        <text x={MARGIN.left + INNER_W / 2} y={CHART_H - 4} textAnchor="middle" fontSize={11} fill={TICK}>
+          {field}
+        </text>
+      </ChartFrame>
+      <p className="mt-1 text-center text-xs text-muted-foreground">
+        {total.toLocaleString()} value{total === 1 ? "" : "s"} · count on y
+      </p>
+    </>
+  );
+}
+
+function ScatterChart({
+  result,
+  xField,
+  yField,
+}: {
+  result: ReturnType<typeof computeScatter>;
+  xField: string;
+  yField: string;
+}) {
+  if (!result) {
+    return <EmptyChart message="No rows have both fields set to a number." />;
+  }
+
+  const { points, xMin, xMax, yMin, yMax } = result;
+
+  return (
+    <>
+      <ChartFrame>
+        <text x={MARGIN.left - 6} y={MARGIN.top} textAnchor="end" dominantBaseline="middle" fontSize={10} fill={TICK}>
+          {formatAxisValue(yMax)}
+        </text>
+        <text x={MARGIN.left - 6} y={MARGIN.top + INNER_H} textAnchor="end" dominantBaseline="middle" fontSize={10} fill={TICK}>
+          {formatAxisValue(yMin)}
+        </text>
+        {points.map((point, index) => {
+          const cx = MARGIN.left + fraction(point.x, xMin, xMax) * INNER_W;
+          const cy = MARGIN.top + INNER_H - fraction(point.y, yMin, yMax) * INNER_H;
+          return (
+            <circle key={index} cx={cx} cy={cy} r={3} fill={SERIES} opacity={0.6}>
+              <title>{`${xField}: ${formatAxisValue(point.x)}, ${yField}: ${formatAxisValue(point.y)}`}</title>
+            </circle>
+          );
+        })}
+        <text x={MARGIN.left} y={MARGIN.top + INNER_H + 14} textAnchor="start" fontSize={10} fill={TICK}>
+          {formatAxisValue(xMin)}
+        </text>
+        <text x={MARGIN.left + INNER_W} y={MARGIN.top + INNER_H + 14} textAnchor="end" fontSize={10} fill={TICK}>
+          {formatAxisValue(xMax)}
+        </text>
+        <text x={MARGIN.left + INNER_W / 2} y={CHART_H - 4} textAnchor="middle" fontSize={11} fill={TICK}>
+          {xField}
+        </text>
+      </ChartFrame>
+      <p className="mt-1 text-center text-xs text-muted-foreground">
+        {points.length.toLocaleString()} point{points.length === 1 ? "" : "s"} ·{" "}
+        {yField} vs {xField}
+      </p>
+    </>
+  );
+}

--- a/apps/geolibre-desktop/src/components/panels/AttributeChartDialog.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeChartDialog.tsx
@@ -11,7 +11,11 @@ import {
 } from "@geolibre/ui";
 import { type ReactNode, useEffect, useMemo, useState } from "react";
 import {
+  categoricalColumns,
+  computeBar,
+  computeBox,
   computeHistogram,
+  computeLine,
   computeScatter,
   DEFAULT_HISTOGRAM_BINS,
   formatAxisValue,
@@ -19,6 +23,7 @@ import {
   MIN_HISTOGRAM_BINS,
   numericColumns,
   numericValues,
+  type BarAggregation,
   type ChartRow,
   type ChartType,
 } from "../../lib/attribute-charts";
@@ -34,7 +39,7 @@ interface AttributeChartDialogProps {
 // SVG geometry. The chart scales to its container via viewBox/width=100%.
 const CHART_W = 560;
 const CHART_H = 300;
-const MARGIN = { top: 16, right: 16, bottom: 44, left: 52 };
+const MARGIN = { top: 16, right: 16, bottom: 52, left: 52 };
 const INNER_W = CHART_W - MARGIN.left - MARGIN.right;
 const INNER_H = CHART_H - MARGIN.top - MARGIN.bottom;
 
@@ -42,10 +47,22 @@ const AXIS = "hsl(var(--border))";
 const TICK = "hsl(var(--muted-foreground))";
 const SERIES = "hsl(var(--primary))";
 
+/** Chart types that plot one or more numeric fields. */
+const NUMERIC_TYPES: ReadonlySet<ChartType> = new Set([
+  "histogram",
+  "scatter",
+  "line",
+  "box",
+]);
+
 /** Map a value within [min, max] to a 0..1 fraction, centering a flat range. */
 function fraction(value: number, min: number, max: number): number {
   if (max === min) return 0.5;
   return (value - min) / (max - min);
+}
+
+function truncateLabel(label: string, max = 14): string {
+  return label.length > max ? `${label.slice(0, max - 1)}…` : label;
 }
 
 export function AttributeChartDialog({
@@ -59,24 +76,40 @@ export function AttributeChartDialog({
     () => numericColumns(rows, columns),
     [rows, columns],
   );
+  const categoryCols = useMemo(
+    () => categoricalColumns(rows, columns),
+    [rows, columns],
+  );
 
   const [chartType, setChartType] = useState<ChartType>("histogram");
   const [field, setField] = useState("");
   const [xField, setXField] = useState("");
   const [yField, setYField] = useState("");
   const [bins, setBins] = useState(DEFAULT_HISTOGRAM_BINS);
+  const [catField, setCatField] = useState("");
+  const [barAgg, setBarAgg] = useState<BarAggregation>("count");
+  const [barValueField, setBarValueField] = useState("");
 
-  // Seed the field pickers when the dialog opens. Keyed on `open` only: `rows`
-  // and `columns` are rebuilt with fresh identities on every parent render, so
-  // depending on numericCols here would reset the user's selections constantly.
-  // numericCols is read from the render in which `open` flipped true.
+  // Seed the pickers when the dialog opens. Keyed on `open` only: `rows` and
+  // `columns` are rebuilt with fresh identities on every parent render, so
+  // depending on the derived column lists here would reset the user's
+  // selections constantly. They are read from the render where `open` flipped.
   useEffect(() => {
     if (!open) return;
-    setChartType("histogram");
+    setChartType(
+      numericCols.length > 0
+        ? "histogram"
+        : categoryCols.length > 0
+          ? "bar"
+          : "histogram",
+    );
     setBins(DEFAULT_HISTOGRAM_BINS);
     setField(numericCols[0] ?? "");
     setXField(numericCols[0] ?? "");
     setYField(numericCols[1] ?? numericCols[0] ?? "");
+    setCatField(categoryCols[0] ?? "");
+    setBarAgg("count");
+    setBarValueField(numericCols[0] ?? "");
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
@@ -90,7 +123,29 @@ export function AttributeChartDialog({
     return computeScatter(rows, xField, yField);
   }, [chartType, xField, yField, rows]);
 
+  const bar = useMemo(() => {
+    if (chartType !== "bar" || !catField) return null;
+    return computeBar(
+      rows,
+      catField,
+      barAgg,
+      barAgg === "count" ? null : barValueField,
+    );
+  }, [chartType, catField, barAgg, barValueField, rows]);
+
+  const line = useMemo(() => {
+    if (chartType !== "line" || !field) return null;
+    return computeLine(rows, field);
+  }, [chartType, field, rows]);
+
+  const box = useMemo(() => {
+    if (chartType !== "box" || !field) return null;
+    return computeBox(numericValues(rows, field));
+  }, [chartType, field, rows]);
+
   const hasNumeric = numericCols.length > 0;
+  const hasCategory = categoryCols.length > 0;
+  const hasChartable = hasNumeric || hasCategory;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -98,13 +153,13 @@ export function AttributeChartDialog({
         <DialogHeader>
           <DialogTitle>Charts</DialogTitle>
           <DialogDescription>
-            {`Visualize numeric fields in "${layerName}".`}
+            {`Visualize fields in "${layerName}".`}
           </DialogDescription>
         </DialogHeader>
 
-        {!hasNumeric ? (
+        {!hasChartable ? (
           <p className="py-6 text-center text-sm text-muted-foreground">
-            This layer has no numeric fields to chart.
+            This layer has no numeric or categorical fields to chart.
           </p>
         ) : (
           <div className="grid gap-3 py-1">
@@ -119,97 +174,135 @@ export function AttributeChartDialog({
                     setChartType(event.target.value as ChartType)
                   }
                 >
-                  <option value="histogram">Histogram</option>
-                  <option value="scatter">Scatter</option>
+                  <option value="histogram" disabled={!hasNumeric}>
+                    Histogram
+                  </option>
+                  <option value="scatter" disabled={!hasNumeric}>
+                    Scatter
+                  </option>
+                  <option value="bar" disabled={!hasCategory}>
+                    Bar
+                  </option>
+                  <option value="line" disabled={!hasNumeric}>
+                    Line
+                  </option>
+                  <option value="box" disabled={!hasNumeric}>
+                    Box plot
+                  </option>
                 </Select>
               </div>
 
-              {chartType === "histogram" ? (
+              {(chartType === "histogram" ||
+                chartType === "line" ||
+                chartType === "box") && (
+                <FieldSelect
+                  id="chart-field"
+                  label="Field"
+                  value={field}
+                  options={numericCols}
+                  onChange={setField}
+                />
+              )}
+
+              {chartType === "histogram" && (
+                <div className="grid gap-1.5">
+                  <Label htmlFor="chart-bins">Bins</Label>
+                  <Input
+                    id="chart-bins"
+                    type="number"
+                    className="w-24"
+                    min={MIN_HISTOGRAM_BINS}
+                    max={MAX_HISTOGRAM_BINS}
+                    value={bins}
+                    onChange={(event) => {
+                      const next = Number(event.target.value);
+                      if (Number.isFinite(next)) {
+                        setBins(
+                          Math.max(
+                            MIN_HISTOGRAM_BINS,
+                            Math.min(MAX_HISTOGRAM_BINS, Math.trunc(next)),
+                          ),
+                        );
+                      }
+                    }}
+                  />
+                </div>
+              )}
+
+              {chartType === "scatter" && (
                 <>
-                  <div className="grid gap-1.5">
-                    <Label htmlFor="chart-field">Field</Label>
-                    <Select
-                      id="chart-field"
-                      className="w-44"
-                      value={field}
-                      onChange={(event) => setField(event.target.value)}
-                    >
-                      {numericCols.map((col) => (
-                        <option key={col} value={col}>
-                          {col}
-                        </option>
-                      ))}
-                    </Select>
-                  </div>
-                  <div className="grid gap-1.5">
-                    <Label htmlFor="chart-bins">Bins</Label>
-                    <Input
-                      id="chart-bins"
-                      type="number"
-                      className="w-24"
-                      min={MIN_HISTOGRAM_BINS}
-                      max={MAX_HISTOGRAM_BINS}
-                      value={bins}
-                      onChange={(event) => {
-                        const next = Number(event.target.value);
-                        if (Number.isFinite(next)) {
-                          setBins(
-                            Math.max(
-                              MIN_HISTOGRAM_BINS,
-                              Math.min(MAX_HISTOGRAM_BINS, Math.trunc(next)),
-                            ),
-                          );
-                        }
-                      }}
-                    />
-                  </div>
+                  <FieldSelect
+                    id="chart-x"
+                    label="X axis"
+                    value={xField}
+                    options={numericCols}
+                    onChange={setXField}
+                  />
+                  <FieldSelect
+                    id="chart-y"
+                    label="Y axis"
+                    value={yField}
+                    options={numericCols}
+                    onChange={setYField}
+                  />
                 </>
-              ) : (
+              )}
+
+              {chartType === "bar" && (
                 <>
+                  <FieldSelect
+                    id="chart-category"
+                    label="Category"
+                    value={catField}
+                    options={categoryCols}
+                    onChange={setCatField}
+                  />
                   <div className="grid gap-1.5">
-                    <Label htmlFor="chart-x">X axis</Label>
+                    <Label htmlFor="chart-agg">Aggregate</Label>
                     <Select
-                      id="chart-x"
-                      className="w-44"
-                      value={xField}
-                      onChange={(event) => setXField(event.target.value)}
+                      id="chart-agg"
+                      className="w-32"
+                      value={barAgg}
+                      onChange={(event) =>
+                        setBarAgg(event.target.value as BarAggregation)
+                      }
                     >
-                      {numericCols.map((col) => (
-                        <option key={col} value={col}>
-                          {col}
-                        </option>
-                      ))}
+                      <option value="count">Count</option>
+                      <option value="sum" disabled={!hasNumeric}>
+                        Sum
+                      </option>
+                      <option value="mean" disabled={!hasNumeric}>
+                        Average
+                      </option>
                     </Select>
                   </div>
-                  <div className="grid gap-1.5">
-                    <Label htmlFor="chart-y">Y axis</Label>
-                    <Select
-                      id="chart-y"
-                      className="w-44"
-                      value={yField}
-                      onChange={(event) => setYField(event.target.value)}
-                    >
-                      {numericCols.map((col) => (
-                        <option key={col} value={col}>
-                          {col}
-                        </option>
-                      ))}
-                    </Select>
-                  </div>
+                  {barAgg !== "count" && (
+                    <FieldSelect
+                      id="chart-value"
+                      label="Value"
+                      value={barValueField}
+                      options={numericCols}
+                      onChange={setBarValueField}
+                    />
+                  )}
                 </>
               )}
             </div>
 
             <div className="rounded-md border bg-background p-2">
-              {chartType === "histogram" ? (
+              {chartType === "histogram" && (
                 <HistogramChart result={histogram} field={field} />
-              ) : (
-                <ScatterChart
-                  result={scatter}
-                  xField={xField}
-                  yField={yField}
-                />
               )}
+              {chartType === "scatter" && (
+                <ScatterChart result={scatter} xField={xField} yField={yField} />
+              )}
+              {chartType === "bar" && (
+                <BarChart result={bar} aggregation={barAgg} />
+              )}
+              {chartType === "line" && (
+                <LineChart result={line} field={field} />
+              )}
+              {chartType === "box" && <BoxChart result={box} field={field} />}
             </div>
           </div>
         )}
@@ -224,6 +317,38 @@ export function AttributeChartDialog({
   );
 }
 
+function FieldSelect({
+  id,
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  options: string[];
+  onChange: (next: string) => void;
+}) {
+  return (
+    <div className="grid gap-1.5">
+      <Label htmlFor={id}>{label}</Label>
+      <Select
+        id={id}
+        className="w-44"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+      >
+        {options.map((col) => (
+          <option key={col} value={col}>
+            {col}
+          </option>
+        ))}
+      </Select>
+    </div>
+  );
+}
+
 function ChartFrame({ children }: { children: ReactNode }) {
   return (
     <svg
@@ -233,7 +358,6 @@ function ChartFrame({ children }: { children: ReactNode }) {
       className="h-auto w-full"
       preserveAspectRatio="xMidYMid meet"
     >
-      {/* Axes */}
       <line
         x1={MARGIN.left}
         y1={MARGIN.top}
@@ -253,9 +377,50 @@ function ChartFrame({ children }: { children: ReactNode }) {
   );
 }
 
+function tickText(
+  x: number,
+  y: number,
+  text: string,
+  anchor: "start" | "middle" | "end",
+  baseline: "middle" | "auto" = "auto",
+) {
+  return (
+    <text
+      x={x}
+      y={y}
+      textAnchor={anchor}
+      dominantBaseline={baseline}
+      fontSize={10}
+      fill={TICK}
+    >
+      {text}
+    </text>
+  );
+}
+
+function axisTitle(text: string) {
+  return (
+    <text
+      x={MARGIN.left + INNER_W / 2}
+      y={CHART_H - 4}
+      textAnchor="middle"
+      fontSize={11}
+      fill={TICK}
+    >
+      {text}
+    </text>
+  );
+}
+
 function EmptyChart({ message }: { message: string }) {
   return (
     <p className="py-10 text-center text-sm text-muted-foreground">{message}</p>
+  );
+}
+
+function Caption({ children }: { children: ReactNode }) {
+  return (
+    <p className="mt-1 text-center text-xs text-muted-foreground">{children}</p>
   );
 }
 
@@ -275,13 +440,8 @@ function HistogramChart({
   return (
     <>
       <ChartFrame>
-        {/* y-axis ticks: 0 and the tallest bin count */}
-        <text x={MARGIN.left - 6} y={MARGIN.top + INNER_H} textAnchor="end" dominantBaseline="middle" fontSize={10} fill={TICK}>
-          0
-        </text>
-        <text x={MARGIN.left - 6} y={MARGIN.top} textAnchor="end" dominantBaseline="middle" fontSize={10} fill={TICK}>
-          {maxCount}
-        </text>
+        {tickText(MARGIN.left - 6, MARGIN.top + INNER_H, "0", "end", "middle")}
+        {tickText(MARGIN.left - 6, MARGIN.top, String(maxCount), "end", "middle")}
         {bins.map((bin, index) => {
           const height = maxCount === 0 ? 0 : (bin.count / maxCount) * INNER_H;
           return (
@@ -300,20 +460,13 @@ function HistogramChart({
             </rect>
           );
         })}
-        {/* x-axis min/max */}
-        <text x={MARGIN.left} y={MARGIN.top + INNER_H + 14} textAnchor="start" fontSize={10} fill={TICK}>
-          {formatAxisValue(min)}
-        </text>
-        <text x={MARGIN.left + INNER_W} y={MARGIN.top + INNER_H + 14} textAnchor="end" fontSize={10} fill={TICK}>
-          {formatAxisValue(max)}
-        </text>
-        <text x={MARGIN.left + INNER_W / 2} y={CHART_H - 4} textAnchor="middle" fontSize={11} fill={TICK}>
-          {field}
-        </text>
+        {tickText(MARGIN.left, MARGIN.top + INNER_H + 14, formatAxisValue(min), "start")}
+        {tickText(MARGIN.left + INNER_W, MARGIN.top + INNER_H + 14, formatAxisValue(max), "end")}
+        {axisTitle(field)}
       </ChartFrame>
-      <p className="mt-1 text-center text-xs text-muted-foreground">
+      <Caption>
         {total.toLocaleString()} value{total === 1 ? "" : "s"} · count on y
-      </p>
+      </Caption>
     </>
   );
 }
@@ -336,35 +489,211 @@ function ScatterChart({
   return (
     <>
       <ChartFrame>
-        <text x={MARGIN.left - 6} y={MARGIN.top} textAnchor="end" dominantBaseline="middle" fontSize={10} fill={TICK}>
-          {formatAxisValue(yMax)}
-        </text>
-        <text x={MARGIN.left - 6} y={MARGIN.top + INNER_H} textAnchor="end" dominantBaseline="middle" fontSize={10} fill={TICK}>
-          {formatAxisValue(yMin)}
-        </text>
+        {tickText(MARGIN.left - 6, MARGIN.top, formatAxisValue(yMax), "end", "middle")}
+        {tickText(MARGIN.left - 6, MARGIN.top + INNER_H, formatAxisValue(yMin), "end", "middle")}
         {points.map((point, index) => {
           const cx = MARGIN.left + fraction(point.x, xMin, xMax) * INNER_W;
-          const cy = MARGIN.top + INNER_H - fraction(point.y, yMin, yMax) * INNER_H;
+          const cy =
+            MARGIN.top + INNER_H - fraction(point.y, yMin, yMax) * INNER_H;
           return (
             <circle key={index} cx={cx} cy={cy} r={3} fill={SERIES} opacity={0.6}>
               <title>{`${xField}: ${formatAxisValue(point.x)}, ${yField}: ${formatAxisValue(point.y)}`}</title>
             </circle>
           );
         })}
-        <text x={MARGIN.left} y={MARGIN.top + INNER_H + 14} textAnchor="start" fontSize={10} fill={TICK}>
-          {formatAxisValue(xMin)}
-        </text>
-        <text x={MARGIN.left + INNER_W} y={MARGIN.top + INNER_H + 14} textAnchor="end" fontSize={10} fill={TICK}>
-          {formatAxisValue(xMax)}
-        </text>
-        <text x={MARGIN.left + INNER_W / 2} y={CHART_H - 4} textAnchor="middle" fontSize={11} fill={TICK}>
-          {xField}
-        </text>
+        {tickText(MARGIN.left, MARGIN.top + INNER_H + 14, formatAxisValue(xMin), "start")}
+        {tickText(MARGIN.left + INNER_W, MARGIN.top + INNER_H + 14, formatAxisValue(xMax), "end")}
+        {axisTitle(xField)}
       </ChartFrame>
-      <p className="mt-1 text-center text-xs text-muted-foreground">
+      <Caption>
         {points.length.toLocaleString()} point{points.length === 1 ? "" : "s"} ·{" "}
         {yField} vs {xField}
-      </p>
+      </Caption>
+    </>
+  );
+}
+
+function BarChart({
+  result,
+  aggregation,
+}: {
+  result: ReturnType<typeof computeBar>;
+  aggregation: BarAggregation;
+}) {
+  if (!result) return <EmptyChart message="No rows to group." />;
+
+  const { bars, maxValue, minValue, truncated } = result;
+  const domainMin = Math.min(0, minValue);
+  const domainMax = Math.max(0, maxValue) || 1;
+  const slot = INNER_W / bars.length;
+  const gap = Math.min(6, slot * 0.2);
+  const scaleY = (value: number) =>
+    MARGIN.top + INNER_H - fraction(value, domainMin, domainMax) * INNER_H;
+  const baselineY = scaleY(0);
+
+  return (
+    <>
+      <ChartFrame>
+        {tickText(MARGIN.left - 6, MARGIN.top, formatAxisValue(domainMax), "end", "middle")}
+        {tickText(MARGIN.left - 6, baselineY, "0", "end", "middle")}
+        {bars.map((datum, index) => {
+          const top = Math.min(baselineY, scaleY(datum.value));
+          const height = Math.abs(scaleY(datum.value) - baselineY);
+          const cx = MARGIN.left + index * slot + slot / 2;
+          return (
+            <g key={datum.label}>
+              <rect
+                x={MARGIN.left + index * slot + gap / 2}
+                y={top}
+                width={Math.max(1, slot - gap)}
+                height={Math.max(0, height)}
+                fill={SERIES}
+                opacity={0.85}
+              >
+                <title>{`${datum.label}: ${formatAxisValue(datum.value)} (${datum.count} row${datum.count === 1 ? "" : "s"})`}</title>
+              </rect>
+              <text
+                x={cx}
+                y={MARGIN.top + INNER_H + 12}
+                textAnchor="end"
+                fontSize={9}
+                fill={TICK}
+                transform={`rotate(-40 ${cx} ${MARGIN.top + INNER_H + 12})`}
+              >
+                {truncateLabel(datum.label)}
+              </text>
+            </g>
+          );
+        })}
+      </ChartFrame>
+      <Caption>
+        {aggregation === "count"
+          ? "row count"
+          : aggregation === "sum"
+            ? "sum on y"
+            : "average on y"}
+        {truncated > 0 ? ` · top ${bars.length} (${truncated} more hidden)` : ""}
+      </Caption>
+    </>
+  );
+}
+
+function LineChart({
+  result,
+  field,
+}: {
+  result: ReturnType<typeof computeLine>;
+  field: string;
+}) {
+  if (!result) return <EmptyChart message="No numeric values to plot." />;
+
+  const { points, min, max, length } = result;
+  const scaleX = (index: number) =>
+    MARGIN.left + (length > 1 ? index / (length - 1) : 0.5) * INNER_W;
+  const scaleY = (value: number) =>
+    MARGIN.top + INNER_H - fraction(value, min, max) * INNER_H;
+  const path = points
+    .map((p, i) => `${i === 0 ? "M" : "L"}${scaleX(p.index)} ${scaleY(p.value)}`)
+    .join(" ");
+
+  return (
+    <>
+      <ChartFrame>
+        {tickText(MARGIN.left - 6, MARGIN.top, formatAxisValue(max), "end", "middle")}
+        {tickText(MARGIN.left - 6, MARGIN.top + INNER_H, formatAxisValue(min), "end", "middle")}
+        <path d={path} fill="none" stroke={SERIES} strokeWidth={1.5} />
+        {points.length <= 80
+          ? points.map((p) => (
+              <circle
+                key={p.index}
+                cx={scaleX(p.index)}
+                cy={scaleY(p.value)}
+                r={2}
+                fill={SERIES}
+              >
+                <title>{`#${p.index}: ${formatAxisValue(p.value)}`}</title>
+              </circle>
+            ))
+          : null}
+        {tickText(MARGIN.left, MARGIN.top + INNER_H + 14, "0", "start")}
+        {tickText(MARGIN.left + INNER_W, MARGIN.top + INNER_H + 14, String(length - 1), "end")}
+        {axisTitle("feature order")}
+      </ChartFrame>
+      <Caption>
+        {points.length.toLocaleString()} value{points.length === 1 ? "" : "s"} ·{" "}
+        {field} by feature order
+      </Caption>
+    </>
+  );
+}
+
+function BoxChart({
+  result,
+  field,
+}: {
+  result: ReturnType<typeof computeBox>;
+  field: string;
+}) {
+  if (!result) return <EmptyChart message="No numeric values to plot." />;
+
+  const { min, q1, median, q3, max, count } = result;
+  const centerX = MARGIN.left + INNER_W / 2;
+  const boxWidth = 96;
+  const scaleY = (value: number) =>
+    MARGIN.top + INNER_H - fraction(value, min, max) * INNER_H;
+
+  const stats: [string, number][] = [
+    ["max", max],
+    ["Q3", q3],
+    ["median", median],
+    ["Q1", q1],
+    ["min", min],
+  ];
+
+  return (
+    <>
+      <ChartFrame>
+        {/* whisker */}
+        <line x1={centerX} y1={scaleY(min)} x2={centerX} y2={scaleY(max)} stroke={AXIS} />
+        <line x1={centerX - 20} y1={scaleY(max)} x2={centerX + 20} y2={scaleY(max)} stroke={AXIS} />
+        <line x1={centerX - 20} y1={scaleY(min)} x2={centerX + 20} y2={scaleY(min)} stroke={AXIS} />
+        {/* box */}
+        <rect
+          x={centerX - boxWidth / 2}
+          y={scaleY(q3)}
+          width={boxWidth}
+          height={Math.max(1, scaleY(q1) - scaleY(q3))}
+          fill={SERIES}
+          opacity={0.25}
+          stroke={SERIES}
+        />
+        <line
+          x1={centerX - boxWidth / 2}
+          y1={scaleY(median)}
+          x2={centerX + boxWidth / 2}
+          y2={scaleY(median)}
+          stroke={SERIES}
+          strokeWidth={2}
+        />
+        {stats.map(([label, value]) => (
+          <text
+            key={label}
+            x={centerX + boxWidth / 2 + 8}
+            y={scaleY(value)}
+            textAnchor="start"
+            dominantBaseline="middle"
+            fontSize={10}
+            fill={TICK}
+          >
+            {`${label} ${formatAxisValue(value)}`}
+          </text>
+        ))}
+        {axisTitle(field)}
+      </ChartFrame>
+      <Caption>
+        {count.toLocaleString()} value{count === 1 ? "" : "s"} · five-number
+        summary
+      </Caption>
     </>
   );
 }

--- a/apps/geolibre-desktop/src/components/panels/AttributeChartDialog.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeChartDialog.tsx
@@ -213,9 +213,17 @@ export function AttributeChartDialog({
                     className="w-24"
                     min={MIN_HISTOGRAM_BINS}
                     max={MAX_HISTOGRAM_BINS}
-                    value={bins}
+                    // 0 is the "empty" sentinel so the field can be cleared and
+                    // retyped; computeHistogram treats it as 1, and onBlur snaps
+                    // it back to the minimum.
+                    value={bins === 0 ? "" : bins}
                     onChange={(event) => {
-                      const next = Number(event.target.value);
+                      const raw = event.target.value;
+                      if (raw === "") {
+                        setBins(0);
+                        return;
+                      }
+                      const next = Number(raw);
                       if (Number.isFinite(next)) {
                         setBins(
                           Math.max(
@@ -224,6 +232,9 @@ export function AttributeChartDialog({
                           ),
                         );
                       }
+                    }}
+                    onBlur={() => {
+                      if (bins < MIN_HISTOGRAM_BINS) setBins(MIN_HISTOGRAM_BINS);
                     }}
                   />
                 </div>
@@ -297,7 +308,11 @@ export function AttributeChartDialog({
                 <ScatterChart result={scatter} xField={xField} yField={yField} />
               )}
               {chartType === "bar" && (
-                <BarChart result={bar} aggregation={barAgg} />
+                <BarChart
+                  result={bar}
+                  aggregation={barAgg}
+                  category={catField}
+                />
               )}
               {chartType === "line" && (
                 <LineChart result={line} field={field} />
@@ -349,12 +364,19 @@ function FieldSelect({
   );
 }
 
-function ChartFrame({ children }: { children: ReactNode }) {
+function ChartFrame({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
   return (
     <svg
       viewBox={`0 0 ${CHART_W} ${CHART_H}`}
       width="100%"
       role="img"
+      aria-label={label}
       className="h-auto w-full"
       preserveAspectRatio="xMidYMid meet"
     >
@@ -439,7 +461,7 @@ function HistogramChart({
 
   return (
     <>
-      <ChartFrame>
+      <ChartFrame label={`Histogram of ${field}`}>
         {tickText(MARGIN.left - 6, MARGIN.top + INNER_H, "0", "end", "middle")}
         {tickText(MARGIN.left - 6, MARGIN.top, String(maxCount), "end", "middle")}
         {bins.map((bin, index) => {
@@ -460,8 +482,16 @@ function HistogramChart({
             </rect>
           );
         })}
-        {tickText(MARGIN.left, MARGIN.top + INNER_H + 14, formatAxisValue(min), "start")}
-        {tickText(MARGIN.left + INNER_W, MARGIN.top + INNER_H + 14, formatAxisValue(max), "end")}
+        {/* A collapsed (min === max) histogram spans the full width, so show a
+            single centered label instead of identical min/max labels. */}
+        {min === max ? (
+          tickText(MARGIN.left + INNER_W / 2, MARGIN.top + INNER_H + 14, formatAxisValue(min), "middle")
+        ) : (
+          <>
+            {tickText(MARGIN.left, MARGIN.top + INNER_H + 14, formatAxisValue(min), "start")}
+            {tickText(MARGIN.left + INNER_W, MARGIN.top + INNER_H + 14, formatAxisValue(max), "end")}
+          </>
+        )}
         {axisTitle(field)}
       </ChartFrame>
       <Caption>
@@ -484,11 +514,12 @@ function ScatterChart({
     return <EmptyChart message="No rows have both fields set to a number." />;
   }
 
-  const { points, xMin, xMax, yMin, yMax } = result;
+  const { points, total, xMin, xMax, yMin, yMax } = result;
+  const sampled = total > points.length;
 
   return (
     <>
-      <ChartFrame>
+      <ChartFrame label={`Scatter plot of ${yField} versus ${xField}`}>
         {tickText(MARGIN.left - 6, MARGIN.top, formatAxisValue(yMax), "end", "middle")}
         {tickText(MARGIN.left - 6, MARGIN.top + INNER_H, formatAxisValue(yMin), "end", "middle")}
         {points.map((point, index) => {
@@ -506,8 +537,9 @@ function ScatterChart({
         {axisTitle(xField)}
       </ChartFrame>
       <Caption>
-        {points.length.toLocaleString()} point{points.length === 1 ? "" : "s"} ·{" "}
-        {yField} vs {xField}
+        {total.toLocaleString()} point{total === 1 ? "" : "s"} · {yField} vs{" "}
+        {xField}
+        {sampled ? ` · showing ${points.length.toLocaleString()} sampled` : ""}
       </Caption>
     </>
   );
@@ -516,9 +548,11 @@ function ScatterChart({
 function BarChart({
   result,
   aggregation,
+  category,
 }: {
   result: ReturnType<typeof computeBar>;
   aggregation: BarAggregation;
+  category: string;
 }) {
   if (!result) return <EmptyChart message="No rows to group." />;
 
@@ -533,7 +567,7 @@ function BarChart({
 
   return (
     <>
-      <ChartFrame>
+      <ChartFrame label={`Bar chart of ${aggregation} by ${category}`}>
         {tickText(MARGIN.left - 6, MARGIN.top, formatAxisValue(domainMax), "end", "middle")}
         {tickText(MARGIN.left - 6, baselineY, "0", "end", "middle")}
         {bars.map((datum, index) => {
@@ -598,7 +632,7 @@ function LineChart({
 
   return (
     <>
-      <ChartFrame>
+      <ChartFrame label={`Line chart of ${field} by feature order`}>
         {tickText(MARGIN.left - 6, MARGIN.top, formatAxisValue(max), "end", "middle")}
         {tickText(MARGIN.left - 6, MARGIN.top + INNER_H, formatAxisValue(min), "end", "middle")}
         <path d={path} fill="none" stroke={SERIES} strokeWidth={1.5} />
@@ -652,7 +686,7 @@ function BoxChart({
 
   return (
     <>
-      <ChartFrame>
+      <ChartFrame label={`Box plot of ${field}`}>
         {/* whisker */}
         <line x1={centerX} y1={scaleY(min)} x2={centerX} y2={scaleY(max)} stroke={AXIS} />
         <line x1={centerX - 20} y1={scaleY(max)} x2={centerX + 20} y2={scaleY(max)} stroke={AXIS} />

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -40,6 +40,7 @@ import {
   ArrowRight,
   ArrowUp,
   Calculator,
+  ChartColumn,
   Columns3,
   Download,
   EyeOff,
@@ -85,6 +86,7 @@ import {
   fieldReference,
   type CalcOutputType,
 } from "../../lib/attribute-expression";
+import { AttributeChartDialog } from "./AttributeChartDialog";
 import {
   exportVectorLayer,
   formatAttributeValue,
@@ -287,6 +289,8 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
   const [newColumnName, setNewColumnName] = useState("");
   const [newColumnType, setNewColumnType] = useState<NewColumnType>("text");
   const [newColumnDefault, setNewColumnDefault] = useState("");
+  // Charts dialog state.
+  const [chartOpen, setChartOpen] = useState(false);
   // Field-calculator dialog state.
   const [calcOpen, setCalcOpen] = useState(false);
   const [calcMode, setCalcMode] = useState<"update" | "create">("update");
@@ -1250,6 +1254,24 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
             </DropdownMenuContent>
           </DropdownMenu>
         ) : null}
+        {!isEditing ? (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 px-2"
+            title={
+              hasAttributeSource
+                ? "Chart numeric fields"
+                : "Charts require a vector or DuckDB query layer"
+            }
+            aria-label="Charts"
+            disabled={!hasAttributeSource}
+            onClick={() => setChartOpen(true)}
+          >
+            <ChartColumn className="h-3.5 w-3.5" />
+            <span className="hidden sm:inline">Charts</span>
+          </Button>
+        ) : null}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
@@ -1704,6 +1726,13 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
           </div>
         </DialogContent>
       </Dialog>
+      <AttributeChartDialog
+        open={chartOpen}
+        onOpenChange={setChartOpen}
+        rows={attributeRows}
+        columns={discoveredColumns}
+        layerName={layer?.name ?? ""}
+      />
     </section>
   );
 }

--- a/apps/geolibre-desktop/src/lib/attribute-charts.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-charts.ts
@@ -6,7 +6,7 @@
  * already builds for both GeoJSON and DuckDB query layers.
  */
 
-export type ChartType = "histogram" | "scatter";
+export type ChartType = "histogram" | "scatter" | "bar" | "line" | "box";
 
 /** A row as seen by the chart helpers — only its property bag matters. */
 export interface ChartRow {
@@ -16,6 +16,11 @@ export interface ChartRow {
 export const MIN_HISTOGRAM_BINS = 1;
 export const MAX_HISTOGRAM_BINS = 50;
 export const DEFAULT_HISTOGRAM_BINS = 10;
+/** A field is offered as a bar category only if it has at most this many
+ * distinct values (so high-cardinality id/text columns are excluded). */
+export const MAX_CATEGORY_CARDINALITY = 50;
+/** The bar chart renders at most this many categories (top-N by value). */
+export const MAX_BAR_CATEGORIES = 20;
 
 /**
  * Parse a value into a finite number, or null when it cannot be one. Numeric
@@ -195,4 +200,184 @@ export function formatAxisValue(value: number): string {
     return value.toExponential(1);
   }
   return parseFloat(value.toFixed(3)).toString();
+}
+
+// A column also counts as categorical only when its distinct values are few:
+// at most this many in absolute terms, OR at most this fraction of its non-null
+// rows. This rejects mostly-unique id/text columns and continuous numeric fields
+// (which have ~one distinct value per row) while still accepting genuine
+// enumerations even in small datasets.
+const CATEGORY_ABSOLUTE_LIMIT = 15;
+const CATEGORY_RATIO = 0.5;
+
+/**
+ * Columns suitable as a bar-chart category: a field whose non-null values have
+ * between one and `MAX_CATEGORY_CARDINALITY` distinct entries AND are repetitive
+ * enough to be a category rather than an id (see the limits above). Low-
+ * cardinality numeric codes (e.g. a year or class id) qualify; a continuous
+ * numeric field or a unique-per-row text column does not.
+ */
+export function categoricalColumns(
+  rows: ChartRow[],
+  columns: string[],
+  maxCardinality: number = MAX_CATEGORY_CARDINALITY,
+): string[] {
+  return columns.filter((key) => {
+    const distinct = new Set<string>();
+    let nonNull = 0;
+    for (const row of rows) {
+      const raw = row.properties[key];
+      if (raw == null || raw === "") continue;
+      nonNull += 1;
+      distinct.add(String(raw));
+      if (distinct.size > maxCardinality) return false;
+    }
+    if (distinct.size < 1) return false;
+    const limit = Math.max(CATEGORY_ABSOLUTE_LIMIT, nonNull * CATEGORY_RATIO);
+    return distinct.size <= limit;
+  });
+}
+
+export type BarAggregation = "count" | "sum" | "mean";
+
+export interface BarDatum {
+  label: string;
+  /** The aggregated value the bar's length encodes. */
+  value: number;
+  /** How many rows fell into this category (independent of aggregation). */
+  count: number;
+}
+
+export interface BarResult {
+  bars: BarDatum[];
+  /** Largest bar value, for scaling (>= 0). */
+  maxValue: number;
+  /** Smallest bar value; negative when sum/mean produce negatives. */
+  minValue: number;
+  /** Categories dropped past the top-N cap. */
+  truncated: number;
+}
+
+/**
+ * Group rows by a category field and aggregate. `count` tallies rows per
+ * category; `sum`/`mean` reduce the finite values of `valueKey`. Bars are sorted
+ * by value descending and capped at `maxBars` (the remainder is reported in
+ * `truncated`). Null/blank category values are bucketed as "(blank)". Returns
+ * null when there are no rows.
+ */
+export function computeBar(
+  rows: ChartRow[],
+  categoryKey: string,
+  aggregation: BarAggregation,
+  valueKey: string | null,
+  maxBars: number = MAX_BAR_CATEGORIES,
+): BarResult | null {
+  const groups = new Map<
+    string,
+    { count: number; sum: number; numericCount: number }
+  >();
+  for (const row of rows) {
+    const raw = row.properties[categoryKey];
+    const label = raw == null || raw === "" ? "(blank)" : String(raw);
+    const group = groups.get(label) ?? { count: 0, sum: 0, numericCount: 0 };
+    group.count += 1;
+    if (aggregation !== "count" && valueKey) {
+      const value = toFiniteNumber(row.properties[valueKey]);
+      if (value !== null) {
+        group.sum += value;
+        group.numericCount += 1;
+      }
+    }
+    groups.set(label, group);
+  }
+  if (groups.size === 0) return null;
+
+  const all: BarDatum[] = [...groups.entries()].map(([label, group]) => {
+    let value = group.count;
+    if (aggregation === "sum") value = group.sum;
+    else if (aggregation === "mean") {
+      value = group.numericCount > 0 ? group.sum / group.numericCount : 0;
+    }
+    return { label, value, count: group.count };
+  });
+  all.sort((a, b) => b.value - a.value);
+
+  const bars = all.slice(0, Math.max(1, maxBars));
+  let maxValue = 0;
+  let minValue = 0;
+  for (const bar of bars) {
+    if (bar.value > maxValue) maxValue = bar.value;
+    if (bar.value < minValue) minValue = bar.value;
+  }
+  return { bars, maxValue, minValue, truncated: Math.max(0, all.length - bars.length) };
+}
+
+export interface LinePoint {
+  /** Original row index (x position). */
+  index: number;
+  value: number;
+}
+
+export interface LineResult {
+  points: LinePoint[];
+  min: number;
+  max: number;
+  /** Total row count, so x can span the full feature order. */
+  length: number;
+}
+
+/**
+ * The finite values of a numeric field plotted against original row order.
+ * Rows without a finite value are skipped (leaving a gap), keeping each point's
+ * x at its true feature index. Returns null when no row has a value.
+ */
+export function computeLine(rows: ChartRow[], key: string): LineResult | null {
+  const points: LinePoint[] = [];
+  let min = Infinity;
+  let max = -Infinity;
+  rows.forEach((row, index) => {
+    const value = toFiniteNumber(row.properties[key]);
+    if (value === null) return;
+    points.push({ index, value });
+    if (value < min) min = value;
+    if (value > max) max = value;
+  });
+  if (points.length === 0) return null;
+  return { points, min, max, length: rows.length };
+}
+
+export interface BoxResult {
+  min: number;
+  q1: number;
+  median: number;
+  q3: number;
+  max: number;
+  count: number;
+}
+
+/** Linear-interpolation quantile of an already-sorted, non-empty array. */
+function quantileSorted(sorted: number[], p: number): number {
+  if (sorted.length === 1) return sorted[0];
+  const pos = (sorted.length - 1) * p;
+  const base = Math.floor(pos);
+  const rest = pos - base;
+  const next = sorted[base + 1];
+  return next === undefined ? sorted[base] : sorted[base] + rest * (next - sorted[base]);
+}
+
+/**
+ * Five-number summary (min, Q1, median, Q3, max) of a set of values. Returns
+ * null when empty.
+ */
+export function computeBox(values: number[]): BoxResult | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  return {
+    min: sorted[0],
+    q1: quantileSorted(sorted, 0.25),
+    median: quantileSorted(sorted, 0.5),
+    q3: quantileSorted(sorted, 0.75),
+    max: sorted[sorted.length - 1],
+    count: sorted.length,
+  };
 }

--- a/apps/geolibre-desktop/src/lib/attribute-charts.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-charts.ts
@@ -146,8 +146,14 @@ export interface ScatterPoint {
   y: number;
 }
 
+/** Cap on scatter points actually rendered, to bound SVG node count. */
+export const MAX_SCATTER_POINTS = 2000;
+
 export interface ScatterResult {
+  /** Points to render — a leading sample capped at `MAX_SCATTER_POINTS`. */
   points: ScatterPoint[];
+  /** All valid (x, y) pairs; `points` is a sample of these when capped. */
+  total: number;
   xMin: number;
   xMax: number;
   yMin: number;
@@ -156,35 +162,42 @@ export interface ScatterResult {
 
 /**
  * Extract the (x, y) pairs where both columns hold a finite number. Returns null
- * when no row has both. Single-axis degenerate ranges (all x equal, etc.) are
- * left to the renderer to pad.
+ * when no row has both. Extents span every valid pair, but `points` is capped at
+ * `maxPoints` so a huge layer doesn't render tens of thousands of SVG nodes;
+ * `total` reports the full count. Degenerate single-axis ranges are left to the
+ * renderer to pad.
  */
 export function computeScatter(
   rows: ChartRow[],
   xKey: string,
   yKey: string,
+  maxPoints: number = MAX_SCATTER_POINTS,
 ): ScatterResult | null {
   const points: ScatterPoint[] = [];
+  let total = 0;
+  let xMin = 0;
+  let xMax = 0;
+  let yMin = 0;
+  let yMax = 0;
   for (const row of rows) {
     const x = toFiniteNumber(row.properties[xKey]);
     const y = toFiniteNumber(row.properties[yKey]);
     if (x === null || y === null) continue;
-    points.push({ x, y });
+    if (total === 0) {
+      xMin = xMax = x;
+      yMin = yMax = y;
+    } else {
+      if (x < xMin) xMin = x;
+      if (x > xMax) xMax = x;
+      if (y < yMin) yMin = y;
+      if (y > yMax) yMax = y;
+    }
+    total += 1;
+    if (points.length < maxPoints) points.push({ x, y });
   }
-  if (points.length === 0) return null;
+  if (total === 0) return null;
 
-  let xMin = points[0].x;
-  let xMax = points[0].x;
-  let yMin = points[0].y;
-  let yMax = points[0].y;
-  for (const point of points) {
-    if (point.x < xMin) xMin = point.x;
-    if (point.x > xMax) xMax = point.x;
-    if (point.y < yMin) yMin = point.y;
-    if (point.y > yMax) yMax = point.y;
-  }
-
-  return { points, xMin, xMax, yMin, yMax };
+  return { points, total, xMin, xMax, yMin, yMax };
 }
 
 /**
@@ -194,11 +207,13 @@ export function computeScatter(
  */
 export function formatAxisValue(value: number): string {
   if (!Number.isFinite(value)) return "";
-  if (Number.isInteger(value)) return String(value);
   const abs = Math.abs(value);
-  if (abs !== 0 && (abs < 1e-3 || abs >= 1e6)) {
+  // Exponential for extreme magnitudes — checked before the integer path so a
+  // huge integer (e.g. 9e15) doesn't print 16 digits and overflow the label.
+  if (abs !== 0 && (abs < 1e-3 || abs >= 1e7)) {
     return value.toExponential(1);
   }
+  if (Number.isInteger(value)) return String(value);
   return parseFloat(value.toFixed(3)).toString();
 }
 

--- a/apps/geolibre-desktop/src/lib/attribute-charts.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-charts.ts
@@ -356,6 +356,11 @@ export interface LineResult {
  * The finite values of a numeric field plotted against original row order.
  * Rows without a finite value are skipped (leaving a gap), keeping each point's
  * x at its true feature index. Returns null when no row has a value.
+ *
+ * Like the other compute helpers, this runs synchronously over every row and is
+ * meant for the in-memory feature sets the attribute table already holds; it
+ * does not page very large layers (the rendered marker count is capped in the
+ * dialog, but the path spans all points).
  */
 export function computeLine(rows: ChartRow[], key: string): LineResult | null {
   const points: LinePoint[] = [];
@@ -396,7 +401,9 @@ function quantileSorted(sorted: number[], p: number): number {
 
 /**
  * Five-number summary (min, Q1, median, Q3, max) of a set of values. Returns
- * null when empty.
+ * null when empty. Sorts a copy of all values synchronously — intended for the
+ * attribute table's in-memory feature sets, not as a pager for arbitrarily
+ * large query results.
  */
 export function computeBox(values: number[]): BoxResult | null {
   if (values.length === 0) return null;

--- a/apps/geolibre-desktop/src/lib/attribute-charts.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-charts.ts
@@ -1,0 +1,198 @@
+/**
+ * Pure data helpers for the attribute Charts panel: numeric-column detection,
+ * histogram binning, and scatter extraction. Kept free of any rendering or React
+ * so they can be unit-tested in isolation; the SVG drawing lives in the dialog
+ * component. Operates on the same `{ properties }` rows the attribute table
+ * already builds for both GeoJSON and DuckDB query layers.
+ */
+
+export type ChartType = "histogram" | "scatter";
+
+/** A row as seen by the chart helpers — only its property bag matters. */
+export interface ChartRow {
+  properties: Record<string, unknown>;
+}
+
+export const MIN_HISTOGRAM_BINS = 1;
+export const MAX_HISTOGRAM_BINS = 50;
+export const DEFAULT_HISTOGRAM_BINS = 10;
+
+/**
+ * Parse a value into a finite number, or null when it cannot be one. Numeric
+ * strings (`"42"`, `" 3.5 "`) are accepted; empty/blank, boolean, null, NaN and
+ * Infinity are rejected so they never enter a chart.
+ */
+export function toFiniteNumber(value: unknown): number | null {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed === "") return null;
+    const next = Number(trimmed);
+    return Number.isFinite(next) ? next : null;
+  }
+  return null;
+}
+
+/**
+ * Columns suitable for charting: a key counts as numeric when it has at least
+ * two finite-number values and those make up at least half of its non-null
+ * values (so an id-like column of mostly strings with a stray number is
+ * excluded). Returned in the order the columns were given.
+ */
+export function numericColumns(rows: ChartRow[], columns: string[]): string[] {
+  return columns.filter((key) => {
+    let numeric = 0;
+    let nonNull = 0;
+    for (const row of rows) {
+      const raw = row.properties[key];
+      if (raw == null || raw === "") continue;
+      nonNull += 1;
+      if (toFiniteNumber(raw) !== null) numeric += 1;
+    }
+    return numeric >= 2 && numeric >= nonNull / 2;
+  });
+}
+
+/** Pull the finite numeric values of one column out of the rows. */
+export function numericValues(rows: ChartRow[], key: string): number[] {
+  const values: number[] = [];
+  for (const row of rows) {
+    const next = toFiniteNumber(row.properties[key]);
+    if (next !== null) values.push(next);
+  }
+  return values;
+}
+
+export interface HistogramBin {
+  /** Inclusive lower edge. */
+  x0: number;
+  /** Exclusive upper edge (inclusive for the final bin). */
+  x1: number;
+  count: number;
+}
+
+export interface HistogramResult {
+  bins: HistogramBin[];
+  min: number;
+  max: number;
+  /** How many values were binned. */
+  total: number;
+  /** The tallest bin's count, for scaling the y axis. */
+  maxCount: number;
+}
+
+/**
+ * Bin a set of values into `binCount` equal-width buckets. Returns null when
+ * there are no values. When every value is identical (min === max) a single
+ * bin holding them all is returned, avoiding a zero-width divide.
+ */
+export function computeHistogram(
+  values: number[],
+  binCount: number,
+): HistogramResult | null {
+  if (values.length === 0) return null;
+
+  let min = values[0];
+  let max = values[0];
+  for (const value of values) {
+    if (value < min) min = value;
+    if (value > max) max = value;
+  }
+
+  if (min === max) {
+    return {
+      bins: [{ x0: min, x1: max, count: values.length }],
+      min,
+      max,
+      total: values.length,
+      maxCount: values.length,
+    };
+  }
+
+  const requested = Math.trunc(binCount);
+  // Clamp a finite request into range (so 0 → 1, not the default); fall back to
+  // the default only for a non-finite request (NaN/Infinity).
+  const count = Number.isFinite(requested)
+    ? Math.max(MIN_HISTOGRAM_BINS, Math.min(MAX_HISTOGRAM_BINS, requested))
+    : DEFAULT_HISTOGRAM_BINS;
+  const width = (max - min) / count;
+  const bins: HistogramBin[] = Array.from({ length: count }, (_, i) => ({
+    x0: min + i * width,
+    x1: i === count - 1 ? max : min + (i + 1) * width,
+    count: 0,
+  }));
+
+  for (const value of values) {
+    // Clamp so the maximum value lands in the last bin rather than index `count`.
+    const index = Math.min(count - 1, Math.floor((value - min) / width));
+    bins[index].count += 1;
+  }
+
+  let maxCount = 0;
+  for (const bin of bins) {
+    if (bin.count > maxCount) maxCount = bin.count;
+  }
+
+  return { bins, min, max, total: values.length, maxCount };
+}
+
+export interface ScatterPoint {
+  x: number;
+  y: number;
+}
+
+export interface ScatterResult {
+  points: ScatterPoint[];
+  xMin: number;
+  xMax: number;
+  yMin: number;
+  yMax: number;
+}
+
+/**
+ * Extract the (x, y) pairs where both columns hold a finite number. Returns null
+ * when no row has both. Single-axis degenerate ranges (all x equal, etc.) are
+ * left to the renderer to pad.
+ */
+export function computeScatter(
+  rows: ChartRow[],
+  xKey: string,
+  yKey: string,
+): ScatterResult | null {
+  const points: ScatterPoint[] = [];
+  for (const row of rows) {
+    const x = toFiniteNumber(row.properties[xKey]);
+    const y = toFiniteNumber(row.properties[yKey]);
+    if (x === null || y === null) continue;
+    points.push({ x, y });
+  }
+  if (points.length === 0) return null;
+
+  let xMin = points[0].x;
+  let xMax = points[0].x;
+  let yMin = points[0].y;
+  let yMax = points[0].y;
+  for (const point of points) {
+    if (point.x < xMin) xMin = point.x;
+    if (point.x > xMax) xMax = point.x;
+    if (point.y < yMin) yMin = point.y;
+    if (point.y > yMax) yMax = point.y;
+  }
+
+  return { points, xMin, xMax, yMin, yMax };
+}
+
+/**
+ * Format a numeric axis label compactly: integers as-is, otherwise up to 3
+ * significant-ish decimals with trailing zeros trimmed. Large/small magnitudes
+ * fall back to exponential so labels stay short.
+ */
+export function formatAxisValue(value: number): string {
+  if (!Number.isFinite(value)) return "";
+  if (Number.isInteger(value)) return String(value);
+  const abs = Math.abs(value);
+  if (abs !== 0 && (abs < 1e-3 || abs >= 1e6)) {
+    return value.toExponential(1);
+  }
+  return parseFloat(value.toFixed(3)).toString();
+}

--- a/apps/geolibre-desktop/src/lib/attribute-charts.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-charts.ts
@@ -248,6 +248,9 @@ export function categoricalColumns(
       if (distinct.size > maxCardinality) return false;
     }
     if (distinct.size < 1) return false;
+    // A field where every populated row is unique is an id, not a category —
+    // reject it even in a small sample where the limit below would let it pass.
+    if (nonNull > 1 && distinct.size === nonNull) return false;
     const limit = Math.max(CATEGORY_ABSOLUTE_LIMIT, nonNull * CATEGORY_RATIO);
     return distinct.size <= limit;
   });
@@ -307,14 +310,17 @@ export function computeBar(
   }
   if (groups.size === 0) return null;
 
-  const all: BarDatum[] = [...groups.entries()].map(([label, group]) => {
-    let value = group.count;
-    if (aggregation === "sum") value = group.sum;
-    else if (aggregation === "mean") {
-      value = group.numericCount > 0 ? group.sum / group.numericCount : 0;
-    }
-    return { label, value, count: group.count };
-  });
+  const all: BarDatum[] = [...groups.entries()]
+    // For sum/mean, drop categories with no numeric samples rather than show a
+    // misleading zero bar that could also displace a real category from top-N.
+    .filter(([, group]) => aggregation === "count" || group.numericCount > 0)
+    .map(([label, group]) => {
+      let value = group.count;
+      if (aggregation === "sum") value = group.sum;
+      else if (aggregation === "mean") value = group.sum / group.numericCount;
+      return { label, value, count: group.count };
+    });
+  if (all.length === 0) return null;
   all.sort((a, b) => b.value - a.value);
 
   const bars = all.slice(0, Math.max(1, maxBars));

--- a/apps/geolibre-desktop/src/lib/attribute-charts.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-charts.ts
@@ -162,10 +162,10 @@ export interface ScatterResult {
 
 /**
  * Extract the (x, y) pairs where both columns hold a finite number. Returns null
- * when no row has both. Extents span every valid pair, but `points` is capped at
- * `maxPoints` so a huge layer doesn't render tens of thousands of SVG nodes;
- * `total` reports the full count. Degenerate single-axis ranges are left to the
- * renderer to pad.
+ * when no row has both. Extents span every valid pair. When there are more than
+ * `maxPoints`, `points` is an **evenly strided** subset (not the leading rows)
+ * so a huge — and often spatially-ordered — layer renders a representative
+ * sample rather than just its first features; `total` reports the full count.
  */
 export function computeScatter(
   rows: ChartRow[],
@@ -173,8 +173,7 @@ export function computeScatter(
   yKey: string,
   maxPoints: number = MAX_SCATTER_POINTS,
 ): ScatterResult | null {
-  const points: ScatterPoint[] = [];
-  let total = 0;
+  const all: ScatterPoint[] = [];
   let xMin = 0;
   let xMax = 0;
   let yMin = 0;
@@ -183,7 +182,7 @@ export function computeScatter(
     const x = toFiniteNumber(row.properties[xKey]);
     const y = toFiniteNumber(row.properties[yKey]);
     if (x === null || y === null) continue;
-    if (total === 0) {
+    if (all.length === 0) {
       xMin = xMax = x;
       yMin = yMax = y;
     } else {
@@ -192,12 +191,16 @@ export function computeScatter(
       if (y < yMin) yMin = y;
       if (y > yMax) yMax = y;
     }
-    total += 1;
-    if (points.length < maxPoints) points.push({ x, y });
+    all.push({ x, y });
   }
-  if (total === 0) return null;
+  if (all.length === 0) return null;
 
-  return { points, total, xMin, xMax, yMin, yMax };
+  let points = all;
+  if (all.length > maxPoints) {
+    const stride = Math.ceil(all.length / maxPoints);
+    points = all.filter((_, index) => index % stride === 0);
+  }
+  return { points, total: all.length, xMin, xMax, yMin, yMax };
 }
 
 /**
@@ -281,7 +284,9 @@ export interface BarResult {
  * category; `sum`/`mean` reduce the finite values of `valueKey`. Bars are sorted
  * by value descending and capped at `maxBars` (the remainder is reported in
  * `truncated`). Null/blank category values are bucketed as "(blank)". Returns
- * null when there are no rows.
+ * null when there are no rows, or — for `sum`/`mean` — when no category has any
+ * numeric value to aggregate (those categories are dropped rather than shown as
+ * misleading zero bars).
  */
 export function computeBar(
   rows: ChartRow[],
@@ -356,13 +361,16 @@ export function computeLine(rows: ChartRow[], key: string): LineResult | null {
   const points: LinePoint[] = [];
   let min = Infinity;
   let max = -Infinity;
-  rows.forEach((row, index) => {
+  let index = 0;
+  for (const row of rows) {
     const value = toFiniteNumber(row.properties[key]);
-    if (value === null) return;
-    points.push({ index, value });
-    if (value < min) min = value;
-    if (value > max) max = value;
-  });
+    if (value !== null) {
+      points.push({ index, value });
+      if (value < min) min = value;
+      if (value > max) max = value;
+    }
+    index += 1;
+  }
   if (points.length === 0) return null;
   return { points, min, max, length: rows.length };
 }

--- a/apps/geolibre-desktop/src/lib/chart-export.ts
+++ b/apps/geolibre-desktop/src/lib/chart-export.ts
@@ -1,0 +1,110 @@
+/**
+ * Export an inline chart `<svg>` as a downloadable SVG or PNG file. The charts
+ * paint with theme CSS variables (e.g. `hsl(var(--primary))`) which do not
+ * resolve outside the app, so the variables are substituted with their computed
+ * values before serializing. Kept DOM-only and framework-free.
+ */
+
+// The theme CSS variables the chart SVG references, resolved at export time.
+const CHART_COLOR_VARS = [
+  "--border",
+  "--muted-foreground",
+  "--primary",
+] as const;
+
+/** Read a CSS custom property off the document root as an `hsl(...)` string. */
+function resolvedHsl(name: string): string | null {
+  const value = getComputedStyle(document.documentElement)
+    .getPropertyValue(name)
+    .trim();
+  return value ? `hsl(${value})` : null;
+}
+
+/**
+ * Serialize a chart SVG into a standalone document string: clone it, set
+ * explicit pixel dimensions, declare the SVG namespace, and replace each
+ * `hsl(var(--x))` reference with the current theme's resolved color.
+ */
+export function serializeChartSvg(
+  svg: SVGSVGElement,
+  width: number,
+  height: number,
+): string {
+  const clone = svg.cloneNode(true) as SVGSVGElement;
+  clone.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+  clone.setAttribute("width", String(width));
+  clone.setAttribute("height", String(height));
+
+  let source = new XMLSerializer().serializeToString(clone);
+  for (const name of CHART_COLOR_VARS) {
+    const resolved = resolvedHsl(name);
+    if (resolved) source = source.split(`hsl(var(${name}))`).join(resolved);
+  }
+  return source;
+}
+
+function triggerDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}
+
+/** Download the chart as a standalone `.svg` file. */
+export function downloadChartSvg(
+  svg: SVGSVGElement,
+  width: number,
+  height: number,
+  filename: string,
+): void {
+  const source = serializeChartSvg(svg, width, height);
+  triggerDownload(
+    new Blob([source], { type: "image/svg+xml;charset=utf-8" }),
+    filename,
+  );
+}
+
+/**
+ * Rasterize the chart to a `.png` at `scale`× resolution. Paints an opaque
+ * background first (defaults to the theme `--background`) so the export isn't
+ * transparent. Resolves once the file has been handed to the browser.
+ */
+export async function downloadChartPng(
+  svg: SVGSVGElement,
+  width: number,
+  height: number,
+  filename: string,
+  scale = 2,
+): Promise<void> {
+  const source = serializeChartSvg(svg, width, height);
+  const svgUrl = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(source)}`;
+
+  const image = new Image();
+  await new Promise<void>((resolve, reject) => {
+    image.onload = () => resolve();
+    image.onerror = () => reject(new Error("Could not render chart image."));
+    image.src = svgUrl;
+  });
+
+  const canvas = document.createElement("canvas");
+  canvas.width = Math.round(width * scale);
+  canvas.height = Math.round(height * scale);
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Canvas 2D context unavailable.");
+
+  ctx.fillStyle = resolvedHsl("--background") ?? "#ffffff";
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.scale(scale, scale);
+  ctx.drawImage(image, 0, 0, width, height);
+
+  await new Promise<void>((resolve) => {
+    canvas.toBlob((blob) => {
+      if (blob) triggerDownload(blob, filename);
+      resolve();
+    }, "image/png");
+  });
+}

--- a/apps/geolibre-desktop/src/lib/chart-export.ts
+++ b/apps/geolibre-desktop/src/lib/chart-export.ts
@@ -101,9 +101,13 @@ export async function downloadChartPng(
   ctx.scale(scale, scale);
   ctx.drawImage(image, 0, 0, width, height);
 
-  await new Promise<void>((resolve) => {
+  await new Promise<void>((resolve, reject) => {
     canvas.toBlob((blob) => {
-      if (blob) triggerDownload(blob, filename);
+      if (!blob) {
+        reject(new Error("Could not encode the chart image."));
+        return;
+      }
+      triggerDownload(blob, filename);
       resolve();
     }, "image/png");
   });

--- a/tests/attribute-charts.test.ts
+++ b/tests/attribute-charts.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  categoricalColumns,
+  computeBar,
+  computeBox,
   computeHistogram,
+  computeLine,
   computeScatter,
   formatAxisValue,
   numericColumns,
@@ -112,6 +116,123 @@ describe("computeScatter", () => {
   it("returns null when no row has both values", () => {
     const data = rows({ x: 1, y: null }, { x: null, y: 2 });
     assert.equal(computeScatter(data, "x", "y"), null);
+  });
+});
+
+describe("categoricalColumns", () => {
+  it("keeps low-cardinality fields and drops high-cardinality ones", () => {
+    const data = rows(
+      { kind: "a", id: "u1" },
+      { kind: "b", id: "u2" },
+      { kind: "a", id: "u3" },
+      { kind: "a", id: "u4" },
+    );
+    // kind has 2 distinct values; id has 4 (one per row) → excluded at cap 3.
+    assert.deepEqual(categoricalColumns(data, ["kind", "id"], 3), ["kind"]);
+  });
+
+  it("treats low-cardinality numeric codes as categorical", () => {
+    const data = rows({ year: 2020 }, { year: 2021 }, { year: 2020 });
+    assert.deepEqual(categoricalColumns(data, ["year"]), ["year"]);
+  });
+
+  it("rejects mostly-unique id-like columns relative to row count", () => {
+    // 20 rows: `name` is unique per row (id-like) and excluded; `kind` repeats.
+    const data = Array.from({ length: 20 }, (_, i) => ({
+      properties: { name: `n${i}`, kind: i % 2 === 0 ? "x" : "y" },
+    }));
+    assert.deepEqual(categoricalColumns(data, ["name", "kind"]), ["kind"]);
+  });
+});
+
+describe("computeBar", () => {
+  const data = rows(
+    { kind: "a", pop: 10 },
+    { kind: "b", pop: 20 },
+    { kind: "a", pop: 30 },
+    { kind: "a", pop: null },
+  );
+
+  it("counts rows per category, sorted by value descending", () => {
+    const result = computeBar(data, "kind", "count", null);
+    assert.ok(result);
+    assert.deepEqual(
+      result.bars.map((b) => [b.label, b.value]),
+      [
+        ["a", 3],
+        ["b", 1],
+      ],
+    );
+    assert.equal(result.maxValue, 3);
+  });
+
+  it("sums and averages a value field over finite values only", () => {
+    const sum = computeBar(data, "kind", "sum", "pop");
+    assert.equal(sum?.bars.find((b) => b.label === "a")?.value, 40);
+    const mean = computeBar(data, "kind", "mean", "pop");
+    // category "a": values 10 and 30 (null skipped) → mean 20
+    assert.equal(mean?.bars.find((b) => b.label === "a")?.value, 20);
+  });
+
+  it("buckets null/blank categories as (blank) and caps to top-N", () => {
+    const blanks = rows({ k: null }, { k: "" }, { k: "x" });
+    const result = computeBar(blanks, "k", "count", null);
+    assert.equal(result?.bars.find((b) => b.label === "(blank)")?.value, 2);
+
+    const many = rows(
+      { k: "a" },
+      { k: "b" },
+      { k: "c" },
+      { k: "a" },
+    );
+    const capped = computeBar(many, "k", "count", null, 2);
+    assert.equal(capped?.bars.length, 2);
+    assert.equal(capped?.truncated, 1);
+  });
+});
+
+describe("computeLine", () => {
+  it("keeps original row index as x and skips non-numeric rows", () => {
+    const data = rows({ v: 5 }, { v: "x" }, { v: 9 });
+    const result = computeLine(data, "v");
+    assert.ok(result);
+    assert.deepEqual(result.points, [
+      { index: 0, value: 5 },
+      { index: 2, value: 9 },
+    ]);
+    assert.equal(result.min, 5);
+    assert.equal(result.max, 9);
+    assert.equal(result.length, 3);
+  });
+
+  it("returns null when no value is numeric", () => {
+    assert.equal(computeLine(rows({ v: "a" }), "v"), null);
+  });
+});
+
+describe("computeBox", () => {
+  it("computes the five-number summary with interpolation", () => {
+    const result = computeBox([1, 2, 3, 4, 5]);
+    assert.deepEqual(result, {
+      min: 1,
+      q1: 2,
+      median: 3,
+      q3: 4,
+      max: 5,
+      count: 5,
+    });
+  });
+
+  it("handles a single value and empty input", () => {
+    assert.deepEqual(computeBox([7]), {
+      min: 7,
+      q1: 7,
+      median: 7,
+      q3: 7,
+      max: 7,
+      count: 1,
+    });
+    assert.equal(computeBox([]), null);
   });
 });
 

--- a/tests/attribute-charts.test.ts
+++ b/tests/attribute-charts.test.ts
@@ -195,6 +195,13 @@ describe("computeBar", () => {
     assert.equal(mean?.bars.find((b) => b.label === "a")?.value, 20);
   });
 
+  it("reports a negative minValue and zero maxValue for all-negative sums", () => {
+    const data = rows({ k: "a", v: -5 }, { k: "a", v: -3 }, { k: "b", v: -1 });
+    const result = computeBar(data, "k", "sum", "v");
+    assert.equal(result?.maxValue, 0);
+    assert.equal(result?.minValue, -8);
+  });
+
   it("omits sum/mean categories that have no numeric samples", () => {
     const data = rows(
       { kind: "a", v: 5 },

--- a/tests/attribute-charts.test.ts
+++ b/tests/attribute-charts.test.ts
@@ -129,6 +129,19 @@ describe("computeScatter", () => {
     assert.equal(result.yMax, 9);
   });
 
+  it("samples evenly across the dataset, not just the leading rows", () => {
+    const data = Array.from({ length: 10 }, (_, i) => ({
+      properties: { x: i, y: i },
+    }));
+    const result = computeScatter(data, "x", "y", 5);
+    assert.ok(result);
+    // stride = ceil(10/5) = 2 → indices 0,2,4,6,8 span the whole range.
+    assert.deepEqual(
+      result.points.map((p) => p.x),
+      [0, 2, 4, 6, 8],
+    );
+  });
+
   it("returns null when no row has both values", () => {
     const data = rows({ x: 1, y: null }, { x: null, y: 2 });
     assert.equal(computeScatter(data, "x", "y"), null);

--- a/tests/attribute-charts.test.ts
+++ b/tests/attribute-charts.test.ts
@@ -107,10 +107,26 @@ describe("computeScatter", () => {
       { x: 1, y: 10 },
       { x: 2, y: 20 },
     ]);
+    assert.equal(result.total, 2);
     assert.equal(result.xMin, 1);
     assert.equal(result.xMax, 2);
     assert.equal(result.yMin, 10);
     assert.equal(result.yMax, 20);
+  });
+
+  it("caps rendered points but keeps full count and extents", () => {
+    const data = rows(
+      { x: 1, y: 1 },
+      { x: 2, y: 2 },
+      { x: 3, y: 3 },
+      { x: 9, y: 9 },
+    );
+    const result = computeScatter(data, "x", "y", 2);
+    assert.ok(result);
+    assert.equal(result.points.length, 2); // capped sample
+    assert.equal(result.total, 4); // full count
+    assert.equal(result.xMax, 9); // extents span all points, not just the sample
+    assert.equal(result.yMax, 9);
   });
 
   it("returns null when no row has both values", () => {
@@ -243,5 +259,10 @@ describe("formatAxisValue", () => {
     assert.equal(formatAxisValue(0.5), "0.5");
     assert.equal(formatAxisValue(1234567), "1234567");
     assert.equal(formatAxisValue(0.0001), "1.0e-4");
+    // negatives mirror their positive counterparts
+    assert.equal(formatAxisValue(-42), "-42");
+    assert.equal(formatAxisValue(-0.0001), "-1.0e-4");
+    // very large integers switch to exponential so labels stay short
+    assert.equal(formatAxisValue(9007199254740991), "9.0e+15");
   });
 });

--- a/tests/attribute-charts.test.ts
+++ b/tests/attribute-charts.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  computeHistogram,
+  computeScatter,
+  formatAxisValue,
+  numericColumns,
+  numericValues,
+  toFiniteNumber,
+  type ChartRow,
+} from "../apps/geolibre-desktop/src/lib/attribute-charts";
+
+function rows(...properties: Record<string, unknown>[]): ChartRow[] {
+  return properties.map((p) => ({ properties: p }));
+}
+
+describe("toFiniteNumber", () => {
+  it("accepts finite numbers and numeric strings, rejects the rest", () => {
+    assert.equal(toFiniteNumber(42), 42);
+    assert.equal(toFiniteNumber("3.5"), 3.5);
+    assert.equal(toFiniteNumber("  -7 "), -7);
+    assert.equal(toFiniteNumber(""), null);
+    assert.equal(toFiniteNumber("abc"), null);
+    assert.equal(toFiniteNumber(true), null);
+    assert.equal(toFiniteNumber(null), null);
+    assert.equal(toFiniteNumber(Number.NaN), null);
+    assert.equal(toFiniteNumber(Infinity), null);
+  });
+});
+
+describe("numericColumns", () => {
+  it("keeps columns that are mostly numeric, drops text/id-like ones", () => {
+    const data = rows(
+      { pop: 10, name: "A", code: "x1" },
+      { pop: 20, name: "B", code: "x2" },
+      { pop: 30, name: "C", code: 99 },
+    );
+    assert.deepEqual(numericColumns(data, ["pop", "name", "code"]), ["pop"]);
+  });
+
+  it("requires at least two numeric values", () => {
+    const data = rows({ a: 1 }, { a: null }, { a: "" });
+    assert.deepEqual(numericColumns(data, ["a"]), []);
+  });
+
+  it("accepts numeric strings as numeric", () => {
+    const data = rows({ a: "1" }, { a: "2" }, { a: "3" });
+    assert.deepEqual(numericColumns(data, ["a"]), ["a"]);
+  });
+});
+
+describe("numericValues", () => {
+  it("collects only the finite numeric values", () => {
+    const data = rows({ a: 1 }, { a: "2" }, { a: "x" }, { a: null });
+    assert.deepEqual(numericValues(data, "a"), [1, 2]);
+  });
+});
+
+describe("computeHistogram", () => {
+  it("returns null for no values", () => {
+    assert.equal(computeHistogram([], 10), null);
+  });
+
+  it("bins values into equal-width buckets with the max in the last bin", () => {
+    const result = computeHistogram([0, 1, 2, 3, 4], 2);
+    assert.ok(result);
+    assert.equal(result.min, 0);
+    assert.equal(result.max, 4);
+    assert.equal(result.total, 5);
+    assert.equal(result.bins.length, 2);
+    // bin 0: [0,2) -> 0,1 ; bin 1: [2,4] -> 2,3,4
+    assert.equal(result.bins[0].count, 2);
+    assert.equal(result.bins[1].count, 3);
+    assert.equal(result.maxCount, 3);
+  });
+
+  it("collapses to a single bin when all values are equal", () => {
+    const result = computeHistogram([5, 5, 5], 8);
+    assert.ok(result);
+    assert.equal(result.bins.length, 1);
+    assert.equal(result.bins[0].count, 3);
+    assert.equal(result.min, 5);
+    assert.equal(result.max, 5);
+  });
+
+  it("clamps the bin count into range", () => {
+    assert.equal(computeHistogram([1, 2, 3], 0)?.bins.length, 1);
+    assert.equal(computeHistogram([1, 2, 3], 999)?.bins.length, 50);
+  });
+});
+
+describe("computeScatter", () => {
+  it("returns only rows where both fields are finite, with extents", () => {
+    const data = rows(
+      { x: 1, y: 10 },
+      { x: 2, y: 20 },
+      { x: "bad", y: 30 },
+      { x: 4, y: null },
+    );
+    const result = computeScatter(data, "x", "y");
+    assert.ok(result);
+    assert.deepEqual(result.points, [
+      { x: 1, y: 10 },
+      { x: 2, y: 20 },
+    ]);
+    assert.equal(result.xMin, 1);
+    assert.equal(result.xMax, 2);
+    assert.equal(result.yMin, 10);
+    assert.equal(result.yMax, 20);
+  });
+
+  it("returns null when no row has both values", () => {
+    const data = rows({ x: 1, y: null }, { x: null, y: 2 });
+    assert.equal(computeScatter(data, "x", "y"), null);
+  });
+});
+
+describe("formatAxisValue", () => {
+  it("formats integers, decimals, and extreme magnitudes compactly", () => {
+    assert.equal(formatAxisValue(42), "42");
+    assert.equal(formatAxisValue(3.14159), "3.142");
+    assert.equal(formatAxisValue(0.5), "0.5");
+    assert.equal(formatAxisValue(1234567), "1234567");
+    assert.equal(formatAxisValue(0.0001), "1.0e-4");
+  });
+});

--- a/tests/attribute-charts.test.ts
+++ b/tests/attribute-charts.test.ts
@@ -152,6 +152,11 @@ describe("categoricalColumns", () => {
     assert.deepEqual(categoricalColumns(data, ["year"]), ["year"]);
   });
 
+  it("rejects fully-unique fields even in a small sample", () => {
+    const data = rows({ code: "a" }, { code: "b" }, { code: "c" });
+    assert.deepEqual(categoricalColumns(data, ["code"]), []);
+  });
+
   it("rejects mostly-unique id-like columns relative to row count", () => {
     // 20 rows: `name` is unique per row (id-like) and excluded; `kind` repeats.
     const data = Array.from({ length: 20 }, (_, i) => ({
@@ -188,6 +193,20 @@ describe("computeBar", () => {
     const mean = computeBar(data, "kind", "mean", "pop");
     // category "a": values 10 and 30 (null skipped) → mean 20
     assert.equal(mean?.bars.find((b) => b.label === "a")?.value, 20);
+  });
+
+  it("omits sum/mean categories that have no numeric samples", () => {
+    const data = rows(
+      { kind: "a", v: 5 },
+      { kind: "b", v: null },
+      { kind: "b", v: "x" },
+    );
+    // "b" has no finite value → excluded from sum (not shown as a zero bar).
+    const result = computeBar(data, "kind", "sum", "v");
+    assert.deepEqual(
+      result?.bars.map((b) => b.label),
+      ["a"],
+    );
   });
 
   it("buckets null/blank categories as (blank) and caps to top-N", () => {


### PR DESCRIPTION
Closes #240.

## What

Adds a **Charts** button to the attribute-table toolbar that opens a dialog to visualize the selected layer's numeric fields as a **histogram** or **scatter** plot — the field-distribution view requested in #240.

It's available whenever the table has an attribute source (GeoJSON **and** DuckDB query layers) and is hidden while editing. Charts are read-only, so — unlike *Add field* / *Calculate* — they aren't limited to editable in-store GeoJSON.

### Histogram
Pick a numeric field and a bin count (1–50, default 10). Bars are equal-width buckets; hovering a bar shows its `[range): count`.

### Scatter
Pick X and Y numeric fields; every row where both are finite numbers is plotted, with per-point tooltips.

## How

- **`lib/attribute-charts.ts`** (new) — dependency-free, fully unit-tested helpers: numeric-column detection (a column counts as numeric when ≥2 of its values are finite numbers and they're the majority of non-null values, so id-like text columns are excluded), equal-width histogram binning (collapses to one bin when all values are equal; clamps the bin count), scatter extraction with extents, and compact axis-value formatting.
- **`AttributeChartDialog.tsx`** (new) — renders the chart as **inline SVG** (no charting library, keeping the web bundle and Jupyter wheel small, consistent with recent bundle-trimming work) with field/bin/axis pickers, value tooltips, and empty states for "no numeric fields" and "no data".
- **`AttributeTable.tsx`** — toolbar button + dialog wiring, reusing the rows/columns the table already derives for both layer kinds.

A subtlety handled: `rows`/`columns` are rebuilt with fresh identities every parent render, so the dialog seeds its field pickers keyed on `open` only — otherwise selections would reset on every re-render.

## Tests

`tests/attribute-charts.test.ts` (12 cases): `toFiniteNumber`, numeric-column detection (text/id exclusion, numeric-string acceptance, the ≥2 threshold), histogram binning (max-in-last-bin, single-value collapse, bin-count clamping), scatter extraction/extents, and axis formatting. Full frontend suite 337 green; `npm run build` and scoped `pre-commit` pass.

## Verification

Browser-tested (Playwright) end-to-end on a 24-feature layer: histogram bars re-bin live with the bin control (counts sum to 24 at 10 and 4 bins), `name` is correctly excluded as non-numeric, and the scatter plots all 24 points with the right axes — screenshots confirmed the SVG renders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added attribute charts to the Attribute Table: a Charts toolbar button opens a dialog to visualize fields as histogram, scatter, bar, line, or box plots; detects numeric/categorical columns, seeds sensible defaults, renders scalable SVG charts with captions/tooltips, shows empty states, and supports exporting charts to PNG/SVG.
* **Tests**
  * Added unit tests for chart utilities covering numeric parsing, histograms, scatter sampling/extents, categorical selection, bar aggregations, line/box summaries, and axis formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->