### PR TITLE
fix(storymaps): present bundled story on load and fix nav rotation

### DIFF
--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -328,6 +328,10 @@ function normalizeProjectPreferences(preferences: unknown): ProjectPreferences {
         (map as Partial<ProjectPreferences["map"]>).renderWorldCopies,
         true,
       ),
+      projection:
+        (map as Partial<ProjectPreferences["map"]>).projection === "mercator"
+          ? "mercator"
+          : "globe",
     },
     environmentVariables: Array.isArray(candidate.environmentVariables)
       ? candidate.environmentVariables

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -160,7 +160,7 @@ export interface AppState {
   loadProject: (
     project: GeoLibreProject,
     path?: string | null,
-    options?: { rememberRecent?: boolean }
+    options?: { rememberRecent?: boolean; presenting?: boolean }
   ) => void;
   setProjectPath: (path: string | null) => void;
   setProjectName: (name: string) => void;
@@ -502,9 +502,10 @@ export const useAppStore = create<AppState>()(
         const applied = applyProjectToStore(project);
         // A project that ships a story map opens straight into the presentation
         // so the reader sees the story, not the editor. Projects without a story
-        // (or with an empty one) open normally.
+        // (or with an empty one) open normally. Callers that open a project for
+        // authoring rather than viewing can pass `presenting: false` to override.
         const presentStory =
-          (applied.storymap?.chapters.length ?? 0) > 0;
+          options.presenting ?? (applied.storymap?.chapters.length ?? 0) > 0;
         set((s) => ({
           ...applied,
           projectPath: path,

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -500,6 +500,11 @@ export const useAppStore = create<AppState>()(
 
       loadProject: (project, path = null, options = {}) => {
         const applied = applyProjectToStore(project);
+        // A project that ships a story map opens straight into the presentation
+        // so the reader sees the story, not the editor. Projects without a story
+        // (or with an empty one) open normally.
+        const presentStory =
+          (applied.storymap?.chapters.length ?? 0) > 0;
         set((s) => ({
           ...applied,
           projectPath: path,
@@ -508,8 +513,13 @@ export const useAppStore = create<AppState>()(
           selectedLayerId: applied.layers[0]?.id ?? null,
           selectedFeatureId: null,
           identifyLayerId: null,
-          // Don't carry an active story presentation into a different project.
-          ui: { ...s.ui, storymapPresenting: false, storymapPanelOpen: false },
+          // Present a bundled story on load; otherwise drop any presentation
+          // carried over from the previous project.
+          ui: {
+            ...s.ui,
+            storymapPresenting: presentStory,
+            storymapPanelOpen: false,
+          },
         }));
         clearHistory();
         if (path && options.rememberRecent !== false) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -210,6 +210,9 @@ export interface MapViewState {
   bbox?: [number, number, number, number];
 }
 
+/** Map projection the renderer uses. Mirrors the GlobeControl toggle. */
+export type MapProjection = "globe" | "mercator";
+
 export interface MapPreferences {
   restrictBounds: boolean;
   bounds: [number, number, number, number];
@@ -217,6 +220,7 @@ export interface MapPreferences {
   maxZoom: number;
   maxPitch: number;
   renderWorldCopies: boolean;
+  projection: MapProjection;
 }
 
 export interface RuntimeEnvironmentVariable {
@@ -259,6 +263,7 @@ export const DEFAULT_PROJECT_PREFERENCES: ProjectPreferences = {
     maxZoom: 24,
     maxPitch: 85,
     renderWorldCopies: true,
+    projection: "globe",
   },
   environmentVariables: [],
 };

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -635,11 +635,17 @@ export const MapCanvas = memo(function MapCanvas({
     // zoom (which also fires this event) leaves the stored preference unchanged.
     const updateProjection = () => {
       const projection = mc.readProjection();
-      const state = useAppStore.getState();
-      if (state.preferences.map.projection === projection) return;
-      state.setPreferences({
-        ...state.preferences,
-        map: { ...state.preferences.map, projection },
+      // Functional update so a concurrent preference change (zoom-limit edit,
+      // loadProject) between read and write is not clobbered by a stale snapshot.
+      useAppStore.setState((s) => {
+        if (s.preferences.map.projection === projection) return s;
+        return {
+          preferences: {
+            ...s.preferences,
+            map: { ...s.preferences.map, projection },
+          },
+          isDirty: true,
+        };
       });
     };
     map.on("projectiontransition", updateProjection);

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -625,8 +625,16 @@ export const MapCanvas = memo(function MapCanvas({
       onMapDiagnosticEventRef.current?.(mapErrorDiagnosticEvent(event));
     });
 
-    const updateView = (event?: { originalEvent?: unknown }) =>
+    const updateView = (event?: { originalEvent?: unknown }) => {
+      // While presenting a story map the presenter owns the camera. Syncing its
+      // transient chapter flies and rotations back into the store would both
+      // overwrite the saved project view and, worse, re-enter the applyView
+      // effect below: its jumpTo cancels an in-flight chapter fly, after which
+      // the rotate handler starts orbiting the previous chapter instead of the
+      // one just clicked. Skipping the sync keeps the presenter authoritative.
+      if (useAppStore.getState().ui.storymapPresenting) return;
       setMapView(mc.readView(), Boolean(event?.originalEvent));
+    };
     map.on("moveend", updateView);
 
     // Persist projection toggles (the GlobeControl) into project preferences so

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -628,6 +628,21 @@ export const MapCanvas = memo(function MapCanvas({
     const updateView = (event?: { originalEvent?: unknown }) =>
       setMapView(mc.readView(), Boolean(event?.originalEvent));
     map.on("moveend", updateView);
+
+    // Persist projection toggles (the GlobeControl) into project preferences so
+    // a project reopens with the projection it was saved in. getProjection()
+    // returns the configured type, so the internal globe→mercator switch at high
+    // zoom (which also fires this event) leaves the stored preference unchanged.
+    const updateProjection = () => {
+      const projection = mc.readProjection();
+      const state = useAppStore.getState();
+      if (state.preferences.map.projection === projection) return;
+      state.setPreferences({
+        ...state.preferences,
+        map: { ...state.preferences.map, projection },
+      });
+    };
+    map.on("projectiontransition", updateProjection);
     map.on("load", () => {
       mc.waitAndSyncLayers(useAppStore.getState().layers);
       mc.setBasemapVisible(useAppStore.getState().basemapVisible);

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -7,6 +7,7 @@ import {
 import type {
   GeoLibreLayer,
   MapPreferences,
+  MapProjection,
   MapViewState,
   StoryChapterAnimation,
   StoryChapterLocation,
@@ -268,7 +269,7 @@ export class MapController {
     // redundant jumpTo that can interrupt the initial camera.
     const handleStyleReady = () => {
       this.styleReady = true;
-      this.enforceDefaultProjection();
+      this.enforceProjection();
       this.addTerrainSource();
       this.applyBasemapVisibility();
       this.applyBasemapOpacity();
@@ -276,7 +277,7 @@ export class MapController {
     };
     this.map.on("style.load", handleStyleReady);
     this.map.once("load", handleStyleReady);
-    this.map.once("idle", () => this.enforceDefaultProjection());
+    this.map.once("idle", () => this.enforceProjection());
     this.addNavigationControl();
     this.addFullscreenControl();
     this.addGeolocateControl();
@@ -559,6 +560,9 @@ export class MapController {
     this.map.setMinZoom(minZoom);
     this.map.setMaxPitch(maxPitch);
     this.map.setRenderWorldCopies(preferences.renderWorldCopies);
+    // Reflect a changed projection preference (e.g. loading a project saved in
+    // mercator) onto the live map.
+    this.enforceProjection();
     this.map.setMaxBounds(mapBoundsForPreferences(preferences));
     this.map.setTransformConstrain(
       createMapTransformConstraint(preferences, this.map, minZoom, maxZoom),
@@ -807,13 +811,26 @@ export class MapController {
     this.syncHighlight(EMPTY_HIGHLIGHT);
   }
 
-  private enforceDefaultProjection(): void {
+  /** Current map projection, normalized to the two values we persist. */
+  readProjection(): MapProjection {
+    return this.map?.getProjection()?.type === "mercator"
+      ? "mercator"
+      : "globe";
+  }
+
+  /**
+   * Apply the projection from the active map preferences. Defaults to globe so
+   * projects saved before projection was persisted keep their previous look.
+   * Retries on the next idle if the style is not ready to accept it yet.
+   */
+  private enforceProjection(): void {
     if (!this.map) return;
+    const desired = this.mapPreferences.projection ?? DEFAULT_PROJECTION.type;
     try {
-      if (this.map.getProjection()?.type === DEFAULT_PROJECTION.type) return;
-      this.map.setProjection(DEFAULT_PROJECTION);
+      if (this.map.getProjection()?.type === desired) return;
+      this.map.setProjection({ type: desired });
     } catch {
-      this.map.once("idle", () => this.enforceDefaultProjection());
+      this.map.once("idle", () => this.enforceProjection());
     }
   }
 

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -380,20 +380,32 @@ export class MapController {
     // supersede an in-progress camera animation, and calling stop() immediately
     // before a new movement during rapid chapter changes can drop it entirely.
     const token = ++this.storyCameraToken;
-    map[animation]({
-      center: location.center,
-      zoom: location.zoom,
-      pitch: location.pitch,
-      bearing: location.bearing,
-    });
+    // Tag the movement so the rotate-on-settle handler can recognize *this*
+    // move's `moveend`. When flyTo/easeTo supersedes a prior chapter's in-flight
+    // rotation, MapLibre fires a deferred `moveend` for that halted rotation; an
+    // untagged `once("moveend")` would catch it and start rotating immediately,
+    // around the previous chapter's center, before the new camera has travelled.
+    map[animation](
+      {
+        center: location.center,
+        zoom: location.zoom,
+        pitch: location.pitch,
+        bearing: location.bearing,
+      },
+      { storyCameraToken: token },
+    );
     if (rotate) {
-      map.once("moveend", () => {
+      const onMoveEnd = (event: { storyCameraToken?: number }) => {
+        // Ignore the moveend of any other move (e.g. the halted prior rotation).
+        if (event?.storyCameraToken !== token) return;
+        map.off("moveend", onMoveEnd);
         if (this.storyCameraToken !== token || !this.map) return;
         this.map.rotateTo(this.map.getBearing() + 180, {
           duration: 30000,
           easing: (time) => time,
         });
-      });
+      };
+      map.on("moveend", onMoveEnd);
     }
   }
 

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -367,7 +367,7 @@ export class MapController {
    * instant move whose `moveend` precedes attachment.
    */
   private pendingRotateHandler:
-    | ((event: { storyCameraToken?: number }) => void)
+    | ((event: maplibregl.MapLibreEvent & { storyCameraToken?: number }) => void)
     | null = null;
 
   /**
@@ -406,6 +406,10 @@ export class MapController {
     // rotation, MapLibre fires a deferred `moveend` for that halted rotation; an
     // untagged `once("moveend")` would catch it and start rotating immediately,
     // around the previous chapter's center, before the new camera has travelled.
+    // MapLibre re-fires the original move's eventData on this deferred moveend
+    // (Camera._afterEase), so the token survives cancellation. The
+    // pendingRotateHandler cleanup above and in restoreLayerStyles is the
+    // backstop should that ever change, so handlers cannot leak regardless.
     map[animation](
       {
         center: location.center,
@@ -419,10 +423,10 @@ export class MapController {
       const onMoveEnd = (
         event: maplibregl.MapLibreEvent & { storyCameraToken?: number },
       ) => {
-        // Ignore the moveend of any other move (e.g. the halted prior rotation).
-        // Do NOT call map.off here: this listener must stay attached past the
-        // deferred moveend from the cancelled rotateTo (no storyCameraToken) so
-        // it can react to the subsequent flyTo's matching moveend.
+        // Only detach once the token matches. Stay attached through any
+        // preceding moveend (e.g. the deferred moveend of a halted prior
+        // rotateTo, which carries no storyCameraToken) so we can still react to
+        // this move's own matching moveend below.
         if (event.storyCameraToken !== token) return;
         map.off("moveend", onMoveEnd);
         if (this.pendingRotateHandler === onMoveEnd) {

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -335,6 +335,10 @@ export class MapController {
     // Invalidate any pending story rotation and halt an in-flight camera move so
     // a deferred rotateTo cannot fire after the presenter has exited.
     this.storyCameraToken++;
+    if (this.pendingRotateHandler) {
+      this.map?.off("moveend", this.pendingRotateHandler);
+      this.pendingRotateHandler = null;
+    }
     this.map?.stop();
     // Clear any opacity transitions left over from playback first, otherwise the
     // restored values animate back in (potentially over a multi-second fade).
@@ -356,6 +360,15 @@ export class MapController {
 
   /** Token guarding deferred story rotations against later chapter changes. */
   private storyCameraToken = 0;
+  /**
+   * The rotate-on-settle `moveend` listener currently awaiting its move, kept so
+   * it can be detached deterministically (on the next chapter or on presenter
+   * exit) instead of relying solely on self-removal, which never fires for an
+   * instant move whose `moveend` precedes attachment.
+   */
+  private pendingRotateHandler:
+    | ((event: { storyCameraToken?: number }) => void)
+    | null = null;
 
   /**
    * Move the camera to a story chapter view during presentation playback.
@@ -381,6 +394,13 @@ export class MapController {
     // supersede an in-progress camera animation, and calling stop() immediately
     // before a new movement during rapid chapter changes can drop it entirely.
     const token = ++this.storyCameraToken;
+    // Detach any rotate-on-settle listener still waiting on a superseded move so
+    // handlers can never accumulate across rapid chapter changes or a presenter
+    // exit. The matching listener for the new move is registered below.
+    if (this.pendingRotateHandler) {
+      map.off("moveend", this.pendingRotateHandler);
+      this.pendingRotateHandler = null;
+    }
     // Tag the movement so the rotate-on-settle handler can recognize *this*
     // move's `moveend`. When flyTo/easeTo supersedes a prior chapter's in-flight
     // rotation, MapLibre fires a deferred `moveend` for that halted rotation; an
@@ -405,12 +425,16 @@ export class MapController {
         // it can react to the subsequent flyTo's matching moveend.
         if (event.storyCameraToken !== token) return;
         map.off("moveend", onMoveEnd);
+        if (this.pendingRotateHandler === onMoveEnd) {
+          this.pendingRotateHandler = null;
+        }
         if (this.storyCameraToken !== token || !this.map) return;
         this.map.rotateTo(this.map.getBearing() + 180, {
           duration: 30000,
           easing: (time) => time,
         });
       };
+      this.pendingRotateHandler = onMoveEnd;
       map.on("moveend", onMoveEnd);
     }
   }

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -396,9 +396,14 @@ export class MapController {
       { storyCameraToken: token },
     );
     if (rotate) {
-      const onMoveEnd = (event: { storyCameraToken?: number }) => {
+      const onMoveEnd = (
+        event: maplibregl.MapLibreEvent & { storyCameraToken?: number },
+      ) => {
         // Ignore the moveend of any other move (e.g. the halted prior rotation).
-        if (event?.storyCameraToken !== token) return;
+        // Do NOT call map.off here: this listener must stay attached past the
+        // deferred moveend from the cancelled rotateTo (no storyCameraToken) so
+        // it can react to the subsequent flyTo's matching moveend.
+        if (event.storyCameraToken !== token) return;
         map.off("moveend", onMoveEnd);
         if (this.storyCameraToken !== token || !this.map) return;
         this.map.rotateTo(this.map.getBearing() + 180, {

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -477,6 +477,16 @@ describe("story maps", () => {
       useAppStore.getState().storymap?.chapters.map((c) => c.id),
       ["chapter-1", "chapter-2"],
     );
+    // A project that ships a story opens straight into the presentation.
+    assert.equal(useAppStore.getState().ui.storymapPresenting, true);
+  });
+
+  it("opens a story-less project without presenting", () => {
+    // Start with a presentation active to prove load clears it.
+    useAppStore.getState().setStorymapPresenting(true);
+    const empty = parseProject(serializeProject(createEmptyProject("Plain")));
+    useAppStore.getState().loadProject(empty);
+    assert.equal(useAppStore.getState().ui.storymapPresenting, false);
   });
 
   it("provides a sample story that survives normalization", () => {

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -521,6 +521,30 @@ describe("story maps", () => {
     assert.equal(useAppStore.getState().ui.storymapPresenting, false);
   });
 
+  it("honors the presenting:false override for a story project", () => {
+    const store = useAppStore.getState();
+    store.addStoryChapter(chapter() as never);
+    const storyProject = parseProject(
+      serializeProject(
+        projectFromStore({
+          projectName: useAppStore.getState().projectName,
+          mapView: useAppStore.getState().mapView,
+          basemapStyleUrl: useAppStore.getState().basemapStyleUrl,
+          basemapVisible: useAppStore.getState().basemapVisible,
+          basemapOpacity: useAppStore.getState().basemapOpacity,
+          layers: useAppStore.getState().layers,
+          preferences: useAppStore.getState().preferences,
+          plugins: useAppStore.getState().projectPlugins,
+          storymap: useAppStore.getState().storymap,
+          metadata: useAppStore.getState().metadata,
+        }),
+      ),
+    );
+    // A caller opening the story for authoring can opt out of auto-presenting.
+    useAppStore.getState().loadProject(storyProject, null, { presenting: false });
+    assert.equal(useAppStore.getState().ui.storymapPresenting, false);
+  });
+
   it("provides a sample story that survives normalization", () => {
     const sample = createSampleStoryMap();
     assert.equal(sample.chapters.length, 5);

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -89,6 +89,8 @@ describe("project parsing", () => {
     assert.equal(project.preferences.map.minZoom, 0);
     assert.equal(project.preferences.map.maxZoom, 18);
     assert.equal(project.preferences.map.renderWorldCopies, false);
+    // Projects saved before projection was persisted default to globe.
+    assert.equal(project.preferences.map.projection, "globe");
     assert.deepEqual(project.preferences.environmentVariables, [
       { key: "VALID_KEY", value: "1", enabled: true },
     ]);
@@ -103,6 +105,19 @@ describe("project parsing", () => {
     assert.deepEqual(project.plugins?.settings, {
       "maplibre-gl-swipe": { position: 50 },
     });
+  });
+
+  it("round-trips the map projection preference", () => {
+    const base = createEmptyProject("Projection");
+    const mercator = {
+      ...base,
+      preferences: {
+        ...base.preferences,
+        map: { ...base.preferences.map, projection: "mercator" as const },
+      },
+    };
+    const reloaded = parseProject(serializeProject(mercator));
+    assert.equal(reloaded.preferences.map.projection, "mercator");
   });
 
   it("normalizes a legend config, dropping malformed overrides", () => {

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, it } from "node:test";
 import {
   DEFAULT_BASEMAP,
   DEFAULT_LAYER_STYLE,
+  DEFAULT_STORY_MAP,
   createEmptyProject,
   createSampleStoryMap,
   parseProject,
@@ -501,6 +502,22 @@ describe("story maps", () => {
     useAppStore.getState().setStorymapPresenting(true);
     const empty = parseProject(serializeProject(createEmptyProject("Plain")));
     useAppStore.getState().loadProject(empty);
+    assert.equal(useAppStore.getState().ui.storymapPresenting, false);
+  });
+
+  it("does not present a story that has no chapters", () => {
+    useAppStore.getState().setStorymapPresenting(true);
+    // A settings-only story survives normalization as a non-null storymap with
+    // an empty chapters array, distinct from "no storymap at all".
+    const withEmptyStory = parseProject(
+      serializeProject({
+        ...createEmptyProject("Settings-only story"),
+        storymap: { ...DEFAULT_STORY_MAP, title: "No chapters" },
+      }),
+    );
+    assert.ok(withEmptyStory.storymap);
+    assert.equal(withEmptyStory.storymap?.chapters.length, 0);
+    useAppStore.getState().loadProject(withEmptyStory);
     assert.equal(useAppStore.getState().ui.storymapPresenting, false);
   });
 


### PR DESCRIPTION
## Summary
- Open a project straight into the story map presentation when it ships a story with chapters, instead of landing in the editor. Projects without a story still open normally; callers can pass `presenting: false` to opt out (e.g. opening for authoring).
- Fix nav-pane chapter clicks that sometimes rotated the map around the previous chapter. Root cause: a chapter `flyTo` internally stops a previous rotating chapter's `rotateTo`, firing a synchronous `moveend` that synced the camera into the store, whose `applyView` effect then `jumpTo`'d the map and cancelled the in-flight fly; the rotate handler then orbited the previous chapter. The camera-to-store sync is now skipped while a story is presenting (the presenter owns the camera), which breaks the feedback loop. This only triggered when leaving a chapter with rotation enabled.
- Harden the rotate-on-settle handler: each camera move is tagged so the handler reacts only to its own `moveend`, and the pending handler is tracked and detached deterministically so listeners cannot accumulate.
- Persist the map projection preference (globe/mercator): added to the project schema, applied on load, and synced from the GlobeControl toggle. Projects saved before this change default to globe.

## Test plan
- [x] `npm run typecheck` (full build) passes
- [x] Frontend test suite passes (projection defaults/persistence, present-on-load, story-less and empty-chapter cases, `presenting: false` override)
- [x] Verified in the real running app with Playwright: loaded the five-city sample, entered present mode, confirmed New York City (the rotating chapter) was actively orbiting, then clicked other chapters while it rotated. Each flew to the correct city, matching the chapter's known coordinates:
  - Tokyo -> `[139.692, 35.690]` (true `[139.6917, 35.6895]`)
  - Sydney -> `[151.209, -33.869]` (true `[151.2093, -33.8688]`)
  - San Francisco -> `[-122.419, 37.775]` (true `[-122.4194, 37.7749]`)
- [x] Projection: toggle to mercator, save, reopen, confirm it reopens in mercator