### PR TITLE
feat(processing): add zonal stats, raster calculator, reclassify, mosaic, focal

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -312,6 +312,11 @@ const RASTER_TOOL_COMMANDS: Array<{ kind: RasterToolKind; titleKey: ParseKeys }>
     { kind: "polygonize", titleKey: "toolbar.rasterTool.polygonize" },
     { kind: "contour", titleKey: "toolbar.rasterTool.contour" },
     { kind: "interpolate", titleKey: "toolbar.rasterTool.interpolate" },
+    { kind: "zonal", titleKey: "toolbar.rasterTool.zonal" },
+    { kind: "raster-calc", titleKey: "toolbar.rasterTool.rasterCalc" },
+    { kind: "reclassify", titleKey: "toolbar.rasterTool.reclassify" },
+    { kind: "mosaic", titleKey: "toolbar.rasterTool.mosaic" },
+    { kind: "focal", titleKey: "toolbar.rasterTool.focal" },
   ];
 
 async function openExternalLink(url: string): Promise<void> {
@@ -1844,6 +1849,29 @@ export function TopToolbar({
                 onSelect={() => setRasterToolOpen("interpolate")}
               >
                 {t("toolbar.rasterTool.interpolate")}
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel className="text-xs text-muted-foreground">
+                {t("toolbar.item.subGroupAnalysis")}
+              </DropdownMenuLabel>
+              <DropdownMenuItem onSelect={() => setRasterToolOpen("zonal")}>
+                {t("toolbar.rasterTool.zonal")}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onSelect={() => setRasterToolOpen("raster-calc")}
+              >
+                {t("toolbar.rasterTool.rasterCalc")}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onSelect={() => setRasterToolOpen("reclassify")}
+              >
+                {t("toolbar.rasterTool.reclassify")}
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => setRasterToolOpen("mosaic")}>
+                {t("toolbar.rasterTool.mosaic")}
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => setRasterToolOpen("focal")}>
+                {t("toolbar.rasterTool.focal")}
               </DropdownMenuItem>
             </DropdownMenuSubContent>
           </DropdownMenuSub>

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -211,7 +211,14 @@
       "polygonize": "Polygonize",
       "contour": "Contour",
       "interpolate": "Interpolation (IDW / Kriging)",
+      "zonal": "Zonal statistics",
+      "rasterCalc": "Raster calculator",
+      "reclassify": "Reclassify",
+      "mosaic": "Mosaic / merge",
+      "focal": "Focal statistics",
       "inputRaster": "Input raster",
+      "inputRasterA": "Input raster A",
+      "inputRaster1": "First raster",
       "inputPoints": "Input points (GeoJSON)"
     },
     "mapControl": {
@@ -276,6 +283,7 @@
       "subGroupClip": "Clip",
       "subGroupRasterToVector": "Raster to Vector",
       "subGroupVectorToRaster": "Vector to Raster",
+      "subGroupAnalysis": "Analysis",
       "mapControls": "Map controls",
       "atmosphereEffects": "Atmosphere Effects",
       "directions": "Directions",

--- a/backend/geolibre_server/geolibre_server/app/raster.py
+++ b/backend/geolibre_server/geolibre_server/app/raster.py
@@ -1118,15 +1118,8 @@ if size < 3 or size % 2 == 0:
 if size > 25:
     raise SystemExit("Window size is capped at 25")
 stat = str(params.get("statistic", "mean")).lower()
-reducers = {
-    "mean": np.nanmean,
-    "median": np.nanmedian,
-    "min": np.nanmin,
-    "max": np.nanmax,
-    "sum": np.nansum,
-    "std": np.nanstd,
-}
-if stat not in reducers and stat != "range":
+allowed = {"mean", "median", "min", "max", "sum", "std", "range"}
+if stat not in allowed:
     raise SystemExit(f"Unsupported statistic: {stat}")
 nodata = -9999.0
 
@@ -1137,14 +1130,6 @@ with rasterio.open(input_path) as src:
     profile = src.profile.copy()
 
 height, width = data.shape
-# A float32 stack of size*size neighbour copies bounds memory; cap the product
-# so a large window over a large raster can't OOM the runtime.
-MAX_WINDOW_CELLS = 40_000_000
-if height * width * size * size > MAX_WINDOW_CELLS:
-    raise SystemExit(
-        f"A {size}x{size} window over {width}x{height} exceeds the work budget; "
-        "use a smaller window or raster."
-    )
 radius = size // 2
 
 
@@ -1163,24 +1148,62 @@ def neighbor(dy, dx):
     return out
 
 
-stack = np.stack(
-    [
-        neighbor(dy, dx)
-        for dy in range(-radius, radius + 1)
-        for dx in range(-radius, radius + 1)
-    ],
-    axis=0,
-)
-with np.errstate(all="ignore"):
-    if stat == "range":
-        res = np.nanmax(stack, axis=0) - np.nanmin(stack, axis=0)
-    else:
-        res = reducers[stat](stack, axis=0)
-# Windows with no valid cells return NaN/0 depending on the reducer; force them
-# to nodata uniformly.
-valid_count = np.sum(np.isfinite(stack), axis=0)
-res = np.where(valid_count > 0, res, np.nan)
+offsets = [
+    (dy, dx)
+    for dy in range(-radius, radius + 1)
+    for dx in range(-radius, radius + 1)
+]
 
+with np.errstate(all="ignore"):
+    if stat == "median":
+        # Median has no streaming form, so it stacks the neighbour copies.
+        # Cap the stack (size*size float32 copies) so a large window over a
+        # large raster can't OOM the runtime.
+        MAX_MEDIAN_CELLS = 60_000_000
+        if height * width * size * size > MAX_MEDIAN_CELLS:
+            raise SystemExit(
+                f"Focal median with a {size}x{size} window over {width}x{height} "
+                "exceeds the memory budget; use a smaller window or raster, or pick "
+                "a streaming statistic (mean/min/max/sum/std/range)."
+            )
+        stack = np.stack([neighbor(dy, dx) for dy, dx in offsets], axis=0)
+        res = np.nanmedian(stack, axis=0)
+        has_data = np.sum(np.isfinite(stack), axis=0) > 0
+    else:
+        # Streaming accumulators keep memory at O(cells) regardless of window
+        # size, so this scales to full-resolution rasters with large windows.
+        count = np.zeros((height, width), dtype="int32")
+        total = np.zeros((height, width), dtype="float64")
+        sumsq = np.zeros((height, width), dtype="float64")
+        vmin = np.full((height, width), np.inf, dtype="float64")
+        vmax = np.full((height, width), -np.inf, dtype="float64")
+        for dy, dx in offsets:
+            nb = neighbor(dy, dx)
+            valid = np.isfinite(nb)
+            count += valid
+            contrib = np.where(valid, nb, 0.0)
+            total += contrib
+            sumsq += contrib * contrib
+            vmin = np.fmin(vmin, nb)
+            vmax = np.fmax(vmax, nb)
+        has_data = count > 0
+        safe_count = np.where(count == 0, 1, count)
+        if stat == "mean":
+            res = total / safe_count
+        elif stat == "sum":
+            res = total
+        elif stat == "min":
+            res = vmin
+        elif stat == "max":
+            res = vmax
+        elif stat == "range":
+            res = vmax - vmin
+        else:  # std (population)
+            mean_ = total / safe_count
+            res = np.sqrt(np.maximum(sumsq / safe_count - mean_ * mean_, 0.0))
+
+# Windows with no valid cells get nodata uniformly (rather than 0 or inf).
+res = np.where(has_data, res, np.nan)
 out = np.where(np.isfinite(res), res, nodata).astype("float32")
 profile.update(count=1, dtype="float32", nodata=nodata, compress="deflate")
 profile.pop("photometric", None)

--- a/backend/geolibre_server/geolibre_server/app/raster.py
+++ b/backend/geolibre_server/geolibre_server/app/raster.py
@@ -867,11 +867,17 @@ with rasterio.open(input_path) as src:
         )
 
 fc = {"type": "FeatureCollection", "features": out_features}
-if zone_crs.to_epsg() and zone_crs.to_epsg() != 4326:
+zone_epsg = zone_crs.to_epsg()
+if zone_epsg and zone_epsg != 4326:
     fc["crs"] = {
         "type": "name",
-        "properties": {"name": f"urn:ogc:def:crs:EPSG::{zone_crs.to_epsg()}"},
+        "properties": {"name": f"urn:ogc:def:crs:EPSG::{zone_epsg}"},
     }
+elif zone_epsg is None and zone_crs != CRS.from_epsg(4326):
+    # A projected CRS with no EPSG mapping (e.g. custom WKT) would otherwise be
+    # silently dropped, leaving consumers to assume WGS84; embed the WKT so the
+    # true CRS travels with the output rather than being mislabeled.
+    fc["crs"] = {"type": "name", "properties": {"name": zone_crs.to_wkt()}}
 with open(output_path, "w") as f:
     json.dump(fc, f)
 print(
@@ -904,38 +910,50 @@ c_path = str(params.get("c_path", "") or "").strip()
 nodata = -9999.0
 
 
-def load_bands(path, letter, namespace, base_shape):
+def load_bands(path, letter, namespace, base):
+    # ``base`` is None for raster A, else (shape, crs) of A to validate against.
     with rasterio.open(path) as ds:
-        if base_shape is not None and (ds.height, ds.width) != base_shape:
-            raise SystemExit(
-                f"Raster {letter} ({ds.width}x{ds.height}) must match the dimensions "
-                f"of raster A ({base_shape[1]}x{base_shape[0]})."
-            )
+        shape = (ds.height, ds.width)
+        crs = ds.crs
+        if base is not None:
+            if shape != base[0]:
+                raise SystemExit(
+                    f"Raster {letter} ({ds.width}x{ds.height}) must match the "
+                    f"dimensions of raster A ({base[0][1]}x{base[0][0]})."
+                )
+            # Identical dimensions over different CRSs would compute band math on
+            # spatially unaligned pixels; reject rather than emit a silent
+            # mismatch.
+            if crs != base[1]:
+                raise SystemExit(
+                    f"Raster {letter} CRS ({crs}) does not match raster A "
+                    f"({base[1]}); reproject before running the calculator."
+                )
         bands = [
             np.ma.filled(ds.read(i, masked=True).astype("float64"), np.nan)
             for i in range(1, ds.count + 1)
         ]
         profile = ds.profile.copy()
-        shape = (ds.height, ds.width)
     # ``A``/``B``/``C`` reference band 1; ``A1``, ``A2``, ... address each band.
     namespace[letter] = bands[0]
     for i, arr in enumerate(bands, start=1):
         namespace[f"{letter}{i}"] = arr
-    return profile, shape
+    return profile, shape, crs
 
 
 namespace = {}
-profile, base_shape = load_bands(input_path, "A", namespace, None)
+profile, base_shape, base_crs = load_bands(input_path, "A", namespace, None)
 for letter, path in (("B", b_path), ("C", c_path)):
     if path:
-        load_bands(path, letter, namespace, base_shape)
+        load_bands(path, letter, namespace, (base_shape, base_crs))
 
 # Evaluate the expression in a restricted namespace: no builtins, only the band
 # arrays and a curated set of NumPy functions. The sidecar is local and confined
 # to the conversion roots, but stripping ``__builtins__`` still blocks arbitrary
-# attribute/import access from a hand-typed expression.
+# attribute/import access from a hand-typed expression. The bare ``np`` module is
+# intentionally NOT exposed: it would re-open file I/O (np.load/fromfile/savetxt)
+# that bypasses the path allowlist. Every function band math needs is listed here.
 safe_funcs = {
-    "np": np,
     "where": np.where,
     "log": np.log,
     "log10": np.log10,
@@ -1075,13 +1093,28 @@ for key in ("raster_2", "raster_3", "raster_4", "raster_5"):
 if len(paths) < 2:
     raise SystemExit("Mosaic needs at least two rasters")
 
-sources = [rasterio.open(p) for p in paths]
+# Open inside the try so a failure on a later path still closes the handles
+# opened before it (a list comprehension would raise before ``finally`` is set).
+sources = []
 try:
+    for p in paths:
+        sources.append(rasterio.open(p))
     base_crs = sources[0].crs
+    if base_crs is None:
+        raise SystemExit("First raster has no CRS; mosaic requires georeferenced inputs.")
+    base_nodata = sources[0].nodata
     for s in sources[1:]:
         if s.crs != base_crs:
             raise SystemExit(
                 "All rasters must share the same CRS; reproject them first."
+            )
+        if s.nodata != base_nodata:
+            # merge masks each input by its own nodata, but the output header
+            # carries only the first source's value; warn so a mixed-nodata
+            # mosaic isn't silently mislabeled.
+            print(
+                f"Warning: inputs have different nodata values "
+                f"({base_nodata} vs {s.nodata}); output nodata will be {base_nodata}."
             )
     mosaic, out_transform = merge(sources, method=method)
     profile = sources[0].profile.copy()

--- a/backend/geolibre_server/geolibre_server/app/raster.py
+++ b/backend/geolibre_server/geolibre_server/app/raster.py
@@ -808,13 +808,19 @@ if not feats:
 zone_crs = CRS.from_epsg(4326)
 crs_member = gj.get("crs")
 if isinstance(crs_member, dict):
-    name = crs_member.get("properties", {}).get("name", "")
-    digits = re.search(r"(\\d+)$", str(name))
-    if digits:
-        try:
-            zone_crs = CRS.from_epsg(int(digits.group(1)))
-        except Exception:
-            pass
+    name = str(crs_member.get("properties", {}).get("name", ""))
+    # Prefer a full parse (handles OGC URNs, ``EPSG:NNNN``, WKT, PROJ strings)
+    # so a descriptive name like "Custom Albers zone 2" isn't mis-read as EPSG:2
+    # by the trailing-digit fallback.
+    try:
+        zone_crs = CRS.from_user_input(name)
+    except Exception:
+        digits = re.search(r"(\\d+)$", name)
+        if digits:
+            try:
+                zone_crs = CRS.from_epsg(int(digits.group(1)))
+            except Exception:
+                pass
 
 out_features = []
 with_data = 0
@@ -889,7 +895,7 @@ print("{marker}" + json.dumps({"output_path": output_path}))
 
 
 _RASTER_CALC_SCRIPT = """
-import json, sys
+import json, re, sys
 
 import numpy as np
 import rasterio
@@ -902,7 +908,9 @@ if not expression:
     raise SystemExit("Expression is required")
 # Dunder access (e.g. ``A.__class__.__bases__[0].__subclasses__()``) is the
 # standard way to break out of an ``eval`` with an emptied ``__builtins__``;
-# rejecting it keeps band math from reaching arbitrary objects.
+# rejecting it keeps band math from reaching arbitrary objects. This check is
+# load-bearing alongside the empty ``__builtins__`` and the np-free namespace
+# below: do not relax it (e.g. to allow a single ``_``) without replacing it.
 if "__" in expression:
     raise SystemExit("Expression may not contain '__'")
 b_path = str(params.get("b_path", "") or "").strip()
@@ -946,6 +954,14 @@ profile, base_shape, base_crs = load_bands(input_path, "A", namespace, None)
 for letter, path in (("B", b_path), ("C", c_path)):
     if path:
         load_bands(path, letter, namespace, (base_shape, base_crs))
+    # An expression that references B/C without a supplied path would otherwise
+    # fail deep in eval with an opaque "name 'B' is not defined". Catch the
+    # common case up front. The word-boundary match avoids false positives from
+    # function names that merely contain the letter (e.g. 'abs' has no bare 'B').
+    elif re.search(rf"(?<![A-Za-z0-9_]){letter}[0-9]*(?![A-Za-z0-9_])", expression):
+        raise SystemExit(
+            f"Expression references '{letter}' but no Raster {letter} path was provided."
+        )
 
 # Evaluate the expression in a restricted namespace: no builtins, only the band
 # arrays and a curated set of NumPy functions. The sidecar is local and confined
@@ -1103,10 +1119,18 @@ try:
     if base_crs is None:
         raise SystemExit("First raster has no CRS; mosaic requires georeferenced inputs.")
     base_nodata = sources[0].nodata
+    base_count = sources[0].count
     for s in sources[1:]:
         if s.crs != base_crs:
             raise SystemExit(
                 "All rasters must share the same CRS; reproject them first."
+            )
+        if s.count != base_count:
+            # merge would otherwise raise an opaque ValueError mid-run; give a
+            # clear message (e.g. a 3-band RGB tile mixed with a 1-band DEM).
+            raise SystemExit(
+                f"All rasters must have the same band count; one has {s.count} "
+                f"but the first has {base_count}."
             )
         if s.nodata != base_nodata:
             # merge masks each input by its own nodata, but the output header
@@ -1189,14 +1213,17 @@ offsets = [
 
 with np.errstate(all="ignore"):
     if stat == "median":
-        # Median has no streaming form, so it stacks the neighbour copies.
-        # Cap the stack (size*size float32 copies) so a large window over a
-        # large raster can't OOM the runtime.
-        MAX_MEDIAN_CELLS = 60_000_000
-        if height * width * size * size > MAX_MEDIAN_CELLS:
+        # Median has no streaming form, so it stacks the neighbour copies
+        # (size*size float32 layers). Cap the stack at ~480 MB so it can't OOM
+        # the runtime; the streaming statistics below have no such limit.
+        MAX_MEDIAN_CELLS = 120_000_000
+        max_pixels = MAX_MEDIAN_CELLS // (size * size)
+        if height * width > max_pixels:
+            side = int(max_pixels**0.5)
             raise SystemExit(
-                f"Focal median with a {size}x{size} window over {width}x{height} "
-                "exceeds the memory budget; use a smaller window or raster, or pick "
+                f"Focal median with a {size}x{size} window is limited to "
+                f"{max_pixels:,} pixels (~{side}x{side}); this raster is "
+                f"{width}x{height}. Use a smaller window, crop the raster, or pick "
                 "a streaming statistic (mean/min/max/sum/std/range)."
             )
         stack = np.stack([neighbor(dy, dx) for dy, dx in offsets], axis=0)

--- a/backend/geolibre_server/geolibre_server/app/raster.py
+++ b/backend/geolibre_server/geolibre_server/app/raster.py
@@ -772,6 +772,425 @@ print("{marker}" + json.dumps({"output_path": output_path}))
 """.replace("{marker}", _RESULT_MARKER)
 
 
+_ZONAL_STATS_SCRIPT = """
+import json, re, sys
+
+import numpy as np
+import rasterio
+from rasterio.crs import CRS
+from rasterio.errors import RasterioError
+from rasterio.mask import mask as rio_mask
+from rasterio.warp import transform_geom
+
+params = json.loads(sys.argv[1])
+input_path = params["input_path"]
+output_path = params["output_path"]
+zones_path = params["zones_path"]
+band = int(params.get("band", 1))
+# Optional prefix so stats don't clobber existing zone attributes named e.g.
+# 'mean'. Empty by default to match QGIS's bare 'min'/'max'/... fields.
+prefix = str(params.get("prefix", "") or "")
+
+with open(zones_path) as f:
+    gj = json.load(f)
+gtype = gj.get("type")
+if gtype == "FeatureCollection":
+    feats = gj.get("features", [])
+elif gtype == "Feature":
+    feats = [gj]
+else:
+    feats = [{"type": "Feature", "properties": {}, "geometry": gj}]
+if not feats:
+    raise SystemExit("Zones layer has no features")
+
+# Resolve the zones CRS: an explicit GeoJSON ``crs`` member if present, else the
+# GeoJSON default of WGS84 (EPSG:4326).
+zone_crs = CRS.from_epsg(4326)
+crs_member = gj.get("crs")
+if isinstance(crs_member, dict):
+    name = crs_member.get("properties", {}).get("name", "")
+    digits = re.search(r"(\\d+)$", str(name))
+    if digits:
+        try:
+            zone_crs = CRS.from_epsg(int(digits.group(1)))
+        except Exception:
+            pass
+
+out_features = []
+with_data = 0
+with rasterio.open(input_path) as src:
+    if src.crs is None:
+        raise SystemExit(
+            "Input raster has no CRS; zonal statistics requires a georeferenced raster."
+        )
+    if band < 1 or band > src.count:
+        raise SystemExit(f"Band {band} out of range (raster has {src.count} band(s))")
+    for feat in feats:
+        geom = (feat or {}).get("geometry")
+        props = dict((feat or {}).get("properties") or {})
+        vals = np.array([], dtype="float64")
+        if geom:
+            shape = geom
+            # rio_mask needs shapes in the raster's CRS; reproject when the zone
+            # CRS differs so a WGS84 zone layer over a projected raster works.
+            if zone_crs != src.crs:
+                shape = transform_geom(zone_crs, src.crs, geom)
+            try:
+                # filled=False returns a masked array combining the dataset
+                # nodata mask with the outside-geometry mask, so a missing
+                # nodata value can't be mistaken for real data.
+                out_img, _ = rio_mask(
+                    src, [shape], crop=True, filled=False, indexes=band
+                )
+                arr = np.ma.filled(out_img.astype("float64"), np.nan)
+                valid = (~np.ma.getmaskarray(out_img)) & np.isfinite(arr)
+                vals = arr[valid]
+            except (ValueError, RasterioError):
+                # Geometry falls entirely outside the raster; report empty stats.
+                vals = np.array([], dtype="float64")
+        n = int(vals.size)
+        if n:
+            with_data += 1
+            props[prefix + "count"] = n
+            props[prefix + "min"] = float(vals.min())
+            props[prefix + "max"] = float(vals.max())
+            props[prefix + "mean"] = float(vals.mean())
+            props[prefix + "sum"] = float(vals.sum())
+            props[prefix + "std"] = float(vals.std())
+            props[prefix + "median"] = float(np.median(vals))
+        else:
+            props[prefix + "count"] = 0
+            for key in ("min", "max", "mean", "sum", "std", "median"):
+                props[prefix + key] = None
+        out_features.append(
+            {"type": "Feature", "properties": props, "geometry": geom}
+        )
+
+fc = {"type": "FeatureCollection", "features": out_features}
+if zone_crs.to_epsg() and zone_crs.to_epsg() != 4326:
+    fc["crs"] = {
+        "type": "name",
+        "properties": {"name": f"urn:ogc:def:crs:EPSG::{zone_crs.to_epsg()}"},
+    }
+with open(output_path, "w") as f:
+    json.dump(fc, f)
+print(
+    f"Computed zonal statistics for {len(out_features)} zone(s) "
+    f"({with_data} with data) -> {output_path}"
+)
+print("{marker}" + json.dumps({"output_path": output_path}))
+""".replace("{marker}", _RESULT_MARKER)
+
+
+_RASTER_CALC_SCRIPT = """
+import json, sys
+
+import numpy as np
+import rasterio
+
+params = json.loads(sys.argv[1])
+input_path = params["input_path"]
+output_path = params["output_path"]
+expression = str(params.get("expression", "") or "").strip()
+if not expression:
+    raise SystemExit("Expression is required")
+# Dunder access (e.g. ``A.__class__.__bases__[0].__subclasses__()``) is the
+# standard way to break out of an ``eval`` with an emptied ``__builtins__``;
+# rejecting it keeps band math from reaching arbitrary objects.
+if "__" in expression:
+    raise SystemExit("Expression may not contain '__'")
+b_path = str(params.get("b_path", "") or "").strip()
+c_path = str(params.get("c_path", "") or "").strip()
+nodata = -9999.0
+
+
+def load_bands(path, letter, namespace, base_shape):
+    with rasterio.open(path) as ds:
+        if base_shape is not None and (ds.height, ds.width) != base_shape:
+            raise SystemExit(
+                f"Raster {letter} ({ds.width}x{ds.height}) must match the dimensions "
+                f"of raster A ({base_shape[1]}x{base_shape[0]})."
+            )
+        bands = [
+            np.ma.filled(ds.read(i, masked=True).astype("float64"), np.nan)
+            for i in range(1, ds.count + 1)
+        ]
+        profile = ds.profile.copy()
+        shape = (ds.height, ds.width)
+    # ``A``/``B``/``C`` reference band 1; ``A1``, ``A2``, ... address each band.
+    namespace[letter] = bands[0]
+    for i, arr in enumerate(bands, start=1):
+        namespace[f"{letter}{i}"] = arr
+    return profile, shape
+
+
+namespace = {}
+profile, base_shape = load_bands(input_path, "A", namespace, None)
+for letter, path in (("B", b_path), ("C", c_path)):
+    if path:
+        load_bands(path, letter, namespace, base_shape)
+
+# Evaluate the expression in a restricted namespace: no builtins, only the band
+# arrays and a curated set of NumPy functions. The sidecar is local and confined
+# to the conversion roots, but stripping ``__builtins__`` still blocks arbitrary
+# attribute/import access from a hand-typed expression.
+safe_funcs = {
+    "np": np,
+    "where": np.where,
+    "log": np.log,
+    "log10": np.log10,
+    "exp": np.exp,
+    "sqrt": np.sqrt,
+    "abs": np.abs,
+    "sin": np.sin,
+    "cos": np.cos,
+    "tan": np.tan,
+    "arctan": np.arctan,
+    "minimum": np.minimum,
+    "maximum": np.maximum,
+    "clip": np.clip,
+    "floor": np.floor,
+    "ceil": np.ceil,
+    "round": np.round,
+    "pi": np.pi,
+    "e": np.e,
+}
+namespace.update(safe_funcs)
+try:
+    with np.errstate(all="ignore"):
+        result = eval(expression, {"__builtins__": {}}, namespace)
+except SystemExit:
+    raise
+except Exception as exc:
+    raise SystemExit(f"Failed to evaluate expression: {exc}")
+
+result = np.asarray(result, dtype="float64")
+if result.shape != base_shape:
+    # A scalar or single-band broadcast result is fine; anything else is a
+    # dimension mismatch the user must fix.
+    try:
+        result = np.broadcast_to(result, base_shape).astype("float64")
+    except ValueError:
+        raise SystemExit(
+            f"Expression produced a {result.shape} array; expected {base_shape}."
+        )
+
+out = np.where(np.isfinite(result), result, nodata).astype("float32")
+profile.update(count=1, dtype="float32", nodata=nodata, compress="deflate")
+# Drop multiband photometric hints carried over from a multiband input A.
+profile.pop("photometric", None)
+with rasterio.open(output_path, "w", **profile) as dst:
+    dst.write(out, 1)
+print(f"Evaluated '{expression}' -> {output_path}")
+print("{marker}" + json.dumps({"output_path": output_path}))
+""".replace("{marker}", _RESULT_MARKER)
+
+
+_RECLASSIFY_SCRIPT = """
+import json, re, sys
+
+import numpy as np
+import rasterio
+
+params = json.loads(sys.argv[1])
+input_path = params["input_path"]
+output_path = params["output_path"]
+band = int(params.get("band", 1))
+table = str(params.get("table", "") or "").strip()
+if not table:
+    raise SystemExit("Reclassification table is required")
+# What to do with values matching no rule: emit nodata (default) or keep the
+# original value untouched.
+unmatched = str(params.get("unmatched", "nodata")).lower()
+nodata = -9999.0
+
+rules = []
+for token in re.split(r"[,;\\n]+", table):
+    token = token.strip()
+    if not token:
+        continue
+    parts = token.split(":")
+    if len(parts) != 3:
+        raise SystemExit(
+            f"Bad rule '{token}'. Use 'min:max:newvalue' (e.g. '0:10:1')."
+        )
+    lo_raw, hi_raw, nv_raw = (p.strip() for p in parts)
+    lo = -np.inf if lo_raw.lower() in ("", "min", "-inf") else float(lo_raw)
+    hi = np.inf if hi_raw.lower() in ("", "max", "inf") else float(hi_raw)
+    try:
+        nv = float(nv_raw)
+    except ValueError:
+        raise SystemExit(f"Bad new value in rule '{token}'")
+    rules.append((lo, hi, nv))
+if not rules:
+    raise SystemExit("No reclassification rules parsed")
+
+with rasterio.open(input_path) as src:
+    if band < 1 or band > src.count:
+        raise SystemExit(f"Band {band} out of range (raster has {src.count} band(s))")
+    arr = src.read(band, masked=True).astype("float64")
+    profile = src.profile.copy()
+
+data = np.ma.filled(arr, np.nan)
+out = np.full(data.shape, np.nan, dtype="float64")
+# Earlier rules win on overlap: apply in reverse so the first rule's assignment
+# is written last and survives.
+for lo, hi, nv in reversed(rules):
+    # Half-open [lo, hi): a value equal to a class's upper bound belongs to the
+    # next class, avoiding double assignment at shared edges.
+    out[(data >= lo) & (data < hi)] = nv
+if unmatched == "original":
+    keep = np.isnan(out) & np.isfinite(data)
+    out[keep] = data[keep]
+
+result = np.where(np.isfinite(out), out, nodata).astype("float32")
+profile.update(count=1, dtype="float32", nodata=nodata, compress="deflate")
+profile.pop("photometric", None)
+with rasterio.open(output_path, "w", **profile) as dst:
+    dst.write(result, 1)
+print(f"Reclassified band {band} with {len(rules)} rule(s) -> {output_path}")
+print("{marker}" + json.dumps({"output_path": output_path}))
+""".replace("{marker}", _RESULT_MARKER)
+
+
+_MOSAIC_SCRIPT = """
+import json, sys
+
+import rasterio
+from rasterio.merge import merge
+
+params = json.loads(sys.argv[1])
+input_path = params["input_path"]
+output_path = params["output_path"]
+method = str(params.get("method", "first")).lower()
+allowed = {"first", "last", "min", "max"}
+if method not in allowed:
+    raise SystemExit(f"Unsupported merge method: {method} (use {sorted(allowed)})")
+
+paths = [input_path]
+for key in ("raster_2", "raster_3", "raster_4", "raster_5"):
+    extra = str(params.get(key, "") or "").strip()
+    if extra:
+        paths.append(extra)
+if len(paths) < 2:
+    raise SystemExit("Mosaic needs at least two rasters")
+
+sources = [rasterio.open(p) for p in paths]
+try:
+    base_crs = sources[0].crs
+    for s in sources[1:]:
+        if s.crs != base_crs:
+            raise SystemExit(
+                "All rasters must share the same CRS; reproject them first."
+            )
+    mosaic, out_transform = merge(sources, method=method)
+    profile = sources[0].profile.copy()
+finally:
+    for s in sources:
+        s.close()
+
+profile.update(
+    height=mosaic.shape[1],
+    width=mosaic.shape[2],
+    transform=out_transform,
+    compress="deflate",
+)
+with rasterio.open(output_path, "w", **profile) as dst:
+    dst.write(mosaic)
+print(f"Merged {len(paths)} rasters (method={method}) -> {output_path}")
+print("{marker}" + json.dumps({"output_path": output_path}))
+""".replace("{marker}", _RESULT_MARKER)
+
+
+_FOCAL_SCRIPT = """
+import json, sys
+
+import numpy as np
+import rasterio
+
+params = json.loads(sys.argv[1])
+input_path = params["input_path"]
+output_path = params["output_path"]
+band = int(params.get("band", 1))
+size = int(params.get("size", 3))
+if size < 3 or size % 2 == 0:
+    raise SystemExit("Window size must be an odd integer >= 3")
+if size > 25:
+    raise SystemExit("Window size is capped at 25")
+stat = str(params.get("statistic", "mean")).lower()
+reducers = {
+    "mean": np.nanmean,
+    "median": np.nanmedian,
+    "min": np.nanmin,
+    "max": np.nanmax,
+    "sum": np.nansum,
+    "std": np.nanstd,
+}
+if stat not in reducers and stat != "range":
+    raise SystemExit(f"Unsupported statistic: {stat}")
+nodata = -9999.0
+
+with rasterio.open(input_path) as src:
+    if band < 1 or band > src.count:
+        raise SystemExit(f"Band {band} out of range (raster has {src.count} band(s))")
+    data = np.ma.filled(src.read(band, masked=True).astype("float32"), np.nan)
+    profile = src.profile.copy()
+
+height, width = data.shape
+# A float32 stack of size*size neighbour copies bounds memory; cap the product
+# so a large window over a large raster can't OOM the runtime.
+MAX_WINDOW_CELLS = 40_000_000
+if height * width * size * size > MAX_WINDOW_CELLS:
+    raise SystemExit(
+        f"A {size}x{size} window over {width}x{height} exceeds the work budget; "
+        "use a smaller window or raster."
+    )
+radius = size // 2
+
+
+def neighbor(dy, dx):
+    # ``out[i, j] = data[i + dy, j + dx]`` with out-of-bounds neighbours set to
+    # NaN (so edge windows aggregate only the cells that exist).
+    out = np.roll(np.roll(data, -dy, axis=0), -dx, axis=1)
+    if dy > 0:
+        out[-dy:, :] = np.nan
+    elif dy < 0:
+        out[:-dy, :] = np.nan
+    if dx > 0:
+        out[:, -dx:] = np.nan
+    elif dx < 0:
+        out[:, :-dx] = np.nan
+    return out
+
+
+stack = np.stack(
+    [
+        neighbor(dy, dx)
+        for dy in range(-radius, radius + 1)
+        for dx in range(-radius, radius + 1)
+    ],
+    axis=0,
+)
+with np.errstate(all="ignore"):
+    if stat == "range":
+        res = np.nanmax(stack, axis=0) - np.nanmin(stack, axis=0)
+    else:
+        res = reducers[stat](stack, axis=0)
+# Windows with no valid cells return NaN/0 depending on the reducer; force them
+# to nodata uniformly.
+valid_count = np.sum(np.isfinite(stack), axis=0)
+res = np.where(valid_count > 0, res, np.nan)
+
+out = np.where(np.isfinite(res), res, nodata).astype("float32")
+profile.update(count=1, dtype="float32", nodata=nodata, compress="deflate")
+profile.pop("photometric", None)
+with rasterio.open(output_path, "w", **profile) as dst:
+    dst.write(out, 1)
+print(f"Focal {stat} ({size}x{size}) -> {output_path}")
+print("{marker}" + json.dumps({"output_path": output_path}))
+""".replace("{marker}", _RESULT_MARKER)
+
+
 _RASTER_TOOL_SCRIPTS: dict[str, str] = {
     "hillshade": _HILLSHADE_SCRIPT,
     "slope": _SLOPE_SCRIPT,
@@ -783,12 +1202,40 @@ _RASTER_TOOL_SCRIPTS: dict[str, str] = {
     "polygonize": _POLYGONIZE_SCRIPT,
     "contour": _CONTOUR_SCRIPT,
     "interpolate": _INTERPOLATE_SCRIPT,
+    "zonal": _ZONAL_STATS_SCRIPT,
+    "raster-calc": _RASTER_CALC_SCRIPT,
+    "reclassify": _RECLASSIFY_SCRIPT,
+    "mosaic": _MOSAIC_SCRIPT,
+    "focal": _FOCAL_SCRIPT,
 }
 
 # Output kind per tool, used only as the key under ``JobState.outputs``.
 _OUTPUT_NAMES: dict[str, str] = {
     "polygonize": "vector",
     "contour": "vector",
+    "zonal": "vector",
+}
+
+_GEOJSON_EXTS = {".geojson", ".json"}
+_GEOTIFF_EXTS = {".tif", ".tiff"}
+
+# Secondary file-path parameters per tool, validated (path + allowlist +
+# extension) before the job starts. Each entry is
+# ``(param_name, label, allowed_extensions, required)``; an empty optional value
+# is passed through to the script as ``""``.
+_EXTRA_INPUTS: dict[str, list[tuple[str, str, set[str], bool]]] = {
+    "clip-mask": [("mask_path", "Mask layer", _GEOJSON_EXTS, True)],
+    "zonal": [("zones_path", "Zones layer", _GEOJSON_EXTS, True)],
+    "raster-calc": [
+        ("b_path", "Raster B", _GEOTIFF_EXTS, False),
+        ("c_path", "Raster C", _GEOTIFF_EXTS, False),
+    ],
+    "mosaic": [
+        ("raster_2", "Second raster", _GEOTIFF_EXTS, True),
+        ("raster_3", "Third raster", _GEOTIFF_EXTS, False),
+        ("raster_4", "Fourth raster", _GEOTIFF_EXTS, False),
+        ("raster_5", "Fifth raster", _GEOTIFF_EXTS, False),
+    ],
 }
 
 
@@ -891,12 +1338,17 @@ def raster_run(request: RasterToolRequest):
         "output_path": output_path,
     }
 
-    if request.tool_id == "clip-mask":
-        params["mask_path"] = _validate_extra_input(
-            str(request.parameters.get("mask_path", "")),
-            "Mask layer",
-            allowed_extensions={".geojson", ".json"},
-        )
+    # Validate any secondary file-path parameters (clip mask, zonal zones,
+    # raster-calc operands, mosaic inputs) against the path allowlist and the
+    # expected extension. An empty optional value is passed through as "".
+    for name, label, exts, required in _EXTRA_INPUTS.get(request.tool_id, []):
+        raw = str(request.parameters.get(name, "") or "").strip()
+        if not raw:
+            if required:
+                raise HTTPException(status_code=400, detail=f"{label} is required")
+            params[name] = ""
+            continue
+        params[name] = _validate_extra_input(raw, label, allowed_extensions=exts)
 
     # Interpolation reads a point GeoJSON (every other raster tool takes a
     # GeoTIFF). Reject a non-JSON primary input here with a clear 400 instead of

--- a/backend/geolibre_server/tests/test_raster.py
+++ b/backend/geolibre_server/tests/test_raster.py
@@ -511,24 +511,20 @@ def test_zonal_statistics_reprojects_wgs84_zones(tmp_path: Path) -> None:
     Exercises the ``zone_crs != src.crs`` -> ``transform_geom`` branch, the most
     common real-world case, which same-CRS fixtures never hit.
     """
-    from pyproj import Transformer
+    # Use rasterio's own warp.transform (no extra pyproj dependency) to convert
+    # the left/right halves from the raster CRS to WGS84, so the zone file carries
+    # lon/lat coordinates with no explicit crs member.
+    from rasterio.warp import transform as warp_transform
 
     src = _write_classes(tmp_path / "classes.tif")  # EPSG:32633
-    # Reproject the same left/right halves from the raster CRS to WGS84 so the
-    # zone file carries lon/lat coordinates with no explicit crs member.
-    to_wgs84 = Transformer.from_crs("EPSG:32633", "EPSG:4326", always_xy=True)
 
     def wgs_square(minx, miny, maxx, maxy):
-        ring = [
-            (minx, miny),
-            (maxx, miny),
-            (maxx, maxy),
-            (minx, maxy),
-            (minx, miny),
-        ]
+        xs = [minx, maxx, maxx, minx, minx]
+        ys = [miny, miny, maxy, maxy, miny]
+        lons, lats = warp_transform("EPSG:32633", "EPSG:4326", xs, ys)
         return {
             "type": "Polygon",
-            "coordinates": [[list(to_wgs84.transform(x, y)) for x, y in ring]],
+            "coordinates": [[[lon, lat] for lon, lat in zip(lons, lats)]],
         }
 
     zones = tmp_path / "zones_wgs84.geojson"
@@ -875,7 +871,6 @@ def test_mosaic_rejects_mismatched_crs(tmp_path: Path) -> None:
 @requires_rasterio
 def test_mosaic_rejects_mismatched_band_count(tmp_path: Path) -> None:
     """A 1-band raster mixed with a 3-band raster fails with a clear message."""
-    import numpy as np
     import rasterio
     from rasterio.transform import from_origin
 

--- a/backend/geolibre_server/tests/test_raster.py
+++ b/backend/geolibre_server/tests/test_raster.py
@@ -505,6 +505,145 @@ def test_zonal_statistics_summarizes_each_zone(tmp_path: Path) -> None:
 
 
 @requires_rasterio
+def test_zonal_statistics_reprojects_wgs84_zones(tmp_path: Path) -> None:
+    """A WGS84 zone layer (no crs member) over a projected raster is reprojected.
+
+    Exercises the ``zone_crs != src.crs`` -> ``transform_geom`` branch, the most
+    common real-world case, which same-CRS fixtures never hit.
+    """
+    from pyproj import Transformer
+
+    src = _write_classes(tmp_path / "classes.tif")  # EPSG:32633
+    # Reproject the same left/right halves from the raster CRS to WGS84 so the
+    # zone file carries lon/lat coordinates with no explicit crs member.
+    to_wgs84 = Transformer.from_crs("EPSG:32633", "EPSG:4326", always_xy=True)
+
+    def wgs_square(minx, miny, maxx, maxy):
+        ring = [
+            (minx, miny),
+            (maxx, miny),
+            (maxx, maxy),
+            (minx, maxy),
+            (minx, miny),
+        ]
+        return {
+            "type": "Polygon",
+            "coordinates": [[list(to_wgs84.transform(x, y)) for x, y in ring]],
+        }
+
+    zones = tmp_path / "zones_wgs84.geojson"
+    zones.write_text(
+        json.dumps(
+            {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "type": "Feature",
+                        "properties": {"name": "left"},
+                        "geometry": wgs_square(500010, 4099610, 500230, 4099990),
+                    },
+                    {
+                        "type": "Feature",
+                        "properties": {"name": "right"},
+                        "geometry": wgs_square(500250, 4099610, 500470, 4099990),
+                    },
+                ],
+            }
+        )
+    )
+    out = tmp_path / "zonal.geojson"
+    _run_script(
+        _RASTER_TOOL_SCRIPTS["zonal"],
+        {
+            "input_path": str(src),
+            "output_path": str(out),
+            "zones_path": str(zones),
+            "band": 1,
+        },
+    )
+    by_name = {
+        f["properties"]["name"]: f["properties"]
+        for f in json.loads(out.read_text())["features"]
+    }
+    assert by_name["left"]["count"] > 0
+    assert by_name["left"]["mean"] == 0.0
+    assert by_name["right"]["mean"] == 1.0
+
+
+@requires_rasterio
+def test_raster_calculator_rejects_crs_mismatch(tmp_path: Path) -> None:
+    """B with A's dimensions but a different CRS is rejected, not silently mixed."""
+    import rasterio
+    from rasterio.transform import from_origin
+
+    a = _write_dem(tmp_path / "a.tif")  # EPSG:32633
+    with rasterio.open(a) as ds:
+        arr = ds.read(1)
+    b = tmp_path / "b.tif"
+    with rasterio.open(
+        b,
+        "w",
+        driver="GTiff",
+        height=arr.shape[0],
+        width=arr.shape[1],
+        count=1,
+        dtype="float32",
+        crs="EPSG:4326",
+        transform=from_origin(0, 10, 0.1, 0.1),
+    ) as dst:
+        dst.write(arr, 1)
+    out = tmp_path / "calc.tif"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _RASTER_TOOL_SCRIPTS["raster-calc"],
+            json.dumps(
+                {
+                    "input_path": str(a),
+                    "output_path": str(out),
+                    "expression": "A + B",
+                    "b_path": str(b),
+                }
+            ),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    assert "does not match raster A" in (completed.stdout + completed.stderr)
+    assert not out.exists()
+
+
+@requires_rasterio
+def test_raster_calculator_blocks_numpy_io(tmp_path: Path) -> None:
+    """The bare ``np`` module is not exposed, so np.* I/O cannot be reached."""
+    src = _write_dem(tmp_path / "dem.tif")
+    out = tmp_path / "calc.tif"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _RASTER_TOOL_SCRIPTS["raster-calc"],
+            json.dumps(
+                {
+                    "input_path": str(src),
+                    "output_path": str(out),
+                    "expression": "np.where(A > 0, 1, 0)",
+                }
+            ),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    assert "Failed to evaluate expression" in (completed.stdout + completed.stderr)
+    assert not out.exists()
+
+
+@requires_rasterio
 def test_raster_calculator_evaluates_expression(tmp_path: Path) -> None:
     import rasterio
 

--- a/backend/geolibre_server/tests/test_raster.py
+++ b/backend/geolibre_server/tests/test_raster.py
@@ -644,6 +644,52 @@ def test_raster_calculator_blocks_numpy_io(tmp_path: Path) -> None:
 
 
 @requires_rasterio
+def test_raster_calculator_reports_missing_referenced_raster(tmp_path: Path) -> None:
+    """Referencing B without supplying a B path gives a clear message, not NameError."""
+    src = _write_dem(tmp_path / "dem.tif")
+    out = tmp_path / "calc.tif"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _RASTER_TOOL_SCRIPTS["raster-calc"],
+            json.dumps(
+                {
+                    "input_path": str(src),
+                    "output_path": str(out),
+                    "expression": "A + B",
+                }
+            ),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    assert "no Raster B path was provided" in (completed.stdout + completed.stderr)
+    assert not out.exists()
+
+
+@requires_rasterio
+def test_raster_calculator_allows_funcs_named_like_bands(tmp_path: Path) -> None:
+    """A function whose name contains 'b' (abs) must not trip the missing-B guard."""
+    import rasterio
+
+    src = _write_dem(tmp_path / "dem.tif")
+    out = tmp_path / "calc.tif"
+    _run_script(
+        _RASTER_TOOL_SCRIPTS["raster-calc"],
+        {
+            "input_path": str(src),
+            "output_path": str(out),
+            "expression": "abs(A - 10)",
+        },
+    )
+    with rasterio.open(out) as ds:
+        assert ds.count == 1
+
+
+@requires_rasterio
 def test_raster_calculator_evaluates_expression(tmp_path: Path) -> None:
     import rasterio
 
@@ -824,6 +870,49 @@ def test_mosaic_rejects_mismatched_crs(tmp_path: Path) -> None:
     )
     assert completed.returncode != 0
     assert "same CRS" in (completed.stdout + completed.stderr)
+
+
+@requires_rasterio
+def test_mosaic_rejects_mismatched_band_count(tmp_path: Path) -> None:
+    """A 1-band raster mixed with a 3-band raster fails with a clear message."""
+    import numpy as np
+    import rasterio
+    from rasterio.transform import from_origin
+
+    a = _write_dem(tmp_path / "a.tif")  # 1 band, EPSG:32633
+    with rasterio.open(a) as ds:
+        arr = ds.read(1)
+        transform = ds.transform
+    b = tmp_path / "b.tif"
+    with rasterio.open(
+        b,
+        "w",
+        driver="GTiff",
+        height=arr.shape[0],
+        width=arr.shape[1],
+        count=3,
+        dtype="float32",
+        crs="EPSG:32633",
+        transform=from_origin(transform.c, transform.f, 30, 30),
+    ) as dst:
+        for band in range(1, 4):
+            dst.write(arr, band)
+    out = tmp_path / "mosaic.tif"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _RASTER_TOOL_SCRIPTS["mosaic"],
+            json.dumps(
+                {"input_path": str(a), "output_path": str(out), "raster_2": str(b)}
+            ),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    assert "same band count" in (completed.stdout + completed.stderr)
 
 
 @requires_rasterio

--- a/backend/geolibre_server/tests/test_raster.py
+++ b/backend/geolibre_server/tests/test_raster.py
@@ -24,6 +24,11 @@ EXPECTED_TOOL_IDS = {
     "polygonize",
     "contour",
     "interpolate",
+    "zonal",
+    "raster-calc",
+    "reclassify",
+    "mosaic",
+    "focal",
 }
 
 try:
@@ -432,3 +437,308 @@ def test_contour_writes_geojson(tmp_path: Path) -> None:
     assert fc["type"] == "FeatureCollection"
     assert len(fc["features"]) >= 1
     assert all(f["geometry"]["type"] == "LineString" for f in fc["features"])
+
+
+def _square(minx: float, miny: float, maxx: float, maxy: float) -> dict:
+    """Build a GeoJSON polygon ring for the given bounding box."""
+    return {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [minx, miny],
+                [maxx, miny],
+                [maxx, maxy],
+                [minx, maxy],
+                [minx, miny],
+            ]
+        ],
+    }
+
+
+@requires_rasterio
+def test_zonal_statistics_summarizes_each_zone(tmp_path: Path) -> None:
+    """Zonal stats over the two-class raster: one zone all 0s, one all 1s."""
+    src = _write_classes(tmp_path / "classes.tif")
+    # Two zones in the raster's CRS (EPSG:32633): the left half (value 0) and
+    # the right half (value 1). The raster spans 480 m at 30 m / 16 px from the
+    # 500000 / 4100000 top-left origin.
+    zones = tmp_path / "zones.geojson"
+    zones.write_text(
+        json.dumps(
+            {
+                "type": "FeatureCollection",
+                "crs": {
+                    "type": "name",
+                    "properties": {"name": "urn:ogc:def:crs:EPSG::32633"},
+                },
+                "features": [
+                    {
+                        "type": "Feature",
+                        "properties": {"name": "left"},
+                        "geometry": _square(500010, 4099610, 500230, 4099990),
+                    },
+                    {
+                        "type": "Feature",
+                        "properties": {"name": "right"},
+                        "geometry": _square(500250, 4099610, 500470, 4099990),
+                    },
+                ],
+            }
+        )
+    )
+    out = tmp_path / "zonal.geojson"
+    _run_script(
+        _RASTER_TOOL_SCRIPTS["zonal"],
+        {
+            "input_path": str(src),
+            "output_path": str(out),
+            "zones_path": str(zones),
+            "band": 1,
+        },
+    )
+    fc = json.loads(out.read_text())
+    by_name = {f["properties"]["name"]: f["properties"] for f in fc["features"]}
+    assert by_name["left"]["count"] > 0
+    assert by_name["left"]["mean"] == 0.0
+    assert by_name["right"]["mean"] == 1.0
+    assert by_name["right"]["max"] == 1.0
+
+
+@requires_rasterio
+def test_raster_calculator_evaluates_expression(tmp_path: Path) -> None:
+    import rasterio
+
+    src = _write_dem(tmp_path / "dem.tif")  # band 1 = x + y
+    out = tmp_path / "calc.tif"
+    _run_script(
+        _RASTER_TOOL_SCRIPTS["raster-calc"],
+        {
+            "input_path": str(src),
+            "output_path": str(out),
+            "expression": "A * 2 + 1",
+        },
+    )
+    with rasterio.open(src) as ds:
+        a = ds.read(1).astype("float64")
+    with rasterio.open(out) as ds:
+        assert ds.count == 1
+        assert ds.dtypes[0] == "float32"
+        result = ds.read(1).astype("float64")
+    assert result == pytest.approx(a * 2 + 1, rel=1e-5)
+
+
+@requires_rasterio
+def test_raster_calculator_rejects_bad_expression(tmp_path: Path) -> None:
+    src = _write_dem(tmp_path / "dem.tif")
+    out = tmp_path / "calc.tif"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _RASTER_TOOL_SCRIPTS["raster-calc"],
+            json.dumps(
+                {
+                    "input_path": str(src),
+                    "output_path": str(out),
+                    "expression": "A +",
+                }
+            ),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    assert "Failed to evaluate expression" in (completed.stdout + completed.stderr)
+    assert not out.exists()
+
+
+@requires_rasterio
+def test_raster_calculator_rejects_dunder_expression(tmp_path: Path) -> None:
+    """A dunder-bearing expression is rejected before evaluation (sandbox guard)."""
+    src = _write_dem(tmp_path / "dem.tif")
+    out = tmp_path / "calc.tif"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _RASTER_TOOL_SCRIPTS["raster-calc"],
+            json.dumps(
+                {
+                    "input_path": str(src),
+                    "output_path": str(out),
+                    "expression": "A.__class__",
+                }
+            ),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    assert "__" in (completed.stdout + completed.stderr)
+    assert not out.exists()
+
+
+@requires_rasterio
+def test_reclassify_remaps_ranges(tmp_path: Path) -> None:
+    import numpy as np
+    import rasterio
+
+    src = _write_dem(tmp_path / "dem.tif")  # values 0..30
+    out = tmp_path / "reclass.tif"
+    _run_script(
+        _RASTER_TOOL_SCRIPTS["reclassify"],
+        {
+            "input_path": str(src),
+            "output_path": str(out),
+            "band": 1,
+            "table": "0:15:10, 15:max:20",
+            "unmatched": "nodata",
+        },
+    )
+    with rasterio.open(out) as ds:
+        data = ds.read(1, masked=True)
+    uniq = set(np.unique(data.compressed()).tolist())
+    assert uniq == {10.0, 20.0}
+
+
+@requires_rasterio
+def test_mosaic_merges_two_rasters(tmp_path: Path) -> None:
+    import rasterio
+
+    a = _write_dem(tmp_path / "a.tif")
+    # A second tile shifted east by its full width so the mosaic is wider.
+    from rasterio.transform import from_origin
+
+    b = tmp_path / "b.tif"
+    with rasterio.open(a) as ds:
+        arr = ds.read(1)
+        width = ds.width
+    transform = from_origin(500000 + width * 30, 4100000, 30, 30)
+    with rasterio.open(
+        b,
+        "w",
+        driver="GTiff",
+        height=arr.shape[0],
+        width=arr.shape[1],
+        count=1,
+        dtype="float32",
+        crs="EPSG:32633",
+        transform=transform,
+    ) as dst:
+        dst.write(arr, 1)
+    out = tmp_path / "mosaic.tif"
+    _run_script(
+        _RASTER_TOOL_SCRIPTS["mosaic"],
+        {
+            "input_path": str(a),
+            "output_path": str(out),
+            "raster_2": str(b),
+            "method": "first",
+        },
+    )
+    with rasterio.open(a) as ds:
+        single_width = ds.width
+    with rasterio.open(out) as ds:
+        assert ds.width >= single_width * 2 - 1
+
+
+@requires_rasterio
+def test_mosaic_rejects_mismatched_crs(tmp_path: Path) -> None:
+    import rasterio
+    from rasterio.transform import from_origin
+
+    a = _write_dem(tmp_path / "a.tif")
+    b = tmp_path / "b.tif"
+    with rasterio.open(a) as ds:
+        arr = ds.read(1)
+    with rasterio.open(
+        b,
+        "w",
+        driver="GTiff",
+        height=arr.shape[0],
+        width=arr.shape[1],
+        count=1,
+        dtype="float32",
+        crs="EPSG:4326",
+        transform=from_origin(0, 10, 0.1, 0.1),
+    ) as dst:
+        dst.write(arr, 1)
+    out = tmp_path / "mosaic.tif"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _RASTER_TOOL_SCRIPTS["mosaic"],
+            json.dumps(
+                {
+                    "input_path": str(a),
+                    "output_path": str(out),
+                    "raster_2": str(b),
+                }
+            ),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    assert "same CRS" in (completed.stdout + completed.stderr)
+
+
+@requires_rasterio
+def test_focal_mean_preserves_shape(tmp_path: Path) -> None:
+    import numpy as np
+    import rasterio
+
+    src = _write_dem(tmp_path / "dem.tif")
+    out = tmp_path / "focal.tif"
+    _run_script(
+        _RASTER_TOOL_SCRIPTS["focal"],
+        {
+            "input_path": str(src),
+            "output_path": str(out),
+            "band": 1,
+            "statistic": "mean",
+            "size": 3,
+        },
+    )
+    with rasterio.open(src) as ds:
+        in_shape = (ds.height, ds.width)
+        original = ds.read(1).astype("float64")
+    with rasterio.open(out) as ds:
+        assert (ds.height, ds.width) == in_shape
+        smoothed = ds.read(1).astype("float64")
+    # A smoothing mean over a planar ramp leaves interior values ~unchanged but
+    # never exceeds the input's global range.
+    assert smoothed.min() >= original.min() - 1e-3
+    assert smoothed.max() <= original.max() + 1e-3
+    assert np.isfinite(smoothed).all()
+
+
+@requires_rasterio
+def test_focal_rejects_even_window(tmp_path: Path) -> None:
+    src = _write_dem(tmp_path / "dem.tif")
+    out = tmp_path / "focal.tif"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _RASTER_TOOL_SCRIPTS["focal"],
+            json.dumps(
+                {
+                    "input_path": str(src),
+                    "output_path": str(out),
+                    "statistic": "mean",
+                    "size": 4,
+                }
+            ),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    assert "odd integer" in (completed.stdout + completed.stderr)
+    assert not out.exists()

--- a/backend/geolibre_server/tests/test_raster.py
+++ b/backend/geolibre_server/tests/test_raster.py
@@ -742,3 +742,65 @@ def test_focal_rejects_even_window(tmp_path: Path) -> None:
     assert completed.returncode != 0
     assert "odd integer" in (completed.stdout + completed.stderr)
     assert not out.exists()
+
+
+@requires_rasterio
+def test_focal_median_matches_numpy(tmp_path: Path) -> None:
+    """The median (stack) path agrees with a direct NumPy windowed median."""
+    import numpy as np
+    import rasterio
+
+    src = _write_dem(tmp_path / "dem.tif")  # 16x16 ramp z = x + y
+    out = tmp_path / "focal.tif"
+    _run_script(
+        _RASTER_TOOL_SCRIPTS["focal"],
+        {
+            "input_path": str(src),
+            "output_path": str(out),
+            "statistic": "median",
+            "size": 3,
+        },
+    )
+    with rasterio.open(src) as ds:
+        data = ds.read(1).astype("float64")
+    with rasterio.open(out) as ds:
+        got = ds.read(1).astype("float64")
+    # Reference 3x3 median over an interior cell (no edge truncation there).
+    i = j = 8
+    expected = float(np.median(data[i - 1 : i + 2, j - 1 : j + 2]))
+    assert got[i, j] == pytest.approx(expected, rel=1e-5)
+
+
+@requires_rasterio
+def test_focal_std_zero_on_flat_input(tmp_path: Path) -> None:
+    """The streaming std accumulator is ~0 where every neighbour is equal."""
+    import numpy as np
+    import rasterio
+    from rasterio.transform import from_origin
+
+    flat = tmp_path / "flat.tif"
+    with rasterio.open(
+        flat,
+        "w",
+        driver="GTiff",
+        height=12,
+        width=12,
+        count=1,
+        dtype="float32",
+        crs="EPSG:32633",
+        transform=from_origin(500000, 4100000, 30, 30),
+    ) as dst:
+        dst.write(np.full((12, 12), 7.0, dtype="float32"), 1)
+    out = tmp_path / "focal.tif"
+    _run_script(
+        _RASTER_TOOL_SCRIPTS["focal"],
+        {
+            "input_path": str(flat),
+            "output_path": str(out),
+            "statistic": "std",
+            "size": 3,
+        },
+    )
+    with rasterio.open(out) as ds:
+        got = ds.read(1)
+    assert np.allclose(got, 0.0, atol=1e-4)

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -74,7 +74,12 @@ export type RasterToolKind =
   | "clip-mask"
   | "polygonize"
   | "contour"
-  | "interpolate";
+  | "interpolate"
+  | "zonal"
+  | "raster-calc"
+  | "reclassify"
+  | "mosaic"
+  | "focal";
 
 export interface AppState {
   projectName: string;

--- a/packages/processing/src/raster-tools.ts
+++ b/packages/processing/src/raster-tools.ts
@@ -14,7 +14,12 @@ export type RasterToolId =
   | "clip-mask"
   | "polygonize"
   | "contour"
-  | "interpolate";
+  | "interpolate"
+  | "zonal"
+  | "raster-calc"
+  | "reclassify"
+  | "mosaic"
+  | "focal";
 
 /** A native file-dialog filter (Tauri `open`/`save` shape). */
 export interface FileFilter {
@@ -33,7 +38,13 @@ export interface RasterTool {
   id: RasterToolId;
   name: string;
   description: string;
-  group: "Terrain" | "Reproject" | "Clip" | "Raster to Vector" | "Vector to Raster";
+  group:
+    | "Terrain"
+    | "Reproject"
+    | "Clip"
+    | "Raster to Vector"
+    | "Vector to Raster"
+    | "Analysis";
   /** Raster output writes a GeoTIFF; vector output writes a GeoJSON. */
   outputKind: "raster" | "vector";
   defaultOutputName: string;
@@ -391,6 +402,200 @@ export const interpolateTool: RasterTool = {
   ],
 };
 
+export const zonalStatisticsTool: RasterTool = {
+  id: "zonal",
+  name: "Zonal statistics",
+  description:
+    "Summarize raster values within each polygon of a vector layer (count, min, max, mean, sum, std, median).",
+  group: "Analysis",
+  outputKind: "vector",
+  defaultOutputName: "zonal-stats.geojson",
+  inputFilters: GEOTIFF_INPUT,
+  outputFilters: GEOJSON_OUTPUT,
+  parameters: [
+    {
+      id: "zones_path",
+      label: "Zones layer",
+      type: "path",
+      required: true,
+      fileFilters: [{ name: "GeoJSON", extensions: ["geojson", "json"] }],
+      description:
+        "A GeoJSON polygon layer defining the zones. It is reprojected to the raster's CRS automatically (a GeoJSON with no CRS is assumed to be WGS84).",
+    },
+    { id: "band", label: "Band", type: "number", default: 1, min: 1, step: 1 },
+    {
+      id: "prefix",
+      label: "Field prefix",
+      type: "string",
+      default: "",
+      description:
+        "Prepended to each statistic field name (e.g. 'dem_' → 'dem_mean'). Leave blank for bare 'mean', 'min', …",
+    },
+  ],
+};
+
+export const rasterCalculatorTool: RasterTool = {
+  id: "raster-calc",
+  name: "Raster calculator",
+  description:
+    "Evaluate a NumPy band-math expression. Reference band 1 of each input as A, B, C and specific bands as A1, A2, …; e.g. NDVI is (A2 - A1) / (A2 + A1).",
+  group: "Analysis",
+  outputKind: "raster",
+  defaultOutputName: "calc.tif",
+  inputFilters: GEOTIFF_INPUT,
+  outputFilters: GEOTIFF_OUTPUT,
+  inputLabel: "toolbar.rasterTool.inputRasterA",
+  parameters: [
+    {
+      id: "expression",
+      label: "Expression",
+      type: "string",
+      required: true,
+      description:
+        "A NumPy expression over A, B, C (and A1, A2, …). Functions: where, log, exp, sqrt, abs, clip, minimum, maximum, sin, cos, tan.",
+    },
+    {
+      id: "b_path",
+      label: "Raster B (optional)",
+      type: "path",
+      fileFilters: GEOTIFF_INPUT,
+      description: "A second raster, referenced as B / B1, B2, …. Must match A's dimensions.",
+    },
+    {
+      id: "c_path",
+      label: "Raster C (optional)",
+      type: "path",
+      fileFilters: GEOTIFF_INPUT,
+      description: "A third raster, referenced as C / C1, C2, …. Must match A's dimensions.",
+    },
+  ],
+};
+
+export const reclassifyTool: RasterTool = {
+  id: "reclassify",
+  name: "Reclassify",
+  description: "Remap value ranges to new class values using a rule table.",
+  group: "Analysis",
+  outputKind: "raster",
+  defaultOutputName: "reclassified.tif",
+  inputFilters: GEOTIFF_INPUT,
+  outputFilters: GEOTIFF_OUTPUT,
+  parameters: [
+    { id: "band", label: "Band", type: "number", default: 1, min: 1, step: 1 },
+    {
+      id: "table",
+      label: "Rules",
+      type: "string",
+      required: true,
+      description:
+        "Comma- or newline-separated 'min:max:newvalue' rules, e.g. '0:10:1, 10:20:2, 20:max:3'. Ranges are half-open [min, max); blank/min/max mean ±∞.",
+    },
+    {
+      id: "unmatched",
+      label: "Unmatched values",
+      type: "select",
+      default: "nodata",
+      options: [
+        { value: "nodata", label: "Set to NoData" },
+        { value: "original", label: "Keep original value" },
+      ],
+    },
+  ],
+};
+
+export const mosaicTool: RasterTool = {
+  id: "mosaic",
+  name: "Mosaic / merge",
+  description:
+    "Combine up to five rasters (sharing a CRS) into a single raster covering their union.",
+  group: "Analysis",
+  outputKind: "raster",
+  defaultOutputName: "mosaic.tif",
+  inputFilters: GEOTIFF_INPUT,
+  outputFilters: GEOTIFF_OUTPUT,
+  inputLabel: "toolbar.rasterTool.inputRaster1",
+  parameters: [
+    {
+      id: "raster_2",
+      label: "Second raster",
+      type: "path",
+      required: true,
+      fileFilters: GEOTIFF_INPUT,
+    },
+    {
+      id: "raster_3",
+      label: "Third raster (optional)",
+      type: "path",
+      fileFilters: GEOTIFF_INPUT,
+    },
+    {
+      id: "raster_4",
+      label: "Fourth raster (optional)",
+      type: "path",
+      fileFilters: GEOTIFF_INPUT,
+    },
+    {
+      id: "raster_5",
+      label: "Fifth raster (optional)",
+      type: "path",
+      fileFilters: GEOTIFF_INPUT,
+    },
+    {
+      id: "method",
+      label: "Overlap method",
+      type: "select",
+      default: "first",
+      options: [
+        { value: "first", label: "First" },
+        { value: "last", label: "Last" },
+        { value: "min", label: "Minimum" },
+        { value: "max", label: "Maximum" },
+      ],
+      description: "Which value wins where inputs overlap.",
+    },
+  ],
+};
+
+export const focalStatisticsTool: RasterTool = {
+  id: "focal",
+  name: "Focal statistics",
+  description:
+    "Apply a moving-window (neighbourhood) statistic to a raster band.",
+  group: "Analysis",
+  outputKind: "raster",
+  defaultOutputName: "focal.tif",
+  inputFilters: GEOTIFF_INPUT,
+  outputFilters: GEOTIFF_OUTPUT,
+  parameters: [
+    { id: "band", label: "Band", type: "number", default: 1, min: 1, step: 1 },
+    {
+      id: "statistic",
+      label: "Statistic",
+      type: "select",
+      default: "mean",
+      options: [
+        { value: "mean", label: "Mean" },
+        { value: "median", label: "Median" },
+        { value: "min", label: "Minimum" },
+        { value: "max", label: "Maximum" },
+        { value: "sum", label: "Sum" },
+        { value: "std", label: "Standard deviation" },
+        { value: "range", label: "Range (max − min)" },
+      ],
+    },
+    {
+      id: "size",
+      label: "Window size",
+      type: "number",
+      default: 3,
+      min: 3,
+      max: 25,
+      step: 2,
+      description: "Odd neighbourhood size in pixels (3 = 3×3). Capped at 25.",
+    },
+  ],
+};
+
 /** Every raster tool, in display order (grouped by `group`). */
 export const RASTER_TOOLS: RasterTool[] = [
   hillshadeTool,
@@ -403,6 +608,11 @@ export const RASTER_TOOLS: RasterTool[] = [
   polygonizeTool,
   contourTool,
   interpolateTool,
+  zonalStatisticsTool,
+  rasterCalculatorTool,
+  reclassifyTool,
+  mosaicTool,
+  focalStatisticsTool,
 ];
 
 export function getRasterTool(id: string): RasterTool | undefined {

--- a/packages/processing/src/raster-tools.ts
+++ b/packages/processing/src/raster-tools.ts
@@ -284,7 +284,7 @@ export const polygonizeTool: RasterTool = {
   inputFilters: GEOTIFF_INPUT,
   outputFilters: GEOJSON_OUTPUT,
   parameters: [
-    { id: "band", label: "Band", type: "number", default: 1, min: 1, step: 1 },
+    { id: "band", label: "Band", type: "number", default: 1, min: 1, max: 99, step: 1 },
     {
       id: "connectivity",
       label: "Connectivity",
@@ -314,7 +314,7 @@ export const contourTool: RasterTool = {
   inputFilters: GEOTIFF_INPUT,
   outputFilters: GEOJSON_OUTPUT,
   parameters: [
-    { id: "band", label: "Band", type: "number", default: 1, min: 1, step: 1 },
+    { id: "band", label: "Band", type: "number", default: 1, min: 1, max: 99, step: 1 },
     {
       id: "interval",
       label: "Interval",
@@ -422,7 +422,7 @@ export const zonalStatisticsTool: RasterTool = {
       description:
         "A GeoJSON polygon layer defining the zones. It is reprojected to the raster's CRS automatically (a GeoJSON with no CRS is assumed to be WGS84).",
     },
-    { id: "band", label: "Band", type: "number", default: 1, min: 1, step: 1 },
+    { id: "band", label: "Band", type: "number", default: 1, min: 1, max: 99, step: 1 },
     {
       id: "prefix",
       label: "Field prefix",
@@ -481,7 +481,7 @@ export const reclassifyTool: RasterTool = {
   inputFilters: GEOTIFF_INPUT,
   outputFilters: GEOTIFF_OUTPUT,
   parameters: [
-    { id: "band", label: "Band", type: "number", default: 1, min: 1, step: 1 },
+    { id: "band", label: "Band", type: "number", default: 1, min: 1, max: 99, step: 1 },
     {
       id: "table",
       label: "Rules",
@@ -567,7 +567,7 @@ export const focalStatisticsTool: RasterTool = {
   inputFilters: GEOTIFF_INPUT,
   outputFilters: GEOTIFF_OUTPUT,
   parameters: [
-    { id: "band", label: "Band", type: "number", default: 1, min: 1, step: 1 },
+    { id: "band", label: "Band", type: "number", default: 1, min: 1, max: 99, step: 1 },
     {
       id: "statistic",
       label: "Statistic",

--- a/tests/raster-tools.test.ts
+++ b/tests/raster-tools.test.ts
@@ -13,6 +13,11 @@ const EXPECTED_IDS = [
   "polygonize",
   "contour",
   "interpolate",
+  "zonal",
+  "raster-calc",
+  "reclassify",
+  "mosaic",
+  "focal",
 ];
 
 describe("raster tools registry", () => {


### PR DESCRIPTION
## Summary
- Adds the five remaining raster tools from #283: Zonal statistics, Raster calculator (band math), Reclassify, Mosaic / merge, and Focal (moving-window) statistics, each as an embedded rasterio/numpy script on the Python sidecar.
- Wires them through the typed raster registry into a new Processing -> Raster "Analysis" group, with store, toolbar menu, and i18n entries, and generalizes the sidecar secondary file-input validation (allowlist + extension) into one table.

## Test plan
- [x] `pytest backend/geolibre_server/tests/test_raster.py` (22 passing: each tool plus error paths for bad/unsafe expressions, mismatched-CRS mosaic, even focal window)
- [x] `npm run build` (tsc + vite) clean
- [x] `tests/i18n-catalogs.test.ts` passing
- [x] `pre-commit run --all-files` clean
- [ ] Exercise each tool in the desktop app against real GeoTIFF / GeoJSON datasets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added five raster analysis tools: Zonal statistics, Raster calculator, Reclassify, Mosaic, and Focal statistics.
  * Tools appear under Processing → Raster in a new "Analysis" subsection and are accessible from the global command palette.

* **Localization**
  * Added English UI translations for the new tools and their input fields.

* **Tests**
  * Added end-to-end and registry tests covering all new raster tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->