### PR TITLE
feat(layout): user-editable legend for print layout (#303)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -207,8 +207,7 @@ export function PrintLayoutDialog({
       showFooter,
       footerText,
       legend,
-      legendConfig.title,
-      legendConfig.groupByLayer,
+      legendConfig,
       captured,
     ],
   );

--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useAppStore } from "@geolibre/core";
+import { DEFAULT_LEGEND_CONFIG, useAppStore } from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
 import {
   Button,
@@ -13,7 +13,16 @@ import {
   Select,
   Separator,
 } from "@geolibre/ui";
-import { FileImage, FileText, RefreshCw } from "lucide-react";
+import {
+  ArrowDown,
+  ArrowUp,
+  Eye,
+  EyeOff,
+  FileImage,
+  FileText,
+  RefreshCw,
+  RotateCcw,
+} from "lucide-react";
 import {
   drawLayout,
   pageDimensionsMm,
@@ -23,10 +32,15 @@ import {
   type PaperSizeId,
 } from "../../lib/print-layout";
 import {
+  applyLegendConfig,
   buildLegend,
   captureMapImage,
   exportLayoutPdf,
   exportLayoutPng,
+  legendEditorRows,
+  reorderLegendEntry,
+  setLegendItemLabel,
+  toggleLegendItemHidden,
   type CapturedMap,
 } from "../../lib/print-layout-export";
 
@@ -83,6 +97,8 @@ export function PrintLayoutDialog({
 }: PrintLayoutDialogProps) {
   const layers = useAppStore((s) => s.layers);
   const projectName = useAppStore((s) => s.projectName);
+  const legendConfig = useAppStore((s) => s.legend);
+  const setLegendConfig = useAppStore((s) => s.setLegend);
 
   const [title, setTitle] = useState("");
   const [subtitle, setSubtitle] = useState("");
@@ -100,7 +116,29 @@ export function PrintLayoutDialog({
   const previewRef = useRef<HTMLCanvasElement | null>(null);
   const wasOpenRef = useRef(false);
 
-  const legend = useMemo(() => buildLegend(layers), [layers]);
+  const baseLegend = useMemo(() => buildLegend(layers), [layers]);
+  const legend = useMemo(
+    () => applyLegendConfig(baseLegend, legendConfig),
+    [baseLegend, legendConfig],
+  );
+  const editorRows = useMemo(
+    () => legendEditorRows(baseLegend, legendConfig),
+    [baseLegend, legendConfig],
+  );
+  const entryIdsInOrder = useMemo(
+    () =>
+      editorRows.filter((r) => r.kind === "entry").map((r) => r.layerId),
+    [editorRows],
+  );
+
+  const moveEntry = useCallback(
+    (layerId: string, direction: "up" | "down") => {
+      setLegendConfig(
+        reorderLegendEntry(legendConfig, entryIdsInOrder, layerId, direction),
+      );
+    },
+    [legendConfig, entryIdsInOrder, setLegendConfig],
+  );
 
   const recapture = useCallback(() => {
     const map = mapControllerRef.current?.getMap();
@@ -147,6 +185,8 @@ export function PrintLayoutDialog({
       showFooter,
       footerText,
       legend,
+      legendTitle: legendConfig.title,
+      legendGroupByLayer: legendConfig.groupByLayer,
       metersPerPixel: captured?.metersPerPixel ?? 0,
       bearingDeg: captured?.bearingDeg ?? 0,
       mapImage: captured?.image ?? null,
@@ -165,6 +205,8 @@ export function PrintLayoutDialog({
       showFooter,
       footerText,
       legend,
+      legendConfig.title,
+      legendConfig.groupByLayer,
       captured,
     ],
   );
@@ -315,6 +357,135 @@ export function PrintLayoutDialog({
                   onChange={(e) => setFooterText(e.target.value)}
                 />
               </div>
+            )}
+
+            {showLegend && (
+              <>
+                <Separator />
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <p className="text-sm font-medium">Legend</p>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() =>
+                        setLegendConfig({ ...DEFAULT_LEGEND_CONFIG })
+                      }
+                    >
+                      <RotateCcw className="mr-1.5 h-3.5 w-3.5" />
+                      Reset
+                    </Button>
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="legend-title">Legend title</Label>
+                    <Input
+                      id="legend-title"
+                      value={legendConfig.title}
+                      placeholder="Legend"
+                      onChange={(e) =>
+                        setLegendConfig({
+                          ...legendConfig,
+                          title: e.target.value,
+                        })
+                      }
+                    />
+                  </div>
+                  <ToggleField
+                    id="legend-group"
+                    label="Group classes by layer"
+                    checked={legendConfig.groupByLayer}
+                    onChange={(next) =>
+                      setLegendConfig({ ...legendConfig, groupByLayer: next })
+                    }
+                  />
+
+                  {editorRows.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                      No visible layers to include in the legend.
+                    </p>
+                  ) : (
+                    <div className="max-h-56 space-y-1 overflow-auto rounded-md border p-2">
+                      {editorRows.map((row) => {
+                        const entryIndex = entryIdsInOrder.indexOf(row.layerId);
+                        return (
+                          <div
+                            key={row.key}
+                            className={`flex items-center gap-1.5 ${
+                              row.kind === "class" ? "pl-5" : ""
+                            } ${row.hidden ? "opacity-50" : ""}`}
+                          >
+                            {row.kind === "entry" ? (
+                              <div className="flex flex-col">
+                                <button
+                                  type="button"
+                                  aria-label="Move entry up"
+                                  className="text-muted-foreground hover:text-foreground disabled:opacity-30"
+                                  disabled={entryIndex <= 0}
+                                  onClick={() => moveEntry(row.layerId, "up")}
+                                >
+                                  <ArrowUp className="h-3 w-3" />
+                                </button>
+                                <button
+                                  type="button"
+                                  aria-label="Move entry down"
+                                  className="text-muted-foreground hover:text-foreground disabled:opacity-30"
+                                  disabled={
+                                    entryIndex >= entryIdsInOrder.length - 1
+                                  }
+                                  onClick={() => moveEntry(row.layerId, "down")}
+                                >
+                                  <ArrowDown className="h-3 w-3" />
+                                </button>
+                              </div>
+                            ) : (
+                              <span className="w-3 shrink-0" />
+                            )}
+                            {row.color ? (
+                              <span
+                                className="h-3.5 w-3.5 shrink-0 rounded-sm border"
+                                style={{ backgroundColor: row.color }}
+                              />
+                            ) : (
+                              <span className="w-3.5 shrink-0" />
+                            )}
+                            <Input
+                              className="h-7 flex-1 text-sm"
+                              value={row.label}
+                              placeholder={row.defaultLabel || "Label"}
+                              onChange={(e) =>
+                                setLegendConfig(
+                                  setLegendItemLabel(
+                                    legendConfig,
+                                    row.key,
+                                    e.target.value,
+                                    row.defaultLabel,
+                                  ),
+                                )
+                              }
+                            />
+                            <button
+                              type="button"
+                              aria-label={row.hidden ? "Show entry" : "Hide entry"}
+                              className="shrink-0 text-muted-foreground hover:text-foreground"
+                              onClick={() =>
+                                setLegendConfig(
+                                  toggleLegendItemHidden(legendConfig, row.key),
+                                )
+                              }
+                            >
+                              {row.hidden ? (
+                                <EyeOff className="h-4 w-4" />
+                              ) : (
+                                <Eye className="h-4 w-4" />
+                              )}
+                            </button>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              </>
             )}
           </div>
 

--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { DEFAULT_LEGEND_CONFIG, useAppStore } from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
 import {
@@ -95,6 +96,7 @@ export function PrintLayoutDialog({
   onOpenChange,
   mapControllerRef,
 }: PrintLayoutDialogProps) {
+  const { t } = useTranslation();
   const layers = useAppStore((s) => s.layers);
   const projectName = useAppStore((s) => s.projectName);
   const legendConfig = useAppStore((s) => s.legend);
@@ -364,7 +366,9 @@ export function PrintLayoutDialog({
                 <Separator />
                 <div className="space-y-2">
                   <div className="flex items-center justify-between">
-                    <p className="text-sm font-medium">Legend</p>
+                    <p className="text-sm font-medium">
+                      {t("printLayout.legend.section")}
+                    </p>
                     <Button
                       variant="ghost"
                       size="sm"
@@ -373,15 +377,17 @@ export function PrintLayoutDialog({
                       }
                     >
                       <RotateCcw className="mr-1.5 h-3.5 w-3.5" />
-                      Reset
+                      {t("common.reset")}
                     </Button>
                   </div>
                   <div className="space-y-1.5">
-                    <Label htmlFor="legend-title">Legend title</Label>
+                    <Label htmlFor="legend-title">
+                      {t("printLayout.legend.titleLabel")}
+                    </Label>
                     <Input
                       id="legend-title"
                       value={legendConfig.title}
-                      placeholder="Legend"
+                      placeholder={t("printLayout.legend.defaultTitle")}
                       onChange={(e) =>
                         setLegendConfig({
                           ...legendConfig,
@@ -392,7 +398,7 @@ export function PrintLayoutDialog({
                   </div>
                   <ToggleField
                     id="legend-group"
-                    label="Group classes by layer"
+                    label={t("printLayout.legend.groupByLayer")}
                     checked={legendConfig.groupByLayer}
                     onChange={(next) =>
                       setLegendConfig({ ...legendConfig, groupByLayer: next })
@@ -401,7 +407,7 @@ export function PrintLayoutDialog({
 
                   {editorRows.length === 0 ? (
                     <p className="text-sm text-muted-foreground">
-                      No visible layers to include in the legend.
+                      {t("printLayout.legend.empty")}
                     </p>
                   ) : (
                     <div className="max-h-56 space-y-1 overflow-auto rounded-md border p-2">
@@ -418,7 +424,7 @@ export function PrintLayoutDialog({
                               <div className="flex flex-col">
                                 <button
                                   type="button"
-                                  aria-label="Move entry up"
+                                  aria-label={t("printLayout.legend.moveUp")}
                                   className="text-muted-foreground hover:text-foreground disabled:opacity-30"
                                   disabled={entryIndex <= 0}
                                   onClick={() => moveEntry(row.layerId, "up")}
@@ -427,7 +433,7 @@ export function PrintLayoutDialog({
                                 </button>
                                 <button
                                   type="button"
-                                  aria-label="Move entry down"
+                                  aria-label={t("printLayout.legend.moveDown")}
                                   className="text-muted-foreground hover:text-foreground disabled:opacity-30"
                                   disabled={
                                     entryIndex >= entryIdsInOrder.length - 1
@@ -451,7 +457,10 @@ export function PrintLayoutDialog({
                             <Input
                               className="h-7 flex-1 text-sm"
                               value={row.label}
-                              placeholder={row.defaultLabel || "Label"}
+                              placeholder={
+                                row.defaultLabel ||
+                                t("printLayout.legend.labelPlaceholder")
+                              }
                               onChange={(e) =>
                                 setLegendConfig(
                                   setLegendItemLabel(
@@ -465,7 +474,11 @@ export function PrintLayoutDialog({
                             />
                             <button
                               type="button"
-                              aria-label={row.hidden ? "Show entry" : "Hide entry"}
+                              aria-label={
+                                row.hidden
+                                  ? t("printLayout.legend.showEntry")
+                                  : t("printLayout.legend.hideEntry")
+                              }
                               className="shrink-0 text-muted-foreground hover:text-foreground"
                               onClick={() =>
                                 setLegendConfig(

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -564,6 +564,7 @@ export function TopToolbar({
         ...getPluginManager().getProjectState(),
         manifestUrls: pluginManifestUrls,
       },
+      legend: state.legend,
       metadata: state.metadata,
     });
     return {

--- a/apps/geolibre-desktop/src/hooks/useEmbedBridge.ts
+++ b/apps/geolibre-desktop/src/hooks/useEmbedBridge.ts
@@ -126,6 +126,7 @@ export function useEmbedBridge(
           ...getPluginManager().getProjectState(),
           manifestUrls: state.projectPlugins?.manifestUrls ?? [],
         },
+        legend: state.legend,
         metadata: state.metadata,
       });
     };

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -12,6 +12,20 @@
     "label": "Language",
     "description": "Choose the language used for the interface."
   },
+  "printLayout": {
+    "legend": {
+      "section": "Legend",
+      "titleLabel": "Legend title",
+      "defaultTitle": "Legend",
+      "groupByLayer": "Group classes by layer",
+      "empty": "No visible layers to include in the legend.",
+      "labelPlaceholder": "Label",
+      "moveUp": "Move entry up",
+      "moveDown": "Move entry down",
+      "showEntry": "Show entry",
+      "hideEntry": "Hide entry"
+    }
+  },
   "settings": {
     "title": "Settings",
     "description": "Configure project preferences and runtime settings.",

--- a/apps/geolibre-desktop/src/lib/print-layout-export.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout-export.ts
@@ -13,7 +13,15 @@ import {
 } from "./print-layout";
 import { saveBinaryFileWithFallback } from "./tauri-io";
 
-export { buildLegend } from "./print-legend";
+export {
+  applyLegendConfig,
+  buildLegend,
+  legendEditorRows,
+  reorderLegendEntry,
+  setLegendItemLabel,
+  toggleLegendItemHidden,
+  type LegendEditorRow,
+} from "./print-legend";
 
 export interface CapturedMap {
   image: HTMLCanvasElement;

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -421,14 +421,17 @@ function drawLegend(
   ctx.stroke();
 
   // Rows advance by rowH before each draw, so seed cy at the top padding; with a
-  // title, draw it first and leave a gap before the first row.
+  // title, draw it first and leave a gap before the first row. Set the text
+  // alignment unconditionally: drawLayout leaves textAlign/textBaseline at
+  // center/middle from the title/footer blocks, so an empty legend title must
+  // still reset them or the row labels render mis-anchored.
   let cy = y + pad;
+  ctx.textAlign = "left";
+  ctx.textBaseline = "alphabetic";
   if (hasTitle) {
     cy += titleSize;
     ctx.fillStyle = INK;
     ctx.font = `600 ${titleSize}px system-ui, sans-serif`;
-    ctx.textAlign = "left";
-    ctx.textBaseline = "alphabetic";
     ctx.fillText(title, x + pad, cy);
     cy += unit;
   }

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -54,6 +54,8 @@ export interface LegendSwatch {
 }
 
 export interface LegendEntry {
+  /** Stable identifier of the source layer (used to key user customizations). */
+  id: string;
   name: string;
   swatches: LegendSwatch[];
 }
@@ -70,6 +72,13 @@ export interface LayoutOptions {
   showFooter: boolean;
   footerText: string;
   legend: LegendEntry[];
+  /** Heading drawn above the legend entries. */
+  legendTitle: string;
+  /**
+   * When true, multi-class entries show a per-layer heading above their
+   * classes; when false, classes are listed flat without the layer heading.
+   */
+  legendGroupByLayer: boolean;
   /** Ground metres per source-image pixel at the map centre. */
   metersPerPixel: number;
   /** Map bearing in degrees clockwise from north. */
@@ -233,7 +242,10 @@ export function drawLayout(
     ctx.beginPath();
     ctx.rect(bodyX, bodyY, bodyW, bodyH);
     ctx.clip();
-    drawLegend(ctx, bodyX + inset, bodyY + inset, opts.legend, unit);
+    drawLegend(ctx, bodyX + inset, bodyY + inset, opts.legend, unit, {
+      title: opts.legendTitle,
+      groupByLayer: opts.legendGroupByLayer,
+    });
     ctx.restore();
   }
 
@@ -359,18 +371,19 @@ function drawLegend(
   y: number,
   entries: LegendEntry[],
   unit: number,
+  opts: { title: string; groupByLayer: boolean },
 ): void {
   const pad = unit * 1.4;
   const rowH = unit * 2.6;
   const swatch = unit * 2;
   const titleSize = unit * 2;
   const labelSize = unit * 1.7;
+  const title = opts.title.trim();
+  const hasTitle = title.length > 0;
 
-  // Measure required width.
-  ctx.save();
-  ctx.font = `600 ${titleSize}px system-ui, sans-serif`;
-  let maxText = ctx.measureText("Legend").width;
-  ctx.font = `400 ${labelSize}px system-ui, sans-serif`;
+  // Flatten entries into drawable rows. Single-swatch entries render inline; a
+  // multi-class entry renders a layer heading (when groupByLayer is on) above
+  // its class swatches, or just the flat class swatches when it is off.
   const rows: { color: string; text: string }[] = [];
   for (const entry of entries) {
     if (entry.swatches.length <= 1) {
@@ -379,19 +392,26 @@ function drawLegend(
         text: entry.name,
       });
     } else {
-      rows.push({ color: "", text: entry.name });
+      if (opts.groupByLayer) rows.push({ color: "", text: entry.name });
       for (const sw of entry.swatches) {
         rows.push({ color: sw.color, text: sw.label ?? "" });
       }
     }
   }
+
+  // Measure required width.
+  ctx.save();
+  ctx.font = `600 ${titleSize}px system-ui, sans-serif`;
+  let maxText = hasTitle ? ctx.measureText(title).width : 0;
+  ctx.font = `400 ${labelSize}px system-ui, sans-serif`;
   for (const r of rows) {
     const w = ctx.measureText(r.text).width + (r.color ? swatch + unit : 0);
     if (w > maxText) maxText = w;
   }
 
   const boxW = maxText + pad * 2;
-  const boxH = pad * 2 + titleSize + unit + rows.length * rowH;
+  const titleBlock = hasTitle ? titleSize + unit : 0;
+  const boxH = pad * 2 + titleBlock + rows.length * rowH;
 
   ctx.fillStyle = "rgba(255,255,255,0.85)";
   ctx.strokeStyle = BORDER;
@@ -400,13 +420,18 @@ function drawLegend(
   ctx.fill();
   ctx.stroke();
 
-  let cy = y + pad + titleSize;
-  ctx.fillStyle = INK;
-  ctx.font = `600 ${titleSize}px system-ui, sans-serif`;
-  ctx.textAlign = "left";
-  ctx.textBaseline = "alphabetic";
-  ctx.fillText("Legend", x + pad, cy);
-  cy += unit;
+  // Rows advance by rowH before each draw, so seed cy at the top padding; with a
+  // title, draw it first and leave a gap before the first row.
+  let cy = y + pad;
+  if (hasTitle) {
+    cy += titleSize;
+    ctx.fillStyle = INK;
+    ctx.font = `600 ${titleSize}px system-ui, sans-serif`;
+    ctx.textAlign = "left";
+    ctx.textBaseline = "alphabetic";
+    ctx.fillText(title, x + pad, cy);
+    cy += unit;
+  }
 
   for (const r of rows) {
     cy += rowH;

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -387,9 +387,14 @@ function drawLegend(
   const rows: { color: string; text: string }[] = [];
   for (const entry of entries) {
     if (entry.swatches.length <= 1) {
+      // Prefer the swatch's own label so a multi-class entry collapsed to one
+      // visible swatch (others hidden) keeps its class label (e.g. "High")
+      // instead of falling back to the layer name. Genuine single-symbol
+      // entries carry no swatch label, so they still show entry.name.
+      const swatch = entry.swatches[0];
       rows.push({
-        color: entry.swatches[0]?.color ?? "#999999",
-        text: entry.name,
+        color: swatch?.color ?? "#999999",
+        text: swatch?.label ?? entry.name,
       });
     } else {
       if (opts.groupByLayer) rows.push({ color: "", text: entry.name });

--- a/apps/geolibre-desktop/src/lib/print-legend.ts
+++ b/apps/geolibre-desktop/src/lib/print-legend.ts
@@ -6,9 +6,11 @@ import {
   styleValue,
   type GeoLibreLayer,
   type LayerType,
+  type LegendConfig,
+  type LegendItemOverride,
   type VectorStyleStop,
 } from "@geolibre/core";
-import type { LegendEntry } from "./print-layout";
+import type { LegendEntry, LegendSwatch } from "./print-layout";
 
 /** Layer types styled as vectors (colored fills the legend can represent). */
 const VECTOR_TYPES: ReadonlySet<LayerType> = new Set<LayerType>([
@@ -64,10 +66,15 @@ export function buildLegend(layers: GeoLibreLayer[]): LegendEntry[] {
         Array.isArray(stops) &&
         stops.length > 0
       ) {
-        entries.push({ name: layer.name, swatches: rampSwatches(stops, mode) });
+        entries.push({
+          id: layer.id,
+          name: layer.name,
+          swatches: rampSwatches(stops, mode),
+        });
         continue;
       }
       entries.push({
+        id: layer.id,
         name: layer.name,
         swatches: [{ color: styleValue(layer.style, "fillColor") }],
       });
@@ -75,9 +82,234 @@ export function buildLegend(layers: GeoLibreLayer[]): LegendEntry[] {
     }
 
     // Raster / service layers: a single neutral marker swatch.
-    entries.push({ name: layer.name, swatches: [{ color: NEUTRAL_SWATCH }] });
+    entries.push({
+      id: layer.id,
+      name: layer.name,
+      swatches: [{ color: NEUTRAL_SWATCH }],
+    });
   }
   return entries;
+}
+
+/** Stable key for an individual class swatch within an entry. */
+function swatchKey(layerId: string, index: number): string {
+  return `${layerId}::${index}`;
+}
+
+/**
+ * Reorder base legend entries to follow {@link LegendConfig.order} (top-first).
+ * Layers absent from `order` keep their default position after the listed ones.
+ */
+function orderEntries(
+  entries: LegendEntry[],
+  order: string[],
+): LegendEntry[] {
+  if (order.length === 0) return entries;
+  const byId = new Map(entries.map((entry) => [entry.id, entry]));
+  const seen = new Set<string>();
+  const ordered: LegendEntry[] = [];
+  for (const id of order) {
+    const entry = byId.get(id);
+    if (entry && !seen.has(id)) {
+      ordered.push(entry);
+      seen.add(id);
+    }
+  }
+  for (const entry of entries) {
+    if (!seen.has(entry.id)) ordered.push(entry);
+  }
+  return ordered;
+}
+
+/**
+ * Apply a user {@link LegendConfig} to the auto-built legend, producing the
+ * final entries to render: ordered, with renamed labels and hidden items
+ * removed. Entries whose every swatch is hidden are dropped entirely.
+ *
+ * @param base - Auto-generated entries from {@link buildLegend}.
+ * @param config - User customizations from the project.
+ * @returns Render-ready legend entries.
+ */
+export function applyLegendConfig(
+  base: LegendEntry[],
+  config: LegendConfig,
+): LegendEntry[] {
+  const ordered = orderEntries(base, config.order);
+  const result: LegendEntry[] = [];
+  for (const entry of ordered) {
+    const entryOverride = config.overrides[entry.id];
+    if (entryOverride?.hidden) continue;
+    const name =
+      entryOverride?.label !== undefined && entryOverride.label.trim() !== ""
+        ? entryOverride.label
+        : entry.name;
+
+    if (entry.swatches.length <= 1) {
+      result.push({ id: entry.id, name, swatches: entry.swatches });
+      continue;
+    }
+
+    const swatches: LegendSwatch[] = [];
+    entry.swatches.forEach((swatch, index) => {
+      const override = config.overrides[swatchKey(entry.id, index)];
+      if (override?.hidden) return;
+      swatches.push({
+        color: swatch.color,
+        label:
+          override?.label !== undefined && override.label.trim() !== ""
+            ? override.label
+            : swatch.label,
+      });
+    });
+    // Every class hidden: drop the whole entry rather than render an empty box.
+    if (swatches.length === 0) continue;
+    result.push({ id: entry.id, name, swatches });
+  }
+  return result;
+}
+
+/**
+ * Return a copy of `config` with `key`'s override replaced by `next`, pruning
+ * the entry when it carries neither a label nor a hidden flag so the persisted
+ * config stays minimal.
+ */
+function withOverride(
+  config: LegendConfig,
+  key: string,
+  next: LegendItemOverride,
+): LegendConfig {
+  const overrides = { ...config.overrides };
+  if (next.label === undefined && !next.hidden) {
+    delete overrides[key];
+  } else {
+    overrides[key] = next;
+  }
+  return { ...config, overrides };
+}
+
+/**
+ * Set (or clear) the user label for a legend item. A blank label or one equal
+ * to the auto-generated default clears the override so the default flows through
+ * later (e.g. after the source layer is renamed).
+ */
+export function setLegendItemLabel(
+  config: LegendConfig,
+  key: string,
+  label: string,
+  defaultLabel: string,
+): LegendConfig {
+  const current = config.overrides[key] ?? {};
+  const trimmed = label.trim();
+  const nextLabel =
+    trimmed === "" || trimmed === defaultLabel.trim() ? undefined : label;
+  return withOverride(config, key, { ...current, label: nextLabel });
+}
+
+/** Toggle whether a legend item is hidden from the rendered legend. */
+export function toggleLegendItemHidden(
+  config: LegendConfig,
+  key: string,
+): LegendConfig {
+  const current = config.overrides[key] ?? {};
+  const hidden = !current.hidden;
+  return withOverride(config, key, {
+    label: current.label,
+    hidden: hidden ? true : undefined,
+  });
+}
+
+/**
+ * Move a top-level entry up or down within the current order. `entryIdsInOrder`
+ * is the full ordered list of entry layer ids, so the persisted order stays
+ * complete even when the user had not reordered anything before.
+ */
+export function reorderLegendEntry(
+  config: LegendConfig,
+  entryIdsInOrder: string[],
+  layerId: string,
+  direction: "up" | "down",
+): LegendConfig {
+  const ids = [...entryIdsInOrder];
+  const i = ids.indexOf(layerId);
+  if (i < 0) return config;
+  const j = direction === "up" ? i - 1 : i + 1;
+  if (j < 0 || j >= ids.length) return config;
+  [ids[i], ids[j]] = [ids[j], ids[i]];
+  return { ...config, order: ids };
+}
+
+/** A flattened, editable legend row surfaced in the Print Layout legend editor. */
+export interface LegendEditorRow {
+  /** Stable override key (layer id for an entry, `${layerId}::${i}` for a class). */
+  key: string;
+  /** The owning layer's id (shared by an entry and its class rows). */
+  layerId: string;
+  /** Class rows are indented under their layer entry. */
+  kind: "entry" | "class";
+  /** Swatch color, when the row has one (entries always do; class rows do too). */
+  color?: string;
+  /** The auto-generated label. */
+  defaultLabel: string;
+  /** Effective label after applying any override. */
+  label: string;
+  /** Whether the row is currently hidden from the rendered legend. */
+  hidden: boolean;
+  /** True when this row can be moved up/down (top-level entries only). */
+  reorderable: boolean;
+}
+
+/**
+ * Flatten the auto-built legend into editor rows in the user's current order,
+ * with overrides applied for display. Hidden rows are included (the editor shows
+ * them dimmed) so the user can unhide them.
+ *
+ * @param base - Auto-generated entries from {@link buildLegend}.
+ * @param config - User customizations from the project.
+ * @returns One row per legend entry, with class rows following multi-class entries.
+ */
+export function legendEditorRows(
+  base: LegendEntry[],
+  config: LegendConfig,
+): LegendEditorRow[] {
+  const ordered = orderEntries(base, config.order);
+  const rows: LegendEditorRow[] = [];
+  for (const entry of ordered) {
+    const entryOverride = config.overrides[entry.id];
+    const single = entry.swatches.length <= 1;
+    rows.push({
+      key: entry.id,
+      layerId: entry.id,
+      kind: "entry",
+      color: single ? entry.swatches[0]?.color : undefined,
+      defaultLabel: entry.name,
+      label:
+        entryOverride?.label !== undefined && entryOverride.label !== ""
+          ? entryOverride.label
+          : entry.name,
+      hidden: Boolean(entryOverride?.hidden),
+      reorderable: true,
+    });
+    if (single) continue;
+    entry.swatches.forEach((swatch, index) => {
+      const key = swatchKey(entry.id, index);
+      const override = config.overrides[key];
+      const defaultLabel = swatch.label ?? "";
+      rows.push({
+        key,
+        layerId: entry.id,
+        kind: "class",
+        color: swatch.color,
+        defaultLabel,
+        label:
+          override?.label !== undefined && override.label !== ""
+            ? override.label
+            : defaultLabel,
+        hidden: Boolean(override?.hidden),
+        reorderable: false,
+      });
+    });
+  }
+  return rows;
 }
 
 function rampSwatches(

--- a/apps/geolibre-desktop/src/lib/print-legend.ts
+++ b/apps/geolibre-desktop/src/lib/print-legend.ts
@@ -97,6 +97,26 @@ function swatchKey(layerId: string, index: number): string {
 }
 
 /**
+ * The label to render for an item: the override trimmed of surrounding
+ * whitespace when it has visible content, otherwise the fallback. Trimming here
+ * (rather than when storing) keeps the editor input free to accept spaces while
+ * the canvas export never shows stray leading/trailing whitespace.
+ */
+function renderedLabel(label: string | undefined, fallback: string): string {
+  const trimmed = label?.trim();
+  return trimmed ? trimmed : fallback;
+}
+
+/**
+ * Whether an override carries a non-blank label. Mirrors {@link renderedLabel}'s
+ * blank test so the editor and the rendered legend agree on when an override is
+ * in effect.
+ */
+function hasLabelOverride(label: string | undefined): boolean {
+  return label !== undefined && label.trim() !== "";
+}
+
+/**
  * Reorder base legend entries to follow {@link LegendConfig.order} (top-first).
  * Layers absent from `order` keep their default position after the listed ones.
  */
@@ -139,10 +159,7 @@ export function applyLegendConfig(
   for (const entry of ordered) {
     const entryOverride = config.overrides[entry.id];
     if (entryOverride?.hidden) continue;
-    const name =
-      entryOverride?.label !== undefined && entryOverride.label.trim() !== ""
-        ? entryOverride.label
-        : entry.name;
+    const name = renderedLabel(entryOverride?.label, entry.name);
 
     if (entry.swatches.length <= 1) {
       result.push({ id: entry.id, name, swatches: entry.swatches });
@@ -155,10 +172,9 @@ export function applyLegendConfig(
       if (override?.hidden) return;
       swatches.push({
         color: swatch.color,
-        label:
-          override?.label !== undefined && override.label.trim() !== ""
-            ? override.label
-            : swatch.label,
+        label: hasLabelOverride(override?.label)
+          ? renderedLabel(override?.label, swatch.label ?? "")
+          : swatch.label,
       });
     });
     // Every class hidden: drop the whole entry rather than render an empty box.
@@ -282,10 +298,12 @@ export function legendEditorRows(
       kind: "entry",
       color: single ? entry.swatches[0]?.color : undefined,
       defaultLabel: entry.name,
-      label:
-        entryOverride?.label !== undefined && entryOverride.label !== ""
-          ? entryOverride.label
-          : entry.name,
+      // Show the raw override (so the input can hold spaces mid-edit) but fall
+      // back to the default when it is blank, matching what applyLegendConfig
+      // renders.
+      label: hasLabelOverride(entryOverride?.label)
+        ? (entryOverride?.label as string)
+        : entry.name,
       hidden: Boolean(entryOverride?.hidden),
       reorderable: true,
     });
@@ -300,10 +318,9 @@ export function legendEditorRows(
         kind: "class",
         color: swatch.color,
         defaultLabel,
-        label:
-          override?.label !== undefined && override.label !== ""
-            ? override.label
-            : defaultLabel,
+        label: hasLabelOverride(override?.label)
+          ? (override?.label as string)
+          : defaultLabel,
         hidden: Boolean(override?.hidden),
         reorderable: false,
       });

--- a/docs/project-format.md
+++ b/docs/project-format.md
@@ -15,6 +15,7 @@ Projects are saved as **`.geolibre.json`** files.
 | `layers`          | array   | Layer definitions (see below)                                                                                |
 | `styles`          | object  | Map of layer id → `LayerStyle`                                                                               |
 | `plugins`         | object  | Optional external plugin manifest URLs, active plugin IDs, plugin map-control positions, and plugin settings |
+| `legend`          | object  | Optional Print Layout legend customizations (title, grouping, ordering, per-item rename/hide)                |
 | `metadata`        | object  | Free-form project metadata                                                                                   |
 
 ## Plugin state
@@ -41,6 +42,37 @@ Projects are saved as **`.geolibre.json`** files.
 ```
 
 Projects without a `plugins` section open with the built-in default plugin state.
+
+## Legend
+
+The Print Layout legend is always derived from the visible layers' symbology; the
+`legend` object stores only the user's edits layered on top, so customizations
+survive layer additions and removals.
+
+```json
+{
+  "title": "Legend",
+  "groupByLayer": true,
+  "order": ["layer-b", "layer-a"],
+  "overrides": {
+    "layer-a": { "label": "Roads", "hidden": false },
+    "layer-b::0": { "label": "Low" },
+    "layer-b::1": { "hidden": true }
+  }
+}
+```
+
+- `title` — heading drawn above the legend entries.
+- `groupByLayer` — when `true`, graduated/categorized classes are grouped under a
+  per-layer heading; when `false`, classes are listed flat.
+- `order` — top-level entry order by layer id (top-first); layers not listed keep
+  their default order after the listed ones.
+- `overrides` — per-item `label` and `hidden` edits keyed by a stable item key: a
+  layer id for a whole entry, or `${layerId}::${index}` for an individual class
+  within a graduated/categorized entry.
+
+Projects without a `legend` section open with the default legend (auto-generated
+from the layers, titled "Legend").
 
 ## Layer object
 

--- a/docs/project-format.md
+++ b/docs/project-format.md
@@ -55,7 +55,7 @@ survive layer additions and removals.
   "groupByLayer": true,
   "order": ["layer-b", "layer-a"],
   "overrides": {
-    "layer-a": { "label": "Roads", "hidden": false },
+    "layer-a": { "label": "Roads" },
     "layer-b::0": { "label": "Low" },
     "layer-b::1": { "hidden": true }
   }

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -97,9 +97,10 @@ function normalizeLegendConfig(legend: unknown): LegendConfig | undefined {
       const override = value as Partial<LegendItemOverride>;
       const normalized: LegendItemOverride = {};
       if (typeof override.label === "string") normalized.label = override.label;
-      if (typeof override.hidden === "boolean") {
-        normalized.hidden = override.hidden;
-      }
+      // Only the truthy hidden flag is meaningful; `hidden: false` is the
+      // default, so dropping it keeps round-tripped projects from accumulating
+      // no-op overrides (matches what the UI mutations store).
+      if (override.hidden === true) normalized.hidden = true;
       if (normalized.label !== undefined || normalized.hidden !== undefined) {
         overrides[key.trim()] = normalized;
       }

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -96,7 +96,11 @@ function normalizeLegendConfig(legend: unknown): LegendConfig | undefined {
       if (!key.trim() || !value || typeof value !== "object") continue;
       const override = value as Partial<LegendItemOverride>;
       const normalized: LegendItemOverride = {};
-      if (typeof override.label === "string") normalized.label = override.label;
+      // Mirror setLegendItemLabel / renderedLabel: a blank or whitespace-only
+      // label is treated as "no override", so don't persist it.
+      if (typeof override.label === "string" && override.label.trim() !== "") {
+        normalized.label = override.label;
+      }
       // Only the truthy hidden flag is meaningful; `hidden: false` is the
       // default, so dropping it keeps round-tripped projects from accumulating
       // no-op overrides (matches what the UI mutations store).

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -1,11 +1,14 @@
 import {
   DEFAULT_BASEMAP,
   DEFAULT_LAYER_STYLE,
+  DEFAULT_LEGEND_CONFIG,
   DEFAULT_PROJECT_PREFERENCES,
   PROJECT_VERSION,
   type GeoLibreLayer,
   type GeoLibreProject,
   type LayerStyle,
+  type LegendConfig,
+  type LegendItemOverride,
   type MapViewState,
   type ProjectPluginControlPosition,
   type ProjectPluginState,
@@ -44,6 +47,7 @@ export function createEmptyProject(
     layers: [],
     styles: {},
     preferences: DEFAULT_PROJECT_PREFERENCES,
+    legend: { ...DEFAULT_LEGEND_CONFIG },
     metadata: {},
   };
 }
@@ -68,7 +72,51 @@ export function parseProject(json: string): GeoLibreProject {
     styles: data.styles ?? {},
     preferences: normalizeProjectPreferences(data.preferences),
     plugins: normalizeProjectPlugins(data.plugins) ?? undefined,
+    legend: normalizeLegendConfig(data.legend),
     metadata: data.metadata ?? {},
+  };
+}
+
+/**
+ * Coerce an untrusted (possibly hand-edited) legend config into a valid
+ * {@link LegendConfig}, dropping malformed entries. Returns undefined when no
+ * usable config is present so the default is applied downstream.
+ */
+function normalizeLegendConfig(legend: unknown): LegendConfig | undefined {
+  if (!legend || typeof legend !== "object") return undefined;
+  const candidate = legend as Partial<LegendConfig>;
+
+  const order = Array.isArray(candidate.order)
+    ? uniqueStrings(candidate.order)
+    : [];
+
+  const overrides: Record<string, LegendItemOverride> = {};
+  if (candidate.overrides && typeof candidate.overrides === "object") {
+    for (const [key, value] of Object.entries(candidate.overrides)) {
+      if (!key.trim() || !value || typeof value !== "object") continue;
+      const override = value as Partial<LegendItemOverride>;
+      const normalized: LegendItemOverride = {};
+      if (typeof override.label === "string") normalized.label = override.label;
+      if (typeof override.hidden === "boolean") {
+        normalized.hidden = override.hidden;
+      }
+      if (normalized.label !== undefined || normalized.hidden !== undefined) {
+        overrides[key.trim()] = normalized;
+      }
+    }
+  }
+
+  return {
+    title:
+      typeof candidate.title === "string"
+        ? candidate.title
+        : DEFAULT_LEGEND_CONFIG.title,
+    groupByLayer: normalizeBoolean(
+      candidate.groupByLayer,
+      DEFAULT_LEGEND_CONFIG.groupByLayer,
+    ),
+    order,
+    overrides,
   };
 }
 
@@ -302,6 +350,7 @@ export function projectFromStore(state: {
   layers: GeoLibreLayer[];
   preferences: ProjectPreferences;
   plugins?: ProjectPluginState | null;
+  legend?: LegendConfig | null;
   metadata: Record<string, unknown>;
 }): GeoLibreProject {
   const styles: Record<string, LayerStyle> = {};
@@ -309,6 +358,7 @@ export function projectFromStore(state: {
     styles[layer.id] = layer.style;
   }
   const plugins = normalizeProjectPlugins(state.plugins);
+  const legend = normalizeLegendConfig(state.legend);
   return {
     version: PROJECT_VERSION,
     name: state.projectName,
@@ -320,6 +370,7 @@ export function projectFromStore(state: {
     styles,
     preferences: state.preferences,
     ...(plugins ? { plugins } : {}),
+    ...(legend ? { legend } : {}),
     metadata: state.metadata,
   };
 }
@@ -389,6 +440,7 @@ export function applyProjectToStore(project: GeoLibreProject): {
   layers: GeoLibreLayer[];
   preferences: ProjectPreferences;
   projectPlugins: ProjectPluginState | null;
+  legend: LegendConfig;
   metadata: Record<string, unknown>;
 } {
   const layers = project.layers.map((layer) => ({
@@ -406,6 +458,7 @@ export function applyProjectToStore(project: GeoLibreProject): {
     layers,
     preferences: normalizeProjectPreferences(project.preferences),
     projectPlugins: normalizeProjectPlugins(project.plugins),
+    legend: normalizeLegendConfig(project.legend) ?? { ...DEFAULT_LEGEND_CONFIG },
     metadata: project.metadata,
   };
 }

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -14,10 +14,12 @@ import {
 import {
   DEFAULT_BASEMAP,
   DEFAULT_LAYER_STYLE,
+  DEFAULT_LEGEND_CONFIG,
   DEFAULT_PROJECT_PREFERENCES,
   type GeoLibreLayer,
   type GeoLibreProject,
   type LayerStyle,
+  type LegendConfig,
   type MapViewState,
   type ProjectPluginState,
   type ProjectPreferences,
@@ -94,6 +96,7 @@ export interface AppState {
   layers: GeoLibreLayer[];
   preferences: ProjectPreferences;
   projectPlugins: ProjectPluginState | null;
+  legend: LegendConfig;
   selectedLayerId: string | null;
   selectedFeatureId: string | null;
   identifyLayerId: string | null;
@@ -117,6 +120,7 @@ export interface AppState {
   setBasemapVisible: (visible: boolean) => void;
   setBasemapOpacity: (opacity: number) => void;
   setPreferences: (preferences: ProjectPreferences) => void;
+  setLegend: (legend: LegendConfig) => void;
   setProjectPlugins: (
     projectPlugins: ProjectPluginState | null,
     shouldMarkDirty?: boolean
@@ -209,6 +213,7 @@ export const useAppStore = create<AppState>()(
       layers: [],
       preferences: DEFAULT_PROJECT_PREFERENCES,
       projectPlugins: null,
+      legend: { ...DEFAULT_LEGEND_CONFIG },
       selectedLayerId: null,
       selectedFeatureId: null,
       identifyLayerId: null,
@@ -238,6 +243,7 @@ export const useAppStore = create<AppState>()(
       setBasemapOpacity: (opacity) =>
         set({ basemapOpacity: opacity, isDirty: true }),
       setPreferences: (preferences) => set({ preferences, isDirty: true }),
+      setLegend: (legend) => set({ legend, isDirty: true }),
       // When shouldMarkDirty is false the existing dirty flag is preserved rather
       // than set; it cannot clear the flag (only markSaved() does that).
       setProjectPlugins: (projectPlugins, shouldMarkDirty = true) =>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -295,12 +295,18 @@ export interface LegendConfig {
   overrides: Record<string, LegendItemOverride>;
 }
 
-export const DEFAULT_LEGEND_CONFIG: LegendConfig = {
+// Frozen so the shared singleton can be safely spread (`{ ...DEFAULT_LEGEND_CONFIG }`)
+// at call sites without risk of a future in-place mutation corrupting the nested
+// `order`/`overrides` references that the spread keeps sharing.
+export const DEFAULT_LEGEND_CONFIG: LegendConfig = Object.freeze({
   title: "Legend",
   groupByLayer: true,
-  order: [],
-  overrides: {},
-};
+  order: Object.freeze([] as string[]) as string[],
+  overrides: Object.freeze({} as Record<string, LegendItemOverride>) as Record<
+    string,
+    LegendItemOverride
+  >,
+});
 
 export interface GeoLibreProject {
   version: string;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -263,6 +263,45 @@ export const DEFAULT_PROJECT_PREFERENCES: ProjectPreferences = {
   environmentVariables: [],
 };
 
+/**
+ * A single user override for one legend item, keyed in {@link LegendConfig.overrides}
+ * by a stable item key (a layer id for a whole entry, or `${layerId}::${index}`
+ * for an individual class within a graduated/categorized entry).
+ */
+export interface LegendItemOverride {
+  /** User-supplied label that replaces the auto-generated one. */
+  label?: string;
+  /** When true, the item is omitted from the rendered legend. */
+  hidden?: boolean;
+}
+
+/**
+ * User customizations for the Print Layout legend. The legend itself is always
+ * derived from the visible layers' symbology; this record only stores the edits
+ * layered on top (title, ordering, per-item rename/hide), so it survives layer
+ * additions and removals and is persisted in the `.geolibre.json` project.
+ */
+export interface LegendConfig {
+  /** Heading drawn above the legend entries. */
+  title: string;
+  /** When true, classes are grouped under a per-layer heading. */
+  groupByLayer: boolean;
+  /**
+   * Custom top-level entry order by layer id, top-first. Layer ids not listed
+   * keep their default order after the listed ones.
+   */
+  order: string[];
+  /** Per-item overrides keyed by stable item key. */
+  overrides: Record<string, LegendItemOverride>;
+}
+
+export const DEFAULT_LEGEND_CONFIG: LegendConfig = {
+  title: "Legend",
+  groupByLayer: true,
+  order: [],
+  overrides: {},
+};
+
 export interface GeoLibreProject {
   version: string;
   name: string;
@@ -274,6 +313,8 @@ export interface GeoLibreProject {
   styles: Record<string, LayerStyle>;
   preferences: ProjectPreferences;
   plugins?: ProjectPluginState;
+  /** User customizations for the Print Layout legend. */
+  legend?: LegendConfig;
   metadata: Record<string, unknown>;
 }
 

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -113,6 +113,7 @@ describe("project parsing", () => {
           overrides: {
             a: { label: "Renamed", hidden: true },
             b: { hidden: "yes", label: 3 },
+            c: { hidden: false },
             "": { hidden: true },
           },
         },

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -100,6 +100,53 @@ describe("project parsing", () => {
     });
   });
 
+  it("normalizes a legend config, dropping malformed overrides", () => {
+    const project = parseProject(
+      JSON.stringify({
+        version: "0.1.0",
+        name: "Legend",
+        mapView: { center: [0, 0], zoom: 2, bearing: 0, pitch: 0 },
+        legend: {
+          title: "My Legend",
+          groupByLayer: false,
+          order: ["a", "a", "b", 5],
+          overrides: {
+            a: { label: "Renamed", hidden: true },
+            b: { hidden: "yes", label: 3 },
+            "": { hidden: true },
+          },
+        },
+      }),
+    );
+    assert.equal(project.legend?.title, "My Legend");
+    assert.equal(project.legend?.groupByLayer, false);
+    assert.deepEqual(project.legend?.order, ["a", "b"]);
+    assert.deepEqual(project.legend?.overrides, { a: { label: "Renamed", hidden: true } });
+  });
+
+  it("round-trips a legend config through projectFromStore", () => {
+    const legend = {
+      title: "Custom",
+      groupByLayer: false,
+      order: ["a"],
+      overrides: { a: { label: "A renamed" } },
+    };
+    const project = projectFromStore({
+      projectName: "Legend",
+      mapView: { center: [0, 0], zoom: 2, bearing: 0, pitch: 0 },
+      basemapStyleUrl: DEFAULT_BASEMAP,
+      basemapVisible: true,
+      basemapOpacity: 1,
+      layers: [],
+      preferences: createEmptyProject().preferences,
+      legend,
+      metadata: {},
+    });
+    assert.deepEqual(project.legend, legend);
+    const reparsed = parseProject(serializeProject(project));
+    assert.deepEqual(reparsed.legend, legend);
+  });
+
   it("saves original XYZ tile templates instead of resolved URLs", () => {
     const project = projectFromStore({
       projectName: "Tiles",

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -114,6 +114,7 @@ describe("project parsing", () => {
             a: { label: "Renamed", hidden: true },
             b: { hidden: "yes", label: 3 },
             c: { hidden: false },
+            d: { label: "   " },
             "": { hidden: true },
           },
         },

--- a/tests/print-layout.test.ts
+++ b/tests/print-layout.test.ts
@@ -1,0 +1,104 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  drawLayout,
+  type LayoutOptions,
+  type LegendEntry,
+} from "../apps/geolibre-desktop/src/lib/print-layout";
+
+/**
+ * A minimal recording stand-in for a 2D canvas context. Every drawing method is
+ * a no-op except `measureText` (returns a fixed width) and `fillText`, which
+ * records the alignment in effect at the moment of the draw so tests can assert
+ * how text was anchored.
+ */
+function recordingCanvas(): {
+  canvas: HTMLCanvasElement;
+  fills: { text: string; textAlign: string; textBaseline: string }[];
+} {
+  const fills: { text: string; textAlign: string; textBaseline: string }[] = [];
+  const state: Record<string, unknown> = {
+    textAlign: "start",
+    textBaseline: "alphabetic",
+  };
+  const ctx = new Proxy(state, {
+    get(target, prop) {
+      if (prop === "measureText") return () => ({ width: 10 });
+      if (prop === "fillText") {
+        return (text: string) =>
+          fills.push({
+            text,
+            textAlign: String(target.textAlign),
+            textBaseline: String(target.textBaseline),
+          });
+      }
+      if (prop in target) return target[prop as string];
+      // Any other method (save, restore, fillRect, beginPath, clip, ...) is a no-op.
+      return () => {};
+    },
+    set(target, prop, value) {
+      target[prop as string] = value;
+      return true;
+    },
+  });
+  const canvas = {
+    width: 400,
+    height: 400,
+    getContext: () => ctx,
+  } as unknown as HTMLCanvasElement;
+  return { canvas, fills };
+}
+
+function baseOptions(overrides: Partial<LayoutOptions> = {}): LayoutOptions {
+  const legend: LegendEntry[] = [
+    { id: "a", name: "Roads", swatches: [{ color: "#ff0000" }] },
+  ];
+  return {
+    title: "Map",
+    subtitle: "",
+    paperSize: "a4",
+    orientation: "landscape",
+    showTitle: true,
+    showLegend: true,
+    showScaleBar: false,
+    showNorthArrow: false,
+    showFooter: false,
+    footerText: "",
+    legend,
+    legendTitle: "Legend",
+    legendGroupByLayer: true,
+    metersPerPixel: 0,
+    bearingDeg: 0,
+    mapImage: null,
+    mapImageWidth: 0,
+    mapImageHeight: 0,
+    ...overrides,
+  };
+}
+
+describe("drawLayout legend rendering", () => {
+  it("left-aligns legend row labels even when the legend title is empty", () => {
+    // The title block draws centered text first; the legend must reset the
+    // alignment for its rows regardless of whether it draws its own title.
+    const { canvas, fills } = recordingCanvas();
+    drawLayout(canvas, baseOptions({ legendTitle: "" }));
+
+    const label = fills.find((f) => f.text === "Roads");
+    assert.ok(label, "expected the legend row label to be drawn");
+    assert.equal(label.textAlign, "left");
+    assert.equal(label.textBaseline, "alphabetic");
+  });
+
+  it("left-aligns legend rows when a legend title is present", () => {
+    const { canvas, fills } = recordingCanvas();
+    drawLayout(canvas, baseOptions({ legendTitle: "Key" }));
+
+    assert.ok(
+      fills.some((f) => f.text === "Key" && f.textAlign === "left"),
+      "expected the legend title to be drawn left-aligned",
+    );
+    const label = fills.find((f) => f.text === "Roads");
+    assert.ok(label, "expected the legend row label to be drawn");
+    assert.equal(label.textAlign, "left");
+  });
+});

--- a/tests/print-layout.test.ts
+++ b/tests/print-layout.test.ts
@@ -89,6 +89,40 @@ describe("drawLayout legend rendering", () => {
     assert.equal(label.textBaseline, "alphabetic");
   });
 
+  it("renders the swatch label for an entry collapsed to one visible class", () => {
+    // applyLegendConfig yields a single-swatch entry (layer name + the one
+    // un-hidden class label) when the other classes are hidden; the label, not
+    // the layer name, must be drawn.
+    const { canvas, fills } = recordingCanvas();
+    drawLayout(
+      canvas,
+      baseOptions({
+        legend: [
+          { id: "pop", name: "Population", swatches: [{ color: "#00aa00", label: "High" }] },
+        ],
+      }),
+    );
+    assert.ok(
+      fills.some((f) => f.text === "High"),
+      "expected the surviving class label to be drawn",
+    );
+    assert.ok(
+      !fills.some((f) => f.text === "Population"),
+      "expected the layer name not to replace the class label",
+    );
+  });
+
+  it("renders the layer name for a genuine single-symbol entry", () => {
+    const { canvas, fills } = recordingCanvas();
+    drawLayout(
+      canvas,
+      baseOptions({
+        legend: [{ id: "a", name: "Roads", swatches: [{ color: "#ff0000" }] }],
+      }),
+    );
+    assert.ok(fills.some((f) => f.text === "Roads"));
+  });
+
   it("left-aligns legend rows when a legend title is present", () => {
     const { canvas, fills } = recordingCanvas();
     drawLayout(canvas, baseOptions({ legendTitle: "Key" }));

--- a/tests/print-legend.test.ts
+++ b/tests/print-legend.test.ts
@@ -239,6 +239,22 @@ describe("applyLegendConfig", () => {
     assert.equal(allHidden.length, 0);
   });
 
+  it("trims surrounding whitespace from a rendered label", () => {
+    const result = applyLegendConfig(
+      base,
+      config({ overrides: { top: { label: "  Spaced  " } } }),
+    );
+    assert.equal(result[0].name, "Spaced");
+  });
+
+  it("treats a whitespace-only label as no override", () => {
+    const result = applyLegendConfig(
+      base,
+      config({ overrides: { top: { label: "   " } } }),
+    );
+    assert.equal(result[0].name, "Top");
+  });
+
   it("renames a class label", () => {
     const categorized = buildLegend([
       makeLayer({
@@ -295,6 +311,22 @@ describe("legendEditorRows", () => {
     assert.equal(rows[0].label, "Renamed");
     assert.equal(rows[0].defaultLabel, "A");
     assert.equal(rows[0].hidden, true);
+  });
+
+  it("keeps a raw override (with spaces) in the editor but falls back when blank", () => {
+    const base = buildLegend([makeLayer({ id: "a", name: "A" })]);
+    // A non-blank override is shown verbatim so the input can hold spaces.
+    const spaced = legendEditorRows(
+      base,
+      config({ overrides: { a: { label: "My label " } } }),
+    );
+    assert.equal(spaced[0].label, "My label ");
+    // A whitespace-only override is treated as no override (shows the default).
+    const blank = legendEditorRows(
+      base,
+      config({ overrides: { a: { label: "   " } } }),
+    );
+    assert.equal(blank[0].label, "A");
   });
 });
 

--- a/tests/print-legend.test.ts
+++ b/tests/print-legend.test.ts
@@ -1,7 +1,23 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import type { GeoLibreLayer, LayerStyle } from "../packages/core/src/types";
-import { buildLegend } from "../apps/geolibre-desktop/src/lib/print-legend";
+import {
+  DEFAULT_LEGEND_CONFIG,
+  type GeoLibreLayer,
+  type LayerStyle,
+  type LegendConfig,
+} from "../packages/core/src/types";
+import {
+  applyLegendConfig,
+  buildLegend,
+  legendEditorRows,
+  reorderLegendEntry,
+  setLegendItemLabel,
+  toggleLegendItemHidden,
+} from "../apps/geolibre-desktop/src/lib/print-legend";
+
+function config(overrides: Partial<LegendConfig> = {}): LegendConfig {
+  return { ...DEFAULT_LEGEND_CONFIG, order: [], overrides: {}, ...overrides };
+}
 
 function makeLayer(overrides: Partial<GeoLibreLayer>): GeoLibreLayer {
   return {
@@ -144,5 +160,175 @@ describe("buildLegend", () => {
       }),
     ]);
     assert.equal(legend[0].swatches[0].color, "#123456");
+  });
+
+  it("carries the source layer id on each entry", () => {
+    const legend = buildLegend([makeLayer({ id: "abc", name: "A" })]);
+    assert.equal(legend[0].id, "abc");
+  });
+});
+
+describe("applyLegendConfig", () => {
+  const base = buildLegend([
+    makeLayer({ id: "bottom", name: "Bottom" }),
+    makeLayer({ id: "top", name: "Top" }),
+  ]);
+
+  it("returns the auto legend unchanged with the default config", () => {
+    const result = applyLegendConfig(base, config());
+    assert.deepEqual(
+      result.map((e) => e.name),
+      ["Top", "Bottom"],
+    );
+  });
+
+  it("renames an entry via a label override", () => {
+    const result = applyLegendConfig(
+      base,
+      config({ overrides: { top: { label: "Renamed" } } }),
+    );
+    assert.equal(result[0].name, "Renamed");
+  });
+
+  it("hides an entry flagged hidden", () => {
+    const result = applyLegendConfig(
+      base,
+      config({ overrides: { top: { hidden: true } } }),
+    );
+    assert.deepEqual(
+      result.map((e) => e.name),
+      ["Bottom"],
+    );
+  });
+
+  it("reorders entries to follow the order list", () => {
+    const result = applyLegendConfig(base, config({ order: ["bottom", "top"] }));
+    assert.deepEqual(
+      result.map((e) => e.name),
+      ["Bottom", "Top"],
+    );
+  });
+
+  it("hides individual classes and drops an entry with all classes hidden", () => {
+    const graduated = buildLegend([
+      makeLayer({
+        id: "pop",
+        name: "Population",
+        style: {
+          vectorStyleMode: "graduated",
+          vectorStyleStops: [
+            { value: 0, color: "#eef" },
+            { value: 100, color: "#88a" },
+          ],
+        } as LayerStyle,
+      }),
+    ]);
+    const oneHidden = applyLegendConfig(
+      graduated,
+      config({ overrides: { "pop::0": { hidden: true } } }),
+    );
+    assert.equal(oneHidden[0].swatches.length, 1);
+    assert.equal(oneHidden[0].swatches[0].color, "#88a");
+
+    const allHidden = applyLegendConfig(
+      graduated,
+      config({
+        overrides: { "pop::0": { hidden: true }, "pop::1": { hidden: true } },
+      }),
+    );
+    assert.equal(allHidden.length, 0);
+  });
+
+  it("renames a class label", () => {
+    const categorized = buildLegend([
+      makeLayer({
+        id: "pop",
+        name: "Population",
+        style: {
+          vectorStyleMode: "categorized",
+          vectorStyleStops: [
+            { value: "A", color: "#eef" },
+            { value: "B", color: "#88a" },
+          ],
+        } as LayerStyle,
+      }),
+    ]);
+    const result = applyLegendConfig(
+      categorized,
+      config({ overrides: { "pop::0": { label: "Class A" } } }),
+    );
+    assert.equal(result[0].swatches[0].label, "Class A");
+    assert.equal(result[0].swatches[1].label, "B");
+  });
+});
+
+describe("legendEditorRows", () => {
+  it("flattens a graduated layer into an entry plus class rows", () => {
+    const base = buildLegend([
+      makeLayer({
+        id: "pop",
+        name: "Population",
+        style: {
+          vectorStyleMode: "graduated",
+          vectorStyleStops: [
+            { value: 0, color: "#eef" },
+            { value: 100, color: "#88a" },
+          ],
+        } as LayerStyle,
+      }),
+    ]);
+    const rows = legendEditorRows(base, config());
+    assert.equal(rows.length, 3);
+    assert.equal(rows[0].kind, "entry");
+    assert.equal(rows[0].reorderable, true);
+    assert.equal(rows[1].kind, "class");
+    assert.equal(rows[1].reorderable, false);
+    assert.equal(rows[1].key, "pop::0");
+  });
+
+  it("reflects overrides and keeps hidden rows visible in the editor", () => {
+    const base = buildLegend([makeLayer({ id: "a", name: "A" })]);
+    const rows = legendEditorRows(
+      base,
+      config({ overrides: { a: { label: "Renamed", hidden: true } } }),
+    );
+    assert.equal(rows[0].label, "Renamed");
+    assert.equal(rows[0].defaultLabel, "A");
+    assert.equal(rows[0].hidden, true);
+  });
+});
+
+describe("legend config mutations", () => {
+  it("sets a label and clears it when blank or equal to the default", () => {
+    const set = setLegendItemLabel(config(), "a", "Custom", "A");
+    assert.equal(set.overrides.a.label, "Custom");
+    const cleared = setLegendItemLabel(set, "a", "  ", "A");
+    assert.equal(cleared.overrides.a, undefined);
+    const sameAsDefault = setLegendItemLabel(config(), "a", "A", "A");
+    assert.equal(sameAsDefault.overrides.a, undefined);
+  });
+
+  it("preserves a hidden flag when the label is cleared", () => {
+    const hidden = toggleLegendItemHidden(config(), "a");
+    const cleared = setLegendItemLabel(hidden, "a", "", "A");
+    assert.equal(cleared.overrides.a.hidden, true);
+    assert.equal(cleared.overrides.a.label, undefined);
+  });
+
+  it("toggles the hidden flag and prunes when toggled back off", () => {
+    const on = toggleLegendItemHidden(config(), "a");
+    assert.equal(on.overrides.a.hidden, true);
+    const off = toggleLegendItemHidden(on, "a");
+    assert.equal(off.overrides.a, undefined);
+  });
+
+  it("reorders an entry and writes the full order list", () => {
+    const moved = reorderLegendEntry(config(), ["top", "bottom"], "bottom", "up");
+    assert.deepEqual(moved.order, ["bottom", "top"]);
+  });
+
+  it("ignores a move past the ends", () => {
+    const unchanged = reorderLegendEntry(config(), ["top", "bottom"], "top", "up");
+    assert.deepEqual(unchanged.order, []);
   });
 });


### PR DESCRIPTION
Closes #303.

## Summary

Adds a **user-editable legend** to the Print Layout composer. The legend is still always derived from each visible layer's symbology (single / categorized / graduated); this change lets the user customize what gets drawn and persists those edits in the project.

You can now:
- **Edit the legend title** (defaults to "Legend").
- **Rename** any entry or class label.
- **Hide** entries/classes (eye toggle).
- **Reorder** top-level entries (up/down).
- **Group classes by layer** toggle.
- **Reset** all customizations.

The edited legend is included in the PNG/PDF export and the live preview, and is saved in `.geolibre.json` so it survives save/reload.

## How it works

Customizations are stored as a small `LegendConfig` (title, `groupByLayer`, `order`, and per-item `label`/`hidden` overrides keyed by layer id or `${layerId}::${index}`). At render time `applyLegendConfig` layers the config over the auto-generated legend, so edits **survive layer additions/removals** — a removed layer just drops out, a new layer appears with defaults.

## Changes

- **`@geolibre/core`**: `LegendConfig` / `LegendItemOverride` types + `DEFAULT_LEGEND_CONFIG`; `legend?` field on `GeoLibreProject`; store state + `setLegend`; serialize/parse/normalize (defensive against hand-edited configs).
- **Legend lib**: `buildLegend` now carries the layer `id`; new `applyLegendConfig`, `legendEditorRows`, and config mutators (`setLegendItemLabel`, `toggleLegendItemHidden`, `reorderLegendEntry`). `drawLayout` accepts the legend title + group-by-layer flag.
- **`PrintLayoutDialog`**: legend editor panel wired to the store.
- **Docs**: `docs/project-format.md` documents the new `legend` object.

## Testing

- `npm run test:frontend` — 520 pass (added 20 tests across `print-legend.test.ts` and `core-project.test.ts` covering merge/order/hide/rename, editor rows, config mutators, and project round-trip/normalization).
- `npm run typecheck` (full `tsc -b && vite build`) — passes.
- `pre-commit run --files <changed>` — passes (eslint + npm build).

Visual verification in the running app was not performed; happy to drive it with Playwright if you'd like.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full legend editor in print/preview: title, reset, group-by-layer, reorder, per-entry label/visibility, empty-state. Legend title and grouping now affect preview and exported layouts.

* **Documentation**
  * Project format docs updated to describe optional persisted legend JSON and behavior.

* **Tests**
  * Added tests for legend building, parsing, persistence round-trips, editor rows, overrides, rendering, and reordering.

* **Chores**
  * App state/types updated to store/init legend; project save/embed include legend; i18n keys added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->