### PR TITLE
feat(print): print layout composer with PNG/PDF export

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -70,6 +70,7 @@ export function PrintLayoutDialog({
   const [exporting, setExporting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const previewRef = useRef<HTMLCanvasElement | null>(null);
+  const wasOpenRef = useRef(false);
 
   const legend = useMemo(() => buildLegend(layers), [layers]);
 
@@ -89,16 +90,19 @@ export function PrintLayoutDialog({
     }
   }, [mapControllerRef]);
 
-  // Capture the map and seed defaults each time the dialog opens.
+  // Capture the map and seed defaults only on the closed -> open transition, so
+  // a background project-name change while the dialog is open does not replace
+  // the snapshot the user is composing.
   useEffect(() => {
-    if (!open) return;
-    setTitle((prev) => prev || (projectName ?? "").trim());
-    setFooterText(
-      (prev) =>
-        prev ||
-        `Created with GeoLibre · ${new Date().toLocaleDateString()}`,
-    );
-    recapture();
+    if (open && !wasOpenRef.current) {
+      setTitle((prev) => prev || (projectName ?? "").trim());
+      setFooterText(
+        (prev) =>
+          prev || `Created with GeoLibre · ${new Date().toLocaleDateString()}`,
+      );
+      recapture();
+    }
+    wasOpenRef.current = open;
   }, [open, projectName, recapture]);
 
   const options = useMemo<LayoutOptions>(
@@ -141,14 +145,17 @@ export function PrintLayoutDialog({
     if (!open) return;
     const canvas = previewRef.current;
     if (!canvas) return;
-    const { widthMm, heightMm } = pageDimensionsMm(paperSize, orientation);
+    const { widthMm, heightMm } = pageDimensionsMm(
+      options.paperSize,
+      options.orientation,
+    );
     const aspect = widthMm / heightMm;
     const pw = aspect >= 1 ? PREVIEW_LONG_EDGE : Math.round(PREVIEW_LONG_EDGE * aspect);
     const ph = aspect >= 1 ? Math.round(PREVIEW_LONG_EDGE / aspect) : PREVIEW_LONG_EDGE;
     canvas.width = pw;
     canvas.height = ph;
     drawLayout(canvas, options);
-  }, [open, options, paperSize, orientation]);
+  }, [open, options]);
 
   const handleExport = async (kind: "png" | "pdf") => {
     if (!captured) {

--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -1,0 +1,329 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useAppStore } from "@geolibre/core";
+import type { MapController } from "@geolibre/map";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+  Select,
+  Separator,
+} from "@geolibre/ui";
+import { FileImage, FileText, RefreshCw } from "lucide-react";
+import {
+  drawLayout,
+  pageDimensionsMm,
+  PAPER_SIZES,
+  type LayoutOptions,
+  type Orientation,
+  type PaperSizeId,
+} from "../../lib/print-layout";
+import {
+  buildLegend,
+  captureMapImage,
+  exportLayoutPdf,
+  exportLayoutPng,
+  type CapturedMap,
+} from "../../lib/print-layout-export";
+
+interface PrintLayoutDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mapControllerRef: React.RefObject<MapController | null>;
+}
+
+const PREVIEW_LONG_EDGE = 560;
+
+function sanitizeFilename(name: string): string {
+  const cleaned = name.trim().replace(/[^A-Za-z0-9 _-]+/g, "").replace(/\s+/g, "-");
+  return cleaned || "map-layout";
+}
+
+/**
+ * Print Layout composer dialog: captures the current map view and composes it
+ * with a title, legend, scale bar, north arrow, and footer onto a chosen paper
+ * size, then exports the result to PNG or PDF.
+ */
+export function PrintLayoutDialog({
+  open,
+  onOpenChange,
+  mapControllerRef,
+}: PrintLayoutDialogProps) {
+  const layers = useAppStore((s) => s.layers);
+  const projectName = useAppStore((s) => s.projectName);
+
+  const [title, setTitle] = useState("");
+  const [subtitle, setSubtitle] = useState("");
+  const [paperSize, setPaperSize] = useState<PaperSizeId>("a4");
+  const [orientation, setOrientation] = useState<Orientation>("landscape");
+  const [showTitle, setShowTitle] = useState(true);
+  const [showLegend, setShowLegend] = useState(true);
+  const [showScaleBar, setShowScaleBar] = useState(true);
+  const [showNorthArrow, setShowNorthArrow] = useState(true);
+  const [showFooter, setShowFooter] = useState(true);
+  const [footerText, setFooterText] = useState("");
+  const [captured, setCaptured] = useState<CapturedMap | null>(null);
+  const [exporting, setExporting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const previewRef = useRef<HTMLCanvasElement | null>(null);
+
+  const legend = useMemo(() => buildLegend(layers), [layers]);
+
+  const recapture = useCallback(() => {
+    const map = mapControllerRef.current?.getMap();
+    if (!map) {
+      setError("Map is not ready yet. Try again in a moment.");
+      setCaptured(null);
+      return;
+    }
+    try {
+      setCaptured(captureMapImage(map));
+      setError(null);
+    } catch {
+      setError("Could not capture the map image.");
+      setCaptured(null);
+    }
+  }, [mapControllerRef]);
+
+  // Capture the map and seed defaults each time the dialog opens.
+  useEffect(() => {
+    if (!open) return;
+    setTitle((prev) => prev || (projectName ?? "").trim());
+    setFooterText(
+      (prev) =>
+        prev ||
+        `Created with GeoLibre · ${new Date().toLocaleDateString()}`,
+    );
+    recapture();
+  }, [open, projectName, recapture]);
+
+  const options = useMemo<LayoutOptions>(
+    () => ({
+      title,
+      subtitle,
+      paperSize,
+      orientation,
+      showTitle,
+      showLegend,
+      showScaleBar,
+      showNorthArrow,
+      showFooter,
+      footerText,
+      legend,
+      metersPerPixel: captured?.metersPerPixel ?? 0,
+      bearingDeg: captured?.bearingDeg ?? 0,
+      mapImage: captured?.image ?? null,
+      mapImageWidth: captured?.width ?? 0,
+      mapImageHeight: captured?.height ?? 0,
+    }),
+    [
+      title,
+      subtitle,
+      paperSize,
+      orientation,
+      showTitle,
+      showLegend,
+      showScaleBar,
+      showNorthArrow,
+      showFooter,
+      footerText,
+      legend,
+      captured,
+    ],
+  );
+
+  // Redraw the preview whenever the layout options change.
+  useEffect(() => {
+    if (!open) return;
+    const canvas = previewRef.current;
+    if (!canvas) return;
+    const { widthMm, heightMm } = pageDimensionsMm(paperSize, orientation);
+    const aspect = widthMm / heightMm;
+    const pw = aspect >= 1 ? PREVIEW_LONG_EDGE : Math.round(PREVIEW_LONG_EDGE * aspect);
+    const ph = aspect >= 1 ? Math.round(PREVIEW_LONG_EDGE / aspect) : PREVIEW_LONG_EDGE;
+    canvas.width = pw;
+    canvas.height = ph;
+    drawLayout(canvas, options);
+  }, [open, options, paperSize, orientation]);
+
+  const handleExport = async (kind: "png" | "pdf") => {
+    if (!captured) {
+      setError("Capture the map before exporting.");
+      return;
+    }
+    setExporting(true);
+    setError(null);
+    try {
+      const base = sanitizeFilename(title || projectName || "map-layout");
+      if (kind === "png") {
+        await exportLayoutPng(options, `${base}.png`);
+      } else {
+        exportLayoutPdf(options, `${base}.pdf`);
+      }
+    } catch {
+      setError(`Failed to export ${kind.toUpperCase()}.`);
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const toggle = (
+    id: string,
+    label: string,
+    checked: boolean,
+    onChange: (next: boolean) => void,
+  ) => (
+    <label
+      htmlFor={id}
+      className="flex cursor-pointer items-center gap-2 text-sm"
+    >
+      <input
+        id={id}
+        type="checkbox"
+        className="h-4 w-4 accent-primary"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+      />
+      {label}
+    </label>
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-5xl">
+        <DialogHeader>
+          <DialogTitle>Print Layout</DialogTitle>
+          <DialogDescription>
+            Compose a print-ready map with a title, legend, scale bar, and north
+            arrow, then export it to PNG or PDF.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-6 md:grid-cols-[320px_1fr]">
+          {/* Controls */}
+          <div className="space-y-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="layout-title">Title</Label>
+              <Input
+                id="layout-title"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="Map title"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="layout-subtitle">Subtitle</Label>
+              <Input
+                id="layout-subtitle"
+                value={subtitle}
+                onChange={(e) => setSubtitle(e.target.value)}
+                placeholder="Optional subtitle"
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="layout-paper">Paper size</Label>
+                <Select
+                  id="layout-paper"
+                  value={paperSize}
+                  onChange={(e) => setPaperSize(e.target.value as PaperSizeId)}
+                >
+                  {PAPER_SIZES.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.label}
+                    </option>
+                  ))}
+                </Select>
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="layout-orientation">Orientation</Label>
+                <Select
+                  id="layout-orientation"
+                  value={orientation}
+                  onChange={(e) =>
+                    setOrientation(e.target.value as Orientation)
+                  }
+                >
+                  <option value="portrait">Portrait</option>
+                  <option value="landscape">Landscape</option>
+                </Select>
+              </div>
+            </div>
+
+            <Separator />
+
+            <div className="space-y-2">
+              <p className="text-sm font-medium">Map elements</p>
+              {toggle("el-title", "Title block", showTitle, setShowTitle)}
+              {toggle("el-legend", "Legend", showLegend, setShowLegend)}
+              {toggle("el-scale", "Scale bar", showScaleBar, setShowScaleBar)}
+              {toggle(
+                "el-north",
+                "North arrow",
+                showNorthArrow,
+                setShowNorthArrow,
+              )}
+              {toggle("el-footer", "Footer", showFooter, setShowFooter)}
+            </div>
+
+            {showFooter && (
+              <div className="space-y-1.5">
+                <Label htmlFor="layout-footer">Footer text</Label>
+                <Input
+                  id="layout-footer"
+                  value={footerText}
+                  onChange={(e) => setFooterText(e.target.value)}
+                />
+              </div>
+            )}
+          </div>
+
+          {/* Preview */}
+          <div className="flex flex-col items-center justify-start gap-3">
+            <div className="flex w-full items-center justify-between">
+              <span className="text-sm text-muted-foreground">Preview</span>
+              <Button variant="ghost" size="sm" onClick={recapture}>
+                <RefreshCw className="mr-2 h-3.5 w-3.5" />
+                Recapture map
+              </Button>
+            </div>
+            <div className="flex max-h-[420px] w-full items-center justify-center overflow-auto rounded-md border bg-muted/30 p-3">
+              <canvas
+                ref={previewRef}
+                className="max-w-full shadow-md"
+                style={{ imageRendering: "auto" }}
+              />
+            </div>
+            {error && <p className="text-sm text-destructive">{error}</p>}
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end gap-2 pt-2">
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+          <Button
+            variant="outline"
+            disabled={exporting || !captured}
+            onClick={() => void handleExport("png")}
+          >
+            <FileImage className="mr-2 h-4 w-4" />
+            Export PNG
+          </Button>
+          <Button
+            disabled={exporting || !captured}
+            onClick={() => void handleExport("pdf")}
+          >
+            <FileText className="mr-2 h-4 w-4" />
+            Export PDF
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -43,6 +43,29 @@ function sanitizeFilename(name: string): string {
   return cleaned || "map-layout";
 }
 
+interface ToggleFieldProps {
+  id: string;
+  label: string;
+  checked: boolean;
+  onChange: (next: boolean) => void;
+}
+
+/** A labelled checkbox row for toggling a map element on or off. */
+function ToggleField({ id, label, checked, onChange }: ToggleFieldProps) {
+  return (
+    <label htmlFor={id} className="flex cursor-pointer items-center gap-2 text-sm">
+      <input
+        id={id}
+        type="checkbox"
+        className="h-4 w-4 accent-primary"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+      />
+      {label}
+    </label>
+  );
+}
+
 /**
  * Print Layout composer dialog: captures the current map view and composes it
  * with a title, legend, scale bar, north arrow, and footer onto a chosen paper
@@ -95,6 +118,7 @@ export function PrintLayoutDialog({
   // the snapshot the user is composing.
   useEffect(() => {
     if (open && !wasOpenRef.current) {
+      setError(null);
       setTitle((prev) => prev || (projectName ?? "").trim());
       setFooterText(
         (prev) =>
@@ -178,27 +202,6 @@ export function PrintLayoutDialog({
     }
   };
 
-  const toggle = (
-    id: string,
-    label: string,
-    checked: boolean,
-    onChange: (next: boolean) => void,
-  ) => (
-    <label
-      htmlFor={id}
-      className="flex cursor-pointer items-center gap-2 text-sm"
-    >
-      <input
-        id={id}
-        type="checkbox"
-        className="h-4 w-4 accent-primary"
-        checked={checked}
-        onChange={(e) => onChange(e.target.checked)}
-      />
-      {label}
-    </label>
-  );
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-5xl">
@@ -266,16 +269,36 @@ export function PrintLayoutDialog({
 
             <div className="space-y-2">
               <p className="text-sm font-medium">Map elements</p>
-              {toggle("el-title", "Title block", showTitle, setShowTitle)}
-              {toggle("el-legend", "Legend", showLegend, setShowLegend)}
-              {toggle("el-scale", "Scale bar", showScaleBar, setShowScaleBar)}
-              {toggle(
-                "el-north",
-                "North arrow",
-                showNorthArrow,
-                setShowNorthArrow,
-              )}
-              {toggle("el-footer", "Footer", showFooter, setShowFooter)}
+              <ToggleField
+                id="el-title"
+                label="Title block"
+                checked={showTitle}
+                onChange={setShowTitle}
+              />
+              <ToggleField
+                id="el-legend"
+                label="Legend"
+                checked={showLegend}
+                onChange={setShowLegend}
+              />
+              <ToggleField
+                id="el-scale"
+                label="Scale bar"
+                checked={showScaleBar}
+                onChange={setShowScaleBar}
+              />
+              <ToggleField
+                id="el-north"
+                label="North arrow"
+                checked={showNorthArrow}
+                onChange={setShowNorthArrow}
+              />
+              <ToggleField
+                id="el-footer"
+                label="Footer"
+                checked={showFooter}
+                onChange={setShowFooter}
+              />
             </div>
 
             {showFooter && (

--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -162,7 +162,7 @@ export function PrintLayoutDialog({
       if (kind === "png") {
         await exportLayoutPng(options, `${base}.png`);
       } else {
-        exportLayoutPdf(options, `${base}.pdf`);
+        await exportLayoutPdf(options, `${base}.pdf`);
       }
     } catch {
       setError(`Failed to export ${kind.toUpperCase()}.`);

--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -39,7 +39,12 @@ interface PrintLayoutDialogProps {
 const PREVIEW_LONG_EDGE = 560;
 
 function sanitizeFilename(name: string): string {
-  const cleaned = name.trim().replace(/[^A-Za-z0-9 _-]+/g, "").replace(/\s+/g, "-");
+  // Keep letters and digits from any script (\p{L}\p{N}) so non-Latin project
+  // names are not stripped to the fallback.
+  const cleaned = name
+    .trim()
+    .replace(/[^\p{L}\p{N} _-]+/gu, "")
+    .replace(/\s+/g, "-");
   return cleaned || "map-layout";
 }
 

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -123,6 +123,7 @@ import {
   Moon,
   Pencil,
   Printer,
+  LayoutTemplate,
   Puzzle,
   Redo2,
   RefreshCw,
@@ -174,6 +175,7 @@ import { NewProjectDialog } from "./NewProjectDialog";
 import { ManagePluginsDialog } from "./ManagePluginsDialog";
 import { ShareProjectDialog } from "./ShareProjectDialog";
 import { SettingsDialog } from "./SettingsDialog";
+import { PrintLayoutDialog } from "./PrintLayoutDialog";
 
 interface TopToolbarProps {
   compact?: boolean;
@@ -390,6 +392,7 @@ export function TopToolbar({
     sizeMb: number;
   } | null>(null);
   const [aboutOpen, setAboutOpen] = useState(false);
+  const [printLayoutOpen, setPrintLayoutOpen] = useState(false);
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [checkForUpdatesRequest, setCheckForUpdatesRequest] = useState(0);
@@ -978,6 +981,13 @@ export function TopToolbar({
       icon: Printer,
       run: handleTogglePrintPanel,
     },
+    {
+      id: "project.print-layout",
+      title: "Print Layout…",
+      group: "Project",
+      icon: LayoutTemplate,
+      run: () => setPrintLayoutOpen(true),
+    },
     // Add Data
     {
       id: "add.vector",
@@ -1412,6 +1422,10 @@ export function TopToolbar({
             <Printer className="mr-2 h-3.5 w-3.5" />
             Print...
             {printPanelVisible ? " ✓" : ""}
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setPrintLayoutOpen(true)}>
+            <LayoutTemplate className="mr-2 h-3.5 w-3.5" />
+            Print Layout...
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
@@ -1951,6 +1965,11 @@ export function TopToolbar({
       <ManagePluginsDialog
         open={managePluginsOpen}
         onOpenChange={setManagePluginsOpen}
+        mapControllerRef={mapControllerRef}
+      />
+      <PrintLayoutDialog
+        open={printLayoutOpen}
+        onOpenChange={setPrintLayoutOpen}
         mapControllerRef={mapControllerRef}
       />
       <ShareProjectDialog

--- a/apps/geolibre-desktop/src/lib/print-layout-export.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout-export.ts
@@ -165,16 +165,9 @@ export async function exportLayoutPdf(
     unit: "mm",
     format: [widthMm, heightMm],
   });
-  pdf.addImage(
-    canvas.toDataURL("image/png"),
-    "PNG",
-    0,
-    0,
-    widthMm,
-    heightMm,
-    undefined,
-    "FAST",
-  );
+  // Pass the canvas directly so jsPDF reads its pixels without an intermediate
+  // base64 data URL (synchronous and ~33% larger in memory).
+  pdf.addImage(canvas, "PNG", 0, 0, widthMm, heightMm, undefined, "FAST");
   const bytes = new Uint8Array(pdf.output("arraybuffer"));
   return saveBinaryFileWithFallback(bytes, {
     defaultName: filename,

--- a/apps/geolibre-desktop/src/lib/print-layout-export.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout-export.ts
@@ -1,0 +1,158 @@
+/**
+ * Print layout capture, legend building, and export (PNG / PDF).
+ *
+ * {@link buildLegend} is a pure transform from layers to legend entries and is
+ * unit tested. {@link captureMapImage} reads the live map's canvases, and the
+ * export helpers rasterize {@link drawLayout} at print resolution.
+ */
+import jsPDF from "jspdf";
+import {
+  drawLayout,
+  pageDimensionsMm,
+  type LayoutOptions,
+} from "./print-layout";
+
+export { buildLegend } from "./print-legend";
+
+export interface CapturedMap {
+  image: HTMLCanvasElement;
+  width: number;
+  height: number;
+  /** Ground metres per device pixel of the captured image, at map centre. */
+  metersPerPixel: number;
+  bearingDeg: number;
+}
+
+interface MapLike {
+  getCanvas(): HTMLCanvasElement;
+  getContainer(): HTMLElement;
+  getBearing(): number;
+  unproject(point: [number, number]): { lng: number; lat: number };
+}
+
+/**
+ * Capture the current map view as a single composited canvas. All `<canvas>`
+ * elements inside the map container (the MapLibre base canvas plus any deck.gl
+ * overlay) are drawn in DOM order so the snapshot matches what is on screen.
+ *
+ * @param map - The MapLibre map instance.
+ * @returns The composited image plus the ground scale and bearing needed to
+ *   render a scale bar and north arrow.
+ */
+export function captureMapImage(map: MapLike): CapturedMap {
+  const base = map.getCanvas();
+  const out = document.createElement("canvas");
+  out.width = base.width;
+  out.height = base.height;
+  const ctx = out.getContext("2d");
+  if (ctx) {
+    const canvases = map.getContainer().querySelectorAll("canvas");
+    canvases.forEach((c) => {
+      try {
+        ctx.drawImage(c, 0, 0, out.width, out.height);
+      } catch {
+        // A tainted or zero-size canvas is skipped rather than aborting.
+      }
+    });
+  }
+
+  const cssWidth = base.clientWidth || base.width;
+  const cssHeight = base.clientHeight || base.height;
+  const midY = cssHeight / 2;
+  const span = Math.min(100, cssWidth / 2);
+  const left = map.unproject([cssWidth / 2 - span / 2, midY]);
+  const right = map.unproject([cssWidth / 2 + span / 2, midY]);
+  const metersPerCssPx = haversineMeters(left, right) / span;
+  const dpr = cssWidth > 0 ? out.width / cssWidth : 1;
+  const metersPerPixel = dpr > 0 ? metersPerCssPx / dpr : metersPerCssPx;
+
+  return {
+    image: out,
+    width: out.width,
+    height: out.height,
+    metersPerPixel,
+    bearingDeg: map.getBearing(),
+  };
+}
+
+function haversineMeters(
+  a: { lng: number; lat: number },
+  b: { lng: number; lat: number },
+): number {
+  const R = 6371008.8;
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(b.lat - a.lat);
+  const dLng = toRad(b.lng - a.lng);
+  const la1 = toRad(a.lat);
+  const la2 = toRad(b.lat);
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(la1) * Math.cos(la2) * Math.sin(dLng / 2) ** 2;
+  return 2 * R * Math.asin(Math.min(1, Math.sqrt(h)));
+}
+
+/** Rasterize a layout to an offscreen canvas at the given DPI. */
+function renderToCanvas(opts: LayoutOptions, dpi: number): HTMLCanvasElement {
+  const { widthMm, heightMm } = pageDimensionsMm(
+    opts.paperSize,
+    opts.orientation,
+  );
+  const pxPerMm = dpi / 25.4;
+  const canvas = document.createElement("canvas");
+  canvas.width = Math.round(widthMm * pxPerMm);
+  canvas.height = Math.round(heightMm * pxPerMm);
+  drawLayout(canvas, opts);
+  return canvas;
+}
+
+function triggerDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+/** Export the layout as a PNG file at the given DPI (default 150). */
+export async function exportLayoutPng(
+  opts: LayoutOptions,
+  filename: string,
+  dpi = 150,
+): Promise<void> {
+  const canvas = renderToCanvas(opts, dpi);
+  const blob = await new Promise<Blob | null>((resolve) =>
+    canvas.toBlob((b) => resolve(b), "image/png"),
+  );
+  if (!blob) throw new Error("Failed to render PNG");
+  triggerDownload(blob, filename);
+}
+
+/** Export the layout as a PDF file at the given DPI (default 150). */
+export function exportLayoutPdf(
+  opts: LayoutOptions,
+  filename: string,
+  dpi = 150,
+): void {
+  const { widthMm, heightMm } = pageDimensionsMm(
+    opts.paperSize,
+    opts.orientation,
+  );
+  const canvas = renderToCanvas(opts, dpi);
+  // Provide already-oriented page dimensions and keep portrait orientation so
+  // jsPDF does not swap width/height a second time.
+  const pdf = new jsPDF({ unit: "mm", format: [widthMm, heightMm] });
+  pdf.addImage(
+    canvas.toDataURL("image/png"),
+    "PNG",
+    0,
+    0,
+    widthMm,
+    heightMm,
+    undefined,
+    "FAST",
+  );
+  pdf.save(filename);
+}

--- a/apps/geolibre-desktop/src/lib/print-layout-export.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout-export.ts
@@ -55,8 +55,12 @@ export function captureMapImage(map: MapLike): CapturedMap {
   canvases.forEach((c) => {
     try {
       ctx.drawImage(c, 0, 0, out.width, out.height);
-    } catch {
-      // A tainted or zero-size canvas is skipped rather than aborting.
+    } catch (err) {
+      // The base map canvas is unrecoverable (most likely cross-origin tile
+      // CORS tainting it): propagate so the dialog reports an error instead of
+      // exporting a blank page. A tainted/zero-size overlay (deck.gl) is only
+      // cosmetic, so skip it.
+      if (c === base) throw err;
     }
   });
 

--- a/apps/geolibre-desktop/src/lib/print-layout-export.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout-export.ts
@@ -46,16 +46,19 @@ export function captureMapImage(map: MapLike): CapturedMap {
   out.width = base.width;
   out.height = base.height;
   const ctx = out.getContext("2d");
-  if (ctx) {
-    const canvases = map.getContainer().querySelectorAll("canvas");
-    canvases.forEach((c) => {
-      try {
-        ctx.drawImage(c, 0, 0, out.width, out.height);
-      } catch {
-        // A tainted or zero-size canvas is skipped rather than aborting.
-      }
-    });
+  // Throw rather than return a blank canvas: the dialog's recapture() catch then
+  // surfaces a clear error instead of letting the user export a white page.
+  if (!ctx) {
+    throw new Error("Could not acquire a 2D canvas context for map capture");
   }
+  const canvases = map.getContainer().querySelectorAll("canvas");
+  canvases.forEach((c) => {
+    try {
+      ctx.drawImage(c, 0, 0, out.width, out.height);
+    } catch {
+      // A tainted or zero-size canvas is skipped rather than aborting.
+    }
+  });
 
   const cssWidth = base.clientWidth || base.width;
   const cssHeight = base.clientHeight || base.height;

--- a/apps/geolibre-desktop/src/lib/print-layout-export.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout-export.ts
@@ -11,6 +11,7 @@ import {
   pageDimensionsMm,
   type LayoutOptions,
 } from "./print-layout";
+import { saveBinaryFileWithFallback } from "./tauri-io";
 
 export { buildLegend } from "./print-legend";
 
@@ -105,37 +106,52 @@ function renderToCanvas(opts: LayoutOptions, dpi: number): HTMLCanvasElement {
   return canvas;
 }
 
-function triggerDownload(blob: Blob, filename: string): void {
-  const url = URL.createObjectURL(blob);
-  const anchor = document.createElement("a");
-  anchor.href = url;
-  anchor.download = filename;
-  document.body.appendChild(anchor);
-  anchor.click();
-  anchor.remove();
-  setTimeout(() => URL.revokeObjectURL(url), 1000);
-}
-
-/** Export the layout as a PNG file at the given DPI (default 150). */
-export async function exportLayoutPng(
-  opts: LayoutOptions,
-  filename: string,
-  dpi = 150,
-): Promise<void> {
-  const canvas = renderToCanvas(opts, dpi);
+async function canvasToPngBytes(canvas: HTMLCanvasElement): Promise<Uint8Array> {
   const blob = await new Promise<Blob | null>((resolve) =>
     canvas.toBlob((b) => resolve(b), "image/png"),
   );
   if (!blob) throw new Error("Failed to render PNG");
-  triggerDownload(blob, filename);
+  return new Uint8Array(await blob.arrayBuffer());
 }
 
-/** Export the layout as a PDF file at the given DPI (default 150). */
-export function exportLayoutPdf(
+/**
+ * Export the layout as a PNG file at the given DPI (default 150).
+ *
+ * Routes through {@link saveBinaryFileWithFallback} so it works in the Tauri
+ * desktop app (native save dialog + filesystem write) as well as the browser
+ * build, where anchor-style downloads are unavailable in the webview.
+ *
+ * @returns The saved file name, or null if the user cancelled the save dialog.
+ */
+export async function exportLayoutPng(
   opts: LayoutOptions,
   filename: string,
   dpi = 150,
-): void {
+): Promise<string | null> {
+  const canvas = renderToCanvas(opts, dpi);
+  const bytes = await canvasToPngBytes(canvas);
+  return saveBinaryFileWithFallback(bytes, {
+    defaultName: filename,
+    filters: [{ name: "PNG Image", extensions: ["png"] }],
+    browserTypes: [{ description: "PNG Image", accept: { "image/png": [".png"] } }],
+    mimeType: "image/png",
+  });
+}
+
+/**
+ * Export the layout as a PDF file at the given DPI (default 150).
+ *
+ * Generates the PDF bytes with jsPDF and saves them through
+ * {@link saveBinaryFileWithFallback}; `jsPDF.save()` does not work inside the
+ * Tauri webview because it relies on an anchor download.
+ *
+ * @returns The saved file name, or null if the user cancelled the save dialog.
+ */
+export async function exportLayoutPdf(
+  opts: LayoutOptions,
+  filename: string,
+  dpi = 150,
+): Promise<string | null> {
   const { widthMm, heightMm } = pageDimensionsMm(
     opts.paperSize,
     opts.orientation,
@@ -154,5 +170,13 @@ export function exportLayoutPdf(
     undefined,
     "FAST",
   );
-  pdf.save(filename);
+  const bytes = new Uint8Array(pdf.output("arraybuffer"));
+  return saveBinaryFileWithFallback(bytes, {
+    defaultName: filename,
+    filters: [{ name: "PDF Document", extensions: ["pdf"] }],
+    browserTypes: [
+      { description: "PDF Document", accept: { "application/pdf": [".pdf"] } },
+    ],
+    mimeType: "application/pdf",
+  });
 }

--- a/apps/geolibre-desktop/src/lib/print-layout-export.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout-export.ts
@@ -157,9 +157,14 @@ export async function exportLayoutPdf(
     opts.orientation,
   );
   const canvas = renderToCanvas(opts, dpi);
-  // Provide already-oriented page dimensions and keep portrait orientation so
-  // jsPDF does not swap width/height a second time.
-  const pdf = new jsPDF({ unit: "mm", format: [widthMm, heightMm] });
+  // Pass the orientation explicitly: jsPDF normalizes the format array to match
+  // the orientation (portrait forces width <= height), so an oriented format
+  // alone would be rotated back to portrait.
+  const pdf = new jsPDF({
+    orientation: opts.orientation,
+    unit: "mm",
+    format: [widthMm, heightMm],
+  });
   pdf.addImage(
     canvas.toDataURL("image/png"),
     "PNG",

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -194,11 +194,17 @@ export function drawLayout(
 
   // --- North arrow (top-right inside the map) ---------------------------
   if (opts.showNorthArrow) {
+    const arrowRadius = unit * 2.6;
+    const discRadius = arrowRadius * 1.5;
+    // The "N" label extends above the arrow tip, so the disc is not the top
+    // extent; account for both so nothing is clipped by the map edge.
+    const topExtent = arrowRadius + unit * 2.4;
+    const arrowMargin = unit * 3;
     drawNorthArrow(
       ctx,
-      bodyX + bodyW - inset - unit * 3,
-      bodyY + inset + unit * 3,
-      unit * 3,
+      bodyX + bodyW - arrowMargin - discRadius,
+      bodyY + arrowMargin + topExtent,
+      arrowRadius,
       opts.bearingDeg,
       unit,
     );

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -273,7 +273,13 @@ function drawNorthArrow(
   ctx.font = `700 ${unit * 1.8}px system-ui, sans-serif`;
   ctx.textAlign = "center";
   ctx.textBaseline = "middle";
-  ctx.fillText("N", 0, -radius - unit * 1.4);
+  // Keep the label upright (only the arrow rotates with bearing): move to the
+  // tip in the rotated frame, then undo the rotation before drawing the glyph.
+  ctx.save();
+  ctx.translate(0, -radius - unit * 1.4);
+  ctx.rotate((bearingDeg * Math.PI) / 180);
+  ctx.fillText("N", 0, 0);
+  ctx.restore();
   ctx.restore();
 }
 

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -156,6 +156,9 @@ export function drawLayout(
   }
 
   // --- Map body ----------------------------------------------------------
+  // Clamp the top so a tall title block plus footer on a very small page can
+  // never push the map area below the footer (which would overflow the page).
+  bodyTop = Math.min(bodyTop, bodyBottom - unit * 10);
   const bodyX = margin;
   const bodyY = bodyTop;
   const bodyW = W - margin * 2;
@@ -269,6 +272,9 @@ function drawNorthArrow(
 
 /** Round a distance down to a "nice" 1/2/5 × 10ⁿ value. */
 function niceDistance(meters: number): number {
+  // Guard against a zero/negative body width: Math.log10(0) is -Infinity, which
+  // would propagate as NaN through the scale-bar geometry.
+  if (meters <= 0) return 1;
   const pow = Math.pow(10, Math.floor(Math.log10(meters)));
   const frac = meters / pow;
   let nice: number;

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -1,0 +1,415 @@
+/**
+ * Print layout composer rendering.
+ *
+ * Pure, framework-free drawing helpers that compose a captured map image with
+ * cartographic furniture (title, legend, scale bar, north arrow, footer) onto a
+ * 2D canvas at a paper page size. The same {@link drawLayout} function backs
+ * both the on-screen preview (small canvas) and the high-resolution export
+ * (PNG / PDF), so the preview is faithful to the output.
+ */
+
+export type PaperSizeId = "a4" | "a3" | "letter" | "legal" | "tabloid";
+export type Orientation = "portrait" | "landscape";
+
+export interface PaperSize {
+  id: PaperSizeId;
+  label: string;
+  /** Width in millimetres in portrait orientation. */
+  widthMm: number;
+  /** Height in millimetres in portrait orientation. */
+  heightMm: number;
+}
+
+/** Standard paper sizes, expressed in their portrait dimensions. */
+export const PAPER_SIZES: PaperSize[] = [
+  { id: "a4", label: "A4 (210 × 297 mm)", widthMm: 210, heightMm: 297 },
+  { id: "a3", label: "A3 (297 × 420 mm)", widthMm: 297, heightMm: 420 },
+  { id: "letter", label: "Letter (8.5 × 11 in)", widthMm: 215.9, heightMm: 279.4 },
+  { id: "legal", label: "Legal (8.5 × 14 in)", widthMm: 215.9, heightMm: 355.6 },
+  { id: "tabloid", label: "Tabloid (11 × 17 in)", widthMm: 279.4, heightMm: 431.8 },
+];
+
+export function getPaperSize(id: PaperSizeId): PaperSize {
+  return PAPER_SIZES.find((p) => p.id === id) ?? PAPER_SIZES[0];
+}
+
+/**
+ * Page dimensions in millimetres for a paper size and orientation, with the
+ * width/height swapped for landscape.
+ */
+export function pageDimensionsMm(
+  id: PaperSizeId,
+  orientation: Orientation,
+): { widthMm: number; heightMm: number } {
+  const paper = getPaperSize(id);
+  return orientation === "landscape"
+    ? { widthMm: paper.heightMm, heightMm: paper.widthMm }
+    : { widthMm: paper.widthMm, heightMm: paper.heightMm };
+}
+
+/** A single swatch in a legend entry (one color, with an optional label). */
+export interface LegendSwatch {
+  color: string;
+  label?: string;
+}
+
+export interface LegendEntry {
+  name: string;
+  swatches: LegendSwatch[];
+}
+
+export interface LayoutOptions {
+  title: string;
+  subtitle: string;
+  paperSize: PaperSizeId;
+  orientation: Orientation;
+  showTitle: boolean;
+  showLegend: boolean;
+  showScaleBar: boolean;
+  showNorthArrow: boolean;
+  showFooter: boolean;
+  footerText: string;
+  legend: LegendEntry[];
+  /** Ground metres per source-image pixel at the map centre. */
+  metersPerPixel: number;
+  /** Map bearing in degrees clockwise from north. */
+  bearingDeg: number;
+  /** The captured map image (already composited). */
+  mapImage: CanvasImageSource | null;
+  /** Intrinsic width of {@link mapImage} in pixels. */
+  mapImageWidth: number;
+  /** Intrinsic height of {@link mapImage} in pixels. */
+  mapImageHeight: number;
+}
+
+const PAGE_BACKGROUND = "#ffffff";
+const INK = "#111827";
+const MUTED = "#6b7280";
+const BORDER = "#9ca3af";
+
+/**
+ * Draw the full page layout onto a canvas. The canvas pixel dimensions define
+ * the render resolution; all furniture is scaled relative to the page so the
+ * preview and the export look identical.
+ *
+ * @param canvas - Destination canvas; its width/height are taken as the page
+ *   size in pixels.
+ * @param opts - Layout content and options.
+ */
+export function drawLayout(
+  canvas: HTMLCanvasElement,
+  opts: LayoutOptions,
+): void {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+
+  const W = canvas.width;
+  const H = canvas.height;
+  // Scale furniture relative to the page's shorter side so output looks the
+  // same at any resolution / paper size.
+  const unit = Math.min(W, H) / 100;
+  const margin = unit * 5;
+
+  ctx.save();
+  ctx.fillStyle = PAGE_BACKGROUND;
+  ctx.fillRect(0, 0, W, H);
+
+  let bodyTop = margin;
+  let bodyBottom = H - margin;
+
+  // --- Title block -------------------------------------------------------
+  if (opts.showTitle && (opts.title.trim() || opts.subtitle.trim())) {
+    const titleSize = unit * 4.5;
+    const subtitleSize = unit * 2.4;
+    let y = margin + titleSize;
+    if (opts.title.trim()) {
+      ctx.fillStyle = INK;
+      ctx.font = `600 ${titleSize}px system-ui, -apple-system, sans-serif`;
+      ctx.textAlign = "center";
+      ctx.textBaseline = "alphabetic";
+      ctx.fillText(opts.title.trim(), W / 2, y, W - margin * 2);
+    }
+    if (opts.subtitle.trim()) {
+      y += subtitleSize * 1.4;
+      ctx.fillStyle = MUTED;
+      ctx.font = `400 ${subtitleSize}px system-ui, -apple-system, sans-serif`;
+      ctx.textAlign = "center";
+      ctx.fillText(opts.subtitle.trim(), W / 2, y, W - margin * 2);
+    }
+    bodyTop = y + unit * 3;
+  }
+
+  // --- Footer ------------------------------------------------------------
+  if (opts.showFooter && opts.footerText.trim()) {
+    const footSize = unit * 2.2;
+    bodyBottom = H - margin - footSize * 1.8;
+    ctx.fillStyle = MUTED;
+    ctx.font = `400 ${footSize}px system-ui, -apple-system, sans-serif`;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText(
+      opts.footerText.trim(),
+      W / 2,
+      H - margin - footSize * 0.6,
+      W - margin * 2,
+    );
+  }
+
+  // --- Map body ----------------------------------------------------------
+  const bodyX = margin;
+  const bodyY = bodyTop;
+  const bodyW = W - margin * 2;
+  const bodyH = Math.max(unit * 10, bodyBottom - bodyTop);
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(bodyX, bodyY, bodyW, bodyH);
+  ctx.clip();
+  ctx.fillStyle = "#e5e7eb";
+  ctx.fillRect(bodyX, bodyY, bodyW, bodyH);
+
+  // Draw the map image with "cover" scaling (fill the body, crop overflow).
+  let coverScale = 1;
+  if (opts.mapImage && opts.mapImageWidth > 0 && opts.mapImageHeight > 0) {
+    coverScale = Math.max(
+      bodyW / opts.mapImageWidth,
+      bodyH / opts.mapImageHeight,
+    );
+    const drawW = opts.mapImageWidth * coverScale;
+    const drawH = opts.mapImageHeight * coverScale;
+    const dx = bodyX + (bodyW - drawW) / 2;
+    const dy = bodyY + (bodyH - drawH) / 2;
+    ctx.drawImage(opts.mapImage, dx, dy, drawW, drawH);
+  }
+  ctx.restore();
+
+  // Body border.
+  ctx.strokeStyle = BORDER;
+  ctx.lineWidth = Math.max(1, unit * 0.2);
+  ctx.strokeRect(bodyX, bodyY, bodyW, bodyH);
+
+  const inset = unit * 2;
+  // Metres per pixel in the *output* image after cover scaling.
+  const outputMpp = opts.metersPerPixel / (coverScale || 1);
+
+  // --- North arrow (top-right inside the map) ---------------------------
+  if (opts.showNorthArrow) {
+    drawNorthArrow(
+      ctx,
+      bodyX + bodyW - inset - unit * 3,
+      bodyY + inset + unit * 3,
+      unit * 3,
+      opts.bearingDeg,
+      unit,
+    );
+  }
+
+  // --- Scale bar (bottom-right inside the map) --------------------------
+  if (opts.showScaleBar && outputMpp > 0 && Number.isFinite(outputMpp)) {
+    drawScaleBar(
+      ctx,
+      bodyX + bodyW - inset,
+      bodyY + bodyH - inset,
+      bodyW * 0.28,
+      outputMpp,
+      unit,
+    );
+  }
+
+  // --- Legend (bottom-left inside the map) ------------------------------
+  if (opts.showLegend && opts.legend.length > 0) {
+    drawLegend(ctx, bodyX + inset, bodyY + inset, opts.legend, unit);
+  }
+
+  ctx.restore();
+}
+
+/** Draw a north-pointing arrow rotated to account for map bearing. */
+function drawNorthArrow(
+  ctx: CanvasRenderingContext2D,
+  cx: number,
+  cy: number,
+  radius: number,
+  bearingDeg: number,
+  unit: number,
+): void {
+  ctx.save();
+  // Translucent backing disc for legibility over imagery.
+  ctx.fillStyle = "rgba(255,255,255,0.78)";
+  ctx.beginPath();
+  ctx.arc(cx, cy, radius * 1.5, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.translate(cx, cy);
+  // North points to -bearing (map rotates clockwise by bearing).
+  ctx.rotate((-bearingDeg * Math.PI) / 180);
+
+  ctx.fillStyle = INK;
+  ctx.beginPath();
+  ctx.moveTo(0, -radius);
+  ctx.lineTo(radius * 0.55, radius * 0.7);
+  ctx.lineTo(0, radius * 0.35);
+  ctx.lineTo(-radius * 0.55, radius * 0.7);
+  ctx.closePath();
+  ctx.fill();
+
+  ctx.fillStyle = INK;
+  ctx.font = `700 ${unit * 1.8}px system-ui, sans-serif`;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  ctx.fillText("N", 0, -radius - unit * 1.4);
+  ctx.restore();
+}
+
+/** Round a distance down to a "nice" 1/2/5 × 10ⁿ value. */
+function niceDistance(meters: number): number {
+  const pow = Math.pow(10, Math.floor(Math.log10(meters)));
+  const frac = meters / pow;
+  let nice: number;
+  if (frac >= 5) nice = 5;
+  else if (frac >= 2) nice = 2;
+  else nice = 1;
+  return nice * pow;
+}
+
+function formatDistance(meters: number): string {
+  if (meters >= 1000) {
+    const km = meters / 1000;
+    return `${km % 1 === 0 ? km : km.toFixed(1)} km`;
+  }
+  return `${meters % 1 === 0 ? meters : meters.toFixed(1)} m`;
+}
+
+/** Draw a scale bar anchored at its bottom-right corner. */
+function drawScaleBar(
+  ctx: CanvasRenderingContext2D,
+  rightX: number,
+  bottomY: number,
+  maxWidthPx: number,
+  metersPerPixel: number,
+  unit: number,
+): void {
+  const maxMeters = maxWidthPx * metersPerPixel;
+  const distance = niceDistance(maxMeters);
+  const barWidth = distance / metersPerPixel;
+  const barHeight = unit * 1.1;
+  const x0 = rightX - barWidth;
+  const y0 = bottomY - barHeight;
+
+  ctx.save();
+  // Backing for legibility.
+  ctx.fillStyle = "rgba(255,255,255,0.78)";
+  ctx.fillRect(
+    x0 - unit * 0.8,
+    y0 - unit * 2.4,
+    barWidth + unit * 1.6,
+    barHeight + unit * 3.2,
+  );
+
+  // Two-tone bar.
+  const half = barWidth / 2;
+  ctx.fillStyle = INK;
+  ctx.fillRect(x0, y0, half, barHeight);
+  ctx.fillStyle = "#ffffff";
+  ctx.fillRect(x0 + half, y0, half, barHeight);
+  ctx.strokeStyle = INK;
+  ctx.lineWidth = Math.max(1, unit * 0.15);
+  ctx.strokeRect(x0, y0, barWidth, barHeight);
+
+  ctx.fillStyle = INK;
+  ctx.font = `500 ${unit * 1.7}px system-ui, sans-serif`;
+  ctx.textAlign = "right";
+  ctx.textBaseline = "bottom";
+  ctx.fillText(formatDistance(distance), rightX, y0 - unit * 0.5);
+  ctx.restore();
+}
+
+/** Draw a legend box anchored at its top-left corner. */
+function drawLegend(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  entries: LegendEntry[],
+  unit: number,
+): void {
+  const pad = unit * 1.4;
+  const rowH = unit * 2.6;
+  const swatch = unit * 2;
+  const titleSize = unit * 2;
+  const labelSize = unit * 1.7;
+
+  // Measure required width.
+  ctx.save();
+  ctx.font = `600 ${titleSize}px system-ui, sans-serif`;
+  let maxText = ctx.measureText("Legend").width;
+  ctx.font = `400 ${labelSize}px system-ui, sans-serif`;
+  const rows: { color: string; text: string }[] = [];
+  for (const entry of entries) {
+    if (entry.swatches.length <= 1) {
+      rows.push({
+        color: entry.swatches[0]?.color ?? "#999999",
+        text: entry.name,
+      });
+    } else {
+      rows.push({ color: "", text: entry.name });
+      for (const sw of entry.swatches) {
+        rows.push({ color: sw.color, text: sw.label ?? "" });
+      }
+    }
+  }
+  for (const r of rows) {
+    const w = ctx.measureText(r.text).width + (r.color ? swatch + unit : 0);
+    if (w > maxText) maxText = w;
+  }
+
+  const boxW = maxText + pad * 2;
+  const boxH = pad * 2 + titleSize + unit + rows.length * rowH;
+
+  ctx.fillStyle = "rgba(255,255,255,0.85)";
+  ctx.strokeStyle = BORDER;
+  ctx.lineWidth = Math.max(1, unit * 0.15);
+  roundRect(ctx, x, y, boxW, boxH, unit);
+  ctx.fill();
+  ctx.stroke();
+
+  let cy = y + pad + titleSize;
+  ctx.fillStyle = INK;
+  ctx.font = `600 ${titleSize}px system-ui, sans-serif`;
+  ctx.textAlign = "left";
+  ctx.textBaseline = "alphabetic";
+  ctx.fillText("Legend", x + pad, cy);
+  cy += unit;
+
+  for (const r of rows) {
+    cy += rowH;
+    const textX = r.color ? x + pad + swatch + unit : x + pad;
+    if (r.color) {
+      ctx.fillStyle = r.color;
+      ctx.fillRect(x + pad, cy - swatch * 0.85, swatch, swatch);
+      ctx.strokeStyle = BORDER;
+      ctx.strokeRect(x + pad, cy - swatch * 0.85, swatch, swatch);
+    }
+    ctx.fillStyle = r.color ? INK : MUTED;
+    ctx.font = `${r.color ? 400 : 600} ${labelSize}px system-ui, sans-serif`;
+    ctx.fillText(r.text, textX, cy);
+  }
+  ctx.restore();
+}
+
+function roundRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number,
+): void {
+  const radius = Math.min(r, w / 2, h / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + radius, y);
+  ctx.arcTo(x + w, y, x + w, y + h, radius);
+  ctx.arcTo(x + w, y + h, x, y + h, radius);
+  ctx.arcTo(x, y + h, x, y, radius);
+  ctx.arcTo(x, y, x + w, y, radius);
+  ctx.closePath();
+}

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -226,8 +226,15 @@ export function drawLayout(
   }
 
   // --- Legend (bottom-left inside the map) ------------------------------
+  // Clip to the map body so a legend with many layers cannot overflow onto the
+  // footer or off the page.
   if (opts.showLegend && opts.legend.length > 0) {
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(bodyX, bodyY, bodyW, bodyH);
+    ctx.clip();
     drawLegend(ctx, bodyX + inset, bodyY + inset, opts.legend, unit);
+    ctx.restore();
   }
 
   ctx.restore();
@@ -289,7 +296,10 @@ function formatDistance(meters: number): string {
     const km = meters / 1000;
     return `${km % 1 === 0 ? km : km.toFixed(1)} km`;
   }
-  return `${meters % 1 === 0 ? meters : meters.toFixed(1)} m`;
+  // Below a metre (street/parcel zoom) label in centimetres instead of showing
+  // a useless "0.0 m".
+  if (meters >= 1) return `${Math.round(meters)} m`;
+  return `${Math.round(meters * 100)} cm`;
 }
 
 /** Draw a scale bar anchored at its bottom-right corner. */

--- a/apps/geolibre-desktop/src/lib/print-legend.ts
+++ b/apps/geolibre-desktop/src/lib/print-legend.ts
@@ -1,0 +1,106 @@
+/**
+ * Pure legend construction for the Print Layout composer. Kept free of DOM and
+ * PDF dependencies so it can be unit tested directly.
+ */
+import {
+  styleValue,
+  type GeoLibreLayer,
+  type LayerType,
+  type VectorStyleStop,
+} from "@geolibre/core";
+import type { LegendEntry } from "./print-layout";
+
+/** Layer types styled as vectors (colored fills the legend can represent). */
+const VECTOR_TYPES: ReadonlySet<LayerType> = new Set<LayerType>([
+  "geojson",
+  "flatgeobuf",
+  "geoparquet",
+  "vector-tiles",
+  "pmtiles",
+  "duckdb-query",
+  "deckgl-viz",
+]);
+
+/** Layer types with no meaningful single-swatch legend representation. */
+const NON_LEGEND_TYPES: ReadonlySet<LayerType> = new Set<LayerType>([
+  "lidar",
+  "gaussian-splat",
+  "3d-tiles",
+  "video",
+]);
+
+const NEUTRAL_SWATCH = "#94a3b8";
+const MAX_RAMP_SWATCHES = 6;
+
+/**
+ * Build legend entries from the visible layers. Vector layers contribute a
+ * colored swatch (or several, for graduated/categorized symbology); raster and
+ * service layers contribute a single neutral swatch; 3D and media layers are
+ * omitted.
+ *
+ * @param layers - All layers from the store, in render order (bottom first).
+ * @returns Legend entries in top-of-stack-first order.
+ */
+export function buildLegend(layers: GeoLibreLayer[]): LegendEntry[] {
+  const entries: LegendEntry[] = [];
+  // Render order in the store is bottom-first; legends read top-first.
+  for (const layer of [...layers].reverse()) {
+    if (!layer.visible) continue;
+    if (NON_LEGEND_TYPES.has(layer.type)) continue;
+
+    if (VECTOR_TYPES.has(layer.type)) {
+      const mode = styleValue(layer.style, "vectorStyleMode");
+      const stops = styleValue(layer.style, "vectorStyleStops");
+      if (
+        (mode === "graduated" || mode === "categorized") &&
+        Array.isArray(stops) &&
+        stops.length > 0
+      ) {
+        entries.push({ name: layer.name, swatches: rampSwatches(stops, mode) });
+        continue;
+      }
+      entries.push({
+        name: layer.name,
+        swatches: [{ color: styleValue(layer.style, "fillColor") }],
+      });
+      continue;
+    }
+
+    // Raster / service layers: a single neutral marker swatch.
+    entries.push({ name: layer.name, swatches: [{ color: NEUTRAL_SWATCH }] });
+  }
+  return entries;
+}
+
+function rampSwatches(
+  stops: VectorStyleStop[],
+  mode: "graduated" | "categorized",
+): { color: string; label: string }[] {
+  const limited =
+    stops.length > MAX_RAMP_SWATCHES
+      ? sampleEvenly(stops, MAX_RAMP_SWATCHES)
+      : stops;
+  return limited.map((stop) => ({
+    color: stop.color,
+    label:
+      mode === "graduated"
+        ? `≥ ${formatStopValue(stop.value)}`
+        : formatStopValue(stop.value),
+  }));
+}
+
+function sampleEvenly<T>(items: T[], count: number): T[] {
+  if (items.length <= count) return items;
+  const out: T[] = [];
+  for (let i = 0; i < count; i++) {
+    out.push(items[Math.round((i * (items.length - 1)) / (count - 1))]);
+  }
+  return out;
+}
+
+function formatStopValue(value: unknown): string {
+  if (typeof value === "number") {
+    return Number.isInteger(value) ? String(value) : value.toFixed(2);
+  }
+  return String(value ?? "");
+}

--- a/apps/geolibre-desktop/src/lib/print-legend.ts
+++ b/apps/geolibre-desktop/src/lib/print-legend.ts
@@ -48,11 +48,14 @@ export function buildLegend(layers: GeoLibreLayer[]): LegendEntry[] {
     if (!layer.visible) continue;
     if (NON_LEGEND_TYPES.has(layer.type)) continue;
 
-    // MBTiles can carry vector or raster tiles and is rendered as vector unless
-    // its metadata says raster, so treat vector MBTiles like the other vectors.
+    // MBTiles can carry vector or raster tiles; the app renders it as vector
+    // unless its metadata or source says raster (mirrors layer-sync), so a
+    // missing or legacy tileType is treated as vector here too.
     const isVector =
       VECTOR_TYPES.has(layer.type) ||
-      (layer.type === "mbtiles" && layer.metadata.tileType === "vector");
+      (layer.type === "mbtiles" &&
+        layer.metadata.tileType !== "raster" &&
+        layer.source.type !== "raster");
     if (isVector) {
       const mode = styleValue(layer.style, "vectorStyleMode");
       const stops = styleValue(layer.style, "vectorStyleStops");

--- a/apps/geolibre-desktop/src/lib/print-legend.ts
+++ b/apps/geolibre-desktop/src/lib/print-legend.ts
@@ -48,7 +48,12 @@ export function buildLegend(layers: GeoLibreLayer[]): LegendEntry[] {
     if (!layer.visible) continue;
     if (NON_LEGEND_TYPES.has(layer.type)) continue;
 
-    if (VECTOR_TYPES.has(layer.type)) {
+    // MBTiles can carry vector or raster tiles and is rendered as vector unless
+    // its metadata says raster, so treat vector MBTiles like the other vectors.
+    const isVector =
+      VECTOR_TYPES.has(layer.type) ||
+      (layer.type === "mbtiles" && layer.metadata.tileType === "vector");
+    if (isVector) {
       const mode = styleValue(layer.style, "vectorStyleMode");
       const stops = styleValue(layer.style, "vectorStyleStops");
       if (
@@ -90,7 +95,8 @@ function rampSwatches(
 }
 
 function sampleEvenly<T>(items: T[], count: number): T[] {
-  if (items.length <= count) return items;
+  // count <= 1 would divide by zero below; return the available slice instead.
+  if (items.length <= count || count <= 1) return items.slice(0, count);
   const out: T[] = [];
   for (let i = 0; i < count; i++) {
     out.push(items[Math.round((i * (items.length - 1)) / (count - 1))]);

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -249,6 +249,10 @@ export class MapController {
       renderWorldCopies: mapPreferences.renderWorldCopies,
       attributionControl: false,
       maplibreLogo: false,
+      // Retain the WebGL drawing buffer so the canvas can be read back for the
+      // Print Layout composer and other image exports. Without this,
+      // `canvas.toDataURL()` / `drawImage` can return a blank frame.
+      canvasContextAttributes: { preserveDrawingBuffer: true },
     });
     // The constructor options above already apply the static constraints.
     // The transform constraint is installed by the MapCanvas effect that

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -249,9 +249,11 @@ export class MapController {
       renderWorldCopies: mapPreferences.renderWorldCopies,
       attributionControl: false,
       maplibreLogo: false,
-      // Retain the WebGL drawing buffer so the canvas can be read back for the
-      // Print Layout composer and other image exports. Without this,
-      // `canvas.toDataURL()` / `drawImage` can return a blank frame.
+      // preserveDrawingBuffer must stay true: the Print Layout composer and any
+      // future export feature reads the canvas via drawImage / toDataURL outside
+      // of a render callback. Removing this causes blank captures on browsers
+      // that discard the drawing buffer after compositing (most mobile GPUs).
+      // Trade-off: adds one extra framebuffer copy per frame on tiled renderers.
       canvasContextAttributes: { preserveDrawingBuffer: true },
     });
     // The constructor options above already apply the static constraints.

--- a/tests/print-legend.test.ts
+++ b/tests/print-legend.test.ts
@@ -109,4 +109,28 @@ describe("buildLegend", () => {
     assert.equal(legend[0].swatches.length, 1);
     assert.equal(legend[1].swatches.length, 1);
   });
+
+  it("treats vector MBTiles as a vector layer using its fill color", () => {
+    const legend = buildLegend([
+      makeLayer({
+        name: "Vector tiles",
+        type: "mbtiles",
+        metadata: { tileType: "vector" },
+        style: { vectorStyleMode: "single", fillColor: "#00aa55" } as LayerStyle,
+      }),
+    ]);
+    assert.equal(legend[0].swatches[0].color, "#00aa55");
+  });
+
+  it("gives raster MBTiles the neutral swatch", () => {
+    const legend = buildLegend([
+      makeLayer({
+        name: "Raster tiles",
+        type: "mbtiles",
+        metadata: { tileType: "raster" },
+        style: { fillColor: "#00aa55" } as LayerStyle,
+      }),
+    ]);
+    assert.notEqual(legend[0].swatches[0].color, "#00aa55");
+  });
 });

--- a/tests/print-legend.test.ts
+++ b/tests/print-legend.test.ts
@@ -133,4 +133,16 @@ describe("buildLegend", () => {
     ]);
     assert.notEqual(legend[0].swatches[0].color, "#00aa55");
   });
+
+  it("treats MBTiles with no tileType as vector", () => {
+    const legend = buildLegend([
+      makeLayer({
+        name: "Legacy tiles",
+        type: "mbtiles",
+        metadata: {},
+        style: { vectorStyleMode: "single", fillColor: "#123456" } as LayerStyle,
+      }),
+    ]);
+    assert.equal(legend[0].swatches[0].color, "#123456");
+  });
 });

--- a/tests/print-legend.test.ts
+++ b/tests/print-legend.test.ts
@@ -1,0 +1,112 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { GeoLibreLayer, LayerStyle } from "../packages/core/src/types";
+import { buildLegend } from "../apps/geolibre-desktop/src/lib/print-legend";
+
+function makeLayer(overrides: Partial<GeoLibreLayer>): GeoLibreLayer {
+  return {
+    id: "layer-1",
+    name: "Layer 1",
+    type: "geojson",
+    source: {},
+    visible: true,
+    opacity: 1,
+    style: {} as LayerStyle,
+    metadata: {},
+    ...overrides,
+  } as unknown as GeoLibreLayer;
+}
+
+describe("buildLegend", () => {
+  it("omits hidden layers", () => {
+    const legend = buildLegend([
+      makeLayer({ id: "a", name: "A", visible: false }),
+      makeLayer({ id: "b", name: "B", visible: true }),
+    ]);
+    assert.deepEqual(
+      legend.map((e) => e.name),
+      ["B"],
+    );
+  });
+
+  it("omits 3D and media layer types", () => {
+    const legend = buildLegend([
+      makeLayer({ id: "a", name: "Cloud", type: "lidar" }),
+      makeLayer({ id: "b", name: "Tiles", type: "3d-tiles" }),
+      makeLayer({ id: "c", name: "Clip", type: "video" }),
+      makeLayer({ id: "d", name: "Points", type: "geojson" }),
+    ]);
+    assert.deepEqual(
+      legend.map((e) => e.name),
+      ["Points"],
+    );
+  });
+
+  it("returns layers top-of-stack first", () => {
+    const legend = buildLegend([
+      makeLayer({ id: "bottom", name: "Bottom" }),
+      makeLayer({ id: "top", name: "Top" }),
+    ]);
+    assert.deepEqual(
+      legend.map((e) => e.name),
+      ["Top", "Bottom"],
+    );
+  });
+
+  it("uses the layer fill color for single-symbol vector layers", () => {
+    const legend = buildLegend([
+      makeLayer({
+        name: "Parcels",
+        style: { vectorStyleMode: "single", fillColor: "#ff0000" } as LayerStyle,
+      }),
+    ]);
+    assert.equal(legend[0].swatches.length, 1);
+    assert.equal(legend[0].swatches[0].color, "#ff0000");
+  });
+
+  it("expands graduated symbology into ramp swatches with labels", () => {
+    const legend = buildLegend([
+      makeLayer({
+        name: "Population",
+        style: {
+          vectorStyleMode: "graduated",
+          vectorStyleStops: [
+            { value: 0, color: "#eef" },
+            { value: 100, color: "#88a" },
+            { value: 200, color: "#114" },
+          ],
+        } as LayerStyle,
+      }),
+    ]);
+    assert.equal(legend[0].swatches.length, 3);
+    assert.equal(legend[0].swatches[0].color, "#eef");
+    assert.equal(legend[0].swatches[1].label, "≥ 100");
+  });
+
+  it("caps ramp swatches at six samples", () => {
+    const stops = Array.from({ length: 12 }, (_, i) => ({
+      value: i,
+      color: `#0000${(i % 10).toString()}0`,
+    }));
+    const legend = buildLegend([
+      makeLayer({
+        name: "Many",
+        style: {
+          vectorStyleMode: "categorized",
+          vectorStyleStops: stops,
+        } as LayerStyle,
+      }),
+    ]);
+    assert.equal(legend[0].swatches.length, 6);
+  });
+
+  it("gives raster and service layers a single neutral swatch", () => {
+    const legend = buildLegend([
+      makeLayer({ name: "Imagery", type: "raster" }),
+      makeLayer({ name: "WMS", type: "wms" }),
+    ]);
+    assert.equal(legend.length, 2);
+    assert.equal(legend[0].swatches.length, 1);
+    assert.equal(legend[1].swatches.length, 1);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a Print Layout composer (Project menu and command palette) that captures the current map view and composes it with a title, subtitle, legend, scale bar, north arrow, and footer onto a chosen paper size and orientation, with a live preview.
- Export to PNG or PDF through the shared Tauri-aware file helper, so saving works in the desktop app (native save dialog plus filesystem write) and the browser build.
- Pure, unit-tested modules for page drawing (`print-layout.ts`) and legend construction (`print-legend.ts`); capture, scale computation, and export live in `print-layout-export.ts`. Map init now retains the WebGL drawing buffer so the canvas can be read back.

## Test plan
- [x] `npm run build` (tsc + vite) passes
- [x] `pre-commit run` (eslint + npm build) passes
- [x] `node --test tests/print-legend.test.ts` passes (legend construction)
- [x] Browser: dialog renders, captures the basemap, exports PNG and PDF with no console errors
- [x] Landscape orientation produces a landscape PDF (verified jsPDF page dimensions)
- [x] North arrow clears the map edge
- [ ] Desktop (Tauri): Export PNG and Export PDF open the native save dialog and write the file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Print Layout composer to design and export print-ready map layouts (title/subtitle, legend, scale bar, north arrow, footer, paper size/orientation) with live preview, recapture, and export controls.
  * PNG and PDF export with sanitized filenames and export progress/disabled states.
  * Integrated “Print Layout…” entry in the top toolbar and Project menu.

* **Tests**
  * Automated tests for legend generation and swatch handling.

* **Bug Fixes**
  * Improved map capture reliability for exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Note

- This enables `preserveDrawingBuffer` on the MapLibre context globally so the canvas can be read back for export. It is a deliberate, always-on choice (MapLibre cannot toggle WebGL context attributes in place); the trade-off is one extra framebuffer copy per frame on tiled renderers, paid by all users.
