### PR TITLE
feat(attribute-table): add field statistics summary panel

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/AttributeStatsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeStatsDialog.tsx
@@ -1,0 +1,252 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Label,
+  Select,
+} from "@geolibre/ui";
+import { Copy } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import type { ChartRow } from "../../lib/attribute-charts";
+import {
+  computeFieldStats,
+  formatStatValue,
+  type FieldStats,
+} from "../../lib/attribute-stats";
+
+interface AttributeStatsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Every row of the layer. */
+  rows: ChartRow[];
+  /** Rows matching the table's current search filter (a subset of `rows`). */
+  filteredRows: ChartRow[];
+  columns: string[];
+  layerName: string;
+}
+
+type StatsScope = "all" | "filtered";
+
+/**
+ * One-click field statistics summary for the attribute table: pick a field and
+ * read its count / nulls / min / max / mean / median / std / sum / unique
+ * (numeric) or count / nulls / unique / most-frequent values (text). When a
+ * search filter is active the scope can switch between all features and the
+ * filtered subset. The computation lives in `attribute-stats`; this only renders
+ * it.
+ */
+export function AttributeStatsDialog({
+  open,
+  onOpenChange,
+  rows,
+  filteredRows,
+  columns,
+  layerName,
+}: AttributeStatsDialogProps) {
+  const [field, setField] = useState("");
+  const [scope, setScope] = useState<StatsScope>("all");
+  const [copied, setCopied] = useState(false);
+
+  // A filter is active (and worth offering as a scope) only when it actually
+  // narrows the row set; otherwise the two scopes would be identical.
+  const hasFilter = filteredRows.length !== rows.length;
+
+  // Seed the field picker when the dialog opens. Keyed on `open` only: `columns`
+  // gets a fresh identity every parent render, so depending on it here would
+  // reset the user's choice constantly (mirrors AttributeChartDialog).
+  useEffect(() => {
+    if (!open) return;
+    setField(columns[0] ?? "");
+    setScope("all");
+    setCopied(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  // Fall back to "all" when the active filter clears while the dialog is open,
+  // so the scope select never points at an option that is no longer offered.
+  useEffect(() => {
+    if (!hasFilter) setScope("all");
+  }, [hasFilter]);
+
+  const scopedRows = scope === "filtered" && hasFilter ? filteredRows : rows;
+
+  const stats = useMemo<FieldStats | null>(() => {
+    if (!open || !field) return null;
+    return computeFieldStats(scopedRows, field);
+  }, [open, field, scopedRows]);
+
+  const copySummary = () => {
+    if (!stats || !field) return;
+    const lines = statRows(stats).map(([label, value]) => `${label}\t${value}`);
+    const header = `Field statistics — ${field}${
+      scope === "filtered" ? " (filtered)" : ""
+    }`;
+    void navigator.clipboard
+      ?.writeText([header, ...lines].join("\n"))
+      .then(() => setCopied(true))
+      .catch(() => setCopied(false));
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Field statistics</DialogTitle>
+          <DialogDescription>
+            {`Summary statistics for a field in "${layerName}".`}
+          </DialogDescription>
+        </DialogHeader>
+
+        {columns.length === 0 ? (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            This layer has no fields to summarize.
+          </p>
+        ) : (
+          <div className="grid gap-3 py-1">
+            <div className="flex flex-wrap items-end gap-3">
+              <div className="grid gap-1.5">
+                <Label htmlFor="stats-field">Field</Label>
+                <Select
+                  id="stats-field"
+                  className="w-52"
+                  value={field}
+                  onChange={(event) => {
+                    setField(event.target.value);
+                    setCopied(false);
+                  }}
+                >
+                  {columns.map((col) => (
+                    <option key={col} value={col}>
+                      {col}
+                    </option>
+                  ))}
+                </Select>
+              </div>
+              {hasFilter ? (
+                <div className="grid gap-1.5">
+                  <Label htmlFor="stats-scope">Scope</Label>
+                  <Select
+                    id="stats-scope"
+                    className="w-44"
+                    value={scope}
+                    onChange={(event) => {
+                      setScope(event.target.value as StatsScope);
+                      setCopied(false);
+                    }}
+                  >
+                    <option value="all">
+                      All features ({rows.length.toLocaleString()})
+                    </option>
+                    <option value="filtered">
+                      Filtered ({filteredRows.length.toLocaleString()})
+                    </option>
+                  </Select>
+                </div>
+              ) : null}
+            </div>
+
+            <StatsReadout stats={stats} />
+          </div>
+        )}
+
+        <div className="flex items-center justify-end gap-2">
+          {copied ? (
+            <span className="mr-auto text-xs text-muted-foreground">
+              Copied to clipboard.
+            </span>
+          ) : null}
+          {stats ? (
+            <Button variant="outline" onClick={copySummary}>
+              <Copy className="h-4 w-4" />
+              Copy
+            </Button>
+          ) : null}
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/** The label/value pairs shown for a field, in display order. */
+function statRows(stats: FieldStats): [string, string][] {
+  if (stats.kind === "numeric") {
+    return [
+      ["Count", stats.count.toLocaleString()],
+      ["Nulls", stats.nulls.toLocaleString()],
+      ...(stats.nonNumeric > 0
+        ? ([["Non-numeric", stats.nonNumeric.toLocaleString()]] as [
+            string,
+            string,
+          ][])
+        : []),
+      ["Unique", stats.unique.toLocaleString()],
+      ["Min", formatStatValue(stats.min)],
+      ["Max", formatStatValue(stats.max)],
+      ["Mean", formatStatValue(stats.mean)],
+      ["Median", formatStatValue(stats.median)],
+      ["Std dev", formatStatValue(stats.std)],
+      ["Sum", formatStatValue(stats.sum)],
+    ];
+  }
+  return [
+    ["Count", stats.count.toLocaleString()],
+    ["Nulls", stats.nulls.toLocaleString()],
+    ["Unique", stats.unique.toLocaleString()],
+  ];
+}
+
+function StatsReadout({ stats }: { stats: FieldStats | null }) {
+  if (!stats) {
+    return (
+      <p className="py-6 text-center text-sm text-muted-foreground">
+        No values to summarize.
+      </p>
+    );
+  }
+
+  return (
+    <div className="grid gap-3">
+      <dl className="grid grid-cols-2 gap-x-6 gap-y-1.5 rounded-md border bg-background p-3 sm:grid-cols-3">
+        {statRows(stats).map(([label, value]) => (
+          <div key={label} className="flex flex-col">
+            <dt className="text-xs text-muted-foreground">{label}</dt>
+            <dd className="font-mono text-sm tabular-nums">{value}</dd>
+          </div>
+        ))}
+      </dl>
+
+      {stats.kind === "text" ? (
+        <div className="grid gap-1.5">
+          <span className="text-xs font-medium text-muted-foreground">
+            Most frequent values
+          </span>
+          {stats.top.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No populated values.</p>
+          ) : (
+            <ul className="rounded-md border bg-background">
+              {stats.top.map(({ value, count }) => (
+                <li
+                  key={value}
+                  className="flex items-center justify-between gap-3 border-b px-3 py-1.5 text-sm last:border-b-0"
+                >
+                  <span className="min-w-0 truncate font-mono" title={value}>
+                    {value}
+                  </span>
+                  <span className="shrink-0 tabular-nums text-muted-foreground">
+                    {count.toLocaleString()}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -51,6 +51,7 @@ import {
   Plus,
   RotateCcw,
   Save,
+  Sigma,
   TableProperties,
   Trash2,
   X,
@@ -87,6 +88,7 @@ import {
   type CalcOutputType,
 } from "../../lib/attribute-expression";
 import { AttributeChartDialog } from "./AttributeChartDialog";
+import { AttributeStatsDialog } from "./AttributeStatsDialog";
 import {
   exportVectorLayer,
   formatAttributeValue,
@@ -291,6 +293,8 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
   const [newColumnDefault, setNewColumnDefault] = useState("");
   // Charts dialog state.
   const [chartOpen, setChartOpen] = useState(false);
+  // Field-statistics dialog state.
+  const [statsOpen, setStatsOpen] = useState(false);
   // Field-calculator dialog state.
   const [calcOpen, setCalcOpen] = useState(false);
   const [calcMode, setCalcMode] = useState<"update" | "create">("update");
@@ -1262,6 +1266,24 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
             className="h-7 px-2"
             title={
               hasAttributeSource
+                ? "Field statistics summary"
+                : "Statistics require a vector or DuckDB query layer"
+            }
+            aria-label="Field statistics"
+            disabled={!hasAttributeSource}
+            onClick={() => setStatsOpen(true)}
+          >
+            <Sigma className="h-3.5 w-3.5" />
+            <span className="hidden sm:inline">Statistics</span>
+          </Button>
+        ) : null}
+        {!isEditing ? (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 px-2"
+            title={
+              hasAttributeSource
                 ? "Chart numeric fields"
                 : "Charts require a vector or DuckDB query layer"
             }
@@ -1732,6 +1754,14 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
         open={chartOpen}
         onOpenChange={setChartOpen}
         rows={attributeRows}
+        columns={discoveredColumns}
+        layerName={layer?.name ?? ""}
+      />
+      <AttributeStatsDialog
+        open={statsOpen}
+        onOpenChange={setStatsOpen}
+        rows={attributeRows}
+        filteredRows={filtered}
         columns={discoveredColumns}
         layerName={layer?.name ?? ""}
       />

--- a/apps/geolibre-desktop/src/lib/attribute-stats.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-stats.ts
@@ -1,0 +1,198 @@
+/**
+ * Pure data helpers for the attribute table's field-statistics summary panel:
+ * detect whether a field reads as numeric or text and compute a compact summary
+ * for it (count / nulls / min / max / mean / median / std / sum / unique for
+ * numbers; count / nulls / unique / most-frequent values for text). Kept free of
+ * any rendering or React so they can be unit-tested in isolation, and built on
+ * the same `{ properties }` rows and numeric coercion the Charts panel uses so
+ * the two panels agree on what counts as a number.
+ */
+
+import { numericColumns, toFiniteNumber, type ChartRow } from "./attribute-charts";
+
+export interface NumericFieldStats {
+  kind: "numeric";
+  /** How many rows hold a finite numeric value. */
+  count: number;
+  /** Rows whose value is null/undefined or an empty/blank string. */
+  nulls: number;
+  /** Non-null rows whose value is not a finite number (e.g. stray text). */
+  nonNumeric: number;
+  /** Distinct finite numeric values. */
+  unique: number;
+  min: number;
+  max: number;
+  mean: number;
+  median: number;
+  /** Sample standard deviation (n − 1); 0 when fewer than two values. */
+  std: number;
+  sum: number;
+}
+
+export interface TextValueCount {
+  value: string;
+  count: number;
+}
+
+export interface TextFieldStats {
+  kind: "text";
+  /** How many rows hold a non-null, non-blank value. */
+  count: number;
+  /** Rows whose value is null/undefined or an empty/blank string. */
+  nulls: number;
+  /** Distinct non-null values (compared as strings). */
+  unique: number;
+  /** Most frequent values, descending by count then by value. */
+  top: TextValueCount[];
+}
+
+export type FieldStats = NumericFieldStats | TextFieldStats;
+
+/** How many most-frequent values a text summary lists by default. */
+export const DEFAULT_TOP_VALUES = 5;
+
+/** True when a value reads as null for statistics: nullish or a blank string. */
+function isBlank(value: unknown): boolean {
+  return value == null || (typeof value === "string" && value.trim() === "");
+}
+
+/**
+ * Summary statistics for a finite numeric sample. `nulls`/`nonNumeric` default
+ * to 0 and let the caller fold in the rows that never produced a number, so this
+ * stays a pure reduction over the values it was handed. Returns null only when
+ * there are no values to summarize.
+ */
+export function computeNumericStats(
+  values: number[],
+  nulls = 0,
+  nonNumeric = 0,
+): NumericFieldStats | null {
+  if (values.length === 0) return null;
+
+  let min = values[0];
+  let max = values[0];
+  let sum = 0;
+  const distinct = new Set<number>();
+  for (const value of values) {
+    if (value < min) min = value;
+    if (value > max) max = value;
+    sum += value;
+    distinct.add(value);
+  }
+  const mean = sum / values.length;
+
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  const median =
+    sorted.length % 2 === 0
+      ? (sorted[mid - 1] + sorted[mid]) / 2
+      : sorted[mid];
+
+  // Sample standard deviation (divide by n − 1, matching pandas/Excel STDEV);
+  // undefined for a single value, reported as 0.
+  let std = 0;
+  if (values.length > 1) {
+    let sumSq = 0;
+    for (const value of values) {
+      const diff = value - mean;
+      sumSq += diff * diff;
+    }
+    std = Math.sqrt(sumSq / (values.length - 1));
+  }
+
+  return {
+    kind: "numeric",
+    count: values.length,
+    nulls,
+    nonNumeric,
+    unique: distinct.size,
+    min,
+    max,
+    mean,
+    median,
+    std,
+    sum,
+  };
+}
+
+/**
+ * Summary statistics for a text/categorical field across `rows`: how many rows
+ * are populated vs blank, how many distinct values there are, and the
+ * `topCount` most frequent values (ties broken alphabetically for a stable
+ * order). Values are compared by their string form so mixed types collapse the
+ * way the table renders them.
+ */
+export function computeTextStats(
+  rows: ChartRow[],
+  key: string,
+  topCount: number = DEFAULT_TOP_VALUES,
+): TextFieldStats {
+  const counts = new Map<string, number>();
+  let nulls = 0;
+  for (const row of rows) {
+    const raw = row.properties[key];
+    if (isBlank(raw)) {
+      nulls += 1;
+      continue;
+    }
+    const value = String(raw);
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+
+  let count = 0;
+  for (const n of counts.values()) count += n;
+
+  const top = [...counts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, Math.max(0, topCount))
+    .map(([value, n]) => ({ value, count: n }));
+
+  return { kind: "text", count, nulls, unique: counts.size, top };
+}
+
+/**
+ * Summary statistics for one field, choosing the numeric or text shape from the
+ * same heuristic the Charts panel uses (`numericColumns`): a field counts as
+ * numeric when enough of its populated rows parse as finite numbers. Numeric
+ * fields fold their blank and non-numeric row counts into the result. Returns
+ * null when `key` is not present, so callers can show an empty state.
+ */
+export function computeFieldStats(
+  rows: ChartRow[],
+  key: string,
+  topCount: number = DEFAULT_TOP_VALUES,
+): FieldStats | null {
+  const isNumeric = numericColumns(rows, [key]).length > 0;
+  if (!isNumeric) return computeTextStats(rows, key, topCount);
+
+  const values: number[] = [];
+  let nulls = 0;
+  let nonNumeric = 0;
+  for (const row of rows) {
+    const raw = row.properties[key];
+    if (isBlank(raw)) {
+      nulls += 1;
+      continue;
+    }
+    const next = toFiniteNumber(raw);
+    if (next === null) nonNumeric += 1;
+    else values.push(next);
+  }
+  return computeNumericStats(values, nulls, nonNumeric);
+}
+
+/**
+ * Format a statistic for display: integers as-is, other finite numbers to a
+ * trimmed fixed precision, with exponential notation for extreme magnitudes so
+ * the readout stays compact. Mirrors the Charts panel's axis formatting but
+ * keeps a little more precision (means/std are rarely whole numbers).
+ */
+export function formatStatValue(value: number): string {
+  if (!Number.isFinite(value)) return "—";
+  if (Number.isInteger(value)) return value.toLocaleString();
+  const abs = Math.abs(value);
+  if (abs !== 0 && (abs < 1e-4 || abs >= 1e9)) return value.toExponential(3);
+  return parseFloat(value.toFixed(4)).toLocaleString(undefined, {
+    maximumFractionDigits: 4,
+  });
+}

--- a/tests/attribute-stats.test.ts
+++ b/tests/attribute-stats.test.ts
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { ChartRow } from "../apps/geolibre-desktop/src/lib/attribute-charts";
+import {
+  computeFieldStats,
+  computeNumericStats,
+  computeTextStats,
+  formatStatValue,
+  type NumericFieldStats,
+  type TextFieldStats,
+} from "../apps/geolibre-desktop/src/lib/attribute-stats";
+
+function rows(...properties: Record<string, unknown>[]): ChartRow[] {
+  return properties.map((p) => ({ properties: p }));
+}
+
+describe("computeNumericStats", () => {
+  it("returns null for an empty sample", () => {
+    assert.equal(computeNumericStats([]), null);
+  });
+
+  it("computes the full summary for a numeric sample", () => {
+    const stats = computeNumericStats([2, 4, 4, 4, 5, 5, 7, 9]);
+    assert.ok(stats);
+    assert.equal(stats.kind, "numeric");
+    assert.equal(stats.count, 8);
+    assert.equal(stats.min, 2);
+    assert.equal(stats.max, 9);
+    assert.equal(stats.sum, 40);
+    assert.equal(stats.mean, 5);
+    assert.equal(stats.median, 4.5);
+    assert.equal(stats.unique, 5);
+    // Sample standard deviation (n − 1).
+    assert.ok(Math.abs(stats.std - 2.13809) < 1e-4);
+  });
+
+  it("uses the middle value as median for an odd count", () => {
+    const stats = computeNumericStats([3, 1, 2]) as NumericFieldStats;
+    assert.equal(stats.median, 2);
+  });
+
+  it("reports a zero standard deviation for a single value", () => {
+    const stats = computeNumericStats([42]) as NumericFieldStats;
+    assert.equal(stats.std, 0);
+    assert.equal(stats.mean, 42);
+    assert.equal(stats.median, 42);
+  });
+
+  it("folds in the supplied null and non-numeric counts", () => {
+    const stats = computeNumericStats([1, 2], 3, 1) as NumericFieldStats;
+    assert.equal(stats.nulls, 3);
+    assert.equal(stats.nonNumeric, 1);
+  });
+});
+
+describe("computeTextStats", () => {
+  it("counts populated, blank, and distinct values", () => {
+    const data = rows(
+      { city: "A" },
+      { city: "B" },
+      { city: "A" },
+      { city: "" },
+      { city: null },
+      { city: "   " },
+    );
+    const stats = computeTextStats(data, "city");
+    assert.equal(stats.kind, "text");
+    assert.equal(stats.count, 3);
+    assert.equal(stats.nulls, 3);
+    assert.equal(stats.unique, 2);
+  });
+
+  it("lists the most frequent values, ties broken alphabetically", () => {
+    const data = rows(
+      { c: "x" },
+      { c: "x" },
+      { c: "y" },
+      { c: "y" },
+      { c: "z" },
+      { c: "a" },
+    );
+    const stats = computeTextStats(data, "c", 2);
+    assert.deepEqual(stats.top, [
+      { value: "x", count: 2 },
+      { value: "y", count: 2 },
+    ]);
+  });
+
+  it("coerces non-string values to their string form", () => {
+    const data = rows({ c: 1 }, { c: 1 }, { c: true });
+    const stats = computeTextStats(data, "c") as TextFieldStats;
+    assert.equal(stats.unique, 2);
+    assert.equal(stats.top[0].value, "1");
+    assert.equal(stats.top[0].count, 2);
+  });
+});
+
+describe("computeFieldStats", () => {
+  it("treats a mostly-numeric field as numeric and counts blanks", () => {
+    const data = rows(
+      { pop: 10 },
+      { pop: "20" },
+      { pop: 30 },
+      { pop: null },
+      { pop: "" },
+    );
+    const stats = computeFieldStats(data, "pop") as NumericFieldStats;
+    assert.equal(stats.kind, "numeric");
+    assert.equal(stats.count, 3);
+    assert.equal(stats.nulls, 2);
+    assert.equal(stats.sum, 60);
+  });
+
+  it("counts non-numeric non-blank values separately for a numeric field", () => {
+    const data = rows({ v: 1 }, { v: 2 }, { v: 3 }, { v: "n/a" });
+    const stats = computeFieldStats(data, "v") as NumericFieldStats;
+    assert.equal(stats.kind, "numeric");
+    assert.equal(stats.count, 3);
+    assert.equal(stats.nonNumeric, 1);
+    assert.equal(stats.nulls, 0);
+  });
+
+  it("treats an id-like text field as text", () => {
+    const data = rows(
+      { name: "Alpha" },
+      { name: "Beta" },
+      { name: "Gamma" },
+    );
+    const stats = computeFieldStats(data, "name");
+    assert.equal(stats.kind, "text");
+  });
+
+  it("returns null for a numeric field with no values", () => {
+    const data = rows({ v: 1 }, { v: null });
+    // Only one numeric value → not detected as numeric → text stats, not null.
+    const stats = computeFieldStats(data, "v");
+    assert.equal(stats?.kind, "text");
+  });
+});
+
+describe("formatStatValue", () => {
+  it("renders integers without decimals", () => {
+    assert.equal(formatStatValue(1000), (1000).toLocaleString());
+  });
+
+  it("trims trailing precision on fractional values", () => {
+    assert.equal(formatStatValue(2.5), "2.5");
+  });
+
+  it("uses exponential notation for extreme magnitudes", () => {
+    assert.equal(formatStatValue(0.00001), (0.00001).toExponential(3));
+  });
+
+  it("renders non-finite values as an em dash", () => {
+    assert.equal(formatStatValue(Number.NaN), "—");
+    assert.equal(formatStatValue(Infinity), "—");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #312. Adds a one-click **field statistics summary** to the attribute table.

A new **Statistics** button (Σ icon) sits next to **Charts**. It opens a dialog where you pick a field and read its summary at a glance:

- **Numeric fields:** count, nulls, non-numeric, unique, min, max, mean, median, sample standard deviation, sum.
- **Text fields:** count, nulls, unique, and the most-frequent values with their counts.

Field type is detected with the same heuristic the Charts panel uses, and numeric coercion is shared (`toFiniteNumber`), so the two panels agree on what counts as a number. When a search filter is active, a **Scope** selector switches between *all features* and the *filtered subset*. A **Copy** button puts the summary (tab-separated) on the clipboard.

## Where it fits

- New pure module `apps/geolibre-desktop/src/lib/attribute-stats.ts` (computation; reuses `attribute-charts` helpers).
- New `AttributeStatsDialog.tsx` (renders the summary).
- Wired into `AttributeTable.tsx` next to the Charts button, fed all rows + the current search-filtered rows.

## Tests

- New unit suite `tests/attribute-stats.test.ts` (16 cases) covering numeric/text detection, the full numeric summary, median (odd/even), sample std, null/non-numeric counts, top-value ordering, and value formatting.
- Full frontend suite passes (504 tests); typecheck and pre-commit (eslint + npm build) clean.

## Verification

Driven in the real app with Playwright against the public ~1,000-row US cities dataset:

- **Numeric (`population`)** matched independently computed truth exactly — Count 1,000 · Unique 993 · Min 36,877 · Max 8,405,837 · Mean 131,132.443 · Median 68,207 · Std dev 341,690.1905 · Sum 131,132,443.
- **Text (`city`)** — Count 1,000 · Nulls 0 · Unique 925 · most-frequent values (Springfield ×5, …).
- **Scope toggle** with search filter `san` → "Filtered (37)" recomputed correctly — Count 37 · Unique 37 · Min 40,275 · Max 1,409,019 · Sum 7,698,551.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added field-level summary statistics dialog to attribute tables, enabling users to view statistical summaries for selected columns.
  * Statistics display includes count, null values, unique values, and for numeric fields: min, max, mean, median, standard deviation, and sum.
  * For text fields, displays the most frequent values with counts.
  * Users can toggle between computing statistics across all rows or only filtered rows.
  * Added "Copy to clipboard" functionality to export statistics summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->