### PR TITLE
feat(network): isochrones, service areas, and OD cost matrices (#308)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -118,6 +118,20 @@ const VectorToolsDialog = lazy(() =>
     }),
 );
 
+const NetworkToolsDialog = lazy(() =>
+  import("../processing/NetworkToolsDialog")
+    .then((module) => ({
+      default: module.NetworkToolsDialog,
+    }))
+    .catch((error) => {
+      // Same chunk-load fallback rationale as ProcessingDialog above.
+      console.error("Failed to load NetworkToolsDialog", error);
+      const Fallback = (() =>
+        null) as unknown as typeof import("../processing/NetworkToolsDialog").NetworkToolsDialog;
+      return { default: Fallback };
+    }),
+);
+
 const GeocodeDialog = lazy(() =>
   import("../processing/GeocodeDialog")
     .then((module) => ({
@@ -984,6 +998,9 @@ export function DesktopShell({
       </Suspense>
       <Suspense fallback={null}>
         <VectorToolsDialog mapControllerRef={mapControllerRef} />
+      </Suspense>
+      <Suspense fallback={null}>
+        <NetworkToolsDialog mapControllerRef={mapControllerRef} />
       </Suspense>
       <Suspense fallback={null}>
         <GeocodeDialog mapControllerRef={mapControllerRef} />

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -402,6 +402,7 @@ export function TopToolbar({
   const setProcessingOpen = useAppStore((s) => s.setProcessingOpen);
   const setConversionOpen = useAppStore((s) => s.setConversionOpen);
   const setVectorToolOpen = useAppStore((s) => s.setVectorToolOpen);
+  const setNetworkToolOpen = useAppStore((s) => s.setNetworkToolOpen);
   const setGeocodeOpen = useAppStore((s) => s.setGeocodeOpen);
   const setRasterToolOpen = useAppStore((s) => s.setRasterToolOpen);
   const setSqlWorkspaceOpen = useAppStore((s) => s.setSqlWorkspaceOpen);
@@ -1877,6 +1878,23 @@ export function TopToolbar({
                 onSelect={() => setVectorToolOpen("h3-bin-points")}
               >
                 {t("toolbar.vectorTool.h3BinPoints")}
+              </DropdownMenuItem>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              {t("toolbar.item.network")}
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              <DropdownMenuItem
+                onSelect={() => setNetworkToolOpen("isochrone")}
+              >
+                {t("toolbar.networkTool.isochrone")}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onSelect={() => setNetworkToolOpen("od-matrix")}
+              >
+                {t("toolbar.networkTool.odMatrix")}
               </DropdownMenuItem>
             </DropdownMenuSubContent>
           </DropdownMenuSub>

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -177,6 +177,10 @@ import {
   hasReverseGeocodeConsent,
   recordReverseGeocodeConsent,
 } from "../../lib/reverse-geocode-consent";
+import {
+  hasRoutingConsent,
+  recordRoutingConsent,
+} from "../../lib/routing-consent";
 import { mergeStringLists } from "../../lib/string-lists";
 import { normalizeProjectUrl } from "../../lib/urls";
 import { resolveProjectXyzLayers } from "../../lib/xyz-url";
@@ -448,6 +452,10 @@ export function TopToolbar({
   const [directionsNoticeOpen, setDirectionsNoticeOpen] = useState(false);
   const [reverseGeocodeNoticeOpen, setReverseGeocodeNoticeOpen] =
     useState(false);
+  const [routingNoticeOpen, setRoutingNoticeOpen] = useState(false);
+  const [pendingNetworkTool, setPendingNetworkTool] = useState<
+    "isochrone" | "od-matrix" | null
+  >(null);
   const [osmPbfLoading, setOsmPbfLoading] = useState(false);
   const osmPbfAbortRef = useRef<AbortController | null>(null);
   const [osmPbfDialogOpen, setOsmPbfDialogOpen] = useState(false);
@@ -708,6 +716,23 @@ export function TopToolbar({
     recordReverseGeocodeConsent();
     setReverseGeocodeNoticeOpen(false);
     toggle(REVERSE_GEOCODE_PLUGIN_ID, appApi);
+  };
+  // Network analysis tools send the coordinates of the input points to a public
+  // Valhalla routing server, so they show the same one-time consent notice as
+  // Directions before opening, gated on every activation path (each menu item).
+  const openNetworkTool = (kind: "isochrone" | "od-matrix") => {
+    if (hasRoutingConsent()) {
+      setNetworkToolOpen(kind);
+      return;
+    }
+    setPendingNetworkTool(kind);
+    setRoutingNoticeOpen(true);
+  };
+  const confirmOpenNetworkTool = () => {
+    recordRoutingConsent();
+    setRoutingNoticeOpen(false);
+    if (pendingNetworkTool) setNetworkToolOpen(pendingNetworkTool);
+    setPendingNetworkTool(null);
   };
   const resetRuntimeControlsForNewProject = () => {
     closeMaplibreComponentControls(appApi);
@@ -1887,12 +1912,12 @@ export function TopToolbar({
             </DropdownMenuSubTrigger>
             <DropdownMenuSubContent>
               <DropdownMenuItem
-                onSelect={() => setNetworkToolOpen("isochrone")}
+                onSelect={() => openNetworkTool("isochrone")}
               >
                 {t("toolbar.networkTool.isochrone")}
               </DropdownMenuItem>
               <DropdownMenuItem
-                onSelect={() => setNetworkToolOpen("od-matrix")}
+                onSelect={() => openNetworkTool("od-matrix")}
               >
                 {t("toolbar.networkTool.odMatrix")}
               </DropdownMenuItem>
@@ -2403,6 +2428,38 @@ export function TopToolbar({
               {t("common.cancel")}
             </Button>
             <Button onClick={confirmEnableReverseGeocode}>
+              {t("toolbar.item.continue")}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+      <Dialog
+        open={routingNoticeOpen}
+        onOpenChange={(open: boolean) => {
+          setRoutingNoticeOpen(open);
+          if (!open) setPendingNetworkTool(null);
+        }}
+      >
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>
+              {t("toolbar.item.networkNoticeTitle")}
+            </DialogTitle>
+            <DialogDescription>
+              {t("toolbar.item.networkNoticeDesc")}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="outline"
+              onClick={() => {
+                setRoutingNoticeOpen(false);
+                setPendingNetworkTool(null);
+              }}
+            >
+              {t("common.cancel")}
+            </Button>
+            <Button onClick={confirmOpenNetworkTool}>
               {t("toolbar.item.continue")}
             </Button>
           </div>

--- a/apps/geolibre-desktop/src/components/processing/NetworkToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/NetworkToolsDialog.tsx
@@ -26,6 +26,7 @@ import {
   useState,
   type ReactElement,
 } from "react";
+import { useTranslation } from "react-i18next";
 import { ParameterField } from "./ParameterField";
 
 interface NetworkToolsDialogProps {
@@ -43,6 +44,7 @@ interface NetworkToolsDialogProps {
 export function NetworkToolsDialog({
   mapControllerRef,
 }: NetworkToolsDialogProps): ReactElement {
+  const { t } = useTranslation();
   const openTool = useAppStore((s) => s.ui.networkToolOpen);
   const setNetworkToolOpen = useAppStore((s) => s.setNetworkToolOpen);
   const layers = useAppStore((s) => s.layers);
@@ -56,6 +58,10 @@ export function NetworkToolsDialog({
   const [log, setLog] = useState<string[]>([]);
   const [running, setRunning] = useState(false);
   const logEndRef = useRef<HTMLDivElement>(null);
+  // Cancels the in-flight run (and any pending routing requests) when the
+  // dialog closes or a new run starts, so closing the dialog mid-batch does not
+  // keep hitting the server and silently adding result layers.
+  const abortRef = useRef<AbortController | null>(null);
 
   const tool = useMemo(
     () => getNetworkTool(selectedId) ?? NETWORK_TOOLS[0],
@@ -130,12 +136,22 @@ export function NetworkToolsDialog({
     for (const param of tool.parameters) {
       if (!param.required) continue;
       const value = params[param.id];
-      if (value === undefined || value === "" || value === null) {
+      if (
+        value === undefined ||
+        value === "" ||
+        value === null ||
+        (param.type === "number" &&
+          typeof value === "number" &&
+          Number.isNaN(value))
+      ) {
         appendLog(`Error: "${param.label}" is required`);
         return;
       }
     }
 
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
     setRunning(true);
     try {
       const ctx: ProcessingContext = {
@@ -144,11 +160,13 @@ export function NetworkToolsDialog({
         log: appendLog,
         fitBounds: (bounds) => mapControllerRef.current?.fitBounds(bounds),
         addResultLayer,
+        signal: controller.signal,
       };
       await tool.run(ctx);
     } catch (error) {
       appendLog(`Error: ${(error as Error).message}`);
     } finally {
+      if (abortRef.current === controller) abortRef.current = null;
       setRunning(false);
     }
   }, [tool, params, layers, appendLog, addResultLayer, mapControllerRef]);
@@ -159,16 +177,17 @@ export function NetworkToolsDialog({
     <Dialog
       open={open}
       onOpenChange={(next: boolean) => {
-        if (!next) setNetworkToolOpen(null);
+        if (!next) {
+          abortRef.current?.abort();
+          abortRef.current = null;
+          setNetworkToolOpen(null);
+        }
       }}
     >
       <DialogContent className="max-w-3xl">
         <DialogHeader>
-          <DialogTitle>Network analysis</DialogTitle>
-          <DialogDescription>
-            Isochrones, service areas, and origin–destination cost matrices from
-            your point layers.
-          </DialogDescription>
+          <DialogTitle>{t("network.title")}</DialogTitle>
+          <DialogDescription>{t("network.description")}</DialogDescription>
         </DialogHeader>
 
         <div className="flex gap-4">
@@ -176,7 +195,7 @@ export function NetworkToolsDialog({
           <ScrollArea className="h-[22rem] w-48 shrink-0 rounded-md border">
             <div className="p-1">
               <div className="px-2 py-1 text-xs font-medium text-muted-foreground">
-                Network
+                {t("network.heading")}
               </div>
               {NETWORK_TOOLS.map((entry) => (
                 <button
@@ -212,10 +231,7 @@ export function NetworkToolsDialog({
             </div>
 
             <p className="text-xs text-muted-foreground">
-              Point coordinates are sent to the routing server ({endpoint}). The
-              default is a shared public Valhalla server (FOSSGIS) with usage
-              limits — point it at your own server (Settings → Environment,
-              VITE_ROUTING_ENDPOINT) for heavy use.
+              {t("network.endpointNotice", { endpoint })}
             </p>
 
             <div>
@@ -225,14 +241,14 @@ export function NetworkToolsDialog({
                 ) : (
                   <Play className="h-4 w-4" />
                 )}
-                Run
+                {t("network.run")}
               </Button>
             </div>
 
             <ScrollArea className="h-24 rounded-md border bg-muted/30 p-2 font-mono text-xs">
               {log.length === 0 ? (
                 <span className="text-muted-foreground">
-                  Output will appear here.
+                  {t("network.outputPlaceholder")}
                 </span>
               ) : (
                 log.map((line, index) => (

--- a/apps/geolibre-desktop/src/components/processing/NetworkToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/NetworkToolsDialog.tsx
@@ -1,0 +1,251 @@
+import { getRoutingConfig, useAppStore } from "@geolibre/core";
+import { detectGeometryProfile, type MapController } from "@geolibre/map";
+import {
+  NETWORK_TOOLS,
+  getNetworkTool,
+  type GeometryFamily,
+  type ProcessingContext,
+} from "@geolibre/processing";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  ScrollArea,
+  cn,
+} from "@geolibre/ui";
+import type { FeatureCollection } from "geojson";
+import { Loader2, Play } from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactElement,
+} from "react";
+import { ParameterField } from "./ParameterField";
+
+interface NetworkToolsDialogProps {
+  mapControllerRef: React.RefObject<MapController | null>;
+}
+
+/**
+ * Processing → Network analysis dialog: isochrones / service areas and OD cost
+ * matrices. Runs client-side against a configurable Valhalla routing server and
+ * adds the result as a GeoJSON layer. A slimmer sibling of VectorToolsDialog
+ * (no sidecar/engine selector); the parameter form is shared via ParameterField.
+ *
+ * @param props.mapControllerRef - Map controller, used to zoom to result layers.
+ */
+export function NetworkToolsDialog({
+  mapControllerRef,
+}: NetworkToolsDialogProps): ReactElement {
+  const openTool = useAppStore((s) => s.ui.networkToolOpen);
+  const setNetworkToolOpen = useAppStore((s) => s.setNetworkToolOpen);
+  const layers = useAppStore((s) => s.layers);
+  const addGeoJsonLayer = useAppStore((s) => s.addGeoJsonLayer);
+
+  const open = openTool !== null;
+  const [selectedId, setSelectedId] = useState<string>(
+    openTool ?? NETWORK_TOOLS[0].id,
+  );
+  const [params, setParams] = useState<Record<string, unknown>>({});
+  const [log, setLog] = useState<string[]>([]);
+  const [running, setRunning] = useState(false);
+  const logEndRef = useRef<HTMLDivElement>(null);
+
+  const tool = useMemo(
+    () => getNetworkTool(selectedId) ?? NETWORK_TOOLS[0],
+    [selectedId],
+  );
+
+  // When the menu opens the dialog with a specific tool, preselect it.
+  useEffect(() => {
+    if (openTool) setSelectedId(openTool);
+  }, [openTool]);
+
+  // Reset parameters to the selected tool's defaults whenever it changes. The
+  // endpoint is seeded from the live routing config so a project-configured
+  // VITE_ROUTING_ENDPOINT wins over the registry's static default.
+  useEffect(() => {
+    const defaults: Record<string, unknown> = {};
+    for (const param of tool.parameters) {
+      if (param.id === "endpoint") defaults[param.id] = getRoutingConfig().endpoint;
+      else if (param.default !== undefined) defaults[param.id] = param.default;
+    }
+    setParams(defaults);
+    setLog([]);
+  }, [tool]);
+
+  // Keep the newest log lines in view as they stream in.
+  useEffect(() => {
+    logEndRef.current?.scrollIntoView({ block: "end" });
+  }, [log]);
+
+  const appendLog = useCallback(
+    (message: string) => setLog((prev) => [...prev, message]),
+    [],
+  );
+
+  const layerOptions = useCallback(
+    (filter?: GeometryFamily[]) =>
+      layers.filter((layer) => {
+        if (layer.type !== "geojson" || !layer.geojson) return false;
+        if (!filter?.length) return true;
+        const profile = detectGeometryProfile(layer.geojson);
+        return filter.some(
+          (family) =>
+            (family === "point" && profile.hasPoint) ||
+            (family === "line" && profile.hasLine) ||
+            (family === "polygon" && profile.hasPolygon),
+        );
+      }),
+    [layers],
+  );
+
+  const addResultLayer = useCallback(
+    (name: string, fc: FeatureCollection) => {
+      if (!fc.features.length) {
+        appendLog(`No features produced for "${name}"`);
+        return;
+      }
+      const layerId = addGeoJsonLayer(name, fc);
+      const layer = useAppStore
+        .getState()
+        .layers.find((item) => item.id === layerId);
+      if (layer) mapControllerRef.current?.fitLayer(layer);
+    },
+    [addGeoJsonLayer, appendLog, mapControllerRef],
+  );
+
+  const handleParamChange = useCallback((id: string, value: unknown) => {
+    setParams((prev) => ({ ...prev, [id]: value }));
+  }, []);
+
+  const handleRun = useCallback(async () => {
+    setLog([]);
+    for (const param of tool.parameters) {
+      if (!param.required) continue;
+      const value = params[param.id];
+      if (value === undefined || value === "" || value === null) {
+        appendLog(`Error: "${param.label}" is required`);
+        return;
+      }
+    }
+
+    setRunning(true);
+    try {
+      const ctx: ProcessingContext = {
+        layers,
+        parameters: params,
+        log: appendLog,
+        fitBounds: (bounds) => mapControllerRef.current?.fitBounds(bounds),
+        addResultLayer,
+      };
+      await tool.run(ctx);
+    } catch (error) {
+      appendLog(`Error: ${(error as Error).message}`);
+    } finally {
+      setRunning(false);
+    }
+  }, [tool, params, layers, appendLog, addResultLayer, mapControllerRef]);
+
+  const endpoint = (params.endpoint as string) || getRoutingConfig().endpoint;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next: boolean) => {
+        if (!next) setNetworkToolOpen(null);
+      }}
+    >
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Network analysis</DialogTitle>
+          <DialogDescription>
+            Isochrones, service areas, and origin–destination cost matrices from
+            your point layers.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex gap-4">
+          {/* Tool list */}
+          <ScrollArea className="h-[22rem] w-48 shrink-0 rounded-md border">
+            <div className="p-1">
+              <div className="px-2 py-1 text-xs font-medium text-muted-foreground">
+                Network
+              </div>
+              {NETWORK_TOOLS.map((entry) => (
+                <button
+                  key={entry.id}
+                  type="button"
+                  onClick={() => setSelectedId(entry.id)}
+                  className={cn(
+                    "w-full rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent",
+                    entry.id === selectedId &&
+                      "bg-accent font-medium text-accent-foreground",
+                  )}
+                >
+                  {entry.name}
+                </button>
+              ))}
+            </div>
+          </ScrollArea>
+
+          {/* Parameter form + run + log */}
+          <div className="flex min-w-0 flex-1 flex-col gap-3">
+            <p className="text-sm text-muted-foreground">{tool.description}</p>
+
+            <div className="flex flex-col gap-3">
+              {tool.parameters.map((param) => (
+                <ParameterField
+                  key={param.id}
+                  param={param}
+                  value={params[param.id]}
+                  layerOptions={layerOptions(param.geometryFilter)}
+                  onChange={(value) => handleParamChange(param.id, value)}
+                />
+              ))}
+            </div>
+
+            <p className="text-xs text-muted-foreground">
+              Point coordinates are sent to the routing server ({endpoint}). The
+              default is a shared public Valhalla server (FOSSGIS) with usage
+              limits — point it at your own server (Settings → Environment,
+              VITE_ROUTING_ENDPOINT) for heavy use.
+            </p>
+
+            <div>
+              <Button onClick={handleRun} disabled={running} className="gap-2">
+                {running ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Play className="h-4 w-4" />
+                )}
+                Run
+              </Button>
+            </div>
+
+            <ScrollArea className="h-24 rounded-md border bg-muted/30 p-2 font-mono text-xs">
+              {log.length === 0 ? (
+                <span className="text-muted-foreground">
+                  Output will appear here.
+                </span>
+              ) : (
+                log.map((line, index) => (
+                  <div key={index} className="whitespace-pre-wrap">
+                    {line}
+                  </div>
+                ))
+              )}
+              <div ref={logEndRef} />
+            </ScrollArea>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/geolibre-desktop/src/components/processing/ParameterField.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ParameterField.tsx
@@ -1,0 +1,152 @@
+import type { AlgorithmParameter } from "@geolibre/processing";
+import { Input, Label, Select } from "@geolibre/ui";
+import type { ReactElement } from "react";
+
+export interface ParameterFieldProps {
+  param: AlgorithmParameter;
+  value: unknown;
+  layerOptions: { id: string; name: string }[];
+  /** Attribute-field names for a `type: "field"` parameter. */
+  fieldOptions?: string[];
+  onChange: (value: unknown) => void;
+}
+
+/**
+ * Renders a single processing-tool parameter input (layer/select/field/
+ * boolean/number/string). Shared by the Vector tools and Network analysis
+ * dialogs so they stay visually and behaviorally consistent.
+ *
+ * @param props - The parameter, its current value, the layer/field options,
+ *   and an onChange callback.
+ */
+export function ParameterField({
+  param,
+  value,
+  layerOptions,
+  fieldOptions,
+  onChange,
+}: ParameterFieldProps): ReactElement {
+  const label = (
+    <Label htmlFor={param.id} className="text-xs">
+      {param.label}
+      {param.required ? <span className="text-destructive"> *</span> : null}
+    </Label>
+  );
+
+  if (param.type === "layer") {
+    return (
+      <div className="flex flex-col gap-1">
+        {label}
+        <Select
+          id={param.id}
+          value={(value as string) ?? ""}
+          onChange={(e) => onChange(e.target.value)}
+        >
+          <option value="">Select a layer...</option>
+          {layerOptions.map((layer) => (
+            <option key={layer.id} value={layer.id}>
+              {layer.name}
+            </option>
+          ))}
+        </Select>
+        {param.description ? (
+          <p className="text-xs text-muted-foreground">{param.description}</p>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (param.type === "select") {
+    return (
+      <div className="flex flex-col gap-1">
+        {label}
+        <Select
+          id={param.id}
+          value={(value as string) ?? ""}
+          onChange={(e) => onChange(e.target.value)}
+        >
+          {param.options?.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </Select>
+      </div>
+    );
+  }
+
+  if (param.type === "field") {
+    return (
+      <div className="flex flex-col gap-1">
+        {label}
+        <Select
+          id={param.id}
+          value={(value as string) ?? ""}
+          onChange={(e) => onChange(e.target.value)}
+        >
+          <option value="">
+            {fieldOptions?.length ? "Select a field..." : "Select a layer first"}
+          </option>
+          {fieldOptions?.map((name) => (
+            <option key={name} value={name}>
+              {name}
+            </option>
+          ))}
+        </Select>
+        {param.description ? (
+          <p className="text-xs text-muted-foreground">{param.description}</p>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (param.type === "boolean") {
+    return (
+      <label className="flex items-center gap-2 text-sm" htmlFor={param.id}>
+        <input
+          id={param.id}
+          type="checkbox"
+          checked={Boolean(value)}
+          onChange={(e) => onChange(e.target.checked)}
+          className="h-4 w-4 rounded border-input"
+        />
+        {param.label}
+      </label>
+    );
+  }
+
+  if (param.type === "number") {
+    return (
+      <div className="flex flex-col gap-1">
+        {label}
+        <Input
+          id={param.id}
+          type="number"
+          value={value === undefined || value === null ? "" : String(value)}
+          min={param.min}
+          max={param.max}
+          step={param.step}
+          onChange={(e) =>
+            onChange(e.target.value === "" ? undefined : Number(e.target.value))
+          }
+        />
+      </div>
+    );
+  }
+
+  // string
+  return (
+    <div className="flex flex-col gap-1">
+      {label}
+      <Input
+        id={param.id}
+        type="text"
+        value={(value as string) ?? ""}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      {param.description ? (
+        <p className="text-xs text-muted-foreground">{param.description}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/geolibre-desktop/src/components/processing/ParameterField.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ParameterField.tsx
@@ -1,6 +1,7 @@
 import type { AlgorithmParameter } from "@geolibre/processing";
 import { Input, Label, Select } from "@geolibre/ui";
 import type { ReactElement } from "react";
+import { useTranslation } from "react-i18next";
 
 export interface ParameterFieldProps {
   param: AlgorithmParameter;
@@ -26,6 +27,7 @@ export function ParameterField({
   fieldOptions,
   onChange,
 }: ParameterFieldProps): ReactElement {
+  const { t } = useTranslation();
   const label = (
     <Label htmlFor={param.id} className="text-xs">
       {param.label}
@@ -42,7 +44,7 @@ export function ParameterField({
           value={(value as string) ?? ""}
           onChange={(e) => onChange(e.target.value)}
         >
-          <option value="">Select a layer...</option>
+          <option value="">{t("processing.parameterField.selectLayer")}</option>
           {layerOptions.map((layer) => (
             <option key={layer.id} value={layer.id}>
               {layer.name}
@@ -85,7 +87,9 @@ export function ParameterField({
           onChange={(e) => onChange(e.target.value)}
         >
           <option value="">
-            {fieldOptions?.length ? "Select a field..." : "Select a layer first"}
+            {fieldOptions?.length
+              ? t("processing.parameterField.selectField")
+              : t("processing.parameterField.selectLayerFirst")}
           </option>
           {fieldOptions?.map((name) => (
             <option key={name} value={name}>

--- a/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/VectorToolsDialog.tsx
@@ -24,12 +24,12 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
-  Input,
   Label,
   ScrollArea,
   Select,
   cn,
 } from "@geolibre/ui";
+import { ParameterField } from "./ParameterField";
 import { Loader2, Play, Server } from "lucide-react";
 import type { FeatureCollection } from "geojson";
 import {
@@ -517,148 +517,5 @@ export function VectorToolsDialog({
         </div>
       </DialogContent>
     </Dialog>
-  );
-}
-
-interface ParameterFieldProps {
-  param: AlgorithmParameter;
-  value: unknown;
-  layerOptions: { id: string; name: string }[];
-  /** Attribute-field names for a `type: "field"` parameter. */
-  fieldOptions?: string[];
-  onChange: (value: unknown) => void;
-}
-
-function ParameterField({
-  param,
-  value,
-  layerOptions,
-  fieldOptions,
-  onChange,
-}: ParameterFieldProps): ReactElement {
-  const label = (
-    <Label htmlFor={param.id} className="text-xs">
-      {param.label}
-      {param.required ? <span className="text-destructive"> *</span> : null}
-    </Label>
-  );
-
-  if (param.type === "layer") {
-    return (
-      <div className="flex flex-col gap-1">
-        {label}
-        <Select
-          id={param.id}
-          value={(value as string) ?? ""}
-          onChange={(e) => onChange(e.target.value)}
-        >
-          <option value="">Select a layer...</option>
-          {layerOptions.map((layer) => (
-            <option key={layer.id} value={layer.id}>
-              {layer.name}
-            </option>
-          ))}
-        </Select>
-        {param.description ? (
-          <p className="text-xs text-muted-foreground">{param.description}</p>
-        ) : null}
-      </div>
-    );
-  }
-
-  if (param.type === "select") {
-    return (
-      <div className="flex flex-col gap-1">
-        {label}
-        <Select
-          id={param.id}
-          value={(value as string) ?? ""}
-          onChange={(e) => onChange(e.target.value)}
-        >
-          {param.options?.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.label}
-            </option>
-          ))}
-        </Select>
-      </div>
-    );
-  }
-
-  if (param.type === "field") {
-    return (
-      <div className="flex flex-col gap-1">
-        {label}
-        <Select
-          id={param.id}
-          value={(value as string) ?? ""}
-          onChange={(e) => onChange(e.target.value)}
-        >
-          <option value="">
-            {fieldOptions?.length ? "Select a field..." : "Select a layer first"}
-          </option>
-          {fieldOptions?.map((name) => (
-            <option key={name} value={name}>
-              {name}
-            </option>
-          ))}
-        </Select>
-        {param.description ? (
-          <p className="text-xs text-muted-foreground">{param.description}</p>
-        ) : null}
-      </div>
-    );
-  }
-
-  if (param.type === "boolean") {
-    return (
-      <label className="flex items-center gap-2 text-sm" htmlFor={param.id}>
-        <input
-          id={param.id}
-          type="checkbox"
-          checked={Boolean(value)}
-          onChange={(e) => onChange(e.target.checked)}
-          className="h-4 w-4 rounded border-input"
-        />
-        {param.label}
-      </label>
-    );
-  }
-
-  if (param.type === "number") {
-    return (
-      <div className="flex flex-col gap-1">
-        {label}
-        <Input
-          id={param.id}
-          type="number"
-          value={value === undefined || value === null ? "" : String(value)}
-          min={param.min}
-          max={param.max}
-          step={param.step}
-          onChange={(e) =>
-            onChange(
-              e.target.value === "" ? undefined : Number(e.target.value),
-            )
-          }
-        />
-      </div>
-    );
-  }
-
-  // string
-  return (
-    <div className="flex flex-col gap-1">
-      {label}
-      <Input
-        id={param.id}
-        type="text"
-        value={(value as string) ?? ""}
-        onChange={(e) => onChange(e.target.value)}
-      />
-      {param.description ? (
-        <p className="text-xs text-muted-foreground">{param.description}</p>
-      ) : null}
-    </div>
   );
 }

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -218,6 +218,10 @@
       "h3Grid": "Create H3 grid",
       "h3BinPoints": "Bin points to H3"
     },
+    "networkTool": {
+      "isochrone": "Isochrone / service area",
+      "odMatrix": "OD cost matrix"
+    },
     "rasterTool": {
       "hillshade": "Hillshade",
       "slope": "Slope",
@@ -291,6 +295,7 @@
       "geocode": "Geocode Addresses",
       "conversion": "Conversion",
       "vector": "Vector",
+      "network": "Network",
       "raster": "Raster",
       "subGroupGeometry": "Geometry",
       "subGroupOverlay": "Overlay",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -339,6 +339,8 @@
       "reverseGeocodeTooltip": "Click the map to look up an address. The clicked coordinates are sent to the public Nominatim service (nominatim.openstreetmap.org).",
       "reverseGeocodeNoticeTitle": "Reverse Geocode uses a public service",
       "reverseGeocodeNoticeDesc": "Turning on Reverse Geocode sends the coordinates of each point you click to the public Nominatim service (nominatim.openstreetmap.org) to resolve an address — your coordinates leave your device for those requests. The public service is rate-limited.",
+      "networkNoticeTitle": "Network analysis uses a public routing server",
+      "networkNoticeDesc": "Running a Network analysis tool sends the coordinates of your input points to the public Valhalla routing server (valhalla1.openstreetmap.de) to compute isochrones and cost matrices — your coordinates leave your device for those requests. The public server is rate-limited; point it at your own server (Settings → Environment, VITE_ROUTING_ENDPOINT) for heavy use.",
       "continue": "Continue",
       "largeOsmPbfTitle": "Large OSM PBF file",
       "largeOsmPbfDesc": "This file is about {{sizeMb}} MB. Parsing it converts every feature to GeoJSON in memory, which can be slow and may use a lot of memory in the browser. Continue?",
@@ -458,5 +460,20 @@
     "exportData": "Export",
     "exportJson": "Export JSON",
     "exportCsv": "Export CSV"
+  },
+  "network": {
+    "title": "Network analysis",
+    "description": "Isochrones, service areas, and origin–destination cost matrices from your point layers.",
+    "heading": "Network",
+    "run": "Run",
+    "outputPlaceholder": "Output will appear here.",
+    "endpointNotice": "Point coordinates are sent to the routing server ({{endpoint}}). The default is a shared public Valhalla server (FOSSGIS) with usage limits — point it at your own server (Settings → Environment, VITE_ROUTING_ENDPOINT) for heavy use."
+  },
+  "processing": {
+    "parameterField": {
+      "selectLayer": "Select a layer...",
+      "selectField": "Select a field...",
+      "selectLayerFirst": "Select a layer first"
+    }
   }
 }

--- a/apps/geolibre-desktop/src/lib/routing-consent.ts
+++ b/apps/geolibre-desktop/src/lib/routing-consent.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared consent gate for the Network analysis tools.
+ *
+ * Isochrones and OD cost matrices send the coordinates of the input points to a
+ * public Valhalla routing server, so the user must acknowledge a one-time
+ * privacy notice before the tools open. The acknowledgment is a persisted
+ * per-device flag, checked from every activation path (each Network menu item)
+ * so coordinates are never sent without consent. Mirrors the directions and
+ * reverse-geocode consent gates.
+ */
+export const ROUTING_CONSENT_KEY = "geolibre:network-routing-valhalla-notice";
+
+/** Whether the user has acknowledged the network-routing privacy notice. */
+export function hasRoutingConsent(): boolean {
+  try {
+    return localStorage.getItem(ROUTING_CONSENT_KEY) === "1";
+  } catch {
+    // localStorage unavailable (private mode): treat as not acknowledged so the
+    // notice is shown rather than silently sending coordinates.
+    return false;
+  }
+}
+
+/** Record that the user acknowledged the network-routing privacy notice. */
+export function recordRoutingConsent(): void {
+  try {
+    localStorage.setItem(ROUTING_CONSENT_KEY, "1");
+  } catch {
+    // Ignore: the notice will simply show again next time.
+  }
+}

--- a/packages/core/src/geocoding.ts
+++ b/packages/core/src/geocoding.ts
@@ -1,4 +1,5 @@
 import type { Feature, Point } from "geojson";
+import { getRuntimeEnvironment } from "./runtime-env";
 
 /**
  * Geocoding client and pure helpers shared by the batch-geocode dialog and the
@@ -86,21 +87,6 @@ export interface ReverseGeocodeDisplay {
   parts: Record<string, string>;
 }
 
-const geocoderEnv = (
-  import.meta as ImportMeta & {
-    env?: Record<string, string | undefined>;
-  }
-).env;
-
-function getRuntimeEnvironment(): Record<string, string | undefined> {
-  if (typeof window === "undefined") return geocoderEnv ?? {};
-
-  // __GEOLIBRE_RUNTIME_ENV__ is declared globally in ./types.
-  return {
-    ...(geocoderEnv ?? {}),
-    ...(window.__GEOLIBRE_RUNTIME_ENV__ ?? {}),
-  };
-}
 
 /**
  * Resolve the geocoder configuration from runtime env, falling back to the

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./types";
 export * from "./color-ramp";
+export * from "./routing";
 export * from "./vector-color";
 export * from "./project";
 export { createSampleStoryMap } from "./storymap-sample";
@@ -17,6 +18,7 @@ export {
   useAppStore,
   type AppState,
   type ConversionToolKind,
+  type NetworkToolKind,
   type RasterToolKind,
   type VectorToolKind,
 } from "./store";

--- a/packages/core/src/routing.ts
+++ b/packages/core/src/routing.ts
@@ -1,0 +1,297 @@
+import type {
+  Feature,
+  FeatureCollection,
+  LineString,
+  MultiPolygon,
+  Polygon,
+} from "geojson";
+import { getRuntimeEnvironment } from "./runtime-env";
+
+/**
+ * Routing / network-analysis client and pure helpers backing the Processing →
+ * Network tools (isochrones / service areas, OD cost matrices).
+ *
+ * Provider: Valhalla. OSRM (the Directions backend) has no isochrone endpoint,
+ * so isochrones require Valhalla, which also serves the OD matrix
+ * (`/sources_to_targets`) — one consistent API. The default is the shared
+ * public FOSSGIS server, overridable via runtime env (`VITE_ROUTING_ENDPOINT`)
+ * so a self-hosted Valhalla can be used instead. The pure request builders and
+ * response parsers carry no React/MapLibre dependency so they can be
+ * unit-tested without a browser or network.
+ */
+
+/** Default public Valhalla server (FOSSGIS). CORS-enabled; usage limits apply. */
+export const DEFAULT_ROUTING_ENDPOINT = "https://valhalla1.openstreetmap.de";
+
+/** Valhalla costing models exposed in the UI. */
+export type RoutingMode = "auto" | "pedestrian" | "bicycle";
+
+/** Isochrone contour metric: travel time (minutes) or distance (km). */
+export type RoutingMetric = "time" | "distance";
+
+export interface RoutingConfig {
+  /** Base URL of the Valhalla server (no trailing slash). */
+  endpoint: string;
+}
+
+/** A point with a stable id, used as an isochrone origin or matrix source/target. */
+export interface RoutingPoint {
+  id: string | number;
+  lon: number;
+  lat: number;
+}
+
+/**
+ * Resolves the routing configuration from runtime env, defaulting to the public
+ * Valhalla server. `VITE_ROUTING_ENDPOINT` overrides the endpoint.
+ *
+ * @returns The resolved routing configuration.
+ */
+export function getRoutingConfig(): RoutingConfig {
+  const env = getRuntimeEnvironment();
+  return {
+    endpoint:
+      stripTrailingSlash(env.VITE_ROUTING_ENDPOINT?.trim()) ||
+      DEFAULT_ROUTING_ENDPOINT,
+  };
+}
+
+function stripTrailingSlash(value: string | undefined): string | undefined {
+  return value ? value.replace(/\/+$/, "") : value;
+}
+
+/**
+ * Parses a comma/space-separated contour string ("5, 10, 15") into a sorted,
+ * de-duplicated list of positive numbers.
+ *
+ * @param value - The raw contour string.
+ * @returns Ascending unique positive contour values.
+ */
+export function parseContours(value: string): number[] {
+  const seen = new Set<number>();
+  for (const token of value.split(/[\s,]+/)) {
+    if (!token) continue;
+    const n = Number(token);
+    if (Number.isFinite(n) && n > 0) seen.add(n);
+  }
+  return [...seen].sort((a, b) => a - b);
+}
+
+export interface IsochroneRequestBody {
+  locations: { lon: number; lat: number }[];
+  costing: RoutingMode;
+  contours: ({ time: number } | { distance: number })[];
+  polygons: true;
+}
+
+/**
+ * Builds a Valhalla `/isochrone` request body for a single origin.
+ *
+ * @param point - The origin `[lon, lat]`.
+ * @param opts - Travel mode, metric, and contour values (minutes for time, km for distance).
+ * @returns The request body.
+ */
+export function buildIsochroneRequest(
+  point: [number, number],
+  opts: { mode: RoutingMode; metric: RoutingMetric; contours: number[] },
+): IsochroneRequestBody {
+  const [lon, lat] = point;
+  return {
+    locations: [{ lon, lat }],
+    costing: opts.mode,
+    contours: opts.contours.map((value) =>
+      opts.metric === "time" ? { time: value } : { distance: value },
+    ),
+    polygons: true,
+  };
+}
+
+type IsochroneFeatureProps = {
+  source_id: string | number;
+  mode: RoutingMode;
+  metric: RoutingMetric;
+  contour: number | null;
+};
+
+/**
+ * Converts a Valhalla isochrone GeoJSON response into polygon features tagged
+ * with their origin, mode, metric, and contour value. Non-polygon features
+ * (Valhalla can also emit contour LineStrings) are dropped.
+ *
+ * @param response - The Valhalla `/isochrone` GeoJSON FeatureCollection.
+ * @param ctx - Origin id, travel mode, and metric to tag onto each polygon.
+ * @returns The tagged polygon features.
+ */
+export function isochroneResponseToFeatures(
+  response: unknown,
+  ctx: { sourceId: string | number; mode: RoutingMode; metric: RoutingMetric },
+): Feature<Polygon | MultiPolygon, IsochroneFeatureProps>[] {
+  const features = (response as FeatureCollection | null)?.features;
+  if (!Array.isArray(features)) return [];
+  const out: Feature<Polygon | MultiPolygon, IsochroneFeatureProps>[] = [];
+  for (const feature of features) {
+    const type = feature?.geometry?.type;
+    if (type !== "Polygon" && type !== "MultiPolygon") continue;
+    const contour = (feature.properties as { contour?: unknown } | null)
+      ?.contour;
+    out.push({
+      type: "Feature",
+      geometry: feature.geometry as Polygon | MultiPolygon,
+      properties: {
+        source_id: ctx.sourceId,
+        mode: ctx.mode,
+        metric: ctx.metric,
+        contour: typeof contour === "number" ? contour : null,
+      },
+    });
+  }
+  return out;
+}
+
+export interface MatrixRequestBody {
+  sources: { lon: number; lat: number }[];
+  targets: { lon: number; lat: number }[];
+  costing: RoutingMode;
+}
+
+/**
+ * Builds a Valhalla `/sources_to_targets` request body.
+ *
+ * @param origins - The source points.
+ * @param targets - The target points.
+ * @param mode - The travel mode.
+ * @returns The request body.
+ */
+export function buildMatrixRequest(
+  origins: RoutingPoint[],
+  targets: RoutingPoint[],
+  mode: RoutingMode,
+): MatrixRequestBody {
+  return {
+    sources: origins.map((p) => ({ lon: p.lon, lat: p.lat })),
+    targets: targets.map((p) => ({ lon: p.lon, lat: p.lat })),
+    costing: mode,
+  };
+}
+
+type MatrixCell = {
+  from_index: number;
+  to_index: number;
+  /** Travel time in seconds, or null when unreachable. */
+  time: number | null;
+  /** Travel distance in km, or null when unreachable. */
+  distance: number | null;
+};
+
+type MatrixFeatureProps = {
+  origin_id: string | number;
+  dest_id: string | number;
+  time_s: number;
+  distance_km: number;
+  mode: RoutingMode;
+};
+
+/**
+ * Converts a Valhalla `/sources_to_targets` response into one LineString per
+ * reachable origin→destination pair, carrying the travel time and distance.
+ * Unreachable pairs (null time) are dropped.
+ *
+ * @param response - The Valhalla matrix response.
+ * @param origins - The origin points (indexed by `from_index`).
+ * @param targets - The target points (indexed by `to_index`).
+ * @param ctx - The travel mode to tag onto each pair.
+ * @returns The OD-pair LineString features.
+ */
+export function matrixResponseToFeatures(
+  response: unknown,
+  origins: RoutingPoint[],
+  targets: RoutingPoint[],
+  ctx: { mode: RoutingMode },
+): Feature<LineString, MatrixFeatureProps>[] {
+  const rows = (response as { sources_to_targets?: MatrixCell[][] } | null)
+    ?.sources_to_targets;
+  if (!Array.isArray(rows)) return [];
+  const out: Feature<LineString, MatrixFeatureProps>[] = [];
+  for (const row of rows) {
+    if (!Array.isArray(row)) continue;
+    for (const cell of row) {
+      if (cell?.time == null) continue;
+      const origin = origins[cell.from_index];
+      const target = targets[cell.to_index];
+      if (!origin || !target) continue;
+      out.push({
+        type: "Feature",
+        geometry: {
+          type: "LineString",
+          coordinates: [
+            [origin.lon, origin.lat],
+            [target.lon, target.lat],
+          ],
+        },
+        properties: {
+          origin_id: origin.id,
+          dest_id: target.id,
+          time_s: cell.time,
+          distance_km: cell.distance ?? 0,
+          mode: ctx.mode,
+        },
+      });
+    }
+  }
+  return out;
+}
+
+async function postJson(
+  url: string,
+  body: unknown,
+  signal?: AbortSignal,
+): Promise<unknown> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    signal,
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Routing request failed (${response.status} ${response.statusText})`,
+    );
+  }
+  return response.json();
+}
+
+/**
+ * Requests an isochrone from the Valhalla server.
+ *
+ * @param endpoint - The Valhalla base URL.
+ * @param body - The request body from {@link buildIsochroneRequest}.
+ * @param signal - Optional abort signal.
+ * @returns The Valhalla GeoJSON response.
+ */
+export function requestIsochrone(
+  endpoint: string,
+  body: IsochroneRequestBody,
+  signal?: AbortSignal,
+): Promise<unknown> {
+  return postJson(`${stripTrailingSlash(endpoint)}/isochrone`, body, signal);
+}
+
+/**
+ * Requests an OD cost matrix from the Valhalla server.
+ *
+ * @param endpoint - The Valhalla base URL.
+ * @param body - The request body from {@link buildMatrixRequest}.
+ * @param signal - Optional abort signal.
+ * @returns The Valhalla matrix response.
+ */
+export function requestMatrix(
+  endpoint: string,
+  body: MatrixRequestBody,
+  signal?: AbortSignal,
+): Promise<unknown> {
+  return postJson(
+    `${stripTrailingSlash(endpoint)}/sources_to_targets`,
+    body,
+    signal,
+  );
+}

--- a/packages/core/src/routing.ts
+++ b/packages/core/src/routing.ts
@@ -215,7 +215,7 @@ export function matrixResponseToFeatures(
   for (const row of rows) {
     if (!Array.isArray(row)) continue;
     for (const cell of row) {
-      if (cell?.time == null) continue;
+      if (cell?.time == null || cell.distance == null) continue;
       const origin = origins[cell.from_index];
       const target = targets[cell.to_index];
       if (!origin || !target) continue;
@@ -232,7 +232,7 @@ export function matrixResponseToFeatures(
           origin_id: origin.id,
           dest_id: target.id,
           time_s: cell.time,
-          distance_km: cell.distance ?? 0,
+          distance_km: cell.distance,
           mode: ctx.mode,
         },
       });

--- a/packages/core/src/runtime-env.ts
+++ b/packages/core/src/runtime-env.ts
@@ -1,0 +1,29 @@
+/**
+ * Resolves runtime environment variables shared by the external-service clients
+ * (geocoding, routing). Build-time Vite vars (`import.meta.env`) are overlaid
+ * with project-supplied runtime vars (`window.__GEOLIBRE_RUNTIME_ENV__`, set
+ * from project preferences) so a self-hosted endpoint can be configured without
+ * a rebuild. Carries no React/MapLibre dependency so callers stay unit-testable.
+ */
+
+const buildEnv = (
+  import.meta as ImportMeta & {
+    env?: Record<string, string | undefined>;
+  }
+).env;
+
+/**
+ * Merges build-time env with project runtime env (the latter wins). Falls back
+ * to build-time env alone outside a browser (e.g. in tests).
+ *
+ * @returns The resolved environment variables.
+ */
+export function getRuntimeEnvironment(): Record<string, string | undefined> {
+  if (typeof window === "undefined") return buildEnv ?? {};
+
+  // __GEOLIBRE_RUNTIME_ENV__ is declared globally in ./types.
+  return {
+    ...(buildEnv ?? {}),
+    ...(window.__GEOLIBRE_RUNTIME_ENV__ ?? {}),
+  };
+}

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -67,6 +67,9 @@ export type VectorToolKind =
   | "h3-grid"
   | "h3-bin-points";
 
+/** Identifiers of the network-analysis tools (`NETWORK_TOOLS` ids). */
+export type NetworkToolKind = "isochrone" | "od-matrix";
+
 /**
  * Identifiers of the raster processing tools. Kept in sync by hand with the
  * `id` fields of `RASTER_TOOLS` in `@geolibre/processing` (`raster-tools.ts`);
@@ -114,6 +117,7 @@ export interface AppState {
     processingOpen: boolean;
     conversionOpen: ConversionToolKind | null;
     vectorToolOpen: VectorToolKind | null;
+    networkToolOpen: NetworkToolKind | null;
     rasterToolOpen: RasterToolKind | null;
     geocodeOpen: boolean;
     sqlWorkspaceOpen: boolean;
@@ -141,6 +145,7 @@ export interface AppState {
   setProcessingOpen: (open: boolean) => void;
   setConversionOpen: (kind: ConversionToolKind | null) => void;
   setVectorToolOpen: (kind: VectorToolKind | null) => void;
+  setNetworkToolOpen: (kind: NetworkToolKind | null) => void;
   setRasterToolOpen: (kind: RasterToolKind | null) => void;
   setGeocodeOpen: (open: boolean) => void;
   setSqlWorkspaceOpen: (open: boolean) => void;
@@ -247,6 +252,7 @@ export const useAppStore = create<AppState>()(
         processingOpen: false,
         conversionOpen: null,
         vectorToolOpen: null,
+        networkToolOpen: null,
         rasterToolOpen: null,
         geocodeOpen: false,
         sqlWorkspaceOpen: false,
@@ -287,6 +293,8 @@ export const useAppStore = create<AppState>()(
         set((s) => ({ ui: { ...s.ui, conversionOpen: kind } })),
       setVectorToolOpen: (kind) =>
         set((s) => ({ ui: { ...s.ui, vectorToolOpen: kind } })),
+      setNetworkToolOpen: (kind) =>
+        set((s) => ({ ui: { ...s.ui, networkToolOpen: kind } })),
       setRasterToolOpen: (kind) =>
         set((s) => ({ ui: { ...s.ui, rasterToolOpen: kind } })),
       setGeocodeOpen: (open) =>

--- a/packages/processing/src/index.ts
+++ b/packages/processing/src/index.ts
@@ -6,6 +6,7 @@ export {
   countFeaturesAlgorithm,
 } from "./registry";
 export { VECTOR_TOOLS, getVectorTool } from "./vector-tools";
+export { NETWORK_TOOLS, getNetworkTool } from "./network-tools";
 export {
   H3_TOOLS,
   getH3Tool,

--- a/packages/processing/src/network-tools.ts
+++ b/packages/processing/src/network-tools.ts
@@ -1,0 +1,264 @@
+import { featureCollection } from "@turf/helpers";
+import type { Feature, Point } from "geojson";
+import {
+  type GeoLibreLayer,
+  type RoutingMetric,
+  type RoutingMode,
+  type RoutingPoint,
+  buildIsochroneRequest,
+  buildMatrixRequest,
+  getRoutingConfig,
+  isochroneResponseToFeatures,
+  matrixResponseToFeatures,
+  parseContours,
+  requestIsochrone,
+  requestMatrix,
+} from "@geolibre/core";
+import type { ProcessingAlgorithm, ProcessingContext } from "./types";
+
+/**
+ * Network-analysis processing tools (isochrones / service areas, OD cost
+ * matrices) backed by a Valhalla routing server. These run client-side: each
+ * `run` calls the configured Valhalla endpoint directly and adds the result as
+ * a GeoJSON layer, so they are NOT sidecar-capable.
+ */
+
+/** Cap on isochrone origins per run, to avoid overloading the public server. */
+const MAX_ISOCHRONE_POINTS = 25;
+/** Cap on OD matrix cells (origins × destinations) per run. */
+const MAX_MATRIX_CELLS = 2500;
+
+const MODE_OPTIONS = [
+  { value: "auto", label: "Driving" },
+  { value: "pedestrian", label: "Walking" },
+  { value: "bicycle", label: "Cycling" },
+];
+
+function getLayer(
+  ctx: ProcessingContext,
+  paramId: string,
+): GeoLibreLayer | undefined {
+  const layerId = ctx.parameters[paramId] as string | undefined;
+  return ctx.layers.find((layer) => layer.id === layerId);
+}
+
+/**
+ * Extracts routing points from a layer's Point features, deriving a stable id
+ * from the feature id, an `id`/`name` property, or the feature index. Non-point
+ * geometries are skipped.
+ */
+function layerToRoutingPoints(layer: GeoLibreLayer | undefined): RoutingPoint[] {
+  const features = layer?.geojson?.features ?? [];
+  const points: RoutingPoint[] = [];
+  features.forEach((feature, index) => {
+    if (feature.geometry?.type !== "Point") return;
+    const [lon, lat] = (feature.geometry as Point).coordinates;
+    if (!Number.isFinite(lon) || !Number.isFinite(lat)) return;
+    const props = feature.properties ?? {};
+    const id =
+      (feature.id as string | number | undefined) ??
+      (props.id as string | number | undefined) ??
+      (props.ID as string | number | undefined) ??
+      (props.name as string | undefined) ??
+      index;
+    points.push({ id, lon, lat });
+  });
+  return points;
+}
+
+function resolveEndpoint(ctx: ProcessingContext): string {
+  const param = (ctx.parameters.endpoint as string | undefined)?.trim();
+  return param || getRoutingConfig().endpoint;
+}
+
+export const isochroneTool: ProcessingAlgorithm = {
+  id: "isochrone",
+  name: "Isochrone / service area",
+  description:
+    "Travel-time or travel-distance reachability polygons from each point in a layer",
+  group: "Network",
+  parameters: [
+    {
+      id: "layer",
+      label: "Origin points",
+      type: "layer",
+      required: true,
+      geometryFilter: ["point"],
+    },
+    {
+      id: "mode",
+      label: "Travel mode",
+      type: "select",
+      default: "auto",
+      options: MODE_OPTIONS,
+    },
+    {
+      id: "metric",
+      label: "Metric",
+      type: "select",
+      default: "time",
+      options: [
+        { value: "time", label: "Travel time (minutes)" },
+        { value: "distance", label: "Distance (km)" },
+      ],
+    },
+    {
+      id: "contours",
+      label: "Contours",
+      type: "string",
+      default: "5,10,15",
+      description: "Comma-separated values (minutes for time, km for distance)",
+    },
+    {
+      id: "endpoint",
+      label: "Routing server (Valhalla)",
+      type: "string",
+      default: getRoutingConfig().endpoint,
+    },
+  ],
+  run: async (ctx) => {
+    const points = layerToRoutingPoints(getLayer(ctx, "layer"));
+    if (!points.length) {
+      ctx.log("Error: the origin layer has no point features");
+      return;
+    }
+    const mode = (ctx.parameters.mode as RoutingMode) || "auto";
+    const metric = (ctx.parameters.metric as RoutingMetric) || "time";
+    const contours = parseContours((ctx.parameters.contours as string) || "");
+    if (!contours.length) {
+      ctx.log("Error: enter at least one positive contour value");
+      return;
+    }
+    const endpoint = resolveEndpoint(ctx);
+
+    const used = points.slice(0, MAX_ISOCHRONE_POINTS);
+    if (points.length > used.length) {
+      ctx.log(
+        `Using the first ${used.length} of ${points.length} points (server-load cap).`,
+      );
+    }
+
+    const features: Feature[] = [];
+    for (const point of used) {
+      try {
+        const response = await requestIsochrone(
+          endpoint,
+          buildIsochroneRequest([point.lon, point.lat], {
+            mode,
+            metric,
+            contours,
+          }),
+        );
+        features.push(
+          ...isochroneResponseToFeatures(response, {
+            sourceId: point.id,
+            mode,
+            metric,
+          }),
+        );
+      } catch (error) {
+        ctx.log(
+          `Isochrone failed for point ${point.id}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    }
+
+    if (!features.length) {
+      ctx.log("No isochrone polygons were returned.");
+      return;
+    }
+    ctx.log(
+      `Computed ${features.length} isochrone polygon(s) for ${used.length} point(s).`,
+    );
+    ctx.addResultLayer?.("Isochrones", featureCollection(features));
+  },
+};
+
+export const odMatrixTool: ProcessingAlgorithm = {
+  id: "od-matrix",
+  name: "OD cost matrix",
+  description:
+    "Travel time and distance between every origin and destination point, as connecting lines",
+  group: "Network",
+  parameters: [
+    {
+      id: "origins",
+      label: "Origin points",
+      type: "layer",
+      required: true,
+      geometryFilter: ["point"],
+    },
+    {
+      id: "destinations",
+      label: "Destination points",
+      type: "layer",
+      required: true,
+      geometryFilter: ["point"],
+    },
+    {
+      id: "mode",
+      label: "Travel mode",
+      type: "select",
+      default: "auto",
+      options: MODE_OPTIONS,
+    },
+    {
+      id: "endpoint",
+      label: "Routing server (Valhalla)",
+      type: "string",
+      default: getRoutingConfig().endpoint,
+    },
+  ],
+  run: async (ctx) => {
+    const origins = layerToRoutingPoints(getLayer(ctx, "origins"));
+    const destinations = layerToRoutingPoints(getLayer(ctx, "destinations"));
+    if (!origins.length || !destinations.length) {
+      ctx.log("Error: both layers must contain point features");
+      return;
+    }
+    const cells = origins.length * destinations.length;
+    if (cells > MAX_MATRIX_CELLS) {
+      ctx.log(
+        `Error: ${origins.length} × ${destinations.length} = ${cells} pairs exceeds the ${MAX_MATRIX_CELLS}-cell limit. Reduce the input sizes.`,
+      );
+      return;
+    }
+    const mode = (ctx.parameters.mode as RoutingMode) || "auto";
+    const endpoint = resolveEndpoint(ctx);
+
+    try {
+      const response = await requestMatrix(
+        endpoint,
+        buildMatrixRequest(origins, destinations, mode),
+      );
+      const features = matrixResponseToFeatures(
+        response,
+        origins,
+        destinations,
+        { mode },
+      );
+      if (!features.length) {
+        ctx.log("No reachable origin–destination pairs were returned.");
+        return;
+      }
+      ctx.log(
+        `Computed ${features.length} origin–destination pair(s) of ${cells} requested.`,
+      );
+      ctx.addResultLayer?.("OD cost matrix", featureCollection(features));
+    } catch (error) {
+      ctx.log(
+        `OD matrix failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  },
+};
+
+export const NETWORK_TOOLS: ProcessingAlgorithm[] = [isochroneTool, odMatrixTool];
+
+export function getNetworkTool(id: string): ProcessingAlgorithm | undefined {
+  return NETWORK_TOOLS.find((tool) => tool.id === id);
+}

--- a/packages/processing/src/network-tools.ts
+++ b/packages/processing/src/network-tools.ts
@@ -25,6 +25,8 @@ import type { ProcessingAlgorithm, ProcessingContext } from "./types";
 
 /** Cap on isochrone origins per run, to avoid overloading the public server. */
 const MAX_ISOCHRONE_POINTS = 25;
+/** Valhalla's hard limit on contour values per isochrone request. */
+const MAX_ISOCHRONE_CONTOURS = 4;
 /** Cap on OD matrix cells (origins × destinations) per run. */
 const MAX_MATRIX_CELLS = 2500;
 
@@ -113,7 +115,10 @@ export const isochroneTool: ProcessingAlgorithm = {
       id: "endpoint",
       label: "Routing server (Valhalla)",
       type: "string",
-      default: getRoutingConfig().endpoint,
+      // Left empty so the live routing config is resolved when the tool runs
+      // (or seeded by the dialog), not baked in at module-import time. See
+      // resolveEndpoint, which falls back to getRoutingConfig().endpoint.
+      default: "",
     },
   ],
   run: async (ctx) => {
@@ -129,6 +134,12 @@ export const isochroneTool: ProcessingAlgorithm = {
       ctx.log("Error: enter at least one positive contour value");
       return;
     }
+    if (contours.length > MAX_ISOCHRONE_CONTOURS) {
+      ctx.log(
+        `Error: Valhalla supports at most ${MAX_ISOCHRONE_CONTOURS} contour values per request — reduce the list.`,
+      );
+      return;
+    }
     const endpoint = resolveEndpoint(ctx);
 
     const used = points.slice(0, MAX_ISOCHRONE_POINTS);
@@ -140,6 +151,7 @@ export const isochroneTool: ProcessingAlgorithm = {
 
     const features: Feature[] = [];
     for (const point of used) {
+      if (ctx.signal?.aborted) return;
       try {
         const response = await requestIsochrone(
           endpoint,
@@ -148,6 +160,7 @@ export const isochroneTool: ProcessingAlgorithm = {
             metric,
             contours,
           }),
+          ctx.signal,
         );
         features.push(
           ...isochroneResponseToFeatures(response, {
@@ -157,6 +170,7 @@ export const isochroneTool: ProcessingAlgorithm = {
           }),
         );
       } catch (error) {
+        if (ctx.signal?.aborted) return;
         ctx.log(
           `Isochrone failed for point ${point.id}: ${
             error instanceof Error ? error.message : String(error)
@@ -208,7 +222,10 @@ export const odMatrixTool: ProcessingAlgorithm = {
       id: "endpoint",
       label: "Routing server (Valhalla)",
       type: "string",
-      default: getRoutingConfig().endpoint,
+      // Left empty so the live routing config is resolved when the tool runs
+      // (or seeded by the dialog), not baked in at module-import time. See
+      // resolveEndpoint, which falls back to getRoutingConfig().endpoint.
+      default: "",
     },
   ],
   run: async (ctx) => {
@@ -232,6 +249,7 @@ export const odMatrixTool: ProcessingAlgorithm = {
       const response = await requestMatrix(
         endpoint,
         buildMatrixRequest(origins, destinations, mode),
+        ctx.signal,
       );
       const features = matrixResponseToFeatures(
         response,
@@ -248,6 +266,7 @@ export const odMatrixTool: ProcessingAlgorithm = {
       );
       ctx.addResultLayer?.("OD cost matrix", featureCollection(features));
     } catch (error) {
+      if (ctx.signal?.aborted) return;
       ctx.log(
         `OD matrix failed: ${
           error instanceof Error ? error.message : String(error)

--- a/packages/processing/src/types.ts
+++ b/packages/processing/src/types.ts
@@ -89,6 +89,11 @@ export interface ProcessingContext {
   duckdb?: DuckDbCapability;
   /** Current map viewport as [west, south, east, north], when available. */
   viewportBounds?: () => [number, number, number, number] | null;
+  /**
+   * Abort signal for long-running or networked tools (e.g. Network analysis),
+   * so in-flight requests can be cancelled when the host dialog closes.
+   */
+  signal?: AbortSignal;
 }
 
 export interface ProcessingAlgorithm {

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import {
+  DEFAULT_ROUTING_ENDPOINT,
+  buildIsochroneRequest,
+  buildMatrixRequest,
+  getRoutingConfig,
+  isochroneResponseToFeatures,
+  matrixResponseToFeatures,
+  parseContours,
+  type RoutingPoint,
+} from "../packages/core/src/routing";
+
+describe("parseContours", () => {
+  it("parses, sorts, and de-duplicates positive values", () => {
+    assert.deepEqual(parseContours("10, 5, 15"), [5, 10, 15]);
+    assert.deepEqual(parseContours("5 10 5"), [5, 10]);
+  });
+
+  it("drops non-finite and non-positive tokens", () => {
+    assert.deepEqual(parseContours("5, abc, -3, 0, 8"), [5, 8]);
+    assert.deepEqual(parseContours(""), []);
+  });
+});
+
+describe("buildIsochroneRequest", () => {
+  it("builds a time request with one contour per value", () => {
+    const body = buildIsochroneRequest([-83, 40], {
+      mode: "auto",
+      metric: "time",
+      contours: [5, 10],
+    });
+    assert.deepEqual(body, {
+      locations: [{ lon: -83, lat: 40 }],
+      costing: "auto",
+      contours: [{ time: 5 }, { time: 10 }],
+      polygons: true,
+    });
+  });
+
+  it("uses the distance key for the distance metric", () => {
+    const body = buildIsochroneRequest([1, 2], {
+      mode: "pedestrian",
+      metric: "distance",
+      contours: [1],
+    });
+    assert.deepEqual(body.contours, [{ distance: 1 }]);
+    assert.equal(body.costing, "pedestrian");
+  });
+});
+
+describe("isochroneResponseToFeatures", () => {
+  const response = {
+    type: "FeatureCollection",
+    features: [
+      {
+        type: "Feature",
+        properties: { contour: 5, metric: "time" },
+        geometry: { type: "Polygon", coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]] },
+      },
+      {
+        type: "Feature",
+        properties: { contour: 10 },
+        geometry: { type: "LineString", coordinates: [[0, 0], [1, 1]] },
+      },
+    ],
+  };
+
+  it("keeps polygons and tags them with origin/mode/metric/contour", () => {
+    const features = isochroneResponseToFeatures(response, {
+      sourceId: "hospital-1",
+      mode: "auto",
+      metric: "time",
+    });
+    assert.equal(features.length, 1);
+    assert.deepEqual(features[0].properties, {
+      source_id: "hospital-1",
+      mode: "auto",
+      metric: "time",
+      contour: 5,
+    });
+    assert.equal(features[0].geometry.type, "Polygon");
+  });
+
+  it("returns an empty array for a malformed response", () => {
+    assert.deepEqual(isochroneResponseToFeatures(null, {
+      sourceId: 0,
+      mode: "auto",
+      metric: "time",
+    }), []);
+  });
+});
+
+describe("buildMatrixRequest", () => {
+  it("maps points to Valhalla sources/targets", () => {
+    const origins: RoutingPoint[] = [{ id: "a", lon: -83, lat: 40 }];
+    const targets: RoutingPoint[] = [
+      { id: "x", lon: -82, lat: 41 },
+      { id: "y", lon: -84, lat: 39 },
+    ];
+    const body = buildMatrixRequest(origins, targets, "bicycle");
+    assert.deepEqual(body, {
+      sources: [{ lon: -83, lat: 40 }],
+      targets: [
+        { lon: -82, lat: 41 },
+        { lon: -84, lat: 39 },
+      ],
+      costing: "bicycle",
+    });
+  });
+});
+
+describe("matrixResponseToFeatures", () => {
+  const origins: RoutingPoint[] = [{ id: "o1", lon: 0, lat: 0 }];
+  const targets: RoutingPoint[] = [
+    { id: "t1", lon: 1, lat: 1 },
+    { id: "t2", lon: 2, lat: 2 },
+  ];
+  const response = {
+    sources_to_targets: [
+      [
+        { from_index: 0, to_index: 0, time: 600, distance: 6.5 },
+        { from_index: 0, to_index: 1, time: null, distance: null },
+      ],
+    ],
+  };
+
+  it("emits one LineString per reachable pair with cost attributes", () => {
+    const features = matrixResponseToFeatures(response, origins, targets, {
+      mode: "auto",
+    });
+    assert.equal(features.length, 1);
+    const [feature] = features;
+    assert.equal(feature.geometry.type, "LineString");
+    assert.deepEqual(feature.geometry.coordinates, [[0, 0], [1, 1]]);
+    assert.deepEqual(feature.properties, {
+      origin_id: "o1",
+      dest_id: "t1",
+      time_s: 600,
+      distance_km: 6.5,
+      mode: "auto",
+    });
+  });
+
+  it("returns an empty array for a malformed response", () => {
+    assert.deepEqual(
+      matrixResponseToFeatures({}, origins, targets, { mode: "auto" }),
+      [],
+    );
+  });
+});
+
+describe("getRoutingConfig", () => {
+  afterEach(() => {
+    delete (globalThis as { window?: unknown }).window;
+  });
+
+  it("defaults to the public Valhalla endpoint", () => {
+    assert.equal(getRoutingConfig().endpoint, DEFAULT_ROUTING_ENDPOINT);
+  });
+
+  it("honors VITE_ROUTING_ENDPOINT from runtime env and trims a trailing slash", () => {
+    (globalThis as { window?: unknown }).window = {
+      __GEOLIBRE_RUNTIME_ENV__: {
+        VITE_ROUTING_ENDPOINT: "https://valhalla.example.com/",
+      },
+    };
+    assert.equal(getRoutingConfig().endpoint, "https://valhalla.example.com");
+  });
+});


### PR DESCRIPTION
Closes #308.

## What

Adds a **Processing → Network** category with two tools, backed by a **configurable Valhalla** routing server. Results are ordinary GeoJSON layers, so they flow into the existing styling/export pipeline.

- **Isochrone / service area** — travel-time *or* travel-distance reachability polygons from each point in a layer (drive/walk/bike). One tool covers both via a metric toggle.
- **OD cost matrix** — travel time + distance between every origin and destination point (two point layers), emitted as connecting LineStrings carrying `time_s` / `distance_km`.

## Why Valhalla

OSRM (the existing Directions backend) has **no isochrone endpoint**, so isochrones require Valhalla. I verified the public FOSSGIS Valhalla (`https://valhalla1.openstreetmap.de`) is browser-callable (`access-control-allow-origin: *`) and serves both `/isochrone` (GeoJSON polygons, time+distance contours) and `/sources_to_targets` (OD matrix) — one consistent API.

## Configurable backend & privacy

- Endpoint is editable per-run and overridable globally via `VITE_ROUTING_ENDPOINT` (Settings → Environment / project preferences), so users can point at a self-hosted Valhalla.
- The dialog shows a privacy note (coordinates are sent to the routing server) and the tools cap input sizes (≤25 isochrone origins, ≤2500 matrix cells) to respect the shared public server.

## Structure

- `@geolibre/core/routing.ts` — `getRoutingConfig()` + pure, unit-tested request builders / response parsers + thin `fetch` wrappers (mirrors `geocoding.ts`). Extracted the shared `runtime-env` resolver out of `geocoding.ts` (no behavior change).
- `@geolibre/processing/network-tools.ts` — `NETWORK_TOOLS` as client-only `ProcessingAlgorithm`s.
- Store: `networkToolOpen` / `setNetworkToolOpen`.
- UI: extracted `ParameterField` to a shared file (reused by both dialogs); new slim `NetworkToolsDialog` (no sidecar/engine selector); Processing → Network submenu + i18n.

## Tests & verification

- `tests/routing.test.ts` — `parseContours`, isochrone/matrix request builders, response→GeoJSON parsers, and `getRoutingConfig` env override (11 cases, no live fetch).
- Full suite green (609 + new), `npm run typecheck` and pre-commit (eslint + build) pass.
- **Verified end-to-end in a browser** against live Valhalla: dropped point layers → Processing → Network → Isochrone (contours 5,10) produced polygons; OD Matrix produced cost LineStrings; both added as layers with zero console errors.

## Notes

- Live calls hit the public Valhalla, so this is **not** added to the hermetic `e2e/` suite (verified manually instead).
- Tool/param labels are plain English (matching the processing registry + VectorToolsDialog); menu labels use `t()` (matching the existing vector-tool menu).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Network analysis tools to the desktop app (Isochrone and OD cost matrix) with a dedicated dialog for selecting tools, editing parameters, streaming output logs, and adding/fitting result layers on the map.
  * Introduced a routing-consent notice gate for network analysis, with pending-tool resume after consent.
* **Bug Fixes**
  * Improved resilience of tool dialogs via lazy loading with safe fallbacks; supports aborting in-flight runs when closing.
* **Documentation**
  * Added new English UI text, including routing-consent messaging and routing server/endpoint guidance.
* **Tests**
  * Added unit tests covering routing request/response helpers and environment endpoint handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->