### PR TITLE
feat(processing): add Smooth, Regular grid, Voronoi/Delaunay vector tools

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         # Cover the declared minimum (requires-python >= 3.11) and current
         # releases so newer-only syntax can't slip in unnoticed.
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ test-results/
 playwright-report/
 blob-report/
 .playwright/
+private/
 
 # Documentation screenshots are hosted on Cloudflare R2 (data.geolibre.app/images),
 # not committed to the repo, to save space.

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -293,6 +293,9 @@ const VECTOR_TOOL_COMMANDS: Array<{ kind: VectorToolKind; titleKey: ParseKeys }>
     { kind: "reproject", titleKey: "toolbar.vectorTool.reproject" },
     { kind: "explode", titleKey: "toolbar.vectorTool.explode" },
     { kind: "aggregate", titleKey: "toolbar.vectorTool.aggregate" },
+    { kind: "smooth", titleKey: "toolbar.vectorTool.smooth" },
+    { kind: "grid", titleKey: "toolbar.vectorTool.grid" },
+    { kind: "voronoi", titleKey: "toolbar.vectorTool.voronoi" },
     { kind: "h3-grid", titleKey: "toolbar.vectorTool.h3Grid" },
     { kind: "h3-bin-points", titleKey: "toolbar.vectorTool.h3BinPoints" },
   ];
@@ -1714,6 +1717,15 @@ export function TopToolbar({
               </DropdownMenuItem>
               <DropdownMenuItem onSelect={() => setVectorToolOpen("aggregate")}>
                 {t("toolbar.vectorTool.aggregate")}
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => setVectorToolOpen("smooth")}>
+                {t("toolbar.vectorTool.smooth")}
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => setVectorToolOpen("grid")}>
+                {t("toolbar.vectorTool.grid")}
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => setVectorToolOpen("voronoi")}>
+                {t("toolbar.vectorTool.voronoi")}
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuLabel className="text-xs text-muted-foreground">

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -194,6 +194,9 @@
       "reproject": "Reproject",
       "explode": "Explode",
       "aggregate": "Aggregate by attribute",
+      "smooth": "Smooth",
+      "grid": "Regular grid",
+      "voronoi": "Voronoi / Delaunay",
       "h3Grid": "Create H3 grid",
       "h3BinPoints": "Bin points to H3"
     },

--- a/backend/geolibre_server/geolibre_server/vector_ops.py
+++ b/backend/geolibre_server/geolibre_server/vector_ops.py
@@ -671,26 +671,32 @@ def _smooth(geojson, overlay, parameters) -> tuple[dict, list[str]]:
         raise ValueError(f"Iterations must be between 1 and {_SMOOTH_MAX_ITERATIONS}")
     out_features = []
     smoothed = 0
+    _smoothable = ("LineString", "MultiLineString", "Polygon", "MultiPolygon")
     for feature in geojson["features"]:
         geometry = feature.get("geometry")
         if not geometry:
             out_features.append(feature)
             continue
-        if geometry.get("type") in (
-            "LineString",
-            "MultiLineString",
-            "Polygon",
-            "MultiPolygon",
-            "GeometryCollection",
-        ):
+        gtype = geometry.get("type")
+        if gtype in _smoothable:
             smoothed += 1
-        out_features.append(
-            {
-                "type": "Feature",
-                "properties": feature.get("properties") or {},
-                "geometry": _smooth_geometry(geometry, iterations),
-            }
-        )
+        elif gtype == "GeometryCollection" and any(
+            g.get("type") in _smoothable
+            for g in geometry.get("geometries", [])
+        ):
+            # Only count a collection that actually has a line/polygon member;
+            # a points-only collection passes through unchanged.
+            smoothed += 1
+        new_feature = {
+            "type": "Feature",
+            "properties": feature.get("properties") or {},
+            "geometry": _smooth_geometry(geometry, iterations),
+        }
+        # Preserve the feature id (this raw-JSON path can keep it cheaply, unlike
+        # the GeoPandas handlers that lose it through the GeoDataFrame round-trip).
+        if "id" in feature:
+            new_feature["id"] = feature["id"]
+        out_features.append(new_feature)
     fc = {"type": "FeatureCollection", "features": out_features}
     return fc, [f"Smoothed {smoothed} feature(s) with {iterations} iteration(s)"]
 

--- a/backend/geolibre_server/geolibre_server/vector_ops.py
+++ b/backend/geolibre_server/geolibre_server/vector_ops.py
@@ -592,10 +592,11 @@ def _smooth_ring(ring: list[list[float]], iterations: int) -> list[list[float]]:
     pts = [list(p[:3]) for p in (ring[:-1] if closed else ring)]
     for _ in range(iterations):
         pts = _chaikin(pts, True)
-    # An invalid (empty/degenerate) ring leaves pts empty; guard so a crafted or
-    # corrupt payload yields an empty ring rather than an IndexError (500).
-    if not pts:
-        return pts
+    # A ring needs >= 3 distinct vertices to form a valid polygon; an empty or
+    # otherwise degenerate (1-2 vertex) ring collapses to an empty ring rather
+    # than being re-closed into invalid GeoJSON (and never an IndexError 500).
+    if len(pts) < 3:
+        return []
     pts.append(list(pts[0]))
     return pts
 
@@ -604,23 +605,27 @@ def _smooth_geometry(geometry: dict, iterations: int) -> dict:
     """Smooth one GeoJSON geometry; non-line/polygon geometries pass through."""
     gtype = geometry.get("type")
     coords = geometry.get("coordinates")
+    # `coords or []` guards a malformed feature missing its coordinates key
+    # (e.g. {"type": "LineString"}), whose `None` would otherwise raise a
+    # TypeError (500) since the server accepts arbitrary JSON.
     if gtype == "LineString":
-        return {"type": gtype, "coordinates": _smooth_line(coords, iterations)}
+        return {"type": gtype, "coordinates": _smooth_line(coords or [], iterations)}
     if gtype == "MultiLineString":
         return {
             "type": gtype,
-            "coordinates": [_smooth_line(line, iterations) for line in coords],
+            "coordinates": [_smooth_line(line, iterations) for line in coords or []],
         }
     if gtype == "Polygon":
         return {
             "type": gtype,
-            "coordinates": [_smooth_ring(ring, iterations) for ring in coords],
+            "coordinates": [_smooth_ring(ring, iterations) for ring in coords or []],
         }
     if gtype == "MultiPolygon":
         return {
             "type": gtype,
             "coordinates": [
-                [_smooth_ring(ring, iterations) for ring in poly] for poly in coords
+                [_smooth_ring(ring, iterations) for ring in poly]
+                for poly in coords or []
             ],
         }
     if gtype == "GeometryCollection":
@@ -649,10 +654,16 @@ def _smooth(geojson, overlay, parameters) -> tuple[dict, list[str]]:
     # non-finite/unparseable value falls back to 3, and math.floor(x + 0.5)
     # rounds half up exactly like JS Math.round (not Python round()'s
     # banker's rounding), keeping the two engines bit-identical.
-    try:
-        value = float(parameters.get("iterations", 3))
-    except (TypeError, ValueError):
+    raw_iterations = parameters.get("iterations", 3)
+    # A JSON boolean is not a number on the client (numberParam returns the
+    # fallback), so treat it as the default rather than float(True/False) = 1/0.
+    if isinstance(raw_iterations, bool):
         value = 3.0
+    else:
+        try:
+            value = float(raw_iterations)
+        except (TypeError, ValueError):
+            value = 3.0
     if not math.isfinite(value):
         value = 3.0
     iterations = math.floor(value + 0.5)
@@ -731,7 +742,14 @@ def _voronoi(geojson, overlay, parameters) -> tuple[dict, list[str]]:
     envelope = box(minx - dx * 0.1, miny - dy * 0.1, maxx + dx * 0.1, maxy + dy * 0.1)
     diagram = voronoi_diagram(multipoint, envelope=envelope)
     cells = [cell.intersection(envelope) for cell in diagram.geoms]
-    cells = [cell for cell in cells if not cell.is_empty]
+    # Clipping a cell whose edge coincides with the envelope can yield a
+    # GeometryCollection (polygon + stray line); keep only polygonal parts so a
+    # non-Polygon geometry never lands in the output.
+    cells = [
+        cell
+        for cell in cells
+        if not cell.is_empty and cell.geom_type in ("Polygon", "MultiPolygon")
+    ]
     result = gpd.GeoDataFrame(geometry=cells, crs=WGS84)
     message = f"Voronoi: produced {len(cells)} cell(s) from {len(points)} point(s)"
     return _to_feature_collection(result), [message]

--- a/backend/geolibre_server/geolibre_server/vector_ops.py
+++ b/backend/geolibre_server/geolibre_server/vector_ops.py
@@ -673,6 +673,11 @@ def _smooth(geojson, overlay, parameters) -> tuple[dict, list[str]]:
     smoothed = 0
     _smoothable = ("LineString", "MultiLineString", "Polygon", "MultiPolygon")
     for feature in geojson["features"]:
+        # The server accepts arbitrary JSON, so a `null`/non-object feature would
+        # raise AttributeError (500); reject it as bad input (ValueError -> 400),
+        # matching the module contract.
+        if not isinstance(feature, dict):
+            raise ValueError("Each feature must be a GeoJSON Feature object")
         geometry = feature.get("geometry")
         if not geometry:
             out_features.append(feature)

--- a/backend/geolibre_server/geolibre_server/vector_ops.py
+++ b/backend/geolibre_server/geolibre_server/vector_ops.py
@@ -529,13 +529,31 @@ def _aggregate(geojson, overlay, parameters) -> tuple[dict, list[str]]:
 _SMOOTH_MAX_ITERATIONS = 10
 
 
+def _chaikin_point(
+    a: list[float], b: list[float], wa: float
+) -> list[float]:
+    """Interpolate the point a fraction ``wa`` from ``a`` toward ``b``.
+
+    ``wa = 0.75`` lands closer to ``a``. Z/elevation is carried through and
+    interpolated when both endpoints are 3D; otherwise the result is 2D.
+    """
+    wb = 1 - wa
+    x = a[0] * wa + b[0] * wb
+    y = a[1] * wa + b[1] * wb
+    if len(a) > 2 and len(b) > 2:
+        return [x, y, a[2] * wa + b[2] * wb]
+    return [x, y]
+
+
 def _chaikin(points: list[list[float]], closed: bool) -> list[list[float]]:
-    """One pass of Chaikin's corner-cutting over a list of ``[x, y]`` positions.
+    """One pass of Chaikin's corner-cutting over a list of positions.
 
     Each segment A->B contributes two new points at 1/4 and 3/4 along it. For a
     closed ring the segments wrap (every vertex is cut); for an open line the
-    endpoints are preserved. The arithmetic and ordering mirror the client's
-    ``chaikinOnce`` exactly so both engines return bit-identical coordinates.
+    endpoints are preserved. Z is preserved/interpolated (see
+    :func:`_chaikin_point`); extra coordinate dimensions are dropped. The
+    arithmetic and ordering mirror the client's ``chaikinOnce`` exactly so both
+    engines return bit-identical coordinates.
     """
     n = len(points)
     if n < (3 if closed else 2):
@@ -545,21 +563,21 @@ def _chaikin(points: list[list[float]], closed: bool) -> list[list[float]]:
         for i in range(n):
             a = points[i]
             b = points[(i + 1) % n]
-            out.append([a[0] * 0.75 + b[0] * 0.25, a[1] * 0.75 + b[1] * 0.25])
-            out.append([a[0] * 0.25 + b[0] * 0.75, a[1] * 0.25 + b[1] * 0.75])
+            out.append(_chaikin_point(a, b, 0.75))
+            out.append(_chaikin_point(a, b, 0.25))
     else:
-        out.append([points[0][0], points[0][1]])
+        out.append(list(points[0][:3]))
         for i in range(n - 1):
             a = points[i]
             b = points[i + 1]
-            out.append([a[0] * 0.75 + b[0] * 0.25, a[1] * 0.75 + b[1] * 0.25])
-            out.append([a[0] * 0.25 + b[0] * 0.75, a[1] * 0.25 + b[1] * 0.75])
-        out.append([points[n - 1][0], points[n - 1][1]])
+            out.append(_chaikin_point(a, b, 0.75))
+            out.append(_chaikin_point(a, b, 0.25))
+        out.append(list(points[n - 1][:3]))
     return out
 
 
 def _smooth_line(coords: list[list[float]], iterations: int) -> list[list[float]]:
-    pts = [[p[0], p[1]] for p in coords]
+    pts = [list(p[:3]) for p in coords]
     for _ in range(iterations):
         pts = _chaikin(pts, False)
     return pts
@@ -571,14 +589,14 @@ def _smooth_ring(ring: list[list[float]], iterations: int) -> list[list[float]]:
         and ring[0][0] == ring[-1][0]
         and ring[0][1] == ring[-1][1]
     )
-    pts = [[p[0], p[1]] for p in (ring[:-1] if closed else ring)]
+    pts = [list(p[:3]) for p in (ring[:-1] if closed else ring)]
     for _ in range(iterations):
         pts = _chaikin(pts, True)
     # An invalid (empty/degenerate) ring leaves pts empty; guard so a crafted or
     # corrupt payload yields an empty ring rather than an IndexError (500).
     if not pts:
         return pts
-    pts.append([pts[0][0], pts[0][1]])
+    pts.append(list(pts[0]))
     return pts
 
 
@@ -603,6 +621,16 @@ def _smooth_geometry(geometry: dict, iterations: int) -> dict:
             "type": gtype,
             "coordinates": [
                 [_smooth_ring(ring, iterations) for ring in poly] for poly in coords
+            ],
+        }
+    if gtype == "GeometryCollection":
+        # Recurse so line/polygon members are smoothed instead of silently
+        # passing through; point members fall to the pass-through below.
+        return {
+            "type": gtype,
+            "geometries": [
+                _smooth_geometry(g, iterations)
+                for g in geometry.get("geometries", [])
             ],
         }
     return geometry
@@ -642,6 +670,7 @@ def _smooth(geojson, overlay, parameters) -> tuple[dict, list[str]]:
             "MultiLineString",
             "Polygon",
             "MultiPolygon",
+            "GeometryCollection",
         ):
             smoothed += 1
         out_features.append(
@@ -678,6 +707,15 @@ def _voronoi(geojson, overlay, parameters) -> tuple[dict, list[str]]:
     if len(points) < 3:
         raise ValueError("Voronoi / Delaunay needs at least 3 points")
     multipoint = MultiPoint(points)
+    # Both diagrams are undefined for collinear/coincident points (a zero-area
+    # bounding box); bail with a clear message rather than a degenerate result.
+    # Mirrors the client guard.
+    minx, miny, maxx, maxy = multipoint.bounds
+    if minx == maxx or miny == maxy:
+        raise ValueError(
+            "The points are collinear or coincident; Voronoi / Delaunay needs "
+            "points that span an area"
+        )
     if kind == "delaunay":
         triangles = triangulate(multipoint)
         result = gpd.GeoDataFrame(geometry=triangles, crs=WGS84)
@@ -688,9 +726,8 @@ def _voronoi(geojson, overlay, parameters) -> tuple[dict, list[str]]:
         return _to_feature_collection(result), [message]
     # Clip the (otherwise unbounded outer) cells to the points' bbox expanded by a
     # 10% margin, matching the client, so they get a finite extent.
-    minx, miny, maxx, maxy = multipoint.bounds
-    dx = (maxx - minx) or 1
-    dy = (maxy - miny) or 1
+    dx = maxx - minx
+    dy = maxy - miny
     envelope = box(minx - dx * 0.1, miny - dy * 0.1, maxx + dx * 0.1, maxy + dy * 0.1)
     diagram = voronoi_diagram(multipoint, envelope=envelope)
     cells = [cell.intersection(envelope) for cell in diagram.geoms]

--- a/backend/geolibre_server/geolibre_server/vector_ops.py
+++ b/backend/geolibre_server/geolibre_server/vector_ops.py
@@ -525,6 +525,167 @@ def _aggregate(geojson, overlay, parameters) -> tuple[dict, list[str]]:
     return _to_feature_collection(result), [message]
 
 
+# Largest iteration count Smooth accepts; kept in sync with the client engine.
+_SMOOTH_MAX_ITERATIONS = 10
+
+
+def _chaikin(points: list[list[float]], closed: bool) -> list[list[float]]:
+    """One pass of Chaikin's corner-cutting over a list of ``[x, y]`` positions.
+
+    Each segment A->B contributes two new points at 1/4 and 3/4 along it. For a
+    closed ring the segments wrap (every vertex is cut); for an open line the
+    endpoints are preserved. The arithmetic and ordering mirror the client's
+    ``chaikinOnce`` exactly so both engines return bit-identical coordinates.
+    """
+    n = len(points)
+    if n < (3 if closed else 2):
+        return points
+    out: list[list[float]] = []
+    if closed:
+        for i in range(n):
+            a = points[i]
+            b = points[(i + 1) % n]
+            out.append([a[0] * 0.75 + b[0] * 0.25, a[1] * 0.75 + b[1] * 0.25])
+            out.append([a[0] * 0.25 + b[0] * 0.75, a[1] * 0.25 + b[1] * 0.75])
+    else:
+        out.append([points[0][0], points[0][1]])
+        for i in range(n - 1):
+            a = points[i]
+            b = points[i + 1]
+            out.append([a[0] * 0.75 + b[0] * 0.25, a[1] * 0.75 + b[1] * 0.25])
+            out.append([a[0] * 0.25 + b[0] * 0.75, a[1] * 0.25 + b[1] * 0.75])
+        out.append([points[n - 1][0], points[n - 1][1]])
+    return out
+
+
+def _smooth_line(coords: list[list[float]], iterations: int) -> list[list[float]]:
+    pts = [[p[0], p[1]] for p in coords]
+    for _ in range(iterations):
+        pts = _chaikin(pts, False)
+    return pts
+
+
+def _smooth_ring(ring: list[list[float]], iterations: int) -> list[list[float]]:
+    closed = (
+        len(ring) > 1
+        and ring[0][0] == ring[-1][0]
+        and ring[0][1] == ring[-1][1]
+    )
+    pts = [[p[0], p[1]] for p in (ring[:-1] if closed else ring)]
+    for _ in range(iterations):
+        pts = _chaikin(pts, True)
+    pts.append([pts[0][0], pts[0][1]])
+    return pts
+
+
+def _smooth_geometry(geometry: dict, iterations: int) -> dict:
+    """Smooth one GeoJSON geometry; non-line/polygon geometries pass through."""
+    gtype = geometry.get("type")
+    coords = geometry.get("coordinates")
+    if gtype == "LineString":
+        return {"type": gtype, "coordinates": _smooth_line(coords, iterations)}
+    if gtype == "MultiLineString":
+        return {
+            "type": gtype,
+            "coordinates": [_smooth_line(line, iterations) for line in coords],
+        }
+    if gtype == "Polygon":
+        return {
+            "type": gtype,
+            "coordinates": [_smooth_ring(ring, iterations) for ring in coords],
+        }
+    if gtype == "MultiPolygon":
+        return {
+            "type": gtype,
+            "coordinates": [
+                [_smooth_ring(ring, iterations) for ring in poly] for poly in coords
+            ],
+        }
+    return geometry
+
+
+def _smooth(geojson, overlay, parameters) -> tuple[dict, list[str]]:
+    """Round the corners of line/polygon features with Chaikin's algorithm.
+
+    Works directly on the GeoJSON coordinates (no GeoPandas) so it produces
+    bit-identical output to the client engine, distinct from Simplify's vertex
+    reduction. Points pass through unchanged.
+    """
+    if not geojson or not geojson.get("features"):
+        raise ValueError("Input layer has no features")
+    iterations = int(parameters.get("iterations", 3) or 3)
+    if iterations < 1 or iterations > _SMOOTH_MAX_ITERATIONS:
+        raise ValueError(f"Iterations must be between 1 and {_SMOOTH_MAX_ITERATIONS}")
+    out_features = []
+    smoothed = 0
+    for feature in geojson["features"]:
+        geometry = feature.get("geometry")
+        if not geometry:
+            out_features.append(feature)
+            continue
+        if geometry.get("type") in (
+            "LineString",
+            "MultiLineString",
+            "Polygon",
+            "MultiPolygon",
+        ):
+            smoothed += 1
+        out_features.append(
+            {
+                "type": "Feature",
+                "properties": feature.get("properties") or {},
+                "geometry": _smooth_geometry(geometry, iterations),
+            }
+        )
+    fc = {"type": "FeatureCollection", "features": out_features}
+    return fc, [f"Smoothed {smoothed} feature(s) with {iterations} iteration(s)"]
+
+
+def _voronoi(geojson, overlay, parameters) -> tuple[dict, list[str]]:
+    """Build a Voronoi diagram or Delaunay triangulation from a point layer."""
+    gpd = _import_geopandas()
+    from shapely.geometry import MultiPoint, box  # noqa: PLC0415
+    from shapely.ops import triangulate, voronoi_diagram  # noqa: PLC0415
+
+    kind = str(parameters.get("type", "voronoi") or "voronoi")
+    if kind not in ("voronoi", "delaunay"):
+        raise ValueError(f"Unknown diagram type '{kind}'. Accepted: delaunay, voronoi")
+    gdf = _load_gdf(geojson, "Input layer")
+    # Collect every point, exploding MultiPoint into its members (mirrors the
+    # client's collectPoints), so a MultiPoint layer is handled the same way.
+    points = []
+    for geom in gdf.geometry:
+        if geom is None:
+            continue
+        if geom.geom_type == "Point":
+            points.append(geom)
+        elif geom.geom_type == "MultiPoint":
+            points.extend(list(geom.geoms))
+    if len(points) < 3:
+        raise ValueError("Voronoi / Delaunay needs at least 3 points")
+    multipoint = MultiPoint(points)
+    if kind == "delaunay":
+        triangles = triangulate(multipoint)
+        result = gpd.GeoDataFrame(geometry=triangles, crs=WGS84)
+        message = (
+            f"Delaunay: produced {len(triangles)} triangle(s) "
+            f"from {len(points)} point(s)"
+        )
+        return _to_feature_collection(result), [message]
+    # Clip the (otherwise unbounded outer) cells to the points' bbox expanded by a
+    # 10% margin, matching the client, so they get a finite extent.
+    minx, miny, maxx, maxy = multipoint.bounds
+    dx = (maxx - minx) or 1
+    dy = (maxy - miny) or 1
+    envelope = box(minx - dx * 0.1, miny - dy * 0.1, maxx + dx * 0.1, maxy + dy * 0.1)
+    diagram = voronoi_diagram(multipoint, envelope=envelope)
+    cells = [cell.intersection(envelope) for cell in diagram.geoms]
+    cells = [cell for cell in cells if not cell.is_empty]
+    result = gpd.GeoDataFrame(geometry=cells, crs=WGS84)
+    message = f"Voronoi: produced {len(cells)} cell(s) from {len(points)} point(s)"
+    return _to_feature_collection(result), [message]
+
+
 # tool_id -> handler(geojson, overlay, parameters) -> (feature_collection, messages)
 _DISPATCH: dict[str, Callable[..., tuple[dict, list[str]]]] = {
     "buffer": _buffer,
@@ -543,6 +704,8 @@ _DISPATCH: dict[str, Callable[..., tuple[dict, list[str]]]] = {
     "reproject": _reproject,
     "explode": _explode,
     "aggregate": _aggregate,
+    "smooth": _smooth,
+    "voronoi": _voronoi,
 }
 
 

--- a/backend/geolibre_server/geolibre_server/vector_ops.py
+++ b/backend/geolibre_server/geolibre_server/vector_ops.py
@@ -729,6 +729,13 @@ def _voronoi(geojson, overlay, parameters) -> tuple[dict, list[str]]:
         )
     if kind == "delaunay":
         triangles = triangulate(multipoint)
+        # The bbox guard above catches axis-aligned collinearity; diagonally
+        # collinear points still yield no triangle with area, so report that.
+        if not triangles:
+            raise ValueError(
+                "Could not triangulate — the points are collinear "
+                "(no triangle has area)"
+            )
         result = gpd.GeoDataFrame(geometry=triangles, crs=WGS84)
         message = (
             f"Delaunay: produced {len(triangles)} triangle(s) "
@@ -750,6 +757,10 @@ def _voronoi(geojson, overlay, parameters) -> tuple[dict, list[str]]:
         for cell in cells
         if not cell.is_empty and cell.geom_type in ("Polygon", "MultiPolygon")
     ]
+    if not cells:
+        raise ValueError(
+            "Could not build a Voronoi diagram — the points are collinear"
+        )
     result = gpd.GeoDataFrame(geometry=cells, crs=WGS84)
     message = f"Voronoi: produced {len(cells)} cell(s) from {len(points)} point(s)"
     return _to_feature_collection(result), [message]

--- a/backend/geolibre_server/geolibre_server/vector_ops.py
+++ b/backend/geolibre_server/geolibre_server/vector_ops.py
@@ -574,6 +574,10 @@ def _smooth_ring(ring: list[list[float]], iterations: int) -> list[list[float]]:
     pts = [[p[0], p[1]] for p in (ring[:-1] if closed else ring)]
     for _ in range(iterations):
         pts = _chaikin(pts, True)
+    # An invalid (empty/degenerate) ring leaves pts empty; guard so a crafted or
+    # corrupt payload yields an empty ring rather than an IndexError (500).
+    if not pts:
+        return pts
     pts.append([pts[0][0], pts[0][1]])
     return pts
 
@@ -613,7 +617,17 @@ def _smooth(geojson, overlay, parameters) -> tuple[dict, list[str]]:
     """
     if not geojson or not geojson.get("features"):
         raise ValueError("Input layer has no features")
-    iterations = int(parameters.get("iterations", 3) or 3)
+    # Mirror the client's `Math.round(numberParam(ctx, "iterations", 3))`: a
+    # non-finite/unparseable value falls back to 3, and math.floor(x + 0.5)
+    # rounds half up exactly like JS Math.round (not Python round()'s
+    # banker's rounding), keeping the two engines bit-identical.
+    try:
+        value = float(parameters.get("iterations", 3))
+    except (TypeError, ValueError):
+        value = 3.0
+    if not math.isfinite(value):
+        value = 3.0
+    iterations = math.floor(value + 0.5)
     if iterations < 1 or iterations > _SMOOTH_MAX_ITERATIONS:
         raise ValueError(f"Iterations must be between 1 and {_SMOOTH_MAX_ITERATIONS}")
     out_features = []

--- a/backend/geolibre_server/tests/test_vector.py
+++ b/backend/geolibre_server/tests/test_vector.py
@@ -68,6 +68,8 @@ def test_dispatch_covers_all_tools() -> None:
         "reproject",
         "explode",
         "aggregate",
+        "smooth",
+        "voronoi",
     }
     assert set(_DISPATCH) == expected
 

--- a/backend/geolibre_server/tests/test_vector_ops.py
+++ b/backend/geolibre_server/tests/test_vector_ops.py
@@ -932,12 +932,32 @@ def test_voronoi_unknown_type_raises() -> None:
 
 @requires_geopandas
 def test_voronoi_collinear_points_raise() -> None:
-    # Collinear points (zero-area bounds) yield a degenerate diagram; reject them.
+    # Axis-aligned collinear points (zero-area bounds) are rejected before the
+    # diagram-type branch, for both Voronoi and Delaunay.
     with pytest.raises(ValueError, match="collinear or coincident"):
         run_vector_tool(
             "voronoi",
             _points((0, 0), (0, 5), (0, 10)),
             parameters={"type": "voronoi"},
+        )
+    with pytest.raises(ValueError, match="collinear or coincident"):
+        run_vector_tool(
+            "voronoi",
+            _points((0, 0), (0, 5), (0, 10)),
+            parameters={"type": "delaunay"},
+        )
+
+
+@requires_geopandas
+def test_voronoi_diagonal_collinear_points_raise() -> None:
+    # Diagonally collinear points have a non-zero-area bbox, so they slip past the
+    # bbox guard but produce no triangle/cell with area; the empty-result guard
+    # reports them rather than returning nothing.
+    with pytest.raises(ValueError, match="collinear"):
+        run_vector_tool(
+            "voronoi",
+            _points((0, 0), (1, 1), (2, 2)),
+            parameters={"type": "delaunay"},
         )
 
 

--- a/backend/geolibre_server/tests/test_vector_ops.py
+++ b/backend/geolibre_server/tests/test_vector_ops.py
@@ -783,6 +783,43 @@ def test_smooth_iterations_round_half_up_matches_js() -> None:
     assert messages and "with 4 iteration(s)" in messages[0]
 
 
+def test_smooth_iterations_zero_is_rejected() -> None:
+    # An explicit 0 must hit the range check, not be silently coerced to 3.
+    line = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {"type": "LineString", "coordinates": [[0, 0], [1, 1]]},
+            }
+        ],
+    }
+    with pytest.raises(ValueError, match="between 1 and 10"):
+        run_vector_tool("smooth", line, parameters={"iterations": 0})
+
+
+def test_smooth_preserves_z_coordinates() -> None:
+    line3d = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {
+                    "type": "LineString",
+                    "coordinates": [[0, 0, 100], [0, 10, 200]],
+                },
+            }
+        ],
+    }
+    geojson, _ = run_vector_tool("smooth", line3d, parameters={"iterations": 1})
+    coords = geojson["features"][0]["geometry"]["coordinates"]
+    # Z is interpolated, not dropped: the 1/4 cut point is 100*0.75 + 200*0.25 = 125.
+    assert all(len(c) == 3 for c in coords)
+    assert coords[1] == [0, 2.5, 125]
+
+
 # --- Voronoi / Delaunay ---
 
 
@@ -840,6 +877,17 @@ def test_voronoi_unknown_type_raises() -> None:
             "voronoi",
             _points((0, 0), (10, 0), (0, 10)),
             parameters={"type": "bogus"},
+        )
+
+
+@requires_geopandas
+def test_voronoi_collinear_points_raise() -> None:
+    # Collinear points (zero-area bounds) yield a degenerate diagram; reject them.
+    with pytest.raises(ValueError, match="collinear or coincident"):
+        run_vector_tool(
+            "voronoi",
+            _points((0, 0), (0, 5), (0, 10)),
+            parameters={"type": "voronoi"},
         )
 
 

--- a/backend/geolibre_server/tests/test_vector_ops.py
+++ b/backend/geolibre_server/tests/test_vector_ops.py
@@ -849,6 +849,24 @@ def test_smooth_degenerate_ring_collapses_to_empty() -> None:
     assert geojson["features"][0]["geometry"]["coordinates"] == [[]]
 
 
+def test_smooth_null_feature_raises_value_error() -> None:
+    # A null/non-object feature is bad input: it must raise ValueError (-> 400),
+    # not AttributeError (-> 500).
+    bad = {
+        "type": "FeatureCollection",
+        "features": [
+            None,
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {"type": "LineString", "coordinates": [[0, 0], [1, 1]]},
+            },
+        ],
+    }
+    with pytest.raises(ValueError, match="GeoJSON Feature object"):
+        run_vector_tool("smooth", bad, parameters={"iterations": 1})
+
+
 def test_smooth_preserves_feature_id() -> None:
     line = {
         "type": "FeatureCollection",

--- a/backend/geolibre_server/tests/test_vector_ops.py
+++ b/backend/geolibre_server/tests/test_vector_ops.py
@@ -746,6 +746,43 @@ def test_smooth_rejects_out_of_range_iterations() -> None:
         run_vector_tool("smooth", line, parameters={"iterations": 99})
 
 
+def test_smooth_empty_ring_does_not_crash() -> None:
+    # A malformed polygon with an empty ring must not raise (IndexError -> 500);
+    # the ring stays empty. Mirrors the client guard.
+    malformed = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {"type": "Polygon", "coordinates": [[]]},
+            }
+        ],
+    }
+    geojson, _ = run_vector_tool("smooth", malformed, parameters={"iterations": 2})
+    assert geojson["features"][0]["geometry"]["coordinates"] == [[]]
+
+
+def test_smooth_iterations_round_half_up_matches_js() -> None:
+    # 3.5 rounds up to 4 (JS Math.round semantics), not down to 3 like Python's
+    # banker's round(), keeping the client and Python engines bit-identical.
+    square = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[[0, 0], [0, 10], [10, 10], [10, 0], [0, 0]]],
+                },
+            }
+        ],
+    }
+    _, messages = run_vector_tool("smooth", square, parameters={"iterations": 3.5})
+    assert messages and "with 4 iteration(s)" in messages[0]
+
+
 # --- Voronoi / Delaunay ---
 
 

--- a/backend/geolibre_server/tests/test_vector_ops.py
+++ b/backend/geolibre_server/tests/test_vector_ops.py
@@ -849,6 +849,22 @@ def test_smooth_degenerate_ring_collapses_to_empty() -> None:
     assert geojson["features"][0]["geometry"]["coordinates"] == [[]]
 
 
+def test_smooth_preserves_feature_id() -> None:
+    line = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "id": "abc",
+                "properties": {},
+                "geometry": {"type": "LineString", "coordinates": [[0, 0], [1, 1]]},
+            }
+        ],
+    }
+    geojson, _ = run_vector_tool("smooth", line, parameters={"iterations": 1})
+    assert geojson["features"][0]["id"] == "abc"
+
+
 def test_smooth_preserves_z_coordinates() -> None:
     line3d = {
         "type": "FeatureCollection",

--- a/backend/geolibre_server/tests/test_vector_ops.py
+++ b/backend/geolibre_server/tests/test_vector_ops.py
@@ -799,6 +799,56 @@ def test_smooth_iterations_zero_is_rejected() -> None:
         run_vector_tool("smooth", line, parameters={"iterations": 0})
 
 
+def test_smooth_boolean_iterations_falls_back_to_default() -> None:
+    # A JSON boolean is not a number on the client (it uses the fallback 3), so
+    # the backend must not treat False as 0 (which would error). Keeps parity.
+    line = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {"type": "LineString", "coordinates": [[0, 0], [1, 1]]},
+            }
+        ],
+    }
+    _, messages = run_vector_tool("smooth", line, parameters={"iterations": False})
+    assert messages and "with 3 iteration(s)" in messages[0]
+
+
+def test_smooth_missing_coordinates_does_not_crash() -> None:
+    # A malformed geometry with no coordinates key must not raise (TypeError ->
+    # 500); the coordinate list is treated as empty.
+    malformed = {
+        "type": "FeatureCollection",
+        "features": [
+            {"type": "Feature", "properties": {}, "geometry": {"type": "LineString"}}
+        ],
+    }
+    geojson, _ = run_vector_tool("smooth", malformed, parameters={"iterations": 2})
+    assert geojson["features"][0]["geometry"]["coordinates"] == []
+
+
+def test_smooth_degenerate_ring_collapses_to_empty() -> None:
+    # A 2-vertex (degenerate) ring can't form a valid polygon; it collapses to an
+    # empty ring rather than being re-closed into invalid GeoJSON.
+    degenerate = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[[0, 0], [1, 1], [0, 0]]],
+                },
+            }
+        ],
+    }
+    geojson, _ = run_vector_tool("smooth", degenerate, parameters={"iterations": 3})
+    assert geojson["features"][0]["geometry"]["coordinates"] == [[]]
+
+
 def test_smooth_preserves_z_coordinates() -> None:
     line3d = {
         "type": "FeatureCollection",

--- a/backend/geolibre_server/tests/test_vector_ops.py
+++ b/backend/geolibre_server/tests/test_vector_ops.py
@@ -681,6 +681,131 @@ def test_aggregate_geometry_group_field_raises_clean_error() -> None:
         )
 
 
+# --- Smooth ---
+
+
+def test_smooth_polygon_chaikin_exact_coordinates() -> None:
+    # Smooth is pure coordinate math (no GeoPandas), so it runs unconditionally
+    # and must match the client engine bit-for-bit on a known case.
+    square = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"name": "s"},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [[0, 0], [0, 10], [10, 10], [10, 0], [0, 0]],
+                    ],
+                },
+            }
+        ],
+    }
+    geojson, messages = run_vector_tool("smooth", square, parameters={"iterations": 1})
+    ring = geojson["features"][0]["geometry"]["coordinates"][0]
+    # One Chaikin pass on the 4-vertex ring -> 8 cut points + the closing vertex.
+    assert len(ring) == 9
+    assert ring[0] == ring[-1]
+    # The first cut point is 1/4 along the first segment ([0,0] -> [0,10]).
+    assert ring[0] == [0, 2.5]
+    assert geojson["features"][0]["geometry"]["type"] == "Polygon"
+    assert geojson["features"][0]["properties"]["name"] == "s"
+    assert messages and "Smoothed 1 feature" in messages[0]
+
+
+def test_smooth_passes_points_through_unchanged() -> None:
+    pts = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {"type": "Point", "coordinates": [1, 2]},
+            }
+        ],
+    }
+    geojson, messages = run_vector_tool("smooth", pts, parameters={"iterations": 3})
+    assert geojson["features"][0]["geometry"] == {"type": "Point", "coordinates": [1, 2]}
+    # No line/polygon features were smoothed.
+    assert messages and "Smoothed 0 feature" in messages[0]
+
+
+def test_smooth_rejects_out_of_range_iterations() -> None:
+    line = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {"type": "LineString", "coordinates": [[0, 0], [1, 1]]},
+            }
+        ],
+    }
+    with pytest.raises(ValueError, match="between 1 and 10"):
+        run_vector_tool("smooth", line, parameters={"iterations": 99})
+
+
+# --- Voronoi / Delaunay ---
+
+
+def _points(*coords: tuple[float, float]) -> dict:
+    return {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {"type": "Point", "coordinates": [x, y]},
+            }
+            for x, y in coords
+        ],
+    }
+
+
+@requires_geopandas
+def test_voronoi_produces_polygon_cells() -> None:
+    geojson, messages = run_vector_tool(
+        "voronoi",
+        _points((0, 0), (10, 0), (0, 10), (10, 10), (5, 5)),
+        parameters={"type": "voronoi"},
+    )
+    assert len(geojson["features"]) > 0
+    assert all(
+        f["geometry"]["type"] in ("Polygon", "MultiPolygon")
+        for f in geojson["features"]
+    )
+    assert messages and "Voronoi" in messages[0]
+
+
+@requires_geopandas
+def test_delaunay_produces_triangles() -> None:
+    geojson, messages = run_vector_tool(
+        "voronoi",
+        _points((0, 0), (10, 0), (0, 10), (10, 10), (5, 5)),
+        parameters={"type": "delaunay"},
+    )
+    assert len(geojson["features"]) > 0
+    assert all(f["geometry"]["type"] == "Polygon" for f in geojson["features"])
+    assert messages and "Delaunay" in messages[0]
+
+
+@requires_geopandas
+def test_voronoi_requires_three_points() -> None:
+    with pytest.raises(ValueError, match="at least 3 points"):
+        run_vector_tool("voronoi", _points((0, 0), (1, 1)), parameters={})
+
+
+@requires_geopandas
+def test_voronoi_unknown_type_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown diagram type"):
+        run_vector_tool(
+            "voronoi",
+            _points((0, 0), (10, 0), (0, 10)),
+            parameters={"type": "bogus"},
+        )
+
+
 @requires_geopandas
 def test_json_wrapper_round_trips() -> None:
     payload = json.dumps(

--- a/e2e/pwa.spec.ts
+++ b/e2e/pwa.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 /**
  * Validates the web build's PWA/offline support (issue #274):
@@ -61,12 +61,26 @@ test("registers a service worker and serves the shell offline after first visit"
     timeout: 30_000,
   });
 
+  // The service worker writes its CacheFirst runtime caches asynchronously,
+  // *after* the page's fetch for a chunk resolves — so the map canvas can be
+  // visible (the ~13 MB MapLibre chunk ran in-page) while the SW is still
+  // persisting that chunk. Going offline in that window leaves the chunk
+  // uncached, so the offline reload can't boot the map. Wait for all first-load
+  // requests to finish, then for the Cache Storage entry count to stop growing,
+  // so every runtime-cached chunk is durably stored before we drop the network.
+  await page.waitForLoadState("networkidle");
+  await waitForCacheStorageToSettle(page);
+
   // Drop the network and reload: the precached shell plus the runtime-cached
   // MapLibre chunk must still bring the app up with no connectivity.
   await context.setOffline(true);
   try {
     await page.reload();
-    await expect(page.getByTestId("map-canvas")).toBeVisible();
+    // The offline cold boot re-parses/executes every chunk from cache, so give
+    // the canvas the same 30s budget the warm boot above gets.
+    await expect(page.getByTestId("map-canvas")).toBeVisible({
+      timeout: 30_000,
+    });
     await expect(page.locator(".maplibregl-canvas")).toBeVisible({
       timeout: 30_000,
     });
@@ -74,3 +88,29 @@ test("registers a service worker and serves the shell offline after first visit"
     await context.setOffline(false);
   }
 });
+
+/**
+ * Wait until the service worker's Cache Storage stops growing, i.e. it has
+ * finished persisting the runtime-cached chunks the first load pulled in.
+ * CacheFirst writes happen asynchronously after the page's fetch resolves, so
+ * "canvas visible" alone does not guarantee the chunk is cached; polling the
+ * total entry count until two consecutive reads match (and it is non-zero)
+ * gives a deterministic "caches settled" signal before we go offline.
+ */
+async function waitForCacheStorageToSettle(page: Page): Promise<void> {
+  await page.waitForFunction(
+    async () => {
+      const w = window as unknown as { __prevCacheEntryCount?: number };
+      const names = await caches.keys();
+      let count = 0;
+      for (const name of names) {
+        count += (await (await caches.open(name)).keys()).length;
+      }
+      const previous = w.__prevCacheEntryCount ?? -1;
+      w.__prevCacheEntryCount = count;
+      return count > 0 && count === previous;
+    },
+    undefined,
+    { timeout: 30_000, polling: 1000 },
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23542,7 +23542,9 @@
         "@turf/helpers": "^7.3.5",
         "@turf/intersect": "^7.3.5",
         "@turf/simplify": "^7.3.5",
-        "@turf/union": "^7.3.5"
+        "@turf/tin": "^7.3.5",
+        "@turf/union": "^7.3.5",
+        "@turf/voronoi": "^7.3.5"
       },
       "devDependencies": {
         "@types/geojson": "^7946.0.16",

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -53,6 +53,9 @@ export type VectorToolKind =
   | "reproject"
   | "explode"
   | "aggregate"
+  | "smooth"
+  | "grid"
+  | "voronoi"
   | "h3-grid"
   | "h3-bin-points";
 

--- a/packages/processing/package.json
+++ b/packages/processing/package.json
@@ -11,6 +11,8 @@
   "dependencies": {
     "@geolibre/core": "*",
     "@turf/bbox": "^7.3.5",
+    "@turf/tin": "^7.3.5",
+    "@turf/voronoi": "^7.3.5",
     "@turf/boolean-contains": "^7.3.5",
     "@turf/boolean-intersects": "^7.3.5",
     "@turf/boolean-within": "^7.3.5",

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -8,16 +8,22 @@ import simplify from "@turf/simplify";
 import intersect from "@turf/intersect";
 import difference from "@turf/difference";
 import union from "@turf/union";
+import voronoiDiagram from "@turf/voronoi";
+import tin from "@turf/tin";
+import bbox from "@turf/bbox";
 import booleanIntersects from "@turf/boolean-intersects";
 import booleanContains from "@turf/boolean-contains";
 import booleanWithin from "@turf/boolean-within";
 import { featureCollection } from "@turf/helpers";
 import type {
+  BBox,
   Feature,
   FeatureCollection,
   GeoJsonProperties,
   Geometry,
+  Point,
   Polygon,
+  Position,
   MultiPolygon,
 } from "geojson";
 import type { GeoLibreLayer } from "@geolibre/core";
@@ -1239,6 +1245,437 @@ export const aggregateTool: ProcessingAlgorithm = {
   },
 };
 
+/** Largest iteration count Smooth accepts; kept in sync with the backend. */
+const SMOOTH_MAX_ITERATIONS = 10;
+
+/**
+ * One pass of Chaikin's corner-cutting algorithm over a list of positions.
+ * Each segment A→B contributes two new points at 1/4 and 3/4 of the way along
+ * it. For a closed ring the segments wrap (so every vertex is cut); for an open
+ * line the first and last endpoints are preserved. Operates on [x, y] only.
+ *
+ * The exact same arithmetic (and ordering) runs in the Python backend's
+ * ``_chaikin`` so the "Sidecar (GeoPandas)" / "Python (Pyodide)" engines return
+ * bit-identical coordinates.
+ */
+function chaikinOnce(points: Position[], closed: boolean): Position[] {
+  const n = points.length;
+  if (n < (closed ? 3 : 2)) return points;
+  const out: Position[] = [];
+  if (closed) {
+    for (let i = 0; i < n; i += 1) {
+      const a = points[i];
+      const b = points[(i + 1) % n];
+      out.push([a[0] * 0.75 + b[0] * 0.25, a[1] * 0.75 + b[1] * 0.25]);
+      out.push([a[0] * 0.25 + b[0] * 0.75, a[1] * 0.25 + b[1] * 0.75]);
+    }
+  } else {
+    out.push([points[0][0], points[0][1]]);
+    for (let i = 0; i < n - 1; i += 1) {
+      const a = points[i];
+      const b = points[i + 1];
+      out.push([a[0] * 0.75 + b[0] * 0.25, a[1] * 0.75 + b[1] * 0.25]);
+      out.push([a[0] * 0.25 + b[0] * 0.75, a[1] * 0.25 + b[1] * 0.75]);
+    }
+    out.push([points[n - 1][0], points[n - 1][1]]);
+  }
+  return out;
+}
+
+/** Smooth an open line's coordinates with `iterations` Chaikin passes. */
+function smoothLine(coords: Position[], iterations: number): Position[] {
+  let pts: Position[] = coords.map((p) => [p[0], p[1]]);
+  for (let k = 0; k < iterations; k += 1) pts = chaikinOnce(pts, false);
+  return pts;
+}
+
+/** Smooth a closed polygon ring, keeping it closed (first === last). */
+function smoothRing(ring: Position[], iterations: number): Position[] {
+  const closed =
+    ring.length > 1 &&
+    ring[0][0] === ring[ring.length - 1][0] &&
+    ring[0][1] === ring[ring.length - 1][1];
+  let pts: Position[] = (closed ? ring.slice(0, -1) : ring).map((p) => [
+    p[0],
+    p[1],
+  ]);
+  for (let k = 0; k < iterations; k += 1) pts = chaikinOnce(pts, true);
+  pts.push([pts[0][0], pts[0][1]]);
+  return pts;
+}
+
+/** Apply Chaikin smoothing to a single geometry; points pass through unchanged. */
+function smoothGeometry(geometry: Geometry, iterations: number): Geometry {
+  switch (geometry.type) {
+    case "LineString":
+      return {
+        type: "LineString",
+        coordinates: smoothLine(geometry.coordinates, iterations),
+      };
+    case "MultiLineString":
+      return {
+        type: "MultiLineString",
+        coordinates: geometry.coordinates.map((l) => smoothLine(l, iterations)),
+      };
+    case "Polygon":
+      return {
+        type: "Polygon",
+        coordinates: geometry.coordinates.map((r) => smoothRing(r, iterations)),
+      };
+    case "MultiPolygon":
+      return {
+        type: "MultiPolygon",
+        coordinates: geometry.coordinates.map((poly) =>
+          poly.map((r) => smoothRing(r, iterations)),
+        ),
+      };
+    default:
+      return geometry;
+  }
+}
+
+export const smoothTool: ProcessingAlgorithm = {
+  id: "smooth",
+  name: "Smooth",
+  description:
+    "Round the corners of line and polygon features with Chaikin's algorithm (adds vertices), distinct from Simplify's vertex reduction. Points pass through unchanged.",
+  group: "Geometry",
+  supportsSidecar: true,
+  parameters: [
+    {
+      id: "layer",
+      label: "Input layer",
+      type: "layer",
+      required: true,
+      geometryFilter: ["line", "polygon"],
+    },
+    {
+      id: "iterations",
+      label: "Iterations",
+      type: "number",
+      default: 3,
+      min: 1,
+      max: SMOOTH_MAX_ITERATIONS,
+      step: 1,
+      description: "More iterations give a smoother result (1-10).",
+    },
+  ],
+  run: (ctx) => {
+    const fc = requireFeatures(ctx);
+    if (!fc) return;
+    const iterations = Math.round(numberParam(ctx, "iterations", 3));
+    if (iterations < 1 || iterations > SMOOTH_MAX_ITERATIONS) {
+      ctx.log(`Error: iterations must be between 1 and ${SMOOTH_MAX_ITERATIONS}`);
+      return;
+    }
+    let smoothed = 0;
+    const features: Feature[] = fc.features.map((feature) => {
+      const geometry = feature.geometry;
+      if (!geometry) return feature;
+      const isSmoothable =
+        isFamily(geometry, "line") || isFamily(geometry, "polygon");
+      if (isSmoothable) smoothed += 1;
+      return {
+        type: "Feature",
+        properties: feature.properties ?? {},
+        geometry: smoothGeometry(geometry, iterations),
+      };
+    });
+    ctx.log(
+      `Smoothed ${smoothed} feature(s) with ${iterations} iteration(s)`,
+    );
+    ctx.addResultLayer?.("Smooth", featureCollection(features));
+  },
+};
+
+/** Hard ceiling on grid cells so a tiny cell size cannot freeze the tab. */
+const GRID_HARD_CAP = 1_000_000;
+
+export const gridTool: ProcessingAlgorithm = {
+  id: "grid",
+  name: "Regular grid",
+  description:
+    "Generate a regular rectangular grid (fishnet) of cells over an extent. Source: the current map view, a layer's extent, or a manual bounding box.",
+  group: "Geometry",
+  parameters: [
+    {
+      id: "source",
+      label: "Extent source",
+      type: "select",
+      default: "viewport",
+      options: [
+        { value: "viewport", label: "Map viewport" },
+        { value: "layer", label: "Layer extent" },
+        { value: "bbox", label: "Manual bounding box" },
+      ],
+    },
+    {
+      id: "layer",
+      label: "Input layer",
+      type: "layer",
+      required: true,
+      visibleWhen: { param: "source", in: ["layer"] },
+    },
+    {
+      id: "west",
+      label: "West (min lon)",
+      type: "number",
+      required: true,
+      min: -180,
+      max: 180,
+      visibleWhen: { param: "source", in: ["bbox"] },
+    },
+    {
+      id: "south",
+      label: "South (min lat)",
+      type: "number",
+      required: true,
+      min: -90,
+      max: 90,
+      visibleWhen: { param: "source", in: ["bbox"] },
+    },
+    {
+      id: "east",
+      label: "East (max lon)",
+      type: "number",
+      required: true,
+      min: -180,
+      max: 180,
+      visibleWhen: { param: "source", in: ["bbox"] },
+    },
+    {
+      id: "north",
+      label: "North (max lat)",
+      type: "number",
+      required: true,
+      min: -90,
+      max: 90,
+      visibleWhen: { param: "source", in: ["bbox"] },
+    },
+    {
+      id: "cell_width",
+      label: "Cell width (degrees)",
+      type: "number",
+      required: true,
+      default: 1,
+      min: 0,
+      step: 0.1,
+    },
+    {
+      id: "cell_height",
+      label: "Cell height (degrees)",
+      type: "number",
+      min: 0,
+      step: 0.1,
+      description: "Leave blank to match the cell width.",
+    },
+    {
+      id: "cell_type",
+      label: "Cell type",
+      type: "select",
+      default: "polygon",
+      options: [
+        { value: "polygon", label: "Rectangles" },
+        { value: "point", label: "Points (cell centers)" },
+      ],
+    },
+  ],
+  run: (ctx) => {
+    const source = (ctx.parameters.source as string) || "viewport";
+    let bounds: [number, number, number, number] | null = null;
+    if (source === "viewport") {
+      const view = ctx.viewportBounds?.();
+      if (!view) {
+        ctx.log("Error: map viewport is unavailable");
+        return;
+      }
+      if (view[0] >= view[2]) {
+        ctx.log(
+          "Error: the map view crosses the antimeridian; pan so it doesn't wrap +/-180, or use a manual bounding box",
+        );
+        return;
+      }
+      bounds = view;
+    } else if (source === "bbox") {
+      const west = numberParam(ctx, "west", NaN);
+      const south = numberParam(ctx, "south", NaN);
+      const east = numberParam(ctx, "east", NaN);
+      const north = numberParam(ctx, "north", NaN);
+      if ([west, south, east, north].some((n) => !Number.isFinite(n))) {
+        ctx.log("Error: enter numeric west, south, east, and north values");
+        return;
+      }
+      if (west >= east || south >= north) {
+        ctx.log("Error: bounding box must have west < east and south < north");
+        return;
+      }
+      bounds = [west, south, east, north];
+    } else {
+      const layer = getLayer(ctx, "layer");
+      if (!layer?.geojson?.features?.length) {
+        ctx.log('Error: parameter "layer" has no GeoJSON features');
+        return;
+      }
+      bounds = bbox(layer.geojson) as [number, number, number, number];
+    }
+
+    const cellWidth = numberParam(ctx, "cell_width", NaN);
+    if (!Number.isFinite(cellWidth) || cellWidth <= 0) {
+      ctx.log("Error: cell width must be greater than 0");
+      return;
+    }
+    let cellHeight = numberParam(ctx, "cell_height", NaN);
+    if (!Number.isFinite(cellHeight) || cellHeight <= 0) cellHeight = cellWidth;
+
+    const [w, s, e, n] = bounds;
+    const cols = Math.ceil((e - w) / cellWidth);
+    const rows = Math.ceil((n - s) / cellHeight);
+    const total = cols * rows;
+    if (total > GRID_HARD_CAP) {
+      ctx.log(
+        `Error: this extent and cell size would generate ${total.toLocaleString()} cells (cap ${GRID_HARD_CAP.toLocaleString()}); use a larger cell size.`,
+      );
+      return;
+    }
+    const asPoints = (ctx.parameters.cell_type as string) === "point";
+    const features: Feature[] = [];
+    for (let col = 0; col < cols; col += 1) {
+      const x0 = w + col * cellWidth;
+      const x1 = Math.min(x0 + cellWidth, e);
+      for (let row = 0; row < rows; row += 1) {
+        const y0 = s + row * cellHeight;
+        const y1 = Math.min(y0 + cellHeight, n);
+        const properties = { col, row };
+        if (asPoints) {
+          features.push({
+            type: "Feature",
+            properties,
+            geometry: {
+              type: "Point",
+              coordinates: [(x0 + x1) / 2, (y0 + y1) / 2],
+            },
+          });
+        } else {
+          features.push({
+            type: "Feature",
+            properties,
+            geometry: {
+              type: "Polygon",
+              coordinates: [
+                [
+                  [x0, y0],
+                  [x1, y0],
+                  [x1, y1],
+                  [x0, y1],
+                  [x0, y0],
+                ],
+              ],
+            },
+          });
+        }
+      }
+    }
+    ctx.log(
+      `Created a ${cols}x${rows} grid (${features.length} cell(s))`,
+    );
+    ctx.addResultLayer?.("Regular grid", featureCollection(features));
+  },
+};
+
+/** Collect every Point (exploding MultiPoint) from a collection as Point features. */
+function collectPoints(fc: FeatureCollection): Feature<Point>[] {
+  const points: Feature<Point>[] = [];
+  for (const feature of fc.features) {
+    const geometry = feature.geometry;
+    if (geometry?.type === "Point") {
+      points.push(feature as Feature<Point>);
+    } else if (geometry?.type === "MultiPoint") {
+      for (const coordinates of geometry.coordinates) {
+        points.push({
+          type: "Feature",
+          properties: feature.properties ?? {},
+          geometry: { type: "Point", coordinates },
+        });
+      }
+    }
+  }
+  return points;
+}
+
+export const voronoiTool: ProcessingAlgorithm = {
+  id: "voronoi",
+  name: "Voronoi / Delaunay",
+  description:
+    "Build a Voronoi diagram (one polygon per point, clipped to the points' extent) or a Delaunay triangulation from a point layer.",
+  group: "Geometry",
+  supportsSidecar: true,
+  parameters: [
+    {
+      id: "layer",
+      label: "Input point layer",
+      type: "layer",
+      required: true,
+      geometryFilter: ["point"],
+    },
+    {
+      id: "type",
+      label: "Diagram",
+      type: "select",
+      default: "voronoi",
+      options: [
+        { value: "voronoi", label: "Voronoi polygons" },
+        { value: "delaunay", label: "Delaunay triangles" },
+      ],
+    },
+  ],
+  run: (ctx) => {
+    const fc = requireFeatures(ctx);
+    if (!fc) return;
+    const kind = (ctx.parameters.type as string) || "voronoi";
+    if (kind !== "voronoi" && kind !== "delaunay") {
+      ctx.log(`Error: unknown diagram type '${kind}'`);
+      return;
+    }
+    const points = collectPoints(fc);
+    if (points.length < 3) {
+      ctx.log("Error: Voronoi / Delaunay needs at least 3 points");
+      return;
+    }
+    const pointsFc = featureCollection(points);
+    if (kind === "delaunay") {
+      const result = tin(pointsFc);
+      ctx.log(
+        `Delaunay: produced ${result.features.length} triangle(s) from ${points.length} point(s)`,
+      );
+      ctx.addResultLayer?.("Delaunay", result);
+      return;
+    }
+    // Clip the Voronoi cells to the points' bounding box expanded by a 10% margin,
+    // matching the backend, so the outer (otherwise unbounded) cells get a finite
+    // extent rather than spanning the whole world.
+    const [minX, minY, maxX, maxY] = bbox(pointsFc) as [
+      number,
+      number,
+      number,
+      number,
+    ];
+    const dx = maxX - minX || 1;
+    const dy = maxY - minY || 1;
+    const clip: BBox = [
+      minX - dx * 0.1,
+      minY - dy * 0.1,
+      maxX + dx * 0.1,
+      maxY + dy * 0.1,
+    ];
+    const result = voronoiDiagram(pointsFc, { bbox: clip });
+    const cells = (result.features ?? []).filter((f) => Boolean(f?.geometry));
+    ctx.log(
+      `Voronoi: produced ${cells.length} cell(s) from ${points.length} point(s)`,
+    );
+    ctx.addResultLayer?.("Voronoi", featureCollection(cells));
+  },
+};
+
 export const VECTOR_TOOLS: ProcessingAlgorithm[] = [
   bufferTool,
   centroidsTool,
@@ -1256,6 +1693,9 @@ export const VECTOR_TOOLS: ProcessingAlgorithm[] = [
   reprojectTool,
   explodeTool,
   aggregateTool,
+  smoothTool,
+  gridTool,
+  voronoiTool,
   createH3GridTool,
   binPointsTool,
 ];

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -1300,6 +1300,9 @@ function smoothRing(ring: Position[], iterations: number): Position[] {
     p[1],
   ]);
   for (let k = 0; k < iterations; k += 1) pts = chaikinOnce(pts, true);
+  // An invalid (empty/degenerate) ring leaves pts empty; guard so a malformed
+  // feature yields an empty ring rather than throwing on pts[0].
+  if (pts.length === 0) return pts;
   pts.push([pts[0][0], pts[0][1]]);
   return pts;
 }
@@ -1338,7 +1341,7 @@ export const smoothTool: ProcessingAlgorithm = {
   id: "smooth",
   name: "Smooth",
   description:
-    "Round the corners of line and polygon features with Chaikin's algorithm (adds vertices), distinct from Simplify's vertex reduction. Points pass through unchanged.",
+    "Round the corners of line and polygon features with Chaikin's algorithm (adds vertices), distinct from Simplify's vertex reduction. Points pass through unchanged. Z/elevation coordinates are not preserved.",
   group: "Geometry",
   supportsSidecar: true,
   parameters: [
@@ -1458,14 +1461,14 @@ export const gridTool: ProcessingAlgorithm = {
       type: "number",
       required: true,
       default: 1,
-      min: 0,
+      min: 0.0001,
       step: 0.1,
     },
     {
       id: "cell_height",
       label: "Cell height (degrees)",
       type: "number",
-      min: 0,
+      min: 0.0001,
       step: 0.1,
       description: "Leave blank to match the cell width.",
     },

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -1525,9 +1525,9 @@ export const gridTool: ProcessingAlgorithm = {
         ctx.log("Error: map viewport is unavailable");
         return;
       }
-      if (view[0] >= view[2]) {
+      if (view[0] >= view[2] || view[1] >= view[3]) {
         ctx.log(
-          "Error: the map view crosses the antimeridian; pan so it doesn't wrap +/-180, or use a manual bounding box",
+          "Error: the map view is empty or crosses the antimeridian; pan so it doesn't wrap +/-180, or use a manual bounding box",
         );
         return;
       }
@@ -1742,7 +1742,13 @@ export const voronoiTool: ProcessingAlgorithm = {
       maxY + dy * 0.1,
     ];
     const result = voronoiDiagram(pointsFc, { bbox: clip });
-    const cells = (result.features ?? []).filter((f) => Boolean(f?.geometry));
+    // Keep only polygonal cells, matching the backend: clipping a cell whose
+    // edge coincides with the bbox can in principle yield a degenerate
+    // non-polygon geometry.
+    const cells = (result.features ?? []).filter(
+      (f) =>
+        f?.geometry?.type === "Polygon" || f?.geometry?.type === "MultiPolygon",
+    );
     if (cells.length === 0) {
       ctx.log(
         "Error: could not build a Voronoi diagram — the points are collinear",

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -1313,9 +1313,10 @@ function smoothRing(ring: Position[], iterations: number): Position[] {
     p.slice(0, 3),
   );
   for (let k = 0; k < iterations; k += 1) pts = chaikinOnce(pts, true);
-  // An invalid (empty/degenerate) ring leaves pts empty; guard so a malformed
-  // feature yields an empty ring rather than throwing on pts[0].
-  if (pts.length === 0) return pts;
+  // A ring needs >= 3 distinct vertices to form a valid polygon; an empty or
+  // otherwise degenerate (1-2 vertex) ring collapses to an empty ring rather
+  // than being re-closed into invalid GeoJSON.
+  if (pts.length < 3) return [];
   pts.push(pts[0].slice());
   return pts;
 }
@@ -1544,6 +1545,16 @@ export const gridTool: ProcessingAlgorithm = {
         return;
       }
       bounds = bbox(layer.geojson) as [number, number, number, number];
+      // Guard the layer path like the viewport/bbox paths: a zero-area extent
+      // (e.g. a single-point layer, west === east) or an antimeridian-spanning
+      // one (west > east) would otherwise make cols/rows zero or negative,
+      // slipping past the cell cap into an empty, misleadingly-logged result.
+      if (bounds[0] >= bounds[2] || bounds[1] >= bounds[3]) {
+        ctx.log(
+          "Error: the layer's extent is empty or spans the antimeridian; use a manual bounding box instead",
+        );
+        return;
+      }
     }
 
     const cellWidth = numberParam(ctx, "cell_width", NaN);

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -1401,10 +1401,18 @@ export const smoothTool: ProcessingAlgorithm = {
       const isSmoothable =
         isFamily(geometry, "line") ||
         isFamily(geometry, "polygon") ||
-        geometry.type === "GeometryCollection";
+        // A GeometryCollection only counts if it actually has a line/polygon
+        // member; a points-only collection passes through unchanged.
+        (geometry.type === "GeometryCollection" &&
+          geometry.geometries.some(
+            (g) => isFamily(g, "line") || isFamily(g, "polygon"),
+          ));
       if (isSmoothable) smoothed += 1;
       return {
         type: "Feature",
+        // Preserve the feature id (the GeoPandas handlers lose it through the
+        // GeoDataFrame round-trip, but this raw-JSON path can keep it cheaply).
+        ...(feature.id !== undefined ? { id: feature.id } : {}),
         properties: feature.properties ?? {},
         geometry: smoothGeometry(geometry, iterations),
       };

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -1249,10 +1249,24 @@ export const aggregateTool: ProcessingAlgorithm = {
 const SMOOTH_MAX_ITERATIONS = 10;
 
 /**
+ * Interpolate the point a fraction `wa` of the way from `a` toward `b` (so
+ * `wa = 0.75` lands closer to `a`). Z/elevation is carried through and
+ * interpolated when both endpoints are 3D; otherwise the result is 2D.
+ */
+function chaikinPoint(a: Position, b: Position, wa: number): Position {
+  const wb = 1 - wa;
+  const x = a[0] * wa + b[0] * wb;
+  const y = a[1] * wa + b[1] * wb;
+  if (a.length > 2 && b.length > 2) return [x, y, a[2] * wa + b[2] * wb];
+  return [x, y];
+}
+
+/**
  * One pass of Chaikin's corner-cutting algorithm over a list of positions.
  * Each segment A→B contributes two new points at 1/4 and 3/4 of the way along
  * it. For a closed ring the segments wrap (so every vertex is cut); for an open
- * line the first and last endpoints are preserved. Operates on [x, y] only.
+ * line the first and last endpoints are preserved. Z is preserved/interpolated
+ * (see {@link chaikinPoint}); extra coordinate dimensions are dropped.
  *
  * The exact same arithmetic (and ordering) runs in the Python backend's
  * ``_chaikin`` so the "Sidecar (GeoPandas)" / "Python (Pyodide)" engines return
@@ -1266,25 +1280,25 @@ function chaikinOnce(points: Position[], closed: boolean): Position[] {
     for (let i = 0; i < n; i += 1) {
       const a = points[i];
       const b = points[(i + 1) % n];
-      out.push([a[0] * 0.75 + b[0] * 0.25, a[1] * 0.75 + b[1] * 0.25]);
-      out.push([a[0] * 0.25 + b[0] * 0.75, a[1] * 0.25 + b[1] * 0.75]);
+      out.push(chaikinPoint(a, b, 0.75));
+      out.push(chaikinPoint(a, b, 0.25));
     }
   } else {
-    out.push([points[0][0], points[0][1]]);
+    out.push(points[0].slice(0, 3));
     for (let i = 0; i < n - 1; i += 1) {
       const a = points[i];
       const b = points[i + 1];
-      out.push([a[0] * 0.75 + b[0] * 0.25, a[1] * 0.75 + b[1] * 0.25]);
-      out.push([a[0] * 0.25 + b[0] * 0.75, a[1] * 0.25 + b[1] * 0.75]);
+      out.push(chaikinPoint(a, b, 0.75));
+      out.push(chaikinPoint(a, b, 0.25));
     }
-    out.push([points[n - 1][0], points[n - 1][1]]);
+    out.push(points[n - 1].slice(0, 3));
   }
   return out;
 }
 
 /** Smooth an open line's coordinates with `iterations` Chaikin passes. */
 function smoothLine(coords: Position[], iterations: number): Position[] {
-  let pts: Position[] = coords.map((p) => [p[0], p[1]]);
+  let pts: Position[] = coords.map((p) => p.slice(0, 3));
   for (let k = 0; k < iterations; k += 1) pts = chaikinOnce(pts, false);
   return pts;
 }
@@ -1295,15 +1309,14 @@ function smoothRing(ring: Position[], iterations: number): Position[] {
     ring.length > 1 &&
     ring[0][0] === ring[ring.length - 1][0] &&
     ring[0][1] === ring[ring.length - 1][1];
-  let pts: Position[] = (closed ? ring.slice(0, -1) : ring).map((p) => [
-    p[0],
-    p[1],
-  ]);
+  let pts: Position[] = (closed ? ring.slice(0, -1) : ring).map((p) =>
+    p.slice(0, 3),
+  );
   for (let k = 0; k < iterations; k += 1) pts = chaikinOnce(pts, true);
   // An invalid (empty/degenerate) ring leaves pts empty; guard so a malformed
   // feature yields an empty ring rather than throwing on pts[0].
   if (pts.length === 0) return pts;
-  pts.push([pts[0][0], pts[0][1]]);
+  pts.push(pts[0].slice());
   return pts;
 }
 
@@ -1332,6 +1345,15 @@ function smoothGeometry(geometry: Geometry, iterations: number): Geometry {
           poly.map((r) => smoothRing(r, iterations)),
         ),
       };
+    case "GeometryCollection":
+      // Recurse so line/polygon members are smoothed instead of silently
+      // passing through; point members fall to the default below.
+      return {
+        type: "GeometryCollection",
+        geometries: geometry.geometries.map((g) =>
+          smoothGeometry(g, iterations),
+        ),
+      };
     default:
       return geometry;
   }
@@ -1341,7 +1363,7 @@ export const smoothTool: ProcessingAlgorithm = {
   id: "smooth",
   name: "Smooth",
   description:
-    "Round the corners of line and polygon features with Chaikin's algorithm (adds vertices), distinct from Simplify's vertex reduction. Points pass through unchanged. Z/elevation coordinates are not preserved.",
+    "Round the corners of line and polygon features with Chaikin's algorithm (adds vertices), distinct from Simplify's vertex reduction. Z/elevation is preserved; points pass through unchanged.",
   group: "Geometry",
   supportsSidecar: true,
   parameters: [
@@ -1376,7 +1398,9 @@ export const smoothTool: ProcessingAlgorithm = {
       const geometry = feature.geometry;
       if (!geometry) return feature;
       const isSmoothable =
-        isFamily(geometry, "line") || isFamily(geometry, "polygon");
+        isFamily(geometry, "line") ||
+        isFamily(geometry, "polygon") ||
+        geometry.type === "GeometryCollection";
       if (isSmoothable) smoothed += 1;
       return {
         type: "Feature",
@@ -1527,8 +1551,18 @@ export const gridTool: ProcessingAlgorithm = {
       ctx.log("Error: cell width must be greater than 0");
       return;
     }
+    const rawHeight = ctx.parameters.cell_height;
     let cellHeight = numberParam(ctx, "cell_height", NaN);
-    if (!Number.isFinite(cellHeight) || cellHeight <= 0) cellHeight = cellWidth;
+    if (!Number.isFinite(cellHeight) || cellHeight <= 0) {
+      // A blank field intentionally means "match the cell width"; only note it
+      // when the user actually entered an invalid (non-positive/non-numeric) value.
+      if (rawHeight !== undefined && rawHeight !== null && rawHeight !== "") {
+        ctx.log(
+          `Note: cell height '${rawHeight}' is not a positive number; using the cell width (${cellWidth}°)`,
+        );
+      }
+      cellHeight = cellWidth;
+    }
 
     const [w, s, e, n] = bounds;
     const cols = Math.ceil((e - w) / cellWidth);
@@ -1645,6 +1679,21 @@ export const voronoiTool: ProcessingAlgorithm = {
       return;
     }
     const pointsFc = featureCollection(points);
+    // Both diagrams are undefined for collinear/coincident points (a zero-area
+    // bounding box). Turf's tin/voronoi would throw or return nothing; bail with
+    // a clear message instead. Mirrors the backend guard.
+    const [minX, minY, maxX, maxY] = bbox(pointsFc) as [
+      number,
+      number,
+      number,
+      number,
+    ];
+    if (minX === maxX || minY === maxY) {
+      ctx.log(
+        "Error: the points are collinear or coincident; Voronoi / Delaunay needs points that span an area",
+      );
+      return;
+    }
     if (kind === "delaunay") {
       const result = tin(pointsFc);
       ctx.log(
@@ -1656,14 +1705,8 @@ export const voronoiTool: ProcessingAlgorithm = {
     // Clip the Voronoi cells to the points' bounding box expanded by a 10% margin,
     // matching the backend, so the outer (otherwise unbounded) cells get a finite
     // extent rather than spanning the whole world.
-    const [minX, minY, maxX, maxY] = bbox(pointsFc) as [
-      number,
-      number,
-      number,
-      number,
-    ];
-    const dx = maxX - minX || 1;
-    const dy = maxY - minY || 1;
+    const dx = maxX - minX;
+    const dy = maxY - minY;
     const clip: BBox = [
       minX - dx * 0.1,
       minY - dy * 0.1,

--- a/packages/processing/src/vector-tools.ts
+++ b/packages/processing/src/vector-tools.ts
@@ -1567,7 +1567,7 @@ export const gridTool: ProcessingAlgorithm = {
     if (!Number.isFinite(cellHeight) || cellHeight <= 0) {
       // A blank field intentionally means "match the cell width"; only note it
       // when the user actually entered an invalid (non-positive/non-numeric) value.
-      if (rawHeight !== undefined && rawHeight !== null && rawHeight !== "") {
+      if (rawHeight != null && rawHeight !== "") {
         ctx.log(
           `Note: cell height '${rawHeight}' is not a positive number; using the cell width (${cellWidth}°)`,
         );
@@ -1707,6 +1707,15 @@ export const voronoiTool: ProcessingAlgorithm = {
     }
     if (kind === "delaunay") {
       const result = tin(pointsFc);
+      // The bbox guard above catches axis-aligned collinearity; diagonally
+      // collinear points (non-zero-area bbox) still yield no triangle with area,
+      // so report that rather than adding an empty layer.
+      if (result.features.length === 0) {
+        ctx.log(
+          "Error: could not triangulate — the points are collinear (no triangle has area)",
+        );
+        return;
+      }
       ctx.log(
         `Delaunay: produced ${result.features.length} triangle(s) from ${points.length} point(s)`,
       );
@@ -1726,6 +1735,12 @@ export const voronoiTool: ProcessingAlgorithm = {
     ];
     const result = voronoiDiagram(pointsFc, { bbox: clip });
     const cells = (result.features ?? []).filter((f) => Boolean(f?.geometry));
+    if (cells.length === 0) {
+      ctx.log(
+        "Error: could not build a Voronoi diagram — the points are collinear",
+      );
+      return;
+    }
     ctx.log(
       `Voronoi: produced ${cells.length} cell(s) from ${points.length} point(s)`,
     );

--- a/tests/processing.test.ts
+++ b/tests/processing.test.ts
@@ -838,6 +838,43 @@ describe("processing registry", () => {
         .coordinates,
       [[]],
     );
+
+    // Z/elevation is interpolated through smoothing, not dropped.
+    const line3d: GeoLibreLayer = {
+      ...square,
+      id: "line3d",
+      geojson: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: {},
+            geometry: {
+              type: "LineString",
+              coordinates: [
+                [0, 0, 100],
+                [0, 10, 200],
+              ],
+            },
+          },
+        ],
+      },
+    };
+    let line3dOut: FeatureCollection | null = null;
+    tool.run({
+      layers: [line3d],
+      parameters: { layer: "line3d", iterations: 1 },
+      log: () => {},
+      addResultLayer: (_n, g) => {
+        line3dOut = g;
+      },
+    });
+    const coords3d = (
+      line3dOut!.features[0].geometry as { coordinates: number[][] }
+    ).coordinates;
+    // Endpoints kept; the 1/4 cut point interpolates Z: 100*0.75 + 200*0.25 = 125.
+    assert.ok(coords3d.every((c) => c.length === 3));
+    assert.deepEqual(coords3d[1], [0, 2.5, 125]);
   });
 
   it("generates a regular grid from a bounding box", () => {
@@ -963,6 +1000,30 @@ describe("processing registry", () => {
     });
     assert.equal(produced, false);
     assert.ok(logs.some((m) => m.includes("at least 3 points")));
+
+    // Collinear points (zero-area bbox) error rather than producing a degenerate
+    // or empty result.
+    let collinearProduced = false;
+    const collinearLogs: string[] = [];
+    tool.run({
+      layers: [
+        {
+          ...points,
+          id: "collinear",
+          geojson: {
+            type: "FeatureCollection",
+            features: [pt(0, 0), pt(0, 5), pt(0, 10)],
+          },
+        },
+      ],
+      parameters: { layer: "collinear", type: "voronoi" },
+      log: (m) => collinearLogs.push(m),
+      addResultLayer: () => {
+        collinearProduced = true;
+      },
+    });
+    assert.equal(collinearProduced, false);
+    assert.ok(collinearLogs.some((m) => m.includes("collinear")));
   });
 
   it("calculates and fits layer bounds", () => {

--- a/tests/processing.test.ts
+++ b/tests/processing.test.ts
@@ -935,6 +935,35 @@ describe("processing registry", () => {
     });
     assert.equal(produced, false);
     assert.ok(logs.some((m) => m.includes("west < east")));
+
+    // A zero-area layer extent (single point) errors rather than logging a
+    // 0-cell grid.
+    const pointLayer: GeoLibreLayer = {
+      ...layer,
+      id: "onept",
+      geojson: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: {},
+            geometry: { type: "Point", coordinates: [5, 5] },
+          },
+        ],
+      },
+    };
+    let layerProduced = false;
+    const layerLogs: string[] = [];
+    tool.run({
+      layers: [pointLayer],
+      parameters: { source: "layer", layer: "onept", cell_width: 1 },
+      log: (m) => layerLogs.push(m),
+      addResultLayer: () => {
+        layerProduced = true;
+      },
+    });
+    assert.equal(layerProduced, false);
+    assert.ok(layerLogs.some((m) => m.includes("extent is empty")));
   });
 
   it("builds Voronoi cells and Delaunay triangles from points", () => {

--- a/tests/processing.test.ts
+++ b/tests/processing.test.ts
@@ -875,6 +875,44 @@ describe("processing registry", () => {
     // Endpoints kept; the 1/4 cut point interpolates Z: 100*0.75 + 200*0.25 = 125.
     assert.ok(coords3d.every((c) => c.length === 3));
     assert.deepEqual(coords3d[1], [0, 2.5, 125]);
+
+    // The feature id is preserved through smoothing.
+    const withId: GeoLibreLayer = {
+      ...square,
+      id: "withId",
+      geojson: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            id: "abc",
+            properties: {},
+            geometry: {
+              type: "Polygon",
+              coordinates: [
+                [
+                  [0, 0],
+                  [0, 10],
+                  [10, 10],
+                  [10, 0],
+                  [0, 0],
+                ],
+              ],
+            },
+          },
+        ],
+      },
+    };
+    let idOut: FeatureCollection | null = null;
+    tool.run({
+      layers: [withId],
+      parameters: { layer: "withId", iterations: 1 },
+      log: () => {},
+      addResultLayer: (_n, g) => {
+        idOut = g;
+      },
+    });
+    assert.equal(idOut!.features[0].id, "abc");
   });
 
   it("generates a regular grid from a bounding box", () => {

--- a/tests/processing.test.ts
+++ b/tests/processing.test.ts
@@ -805,6 +805,39 @@ describe("processing registry", () => {
     });
     assert.equal(produced, false);
     assert.ok(logs.some((m) => m.includes("between 1 and 10")));
+
+    // A malformed polygon with an empty ring must not throw; the ring stays empty.
+    const malformed: GeoLibreLayer = {
+      ...square,
+      id: "malformed",
+      geojson: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: {},
+            geometry: { type: "Polygon", coordinates: [[]] },
+          },
+        ],
+      },
+    };
+    let malformedOut: FeatureCollection | null = null;
+    assert.doesNotThrow(() =>
+      tool.run({
+        layers: [malformed],
+        parameters: { layer: "malformed", iterations: 2 },
+        log: () => {},
+        addResultLayer: (_n, g) => {
+          malformedOut = g;
+        },
+      }),
+    );
+    assert.ok(malformedOut);
+    assert.deepEqual(
+      (malformedOut!.features[0].geometry as { coordinates: number[][][] })
+        .coordinates,
+      [[]],
+    );
   });
 
   it("generates a regular grid from a bounding box", () => {

--- a/tests/processing.test.ts
+++ b/tests/processing.test.ts
@@ -1053,6 +1053,44 @@ describe("processing registry", () => {
     });
     assert.equal(collinearProduced, false);
     assert.ok(collinearLogs.some((m) => m.includes("collinear")));
+
+    // The guard runs before the diagram-type branch, so Delaunay rejects the
+    // same axis-aligned input...
+    const runCollinear = (
+      type: string,
+      feats: typeof points.geojson.features,
+    ): string[] => {
+      const out: string[] = [];
+      let made = false;
+      tool.run({
+        layers: [
+          {
+            ...points,
+            id: "col",
+            geojson: { type: "FeatureCollection", features: feats },
+          },
+        ],
+        parameters: { layer: "col", type },
+        log: (m) => out.push(m),
+        addResultLayer: () => {
+          made = true;
+        },
+      });
+      assert.equal(made, false);
+      return out;
+    };
+    assert.ok(
+      runCollinear("delaunay", [pt(0, 0), pt(0, 5), pt(0, 10)]).some((m) =>
+        m.includes("collinear"),
+      ),
+    );
+    // ...and diagonally collinear points (non-zero-area bbox) are caught by the
+    // empty-result guard rather than silently producing nothing.
+    assert.ok(
+      runCollinear("delaunay", [pt(0, 0), pt(1, 1), pt(2, 2)]).some((m) =>
+        m.includes("collinear"),
+      ),
+    );
   });
 
   it("calculates and fits layer bounds", () => {

--- a/tests/processing.test.ts
+++ b/tests/processing.test.ts
@@ -743,6 +743,195 @@ describe("processing registry", () => {
     assert.ok(messages.some((m) => m.includes("Python engine")));
   });
 
+  it("smooths polygon corners with Chaikin's algorithm", () => {
+    const tool = getVectorTool("smooth");
+    assert.ok(tool);
+    const square: GeoLibreLayer = {
+      ...layer,
+      id: "square",
+      name: "Square",
+      geojson: {
+        type: "FeatureCollection",
+        features: [
+          {
+            type: "Feature",
+            properties: { name: "s" },
+            geometry: {
+              type: "Polygon",
+              coordinates: [
+                [
+                  [0, 0],
+                  [0, 10],
+                  [10, 10],
+                  [10, 0],
+                  [0, 0],
+                ],
+              ],
+            },
+          },
+        ],
+      },
+    };
+    let out: FeatureCollection | null = null;
+    tool.run({
+      layers: [square],
+      parameters: { layer: "square", iterations: 1 },
+      log: () => {},
+      addResultLayer: (_n, g) => {
+        out = g;
+      },
+    });
+    assert.ok(out);
+    const ring = (out!.features[0].geometry as { coordinates: number[][][] })
+      .coordinates[0];
+    // One Chaikin pass on a 4-vertex closed ring yields 8 cut points + the
+    // closing vertex, and stays a closed ring (more vertices than the input).
+    assert.equal(ring.length, 9);
+    assert.deepEqual(ring[0], ring[ring.length - 1]);
+    assert.ok(out!.features[0].geometry.type === "Polygon");
+    // Properties are preserved.
+    assert.equal(out!.features[0].properties?.name, "s");
+
+    // Out-of-range iterations error rather than running.
+    let produced = false;
+    const logs: string[] = [];
+    tool.run({
+      layers: [square],
+      parameters: { layer: "square", iterations: 99 },
+      log: (m) => logs.push(m),
+      addResultLayer: () => {
+        produced = true;
+      },
+    });
+    assert.equal(produced, false);
+    assert.ok(logs.some((m) => m.includes("between 1 and 10")));
+  });
+
+  it("generates a regular grid from a bounding box", () => {
+    const tool = getVectorTool("grid");
+    assert.ok(tool);
+    const run = (parameters: Record<string, unknown>): FeatureCollection => {
+      let out: FeatureCollection = { type: "FeatureCollection", features: [] };
+      tool.run({
+        layers: [],
+        parameters: { source: "bbox", ...parameters },
+        log: () => {},
+        addResultLayer: (_n, g) => {
+          out = g;
+        },
+      });
+      return out;
+    };
+    // A 10x10 box with 5-degree cells is a 2x2 grid of rectangles.
+    const grid = run({
+      west: 0,
+      south: 0,
+      east: 10,
+      north: 10,
+      cell_width: 5,
+    });
+    assert.equal(grid.features.length, 4);
+    assert.ok(grid.features.every((f) => f.geometry.type === "Polygon"));
+
+    // Point cells emit one centroid per cell.
+    const points = run({
+      west: 0,
+      south: 0,
+      east: 10,
+      north: 10,
+      cell_width: 5,
+      cell_type: "point",
+    });
+    assert.equal(points.features.length, 4);
+    assert.ok(points.features.every((f) => f.geometry.type === "Point"));
+
+    // A degenerate box (west >= east) errors rather than producing cells.
+    let produced = false;
+    const logs: string[] = [];
+    tool.run({
+      layers: [],
+      parameters: {
+        source: "bbox",
+        west: 10,
+        south: 0,
+        east: 0,
+        north: 10,
+        cell_width: 5,
+      },
+      log: (m) => logs.push(m),
+      addResultLayer: () => {
+        produced = true;
+      },
+    });
+    assert.equal(produced, false);
+    assert.ok(logs.some((m) => m.includes("west < east")));
+  });
+
+  it("builds Voronoi cells and Delaunay triangles from points", () => {
+    const tool = getVectorTool("voronoi");
+    assert.ok(tool);
+    const pt = (x: number, y: number) => ({
+      type: "Feature" as const,
+      properties: {},
+      geometry: { type: "Point" as const, coordinates: [x, y] },
+    });
+    const points: GeoLibreLayer = {
+      ...layer,
+      id: "pts",
+      name: "Points",
+      geojson: {
+        type: "FeatureCollection",
+        features: [pt(0, 0), pt(10, 0), pt(0, 10), pt(10, 10), pt(5, 5)],
+      },
+    };
+    const run = (type: string): FeatureCollection => {
+      let out: FeatureCollection = { type: "FeatureCollection", features: [] };
+      tool.run({
+        layers: [points],
+        parameters: { layer: "pts", type },
+        log: () => {},
+        addResultLayer: (_n, g) => {
+          out = g;
+        },
+      });
+      return out;
+    };
+    const cells = run("voronoi");
+    assert.ok(cells.features.length > 0);
+    assert.ok(
+      cells.features.every(
+        (f) =>
+          f.geometry.type === "Polygon" || f.geometry.type === "MultiPolygon",
+      ),
+    );
+    const triangles = run("delaunay");
+    assert.ok(triangles.features.length > 0);
+    assert.ok(triangles.features.every((f) => f.geometry.type === "Polygon"));
+
+    // Fewer than 3 points errors on both engines.
+    let produced = false;
+    const logs: string[] = [];
+    tool.run({
+      layers: [
+        {
+          ...points,
+          id: "two",
+          geojson: {
+            type: "FeatureCollection",
+            features: [pt(0, 0), pt(1, 1)],
+          },
+        },
+      ],
+      parameters: { layer: "two", type: "voronoi" },
+      log: (m) => logs.push(m),
+      addResultLayer: () => {
+        produced = true;
+      },
+    });
+    assert.equal(produced, false);
+    assert.ok(logs.some((m) => m.includes("at least 3 points")));
+  });
+
   it("calculates and fits layer bounds", () => {
     const messages: string[] = [];
     let fittedBounds: [number, number, number, number] | null = null;


### PR DESCRIPTION
## Summary
- Adds the three remaining vector tools tracked in #283: Smooth (Chaikin corner-cutting, distinct from Simplify), Regular grid (fishnet of rectangles or cell-center points), and Voronoi / Delaunay from a point layer. Each is wired into the Processing -> Vector menu and the command palette.
- Smooth and Voronoi/Delaunay run on both the client (Turf.js) and the Python sidecar/Pyodide engines; Smooth shares one Chaikin implementation across engines so results are identical, and Voronoi clips cells to the points' bounding box plus a 10% margin on both. Regular grid is client-side (like the H3 tools) with a hard cell cap.
- Confirms the related #283 cleanup item is already resolved: the dead registry placeholders are gone and the format placeholder messages were refreshed in an earlier change; the only remaining placeholder message covers a genuinely unshipped feature.

## Test plan
- [x] Frontend `node:test` covers the Smooth, Regular grid, and Voronoi/Delaunay client paths.
- [x] Backend `pytest` covers the smooth and voronoi handlers and the updated dispatch-coverage guard.
- [x] Full build / typecheck and the existing frontend and backend suites pass.
- [x] Verified end-to-end in the running app with Playwright on real public data (52 US-state polygons, 1000 US-city points): grid produced the expected 12x5 = 60 cells from a bounding box, Smooth preserved all 52 features, Voronoi produced 1000 cells from 1000 points, and Delaunay produced 1990 triangles (consistent with 2n - 2 - h for an 8-vertex convex hull).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three vector processing tools: Smooth, Regular grid, and Voronoi/Delaunay (smoothing, grid generation, Voronoi/Delaunay from points).

* **Localization**
  * English labels added for the three new tools.

* **Tests**
  * Expanded unit and integration tests for smoothing, grid, Voronoi/Delaunay, 3D handling, parameter validation, and edge cases.

* **Chores**
  * CI matrix now includes Python 3.14; processing package gained Turf-based geometry dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->