### PR TITLE
feat(macos): Homebrew Cask packaging for macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,3 +111,56 @@ jobs:
             throw "No MSIX package was created at '$msix'."
           }
           gh release upload "${{ github.event.release.tag_name }}" $msix --clobber
+
+  homebrew:
+    name: Update Homebrew cask
+    needs: build
+    runs-on: ubuntu-latest
+    # Only update the tap for full releases, not prereleases.
+    if: ${{ !github.event.release.prerelease }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Compute DMG checksums
+        id: checksums
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          version="${TAG#v}"
+          arm="GeoLibre.Desktop_${version}_aarch64.dmg"
+          intel="GeoLibre.Desktop_${version}_x64.dmg"
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --pattern "$arm" --pattern "$intel" --dir dmgs
+          {
+            echo "version=$version"
+            echo "sha_arm=$(sha256sum "dmgs/$arm" | awk '{print $1}')"
+            echo "sha_intel=$(sha256sum "dmgs/$intel" | awk '{print $1}')"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Check out Homebrew tap
+        uses: actions/checkout@v6
+        with:
+          repository: opengeos/homebrew-geolibre
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: tap
+
+      - name: Render and commit cask
+        env:
+          VERSION: ${{ steps.checksums.outputs.version }}
+          SHA256_ARM: ${{ steps.checksums.outputs.sha_arm }}
+          SHA256_INTEL: ${{ steps.checksums.outputs.sha_intel }}
+        run: |
+          mkdir -p tap/Casks
+          scripts/render-homebrew-cask.sh > tap/Casks/geolibre.rb
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet; then
+            echo "Cask already up to date for ${VERSION}."
+            exit 0
+          fi
+          git add Casks/geolibre.rb
+          git commit -m "geolibre ${VERSION}"
+          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,11 +116,17 @@ jobs:
     name: Update Homebrew cask
     needs: build
     runs-on: ubuntu-latest
+    # Serialise tap pushes so two close releases can't race on a non-fast-forward.
+    concurrency:
+      group: homebrew-tap-update
+      cancel-in-progress: false
     # Only update the tap for full releases, not prereleases.
     if: ${{ !github.event.release.prerelease }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Compute DMG checksums
         id: checksums
@@ -145,22 +151,25 @@ jobs:
           repository: opengeos/homebrew-geolibre
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: tap
+          persist-credentials: false
 
       - name: Render and commit cask
         env:
           VERSION: ${{ steps.checksums.outputs.version }}
           SHA256_ARM: ${{ steps.checksums.outputs.sha_arm }}
           SHA256_INTEL: ${{ steps.checksums.outputs.sha_intel }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           mkdir -p tap/Casks
           scripts/render-homebrew-cask.sh > tap/Casks/geolibre.rb
           cd tap
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          if git diff --quiet; then
+          git add Casks/geolibre.rb
+          # --cached so an initially untracked cask (fresh tap) is still detected.
+          if git diff --cached --quiet; then
             echo "Cask already up to date for ${VERSION}."
             exit 0
           fi
-          git add Casks/geolibre.rb
           git commit -m "geolibre ${VERSION}"
-          git push
+          git push "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/opengeos/homebrew-geolibre.git" HEAD:main

--- a/README.md
+++ b/README.md
@@ -68,6 +68,21 @@ GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS
 
 ## Install
 
+Prebuilt desktop installers for Linux, Windows, and macOS are published on the
+[Releases](https://github.com/opengeos/GeoLibre/releases) page. On macOS you can
+install and update with Homebrew:
+
+```bash
+brew tap opengeos/geolibre
+brew install --cask --no-quarantine geolibre
+```
+
+`--no-quarantine` is required because the app is ad-hoc signed but not notarized
+by Apple. See [Downloads](docs/downloads.md) for details and the manual install
+steps.
+
+To build from source instead:
+
 ```bash
 git clone https://github.com/opengeos/GeoLibre.git
 cd GeoLibre

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -18,6 +18,29 @@ The Windows build is unsigned and may require a platform-specific trust prompt. 
 
 ## macOS installation
 
+### Homebrew (recommended)
+
+GeoLibre is available as a [Homebrew Cask](https://docs.brew.sh/Cask-Cookbook)
+from a self-hosted tap:
+
+```bash
+brew tap opengeos/geolibre
+brew install --cask --no-quarantine geolibre
+```
+
+The `--no-quarantine` flag is required because the DMGs are ad-hoc signed but
+not notarized by Apple; it lets Homebrew skip the Gatekeeper quarantine that
+would otherwise show a "damaged" prompt (see below). Upgrade later with:
+
+```bash
+brew upgrade --cask --no-quarantine geolibre
+```
+
+The tap is not the official `homebrew/cask` repository, which requires a
+notarized, Apple-signed app.
+
+### Manual installation
+
 The macOS builds are not signed with an Apple Developer certificate, so
 Gatekeeper blocks them on first launch. Depending on your macOS version and
 which release you downloaded, the message is one of:

--- a/scripts/render-homebrew-cask.sh
+++ b/scripts/render-homebrew-cask.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Render the Homebrew cask for the GeoLibre desktop app.
+#
+# The macOS DMGs are ad-hoc signed but not notarized by Apple, so the cask is
+# meant to be installed from a self-hosted tap with `--no-quarantine`. It is not
+# suitable for the official homebrew/cask repository.
+#
+# Usage:
+#   VERSION=1.2.0 \
+#   SHA256_ARM=<sha256 of GeoLibre.Desktop_<version>_aarch64.dmg> \
+#   SHA256_INTEL=<sha256 of GeoLibre.Desktop_<version>_x64.dmg> \
+#   scripts/render-homebrew-cask.sh > Casks/geolibre.rb
+#
+# All three variables are required. The rendered cask is written to stdout.
+set -euo pipefail
+
+: "${VERSION:?Set VERSION to the release version, e.g. 1.2.0}"
+: "${SHA256_ARM:?Set SHA256_ARM to the sha256 of the aarch64 DMG}"
+: "${SHA256_INTEL:?Set SHA256_INTEL to the sha256 of the x64 DMG}"
+
+REPO="${REPO:-opengeos/GeoLibre}"
+
+cat <<RUBY
+cask "geolibre" do
+  version "${VERSION}"
+
+  on_arm do
+    sha256 "${SHA256_ARM}"
+
+    url "https://github.com/${REPO}/releases/download/v#{version}/GeoLibre.Desktop_#{version}_aarch64.dmg",
+        verified: "github.com/${REPO}/"
+  end
+  on_intel do
+    sha256 "${SHA256_INTEL}"
+
+    url "https://github.com/${REPO}/releases/download/v#{version}/GeoLibre.Desktop_#{version}_x64.dmg",
+        verified: "github.com/${REPO}/"
+  end
+
+  name "GeoLibre Desktop"
+  desc "Lightweight, cloud-native GIS platform"
+  homepage "https://geolibre.app/"
+
+  # The DMGs are ad-hoc signed but not notarized, so install with
+  # \`--no-quarantine\` to avoid the Gatekeeper "damaged" prompt.
+  app "GeoLibre Desktop.app"
+
+  zap trash: [
+    "~/Library/Application Support/org.geolibre.desktop",
+    "~/Library/Caches/org.geolibre.desktop",
+    "~/Library/Preferences/org.geolibre.desktop.plist",
+    "~/Library/Saved Application State/org.geolibre.desktop.savedState",
+    "~/Library/WebKit/org.geolibre.desktop",
+  ]
+end
+RUBY

--- a/scripts/render-homebrew-cask.sh
+++ b/scripts/render-homebrew-cask.sh
@@ -19,6 +19,12 @@ set -euo pipefail
 : "${SHA256_ARM:?Set SHA256_ARM to the sha256 of the aarch64 DMG}"
 : "${SHA256_INTEL:?Set SHA256_INTEL to the sha256 of the x64 DMG}"
 
+# Validate formats so a truncated hash or stray metacharacter can't silently
+# produce a malformed cask that only fails at `brew install` time.
+[[ "$SHA256_ARM" =~ ^[0-9a-f]{64}$ ]] || { echo "SHA256_ARM is not a 64-char sha256 hex string" >&2; exit 1; }
+[[ "$SHA256_INTEL" =~ ^[0-9a-f]{64}$ ]] || { echo "SHA256_INTEL is not a 64-char sha256 hex string" >&2; exit 1; }
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]] || { echo "VERSION does not look like a semver string" >&2; exit 1; }
+
 REPO="${REPO:-opengeos/GeoLibre}"
 
 cat <<RUBY


### PR DESCRIPTION
Closes #292

## What

Adds a Homebrew Cask install path for the macOS desktop app:

```bash
brew tap opengeos/geolibre
brew install --cask --no-quarantine geolibre
```

The cask lives in a dedicated self-hosted tap, **opengeos/homebrew-geolibre** (already created and seeded with the v1.2.0 cask). The official `homebrew/cask` repo requires a notarized, Apple-signed app, which we can't provide without an Apple Developer account, so a self-hosted tap is the right home. Because the DMGs are ad-hoc signed but not notarized, users install with `--no-quarantine` to avoid the Gatekeeper "damaged" prompt.

## Changes in this repo

- **`scripts/render-homebrew-cask.sh`** — renders `Casks/geolibre.rb` from `VERSION` + the two DMG checksums (`SHA256_ARM`, `SHA256_INTEL`). Emits `on_arm`/`on_intel` blocks, `app "GeoLibre Desktop.app"`, and a `zap` stanza. Usable from CI and for manual bumps.
- **`.github/workflows/release.yml`** — new `homebrew` job that runs after the build matrix, downloads the release DMGs, computes their sha256, regenerates the cask, and commits/pushes it to the tap repo. Skips prereleases.
- **`README.md` / `docs/downloads.md`** — document the `brew` install/upgrade path alongside the existing manual `xattr` instructions.

## Action required before this works end-to-end

The release job pushes to a second repo, so the built-in `GITHUB_TOKEN` is not enough. Add a repo (or org) secret **`HOMEBREW_TAP_TOKEN`** — a fine-grained PAT with **Contents: read & write** on `opengeos/homebrew-geolibre`. Without it, the `homebrew` job fails at the tap checkout/push; the rest of the release is unaffected.

## Verification

- Cask Ruby syntax validated (`ruby -c`).
- v1.2.0 checksums computed from the published DMGs and seeded into the tap.
- `pre-commit run --files ...` passes (including `npm build`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated Homebrew cask publishing so macOS installers on the project tap are kept in sync with releases (includes architecture-specific installers).

* **Documentation**
  * Added “Prebuilt desktop installers” and a recommended Homebrew install section with upgrade instructions and note about using --no-quarantine for ad-hoc signed macOS builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->