### PR TITLE
feat(layers): add glTF/GLB 3D model layer (#306)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS
 - MapLibre map workspace with OpenFreeMap basemaps, blank background support, and toggleable navigation, fullscreen, geolocation, globe, terrain, scale, attribution, and logo controls
 - Load local vector layers supported by DuckDB-WASM Spatial, including common formats such as GeoJSON, GeoParquet, GeoPackage, Shapefile, FlatGeobuf, KML/KMZ, GML, delimited text, GPX, and OpenStreetMap PBF extracts (parsed in-browser with osmix)
 - Reproject vector layers to EPSG:4326 on load and split dragged GPX files into named waypoint, track, and route layers
-- Add Data menu for XYZ tiles, WMS, WFS, GeoJSON URLs, vector tiles, COG and GeoTIFF rasters, Cloud-Optimized NetCDF/HDF (via kerchunk references), MBTiles, ArcGIS FeatureServer and VectorTileServer layers, PMTiles, Zarr, LiDAR, 3D Tiles (including authenticated tilesets via custom request headers), Gaussian splats, and georeferenced video overlays
+- Add Data menu for XYZ tiles, WMS, WFS, GeoJSON URLs, vector tiles, COG and GeoTIFF rasters, Cloud-Optimized NetCDF/HDF (via kerchunk references), MBTiles, ArcGIS FeatureServer and VectorTileServer layers, PMTiles, Zarr, LiDAR, 3D Tiles (including authenticated tilesets via custom request headers), Gaussian splats, glTF/GLB 3D models placed at coordinates, and georeferenced video overlays
 - Deck.gl Layer builder for composing deck.gl overlays from uploaded files or remote URLs
 - Cloud data integrations through the Planetary Computer and Earth Engine panels, the Overture Maps plugin, and federal Web Services plugins
 - Manual and automatic refresh for WFS, GeoJSON URL, and Add Vector Layer URL layers

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -670,7 +670,8 @@ export function AddDataDialog({
     setIsLoadingDeckViz(false);
     // Pre-fill the scenegraph model + transform from the bundled example when
     // the dialog opens directly on the 3D-model kind.
-    const startSg = getDeckVizLayerDef(startKind)?.example.scenegraph;
+    const startExample = getDeckVizLayerDef(startKind)?.example;
+    const startSg = startExample?.scenegraph;
     setDeckVizModelUrl(startSg?.modelUrl ?? "");
     setDeckVizModelMode("single");
     setDeckVizModelScale(
@@ -678,8 +679,9 @@ export function AddDataDialog({
     );
     setDeckVizModelBearing(String(startSg?.bearing ?? 0));
     setDeckVizModelAltitude(String(startSg?.altitude ?? 0));
-    setDeckVizModelLng("");
-    setDeckVizModelLat("");
+    const [startLng, startLat] = startExample?.scenegraphLocation ?? ["", ""];
+    setDeckVizModelLng(String(startLng));
+    setDeckVizModelLat(String(startLat));
   }, [kind, initialDeckVizKind]);
 
   const description = useMemo(() => {
@@ -898,8 +900,9 @@ export function AddDataDialog({
       // cleared above, so leaving mode on "data" would strand the submit
       // button disabled with no point file loaded.
       setDeckVizModelMode("single");
-      setDeckVizModelLng("");
-      setDeckVizModelLat("");
+      const [lng, lat] = nextDef?.example.scenegraphLocation ?? ["", ""];
+      setDeckVizModelLng(String(lng));
+      setDeckVizModelLat(String(lat));
     }
   };
 

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -47,6 +47,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { useTranslation } from "react-i18next";
 import { openLocalDataFileWithFallback } from "../../lib/tauri-io";
 import { createAppAPI } from "../../hooks/usePlugins";
 import {
@@ -385,12 +386,54 @@ function inferDelimitedTextField(
   return fields[0] ?? currentField;
 }
 
+/** Recursively finds the first `[lng, lat]` pair in a GeoJSON coordinate array. */
+function firstCoordinate(coords: unknown): [number, number] | null {
+  if (!Array.isArray(coords)) return null;
+  if (typeof coords[0] === "number" && typeof coords[1] === "number") {
+    return [coords[0], coords[1]];
+  }
+  for (const child of coords) {
+    const found = firstCoordinate(child);
+    if (found) return found;
+  }
+  return null;
+}
+
+/**
+ * Flattens a GeoJSON FeatureCollection into `{ lng, lat, ...properties }` rows
+ * so the 3D-model (scenegraph) layer can place a model at each feature. The
+ * lon/lat come from each feature's geometry (its first coordinate), while the
+ * properties remain available for the optional altitude/bearing/scale columns.
+ *
+ * @param geojson - The parsed FeatureCollection.
+ * @returns One row per feature that has a usable coordinate.
+ */
+function geoJsonToPointRows(
+  geojson: FeatureCollection | undefined,
+): Record<string, unknown>[] {
+  if (!geojson) return [];
+  const rows: Record<string, unknown>[] = [];
+  for (const feature of geojson.features) {
+    const coord = firstCoordinate(
+      (feature.geometry as { coordinates?: unknown } | null)?.coordinates,
+    );
+    if (!coord) continue;
+    rows.push({
+      ...(feature.properties ?? {}),
+      lng: coord[0],
+      lat: coord[1],
+    });
+  }
+  return rows;
+}
+
 export function AddDataDialog({
   kind,
   mapControllerRef,
   onOpenChange,
   initialDeckVizKind,
 }: AddDataDialogProps) {
+  const { t } = useTranslation();
   const open = kind !== null;
   const addLayer = useAppStore((s) => s.addLayer);
   const existingLayers = useAppStore((s) => s.layers);
@@ -851,6 +894,12 @@ export function AddDataDialog({
       setDeckVizModelScale(String(exampleSg.sizeScale));
       setDeckVizModelBearing(String(exampleSg.bearing));
       setDeckVizModelAltitude(String(exampleSg.altitude));
+      // Reset placement back to single-location: the data-mode parse was
+      // cleared above, so leaving mode on "data" would strand the submit
+      // button disabled with no point file loaded.
+      setDeckVizModelMode("single");
+      setDeckVizModelLng("");
+      setDeckVizModelLat("");
     }
   };
 
@@ -858,6 +907,9 @@ export function AddDataDialog({
   // defaults for any field the user left blank/invalid.
   const buildScenegraphConfig = (): DeckVizScenegraphConfig => {
     const numOr = (value: string, fallback: number): number => {
+      // Number("") is 0 (and finite), so treat a blank field as unset and use
+      // the fallback rather than silently zeroing scale/bearing/altitude.
+      if (value.trim() === "") return fallback;
       const parsed = Number(value);
       return Number.isFinite(parsed) ? parsed : fallback;
     };
@@ -920,9 +972,28 @@ export function AddDataDialog({
   }) => {
     const def = getDeckVizLayerDef(deckVizKind);
     if (!def) throw new Error("Unknown layer type.");
-    const { parsed, mapping, style, sourcePath, scenegraph } = params;
-    if (def.kind === "scenegraph" && !scenegraph?.modelUrl) {
-      throw new Error("Enter a glTF/GLB model URL.");
+    // The model URL is already enforced by the submit handler and the disabled
+    // state of the Add button, and the example path always supplies one, so no
+    // redundant guard is needed here.
+    const { style, sourcePath, scenegraph } = params;
+    let { parsed, mapping } = params;
+
+    // The 3D-model layer renders from row data; a dropped GeoJSON point
+    // collection is converted to rows so GeoJSON point files work alongside
+    // CSV/JSON (the shared file picker offers .geojson).
+    if (def.kind === "scenegraph" && parsed.format === "geojson") {
+      const rows = geoJsonToPointRows(parsed.geojson);
+      if (rows.length === 0) {
+        throw new Error(t("toolbar.error.scenegraphNoPointFeatures"));
+      }
+      parsed = {
+        format: "csv-rows",
+        columns: Object.keys(rows[0]).map((key) => ({ value: key, label: key })),
+        rows,
+        rowCount: rows.length,
+      };
+      // lon/lat come from geometry; keep any property-mapped roles intact.
+      mapping = { ...mapping, lng: "lng", lat: "lat" };
     }
 
     if (def.format === "geojson" && parsed.format !== "geojson") {
@@ -1284,7 +1355,7 @@ export function AddDataDialog({
         const isScenegraph = deckVizKind === "scenegraph";
         const scenegraph = isScenegraph ? buildScenegraphConfig() : undefined;
         if (isScenegraph && !scenegraph?.modelUrl) {
-          throw new Error("Enter a glTF/GLB model URL.");
+          throw new Error(t("toolbar.error.scenegraphModelUrlRequired"));
         }
         // Single-location mode synthesizes a one-row dataset from the typed
         // coordinate instead of loading a point file.
@@ -1296,7 +1367,10 @@ export function AddDataDialog({
           const lng = parseCoord(deckVizModelLng);
           const lat = parseCoord(deckVizModelLat);
           if (!Number.isFinite(lng) || !Number.isFinite(lat)) {
-            throw new Error("Enter a valid longitude and latitude.");
+            throw new Error(t("toolbar.error.scenegraphInvalidLngLat"));
+          }
+          if (lng < -180 || lng > 180 || lat < -90 || lat > 90) {
+            throw new Error(t("toolbar.error.scenegraphOutOfRange"));
           }
           finalizeDeckVizLayer({
             parsed: {
@@ -1879,7 +1953,7 @@ export function AddDataDialog({
                 <div className="space-y-3 rounded-md border border-border p-3">
                   <div className="space-y-1.5">
                     <Label htmlFor="deckviz-model-url">
-                      glTF / GLB model URL
+                      {t("toolbar.scenegraph.modelUrl")}
                     </Label>
                     <Input
                       id="deckviz-model-url"
@@ -1892,7 +1966,9 @@ export function AddDataDialog({
                   </div>
 
                   <div className="space-y-1.5">
-                    <Label htmlFor="deckviz-model-mode">Placement</Label>
+                    <Label htmlFor="deckviz-model-mode">
+                      {t("toolbar.scenegraph.placement")}
+                    </Label>
                     <Select
                       id="deckviz-model-mode"
                       value={deckVizModelMode}
@@ -1904,15 +1980,21 @@ export function AddDataDialog({
                         setDeckVizStatus(null);
                       }}
                     >
-                      <option value="single">Single location</option>
-                      <option value="data">From point data</option>
+                      <option value="single">
+                        {t("toolbar.scenegraph.placementSingle")}
+                      </option>
+                      <option value="data">
+                        {t("toolbar.scenegraph.placementData")}
+                      </option>
                     </Select>
                   </div>
 
                   {deckVizModelMode === "single" ? (
                     <div className="grid gap-3 sm:grid-cols-2">
                       <div className="space-y-1.5">
-                        <Label htmlFor="deckviz-model-lng">Longitude</Label>
+                        <Label htmlFor="deckviz-model-lng">
+                          {t("toolbar.scenegraph.longitude")}
+                        </Label>
                         <Input
                           id="deckviz-model-lng"
                           inputMode="decimal"
@@ -1924,7 +2006,9 @@ export function AddDataDialog({
                         />
                       </div>
                       <div className="space-y-1.5">
-                        <Label htmlFor="deckviz-model-lat">Latitude</Label>
+                        <Label htmlFor="deckviz-model-lat">
+                          {t("toolbar.scenegraph.latitude")}
+                        </Label>
                         <Input
                           id="deckviz-model-lat"
                           inputMode="decimal"
@@ -1940,7 +2024,9 @@ export function AddDataDialog({
 
                   <div className="grid gap-3 sm:grid-cols-3">
                     <div className="space-y-1.5">
-                      <Label htmlFor="deckviz-model-scale">Scale</Label>
+                      <Label htmlFor="deckviz-model-scale">
+                        {t("toolbar.scenegraph.scale")}
+                      </Label>
                       <Input
                         id="deckviz-model-scale"
                         inputMode="numeric"
@@ -1951,7 +2037,9 @@ export function AddDataDialog({
                       />
                     </div>
                     <div className="space-y-1.5">
-                      <Label htmlFor="deckviz-model-bearing">Bearing°</Label>
+                      <Label htmlFor="deckviz-model-bearing">
+                        {t("toolbar.scenegraph.bearing")}
+                      </Label>
                       <Input
                         id="deckviz-model-bearing"
                         inputMode="numeric"
@@ -1962,7 +2050,9 @@ export function AddDataDialog({
                       />
                     </div>
                     <div className="space-y-1.5">
-                      <Label htmlFor="deckviz-model-altitude">Altitude m</Label>
+                      <Label htmlFor="deckviz-model-altitude">
+                        {t("toolbar.scenegraph.altitude")}
+                      </Label>
                       <Input
                         id="deckviz-model-altitude"
                         inputMode="numeric"

--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -10,12 +10,14 @@ import {
   type ArcGISSourceType,
   createDeckVizStoreLayer,
   DECK_VIZ_CATEGORY_LABELS,
+  DEFAULT_DECK_VIZ_SCENEGRAPH,
   DEFAULT_DECK_VIZ_STYLE,
   ensureMercatorProjection,
   getDeckVizLayerDef,
   listDeckVizLayerDefs,
   type DeckVizCategory,
   type DeckVizFieldMapping,
+  type DeckVizScenegraphConfig,
   type DeckVizStyle,
 } from "@geolibre/plugins";
 import {
@@ -102,6 +104,11 @@ interface AddDataDialogProps {
   kind: AddDataKind | null;
   mapControllerRef: RefObject<MapController | null>;
   onOpenChange: (open: boolean) => void;
+  /**
+   * Deck.gl Layer kind to pre-select when the dialog opens as `deckgl-viz`
+   * (e.g. a "3D model" menu entry opens it on the scenegraph layer type).
+   */
+  initialDeckVizKind?: string;
 }
 
 type GpxMode = "url" | "file";
@@ -382,6 +389,7 @@ export function AddDataDialog({
   kind,
   mapControllerRef,
   onOpenChange,
+  initialDeckVizKind,
 }: AddDataDialogProps) {
   const open = kind !== null;
   const addLayer = useAppStore((s) => s.addLayer);
@@ -498,6 +506,18 @@ export function AddDataDialog({
   });
   const [deckVizStatus, setDeckVizStatus] = useState<string | null>(null);
   const [isLoadingDeckViz, setIsLoadingDeckViz] = useState(false);
+  // Scenegraph (glTF 3D model) layer-specific inputs.
+  const [deckVizModelUrl, setDeckVizModelUrl] = useState("");
+  const [deckVizModelMode, setDeckVizModelMode] = useState<"single" | "data">(
+    "single",
+  );
+  const [deckVizModelScale, setDeckVizModelScale] = useState(
+    String(DEFAULT_DECK_VIZ_SCENEGRAPH.sizeScale),
+  );
+  const [deckVizModelBearing, setDeckVizModelBearing] = useState("0");
+  const [deckVizModelAltitude, setDeckVizModelAltitude] = useState("0");
+  const [deckVizModelLng, setDeckVizModelLng] = useState("");
+  const [deckVizModelLat, setDeckVizModelLat] = useState("");
 
   useEffect(() => {
     if (!kind) return;
@@ -587,7 +607,16 @@ export function AddDataDialog({
     if (kind === "deckgl-viz") {
       ensureMercatorProjection(mapControllerRef.current?.getMap());
     }
-    setDeckVizKind("scatterplot");
+    const startKind =
+      kind === "deckgl-viz" && initialDeckVizKind
+        ? initialDeckVizKind
+        : "scatterplot";
+    setDeckVizKind(startKind);
+    // Keep the layer-name field in step with the pre-selected kind (the name
+    // map above defaults deckgl-viz to the scatterplot label).
+    if (kind === "deckgl-viz") {
+      setLayerName(getDeckVizLayerDef(startKind)?.label ?? "Deck.gl Layer");
+    }
     setDeckVizMode("url");
     setDeckVizUrl("");
     setDeckVizSourcePath("");
@@ -596,7 +625,19 @@ export function AddDataDialog({
     setDeckVizStyle({ ...DEFAULT_DECK_VIZ_STYLE });
     setDeckVizStatus(null);
     setIsLoadingDeckViz(false);
-  }, [kind]);
+    // Pre-fill the scenegraph model + transform from the bundled example when
+    // the dialog opens directly on the 3D-model kind.
+    const startSg = getDeckVizLayerDef(startKind)?.example.scenegraph;
+    setDeckVizModelUrl(startSg?.modelUrl ?? "");
+    setDeckVizModelMode("single");
+    setDeckVizModelScale(
+      String(startSg?.sizeScale ?? DEFAULT_DECK_VIZ_SCENEGRAPH.sizeScale),
+    );
+    setDeckVizModelBearing(String(startSg?.bearing ?? 0));
+    setDeckVizModelAltitude(String(startSg?.altitude ?? 0));
+    setDeckVizModelLng("");
+    setDeckVizModelLat("");
+  }, [kind, initialDeckVizKind]);
 
   const description = useMemo(() => {
     if (kind === "xyz") {
@@ -786,6 +827,12 @@ export function AddDataDialog({
   const beforeLayer = beforeLayerId.trim() || null;
 
   const deckVizDef = getDeckVizLayerDef(deckVizKind);
+  const isScenegraphKind = deckVizKind === "scenegraph";
+  // Single-location scenegraph mode types a coordinate instead of loading a
+  // point file, so the data-loader UI is hidden then.
+  const showDeckVizDataLoader = !(
+    isScenegraphKind && deckVizModelMode === "single"
+  );
 
   const handleDeckVizKindChange = (nextKind: string) => {
     setDeckVizKind(nextKind);
@@ -794,7 +841,35 @@ export function AddDataDialog({
     setDeckVizStatus(null);
     setError(null);
     setDeckVizStyle({ ...DEFAULT_DECK_VIZ_STYLE });
-    setLayerName(getDeckVizLayerDef(nextKind)?.label ?? "Deck.gl Layer");
+    const nextDef = getDeckVizLayerDef(nextKind);
+    setLayerName(nextDef?.label ?? "Deck.gl Layer");
+    // Pre-fill the scenegraph model URL and transform from the bundled example
+    // so the user can place a model immediately (and tweak from there).
+    const exampleSg = nextDef?.example.scenegraph;
+    if (nextKind === "scenegraph" && exampleSg) {
+      setDeckVizModelUrl(exampleSg.modelUrl);
+      setDeckVizModelScale(String(exampleSg.sizeScale));
+      setDeckVizModelBearing(String(exampleSg.bearing));
+      setDeckVizModelAltitude(String(exampleSg.altitude));
+    }
+  };
+
+  // Builds the scenegraph config from the dialog inputs, falling back to the
+  // defaults for any field the user left blank/invalid.
+  const buildScenegraphConfig = (): DeckVizScenegraphConfig => {
+    const numOr = (value: string, fallback: number): number => {
+      const parsed = Number(value);
+      return Number.isFinite(parsed) ? parsed : fallback;
+    };
+    return {
+      modelUrl: deckVizModelUrl.trim(),
+      sizeScale: numOr(
+        deckVizModelScale,
+        DEFAULT_DECK_VIZ_SCENEGRAPH.sizeScale,
+      ),
+      bearing: numOr(deckVizModelBearing, 0),
+      altitude: numOr(deckVizModelAltitude, 0),
+    };
   };
 
   const readDeckVizSource = async (): Promise<{
@@ -841,10 +916,14 @@ export function AddDataDialog({
     mapping: DeckVizFieldMapping;
     style: DeckVizStyle;
     sourcePath: string;
+    scenegraph?: DeckVizScenegraphConfig;
   }) => {
     const def = getDeckVizLayerDef(deckVizKind);
     if (!def) throw new Error("Unknown layer type.");
-    const { parsed, mapping, style, sourcePath } = params;
+    const { parsed, mapping, style, sourcePath, scenegraph } = params;
+    if (def.kind === "scenegraph" && !scenegraph?.modelUrl) {
+      throw new Error("Enter a glTF/GLB model URL.");
+    }
 
     if (def.format === "geojson" && parsed.format !== "geojson") {
       throw new Error(`${def.label} needs a GeoJSON file.`);
@@ -876,6 +955,7 @@ export function AddDataDialog({
         format: parsed.format,
         fieldMapping: mapping,
         style,
+        ...(scenegraph ? { scenegraph } : {}),
       },
       rows: parsed.format === "geojson" ? undefined : parsed.rows,
       geojson: parsed.geojson,
@@ -910,6 +990,7 @@ export function AddDataDialog({
         mapping: def.example.fieldMapping,
         style: { ...DEFAULT_DECK_VIZ_STYLE, ...(def.example.style ?? {}) },
         sourcePath: def.example.url,
+        scenegraph: def.example.scenegraph,
       });
     } catch (err) {
       setError(errorMessage(err, "Could not load the example data."));
@@ -1200,6 +1281,40 @@ export function AddDataDialog({
       const name = layerName.trim() || KIND_LABELS[kind].replace("Add ", "");
 
       if (kind === "deckgl-viz") {
+        const isScenegraph = deckVizKind === "scenegraph";
+        const scenegraph = isScenegraph ? buildScenegraphConfig() : undefined;
+        if (isScenegraph && !scenegraph?.modelUrl) {
+          throw new Error("Enter a glTF/GLB model URL.");
+        }
+        // Single-location mode synthesizes a one-row dataset from the typed
+        // coordinate instead of loading a point file.
+        if (isScenegraph && deckVizModelMode === "single") {
+          // Number("") is 0, so treat a blank field as missing rather than the
+          // valid coordinate 0.
+          const parseCoord = (value: string): number =>
+            value.trim() === "" ? Number.NaN : Number(value);
+          const lng = parseCoord(deckVizModelLng);
+          const lat = parseCoord(deckVizModelLat);
+          if (!Number.isFinite(lng) || !Number.isFinite(lat)) {
+            throw new Error("Enter a valid longitude and latitude.");
+          }
+          finalizeDeckVizLayer({
+            parsed: {
+              format: "csv-rows",
+              columns: [
+                { value: "lng", label: "lng" },
+                { value: "lat", label: "lat" },
+              ],
+              rows: [{ lng, lat }],
+              rowCount: 1,
+            },
+            mapping: { lng: "lng", lat: "lat" },
+            style: deckVizStyle,
+            sourcePath: scenegraph?.modelUrl ?? "",
+            scenegraph,
+          });
+          return;
+        }
         if (!deckVizParsed) {
           throw new Error("Load the example data, or a file/URL, first.");
         }
@@ -1208,6 +1323,7 @@ export function AddDataDialog({
           mapping: deckVizMapping,
           style: deckVizStyle,
           sourcePath: deckVizSourcePath,
+          scenegraph,
         });
         return;
       }
@@ -1628,7 +1744,12 @@ export function AddDataDialog({
     isLoadingDeckViz ||
     (kind === "gpx" && !hasSelectedGpxLayerKind) ||
     (kind === "delimited-text" && missingCustomDelimiter) ||
-    (kind === "deckgl-viz" && !deckVizParsed) ||
+    (kind === "deckgl-viz" &&
+      deckVizKind === "scenegraph" &&
+      !deckVizModelUrl.trim()) ||
+    (kind === "deckgl-viz" &&
+      !deckVizParsed &&
+      !(deckVizKind === "scenegraph" && deckVizModelMode === "single")) ||
     (kind === "postgres" && (!martinServer || !selectedMartinSourceId));
 
   return (
@@ -1754,18 +1875,121 @@ export function AddDataDialog({
                 ) : null}
               </div>
 
-              <Button
-                type="button"
-                variant="outline"
-                onClick={handleUseDeckVizExample}
-                disabled={isLoadingDeckViz}
-              >
-                <Globe2 className="mr-2 h-3.5 w-3.5" />
-                {isLoadingDeckViz ? "Loading..." : "Use example data"}
-              </Button>
+              {isScenegraphKind ? (
+                <div className="space-y-3 rounded-md border border-border p-3">
+                  <div className="space-y-1.5">
+                    <Label htmlFor="deckviz-model-url">
+                      glTF / GLB model URL
+                    </Label>
+                    <Input
+                      id="deckviz-model-url"
+                      placeholder="https://example.com/model.glb"
+                      value={deckVizModelUrl}
+                      onChange={(event) =>
+                        setDeckVizModelUrl(event.target.value)
+                      }
+                    />
+                  </div>
 
-              <div className="space-y-1.5">
-                <Label htmlFor="deckviz-mode">Or load your own</Label>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="deckviz-model-mode">Placement</Label>
+                    <Select
+                      id="deckviz-model-mode"
+                      value={deckVizModelMode}
+                      onChange={(event) => {
+                        setDeckVizModelMode(
+                          event.target.value as "single" | "data",
+                        );
+                        setDeckVizParsed(null);
+                        setDeckVizStatus(null);
+                      }}
+                    >
+                      <option value="single">Single location</option>
+                      <option value="data">From point data</option>
+                    </Select>
+                  </div>
+
+                  {deckVizModelMode === "single" ? (
+                    <div className="grid gap-3 sm:grid-cols-2">
+                      <div className="space-y-1.5">
+                        <Label htmlFor="deckviz-model-lng">Longitude</Label>
+                        <Input
+                          id="deckviz-model-lng"
+                          inputMode="decimal"
+                          placeholder="-122.45"
+                          value={deckVizModelLng}
+                          onChange={(event) =>
+                            setDeckVizModelLng(event.target.value)
+                          }
+                        />
+                      </div>
+                      <div className="space-y-1.5">
+                        <Label htmlFor="deckviz-model-lat">Latitude</Label>
+                        <Input
+                          id="deckviz-model-lat"
+                          inputMode="decimal"
+                          placeholder="37.78"
+                          value={deckVizModelLat}
+                          onChange={(event) =>
+                            setDeckVizModelLat(event.target.value)
+                          }
+                        />
+                      </div>
+                    </div>
+                  ) : null}
+
+                  <div className="grid gap-3 sm:grid-cols-3">
+                    <div className="space-y-1.5">
+                      <Label htmlFor="deckviz-model-scale">Scale</Label>
+                      <Input
+                        id="deckviz-model-scale"
+                        inputMode="numeric"
+                        value={deckVizModelScale}
+                        onChange={(event) =>
+                          setDeckVizModelScale(event.target.value)
+                        }
+                      />
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="deckviz-model-bearing">Bearing°</Label>
+                      <Input
+                        id="deckviz-model-bearing"
+                        inputMode="numeric"
+                        value={deckVizModelBearing}
+                        onChange={(event) =>
+                          setDeckVizModelBearing(event.target.value)
+                        }
+                      />
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="deckviz-model-altitude">Altitude m</Label>
+                      <Input
+                        id="deckviz-model-altitude"
+                        inputMode="numeric"
+                        value={deckVizModelAltitude}
+                        onChange={(event) =>
+                          setDeckVizModelAltitude(event.target.value)
+                        }
+                      />
+                    </div>
+                  </div>
+                </div>
+              ) : null}
+
+              {showDeckVizDataLoader ? (
+                <>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={handleUseDeckVizExample}
+                    disabled={isLoadingDeckViz}
+                  >
+                    <Globe2 className="mr-2 h-3.5 w-3.5" />
+                    {isLoadingDeckViz ? "Loading..." : "Use example data"}
+                  </Button>
+
+                  <div className="space-y-1.5">
+                    <Label htmlFor="deckviz-mode">Or load your own</Label>
                 <Select
                   id="deckviz-mode"
                   value={deckVizMode}
@@ -1850,6 +2074,8 @@ export function AddDataDialog({
                     </div>
                   ))}
                 </div>
+                  ) : null}
+                </>
               ) : null}
 
               {deckVizDef ? (

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -1665,14 +1665,6 @@ export function TopToolbar({
           <DropdownMenuItem onSelect={() => setAddDataKind("deckgl-viz")}>
             {t("toolbar.layerType.deckglViz")}
           </DropdownMenuItem>
-          <DropdownMenuItem
-            onSelect={() => {
-              setAddDataDeckVizKind("scenegraph");
-              setAddDataKind("deckgl-viz");
-            }}
-          >
-            {t("toolbar.layerType.gltfModel")}
-          </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuLabel className="text-xs text-muted-foreground">
             {t("toolbar.item.sectionCloudFormats")}
@@ -1704,6 +1696,14 @@ export function TopToolbar({
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={handleAddThreeDTilesLayer}>
             {t("toolbar.item.threeDTilesLayer")}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={() => {
+              setAddDataDeckVizKind("scenegraph");
+              setAddDataKind("deckgl-viz");
+            }}
+          >
+            {t("toolbar.layerType.gltfModel")}
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuLabel className="text-xs text-muted-foreground">

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -435,6 +435,11 @@ export function TopToolbar({
     ),
   );
   const [addDataKind, setAddDataKind] = useState<AddDataKind | null>(null);
+  // Deck.gl Layer kind the Add Data dialog opens on (e.g. the 3D-model entry
+  // jumps straight to the scenegraph layer type).
+  const [addDataDeckVizKind, setAddDataDeckVizKind] = useState<
+    string | undefined
+  >(undefined);
   const [netcdfDialogOpen, setNetcdfDialogOpen] = useState(false);
   const [newProjectDialogOpen, setNewProjectDialogOpen] = useState(false);
   const [projectUrlDialogOpen, setProjectUrlDialogOpen] = useState(false);
@@ -1660,6 +1665,14 @@ export function TopToolbar({
           <DropdownMenuItem onSelect={() => setAddDataKind("deckgl-viz")}>
             {t("toolbar.layerType.deckglViz")}
           </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={() => {
+              setAddDataDeckVizKind("scenegraph");
+              setAddDataKind("deckgl-viz");
+            }}
+          >
+            {t("toolbar.layerType.gltfModel")}
+          </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuLabel className="text-xs text-muted-foreground">
             {t("toolbar.item.sectionCloudFormats")}
@@ -2258,8 +2271,12 @@ export function TopToolbar({
       <AddDataDialog
         kind={addDataKind}
         mapControllerRef={mapControllerRef}
+        initialDeckVizKind={addDataDeckVizKind}
         onOpenChange={(open: boolean) => {
-          if (!open) setAddDataKind(null);
+          if (!open) {
+            setAddDataKind(null);
+            setAddDataDeckVizKind(undefined);
+          }
         }}
       />
       <AddNetcdfDialog

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -361,7 +361,22 @@
       "osmPbfLoadFailedWithHint": "{{message}} If this is a Mapbox Vector Tile (.pbf), it cannot be loaded as an OSM extract.",
       "couldNotOpenOsmPbf": "Could not open the OSM PBF file.",
       "invalidOsmPbfUrl": "Enter a valid http(s) URL to an .osm.pbf file.",
-      "couldNotDownloadOsmPbf": "Could not download the OSM PBF file."
+      "couldNotDownloadOsmPbf": "Could not download the OSM PBF file.",
+      "scenegraphModelUrlRequired": "Enter a glTF/GLB model URL.",
+      "scenegraphInvalidLngLat": "Enter a valid longitude and latitude.",
+      "scenegraphOutOfRange": "Longitude must be between -180 and 180, and latitude between -90 and 90.",
+      "scenegraphNoPointFeatures": "The GeoJSON has no point features to place models at."
+    },
+    "scenegraph": {
+      "modelUrl": "glTF / GLB model URL",
+      "placement": "Placement",
+      "placementSingle": "Single location",
+      "placementData": "From point data",
+      "longitude": "Longitude",
+      "latitude": "Latitude",
+      "scale": "Scale",
+      "bearing": "Bearing°",
+      "altitude": "Altitude m"
     }
   },
   "geocode": {

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -183,6 +183,7 @@
       "arcgis": "ArcGIS Layer",
       "video": "Video Layer",
       "deckglViz": "Deck.gl Layer",
+      "gltfModel": "3D Model (glTF)",
       "postgres": "PostgreSQL Layer"
     },
     "conversion": {

--- a/e2e/pwa.spec.ts
+++ b/e2e/pwa.spec.ts
@@ -65,24 +65,24 @@ test("registers a service worker and serves the shell offline after first visit"
   // *after* the page's fetch for a chunk resolves — so the map canvas can be
   // visible (the ~13 MB MapLibre chunk ran in-page) while the SW is still
   // persisting that chunk. Going offline in that window leaves the chunk
-  // uncached, so the offline reload can't boot the map. Wait for all first-load
-  // requests to finish, then for the Cache Storage entry count to stop growing,
-  // so every runtime-cached chunk is durably stored before we drop the network.
+  // uncached, so the offline reload can't import MapLibre and never renders the
+  // map. Wait for all first-load requests to finish, then for every heavy
+  // runtime-cached chunk the boot pulled in to be durably stored.
   await page.waitForLoadState("networkidle");
-  await waitForCacheStorageToSettle(page);
+  await waitForHeavyAssetsCached(page);
 
   // Drop the network and reload: the precached shell plus the runtime-cached
   // MapLibre chunk must still bring the app up with no connectivity.
   await context.setOffline(true);
   try {
     await page.reload();
-    // The offline cold boot re-parses/executes every chunk from cache, so give
-    // the canvas the same 30s budget the warm boot above gets.
+    // The offline cold boot re-parses/executes the ~13 MB MapLibre chunk from
+    // cache under software WebGL on CI, so give it a generous budget.
     await expect(page.getByTestId("map-canvas")).toBeVisible({
-      timeout: 30_000,
+      timeout: 60_000,
     });
     await expect(page.locator(".maplibregl-canvas")).toBeVisible({
-      timeout: 30_000,
+      timeout: 60_000,
     });
   } finally {
     await context.setOffline(false);
@@ -90,27 +90,44 @@ test("registers a service worker and serves the shell offline after first visit"
 });
 
 /**
- * Wait until the service worker's Cache Storage stops growing, i.e. it has
- * finished persisting the runtime-cached chunks the first load pulled in.
- * CacheFirst writes happen asynchronously after the page's fetch resolves, so
- * "canvas visible" alone does not guarantee the chunk is cached; polling the
- * total entry count until two consecutive reads match (and it is non-zero)
- * gives a deterministic "caches settled" signal before we go offline.
+ * Wait until every heavy runtime-cached asset the first load pulled in is
+ * durably present in Cache Storage. Chunks larger than the precache size limit
+ * (4 MB — the MapLibre bundle, DuckDB-WASM, etc.) are excluded from the precache
+ * and CacheFirst-cached on first fetch; that write completes asynchronously
+ * after the page's fetch resolves, so "canvas visible" alone does not guarantee
+ * the chunk is on disk. Polling `caches.match()` for each heavy `/assets/` chunk
+ * the page actually loaded gives a deterministic "ready to go offline" signal —
+ * runtime CacheFirst entries are keyed by plain URL, so the match is reliable
+ * (unlike revision-keyed precache entries, which are already durable at SW
+ * install and need no wait).
  */
-async function waitForCacheStorageToSettle(page: Page): Promise<void> {
+async function waitForHeavyAssetsCached(page: Page): Promise<void> {
   await page.waitForFunction(
     async () => {
-      const w = window as unknown as { __prevCacheEntryCount?: number };
-      const names = await caches.keys();
-      let count = 0;
-      for (const name of names) {
-        count += (await (await caches.open(name)).keys()).length;
+      const origin = location.origin;
+      const heavy = performance
+        .getEntriesByType("resource")
+        .filter((entry): entry is PerformanceResourceTiming => {
+          const resource = entry as PerformanceResourceTiming;
+          return (
+            resource.name.startsWith(origin) &&
+            resource.name.includes("/assets/") &&
+            resource.name.endsWith(".js") &&
+            // > 4 MB: globIgnored from the precache, so CacheFirst-cached at
+            // runtime (matches maximumFileSizeToCacheInBytes in vite.config.ts).
+            resource.decodedBodySize > 4 * 1024 * 1024
+          );
+        })
+        .map((resource) => resource.name);
+      // The MapLibre chunk must have loaded for the warm map boot above; if no
+      // heavy chunk is visible yet, keep polling rather than passing vacuously.
+      if (heavy.length === 0) return false;
+      for (const url of heavy) {
+        if (!(await caches.match(url))) return false;
       }
-      const previous = w.__prevCacheEntryCount ?? -1;
-      w.__prevCacheEntryCount = count;
-      return count > 0 && count === previous;
+      return true;
     },
     undefined,
-    { timeout: 30_000, polling: 1000 },
+    { timeout: 60_000, polling: 500 },
   );
 }

--- a/e2e/scenegraph.spec.ts
+++ b/e2e/scenegraph.spec.ts
@@ -27,15 +27,14 @@ test("adds a glTF 3D model layer placed at a single coordinate", async ({
   await page.getByRole("button", { name: "Add Data" }).click();
   await page.getByRole("menuitem", { name: "3D Model (glTF)" }).click();
 
-  // The dialog opens pre-selected on the scenegraph layer type, with the model
-  // URL pre-filled from the bundled example.
+  // The dialog opens pre-selected on the scenegraph layer type, pre-filled from
+  // the bundled example: model URL plus a default single-location coordinate so
+  // the user can place a model with one click.
   const dialog = page.getByRole("dialog");
   await expect(dialog).toBeVisible();
   await expect(dialog.getByLabel("glTF / GLB model URL")).not.toHaveValue("");
-
-  // Single-location placement is the default; type a coordinate.
-  await dialog.getByLabel("Longitude").fill("-122.45");
-  await dialog.getByLabel("Latitude").fill("37.78");
+  await expect(dialog.getByLabel("Longitude")).not.toHaveValue("");
+  await expect(dialog.getByLabel("Latitude")).not.toHaveValue("");
 
   await dialog.getByRole("button", { name: "Add layer" }).click();
 
@@ -58,8 +57,10 @@ test("blocks single-location placement without a valid coordinate", async ({
   const dialog = page.getByRole("dialog");
   await expect(dialog).toBeVisible();
 
-  // No coordinate entered: submitting surfaces a validation error and keeps the
-  // dialog open (a blank field must not be treated as the coordinate 0).
+  // Clearing the pre-filled longitude and submitting surfaces a validation
+  // error and keeps the dialog open (a blank field must not be read as the
+  // coordinate 0).
+  await dialog.getByLabel("Longitude").fill("");
   await dialog.getByRole("button", { name: "Add layer" }).click();
   await expect(
     dialog.getByText("Enter a valid longitude and latitude."),

--- a/e2e/scenegraph.spec.ts
+++ b/e2e/scenegraph.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * Exercises the glTF 3D model layer (#306): the "3D Model (glTF)" Add Data
+ * entry, single-location placement, and the resulting deck.gl scenegraph store
+ * layer. The store-layer assertion is hermetic — it does not depend on the
+ * model URL actually loading (model loading happens asynchronously in a deck.gl
+ * worker and is non-fatal if the network is unavailable), so this runs without
+ * external network access.
+ */
+
+/** Waits for MapLibre to mount its WebGL canvas — the app's "map ready" signal. */
+async function waitForMap(page: Page): Promise<void> {
+  await page.goto("/");
+  await expect(page.getByTestId("map-canvas")).toBeVisible();
+  await expect(page.locator(".maplibregl-canvas")).toBeVisible({
+    timeout: 30_000,
+  });
+}
+
+test("adds a glTF 3D model layer placed at a single coordinate", async ({
+  page,
+}) => {
+  await waitForMap(page);
+
+  // Open Add Data -> 3D Model (glTF).
+  await page.getByRole("button", { name: "Add Data" }).click();
+  await page.getByRole("menuitem", { name: "3D Model (glTF)" }).click();
+
+  // The dialog opens pre-selected on the scenegraph layer type, with the model
+  // URL pre-filled from the bundled example.
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByLabel("glTF / GLB model URL")).not.toHaveValue("");
+
+  // Single-location placement is the default; type a coordinate.
+  await dialog.getByLabel("Longitude").fill("-122.45");
+  await dialog.getByLabel("Latitude").fill("37.78");
+
+  await dialog.getByRole("button", { name: "Add layer" }).click();
+
+  // The layer appears in the panel as a deck.gl (scenegraph) layer.
+  const row = page.locator(
+    '[data-testid="layer-row"][data-layer-name="3D model (glTF)"]',
+  );
+  await expect(row).toBeVisible();
+  await expect(dialog).toBeHidden();
+});
+
+test("blocks single-location placement without a valid coordinate", async ({
+  page,
+}) => {
+  await waitForMap(page);
+
+  await page.getByRole("button", { name: "Add Data" }).click();
+  await page.getByRole("menuitem", { name: "3D Model (glTF)" }).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+
+  // No coordinate entered: submitting surfaces a validation error and keeps the
+  // dialog open (a blank field must not be treated as the coordinate 0).
+  await dialog.getByRole("button", { name: "Add layer" }).click();
+  await expect(
+    dialog.getByText("Enter a valid longitude and latitude."),
+  ).toBeVisible();
+  await expect(dialog).toBeVisible();
+});

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -135,6 +135,7 @@ export { restoreDeckViz } from "./plugins/deckgl-viz/overlay";
 export { ensureMercatorProjection } from "./plugins/map-projection-utils";
 export {
   DECK_VIZ_CATEGORY_LABELS,
+  DEFAULT_DECK_VIZ_SCENEGRAPH,
   DEFAULT_DECK_VIZ_STYLE,
   getDeckVizLayerDef,
   listDeckVizLayerDefs,
@@ -145,6 +146,7 @@ export {
   type DeckVizInputKind,
   type DeckVizLayerDef,
   type DeckVizRole,
+  type DeckVizScenegraphConfig,
   type DeckVizStyle,
   type DeckVizStyleControl,
 } from "./plugins/deckgl-viz/registry";

--- a/packages/plugins/src/plugins/deckgl-viz/overlay.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/overlay.ts
@@ -236,6 +236,7 @@ function buildContext(layer: GeoLibreLayer): RenderEntry | null {
     fieldMapping: config.fieldMapping,
     style,
     opacity: layer.opacity * layer.style.fillOpacity,
+    scenegraph: config.scenegraph,
   };
   return { id: layer.id, def, ctx };
 }

--- a/packages/plugins/src/plugins/deckgl-viz/registry.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/registry.ts
@@ -134,6 +134,12 @@ export interface DeckVizExample {
   style?: Partial<DeckVizStyle>;
   /** Default model + transform for the `scenegraph` layer kind. */
   scenegraph?: DeckVizScenegraphConfig;
+  /**
+   * Default `[lng, lat]` to pre-fill the 3D-model dialog's single-location
+   * inputs. Dialog convenience only; placement at render time comes from the
+   * row data, so this is not part of the persisted config.
+   */
+  scenegraphLocation?: [number, number];
 }
 
 export interface DeckVizLayerDef {
@@ -898,6 +904,9 @@ const DEFINITIONS: DeckVizLayerDef[] = [
         bearing: 0,
         altitude: 0,
       },
+      // San Francisco International Airport — a fitting spot for the airplane
+      // model in single-location mode.
+      scenegraphLocation: [-122.379, 37.6213],
     },
   },
 ];

--- a/packages/plugins/src/plugins/deckgl-viz/registry.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/registry.ts
@@ -858,10 +858,10 @@ const DEFINITIONS: DeckVizLayerDef[] = [
         scenegraph: sg.modelUrl,
         _lighting: "pbr",
         sizeScale: sg.sizeScale,
-        // Keep the model visible at every zoom even when the metric size is
-        // tiny on screen.
+        // Floor the on-screen size so distant models stay visible; leave the
+        // ceiling unset so zooming in scales the model up naturally instead of
+        // clamping a single large asset (building, turbine) to a small dot.
         sizeMinPixels: 1,
-        sizeMaxPixels: 100,
         getPosition: (record: AnyRecord) => {
           const [lng, lat] = position(record);
           const altitude =
@@ -891,7 +891,9 @@ const DEFINITIONS: DeckVizLayerDef[] = [
       url: `${DATA_BASE}/text-layer/cities-1000.csv`,
       fieldMapping: { lng: "longitude", lat: "latitude" },
       scenegraph: {
-        modelUrl: `https://raw.githubusercontent.com/visgl/deck.gl-data/master/examples/scenegraph-layer/airplane.glb`,
+        // Pinned to a commit SHA (not `master`) so the bundled example does
+        // not silently break if the asset is moved/renamed upstream.
+        modelUrl: `https://raw.githubusercontent.com/visgl/deck.gl-data/1d1f1f2a8de2d2ff5a3f55cb4763171253cc2738/examples/scenegraph-layer/airplane.glb`,
         sizeScale: 3000,
         bearing: 0,
         altitude: 0,

--- a/packages/plugins/src/plugins/deckgl-viz/registry.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/registry.ts
@@ -12,7 +12,12 @@ import type { GeoLibreDeckGL } from "../../types";
  */
 
 /** Visual grouping shown in the layer-type picker. */
-export type DeckVizCategory = "point" | "flow" | "geojson" | "advanced";
+export type DeckVizCategory =
+  | "point"
+  | "flow"
+  | "geojson"
+  | "advanced"
+  | "models";
 
 /**
  * How the source data is shaped. Drives both the dialog (file picker vs URL
@@ -71,12 +76,40 @@ export const DEFAULT_DECK_VIZ_STYLE: DeckVizStyle = {
 /** Maps a role key to a column name (string) or tuple index (number). */
 export type DeckVizFieldMapping = Record<string, string | number>;
 
+/**
+ * Configuration specific to the glTF 3D-model (`scenegraph`) layer: the model
+ * URL plus the default transform applied to every instance. Per-instance
+ * altitude/bearing/scale can additionally be data-driven via mapped columns.
+ */
+export interface DeckVizScenegraphConfig {
+  /** glTF/GLB model URL (the model itself, not the placement data). */
+  modelUrl: string;
+  /** Overall size multiplier in meters (ScenegraphLayer `sizeScale`). */
+  sizeScale: number;
+  /** Heading in degrees clockwise from north, applied as the model's yaw. */
+  bearing: number;
+  /**
+   * Constant altitude in meters, added to the per-instance altitude (or used
+   * alone when no altitude column is mapped).
+   */
+  altitude: number;
+}
+
+export const DEFAULT_DECK_VIZ_SCENEGRAPH: DeckVizScenegraphConfig = {
+  modelUrl: "",
+  sizeScale: 1000,
+  bearing: 0,
+  altitude: 0,
+};
+
 /** The serialisable description of a built visualization (stored in metadata). */
 export interface DeckVizConfig {
   layerKind: string;
   format: DeckVizFormat;
   fieldMapping: DeckVizFieldMapping;
   style: DeckVizStyle;
+  /** Present only for the `scenegraph` layer kind. */
+  scenegraph?: DeckVizScenegraphConfig;
 }
 
 /** Inputs handed to a registry `build` function. */
@@ -91,12 +124,16 @@ export interface DeckVizBuildContext {
   opacity: number;
   /** Animation clock for animated layers (same units as the data timestamps). */
   currentTime?: number;
+  /** Model URL and transform for the `scenegraph` layer kind. */
+  scenegraph?: DeckVizScenegraphConfig;
 }
 
 export interface DeckVizExample {
   url: string;
   fieldMapping: DeckVizFieldMapping;
   style?: Partial<DeckVizStyle>;
+  /** Default model + transform for the `scenegraph` layer kind. */
+  scenegraph?: DeckVizScenegraphConfig;
 }
 
 export interface DeckVizLayerDef {
@@ -230,7 +267,33 @@ const TARGET_LAT_ROLE: DeckVizRole = {
   detect: ["lat2", "target_lat", "to_lat", "dest_lat", "end_lat"],
 };
 
+const ALTITUDE_ROLE: DeckVizRole = {
+  key: "altitude",
+  label: "Altitude (optional)",
+  required: false,
+  detect: ["altitude", "alt", "elevation", "height", "z"],
+};
+const BEARING_ROLE: DeckVizRole = {
+  key: "bearing",
+  label: "Bearing / heading (optional)",
+  required: false,
+  detect: ["bearing", "heading", "azimuth", "rotation", "angle", "track"],
+};
+const SCALE_ROLE: DeckVizRole = {
+  key: "scale",
+  label: "Scale factor (optional)",
+  required: false,
+  detect: ["scale", "size"],
+};
+
 const POINT_ROLES: DeckVizRole[] = [LNG_ROLE, LAT_ROLE, WEIGHT_ROLE];
+const SCENEGRAPH_ROLES: DeckVizRole[] = [
+  LNG_ROLE,
+  LAT_ROLE,
+  ALTITUDE_ROLE,
+  BEARING_ROLE,
+  SCALE_ROLE,
+];
 const OD_ROLES: DeckVizRole[] = [
   SOURCE_LNG_ROLE,
   SOURCE_LAT_ROLE,
@@ -765,6 +828,76 @@ const DEFINITIONS: DeckVizLayerDef[] = [
       style: { lineWidth: 2, color: "#f97316" },
     },
   },
+  // ---- 3D models -----------------------------------------------------------
+  {
+    kind: "scenegraph",
+    label: "3D model (glTF)",
+    category: "models",
+    description:
+      "Place a glTF/GLB 3D model at each point. CSV/JSON with longitude & latitude, plus a model URL.",
+    inputKind: "point-csv",
+    format: "csv-rows",
+    roles: SCENEGRAPH_ROLES,
+    styleControls: [],
+    build: (deckGL, id, ctx) => {
+      const sg = ctx.scenegraph ?? DEFAULT_DECK_VIZ_SCENEGRAPH;
+      const mapping = ctx.fieldMapping;
+      const position = positionAccessor(mapping);
+      const altKey = mapping.altitude;
+      const bearingKey = mapping.bearing;
+      const scaleKey = mapping.scale;
+      const hasAlt = altKey !== undefined && altKey !== "";
+      const hasBearing = bearingKey !== undefined && bearingKey !== "";
+      const hasScale = scaleKey !== undefined && scaleKey !== "";
+      // ScenegraphLayer needs a model; with no URL there is nothing to render,
+      // so emit an empty layer rather than throwing (keeps the overlay alive).
+      const data = sg.modelUrl ? rowsOf(ctx) : [];
+      return new deckGL.meshLayers.ScenegraphLayer({
+        id,
+        data,
+        scenegraph: sg.modelUrl,
+        _lighting: "pbr",
+        sizeScale: sg.sizeScale,
+        // Keep the model visible at every zoom even when the metric size is
+        // tiny on screen.
+        sizeMinPixels: 1,
+        sizeMaxPixels: 100,
+        getPosition: (record: AnyRecord) => {
+          const [lng, lat] = position(record);
+          const altitude =
+            (hasAlt ? readNumber(record, altKey) : 0) + sg.altitude;
+          return [lng, lat, altitude];
+        },
+        // glTF models are Y-up; the trailing 90° roll stands them upright in
+        // deck.gl's Z-up frame (matching deck.gl's ScenegraphLayer examples).
+        getOrientation: (record: AnyRecord): [number, number, number] => [
+          0,
+          hasBearing ? readNumber(record, bearingKey) : sg.bearing,
+          90,
+        ],
+        ...(hasScale
+          ? {
+              getScale: (record: AnyRecord): [number, number, number] => {
+                const s = readNumber(record, scaleKey) || 1;
+                return [s, s, s];
+              },
+            }
+          : {}),
+        opacity: ctx.opacity,
+        pickable: true,
+      });
+    },
+    example: {
+      url: `${DATA_BASE}/text-layer/cities-1000.csv`,
+      fieldMapping: { lng: "longitude", lat: "latitude" },
+      scenegraph: {
+        modelUrl: `https://raw.githubusercontent.com/visgl/deck.gl-data/master/examples/scenegraph-layer/airplane.glb`,
+        sizeScale: 3000,
+        bearing: 0,
+        altitude: 0,
+      },
+    },
+  },
 ];
 
 const REGISTRY = new Map<string, DeckVizLayerDef>(
@@ -787,4 +920,5 @@ export const DECK_VIZ_CATEGORY_LABELS: Record<DeckVizCategory, string> = {
   flow: "Flow / origin-destination",
   geojson: "GeoJSON",
   advanced: "Advanced / animated",
+  models: "3D models",
 };

--- a/packages/plugins/src/plugins/deckgl-viz/store-layer.ts
+++ b/packages/plugins/src/plugins/deckgl-viz/store-layer.ts
@@ -4,9 +4,11 @@ import {
 } from "@geolibre/core";
 import type { FeatureCollection } from "geojson";
 import {
+  DEFAULT_DECK_VIZ_SCENEGRAPH,
   DEFAULT_DECK_VIZ_STYLE,
   type DeckVizConfig,
   type DeckVizFieldMapping,
+  type DeckVizScenegraphConfig,
   type DeckVizStyle,
   getDeckVizLayerDef,
 } from "./registry";
@@ -156,10 +158,36 @@ export function readDeckVizConfig(layer: GeoLibreLayer): DeckVizConfig | null {
     ...DEFAULT_DECK_VIZ_STYLE,
     ...(candidate.style ?? {}),
   };
+  const scenegraph = readScenegraphConfig(candidate.scenegraph);
   return {
     layerKind: candidate.layerKind,
     format: candidate.format ?? "csv-rows",
     fieldMapping,
     style,
+    ...(scenegraph ? { scenegraph } : {}),
+  };
+}
+
+/**
+ * Normalises the persisted scenegraph (glTF model) config, filling defaults so
+ * a hand-edited or older project still renders. Returns null when absent.
+ */
+function readScenegraphConfig(
+  raw: unknown,
+): DeckVizScenegraphConfig | null {
+  if (!raw || typeof raw !== "object") return null;
+  const candidate = raw as Partial<DeckVizScenegraphConfig>;
+  return {
+    modelUrl:
+      typeof candidate.modelUrl === "string" ? candidate.modelUrl : "",
+    sizeScale: Number.isFinite(candidate.sizeScale)
+      ? (candidate.sizeScale as number)
+      : DEFAULT_DECK_VIZ_SCENEGRAPH.sizeScale,
+    bearing: Number.isFinite(candidate.bearing)
+      ? (candidate.bearing as number)
+      : DEFAULT_DECK_VIZ_SCENEGRAPH.bearing,
+    altitude: Number.isFinite(candidate.altitude)
+      ? (candidate.altitude as number)
+      : DEFAULT_DECK_VIZ_SCENEGRAPH.altitude,
   };
 }

--- a/tests/deck-viz.test.ts
+++ b/tests/deck-viz.test.ts
@@ -275,6 +275,11 @@ describe("scenegraph (glTF 3D model) layer", () => {
     assert.match(def.example.scenegraph.modelUrl, /\.glb$/);
     assert.equal(def.example.fieldMapping.lng, "longitude");
     assert.equal(def.example.fieldMapping.lat, "latitude");
+    // A default single-location coordinate pre-fills the dialog's lng/lat.
+    assert.ok(def.example.scenegraphLocation);
+    const [lng, lat] = def.example.scenegraphLocation;
+    assert.ok(lng >= -180 && lng <= 180);
+    assert.ok(lat >= -90 && lat <= 90);
   });
 
   it("round-trips the model URL and transform through the store layer", () => {

--- a/tests/deck-viz.test.ts
+++ b/tests/deck-viz.test.ts
@@ -7,6 +7,7 @@ import {
   detectAndParseDeckVizInput,
 } from "../apps/geolibre-desktop/src/lib/deck-viz-input";
 import {
+  DEFAULT_DECK_VIZ_SCENEGRAPH,
   DEFAULT_DECK_VIZ_STYLE,
   getDeckVizLayerDef,
   listDeckVizLayerDefs,
@@ -261,6 +262,147 @@ describe("deck-viz registry & store layer", () => {
       rows: [],
     });
     assert.equal(readDeckVizConfig(layer), null);
+  });
+});
+
+describe("scenegraph (glTF 3D model) layer", () => {
+  const def = getDeckVizLayerDef("scenegraph")!;
+
+  it("declares a glTF model example with required point roles", () => {
+    assert.ok(def);
+    assert.equal(def.category, "models");
+    assert.ok(def.example.scenegraph);
+    assert.match(def.example.scenegraph.modelUrl, /\.glb$/);
+    assert.equal(def.example.fieldMapping.lng, "longitude");
+    assert.equal(def.example.fieldMapping.lat, "latitude");
+  });
+
+  it("round-trips the model URL and transform through the store layer", () => {
+    const layer = createDeckVizStoreLayer({
+      name: "Plane",
+      config: {
+        layerKind: "scenegraph",
+        format: "csv-rows",
+        fieldMapping: { lng: "lng", lat: "lat" },
+        style: { ...DEFAULT_DECK_VIZ_STYLE },
+        scenegraph: {
+          modelUrl: "https://example.com/model.glb",
+          sizeScale: 250,
+          bearing: 45,
+          altitude: 100,
+        },
+      },
+      rows: [{ lng: -122.4, lat: 37.8 }],
+      sourcePath: "https://example.com/model.glb",
+    });
+    assert.equal(layer.metadata.customLayerType, "scenegraph");
+    const config = readDeckVizConfig(layer);
+    assert.ok(config?.scenegraph);
+    assert.equal(config.scenegraph.modelUrl, "https://example.com/model.glb");
+    assert.equal(config.scenegraph.sizeScale, 250);
+    assert.equal(config.scenegraph.bearing, 45);
+    assert.equal(config.scenegraph.altitude, 100);
+  });
+
+  it("fills scenegraph defaults for a partial persisted config", () => {
+    const layer = createDeckVizStoreLayer({
+      name: "Partial",
+      config: {
+        layerKind: "scenegraph",
+        format: "csv-rows",
+        fieldMapping: { lng: "lng", lat: "lat" },
+        style: { ...DEFAULT_DECK_VIZ_STYLE },
+        scenegraph: { modelUrl: "https://example.com/m.glb" } as never,
+      },
+      rows: [],
+    });
+    const config = readDeckVizConfig(layer);
+    assert.equal(
+      config?.scenegraph?.sizeScale,
+      DEFAULT_DECK_VIZ_SCENEGRAPH.sizeScale,
+    );
+    assert.equal(config?.scenegraph?.bearing, 0);
+  });
+
+  it("builds a ScenegraphLayer whose accessors fold in transform + columns", () => {
+    const captured: { props?: Record<string, unknown> } = {};
+    const fakeDeck = {
+      meshLayers: {
+        ScenegraphLayer: class {
+          constructor(props: Record<string, unknown>) {
+            captured.props = props;
+          }
+        },
+      },
+    } as unknown as Parameters<typeof def.build>[0];
+
+    def.build(fakeDeck, "sg-1", {
+      rows: [{ lng: -122.4, lat: 37.8, alt: 50, heading: 90 }],
+      fieldMapping: {
+        lng: "lng",
+        lat: "lat",
+        altitude: "alt",
+        bearing: "heading",
+      },
+      style: { ...DEFAULT_DECK_VIZ_STYLE },
+      opacity: 0.5,
+      scenegraph: {
+        modelUrl: "https://example.com/model.glb",
+        sizeScale: 300,
+        bearing: 10,
+        altitude: 25,
+      },
+    });
+
+    const props = captured.props!;
+    assert.equal(props.scenegraph, "https://example.com/model.glb");
+    assert.equal(props.sizeScale, 300);
+    assert.equal(props.opacity, 0.5);
+    const record = { lng: -122.4, lat: 37.8, alt: 50, heading: 90 };
+    const position = (props.getPosition as (r: unknown) => number[])(record);
+    // altitude column (50) + base altitude (25)
+    assert.deepEqual(position, [-122.4, 37.8, 75]);
+    const orientation = (
+      props.getOrientation as (r: unknown) => number[]
+    )(record);
+    // bearing column (90) drives yaw; trailing 90° roll stands the model up
+    assert.deepEqual(orientation, [0, 90, 90]);
+  });
+
+  it("uses the constant bearing/altitude when no columns are mapped", () => {
+    const captured: { props?: Record<string, unknown> } = {};
+    const fakeDeck = {
+      meshLayers: {
+        ScenegraphLayer: class {
+          constructor(props: Record<string, unknown>) {
+            captured.props = props;
+          }
+        },
+      },
+    } as unknown as Parameters<typeof def.build>[0];
+
+    def.build(fakeDeck, "sg-2", {
+      rows: [{ lng: 1, lat: 2 }],
+      fieldMapping: { lng: "lng", lat: "lat" },
+      style: { ...DEFAULT_DECK_VIZ_STYLE },
+      opacity: 1,
+      scenegraph: {
+        modelUrl: "https://example.com/model.glb",
+        sizeScale: 100,
+        bearing: 30,
+        altitude: 12,
+      },
+    });
+    const props = captured.props!;
+    const record = { lng: 1, lat: 2 };
+    assert.deepEqual(
+      (props.getPosition as (r: unknown) => number[])(record),
+      [1, 2, 12],
+    );
+    assert.deepEqual(
+      (props.getOrientation as (r: unknown) => number[])(record),
+      [0, 30, 90],
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #306. Adds a **glTF / GLB 3D model layer** so users can drop individual 3D models (trees, buildings, turbines, vehicles, campus assets) at geographic coordinates, rounding out the 3D story alongside 3D Tiles, Gaussian splats, and polygon extrusions.

Models render through deck.gl's `ScenegraphLayer` on the host's shared deck.gl overlay (`app.getDeckGL()`), reusing the existing Deck.gl Layer pipeline (overlay lifecycle, project persistence, and restore) rather than introducing a second overlay.

## What's included

- **New `scenegraph` deck.gl layer kind** (`packages/plugins/.../deckgl-viz/registry.ts`) with per-instance **scale**, **bearing/heading**, and **altitude**, plus optional **data-driven placement** — a point file with lng/lat (and optional altitude/bearing/scale columns) drives many instances. glTF Y-up models are stood upright with a trailing 90° roll, matching deck.gl's own examples.
- **"3D Model (glTF)" Add Data entry** that opens the dialog pre-selected on the scenegraph kind, supporting:
  - **Single location** — type lon/lat (+ altitude/scale/bearing), no data file needed.
  - **From point data** — load a CSV/JSON/GeoJSON of points and map columns.
- **Persistence** — the model URL and transform are stored in the deck-viz config, so URL-backed models restore on project reload.
- **Bundled example** — "Use example data" places deck.gl's `airplane.glb` at 1,000 world cities with zero configuration.

> Note: this reuses the Deck.gl Layer overlay, so the store record keeps `type: "deckgl-viz"` with `customLayerType: "scenegraph"` (the same convention the other deck.gl kinds use), rather than adding a separate top-level layer type. ScenegraphLayer bundles `GLTFLoader`, so glTF/GLB works out of the box; OBJ would need an additional loader and is left as a follow-up.

## Testing

- **Unit** (`tests/deck-viz.test.ts`): registry build accessors (position folds altitude column + base altitude; orientation folds bearing column/constant) and store-layer round-trip of the model URL + transform, incl. default-filling a partial config. All 582 frontend tests pass.
- **e2e** (`e2e/scenegraph.spec.ts`): drives the real built app — opens the Add Data → 3D Model flow, places a model at a single coordinate, and asserts blank coordinates are rejected (a blank field must not be read as the coordinate 0).
- **Manual** (Playwright CLI against the real `airplane.glb`): confirmed the example flow renders 1,000 airplane models globally and single-location placement lands at the typed coordinate.

`npm run lint`, `pre-commit run --files` (incl. full `npm build`), and the unit + e2e suites all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for adding and configuring 3D glTF/GLB models via the Deck.gl **scenegraph** layer, including single-location coordinate placement and model/transform controls.
  * Added a dedicated **“3D models”** category and improved the Add Data dialog when launched from the Deck.gl toolbar, including smarter pre-fill.
* **Bug Fixes**
  * Improved scenegraph submission, including better single-location longitude/latitude validation and handling of point-based inputs.
* **Documentation**
  * Updated the README “Features (v1.2)” entry to explicitly call out coordinate placement support for glTF/GLB models.
* **Tests**
  * Added end-to-end and unit test coverage for the new scenegraph workflow, defaults, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->