### PR TITLE
feat(map): add heatmap renderer and point clustering (#243)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS
 - Cloud data integrations through the Planetary Computer and Earth Engine panels, the Overture Maps plugin, and federal Web Services plugins
 - Manual and automatic refresh for WFS, GeoJSON URL, and Add Vector Layer URL layers
 - Layer panel for visibility, opacity, reordering, rename, zoom-to-layer, identify, labels, open attribute table, export, and remove actions
-- Live style panel with single, categorized, graduated, and expression symbology (fill, stroke, opacity, circle radius), point heatmap and clustering renderers, including for Add Vector Layer layers
+- Live style panel with single, categorized, graduated, and expression symbology (fill, stroke, opacity, circle radius), including for Add Vector Layer layers, plus point heatmap and clustering renderers for GeoJSON point layers
 - Attribute table with filtering, sorting, resize controls, feature highlighting, optional zoom to selected features, column management (rename, delete, hide/show, reorder), and export to GeoJSON/GeoParquet/CSV
 - SQL Workspace for running DuckDB Spatial SQL against loaded layers, local files, and remote URLs, with sample queries, query history, and adding results to the map or exporting them
 - Multiple DuckDB SQL query-result layers with identify, selection, and attribute table support

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS
 - Cloud data integrations through the Planetary Computer and Earth Engine panels, the Overture Maps plugin, and federal Web Services plugins
 - Manual and automatic refresh for WFS, GeoJSON URL, and Add Vector Layer URL layers
 - Layer panel for visibility, opacity, reordering, rename, zoom-to-layer, identify, labels, open attribute table, export, and remove actions
-- Live style panel with single, categorized, graduated, and expression symbology (fill, stroke, opacity, circle radius), including for Add Vector Layer layers
+- Live style panel with single, categorized, graduated, and expression symbology (fill, stroke, opacity, circle radius), point heatmap and clustering renderers, including for Add Vector Layer layers
 - Attribute table with filtering, sorting, resize controls, feature highlighting, optional zoom to selected features, column management (rename, delete, hide/show, reorder), and export to GeoJSON/GeoParquet/CSV
 - SQL Workspace for running DuckDB Spatial SQL against loaded layers, local files, and remote URLs, with sample queries, query history, and adding results to the map or exporting them
 - Multiple DuckDB SQL query-result layers with identify, selection, and attribute table support

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1,6 +1,7 @@
 import {
   DEFAULT_LAYER_STYLE,
   type LayerType,
+  type PointRenderer,
   type VectorStyleMode,
   type VectorStyleStop,
   styleValue,
@@ -127,6 +128,23 @@ function hasPolygonGeometryMetadata(value: unknown): boolean {
       typeof geometryType === "string" &&
       geometryType.toLowerCase().includes("polygon"),
   );
+}
+
+/**
+ * True when a GeoJSON layer contains only point geometry, so the heatmap and
+ * cluster renderers (which only make sense for points) can be offered.
+ */
+function isPointOnlyGeoJsonLayer(layer: {
+  type: LayerType;
+  geojson?: { features?: Array<{ geometry?: { type?: string } | null }> };
+}): boolean {
+  if (layer.type !== "geojson") return false;
+  const features = layer.geojson?.features ?? [];
+  if (features.length === 0) return false;
+  return features.every((feature) => {
+    const type = feature.geometry?.type;
+    return type === "Point" || type === "MultiPoint";
+  });
 }
 
 function getMetadataFieldNames(metadata: Record<string, unknown>): string[] {
@@ -1133,6 +1151,13 @@ export function StylePanel({
     isRasterPaintLayer(layer.type) || isRasterTileLayer || isDeckRasterLayer;
   const hasTextMarkerControls =
     layer.type === "geojson" && hasTextMarkerFeatures(layer);
+  // Heatmap/cluster are rendered by the core GeoJSON sync, so only offer them
+  // for layers it actually paints — not control-owned or deck.gl layers.
+  const supportsPointRenderer =
+    isPointOnlyGeoJsonLayer(layer) &&
+    !hasExternalNativeLayers(layer) &&
+    !hasExternalDeckLayer(layer);
+  const pointRenderer = styleValue(style, "pointRenderer");
   const extrusionEnabled = styleValue(style, "extrusionEnabled");
   const extrusionHeightPropertyOptions = getAttributePropertyNames(layer);
   const vectorStylePropertyOptions = extrusionHeightPropertyOptions;
@@ -1676,6 +1701,79 @@ export function StylePanel({
   );
   const twoDimensionalControls = (
     <>
+      {supportsPointRenderer ? (
+        <>
+          <div className="space-y-2">
+            <Label htmlFor="pointRenderer">Point renderer</Label>
+            <Select
+              id="pointRenderer"
+              value={pointRenderer}
+              onChange={(event) =>
+                setLayerStyle(layer.id, {
+                  pointRenderer: event.target.value as PointRenderer,
+                })
+              }
+            >
+              <option value="single">Single symbol</option>
+              <option value="heatmap">Heatmap</option>
+              <option value="cluster">Clustered</option>
+            </Select>
+          </div>
+          {pointRenderer === "heatmap" ? (
+            <>
+              <NumericStyleInput
+                id="heatmapRadius"
+                label="Heatmap radius"
+                min={1}
+                max={100}
+                step={1}
+                value={styleValue(style, "heatmapRadius")}
+                onChange={(heatmapRadius) =>
+                  setLayerStyle(layer.id, { heatmapRadius })
+                }
+              />
+              <NumericStyleInput
+                id="heatmapIntensity"
+                label="Heatmap intensity"
+                min={0.1}
+                max={5}
+                step={0.1}
+                value={styleValue(style, "heatmapIntensity")}
+                onChange={(heatmapIntensity) =>
+                  setLayerStyle(layer.id, { heatmapIntensity })
+                }
+              />
+            </>
+          ) : null}
+          {pointRenderer === "cluster" ? (
+            <>
+              <NumericStyleInput
+                id="clusterRadius"
+                label="Cluster radius (px)"
+                min={10}
+                max={200}
+                step={5}
+                value={styleValue(style, "clusterRadius")}
+                onChange={(clusterRadius) =>
+                  setLayerStyle(layer.id, { clusterRadius })
+                }
+              />
+              <NumericStyleInput
+                id="clusterMaxZoom"
+                label="Cluster max zoom"
+                min={0}
+                max={24}
+                step={1}
+                value={styleValue(style, "clusterMaxZoom")}
+                onChange={(clusterMaxZoom) =>
+                  setLayerStyle(layer.id, { clusterMaxZoom })
+                }
+              />
+            </>
+          ) : null}
+          <Separator />
+        </>
+      ) : null}
       {draftVectorStyleMode === "single" ? (
         <div className="space-y-2">
           <Label htmlFor="fillColor">Fill color</Label>

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -30,6 +30,7 @@ import {
   type MouseEvent as ReactMouseEvent,
   type RefObject,
   useEffect,
+  useMemo,
   useState,
 } from "react";
 
@@ -1152,9 +1153,14 @@ export function StylePanel({
   const hasTextMarkerControls =
     layer.type === "geojson" && hasTextMarkerFeatures(layer);
   // Heatmap/cluster are rendered by the core GeoJSON sync, so only offer them
-  // for layers it actually paints — not control-owned or deck.gl layers.
+  // for layers it actually paints — not control-owned or deck.gl layers. Memoize
+  // the point-only scan so a large layer isn't re-scanned on every panel render.
+  const isPointOnly = useMemo(
+    () => isPointOnlyGeoJsonLayer(layer),
+    [layer],
+  );
   const supportsPointRenderer =
-    isPointOnlyGeoJsonLayer(layer) &&
+    isPointOnly &&
     !hasExternalNativeLayers(layer) &&
     !hasExternalDeckLayer(layer);
   const pointRenderer = styleValue(style, "pointRenderer");
@@ -1774,6 +1780,10 @@ export function StylePanel({
           <Separator />
         </>
       ) : null}
+      {/* The heatmap renderer ignores fill/stroke/circle/data-driven styling, so
+          hide those controls when it is selected. */}
+      {pointRenderer === "heatmap" ? null : (
+        <>
       {draftVectorStyleMode === "single" ? (
         <div className="space-y-2">
           <Label htmlFor="fillColor">Fill color</Label>
@@ -1872,6 +1882,8 @@ export function StylePanel({
           />
         </>
       ) : null}
+        </>
+      )}
     </>
   );
   const extrusionControls = (
@@ -2164,7 +2176,8 @@ export function StylePanel({
               </div>
             </div>
           )}
-          {vectorSymbologyControls}
+          {/* Data-driven coloring doesn't apply to the heatmap renderer. */}
+          {pointRenderer === "heatmap" ? null : vectorSymbologyControls}
           {!hasExtrusionControls || !extrusionEnabled ? (
             twoDimensionalControls
           ) : (

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ Pan, zoom, rotate, and tilt a MapLibre map with OpenFreeMap basemaps or a blank 
 <div class="feature-card" markdown>
 ### Local and remote data
 
-Load local and remote vector and raster data, inspect and manage attributes in the table (rename, hide, reorder, and delete fields, plus export), style layers with single, categorized, graduated, and expression symbology, reorder, rename, and refresh layers, and save, reopen, or share `.geolibre.json` projects.
+Load local and remote vector and raster data, inspect and manage attributes in the table (rename, hide, reorder, and delete fields, plus export), style layers with single, categorized, graduated, and expression symbology (plus point heatmap and clustering renderers), reorder, rename, and refresh layers, and save, reopen, or share `.geolibre.json` projects.
 </div>
 
 <div class="feature-card" markdown>

--- a/docs/user-guide/styling.md
+++ b/docs/user-guide/styling.md
@@ -16,6 +16,18 @@ For vector layers the Style panel covers fill, stroke, points, labels, and 3D ex
 
 You can also set a per-style minimum and maximum zoom so a style only applies within a zoom range.
 
+### Point renderer (heatmap and clustering)
+
+For point-only layers the Style panel adds a **Point renderer** control:
+
+| Renderer | Description |
+| --- | --- |
+| **Single symbol** | One circle per point (the default). |
+| **Heatmap** | A density surface colored from cold to hot. Adjust **Heatmap radius** (the kernel size in pixels) and **Heatmap intensity**. |
+| **Clustered** | Group nearby points into bubbles labeled with the count; zooming in splits them apart. Adjust the **Cluster radius** (in pixels) and the **Cluster max zoom** above which points stop clustering. Individual (unclustered) points keep the layer's circle style. |
+
+The renderer choice is saved with the project.
+
 ### Style type (data-driven styling)
 
 The **Style type** control chooses how feature values map to color:

--- a/docs/user-guide/styling.md
+++ b/docs/user-guide/styling.md
@@ -18,7 +18,7 @@ You can also set a per-style minimum and maximum zoom so a style only applies wi
 
 ### Point renderer (heatmap and clustering)
 
-For point-only layers the Style panel adds a **Point renderer** control:
+For point-only GeoJSON layers that GeoLibre renders itself (dropped on the map or produced by a tool), the Style panel adds a **Point renderer** control:
 
 | Renderer | Description |
 | --- | --- |

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -66,6 +66,12 @@ export type VectorStyleMode =
   | "categorized"
   | "expression";
 
+/**
+ * How a point layer is rendered: as individual markers, a density heatmap, or
+ * clustered bubbles. Only applies to point geometry.
+ */
+export type PointRenderer = "single" | "heatmap" | "cluster";
+
 export interface VectorStyleStop {
   value: string | number;
   color: string;
@@ -100,6 +106,11 @@ export interface LayerStyle {
   vectorStyleClassificationScheme: string;
   vectorStyleStops: VectorStyleStop[];
   vectorStyleExpression: string;
+  pointRenderer: PointRenderer;
+  heatmapRadius: number;
+  heatmapIntensity: number;
+  clusterRadius: number;
+  clusterMaxZoom: number;
   rasterBrightnessMin: number;
   rasterBrightnessMax: number;
   rasterSaturation: number;
@@ -138,6 +149,11 @@ export const DEFAULT_LAYER_STYLE: LayerStyle = {
     { value: 1, color: "#2563eb" },
   ],
   vectorStyleExpression: "",
+  pointRenderer: "single",
+  heatmapRadius: 30,
+  heatmapIntensity: 1,
+  clusterRadius: 50,
+  clusterMaxZoom: 14,
   rasterBrightnessMin: 0,
   rasterBrightnessMax: 1,
   rasterSaturation: 0,

--- a/packages/map/src/geojson-loader.ts
+++ b/packages/map/src/geojson-loader.ts
@@ -73,6 +73,18 @@ export function circleLayerId(layerId: string): string {
   return `layer-${layerId}-circle`;
 }
 
+export function heatmapLayerId(layerId: string): string {
+  return `layer-${layerId}-heatmap`;
+}
+
+export function clusterLayerId(layerId: string): string {
+  return `layer-${layerId}-cluster`;
+}
+
+export function clusterCountLayerId(layerId: string): string {
+  return `layer-${layerId}-cluster-count`;
+}
+
 export function textLayerId(layerId: string): string {
   return `layer-${layerId}-text`;
 }

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -9,9 +9,12 @@ import type maplibregl from "maplibre-gl";
 import { PMTiles, Protocol } from "pmtiles";
 import {
   circleLayerId,
+  clusterCountLayerId,
+  clusterLayerId,
   detectGeometryProfile,
   fillExtrusionLayerId,
   fillLayerId,
+  heatmapLayerId,
   lineLayerId,
   sourceId,
   textLayerId,
@@ -19,8 +22,10 @@ import {
 import { isPlaceholderLayer } from "./placeholders";
 import {
   circlePaint,
+  clusterCirclePaint,
   fillExtrusionPaint,
   fillPaint,
+  heatmapPaint,
   linePaint,
   rasterPaint,
 } from "./style-mapper";
@@ -948,11 +953,43 @@ function syncGeoJsonLayer(
   const src = sourceId(layer.id);
   const profile = detectGeometryProfile(layer.geojson!);
 
+  // The heatmap and cluster renderers only make sense for point geometry, so
+  // ignore the setting on layers that also carry lines/polygons.
+  const pointOnly =
+    profile.hasPoint && !profile.hasLine && !profile.hasPolygon;
+  const renderer = pointOnly ? styleValue(layer.style, "pointRenderer") : "single";
+  const clusterRadius = styleValue(layer.style, "clusterRadius");
+  const clusterMaxZoom = styleValue(layer.style, "clusterMaxZoom");
+  const wantCluster = renderer === "cluster";
+
+  // Clustering is a source-level option, so toggling it (or changing its params)
+  // means recreating the source — which first requires dropping every layer that
+  // references it. MapLibre forbids removing a source still in use.
+  const existingCluster = geojsonSourceClusterState(map, src);
+  const needsSourceRecreate =
+    existingCluster !== null &&
+    (existingCluster.cluster !== wantCluster ||
+      (wantCluster &&
+        (existingCluster.radius !== clusterRadius ||
+          existingCluster.maxZoom !== clusterMaxZoom)));
+  if (needsSourceRecreate) {
+    removeGeoJsonRenderLayers(map, layer.id);
+    map.removeSource(src);
+  }
+
   if (!map.getSource(src)) {
-    map.addSource(src, {
-      type: "geojson",
-      data: layer.geojson!,
-    });
+    map.addSource(
+      src,
+      wantCluster
+        ? {
+            type: "geojson",
+            data: layer.geojson!,
+            cluster: true,
+            clusterRadius,
+            clusterMaxZoom,
+          }
+        : { type: "geojson", data: layer.geojson! },
+    );
   } else {
     (map.getSource(src) as maplibregl.GeoJSONSource).setData(layer.geojson!);
   }
@@ -1040,7 +1077,90 @@ function syncGeoJsonLayer(
     removeIfExists(map, lineLayerId(layer.id));
   }
 
-  if (!layer.style.extrusionEnabled && profile.hasPoint) {
+  if (!layer.style.extrusionEnabled && profile.hasPoint && renderer === "heatmap") {
+    // Heatmap renderer: one density layer, no circle/cluster layers.
+    removeIfExists(map, circleLayerId(layer.id));
+    removeIfExists(map, clusterLayerId(layer.id));
+    removeIfExists(map, clusterCountLayerId(layer.id));
+    ensureLayer(
+      map,
+      heatmapLayerId(layer.id),
+      {
+        id: heatmapLayerId(layer.id),
+        type: "heatmap",
+        source: src,
+        ...styleLayerZoomRange(layer.style),
+        filter: pointGeometryFilter,
+        paint: heatmapPaint(layer.style, opacity),
+        layout: { visibility },
+      },
+      beforeId,
+    );
+  } else if (
+    !layer.style.extrusionEnabled &&
+    profile.hasPoint &&
+    renderer === "cluster"
+  ) {
+    // Cluster renderer: a bubble + count for aggregated clusters, plus a circle
+    // for the individual (unclustered) points. The source carries cluster: true.
+    removeIfExists(map, heatmapLayerId(layer.id));
+    ensureLayer(
+      map,
+      clusterLayerId(layer.id),
+      {
+        id: clusterLayerId(layer.id),
+        type: "circle",
+        source: src,
+        ...styleLayerZoomRange(layer.style),
+        filter: ["has", "point_count"],
+        paint: clusterCirclePaint(layer.style, opacity),
+        layout: { visibility },
+      },
+      beforeId,
+    );
+    ensureLayer(
+      map,
+      clusterCountLayerId(layer.id),
+      {
+        id: clusterCountLayerId(layer.id),
+        type: "symbol",
+        source: src,
+        ...styleLayerZoomRange(layer.style),
+        filter: ["has", "point_count"],
+        layout: {
+          "text-field": ["get", "point_count_abbreviated"],
+          "text-font": textFontForMapStyle(map),
+          "text-size": 12,
+          "text-allow-overlap": true,
+          "text-ignore-placement": true,
+          visibility,
+        },
+        paint: {
+          "text-color": styleValue(layer.style, "textColor"),
+          "text-opacity": opacity,
+        },
+      },
+      beforeId,
+    );
+    ensureLayer(
+      map,
+      circleLayerId(layer.id),
+      {
+        id: circleLayerId(layer.id),
+        type: "circle",
+        source: src,
+        ...styleLayerZoomRange(layer.style),
+        filter: ["!", ["has", "point_count"]],
+        paint: circlePaint(layer.style, opacity),
+        layout: { visibility },
+      },
+      beforeId,
+    );
+  } else if (!layer.style.extrusionEnabled && profile.hasPoint) {
+    // Single (default) renderer: one circle per point.
+    removeIfExists(map, heatmapLayerId(layer.id));
+    removeIfExists(map, clusterLayerId(layer.id));
+    removeIfExists(map, clusterCountLayerId(layer.id));
     ensureLayer(
       map,
       circleLayerId(layer.id),
@@ -1057,6 +1177,9 @@ function syncGeoJsonLayer(
     );
   } else {
     removeIfExists(map, circleLayerId(layer.id));
+    removeIfExists(map, heatmapLayerId(layer.id));
+    removeIfExists(map, clusterLayerId(layer.id));
+    removeIfExists(map, clusterCountLayerId(layer.id));
   }
 
   if (!layer.style.extrusionEnabled && hasTextMarkers) {
@@ -1827,6 +1950,51 @@ function removeIfExists(map: maplibregl.Map, id: string): void {
   if (map.getLayer(id)) map.removeLayer(id);
 }
 
+/**
+ * Read a GeoJSON source's clustering config from the current style, or null if
+ * the source doesn't exist yet (or isn't a GeoJSON source). Used to decide
+ * whether a cluster toggle requires recreating the source.
+ */
+function geojsonSourceClusterState(
+  map: maplibregl.Map,
+  src: string,
+): { cluster: boolean; radius: number; maxZoom: number } | null {
+  const spec = map.getStyle()?.sources?.[src];
+  if (!spec || spec.type !== "geojson") return null;
+  const clusterSpec = spec as {
+    cluster?: boolean;
+    clusterRadius?: number;
+    clusterMaxZoom?: number;
+  };
+  return {
+    cluster: Boolean(clusterSpec.cluster),
+    radius:
+      typeof clusterSpec.clusterRadius === "number"
+        ? clusterSpec.clusterRadius
+        : 50,
+    maxZoom:
+      typeof clusterSpec.clusterMaxZoom === "number"
+        ? clusterSpec.clusterMaxZoom
+        : 14,
+  };
+}
+
+/** Remove every style layer a GeoJSON layer can own (all renderer variants). */
+function removeGeoJsonRenderLayers(map: maplibregl.Map, layerId: string): void {
+  for (const id of [
+    fillLayerId(layerId),
+    fillExtrusionLayerId(layerId),
+    lineLayerId(layerId),
+    circleLayerId(layerId),
+    heatmapLayerId(layerId),
+    clusterLayerId(layerId),
+    clusterCountLayerId(layerId),
+    textLayerId(layerId),
+  ]) {
+    removeIfExists(map, id);
+  }
+}
+
 function moveLayer(map: maplibregl.Map, id: string, beforeId?: string): void {
   if (!map.getLayer(id)) return;
 
@@ -1854,6 +2022,9 @@ export function removeLayerFromMap(
     fillExtrusionLayerId(layerId),
     lineLayerId(layerId),
     circleLayerId(layerId),
+    heatmapLayerId(layerId),
+    clusterLayerId(layerId),
+    clusterCountLayerId(layerId),
     textLayerId(layerId),
     `layer-${layerId}-raster`,
     `layer-${layerId}-video`,

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -65,6 +65,22 @@ const nonTextMarkerPointFilter: maplibregl.FilterSpecification = [
   ["!", textMarkerShapeFilter],
 ];
 
+/**
+ * Filter for the unclustered-point circle layer in cluster mode: every feature
+ * without a `point_count`, excluding text markers when present so they render
+ * only through the symbol layer rather than also as plain circles.
+ */
+function unclusteredPointFilter(
+  hasTextMarkers: boolean,
+): maplibregl.FilterSpecification {
+  if (!hasTextMarkers) return ["!", ["has", "point_count"]];
+  return [
+    "all",
+    ["!", ["has", "point_count"]],
+    nonTextMarkerPointFilter,
+  ] as maplibregl.FilterSpecification;
+}
+
 // Native layer ids whose zoom range GeoLibre has taken over. A pristine external
 // layer keeps its source-declared range, but once the user sets a non-default
 // range we keep applying the style range on every sync, including a later reset
@@ -1090,7 +1106,9 @@ function syncGeoJsonLayer(
         type: "heatmap",
         source: src,
         ...styleLayerZoomRange(layer.style),
-        filter: pointGeometryFilter,
+        // Keep text-marker points out of the density, mirroring single mode;
+        // they still render through the text symbol layer below.
+        filter: hasTextMarkers ? nonTextMarkerPointFilter : pointGeometryFilter,
         paint: heatmapPaint(layer.style, opacity),
         layout: { visibility },
       },
@@ -1150,7 +1168,9 @@ function syncGeoJsonLayer(
         type: "circle",
         source: src,
         ...styleLayerZoomRange(layer.style),
-        filter: ["!", ["has", "point_count"]],
+        // Unclustered points, excluding text markers (which the symbol layer
+        // renders) so they don't also appear as plain circles.
+        filter: unclusteredPointFilter(hasTextMarkers),
         paint: circlePaint(layer.style, opacity),
         layout: { visibility },
       },
@@ -1971,11 +1991,11 @@ function geojsonSourceClusterState(
     radius:
       typeof clusterSpec.clusterRadius === "number"
         ? clusterSpec.clusterRadius
-        : 50,
+        : DEFAULT_LAYER_STYLE.clusterRadius,
     maxZoom:
       typeof clusterSpec.clusterMaxZoom === "number"
         ? clusterSpec.clusterMaxZoom
-        : 14,
+        : DEFAULT_LAYER_STYLE.clusterMaxZoom,
   };
 }
 

--- a/packages/map/src/style-mapper.ts
+++ b/packages/map/src/style-mapper.ts
@@ -97,7 +97,7 @@ export function circlePaint(style: LayerStyle, opacity: number) {
 }
 
 // A perceptually-ordered cold→hot ramp over MapLibre's heatmap-density (0..1).
-const HEATMAP_COLOR_RAMP = [
+const HEATMAP_COLOR_RAMP: ExpressionSpecification = [
   "interpolate",
   ["linear"],
   ["heatmap-density"],
@@ -120,7 +120,7 @@ export function heatmapPaint(style: LayerStyle, opacity: number) {
     "heatmap-radius": styleValue(style, "heatmapRadius"),
     "heatmap-intensity": styleValue(style, "heatmapIntensity"),
     "heatmap-opacity": opacity,
-    "heatmap-color": HEATMAP_COLOR_RAMP as unknown as ExpressionSpecification,
+    "heatmap-color": HEATMAP_COLOR_RAMP,
   };
 }
 

--- a/packages/map/src/style-mapper.ts
+++ b/packages/map/src/style-mapper.ts
@@ -7,7 +7,10 @@ import {
   vectorLineColorValue,
   type LayerStyle,
 } from "@geolibre/core";
-import type { PropertyValueSpecification } from "maplibre-gl";
+import type {
+  ExpressionSpecification,
+  PropertyValueSpecification,
+} from "maplibre-gl";
 
 function styleValue<K extends keyof LayerStyle>(
   style: LayerStyle,
@@ -87,6 +90,53 @@ export function circlePaint(style: LayerStyle, opacity: number) {
       style,
     ) as PropertyValueSpecification<string>,
     "circle-radius": styleValue(style, "circleRadius"),
+    "circle-opacity": styleValue(style, "fillOpacity") * opacity,
+    "circle-stroke-color": styleValue(style, "strokeColor"),
+    "circle-stroke-width": styleValue(style, "strokeWidth"),
+  };
+}
+
+// A perceptually-ordered cold→hot ramp over MapLibre's heatmap-density (0..1).
+const HEATMAP_COLOR_RAMP = [
+  "interpolate",
+  ["linear"],
+  ["heatmap-density"],
+  0,
+  "rgba(33,102,172,0)",
+  0.2,
+  "rgb(103,169,207)",
+  0.4,
+  "rgb(209,229,240)",
+  0.6,
+  "rgb(253,219,199)",
+  0.8,
+  "rgb(239,138,98)",
+  1,
+  "rgb(178,24,43)",
+];
+
+export function heatmapPaint(style: LayerStyle, opacity: number) {
+  return {
+    "heatmap-radius": styleValue(style, "heatmapRadius"),
+    "heatmap-intensity": styleValue(style, "heatmapIntensity"),
+    "heatmap-opacity": opacity,
+    "heatmap-color": HEATMAP_COLOR_RAMP as unknown as ExpressionSpecification,
+  };
+}
+
+export function clusterCirclePaint(style: LayerStyle, opacity: number) {
+  return {
+    // Cluster bubbles take the layer's fill color; size steps up with the count.
+    "circle-color": styleValue(style, "fillColor"),
+    "circle-radius": [
+      "step",
+      ["get", "point_count"],
+      16,
+      50,
+      22,
+      200,
+      30,
+    ] as PropertyValueSpecification<number>,
     "circle-opacity": styleValue(style, "fillOpacity") * opacity,
     "circle-stroke-color": styleValue(style, "strokeColor"),
     "circle-stroke-width": styleValue(style, "strokeWidth"),

--- a/tests/point-renderer-sync.test.ts
+++ b/tests/point-renderer-sync.test.ts
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  DEFAULT_LAYER_STYLE,
+  type GeoLibreLayer,
+  type LayerStyle,
+} from "@geolibre/core";
+import { syncLayer } from "../packages/map/src/layer-sync";
+
+// Stateful fake MapLibre map: tracks sources and layers across sync passes so a
+// test can assert which native layers/sources a point renderer produces and
+// which were removed when the renderer changes.
+function makeMap() {
+  const sources = new Map<string, Record<string, unknown>>();
+  const layers = new Map<string, Record<string, unknown>>();
+  const calls: { method: string; args: unknown[] }[] = [];
+  const record =
+    (method: string) =>
+    (...args: unknown[]) => {
+      calls.push({ method, args });
+    };
+  const map = {
+    getSource: (id: string) =>
+      sources.has(id) ? { setData: record("setData") } : undefined,
+    addSource: (id: string, spec: Record<string, unknown>) => {
+      sources.set(id, spec);
+      calls.push({ method: "addSource", args: [id, spec] });
+    },
+    removeSource: (id: string) => {
+      sources.delete(id);
+      calls.push({ method: "removeSource", args: [id] });
+    },
+    getLayer: (id: string) =>
+      layers.has(id) ? { id, ...layers.get(id) } : undefined,
+    addLayer: (spec: Record<string, unknown>, beforeId?: string) => {
+      layers.set(spec.id as string, spec);
+      calls.push({ method: "addLayer", args: [spec, beforeId] });
+    },
+    removeLayer: (id: string) => {
+      layers.delete(id);
+      calls.push({ method: "removeLayer", args: [id] });
+    },
+    getFilter: (id: string) => layers.get(id)?.filter,
+    setFilter: record("setFilter"),
+    setPaintProperty: record("setPaintProperty"),
+    setLayoutProperty: record("setLayoutProperty"),
+    setLayerZoomRange: record("setLayerZoomRange"),
+    moveLayer: record("moveLayer"),
+    getStyle: () => ({
+      layers: [...layers.values()],
+      sources: Object.fromEntries(sources),
+    }),
+    once: () => {},
+  };
+  return { map, sources, layers, calls };
+}
+
+function pointLayer(style: Partial<LayerStyle> = {}): GeoLibreLayer {
+  return {
+    id: "pts",
+    name: "Points",
+    type: "geojson",
+    source: { type: "geojson" },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE, ...style },
+    metadata: {},
+    geojson: {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          properties: {},
+          geometry: { type: "Point", coordinates: [0, 0] },
+        },
+        {
+          type: "Feature",
+          properties: {},
+          geometry: { type: "Point", coordinates: [1, 1] },
+        },
+      ],
+    },
+  };
+}
+
+describe("point renderer sync", () => {
+  it("renders a single-symbol point layer as a circle layer", () => {
+    const { map, layers, sources } = makeMap();
+    syncLayer(map as never, pointLayer());
+
+    assert.equal((layers.get("layer-pts-circle") as { type: string }).type, "circle");
+    assert.ok(!layers.has("layer-pts-heatmap"));
+    assert.ok(!layers.has("layer-pts-cluster"));
+    // A single-symbol source is a plain GeoJSON source (no clustering).
+    assert.equal(sources.get("source-pts")?.cluster, undefined);
+  });
+
+  it("renders a heatmap layer and drops the circle when switched", () => {
+    const { map, layers } = makeMap();
+    // Start single, then switch to heatmap on the same map.
+    syncLayer(map as never, pointLayer());
+    assert.ok(layers.has("layer-pts-circle"));
+
+    syncLayer(map as never, pointLayer({ pointRenderer: "heatmap" }));
+    assert.equal(
+      (layers.get("layer-pts-heatmap") as { type: string }).type,
+      "heatmap",
+    );
+    assert.ok(!layers.has("layer-pts-circle"));
+  });
+
+  it("clusters: a clustered source plus cluster, count, and unclustered layers", () => {
+    const { map, layers, sources } = makeMap();
+    syncLayer(
+      map as never,
+      pointLayer({ pointRenderer: "cluster", clusterRadius: 40, clusterMaxZoom: 12 }),
+    );
+
+    const src = sources.get("source-pts") as Record<string, unknown>;
+    assert.equal(src.cluster, true);
+    assert.equal(src.clusterRadius, 40);
+    assert.equal(src.clusterMaxZoom, 12);
+
+    assert.equal((layers.get("layer-pts-cluster") as { type: string }).type, "circle");
+    assert.equal(
+      (layers.get("layer-pts-cluster-count") as { type: string }).type,
+      "symbol",
+    );
+    // The unclustered points reuse the circle layer, filtered to non-clusters.
+    const circle = layers.get("layer-pts-circle") as { filter: unknown };
+    assert.deepEqual(circle.filter, ["!", ["has", "point_count"]]);
+    assert.ok(!layers.has("layer-pts-heatmap"));
+  });
+
+  it("recreates the source when clustering is turned off again", () => {
+    const { map, sources, calls } = makeMap();
+    syncLayer(map as never, pointLayer({ pointRenderer: "cluster" }));
+    assert.equal(sources.get("source-pts")?.cluster, true);
+
+    syncLayer(map as never, pointLayer({ pointRenderer: "single" }));
+    // The clustered source was removed and re-added without clustering.
+    assert.ok(calls.some((c) => c.method === "removeSource" && c.args[0] === "source-pts"));
+    assert.equal(sources.get("source-pts")?.cluster, undefined);
+  });
+
+  it("ignores the renderer on layers with non-point geometry", () => {
+    const { map, layers } = makeMap();
+    const mixed = pointLayer({ pointRenderer: "heatmap" });
+    mixed.geojson!.features.push({
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "LineString",
+        coordinates: [
+          [0, 0],
+          [1, 1],
+        ],
+      },
+    });
+    syncLayer(map as never, mixed);
+
+    // hasPoint is still true, so a circle layer renders; heatmap does not.
+    assert.ok(layers.has("layer-pts-circle"));
+    assert.ok(!layers.has("layer-pts-heatmap"));
+  });
+});


### PR DESCRIPTION
Closes #243.

## Summary

Adds a **Point renderer** choice for point GeoJSON layers, rendered by the core MapLibre layer sync:

- **Heatmap** — a MapLibre `heatmap` layer with a cold→hot density ramp. Adjustable **radius** and **intensity**.
- **Clustered** — the GeoJSON source gets `cluster: true` (adjustable **cluster radius** and **max zoom**); the sync builds a cluster-bubble layer, a count-label layer, and an unclustered-point circle layer. Zooming in splits clusters apart. Toggling clustering recreates the source after dropping its dependent layers (MapLibre forbids removing a source still in use).
- **Single symbol** — the existing one-circle-per-point default.

The renderer is saved with the `.geolibre.json` project.

## Changes
- `packages/core/src/types.ts` — `PointRenderer` type; `pointRenderer`, `heatmapRadius`, `heatmapIntensity`, `clusterRadius`, `clusterMaxZoom` on `LayerStyle` + defaults (persists via the existing style serialization).
- `packages/map/src/geojson-loader.ts` — `heatmapLayerId` / `clusterLayerId` / `clusterCountLayerId`.
- `packages/map/src/style-mapper.ts` — `heatmapPaint`, `clusterCirclePaint`.
- `packages/map/src/layer-sync.ts` — renderer branching in `syncGeoJsonLayer`, source-cluster recreation, and cleanup of the new layers in `removeLayerFromMap`.
- `apps/.../StylePanel.tsx` — a **Point renderer** section, shown only for point-only GeoJSON layers the core renders (not control-owned / deck.gl layers), with conditional heatmap/cluster controls.
- `tests/point-renderer-sync.test.ts` — single/heatmap/cluster, source recreation on toggle, and the non-point guard.
- Docs: styling guide, README, index.

## Testing
- `npm run build` ✅ · 361 frontend tests (incl. 5 new) ✅ · `pre-commit` ✅
- **Playwright + real data** (1000 US city points → Centroids gives a core GeoJSON point layer): **Heatmap** rendered a cold→hot density surface (densest in the populous east); **Clustered** rendered count-labeled bubbles that split on zoom. Confirmed the Point renderer control is shown for core point layers and correctly **hidden** for the external vector-control layer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live style panel now supports point renderers for point-only GeoJSON layers: Single symbol, Heatmap (radius, intensity) and Clustered (radius, max zoom). Renderer selection is saved with the project and hides incompatible symbology controls when Heatmap is chosen.

* **Documentation**
  * User guide and product docs updated to describe the new point renderer modes and controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->