### PR TITLE
fix(gpkg): repair GeoPackages missing gpkg_ogr_contents before ST_Read (#258)

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -64,12 +64,14 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "shpjs": "^6.2.0",
+    "sql.js": "^1.14.0",
     "three": "^0.184.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.0",
     "@tauri-apps/cli": "^2.11.2",
     "@types/geojson": "^7946.0.16",
+    "@types/sql.js": "^1.4.9",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -4,6 +4,7 @@ import ehWorker from "@duckdb/duckdb-wasm/dist/duckdb-browser-eh.worker.js?url";
 import duckdbWasmMvp from "@duckdb/duckdb-wasm/dist/duckdb-mvp.wasm?url";
 import mvpWorker from "@duckdb/duckdb-wasm/dist/duckdb-browser-mvp.worker.js?url";
 import type { Feature, FeatureCollection, Geometry } from "geojson";
+import { ensureGpkgFeatureCount } from "./gpkg-ogr-contents";
 import { getSpatialExtensionPath } from "./spatial-extension-config";
 
 const GEOMETRY_JSON_COLUMN = "__geolibre_geometry_geojson";
@@ -146,6 +147,25 @@ function isParquetExtension(extension: string): boolean {
   return extension === "parquet" || extension === "geoparquet";
 }
 
+/**
+ * Register a vector file (and any siblings) as DuckDB file buffers, repairing
+ * GeoPackages that lack `gpkg_ogr_contents` first so `ST_Read` does not crash on
+ * the single-threaded WASM build. See `gpkg-ogr-contents.ts` and issue #258.
+ */
+async function registerVectorFileBuffers(
+  db: duckdb.AsyncDuckDB,
+  file: DuckDbVectorFile,
+): Promise<void> {
+  const data =
+    file.extension === "gpkg"
+      ? await ensureGpkgFeatureCount(file.data)
+      : file.data;
+  await db.registerFileBuffer(file.name, data as Uint8Array<ArrayBuffer>);
+  for (const sibling of file.siblingFiles ?? []) {
+    await db.registerFileBuffer(sibling.name, sibling.data);
+  }
+}
+
 function sourceSql(fileName: string, extension: string): string {
   const quotedName = quoteSqlString(fileName);
   if (isParquetExtension(extension)) {
@@ -266,10 +286,7 @@ export async function loadDuckDbVectorFile(
   const connection = await db.connect();
 
   try {
-    await db.registerFileBuffer(file.name, file.data);
-    for (const sibling of file.siblingFiles ?? []) {
-      await db.registerFileBuffer(sibling.name, sibling.data);
-    }
+    await registerVectorFileBuffers(db, file);
     await ensureSpatialExtension(connection);
 
     const sql = sourceSql(file.name, file.extension);
@@ -384,10 +401,7 @@ export async function convertDuckDbVectorToGeoParquet(
   ];
 
   try {
-    await db.registerFileBuffer(file.name, file.data);
-    for (const sibling of file.siblingFiles ?? []) {
-      await db.registerFileBuffer(sibling.name, sibling.data);
-    }
+    await registerVectorFileBuffers(db, file);
     await ensureSpatialExtension(connection);
 
     let geometryColumn: string;

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -160,7 +160,7 @@ async function registerVectorFileBuffers(
     file.extension === "gpkg"
       ? await ensureGpkgFeatureCount(file.data)
       : file.data;
-  await db.registerFileBuffer(file.name, data as Uint8Array<ArrayBuffer>);
+  await db.registerFileBuffer(file.name, data);
   for (const sibling of file.siblingFiles ?? []) {
     await db.registerFileBuffer(sibling.name, sibling.data);
   }

--- a/apps/geolibre-desktop/src/lib/gpkg-ogr-contents.ts
+++ b/apps/geolibre-desktop/src/lib/gpkg-ogr-contents.ts
@@ -1,0 +1,150 @@
+import type { Database, SqlJsStatic } from "sql.js";
+
+/**
+ * Ensures a GeoPackage carries the `gpkg_ogr_contents` feature-count table so
+ * DuckDB-WASM's `ST_Read` can open it without crashing.
+ *
+ * GeoPackages written without `gpkg_ogr_contents` (e.g. by QGIS, or any tool
+ * that skips the OGR feature-count cache) force GDAL's GeoPackage driver to
+ * compute the feature count the slow way, which sends it down a multithreaded
+ * Arrow read path. That path calls `std::thread`/`pthread_create`, and the
+ * single-threaded DuckDB-WASM `eh` bundle the app loads in the browser and the
+ * Tauri webview has no pthread support, so the read fails with:
+ *
+ *   "thread constructor failed: Resource temporarily unavailable"
+ *
+ * Injecting `gpkg_ogr_contents` with a cached count keeps GDAL on the fast,
+ * single-threaded path. See GitHub issue #258.
+ */
+
+const SQLITE_MAGIC = "SQLite format 3\0";
+
+/** A SQLite/GeoPackage file begins with the 16-byte "SQLite format 3\0" magic. */
+export function looksLikeSqlite(bytes: Uint8Array): boolean {
+  if (bytes.length < SQLITE_MAGIC.length) return false;
+  for (let i = 0; i < SQLITE_MAGIC.length; i += 1) {
+    if (bytes[i] !== SQLITE_MAGIC.charCodeAt(i)) return false;
+  }
+  return true;
+}
+
+function quoteIdentifier(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`;
+}
+
+function tableExists(db: Database, name: string): boolean {
+  const result = db.exec(
+    "SELECT 1 FROM sqlite_master WHERE type='table' AND name=:name",
+    { ":name": name },
+  );
+  return result.length > 0 && result[0].values.length > 0;
+}
+
+/**
+ * Synchronous core of {@link ensureGpkgFeatureCount}, kept separate so it can be
+ * unit-tested with an already-initialised sql.js factory. Returns the original
+ * buffer unchanged when the file is not a GeoPackage or already has a count for
+ * every feature table; otherwise returns a patched buffer.
+ */
+export function ensureGpkgFeatureCountSync(
+  SQL: SqlJsStatic,
+  bytes: Uint8Array,
+): Uint8Array {
+  const db = new SQL.Database(bytes);
+  try {
+    // Only touch real GeoPackages; gpkg_contents is mandatory in the spec.
+    if (!tableExists(db, "gpkg_contents")) return bytes;
+
+    const featureTablesResult = db.exec(
+      "SELECT table_name FROM gpkg_contents WHERE data_type='features'",
+    );
+    if (
+      featureTablesResult.length === 0 ||
+      featureTablesResult[0].values.length === 0
+    ) {
+      return bytes;
+    }
+    const featureTables = featureTablesResult[0].values
+      .map((row) => row[0])
+      .filter((name): name is string => typeof name === "string");
+
+    const hasOgrContents = tableExists(db, "gpkg_ogr_contents");
+    const existingCounts = hasOgrContents
+      ? new Set(
+          (
+            db.exec("SELECT table_name FROM gpkg_ogr_contents")[0]?.values ?? []
+          )
+            .map((row) => row[0])
+            .filter((name): name is string => typeof name === "string"),
+        )
+      : new Set<string>();
+
+    const missing = featureTables.filter((name) => !existingCounts.has(name));
+    if (missing.length === 0) return bytes;
+
+    if (!hasOgrContents) {
+      db.run(
+        "CREATE TABLE gpkg_ogr_contents (" +
+          "table_name TEXT NOT NULL PRIMARY KEY, " +
+          "feature_count INTEGER DEFAULT NULL)",
+      );
+    }
+
+    for (const tableName of missing) {
+      const countResult = db.exec(
+        `SELECT count(*) FROM ${quoteIdentifier(tableName)}`,
+      );
+      const count = countResult[0]?.values[0]?.[0] ?? 0;
+      db.run(
+        "INSERT INTO gpkg_ogr_contents (table_name, feature_count) VALUES (:name, :count)",
+        { ":name": tableName, ":count": count },
+      );
+    }
+
+    return db.export();
+  } finally {
+    db.close();
+  }
+}
+
+let sqlJsPromise: Promise<SqlJsStatic> | null = null;
+
+async function loadSqlJs(): Promise<SqlJsStatic> {
+  sqlJsPromise ??= (async () => {
+    const [{ default: initSqlJs }, { default: wasmUrl }] = await Promise.all([
+      import("sql.js"),
+      // Bundled locally by Vite (works offline and in the Tauri webview).
+      import("sql.js/dist/sql-wasm.wasm?url"),
+    ]);
+    return initSqlJs({ locateFile: () => wasmUrl });
+  })();
+  try {
+    return await sqlJsPromise;
+  } catch (error) {
+    sqlJsPromise = null;
+    throw error;
+  }
+}
+
+/**
+ * Returns a GeoPackage buffer guaranteed to carry `gpkg_ogr_contents` for every
+ * feature table, patching it in-memory when needed. Non-GeoPackage input and
+ * already-complete files are returned untouched. Best-effort: if sql.js fails to
+ * load or the file cannot be parsed, the original buffer is returned so the
+ * normal `ST_Read` error path still applies.
+ */
+export async function ensureGpkgFeatureCount(
+  bytes: Uint8Array,
+): Promise<Uint8Array> {
+  if (!looksLikeSqlite(bytes)) return bytes;
+  try {
+    const SQL = await loadSqlJs();
+    return ensureGpkgFeatureCountSync(SQL, bytes);
+  } catch (error) {
+    console.warn(
+      "[GeoLibre] Could not ensure gpkg_ogr_contents; reading file as-is.",
+      error,
+    );
+    return bytes;
+  }
+}

--- a/apps/geolibre-desktop/src/lib/gpkg-ogr-contents.ts
+++ b/apps/geolibre-desktop/src/lib/gpkg-ogr-contents.ts
@@ -45,18 +45,23 @@ function tableExists(db: Database, name: string): boolean {
  * unit-tested with an already-initialised sql.js factory. Returns the original
  * buffer unchanged when the file is not a GeoPackage or already has a count for
  * every feature table; otherwise returns a patched buffer.
+ *
+ * Loads the whole file into the sql.js WASM heap. When patching is needed the
+ * exported buffer is a second full-size allocation, so peak memory is roughly
+ * 2x the file size. Fine for typical browser-side GeoPackages.
  */
 export function ensureGpkgFeatureCountSync(
   SQL: SqlJsStatic,
-  bytes: Uint8Array,
-): Uint8Array {
+  bytes: Uint8Array<ArrayBuffer>,
+): Uint8Array<ArrayBuffer> {
   const db = new SQL.Database(bytes);
   try {
     // Only touch real GeoPackages; gpkg_contents is mandatory in the spec.
     if (!tableExists(db, "gpkg_contents")) return bytes;
 
     const featureTablesResult = db.exec(
-      "SELECT table_name FROM gpkg_contents WHERE data_type='features'",
+      // lower() so out-of-spec producers writing 'Features'/'FEATURES' still match.
+      "SELECT table_name FROM gpkg_contents WHERE lower(data_type)='features'",
     );
     if (
       featureTablesResult.length === 0 ||
@@ -101,7 +106,8 @@ export function ensureGpkgFeatureCountSync(
       );
     }
 
-    return db.export();
+    // sql.js always exports an ArrayBuffer-backed Uint8Array; re-narrow the type.
+    return db.export() as Uint8Array<ArrayBuffer>;
   } finally {
     db.close();
   }
@@ -134,8 +140,8 @@ async function loadSqlJs(): Promise<SqlJsStatic> {
  * normal `ST_Read` error path still applies.
  */
 export async function ensureGpkgFeatureCount(
-  bytes: Uint8Array,
-): Promise<Uint8Array> {
+  bytes: Uint8Array<ArrayBuffer>,
+): Promise<Uint8Array<ArrayBuffer>> {
   if (!looksLikeSqlite(bytes)) return bytes;
   try {
     const SQL = await loadSqlJs();

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,7 @@
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "shpjs": "^6.2.0",
+        "sql.js": "^1.14.0",
         "three": "^0.184.0"
       },
       "devDependencies": {
@@ -83,6 +84,7 @@
         "@types/geojson": "^7946.0.16",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
+        "@types/sql.js": "^1.4.9",
         "@vitejs/plugin-react": "^6.0.2",
         "esbuild": "^0.28.0",
         "osmix": "^0.2.0",
@@ -8676,6 +8678,13 @@
       "integrity": "sha512-qp3m9PPz4gULB9MhjGID7wpo3gJ4bTGXm7ltNDsmOvsPduTeHp8wSW9YckBj3mljeOh4F0m2z/0JKAALRKbmLQ==",
       "license": "MIT"
     },
+    "node_modules/@types/emscripten": {
+      "version": "1.41.5",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
+      "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -8752,6 +8761,17 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "license": "MIT"
+    },
+    "node_modules/@types/sql.js": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@types/sql.js/-/sql.js-1.4.11.tgz",
+      "integrity": "sha512-QXIx38p2ZThJaK9vP5ZdqdlRe1FG9I8SmCZOS7FHfB/2qPAjZwkL7/vlfPg6N/oWHuuOaGg/P/IRwfP2W0kWVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/emscripten": "*",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/supercluster": {
       "version": "7.1.3",
@@ -15254,6 +15274,12 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/sql.js": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.1.tgz",
+      "integrity": "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==",
+      "license": "MIT"
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",

--- a/tests/gpkg-ogr-contents.test.ts
+++ b/tests/gpkg-ogr-contents.test.ts
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { before, describe, it } from "node:test";
+import initSqlJs from "sql.js";
+import type { Database, SqlJsStatic } from "sql.js";
+import {
+  ensureGpkgFeatureCountSync,
+  looksLikeSqlite,
+} from "../apps/geolibre-desktop/src/lib/gpkg-ogr-contents";
+
+const require = createRequire(import.meta.url);
+
+let SQL: SqlJsStatic;
+
+before(async () => {
+  const wasmPath = require.resolve("sql.js/dist/sql-wasm.wasm");
+  SQL = await initSqlJs({ locateFile: () => wasmPath });
+});
+
+/** Build a minimal in-memory GeoPackage and return its bytes. */
+function buildGpkg(options: {
+  withOgrContents?: boolean;
+  featureCount?: number;
+  tableName?: string;
+}): Uint8Array {
+  const tableName = options.tableName ?? "places";
+  const featureCount = options.featureCount ?? 3;
+  const db: Database = new SQL.Database();
+  db.run(`
+    CREATE TABLE gpkg_contents (
+      table_name TEXT NOT NULL PRIMARY KEY,
+      data_type TEXT NOT NULL,
+      identifier TEXT,
+      description TEXT,
+      min_x DOUBLE, min_y DOUBLE, max_x DOUBLE, max_y DOUBLE,
+      srs_id INTEGER
+    );
+    CREATE TABLE "${tableName}" (fid INTEGER PRIMARY KEY, geom BLOB, name TEXT);
+  `);
+  db.run(
+    "INSERT INTO gpkg_contents (table_name, data_type, srs_id) VALUES (:t, 'features', 4326)",
+    { ":t": tableName },
+  );
+  for (let i = 0; i < featureCount; i += 1) {
+    db.run(`INSERT INTO "${tableName}" (name) VALUES (:n)`, {
+      ":n": `feature-${i}`,
+    });
+  }
+  if (options.withOgrContents) {
+    db.run(
+      "CREATE TABLE gpkg_ogr_contents (table_name TEXT NOT NULL PRIMARY KEY, feature_count INTEGER)",
+    );
+    db.run(
+      "INSERT INTO gpkg_ogr_contents (table_name, feature_count) VALUES (:t, :c)",
+      { ":t": tableName, ":c": featureCount },
+    );
+  }
+  const bytes = db.export();
+  db.close();
+  return bytes;
+}
+
+function readOgrContents(
+  bytes: Uint8Array,
+): Array<{ table_name: string; feature_count: number }> {
+  const db = new SQL.Database(bytes);
+  try {
+    const result = db.exec(
+      "SELECT table_name, feature_count FROM gpkg_ogr_contents ORDER BY table_name",
+    );
+    if (result.length === 0) return [];
+    return result[0].values.map((row) => ({
+      table_name: row[0] as string,
+      feature_count: row[1] as number,
+    }));
+  } finally {
+    db.close();
+  }
+}
+
+describe("looksLikeSqlite", () => {
+  it("detects the SQLite magic header", () => {
+    assert.equal(looksLikeSqlite(buildGpkg({})), true);
+  });
+
+  it("rejects non-SQLite buffers", () => {
+    assert.equal(looksLikeSqlite(new Uint8Array([1, 2, 3, 4])), false);
+    assert.equal(
+      looksLikeSqlite(new TextEncoder().encode("not a database at all")),
+      false,
+    );
+  });
+});
+
+describe("ensureGpkgFeatureCountSync", () => {
+  it("injects gpkg_ogr_contents when missing", () => {
+    const original = buildGpkg({ withOgrContents: false, featureCount: 5 });
+    const patched = ensureGpkgFeatureCountSync(SQL, original);
+
+    assert.notEqual(patched, original);
+    assert.deepEqual(readOgrContents(patched), [
+      { table_name: "places", feature_count: 5 },
+    ]);
+  });
+
+  it("adds a row for every feature table", () => {
+    const db: Database = new SQL.Database();
+    db.run(`
+      CREATE TABLE gpkg_contents (
+        table_name TEXT NOT NULL PRIMARY KEY, data_type TEXT NOT NULL, srs_id INTEGER
+      );
+      CREATE TABLE roads (fid INTEGER PRIMARY KEY, geom BLOB);
+      CREATE TABLE rivers (fid INTEGER PRIMARY KEY, geom BLOB);
+      INSERT INTO gpkg_contents VALUES ('roads', 'features', 4326);
+      INSERT INTO gpkg_contents VALUES ('rivers', 'features', 4326);
+      INSERT INTO roads (geom) VALUES (NULL), (NULL);
+      INSERT INTO rivers (geom) VALUES (NULL), (NULL), (NULL), (NULL);
+    `);
+    const original = db.export();
+    db.close();
+
+    const patched = ensureGpkgFeatureCountSync(SQL, original);
+    assert.deepEqual(readOgrContents(patched), [
+      { table_name: "rivers", feature_count: 4 },
+      { table_name: "roads", feature_count: 2 },
+    ]);
+  });
+
+  it("leaves a complete GeoPackage untouched", () => {
+    const original = buildGpkg({ withOgrContents: true, featureCount: 3 });
+    const patched = ensureGpkgFeatureCountSync(SQL, original);
+    assert.equal(patched, original);
+  });
+
+  it("ignores SQLite databases that are not GeoPackages", () => {
+    const db: Database = new SQL.Database();
+    db.run("CREATE TABLE notes (id INTEGER, body TEXT); INSERT INTO notes VALUES (1, 'hi');");
+    const original = db.export();
+    db.close();
+
+    const patched = ensureGpkgFeatureCountSync(SQL, original);
+    assert.equal(patched, original);
+  });
+});

--- a/tests/gpkg-ogr-contents.test.ts
+++ b/tests/gpkg-ogr-contents.test.ts
@@ -126,6 +126,34 @@ describe("ensureGpkgFeatureCountSync", () => {
     ]);
   });
 
+  it("fills gaps when gpkg_ogr_contents exists but is incomplete", () => {
+    const db: Database = new SQL.Database();
+    db.run(`
+      CREATE TABLE gpkg_contents (
+        table_name TEXT NOT NULL PRIMARY KEY, data_type TEXT NOT NULL, srs_id INTEGER
+      );
+      CREATE TABLE roads (fid INTEGER PRIMARY KEY, geom BLOB);
+      CREATE TABLE rivers (fid INTEGER PRIMARY KEY, geom BLOB);
+      INSERT INTO gpkg_contents VALUES ('roads', 'features', 4326);
+      INSERT INTO gpkg_contents VALUES ('rivers', 'features', 4326);
+      INSERT INTO roads (geom) VALUES (NULL);
+      INSERT INTO rivers (geom) VALUES (NULL), (NULL), (NULL);
+      CREATE TABLE gpkg_ogr_contents (
+        table_name TEXT NOT NULL PRIMARY KEY, feature_count INTEGER
+      );
+      INSERT INTO gpkg_ogr_contents VALUES ('roads', 1);
+    `);
+    const original = db.export();
+    db.close();
+
+    const patched = ensureGpkgFeatureCountSync(SQL, original);
+    assert.notEqual(patched, original);
+    assert.deepEqual(readOgrContents(patched), [
+      { table_name: "rivers", feature_count: 3 },
+      { table_name: "roads", feature_count: 1 },
+    ]);
+  });
+
   it("leaves a complete GeoPackage untouched", () => {
     const original = buildGpkg({ withOgrContents: true, featureCount: 3 });
     const patched = ensureGpkgFeatureCountSync(SQL, original);


### PR DESCRIPTION
## Summary

Fixes the GeoPackage loading failures in #258, where some `.gpkg` files load fine and others fail with:

```
thread constructor failed: Resource temporarily unavailable
```

with no relation to file size.

## Root cause

When a GeoPackage lacks the `gpkg_ogr_contents` feature-count table, GDAL's GeoPackage driver (inside DuckDB-WASM Spatial's `ST_Read`) cannot get a cheap feature count, so it takes its multithreaded async Arrow read path, which calls `pthread_create`. The single-threaded DuckDB-WASM `eh` bundle the app loads in the browser and the Tauri webview (neither is cross-origin isolated) has no pthread support, so the read throws.

This explains the "some work, some don't" behavior:
- Files written by ogr2ogr/GDAL include `gpkg_ogr_contents` and load fine.
- Files written by QGIS often omit it (and carry the `gpkg_schema` extension, which is also why labels were lost), so they fail.

Confirmed by a controlled experiment in the exact bundled DuckDB-WASM version:

| File | `gpkg_ogr_contents`? | `ST_Read` |
|---|---|---|
| working file (original) | yes | OK |
| working file (table removed) | no | thread constructor failed |
| failing file (original) | no | thread constructor failed |
| failing file (table added) | yes | OK |

Things that do not help: `SET threads TO 1` (already 1), `ST_Read` params (`keep_wkb`, `max_batch_size`, `open_options`), GDAL env vars (never reach WASM), and the sqlite extension's `ATTACH` (uses SQLite's own VFS and cannot see DuckDB-registered buffers).

## Fix

Before `ST_Read`, open `.gpkg` buffers with a lazily loaded `sql.js` and inject `gpkg_ogr_contents` with a cached count for every feature table missing one. Already-complete and non-GeoPackage files are returned untouched, and any failure falls back to reading the file as-is so the normal error path still applies. Applied to both the layer-load path and the GeoPackage to GeoParquet conversion path.

`sql.js` (and its ~660 KB wasm) is a lazy-loaded chunk, fetched only when a GeoPackage is opened.

## Tests

- New `tests/gpkg-ogr-contents.test.ts` covers injection, multi-table files, idempotency on complete files, and non-GeoPackage SQLite input.
- Full frontend suite (315 tests) and the production build pass.

## Out of scope (follow-ups)

- Lost vector labels: QGIS stores these in `gpkg_data_columns`/layer styles, which the `ST_Read` path ignores.
- GeoTIFF/raster load failures: likely non-COG inputs; separate from this crash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved GeoPackage handling: in-memory repair and automatic population of feature-count metadata for more reliable vector file loading; integrated into the vector loading flow with lazy WASM initialization.

* **Tests**
  * Added tests validating GeoPackage detection, metadata injection, and behavior across varied GeoPackage/SQLite scenarios.

* **Chores**
  * Added sql.js runtime (and types) to support the new GeoPackage handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->