### PR TITLE
chore: release v1.2.0 (version bump, README, docs, roadmap)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,26 +20,29 @@ GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS
 
 **Video tutorial:** [GeoLibre 1.0: A Free, Open-Source Cloud-Native GIS That Runs Anywhere (Browser, Desktop & Jupyter)](https://youtu.be/87Cm0QagtxI)
 
-## Features (v1.1)
+## Features (v1.2)
 
 - Runs across desktop (Tauri), web (browser), and mobile or small screens, with a responsive layout that adapts menus, dialogs, and panels, plus per-panel visibility through Layout settings
 - MapLibre map workspace with OpenFreeMap basemaps, blank background support, and toggleable navigation, fullscreen, geolocation, globe, terrain, scale, attribution, and logo controls
-- Load local vector layers supported by DuckDB-WASM Spatial, including common formats such as GeoJSON, GeoParquet, GeoPackage, Shapefile, FlatGeobuf, KML/KMZ, GML, delimited text, and GPX
+- Load local vector layers supported by DuckDB-WASM Spatial, including common formats such as GeoJSON, GeoParquet, GeoPackage, Shapefile, FlatGeobuf, KML/KMZ, GML, delimited text, GPX, and OpenStreetMap PBF extracts (parsed in-browser with osmix)
 - Reproject vector layers to EPSG:4326 on load and split dragged GPX files into named waypoint, track, and route layers
-- Add Data menu for XYZ tiles, WMS, WFS, GeoJSON URLs, vector tiles, COG and GeoTIFF rasters, MBTiles, ArcGIS FeatureServer and VectorTileServer layers, PMTiles, Zarr, LiDAR, 3D Tiles, Gaussian splats, and georeferenced video overlays
+- Add Data menu for XYZ tiles, WMS, WFS, GeoJSON URLs, vector tiles, COG and GeoTIFF rasters, Cloud-Optimized NetCDF/HDF (via kerchunk references), MBTiles, ArcGIS FeatureServer and VectorTileServer layers, PMTiles, Zarr, LiDAR, 3D Tiles (including authenticated tilesets via custom request headers), Gaussian splats, and georeferenced video overlays
+- Deck.gl Layer builder for composing deck.gl overlays from uploaded files or remote URLs
 - Cloud data integrations through the Planetary Computer and Earth Engine panels, the Overture Maps plugin, and federal Web Services plugins
 - Manual and automatic refresh for WFS, GeoJSON URL, and Add Vector Layer URL layers
 - Layer panel for visibility, opacity, reordering, rename, zoom-to-layer, identify, labels, open attribute table, export, and remove actions
 - Live style panel with single, categorized, graduated, and expression symbology (fill, stroke, opacity, circle radius), plus point heatmap and clustering renderers — all including for Add Vector Layer point layers
-- Attribute table with filtering, sorting, resize controls, feature highlighting, optional zoom to selected features, column management (rename, delete, hide/show, reorder), and export to GeoJSON/GeoParquet/CSV
-- SQL Workspace for running DuckDB Spatial SQL against loaded layers, local files, and remote URLs, with sample queries, query history, and adding results to the map or exporting them
+- Attribute table with filtering, sorting, resize controls, feature highlighting, optional zoom to selected features, add-field and field-calculator tools, a Charts panel (histogram, scatter, bar, line, box), column management (rename, delete, hide/show, reorder), and export to GeoJSON/GeoParquet/CSV
+- SQL Workspace for running DuckDB Spatial SQL against loaded layers, local files, and remote URLs, with sample queries, query history, and adding results to the map or exporting them, plus an in-browser PostGIS SQL engine via PGlite
 - Multiple DuckDB SQL query-result layers with identify, selection, and attribute table support
-- Controls menu with Measure, Bookmark, Minimap, and View State tools, plus a Print menu and a Search panel
+- Controls menu with Measure, Bookmark, Minimap, and View State tools, a Search panel, and a Print menu with a print layout composer that exports the map to PNG or PDF
 - Command palette (`Ctrl`/`Cmd` + `K`) that searches and runs menu and toolbar actions across Add Data, Processing, Controls, Plugins, and Help, global keyboard shortcuts for New/Open/Save/Save As, and a `?` shortcuts cheat sheet
 - Conversion menu for Vector to GeoParquet/FlatGeobuf/PMTiles, CSV to GeoParquet, and Raster to COG; GeoParquet and CSV conversions run in the browser with DuckDB-WASM, while FlatGeobuf, PMTiles, and COG require the optional Python sidecar
 - Whitebox toolbox with batch tools run against a selected input directory
 - Vector menu with common geometry tools (buffer, centroids, convex hull, dissolve, bounding box, simplify, clip, intersection, difference, union, spatial join, select by value, select by location) that run in the browser with Turf.js, an optional GeoPandas sidecar engine for every tool, and an in-browser GeoPandas engine via Pyodide (no server, same results as the sidecar)
 - Raster menu with common raster tools (hillshade, slope, aspect, reproject, resample, clip by extent, clip by mask layer, polygonize, contour) backed by a rasterio Python sidecar, with a file path in and a file path out
+- H3 tools to create hexagonal grids over an extent and bin point layers into H3 cells
+- Undo/redo for layer and style operations
 - Drag and drop vector and GeoTIFF/COG raster files onto the map to add them as layers
 - Project menu to create, open, save, and Save As `.geolibre.json` projects
 - Desktop diagnostics panel, update check, and MSIX packaging support
@@ -50,7 +53,11 @@ GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS
 - External plugin zip loading from the app data plugins directory and local development plugin directories
 - Bundled drop-in plugins under `public/plugins/<id>/` that bake into both the web and desktop builds and load automatically with no manifest URL
 - Browser deployment with Docker, embed-friendly URL parameters, and a `maponly` chrome-free mode
-- Python package (`geolibre`) that embeds the full app in Jupyter notebooks as an [anywidget](https://anywidget.dev), with a leafmap-style API and two-way project sync
+- Installable, offline-capable Progressive Web App (PWA) build
+- Internationalization framework with react-i18next and per-build translation catalogs, plus a `?locale`/`?lang` query parameter to set the embed language
+- Accessibility pass with axe-checked screens, keyboard navigation, and screen-reader labels
+- App-wide, section, and plugin React error boundaries that contain failures and keep the rest of the workspace usable
+- Python package (`geolibre`) that embeds the full app in Jupyter notebooks as an [anywidget](https://anywidget.dev), with an expanded leafmap-style API covering more Add Data layer types and two-way project sync
 - Optional Python FastAPI sidecar for heavier processing workflows
 
 ## Prerequisites

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geolibre-desktop",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/geolibre-desktop/src-tauri/Cargo.lock
+++ b/apps/geolibre-desktop/src-tauri/Cargo.lock
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "geolibre-desktop"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "flate2",
  "reqwest 0.12.28",

--- a/apps/geolibre-desktop/src-tauri/Cargo.toml
+++ b/apps/geolibre-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geolibre-desktop"
-version = "1.1.0"
+version = "1.2.0"
 description = "GeoLibre Desktop — lightweight cloud-native desktop GIS"
 authors = ["GeoLibre Contributors"]
 edition = "2021"

--- a/apps/geolibre-desktop/src-tauri/tauri.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "GeoLibre Desktop",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "identifier": "org.geolibre.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ Pan, zoom, rotate, and tilt a MapLibre map with OpenFreeMap basemaps or a blank 
 <div class="feature-card" markdown>
 ### Local and remote data
 
-Load local and remote vector and raster data, inspect and manage attributes in the table (rename, hide, reorder, and delete fields, plus export), style layers with single, categorized, graduated, and expression symbology (plus point heatmap and clustering renderers), reorder, rename, and refresh layers, and save, reopen, or share `.geolibre.json` projects.
+Load local and remote vector and raster data, inspect and manage attributes in the table (add fields, a field calculator, a Charts panel, plus rename, hide, reorder, delete, and export), style layers with single, categorized, graduated, and expression symbology (plus point heatmap and clustering renderers), reorder, rename, and refresh layers with undo/redo, and save, reopen, or share `.geolibre.json` projects.
 </div>
 
 <div class="feature-card" markdown>
@@ -51,7 +51,7 @@ Activate built-in plugins for layer control, basemaps, MapLibre components, swip
 <div class="feature-card" markdown>
 ### Advanced layer formats
 
-Add Data covers XYZ, WMS, WFS, WMTS, ArcGIS, and STAC services; GeoParquet, FlatGeobuf, PMTiles, and Zarr cloud formats; COG and GeoTIFF rasters and MBTiles; LiDAR, Gaussian splats, and 3D Tiles; and DuckDB and PostgreSQL databases.
+Add Data covers XYZ, WMS, WFS, WMTS, ArcGIS, and STAC services; GeoParquet, FlatGeobuf, PMTiles, Zarr, and OpenStreetMap PBF; COG and GeoTIFF rasters, Cloud-Optimized NetCDF/HDF, and MBTiles; LiDAR, Gaussian splats, 3D Tiles (including authenticated tilesets), georeferenced video overlays, and deck.gl layers; and DuckDB and PostgreSQL databases.
 </div>
 
 <div class="feature-card" markdown>
@@ -63,13 +63,13 @@ Convert data to cloud-native GeoParquet, FlatGeobuf, PMTiles, and COG from the C
 <div class="feature-card" markdown>
 ### SQL Workspace
 
-Run DuckDB Spatial SQL in the browser against loaded layers, local files, and remote URLs. Auto-wraps bare URLs into the matching reader and streams remote files over HTTP range requests. Includes sample queries, query history, and adding a result (with an optional layer name) to the map or exporting it as CSV or GeoParquet.
+Run DuckDB Spatial SQL in the browser against loaded layers, local files, and remote URLs, or query with the in-browser PostGIS engine powered by PGlite. Auto-wraps bare URLs into the matching reader and streams remote files over HTTP range requests. Includes sample queries, query history, and adding a result (with an optional layer name) to the map or exporting it as CSV or GeoParquet.
 </div>
 
 <div class="feature-card" markdown>
 ### Vector tools
 
-Common geometry tools under Processing → Vector: buffer, centroids, convex hull, dissolve, bounding box, simplify, clip, intersection, difference, union, spatial join, select by value, and select by location. They run in the browser with Turf.js, with an optional GeoPandas sidecar engine for every tool.
+Common geometry tools under Processing → Vector: buffer, centroids, convex hull, dissolve, bounding box, simplify, clip, intersection, difference, union, spatial join, select by value, select by location, and H3 hexagonal grids and binning. They run in the browser with Turf.js, with an optional GeoPandas sidecar engine for every tool.
 </div>
 
 <div class="feature-card" markdown>
@@ -81,7 +81,7 @@ Common raster tools under Processing → Raster: hillshade, slope, aspect, repro
 <div class="feature-card" markdown>
 ### Python and Jupyter
 
-Embed the full GeoLibre app in a Jupyter notebook with the [`geolibre`](python.md) Python package. A leafmap-style API (`add_geojson`, `add_tile_layer`, `add_cog`) drives the map, and the project syncs both ways so UI edits are readable back from Python.
+Embed the full GeoLibre app in a Jupyter notebook with the [`geolibre`](python.md) Python package. An expanded leafmap-style API (`add_geojson`, `add_tile_layer`, `add_cog`, and many more Add Data layer types) drives the map, and the project syncs both ways so UI edits are readable back from Python.
 </div>
 
 </div>

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -126,7 +126,7 @@
 - [x] Cross-platform installers
 - [x] Documentation and tutorials
 
-## v1.1: Vector styling, attribute table management, and atmosphere effects (current)
+## v1.1: Vector styling, attribute table management, and atmosphere effects
 
 - [x] In-browser GeoPandas engine for the Vector tools via Pyodide (no server, same results as the optional sidecar)
 - [x] Host deck.gl exposed to external plugins via `app.getDeckGL()`, so plugins render on the shared instance instead of bundling their own copy
@@ -139,6 +139,32 @@
 - [x] conda-forge install instructions and a video tutorial in the documentation
 - [x] MIT license
 - [x] CSP allowance for `cdn.jsdelivr.net` so DuckDB-WASM loads its bundles in the browser build
+
+## v1.2: New data sources, attribute analytics, routing, and platform polish (current)
+
+- [x] OpenStreetMap PBF file loading parsed in-browser with osmix
+- [x] Cloud-Optimized NetCDF/HDF layers loaded via kerchunk references
+- [x] Authenticated 3D Tiles tilesets via custom request headers
+- [x] Georeferenced video overlay layers
+- [x] Deck.gl Layer builder for composing deck.gl overlays from uploaded files and remote URLs
+- [x] In-browser PostGIS SQL engine via PGlite, alongside the DuckDB Spatial SQL Workspace
+- [x] Attribute table add-field and field-calculator tools
+- [x] Attribute table Charts panel (histogram, scatter, bar, line, box)
+- [x] Spatial join added to the Vector tools
+- [x] Select by value and Select by location tools
+- [x] H3 tools to create hexagonal grids and bin points into H3 cells
+- [x] Point heatmap renderer and clustering, including for Add Vector Layer point layers
+- [x] Directions plugin for interactive routing via `maplibre-gl-directions`, with a one-time privacy notice before enabling it
+- [x] Undo/redo for layer and style operations
+- [x] Command palette (`Ctrl`/`Cmd` + `K`) and global keyboard shortcuts with a `?` cheat sheet
+- [x] Print layout composer with PNG and PDF export
+- [x] Installable, offline-capable Progressive Web App (PWA) build
+- [x] Internationalization framework (react-i18next) with extracted string catalogs and a `?locale`/`?lang` embed language parameter
+- [x] Accessibility pass with axe checks across key screens
+- [x] App, section, and plugin React error boundaries
+- [x] Playwright end-to-end smoke tests and a CI job
+- [x] Expanded Python `Map` API covering more Add Data layer types
+- [x] CDN-loaded PGlite/PostGIS to shrink the Jupyter wheel and the desktop binary
 
 ## Plugin marketplace and registry (design)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geolibre",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geolibre",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "workspaces": [
         "apps/*",
         "packages/*",
@@ -26,7 +26,7 @@
       }
     },
     "apps/geolibre-desktop": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@carbonplan/zarr-layer": "^0.5.0",
         "@deck.gl/aggregation-layers": "9.3.3",
@@ -23302,7 +23302,7 @@
     },
     "packages/core": {
       "name": "@geolibre/core",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "uuid": "^14.0.0",
         "zundo": "^2.3.0",
@@ -23315,7 +23315,7 @@
     },
     "packages/map": {
       "name": "@geolibre/map",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@geolibre/core": "*",
         "@turf/bbox": "^7.3.5",
@@ -23386,7 +23386,7 @@
     },
     "packages/plugins": {
       "name": "@geolibre/plugins",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@carbonplan/zarr-layer": "^0.5.0",
         "@deck.gl/aggregation-layers": "9.3.3",
@@ -23525,7 +23525,7 @@
     },
     "packages/processing": {
       "name": "@geolibre/processing",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@geolibre/core": "*",
         "@turf/bbox": "^7.3.5",
@@ -23550,7 +23550,7 @@
     },
     "packages/ui": {
       "name": "@geolibre/ui",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.16",
         "@radix-ui/react-dropdown-menu": "^2.1.17",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geolibre",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "GeoLibre: a lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data across desktop and web environments, with a responsive layout for mobile screens",
   "workspaces": [
     "apps/*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/core",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/map",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/plugins",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/processing/package.json
+++ b/packages/processing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/processing",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geolibre/ui",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/python/src/geolibre/__init__.py
+++ b/python/src/geolibre/__init__.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from .geolibre import Map
 
-__version__ = "1.1.2"
+__version__ = "1.2.0"
 __all__ = ["Map", "__version__"]
 
 


### PR DESCRIPTION
## Summary
- Bump version 1.1.x to 1.2.0 across the JS workspaces (root + @geolibre/* + geolibre-desktop), the Tauri config and Rust crate, the lockfiles, and the geolibre Python package.
- Document the features shipped since v1.1.0 in the README features list, the docs landing page cards, and a new v1.2 roadmap section: OSM PBF loading, Cloud-Optimized NetCDF/HDF, authenticated 3D Tiles, deck.gl Layer builder, in-browser PostGIS via PGlite, attribute-table add-field/field-calculator/Charts panel, H3 grids and binning, Directions plugin, undo/redo, print layout composer, PWA build, i18n framework, accessibility pass, React error boundaries, and the expanded Python Map API.

## Test plan
- [ ] `npm run ci` passes
- [ ] `npm run build` produces a working web build reporting v1.2.0
- [ ] Python package reports `geolibre.__version__ == "1.2.0"`
- [ ] Rendered README, docs landing page, and roadmap read correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deck.gl layer composition and H3 grid tools
  * Undo/redo functionality for layer and style operations
  * Offline-capable installable PWA with i18n framework
  * Enhanced field calculator and charting capabilities
  * Expanded vector processing tools and routing/directions support
  * Command palette and improved Python API with bidirectional project sync
  * App-wide error boundaries and accessibility improvements

* **Documentation**
  * Updated feature documentation and roadmap for v1.2 release

<!-- end of auto-generated comment: release notes by coderabbit.ai -->