### PR TITLE
feat(processing): add Spatial join to Vector tools (#239)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS
 - Controls menu with Measure, Bookmark, Minimap, and View State tools, plus a Print menu and a Search panel
 - Conversion menu for Vector to GeoParquet/FlatGeobuf/PMTiles, CSV to GeoParquet, and Raster to COG; GeoParquet and CSV conversions run in the browser with DuckDB-WASM, while FlatGeobuf, PMTiles, and COG require the optional Python sidecar
 - Whitebox toolbox with batch tools run against a selected input directory
-- Vector menu with common geometry tools (buffer, centroids, convex hull, dissolve, bounding box, simplify, clip, intersection, difference, union) that run in the browser with Turf.js, an optional GeoPandas sidecar engine for every tool, and an in-browser GeoPandas engine via Pyodide (no server, same results as the sidecar)
+- Vector menu with common geometry tools (buffer, centroids, convex hull, dissolve, bounding box, simplify, clip, intersection, difference, union, spatial join) that run in the browser with Turf.js, an optional GeoPandas sidecar engine for every tool, and an in-browser GeoPandas engine via Pyodide (no server, same results as the sidecar)
 - Raster menu with common raster tools (hillshade, slope, aspect, reproject, resample, clip by extent, clip by mask layer, polygonize, contour) backed by a rasterio Python sidecar, with a file path in and a file path out
 - Drag and drop vector and GeoTIFF/COG raster files onto the map to add them as layers
 - Project menu to create, open, save, and Save As `.geolibre.json` projects
@@ -173,6 +173,7 @@ The **Processing → Vector** menu opens a single Vector tools dialog with commo
 
 - **Geometry tools.** **Buffer** (by a distance in kilometers, meters, or miles), **Centroids** (one centroid point per feature), **Convex hull** (a single polygon enclosing all features), **Dissolve** (merge polygons, optionally grouped by an attribute field), **Bounding box** (the rectangular envelope of all features), and **Simplify** (Douglas-Peucker vertex reduction).
 - **Overlay tools.** **Clip** (clip the input to an overlay layer, keeping input attributes), **Intersection**, **Difference**, and **Union** between two polygon layers.
+- **Join tools.** **Spatial join** (attach a join layer's attributes to each input feature by a spatial relationship — intersects, within, or contains — with an inner or left join, for any geometry type).
 - **Three engines.** Every tool runs fully in the browser with [Turf.js](https://turfjs.org/), so no sidecar is required. Every tool can also run on the optional GeoPandas sidecar for projection-aware results; when the sidecar is unavailable the dialog falls back to the client engine. A third **Python (Pyodide)** engine runs the same GeoPandas/Shapely code as the sidecar but **entirely in the browser** via [Pyodide](https://pyodide.org) — no server, so it works on the web build too. The first run lazily downloads the Python runtime from a CDN (override with `VITE_PYODIDE_INDEX_URL` to self-host for offline use); results match the sidecar because both share one `vector_ops.py`.
 
 To enable the sidecar engine, install the optional `vector` extra (it is not bundled by default to keep the sidecar small):

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -1189,6 +1189,15 @@ export function TopToolbar({
               <DropdownMenuItem onSelect={() => setVectorToolOpen("union")}>
                 Union
               </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel className="text-xs text-muted-foreground">
+                Join
+              </DropdownMenuLabel>
+              <DropdownMenuItem
+                onSelect={() => setVectorToolOpen("spatial-join")}
+              >
+                Spatial join
+              </DropdownMenuItem>
             </DropdownMenuSubContent>
           </DropdownMenuSub>
           <DropdownMenuSub>

--- a/backend/geolibre_server/geolibre_server/vector_ops.py
+++ b/backend/geolibre_server/geolibre_server/vector_ops.py
@@ -200,7 +200,8 @@ _SJOIN_HOW = {"inner", "left"}
 
 def _spatial_join(geojson, overlay, parameters) -> tuple[dict, list[str]]:
     gpd = _import_geopandas()
-    left = _load_gdf(geojson, "Input layer")
+    # Validate parameters before loading the layers so an unknown predicate/how
+    # surfaces its actionable message instead of a generic load error.
     predicate = str(parameters.get("predicate", "intersects") or "intersects")
     if predicate not in _SJOIN_PREDICATES:
         raise ValueError(
@@ -209,6 +210,7 @@ def _spatial_join(geojson, overlay, parameters) -> tuple[dict, list[str]]:
     how = str(parameters.get("how", "inner") or "inner")
     if how not in _SJOIN_HOW:
         raise ValueError(f"Unknown join type '{how}'. Accepted: {sorted(_SJOIN_HOW)}")
+    left = _load_gdf(geojson, "Input layer")
     # An empty join layer is still well-defined and avoids a misleading "has no
     # features" error: a left join keeps every input feature unchanged, an inner
     # join yields nothing. Matches the client engine.

--- a/backend/geolibre_server/geolibre_server/vector_ops.py
+++ b/backend/geolibre_server/geolibre_server/vector_ops.py
@@ -201,7 +201,6 @@ _SJOIN_HOW = {"inner", "left"}
 def _spatial_join(geojson, overlay, parameters) -> tuple[dict, list[str]]:
     gpd = _import_geopandas()
     left = _load_gdf(geojson, "Input layer")
-    right = _load_gdf(overlay, "Join layer")
     predicate = str(parameters.get("predicate", "intersects") or "intersects")
     if predicate not in _SJOIN_PREDICATES:
         raise ValueError(
@@ -210,6 +209,16 @@ def _spatial_join(geojson, overlay, parameters) -> tuple[dict, list[str]]:
     how = str(parameters.get("how", "inner") or "inner")
     if how not in _SJOIN_HOW:
         raise ValueError(f"Unknown join type '{how}'. Accepted: {sorted(_SJOIN_HOW)}")
+    # An empty join layer is still well-defined and avoids a misleading "has no
+    # features" error: a left join keeps every input feature unchanged, an inner
+    # join yields nothing. Matches the client engine.
+    if not overlay or not overlay.get("features"):
+        result = left if how == "left" else left.iloc[0:0]
+        return (
+            _to_feature_collection(result),
+            [f"Spatial join: produced {len(result)} feature(s)"],
+        )
+    right = _load_gdf(overlay, "Join layer")
     joined = gpd.sjoin(left, right, predicate=predicate, how=how)
     # sjoin appends an "index_right" bookkeeping column; drop it so the output
     # carries only the two layers' real attributes.

--- a/backend/geolibre_server/geolibre_server/vector_ops.py
+++ b/backend/geolibre_server/geolibre_server/vector_ops.py
@@ -191,6 +191,35 @@ def _clip(geojson, overlay, parameters) -> tuple[dict, list[str]]:
     return _to_feature_collection(clipped), [f"Clip: produced {len(clipped)} feature(s)"]
 
 
+# Spatial-join predicates exposed by the UI (a safe subset of the predicates
+# GeoPandas' spatial index accepts). The relationship reads left (input) → right
+# (join): "within" is input-within-join, "contains" is input-contains-join.
+_SJOIN_PREDICATES = {"intersects", "within", "contains"}
+_SJOIN_HOW = {"inner", "left"}
+
+
+def _spatial_join(geojson, overlay, parameters) -> tuple[dict, list[str]]:
+    gpd = _import_geopandas()
+    left = _load_gdf(geojson, "Input layer")
+    right = _load_gdf(overlay, "Join layer")
+    predicate = str(parameters.get("predicate", "intersects") or "intersects")
+    if predicate not in _SJOIN_PREDICATES:
+        raise ValueError(
+            f"Unknown predicate '{predicate}'. Accepted: {sorted(_SJOIN_PREDICATES)}"
+        )
+    how = str(parameters.get("how", "inner") or "inner")
+    if how not in _SJOIN_HOW:
+        raise ValueError(f"Unknown join type '{how}'. Accepted: {sorted(_SJOIN_HOW)}")
+    joined = gpd.sjoin(left, right, predicate=predicate, how=how)
+    # sjoin appends an "index_right" bookkeeping column; drop it so the output
+    # carries only the two layers' real attributes.
+    joined = joined.drop(columns=["index_right"], errors="ignore")
+    return (
+        _to_feature_collection(joined),
+        [f"Spatial join: produced {len(joined)} feature(s)"],
+    )
+
+
 def _union(geojson, overlay, parameters) -> tuple[dict, list[str]]:
     gpd = _import_geopandas()
     left = _load_gdf(geojson, "Input layer")
@@ -217,6 +246,7 @@ _DISPATCH: dict[str, Callable[..., tuple[dict, list[str]]]] = {
     "intersection": lambda g, o, p: _overlay_op(g, o, p, "intersection"),
     "difference": lambda g, o, p: _overlay_op(g, o, p, "difference"),
     "union": _union,
+    "spatial-join": _spatial_join,
 }
 
 

--- a/backend/geolibre_server/tests/test_vector.py
+++ b/backend/geolibre_server/tests/test_vector.py
@@ -62,6 +62,7 @@ def test_dispatch_covers_all_tools() -> None:
         "intersection",
         "difference",
         "union",
+        "spatial-join",
     }
     assert set(_DISPATCH) == expected
 

--- a/backend/geolibre_server/tests/test_vector_ops.py
+++ b/backend/geolibre_server/tests/test_vector_ops.py
@@ -56,6 +56,7 @@ def _square(name: str, x: float = 0.0, y: float = 0.0) -> dict:
 SQUARE = _square("a")
 OVERLAP = _square("b", x=0.5, y=0.5)
 DISJOINT = _square("c", x=10.0, y=10.0)
+EMPTY = {"type": "FeatureCollection", "features": []}
 
 
 def test_unknown_tool_raises_value_error() -> None:
@@ -129,6 +130,20 @@ def test_spatial_join_left_keeps_unmatched_input() -> None:
 def test_spatial_join_inner_drops_unmatched_input() -> None:
     geojson, _ = run_vector_tool(
         "spatial-join", SQUARE, DISJOINT, parameters={"how": "inner"}
+    )
+    assert geojson["features"] == []
+
+
+@requires_geopandas
+def test_spatial_join_empty_join_layer_left_keeps_input() -> None:
+    geojson, _ = run_vector_tool("spatial-join", SQUARE, EMPTY, parameters={"how": "left"})
+    assert len(geojson["features"]) == 1
+
+
+@requires_geopandas
+def test_spatial_join_empty_join_layer_inner_is_empty() -> None:
+    geojson, _ = run_vector_tool(
+        "spatial-join", SQUARE, EMPTY, parameters={"how": "inner"}
     )
     assert geojson["features"] == []
 

--- a/backend/geolibre_server/tests/test_vector_ops.py
+++ b/backend/geolibre_server/tests/test_vector_ops.py
@@ -57,6 +57,16 @@ SQUARE = _square("a")
 OVERLAP = _square("b", x=0.5, y=0.5)
 DISJOINT = _square("c", x=10.0, y=10.0)
 EMPTY = {"type": "FeatureCollection", "features": []}
+POINT_IN_SQUARE = {
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {"name": "p"},
+            "geometry": {"type": "Point", "coordinates": [0.5, 0.5]},
+        }
+    ],
+}
 
 
 def test_unknown_tool_raises_value_error() -> None:
@@ -149,11 +159,37 @@ def test_spatial_join_empty_join_layer_inner_is_empty() -> None:
 
 
 @requires_geopandas
+def test_spatial_join_within_predicate_matches() -> None:
+    # The point lies within the square, so a within-join (point -> square) matches.
+    geojson, _ = run_vector_tool(
+        "spatial-join", POINT_IN_SQUARE, SQUARE, parameters={"predicate": "within"}
+    )
+    assert len(geojson["features"]) == 1
+    assert geojson["features"][0]["properties"].get("name_right") == "a"
+
+
+@requires_geopandas
+def test_spatial_join_contains_predicate_matches() -> None:
+    # The square contains the point, so a contains-join (square -> point) matches.
+    geojson, _ = run_vector_tool(
+        "spatial-join", SQUARE, POINT_IN_SQUARE, parameters={"predicate": "contains"}
+    )
+    assert len(geojson["features"]) == 1
+    assert geojson["features"][0]["properties"].get("name_left") == "a"
+
+
+@requires_geopandas
 def test_spatial_join_invalid_predicate_raises_value_error() -> None:
     with pytest.raises(ValueError, match="predicate"):
         run_vector_tool(
             "spatial-join", SQUARE, OVERLAP, parameters={"predicate": "bogus"}
         )
+
+
+@requires_geopandas
+def test_spatial_join_invalid_how_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="join type"):
+        run_vector_tool("spatial-join", SQUARE, OVERLAP, parameters={"how": "outer"})
 
 
 @requires_geopandas

--- a/backend/geolibre_server/tests/test_vector_ops.py
+++ b/backend/geolibre_server/tests/test_vector_ops.py
@@ -55,6 +55,7 @@ def _square(name: str, x: float = 0.0, y: float = 0.0) -> dict:
 
 SQUARE = _square("a")
 OVERLAP = _square("b", x=0.5, y=0.5)
+DISJOINT = _square("c", x=10.0, y=10.0)
 
 
 def test_unknown_tool_raises_value_error() -> None:
@@ -96,6 +97,48 @@ def test_overlay_tools(tool_id: str) -> None:
     geojson, _ = run_vector_tool(tool_id, SQUARE, OVERLAP)
     assert geojson["type"] == "FeatureCollection"
     assert len(geojson["features"]) >= 1
+
+
+@requires_geopandas
+def test_spatial_join_attaches_join_attributes() -> None:
+    geojson, messages = run_vector_tool(
+        "spatial-join",
+        SQUARE,
+        OVERLAP,
+        parameters={"predicate": "intersects", "how": "inner"},
+    )
+    assert geojson["type"] == "FeatureCollection"
+    assert len(geojson["features"]) == 1
+    props = geojson["features"][0]["properties"]
+    # Both layers carry a "name" column, so gpd.sjoin suffixes the collision.
+    assert props.get("name_left") == "a"
+    assert props.get("name_right") == "b"
+    assert "index_right" not in props
+    assert messages and "Spatial join" in messages[0]
+
+
+@requires_geopandas
+def test_spatial_join_left_keeps_unmatched_input() -> None:
+    geojson, _ = run_vector_tool(
+        "spatial-join", SQUARE, DISJOINT, parameters={"how": "left"}
+    )
+    assert len(geojson["features"]) == 1
+
+
+@requires_geopandas
+def test_spatial_join_inner_drops_unmatched_input() -> None:
+    geojson, _ = run_vector_tool(
+        "spatial-join", SQUARE, DISJOINT, parameters={"how": "inner"}
+    )
+    assert geojson["features"] == []
+
+
+@requires_geopandas
+def test_spatial_join_invalid_predicate_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="predicate"):
+        run_vector_tool(
+            "spatial-join", SQUARE, OVERLAP, parameters={"predicate": "bogus"}
+        )
 
 
 @requires_geopandas

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,7 +69,7 @@ Run DuckDB Spatial SQL in the browser against loaded layers, local files, and re
 <div class="feature-card" markdown>
 ### Vector tools
 
-Common geometry tools under Processing → Vector: buffer, centroids, convex hull, dissolve, bounding box, simplify, clip, intersection, difference, and union. They run in the browser with Turf.js, with an optional GeoPandas sidecar engine for every tool.
+Common geometry tools under Processing → Vector: buffer, centroids, convex hull, dissolve, bounding box, simplify, clip, intersection, difference, union, and spatial join. They run in the browser with Turf.js, with an optional GeoPandas sidecar engine for every tool.
 </div>
 
 <div class="feature-card" markdown>

--- a/docs/tutorials/vector-analysis.md
+++ b/docs/tutorials/vector-analysis.md
@@ -27,6 +27,7 @@ With the buffer (or any polygon layer) and a second layer, run an overlay:
 - **Intersection** keeps only the overlapping areas of two polygon layers.
 - **Difference** removes the overlay's area from the input.
 - **Union** merges two polygon layers into one (attributes are not preserved, on either engine).
+- **Spatial join** attaches a join layer's attributes to each input feature based on a spatial relationship (intersects, within, or contains) — for example, tagging each point with the polygon that contains it. Works with any geometry type.
 
 Open the tool from **Processing → Vector**, pick the input and overlay layers, and **Run**.
 

--- a/docs/user-guide/processing.md
+++ b/docs/user-guide/processing.md
@@ -31,6 +31,12 @@ The **Processing** menu collects GeoLibre's analysis and conversion tools: vecto
 | **Difference** | Remove the overlay layer's area from the input layer (keeps input attributes). |
 | **Union** | Merge two polygon layers into a single combined geometry (attributes are not preserved on either engine). |
 
+**Join**
+
+| Tool | Description |
+| --- | --- |
+| **Spatial join** | Attach attributes from a join layer to each input feature based on a spatial relationship (intersects, within, or contains). Choose an *inner* join to keep only matched features or a *left* join to keep all input features. Works with any geometry type. |
+
 ### Engines
 
 Every vector tool can run on one of three engines, selectable in the dialog:

--- a/package-lock.json
+++ b/package-lock.json
@@ -17931,6 +17931,9 @@
       "dependencies": {
         "@geolibre/core": "*",
         "@turf/bbox": "^7.3.5",
+        "@turf/boolean-contains": "^7.3.5",
+        "@turf/boolean-intersects": "^7.3.5",
+        "@turf/boolean-within": "^7.3.5",
         "@turf/buffer": "^7.3.5",
         "@turf/centroid": "^7.3.5",
         "@turf/convex": "^7.3.5",

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -43,7 +43,8 @@ export type VectorToolKind =
   | "clip"
   | "intersection"
   | "difference"
-  | "union";
+  | "union"
+  | "spatial-join";
 
 /**
  * Identifiers of the raster processing tools. Kept in sync by hand with the

--- a/packages/processing/package.json
+++ b/packages/processing/package.json
@@ -11,6 +11,9 @@
   "dependencies": {
     "@geolibre/core": "*",
     "@turf/bbox": "^7.3.5",
+    "@turf/boolean-contains": "^7.3.5",
+    "@turf/boolean-intersects": "^7.3.5",
+    "@turf/boolean-within": "^7.3.5",
     "@turf/buffer": "^7.3.5",
     "@turf/centroid": "^7.3.5",
     "@turf/convex": "^7.3.5",

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -532,9 +532,16 @@ function matchesPredicate(
   join: Feature,
   predicate: SpatialPredicate,
 ): boolean {
-  if (predicate === "within") return booleanWithin(input, join);
-  if (predicate === "contains") return booleanContains(input, join);
-  return booleanIntersects(input, join);
+  try {
+    if (predicate === "within") return booleanWithin(input, join);
+    if (predicate === "contains") return booleanContains(input, join);
+    return booleanIntersects(input, join);
+  } catch {
+    // Turf's boolean predicates throw on unsupported geometries (e.g. a
+    // GeometryCollection). Treat such a pair as a non-match rather than letting
+    // the exception abort the whole join.
+    return false;
+  }
 }
 
 export const spatialJoinTool: ProcessingAlgorithm = {
@@ -579,7 +586,7 @@ export const spatialJoinTool: ProcessingAlgorithm = {
     }
     const inputFeatures = input.features.filter((f) => f.geometry);
     if (!inputFeatures.length) {
-      ctx.log("Error: input layer has no features");
+      ctx.log("Error: input layer has no features with geometry");
       return;
     }
     // Validate up front so unknown values fail loudly instead of silently
@@ -615,9 +622,14 @@ export const spatialJoinTool: ProcessingAlgorithm = {
     // Collect every join-layer attribute key so unmatched left-join rows get a
     // null for each one. This keeps the output schema consistent with matched
     // rows and mirrors GeoPandas, which fills NaN (→ null in GeoJSON) there.
+    // Only the left path consumes this, so skip the scan for inner joins.
     const nullJoinProps: GeoJsonProperties = {};
-    for (const j of joinFeatures) {
-      for (const key of Object.keys(j.properties ?? {})) nullJoinProps[key] = null;
+    if (how === "left") {
+      for (const j of joinFeatures) {
+        for (const key of Object.keys(j.properties ?? {})) {
+          nullJoinProps[key] = null;
+        }
+      }
     }
     const results: Feature[] = [];
     for (const feature of inputFeatures) {

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -612,19 +612,27 @@ export const spatialJoinTool: ProcessingAlgorithm = {
       );
       return;
     }
+    // Collect every join-layer attribute key so unmatched left-join rows get a
+    // null for each one. This keeps the output schema consistent with matched
+    // rows and mirrors GeoPandas, which fills NaN (→ null in GeoJSON) there.
+    const nullJoinProps: GeoJsonProperties = {};
+    for (const j of joinFeatures) {
+      for (const key of Object.keys(j.properties ?? {})) nullJoinProps[key] = null;
+    }
     const results: Feature[] = [];
     for (const feature of inputFeatures) {
       const matches = joinFeatures.filter((j) =>
         matchesPredicate(feature, j, predicate as SpatialPredicate),
       );
       if (!matches.length) {
-        // Left join keeps unmatched input features (with only their own
-        // attributes); inner join drops them, mirroring gpd.sjoin(how=...).
+        // Left join keeps unmatched input features; inner join drops them,
+        // mirroring gpd.sjoin(how=...). Null-fill the join columns so the
+        // schema matches matched rows and the sidecar.
         if (how === "left") {
           results.push({
             type: "Feature",
             geometry: feature.geometry,
-            properties: { ...(feature.properties ?? {}) },
+            properties: { ...nullJoinProps, ...(feature.properties ?? {}) },
           });
         }
         continue;

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -512,6 +512,15 @@ export const unionTool: ProcessingAlgorithm = {
 
 /** Spatial relationship used to match input features against join features. */
 type SpatialPredicate = "intersects" | "within" | "contains";
+type SpatialJoinHow = "inner" | "left";
+
+/** Valid spatial-join predicates/join-types; kept in sync with the backend guard. */
+const SPATIAL_JOIN_PREDICATES: SpatialPredicate[] = [
+  "intersects",
+  "within",
+  "contains",
+];
+const SPATIAL_JOIN_HOW: SpatialJoinHow[] = ["inner", "left"];
 
 /**
  * Test an input feature against a join feature for the given predicate, mirroring
@@ -562,17 +571,38 @@ export const spatialJoinTool: ProcessingAlgorithm = {
   ],
   run: (ctx) => {
     const input = requireFeatures(ctx, "layer");
-    const joinFc = requireFeatures(ctx, "overlay");
-    if (!input || !joinFc) return;
-    const inputFeatures = input.features.filter((f) => f.geometry);
-    const joinFeatures = joinFc.features.filter((f) => f.geometry);
-    if (!inputFeatures.length || !joinFeatures.length) {
-      ctx.log("Error: both layers must contain features");
+    if (!input) return;
+    const joinLayer = getLayer(ctx, "overlay");
+    if (!joinLayer) {
+      ctx.log('Error: parameter "overlay" has no layer selected');
       return;
     }
-    const predicate = ((ctx.parameters.predicate as string) ||
-      "intersects") as SpatialPredicate;
+    const inputFeatures = input.features.filter((f) => f.geometry);
+    if (!inputFeatures.length) {
+      ctx.log("Error: input layer has no features");
+      return;
+    }
+    // Validate up front so unknown values fail loudly instead of silently
+    // coercing to a default, matching the backend's ValueError guard.
+    const predicate = (ctx.parameters.predicate as string) || "intersects";
+    if (!SPATIAL_JOIN_PREDICATES.includes(predicate as SpatialPredicate)) {
+      ctx.log(
+        `Error: unknown predicate '${predicate}'; expected ${SPATIAL_JOIN_PREDICATES.join(", ")}`,
+      );
+      return;
+    }
     const how = (ctx.parameters.how as string) || "inner";
+    if (!SPATIAL_JOIN_HOW.includes(how as SpatialJoinHow)) {
+      ctx.log(
+        `Error: unknown join type '${how}'; expected ${SPATIAL_JOIN_HOW.join(", ")}`,
+      );
+      return;
+    }
+    // An empty join layer is still well-defined: a left join keeps every input
+    // feature unchanged, an inner join yields nothing (mirrors gpd.sjoin).
+    const joinFeatures = (joinLayer.geojson?.features ?? []).filter(
+      (f) => f.geometry,
+    );
     // This pairwise test runs on the main thread; cap it so very large layers
     // cannot freeze the browser tab. Use the Sidecar engine for bigger jobs.
     const pairs = inputFeatures.length * joinFeatures.length;
@@ -585,14 +615,15 @@ export const spatialJoinTool: ProcessingAlgorithm = {
     const results: Feature[] = [];
     for (const feature of inputFeatures) {
       const matches = joinFeatures.filter((j) =>
-        matchesPredicate(feature, j, predicate),
+        matchesPredicate(feature, j, predicate as SpatialPredicate),
       );
       if (!matches.length) {
         // Left join keeps unmatched input features (with only their own
         // attributes); inner join drops them, mirroring gpd.sjoin(how=...).
         if (how === "left") {
           results.push({
-            ...feature,
+            type: "Feature",
+            geometry: feature.geometry,
             properties: { ...(feature.properties ?? {}) },
           });
         }
@@ -600,9 +631,12 @@ export const spatialJoinTool: ProcessingAlgorithm = {
       }
       // One output feature per match, like GeoPandas sjoin. Input attributes win
       // on name collisions (the sidecar instead suffixes them _left/_right).
+      // Build a fresh feature (no `id`) so a one-to-many join does not emit
+      // duplicate feature ids, which would corrupt MapLibre feature state.
       for (const match of matches) {
         results.push({
-          ...feature,
+          type: "Feature",
+          geometry: feature.geometry,
           properties: {
             ...(match.properties ?? {}),
             ...(feature.properties ?? {}),

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -7,6 +7,9 @@ import simplify from "@turf/simplify";
 import intersect from "@turf/intersect";
 import difference from "@turf/difference";
 import union from "@turf/union";
+import booleanIntersects from "@turf/boolean-intersects";
+import booleanContains from "@turf/boolean-contains";
+import booleanWithin from "@turf/boolean-within";
 import { featureCollection } from "@turf/helpers";
 import type {
   Feature,
@@ -507,6 +510,111 @@ export const unionTool: ProcessingAlgorithm = {
   },
 };
 
+/** Spatial relationship used to match input features against join features. */
+type SpatialPredicate = "intersects" | "within" | "contains";
+
+/**
+ * Test an input feature against a join feature for the given predicate, mirroring
+ * GeoPandas `sjoin(predicate=...)` semantics (the relationship reads left→right):
+ * `within` is "input within join" and `contains` is "input contains join".
+ */
+function matchesPredicate(
+  input: Feature,
+  join: Feature,
+  predicate: SpatialPredicate,
+): boolean {
+  if (predicate === "within") return booleanWithin(input, join);
+  if (predicate === "contains") return booleanContains(input, join);
+  return booleanIntersects(input, join);
+}
+
+export const spatialJoinTool: ProcessingAlgorithm = {
+  id: "spatial-join",
+  name: "Spatial join",
+  description:
+    "Attach attributes from a join layer to each input feature based on a spatial relationship",
+  group: "Join",
+  supportsSidecar: true,
+  parameters: [
+    { id: "layer", label: "Input layer", type: "layer", required: true },
+    { id: "overlay", label: "Join layer", type: "layer", required: true },
+    {
+      id: "predicate",
+      label: "Spatial relationship",
+      type: "select",
+      default: "intersects",
+      options: [
+        { value: "intersects", label: "Intersects" },
+        { value: "within", label: "Within" },
+        { value: "contains", label: "Contains" },
+      ],
+    },
+    {
+      id: "how",
+      label: "Join type",
+      type: "select",
+      default: "inner",
+      options: [
+        { value: "inner", label: "Inner (keep only matched features)" },
+        { value: "left", label: "Left (keep all input features)" },
+      ],
+    },
+  ],
+  run: (ctx) => {
+    const input = requireFeatures(ctx, "layer");
+    const joinFc = requireFeatures(ctx, "overlay");
+    if (!input || !joinFc) return;
+    const inputFeatures = input.features.filter((f) => f.geometry);
+    const joinFeatures = joinFc.features.filter((f) => f.geometry);
+    if (!inputFeatures.length || !joinFeatures.length) {
+      ctx.log("Error: both layers must contain features");
+      return;
+    }
+    const predicate = ((ctx.parameters.predicate as string) ||
+      "intersects") as SpatialPredicate;
+    const how = (ctx.parameters.how as string) || "inner";
+    // This pairwise test runs on the main thread; cap it so very large layers
+    // cannot freeze the browser tab. Use the Sidecar engine for bigger jobs.
+    const pairs = inputFeatures.length * joinFeatures.length;
+    if (pairs > MAX_CLIENT_PAIRS) {
+      ctx.log(
+        `Error: spatial join needs ${pairs} comparisons (limit ${MAX_CLIENT_PAIRS}); use the Sidecar engine for large layers`,
+      );
+      return;
+    }
+    const results: Feature[] = [];
+    for (const feature of inputFeatures) {
+      const matches = joinFeatures.filter((j) =>
+        matchesPredicate(feature, j, predicate),
+      );
+      if (!matches.length) {
+        // Left join keeps unmatched input features (with only their own
+        // attributes); inner join drops them, mirroring gpd.sjoin(how=...).
+        if (how === "left") {
+          results.push({
+            ...feature,
+            properties: { ...(feature.properties ?? {}) },
+          });
+        }
+        continue;
+      }
+      // One output feature per match, like GeoPandas sjoin. Input attributes win
+      // on name collisions (the sidecar instead suffixes them _left/_right).
+      for (const match of matches) {
+        results.push({
+          ...feature,
+          properties: {
+            ...(match.properties ?? {}),
+            ...(feature.properties ?? {}),
+          },
+        });
+      }
+    }
+    ctx.log(`Spatial join: produced ${results.length} feature(s)`);
+    ctx.addResultLayer?.("Spatial join", featureCollection(results));
+  },
+};
+
 export const VECTOR_TOOLS: ProcessingAlgorithm[] = [
   bufferTool,
   centroidsTool,
@@ -518,6 +626,7 @@ export const VECTOR_TOOLS: ProcessingAlgorithm[] = [
   intersectionTool,
   differenceTool,
   unionTool,
+  spatialJoinTool,
 ];
 
 export function getVectorTool(id: string): ProcessingAlgorithm | undefined {

--- a/tests/processing.test.ts
+++ b/tests/processing.test.ts
@@ -134,6 +134,110 @@ describe("processing registry", () => {
     assert.equal(outside?.properties?.region, undefined);
   });
 
+  it("spatial join drops feature ids, validates inputs, and handles empty join layers", () => {
+    const tool = getVectorTool("spatial-join");
+    assert.ok(tool);
+
+    // Two overlapping zones so a single input point matches both (one-to-many).
+    const zoneFeature = (region: string) => ({
+      type: "Feature" as const,
+      properties: { region },
+      geometry: {
+        type: "Polygon" as const,
+        coordinates: [
+          [
+            [0, 0],
+            [0, 10],
+            [10, 10],
+            [10, 0],
+            [0, 0],
+          ],
+        ],
+      },
+    });
+    const zones: GeoLibreLayer = {
+      ...layer,
+      id: "zones",
+      name: "Zones",
+      geojson: {
+        type: "FeatureCollection",
+        features: [zoneFeature("north"), zoneFeature("south")],
+      },
+    };
+    // Input point carries an `id`; a one-to-many join must not duplicate it.
+    const pts: GeoLibreLayer = {
+      ...layer,
+      id: "pts",
+      name: "Pts",
+      geojson: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            id: "p1",
+            properties: { name: "pt" },
+            geometry: { type: "Point", coordinates: [5, 5] },
+          },
+        ],
+      },
+    };
+
+    let res: FeatureCollection | null = null;
+    tool.run({
+      layers: [zones, pts],
+      parameters: { layer: "pts", overlay: "zones", how: "inner" },
+      log: () => {},
+      addResultLayer: (_n, g) => {
+        res = g;
+      },
+    });
+    assert.equal(res!.features.length, 2);
+    assert.ok(res!.features.every((f) => f.id === undefined));
+
+    // Empty join layer: left keeps the input, inner returns nothing.
+    const emptyJoin: GeoLibreLayer = {
+      ...layer,
+      id: "empty",
+      name: "Empty",
+      geojson: { type: "FeatureCollection", features: [] },
+    };
+    let leftEmpty: FeatureCollection | null = null;
+    tool.run({
+      layers: [pts, emptyJoin],
+      parameters: { layer: "pts", overlay: "empty", how: "left" },
+      log: () => {},
+      addResultLayer: (_n, g) => {
+        leftEmpty = g;
+      },
+    });
+    assert.equal(leftEmpty!.features.length, 1);
+
+    let innerEmpty: FeatureCollection | null = null;
+    tool.run({
+      layers: [pts, emptyJoin],
+      parameters: { layer: "pts", overlay: "empty", how: "inner" },
+      log: () => {},
+      addResultLayer: (_n, g) => {
+        innerEmpty = g;
+      },
+    });
+    assert.equal(innerEmpty!.features.length, 0);
+
+    // Unknown predicate is rejected (no result layer), mirroring the backend.
+    let produced = false;
+    const logs: string[] = [];
+    tool.run({
+      layers: [zones, pts],
+      parameters: { layer: "pts", overlay: "zones", predicate: "bogus" },
+      log: (m) => logs.push(m),
+      addResultLayer: () => {
+        produced = true;
+      },
+    });
+    assert.equal(produced, false);
+    assert.ok(logs.some((m) => m.includes("unknown predicate")));
+  });
+
   it("calculates and fits layer bounds", () => {
     const messages: string[] = [];
     let fittedBounds: [number, number, number, number] | null = null;

--- a/tests/processing.test.ts
+++ b/tests/processing.test.ts
@@ -5,7 +5,9 @@ import {
   calculateBoundsAlgorithm,
   countFeaturesAlgorithm,
   getAlgorithm,
+  getVectorTool,
 } from "@geolibre/processing";
+import type { FeatureCollection } from "geojson";
 
 const layer: GeoLibreLayer = {
   id: "layer-a",
@@ -48,6 +50,88 @@ describe("processing registry", () => {
     });
 
     assert.deepEqual(messages, ["Feature count: 2"]);
+  });
+
+  it("spatially joins zone attributes onto points", () => {
+    const zone: GeoLibreLayer = {
+      ...layer,
+      id: "zone",
+      name: "Zone",
+      geojson: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: { region: "north" },
+            geometry: {
+              type: "Polygon",
+              coordinates: [
+                [
+                  [0, 0],
+                  [0, 10],
+                  [10, 10],
+                  [10, 0],
+                  [0, 0],
+                ],
+              ],
+            },
+          },
+        ],
+      },
+    };
+    const points: GeoLibreLayer = {
+      ...layer,
+      id: "points",
+      name: "Points",
+      geojson: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: { name: "inside" },
+            geometry: { type: "Point", coordinates: [5, 5] },
+          },
+          {
+            type: "Feature",
+            properties: { name: "outside" },
+            geometry: { type: "Point", coordinates: [20, 20] },
+          },
+        ],
+      },
+    };
+
+    const tool = getVectorTool("spatial-join");
+    assert.ok(tool);
+
+    // Inner join keeps only the point that falls inside the zone.
+    let inner: FeatureCollection | null = null;
+    tool.run({
+      layers: [zone, points],
+      parameters: { layer: "points", overlay: "zone", how: "inner" },
+      log: () => {},
+      addResultLayer: (_name, geojson) => {
+        inner = geojson;
+      },
+    });
+    assert.equal(inner!.features.length, 1);
+    assert.equal(inner!.features[0].properties?.name, "inside");
+    assert.equal(inner!.features[0].properties?.region, "north");
+
+    // Left join keeps both points; the outside one gets no zone attribute.
+    let left: FeatureCollection | null = null;
+    tool.run({
+      layers: [zone, points],
+      parameters: { layer: "points", overlay: "zone", how: "left" },
+      log: () => {},
+      addResultLayer: (_name, geojson) => {
+        left = geojson;
+      },
+    });
+    assert.equal(left!.features.length, 2);
+    const outside = left!.features.find(
+      (f) => f.properties?.name === "outside",
+    );
+    assert.equal(outside?.properties?.region, undefined);
   });
 
   it("calculates and fits layer bounds", () => {

--- a/tests/processing.test.ts
+++ b/tests/processing.test.ts
@@ -131,7 +131,9 @@ describe("processing registry", () => {
     const outside = left!.features.find(
       (f) => f.properties?.name === "outside",
     );
-    assert.equal(outside?.properties?.region, undefined);
+    // Unmatched left-join rows null-fill the join columns (consistent schema,
+    // mirrors the sidecar), so `region` is present and null rather than absent.
+    assert.equal(outside?.properties?.region, null);
   });
 
   it("spatial join drops feature ids, validates inputs, and handles empty join layers", () => {
@@ -193,6 +195,10 @@ describe("processing registry", () => {
     });
     assert.equal(res!.features.length, 2);
     assert.ok(res!.features.every((f) => f.id === undefined));
+    // The one input feature matching two zones yields one output per match,
+    // each carrying that join feature's distinct attribute.
+    const regions = res!.features.map((f) => f.properties?.region).sort();
+    assert.deepEqual(regions, ["north", "south"]);
 
     // Empty join layer: left keeps the input, inner returns nothing.
     const emptyJoin: GeoLibreLayer = {


### PR DESCRIPTION
Closes #239.

## Summary

Adds a **Spatial join** tool to **Processing → Vector**. It attaches a join layer's attributes to each input feature based on a spatial relationship. Like every other vector tool, it runs on all three engines (Client/Turf.js, Sidecar/GeoPandas, Pyodide) from one shared `vector_ops.py`.

**Parameters**
- **Input layer** / **Join layer**
- **Spatial relationship** — `intersects` (default), `within`, `contains` (reads left→right, matching `gpd.sjoin` predicate semantics)
- **Join type** — `inner` (keep only matched features) or `left` (keep all input features)
- Works on **any** geometry type (not polygon-restricted)

## Changes

- `packages/processing/src/vector-tools.ts` — `spatialJoinTool` + predicate helper, registered in `VECTOR_TOOLS`; new `@turf/boolean-{intersects,within,contains}` deps.
- `backend/geolibre_server/.../vector_ops.py` — `_spatial_join` via `gpd.sjoin`, wired into `_DISPATCH` (drops the `index_right` bookkeeping column; validates predicate/how).
- `packages/core/src/store.ts` — `"spatial-join"` added to `VectorToolKind`.
- `apps/.../TopToolbar.tsx` — new **Join** section under Processing → Vector.
- Tests — client (`tests/processing.test.ts`) and backend (`test_vector_ops.py`, plus `test_vector.py` dispatch-coverage).
- Docs — README, `docs/index.md`, `docs/user-guide/processing.md`, `docs/tutorials/vector-analysis.md`.

### Client/sidecar parity note
The client engine keeps the input feature's value on attribute-name collisions; the GeoPandas engine instead suffixes colliding columns `_left`/`_right` (standard `sjoin` behavior). This mirrors the existing documented divergences (e.g. Union).

## Testing

- `npm run build` ✅ · 353 frontend tests ✅ · 65 backend tests ✅ · `pre-commit` (incl. npm-build) ✅
- **Playwright + real data** (1000 US city points + 52 state polygons, via the running web app):
  - Inner `within` join → **992/1000** cities matched (offshore/AK/HI points correctly dropped).
  - Attribute table confirmed merged columns `name, density` (states) + `city, state, population` (cities); the join is spatially correct — every joined state `name` matches each city's own `state` field (e.g. Houston→Texas, Washington→District of Columbia at density 10065).
  - Left join → **1000/1000** features kept, confirming the inner/left distinction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Spatial Join: attach attributes from a secondary layer to input features using spatial predicates (intersects/within/contains) with inner/left join modes; available via Processing → Vector → Join → Spatial join.

* **Documentation**
  * README, user guide, tutorial and docs updated with Spatial Join details and examples.

* **Tests**
  * Added coverage for predicates, left/inner semantics, one-to-many joins and empty-join scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->