### PR TITLE
feat(storymaps): scroll-driven story map builder, presenter, and HTML export

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -38,6 +38,7 @@
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-fs": "^2.5.1",
     "@tauri-apps/plugin-opener": "^2.5.4",
+    "dompurify": "^3.4.10",
     "fflate": "^0.8.3",
     "i18next": "^25.10.10",
     "jspdf": "^4.2.1",

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -62,6 +62,8 @@ import { SectionErrorBoundary } from "../common/error-boundaries";
 import { AttributeTable } from "../panels/AttributeTable";
 import { LayerPanel } from "../panels/LayerPanel";
 import { StylePanel } from "../panels/StylePanel";
+import { StoryMapPanel } from "../storymap/StoryMapPanel";
+import { StoryMapPresenter } from "../storymap/StoryMapPresenter";
 import { DiagnosticsDialog } from "./DiagnosticsDialog";
 import { StatusBar } from "./StatusBar";
 import { TopToolbar } from "./TopToolbar";
@@ -957,6 +959,8 @@ export function DesktopShell({
       <Suspense fallback={null}>
         <SqlWorkspaceDialog />
       </Suspense>
+      <StoryMapPanel mapControllerRef={mapControllerRef} />
+      <StoryMapPresenter mapControllerRef={mapControllerRef} />
       <div
         ref={verticalResizeGuideRef}
         className="pointer-events-none fixed bottom-7 top-11 z-50 hidden w-px bg-primary shadow-[0_0_0_1px_hsl(var(--primary)/0.25)]"

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -559,6 +559,7 @@ export function TopToolbar({
         ...getPluginManager().getProjectState(),
         manifestUrls: pluginManifestUrls,
       },
+      storymap: state.storymap,
       metadata: state.metadata,
     });
     return {

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -124,6 +124,7 @@ import {
   Pencil,
   Printer,
   LayoutTemplate,
+  BookOpen,
   Puzzle,
   Redo2,
   RefreshCw,
@@ -364,6 +365,7 @@ export function TopToolbar({
   const setVectorToolOpen = useAppStore((s) => s.setVectorToolOpen);
   const setRasterToolOpen = useAppStore((s) => s.setRasterToolOpen);
   const setSqlWorkspaceOpen = useAppStore((s) => s.setSqlWorkspaceOpen);
+  const setStorymapPanelOpen = useAppStore((s) => s.setStorymapPanelOpen);
   const projectName = useAppStore((s) => s.projectName);
   const projectPath = useAppStore((s) => s.projectPath);
   const recentProjects = useAppStore((s) => s.recentProjects);
@@ -1475,6 +1477,11 @@ export function TopToolbar({
           <DropdownMenuItem onSelect={() => setPrintLayoutOpen(true)}>
             <LayoutTemplate className="mr-2 h-3.5 w-3.5" />
             Print Layout...
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={() => setStorymapPanelOpen(true)}>
+            <BookOpen className="mr-2 h-3.5 w-3.5" />
+            {t("toolbar.item.storymapEllipsis")}
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
@@ -112,14 +112,7 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
     setStorymap(sample);
     setExpandedId(null);
     const first = sample.chapters[0];
-    if (first) {
-      mapControllerRef.current?.getMap()?.flyTo({
-        center: first.location.center,
-        zoom: first.location.zoom,
-        pitch: first.location.pitch,
-        bearing: first.location.bearing,
-      });
-    }
+    if (first) mapControllerRef.current?.flyToView(first.location);
   }, [mapControllerRef, setStorymap]);
 
   const handleCaptureView = useCallback(
@@ -140,13 +133,7 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
 
   const handlePreview = useCallback(
     (chapter: StoryChapter) => {
-      const map = mapControllerRef.current?.getMap();
-      map?.flyTo({
-        center: chapter.location.center,
-        zoom: chapter.location.zoom,
-        pitch: chapter.location.pitch,
-        bearing: chapter.location.bearing,
-      });
+      mapControllerRef.current?.flyToView(chapter.location);
     },
     [mapControllerRef],
   );
@@ -173,9 +160,12 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
           .replace(/^-+|-+$/g, "") || "story-map";
       await saveTextFileWithFallback(html, {
         defaultName: `${slug}.html`,
-        filters: [{ name: "HTML", extensions: ["html"] }],
+        filters: [{ name: t("storymap.htmlFile"), extensions: ["html"] }],
         browserTypes: [
-          { description: "HTML", accept: { "text/html": [".html"] } },
+          {
+            description: t("storymap.htmlFile"),
+            accept: { "text/html": [".html"] },
+          },
         ],
         mimeType: "text/html",
       });
@@ -484,7 +474,7 @@ function ChapterCard({
           </Field>
           <Field label={t("storymap.field.image")}>
             <Input
-              placeholder="https://..."
+              placeholder={t("storymap.field.imagePlaceholder")}
               value={chapter.image ?? ""}
               onChange={(e) =>
                 onUpdate({ image: e.target.value || undefined })
@@ -601,7 +591,10 @@ function LayerEffectsEditor({
     return (id: string) => map.get(id) ?? id;
   }, [layers]);
 
-  if (layers.length === 0) return null;
+  // Nothing to add and nothing to clean up: hide the section entirely. When
+  // stale effects remain after the last layer is deleted, keep rendering them so
+  // the user can still remove the now-broken references.
+  if (layers.length === 0 && changes.length === 0) return null;
 
   const update = (i: number, patch: Partial<StoryLayerOpacityChange>) =>
     onChange(changes.map((c, idx) => (idx === i ? { ...c, ...patch } : c)));
@@ -614,6 +607,7 @@ function LayerEffectsEditor({
           size="sm"
           variant="ghost"
           className="h-6 px-2 text-xs"
+          disabled={layers.length === 0}
           onClick={() =>
             onChange([
               ...changes,
@@ -632,6 +626,11 @@ function LayerEffectsEditor({
             value={change.layerId}
             onChange={(e) => update(i, { layerId: e.target.value })}
           >
+            {/* Keep an orphaned layerId selectable so it can be inspected and
+                removed even after its layer was deleted. */}
+            {!layers.some((layer) => layer.id === change.layerId) ? (
+              <option value={change.layerId}>{layerName(change.layerId)}</option>
+            ) : null}
             {layers.map((layer) => (
               <option key={layer.id} value={layer.id}>
                 {layerName(layer.id)}
@@ -640,7 +639,7 @@ function LayerEffectsEditor({
           </Select>
           <Slider
             className="w-24"
-            aria-label="opacity"
+            aria-label={t("storymap.opacityLabel")}
             min={0}
             max={1}
             step={0.1}

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
@@ -1,0 +1,660 @@
+import { type RefObject, useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { TFunction } from "i18next";
+import {
+  DEFAULT_STORY_MAP,
+  useAppStore,
+  type StoryChapter,
+  type StoryChapterAlignment,
+  type StoryChapterAnimation,
+  type StoryInsetPosition,
+  type StoryLayerOpacityChange,
+  type StoryMap,
+} from "@geolibre/core";
+import type { MapController } from "@geolibre/map";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+  ScrollArea,
+  Select,
+  Separator,
+  Slider,
+  Textarea,
+} from "@geolibre/ui";
+import {
+  ChevronDown,
+  ChevronUp,
+  Crosshair,
+  Download,
+  MapPin,
+  Play,
+  Plus,
+  Trash2,
+} from "lucide-react";
+import { saveTextFileWithFallback } from "../../lib/tauri-io";
+import { buildStoryMapHtml } from "../../lib/storymap-export";
+
+interface StoryMapPanelProps {
+  mapControllerRef: RefObject<MapController | null>;
+}
+
+function createId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `chapter-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+}
+
+/**
+ * Authoring panel for scroll-driven story maps.
+ *
+ * Lets the user capture the current map camera into ordered chapters, edit the
+ * story metadata, control per-chapter layer fades, preview chapters on the live
+ * map, present the story, and export a standalone HTML document.
+ */
+export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
+  const { t } = useTranslation();
+  const open = useAppStore((s) => s.ui.storymapPanelOpen);
+  const setOpen = useAppStore((s) => s.setStorymapPanelOpen);
+  const setPresenting = useAppStore((s) => s.setStorymapPresenting);
+  const storymap = useAppStore((s) => s.storymap);
+  const layers = useAppStore((s) => s.layers);
+  const basemapStyleUrl = useAppStore((s) => s.basemapStyleUrl);
+
+  const updateSettings = useAppStore((s) => s.updateStorymapSettings);
+  const addChapter = useAppStore((s) => s.addStoryChapter);
+  const updateChapter = useAppStore((s) => s.updateStoryChapter);
+  const removeChapter = useAppStore((s) => s.removeStoryChapter);
+  const moveChapter = useAppStore((s) => s.moveStoryChapter);
+
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [exportError, setExportError] = useState<string | null>(null);
+
+  const story: StoryMap = storymap ?? DEFAULT_STORY_MAP;
+  const chapters = story.chapters;
+
+  const handleAddChapter = useCallback(() => {
+    const view = mapControllerRef.current?.readView();
+    const chapter: StoryChapter = {
+      id: createId(),
+      title: t("storymap.defaultChapterTitle", {
+        index: chapters.length + 1,
+      }),
+      description: "",
+      alignment: "left",
+      hidden: false,
+      location: {
+        center: view?.center ?? [0, 0],
+        zoom: view?.zoom ?? 2,
+        pitch: view?.pitch ?? 0,
+        bearing: view?.bearing ?? 0,
+      },
+      mapAnimation: "flyTo",
+      rotateAnimation: false,
+      onChapterEnter: [],
+      onChapterExit: [],
+    };
+    addChapter(chapter);
+    setExpandedId(chapter.id);
+  }, [addChapter, chapters.length, mapControllerRef, t]);
+
+  const handleCaptureView = useCallback(
+    (id: string) => {
+      const view = mapControllerRef.current?.readView();
+      if (!view) return;
+      updateChapter(id, {
+        location: {
+          center: view.center,
+          zoom: view.zoom,
+          pitch: view.pitch,
+          bearing: view.bearing,
+        },
+      });
+    },
+    [mapControllerRef, updateChapter],
+  );
+
+  const handlePreview = useCallback(
+    (chapter: StoryChapter) => {
+      const map = mapControllerRef.current?.getMap();
+      map?.flyTo({
+        center: chapter.location.center,
+        zoom: chapter.location.zoom,
+        pitch: chapter.location.pitch,
+        bearing: chapter.location.bearing,
+      });
+    },
+    [mapControllerRef],
+  );
+
+  const handlePresent = useCallback(() => {
+    if (chapters.length === 0) return;
+    setOpen(false);
+    setPresenting(true);
+  }, [chapters.length, setOpen, setPresenting]);
+
+  const handleExport = useCallback(async () => {
+    setExportError(null);
+    if (chapters.length === 0) return;
+    try {
+      const html = buildStoryMapHtml({
+        storymap: story,
+        basemapStyleUrl,
+        layers,
+      });
+      const slug =
+        (story.title || "story-map")
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, "-")
+          .replace(/^-+|-+$/g, "") || "story-map";
+      await saveTextFileWithFallback(html, {
+        defaultName: `${slug}.html`,
+        filters: [{ name: "HTML", extensions: ["html"] }],
+        browserTypes: [
+          { description: "HTML", accept: { "text/html": [".html"] } },
+        ],
+        mimeType: "text/html",
+      });
+    } catch (error) {
+      setExportError(
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }, [basemapStyleUrl, chapters.length, layers, story]);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="flex max-h-[88vh] w-[min(92vw,46rem)] flex-col gap-0 p-0">
+        <DialogHeader className="border-b px-5 py-4">
+          <DialogTitle className="flex items-center gap-2">
+            <MapPin className="h-4 w-4" />
+            {t("storymap.title")}
+          </DialogTitle>
+          <DialogDescription>{t("storymap.description")}</DialogDescription>
+        </DialogHeader>
+
+        <ScrollArea className="flex-1 overflow-y-auto px-5 py-4">
+          <StorySettings story={story} onChange={updateSettings} t={t} />
+
+          <Separator className="my-4" />
+
+          <div className="mb-2 flex items-center justify-between">
+            <h3 className="text-sm font-semibold">
+              {t("storymap.chapters", { count: chapters.length })}
+            </h3>
+            <Button size="sm" variant="outline" onClick={handleAddChapter}>
+              <Plus className="mr-1 h-4 w-4" />
+              {t("storymap.addChapter")}
+            </Button>
+          </div>
+
+          {chapters.length === 0 ? (
+            <p className="rounded-md border border-dashed px-3 py-6 text-center text-sm text-muted-foreground">
+              {t("storymap.empty")}
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {chapters.map((chapter, index) => (
+                <ChapterCard
+                  key={chapter.id}
+                  chapter={chapter}
+                  index={index}
+                  total={chapters.length}
+                  expanded={expandedId === chapter.id}
+                  layers={layers}
+                  t={t}
+                  onToggle={() =>
+                    setExpandedId((id) =>
+                      id === chapter.id ? null : chapter.id,
+                    )
+                  }
+                  onUpdate={(patch) => updateChapter(chapter.id, patch)}
+                  onRemove={() => removeChapter(chapter.id)}
+                  onMove={(direction) =>
+                    moveChapter(
+                      chapter.id,
+                      direction === "up" ? index - 1 : index + 1,
+                    )
+                  }
+                  onCaptureView={() => handleCaptureView(chapter.id)}
+                  onPreview={() => handlePreview(chapter)}
+                />
+              ))}
+            </div>
+          )}
+        </ScrollArea>
+
+        <div className="flex items-center justify-between gap-2 border-t px-5 py-3">
+          <div className="min-h-[1.25rem] text-xs text-destructive">
+            {exportError}
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={chapters.length === 0}
+              onClick={() => void handleExport()}
+            >
+              <Download className="mr-1 h-4 w-4" />
+              {t("storymap.exportHtml")}
+            </Button>
+            <Button
+              size="sm"
+              disabled={chapters.length === 0}
+              onClick={handlePresent}
+            >
+              <Play className="mr-1 h-4 w-4" />
+              {t("storymap.present")}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+type TFn = TFunction;
+
+function StorySettings({
+  story,
+  onChange,
+  t,
+}: {
+  story: StoryMap;
+  onChange: (patch: Partial<Omit<StoryMap, "chapters">>) => void;
+  t: TFn;
+}) {
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <Field label={t("storymap.field.title")}>
+          <Input
+            value={story.title}
+            onChange={(e) => onChange({ title: e.target.value })}
+          />
+        </Field>
+        <Field label={t("storymap.field.subtitle")}>
+          <Input
+            value={story.subtitle}
+            onChange={(e) => onChange({ subtitle: e.target.value })}
+          />
+        </Field>
+        <Field label={t("storymap.field.byline")}>
+          <Input
+            value={story.byline}
+            onChange={(e) => onChange({ byline: e.target.value })}
+          />
+        </Field>
+        <Field label={t("storymap.field.theme")}>
+          <Select
+            value={story.theme}
+            onChange={(e) =>
+              onChange({ theme: e.target.value as StoryMap["theme"] })
+            }
+          >
+            <option value="dark">{t("storymap.theme.dark")}</option>
+            <option value="light">{t("storymap.theme.light")}</option>
+          </Select>
+        </Field>
+      </div>
+      <Field label={t("storymap.field.footer")}>
+        <Input
+          value={story.footer}
+          onChange={(e) => onChange({ footer: e.target.value })}
+        />
+      </Field>
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm">
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={story.showMarkers}
+            onChange={(e) => onChange({ showMarkers: e.target.checked })}
+          />
+          {t("storymap.field.showMarkers")}
+        </label>
+        {story.showMarkers ? (
+          <input
+            type="color"
+            aria-label={t("storymap.field.markerColor")}
+            value={story.markerColor}
+            onChange={(e) => onChange({ markerColor: e.target.value })}
+            className="h-7 w-10 cursor-pointer rounded border"
+          />
+        ) : null}
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={story.inset}
+            onChange={(e) => onChange({ inset: e.target.checked })}
+          />
+          {t("storymap.field.inset")}
+        </label>
+        {story.inset ? (
+          <Select
+            className="w-40"
+            value={story.insetPosition}
+            onChange={(e) =>
+              onChange({
+                insetPosition: e.target.value as StoryInsetPosition,
+              })
+            }
+          >
+            <option value="top-left">{t("storymap.inset.topLeft")}</option>
+            <option value="top-right">{t("storymap.inset.topRight")}</option>
+            <option value="bottom-left">
+              {t("storymap.inset.bottomLeft")}
+            </option>
+            <option value="bottom-right">
+              {t("storymap.inset.bottomRight")}
+            </option>
+          </Select>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+interface ChapterCardProps {
+  chapter: StoryChapter;
+  index: number;
+  total: number;
+  expanded: boolean;
+  layers: { id: string; name: string }[];
+  t: TFn;
+  onToggle: () => void;
+  onUpdate: (patch: Partial<StoryChapter>) => void;
+  onRemove: () => void;
+  onMove: (direction: "up" | "down") => void;
+  onCaptureView: () => void;
+  onPreview: () => void;
+}
+
+function ChapterCard({
+  chapter,
+  index,
+  total,
+  expanded,
+  layers,
+  t,
+  onToggle,
+  onUpdate,
+  onRemove,
+  onMove,
+  onCaptureView,
+  onPreview,
+}: ChapterCardProps) {
+  const { center, zoom, pitch, bearing } = chapter.location;
+  return (
+    <div className="rounded-md border">
+      <div className="flex items-center gap-1 px-2 py-1.5">
+        <button
+          type="button"
+          className="flex flex-1 items-center gap-2 truncate text-left text-sm font-medium"
+          onClick={onToggle}
+        >
+          <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded bg-muted text-xs">
+            {index + 1}
+          </span>
+          <span className="truncate">
+            {chapter.title || t("storymap.untitledChapter")}
+          </span>
+        </button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          title={t("storymap.preview")}
+          onClick={onPreview}
+        >
+          <MapPin className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          disabled={index === 0}
+          title={t("storymap.moveUp")}
+          onClick={() => onMove("up")}
+        >
+          <ChevronUp className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          disabled={index === total - 1}
+          title={t("storymap.moveDown")}
+          onClick={() => onMove("down")}
+        >
+          <ChevronDown className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 text-destructive"
+          title={t("common.remove")}
+          onClick={onRemove}
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {expanded ? (
+        <div className="space-y-3 border-t px-3 py-3">
+          <Field label={t("storymap.field.chapterTitle")}>
+            <Input
+              value={chapter.title}
+              onChange={(e) => onUpdate({ title: e.target.value })}
+            />
+          </Field>
+          <Field label={t("storymap.field.description")}>
+            <Textarea
+              rows={3}
+              value={chapter.description}
+              onChange={(e) => onUpdate({ description: e.target.value })}
+            />
+          </Field>
+          <Field label={t("storymap.field.image")}>
+            <Input
+              placeholder="https://..."
+              value={chapter.image ?? ""}
+              onChange={(e) =>
+                onUpdate({ image: e.target.value || undefined })
+              }
+            />
+          </Field>
+
+          <div className="grid grid-cols-2 gap-3">
+            <Field label={t("storymap.field.alignment")}>
+              <Select
+                value={chapter.alignment}
+                onChange={(e) =>
+                  onUpdate({
+                    alignment: e.target.value as StoryChapterAlignment,
+                  })
+                }
+              >
+                <option value="left">{t("storymap.align.left")}</option>
+                <option value="center">{t("storymap.align.center")}</option>
+                <option value="right">{t("storymap.align.right")}</option>
+                <option value="full">{t("storymap.align.full")}</option>
+              </Select>
+            </Field>
+            <Field label={t("storymap.field.animation")}>
+              <Select
+                value={chapter.mapAnimation}
+                onChange={(e) =>
+                  onUpdate({
+                    mapAnimation: e.target.value as StoryChapterAnimation,
+                  })
+                }
+              >
+                <option value="flyTo">flyTo</option>
+                <option value="easeTo">easeTo</option>
+                <option value="jumpTo">jumpTo</option>
+              </Select>
+            </Field>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm">
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={chapter.hidden}
+                onChange={(e) => onUpdate({ hidden: e.target.checked })}
+              />
+              {t("storymap.field.hidden")}
+            </label>
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={chapter.rotateAnimation}
+                onChange={(e) =>
+                  onUpdate({ rotateAnimation: e.target.checked })
+                }
+              />
+              {t("storymap.field.rotate")}
+            </label>
+          </div>
+
+          <div className="rounded-md bg-muted/50 px-3 py-2 text-xs">
+            <div className="mb-2 flex items-center justify-between">
+              <span className="font-mono">
+                {center[0].toFixed(4)}, {center[1].toFixed(4)} · z
+                {zoom.toFixed(1)} · p{pitch.toFixed(0)} · b{bearing.toFixed(0)}
+              </span>
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-7"
+                onClick={onCaptureView}
+              >
+                <Crosshair className="mr-1 h-3.5 w-3.5" />
+                {t("storymap.captureView")}
+              </Button>
+            </div>
+          </div>
+
+          <LayerEffectsEditor
+            label={t("storymap.onEnter")}
+            changes={chapter.onChapterEnter}
+            layers={layers}
+            t={t}
+            onChange={(onChapterEnter) => onUpdate({ onChapterEnter })}
+          />
+          <LayerEffectsEditor
+            label={t("storymap.onExit")}
+            changes={chapter.onChapterExit}
+            layers={layers}
+            t={t}
+            onChange={(onChapterExit) => onUpdate({ onChapterExit })}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function LayerEffectsEditor({
+  label,
+  changes,
+  layers,
+  t,
+  onChange,
+}: {
+  label: string;
+  changes: StoryLayerOpacityChange[];
+  layers: { id: string; name: string }[];
+  t: TFn;
+  onChange: (changes: StoryLayerOpacityChange[]) => void;
+}) {
+  const layerName = useMemo(() => {
+    const map = new Map(layers.map((l) => [l.id, l.name]));
+    return (id: string) => map.get(id) ?? id;
+  }, [layers]);
+
+  if (layers.length === 0) return null;
+
+  const update = (i: number, patch: Partial<StoryLayerOpacityChange>) =>
+    onChange(changes.map((c, idx) => (idx === i ? { ...c, ...patch } : c)));
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between">
+        <Label className="text-xs">{label}</Label>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="h-6 px-2 text-xs"
+          onClick={() =>
+            onChange([
+              ...changes,
+              { layerId: layers[0].id, opacity: 1, duration: 1000 },
+            ])
+          }
+        >
+          <Plus className="mr-1 h-3 w-3" />
+          {t("storymap.addEffect")}
+        </Button>
+      </div>
+      {changes.map((change, i) => (
+        <div key={i} className="flex items-center gap-2">
+          <Select
+            className="flex-1"
+            value={change.layerId}
+            onChange={(e) => update(i, { layerId: e.target.value })}
+          >
+            {layers.map((layer) => (
+              <option key={layer.id} value={layer.id}>
+                {layerName(layer.id)}
+              </option>
+            ))}
+          </Select>
+          <Slider
+            className="w-24"
+            aria-label="opacity"
+            min={0}
+            max={1}
+            step={0.1}
+            value={[change.opacity]}
+            onValueChange={([next]: number[]) => {
+              if (typeof next === "number") update(i, { opacity: next });
+            }}
+          />
+          <span className="w-8 shrink-0 text-right font-mono text-xs">
+            {change.opacity.toFixed(1)}
+          </span>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 text-destructive"
+            onClick={() => onChange(changes.filter((_, idx) => idx !== i))}
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1">
+      <Label className="text-xs">{label}</Label>
+      {children}
+    </div>
+  );
+}

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
@@ -774,13 +774,15 @@ function LayerEffectsEditor({
           <Input
             type="number"
             min={0}
+            max={60000}
             step={100}
             className="h-7 w-20 shrink-0"
             aria-label={t("storymap.durationLabel")}
             title={t("storymap.durationLabel")}
             value={change.duration ?? 0}
             onChange={(e) => {
-              const ms = Math.max(0, Number(e.target.value) || 0);
+              // Cap at 60s so a typo can't produce a multi-minute transition.
+              const ms = Math.min(60000, Math.max(0, Number(e.target.value) || 0));
               update(i, { duration: ms });
             }}
           />

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
@@ -617,7 +617,7 @@ function LayerEffectsEditor({
           onClick={() =>
             onChange([
               ...changes,
-              { layerId: layers[0].id, opacity: 1, duration: 1000 },
+              { id: createId(), layerId: layers[0].id, opacity: 1, duration: 1000 },
             ])
           }
         >
@@ -626,7 +626,7 @@ function LayerEffectsEditor({
         </Button>
       </div>
       {changes.map((change, i) => (
-        <div key={i} className="flex items-center gap-2">
+        <div key={change.id ?? `${change.layerId}-${i}`} className="flex items-center gap-2">
           <Select
             className="flex-1"
             value={change.layerId}

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
@@ -661,7 +661,7 @@ function LayerEffectsEditor({
             value={change.duration ?? 0}
             onChange={(e) => {
               const ms = Math.max(0, Number(e.target.value) || 0);
-              update(i, { duration: ms || undefined });
+              update(i, { duration: ms });
             }}
           />
           <Button

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import {
   DEFAULT_STORY_MAP,
+  createSampleStoryMap,
   useAppStore,
   type StoryChapter,
   type StoryChapterAlignment,
@@ -35,6 +36,7 @@ import {
   MapPin,
   Play,
   Plus,
+  Sparkles,
   Trash2,
 } from "lucide-react";
 import { saveTextFileWithFallback } from "../../lib/tauri-io";
@@ -67,6 +69,7 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
   const layers = useAppStore((s) => s.layers);
   const basemapStyleUrl = useAppStore((s) => s.basemapStyleUrl);
 
+  const setStorymap = useAppStore((s) => s.setStorymap);
   const updateSettings = useAppStore((s) => s.updateStorymapSettings);
   const addChapter = useAppStore((s) => s.addStoryChapter);
   const updateChapter = useAppStore((s) => s.updateStoryChapter);
@@ -103,6 +106,21 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
     addChapter(chapter);
     setExpandedId(chapter.id);
   }, [addChapter, chapters.length, mapControllerRef, t]);
+
+  const handleLoadSample = useCallback(() => {
+    const sample = createSampleStoryMap();
+    setStorymap(sample);
+    setExpandedId(null);
+    const first = sample.chapters[0];
+    if (first) {
+      mapControllerRef.current?.getMap()?.flyTo({
+        center: first.location.center,
+        zoom: first.location.zoom,
+        pitch: first.location.pitch,
+        bearing: first.location.bearing,
+      });
+    }
+  }, [mapControllerRef, setStorymap]);
 
   const handleCaptureView = useCallback(
     (id: string) => {
@@ -195,9 +213,13 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
           </div>
 
           {chapters.length === 0 ? (
-            <p className="rounded-md border border-dashed px-3 py-6 text-center text-sm text-muted-foreground">
-              {t("storymap.empty")}
-            </p>
+            <div className="flex flex-col items-center gap-3 rounded-md border border-dashed px-3 py-6 text-center text-sm text-muted-foreground">
+              <p>{t("storymap.empty")}</p>
+              <Button size="sm" variant="secondary" onClick={handleLoadSample}>
+                <Sparkles className="mr-1 h-4 w-4" />
+                {t("storymap.loadSample")}
+              </Button>
+            </div>
           ) : (
             <div className="space-y-2">
               {chapters.map((chapter, index) => (

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
@@ -1,9 +1,13 @@
-import { type RefObject, useCallback, useMemo, useState } from "react";
+import { type RefObject, useCallback, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import {
   DEFAULT_STORY_MAP,
   createSampleStoryMap,
+  parseStoryMapCsv,
+  parseStoryMapJson,
+  serializeStoryMapCsv,
+  serializeStoryMapJson,
   useAppStore,
   type StoryChapter,
   type StoryChapterAlignment,
@@ -20,6 +24,10 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   Input,
   Label,
   ScrollArea,
@@ -38,6 +46,7 @@ import {
   Plus,
   Sparkles,
   Trash2,
+  Upload,
 } from "lucide-react";
 import { saveTextFileWithFallback } from "../../lib/tauri-io";
 import { buildStoryMapHtml } from "../../lib/storymap-export";
@@ -78,6 +87,8 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
 
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [exportError, setExportError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const importFormatRef = useRef<"json" | "csv">("json");
 
   const story: StoryMap = storymap ?? DEFAULT_STORY_MAP;
   const chapters = story.chapters;
@@ -174,7 +185,74 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
         error instanceof Error ? error.message : String(error),
       );
     }
-  }, [basemapStyleUrl, chapters.length, layers, story]);
+  }, [basemapStyleUrl, chapters.length, layers, story, t]);
+
+  const handleExportData = useCallback(
+    async (format: "json" | "csv") => {
+      setExportError(null);
+      if (chapters.length === 0) return;
+      const slug =
+        (story.title || "story-map")
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, "-")
+          .replace(/^-+|-+$/g, "") || "story-map";
+      try {
+        const content =
+          format === "json"
+            ? serializeStoryMapJson(story)
+            : serializeStoryMapCsv(story);
+        const mimeType = format === "json" ? "application/json" : "text/csv";
+        await saveTextFileWithFallback(content, {
+          defaultName: `${slug}.${format}`,
+          filters: [{ name: format.toUpperCase(), extensions: [format] }],
+          browserTypes: [
+            {
+              description: format.toUpperCase(),
+              accept: { [mimeType]: [`.${format}`] },
+            },
+          ],
+          mimeType,
+        });
+      } catch (error) {
+        setExportError(error instanceof Error ? error.message : String(error));
+      }
+    },
+    [chapters.length, story],
+  );
+
+  const triggerImport = useCallback((format: "json" | "csv") => {
+    importFormatRef.current = format;
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleImportFile = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      setExportError(null);
+      const file = event.target.files?.[0];
+      // Reset so selecting the same file again re-triggers change.
+      event.target.value = "";
+      if (!file) return;
+      try {
+        const text = await file.text();
+        // Detect by extension, falling back to the menu choice.
+        const isCsv = file.name.toLowerCase().endsWith(".csv")
+          ? true
+          : file.name.toLowerCase().endsWith(".json")
+            ? false
+            : importFormatRef.current === "csv";
+        const imported = isCsv
+          ? parseStoryMapCsv(text, storymap)
+          : parseStoryMapJson(text);
+        setStorymap(imported);
+        setExpandedId(null);
+      } catch (error) {
+        setExportError(
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+    },
+    [setStorymap, storymap],
+  );
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -187,19 +265,61 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
           <DialogDescription>{t("storymap.description")}</DialogDescription>
         </DialogHeader>
 
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".json,.csv,application/json,text/csv,text/plain"
+          className="hidden"
+          onChange={(e) => void handleImportFile(e)}
+        />
+
         <ScrollArea className="flex-1 overflow-y-auto px-5 py-4">
           <StorySettings story={story} onChange={updateSettings} t={t} />
 
           <Separator className="my-4" />
 
-          <div className="mb-2 flex items-center justify-between">
+          <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
             <h3 className="text-sm font-semibold">
               {t("storymap.chapters", { count: chapters.length })}
             </h3>
-            <Button size="sm" variant="outline" onClick={handleAddChapter}>
-              <Plus className="mr-1 h-4 w-4" />
-              {t("storymap.addChapter")}
-            </Button>
+            <div className="flex items-center gap-2">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button size="sm" variant="outline">
+                    <Upload className="mr-1 h-4 w-4" />
+                    {t("storymap.import")}
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem onSelect={() => triggerImport("json")}>
+                    {t("storymap.importJson")}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onSelect={() => triggerImport("csv")}>
+                    {t("storymap.importCsv")}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button size="sm" variant="outline" disabled={chapters.length === 0}>
+                    <Download className="mr-1 h-4 w-4" />
+                    {t("storymap.exportData")}
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem onSelect={() => void handleExportData("json")}>
+                    {t("storymap.exportJson")}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onSelect={() => void handleExportData("csv")}>
+                    {t("storymap.exportCsv")}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+              <Button size="sm" variant="outline" onClick={handleAddChapter}>
+                <Plus className="mr-1 h-4 w-4" />
+                {t("storymap.addChapter")}
+              </Button>
+            </div>
           </div>
 
           {chapters.length === 0 ? (

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
@@ -651,6 +651,19 @@ function LayerEffectsEditor({
           <span className="w-8 shrink-0 text-right font-mono text-xs">
             {change.opacity.toFixed(1)}
           </span>
+          <Input
+            type="number"
+            min={0}
+            step={100}
+            className="h-7 w-20 shrink-0"
+            aria-label={t("storymap.durationLabel")}
+            title={t("storymap.durationLabel")}
+            value={change.duration ?? 0}
+            onChange={(e) => {
+              const ms = Math.max(0, Number(e.target.value) || 0);
+              update(i, { duration: ms || undefined });
+            }}
+          />
           <Button
             variant="ghost"
             size="icon"

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
@@ -668,6 +668,7 @@ function LayerEffectsEditor({
             variant="ghost"
             size="icon"
             className="h-7 w-7 text-destructive"
+            title={t("common.remove")}
             onClick={() => onChange(changes.filter((_, idx) => idx !== i))}
           >
             <Trash2 className="h-4 w-4" />

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
@@ -103,17 +103,14 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
         step.classList.toggle("glsm-active", i === index),
       );
 
-      // Cancel any in-progress camera movement (e.g. a previous chapter's
-      // 30s rotateTo) so it cannot fight the new transition for control.
-      map.stop();
-
-      const animation = chapter.mapAnimation || "flyTo";
-      map[animation]({
-        center: chapter.location.center,
-        zoom: chapter.location.zoom,
-        pitch: chapter.location.pitch,
-        bearing: chapter.location.bearing,
-      });
+      // Drive the camera through the controller (which cancels any in-progress
+      // movement and handles the optional rotation) rather than mutating the
+      // MapLibre instance directly from UI code.
+      controller.applyStoryChapterCamera(
+        chapter.location,
+        chapter.mapAnimation || "flyTo",
+        chapter.rotateAnimation,
+      );
 
       markerRef.current?.setLngLat(chapter.location.center);
       if (insetMapRef.current) {
@@ -137,17 +134,6 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
           change.opacity,
           change.duration,
         );
-      }
-
-      if (chapter.rotateAnimation) {
-        map.once("moveend", () => {
-          if (activeIndexRef.current !== index) return;
-          const bearing = map.getBearing();
-          map.rotateTo(bearing + 180, {
-            duration: 30000,
-            easing: (time) => time,
-          });
-        });
       }
     };
 

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
@@ -1,10 +1,12 @@
 import { type RefObject, useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import maplibregl from "maplibre-gl";
 import { useAppStore, type StoryChapter } from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
 import { Button } from "@geolibre/ui";
 import { X } from "lucide-react";
+import { sanitizeStoryHtml } from "../../lib/sanitize-html";
 
 interface StoryMapPresenterProps {
   mapControllerRef: RefObject<MapController | null>;
@@ -100,6 +102,10 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
       steps.forEach((step, i) =>
         step.classList.toggle("glsm-active", i === index),
       );
+
+      // Cancel any in-progress camera movement (e.g. a previous chapter's
+      // 30s rotateTo) so it cannot fight the new transition for control.
+      map.stop();
 
       const animation = chapter.mapAnimation || "flyTo";
       map[animation]({
@@ -198,11 +204,18 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
 
   if (!presenting || chapters.length === 0) return null;
 
+  // Render into the MapLibre container so the presentation is clipped to the
+  // map canvas instead of overlaying the toolbar and side panels. The container
+  // carries `.maplibregl-map { position: relative }`, so `absolute inset-0`
+  // lines the overlay up exactly with the map.
+  const container = mapControllerRef.current?.getMap()?.getContainer() ?? null;
+  if (!container) return null;
+
   const theme = storymap?.theme ?? "dark";
   const themeClass = theme === "light" ? "glsm-light" : "glsm-dark";
 
-  return (
-    <div className="fixed inset-0 z-[70]">
+  return createPortal(
+    <div className="absolute inset-0 z-[70] overflow-hidden">
       <Button
         variant="secondary"
         size="sm"
@@ -214,20 +227,24 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
       </Button>
 
       {storymap?.inset ? (
+        // The inner div is the MapLibre container; MapLibre stamps it with
+        // `.maplibregl-map { position: relative }`, so keep the corner
+        // positioning on the outer wrapper where it cannot be overridden.
         <div
-          ref={insetRef}
           className={`pointer-events-none absolute z-[71] h-44 w-44 overflow-hidden rounded-md border-2 border-white/80 shadow-lg ${
             INSET_POSITION_CLASS[storymap.insetPosition] ??
             INSET_POSITION_CLASS["bottom-right"]
           }`}
-        />
+        >
+          <div ref={insetRef} className="h-full w-full" />
+        </div>
       ) : null}
 
       <StoryMapStyles />
 
       <div
         ref={scrollRef}
-        className="glsm-scroll h-full w-full overflow-y-auto"
+        className="glsm-scroll absolute inset-0 overflow-y-auto"
       >
         {storymap &&
         (storymap.title || storymap.subtitle || storymap.byline) ? (
@@ -254,8 +271,11 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
                 ) : null}
                 {chapter.description ? (
                   <p
-                    // Descriptions support inline HTML, matching the template.
-                    dangerouslySetInnerHTML={{ __html: chapter.description }}
+                    // Descriptions support inline HTML, matching the template;
+                    // sanitized because chapters can come from a shared project.
+                    dangerouslySetInnerHTML={{
+                      __html: sanitizeStoryHtml(chapter.description),
+                    }}
                   />
                 ) : null}
               </div>
@@ -265,11 +285,12 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
 
         {storymap?.footer ? (
           <div className={`glsm-footer ${themeClass}`}>
-            <p dangerouslySetInnerHTML={{ __html: storymap.footer }} />
+            <p dangerouslySetInnerHTML={{ __html: sanitizeStoryHtml(storymap.footer) }} />
           </div>
         ) : null}
       </div>
-    </div>
+    </div>,
+    container,
   );
 }
 

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
@@ -1,11 +1,18 @@
-import { type RefObject, useEffect, useMemo, useRef } from "react";
+import {
+  type RefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import maplibregl from "maplibre-gl";
 import { useAppStore, type StoryChapter } from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
-import { Button } from "@geolibre/ui";
-import { X } from "lucide-react";
+import { Button, cn } from "@geolibre/ui";
+import { List, X } from "lucide-react";
 import { sanitizeStoryHtml } from "../../lib/sanitize-html";
 import { STORY_INSET_STYLE_URL } from "../../lib/storymap-constants";
 
@@ -47,10 +54,23 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
   const insetMarkerRef = useRef<maplibregl.Marker | null>(null);
   const markerRef = useRef<maplibregl.Marker | null>(null);
   const activeIndexRef = useRef<number>(-1);
+  // Mirror of activeIndexRef as state so the navigation pane can highlight the
+  // current chapter.
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [navOpen, setNavOpen] = useState(true);
 
   // Memoized so the render path and `hasChapters` get a stable reference.
   const chapters = useMemo(() => storymap?.chapters ?? [], [storymap]);
   const hasChapters = presenting && chapters.length > 0;
+
+  // Scroll a chapter into view; the IntersectionObserver then activates it and
+  // flies the camera, so clicking the nav reuses the same scroll-driven path.
+  const goToChapter = useCallback((index: number) => {
+    const step = scrollRef.current?.querySelector<HTMLElement>(
+      `[data-chapter-index="${index}"]`,
+    );
+    step?.scrollIntoView({ block: "center", behavior: "smooth" });
+  }, []);
 
   // The playback effect reads the story through a ref so it only sets up on
   // present/exit (hasChapters) and not on every edit. Edits cannot happen mid-
@@ -105,6 +125,7 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
       activeIndexRef.current = index;
       const chapter = chapters[index];
       if (!chapter) return;
+      setActiveIndex(index);
 
       steps.forEach((step, i) =>
         step.classList.toggle("glsm-active", i === index),
@@ -212,15 +233,62 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
     // The map controls are lifted above it (see StoryMapStyles) so they stay
     // clickable even though the story drives the camera.
     <div className="absolute inset-0 z-[70] overflow-hidden">
-      <Button
-        variant="secondary"
-        size="sm"
-        className="absolute left-3 top-3 z-[72] shadow-md"
-        onClick={() => setPresenting(false)}
-      >
-        <X className="mr-1 h-4 w-4" />
-        {t("storymap.exitPresentation")}
-      </Button>
+      <div className="absolute left-3 top-3 z-[72] flex items-center gap-2">
+        <Button
+          variant="secondary"
+          size="sm"
+          className="shadow-md"
+          onClick={() => setPresenting(false)}
+        >
+          <X className="mr-1 h-4 w-4" />
+          {t("storymap.exitPresentation")}
+        </Button>
+        <Button
+          variant="secondary"
+          size="icon"
+          className="h-8 w-8 shadow-md"
+          title={t("storymap.toggleNav")}
+          aria-pressed={navOpen}
+          onClick={() => setNavOpen((open) => !open)}
+        >
+          <List className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {navOpen ? (
+        <nav
+          aria-label={t("storymap.chapterNav")}
+          className="absolute left-3 top-14 z-[72] max-h-[calc(100%-4.5rem)] w-52 overflow-y-auto rounded-md border bg-background/85 p-1.5 shadow-lg backdrop-blur"
+        >
+          {chapters.map((chapter, index) => (
+            <button
+              key={chapter.id}
+              type="button"
+              onClick={() => goToChapter(index)}
+              className={cn(
+                "flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs transition-colors",
+                index === activeIndex
+                  ? "bg-primary/15 font-medium text-foreground"
+                  : "text-muted-foreground hover:bg-muted",
+              )}
+            >
+              <span
+                className={cn(
+                  "flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px]",
+                  index === activeIndex
+                    ? "bg-primary text-primary-foreground"
+                    : "bg-muted text-muted-foreground",
+                )}
+              >
+                {index + 1}
+              </span>
+              <span className="truncate">
+                {chapter.title || t("storymap.untitledChapter")}
+              </span>
+            </button>
+          ))}
+        </nav>
+      ) : null}
 
       {storymap?.inset ? (
         // The inner div is the MapLibre container; MapLibre stamps it with
@@ -240,7 +308,10 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
 
       <div
         ref={scrollRef}
-        className="glsm-scroll absolute inset-0 overflow-y-auto"
+        className={cn(
+          "glsm-scroll absolute inset-0 overflow-y-auto",
+          navOpen && "glsm-with-nav",
+        )}
       >
         {storymap &&
         (storymap.title || storymap.subtitle || storymap.byline) ? (
@@ -305,6 +376,9 @@ function StoryMapStyles() {
       .maplibregl-control-container { z-index: 73; }
       .glsm-scroll { scrollbar-width: none; }
       .glsm-scroll::-webkit-scrollbar { width: 0; height: 0; }
+      /* Reserve room for the navigation pane so panels never slide under it. */
+      .glsm-with-nav { padding-left: 14rem; }
+      @media (max-width: 900px) { .glsm-with-nav { padding-left: 0; } }
       .glsm-scroll a, .glsm-scroll a:hover, .glsm-scroll a:visited { color: #0071bc; }
       .glsm-header { margin: auto; width: 100%; position: relative; z-index: 5; }
       .glsm-header h1, .glsm-header h2, .glsm-header p { margin: 0; padding: 1.5vh 2%; text-align: center; }

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
@@ -7,6 +7,7 @@ import type { MapController } from "@geolibre/map";
 import { Button } from "@geolibre/ui";
 import { X } from "lucide-react";
 import { sanitizeStoryHtml } from "../../lib/sanitize-html";
+import { STORY_INSET_STYLE_URL } from "../../lib/storymap-constants";
 
 interface StoryMapPresenterProps {
   mapControllerRef: RefObject<MapController | null>;
@@ -25,9 +26,6 @@ const INSET_POSITION_CLASS: Record<string, string> = {
   "bottom-left": "bottom-3 left-3",
   "bottom-right": "bottom-3 right-3",
 };
-
-const INSET_STYLE_URL =
-  "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json";
 
 /**
  * Full-screen scroll-driven presentation overlay for a story map.
@@ -87,7 +85,7 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
     if (story.inset && insetRef.current) {
       const insetMap = new maplibregl.Map({
         container: insetRef.current,
-        style: INSET_STYLE_URL,
+        style: STORY_INSET_STYLE_URL,
         center: chapters[0].location.center,
         zoom: 1,
         interactive: false,
@@ -210,11 +208,14 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
   const themeClass = theme === "light" ? "glsm-light" : "glsm-dark";
 
   return createPortal(
-    <div className="absolute inset-0 z-[70] overflow-hidden">
+    // The root is click-through (pointer-events-none) so the map and its
+    // controls stay usable during playback; only the chapter panels, footer,
+    // and the Exit button opt back into pointer events.
+    <div className="pointer-events-none absolute inset-0 z-[70] overflow-hidden">
       <Button
         variant="secondary"
         size="sm"
-        className="absolute right-3 top-3 z-[72] shadow-md"
+        className="pointer-events-auto absolute left-3 top-3 z-[72] shadow-md"
         onClick={() => setPresenting(false)}
       >
         <X className="mr-1 h-4 w-4" />
@@ -293,24 +294,30 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
 function StoryMapStyles() {
   return (
     <style>{`
+      /* Widths are percentages of the overlay (which is sized to the map
+         canvas, not the viewport) so panels and images never spill past the
+         map. The scroll surface is click-through; only the panels/footer
+         capture events, leaving the map and its controls interactive. */
+      .glsm-scroll { pointer-events: none; scrollbar-width: none; }
+      .glsm-scroll::-webkit-scrollbar { width: 0; height: 0; }
       .glsm-scroll a, .glsm-scroll a:hover, .glsm-scroll a:visited { color: #0071bc; }
       .glsm-header { margin: auto; width: 100%; position: relative; z-index: 5; }
-      .glsm-header h1, .glsm-header h2, .glsm-header p { margin: 0; padding: 2vh 2vw; text-align: center; }
-      .glsm-footer { width: 100%; min-height: 5vh; padding: 2vh 0; text-align: center; line-height: 25px; font-size: 13px; position: relative; z-index: 5; }
-      .glsm-footer p { margin: 0; }
-      .glsm-features { padding-top: 12vh; padding-bottom: 50vh; }
+      .glsm-header h1, .glsm-header h2, .glsm-header p { margin: 0; padding: 1.5vh 2%; text-align: center; }
+      .glsm-footer { pointer-events: auto; width: 100%; min-height: 5vh; padding: 2vh 0; text-align: center; line-height: 22px; font-size: 13px; position: relative; z-index: 5; }
+      .glsm-footer p { margin: 0; padding: 0 5%; }
+      .glsm-features { padding-top: 10vh; padding-bottom: 45vh; }
       .glsm-hidden { visibility: hidden; }
-      .glsm-centered { width: 50vw; margin: 0 auto; }
-      .glsm-lefty { width: 33vw; margin-left: 5vw; }
-      .glsm-righty { width: 33vw; margin-left: 62vw; }
-      .glsm-fully { width: 100%; margin: auto; }
+      .glsm-centered { width: 50%; margin: 0 auto; }
+      .glsm-lefty { width: 33%; margin-left: 5%; }
+      .glsm-righty { width: 33%; margin-left: 62%; }
+      .glsm-fully { width: 80%; margin: 0 auto; }
       .glsm-light { color: #444; background-color: #fafafa; }
       .glsm-dark { color: #fafafa; background-color: #444; }
-      .glsm-step { padding-bottom: 50vh; opacity: 0.25; transition: opacity 0.3s; }
+      .glsm-step { padding-bottom: 45vh; opacity: 0.25; transition: opacity 0.3s; }
       .glsm-step.glsm-active { opacity: 0.95; }
-      .glsm-step > div { padding: 25px 50px; line-height: 25px; font-size: 14px; border-radius: 4px; }
+      .glsm-step > div { pointer-events: auto; padding: 20px 28px; line-height: 22px; font-size: 14px; border-radius: 4px; }
       .glsm-step h3 { margin-top: 0; }
-      .glsm-step img { width: 100%; border-radius: 2px; }
+      .glsm-step img { width: 100%; max-height: 38vh; object-fit: cover; border-radius: 2px; }
       .glsm-inset-marker { width: 12px; height: 12px; background-color: #ff6b6b; border: 2px solid white; border-radius: 50%; box-shadow: 0 2px 4px rgba(0,0,0,0.3); }
       @media (max-width: 750px) {
         .glsm-centered, .glsm-lefty, .glsm-righty, .glsm-fully { width: 90vw; margin: 0 auto; }

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
@@ -100,35 +100,68 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
       event.stopPropagation();
       const existing = cardLayouts[id];
       const rect = cardEl?.getBoundingClientRect();
+      // Bounds of the visible map area and the card's flow (un-offset) position,
+      // captured once so a drag can be clamped to keep the title bar reachable.
+      const viewport = scrollRef.current?.getBoundingClientRect() ?? null;
+      const baseDx = existing?.dx ?? 0;
+      const baseDy = existing?.dy ?? 0;
+      const flowLeft = rect ? rect.left - baseDx : 0;
+      const flowTop = rect ? rect.top - baseDy : 0;
       gestureRef.current = {
         id,
         mode,
         startX: event.clientX,
         startY: event.clientY,
         base: {
-          dx: existing?.dx ?? 0,
-          dy: existing?.dy ?? 0,
+          dx: baseDx,
+          dy: baseDy,
           w: existing?.w ?? (mode === "resize" ? (rect?.width ?? null) : null),
           h: existing?.h ?? (mode === "resize" ? (rect?.height ?? null) : null),
         },
       };
+
+      // Keep at least this much of the card on screen, and clear the top
+      // control row so the drag bar never hides behind Exit/the map controls.
+      const TOP_INSET = 52;
+      const EDGE_KEEP = 80;
+      // Left boundary clears the nav pane (matches the `.glsm-with-nav` reserve)
+      // so a dragged card can't slip behind it.
+      const leftBoundary = (viewport?.left ?? 0) + (navOpen ? 14 * 16 : 0);
 
       const onMove = (e: PointerEvent) => {
         const g = gestureRef.current;
         if (!g) return;
         const ddx = e.clientX - g.startX;
         const ddy = e.clientY - g.startY;
-        setCardLayouts((prev) => ({
-          ...prev,
-          [g.id]:
-            g.mode === "drag"
-              ? { ...g.base, dx: g.base.dx + ddx, dy: g.base.dy + ddy }
-              : {
-                  ...g.base,
-                  w: Math.max(200, (g.base.w ?? 280) + ddx),
-                  h: Math.max(120, (g.base.h ?? 200) + ddy),
-                },
-        }));
+        if (g.mode === "resize") {
+          setCardLayouts((prev) => ({
+            ...prev,
+            [g.id]: {
+              ...g.base,
+              w: Math.max(200, (g.base.w ?? 280) + ddx),
+              h: Math.max(120, (g.base.h ?? 200) + ddy),
+            },
+          }));
+          return;
+        }
+        let dx = g.base.dx + ddx;
+        let dy = g.base.dy + ddy;
+        if (viewport) {
+          // Clamp the title bar within [top control row, bottom] and keep part
+          // of the card horizontally on screen.
+          const minTop = viewport.top + TOP_INSET;
+          const maxTop = viewport.bottom - TOP_INSET;
+          dy = Math.min(
+            maxTop - flowTop,
+            Math.max(minTop - flowTop, dy),
+          );
+          const maxLeft = viewport.right - EDGE_KEEP;
+          dx = Math.min(
+            maxLeft - flowLeft,
+            Math.max(leftBoundary - flowLeft, dx),
+          );
+        }
+        setCardLayouts((prev) => ({ ...prev, [g.id]: { ...g.base, dx, dy } }));
       };
       const onUp = () => {
         gestureRef.current = null;
@@ -138,7 +171,7 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
       window.addEventListener("pointermove", onMove);
       window.addEventListener("pointerup", onUp);
     },
-    [cardLayouts],
+    [cardLayouts, navOpen],
   );
 
   const resetCard = useCallback((id: string) => {
@@ -505,7 +538,8 @@ function StoryMapStyles() {
       .glsm-with-nav { padding-left: 14rem; }
       @media (max-width: 900px) { .glsm-with-nav { padding-left: 0; } }
       .glsm-scroll a, .glsm-scroll a:hover, .glsm-scroll a:visited { color: #0071bc; }
-      .glsm-header { margin: auto; width: 100%; position: relative; z-index: 5; }
+      /* Decorative text only; never intercept pointers meant for cards/map. */
+      .glsm-header { margin: auto; width: 100%; position: relative; z-index: 5; pointer-events: none; }
       .glsm-header h1, .glsm-header h2, .glsm-header p { margin: 0; padding: 1.5vh 2%; text-align: center; }
       .glsm-footer { width: 100%; min-height: 5vh; padding: 2vh 0; text-align: center; line-height: 22px; font-size: 13px; position: relative; z-index: 5; }
       .glsm-footer p { margin: 0; padding: 0 5%; }
@@ -520,7 +554,8 @@ function StoryMapStyles() {
       .glsm-step { padding-bottom: 45vh; opacity: 0.25; transition: opacity 0.3s; }
       .glsm-step.glsm-active { opacity: 0.95; }
       /* Each chapter renders as a movable, resizable card. */
-      .glsm-card { position: relative; display: flex; flex-direction: column; max-height: 60vh; line-height: 22px; font-size: 14px; border-radius: 6px; box-shadow: 0 6px 20px rgba(0,0,0,0.25); overflow: hidden; }
+      /* z-index keeps a dragged card above the (z-index:5) header it overlaps. */
+      .glsm-card { position: relative; z-index: 6; display: flex; flex-direction: column; max-height: 60vh; line-height: 22px; font-size: 14px; border-radius: 6px; box-shadow: 0 6px 20px rgba(0,0,0,0.25); overflow: hidden; }
       .glsm-card-bar { display: flex; align-items: center; gap: 6px; padding: 7px 10px; cursor: move; touch-action: none; user-select: none; font-weight: 600; font-size: 13px; border-bottom: 1px solid rgba(127,127,127,0.25); }
       .glsm-grip { width: 14px; height: 14px; flex-shrink: 0; opacity: 0.55; }
       .glsm-card-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
@@ -1,4 +1,5 @@
 import {
+  type PointerEvent as ReactPointerEvent,
   type RefObject,
   useCallback,
   useEffect,
@@ -12,7 +13,7 @@ import maplibregl from "maplibre-gl";
 import { useAppStore, type StoryChapter } from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
 import { Button, cn } from "@geolibre/ui";
-import { List, X } from "lucide-react";
+import { GripVertical, List, X } from "lucide-react";
 import { sanitizeStoryHtml } from "../../lib/sanitize-html";
 import { STORY_INSET_STYLE_URL } from "../../lib/storymap-constants";
 
@@ -70,6 +71,83 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
       `[data-chapter-index="${index}"]`,
     );
     step?.scrollIntoView({ block: "center", behavior: "smooth" });
+  }, []);
+
+  // Per-chapter drag offset / explicit size so the reader can move and resize a
+  // chapter card out of the way to explore the map beneath it.
+  const [cardLayouts, setCardLayouts] = useState<
+    Record<string, { dx: number; dy: number; w: number | null; h: number | null }>
+  >({});
+  const gestureRef = useRef<
+    | {
+        id: string;
+        mode: "drag" | "resize";
+        startX: number;
+        startY: number;
+        base: { dx: number; dy: number; w: number | null; h: number | null };
+      }
+    | null
+  >(null);
+
+  const startGesture = useCallback(
+    (
+      event: ReactPointerEvent,
+      id: string,
+      mode: "drag" | "resize",
+      cardEl: HTMLElement | null,
+    ) => {
+      event.preventDefault();
+      event.stopPropagation();
+      const existing = cardLayouts[id];
+      const rect = cardEl?.getBoundingClientRect();
+      gestureRef.current = {
+        id,
+        mode,
+        startX: event.clientX,
+        startY: event.clientY,
+        base: {
+          dx: existing?.dx ?? 0,
+          dy: existing?.dy ?? 0,
+          w: existing?.w ?? (mode === "resize" ? (rect?.width ?? null) : null),
+          h: existing?.h ?? (mode === "resize" ? (rect?.height ?? null) : null),
+        },
+      };
+
+      const onMove = (e: PointerEvent) => {
+        const g = gestureRef.current;
+        if (!g) return;
+        const ddx = e.clientX - g.startX;
+        const ddy = e.clientY - g.startY;
+        setCardLayouts((prev) => ({
+          ...prev,
+          [g.id]:
+            g.mode === "drag"
+              ? { ...g.base, dx: g.base.dx + ddx, dy: g.base.dy + ddy }
+              : {
+                  ...g.base,
+                  w: Math.max(200, (g.base.w ?? 280) + ddx),
+                  h: Math.max(120, (g.base.h ?? 200) + ddy),
+                },
+        }));
+      };
+      const onUp = () => {
+        gestureRef.current = null;
+        window.removeEventListener("pointermove", onMove);
+        window.removeEventListener("pointerup", onUp);
+      };
+      window.addEventListener("pointermove", onMove);
+      window.addEventListener("pointerup", onUp);
+    },
+    [cardLayouts],
+  );
+
+  const resetCard = useCallback((id: string) => {
+    setCardLayouts((prev) => {
+      if (!prev[id]) return prev;
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
   }, []);
 
   // The playback effect reads the story through a ref so it only sets up on
@@ -203,8 +281,10 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
       insetMapRef.current?.remove();
       insetMapRef.current = null;
       activeIndexRef.current = -1;
-      // Reset the nav highlight so the next presentation starts at chapter 1.
+      // Reset nav highlight and any card drag/resize so the next presentation
+      // starts clean.
       setActiveIndex(0);
+      setCardLayouts({});
       // Undo any direct opacity changes made during playback.
       controller.restoreLayerStyles();
     };
@@ -332,31 +412,67 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
         ) : null}
 
         <div className="glsm-features">
-          {chapters.map((chapter, index) => (
-            <div
-              key={chapter.id}
-              data-chapter-index={index}
-              className={`glsm-step ${ALIGNMENT_CLASS[chapter.alignment]} ${
-                chapter.hidden ? "glsm-hidden" : ""
-              }`}
-            >
-              <div className={themeClass}>
-                {chapter.title ? <h3>{chapter.title}</h3> : null}
-                {chapter.image ? (
-                  <img src={chapter.image} alt={chapter.title} />
-                ) : null}
-                {chapter.description ? (
-                  <p
-                    // Descriptions support inline HTML, matching the template;
-                    // sanitized because chapters can come from a shared project.
-                    dangerouslySetInnerHTML={{
-                      __html: sanitizeStoryHtml(chapter.description),
-                    }}
+          {chapters.map((chapter, index) => {
+            const layout = cardLayouts[chapter.id];
+            const cardStyle = {
+              transform: layout
+                ? `translate(${layout.dx}px, ${layout.dy}px)`
+                : undefined,
+              width: layout?.w ? `${layout.w}px` : undefined,
+              height: layout?.h ? `${layout.h}px` : undefined,
+            };
+            return (
+              <div
+                key={chapter.id}
+                data-chapter-index={index}
+                className={`glsm-step ${ALIGNMENT_CLASS[chapter.alignment]} ${
+                  chapter.hidden ? "glsm-hidden" : ""
+                }`}
+              >
+                <div className={`glsm-card ${themeClass}`} style={cardStyle}>
+                  <div
+                    className="glsm-card-bar"
+                    onPointerDown={(e) =>
+                      startGesture(e, chapter.id, "drag", e.currentTarget.parentElement)
+                    }
+                    onDoubleClick={() => resetCard(chapter.id)}
+                    title={t("storymap.dragHint")}
+                  >
+                    <GripVertical className="glsm-grip" />
+                    <span className="glsm-card-title">
+                      {chapter.title || t("storymap.untitledChapter")}
+                    </span>
+                  </div>
+                  <div className="glsm-card-body">
+                    {chapter.image ? (
+                      <img src={chapter.image} alt={chapter.title} />
+                    ) : null}
+                    {chapter.description ? (
+                      <div
+                        // Descriptions support inline HTML, matching the template;
+                        // sanitized because chapters can come from a shared project.
+                        dangerouslySetInnerHTML={{
+                          __html: sanitizeStoryHtml(chapter.description),
+                        }}
+                      />
+                    ) : null}
+                  </div>
+                  <span
+                    className="glsm-resize"
+                    title={t("storymap.resizeHint")}
+                    onPointerDown={(e) =>
+                      startGesture(
+                        e,
+                        chapter.id,
+                        "resize",
+                        e.currentTarget.parentElement,
+                      )
+                    }
                   />
-                ) : null}
+                </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
 
         {storymap?.footer ? (
@@ -403,9 +519,15 @@ function StoryMapStyles() {
       .glsm-dark { color: #fafafa; background-color: #444; }
       .glsm-step { padding-bottom: 45vh; opacity: 0.25; transition: opacity 0.3s; }
       .glsm-step.glsm-active { opacity: 0.95; }
-      .glsm-step > div { padding: 20px 28px; line-height: 22px; font-size: 14px; border-radius: 4px; }
-      .glsm-step h3 { margin-top: 0; }
-      .glsm-step img { width: 100%; max-height: 38vh; object-fit: cover; border-radius: 2px; }
+      /* Each chapter renders as a movable, resizable card. */
+      .glsm-card { position: relative; display: flex; flex-direction: column; max-height: 60vh; line-height: 22px; font-size: 14px; border-radius: 6px; box-shadow: 0 6px 20px rgba(0,0,0,0.25); overflow: hidden; }
+      .glsm-card-bar { display: flex; align-items: center; gap: 6px; padding: 7px 10px; cursor: move; touch-action: none; user-select: none; font-weight: 600; font-size: 13px; border-bottom: 1px solid rgba(127,127,127,0.25); }
+      .glsm-grip { width: 14px; height: 14px; flex-shrink: 0; opacity: 0.55; }
+      .glsm-card-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+      .glsm-card-body { flex: 1 1 auto; min-height: 0; overflow-y: auto; padding: 14px 18px; }
+      .glsm-card-body img { width: 100%; max-height: 38vh; object-fit: cover; border-radius: 2px; }
+      .glsm-resize { position: absolute; right: 0; bottom: 0; width: 18px; height: 18px; cursor: nwse-resize; touch-action: none; }
+      .glsm-resize::after { content: ''; position: absolute; right: 4px; bottom: 4px; width: 7px; height: 7px; border-right: 2px solid currentColor; border-bottom: 2px solid currentColor; opacity: 0.5; }
       .glsm-inset-marker { width: 12px; height: 12px; background-color: #ff6b6b; border: 2px solid white; border-radius: 50%; box-shadow: 0 2px 4px rgba(0,0,0,0.3); }
       @media (max-width: 750px) {
         .glsm-centered, .glsm-lefty, .glsm-righty, .glsm-fully { width: 90vw; margin: 0 auto; }

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
@@ -146,28 +146,30 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
         insetMarkerRef.current?.setLngLat(chapter.location.center);
       }
 
-      // Fire exit effects for every chapter being left, not just the one
-      // directly before, so quick scrolls or nav jumps over several chapters
-      // don't strand layers at an intermediate opacity.
+      const applyEffects = (changes: typeof chapter.onChapterEnter) => {
+        for (const change of changes) {
+          controller.setStoryLayerOpacity(
+            change.layerId,
+            change.opacity,
+            change.duration,
+          );
+        }
+      };
+
+      // Replay the chapters between the old and new position as if scrolled
+      // through (exit the one we leave, then enter+exit each skipped chapter in
+      // order) so a fast scroll or nav jump reaches the same layer state as
+      // stepping one chapter at a time, without firing exits for chapters whose
+      // enter never ran.
       if (previous >= 0 && previous !== index) {
         const step = previous < index ? 1 : -1;
-        for (let i = previous; i !== index; i += step) {
-          for (const change of chapters[i]?.onChapterExit ?? []) {
-            controller.setStoryLayerOpacity(
-              change.layerId,
-              change.opacity,
-              change.duration,
-            );
-          }
+        applyEffects(chapters[previous]?.onChapterExit ?? []);
+        for (let i = previous + step; i !== index; i += step) {
+          applyEffects(chapters[i]?.onChapterEnter ?? []);
+          applyEffects(chapters[i]?.onChapterExit ?? []);
         }
       }
-      for (const change of chapter.onChapterEnter) {
-        controller.setStoryLayerOpacity(
-          change.layerId,
-          change.opacity,
-          change.duration,
-        );
-      }
+      applyEffects(chapter.onChapterEnter);
     };
 
     const observer = new IntersectionObserver(
@@ -201,6 +203,8 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
       insetMapRef.current?.remove();
       insetMapRef.current = null;
       activeIndexRef.current = -1;
+      // Reset the nav highlight so the next presentation starts at chapter 1.
+      setActiveIndex(0);
       // Undo any direct opacity changes made during playback.
       controller.restoreLayerStyles();
     };

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
@@ -146,14 +146,19 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
         insetMarkerRef.current?.setLngLat(chapter.location.center);
       }
 
-      // Exit effects of the chapter we are leaving, then enter effects.
-      if (previous >= 0 && chapters[previous]) {
-        for (const change of chapters[previous].onChapterExit) {
-          controller.setStoryLayerOpacity(
-            change.layerId,
-            change.opacity,
-            change.duration,
-          );
+      // Fire exit effects for every chapter being left, not just the one
+      // directly before, so quick scrolls or nav jumps over several chapters
+      // don't strand layers at an intermediate opacity.
+      if (previous >= 0 && previous !== index) {
+        const step = previous < index ? 1 : -1;
+        for (let i = previous; i !== index; i += step) {
+          for (const change of chapters[i]?.onChapterExit ?? []) {
+            controller.setStoryLayerOpacity(
+              change.layerId,
+              change.opacity,
+              change.duration,
+            );
+          }
         }
       }
       for (const change of chapter.onChapterEnter) {

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
@@ -31,8 +31,9 @@ const ALIGNMENT_CLASS: Record<StoryChapter["alignment"], string> = {
 const INSET_POSITION_CLASS: Record<string, string> = {
   "top-left": "top-3 left-3",
   "top-right": "top-3 right-3",
-  "bottom-left": "bottom-3 left-3",
-  "bottom-right": "bottom-3 right-3",
+  // Raised so the inset clears the map's scale control in the bottom corners.
+  "bottom-left": "bottom-10 left-3",
+  "bottom-right": "bottom-10 right-3",
 };
 
 /**
@@ -104,6 +105,8 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
       }
     | null
   >(null);
+  // Detaches the active gesture's window listeners; set while a drag is live.
+  const gestureCleanupRef = useRef<(() => void) | null>(null);
 
   const startGesture = useCallback(
     (
@@ -180,15 +183,22 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
         setCardLayouts((prev) => ({ ...prev, [g.id]: { ...g.base, dx, dy } }));
       };
       const onUp = () => {
+        gestureCleanupRef.current = null;
         gestureRef.current = null;
         window.removeEventListener("pointermove", onMove);
         window.removeEventListener("pointerup", onUp);
       };
+      // Remembered so an unmount mid-drag (e.g. Exit while dragging) can detach
+      // the window listeners instead of leaking them until the next pointerup.
+      gestureCleanupRef.current = onUp;
       window.addEventListener("pointermove", onMove);
       window.addEventListener("pointerup", onUp);
     },
     [cardLayouts, navOpen],
   );
+
+  // Detach any in-flight drag/resize listeners when the presenter unmounts.
+  useEffect(() => () => gestureCleanupRef.current?.(), []);
 
   const resetCard = useCallback((id: string) => {
     setCardLayouts((prev) => {
@@ -213,6 +223,8 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
     const container = scrollRef.current;
     const story = storymapRef.current;
     if (!controller || !map || !container || !story) return;
+    // Frozen snapshot for this presentation run (edits are blocked while
+    // presenting), shadowing the outer memoized `chapters` deliberately.
     const chapters = story.chapters;
 
     const steps = Array.from(

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
@@ -66,11 +66,27 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
 
   // Scroll a chapter into view; the IntersectionObserver then activates it and
   // flies the camera, so clicking the nav reuses the same scroll-driven path.
+  // Holds the playback effect's enterChapter so the nav pane can drive the
+  // camera deterministically rather than waiting on a scroll-triggered observer.
+  const enterChapterRef = useRef<(index: number) => void>(() => {});
+  // While true, the scroll observer ignores transient intersections caused by a
+  // programmatic jump so they can't override the target we just entered.
+  const jumpingRef = useRef(false);
   const goToChapter = useCallback((index: number) => {
     const step = scrollRef.current?.querySelector<HTMLElement>(
       `[data-chapter-index="${index}"]`,
     );
-    step?.scrollIntoView({ block: "center", behavior: "smooth" });
+    // Center the card, not the step: the step carries a tall bottom padding, so
+    // centering it would push the card (and its drag bar) above the viewport.
+    const target = step?.querySelector<HTMLElement>(".glsm-card") ?? step;
+    jumpingRef.current = true;
+    target?.scrollIntoView({ block: "center" });
+    // Enter the target directly so its camera move always runs, then let the
+    // observer take over once the programmatic scroll has settled.
+    enterChapterRef.current(index);
+    window.setTimeout(() => {
+      jumpingRef.current = false;
+    }, 500);
   }, []);
 
   // Per-chapter drag offset / explicit size so the reader can move and resize a
@@ -242,9 +258,8 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
         step.classList.toggle("glsm-active", i === index),
       );
 
-      // Drive the camera through the controller (which cancels any in-progress
-      // movement and handles the optional rotation) rather than mutating the
-      // MapLibre instance directly from UI code.
+      // Drive the camera through the controller (which handles the optional
+      // rotation) rather than mutating the MapLibre instance directly.
       controller.applyStoryChapterCamera(
         chapter.location,
         chapter.mapAnimation || "flyTo",
@@ -282,9 +297,14 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
       }
       applyEffects(chapter.onChapterEnter);
     };
+    // Expose enterChapter so the nav pane can jump directly.
+    enterChapterRef.current = enterChapter;
 
     const observer = new IntersectionObserver(
       (entries) => {
+        // Ignore intersections triggered by a programmatic nav jump; the jump
+        // already entered the target directly.
+        if (jumpingRef.current) return;
         for (const entry of entries) {
           if (!entry.isIntersecting) continue;
           const index = Number(
@@ -419,7 +439,7 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
         <div
           className={`pointer-events-none absolute z-[71] h-44 w-44 overflow-hidden rounded-md border-2 border-white/80 shadow-lg ${
             INSET_POSITION_CLASS[storymap.insetPosition] ??
-            INSET_POSITION_CLASS["bottom-right"]
+            INSET_POSITION_CLASS["bottom-left"]
           }`}
         >
           <div ref={insetRef} className="h-full w-full" />
@@ -540,7 +560,11 @@ function StoryMapStyles() {
       .glsm-scroll a, .glsm-scroll a:hover, .glsm-scroll a:visited { color: #0071bc; }
       /* Decorative text only; never intercept pointers meant for cards/map. */
       .glsm-header { margin: auto; width: 100%; position: relative; z-index: 5; pointer-events: none; }
-      .glsm-header h1, .glsm-header h2, .glsm-header p { margin: 0; padding: 1.5vh 2%; text-align: center; }
+      /* Explicit sizes: the app's CSS reset would otherwise shrink headings to inherit. */
+      .glsm-header h1, .glsm-header h2, .glsm-header p { margin: 0; padding: 1vh 2%; text-align: center; }
+      .glsm-header h1 { font-size: 2rem; font-weight: 700; line-height: 1.2; }
+      .glsm-header h2 { font-size: 1.3rem; font-weight: 600; line-height: 1.3; }
+      .glsm-header p { font-size: 1rem; }
       .glsm-footer { width: 100%; min-height: 5vh; padding: 2vh 0; text-align: center; line-height: 22px; font-size: 13px; position: relative; z-index: 5; }
       .glsm-footer p { margin: 0; padding: 0 5%; }
       .glsm-features { padding-top: 10vh; padding-bottom: 45vh; }

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
@@ -1,4 +1,4 @@
-import { type RefObject, useEffect, useRef } from "react";
+import { type RefObject, useEffect, useMemo, useRef } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import maplibregl from "maplibre-gl";
@@ -50,7 +50,9 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
   const markerRef = useRef<maplibregl.Marker | null>(null);
   const activeIndexRef = useRef<number>(-1);
 
-  const chapters = storymap?.chapters ?? [];
+  // Memoized so the effect below does not re-run on every render from a fresh
+  // `?? []` array reference; it only changes when the story does.
+  const chapters = useMemo(() => storymap?.chapters ?? [], [storymap]);
   const hasChapters = presenting && chapters.length > 0;
 
   // Set up scroll observation and the live map side-effects while presenting.

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
@@ -208,14 +208,14 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
   const themeClass = theme === "light" ? "glsm-light" : "glsm-dark";
 
   return createPortal(
-    // The root is click-through (pointer-events-none) so the map and its
-    // controls stay usable during playback; only the chapter panels, footer,
-    // and the Exit button opt back into pointer events.
-    <div className="pointer-events-none absolute inset-0 z-[70] overflow-hidden">
+    // The scroll surface captures the wheel so scrolling navigates chapters.
+    // The map controls are lifted above it (see StoryMapStyles) so they stay
+    // clickable even though the story drives the camera.
+    <div className="absolute inset-0 z-[70] overflow-hidden">
       <Button
         variant="secondary"
         size="sm"
-        className="pointer-events-auto absolute left-3 top-3 z-[72] shadow-md"
+        className="absolute left-3 top-3 z-[72] shadow-md"
         onClick={() => setPresenting(false)}
       >
         <X className="mr-1 h-4 w-4" />
@@ -296,14 +296,19 @@ function StoryMapStyles() {
     <style>{`
       /* Widths are percentages of the overlay (which is sized to the map
          canvas, not the viewport) so panels and images never spill past the
-         map. The scroll surface is click-through; only the panels/footer
-         capture events, leaving the map and its controls interactive. */
-      .glsm-scroll { pointer-events: none; scrollbar-width: none; }
+         map. The scroll surface captures the wheel so scrolling advances
+         chapters; the scrollbar is hidden so it cannot cover the map controls,
+         which are lifted above the overlay to stay clickable. */
+      /* Lift the whole control layer (a positioned z-index:2 stacking context)
+         above the overlay; it is pointer-events:none, so only its buttons take
+         clicks while scroll/clicks elsewhere still reach the overlay. */
+      .maplibregl-control-container { z-index: 73; }
+      .glsm-scroll { scrollbar-width: none; }
       .glsm-scroll::-webkit-scrollbar { width: 0; height: 0; }
       .glsm-scroll a, .glsm-scroll a:hover, .glsm-scroll a:visited { color: #0071bc; }
       .glsm-header { margin: auto; width: 100%; position: relative; z-index: 5; }
       .glsm-header h1, .glsm-header h2, .glsm-header p { margin: 0; padding: 1.5vh 2%; text-align: center; }
-      .glsm-footer { pointer-events: auto; width: 100%; min-height: 5vh; padding: 2vh 0; text-align: center; line-height: 22px; font-size: 13px; position: relative; z-index: 5; }
+      .glsm-footer { width: 100%; min-height: 5vh; padding: 2vh 0; text-align: center; line-height: 22px; font-size: 13px; position: relative; z-index: 5; }
       .glsm-footer p { margin: 0; padding: 0 5%; }
       .glsm-features { padding-top: 10vh; padding-bottom: 45vh; }
       .glsm-hidden { visibility: hidden; }
@@ -315,7 +320,7 @@ function StoryMapStyles() {
       .glsm-dark { color: #fafafa; background-color: #444; }
       .glsm-step { padding-bottom: 45vh; opacity: 0.25; transition: opacity 0.3s; }
       .glsm-step.glsm-active { opacity: 0.95; }
-      .glsm-step > div { pointer-events: auto; padding: 20px 28px; line-height: 22px; font-size: 14px; border-radius: 4px; }
+      .glsm-step > div { padding: 20px 28px; line-height: 22px; font-size: 14px; border-radius: 4px; }
       .glsm-step h3 { margin-top: 0; }
       .glsm-step img { width: 100%; max-height: 38vh; object-fit: cover; border-radius: 2px; }
       .glsm-inset-marker { width: 12px; height: 12px; background-color: #ff6b6b; border: 2px solid white; border-radius: 50%; box-shadow: 0 2px 4px rgba(0,0,0,0.3); }

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
@@ -1,0 +1,304 @@
+import { type RefObject, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import maplibregl from "maplibre-gl";
+import { useAppStore, type StoryChapter } from "@geolibre/core";
+import type { MapController } from "@geolibre/map";
+import { Button } from "@geolibre/ui";
+import { X } from "lucide-react";
+
+interface StoryMapPresenterProps {
+  mapControllerRef: RefObject<MapController | null>;
+}
+
+const ALIGNMENT_CLASS: Record<StoryChapter["alignment"], string> = {
+  left: "glsm-lefty",
+  center: "glsm-centered",
+  right: "glsm-righty",
+  full: "glsm-fully",
+};
+
+const INSET_POSITION_CLASS: Record<string, string> = {
+  "top-left": "top-3 left-3",
+  "top-right": "top-3 right-3",
+  "bottom-left": "bottom-3 left-3",
+  "bottom-right": "bottom-3 right-3",
+};
+
+const INSET_STYLE_URL =
+  "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json";
+
+/**
+ * Full-screen scroll-driven presentation overlay for a story map.
+ *
+ * Drives the live GeoLibre map underneath: as the reader scrolls each chapter
+ * into view the map flies to the chapter's camera and applies its layer fades,
+ * mirroring the standalone storytelling template. Rendering nothing unless a
+ * presentation is active keeps it inert the rest of the time.
+ */
+export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) {
+  const { t } = useTranslation();
+  const presenting = useAppStore((s) => s.ui.storymapPresenting);
+  const setPresenting = useAppStore((s) => s.setStorymapPresenting);
+  const storymap = useAppStore((s) => s.storymap);
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const insetRef = useRef<HTMLDivElement>(null);
+  const insetMapRef = useRef<maplibregl.Map | null>(null);
+  const insetMarkerRef = useRef<maplibregl.Marker | null>(null);
+  const markerRef = useRef<maplibregl.Marker | null>(null);
+  const activeIndexRef = useRef<number>(-1);
+
+  const chapters = storymap?.chapters ?? [];
+  const hasChapters = presenting && chapters.length > 0;
+
+  // Set up scroll observation and the live map side-effects while presenting.
+  useEffect(() => {
+    if (!hasChapters) return;
+    const controller = mapControllerRef.current;
+    const map = controller?.getMap();
+    const container = scrollRef.current;
+    if (!controller || !map || !container || !storymap) return;
+
+    const steps = Array.from(
+      container.querySelectorAll<HTMLElement>("[data-chapter-index]"),
+    );
+
+    // Main-map marker, created once and moved per chapter.
+    if (storymap.showMarkers) {
+      markerRef.current = new maplibregl.Marker({
+        color: storymap.markerColor,
+      })
+        .setLngLat(chapters[0].location.center)
+        .addTo(map);
+    }
+
+    // Optional inset minimap.
+    if (storymap.inset && insetRef.current) {
+      const insetMap = new maplibregl.Map({
+        container: insetRef.current,
+        style: INSET_STYLE_URL,
+        center: chapters[0].location.center,
+        zoom: 1,
+        interactive: false,
+        attributionControl: false,
+      });
+      insetMapRef.current = insetMap;
+      const el = document.createElement("div");
+      el.className = "glsm-inset-marker";
+      insetMarkerRef.current = new maplibregl.Marker({ element: el })
+        .setLngLat(chapters[0].location.center)
+        .addTo(insetMap);
+    }
+
+    const enterChapter = (index: number) => {
+      if (index === activeIndexRef.current) return;
+      const previous = activeIndexRef.current;
+      activeIndexRef.current = index;
+      const chapter = chapters[index];
+      if (!chapter) return;
+
+      steps.forEach((step, i) =>
+        step.classList.toggle("glsm-active", i === index),
+      );
+
+      const animation = chapter.mapAnimation || "flyTo";
+      map[animation]({
+        center: chapter.location.center,
+        zoom: chapter.location.zoom,
+        pitch: chapter.location.pitch,
+        bearing: chapter.location.bearing,
+      });
+
+      markerRef.current?.setLngLat(chapter.location.center);
+      if (insetMapRef.current) {
+        insetMapRef.current.setCenter(chapter.location.center);
+        insetMarkerRef.current?.setLngLat(chapter.location.center);
+      }
+
+      // Exit effects of the chapter we are leaving, then enter effects.
+      if (previous >= 0 && chapters[previous]) {
+        for (const change of chapters[previous].onChapterExit) {
+          controller.setStoryLayerOpacity(
+            change.layerId,
+            change.opacity,
+            change.duration,
+          );
+        }
+      }
+      for (const change of chapter.onChapterEnter) {
+        controller.setStoryLayerOpacity(
+          change.layerId,
+          change.opacity,
+          change.duration,
+        );
+      }
+
+      if (chapter.rotateAnimation) {
+        map.once("moveend", () => {
+          if (activeIndexRef.current !== index) return;
+          const bearing = map.getBearing();
+          map.rotateTo(bearing + 180, {
+            duration: 30000,
+            easing: (time) => time,
+          });
+        });
+      }
+    };
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (!entry.isIntersecting) continue;
+          const index = Number(
+            (entry.target as HTMLElement).dataset.chapterIndex,
+          );
+          if (Number.isFinite(index)) enterChapter(index);
+        }
+      },
+      {
+        root: container,
+        // Treat a step as active once it crosses the vertical center.
+        rootMargin: "-45% 0px -45% 0px",
+        threshold: 0,
+      },
+    );
+    for (const step of steps) observer.observe(step);
+
+    // Kick off the first chapter immediately.
+    enterChapter(0);
+
+    return () => {
+      observer.disconnect();
+      markerRef.current?.remove();
+      markerRef.current = null;
+      insetMarkerRef.current?.remove();
+      insetMarkerRef.current = null;
+      insetMapRef.current?.remove();
+      insetMapRef.current = null;
+      activeIndexRef.current = -1;
+      // Undo any direct opacity changes made during playback.
+      controller.restoreLayerStyles();
+    };
+  }, [hasChapters, chapters, storymap, mapControllerRef]);
+
+  // Allow Escape to exit the presentation.
+  useEffect(() => {
+    if (!presenting) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setPresenting(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [presenting, setPresenting]);
+
+  // A presentation with no chapters has nothing to show; close it.
+  useEffect(() => {
+    if (presenting && chapters.length === 0) setPresenting(false);
+  }, [presenting, chapters.length, setPresenting]);
+
+  if (!presenting || chapters.length === 0) return null;
+
+  const theme = storymap?.theme ?? "dark";
+  const themeClass = theme === "light" ? "glsm-light" : "glsm-dark";
+
+  return (
+    <div className="fixed inset-0 z-[70]">
+      <Button
+        variant="secondary"
+        size="sm"
+        className="absolute right-3 top-3 z-[72] shadow-md"
+        onClick={() => setPresenting(false)}
+      >
+        <X className="mr-1 h-4 w-4" />
+        {t("storymap.exitPresentation")}
+      </Button>
+
+      {storymap?.inset ? (
+        <div
+          ref={insetRef}
+          className={`pointer-events-none absolute z-[71] h-44 w-44 overflow-hidden rounded-md border-2 border-white/80 shadow-lg ${
+            INSET_POSITION_CLASS[storymap.insetPosition] ??
+            INSET_POSITION_CLASS["bottom-right"]
+          }`}
+        />
+      ) : null}
+
+      <StoryMapStyles />
+
+      <div
+        ref={scrollRef}
+        className="glsm-scroll h-full w-full overflow-y-auto"
+      >
+        {storymap &&
+        (storymap.title || storymap.subtitle || storymap.byline) ? (
+          <div className={`glsm-header ${themeClass}`}>
+            {storymap.title ? <h1>{storymap.title}</h1> : null}
+            {storymap.subtitle ? <h2>{storymap.subtitle}</h2> : null}
+            {storymap.byline ? <p>{storymap.byline}</p> : null}
+          </div>
+        ) : null}
+
+        <div className="glsm-features">
+          {chapters.map((chapter, index) => (
+            <div
+              key={chapter.id}
+              data-chapter-index={index}
+              className={`glsm-step ${ALIGNMENT_CLASS[chapter.alignment]} ${
+                chapter.hidden ? "glsm-hidden" : ""
+              }`}
+            >
+              <div className={themeClass}>
+                {chapter.title ? <h3>{chapter.title}</h3> : null}
+                {chapter.image ? (
+                  <img src={chapter.image} alt={chapter.title} />
+                ) : null}
+                {chapter.description ? (
+                  <p
+                    // Descriptions support inline HTML, matching the template.
+                    dangerouslySetInnerHTML={{ __html: chapter.description }}
+                  />
+                ) : null}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {storymap?.footer ? (
+          <div className={`glsm-footer ${themeClass}`}>
+            <p dangerouslySetInnerHTML={{ __html: storymap.footer }} />
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/** Scoped styles mirroring the standalone storytelling template. */
+function StoryMapStyles() {
+  return (
+    <style>{`
+      .glsm-scroll a, .glsm-scroll a:hover, .glsm-scroll a:visited { color: #0071bc; }
+      .glsm-header { margin: auto; width: 100%; position: relative; z-index: 5; }
+      .glsm-header h1, .glsm-header h2, .glsm-header p { margin: 0; padding: 2vh 2vw; text-align: center; }
+      .glsm-footer { width: 100%; min-height: 5vh; padding: 2vh 0; text-align: center; line-height: 25px; font-size: 13px; position: relative; z-index: 5; }
+      .glsm-footer p { margin: 0; }
+      .glsm-features { padding-top: 12vh; padding-bottom: 50vh; }
+      .glsm-hidden { visibility: hidden; }
+      .glsm-centered { width: 50vw; margin: 0 auto; }
+      .glsm-lefty { width: 33vw; margin-left: 5vw; }
+      .glsm-righty { width: 33vw; margin-left: 62vw; }
+      .glsm-fully { width: 100%; margin: auto; }
+      .glsm-light { color: #444; background-color: #fafafa; }
+      .glsm-dark { color: #fafafa; background-color: #444; }
+      .glsm-step { padding-bottom: 50vh; opacity: 0.25; transition: opacity 0.3s; }
+      .glsm-step.glsm-active { opacity: 0.95; }
+      .glsm-step > div { padding: 25px 50px; line-height: 25px; font-size: 14px; border-radius: 4px; }
+      .glsm-step h3 { margin-top: 0; }
+      .glsm-step img { width: 100%; border-radius: 2px; }
+      .glsm-inset-marker { width: 12px; height: 12px; background-color: #ff6b6b; border: 2px solid white; border-radius: 50%; box-shadow: 0 2px 4px rgba(0,0,0,0.3); }
+      @media (max-width: 750px) {
+        .glsm-centered, .glsm-lefty, .glsm-righty, .glsm-fully { width: 90vw; margin: 0 auto; }
+      }
+    `}</style>
+  );
+}

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPresenter.tsx
@@ -50,10 +50,15 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
   const markerRef = useRef<maplibregl.Marker | null>(null);
   const activeIndexRef = useRef<number>(-1);
 
-  // Memoized so the effect below does not re-run on every render from a fresh
-  // `?? []` array reference; it only changes when the story does.
+  // Memoized so the render path and `hasChapters` get a stable reference.
   const chapters = useMemo(() => storymap?.chapters ?? [], [storymap]);
   const hasChapters = presenting && chapters.length > 0;
+
+  // The playback effect reads the story through a ref so it only sets up on
+  // present/exit (hasChapters) and not on every edit. Edits cannot happen mid-
+  // presentation anyway (the builder is closed first), so the story is frozen.
+  const storymapRef = useRef(storymap);
+  storymapRef.current = storymap;
 
   // Set up scroll observation and the live map side-effects while presenting.
   useEffect(() => {
@@ -61,23 +66,25 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
     const controller = mapControllerRef.current;
     const map = controller?.getMap();
     const container = scrollRef.current;
-    if (!controller || !map || !container || !storymap) return;
+    const story = storymapRef.current;
+    if (!controller || !map || !container || !story) return;
+    const chapters = story.chapters;
 
     const steps = Array.from(
       container.querySelectorAll<HTMLElement>("[data-chapter-index]"),
     );
 
     // Main-map marker, created once and moved per chapter.
-    if (storymap.showMarkers) {
+    if (story.showMarkers) {
       markerRef.current = new maplibregl.Marker({
-        color: storymap.markerColor,
+        color: story.markerColor,
       })
         .setLngLat(chapters[0].location.center)
         .addTo(map);
     }
 
     // Optional inset minimap.
-    if (storymap.inset && insetRef.current) {
+    if (story.inset && insetRef.current) {
       const insetMap = new maplibregl.Map({
         container: insetRef.current,
         style: INSET_STYLE_URL,
@@ -173,7 +180,7 @@ export function StoryMapPresenter({ mapControllerRef }: StoryMapPresenterProps) 
       // Undo any direct opacity changes made during playback.
       controller.restoreLayerStyles();
     };
-  }, [hasChapters, chapters, storymap, mapControllerRef]);
+  }, [hasChapters, mapControllerRef]);
 
   // Allow Escape to exit the presentation.
   useEffect(() => {

--- a/apps/geolibre-desktop/src/hooks/useEmbedBridge.ts
+++ b/apps/geolibre-desktop/src/hooks/useEmbedBridge.ts
@@ -126,6 +126,7 @@ export function useEmbedBridge(
           ...getPluginManager().getProjectState(),
           manifestUrls: state.projectPlugins?.manifestUrls ?? [],
         },
+        storymap: state.storymap,
         metadata: state.metadata,
       });
     };

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -385,6 +385,8 @@
     "opacityLabel": "Opacity",
     "toggleNav": "Toggle chapter list",
     "chapterNav": "Story chapters",
-    "durationLabel": "Transition (ms)"
+    "durationLabel": "Transition (ms)",
+    "dragHint": "Drag to move (double-click to reset)",
+    "resizeHint": "Drag to resize"
   }
 }

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -382,6 +382,8 @@
     },
     "loadSample": "Load sample story",
     "htmlFile": "HTML",
-    "opacityLabel": "Opacity"
+    "opacityLabel": "Opacity",
+    "toggleNav": "Toggle chapter list",
+    "chapterNav": "Story chapters"
   }
 }

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -310,7 +310,8 @@
       "loadFromUrl": "Load from URL",
       "loadingOsmPbf": "Loading OSM PBF…",
       "loadingOsmPbfDesc": "Parsing the file and converting features to GeoJSON. This runs in the background and may take a moment for large extracts.",
-      "projectName": "Project name"
+      "projectName": "Project name",
+      "storymapEllipsis": "Story Map..."
     },
     "error": {
       "couldNotOpenProject": "Could not open project.",
@@ -325,6 +326,58 @@
       "couldNotOpenOsmPbf": "Could not open the OSM PBF file.",
       "invalidOsmPbfUrl": "Enter a valid http(s) URL to an .osm.pbf file.",
       "couldNotDownloadOsmPbf": "Could not download the OSM PBF file."
+    }
+  },
+  "storymap": {
+    "title": "Story Map",
+    "description": "Build a scroll-driven story from map chapters. Each chapter captures a camera view and text.",
+    "chapters": "Chapters ({{count}})",
+    "addChapter": "Add chapter",
+    "empty": "No chapters yet. Navigate the map, then add a chapter to capture the current view.",
+    "defaultChapterTitle": "Chapter {{index}}",
+    "untitledChapter": "Untitled chapter",
+    "present": "Present",
+    "exportHtml": "Export HTML",
+    "exitPresentation": "Exit",
+    "preview": "Fly to this chapter",
+    "captureView": "Set to current view",
+    "moveUp": "Move up",
+    "moveDown": "Move down",
+    "onEnter": "On enter",
+    "onExit": "On exit",
+    "addEffect": "Add layer effect",
+    "field": {
+      "title": "Title",
+      "subtitle": "Subtitle",
+      "byline": "Byline",
+      "footer": "Footer",
+      "theme": "Panel theme",
+      "showMarkers": "Show markers",
+      "markerColor": "Marker color",
+      "inset": "Inset minimap",
+      "chapterTitle": "Chapter title",
+      "description": "Description (HTML allowed)",
+      "image": "Image URL",
+      "alignment": "Panel alignment",
+      "animation": "Map animation",
+      "hidden": "Hide panel",
+      "rotate": "Rotate camera"
+    },
+    "theme": {
+      "dark": "Dark",
+      "light": "Light"
+    },
+    "align": {
+      "left": "Left",
+      "center": "Center",
+      "right": "Right",
+      "full": "Full"
+    },
+    "inset": {
+      "topLeft": "Top left",
+      "topRight": "Top right",
+      "bottomLeft": "Bottom left",
+      "bottomRight": "Bottom right"
     }
   }
 }

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -384,6 +384,7 @@
     "htmlFile": "HTML",
     "opacityLabel": "Opacity",
     "toggleNav": "Toggle chapter list",
-    "chapterNav": "Story chapters"
+    "chapterNav": "Story chapters",
+    "durationLabel": "Transition (ms)"
   }
 }

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -378,6 +378,7 @@
       "topRight": "Top right",
       "bottomLeft": "Bottom left",
       "bottomRight": "Bottom right"
-    }
+    },
+    "loadSample": "Load sample story"
   }
 }

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -361,7 +361,8 @@
       "alignment": "Panel alignment",
       "animation": "Map animation",
       "hidden": "Hide panel",
-      "rotate": "Rotate camera"
+      "rotate": "Rotate camera",
+      "imagePlaceholder": "https://example.com/image.jpg"
     },
     "theme": {
       "dark": "Dark",
@@ -379,6 +380,8 @@
       "bottomLeft": "Bottom left",
       "bottomRight": "Bottom right"
     },
-    "loadSample": "Load sample story"
+    "loadSample": "Load sample story",
+    "htmlFile": "HTML",
+    "opacityLabel": "Opacity"
   }
 }

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -387,6 +387,12 @@
     "chapterNav": "Story chapters",
     "durationLabel": "Transition (ms)",
     "dragHint": "Drag to move (double-click to reset)",
-    "resizeHint": "Drag to resize"
+    "resizeHint": "Drag to resize",
+    "import": "Import",
+    "importJson": "Import JSON…",
+    "importCsv": "Import CSV…",
+    "exportData": "Export",
+    "exportJson": "Export JSON",
+    "exportCsv": "Export CSV"
   }
 }

--- a/apps/geolibre-desktop/src/lib/sanitize-html.ts
+++ b/apps/geolibre-desktop/src/lib/sanitize-html.ts
@@ -29,11 +29,16 @@ if (!purify.__glRelHook) {
  * @returns A sanitized HTML string safe for `dangerouslySetInnerHTML`.
  */
 export function sanitizeStoryHtml(html: string): string {
+  // Story text is prose with links/images and light formatting, so allow only
+  // that set of tags rather than the full HTML profile. This excludes forms,
+  // tables, media, and other structural elements by construction.
   return DOMPurify.sanitize(html, {
-    ADD_ATTR: ["target", "rel"],
-    USE_PROFILES: { html: true },
-    // Story text is prose/links/images; forms add no value and `target` on a
-    // form is an exfiltration vector, so drop form controls entirely.
-    FORBID_TAGS: ["form", "input", "button", "select", "option", "textarea"],
+    ALLOWED_TAGS: [
+      "a", "abbr", "b", "blockquote", "br", "code", "del", "em",
+      "h1", "h2", "h3", "h4", "h5", "h6", "hr", "i", "img", "ins", "kbd",
+      "li", "mark", "ol", "p", "pre", "s", "small", "span", "strong",
+      "sub", "sup", "u", "ul",
+    ],
+    ALLOWED_ATTR: ["href", "title", "target", "rel", "src", "alt", "width", "height"],
   });
 }

--- a/apps/geolibre-desktop/src/lib/sanitize-html.ts
+++ b/apps/geolibre-desktop/src/lib/sanitize-html.ts
@@ -2,12 +2,17 @@ import DOMPurify from "dompurify";
 
 // Harden links that open in a new tab so the opened page cannot reach back
 // through `window.opener`. DOMPurify passes `target`/`rel` through but does not
-// add `rel`, so enforce it ourselves.
-DOMPurify.addHook("afterSanitizeAttributes", (node) => {
-  if (node.tagName === "A" && node.getAttribute("target") === "_blank") {
-    node.setAttribute("rel", "noopener noreferrer");
-  }
-});
+// add `rel`, so enforce it ourselves. The flag lives on the DOMPurify singleton
+// so a re-evaluated module (HMR, dynamic import) cannot register it twice.
+const purify = DOMPurify as typeof DOMPurify & { __glRelHook?: boolean };
+if (!purify.__glRelHook) {
+  purify.addHook("afterSanitizeAttributes", (node) => {
+    if (node.tagName === "A" && node.getAttribute("target") === "_blank") {
+      node.setAttribute("rel", "noopener noreferrer");
+    }
+  });
+  purify.__glRelHook = true;
+}
 
 /**
  * Sanitize a fragment of user-authored HTML for safe rendering.

--- a/apps/geolibre-desktop/src/lib/sanitize-html.ts
+++ b/apps/geolibre-desktop/src/lib/sanitize-html.ts
@@ -15,8 +15,10 @@ DOMPurify.addHook("afterSanitizeAttributes", (node) => {
  * Story map titles, descriptions, and footers support inline formatting
  * (`<br>`, `<em>`, `<a>`, etc.) like the storytelling template, but a project
  * can be shared or loaded from a URL, so the markup is untrusted. DOMPurify
- * strips scripts and event-handler attributes while keeping formatting, and we
- * force external links to open in a new tab without leaking the opener.
+ * strips scripts and event-handler attributes while keeping formatting;
+ * `ADD_ATTR` keeps author-provided `target`/`rel`, and the module-level hook
+ * above adds `rel="noopener noreferrer"` to any `target="_blank"` link so the
+ * opener cannot be leaked.
  *
  * @param html Raw HTML string to clean.
  * @returns A sanitized HTML string safe for `dangerouslySetInnerHTML`.

--- a/apps/geolibre-desktop/src/lib/sanitize-html.ts
+++ b/apps/geolibre-desktop/src/lib/sanitize-html.ts
@@ -21,24 +21,27 @@ if (!purify.__glRelHook) {
  * (`<br>`, `<em>`, `<a>`, etc.) like the storytelling template, but a project
  * can be shared or loaded from a URL, so the markup is untrusted. DOMPurify
  * strips scripts and event-handler attributes while keeping formatting;
- * `ADD_ATTR` keeps author-provided `target`/`rel`, and the module-level hook
- * above adds `rel="noopener noreferrer"` to any `target="_blank"` link so the
- * opener cannot be leaked.
+ * `ALLOWED_TAGS`/`ALLOWED_ATTR` whitelist only the permitted prose elements and
+ * attributes (replacing DOMPurify's defaults), and the module-level hook above
+ * adds `rel="noopener noreferrer"` to any `target="_blank"` link so the opener
+ * cannot be leaked. `<img>` is intentionally excluded so a shared project cannot
+ * embed tracking pixels in a description; chapter images use the dedicated
+ * `image` field instead.
  *
  * @param html Raw HTML string to clean.
  * @returns A sanitized HTML string safe for `dangerouslySetInnerHTML`.
  */
 export function sanitizeStoryHtml(html: string): string {
-  // Story text is prose with links/images and light formatting, so allow only
-  // that set of tags rather than the full HTML profile. This excludes forms,
-  // tables, media, and other structural elements by construction.
+  // Story text is prose with links and light formatting, so allow only that set
+  // of tags rather than the full HTML profile. This excludes forms, tables,
+  // media, and other structural elements by construction.
   return DOMPurify.sanitize(html, {
     ALLOWED_TAGS: [
       "a", "abbr", "b", "blockquote", "br", "code", "del", "em",
-      "h1", "h2", "h3", "h4", "h5", "h6", "hr", "i", "img", "ins", "kbd",
+      "h1", "h2", "h3", "h4", "h5", "h6", "hr", "i", "ins", "kbd",
       "li", "mark", "ol", "p", "pre", "s", "small", "span", "strong",
       "sub", "sup", "u", "ul",
     ],
-    ALLOWED_ATTR: ["href", "title", "target", "rel", "src", "alt", "width", "height"],
+    ALLOWED_ATTR: ["href", "title", "target", "rel"],
   });
 }

--- a/apps/geolibre-desktop/src/lib/sanitize-html.ts
+++ b/apps/geolibre-desktop/src/lib/sanitize-html.ts
@@ -32,5 +32,8 @@ export function sanitizeStoryHtml(html: string): string {
   return DOMPurify.sanitize(html, {
     ADD_ATTR: ["target", "rel"],
     USE_PROFILES: { html: true },
+    // Story text is prose/links/images; forms add no value and `target` on a
+    // form is an exfiltration vector, so drop form controls entirely.
+    FORBID_TAGS: ["form", "input", "button", "select", "option", "textarea"],
   });
 }

--- a/apps/geolibre-desktop/src/lib/sanitize-html.ts
+++ b/apps/geolibre-desktop/src/lib/sanitize-html.ts
@@ -1,0 +1,20 @@
+import DOMPurify from "dompurify";
+
+/**
+ * Sanitize a fragment of user-authored HTML for safe rendering.
+ *
+ * Story map titles, descriptions, and footers support inline formatting
+ * (`<br>`, `<em>`, `<a>`, etc.) like the storytelling template, but a project
+ * can be shared or loaded from a URL, so the markup is untrusted. DOMPurify
+ * strips scripts and event-handler attributes while keeping formatting, and we
+ * force external links to open in a new tab without leaking the opener.
+ *
+ * @param html Raw HTML string to clean.
+ * @returns A sanitized HTML string safe for `dangerouslySetInnerHTML`.
+ */
+export function sanitizeStoryHtml(html: string): string {
+  return DOMPurify.sanitize(html, {
+    ADD_ATTR: ["target", "rel"],
+    USE_PROFILES: { html: true },
+  });
+}

--- a/apps/geolibre-desktop/src/lib/sanitize-html.ts
+++ b/apps/geolibre-desktop/src/lib/sanitize-html.ts
@@ -1,5 +1,14 @@
 import DOMPurify from "dompurify";
 
+// Harden links that open in a new tab so the opened page cannot reach back
+// through `window.opener`. DOMPurify passes `target`/`rel` through but does not
+// add `rel`, so enforce it ourselves.
+DOMPurify.addHook("afterSanitizeAttributes", (node) => {
+  if (node.tagName === "A" && node.getAttribute("target") === "_blank") {
+    node.setAttribute("rel", "noopener noreferrer");
+  }
+});
+
 /**
  * Sanitize a fragment of user-authored HTML for safe rendering.
  *

--- a/apps/geolibre-desktop/src/lib/storymap-constants.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-constants.ts
@@ -1,0 +1,3 @@
+/** Basemap style for the story-map inset minimap (in-app and export). */
+export const STORY_INSET_STYLE_URL =
+  "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json";

--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -304,11 +304,27 @@ function renderTemplate(
         .fully { width: 100%; margin: auto; }
         .light { color: #444; background-color: #fafafa; }
         .dark { color: #fafafa; background-color: #444; }
-        .step { padding-bottom: 50vh; opacity: 0.25; }
-        .step.active { opacity: 0.9; }
-        .step div { padding: 25px 50px; line-height: 25px; font-size: 13px; }
-        .step img { width: 100%; }
-        @media (max-width: 750px) { .centered, .lefty, .righty, .fully { width: 90vw; margin: 0 auto; } }
+        .step { padding-bottom: 50vh; opacity: 0.25; transition: opacity 0.3s; }
+        .step.active { opacity: 0.95; }
+        .sm-card { position: relative; display: flex; flex-direction: column; max-height: 70vh; line-height: 22px; font-size: 14px; border-radius: 6px; box-shadow: 0 6px 20px rgba(0,0,0,0.25); overflow: hidden; }
+        .sm-bar { display: flex; align-items: center; gap: 6px; padding: 7px 10px; cursor: move; user-select: none; touch-action: none; font-weight: 600; font-size: 13px; border-bottom: 1px solid rgba(127,127,127,0.25); }
+        .sm-grip { opacity: 0.5; flex-shrink: 0; }
+        .sm-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        .sm-body { flex: 1 1 auto; min-height: 0; overflow-y: auto; padding: 14px 18px; }
+        .sm-body p { margin: 0; }
+        .sm-body img { width: 100%; max-height: 38vh; object-fit: cover; border-radius: 2px; }
+        .sm-resize { position: absolute; right: 0; bottom: 0; width: 18px; height: 18px; cursor: nwse-resize; touch-action: none; }
+        .sm-resize::after { content: ''; position: absolute; right: 4px; bottom: 4px; width: 7px; height: 7px; border-right: 2px solid currentColor; border-bottom: 2px solid currentColor; opacity: 0.5; }
+        #nav { position: fixed; left: 12px; top: 12px; max-height: calc(100vh - 24px); width: 220px; overflow-y: auto; z-index: 20; border-radius: 6px; padding: 6px; box-shadow: 0 4px 16px rgba(0,0,0,0.3); font-size: 13px; }
+        #nav.dark { background: rgba(40,40,40,0.85); color: #fafafa; }
+        #nav.light { background: rgba(250,250,250,0.92); color: #444; }
+        .nav-item { display: flex; gap: 8px; align-items: center; padding: 7px 9px; border-radius: 4px; cursor: pointer; }
+        .nav-item:hover { background: rgba(127,127,127,0.18); }
+        .nav-item.active { background: rgba(63,177,206,0.22); font-weight: 600; }
+        .nav-num { width: 20px; height: 20px; border-radius: 50%; background: rgba(127,127,127,0.3); display: inline-flex; align-items: center; justify-content: center; font-size: 11px; flex-shrink: 0; }
+        .nav-item.active .nav-num { background: #3fb1ce; color: #fff; }
+        .nav-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        @media (max-width: 750px) { .centered, .lefty, .righty, .fully { width: 90vw; margin: 0 auto; } #nav { display: none; } }
         .maplibregl-canvas-container.maplibregl-touch-zoom-rotate.maplibregl-touch-drag-pan,
         .maplibregl-canvas-container.maplibregl-touch-zoom-rotate.maplibregl-touch-drag-pan .maplibregl-canvas { touch-action: unset; }
         #inset-map { position: fixed; width: 180px; height: 180px; border: 2px solid rgba(255, 255, 255, 0.8); border-radius: 4px; box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3); z-index: 10; }
@@ -363,22 +379,81 @@ function renderTemplate(
         if (config.byline) { var b = document.createElement('p'); b.innerText = config.byline; header.appendChild(b); }
         if (header.children.length > 0) { header.classList.add(config.theme); header.setAttribute('id', 'header'); story.appendChild(header); }
 
+        function makeDraggable(handle, card) {
+            var dx = 0, dy = 0;
+            handle.addEventListener('pointerdown', function (e) {
+                e.preventDefault();
+                var sx = e.clientX, sy = e.clientY, bx = dx, by = dy;
+                function move(ev) { dx = bx + (ev.clientX - sx); dy = by + (ev.clientY - sy); card.style.transform = 'translate(' + dx + 'px,' + dy + 'px)'; }
+                function up() { window.removeEventListener('pointermove', move); window.removeEventListener('pointerup', up); }
+                window.addEventListener('pointermove', move); window.addEventListener('pointerup', up);
+            });
+            handle.addEventListener('dblclick', function () { dx = 0; dy = 0; card.style.transform = ''; });
+        }
+        function makeResizable(handle, card) {
+            handle.addEventListener('pointerdown', function (e) {
+                e.preventDefault(); e.stopPropagation();
+                var sx = e.clientX, sy = e.clientY, r = card.getBoundingClientRect(), bw = r.width, bh = r.height;
+                function move(ev) { card.style.width = Math.max(200, bw + (ev.clientX - sx)) + 'px'; card.style.height = Math.max(120, bh + (ev.clientY - sy)) + 'px'; }
+                function up() { window.removeEventListener('pointermove', move); window.removeEventListener('pointerup', up); }
+                window.addEventListener('pointermove', move); window.addEventListener('pointerup', up);
+            });
+        }
+
         config.chapters.forEach(function (record, idx) {
             var container = document.createElement('div');
-            var chapter = document.createElement('div');
-            if (record.title) { var h = document.createElement('h3'); h.innerText = record.title; chapter.appendChild(h); }
-            if (record.image) { var img = new Image(); img.src = record.image; chapter.appendChild(img); }
-            if (record.description) { var p = document.createElement('p'); p.innerHTML = record.description; chapter.appendChild(p); }
             container.setAttribute('id', record.id);
             container.classList.add('step');
-            if (idx === 0) container.classList.add('active');
-            chapter.classList.add(config.theme);
-            container.appendChild(chapter);
             container.classList.add(alignments[record.alignment] || 'centered');
+            if (idx === 0) container.classList.add('active');
             if (record.hidden) container.classList.add('hidden');
+
+            var card = document.createElement('div');
+            card.className = 'sm-card ' + config.theme;
+
+            var bar = document.createElement('div');
+            bar.className = 'sm-bar';
+            var grip = document.createElement('span'); grip.className = 'sm-grip'; grip.textContent = '☰';
+            var barTitle = document.createElement('span'); barTitle.className = 'sm-title'; barTitle.innerText = record.title || ('Chapter ' + (idx + 1));
+            bar.appendChild(grip); bar.appendChild(barTitle);
+            makeDraggable(bar, card);
+            card.appendChild(bar);
+
+            var body = document.createElement('div');
+            body.className = 'sm-body';
+            if (record.image) { var img = new Image(); img.src = record.image; body.appendChild(img); }
+            if (record.description) { var p = document.createElement('p'); p.innerHTML = record.description; body.appendChild(p); }
+            card.appendChild(body);
+
+            var rz = document.createElement('div'); rz.className = 'sm-resize';
+            makeResizable(rz, card);
+            card.appendChild(rz);
+
+            container.appendChild(card);
             features.appendChild(container);
         });
         story.appendChild(features);
+
+        // Navigation pane: list chapters and jump to one on click.
+        var nav = document.createElement('div');
+        nav.id = 'nav';
+        nav.className = config.theme;
+        config.chapters.forEach(function (record, idx) {
+            var item = document.createElement('div');
+            item.className = 'nav-item' + (idx === 0 ? ' active' : '');
+            item.setAttribute('data-id', record.id);
+            var num = document.createElement('span'); num.className = 'nav-num'; num.innerText = (idx + 1);
+            var t = document.createElement('span'); t.className = 'nav-title'; t.innerText = record.title || ('Chapter ' + (idx + 1));
+            item.appendChild(num); item.appendChild(t);
+            item.addEventListener('click', function () {
+                var c = document.getElementById(record.id);
+                var card = c && c.querySelector('.sm-card');
+                (card || c).scrollIntoView({ block: 'center' });
+            });
+            nav.appendChild(item);
+        });
+        document.body.appendChild(nav);
+        var navItems = nav.querySelectorAll('.nav-item');
 
         var footer = document.createElement('div');
         if (config.footer) { var f = document.createElement('p'); f.innerHTML = config.footer; footer.appendChild(f); }
@@ -398,7 +473,7 @@ function renderTemplate(
         if (config.inset) {
             var insetContainer = document.createElement('div');
             insetContainer.id = 'inset-map';
-            insetContainer.classList.add(config.insetPosition || 'bottom-right');
+            insetContainer.classList.add(config.insetPosition || 'bottom-left');
             document.body.appendChild(insetContainer);
             insetMap = new maplibregl.Map({ container: 'inset-map', style: config.insetStyle, center: config.chapters[0].location.center, zoom: config.insetZoom || 1, interactive: false, attributionControl: false });
             var markerEl = document.createElement('div');
@@ -424,6 +499,7 @@ ${inlineLayerScript}
                     var chapter = config.chapters[idx];
                     if (!chapter) return;
                     response.element.classList.add('active');
+                    navItems.forEach(function (it) { it.classList.toggle('active', it.getAttribute('data-id') === response.element.id); });
                     // Cancel any in-progress move (e.g. a prior chapter's rotation)
                     // and bump the token so its pending moveend handler is ignored.
                     map.stop();

--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -398,6 +398,7 @@ ${inlineLayerScript}
                 .onStepEnter(function (response) {
                     var idx = config.chapters.findIndex(function (c) { return c.id === response.element.id; });
                     var chapter = config.chapters[idx];
+                    if (!chapter) return;
                     response.element.classList.add('active');
                     map[chapter.mapAnimation || 'flyTo'](chapter.location);
                     if (config.showMarkers && marker) marker.setLngLat(chapter.location.center);
@@ -412,6 +413,7 @@ ${inlineLayerScript}
                 })
                 .onStepExit(function (response) {
                     var chapter = config.chapters.find(function (c) { return c.id === response.element.id; });
+                    if (!chapter) return;
                     response.element.classList.remove('active');
                     if (chapter.onChapterExit.length > 0) chapter.onChapterExit.forEach(setLayerOpacity);
                 });

--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -4,6 +4,7 @@ import {
   type GeoLibreLayer,
   type StoryMap,
 } from "@geolibre/core";
+import { sanitizeStoryHtml } from "./sanitize-html";
 
 export interface StoryMapExportOptions {
   storymap: StoryMap;
@@ -79,10 +80,18 @@ export function buildStoryMapHtml(options: StoryMapExportOptions): string {
   }
 
   // Opacity effects can only target layers that actually exist in the export;
-  // others would make the exported page throw on `map.getLayer(...).type`.
+  // others would make the exported page throw on `map.getLayer(...).type`. The
+  // template runtime reads `layer.layer` for the MapLibre id, so map our
+  // `layerId` field onto that shape as well.
   const inlinedIds = new Set(inlineLayers.map((entry) => entry.id));
   const keepChanges = (changes: StoryMap["chapters"][number]["onChapterEnter"]) =>
-    changes.filter((change) => inlinedIds.has(change.layerId));
+    changes
+      .filter((change) => inlinedIds.has(change.layerId))
+      .map((change) => ({
+        layer: change.layerId,
+        opacity: change.opacity,
+        ...(change.duration !== undefined ? { duration: change.duration } : {}),
+      }));
 
   const config = {
     style: basemapStyleUrl,
@@ -97,14 +106,16 @@ export function buildStoryMapHtml(options: StoryMapExportOptions): string {
     title: storymap.title,
     subtitle: storymap.subtitle,
     byline: storymap.byline,
-    footer: storymap.footer,
+    // Description and footer are written into the exported page via innerHTML,
+    // so sanitize them here just like the in-app presenter does.
+    footer: sanitizeStoryHtml(storymap.footer),
     chapters: storymap.chapters.map((chapter) => ({
       id: chapter.id,
       alignment: chapter.alignment,
       hidden: chapter.hidden,
       title: chapter.title,
       image: chapter.image ?? "",
-      description: chapter.description,
+      description: sanitizeStoryHtml(chapter.description),
       location: {
         center: chapter.location.center,
         zoom: chapter.location.zoom,

--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -340,7 +340,7 @@ function renderTemplate(
         if (config.title) { var t = document.createElement('h1'); t.innerText = config.title; header.appendChild(t); }
         if (config.subtitle) { var s = document.createElement('h2'); s.innerText = config.subtitle; header.appendChild(s); }
         if (config.byline) { var b = document.createElement('p'); b.innerText = config.byline; header.appendChild(b); }
-        if (header.innerText.length > 0) { header.classList.add(config.theme); header.setAttribute('id', 'header'); story.appendChild(header); }
+        if (header.children.length > 0) { header.classList.add(config.theme); header.setAttribute('id', 'header'); story.appendChild(header); }
 
         config.chapters.forEach(function (record, idx) {
             var container = document.createElement('div');
@@ -361,7 +361,7 @@ function renderTemplate(
 
         var footer = document.createElement('div');
         if (config.footer) { var f = document.createElement('p'); f.innerHTML = config.footer; footer.appendChild(f); }
-        if (footer.innerText.length > 0) { footer.classList.add(config.theme); footer.setAttribute('id', 'footer'); story.appendChild(footer); }
+        if (footer.children.length > 0) { footer.classList.add(config.theme); footer.setAttribute('id', 'footer'); story.appendChild(footer); }
 
         var map = new maplibregl.Map({
             container: 'map',

--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -38,6 +38,13 @@ const INSET_STYLE_URL =
 export function buildStoryMapHtml(options: StoryMapExportOptions): string {
   const { storymap, basemapStyleUrl, layers } = options;
 
+  // The template reads chapters[0] for the initial camera, so an empty story
+  // cannot produce a working page. Callers gate this behind a chapter count,
+  // but fail loudly if that ever slips.
+  if (storymap.chapters.length === 0) {
+    throw new Error("Cannot export a story map with no chapters.");
+  }
+
   // Only inline layers that are actually referenced by a chapter transition or
   // that are visible GeoJSON layers, so the export stays focused on the story.
   // `referenced` (enter ∪ exit) drives which layers to inline; only layers a
@@ -71,6 +78,12 @@ export function buildStoryMapHtml(options: StoryMapExportOptions): string {
     });
   }
 
+  // Opacity effects can only target layers that actually exist in the export;
+  // others would make the exported page throw on `map.getLayer(...).type`.
+  const inlinedIds = new Set(inlineLayers.map((entry) => entry.id));
+  const keepChanges = (changes: StoryMap["chapters"][number]["onChapterEnter"]) =>
+    changes.filter((change) => inlinedIds.has(change.layerId));
+
   const config = {
     style: basemapStyleUrl,
     showMarkers: storymap.showMarkers,
@@ -101,8 +114,8 @@ export function buildStoryMapHtml(options: StoryMapExportOptions): string {
       mapAnimation: chapter.mapAnimation,
       rotateAnimation: chapter.rotateAnimation,
       callback: "",
-      onChapterEnter: chapter.onChapterEnter,
-      onChapterExit: chapter.onChapterExit,
+      onChapterEnter: keepChanges(chapter.onChapterEnter),
+      onChapterExit: keepChanges(chapter.onChapterExit),
     })),
   };
 
@@ -241,8 +254,8 @@ function renderTemplate(
     <meta charset='utf-8' />
     <title>${escapeHtml(String(config.title || "Story Map"))}</title>
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-    <script src='https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js'></script>
-    <link href='https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css' rel='stylesheet' />
+    <script src='https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js'></script>
+    <link href='https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css' rel='stylesheet' />
     <script src="https://unpkg.com/scrollama@3.2.0"></script>
     <style>
         body { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }

--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -413,6 +413,7 @@ function renderTemplate(
         }
 
         var scroller = scrollama();
+        var cameraToken = 0;
 
         map.on('load', function () {
 ${inlineLayerScript}
@@ -423,12 +424,17 @@ ${inlineLayerScript}
                     var chapter = config.chapters[idx];
                     if (!chapter) return;
                     response.element.classList.add('active');
+                    // Cancel any in-progress move (e.g. a prior chapter's rotation)
+                    // and bump the token so its pending moveend handler is ignored.
+                    map.stop();
+                    var token = ++cameraToken;
                     map[chapter.mapAnimation || 'flyTo'](chapter.location);
                     if (config.showMarkers && marker) marker.setLngLat(chapter.location.center);
                     if (insetMap && insetMarker) { insetMap.setCenter(chapter.location.center); insetMarker.setLngLat(chapter.location.center); }
                     if (chapter.onChapterEnter.length > 0) chapter.onChapterEnter.forEach(setLayerOpacity);
                     if (chapter.rotateAnimation) {
                         map.once('moveend', function () {
+                            if (token !== cameraToken) return;
                             var bearing = map.getBearing();
                             map.rotateTo(bearing + 180, { duration: 30000, easing: function (t) { return t; } });
                         });

--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -1,0 +1,392 @@
+import type { FeatureCollection, Geometry } from "geojson";
+import {
+  styleValue,
+  type GeoLibreLayer,
+  type StoryMap,
+} from "@geolibre/core";
+
+export interface StoryMapExportOptions {
+  storymap: StoryMap;
+  /** MapLibre style URL used as the story basemap. */
+  basemapStyleUrl: string;
+  /** Project layers; only in-memory GeoJSON layers are inlined into the export. */
+  layers: GeoLibreLayer[];
+}
+
+interface InlineLayerExport {
+  id: string;
+  geojson: FeatureCollection;
+  layerSpec: Record<string, unknown>;
+  /** Opacity paint property to drive with story chapter transitions. */
+  initialOpacity: number;
+}
+
+const INSET_STYLE_URL =
+  "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json";
+
+/**
+ * Build a self-contained MapLibre storytelling HTML document for a story map.
+ *
+ * The output mirrors the `opengeos/maplibre-gl-storymaps` template: a single
+ * scroll-driven page that flies between chapter locations. Project GeoJSON
+ * layers referenced by chapter opacity transitions are inlined so the exported
+ * story behaves like the in-app preview without any external data files.
+ *
+ * @param options Story map, basemap style, and project layers to export.
+ * @returns A complete HTML document as a string.
+ */
+export function buildStoryMapHtml(options: StoryMapExportOptions): string {
+  const { storymap, basemapStyleUrl, layers } = options;
+
+  // Only inline layers that are actually referenced by a chapter transition or
+  // that are visible GeoJSON layers, so the export stays focused on the story.
+  const referenced = new Set<string>();
+  for (const chapter of storymap.chapters) {
+    for (const change of [...chapter.onChapterEnter, ...chapter.onChapterExit]) {
+      referenced.add(change.layerId);
+    }
+  }
+
+  const inlineLayers: InlineLayerExport[] = [];
+  for (const layer of layers) {
+    if (layer.type !== "geojson" || !layer.geojson) continue;
+    const isReferenced = referenced.has(layer.id);
+    if (!isReferenced && !layer.visible) continue;
+    const layerSpec = buildLayerSpec(layer);
+    if (!layerSpec) continue;
+    inlineLayers.push({
+      id: layer.id,
+      geojson: layer.geojson,
+      layerSpec,
+      // Referenced layers start hidden so the first chapter can fade them in.
+      initialOpacity: isReferenced ? 0 : layer.opacity,
+    });
+  }
+
+  const config = {
+    style: basemapStyleUrl,
+    showMarkers: storymap.showMarkers,
+    markerColor: storymap.markerColor,
+    inset: storymap.inset,
+    insetPosition: storymap.insetPosition,
+    insetStyle: INSET_STYLE_URL,
+    insetZoom: 1,
+    theme: storymap.theme,
+    auto: false,
+    title: storymap.title,
+    subtitle: storymap.subtitle,
+    byline: storymap.byline,
+    footer: storymap.footer,
+    chapters: storymap.chapters.map((chapter) => ({
+      id: chapter.id,
+      alignment: chapter.alignment,
+      hidden: chapter.hidden,
+      title: chapter.title,
+      image: chapter.image ?? "",
+      description: chapter.description,
+      location: {
+        center: chapter.location.center,
+        zoom: chapter.location.zoom,
+        pitch: chapter.location.pitch,
+        bearing: chapter.location.bearing,
+      },
+      mapAnimation: chapter.mapAnimation,
+      rotateAnimation: chapter.rotateAnimation,
+      callback: "",
+      onChapterEnter: chapter.onChapterEnter,
+      onChapterExit: chapter.onChapterExit,
+    })),
+  };
+
+  const inlineLayerScript = inlineLayers
+    .map((entry) => {
+      const sourceId = `${entry.id}-source`;
+      const paint = { ...(entry.layerSpec.paint as Record<string, unknown>) };
+      // Override the opacity paint property with the story's initial value.
+      const opacityProp = opacityProperty(entry.layerSpec.type as string);
+      if (opacityProp) paint[opacityProp] = entry.initialOpacity;
+      const spec = {
+        ...entry.layerSpec,
+        id: entry.id,
+        source: sourceId,
+        paint,
+      };
+      return `    map.addSource(${JSON.stringify(sourceId)}, { type: 'geojson', data: ${JSON.stringify(entry.geojson)} });
+    map.addLayer(${JSON.stringify(spec)});`;
+    })
+    .join("\n");
+
+  return renderTemplate(config, inlineLayerScript);
+}
+
+function opacityProperty(type: string): string | null {
+  switch (type) {
+    case "fill":
+      return "fill-opacity";
+    case "line":
+      return "line-opacity";
+    case "circle":
+      return "circle-opacity";
+    case "fill-extrusion":
+      return "fill-extrusion-opacity";
+    default:
+      return null;
+  }
+}
+
+/** Pick a dominant geometry kind for choosing a MapLibre layer type. */
+function geometryKind(
+  geojson: FeatureCollection,
+): "polygon" | "line" | "point" | null {
+  for (const feature of geojson.features) {
+    const kind = classifyGeometry(feature.geometry);
+    if (kind) return kind;
+  }
+  return null;
+}
+
+function classifyGeometry(
+  geometry: Geometry | null,
+): "polygon" | "line" | "point" | null {
+  if (!geometry) return null;
+  switch (geometry.type) {
+    case "Polygon":
+    case "MultiPolygon":
+      return "polygon";
+    case "LineString":
+    case "MultiLineString":
+      return "line";
+    case "Point":
+    case "MultiPoint":
+      return "point";
+    case "GeometryCollection":
+      for (const sub of geometry.geometries) {
+        const kind = classifyGeometry(sub);
+        if (kind) return kind;
+      }
+      return null;
+    default:
+      return null;
+  }
+}
+
+/** Convert a GeoLibre GeoJSON layer to a minimal MapLibre layer spec. */
+function buildLayerSpec(
+  layer: GeoLibreLayer,
+): Record<string, unknown> | null {
+  if (!layer.geojson) return null;
+  const kind = geometryKind(layer.geojson);
+  if (!kind) return null;
+
+  if (kind === "polygon") {
+    return {
+      type: "fill",
+      paint: {
+        "fill-color": styleValue(layer.style, "fillColor"),
+        "fill-opacity": styleValue(layer.style, "fillOpacity"),
+        "fill-outline-color": styleValue(layer.style, "strokeColor"),
+      },
+    };
+  }
+  if (kind === "line") {
+    return {
+      type: "line",
+      paint: {
+        "line-color": styleValue(layer.style, "strokeColor"),
+        "line-width": styleValue(layer.style, "strokeWidth"),
+        "line-opacity": 1,
+      },
+    };
+  }
+  return {
+    type: "circle",
+    paint: {
+      "circle-color": styleValue(layer.style, "fillColor"),
+      "circle-radius": styleValue(layer.style, "circleRadius"),
+      "circle-stroke-color": styleValue(layer.style, "strokeColor"),
+      "circle-stroke-width": styleValue(layer.style, "strokeWidth"),
+      "circle-opacity": 1,
+    },
+  };
+}
+
+function renderTemplate(
+  config: Record<string, unknown>,
+  inlineLayerScript: string,
+): string {
+  const configJson = JSON.stringify(config, null, 4);
+  return `<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset='utf-8' />
+    <title>${escapeHtml(String(config.title || "Story Map"))}</title>
+    <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
+    <script src='https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js'></script>
+    <link href='https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css' rel='stylesheet' />
+    <script src="https://unpkg.com/scrollama"></script>
+    <style>
+        body { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+        a, a:hover, a:visited { color: #0071bc; }
+        #map { top: 0; height: 100vh; width: 100vw; position: fixed; }
+        #header { margin: auto; width: 100%; position: relative; z-index: 5; }
+        #header h1, #header h2, #header p { margin: 0; padding: 2vh 2vw; text-align: center; }
+        #footer { width: 100%; min-height: 5vh; padding: 2vh 0; text-align: center; line-height: 25px; font-size: 13px; position: relative; z-index: 5; }
+        #features { padding-top: 10vh; padding-bottom: 10vh; }
+        .hidden { visibility: hidden; }
+        .centered { width: 50vw; margin: 0 auto; }
+        .lefty { width: 33vw; margin-left: 5vw; }
+        .righty { width: 33vw; margin-left: 62vw; }
+        .fully { width: 100%; margin: auto; }
+        .light { color: #444; background-color: #fafafa; }
+        .dark { color: #fafafa; background-color: #444; }
+        .step { padding-bottom: 50vh; opacity: 0.25; }
+        .step.active { opacity: 0.9; }
+        .step div { padding: 25px 50px; line-height: 25px; font-size: 13px; }
+        .step img { width: 100%; }
+        @media (max-width: 750px) { .centered, .lefty, .righty, .fully { width: 90vw; margin: 0 auto; } }
+        .maplibregl-canvas-container.maplibregl-touch-zoom-rotate.maplibregl-touch-drag-pan,
+        .maplibregl-canvas-container.maplibregl-touch-zoom-rotate.maplibregl-touch-drag-pan .maplibregl-canvas { touch-action: unset; }
+        #inset-map { position: fixed; width: 180px; height: 180px; border: 2px solid rgba(255, 255, 255, 0.8); border-radius: 4px; box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3); z-index: 10; }
+        #inset-map.top-left { top: 10px; left: 10px; }
+        #inset-map.top-right { top: 10px; right: 10px; }
+        #inset-map.bottom-left { bottom: 30px; left: 10px; }
+        #inset-map.bottom-right { bottom: 30px; right: 10px; }
+        .inset-marker { width: 12px; height: 12px; background-color: #ff6b6b; border: 2px solid white; border-radius: 50%; box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3); }
+    </style>
+</head>
+
+<body>
+    <div id="map"></div>
+    <div id="story"></div>
+
+    <script>
+        var config = ${configJson};
+    </script>
+    <script>
+        var layerTypes = {
+            'fill': ['fill-opacity'],
+            'line': ['line-opacity'],
+            'circle': ['circle-opacity', 'circle-stroke-opacity'],
+            'symbol': ['icon-opacity', 'text-opacity'],
+            'raster': ['raster-opacity'],
+            'fill-extrusion': ['fill-extrusion-opacity'],
+            'heatmap': ['heatmap-opacity'],
+            'hillshade': ['hillshade-exaggeration']
+        };
+        var alignments = { 'left': 'lefty', 'center': 'centered', 'right': 'righty', 'full': 'fully' };
+
+        function getLayerPaintType(layer) { return layerTypes[map.getLayer(layer).type]; }
+        function setLayerOpacity(layer) {
+            var paintProps = getLayerPaintType(layer.layer);
+            if (!paintProps) return;
+            paintProps.forEach(function (prop) {
+                var options = {};
+                if (layer.duration) {
+                    map.setPaintProperty(layer.layer, prop + '-transition', { duration: layer.duration });
+                }
+                map.setPaintProperty(layer.layer, prop, layer.opacity, options);
+            });
+        }
+
+        var story = document.getElementById('story');
+        var features = document.createElement('div');
+        features.setAttribute('id', 'features');
+        var header = document.createElement('div');
+
+        if (config.title) { var t = document.createElement('h1'); t.innerText = config.title; header.appendChild(t); }
+        if (config.subtitle) { var s = document.createElement('h2'); s.innerText = config.subtitle; header.appendChild(s); }
+        if (config.byline) { var b = document.createElement('p'); b.innerText = config.byline; header.appendChild(b); }
+        if (header.innerText.length > 0) { header.classList.add(config.theme); header.setAttribute('id', 'header'); story.appendChild(header); }
+
+        config.chapters.forEach(function (record, idx) {
+            var container = document.createElement('div');
+            var chapter = document.createElement('div');
+            if (record.title) { var h = document.createElement('h3'); h.innerText = record.title; chapter.appendChild(h); }
+            if (record.image) { var img = new Image(); img.src = record.image; chapter.appendChild(img); }
+            if (record.description) { var p = document.createElement('p'); p.innerHTML = record.description; chapter.appendChild(p); }
+            container.setAttribute('id', record.id);
+            container.classList.add('step');
+            if (idx === 0) container.classList.add('active');
+            chapter.classList.add(config.theme);
+            container.appendChild(chapter);
+            container.classList.add(alignments[record.alignment] || 'centered');
+            if (record.hidden) container.classList.add('hidden');
+            features.appendChild(container);
+        });
+        story.appendChild(features);
+
+        var footer = document.createElement('div');
+        if (config.footer) { var f = document.createElement('p'); f.innerHTML = config.footer; footer.appendChild(f); }
+        if (footer.innerText.length > 0) { footer.classList.add(config.theme); footer.setAttribute('id', 'footer'); story.appendChild(footer); }
+
+        var map = new maplibregl.Map({
+            container: 'map',
+            style: config.style,
+            center: config.chapters[0].location.center,
+            zoom: config.chapters[0].location.zoom,
+            bearing: config.chapters[0].location.bearing,
+            pitch: config.chapters[0].location.pitch,
+            interactive: false
+        });
+
+        var insetMap = null, insetMarker = null;
+        if (config.inset) {
+            var insetContainer = document.createElement('div');
+            insetContainer.id = 'inset-map';
+            insetContainer.classList.add(config.insetPosition || 'bottom-right');
+            document.body.appendChild(insetContainer);
+            insetMap = new maplibregl.Map({ container: 'inset-map', style: config.insetStyle, center: config.chapters[0].location.center, zoom: config.insetZoom || 1, interactive: false, attributionControl: false });
+            var markerEl = document.createElement('div');
+            markerEl.className = 'inset-marker';
+            insetMarker = new maplibregl.Marker({ element: markerEl }).setLngLat(config.chapters[0].location.center).addTo(insetMap);
+        }
+
+        var marker = null;
+        if (config.showMarkers) {
+            marker = new maplibregl.Marker({ color: config.markerColor });
+            marker.setLngLat(config.chapters[0].location.center).addTo(map);
+        }
+
+        var scroller = scrollama();
+
+        map.on('load', function () {
+${inlineLayerScript}
+
+            scroller.setup({ step: '.step', offset: 0.5, progress: true })
+                .onStepEnter(function (response) {
+                    var idx = config.chapters.findIndex(function (c) { return c.id === response.element.id; });
+                    var chapter = config.chapters[idx];
+                    response.element.classList.add('active');
+                    map[chapter.mapAnimation || 'flyTo'](chapter.location);
+                    if (config.showMarkers && marker) marker.setLngLat(chapter.location.center);
+                    if (insetMap && insetMarker) { insetMap.setCenter(chapter.location.center); insetMarker.setLngLat(chapter.location.center); }
+                    if (chapter.onChapterEnter.length > 0) chapter.onChapterEnter.forEach(setLayerOpacity);
+                    if (chapter.rotateAnimation) {
+                        map.once('moveend', function () {
+                            var bearing = map.getBearing();
+                            map.rotateTo(bearing + 180, { duration: 30000, easing: function (t) { return t; } });
+                        });
+                    }
+                })
+                .onStepExit(function (response) {
+                    var chapter = config.chapters.find(function (c) { return c.id === response.element.id; });
+                    response.element.classList.remove('active');
+                    if (chapter.onChapterExit.length > 0) chapter.onChapterExit.forEach(setLayerOpacity);
+                });
+        });
+
+        window.addEventListener('resize', scroller.resize);
+    </script>
+</body>
+
+</html>
+`;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}

--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -73,7 +73,9 @@ export function buildStoryMapHtml(options: StoryMapExportOptions): string {
       id: layer.id,
       geojson: layer.geojson,
       layerSpec,
-      layerOpacity: layer.opacity,
+      // Hidden layers export fully transparent so the export matches what
+      // GeoLibre renders (the opacity slider value alone ignores visibility).
+      layerOpacity: layer.visible ? layer.opacity : 0,
       // Layers a chapter fades in start hidden; exit-only and unreferenced
       // layers keep their natural opacity so they are visible until faded out.
       fadesIn: referencedOnEnter.has(layer.id),
@@ -165,12 +167,14 @@ export function buildStoryMapHtml(options: StoryMapExportOptions): string {
 /**
  * Serialize a value to JSON for embedding inside an inline `<script>` block.
  *
- * Escapes `</` so a string containing `</script>` (or any other closing tag)
- * cannot terminate the script element early, which would let crafted project
- * content inject markup into the exported page.
+ * Escapes `</` and `<!--` so a string containing `</script>` or an HTML comment
+ * opener cannot terminate the script element early or start a comment, which
+ * would let crafted project content inject markup into the exported page.
  */
 function jsonForScript(value: unknown, space?: number): string {
-  return JSON.stringify(value, null, space).replace(/<\//g, "<\\/");
+  return JSON.stringify(value, null, space)
+    .replace(/<\//g, "<\\/")
+    .replace(/<!--/g, "<\\!--");
 }
 
 function opacityProperty(type: string): string | null {
@@ -347,7 +351,7 @@ function renderTemplate(
         var layerTypes = {
             'fill': ['fill-opacity'],
             'line': ['line-opacity'],
-            'circle': ['circle-opacity', 'circle-stroke-opacity'],
+            'circle': ['circle-opacity'],
             'symbol': ['icon-opacity', 'text-opacity'],
             'raster': ['raster-opacity'],
             'fill-extrusion': ['fill-extrusion-opacity'],
@@ -493,7 +497,7 @@ function renderTemplate(
         map.on('load', function () {
 ${inlineLayerScript}
 
-            scroller.setup({ step: '.step', offset: 0.5, progress: true })
+            scroller.setup({ step: '.step', offset: 0.5 })
                 .onStepEnter(function (response) {
                     var idx = config.chapters.findIndex(function (c) { return c.id === response.element.id; });
                     var chapter = config.chapters[idx];

--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -19,8 +19,10 @@ interface InlineLayerExport {
   id: string;
   geojson: FeatureCollection;
   layerSpec: Record<string, unknown>;
-  /** Opacity paint property to drive with story chapter transitions. */
-  initialOpacity: number;
+  /** GeoLibre layer-level opacity, combined with the style's per-geometry one. */
+  layerOpacity: number;
+  /** Whether a chapter fades this layer in (so it starts hidden). */
+  fadesIn: boolean;
 }
 
 /**
@@ -71,9 +73,10 @@ export function buildStoryMapHtml(options: StoryMapExportOptions): string {
       id: layer.id,
       geojson: layer.geojson,
       layerSpec,
-      // Layers a chapter fades in start hidden; exit-only layers keep their
-      // natural opacity so they are visible until faded out.
-      initialOpacity: referencedOnEnter.has(layer.id) ? 0 : layer.opacity,
+      layerOpacity: layer.opacity,
+      // Layers a chapter fades in start hidden; exit-only and unreferenced
+      // layers keep their natural opacity so they are visible until faded out.
+      fadesIn: referencedOnEnter.has(layer.id),
     });
   }
 
@@ -132,9 +135,19 @@ export function buildStoryMapHtml(options: StoryMapExportOptions): string {
     .map((entry) => {
       const sourceId = `${entry.id}-source`;
       const paint = { ...(entry.layerSpec.paint as Record<string, unknown>) };
-      // Override the opacity paint property with the story's initial value.
+      // Seed the opacity paint property: 0 when a chapter fades the layer in,
+      // otherwise the style's per-geometry opacity scaled by the layer opacity
+      // so the export matches what GeoLibre renders.
       const opacityProp = opacityProperty(entry.layerSpec.type as string);
-      if (opacityProp) paint[opacityProp] = entry.initialOpacity;
+      if (opacityProp) {
+        const styleOpacity =
+          typeof paint[opacityProp] === "number"
+            ? (paint[opacityProp] as number)
+            : 1;
+        paint[opacityProp] = entry.fadesIn
+          ? 0
+          : styleOpacity * entry.layerOpacity;
+      }
       const spec = {
         ...entry.layerSpec,
         id: entry.id,
@@ -263,9 +276,10 @@ function renderTemplate(
     <meta charset='utf-8' />
     <title>${escapeHtml(String(config.title || "Story Map"))}</title>
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-    <script src='https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js'></script>
-    <link href='https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css' rel='stylesheet' />
-    <script src="https://unpkg.com/scrollama@3.2.0"></script>
+    <!-- SRI hashes are pinned to the versions above; update both together. -->
+    <script src='https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js' integrity='sha384-5+cfbwT0iiub6VsQAdn6yz16nr6sDiQoHx6tm4O8OVYXHYOxcffFmCJBL0dgdvGp' crossorigin='anonymous'></script>
+    <link href='https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css' rel='stylesheet' integrity='sha384-uTttxo/aOKbdE5RlD/SPzSDoDmNvGlUYPjONi2MN/b7c9HPSvW07OIuyP7uL6jxK' crossorigin='anonymous' />
+    <script src="https://unpkg.com/scrollama@3.2.0/build/scrollama.js" integrity="sha384-cQr5Cx9W8UDNyE09swPH4QMork1pq5sHUzY32DbxJ/WpWFSpr2MG8FGs/3pMjp2S" crossorigin="anonymous"></script>
     <style>
         body { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
         a, a:hover, a:visited { color: #0071bc; }

--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -279,7 +279,7 @@ function renderTemplate(
 ): string {
   const configJson = jsonForScript(config, 4);
   return `<!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
     <meta charset='utf-8' />

--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -5,6 +5,7 @@ import {
   type StoryMap,
 } from "@geolibre/core";
 import { sanitizeStoryHtml } from "./sanitize-html";
+import { STORY_INSET_STYLE_URL } from "./storymap-constants";
 
 export interface StoryMapExportOptions {
   storymap: StoryMap;
@@ -21,9 +22,6 @@ interface InlineLayerExport {
   /** Opacity paint property to drive with story chapter transitions. */
   initialOpacity: number;
 }
-
-const INSET_STYLE_URL =
-  "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json";
 
 /**
  * Build a self-contained MapLibre storytelling HTML document for a story map.
@@ -99,7 +97,7 @@ export function buildStoryMapHtml(options: StoryMapExportOptions): string {
     markerColor: storymap.markerColor,
     inset: storymap.inset,
     insetPosition: storymap.insetPosition,
-    insetStyle: INSET_STYLE_URL,
+    insetStyle: STORY_INSET_STYLE_URL,
     insetZoom: 1,
     theme: storymap.theme,
     auto: false,
@@ -319,16 +317,16 @@ function renderTemplate(
         };
         var alignments = { 'left': 'lefty', 'center': 'centered', 'right': 'righty', 'full': 'fully' };
 
-        function getLayerPaintType(layer) { return layerTypes[map.getLayer(layer).type]; }
+        function getLayerPaintType(layer) { var sl = map.getLayer(layer); return sl ? layerTypes[sl.type] : null; }
         function setLayerOpacity(layer) {
+            if (!map.getLayer(layer.layer)) return;
             var paintProps = getLayerPaintType(layer.layer);
             if (!paintProps) return;
             paintProps.forEach(function (prop) {
-                var options = {};
                 if (layer.duration) {
                     map.setPaintProperty(layer.layer, prop + '-transition', { duration: layer.duration });
                 }
-                map.setPaintProperty(layer.layer, prop, layer.opacity, options);
+                map.setPaintProperty(layer.layer, prop, layer.opacity);
             });
         }
 

--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -188,15 +188,22 @@ function opacityProperty(type: string): string | null {
   }
 }
 
-/** Pick a dominant geometry kind for choosing a MapLibre layer type. */
+/** Pick the dominant (most common) geometry kind for the MapLibre layer type. */
 function geometryKind(
   geojson: FeatureCollection,
 ): "polygon" | "line" | "point" | null {
+  const counts = { polygon: 0, line: 0, point: 0 };
   for (const feature of geojson.features) {
     const kind = classifyGeometry(feature.geometry);
-    if (kind) return kind;
+    if (kind) counts[kind]++;
   }
-  return null;
+  let best: "polygon" | "line" | "point" | null = null;
+  for (const kind of ["polygon", "line", "point"] as const) {
+    if (counts[kind] > 0 && (best === null || counts[kind] > counts[best])) {
+      best = kind;
+    }
+  }
+  return best;
 }
 
 function classifyGeometry(
@@ -259,7 +266,9 @@ function buildLayerSpec(
       "circle-radius": styleValue(layer.style, "circleRadius"),
       "circle-stroke-color": styleValue(layer.style, "strokeColor"),
       "circle-stroke-width": styleValue(layer.style, "strokeWidth"),
-      "circle-opacity": 1,
+      // In-app circle-opacity is fillOpacity * layerOpacity; seed fillOpacity
+      // here so the later layerOpacity scaling matches.
+      "circle-opacity": styleValue(layer.style, "fillOpacity"),
     },
   };
 }

--- a/apps/geolibre-desktop/src/lib/storymap-export.ts
+++ b/apps/geolibre-desktop/src/lib/storymap-export.ts
@@ -40,9 +40,16 @@ export function buildStoryMapHtml(options: StoryMapExportOptions): string {
 
   // Only inline layers that are actually referenced by a chapter transition or
   // that are visible GeoJSON layers, so the export stays focused on the story.
+  // `referenced` (enter ∪ exit) drives which layers to inline; only layers a
+  // chapter fades *in* should start hidden, so those are tracked separately.
   const referenced = new Set<string>();
+  const referencedOnEnter = new Set<string>();
   for (const chapter of storymap.chapters) {
-    for (const change of [...chapter.onChapterEnter, ...chapter.onChapterExit]) {
+    for (const change of chapter.onChapterEnter) {
+      referenced.add(change.layerId);
+      referencedOnEnter.add(change.layerId);
+    }
+    for (const change of chapter.onChapterExit) {
       referenced.add(change.layerId);
     }
   }
@@ -58,8 +65,9 @@ export function buildStoryMapHtml(options: StoryMapExportOptions): string {
       id: layer.id,
       geojson: layer.geojson,
       layerSpec,
-      // Referenced layers start hidden so the first chapter can fade them in.
-      initialOpacity: isReferenced ? 0 : layer.opacity,
+      // Layers a chapter fades in start hidden; exit-only layers keep their
+      // natural opacity so they are visible until faded out.
+      initialOpacity: referencedOnEnter.has(layer.id) ? 0 : layer.opacity,
     });
   }
 
@@ -111,12 +119,23 @@ export function buildStoryMapHtml(options: StoryMapExportOptions): string {
         source: sourceId,
         paint,
       };
-      return `    map.addSource(${JSON.stringify(sourceId)}, { type: 'geojson', data: ${JSON.stringify(entry.geojson)} });
-    map.addLayer(${JSON.stringify(spec)});`;
+      return `    map.addSource(${jsonForScript(sourceId)}, { type: 'geojson', data: ${jsonForScript(entry.geojson)} });
+    map.addLayer(${jsonForScript(spec)});`;
     })
     .join("\n");
 
   return renderTemplate(config, inlineLayerScript);
+}
+
+/**
+ * Serialize a value to JSON for embedding inside an inline `<script>` block.
+ *
+ * Escapes `</` so a string containing `</script>` (or any other closing tag)
+ * cannot terminate the script element early, which would let crafted project
+ * content inject markup into the exported page.
+ */
+function jsonForScript(value: unknown, space?: number): string {
+  return JSON.stringify(value, null, space).replace(/<\//g, "<\\/");
 }
 
 function opacityProperty(type: string): string | null {
@@ -214,7 +233,7 @@ function renderTemplate(
   config: Record<string, unknown>,
   inlineLayerScript: string,
 ): string {
-  const configJson = JSON.stringify(config, null, 4);
+  const configJson = jsonForScript(config, 4);
   return `<!DOCTYPE html>
 <html>
 
@@ -224,7 +243,7 @@ function renderTemplate(
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
     <script src='https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js'></script>
     <link href='https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css' rel='stylesheet' />
-    <script src="https://unpkg.com/scrollama"></script>
+    <script src="https://unpkg.com/scrollama@3.2.0"></script>
     <style>
         body { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
         a, a:hover, a:visited { color: #0071bc; }

--- a/docs/project-format.md
+++ b/docs/project-format.md
@@ -15,6 +15,7 @@ Projects are saved as **`.geolibre.json`** files.
 | `layers`          | array   | Layer definitions (see below)                                                                                |
 | `styles`          | object  | Map of layer id → `LayerStyle`                                                                               |
 | `plugins`         | object  | Optional external plugin manifest URLs, active plugin IDs, plugin map-control positions, and plugin settings |
+| `storymap`        | object  | Optional scroll-driven story map (chapters and presentation settings); omitted when there are no chapters    |
 | `metadata`        | object  | Free-form project metadata                                                                                   |
 
 ## Plugin state
@@ -41,6 +42,46 @@ Projects are saved as **`.geolibre.json`** files.
 ```
 
 Projects without a `plugins` section open with the built-in default plugin state.
+
+## Story map
+
+A story map turns the project into a scroll-driven narrative. Each chapter
+captures a camera view plus text, and can fade project layers in or out on
+enter/exit. The section is omitted entirely when the project has no chapters.
+
+```json
+{
+  "title": "A Tour of Three Cities",
+  "subtitle": "Built with GeoLibre",
+  "byline": "By the GeoLibre team",
+  "footer": "Source: OpenStreetMap",
+  "theme": "dark",
+  "showMarkers": true,
+  "markerColor": "#3fb1ce",
+  "inset": false,
+  "insetPosition": "bottom-right",
+  "chapters": [
+    {
+      "id": "intro",
+      "title": "San Francisco",
+      "description": "A hilly city on the tip of a peninsula. <em>HTML allowed.</em>",
+      "image": "https://example.com/sf.jpg",
+      "alignment": "left",
+      "hidden": false,
+      "location": { "center": [-122.4194, 37.7749], "zoom": 11, "pitch": 45, "bearing": 0 },
+      "mapAnimation": "flyTo",
+      "rotateAnimation": false,
+      "onChapterEnter": [{ "layerId": "layer-a", "opacity": 1, "duration": 2000 }],
+      "onChapterExit": [{ "layerId": "layer-a", "opacity": 0 }]
+    }
+  ]
+}
+```
+
+`alignment` is one of `left`, `center`, `right`, `full`; `mapAnimation` is
+`flyTo`, `easeTo`, or `jumpTo`. Layer opacity changes reference project layer
+ids. Build and present story maps from **Project → Story Map**, or export a
+self-contained HTML page for static hosting.
 
 ## Layer object
 

--- a/docs/user-guide/storymaps.md
+++ b/docs/user-guide/storymaps.md
@@ -43,6 +43,23 @@ Use **Set to current view** to re-capture the camera after panning, zooming, or
 tilting the map, and the map-pin button to fly to a chapter while editing.
 Reorder chapters with the arrows and remove them with the trash icon.
 
+## Import and export chapters
+
+To author content outside GeoLibre, use **Import** / **Export** next to **Add
+chapter**:
+
+- **Export JSON** writes the whole story (settings and chapters); **Import JSON**
+  reads it back (a full `.geolibre.json` project file also works).
+- **Export CSV** writes one row per chapter (spreadsheet-friendly). **Import CSV**
+  replaces the chapters while keeping your current story settings.
+
+The CSV columns are `id, title, description, image, alignment, hidden, lng, lat,
+zoom, pitch, bearing, mapAnimation, rotateAnimation, onChapterEnter,
+onChapterExit`. Columns are matched by name, so order is flexible and you only
+need the ones you use; `lng`/`lat` set the chapter center, and missing ids are
+generated on import. The `onChapterEnter`/`onChapterExit` columns hold JSON and
+can be left blank when authoring by hand.
+
 ### Layer effects
 
 Under **On enter** and **On exit**, add layer fades that run as a chapter

--- a/docs/user-guide/storymaps.md
+++ b/docs/user-guide/storymaps.md
@@ -55,6 +55,11 @@ progresses.
 Click **Present** to start the scroll-driven presentation over the live map.
 Scroll to move between chapters; press **Esc** or **Exit** to return to editing.
 
+A **navigation pane** on the left lists every chapter for a quick overview;
+click any entry to jump straight to it. Toggle the pane with the list button next
+to **Exit**. The map controls (navigation, fullscreen, globe, layer control)
+stay usable during the presentation.
+
 ## Export to HTML
 
 Click **Export HTML** to save a self-contained `.html` page that reproduces the

--- a/docs/user-guide/storymaps.md
+++ b/docs/user-guide/storymaps.md
@@ -4,7 +4,9 @@ Story maps turn a project into a scroll-driven narrative. As the reader scrolls,
 the map flies between chapters, and project layers can fade in and out. The
 feature is inspired by the
 [maplibre-gl-storymaps](https://github.com/opengeos/maplibre-gl-storymaps)
-template and works fully offline once your data is loaded.
+template. Authoring and the in-app presentation run locally, though basemap
+styles and any chapter images are still fetched from their URLs, and the
+standalone HTML export loads MapLibre and scrollama from a CDN.
 
 ## Open the builder
 

--- a/docs/user-guide/storymaps.md
+++ b/docs/user-guide/storymaps.md
@@ -60,6 +60,10 @@ click any entry to jump straight to it. Toggle the pane with the list button nex
 to **Exit**. The map controls (navigation, fullscreen, globe, layer control)
 stay usable during the presentation.
 
+Each chapter card is **movable and resizable**: drag its title bar to reposition
+it (double-click the bar to reset), or drag the bottom-right corner to resize, so
+you can move a card aside and explore the map beneath it.
+
 ## Export to HTML
 
 Click **Export HTML** to save a self-contained `.html` page that reproduces the

--- a/docs/user-guide/storymaps.md
+++ b/docs/user-guide/storymaps.md
@@ -1,0 +1,57 @@
+# Story Maps
+
+Story maps turn a project into a scroll-driven narrative. As the reader scrolls,
+the map flies between chapters, and project layers can fade in and out. The
+feature is inspired by the
+[maplibre-gl-storymaps](https://github.com/opengeos/maplibre-gl-storymaps)
+template and works fully offline once your data is loaded.
+
+## Open the builder
+
+Choose **Project → Story Map** to open the builder. The builder edits a story
+that is saved inside the `.geolibre.json` project file, so it travels with your
+project.
+
+## Story settings
+
+- **Title / Subtitle / Byline / Footer** appear in the presentation header and
+  footer. The footer accepts inline HTML (for example, links and credits).
+- **Panel theme** switches the chapter panels between light and dark.
+- **Show markers** drops a marker at each chapter's center; pick its color.
+- **Inset minimap** shows a small overview map in a chosen corner.
+
+## Chapters
+
+Click **Add chapter** to capture the current map view as a new chapter. Each
+chapter has:
+
+- **Title**, **Description** (inline HTML allowed), and an optional **Image URL**.
+- **Panel alignment**: `left`, `center`, `right`, or `full`.
+- **Map animation**: `flyTo`, `easeTo`, or `jumpTo`.
+- **Hide panel** keeps the map transition but hides the text (useful for a pure
+  map beat).
+- **Rotate camera** slowly spins the view after the transition settles.
+
+Use **Set to current view** to re-capture the camera after panning, zooming, or
+tilting the map, and the map-pin button to fly to a chapter while editing.
+Reorder chapters with the arrows and remove them with the trash icon.
+
+### Layer effects
+
+Under **On enter** and **On exit**, add layer fades that run as a chapter
+becomes active or is left behind. Pick a project layer and a target opacity (and
+optional transition duration). This is how you reveal or hide data as the story
+progresses.
+
+## Present
+
+Click **Present** to start the scroll-driven presentation over the live map.
+Scroll to move between chapters; press **Esc** or **Exit** to return to editing.
+
+## Export to HTML
+
+Click **Export HTML** to save a self-contained `.html` page that reproduces the
+story without GeoLibre. In-memory GeoJSON layers referenced by chapter effects
+are inlined so the exported story behaves like the in-app preview. The page is a
+single static file you can host anywhere (GitHub Pages, Netlify, S3, or any web
+server).

--- a/docs/user-guide/storymaps.md
+++ b/docs/user-guide/storymaps.md
@@ -12,6 +12,11 @@ Choose **Project → Story Map** to open the builder. The builder edits a story
 that is saved inside the `.geolibre.json` project file, so it travels with your
 project.
 
+!!! tip "Try it instantly"
+    When the story is empty, click **Load sample story** to populate a five-city
+    world tour. Hit **Present** and scroll to see it in action, then edit or
+    replace the chapters with your own.
+
 ## Story settings
 
 - **Title / Subtitle / Byline / Footer** appear in the presentation header and

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
       - Data Integrations: user-guide/data-integrations.md
       - Plugins & Marketplace: user-guide/plugins.md
       - Settings & Preferences: user-guide/settings.md
+      - Story Maps: user-guide/storymaps.md
       - Embedding & Sharing: user-guide/embedding.md
   - Tutorials:
       - Overview: tutorials/index.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "@tauri-apps/plugin-dialog": "^2.7.1",
         "@tauri-apps/plugin-fs": "^2.5.1",
         "@tauri-apps/plugin-opener": "^2.5.4",
+        "dompurify": "^3.4.10",
         "fflate": "^0.8.3",
         "i18next": "^25.10.10",
         "jspdf": "^4.2.1",
@@ -13039,9 +13040,9 @@
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
     },
     "node_modules/dompurify": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
-      "integrity": "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
+      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,12 @@ export * from "./vector-color";
 export * from "./project";
 export { createSampleStoryMap } from "./storymap-sample";
 export {
+  serializeStoryMapJson,
+  parseStoryMapJson,
+  serializeStoryMapCsv,
+  parseStoryMapCsv,
+} from "./storymap-io";
+export {
   clearHistory,
   projectPathLabel,
   redo,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./types";
 export * from "./vector-color";
 export * from "./project";
+export { createSampleStoryMap } from "./storymap-sample";
 export {
   clearHistory,
   projectPathLabel,

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -106,9 +106,7 @@ function normalizeStoryMap(storymap: unknown): StoryMap | null {
         })
     : [];
 
-  if (chapters.length === 0) return null;
-
-  return {
+  const normalized: StoryMap = {
     title: normalizeString(candidate.title),
     subtitle: normalizeString(candidate.subtitle),
     byline: normalizeString(candidate.byline),
@@ -125,6 +123,27 @@ function normalizeStoryMap(storymap: unknown): StoryMap | null {
       : DEFAULT_STORY_MAP.insetPosition,
     chapters,
   };
+
+  // Keep the story if it has chapters or any author-entered settings; only a
+  // wholly-default, chapter-less story is dropped (so blank stories stay out of
+  // saved projects without discarding settings entered before the first chapter).
+  return storyMapHasContent(normalized) ? normalized : null;
+}
+
+/** Whether a story map carries chapters or any non-default setting. */
+function storyMapHasContent(story: StoryMap): boolean {
+  if (story.chapters.length > 0) return true;
+  return (
+    story.title.trim() !== "" ||
+    story.subtitle.trim() !== "" ||
+    story.byline.trim() !== "" ||
+    story.footer.trim() !== "" ||
+    story.theme !== DEFAULT_STORY_MAP.theme ||
+    story.showMarkers !== DEFAULT_STORY_MAP.showMarkers ||
+    story.markerColor !== DEFAULT_STORY_MAP.markerColor ||
+    story.inset !== DEFAULT_STORY_MAP.inset ||
+    story.insetPosition !== DEFAULT_STORY_MAP.insetPosition
+  );
 }
 
 const STORY_ALIGNMENTS = new Set<StoryChapterAlignment>([
@@ -174,7 +193,11 @@ function normalizeStoryChapter(chapter: unknown): StoryChapter | null {
       : "left",
     hidden: normalizeBoolean(candidate.hidden, false),
     location: {
-      center: [Number(center[0]), Number(center[1])],
+      // Clamp to valid lng/lat so a hand-edited file can't make flyTo throw.
+      center: [
+        clampCoordinate(Number(center[0]), -180, 180),
+        clampCoordinate(Number(center[1]), -90, 90),
+      ],
       zoom: normalizeNumber(location?.zoom, 2),
       pitch: normalizeNumber(location?.pitch, 0),
       bearing: normalizeNumber(location?.bearing, 0),

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -191,7 +191,9 @@ function normalizeOpacityChanges(value: unknown): StoryLayerOpacityChange[] {
       const candidate = entry as Partial<StoryLayerOpacityChange>;
       const layerId = normalizeString(candidate.layerId);
       if (!layerId) return null;
+      const id = normalizeString(candidate.id);
       return {
+        ...(id ? { id } : {}),
         layerId,
         opacity: clampCoordinate(normalizeNumber(candidate.opacity, 1), 0, 1),
         ...(Number.isFinite(candidate.duration)

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -89,7 +89,7 @@ export function parseProject(json: string): GeoLibreProject {
  * @param storymap Raw value read from the project JSON.
  * @returns A normalized story map, or null when there is nothing to keep.
  */
-function normalizeStoryMap(storymap: unknown): StoryMap | null {
+export function normalizeStoryMap(storymap: unknown): StoryMap | null {
   if (!storymap || typeof storymap !== "object") return null;
 
   const candidate = storymap as Partial<StoryMap>;

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -2,6 +2,7 @@ import {
   DEFAULT_BASEMAP,
   DEFAULT_LAYER_STYLE,
   DEFAULT_PROJECT_PREFERENCES,
+  DEFAULT_STORY_MAP,
   PROJECT_VERSION,
   type GeoLibreLayer,
   type GeoLibreProject,
@@ -11,6 +12,12 @@ import {
   type ProjectPluginState,
   type ProjectPreferences,
   type RuntimeEnvironmentVariable,
+  type StoryChapter,
+  type StoryChapterAlignment,
+  type StoryChapterAnimation,
+  type StoryInsetPosition,
+  type StoryLayerOpacityChange,
+  type StoryMap,
 } from "./types";
 
 /** Placeholder name a project carries before the user names it. */
@@ -68,8 +75,135 @@ export function parseProject(json: string): GeoLibreProject {
     styles: data.styles ?? {},
     preferences: normalizeProjectPreferences(data.preferences),
     plugins: normalizeProjectPlugins(data.plugins) ?? undefined,
+    storymap: normalizeStoryMap(data.storymap) ?? undefined,
     metadata: data.metadata ?? {},
   };
+}
+
+/**
+ * Validate and coerce a story map loaded from an untrusted project file.
+ *
+ * Returns null when the value carries no chapters so empty story maps stay out
+ * of the saved project, mirroring how plugins are only persisted when present.
+ *
+ * @param storymap Raw value read from the project JSON.
+ * @returns A normalized story map, or null when there is nothing to keep.
+ */
+function normalizeStoryMap(storymap: unknown): StoryMap | null {
+  if (!storymap || typeof storymap !== "object") return null;
+
+  const candidate = storymap as Partial<StoryMap>;
+  const chapters = Array.isArray(candidate.chapters)
+    ? candidate.chapters
+        .map(normalizeStoryChapter)
+        .filter((chapter): chapter is StoryChapter => Boolean(chapter))
+    : [];
+
+  if (chapters.length === 0) return null;
+
+  return {
+    title: normalizeString(candidate.title),
+    subtitle: normalizeString(candidate.subtitle),
+    byline: normalizeString(candidate.byline),
+    footer: normalizeString(candidate.footer),
+    theme: candidate.theme === "light" ? "light" : "dark",
+    showMarkers: normalizeBoolean(candidate.showMarkers, false),
+    markerColor:
+      normalizeString(candidate.markerColor) || DEFAULT_STORY_MAP.markerColor,
+    inset: normalizeBoolean(candidate.inset, false),
+    insetPosition: STORY_INSET_POSITIONS.has(
+      candidate.insetPosition as StoryInsetPosition,
+    )
+      ? (candidate.insetPosition as StoryInsetPosition)
+      : DEFAULT_STORY_MAP.insetPosition,
+    chapters,
+  };
+}
+
+const STORY_ALIGNMENTS = new Set<StoryChapterAlignment>([
+  "left",
+  "center",
+  "right",
+  "full",
+]);
+
+const STORY_ANIMATIONS = new Set<StoryChapterAnimation>([
+  "flyTo",
+  "easeTo",
+  "jumpTo",
+]);
+
+const STORY_INSET_POSITIONS = new Set<StoryInsetPosition>([
+  "top-left",
+  "top-right",
+  "bottom-left",
+  "bottom-right",
+]);
+
+function normalizeStoryChapter(chapter: unknown): StoryChapter | null {
+  if (!chapter || typeof chapter !== "object") return null;
+
+  const candidate = chapter as Partial<StoryChapter>;
+  const id = normalizeString(candidate.id);
+  if (!id) return null;
+
+  const location = candidate.location;
+  const center = location?.center;
+  if (
+    !Array.isArray(center) ||
+    center.length !== 2 ||
+    !center.every((value) => Number.isFinite(value))
+  ) {
+    return null;
+  }
+
+  return {
+    id,
+    title: normalizeString(candidate.title),
+    description: normalizeString(candidate.description),
+    image: normalizeString(candidate.image) || undefined,
+    alignment: STORY_ALIGNMENTS.has(candidate.alignment as StoryChapterAlignment)
+      ? (candidate.alignment as StoryChapterAlignment)
+      : "left",
+    hidden: normalizeBoolean(candidate.hidden, false),
+    location: {
+      center: [Number(center[0]), Number(center[1])],
+      zoom: normalizeNumber(location?.zoom, 2),
+      pitch: normalizeNumber(location?.pitch, 0),
+      bearing: normalizeNumber(location?.bearing, 0),
+    },
+    mapAnimation: STORY_ANIMATIONS.has(
+      candidate.mapAnimation as StoryChapterAnimation,
+    )
+      ? (candidate.mapAnimation as StoryChapterAnimation)
+      : "flyTo",
+    rotateAnimation: normalizeBoolean(candidate.rotateAnimation, false),
+    onChapterEnter: normalizeOpacityChanges(candidate.onChapterEnter),
+    onChapterExit: normalizeOpacityChanges(candidate.onChapterExit),
+  };
+}
+
+function normalizeOpacityChanges(value: unknown): StoryLayerOpacityChange[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry): StoryLayerOpacityChange | null => {
+      if (!entry || typeof entry !== "object") return null;
+      const candidate = entry as Partial<StoryLayerOpacityChange>;
+      const layerId = normalizeString(candidate.layerId);
+      if (!layerId) return null;
+      return {
+        layerId,
+        opacity: clampCoordinate(normalizeNumber(candidate.opacity, 1), 0, 1),
+        ...(Number.isFinite(candidate.duration)
+          ? { duration: Number(candidate.duration) }
+          : {}),
+      };
+    })
+    .filter((entry): entry is StoryLayerOpacityChange => Boolean(entry));
+}
+
+function normalizeString(value: unknown): string {
+  return typeof value === "string" ? value : "";
 }
 
 function normalizeProjectPreferences(preferences: unknown): ProjectPreferences {
@@ -302,6 +436,7 @@ export function projectFromStore(state: {
   layers: GeoLibreLayer[];
   preferences: ProjectPreferences;
   plugins?: ProjectPluginState | null;
+  storymap?: StoryMap | null;
   metadata: Record<string, unknown>;
 }): GeoLibreProject {
   const styles: Record<string, LayerStyle> = {};
@@ -309,6 +444,7 @@ export function projectFromStore(state: {
     styles[layer.id] = layer.style;
   }
   const plugins = normalizeProjectPlugins(state.plugins);
+  const storymap = normalizeStoryMap(state.storymap);
   return {
     version: PROJECT_VERSION,
     name: state.projectName,
@@ -320,6 +456,7 @@ export function projectFromStore(state: {
     styles,
     preferences: state.preferences,
     ...(plugins ? { plugins } : {}),
+    ...(storymap ? { storymap } : {}),
     metadata: state.metadata,
   };
 }
@@ -389,6 +526,7 @@ export function applyProjectToStore(project: GeoLibreProject): {
   layers: GeoLibreLayer[];
   preferences: ProjectPreferences;
   projectPlugins: ProjectPluginState | null;
+  storymap: StoryMap | null;
   metadata: Record<string, unknown>;
 } {
   const layers = project.layers.map((layer) => ({
@@ -406,6 +544,7 @@ export function applyProjectToStore(project: GeoLibreProject): {
     layers,
     preferences: normalizeProjectPreferences(project.preferences),
     projectPlugins: normalizeProjectPlugins(project.plugins),
+    storymap: normalizeStoryMap(project.storymap),
     metadata: project.metadata,
   };
 }

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -198,9 +198,11 @@ function normalizeStoryChapter(chapter: unknown): StoryChapter | null {
         clampCoordinate(Number(center[0]), -180, 180),
         clampCoordinate(Number(center[1]), -90, 90),
       ],
-      zoom: normalizeNumber(location?.zoom, 2),
-      pitch: normalizeNumber(location?.pitch, 0),
-      bearing: normalizeNumber(location?.bearing, 0),
+      // Clamp to MapLibre's valid ranges so a stored value matches the camera
+      // that actually lands (bearing wraps to 0-360).
+      zoom: clamp(normalizeNumber(location?.zoom, 2), 0, 24),
+      pitch: clamp(normalizeNumber(location?.pitch, 0), 0, 85),
+      bearing: ((normalizeNumber(location?.bearing, 0) % 360) + 360) % 360,
     },
     mapAnimation: STORY_ANIMATIONS.has(
       candidate.mapAnimation as StoryChapterAnimation,
@@ -225,7 +227,7 @@ function normalizeOpacityChanges(value: unknown): StoryLayerOpacityChange[] {
       return {
         ...(id ? { id } : {}),
         layerId,
-        opacity: clampCoordinate(normalizeNumber(candidate.opacity, 1), 0, 1),
+        opacity: clamp(normalizeNumber(candidate.opacity, 1), 0, 1),
         ...(Number.isFinite(candidate.duration)
           ? { duration: Math.max(0, Number(candidate.duration)) }
           : {}),
@@ -309,8 +311,12 @@ function normalizeNumber(value: unknown, fallback: number): number {
   return Number.isFinite(value) ? Number(value) : fallback;
 }
 
-function clampCoordinate(value: number, min: number, max: number): number {
+function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
+}
+
+function clampCoordinate(value: number, min: number, max: number): number {
+  return clamp(value, min, max);
 }
 
 function normalizeBoolean(value: unknown, fallback: boolean): boolean {

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -93,10 +93,17 @@ function normalizeStoryMap(storymap: unknown): StoryMap | null {
   if (!storymap || typeof storymap !== "object") return null;
 
   const candidate = storymap as Partial<StoryMap>;
+  // Drop duplicate chapter ids so updates/removals stay unambiguous and keyed
+  // rendering stays stable.
+  const seenChapterIds = new Set<string>();
   const chapters = Array.isArray(candidate.chapters)
     ? candidate.chapters
         .map(normalizeStoryChapter)
-        .filter((chapter): chapter is StoryChapter => Boolean(chapter))
+        .filter((chapter): chapter is StoryChapter => {
+          if (!chapter || seenChapterIds.has(chapter.id)) return false;
+          seenChapterIds.add(chapter.id);
+          return true;
+        })
     : [];
 
   if (chapters.length === 0) return null;
@@ -197,7 +204,7 @@ function normalizeOpacityChanges(value: unknown): StoryLayerOpacityChange[] {
         layerId,
         opacity: clampCoordinate(normalizeNumber(candidate.opacity, 1), 0, 1),
         ...(Number.isFinite(candidate.duration)
-          ? { duration: Number(candidate.duration) }
+          ? { duration: Math.max(0, Number(candidate.duration)) }
           : {}),
       };
     })

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -473,6 +473,8 @@ export const useAppStore = create<AppState>()(
           identifyLayerId: null,
           pointerCoords: null,
           attributeFilter: "",
+          // Don't carry an active story presentation into a different project.
+          ui: { ...s.ui, storymapPresenting: false, storymapPanelOpen: false },
         }));
         clearHistory();
       },
@@ -487,6 +489,8 @@ export const useAppStore = create<AppState>()(
           selectedLayerId: applied.layers[0]?.id ?? null,
           selectedFeatureId: null,
           identifyLayerId: null,
+          // Don't carry an active story presentation into a different project.
+          ui: { ...s.ui, storymapPresenting: false, storymapPanelOpen: false },
         }));
         clearHistory();
         if (path && options.rememberRecent !== false) {

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -15,6 +15,7 @@ import {
   DEFAULT_BASEMAP,
   DEFAULT_LAYER_STYLE,
   DEFAULT_PROJECT_PREFERENCES,
+  DEFAULT_STORY_MAP,
   type GeoLibreLayer,
   type GeoLibreProject,
   type LayerStyle,
@@ -22,6 +23,8 @@ import {
   type ProjectPluginState,
   type ProjectPreferences,
   type RecentProjectEntry,
+  type StoryChapter,
+  type StoryMap,
 } from "./types";
 
 export type ConversionToolKind =
@@ -87,6 +90,7 @@ export interface AppState {
   layers: GeoLibreLayer[];
   preferences: ProjectPreferences;
   projectPlugins: ProjectPluginState | null;
+  storymap: StoryMap | null;
   selectedLayerId: string | null;
   selectedFeatureId: string | null;
   identifyLayerId: string | null;
@@ -101,6 +105,8 @@ export interface AppState {
     rasterToolOpen: RasterToolKind | null;
     sqlWorkspaceOpen: boolean;
     attributeTableOpen: boolean;
+    storymapPanelOpen: boolean;
+    storymapPresenting: boolean;
     zoomToSelectedFeature: boolean;
   };
 
@@ -124,7 +130,18 @@ export interface AppState {
   setRasterToolOpen: (kind: RasterToolKind | null) => void;
   setSqlWorkspaceOpen: (open: boolean) => void;
   setAttributeTableOpen: (open: boolean) => void;
+  setStorymapPanelOpen: (open: boolean) => void;
+  setStorymapPresenting: (presenting: boolean) => void;
   setZoomToSelectedFeature: (enabled: boolean) => void;
+
+  setStorymap: (storymap: StoryMap | null) => void;
+  updateStorymapSettings: (
+    patch: Partial<Omit<StoryMap, "chapters">>
+  ) => void;
+  addStoryChapter: (chapter: StoryChapter, atIndex?: number) => void;
+  updateStoryChapter: (id: string, patch: Partial<StoryChapter>) => void;
+  removeStoryChapter: (id: string) => void;
+  moveStoryChapter: (id: string, targetIndex: number) => void;
 
   newProject: (options?: CreateProjectOptions & { name?: string }) => void;
   loadProject: (
@@ -202,6 +219,7 @@ export const useAppStore = create<AppState>()(
       layers: [],
       preferences: DEFAULT_PROJECT_PREFERENCES,
       projectPlugins: null,
+      storymap: null,
       selectedLayerId: null,
       selectedFeatureId: null,
       identifyLayerId: null,
@@ -216,6 +234,8 @@ export const useAppStore = create<AppState>()(
         rasterToolOpen: null,
         sqlWorkspaceOpen: false,
         attributeTableOpen: false,
+        storymapPanelOpen: false,
+        storymapPresenting: false,
         zoomToSelectedFeature: false,
       },
 
@@ -255,8 +275,72 @@ export const useAppStore = create<AppState>()(
         set((s) => ({ ui: { ...s.ui, sqlWorkspaceOpen: open } })),
       setAttributeTableOpen: (open) =>
         set((s) => ({ ui: { ...s.ui, attributeTableOpen: open } })),
+      setStorymapPanelOpen: (open) =>
+        set((s) => ({ ui: { ...s.ui, storymapPanelOpen: open } })),
+      setStorymapPresenting: (presenting) =>
+        set((s) => ({ ui: { ...s.ui, storymapPresenting: presenting } })),
       setZoomToSelectedFeature: (enabled) =>
         set((s) => ({ ui: { ...s.ui, zoomToSelectedFeature: enabled } })),
+
+      setStorymap: (storymap) => set({ storymap, isDirty: true }),
+      updateStorymapSettings: (patch) =>
+        set((s) => ({
+          storymap: { ...(s.storymap ?? DEFAULT_STORY_MAP), ...patch },
+          isDirty: true,
+        })),
+      addStoryChapter: (chapter, atIndex) =>
+        set((s) => {
+          const base = s.storymap ?? DEFAULT_STORY_MAP;
+          const chapters = [...base.chapters];
+          const index =
+            atIndex === undefined
+              ? chapters.length
+              : Math.min(Math.max(atIndex, 0), chapters.length);
+          chapters.splice(index, 0, chapter);
+          return { storymap: { ...base, chapters }, isDirty: true };
+        }),
+      updateStoryChapter: (id, patch) =>
+        set((s) => {
+          if (!s.storymap) return s;
+          return {
+            storymap: {
+              ...s.storymap,
+              chapters: s.storymap.chapters.map((chapter) =>
+                chapter.id === id ? { ...chapter, ...patch } : chapter
+              ),
+            },
+            isDirty: true,
+          };
+        }),
+      removeStoryChapter: (id) =>
+        set((s) => {
+          if (!s.storymap) return s;
+          return {
+            storymap: {
+              ...s.storymap,
+              chapters: s.storymap.chapters.filter(
+                (chapter) => chapter.id !== id
+              ),
+            },
+            isDirty: true,
+          };
+        }),
+      moveStoryChapter: (id, targetIndex) =>
+        set((s) => {
+          if (!s.storymap) return s;
+          const current = s.storymap.chapters.findIndex(
+            (chapter) => chapter.id === id
+          );
+          if (current < 0) return s;
+          const chapters = [...s.storymap.chapters];
+          const [chapter] = chapters.splice(current, 1);
+          const next = Math.min(Math.max(targetIndex, 0), chapters.length);
+          chapters.splice(next, 0, chapter);
+          if (chapters.every((item, i) => item.id === s.storymap?.chapters[i]?.id)) {
+            return s;
+          }
+          return { storymap: { ...s.storymap, chapters }, isDirty: true };
+        }),
 
       setProjectPath: (path) => set({ projectPath: path }),
       setProjectName: (name) => set({ projectName: name, isDirty: true }),

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -334,6 +334,7 @@ export const useAppStore = create<AppState>()(
           if (current < 0) return s;
           const chapters = [...s.storymap.chapters];
           const [chapter] = chapters.splice(current, 1);
+          if (!chapter) return s;
           const next = Math.min(Math.max(targetIndex, 0), chapters.length);
           chapters.splice(next, 0, chapter);
           if (chapters.every((item, i) => item.id === s.storymap?.chapters[i]?.id)) {

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -507,16 +507,20 @@ export const useAppStore = create<AppState>()(
         basemapStyleUrl: s.basemapStyleUrl,
         basemapVisible: s.basemapVisible,
         basemapOpacity: s.basemapOpacity,
+        storymap: s.storymap,
       }),
       // Records a history entry only when the tracked slice really changed.
       // Basemap fields compare with ===; `layers` is compared element-by-element
       // (Object.is per element) via shallow. Every mutating action creates new
       // layer objects, so real changes differ; two distinct empty arrays compare
-      // equal, so resetting layers (e.g. newProject) records nothing.
+      // equal, so resetting layers (e.g. newProject) records nothing. `storymap`
+      // is compared by reference: every authoring action creates a new object,
+      // so real edits differ while an unchanged null stays equal.
       equality: (a, b) =>
         a.basemapStyleUrl === b.basemapStyleUrl &&
         a.basemapVisible === b.basemapVisible &&
         a.basemapOpacity === b.basemapOpacity &&
+        a.storymap === b.storymap &&
         shallow(a.layers, b.layers),
       limit: 100,
       // Group rapid bursts (slider drags) into one entry; window is 0 in tests.

--- a/packages/core/src/storymap-io.ts
+++ b/packages/core/src/storymap-io.ts
@@ -1,0 +1,221 @@
+import { normalizeStoryMap } from "./project";
+import { DEFAULT_STORY_MAP, type StoryMap } from "./types";
+
+/**
+ * Serialize a story map to pretty-printed JSON for export.
+ *
+ * @param storymap The story map to serialize.
+ * @returns A JSON string (settings and chapters).
+ */
+export function serializeStoryMapJson(storymap: StoryMap): string {
+  return JSON.stringify(storymap, null, 2);
+}
+
+/**
+ * Parse a story map from JSON authored outside GeoLibre.
+ *
+ * Accepts either a bare story map object or a full `.geolibre.json` project with
+ * a `storymap` field, then validates it through the same normalizer used when
+ * loading projects.
+ *
+ * @param text JSON text to import.
+ * @returns A normalized story map.
+ * @throws If the JSON is invalid or contains no usable chapters.
+ */
+export function parseStoryMapJson(text: string): StoryMap {
+  const data = JSON.parse(text) as unknown;
+  const candidate =
+    data && typeof data === "object" && "storymap" in (data as object)
+      ? (data as { storymap: unknown }).storymap
+      : data;
+  const normalized = normalizeStoryMap(candidate);
+  if (!normalized) {
+    throw new Error("The imported story map has no chapters.");
+  }
+  return normalized;
+}
+
+// Flat, spreadsheet-friendly chapter columns. Layer opacity effects are stored
+// as JSON in their own columns so the CSV round-trips, but hand-authors can
+// simply leave them blank.
+const CSV_HEADERS = [
+  "id",
+  "title",
+  "description",
+  "image",
+  "alignment",
+  "hidden",
+  "lng",
+  "lat",
+  "zoom",
+  "pitch",
+  "bearing",
+  "mapAnimation",
+  "rotateAnimation",
+  "onChapterEnter",
+  "onChapterExit",
+] as const;
+
+/**
+ * Serialize a story map's chapters to CSV (one row per chapter).
+ *
+ * Story-level settings are not represented in CSV; they are kept in the project
+ * and preserved on CSV import.
+ *
+ * @param storymap The story map whose chapters to serialize.
+ * @returns A CSV string with a header row.
+ */
+export function serializeStoryMapCsv(storymap: StoryMap): string {
+  const rows = [CSV_HEADERS.join(",")];
+  for (const c of storymap.chapters) {
+    rows.push(
+      [
+        c.id,
+        c.title,
+        c.description,
+        c.image ?? "",
+        c.alignment,
+        String(c.hidden),
+        String(c.location.center[0]),
+        String(c.location.center[1]),
+        String(c.location.zoom),
+        String(c.location.pitch),
+        String(c.location.bearing),
+        c.mapAnimation,
+        String(c.rotateAnimation),
+        JSON.stringify(c.onChapterEnter),
+        JSON.stringify(c.onChapterExit),
+      ]
+        .map(csvEscape)
+        .join(","),
+    );
+  }
+  return rows.join("\n") + "\n";
+}
+
+/**
+ * Parse chapters from a CSV authored outside GeoLibre.
+ *
+ * Columns are matched by header name (case-insensitive) so column order is
+ * flexible; `lng`/`lat` set the chapter center. Story-level settings come from
+ * `base` (the current story) since CSV only carries chapters; missing ids are
+ * generated.
+ *
+ * @param text CSV text to import.
+ * @param base Existing story map whose settings should be preserved.
+ * @returns A normalized story map.
+ * @throws If the CSV has no data rows or no valid chapters.
+ */
+export function parseStoryMapCsv(
+  text: string,
+  base?: StoryMap | null,
+): StoryMap {
+  const rows = parseCsvRows(text);
+  if (rows.length < 2) {
+    throw new Error("The CSV has no chapter rows.");
+  }
+  const header = rows[0].map((h) => h.trim().toLowerCase());
+  const col = (name: string) => header.indexOf(name.toLowerCase());
+
+  const chapters = rows
+    .slice(1)
+    .filter((row) => row.some((cell) => cell.trim() !== ""))
+    .map((row, index) => {
+      const get = (name: string) => {
+        const j = col(name);
+        return j >= 0 ? (row[j] ?? "") : "";
+      };
+      const num = (name: string, fallback: number) => {
+        const value = Number(get(name));
+        return Number.isFinite(value) ? value : fallback;
+      };
+      const bool = (name: string) => /^(true|1|yes)$/i.test(get(name).trim());
+      const jsonArray = (name: string) => {
+        try {
+          const parsed = JSON.parse(get(name) || "[]");
+          return Array.isArray(parsed) ? parsed : [];
+        } catch {
+          return [];
+        }
+      };
+      return {
+        id: get("id").trim() || `chapter-${index + 1}`,
+        title: get("title"),
+        description: get("description"),
+        image: get("image").trim() || undefined,
+        alignment: get("alignment").trim() || "left",
+        hidden: bool("hidden"),
+        location: {
+          center: [num("lng", 0), num("lat", 0)],
+          zoom: num("zoom", 2),
+          pitch: num("pitch", 0),
+          bearing: num("bearing", 0),
+        },
+        mapAnimation: get("mapanimation").trim() || "flyTo",
+        rotateAnimation: bool("rotateanimation"),
+        onChapterEnter: jsonArray("onchapterenter"),
+        onChapterExit: jsonArray("onchapterexit"),
+      };
+    });
+
+  const normalized = normalizeStoryMap({
+    ...(base ?? DEFAULT_STORY_MAP),
+    chapters,
+  });
+  if (!normalized) {
+    throw new Error("The CSV contained no valid chapters.");
+  }
+  return normalized;
+}
+
+/** Quote a CSV field when it contains a comma, quote, or newline. */
+function csvEscape(value: string): string {
+  if (/[",\n\r]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+/** Parse CSV text into rows of fields, honoring quotes and escaped quotes. */
+function parseCsvRows(text: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let inQuotes = false;
+  // Normalize line endings so \r\n and \r behave like \n.
+  const input = text.replace(/\r\n?/g, "\n");
+
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (input[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += ch;
+      }
+    } else if (ch === '"') {
+      inQuotes = true;
+    } else if (ch === ",") {
+      row.push(field);
+      field = "";
+    } else if (ch === "\n") {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = "";
+    } else {
+      field += ch;
+    }
+  }
+  // Flush the final field/row unless the input ended with a trailing newline.
+  if (field !== "" || row.length > 0) {
+    row.push(field);
+    rows.push(row);
+  }
+  return rows;
+}

--- a/packages/core/src/storymap-sample.ts
+++ b/packages/core/src/storymap-sample.ts
@@ -22,7 +22,7 @@ export function createSampleStoryMap(): StoryMap {
     showMarkers: true,
     markerColor: "#3fb1ce",
     inset: true,
-    insetPosition: "bottom-right",
+    insetPosition: "bottom-left",
     chapters: [
       {
         id: "sample-san-francisco",

--- a/packages/core/src/storymap-sample.ts
+++ b/packages/core/src/storymap-sample.ts
@@ -1,0 +1,124 @@
+import type { StoryMap } from "./types";
+
+const SAMPLE_ASSET_BASE = "https://opengeos.org/maplibre-gl-storymaps/assets";
+
+/**
+ * Build a ready-to-play sample story map.
+ *
+ * Mirrors the chapters of the `opengeos/maplibre-gl-storymaps` demo (five world
+ * cities) so users can explore the feature instantly without authoring content.
+ * A fresh object is returned on each call so callers can mutate it freely.
+ *
+ * @returns A populated {@link StoryMap} with five sample chapters.
+ */
+export function createSampleStoryMap(): StoryMap {
+  return {
+    title: "A Tour of Five Cities",
+    subtitle: "A scrollytelling map experience built with GeoLibre",
+    byline: "By GeoLibre",
+    footer:
+      'Source: Wikipedia. Built with <a href="https://github.com/opengeos/GeoLibre" target="_blank">GeoLibre</a>, inspired by <a href="https://github.com/opengeos/maplibre-gl-storymaps" target="_blank">MapLibre Storytelling</a>.',
+    theme: "dark",
+    showMarkers: true,
+    markerColor: "#3fb1ce",
+    inset: true,
+    insetPosition: "bottom-right",
+    chapters: [
+      {
+        id: "sample-san-francisco",
+        title: "San Francisco, California",
+        image: `${SAMPLE_ASSET_BASE}/san-francisco.jpg`,
+        description:
+          "San Francisco, a hilly city on the tip of a peninsula surrounded by the Pacific Ocean and San Francisco Bay, is known for its year-round fog, iconic Golden Gate Bridge, cable cars and colorful Victorian houses. <br><br>The city is also known for its vibrant tech industry, diverse neighborhoods, and rich cultural scene.",
+        alignment: "left",
+        hidden: false,
+        location: {
+          center: [-122.4194, 37.7749],
+          zoom: 11,
+          pitch: 45,
+          bearing: 0,
+        },
+        mapAnimation: "flyTo",
+        rotateAnimation: false,
+        onChapterEnter: [],
+        onChapterExit: [],
+      },
+      {
+        id: "sample-new-york",
+        title: "New York City, New York",
+        image: `${SAMPLE_ASSET_BASE}/new-york.jpg`,
+        description:
+          "New York City comprises 5 boroughs sitting where the Hudson River meets the Atlantic Ocean. At its core is Manhattan, a densely populated borough that's among the world's major commercial, financial and cultural centers. <br><br>Its iconic sites include skyscrapers such as the Empire State Building and sprawling Central Park.",
+        alignment: "right",
+        hidden: false,
+        location: {
+          center: [-74.006, 40.7128],
+          zoom: 11,
+          pitch: 60,
+          bearing: -43.2,
+        },
+        mapAnimation: "flyTo",
+        rotateAnimation: true,
+        onChapterEnter: [],
+        onChapterExit: [],
+      },
+      {
+        id: "sample-tokyo",
+        title: "Tokyo, Japan",
+        image: `${SAMPLE_ASSET_BASE}/tokyo.jpg`,
+        description:
+          "Tokyo, Japan's busy capital, mixes the ultramodern and the traditional, from neon-lit skyscrapers to historic temples. The opulent Meiji Shinto Shrine is known for its towering gate and surrounding woods. <br><br>The Imperial Palace sits amid large public gardens. The city's many museums offer exhibits ranging from classical art to a reconstructed kabuki theater.",
+        alignment: "left",
+        hidden: false,
+        location: {
+          center: [139.6917, 35.6895],
+          zoom: 10,
+          pitch: 30,
+          bearing: 20,
+        },
+        mapAnimation: "flyTo",
+        rotateAnimation: false,
+        onChapterEnter: [],
+        onChapterExit: [],
+      },
+      {
+        id: "sample-sydney",
+        title: "Sydney, Australia",
+        image: `${SAMPLE_ASSET_BASE}/sydney.jpg`,
+        description:
+          "Sydney, capital of New South Wales and one of Australia's largest cities, is best known for its harbourfront Sydney Opera House, with a distinctive sail-like design. <br><br>Massive Darling Harbour and the smaller Circular Quay port are hubs of waterside life, with the arched Harbour Bridge and esteemed Royal Botanic Garden nearby.",
+        alignment: "center",
+        hidden: false,
+        location: {
+          center: [151.2093, -33.8688],
+          zoom: 11,
+          pitch: 45,
+          bearing: 0,
+        },
+        mapAnimation: "flyTo",
+        rotateAnimation: false,
+        onChapterEnter: [],
+        onChapterExit: [],
+      },
+      {
+        id: "sample-cape-town",
+        title: "Cape Town, South Africa",
+        image: `${SAMPLE_ASSET_BASE}/cape-town.jpg`,
+        description:
+          "Cape Town is a port city on South Africa's southwest coast, on a peninsula beneath the imposing Table Mountain. Slowly rotating cable cars climb to the mountain's flat top, from which there are sweeping views of the city, the busy harbor and boats headed for Robben Island, the infamous prison that once held Nelson Mandela. <br><br>You can add as many chapters as you need to tell your story.",
+        alignment: "full",
+        hidden: false,
+        location: {
+          center: [18.4241, -33.9249],
+          zoom: 10,
+          pitch: 50,
+          bearing: 30,
+        },
+        mapAnimation: "flyTo",
+        rotateAnimation: false,
+        onChapterEnter: [],
+        onChapterExit: [],
+      },
+    ],
+  };
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -263,6 +263,80 @@ export const DEFAULT_PROJECT_PREFERENCES: ProjectPreferences = {
   environmentVariables: [],
 };
 
+/** Camera target captured for a story chapter. */
+export interface StoryChapterLocation {
+  center: [number, number];
+  zoom: number;
+  pitch: number;
+  bearing: number;
+}
+
+/** Where a chapter's text panel sits over the map. */
+export type StoryChapterAlignment = "left" | "center" | "right" | "full";
+
+/** How the map transitions to a chapter's location. */
+export type StoryChapterAnimation = "flyTo" | "easeTo" | "jumpTo";
+
+/** A layer opacity change triggered when a chapter is entered or exited. */
+export interface StoryLayerOpacityChange {
+  /** GeoLibre store layer id whose opacity should change. */
+  layerId: string;
+  opacity: number;
+  /** Transition duration in milliseconds. */
+  duration?: number;
+}
+
+/** A single scene in a scroll-driven story map. */
+export interface StoryChapter {
+  id: string;
+  title: string;
+  description: string;
+  /** Optional image shown in the chapter panel (URL or data URI). */
+  image?: string;
+  alignment: StoryChapterAlignment;
+  /** Hide the text panel while still transitioning the map. */
+  hidden: boolean;
+  location: StoryChapterLocation;
+  mapAnimation: StoryChapterAnimation;
+  /** Slowly rotate the camera once the transition settles. */
+  rotateAnimation: boolean;
+  onChapterEnter: StoryLayerOpacityChange[];
+  onChapterExit: StoryLayerOpacityChange[];
+}
+
+export type StoryInsetPosition =
+  | "top-left"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-right";
+
+/** Scroll-driven story map authored on top of a GeoLibre project. */
+export interface StoryMap {
+  title: string;
+  subtitle: string;
+  byline: string;
+  footer: string;
+  theme: "light" | "dark";
+  showMarkers: boolean;
+  markerColor: string;
+  inset: boolean;
+  insetPosition: StoryInsetPosition;
+  chapters: StoryChapter[];
+}
+
+export const DEFAULT_STORY_MAP: StoryMap = {
+  title: "",
+  subtitle: "",
+  byline: "",
+  footer: "",
+  theme: "dark",
+  showMarkers: false,
+  markerColor: "#3fb1ce",
+  inset: false,
+  insetPosition: "bottom-right",
+  chapters: [],
+};
+
 export interface GeoLibreProject {
   version: string;
   name: string;
@@ -274,6 +348,7 @@ export interface GeoLibreProject {
   styles: Record<string, LayerStyle>;
   preferences: ProjectPreferences;
   plugins?: ProjectPluginState;
+  storymap?: StoryMap;
   metadata: Record<string, unknown>;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -279,6 +279,8 @@ export type StoryChapterAnimation = "flyTo" | "easeTo" | "jumpTo";
 
 /** A layer opacity change triggered when a chapter is entered or exited. */
 export interface StoryLayerOpacityChange {
+  /** Stable identity for React list keys; optional for older project files. */
+  id?: string;
   /** GeoLibre store layer id whose opacity should change. */
   layerId: string;
   opacity: number;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -335,7 +335,7 @@ export const DEFAULT_STORY_MAP: StoryMap = {
   showMarkers: false,
   markerColor: "#3fb1ce",
   inset: false,
-  insetPosition: "bottom-right",
+  insetPosition: "bottom-left",
   chapters: [],
 };
 

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -331,6 +331,10 @@ export class MapController {
    * changes made during story-map playback by {@link setStoryLayerOpacity}.
    */
   restoreLayerStyles(): void {
+    // Invalidate any pending story rotation and halt an in-flight camera move so
+    // a deferred rotateTo cannot fire after the presenter has exited.
+    this.storyCameraToken++;
+    this.map?.stop();
     // Clear any opacity transitions left over from playback first, otherwise the
     // restored values animate back in (potentially over a multi-second fade).
     if (this.map) {

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -325,6 +325,21 @@ export class MapController {
    * changes made during story-map playback by {@link setStoryLayerOpacity}.
    */
   restoreLayerStyles(): void {
+    // Clear any opacity transitions left over from playback first, otherwise the
+    // restored values animate back in (potentially over a multi-second fade).
+    if (this.map) {
+      for (const layer of this.syncedLayers) {
+        for (const nativeId of this.getNativeLayerIdsByLayerId(layer.id)) {
+          const styleLayer = this.map.getLayer(nativeId);
+          if (!styleLayer) continue;
+          for (const prop of OPACITY_PAINT_PROPERTIES[styleLayer.type] ?? []) {
+            this.map.setPaintProperty(nativeId, `${prop}-transition`, {
+              duration: 0,
+            });
+          }
+        }
+      }
+    }
     this.syncLayers(this.syncedLayers);
   }
 

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -4,7 +4,13 @@ import {
   DEFAULT_PROJECT_PREFERENCES,
   useAppStore,
 } from "@geolibre/core";
-import type { GeoLibreLayer, MapPreferences, MapViewState } from "@geolibre/core";
+import type {
+  GeoLibreLayer,
+  MapPreferences,
+  MapViewState,
+  StoryChapterAnimation,
+  StoryChapterLocation,
+} from "@geolibre/core";
 import bbox from "@turf/bbox";
 import type { Feature, FeatureCollection, Geometry } from "geojson";
 import maplibregl from "maplibre-gl";
@@ -341,6 +347,61 @@ export class MapController {
       }
     }
     this.syncLayers(this.syncedLayers);
+  }
+
+  /** Token guarding deferred story rotations against later chapter changes. */
+  private storyCameraToken = 0;
+
+  /**
+   * Move the camera to a story chapter view during presentation playback.
+   *
+   * Cancels any in-progress movement first so a prior chapter's rotation cannot
+   * fight the new transition, then optionally starts a slow rotation once the
+   * move settles. Keeping this in the controller lets the presenter drive the
+   * camera without reaching into the raw MapLibre instance.
+   *
+   * @param location Target camera (center, zoom, pitch, bearing).
+   * @param animation MapLibre camera method to use.
+   * @param rotate When true, slowly rotate 180° after the move settles.
+   */
+  applyStoryChapterCamera(
+    location: StoryChapterLocation,
+    animation: StoryChapterAnimation = "flyTo",
+    rotate = false,
+  ): void {
+    if (!this.map) return;
+    const map = this.map;
+    map.stop();
+    const token = ++this.storyCameraToken;
+    map[animation]({
+      center: location.center,
+      zoom: location.zoom,
+      pitch: location.pitch,
+      bearing: location.bearing,
+    });
+    if (rotate) {
+      map.once("moveend", () => {
+        if (this.storyCameraToken !== token || !this.map) return;
+        this.map.rotateTo(this.map.getBearing() + 180, {
+          duration: 30000,
+          easing: (time) => time,
+        });
+      });
+    }
+  }
+
+  /**
+   * Fly the camera to a view, used for story authoring previews.
+   *
+   * @param location Target camera (center, zoom, pitch, bearing).
+   */
+  flyToView(location: StoryChapterLocation): void {
+    this.map?.flyTo({
+      center: location.center,
+      zoom: location.zoom,
+      pitch: location.pitch,
+      bearing: location.bearing,
+    });
   }
 
   private isStyleReady(): boolean {

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -286,6 +286,48 @@ export class MapController {
     return this.map;
   }
 
+  /**
+   * Fade a project layer in or out for story-map playback.
+   *
+   * Story chapters change layer opacity as the reader scrolls. This writes the
+   * MapLibre paint properties directly instead of going through the store, so
+   * playback never marks the project dirty or pushes undo history. Call
+   * {@link restoreLayerStyles} when playback ends to reset opacities.
+   *
+   * @param layerId GeoLibre store layer id to fade.
+   * @param opacity Target opacity, clamped to the 0-1 range.
+   * @param durationMs Optional transition duration in milliseconds.
+   */
+  setStoryLayerOpacity(
+    layerId: string,
+    opacity: number,
+    durationMs?: number,
+  ): void {
+    if (!this.map) return;
+    const clamped = Math.min(1, Math.max(0, opacity));
+    for (const nativeId of this.getNativeLayerIdsByLayerId(layerId)) {
+      const styleLayer = this.map.getLayer(nativeId);
+      if (!styleLayer) continue;
+      const props = OPACITY_PAINT_PROPERTIES[styleLayer.type] ?? [];
+      for (const prop of props) {
+        if (durationMs && durationMs > 0) {
+          this.map.setPaintProperty(nativeId, `${prop}-transition`, {
+            duration: durationMs,
+          });
+        }
+        this.map.setPaintProperty(nativeId, prop, clamped);
+      }
+    }
+  }
+
+  /**
+   * Re-apply layer styles from the last synced layers, undoing any direct paint
+   * changes made during story-map playback by {@link setStoryLayerOpacity}.
+   */
+  restoreLayerStyles(): void {
+    this.syncLayers(this.syncedLayers);
+  }
+
   private isStyleReady(): boolean {
     return Boolean(this.map && this.styleReady);
   }

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -375,7 +375,10 @@ export class MapController {
   ): void {
     if (!this.map) return;
     const map = this.map;
-    map.stop();
+    // Bump the token first so any pending rotation from a prior chapter is
+    // invalidated. We do NOT call map.stop() here: flyTo/easeTo already
+    // supersede an in-progress camera animation, and calling stop() immediately
+    // before a new movement during rapid chapter changes can drop it entirely.
     const token = ++this.storyCameraToken;
     map[animation]({
       center: location.center,

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -321,6 +321,36 @@ describe("story maps", () => {
     assert.equal(project.storymap.chapters[0].mapAnimation, "flyTo");
   });
 
+  it("dedupes chapter ids and clamps negative effect durations", () => {
+    const project = parseProject(
+      JSON.stringify({
+        version: "0.1.0",
+        name: "Story",
+        mapView: { center: [0, 0], zoom: 2, bearing: 0, pitch: 0 },
+        storymap: {
+          chapters: [
+            chapter({
+              id: "dup",
+              onChapterEnter: [
+                { layerId: "a", opacity: 1, duration: -500 },
+              ],
+            }),
+            chapter({ id: "dup", title: "Duplicate id" }),
+            chapter({ id: "unique" }),
+          ],
+        },
+      }),
+    );
+
+    assert.ok(project.storymap);
+    // The second "dup" chapter is dropped; the first one wins.
+    assert.deepEqual(
+      project.storymap.chapters.map((c) => c.id),
+      ["dup", "unique"],
+    );
+    assert.equal(project.storymap.chapters[0].onChapterEnter[0].duration, 0);
+  });
+
   it("omits an empty story map from a parsed project", () => {
     const project = parseProject(
       JSON.stringify({

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -269,3 +269,118 @@ describe("app store", () => {
     ]);
   });
 });
+
+function chapter(patch: Record<string, unknown> = {}) {
+  return {
+    id: "chapter-1",
+    title: "Intro",
+    description: "Hello",
+    alignment: "left",
+    hidden: false,
+    location: { center: [10, 20], zoom: 4, pitch: 30, bearing: 45 },
+    mapAnimation: "flyTo",
+    rotateAnimation: false,
+    onChapterEnter: [],
+    onChapterExit: [],
+    ...patch,
+  };
+}
+
+describe("story maps", () => {
+  beforeEach(() => {
+    useAppStore.getState().newProject({ name: "Story Project" });
+  });
+
+  it("parses a valid story map and drops invalid chapters", () => {
+    const project = parseProject(
+      JSON.stringify({
+        version: "0.1.0",
+        name: "Story",
+        mapView: { center: [0, 0], zoom: 2, bearing: 0, pitch: 0 },
+        storymap: {
+          title: "My Story",
+          theme: "weird",
+          insetPosition: "nowhere",
+          chapters: [
+            chapter({ alignment: "diagonal", mapAnimation: "warp" }),
+            chapter({ id: "", location: { center: [0, 0], zoom: 1 } }),
+            { id: "no-location", title: "Bad" },
+          ],
+        },
+      }),
+    );
+
+    assert.ok(project.storymap);
+    // The theme/inset fall back to defaults, and only the first chapter (with a
+    // valid id and center) survives; its bad enums normalize to defaults.
+    assert.equal(project.storymap.theme, "dark");
+    assert.equal(project.storymap.insetPosition, "bottom-right");
+    assert.equal(project.storymap.chapters.length, 1);
+    assert.equal(project.storymap.chapters[0].alignment, "left");
+    assert.equal(project.storymap.chapters[0].mapAnimation, "flyTo");
+  });
+
+  it("omits an empty story map from a parsed project", () => {
+    const project = parseProject(
+      JSON.stringify({
+        version: "0.1.0",
+        name: "Story",
+        mapView: { center: [0, 0], zoom: 2, bearing: 0, pitch: 0 },
+        storymap: { title: "Empty", chapters: [] },
+      }),
+    );
+    assert.equal(project.storymap, undefined);
+  });
+
+  it("round-trips a story map through the store and back to a project", () => {
+    const store = useAppStore.getState();
+    store.addStoryChapter(chapter() as never);
+    store.addStoryChapter(chapter({ id: "chapter-2", title: "Second" }) as never);
+    store.updateStorymapSettings({ title: "Trip", showMarkers: true });
+
+    const saved = projectFromStore({
+      projectName: useAppStore.getState().projectName,
+      mapView: useAppStore.getState().mapView,
+      basemapStyleUrl: useAppStore.getState().basemapStyleUrl,
+      basemapVisible: useAppStore.getState().basemapVisible,
+      basemapOpacity: useAppStore.getState().basemapOpacity,
+      layers: useAppStore.getState().layers,
+      preferences: useAppStore.getState().preferences,
+      plugins: useAppStore.getState().projectPlugins,
+      storymap: useAppStore.getState().storymap,
+      metadata: useAppStore.getState().metadata,
+    });
+
+    assert.ok(saved.storymap);
+    assert.equal(saved.storymap.title, "Trip");
+    assert.equal(saved.storymap.showMarkers, true);
+    assert.equal(saved.storymap.chapters.length, 2);
+
+    // Reloading the serialized project restores the chapters in order.
+    const reloaded = parseProject(serializeProject(saved));
+    useAppStore.getState().loadProject(reloaded);
+    assert.deepEqual(
+      useAppStore.getState().storymap?.chapters.map((c) => c.id),
+      ["chapter-1", "chapter-2"],
+    );
+  });
+
+  it("moves and removes chapters", () => {
+    const store = useAppStore.getState();
+    store.addStoryChapter(chapter({ id: "a" }) as never);
+    store.addStoryChapter(chapter({ id: "b" }) as never);
+    store.addStoryChapter(chapter({ id: "c" }) as never);
+
+    useAppStore.getState().moveStoryChapter("c", 0);
+    assert.deepEqual(
+      useAppStore.getState().storymap?.chapters.map((c) => c.id),
+      ["c", "a", "b"],
+    );
+
+    useAppStore.getState().removeStoryChapter("a");
+    assert.deepEqual(
+      useAppStore.getState().storymap?.chapters.map((c) => c.id),
+      ["c", "b"],
+    );
+  });
+});

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -355,6 +355,29 @@ describe("story maps", () => {
     assert.equal(project.storymap.chapters[0].onChapterEnter[0].duration, 0);
   });
 
+  it("clamps chapter zoom/pitch and wraps bearing into range", () => {
+    const project = parseProject(
+      JSON.stringify({
+        version: "0.1.0",
+        name: "Story",
+        mapView: { center: [0, 0], zoom: 2, bearing: 0, pitch: 0 },
+        storymap: {
+          chapters: [
+            chapter({
+              id: "a",
+              location: { center: [10, 20], zoom: 999, pitch: 200, bearing: -43.2 },
+            }),
+          ],
+        },
+      }),
+    );
+    const loc = project.storymap?.chapters[0].location;
+    assert.equal(loc?.zoom, 24);
+    assert.equal(loc?.pitch, 85);
+    // -43.2 wraps to an equivalent positive bearing rather than clamping to 0.
+    assert.ok(Math.abs((loc?.bearing ?? 0) - 316.8) < 1e-9);
+  });
+
   it("omits a wholly-default empty story map but keeps settings-only stories", () => {
     const base = {
       version: "0.1.0",

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_BASEMAP,
   DEFAULT_LAYER_STYLE,
   createEmptyProject,
+  createSampleStoryMap,
   parseProject,
   projectFromStore,
   serializeProject,
@@ -363,6 +364,21 @@ describe("story maps", () => {
       useAppStore.getState().storymap?.chapters.map((c) => c.id),
       ["chapter-1", "chapter-2"],
     );
+  });
+
+  it("provides a sample story that survives normalization", () => {
+    const sample = createSampleStoryMap();
+    assert.equal(sample.chapters.length, 5);
+
+    // Loading it as a project must keep every chapter (valid ids + centers).
+    const reloaded = parseProject(
+      serializeProject({
+        ...createEmptyProject("Sample"),
+        storymap: sample,
+      }),
+    );
+    assert.equal(reloaded.storymap?.chapters.length, 5);
+    assert.equal(reloaded.storymap?.chapters[0].id, "sample-san-francisco");
   });
 
   it("moves and removes chapters", () => {

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -319,7 +319,7 @@ describe("story maps", () => {
     // The theme/inset fall back to defaults, and only the first chapter (with a
     // valid id and center) survives; its bad enums normalize to defaults.
     assert.equal(project.storymap.theme, "dark");
-    assert.equal(project.storymap.insetPosition, "bottom-right");
+    assert.equal(project.storymap.insetPosition, "bottom-left");
     assert.equal(project.storymap.chapters.length, 1);
     assert.equal(project.storymap.chapters[0].alignment, "left");
     assert.equal(project.storymap.chapters[0].mapAnimation, "flyTo");

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -351,16 +351,23 @@ describe("story maps", () => {
     assert.equal(project.storymap.chapters[0].onChapterEnter[0].duration, 0);
   });
 
-  it("omits an empty story map from a parsed project", () => {
-    const project = parseProject(
-      JSON.stringify({
-        version: "0.1.0",
-        name: "Story",
-        mapView: { center: [0, 0], zoom: 2, bearing: 0, pitch: 0 },
-        storymap: { title: "Empty", chapters: [] },
-      }),
+  it("omits a wholly-default empty story map but keeps settings-only stories", () => {
+    const base = {
+      version: "0.1.0",
+      name: "Story",
+      mapView: { center: [0, 0], zoom: 2, bearing: 0, pitch: 0 },
+    };
+    // No chapters and all-default settings -> dropped.
+    const empty = parseProject(
+      JSON.stringify({ ...base, storymap: { chapters: [] } }),
     );
-    assert.equal(project.storymap, undefined);
+    assert.equal(empty.storymap, undefined);
+    // No chapters but an author-entered title -> kept (settings preserved).
+    const settingsOnly = parseProject(
+      JSON.stringify({ ...base, storymap: { title: "My Story", chapters: [] } }),
+    );
+    assert.equal(settingsOnly.storymap?.title, "My Story");
+    assert.equal(settingsOnly.storymap?.chapters.length, 0);
   });
 
   it("round-trips a story map through the store and back to a project", () => {

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -6,8 +6,12 @@ import {
   createEmptyProject,
   createSampleStoryMap,
   parseProject,
+  parseStoryMapCsv,
+  parseStoryMapJson,
   projectFromStore,
   serializeProject,
+  serializeStoryMapCsv,
+  serializeStoryMapJson,
   useAppStore,
   type GeoLibreLayer,
 } from "@geolibre/core";
@@ -435,5 +439,55 @@ describe("story maps", () => {
       useAppStore.getState().storymap?.chapters.map((c) => c.id),
       ["c", "b"],
     );
+  });
+});
+
+describe("story map import/export", () => {
+  it("round-trips a story map through JSON", () => {
+    const sample = createSampleStoryMap();
+    const restored = parseStoryMapJson(serializeStoryMapJson(sample));
+    assert.equal(restored.title, sample.title);
+    assert.equal(restored.chapters.length, 5);
+    assert.deepEqual(
+      restored.chapters.map((c) => c.id),
+      sample.chapters.map((c) => c.id),
+    );
+  });
+
+  it("accepts a project-shaped JSON object on import", () => {
+    const sample = createSampleStoryMap();
+    const restored = parseStoryMapJson(JSON.stringify({ storymap: sample }));
+    assert.equal(restored.chapters.length, 5);
+  });
+
+  it("round-trips chapters through CSV and preserves base settings", () => {
+    const sample = createSampleStoryMap();
+    const csv = serializeStoryMapCsv(sample);
+    // Import with different base settings; CSV carries only chapters.
+    const base = { ...sample, title: "Kept Title", chapters: [] };
+    const restored = parseStoryMapCsv(csv, base);
+    assert.equal(restored.title, "Kept Title");
+    assert.equal(restored.chapters.length, 5);
+    assert.deepEqual(
+      restored.chapters[0].location.center,
+      sample.chapters[0].location.center,
+    );
+  });
+
+  it("imports hand-authored CSV with reordered columns and missing ids", () => {
+    const csv = [
+      "title,lat,lng,description,zoom",
+      "Paris,48.8566,2.3522,The City of Light,11",
+      '"Tokyo",35.6895,139.6917,"Mixes, modern and old",10',
+    ].join("\n");
+    const restored = parseStoryMapCsv(csv, null);
+    assert.equal(restored.chapters.length, 2);
+    assert.equal(restored.chapters[0].title, "Paris");
+    assert.deepEqual(restored.chapters[0].location.center, [2.3522, 48.8566]);
+    // Quoted field with a comma is preserved.
+    assert.equal(restored.chapters[1].description, "Mixes, modern and old");
+    // Missing ids are generated.
+    assert.ok(restored.chapters[0].id);
+    assert.notEqual(restored.chapters[0].id, restored.chapters[1].id);
   });
 });


### PR DESCRIPTION
## Summary

Adds **Story Maps** to GeoLibre (closes #291), inspired by the [opengeos/maplibre-gl-storymaps](https://github.com/opengeos/maplibre-gl-storymaps) template. Authors can build a scroll-driven map narrative, present it over the live map, and export a self-contained HTML page.

Open it from **Project → Story Map**.

## What's included

- **Authoring panel** — capture the current map camera into ordered chapters; edit title, description (inline HTML), image, panel alignment, map animation (`flyTo`/`easeTo`/`jumpTo`), hidden, and rotate; reorder, preview (fly to), and delete chapters. Story-level settings: title/subtitle/byline/footer, light/dark theme, markers + color, and inset minimap + position.
- **In-app presenter** — full-screen scroll-driven overlay that flies the live map between chapters using `IntersectionObserver` (no new dependency). Optional marker and inset minimap; `Esc`/Exit returns to editing.
- **Layer opacity transitions** — per-chapter `onChapterEnter`/`onChapterExit` fades applied directly to rendered MapLibre layers (no store/undo pollution; restored on exit).
- **Standalone HTML export** — a single static file mirroring the storytelling template, with in-memory GeoJSON layers inlined so the export behaves like the in-app preview.
- **Persistence** — a new optional `storymap` field in `.geolibre.json` (with normalization), plus store state and chapter actions.
- **Docs, i18n, and tests.**

## Architecture

- `@geolibre/core`: `StoryMap`/`StoryChapter` types, project serialization/normalization, store slice + actions.
- `@geolibre/map`: `MapController.setStoryLayerOpacity` / `restoreLayerStyles` for playback-only layer fades.
- `geolibre-desktop`: `StoryMapPanel`, `StoryMapPresenter`, and `lib/storymap-export.ts`; wired into `DesktopShell` and the Project toolbar menu.

## Testing

- `npm run test:frontend` — all pass (added story-map parse/normalize, round-trip, and reorder/remove tests).
- `npm run build` — passes.
- `pre-commit run --files <changed>` — passes (eslint + npm build).
- Drove the full flow with Playwright (open builder → add chapters → present → exit): no console errors, map flew to captured views, header/panels/Exit rendered correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Story Maps: builder panel, full‑screen presenter overlay, Project menu item, bundled sample story, and export to standalone HTML

* **Enhancements**
  * Project format, app state, and UI support storymap data and chapter management
  * Per‑chapter layer opacity transitions during presentation (non‑persistent)
  * English UI strings added; safer sanitization of author HTML for story content

* **Documentation**
  * New user guide and updated project schema

* **Tests**
  * Parsing and store integration tests for Story Maps
<!-- end of auto-generated comment: release notes by coderabbit.ai -->