### PR TITLE
feat(resilience): add React error boundaries (app + sections + plugins)

### DIFF
--- a/apps/geolibre-desktop/src/components/common/error-boundaries.tsx
+++ b/apps/geolibre-desktop/src/components/common/error-boundaries.tsx
@@ -60,7 +60,8 @@ export function AppErrorBoundary({ children }: { children: ReactNode }) {
               may be unsaved — try recovering before reloading.
             </p>
             <p className="max-w-md break-words font-mono text-xs text-muted-foreground/80">
-              {error.message}
+              {/* Non-Error throws (common from plugin code) have no .message. */}
+              {error.message || String(error)}
             </p>
           </div>
           <div className="flex gap-2">
@@ -87,12 +88,16 @@ export function AppErrorBoundary({ children }: { children: ReactNode }) {
 export function SectionErrorBoundary({
   label,
   children,
-  className,
+  fallbackClassName,
   resetKeys,
 }: {
   label: string;
   children: ReactNode;
-  className?: string;
+  /**
+   * Class applied to the error fallback container. It has no effect during
+   * normal rendering — the boundary injects no wrapper around its children.
+   */
+  fallbackClassName?: string;
   resetKeys?: readonly unknown[];
 }) {
   return (
@@ -103,7 +108,7 @@ export function SectionErrorBoundary({
         <SectionErrorFallback
           label={label}
           reset={reset}
-          className={className}
+          className={fallbackClassName}
         />
       )}
     >

--- a/apps/geolibre-desktop/src/components/common/error-boundaries.tsx
+++ b/apps/geolibre-desktop/src/components/common/error-boundaries.tsx
@@ -1,0 +1,135 @@
+import {
+  Button,
+  ErrorBoundary,
+  type ErrorBoundaryFallbackProps,
+} from "@geolibre/ui";
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import type { ErrorInfo, ReactNode } from "react";
+
+import { appendDiagnostic } from "../../lib/diagnostics";
+
+/**
+ * Records a boundary-caught error in the diagnostics panel so it is visible to
+ * the user (and copyable for bug reports) instead of only landing in the
+ * console.
+ */
+function reportBoundaryError(
+  label: string,
+  error: Error,
+  info?: ErrorInfo,
+): void {
+  appendDiagnostic({
+    category: "runtime",
+    level: "error",
+    message: `${label} crashed: ${error.message}`,
+    detail: [error.stack, info?.componentStack]
+      .filter((part): part is string => Boolean(part))
+      .join("\n\n"),
+    source: label,
+  });
+}
+
+export { reportBoundaryError };
+
+/**
+ * Top-level boundary. A render error anywhere not caught by a more specific
+ * boundary lands here and shows a full-screen recovery panel rather than a
+ * blank page. Reloading is the surest recovery for an error this high in the
+ * tree, so the primary action reloads the app; "Try again" attempts an in-place
+ * recovery without losing unsaved work.
+ */
+export function AppErrorBoundary({ children }: { children: ReactNode }) {
+  return (
+    <ErrorBoundary
+      onError={(error, info) => reportBoundaryError("Application", error, info)}
+      fallback={({ error, reset }) => (
+        <div
+          role="alert"
+          className="flex h-full w-full flex-col items-center justify-center gap-4 bg-background p-8 text-center"
+        >
+          <AlertTriangle className="h-10 w-10 text-destructive" />
+          <div className="space-y-1">
+            <h1 className="text-lg font-semibold">Something went wrong</h1>
+            <p className="max-w-md text-sm text-muted-foreground">
+              GeoLibre hit an unexpected error and could not continue. Your work
+              may be unsaved — try recovering before reloading.
+            </p>
+            <p className="max-w-md break-words font-mono text-xs text-muted-foreground/80">
+              {error.message}
+            </p>
+          </div>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={reset}>
+              <RefreshCw className="h-4 w-4" />
+              Try again
+            </Button>
+            <Button onClick={() => window.location.reload()}>Reload app</Button>
+          </div>
+        </div>
+      )}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}
+
+/**
+ * Boundary for an individual region of the shell (a panel, the toolbar, the map
+ * surface, etc.). A crash in one region shows a compact inline notice and a
+ * retry button while the rest of the app keeps working. `resetKeys` lets the
+ * region recover automatically when its driving inputs change.
+ */
+export function SectionErrorBoundary({
+  label,
+  children,
+  className,
+  resetKeys,
+}: {
+  label: string;
+  children: ReactNode;
+  className?: string;
+  resetKeys?: readonly unknown[];
+}) {
+  return (
+    <ErrorBoundary
+      resetKeys={resetKeys}
+      onError={(error, info) => reportBoundaryError(label, error, info)}
+      fallback={({ reset }) => (
+        <SectionErrorFallback
+          label={label}
+          reset={reset}
+          className={className}
+        />
+      )}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}
+
+function SectionErrorFallback({
+  label,
+  reset,
+  className,
+}: Pick<ErrorBoundaryFallbackProps, "reset"> & {
+  label: string;
+  className?: string;
+}) {
+  return (
+    <div
+      role="alert"
+      className={`flex flex-col items-center justify-center gap-3 p-4 text-center ${
+        className ?? ""
+      }`}
+    >
+      <AlertTriangle className="h-6 w-6 text-destructive" />
+      <p className="text-sm text-muted-foreground">
+        {label} failed to render. The rest of GeoLibre is still available.
+      </p>
+      <Button variant="outline" size="sm" onClick={reset}>
+        <RefreshCw className="h-4 w-4" />
+        Retry
+      </Button>
+    </div>
+  );
+}

--- a/apps/geolibre-desktop/src/components/common/error-boundaries.tsx
+++ b/apps/geolibre-desktop/src/components/common/error-boundaries.tsx
@@ -12,6 +12,11 @@ import { appendDiagnostic } from "../../lib/diagnostics";
  * Records a boundary-caught error in the diagnostics panel so it is visible to
  * the user (and copyable for bug reports) instead of only landing in the
  * console.
+ *
+ * Note: in development React re-throws boundary-caught errors as a synthetic
+ * `window.error` event, which `installDiagnosticsCapture` also records — so
+ * each error shows up twice in the Diagnostics panel in dev mode. Production
+ * builds (where React does not re-throw) record it once.
  */
 function reportBoundaryError(
   label: string,

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -58,6 +58,7 @@ import {
   appendDiagnostic,
   useDiagnosticsSnapshot,
 } from "../../lib/diagnostics";
+import { SectionErrorBoundary } from "../common/error-boundaries";
 import { AttributeTable } from "../panels/AttributeTable";
 import { LayerPanel } from "../panels/LayerPanel";
 import { StylePanel } from "../panels/StylePanel";
@@ -867,56 +868,68 @@ export function DesktopShell({
       onDrop={handleDrop}
     >
       {layoutOptions.toolbarVisible ? (
-        <TopToolbar
-          compact={layoutOptions.compact}
-          diagnosticsErrorCount={diagnostics.errorCount}
-          mapControllerRef={mapControllerRef}
-          showLabels={layoutOptions.toolbarLabels}
-          showProjectInfo={layoutOptions.showProjectInfo}
-          themeMode={themeMode}
-          onOpenDiagnostics={() => setDiagnosticsOpen(true)}
-          onToggleThemeMode={onToggleThemeMode}
-        />
+        <SectionErrorBoundary label="Toolbar">
+          <TopToolbar
+            compact={layoutOptions.compact}
+            diagnosticsErrorCount={diagnostics.errorCount}
+            mapControllerRef={mapControllerRef}
+            showLabels={layoutOptions.toolbarLabels}
+            showProjectInfo={layoutOptions.showProjectInfo}
+            themeMode={themeMode}
+            onOpenDiagnostics={() => setDiagnosticsOpen(true)}
+            onToggleThemeMode={onToggleThemeMode}
+          />
+        </SectionErrorBoundary>
       ) : null}
       <div className="flex min-h-0 flex-1 flex-col md:flex-row">
         {layoutOptions.layerPanelVisible ? (
-          <LayerPanel
-            mapControllerRef={mapControllerRef}
-            onResizeStart={startLayerPanelResize}
-            geometryEditLayerId={geometryEditLayerId}
-            onToggleGeometryEdit={handleToggleGeometryEdit}
-            onCancelGeometryEdit={handleCancelGeometryEdit}
-            onMaterializeDuckDBLayer={handleMaterializeDuckDBLayer}
-          />
+          <SectionErrorBoundary label="Layer panel">
+            <LayerPanel
+              mapControllerRef={mapControllerRef}
+              onResizeStart={startLayerPanelResize}
+              geometryEditLayerId={geometryEditLayerId}
+              onToggleGeometryEdit={handleToggleGeometryEdit}
+              onCancelGeometryEdit={handleCancelGeometryEdit}
+              onMaterializeDuckDBLayer={handleMaterializeDuckDBLayer}
+            />
+          </SectionErrorBoundary>
         ) : null}
         <main
           className={`relative min-w-0 flex-1 overflow-hidden ${
             layoutOptions.compact ? "min-h-0" : "min-h-72 md:min-h-0"
           }`}
         >
-          <MapCanvas
-            controllerRef={mapControllerRef}
-            onMapDiagnosticEvent={handleMapDiagnosticEvent}
-            onControllerReady={handleMapControllerReady}
-          />
+          <SectionErrorBoundary label="Map" className="h-full w-full">
+            <MapCanvas
+              controllerRef={mapControllerRef}
+              onMapDiagnosticEvent={handleMapDiagnosticEvent}
+              onControllerReady={handleMapControllerReady}
+            />
+          </SectionErrorBoundary>
         </main>
         {layoutOptions.stylePanelVisible ? (
-          <StylePanel
-            mapControllerRef={mapControllerRef}
-            onResizeStart={startStylePanelResize}
-          />
+          <SectionErrorBoundary label="Style panel">
+            <StylePanel
+              mapControllerRef={mapControllerRef}
+              onResizeStart={startStylePanelResize}
+            />
+          </SectionErrorBoundary>
         ) : null}
       </div>
       {layoutOptions.attributePanelVisible ? (
-        <AttributeTable mapControllerRef={mapControllerRef} />
+        <SectionErrorBoundary label="Attribute table">
+          <AttributeTable mapControllerRef={mapControllerRef} />
+        </SectionErrorBoundary>
       ) : null}
       {layoutOptions.statusBarVisible ? (
-        <StatusBar
-          compact={layoutOptions.compact}
-          diagnosticsErrorCount={diagnostics.errorCount}
-          diagnosticsWarningCount={diagnostics.warningCount}
-          onOpenDiagnostics={() => setDiagnosticsOpen(true)}
-        />
+        <SectionErrorBoundary label="Status bar">
+          <StatusBar
+            compact={layoutOptions.compact}
+            diagnosticsErrorCount={diagnostics.errorCount}
+            diagnosticsWarningCount={diagnostics.warningCount}
+            onOpenDiagnostics={() => setDiagnosticsOpen(true)}
+          />
+        </SectionErrorBoundary>
       ) : null}
       <DiagnosticsDialog
         diagnostics={diagnostics}

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -899,7 +899,7 @@ export function DesktopShell({
             layoutOptions.compact ? "min-h-0" : "min-h-72 md:min-h-0"
           }`}
         >
-          <SectionErrorBoundary label="Map" className="h-full w-full">
+          <SectionErrorBoundary label="Map" fallbackClassName="h-full w-full">
             <MapCanvas
               controllerRef={mapControllerRef}
               onMapDiagnosticEvent={handleMapDiagnosticEvent}

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -43,6 +43,7 @@ import {
   resolvePluginAssetUrlForLoadedPlugin,
   unloadRemovedUrlPlugins,
 } from "../lib/external-plugins";
+import { appendDiagnostic } from "../lib/diagnostics";
 import { mergeStringLists } from "../lib/string-lists";
 import {
   openLocalDataFileWithFallback,
@@ -51,6 +52,22 @@ import {
 import { useDesktopSettingsStore } from "./useDesktopSettings";
 
 const RASTER_PROXY_PATH = "/__geolibre_raster_proxy";
+
+/** Records a plugin failure in the diagnostics panel without crashing the app. */
+function reportPluginError(
+  pluginId: string,
+  action: string,
+  error: unknown,
+): void {
+  const normalized = error instanceof Error ? error : new Error(String(error));
+  appendDiagnostic({
+    category: "runtime",
+    level: "error",
+    message: `Plugin "${pluginId}" failed to ${action}: ${normalized.message}`,
+    detail: normalized.stack,
+    source: `plugin:${pluginId}`,
+  });
+}
 
 interface TauriRuntimeWindow extends Window {
   __TAURI_INTERNALS__?: unknown;
@@ -158,7 +175,14 @@ export function usePluginRegistry() {
     getProjectState: () => manager.getProjectState(),
     toggle: (id: string, appApi: ReturnType<typeof createAppAPI>) => {
       const before = JSON.stringify(projectPluginStateSnapshot());
-      manager.toggle(id, appApi);
+      // Plugin controls are imperative MapLibre code, so a throw here escapes
+      // React's error boundaries. Contain it so one bad plugin can't break the
+      // toggle handler — surface it in diagnostics instead.
+      try {
+        manager.toggle(id, appApi);
+      } catch (error) {
+        reportPluginError(id, "toggle", error);
+      }
       persistProjectPluginState(before);
     },
     setMapControlPosition: (
@@ -167,7 +191,11 @@ export function usePluginRegistry() {
       position: GeoLibreMapControlPosition,
     ) => {
       const before = JSON.stringify(projectPluginStateSnapshot());
-      manager.setMapControlPosition(id, appApi, position);
+      try {
+        manager.setMapControlPosition(id, appApi, position);
+      } catch (error) {
+        reportPluginError(id, "reposition", error);
+      }
       persistProjectPluginState(before);
     },
   };

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -182,6 +182,10 @@ export function usePluginRegistry() {
       try {
         manager.toggle(id, appApi);
       } catch (error) {
+        // Known limitation: if toggle throws after a partial mutation (e.g. the
+        // control attached but a later step failed), the in-memory PluginManager
+        // state may be inconsistent. Project persistence is protected by the
+        // early return below; in-memory state is not rolled back.
         reportPluginError(id, "toggle", error);
         return;
       }

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -177,11 +177,13 @@ export function usePluginRegistry() {
       const before = JSON.stringify(projectPluginStateSnapshot());
       // Plugin controls are imperative MapLibre code, so a throw here escapes
       // React's error boundaries. Contain it so one bad plugin can't break the
-      // toggle handler — surface it in diagnostics instead.
+      // toggle handler — surface it in diagnostics instead. Return without
+      // persisting so a half-applied failure is not written to the project.
       try {
         manager.toggle(id, appApi);
       } catch (error) {
         reportPluginError(id, "toggle", error);
+        return;
       }
       persistProjectPluginState(before);
     },
@@ -195,6 +197,7 @@ export function usePluginRegistry() {
         manager.setMapControlPosition(id, appApi, position);
       } catch (error) {
         reportPluginError(id, "reposition", error);
+        return;
       }
       persistProjectPluginState(before);
     },

--- a/apps/geolibre-desktop/src/main.tsx
+++ b/apps/geolibre-desktop/src/main.tsx
@@ -36,11 +36,11 @@ installDiagnosticsCapture();
 // no-op in the desktop build, whose chunks are bundled locally.
 installStaleChunkReload();
 
-void import("./App")
-  .then(async ({ default: App }) => {
-    const { AppErrorBoundary } = await import(
-      "./components/common/error-boundaries"
-    );
+// Fetch both chunks in parallel rather than waterfalling the boundary import
+// after App resolves — a free win, and it matters over the network in the web
+// build where these are separate fetches.
+void Promise.all([import("./App"), import("./components/common/error-boundaries")])
+  .then(([{ default: App }, { AppErrorBoundary }]) => {
     ReactDOM.createRoot(document.getElementById("root")!).render(
       <React.StrictMode>
         <AppErrorBoundary>

--- a/apps/geolibre-desktop/src/main.tsx
+++ b/apps/geolibre-desktop/src/main.tsx
@@ -37,10 +37,15 @@ installDiagnosticsCapture();
 installStaleChunkReload();
 
 void import("./App")
-  .then(({ default: App }) => {
+  .then(async ({ default: App }) => {
+    const { AppErrorBoundary } = await import(
+      "./components/common/error-boundaries"
+    );
     ReactDOM.createRoot(document.getElementById("root")!).render(
       <React.StrictMode>
-        <App />
+        <AppErrorBoundary>
+          <App />
+        </AppErrorBoundary>
       </React.StrictMode>,
     );
   })

--- a/packages/ui/src/components/error-boundary.tsx
+++ b/packages/ui/src/components/error-boundary.tsx
@@ -18,6 +18,10 @@ export interface ErrorBoundaryProps {
    * its captured error and re-renders its children. Use it to recover
    * automatically when the inputs that caused the crash change (for example a
    * different selected layer).
+   *
+   * Note: adding or removing the prop entirely (undefined ↔ non-empty array)
+   * also counts as a change and will trigger a reset. Absent and empty (`[]`)
+   * are treated as equivalent, so toggling between those two does not reset.
    */
   resetKeys?: readonly unknown[];
 }

--- a/packages/ui/src/components/error-boundary.tsx
+++ b/packages/ui/src/components/error-boundary.tsx
@@ -1,0 +1,83 @@
+import * as React from "react";
+
+export interface ErrorBoundaryFallbackProps {
+  /** The error that was thrown by a descendant during render. */
+  error: Error;
+  /** Clears the error and re-renders the boundary's children. */
+  reset: () => void;
+}
+
+export interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  /** Rendered in place of the children once a descendant throws. */
+  fallback: (props: ErrorBoundaryFallbackProps) => React.ReactNode;
+  /** Called when a descendant throws, after the fallback is shown. */
+  onError?: (error: Error, info: React.ErrorInfo) => void;
+  /**
+   * When any value in this array changes between renders, the boundary clears
+   * its captured error and re-renders its children. Use it to recover
+   * automatically when the inputs that caused the crash change (for example a
+   * different selected layer).
+   */
+  resetKeys?: readonly unknown[];
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * A generic React error boundary. It catches render-time errors thrown by its
+ * descendants, renders a caller-supplied fallback in their place, and reports
+ * the error through `onError`. It is deliberately presentation-agnostic so each
+ * call site can supply an appropriate fallback (full-screen recovery, compact
+ * inline notice, etc.).
+ *
+ * Note: error boundaries only catch errors thrown during React rendering,
+ * lifecycle methods, and constructors of descendants. They do not catch errors
+ * in event handlers, asynchronous code, or imperative (non-React) code.
+ */
+export class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    this.props.onError?.(error, info);
+  }
+
+  componentDidUpdate(prevProps: ErrorBoundaryProps): void {
+    if (this.state.error === null) return;
+    if (!resetKeysChanged(prevProps.resetKeys, this.props.resetKeys)) return;
+    this.reset();
+  }
+
+  reset = (): void => {
+    this.setState({ error: null });
+  };
+
+  render(): React.ReactNode {
+    const { error } = this.state;
+    if (error !== null) {
+      return this.props.fallback({ error, reset: this.reset });
+    }
+    return this.props.children;
+  }
+}
+
+function resetKeysChanged(
+  prev: readonly unknown[] | undefined,
+  next: readonly unknown[] | undefined,
+): boolean {
+  if (prev === next) return false;
+  if (!prev || !next || prev.length !== next.length) return true;
+  for (let index = 0; index < prev.length; index += 1) {
+    if (!Object.is(prev[index], next[index])) return true;
+  }
+  return false;
+}

--- a/packages/ui/src/components/error-boundary.tsx
+++ b/packages/ui/src/components/error-boundary.tsx
@@ -70,11 +70,14 @@ export class ErrorBoundary extends React.Component<
   }
 }
 
-function resetKeysChanged(
+export function resetKeysChanged(
   prev: readonly unknown[] | undefined,
   next: readonly unknown[] | undefined,
 ): boolean {
   if (prev === next) return false;
+  // Treat absent and empty the same: no keys means no automatic resets, so a
+  // transition between `undefined` and `[]` must not trigger one.
+  if ((!prev || prev.length === 0) && (!next || next.length === 0)) return false;
   if (!prev || !next || prev.length !== next.length) return true;
   for (let index = 0; index < prev.length; index += 1) {
     if (!Object.is(prev[index], next[index])) return true;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -38,3 +38,8 @@ export {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "./components/dropdown-menu";
+export {
+  ErrorBoundary,
+  type ErrorBoundaryProps,
+  type ErrorBoundaryFallbackProps,
+} from "./components/error-boundary";

--- a/tests/error-boundary.test.ts
+++ b/tests/error-boundary.test.ts
@@ -71,6 +71,45 @@ describe("resetKeysChanged", () => {
   });
 });
 
+describe("ErrorBoundary recovery wiring (componentDidUpdate)", () => {
+  // reset() uses setState, which is a no-op on an instance that React has not
+  // mounted, so spy on reset to assert the control flow instead.
+  function makeBoundary(resetKeys: readonly unknown[] | undefined) {
+    const props = {
+      children: null,
+      fallback: () => null,
+      resetKeys,
+    };
+    const boundary = new ErrorBoundary(props);
+    let resetCalls = 0;
+    boundary.reset = () => {
+      resetCalls += 1;
+    };
+    return { boundary, props, resetCalls: () => resetCalls };
+  }
+
+  it("resets when a resetKey changes while in the error state", () => {
+    const { boundary, props, resetCalls } = makeBoundary(["a"]);
+    boundary.state = { error: new Error("boom") };
+    boundary.componentDidUpdate({ ...props, resetKeys: ["b"] });
+    assert.equal(resetCalls(), 1);
+  });
+
+  it("does not reset when resetKeys are unchanged", () => {
+    const { boundary, props, resetCalls } = makeBoundary(["a"]);
+    boundary.state = { error: new Error("boom") };
+    boundary.componentDidUpdate(props);
+    assert.equal(resetCalls(), 0);
+  });
+
+  it("does not reset when there is no active error", () => {
+    const { boundary, props, resetCalls } = makeBoundary(["a"]);
+    // state.error stays null
+    boundary.componentDidUpdate({ ...props, resetKeys: ["b"] });
+    assert.equal(resetCalls(), 0);
+  });
+});
+
 describe("reportBoundaryError", () => {
   beforeEach(() => {
     clearDiagnostics();

--- a/tests/error-boundary.test.ts
+++ b/tests/error-boundary.test.ts
@@ -25,12 +25,13 @@ type DiagnosticsModule =
   typeof import("../apps/geolibre-desktop/src/lib/diagnostics");
 
 let ErrorBoundary: ErrorBoundaryModule["ErrorBoundary"];
+let resetKeysChanged: ErrorBoundaryModule["resetKeysChanged"];
 let reportBoundaryError: BoundariesModule["reportBoundaryError"];
 let clearDiagnostics: DiagnosticsModule["clearDiagnostics"];
 let getDiagnosticsSnapshot: DiagnosticsModule["getDiagnosticsSnapshot"];
 
 before(async () => {
-  ({ ErrorBoundary } = await import(
+  ({ ErrorBoundary, resetKeysChanged } = await import(
     "../packages/ui/src/components/error-boundary"
   ));
   ({ reportBoundaryError } = await import(
@@ -45,6 +46,28 @@ describe("ErrorBoundary derived state", () => {
   it("captures the thrown error into state", () => {
     const error = new Error("boom");
     assert.deepEqual(ErrorBoundary.getDerivedStateFromError(error), { error });
+  });
+});
+
+describe("resetKeysChanged", () => {
+  it("treats absent and empty key lists the same (no reset)", () => {
+    assert.equal(resetKeysChanged(undefined, undefined), false);
+    assert.equal(resetKeysChanged(undefined, []), false);
+    assert.equal(resetKeysChanged([], undefined), false);
+    assert.equal(resetKeysChanged([], []), false);
+  });
+
+  it("does not reset when keys are unchanged", () => {
+    assert.equal(resetKeysChanged(["a", 1], ["a", 1]), false);
+  });
+
+  it("resets when a key value changes", () => {
+    assert.equal(resetKeysChanged(["a"], ["b"]), true);
+  });
+
+  it("resets when the key count changes", () => {
+    assert.equal(resetKeysChanged(["a"], ["a", "b"]), true);
+    assert.equal(resetKeysChanged([], ["a"]), true);
   });
 });
 

--- a/tests/error-boundary.test.ts
+++ b/tests/error-boundary.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { before, beforeEach, describe, it } from "node:test";
+
+// diagnostics.ts (pulled in transitively by the desktop boundaries) reads
+// localStorage at import time, so the window stub must be installed before the
+// modules are loaded; hence the dynamic imports below.
+const storage = new Map<string, string>();
+(globalThis as { window?: unknown }).window = {
+  localStorage: {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      storage.set(key, value);
+    },
+    removeItem: (key: string) => {
+      storage.delete(key);
+    },
+  },
+};
+
+type ErrorBoundaryModule =
+  typeof import("../packages/ui/src/components/error-boundary");
+type BoundariesModule =
+  typeof import("../apps/geolibre-desktop/src/components/common/error-boundaries");
+type DiagnosticsModule =
+  typeof import("../apps/geolibre-desktop/src/lib/diagnostics");
+
+let ErrorBoundary: ErrorBoundaryModule["ErrorBoundary"];
+let reportBoundaryError: BoundariesModule["reportBoundaryError"];
+let clearDiagnostics: DiagnosticsModule["clearDiagnostics"];
+let getDiagnosticsSnapshot: DiagnosticsModule["getDiagnosticsSnapshot"];
+
+before(async () => {
+  ({ ErrorBoundary } = await import(
+    "../packages/ui/src/components/error-boundary"
+  ));
+  ({ reportBoundaryError } = await import(
+    "../apps/geolibre-desktop/src/components/common/error-boundaries"
+  ));
+  ({ clearDiagnostics, getDiagnosticsSnapshot } = await import(
+    "../apps/geolibre-desktop/src/lib/diagnostics"
+  ));
+});
+
+describe("ErrorBoundary derived state", () => {
+  it("captures the thrown error into state", () => {
+    const error = new Error("boom");
+    assert.deepEqual(ErrorBoundary.getDerivedStateFromError(error), { error });
+  });
+});
+
+describe("reportBoundaryError", () => {
+  beforeEach(() => {
+    clearDiagnostics();
+  });
+
+  it("records a runtime error diagnostic the user can see", () => {
+    reportBoundaryError("Layer panel", new Error("render failed"), {
+      componentStack: "\n at LayerPanel",
+    });
+    const snapshot = getDiagnosticsSnapshot();
+    assert.equal(snapshot.totalCount, 1);
+    assert.equal(snapshot.errorCount, 1);
+    const [record] = snapshot.records;
+    assert.equal(record.category, "runtime");
+    assert.equal(record.level, "error");
+    assert.match(record.message, /Layer panel crashed: render failed/);
+    assert.equal(record.source, "Layer panel");
+    assert.ok(record.detail?.includes("at LayerPanel"));
+  });
+});


### PR DESCRIPTION
Closes #268.

## Problem

`apps/geolibre-desktop/src/main.tsx` rendered `<App/>` with **no error boundary anywhere in the tree**. A single render-time throw — a malformed layer style, a crashing panel, or a bad `.geolibre.json` — white-screened the entire app, leaving only a `console.error`. This is especially risky because GeoLibre loads arbitrary user data and runs trusted-but-third-party plugin code.

## Changes

- **Reusable primitive** — `ErrorBoundary` added to `@geolibre/ui`: presentation-agnostic (caller supplies the fallback render prop), with `onError` reporting and `resetKeys` for automatic recovery when inputs change.
- **App-level boundary** — `AppErrorBoundary` wraps `<App/>` in `main.tsx` and shows a full-screen recovery panel (Try again / Reload app) instead of a blank page.
- **Section boundaries** — `SectionErrorBoundary` wraps each shell region in `DesktopShell` (toolbar, layer panel, map, style panel, attribute table, status bar). A crash in one region shows a compact inline notice with a Retry button while the rest of the app keeps working.
- **Plugin hardening** — plugin controls are imperative MapLibre code, so their throws escape React boundaries. The `toggle`/`setMapControlPosition` paths in `usePlugins.ts` now `try/catch` and report failures so one bad plugin can't break the handler.
- **Diagnostics integration** — every boundary-caught error and plugin failure is recorded as a `runtime` diagnostic, so it's visible and copyable in the existing Diagnostics panel rather than console-only.

## Tests

- New `tests/error-boundary.test.ts`: covers the boundary's derived-state capture and the diagnostics reporting helper.
- Full suite green: `npm run test:frontend` (371 tests), `npm run lint` (0 errors), `npm run build` (typecheck + bundle), and `pre-commit run --files` all pass.

## Notes

React error boundaries only catch errors thrown during rendering/lifecycle of React descendants — not event handlers, async code, or imperative non-React code. The imperative paths (plugin controls, MapLibre internals) remain covered by the existing global `window.error` diagnostics capture, now complemented by the targeted plugin `try/catch`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App-wide and per-section error boundaries so individual UI areas (toolbar, map, panels, tables, status) fail and recover independently.
  * Full-screen app fallback offering "Try again" and "Reload app"; compact inline fallbacks with "Retry" for sections.
  * Diagnostics capture for component and plugin errors; error boundaries used at startup.
  * UI library now exposes a reusable ErrorBoundary component and reset-key utility.

* **Tests**
  * Added unit tests for error boundary behavior, reset-key logic, and diagnostics reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->