### PR TITLE
chore(deps): bump maplibre-gl-3d-tiles to 0.5.0

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -43,7 +43,7 @@
     "jspdf": "^4.2.1",
     "mapillary-js": "^4.1.2",
     "maplibre-gl": "^5.24.0",
-    "maplibre-gl-3d-tiles": "^0.4.0",
+    "maplibre-gl-3d-tiles": "^0.5.0",
     "maplibre-gl-basemap-control": "^0.3.0",
     "maplibre-gl-components": "^0.20.4",
     "maplibre-gl-duckdb": "^0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "jspdf": "^4.2.1",
         "mapillary-js": "^4.1.2",
         "maplibre-gl": "^5.24.0",
-        "maplibre-gl-3d-tiles": "^0.4.0",
+        "maplibre-gl-3d-tiles": "^0.5.0",
         "maplibre-gl-basemap-control": "^0.3.0",
         "maplibre-gl-components": "^0.20.4",
         "maplibre-gl-duckdb": "^0.2.0",
@@ -16730,9 +16730,9 @@
       }
     },
     "node_modules/maplibre-gl-3d-tiles": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-3d-tiles/-/maplibre-gl-3d-tiles-0.4.0.tgz",
-      "integrity": "sha512-I9V240lbbpHmpxKAoa2BslYxck9Hp4jRczGo3iq0qJLZG1s27zoQMLQTqeMnzqNNcBmS5rkpY6ZoP06/65qfgQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-3d-tiles/-/maplibre-gl-3d-tiles-0.5.0.tgz",
+      "integrity": "sha512-fa0ilRsJwdwHywV1vpBp8gHqRaANVHTK3/RrNN6TWjdSSWTMUhajf9jDpM2i7kCt4p9leRE19Vd/wXGu2n/tsw==",
       "license": "MIT",
       "dependencies": {
         "3d-tiles-renderer": "^0.4.27",
@@ -23408,7 +23408,7 @@
         "geotiff": "^3.0.5",
         "jspdf": "^4.2.1",
         "maplibre-gl": "^5.24.0",
-        "maplibre-gl-3d-tiles": "^0.4.0",
+        "maplibre-gl-3d-tiles": "^0.5.0",
         "maplibre-gl-basemap-control": "^0.3.0",
         "maplibre-gl-components": "^0.20.4",
         "maplibre-gl-duckdb": "^0.2.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -29,7 +29,7 @@
     "geotiff": "^3.0.5",
     "jspdf": "^4.2.1",
     "maplibre-gl": "^5.24.0",
-    "maplibre-gl-3d-tiles": "^0.4.0",
+    "maplibre-gl-3d-tiles": "^0.5.0",
     "maplibre-gl-basemap-control": "^0.3.0",
     "maplibre-gl-components": "^0.20.4",
     "maplibre-gl-duckdb": "^0.2.0",


### PR DESCRIPTION
Bumps `maplibre-gl-3d-tiles` from `^0.4.0` to `^0.5.0` in `apps/geolibre-desktop` and `packages/plugins`.

## What 0.5.0 fixes ([opengeos/maplibre-gl-3d-tiles#7](https://github.com/opengeos/maplibre-gl-3d-tiles/pull/7))

- **Orientation:** region-based tilesets with an identity root transform (point clouds with `.pnts` content / an RTC center, e.g. LumiDB) were rendered **tilted by the site's colatitude (~45° at mid-latitudes)**. Orientation is now derived from the East/North/Up basis at the tileset anchor, which reproduces a Cesium-style root transform exactly and keeps these tilesets upright.
- **Altitude offset:** placement was computed once on load, so editing **Altitude offset** did nothing without a reload. The offset now re-positions the active tileset **live**.

## Verification

- `npm run build` passes (exit 0).
- Verified end-to-end in the running app with Playwright against the public LumiDB tileset before the release: auth works, the offset repositions live (no tileset refetch), and the LiDAR scan renders upright and grounded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated 3D tiles rendering library to the latest version for improved performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->