### PR TITLE
feat(processing): add Reproject, Explode, Aggregate vector tools (#283)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -1703,6 +1703,15 @@ export function TopToolbar({
               <DropdownMenuItem onSelect={() => setVectorToolOpen("simplify")}>
                 {t("toolbar.vectorTool.simplify")}
               </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => setVectorToolOpen("reproject")}>
+                {t("toolbar.vectorTool.reproject")}
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => setVectorToolOpen("explode")}>
+                {t("toolbar.vectorTool.explode")}
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => setVectorToolOpen("aggregate")}>
+                {t("toolbar.vectorTool.aggregate")}
+              </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuLabel className="text-xs text-muted-foreground">
                 {t("toolbar.item.subGroupOverlay")}

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -290,6 +290,9 @@ const VECTOR_TOOL_COMMANDS: Array<{ kind: VectorToolKind; titleKey: ParseKeys }>
       kind: "select-by-location",
       titleKey: "toolbar.vectorTool.selectByLocation",
     },
+    { kind: "reproject", titleKey: "toolbar.vectorTool.reproject" },
+    { kind: "explode", titleKey: "toolbar.vectorTool.explode" },
+    { kind: "aggregate", titleKey: "toolbar.vectorTool.aggregate" },
     { kind: "h3-grid", titleKey: "toolbar.vectorTool.h3Grid" },
     { kind: "h3-bin-points", titleKey: "toolbar.vectorTool.h3BinPoints" },
   ];

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -1202,7 +1202,6 @@ export function LayerPanel({
       </ScrollArea>
       <Separator />
       <p className="p-2 text-[10px] text-muted-foreground">
-        {/* TODO(v0.3): Add native PMTiles, COG, and FlatGeobuf layer types */}
         Advanced formats: see docs/roadmap.md
       </p>
       <Dialog

--- a/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
@@ -450,7 +450,11 @@ export function VectorToolsDialog({
                   value={engine}
                   onChange={(e) => setEngine(e.target.value as Engine)}
                 >
-                  <option value="client">Client (Turf.js)</option>
+                  {/* requiresSidecar tools (e.g. Reproject) have no working client
+                      path, so don't let the user pick a dead-end engine. */}
+                  <option value="client" disabled={tool.requiresSidecar}>
+                    Client (Turf.js)
+                  </option>
                   <option value="sidecar">Sidecar (GeoPandas)</option>
                   <option value="pyodide">Python (Pyodide)</option>
                 </Select>

--- a/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
@@ -439,7 +439,7 @@ export function VectorToolsDialog({
               ))}
             </div>
 
-            {tool.supportsSidecar ? (
+            {tool.supportsSidecar || tool.requiresSidecar ? (
               <div className="flex flex-col gap-1">
                 <Label className="flex items-center gap-1.5 text-xs">
                   <Server className="h-3.5 w-3.5" /> Engine
@@ -460,7 +460,10 @@ export function VectorToolsDialog({
                 {engine === "sidecar" && sidecarAvailable === false ? (
                   <p className="text-xs text-destructive">
                     The GeoPandas sidecar is not available. Start the sidecar
-                    with the vector extra, or switch to the client engine.
+                    with the vector extra, or switch to
+                    {tool.requiresSidecar
+                      ? " Python (Pyodide)."
+                      : " the client engine."}
                   </p>
                 ) : null}
                 {engine === "pyodide" ? (

--- a/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
@@ -102,11 +102,13 @@ export function VectorToolsDialog({
     }
     setParams(defaults);
     setLog([]);
-    // Pick the engine that can actually run this tool: client-only tools force
-    // "client"; sidecar-only tools (e.g. Reproject, whose client run just defers)
-    // default to "sidecar" so Run produces a result without touching the selector.
-    if (!tool.supportsSidecar) setEngine("client");
-    else if (tool.requiresSidecar) setEngine("sidecar");
+    // Pick the engine that can actually run this tool: sidecar-only tools (e.g.
+    // Reproject, whose client run just defers) default to "sidecar" so Run
+    // produces a result without touching the selector; client-only tools force
+    // "client". requiresSidecar is checked first so it wins even if a tool ever
+    // sets it without supportsSidecar (the JSDoc says it implies supportsSidecar).
+    if (tool.requiresSidecar) setEngine("sidecar");
+    else if (!tool.supportsSidecar) setEngine("client");
   }, [tool]);
 
   // Prefill the H3 grid's manual bounding-box fields from the current map

--- a/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
@@ -102,7 +102,11 @@ export function VectorToolsDialog({
     }
     setParams(defaults);
     setLog([]);
+    // Pick the engine that can actually run this tool: client-only tools force
+    // "client"; sidecar-only tools (e.g. Reproject, whose client run just defers)
+    // default to "sidecar" so Run produces a result without touching the selector.
     if (!tool.supportsSidecar) setEngine("client");
+    else if (tool.requiresSidecar) setEngine("sidecar");
   }, [tool]);
 
   // Prefill the H3 grid's manual bounding-box fields from the current map

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -191,6 +191,9 @@
       "spatialJoin": "Spatial join",
       "selectByValue": "Select by value",
       "selectByLocation": "Select by location",
+      "reproject": "Reproject",
+      "explode": "Explode",
+      "aggregate": "Aggregate by attribute",
       "h3Grid": "Create H3 grid",
       "h3BinPoints": "Bin points to H3"
     },

--- a/backend/geolibre_server/geolibre_server/vector_ops.py
+++ b/backend/geolibre_server/geolibre_server/vector_ops.py
@@ -189,7 +189,9 @@ def _clip(geojson, overlay, parameters) -> tuple[dict, list[str]]:
     left = _load_gdf(geojson, "Input layer")
     right = _load_gdf(overlay, "Overlay layer")
     clipped = gpd.clip(left, right)
-    return _to_feature_collection(clipped), [f"Clip: produced {len(clipped)} feature(s)"]
+    return _to_feature_collection(clipped), [
+        f"Clip: produced {len(clipped)} feature(s)"
+    ]
 
 
 # Spatial-join predicates exposed by the UI (a safe subset of the predicates
@@ -407,6 +409,106 @@ def _union(geojson, overlay, parameters) -> tuple[dict, list[str]]:
     return _to_feature_collection(result), ["Union: produced 1 feature"]
 
 
+def _reproject(geojson, overlay, parameters) -> tuple[dict, list[str]]:
+    """Reinterpret a layer's coordinates as a source CRS and transform to WGS84.
+
+    GeoLibre stores and displays every vector layer as WGS84 GeoJSON, so the
+    only reprojection that yields a *displayable* result is mapping data that is
+    really in some other CRS back to longitude/latitude. The common case is data
+    whose coordinates are in a projected CRS (e.g. Web Mercator EPSG:3857) but
+    were loaded as if they were lon/lat, so the layer lands in the wrong place.
+    This reads the input coordinates as ``source_crs`` and reprojects them to
+    WGS84 (:func:`_to_feature_collection` always normalizes the output to WGS84).
+    """
+    gpd = _import_geopandas()
+    if not geojson or not geojson.get("features"):
+        raise ValueError("Input layer has no features")
+    source_crs = str(parameters.get("source_crs", "") or "").strip()
+    if not source_crs:
+        raise ValueError("A source CRS is required (e.g. EPSG:3857)")
+    # Build the frame WITHOUT the WGS84 assumption in _load_gdf: the stored
+    # coordinates are really in `source_crs`. An unknown CRS raises here.
+    try:
+        gdf = gpd.GeoDataFrame.from_features(geojson["features"], crs=source_crs)
+    except Exception as exc:  # noqa: BLE001 - surface any CRS/parse failure as 400
+        raise ValueError(f"Invalid source CRS '{source_crs}': {exc}") from exc
+    if gdf.empty:
+        raise ValueError("Input layer has no features")
+    return (
+        _to_feature_collection(gdf),
+        [f"Reprojected {len(gdf)} feature(s) from {source_crs} to WGS84"],
+    )
+
+
+def _explode(geojson, overlay, parameters) -> tuple[dict, list[str]]:
+    """Split multipart geometries into single-part features (multi -> single)."""
+    gdf = _load_gdf(geojson, "Input layer")
+    # index_parts=False keeps a flat index so the output is a plain list of
+    # single-part features carrying each parent's attributes (one row per part).
+    exploded = gdf.explode(index_parts=False).reset_index(drop=True)
+    return (
+        _to_feature_collection(exploded),
+        [f"Exploded {len(gdf)} feature(s) into {len(exploded)} single-part feature(s)"],
+    )
+
+
+# Summary statistics supported by Aggregate by attribute; kept in sync with the
+# client engine. "count" needs no value field; the rest reduce a numeric field.
+_AGGREGATE_STATS = {"count", "sum", "mean", "min", "max", "median"}
+
+
+def _aggregate(geojson, overlay, parameters) -> tuple[dict, list[str]]:
+    """Dissolve geometries by an attribute and attach a per-group summary stat.
+
+    Mirrors GeoPandas ``dissolve(by=...)`` for the geometry merge plus a
+    pandas ``groupby`` for the statistic. The output has one feature per group
+    with the group field and a single statistic column (``count`` or
+    ``<field>_<stat>``); kept in sync with the client engine.
+    """
+    import pandas as pd  # noqa: PLC0415
+
+    gdf = _load_gdf(geojson, "Input layer")
+    group_field = str(parameters.get("group_field", "") or "").strip()
+    if not group_field:
+        raise ValueError("A group field is required")
+    if group_field not in gdf.columns:
+        raise ValueError(f"Group field '{group_field}' not found in layer attributes.")
+    statistic = str(parameters.get("statistic", "count") or "count")
+    if statistic not in _AGGREGATE_STATS:
+        raise ValueError(
+            f"Unknown statistic '{statistic}'. Accepted: {sorted(_AGGREGATE_STATS)}"
+        )
+    stat_field = str(parameters.get("stat_field", "") or "").strip()
+    if statistic != "count":
+        if not stat_field:
+            raise ValueError(f"A statistic field is required for '{statistic}'")
+        if stat_field not in gdf.columns:
+            raise ValueError(
+                f"Statistic field '{stat_field}' not found in layer attributes."
+            )
+    # Merge each group's geometries into one (union), keeping only geometry so the
+    # output carries just the group key and the computed statistic.
+    result = gdf.dissolve(by=group_field)[["geometry"]].copy()
+    if statistic == "count":
+        out_col = "count"
+        values = gdf.groupby(group_field).size()
+    else:
+        out_col = f"{stat_field}_{statistic}"
+        # Coerce non-numeric/empty values to NaN so they are skipped, matching the
+        # client engine (and pandas' default skipna behaviour for these reducers).
+        numeric = pd.to_numeric(gdf[stat_field], errors="coerce")
+        values = numeric.groupby(gdf[group_field]).agg(statistic)
+    result[out_col] = values
+    result = result.reset_index()
+    return (
+        _to_feature_collection(result),
+        [
+            f"Aggregated {len(gdf)} feature(s) into {len(result)} group(s) "
+            f"by '{group_field}'"
+        ],
+    )
+
+
 # tool_id -> handler(geojson, overlay, parameters) -> (feature_collection, messages)
 _DISPATCH: dict[str, Callable[..., tuple[dict, list[str]]]] = {
     "buffer": _buffer,
@@ -422,6 +524,9 @@ _DISPATCH: dict[str, Callable[..., tuple[dict, list[str]]]] = {
     "spatial-join": _spatial_join,
     "select-by-value": _select_by_value,
     "select-by-location": _select_by_location,
+    "reproject": _reproject,
+    "explode": _explode,
+    "aggregate": _aggregate,
 }
 
 

--- a/backend/geolibre_server/geolibre_server/vector_ops.py
+++ b/backend/geolibre_server/geolibre_server/vector_ops.py
@@ -493,9 +493,11 @@ def _aggregate(geojson, overlay, parameters) -> tuple[dict, list[str]]:
     # Restrict to polygons to match the client engine (and the tool's polygon-only
     # layer picker), so a mixed-geometry layer can't make the two engines count
     # different features per group.
+    total = len(gdf)
     gdf = gdf[gdf.geometry.geom_type.isin(["Polygon", "MultiPolygon"])]
     if gdf.empty:
         raise ValueError("Aggregate by attribute requires polygon features")
+    skipped = total - len(gdf)
     # Merge each group's geometries into one (union), keeping only geometry so the
     # output carries just the group key and the computed statistic.
     result = gdf.dissolve(by=group_field)[["geometry"]].copy()
@@ -505,20 +507,22 @@ def _aggregate(geojson, overlay, parameters) -> tuple[dict, list[str]]:
     else:
         out_col = f"{stat_field}_{statistic}"
         # Coerce non-numeric/empty values to NaN so they are skipped, matching the
-        # client engine (and pandas' default skipna behaviour for these reducers).
+        # client engine. Call the GroupBy reducer by name (e.g. .median()) rather
+        # than .agg("median"), whose NaN-skipping can vary by pandas version.
         numeric = pd.to_numeric(gdf[stat_field], errors="coerce")
-        values = numeric.groupby(gdf[group_field]).agg(statistic)
+        values = getattr(numeric.groupby(gdf[group_field]), statistic)()
     # Align the statistic to the dissolved geometry explicitly by index label so the
     # assignment stays correct even if either call's group ordering changes.
     result[out_col] = values.reindex(result.index)
     result = result.reset_index()
-    return (
-        _to_feature_collection(result),
-        [
-            f"Aggregated {len(gdf)} feature(s) into {len(result)} group(s) "
-            f"by '{group_field}'"
-        ],
+    message = (
+        f"Aggregated {len(gdf)} feature(s) into {len(result)} group(s) "
+        f"by '{group_field}'"
     )
+    # Mirror the client's "(N skipped, not polygons)" note for mixed-geometry input.
+    if skipped:
+        message += f" ({skipped} skipped, not polygons)"
+    return _to_feature_collection(result), [message]
 
 
 # tool_id -> handler(geojson, overlay, parameters) -> (feature_collection, messages)

--- a/backend/geolibre_server/geolibre_server/vector_ops.py
+++ b/backend/geolibre_server/geolibre_server/vector_ops.py
@@ -490,6 +490,12 @@ def _aggregate(geojson, overlay, parameters) -> tuple[dict, list[str]]:
             raise ValueError(
                 f"Statistic field '{stat_field}' not found in layer attributes."
             )
+    # Restrict to polygons to match the client engine (and the tool's polygon-only
+    # layer picker), so a mixed-geometry layer can't make the two engines count
+    # different features per group.
+    gdf = gdf[gdf.geometry.geom_type.isin(["Polygon", "MultiPolygon"])]
+    if gdf.empty:
+        raise ValueError("Aggregate by attribute requires polygon features")
     # Merge each group's geometries into one (union), keeping only geometry so the
     # output carries just the group key and the computed statistic.
     result = gdf.dissolve(by=group_field)[["geometry"]].copy()

--- a/backend/geolibre_server/geolibre_server/vector_ops.py
+++ b/backend/geolibre_server/geolibre_server/vector_ops.py
@@ -468,10 +468,14 @@ def _aggregate(geojson, overlay, parameters) -> tuple[dict, list[str]]:
     import pandas as pd  # noqa: PLC0415
 
     gdf = _load_gdf(geojson, "Input layer")
+    # The geometry column is in gdf.columns but is not a groupable/numeric
+    # attribute; reject it explicitly so it fails with a clean 400 instead of a
+    # later TypeError (unhashable geometry) surfacing as a 500.
+    geom_col = gdf.geometry.name
     group_field = str(parameters.get("group_field", "") or "").strip()
     if not group_field:
         raise ValueError("A group field is required")
-    if group_field not in gdf.columns:
+    if group_field not in gdf.columns or group_field == geom_col:
         raise ValueError(f"Group field '{group_field}' not found in layer attributes.")
     statistic = str(parameters.get("statistic", "count") or "count")
     if statistic not in _AGGREGATE_STATS:
@@ -482,7 +486,7 @@ def _aggregate(geojson, overlay, parameters) -> tuple[dict, list[str]]:
     if statistic != "count":
         if not stat_field:
             raise ValueError(f"A statistic field is required for '{statistic}'")
-        if stat_field not in gdf.columns:
+        if stat_field not in gdf.columns or stat_field == geom_col:
             raise ValueError(
                 f"Statistic field '{stat_field}' not found in layer attributes."
             )
@@ -498,7 +502,9 @@ def _aggregate(geojson, overlay, parameters) -> tuple[dict, list[str]]:
         # client engine (and pandas' default skipna behaviour for these reducers).
         numeric = pd.to_numeric(gdf[stat_field], errors="coerce")
         values = numeric.groupby(gdf[group_field]).agg(statistic)
-    result[out_col] = values
+    # Align the statistic to the dissolved geometry explicitly by index label so the
+    # assignment stays correct even if either call's group ordering changes.
+    result[out_col] = values.reindex(result.index)
     result = result.reset_index()
     return (
         _to_feature_collection(result),

--- a/backend/geolibre_server/tests/test_vector.py
+++ b/backend/geolibre_server/tests/test_vector.py
@@ -65,6 +65,9 @@ def test_dispatch_covers_all_tools() -> None:
         "spatial-join",
         "select-by-value",
         "select-by-location",
+        "reproject",
+        "explode",
+        "aggregate",
     }
     assert set(_DISPATCH) == expected
 

--- a/backend/geolibre_server/tests/test_vector_ops.py
+++ b/backend/geolibre_server/tests/test_vector_ops.py
@@ -602,6 +602,18 @@ def test_aggregate_unknown_group_field_raises() -> None:
 
 
 @requires_geopandas
+def test_aggregate_geometry_group_field_raises_clean_error() -> None:
+    # "geometry" is in gdf.columns but grouping by it would raise an unhashable
+    # TypeError (a 500); it must be rejected as a clean "not found" (400) instead.
+    with pytest.raises(ValueError, match="not found"):
+        run_vector_tool(
+            "aggregate",
+            _parcels(),
+            parameters={"group_field": "geometry", "statistic": "count"},
+        )
+
+
+@requires_geopandas
 def test_json_wrapper_round_trips() -> None:
     payload = json.dumps(
         {

--- a/backend/geolibre_server/tests/test_vector_ops.py
+++ b/backend/geolibre_server/tests/test_vector_ops.py
@@ -171,7 +171,9 @@ def test_spatial_join_inner_drops_unmatched_input() -> None:
 
 @requires_geopandas
 def test_spatial_join_empty_join_layer_left_keeps_input() -> None:
-    geojson, _ = run_vector_tool("spatial-join", SQUARE, EMPTY, parameters={"how": "left"})
+    geojson, _ = run_vector_tool(
+        "spatial-join", SQUARE, EMPTY, parameters={"how": "left"}
+    )
     assert len(geojson["features"]) == 1
 
 
@@ -252,7 +254,9 @@ def test_select_by_value_contains_is_case_insensitive() -> None:
 def test_select_by_value_is_null_matches_null_and_missing() -> None:
     # gamma has pop=None and delta omits the key entirely; both are "empty".
     geojson, _ = run_vector_tool(
-        "select-by-value", ATTR_LAYER, parameters={"field": "pop", "operator": "is-null"}
+        "select-by-value",
+        ATTR_LAYER,
+        parameters={"field": "pop", "operator": "is-null"},
     )
     names = sorted(f["properties"]["name"] for f in geojson["features"])
     assert names == ["delta", "gamma"]
@@ -323,7 +327,9 @@ def test_select_by_value_hexlike_string_compared_as_text() -> None:
         ],
     }
     miss, _ = run_vector_tool(
-        "select-by-value", layer, parameters={"field": "code", "operator": "eq", "value": "16"}
+        "select-by-value",
+        layer,
+        parameters={"field": "code", "operator": "eq", "value": "16"},
     )
     assert miss["features"] == []
     hit, _ = run_vector_tool(
@@ -454,6 +460,145 @@ def test_select_by_location_unknown_predicate_raises() -> None:
 def test_dissolve_unknown_field_raises_value_error() -> None:
     with pytest.raises(ValueError, match="not found"):
         run_vector_tool("dissolve", SQUARE, parameters={"field": "missing"})
+
+
+# --- Reproject ---
+
+
+@requires_geopandas
+def test_reproject_web_mercator_to_wgs84() -> None:
+    # A point at the eastern edge of Web Mercator (x ≈ 20037508.34) maps to
+    # lon ≈ 180, lat ≈ 0 once reinterpreted as EPSG:3857 and sent to WGS84.
+    mercator_point = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"name": "edge"},
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [20037508.342789244, 0.0],
+                },
+            }
+        ],
+    }
+    geojson, messages = run_vector_tool(
+        "reproject", mercator_point, parameters={"source_crs": "EPSG:3857"}
+    )
+    lon, lat = geojson["features"][0]["geometry"]["coordinates"]
+    assert abs(lon - 180.0) < 1e-6
+    assert abs(lat) < 1e-6
+    assert messages and "Reprojected" in messages[0]
+
+
+@requires_geopandas
+def test_reproject_missing_source_crs_raises() -> None:
+    with pytest.raises(ValueError, match="source CRS is required"):
+        run_vector_tool("reproject", SQUARE, parameters={})
+
+
+@requires_geopandas
+def test_reproject_invalid_source_crs_raises() -> None:
+    with pytest.raises(ValueError, match="Invalid source CRS"):
+        run_vector_tool("reproject", SQUARE, parameters={"source_crs": "EPSG:bogus"})
+
+
+# --- Explode ---
+
+
+@requires_geopandas
+def test_explode_splits_multipart_into_singlepart() -> None:
+    multipolygon = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"name": "mp"},
+                "geometry": {
+                    "type": "MultiPolygon",
+                    "coordinates": [
+                        [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]],
+                        [[[2, 2], [2, 3], [3, 3], [3, 2], [2, 2]]],
+                    ],
+                },
+            }
+        ],
+    }
+    geojson, messages = run_vector_tool("explode", multipolygon)
+    assert len(geojson["features"]) == 2
+    assert all(f["geometry"]["type"] == "Polygon" for f in geojson["features"])
+    # Each part keeps the parent's attributes.
+    assert all(f["properties"]["name"] == "mp" for f in geojson["features"])
+    assert messages and "single-part" in messages[0]
+
+
+# --- Aggregate by attribute ---
+
+
+def _parcels() -> dict:
+    def cell(region: str, pop: int, x: float) -> dict:
+        return {
+            "type": "Feature",
+            "properties": {"region": region, "pop": pop},
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [[[x, 0], [x, 1], [x + 1, 1], [x + 1, 0], [x, 0]]],
+            },
+        }
+
+    return {
+        "type": "FeatureCollection",
+        "features": [cell("north", 10, 0), cell("north", 30, 1), cell("south", 5, 5)],
+    }
+
+
+@requires_geopandas
+def test_aggregate_count_per_group() -> None:
+    geojson, messages = run_vector_tool(
+        "aggregate",
+        _parcels(),
+        parameters={"group_field": "region", "statistic": "count"},
+    )
+    by_region = {
+        f["properties"]["region"]: f["properties"] for f in geojson["features"]
+    }
+    assert by_region["north"]["count"] == 2
+    assert by_region["south"]["count"] == 1
+    assert messages and "Aggregated" in messages[0]
+
+
+@requires_geopandas
+def test_aggregate_sum_names_column_field_stat() -> None:
+    geojson, _ = run_vector_tool(
+        "aggregate",
+        _parcels(),
+        parameters={"group_field": "region", "statistic": "sum", "stat_field": "pop"},
+    )
+    by_region = {
+        f["properties"]["region"]: f["properties"] for f in geojson["features"]
+    }
+    assert by_region["north"]["pop_sum"] == 40
+    assert by_region["south"]["pop_sum"] == 5
+
+
+@requires_geopandas
+def test_aggregate_requires_stat_field_for_non_count() -> None:
+    with pytest.raises(ValueError, match="statistic field is required"):
+        run_vector_tool(
+            "aggregate",
+            _parcels(),
+            parameters={"group_field": "region", "statistic": "sum"},
+        )
+
+
+@requires_geopandas
+def test_aggregate_unknown_group_field_raises() -> None:
+    with pytest.raises(ValueError, match="Group field"):
+        run_vector_tool(
+            "aggregate",
+            _parcels(),
+            parameters={"group_field": "missing", "statistic": "count"},
+        )
 
 
 @requires_geopandas

--- a/backend/geolibre_server/tests/test_vector_ops.py
+++ b/backend/geolibre_server/tests/test_vector_ops.py
@@ -636,6 +636,40 @@ def test_aggregate_counts_polygons_only_for_mixed_geometry() -> None:
 
 
 @requires_geopandas
+def test_aggregate_all_null_group_values_returns_empty_result() -> None:
+    # Polygons exist but every group value is null: pandas groupby(dropna=True)
+    # yields no groups, so the result is empty (not an error), matching the client.
+    all_null = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"region": None, "pop": 1},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]],
+                },
+            },
+            {
+                "type": "Feature",
+                "properties": {"region": None, "pop": 2},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[[2, 0], [2, 1], [3, 1], [3, 0], [2, 0]]],
+                },
+            },
+        ],
+    }
+    geojson, messages = run_vector_tool(
+        "aggregate",
+        all_null,
+        parameters={"group_field": "region", "statistic": "count"},
+    )
+    assert geojson["features"] == []
+    assert messages and "0 group(s)" in messages[0]
+
+
+@requires_geopandas
 def test_aggregate_geometry_group_field_raises_clean_error() -> None:
     # "geometry" is in gdf.columns but grouping by it would raise an unhashable
     # TypeError (a 500); it must be rejected as a clean "not found" (400) instead.

--- a/backend/geolibre_server/tests/test_vector_ops.py
+++ b/backend/geolibre_server/tests/test_vector_ops.py
@@ -602,6 +602,40 @@ def test_aggregate_unknown_group_field_raises() -> None:
 
 
 @requires_geopandas
+def test_aggregate_counts_polygons_only_for_mixed_geometry() -> None:
+    # A mixed layer (2 polygons + 1 point, all group "a") must count only the
+    # polygons, matching the client engine's polygon-only restriction.
+    poly = {
+        "type": "Feature",
+        "properties": {"region": "a", "pop": 10},
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]],
+        },
+    }
+    poly2 = {
+        "type": "Feature",
+        "properties": {"region": "a", "pop": 20},
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [[[1, 0], [1, 1], [2, 1], [2, 0], [1, 0]]],
+        },
+    }
+    point = {
+        "type": "Feature",
+        "properties": {"region": "a", "pop": 99},
+        "geometry": {"type": "Point", "coordinates": [0.5, 0.5]},
+    }
+    mixed = {"type": "FeatureCollection", "features": [poly, poly2, point]}
+    geojson, _ = run_vector_tool(
+        "aggregate", mixed, parameters={"group_field": "region", "statistic": "count"}
+    )
+    assert len(geojson["features"]) == 1
+    # Only the 2 polygons count; the point is excluded.
+    assert geojson["features"][0]["properties"]["count"] == 2
+
+
+@requires_geopandas
 def test_aggregate_geometry_group_field_raises_clean_error() -> None:
     # "geometry" is in gdf.columns but grouping by it would raise an unhashable
     # TypeError (a 500); it must be rejected as a clean "not found" (400) instead.

--- a/package-lock.json
+++ b/package-lock.json
@@ -23538,6 +23538,7 @@
         "@turf/difference": "^7.3.5",
         "@turf/dissolve": "^7.3.5",
         "@turf/envelope": "^7.3.5",
+        "@turf/flatten": "^7.3.5",
         "@turf/helpers": "^7.3.5",
         "@turf/intersect": "^7.3.5",
         "@turf/simplify": "^7.3.5",

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -50,6 +50,9 @@ export type VectorToolKind =
   | "spatial-join"
   | "select-by-value"
   | "select-by-location"
+  | "reproject"
+  | "explode"
+  | "aggregate"
   | "h3-grid"
   | "h3-bin-points";
 

--- a/packages/map/src/placeholders.ts
+++ b/packages/map/src/placeholders.ts
@@ -27,18 +27,18 @@ export function isPlaceholderLayer(layer: GeoLibreLayer): boolean {
 
 export function placeholderMessage(layer: GeoLibreLayer): string {
   switch (layer.type) {
+    // PMTiles, COG, FlatGeobuf, and GeoParquet now render natively (each creates
+    // its own `nativeLayerIds`, which short-circuits isPlaceholderLayer above).
+    // Reaching this branch therefore means native layer creation did not happen
+    // for this layer, not that the format is unimplemented.
     case "pmtiles":
-      // TODO(v0.3): PMTiles — see docs/roadmap.md
-      return "PMTiles support planned for v0.3";
+      return "This PMTiles layer could not be displayed.";
     case "cog":
-      // TODO(v0.3): Cloud Optimized GeoTIFF
-      return "COG support planned for v0.3";
+      return "This COG layer could not be displayed.";
     case "flatgeobuf":
-      // TODO(v0.3): FlatGeobuf streaming
-      return "FlatGeobuf support planned for v0.3";
+      return "This FlatGeobuf layer could not be displayed.";
     case "geoparquet":
-      // TODO(v0.3): GeoParquet via DuckDB or parquet-wasm
-      return "GeoParquet support planned for v0.3";
+      return "This GeoParquet layer could not be displayed.";
     case "duckdb-query":
       // TODO(v0.4): DuckDB Spatial query results as layers
       return "DuckDB query layers planned for v0.4";

--- a/packages/processing/package.json
+++ b/packages/processing/package.json
@@ -20,6 +20,7 @@
     "@turf/difference": "^7.3.5",
     "@turf/dissolve": "^7.3.5",
     "@turf/envelope": "^7.3.5",
+    "@turf/flatten": "^7.3.5",
     "@turf/helpers": "^7.3.5",
     "@turf/intersect": "^7.3.5",
     "@turf/simplify": "^7.3.5",

--- a/packages/processing/src/registry.ts
+++ b/packages/processing/src/registry.ts
@@ -49,38 +49,9 @@ export const countFeaturesAlgorithm: ProcessingAlgorithm = {
   },
 };
 
-export const exportGeoJsonPlaceholder: ProcessingAlgorithm = {
-  id: "export-geojson",
-  name: "Export GeoJSON",
-  description: "Export layer to GeoJSON file",
-  parameters: [
-    { id: "layer", label: "Layer", type: "layer", required: true },
-  ],
-  run: (ctx) => {
-    // TODO(v0.5): Export via Tauri save dialog
-    ctx.log("Not implemented — export GeoJSON planned for v0.5");
-  },
-};
-
-export const reprojectPlaceholder: ProcessingAlgorithm = {
-  id: "reproject",
-  name: "Reproject",
-  description: "Reproject layer to another CRS",
-  parameters: [
-    { id: "layer", label: "Layer", type: "layer", required: true },
-    { id: "crs", label: "Target CRS", type: "string", default: "EPSG:4326" },
-  ],
-  run: (ctx) => {
-    // TODO(v0.5): Reproject via GDAL in Python sidecar
-    ctx.log("Not implemented — reproject planned for v0.5 (GDAL sidecar)");
-  },
-};
-
 export const ALGORITHMS: ProcessingAlgorithm[] = [
   calculateBoundsAlgorithm,
   countFeaturesAlgorithm,
-  exportGeoJsonPlaceholder,
-  reprojectPlaceholder,
 ];
 
 export function getAlgorithm(id: string): ProcessingAlgorithm | undefined {

--- a/packages/processing/src/types.ts
+++ b/packages/processing/src/types.ts
@@ -100,5 +100,12 @@ export interface ProcessingAlgorithm {
   group?: string;
   /** Whether this algorithm can also run on the Python (GeoPandas) sidecar. */
   supportsSidecar?: boolean;
+  /**
+   * Whether this algorithm can ONLY run on a Python engine (sidecar/Pyodide) —
+   * its client `run` is a no-op that defers. The dialog defaults the engine
+   * selector to "sidecar" so the tool produces a result on the first run.
+   * Implies {@link supportsSidecar}.
+   */
+  requiresSidecar?: boolean;
   run: (ctx: ProcessingContext) => Promise<void> | void;
 }

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -124,12 +124,14 @@ const AGGREGATE_STATS = new Set([
 
 /**
  * Coerce a property value to a finite number the way pandas' ``to_numeric`` does
- * for the aggregate engine: real numbers pass through, numeric strings parse
- * (decimal/scientific only — see {@link parseFiniteNumber}), everything else
- * (null, NaN, booleans, text, objects) becomes null and is skipped by the
- * reducers, matching pandas' default skipna behaviour.
+ * for the aggregate engine: real numbers pass through, booleans map to 1/0 (as
+ * pandas' `to_numeric` does), numeric strings parse (decimal/scientific only —
+ * see {@link parseFiniteNumber}), and everything else (null, NaN, text, objects)
+ * becomes null and is skipped by the reducers, matching pandas' default skipna
+ * behaviour.
  */
 function toNumeric(value: unknown): number | null {
+  if (typeof value === "boolean") return value ? 1 : 0;
   if (typeof value === "number") return Number.isFinite(value) ? value : null;
   if (typeof value === "string") {
     const n = parseFiniteNumber(value);

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -149,8 +149,11 @@ function computeStat(nums: number[], statistic: string): number | null {
   if (!nums.length) return null;
   if (statistic === "mean")
     return nums.reduce((a, b) => a + b, 0) / nums.length;
-  if (statistic === "min") return Math.min(...nums);
-  if (statistic === "max") return Math.max(...nums);
+  // reduce, not Math.min/max(...nums): the spread passes every element as an
+  // argument and a tens-of-thousands-element group would exceed the engine's
+  // argument-count limit and throw.
+  if (statistic === "min") return nums.reduce((a, b) => (a < b ? a : b));
+  if (statistic === "max") return nums.reduce((a, b) => (a > b ? a : b));
   if (statistic === "median") {
     const sorted = [...nums].sort((a, b) => a - b);
     const mid = Math.floor(sorted.length / 2);
@@ -1041,6 +1044,7 @@ export const reprojectTool: ProcessingAlgorithm = {
     "Reinterpret a layer's coordinates as a source CRS and transform them to WGS84 so they display in the correct location. Requires the Sidecar or Python engine.",
   group: "Geometry",
   supportsSidecar: true,
+  requiresSidecar: true,
   parameters: [
     { id: "layer", label: "Input layer", type: "layer", required: true },
     {
@@ -1142,6 +1146,15 @@ export const aggregateTool: ProcessingAlgorithm = {
       ctx.log("Error: a group field is required");
       return;
     }
+    // Mirror the backend's `group_field not in gdf.columns` guard: if no feature
+    // carries the field at all, fail rather than producing a single empty bucket.
+    const hasGroupField = fc.features.some((f) =>
+      Object.prototype.hasOwnProperty.call(f.properties ?? {}, groupField),
+    );
+    if (!hasGroupField) {
+      ctx.log(`Error: group field '${groupField}' not found in layer attributes.`);
+      return;
+    }
     const statistic = (ctx.parameters.statistic as string) || "count";
     if (!AGGREGATE_STATS.has(statistic)) {
       ctx.log(`Error: unknown statistic '${statistic}'`);
@@ -1166,6 +1179,9 @@ export const aggregateTool: ProcessingAlgorithm = {
         continue;
       }
       const raw = feature.properties?.[groupField];
+      // Skip features with no group value, matching pandas `groupby` (dropna=True),
+      // so the client never invents a "null" bucket the sidecar wouldn't produce.
+      if (raw === null || raw === undefined) continue;
       const key = stableStringify(raw);
       let group = groups.get(key);
       if (!group) {
@@ -1186,9 +1202,15 @@ export const aggregateTool: ProcessingAlgorithm = {
     const outColumn =
       statistic === "count" ? "count" : `${statField}_${statistic}`;
     const results: Feature[] = [];
+    let droppedGroups = 0;
     for (const group of groups.values()) {
       const merged = mergePolygons(featureCollection(group.features));
-      if (!merged?.geometry) continue;
+      // mergePolygons returns null for a degenerate/self-intersecting group; count
+      // it so the user understands why the output has fewer groups than expected.
+      if (!merged?.geometry) {
+        droppedGroups += 1;
+        continue;
+      }
       const statValue =
         statistic === "count"
           ? group.count
@@ -1201,7 +1223,10 @@ export const aggregateTool: ProcessingAlgorithm = {
     }
     ctx.log(
       `Aggregated ${fc.features.length - skipped} feature(s) into ${results.length} group(s) by '${groupField}'` +
-        (skipped > 0 ? ` (${skipped} skipped, not polygons)` : ""),
+        (skipped > 0 ? ` (${skipped} skipped, not polygons)` : "") +
+        (droppedGroups > 0
+          ? ` (${droppedGroups} group(s) dropped: could not merge geometry)`
+          : ""),
     );
     ctx.addResultLayer?.("Aggregate by attribute", featureCollection(results));
   },

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -1165,9 +1165,10 @@ export const aggregateTool: ProcessingAlgorithm = {
       ctx.log(`Error: a statistic field is required for '${statistic}'`);
       return;
     }
-    // The client engine merges polygons per group (like Dissolve); the sidecar
-    // handles all geometry types. Group the original features (so count and the
-    // numeric stats match the sidecar), then union each group's polygons.
+    // Both engines restrict Aggregate to polygons (the layer picker filters to
+    // polygon layers, and the sidecar drops non-polygons too), so count and the
+    // numeric stats stay in sync. Group the polygon features, then union each
+    // group's polygons for the output geometry.
     const groups = new Map<
       string,
       { value: unknown; features: Feature[]; nums: number[]; count: number }
@@ -1195,8 +1196,19 @@ export const aggregateTool: ProcessingAlgorithm = {
         if (num !== null) group.nums.push(num);
       }
     }
-    if (!groups.size) {
+    const polygonCount = fc.features.length - skipped;
+    if (polygonCount === 0) {
       ctx.log("Error: Aggregate by attribute requires polygon features");
+      return;
+    }
+    if (!groups.size) {
+      // Polygons exist but every one had a null/undefined group value; the
+      // sidecar (pandas groupby dropna=True) yields an empty grouped result
+      // here, so match it instead of erroring on "no polygons".
+      ctx.log(
+        `Aggregated ${polygonCount} feature(s) into 0 group(s) by '${groupField}'`,
+      );
+      ctx.addResultLayer?.("Aggregate by attribute", featureCollection([]));
       return;
     }
     const outColumn =

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -1216,15 +1216,11 @@ export const aggregateTool: ProcessingAlgorithm = {
     const outColumn =
       statistic === "count" ? "count" : `${statField}_${statistic}`;
     const results: Feature[] = [];
-    let droppedGroups = 0;
     for (const group of groups.values()) {
+      // Each group holds only polygon features, so mergePolygons always returns a
+      // geometry; the null check just satisfies its `| null` return type.
       const merged = mergePolygons(featureCollection(group.features));
-      // mergePolygons returns null for a degenerate/self-intersecting group; count
-      // it so the user understands why the output has fewer groups than expected.
-      if (!merged?.geometry) {
-        droppedGroups += 1;
-        continue;
-      }
+      if (!merged) continue;
       const statValue =
         statistic === "count"
           ? group.count
@@ -1236,11 +1232,8 @@ export const aggregateTool: ProcessingAlgorithm = {
       });
     }
     ctx.log(
-      `Aggregated ${fc.features.length - skipped} feature(s) into ${results.length} group(s) by '${groupField}'` +
-        (skipped > 0 ? ` (${skipped} skipped, not polygons)` : "") +
-        (droppedGroups > 0
-          ? ` (${droppedGroups} group(s) dropped: could not merge geometry)`
-          : ""),
+      `Aggregated ${polygonCount} feature(s) into ${results.length} group(s) by '${groupField}'` +
+        (skipped > 0 ? ` (${skipped} skipped, not polygons)` : ""),
     );
     ctx.addResultLayer?.("Aggregate by attribute", featureCollection(results));
   },

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -3,6 +3,7 @@ import centroid from "@turf/centroid";
 import convex from "@turf/convex";
 import dissolve from "@turf/dissolve";
 import envelope from "@turf/envelope";
+import flatten from "@turf/flatten";
 import simplify from "@turf/simplify";
 import intersect from "@turf/intersect";
 import difference from "@turf/difference";
@@ -109,6 +110,55 @@ function mergePolygons(
     if (next) merged = next as Feature<Polygon | MultiPolygon>;
   }
   return merged;
+}
+
+/** Summary statistics for Aggregate by attribute; kept in sync with the backend. */
+const AGGREGATE_STATS = new Set([
+  "count",
+  "sum",
+  "mean",
+  "min",
+  "max",
+  "median",
+]);
+
+/**
+ * Coerce a property value to a finite number the way pandas' ``to_numeric`` does
+ * for the aggregate engine: real numbers pass through, numeric strings parse
+ * (decimal/scientific only — see {@link parseFiniteNumber}), everything else
+ * (null, NaN, booleans, text, objects) becomes null and is skipped by the
+ * reducers, matching pandas' default skipna behaviour.
+ */
+function toNumeric(value: unknown): number | null {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "string") {
+    const n = parseFiniteNumber(value);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+/**
+ * Reduce a group's numeric values with one statistic, mirroring pandas:
+ * ``sum`` of an empty group is 0 (skipna), while ``mean``/``min``/``max``/
+ * ``median`` of an empty group are null (NaN → null in GeoJSON). ``count`` is
+ * handled by the caller (it counts features, not numeric values).
+ */
+function computeStat(nums: number[], statistic: string): number | null {
+  if (statistic === "sum") return nums.reduce((a, b) => a + b, 0);
+  if (!nums.length) return null;
+  if (statistic === "mean")
+    return nums.reduce((a, b) => a + b, 0) / nums.length;
+  if (statistic === "min") return Math.min(...nums);
+  if (statistic === "max") return Math.max(...nums);
+  if (statistic === "median") {
+    const sorted = [...nums].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    return sorted.length % 2
+      ? sorted[mid]
+      : (sorted[mid - 1] + sorted[mid]) / 2;
+  }
+  return null;
 }
 
 export const bufferTool: ProcessingAlgorithm = {
@@ -984,6 +1034,179 @@ export const selectByLocationTool: ProcessingAlgorithm = {
   },
 };
 
+export const reprojectTool: ProcessingAlgorithm = {
+  id: "reproject",
+  name: "Reproject",
+  description:
+    "Reinterpret a layer's coordinates as a source CRS and transform them to WGS84 so they display in the correct location. Requires the Sidecar or Python engine.",
+  group: "Geometry",
+  supportsSidecar: true,
+  parameters: [
+    { id: "layer", label: "Input layer", type: "layer", required: true },
+    {
+      id: "source_crs",
+      label: "Source CRS",
+      type: "string",
+      required: true,
+      default: "EPSG:3857",
+      description:
+        "The CRS the layer's coordinates are really in (e.g. EPSG:3857). The result is transformed to WGS84 (EPSG:4326).",
+    },
+  ],
+  run: (ctx) => {
+    // GeoLibre layers are WGS84 GeoJSON, and real CRS math needs pyproj, so the
+    // client (Turf.js) engine cannot reproject. Point the user at the engines
+    // that share the backend's _reproject (Sidecar/GeoPandas or Pyodide).
+    ctx.log(
+      'Reproject runs on the Python engine. Choose "Sidecar (GeoPandas)" or ' +
+        '"Python (Pyodide)" in the Engine selector above, then run again.',
+    );
+  },
+};
+
+export const explodeTool: ProcessingAlgorithm = {
+  id: "explode",
+  name: "Explode",
+  description:
+    "Split multipart geometries into single-part features (one feature per part), keeping each parent's attributes",
+  group: "Geometry",
+  supportsSidecar: true,
+  parameters: [
+    { id: "layer", label: "Input layer", type: "layer", required: true },
+  ],
+  run: (ctx) => {
+    const fc = requireFeatures(ctx);
+    if (!fc) return;
+    // Turf's flatten splits Multi* and GeometryCollection features into their
+    // single-part components, copying properties — matching GeoPandas explode().
+    const exploded = flatten(fc);
+    ctx.log(
+      `Exploded ${fc.features.length} feature(s) into ${exploded.features.length} single-part feature(s)`,
+    );
+    ctx.addResultLayer?.("Explode", exploded);
+  },
+};
+
+export const aggregateTool: ProcessingAlgorithm = {
+  id: "aggregate",
+  name: "Aggregate by attribute",
+  description:
+    "Dissolve features that share an attribute value into one geometry per group, with a summary statistic",
+  group: "Geometry",
+  supportsSidecar: true,
+  parameters: [
+    {
+      id: "layer",
+      label: "Input layer",
+      type: "layer",
+      required: true,
+      geometryFilter: ["polygon"],
+    },
+    {
+      id: "group_field",
+      label: "Group by field",
+      type: "field",
+      fieldSource: "layer",
+      required: true,
+    },
+    {
+      id: "statistic",
+      label: "Statistic",
+      type: "select",
+      default: "count",
+      options: [
+        { value: "count", label: "Count" },
+        { value: "sum", label: "Sum" },
+        { value: "mean", label: "Mean" },
+        { value: "min", label: "Min" },
+        { value: "max", label: "Max" },
+        { value: "median", label: "Median" },
+      ],
+    },
+    {
+      id: "stat_field",
+      label: "Statistic field",
+      type: "field",
+      fieldSource: "layer",
+      required: true,
+      description: "Numeric field summarized by the statistic above.",
+      // Count needs no field; every other statistic reduces this numeric field.
+      visibleWhen: { param: "statistic", notIn: ["count"] },
+    },
+  ],
+  run: (ctx) => {
+    const fc = requireFeatures(ctx);
+    if (!fc) return;
+    const groupField = (ctx.parameters.group_field as string)?.trim();
+    if (!groupField) {
+      ctx.log("Error: a group field is required");
+      return;
+    }
+    const statistic = (ctx.parameters.statistic as string) || "count";
+    if (!AGGREGATE_STATS.has(statistic)) {
+      ctx.log(`Error: unknown statistic '${statistic}'`);
+      return;
+    }
+    const statField = (ctx.parameters.stat_field as string)?.trim();
+    if (statistic !== "count" && !statField) {
+      ctx.log(`Error: a statistic field is required for '${statistic}'`);
+      return;
+    }
+    // The client engine merges polygons per group (like Dissolve); the sidecar
+    // handles all geometry types. Group the original features (so count and the
+    // numeric stats match the sidecar), then union each group's polygons.
+    const groups = new Map<
+      string,
+      { value: unknown; features: Feature[]; nums: number[]; count: number }
+    >();
+    let skipped = 0;
+    for (const feature of fc.features) {
+      if (!isFamily(feature.geometry, "polygon")) {
+        skipped += 1;
+        continue;
+      }
+      const raw = feature.properties?.[groupField];
+      const key = stableStringify(raw);
+      let group = groups.get(key);
+      if (!group) {
+        group = { value: raw, features: [], nums: [], count: 0 };
+        groups.set(key, group);
+      }
+      group.features.push(feature);
+      group.count += 1;
+      if (statistic !== "count" && statField) {
+        const num = toNumeric(feature.properties?.[statField]);
+        if (num !== null) group.nums.push(num);
+      }
+    }
+    if (!groups.size) {
+      ctx.log("Error: Aggregate by attribute requires polygon features");
+      return;
+    }
+    const outColumn =
+      statistic === "count" ? "count" : `${statField}_${statistic}`;
+    const results: Feature[] = [];
+    for (const group of groups.values()) {
+      const merged = mergePolygons(featureCollection(group.features));
+      if (!merged?.geometry) continue;
+      const statValue =
+        statistic === "count"
+          ? group.count
+          : computeStat(group.nums, statistic);
+      results.push({
+        type: "Feature",
+        properties: { [groupField]: group.value, [outColumn]: statValue },
+        geometry: merged.geometry,
+      });
+    }
+    ctx.log(
+      `Aggregated ${fc.features.length - skipped} feature(s) into ${results.length} group(s) by '${groupField}'` +
+        (skipped > 0 ? ` (${skipped} skipped, not polygons)` : ""),
+    );
+    ctx.addResultLayer?.("Aggregate by attribute", featureCollection(results));
+  },
+};
+
 export const VECTOR_TOOLS: ProcessingAlgorithm[] = [
   bufferTool,
   centroidsTool,
@@ -998,6 +1221,9 @@ export const VECTOR_TOOLS: ProcessingAlgorithm[] = [
   spatialJoinTool,
   selectByValueTool,
   selectByLocationTool,
+  reprojectTool,
+  explodeTool,
+  aggregateTool,
   createH3GridTool,
   binPointsTool,
 ];

--- a/tests/processing.test.ts
+++ b/tests/processing.test.ts
@@ -485,6 +485,161 @@ describe("processing registry", () => {
     assert.equal(run(empty, "intersects").features.length, 0);
   });
 
+  it("explodes multipart geometries into single-part features", () => {
+    const tool = getVectorTool("explode");
+    assert.ok(tool);
+    const multi: GeoLibreLayer = {
+      ...layer,
+      id: "multi",
+      name: "Multi",
+      geojson: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: { name: "mp" },
+            geometry: {
+              type: "MultiPolygon",
+              coordinates: [
+                [
+                  [
+                    [0, 0],
+                    [0, 1],
+                    [1, 1],
+                    [1, 0],
+                    [0, 0],
+                  ],
+                ],
+                [
+                  [
+                    [2, 2],
+                    [2, 3],
+                    [3, 3],
+                    [3, 2],
+                    [2, 2],
+                  ],
+                ],
+              ],
+            },
+          },
+          {
+            type: "Feature",
+            properties: { name: "single" },
+            geometry: {
+              type: "Polygon",
+              coordinates: [
+                [
+                  [5, 5],
+                  [5, 6],
+                  [6, 6],
+                  [6, 5],
+                  [5, 5],
+                ],
+              ],
+            },
+          },
+        ],
+      },
+    };
+    let out: FeatureCollection | null = null;
+    tool.run({
+      layers: [multi],
+      parameters: { layer: "multi" },
+      log: () => {},
+      addResultLayer: (_n, g) => {
+        out = g;
+      },
+    });
+    // The 2-part MultiPolygon splits into 2 Polygons; the single Polygon stays.
+    assert.equal(out!.features.length, 3);
+    assert.ok(out!.features.every((f) => f.geometry.type === "Polygon"));
+    // Each part keeps its parent's attributes.
+    const names = out!.features.map((f) => f.properties?.name).sort();
+    assert.deepEqual(names, ["mp", "mp", "single"]);
+  });
+
+  it("aggregates features by attribute with a summary statistic", () => {
+    const tool = getVectorTool("aggregate");
+    assert.ok(tool);
+    const cell = (region: string, pop: number, x: number) => ({
+      type: "Feature" as const,
+      properties: { region, pop },
+      geometry: {
+        type: "Polygon" as const,
+        coordinates: [
+          [
+            [x, 0],
+            [x, 1],
+            [x + 1, 1],
+            [x + 1, 0],
+            [x, 0],
+          ],
+        ],
+      },
+    });
+    const parcels: GeoLibreLayer = {
+      ...layer,
+      id: "parcels",
+      name: "Parcels",
+      geojson: {
+        type: "FeatureCollection",
+        features: [
+          cell("north", 10, 0),
+          cell("north", 30, 1),
+          cell("south", 5, 5),
+        ],
+      },
+    };
+    const run = (parameters: Record<string, unknown>): FeatureCollection => {
+      let out: FeatureCollection = { type: "FeatureCollection", features: [] };
+      tool.run({
+        layers: [parcels],
+        parameters: { layer: "parcels", group_field: "region", ...parameters },
+        log: () => {},
+        addResultLayer: (_n, g) => {
+          out = g;
+        },
+      });
+      return out;
+    };
+    const byRegion = (fc: FeatureCollection) =>
+      new Map(fc.features.map((f) => [f.properties?.region, f.properties]));
+
+    // Count: 2 north parcels, 1 south.
+    const counts = byRegion(run({ statistic: "count" }));
+    assert.equal(counts.size, 2);
+    assert.equal(counts.get("north")?.count, 2);
+    assert.equal(counts.get("south")?.count, 1);
+
+    // Sum of pop per region, output column named "<field>_<stat>".
+    const sums = byRegion(run({ statistic: "sum", stat_field: "pop" }));
+    assert.equal(sums.get("north")?.pop_sum, 40);
+    assert.equal(sums.get("south")?.pop_sum, 5);
+
+    // Mean reduces the same numeric field.
+    const means = byRegion(run({ statistic: "mean", stat_field: "pop" }));
+    assert.equal(means.get("north")?.pop_mean, 20);
+  });
+
+  it("reproject defers to the Python engine on the client", () => {
+    const tool = getVectorTool("reproject");
+    assert.ok(tool);
+    const messages: string[] = [];
+    let produced = false;
+    tool.run({
+      layers: [layer],
+      parameters: { layer: "layer-a", source_crs: "EPSG:3857" },
+      log: (m) => messages.push(m),
+      addResultLayer: () => {
+        produced = true;
+      },
+    });
+    // The client engine cannot reproject; it points the user at Sidecar/Pyodide
+    // and produces no layer.
+    assert.equal(produced, false);
+    assert.ok(messages.some((m) => m.includes("Python engine")));
+  });
+
   it("calculates and fits layer bounds", () => {
     const messages: string[] = [];
     let fittedBounds: [number, number, number, number] | null = null;

--- a/tests/processing.test.ts
+++ b/tests/processing.test.ts
@@ -665,6 +665,34 @@ describe("processing registry", () => {
     });
     assert.equal(missingProduced, false);
     assert.ok(missingLogs.some((m) => m.includes("not found")));
+
+    // The field exists but every value is null: not an error (polygons exist),
+    // an empty grouped result matching the sidecar's pandas dropna behaviour.
+    const allNull: GeoLibreLayer = {
+      ...parcels,
+      id: "allNull",
+      geojson: {
+        type: "FeatureCollection",
+        features: [
+          { ...cell("x", 1, 0), properties: { region: null, pop: 1 } },
+          { ...cell("y", 2, 5), properties: { region: null, pop: 2 } },
+        ],
+      },
+    };
+    let allNullOut: FeatureCollection | null = null;
+    const allNullLogs: string[] = [];
+    tool.run({
+      layers: [allNull],
+      parameters: { layer: "allNull", group_field: "region", statistic: "count" },
+      log: (m) => allNullLogs.push(m),
+      addResultLayer: (_n, g) => {
+        allNullOut = g;
+      },
+    });
+    assert.ok(allNullOut);
+    assert.equal(allNullOut!.features.length, 0);
+    assert.ok(allNullLogs.some((m) => m.includes("0 group(s)")));
+    assert.ok(!allNullLogs.some((m) => m.includes("requires polygon")));
   });
 
   it("reproject defers to the Python engine on the client", () => {

--- a/tests/processing.test.ts
+++ b/tests/processing.test.ts
@@ -619,6 +619,52 @@ describe("processing registry", () => {
     // Mean reduces the same numeric field.
     const means = byRegion(run({ statistic: "mean", stat_field: "pop" }));
     assert.equal(means.get("north")?.pop_mean, 20);
+
+    // min/max exercise the reduce path (no Math.min/max spread).
+    const mins = byRegion(run({ statistic: "min", stat_field: "pop" }));
+    assert.equal(mins.get("north")?.pop_min, 10);
+    const maxes = byRegion(run({ statistic: "max", stat_field: "pop" }));
+    assert.equal(maxes.get("north")?.pop_max, 30);
+
+    // A feature whose group value is null is skipped (no "null" bucket), matching
+    // pandas groupby(dropna=True) on the sidecar.
+    const withNull: GeoLibreLayer = {
+      ...parcels,
+      id: "withNull",
+      geojson: {
+        type: "FeatureCollection",
+        features: [
+          cell("north", 10, 0),
+          { ...cell("x", 1, 5), properties: { region: null, pop: 1 } },
+        ],
+      },
+    };
+    let nullOut: FeatureCollection = { type: "FeatureCollection", features: [] };
+    tool.run({
+      layers: [withNull],
+      parameters: { layer: "withNull", group_field: "region", statistic: "count" },
+      log: () => {},
+      addResultLayer: (_n, g) => {
+        nullOut = g;
+      },
+    });
+    assert.equal(nullOut.features.length, 1);
+    assert.equal(nullOut.features[0].properties?.region, "north");
+
+    // A group field absent from every feature errors (parity with the backend's
+    // "not found" guard) rather than producing one empty bucket.
+    let missingProduced = false;
+    const missingLogs: string[] = [];
+    tool.run({
+      layers: [parcels],
+      parameters: { layer: "parcels", group_field: "nope", statistic: "count" },
+      log: (m) => missingLogs.push(m),
+      addResultLayer: () => {
+        missingProduced = true;
+      },
+    });
+    assert.equal(missingProduced, false);
+    assert.ok(missingLogs.some((m) => m.includes("not found")));
   });
 
   it("reproject defers to the Python engine on the client", () => {

--- a/tests/processing.test.ts
+++ b/tests/processing.test.ts
@@ -626,6 +626,35 @@ describe("processing registry", () => {
     const maxes = byRegion(run({ statistic: "max", stat_field: "pop" }));
     assert.equal(maxes.get("north")?.pop_max, 30);
 
+    // Boolean stat values coerce to 1/0 like pandas to_numeric (sum of two
+    // north parcels, one true + one false → 1), not dropped as non-numeric.
+    const boolLayer: GeoLibreLayer = {
+      ...parcels,
+      id: "boolLayer",
+      geojson: {
+        type: "FeatureCollection",
+        features: [
+          { ...cell("north", 1, 0), properties: { region: "north", flag: true } },
+          { ...cell("north", 1, 1), properties: { region: "north", flag: false } },
+        ],
+      },
+    };
+    let boolOut: FeatureCollection = { type: "FeatureCollection", features: [] };
+    tool.run({
+      layers: [boolLayer],
+      parameters: {
+        layer: "boolLayer",
+        group_field: "region",
+        statistic: "sum",
+        stat_field: "flag",
+      },
+      log: () => {},
+      addResultLayer: (_n, g) => {
+        boolOut = g;
+      },
+    });
+    assert.equal(boolOut.features[0]?.properties?.flag_sum, 1);
+
     // A feature whose group value is null is skipped (no "null" bucket), matching
     // pandas groupby(dropna=True) on the sidecar.
     const withNull: GeoLibreLayer = {


### PR DESCRIPTION
Fills three of the vector gaps tracked in #283, plus the related dead-placeholder cleanup. Each tool is wired through the structured processing registry, so it appears in **Processing → Vector** and runs on both the client (Turf.js) and Python (GeoPandas sidecar / Pyodide) engines.

## New vector tools

- **Reproject** — reinterpret a layer's coordinates as a *source* CRS and transform them to WGS84 so misplaced data displays in the correct location. Because the whole app stores/displays WGS84 GeoJSON (and the sidecar output path always normalizes to WGS84), source→WGS84 is the only reprojection that yields a displayable result; the common case is data that's really EPSG:3857 but loaded as lon/lat. Real CRS math needs pyproj, so the client engine defers to the Sidecar/Pyodide engine.
- **Explode** — split multipart geometries into single-part features (`@turf/flatten` on the client, GeoPandas `explode()` on the sidecar).
- **Aggregate by attribute** — dissolve features sharing an attribute value into one geometry per group with a `count`/`sum`/`mean`/`min`/`max`/`median` summary. Output column is `count` or `<field>_<stat>`; client and sidecar kept in numeric sync (pandas `skipna` semantics).

## Cleanup (related #283 item)

- Removed the dead `reprojectPlaceholder` / `exportGeoJsonPlaceholder` from `packages/processing/src/registry.ts` (the `reproject` id is now a real tool).
- Refreshed the stale `TODO(v0.3)` "planned for vX" stubs in `packages/map/src/placeholders.ts` and `LayerPanel.tsx` — PMTiles/COG/FlatGeobuf/GeoParquet now render natively (they create `nativeLayerIds`, which short-circuits `isPlaceholderLayer`), so those messages were misleading and now only surface if native layer creation failed. The runtime safety-net mechanism is left intact.

## Tests

- **Backend** (`pytest`): handlers for all three tools incl. an EPSG:3857→WGS84 numeric assertion, plus the dispatch-coverage guard (69 vector tests pass).
- **Frontend** (`node:test`): client Explode/Aggregate/Reproject paths (484 frontend tests pass).
- `tsc -b` clean; eslint + full npm build (pre-commit) pass; ruff check/format clean.

## End-to-end verification

Drove the real app with Playwright against real public datasets, checked against known truth:

| Tool | Dataset | Result | Expected |
|---|---|---|---|
| Explode | US states (52 feat, 7 MultiPolygons) | 103 single-part | 103 (geopandas) ✓ |
| Aggregate (count) | US counties (DE/RI/CT) | CT=8, DE=3, RI=5 | known county counts ✓ |
| Aggregate (sum) | counties `CENSUSAREA` | col `CENSUSAREA_sum`, exact values | geopandas ✓ |
| Reproject (sidecar) | Web Mercator points | [180,0] and [90,0] | exact ✓ |

Tracking issue #283; the remaining items (raster zonal stats / map algebra / reclassify / mosaic / focal; vector voronoi / smooth / grid; interpolation) are each their own follow-up PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three vector processing tools in Processing → Vector: Reproject, Explode, Aggregate.

* **Behavior**
  * Processing dialog now prefers the Python sidecar when a tool requires it; engine selector shown/adjusted for sidecar-capable tools.

* **Documentation**
  * Layer panel help now points to the roadmap for advanced formats.
  * Added translations for the new vector tools.

* **Tests**
  * Expanded regression and unit tests covering the new vector tools.

* **Chores**
  * Improved placeholder messages for unsupported native layer displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->