### PR TITLE
feat(h3): create H3 hexagonal grids and bin points to H3 (#245)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -1213,6 +1213,18 @@ export function TopToolbar({
               >
                 Select by location
               </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel className="text-xs text-muted-foreground">
+                H3
+              </DropdownMenuLabel>
+              <DropdownMenuItem onSelect={() => setVectorToolOpen("h3-grid")}>
+                Create H3 grid
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onSelect={() => setVectorToolOpen("h3-bin-points")}
+              >
+                Bin points to H3
+              </DropdownMenuItem>
             </DropdownMenuSubContent>
           </DropdownMenuSub>
           <DropdownMenuSub>

--- a/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
@@ -105,6 +105,35 @@ export function VectorToolsDialog({
     if (!tool.supportsSidecar) setEngine("client");
   }, [tool]);
 
+  // Prefill the H3 grid's manual bounding-box fields from the current map
+  // viewport when the user first switches to that source, so they can tweak the
+  // box rather than type it from scratch. Only fills empty fields, so it never
+  // clobbers manual edits. Keyed on the source value, not every keystroke.
+  useEffect(() => {
+    if (selectedId !== "h3-grid" || params.source !== "bbox") return;
+    if (
+      params.west !== undefined ||
+      params.south !== undefined ||
+      params.east !== undefined ||
+      params.north !== undefined
+    )
+      return;
+    const map = mapControllerRef.current?.getMap();
+    if (!map) return;
+    const b = map.getBounds();
+    const round = (n: number) => Number(n.toFixed(6));
+    setParams((prev) => ({
+      ...prev,
+      west: round(b.getWest()),
+      south: round(b.getSouth()),
+      east: round(b.getEast()),
+      north: round(b.getNorth()),
+    }));
+    // params.west/south/east/north are read as a one-time guard; re-running only
+    // when the source changes is intentional.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedId, params.source, mapControllerRef]);
+
   // Probe the sidecar's vector capability when the dialog opens.
   useEffect(() => {
     if (!open) return;

--- a/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
@@ -16,6 +16,7 @@ import {
   onPyodideProgress,
   runVectorToolInPyodide,
 } from "../../lib/pyodide/pyodide-vector-loader";
+import { createDuckDbCapability } from "../../lib/duckdb-processing";
 import {
   Button,
   Dialog,
@@ -84,6 +85,9 @@ export function VectorToolsDialog({
     () => getVectorTool(selectedId) ?? VECTOR_TOOLS[0],
     [selectedId],
   );
+
+  // One DuckDB capability per dialog instance; the H3 tools use it via ctx.
+  const duckdb = useMemo(() => createDuckDbCapability(), []);
 
   // When the menu opens the dialog with a specific tool, preselect it.
   useEffect(() => {
@@ -310,6 +314,13 @@ export function VectorToolsDialog({
           log: appendLog,
           fitBounds: (bounds) => mapControllerRef.current?.fitBounds(bounds),
           addResultLayer,
+          duckdb,
+          viewportBounds: () => {
+            const map = mapControllerRef.current?.getMap();
+            if (!map) return null;
+            const b = map.getBounds();
+            return [b.getWest(), b.getSouth(), b.getEast(), b.getNorth()];
+          },
         };
         await tool.run(ctx);
       }
@@ -328,6 +339,7 @@ export function VectorToolsDialog({
     runRemoteEngine,
     mapControllerRef,
     isParamVisible,
+    duckdb,
   ]);
 
   const groups = useMemo(groupedTools, []);

--- a/apps/geolibre-desktop/src/lib/duckdb-processing.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-processing.ts
@@ -1,0 +1,64 @@
+import type {
+  DuckDbCapability,
+  DuckDbGeoJsonSource,
+} from "@geolibre/processing";
+import type { FeatureCollection } from "geojson";
+import {
+  ensureH3Extension,
+  ensureSpatialExtension,
+  getDatabase,
+  quoteSqlString,
+  rowsFromResult,
+} from "./duckdb-vector-loader";
+
+let counter = 0;
+
+/**
+ * A {@link DuckDbCapability} backed by the shared DuckDB-WASM instance. Each
+ * call opens a short-lived connection; loaded extensions persist at the
+ * database level, so `ensureExtensions` and `query` may use separate
+ * connections safely.
+ */
+export function createDuckDbCapability(): DuckDbCapability {
+  return {
+    async ensureExtensions(names: string[]): Promise<void> {
+      const db = await getDatabase();
+      const connection = await db.connect();
+      try {
+        if (names.includes("spatial")) await ensureSpatialExtension(connection);
+        if (names.includes("h3")) await ensureH3Extension(connection);
+      } finally {
+        await connection.close();
+      }
+    },
+
+    async registerGeoJson(
+      geojson: FeatureCollection,
+    ): Promise<DuckDbGeoJsonSource> {
+      const db = await getDatabase();
+      counter += 1;
+      const name = `__geolibre_h3_${Date.now()}_${counter}.geojson`;
+      await db.registerFileText(name, JSON.stringify(geojson));
+      return {
+        sql: `ST_Read(${quoteSqlString(name)})`,
+        async release(): Promise<void> {
+          try {
+            await db.dropFiles([name]);
+          } catch {
+            // File may already be gone; releasing twice is harmless.
+          }
+        },
+      };
+    },
+
+    async query(sql: string): Promise<Record<string, unknown>[]> {
+      const db = await getDatabase();
+      const connection = await db.connect();
+      try {
+        return rowsFromResult(await connection.query(sql));
+      } finally {
+        await connection.close();
+      }
+    },
+  };
+}

--- a/apps/geolibre-desktop/src/lib/duckdb-processing.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-processing.ts
@@ -37,7 +37,7 @@ export function createDuckDbCapability(): DuckDbCapability {
     ): Promise<DuckDbGeoJsonSource> {
       const db = await getDatabase();
       counter += 1;
-      const name = `__geolibre_h3_${Date.now()}_${counter}.geojson`;
+      const name = `__geolibre_geojson_${Date.now()}_${counter}.geojson`;
       await db.registerFileText(name, JSON.stringify(geojson));
       return {
         sql: `ST_Read(${quoteSqlString(name)})`,

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -101,6 +101,30 @@ export async function ensureSpatialExtension(
   }
 }
 
+let h3ExtensionPromise: Promise<void> | null = null;
+
+/**
+ * Install and load the DuckDB `h3` community extension once per database
+ * instance. Mirrors {@link ensureSpatialExtension}: memoized as a promise so
+ * concurrent callers share one INSTALL/LOAD, and cleared on failure so a later
+ * call can retry. `h3` is published for the bundled DuckDB version (v1.5.1) on
+ * all WASM platforms.
+ */
+export async function ensureH3Extension(
+  connection: duckdb.AsyncDuckDBConnection,
+): Promise<void> {
+  h3ExtensionPromise ??= (async () => {
+    await connection.query("INSTALL h3 FROM community");
+    await connection.query("LOAD h3");
+  })();
+  try {
+    await h3ExtensionPromise;
+  } catch (error) {
+    h3ExtensionPromise = null;
+    throw error;
+  }
+}
+
 async function createDatabase(): Promise<duckdb.AsyncDuckDB> {
   const bundle = await duckdb.selectBundle(MANUAL_BUNDLES);
   const worker = new Worker(bundle.mainWorker!, { type: "module" });

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -114,6 +114,9 @@ export async function ensureH3Extension(
   connection: duckdb.AsyncDuckDBConnection,
 ): Promise<void> {
   h3ExtensionPromise ??= (async () => {
+    // Unlike `ensureSpatialExtension`, no `beforeLoad` warm-up is needed here:
+    // the duckdb-wasm v1.33.1-dev45 remote-read bug only affects `spatial`. If a
+    // similar issue ever surfaces for `h3`, add a `beforeLoad` hook to match.
     await connection.query("INSTALL h3 FROM community");
     await connection.query("LOAD h3");
   })();

--- a/docs/superpowers/plans/2026-06-12-h3-hexagonal-grid.md
+++ b/docs/superpowers/plans/2026-06-12-h3-hexagonal-grid.md
@@ -1,0 +1,1157 @@
+# H3 Hexagonal Grid Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add two client-side processing tools — "Create H3 Grid" and "Bin Points to H3" — backed by the DuckDB-WASM `h3` + `spatial` extensions, surfaced in the existing Vector Tools dialog and Processing menu.
+
+**Architecture:** The `@geolibre/processing` package stays framework-agnostic. It gains a new `h3-tools.ts` with two `ProcessingAlgorithm`s whose `run()` calls an injected `ctx.duckdb` capability (a small interface) plus a `ctx.viewportBounds()` accessor. The desktop app implements that capability over the existing `duckdb-vector-loader.ts` and wires both into the context built in `VectorToolsDialog`. All SQL/area/resolution logic lives in pure, unit-tested helpers; the DuckDB-coupled code (capability + extension loader) is thin and verified by build + manual test.
+
+**Tech Stack:** TypeScript, DuckDB-WASM (`@duckdb/duckdb-wasm` 1.33.1-dev45 → DuckDB v1.5.1), DuckDB `h3` community extension, `@turf/bbox`, React, `node --test` (tsx).
+
+**Verified feasibility (2026-06-12):** `INSTALL h3 FROM community; LOAD h3;` is valid for DuckDB v1.5.1 on all WASM platforms. Functions used: `h3_polygon_wkt_to_cells(wkt, res)`, `h3_cell_to_boundary_wkt(cell)`, `h3_h3_to_string(cell)`, `h3_latlng_to_cell(lat, lng, res)`.
+
+---
+
+## File Structure
+
+- Create `packages/processing/src/h3-tools.ts` — pure helpers (area, resolution, WKT/SQL builders, row→FeatureCollection) + the two `ProcessingAlgorithm` objects + `H3_TOOLS`/`getH3Tool`.
+- Modify `packages/processing/src/types.ts` — add `DuckDbCapability`, `DuckDbGeoJsonSource`, and `duckdb?` / `viewportBounds?` fields on `ProcessingContext`.
+- Modify `packages/processing/src/vector-tools.ts` — append the two H3 tools to `VECTOR_TOOLS` so the dialog lists them.
+- Modify `packages/processing/src/index.ts` — export the H3 tools.
+- Modify `apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts` — add `ensureH3Extension`.
+- Create `apps/geolibre-desktop/src/lib/duckdb-processing.ts` — `createDuckDbCapability()` implementing `DuckDbCapability`.
+- Modify `apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx` — inject `duckdb` + `viewportBounds` into the client-engine context.
+- Modify `apps/geolibre-desktop/src/components/layout/TopToolbar.tsx` — add menu entries.
+- Create `tests/h3-tools.test.ts` — unit tests for helpers and tool `run()` against a mock capability.
+
+---
+
+## Task 1: H3 area constants + resolution math (pure)
+
+**Files:**
+- Create: `packages/processing/src/h3-tools.ts`
+- Test: `tests/h3-tools.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/h3-tools.test.ts`:
+
+```ts
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  H3_AVG_AREA_KM2,
+  H3_HARD_CAP,
+  bboxAreaKm2,
+  estimateCellCount,
+  suggestResolution,
+} from "../packages/processing/src/h3-tools";
+
+describe("h3 resolution math", () => {
+  it("exposes 16 average-area entries (res 0..15), strictly decreasing", () => {
+    assert.equal(H3_AVG_AREA_KM2.length, 16);
+    for (let r = 1; r < 16; r += 1) {
+      assert.ok(H3_AVG_AREA_KM2[r] < H3_AVG_AREA_KM2[r - 1]);
+    }
+  });
+
+  it("computes an approximate bbox area in km^2", () => {
+    // 1 deg x 1 deg near the equator is roughly 12,300 km^2.
+    const area = bboxAreaKm2([0, 0, 1, 1]);
+    assert.ok(area > 11_000 && area < 13_500, `got ${area}`);
+  });
+
+  it("suggests the finest resolution that stays under the target cell count", () => {
+    // A large area should pick a coarse resolution.
+    const big = bboxAreaKm2([-10, -10, 10, 10]);
+    const rBig = suggestResolution(big);
+    // A tiny area should pick the finest allowed (capped at 12).
+    const tiny = bboxAreaKm2([0, 0, 0.001, 0.001]);
+    const rTiny = suggestResolution(tiny);
+    assert.ok(rBig < rTiny);
+    assert.ok(rTiny <= 12);
+    assert.ok(rBig >= 0);
+    // Whatever it picks, the estimate must not exceed the 10k target.
+    assert.ok(estimateCellCount(big, rBig) <= 10_000);
+  });
+
+  it("clamps an out-of-range resolution request via estimateCellCount monotonicity", () => {
+    const area = bboxAreaKm2([0, 0, 1, 1]);
+    assert.ok(estimateCellCount(area, 10) > estimateCellCount(area, 9));
+  });
+
+  it("exposes a hard cap constant", () => {
+    assert.equal(typeof H3_HARD_CAP, "number");
+    assert.ok(H3_HARD_CAP > 10_000);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --import tsx --test tests/h3-tools.test.ts`
+Expected: FAIL — cannot find module `../packages/processing/src/h3-tools`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `packages/processing/src/h3-tools.ts`:
+
+```ts
+/** Average area (km^2) of an H3 cell at each resolution 0..15 (official values). */
+export const H3_AVG_AREA_KM2: number[] = [
+  4_357_449.416078381, 609_788.441794133, 86_801.780398997, 12_393.434655088,
+  1_770.347654491, 252.903858182, 36.129062164, 5.16129336, 0.737327598,
+  0.105332513, 0.015047502, 0.002149643, 0.000307092, 0.00004387, 0.000006267,
+  0.000000895,
+];
+
+/** Soft target used when auto-suggesting a resolution. */
+export const H3_TARGET_CELLS = 10_000;
+/** Finest resolution the auto-suggester will pick. */
+export const H3_MAX_SUGGESTED_RES = 12;
+/** Hard ceiling: a grid larger than this aborts rather than running away. */
+export const H3_HARD_CAP = 200_000;
+
+const KM_PER_DEG_LAT = 110.574;
+const KM_PER_DEG_LON_EQ = 111.32;
+
+/** Rough planar area (km^2) of a [west, south, east, north] bbox. */
+export function bboxAreaKm2(bbox: [number, number, number, number]): number {
+  const [w, s, e, n] = bbox;
+  const midLat = (s + n) / 2;
+  const kmPerDegLon = KM_PER_DEG_LON_EQ * Math.cos((midLat * Math.PI) / 180);
+  const width = Math.abs(e - w) * kmPerDegLon;
+  const height = Math.abs(n - s) * KM_PER_DEG_LAT;
+  return Math.max(width * height, 0);
+}
+
+/** Estimated number of H3 cells covering `areaKm2` at `res`. */
+export function estimateCellCount(areaKm2: number, res: number): number {
+  return areaKm2 / H3_AVG_AREA_KM2[res];
+}
+
+/** Finest resolution whose estimated cell count stays <= the target. */
+export function suggestResolution(
+  areaKm2: number,
+  targetCells = H3_TARGET_CELLS,
+  maxRes = H3_MAX_SUGGESTED_RES,
+): number {
+  for (let res = maxRes; res >= 0; res -= 1) {
+    if (estimateCellCount(areaKm2, res) <= targetCells) return res;
+  }
+  return 0;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --import tsx --test tests/h3-tools.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/processing/src/h3-tools.ts tests/h3-tools.test.ts
+git commit -m "feat(h3): area + resolution helpers for H3 grid (#245)"
+```
+
+---
+
+## Task 2: WKT + SQL builders + row→FeatureCollection (pure)
+
+**Files:**
+- Modify: `packages/processing/src/h3-tools.ts`
+- Test: `tests/h3-tools.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/h3-tools.test.ts`:
+
+```ts
+import {
+  bboxToWktPolygon,
+  buildBinSql,
+  buildGridFromSourceSql,
+  buildGridFromWktSql,
+  rowsToFeatureCollection,
+} from "../packages/processing/src/h3-tools";
+
+describe("h3 SQL + geometry builders", () => {
+  it("builds a closed POLYGON WKT from a bbox", () => {
+    assert.equal(
+      bboxToWktPolygon([0, 1, 2, 3]),
+      "POLYGON((0 1, 2 1, 2 3, 0 3, 0 1))",
+    );
+  });
+
+  it("builds grid SQL from a WKT literal, escaping quotes", () => {
+    const sql = buildGridFromWktSql("POLYGON((0 0, 1 0, 1 1, 0 0))", 7);
+    assert.match(sql, /h3_polygon_wkt_to_cells\('POLYGON\(\(0 0, 1 0, 1 1, 0 0\)\)', 7\)/);
+    assert.match(sql, /h3_h3_to_string\(cell\) AS h3/);
+    assert.match(sql, /ST_AsGeoJSON\(ST_GeomFromText\(h3_cell_to_boundary_wkt\(cell\)\)\) AS geojson/);
+  });
+
+  it("builds polyfill grid SQL that unions the source geometry", () => {
+    const sql = buildGridFromSourceSql("ST_Read('a.geojson')", 8);
+    assert.match(sql, /ST_Union_Agg\(geom\)/);
+    assert.match(sql, /ST_Read\('a\.geojson'\)/);
+    assert.match(sql, /h3_polygon_wkt_to_cells\(\(SELECT wkt FROM merged\), 8\)/);
+  });
+
+  it("builds bin SQL for count (no field)", () => {
+    const sql = buildBinSql("ST_Read('p.geojson')", 9, "count");
+    assert.match(sql, /h3_latlng_to_cell\(ST_Y\(geom\), ST_X\(geom\), 9\)/);
+    assert.match(sql, /count\(\*\) AS count/);
+    assert.doesNotMatch(sql, /AS value/);
+    assert.match(sql, /ST_GeometryType\(geom\) = 'POINT'/);
+  });
+
+  it("builds bin SQL for an aggregate, mapping mean->avg and quoting the field", () => {
+    const sql = buildBinSql("ST_Read('p.geojson')", 9, "mean", "pop");
+    assert.match(sql, /avg\(CAST\("pop" AS DOUBLE\)\) AS value/);
+    assert.match(sql, /count, value,/);
+  });
+
+  it("converts result rows to a FeatureCollection with h3/count/value props", () => {
+    const fc = rowsToFeatureCollection([
+      {
+        h3: "8928308280fffff",
+        count: 3n,
+        value: 12.5,
+        geojson: '{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,0]]]}',
+      },
+      { h3: "x", count: 1, geojson: null },
+    ]);
+    assert.equal(fc.features.length, 1);
+    assert.equal(fc.features[0].properties?.h3, "8928308280fffff");
+    assert.equal(fc.features[0].properties?.count, 3);
+    assert.equal(fc.features[0].properties?.value, 12.5);
+    assert.equal(fc.features[0].geometry?.type, "Polygon");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --import tsx --test tests/h3-tools.test.ts`
+Expected: FAIL — the builder exports do not exist yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `packages/processing/src/h3-tools.ts`:
+
+```ts
+import type { FeatureCollection, Geometry } from "geojson";
+
+function sqlStr(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function sqlIdent(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`;
+}
+
+/** A closed POLYGON WKT ring for a [west, south, east, north] bbox. */
+export function bboxToWktPolygon(bbox: [number, number, number, number]): string {
+  const [w, s, e, n] = bbox;
+  return `POLYGON((${w} ${s}, ${e} ${s}, ${e} ${n}, ${w} ${n}, ${w} ${s}))`;
+}
+
+const GRID_SELECT =
+  "SELECT h3_h3_to_string(cell) AS h3, " +
+  "ST_AsGeoJSON(ST_GeomFromText(h3_cell_to_boundary_wkt(cell))) AS geojson FROM cells";
+
+/** Grid SQL from a polygon WKT literal (used for bbox / viewport sources). */
+export function buildGridFromWktSql(wkt: string, res: number): string {
+  return (
+    `WITH cells AS (SELECT unnest(h3_polygon_wkt_to_cells(${sqlStr(wkt)}, ${res})) AS cell) ` +
+    GRID_SELECT
+  );
+}
+
+/**
+ * Grid SQL that unions all geometry from a registered source into one
+ * (multi)polygon and fills it (used for the polyfill source). `sourceSql` is a
+ * FROM-able expression whose geometry column is `geom` (DuckDB `ST_Read`).
+ */
+export function buildGridFromSourceSql(sourceSql: string, res: number): string {
+  return (
+    `WITH merged AS (SELECT ST_AsText(ST_Union_Agg(geom)) AS wkt FROM ${sourceSql}), ` +
+    `cells AS (SELECT unnest(h3_polygon_wkt_to_cells((SELECT wkt FROM merged), ${res})) AS cell) ` +
+    GRID_SELECT
+  );
+}
+
+const AGG_FN: Record<string, string> = {
+  sum: "sum",
+  mean: "avg",
+  min: "min",
+  max: "max",
+};
+
+/**
+ * Aggregate point geometry from `sourceSql` (geometry column `geom`) into H3
+ * cells. `op` is one of count/sum/mean/min/max; a field is required for all but
+ * count.
+ */
+export function buildBinSql(
+  sourceSql: string,
+  res: number,
+  op: string,
+  field?: string,
+): string {
+  const fn = AGG_FN[op];
+  const aggSelect =
+    fn && field ? `, ${fn}(CAST(${sqlIdent(field)} AS DOUBLE)) AS value` : "";
+  const aggOut = fn && field ? ", value" : "";
+  return (
+    `WITH pts AS (SELECT * FROM ${sourceSql} ` +
+    `WHERE geom IS NOT NULL AND ST_GeometryType(geom) = 'POINT'), ` +
+    `binned AS (SELECT h3_latlng_to_cell(ST_Y(geom), ST_X(geom), ${res}) AS cell, ` +
+    `count(*) AS count${aggSelect} FROM pts GROUP BY cell) ` +
+    `SELECT h3_h3_to_string(cell) AS h3, count${aggOut}, ` +
+    `ST_AsGeoJSON(ST_GeomFromText(h3_cell_to_boundary_wkt(cell))) AS geojson FROM binned`
+  );
+}
+
+/** Build a FeatureCollection from rows carrying `h3`, optional `count`/`value`, and `geojson`. */
+export function rowsToFeatureCollection(
+  rows: Record<string, unknown>[],
+): FeatureCollection {
+  const features = [];
+  for (const row of rows) {
+    const raw = row.geojson;
+    if (typeof raw !== "string") continue;
+    const geometry = JSON.parse(raw) as Geometry;
+    const properties: Record<string, unknown> = { h3: row.h3 };
+    if (row.count !== undefined && row.count !== null) {
+      properties.count = Number(row.count);
+    }
+    if (row.value !== undefined && row.value !== null) {
+      properties.value = Number(row.value);
+    }
+    features.push({ type: "Feature" as const, geometry, properties });
+  }
+  return { type: "FeatureCollection", features };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --import tsx --test tests/h3-tools.test.ts`
+Expected: PASS (all tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/processing/src/h3-tools.ts tests/h3-tools.test.ts
+git commit -m "feat(h3): WKT/SQL builders and row mapping for H3 tools (#245)"
+```
+
+---
+
+## Task 3: ProcessingContext capability types + the two H3 tools
+
+**Files:**
+- Modify: `packages/processing/src/types.ts`
+- Modify: `packages/processing/src/h3-tools.ts`
+- Modify: `packages/processing/src/vector-tools.ts:_VECTOR_TOOLS_array_`
+- Modify: `packages/processing/src/index.ts`
+- Test: `tests/h3-tools.test.ts`
+
+- [ ] **Step 1: Add capability types to `types.ts`**
+
+In `packages/processing/src/types.ts`, replace the `ProcessingContext` interface (lines 55-62) with:
+
+```ts
+/** A GeoJSON FeatureCollection registered as a queryable DuckDB source. */
+export interface DuckDbGeoJsonSource {
+  /** FROM-able SQL expression; its geometry column is named `geom`. */
+  sql: string;
+  /** Drop the registered source. Safe to call once. */
+  release: () => Promise<void>;
+}
+
+/** Minimal DuckDB-WASM surface a processing tool needs. Injected by the host. */
+export interface DuckDbCapability {
+  /** Install + load the named extensions (e.g. `["spatial", "h3"]`). */
+  ensureExtensions: (names: string[]) => Promise<void>;
+  /** Register a FeatureCollection and return a SQL source handle. */
+  registerGeoJson: (geojson: FeatureCollection) => Promise<DuckDbGeoJsonSource>;
+  /** Run a query and return plain rows. */
+  query: (sql: string) => Promise<Record<string, unknown>[]>;
+}
+
+export interface ProcessingContext {
+  layers: GeoLibreLayer[];
+  parameters: Record<string, unknown>;
+  log: (message: string) => void;
+  fitBounds?: (bounds: [number, number, number, number]) => void;
+  /** Add an algorithm result back to the map as a new GeoJSON layer. */
+  addResultLayer?: (name: string, geojson: FeatureCollection) => void;
+  /** DuckDB-WASM capability, when the host provides it (browser/desktop). */
+  duckdb?: DuckDbCapability;
+  /** Current map viewport as [west, south, east, north], when available. */
+  viewportBounds?: () => [number, number, number, number] | null;
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `tests/h3-tools.test.ts`:
+
+```ts
+import { DEFAULT_LAYER_STYLE, type GeoLibreLayer } from "@geolibre/core";
+import type {
+  DuckDbCapability,
+  ProcessingContext,
+} from "../packages/processing/src/types";
+import {
+  binPointsTool,
+  createH3GridTool,
+  getH3Tool,
+} from "../packages/processing/src/h3-tools";
+
+function polygonLayer(): GeoLibreLayer {
+  return {
+    id: "poly",
+    name: "Poly",
+    type: "geojson",
+    source: { type: "geojson" },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {},
+    geojson: {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          properties: {},
+          geometry: {
+            type: "Polygon",
+            coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+          },
+        },
+      ],
+    },
+  };
+}
+
+function pointLayer(): GeoLibreLayer {
+  return {
+    ...polygonLayer(),
+    id: "pts",
+    name: "Pts",
+    geojson: {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          properties: { pop: 5 },
+          geometry: { type: "Point", coordinates: [0.5, 0.5] },
+        },
+      ],
+    },
+  };
+}
+
+/** Capability stub that records queries and returns one canned hex row. */
+function mockDuckDb(): DuckDbCapability & { queries: string[] } {
+  const queries: string[] = [];
+  return {
+    queries,
+    ensureExtensions: async () => {},
+    registerGeoJson: async () => ({
+      sql: "ST_Read('mock.geojson')",
+      release: async () => {},
+    }),
+    query: async (sql: string) => {
+      queries.push(sql);
+      return [
+        {
+          h3: "8928308280fffff",
+          count: 1,
+          geojson:
+            '{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,0]]]}',
+        },
+      ];
+    },
+  };
+}
+
+function baseCtx(
+  layers: GeoLibreLayer[],
+  parameters: Record<string, unknown>,
+): { ctx: ProcessingContext; logs: string[]; added: string[] } {
+  const logs: string[] = [];
+  const added: string[] = [];
+  const ctx: ProcessingContext = {
+    layers,
+    parameters,
+    log: (m) => logs.push(m),
+    addResultLayer: (name) => added.push(name),
+    duckdb: mockDuckDb(),
+    viewportBounds: () => [0, 0, 1, 1],
+  };
+  return { ctx, logs, added };
+}
+
+describe("h3 tools", () => {
+  it("registers both tools under getH3Tool", () => {
+    assert.equal(getH3Tool("h3-grid"), createH3GridTool);
+    assert.equal(getH3Tool("h3-bin-points"), binPointsTool);
+    assert.equal(getH3Tool("missing"), undefined);
+  });
+
+  it("throws a clear error when duckdb is unavailable", async () => {
+    await assert.rejects(
+      () =>
+        Promise.resolve(
+          createH3GridTool.run({
+            layers: [],
+            parameters: { source: "viewport" },
+            log: () => {},
+          }),
+        ),
+      /requires DuckDB/,
+    );
+  });
+
+  it("creates a grid from the map viewport", async () => {
+    const { ctx, added } = baseCtx([], { source: "viewport", resolution: 5 });
+    await createH3GridTool.run(ctx);
+    assert.equal(added.length, 1);
+    assert.match(added[0], /res 5/);
+  });
+
+  it("auto-suggests a resolution when none is given", async () => {
+    const { ctx, logs } = baseCtx([], { source: "viewport" });
+    await createH3GridTool.run(ctx);
+    assert.ok(logs.some((l) => /suggested resolution/i.test(l)));
+  });
+
+  it("aborts when the requested resolution exceeds the hard cap", async () => {
+    const { ctx, added, logs } = baseCtx([polygonLayer()], {
+      source: "extent",
+      layer: "poly",
+      resolution: 15,
+    });
+    await createH3GridTool.run(ctx);
+    assert.equal(added.length, 0);
+    assert.ok(logs.some((l) => /cap/i.test(l)));
+  });
+
+  it("polyfills a selected polygon layer", async () => {
+    const { ctx, added } = baseCtx([polygonLayer()], {
+      source: "polyfill",
+      layer: "poly",
+      resolution: 6,
+    });
+    await createH3GridTool.run(ctx);
+    assert.equal(added.length, 1);
+  });
+
+  it("bins points and requires a field for non-count aggregates", async () => {
+    const missing = baseCtx([pointLayer()], {
+      layer: "pts",
+      aggOp: "sum",
+      resolution: 7,
+    });
+    await binPointsTool.run(missing.ctx);
+    assert.equal(missing.added.length, 0);
+    assert.ok(missing.logs.some((l) => /field/i.test(l)));
+
+    const ok = baseCtx([pointLayer()], {
+      layer: "pts",
+      aggOp: "count",
+      resolution: 7,
+    });
+    await binPointsTool.run(ok.ctx);
+    assert.equal(ok.added.length, 1);
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `node --import tsx --test tests/h3-tools.test.ts`
+Expected: FAIL — `createH3GridTool` / `binPointsTool` / `getH3Tool` not exported.
+
+- [ ] **Step 4: Implement the tools**
+
+Append to `packages/processing/src/h3-tools.ts`:
+
+```ts
+import bbox from "@turf/bbox";
+import type { GeoLibreLayer } from "@geolibre/core";
+import type {
+  DuckDbCapability,
+  DuckDbGeoJsonSource,
+  ProcessingAlgorithm,
+  ProcessingContext,
+} from "./types";
+
+const NO_DUCKDB =
+  "This tool requires DuckDB-WASM, which is unavailable in this environment.";
+
+function requireDuckDb(ctx: ProcessingContext): DuckDbCapability {
+  if (!ctx.duckdb) throw new Error(NO_DUCKDB);
+  return ctx.duckdb;
+}
+
+function getLayer(
+  ctx: ProcessingContext,
+  paramId = "layer",
+): GeoLibreLayer | undefined {
+  const id = ctx.parameters[paramId] as string | undefined;
+  return ctx.layers.find((l) => l.id === id);
+}
+
+/** Parse the `resolution` param, or auto-suggest from area. Logs + returns null on bad input. */
+function resolveResolution(
+  ctx: ProcessingContext,
+  areaKm2: number,
+): number | null {
+  const raw = ctx.parameters.resolution;
+  if (raw === undefined || raw === null || raw === "") {
+    const suggested = suggestResolution(areaKm2);
+    ctx.log(`Using suggested resolution ${suggested}`);
+    return suggested;
+  }
+  const res = typeof raw === "string" ? Number(raw) : (raw as number);
+  if (!Number.isInteger(res) || res < 0 || res > 15) {
+    ctx.log("Error: resolution must be an integer from 0 to 15");
+    return null;
+  }
+  return res;
+}
+
+export const createH3GridTool: ProcessingAlgorithm = {
+  id: "h3-grid",
+  name: "Create H3 grid",
+  description:
+    "Fill an area with H3 hexagons (DuckDB h3 extension). Source: a layer's geometry, a layer's extent, or the current map view.",
+  group: "H3",
+  parameters: [
+    {
+      id: "source",
+      label: "Area source",
+      type: "select",
+      default: "polyfill",
+      options: [
+        { value: "polyfill", label: "Layer geometry (polyfill)" },
+        { value: "extent", label: "Layer extent (bbox)" },
+        { value: "viewport", label: "Map viewport" },
+      ],
+    },
+    {
+      id: "layer",
+      label: "Input layer",
+      type: "layer",
+      required: true,
+      geometryFilter: ["polygon"],
+      visibleWhen: { param: "source", in: ["polyfill", "extent"] },
+    },
+    {
+      id: "resolution",
+      label: "Resolution (0-15)",
+      type: "number",
+      min: 0,
+      max: 15,
+      step: 1,
+      description: "Leave blank to auto-pick from the area.",
+    },
+  ],
+  run: async (ctx) => {
+    const duckdb = requireDuckDb(ctx);
+    const source = (ctx.parameters.source as string) || "polyfill";
+
+    let areaKm2: number;
+    let wkt: string | null = null;
+    if (source === "viewport") {
+      const bounds = ctx.viewportBounds?.();
+      if (!bounds) {
+        ctx.log("Error: map viewport is unavailable");
+        return;
+      }
+      areaKm2 = bboxAreaKm2(bounds);
+      wkt = bboxToWktPolygon(bounds);
+    } else {
+      const layer = getLayer(ctx, "layer");
+      if (!layer?.geojson?.features?.length) {
+        ctx.log('Error: parameter "layer" has no GeoJSON features');
+        return;
+      }
+      const bb = bbox(layer.geojson) as [number, number, number, number];
+      areaKm2 = bboxAreaKm2(bb);
+      if (source === "extent") wkt = bboxToWktPolygon(bb);
+    }
+
+    const res = resolveResolution(ctx, areaKm2);
+    if (res === null) return;
+
+    const estimate = estimateCellCount(areaKm2, res);
+    if (estimate > H3_HARD_CAP) {
+      ctx.log(
+        `Error: resolution ${res} would generate about ${Math.round(
+          estimate,
+        ).toLocaleString()} cells (cap ${H3_HARD_CAP.toLocaleString()}). Choose a coarser resolution.`,
+      );
+      return;
+    }
+
+    await duckdb.ensureExtensions(["spatial", "h3"]);
+    let registered: DuckDbGeoJsonSource | null = null;
+    try {
+      let sql: string;
+      if (wkt) {
+        sql = buildGridFromWktSql(wkt, res);
+      } else {
+        const layer = getLayer(ctx, "layer");
+        registered = await duckdb.registerGeoJson(layer!.geojson!);
+        sql = buildGridFromSourceSql(registered.sql, res);
+      }
+      const rows = await duckdb.query(sql);
+      const fc = rowsToFeatureCollection(rows);
+      ctx.log(`Created ${fc.features.length} H3 cell(s) at resolution ${res}`);
+      ctx.addResultLayer?.(`H3 grid (res ${res})`, fc);
+    } finally {
+      await registered?.release();
+    }
+  },
+};
+
+export const binPointsTool: ProcessingAlgorithm = {
+  id: "h3-bin-points",
+  name: "Bin points to H3",
+  description:
+    "Aggregate a point layer into H3 cells (count, or sum/mean/min/max of a numeric field).",
+  group: "H3",
+  parameters: [
+    {
+      id: "layer",
+      label: "Input point layer",
+      type: "layer",
+      required: true,
+      geometryFilter: ["point"],
+    },
+    {
+      id: "aggOp",
+      label: "Aggregate",
+      type: "select",
+      default: "count",
+      options: [
+        { value: "count", label: "Count" },
+        { value: "sum", label: "Sum" },
+        { value: "mean", label: "Mean" },
+        { value: "min", label: "Min" },
+        { value: "max", label: "Max" },
+      ],
+    },
+    {
+      id: "field",
+      label: "Field",
+      type: "field",
+      fieldSource: "layer",
+      required: true,
+      visibleWhen: { param: "aggOp", notIn: ["count"] },
+      description: "Numeric field to aggregate.",
+    },
+    {
+      id: "resolution",
+      label: "Resolution (0-15)",
+      type: "number",
+      min: 0,
+      max: 15,
+      step: 1,
+      description: "Leave blank to auto-pick from the area.",
+    },
+  ],
+  run: async (ctx) => {
+    const duckdb = requireDuckDb(ctx);
+    const layer = getLayer(ctx, "layer");
+    if (!layer?.geojson?.features?.length) {
+      ctx.log('Error: parameter "layer" has no GeoJSON features');
+      return;
+    }
+    const op = (ctx.parameters.aggOp as string) || "count";
+    const field = ctx.parameters.field as string | undefined;
+    if (op !== "count" && !field) {
+      ctx.log(`Error: select a numeric field to ${op}`);
+      return;
+    }
+
+    const bb = bbox(layer.geojson) as [number, number, number, number];
+    const res = resolveResolution(ctx, bboxAreaKm2(bb));
+    if (res === null) return;
+
+    await duckdb.ensureExtensions(["spatial", "h3"]);
+    const registered = await duckdb.registerGeoJson(layer.geojson);
+    try {
+      const sql = buildBinSql(registered.sql, res, op, field);
+      const rows = await duckdb.query(sql);
+      const fc = rowsToFeatureCollection(rows);
+      ctx.log(
+        `Binned points into ${fc.features.length} H3 cell(s) at resolution ${res}`,
+      );
+      ctx.addResultLayer?.(`H3 bins (res ${res})`, fc);
+    } finally {
+      await registered.release();
+    }
+  },
+};
+
+export const H3_TOOLS: ProcessingAlgorithm[] = [createH3GridTool, binPointsTool];
+
+export function getH3Tool(id: string): ProcessingAlgorithm | undefined {
+  return H3_TOOLS.find((tool) => tool.id === id);
+}
+```
+
+- [ ] **Step 5: Surface the tools in the registry and exports**
+
+In `packages/processing/src/vector-tools.ts`, add an import near the top (after line 23):
+
+```ts
+import { createH3GridTool, binPointsTool } from "./h3-tools";
+```
+
+Then append the two tools to the `VECTOR_TOOLS` array (after `selectByLocationTool,`):
+
+```ts
+  selectByLocationTool,
+  createH3GridTool,
+  binPointsTool,
+];
+```
+
+In `packages/processing/src/index.ts`, after the `VECTOR_TOOLS`/`getVectorTool` export line, add:
+
+```ts
+export {
+  H3_TOOLS,
+  getH3Tool,
+  createH3GridTool,
+  binPointsTool,
+} from "./h3-tools";
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `node --import tsx --test tests/h3-tools.test.ts`
+Expected: PASS (all tests in the file).
+
+Also run the existing processing test to confirm no regression:
+Run: `node --import tsx --test tests/processing.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/processing/src/types.ts packages/processing/src/h3-tools.ts packages/processing/src/vector-tools.ts packages/processing/src/index.ts tests/h3-tools.test.ts
+git commit -m "feat(h3): add Create H3 grid and Bin points to H3 tools (#245)"
+```
+
+---
+
+## Task 4: `ensureH3Extension` in the DuckDB loader
+
+**Files:**
+- Modify: `apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts:45-102`
+
+(No node unit test: this module imports `*.wasm?url`, which only resolves under Vite. It is exercised by the build + manual verification. Its SQL is a two-line constant.)
+
+- [ ] **Step 1: Add the loader**
+
+In `apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts`, immediately after the `ensureSpatialExtension` function (after line 102), add:
+
+```ts
+let h3ExtensionPromise: Promise<void> | null = null;
+
+/**
+ * Install and load the DuckDB `h3` community extension once per database
+ * instance. Mirrors {@link ensureSpatialExtension}: memoized as a promise so
+ * concurrent callers share one INSTALL/LOAD, and cleared on failure so a later
+ * call can retry. `h3` is published for the bundled DuckDB version (v1.5.1) on
+ * all WASM platforms.
+ */
+export async function ensureH3Extension(
+  connection: duckdb.AsyncDuckDBConnection,
+): Promise<void> {
+  h3ExtensionPromise ??= (async () => {
+    await connection.query("INSTALL h3 FROM community");
+    await connection.query("LOAD h3");
+  })();
+  try {
+    await h3ExtensionPromise;
+  } catch (error) {
+    h3ExtensionPromise = null;
+    throw error;
+  }
+}
+```
+
+- [ ] **Step 2: Verify it type-checks**
+
+Run: `npm run test:worker` is unrelated; instead verify the package compiles as part of Task 7's build. For a quick local check now:
+Run: `npx tsc -p apps/geolibre-desktop/tsconfig.json --noEmit` (if a standalone tsconfig exists) — otherwise defer verification to the full build in Task 8.
+Expected: no new type errors referencing `ensureH3Extension`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+git commit -m "feat(h3): load the DuckDB h3 community extension in WASM (#245)"
+```
+
+---
+
+## Task 5: `createDuckDbCapability` in the desktop app
+
+**Files:**
+- Create: `apps/geolibre-desktop/src/lib/duckdb-processing.ts`
+
+(No node unit test: depends on the WASM loader. Its SQL-building logic lives in the already-tested `h3-tools` helpers; this file only wires DuckDB primitives.)
+
+- [ ] **Step 1: Create the capability**
+
+Create `apps/geolibre-desktop/src/lib/duckdb-processing.ts`:
+
+```ts
+import type {
+  DuckDbCapability,
+  DuckDbGeoJsonSource,
+} from "@geolibre/processing";
+import type { FeatureCollection } from "geojson";
+import {
+  ensureH3Extension,
+  ensureSpatialExtension,
+  getDatabase,
+  quoteSqlString,
+  rowsFromResult,
+} from "./duckdb-vector-loader";
+
+let counter = 0;
+
+/**
+ * A {@link DuckDbCapability} backed by the shared DuckDB-WASM instance. Each
+ * call opens a short-lived connection; loaded extensions persist at the
+ * database level, so `ensureExtensions` and `query` may use separate
+ * connections safely.
+ */
+export function createDuckDbCapability(): DuckDbCapability {
+  return {
+    async ensureExtensions(names: string[]): Promise<void> {
+      const db = await getDatabase();
+      const connection = await db.connect();
+      try {
+        if (names.includes("spatial")) await ensureSpatialExtension(connection);
+        if (names.includes("h3")) await ensureH3Extension(connection);
+      } finally {
+        await connection.close();
+      }
+    },
+
+    async registerGeoJson(
+      geojson: FeatureCollection,
+    ): Promise<DuckDbGeoJsonSource> {
+      const db = await getDatabase();
+      counter += 1;
+      const name = `__geolibre_h3_${Date.now()}_${counter}.geojson`;
+      await db.registerFileText(name, JSON.stringify(geojson));
+      return {
+        sql: `ST_Read(${quoteSqlString(name)})`,
+        async release(): Promise<void> {
+          try {
+            await db.dropFiles([name]);
+          } catch {
+            // File may already be gone; releasing twice is harmless.
+          }
+        },
+      };
+    },
+
+    async query(sql: string): Promise<Record<string, unknown>[]> {
+      const db = await getDatabase();
+      const connection = await db.connect();
+      try {
+        return rowsFromResult(await connection.query(sql));
+      } finally {
+        await connection.close();
+      }
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/geolibre-desktop/src/lib/duckdb-processing.ts
+git commit -m "feat(h3): DuckDB processing capability for the H3 tools (#245)"
+```
+
+---
+
+## Task 6: Wire the capability into `VectorToolsDialog`
+
+**Files:**
+- Modify: `apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx`
+
+- [ ] **Step 1: Import the capability and a memo hook**
+
+In `VectorToolsDialog.tsx`, add to the existing import from `../../lib/...` (a new line near line 18):
+
+```ts
+import { createDuckDbCapability } from "../../lib/duckdb-processing";
+```
+
+`useMemo` is already imported (line 37).
+
+- [ ] **Step 2: Create the capability once**
+
+Inside the component, after the `tool` memo (after line 86), add:
+
+```ts
+  // One DuckDB capability per dialog instance; the H3 tools use it via ctx.
+  const duckdb = useMemo(() => createDuckDbCapability(), []);
+```
+
+- [ ] **Step 3: Inject `duckdb` + `viewportBounds` into the client-engine context**
+
+In `handleRun`, replace the client-engine `ctx` object (lines 307-313) with:
+
+```ts
+        const ctx: ProcessingContext = {
+          layers,
+          parameters: params,
+          log: appendLog,
+          fitBounds: (bounds) => mapControllerRef.current?.fitBounds(bounds),
+          addResultLayer,
+          duckdb,
+          viewportBounds: () => {
+            const map = mapControllerRef.current?.getMap();
+            if (!map) return null;
+            const b = map.getBounds();
+            return [b.getWest(), b.getSouth(), b.getEast(), b.getNorth()];
+          },
+        };
+        await tool.run(ctx);
+```
+
+- [ ] **Step 4: Add `duckdb` to the `handleRun` dependency array**
+
+In the `useCallback` deps for `handleRun` (lines 321-331), add `duckdb`:
+
+```ts
+  }, [
+    tool,
+    params,
+    engine,
+    layers,
+    appendLog,
+    addResultLayer,
+    runRemoteEngine,
+    mapControllerRef,
+    isParamVisible,
+    duckdb,
+  ]);
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
+git commit -m "feat(h3): provide DuckDB + viewport context to vector tools (#245)"
+```
+
+---
+
+## Task 7: Add H3 entries to the Processing menu
+
+**Files:**
+- Modify: `apps/geolibre-desktop/src/components/layout/TopToolbar.tsx:1206-1216`
+
+- [ ] **Step 1: Add an H3 group to the Vector submenu**
+
+In `TopToolbar.tsx`, after the "Select by location" item and before the closing `</DropdownMenuSubContent>` (after line 1215), add:
+
+```tsx
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel className="text-xs text-muted-foreground">
+                H3
+              </DropdownMenuLabel>
+              <DropdownMenuItem onSelect={() => setVectorToolOpen("h3-grid")}>
+                Create H3 grid
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onSelect={() => setVectorToolOpen("h3-bin-points")}
+              >
+                Bin points to H3
+              </DropdownMenuItem>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+git commit -m "feat(h3): add H3 tools to the Processing menu (#245)"
+```
+
+---
+
+## Task 8: Full verification gate
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the frontend test suite**
+
+Run: `npm run test:frontend`
+Expected: PASS, including `tests/h3-tools.test.ts` and `tests/processing.test.ts`.
+
+- [ ] **Step 2: Type-check / build the app**
+
+Run: `npm run build`
+Expected: build succeeds with no type errors (this is the real type-check gate per CLAUDE.md).
+
+- [ ] **Step 3: Pre-commit on changed files**
+
+Run: `pre-commit run --files packages/processing/src/h3-tools.ts packages/processing/src/types.ts packages/processing/src/vector-tools.ts packages/processing/src/index.ts apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts apps/geolibre-desktop/src/lib/duckdb-processing.ts apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx apps/geolibre-desktop/src/components/layout/TopToolbar.tsx tests/h3-tools.test.ts`
+Expected: all hooks pass (fix and re-run if any reformat).
+
+- [ ] **Step 4: Manual verification (desktop dev)**
+
+Run: `npm run tauri:dev`
+Then:
+1. Load a polygon layer. Processing → Vector → Create H3 grid. Try each source (Layer geometry, Layer extent, Map viewport), leave resolution blank once (confirm "Using suggested resolution N" log) and set it once. Confirm a hexagon layer is added and the map fits to it.
+2. Load a point layer. Processing → Vector → Bin points to H3. Run with Count, then with Sum/Mean on a numeric field. Confirm cells carry `count`/`value` (check the attribute table or feature popup).
+3. Confirm the first run logs the one-time `h3` extension fetch and that a deliberately too-fine resolution on a large area aborts with the cap message.
+
+- [ ] **Step 5: Final commit (if pre-commit reformatted anything)**
+
+```bash
+git add -A
+git commit -m "chore(h3): formatting from pre-commit (#245)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Three area sources (polyfill / extent / viewport) → Task 3 `createH3GridTool` `source` param + `run` branches. ✓
+- User-picked resolution 0-15 → `resolution` param + `resolveResolution`. ✓
+- Auto-suggested resolution → `suggestResolution` (Task 1) wired via blank-resolution path (Task 3). ✓
+- Bin/count points with sum/mean/min/max → `binPointsTool` + `buildBinSql` (Tasks 2-3). ✓
+- DuckDB capability injected into `ProcessingContext` (Approach A) → Task 3 types + Task 5 impl + Task 6 wiring. ✓
+- `INSTALL h3 FROM community; LOAD h3;` memoized → Task 4. ✓
+- Safety cap + clear errors → `H3_HARD_CAP` check + `NO_DUCKDB`/validation messages (Tasks 1, 3). ✓
+- Surfaced in UI (dialog auto-lists via `VECTOR_TOOLS`; menu entries) → Tasks 3, 7. ✓
+- Testing of pure builders + mocked-capability `run` → Tasks 1-3 tests. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows full content. ✓
+
+**Type consistency:** `DuckDbCapability` (`ensureExtensions`, `registerGeoJson`, `query`) and `DuckDbGeoJsonSource` (`sql`, `release`) match across types.ts (Task 3), the mock (Task 3 test), and the impl (Task 5). Tool ids `h3-grid` / `h3-bin-points` match between `h3-tools.ts`, `getH3Tool` tests, and the menu `setVectorToolOpen` calls. Geometry column name `geom` (from `ST_Read`) is assumed consistently in `buildGridFromSourceSql` / `buildBinSql` and produced by `registerGeoJson`'s `ST_Read(...)`. ✓
+
+**Known limitation (documented in spec):** `h3_cell_to_boundary_wkt` can emit antimeridian-spanning boundaries for cells crossing ±180°; rendered as-is in v1. Bin tool handles single-`POINT` geometries (MultiPoint excluded by the `ST_GeometryType = 'POINT'` filter).

--- a/docs/superpowers/specs/2026-06-12-h3-hexagonal-grid-design.md
+++ b/docs/superpowers/specs/2026-06-12-h3-hexagonal-grid-design.md
@@ -31,14 +31,21 @@ Out of scope: server/sidecar H3, raster H3, H3 compaction/parent-child hierarchy
 
 ```ts
 // packages/processing/src/types.ts
+export interface DuckDbGeoJsonSource {
+  sql: string; // FROM-able expression; geometry column is `geom`
+  release: () => Promise<void>;
+}
+
 export interface DuckDbCapability {
   ensureExtensions: (names: string[]) => Promise<void>;
-  runQuery: (sql: string) => Promise<Record<string, unknown>[]>;
+  registerGeoJson: (geojson: FeatureCollection) => Promise<DuckDbGeoJsonSource>;
+  query: (sql: string) => Promise<Record<string, unknown>[]>;
 }
 
 export interface ProcessingContext {
   // ...existing fields...
   duckdb?: DuckDbCapability;
+  viewportBounds?: () => [number, number, number, number] | null;
 }
 ```
 
@@ -79,11 +86,11 @@ FROM cells;
 WITH binned AS (
   SELECT h3_latlng_to_cell(lat, lng, :res) AS cell,
          count(*) AS count,
-         <AGG>(value) AS agg   -- omitted when op = count
+         <AGG>(value) AS value   -- omitted when op = count
   FROM points
   GROUP BY cell
 )
-SELECT h3_h3_to_string(cell) AS h3, count, agg,
+SELECT h3_h3_to_string(cell) AS h3, count, value,
        ST_AsGeoJSON(ST_GeomFromText(h3_cell_to_boundary_wkt(cell))) AS geojson
 FROM binned;
 ```
@@ -94,7 +101,7 @@ Each result row's `geojson` (a polygon geometry) is wrapped into a `Feature` wit
 ### Auto-suggested resolution + safety cap
 
 - Compute the target area (km²) from the chosen source. Using H3 average hexagon areas per resolution, pick the **finest** resolution whose estimated cell count stays under a soft target (~10,000). This fills the default; the user can override.
-- Before running, estimate cell count for the chosen resolution. If it exceeds a hard cap (~50,000), abort with a clear message rather than generating a runaway grid. `Bin Points to H3` is naturally bounded by the data but still validates resolution range.
+- Before running, estimate cell count for the chosen resolution. If it exceeds a hard cap (200,000), abort with a clear message rather than generating a runaway grid. `Bin Points to H3` is naturally bounded by the data but still validates resolution range.
 
 ### Antimeridian / edge cases
 
@@ -104,7 +111,7 @@ Each result row's `geojson` (a polygon geometry) is wrapped into a `Feature` wit
 
 1. User opens Processing → Vector Tools, selects an H3 tool, sets parameters.
 2. `VectorToolsDialog` builds `ProcessingContext` including `duckdb` capability and (for viewport) current map bounds.
-3. Tool `run(ctx)`: `await ctx.duckdb.ensureExtensions(['spatial','h3'])`, build WKT/SQL via helpers, `runQuery`, assemble `FeatureCollection`, `ctx.addResultLayer(name, fc)`.
+3. Tool `run(ctx)`: `await ctx.duckdb.ensureExtensions(['spatial','h3'])`, build WKT/SQL via helpers, `query` (and `registerGeoJson`/`release` for the polyfill and bin paths), assemble `FeatureCollection`, `ctx.addResultLayer(name, fc)`.
 4. `addResultLayer` → `addGeoJsonLayer` → store → `MapController.syncLayers` renders it; dialog fits to the new layer.
 
 ## Error handling

--- a/docs/superpowers/specs/2026-06-12-h3-hexagonal-grid-design.md
+++ b/docs/superpowers/specs/2026-06-12-h3-hexagonal-grid-design.md
@@ -124,6 +124,10 @@ In `tests/` (frontend `node --test`):
 
 Manual verification (desktop dev): load a polygon layer, create grid (each of the 3 sources); load a point layer, bin with count and with a sum field; confirm extension loads and grids render.
 
-## Risk to verify early
+## Feasibility — verified (2026-06-12)
 
-The installed `@duckdb/duckdb-wasm` version must have a matching `h3` community-extension WASM build. Confirm the version and a successful `LOAD h3` before building out the tools; if unavailable, fall back to pinning a compatible duckdb-wasm version or revisit Approach C (`h3-js`).
+- Installed `@duckdb/duckdb-wasm` is `1.33.1-dev45.0`, which wraps **DuckDB core v1.5.1**.
+- The `h3` community extension is published for v1.5.1 on all WASM platforms — `wasm_eh`, `wasm_mvp`, and `wasm_threads` (`https://community-extensions.duckdb.org/v1.5.1/<platform>/h3.duckdb_extension.wasm` → HTTP 200). `INSTALL h3 FROM community; LOAD h3;` is therefore valid in this app.
+- All required functions exist in the extension: `h3_polygon_wkt_to_cells(wkt, res)`, `h3_cell_to_boundary_wkt(cell)`, `h3_h3_to_string(cell)`, `h3_latlng_to_cell(lat, lng, res)`. Convenience variants `h3_latlng_to_cell_string` and `h3_string_to_h3` are also available.
+
+Residual risk: none blocking. The `LOAD h3` fetch (~MB, signature-checked) requires network on first use; surface failures in the dialog log and reset the memoized promise for retry.

--- a/docs/superpowers/specs/2026-06-12-h3-hexagonal-grid-design.md
+++ b/docs/superpowers/specs/2026-06-12-h3-hexagonal-grid-design.md
@@ -11,8 +11,9 @@ Let users generate H3 hexagonal grids and aggregate point data into H3 cells, en
 Two processing tools, group `"H3"`, defined in a new file `packages/processing/src/h3-tools.ts` and registered in the vector tools registry:
 
 1. **Create H3 Grid** — fill an area with H3 hexagons at a chosen resolution.
-   - Area source (`select`): `Layer geometry (polyfill)` | `Layer extent (bbox)` | `Map viewport`.
-   - Input layer (`layer`) — visible when source is polyfill or extent.
+   - Area source (`select`): `Layer geometry (polyfill)` | `Layer extent (bbox)` | `Map viewport` | `Manual bounding box`.
+   - Input layer (`layer`) — visible/required only when source is polyfill or extent (viewport and manual bbox need no layer).
+   - Manual bbox (`west`/`south`/`east`/`north` numbers) — visible when source is `bbox`; the dialog prefills them from the current viewport, editable before running.
    - Resolution (`number`, 0–15) — pre-filled with an auto-suggested value.
    - Output: polygon layer; each hexagon carries its `h3` index string as a property.
 2. **Bin Points to H3** — aggregate a point layer into H3 cells.
@@ -80,6 +81,7 @@ FROM cells;
   - `Layer geometry (polyfill)`: union of the input layer's features → WKT (`ST_Union_Agg` / `ST_AsText`). For multi-feature layers, dissolve to a single (multi)polygon first.
   - `Layer extent (bbox)`: build a rectangle WKT from the layer's bounds.
   - `Map viewport`: rectangle WKT from `map.getBounds()` provided by the dialog.
+  - `Manual bounding box`: rectangle WKT from user-entered west/south/east/north (validated: west < east, south < north).
 
 **Bin Points to H3:**
 ```sql

--- a/docs/superpowers/specs/2026-06-12-h3-hexagonal-grid-design.md
+++ b/docs/superpowers/specs/2026-06-12-h3-hexagonal-grid-design.md
@@ -1,0 +1,129 @@
+# H3 Hexagonal Grid — Design
+
+Issue: #245 — Add support for creating H3 Hexagonal Grid using the DuckDB `h3` community extension and the `spatial` extension.
+
+## Goal
+
+Let users generate H3 hexagonal grids and aggregate point data into H3 cells, entirely client-side via DuckDB-WASM, surfaced through the existing Processing → Vector Tools dialog. Output is a polygon GeoJSON layer added to the map via `addGeoJsonLayer`.
+
+## Scope
+
+Two processing tools, group `"H3"`, defined in a new file `packages/processing/src/h3-tools.ts` and registered in the vector tools registry:
+
+1. **Create H3 Grid** — fill an area with H3 hexagons at a chosen resolution.
+   - Area source (`select`): `Layer geometry (polyfill)` | `Layer extent (bbox)` | `Map viewport`.
+   - Input layer (`layer`) — visible when source is polyfill or extent.
+   - Resolution (`number`, 0–15) — pre-filled with an auto-suggested value.
+   - Output: polygon layer; each hexagon carries its `h3` index string as a property.
+2. **Bin Points to H3** — aggregate a point layer into H3 cells.
+   - Input point layer (`layer`).
+   - Resolution (`number`, 0–15) — auto-suggested.
+   - Aggregate field (`field`, optional) + aggregate op (`select`: `count` | `sum` | `mean` | `min` | `max`). `count` needs no field.
+   - Output: polygon hexagon layer with properties `h3`, `count`, and the aggregate value (when a field is chosen).
+
+Out of scope: server/sidecar H3, raster H3, H3 compaction/parent-child hierarchy tools, persisting H3 indexes back to source layers.
+
+## Architecture
+
+### Integration: inject a DuckDB capability into `ProcessingContext` (Approach A)
+
+`@geolibre/processing` stays framework-agnostic and must not import `@duckdb/duckdb-wasm`. DuckDB-WASM lives in `apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts`. We add an optional capability to the context so processing tools can run SQL without the package depending on DuckDB:
+
+```ts
+// packages/processing/src/types.ts
+export interface DuckDbCapability {
+  ensureExtensions: (names: string[]) => Promise<void>;
+  runQuery: (sql: string) => Promise<Record<string, unknown>[]>;
+}
+
+export interface ProcessingContext {
+  // ...existing fields...
+  duckdb?: DuckDbCapability;
+}
+```
+
+- The H3 tools call `ctx.duckdb`. If it is absent (e.g. headless/test without wiring), the tool throws a clear error: `"This tool requires DuckDB-WASM, which is unavailable in this environment."`.
+- The desktop app implements `DuckDbCapability` over the existing loader (memoized DB + connection) and passes it into the context built in `VectorToolsDialog.tsx`.
+
+### Extension loading
+
+Add `ensureH3Extension(connection, beforeLoad?)` in `duckdb-vector-loader.ts`, mirroring `ensureSpatialExtension`:
+
+```ts
+await connection.query("INSTALL h3 FROM community");
+await connection.query("LOAD h3");
+```
+
+Memoized via a module-level promise, cleared on error for retry (same pattern as spatial). `ensureExtensions(['spatial','h3'])` calls `ensureSpatialExtension` then `ensureH3Extension`.
+
+### H3 engine (SQL)
+
+Helpers (pure, unit-tested) build SQL strings; the DuckDB capability executes them.
+
+**Create H3 Grid (polyfill):**
+```sql
+WITH cells AS (
+  SELECT unnest(h3_polygon_wkt_to_cells(:wkt, :res)) AS cell
+)
+SELECT h3_h3_to_string(cell) AS h3,
+       ST_AsGeoJSON(ST_GeomFromText(h3_cell_to_boundary_wkt(cell))) AS geojson
+FROM cells;
+```
+- Area WKT:
+  - `Layer geometry (polyfill)`: union of the input layer's features → WKT (`ST_Union_Agg` / `ST_AsText`). For multi-feature layers, dissolve to a single (multi)polygon first.
+  - `Layer extent (bbox)`: build a rectangle WKT from the layer's bounds.
+  - `Map viewport`: rectangle WKT from `map.getBounds()` provided by the dialog.
+
+**Bin Points to H3:**
+```sql
+WITH binned AS (
+  SELECT h3_latlng_to_cell(lat, lng, :res) AS cell,
+         count(*) AS count,
+         <AGG>(value) AS agg   -- omitted when op = count
+  FROM points
+  GROUP BY cell
+)
+SELECT h3_h3_to_string(cell) AS h3, count, agg,
+       ST_AsGeoJSON(ST_GeomFromText(h3_cell_to_boundary_wkt(cell))) AS geojson
+FROM binned;
+```
+Points are loaded into DuckDB from the layer's GeoJSON (register as a virtual file / table; reuse the existing GeoJSON-into-DuckDB path used by the vector loader where possible). Latitude/longitude come from each point geometry.
+
+Each result row's `geojson` (a polygon geometry) is wrapped into a `Feature` with `{ h3, count?, agg? }` properties; rows are collected into a `FeatureCollection` and passed to `ctx.addResultLayer(name, fc)`.
+
+### Auto-suggested resolution + safety cap
+
+- Compute the target area (km²) from the chosen source. Using H3 average hexagon areas per resolution, pick the **finest** resolution whose estimated cell count stays under a soft target (~10,000). This fills the default; the user can override.
+- Before running, estimate cell count for the chosen resolution. If it exceeds a hard cap (~50,000), abort with a clear message rather than generating a runaway grid. `Bin Points to H3` is naturally bounded by the data but still validates resolution range.
+
+### Antimeridian / edge cases
+
+`h3_cell_to_boundary_wkt` can produce boundaries spanning the antimeridian for cells crossing ±180°. This is a known H3 edge case; for v1 we render the WKT as returned and note the limitation. Hexagons at the poles/antimeridian may render distorted — acceptable for v1.
+
+## Data flow
+
+1. User opens Processing → Vector Tools, selects an H3 tool, sets parameters.
+2. `VectorToolsDialog` builds `ProcessingContext` including `duckdb` capability and (for viewport) current map bounds.
+3. Tool `run(ctx)`: `await ctx.duckdb.ensureExtensions(['spatial','h3'])`, build WKT/SQL via helpers, `runQuery`, assemble `FeatureCollection`, `ctx.addResultLayer(name, fc)`.
+4. `addResultLayer` → `addGeoJsonLayer` → store → `MapController.syncLayers` renders it; dialog fits to the new layer.
+
+## Error handling
+
+- Missing `ctx.duckdb` → clear "requires DuckDB-WASM" error.
+- Extension `LOAD` failure (version mismatch / network) → surface the DuckDB error in the dialog log; reset the memoized promise so a retry can succeed.
+- Empty area / no points / zero cells → log "No features produced" (existing `addResultLayer` already guards empty FCs).
+- Resolution out of range or over the hard cap → validation error before query.
+
+## Testing
+
+In `tests/` (frontend `node --test`):
+- WKT builders: bbox → rectangle WKT; viewport bounds → WKT.
+- SQL builders for both tools (correct function names, parameter substitution, agg-op branching, `count` with no field).
+- Auto-resolution math: known area → expected resolution; monotonicity; hard-cap enforcement.
+- DuckDB capability is mocked (returns canned rows) to test the FeatureCollection assembly without DuckDB.
+
+Manual verification (desktop dev): load a polygon layer, create grid (each of the 3 sources); load a point layer, bin with count and with a sum field; confirm extension loads and grids render.
+
+## Risk to verify early
+
+The installed `@duckdb/duckdb-wasm` version must have a matching `h3` community-extension WASM build. Confirm the version and a successful `LOAD h3` before building out the tools; if unavailable, fall back to pinning a compatible duckdb-wasm version or revisit Approach C (`h3-js`).

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -46,7 +46,9 @@ export type VectorToolKind =
   | "union"
   | "spatial-join"
   | "select-by-value"
-  | "select-by-location";
+  | "select-by-location"
+  | "h3-grid"
+  | "h3-bin-points";
 
 /**
  * Identifiers of the raster processing tools. Kept in sync by hand with the

--- a/packages/processing/src/h3-tools.ts
+++ b/packages/processing/src/h3-tools.ts
@@ -1,0 +1,44 @@
+/** Average area (km^2) of an H3 cell at each resolution 0..15 (official values). */
+export const H3_AVG_AREA_KM2: number[] = [
+  4_357_449.416078381, 609_788.441794133, 86_801.780398997, 12_393.434655088,
+  1_770.347654491, 252.903858182, 36.129062164, 5.16129336, 0.737327598,
+  0.105332513, 0.015047502, 0.002149643, 0.000307092, 0.00004387, 0.000006267,
+  0.000000895,
+];
+
+/** Soft target used when auto-suggesting a resolution. */
+export const H3_TARGET_CELLS = 10_000;
+/** Finest resolution the auto-suggester will pick. */
+export const H3_MAX_SUGGESTED_RES = 12;
+/** Hard ceiling: a grid larger than this aborts rather than running away. */
+export const H3_HARD_CAP = 200_000;
+
+const KM_PER_DEG_LAT = 110.574;
+const KM_PER_DEG_LON_EQ = 111.32;
+
+/** Rough planar area (km^2) of a [west, south, east, north] bbox. */
+export function bboxAreaKm2(bbox: [number, number, number, number]): number {
+  const [w, s, e, n] = bbox;
+  const midLat = (s + n) / 2;
+  const kmPerDegLon = KM_PER_DEG_LON_EQ * Math.cos((midLat * Math.PI) / 180);
+  const width = Math.abs(e - w) * kmPerDegLon;
+  const height = Math.abs(n - s) * KM_PER_DEG_LAT;
+  return Math.max(width * height, 0);
+}
+
+/** Estimated number of H3 cells covering `areaKm2` at `res`. */
+export function estimateCellCount(areaKm2: number, res: number): number {
+  return areaKm2 / H3_AVG_AREA_KM2[res];
+}
+
+/** Finest resolution whose estimated cell count stays <= the target. */
+export function suggestResolution(
+  areaKm2: number,
+  targetCells = H3_TARGET_CELLS,
+  maxRes = H3_MAX_SUGGESTED_RES,
+): number {
+  for (let res = maxRes; res >= 0; res -= 1) {
+    if (estimateCellCount(areaKm2, res) <= targetCells) return res;
+  }
+  return 0;
+}

--- a/packages/processing/src/h3-tools.ts
+++ b/packages/processing/src/h3-tools.ts
@@ -177,6 +177,36 @@ function getLayer(
   return ctx.layers.find((l) => l.id === id);
 }
 
+/** Read a numeric parameter, returning NaN when missing or non-numeric. */
+function numberParam(ctx: ProcessingContext, id: string): number {
+  const raw = ctx.parameters[id];
+  if (raw === undefined || raw === null || raw === "") return NaN;
+  return typeof raw === "string" ? Number(raw) : (raw as number);
+}
+
+/**
+ * Read and validate the manual [west, south, east, north] bbox parameters.
+ * Logs a clear error and returns null when any value is missing or the box is
+ * degenerate (west >= east or south >= north).
+ */
+function bboxFromParams(
+  ctx: ProcessingContext,
+): [number, number, number, number] | null {
+  const west = numberParam(ctx, "west");
+  const south = numberParam(ctx, "south");
+  const east = numberParam(ctx, "east");
+  const north = numberParam(ctx, "north");
+  if ([west, south, east, north].some((n) => !Number.isFinite(n))) {
+    ctx.log("Error: enter numeric west, south, east, and north values");
+    return null;
+  }
+  if (west >= east || south >= north) {
+    ctx.log("Error: bounding box must have west < east and south < north");
+    return null;
+  }
+  return [west, south, east, north];
+}
+
 /** Parse the `resolution` param, or auto-suggest from area. Logs + returns null on bad input. */
 function resolveResolution(
   ctx: ProcessingContext,
@@ -200,7 +230,7 @@ export const createH3GridTool: ProcessingAlgorithm = {
   id: "h3-grid",
   name: "Create H3 grid",
   description:
-    "Fill an area with H3 hexagons (DuckDB h3 extension). Source: a layer's geometry, a layer's extent, or the current map view.",
+    "Fill an area with H3 hexagons (DuckDB h3 extension). Source: a layer's geometry, a layer's extent, the current map view, or a manual bounding box.",
   group: "H3",
   parameters: [
     {
@@ -212,6 +242,7 @@ export const createH3GridTool: ProcessingAlgorithm = {
         { value: "polyfill", label: "Layer geometry (polyfill)" },
         { value: "extent", label: "Layer extent (bbox)" },
         { value: "viewport", label: "Map viewport" },
+        { value: "bbox", label: "Manual bounding box" },
       ],
     },
     {
@@ -220,8 +251,46 @@ export const createH3GridTool: ProcessingAlgorithm = {
       type: "layer",
       required: true,
       // No geometry filter: "extent" fills any layer's bounding box, while
-      // "polyfill" needs polygons (validated at run time below).
+      // "polyfill" needs polygons (validated at run time below). The layer is
+      // only required for the layer-based sources, so it stays hidden (and
+      // skips required validation) for the viewport and bbox sources.
       visibleWhen: { param: "source", in: ["polyfill", "extent"] },
+    },
+    {
+      id: "west",
+      label: "West (min lon)",
+      type: "number",
+      required: true,
+      min: -180,
+      max: 180,
+      visibleWhen: { param: "source", in: ["bbox"] },
+    },
+    {
+      id: "south",
+      label: "South (min lat)",
+      type: "number",
+      required: true,
+      min: -90,
+      max: 90,
+      visibleWhen: { param: "source", in: ["bbox"] },
+    },
+    {
+      id: "east",
+      label: "East (max lon)",
+      type: "number",
+      required: true,
+      min: -180,
+      max: 180,
+      visibleWhen: { param: "source", in: ["bbox"] },
+    },
+    {
+      id: "north",
+      label: "North (max lat)",
+      type: "number",
+      required: true,
+      min: -90,
+      max: 90,
+      visibleWhen: { param: "source", in: ["bbox"] },
     },
     {
       id: "resolution",
@@ -246,6 +315,11 @@ export const createH3GridTool: ProcessingAlgorithm = {
         ctx.log("Error: map viewport is unavailable");
         return;
       }
+      areaKm2 = bboxAreaKm2(bounds);
+      wkt = bboxToWktPolygon(bounds);
+    } else if (source === "bbox") {
+      const bounds = bboxFromParams(ctx);
+      if (!bounds) return;
       areaKm2 = bboxAreaKm2(bounds);
       wkt = bboxToWktPolygon(bounds);
     } else {

--- a/packages/processing/src/h3-tools.ts
+++ b/packages/processing/src/h3-tools.ts
@@ -206,7 +206,8 @@ export const createH3GridTool: ProcessingAlgorithm = {
       label: "Input layer",
       type: "layer",
       required: true,
-      geometryFilter: ["polygon"],
+      // No geometry filter: "extent" fills any layer's bounding box, while
+      // "polyfill" needs polygons (validated at run time below).
       visibleWhen: { param: "source", in: ["polyfill", "extent"] },
     },
     {
@@ -239,6 +240,19 @@ export const createH3GridTool: ProcessingAlgorithm = {
       if (!layer?.geojson?.features?.length) {
         ctx.log('Error: parameter "layer" has no GeoJSON features');
         return;
+      }
+      if (source === "polyfill") {
+        const hasPolygon = layer.geojson.features.some(
+          (f) =>
+            f.geometry?.type === "Polygon" ||
+            f.geometry?.type === "MultiPolygon",
+        );
+        if (!hasPolygon) {
+          ctx.log(
+            'Error: polyfill needs a polygon layer; use the "Layer extent" source for point or line layers',
+          );
+          return;
+        }
       }
       inputGeojson = layer.geojson;
       const bb = bbox(layer.geojson) as [number, number, number, number];

--- a/packages/processing/src/h3-tools.ts
+++ b/packages/processing/src/h3-tools.ts
@@ -38,7 +38,13 @@ export function bboxAreaKm2(bbox: [number, number, number, number]): number {
 
 /** Estimated number of H3 cells covering `areaKm2` at `res`. */
 export function estimateCellCount(areaKm2: number, res: number): number {
-  return areaKm2 / H3_AVG_AREA_KM2[res];
+  const cellArea = H3_AVG_AREA_KM2[res];
+  // Fail safe for an out-of-range resolution: return Infinity so a downstream
+  // cap check (`estimate > H3_HARD_CAP`) trips rather than silently passing on a
+  // `NaN` comparison. Internal callers validate the range first via
+  // `resolveResolution`; this guards external callers.
+  if (cellArea === undefined) return Number.POSITIVE_INFINITY;
+  return areaKm2 / cellArea;
 }
 
 /** Finest resolution whose estimated cell count stays <= the target. */
@@ -86,7 +92,7 @@ export function buildGridFromWktSql(wkt: string, res: number): string {
  */
 export function buildGridFromSourceSql(sourceSql: string, res: number): string {
   return (
-    `WITH merged AS (SELECT ST_AsText(ST_Union_Agg(geom)) AS wkt FROM ${sourceSql}), ` +
+    `WITH merged AS (SELECT ST_AsText(ST_Union_Agg(geom)) AS wkt FROM ${sourceSql} WHERE geom IS NOT NULL), ` +
     `cells AS (SELECT unnest(h3_polygon_wkt_to_cells((SELECT wkt FROM merged), ${res})) AS cell) ` +
     GRID_SELECT
   );
@@ -132,7 +138,14 @@ export function rowsToFeatureCollection(
   for (const row of rows) {
     const raw = row.geojson;
     if (typeof raw !== "string") continue;
-    const geometry = JSON.parse(raw) as Geometry;
+    let geometry: Geometry;
+    try {
+      geometry = JSON.parse(raw) as Geometry;
+    } catch {
+      // ST_AsGeoJSON should always emit valid JSON; skip a row rather than
+      // throwing out of this exported pure helper if it ever does not.
+      continue;
+    }
     const properties: Record<string, unknown> = { h3: row.h3 };
     if (row.count !== undefined && row.count !== null) {
       properties.count = Number(row.count);

--- a/packages/processing/src/h3-tools.ts
+++ b/packages/processing/src/h3-tools.ts
@@ -146,10 +146,10 @@ export function buildBinSql(
   // MULTIPOINT, so MultiPoint features are binned by their centroid rather than
   // being silently dropped by an `ST_X`/`ST_Y`-on-a-point-only filter.
   return (
-    `WITH pts AS (SELECT ST_Centroid(geom) AS pt FROM ${sourceSql} ` +
-    `WHERE geom IS NOT NULL AND ST_GeometryType(geom) IN ('POINT', 'MULTIPOINT')` +
+    `WITH pts AS (SELECT ST_Centroid(geom) AS pt` +
     (field ? `, ${sqlIdent(field)}` : "") +
-    `), ` +
+    ` FROM ${sourceSql} ` +
+    `WHERE geom IS NOT NULL AND ST_GeometryType(geom) IN ('POINT', 'MULTIPOINT')), ` +
     `binned AS (SELECT h3_latlng_to_cell(ST_Y(pt), ST_X(pt), ${res}) AS cell, ` +
     `count(*) AS count${aggSelect} FROM pts GROUP BY cell) ` +
     `SELECT h3_h3_to_string(cell) AS h3, count${aggOut}, ` +
@@ -173,7 +173,7 @@ export function rowsToFeatureCollection(
       // throwing out of this exported pure helper if it ever does not.
       continue;
     }
-    const properties: Record<string, unknown> = { h3: row.h3 };
+    const properties: Record<string, unknown> = { h3: String(row.h3) };
     if (row.count !== undefined && row.count !== null) {
       properties.count = Number(row.count);
     }
@@ -340,6 +340,15 @@ export const createH3GridTool: ProcessingAlgorithm = {
       const bounds = ctx.viewportBounds?.();
       if (!bounds) {
         ctx.log("Error: map viewport is unavailable");
+        return;
+      }
+      if (bounds[0] >= bounds[2]) {
+        // west >= east means the viewport wraps the antimeridian; the rectangle
+        // WKT would self-cross and fill the wrong (340deg) span. Bail with a
+        // clear message rather than producing wrong cells.
+        ctx.log(
+          "Error: the map view crosses the antimeridian; pan so it doesn't wrap +/-180, or use a manual bounding box",
+        );
         return;
       }
       areaKm2 = bboxAreaKm2(bounds);

--- a/packages/processing/src/h3-tools.ts
+++ b/packages/processing/src/h3-tools.ts
@@ -1,4 +1,12 @@
 import type { FeatureCollection, Geometry } from "geojson";
+import bbox from "@turf/bbox";
+import type { GeoLibreLayer } from "@geolibre/core";
+import type {
+  DuckDbCapability,
+  DuckDbGeoJsonSource,
+  ProcessingAlgorithm,
+  ProcessingContext,
+} from "./types";
 
 /** Average area (km^2) of an H3 cell at each resolution 0..15 (official values). */
 export const H3_AVG_AREA_KM2: number[] = [
@@ -135,4 +143,220 @@ export function rowsToFeatureCollection(
     features.push({ type: "Feature" as const, geometry, properties });
   }
   return { type: "FeatureCollection", features };
+}
+
+const NO_DUCKDB =
+  "This tool requires DuckDB-WASM, which is unavailable in this environment.";
+
+function requireDuckDb(ctx: ProcessingContext): DuckDbCapability {
+  if (!ctx.duckdb) throw new Error(NO_DUCKDB);
+  return ctx.duckdb;
+}
+
+function getLayer(
+  ctx: ProcessingContext,
+  paramId = "layer",
+): GeoLibreLayer | undefined {
+  const id = ctx.parameters[paramId] as string | undefined;
+  return ctx.layers.find((l) => l.id === id);
+}
+
+/** Parse the `resolution` param, or auto-suggest from area. Logs + returns null on bad input. */
+function resolveResolution(
+  ctx: ProcessingContext,
+  areaKm2: number,
+): number | null {
+  const raw = ctx.parameters.resolution;
+  if (raw === undefined || raw === null || raw === "") {
+    const suggested = suggestResolution(areaKm2);
+    ctx.log(`Using suggested resolution ${suggested}`);
+    return suggested;
+  }
+  const res = typeof raw === "string" ? Number(raw) : (raw as number);
+  if (!Number.isInteger(res) || res < 0 || res > 15) {
+    ctx.log("Error: resolution must be an integer from 0 to 15");
+    return null;
+  }
+  return res;
+}
+
+export const createH3GridTool: ProcessingAlgorithm = {
+  id: "h3-grid",
+  name: "Create H3 grid",
+  description:
+    "Fill an area with H3 hexagons (DuckDB h3 extension). Source: a layer's geometry, a layer's extent, or the current map view.",
+  group: "H3",
+  parameters: [
+    {
+      id: "source",
+      label: "Area source",
+      type: "select",
+      default: "polyfill",
+      options: [
+        { value: "polyfill", label: "Layer geometry (polyfill)" },
+        { value: "extent", label: "Layer extent (bbox)" },
+        { value: "viewport", label: "Map viewport" },
+      ],
+    },
+    {
+      id: "layer",
+      label: "Input layer",
+      type: "layer",
+      required: true,
+      geometryFilter: ["polygon"],
+      visibleWhen: { param: "source", in: ["polyfill", "extent"] },
+    },
+    {
+      id: "resolution",
+      label: "Resolution (0-15)",
+      type: "number",
+      min: 0,
+      max: 15,
+      step: 1,
+      description: "Leave blank to auto-pick from the area.",
+    },
+  ],
+  run: async (ctx) => {
+    const duckdb = requireDuckDb(ctx);
+    const source = (ctx.parameters.source as string) || "polyfill";
+
+    let areaKm2: number;
+    let wkt: string | null = null;
+    if (source === "viewport") {
+      const bounds = ctx.viewportBounds?.();
+      if (!bounds) {
+        ctx.log("Error: map viewport is unavailable");
+        return;
+      }
+      areaKm2 = bboxAreaKm2(bounds);
+      wkt = bboxToWktPolygon(bounds);
+    } else {
+      const layer = getLayer(ctx, "layer");
+      if (!layer?.geojson?.features?.length) {
+        ctx.log('Error: parameter "layer" has no GeoJSON features');
+        return;
+      }
+      const bb = bbox(layer.geojson) as [number, number, number, number];
+      areaKm2 = bboxAreaKm2(bb);
+      if (source === "extent") wkt = bboxToWktPolygon(bb);
+    }
+
+    const res = resolveResolution(ctx, areaKm2);
+    if (res === null) return;
+
+    const estimate = estimateCellCount(areaKm2, res);
+    if (estimate > H3_HARD_CAP) {
+      ctx.log(
+        `Error: resolution ${res} would generate about ${Math.round(
+          estimate,
+        ).toLocaleString()} cells (cap ${H3_HARD_CAP.toLocaleString()}). Choose a coarser resolution.`,
+      );
+      return;
+    }
+
+    await duckdb.ensureExtensions(["spatial", "h3"]);
+    let registered: DuckDbGeoJsonSource | null = null;
+    try {
+      let sql: string;
+      if (wkt) {
+        sql = buildGridFromWktSql(wkt, res);
+      } else {
+        const layer = getLayer(ctx, "layer");
+        registered = await duckdb.registerGeoJson(layer!.geojson!);
+        sql = buildGridFromSourceSql(registered.sql, res);
+      }
+      const rows = await duckdb.query(sql);
+      const fc = rowsToFeatureCollection(rows);
+      ctx.log(`Created ${fc.features.length} H3 cell(s) at resolution ${res}`);
+      ctx.addResultLayer?.(`H3 grid (res ${res})`, fc);
+    } finally {
+      await registered?.release();
+    }
+  },
+};
+
+export const binPointsTool: ProcessingAlgorithm = {
+  id: "h3-bin-points",
+  name: "Bin points to H3",
+  description:
+    "Aggregate a point layer into H3 cells (count, or sum/mean/min/max of a numeric field).",
+  group: "H3",
+  parameters: [
+    {
+      id: "layer",
+      label: "Input point layer",
+      type: "layer",
+      required: true,
+      geometryFilter: ["point"],
+    },
+    {
+      id: "aggOp",
+      label: "Aggregate",
+      type: "select",
+      default: "count",
+      options: [
+        { value: "count", label: "Count" },
+        { value: "sum", label: "Sum" },
+        { value: "mean", label: "Mean" },
+        { value: "min", label: "Min" },
+        { value: "max", label: "Max" },
+      ],
+    },
+    {
+      id: "field",
+      label: "Field",
+      type: "field",
+      fieldSource: "layer",
+      required: true,
+      visibleWhen: { param: "aggOp", notIn: ["count"] },
+      description: "Numeric field to aggregate.",
+    },
+    {
+      id: "resolution",
+      label: "Resolution (0-15)",
+      type: "number",
+      min: 0,
+      max: 15,
+      step: 1,
+      description: "Leave blank to auto-pick from the area.",
+    },
+  ],
+  run: async (ctx) => {
+    const duckdb = requireDuckDb(ctx);
+    const layer = getLayer(ctx, "layer");
+    if (!layer?.geojson?.features?.length) {
+      ctx.log('Error: parameter "layer" has no GeoJSON features');
+      return;
+    }
+    const op = (ctx.parameters.aggOp as string) || "count";
+    const field = ctx.parameters.field as string | undefined;
+    if (op !== "count" && !field) {
+      ctx.log(`Error: select a numeric field to ${op}`);
+      return;
+    }
+
+    const bb = bbox(layer.geojson) as [number, number, number, number];
+    const res = resolveResolution(ctx, bboxAreaKm2(bb));
+    if (res === null) return;
+
+    await duckdb.ensureExtensions(["spatial", "h3"]);
+    const registered = await duckdb.registerGeoJson(layer.geojson);
+    try {
+      const sql = buildBinSql(registered.sql, res, op, field);
+      const rows = await duckdb.query(sql);
+      const fc = rowsToFeatureCollection(rows);
+      ctx.log(
+        `Binned points into ${fc.features.length} H3 cell(s) at resolution ${res}`,
+      );
+      ctx.addResultLayer?.(`H3 bins (res ${res})`, fc);
+    } finally {
+      await registered.release();
+    }
+  },
+};
+
+export const H3_TOOLS: ProcessingAlgorithm[] = [createH3GridTool, binPointsTool];
+
+export function getH3Tool(id: string): ProcessingAlgorithm | undefined {
+  return H3_TOOLS.find((tool) => tool.id === id);
 }

--- a/packages/processing/src/h3-tools.ts
+++ b/packages/processing/src/h3-tools.ts
@@ -153,6 +153,9 @@ function requireDuckDb(ctx: ProcessingContext): DuckDbCapability {
   return ctx.duckdb;
 }
 
+// Mirrors the same helper in vector-tools.ts and registry.ts; intentionally
+// duplicated because vector-tools.ts imports from this file, so importing the
+// other direction would create a cycle. Keep the three copies in sync.
 function getLayer(
   ctx: ProcessingContext,
   paramId = "layer",
@@ -222,6 +225,7 @@ export const createH3GridTool: ProcessingAlgorithm = {
 
     let areaKm2: number;
     let wkt: string | null = null;
+    let inputGeojson: FeatureCollection | null = null;
     if (source === "viewport") {
       const bounds = ctx.viewportBounds?.();
       if (!bounds) {
@@ -236,6 +240,7 @@ export const createH3GridTool: ProcessingAlgorithm = {
         ctx.log('Error: parameter "layer" has no GeoJSON features');
         return;
       }
+      inputGeojson = layer.geojson;
       const bb = bbox(layer.geojson) as [number, number, number, number];
       areaKm2 = bboxAreaKm2(bb);
       if (source === "extent") wkt = bboxToWktPolygon(bb);
@@ -261,8 +266,7 @@ export const createH3GridTool: ProcessingAlgorithm = {
       if (wkt) {
         sql = buildGridFromWktSql(wkt, res);
       } else {
-        const layer = getLayer(ctx, "layer");
-        registered = await duckdb.registerGeoJson(layer!.geojson!);
+        registered = await duckdb.registerGeoJson(inputGeojson!); // non-null: polyfill path only runs after the layer guard above set inputGeojson
         sql = buildGridFromSourceSql(registered.sql, res);
       }
       const rows = await duckdb.query(sql);

--- a/packages/processing/src/h3-tools.ts
+++ b/packages/processing/src/h3-tools.ts
@@ -31,7 +31,12 @@ export function bboxAreaKm2(bbox: [number, number, number, number]): number {
   const [w, s, e, n] = bbox;
   const midLat = (s + n) / 2;
   const kmPerDegLon = KM_PER_DEG_LON_EQ * Math.cos((midLat * Math.PI) / 180);
-  const width = Math.abs(e - w) * kmPerDegLon;
+  // Handle a bbox that crosses the antimeridian (west > east, e.g. a viewport
+  // returning west=170, east=-170): wrap the longitude span into [0, 360) so the
+  // area isn't inflated ~17x and the hard-cap guard doesn't falsely trip.
+  let lonSpan = e - w;
+  if (lonSpan < 0) lonSpan += 360;
+  const width = lonSpan * kmPerDegLon;
   const height = Math.abs(n - s) * KM_PER_DEG_LAT;
   return Math.max(width * height, 0);
 }
@@ -91,14 +96,31 @@ export function buildGridFromWktSql(wkt: string, res: number): string {
  * FROM-able expression whose geometry column is `geom` (DuckDB `ST_Read`).
  */
 export function buildGridFromSourceSql(sourceSql: string, res: number): string {
+  // Union only polygonal geometries: a mixed layer would otherwise aggregate to
+  // a GEOMETRYCOLLECTION that `h3_polygon_wkt_to_cells` rejects. The `cells` CTE
+  // filters a NULL union result (no polygons survived) so a NULL WKT never
+  // reaches the h3 function, which can throw on NULL.
   return (
-    `WITH merged AS (SELECT ST_AsText(ST_Union_Agg(geom)) AS wkt FROM ${sourceSql} WHERE geom IS NOT NULL), ` +
-    `cells AS (SELECT unnest(h3_polygon_wkt_to_cells((SELECT wkt FROM merged), ${res})) AS cell) ` +
+    `WITH merged AS (SELECT ST_AsText(ST_Union_Agg(geom)) AS wkt FROM ${sourceSql} ` +
+    `WHERE geom IS NOT NULL AND ST_GeometryType(geom) IN ('POLYGON', 'MULTIPOLYGON')), ` +
+    `cells AS (SELECT unnest(h3_polygon_wkt_to_cells(wkt, ${res})) AS cell FROM merged WHERE wkt IS NOT NULL) ` +
     GRID_SELECT
   );
 }
 
-const AGG_FN: Record<string, string> = {
+/** Supported point-binning aggregate operations. */
+export type H3AggOp = "count" | "sum" | "mean" | "min" | "max";
+
+/** Valid aggregate operations, used to validate the `aggOp` parameter. */
+export const H3_AGG_OPS: readonly H3AggOp[] = [
+  "count",
+  "sum",
+  "mean",
+  "min",
+  "max",
+];
+
+const AGG_FN: Record<Exclude<H3AggOp, "count">, string> = {
   sum: "sum",
   mean: "avg",
   min: "min",
@@ -108,22 +130,27 @@ const AGG_FN: Record<string, string> = {
 /**
  * Aggregate point geometry from `sourceSql` (geometry column `geom`) into H3
  * cells. `op` is one of count/sum/mean/min/max; a field is required for all but
- * count.
+ * count. Both `POINT` and `MULTIPOINT` geometries are binned (by centroid).
  */
 export function buildBinSql(
   sourceSql: string,
   res: number,
-  op: string,
+  op: H3AggOp,
   field?: string,
 ): string {
-  const fn = AGG_FN[op];
+  const fn = op === "count" ? undefined : AGG_FN[op];
   const aggSelect =
     fn && field ? `, ${fn}(CAST(${sqlIdent(field)} AS DOUBLE)) AS value` : "";
   const aggOut = fn && field ? ", value" : "";
+  // ST_Centroid handles both POINT (centroid is the point itself) and
+  // MULTIPOINT, so MultiPoint features are binned by their centroid rather than
+  // being silently dropped by an `ST_X`/`ST_Y`-on-a-point-only filter.
   return (
-    `WITH pts AS (SELECT * FROM ${sourceSql} ` +
-    `WHERE geom IS NOT NULL AND ST_GeometryType(geom) = 'POINT'), ` +
-    `binned AS (SELECT h3_latlng_to_cell(ST_Y(geom), ST_X(geom), ${res}) AS cell, ` +
+    `WITH pts AS (SELECT ST_Centroid(geom) AS pt FROM ${sourceSql} ` +
+    `WHERE geom IS NOT NULL AND ST_GeometryType(geom) IN ('POINT', 'MULTIPOINT')` +
+    (field ? `, ${sqlIdent(field)}` : "") +
+    `), ` +
+    `binned AS (SELECT h3_latlng_to_cell(ST_Y(pt), ST_X(pt), ${res}) AS cell, ` +
     `count(*) AS count${aggSelect} FROM pts GROUP BY cell) ` +
     `SELECT h3_h3_to_string(cell) AS h3, count${aggOut}, ` +
     `ST_AsGeoJSON(ST_GeomFromText(h3_cell_to_boundary_wkt(cell))) AS geojson FROM binned`
@@ -372,6 +399,12 @@ export const createH3GridTool: ProcessingAlgorithm = {
       }
       const rows = await duckdb.query(sql);
       const fc = rowsToFeatureCollection(rows);
+      if (fc.features.length === 0) {
+        ctx.log(
+          `No H3 cells were produced at resolution ${res}. Try a coarser resolution or a larger area.`,
+        );
+        return;
+      }
       ctx.log(`Created ${fc.features.length} H3 cell(s) at resolution ${res}`);
       ctx.addResultLayer?.(`H3 grid (res ${res})`, fc);
     } finally {
@@ -434,6 +467,10 @@ export const binPointsTool: ProcessingAlgorithm = {
       return;
     }
     const op = (ctx.parameters.aggOp as string) || "count";
+    if (!H3_AGG_OPS.includes(op as H3AggOp)) {
+      ctx.log(`Error: unknown aggregate "${op}"`);
+      return;
+    }
     const field = ctx.parameters.field as string | undefined;
     if (op !== "count" && !field) {
       ctx.log(`Error: select a numeric field to ${op}`);
@@ -447,9 +484,15 @@ export const binPointsTool: ProcessingAlgorithm = {
     await duckdb.ensureExtensions(["spatial", "h3"]);
     const registered = await duckdb.registerGeoJson(layer.geojson);
     try {
-      const sql = buildBinSql(registered.sql, res, op, field);
+      const sql = buildBinSql(registered.sql, res, op as H3AggOp, field);
       const rows = await duckdb.query(sql);
       const fc = rowsToFeatureCollection(rows);
+      if (fc.features.length === 0) {
+        ctx.log(
+          `No points fell into H3 cells at resolution ${res}. Check the layer has point geometries.`,
+        );
+        return;
+      }
       ctx.log(
         `Binned points into ${fc.features.length} H3 cell(s) at resolution ${res}`,
       );

--- a/packages/processing/src/h3-tools.ts
+++ b/packages/processing/src/h3-tools.ts
@@ -1,3 +1,5 @@
+import type { FeatureCollection, Geometry } from "geojson";
+
 /** Average area (km^2) of an H3 cell at each resolution 0..15 (official values). */
 export const H3_AVG_AREA_KM2: number[] = [
   4_357_449.416078381, 609_788.441794133, 86_801.780398997, 12_393.434655088,
@@ -41,4 +43,96 @@ export function suggestResolution(
     if (estimateCellCount(areaKm2, res) <= targetCells) return res;
   }
   return 0;
+}
+
+function sqlStr(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function sqlIdent(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`;
+}
+
+/** A closed POLYGON WKT ring for a [west, south, east, north] bbox. */
+export function bboxToWktPolygon(bbox: [number, number, number, number]): string {
+  const [w, s, e, n] = bbox;
+  return `POLYGON((${w} ${s}, ${e} ${s}, ${e} ${n}, ${w} ${n}, ${w} ${s}))`;
+}
+
+const GRID_SELECT =
+  "SELECT h3_h3_to_string(cell) AS h3, " +
+  "ST_AsGeoJSON(ST_GeomFromText(h3_cell_to_boundary_wkt(cell))) AS geojson FROM cells";
+
+/** Grid SQL from a polygon WKT literal (used for bbox / viewport sources). */
+export function buildGridFromWktSql(wkt: string, res: number): string {
+  return (
+    `WITH cells AS (SELECT unnest(h3_polygon_wkt_to_cells(${sqlStr(wkt)}, ${res})) AS cell) ` +
+    GRID_SELECT
+  );
+}
+
+/**
+ * Grid SQL that unions all geometry from a registered source into one
+ * (multi)polygon and fills it (used for the polyfill source). `sourceSql` is a
+ * FROM-able expression whose geometry column is `geom` (DuckDB `ST_Read`).
+ */
+export function buildGridFromSourceSql(sourceSql: string, res: number): string {
+  return (
+    `WITH merged AS (SELECT ST_AsText(ST_Union_Agg(geom)) AS wkt FROM ${sourceSql}), ` +
+    `cells AS (SELECT unnest(h3_polygon_wkt_to_cells((SELECT wkt FROM merged), ${res})) AS cell) ` +
+    GRID_SELECT
+  );
+}
+
+const AGG_FN: Record<string, string> = {
+  sum: "sum",
+  mean: "avg",
+  min: "min",
+  max: "max",
+};
+
+/**
+ * Aggregate point geometry from `sourceSql` (geometry column `geom`) into H3
+ * cells. `op` is one of count/sum/mean/min/max; a field is required for all but
+ * count.
+ */
+export function buildBinSql(
+  sourceSql: string,
+  res: number,
+  op: string,
+  field?: string,
+): string {
+  const fn = AGG_FN[op];
+  const aggSelect =
+    fn && field ? `, ${fn}(CAST(${sqlIdent(field)} AS DOUBLE)) AS value` : "";
+  const aggOut = fn && field ? ", value" : "";
+  return (
+    `WITH pts AS (SELECT * FROM ${sourceSql} ` +
+    `WHERE geom IS NOT NULL AND ST_GeometryType(geom) = 'POINT'), ` +
+    `binned AS (SELECT h3_latlng_to_cell(ST_Y(geom), ST_X(geom), ${res}) AS cell, ` +
+    `count(*) AS count${aggSelect} FROM pts GROUP BY cell) ` +
+    `SELECT h3_h3_to_string(cell) AS h3, count${aggOut}, ` +
+    `ST_AsGeoJSON(ST_GeomFromText(h3_cell_to_boundary_wkt(cell))) AS geojson FROM binned`
+  );
+}
+
+/** Build a FeatureCollection from rows carrying `h3`, optional `count`/`value`, and `geojson`. */
+export function rowsToFeatureCollection(
+  rows: Record<string, unknown>[],
+): FeatureCollection {
+  const features = [];
+  for (const row of rows) {
+    const raw = row.geojson;
+    if (typeof raw !== "string") continue;
+    const geometry = JSON.parse(raw) as Geometry;
+    const properties: Record<string, unknown> = { h3: row.h3 };
+    if (row.count !== undefined && row.count !== null) {
+      properties.count = Number(row.count);
+    }
+    if (row.value !== undefined && row.value !== null) {
+      properties.value = Number(row.value);
+    }
+    features.push({ type: "Feature" as const, geometry, properties });
+  }
+  return { type: "FeatureCollection", features };
 }

--- a/packages/processing/src/index.ts
+++ b/packages/processing/src/index.ts
@@ -7,6 +7,12 @@ export {
 } from "./registry";
 export { VECTOR_TOOLS, getVectorTool } from "./vector-tools";
 export {
+  H3_TOOLS,
+  getH3Tool,
+  createH3GridTool,
+  binPointsTool,
+} from "./h3-tools";
+export {
   RASTER_TOOLS,
   getRasterTool,
   type RasterTool,

--- a/packages/processing/src/types.ts
+++ b/packages/processing/src/types.ts
@@ -54,7 +54,15 @@ export interface AlgorithmParameter {
 
 /** A GeoJSON FeatureCollection registered as a queryable DuckDB source. */
 export interface DuckDbGeoJsonSource {
-  /** FROM-able SQL expression; its geometry column is named `geom`. */
+  /**
+   * FROM-able SQL expression; its geometry column is named `geom`.
+   *
+   * Trust boundary: this value is interpolated verbatim into SQL by the tools
+   * (e.g. `FROM ${sql}`). Implementations MUST produce it from
+   * host-controlled input only (the built-in capability uses
+   * `ST_Read(<quoted temp file>)`); never embed user-supplied content here, or
+   * the consuming tool becomes a SQL-injection vector.
+   */
   sql: string;
   /** Drop the registered source. Safe to call once. */
   release: () => Promise<void>;

--- a/packages/processing/src/types.ts
+++ b/packages/processing/src/types.ts
@@ -52,6 +52,24 @@ export interface AlgorithmParameter {
   fileFilters?: { name: string; extensions: string[] }[];
 }
 
+/** A GeoJSON FeatureCollection registered as a queryable DuckDB source. */
+export interface DuckDbGeoJsonSource {
+  /** FROM-able SQL expression; its geometry column is named `geom`. */
+  sql: string;
+  /** Drop the registered source. Safe to call once. */
+  release: () => Promise<void>;
+}
+
+/** Minimal DuckDB-WASM surface a processing tool needs. Injected by the host. */
+export interface DuckDbCapability {
+  /** Install + load the named extensions (e.g. `["spatial", "h3"]`). */
+  ensureExtensions: (names: string[]) => Promise<void>;
+  /** Register a FeatureCollection and return a SQL source handle. */
+  registerGeoJson: (geojson: FeatureCollection) => Promise<DuckDbGeoJsonSource>;
+  /** Run a query and return plain rows. */
+  query: (sql: string) => Promise<Record<string, unknown>[]>;
+}
+
 export interface ProcessingContext {
   layers: GeoLibreLayer[];
   parameters: Record<string, unknown>;
@@ -59,6 +77,10 @@ export interface ProcessingContext {
   fitBounds?: (bounds: [number, number, number, number]) => void;
   /** Add an algorithm result back to the map as a new GeoJSON layer. */
   addResultLayer?: (name: string, geojson: FeatureCollection) => void;
+  /** DuckDB-WASM capability, when the host provides it (browser/desktop). */
+  duckdb?: DuckDbCapability;
+  /** Current map viewport as [west, south, east, north], when available. */
+  viewportBounds?: () => [number, number, number, number] | null;
 }
 
 export interface ProcessingAlgorithm {

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -21,6 +21,7 @@ import type {
 } from "geojson";
 import type { GeoLibreLayer } from "@geolibre/core";
 import type { GeometryFamily, ProcessingAlgorithm, ProcessingContext } from "./types";
+import { createH3GridTool, binPointsTool } from "./h3-tools";
 
 /** Upper bound on input×overlay pairs for the main-thread intersection loop. */
 const MAX_CLIENT_PAIRS = 250_000;
@@ -997,6 +998,8 @@ export const VECTOR_TOOLS: ProcessingAlgorithm[] = [
   spatialJoinTool,
   selectByValueTool,
   selectByLocationTool,
+  createH3GridTool,
+  binPointsTool,
 ];
 
 export function getVectorTool(id: string): ProcessingAlgorithm | undefined {

--- a/tests/h3-tools.test.ts
+++ b/tests/h3-tools.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  H3_AVG_AREA_KM2,
+  H3_HARD_CAP,
+  bboxAreaKm2,
+  estimateCellCount,
+  suggestResolution,
+} from "../packages/processing/src/h3-tools";
+
+describe("h3 resolution math", () => {
+  it("exposes 16 average-area entries (res 0..15), strictly decreasing", () => {
+    assert.equal(H3_AVG_AREA_KM2.length, 16);
+    for (let r = 1; r < 16; r += 1) {
+      assert.ok(H3_AVG_AREA_KM2[r] < H3_AVG_AREA_KM2[r - 1]);
+    }
+  });
+
+  it("computes an approximate bbox area in km^2", () => {
+    // 1 deg x 1 deg near the equator is roughly 12,300 km^2.
+    const area = bboxAreaKm2([0, 0, 1, 1]);
+    assert.ok(area > 11_000 && area < 13_500, `got ${area}`);
+  });
+
+  it("suggests the finest resolution that stays under the target cell count", () => {
+    // A large area should pick a coarse resolution.
+    const big = bboxAreaKm2([-10, -10, 10, 10]);
+    const rBig = suggestResolution(big);
+    // A tiny area should pick the finest allowed (capped at 12).
+    const tiny = bboxAreaKm2([0, 0, 0.001, 0.001]);
+    const rTiny = suggestResolution(tiny);
+    assert.ok(rBig < rTiny);
+    assert.ok(rTiny <= 12);
+    assert.ok(rBig >= 0);
+    // Whatever it picks, the estimate must not exceed the 10k target.
+    assert.ok(estimateCellCount(big, rBig) <= 10_000);
+  });
+
+  it("clamps an out-of-range resolution request via estimateCellCount monotonicity", () => {
+    const area = bboxAreaKm2([0, 0, 1, 1]);
+    assert.ok(estimateCellCount(area, 10) > estimateCellCount(area, 9));
+  });
+
+  it("exposes a hard cap constant", () => {
+    assert.equal(typeof H3_HARD_CAP, "number");
+    assert.ok(H3_HARD_CAP > 10_000);
+  });
+});

--- a/tests/h3-tools.test.ts
+++ b/tests/h3-tools.test.ts
@@ -193,6 +193,47 @@ describe("h3 tools", () => {
     assert.match(added[0], /res 5/);
   });
 
+  it("creates a grid from a manual bounding box without a layer", async () => {
+    const { ctx, added } = baseCtx([], {
+      source: "bbox",
+      west: 0,
+      south: 0,
+      east: 1,
+      north: 1,
+      resolution: 5,
+    });
+    await createH3GridTool.run(ctx);
+    assert.equal(added.length, 1);
+    assert.match(added[0], /res 5/);
+  });
+
+  it("rejects a degenerate manual bounding box", async () => {
+    const { ctx, added, logs } = baseCtx([], {
+      source: "bbox",
+      west: 2,
+      south: 0,
+      east: 1,
+      north: 1,
+      resolution: 5,
+    });
+    await createH3GridTool.run(ctx);
+    assert.equal(added.length, 0);
+    assert.ok(logs.some((l) => /west < east/i.test(l)));
+  });
+
+  it("rejects a manual bounding box with missing values", async () => {
+    const { ctx, added, logs } = baseCtx([], {
+      source: "bbox",
+      west: 0,
+      south: 0,
+      east: 1,
+      resolution: 5,
+    });
+    await createH3GridTool.run(ctx);
+    assert.equal(added.length, 0);
+    assert.ok(logs.some((l) => /numeric/i.test(l)));
+  });
+
   it("auto-suggests a resolution when none is given", async () => {
     const { ctx, logs } = baseCtx([], { source: "viewport" });
     await createH3GridTool.run(ctx);

--- a/tests/h3-tools.test.ts
+++ b/tests/h3-tools.test.ts
@@ -4,26 +4,22 @@ import {
   H3_AVG_AREA_KM2,
   H3_HARD_CAP,
   bboxAreaKm2,
-  estimateCellCount,
-  suggestResolution,
-} from "../packages/processing/src/h3-tools";
-import {
   bboxToWktPolygon,
+  binPointsTool,
   buildBinSql,
   buildGridFromSourceSql,
   buildGridFromWktSql,
+  createH3GridTool,
+  estimateCellCount,
+  getH3Tool,
   rowsToFeatureCollection,
+  suggestResolution,
 } from "../packages/processing/src/h3-tools";
 import { DEFAULT_LAYER_STYLE, type GeoLibreLayer } from "@geolibre/core";
 import type {
   DuckDbCapability,
   ProcessingContext,
 } from "../packages/processing/src/types";
-import {
-  binPointsTool,
-  createH3GridTool,
-  getH3Tool,
-} from "../packages/processing/src/h3-tools";
 
 describe("h3 resolution math", () => {
   it("exposes 16 average-area entries (res 0..15), strictly decreasing", () => {

--- a/tests/h3-tools.test.ts
+++ b/tests/h3-tools.test.ts
@@ -54,6 +54,13 @@ describe("h3 resolution math", () => {
     assert.ok(estimateCellCount(area, 10) > estimateCellCount(area, 9));
   });
 
+  it("fails safe (Infinity) for an out-of-range resolution so the cap trips", () => {
+    const area = bboxAreaKm2([0, 0, 1, 1]);
+    assert.equal(estimateCellCount(area, 16), Number.POSITIVE_INFINITY);
+    assert.equal(estimateCellCount(area, -1), Number.POSITIVE_INFINITY);
+    assert.ok(estimateCellCount(area, 16) > H3_HARD_CAP);
+  });
+
   it("exposes a hard cap constant", () => {
     assert.equal(typeof H3_HARD_CAP, "number");
     assert.ok(H3_HARD_CAP > 10_000);
@@ -104,15 +111,22 @@ function pointLayer(): GeoLibreLayer {
   };
 }
 
-/** Capability stub that records queries and returns one canned hex row. */
-function mockDuckDb(): DuckDbCapability & { queries: string[] } {
+/** Capability stub that records queries/releases and returns one canned hex row. */
+function mockDuckDb(): DuckDbCapability & {
+  queries: string[];
+  released: number[];
+} {
   const queries: string[] = [];
+  const released: number[] = [];
   return {
     queries,
+    released,
     ensureExtensions: async () => {},
     registerGeoJson: async () => ({
       sql: "ST_Read('mock.geojson')",
-      release: async () => {},
+      release: async () => {
+        released.push(1);
+      },
     }),
     query: async (sql: string) => {
       queries.push(sql);
@@ -131,18 +145,24 @@ function mockDuckDb(): DuckDbCapability & { queries: string[] } {
 function baseCtx(
   layers: GeoLibreLayer[],
   parameters: Record<string, unknown>,
-): { ctx: ProcessingContext; logs: string[]; added: string[] } {
+): {
+  ctx: ProcessingContext;
+  logs: string[];
+  added: string[];
+  duckdb: ReturnType<typeof mockDuckDb>;
+} {
   const logs: string[] = [];
   const added: string[] = [];
+  const duckdb = mockDuckDb();
   const ctx: ProcessingContext = {
     layers,
     parameters,
     log: (m) => logs.push(m),
     addResultLayer: (name) => added.push(name),
-    duckdb: mockDuckDb(),
+    duckdb,
     viewportBounds: () => [0, 0, 1, 1],
   };
-  return { ctx, logs, added };
+  return { ctx, logs, added, duckdb };
 }
 
 describe("h3 tools", () => {
@@ -190,14 +210,16 @@ describe("h3 tools", () => {
     assert.ok(logs.some((l) => /cap/i.test(l)));
   });
 
-  it("polyfills a selected polygon layer", async () => {
-    const { ctx, added } = baseCtx([polygonLayer()], {
+  it("polyfills a selected polygon layer and releases the registered source", async () => {
+    const { ctx, added, duckdb } = baseCtx([polygonLayer()], {
       source: "polyfill",
       layer: "poly",
       resolution: 6,
     });
     await createH3GridTool.run(ctx);
     assert.equal(added.length, 1);
+    // The registered temp GeoJSON source must be released after the run.
+    assert.equal(duckdb.released.length, 1);
   });
 
   it("rejects polyfill of a non-polygon layer", async () => {
@@ -238,6 +260,8 @@ describe("h3 tools", () => {
     });
     await binPointsTool.run(ok.ctx);
     assert.equal(ok.added.length, 1);
+    // The registered temp GeoJSON source must be released after the run.
+    assert.equal(ok.duckdb.released.length, 1);
   });
 });
 
@@ -249,9 +273,11 @@ describe("h3 SQL + geometry builders", () => {
     );
   });
 
-  it("builds grid SQL from a WKT literal, escaping quotes", () => {
-    const sql = buildGridFromWktSql("POLYGON((0 0, 1 0, 1 1, 0 0))", 7);
-    assert.match(sql, /h3_polygon_wkt_to_cells\('POLYGON\(\(0 0, 1 0, 1 1, 0 0\)\)', 7\)/);
+  it("builds grid SQL from a WKT literal, escaping single quotes", () => {
+    // Include a single quote in the input so the test actually exercises the
+    // doubling done by sqlStr (a malformed escape would break this assertion).
+    const sql = buildGridFromWktSql("POLYGON((0 0, 1 0, 1 1, 0 0))'x", 7);
+    assert.match(sql, /h3_polygon_wkt_to_cells\('POLYGON\(\(0 0, 1 0, 1 1, 0 0\)\)''x', 7\)/);
     assert.match(sql, /h3_h3_to_string\(cell\) AS h3/);
     assert.match(sql, /ST_AsGeoJSON\(ST_GeomFromText\(h3_cell_to_boundary_wkt\(cell\)\)\) AS geojson/);
   });
@@ -259,7 +285,7 @@ describe("h3 SQL + geometry builders", () => {
   it("builds polyfill grid SQL that unions the source geometry", () => {
     const sql = buildGridFromSourceSql("ST_Read('a.geojson')", 8);
     assert.match(sql, /ST_Union_Agg\(geom\)/);
-    assert.match(sql, /ST_Read\('a\.geojson'\)/);
+    assert.match(sql, /ST_Read\('a\.geojson'\) WHERE geom IS NOT NULL/);
     assert.match(sql, /h3_polygon_wkt_to_cells\(\(SELECT wkt FROM merged\), 8\)/);
   });
 

--- a/tests/h3-tools.test.ts
+++ b/tests/h3-tools.test.ts
@@ -14,6 +14,16 @@ import {
   buildGridFromWktSql,
   rowsToFeatureCollection,
 } from "../packages/processing/src/h3-tools";
+import { DEFAULT_LAYER_STYLE, type GeoLibreLayer } from "@geolibre/core";
+import type {
+  DuckDbCapability,
+  ProcessingContext,
+} from "../packages/processing/src/types";
+import {
+  binPointsTool,
+  createH3GridTool,
+  getH3Tool,
+} from "../packages/processing/src/h3-tools";
 
 describe("h3 resolution math", () => {
   it("exposes 16 average-area entries (res 0..15), strictly decreasing", () => {
@@ -51,6 +61,166 @@ describe("h3 resolution math", () => {
   it("exposes a hard cap constant", () => {
     assert.equal(typeof H3_HARD_CAP, "number");
     assert.ok(H3_HARD_CAP > 10_000);
+  });
+});
+
+function polygonLayer(): GeoLibreLayer {
+  return {
+    id: "poly",
+    name: "Poly",
+    type: "geojson",
+    source: { type: "geojson" },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {},
+    geojson: {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          properties: {},
+          geometry: {
+            type: "Polygon",
+            coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+          },
+        },
+      ],
+    },
+  };
+}
+
+function pointLayer(): GeoLibreLayer {
+  return {
+    ...polygonLayer(),
+    id: "pts",
+    name: "Pts",
+    geojson: {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          properties: { pop: 5 },
+          geometry: { type: "Point", coordinates: [0.5, 0.5] },
+        },
+      ],
+    },
+  };
+}
+
+/** Capability stub that records queries and returns one canned hex row. */
+function mockDuckDb(): DuckDbCapability & { queries: string[] } {
+  const queries: string[] = [];
+  return {
+    queries,
+    ensureExtensions: async () => {},
+    registerGeoJson: async () => ({
+      sql: "ST_Read('mock.geojson')",
+      release: async () => {},
+    }),
+    query: async (sql: string) => {
+      queries.push(sql);
+      return [
+        {
+          h3: "8928308280fffff",
+          count: 1,
+          geojson:
+            '{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,0]]]}',
+        },
+      ];
+    },
+  };
+}
+
+function baseCtx(
+  layers: GeoLibreLayer[],
+  parameters: Record<string, unknown>,
+): { ctx: ProcessingContext; logs: string[]; added: string[] } {
+  const logs: string[] = [];
+  const added: string[] = [];
+  const ctx: ProcessingContext = {
+    layers,
+    parameters,
+    log: (m) => logs.push(m),
+    addResultLayer: (name) => added.push(name),
+    duckdb: mockDuckDb(),
+    viewportBounds: () => [0, 0, 1, 1],
+  };
+  return { ctx, logs, added };
+}
+
+describe("h3 tools", () => {
+  it("registers both tools under getH3Tool", () => {
+    assert.equal(getH3Tool("h3-grid"), createH3GridTool);
+    assert.equal(getH3Tool("h3-bin-points"), binPointsTool);
+    assert.equal(getH3Tool("missing"), undefined);
+  });
+
+  it("throws a clear error when duckdb is unavailable", async () => {
+    await assert.rejects(
+      () =>
+        Promise.resolve(
+          createH3GridTool.run({
+            layers: [],
+            parameters: { source: "viewport" },
+            log: () => {},
+          }),
+        ),
+      /requires DuckDB/,
+    );
+  });
+
+  it("creates a grid from the map viewport", async () => {
+    const { ctx, added } = baseCtx([], { source: "viewport", resolution: 5 });
+    await createH3GridTool.run(ctx);
+    assert.equal(added.length, 1);
+    assert.match(added[0], /res 5/);
+  });
+
+  it("auto-suggests a resolution when none is given", async () => {
+    const { ctx, logs } = baseCtx([], { source: "viewport" });
+    await createH3GridTool.run(ctx);
+    assert.ok(logs.some((l) => /suggested resolution/i.test(l)));
+  });
+
+  it("aborts when the requested resolution exceeds the hard cap", async () => {
+    const { ctx, added, logs } = baseCtx([polygonLayer()], {
+      source: "extent",
+      layer: "poly",
+      resolution: 15,
+    });
+    await createH3GridTool.run(ctx);
+    assert.equal(added.length, 0);
+    assert.ok(logs.some((l) => /cap/i.test(l)));
+  });
+
+  it("polyfills a selected polygon layer", async () => {
+    const { ctx, added } = baseCtx([polygonLayer()], {
+      source: "polyfill",
+      layer: "poly",
+      resolution: 6,
+    });
+    await createH3GridTool.run(ctx);
+    assert.equal(added.length, 1);
+  });
+
+  it("bins points and requires a field for non-count aggregates", async () => {
+    const missing = baseCtx([pointLayer()], {
+      layer: "pts",
+      aggOp: "sum",
+      resolution: 7,
+    });
+    await binPointsTool.run(missing.ctx);
+    assert.equal(missing.added.length, 0);
+    assert.ok(missing.logs.some((l) => /field/i.test(l)));
+
+    const ok = baseCtx([pointLayer()], {
+      layer: "pts",
+      aggOp: "count",
+      resolution: 7,
+    });
+    await binPointsTool.run(ok.ctx);
+    assert.equal(ok.added.length, 1);
   });
 });
 

--- a/tests/h3-tools.test.ts
+++ b/tests/h3-tools.test.ts
@@ -54,6 +54,13 @@ describe("h3 resolution math", () => {
     assert.ok(estimateCellCount(area, 10) > estimateCellCount(area, 9));
   });
 
+  it("handles an antimeridian-crossing bbox without inflating the area", () => {
+    // west=170, east=-170 is a 20deg span across the antimeridian, not 340deg.
+    const wrapped = bboxAreaKm2([170, 0, -170, 1]);
+    const equivalent = bboxAreaKm2([0, 0, 20, 1]);
+    assert.ok(Math.abs(wrapped - equivalent) < 1, `${wrapped} vs ${equivalent}`);
+  });
+
   it("fails safe (Infinity) for an out-of-range resolution so the cap trips", () => {
     const area = bboxAreaKm2([0, 0, 1, 1]);
     assert.equal(estimateCellCount(area, 16), Number.POSITIVE_INFINITY);
@@ -304,6 +311,40 @@ describe("h3 tools", () => {
     // The registered temp GeoJSON source must be released after the run.
     assert.equal(ok.duckdb.released.length, 1);
   });
+
+  it("rejects an unknown aggregate operation", async () => {
+    const { ctx, added, logs } = baseCtx([pointLayer()], {
+      layer: "pts",
+      aggOp: "median",
+      resolution: 7,
+    });
+    await binPointsTool.run(ctx);
+    assert.equal(added.length, 0);
+    assert.ok(logs.some((l) => /unknown aggregate/i.test(l)));
+  });
+
+  it("logs a soft message and adds no layer when zero cells are produced", async () => {
+    const logs: string[] = [];
+    const added: string[] = [];
+    const ctx: ProcessingContext = {
+      layers: [],
+      parameters: { source: "viewport", resolution: 5 },
+      log: (m) => logs.push(m),
+      addResultLayer: (name) => added.push(name),
+      viewportBounds: () => [0, 0, 1, 1],
+      duckdb: {
+        ensureExtensions: async () => {},
+        registerGeoJson: async () => ({
+          sql: "ST_Read('mock.geojson')",
+          release: async () => {},
+        }),
+        query: async () => [], // no cells
+      },
+    };
+    await createH3GridTool.run(ctx);
+    assert.equal(added.length, 0);
+    assert.ok(logs.some((l) => /no h3 cells/i.test(l)));
+  });
 });
 
 describe("h3 SQL + geometry builders", () => {
@@ -323,19 +364,30 @@ describe("h3 SQL + geometry builders", () => {
     assert.match(sql, /ST_AsGeoJSON\(ST_GeomFromText\(h3_cell_to_boundary_wkt\(cell\)\)\) AS geojson/);
   });
 
-  it("builds polyfill grid SQL that unions the source geometry", () => {
+  it("builds polyfill grid SQL that unions only polygon geometry and guards NULL", () => {
     const sql = buildGridFromSourceSql("ST_Read('a.geojson')", 8);
     assert.match(sql, /ST_Union_Agg\(geom\)/);
-    assert.match(sql, /ST_Read\('a\.geojson'\) WHERE geom IS NOT NULL/);
-    assert.match(sql, /h3_polygon_wkt_to_cells\(\(SELECT wkt FROM merged\), 8\)/);
+    // Only polygonal geometry is unioned (a mixed layer would otherwise produce
+    // a GEOMETRYCOLLECTION that h3_polygon_wkt_to_cells rejects).
+    assert.match(
+      sql,
+      /WHERE geom IS NOT NULL AND ST_GeometryType\(geom\) IN \('POLYGON', 'MULTIPOLYGON'\)/,
+    );
+    // A NULL union result (no polygons) is filtered before reaching the h3 fn.
+    assert.match(sql, /h3_polygon_wkt_to_cells\(wkt, 8\)/);
+    assert.match(sql, /FROM merged WHERE wkt IS NOT NULL/);
   });
 
-  it("builds bin SQL for count (no field)", () => {
+  it("builds bin SQL for count (no field), binning POINT and MULTIPOINT by centroid", () => {
     const sql = buildBinSql("ST_Read('p.geojson')", 9, "count");
-    assert.match(sql, /h3_latlng_to_cell\(ST_Y\(geom\), ST_X\(geom\), 9\)/);
+    assert.match(sql, /h3_latlng_to_cell\(ST_Y\(pt\), ST_X\(pt\), 9\)/);
+    assert.match(sql, /ST_Centroid\(geom\) AS pt/);
     assert.match(sql, /count\(\*\) AS count/);
     assert.doesNotMatch(sql, /AS value/);
-    assert.match(sql, /ST_GeometryType\(geom\) = 'POINT'/);
+    assert.match(
+      sql,
+      /ST_GeometryType\(geom\) IN \('POINT', 'MULTIPOINT'\)/,
+    );
   });
 
   it("builds bin SQL for an aggregate, mapping mean->avg and quoting the field", () => {

--- a/tests/h3-tools.test.ts
+++ b/tests/h3-tools.test.ts
@@ -200,6 +200,27 @@ describe("h3 tools", () => {
     assert.equal(added.length, 1);
   });
 
+  it("rejects polyfill of a non-polygon layer", async () => {
+    const { ctx, added, logs } = baseCtx([pointLayer()], {
+      source: "polyfill",
+      layer: "pts",
+      resolution: 6,
+    });
+    await createH3GridTool.run(ctx);
+    assert.equal(added.length, 0);
+    assert.ok(logs.some((l) => /polygon/i.test(l)));
+  });
+
+  it("fills the extent of a non-polygon layer", async () => {
+    const { ctx, added } = baseCtx([pointLayer()], {
+      source: "extent",
+      layer: "pts",
+      resolution: 6,
+    });
+    await createH3GridTool.run(ctx);
+    assert.equal(added.length, 1);
+  });
+
   it("bins points and requires a field for non-count aggregates", async () => {
     const missing = baseCtx([pointLayer()], {
       layer: "pts",

--- a/tests/h3-tools.test.ts
+++ b/tests/h3-tools.test.ts
@@ -200,6 +200,17 @@ describe("h3 tools", () => {
     assert.match(added[0], /res 5/);
   });
 
+  it("rejects an antimeridian-crossing viewport", async () => {
+    const { ctx, added, logs } = baseCtx([], {
+      source: "viewport",
+      resolution: 4,
+    });
+    ctx.viewportBounds = () => [170, 0, -170, 1]; // west >= east
+    await createH3GridTool.run(ctx);
+    assert.equal(added.length, 0);
+    assert.ok(logs.some((l) => /antimeridian/i.test(l)));
+  });
+
   it("creates a grid from a manual bounding box without a layer", async () => {
     const { ctx, added } = baseCtx([], {
       source: "bbox",
@@ -394,6 +405,9 @@ describe("h3 SQL + geometry builders", () => {
     const sql = buildBinSql("ST_Read('p.geojson')", 9, "mean", "pop");
     assert.match(sql, /avg\(CAST\("pop" AS DOUBLE\)\) AS value/);
     assert.match(sql, /count, value,/);
+    // The field must be in the SELECT list, not appended after the WHERE clause.
+    assert.match(sql, /SELECT ST_Centroid\(geom\) AS pt, "pop" FROM/);
+    assert.doesNotMatch(sql, /MULTIPOINT'\), "pop"/);
   });
 
   it("converts result rows to a FeatureCollection with h3/count/value props", () => {

--- a/tests/h3-tools.test.ts
+++ b/tests/h3-tools.test.ts
@@ -7,6 +7,13 @@ import {
   estimateCellCount,
   suggestResolution,
 } from "../packages/processing/src/h3-tools";
+import {
+  bboxToWktPolygon,
+  buildBinSql,
+  buildGridFromSourceSql,
+  buildGridFromWktSql,
+  rowsToFeatureCollection,
+} from "../packages/processing/src/h3-tools";
 
 describe("h3 resolution math", () => {
   it("exposes 16 average-area entries (res 0..15), strictly decreasing", () => {
@@ -44,5 +51,59 @@ describe("h3 resolution math", () => {
   it("exposes a hard cap constant", () => {
     assert.equal(typeof H3_HARD_CAP, "number");
     assert.ok(H3_HARD_CAP > 10_000);
+  });
+});
+
+describe("h3 SQL + geometry builders", () => {
+  it("builds a closed POLYGON WKT from a bbox", () => {
+    assert.equal(
+      bboxToWktPolygon([0, 1, 2, 3]),
+      "POLYGON((0 1, 2 1, 2 3, 0 3, 0 1))",
+    );
+  });
+
+  it("builds grid SQL from a WKT literal, escaping quotes", () => {
+    const sql = buildGridFromWktSql("POLYGON((0 0, 1 0, 1 1, 0 0))", 7);
+    assert.match(sql, /h3_polygon_wkt_to_cells\('POLYGON\(\(0 0, 1 0, 1 1, 0 0\)\)', 7\)/);
+    assert.match(sql, /h3_h3_to_string\(cell\) AS h3/);
+    assert.match(sql, /ST_AsGeoJSON\(ST_GeomFromText\(h3_cell_to_boundary_wkt\(cell\)\)\) AS geojson/);
+  });
+
+  it("builds polyfill grid SQL that unions the source geometry", () => {
+    const sql = buildGridFromSourceSql("ST_Read('a.geojson')", 8);
+    assert.match(sql, /ST_Union_Agg\(geom\)/);
+    assert.match(sql, /ST_Read\('a\.geojson'\)/);
+    assert.match(sql, /h3_polygon_wkt_to_cells\(\(SELECT wkt FROM merged\), 8\)/);
+  });
+
+  it("builds bin SQL for count (no field)", () => {
+    const sql = buildBinSql("ST_Read('p.geojson')", 9, "count");
+    assert.match(sql, /h3_latlng_to_cell\(ST_Y\(geom\), ST_X\(geom\), 9\)/);
+    assert.match(sql, /count\(\*\) AS count/);
+    assert.doesNotMatch(sql, /AS value/);
+    assert.match(sql, /ST_GeometryType\(geom\) = 'POINT'/);
+  });
+
+  it("builds bin SQL for an aggregate, mapping mean->avg and quoting the field", () => {
+    const sql = buildBinSql("ST_Read('p.geojson')", 9, "mean", "pop");
+    assert.match(sql, /avg\(CAST\("pop" AS DOUBLE\)\) AS value/);
+    assert.match(sql, /count, value,/);
+  });
+
+  it("converts result rows to a FeatureCollection with h3/count/value props", () => {
+    const fc = rowsToFeatureCollection([
+      {
+        h3: "8928308280fffff",
+        count: 3n,
+        value: 12.5,
+        geojson: '{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,0]]]}',
+      },
+      { h3: "x", count: 1, geojson: null },
+    ]);
+    assert.equal(fc.features.length, 1);
+    assert.equal(fc.features[0].properties?.h3, "8928308280fffff");
+    assert.equal(fc.features[0].properties?.count, 3);
+    assert.equal(fc.features[0].properties?.value, 12.5);
+    assert.equal(fc.features[0].geometry?.type, "Polygon");
   });
 });


### PR DESCRIPTION
## Summary

Closes #245. Adds two client-side processing tools backed by the DuckDB-WASM `h3` community extension + `spatial` extension, surfaced in Processing -> Vector:

- **Create H3 grid** - fills an area with H3 hexagons. Area source can be a polygon layer's geometry (polyfill), any layer's bounding-box extent, or the current map viewport. Resolution is user-selectable (0-15) or auto-suggested from the area, with a hard cap that aborts runaway grids.
- **Bin points to H3** - aggregates a point layer into H3 cells (count, or sum/mean/min/max of a numeric field).

## Design

- `@geolibre/processing` stays framework-agnostic: the tools call an injected `ctx.duckdb` capability (`DuckDbCapability`) plus `ctx.viewportBounds()`. The desktop app implements the capability over the existing `duckdb-vector-loader.ts` and wires it into `VectorToolsDialog`.
- New `ensureH3Extension` mirrors `ensureSpatialExtension` (`INSTALL h3 FROM community; LOAD h3;`, memoized). Verified the bundled DuckDB-WASM (v1.5.1) has matching `h3` builds on all WASM platforms.
- All WKT/SQL building, area, and resolution math live in pure, unit-tested helpers; the DuckDB-coupled code is thin.
- Design spec and implementation plan are under `docs/superpowers/`.

## Known follow-ups (non-blocking)

- Viewport area estimate near the antimeridian can over-count; would surface as a "too many cells" message, not wrong data.
- No offline/custom-path override for the `h3` extension (the `spatial` extension has one).

## Test Plan

- [x] `npm run test:frontend` - 387 pass (20 new H3 tests in `tests/h3-tools.test.ts`)
- [x] `npm run build` - passes (type-check gate)
- [x] `pre-commit run --files <changed>` - eslint + npm build pass
- [ ] Manual (desktop `tauri:dev`): create grid from each source (polyfill / extent / viewport), blank vs explicit resolution; bin points with count and with a sum/mean field; confirm first-run `h3` extension download and the hard-cap abort message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Two H3 hexagonal tools added to Processing → Vector → H3 (Create H3 Grid, Bin Points to H3) with toolbar entries; manual bbox fields auto-fill from the current map when available.
  * DuckDB-backed client-side processing support for H3/spatial operations, improving local H3 grid and binning workflows.

* **Documentation**
  * Added design and implementation plans describing behavior and limitations.

* **Tests**
  * Added unit tests for H3 math, SQL/geometry builders, tool behavior, and result conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->