### PR TITLE
feat(shortcuts): command palette and global keyboard shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS
 - SQL Workspace for running DuckDB Spatial SQL against loaded layers, local files, and remote URLs, with sample queries, query history, and adding results to the map or exporting them
 - Multiple DuckDB SQL query-result layers with identify, selection, and attribute table support
 - Controls menu with Measure, Bookmark, Minimap, and View State tools, plus a Print menu and a Search panel
-- Command palette (`Ctrl`/`Cmd` + `K`) that searches and runs every menu and toolbar action, global keyboard shortcuts for New/Open/Save/Save As, and a `?` shortcuts cheat sheet
+- Command palette (`Ctrl`/`Cmd` + `K`) that searches and runs menu and toolbar actions across Add Data, Processing, Controls, Plugins, and Help, global keyboard shortcuts for New/Open/Save/Save As, and a `?` shortcuts cheat sheet
 - Conversion menu for Vector to GeoParquet/FlatGeobuf/PMTiles, CSV to GeoParquet, and Raster to COG; GeoParquet and CSV conversions run in the browser with DuckDB-WASM, while FlatGeobuf, PMTiles, and COG require the optional Python sidecar
 - Whitebox toolbox with batch tools run against a selected input directory
 - Vector menu with common geometry tools (buffer, centroids, convex hull, dissolve, bounding box, simplify, clip, intersection, difference, union, spatial join, select by value, select by location) that run in the browser with Turf.js, an optional GeoPandas sidecar engine for every tool, and an in-browser GeoPandas engine via Pyodide (no server, same results as the sidecar)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS
 - SQL Workspace for running DuckDB Spatial SQL against loaded layers, local files, and remote URLs, with sample queries, query history, and adding results to the map or exporting them
 - Multiple DuckDB SQL query-result layers with identify, selection, and attribute table support
 - Controls menu with Measure, Bookmark, Minimap, and View State tools, plus a Print menu and a Search panel
+- Command palette (`Ctrl`/`Cmd` + `K`) that searches and runs every menu and toolbar action, global keyboard shortcuts for New/Open/Save/Save As, and a `?` shortcuts cheat sheet
 - Conversion menu for Vector to GeoParquet/FlatGeobuf/PMTiles, CSV to GeoParquet, and Raster to COG; GeoParquet and CSV conversions run in the browser with DuckDB-WASM, while FlatGeobuf, PMTiles, and COG require the optional Python sidecar
 - Whitebox toolbox with batch tools run against a selected input directory
 - Vector menu with common geometry tools (buffer, centroids, convex hull, dissolve, bounding box, simplify, clip, intersection, difference, union, spatial join, select by value, select by location) that run in the browser with Turf.js, an optional GeoPandas sidecar engine for every tool, and an in-browser GeoPandas engine via Pyodide (no server, same results as the sidecar)

--- a/apps/geolibre-desktop/src/components/command/CommandPalette.tsx
+++ b/apps/geolibre-desktop/src/components/command/CommandPalette.tsx
@@ -1,0 +1,176 @@
+import { Dialog, DialogContent, DialogTitle } from "@geolibre/ui";
+import { Search } from "lucide-react";
+import {
+  type KeyboardEvent as ReactKeyboardEvent,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  type Command,
+  filterCommands,
+  formatShortcut,
+  isMacPlatform,
+} from "../../lib/commands";
+
+interface CommandPaletteProps {
+  open: boolean;
+  commands: Command[];
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * A searchable command palette (Cmd/Ctrl-K) built from the shared command
+ * registry. Type to filter, navigate with arrow keys, and press Enter to run
+ * the highlighted command.
+ */
+export function CommandPalette({
+  open,
+  commands,
+  onOpenChange,
+}: CommandPaletteProps) {
+  const [query, setQuery] = useState("");
+  const [activeIndex, setActiveIndex] = useState(0);
+  const listRef = useRef<HTMLDivElement>(null);
+  const isMac = useMemo(() => isMacPlatform(), []);
+
+  const filtered = useMemo(
+    () => filterCommands(commands, query),
+    [commands, query],
+  );
+
+  // Reset the query each time the palette opens so it always starts fresh.
+  useEffect(() => {
+    if (open) {
+      setQuery("");
+      setActiveIndex(0);
+    }
+  }, [open]);
+
+  // Keep the highlight within bounds as the filtered list shrinks/grows.
+  useEffect(() => {
+    setActiveIndex((index) =>
+      filtered.length === 0 ? 0 : Math.min(index, filtered.length - 1),
+    );
+  }, [filtered.length]);
+
+  // Scroll the highlighted row into view as the user navigates.
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+    const active = list.querySelector<HTMLElement>('[data-active="true"]');
+    active?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex, filtered]);
+
+  const runCommand = (command: Command) => {
+    onOpenChange(false);
+    command.run();
+  };
+
+  const handleInputKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setActiveIndex((index) =>
+        filtered.length === 0 ? 0 : (index + 1) % filtered.length,
+      );
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveIndex((index) =>
+        filtered.length === 0
+          ? 0
+          : (index - 1 + filtered.length) % filtered.length,
+      );
+    } else if (event.key === "Home") {
+      event.preventDefault();
+      setActiveIndex(0);
+    } else if (event.key === "End") {
+      event.preventDefault();
+      setActiveIndex(Math.max(0, filtered.length - 1));
+    } else if (event.key === "Enter") {
+      event.preventDefault();
+      const command = filtered[activeIndex];
+      if (command) runCommand(command);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        aria-describedby={undefined}
+        bodyClassName="p-0 gap-0"
+        className="top-[15%] max-w-xl translate-y-0"
+      >
+        <DialogTitle className="sr-only">Command palette</DialogTitle>
+        <div className="flex items-center gap-2 border-b px-3 pr-10">
+          <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <input
+            autoFocus
+            aria-label="Search commands"
+            className="h-11 w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+            placeholder="Search commands…"
+            value={query}
+            onChange={(event) => {
+              setQuery(event.target.value);
+              setActiveIndex(0);
+            }}
+            onKeyDown={handleInputKeyDown}
+          />
+        </div>
+        <div
+          ref={listRef}
+          className="max-h-[min(60vh,24rem)] overflow-y-auto p-1"
+          role="listbox"
+          aria-label="Commands"
+        >
+          {filtered.length === 0 ? (
+            <p className="px-3 py-6 text-center text-sm text-muted-foreground">
+              No matching commands
+            </p>
+          ) : (
+            filtered.map((command, index) => {
+              const Icon = command.icon;
+              const previousGroup = filtered[index - 1]?.group;
+              const showGroup = command.group !== previousGroup;
+              const isActive = index === activeIndex;
+              return (
+                <div key={command.id}>
+                  {showGroup ? (
+                    <div className="px-2 pb-1 pt-2 text-xs font-medium text-muted-foreground">
+                      {command.group}
+                    </div>
+                  ) : null}
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={isActive}
+                    data-active={isActive}
+                    className={`flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm ${
+                      isActive
+                        ? "bg-accent text-accent-foreground"
+                        : "text-foreground"
+                    }`}
+                    onMouseMove={() => setActiveIndex(index)}
+                    onClick={() => runCommand(command)}
+                  >
+                    {Icon ? (
+                      <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                    ) : null}
+                    <span className="min-w-0 flex-1 truncate">
+                      {command.title}
+                    </span>
+                    {command.shortcut ? (
+                      <kbd className="shrink-0 rounded border bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+                        {formatShortcut(command.shortcut, isMac)}
+                      </kbd>
+                    ) : null}
+                  </button>
+                </div>
+              );
+            })
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/geolibre-desktop/src/components/command/CommandPalette.tsx
+++ b/apps/geolibre-desktop/src/components/command/CommandPalette.tsx
@@ -34,11 +34,14 @@ export function CommandPalette({
   const [activeIndex, setActiveIndex] = useState(0);
   const listRef = useRef<HTMLDivElement>(null);
   const isMac = useMemo(() => isMacPlatform(), []);
+  const listboxId = "command-palette-listbox";
+  const optionId = (command: Command) => `command-option-${command.id}`;
 
   const filtered = useMemo(
     () => filterCommands(commands, query),
     [commands, query],
   );
+  const activeCommand = filtered[activeIndex];
 
   // Reset the query each time the palette opens so it always starts fresh.
   useEffect(() => {
@@ -106,7 +109,13 @@ export function CommandPalette({
           <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
           <input
             autoFocus
+            role="combobox"
             aria-label="Search commands"
+            aria-expanded={true}
+            aria-controls={listboxId}
+            aria-activedescendant={
+              activeCommand ? optionId(activeCommand) : undefined
+            }
             className="h-11 w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
             placeholder="Search commands…"
             value={query}
@@ -119,6 +128,7 @@ export function CommandPalette({
         </div>
         <div
           ref={listRef}
+          id={listboxId}
           className="max-h-[min(60vh,24rem)] overflow-y-auto p-1"
           role="listbox"
           aria-label="Commands"
@@ -142,6 +152,7 @@ export function CommandPalette({
                   ) : null}
                   <button
                     type="button"
+                    id={optionId(command)}
                     role="option"
                     aria-selected={isActive}
                     data-active={isActive}

--- a/apps/geolibre-desktop/src/components/command/KeyboardShortcutsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/command/KeyboardShortcutsDialog.tsx
@@ -22,6 +22,7 @@ interface KeyboardShortcutsDialogProps {
 }
 
 interface ShortcutRow {
+  id: string;
   label: string;
   shortcut: Shortcut;
 }
@@ -53,10 +54,12 @@ export function KeyboardShortcutsDialog({
     // The palette and cheat-sheet shortcuts are not commands, so list them
     // first under a "General" group.
     pushRow("General", {
+      id: "general.open-command-palette",
       label: "Open command palette",
       shortcut: PALETTE_SHORTCUT,
     });
     pushRow("General", {
+      id: "general.show-keyboard-shortcuts",
       label: "Show keyboard shortcuts",
       shortcut: SHORTCUTS_HELP_SHORTCUT,
     });
@@ -64,6 +67,7 @@ export function KeyboardShortcutsDialog({
     for (const command of commands) {
       if (command.shortcut) {
         pushRow(command.group, {
+          id: command.id,
           label: command.title,
           shortcut: command.shortcut,
         });
@@ -91,7 +95,7 @@ export function KeyboardShortcutsDialog({
               <ul className="space-y-1">
                 {rows.map((row) => (
                   <li
-                    key={row.label}
+                    key={row.id}
                     className="flex items-center justify-between gap-4 text-sm"
                   >
                     <span className="min-w-0 truncate">{row.label}</span>

--- a/apps/geolibre-desktop/src/components/command/KeyboardShortcutsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/command/KeyboardShortcutsDialog.tsx
@@ -1,0 +1,110 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@geolibre/ui";
+import { useMemo } from "react";
+import {
+  type Command,
+  type Shortcut,
+  PALETTE_SHORTCUT,
+  SHORTCUTS_HELP_SHORTCUT,
+  formatShortcut,
+  isMacPlatform,
+} from "../../lib/commands";
+
+interface KeyboardShortcutsDialogProps {
+  open: boolean;
+  commands: Command[];
+  onOpenChange: (open: boolean) => void;
+}
+
+interface ShortcutRow {
+  label: string;
+  shortcut: Shortcut;
+}
+
+/**
+ * A cheat sheet (opened with `?`) listing every global keyboard shortcut,
+ * grouped the same way as the command palette.
+ */
+export function KeyboardShortcutsDialog({
+  open,
+  commands,
+  onOpenChange,
+}: KeyboardShortcutsDialogProps) {
+  const isMac = useMemo(() => isMacPlatform(), []);
+
+  const groups = useMemo(() => {
+    const ordered: Array<{ group: string; rows: ShortcutRow[] }> = [];
+    const indexByGroup = new Map<string, number>();
+    const pushRow = (group: string, row: ShortcutRow) => {
+      let position = indexByGroup.get(group);
+      if (position === undefined) {
+        position = ordered.length;
+        indexByGroup.set(group, position);
+        ordered.push({ group, rows: [] });
+      }
+      ordered[position].rows.push(row);
+    };
+
+    // The palette and cheat-sheet shortcuts are not commands, so list them
+    // first under a "General" group.
+    pushRow("General", {
+      label: "Open command palette",
+      shortcut: PALETTE_SHORTCUT,
+    });
+    pushRow("General", {
+      label: "Show keyboard shortcuts",
+      shortcut: SHORTCUTS_HELP_SHORTCUT,
+    });
+
+    for (const command of commands) {
+      if (command.shortcut) {
+        pushRow(command.group, {
+          label: command.title,
+          shortcut: command.shortcut,
+        });
+      }
+    }
+    return ordered;
+  }, [commands]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Keyboard shortcuts</DialogTitle>
+          <DialogDescription>
+            Press {formatShortcut(PALETTE_SHORTCUT, isMac)} to search every
+            action in the command palette.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          {groups.map(({ group, rows }) => (
+            <div key={group} className="space-y-1.5">
+              <p className="text-xs font-medium text-muted-foreground">
+                {group}
+              </p>
+              <ul className="space-y-1">
+                {rows.map((row) => (
+                  <li
+                    key={row.label}
+                    className="flex items-center justify-between gap-4 text-sm"
+                  >
+                    <span className="min-w-0 truncate">{row.label}</span>
+                    <kbd className="shrink-0 rounded border bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+                      {formatShortcut(row.shortcut, isMac)}
+                    </kbd>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -33,12 +33,14 @@ import {
   Eye,
   EyeOff,
   FolderCog,
+  Keyboard,
   MapPinned,
   LayoutPanelTop,
   PanelLeft,
   PanelRight,
   Plus,
   RotateCcw,
+  Search,
   Settings,
   TableProperties,
   Type,
@@ -63,6 +65,8 @@ interface SettingsDialogProps {
   mapControllerRef: RefObject<MapController | null>;
   showLabels?: boolean;
   onOpenManagePlugins: () => void;
+  onOpenCommandPalette: () => void;
+  onOpenKeyboardShortcuts: () => void;
 }
 
 const SECTION_ITEMS: Array<{
@@ -190,6 +194,8 @@ export function SettingsDialog({
   mapControllerRef,
   showLabels = true,
   onOpenManagePlugins,
+  onOpenCommandPalette,
+  onOpenKeyboardShortcuts,
 }: SettingsDialogProps) {
   const preferences = useAppStore((s) => s.preferences);
   const setPreferences = useAppStore((s) => s.setPreferences);
@@ -524,6 +530,15 @@ export function SettingsDialog({
           <DropdownMenuItem onSelect={() => onOpenManagePlugins()}>
             <Puzzle className="mr-2 h-3.5 w-3.5" />
             Manage Plugins
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={() => onOpenCommandPalette()}>
+            <Search className="mr-2 h-3.5 w-3.5" />
+            Command Palette
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => onOpenKeyboardShortcuts()}>
+            <Keyboard className="mr-2 h-3.5 w-3.5" />
+            Keyboard Shortcuts
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -914,7 +914,7 @@ export function TopToolbar({
       group: "Project",
       keywords: "create",
       icon: FilePlus2,
-      shortcut: { key: "n", mod: true },
+      shortcut: { key: "n", mod: true, shift: false },
       run: () => setNewProjectDialogOpen(true),
     },
     {
@@ -923,7 +923,7 @@ export function TopToolbar({
       group: "Project",
       keywords: "load",
       icon: FolderOpen,
-      shortcut: { key: "o", mod: true },
+      shortcut: { key: "o", mod: true, shift: false },
       run: () => void handleOpenFromFile(),
     },
     {
@@ -1216,6 +1216,31 @@ export function TopToolbar({
       group: "Help",
       icon: Info,
       run: () => setAboutOpen(true),
+    },
+    // Plugins — one toggle per registered plugin. Atmosphere Effects,
+    // Directions, and the deck.gl viz renderer are excluded here because they
+    // are surfaced under Controls / Add Data instead (matching the menus).
+    ...plugins
+      .filter(
+        (plugin) =>
+          plugin.id !== EFFECTS_PLUGIN_ID &&
+          plugin.id !== DIRECTIONS_PLUGIN_ID &&
+          plugin.id !== DECK_VIZ_PLUGIN_ID,
+      )
+      .map((plugin) => ({
+        id: `plugin.${plugin.id}`,
+        title: `Toggle ${plugin.name}`,
+        group: "Plugins",
+        keywords: isActive(plugin.id) ? "plugin deactivate" : "plugin activate",
+        run: () => toggle(plugin.id, appApi),
+      })),
+    // Settings
+    {
+      id: "settings.manage-plugins",
+      title: "Manage Plugins",
+      group: "Settings",
+      keywords: "install external plugin marketplace",
+      run: () => setManagePluginsOpen(true),
     },
   ];
 

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -1894,6 +1894,8 @@ export function TopToolbar({
         mapControllerRef={mapControllerRef}
         showLabels={showLabels}
         onOpenManagePlugins={() => setManagePluginsOpen(true)}
+        onOpenCommandPalette={() => setCommandPaletteOpen(true)}
+        onOpenKeyboardShortcuts={() => setShortcutsOpen(true)}
       />
       <ManagePluginsDialog
         open={managePluginsOpen}

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -5,6 +5,11 @@ import {
   serializeProject,
   useAppStore,
 } from "@geolibre/core";
+import type {
+  ConversionToolKind,
+  RasterToolKind,
+  VectorToolKind,
+} from "@geolibre/core";
 import {
   type BuiltInMapControl,
   DEFAULT_BUILT_IN_CONTROL_VISIBILITY,
@@ -108,6 +113,7 @@ import {
   FolderOpen,
   History,
   Info,
+  Keyboard,
   Layers,
   Link2,
   Map,
@@ -117,6 +123,7 @@ import {
   Puzzle,
   RefreshCw,
   Save,
+  Search,
   SlidersHorizontal,
   Sun,
   Wrench,
@@ -150,6 +157,10 @@ import {
 import { mergeStringLists } from "../../lib/string-lists";
 import { normalizeProjectUrl } from "../../lib/urls";
 import { resolveProjectXyzLayers } from "../../lib/xyz-url";
+import { CommandPalette } from "../command/CommandPalette";
+import { KeyboardShortcutsDialog } from "../command/KeyboardShortcutsDialog";
+import { useGlobalShortcuts } from "../../hooks/useGlobalShortcuts";
+import type { Command } from "../../lib/commands";
 import { AddDataDialog, type AddDataKind } from "./AddDataDialog";
 import { AddNetcdfDialog } from "./AddNetcdfDialog";
 import { AboutDialog } from "./AboutDialog";
@@ -215,6 +226,63 @@ const FEEDBACK_URL = "https://github.com/opengeos/GeoLibre/issues";
 // out of the box on both the desktop and web builds.
 const DEFAULT_OSM_PBF_URL =
   "https://data.source.coop/giswqs/opengeos/LasVegas.osm.pbf";
+
+// Static command metadata for the menus that map a single id to a label. These
+// drive the command palette so it stays in sync with the menus without each
+// action being defined twice. The `run` closures are built in the component
+// where the store setters are in scope.
+const ADD_DATA_KIND_COMMANDS: Array<{ kind: AddDataKind; title: string }> = [
+  { kind: "delimited-text", title: "Delimited Text Layer" },
+  { kind: "gpx", title: "GPX Layer" },
+  { kind: "mbtiles", title: "MBTiles Layer" },
+  { kind: "xyz", title: "XYZ Layer" },
+  { kind: "wms", title: "WMS Layer" },
+  { kind: "wfs", title: "WFS Layer" },
+  { kind: "wmts", title: "WMTS Layer" },
+  { kind: "arcgis", title: "ArcGIS Layer" },
+  { kind: "video", title: "Video Layer" },
+  { kind: "deckgl-viz", title: "Deck.gl Layer" },
+  { kind: "postgres", title: "PostgreSQL Layer" },
+];
+
+const CONVERSION_COMMANDS: Array<{ kind: ConversionToolKind; title: string }> =
+  [
+    { kind: "vector-to-geoparquet", title: "Vector to GeoParquet" },
+    { kind: "vector-to-flatgeobuf", title: "Vector to FlatGeobuf" },
+    { kind: "csv-to-geoparquet", title: "CSV to GeoParquet" },
+    { kind: "vector-to-pmtiles", title: "Vector to PMTiles" },
+    { kind: "raster-to-cog", title: "Raster to COG" },
+  ];
+
+const VECTOR_TOOL_COMMANDS: Array<{ kind: VectorToolKind; title: string }> = [
+  { kind: "buffer", title: "Buffer" },
+  { kind: "centroids", title: "Centroids" },
+  { kind: "convex-hull", title: "Convex hull" },
+  { kind: "dissolve", title: "Dissolve" },
+  { kind: "bounding-box", title: "Bounding box" },
+  { kind: "simplify", title: "Simplify" },
+  { kind: "clip", title: "Clip" },
+  { kind: "intersection", title: "Intersection" },
+  { kind: "difference", title: "Difference" },
+  { kind: "union", title: "Union" },
+  { kind: "spatial-join", title: "Spatial join" },
+  { kind: "select-by-value", title: "Select by value" },
+  { kind: "select-by-location", title: "Select by location" },
+  { kind: "h3-grid", title: "Create H3 grid" },
+  { kind: "h3-bin-points", title: "Bin points to H3" },
+];
+
+const RASTER_TOOL_COMMANDS: Array<{ kind: RasterToolKind; title: string }> = [
+  { kind: "hillshade", title: "Hillshade" },
+  { kind: "slope", title: "Slope" },
+  { kind: "aspect", title: "Aspect" },
+  { kind: "reproject", title: "Reproject" },
+  { kind: "resample", title: "Resample" },
+  { kind: "clip-extent", title: "Clip by extent" },
+  { kind: "clip-mask", title: "Clip by mask layer" },
+  { kind: "polygonize", title: "Polygonize" },
+  { kind: "contour", title: "Contour" },
+];
 
 async function openExternalLink(url: string): Promise<void> {
   if (isTauri()) {
@@ -308,6 +376,8 @@ export function TopToolbar({
     sizeMb: number;
   } | null>(null);
   const [aboutOpen, setAboutOpen] = useState(false);
+  const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [checkForUpdatesRequest, setCheckForUpdatesRequest] = useState(0);
   const projectUrlAbortRef = useRef<AbortController | null>(null);
   const recentAbortRef = useRef<AbortController | null>(null);
@@ -831,6 +901,330 @@ export function TopToolbar({
       return updated ? { ...current, [control]: visible } : current;
     });
   };
+  // The command registry: the single source of truth shared by the command
+  // palette, the global shortcut layer, and the keyboard cheat sheet. Each
+  // entry reuses the same handler the matching menu item calls, so behaviour is
+  // defined once. Only file operations get global shortcuts to avoid clobbering
+  // MapLibre or browser keys; everything else is reachable through the palette.
+  const commands: Command[] = [
+    // Project
+    {
+      id: "project.new",
+      title: "New Project",
+      group: "Project",
+      keywords: "create",
+      icon: FilePlus2,
+      shortcut: { key: "n", mod: true },
+      run: () => setNewProjectDialogOpen(true),
+    },
+    {
+      id: "project.open-file",
+      title: "Open Project from File",
+      group: "Project",
+      keywords: "load",
+      icon: FolderOpen,
+      shortcut: { key: "o", mod: true },
+      run: () => void handleOpenFromFile(),
+    },
+    {
+      id: "project.open-url",
+      title: "Open Project from URL",
+      group: "Project",
+      keywords: "load",
+      icon: Link2,
+      run: () => setProjectUrlDialogOpen(true),
+    },
+    {
+      id: "project.save",
+      title: "Save Project",
+      group: "Project",
+      icon: Save,
+      shortcut: { key: "s", mod: true, shift: false },
+      run: () => void handleSave(),
+    },
+    {
+      id: "project.save-as",
+      title: "Save Project As…",
+      group: "Project",
+      icon: FilePen,
+      shortcut: { key: "s", mod: true, shift: true },
+      run: () => void handleSaveAs(),
+    },
+    {
+      id: "project.share",
+      title: "Share Project…",
+      group: "Project",
+      icon: Share2,
+      run: () => setShareDialogOpen(true),
+    },
+    {
+      id: "project.print",
+      title: "Print…",
+      group: "Project",
+      icon: Printer,
+      run: handleTogglePrintPanel,
+    },
+    // Add Data
+    {
+      id: "add.vector",
+      title: "Add Vector Layer",
+      group: "Add Data",
+      icon: Database,
+      run: handleAddVectorLayer,
+    },
+    {
+      id: "add.raster",
+      title: "Add Raster Layer",
+      group: "Add Data",
+      icon: Database,
+      run: handleAddRasterLayer,
+    },
+    {
+      id: "add.osm-pbf",
+      title: "Add OSM PBF Layer",
+      group: "Add Data",
+      run: () => setOsmPbfDialogOpen(true),
+    },
+    ...ADD_DATA_KIND_COMMANDS.map(({ kind, title }) => ({
+      id: `add.${kind}`,
+      title: `Add ${title}`,
+      group: "Add Data",
+      run: () => setAddDataKind(kind),
+    })),
+    {
+      id: "add.stac",
+      title: "Add STAC Layer",
+      group: "Add Data",
+      run: handleAddStacLayer,
+    },
+    {
+      id: "add.geoparquet",
+      title: "Add GeoParquet Layer",
+      group: "Add Data",
+      run: handleAddVectorLayer,
+    },
+    {
+      id: "add.flatgeobuf",
+      title: "Add FlatGeobuf Layer",
+      group: "Add Data",
+      run: handleAddFlatGeobufLayer,
+    },
+    {
+      id: "add.pmtiles",
+      title: "Add PMTiles Layer",
+      group: "Add Data",
+      run: handleAddPMTilesLayer,
+    },
+    {
+      id: "add.zarr",
+      title: "Add Zarr Layer",
+      group: "Add Data",
+      run: handleAddZarrLayer,
+    },
+    {
+      id: "add.netcdf",
+      title: "Add NetCDF / HDF Layer",
+      group: "Add Data",
+      run: handleAddNetcdfLayer,
+    },
+    {
+      id: "add.lidar",
+      title: "Add LiDAR Layer",
+      group: "Add Data",
+      run: handleAddLidarLayer,
+    },
+    {
+      id: "add.splatting",
+      title: "Add Splatting Layer",
+      group: "Add Data",
+      run: handleAddSplattingLayer,
+    },
+    {
+      id: "add.3d-tiles",
+      title: "Add 3D Tiles Layer",
+      group: "Add Data",
+      run: handleAddThreeDTilesLayer,
+    },
+    {
+      id: "add.duckdb",
+      title: "Add DuckDB Layer",
+      group: "Add Data",
+      run: handleAddDuckDBLayer,
+    },
+    // Processing
+    {
+      id: "proc.whitebox",
+      title: "Whitebox Tools",
+      group: "Processing",
+      icon: Wrench,
+      run: () => setProcessingOpen(true),
+    },
+    {
+      id: "proc.sql",
+      title: "SQL Workspace",
+      group: "Processing",
+      icon: Wrench,
+      run: () => setSqlWorkspaceOpen(true),
+    },
+    ...CONVERSION_COMMANDS.map(({ kind, title }) => ({
+      id: `proc.conversion.${kind}`,
+      title,
+      group: "Processing",
+      keywords: "conversion convert",
+      run: () => setConversionOpen(kind),
+    })),
+    ...VECTOR_TOOL_COMMANDS.map(({ kind, title }) => ({
+      id: `proc.vector.${kind}`,
+      title,
+      group: "Processing",
+      keywords: "vector tool",
+      run: () => setVectorToolOpen(kind),
+    })),
+    ...RASTER_TOOL_COMMANDS.map(({ kind, title }) => ({
+      id: `proc.raster.${kind}`,
+      title,
+      group: "Processing",
+      keywords: "raster tool",
+      run: () => setRasterToolOpen(kind),
+    })),
+    {
+      id: "proc.planetary-computer",
+      title: "Planetary Computer",
+      group: "Processing",
+      run: handleOpenPlanetaryComputerPanel,
+    },
+    {
+      id: "proc.earth-engine",
+      title: "Earth Engine",
+      group: "Processing",
+      run: handleToggleEarthEnginePanel,
+    },
+    // Controls
+    ...MAP_CONTROL_ITEMS.map((control) => ({
+      id: `control.${control.id}`,
+      title: `Toggle ${control.label} Control`,
+      group: "Controls",
+      keywords: "control toggle map",
+      run: () => toggleMapControl(control.id),
+    })),
+    {
+      id: "control.effects",
+      title: "Toggle Atmosphere Effects",
+      group: "Controls",
+      run: () => toggle(EFFECTS_PLUGIN_ID, appApi),
+    },
+    {
+      id: "control.directions",
+      title: "Toggle Directions",
+      group: "Controls",
+      run: handleToggleDirections,
+    },
+    {
+      id: "control.search",
+      title: "Toggle Search",
+      group: "Controls",
+      run: handleToggleSearchPlacesPanel,
+    },
+    {
+      id: "control.colorbar",
+      title: "Toggle Colorbar",
+      group: "Controls",
+      run: handleToggleColorbarPanel,
+    },
+    {
+      id: "control.legend",
+      title: "Toggle Legend",
+      group: "Controls",
+      run: handleToggleLegendPanel,
+    },
+    {
+      id: "control.html",
+      title: "Toggle HTML Panel",
+      group: "Controls",
+      run: handleToggleHtmlPanel,
+    },
+    {
+      id: "control.measure",
+      title: "Toggle Measure",
+      group: "Controls",
+      run: handleToggleMeasurePanel,
+    },
+    {
+      id: "control.bookmark",
+      title: "Toggle Bookmark",
+      group: "Controls",
+      run: handleToggleBookmarkPanel,
+    },
+    {
+      id: "control.minimap",
+      title: "Toggle Minimap",
+      group: "Controls",
+      run: handleToggleMinimapPanel,
+    },
+    {
+      id: "control.view-state",
+      title: "Toggle View State",
+      group: "Controls",
+      run: handleToggleViewStatePanel,
+    },
+    // View
+    {
+      id: "view.theme",
+      title:
+        themeMode === "dark" ? "Switch to Light Mode" : "Switch to Dark Mode",
+      group: "View",
+      keywords: "theme dark light appearance",
+      icon: themeMode === "dark" ? Sun : Moon,
+      run: onToggleThemeMode,
+    },
+    // Help
+    {
+      id: "help.shortcuts",
+      title: "Keyboard Shortcuts",
+      group: "Help",
+      keywords: "hotkeys cheat sheet",
+      icon: Keyboard,
+      run: () => setShortcutsOpen(true),
+    },
+    {
+      id: "help.diagnostics",
+      title: "Diagnostics",
+      group: "Help",
+      icon: Bug,
+      run: onOpenDiagnostics,
+    },
+    {
+      id: "help.feedback",
+      title: "Give Feedback",
+      group: "Help",
+      icon: MessageSquare,
+      run: () => void openExternalLink(FEEDBACK_URL),
+    },
+    {
+      id: "help.updates",
+      title: "Check for Updates",
+      group: "Help",
+      icon: RefreshCw,
+      run: () => {
+        setAboutOpen(true);
+        setCheckForUpdatesRequest((value) => value + 1);
+      },
+    },
+    {
+      id: "help.about",
+      title: "About",
+      group: "Help",
+      icon: Info,
+      run: () => setAboutOpen(true),
+    },
+  ];
+
+  useGlobalShortcuts({
+    commands,
+    onOpenPalette: () => setCommandPaletteOpen(true),
+    onOpenShortcuts: () => setShortcutsOpen(true),
+  });
+
   const toolbarButtonSize = compact ? "icon" : "sm";
   const toolbarButtonClass = compact ? "h-8 w-8 shrink-0" : "shrink-0";
   const toolbarIconClassName = cn("h-3.5 w-3.5", showLabels && "sm:mr-1");
@@ -1514,6 +1908,15 @@ export function TopToolbar({
         <DropdownMenuContent align="start">
           <DropdownMenuLabel>Help</DropdownMenuLabel>
           <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={() => setCommandPaletteOpen(true)}>
+            <Search className="mr-2 h-3.5 w-3.5" />
+            Command Palette
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setShortcutsOpen(true)}>
+            <Keyboard className="mr-2 h-3.5 w-3.5" />
+            Keyboard Shortcuts
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
           <DropdownMenuItem onSelect={onOpenDiagnostics}>
             <Bug className="mr-2 h-3.5 w-3.5" />
             Diagnostics
@@ -1760,6 +2163,16 @@ export function TopToolbar({
         open={aboutOpen}
         renderTrigger={false}
         onOpenChange={setAboutOpen}
+      />
+      <CommandPalette
+        open={commandPaletteOpen}
+        commands={commands}
+        onOpenChange={setCommandPaletteOpen}
+      />
+      <KeyboardShortcutsDialog
+        open={shortcutsOpen}
+        commands={commands}
+        onOpenChange={setShortcutsOpen}
       />
       <div className="ml-auto flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
         <Button

--- a/apps/geolibre-desktop/src/hooks/useGlobalShortcuts.ts
+++ b/apps/geolibre-desktop/src/hooks/useGlobalShortcuts.ts
@@ -1,0 +1,77 @@
+import { useEffect, useMemo, useRef } from "react";
+import {
+  type Command,
+  PALETTE_SHORTCUT,
+  SHORTCUTS_HELP_SHORTCUT,
+  isEditableTarget,
+  isMacPlatform,
+  matchesShortcut,
+} from "../lib/commands";
+
+interface UseGlobalShortcutsOptions {
+  /** The current command registry; commands with a `shortcut` are bound. */
+  commands: Command[];
+  /** Opens the command palette (Cmd/Ctrl-K). */
+  onOpenPalette: () => void;
+  /** Opens the keyboard shortcuts cheat sheet (?). */
+  onOpenShortcuts: () => void;
+  /** When false, no listener is attached. */
+  enabled?: boolean;
+}
+
+/**
+ * Centralized global hotkey layer. Attaches a single window keydown listener
+ * that opens the command palette, opens the cheat sheet, and runs any command
+ * whose `shortcut` matches. Shortcuts are ignored while the user is typing in a
+ * text field, and only `mod`/`?`-style combinations are used so MapLibre's own
+ * arrow/zoom key handling on the focused canvas is left untouched.
+ */
+export function useGlobalShortcuts({
+  commands,
+  onOpenPalette,
+  onOpenShortcuts,
+  enabled = true,
+}: UseGlobalShortcutsOptions): void {
+  const isMac = useMemo(() => isMacPlatform(), []);
+  // Keep the latest values in refs so the listener can stay attached without
+  // re-binding on every render (the command array is rebuilt frequently).
+  const commandsRef = useRef(commands);
+  const onOpenPaletteRef = useRef(onOpenPalette);
+  const onOpenShortcutsRef = useRef(onOpenShortcuts);
+  commandsRef.current = commands;
+  onOpenPaletteRef.current = onOpenPalette;
+  onOpenShortcutsRef.current = onOpenShortcuts;
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      // Respect anything that already handled the event (e.g. an open dialog's
+      // own key handling) and skip while typing in inputs.
+      if (event.defaultPrevented) return;
+      if (event.repeat) return;
+      if (isEditableTarget(event.target)) return;
+
+      if (matchesShortcut(event, PALETTE_SHORTCUT, isMac)) {
+        event.preventDefault();
+        onOpenPaletteRef.current();
+        return;
+      }
+      if (matchesShortcut(event, SHORTCUTS_HELP_SHORTCUT, isMac)) {
+        event.preventDefault();
+        onOpenShortcutsRef.current();
+        return;
+      }
+      for (const command of commandsRef.current) {
+        if (command.shortcut && matchesShortcut(event, command.shortcut, isMac)) {
+          event.preventDefault();
+          command.run();
+          return;
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [enabled, isMac]);
+}

--- a/apps/geolibre-desktop/src/lib/commands.ts
+++ b/apps/geolibre-desktop/src/lib/commands.ts
@@ -1,0 +1,147 @@
+import type { LucideIcon } from "lucide-react";
+
+/**
+ * A keyboard shortcut definition. `mod` maps to ⌘ on macOS and Ctrl
+ * elsewhere, so the same definition works cross-platform.
+ */
+export interface Shortcut {
+  /** The `KeyboardEvent.key` to match (case-insensitive for letters). */
+  key: string;
+  /** Requires the platform command/control modifier (⌘ on macOS, Ctrl elsewhere). */
+  mod?: boolean;
+  /** Requires (true) or forbids (false) the Shift modifier. Ignored when undefined. */
+  shift?: boolean;
+  /** Requires (true) or forbids (false) the Alt/Option modifier. Defaults to forbidden. */
+  alt?: boolean;
+}
+
+/**
+ * A single invocable action. The command registry is the single source of
+ * truth shared by the command palette, the global shortcut layer, and the
+ * keyboard cheat sheet.
+ */
+export interface Command {
+  /** Stable unique id (used as React key and for tests). */
+  id: string;
+  /** Human-readable label shown in the palette and cheat sheet. */
+  title: string;
+  /** Grouping label (e.g. "Project", "Add Data"). */
+  group: string;
+  /** Extra search terms that should match this command in the palette. */
+  keywords?: string;
+  /** Optional global hotkey that triggers `run` without opening the palette. */
+  shortcut?: Shortcut;
+  /** Optional icon shown beside the command in the palette. */
+  icon?: LucideIcon;
+  /** Invoked when the command is selected or its shortcut is pressed. */
+  run: () => void;
+}
+
+/** The shortcut that opens the command palette. */
+export const PALETTE_SHORTCUT: Shortcut = { key: "k", mod: true };
+
+/** The shortcut that opens the keyboard shortcuts cheat sheet. */
+export const SHORTCUTS_HELP_SHORTCUT: Shortcut = { key: "?" };
+
+/**
+ * Detect whether the current platform is macOS, so shortcuts can prefer ⌘
+ * over Ctrl. Falls back to false in non-browser (test) environments.
+ */
+export function isMacPlatform(): boolean {
+  if (typeof navigator === "undefined") return false;
+  // navigator.platform is deprecated but still the most reliable signal across
+  // the browsers and webviews this app targets; userAgent is the fallback.
+  const platform = navigator.platform || navigator.userAgent || "";
+  return /mac|iphone|ipad|ipod/i.test(platform);
+}
+
+/**
+ * Whether a keyboard event originated from a text-entry control, where global
+ * shortcuts must not fire (so typing "s" doesn't trigger Save, etc.).
+ */
+export function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+  return target.isContentEditable;
+}
+
+/**
+ * Test a keyboard event against a shortcut definition for the given platform.
+ * Requires the exact modifier combination so e.g. ⌘S and ⇧⌘S stay distinct,
+ * and rejects the non-platform command modifier to avoid accidental matches.
+ */
+export function matchesShortcut(
+  event: Pick<
+    KeyboardEvent,
+    "key" | "metaKey" | "ctrlKey" | "shiftKey" | "altKey"
+  >,
+  shortcut: Shortcut,
+  isMac: boolean,
+): boolean {
+  if (event.key.toLowerCase() !== shortcut.key.toLowerCase()) return false;
+
+  const modPressed = isMac ? event.metaKey : event.ctrlKey;
+  const otherModPressed = isMac ? event.ctrlKey : event.metaKey;
+  if (Boolean(shortcut.mod) !== modPressed) return false;
+  // Never let the non-platform command key satisfy a match (e.g. Ctrl+⌘+S on
+  // macOS should not fire ⌘S).
+  if (otherModPressed) return false;
+
+  if (Boolean(shortcut.alt) !== event.altKey) return false;
+  if (shortcut.shift !== undefined && shortcut.shift !== event.shiftKey) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Render a shortcut as a display string, e.g. "⌘K" / "⇧⌘S" on macOS or
+ * "Ctrl+K" / "Ctrl+Shift+S" elsewhere.
+ */
+export function formatShortcut(shortcut: Shortcut, isMac: boolean): string {
+  const parts: string[] = [];
+  if (isMac) {
+    if (shortcut.alt) parts.push("⌥");
+    if (shortcut.shift) parts.push("⇧");
+    if (shortcut.mod) parts.push("⌘");
+    parts.push(formatKey(shortcut.key));
+    return parts.join("");
+  }
+  if (shortcut.mod) parts.push("Ctrl");
+  if (shortcut.shift) parts.push("Shift");
+  if (shortcut.alt) parts.push("Alt");
+  parts.push(formatKey(shortcut.key));
+  return parts.join("+");
+}
+
+function formatKey(key: string): string {
+  if (key.length === 1) return key.toUpperCase();
+  return key;
+}
+
+/**
+ * Filter and rank commands for a palette query. Matching is token-based: every
+ * whitespace-separated token in the query must appear in the command's title,
+ * group, or keywords. Title-prefix matches rank ahead of other matches, and
+ * the original registry order is preserved within each rank.
+ */
+export function filterCommands(commands: Command[], query: string): Command[] {
+  const trimmed = query.trim().toLowerCase();
+  if (!trimmed) return commands;
+  const tokens = trimmed.split(/\s+/);
+
+  const scored: Array<{ command: Command; rank: number; index: number }> = [];
+  commands.forEach((command, index) => {
+    const title = command.title.toLowerCase();
+    const haystack = `${title} ${command.group.toLowerCase()} ${
+      command.keywords?.toLowerCase() ?? ""
+    }`;
+    if (!tokens.every((token) => haystack.includes(token))) return;
+    const rank = title.startsWith(trimmed) ? 0 : 1;
+    scored.push({ command, rank, index });
+  });
+
+  scored.sort((a, b) => a.rank - b.rank || a.index - b.index);
+  return scored.map((entry) => entry.command);
+}

--- a/apps/geolibre-desktop/src/lib/commands.ts
+++ b/apps/geolibre-desktop/src/lib/commands.ts
@@ -88,6 +88,14 @@ export function matchesShortcut(
   // macOS should not fire ⌘S).
   if (otherModPressed) return false;
 
+  // `alt` and `shift` default differently on purpose:
+  //   - alt: omitted means *forbidden*. Alt is never part of an app shortcut,
+  //     and on some keyboard layouts Alt+key produces a character, so a held
+  //     Alt must not accidentally satisfy a match.
+  //   - shift: omitted means *ignored*. Shifted symbol keys such as "?" carry
+  //     Shift in the event, so requiring its absence would break them.
+  // For letter shortcuts that have a distinct shifted variant (e.g. Save vs
+  // Save As), set `shift` explicitly on both so they stay unambiguous.
   if (Boolean(shortcut.alt) !== event.altKey) return false;
   if (shortcut.shift !== undefined && shortcut.shift !== event.shiftKey) {
     return false;

--- a/docs/user-guide/interface.md
+++ b/docs/user-guide/interface.md
@@ -16,12 +16,32 @@ The toolbar across the top of the window groups every action into seven menus:
 | **Controls** | Toggle map controls and component panels (Measure, Bookmark, Minimap, and more). See [Map Controls & Tools](map-controls.md). |
 | **Plugins** | Activate built-in plugins and set their on-map position. See [Plugins & Marketplace](plugins.md). |
 | **Settings** | Map preferences, layout, environment variables, project settings, and Manage Plugins. See [Settings & Preferences](settings.md). |
-| **Help** | Diagnostics, feedback, update checks, and the About dialog. |
+| **Help** | The command palette, keyboard shortcuts, diagnostics, feedback, update checks, and the About dialog. |
 
 On the right side of the toolbar are the light/dark theme toggle and the editable project name.
 
 !!! tip "Toolbar labels"
     On narrow windows the toolbar collapses to icon-only buttons. You can also force icon-only buttons from **Settings → Layout**, or with the `toolbar=icons` URL parameter. See [Embedding & Sharing](embedding.md).
+
+## Command palette and keyboard shortcuts
+
+Every menu and toolbar action is also reachable from the keyboard, so you don't have to hunt through nested menus.
+
+- **Command palette** — press `Ctrl`/`Cmd` + `K` (or **Help → Command Palette**) to open a searchable list of every action: Add Data sources, Processing tools, Controls, Help, and more. Type to filter, move the highlight with the arrow keys, and press `Enter` to run the highlighted command.
+- **Keyboard shortcuts cheat sheet** — press `?` (or **Help → Keyboard Shortcuts**) to see the full list of global shortcuts.
+
+The built-in global shortcuts are:
+
+| Shortcut | Action |
+| --- | --- |
+| `Ctrl`/`Cmd` + `K` | Open the command palette |
+| `?` | Show the keyboard shortcuts |
+| `Ctrl`/`Cmd` + `N` | New project |
+| `Ctrl`/`Cmd` + `O` | Open project from file |
+| `Ctrl`/`Cmd` + `S` | Save project |
+| `Ctrl`/`Cmd` + `Shift` + `S` | Save project as… |
+
+Shortcuts are ignored while you are typing in a text field, so they never interfere with search boxes or attribute editing. On macOS the `Cmd` key is used; on Windows and Linux the `Ctrl` key is used.
 
 ## The three panels
 

--- a/docs/user-guide/interface.md
+++ b/docs/user-guide/interface.md
@@ -27,7 +27,7 @@ On the right side of the toolbar are the light/dark theme toggle and the editabl
 
 Every menu and toolbar action is also reachable from the keyboard, so you don't have to hunt through nested menus.
 
-- **Command palette** — press `Ctrl`/`Cmd` + `K` (or **Help → Command Palette**) to open a searchable list of every action: Add Data sources, Processing tools, Controls, Help, and more. Type to filter, move the highlight with the arrow keys, and press `Enter` to run the highlighted command.
+- **Command palette** — press `Ctrl`/`Cmd` + `K` (or **Help → Command Palette**) to open a searchable list of actions: Add Data sources, Processing tools, Controls, Plugins, and more. Type to filter, move the highlight with the arrow keys, and press `Enter` to run the highlighted command.
 - **Keyboard shortcuts cheat sheet** — press `?` (or **Help → Keyboard Shortcuts**) to see the full list of global shortcuts.
 
 The built-in global shortcuts are:

--- a/docs/user-guide/interface.md
+++ b/docs/user-guide/interface.md
@@ -27,8 +27,8 @@ On the right side of the toolbar are the light/dark theme toggle and the editabl
 
 Every menu and toolbar action is also reachable from the keyboard, so you don't have to hunt through nested menus.
 
-- **Command palette** — press `Ctrl`/`Cmd` + `K` (or **Help → Command Palette**) to open a searchable list of actions: Add Data sources, Processing tools, Controls, Plugins, and more. Type to filter, move the highlight with the arrow keys, and press `Enter` to run the highlighted command.
-- **Keyboard shortcuts cheat sheet** — press `?` (or **Help → Keyboard Shortcuts**) to see the full list of global shortcuts.
+- **Command palette** — press `Ctrl`/`Cmd` + `K` (or **Help → Command Palette**, or **Settings → Command Palette**) to open a searchable list of actions: Add Data sources, Processing tools, Controls, Plugins, and more. Type to filter, move the highlight with the arrow keys, and press `Enter` to run the highlighted command.
+- **Keyboard shortcuts cheat sheet** — press `?` (or **Help → Keyboard Shortcuts**, or **Settings → Keyboard Shortcuts**) to see the full list of global shortcuts.
 
 The built-in global shortcuts are:
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,4 +6,6 @@ export {
   useAppStore,
   type AppState,
   type ConversionToolKind,
+  type RasterToolKind,
+  type VectorToolKind,
 } from "./store";

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  type Command,
+  type Shortcut,
+  filterCommands,
+  formatShortcut,
+  matchesShortcut,
+} from "../apps/geolibre-desktop/src/lib/commands";
+
+interface KeyEvent {
+  key: string;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+}
+
+function keyEvent(key: string, mods: Partial<KeyEvent> = {}): KeyEvent {
+  return {
+    key,
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    ...mods,
+  };
+}
+
+function command(patch: Partial<Command> & Pick<Command, "id" | "title">): Command {
+  return {
+    group: "Group",
+    run: () => {},
+    ...patch,
+  };
+}
+
+describe("matchesShortcut", () => {
+  const save: Shortcut = { key: "s", mod: true, shift: false };
+
+  it("matches the platform command modifier (Ctrl on non-mac, ⌘ on mac)", () => {
+    assert.equal(matchesShortcut(keyEvent("s", { ctrlKey: true }), save, false), true);
+    assert.equal(matchesShortcut(keyEvent("s", { metaKey: true }), save, true), true);
+  });
+
+  it("does not match when the non-platform modifier is used", () => {
+    assert.equal(matchesShortcut(keyEvent("s", { metaKey: true }), save, false), false);
+    assert.equal(matchesShortcut(keyEvent("s", { ctrlKey: true }), save, true), false);
+  });
+
+  it("rejects the other command modifier even when the platform one is held", () => {
+    assert.equal(
+      matchesShortcut(keyEvent("s", { ctrlKey: true, metaKey: true }), save, false),
+      false,
+    );
+  });
+
+  it("distinguishes Shift (Save vs Save As)", () => {
+    const saveAs: Shortcut = { key: "s", mod: true, shift: true };
+    assert.equal(matchesShortcut(keyEvent("s", { ctrlKey: true }), saveAs, false), false);
+    assert.equal(
+      matchesShortcut(keyEvent("s", { ctrlKey: true, shiftKey: true }), saveAs, false),
+      true,
+    );
+    // Save explicitly forbids Shift.
+    assert.equal(
+      matchesShortcut(keyEvent("s", { ctrlKey: true, shiftKey: true }), save, false),
+      false,
+    );
+  });
+
+  it("ignores Shift when the shortcut leaves it unspecified", () => {
+    const help: Shortcut = { key: "?" };
+    assert.equal(matchesShortcut(keyEvent("?", { shiftKey: true }), help, false), true);
+    assert.equal(matchesShortcut(keyEvent("?"), help, false), true);
+  });
+
+  it("matches letters case-insensitively", () => {
+    assert.equal(matchesShortcut(keyEvent("S", { ctrlKey: true }), save, false), true);
+  });
+
+  it("requires Alt only when specified", () => {
+    assert.equal(matchesShortcut(keyEvent("s", { ctrlKey: true, altKey: true }), save, false), false);
+    const altShortcut: Shortcut = { key: "s", mod: true, shift: false, alt: true };
+    assert.equal(
+      matchesShortcut(keyEvent("s", { ctrlKey: true, altKey: true }), altShortcut, false),
+      true,
+    );
+  });
+});
+
+describe("formatShortcut", () => {
+  it("renders mac glyphs", () => {
+    assert.equal(formatShortcut({ key: "k", mod: true }, true), "⌘K");
+    assert.equal(formatShortcut({ key: "s", mod: true, shift: true }, true), "⇧⌘S");
+    assert.equal(formatShortcut({ key: "?" }, true), "?");
+  });
+
+  it("renders Ctrl-style on other platforms", () => {
+    assert.equal(formatShortcut({ key: "k", mod: true }, false), "Ctrl+K");
+    assert.equal(formatShortcut({ key: "s", mod: true, shift: true }, false), "Ctrl+Shift+S");
+  });
+});
+
+describe("filterCommands", () => {
+  const commands: Command[] = [
+    command({ id: "a", title: "Save Project", group: "Project" }),
+    command({ id: "b", title: "Add Vector Layer", group: "Add Data", keywords: "geojson" }),
+    command({ id: "c", title: "Add Raster Layer", group: "Add Data" }),
+  ];
+
+  it("returns everything for an empty query", () => {
+    assert.equal(filterCommands(commands, "  ").length, 3);
+  });
+
+  it("matches across title, group, and keywords", () => {
+    assert.deepEqual(
+      filterCommands(commands, "geojson").map((c) => c.id),
+      ["b"],
+    );
+    assert.deepEqual(
+      filterCommands(commands, "add").map((c) => c.id).sort(),
+      ["b", "c"],
+    );
+  });
+
+  it("requires every token to match", () => {
+    assert.deepEqual(
+      filterCommands(commands, "add raster").map((c) => c.id),
+      ["c"],
+    );
+  });
+
+  it("ranks title-prefix matches first", () => {
+    const list: Command[] = [
+      command({ id: "x", title: "Resave Layer", group: "G" }),
+      command({ id: "y", title: "Save Layer", group: "G" }),
+    ];
+    assert.deepEqual(
+      filterCommands(list, "save").map((c) => c.id),
+      ["y", "x"],
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add a Ctrl/Cmd-K command palette that searches and runs every menu and toolbar action, built from a single command registry so actions are defined once.
- Add a centralized global shortcut layer (New, Open, Save, Save As) that is ignored while typing in inputs and avoids clobbering MapLibre's own key handling, plus a `?` keyboard shortcuts cheat sheet.
- Document the shortcuts in the README and user guide, and add unit tests for the shortcut matching, formatting, and filtering utilities.

Resolves #271.

## Test plan
- [x] `npm run build` (tsc -b + vite build) passes
- [x] `npm run test:frontend` passes (includes new tests/commands.test.ts)
- [x] `npx eslint` clean on changed files
- [x] pre-commit hooks pass on changed files
- [ ] Manually verify Ctrl/Cmd-K opens the palette, search and Enter run a command, and the `?` cheat sheet opens
- [ ] Manually verify New/Open/Save/Save As shortcuts work and are ignored while typing in inputs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command Palette (Ctrl/Cmd+K) to search and run app actions; accessible from toolbar/Help/Settings.
  * Centralized global keyboard shortcuts including New/Open/Save/Save As and a help shortcut (?).
  * Keyboard shortcuts cheat-sheet dialog with platform-formatted keys.

* **Documentation**
  * Updated user guide with Command Palette and keyboard shortcuts section; clarifies shortcut behavior while typing.

* **Tests**
  * Added unit tests for shortcut matching, formatting, and command filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->