### PR TITLE
chore(toolbar): hide deck.gl viz overlay from the Plugins menu

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -68,6 +68,7 @@ import {
   subscribeSearchPlacesPanel,
   subscribeViewStatePanel,
   toggleEarthEnginePanel,
+  DECK_VIZ_PLUGIN_ID,
   DIRECTIONS_PLUGIN_ID,
   EFFECTS_PLUGIN_ID,
   WEB_SERVICE_PLUGIN_IDS,
@@ -1423,8 +1424,14 @@ export function TopToolbar({
             return plugins.map((p) => {
               // Atmosphere Effects and Directions are toggled from the Controls
               // menu instead, so they are omitted here to avoid a duplicate
-              // toggle.
-              if (p.id === EFFECTS_PLUGIN_ID || p.id === DIRECTIONS_PLUGIN_ID) {
+              // toggle. The deck.gl viz overlay is an internal renderer driven
+              // by the Add Data → "Deck.gl Layer" dialog, not a user-facing
+              // toggle, so it is hidden here too.
+              if (
+                p.id === EFFECTS_PLUGIN_ID ||
+                p.id === DIRECTIONS_PLUGIN_ID ||
+                p.id === DECK_VIZ_PLUGIN_ID
+              ) {
                 return null;
               }
               if (!WEB_SERVICE_PLUGIN_ID_SET.has(p.id)) {


### PR DESCRIPTION
## Summary
- The `maplibre-deckgl-viz` plugin is an internal overlay that renders layers built through the Add Data "Deck.gl Layer" dialog, not a user-facing plugin toggle.
- It was appearing in the Plugins menu under the same "Deck.gl Layer" name as the unrelated Add Data action, and deactivating it from there silently stopped deck.gl layers from rendering.
- Filter it out of the Plugins menu alongside Atmosphere Effects and Directions, which are already hidden because they are toggled elsewhere.

## Test plan
- [ ] Open the Plugins menu and confirm "Deck.gl Layer" no longer appears there.
- [ ] Confirm Add Data still lists "Deck.gl Layer" and the builder dialog works.
- [ ] Build a deck.gl visualization and confirm it still renders (overlay remains active by default).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated plugin activation menu to hide the Deck.gl visualization plugin alongside other internal tools, preventing accidental user activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->