### PR TITLE
fix(macos): update Homebrew docs for tap trust and removed --no-quarantine

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,15 @@ install and update with Homebrew:
 
 ```bash
 brew tap opengeos/geolibre
-brew install --cask --no-quarantine geolibre
+brew trust --cask opengeos/geolibre/geolibre
+brew install --cask geolibre
+xattr -dr com.apple.quarantine "/Applications/GeoLibre Desktop.app"
 ```
 
-`--no-quarantine` is required because the app is ad-hoc signed but not notarized
-by Apple. See [Downloads](docs/downloads.md) for details and the manual install
+`brew trust` is a one-time approval for the non-official tap (skip it on
+Homebrew older than 5.1). The `xattr` step is required because the app is ad-hoc
+signed but not notarized by Apple (Homebrew removed the `--no-quarantine` flag in
+5.1). See [Downloads](docs/downloads.md) for details and the manual install
 steps.
 
 To build from source instead:

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -25,19 +25,34 @@ from a self-hosted tap:
 
 ```bash
 brew tap opengeos/geolibre
-brew install --cask --no-quarantine geolibre
+brew trust --cask opengeos/geolibre/geolibre
+brew install --cask geolibre
+xattr -dr com.apple.quarantine "/Applications/GeoLibre Desktop.app"
 ```
 
-The `--no-quarantine` flag is required because the DMGs are ad-hoc signed but
-not notarized by Apple; it lets Homebrew skip the Gatekeeper quarantine that
-would otherwise show a "damaged" prompt (see below). Upgrade later with:
+The `brew trust` step is a one-time approval. Homebrew refuses to load casks
+from non-official taps until you trust them; this is enforced when
+`HOMEBREW_REQUIRE_TAP_TRUST=1` is set and becomes the default in a future
+Homebrew release. `brew trust opengeos/geolibre` trusts the whole tap instead of
+just this cask. The command exists in Homebrew 5.1 and later; on older versions
+skip it.
+
+The `xattr` step is required because the DMGs are ad-hoc signed but not
+notarized by Apple, so macOS Gatekeeper would otherwise block the app with a
+"damaged" prompt (see below). It removes the quarantine attribute Homebrew
+attaches on download. Upgrade later with:
 
 ```bash
-brew upgrade --cask --no-quarantine geolibre
+brew upgrade --cask geolibre
+xattr -dr com.apple.quarantine "/Applications/GeoLibre Desktop.app"
 ```
 
-The tap is not the official `homebrew/cask` repository, which requires a
-notarized, Apple-signed app.
+Re-run the `xattr` command after each upgrade, since it applies to the newly
+installed app bundle.
+
+Homebrew removed the `--no-quarantine` flag in version 5.1, so the manual
+`xattr` step replaces it. The tap is also not the official `homebrew/cask`
+repository, which requires a notarized, Apple-signed app.
 
 ### Manual installation
 

--- a/scripts/render-homebrew-cask.sh
+++ b/scripts/render-homebrew-cask.sh
@@ -48,9 +48,17 @@ cask "geolibre" do
   desc "Lightweight, cloud-native GIS platform"
   homepage "https://geolibre.app/"
 
-  # The DMGs are ad-hoc signed but not notarized, so install with
-  # \`--no-quarantine\` to avoid the Gatekeeper "damaged" prompt.
   app "GeoLibre Desktop.app"
+
+  # The DMGs are ad-hoc signed but not notarized by Apple, so macOS Gatekeeper
+  # blocks them with a "damaged" prompt. Homebrew removed the --no-quarantine
+  # flag in 5.1, so the user must strip the quarantine attribute by hand.
+  caveats <<~EOS
+    GeoLibre Desktop is not notarized by Apple. Before first launch, remove the
+    quarantine attribute (repeat this after every upgrade):
+
+      xattr -dr com.apple.quarantine "/Applications/GeoLibre Desktop.app"
+  EOS
 
   zap trash: [
     "~/Library/Application Support/org.geolibre.desktop",


### PR DESCRIPTION
Follow-up to #294. Two recent Homebrew changes broke the documented install flow when tested on a real Mac:

1. **`--no-quarantine` was removed in Homebrew 5.1** — it now errors with `invalid option: --no-quarantine`. ([Homebrew/brew#20755](https://github.com/Homebrew/brew/issues/20755))
2. **Tap-trust enforcement** — Homebrew refuses to load casks from non-official taps until trusted: `Refusing to load cask ... from untrusted tap`. ([Tap Trust docs](https://docs.brew.sh/Tap-Trust))

## Changes

- Replace `--no-quarantine` with a manual `xattr -dr com.apple.quarantine "/Applications/GeoLibre Desktop.app"` step (README + `docs/downloads.md`), noting it must be re-run after each upgrade.
- Add the one-time `brew trust --cask opengeos/geolibre/geolibre` step.
- Add a `caveats` stanza to the rendered cask (`scripts/render-homebrew-cask.sh`) so the `xattr` reminder prints right after install.

The published tap (`opengeos/homebrew-geolibre`) cask and README were updated directly so the fix is live immediately, independent of this PR.

## Verified working flow on macOS

```bash
brew tap opengeos/geolibre
brew trust --cask opengeos/geolibre/geolibre
brew install --cask geolibre
xattr -dr com.apple.quarantine "/Applications/GeoLibre Desktop.app"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated macOS Homebrew installation instructions to include the `brew trust` command for the non-official tap.
  * Added explicit quarantine attribute removal step via `xattr` to address app signing restrictions.
  * Enhanced installation guidance in the downloads page with detailed explanations of tap-trust enforcement and notarization status.
  * Updated Homebrew cask metadata with clearer caveats regarding the installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->