### PR TITLE
feat(a11y): accessibility pass with axe checks across key screens

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -899,6 +899,12 @@ export function DesktopShell({
             layoutOptions.compact ? "min-h-0" : "min-h-72 md:min-h-0"
           }`}
         >
+          {/* Visually-hidden page title: gives the document the single
+              top-level heading that assistive tech (and the axe
+              `page-has-heading-one` check) expect, without altering the
+              chrome-free visual layout. Placed inside the main landmark so it
+              is not flagged as content outside a landmark. */}
+          <h1 className="sr-only">GeoLibre map workspace</h1>
           <SectionErrorBoundary label="Map" fallbackClassName="h-full w-full">
             <MapCanvas
               controllerRef={mapControllerRef}

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -1095,6 +1095,7 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
   return (
     <section
       ref={tableSectionRef}
+      aria-label="Attribute table"
       className="relative flex shrink-0 flex-col border-t bg-card"
       style={{ height: tableHeight }}
     >

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -615,7 +615,10 @@ export function LayerPanel({
 
   if (isCollapsed) {
     return (
-      <aside className="flex h-11 w-full shrink-0 items-center gap-2 border-b bg-card px-2 md:h-auto md:w-11 md:flex-col md:border-b-0 md:border-r md:py-2">
+      <aside
+        aria-label="Layers (collapsed)"
+        className="flex h-11 w-full shrink-0 items-center gap-2 border-b bg-card px-2 md:h-auto md:w-11 md:flex-col md:border-b-0 md:border-r md:py-2"
+      >
         <Button
           variant="ghost"
           size="icon"
@@ -637,7 +640,10 @@ export function LayerPanel({
   }
 
   return (
-    <aside className="relative flex max-h-[min(24rem,42vh)] supports-[max-height:1dvh]:max-h-[min(24rem,42dvh)] w-full shrink-0 flex-col border-b bg-card md:max-h-none md:w-[var(--layer-panel-width)] md:border-b-0 md:border-r">
+    <aside
+      aria-label="Layers"
+      className="relative flex max-h-[min(24rem,42vh)] supports-[max-height:1dvh]:max-h-[min(24rem,42dvh)] w-full shrink-0 flex-col border-b bg-card md:max-h-none md:w-[var(--layer-panel-width)] md:border-b-0 md:border-r"
+    >
       <div
         role="separator"
         aria-orientation="vertical"
@@ -869,6 +875,7 @@ export function LayerPanel({
                     Opacity
                   </span>
                   <Slider
+                    aria-label={`Opacity for ${layer.name}`}
                     className="flex-1"
                     min={0}
                     max={1}
@@ -1178,6 +1185,7 @@ export function LayerPanel({
             <div className="mt-2 flex items-center gap-1">
               <span className="text-[10px] text-muted-foreground">Opacity</span>
               <Slider
+                aria-label="Basemap opacity"
                 className="flex-1"
                 min={0}
                 max={1}

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -727,6 +727,7 @@ export function LayerPanel({
             return (
               <div
                 key={layer.id}
+                data-layer-card=""
                 data-testid="layer-row"
                 data-layer-name={layer.name}
                 className={`relative rounded-md border p-2 transition-colors ${
@@ -1137,6 +1138,7 @@ export function LayerPanel({
             );
           })}
           <div
+            data-layer-card=""
             className={`rounded-md border p-2 transition-colors ${
               backgroundSelected
                 ? "border-primary bg-primary/5"

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -906,6 +906,7 @@ function RasterStyleSlider({
         </span>
       </div>
       <Slider
+        aria-label={label}
         min={min}
         max={max}
         step={step}
@@ -1091,7 +1092,10 @@ export function StylePanel({
 
   if (isCollapsed) {
     return (
-      <aside className="flex h-11 w-full shrink-0 items-center gap-2 border-t bg-card px-2 md:h-auto md:w-11 md:flex-col md:border-l md:border-t-0 md:py-2">
+      <aside
+        aria-label="Layer style (collapsed)"
+        className="flex h-11 w-full shrink-0 items-center gap-2 border-t bg-card px-2 md:h-auto md:w-11 md:flex-col md:border-l md:border-t-0 md:py-2"
+      >
         <Button
           variant="ghost"
           size="icon"
@@ -1114,7 +1118,7 @@ export function StylePanel({
 
   if (!layer) {
     return (
-      <aside className={STYLE_PANEL_ASIDE_CLASS}>
+      <aside aria-label="Layer style" className={STYLE_PANEL_ASIDE_CLASS}>
         {resizeHandle}
         <div className="flex items-center justify-between border-b px-3 py-1.5">
           <span className="text-sm font-semibold">Style</span>
@@ -2008,7 +2012,7 @@ export function StylePanel({
 
   if (hasRasterPaintControls) {
     return (
-      <aside className={STYLE_PANEL_ASIDE_CLASS}>
+      <aside aria-label="Layer style" className={STYLE_PANEL_ASIDE_CLASS}>
         {resizeHandle}
         <div className="flex items-center justify-between gap-2 border-b px-3 py-1.5">
           <span className="truncate text-sm font-semibold">
@@ -2106,7 +2110,7 @@ export function StylePanel({
 
   if (!hasVectorPaintControls) {
     return (
-      <aside className={STYLE_PANEL_ASIDE_CLASS}>
+      <aside aria-label="Layer style" className={STYLE_PANEL_ASIDE_CLASS}>
         {resizeHandle}
         <div className="flex items-center justify-between gap-2 border-b px-3 py-1.5">
           <span className="truncate text-sm font-semibold">
@@ -2136,7 +2140,7 @@ export function StylePanel({
   }
 
   return (
-    <aside className={STYLE_PANEL_ASIDE_CLASS}>
+    <aside aria-label="Layer style" className={STYLE_PANEL_ASIDE_CLASS}>
       {resizeHandle}
       <div className="flex items-center justify-between gap-2 border-b px-3 py-1.5">
         <span className="truncate text-sm font-semibold">

--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -12,9 +12,23 @@ const FIXTURE_TEXT = readFileSync(
 // panel renders each row as a `role="button"` card that wraps interactive
 // children (visibility toggle, opacity slider, actions menu), which axe flags
 // as `nested-interactive`. The rows are already keyboard-operable; removing the
-// nesting needs a layer-panel interaction redesign. It is allowlisted here so
-// the suite still fails on any *new* serious/critical regression.
-const ALLOWED_SERIOUS = new Set<string>(["nested-interactive"]);
+// nesting needs a layer-panel interaction redesign.
+//
+// The allowlist is scoped to the LayerPanel selection cards specifically (not
+// the rule id globally), so a new `nested-interactive` violation anywhere else
+// still fails the suite. Both the per-layer rows and the basemap row carry a
+// `data-layer-card` marker (placed first so it stays within axe's truncated
+// `html` snippet); we allow the violation only when every offending node is one
+// of those cards.
+function isAllowlistedSerious(violation: {
+  id: string;
+  nodes: Array<{ target: string[]; html: string }>;
+}): boolean {
+  if (violation.id !== "nested-interactive" || violation.nodes.length === 0) {
+    return false;
+  }
+  return violation.nodes.every((node) => node.html.includes("data-layer-card"));
+}
 
 async function waitForMap(page: Page): Promise<void> {
   await page.goto("/");
@@ -62,7 +76,7 @@ async function expectAccessible(
   const blocking = violations.filter(
     (v) =>
       v.impact === "critical" ||
-      (v.impact === "serious" && !ALLOWED_SERIOUS.has(v.id)),
+      (v.impact === "serious" && !isAllowlistedSerious(v)),
   );
   expect(
     blocking,
@@ -96,8 +110,11 @@ test("no critical/serious axe violations across key screens", async ({
     .waitFor({ state: "detached" });
   await expectAccessible(page, "attribute-table", testInfo);
 
-  // Command palette (Ctrl/Cmd-K).
-  await page.keyboard.press("Control+KeyK");
+  // Command palette (Ctrl/Cmd-K). The app picks the modifier from the platform
+  // (Meta on macOS, Ctrl elsewhere), so match it here for local macOS runs.
+  await page.keyboard.press(
+    process.platform === "darwin" ? "Meta+KeyK" : "Control+KeyK",
+  );
   await expect(page.getByPlaceholder("Search commands…")).toBeVisible();
   await expectAccessible(page, "command-palette", testInfo);
   await page.keyboard.press("Escape");

--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -1,0 +1,112 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test, type Page, type TestInfo } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const FIXTURE_TEXT = readFileSync(
+  join(__dirname, "fixtures", "smoke.geojson"),
+  "utf8",
+);
+
+// Known, pre-existing serious issue tracked as a separate follow-up: the layer
+// panel renders each row as a `role="button"` card that wraps interactive
+// children (visibility toggle, opacity slider, actions menu), which axe flags
+// as `nested-interactive`. The rows are already keyboard-operable; removing the
+// nesting needs a layer-panel interaction redesign. It is allowlisted here so
+// the suite still fails on any *new* serious/critical regression.
+const ALLOWED_SERIOUS = new Set<string>(["nested-interactive"]);
+
+async function waitForMap(page: Page): Promise<void> {
+  await page.goto("/");
+  await expect(page.getByTestId("map-canvas")).toBeVisible();
+  await expect(page.locator(".maplibregl-canvas")).toBeVisible({
+    timeout: 30_000,
+  });
+}
+
+async function dropFixtureLayer(page: Page): Promise<void> {
+  const dataTransfer = await page.evaluateHandle((contents) => {
+    const dt = new DataTransfer();
+    dt.items.add(
+      new File([contents], "smoke.geojson", { type: "application/geo+json" }),
+    );
+    return dt;
+  }, FIXTURE_TEXT);
+  for (const type of ["dragenter", "dragover", "drop"]) {
+    await page.dispatchEvent('[data-testid="map-canvas"]', type, {
+      dataTransfer,
+    });
+  }
+  await dataTransfer.dispose();
+  await page
+    .locator('[data-testid="layer-row"][data-layer-name="smoke"]')
+    .waitFor();
+}
+
+/**
+ * Run axe against the current screen and fail on any critical violation, or any
+ * serious violation that isn't on the documented allowlist. Moderate/minor
+ * findings are attached for review but don't fail the build. Every screen's
+ * full violation list is attached as a test artifact.
+ */
+async function expectAccessible(
+  page: Page,
+  label: string,
+  testInfo: TestInfo,
+): Promise<void> {
+  const { violations } = await new AxeBuilder({ page }).analyze();
+  await testInfo.attach(`axe-${label}`, {
+    body: JSON.stringify(violations, null, 2),
+    contentType: "application/json",
+  });
+  const blocking = violations.filter(
+    (v) =>
+      v.impact === "critical" ||
+      (v.impact === "serious" && !ALLOWED_SERIOUS.has(v.id)),
+  );
+  expect(
+    blocking,
+    `${label} — blocking a11y violations: ${
+      blocking.map((v) => `${v.impact}/${v.id}`).join(", ") || "none"
+    }`,
+  ).toEqual([]);
+}
+
+test("no critical/serious axe violations across key screens", async ({
+  page,
+}, testInfo) => {
+  test.setTimeout(120_000);
+
+  await waitForMap(page);
+  await expectAccessible(page, "initial", testInfo);
+
+  await dropFixtureLayer(page);
+  await expectAccessible(page, "layer-loaded", testInfo);
+
+  // Attribute table. The layer-actions menu intentionally stays open after a
+  // selection, and an open modal menu aria-hides the background, so close it
+  // before scanning the table's resting state.
+  const row = page.locator('[data-testid="layer-row"][data-layer-name="smoke"]');
+  await row.locator('button[aria-label="Layer actions"]').click();
+  await page.getByRole("menuitem", { name: "Open attribute table" }).click();
+  await expect(page.getByTestId("attribute-table")).toBeVisible();
+  await page.keyboard.press("Escape");
+  await page
+    .locator("[data-radix-popper-content-wrapper]")
+    .waitFor({ state: "detached" });
+  await expectAccessible(page, "attribute-table", testInfo);
+
+  // Command palette (Ctrl/Cmd-K).
+  await page.keyboard.press("Control+KeyK");
+  await expect(page.getByPlaceholder("Search commands…")).toBeVisible();
+  await expectAccessible(page, "command-palette", testInfo);
+  await page.keyboard.press("Escape");
+  await expect(page.getByPlaceholder("Search commands…")).toBeHidden();
+
+  // Keyboard shortcuts cheat sheet (?).
+  await page.keyboard.press("?");
+  await expect(
+    page.getByRole("heading", { name: "Keyboard shortcuts" }),
+  ).toBeVisible();
+  await expectAccessible(page, "shortcuts-dialog", testInfo);
+});

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,4 +1,3 @@
-import AxeBuilder from "@axe-core/playwright";
 import { expect, test, type Page } from "@playwright/test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -77,22 +76,5 @@ test("loads a GeoJSON layer, opens the attribute table, and toggles visibility",
   );
 });
 
-test("has no critical accessibility violations on the initial view", async ({
-  page,
-}, testInfo) => {
-  await waitForMap(page);
-
-  const results = await new AxeBuilder({ page }).analyze();
-  await testInfo.attach("axe-violations", {
-    body: JSON.stringify(results.violations, null, 2),
-    contentType: "application/json",
-  });
-
-  // A full a11y gate lands with the accessibility pass (#272); this smoke check
-  // guards only against the most severe (critical-impact) regressions.
-  const critical = results.violations.filter((v) => v.impact === "critical");
-  expect(
-    critical,
-    `critical a11y violations: ${critical.map((v) => v.id).join(", ") || "none"}`,
-  ).toEqual([]);
-});
+// The accessibility gate now lives in its own multi-screen suite (a11y.spec.ts,
+// added with the #272 accessibility pass).

--- a/packages/ui/src/components/slider.tsx
+++ b/packages/ui/src/components/slider.tsx
@@ -28,6 +28,8 @@ export const Slider = React.forwardRef<
       <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-primary/20">
         <SliderPrimitive.Range className="absolute h-full bg-primary" />
       </SliderPrimitive.Track>
+      {/* Single-thumb only. For a range slider (multiple values) render one
+          Thumb per value and give each its own aria-label. */}
       <SliderPrimitive.Thumb
         aria-label={ariaLabel}
         aria-labelledby={ariaLabelledby}

--- a/packages/ui/src/components/slider.tsx
+++ b/packages/ui/src/components/slider.tsx
@@ -5,19 +5,35 @@ import { cn } from "../lib/utils";
 export const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <SliderPrimitive.Root
-    ref={ref}
-    className={cn(
-      "relative flex w-full touch-none select-none items-center",
+>(
+  (
+    {
       className,
-    )}
-    {...props}
-  >
-    <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-primary/20">
-      <SliderPrimitive.Range className="absolute h-full bg-primary" />
-    </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="block h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" />
-  </SliderPrimitive.Root>
-));
+      // The accessible name belongs on the thumb (it carries role="slider"),
+      // not on the Root, so pull these out and forward them to the Thumb.
+      "aria-label": ariaLabel,
+      "aria-labelledby": ariaLabelledby,
+      ...props
+    },
+    ref,
+  ) => (
+    <SliderPrimitive.Root
+      ref={ref}
+      className={cn(
+        "relative flex w-full touch-none select-none items-center",
+        className,
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-primary/20">
+        <SliderPrimitive.Range className="absolute h-full bg-primary" />
+      </SliderPrimitive.Track>
+      <SliderPrimitive.Thumb
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledby}
+        className="block h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      />
+    </SliderPrimitive.Root>
+  ),
+);
 Slider.displayName = SliderPrimitive.Root.displayName;

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -61,7 +61,11 @@
      interactive element that doesn't already manage its own. Components that
      render their own ring (Button, Input, dialog close, etc.) set
      `focus-visible:outline-none`, whose utility layer wins over this base rule,
-     so they keep their existing indicator and don't double up. */
+     so they keep their existing indicator and don't double up.
+     Note: the dialog close button uses the older `focus:outline-none` form,
+     which also silences this outline correctly. Any future component using
+     `focus:ring-*` WITHOUT `focus-visible:outline-none` would get both this
+     outline and its own ring, so prefer the `focus-visible:` variants. */
   :focus-visible {
     outline: 2px solid hsl(var(--ring));
     outline-offset: 2px;

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -14,7 +14,9 @@
     --secondary: 210 40% 96.1%;
     --secondary-foreground: 222.2 47.4% 11.2%;
     --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
+    /* Darkened from 46.9% L so secondary text meets WCAG AA (4.5:1) even on the
+       muted/secondary backgrounds it is paired with (e.g. kbd badges). */
+    --muted-foreground: 215.4 16.3% 40%;
     --accent: 210 40% 96.1%;
     --accent-foreground: 222.2 47.4% 11.2%;
     --destructive: 0 84.2% 60.2%;
@@ -53,5 +55,15 @@
 
   body {
     @apply bg-background text-foreground;
+  }
+
+  /* Keyboard focus fallback: a visible, theme-aware focus ring for any
+     interactive element that doesn't already manage its own. Components that
+     render their own ring (Button, Input, dialog close, etc.) set
+     `focus-visible:outline-none`, whose utility layer wins over this base rule,
+     so they keep their existing indicator and don't double up. */
+  :focus-visible {
+    outline: 2px solid hsl(var(--ring));
+    outline-offset: 2px;
   }
 }


### PR DESCRIPTION
## Summary
- Fixes the real serious axe violations found by auditing the built app: opacity/style sliders now expose accessible names (forwarded to the Radix slider thumb), the Layers/Style/attribute-table landmarks get unique labels, and light-theme secondary text (kbd badges, small labels) is darkened to meet WCAG AA contrast on muted backgrounds.
- Adds a global `:focus-visible` outline fallback so every interactive element shows a theme-aware focus ring in both light and dark modes; components that render their own ring opt out via `focus-visible:outline-none`, so they do not double up.
- Adds a visually-hidden `<h1>` page title inside `<main>` to satisfy the single top-level heading expectation without changing the chrome-free layout.
- Replaces the single-view, critical-only axe smoke check with a dedicated multi-screen suite (`e2e/a11y.spec.ts`) covering the initial view, a loaded layer, the attribute table, the command palette, and the keyboard-shortcuts dialog. It fails on any critical or serious violation.

## Notes
- The audit found no critical violations anywhere. The command palette and shortcuts dialog scan completely clean.
- One pre-existing serious issue is allowlisted and documented in the suite: layer-panel rows are `role="button"` cards that wrap interactive children (`nested-interactive`). The rows are already keyboard-operable; removing the nesting needs a layer-panel interaction redesign and is left as a focused follow-up. The allowlist still fails the build on any new serious or critical regression.
- The light `--muted-foreground` token was darkened (46.9% to 40% lightness), which slightly darkens secondary text in light mode.

## Test plan
- [x] `npm run test:e2e` (a11y suite passes across all five screens; smoke suite still passes)
- [x] `npm run build` / `tsc -b` passes
- [x] `npm run test:frontend` passes (419 tests)
- [x] ESLint and pre-commit hooks pass
- [ ] Manually verify keyboard focus rings are visible in both light and dark themes
- [ ] Manually verify sliders announce their names with a screen reader

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Added hidden top-level heading and descriptive labels for map panels, tables, and layer controls to improve screen-reader navigation.
  * Ensured sliders and other controls expose accessible names.
  * Improved focus-visible outlines and boosted contrast for secondary text to meet WCAG AA targets.

* **Tests**
  * Expanded end-to-end accessibility testing into a dedicated multi-screen suite that scans key UI states and reports violations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->