### PR TITLE
refactor(menu): drop duplicate Command Palette and Shortcuts entries

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -33,14 +33,12 @@ import {
   Eye,
   EyeOff,
   FolderCog,
-  Keyboard,
   MapPinned,
   LayoutPanelTop,
   PanelLeft,
   PanelRight,
   Plus,
   RotateCcw,
-  Search,
   Settings,
   TableProperties,
   Type,
@@ -65,8 +63,6 @@ interface SettingsDialogProps {
   mapControllerRef: RefObject<MapController | null>;
   showLabels?: boolean;
   onOpenManagePlugins: () => void;
-  onOpenCommandPalette: () => void;
-  onOpenKeyboardShortcuts: () => void;
 }
 
 const SECTION_ITEMS: Array<{
@@ -194,8 +190,6 @@ export function SettingsDialog({
   mapControllerRef,
   showLabels = true,
   onOpenManagePlugins,
-  onOpenCommandPalette,
-  onOpenKeyboardShortcuts,
 }: SettingsDialogProps) {
   const preferences = useAppStore((s) => s.preferences);
   const setPreferences = useAppStore((s) => s.setPreferences);
@@ -530,15 +524,6 @@ export function SettingsDialog({
           <DropdownMenuItem onSelect={() => onOpenManagePlugins()}>
             <Puzzle className="mr-2 h-3.5 w-3.5" />
             Manage Plugins
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onSelect={() => onOpenCommandPalette()}>
-            <Search className="mr-2 h-3.5 w-3.5" />
-            Command Palette
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => onOpenKeyboardShortcuts()}>
-            <Keyboard className="mr-2 h-3.5 w-3.5" />
-            Keyboard Shortcuts
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -1947,8 +1947,6 @@ export function TopToolbar({
         mapControllerRef={mapControllerRef}
         showLabels={showLabels}
         onOpenManagePlugins={() => setManagePluginsOpen(true)}
-        onOpenCommandPalette={() => setCommandPaletteOpen(true)}
-        onOpenKeyboardShortcuts={() => setShortcutsOpen(true)}
       />
       <ManagePluginsDialog
         open={managePluginsOpen}


### PR DESCRIPTION
## Summary
- Remove the Command Palette and Keyboard Shortcuts items from the Settings menu since both already exist in the Help menu.
- Clean up the now-unused props and icon imports tied to those entries.

## Test plan
- [ ] Open the Settings menu and confirm Command Palette and Keyboard Shortcuts are gone.
- [ ] Open the Help menu and confirm both still work.
- [ ] `npm run typecheck` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed "Command Palette" and "Keyboard Shortcuts" options from the settings dropdown menu. These features are no longer accessible through the settings interface. The "Manage Plugins" feature remains available in the settings menu, allowing users to easily manage and configure installed extensions and plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->