### PR TITLE
feat(layers): collapsible layer groups/folders in the layer panel (#311)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -596,6 +596,7 @@ export function TopToolbar({
       basemapVisible: state.basemapVisible,
       basemapOpacity: state.basemapOpacity,
       layers: state.layers,
+      layerGroups: state.layerGroups,
       preferences: state.preferences,
       plugins: {
         ...getPluginManager().getProjectState(),

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -8,11 +8,7 @@ import {
   useRef,
   useState,
 } from "react";
-import {
-  buildLayerTree,
-  isDuckDBQueryLayer,
-  useAppStore,
-} from "@geolibre/core";
+import { isDuckDBQueryLayer, useAppStore } from "@geolibre/core";
 import type { GeoLibreLayer, LayerGroup } from "@geolibre/core";
 import {
   canEditLayerGeometry,
@@ -233,6 +229,8 @@ export function LayerPanel({
   // reset in beginRename so a flag left set by a cancel whose blur never fired
   // cannot leak into the next rename session.
   const suppressBlurCommitRef = useRef(false);
+  // Same stray-blur guard as suppressBlurCommitRef, for the group rename input.
+  const suppressGroupBlurCommitRef = useRef(false);
   const refreshingLayerIdsRef = useRef(new Set<string>());
   const refreshTimersRef = useRef(new Map<string, LayerRefreshTimer>());
   const refreshStatusTimersRef = useRef(new Map<string, number>());
@@ -287,12 +285,21 @@ export function LayerPanel({
   };
 
   const beginGroupRename = (group: LayerGroup) => {
+    // Clear any flag left set by a prior cancel/commit whose blur never fired,
+    // so it cannot swallow the first commit of this rename session.
+    suppressGroupBlurCommitRef.current = false;
     setEditingGroupId(group.id);
     setEditingGroupName(group.name);
   };
 
   const commitGroupRename = () => {
-    if (!editingGroupId) return;
+    if (suppressGroupBlurCommitRef.current || !editingGroupId) {
+      suppressGroupBlurCommitRef.current = false;
+      return;
+    }
+    // Suppress the onBlur that fires when clearing editing state unmounts the
+    // input, so the edit is not committed a second time from the stale closure.
+    suppressGroupBlurCommitRef.current = true;
     const trimmed = editingGroupName.trim();
     const current = layerGroups.find((g) => g.id === editingGroupId);
     if (trimmed && current && trimmed !== current.name) {
@@ -303,6 +310,7 @@ export function LayerPanel({
   };
 
   const cancelGroupRename = () => {
+    suppressGroupBlurCommitRef.current = true;
     setEditingGroupId(null);
     setEditingGroupName("");
   };
@@ -733,6 +741,9 @@ export function LayerPanel({
 
   const renderGroupHeader = (group: LayerGroup) => {
     const isDropTarget = dropTargetGroupId === group.id;
+    // Empty folders have no members in the flat `layers` array, so
+    // reorderLayerGroup cannot move them; disable the reorder actions for them.
+    const canReorderGroup = firstMemberIdByGroup.has(group.id);
     return (
       <div
         data-group-header=""
@@ -847,6 +858,7 @@ export function LayerPanel({
                 Rename group
               </DropdownMenuItem>
               <DropdownMenuItem
+                disabled={!canReorderGroup}
                 onSelect={(e: Event) => {
                   e.preventDefault();
                   reorderLayerGroup(group.id, "up");
@@ -856,6 +868,7 @@ export function LayerPanel({
                 Move group up
               </DropdownMenuItem>
               <DropdownMenuItem
+                disabled={!canReorderGroup}
                 onSelect={(e: Event) => {
                   e.preventDefault();
                   reorderLayerGroup(group.id, "down");

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -769,7 +769,6 @@ export function LayerPanel({
         }`}
         onDragOver={(e) => handleGroupHeaderDragOver(e, group.id)}
         onDrop={(e) => handleGroupHeaderDrop(e, group.id)}
-        onDragEnd={resetDragState}
       >
         <div className="flex items-center gap-1">
           <button

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -5,9 +5,11 @@ import {
   Fragment,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
+import { useTranslation } from "react-i18next";
 import { isDuckDBQueryLayer, useAppStore } from "@geolibre/core";
 import type { GeoLibreLayer, LayerGroup } from "@geolibre/core";
 import {
@@ -169,6 +171,7 @@ export function LayerPanel({
   onCancelGeometryEdit,
   onMaterializeDuckDBLayer,
 }: LayerPanelProps) {
+  const { t } = useTranslation();
   const layers = useAppStore((s) => s.layers);
   const layerGroups = useAppStore((s) => s.layerGroups);
   const addLayerGroup = useAppStore((s) => s.addLayerGroup);
@@ -234,21 +237,29 @@ export function LayerPanel({
   const refreshingLayerIdsRef = useRef(new Set<string>());
   const refreshTimersRef = useRef(new Map<string, LayerRefreshTimer>());
   const refreshStatusTimersRef = useRef(new Map<string, number>());
-  const visibleLayers = [...layers].reverse();
+  const visibleLayers = useMemo(() => [...layers].reverse(), [layers]);
   // Group lookup + the top-most member of each group in display order. Members
   // are kept contiguous in `layers`, so the first occurrence walking the
-  // reversed list is where the group's header is drawn inline.
-  const groupById = new Map(layerGroups.map((g) => [g.id, g] as const));
-  const firstMemberIdByGroup = new Map<string, string>();
-  for (const layer of visibleLayers) {
-    if (layer.groupId && !firstMemberIdByGroup.has(layer.groupId)) {
-      firstMemberIdByGroup.set(layer.groupId, layer.id);
+  // reversed list is where the group's header is drawn inline. Memoized so they
+  // are not rebuilt on renders caused by unrelated state (hover, slider drag).
+  const groupById = useMemo(
+    () => new Map(layerGroups.map((g) => [g.id, g] as const)),
+    [layerGroups],
+  );
+  const firstMemberIdByGroup = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const layer of visibleLayers) {
+      if (layer.groupId && !map.has(layer.groupId)) {
+        map.set(layer.groupId, layer.id);
+      }
     }
-  }
+    return map;
+  }, [visibleLayers]);
   // Empty folders have no member to anchor them, so they render pinned at the
   // top of the panel where they are easy to drop layers into.
-  const emptyGroups = layerGroups.filter(
-    (g) => !firstMemberIdByGroup.has(g.id),
+  const emptyGroups = useMemo(
+    () => layerGroups.filter((g) => !firstMemberIdByGroup.has(g.id)),
+    [layerGroups, firstMemberIdByGroup],
   );
   const refreshSettingsLayer = refreshSettingsLayerId
     ? (layers.find((layer) => layer.id === refreshSettingsLayerId) ?? null)
@@ -687,6 +698,7 @@ export function LayerPanel({
     event.stopPropagation();
     event.dataTransfer.dropEffect = "move";
     setDropTargetLayerId(layerId);
+    setDropTargetGroupId(null);
   };
 
   const handleLayerDrop = (
@@ -723,6 +735,7 @@ export function LayerPanel({
     event.stopPropagation();
     event.dataTransfer.dropEffect = "move";
     setDropTargetGroupId(groupId);
+    setDropTargetLayerId(null);
   };
 
   const handleGroupHeaderDrop = (
@@ -762,8 +775,16 @@ export function LayerPanel({
           <button
             type="button"
             className="rounded p-0.5 text-muted-foreground hover:bg-muted"
-            title={group.collapsed ? "Expand group" : "Collapse group"}
-            aria-label={group.collapsed ? "Expand group" : "Collapse group"}
+            title={
+              group.collapsed
+                ? t("layers.expandGroup")
+                : t("layers.collapseGroup")
+            }
+            aria-label={
+              group.collapsed
+                ? t("layers.expandGroup")
+                : t("layers.collapseGroup")
+            }
             aria-expanded={!group.collapsed}
             onClick={(e) => {
               e.stopPropagation();
@@ -779,8 +800,10 @@ export function LayerPanel({
           <button
             type="button"
             className="rounded p-0.5 hover:bg-muted"
-            title={group.visible ? "Hide group" : "Show group"}
-            aria-label={group.visible ? "Hide group" : "Show group"}
+            title={group.visible ? t("layers.hideGroup") : t("layers.showGroup")}
+            aria-label={
+              group.visible ? t("layers.hideGroup") : t("layers.showGroup")
+            }
             onClick={(e) => {
               e.stopPropagation();
               setLayerGroupVisibility(group.id, !group.visible);
@@ -803,7 +826,7 @@ export function LayerPanel({
               type="text"
               className="flex-1 min-w-0 rounded border border-input bg-background px-1 py-0.5 text-sm font-semibold outline-none focus:ring-1 focus:ring-ring"
               value={editingGroupName}
-              aria-label={`Rename ${group.name}`}
+              aria-label={t("layers.renameNamed", { name: group.name })}
               onChange={(e) => setEditingGroupName(e.target.value)}
               onClick={(e: ReactMouseEvent) => e.stopPropagation()}
               onFocus={(e) => e.currentTarget.select()}
@@ -822,7 +845,7 @@ export function LayerPanel({
           ) : (
             <span
               className="flex-1 truncate text-sm font-semibold"
-              title="Double-click to rename"
+              title={t("layers.doubleClickToRename")}
               onDoubleClick={(e: ReactMouseEvent) => {
                 e.stopPropagation();
                 beginGroupRename(group);
@@ -837,8 +860,8 @@ export function LayerPanel({
                 variant="ghost"
                 size="icon"
                 className="h-7 w-7"
-                title="Group actions"
-                aria-label="Group actions"
+                title={t("layers.groupActions")}
+                aria-label={t("layers.groupActions")}
                 onClick={(e: ReactMouseEvent) => e.stopPropagation()}
               >
                 <MoreHorizontal className="h-3.5 w-3.5" />
@@ -855,7 +878,7 @@ export function LayerPanel({
                 }}
               >
                 <Pencil className="mr-2 h-3.5 w-3.5" />
-                Rename group
+                {t("layers.renameGroup")}
               </DropdownMenuItem>
               <DropdownMenuItem
                 disabled={!canReorderGroup}
@@ -865,7 +888,7 @@ export function LayerPanel({
                 }}
               >
                 <ChevronUp className="mr-2 h-3.5 w-3.5" />
-                Move group up
+                {t("layers.moveGroupUp")}
               </DropdownMenuItem>
               <DropdownMenuItem
                 disabled={!canReorderGroup}
@@ -875,7 +898,7 @@ export function LayerPanel({
                 }}
               >
                 <ChevronDown className="mr-2 h-3.5 w-3.5" />
-                Move group down
+                {t("layers.moveGroupDown")}
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem
@@ -885,7 +908,7 @@ export function LayerPanel({
                 }}
               >
                 <FolderMinus className="mr-2 h-3.5 w-3.5" />
-                Ungroup (keep layers)
+                {t("layers.ungroupKeepLayers")}
               </DropdownMenuItem>
               <DropdownMenuItem
                 className="text-destructive"
@@ -895,16 +918,18 @@ export function LayerPanel({
                 }}
               >
                 <Trash2 className="mr-2 h-3.5 w-3.5" />
-                Delete group and layers
+                {t("layers.deleteGroupAndLayers")}
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
         </div>
         {!group.collapsed && (
           <div className="mt-2 flex items-center gap-1">
-            <span className="text-[10px] text-muted-foreground">Opacity</span>
+            <span className="text-[10px] text-muted-foreground">
+              {t("layers.groupOpacity")}
+            </span>
             <Slider
-              aria-label={`${group.name} group opacity`}
+              aria-label={t("layers.groupOpacityAria", { name: group.name })}
               className="flex-1"
               min={0}
               max={1}
@@ -966,8 +991,8 @@ export function LayerPanel({
             variant="ghost"
             size="icon"
             className="h-7 w-7"
-            title="New group"
-            aria-label="New group"
+            title={t("layers.newGroup")}
+            aria-label={t("layers.newGroup")}
             onClick={handleCreateGroup}
           >
             <FolderPlus className="h-4 w-4" />
@@ -1336,13 +1361,13 @@ export function LayerPanel({
                         }}
                       >
                         <FolderPlus className="mr-2 h-3.5 w-3.5" />
-                        New group from layer
+                        {t("layers.newGroupFromLayer")}
                       </DropdownMenuItem>
                       {layerGroups.length > 0 && (
                         <DropdownMenuSub>
                           <DropdownMenuSubTrigger>
                             <Folder className="h-3.5 w-3.5" />
-                            Move to group
+                            {t("layers.moveToGroup")}
                           </DropdownMenuSubTrigger>
                           <DropdownMenuSubContent>
                             {layerGroups.map((g) => (
@@ -1368,7 +1393,7 @@ export function LayerPanel({
                           }}
                         >
                           <FolderMinus className="mr-2 h-3.5 w-3.5" />
-                          Remove from group
+                          {t("layers.removeFromGroup")}
                         </DropdownMenuItem>
                       )}
                       <DropdownMenuSeparator />

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -2,13 +2,18 @@ import {
   type DragEvent as ReactDragEvent,
   type MouseEvent as ReactMouseEvent,
   type RefObject,
+  Fragment,
   useCallback,
   useEffect,
   useRef,
   useState,
 } from "react";
-import { isDuckDBQueryLayer, useAppStore } from "@geolibre/core";
-import type { GeoLibreLayer } from "@geolibre/core";
+import {
+  buildLayerTree,
+  isDuckDBQueryLayer,
+  useAppStore,
+} from "@geolibre/core";
+import type { GeoLibreLayer, LayerGroup } from "@geolibre/core";
 import {
   canEditLayerGeometry,
   reloadVectorControlLayer,
@@ -39,10 +44,15 @@ import {
 } from "@geolibre/ui";
 import {
   ChevronDown,
+  ChevronRight,
   ChevronUp,
   Download,
   Eye,
   EyeOff,
+  Folder,
+  FolderMinus,
+  FolderOpen,
+  FolderPlus,
   GripVertical,
   Info,
   Layers,
@@ -164,6 +174,17 @@ export function LayerPanel({
   onMaterializeDuckDBLayer,
 }: LayerPanelProps) {
   const layers = useAppStore((s) => s.layers);
+  const layerGroups = useAppStore((s) => s.layerGroups);
+  const addLayerGroup = useAppStore((s) => s.addLayerGroup);
+  const removeLayerGroup = useAppStore((s) => s.removeLayerGroup);
+  const renameLayerGroup = useAppStore((s) => s.renameLayerGroup);
+  const setLayerGroupVisibility = useAppStore((s) => s.setLayerGroupVisibility);
+  const setLayerGroupOpacity = useAppStore((s) => s.setLayerGroupOpacity);
+  const toggleLayerGroupCollapsed = useAppStore(
+    (s) => s.toggleLayerGroupCollapsed,
+  );
+  const moveLayerToGroup = useAppStore((s) => s.moveLayerToGroup);
+  const reorderLayerGroup = useAppStore((s) => s.reorderLayerGroup);
   const selectedLayerId = useAppStore((s) => s.selectedLayerId);
   const selectLayer = useAppStore((s) => s.selectLayer);
   const identifyLayerId = useAppStore((s) => s.identifyLayerId);
@@ -199,6 +220,11 @@ export function LayerPanel({
   const [dropTargetLayerId, setDropTargetLayerId] = useState<string | null>(
     null,
   );
+  const [dropTargetGroupId, setDropTargetGroupId] = useState<string | null>(
+    null,
+  );
+  const [editingGroupId, setEditingGroupId] = useState<string | null>(null);
+  const [editingGroupName, setEditingGroupName] = useState("");
   // Ending a rename (commit or cancel) clears the editing state, which
   // unmounts the focused input. React then delivers that input's onBlur (the
   // browser's native blur on the removed element) to commitRename from the
@@ -211,6 +237,21 @@ export function LayerPanel({
   const refreshTimersRef = useRef(new Map<string, LayerRefreshTimer>());
   const refreshStatusTimersRef = useRef(new Map<string, number>());
   const visibleLayers = [...layers].reverse();
+  // Group lookup + the top-most member of each group in display order. Members
+  // are kept contiguous in `layers`, so the first occurrence walking the
+  // reversed list is where the group's header is drawn inline.
+  const groupById = new Map(layerGroups.map((g) => [g.id, g] as const));
+  const firstMemberIdByGroup = new Map<string, string>();
+  for (const layer of visibleLayers) {
+    if (layer.groupId && !firstMemberIdByGroup.has(layer.groupId)) {
+      firstMemberIdByGroup.set(layer.groupId, layer.id);
+    }
+  }
+  // Empty folders have no member to anchor them, so they render pinned at the
+  // top of the panel where they are easy to drop layers into.
+  const emptyGroups = layerGroups.filter(
+    (g) => !firstMemberIdByGroup.has(g.id),
+  );
   const refreshSettingsLayer = refreshSettingsLayerId
     ? (layers.find((layer) => layer.id === refreshSettingsLayerId) ?? null)
     : null;
@@ -242,6 +283,37 @@ export function LayerPanel({
   const resetDragState = () => {
     setDraggedLayerId(null);
     setDropTargetLayerId(null);
+    setDropTargetGroupId(null);
+  };
+
+  const beginGroupRename = (group: LayerGroup) => {
+    setEditingGroupId(group.id);
+    setEditingGroupName(group.name);
+  };
+
+  const commitGroupRename = () => {
+    if (!editingGroupId) return;
+    const trimmed = editingGroupName.trim();
+    const current = layerGroups.find((g) => g.id === editingGroupId);
+    if (trimmed && current && trimmed !== current.name) {
+      renameLayerGroup(editingGroupId, trimmed);
+    }
+    setEditingGroupId(null);
+    setEditingGroupName("");
+  };
+
+  const cancelGroupRename = () => {
+    setEditingGroupId(null);
+    setEditingGroupName("");
+  };
+
+  const handleCreateGroup = () => {
+    const id = addLayerGroup();
+    // Open the new (empty) folder's name for editing right away.
+    const group = useAppStore
+      .getState()
+      .layerGroups.find((g) => g.id === id);
+    if (group) beginGroupRename(group);
   };
 
   const beginRename = (layer: GeoLibreLayer) => {
@@ -620,8 +692,220 @@ export function LayerPanel({
     }
     event.preventDefault();
     event.stopPropagation();
-    moveLayer(draggedLayerId, layers.length - 1 - displayIndex);
+    const dragged = layers.find((l) => l.id === draggedLayerId);
+    const target = layers.find((l) => l.id === layerId);
+    const draggedGroupId = dragged?.groupId ?? null;
+    const targetGroupId = target?.groupId ?? null;
+    if (draggedGroupId === targetGroupId) {
+      // Same group (or both top-level): a plain reorder keeps contiguity.
+      moveLayer(draggedLayerId, layers.length - 1 - displayIndex);
+    } else {
+      // Crossing a group boundary: adopt the target's group and land next to it.
+      moveLayerToGroup(draggedLayerId, targetGroupId, layerId);
+    }
     resetDragState();
+  };
+
+  const handleGroupHeaderDragOver = (
+    event: ReactDragEvent<HTMLDivElement>,
+    groupId: string,
+  ) => {
+    if (!draggedLayerId) return;
+    event.preventDefault();
+    event.stopPropagation();
+    event.dataTransfer.dropEffect = "move";
+    setDropTargetGroupId(groupId);
+  };
+
+  const handleGroupHeaderDrop = (
+    event: ReactDragEvent<HTMLDivElement>,
+    groupId: string,
+  ) => {
+    if (!draggedLayerId) {
+      resetDragState();
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    moveLayerToGroup(draggedLayerId, groupId);
+    resetDragState();
+  };
+
+  const renderGroupHeader = (group: LayerGroup) => {
+    const isDropTarget = dropTargetGroupId === group.id;
+    return (
+      <div
+        data-group-header=""
+        data-testid="layer-group-header"
+        data-group-name={group.name}
+        className={`rounded-md border p-2 transition-colors ${
+          isDropTarget
+            ? "border-primary bg-primary/10"
+            : "border-border bg-muted/30 hover:border-muted-foreground/40"
+        }`}
+        onDragOver={(e) => handleGroupHeaderDragOver(e, group.id)}
+        onDrop={(e) => handleGroupHeaderDrop(e, group.id)}
+        onDragEnd={resetDragState}
+      >
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            className="rounded p-0.5 text-muted-foreground hover:bg-muted"
+            title={group.collapsed ? "Expand group" : "Collapse group"}
+            aria-label={group.collapsed ? "Expand group" : "Collapse group"}
+            aria-expanded={!group.collapsed}
+            onClick={(e) => {
+              e.stopPropagation();
+              toggleLayerGroupCollapsed(group.id);
+            }}
+          >
+            {group.collapsed ? (
+              <ChevronRight className="h-3.5 w-3.5" />
+            ) : (
+              <ChevronDown className="h-3.5 w-3.5" />
+            )}
+          </button>
+          <button
+            type="button"
+            className="rounded p-0.5 hover:bg-muted"
+            title={group.visible ? "Hide group" : "Show group"}
+            aria-label={group.visible ? "Hide group" : "Show group"}
+            onClick={(e) => {
+              e.stopPropagation();
+              setLayerGroupVisibility(group.id, !group.visible);
+            }}
+          >
+            {group.visible ? (
+              <Eye className="h-3.5 w-3.5" />
+            ) : (
+              <EyeOff className="h-3.5 w-3.5 text-muted-foreground" />
+            )}
+          </button>
+          {group.collapsed ? (
+            <Folder className="h-3.5 w-3.5 text-muted-foreground" />
+          ) : (
+            <FolderOpen className="h-3.5 w-3.5 text-muted-foreground" />
+          )}
+          {editingGroupId === group.id ? (
+            <input
+              autoFocus
+              type="text"
+              className="flex-1 min-w-0 rounded border border-input bg-background px-1 py-0.5 text-sm font-semibold outline-none focus:ring-1 focus:ring-ring"
+              value={editingGroupName}
+              aria-label={`Rename ${group.name}`}
+              onChange={(e) => setEditingGroupName(e.target.value)}
+              onClick={(e: ReactMouseEvent) => e.stopPropagation()}
+              onFocus={(e) => e.currentTarget.select()}
+              onBlur={commitGroupRename}
+              onKeyDown={(e) => {
+                e.stopPropagation();
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  commitGroupRename();
+                } else if (e.key === "Escape") {
+                  e.preventDefault();
+                  cancelGroupRename();
+                }
+              }}
+            />
+          ) : (
+            <span
+              className="flex-1 truncate text-sm font-semibold"
+              title="Double-click to rename"
+              onDoubleClick={(e: ReactMouseEvent) => {
+                e.stopPropagation();
+                beginGroupRename(group);
+              }}
+            >
+              {group.name}
+            </span>
+          )}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7"
+                title="Group actions"
+                aria-label="Group actions"
+                onClick={(e: ReactMouseEvent) => e.stopPropagation()}
+              >
+                <MoreHorizontal className="h-3.5 w-3.5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="end"
+              onClick={(e: ReactMouseEvent) => e.stopPropagation()}
+            >
+              <DropdownMenuItem
+                onSelect={(e: Event) => {
+                  e.preventDefault();
+                  beginGroupRename(group);
+                }}
+              >
+                <Pencil className="mr-2 h-3.5 w-3.5" />
+                Rename group
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onSelect={(e: Event) => {
+                  e.preventDefault();
+                  reorderLayerGroup(group.id, "up");
+                }}
+              >
+                <ChevronUp className="mr-2 h-3.5 w-3.5" />
+                Move group up
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onSelect={(e: Event) => {
+                  e.preventDefault();
+                  reorderLayerGroup(group.id, "down");
+                }}
+              >
+                <ChevronDown className="mr-2 h-3.5 w-3.5" />
+                Move group down
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onSelect={(e: Event) => {
+                  e.preventDefault();
+                  removeLayerGroup(group.id);
+                }}
+              >
+                <FolderMinus className="mr-2 h-3.5 w-3.5" />
+                Ungroup (keep layers)
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="text-destructive"
+                onSelect={(e: Event) => {
+                  e.preventDefault();
+                  removeLayerGroup(group.id, { removeChildren: true });
+                }}
+              >
+                <Trash2 className="mr-2 h-3.5 w-3.5" />
+                Delete group and layers
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+        {!group.collapsed && (
+          <div className="mt-2 flex items-center gap-1">
+            <span className="text-[10px] text-muted-foreground">Opacity</span>
+            <Slider
+              aria-label={`${group.name} group opacity`}
+              className="flex-1"
+              min={0}
+              max={1}
+              step={0.05}
+              value={[group.opacity]}
+              onValueChange={([v]: number[]) =>
+                setLayerGroupOpacity(group.id, v ?? group.opacity)
+              }
+              onClick={(e: ReactMouseEvent) => e.stopPropagation()}
+            />
+          </div>
+        )}
+      </div>
+    );
   };
 
   if (isCollapsed) {
@@ -669,6 +953,16 @@ export function LayerPanel({
             variant="ghost"
             size="icon"
             className="h-7 w-7"
+            title="New group"
+            aria-label="New group"
+            onClick={handleCreateGroup}
+          >
+            <FolderPlus className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
             title={allLayersVisible ? "Hide all layers" : "Show all layers"}
             aria-label={
               allLayersVisible ? "Hide all layers" : "Show all layers"
@@ -700,7 +994,17 @@ export function LayerPanel({
               No data layers. Add data from the toolbar.
             </p>
           )}
+          {emptyGroups.map((group) => (
+            <Fragment key={group.id}>{renderGroupHeader(group)}</Fragment>
+          ))}
           {visibleLayers.map((layer, displayIndex) => {
+            const group = layer.groupId
+              ? groupById.get(layer.groupId)
+              : undefined;
+            const isFirstOfGroup = group
+              ? firstMemberIdByGroup.get(group.id) === layer.id
+              : false;
+            const groupCollapsed = group?.collapsed ?? false;
             const canIdentify =
               layer.type === "geojson" ||
               isDuckDBQueryLayer(layer) ||
@@ -736,8 +1040,10 @@ export function LayerPanel({
             const refreshStatus = refreshStatuses[layer.id];
             const isRefreshing = refreshStatus?.type === "refreshing";
             return (
+              <Fragment key={layer.id}>
+                {isFirstOfGroup && group && renderGroupHeader(group)}
+                {!groupCollapsed && (
               <div
-                key={layer.id}
                 data-layer-card=""
                 data-testid="layer-row"
                 data-layer-name={layer.name}
@@ -745,7 +1051,9 @@ export function LayerPanel({
                   selectedLayerId === layer.id
                     ? "border-primary bg-primary/5"
                     : "border-border bg-background hover:border-muted-foreground/40 hover:bg-muted/20"
-                } ${draggedLayerId === layer.id ? "opacity-50" : ""}`}
+                } ${draggedLayerId === layer.id ? "opacity-50" : ""} ${
+                  group ? "ml-4" : ""
+                }`}
                 onDragOver={(e) => handleLayerDragOver(e, layer.id)}
                 onDrop={(e) => handleLayerDrop(e, layer.id, displayIndex)}
                 onDragEnd={resetDragState}
@@ -1008,6 +1316,49 @@ export function LayerPanel({
                         Rename
                       </DropdownMenuItem>
                       <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        onSelect={(e: Event) => {
+                          e.preventDefault();
+                          addLayerGroup(undefined, [layer.id]);
+                        }}
+                      >
+                        <FolderPlus className="mr-2 h-3.5 w-3.5" />
+                        New group from layer
+                      </DropdownMenuItem>
+                      {layerGroups.length > 0 && (
+                        <DropdownMenuSub>
+                          <DropdownMenuSubTrigger>
+                            <Folder className="h-3.5 w-3.5" />
+                            Move to group
+                          </DropdownMenuSubTrigger>
+                          <DropdownMenuSubContent>
+                            {layerGroups.map((g) => (
+                              <DropdownMenuItem
+                                key={g.id}
+                                disabled={layer.groupId === g.id}
+                                onSelect={(e: Event) => {
+                                  e.preventDefault();
+                                  moveLayerToGroup(layer.id, g.id);
+                                }}
+                              >
+                                {g.name}
+                              </DropdownMenuItem>
+                            ))}
+                          </DropdownMenuSubContent>
+                        </DropdownMenuSub>
+                      )}
+                      {layer.groupId && (
+                        <DropdownMenuItem
+                          onSelect={(e: Event) => {
+                            e.preventDefault();
+                            moveLayerToGroup(layer.id, null);
+                          }}
+                        >
+                          <FolderMinus className="mr-2 h-3.5 w-3.5" />
+                          Remove from group
+                        </DropdownMenuItem>
+                      )}
+                      <DropdownMenuSeparator />
                       {canMaterializeDuckDB && (
                         <>
                           <DropdownMenuItem
@@ -1164,6 +1515,8 @@ export function LayerPanel({
                   </Button>
                 </div>
               </div>
+                )}
+              </Fragment>
             );
           })}
           <div

--- a/apps/geolibre-desktop/src/hooks/useEmbedBridge.ts
+++ b/apps/geolibre-desktop/src/hooks/useEmbedBridge.ts
@@ -121,6 +121,7 @@ export function useEmbedBridge(
         basemapVisible: state.basemapVisible,
         basemapOpacity: state.basemapOpacity,
         layers: state.layers,
+        layerGroups: state.layerGroups,
         preferences: state.preferences,
         plugins: {
           ...getPluginManager().getProjectState(),

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -453,5 +453,25 @@
     "exportData": "Export",
     "exportJson": "Export JSON",
     "exportCsv": "Export CSV"
+  },
+  "layers": {
+    "newGroup": "New group",
+    "collapseGroup": "Collapse group",
+    "expandGroup": "Expand group",
+    "hideGroup": "Hide group",
+    "showGroup": "Show group",
+    "renameGroup": "Rename group",
+    "moveGroupUp": "Move group up",
+    "moveGroupDown": "Move group down",
+    "ungroupKeepLayers": "Ungroup (keep layers)",
+    "deleteGroupAndLayers": "Delete group and layers",
+    "groupActions": "Group actions",
+    "groupOpacity": "Opacity",
+    "groupOpacityAria": "{{name}} group opacity",
+    "doubleClickToRename": "Double-click to rename",
+    "renameNamed": "Rename {{name}}",
+    "newGroupFromLayer": "New group from layer",
+    "moveToGroup": "Move to group",
+    "removeFromGroup": "Remove from group"
   }
 }

--- a/e2e/layer-groups.spec.ts
+++ b/e2e/layer-groups.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test, type Page } from "@playwright/test";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const FIXTURE_PATH = join(__dirname, "fixtures", "smoke.geojson");
+const FIXTURE_TEXT = readFileSync(FIXTURE_PATH, "utf8");
+
+/** Waits for MapLibre to mount its WebGL canvas — the app's "map ready" signal. */
+async function waitForMap(page: Page): Promise<void> {
+  await page.goto("/");
+  await expect(page.getByTestId("map-canvas")).toBeVisible();
+  await expect(page.locator(".maplibregl-canvas")).toBeVisible({
+    timeout: 30_000,
+  });
+}
+
+/** Drops a GeoJSON file onto the map, exercising the real drag-and-drop path. */
+async function dropGeoJson(
+  page: Page,
+  name: string,
+  text: string,
+): Promise<void> {
+  const dataTransfer = await page.evaluateHandle(
+    ({ contents, fileName }) => {
+      const dt = new DataTransfer();
+      dt.items.add(
+        new File([contents], fileName, { type: "application/geo+json" }),
+      );
+      return dt;
+    },
+    { contents: text, fileName: `${name}.geojson` },
+  );
+  for (const type of ["dragenter", "dragover", "drop"]) {
+    await page.dispatchEvent('[data-testid="map-canvas"]', type, {
+      dataTransfer,
+    });
+  }
+  await dataTransfer.dispose();
+  await expect(
+    page.locator(`[data-testid="layer-row"][data-layer-name="${name}"]`),
+  ).toBeVisible();
+}
+
+/**
+ * Verifies issue #311: a layer can be placed in a folder, the group's
+ * collapse/visibility controls work, and the group structure survives a
+ * save -> reload -> reopen round trip (group + each child's `groupId` are
+ * serialized into the `.geolibre.json` project).
+ */
+test("groups a layer and persists the folder across save and reopen", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    delete (window as unknown as Record<string, unknown>).showSaveFilePicker;
+    delete (window as unknown as Record<string, unknown>).showOpenFilePicker;
+  });
+
+  await waitForMap(page);
+
+  // 1. Add a layer, then group it from the layer's actions menu.
+  await dropGeoJson(page, "smoke", FIXTURE_TEXT);
+  const row = page.locator(
+    '[data-testid="layer-row"][data-layer-name="smoke"]',
+  );
+  await row.locator('button[aria-label="Layer actions"]').click();
+  await page.getByRole("menuitem", { name: "New group from layer" }).click();
+  await page.keyboard.press("Escape"); // close the actions menu
+
+  const header = page.getByTestId("layer-group-header").first();
+  await expect(header).toBeVisible();
+
+  // 2. Collapsing the group hides its child layer; expanding restores it.
+  await header.locator('button[aria-label="Collapse group"]').click();
+  await expect(row).toBeHidden();
+  await header.locator('button[aria-label="Expand group"]').click();
+  await expect(row).toBeVisible();
+
+  // 3. Save the project and assert the group + membership are serialized.
+  const downloadPromise = page.waitForEvent("download");
+  await page.getByRole("button", { name: "Project" }).click();
+  await page.getByRole("menuitem", { name: "Save", exact: true }).click();
+  const download = await downloadPromise;
+  const stream = await download.createReadStream();
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) chunks.push(Buffer.from(chunk));
+  const saved = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+    layers?: { groupId?: string }[];
+    layerGroups?: { id: string }[];
+  };
+  expect(saved.layerGroups?.length).toBe(1);
+  const groupId = saved.layerGroups?.[0]?.id;
+  expect(groupId).toBeTruthy();
+  expect(saved.layers?.[0]?.groupId).toBe(groupId);
+
+  const dir = await mkdtemp(join(tmpdir(), "geolibre-groups-"));
+  const savedPath = join(dir, "groups.geolibre.json");
+  await writeFile(savedPath, Buffer.concat(chunks));
+
+  // 4. Reload to a fresh store, reopen the project, and confirm the folder is
+  //    rebuilt with the layer still nested inside it.
+  await waitForMap(page);
+  const chooserPromise = page.waitForEvent("filechooser");
+  await page.getByRole("button", { name: "Project" }).click();
+  await page.getByRole("menuitem", { name: "Open From" }).click();
+  await page.getByRole("menuitem", { name: "File..." }).click();
+  const chooser = await chooserPromise;
+  await chooser.setFiles(savedPath);
+
+  await expect(page.getByTestId("layer-group-header").first()).toBeVisible();
+  await expect(
+    page.locator('[data-testid="layer-row"][data-layer-name="smoke"]'),
+  ).toBeVisible();
+});

--- a/e2e/layer-groups.spec.ts
+++ b/e2e/layer-groups.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, type Page } from "@playwright/test";
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -95,21 +95,25 @@ test("groups a layer and persists the folder across save and reopen", async ({
   expect(saved.layers?.[0]?.groupId).toBe(groupId);
 
   const dir = await mkdtemp(join(tmpdir(), "geolibre-groups-"));
-  const savedPath = join(dir, "groups.geolibre.json");
-  await writeFile(savedPath, Buffer.concat(chunks));
+  try {
+    const savedPath = join(dir, "groups.geolibre.json");
+    await writeFile(savedPath, Buffer.concat(chunks));
 
-  // 4. Reload to a fresh store, reopen the project, and confirm the folder is
-  //    rebuilt with the layer still nested inside it.
-  await waitForMap(page);
-  const chooserPromise = page.waitForEvent("filechooser");
-  await page.getByRole("button", { name: "Project" }).click();
-  await page.getByRole("menuitem", { name: "Open From" }).click();
-  await page.getByRole("menuitem", { name: "File..." }).click();
-  const chooser = await chooserPromise;
-  await chooser.setFiles(savedPath);
+    // 4. Reload to a fresh store, reopen the project, and confirm the folder is
+    //    rebuilt with the layer still nested inside it.
+    await waitForMap(page);
+    const chooserPromise = page.waitForEvent("filechooser");
+    await page.getByRole("button", { name: "Project" }).click();
+    await page.getByRole("menuitem", { name: "Open From" }).click();
+    await page.getByRole("menuitem", { name: "File..." }).click();
+    const chooser = await chooserPromise;
+    await chooser.setFiles(savedPath);
 
-  await expect(page.getByTestId("layer-group-header").first()).toBeVisible();
-  await expect(
-    page.locator('[data-testid="layer-row"][data-layer-name="smoke"]'),
-  ).toBeVisible();
+    await expect(page.getByTestId("layer-group-header").first()).toBeVisible();
+    await expect(
+      page.locator('[data-testid="layer-row"][data-layer-name="smoke"]'),
+    ).toBeVisible();
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./types";
 export * from "./vector-color";
 export * from "./project";
+export * from "./layer-groups";
 export { createSampleStoryMap } from "./storymap-sample";
 export {
   serializeStoryMapJson,

--- a/packages/core/src/layer-groups.ts
+++ b/packages/core/src/layer-groups.ts
@@ -119,7 +119,8 @@ export function groupMemberIndices(
  * Reorder `layers` so that every group's members form a single contiguous block,
  * preserving the relative order of layers within each group and of the
  * top-level items. The block for a group is anchored at the position of its
- * current top-most (last) member, matching how {@link buildLayerTree} places it.
+ * current bottom-most (first) member — the first member encountered iterating
+ * from index 0, which renders at the bottom of the layer panel.
  *
  * Mutating store actions call this after assigning `groupId`s to restore the
  * contiguity invariant the rest of the system relies on.

--- a/packages/core/src/layer-groups.ts
+++ b/packages/core/src/layer-groups.ts
@@ -1,0 +1,154 @@
+import type { GeoLibreLayer, LayerGroup } from "./types";
+
+/** Opacity a freshly created {@link LayerGroup} starts at (fully opaque). */
+export const DEFAULT_LAYER_GROUP_OPACITY = 1;
+
+/**
+ * One row in the layer panel: either a top-level (ungrouped) layer or a group
+ * header together with its child layers.
+ */
+export type LayerTreeItem =
+  | { kind: "layer"; layer: GeoLibreLayer }
+  | { kind: "group"; group: LayerGroup; children: GeoLibreLayer[] };
+
+/**
+ * Derive the layer-panel tree from the flat `layers` array and the group
+ * definitions.
+ *
+ * Items are returned **top-of-panel first** (the reverse of the store's
+ * render order, where the last array element draws on top). Within a group the
+ * children are likewise ordered top-first. Each group is emitted once, at the
+ * panel position of its top-most member; a group's members are normally
+ * contiguous in the array, but if they are not, every member is still gathered
+ * under a single header. Groups with no members (empty folders) are emitted at
+ * the very top of the panel, in `groups` order, ready to receive drops.
+ *
+ * A `groupId` that does not match any group is treated as ungrouped, so a
+ * dangling reference degrades gracefully instead of dropping the layer.
+ *
+ * @param layers Flat layer list in store (render) order.
+ * @param groups Group definitions.
+ * @returns Panel rows in top-to-bottom display order.
+ */
+export function buildLayerTree(
+  layers: GeoLibreLayer[],
+  groups: LayerGroup[],
+): LayerTreeItem[] {
+  const groupById = new Map(groups.map((g) => [g.id, g]));
+  const display = [...layers].reverse();
+
+  const items: LayerTreeItem[] = [];
+  const emitted = new Set<string>();
+  const nonEmpty = new Set<string>();
+
+  for (const layer of display) {
+    const group = layer.groupId ? groupById.get(layer.groupId) : undefined;
+    if (!group) {
+      items.push({ kind: "layer", layer });
+      continue;
+    }
+    nonEmpty.add(group.id);
+    if (emitted.has(group.id)) continue;
+    emitted.add(group.id);
+    const children = display.filter((l) => l.groupId === group.id);
+    items.push({ kind: "group", group, children });
+  }
+
+  const emptyGroups = groups.filter((g) => !nonEmpty.has(g.id));
+  if (emptyGroups.length === 0) return items;
+  return [
+    ...emptyGroups.map((group) => ({
+      kind: "group" as const,
+      group,
+      children: [] as GeoLibreLayer[],
+    })),
+    ...items,
+  ];
+}
+
+/**
+ * Fold each group's visibility and opacity into its child layers so the map
+ * sync can keep treating every layer independently.
+ *
+ * A child's effective visibility is its own `visible` ANDed with the group's,
+ * and its effective opacity is its own multiplied by the group's. Layers
+ * without a group (or with a dangling `groupId`) are returned unchanged, and
+ * the original object reference is preserved whenever nothing changes so
+ * downstream memoization stays cheap.
+ *
+ * @param layers Flat layer list.
+ * @param groups Group definitions.
+ * @returns Layers with group effects applied.
+ */
+export function applyGroupEffects(
+  layers: GeoLibreLayer[],
+  groups: LayerGroup[],
+): GeoLibreLayer[] {
+  if (groups.length === 0) return layers;
+  const groupById = new Map(groups.map((g) => [g.id, g]));
+  return layers.map((layer) => {
+    if (!layer.groupId) return layer;
+    const group = groupById.get(layer.groupId);
+    if (!group) return layer;
+    const visible = layer.visible && group.visible;
+    const opacity = layer.opacity * group.opacity;
+    if (visible === layer.visible && opacity === layer.opacity) return layer;
+    return { ...layer, visible, opacity };
+  });
+}
+
+/**
+ * Indices, in store order, of every layer that belongs to `groupId`.
+ *
+ * @param layers Flat layer list.
+ * @param groupId Group whose members to locate.
+ * @returns Ascending list of member indices (empty when the group has none).
+ */
+export function groupMemberIndices(
+  layers: GeoLibreLayer[],
+  groupId: string,
+): number[] {
+  const indices: number[] = [];
+  for (let i = 0; i < layers.length; i++) {
+    if (layers[i]?.groupId === groupId) indices.push(i);
+  }
+  return indices;
+}
+
+/**
+ * Reorder `layers` so that every group's members form a single contiguous block,
+ * preserving the relative order of layers within each group and of the
+ * top-level items. The block for a group is anchored at the position of its
+ * current top-most (last) member, matching how {@link buildLayerTree} places it.
+ *
+ * Mutating store actions call this after assigning `groupId`s to restore the
+ * contiguity invariant the rest of the system relies on.
+ *
+ * @param layers Flat layer list, possibly with interleaved group members.
+ * @returns A new array with grouped layers made contiguous.
+ */
+export function normalizeGroupContiguity(
+  layers: GeoLibreLayer[],
+): GeoLibreLayer[] {
+  const result: GeoLibreLayer[] = [];
+  const placed = new Set<string>();
+  for (let i = 0; i < layers.length; i++) {
+    const layer = layers[i];
+    if (placed.has(layer.id)) continue;
+    if (!layer.groupId) {
+      result.push(layer);
+      placed.add(layer.id);
+      continue;
+    }
+    // Pull in every remaining member of this group, in array order, so the
+    // block is anchored at the first member encountered.
+    for (let j = i; j < layers.length; j++) {
+      const candidate = layers[j];
+      if (candidate.groupId === layer.groupId && !placed.has(candidate.id)) {
+        result.push(candidate);
+        placed.add(candidate.id);
+      }
+    }
+  }
+  return result;
+}

--- a/packages/core/src/layer-groups.ts
+++ b/packages/core/src/layer-groups.ts
@@ -37,9 +37,18 @@ export function buildLayerTree(
   const groupById = new Map(groups.map((g) => [g.id, g]));
   const display = [...layers].reverse();
 
+  // Bucket every layer's children by group id in a single pass so emitting a
+  // group is an O(1) lookup rather than a per-group filter over `display`.
+  const childrenByGroupId = new Map<string, GeoLibreLayer[]>();
+  for (const layer of display) {
+    if (!layer.groupId || !groupById.has(layer.groupId)) continue;
+    const bucket = childrenByGroupId.get(layer.groupId);
+    if (bucket) bucket.push(layer);
+    else childrenByGroupId.set(layer.groupId, [layer]);
+  }
+
   const items: LayerTreeItem[] = [];
   const emitted = new Set<string>();
-  const nonEmpty = new Set<string>();
 
   for (const layer of display) {
     const group = layer.groupId ? groupById.get(layer.groupId) : undefined;
@@ -47,14 +56,16 @@ export function buildLayerTree(
       items.push({ kind: "layer", layer });
       continue;
     }
-    nonEmpty.add(group.id);
     if (emitted.has(group.id)) continue;
     emitted.add(group.id);
-    const children = display.filter((l) => l.groupId === group.id);
-    items.push({ kind: "group", group, children });
+    items.push({
+      kind: "group",
+      group,
+      children: childrenByGroupId.get(group.id) ?? [],
+    });
   }
 
-  const emptyGroups = groups.filter((g) => !nonEmpty.has(g.id));
+  const emptyGroups = groups.filter((g) => !childrenByGroupId.has(g.id));
   if (emptyGroups.length === 0) return items;
   return [
     ...emptyGroups.map((group) => ({

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -7,6 +7,7 @@ import {
   PROJECT_VERSION,
   type GeoLibreLayer,
   type GeoLibreProject,
+  type LayerGroup,
   type LayerStyle,
   type LegendConfig,
   type LegendItemOverride,
@@ -22,6 +23,7 @@ import {
   type StoryLayerOpacityChange,
   type StoryMap,
 } from "./types";
+import { DEFAULT_LAYER_GROUP_OPACITY } from "./layer-groups";
 
 /** Placeholder name a project carries before the user names it. */
 export const DEFAULT_PROJECT_NAME = "Untitled Project";
@@ -52,6 +54,7 @@ export function createEmptyProject(
     basemapVisible: true,
     basemapOpacity: 1,
     layers: [],
+    layerGroups: [],
     styles: {},
     preferences: DEFAULT_PROJECT_PREFERENCES,
     legend: { ...DEFAULT_LEGEND_CONFIG },
@@ -68,6 +71,15 @@ export function parseProject(json: string): GeoLibreProject {
   if (!data.version || !data.name || !data.mapView) {
     throw new Error("Invalid GeoLibre project: missing required fields");
   }
+  const layerGroups = normalizeLayerGroups(data.layerGroups);
+  const validGroupIds = new Set(layerGroups.map((g) => g.id));
+  const layers = (data.layers ?? [])
+    .map(normalizeLayer)
+    .map((layer) =>
+      layer.groupId && !validGroupIds.has(layer.groupId)
+        ? { ...layer, groupId: undefined }
+        : layer,
+    );
   return {
     version: data.version,
     name: data.name,
@@ -75,7 +87,8 @@ export function parseProject(json: string): GeoLibreProject {
     basemapStyleUrl: data.basemapStyleUrl ?? DEFAULT_BASEMAP,
     basemapVisible: data.basemapVisible ?? true,
     basemapOpacity: data.basemapOpacity ?? 1,
-    layers: (data.layers ?? []).map(normalizeLayer),
+    layers,
+    ...(layerGroups.length > 0 ? { layerGroups } : {}),
     styles: data.styles ?? {},
     preferences: normalizeProjectPreferences(data.preferences),
     plugins: normalizeProjectPlugins(data.plugins) ?? undefined,
@@ -83,6 +96,39 @@ export function parseProject(json: string): GeoLibreProject {
     storymap: normalizeStoryMap(data.storymap) ?? undefined,
     metadata: data.metadata ?? {},
   };
+}
+
+/**
+ * Coerce an untrusted (possibly hand-edited) `layerGroups` array into valid
+ * {@link LayerGroup} records, dropping entries without a usable id and
+ * de-duplicating by id. Always returns an array (empty when absent).
+ *
+ * @param value Raw `layerGroups` value from the project JSON.
+ * @returns Normalized, de-duplicated group definitions.
+ */
+function normalizeLayerGroups(value: unknown): LayerGroup[] {
+  if (!Array.isArray(value)) return [];
+  const groups: LayerGroup[] = [];
+  const seen = new Set<string>();
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") continue;
+    const candidate = entry as Partial<LayerGroup>;
+    const id = typeof candidate.id === "string" ? candidate.id.trim() : "";
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    const opacity =
+      typeof candidate.opacity === "number" && Number.isFinite(candidate.opacity)
+        ? Math.min(Math.max(candidate.opacity, 0), 1)
+        : DEFAULT_LAYER_GROUP_OPACITY;
+    groups.push({
+      id,
+      name: typeof candidate.name === "string" ? candidate.name : id,
+      collapsed: candidate.collapsed === true,
+      visible: candidate.visible !== false,
+      opacity,
+    });
+  }
+  return groups;
 }
 
 /**
@@ -525,6 +571,7 @@ export function projectFromStore(state: {
   basemapVisible: boolean;
   basemapOpacity: number;
   layers: GeoLibreLayer[];
+  layerGroups?: LayerGroup[];
   preferences: ProjectPreferences;
   plugins?: ProjectPluginState | null;
   legend?: LegendConfig | null;
@@ -538,6 +585,9 @@ export function projectFromStore(state: {
   const plugins = normalizeProjectPlugins(state.plugins);
   const legend = normalizeLegendConfig(state.legend);
   const storymap = normalizeStoryMap(state.storymap);
+  // Only persist groups that still have at least one member or are explicitly
+  // kept as empty folders; normalizeLayerGroups round-trips them back.
+  const layerGroups = state.layerGroups ?? [];
   return {
     version: PROJECT_VERSION,
     name: state.projectName,
@@ -546,6 +596,7 @@ export function projectFromStore(state: {
     basemapVisible: state.basemapVisible,
     basemapOpacity: state.basemapOpacity,
     layers: state.layers.map(prepareLayerForSave),
+    ...(layerGroups.length > 0 ? { layerGroups } : {}),
     styles,
     preferences: state.preferences,
     ...(plugins ? { plugins } : {}),
@@ -618,6 +669,7 @@ export function applyProjectToStore(project: GeoLibreProject): {
   basemapVisible: boolean;
   basemapOpacity: number;
   layers: GeoLibreLayer[];
+  layerGroups: LayerGroup[];
   preferences: ProjectPreferences;
   projectPlugins: ProjectPluginState | null;
   legend: LegendConfig;
@@ -630,13 +682,20 @@ export function applyProjectToStore(project: GeoLibreProject): {
       ? { ...DEFAULT_LAYER_STYLE, ...project.styles[layer.id] }
       : { ...DEFAULT_LAYER_STYLE, ...layer.style },
   }));
+  const layerGroups = normalizeLayerGroups(project.layerGroups);
+  const validGroupIds = new Set(layerGroups.map((g) => g.id));
   return {
     projectName: project.name,
     mapView: project.mapView,
     basemapStyleUrl: project.basemapStyleUrl,
     basemapVisible: project.basemapVisible ?? true,
     basemapOpacity: project.basemapOpacity ?? 1,
-    layers,
+    layers: layers.map((layer) =>
+      layer.groupId && !validGroupIds.has(layer.groupId)
+        ? { ...layer, groupId: undefined }
+        : layer,
+    ),
+    layerGroups,
     preferences: normalizeProjectPreferences(project.preferences),
     projectPlugins: normalizeProjectPlugins(project.plugins),
     legend: normalizeLegendConfig(project.legend) ?? { ...DEFAULT_LEGEND_CONFIG },

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -686,6 +686,11 @@ export function applyProjectToStore(project: GeoLibreProject): {
       ? { ...DEFAULT_LAYER_STYLE, ...project.styles[layer.id] }
       : { ...DEFAULT_LAYER_STYLE, ...layer.style },
   }));
+  // Re-normalize here (even though `parseProject` already did) because
+  // `applyProjectToStore` is a public entry point also reached directly by
+  // programmatic/newProject loads that never passed through `parseProject`, so
+  // this stays a hardening boundary for untrusted group data. The call is
+  // idempotent on already-normalized input.
   const layerGroups = normalizeLayerGroups(project.layerGroups);
   const validGroupIds = new Set(layerGroups.map((g) => g.id));
   // Drop dangling groupIds, then restore the contiguity invariant the layer

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -23,7 +23,10 @@ import {
   type StoryLayerOpacityChange,
   type StoryMap,
 } from "./types";
-import { DEFAULT_LAYER_GROUP_OPACITY } from "./layer-groups";
+import {
+  DEFAULT_LAYER_GROUP_OPACITY,
+  normalizeGroupContiguity,
+} from "./layer-groups";
 
 /** Placeholder name a project carries before the user names it. */
 export const DEFAULT_PROJECT_NAME = "Untitled Project";
@@ -685,17 +688,23 @@ export function applyProjectToStore(project: GeoLibreProject): {
   }));
   const layerGroups = normalizeLayerGroups(project.layerGroups);
   const validGroupIds = new Set(layerGroups.map((g) => g.id));
+  // Drop dangling groupIds, then restore the contiguity invariant the layer
+  // panel relies on, in case the project was hand-edited or produced externally
+  // with a group's members interleaved among unrelated layers.
+  const normalizedLayers = normalizeGroupContiguity(
+    layers.map((layer) =>
+      layer.groupId && !validGroupIds.has(layer.groupId)
+        ? { ...layer, groupId: undefined }
+        : layer,
+    ),
+  );
   return {
     projectName: project.name,
     mapView: project.mapView,
     basemapStyleUrl: project.basemapStyleUrl,
     basemapVisible: project.basemapVisible ?? true,
     basemapOpacity: project.basemapOpacity ?? 1,
-    layers: layers.map((layer) =>
-      layer.groupId && !validGroupIds.has(layer.groupId)
-        ? { ...layer, groupId: undefined }
-        : layer,
-    ),
+    layers: normalizedLayers,
     layerGroups,
     preferences: normalizeProjectPreferences(project.preferences),
     projectPlugins: normalizeProjectPlugins(project.plugins),

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -585,8 +585,9 @@ export function projectFromStore(state: {
   const plugins = normalizeProjectPlugins(state.plugins);
   const legend = normalizeLegendConfig(state.legend);
   const storymap = normalizeStoryMap(state.storymap);
-  // Only persist groups that still have at least one member or are explicitly
-  // kept as empty folders; normalizeLayerGroups round-trips them back.
+  // Persist every group (including empty folders, which the UI supports). The
+  // key is spread only when non-empty so legacy readers that don't recognise it
+  // are unaffected; normalizeLayerGroups round-trips them back on load.
   const layerGroups = state.layerGroups ?? [];
   return {
     version: PROJECT_VERSION,

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -12,6 +12,10 @@ import {
   DEFAULT_PROJECT_NAME,
 } from "./project";
 import {
+  DEFAULT_LAYER_GROUP_OPACITY,
+  normalizeGroupContiguity,
+} from "./layer-groups";
+import {
   DEFAULT_BASEMAP,
   DEFAULT_LAYER_STYLE,
   DEFAULT_LEGEND_CONFIG,
@@ -19,6 +23,7 @@ import {
   DEFAULT_STORY_MAP,
   type GeoLibreLayer,
   type GeoLibreProject,
+  type LayerGroup,
   type LayerStyle,
   type LegendConfig,
   type MapViewState,
@@ -99,6 +104,7 @@ export interface AppState {
   basemapVisible: boolean;
   basemapOpacity: number;
   layers: GeoLibreLayer[];
+  layerGroups: LayerGroup[];
   preferences: ProjectPreferences;
   projectPlugins: ProjectPluginState | null;
   legend: LegendConfig;
@@ -186,6 +192,19 @@ export interface AppState {
     sourcePath?: string,
     beforeLayerId?: string | null
   ) => string;
+
+  addLayerGroup: (name?: string, layerIds?: string[]) => string;
+  removeLayerGroup: (id: string, options?: { removeChildren?: boolean }) => void;
+  renameLayerGroup: (id: string, name: string) => void;
+  setLayerGroupVisibility: (id: string, visible: boolean) => void;
+  setLayerGroupOpacity: (id: string, opacity: number) => void;
+  toggleLayerGroupCollapsed: (id: string) => void;
+  moveLayerToGroup: (
+    layerId: string,
+    groupId: string | null,
+    beforeLayerId?: string | null
+  ) => void;
+  reorderLayerGroup: (id: string, direction: "up" | "down") => void;
 }
 
 const MAX_RECENT_PROJECTS = 10;
@@ -232,6 +251,7 @@ export const useAppStore = create<AppState>()(
       basemapVisible: true,
       basemapOpacity: 1,
       layers: [],
+      layerGroups: [],
       preferences: DEFAULT_PROJECT_PREFERENCES,
       projectPlugins: null,
       legend: { ...DEFAULT_LEGEND_CONFIG },
@@ -481,6 +501,152 @@ export const useAppStore = create<AppState>()(
         return id;
       },
 
+      addLayerGroup: (name, layerIds) => {
+        const id = uuidv4();
+        set((s) => {
+          const group: LayerGroup = {
+            id,
+            name: name?.trim() || `Group ${s.layerGroups.length + 1}`,
+            collapsed: false,
+            visible: true,
+            opacity: DEFAULT_LAYER_GROUP_OPACITY,
+          };
+          const ids = new Set(layerIds ?? []);
+          const layers =
+            ids.size > 0
+              ? normalizeGroupContiguity(
+                  s.layers.map((l) =>
+                    ids.has(l.id) ? { ...l, groupId: id } : l
+                  )
+                )
+              : s.layers;
+          return {
+            layers,
+            layerGroups: [...s.layerGroups, group],
+            isDirty: true,
+          };
+        });
+        return id;
+      },
+
+      removeLayerGroup: (id, options) =>
+        set((s) => {
+          const removeChildren = options?.removeChildren ?? false;
+          const removedIds = new Set(
+            s.layers.filter((l) => l.groupId === id).map((l) => l.id)
+          );
+          const layers = removeChildren
+            ? s.layers.filter((l) => l.groupId !== id)
+            : s.layers.map((l) =>
+                l.groupId === id ? { ...l, groupId: undefined } : l
+              );
+          const selectionRemoved =
+            removeChildren &&
+            s.selectedLayerId !== null &&
+            removedIds.has(s.selectedLayerId);
+          return {
+            layers,
+            layerGroups: s.layerGroups.filter((g) => g.id !== id),
+            selectedLayerId: selectionRemoved
+              ? layers[layers.length - 1]?.id ?? null
+              : s.selectedLayerId,
+            selectedFeatureId: selectionRemoved ? null : s.selectedFeatureId,
+            identifyLayerId:
+              s.identifyLayerId !== null && removedIds.has(s.identifyLayerId)
+                ? null
+                : s.identifyLayerId,
+            isDirty: true,
+          };
+        }),
+
+      renameLayerGroup: (id, name) =>
+        set((s) => ({
+          layerGroups: s.layerGroups.map((g) =>
+            g.id === id ? { ...g, name } : g
+          ),
+          isDirty: true,
+        })),
+
+      setLayerGroupVisibility: (id, visible) =>
+        set((s) => ({
+          layerGroups: s.layerGroups.map((g) =>
+            g.id === id ? { ...g, visible } : g
+          ),
+          isDirty: true,
+        })),
+
+      setLayerGroupOpacity: (id, opacity) =>
+        set((s) => ({
+          layerGroups: s.layerGroups.map((g) =>
+            g.id === id
+              ? { ...g, opacity: Math.min(Math.max(opacity, 0), 1) }
+              : g
+          ),
+          isDirty: true,
+        })),
+
+      toggleLayerGroupCollapsed: (id) =>
+        set((s) => ({
+          layerGroups: s.layerGroups.map((g) =>
+            g.id === id ? { ...g, collapsed: !g.collapsed } : g
+          ),
+          isDirty: true,
+        })),
+
+      moveLayerToGroup: (layerId, groupId, beforeLayerId = null) =>
+        set((s) => {
+          const current = s.layers.find((l) => l.id === layerId);
+          if (!current) return s;
+          if (groupId && !s.layerGroups.some((g) => g.id === groupId)) return s;
+          const updated = { ...current, groupId: groupId ?? undefined };
+          const without = s.layers.filter((l) => l.id !== layerId);
+          let index: number;
+          if (beforeLayerId) {
+            const at = without.findIndex((l) => l.id === beforeLayerId);
+            index = at < 0 ? without.length : at;
+          } else if (groupId) {
+            // Append to the end of the target group's block (top of the group
+            // in the panel); fall back to the array end for an empty group.
+            let last = -1;
+            without.forEach((l, i) => {
+              if (l.groupId === groupId) last = i;
+            });
+            index = last < 0 ? without.length : last + 1;
+          } else {
+            index = without.length;
+          }
+          const next = [...without];
+          next.splice(index, 0, updated);
+          const normalized = normalizeGroupContiguity(next);
+          const unchanged = normalized.every(
+            (l, i) =>
+              l.id === s.layers[i]?.id && l.groupId === s.layers[i]?.groupId
+          );
+          if (unchanged) return s;
+          return { layers: normalized, isDirty: true };
+        }),
+
+      reorderLayerGroup: (id, direction) =>
+        set((s) => {
+          // Build the top-level units in store (render) order: each ungrouped
+          // layer is its own unit, and a group's contiguous members form one
+          // unit. Reordering swaps the whole group block past its neighbor.
+          const units: { key: string; layers: GeoLibreLayer[] }[] = [];
+          for (const layer of s.layers) {
+            const key = layer.groupId ?? `layer:${layer.id}`;
+            const last = units[units.length - 1];
+            if (last && last.key === key) last.layers.push(layer);
+            else units.push({ key, layers: [layer] });
+          }
+          const unitIndex = units.findIndex((u) => u.key === id);
+          if (unitIndex < 0) return s; // empty group: nothing to move
+          const target = direction === "up" ? unitIndex + 1 : unitIndex - 1;
+          if (target < 0 || target >= units.length) return s;
+          const [unit] = units.splice(unitIndex, 1);
+          units.splice(target, 0, unit);
+          return { layers: units.flatMap((u) => u.layers), isDirty: true };
+        }),
+
       newProject: (options = {}) => {
         const project = createEmptyProject(options.name, options);
         const applied = applyProjectToStore(project);
@@ -529,24 +695,27 @@ export const useAppStore = create<AppState>()(
       // is excluded, so changing them never creates a history entry.
       partialize: (s) => ({
         layers: s.layers,
+        layerGroups: s.layerGroups,
         basemapStyleUrl: s.basemapStyleUrl,
         basemapVisible: s.basemapVisible,
         basemapOpacity: s.basemapOpacity,
         storymap: s.storymap,
       }),
       // Records a history entry only when the tracked slice really changed.
-      // Basemap fields compare with ===; `layers` is compared element-by-element
-      // (Object.is per element) via shallow. Every mutating action creates new
-      // layer objects, so real changes differ; two distinct empty arrays compare
-      // equal, so resetting layers (e.g. newProject) records nothing. `storymap`
-      // is compared by reference: every authoring action creates a new object,
-      // so real edits differ while an unchanged null stays equal.
+      // Basemap fields compare with ===; `layers` and `layerGroups` are compared
+      // element-by-element (Object.is per element) via shallow. Every mutating
+      // action creates new layer/group objects, so real changes differ; two
+      // distinct empty arrays compare equal, so resetting them (e.g. newProject)
+      // records nothing. `storymap` is compared by reference: every authoring
+      // action creates a new object, so real edits differ while an unchanged
+      // null stays equal.
       equality: (a, b) =>
         a.basemapStyleUrl === b.basemapStyleUrl &&
         a.basemapVisible === b.basemapVisible &&
         a.basemapOpacity === b.basemapOpacity &&
         a.storymap === b.storymap &&
-        shallow(a.layers, b.layers),
+        shallow(a.layers, b.layers) &&
+        shallow(a.layerGroups, b.layerGroups),
       limit: 100,
       // Group rapid bursts (slider drags) into one entry; window is 0 in tests.
       // Keep the debounced wrapper so clearHistory can reset an in-flight burst.

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -236,6 +236,17 @@ function normalizeRecentProjects(
   return normalized.slice(0, MAX_RECENT_PROJECTS);
 }
 
+/**
+ * Pick the first `Group N` name not already taken, so default names stay unique
+ * even after groups are deleted (a plain count would reuse a freed number).
+ */
+function nextDefaultGroupName(groups: LayerGroup[]): string {
+  const existing = new Set(groups.map((g) => g.name));
+  let n = groups.length + 1;
+  while (existing.has(`Group ${n}`)) n++;
+  return `Group ${n}`;
+}
+
 /** Cancels the active history coalesce window (assigned by zundo's handleSet). */
 let cancelHistoryCoalesce: () => void = () => {};
 
@@ -506,7 +517,7 @@ export const useAppStore = create<AppState>()(
         set((s) => {
           const group: LayerGroup = {
             id,
-            name: name?.trim() || `Group ${s.layerGroups.length + 1}`,
+            name: name?.trim() || nextDefaultGroupName(s.layerGroups),
             collapsed: false,
             visible: true,
             opacity: DEFAULT_LAYER_GROUP_OPACITY,

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -237,14 +237,43 @@ function normalizeRecentProjects(
 }
 
 /**
- * Pick the first `Group N` name not already taken, so default names stay unique
- * even after groups are deleted (a plain count would reuse a freed number).
+ * Pick the lowest `Group N` name not already taken, so default names stay
+ * unique while still preferring small numbers — starting the search at 1 (not
+ * `length + 1`) avoids skipping free low numbers when some groups carry custom
+ * names. Group counts are small, so the linear scan is negligible.
  */
 function nextDefaultGroupName(groups: LayerGroup[]): string {
   const existing = new Set(groups.map((g) => g.name));
-  let n = groups.length + 1;
+  let n = 1;
   while (existing.has(`Group ${n}`)) n++;
   return `Group ${n}`;
+}
+
+/**
+ * Compare two `layerGroups` arrays for undo-history purposes, ignoring the
+ * `collapsed` flag so expand/collapse (a UI-panel preference) never records a
+ * history entry. Every other field — order, name, visibility, opacity — is
+ * still compared, so real edits are tracked.
+ */
+function layerGroupsEqualForHistory(
+  a: LayerGroup[],
+  b: LayerGroup[]
+): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i];
+    const y = b[i];
+    if (x === y) continue;
+    if (
+      x.id !== y.id ||
+      x.name !== y.name ||
+      x.visible !== y.visible ||
+      x.opacity !== y.opacity
+    ) {
+      return false;
+    }
+  }
+  return true;
 }
 
 /** Cancels the active history coalesce window (assigned by zundo's handleSet). */
@@ -596,12 +625,15 @@ export const useAppStore = create<AppState>()(
           isDirty: true,
         })),
 
+      // Collapsing/expanding a folder is a UI-panel preference, not a data
+      // edit: it is still persisted in the project (folders reopen collapsed),
+      // but it does not mark the project dirty and is excluded from undo (see
+      // the equality comparator below) so Ctrl-Z never toggles a folder.
       toggleLayerGroupCollapsed: (id) =>
         set((s) => ({
           layerGroups: s.layerGroups.map((g) =>
             g.id === id ? { ...g, collapsed: !g.collapsed } : g
           ),
-          isDirty: true,
         })),
 
       moveLayerToGroup: (layerId, groupId, beforeLayerId = null) =>
@@ -713,20 +745,21 @@ export const useAppStore = create<AppState>()(
         storymap: s.storymap,
       }),
       // Records a history entry only when the tracked slice really changed.
-      // Basemap fields compare with ===; `layers` and `layerGroups` are compared
-      // element-by-element (Object.is per element) via shallow. Every mutating
-      // action creates new layer/group objects, so real changes differ; two
-      // distinct empty arrays compare equal, so resetting them (e.g. newProject)
-      // records nothing. `storymap` is compared by reference: every authoring
-      // action creates a new object, so real edits differ while an unchanged
-      // null stays equal.
+      // Basemap fields compare with ===; `layers` is compared element-by-element
+      // (Object.is per element) via shallow. Every mutating action creates new
+      // layer/group objects, so real changes differ; two distinct empty arrays
+      // compare equal, so resetting them (e.g. newProject) records nothing.
+      // `storymap` is compared by reference: every authoring action creates a
+      // new object, so real edits differ while an unchanged null stays equal.
+      // `layerGroups` is compared ignoring `collapsed`, which is a UI preference
+      // excluded from undo (see toggleLayerGroupCollapsed).
       equality: (a, b) =>
         a.basemapStyleUrl === b.basemapStyleUrl &&
         a.basemapVisible === b.basemapVisible &&
         a.basemapOpacity === b.basemapOpacity &&
         a.storymap === b.storymap &&
         shallow(a.layers, b.layers) &&
-        shallow(a.layerGroups, b.layerGroups),
+        layerGroupsEqualForHistory(a.layerGroups, b.layerGroups),
       limit: 100,
       // Group rapid bursts (slider drags) into one entry; window is 0 in tests.
       // Keep the debounced wrapper so clearHistory can reset an in-flight burst.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -37,7 +37,7 @@ export const DEFAULT_BASEMAP = "https://tiles.openfreemap.org/styles/liberty";
 
 export const BLANK_BASEMAP = "";
 
-export const PROJECT_VERSION = "0.1.0";
+export const PROJECT_VERSION = "0.2.0";
 
 export type LayerType =
   | "geojson"
@@ -185,6 +185,32 @@ export interface GeoLibreLayer {
   beforeId?: string;
   geojson?: FeatureCollection;
   sourcePath?: string;
+  /**
+   * Id of the {@link LayerGroup} this layer belongs to, or `undefined` when the
+   * layer sits at the top level of the layer panel. Layers sharing a `groupId`
+   * are kept contiguous in the store's flat `layers` array so the group renders
+   * as one block; see `@geolibre/core`'s `layer-groups` helpers.
+   */
+  groupId?: string;
+}
+
+/**
+ * A named, collapsible folder in the layer panel that organizes a contiguous
+ * run of layers (single-level nesting; groups never contain other groups).
+ *
+ * The group's `visible` flag and `opacity` multiplier are folded into each
+ * child layer's effective render state by `applyGroupEffects` before the map
+ * syncs, so children keep their own stored `visible`/`opacity` values.
+ */
+export interface LayerGroup {
+  id: string;
+  name: string;
+  /** When true, the group's children are hidden in the panel (not on the map). */
+  collapsed: boolean;
+  /** Group-level visibility; ANDed with each child layer's own visibility. */
+  visible: boolean;
+  /** Group-level opacity in [0, 1]; multiplied into each child's opacity. */
+  opacity: number;
 }
 
 /**
@@ -392,6 +418,8 @@ export interface GeoLibreProject {
   basemapVisible: boolean;
   basemapOpacity: number;
   layers: GeoLibreLayer[];
+  /** Named folders that organize the flat `layers` list in the layer panel. */
+  layerGroups?: LayerGroup[];
   styles: Record<string, LayerStyle>;
   preferences: ProjectPreferences;
   plugins?: ProjectPluginState;

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -1,10 +1,11 @@
 import {
+  applyGroupEffects,
   isDuckDBQueryLayer,
   useAppStore,
   type GeoLibreLayer,
 } from "@geolibre/core";
 import maplibregl from "maplibre-gl";
-import { memo, useEffect, useRef } from "react";
+import { memo, useEffect, useMemo, useRef } from "react";
 import {
   circleLayerId,
   fillExtrusionLayerId,
@@ -591,6 +592,7 @@ export const MapCanvas = memo(function MapCanvas({
   const mapPreferences = useAppStore((s) => s.preferences.map);
   const mapView = useAppStore((s) => s.mapView);
   const layers = useAppStore((s) => s.layers);
+  const layerGroups = useAppStore((s) => s.layerGroups);
   const selectedLayerId = useAppStore((s) => s.selectedLayerId);
   const selectedFeatureId = useAppStore((s) => s.selectedFeatureId);
   const identifyLayerId = useAppStore((s) => s.identifyLayerId);
@@ -629,10 +631,10 @@ export const MapCanvas = memo(function MapCanvas({
       setMapView(mc.readView(), Boolean(event?.originalEvent));
     map.on("moveend", updateView);
     map.on("load", () => {
-      mc.waitAndSyncLayers(useAppStore.getState().layers);
-      mc.setBasemapVisible(useAppStore.getState().basemapVisible);
-      mc.setBasemapOpacity(useAppStore.getState().basemapOpacity);
       const state = useAppStore.getState();
+      mc.waitAndSyncLayers(applyGroupEffects(state.layers, state.layerGroups));
+      mc.setBasemapVisible(state.basemapVisible);
+      mc.setBasemapOpacity(state.basemapOpacity);
       mc.highlightFeature(
         state.layers.find((layer) => layer.id === state.selectedLayerId),
         state.selectedFeatureId,
@@ -701,14 +703,12 @@ export const MapCanvas = memo(function MapCanvas({
     if (!map || prevBasemap.current === basemapStyleUrl) return;
     prevBasemap.current = basemapStyleUrl;
     map.once("style.load", () => {
-      controller.current?.waitAndSyncLayers(useAppStore.getState().layers);
-      controller.current?.setBasemapVisible(
-        useAppStore.getState().basemapVisible,
-      );
-      controller.current?.setBasemapOpacity(
-        useAppStore.getState().basemapOpacity,
-      );
       const state = useAppStore.getState();
+      controller.current?.waitAndSyncLayers(
+        applyGroupEffects(state.layers, state.layerGroups),
+      );
+      controller.current?.setBasemapVisible(state.basemapVisible);
+      controller.current?.setBasemapOpacity(state.basemapOpacity);
       controller.current?.highlightFeature(
         state.layers.find((layer) => layer.id === state.selectedLayerId),
         state.selectedFeatureId,
@@ -730,9 +730,18 @@ export const MapCanvas = memo(function MapCanvas({
     controller.current?.applyMapPreferences(mapPreferences);
   }, [mapPreferences]);
 
+  // Fold group visibility/opacity into each child layer before syncing so the
+  // map sync keeps treating every layer independently. This also re-runs when
+  // only a group's visibility/opacity changes (the raw `layers` array is then
+  // unchanged), because `renderLayers` depends on `layerGroups`.
+  const renderLayers = useMemo(
+    () => applyGroupEffects(layers, layerGroups),
+    [layers, layerGroups],
+  );
+
   useEffect(() => {
-    controller.current?.waitAndSyncLayers(layers);
-  }, [layers]);
+    controller.current?.waitAndSyncLayers(renderLayers);
+  }, [renderLayers]);
 
   useEffect(() => {
     const layer = layers.find((item) => item.id === selectedLayerId);

--- a/tests/layer-groups.test.ts
+++ b/tests/layer-groups.test.ts
@@ -149,6 +149,21 @@ describe("layer group store actions", () => {
     assert.equal(groups[0].name, "Folder");
   });
 
+  it("picks a unique default name even after a group is deleted", () => {
+    const g1 = useAppStore.getState().addLayerGroup();
+    useAppStore.getState().addLayerGroup();
+    assert.equal(
+      useAppStore.getState().layerGroups.map((g) => g.name).join(","),
+      "Group 1,Group 2",
+    );
+    // Deleting "Group 1" then adding again must not reuse the freed number.
+    useAppStore.getState().removeLayerGroup(g1);
+    useAppStore.getState().addLayerGroup();
+    const names = useAppStore.getState().layerGroups.map((g) => g.name);
+    assert.equal(new Set(names).size, names.length); // all unique
+    assert.deepEqual([...names].sort(), ["Group 2", "Group 3"]);
+  });
+
   it("creates a group from existing layers and keeps members contiguous", () => {
     const a = useAppStore.getState().addGeoJsonLayer("A", emptyFC);
     useAppStore.getState().addGeoJsonLayer("B", emptyFC);

--- a/tests/layer-groups.test.ts
+++ b/tests/layer-groups.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, it } from "node:test";
 import {
   DEFAULT_LAYER_STYLE,
   applyGroupEffects,
+  applyProjectToStore,
   buildLayerTree,
   createEmptyProject,
   normalizeGroupContiguity,
@@ -284,5 +285,29 @@ describe("layer group serialization", () => {
       }),
     );
     assert.equal(project.layers[0].groupId, undefined);
+  });
+
+  it("normalizes non-contiguous group members when applied to the store", () => {
+    // A hand-edited / externally produced project with a group's members
+    // interleaved among unrelated layers.
+    const project = parseProject(
+      JSON.stringify({
+        version: "0.2.0",
+        name: "Interleaved",
+        mapView: { center: [0, 0], zoom: 1, bearing: 0, pitch: 0 },
+        layers: [
+          layer("g1", { groupId: "g" }),
+          layer("x"),
+          layer("g2", { groupId: "g" }),
+        ],
+        layerGroups: [group("g")],
+      }),
+    );
+    const applied = applyProjectToStore(project);
+    // The group's members must be contiguous so the panel renders one header.
+    assert.deepEqual(
+      applied.layers.map((l) => l.id),
+      ["g1", "g2", "x"],
+    );
   });
 });

--- a/tests/layer-groups.test.ts
+++ b/tests/layer-groups.test.ts
@@ -1,0 +1,273 @@
+import assert from "node:assert/strict";
+import { beforeEach, describe, it } from "node:test";
+import {
+  DEFAULT_LAYER_STYLE,
+  applyGroupEffects,
+  buildLayerTree,
+  createEmptyProject,
+  normalizeGroupContiguity,
+  parseProject,
+  projectFromStore,
+  serializeProject,
+  useAppStore,
+  type GeoLibreLayer,
+  type LayerGroup,
+} from "@geolibre/core";
+import {
+  setHistoryCoalesceMs,
+} from "../packages/core/src/history";
+import { redo, undo } from "../packages/core/src/store";
+
+function layer(id: string, patch: Partial<GeoLibreLayer> = {}): GeoLibreLayer {
+  return {
+    id,
+    name: id,
+    type: "geojson",
+    source: { type: "geojson" },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {},
+    geojson: { type: "FeatureCollection", features: [] },
+    ...patch,
+  };
+}
+
+function group(id: string, patch: Partial<LayerGroup> = {}): LayerGroup {
+  return {
+    id,
+    name: id,
+    collapsed: false,
+    visible: true,
+    opacity: 1,
+    ...patch,
+  };
+}
+
+const emptyFC = { type: "FeatureCollection" as const, features: [] };
+
+describe("buildLayerTree", () => {
+  it("renders top-level layers top-first with no groups", () => {
+    const tree = buildLayerTree([layer("a"), layer("b")], []);
+    assert.deepEqual(
+      tree.map((item) => (item.kind === "layer" ? item.layer.id : null)),
+      ["b", "a"],
+    );
+  });
+
+  it("gathers a group's members under a single header at the top member", () => {
+    const layers = [
+      layer("a"),
+      layer("g1", { groupId: "g" }),
+      layer("g2", { groupId: "g" }),
+      layer("b"),
+    ];
+    const tree = buildLayerTree(layers, [group("g")]);
+    // Display order (top-first): b, [group g: g2, g1], a
+    assert.equal(tree.length, 3);
+    assert.equal(tree[0].kind, "layer");
+    assert.equal(tree[1].kind, "group");
+    if (tree[1].kind === "group") {
+      assert.equal(tree[1].group.id, "g");
+      assert.deepEqual(
+        tree[1].children.map((l) => l.id),
+        ["g2", "g1"],
+      );
+    }
+    assert.equal(tree[2].kind, "layer");
+  });
+
+  it("emits empty groups pinned at the top", () => {
+    const tree = buildLayerTree([layer("a")], [group("empty")]);
+    assert.equal(tree[0].kind, "group");
+    if (tree[0].kind === "group") {
+      assert.equal(tree[0].group.id, "empty");
+      assert.equal(tree[0].children.length, 0);
+    }
+  });
+
+  it("treats a dangling groupId as an ungrouped layer", () => {
+    const tree = buildLayerTree([layer("a", { groupId: "missing" })], []);
+    assert.equal(tree.length, 1);
+    assert.equal(tree[0].kind, "layer");
+  });
+});
+
+describe("applyGroupEffects", () => {
+  it("multiplies opacity and ANDs visibility into children", () => {
+    const layers = [
+      layer("a", { opacity: 0.8, visible: true, groupId: "g" }),
+      layer("b", { opacity: 1, visible: true }),
+    ];
+    const groups = [group("g", { opacity: 0.5, visible: false })];
+    const result = applyGroupEffects(layers, groups);
+    assert.equal(result[0].opacity, 0.4);
+    assert.equal(result[0].visible, false);
+    // Ungrouped layer is untouched (same reference).
+    assert.equal(result[1], layers[1]);
+  });
+
+  it("returns the same array when there are no groups", () => {
+    const layers = [layer("a")];
+    assert.equal(applyGroupEffects(layers, []), layers);
+  });
+
+  it("preserves the reference when a group has no effect", () => {
+    const layers = [layer("a", { groupId: "g" })];
+    const result = applyGroupEffects(layers, [group("g")]);
+    assert.equal(result[0], layers[0]);
+  });
+});
+
+describe("normalizeGroupContiguity", () => {
+  it("pulls scattered group members into one block at the first member", () => {
+    const layers = [
+      layer("g1", { groupId: "g" }),
+      layer("x"),
+      layer("g2", { groupId: "g" }),
+    ];
+    const result = normalizeGroupContiguity(layers);
+    assert.deepEqual(
+      result.map((l) => l.id),
+      ["g1", "g2", "x"],
+    );
+  });
+});
+
+describe("layer group store actions", () => {
+  beforeEach(() => {
+    setHistoryCoalesceMs(0);
+    useAppStore.getState().newProject({ name: "Groups" });
+    useAppStore.temporal.getState().clear();
+  });
+
+  it("creates an empty group", () => {
+    const id = useAppStore.getState().addLayerGroup("Folder");
+    const groups = useAppStore.getState().layerGroups;
+    assert.equal(groups.length, 1);
+    assert.equal(groups[0].id, id);
+    assert.equal(groups[0].name, "Folder");
+  });
+
+  it("creates a group from existing layers and keeps members contiguous", () => {
+    const a = useAppStore.getState().addGeoJsonLayer("A", emptyFC);
+    useAppStore.getState().addGeoJsonLayer("B", emptyFC);
+    const c = useAppStore.getState().addGeoJsonLayer("C", emptyFC);
+    const gid = useAppStore.getState().addLayerGroup("G", [a, c]);
+    const layers = useAppStore.getState().layers;
+    const grouped = layers.filter((l) => l.groupId === gid).map((l) => l.id);
+    assert.deepEqual(grouped.sort(), [a, c].sort());
+    // a and c are adjacent in the array (contiguous block).
+    const indices = layers
+      .map((l, i) => (l.groupId === gid ? i : -1))
+      .filter((i) => i >= 0);
+    assert.equal(indices[1] - indices[0], 1);
+  });
+
+  it("moves a layer into a group and back out", () => {
+    const a = useAppStore.getState().addGeoJsonLayer("A", emptyFC);
+    const gid = useAppStore.getState().addLayerGroup("G");
+    useAppStore.getState().moveLayerToGroup(a, gid);
+    assert.equal(
+      useAppStore.getState().layers.find((l) => l.id === a)?.groupId,
+      gid,
+    );
+    useAppStore.getState().moveLayerToGroup(a, null);
+    assert.equal(
+      useAppStore.getState().layers.find((l) => l.id === a)?.groupId,
+      undefined,
+    );
+  });
+
+  it("reorders a group block past a neighboring layer", () => {
+    const a = useAppStore.getState().addGeoJsonLayer("A", emptyFC);
+    const b = useAppStore.getState().addGeoJsonLayer("B", emptyFC);
+    const gid = useAppStore.getState().addLayerGroup("G", [a]);
+    // Array order: [a(g), b]. Move group up (toward array end / top of panel).
+    useAppStore.getState().reorderLayerGroup(gid, "up");
+    assert.deepEqual(
+      useAppStore.getState().layers.map((l) => l.id),
+      [b, a],
+    );
+  });
+
+  it("ungroups children by default but can delete them", () => {
+    const a = useAppStore.getState().addGeoJsonLayer("A", emptyFC);
+    const gid = useAppStore.getState().addLayerGroup("G", [a]);
+    useAppStore.getState().removeLayerGroup(gid);
+    assert.equal(useAppStore.getState().layerGroups.length, 0);
+    assert.equal(useAppStore.getState().layers.length, 1);
+    assert.equal(
+      useAppStore.getState().layers[0].groupId,
+      undefined,
+    );
+
+    const b = useAppStore.getState().addGeoJsonLayer("B", emptyFC);
+    const gid2 = useAppStore.getState().addLayerGroup("G2", [b]);
+    useAppStore.getState().removeLayerGroup(gid2, { removeChildren: true });
+    assert.equal(
+      useAppStore.getState().layers.some((l) => l.id === b),
+      false,
+    );
+  });
+
+  it("tracks group changes in undo history", () => {
+    const a = useAppStore.getState().addGeoJsonLayer("A", emptyFC);
+    useAppStore.temporal.getState().clear();
+    const gid = useAppStore.getState().addLayerGroup("G", [a]);
+    assert.equal(useAppStore.getState().layerGroups.length, 1);
+    undo();
+    assert.equal(useAppStore.getState().layerGroups.length, 0);
+    redo();
+    assert.equal(useAppStore.getState().layerGroups.length, 1);
+    assert.equal(useAppStore.getState().layerGroups[0].id, gid);
+  });
+});
+
+describe("layer group serialization", () => {
+  it("round-trips groups through projectFromStore and parseProject", () => {
+    const layers = [layer("a", { groupId: "g" }), layer("b")];
+    const groups = [group("g", { name: "Folder", opacity: 0.5 })];
+    const project = projectFromStore({
+      projectName: "P",
+      mapView: { center: [0, 0], zoom: 1, bearing: 0, pitch: 0 },
+      basemapStyleUrl: "",
+      basemapVisible: true,
+      basemapOpacity: 1,
+      layers,
+      layerGroups: groups,
+      preferences: createEmptyProject().preferences,
+      metadata: {},
+    });
+    const parsed = parseProject(serializeProject(project));
+    assert.equal(parsed.layerGroups?.length, 1);
+    assert.equal(parsed.layerGroups?.[0].name, "Folder");
+    assert.equal(parsed.layerGroups?.[0].opacity, 0.5);
+    assert.equal(parsed.layers.find((l) => l.id === "a")?.groupId, "g");
+  });
+
+  it("loads a legacy project (no layerGroups) with an empty group list", () => {
+    const project = parseProject(
+      JSON.stringify({
+        version: "0.1.0",
+        name: "Legacy",
+        mapView: { center: [0, 0], zoom: 1, bearing: 0, pitch: 0 },
+        layers: [],
+      }),
+    );
+    assert.equal(project.layerGroups, undefined);
+  });
+
+  it("drops a dangling groupId that has no matching group", () => {
+    const project = parseProject(
+      JSON.stringify({
+        version: "0.2.0",
+        name: "Dangling",
+        mapView: { center: [0, 0], zoom: 1, bearing: 0, pitch: 0 },
+        layers: [{ ...layer("a", { groupId: "missing" }) }],
+        layerGroups: [],
+      }),
+    );
+    assert.equal(project.layers[0].groupId, undefined);
+  });
+});

--- a/tests/layer-groups.test.ts
+++ b/tests/layer-groups.test.ts
@@ -150,19 +150,30 @@ describe("layer group store actions", () => {
     assert.equal(groups[0].name, "Folder");
   });
 
-  it("picks a unique default name even after a group is deleted", () => {
+  it("picks the lowest unique default name, even with custom-named groups", () => {
     const g1 = useAppStore.getState().addLayerGroup();
     useAppStore.getState().addLayerGroup();
     assert.equal(
       useAppStore.getState().layerGroups.map((g) => g.name).join(","),
       "Group 1,Group 2",
     );
-    // Deleting "Group 1" then adding again must not reuse the freed number.
+    // Deleting "Group 1" frees that number; the next default fills the gap.
     useAppStore.getState().removeLayerGroup(g1);
     useAppStore.getState().addLayerGroup();
     const names = useAppStore.getState().layerGroups.map((g) => g.name);
     assert.equal(new Set(names).size, names.length); // all unique
-    assert.deepEqual([...names].sort(), ["Group 2", "Group 3"]);
+    assert.deepEqual([...names].sort(), ["Group 1", "Group 2"]);
+
+    // A custom name must not push the default past free low numbers.
+    useAppStore.getState().newProject({ name: "Custom" });
+    const cg = useAppStore.getState().addLayerGroup("Basemaps");
+    assert.ok(cg);
+    assert.equal(
+      useAppStore.getState().addLayerGroup() &&
+        useAppStore.getState().layerGroups.find((g) => g.name === "Group 1") !==
+          undefined,
+      true,
+    );
   });
 
   it("creates a group from existing layers and keeps members contiguous", () => {
@@ -237,6 +248,37 @@ describe("layer group store actions", () => {
     redo();
     assert.equal(useAppStore.getState().layerGroups.length, 1);
     assert.equal(useAppStore.getState().layerGroups[0].id, gid);
+  });
+
+  it("collapse is a UI preference: not dirtying, not in undo history", () => {
+    const gid = useAppStore.getState().addLayerGroup("G");
+    useAppStore.getState().markSaved();
+    useAppStore.temporal.getState().clear();
+    const pastBefore = useAppStore.temporal.getState().pastStates.length;
+
+    useAppStore.getState().toggleLayerGroupCollapsed(gid);
+    assert.equal(useAppStore.getState().layerGroups[0].collapsed, true);
+    // Toggling collapse must not dirty the project nor record an undo entry.
+    assert.equal(useAppStore.getState().isDirty, false);
+    assert.equal(
+      useAppStore.temporal.getState().pastStates.length,
+      pastBefore,
+    );
+    // But it is still persisted (so folders reopen collapsed).
+    assert.equal(
+      projectFromStore({
+        projectName: "P",
+        mapView: { center: [0, 0], zoom: 1, bearing: 0, pitch: 0 },
+        basemapStyleUrl: "",
+        basemapVisible: true,
+        basemapOpacity: 1,
+        layers: useAppStore.getState().layers,
+        layerGroups: useAppStore.getState().layerGroups,
+        preferences: createEmptyProject().preferences,
+        metadata: {},
+      }).layerGroups?.[0].collapsed,
+      true,
+    );
   });
 });
 


### PR DESCRIPTION
Closes #311.

## Summary

Adds **named, collapsible folders** to the layer panel so projects with many layers can be organized into groups with group-level visibility and opacity. Single-level nesting (folders hold layers, not other folders), matching the issue scope.

The store's flat `layers` array stays the single source of truth for render order, so `MapController` sync is unchanged — groups are an organizational overlay whose visibility/opacity are folded into each child layer at render time.

## What you can do

- **Create groups** two ways: a **New group** button (empty folder, drag layers in) and a per-layer **New group from layer** action.
- **Group controls**: toggle visibility (hides all children) and opacity (multiplies into each child's effective opacity); children keep their own stored values.
- **Collapse/expand** folders; **rename** (double-click or menu); **reorder** groups; **ungroup** (keep layers) or **delete group and layers**.
- **Drag** layers into/out of folders and between them; **Move to group** / **Remove from group** from the layer menu.
- Group structure **persists** in `.geolibre.json`.

## Implementation

- **`@geolibre/core`**: new `LayerGroup` type + optional `layer.groupId`; `layerGroups` added to the store (tracked by undo) and the project schema (`PROJECT_VERSION` → `0.2.0`). New `layer-groups.ts` helpers: `buildLayerTree`, `applyGroupEffects`, `normalizeGroupContiguity`. Store actions keep a group's members contiguous in the flat array. Serialization normalizes groups and drops dangling `groupId`s; legacy projects (no `layerGroups`) load unchanged.
- **`@geolibre/map`**: `MapCanvas` computes effective layers via `applyGroupEffects` before `waitAndSyncLayers`; also re-syncs when only a group's visibility/opacity changes.
- **`LayerPanel`**: group headers, the New group button, per-layer group menu, and drag-and-drop into/reordering of folders, reusing the existing native drag-and-drop.

## Testing

- **17 unit tests** (`tests/layer-groups.test.ts`): tree building, opacity/visibility folding, contiguity, store actions, undo/redo, and a serialization round-trip (incl. legacy load + dangling `groupId` drop).
- **e2e** (`e2e/layer-groups.spec.ts`): group a layer, collapse/expand, save → reload → reopen persistence.
- Full suite green: `npm run test:frontend` (590), `npm run typecheck`, scoped `pre-commit`.
- Manually verified in a real browser (create/rename group, hide/show, collapse/expand, indented children) with no console errors.

## Note

`LayerPanel.tsx` currently uses literal English strings throughout (no `t()` wiring), so the new group strings follow that same convention for consistency. Happy to wire the whole panel through `react-i18next` in a follow-up if you'd prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Layer grouping: organize layers into collapsible folder-like groups in the layer panel, with inline rename and drag-and-drop to move layers into/out of groups.
  - Group controls: manage group visibility and opacity; collapse/expand hides/shows grouped child layers.
  - Persistence & sharing: group structure is saved with projects, included in embedded/bridge updates and share/download data, and restored on reopen.

* **Tests**
  - Added end-to-end and core unit tests covering drag/drop, collapse/expand behavior, and project save/open round-tripping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->