### PR TITLE
feat(style): heatmap/cluster for Add Vector Layer data (depends on maplibre-gl-vector v0.3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS
 - Cloud data integrations through the Planetary Computer and Earth Engine panels, the Overture Maps plugin, and federal Web Services plugins
 - Manual and automatic refresh for WFS, GeoJSON URL, and Add Vector Layer URL layers
 - Layer panel for visibility, opacity, reordering, rename, zoom-to-layer, identify, labels, open attribute table, export, and remove actions
-- Live style panel with single, categorized, graduated, and expression symbology (fill, stroke, opacity, circle radius), including for Add Vector Layer layers, plus point heatmap and clustering renderers for GeoJSON point layers
+- Live style panel with single, categorized, graduated, and expression symbology (fill, stroke, opacity, circle radius), plus point heatmap and clustering renderers — all including for Add Vector Layer point layers
 - Attribute table with filtering, sorting, resize controls, feature highlighting, optional zoom to selected features, column management (rename, delete, hide/show, reorder), and export to GeoJSON/GeoParquet/CSV
 - SQL Workspace for running DuckDB Spatial SQL against loaded layers, local files, and remote URLs, with sample queries, query history, and adding results to the map or exporting them
 - Multiple DuckDB SQL query-result layers with identify, selection, and attribute table support

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -60,7 +60,7 @@
     "maplibre-gl-streetview": "^0.5.0",
     "maplibre-gl-swipe": "^0.7.1",
     "maplibre-gl-time-slider": "^1.0.3",
-    "maplibre-gl-vector": "^0.2.4",
+    "maplibre-gl-vector": "^0.3.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "shpjs": "^6.2.0",

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1152,17 +1152,23 @@ export function StylePanel({
     isRasterPaintLayer(layer.type) || isRasterTileLayer || isDeckRasterLayer;
   const hasTextMarkerControls =
     layer.type === "geojson" && hasTextMarkerFeatures(layer);
-  // Heatmap/cluster are rendered by the core GeoJSON sync, so only offer them
-  // for layers it actually paints — not control-owned or deck.gl layers. Memoize
+  // Heatmap/cluster apply to point layers in two render paths: core GeoJSON
+  // layers (drag-drop, processing results) and Add Vector Layer point layers in
+  // the geojson render mode (the maplibre-gl-vector control renders those, so
+  // type stays "geojson"; tile-rendered layers become "vector-tiles"). Memoize
   // the point-only scan so a large layer isn't re-scanned on every panel render.
-  const isPointOnly = useMemo(
-    () => isPointOnlyGeoJsonLayer(layer),
-    [layer],
-  );
-  const supportsPointRenderer =
+  const isPointOnly = useMemo(() => isPointOnlyGeoJsonLayer(layer), [layer]);
+  const isCoreGeoJsonPoint =
     isPointOnly &&
     !hasExternalNativeLayers(layer) &&
     !hasExternalDeckLayer(layer);
+  const isVectorControlPoint =
+    hasExternalNativeLayers(layer) &&
+    !hasExternalDeckLayer(layer) &&
+    layer.type === "geojson" &&
+    layer.metadata.sourceKind === "maplibre-gl-vector" &&
+    layer.metadata.geometryType === "point";
+  const supportsPointRenderer = isCoreGeoJsonPoint || isVectorControlPoint;
   const pointRenderer = styleValue(style, "pointRenderer");
   const extrusionEnabled = styleValue(style, "extrusionEnabled");
   const extrusionHeightPropertyOptions = getAttributePropertyNames(layer);

--- a/docs/user-guide/styling.md
+++ b/docs/user-guide/styling.md
@@ -18,7 +18,7 @@ You can also set a per-style minimum and maximum zoom so a style only applies wi
 
 ### Point renderer (heatmap and clustering)
 
-For point-only GeoJSON layers that GeoLibre renders itself (dropped on the map or produced by a tool), the Style panel adds a **Point renderer** control:
+For point-only GeoJSON layers — whether dropped on the map, produced by a tool, or loaded through **Add Vector Layer** in the geojson render mode — the Style panel adds a **Point renderer** control:
 
 | Renderer | Description |
 | --- | --- |

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "maplibre-gl-streetview": "^0.5.0",
         "maplibre-gl-swipe": "^0.7.1",
         "maplibre-gl-time-slider": "^1.0.3",
-        "maplibre-gl-vector": "^0.2.4",
+        "maplibre-gl-vector": "^0.3.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "shpjs": "^6.2.0",
@@ -13423,9 +13423,9 @@
       }
     },
     "node_modules/maplibre-gl-vector": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.2.5.tgz",
-      "integrity": "sha512-aGSLrle87mUBWjOKkCpvo525lOODOoG0O0CjzwAHyreZ3OpNuQ4xtuI51h0RbNWvQfg9d9By338CqG0vLlQUtA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.3.0.tgz",
+      "integrity": "sha512-G4Q705O93wZq2tKHKuvZxPSH1Ip67Sdr6TvXcfzfV9GthnN6vw0QwauevTjleCw8nfUcaWHfeWsYbKqzzS8f9g==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"
@@ -17829,7 +17829,7 @@
         "maplibre-gl-streetview": "^0.5.0",
         "maplibre-gl-swipe": "^0.7.1",
         "maplibre-gl-time-slider": "^1.0.3",
-        "maplibre-gl-vector": "^0.2.5",
+        "maplibre-gl-vector": "^0.3.0",
         "proj4": "^2.20.9",
         "shpjs": "^6.2.0",
         "three": "^0.184.0"

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -48,7 +48,7 @@
     "maplibre-gl-streetview": "^0.5.0",
     "maplibre-gl-swipe": "^0.7.1",
     "maplibre-gl-time-slider": "^1.0.3",
-    "maplibre-gl-vector": "^0.2.5",
+    "maplibre-gl-vector": "^0.3.0",
     "proj4": "^2.20.9",
     "shpjs": "^6.2.0",
     "three": "^0.184.0"

--- a/packages/plugins/src/plugins/vector-layer-sync.ts
+++ b/packages/plugins/src/plugins/vector-layer-sync.ts
@@ -101,6 +101,11 @@ export function createVectorStoreLayer(
     metadata: {
       customLayerType: vectorCustomLayerType(info.geometryType),
       externalNativeLayer: true,
+      // The control owns its layers' paint: GeoLibre pushes style edits through
+      // control.setLayerStyle (see wireVectorStoreSync), so the core sync must
+      // not also re-apply paint — that would clobber control-only renderers like
+      // the cluster bubble's stepped radius.
+      controlOwnsPaint: true,
       // The control's own picker popup handles feature inspection; the
       // app-level identify tool does not target these layers.
       identifiable: false,
@@ -238,6 +243,19 @@ export function wireVectorStoreSync(control: VectorSyncableControl): void {
         const nextStyle = layerStyleToVectorStyle(current.style);
         if (!vectorStylesEqual(layerStyleToVectorStyle(layer.style), nextStyle)) {
           activeControl.setLayerStyle(layer.id, nextStyle);
+          // A pointMode change makes the control rebuild its map layers, so the
+          // new layer ids replace the old ones. Refresh nativeLayerIds/sourceIds
+          // from the control so the core sync orders/toggles the new layers.
+          const updated = activeControl
+            .getLayers()
+            .find((info) => info.id === layer.id);
+          const metadataPatch: Record<string, unknown> = {
+            ...current.metadata,
+          };
+          if (updated) {
+            metadataPatch.nativeLayerIds = [...updated.layerIds];
+            metadataPatch.sourceIds = [updated.sourceId];
+          }
           // Keep the persisted control-seed style in sync so a saved project
           // restores the user-edited colors: restoreVectorLayers seeds the
           // control's addData from metadata.vectorState.style. (The control's
@@ -250,16 +268,14 @@ export function wireVectorStoreSync(control: VectorSyncableControl): void {
             typeof vectorState === "object" &&
             !Array.isArray(vectorState)
           ) {
-            useAppStore.getState().updateLayer(layer.id, {
-              metadata: {
-                ...current.metadata,
-                vectorState: {
-                  ...(vectorState as Record<string, unknown>),
-                  style: nextStyle,
-                },
-              },
-            });
+            metadataPatch.vectorState = {
+              ...(vectorState as Record<string, unknown>),
+              style: nextStyle,
+            };
           }
+          useAppStore.getState().updateLayer(layer.id, {
+            metadata: metadataPatch,
+          });
         }
       }
     });
@@ -505,6 +521,15 @@ function layerStyleToVectorStyle(style: LayerStyle): VectorLayerStyle {
     fillColorExpression: colorExpressionField(vectorFillColorValue(style)),
     lineColorExpression: colorExpressionField(vectorLineColorValue(style)),
     circleColorExpression: colorExpressionField(vectorCircleColorValue(style)),
+    // Point renderer: GeoLibre's "single" maps to the control's "circle".
+    pointMode:
+      (style.pointRenderer ?? "single") === "single"
+        ? "circle"
+        : (style.pointRenderer as "heatmap" | "cluster"),
+    heatmapRadius: style.heatmapRadius,
+    heatmapIntensity: style.heatmapIntensity,
+    clusterRadius: style.clusterRadius,
+    clusterMaxZoom: style.clusterMaxZoom,
   };
 }
 
@@ -551,6 +576,19 @@ function vectorStyleToLayerStyle(info: VectorLayerInfo): Partial<LayerStyle> {
   if (fillColor !== undefined) seed.fillColor = fillColor;
   if (fillOpacity !== undefined) seed.fillOpacity = fillOpacity;
 
+  // Reflect the control's point render mode in the panel ("circle" -> "single").
+  if (style.pointMode !== undefined) {
+    seed.pointRenderer = style.pointMode === "circle" ? "single" : style.pointMode;
+  }
+  if (typeof style.heatmapRadius === "number") seed.heatmapRadius = style.heatmapRadius;
+  if (typeof style.heatmapIntensity === "number") {
+    seed.heatmapIntensity = style.heatmapIntensity;
+  }
+  if (typeof style.clusterRadius === "number") seed.clusterRadius = style.clusterRadius;
+  if (typeof style.clusterMaxZoom === "number") {
+    seed.clusterMaxZoom = style.clusterMaxZoom;
+  }
+
   return seed;
 }
 
@@ -579,7 +617,14 @@ function vectorStylesEqual(
     // a different expression, which must still register as a style change.
     valuesEqual(left.fillColorExpression, right.fillColorExpression) &&
     valuesEqual(left.lineColorExpression, right.lineColorExpression) &&
-    valuesEqual(left.circleColorExpression, right.circleColorExpression)
+    valuesEqual(left.circleColorExpression, right.circleColorExpression) &&
+    // Point renderer fields: a pointMode/heatmap/cluster change must register so
+    // it is pushed to the control (which rebuilds the layers structurally).
+    left.pointMode === right.pointMode &&
+    left.heatmapRadius === right.heatmapRadius &&
+    left.heatmapIntensity === right.heatmapIntensity &&
+    left.clusterRadius === right.clusterRadius &&
+    left.clusterMaxZoom === right.clusterMaxZoom
   );
 }
 

--- a/tests/vector-layer-sync.test.ts
+++ b/tests/vector-layer-sync.test.ts
@@ -463,6 +463,13 @@ describe("wireVectorStoreSync", () => {
       fillColorExpression: undefined,
       lineColorExpression: undefined,
       circleColorExpression: undefined,
+      // Point renderer fields default through from DEFAULT_LAYER_STYLE
+      // ("single" -> "circle"); they ride along on every style push.
+      pointMode: "circle",
+      heatmapRadius: 30,
+      heatmapIntensity: 1,
+      clusterRadius: 50,
+      clusterMaxZoom: 14,
     };
     assert.deepEqual(calls, [
       { method: "setLayerStyle", args: ["vector-1", expectedStyle] },
@@ -475,6 +482,23 @@ describe("wireVectorStoreSync", () => {
       (stored.metadata.vectorState as { style: unknown }).style,
       expectedStyle,
     );
+  });
+
+  it("pushes the point renderer (heatmap/cluster) through the control", () => {
+    const { control, calls } = fakeControl([vectorInfo({ geometryType: "point" })]);
+    syncVectorLayersToStore(control);
+    wireVectorStoreSync(control);
+
+    useAppStore.getState().setLayerStyle("vector-1", {
+      pointRenderer: "cluster",
+      clusterRadius: 40,
+    });
+
+    assert.equal(calls.length, 1);
+    const pushed = calls[0].args[1] as VectorLayerStyle;
+    // GeoLibre's "cluster" maps to the control's pointMode, with cluster params.
+    assert.equal(pushed.pointMode, "cluster");
+    assert.equal(pushed.clusterRadius, 40);
   });
 
   it("pushes a categorized color expression through the control", () => {


### PR DESCRIPTION
**Draft — blocked on [opengeos/maplibre-gl-vector#13](https://github.com/opengeos/maplibre-gl-vector/pull/13) being merged and released as v0.3.0, and on #261 (core heatmap/cluster) merging first.**

## Summary

Extends the heatmap/cluster point renderers (added for core GeoJSON layers in #261) to point layers loaded via **Add Data → Add Vector Layer**, which are drawn by the `maplibre-gl-vector` control rather than GeoLibre's core sync.

The control now supports the renderers (maplibre-gl-vector#13: a `pointMode` style with a structural rebuild). This PR wires GeoLibre to it.

## Changes
- `vector-layer-sync.ts`:
  - Map GeoLibre's `pointRenderer`/`heatmapRadius`/`heatmapIntensity`/`clusterRadius`/`clusterMaxZoom` onto the control's `pointMode`/… style (and back when seeding the panel).
  - Compare those fields in `vectorStylesEqual` so the change is pushed to the control.
  - After a structural rebuild the control's map-layer ids change, so refresh `nativeLayerIds`/`sourceIds` from the control.
  - Set `controlOwnsPaint: true` so the core sync stops re-applying `circlePaint` over the cluster bubble's stepped radius.
- `StylePanel.tsx`: offer the **Point renderer** for point-only, geojson-render-mode vector-control layers (tile-rendered layers stay `vector-tiles`).
- Bump `maplibre-gl-vector` to `^0.3.0`.

## Testing
- Built + 362 frontend tests pass against a local build of maplibre-gl-vector#13.
- **Playwright + real data** (1000 US city points via Add Vector Layer): **cluster** renders counted bubbles (source `cluster:true`), **heatmap** a cold→hot density surface, **single** circles — and the three modes round-trip (verified by inspecting `map.getStyle()`).

## Merge order
1. Merge + release maplibre-gl-vector#13 as **v0.3.0**.
2. Merge #261 (core heatmap/cluster).
3. Mark this ready, run `npm install` to refresh the lockfile, merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Point renderer controls (heatmap and clustering) now available for vector layers loaded via Add Vector Layer in GeoJSON render mode.

* **Documentation**
  * Updated styling guide and feature documentation to reflect expanded point renderer support for vector-loaded layers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->