### PR TITLE
fix(collab): render plugin layer types (raster/LiDAR/3D-tiles) on collaborators

### DIFF
--- a/apps/geolibre-desktop/src/hooks/useCollaboration.ts
+++ b/apps/geolibre-desktop/src/hooks/useCollaboration.ts
@@ -83,6 +83,9 @@ export function useCollaboration(
   // Set when the relay rejects a snapshot as too large; stops further sends so
   // an over-size project doesn't re-fail on every keystroke. Reset on reconnect.
   const syncPausedRef = useRef(false);
+  // Debounces the projectGeneration bump that drives plugin-layer restoration
+  // after a burst of incremental remote edits.
+  const restoreTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Settles when the current connect attempt joins (welcome) or fatally fails,
   // so start()/join() resolve only on real success and the dialog keeps its
   // busy spinner until then.
@@ -122,6 +125,21 @@ export function useCollaboration(
     conn.send({ type: "snapshot", project, rev: revRef.current });
   };
 
+  // Bump projectGeneration (debounced) to run DesktopShell's plugin/native-layer
+  // restoration once after a burst of incremental edits settles. The bump alone
+  // re-runs the restoration effect; it changes no serialized project field, so
+  // the snapshot subscription dedupes it (no echo).
+  const RESTORE_DEBOUNCE_MS = 200;
+  const scheduleRestore = (): void => {
+    if (restoreTimerRef.current) clearTimeout(restoreTimerRef.current);
+    restoreTimerRef.current = setTimeout(() => {
+      restoreTimerRef.current = null;
+      useAppStore.setState((s) => ({
+        projectGeneration: s.projectGeneration + 1,
+      }));
+    }, RESTORE_DEBOUNCE_MS);
+  };
+
   const applyRemoteSnapshot = (
     project: GeoLibreProject,
     initial: boolean,
@@ -140,16 +158,20 @@ export function useCollaboration(
         .getState()
         .loadProject(merged, null, { rememberRecent: false, presenting: false });
     } else {
-      // Incremental remote edit: apply the project slice DIRECTLY, never via
-      // loadProject. loadProject bumps `projectGeneration`, which re-runs
-      // DesktopShell's heavy plugin/native-layer restoration on every remote
-      // snapshot and races the map into "Map failed to render". MapCanvas
-      // reconciles from the changed `layers`/basemap refs and store-subscribing
-      // plugins (deck-viz) rebuild on their own, so a plain slice update is
-      // enough. clearHistory keeps remote edits out of the local undo stack.
+      // Incremental remote edit: apply the project slice immediately so
+      // MapLibre-native layers (geojson, vector/raster tiles, …) reconcile via
+      // MapCanvas's syncLayers without flicker. We apply directly rather than
+      // via loadProject so the local user's selectedLayerId isn't reset to the
+      // first layer on every remote edit.
       const applied = applyProjectToStore(merged);
       useAppStore.setState({ ...applied });
       clearHistory();
+      // Plugin-rendered layer types (raster-COG, LiDAR, 3D-tiles, deck) are NOT
+      // handled by syncLayers — DesktopShell's restoration effect (keyed on
+      // projectGeneration) renders them. Bump it, debounced, so a burst of edits
+      // triggers that heavier restoration once after it settles rather than on
+      // every snapshot.
+      scheduleRestore();
     }
     // Cache the POST-normalization serialization (mirrors useEmbedBridge): the
     // store update we just made re-serializes to this exact string and is
@@ -388,6 +410,10 @@ export function useCollaboration(
     connRef.current?.close();
     connRef.current = null;
     selfIdRef.current = null;
+    if (restoreTimerRef.current) {
+      clearTimeout(restoreTimerRef.current);
+      restoreTimerRef.current = null;
+    }
     // Drop any in-flight connect promise without settling it; a fresh connect()
     // installs a new one, and the only fatal path settles it explicitly above.
     pendingConnectRef.current = null;


### PR DESCRIPTION
Follow-up to #329 (real-time collaboration). Two issues reported during live testing:

1. **Plugin-rendered layer types don't sync visually.** Raster (COG), LiDAR, 3D-tiles, and deck layers appeared in collaborators' Layers panel but were never drawn on the map. Vector / GeoJSON / raster-tiles / WMS / XYZ / MBTiles / video (the MapLibre-native types) synced fine.

## Root cause

`MapController.syncLayers` (which collaborators rely on for incremental updates) only renders **MapLibre-native** layer types. The plugin-rendered types are drawn imperatively by their plugins, which `DesktopShell` re-runs through a restoration effect keyed on **`projectGeneration`** (`restoreRasterLayers`, `restoreThreeDTilesLayers`, `restoreDeckViz`, `restoreProjectState`, …). The incremental remote-apply path deliberately did **not** bump `projectGeneration` (that was the earlier fix to stop restoration churn from crashing the map), so plugin layers landed in the store but never rendered.

## Fix

Incremental remote applies now:
- update the store slice immediately, so MapLibre-native layers reconcile via `syncLayers` with no flicker, and the local user's `selectedLayerId` is preserved (applying directly rather than via `loadProject`, which would reset selection on every remote edit);
- additionally bump `projectGeneration` on a **200 ms debounce**, so the plugin/native-layer restoration runs **once after a burst of edits settles** — rendering the plugin layer types using the same tested path the welcome bootstrap (`loadProject`) already uses, without per-edit churn.

The one-time welcome bootstrap still uses `loadProject` (full restoration) so late joiners get everything.

## Testing

- Typecheck (app + core), `npm run test:frontend` (649 pass), lint, pre-commit (full build) all pass.
- Needs live two-window verification with real raster/LiDAR/3D-tiles data (relay + two browsers), which I can't run here — please confirm on the deployed app.

## Note on the intermittent "Map failed to render"

This restoration is the canonical, tested rendering path (same as a normal project load), so routing plugin layers through it should also be more robust than the prior custom slice-only apply. If collaborators still hit the occasional render error after this, it'll need a concrete repro (which layer type / action triggers it) to pin down further.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized collaborative session restoration handling to improve performance during rapid remote edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->