### PR TITLE
feat(python): expand Map API to cover more Add Data types (#246)

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -26,7 +26,9 @@ Or with conda from [conda-forge](https://anaconda.org/conda-forge/geolibre):
 conda install -c conda-forge geolibre
 ```
 
-Optional extras for `add_geojson()` from a GeoDataFrame:
+Optional extras for `add_geojson()` from a GeoDataFrame and for reading **local**
+vector files with `add_vector()` / `add_geoparquet()` / `add_flatgeobuf()` /
+`add_shp()` (remote URLs for those formats need no extras):
 
 ```bash
 pip install "geolibre[all]"   # adds GeoPandas and Shapely
@@ -98,8 +100,20 @@ Map(
 | --- | --- |
 | `Map(center, zoom, basemap=, height=, layout=, theme=)` | Create a map. |
 | `add_geojson(data, name=, **style)` | Add GeoJSON from a dict, file path, URL, JSON string, or GeoDataFrame. |
+| `add_vector(data, name=, render_mode=, data_format=, source_layer=, **style)` | Add a vector dataset from a URL (GeoParquet, FlatGeobuf, zipped Shapefile, GeoJSON, …) or a local file (read via GeoPandas and inlined). |
+| `add_geoparquet(data, name=, **style)` | Add a GeoParquet dataset (URL or local file). |
+| `add_flatgeobuf(data, name=, **style)` | Add a FlatGeobuf dataset (URL or local file). |
+| `add_shp(data, name=, **style)` | Add a Shapefile (zipped URL or local `.shp`). |
+| `add_vector_tiles(url, name=, source_layers=, source_layer=, **style)` | Add a vector tile layer from a TileJSON endpoint. |
+| `add_pmtiles(url, name=, tile_type=, source_layers=, **style)` | Add a PMTiles archive (vector or raster). |
 | `add_tile_layer(url, name=, tile_size=, attribution=)` | Add a raster XYZ tile layer. |
+| `add_wms(endpoint, layers, name=, styles=, image_format=, transparent=, tile_size=, **style)` | Add a WMS layer (GetMap, tiled raster). |
+| `add_wmts(url, name=, tile_size=, **style)` | Add a WMTS layer from a tile URL template. |
+| `add_wfs(endpoint, type_name, name=, version=, output_format=, srs_name=, max_features=, **style)` | Add a WFS layer (GetFeature GeoJSON, fetched and inlined). |
 | `add_cog(url, name=, bands=, colormap=, rescale=)` | Add a Cloud Optimized GeoTIFF. |
+| `add_raster(url, name=, bands=, colormap=, rescale=)` | Add a raster (COG/GeoTIFF); alias of `add_cog`. |
+| `add_3d_tiles(url, name=, altitude_offset=, request_headers=, **style)` | Add a 3D Tiles `tileset.json`. |
+| `add_video(urls, coordinates, name=, **style)` | Add a georeferenced video (four `[lng, lat]` corners). |
 | `add_basemap(basemap)` | Set the background basemap. |
 | `set_center(lng, lat, zoom=None)` | Center (and optionally zoom) the map. |
 | `set_center_zoom(lng, lat, zoom=None)` | Alias of `set_center` (leafmap compatibility). |

--- a/python/README.md
+++ b/python/README.md
@@ -66,8 +66,18 @@ m.to_project()["mapView"]["center"]
 | --- | --- |
 | `Map(center, zoom, basemap=, height=, layout=, theme=)` | Create a map. `layout` is `"embed"`, `"full"`, or `"maponly"`. |
 | `add_geojson(data, name=, **style)` | Add GeoJSON (dict, path, URL, JSON, or GeoDataFrame). |
+| `add_vector(data, name=, render_mode=, data_format=, source_layer=, **style)` | Add a vector dataset from a URL (GeoParquet, FlatGeobuf, zipped Shapefile, GeoJSON) or a local file (read via GeoPandas, inlined). |
+| `add_geoparquet` / `add_flatgeobuf` / `add_shp` `(data, name=, **style)` | Format-specific wrappers over `add_vector`. |
+| `add_vector_tiles(url, name=, source_layers=, source_layer=, **style)` | Add vector tiles from a TileJSON endpoint. |
+| `add_pmtiles(url, name=, tile_type=, source_layers=, **style)` | Add a PMTiles archive (vector or raster). |
 | `add_tile_layer(url, name=, tile_size=, attribution=)` | Add a raster XYZ tile layer. |
+| `add_wms(endpoint, layers, name=, styles=, image_format=, transparent=, tile_size=, **style)` | Add a WMS (GetMap) tiled raster layer. |
+| `add_wmts(url, name=, tile_size=, **style)` | Add a WMTS tile URL template. |
+| `add_wfs(endpoint, type_name, name=, version=, output_format=, srs_name=, max_features=, **style)` | Add a WFS layer (GeoJSON, fetched and inlined). |
 | `add_cog(url, name=, bands=, colormap=, rescale=)` | Add a Cloud Optimized GeoTIFF. |
+| `add_raster(url, name=, bands=, colormap=, rescale=)` | Add a raster (alias of `add_cog`). |
+| `add_3d_tiles(url, name=, altitude_offset=, request_headers=, **style)` | Add a 3D Tiles `tileset.json`. |
+| `add_video(urls, coordinates, name=, **style)` | Add a georeferenced video (four `[lng, lat]` corners). |
 | `add_basemap(basemap)` | Set the background basemap. |
 | `set_center(lng, lat, zoom=None)` | Center (and optionally zoom) the map. |
 | `set_center_zoom(lng, lat, zoom=None)` | Alias of `set_center` (leafmap compatibility). |
@@ -88,7 +98,10 @@ m.to_project()["mapView"]["center"]
   remote servers (Binder, remote JupyterLab), pass `Map(server_proxy=True)` to
   use that same remote path; `Map(server_proxy=False)` forces the direct path.
 - Optional extras: `pip install geolibre[all]` adds GeoPandas/Shapely support
-  for `add_geojson(geodataframe)`.
+  for `add_geojson(geodataframe)` and for reading **local** vector files
+  (`add_vector`/`add_geoparquet`/`add_flatgeobuf`/`add_shp`), which the kernel
+  reads and inlines as GeoJSON. Remote URLs for the same formats stream through
+  the in-browser vector control and need no extras.
 - `add_geojson` inlines file/URL data into the project (up to 50 MB), so a large
   dataset is held in memory and re-synced on every project update. For very large
   layers, prefer a tile or COG source (`add_tile_layer`/`add_cog`) the app fetches

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -447,7 +447,7 @@ class Map(anywidget.AnyWidget):
         version: str = "2.0.0",
         output_format: str = "application/json",
         srs_name: str = "EPSG:4326",
-        max_features: int | None = None,
+        max_features: int | None = 1000,
         **style: Any,
     ) -> str:
         """Add a WFS layer.
@@ -462,7 +462,9 @@ class Map(anywidget.AnyWidget):
             version: WFS protocol version (e.g. ``"2.0.0"`` or ``"1.1.0"``).
             output_format: Requested output format (must yield GeoJSON).
             srs_name: Spatial reference of the response.
-            max_features: Optional cap on the number of returned features.
+            max_features: Cap on the number of returned features (defaults to
+                1000, matching the UI, since the response is inlined). Pass
+                ``None`` to request every feature.
             **style: Style overrides.
 
         Returns:

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -24,6 +24,43 @@ _VALID_LAYOUTS = frozenset({"embed", "full", "maponly"})
 _VALID_THEMES = frozenset({"light", "dark"})
 
 
+def _read_local_vector(path: Any) -> dict[str, Any]:
+    """Read a local vector file into a GeoJSON FeatureCollection via GeoPandas.
+
+    The browser cannot read a file that lives on the kernel host, so a local
+    vector dataset is read here and inlined as GeoJSON (reprojected to EPSG:4326)
+    instead of being streamed by the in-browser vector control. GeoPandas is an
+    optional dependency, imported lazily so the rest of the API works without it.
+
+    Args:
+        path: Filesystem path to a vector file (Shapefile, GeoParquet,
+            FlatGeobuf, GeoPackage, ...).
+
+    Returns:
+        A GeoJSON FeatureCollection dict in EPSG:4326.
+
+    Raises:
+        ValueError: If the file does not exist.
+        ImportError: If GeoPandas is not installed.
+    """
+    file_path = pathlib.Path(str(path)).expanduser()
+    if not file_path.exists():
+        raise ValueError(f"Vector file not found: {path}")
+    try:
+        import geopandas
+    except ImportError as exc:
+        raise ImportError(
+            "Reading a local vector file requires GeoPandas. Install it with "
+            "`pip install geopandas`, or pass a URL to a hosted dataset instead."
+        ) from exc
+    gdf = geopandas.read_file(file_path)
+    if gdf.crs is not None:
+        gdf = gdf.to_crs(epsg=4326)
+    # Round-trip through GeoPandas' own GeoJSON writer so numpy/datetime property
+    # values become plain JSON the widget bus can serialize.
+    return json.loads(gdf.to_json())
+
+
 class Map(anywidget.AnyWidget):
     """An interactive GeoLibre map for Jupyter notebooks.
 
@@ -288,6 +325,350 @@ class Map(anywidget.AnyWidget):
             )
         )
 
+    def add_raster(
+        self,
+        url: str,
+        name: str = "Raster",
+        *,
+        bands: list[int] | None = None,
+        colormap: str | None = None,
+        rescale: list[list[float]] | None = None,
+        **style: Any,
+    ) -> str:
+        """Add a raster (COG / GeoTIFF) layer.
+
+        Alias of :meth:`add_cog` with a generic default name.
+
+        Args:
+            url: URL of the COG / GeoTIFF.
+            name: Layer display name.
+            bands: Optional 1-based band indices to render.
+            colormap: Optional colormap name (single-band rendering).
+            rescale: Optional ``[[min, max], ...]`` ranges per band.
+            **style: Style overrides.
+
+        Returns:
+            The id of the added layer.
+        """
+        return self.add_cog(
+            url, name, bands=bands, colormap=colormap, rescale=rescale, **style
+        )
+
+    def add_wms(
+        self,
+        endpoint: str,
+        layers: str,
+        name: str = "WMS Layer",
+        *,
+        styles: str = "",
+        image_format: str = "image/png",
+        transparent: bool = True,
+        tile_size: int = 256,
+        **style: Any,
+    ) -> str:
+        """Add a WMS layer rendered as tiled raster (a WMS GetMap request).
+
+        Args:
+            endpoint: WMS service endpoint (the GetMap base URL).
+            layers: Comma-separated WMS layer name(s).
+            name: Layer display name.
+            styles: Comma-separated WMS style name(s) (empty for the default).
+            image_format: WMS image format (e.g. ``"image/png"``).
+            transparent: Whether to request transparent tiles.
+            tile_size: Tile size in pixels.
+            **style: Style overrides.
+
+        Returns:
+            The id of the added layer.
+        """
+        return self._add_layer(
+            _project.wms_layer(
+                name,
+                endpoint,
+                layers,
+                styles=styles,
+                image_format=image_format,
+                transparent=transparent,
+                tile_size=tile_size,
+                **style,
+            )
+        )
+
+    def add_wmts(
+        self,
+        url: str,
+        name: str = "WMTS Layer",
+        *,
+        tile_size: int = 256,
+        **style: Any,
+    ) -> str:
+        """Add a WMTS layer from a tile URL template.
+
+        Args:
+            url: A WMTS tile URL template (``{z}/{y}/{x}``).
+            name: Layer display name.
+            tile_size: Tile size in pixels.
+            **style: Style overrides.
+
+        Returns:
+            The id of the added layer.
+        """
+        return self._add_layer(
+            _project.wmts_layer(name, url, tile_size=tile_size, **style)
+        )
+
+    def add_wfs(
+        self,
+        endpoint: str,
+        type_name: str,
+        name: str = "WFS Layer",
+        *,
+        version: str = "2.0.0",
+        output_format: str = "application/json",
+        srs_name: str = "EPSG:4326",
+        max_features: int | None = None,
+        **style: Any,
+    ) -> str:
+        """Add a WFS layer.
+
+        The WFS GetFeature response (GeoJSON) is fetched and inlined into the
+        project, so the endpoint must support a GeoJSON ``output_format``.
+
+        Args:
+            endpoint: WFS service endpoint.
+            type_name: WFS feature type name (e.g. ``"topp:states"``).
+            name: Layer display name.
+            version: WFS protocol version (e.g. ``"2.0.0"`` or ``"1.1.0"``).
+            output_format: Requested output format (must yield GeoJSON).
+            srs_name: Spatial reference of the response.
+            max_features: Optional cap on the number of returned features.
+            **style: Style overrides.
+
+        Returns:
+            The id of the added layer.
+        """
+        url = _project.wfs_getfeature_url(
+            endpoint,
+            type_name,
+            version=version,
+            output_format=output_format,
+            srs_name=srs_name,
+            max_features=max_features,
+        )
+        fc = _project.load_featurecollection(url)
+        layer = _project.geojson_layer(name, fc, source_url=url, **style)
+        layer["metadata"].update(
+            {"service": "wfs", "sourceKind": "wfs-getfeature", "typeName": type_name}
+        )
+        return self._add_layer(layer)
+
+    def add_vector(
+        self,
+        data: Any,
+        name: str = "Vector",
+        *,
+        render_mode: str = "geojson",
+        data_format: str | None = None,
+        source_layer: str | None = None,
+        **style: Any,
+    ) -> str:
+        """Add a vector layer from a URL, a local file, or a geo object.
+
+        A remote URL is handed to the in-browser vector control (so any
+        GDAL-readable format streams without being inlined). A local file path is
+        read with GeoPandas and inlined as GeoJSON, since the browser cannot read
+        a kernel-side file. An object exposing ``__geo_interface__`` (e.g. a
+        GeoDataFrame) is inlined directly.
+
+        Args:
+            data: A dataset URL, a local file path, or a ``__geo_interface__``
+                object.
+            name: Layer display name.
+            render_mode: ``"geojson"`` or ``"tiles"`` (remote URLs only).
+            data_format: Optional GDAL format hint for remote URLs
+                (e.g. ``"parquet"``, ``"flatgeobuf"``).
+            source_layer: Optional source/container layer for multi-layer files.
+            **style: Style overrides.
+
+        Returns:
+            The id of the added layer.
+
+        Raises:
+            ImportError: If a local file is given but GeoPandas is not installed.
+            ValueError: If a local file path does not exist.
+        """
+        if isinstance(data, str) and data.startswith(("http://", "https://")):
+            return self._add_layer(
+                _project.vector_layer(
+                    name,
+                    data,
+                    render_mode=render_mode,
+                    data_format=data_format,
+                    source_layer=source_layer,
+                    **style,
+                )
+            )
+        if hasattr(data, "__geo_interface__"):
+            return self.add_geojson(data, name=name, **style)
+        fc = _read_local_vector(data)
+        return self._add_layer(_project.geojson_layer(name, fc, **style))
+
+    def add_geoparquet(self, data: Any, name: str = "GeoParquet", **style: Any) -> str:
+        """Add a GeoParquet layer from a URL or local file.
+
+        Args:
+            data: A GeoParquet URL or local file path.
+            name: Layer display name.
+            **style: Style overrides.
+
+        Returns:
+            The id of the added layer.
+        """
+        return self.add_vector(data, name=name, data_format="parquet", **style)
+
+    def add_flatgeobuf(self, data: Any, name: str = "FlatGeobuf", **style: Any) -> str:
+        """Add a FlatGeobuf layer from a URL or local file.
+
+        Args:
+            data: A FlatGeobuf URL or local file path.
+            name: Layer display name.
+            **style: Style overrides.
+
+        Returns:
+            The id of the added layer.
+        """
+        return self.add_vector(data, name=name, data_format="flatgeobuf", **style)
+
+    def add_shp(self, data: Any, name: str = "Shapefile", **style: Any) -> str:
+        """Add a Shapefile layer from a URL (zipped) or local file.
+
+        Args:
+            data: A zipped Shapefile URL or a local ``.shp`` path.
+            name: Layer display name.
+            **style: Style overrides.
+
+        Returns:
+            The id of the added layer.
+        """
+        return self.add_vector(data, name=name, data_format="shp", **style)
+
+    def add_vector_tiles(
+        self,
+        url: str,
+        name: str = "Vector Tiles",
+        *,
+        source_layers: list[str] | None = None,
+        source_layer: str | None = None,
+        **style: Any,
+    ) -> str:
+        """Add a vector tile layer from a TileJSON endpoint.
+
+        Args:
+            url: TileJSON endpoint for the vector tileset.
+            name: Layer display name.
+            source_layers: Source-layer names to render (multi-layer tilesets).
+            source_layer: A single source-layer name (single-layer convenience).
+            **style: Style overrides.
+
+        Returns:
+            The id of the added layer.
+        """
+        return self._add_layer(
+            _project.vector_tiles_layer(
+                name,
+                url,
+                source_layers=source_layers,
+                source_layer=source_layer,
+                **style,
+            )
+        )
+
+    def add_pmtiles(
+        self,
+        url: str,
+        name: str = "PMTiles",
+        *,
+        tile_type: str = "vector",
+        source_layers: list[str] | None = None,
+        **style: Any,
+    ) -> str:
+        """Add a PMTiles layer from a ``.pmtiles`` URL.
+
+        Args:
+            url: URL of the ``.pmtiles`` archive.
+            name: Layer display name.
+            tile_type: ``"vector"`` or ``"raster"``.
+            source_layers: Vector source-layer names to render (vector only).
+            **style: Style overrides.
+
+        Returns:
+            The id of the added layer.
+        """
+        return self._add_layer(
+            _project.pmtiles_layer(
+                name,
+                url,
+                tile_type=tile_type,
+                source_layers=source_layers,
+                **style,
+            )
+        )
+
+    def add_3d_tiles(
+        self,
+        url: str,
+        name: str = "3D Tiles",
+        *,
+        altitude_offset: float = 0,
+        request_headers: dict[str, str] | None = None,
+        **style: Any,
+    ) -> str:
+        """Add a 3D Tiles layer from a ``tileset.json`` URL.
+
+        Args:
+            url: URL of the 3D Tiles ``tileset.json``.
+            name: Layer display name.
+            altitude_offset: Vertical offset applied to the tileset, in meters.
+            request_headers: Optional request headers (persisted in the project).
+            **style: Style overrides.
+
+        Returns:
+            The id of the added layer.
+        """
+        return self._add_layer(
+            _project.three_d_tiles_layer(
+                name,
+                url,
+                altitude_offset=altitude_offset,
+                request_headers=request_headers,
+                **style,
+            )
+        )
+
+    def add_video(
+        self,
+        urls: str | list[str],
+        coordinates: list[list[float]],
+        name: str = "Video",
+        **style: Any,
+    ) -> str:
+        """Add a georeferenced video layer.
+
+        Args:
+            urls: One video URL or a list of format fallbacks (e.g. MP4, WebM).
+            coordinates: Four ``[lng, lat]`` corners in top-left, top-right,
+                bottom-right, bottom-left order.
+            name: Layer display name.
+            **style: Style overrides.
+
+        Returns:
+            The id of the added layer.
+        """
+        url_list = [urls] if isinstance(urls, str) else list(urls)
+        return self._add_layer(
+            _project.video_layer(name, url_list, coordinates, **style)
+        )
+
     def remove_layer(self, layer_id: str) -> None:
         """Remove a layer by id.
 
@@ -375,8 +756,7 @@ class Map(anywidget.AnyWidget):
                     # Honour the documented ValueError contract instead of
                     # leaking a raw FileNotFoundError/JSONDecodeError.
                     raise ValueError(
-                        f"Project source is not valid JSON nor an existing "
-                        f"file: {text}"
+                        f"Project source is not valid JSON nor an existing file: {text}"
                     ) from exc
                 except json.JSONDecodeError as exc:
                     raise ValueError(

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -549,6 +549,18 @@ class Map(anywidget.AnyWidget):
                 )
             )
         if hasattr(data, "__geo_interface__"):
+            # The object is inlined as GeoJSON; none of the vector-control
+            # options apply, so flag them rather than dropping them silently.
+            if (
+                render_mode != "geojson"
+                or data_format is not None
+                or source_layer is not None
+            ):
+                warnings.warn(
+                    "render_mode, data_format, and source_layer are ignored for "
+                    "__geo_interface__ objects; they only apply to remote URLs.",
+                    stacklevel=2,
+                )
             return self.add_geojson(data, name=name, **style)
         # A local file is read and inlined as GeoJSON; render_mode and
         # source_layer only apply to the in-browser vector control (remote URLs),

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -6,6 +6,7 @@ import copy
 import json
 import os
 import pathlib
+import warnings
 from typing import Any, Callable
 
 import anywidget
@@ -24,7 +25,7 @@ _VALID_LAYOUTS = frozenset({"embed", "full", "maponly"})
 _VALID_THEMES = frozenset({"light", "dark"})
 
 
-def _read_local_vector(path: Any) -> dict[str, Any]:
+def _read_local_vector(path: Any, data_format: str | None = None) -> dict[str, Any]:
     """Read a local vector file into a GeoJSON FeatureCollection via GeoPandas.
 
     The browser cannot read a file that lives on the kernel host, so a local
@@ -35,6 +36,9 @@ def _read_local_vector(path: Any) -> dict[str, Any]:
     Args:
         path: Filesystem path to a vector file (Shapefile, GeoParquet,
             FlatGeobuf, GeoPackage, ...).
+        data_format: Optional format hint (e.g. ``"parquet"``) that overrides
+            filename-suffix detection, so a GeoParquet file saved under a
+            non-standard name still uses the dedicated Parquet reader.
 
     Returns:
         A GeoJSON FeatureCollection dict in EPSG:4326.
@@ -55,8 +59,12 @@ def _read_local_vector(path: Any) -> dict[str, Any]:
             "`pip install geopandas`, or pass a URL to a hosted dataset instead."
         ) from exc
     # GeoPandas' GDAL-backed read_file may lack the Parquet driver depending on
-    # the GDAL build, so dispatch (Geo)Parquet to the dedicated reader.
-    if file_path.suffix.lower() in (".parquet", ".geoparquet", ".pq"):
+    # the GDAL build, so dispatch (Geo)Parquet to the dedicated reader. Honour an
+    # explicit format hint so a Parquet file under a non-standard name still works.
+    is_parquet = (data_format or "").lower() in ("parquet", "geoparquet") or (
+        file_path.suffix.lower() in (".parquet", ".geoparquet", ".pq")
+    )
+    if is_parquet:
         gdf = geopandas.read_parquet(file_path)
     else:
         gdf = geopandas.read_file(file_path)
@@ -540,7 +548,17 @@ class Map(anywidget.AnyWidget):
             )
         if hasattr(data, "__geo_interface__"):
             return self.add_geojson(data, name=name, **style)
-        fc = _read_local_vector(data)
+        # A local file is read and inlined as GeoJSON; render_mode and
+        # source_layer only apply to the in-browser vector control (remote URLs),
+        # so flag them as no-ops here rather than dropping them silently.
+        if render_mode != "geojson" or source_layer is not None:
+            warnings.warn(
+                "render_mode and source_layer are ignored for local files; they "
+                "only apply to remote URLs handled by the in-browser vector "
+                "control.",
+                stacklevel=2,
+            )
+        fc = _read_local_vector(data, data_format=data_format)
         return self._add_layer(_project.geojson_layer(name, fc, **style))
 
     def add_geoparquet(self, data: Any, name: str = "GeoParquet", **style: Any) -> str:

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -40,7 +40,8 @@ def _read_local_vector(path: Any) -> dict[str, Any]:
         A GeoJSON FeatureCollection dict in EPSG:4326.
 
     Raises:
-        ValueError: If the file does not exist.
+        ValueError: If the file does not exist or, after conversion to GeoJSON,
+            exceeds the 50 MB size limit.
         ImportError: If GeoPandas is not installed.
     """
     file_path = pathlib.Path(str(path)).expanduser()
@@ -53,12 +54,24 @@ def _read_local_vector(path: Any) -> dict[str, Any]:
             "Reading a local vector file requires GeoPandas. Install it with "
             "`pip install geopandas`, or pass a URL to a hosted dataset instead."
         ) from exc
-    gdf = geopandas.read_file(file_path)
+    # GeoPandas' GDAL-backed read_file may lack the Parquet driver depending on
+    # the GDAL build, so dispatch (Geo)Parquet to the dedicated reader.
+    if file_path.suffix.lower() in (".parquet", ".geoparquet", ".pq"):
+        gdf = geopandas.read_parquet(file_path)
+    else:
+        gdf = geopandas.read_file(file_path)
     if gdf.crs is not None:
         gdf = gdf.to_crs(epsg=4326)
     # Round-trip through GeoPandas' own GeoJSON writer so numpy/datetime property
     # values become plain JSON the widget bus can serialize.
-    return json.loads(gdf.to_json())
+    geojson = gdf.to_json()
+    # Cap the inlined payload like load_featurecollection does for URL/file
+    # GeoJSON; a format like Shapefile can expand sharply once converted.
+    if len(geojson.encode("utf-8")) > _project._MAX_GEOJSON_BYTES:
+        raise ValueError(
+            f"Vector file exceeds the 50 MB GeoJSON size limit after conversion: {path}"
+        )
+    return json.loads(geojson)
 
 
 class Map(anywidget.AnyWidget):
@@ -457,8 +470,25 @@ class Map(anywidget.AnyWidget):
         )
         fc = _project.load_featurecollection(url)
         layer = _project.geojson_layer(name, fc, source_url=url, **style)
+        # Mirror the protocol fields the UI persists on the source so the Edit
+        # Layer panel can pre-populate the WFS form and isWfsLayer() recognizes
+        # the layer when round-tripped from a Python-produced project.
+        layer["source"].update(
+            {
+                "service": "wfs",
+                "typeName": type_name,
+                "version": version,
+                "outputFormat": output_format,
+                **({"srsName": srs_name} if srs_name else {}),
+            }
+        )
         layer["metadata"].update(
-            {"service": "wfs", "sourceKind": "wfs-getfeature", "typeName": type_name}
+            {
+                "service": "wfs",
+                "sourceKind": "wfs-getfeature",
+                "typeName": type_name,
+                "featureCount": len(fc.get("features", [])),
+            }
         )
         return self._add_layer(layer)
 

--- a/python/src/geolibre/project.py
+++ b/python/src/geolibre/project.py
@@ -16,12 +16,17 @@ import uuid
 from pathlib import Path
 from typing import Any
 from urllib.error import URLError
-from urllib.parse import urlsplit
+from urllib.parse import quote, urlsplit
 from urllib.request import HTTPRedirectHandler, build_opener
 
 from .basemaps import DEFAULT_BASEMAP
 
 PROJECT_VERSION = "0.1.0"
+
+# Characters JavaScript's encodeURIComponent leaves unescaped on top of the
+# always-unreserved set (alphanumerics and ``-_.~``), so _append_query produces
+# byte-identical query strings to the app's appendQuery helper.
+_ENCODE_URI_SAFE = "!*'()"
 
 # Cap GeoJSON inputs (URL fetches and local files alike) so a huge source cannot
 # silently exhaust kernel memory when inlined into the project.
@@ -301,6 +306,413 @@ def cog_layer(
         "sourceKind": "maplibre-gl-raster",
     }
     layer["sourcePath"] = url
+    return layer
+
+
+def _append_query(endpoint: str, params: list[tuple[str, str]]) -> str:
+    """Append query params to a URL, mirroring ``appendQuery`` in the app.
+
+    Matches ``AddDataDialog.tsx``/``layer-refresh.ts``: an existing ``?`` or
+    ``&`` is respected, values are URL-encoded the way ``encodeURIComponent``
+    does (so ``!*'()`` and the unreserved ``-_.~`` stay literal), and the
+    ``{bbox-epsg-3857}`` placeholder is preserved verbatim so the raster source
+    can substitute the tile bounding box at request time.
+
+    Args:
+        endpoint: Base service URL (may already carry a query string).
+        params: Ordered ``(key, value)`` pairs to append.
+
+    Returns:
+        The endpoint with the encoded query string appended.
+    """
+    if "?" in endpoint:
+        separator = "" if endpoint.endswith(("?", "&")) else "&"
+    else:
+        separator = "?"
+    query = "&".join(
+        f"{quote(key, safe=_ENCODE_URI_SAFE)}="
+        + (
+            value
+            if value == "{bbox-epsg-3857}"
+            else quote(value, safe=_ENCODE_URI_SAFE)
+        )
+        for key, value in params
+    )
+    return f"{endpoint}{separator}{query}"
+
+
+def wms_layer(
+    name: str,
+    endpoint: str,
+    layers: str,
+    *,
+    styles: str = "",
+    image_format: str = "image/png",
+    transparent: bool = True,
+    tile_size: int = 256,
+    **style: Any,
+) -> dict[str, Any]:
+    """Build a WMS layer rendered as tiled raster (a WMS GetMap request).
+
+    The GetMap tile template is built exactly as ``createWmsTileUrl`` in the Add
+    Data dialog, so the core raster sync renders it identically to a layer added
+    through the UI. The ``{bbox-epsg-3857}`` placeholder is substituted per tile.
+
+    Args:
+        name: Layer display name.
+        endpoint: WMS service endpoint (the GetMap base URL).
+        layers: Comma-separated WMS layer name(s).
+        styles: Comma-separated WMS style name(s) (empty for the default).
+        image_format: WMS image format (e.g. ``"image/png"``).
+        transparent: Whether to request transparent tiles.
+        tile_size: Tile size in pixels.
+        **style: Style overrides merged into the default layer style.
+
+    Returns:
+        A layer dict for the project's ``layers`` array.
+    """
+    tile_url = _append_query(
+        endpoint,
+        [
+            ("SERVICE", "WMS"),
+            ("REQUEST", "GetMap"),
+            ("VERSION", "1.1.1"),
+            ("LAYERS", layers),
+            ("STYLES", styles),
+            ("FORMAT", image_format),
+            ("TRANSPARENT", "TRUE" if transparent else "FALSE"),
+            ("SRS", "EPSG:3857"),
+            ("BBOX", "{bbox-epsg-3857}"),
+            ("WIDTH", str(tile_size)),
+            ("HEIGHT", str(tile_size)),
+        ],
+    )
+    layer = _layer_base(name, "wms", **style)
+    layer["source"] = {
+        "type": "raster",
+        "tiles": [tile_url],
+        "tileSize": tile_size,
+        "url": endpoint,
+        "layers": layers,
+        "styles": styles,
+        "format": image_format,
+        "transparent": transparent,
+    }
+    layer["metadata"] = {"service": "wms"}
+    return layer
+
+
+def wmts_layer(
+    name: str,
+    url: str,
+    *,
+    tile_size: int = 256,
+    **style: Any,
+) -> dict[str, Any]:
+    """Build a WMTS layer from a tile URL template.
+
+    Args:
+        name: Layer display name.
+        url: A WMTS tile URL template (``{z}/{y}/{x}``).
+        tile_size: Tile size in pixels.
+        **style: Style overrides merged into the default layer style.
+
+    Returns:
+        A layer dict for the project's ``layers`` array.
+    """
+    layer = _layer_base(name, "wmts", **style)
+    layer["source"] = {
+        "type": "raster",
+        "tiles": [url],
+        "tileSize": tile_size,
+        "url": url,
+    }
+    layer["metadata"] = {"service": "wmts"}
+    return layer
+
+
+def wfs_getfeature_url(
+    endpoint: str,
+    type_name: str,
+    *,
+    version: str = "2.0.0",
+    output_format: str = "application/json",
+    srs_name: str = "EPSG:4326",
+    max_features: int | None = None,
+) -> str:
+    """Build a WFS GetFeature URL, mirroring ``createWfsGetFeatureUrl``.
+
+    WFS 2.x uses ``typeNames``/``count`` while WFS 1.x uses
+    ``typeName``/``maxFeatures``. The endpoint is expected to return GeoJSON when
+    ``output_format`` is ``application/json`` so the result can be inlined as a
+    GeoJSON layer.
+
+    Args:
+        endpoint: WFS service endpoint.
+        type_name: WFS feature type name (e.g. ``"topp:states"``).
+        version: WFS protocol version (e.g. ``"2.0.0"`` or ``"1.1.0"``).
+        output_format: Requested output format.
+        srs_name: Spatial reference of the response.
+        max_features: Optional cap on the number of returned features.
+
+    Returns:
+        The fully-formed GetFeature request URL.
+    """
+    is_wfs2 = version.startswith("2")
+    params: list[tuple[str, str]] = [
+        ("service", "WFS"),
+        ("request", "GetFeature"),
+        ("version", version),
+        ("typeNames" if is_wfs2 else "typeName", type_name),
+        ("outputFormat", output_format),
+    ]
+    if srs_name:
+        params.append(("srsName", srs_name))
+    if max_features is not None:
+        params.append(("count" if is_wfs2 else "maxFeatures", str(max_features)))
+    return _append_query(endpoint, params)
+
+
+def vector_layer(
+    name: str,
+    url: str,
+    *,
+    render_mode: str = "geojson",
+    data_format: str | None = None,
+    source_layer: str | None = None,
+    picker: bool | None = None,
+    ingest_mode: str | None = None,
+    **style: Any,
+) -> dict[str, Any]:
+    """Build a vector layer backed by the maplibre-gl-vector control.
+
+    Covers any GDAL-readable vector served from a URL (GeoParquet, FlatGeobuf,
+    zipped Shapefile, GeoJSON, ...). The shape matches what ``restoreVectorLayers``
+    replays from a saved project: it reads ``source.url`` and the persisted
+    ``metadata.vectorState`` and re-runs ``VectorControl.addData`` on load, so the
+    in-browser DuckDB-backed control fetches and renders the data.
+
+    Args:
+        name: Layer display name.
+        url: URL of the vector dataset.
+        render_mode: ``"geojson"`` (load into a GeoJSON source) or ``"tiles"``
+            (stream as vector tiles).
+        data_format: Optional GDAL format hint (e.g. ``"parquet"``,
+            ``"flatgeobuf"``); the control auto-detects when omitted.
+        source_layer: Optional source/container layer name for multi-layer files.
+        picker: Optional toggle for the control's feature-inspection popup.
+        ingest_mode: Optional ingest strategy, ``"table"`` or ``"stream"``.
+        **style: Style overrides merged into the default layer style.
+
+    Returns:
+        A layer dict for the project's ``layers`` array.
+
+    Raises:
+        ValueError: If ``render_mode`` or ``ingest_mode`` is not a valid value.
+    """
+    if render_mode not in ("geojson", "tiles"):
+        raise ValueError("render_mode must be 'geojson' or 'tiles'")
+    if ingest_mode is not None and ingest_mode not in ("table", "stream"):
+        raise ValueError("ingest_mode must be 'table' or 'stream'")
+    is_tiles = render_mode == "tiles"
+    layer = _layer_base(name, "vector-tiles" if is_tiles else "geojson", **style)
+    layer["source"] = {"type": "vector" if is_tiles else "geojson", "url": url}
+    vector_state: dict[str, Any] = {"renderMode": render_mode}
+    if data_format:
+        vector_state["format"] = data_format
+    if source_layer:
+        vector_state["sourceLayer"] = source_layer
+    if picker is not None:
+        vector_state["picker"] = picker
+    if ingest_mode is not None:
+        vector_state["ingestMode"] = ingest_mode
+    layer["metadata"] = {
+        "sourceKind": "maplibre-gl-vector",
+        "externalNativeLayer": True,
+        # The control owns its layers' paint; the core sync must not re-apply it.
+        "controlOwnsPaint": True,
+        "identifiable": False,
+        # The control re-derives these on load; the post-load sync overwrites
+        # them with the real ids it creates, so empty placeholders are fine.
+        "nativeLayerIds": [],
+        "sourceIds": [f"{layer['id']}-source"],
+        "vectorSource": "url",
+        "vectorState": vector_state,
+    }
+    layer["sourcePath"] = url
+    return layer
+
+
+def vector_tiles_layer(
+    name: str,
+    url: str,
+    *,
+    source_layers: list[str] | None = None,
+    source_layer: str | None = None,
+    **style: Any,
+) -> dict[str, Any]:
+    """Build a vector tile layer from a TileJSON endpoint.
+
+    Rendered directly by the core layer sync (no control), which reads
+    ``source.url`` as a TileJSON URL and styles each named source layer.
+
+    Args:
+        name: Layer display name.
+        url: TileJSON endpoint for the vector tileset.
+        source_layers: Source-layer names to render (for multi-layer tilesets).
+        source_layer: A single source-layer name (convenience for the common
+            single-layer case).
+        **style: Style overrides merged into the default layer style.
+
+    Returns:
+        A layer dict for the project's ``layers`` array.
+    """
+    layer = _layer_base(name, "vector-tiles", **style)
+    source: dict[str, Any] = {"type": "vector", "url": url}
+    if source_layers:
+        source["sourceLayers"] = list(source_layers)
+    elif source_layer:
+        source["sourceLayer"] = source_layer
+    layer["source"] = source
+    return layer
+
+
+def pmtiles_layer(
+    name: str,
+    url: str,
+    *,
+    tile_type: str = "vector",
+    source_layers: list[str] | None = None,
+    **style: Any,
+) -> dict[str, Any]:
+    """Build a PMTiles layer from a ``.pmtiles`` URL.
+
+    The core sync registers the ``pmtiles://`` protocol and prepends it to the
+    URL automatically, so a plain ``https://`` URL is accepted here.
+
+    Args:
+        name: Layer display name.
+        url: URL of the ``.pmtiles`` archive.
+        tile_type: ``"vector"`` or ``"raster"``.
+        source_layers: Vector source-layer names to render (vector tiles only).
+        **style: Style overrides merged into the default layer style.
+
+    Returns:
+        A layer dict for the project's ``layers`` array.
+
+    Raises:
+        ValueError: If ``tile_type`` is not ``"vector"`` or ``"raster"``.
+    """
+    if tile_type not in ("vector", "raster"):
+        raise ValueError("tile_type must be 'vector' or 'raster'")
+    source_layers = list(source_layers or [])
+    layer = _layer_base(name, "pmtiles", **style)
+    source_id = layer["id"]
+    layer["source"] = {
+        "type": "raster" if tile_type == "raster" else "vector",
+        "url": url,
+        "sourceId": source_id,
+        "sourceLayers": source_layers,
+        "tileType": tile_type,
+    }
+    layer["metadata"] = {
+        "sourceKind": "pmtiles-url",
+        "externalNativeLayer": True,
+        "sourceId": source_id,
+        "tileType": tile_type,
+        "sourceLayers": source_layers,
+        "nativeLayerIds": [],
+    }
+    layer["sourcePath"] = url
+    return layer
+
+
+def three_d_tiles_layer(
+    name: str,
+    url: str,
+    *,
+    altitude_offset: float = 0,
+    request_headers: dict[str, str] | None = None,
+    **style: Any,
+) -> dict[str, Any]:
+    """Build a 3D Tiles layer from a ``tileset.json`` URL.
+
+    The shape matches what ``restoreThreeDTilesLayers`` replays from a saved
+    project, so the deck.gl 3D-tiles overlay is rebuilt on load.
+
+    Args:
+        name: Layer display name.
+        url: URL of the 3D Tiles ``tileset.json``.
+        altitude_offset: Vertical offset applied to the tileset, in meters.
+        request_headers: Optional request headers (e.g. an auth token). Stored in
+            the project file, so avoid persisting secrets you do not want saved.
+        **style: Style overrides merged into the default layer style.
+
+    Returns:
+        A layer dict for the project's ``layers`` array.
+    """
+    layer = _layer_base(name, "3d-tiles", **style)
+    source_id = layer["id"]
+    source: dict[str, Any] = {
+        "type": "3d-tiles",
+        "url": url,
+        "sourceId": source_id,
+        "altitudeOffset": altitude_offset,
+    }
+    if request_headers:
+        source["requestHeaders"] = request_headers
+    layer["source"] = source
+    layer["metadata"] = {
+        "sourceKind": "3d-tiles-url",
+        "externalNativeLayer": True,
+        "customLayerType": "3d-tiles",
+        "identifiable": False,
+        "sourceId": source_id,
+        "nativeLayerIds": [source_id],
+        "altitudeOffset": altitude_offset,
+        "panelCollapsed": True,
+        "status": "loading",
+    }
+    layer["sourcePath"] = url
+    return layer
+
+
+def video_layer(
+    name: str,
+    urls: list[str],
+    coordinates: list[list[float]],
+    **style: Any,
+) -> dict[str, Any]:
+    """Build a georeferenced video layer.
+
+    Args:
+        name: Layer display name.
+        urls: One or more video URLs (format fallbacks, e.g. MP4 then WebM).
+        coordinates: Four ``[lng, lat]`` corners in top-left, top-right,
+            bottom-right, bottom-left order.
+        **style: Style overrides merged into the default layer style.
+
+    Returns:
+        A layer dict for the project's ``layers`` array.
+
+    Raises:
+        ValueError: If ``urls`` is empty or ``coordinates`` is not four
+            ``[lng, lat]`` pairs.
+    """
+    clean_urls = [u for u in urls if isinstance(u, str) and u]
+    if not clean_urls:
+        raise ValueError("video_layer requires at least one non-empty URL")
+    if len(coordinates) != 4 or any(len(corner) != 2 for corner in coordinates):
+        raise ValueError(
+            "coordinates must be four [lng, lat] corners (top-left, top-right, "
+            "bottom-right, bottom-left)"
+        )
+    layer = _layer_base(name, "video", **style)
+    layer["source"] = {
+        "urls": clean_urls,
+        "coordinates": [[float(c[0]), float(c[1])] for c in coordinates],
+    }
+    layer["sourcePath"] = clean_urls[0]
     return layer
 
 

--- a/python/src/geolibre/project.py
+++ b/python/src/geolibre/project.py
@@ -13,6 +13,7 @@ import ipaddress
 import json
 import socket
 import uuid
+import warnings
 from pathlib import Path
 from typing import Any
 from urllib.error import URLError
@@ -325,8 +326,13 @@ def _append_query(endpoint: str, params: list[tuple[str, str]]) -> str:
     Returns:
         The endpoint with the encoded query string appended.
     """
-    if "?" in endpoint:
-        separator = "" if endpoint.endswith(("?", "&")) else "&"
+    # Split off any fragment first: a query string must precede the "#", so
+    # appending after it would push the params past the fragment where the
+    # server never sees them. (Service endpoints rarely carry one, but this is
+    # cheap to handle correctly.)
+    base, sep, fragment = endpoint.partition("#")
+    if "?" in base:
+        separator = "" if base.endswith(("?", "&")) else "&"
     else:
         separator = "?"
     query = "&".join(
@@ -338,7 +344,7 @@ def _append_query(endpoint: str, params: list[tuple[str, str]]) -> str:
         )
         for key, value in params
     )
-    return f"{endpoint}{separator}{query}"
+    return f"{base}{separator}{query}{sep}{fragment}"
 
 
 def wms_layer(
@@ -577,6 +583,12 @@ def vector_tiles_layer(
     layer = _layer_base(name, "vector-tiles", **style)
     source: dict[str, Any] = {"type": "vector", "url": url}
     if source_layers:
+        if source_layer is not None:
+            warnings.warn(
+                "source_layer is ignored when source_layers is provided; pass "
+                "one or the other.",
+                stacklevel=2,
+            )
         source["sourceLayers"] = list(source_layers)
     elif source_layer:
         source["sourceLayer"] = source_layer

--- a/python/src/geolibre/project.py
+++ b/python/src/geolibre/project.py
@@ -532,8 +532,13 @@ def vector_layer(
         # The control owns its layers' paint; the core sync must not re-apply it.
         "controlOwnsPaint": True,
         "identifiable": False,
-        # The control re-derives these on load; the post-load sync overwrites
-        # them with the real ids it creates, so empty placeholders are fine.
+        # Empty is safe here (unlike pmtiles_layer): restoreVectorLayers detects
+        # the layer via isVectorControlStoreLayer (sourceKind + externalNativeLayer,
+        # not list length) and loads it through the control's async addData;
+        # syncVectorLayersToStore then fills in the real nativeLayerIds.
+        # Caveat: render_mode="tiles" yields a type:"vector-tiles" layer that,
+        # before the control loads, briefly falls through to syncVectorTileLayer
+        # until that store sync replaces these ids.
         "nativeLayerIds": [],
         "sourceIds": [f"{layer['id']}-source"],
         "vectorSource": "url",
@@ -615,13 +620,20 @@ def pmtiles_layer(
         "sourceLayers": source_layers,
         "tileType": tile_type,
     }
+    # nativeLayerIds must be non-empty: isExternalNativeLayer() in layer-sync.ts
+    # gates on its length, and a "pmtiles" layer has no fallback dispatch in
+    # syncLayer, so an empty list means the source/layers are never added.
+    # ensurePMTilesExternalLayer tolerates these placeholders — for raster it
+    # matches the `${sourceId}-raster` fallback it would otherwise compute; for
+    # vector getPMTilesNativeLayerId derives the real per-source-layer ids.
+    native_layer_ids = [f"{source_id}-raster"] if tile_type == "raster" else [source_id]
     layer["metadata"] = {
         "sourceKind": "pmtiles-url",
         "externalNativeLayer": True,
         "sourceId": source_id,
         "tileType": tile_type,
         "sourceLayers": source_layers,
-        "nativeLayerIds": [],
+        "nativeLayerIds": native_layer_ids,
     }
     layer["sourcePath"] = url
     return layer
@@ -700,9 +712,16 @@ def video_layer(
             browser's ``media-src`` CSP blocks ``http://``), or ``coordinates``
             is not four ``[lng, lat]`` pairs.
     """
-    clean_urls = [u for u in urls if isinstance(u, str) and u]
-    if not clean_urls:
+    if not urls:
         raise ValueError("video_layer requires at least one non-empty URL")
+    # Validate strictly rather than silently dropping a None/non-string entry,
+    # which would mask a malformed call and build a layer with fewer URLs.
+    invalid = [u for u in urls if not (isinstance(u, str) and u)]
+    if invalid:
+        raise ValueError(
+            f"video_layer: every URL must be a non-empty string; got {invalid!r}"
+        )
+    clean_urls = list(urls)
     if any(not u.lower().startswith("https://") for u in clean_urls):
         raise ValueError(
             "Video URLs must start with https:// (the browser CSP blocks http://)"

--- a/python/src/geolibre/project.py
+++ b/python/src/geolibre/project.py
@@ -696,21 +696,35 @@ def video_layer(
         A layer dict for the project's ``layers`` array.
 
     Raises:
-        ValueError: If ``urls`` is empty or ``coordinates`` is not four
-            ``[lng, lat]`` pairs.
+        ValueError: If ``urls`` is empty, any URL is not ``https://`` (the
+            browser's ``media-src`` CSP blocks ``http://``), or ``coordinates``
+            is not four ``[lng, lat]`` pairs.
     """
     clean_urls = [u for u in urls if isinstance(u, str) and u]
     if not clean_urls:
         raise ValueError("video_layer requires at least one non-empty URL")
+    if any(not u.lower().startswith("https://") for u in clean_urls):
+        raise ValueError(
+            "Video URLs must start with https:// (the browser CSP blocks http://)"
+        )
     if len(coordinates) != 4 or any(len(corner) != 2 for corner in coordinates):
         raise ValueError(
             "coordinates must be four [lng, lat] corners (top-left, top-right, "
             "bottom-right, bottom-left)"
         )
+    lngs = [float(c[0]) for c in coordinates]
+    lats = [float(c[1]) for c in coordinates]
     layer = _layer_base(name, "video", **style)
     layer["source"] = {
+        "type": "video",
         "urls": clean_urls,
-        "coordinates": [[float(c[0]), float(c[1])] for c in coordinates],
+        "coordinates": [[lng, lat] for lng, lat in zip(lngs, lats)],
+    }
+    # Persist the corner bbox ([west, south, east, north]) so "Zoom to layer"
+    # works — a video source exposes no bounds for fitLayer to fall back on.
+    layer["metadata"] = {
+        "sourceKind": "video-url",
+        "bounds": [min(lngs), min(lats), max(lngs), max(lats)],
     }
     layer["sourcePath"] = clean_urls[0]
     return layer

--- a/python/src/geolibre/project.py
+++ b/python/src/geolibre/project.py
@@ -413,7 +413,9 @@ def wmts_layer(
 
     Args:
         name: Layer display name.
-        url: A WMTS tile URL template (``{z}/{y}/{x}``).
+        url: A WMTS tile URL template in WMTS REST ``{z}/{y}/{x}`` order (row
+            before column — unlike XYZ templates in ``tile_layer``/``add_tile_layer``,
+            which use ``{z}/{x}/{y}``).
         tile_size: Tile size in pixels.
         **style: Style overrides merged into the default layer style.
 

--- a/python/tests/test_map.py
+++ b/python/tests/test_map.py
@@ -4,7 +4,20 @@ from __future__ import annotations
 
 import pytest
 
+import geolibre.geolibre as gmod
 from geolibre.geolibre import Map
+
+
+@pytest.fixture
+def m(monkeypatch):
+    """A Map instance with the static server stubbed out (no bundle needed)."""
+    monkeypatch.setattr(gmod, "serve_app", lambda *_a, **_k: "http://127.0.0.1:0/")
+    monkeypatch.setattr(gmod, "app_port", lambda: 0)
+    return Map()
+
+
+def _last_layer(widget):
+    return widget.project["layers"][-1]
 
 
 def test_remote_mode_explicit():
@@ -38,3 +51,98 @@ def test_remote_mode_colab_forces_direct(monkeypatch):
 def test_remote_mode_non_colab_uses_remote(monkeypatch):
     monkeypatch.setattr(Map, "_running_on_colab", staticmethod(lambda: False))
     assert Map._resolve_remote_mode(True) == "remote"
+
+
+def test_add_wms_appends_record_and_bumps_seq(m):
+    seq = m._seq
+    layer_id = m.add_wms("https://e/wms", "a,b")
+    layer = _last_layer(m)
+    assert layer["id"] == layer_id
+    assert layer["type"] == "wms"
+    assert m._seq == seq + 1
+
+
+def test_add_wmts(m):
+    m.add_wmts("https://t/{z}/{y}/{x}.png")
+    assert _last_layer(m)["type"] == "wmts"
+
+
+def test_add_raster_is_cog(m):
+    m.add_raster("https://e/dem.tif", bands=[1, 2, 3])
+    layer = _last_layer(m)
+    assert layer["type"] == "cog"
+    assert layer["metadata"]["rasterState"]["bands"] == [1, 2, 3]
+
+
+def test_add_vector_url_uses_control(m):
+    m.add_vector("https://e/data.fgb", data_format="flatgeobuf")
+    layer = _last_layer(m)
+    assert layer["type"] == "geojson"
+    assert layer["metadata"]["sourceKind"] == "maplibre-gl-vector"
+
+
+def test_add_geoparquet_sets_format(m):
+    m.add_geoparquet("https://e/d.parquet")
+    assert _last_layer(m)["metadata"]["vectorState"]["format"] == "parquet"
+
+
+def test_add_flatgeobuf_sets_format(m):
+    m.add_flatgeobuf("https://e/d.fgb")
+    assert _last_layer(m)["metadata"]["vectorState"]["format"] == "flatgeobuf"
+
+
+def test_add_vector_tiles(m):
+    m.add_vector_tiles("https://e/tiles.json", source_layer="x")
+    layer = _last_layer(m)
+    assert layer["type"] == "vector-tiles"
+    assert layer["source"]["sourceLayer"] == "x"
+
+
+def test_add_pmtiles(m):
+    m.add_pmtiles("https://e/x.pmtiles", source_layers=["roads"])
+    layer = _last_layer(m)
+    assert layer["type"] == "pmtiles"
+    assert layer["metadata"]["sourceLayers"] == ["roads"]
+
+
+def test_add_3d_tiles(m):
+    m.add_3d_tiles("https://e/tileset.json", altitude_offset=5)
+    layer = _last_layer(m)
+    assert layer["type"] == "3d-tiles"
+    assert layer["source"]["altitudeOffset"] == 5
+
+
+def test_add_video_wraps_single_url(m):
+    m.add_video("https://e/a.mp4", [[0, 0], [1, 0], [1, 1], [0, 1]])
+    assert _last_layer(m)["source"]["urls"] == ["https://e/a.mp4"]
+
+
+def test_add_wfs_inlines_geojson(monkeypatch, m):
+    fake_fc = {"type": "FeatureCollection", "features": []}
+    monkeypatch.setattr(gmod._project, "load_featurecollection", lambda _url: fake_fc)
+    m.add_wfs("https://e/wfs", "topp:states")
+    layer = _last_layer(m)
+    assert layer["type"] == "geojson"
+    assert layer["geojson"] == fake_fc
+    assert layer["metadata"]["service"] == "wfs"
+    assert layer["metadata"]["sourceKind"] == "wfs-getfeature"
+    assert layer["metadata"]["typeName"] == "topp:states"
+
+
+def test_add_vector_local_file_inlined(monkeypatch, m):
+    fake_fc = {"type": "FeatureCollection", "features": []}
+    monkeypatch.setattr(gmod, "_read_local_vector", lambda _p: fake_fc)
+    m.add_vector("/data/parcels.shp")
+    layer = _last_layer(m)
+    assert layer["type"] == "geojson"
+    assert layer["geojson"] == fake_fc
+
+
+def test_add_vector_geo_interface_inlined(m):
+    class Fake:
+        __geo_interface__ = {"type": "FeatureCollection", "features": []}
+
+    m.add_vector(Fake(), name="GDF")
+    layer = _last_layer(m)
+    assert layer["type"] == "geojson"
+    assert layer["name"] == "GDF"

--- a/python/tests/test_map.py
+++ b/python/tests/test_map.py
@@ -118,7 +118,10 @@ def test_add_video_wraps_single_url(m):
 
 
 def test_add_wfs_inlines_geojson(monkeypatch, m):
-    fake_fc = {"type": "FeatureCollection", "features": []}
+    fake_fc = {
+        "type": "FeatureCollection",
+        "features": [{"type": "Feature", "properties": {}, "geometry": None}],
+    }
     monkeypatch.setattr(gmod._project, "load_featurecollection", lambda _url: fake_fc)
     m.add_wfs("https://e/wfs", "topp:states")
     layer = _last_layer(m)
@@ -127,6 +130,12 @@ def test_add_wfs_inlines_geojson(monkeypatch, m):
     assert layer["metadata"]["service"] == "wfs"
     assert layer["metadata"]["sourceKind"] == "wfs-getfeature"
     assert layer["metadata"]["typeName"] == "topp:states"
+    assert layer["metadata"]["featureCount"] == 1
+    # Protocol fields are persisted on the source for round-trip editing.
+    assert layer["source"]["service"] == "wfs"
+    assert layer["source"]["typeName"] == "topp:states"
+    assert layer["source"]["version"] == "2.0.0"
+    assert layer["source"]["outputFormat"] == "application/json"
 
 
 def test_add_vector_local_file_inlined(monkeypatch, m):

--- a/python/tests/test_map.py
+++ b/python/tests/test_map.py
@@ -172,3 +172,11 @@ def test_add_vector_geo_interface_inlined(m):
     layer = _last_layer(m)
     assert layer["type"] == "geojson"
     assert layer["name"] == "GDF"
+
+
+def test_add_vector_geo_interface_warns_on_ignored_kwargs(m):
+    class Fake:
+        __geo_interface__ = {"type": "FeatureCollection", "features": []}
+
+    with pytest.warns(UserWarning, match="__geo_interface__ objects"):
+        m.add_vector(Fake(), render_mode="tiles")

--- a/python/tests/test_map.py
+++ b/python/tests/test_map.py
@@ -140,11 +140,28 @@ def test_add_wfs_inlines_geojson(monkeypatch, m):
 
 def test_add_vector_local_file_inlined(monkeypatch, m):
     fake_fc = {"type": "FeatureCollection", "features": []}
-    monkeypatch.setattr(gmod, "_read_local_vector", lambda _p: fake_fc)
-    m.add_vector("/data/parcels.shp")
+    captured = {}
+
+    def fake_read(path, data_format=None):
+        captured["path"] = path
+        captured["data_format"] = data_format
+        return fake_fc
+
+    monkeypatch.setattr(gmod, "_read_local_vector", fake_read)
+    # add_geoparquet routes a local path with the parquet hint threaded through.
+    m.add_geoparquet("/data/cities.parquet")
     layer = _last_layer(m)
     assert layer["type"] == "geojson"
     assert layer["geojson"] == fake_fc
+    assert captured["data_format"] == "parquet"
+
+
+def test_add_vector_local_file_warns_on_ignored_kwargs(monkeypatch, m):
+    monkeypatch.setattr(
+        gmod, "_read_local_vector", lambda _p, data_format=None: {"type": "x"}
+    )
+    with pytest.warns(UserWarning, match="ignored for local files"):
+        m.add_vector("/data/parcels.shp", source_layer="layer0")
 
 
 def test_add_vector_geo_interface_inlined(m):

--- a/python/tests/test_project.py
+++ b/python/tests/test_project.py
@@ -165,7 +165,7 @@ def test_vector_layer_tiles_mode():
 
 
 def test_vector_layer_invalid_render_mode():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="render_mode must be"):
         project.vector_layer("V", "https://e/x", render_mode="bogus")
 
 
@@ -202,7 +202,7 @@ def test_pmtiles_layer_raster_shape():
 
 
 def test_pmtiles_layer_invalid_tile_type():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="tile_type must be"):
         project.pmtiles_layer("P", "https://e/x.pmtiles", tile_type="bogus")
 
 
@@ -230,19 +230,28 @@ def test_video_layer_shape():
     corners = [[-122, 38], [-121, 38], [-121, 37], [-122, 37]]
     layer = project.video_layer("Vid", ["https://e/a.mp4", "https://e/a.webm"], corners)
     assert layer["type"] == "video"
+    assert layer["source"]["type"] == "video"
     assert layer["source"]["urls"] == ["https://e/a.mp4", "https://e/a.webm"]
     assert layer["source"]["coordinates"] == corners
     assert layer["sourcePath"] == "https://e/a.mp4"
+    assert layer["metadata"]["sourceKind"] == "video-url"
+    # bounds is [west, south, east, north] of the four corners.
+    assert layer["metadata"]["bounds"] == [-122, 37, -121, 38]
 
 
 def test_video_layer_requires_url():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="non-empty URL"):
         project.video_layer("Vid", [], [[0, 0], [1, 0], [1, 1], [0, 1]])
 
 
 def test_video_layer_requires_four_corners():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"four \[lng, lat\] corners"):
         project.video_layer("Vid", ["https://e/a.mp4"], [[0, 0], [1, 1]])
+
+
+def test_video_layer_rejects_non_https():
+    with pytest.raises(ValueError, match="https://"):
+        project.video_layer("Vid", ["http://e/a.mp4"], [[0, 0], [1, 0], [1, 1], [0, 1]])
 
 
 def test_load_featurecollection_passthrough():

--- a/python/tests/test_project.py
+++ b/python/tests/test_project.py
@@ -81,6 +81,170 @@ def test_cog_layer_restore_shape():
     assert md["rasterState"]["colormap"] == "terrain"
 
 
+def test_wms_layer_shape_and_url():
+    layer = project.wms_layer(
+        "NAIP",
+        "https://example.com/wms",
+        "layer:a,layer:b",
+        styles="",
+        image_format="image/png",
+    )
+    assert layer["type"] == "wms"
+    src = layer["source"]
+    assert src["type"] == "raster"
+    assert src["tileSize"] == 256
+    assert src["url"] == "https://example.com/wms"
+    assert src["layers"] == "layer:a,layer:b"
+    assert layer["metadata"]["service"] == "wms"
+    tile = src["tiles"][0]
+    # The bbox placeholder is preserved verbatim; other values are encoded.
+    assert "BBOX={bbox-epsg-3857}" in tile
+    assert "SERVICE=WMS" in tile
+    assert "REQUEST=GetMap" in tile
+    assert "LAYERS=layer%3Aa%2Clayer%3Ab" in tile
+    assert "SRS=EPSG%3A3857" in tile
+    assert "WIDTH=256" in tile
+
+
+def test_wms_layer_transparent_false():
+    layer = project.wms_layer(
+        "x", "https://e/wms", "a", transparent=False, tile_size=512
+    )
+    tile = layer["source"]["tiles"][0]
+    assert "TRANSPARENT=FALSE" in tile
+    assert "WIDTH=512" in tile
+    assert layer["source"]["tileSize"] == 512
+
+
+def test_wmts_layer_shape():
+    layer = project.wmts_layer("W", "https://t/{z}/{y}/{x}.png")
+    assert layer["type"] == "wmts"
+    assert layer["source"]["tiles"] == ["https://t/{z}/{y}/{x}.png"]
+    assert layer["source"]["type"] == "raster"
+    assert layer["metadata"]["service"] == "wmts"
+
+
+def test_wfs_getfeature_url_v2():
+    url = project.wfs_getfeature_url(
+        "https://e/wfs", "topp:states", version="2.0.0", max_features=10
+    )
+    assert "typeNames=topp%3Astates" in url
+    assert "count=10" in url
+    assert "service=WFS" in url
+    assert "outputFormat=application%2Fjson" in url
+
+
+def test_wfs_getfeature_url_v1_uses_legacy_params():
+    url = project.wfs_getfeature_url(
+        "https://e/wfs?token=1", "ns:type", version="1.1.0", max_features=5
+    )
+    assert "typeName=ns%3Atype" in url
+    assert "maxFeatures=5" in url
+    # An existing query string is respected with an "&" separator.
+    assert "wfs?token=1&" in url
+
+
+def test_vector_layer_geojson_mode():
+    layer = project.vector_layer("V", "https://e/data.parquet", data_format="parquet")
+    assert layer["type"] == "geojson"
+    assert layer["source"] == {"type": "geojson", "url": "https://e/data.parquet"}
+    md = layer["metadata"]
+    assert md["sourceKind"] == "maplibre-gl-vector"
+    assert md["externalNativeLayer"] is True
+    assert md["controlOwnsPaint"] is True
+    assert md["vectorSource"] == "url"
+    assert md["vectorState"] == {"renderMode": "geojson", "format": "parquet"}
+    assert layer["sourcePath"] == "https://e/data.parquet"
+
+
+def test_vector_layer_tiles_mode():
+    layer = project.vector_layer("V", "https://e/data.fgb", render_mode="tiles")
+    assert layer["type"] == "vector-tiles"
+    assert layer["source"]["type"] == "vector"
+    assert layer["metadata"]["vectorState"]["renderMode"] == "tiles"
+
+
+def test_vector_layer_invalid_render_mode():
+    with pytest.raises(ValueError):
+        project.vector_layer("V", "https://e/x", render_mode="bogus")
+
+
+def test_vector_tiles_layer_shape():
+    layer = project.vector_tiles_layer(
+        "VT", "https://e/tiles.json", source_layers=["a", "b"]
+    )
+    assert layer["type"] == "vector-tiles"
+    assert layer["source"] == {
+        "type": "vector",
+        "url": "https://e/tiles.json",
+        "sourceLayers": ["a", "b"],
+    }
+
+
+def test_pmtiles_layer_vector_shape():
+    layer = project.pmtiles_layer(
+        "P", "https://e/tiles.pmtiles", source_layers=["roads"]
+    )
+    assert layer["type"] == "pmtiles"
+    assert layer["source"]["type"] == "vector"
+    assert layer["source"]["tileType"] == "vector"
+    assert layer["source"]["sourceId"] == layer["id"]
+    md = layer["metadata"]
+    assert md["sourceKind"] == "pmtiles-url"
+    assert md["externalNativeLayer"] is True
+    assert md["sourceLayers"] == ["roads"]
+
+
+def test_pmtiles_layer_raster_shape():
+    layer = project.pmtiles_layer("P", "https://e/r.pmtiles", tile_type="raster")
+    assert layer["source"]["type"] == "raster"
+    assert layer["metadata"]["tileType"] == "raster"
+
+
+def test_pmtiles_layer_invalid_tile_type():
+    with pytest.raises(ValueError):
+        project.pmtiles_layer("P", "https://e/x.pmtiles", tile_type="bogus")
+
+
+def test_three_d_tiles_layer_shape():
+    layer = project.three_d_tiles_layer(
+        "T", "https://e/tileset.json", altitude_offset=12, request_headers={"k": "v"}
+    )
+    assert layer["type"] == "3d-tiles"
+    assert layer["source"]["url"] == "https://e/tileset.json"
+    assert layer["source"]["altitudeOffset"] == 12
+    assert layer["source"]["requestHeaders"] == {"k": "v"}
+    md = layer["metadata"]
+    assert md["sourceKind"] == "3d-tiles-url"
+    assert md["externalNativeLayer"] is True
+    assert md["customLayerType"] == "3d-tiles"
+    assert md["nativeLayerIds"] == [layer["id"]]
+
+
+def test_three_d_tiles_layer_omits_empty_headers():
+    layer = project.three_d_tiles_layer("T", "https://e/tileset.json")
+    assert "requestHeaders" not in layer["source"]
+
+
+def test_video_layer_shape():
+    corners = [[-122, 38], [-121, 38], [-121, 37], [-122, 37]]
+    layer = project.video_layer("Vid", ["https://e/a.mp4", "https://e/a.webm"], corners)
+    assert layer["type"] == "video"
+    assert layer["source"]["urls"] == ["https://e/a.mp4", "https://e/a.webm"]
+    assert layer["source"]["coordinates"] == corners
+    assert layer["sourcePath"] == "https://e/a.mp4"
+
+
+def test_video_layer_requires_url():
+    with pytest.raises(ValueError):
+        project.video_layer("Vid", [], [[0, 0], [1, 0], [1, 1], [0, 1]])
+
+
+def test_video_layer_requires_four_corners():
+    with pytest.raises(ValueError):
+        project.video_layer("Vid", ["https://e/a.mp4"], [[0, 0], [1, 1]])
+
+
 def test_load_featurecollection_passthrough():
     assert project.load_featurecollection(POINT_FC) is POINT_FC
 

--- a/python/tests/test_project.py
+++ b/python/tests/test_project.py
@@ -116,6 +116,22 @@ def test_wms_layer_transparent_false():
     assert layer["source"]["tileSize"] == 512
 
 
+def test_append_query_keeps_fragment_after_query():
+    # A "#fragment" must stay at the end so the query is not pushed past it.
+    layer = project.wms_layer("x", "https://e/ows#v2", "a")
+    tile = layer["source"]["tiles"][0]
+    assert tile.startswith("https://e/ows?SERVICE=WMS")
+    assert tile.endswith("#v2")
+    assert tile.index("SERVICE=WMS") < tile.index("#v2")
+
+
+def test_vector_tiles_layer_warns_on_both_source_layer_args():
+    with pytest.warns(UserWarning, match="source_layer is ignored"):
+        project.vector_tiles_layer(
+            "VT", "https://e/t.json", source_layers=["a"], source_layer="b"
+        )
+
+
 def test_wmts_layer_shape():
     layer = project.wmts_layer("W", "https://t/{z}/{y}/{x}.png")
     assert layer["type"] == "wmts"

--- a/python/tests/test_project.py
+++ b/python/tests/test_project.py
@@ -193,12 +193,16 @@ def test_pmtiles_layer_vector_shape():
     assert md["sourceKind"] == "pmtiles-url"
     assert md["externalNativeLayer"] is True
     assert md["sourceLayers"] == ["roads"]
+    # nativeLayerIds must be non-empty or isExternalNativeLayer() skips render.
+    assert md["nativeLayerIds"] == [layer["id"]]
 
 
 def test_pmtiles_layer_raster_shape():
     layer = project.pmtiles_layer("P", "https://e/r.pmtiles", tile_type="raster")
     assert layer["source"]["type"] == "raster"
     assert layer["metadata"]["tileType"] == "raster"
+    # Raster placeholder matches ensurePMTilesExternalLayer's computed fallback.
+    assert layer["metadata"]["nativeLayerIds"] == [f"{layer['id']}-raster"]
 
 
 def test_pmtiles_layer_invalid_tile_type():
@@ -252,6 +256,13 @@ def test_video_layer_requires_four_corners():
 def test_video_layer_rejects_non_https():
     with pytest.raises(ValueError, match="https://"):
         project.video_layer("Vid", ["http://e/a.mp4"], [[0, 0], [1, 0], [1, 1], [0, 1]])
+
+
+def test_video_layer_rejects_non_string_url():
+    with pytest.raises(ValueError, match="non-empty string"):
+        project.video_layer(
+            "Vid", ["https://e/a.mp4", None], [[0, 0], [1, 0], [1, 1], [0, 1]]
+        )
 
 
 def test_load_featurecollection_passthrough():


### PR DESCRIPTION
## Summary

Closes #246. Expands the `geolibre` Python widget API so users can add — programmatically — the URL/cloud-native data types the desktop **Add Data** menu supports, going well beyond the previous `add_geojson` / `add_tile_layer` / `add_cog`.

### New `Map` methods

| Category | Methods |
| --- | --- |
| Web services | `add_wms`, `add_wmts`, `add_wfs` |
| Vector files | `add_vector`, `add_geoparquet`, `add_flatgeobuf`, `add_shp` |
| Tiled / cloud | `add_vector_tiles`, `add_pmtiles` |
| 3D / media | `add_3d_tiles`, `add_video` |
| Raster | `add_raster` (alias of `add_cog`) |

### How it works

Each method builds a project-layer record in `project.py` that mirrors the corresponding TypeScript store-layer shape (`createVectorStoreLayer`, `createWmsTileUrl`, the PMTiles/3D-Tiles/video records, etc.). Because every Python `add_*` call posts a new project → `loadProject` bumps `projectGeneration` → the `DesktopShell` restore effect re-runs idempotently, the embedded app reconstructs these layers through the **same restore paths and core layer sync** it uses for layers added through the UI (`restoreVectorLayers`, `restoreRasterLayers`, `restoreThreeDTilesLayers`, and `syncLayer`). No frontend changes were needed.

### Local files

`add_vector` (and the format wrappers) accept a remote URL — streamed by the in-browser vector control — or a **local** file path, which the kernel reads with GeoPandas (optional dependency) and inlines as GeoJSON, since the browser cannot read a kernel-side file. A missing GeoPandas raises a clear, actionable error.

### Out of scope (follow-ups)

- **ArcGIS** — needs a new upstream `restoreArcGISLayers` (no restore path exists today; `addArcGISLayer` runs only at UI add-time).
- **deck.gl viz** — needs full `vizConfig` + inline-data plumbing.
- **Zarr / LiDAR / Gaussian splat** — niche; each needs restore verification.
- **Local MBTiles / OSM PBF / local raster reads** — Tauri/browser-only, not feasible from the Jupyter kernel.

## Test plan

- [x] `pytest` — 60 passed (new builder-shape tests in `test_project.py`; new `Map`-method tests in `test_map.py` that stub the static server so `Map()` constructs without a bundle).
- [x] `ruff check` / `ruff format` clean.
- [x] `pre-commit run` (incl. the `npm build` hook) passes — the full app still compiles.
- [ ] Manual: load a `.geolibre.json` containing one layer of each new type in the web app and confirm it renders (recommended before release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added many new layer types: local vector files (GeoParquet, FlatGeobuf, Shapefile), vector tiles & PMTiles, OGC services (WMS, WMTS, WFS), 3D tiles, georeferenced video, and a raster alias; unified vector add helper handles URLs, geo-interface objects, and local inlining (with warnings for ignored params).

* **Documentation**
  * Expanded API reference with signatures/descriptions for all new layer helpers and clarified when optional extras are required (local vector inlining and GeoDataFrame vs remote streaming).

* **Tests**
  * Added comprehensive unit tests for all new layer helpers, inlining/WFS behavior, validations, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->