### PR TITLE
feat(ci): add Playwright E2E smoke tests and CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,18 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
 
-      - name: Install Playwright Chromium
+      - name: Install Playwright Chromium (cache miss)
+        if: steps.pw-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps (cache hit)
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       - name: Run E2E smoke tests
         run: npm run test:e2e
+        env:
+          VITE_GEE_OAUTH_CLIENT_ID: ${{ secrets.VITE_GEE_OAUTH_CLIENT_ID }}
 
       - name: Upload Playwright report
         if: ${{ failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,52 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  e2e:
+    name: E2E smoke (Playwright)
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Resolve Playwright version
+        id: pw
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E smoke tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7
+
   checks:
     name: Build and test
     runs-on: ubuntu-22.04

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,12 @@ apps/geolibre-desktop/src/lib/pyodide/vector_ops.generated.py
 .claude/
 uv.lock
 
+# Playwright E2E artifacts
+test-results/
+playwright-report/
+blob-report/
+.playwright/
+
 # Documentation screenshots are hosted on Cloudflare R2 (data.geolibre.app/images),
 # not committed to the repo, to save space.
 docs/assets/screenshots/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,8 +27,14 @@ node --import tsx --test tests/<name>.test.ts      # a single frontend test file
 npm run test:backend                               # pytest backend/geolibre_server/tests
 python -m pytest backend/geolibre_server/tests/test_x.py::test_y   # a single backend test
 npm run test:worker                                # typecheck workers/viewer
+npm run test:e2e                                    # Playwright smoke tests (e2e/) against the built web app
 npm run check:rust                                 # cargo check the Tauri crate
 ```
+
+`npm run test:e2e` builds the web app, serves it with `vite preview`, and drives
+it with Playwright (`@playwright/test`). First run: `npx playwright install
+chromium`. The webServer reuses an already-running preview locally and rebuilds
+in CI; add specs under `e2e/`.
 
 The `python/` package has its own pytest suite (`cd python && pytest`) and is built into a wheel via `npm run build:embed` (produces `apps/geolibre-desktop/dist-embed`, consumed by `python/hatch_build.py`). Its version is dynamic, sourced from `python/src/geolibre/__init__.py`.
 

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -1360,6 +1360,7 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
           </p>
         ) : (
           <table
+            data-testid="attribute-table"
             className="table-fixed caption-bottom text-sm"
             style={{ minWidth: "100%", width: tableWidth }}
           >

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -721,6 +721,8 @@ export function LayerPanel({
             return (
               <div
                 key={layer.id}
+                data-testid="layer-row"
+                data-layer-name={layer.name}
                 className={`relative rounded-md border p-2 transition-colors ${
                   selectedLayerId === layer.id
                     ? "border-primary bg-primary/5"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -128,6 +128,16 @@ You only need the toolchains for the areas you touched. A docs-only or
 frontend-only change does not require Rust or Python, though the full `npm run
 ci` gate does.
 
+### End-to-end smoke tests
+
+`npm run test:e2e` runs the Playwright smoke suite in `e2e/` against the built
+web app (it builds, serves it with `vite preview`, and drives a headless
+Chromium). It is a render-path guardrail — it loads a GeoJSON layer, opens the
+attribute table, toggles visibility, and runs an accessibility check — not
+exhaustive coverage. Install the browser once with `npx playwright install
+chromium`. The suite runs as a separate `E2E smoke (Playwright)` job in CI and
+uploads its report as an artifact on failure.
+
 ### Coding conventions
 
 - The pre-commit hooks enforce TypeScript compile errors (`npm run build`), LF

--- a/e2e/fixtures/smoke.geojson
+++ b/e2e/fixtures/smoke.geojson
@@ -1,0 +1,20 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": { "name": "Alpha", "category": "north", "value": 12 },
+      "geometry": { "type": "Point", "coordinates": [-122.42, 37.77] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "Bravo", "category": "south", "value": 34 },
+      "geometry": { "type": "Point", "coordinates": [-118.24, 34.05] }
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "Charlie", "category": "north", "value": 56 },
+      "geometry": { "type": "Point", "coordinates": [-73.99, 40.73] }
+    }
+  ]
+}

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -22,19 +22,25 @@ async function waitForMap(page: Page): Promise<void> {
  * parsed in-browser with no DuckDB/CDN dependency, so this stays hermetic.
  */
 async function dropGeoJson(page: Page, name: string, text: string): Promise<void> {
-  const dataTransfer = await page.evaluateHandle((contents) => {
-    const dt = new DataTransfer();
-    dt.items.add(
-      new File([contents], "smoke.geojson", { type: "application/geo+json" }),
-    );
-    return dt;
-  }, text);
+  // `name` is test-controlled and assumed simple/ASCII: it is the dropped
+  // file's base name and, after the drop pipeline strips the extension, the
+  // layer name interpolated into the CSS attribute selector below.
+  const dataTransfer = await page.evaluateHandle(
+    ({ contents, fileName }) => {
+      const dt = new DataTransfer();
+      dt.items.add(
+        new File([contents], fileName, { type: "application/geo+json" }),
+      );
+      return dt;
+    },
+    { contents: text, fileName: `${name}.geojson` },
+  );
   for (const type of ["dragenter", "dragover", "drop"]) {
     await page.dispatchEvent('[data-testid="map-canvas"]', type, {
       dataTransfer,
     });
   }
-  // name is the layer label the drop pipeline derives from the file name.
+  await dataTransfer.dispose();
   await expect(
     page.locator(`[data-testid="layer-row"][data-layer-name="${name}"]`),
   ).toBeVisible();

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,87 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test, type Page } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const FIXTURE_PATH = join(__dirname, "fixtures", "smoke.geojson");
+const FIXTURE_TEXT = readFileSync(FIXTURE_PATH, "utf8");
+const FIXTURE_FEATURE_COUNT = 3;
+
+/** Waits for MapLibre to mount its WebGL canvas — the app's "map ready" signal. */
+async function waitForMap(page: Page): Promise<void> {
+  await page.goto("/");
+  await expect(page.getByTestId("map-canvas")).toBeVisible();
+  await expect(page.locator(".maplibregl-canvas")).toBeVisible({
+    timeout: 30_000,
+  });
+}
+
+/**
+ * Drops a GeoJSON file onto the map surface, exercising the real browser
+ * drag-and-drop path (`handleDrop` -> `addGeoJsonLayer`). A `.geojson` file is
+ * parsed in-browser with no DuckDB/CDN dependency, so this stays hermetic.
+ */
+async function dropGeoJson(page: Page, name: string, text: string): Promise<void> {
+  const dataTransfer = await page.evaluateHandle((contents) => {
+    const dt = new DataTransfer();
+    dt.items.add(
+      new File([contents], "smoke.geojson", { type: "application/geo+json" }),
+    );
+    return dt;
+  }, text);
+  for (const type of ["dragenter", "dragover", "drop"]) {
+    await page.dispatchEvent('[data-testid="map-canvas"]', type, {
+      dataTransfer,
+    });
+  }
+  // name is the layer label the drop pipeline derives from the file name.
+  await expect(
+    page.locator(`[data-testid="layer-row"][data-layer-name="${name}"]`),
+  ).toBeVisible();
+}
+
+test("loads a GeoJSON layer, opens the attribute table, and toggles visibility", async ({
+  page,
+}) => {
+  await waitForMap(page);
+
+  // 1. Add a layer via drag-and-drop and confirm it appears in the layer panel.
+  await dropGeoJson(page, "smoke", FIXTURE_TEXT);
+  const row = page
+    .locator('[data-testid="layer-row"]', { hasText: "smoke" })
+    .first();
+
+  // 2. Toggle layer visibility and confirm the control reflects the new state.
+  // Done before the actions menu below so no Radix dropdown overlay (which
+  // briefly sets pointer-events:none on the body) can intercept the click.
+  await row.locator('button[aria-label="Hide layer"]').click();
+  await expect(row.locator('button[aria-label="Show layer"]')).toBeVisible();
+
+  // 3. Open the attribute table from the layer actions menu and assert rows.
+  await row.locator('button[aria-label="Layer actions"]').click();
+  await page.getByRole("menuitem", { name: "Open attribute table" }).click();
+  await expect(page.getByTestId("attribute-table")).toBeVisible();
+  await expect(page.locator('[data-testid="attribute-table"] tbody tr')).toHaveCount(
+    FIXTURE_FEATURE_COUNT,
+  );
+});
+
+test("has no critical accessibility violations on the initial view", async ({
+  page,
+}, testInfo) => {
+  await waitForMap(page);
+
+  const results = await new AxeBuilder({ page }).analyze();
+  await testInfo.attach("axe-violations", {
+    body: JSON.stringify(results.violations, null, 2),
+    contentType: "application/json",
+  });
+
+  // A full a11y gate lands with the accessibility pass (#272); this smoke check
+  // guards only against the most severe (critical-impact) regressions.
+  const critical = results.violations.filter((v) => v.impact === "critical");
+  expect(
+    critical,
+    `critical a11y violations: ${critical.map((v) => v.id).join(", ") || "none"}`,
+  ).toEqual([]);
+});

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -5,7 +5,11 @@ import { join } from "node:path";
 
 const FIXTURE_PATH = join(__dirname, "fixtures", "smoke.geojson");
 const FIXTURE_TEXT = readFileSync(FIXTURE_PATH, "utf8");
-const FIXTURE_FEATURE_COUNT = 3;
+// Derived from the fixture so the expected row count can't drift if a feature
+// is added or removed.
+const FIXTURE_FEATURE_COUNT = (
+  JSON.parse(FIXTURE_TEXT) as { features: unknown[] }
+).features.length;
 
 /** Waits for MapLibre to mount its WebGL canvas — the app's "map ready" signal. */
 async function waitForMap(page: Page): Promise<void> {
@@ -53,9 +57,8 @@ test("loads a GeoJSON layer, opens the attribute table, and toggles visibility",
 
   // 1. Add a layer via drag-and-drop and confirm it appears in the layer panel.
   await dropGeoJson(page, "smoke", FIXTURE_TEXT);
-  const row = page
-    .locator('[data-testid="layer-row"]', { hasText: "smoke" })
-    .first();
+  // dropGeoJson already asserted exactly one row with this name is visible.
+  const row = page.locator('[data-testid="layer-row"][data-layer-name="smoke"]');
 
   // 2. Toggle layer visibility and confirm the control reflects the new state.
   // Done before the actions menu below so no Radix dropdown overlay (which
@@ -64,6 +67,8 @@ test("loads a GeoJSON layer, opens the attribute table, and toggles visibility",
   await expect(row.locator('button[aria-label="Show layer"]')).toBeVisible();
 
   // 3. Open the attribute table from the layer actions menu and assert rows.
+  // Opening it while the layer is hidden (from step 2) is intentional and fine:
+  // the table reads features from the store, not from the rendered map.
   await row.locator('button[aria-label="Layer actions"]').click();
   await page.getByRole("menuitem", { name: "Open attribute table" }).click();
   await expect(page.getByTestId("attribute-table")).toBeVisible();

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "workers/*"
       ],
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.3",
+        "@playwright/test": "^1.60.0",
         "@types/node": "^22.19.21",
         "eslint": "^10.4.1",
         "eslint-plugin-react-hooks": "^7.1.1",
@@ -799,6 +801,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4597,6 +4612,22 @@
       },
       "peerDependencies": {
         "@types/geojson": "*"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@poppinss/colors": {
@@ -10241,6 +10272,16 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -15610,6 +15651,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plur": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:frontend": "node --import tsx --test tests/*.test.ts",
     "test:backend": "python -m pytest backend/geolibre_server/tests",
     "test:worker": "npm run typecheck -w geolibre-viewer-worker",
+    "test:e2e": "playwright test",
     "check:rust": "cargo check --manifest-path apps/geolibre-desktop/src-tauri/Cargo.toml",
     "ci": "npm run lint && npm run build && npm run test:frontend && npm run test:worker && npm run test:backend && npm run check:rust",
     "tauri": "npm run tauri -w geolibre-desktop",
@@ -34,6 +35,8 @@
     "node": ">=22"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.3",
+    "@playwright/test": "^1.60.0",
     "@types/node": "^22.19.21",
     "eslint": "^10.4.1",
     "eslint-plugin-react-hooks": "^7.1.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,51 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = 4173;
+const BASE_URL = `http://localhost:${PORT}`;
+
+// End-to-end smoke tests run against the *built* web app served by `vite
+// preview` (matching production output), not the dev server. The webServer
+// command builds first so the suite is self-contained; locally an
+// already-running preview is reused instead of rebuilding.
+export default defineConfig({
+  testDir: "./e2e",
+  // One small smoke file driving a single shared server — keep it serial.
+  workers: 1,
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  reporter: process.env.CI
+    ? [["list"], ["html", { open: "never" }]]
+    : [["list"]],
+  use: {
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "off",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        launchOptions: {
+          // MapLibre needs a WebGL context; force software ANGLE/SwiftShader so
+          // the map initializes on headless CI runners without a real GPU.
+          args: ["--use-gl=angle", "--use-angle=swiftshader"],
+        },
+      },
+    },
+  ],
+  webServer: {
+    command: `npm run build && npm run preview -w geolibre-desktop -- --port ${PORT} --strictPort`,
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    // The build (tsc -b + vite build) runs as part of this command, so allow
+    // generous startup time on cold CI runners.
+    timeout: 300_000,
+    stdout: "pipe",
+    stderr: "pipe",
+  },
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,7 +11,6 @@ export default defineConfig({
   testDir: "./e2e",
   // One small smoke file driving a single shared server — keep it serial.
   workers: 1,
-  fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   timeout: 60_000,


### PR DESCRIPTION
Closes #270.

## Problem

CI runs lint + build + unit tests, but nothing exercises the **MapLibre GL / deck.gl render path**. Regressions in layer rendering, store→sync reconciliation, and dialogs can pass CI today.

## What this adds

A small, fast end-to-end **smoke** guardrail (not exhaustive coverage) against the **built** web app:

- **`playwright.config.ts`** — builds the app and serves it with `vite preview` on a fixed port; forces software WebGL (`--use-gl=angle --use-angle=swiftshader`) so MapLibre initializes on headless CI runners; reuses a running preview locally and rebuilds in CI.
- **`e2e/smoke.spec.ts`**:
  1. Loads the app and waits for the MapLibre canvas (map-ready signal).
  2. Adds a GeoJSON layer through the **real drag-and-drop path** (`handleDrop` → `addGeoJsonLayer`). A `.geojson` parses in-browser via `JSON.parse` with **no DuckDB/CDN dependency**, so the test is hermetic (only the basemap needs network, and we wait on the canvas element, not tiles).
  3. Asserts the layer row appears in the layer panel.
  4. Toggles layer visibility and asserts the control flips.
  5. Opens the attribute table from the layer actions menu and asserts the row count (3).
  - A second test runs **`@axe-core/playwright`** and fails only on **critical-impact** violations — the full a11y gate lands with #272; this guards against the most severe regressions and attaches the violation report.
- **Minimal test hooks**: `data-testid` on the layer row (+ `data-layer-name`) and the attribute table (the map canvas already had one). No behavior change.
- **CI**: new `E2E smoke (Playwright)` job in `ci.yml` with Playwright browser caching that uploads the report as an artifact on failure, on PRs/pushes to `main`.
- `npm run test:e2e` script; docs in `CLAUDE.md` and `docs/contributing.md`; Playwright artifacts gitignored.

## Verification

- `npm run test:e2e` — both tests pass locally (~16s including build).
- `npm run lint` (0 errors), `npm run test:frontend` (406 pass), and `pre-commit run --files` all green.

## Notes

The drag-and-drop load path was chosen over the third-party vector panel because it's first-party and ends in the core `addGeoJsonLayer`, making the test stable and CDN-free. First-time local run needs `npx playwright install chromium`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end smoke tests covering map load, drag-and-drop GeoJSON import, layer visibility toggles, attribute table behavior, and automated accessibility checks; includes fixture data and UI test selectors.

* **Documentation**
  * Expanded testing guidance for running and interpreting E2E smoke tests locally and in CI.

* **Chores**
  * Added CI job to run E2E tests with artifact upload on failure, added test script and Playwright tooling, and excluded test artifacts from source control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->