### PR TITLE
feat(raster): single-band pseudocolor + classification and RGB band combination (#305)

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
+++ b/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
@@ -291,6 +291,13 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
             }
           }}
         >
+          {/* A raster may arrive with any upstream colormap name (e.g. the
+              control's "gray"/"palette" default); surface it so the select
+              reflects what is actually rendered instead of silently showing
+              the first ramp. */}
+          {!VECTOR_COLOR_RAMPS.some((r) => r.value === ramp) && (
+            <option value={ramp}>{ramp}</option>
+          )}
           {VECTOR_COLOR_RAMPS.map((colorRamp) => (
             <option key={colorRamp.value} value={colorRamp.value}>
               {colorRamp.label}

--- a/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
+++ b/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
@@ -306,7 +306,7 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
         </Select>
         <div
           aria-hidden="true"
-          className="h-2 rounded-sm border"
+          className="h-4 rounded-sm border"
           style={{
             background: `linear-gradient(90deg, ${previewColors.join(", ")})`,
           }}

--- a/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
+++ b/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
@@ -15,7 +15,7 @@ import {
   savedRasterSymbology,
 } from "@geolibre/plugins";
 import { Input, Label, Select, Separator } from "@geolibre/ui";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 type RasterStateRecord = {
   mode: "single" | "rgb";
@@ -117,11 +117,15 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
   const band = state.bands[0] ?? 1;
 
   const [stats, setStats] = useState<RasterBandStats | null>(null);
+  const lastStatsRef = useRef<RasterBandStats | null>(null);
 
   // Fetch band statistics lazily once the user is classifying (equal-interval
   // and quantile both need a data range / histogram). Aborts implicitly via
-  // the cache + the manager's per-layer AbortController.
+  // the cache + the manager's per-layer AbortController. Stats are cleared
+  // first so a band/method switch shows "Computing data range…" rather than
+  // the previous band's values.
   useEffect(() => {
+    setStats(null);
     let cancelled = false;
     if (!symbology?.classified || symbology.method === "manual") return;
     void getRasterBandStats(layer.id, band).then((result) => {
@@ -131,6 +135,20 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
       cancelled = true;
     };
   }, [layer.id, band, symbology?.classified, symbology?.method]);
+
+  // Classification can be enabled before stats arrive, in which case the
+  // breaks fall back to the [0, …, 1] default range. Once real stats land,
+  // replace that fallback with data-range breaks so the user sees them
+  // without any extra interaction.
+  useEffect(() => {
+    if (!stats || stats === lastStatsRef.current) return;
+    lastStatsRef.current = stats;
+    if (!symbology?.classified || symbology.method === "manual") return;
+    const isDefaultRange =
+      symbology.breaks[0] === 0 && symbology.breaks.at(-1) === 1;
+    if (isDefaultRange) recomputeSymbology({ ...symbology });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [stats]);
 
   const bandOptions = useMemo(() => {
     if (!bandCount) return [];
@@ -161,6 +179,9 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
     next: Pick<RasterSymbology, "ramp" | "reversed" | "method" | "classCount">,
     overrides: { range?: [number, number]; manualBreaks?: number[] } = {},
   ): void {
+    // Reusing the prior histogram here is safe: a range override only happens
+    // for equal-interval (the Min/Max inputs are disabled for quantile), and
+    // equal-interval breaks use only min/max — never the histogram.
     const effectiveStats: RasterBandStats | null = overrides.range
       ? { min: overrides.range[0], max: overrides.range[1], histogram: stats?.histogram ?? [] }
       : stats;
@@ -543,6 +564,9 @@ function RescaleControls({
   onChange: (rescale: [number, number][] | null) => void;
 }) {
   const range = rescale?.[0];
+  // The rescale data model is all-or-nothing ([min, max] or null = auto), so
+  // clearing either bound drops back to auto-stretch on both — a single bound
+  // can't be pinned independently.
   return (
     <div className="grid grid-cols-2 gap-3">
       <NumberField
@@ -630,12 +654,20 @@ function NumberField({
   placeholder?: string;
   onCommit: (value: number, empty: boolean) => void;
 }) {
-  // Local draft so the user can clear / retype without the value snapping back
-  // mid-edit; committed on change when it parses to a finite number.
+  // Local draft so the user can clear / retype freely; committed on blur (one
+  // store write / setRasterState per edit, instead of one per keystroke).
   const [draft, setDraft] = useState<string>(value === "" ? "" : String(value));
   useEffect(() => {
     setDraft(value === "" ? "" : String(value));
   }, [value]);
+  const commitDraft = () => {
+    if (draft.trim() === "") {
+      onCommit(0, true);
+      return;
+    }
+    const parsed = Number(draft);
+    if (Number.isFinite(parsed)) onCommit(parsed, false);
+  };
   return (
     <div className="space-y-2">
       <Label className="text-xs">{label}</Label>
@@ -647,15 +679,10 @@ function NumberField({
         disabled={disabled}
         placeholder={placeholder}
         value={draft}
-        onChange={(event) => {
-          const next = event.target.value;
-          setDraft(next);
-          if (next.trim() === "") {
-            onCommit(0, true);
-            return;
-          }
-          const parsed = Number(next);
-          if (Number.isFinite(parsed)) onCommit(parsed, false);
+        onChange={(event) => setDraft(event.target.value)}
+        onBlur={commitDraft}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") event.currentTarget.blur();
         }}
       />
     </div>

--- a/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
+++ b/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
@@ -1,0 +1,663 @@
+import {
+  type GeoLibreLayer,
+  VECTOR_COLOR_RAMPS,
+  getVectorColorRamp,
+  useAppStore,
+} from "@geolibre/core";
+import {
+  RASTER_MAX_CLASSES,
+  RASTER_MIN_CLASSES,
+  type RasterBandStats,
+  type RasterClassificationMethod,
+  type RasterSymbology,
+  computeRasterBreaks,
+  getRasterBandStats,
+  savedRasterSymbology,
+} from "@geolibre/plugins";
+import { Input, Label, Select, Separator } from "@geolibre/ui";
+import { useEffect, useMemo, useState } from "react";
+
+type RasterStateRecord = {
+  mode: "single" | "rgb";
+  bands: number[];
+  colormap: string;
+  rescale: [number, number][] | null;
+  nodata: number | "auto" | "off";
+  stretch: "linear" | "log" | "sqrt";
+  gamma: number;
+};
+
+const CLASSIFICATION_METHODS: {
+  value: RasterClassificationMethod;
+  label: string;
+}[] = [
+  { value: "equal-interval", label: "Equal interval" },
+  { value: "quantile", label: "Quantile" },
+  { value: "manual", label: "Manual breaks" },
+];
+
+const DEFAULT_RAMP = "viridis";
+const DEFAULT_CLASS_COUNT = 5;
+
+function readRasterState(layer: GeoLibreLayer): RasterStateRecord {
+  const raw =
+    layer.metadata.rasterState &&
+    typeof layer.metadata.rasterState === "object" &&
+    !Array.isArray(layer.metadata.rasterState)
+      ? (layer.metadata.rasterState as Record<string, unknown>)
+      : {};
+  const bands = Array.isArray(raw.bands)
+    ? (raw.bands.filter((b) => typeof b === "number") as number[])
+    : [1];
+  const rescale =
+    Array.isArray(raw.rescale) &&
+    raw.rescale.every(
+      (range) => Array.isArray(range) && range.length === 2,
+    )
+      ? (raw.rescale as [number, number][])
+      : null;
+  return {
+    mode: raw.mode === "rgb" ? "rgb" : "single",
+    bands: bands.length > 0 ? bands : [1],
+    colormap: typeof raw.colormap === "string" ? raw.colormap : DEFAULT_RAMP,
+    rescale,
+    nodata:
+      raw.nodata === "off" || typeof raw.nodata === "number"
+        ? (raw.nodata as number | "off")
+        : "auto",
+    stretch:
+      raw.stretch === "log" || raw.stretch === "sqrt"
+        ? raw.stretch
+        : "linear",
+    gamma: typeof raw.gamma === "number" && raw.gamma > 0 ? raw.gamma : 1,
+  };
+}
+
+function readBandCount(layer: GeoLibreLayer): number | null {
+  const value = layer.metadata.bandCount;
+  return typeof value === "number" && value > 0 ? value : null;
+}
+
+function readBandNames(layer: GeoLibreLayer): Map<number, string> {
+  const raw = layer.metadata.bandNames;
+  const map = new Map<number, string>();
+  if (Array.isArray(raw)) {
+    for (const pair of raw) {
+      if (
+        Array.isArray(pair) &&
+        typeof pair[0] === "number" &&
+        typeof pair[1] === "string"
+      ) {
+        map.set(pair[0], pair[1]);
+      }
+    }
+  }
+  return map;
+}
+
+function rangeFromBreaks(breaks: number[]): [number, number][] {
+  return [[breaks[0], breaks[breaks.length - 1]]];
+}
+
+/**
+ * Single-band pseudocolor (with optional discrete classification) and RGB
+ * band-combination controls for a maplibre-gl-raster COG layer. Edits the
+ * layer's `metadata.rasterState` (pushed to the control by the store sync) and
+ * GeoLibre-owned `metadata.rasterSymbology` (consumed by the classification
+ * render injection).
+ *
+ * @param props.layer - The selected raster store layer.
+ */
+export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
+  const updateLayer = useAppStore((s) => s.updateLayer);
+  const state = readRasterState(layer);
+  const bandCount = readBandCount(layer);
+  const bandNames = readBandNames(layer);
+  const symbology = savedRasterSymbology(layer);
+  const band = state.bands[0] ?? 1;
+
+  const [stats, setStats] = useState<RasterBandStats | null>(null);
+
+  // Fetch band statistics lazily once the user is classifying (equal-interval
+  // and quantile both need a data range / histogram). Aborts implicitly via
+  // the cache + the manager's per-layer AbortController.
+  useEffect(() => {
+    let cancelled = false;
+    if (!symbology?.classified || symbology.method === "manual") return;
+    void getRasterBandStats(layer.id, band).then((result) => {
+      if (!cancelled && result) setStats(result);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [layer.id, band, symbology?.classified, symbology?.method]);
+
+  const bandOptions = useMemo(() => {
+    if (!bandCount) return [];
+    return Array.from({ length: bandCount }, (_, index) => {
+      const value = index + 1;
+      const name = bandNames.get(value);
+      return { value, label: name ? `${value}: ${name}` : `Band ${value}` };
+    });
+  }, [bandCount, bandNames]);
+
+  function commit(options: {
+    statePatch?: Partial<RasterStateRecord>;
+    symbology?: RasterSymbology | null;
+  }): void {
+    const metadata: Record<string, unknown> = { ...layer.metadata };
+    if (options.statePatch) {
+      metadata.rasterState = { ...state, ...options.statePatch };
+    }
+    if (options.symbology === null) {
+      delete metadata.rasterSymbology;
+    } else if (options.symbology) {
+      metadata.rasterSymbology = options.symbology;
+    }
+    updateLayer(layer.id, { metadata });
+  }
+
+  function recomputeSymbology(
+    next: Pick<RasterSymbology, "ramp" | "reversed" | "method" | "classCount">,
+    overrides: { range?: [number, number]; manualBreaks?: number[] } = {},
+  ): void {
+    const effectiveStats: RasterBandStats | null = overrides.range
+      ? { min: overrides.range[0], max: overrides.range[1], histogram: stats?.histogram ?? [] }
+      : stats;
+    const breaks = computeRasterBreaks(
+      next.method,
+      effectiveStats,
+      next.classCount,
+      overrides.manualBreaks ?? symbology?.breaks,
+    );
+    commit({
+      statePatch: { colormap: next.ramp, rescale: rangeFromBreaks(breaks) },
+      symbology: { classified: true, ...next, breaks },
+    });
+  }
+
+  // --- Mode ---
+  const modeControl = (
+    <div className="space-y-2">
+      <Label htmlFor="rasterMode">Render mode</Label>
+      <Select
+        id="rasterMode"
+        value={state.mode}
+        disabled={bandCount === null}
+        onChange={(event) => {
+          const mode = event.target.value as "single" | "rgb";
+          if (mode === "rgb") {
+            const bands =
+              state.bands.length >= 3 ? state.bands.slice(0, 3) : [1, 2, 3];
+            commit({ statePatch: { mode, bands }, symbology: null });
+          } else {
+            commit({ statePatch: { mode } });
+          }
+        }}
+      >
+        <option value="single">Single band (pseudocolor)</option>
+        {(bandCount === null || bandCount >= 3) && (
+          <option value="rgb">RGB composite</option>
+        )}
+      </Select>
+      {bandCount === null && (
+        <p className="text-[10px] text-muted-foreground">Loading bands…</p>
+      )}
+    </div>
+  );
+
+  if (state.mode === "rgb") {
+    return (
+      <div className="space-y-3">
+        <Separator />
+        <p className="text-xs font-semibold">Raster symbology</p>
+        {modeControl}
+        <RgbControls
+          state={state}
+          bandOptions={bandOptions}
+          onChange={(patch) => commit({ statePatch: patch })}
+        />
+        <NodataControl state={state} onChange={(nodata) => commit({ statePatch: { nodata } })} />
+      </div>
+    );
+  }
+
+  const ramp = symbology?.ramp ?? state.colormap ?? DEFAULT_RAMP;
+  const classified = symbology?.classified ?? false;
+  const classCount = symbology?.classCount ?? DEFAULT_CLASS_COUNT;
+  const method = symbology?.method ?? "equal-interval";
+  const previewColors = getVectorColorRamp(ramp).colors;
+
+  return (
+    <div className="space-y-3">
+      <Separator />
+      <p className="text-xs font-semibold">Raster symbology</p>
+      {modeControl}
+
+      <div className="space-y-2">
+        <Label htmlFor="rasterBand">Band</Label>
+        <Select
+          id="rasterBand"
+          value={String(band)}
+          disabled={bandOptions.length === 0}
+          onChange={(event) =>
+            commit({ statePatch: { bands: [Number(event.target.value)] } })
+          }
+        >
+          {bandOptions.length === 0 ? (
+            <option value={String(band)}>{`Band ${band}`}</option>
+          ) : (
+            bandOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))
+          )}
+        </Select>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="rasterRamp">Color ramp</Label>
+        <Select
+          id="rasterRamp"
+          value={ramp}
+          onChange={(event) => {
+            const value = event.target.value;
+            if (classified && symbology) {
+              recomputeSymbology({ ...symbology, ramp: value });
+            } else {
+              commit({ statePatch: { colormap: value } });
+            }
+          }}
+        >
+          {VECTOR_COLOR_RAMPS.map((colorRamp) => (
+            <option key={colorRamp.value} value={colorRamp.value}>
+              {colorRamp.label}
+            </option>
+          ))}
+        </Select>
+        <div
+          aria-hidden="true"
+          className="h-2 rounded-sm border"
+          style={{
+            background: `linear-gradient(90deg, ${previewColors.join(", ")})`,
+          }}
+        />
+      </div>
+
+      <label className="flex items-center gap-2 text-xs">
+        <input
+          type="checkbox"
+          checked={classified}
+          onChange={(event) => {
+            if (event.target.checked) {
+              recomputeSymbology({
+                ramp,
+                reversed: symbology?.reversed ?? false,
+                method,
+                classCount,
+              });
+            } else {
+              commit({ symbology: null });
+            }
+          }}
+        />
+        Classify into discrete classes
+      </label>
+
+      {classified && symbology && (
+        <ClassificationControls
+          symbology={symbology}
+          stats={stats}
+          onMethod={(nextMethod) =>
+            recomputeSymbology({ ...symbology, method: nextMethod })
+          }
+          onClassCount={(count) =>
+            recomputeSymbology({ ...symbology, classCount: count })
+          }
+          onReversed={(reversed) =>
+            commit({ symbology: { ...symbology, reversed } })
+          }
+          onManualBreaks={(breaks) =>
+            commit({
+              statePatch: { rescale: rangeFromBreaks(breaks) },
+              symbology: { ...symbology, breaks },
+            })
+          }
+          onRange={(range) => recomputeSymbology({ ...symbology }, { range })}
+        />
+      )}
+
+      {!classified && (
+        <RescaleControls
+          rescale={state.rescale}
+          onChange={(rescale) => commit({ statePatch: { rescale } })}
+        />
+      )}
+
+      {!classified && (
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-2">
+            <Label htmlFor="rasterStretch">Stretch</Label>
+            <Select
+              id="rasterStretch"
+              value={state.stretch}
+              onChange={(event) =>
+                commit({
+                  statePatch: {
+                    stretch: event.target.value as "linear" | "log" | "sqrt",
+                  },
+                })
+              }
+            >
+              <option value="linear">Linear</option>
+              <option value="log">Logarithmic</option>
+              <option value="sqrt">Square root</option>
+            </Select>
+          </div>
+          <NumberField
+            label="Gamma"
+            value={state.gamma}
+            step={0.1}
+            min={0.1}
+            onCommit={(value) =>
+              commit({ statePatch: { gamma: value > 0 ? value : 1 } })
+            }
+          />
+        </div>
+      )}
+
+      <NodataControl
+        state={state}
+        onChange={(nodata) => commit({ statePatch: { nodata } })}
+      />
+    </div>
+  );
+}
+
+function RgbControls({
+  state,
+  bandOptions,
+  onChange,
+}: {
+  state: RasterStateRecord;
+  bandOptions: { value: number; label: string }[];
+  onChange: (patch: Partial<RasterStateRecord>) => void;
+}) {
+  const bands = state.bands.length >= 3 ? state.bands : [1, 2, 3];
+  const channels: { key: "R" | "G" | "B"; index: number }[] = [
+    { key: "R", index: 0 },
+    { key: "G", index: 1 },
+    { key: "B", index: 2 },
+  ];
+  return (
+    <div className="space-y-2">
+      {channels.map(({ key, index }) => (
+        <div key={key} className="grid grid-cols-[1.5rem_1fr] items-center gap-2">
+          <Label className="text-xs">{key}</Label>
+          <Select
+            value={String(bands[index] ?? index + 1)}
+            disabled={bandOptions.length === 0}
+            onChange={(event) => {
+              const next = [...bands];
+              next[index] = Number(event.target.value);
+              onChange({ bands: next });
+            }}
+          >
+            {bandOptions.length === 0 ? (
+              <option value={String(bands[index] ?? index + 1)}>
+                {`Band ${bands[index] ?? index + 1}`}
+              </option>
+            ) : (
+              bandOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))
+            )}
+          </Select>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ClassificationControls({
+  symbology,
+  stats,
+  onMethod,
+  onClassCount,
+  onReversed,
+  onManualBreaks,
+  onRange,
+}: {
+  symbology: RasterSymbology;
+  stats: RasterBandStats | null;
+  onMethod: (method: RasterClassificationMethod) => void;
+  onClassCount: (count: number) => void;
+  onReversed: (reversed: boolean) => void;
+  onManualBreaks: (breaks: number[]) => void;
+  onRange: (range: [number, number]) => void;
+}) {
+  const min = symbology.breaks[0];
+  const max = symbology.breaks[symbology.breaks.length - 1];
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-2">
+          <Label htmlFor="rasterMethod">Method</Label>
+          <Select
+            id="rasterMethod"
+            value={symbology.method}
+            onChange={(event) =>
+              onMethod(event.target.value as RasterClassificationMethod)
+            }
+          >
+            {CLASSIFICATION_METHODS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </Select>
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="rasterClasses">Classes</Label>
+          <Select
+            id="rasterClasses"
+            value={String(symbology.classCount)}
+            onChange={(event) => onClassCount(Number(event.target.value))}
+          >
+            {Array.from(
+              { length: RASTER_MAX_CLASSES - RASTER_MIN_CLASSES + 1 },
+              (_, index) => RASTER_MIN_CLASSES + index,
+            ).map((count) => (
+              <option key={count} value={count}>
+                {count}
+              </option>
+            ))}
+          </Select>
+        </div>
+      </div>
+
+      {symbology.method !== "manual" && (
+        <div className="grid grid-cols-2 gap-3">
+          <NumberField
+            label="Min"
+            value={min}
+            step={Number.isFinite(max - min) ? (max - min) / 100 || 0.1 : 0.1}
+            disabled={symbology.method === "quantile"}
+            onCommit={(value) => onRange([value, max])}
+          />
+          <NumberField
+            label="Max"
+            value={max}
+            step={Number.isFinite(max - min) ? (max - min) / 100 || 0.1 : 0.1}
+            disabled={symbology.method === "quantile"}
+            onCommit={(value) => onRange([min, value])}
+          />
+        </div>
+      )}
+
+      {symbology.method === "manual" && (
+        <div className="space-y-2">
+          <Label className="text-xs">Class edges</Label>
+          {symbology.breaks.map((edge, index) => (
+            <NumberField
+              key={index}
+              label={`Edge ${index + 1}`}
+              value={edge}
+              step={0.1}
+              onCommit={(value) => {
+                const next = [...symbology.breaks];
+                next[index] = value;
+                onManualBreaks(next);
+              }}
+            />
+          ))}
+        </div>
+      )}
+
+      <label className="flex items-center gap-2 text-xs">
+        <input
+          type="checkbox"
+          checked={symbology.reversed}
+          onChange={(event) => onReversed(event.target.checked)}
+        />
+        Reverse ramp
+      </label>
+
+      {symbology.method !== "manual" && !stats && (
+        <p className="text-[10px] text-muted-foreground">
+          Computing data range…
+        </p>
+      )}
+    </div>
+  );
+}
+
+function RescaleControls({
+  rescale,
+  onChange,
+}: {
+  rescale: [number, number][] | null;
+  onChange: (rescale: [number, number][] | null) => void;
+}) {
+  const range = rescale?.[0];
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      <NumberField
+        label="Min"
+        value={range?.[0] ?? ""}
+        placeholder="auto"
+        step={0.1}
+        onCommit={(value, empty) => {
+          if (empty) return onChange(null);
+          onChange([[value, range?.[1] ?? value]]);
+        }}
+      />
+      <NumberField
+        label="Max"
+        value={range?.[1] ?? ""}
+        placeholder="auto"
+        step={0.1}
+        onCommit={(value, empty) => {
+          if (empty) return onChange(null);
+          onChange([[range?.[0] ?? value, value]]);
+        }}
+      />
+    </div>
+  );
+}
+
+function NodataControl({
+  state,
+  onChange,
+}: {
+  state: RasterStateRecord;
+  onChange: (nodata: number | "auto" | "off") => void;
+}) {
+  const mode =
+    state.nodata === "off"
+      ? "off"
+      : typeof state.nodata === "number"
+        ? "custom"
+        : "auto";
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      <div className="space-y-2">
+        <Label htmlFor="rasterNodata">No data</Label>
+        <Select
+          id="rasterNodata"
+          value={mode}
+          onChange={(event) => {
+            const value = event.target.value;
+            if (value === "off") onChange("off");
+            else if (value === "custom") onChange(0);
+            else onChange("auto");
+          }}
+        >
+          <option value="auto">Auto (from file)</option>
+          <option value="off">Render all pixels</option>
+          <option value="custom">Custom value</option>
+        </Select>
+      </div>
+      {mode === "custom" && (
+        <NumberField
+          label="Value"
+          value={typeof state.nodata === "number" ? state.nodata : 0}
+          step={1}
+          onCommit={(value) => onChange(value)}
+        />
+      )}
+    </div>
+  );
+}
+
+function NumberField({
+  label,
+  value,
+  step,
+  min,
+  disabled,
+  placeholder,
+  onCommit,
+}: {
+  label: string;
+  value: number | "";
+  step: number;
+  min?: number;
+  disabled?: boolean;
+  placeholder?: string;
+  onCommit: (value: number, empty: boolean) => void;
+}) {
+  // Local draft so the user can clear / retype without the value snapping back
+  // mid-edit; committed on change when it parses to a finite number.
+  const [draft, setDraft] = useState<string>(value === "" ? "" : String(value));
+  useEffect(() => {
+    setDraft(value === "" ? "" : String(value));
+  }, [value]);
+  return (
+    <div className="space-y-2">
+      <Label className="text-xs">{label}</Label>
+      <Input
+        type="number"
+        inputMode="decimal"
+        step={step}
+        min={min}
+        disabled={disabled}
+        placeholder={placeholder}
+        value={draft}
+        onChange={(event) => {
+          const next = event.target.value;
+          setDraft(next);
+          if (next.trim() === "") {
+            onCommit(0, true);
+            return;
+          }
+          const parsed = Number(next);
+          if (Number.isFinite(parsed)) onCommit(parsed, false);
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
+++ b/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
@@ -136,17 +136,22 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
     };
   }, [layer.id, band, symbology?.classified, symbology?.method]);
 
-  // Classification can be enabled before stats arrive, in which case the
-  // breaks fall back to the [0, …, 1] default range. Once real stats land,
-  // replace that fallback with data-range breaks so the user sees them
-  // without any extra interaction.
+  // Classification can be enabled before stats arrive (breaks fall back to the
+  // [0, …, 1] default range), and switching bands while classified leaves the
+  // previous band's edges in place. When fresh stats land, recompute the breaks
+  // if they're the placeholder range or no longer cover the band's data, so the
+  // classification follows the band without extra interaction. A range the user
+  // narrowed by hand (same band, so stats is unchanged) never reaches here.
   useEffect(() => {
     if (!stats || stats === lastStatsRef.current) return;
     lastStatsRef.current = stats;
     if (!symbology?.classified || symbology.method === "manual") return;
     const isDefaultRange =
       symbology.breaks[0] === 0 && symbology.breaks.at(-1) === 1;
-    if (isDefaultRange) recomputeSymbology({ ...symbology });
+    const coversData =
+      stats.min >= symbology.breaks[0] &&
+      stats.max <= symbology.breaks[symbology.breaks.length - 1];
+    if (isDefaultRange || !coversData) recomputeSymbology({ ...symbology });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [stats]);
 
@@ -346,12 +351,15 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
           onReversed={(reversed) =>
             commit({ symbology: { ...symbology, reversed } })
           }
-          onManualBreaks={(breaks) =>
+          onManualBreaks={(breaks) => {
+            // Keep edges ascending: savedRasterSymbology rejects unsorted
+            // breaks, which would silently collapse the classification UI.
+            const sorted = [...breaks].sort((a, b) => a - b);
             commit({
-              statePatch: { rescale: rangeFromBreaks(breaks) },
-              symbology: { ...symbology, breaks },
-            })
-          }
+              statePatch: { rescale: rangeFromBreaks(sorted) },
+              symbology: { ...symbology, breaks: sorted },
+            });
+          }}
           onRange={(range) => recomputeSymbology({ ...symbology }, { range })}
         />
       )}

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -2,8 +2,13 @@ import {
   DEFAULT_LAYER_STYLE,
   type LayerType,
   type PointRenderer,
+  VECTOR_COLOR_RAMPS,
   type VectorStyleMode,
   type VectorStyleStop,
+  createEqualIntervalBreaks,
+  createQuantileBreaks,
+  getVectorColorRamp,
+  interpolateRampColors,
   styleValue,
   useAppStore,
 } from "@geolibre/core";
@@ -16,7 +21,9 @@ import {
   Separator,
   Slider,
 } from "@geolibre/ui";
+import { RASTER_SOURCE_KIND } from "@geolibre/plugins";
 import type { MapController } from "@geolibre/map";
+import { RasterSymbologySection } from "./RasterSymbologySection";
 import {
   ChevronDown,
   ChevronUp,
@@ -233,59 +240,6 @@ const VECTOR_STYLE_CLASS_COUNTS = Array.from({ length: 12 }, (_, index) =>
   index + 1,
 );
 
-const VECTOR_COLOR_RAMPS = [
-  {
-    value: "viridis",
-    label: "Viridis",
-    colors: ["#440154", "#31688e", "#35b779", "#fde725"],
-  },
-  {
-    value: "plasma",
-    label: "Plasma",
-    colors: ["#0d0887", "#9c179e", "#ed7953", "#f0f921"],
-  },
-  {
-    value: "inferno",
-    label: "Inferno",
-    colors: ["#000004", "#781c6d", "#ed6925", "#fcffa4"],
-  },
-  {
-    value: "magma",
-    label: "Magma",
-    colors: ["#000004", "#721f81", "#f1605d", "#fcfdbf"],
-  },
-  {
-    value: "cividis",
-    label: "Cividis",
-    colors: ["#00204d", "#575d6d", "#a59c74", "#ffea46"],
-  },
-  {
-    value: "turbo",
-    label: "Turbo",
-    colors: ["#30123b", "#4777ef", "#1ccfd0", "#b9e642", "#fb8022", "#7a0403"],
-  },
-  {
-    value: "spectral",
-    label: "Spectral",
-    colors: ["#9e0142", "#f46d43", "#ffffbf", "#66c2a5", "#5e4fa2"],
-  },
-  {
-    value: "blues",
-    label: "Blues",
-    colors: ["#eff6ff", "#93c5fd", "#2563eb", "#1e3a8a"],
-  },
-  {
-    value: "greens",
-    label: "Greens",
-    colors: ["#f0fdf4", "#86efac", "#16a34a", "#14532d"],
-  },
-  {
-    value: "oranges",
-    label: "Oranges",
-    colors: ["#fff7ed", "#fdba74", "#f97316", "#7c2d12"],
-  },
-] as const;
-
 const GRADUATED_CLASSIFICATION_SCHEMES = [
   { value: "equal-interval", label: "Equal interval" },
   { value: "quantile", label: "Quantile" },
@@ -435,75 +389,6 @@ function normalizeClassificationScheme(
   return options.some((option) => option.value === scheme)
     ? scheme
     : defaultClassificationScheme(mode);
-}
-
-function getVectorColorRamp(value: string) {
-  return (
-    VECTOR_COLOR_RAMPS.find((colorRamp) => colorRamp.value === value) ??
-    VECTOR_COLOR_RAMPS[0]
-  );
-}
-
-function interpolateRampColors(colorRamp: string, count: number): string[] {
-  const colors = getVectorColorRamp(colorRamp).colors;
-  if (count <= 1) return [colors[colors.length - 1]];
-  return Array.from({ length: count }, (_, index) => {
-    const scaled = (index / (count - 1)) * (colors.length - 1);
-    const lowerIndex = Math.floor(scaled);
-    const upperIndex = Math.min(colors.length - 1, Math.ceil(scaled));
-    const ratio = scaled - lowerIndex;
-    return interpolateHexColor(colors[lowerIndex], colors[upperIndex], ratio);
-  });
-}
-
-function interpolateHexColor(from: string, to: string, ratio: number): string {
-  const start = parseHexColor(from);
-  const end = parseHexColor(to);
-  return rgbToHex({
-    r: Math.round(start.r + (end.r - start.r) * ratio),
-    g: Math.round(start.g + (end.g - start.g) * ratio),
-    b: Math.round(start.b + (end.b - start.b) * ratio),
-  });
-}
-
-function parseHexColor(value: string): { b: number; g: number; r: number } {
-  const numeric = Number.parseInt(value.slice(1), 16);
-  return {
-    r: (numeric >> 16) & 255,
-    g: (numeric >> 8) & 255,
-    b: numeric & 255,
-  };
-}
-
-function rgbToHex(color: { b: number; g: number; r: number }): string {
-  return `#${[color.r, color.g, color.b]
-    .map((channel) => channel.toString(16).padStart(2, "0"))
-    .join("")}`;
-}
-
-function createEqualIntervalBreaks(
-  min: number,
-  max: number,
-  count: number,
-): number[] {
-  return Array.from({ length: count }, (_, index) => {
-    const ratio = count === 1 ? 0 : index / (count - 1);
-    return min + (max - min) * ratio;
-  });
-}
-
-function createQuantileBreaks(values: number[], count: number): number[] {
-  const sorted = [...values].sort((a, b) => a - b);
-  return Array.from({ length: count }, (_, index) => {
-    const position =
-      count === 1 ? 0 : (index / (count - 1)) * (sorted.length - 1);
-    const lowerIndex = Math.floor(position);
-    const upperIndex = Math.min(sorted.length - 1, Math.ceil(position));
-    const ratio = position - lowerIndex;
-    return (
-      sorted[lowerIndex] + (sorted[upperIndex] - sorted[lowerIndex]) * ratio
-    );
-  });
 }
 
 const MAX_NATURAL_BREAK_SAMPLES = 1000;
@@ -2095,6 +1980,9 @@ export function StylePanel({
                   format={(value) => value.toFixed(0)}
                 />
               </>
+            )}
+            {layer.metadata.sourceKind === RASTER_SOURCE_KIND && (
+              <RasterSymbologySection layer={layer} />
             )}
           </div>
         </ScrollArea>

--- a/packages/core/src/color-ramp.ts
+++ b/packages/core/src/color-ramp.ts
@@ -66,6 +66,56 @@ export const VECTOR_COLOR_RAMPS: readonly ColorRamp[] = [
     label: "Oranges",
     colors: ["#fff7ed", "#fdba74", "#f97316", "#7c2d12"],
   },
+  {
+    value: "reds",
+    label: "Reds",
+    colors: ["#fff5f0", "#fcae91", "#fb6a4a", "#cb181d", "#67000d"],
+  },
+  {
+    value: "purples",
+    label: "Purples",
+    colors: ["#fcfbfd", "#bcbddc", "#807dba", "#54278f", "#3f007d"],
+  },
+  {
+    value: "terrain",
+    label: "Terrain",
+    colors: ["#333399", "#21bcb3", "#79d05a", "#e8e85a", "#a87b54", "#ffffff"],
+  },
+  {
+    value: "rdylgn",
+    label: "Red-Yellow-Green",
+    colors: ["#a50026", "#f46d43", "#ffffbf", "#66bd63", "#006837"],
+  },
+  {
+    value: "rdylbu",
+    label: "Red-Yellow-Blue",
+    colors: ["#a50026", "#f46d43", "#ffffbf", "#74add1", "#313695"],
+  },
+  {
+    value: "rdbu",
+    label: "Red-Blue",
+    colors: ["#b2182b", "#ef8a62", "#f7f7f7", "#67a9cf", "#2166ac"],
+  },
+  {
+    value: "coolwarm",
+    label: "Cool-Warm",
+    colors: ["#3b4cc0", "#7b9ff9", "#dddcdc", "#f49a7b", "#b40426"],
+  },
+  {
+    value: "jet",
+    label: "Jet",
+    colors: ["#000080", "#0000ff", "#00ffff", "#ffff00", "#ff0000", "#800000"],
+  },
+  {
+    value: "greys",
+    label: "Greys",
+    colors: ["#ffffff", "#bdbdbd", "#636363", "#000000"],
+  },
+  {
+    value: "gray",
+    label: "Grayscale",
+    colors: ["#000000", "#ffffff"],
+  },
 ] as const;
 
 /**

--- a/packages/core/src/color-ramp.ts
+++ b/packages/core/src/color-ramp.ts
@@ -181,7 +181,11 @@ export function createEqualIntervalBreaks(
  * @returns The quantile break values.
  */
 export function createQuantileBreaks(values: number[], count: number): number[] {
+  if (count <= 0) return [];
   const sorted = [...values].sort((a, b) => a - b);
+  // An empty sample would read `undefined` through the index math below and
+  // yield NaN breaks; callers that have no values get an empty result instead.
+  if (sorted.length === 0) return [];
   return Array.from({ length: count }, (_, index) => {
     const position =
       count === 1 ? 0 : (index / (count - 1)) * (sorted.length - 1);

--- a/packages/core/src/color-ramp.ts
+++ b/packages/core/src/color-ramp.ts
@@ -184,6 +184,8 @@ export function interpolateHexColor(
  * @returns The red, green, and blue channels (0-255).
  */
 export function parseHexColor(value: string): { b: number; g: number; r: number } {
+  // Caller must pass a well-formed "#rrggbb" string; malformed input parses to
+  // NaN and the bitwise ops below coerce it to black ({ r: 0, g: 0, b: 0 }).
   const numeric = Number.parseInt(value.slice(1), 16);
   return {
     r: (numeric >> 16) & 255,

--- a/packages/core/src/color-ramp.ts
+++ b/packages/core/src/color-ramp.ts
@@ -1,0 +1,195 @@
+/**
+ * Color-ramp definitions and classification-break helpers shared by the
+ * vector graduated-styling panel and the raster symbology panel. Kept in
+ * `@geolibre/core` (dependency-light, map-agnostic) so both UIs derive class
+ * colors and breaks from the same source. The ramp `value`s intentionally
+ * match the named colormaps shipped by `@developmentseed/deck.gl-raster`
+ * (`COLORMAP_INDEX` keys) so a ramp choice maps 1:1 onto the raster render
+ * path.
+ */
+
+export type ColorRamp = {
+  value: string;
+  label: string;
+  colors: readonly string[];
+};
+
+/** The built-in color ramps offered by the style panels. */
+export const VECTOR_COLOR_RAMPS: readonly ColorRamp[] = [
+  {
+    value: "viridis",
+    label: "Viridis",
+    colors: ["#440154", "#31688e", "#35b779", "#fde725"],
+  },
+  {
+    value: "plasma",
+    label: "Plasma",
+    colors: ["#0d0887", "#9c179e", "#ed7953", "#f0f921"],
+  },
+  {
+    value: "inferno",
+    label: "Inferno",
+    colors: ["#000004", "#781c6d", "#ed6925", "#fcffa4"],
+  },
+  {
+    value: "magma",
+    label: "Magma",
+    colors: ["#000004", "#721f81", "#f1605d", "#fcfdbf"],
+  },
+  {
+    value: "cividis",
+    label: "Cividis",
+    colors: ["#00204d", "#575d6d", "#a59c74", "#ffea46"],
+  },
+  {
+    value: "turbo",
+    label: "Turbo",
+    colors: ["#30123b", "#4777ef", "#1ccfd0", "#b9e642", "#fb8022", "#7a0403"],
+  },
+  {
+    value: "spectral",
+    label: "Spectral",
+    colors: ["#9e0142", "#f46d43", "#ffffbf", "#66c2a5", "#5e4fa2"],
+  },
+  {
+    value: "blues",
+    label: "Blues",
+    colors: ["#eff6ff", "#93c5fd", "#2563eb", "#1e3a8a"],
+  },
+  {
+    value: "greens",
+    label: "Greens",
+    colors: ["#f0fdf4", "#86efac", "#16a34a", "#14532d"],
+  },
+  {
+    value: "oranges",
+    label: "Oranges",
+    colors: ["#fff7ed", "#fdba74", "#f97316", "#7c2d12"],
+  },
+] as const;
+
+/**
+ * Resolves a ramp definition by name, falling back to the first ramp when the
+ * name is unknown.
+ *
+ * @param value - The ramp `value` (e.g. "viridis").
+ * @returns The matching ramp, or the first ramp.
+ */
+export function getVectorColorRamp(value: string): ColorRamp {
+  return (
+    VECTOR_COLOR_RAMPS.find((colorRamp) => colorRamp.value === value) ??
+    VECTOR_COLOR_RAMPS[0]
+  );
+}
+
+/**
+ * Samples a ramp into `count` evenly spaced hex colors by linearly
+ * interpolating between the ramp's anchor colors.
+ *
+ * @param colorRamp - The ramp `value`.
+ * @param count - Number of colors to produce.
+ * @returns An array of `count` hex colors (a single end color when count <= 1).
+ */
+export function interpolateRampColors(
+  colorRamp: string,
+  count: number,
+): string[] {
+  const colors = getVectorColorRamp(colorRamp).colors;
+  if (count <= 1) return [colors[colors.length - 1]];
+  return Array.from({ length: count }, (_, index) => {
+    const scaled = (index / (count - 1)) * (colors.length - 1);
+    const lowerIndex = Math.floor(scaled);
+    const upperIndex = Math.min(colors.length - 1, Math.ceil(scaled));
+    const ratio = scaled - lowerIndex;
+    return interpolateHexColor(colors[lowerIndex], colors[upperIndex], ratio);
+  });
+}
+
+/**
+ * Linearly interpolates between two hex colors.
+ *
+ * @param from - Start hex color (e.g. "#440154").
+ * @param to - End hex color.
+ * @param ratio - Blend factor in [0, 1].
+ * @returns The interpolated hex color.
+ */
+export function interpolateHexColor(
+  from: string,
+  to: string,
+  ratio: number,
+): string {
+  const start = parseHexColor(from);
+  const end = parseHexColor(to);
+  return rgbToHex({
+    r: Math.round(start.r + (end.r - start.r) * ratio),
+    g: Math.round(start.g + (end.g - start.g) * ratio),
+    b: Math.round(start.b + (end.b - start.b) * ratio),
+  });
+}
+
+/**
+ * Parses a `#rrggbb` hex color into its RGB channels.
+ *
+ * @param value - A `#rrggbb` hex color.
+ * @returns The red, green, and blue channels (0-255).
+ */
+export function parseHexColor(value: string): { b: number; g: number; r: number } {
+  const numeric = Number.parseInt(value.slice(1), 16);
+  return {
+    r: (numeric >> 16) & 255,
+    g: (numeric >> 8) & 255,
+    b: numeric & 255,
+  };
+}
+
+/**
+ * Formats RGB channels as a `#rrggbb` hex color.
+ *
+ * @param color - The red, green, and blue channels (0-255).
+ * @returns A `#rrggbb` hex color.
+ */
+export function rgbToHex(color: { b: number; g: number; r: number }): string {
+  return `#${[color.r, color.g, color.b]
+    .map((channel) => channel.toString(16).padStart(2, "0"))
+    .join("")}`;
+}
+
+/**
+ * Builds `count` evenly spaced break values across [min, max].
+ *
+ * @param min - The minimum value.
+ * @param max - The maximum value.
+ * @param count - Number of breaks to produce.
+ * @returns The break values (min..max inclusive when count > 1).
+ */
+export function createEqualIntervalBreaks(
+  min: number,
+  max: number,
+  count: number,
+): number[] {
+  return Array.from({ length: count }, (_, index) => {
+    const ratio = count === 1 ? 0 : index / (count - 1);
+    return min + (max - min) * ratio;
+  });
+}
+
+/**
+ * Builds `count` quantile break values from a sample of numeric values.
+ *
+ * @param values - The sample values.
+ * @param count - Number of breaks to produce.
+ * @returns The quantile break values.
+ */
+export function createQuantileBreaks(values: number[], count: number): number[] {
+  const sorted = [...values].sort((a, b) => a - b);
+  return Array.from({ length: count }, (_, index) => {
+    const position =
+      count === 1 ? 0 : (index / (count - 1)) * (sorted.length - 1);
+    const lowerIndex = Math.floor(position);
+    const upperIndex = Math.min(sorted.length - 1, Math.ceil(position));
+    const ratio = position - lowerIndex;
+    return (
+      sorted[lowerIndex] + (sorted[upperIndex] - sorted[lowerIndex]) * ratio
+    );
+  });
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./types";
+export * from "./color-ramp";
 export * from "./vector-color";
 export * from "./project";
 export { createSampleStoryMap } from "./storymap-sample";

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -102,6 +102,21 @@ export {
   restoreRasterLayers,
 } from "./plugins/maplibre-raster";
 export {
+  RASTER_MAX_CLASSES,
+  RASTER_MIN_CLASSES,
+  type RasterBandStats,
+  type RasterClassificationMethod,
+  type RasterSymbology,
+  clampRasterClassCount,
+  computeRasterBreaks,
+  defaultRasterSymbology,
+  savedRasterSymbology,
+} from "./plugins/raster-symbology";
+export {
+  RASTER_SOURCE_KIND,
+  getRasterBandStats,
+} from "./plugins/raster-symbology-texture";
+export {
   closeVectorLayerPanel,
   openVectorLayerPanel,
   reloadVectorControlLayer,

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -300,6 +300,11 @@ async function ensureRasterControl(
     // The control mounts hidden: project restore must not surface a map
     // button the user never asked for. openRasterLayerPanel shows it.
     await patchTauriRasterOverlayFactory(rasterControl);
+    // Patch the deck.gl render path so classified single-band rasters sample a
+    // custom stepped colormap. Must run after addMapControl: the LayerManager
+    // (and its _renderTileFor / _device) is created in the control's onAdd,
+    // not its constructor.
+    activateRasterClassification(rasterControl);
     hideRasterControl(rasterControl);
     disableRasterClickOutsideCollapse(rasterControl);
     wireRasterCloseButton(rasterControl);
@@ -356,9 +361,6 @@ function createRasterControl(
   control.on("rasterremove", (event) => {
     if (event.layerId) disposeRasterClassification(event.layerId);
   });
-  // Patch the deck.gl render path so classified single-band rasters sample a
-  // custom stepped colormap, and reconcile the registry with the store.
-  activateRasterClassification(control);
   // syncRasterLayersToStore re-reads getState().collapsed when these fire.
   // Safe: expand()/collapse() delegate to toggle(), which flips
   // _state.collapsed BEFORE emitting the event (verified against v0.2.0) --

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -14,6 +14,11 @@ import {
   unwireRasterStoreSync,
   wireRasterStoreSync,
 } from "./raster-layer-sync";
+import {
+  activateRasterClassification,
+  disposeAllRasterClassification,
+  disposeRasterClassification,
+} from "./raster-symbology-texture";
 
 const rasterControlPosition: GeoLibreMapControlPosition = "top-left";
 const RASTER_PANEL_CLASS = "geolibre-raster-panel";
@@ -347,6 +352,13 @@ function createRasterControl(
   for (const event of ["rasteradd", "rasterchange", "rasterremove"] as const) {
     control.on(event, () => syncRasterLayersToStoreForRuntime(control));
   }
+  // Free the per-layer classification GPU texture when its raster is dropped.
+  control.on("rasterremove", (event) => {
+    if (event.layerId) disposeRasterClassification(event.layerId);
+  });
+  // Patch the deck.gl render path so classified single-band rasters sample a
+  // custom stepped colormap, and reconcile the registry with the store.
+  activateRasterClassification(control);
   // syncRasterLayersToStore re-reads getState().collapsed when these fire.
   // Safe: expand()/collapse() delegate to toggle(), which flips
   // _state.collapsed BEFORE emitting the event (verified against v0.2.0) --
@@ -481,6 +493,7 @@ function patchRasterControlOnRemove(
       restorePanelExpandTimeout = null;
     }
     unwireRasterStoreSync();
+    disposeAllRasterClassification();
     // A control torn down mid-restore must not leave its successor
     // permanently suppressing store sync events.
     resetRasterStoreSyncSuspension();

--- a/packages/plugins/src/plugins/raster-layer-sync.ts
+++ b/packages/plugins/src/plugins/raster-layer-sync.ts
@@ -98,6 +98,12 @@ export function createRasterStoreLayer(
       // replay URL-backed rasters when a saved project is reopened.
       rasterSource: info.source.kind,
       rasterState: serializableRasterState(info.state),
+      // Band metadata powers the symbology panel's band / RGB pickers. Known
+      // only once the GeoTIFF header loads (null until then). The Map is
+      // serialized to pairs so the store / project JSON and the deep-equal
+      // diff below can compare it.
+      bandCount: info.bandCount,
+      bandNames: serializeBandNames(info.bandNames),
       sourceIds: [],
       sourceKind: RASTER_SOURCE_KIND,
       ...(info.bounds
@@ -158,17 +164,28 @@ export function syncRasterLayersToStoreWithOptions(
         continue;
       }
 
+      // rasterSymbology (discrete classification) is GeoLibre-owned and not
+      // present on RasterLayerInfo, so carry it forward across the wholesale
+      // metadata rebuild instead of letting every control event wipe it.
+      const metadata =
+        existing.metadata.rasterSymbology !== undefined
+          ? {
+              ...layer.metadata,
+              rasterSymbology: existing.metadata.rasterSymbology,
+            }
+          : layer.metadata;
+
       if (
         existing.visible !== layer.visible ||
         existing.opacity !== layer.opacity ||
         existing.sourcePath !== layer.sourcePath ||
         !recordsEqual(existing.source, layer.source) ||
-        !recordsEqual(existing.metadata, layer.metadata)
+        !recordsEqual(existing.metadata, metadata)
       ) {
         useAppStore.getState().updateLayer(layer.id, {
           // Replace metadata wholesale so stale keys (error, bounds) cannot
           // survive a raster being swapped out under the same id.
-          metadata: layer.metadata,
+          metadata,
           opacity: layer.opacity,
           source: layer.source,
           sourcePath: layer.sourcePath,
@@ -226,9 +243,63 @@ export function wireRasterStoreSync(control: RasterSyncableControl): void {
         if (current.opacity !== layer.opacity) {
           activeControl.setRasterState(layer.id, { opacity: current.opacity });
         }
+        const patch = rasterStatePatch(layer, current);
+        if (patch) activeControl.setRasterState(layer.id, patch);
       }
     });
   });
+}
+
+// The rasterState fields the symbology panel edits and pushes back to the
+// control. opacity/visible are handled above (they live on top-level layer
+// fields); these live in metadata.rasterState.
+const SYNCED_RASTER_STATE_KEYS = [
+  "mode",
+  "bands",
+  "colormap",
+  "rescale",
+  "nodata",
+  "stretch",
+  "gamma",
+] as const;
+
+/**
+ * Diffs the editable rasterState fields between two store snapshots of the
+ * same layer and returns the changed subset to push through setRasterState,
+ * or null when nothing relevant changed.
+ *
+ * @param previous - The prior store layer.
+ * @param current - The current store layer.
+ * @returns A partial RasterLayerState patch, or null.
+ */
+function rasterStatePatch(
+  previous: GeoLibreLayer,
+  current: GeoLibreLayer,
+): Partial<RasterLayerState> | null {
+  const before = rasterStateRecord(previous);
+  const after = rasterStateRecord(current);
+  const patch: Record<string, unknown> = {};
+  let changed = false;
+  for (const key of SYNCED_RASTER_STATE_KEYS) {
+    if (!valuesEqual(before[key], after[key])) {
+      patch[key] = after[key];
+      changed = true;
+    }
+  }
+  return changed ? (patch as Partial<RasterLayerState>) : null;
+}
+
+function rasterStateRecord(layer: GeoLibreLayer): Record<string, unknown> {
+  const raw = layer.metadata.rasterState;
+  return raw && typeof raw === "object" && !Array.isArray(raw)
+    ? (raw as Record<string, unknown>)
+    : {};
+}
+
+function serializeBandNames(
+  bandNames: Map<number, string> | null,
+): [number, string][] | null {
+  return bandNames ? [...bandNames.entries()] : null;
 }
 
 /**

--- a/packages/plugins/src/plugins/raster-symbology-texture.ts
+++ b/packages/plugins/src/plugins/raster-symbology-texture.ts
@@ -123,7 +123,10 @@ export function installRasterClassification(control: unknown): void {
                   ...mod.props,
                   colormapTexture: texture,
                   colormapIndex: 0,
-                  reversed: entry.symbology.reversed,
+                  // The reversal is already baked into the texture's class
+                  // colors (buildSteppedColormapRgba), so the shader uniform
+                  // must stay false or the two cancel out.
+                  reversed: false,
                 },
               }
             : mod,

--- a/packages/plugins/src/plugins/raster-symbology-texture.ts
+++ b/packages/plugins/src/plugins/raster-symbology-texture.ts
@@ -1,0 +1,348 @@
+import { useAppStore } from "@geolibre/core";
+import { createColormapTexture } from "@developmentseed/deck.gl-raster/gpu-modules";
+import {
+  type AutoStats,
+  computeAutoStats,
+  loadGeoTIFF,
+} from "maplibre-gl-raster";
+import {
+  COLORMAP_TEXTURE_WIDTH,
+  type RasterBandStats,
+  type RasterSymbology,
+  buildSteppedColormapRgba,
+  savedRasterSymbology,
+} from "./raster-symbology";
+import { RASTER_SOURCE_KIND, isRasterControlStoreLayer } from "./raster-layer-sync";
+
+// These types mirror undocumented private members of the maplibre-gl-raster
+// LayerManager (verified against v0.2.0) and the deck.gl-raster Colormap
+// module name (deck.gl-raster v0.7.0). Access is feature-detected and falls
+// back to a no-op rather than throwing -- re-verify these names AND the
+// "colormap" module name when bumping either dependency.
+type GpuTexture = { destroy?: () => void };
+type RenderPipelineModule = {
+  module?: { name?: string };
+  props?: Record<string, unknown>;
+};
+type RenderTileResult = { renderPipeline?: RenderPipelineModule[] } | null;
+type RenderTileFn = (data: unknown) => RenderTileResult;
+type RasterLayerLike = {
+  id: string;
+  state?: { mode?: string; colormap?: string };
+};
+type RasterLayerManager = {
+  _device?: unknown;
+  _colormapTexture?: unknown;
+  _renderTileFor?: (layer: RasterLayerLike) => RenderTileFn;
+  _rebuild?: () => void;
+  _deps?: { geolibreClassifiedPatched?: boolean };
+};
+type ControlWithManager = {
+  _layerManager?: RasterLayerManager;
+  getRaster?: (id: string) => RasterInfoLike | undefined;
+};
+type RasterInfoLike = {
+  source?:
+    | { kind: "url"; url: string }
+    | { kind: "file"; fileName: string; objectUrl: string };
+};
+
+type ClassificationEntry = {
+  symbology: RasterSymbology;
+  /** Cache key for the built texture (breaks + ramp + reversed). */
+  key: string;
+  texture?: GpuTexture;
+};
+
+// Per-layer classification state and built GPU textures. Module-global to
+// match the single mounted raster control (see maplibre-raster.ts).
+const entries = new Map<string, ClassificationEntry>();
+const statsCache = new Map<string, RasterBandStats>();
+const statsInflight = new Map<string, AbortController>();
+let storeUnsubscribe: (() => void) | null = null;
+
+function symbologyKey(symbology: RasterSymbology): string {
+  return JSON.stringify([symbology.breaks, symbology.ramp, symbology.reversed]);
+}
+
+/**
+ * Installs the per-layer classification injection on a raster control. Wraps
+ * the LayerManager's `_renderTileFor` so that a classified single-band layer
+ * renders through the unchanged upstream pipeline (composite / nodata /
+ * rescale / stretch) but samples a custom stepped colormap texture instead of
+ * the shared named-colormap sprite. Idempotent and feature-detected: if the
+ * private surface is missing it warns once and leaves the control untouched.
+ *
+ * @param control - The mounted maplibre-gl-raster control.
+ */
+export function installRasterClassification(control: unknown): void {
+  const manager = (control as ControlWithManager)._layerManager;
+  if (
+    !manager ||
+    typeof manager._renderTileFor !== "function" ||
+    typeof createColormapTexture !== "function"
+  ) {
+    console.warn(
+      "[GeoLibre] Raster classification unavailable: maplibre-gl-raster internals not found (re-verify on dependency bump).",
+    );
+    return;
+  }
+
+  manager._deps ??= {};
+  if (!manager._deps.geolibreClassifiedPatched) {
+    const originalRenderTileFor = manager._renderTileFor.bind(manager);
+    manager._renderTileFor = (layer: RasterLayerLike): RenderTileFn => {
+      const renderTile = originalRenderTileFor(layer);
+      const entry = entries.get(layer.id);
+      if (
+        layer.state?.mode !== "single" ||
+        !entry?.symbology.classified ||
+        !manager._device
+      ) {
+        return renderTile;
+      }
+      return (data: unknown): RenderTileResult => {
+        const result = renderTile(data);
+        const pipeline = result?.renderPipeline;
+        if (!Array.isArray(pipeline)) return result;
+        const texture = ensureTexture(manager, entry);
+        if (!texture) return result;
+        // Swap ONLY the trailing colormap module's texture; every other
+        // module (composite, nodata, rescale, stretch, gamma) is reused as
+        // built upstream, so nodata transparency and the rescale window
+        // behave identically to the named-colormap path.
+        const patched = pipeline.map((mod) =>
+          mod?.module?.name === "colormap"
+            ? {
+                ...mod,
+                props: {
+                  ...mod.props,
+                  colormapTexture: texture,
+                  colormapIndex: 0,
+                  reversed: entry.symbology.reversed,
+                },
+              }
+            : mod,
+        );
+        return { ...result, renderPipeline: patched };
+      };
+    };
+    manager._deps.geolibreClassifiedPatched = true;
+  }
+
+  subscribeToStore();
+}
+
+function ensureTexture(
+  manager: RasterLayerManager,
+  entry: ClassificationEntry,
+): GpuTexture | null {
+  const key = symbologyKey(entry.symbology);
+  if (entry.texture && entry.key === key) return entry.texture;
+  entry.texture?.destroy?.();
+  try {
+    const rgba = buildSteppedColormapRgba(
+      entry.symbology.breaks,
+      entry.symbology.ramp,
+      entry.symbology.reversed,
+    );
+    // The DOM ImageData ctor types its buffer as ArrayBuffer (not the wider
+    // ArrayBufferLike the Uint8ClampedArray generic carries); the runtime
+    // buffer is a plain ArrayBuffer, so narrow it for the type checker.
+    const imageData = new ImageData(
+      rgba as Uint8ClampedArray<ArrayBuffer>,
+      COLORMAP_TEXTURE_WIDTH,
+      1,
+    );
+    entry.texture = createColormapTexture(
+      manager._device as never,
+      imageData,
+    ) as GpuTexture;
+    entry.key = key;
+    return entry.texture;
+  } catch (error) {
+    console.error("[GeoLibre] Failed to build raster classification texture", error);
+    entry.texture = undefined;
+    return null;
+  }
+}
+
+/**
+ * Reconciles the classification registry with the current store layers and
+ * triggers a re-render when a classified layer's symbology changes. Driven by
+ * the store subscription so the UI only has to write `metadata.rasterSymbology`.
+ *
+ * @param control - The mounted raster control (for `_rebuild`).
+ */
+function reconcile(control: unknown): void {
+  const manager = (control as ControlWithManager)._layerManager;
+  if (!manager) return;
+
+  const layers = useAppStore.getState().layers;
+  const seen = new Set<string>();
+  let changed = false;
+
+  for (const layer of layers) {
+    if (!isRasterControlStoreLayer(layer)) continue;
+    seen.add(layer.id);
+    const symbology = savedRasterSymbology(layer);
+    const existing = entries.get(layer.id);
+
+    if (!symbology || !symbology.classified) {
+      if (existing) {
+        existing.texture?.destroy?.();
+        entries.delete(layer.id);
+        changed = true;
+      }
+      continue;
+    }
+
+    const key = symbologyKey(symbology);
+    if (!existing) {
+      entries.set(layer.id, { symbology, key });
+      changed = true;
+    } else if (existing.key !== key) {
+      existing.symbology = symbology;
+      // Texture rebuilt lazily on next render via ensureTexture's key check.
+      changed = true;
+    }
+  }
+
+  // Drop entries for rasters that left the store.
+  for (const id of [...entries.keys()]) {
+    if (!seen.has(id)) {
+      entries.get(id)?.texture?.destroy?.();
+      entries.delete(id);
+      changed = true;
+    }
+  }
+
+  if (changed) manager._rebuild?.();
+}
+
+function subscribeToStore(): void {
+  storeUnsubscribe ??= useAppStore.subscribe((state, previous) => {
+    if (state.layers === previous.layers) return;
+    // Cheap guard: only reconcile when a control-managed raster is present.
+    if (
+      !state.layers.some(isRasterControlStoreLayer) &&
+      !previous.layers.some(isRasterControlStoreLayer)
+    ) {
+      return;
+    }
+    reconcile(currentControl);
+  });
+}
+
+// The single mounted control, set by installRasterClassification's caller.
+let currentControl: unknown = null;
+
+/**
+ * Points the classification manager at the active control and performs an
+ * initial reconcile. Call after the control mounts (and on project restore).
+ *
+ * @param control - The mounted raster control.
+ */
+export function activateRasterClassification(control: unknown): void {
+  currentControl = control;
+  installRasterClassification(control);
+  reconcile(control);
+}
+
+/**
+ * Disposes a single layer's classification texture (on raster removal).
+ *
+ * @param layerId - The layer id.
+ */
+export function disposeRasterClassification(layerId: string): void {
+  const entry = entries.get(layerId);
+  entry?.texture?.destroy?.();
+  entries.delete(layerId);
+  statsCache.delete(layerId);
+  statsInflight.get(layerId)?.abort();
+  statsInflight.delete(layerId);
+}
+
+/**
+ * Disposes all classification textures and detaches the store subscription
+ * (on control teardown).
+ */
+export function disposeAllRasterClassification(): void {
+  for (const entry of entries.values()) entry.texture?.destroy?.();
+  entries.clear();
+  for (const controller of statsInflight.values()) controller.abort();
+  statsInflight.clear();
+  statsCache.clear();
+  storeUnsubscribe?.();
+  storeUnsubscribe = null;
+  currentControl = null;
+}
+
+function sourceUrl(info: RasterInfoLike | undefined): string | null {
+  const source = info?.source;
+  if (!source) return null;
+  if (source.kind === "url") return source.url;
+  if (source.kind === "file") return source.objectUrl;
+  return null;
+}
+
+function bandStatsFromAuto(stats: AutoStats, band: number): RasterBandStats | null {
+  const perBand = stats.perBand?.get(band) ?? stats.global;
+  if (!perBand) return null;
+  return {
+    min: perBand.min,
+    max: perBand.max,
+    histogram: [...perBand.histogram],
+  };
+}
+
+/**
+ * Fetches (and caches) a band's min/max/histogram for classification breaks,
+ * reading the GeoTIFF via the same loader the control uses. Aborts any prior
+ * in-flight request for the layer. File-backed rasters use the session blob
+ * URL and are unavailable after a project reload (no URL persisted).
+ *
+ * @param control - The mounted raster control.
+ * @param layerId - The layer id.
+ * @param band - The 1-indexed band to summarize.
+ * @returns The band statistics, or null when the source is unavailable.
+ */
+export async function getRasterBandStats(
+  layerId: string,
+  band: number,
+): Promise<RasterBandStats | null> {
+  const cacheKey = `${layerId}:${band}`;
+  const cached = statsCache.get(cacheKey);
+  if (cached) return cached;
+
+  const info = (currentControl as ControlWithManager | null)?.getRaster?.(
+    layerId,
+  );
+  const url = sourceUrl(info);
+  if (!url) return null;
+
+  statsInflight.get(layerId)?.abort();
+  const controller = new AbortController();
+  statsInflight.set(layerId, controller);
+  try {
+    const tiff = await loadGeoTIFF(url);
+    const auto = await computeAutoStats(tiff, controller.signal);
+    const stats = bandStatsFromAuto(auto, band);
+    if (stats) statsCache.set(cacheKey, stats);
+    return stats;
+  } catch (error) {
+    if (!controller.signal.aborted) {
+      console.warn(
+        `[GeoLibre] Failed to compute raster statistics for layer "${layerId}"`,
+        error,
+      );
+    }
+    return null;
+  } finally {
+    if (statsInflight.get(layerId) === controller) {
+      statsInflight.delete(layerId);
+    }
+  }
+}
+
+export { RASTER_SOURCE_KIND };

--- a/packages/plugins/src/plugins/raster-symbology-texture.ts
+++ b/packages/plugins/src/plugins/raster-symbology-texture.ts
@@ -61,7 +61,11 @@ type ClassificationEntry = {
 // Per-layer classification state and built GPU textures. Module-global to
 // match the single mounted raster control (see maplibre-raster.ts).
 const entries = new Map<string, ClassificationEntry>();
-const statsCache = new Map<string, RasterBandStats>();
+// Keyed by layerId: computeAutoStats derives every band in one GeoTIFF pass,
+// so caching the whole AutoStats lets band-picker switches hit the cache
+// instead of re-scanning the file, and keeps the key aligned with the
+// disposal key below (so eviction actually matches).
+const statsCache = new Map<string, AutoStats>();
 const statsInflight = new Map<string, AbortController>();
 let storeUnsubscribe: (() => void) | null = null;
 
@@ -298,7 +302,12 @@ function sourceUrl(info: RasterInfoLike | undefined): string | null {
 }
 
 function bandStatsFromAuto(stats: AutoStats, band: number): RasterBandStats | null {
-  const perBand = stats.perBand?.get(band) ?? stats.global;
+  // Only fall back to the averaged global block when per-band stats are
+  // unavailable entirely; if the per-band map exists but lacks this band,
+  // the global average would be wrong for it, so report unknown instead.
+  const perBand = stats.perBand
+    ? (stats.perBand.get(band) ?? null)
+    : stats.global;
   if (!perBand) return null;
   return {
     min: perBand.min,
@@ -322,9 +331,8 @@ export async function getRasterBandStats(
   layerId: string,
   band: number,
 ): Promise<RasterBandStats | null> {
-  const cacheKey = `${layerId}:${band}`;
-  const cached = statsCache.get(cacheKey);
-  if (cached) return cached;
+  const cached = statsCache.get(layerId);
+  if (cached) return bandStatsFromAuto(cached, band);
 
   const info = (currentControl as ControlWithManager | null)?.getRaster?.(
     layerId,
@@ -338,9 +346,8 @@ export async function getRasterBandStats(
   try {
     const tiff = await loadGeoTIFF(url);
     const auto = await computeAutoStats(tiff, controller.signal);
-    const stats = bandStatsFromAuto(auto, band);
-    if (stats) statsCache.set(cacheKey, stats);
-    return stats;
+    statsCache.set(layerId, auto);
+    return bandStatsFromAuto(auto, band);
   } catch (error) {
     if (!controller.signal.aborted) {
       console.warn(

--- a/packages/plugins/src/plugins/raster-symbology-texture.ts
+++ b/packages/plugins/src/plugins/raster-symbology-texture.ts
@@ -12,7 +12,11 @@ import {
   buildSteppedColormapRgba,
   savedRasterSymbology,
 } from "./raster-symbology";
-import { RASTER_SOURCE_KIND, isRasterControlStoreLayer } from "./raster-layer-sync";
+import {
+  RASTER_SOURCE_KIND,
+  isRasterControlStoreLayer,
+  isRasterStoreSyncSuspended,
+} from "./raster-layer-sync";
 
 // These types mirror undocumented private members of the maplibre-gl-raster
 // LayerManager (verified against v0.2.0) and the deck.gl-raster Colormap
@@ -223,6 +227,10 @@ function reconcile(control: unknown): void {
 function subscribeToStore(): void {
   storeUnsubscribe ??= useAppStore.subscribe((state, previous) => {
     if (state.layers === previous.layers) return;
+    // Skip the control->store echo: when the control rewrites a store layer
+    // from its own state (e.g. after setRasterState), symbology is unchanged,
+    // so reconciling again is wasted work.
+    if (isRasterStoreSyncSuspended()) return;
     // Cheap guard: only reconcile when a control-managed raster is present.
     if (
       !state.layers.some(isRasterControlStoreLayer) &&

--- a/packages/plugins/src/plugins/raster-symbology.ts
+++ b/packages/plugins/src/plugins/raster-symbology.ts
@@ -123,9 +123,16 @@ export function computeRasterBreaks(
     if (edges.length === edgeCount) return [...edges].sort((a, b) => a - b);
     // Fall back to an even spread across whatever range we can infer so the
     // editor always starts from a sensible, correctly sized set of edges.
-    const min = stats?.min ?? edges[0] ?? 0;
-    const max = stats?.max ?? edges.at(-1) ?? 1;
-    return createEqualIntervalBreaks(min, max, edgeCount);
+    // Order the inferred bounds so unsorted manual input cannot produce
+    // descending edges (which would violate the ascending-edge contract).
+    const sortedEdges = [...edges].sort((a, b) => a - b);
+    const inferredMin = stats?.min ?? sortedEdges[0] ?? 0;
+    const inferredMax = stats?.max ?? sortedEdges.at(-1) ?? 1;
+    return createEqualIntervalBreaks(
+      Math.min(inferredMin, inferredMax),
+      Math.max(inferredMin, inferredMax),
+      edgeCount,
+    );
   }
 
   const min = stats?.min ?? 0;
@@ -171,6 +178,7 @@ export function buildSteppedColormapRgba(
 
   for (let column = 0; column < width; column += 1) {
     const t = column / (width - 1);
+    // Defaults to the last class (covers t === 1 and the degenerate range).
     let classIndex = classCount - 1;
     if (normalizedEdges) {
       for (let edge = 1; edge < normalizedEdges.length; edge += 1) {
@@ -179,8 +187,6 @@ export function buildSteppedColormapRgba(
           break;
         }
       }
-    } else {
-      classIndex = classCount - 1;
     }
     const color = parseHexColor(
       orderedColors[classIndex] ?? orderedColors.at(-1) ?? "#000000",

--- a/packages/plugins/src/plugins/raster-symbology.ts
+++ b/packages/plugins/src/plugins/raster-symbology.ts
@@ -1,0 +1,272 @@
+import {
+  type GeoLibreLayer,
+  createEqualIntervalBreaks,
+  interpolateRampColors,
+  parseHexColor,
+} from "@geolibre/core";
+
+/**
+ * The classification methods offered for single-band pseudocolor rasters.
+ * Mirrors the vector graduated schemes minus natural-breaks (which needs raw
+ * per-pixel samples a raster histogram does not provide).
+ */
+export type RasterClassificationMethod = "equal-interval" | "quantile" | "manual";
+
+/**
+ * GeoLibre-owned raster symbology, stored at `metadata.rasterSymbology`. The
+ * upstream `maplibre-gl-raster` control owns the continuous render state
+ * (`metadata.rasterState`: mode/bands/colormap/rescale/nodata/stretch/gamma);
+ * this record adds discrete classification that the control cannot express.
+ * When `classified` is true the stepped colormap drives color and
+ * `rasterState.colormap` is ignored.
+ */
+export type RasterSymbology = {
+  /** Whether the single band is rendered as discrete classes. */
+  classified: boolean;
+  /** Color ramp name (a `VECTOR_COLOR_RAMPS` value / deck.gl-raster colormap). */
+  ramp: string;
+  /** Sample the ramp in reverse (classified-only; continuous path can't reverse). */
+  reversed: boolean;
+  /** How the class edges are derived. */
+  method: RasterClassificationMethod;
+  /** Number of classes, clamped to [2, 12]. */
+  classCount: number;
+  /** Class edges, ascending, length `classCount + 1` (min..max inclusive). */
+  breaks: number[];
+};
+
+/** Minimum and maximum class count for raster classification. */
+export const RASTER_MIN_CLASSES = 2;
+export const RASTER_MAX_CLASSES = 12;
+
+/** Number of columns in a colormap lookup texture (matches deck.gl-raster). */
+export const COLORMAP_TEXTURE_WIDTH = 256;
+
+/** A single band's statistics, as produced by `computeAutoStats`. */
+export type RasterBandStats = {
+  min: number;
+  max: number;
+  /** Bin counts evenly distributed over [min, max]. */
+  histogram: number[];
+};
+
+/**
+ * Clamps a requested class count into the supported range.
+ *
+ * @param value - The requested class count.
+ * @returns An integer in [RASTER_MIN_CLASSES, RASTER_MAX_CLASSES].
+ */
+export function clampRasterClassCount(value: number): number {
+  if (!Number.isFinite(value)) return RASTER_MIN_CLASSES;
+  return Math.min(
+    RASTER_MAX_CLASSES,
+    Math.max(RASTER_MIN_CLASSES, Math.round(value)),
+  );
+}
+
+/**
+ * Linear-interpolated percentile from a histogram. Mirrors
+ * `maplibre-gl-raster`'s `percentileFromHistogram` but kept dependency-free so
+ * break computation stays a pure, unit-testable function.
+ *
+ * @param stats - The band statistics (min, max, histogram bins).
+ * @param p - The percentile in [0, 1].
+ * @returns The value at percentile `p`.
+ */
+export function percentileFromHistogram(
+  stats: RasterBandStats,
+  p: number,
+): number {
+  const { min, max, histogram } = stats;
+  const bins = histogram.length;
+  if (bins === 0 || max <= min) return min;
+  const total = histogram.reduce((sum, count) => sum + count, 0);
+  if (total === 0) return min + (max - min) * p;
+
+  const target = p * total;
+  let cumulative = 0;
+  const binWidth = (max - min) / bins;
+  for (let index = 0; index < bins; index += 1) {
+    const next = cumulative + histogram[index];
+    if (next >= target) {
+      // Linear interpolation within the bin that crosses the target count.
+      const within = histogram[index] === 0 ? 0 : (target - cumulative) / histogram[index];
+      return min + (index + within) * binWidth;
+    }
+    cumulative = next;
+  }
+  return max;
+}
+
+/**
+ * Computes ascending class edges (length `classCount + 1`) for a band.
+ *
+ * @param method - The classification method.
+ * @param stats - The band statistics (used for equal-interval / quantile).
+ * @param classCount - The number of classes.
+ * @param manualBreaks - User-entered edges, used when `method` is "manual".
+ * @returns The class edges, ascending, length `classCount + 1`.
+ */
+export function computeRasterBreaks(
+  method: RasterClassificationMethod,
+  stats: RasterBandStats | null,
+  classCount: number,
+  manualBreaks?: number[],
+): number[] {
+  const count = clampRasterClassCount(classCount);
+  const edgeCount = count + 1;
+
+  if (method === "manual") {
+    const edges = (manualBreaks ?? [])
+      .map((value) => Number(value))
+      .filter(Number.isFinite);
+    if (edges.length === edgeCount) return [...edges].sort((a, b) => a - b);
+    // Fall back to an even spread across whatever range we can infer so the
+    // editor always starts from a sensible, correctly sized set of edges.
+    const min = stats?.min ?? edges[0] ?? 0;
+    const max = stats?.max ?? edges.at(-1) ?? 1;
+    return createEqualIntervalBreaks(min, max, edgeCount);
+  }
+
+  const min = stats?.min ?? 0;
+  const max = stats?.max ?? 1;
+  if (method === "quantile" && stats && stats.histogram.length > 0) {
+    return Array.from({ length: edgeCount }, (_, index) =>
+      percentileFromHistogram(stats, index / count),
+    );
+  }
+  return createEqualIntervalBreaks(min, max, edgeCount);
+}
+
+/**
+ * Builds a 256-wide RGBA lookup row for a classified single-band raster. Each
+ * column is colored by the class its normalized position (within
+ * `[breaks[0], breaks[last]]`) falls into, so the deck.gl-raster `Colormap`
+ * module samples discrete classes after the layer's `LinearRescale` maps the
+ * data window to [0, 1]. Returned as a flat `Uint8ClampedArray` (length 1024)
+ * rather than an `ImageData` so it is constructible and testable without a DOM.
+ *
+ * @param breaks - Class edges, ascending, length `classCount + 1`.
+ * @param ramp - The color ramp name.
+ * @param reversed - Whether to reverse the class colors.
+ * @returns A 256x1 RGBA buffer (length COLORMAP_TEXTURE_WIDTH * 4).
+ */
+export function buildSteppedColormapRgba(
+  breaks: number[],
+  ramp: string,
+  reversed = false,
+): Uint8ClampedArray {
+  const width = COLORMAP_TEXTURE_WIDTH;
+  const rgba = new Uint8ClampedArray(width * 4);
+  const classCount = Math.max(1, breaks.length - 1);
+  const colors = interpolateRampColors(ramp, classCount);
+  const orderedColors = reversed ? [...colors].reverse() : colors;
+
+  const min = breaks[0];
+  const max = breaks[breaks.length - 1];
+  const span = max - min;
+  // Normalized interior edges in [0, 1]; degenerate (min === max) → single class.
+  const normalizedEdges =
+    span > 0 ? breaks.map((edge) => (edge - min) / span) : null;
+
+  for (let column = 0; column < width; column += 1) {
+    const t = column / (width - 1);
+    let classIndex = classCount - 1;
+    if (normalizedEdges) {
+      for (let edge = 1; edge < normalizedEdges.length; edge += 1) {
+        if (t < normalizedEdges[edge]) {
+          classIndex = edge - 1;
+          break;
+        }
+      }
+    } else {
+      classIndex = classCount - 1;
+    }
+    const color = parseHexColor(
+      orderedColors[classIndex] ?? orderedColors.at(-1) ?? "#000000",
+    );
+    const offset = column * 4;
+    rgba[offset] = color.r;
+    rgba[offset + 1] = color.g;
+    rgba[offset + 2] = color.b;
+    rgba[offset + 3] = 255;
+  }
+  return rgba;
+}
+
+/**
+ * Reads and validates the persisted raster symbology from a store layer's
+ * metadata, keeping only well-formed fields so a hand-edited project file
+ * cannot crash the renderer. Mirrors the defensive style of
+ * `savedRasterState`.
+ *
+ * @param layer - A store layer created by `createRasterStoreLayer`.
+ * @returns The validated symbology, or null when absent / malformed.
+ */
+export function savedRasterSymbology(
+  layer: GeoLibreLayer,
+): RasterSymbology | null {
+  const raw = layer.metadata.rasterSymbology;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const candidate = raw as Record<string, unknown>;
+
+  if (typeof candidate.classified !== "boolean") return null;
+  if (typeof candidate.ramp !== "string" || candidate.ramp.length === 0) {
+    return null;
+  }
+  if (
+    candidate.method !== "equal-interval" &&
+    candidate.method !== "quantile" &&
+    candidate.method !== "manual"
+  ) {
+    return null;
+  }
+  if (typeof candidate.classCount !== "number") return null;
+  const classCount = clampRasterClassCount(candidate.classCount);
+
+  if (
+    !Array.isArray(candidate.breaks) ||
+    candidate.breaks.length !== classCount + 1 ||
+    !candidate.breaks.every(
+      (value) => typeof value === "number" && Number.isFinite(value),
+    )
+  ) {
+    return null;
+  }
+  const breaks = candidate.breaks as number[];
+  for (let index = 1; index < breaks.length; index += 1) {
+    if (breaks[index] < breaks[index - 1]) return null;
+  }
+
+  return {
+    classified: candidate.classified,
+    ramp: candidate.ramp,
+    reversed: candidate.reversed === true,
+    method: candidate.method,
+    classCount,
+    breaks,
+  };
+}
+
+/**
+ * The default symbology applied when a user first opens the classification
+ * controls for a band, given its data range.
+ *
+ * @param ramp - The initial color ramp.
+ * @param stats - The band statistics, when known.
+ * @returns A continuous (unclassified) symbology seeded with equal-interval edges.
+ */
+export function defaultRasterSymbology(
+  ramp = "viridis",
+  stats: RasterBandStats | null = null,
+): RasterSymbology {
+  const classCount = 5;
+  return {
+    classified: false,
+    ramp,
+    reversed: false,
+    method: "equal-interval",
+    classCount,
+    breaks: computeRasterBreaks("equal-interval", stats, classCount),
+  };
+}

--- a/tests/raster-layer-sync.test.ts
+++ b/tests/raster-layer-sync.test.ts
@@ -170,6 +170,33 @@ describe("createRasterStoreLayer", () => {
     assert.equal(layer.metadata.rasterOverlayMode, "overlaid");
     assert.deepEqual(layer.metadata.nativeLayerIds, []);
   });
+
+  it("persists band count and serializes band names to pairs", () => {
+    const layer = createRasterStoreLayer(
+      rasterInfo({
+        bandCount: 2,
+        bandNames: new Map([
+          [1, "Red"],
+          [2, "NIR"],
+        ]),
+      }),
+    );
+
+    assert.equal(layer.metadata.bandCount, 2);
+    assert.deepEqual(layer.metadata.bandNames, [
+      [1, "Red"],
+      [2, "NIR"],
+    ]);
+  });
+
+  it("stores a null band count and band names before the header loads", () => {
+    const layer = createRasterStoreLayer(
+      rasterInfo({ bandCount: null, bandNames: null }),
+    );
+
+    assert.equal(layer.metadata.bandCount, null);
+    assert.equal(layer.metadata.bandNames, null);
+  });
 });
 
 describe("syncRasterLayersToStore", () => {
@@ -230,6 +257,38 @@ describe("syncRasterLayersToStore", () => {
     assert.equal(layer.name, "My DEM");
     assert.equal(layer.opacity, 0.4);
     assert.deepEqual(layer.metadata.bounds, [0, 0, 1, 1]);
+  });
+
+  it("preserves GeoLibre-owned symbology across a control resync", () => {
+    const { control } = fakeControl([rasterInfo()]);
+    syncRasterLayersToStore(control);
+
+    const symbology = {
+      classified: true,
+      ramp: "viridis",
+      reversed: false,
+      method: "equal-interval",
+      classCount: 2,
+      breaks: [0, 50, 100],
+    };
+    const layer = useAppStore.getState().layers[0];
+    useAppStore.getState().updateLayer("raster-1", {
+      metadata: { ...layer.metadata, rasterSymbology: symbology },
+    });
+
+    // A control event (e.g. bounds arriving) rebuilds the store layer's
+    // metadata wholesale; the symbology must survive since it is not on the
+    // control's RasterLayerInfo.
+    syncRasterLayersToStore(
+      fakeControl([
+        rasterInfo({ bounds: { west: 0, south: 0, east: 1, north: 1 } }),
+      ]).control,
+    );
+
+    assert.deepEqual(
+      useAppStore.getState().layers[0].metadata.rasterSymbology,
+      symbology,
+    );
   });
 
   it("refreshes the saved panel collapsed state", () => {
@@ -360,6 +419,70 @@ describe("wireRasterStoreSync", () => {
 
     useAppStore.getState().addLayer(otherStoreLayer());
     useAppStore.getState().updateLayer("unrelated", { opacity: 0.5 });
+
+    assert.deepEqual(calls, []);
+  });
+
+  it("pushes edited rasterState fields through setRasterState", () => {
+    const { control, calls } = fakeControl([rasterInfo()]);
+    syncRasterLayersToStore(control);
+    wireRasterStoreSync(control);
+
+    const layer = useAppStore.getState().layers[0];
+    useAppStore.getState().updateLayer("raster-1", {
+      metadata: {
+        ...layer.metadata,
+        rasterState: {
+          ...(layer.metadata.rasterState as Record<string, unknown>),
+          mode: "single",
+          bands: [2],
+          colormap: "viridis",
+          rescale: [[0, 4000]],
+          nodata: 0,
+          stretch: "sqrt",
+          gamma: 2,
+        },
+      },
+    });
+
+    assert.deepEqual(calls, [
+      {
+        method: "setRasterState",
+        args: [
+          "raster-1",
+          {
+            mode: "single",
+            bands: [2],
+            colormap: "viridis",
+            rescale: [[0, 4000]],
+            nodata: 0,
+            stretch: "sqrt",
+            gamma: 2,
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("does not push rasterState when only the symbology metadata changes", () => {
+    const { control, calls } = fakeControl([rasterInfo()]);
+    syncRasterLayersToStore(control);
+    wireRasterStoreSync(control);
+
+    const layer = useAppStore.getState().layers[0];
+    useAppStore.getState().updateLayer("raster-1", {
+      metadata: {
+        ...layer.metadata,
+        rasterSymbology: {
+          classified: true,
+          ramp: "viridis",
+          reversed: false,
+          method: "equal-interval",
+          classCount: 2,
+          breaks: [0, 50, 100],
+        },
+      },
+    });
 
     assert.deepEqual(calls, []);
   });

--- a/tests/raster-symbology.test.ts
+++ b/tests/raster-symbology.test.ts
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { GeoLibreLayer } from "@geolibre/core";
+import {
+  buildSteppedColormapRgba,
+  clampRasterClassCount,
+  computeRasterBreaks,
+  defaultRasterSymbology,
+  percentileFromHistogram,
+  savedRasterSymbology,
+} from "../packages/plugins/src/plugins/raster-symbology";
+
+function layerWith(rasterSymbology: unknown): GeoLibreLayer {
+  return {
+    id: "raster-1",
+    name: "dem.tif",
+    type: "cog",
+    source: { type: "raster" },
+    visible: true,
+    opacity: 1,
+    style: {} as GeoLibreLayer["style"],
+    metadata: { rasterSymbology },
+  };
+}
+
+describe("clampRasterClassCount", () => {
+  it("clamps to [2, 12] and rounds", () => {
+    assert.equal(clampRasterClassCount(0), 2);
+    assert.equal(clampRasterClassCount(1), 2);
+    assert.equal(clampRasterClassCount(99), 12);
+    assert.equal(clampRasterClassCount(5.6), 6);
+    assert.equal(clampRasterClassCount(Number.NaN), 2);
+  });
+});
+
+describe("percentileFromHistogram", () => {
+  const uniform = { min: 0, max: 100, histogram: Array(10).fill(10) };
+
+  it("interpolates the median of a uniform histogram", () => {
+    assert.equal(percentileFromHistogram(uniform, 0.5), 50);
+  });
+
+  it("returns the bounds at p=0 and p=1", () => {
+    assert.equal(percentileFromHistogram(uniform, 0), 0);
+    assert.equal(percentileFromHistogram(uniform, 1), 100);
+  });
+
+  it("returns min for an empty histogram", () => {
+    assert.equal(
+      percentileFromHistogram({ min: 5, max: 9, histogram: [] }, 0.5),
+      5,
+    );
+  });
+});
+
+describe("computeRasterBreaks", () => {
+  it("produces classCount+1 evenly spaced equal-interval edges", () => {
+    const breaks = computeRasterBreaks(
+      "equal-interval",
+      { min: 0, max: 100, histogram: [] },
+      4,
+    );
+    assert.deepEqual(breaks, [0, 25, 50, 75, 100]);
+  });
+
+  it("derives quantile edges from the histogram", () => {
+    const breaks = computeRasterBreaks(
+      "quantile",
+      { min: 0, max: 100, histogram: Array(10).fill(10) },
+      2,
+    );
+    assert.deepEqual(breaks, [0, 50, 100]);
+  });
+
+  it("passes through and sorts manual edges of the right length", () => {
+    const breaks = computeRasterBreaks("manual", null, 3, [10, 0, 30, 20]);
+    assert.deepEqual(breaks, [0, 10, 20, 30]);
+  });
+
+  it("falls back to equal-interval when manual edges are the wrong length", () => {
+    const breaks = computeRasterBreaks(
+      "manual",
+      { min: 0, max: 10, histogram: [] },
+      2,
+      [1, 2],
+    );
+    assert.deepEqual(breaks, [0, 5, 10]);
+  });
+});
+
+describe("buildSteppedColormapRgba", () => {
+  it("produces a 256x1 RGBA buffer with stepped class colors", () => {
+    // viridis sampled to 2 classes: #440154 and #fde725.
+    const rgba = buildSteppedColormapRgba([0, 1, 2], "viridis", false);
+    assert.equal(rgba.length, 256 * 4);
+    // First column -> class 0.
+    assert.deepEqual([rgba[0], rgba[1], rgba[2], rgba[3]], [68, 1, 84, 255]);
+    // Just below the midpoint stays in class 0, just above flips to class 1.
+    assert.equal(rgba[127 * 4], 68);
+    assert.equal(rgba[128 * 4], 253);
+    // Last column -> class 1.
+    assert.deepEqual(
+      [rgba[255 * 4], rgba[255 * 4 + 1], rgba[255 * 4 + 2]],
+      [253, 231, 37],
+    );
+  });
+
+  it("reverses the class colors when requested", () => {
+    const rgba = buildSteppedColormapRgba([0, 1, 2], "viridis", true);
+    // Reversed: first column is now the last class color.
+    assert.deepEqual([rgba[0], rgba[1], rgba[2]], [253, 231, 37]);
+    assert.deepEqual([rgba[255 * 4], rgba[255 * 4 + 1], rgba[255 * 4 + 2]], [
+      68, 1, 84,
+    ]);
+  });
+
+  it("renders a single flat color when the range is degenerate", () => {
+    const rgba = buildSteppedColormapRgba([5, 5], "viridis", false);
+    assert.equal(rgba.length, 256 * 4);
+    assert.deepEqual([rgba[0], rgba[255 * 4]], [rgba[0], rgba[0]]);
+  });
+});
+
+describe("savedRasterSymbology", () => {
+  it("returns null when absent or malformed", () => {
+    assert.equal(savedRasterSymbology(layerWith(undefined)), null);
+    assert.equal(savedRasterSymbology(layerWith({ ramp: "viridis" })), null);
+    assert.equal(savedRasterSymbology(layerWith([1, 2, 3])), null);
+  });
+
+  it("validates and clamps a well-formed record", () => {
+    const result = savedRasterSymbology(
+      layerWith({
+        classified: true,
+        ramp: "plasma",
+        reversed: true,
+        method: "quantile",
+        classCount: 99,
+        // classCount clamps to 12, so breaks must have 13 edges.
+        breaks: Array.from({ length: 13 }, (_, index) => index),
+      }),
+    );
+    assert.ok(result);
+    assert.equal(result.classCount, 12);
+    assert.equal(result.method, "quantile");
+    assert.equal(result.reversed, true);
+  });
+
+  it("rejects non-ascending or wrong-length breaks", () => {
+    assert.equal(
+      savedRasterSymbology(
+        layerWith({
+          classified: true,
+          ramp: "viridis",
+          reversed: false,
+          method: "equal-interval",
+          classCount: 2,
+          breaks: [0, 50], // needs 3 edges
+        }),
+      ),
+      null,
+    );
+    assert.equal(
+      savedRasterSymbology(
+        layerWith({
+          classified: true,
+          ramp: "viridis",
+          reversed: false,
+          method: "equal-interval",
+          classCount: 2,
+          breaks: [0, 100, 50], // not ascending
+        }),
+      ),
+      null,
+    );
+  });
+});
+
+describe("defaultRasterSymbology", () => {
+  it("starts unclassified with correctly sized equal-interval edges", () => {
+    const symbology = defaultRasterSymbology("turbo", {
+      min: 0,
+      max: 10,
+      histogram: [],
+    });
+    assert.equal(symbology.classified, false);
+    assert.equal(symbology.ramp, "turbo");
+    assert.equal(symbology.breaks.length, symbology.classCount + 1);
+    assert.equal(symbology.breaks[0], 0);
+    assert.equal(symbology.breaks.at(-1), 10);
+  });
+});

--- a/tests/raster-symbology.test.ts
+++ b/tests/raster-symbology.test.ts
@@ -86,6 +86,11 @@ describe("computeRasterBreaks", () => {
     );
     assert.deepEqual(breaks, [0, 5, 10]);
   });
+
+  it("keeps fallback edges ascending when stats are absent and manual edges are unsorted", () => {
+    const breaks = computeRasterBreaks("manual", null, 2, [10, -5]);
+    assert.deepEqual(breaks, [-5, 2.5, 10]);
+  });
 });
 
 describe("buildSteppedColormapRgba", () => {


### PR DESCRIPTION
Closes #305.

## What

Adds proper **raster symbology** for `maplibre-gl-raster` COG layers, surfaced in the GeoLibre **Style panel** (previously these layers only exposed opacity):

- **Single-band pseudocolor** — pick a band, a color ramp, an optional discrete classification (equal-interval / quantile / manual breaks, 2–12 classes), min/max stretch, stretch curve, gamma, and NoData handling.
- **RGB composite** — choose band → R/G/B mapping for multiband COGs, with per-band stretch.
- **NoData / transparency** — auto (from file) / render-all / custom value.

## How it renders classification

The upstream `maplibre-gl-raster` render path applies pseudocolor by *named continuous colormap* + min/max stretch — it has no API for a discrete ramp. To add classification without reimplementing the pipeline, the LayerManager's private `_renderTileFor` is wrapped: for a classified single-band layer it builds the unchanged upstream pipeline (composite → nodata → rescale → stretch → colormap) and swaps **only the trailing `Colormap` module's texture** for a per-layer stepped 256×1 RGBA texture (built via the public `createColormapTexture` "bring your own" path, `colormapIndex: 0`). Nodata transparency and the rescale window therefore behave exactly as in the named-colormap path. The patch is feature-detected and guarded (`geolibreClassifiedPatched`), matching the existing `geolibre*Patched` monkey-patches, and applies in both interleaved and the Tauri/WebKit overlay modes.

## Reuse

Per the issue, the vector graduated-styling ramp + classification helpers (`VECTOR_COLOR_RAMPS`, `interpolateRampColors`, equal-interval / quantile breaks) are extracted to **`@geolibre/core` (`color-ramp.ts`)** and shared by both the vector and raster panels. Quantile breaks for rasters come from the band histogram (`computeAutoStats` / `percentileFromHistogram`), since per-pixel samples aren't available.

## Data model & persistence

- `metadata.rasterState` (unchanged, upstream-owned) round-trips through `setRasterState`.
- New GeoLibre-owned `metadata.rasterSymbology` (classified / ramp / reversed / method / classCount / breaks) is validated on load and **preserved** across the control→store metadata rebuild (it isn't on `RasterLayerInfo`).
- Band count + names are persisted to power the band / RGB pickers; the store→control sync now pushes edited `rasterState` fields.

## Tests & verification

- `tests/raster-symbology.test.ts` — break computation, histogram percentile, stepped-texture generation, validators (15 cases).
- `tests/raster-layer-sync.test.ts` — band-metadata persistence, symbology preservation across resync, rasterState-diff push with no echo.
- Full suite green (558 + new), `npm run typecheck` (tsc -b + vite build) passes, pre-commit (eslint + npm build) passes.
- **Verified end-to-end in a real browser** against the NLCD COG: load → Style panel → pseudocolor → viridis → classify → quantile → class-count → reverse, with zero console errors; the classified ramp visibly replaces the native palette.

## Notes

- `reversed` is scoped to classified mode (the continuous path hardcodes `reversed:false`).
- The committed e2e suite is intentionally hermetic (no network); a raster spec would require a remote COG, so rendering is covered by the manual browser verification above instead.
- StylePanel is not internationalized today (plain strings throughout); the new section matches that for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced raster symbology editor: RGB vs single-band controls, band selectors, color-ramp chooser, nodata, rescale/min-max, stretch/gamma, and discrete classification with editable class breaks and ramp reversal; lazy band-statistics and GPU-backed classified rendering with persisted symbology.
* **Core**
  * Added shared color-ramp utilities and public APIs for ramps, color interpolation, and break generation.
* **Integration**
  * Store/control sync now preserves persisted raster symbology and forwards only changed raster state keys.
* **Tests**
  * Added tests for raster sync and symbology utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->