### PR TITLE
feat(assistant): natural-language GIS assistant (Strands agent)

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -12,6 +12,7 @@
     "tauri:build": "node ../../scripts/tauri-build.mjs"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.92.0",
     "@carbonplan/zarr-layer": "^0.5.0",
     "@deck.gl/aggregation-layers": "9.3.3",
     "@deck.gl/core": "^9.3.3",
@@ -31,9 +32,13 @@
     "@geolibre/processing": "*",
     "@geolibre/ui": "*",
     "@geoman-io/maplibre-geoman-free": "^0.7.1",
+    "@google/genai": "^1.52.0",
+    "@modelcontextprotocol/sdk": "^1.25.2",
+    "@opentelemetry/api": "^1.9.0",
     "@osmix/core": "^0.1.8",
     "@osmix/geojson": "^0.0.13",
     "@osmix/pbf": "^0.0.9",
+    "@strands-agents/sdk": "^1.3.0",
     "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-fs": "^2.5.1",
@@ -63,13 +68,15 @@
     "maplibre-gl-swipe": "^0.7.1",
     "maplibre-gl-time-slider": "^1.0.3",
     "maplibre-gl-vector": "^0.3.0",
+    "openai": "^6.39.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-i18next": "^16.6.6",
     "shpjs": "^6.2.0",
     "sql.js": "^1.14.0",
-    "three": "^0.184.0"
+    "three": "^0.184.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.0",

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -176,6 +176,20 @@ const SqlWorkspaceDialog = lazy(() =>
     }),
 );
 
+const AssistantPanel = lazy(() =>
+  import("../panels/AssistantPanel")
+    .then((module) => ({
+      default: module.AssistantPanel,
+    }))
+    .catch((error) => {
+      // Same chunk-load fallback rationale as the dialogs above.
+      console.error("Failed to load AssistantPanel", error);
+      const Fallback = (() =>
+        null) as unknown as typeof import("../panels/AssistantPanel").AssistantPanel;
+      return { default: Fallback };
+    }),
+);
+
 const PythonConsolePanel = lazy(() =>
   import("../panels/PythonConsolePanel")
     .then((module) => ({
@@ -242,6 +256,7 @@ export function DesktopShell({
   const addGeoJsonLayer = useAppStore((s) => s.addGeoJsonLayer);
   const projectGeneration = useAppStore((s) => s.projectGeneration);
   const pythonConsoleOpen = useAppStore((s) => s.ui.pythonConsoleOpen);
+  const assistantOpen = useAppStore((s) => s.ui.assistantOpen);
   const geometryEditLayerId = useSyncExternalStore(
     subscribeGeometryEdit,
     getGeometryEditTargetLayerId,
@@ -1000,6 +1015,13 @@ export function DesktopShell({
         <SectionErrorBoundary label="Python console">
           <Suspense fallback={null}>
             <PythonConsolePanel mapControllerRef={mapControllerRef} />
+          </Suspense>
+        </SectionErrorBoundary>
+      ) : null}
+      {assistantOpen ? (
+        <SectionErrorBoundary label="Assistant">
+          <Suspense fallback={null}>
+            <AssistantPanel mapControllerRef={mapControllerRef} />
           </Suspense>
         </SectionErrorBoundary>
       ) : null}

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -135,6 +135,7 @@ import {
   Save,
   Search,
   SlidersHorizontal,
+  Sparkles,
   Sun,
   Undo2,
   Wrench,
@@ -414,6 +415,7 @@ export function TopToolbar({
   const setRasterToolOpen = useAppStore((s) => s.setRasterToolOpen);
   const setSqlWorkspaceOpen = useAppStore((s) => s.setSqlWorkspaceOpen);
   const setPythonConsoleOpen = useAppStore((s) => s.setPythonConsoleOpen);
+  const setAssistantOpen = useAppStore((s) => s.setAssistantOpen);
   const setStorymapPanelOpen = useAppStore((s) => s.setStorymapPanelOpen);
   const projectName = useAppStore((s) => s.projectName);
   const projectPath = useAppStore((s) => s.projectPath);
@@ -1262,6 +1264,14 @@ export function TopToolbar({
       run: () => setPythonConsoleOpen(true),
     },
     {
+      id: "proc.assistant",
+      title: t("toolbar.command.assistant"),
+      group: t("toolbar.commandGroup.processing"),
+      keywords: "assistant ai chat llm natural language gemini agent",
+      icon: Sparkles,
+      run: () => setAssistantOpen(true),
+    },
+    {
       id: "proc.geocode",
       title: t("toolbar.command.geocode"),
       group: t("toolbar.commandGroup.processing"),
@@ -1808,6 +1818,9 @@ export function TopToolbar({
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => setPythonConsoleOpen(true)}>
             {t("toolbar.command.pythonConsole")}
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setAssistantOpen(true)}>
+            {t("toolbar.command.assistant")}
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => setGeocodeOpen(true)}>
             {t("toolbar.item.geocode")}

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -488,6 +488,12 @@ export function TopToolbar({
     sourcePath: string;
     sizeMb: number;
   } | null>(null);
+  // Pending "strip env vars before saving?" prompt. Holds the count to display
+  // and the resolver that the dialog buttons call to continue the save.
+  const [envStripPrompt, setEnvStripPrompt] = useState<{
+    count: number;
+    resolve: (choice: "strip" | "keep" | "cancel") => void;
+  } | null>(null);
   const [aboutOpen, setAboutOpen] = useState(false);
   const [printLayoutOpen, setPrintLayoutOpen] = useState(false);
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
@@ -647,11 +653,41 @@ export function TopToolbar({
     };
   };
 
+  // Ask whether to strip environment variables before writing the file. The
+  // promise resolves when the user picks an option in the dialog.
+  const askStripEnvVars = (count: number) =>
+    new Promise<"strip" | "keep" | "cancel">((resolve) => {
+      setEnvStripPrompt({ count, resolve });
+    });
+
+  const resolveEnvStripPrompt = (choice: "strip" | "keep" | "cancel") => {
+    setEnvStripPrompt((current) => {
+      current?.resolve(choice);
+      return null;
+    });
+  };
+
   const saveProject = async (options?: {
     saveAs?: boolean;
   }): Promise<boolean> => {
     const { project, defaultProjectName, content, projectPath } =
       buildCurrentProject();
+    // Env vars (possibly API keys) are serialized in plain text. If any are set,
+    // offer to strip them from the saved file before writing.
+    let contentToSave = content;
+    const envVarCount = (project.preferences.environmentVariables ?? []).filter(
+      (variable) => variable.key.trim(),
+    ).length;
+    if (envVarCount > 0) {
+      const choice = await askStripEnvVars(envVarCount);
+      if (choice === "cancel") return false;
+      if (choice === "strip") {
+        contentToSave = serializeProject({
+          ...project,
+          preferences: { ...project.preferences, environmentVariables: [] },
+        });
+      }
+    }
     // Projects opened from a URL have no writable path, so both Save and
     // Save As fall back to the save dialog for them.
     const existingLocalPath =
@@ -660,9 +696,9 @@ export function TopToolbar({
     try {
       path =
         !options?.saveAs && existingLocalPath
-          ? await saveProjectFileToPath(content, existingLocalPath)
+          ? await saveProjectFileToPath(contentToSave, existingLocalPath)
           : await saveProjectFile(
-              content,
+              contentToSave,
               existingLocalPath ?? `${defaultProjectName}.geolibre.json`,
             );
     } catch (error) {
@@ -2459,6 +2495,40 @@ export function TopToolbar({
           <div className="flex justify-end">
             <Button onClick={() => setActionError(null)}>
               {t("toolbar.item.dismiss")}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+      <Dialog
+        open={envStripPrompt !== null}
+        onOpenChange={(open: boolean) => {
+          if (!open) resolveEnvStripPrompt("cancel");
+        }}
+      >
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{t("settings.env.stripPromptTitle")}</DialogTitle>
+            <DialogDescription>
+              {t("settings.env.stripPromptDesc", {
+                count: envStripPrompt?.count ?? 0,
+              })}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="outline"
+              onClick={() => resolveEnvStripPrompt("cancel")}
+            >
+              {t("common.cancel")}
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => resolveEnvStripPrompt("keep")}
+            >
+              {t("settings.env.keepButton")}
+            </Button>
+            <Button onClick={() => resolveEnvStripPrompt("strip")}>
+              {t("settings.env.stripButton")}
             </Button>
           </div>
         </DialogContent>

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -661,10 +661,9 @@ export function TopToolbar({
     });
 
   const resolveEnvStripPrompt = (choice: "strip" | "keep" | "cancel") => {
-    setEnvStripPrompt((current) => {
-      current?.resolve(choice);
-      return null;
-    });
+    // Resolve outside the state updater (updaters must be side-effect free).
+    envStripPrompt?.resolve(choice);
+    setEnvStripPrompt(null);
   };
 
   const saveProject = async (options?: {

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -1846,6 +1846,10 @@ export function TopToolbar({
         <DropdownMenuContent align="start">
           <DropdownMenuLabel>{t("toolbar.menu.processing")}</DropdownMenuLabel>
           <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={() => setAssistantOpen(true)}>
+            {t("toolbar.command.assistant")}
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
           <DropdownMenuItem onSelect={() => setProcessingOpen(true)}>
             {t("toolbar.item.whitebox")}
           </DropdownMenuItem>
@@ -1854,9 +1858,6 @@ export function TopToolbar({
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => setPythonConsoleOpen(true)}>
             {t("toolbar.command.pythonConsole")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setAssistantOpen(true)}>
-            {t("toolbar.command.assistant")}
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => setGeocodeOpen(true)}>
             {t("toolbar.item.geocode")}

--- a/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
@@ -120,6 +120,9 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
   const cancelledRef = useRef(false);
   // Monotonic id source for transcript turns (stable React keys + update target).
   const turnIdRef = useRef(0);
+  // Identifies the current send so a stopped run's cleanup can't reset the
+  // running state of a newer send started right after Stop.
+  const sendGenerationRef = useRef(0);
   // Tears down an in-flight drag's window listeners if the panel unmounts
   // mid-drag (e.g. the user closes it while dragging).
   const resizeCleanupRef = useRef<(() => void) | null>(null);
@@ -203,6 +206,7 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
     if (!prompt || runningRef.current || !hasKey) return;
     runningRef.current = true;
     cancelledRef.current = false;
+    const myGeneration = (sendGenerationRef.current += 1);
     setRunning(true);
     setInput("");
     // Turns are tracked by stable id (not array index), so updaters stay pure —
@@ -263,8 +267,12 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
             !(turn.id === assistantId && turn.role === "assistant" && !turn.text),
         ),
       );
-      runningRef.current = false;
-      setRunning(false);
+      // Only clear the running state if no newer send has superseded this one
+      // (e.g. the user stopped and immediately sent again).
+      if (sendGenerationRef.current === myGeneration) {
+        runningRef.current = false;
+        setRunning(false);
+      }
     }
   };
 

--- a/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
@@ -1,6 +1,6 @@
 import { useAppStore } from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
-import { Button, Textarea, cn } from "@geolibre/ui";
+import { Button, Select, Textarea, cn } from "@geolibre/ui";
 import {
   AlertCircle,
   Eraser,
@@ -21,10 +21,44 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { AssistantSession } from "../../lib/assistant/agent";
-import { hasProviderKey } from "../../lib/assistant/provider";
+import {
+  availableProviders,
+  defaultModelFor,
+  hasProviderKey,
+  PROVIDER_LABELS,
+  PROVIDER_MODELS,
+  type AssistantProviderId,
+} from "../../lib/assistant/provider";
 
 const PANEL_HEIGHT = 360;
 const RUNTIME_ENV_EVENT = "geolibre:runtime-env-change";
+const PROVIDER_STORAGE_KEY = "geolibre.assistant.provider";
+const MODEL_STORAGE_KEY = "geolibre.assistant.model";
+const PROVIDER_IDS: readonly AssistantProviderId[] = [
+  "google",
+  "anthropic",
+  "openai",
+];
+
+/** Read a persisted string setting, ignoring storage failures. */
+function loadStored(key: string): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+/** Persist a string setting; ignore quota/privacy-mode failures. */
+function saveStored(key: string, value: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // Best-effort persistence only.
+  }
+}
 
 /** One rendered line in the conversation transcript. */
 interface Turn {
@@ -78,6 +112,18 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
   const [input, setInput] = useState("");
   const [running, setRunning] = useState(false);
   const [hasKey, setHasKey] = useState(() => hasProviderKey());
+  const [providers, setProviders] = useState<AssistantProviderId[]>(() =>
+    availableProviders(),
+  );
+  const [provider, setProvider] = useState<AssistantProviderId | null>(() => {
+    const stored = loadStored(PROVIDER_STORAGE_KEY);
+    return stored && PROVIDER_IDS.includes(stored as AssistantProviderId)
+      ? (stored as AssistantProviderId)
+      : null;
+  });
+  const [model, setModel] = useState<string>(
+    () => loadStored(MODEL_STORAGE_KEY) ?? "",
+  );
 
   // One session per mounted panel; conversation history lives inside it.
   const session = useMemo(
@@ -91,16 +137,39 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
   // Tear down the session and any in-flight run on unmount.
   useEffect(() => () => session.cancel(), [session]);
 
-  // Track whether a provider key is configured; rebuild the agent on change so
-  // a newly-added key takes effect without reopening the panel.
+  // Track which provider keys are configured; rebuild the agent on change so a
+  // newly-added key takes effect without reopening the panel.
   useEffect(() => {
     const onEnvChange = () => {
       setHasKey(hasProviderKey());
-      session.reset();
+      setProviders(availableProviders());
     };
     window.addEventListener(RUNTIME_ENV_EVENT, onEnvChange);
     return () => window.removeEventListener(RUNTIME_ENV_EVENT, onEnvChange);
-  }, [session]);
+  }, []);
+
+  // Keep the selected provider valid: fall back to the first available one when
+  // the stored choice has no key (e.g. its key was removed).
+  useEffect(() => {
+    if (providers.length === 0) return;
+    setProvider((current) =>
+      current && providers.includes(current) ? current : providers[0],
+    );
+  }, [providers]);
+
+  // Push the resolved provider/model into the session. Selecting null lets the
+  // session auto-resolve from the configured keys.
+  useEffect(() => {
+    if (!provider) {
+      session.setSelection(null);
+      return;
+    }
+    const models = PROVIDER_MODELS[provider];
+    const effectiveModel =
+      model && models.includes(model) ? model : defaultModelFor(provider);
+    if (effectiveModel !== model) setModel(effectiveModel);
+    session.setSelection({ provider, model: effectiveModel });
+  }, [provider, model, session]);
 
   // Keep the latest turn in view.
   useEffect(() => {
@@ -178,6 +247,18 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
     }
   };
 
+  const onProviderChange = (value: AssistantProviderId) => {
+    setProvider(value);
+    setModel("");
+    saveStored(PROVIDER_STORAGE_KEY, value);
+    saveStored(MODEL_STORAGE_KEY, "");
+  };
+
+  const onModelChange = (value: string) => {
+    setModel(value);
+    saveStored(MODEL_STORAGE_KEY, value);
+  };
+
   return (
     <section
       aria-label={t("assistant.title")}
@@ -194,6 +275,40 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
           </span>
         ) : null}
         <div className="ml-auto flex items-center gap-1">
+          {hasKey && provider && providers.length > 0 ? (
+            <>
+              {providers.length > 1 ? (
+                <Select
+                  aria-label={t("assistant.provider")}
+                  className="h-8 w-auto text-xs"
+                  value={provider}
+                  disabled={running}
+                  onChange={(event) =>
+                    onProviderChange(event.target.value as AssistantProviderId)
+                  }
+                >
+                  {providers.map((id) => (
+                    <option key={id} value={id}>
+                      {PROVIDER_LABELS[id]}
+                    </option>
+                  ))}
+                </Select>
+              ) : null}
+              <Select
+                aria-label={t("assistant.model")}
+                className="h-8 w-auto text-xs"
+                value={model || defaultModelFor(provider)}
+                disabled={running}
+                onChange={(event) => onModelChange(event.target.value)}
+              >
+                {PROVIDER_MODELS[provider].map((id) => (
+                  <option key={id} value={id}>
+                    {id}
+                  </option>
+                ))}
+              </Select>
+            </>
+          ) : null}
           <Button
             variant="ghost"
             size="icon"

--- a/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
@@ -116,8 +116,9 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
   const inputRef = useRef<HTMLTextAreaElement>(null);
   // Guards a synchronous double-submit before `running` re-renders.
   const runningRef = useRef(false);
-  // Set true by Stop/Clear so the stream's rejection isn't shown as an error.
-  const cancelledRef = useRef(false);
+  // Generation that was stopped (0 = none), so a stopped run's rejection isn't
+  // shown as an error even after a newer send has started.
+  const cancelledGenerationRef = useRef(0);
   // Monotonic id source for transcript turns (stable React keys + update target).
   const turnIdRef = useRef(0);
   // Identifies the current send so a stopped run's cleanup can't reset the
@@ -205,7 +206,6 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
     const prompt = input.trim();
     if (!prompt || runningRef.current || !hasKey) return;
     runningRef.current = true;
-    cancelledRef.current = false;
     const myGeneration = (sendGenerationRef.current += 1);
     setRunning(true);
     setInput("");
@@ -231,9 +231,12 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
             ),
           );
         } else {
+          const label = describeTool(event.name, event.input);
           const detail = event.error
-            ? `${describeTool(event.name, event.input)} — ${event.error}`.trim()
-            : describeTool(event.name, event.input);
+            ? label
+              ? `${label} — ${event.error}`
+              : event.error
+            : label;
           const toolId = (turnIdRef.current += 1);
           setTurns((prev) => {
             const index = prev.findIndex((turn) => turn.id === assistantId);
@@ -254,7 +257,9 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
       }
     } catch (error) {
       // A user-initiated stop rejects the stream; that isn't an error to show.
-      if (!cancelledRef.current) {
+      // Compare against myGeneration so a newer send can't unmask this older
+      // run's cancellation as a failure.
+      if (cancelledGenerationRef.current !== myGeneration) {
         const message = error instanceof Error ? error.message : String(error);
         const errorId = (turnIdRef.current += 1);
         setTurns((prev) => [...prev, { id: errorId, role: "error", text: message }]);
@@ -277,7 +282,7 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
   };
 
   const stop = () => {
-    cancelledRef.current = true;
+    cancelledGenerationRef.current = sendGenerationRef.current;
     session.cancel();
     runningRef.current = false;
     setRunning(false);

--- a/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
@@ -22,7 +22,9 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { AssistantSession } from "../../lib/assistant/agent";
+import { renderAssistantMarkdown } from "../../lib/assistant/markdown";
 import {
+  ASSISTANT_PROVIDER_IDS,
   availableProviders,
   defaultModelFor,
   hasProviderKey,
@@ -40,11 +42,6 @@ const PANEL_RESIZE_START_EVENT = "geolibre:panel-resize-start";
 const PANEL_RESIZE_END_EVENT = "geolibre:panel-resize-end";
 const PROVIDER_STORAGE_KEY = "geolibre.assistant.provider";
 const MODEL_STORAGE_KEY = "geolibre.assistant.model";
-const PROVIDER_IDS: readonly AssistantProviderId[] = [
-  "google",
-  "anthropic",
-  "openai",
-];
 
 /** Read a persisted string setting, ignoring storage failures. */
 function loadStored(key: string): string | null {
@@ -139,7 +136,8 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
   );
   const [provider, setProvider] = useState<AssistantProviderId | null>(() => {
     const stored = loadStored(PROVIDER_STORAGE_KEY);
-    return stored && PROVIDER_IDS.includes(stored as AssistantProviderId)
+    return stored &&
+      ASSISTANT_PROVIDER_IDS.includes(stored as AssistantProviderId)
       ? (stored as AssistantProviderId)
       : null;
   });
@@ -406,19 +404,21 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
                   ))}
                 </Select>
               ) : null}
-              <Select
-                aria-label={t("assistant.model")}
-                className="h-8 w-auto text-xs"
-                value={model || defaultModelFor(provider)}
-                disabled={running}
-                onChange={(event) => onModelChange(event.target.value)}
-              >
-                {PROVIDER_MODELS[provider].map((id) => (
-                  <option key={id} value={id}>
-                    {id}
-                  </option>
-                ))}
-              </Select>
+              {PROVIDER_MODELS[provider].length > 0 ? (
+                <Select
+                  aria-label={t("assistant.model")}
+                  className="h-8 w-auto text-xs"
+                  value={model || defaultModelFor(provider)}
+                  disabled={running}
+                  onChange={(event) => onModelChange(event.target.value)}
+                >
+                  {PROVIDER_MODELS[provider].map((id) => (
+                    <option key={id} value={id}>
+                      {id}
+                    </option>
+                  ))}
+                </Select>
+              ) : null}
             </>
           ) : null}
           <Button
@@ -478,18 +478,34 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
                 </p>
               );
             }
+            if (turn.role === "user") {
+              return (
+                <div
+                  key={turn.id}
+                  className="whitespace-pre-wrap font-medium text-foreground"
+                >
+                  {`❯ ${turn.text}`}
+                </div>
+              );
+            }
+            // Assistant replies are markdown — render (and sanitize) them.
             return (
               <div
                 key={turn.id}
                 className={cn(
-                  "whitespace-pre-wrap",
-                  turn.role === "user"
-                    ? "font-medium text-foreground"
-                    : "text-foreground",
+                  "text-foreground",
+                  "[&_p]:my-1 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0",
+                  "[&_ul]:my-1 [&_ul]:list-disc [&_ul]:pl-5",
+                  "[&_ol]:my-1 [&_ol]:list-decimal [&_ol]:pl-5",
+                  "[&_a]:text-primary [&_a]:underline",
+                  "[&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-xs",
+                  "[&_pre]:my-1 [&_pre]:overflow-auto [&_pre]:rounded [&_pre]:bg-muted [&_pre]:p-2",
+                  "[&_pre_code]:bg-transparent [&_pre_code]:p-0",
                 )}
-              >
-                {turn.role === "user" ? `❯ ${turn.text}` : turn.text}
-              </div>
+                dangerouslySetInnerHTML={{
+                  __html: renderAssistantMarkdown(turn.text),
+                }}
+              />
             );
           })
         )}

--- a/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
@@ -68,6 +68,8 @@ function saveStored(key: string, value: string): void {
 
 /** One rendered line in the conversation transcript. */
 interface Turn {
+  /** Stable, monotonic id — used as the React key and to target updates. */
+  id: number;
   role: "user" | "assistant" | "tool" | "error";
   text: string;
   /** Tool name for `role === "tool"`. */
@@ -114,6 +116,10 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
   const inputRef = useRef<HTMLTextAreaElement>(null);
   // Guards a synchronous double-submit before `running` re-renders.
   const runningRef = useRef(false);
+  // Set true by Stop/Clear so the stream's rejection isn't shown as an error.
+  const cancelledRef = useRef(false);
+  // Monotonic id source for transcript turns (stable React keys + update target).
+  const turnIdRef = useRef(0);
   // Tears down an in-flight drag's window listeners if the panel unmounts
   // mid-drag (e.g. the user closes it while dragging).
   const resizeCleanupRef = useRef<(() => void) | null>(null);
@@ -196,52 +202,65 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
     const prompt = input.trim();
     if (!prompt || runningRef.current || !hasKey) return;
     runningRef.current = true;
+    cancelledRef.current = false;
     setRunning(true);
     setInput("");
-    setTurns((prev) => [...prev, { role: "user", text: prompt }]);
-    // Reserve a streaming assistant turn whose text we append into.
-    let assistantIndex = -1;
-    setTurns((prev) => {
-      assistantIndex = prev.length;
-      return [...prev, { role: "assistant", text: "" }];
-    });
+    // Turns are tracked by stable id (not array index), so updaters stay pure —
+    // safe under React Strict Mode / concurrent re-invocation — and a stale
+    // generator from a stopped/cleared run can no longer corrupt a new one.
+    const userId = (turnIdRef.current += 1);
+    const assistantId = (turnIdRef.current += 1);
+    setTurns((prev) => [
+      ...prev,
+      { id: userId, role: "user", text: prompt },
+      { id: assistantId, role: "assistant", text: "" },
+    ]);
 
     try {
       for await (const event of session.stream(prompt)) {
         if (event.type === "text") {
-          setTurns((prev) => {
-            const next = [...prev];
-            const turn = next[assistantIndex];
-            if (turn) next[assistantIndex] = { ...turn, text: turn.text + event.text };
-            return next;
-          });
+          setTurns((prev) =>
+            prev.map((turn) =>
+              turn.id === assistantId
+                ? { ...turn, text: turn.text + event.text }
+                : turn,
+            ),
+          );
         } else {
-          // Insert a tool line before the streaming assistant turn.
           const detail = event.error
             ? `${describeTool(event.name, event.input)} — ${event.error}`.trim()
             : describeTool(event.name, event.input);
+          const toolId = (turnIdRef.current += 1);
           setTurns((prev) => {
+            const index = prev.findIndex((turn) => turn.id === assistantId);
+            // The streaming turn was cleared (Clear/Stop) — drop the late event
+            // instead of ghosting it back into an empty transcript.
+            if (index < 0) return prev;
             const next = [...prev];
-            next.splice(assistantIndex, 0, {
+            next.splice(index, 0, {
+              id: toolId,
               role: "tool",
               tool: event.name,
               text: detail,
               failed: Boolean(event.error),
             });
-            assistantIndex += 1;
             return next;
           });
         }
       }
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      setTurns((prev) => [...prev, { role: "error", text: message }]);
+      // A user-initiated stop rejects the stream; that isn't an error to show.
+      if (!cancelledRef.current) {
+        const message = error instanceof Error ? error.message : String(error);
+        const errorId = (turnIdRef.current += 1);
+        setTurns((prev) => [...prev, { id: errorId, role: "error", text: message }]);
+      }
     } finally {
-      // Drop an empty assistant turn (e.g. a run that only made tool calls).
+      // Drop the assistant turn if it never produced text (e.g. tool-only run).
       setTurns((prev) =>
         prev.filter(
-          (turn, index) =>
-            !(index === assistantIndex && turn.role === "assistant" && !turn.text),
+          (turn) =>
+            !(turn.id === assistantId && turn.role === "assistant" && !turn.text),
         ),
       );
       runningRef.current = false;
@@ -250,9 +269,18 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
   };
 
   const stop = () => {
+    cancelledRef.current = true;
     session.cancel();
     runningRef.current = false;
     setRunning(false);
+  };
+
+  // Clear the transcript and the agent's conversation history (so the next
+  // message starts fresh), stopping any in-flight run first.
+  const clearConversation = () => {
+    stop();
+    setTurns([]);
+    session.reset();
   };
 
   const onKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
@@ -385,7 +413,7 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
             size="icon"
             className="h-8 w-8"
             title={t("assistant.clear")}
-            onClick={() => setTurns([])}
+            onClick={clearConversation}
           >
             <Eraser className="h-4 w-4" />
           </Button>
@@ -408,11 +436,11 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
         {turns.length === 0 ? (
           <p className="text-muted-foreground">{t("assistant.intro")}</p>
         ) : (
-          turns.map((turn, index) => {
+          turns.map((turn) => {
             if (turn.role === "tool") {
               return (
                 <div
-                  key={index}
+                  key={turn.id}
                   className={cn(
                     "flex items-start gap-1.5 font-mono text-xs",
                     turn.failed ? "text-destructive" : "text-muted-foreground",
@@ -429,7 +457,7 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
             if (turn.role === "error") {
               return (
                 <p
-                  key={index}
+                  key={turn.id}
                   className="flex items-start gap-1.5 text-xs text-destructive"
                 >
                   <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
@@ -439,7 +467,7 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
             }
             return (
               <div
-                key={index}
+                key={turn.id}
                 className={cn(
                   "whitespace-pre-wrap",
                   turn.role === "user"

--- a/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
@@ -1,0 +1,308 @@
+import { useAppStore } from "@geolibre/core";
+import type { MapController } from "@geolibre/map";
+import { Button, Textarea, cn } from "@geolibre/ui";
+import {
+  AlertCircle,
+  Eraser,
+  Loader2,
+  Send,
+  Sparkles,
+  Square,
+  Wrench,
+  X,
+} from "lucide-react";
+import {
+  type KeyboardEvent as ReactKeyboardEvent,
+  type RefObject,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useTranslation } from "react-i18next";
+import { AssistantSession } from "../../lib/assistant/agent";
+import { hasProviderKey } from "../../lib/assistant/provider";
+
+const PANEL_HEIGHT = 360;
+const RUNTIME_ENV_EVENT = "geolibre:runtime-env-change";
+
+/** One rendered line in the conversation transcript. */
+interface Turn {
+  role: "user" | "assistant" | "tool" | "error";
+  text: string;
+  /** Tool name for `role === "tool"`. */
+  tool?: string;
+  /** Whether a tool call errored. */
+  failed?: boolean;
+}
+
+interface AssistantPanelProps {
+  mapControllerRef: RefObject<MapController | null>;
+}
+
+/** Short human-readable summary of a finished tool call. */
+function describeTool(name: string, input: unknown): string {
+  if (name === "run_sql" && input && typeof input === "object") {
+    const sql = (input as { sql?: string }).sql;
+    if (sql) return sql;
+  }
+  if (input && typeof input === "object" && Object.keys(input).length > 0) {
+    try {
+      return JSON.stringify(input);
+    } catch {
+      return "";
+    }
+  }
+  return "";
+}
+
+/**
+ * The natural-language assistant: a bottom-docked chat panel powered by a
+ * GeoLibre-native Strands agent. The agent drives the app exclusively through
+ * store actions, the SQL Workspace, and the symbology helpers, so every change
+ * is reconciled by the normal one-way data flow and covered by undo/redo.
+ * Rendered only while open.
+ *
+ * @param mapControllerRef - Live map controller, read lazily by camera tools.
+ */
+export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
+  const { t } = useTranslation();
+  const setAssistantOpen = useAppStore((s) => s.setAssistantOpen);
+
+  const outputRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  // Guards a synchronous double-submit before `running` re-renders.
+  const runningRef = useRef(false);
+
+  const [turns, setTurns] = useState<Turn[]>([]);
+  const [input, setInput] = useState("");
+  const [running, setRunning] = useState(false);
+  const [hasKey, setHasKey] = useState(() => hasProviderKey());
+
+  // One session per mounted panel; conversation history lives inside it.
+  const session = useMemo(
+    () =>
+      new AssistantSession({
+        getMapController: () => mapControllerRef.current,
+      }),
+    [mapControllerRef],
+  );
+
+  // Tear down the session and any in-flight run on unmount.
+  useEffect(() => () => session.cancel(), [session]);
+
+  // Track whether a provider key is configured; rebuild the agent on change so
+  // a newly-added key takes effect without reopening the panel.
+  useEffect(() => {
+    const onEnvChange = () => {
+      setHasKey(hasProviderKey());
+      session.reset();
+    };
+    window.addEventListener(RUNTIME_ENV_EVENT, onEnvChange);
+    return () => window.removeEventListener(RUNTIME_ENV_EVENT, onEnvChange);
+  }, [session]);
+
+  // Keep the latest turn in view.
+  useEffect(() => {
+    const el = outputRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [turns]);
+
+  const send = async () => {
+    const prompt = input.trim();
+    if (!prompt || runningRef.current || !hasKey) return;
+    runningRef.current = true;
+    setRunning(true);
+    setInput("");
+    setTurns((prev) => [...prev, { role: "user", text: prompt }]);
+    // Reserve a streaming assistant turn whose text we append into.
+    let assistantIndex = -1;
+    setTurns((prev) => {
+      assistantIndex = prev.length;
+      return [...prev, { role: "assistant", text: "" }];
+    });
+
+    try {
+      for await (const event of session.stream(prompt)) {
+        if (event.type === "text") {
+          setTurns((prev) => {
+            const next = [...prev];
+            const turn = next[assistantIndex];
+            if (turn) next[assistantIndex] = { ...turn, text: turn.text + event.text };
+            return next;
+          });
+        } else {
+          // Insert a tool line before the streaming assistant turn.
+          const detail = event.error
+            ? `${describeTool(event.name, event.input)} — ${event.error}`.trim()
+            : describeTool(event.name, event.input);
+          setTurns((prev) => {
+            const next = [...prev];
+            next.splice(assistantIndex, 0, {
+              role: "tool",
+              tool: event.name,
+              text: detail,
+              failed: Boolean(event.error),
+            });
+            assistantIndex += 1;
+            return next;
+          });
+        }
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setTurns((prev) => [...prev, { role: "error", text: message }]);
+    } finally {
+      // Drop an empty assistant turn (e.g. a run that only made tool calls).
+      setTurns((prev) =>
+        prev.filter(
+          (turn, index) =>
+            !(index === assistantIndex && turn.role === "assistant" && !turn.text),
+        ),
+      );
+      runningRef.current = false;
+      setRunning(false);
+    }
+  };
+
+  const stop = () => {
+    session.cancel();
+    runningRef.current = false;
+    setRunning(false);
+  };
+
+  const onKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+      event.preventDefault();
+      void send();
+    }
+  };
+
+  return (
+    <section
+      aria-label={t("assistant.title")}
+      className="relative flex shrink-0 flex-col border-t bg-card"
+      style={{ height: PANEL_HEIGHT }}
+    >
+      <div className="flex items-center gap-2 border-b px-3 py-1.5">
+        <Sparkles className="h-4 w-4 text-muted-foreground" />
+        <span className="text-sm font-semibold">{t("assistant.title")}</span>
+        {running ? (
+          <span className="flex items-center gap-1 text-xs text-muted-foreground">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            {t("assistant.thinking")}
+          </span>
+        ) : null}
+        <div className="ml-auto flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            title={t("assistant.clear")}
+            onClick={() => setTurns([])}
+          >
+            <Eraser className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            title={t("assistant.close")}
+            onClick={() => setAssistantOpen(false)}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+
+      <div
+        ref={outputRef}
+        className="flex-1 space-y-2 overflow-auto px-3 py-2 text-sm leading-relaxed"
+      >
+        {turns.length === 0 ? (
+          <p className="text-muted-foreground">{t("assistant.intro")}</p>
+        ) : (
+          turns.map((turn, index) => {
+            if (turn.role === "tool") {
+              return (
+                <div
+                  key={index}
+                  className={cn(
+                    "flex items-start gap-1.5 font-mono text-xs",
+                    turn.failed ? "text-destructive" : "text-muted-foreground",
+                  )}
+                >
+                  <Wrench className="mt-0.5 h-3 w-3 shrink-0" />
+                  <span className="break-all">
+                    <span className="font-semibold">{turn.tool}</span>
+                    {turn.text ? ` · ${turn.text}` : ""}
+                  </span>
+                </div>
+              );
+            }
+            if (turn.role === "error") {
+              return (
+                <p
+                  key={index}
+                  className="flex items-start gap-1.5 text-xs text-destructive"
+                >
+                  <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                  <span>{turn.text}</span>
+                </p>
+              );
+            }
+            return (
+              <div
+                key={index}
+                className={cn(
+                  "whitespace-pre-wrap",
+                  turn.role === "user"
+                    ? "font-medium text-foreground"
+                    : "text-foreground",
+                )}
+              >
+                {turn.role === "user" ? `❯ ${turn.text}` : turn.text}
+              </div>
+            );
+          })
+        )}
+      </div>
+
+      {!hasKey ? (
+        <p className="border-t bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+          {t("assistant.needsKey")}
+        </p>
+      ) : null}
+
+      <div className="flex items-end gap-2 border-t px-3 py-2">
+        <Textarea
+          ref={inputRef}
+          value={input}
+          onChange={(event) => setInput(event.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder={t("assistant.placeholder")}
+          spellCheck
+          rows={2}
+          disabled={!hasKey}
+          className="min-h-[2.5rem] flex-1 resize-none text-sm"
+        />
+        {running ? (
+          <Button size="sm" variant="outline" onClick={stop} title={t("assistant.stop")}>
+            <Square className="mr-1 h-4 w-4" />
+            {t("assistant.stop")}
+          </Button>
+        ) : (
+          <Button
+            size="sm"
+            onClick={() => void send()}
+            disabled={!hasKey || !input.trim()}
+            title={t("assistant.sendHint")}
+          >
+            <Send className="mr-1 h-4 w-4" />
+            {t("assistant.send")}
+          </Button>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import {
   type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
   type RefObject,
   useEffect,
   useMemo,
@@ -30,8 +31,13 @@ import {
   type AssistantProviderId,
 } from "../../lib/assistant/provider";
 
-const PANEL_HEIGHT = 360;
+const DEFAULT_PANEL_HEIGHT = 360;
+const MIN_PANEL_HEIGHT = 160;
+const MAX_PANEL_HEIGHT = 640;
 const RUNTIME_ENV_EVENT = "geolibre:runtime-env-change";
+// Paired with MapCanvas so it suspends pointer interaction while dragging.
+const PANEL_RESIZE_START_EVENT = "geolibre:panel-resize-start";
+const PANEL_RESIZE_END_EVENT = "geolibre:panel-resize-end";
 const PROVIDER_STORAGE_KEY = "geolibre.assistant.provider";
 const MODEL_STORAGE_KEY = "geolibre.assistant.model";
 const PROVIDER_IDS: readonly AssistantProviderId[] = [
@@ -103,10 +109,16 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
   const { t } = useTranslation();
   const setAssistantOpen = useAppStore((s) => s.setAssistantOpen);
 
+  const sectionRef = useRef<HTMLElement>(null);
   const outputRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   // Guards a synchronous double-submit before `running` re-renders.
   const runningRef = useRef(false);
+  // Tears down an in-flight drag's window listeners if the panel unmounts
+  // mid-drag (e.g. the user closes it while dragging).
+  const resizeCleanupRef = useRef<(() => void) | null>(null);
+
+  const [height, setHeight] = useState(DEFAULT_PANEL_HEIGHT);
 
   const [turns, setTurns] = useState<Turn[]>([]);
   const [input, setInput] = useState("");
@@ -136,6 +148,9 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
 
   // Tear down the session and any in-flight run on unmount.
   useEffect(() => () => session.cancel(), [session]);
+
+  // On unmount mid-drag, tear down the drag's window listeners.
+  useEffect(() => () => resizeCleanupRef.current?.(), []);
 
   // Track which provider keys are configured; rebuild the agent on change so a
   // newly-added key takes effect without reopening the panel.
@@ -259,12 +274,68 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
     saveStored(MODEL_STORAGE_KEY, value);
   };
 
+  // Drag the top edge to resize the panel height. Mirrors the Python Console:
+  // writes are throttled to one DOM mutation per frame and committed to state on
+  // mouseup, and the panel-resize events let MapCanvas pause pointer handling.
+  const startResize = (event: ReactMouseEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const startY = event.clientY;
+    const startHeight = height;
+    let nextHeight = startHeight;
+    let frame: number | null = null;
+    const prevCursor = document.body.style.cursor;
+    const prevSelect = document.body.style.userSelect;
+    document.body.style.cursor = "row-resize";
+    document.body.style.userSelect = "none";
+    window.dispatchEvent(new Event(PANEL_RESIZE_START_EVENT));
+
+    const onMove = (moveEvent: MouseEvent) => {
+      const available = Math.max(MIN_PANEL_HEIGHT, window.innerHeight - 180);
+      const maxHeight = Math.min(MAX_PANEL_HEIGHT, available);
+      nextHeight = Math.min(
+        maxHeight,
+        Math.max(MIN_PANEL_HEIGHT, startHeight + startY - moveEvent.clientY),
+      );
+      if (frame !== null) return;
+      frame = window.requestAnimationFrame(() => {
+        frame = null;
+        if (sectionRef.current) {
+          sectionRef.current.style.height = `${nextHeight}px`;
+        }
+      });
+    };
+
+    const finish = () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", finish);
+      resizeCleanupRef.current = null;
+      if (frame !== null) window.cancelAnimationFrame(frame);
+      setHeight(nextHeight);
+      window.dispatchEvent(new Event(PANEL_RESIZE_END_EVENT));
+      document.body.style.cursor = prevCursor;
+      document.body.style.userSelect = prevSelect;
+    };
+
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", finish);
+    resizeCleanupRef.current = finish;
+  };
+
   return (
     <section
+      ref={sectionRef}
       aria-label={t("assistant.title")}
       className="relative flex shrink-0 flex-col border-t bg-card"
-      style={{ height: PANEL_HEIGHT }}
+      style={{ height }}
     >
+      <div
+        role="separator"
+        aria-orientation="horizontal"
+        aria-label={t("assistant.resize")}
+        className="absolute -top-1 left-0 right-0 z-20 h-2 cursor-row-resize select-none border-t border-transparent hover:border-primary"
+        onMouseDown={startResize}
+      />
       <div className="flex items-center gap-2 border-b px-3 py-1.5">
         <Sparkles className="h-4 w-4 text-muted-foreground" />
         <span className="text-sm font-semibold">{t("assistant.title")}</span>

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -128,7 +128,11 @@
       "hideValueAria": "Hide value for {{name}}",
       "removeAria": "Remove {{name}}",
       "errorNamePattern": "Environment variable names must start with a letter or underscore and contain only letters, numbers, and underscores.",
-      "errorDuplicate": "Environment variable \"{{name}}\" is duplicated."
+      "errorDuplicate": "Environment variable \"{{name}}\" is duplicated.",
+      "stripPromptTitle": "Strip environment variables?",
+      "stripPromptDesc": "This project has {{count}} environment variable(s) (which may include API keys). They are stored in plain text in the project file and could be exposed if you share it. Remove them from the saved file? Your Settings keep them on this device either way.",
+      "stripButton": "Strip from file",
+      "keepButton": "Keep in file"
     },
     "project": {
       "title": "Project",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -186,7 +186,7 @@
       "whiteboxTools": "Whitebox Tools",
       "sqlWorkspace": "SQL Workspace",
       "pythonConsole": "Python Console",
-      "assistant": "Assistant",
+      "assistant": "AI Assistant",
       "geocode": "Geocode Addresses",
       "planetaryComputer": "Planetary Computer",
       "earthEngine": "Earth Engine",
@@ -481,7 +481,7 @@
     "editorPlaceholder": "Write a multi-line Python script here. Ctrl/Cmd+Enter runs it (or the selection) in the console; Tab indents; Ctrl+Space autocompletes."
   },
   "assistant": {
-    "title": "Assistant",
+    "title": "AI Assistant",
     "clear": "Clear conversation",
     "close": "Close assistant",
     "send": "Send",
@@ -491,7 +491,9 @@
     "intro": "Chat with your data. I can run Spatial SQL, add or remove layers, restyle them, and move the map — every change is undoable. Try \"color the countries by population with a graduated red ramp\".",
     "needsKey": "Add an LLM API key (e.g. GEMINI_API_KEY) in Settings → Environment to enable the assistant.",
     "thinking": "Working…",
-    "toolError": "failed"
+    "toolError": "failed",
+    "provider": "LLM provider",
+    "model": "Model"
   },
   "storymap": {
     "title": "Story Map",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -482,6 +482,7 @@
   },
   "assistant": {
     "title": "AI Assistant",
+    "resize": "Resize assistant panel",
     "clear": "Clear conversation",
     "close": "Close assistant",
     "send": "Send",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -494,7 +494,7 @@
     "stop": "Stop",
     "placeholder": "Ask about your data, e.g. \"show countries with population over 50 million\" · Ctrl/Cmd+Enter to send",
     "intro": "Chat with your data. I can run Spatial SQL, add or remove layers, restyle them, and move the map — every change is undoable. Try \"color the countries by population with a graduated red ramp\".",
-    "needsKey": "Add an LLM API key (e.g. GEMINI_API_KEY) in Settings → Environment to enable the assistant.",
+    "needsKey": "Add an LLM API key (GEMINI_API_KEY, ANTHROPIC_API_KEY, or OPENAI_API_KEY) in Settings → Environment to enable the assistant.",
     "thinking": "Working…",
     "toolError": "failed",
     "provider": "LLM provider",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -494,7 +494,7 @@
     "stop": "Stop",
     "placeholder": "Ask about your data, e.g. \"show countries with population over 50 million\" · Ctrl/Cmd+Enter to send",
     "intro": "Chat with your data. I can run Spatial SQL, add or remove layers, restyle them, and move the map — every change is undoable. Try \"color the countries by population with a graduated red ramp\".",
-    "needsKey": "Add an LLM API key (GEMINI_API_KEY, ANTHROPIC_API_KEY, or OPENAI_API_KEY) in Settings → Environment to enable the assistant.",
+    "needsKey": "Configure an LLM provider in Settings → Environment to enable the assistant — an API key (GEMINI_API_KEY, ANTHROPIC_API_KEY, OPENAI_API_KEY), AWS credentials for Bedrock, a local Ollama (OLLAMA_BASE_URL), or a custom OpenAI-compatible endpoint (OPENAI_COMPATIBLE_BASE_URL).",
     "thinking": "Working…",
     "toolError": "failed",
     "provider": "LLM provider",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -186,6 +186,7 @@
       "whiteboxTools": "Whitebox Tools",
       "sqlWorkspace": "SQL Workspace",
       "pythonConsole": "Python Console",
+      "assistant": "Assistant",
       "geocode": "Geocode Addresses",
       "planetaryComputer": "Planetary Computer",
       "earthEngine": "Earth Engine",
@@ -478,6 +479,19 @@
     "untitled": "untitled.py",
     "discardChanges": "Discard unsaved changes to the current script?",
     "editorPlaceholder": "Write a multi-line Python script here. Ctrl/Cmd+Enter runs it (or the selection) in the console; Tab indents; Ctrl+Space autocompletes."
+  },
+  "assistant": {
+    "title": "Assistant",
+    "clear": "Clear conversation",
+    "close": "Close assistant",
+    "send": "Send",
+    "sendHint": "Send (Ctrl/Cmd+Enter)",
+    "stop": "Stop",
+    "placeholder": "Ask about your data, e.g. \"show countries with population over 50 million\" · Ctrl/Cmd+Enter to send",
+    "intro": "Chat with your data. I can run Spatial SQL, add or remove layers, restyle them, and move the map — every change is undoable. Try \"color the countries by population with a graduated red ramp\".",
+    "needsKey": "Add an LLM API key (e.g. GEMINI_API_KEY) in Settings → Environment to enable the assistant.",
+    "thinking": "Working…",
+    "toolError": "failed"
   },
   "storymap": {
     "title": "Story Map",

--- a/apps/geolibre-desktop/src/lib/assistant/agent.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/agent.ts
@@ -20,7 +20,7 @@ Guidelines:
 - Call list_layers to discover the current layers, their attribute fields, and the SQL table names before referencing them.
 - For data questions, prefer run_sql with a single read-only DuckDB Spatial SQL statement against the SQL table names from list_layers. Show the SQL you ran. Only add the result as a layer when the user asks to map it or when geometry is clearly wanted.
 - For styling requests, use apply_symbology with the layer's real field names.
-- To add imagery or tile basemaps (Google Satellite, Esri imagery, OpenStreetMap, etc.), use add_tile_layer. You already know the common XYZ tile URLs, so add them directly rather than asking the user or saying you cannot.
+- To add imagery or tile basemaps (Esri World Imagery, OpenStreetMap, OpenTopoMap, etc.), use add_tile_layer with a known name or an XYZ url, rather than asking the user or saying you cannot.
 - Use web_search when you need current information from the internet.
 - When no dedicated tool fits the request (e.g. changing the map projection to globe, enabling terrain or sky, setting a custom paint/layout property), do not say you can't — use run_maplibre_js to accomplish it with a small JavaScript snippet against the live \`map\` object.
 - For data processing or computation (numpy/pandas/geopandas, custom analysis), use run_python; a \`geolibre\` object is available there to drive the map.

--- a/apps/geolibre-desktop/src/lib/assistant/agent.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/agent.ts
@@ -22,6 +22,7 @@ Guidelines:
 - For styling requests, use apply_symbology with the layer's real field names.
 - To add imagery or tile basemaps (Google Satellite, Esri imagery, OpenStreetMap, etc.), use add_tile_layer. You already know the common XYZ tile URLs, so add them directly rather than asking the user or saying you cannot.
 - Use web_search when you need current information from the internet.
+- When no dedicated tool fits the request (e.g. changing the map projection to globe, enabling terrain or sky, setting a custom paint/layout property), do not say you can't — use run_maplibre_js to accomplish it with a small JavaScript snippet against the live \`map\` object.
 - Keep replies short. Report exactly what each tool did (e.g. the SQL run, the rows returned, the layer added/styled). Every change is undoable, so prefer acting over asking when the request is clear.
 - Never fabricate field names, layer names, or results — read them with the tools first.`;
 

--- a/apps/geolibre-desktop/src/lib/assistant/agent.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/agent.ts
@@ -20,6 +20,8 @@ Guidelines:
 - Call list_layers to discover the current layers, their attribute fields, and the SQL table names before referencing them.
 - For data questions, prefer run_sql with a single read-only DuckDB Spatial SQL statement against the SQL table names from list_layers. Show the SQL you ran. Only add the result as a layer when the user asks to map it or when geometry is clearly wanted.
 - For styling requests, use apply_symbology with the layer's real field names.
+- To add imagery or tile basemaps (Google Satellite, Esri imagery, OpenStreetMap, etc.), use add_tile_layer. You already know the common XYZ tile URLs, so add them directly rather than asking the user or saying you cannot.
+- Use web_search when you need current information from the internet.
 - Keep replies short. Report exactly what each tool did (e.g. the SQL run, the rows returned, the layer added/styled). Every change is undoable, so prefer acting over asking when the request is clear.
 - Never fabricate field names, layer names, or results — read them with the tools first.`;
 

--- a/apps/geolibre-desktop/src/lib/assistant/agent.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/agent.ts
@@ -43,6 +43,8 @@ export class AssistantSession {
   /** Explicit provider/model chosen in the UI; null means auto-resolve. */
   private selection: { provider: AssistantProviderId; model?: string } | null =
     null;
+  /** Last layer context sent, so it is only re-sent when it actually changes. */
+  private lastContext: string | null = null;
 
   constructor(private readonly deps: AssistantToolDeps) {}
 
@@ -66,6 +68,7 @@ export class AssistantSession {
   reset(): void {
     this.agent?.cancel();
     this.agent = null;
+    this.lastContext = null;
   }
 
   /** Cancel the in-flight model/tool run, if any. */
@@ -79,8 +82,11 @@ export class AssistantSession {
       ? configForProvider(this.selection.provider, this.selection.model)
       : resolveProviderConfig();
     if (!config) {
+      const pinned = this.selection?.provider;
       throw new Error(
-        "No LLM API key is configured. Add one (e.g. GEMINI_API_KEY) in Settings → Environment.",
+        pinned
+          ? `No API key for the selected provider "${pinned}". Add its key in Settings → Environment, or pick another provider.`
+          : "No LLM API key is configured. Add one (e.g. GEMINI_API_KEY) in Settings → Environment.",
       );
     }
     const model = await createModel(config);
@@ -102,19 +108,24 @@ export class AssistantSession {
    */
   async *stream(prompt: string): AsyncGenerator<AssistantStreamEvent> {
     const agent = await this.ensureAgent();
+    // Only prepend the layer context when it changed since the last message, so
+    // long conversations don't re-send the full layer list on every turn.
     const context = describeLayers(useAppStore.getState().layers);
-    const message = `Current layers:\n${context}\n\nUser request: ${prompt}`;
+    const message =
+      context === this.lastContext
+        ? prompt
+        : `Current layers:\n${context}\n\nUser request: ${prompt}`;
+    this.lastContext = context;
 
     for await (const event of agent.stream(message)) {
-      // Text deltas as the model writes its reply.
+      // Text deltas as the model writes its reply. `event.event` is the SDK's
+      // normalized ModelStreamEvent (provider-agnostic), so we narrow on its
+      // public discriminants rather than casting to an ad-hoc shape.
       if (event.type === "modelStreamUpdateEvent") {
-        const inner = event.event as {
-          type?: string;
-          delta?: { type?: string; text?: string };
-        };
+        const inner = event.event;
         if (
-          inner?.type === "modelContentBlockDeltaEvent" &&
-          inner.delta?.type === "textDelta" &&
+          inner.type === "modelContentBlockDeltaEvent" &&
+          inner.delta.type === "textDelta" &&
           inner.delta.text
         ) {
           yield { type: "text", text: inner.delta.text };

--- a/apps/geolibre-desktop/src/lib/assistant/agent.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/agent.ts
@@ -86,7 +86,7 @@ export class AssistantSession {
       throw new Error(
         pinned
           ? `No API key for the selected provider "${pinned}". Add its key in Settings → Environment, or pick another provider.`
-          : "No LLM API key is configured. Add one (e.g. GEMINI_API_KEY) in Settings → Environment.",
+          : "No LLM API key is configured. Add GEMINI_API_KEY, ANTHROPIC_API_KEY, or OPENAI_API_KEY in Settings → Environment.",
       );
     }
     const model = await createModel(config);

--- a/apps/geolibre-desktop/src/lib/assistant/agent.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/agent.ts
@@ -23,6 +23,7 @@ Guidelines:
 - To add imagery or tile basemaps (Google Satellite, Esri imagery, OpenStreetMap, etc.), use add_tile_layer. You already know the common XYZ tile URLs, so add them directly rather than asking the user or saying you cannot.
 - Use web_search when you need current information from the internet.
 - When no dedicated tool fits the request (e.g. changing the map projection to globe, enabling terrain or sky, setting a custom paint/layout property), do not say you can't — use run_maplibre_js to accomplish it with a small JavaScript snippet against the live \`map\` object.
+- For data processing or computation (numpy/pandas/geopandas, custom analysis), use run_python; a \`geolibre\` object is available there to drive the map.
 - Keep replies short. Report exactly what each tool did (e.g. the SQL run, the rows returned, the layer added/styled). Every change is undoable, so prefer acting over asking when the request is clear.
 - Never fabricate field names, layer names, or results — read them with the tools first.`;
 

--- a/apps/geolibre-desktop/src/lib/assistant/agent.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/agent.ts
@@ -1,0 +1,110 @@
+import { useAppStore } from "@geolibre/core";
+import { Agent } from "@strands-agents/sdk";
+import { createModel, resolveProviderConfig } from "./provider";
+import {
+  createAssistantTools,
+  describeLayers,
+  type AssistantToolDeps,
+} from "./tools";
+
+/** System prompt establishing the assistant's role, tools, and guardrails. */
+const SYSTEM_PROMPT = `You are GeoLibre's geospatial assistant. You help the user explore and analyze the data already loaded in their map by calling the provided tools.
+
+Guidelines:
+- Always act through the tools. Never claim to have changed the map unless a tool call succeeded.
+- Call list_layers to discover the current layers, their attribute fields, and the SQL table names before referencing them.
+- For data questions, prefer run_sql with a single read-only DuckDB Spatial SQL statement against the SQL table names from list_layers. Show the SQL you ran. Only add the result as a layer when the user asks to map it or when geometry is clearly wanted.
+- For styling requests, use apply_symbology with the layer's real field names.
+- Keep replies short. Report exactly what each tool did (e.g. the SQL run, the rows returned, the layer added/styled). Every change is undoable, so prefer acting over asking when the request is clear.
+- Never fabricate field names, layer names, or results — read them with the tools first.`;
+
+/** A streamed update surfaced to the chat UI. */
+export type AssistantStreamEvent =
+  | { type: "text"; text: string }
+  | { type: "tool"; name: string; input: unknown; error?: string };
+
+/**
+ * A long-lived assistant session wrapping a Strands {@link Agent}. The agent is
+ * built lazily on first use (so it picks up whichever provider key is
+ * configured) and can be {@link reset} when settings change. Conversation
+ * history persists across {@link stream} calls for multi-turn chat.
+ */
+export class AssistantSession {
+  private agent: Agent | null = null;
+
+  constructor(private readonly deps: AssistantToolDeps) {}
+
+  /** True when a provider API key is currently configured. */
+  get available(): boolean {
+    return resolveProviderConfig() !== null;
+  }
+
+  /** Drop the underlying agent so the next prompt rebuilds it (and its key). */
+  reset(): void {
+    this.agent?.cancel();
+    this.agent = null;
+  }
+
+  /** Cancel the in-flight model/tool run, if any. */
+  cancel(): void {
+    this.agent?.cancel();
+  }
+
+  private async ensureAgent(): Promise<Agent> {
+    if (this.agent) return this.agent;
+    const config = resolveProviderConfig();
+    if (!config) {
+      throw new Error(
+        "No LLM API key is configured. Add one (e.g. GEMINI_API_KEY) in Settings → Environment.",
+      );
+    }
+    const model = await createModel(config);
+    this.agent = new Agent({
+      model,
+      tools: createAssistantTools(this.deps),
+      systemPrompt: SYSTEM_PROMPT,
+    });
+    return this.agent;
+  }
+
+  /**
+   * Send a user prompt and stream back text deltas and tool-call notifications.
+   * The current layer context is prepended so the model stays grounded across
+   * turns without rebuilding the agent.
+   *
+   * @param prompt The user's natural-language request.
+   * @yields {@link AssistantStreamEvent} updates as the model and tools run.
+   */
+  async *stream(prompt: string): AsyncGenerator<AssistantStreamEvent> {
+    const agent = await this.ensureAgent();
+    const context = describeLayers(useAppStore.getState().layers);
+    const message = `Current layers:\n${context}\n\nUser request: ${prompt}`;
+
+    for await (const event of agent.stream(message)) {
+      // Text deltas as the model writes its reply.
+      if (event.type === "modelStreamUpdateEvent") {
+        const inner = event.event as {
+          type?: string;
+          delta?: { type?: string; text?: string };
+        };
+        if (
+          inner?.type === "modelContentBlockDeltaEvent" &&
+          inner.delta?.type === "textDelta" &&
+          inner.delta.text
+        ) {
+          yield { type: "text", text: inner.delta.text };
+        }
+        continue;
+      }
+      // A tool finished — surface it (with any error) in the transcript.
+      if (event.type === "afterToolCallEvent") {
+        yield {
+          type: "tool",
+          name: event.toolUse.name,
+          input: event.toolUse.input,
+          error: event.error?.message,
+        };
+      }
+    }
+  }
+}

--- a/apps/geolibre-desktop/src/lib/assistant/agent.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/agent.ts
@@ -1,6 +1,11 @@
 import { useAppStore } from "@geolibre/core";
 import { Agent } from "@strands-agents/sdk";
-import { createModel, resolveProviderConfig } from "./provider";
+import {
+  configForProvider,
+  createModel,
+  resolveProviderConfig,
+  type AssistantProviderId,
+} from "./provider";
 import {
   createAssistantTools,
   describeLayers,
@@ -31,12 +36,26 @@ export type AssistantStreamEvent =
  */
 export class AssistantSession {
   private agent: Agent | null = null;
+  /** Explicit provider/model chosen in the UI; null means auto-resolve. */
+  private selection: { provider: AssistantProviderId; model?: string } | null =
+    null;
 
   constructor(private readonly deps: AssistantToolDeps) {}
 
   /** True when a provider API key is currently configured. */
   get available(): boolean {
     return resolveProviderConfig() !== null;
+  }
+
+  /**
+   * Pin the provider/model (from the UI picker), or pass null to auto-resolve
+   * from the configured keys. Rebuilds the agent on the next prompt.
+   */
+  setSelection(
+    selection: { provider: AssistantProviderId; model?: string } | null,
+  ): void {
+    this.selection = selection;
+    this.reset();
   }
 
   /** Drop the underlying agent so the next prompt rebuilds it (and its key). */
@@ -52,7 +71,9 @@ export class AssistantSession {
 
   private async ensureAgent(): Promise<Agent> {
     if (this.agent) return this.agent;
-    const config = resolveProviderConfig();
+    const config = this.selection
+      ? configForProvider(this.selection.provider, this.selection.model)
+      : resolveProviderConfig();
     if (!config) {
       throw new Error(
         "No LLM API key is configured. Add one (e.g. GEMINI_API_KEY) in Settings → Environment.",

--- a/apps/geolibre-desktop/src/lib/assistant/agent.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/agent.ts
@@ -20,6 +20,8 @@ Guidelines:
 - Call list_layers to discover the current layers, their attribute fields, and the SQL table names before referencing them.
 - For data questions, prefer run_sql with a single read-only DuckDB Spatial SQL statement against the SQL table names from list_layers. Show the SQL you ran. Only add the result as a layer when the user asks to map it or when geometry is clearly wanted.
 - For styling requests, use apply_symbology with the layer's real field names.
+- For geoprocessing (buffer, clip, dissolve, intersection, difference, union, spatial join, simplify, centroids, H3 grids, …), call list_algorithms to discover ids and typed parameters, then run_algorithm with the algorithm id and parameters. A 'layer' parameter takes a layer id. Build a multi-step pipeline by feeding one run's returned result layer id into the next.
+- To add satellite/aerial imagery or other earth-observation data, use search_stac and add_stac_layer against the Planetary Computer (collections such as sentinel-2-l2a, landsat-c2-l2, naip, cop-dem-glo-30); the bounding box defaults to the current view.
 - To add imagery or tile basemaps (Esri World Imagery, OpenStreetMap, OpenTopoMap, etc.), use add_tile_layer with a known name or an XYZ url, rather than asking the user or saying you cannot.
 - Use web_search when you need current information from the internet.
 - When no dedicated tool fits the request (e.g. changing the map projection to globe, enabling terrain or sky, setting a custom paint/layout property), do not say you can't — use run_maplibre_js to accomplish it with a small JavaScript snippet against the live \`map\` object.

--- a/apps/geolibre-desktop/src/lib/assistant/basemaps.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/basemaps.ts
@@ -1,0 +1,107 @@
+/** A well-known XYZ raster tile basemap the assistant can add by name. */
+export interface NamedTileBasemap {
+  id: string;
+  label: string;
+  /** XYZ URL template with {z}/{x}/{y} placeholders. */
+  url: string;
+  attribution: string;
+  tileSize?: number;
+}
+
+/**
+ * Curated registry of common imagery/tile basemaps so the assistant can add,
+ * e.g., "Google Satellite" without needing to look up a URL. These are raster
+ * XYZ layers (added on the map), distinct from the MapLibre vector styles that
+ * `set_basemap` switches between.
+ */
+export const NAMED_TILE_BASEMAPS: readonly NamedTileBasemap[] = [
+  {
+    id: "google-satellite",
+    label: "Google Satellite",
+    url: "https://mt1.google.com/vt/lyrs=s&x={x}&y={y}&z={z}",
+    attribution: "© Google",
+  },
+  {
+    id: "google-hybrid",
+    label: "Google Hybrid",
+    url: "https://mt1.google.com/vt/lyrs=y&x={x}&y={y}&z={z}",
+    attribution: "© Google",
+  },
+  {
+    id: "google-roads",
+    label: "Google Roads",
+    url: "https://mt1.google.com/vt/lyrs=m&x={x}&y={y}&z={z}",
+    attribution: "© Google",
+  },
+  {
+    id: "google-terrain",
+    label: "Google Terrain",
+    url: "https://mt1.google.com/vt/lyrs=p&x={x}&y={y}&z={z}",
+    attribution: "© Google",
+  },
+  {
+    id: "esri-imagery",
+    label: "Esri World Imagery",
+    url: "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+    attribution: "© Esri, Maxar, Earthstar Geographics",
+  },
+  {
+    id: "esri-topo",
+    label: "Esri World Topo",
+    url: "https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}",
+    attribution: "© Esri",
+  },
+  {
+    id: "osm",
+    label: "OpenStreetMap",
+    url: "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
+    attribution: "© OpenStreetMap contributors",
+  },
+  {
+    id: "opentopomap",
+    label: "OpenTopoMap",
+    url: "https://a.tile.opentopomap.org/{z}/{x}/{y}.png",
+    attribution: "© OpenTopoMap (CC-BY-SA)",
+  },
+  {
+    id: "carto-dark",
+    label: "CARTO Dark Matter",
+    url: "https://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
+    attribution: "© CARTO, © OpenStreetMap contributors",
+  },
+];
+
+/** Tokenize a reference into lowercase word parts (splitting on non-alphanum). */
+function tokens(value: string): string[] {
+  return value
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+/**
+ * Resolve a basemap by id or (fuzzy) label, e.g. "google satellite",
+ * "esri imagery", or "satellite". Tries exact id, exact label, substring, then
+ * a token-subset match (every word of the query appears in the id+label).
+ */
+export function findNamedTileBasemap(reference: string): NamedTileBasemap | null {
+  const target = reference.trim().toLowerCase();
+  if (!target) return null;
+  const exact =
+    NAMED_TILE_BASEMAPS.find((basemap) => basemap.id === target) ??
+    NAMED_TILE_BASEMAPS.find(
+      (basemap) => basemap.label.toLowerCase() === target,
+    ) ??
+    NAMED_TILE_BASEMAPS.find((basemap) =>
+      basemap.label.toLowerCase().includes(target),
+    );
+  if (exact) return exact;
+  const queryTokens = tokens(target);
+  if (queryTokens.length === 0) return null;
+  return (
+    NAMED_TILE_BASEMAPS.find((basemap) => {
+      const haystack = tokens(`${basemap.id} ${basemap.label}`);
+      return queryTokens.every((token) => haystack.includes(token));
+    }) ?? null
+  );
+}

--- a/apps/geolibre-desktop/src/lib/assistant/basemaps.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/basemaps.ts
@@ -9,36 +9,13 @@ export interface NamedTileBasemap {
 }
 
 /**
- * Curated registry of common imagery/tile basemaps so the assistant can add,
- * e.g., "Google Satellite" without needing to look up a URL. These are raster
- * XYZ layers (added on the map), distinct from the MapLibre vector styles that
- * `set_basemap` switches between.
+ * Curated registry of common imagery/tile basemaps with documented usage terms
+ * so the assistant can add, e.g., "Esri World Imagery" without looking up a URL.
+ * These are raster XYZ layers (added on the map), distinct from the MapLibre
+ * vector styles that `set_basemap` switches between. (Undocumented endpoints
+ * such as Google's `mt*.google.com` tiles are intentionally excluded.)
  */
 export const NAMED_TILE_BASEMAPS: readonly NamedTileBasemap[] = [
-  {
-    id: "google-satellite",
-    label: "Google Satellite",
-    url: "https://mt1.google.com/vt/lyrs=s&x={x}&y={y}&z={z}",
-    attribution: "© Google",
-  },
-  {
-    id: "google-hybrid",
-    label: "Google Hybrid",
-    url: "https://mt1.google.com/vt/lyrs=y&x={x}&y={y}&z={z}",
-    attribution: "© Google",
-  },
-  {
-    id: "google-roads",
-    label: "Google Roads",
-    url: "https://mt1.google.com/vt/lyrs=m&x={x}&y={y}&z={z}",
-    attribution: "© Google",
-  },
-  {
-    id: "google-terrain",
-    label: "Google Terrain",
-    url: "https://mt1.google.com/vt/lyrs=p&x={x}&y={y}&z={z}",
-    attribution: "© Google",
-  },
   {
     id: "esri-imagery",
     label: "Esri World Imagery",
@@ -80,9 +57,9 @@ function tokens(value: string): string[] {
 }
 
 /**
- * Resolve a basemap by id or (fuzzy) label, e.g. "google satellite",
- * "esri imagery", or "satellite". Tries exact id, exact label, substring, then
- * a token-subset match (every word of the query appears in the id+label).
+ * Resolve a basemap by id or (fuzzy) label, e.g. "esri imagery", "opentopomap",
+ * or "imagery". Tries exact id, exact label, substring, then a token-subset
+ * match (every word of the query appears in the id+label).
  */
 export function findNamedTileBasemap(reference: string): NamedTileBasemap | null {
   const target = reference.trim().toLowerCase();

--- a/apps/geolibre-desktop/src/lib/assistant/markdown.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/markdown.ts
@@ -1,0 +1,17 @@
+import { marked } from "marked";
+import { sanitizeStoryHtml } from "../sanitize-html";
+
+/**
+ * Render the assistant's markdown reply to sanitized HTML for the transcript.
+ * The model output is treated as untrusted (it can be shaped by user data), so
+ * the parsed HTML is passed through the same DOMPurify whitelist used for story
+ * text — scripts, event handlers, and raw media are stripped, and links that
+ * open a new tab get `rel="noopener noreferrer"`.
+ *
+ * @param text Markdown text from the assistant.
+ * @returns Sanitized HTML safe for `dangerouslySetInnerHTML`.
+ */
+export function renderAssistantMarkdown(text: string): string {
+  const html = marked.parse(text, { gfm: true, breaks: true }) as string;
+  return sanitizeStoryHtml(html);
+}

--- a/apps/geolibre-desktop/src/lib/assistant/provider.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/provider.ts
@@ -4,23 +4,56 @@ import type { Model } from "@strands-agents/sdk";
  * Supported LLM providers for the natural-language assistant. The boundary is
  * kept deliberately small and provider-pluggable: each provider maps to a
  * Strands model class that is dynamically imported so only the selected
- * provider's SDK is pulled into the bundle.
+ * provider's SDK is pulled into the bundle. `ollama` and `custom` reuse the
+ * OpenAI-compatible client against a configurable base URL.
  */
-export type AssistantProviderId = "google" | "anthropic" | "openai";
+export type AssistantProviderId =
+  | "google"
+  | "anthropic"
+  | "openai"
+  | "ollama"
+  | "bedrock"
+  | "custom";
+
+/** All provider ids, in auto-selection preference order. */
+export const ASSISTANT_PROVIDER_IDS: readonly AssistantProviderId[] = [
+  "google",
+  "anthropic",
+  "openai",
+  "ollama",
+  "bedrock",
+  "custom",
+];
+
+/** AWS credentials for the Bedrock provider. */
+export interface BedrockCredentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+}
 
 /** A fully resolved provider selection ready to build a model from. */
 export interface AssistantProviderConfig {
   provider: AssistantProviderId;
-  apiKey: string;
   modelId: string;
+  /** API key for key-based providers (a placeholder for ollama/custom). */
+  apiKey?: string;
+  /** OpenAI-compatible base URL (ollama, custom). */
+  baseURL?: string;
+  /** AWS region (bedrock). */
+  region?: string;
+  /** AWS credentials (bedrock). */
+  credentials?: BedrockCredentials;
 }
 
 /**
- * Environment-variable names that supply an API key for each provider. The
- * first present, non-empty key wins. These are read from the user's
+ * Environment-variable names that supply an API key for the key-based providers.
+ * The first present, non-empty value wins. Read from the user's
  * Settings → Environment variables (never hard-coded).
  */
-const PROVIDER_KEY_NAMES: Record<AssistantProviderId, readonly string[]> = {
+const PROVIDER_KEY_NAMES: Partial<
+  Record<AssistantProviderId, readonly string[]>
+> = {
   google: ["GEMINI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_GENAI_API_KEY"],
   anthropic: ["ANTHROPIC_API_KEY"],
   openai: ["OPENAI_API_KEY"],
@@ -28,9 +61,11 @@ const PROVIDER_KEY_NAMES: Record<AssistantProviderId, readonly string[]> = {
 
 /**
  * Selectable models per provider, recommended/newest first. The first entry is
- * the provider default (a capable, broadly-available model). Users can still pin
- * any other id via `GEOLIBRE_ASSISTANT_MODEL` or the model picker. Verified
- * against the providers' model docs as of 2026-06.
+ * the provider default. Users can pin any other id via `GEOLIBRE_ASSISTANT_MODEL`
+ * (or the per-provider env var) or the model picker. The hosted-model ids were
+ * verified against the providers' docs as of 2026-06; the `ollama`/`bedrock`
+ * lists are common examples (use your own via the env vars). `custom` has no
+ * preset — supply the model with `OPENAI_COMPATIBLE_MODEL`.
  */
 export const PROVIDER_MODELS: Record<AssistantProviderId, readonly string[]> = {
   google: ["gemini-3.5-flash", "gemini-3.1-pro-preview", "gemini-2.5-flash"],
@@ -41,13 +76,23 @@ export const PROVIDER_MODELS: Record<AssistantProviderId, readonly string[]> = {
     "claude-haiku-4-5",
   ],
   openai: ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"],
+  ollama: ["llama3.2", "llama3.1", "qwen2.5", "mistral", "gemma2"],
+  bedrock: [
+    "global.anthropic.claude-sonnet-4-6",
+    "global.anthropic.claude-opus-4-8",
+    "global.anthropic.claude-haiku-4-5",
+  ],
+  custom: [],
 };
 
-/** Default model per provider; override with `GEOLIBRE_ASSISTANT_MODEL`. */
+/** Default model per provider (empty for `custom`, which requires its own). */
 const DEFAULT_MODEL: Record<AssistantProviderId, string> = {
   google: PROVIDER_MODELS.google[0],
   anthropic: PROVIDER_MODELS.anthropic[0],
   openai: PROVIDER_MODELS.openai[0],
+  ollama: PROVIDER_MODELS.ollama[0],
+  bedrock: PROVIDER_MODELS.bedrock[0],
+  custom: "",
 };
 
 /** Human-readable provider labels for the UI. */
@@ -55,14 +100,10 @@ export const PROVIDER_LABELS: Record<AssistantProviderId, string> = {
   google: "Google Gemini",
   anthropic: "Anthropic",
   openai: "OpenAI",
+  ollama: "Ollama (local)",
+  bedrock: "Amazon Bedrock",
+  custom: "Custom (OpenAI-compatible)",
 };
-
-/** Provider preference order when several keys are configured. */
-const PROVIDER_ORDER: readonly AssistantProviderId[] = [
-  "google",
-  "anthropic",
-  "openai",
-];
 
 /**
  * Runtime environment map, populated from the user's Settings environment
@@ -82,7 +123,7 @@ export function readRuntimeEnv(): RuntimeEnv {
 }
 
 /** First non-empty value among `names` in `env`, or null. */
-function firstKey(env: RuntimeEnv, names: readonly string[]): string | null {
+function firstValue(env: RuntimeEnv, ...names: string[]): string | null {
   for (const name of names) {
     const value = env[name]?.trim();
     if (value) return value;
@@ -90,53 +131,23 @@ function firstKey(env: RuntimeEnv, names: readonly string[]): string | null {
   return null;
 }
 
-/**
- * Resolve which provider/model/key to use from a runtime environment map.
- *
- * Honors an explicit `GEOLIBRE_ASSISTANT_PROVIDER` override, otherwise picks the
- * first provider (in {@link PROVIDER_ORDER}) that has a configured API key. The
- * model is `GEOLIBRE_ASSISTANT_MODEL` when set, else the provider default.
- *
- * @param env Runtime environment variables (defaults to {@link readRuntimeEnv}).
- * @returns A resolved config, or null when no provider key is configured.
- */
-export function resolveProviderConfig(
-  env: RuntimeEnv = readRuntimeEnv(),
-): AssistantProviderConfig | null {
-  const requested = env.GEOLIBRE_ASSISTANT_PROVIDER?.trim().toLowerCase();
-  const order =
-    requested && requested in PROVIDER_KEY_NAMES
-      ? [requested as AssistantProviderId]
-      : PROVIDER_ORDER;
-
-  for (const provider of order) {
-    const apiKey = firstKey(env, PROVIDER_KEY_NAMES[provider]);
-    if (!apiKey) continue;
-    const modelId =
-      env.GEOLIBRE_ASSISTANT_MODEL?.trim() || DEFAULT_MODEL[provider];
-    return { provider, apiKey, modelId };
-  }
-  return null;
+/** Normalize an Ollama host into an OpenAI-compatible `…/v1` base URL. */
+function ollamaBaseUrl(env: RuntimeEnv): string | null {
+  const raw = firstValue(env, "OLLAMA_BASE_URL", "OLLAMA_HOST");
+  if (!raw) return null;
+  let url = raw.replace(/\/+$/, "");
+  if (!/^https?:\/\//i.test(url)) url = `http://${url}`;
+  if (!/\/v1$/i.test(url)) url = `${url}/v1`;
+  return url;
 }
 
-/** True when at least one provider key is configured. */
-export function hasProviderKey(env: RuntimeEnv = readRuntimeEnv()): boolean {
-  return resolveProviderConfig(env) !== null;
-}
-
-/** The configured API key for a specific provider, or null. */
+/** The configured API key for a key-based provider, or null. */
 export function getApiKey(
   provider: AssistantProviderId,
   env: RuntimeEnv = readRuntimeEnv(),
 ): string | null {
-  return firstKey(env, PROVIDER_KEY_NAMES[provider]);
-}
-
-/** Providers that currently have an API key, in preference order. */
-export function availableProviders(
-  env: RuntimeEnv = readRuntimeEnv(),
-): AssistantProviderId[] {
-  return PROVIDER_ORDER.filter((provider) => getApiKey(provider, env) !== null);
+  const names = PROVIDER_KEY_NAMES[provider];
+  return names ? firstValue(env, ...names) : null;
 }
 
 /** The default model id for a provider. */
@@ -144,32 +155,134 @@ export function defaultModelFor(provider: AssistantProviderId): string {
   return DEFAULT_MODEL[provider];
 }
 
+/** Resolve the model id for a provider: explicit → env → provider default. */
+function resolveModelId(
+  provider: AssistantProviderId,
+  model: string | undefined,
+  env: RuntimeEnv,
+): string {
+  const perProvider =
+    provider === "ollama"
+      ? env.OLLAMA_MODEL
+      : provider === "bedrock"
+        ? env.BEDROCK_MODEL
+        : provider === "custom"
+          ? env.OPENAI_COMPATIBLE_MODEL
+          : undefined;
+  return (
+    model?.trim() ||
+    env.GEOLIBRE_ASSISTANT_MODEL?.trim() ||
+    perProvider?.trim() ||
+    DEFAULT_MODEL[provider]
+  );
+}
+
 /**
- * Build a config for an explicitly chosen provider/model (the UI picker path).
- * Falls back to the env model override then the provider default when `model`
- * is omitted. Returns null when the chosen provider has no API key.
+ * Build a config for an explicitly chosen provider/model (the UI picker path),
+ * or null when that provider is not configured. Each provider type reads its own
+ * Settings → Environment variables:
  *
- * @param provider The provider the user selected.
- * @param model An explicit model id, or undefined for the default.
- * @param env Runtime environment variables.
+ * - google / anthropic / openai — an API key (see {@link PROVIDER_KEY_NAMES}).
+ * - ollama — `OLLAMA_BASE_URL` (or `OLLAMA_HOST`); keyless, local.
+ * - bedrock — `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` (+ `AWS_REGION`,
+ *   `AWS_SESSION_TOKEN`).
+ * - custom — `OPENAI_COMPATIBLE_BASE_URL` (+ optional `OPENAI_COMPATIBLE_API_KEY`)
+ *   and a model via `OPENAI_COMPATIBLE_MODEL`.
  */
 export function configForProvider(
   provider: AssistantProviderId,
   model?: string,
   env: RuntimeEnv = readRuntimeEnv(),
 ): AssistantProviderConfig | null {
-  const apiKey = getApiKey(provider, env);
-  if (!apiKey) return null;
-  const modelId =
-    model?.trim() ||
-    env.GEOLIBRE_ASSISTANT_MODEL?.trim() ||
-    DEFAULT_MODEL[provider];
-  return { provider, apiKey, modelId };
+  const modelId = resolveModelId(provider, model, env);
+
+  switch (provider) {
+    case "google":
+    case "anthropic":
+    case "openai": {
+      const apiKey = getApiKey(provider, env);
+      if (!apiKey) return null;
+      return { provider, apiKey, modelId };
+    }
+    case "ollama": {
+      const baseURL = ollamaBaseUrl(env);
+      if (!baseURL) return null;
+      return { provider, apiKey: "ollama", baseURL, modelId };
+    }
+    case "custom": {
+      const baseURL = firstValue(env, "OPENAI_COMPATIBLE_BASE_URL");
+      if (!baseURL || !modelId) return null;
+      const apiKey =
+        firstValue(env, "OPENAI_COMPATIBLE_API_KEY") ?? "not-needed";
+      return {
+        provider,
+        apiKey,
+        baseURL: baseURL.replace(/\/+$/, ""),
+        modelId,
+      };
+    }
+    case "bedrock": {
+      const accessKeyId = firstValue(env, "AWS_ACCESS_KEY_ID");
+      const secretAccessKey = firstValue(env, "AWS_SECRET_ACCESS_KEY");
+      if (!accessKeyId || !secretAccessKey) return null;
+      const region =
+        firstValue(env, "AWS_REGION", "AWS_DEFAULT_REGION") ?? "us-east-1";
+      const sessionToken = firstValue(env, "AWS_SESSION_TOKEN") ?? undefined;
+      return {
+        provider,
+        modelId,
+        region,
+        credentials: { accessKeyId, secretAccessKey, sessionToken },
+      };
+    }
+  }
+}
+
+/**
+ * Resolve which provider/model to use from a runtime environment map. Honors an
+ * explicit `GEOLIBRE_ASSISTANT_PROVIDER` override, otherwise picks the first
+ * configured provider in {@link ASSISTANT_PROVIDER_IDS} order.
+ *
+ * @param env Runtime environment variables (defaults to {@link readRuntimeEnv}).
+ * @returns A resolved config, or null when no provider is configured.
+ */
+export function resolveProviderConfig(
+  env: RuntimeEnv = readRuntimeEnv(),
+): AssistantProviderConfig | null {
+  const requested = env.GEOLIBRE_ASSISTANT_PROVIDER?.trim().toLowerCase();
+  const order =
+    requested && ASSISTANT_PROVIDER_IDS.includes(requested as AssistantProviderId)
+      ? [requested as AssistantProviderId]
+      : ASSISTANT_PROVIDER_IDS;
+
+  for (const provider of order) {
+    const config = configForProvider(provider, undefined, env);
+    if (config) return config;
+  }
+  return null;
+}
+
+/** True when at least one provider is configured. */
+export function hasProviderKey(env: RuntimeEnv = readRuntimeEnv()): boolean {
+  return resolveProviderConfig(env) !== null;
+}
+
+/** Providers that are currently configured, in preference order. */
+export function availableProviders(
+  env: RuntimeEnv = readRuntimeEnv(),
+): AssistantProviderId[] {
+  return ASSISTANT_PROVIDER_IDS.filter(
+    (provider) => configForProvider(provider, undefined, env) !== null,
+  );
 }
 
 /**
  * Build a Strands {@link Model} for the resolved provider. The provider SDK is
  * dynamically imported so unused providers never enter the initial bundle.
+ *
+ * GeoLibre runs entirely client-side and the credentials are the user's own
+ * (entered in their local Settings), so the OpenAI/Anthropic SDKs are opted into
+ * browser mode — the same model as the existing GeoAgent plugin.
  *
  * @param config A resolved provider selection.
  * @returns A ready-to-use Strands model instance.
@@ -192,9 +305,6 @@ export async function createModel(
       return new AnthropicModel({
         apiKey: config.apiKey,
         modelId: config.modelId,
-        // GeoLibre runs entirely client-side; the key is the user's own,
-        // entered in their local Settings. Opt into the SDK's browser mode (the
-        // same model as the existing GeoAgent plugin).
         clientConfig: { dangerouslyAllowBrowser: true },
       }) as unknown as Model;
     }
@@ -204,6 +314,34 @@ export async function createModel(
         apiKey: config.apiKey,
         modelId: config.modelId,
         clientConfig: { dangerouslyAllowBrowser: true },
+      }) as unknown as Model;
+    }
+    case "ollama":
+    case "custom": {
+      // Ollama and custom endpoints speak the OpenAI Chat Completions API; the
+      // Responses API (OpenAI's default) is not generally supported there.
+      const { OpenAIModel } = await import("@strands-agents/sdk/models/openai");
+      return new OpenAIModel({
+        api: "chat",
+        apiKey: config.apiKey ?? "not-needed",
+        modelId: config.modelId,
+        clientConfig: {
+          baseURL: config.baseURL,
+          dangerouslyAllowBrowser: true,
+        },
+      }) as unknown as Model;
+    }
+    case "bedrock": {
+      const { BedrockModel } = await import(
+        "@strands-agents/sdk/models/bedrock"
+      );
+      return new BedrockModel({
+        modelId: config.modelId,
+        region: config.region,
+        clientConfig: {
+          region: config.region,
+          credentials: config.credentials,
+        },
       }) as unknown as Model;
     }
   }

--- a/apps/geolibre-desktop/src/lib/assistant/provider.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/provider.ts
@@ -27,14 +27,20 @@ const PROVIDER_KEY_NAMES: Record<AssistantProviderId, readonly string[]> = {
 };
 
 /**
- * Selectable models per provider, most capable/common first. The first entry is
- * also the provider default. Users can still pin any other id via
- * `GEOLIBRE_ASSISTANT_MODEL`.
+ * Selectable models per provider, recommended/newest first. The first entry is
+ * the provider default (a capable, broadly-available model). Users can still pin
+ * any other id via `GEOLIBRE_ASSISTANT_MODEL` or the model picker. Verified
+ * against the providers' model docs as of 2026-06.
  */
 export const PROVIDER_MODELS: Record<AssistantProviderId, readonly string[]> = {
-  google: ["gemini-2.5-flash", "gemini-2.5-pro", "gemini-2.0-flash"],
-  anthropic: ["claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5"],
-  openai: ["gpt-4o", "gpt-4o-mini", "gpt-4.1"],
+  google: ["gemini-3.5-flash", "gemini-3.1-pro-preview", "gemini-2.5-flash"],
+  anthropic: [
+    "claude-opus-4-8",
+    "claude-fable-5",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5",
+  ],
+  openai: ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"],
 };
 
 /** Default model per provider; override with `GEOLIBRE_ASSISTANT_MODEL`. */

--- a/apps/geolibre-desktop/src/lib/assistant/provider.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/provider.ts
@@ -1,0 +1,138 @@
+import type { Model } from "@strands-agents/sdk";
+
+/**
+ * Supported LLM providers for the natural-language assistant. The boundary is
+ * kept deliberately small and provider-pluggable: each provider maps to a
+ * Strands model class that is dynamically imported so only the selected
+ * provider's SDK is pulled into the bundle.
+ */
+export type AssistantProviderId = "google" | "anthropic" | "openai";
+
+/** A fully resolved provider selection ready to build a model from. */
+export interface AssistantProviderConfig {
+  provider: AssistantProviderId;
+  apiKey: string;
+  modelId: string;
+}
+
+/**
+ * Environment-variable names that supply an API key for each provider. The
+ * first present, non-empty key wins. These are read from the user's
+ * Settings → Environment variables (never hard-coded).
+ */
+const PROVIDER_KEY_NAMES: Record<AssistantProviderId, readonly string[]> = {
+  google: ["GEMINI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_GENAI_API_KEY"],
+  anthropic: ["ANTHROPIC_API_KEY"],
+  openai: ["OPENAI_API_KEY"],
+};
+
+/** Default model per provider; override with `GEOLIBRE_ASSISTANT_MODEL`. */
+const DEFAULT_MODEL: Record<AssistantProviderId, string> = {
+  google: "gemini-2.5-flash",
+  anthropic: "claude-opus-4-8",
+  openai: "gpt-4o",
+};
+
+/** Provider preference order when several keys are configured. */
+const PROVIDER_ORDER: readonly AssistantProviderId[] = [
+  "google",
+  "anthropic",
+  "openai",
+];
+
+/**
+ * Runtime environment map, populated from the user's Settings environment
+ * variables by {@link ../../hooks/useRuntimeEnvironmentVariables}. Reading the
+ * global keeps the assistant decoupled from React state and lets it pick up the
+ * latest keys whenever a prompt is sent.
+ */
+export type RuntimeEnv = Record<string, string>;
+
+/** Read the live runtime environment map, or `{}` outside the browser. */
+export function readRuntimeEnv(): RuntimeEnv {
+  if (typeof window === "undefined") return {};
+  return (
+    (window as unknown as { __GEOLIBRE_RUNTIME_ENV__?: RuntimeEnv })
+      .__GEOLIBRE_RUNTIME_ENV__ ?? {}
+  );
+}
+
+/** First non-empty value among `names` in `env`, or null. */
+function firstKey(env: RuntimeEnv, names: readonly string[]): string | null {
+  for (const name of names) {
+    const value = env[name]?.trim();
+    if (value) return value;
+  }
+  return null;
+}
+
+/**
+ * Resolve which provider/model/key to use from a runtime environment map.
+ *
+ * Honors an explicit `GEOLIBRE_ASSISTANT_PROVIDER` override, otherwise picks the
+ * first provider (in {@link PROVIDER_ORDER}) that has a configured API key. The
+ * model is `GEOLIBRE_ASSISTANT_MODEL` when set, else the provider default.
+ *
+ * @param env Runtime environment variables (defaults to {@link readRuntimeEnv}).
+ * @returns A resolved config, or null when no provider key is configured.
+ */
+export function resolveProviderConfig(
+  env: RuntimeEnv = readRuntimeEnv(),
+): AssistantProviderConfig | null {
+  const requested = env.GEOLIBRE_ASSISTANT_PROVIDER?.trim().toLowerCase();
+  const order =
+    requested && requested in PROVIDER_KEY_NAMES
+      ? [requested as AssistantProviderId]
+      : PROVIDER_ORDER;
+
+  for (const provider of order) {
+    const apiKey = firstKey(env, PROVIDER_KEY_NAMES[provider]);
+    if (!apiKey) continue;
+    const modelId =
+      env.GEOLIBRE_ASSISTANT_MODEL?.trim() || DEFAULT_MODEL[provider];
+    return { provider, apiKey, modelId };
+  }
+  return null;
+}
+
+/** True when at least one provider key is configured. */
+export function hasProviderKey(env: RuntimeEnv = readRuntimeEnv()): boolean {
+  return resolveProviderConfig(env) !== null;
+}
+
+/**
+ * Build a Strands {@link Model} for the resolved provider. The provider SDK is
+ * dynamically imported so unused providers never enter the initial bundle.
+ *
+ * @param config A resolved provider selection.
+ * @returns A ready-to-use Strands model instance.
+ */
+export async function createModel(
+  config: AssistantProviderConfig,
+): Promise<Model> {
+  switch (config.provider) {
+    case "google": {
+      const { GoogleModel } = await import("@strands-agents/sdk/models/google");
+      return new GoogleModel({
+        apiKey: config.apiKey,
+        modelId: config.modelId,
+      }) as unknown as Model;
+    }
+    case "anthropic": {
+      const { AnthropicModel } = await import(
+        "@strands-agents/sdk/models/anthropic"
+      );
+      return new AnthropicModel({
+        apiKey: config.apiKey,
+        modelId: config.modelId,
+      }) as unknown as Model;
+    }
+    case "openai": {
+      const { OpenAIModel } = await import("@strands-agents/sdk/models/openai");
+      return new OpenAIModel({
+        apiKey: config.apiKey,
+        modelId: config.modelId,
+      }) as unknown as Model;
+    }
+  }
+}

--- a/apps/geolibre-desktop/src/lib/assistant/provider.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/provider.ts
@@ -26,11 +26,29 @@ const PROVIDER_KEY_NAMES: Record<AssistantProviderId, readonly string[]> = {
   openai: ["OPENAI_API_KEY"],
 };
 
+/**
+ * Selectable models per provider, most capable/common first. The first entry is
+ * also the provider default. Users can still pin any other id via
+ * `GEOLIBRE_ASSISTANT_MODEL`.
+ */
+export const PROVIDER_MODELS: Record<AssistantProviderId, readonly string[]> = {
+  google: ["gemini-2.5-flash", "gemini-2.5-pro", "gemini-2.0-flash"],
+  anthropic: ["claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5"],
+  openai: ["gpt-4o", "gpt-4o-mini", "gpt-4.1"],
+};
+
 /** Default model per provider; override with `GEOLIBRE_ASSISTANT_MODEL`. */
 const DEFAULT_MODEL: Record<AssistantProviderId, string> = {
-  google: "gemini-2.5-flash",
-  anthropic: "claude-opus-4-8",
-  openai: "gpt-4o",
+  google: PROVIDER_MODELS.google[0],
+  anthropic: PROVIDER_MODELS.anthropic[0],
+  openai: PROVIDER_MODELS.openai[0],
+};
+
+/** Human-readable provider labels for the UI. */
+export const PROVIDER_LABELS: Record<AssistantProviderId, string> = {
+  google: "Google Gemini",
+  anthropic: "Anthropic",
+  openai: "OpenAI",
 };
 
 /** Provider preference order when several keys are configured. */
@@ -98,6 +116,49 @@ export function resolveProviderConfig(
 /** True when at least one provider key is configured. */
 export function hasProviderKey(env: RuntimeEnv = readRuntimeEnv()): boolean {
   return resolveProviderConfig(env) !== null;
+}
+
+/** The configured API key for a specific provider, or null. */
+export function getApiKey(
+  provider: AssistantProviderId,
+  env: RuntimeEnv = readRuntimeEnv(),
+): string | null {
+  return firstKey(env, PROVIDER_KEY_NAMES[provider]);
+}
+
+/** Providers that currently have an API key, in preference order. */
+export function availableProviders(
+  env: RuntimeEnv = readRuntimeEnv(),
+): AssistantProviderId[] {
+  return PROVIDER_ORDER.filter((provider) => getApiKey(provider, env) !== null);
+}
+
+/** The default model id for a provider. */
+export function defaultModelFor(provider: AssistantProviderId): string {
+  return DEFAULT_MODEL[provider];
+}
+
+/**
+ * Build a config for an explicitly chosen provider/model (the UI picker path).
+ * Falls back to the env model override then the provider default when `model`
+ * is omitted. Returns null when the chosen provider has no API key.
+ *
+ * @param provider The provider the user selected.
+ * @param model An explicit model id, or undefined for the default.
+ * @param env Runtime environment variables.
+ */
+export function configForProvider(
+  provider: AssistantProviderId,
+  model?: string,
+  env: RuntimeEnv = readRuntimeEnv(),
+): AssistantProviderConfig | null {
+  const apiKey = getApiKey(provider, env);
+  if (!apiKey) return null;
+  const modelId =
+    model?.trim() ||
+    env.GEOLIBRE_ASSISTANT_MODEL?.trim() ||
+    DEFAULT_MODEL[provider];
+  return { provider, apiKey, modelId };
 }
 
 /**

--- a/apps/geolibre-desktop/src/lib/assistant/provider.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/provider.ts
@@ -192,6 +192,10 @@ export async function createModel(
       return new AnthropicModel({
         apiKey: config.apiKey,
         modelId: config.modelId,
+        // GeoLibre runs entirely client-side; the key is the user's own,
+        // entered in their local Settings. Opt into the SDK's browser mode (the
+        // same model as the existing GeoAgent plugin).
+        clientConfig: { dangerouslyAllowBrowser: true },
       }) as unknown as Model;
     }
     case "openai": {
@@ -199,6 +203,7 @@ export async function createModel(
       return new OpenAIModel({
         apiKey: config.apiKey,
         modelId: config.modelId,
+        clientConfig: { dangerouslyAllowBrowser: true },
       }) as unknown as Model;
     }
   }

--- a/apps/geolibre-desktop/src/lib/assistant/symbology.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/symbology.ts
@@ -114,7 +114,12 @@ export function buildSymbologyStyle(
         `Property "${request.property}" is not numeric; use categorized mode instead.`,
       );
     }
-    const classCount = Math.max(2, Math.min(request.classCount ?? 5, 12));
+    // Cap classes by the number of values too, so we never ask for more breaks
+    // than the data supports (which would yield duplicate/empty color stops).
+    const classCount = Math.max(
+      2,
+      Math.min(request.classCount ?? 5, 12, numbers.length),
+    );
     const scheme = request.scheme ?? "equal-interval";
     return {
       vectorStyleMode: "graduated",

--- a/apps/geolibre-desktop/src/lib/assistant/symbology.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/symbology.ts
@@ -1,0 +1,135 @@
+import {
+  createEqualIntervalBreaks,
+  createQuantileBreaks,
+  interpolateRampColors,
+  type GeoLibreLayer,
+  type LayerStyle,
+  type VectorStyleStop,
+} from "@geolibre/core";
+
+/** Styling mode the assistant can apply to a vector layer. */
+export type AssistantSymbologyMode = "graduated" | "categorized";
+
+/** Options describing the symbology the assistant wants to apply. */
+export interface SymbologyRequest {
+  mode: AssistantSymbologyMode;
+  /** Feature property to drive the styling. */
+  property: string;
+  /** Color ramp id (e.g. "reds", "viridis"); defaults to "viridis". */
+  colorRamp?: string;
+  /** Number of classes for graduated mode (default 5). */
+  classCount?: number;
+  /** Classification scheme for graduated mode. */
+  scheme?: "equal-interval" | "quantile";
+}
+
+/** Read every value a property takes across a layer's features. */
+function propertyValues(layer: GeoLibreLayer, property: string): unknown[] {
+  const features = layer.geojson?.features ?? [];
+  const values: unknown[] = [];
+  for (const feature of features) {
+    const value = feature.properties?.[property];
+    if (value !== undefined && value !== null) values.push(value);
+  }
+  return values;
+}
+
+/** Build graduated color stops from numeric breaks and a ramp. */
+function graduatedStops(
+  values: number[],
+  classCount: number,
+  scheme: "equal-interval" | "quantile",
+  colorRamp: string,
+): VectorStyleStop[] {
+  const breaks =
+    scheme === "quantile"
+      ? createQuantileBreaks(values, classCount)
+      : createEqualIntervalBreaks(
+          Math.min(...values),
+          Math.max(...values),
+          classCount,
+        );
+  const colors = interpolateRampColors(colorRamp, breaks.length);
+  return breaks.map((value, index) => ({
+    value,
+    color: colors[index],
+  }));
+}
+
+/** Build categorized color stops, one per distinct value (capped). */
+function categorizedStops(
+  values: unknown[],
+  colorRamp: string,
+): VectorStyleStop[] {
+  // Cap categories so a high-cardinality field can't produce a giant legend.
+  const MAX_CATEGORIES = 24;
+  const distinct: string[] = [];
+  const seen = new Set<string>();
+  for (const value of values) {
+    const key = String(value);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    distinct.push(key);
+    if (distinct.length >= MAX_CATEGORIES) break;
+  }
+  const colors = interpolateRampColors(colorRamp, distinct.length);
+  return distinct.map((value, index) => ({
+    value,
+    color: colors[index],
+    label: value,
+  }));
+}
+
+/**
+ * Build a {@link LayerStyle} patch implementing the requested data-driven
+ * symbology, mapping onto the store's existing `graduated`/`categorized` modes
+ * and color-ramp helpers. Pure and side-effect-free so it is unit-testable; the
+ * tool layer applies the result via `setLayerStyle`.
+ *
+ * @param layer The layer to read property values from.
+ * @param request The symbology to apply.
+ * @returns A partial style ready for `setLayerStyle`.
+ * @throws If the property is missing, or graduated mode has too few numeric values.
+ */
+export function buildSymbologyStyle(
+  layer: GeoLibreLayer,
+  request: SymbologyRequest,
+): Partial<LayerStyle> {
+  const colorRamp = request.colorRamp?.trim() || "viridis";
+  const values = propertyValues(layer, request.property);
+  if (values.length === 0) {
+    throw new Error(
+      `Property "${request.property}" has no values on layer "${layer.name}".`,
+    );
+  }
+
+  if (request.mode === "graduated") {
+    const numbers = values
+      .map((value) =>
+        typeof value === "number" ? value : Number.parseFloat(String(value)),
+      )
+      .filter((value) => Number.isFinite(value));
+    if (numbers.length < 2) {
+      throw new Error(
+        `Property "${request.property}" is not numeric; use categorized mode instead.`,
+      );
+    }
+    const classCount = Math.max(2, Math.min(request.classCount ?? 5, 12));
+    const scheme = request.scheme ?? "equal-interval";
+    return {
+      vectorStyleMode: "graduated",
+      vectorStyleProperty: request.property,
+      vectorStyleColorRamp: colorRamp,
+      vectorStyleClassCount: classCount,
+      vectorStyleClassificationScheme: scheme,
+      vectorStyleStops: graduatedStops(numbers, classCount, scheme, colorRamp),
+    };
+  }
+
+  return {
+    vectorStyleMode: "categorized",
+    vectorStyleProperty: request.property,
+    vectorStyleColorRamp: colorRamp,
+    vectorStyleStops: categorizedStops(values, colorRamp),
+  };
+}

--- a/apps/geolibre-desktop/src/lib/assistant/tools.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/tools.ts
@@ -374,6 +374,33 @@ export function createAssistantTools(
     },
   });
 
+  const runMaplibreJs = tool({
+    name: "run_maplibre_js",
+    description:
+      "Fallback for tasks with no dedicated tool (e.g. globe projection, terrain, sky, custom paint/layout properties). Runs a small JavaScript snippet against the live map. The snippet is a function body with `map` (the MapLibre GL JS map) in scope and may `return` a JSON-serializable value. Example — switch to globe: `map.setProjection({ type: 'globe' })`. Prefer dedicated tools when one exists.",
+    inputSchema: z.object({
+      code: z
+        .string()
+        .describe("JavaScript function body; `map` (MapLibre map) is in scope."),
+    }),
+    callback: (input) => {
+      const map = deps.getMapController()?.getMap();
+      if (!map) throw new Error("The map is not ready yet.");
+      // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+      const run = new Function("map", input.code) as (map: unknown) => unknown;
+      const result = run(map);
+      // Coerce to a JSON-safe value so non-serializable returns (e.g. the map
+      // object itself) don't blow up the tool result.
+      let safe: JSONValue = null;
+      try {
+        safe = JSON.parse(JSON.stringify(result ?? null)) as JSONValue;
+      } catch {
+        safe = String(result);
+      }
+      return json({ ok: true, result: safe });
+    },
+  });
+
   const applySymbology = tool({
     name: "apply_symbology",
     description:
@@ -418,5 +445,6 @@ export function createAssistantTools(
     setBasemap,
     zoomTo,
     applySymbology,
+    runMaplibreJs,
   ] as InvokableTool<unknown, unknown>[];
 }

--- a/apps/geolibre-desktop/src/lib/assistant/tools.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/tools.ts
@@ -10,6 +10,7 @@ import { tool } from "@strands-agents/sdk";
 import type { FeatureCollection } from "geojson";
 import { z } from "zod";
 import { inferPropertyColumns } from "../pglite-sql";
+import { consoleDeps, runConsoleCode } from "../pyodide/pyodide-console";
 import { previewLayerTables, runSqlQuery } from "../sql-workspace";
 import { createXyzTileUrlTemplate } from "../xyz-url";
 import {
@@ -140,6 +141,9 @@ export function createAssistantTools(
   // Tool results are serialized to the model; the data we return is JSON-safe by
   // construction, so this asserts the shape against Strands' strict JSONValue.
   const json = (value: unknown): JSONValue => value as JSONValue;
+  // Shared Pyodide scripting context for run_python (exposes the `geolibre`
+  // facade that drives the live map).
+  const pyDeps = consoleDeps(deps.getMapController);
 
   const listLayers = tool({
     name: "list_layers",
@@ -374,6 +378,19 @@ export function createAssistantTools(
     },
   });
 
+  const runPython = tool({
+    name: "run_python",
+    description:
+      "Run a Python snippet in the in-app Pyodide runtime for data/compute tasks (numpy, pandas, etc.). A `geolibre` object is in scope to drive the live map, e.g. `geolibre.get_center()` or `geolibre.add_geojson(name, data)`; `await geolibre.load_package('geopandas')` installs packages. Returns captured stdout and the repr of the last expression. The first call boots the Python runtime and can take several seconds. Prefer run_sql for querying layer attributes.",
+    inputSchema: z.object({
+      code: z.string().describe("Python source to execute."),
+    }),
+    callback: async (input) => {
+      const result = await runConsoleCode(pyDeps, input.code);
+      return json({ output: result.output, error: result.error });
+    },
+  });
+
   const runMaplibreJs = tool({
     name: "run_maplibre_js",
     description:
@@ -446,5 +463,6 @@ export function createAssistantTools(
     zoomTo,
     applySymbology,
     runMaplibreJs,
+    runPython,
   ] as InvokableTool<unknown, unknown>[];
 }

--- a/apps/geolibre-desktop/src/lib/assistant/tools.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/tools.ts
@@ -6,6 +6,7 @@ import {
 } from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
 import type { InvokableTool, JSONValue } from "@strands-agents/sdk";
+import maplibregl from "maplibre-gl";
 import { tool } from "@strands-agents/sdk";
 import type { FeatureCollection } from "geojson";
 import { z } from "zod";
@@ -551,18 +552,23 @@ export function createAssistantTools(
   const runMaplibreJs = tool({
     name: "run_maplibre_js",
     description:
-      "Fallback for tasks with no dedicated tool (e.g. globe projection, terrain, sky, custom paint/layout properties). Runs a small JavaScript snippet against the live map. The snippet is a function body with `map` (the MapLibre GL JS map) in scope and may `return` a JSON-serializable value. Example — switch to globe: `map.setProjection({ type: 'globe' })`. Prefer dedicated tools when one exists; changes made here bypass the store and are NOT undoable.",
+      "Fallback for tasks with no dedicated tool (e.g. globe projection, terrain, sky, custom paint/layout properties, controls, markers). Runs a small JavaScript snippet against the live map. The snippet is a function body with `map` (the MapLibre GL JS map) and `maplibregl` (the MapLibre GL JS module, e.g. `maplibregl.TerrainControl`, `maplibregl.Marker`) in scope, and may `return` a JSON-serializable value. Example — switch to globe: `map.setProjection({ type: 'globe' })`. Prefer dedicated tools when one exists; changes made here bypass the store and are NOT undoable.",
     inputSchema: z.object({
       code: z
         .string()
-        .describe("JavaScript function body; `map` (MapLibre map) is in scope."),
+        .describe(
+          "JavaScript function body; `map` and `maplibregl` are in scope.",
+        ),
     }),
     callback: (input) => {
       const map = deps.getMapController()?.getMap();
       if (!map) throw new Error("The map is not ready yet.");
       // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
-      const run = new Function("map", input.code) as (map: unknown) => unknown;
-      const result = run(map);
+      const run = new Function("map", "maplibregl", input.code) as (
+        map: unknown,
+        maplibregl: unknown,
+      ) => unknown;
+      const result = run(map, maplibregl);
       // Coerce to a JSON-safe value so non-serializable returns (e.g. the map
       // object itself) don't blow up the tool result.
       let safe: JSONValue = null;

--- a/apps/geolibre-desktop/src/lib/assistant/tools.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/tools.ts
@@ -256,6 +256,42 @@ export function createAssistantTools(
   // facade that drives the live map).
   const pyDeps = consoleDeps(deps.getMapController);
 
+  /** The current map viewport as [west, south, east, north], or null. */
+  const viewBbox = (): [number, number, number, number] | null => {
+    const map = deps.getMapController()?.getMap();
+    if (!map) return null;
+    const b = map.getBounds();
+    return [b.getWest(), b.getSouth(), b.getEast(), b.getNorth()];
+  };
+
+  /** Reduce a STAC bbox (2D or 3D) to a 2D [w, s, e, n]. */
+  const bbox2d = (bbox: number[]): [number, number, number, number] | null =>
+    bbox.length >= 6
+      ? [bbox[0], bbox[1], bbox[3], bbox[4]]
+      : bbox.length >= 4
+        ? [bbox[0], bbox[1], bbox[2], bbox[3]]
+        : null;
+
+  // Lazily load the shared processing executor (Phase 2). It pulls in the
+  // algorithm registries (Turf, DuckDB), so it is imported only when used.
+  type ScriptingHandlers = {
+    listAlgorithms: () => unknown;
+    runAlgorithm: (input: {
+      id: string;
+      params: Record<string, unknown>;
+    }) => Promise<{ logs?: string[]; resultLayerIds?: string[] }>;
+  };
+  let scriptingPromise: Promise<ScriptingHandlers> | null = null;
+  const getScripting = (): Promise<ScriptingHandlers> => {
+    scriptingPromise ??= import("../scripting/scriptingApi").then(
+      ({ createScriptingHandlers }) =>
+        createScriptingHandlers({
+          getController: deps.getMapController,
+        }) as unknown as ScriptingHandlers,
+    );
+    return scriptingPromise;
+  };
+
   const listLayers = tool({
     name: "list_layers",
     description:
@@ -613,11 +649,168 @@ export function createAssistantTools(
     },
   });
 
+  const listAlgorithms = tool({
+    name: "list_algorithms",
+    description:
+      "List the available client-side processing algorithms (vector geometry/overlay tools like buffer, clip, dissolve, intersection, difference, union, spatial-join; plus H3 grids) with their id, name, group, and typed parameters. Call this before run_algorithm.",
+    inputSchema: z.object({}),
+    callback: async () => json({ algorithms: (await getScripting()).listAlgorithms() }),
+  });
+
+  const runAlgorithm = tool({
+    name: "run_algorithm",
+    description:
+      "Run a processing algorithm by id (from list_algorithms) and add its result as a new layer. `params` is an object keyed by parameter id; a 'layer' parameter takes a layer id (from list_layers). Build a pipeline by running one algorithm, then passing its returned result layer id into the next. Returns the run log and the new layer id(s).",
+    inputSchema: z.object({
+      id: z.string().describe("Algorithm id, e.g. 'buffer', 'clip', 'dissolve'."),
+      params: z
+        .record(z.string(), z.unknown())
+        .optional()
+        .describe("Parameter values keyed by parameter id; layer params take a layer id."),
+    }),
+    callback: async (input) => {
+      const result = await (await getScripting()).runAlgorithm({
+        id: input.id,
+        params: (input.params as Record<string, unknown>) ?? {},
+      });
+      return json({
+        logs: result.logs ?? [],
+        resultLayerIds: result.resultLayerIds ?? [],
+      });
+    },
+  });
+
+  const searchStac = tool({
+    name: "search_stac",
+    description:
+      "Search the Microsoft Planetary Computer STAC catalog for earth-observation items in a collection (e.g. 'sentinel-2-l2a', 'landsat-c2-l2', 'naip', 'cop-dem-glo-30'). Defaults the bounding box to the current map view and sorts newest-first. Returns matching items (id, datetime, cloud cover, bbox).",
+    inputSchema: z.object({
+      collection: z.string().describe("STAC collection id, e.g. 'sentinel-2-l2a'."),
+      bbox: z
+        .array(z.number())
+        .length(4)
+        .optional()
+        .describe("[west, south, east, north]; defaults to the current view."),
+      datetime: z
+        .string()
+        .optional()
+        .describe("RFC3339 datetime or range, e.g. '2024-06-01/2024-09-30'."),
+      limit: z.number().optional().describe("Max items (default 10)."),
+    }),
+    callback: async (input) => {
+      const { STACClient } = await import("maplibre-gl-planetary-computer");
+      const bbox =
+        (input.bbox as [number, number, number, number] | undefined) ??
+        viewBbox() ??
+        undefined;
+      const items = await new STACClient().search({
+        collections: [input.collection],
+        bbox,
+        datetime: input.datetime,
+        limit: input.limit ?? 10,
+        sortby: [{ field: "datetime", direction: "desc" }],
+      });
+      return json({
+        count: items.length,
+        items: items.map((item) => ({
+          id: item.id,
+          datetime: item.properties.datetime,
+          cloudCover: item.properties["eo:cloud_cover"] ?? null,
+          bbox: item.bbox,
+        })),
+      });
+    },
+  });
+
+  const addStacLayer = tool({
+    name: "add_stac_layer",
+    description:
+      "Add a Planetary Computer STAC item as a raster tile layer (tiles are signed server-side — no credentials needed). Give a collection and optionally a specific itemId from search_stac; otherwise the newest item over the current view is used. Renders with the collection's default band/colormap preset.",
+    inputSchema: z.object({
+      collection: z.string().describe("STAC collection id, e.g. 'sentinel-2-l2a'."),
+      itemId: z
+        .string()
+        .optional()
+        .describe("A specific item id; otherwise the latest over the view is used."),
+      bbox: z.array(z.number()).length(4).optional(),
+      datetime: z.string().optional(),
+      name: z.string().optional(),
+    }),
+    callback: async (input) => {
+      const { STACClient, TiTilerClient, getDefaultPreset } = await import(
+        "maplibre-gl-planetary-computer"
+      );
+      const stac = new STACClient();
+      let item;
+      if (input.itemId) {
+        item = await stac.getItem(input.collection, input.itemId);
+      } else {
+        const bbox =
+          (input.bbox as [number, number, number, number] | undefined) ??
+          viewBbox() ??
+          undefined;
+        const items = await stac.search({
+          collections: [input.collection],
+          bbox,
+          datetime: input.datetime,
+          limit: 1,
+          sortby: [{ field: "datetime", direction: "desc" }],
+        });
+        if (!items.length) {
+          throw new Error(
+            `No ${input.collection} items found for the given area/time.`,
+          );
+        }
+        item = items[0];
+      }
+      const preset = getDefaultPreset(input.collection);
+      const tileUrl = new TiTilerClient().getItemTileUrl(
+        input.collection,
+        item.id,
+        preset?.params,
+      );
+      const bounds = bbox2d(item.bbox);
+      const layer: GeoLibreLayer = {
+        id: crypto.randomUUID(),
+        name:
+          input.name?.trim() ||
+          `${input.collection} ${item.properties.datetime ?? item.id}`,
+        type: "xyz",
+        source: {
+          type: "raster",
+          tiles: [tileUrl],
+          tileSize: 256,
+          attribution: "Microsoft Planetary Computer",
+        },
+        visible: true,
+        opacity: 1,
+        style: { ...DEFAULT_LAYER_STYLE },
+        metadata: {
+          sourceKind: "stac-planetary-computer",
+          stacCollectionId: input.collection,
+          stacItemId: item.id,
+        },
+      };
+      const bottomBeforeId = store().layers[0]?.id ?? null;
+      store().addLayer(layer, bottomBeforeId);
+      if (bounds) deps.getMapController()?.fitBounds(bounds);
+      return json({
+        addedLayerId: layer.id,
+        itemId: item.id,
+        datetime: item.properties.datetime ?? null,
+      });
+    },
+  });
+
   return [
     listLayers,
     runSql,
     addLayerFromUrl,
     addTileLayer,
+    listAlgorithms,
+    runAlgorithm,
+    searchStac,
+    addStacLayer,
     webSearchTool,
     removeLayer,
     setLayerVisibility,

--- a/apps/geolibre-desktop/src/lib/assistant/tools.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/tools.ts
@@ -1,0 +1,332 @@
+import {
+  OPENFREEMAP_BASEMAPS,
+  useAppStore,
+  type GeoLibreLayer,
+} from "@geolibre/core";
+import type { MapController } from "@geolibre/map";
+import type { InvokableTool, JSONValue } from "@strands-agents/sdk";
+import { tool } from "@strands-agents/sdk";
+import type { FeatureCollection } from "geojson";
+import { z } from "zod";
+import { inferPropertyColumns } from "../pglite-sql";
+import { previewLayerTables, runSqlQuery } from "../sql-workspace";
+import { buildSymbologyStyle } from "./symbology";
+
+/** Dependencies the assistant tools need beyond the global store. */
+export interface AssistantToolDeps {
+  /** Returns the live map controller, or null before the map mounts. */
+  getMapController: () => MapController | null;
+}
+
+/** A short, model-facing description of one layer (no feature data leaked). */
+interface LayerSummary {
+  id: string;
+  name: string;
+  type: string;
+  geometryType: string | null;
+  featureCount: number;
+  fields: { name: string; type: string }[];
+}
+
+/** Detect a layer's geometry family from its first feature. */
+function geometryTypeOf(layer: GeoLibreLayer): string | null {
+  return layer.geojson?.features?.[0]?.geometry?.type ?? null;
+}
+
+/** Summarize a layer's identity and schema without exposing row data. */
+function summarizeLayer(layer: GeoLibreLayer): LayerSummary {
+  const features = layer.geojson?.features ?? [];
+  return {
+    id: layer.id,
+    name: layer.name,
+    type: layer.type,
+    geometryType: geometryTypeOf(layer),
+    featureCount: features.length,
+    fields: features.length
+      ? inferPropertyColumns(features).map((column) => ({
+          name: column.name,
+          type: column.type,
+        }))
+      : [],
+  };
+}
+
+/**
+ * Build a compact, model-facing description of the current layers and the SQL
+ * table names they map to. Used to seed the agent's system prompt with names
+ * and schemas only — never full datasets.
+ */
+export function describeLayers(layers: GeoLibreLayer[]): string {
+  if (layers.length === 0) return "No layers are currently loaded.";
+  const tables = new Map(
+    previewLayerTables(layers).map((table) => [table.layerName, table.tableName]),
+  );
+  return layers
+    .map((layer) => {
+      const summary = summarizeLayer(layer);
+      const table = tables.get(layer.name);
+      const fields = summary.fields
+        .map((field) => `${field.name}:${field.type}`)
+        .join(", ");
+      return [
+        `- "${layer.name}" (${summary.type}`,
+        summary.geometryType ? `, ${summary.geometryType}` : "",
+        `, ${summary.featureCount} features`,
+        table ? `, SQL table ${table}` : "",
+        `)`,
+        fields ? ` fields: ${fields}` : "",
+      ].join("");
+    })
+    .join("\n");
+}
+
+/** Resolve a layer by id first, then case-insensitive name match. */
+function resolveLayer(reference: string): GeoLibreLayer | null {
+  const layers = useAppStore.getState().layers;
+  const byId = layers.find((layer) => layer.id === reference);
+  if (byId) return byId;
+  const target = reference.trim().toLowerCase();
+  return (
+    layers.find((layer) => layer.name.toLowerCase() === target) ??
+    layers.find((layer) => layer.name.toLowerCase().includes(target)) ??
+    null
+  );
+}
+
+/** Resolve a basemap name/id/url to a style URL via the known presets. */
+function resolveBasemap(reference: string): string | null {
+  const target = reference.trim().toLowerCase();
+  if (target.startsWith("http")) return reference.trim();
+  const preset = OPENFREEMAP_BASEMAPS.find(
+    (basemap) =>
+      basemap.id.toLowerCase() === target ||
+      basemap.name.toLowerCase() === target,
+  );
+  return preset?.styleUrl ?? null;
+}
+
+/** Validate that a fetched payload is GeoJSON the store can ingest. */
+function asFeatureCollection(data: unknown): FeatureCollection {
+  const value = data as { type?: string; features?: unknown };
+  if (value?.type === "FeatureCollection" && Array.isArray(value.features)) {
+    return value as FeatureCollection;
+  }
+  if (value?.type === "Feature") {
+    return { type: "FeatureCollection", features: [value as never] };
+  }
+  throw new Error("URL did not return a GeoJSON Feature or FeatureCollection.");
+}
+
+/**
+ * Build the GeoLibre-native tool set the Strands agent can call. Every tool acts
+ * through the Zustand store, the SQL Workspace, or the symbology helpers — never
+ * by mutating MapLibre directly — so all changes flow through the app's one-way
+ * data flow and are covered by undo/redo.
+ *
+ * @param deps Map-controller accessor for camera tools.
+ * @returns The tools to register on the agent.
+ */
+export function createAssistantTools(
+  deps: AssistantToolDeps,
+): InvokableTool<unknown, unknown>[] {
+  const store = () => useAppStore.getState();
+  // Tool results are serialized to the model; the data we return is JSON-safe by
+  // construction, so this asserts the shape against Strands' strict JSONValue.
+  const json = (value: unknown): JSONValue => value as JSONValue;
+
+  const listLayers = tool({
+    name: "list_layers",
+    description:
+      "List the layers currently loaded in the map, with their id, type, geometry, feature count, attribute field names, and the SQL table name to use in run_sql. Call this before referring to a layer.",
+    inputSchema: z.object({}),
+    callback: () => json({ layers: store().layers.map(summarizeLayer) }),
+  });
+
+  const runSql = tool({
+    name: "run_sql",
+    description:
+      "Run a single read-only DuckDB Spatial SQL statement against the loaded layers (use the SQL table names from list_layers) and/or remote files. Returns column names, the row count, and a small preview. Set add_as_layer to add a geometry result to the map.",
+    inputSchema: z.object({
+      sql: z.string().describe("A single SELECT statement (no trailing semicolon needed)."),
+      add_as_layer: z
+        .boolean()
+        .optional()
+        .describe("When the result has geometry, add it to the map as a new layer."),
+      layer_name: z
+        .string()
+        .optional()
+        .describe("Name for the added layer (when add_as_layer is true)."),
+    }),
+    callback: async (input) => {
+      const result = await runSqlQuery(input.sql, store().layers);
+      let addedLayerId: string | null = null;
+      if (input.add_as_layer && result.geojson) {
+        addedLayerId = store().addGeoJsonLayer(
+          input.layer_name?.trim() || "SQL result",
+          result.geojson,
+        );
+      }
+      return json({
+        columns: result.columns,
+        rowCount: result.rowCount,
+        hasGeometry: Boolean(result.geojson),
+        preview: result.rows.slice(0, 10),
+        addedLayerId,
+      });
+    },
+  });
+
+  const addLayerFromUrl = tool({
+    name: "add_layer_from_url",
+    description:
+      "Fetch a public GeoJSON URL and add it to the map as a new vector layer.",
+    inputSchema: z.object({
+      url: z.string().describe("A public URL returning GeoJSON."),
+      name: z.string().optional().describe("Optional layer name."),
+    }),
+    callback: async (input) => {
+      const response = await fetch(input.url);
+      if (!response.ok) {
+        throw new Error(`Fetch failed: ${response.status} ${response.statusText}`);
+      }
+      const geojson = asFeatureCollection(await response.json());
+      const name =
+        input.name?.trim() ||
+        input.url.split("/").pop()?.split("?")[0] ||
+        "Remote layer";
+      const id = store().addGeoJsonLayer(name, geojson, input.url);
+      return json({ addedLayerId: id, name, featureCount: geojson.features.length });
+    },
+  });
+
+  const removeLayer = tool({
+    name: "remove_layer",
+    description: "Remove a layer from the map by name or id.",
+    inputSchema: z.object({
+      layer: z.string().describe("Layer name or id."),
+    }),
+    callback: (input) => {
+      const layer = resolveLayer(input.layer);
+      if (!layer) throw new Error(`No layer matching "${input.layer}".`);
+      store().removeLayer(layer.id);
+      return json({ removedLayerId: layer.id, name: layer.name });
+    },
+  });
+
+  const setLayerVisibility = tool({
+    name: "set_layer_visibility",
+    description: "Show or hide a layer by name or id.",
+    inputSchema: z.object({
+      layer: z.string().describe("Layer name or id."),
+      visible: z.boolean(),
+    }),
+    callback: (input) => {
+      const layer = resolveLayer(input.layer);
+      if (!layer) throw new Error(`No layer matching "${input.layer}".`);
+      store().setLayerVisibility(layer.id, input.visible);
+      return json({ layerId: layer.id, visible: input.visible });
+    },
+  });
+
+  const setLayerOpacity = tool({
+    name: "set_layer_opacity",
+    description: "Set a layer's opacity (0 transparent to 1 opaque) by name or id.",
+    inputSchema: z.object({
+      layer: z.string().describe("Layer name or id."),
+      opacity: z.number().min(0).max(1),
+    }),
+    callback: (input) => {
+      const layer = resolveLayer(input.layer);
+      if (!layer) throw new Error(`No layer matching "${input.layer}".`);
+      store().setLayerOpacity(layer.id, input.opacity);
+      return json({ layerId: layer.id, opacity: input.opacity });
+    },
+  });
+
+  const setBasemap = tool({
+    name: "set_basemap",
+    description: `Switch the basemap. Accepts a known name (${OPENFREEMAP_BASEMAPS.map((basemap) => basemap.id).join(", ")}) or a full style URL.`,
+    inputSchema: z.object({
+      basemap: z.string().describe("A basemap name/id or a style URL."),
+    }),
+    callback: (input) => {
+      const styleUrl = resolveBasemap(input.basemap);
+      if (!styleUrl) throw new Error(`Unknown basemap "${input.basemap}".`);
+      store().setBasemapStyleUrl(styleUrl);
+      return json({ basemap: styleUrl });
+    },
+  });
+
+  const zoomTo = tool({
+    name: "zoom_to",
+    description:
+      "Move the camera to fit a layer (by name or id) or an explicit bounding box [west, south, east, north].",
+    inputSchema: z.object({
+      layer: z.string().optional().describe("Layer name or id to fit."),
+      bbox: z
+        .array(z.number())
+        .length(4)
+        .optional()
+        .describe("Bounding box [west, south, east, north] in WGS84."),
+    }),
+    callback: (input) => {
+      const controller = deps.getMapController();
+      if (!controller) throw new Error("The map is not ready yet.");
+      if (input.bbox) {
+        controller.fitBounds(input.bbox as [number, number, number, number]);
+        return json({ fit: "bbox", bbox: input.bbox });
+      }
+      if (input.layer) {
+        const layer = resolveLayer(input.layer);
+        if (!layer) throw new Error(`No layer matching "${input.layer}".`);
+        controller.fitLayer(layer);
+        return json({ fit: "layer", layerId: layer.id });
+      }
+      throw new Error("Provide either a layer or a bbox.");
+    },
+  });
+
+  const applySymbology = tool({
+    name: "apply_symbology",
+    description:
+      "Color a vector layer by one of its attribute fields using a graduated (numeric) or categorized (text) color ramp. Use list_layers to find field names and color ramps like reds, blues, viridis.",
+    inputSchema: z.object({
+      layer: z.string().describe("Layer name or id."),
+      property: z.string().describe("Attribute field to style by."),
+      mode: z.enum(["graduated", "categorized"]),
+      color_ramp: z.string().optional().describe("Color ramp id (e.g. reds, viridis)."),
+      class_count: z.number().optional().describe("Number of classes for graduated mode."),
+      scheme: z.enum(["equal-interval", "quantile"]).optional(),
+    }),
+    callback: (input) => {
+      const layer = resolveLayer(input.layer);
+      if (!layer) throw new Error(`No layer matching "${input.layer}".`);
+      const style = buildSymbologyStyle(layer, {
+        mode: input.mode,
+        property: input.property,
+        colorRamp: input.color_ramp,
+        classCount: input.class_count,
+        scheme: input.scheme,
+      });
+      store().setLayerStyle(layer.id, style);
+      return json({
+        layerId: layer.id,
+        mode: input.mode,
+        property: input.property,
+        classes: style.vectorStyleStops?.length ?? 0,
+      });
+    },
+  });
+
+  return [
+    listLayers,
+    runSql,
+    addLayerFromUrl,
+    removeLayer,
+    setLayerVisibility,
+    setLayerOpacity,
+    setBasemap,
+    zoomTo,
+    applySymbology,
+  ] as InvokableTool<unknown, unknown>[];
+}

--- a/apps/geolibre-desktop/src/lib/assistant/tools.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/tools.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_LAYER_STYLE,
   OPENFREEMAP_BASEMAPS,
   useAppStore,
   type GeoLibreLayer,
@@ -10,7 +11,13 @@ import type { FeatureCollection } from "geojson";
 import { z } from "zod";
 import { inferPropertyColumns } from "../pglite-sql";
 import { previewLayerTables, runSqlQuery } from "../sql-workspace";
+import { createXyzTileUrlTemplate } from "../xyz-url";
+import {
+  findNamedTileBasemap,
+  NAMED_TILE_BASEMAPS,
+} from "./basemaps";
 import { buildSymbologyStyle } from "./symbology";
+import { webSearch } from "./web-search";
 
 /** Dependencies the assistant tools need beyond the global store. */
 export interface AssistantToolDeps {
@@ -243,6 +250,87 @@ export function createAssistantTools(
     },
   });
 
+  const addTileLayer = tool({
+    name: "add_tile_layer",
+    description: `Add an XYZ raster tile basemap/layer to the map. Use a known name (${NAMED_TILE_BASEMAPS.map((basemap) => basemap.id).join(", ")}) or a custom XYZ url template containing {z}/{x}/{y}. You know the common imagery URLs (e.g. Google Satellite is https://mt1.google.com/vt/lyrs=s&x={x}&y={y}&z={z}), so add them directly instead of asking the user. The layer is placed underneath existing layers so it acts as a basemap.`,
+    inputSchema: z.object({
+      basemap: z
+        .string()
+        .optional()
+        .describe("Known basemap name, e.g. 'google satellite', 'esri imagery', 'opentopomap'."),
+      url: z
+        .string()
+        .optional()
+        .describe("Custom XYZ tile URL template with {z}, {x}, {y} placeholders."),
+      name: z.string().optional(),
+      attribution: z.string().optional(),
+    }),
+    callback: (input) => {
+      let url = input.url?.trim();
+      let name = input.name?.trim();
+      let attribution = input.attribution?.trim();
+      if (input.basemap?.trim()) {
+        const found = findNamedTileBasemap(input.basemap);
+        if (found) {
+          url = url || found.url;
+          name = name || found.label;
+          attribution = attribution || found.attribution;
+        } else if (!url) {
+          throw new Error(
+            `Unknown basemap "${input.basemap}". Known: ${NAMED_TILE_BASEMAPS.map((basemap) => basemap.id).join(", ")} — or pass a url.`,
+          );
+        }
+      }
+      if (!url) {
+        throw new Error(
+          "Provide a known basemap name or an XYZ url template with {z}/{x}/{y}.",
+        );
+      }
+      const tileUrl = createXyzTileUrlTemplate(url);
+      const layer: GeoLibreLayer = {
+        id: crypto.randomUUID(),
+        name: name || "Tile layer",
+        type: "xyz",
+        source: {
+          type: "raster",
+          tiles: [tileUrl.renderUrl],
+          tileSize: 256,
+          url: tileUrl.originalUrl,
+          ...(attribution ? { attribution } : {}),
+        },
+        visible: true,
+        opacity: 1,
+        style: { ...DEFAULT_LAYER_STYLE },
+        metadata: { sourceKind: "xyz-url" },
+      };
+      // Insert at the bottom of the stack (index 0) so imagery sits under data.
+      const bottomBeforeId = store().layers[0]?.id ?? null;
+      store().addLayer(layer, bottomBeforeId);
+      return json({
+        addedLayerId: layer.id,
+        name: layer.name,
+        url: tileUrl.originalUrl,
+      });
+    },
+  });
+
+  const webSearchTool = tool({
+    name: "web_search",
+    description:
+      "Search the web for current information (news, recent data, documentation, tile/style URLs). Returns top results with title, url, and snippet, plus a short answer when available.",
+    inputSchema: z.object({
+      query: z.string().describe("The search query."),
+    }),
+    callback: async (input) => {
+      const response = await webSearch(input.query);
+      return json({
+        provider: response.provider,
+        answer: response.answer ?? null,
+        results: response.results.slice(0, 8),
+      });
+    },
+  });
+
   const setBasemap = tool({
     name: "set_basemap",
     description: `Switch the basemap. Accepts a known name (${OPENFREEMAP_BASEMAPS.map((basemap) => basemap.id).join(", ")}) or a full style URL.`,
@@ -322,6 +410,8 @@ export function createAssistantTools(
     listLayers,
     runSql,
     addLayerFromUrl,
+    addTileLayer,
+    webSearchTool,
     removeLayer,
     setLayerVisibility,
     setLayerOpacity,

--- a/apps/geolibre-desktop/src/lib/assistant/tools.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/tools.ts
@@ -391,12 +391,12 @@ export function createAssistantTools(
 
   const addTileLayer = tool({
     name: "add_tile_layer",
-    description: `Add an XYZ raster tile basemap/layer to the map. Use a known name (${NAMED_TILE_BASEMAPS.map((basemap) => basemap.id).join(", ")}) or a custom XYZ url template containing {z}/{x}/{y}. You know the common imagery URLs (e.g. Google Satellite is https://mt1.google.com/vt/lyrs=s&x={x}&y={y}&z={z}), so add them directly instead of asking the user. The layer is placed underneath existing layers so it acts as a basemap.`,
+    description: `Add an XYZ raster tile basemap/layer to the map. Use a known name (${NAMED_TILE_BASEMAPS.map((basemap) => basemap.id).join(", ")}) or a custom XYZ url template containing {z}/{x}/{y}. The layer is placed underneath existing layers so it acts as a basemap.`,
     inputSchema: z.object({
       basemap: z
         .string()
         .optional()
-        .describe("Known basemap name, e.g. 'google satellite', 'esri imagery', 'opentopomap'."),
+        .describe("Known basemap name, e.g. 'esri imagery', 'opentopomap', 'osm'."),
       url: z
         .string()
         .optional()

--- a/apps/geolibre-desktop/src/lib/assistant/tools.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/tools.ts
@@ -11,7 +11,12 @@ import type { FeatureCollection } from "geojson";
 import { z } from "zod";
 import { inferPropertyColumns } from "../pglite-sql";
 import { consoleDeps, runConsoleCode } from "../pyodide/pyodide-console";
-import { cleanStatement, previewLayerTables, runSqlQuery } from "../sql-workspace";
+import {
+  cleanStatement,
+  maskSqlLiterals,
+  previewLayerTables,
+  runSqlQuery,
+} from "../sql-workspace";
 import { createXyzTileUrlTemplate } from "../xyz-url";
 import {
   findNamedTileBasemap,
@@ -36,10 +41,20 @@ interface LayerSummary {
   fields: { name: string; type: string }[];
 }
 
-/** True when a SQL statement is a read-only SELECT/WITH query. */
+/** Statement keywords that write data or have side effects. */
+const SQL_WRITE_KEYWORDS =
+  /\b(INSERT|UPDATE|DELETE|MERGE|CREATE|DROP|ALTER|TRUNCATE|REPLACE|ATTACH|DETACH|COPY|EXPORT|IMPORT|INSTALL|LOAD|PRAGMA|VACUUM|CHECKPOINT)\b/;
+
+/**
+ * True when a SQL statement is a read-only SELECT/WITH query. Guards both the
+ * leading keyword and the body (with string/comment literals masked) so a
+ * data-modifying CTE — `WITH x AS (DELETE …) …` — is also rejected.
+ */
 function isReadOnlySql(sql: string): boolean {
-  const head = cleanStatement(sql).trimStart().toUpperCase();
-  return head.startsWith("SELECT") || head.startsWith("WITH");
+  const cleaned = cleanStatement(sql);
+  const head = cleaned.trimStart().toUpperCase();
+  if (!head.startsWith("SELECT") && !head.startsWith("WITH")) return false;
+  return !SQL_WRITE_KEYWORDS.test(maskSqlLiterals(cleaned).toUpperCase());
 }
 
 /**
@@ -58,17 +73,22 @@ function assertPublicHttpUrl(raw: string): void {
     throw new Error(`Only http(s) URLs are allowed (got ${url.protocol}).`);
   }
   const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  // Unwrap IPv4-mapped IPv6 (e.g. ::ffff:127.0.0.1) before the IPv4 checks.
+  const v4 = host.startsWith("::ffff:") ? host.slice(7) : host;
   const isPrivate =
     host === "localhost" ||
     host.endsWith(".localhost") ||
-    host === "0.0.0.0" ||
+    host === "::" ||
     host === "::1" ||
-    /^127\./.test(host) ||
-    /^10\./.test(host) ||
-    /^192\.168\./.test(host) ||
-    /^172\.(1[6-9]|2\d|3[01])\./.test(host) ||
-    /^169\.254\./.test(host) ||
-    /^(fc|fd)[0-9a-f]{2}:/.test(host);
+    /^0\./.test(v4) || // 0.0.0.0/8 (incl. 0.0.0.0)
+    /^127\./.test(v4) ||
+    /^10\./.test(v4) ||
+    /^192\.168\./.test(v4) ||
+    /^172\.(1[6-9]|2\d|3[01])\./.test(v4) ||
+    /^169\.254\./.test(v4) || // link-local
+    /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./.test(v4) || // 100.64/10 CGNAT
+    /^(fc|fd)[0-9a-f]{2}:/.test(host) || // unique-local IPv6
+    /^fe80:/.test(host); // link-local IPv6
   if (isPrivate) {
     throw new Error(`Refusing to fetch a private/loopback address: ${host}`);
   }
@@ -255,11 +275,17 @@ export function createAssistantTools(
             `Fetch failed: ${response.status} ${response.statusText}`,
           );
         }
+        // Check the advertised length first (cheap), then the actual body —
+        // Content-Length is optional, so a server can omit it to bypass it.
         const length = response.headers.get("content-length");
         if (length && Number(length) > MAX_BYTES) {
           throw new Error(`Response too large (${length} bytes).`);
         }
-        const geojson = asFeatureCollection(await response.json());
+        const body = await response.text();
+        if (body.length > MAX_BYTES) {
+          throw new Error(`Response too large (${body.length} bytes).`);
+        }
+        const geojson = asFeatureCollection(JSON.parse(body));
         const name =
           input.name?.trim() ||
           input.url.split("/").pop()?.split("?")[0] ||

--- a/apps/geolibre-desktop/src/lib/assistant/tools.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/tools.ts
@@ -11,7 +11,7 @@ import type { FeatureCollection } from "geojson";
 import { z } from "zod";
 import { inferPropertyColumns } from "../pglite-sql";
 import { consoleDeps, runConsoleCode } from "../pyodide/pyodide-console";
-import { previewLayerTables, runSqlQuery } from "../sql-workspace";
+import { cleanStatement, previewLayerTables, runSqlQuery } from "../sql-workspace";
 import { createXyzTileUrlTemplate } from "../xyz-url";
 import {
   findNamedTileBasemap,
@@ -34,6 +34,44 @@ interface LayerSummary {
   geometryType: string | null;
   featureCount: number;
   fields: { name: string; type: string }[];
+}
+
+/** True when a SQL statement is a read-only SELECT/WITH query. */
+function isReadOnlySql(sql: string): boolean {
+  const head = cleanStatement(sql).trimStart().toUpperCase();
+  return head.startsWith("SELECT") || head.startsWith("WITH");
+}
+
+/**
+ * Validate a model-supplied URL before fetching: only http(s), and never a
+ * loopback/private/link-local address (guards against AI-directed SSRF to the
+ * local sidecar or internal services via prompt injection).
+ */
+function assertPublicHttpUrl(raw: string): void {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error(`Invalid URL: ${raw}`);
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new Error(`Only http(s) URLs are allowed (got ${url.protocol}).`);
+  }
+  const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  const isPrivate =
+    host === "localhost" ||
+    host.endsWith(".localhost") ||
+    host === "0.0.0.0" ||
+    host === "::1" ||
+    /^127\./.test(host) ||
+    /^10\./.test(host) ||
+    /^192\.168\./.test(host) ||
+    /^172\.(1[6-9]|2\d|3[01])\./.test(host) ||
+    /^169\.254\./.test(host) ||
+    /^(fc|fd)[0-9a-f]{2}:/.test(host);
+  if (isPrivate) {
+    throw new Error(`Refusing to fetch a private/loopback address: ${host}`);
+  }
 }
 
 /** Detect a layer's geometry family from its first feature. */
@@ -66,13 +104,13 @@ function summarizeLayer(layer: GeoLibreLayer): LayerSummary {
  */
 export function describeLayers(layers: GeoLibreLayer[]): string {
   if (layers.length === 0) return "No layers are currently loaded.";
-  const tables = new Map(
-    previewLayerTables(layers).map((table) => [table.layerName, table.tableName]),
-  );
+  // previewLayerTables returns one entry per layer in order, so align by index —
+  // keying by name would collapse layers that share a name onto one table.
+  const tables = previewLayerTables(layers);
   return layers
-    .map((layer) => {
+    .map((layer, index) => {
       const summary = summarizeLayer(layer);
-      const table = tables.get(layer.name);
+      const table = tables[index]?.tableName;
       const fields = summary.fields
         .map((field) => `${field.name}:${field.type}`)
         .join(", ");
@@ -94,17 +132,24 @@ function resolveLayer(reference: string): GeoLibreLayer | null {
   const byId = layers.find((layer) => layer.id === reference);
   if (byId) return byId;
   const target = reference.trim().toLowerCase();
+  const exact = layers.find((layer) => layer.name.toLowerCase() === target);
+  if (exact) return exact;
+  // Only fall back to a substring match for references long enough to be
+  // meaningful, so a 1–2 char string can't match an arbitrary layer.
+  if (target.length < 3) return null;
   return (
-    layers.find((layer) => layer.name.toLowerCase() === target) ??
-    layers.find((layer) => layer.name.toLowerCase().includes(target)) ??
-    null
+    layers.find((layer) => layer.name.toLowerCase().includes(target)) ?? null
   );
 }
 
 /** Resolve a basemap name/id/url to a style URL via the known presets. */
 function resolveBasemap(reference: string): string | null {
   const target = reference.trim().toLowerCase();
-  if (target.startsWith("http")) return reference.trim();
+  if (target.startsWith("http")) {
+    // Only accept https style URLs; an http style could mix-content fail and is
+    // a needless freeform-URL surface.
+    return target.startsWith("https://") ? reference.trim() : null;
+  }
   const preset = OPENFREEMAP_BASEMAPS.find(
     (basemap) =>
       basemap.id.toLowerCase() === target ||
@@ -169,6 +214,9 @@ export function createAssistantTools(
         .describe("Name for the added layer (when add_as_layer is true)."),
     }),
     callback: async (input) => {
+      if (!isReadOnlySql(input.sql)) {
+        throw new Error("Only read-only SELECT/WITH queries are allowed.");
+      }
       const result = await runSqlQuery(input.sql, store().layers);
       let addedLayerId: string | null = null;
       if (input.add_as_layer && result.geojson) {
@@ -196,17 +244,35 @@ export function createAssistantTools(
       name: z.string().optional().describe("Optional layer name."),
     }),
     callback: async (input) => {
-      const response = await fetch(input.url);
-      if (!response.ok) {
-        throw new Error(`Fetch failed: ${response.status} ${response.statusText}`);
+      assertPublicHttpUrl(input.url);
+      const MAX_BYTES = 100 * 1024 * 1024; // 100 MB guard against OOM.
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 30_000);
+      try {
+        const response = await fetch(input.url, { signal: controller.signal });
+        if (!response.ok) {
+          throw new Error(
+            `Fetch failed: ${response.status} ${response.statusText}`,
+          );
+        }
+        const length = response.headers.get("content-length");
+        if (length && Number(length) > MAX_BYTES) {
+          throw new Error(`Response too large (${length} bytes).`);
+        }
+        const geojson = asFeatureCollection(await response.json());
+        const name =
+          input.name?.trim() ||
+          input.url.split("/").pop()?.split("?")[0] ||
+          "Remote layer";
+        const id = store().addGeoJsonLayer(name, geojson, input.url);
+        return json({
+          addedLayerId: id,
+          name,
+          featureCount: geojson.features.length,
+        });
+      } finally {
+        clearTimeout(timeout);
       }
-      const geojson = asFeatureCollection(await response.json());
-      const name =
-        input.name?.trim() ||
-        input.url.split("/").pop()?.split("?")[0] ||
-        "Remote layer";
-      const id = store().addGeoJsonLayer(name, geojson, input.url);
-      return json({ addedLayerId: id, name, featureCount: geojson.features.length });
     },
   });
 
@@ -353,14 +419,18 @@ export function createAssistantTools(
     name: "zoom_to",
     description:
       "Move the camera to fit a layer (by name or id) or an explicit bounding box [west, south, east, north].",
-    inputSchema: z.object({
-      layer: z.string().optional().describe("Layer name or id to fit."),
-      bbox: z
-        .array(z.number())
-        .length(4)
-        .optional()
-        .describe("Bounding box [west, south, east, north] in WGS84."),
-    }),
+    inputSchema: z
+      .object({
+        layer: z.string().optional().describe("Layer name or id to fit."),
+        bbox: z
+          .array(z.number())
+          .length(4)
+          .optional()
+          .describe("Bounding box [west, south, east, north] in WGS84."),
+      })
+      .refine((value) => value.layer !== undefined || value.bbox !== undefined, {
+        message: "Provide either a layer or a bbox.",
+      }),
     callback: (input) => {
       const controller = deps.getMapController();
       if (!controller) throw new Error("The map is not ready yet.");

--- a/apps/geolibre-desktop/src/lib/assistant/tools.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/tools.ts
@@ -94,6 +94,51 @@ function assertPublicHttpUrl(raw: string): void {
   }
 }
 
+/**
+ * Read a response body as text, aborting once `maxBytes` is exceeded — so an
+ * over-large (or Content-Length–less) response can't buffer unbounded into
+ * memory before the size check.
+ */
+async function readTextCapped(
+  response: Response,
+  maxBytes: number,
+): Promise<string> {
+  if (!response.body) {
+    const text = await response.text();
+    if (text.length > maxBytes) throw new Error("Response too large.");
+    return text;
+  }
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) {
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel();
+        throw new Error(`Response too large (> ${maxBytes} bytes).`);
+      }
+      chunks.push(value);
+    }
+  }
+  return new TextDecoder().decode(
+    chunks.length === 1 ? chunks[0] : concatBytes(chunks, total),
+  );
+}
+
+/** Concatenate byte chunks into one buffer. */
+function concatBytes(chunks: Uint8Array[], total: number): Uint8Array {
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out;
+}
+
 /** Detect a layer's geometry family from its first feature. */
 function geometryTypeOf(layer: GeoLibreLayer): string | null {
   return layer.geojson?.features?.[0]?.geometry?.type ?? null;
@@ -275,17 +320,15 @@ export function createAssistantTools(
             `Fetch failed: ${response.status} ${response.statusText}`,
           );
         }
-        // Check the advertised length first (cheap), then the actual body —
-        // Content-Length is optional, so a server can omit it to bypass it.
+        // Check the advertised length first (cheap), then stream the body with
+        // a hard byte cap — Content-Length is optional and bypassable.
         const length = response.headers.get("content-length");
         if (length && Number(length) > MAX_BYTES) {
           throw new Error(`Response too large (${length} bytes).`);
         }
-        const body = await response.text();
-        if (body.length > MAX_BYTES) {
-          throw new Error(`Response too large (${body.length} bytes).`);
-        }
-        const geojson = asFeatureCollection(JSON.parse(body));
+        const geojson = asFeatureCollection(
+          JSON.parse(await readTextCapped(response, MAX_BYTES)),
+        );
         const name =
           input.name?.trim() ||
           input.url.split("/").pop()?.split("?")[0] ||
@@ -413,17 +456,28 @@ export function createAssistantTools(
   const webSearchTool = tool({
     name: "web_search",
     description:
-      "Search the web for current information (news, recent data, documentation, tile/style URLs). Returns top results with title, url, and snippet, plus a short answer when available.",
+      "Search the web for current information (news, recent data, documentation). Returns top results with title, url, and snippet, plus a short answer when available. Most reliable when TAVILY_API_KEY is configured; the keyless fallback is best-effort and may be blocked by the browser.",
     inputSchema: z.object({
       query: z.string().describe("The search query."),
     }),
     callback: async (input) => {
-      const response = await webSearch(input.query);
-      return json({
-        provider: response.provider,
-        answer: response.answer ?? null,
-        results: response.results.slice(0, 8),
-      });
+      try {
+        const response = await webSearch(input.query);
+        return json({
+          provider: response.provider,
+          answer: response.answer ?? null,
+          results: response.results.slice(0, 8),
+        });
+      } catch (error) {
+        // Don't surface a raw fetch/CORS error as a tool crash — tell the model
+        // search is unavailable so it can fall back gracefully.
+        return json({
+          error:
+            "Web search is unavailable from the browser. Configure TAVILY_API_KEY in Settings → Environment for reliable search.",
+          detail: error instanceof Error ? error.message : String(error),
+          results: [],
+        });
+      }
     },
   });
 
@@ -483,14 +537,21 @@ export function createAssistantTools(
     }),
     callback: async (input) => {
       const result = await runConsoleCode(pyDeps, input.code);
-      return json({ output: result.output, error: result.error });
+      // Cap stdout so a snippet printing megabytes can't blow the model's
+      // context window on the next turn.
+      const MAX_OUTPUT = 8000;
+      const output =
+        result.output.length > MAX_OUTPUT
+          ? `${result.output.slice(0, MAX_OUTPUT)}\n[truncated]`
+          : result.output;
+      return json({ output, error: result.error });
     },
   });
 
   const runMaplibreJs = tool({
     name: "run_maplibre_js",
     description:
-      "Fallback for tasks with no dedicated tool (e.g. globe projection, terrain, sky, custom paint/layout properties). Runs a small JavaScript snippet against the live map. The snippet is a function body with `map` (the MapLibre GL JS map) in scope and may `return` a JSON-serializable value. Example — switch to globe: `map.setProjection({ type: 'globe' })`. Prefer dedicated tools when one exists.",
+      "Fallback for tasks with no dedicated tool (e.g. globe projection, terrain, sky, custom paint/layout properties). Runs a small JavaScript snippet against the live map. The snippet is a function body with `map` (the MapLibre GL JS map) in scope and may `return` a JSON-serializable value. Example — switch to globe: `map.setProjection({ type: 'globe' })`. Prefer dedicated tools when one exists; changes made here bypass the store and are NOT undoable.",
     inputSchema: z.object({
       code: z
         .string()

--- a/apps/geolibre-desktop/src/lib/assistant/web-search.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/web-search.ts
@@ -1,0 +1,124 @@
+import { readRuntimeEnv, type RuntimeEnv } from "./provider";
+
+/** One web search hit. */
+export interface WebSearchResult {
+  title: string;
+  url: string;
+  snippet: string;
+}
+
+/** A normalized search response across backends. */
+export interface WebSearchResponse {
+  provider: "tavily" | "duckduckgo";
+  /** A direct answer/abstract when the backend provides one. */
+  answer?: string;
+  results: WebSearchResult[];
+}
+
+/** Richer web search via Tavily (requires `TAVILY_API_KEY`). */
+async function tavilySearch(
+  query: string,
+  apiKey: string,
+  signal?: AbortSignal,
+): Promise<WebSearchResponse> {
+  const response = await fetch("https://api.tavily.com/search", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      api_key: apiKey,
+      query,
+      max_results: 6,
+      include_answer: true,
+    }),
+    signal,
+  });
+  if (!response.ok) {
+    throw new Error(`Tavily ${response.status} ${response.statusText}`);
+  }
+  const data = (await response.json()) as {
+    answer?: string;
+    results?: { title?: string; url?: string; content?: string }[];
+  };
+  return {
+    provider: "tavily",
+    answer: data.answer,
+    results: (data.results ?? []).map((result) => ({
+      title: result.title ?? result.url ?? "",
+      url: result.url ?? "",
+      snippet: result.content ?? "",
+    })),
+  };
+}
+
+/** Keyless fallback: DuckDuckGo Instant Answer (CORS-enabled, best-effort). */
+async function duckDuckGoSearch(
+  query: string,
+  signal?: AbortSignal,
+): Promise<WebSearchResponse> {
+  const url = `https://api.duckduckgo.com/?q=${encodeURIComponent(
+    query,
+  )}&format=json&no_html=1&skip_disambig=1&t=geolibre`;
+  const response = await fetch(url, { signal });
+  if (!response.ok) {
+    throw new Error(`DuckDuckGo ${response.status} ${response.statusText}`);
+  }
+  const data = (await response.json()) as {
+    AbstractText?: string;
+    AbstractURL?: string;
+    Heading?: string;
+    RelatedTopics?: {
+      Text?: string;
+      FirstURL?: string;
+      Topics?: { Text?: string; FirstURL?: string }[];
+    }[];
+  };
+  const results: WebSearchResult[] = [];
+  const collect = (topic: { Text?: string; FirstURL?: string }) => {
+    if (topic.FirstURL && topic.Text) {
+      results.push({
+        title: topic.Text.split(" - ")[0],
+        url: topic.FirstURL,
+        snippet: topic.Text,
+      });
+    }
+  };
+  for (const topic of data.RelatedTopics ?? []) {
+    if (topic.Topics) topic.Topics.forEach(collect);
+    else collect(topic);
+    if (results.length >= 8) break;
+  }
+  if (data.AbstractURL && data.AbstractText) {
+    results.unshift({
+      title: data.Heading ?? query,
+      url: data.AbstractURL,
+      snippet: data.AbstractText,
+    });
+  }
+  return { provider: "duckduckgo", answer: data.AbstractText, results };
+}
+
+/**
+ * Search the web. Uses Tavily when `TAVILY_API_KEY` is configured (richer,
+ * full-text results) and otherwise falls back to DuckDuckGo's keyless Instant
+ * Answer API. Both run directly from the browser, so results depend on each
+ * service's CORS policy.
+ *
+ * @param query The search query.
+ * @param env Runtime environment variables (for `TAVILY_API_KEY`).
+ * @param signal Optional abort signal.
+ */
+export async function webSearch(
+  query: string,
+  env: RuntimeEnv = readRuntimeEnv(),
+  signal?: AbortSignal,
+): Promise<WebSearchResponse> {
+  const tavilyKey = env.TAVILY_API_KEY?.trim();
+  if (tavilyKey) {
+    try {
+      return await tavilySearch(query, tavilyKey, signal);
+    } catch {
+      // Fall back to the keyless backend if Tavily fails (bad key, CORS, …).
+    }
+  }
+  return duckDuckGoSearch(query, signal);
+}

--- a/apps/geolibre-desktop/src/lib/assistant/web-search.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/web-search.ts
@@ -1,5 +1,22 @@
 import { readRuntimeEnv, type RuntimeEnv } from "./provider";
 
+/** Fetch with a hard timeout so a slow search backend can't hang the tool. */
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit = {},
+  ms = 20_000,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), ms);
+  // Honor an upstream signal (e.g. the agent run being cancelled) too.
+  init.signal?.addEventListener("abort", () => controller.abort());
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 /** One web search hit. */
 export interface WebSearchResult {
   title: string;
@@ -21,7 +38,7 @@ async function tavilySearch(
   apiKey: string,
   signal?: AbortSignal,
 ): Promise<WebSearchResponse> {
-  const response = await fetch("https://api.tavily.com/search", {
+  const response = await fetchWithTimeout("https://api.tavily.com/search", {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({
@@ -50,7 +67,11 @@ async function tavilySearch(
   };
 }
 
-/** Keyless fallback: DuckDuckGo Instant Answer (CORS-enabled, best-effort). */
+/**
+ * Keyless fallback: DuckDuckGo Instant Answer. Best-effort only — DDG does not
+ * reliably send CORS headers, so this may fail from a browser origin; callers
+ * should treat a rejection as "search unavailable" and recommend TAVILY_API_KEY.
+ */
 async function duckDuckGoSearch(
   query: string,
   signal?: AbortSignal,
@@ -58,7 +79,7 @@ async function duckDuckGoSearch(
   const url = `https://api.duckduckgo.com/?q=${encodeURIComponent(
     query,
   )}&format=json&no_html=1&skip_disambig=1&t=geolibre`;
-  const response = await fetch(url, { signal });
+  const response = await fetchWithTimeout(url, { signal });
   if (!response.ok) {
     throw new Error(`DuckDuckGo ${response.status} ${response.statusText}`);
   }

--- a/apps/geolibre-desktop/src/lib/assistant/web-search.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/web-search.ts
@@ -116,8 +116,10 @@ export async function webSearch(
   if (tavilyKey) {
     try {
       return await tavilySearch(query, tavilyKey, signal);
-    } catch {
-      // Fall back to the keyless backend if Tavily fails (bad key, CORS, …).
+    } catch (error) {
+      // Fall back to the keyless backend if Tavily fails (bad key, CORS, …),
+      // but surface why so a misconfigured key isn't silently ignored.
+      console.warn("Tavily search failed; falling back to DuckDuckGo.", error);
     }
   }
   return duckDuckGoSearch(query, signal);

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -589,6 +589,7 @@ export default defineConfig({
       "@strands-agents/sdk/models/google",
       "@strands-agents/sdk/models/anthropic",
       "@strands-agents/sdk/models/openai",
+      "@strands-agents/sdk/models/bedrock",
       "@anthropic-ai/sdk",
       "@google/genai",
       "openai",

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -578,6 +578,22 @@ export default defineConfig({
   },
   envPrefix: ["VITE_", "TAURI_"],
   optimizeDeps: {
+    // Pre-bundle the AI Assistant's heavy deps at dev-server startup. They are
+    // only reached through the lazily-imported assistant panel (and, for the
+    // provider models, through dynamic import() inside it), so Vite would
+    // otherwise discover them on first open and trigger a full-page reload to
+    // re-optimize — which manifests as the map reloading and the panel needing
+    // a second click. Listing them here pre-bundles them up front instead.
+    include: [
+      "@strands-agents/sdk",
+      "@strands-agents/sdk/models/google",
+      "@strands-agents/sdk/models/anthropic",
+      "@strands-agents/sdk/models/openai",
+      "@anthropic-ai/sdk",
+      "@google/genai",
+      "openai",
+      "zod",
+    ],
     // PGlite ships its own WASM + filesystem bundles and must not be pre-bundled
     // by esbuild, which mangles those asset references (per PGlite's Vite guide).
     exclude: [

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,6 +84,12 @@ Common raster tools under Processing → Raster: hillshade, slope, aspect, repro
 Embed the full GeoLibre app in a Jupyter notebook with the [`geolibre`](python.md) Python package. An expanded leafmap-style API (`add_geojson`, `add_tile_layer`, `add_cog`, and many more Add Data layer types) drives the map, and the project syncs both ways so UI edits are readable back from Python.
 </div>
 
+<div class="feature-card" markdown>
+### AI Assistant
+
+Chat with your data: a natural-language [assistant](user-guide/ai-assistant.md) that turns plain-English requests into GeoLibre's own operations — Spatial SQL, symbology, add/remove data, and map control — applied through the app so they stay auditable and undoable. Provider-pluggable (Google Gemini, Anthropic, OpenAI) with your own API key, disabled until configured.
+</div>
+
 </div>
 
 ## Learn GeoLibre
@@ -93,6 +99,7 @@ New to GeoLibre? Start with the [User Guide](user-guide/interface.md) for a feat
 - [Interface Overview](user-guide/interface.md): the toolbar, panels, map, and status bar.
 - [Adding Data](user-guide/adding-data.md): every file, web service, cloud, 3D, and database source.
 - [Processing Tools](user-guide/processing.md) and [SQL Workspace](user-guide/sql-workspace.md): analysis with vector, raster, conversion, Whitebox, and DuckDB Spatial SQL.
+- [AI Assistant](user-guide/ai-assistant.md): chat with your data — natural language to SQL, symbology, and map control.
 - [Plugins & Marketplace](user-guide/plugins.md): activate built-ins and install from the registry.
 - [Your First Map](tutorials/first-map.md): add a layer, style it, inspect it, and share it.
 

--- a/docs/user-guide/ai-assistant.md
+++ b/docs/user-guide/ai-assistant.md
@@ -88,6 +88,70 @@ operations, so its actions stay within GeoLibre's validated surface.
 | **Web search** | Looks up current information online (best with `TAVILY_API_KEY`). |
 | **Code fallback** | For tasks with no dedicated tool, runs a small **JavaScript** snippet against the live map (e.g. globe projection) or a **Python** snippet in the [Pyodide runtime](python-console.md). |
 
+## Sample prompts
+
+Prompts are free-form — these are starting points, not fixed commands. Refer to
+layers by name; the assistant looks up the rest. You can also chain steps in one
+message ("buffer the roads by 100 m **and then** clip to the county boundary")
+or keep refining across turns ("now color it by area").
+
+**Explore & query**
+
+```text
+what layers are loaded, and what fields does the parcels layer have?
+how many parcels are larger than 1 hectare?
+list the 10 most populous counties with their population
+show parcels within 500 m of a river and add them as a layer
+count points in each polygon of the districts layer
+```
+
+**Geoprocessing & analysis**
+
+```text
+buffer the roads by 100 meters
+buffer the roads by 100 m, then clip the buffer to the county boundary
+dissolve the parcels by zoning type
+find where the floodplain overlaps the buildings (intersection)
+create an H3 hex grid at resolution 8 over the points and count points per cell
+compute centroids of the counties and add them as a layer
+```
+
+**Symbology**
+
+```text
+color the counties by population with a graduated red ramp
+style the parcels categorized by land-use type
+shade the tracts by median income using a viridis ramp with 7 classes
+```
+
+**Add data & imagery**
+
+```text
+load the latest Sentinel-2 scene over this view
+add the most recent cloud-free Landsat image for this area
+search the Planetary Computer for NAIP imagery here
+add an Esri World Imagery basemap
+add this GeoJSON: https://example.com/data.geojson
+```
+
+**Map control & styling**
+
+```text
+zoom to the parcels layer
+fly to San Francisco
+switch to a dark basemap
+hide the buildings layer and set the parcels opacity to 0.5
+remove the temporary buffer layer
+```
+
+**Advanced (code fallback)**
+
+```text
+switch the map to a 3D globe projection
+enable terrain with hillshade exaggeration of 1.5
+load a CSV from a URL with pandas and summarize its columns
+```
+
 ## Safety and privacy
 
 - **Acts through the store.** Layer, style, basemap, and add/remove actions go

--- a/docs/user-guide/ai-assistant.md
+++ b/docs/user-guide/ai-assistant.md
@@ -65,7 +65,8 @@ eraser icon) starts a fresh conversation.
 ```text
 show me all parcels larger than 1 hectare within 500 m of a river
 color the counties by population using a graduated red ramp
-buffer the roads by 100 m and add the result as a layer
+buffer the roads by 100 m, then clip them to the county boundary
+load the latest Sentinel-2 scene over this view
 zoom to Africa, then switch to a dark basemap
 add an Esri World Imagery basemap
 ```
@@ -79,8 +80,10 @@ operations, so its actions stay within GeoLibre's validated surface.
 | --- | --- |
 | **Inspect layers** | Lists loaded layers, their geometry, attribute fields, and SQL table names (schema only — never your full data). |
 | **NL → Spatial SQL** | Generates and runs a **read-only** DuckDB Spatial SQL query through the [SQL Workspace](sql-workspace.md), and can add the result as a layer. |
+| **Geoprocessing** | Runs the registered [processing](processing.md) algorithms (buffer, clip, dissolve, intersection, difference, union, spatial join, simplify, H3 grids, …) and chains them into multi-step pipelines, adding each result as a layer. |
 | **Symbology** | Applies a **graduated** (numeric) or **categorized** (text) color ramp to a layer. |
 | **Add data** | Adds a layer from a public GeoJSON URL, or an XYZ tile basemap by name (`esri-imagery`, `esri-topo`, `osm`, `opentopomap`, `carto-dark`) or a custom `{z}/{x}/{y}` URL. |
+| **Earth observation** | Searches the Microsoft [Planetary Computer](https://planetarycomputer.microsoft.com) STAC catalog (Sentinel-2, Landsat, NAIP, DEMs, …) and adds an item over the current view as a raster layer — tiles are signed server-side, so no credentials are needed. |
 | **Map control** | Moves the camera (fit a layer or a bounding box), switches the basemap, toggles layer visibility/opacity, and removes layers. |
 | **Web search** | Looks up current information online (best with `TAVILY_API_KEY`). |
 | **Code fallback** | For tasks with no dedicated tool, runs a small **JavaScript** snippet against the live map (e.g. globe projection) or a **Python** snippet in the [Pyodide runtime](python-console.md). |

--- a/docs/user-guide/ai-assistant.md
+++ b/docs/user-guide/ai-assistant.md
@@ -1,0 +1,102 @@
+# AI Assistant
+
+The **AI Assistant** is a "chat with your data" panel that turns plain-English
+requests into GeoLibre's own operations — Spatial SQL, layer styling, map
+control, and more — and applies them **through the app**, the same way you would
+by hand. Open it from **Processing → AI Assistant** (top of the menu) or the
+command palette. It docks as a resizable panel at the bottom of the window (drag
+its top edge to resize, **✕** to close).
+
+Because the assistant acts through the store rather than poking the map
+directly, almost everything it does is **undoable** with **Ctrl/Cmd + Z**, and
+every tool call (including the SQL it generates) is shown in the transcript so
+you can see exactly what ran.
+
+The assistant is **optional and disabled until you configure an API key**. No
+data leaves your machine until you add a key and send a prompt.
+
+## Setup: add an API key
+
+The assistant is **provider-pluggable** — it uses the
+[Strands Agents](https://strandsagents.com) SDK and supports **Google Gemini**
+(default), **Anthropic**, and **OpenAI**. Add a key for one (or more) of them in
+**Settings → Environment** as an environment variable:
+
+| Provider | Environment variable (any of) | Default model |
+| --- | --- | --- |
+| Google Gemini | `GEMINI_API_KEY`, `GOOGLE_API_KEY` | `gemini-3.5-flash` |
+| Anthropic | `ANTHROPIC_API_KEY` | `claude-opus-4-8` |
+| OpenAI | `OPENAI_API_KEY` | `gpt-5.5` |
+
+The key is used **directly from your browser** to call the provider; it is never
+sent to GeoLibre's servers. Saving the setting enables the panel immediately — no
+reload needed.
+
+Optional variables:
+
+| Variable | Purpose |
+| --- | --- |
+| `GEOLIBRE_ASSISTANT_PROVIDER` | Force a provider (`google` / `anthropic` / `openai`) when several keys are set. |
+| `GEOLIBRE_ASSISTANT_MODEL` | Pin a specific model id, overriding the default and the picker. |
+| `TAVILY_API_KEY` | Enable reliable [web search](#what-it-can-do) (the keyless fallback is best-effort and may be blocked by the browser). |
+
+When more than one provider key is configured, a **provider** dropdown appears in
+the panel header; a **model** dropdown lets you switch models for the selected
+provider. Your choice is remembered across sessions.
+
+## Using it
+
+Type a request and press **Ctrl/Cmd + Enter** (or click **Send**). The
+assistant streams its reply, runs tools as needed, and reports what it did. While
+it is working, **Send** becomes **Stop** — click it to cancel. **Clear** (the
+eraser icon) starts a fresh conversation.
+
+```text
+show me all parcels larger than 1 hectare within 500 m of a river
+color the counties by population using a graduated red ramp
+buffer the roads by 100 m and add the result as a layer
+zoom to Africa, then switch to a dark basemap
+add an Esri World Imagery basemap
+```
+
+## What it can do
+
+The assistant works by calling a fixed set of tools — it cannot invent
+operations, so its actions stay within GeoLibre's validated surface.
+
+| Capability | What it does |
+| --- | --- |
+| **Inspect layers** | Lists loaded layers, their geometry, attribute fields, and SQL table names (schema only — never your full data). |
+| **NL → Spatial SQL** | Generates and runs a **read-only** DuckDB Spatial SQL query through the [SQL Workspace](sql-workspace.md), and can add the result as a layer. |
+| **Symbology** | Applies a **graduated** (numeric) or **categorized** (text) color ramp to a layer. |
+| **Add data** | Adds a layer from a public GeoJSON URL, or an XYZ tile basemap by name (`esri-imagery`, `esri-topo`, `osm`, `opentopomap`, `carto-dark`) or a custom `{z}/{x}/{y}` URL. |
+| **Map control** | Moves the camera (fit a layer or a bounding box), switches the basemap, toggles layer visibility/opacity, and removes layers. |
+| **Web search** | Looks up current information online (best with `TAVILY_API_KEY`). |
+| **Code fallback** | For tasks with no dedicated tool, runs a small **JavaScript** snippet against the live map (e.g. globe projection) or a **Python** snippet in the [Pyodide runtime](python-console.md). |
+
+## Safety and privacy
+
+- **Acts through the store.** Layer, style, basemap, and add/remove actions go
+  through the same one-way data flow as the rest of the app, so they are
+  reconciled consistently and covered by **undo/redo**.
+- **Auditable.** The generated SQL and every tool call appear in the transcript.
+- **Read-only SQL.** The `run_sql` tool rejects anything that isn't a `SELECT` /
+  `WITH` query.
+- **Scoped context.** Only layer/table **names**, attribute **field names**, and
+  the current view are sent to the model — not your feature data.
+- **What leaves your browser.** When you send a prompt, it (plus that scoped
+  context) is sent to your chosen LLM provider using your own key. Don't enable
+  the assistant on sensitive data you can't share with that provider.
+
+!!! note "Code-execution caveat"
+    The JavaScript and Python fallbacks execute model-generated code in the app
+    to cover requests no dedicated tool handles. Their direct map changes bypass
+    the store and are **not undoable**. The code is shown in the transcript.
+
+## Limitations
+
+- Requires a provider API key; offline use is not supported.
+- Subject to each provider's cost, rate limits, and your network's CORS/CSP
+  policy (browser-side calls).
+- The unofficial Google Maps tile endpoints are intentionally **not** included;
+  use the listed officially-supported basemaps or supply your own XYZ URL.

--- a/docs/user-guide/ai-assistant.md
+++ b/docs/user-guide/ai-assistant.md
@@ -18,19 +18,30 @@ data leaves your machine until you add a key and send a prompt.
 ## Setup: add an API key
 
 The assistant is **provider-pluggable** — it uses the
-[Strands Agents](https://strandsagents.com) SDK and supports **Google Gemini**
-(default), **Anthropic**, and **OpenAI**. Add a key for one (or more) of them in
-**Settings → Environment** as an environment variable:
+[Strands Agents](https://strandsagents.com) SDK. Configure one (or more)
+providers in **Settings → Environment** as environment variables:
 
-| Provider | Environment variable (any of) | Default model |
+| Provider | Environment variable(s) | Default model |
 | --- | --- | --- |
-| Google Gemini | `GEMINI_API_KEY`, `GOOGLE_API_KEY` | `gemini-3.5-flash` |
+| Google Gemini | `GEMINI_API_KEY` or `GOOGLE_API_KEY` | `gemini-3.5-flash` |
 | Anthropic | `ANTHROPIC_API_KEY` | `claude-opus-4-8` |
 | OpenAI | `OPENAI_API_KEY` | `gpt-5.5` |
+| **Ollama** (local) | `OLLAMA_BASE_URL` (e.g. `http://localhost:11434`) | `llama3.2` |
+| **Amazon Bedrock** | `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` (+ `AWS_REGION`, optional `AWS_SESSION_TOKEN`) | `global.anthropic.claude-sonnet-4-6` |
+| **Custom** (OpenAI-compatible) | `OPENAI_COMPATIBLE_BASE_URL` (+ optional `OPENAI_COMPATIBLE_API_KEY`) and `OPENAI_COMPATIBLE_MODEL` | — |
 
-The key is used **directly from your browser** to call the provider; it is never
-sent to GeoLibre's servers. Saving the setting enables the panel immediately — no
-reload needed.
+- **Ollama** runs models on your own machine — no API key and nothing leaves your
+  computer. Point `OLLAMA_BASE_URL` at your Ollama host (the `/v1` suffix is added
+  automatically); set `OLLAMA_MODEL` to pick which pulled model to use.
+- **Bedrock** calls AWS from the browser using your credentials (and the model
+  id is an inference-profile id such as `global.anthropic.claude-sonnet-4-6`; set
+  `BEDROCK_MODEL` to choose another).
+- **Custom** covers any OpenAI-compatible endpoint — LiteLLM, vLLM, OpenRouter,
+  Groq, Together, a local server, etc. — via its chat-completions API.
+
+Hosted keys (and AWS credentials) are used **directly from your browser** to call
+the provider; they are never sent to GeoLibre's servers. Saving the setting
+enables the panel immediately — no reload needed.
 
 Optional variables:
 

--- a/docs/user-guide/interface.md
+++ b/docs/user-guide/interface.md
@@ -12,7 +12,7 @@ The toolbar across the top of the window groups every action into seven menus:
 | --- | --- |
 | **Project** | Create, open, save, share, and print projects. See [Projects](projects.md). |
 | **Add Data** | Add layers from files, web services, cloud formats, 3D data, and databases. See [Adding Data](adding-data.md). |
-| **Processing** | Run vector, raster, conversion, Whitebox, and SQL tools. See [Processing Tools](processing.md) and [SQL Workspace](sql-workspace.md). |
+| **Processing** | Run vector, raster, conversion, Whitebox, and SQL tools, plus the [AI Assistant](ai-assistant.md). See [Processing Tools](processing.md) and [SQL Workspace](sql-workspace.md). |
 | **Controls** | Toggle map controls and component panels (Measure, Bookmark, Minimap, and more). See [Map Controls & Tools](map-controls.md). |
 | **Plugins** | Activate built-in plugins and set their on-map position. See [Plugins & Marketplace](plugins.md). |
 | **Settings** | Map preferences, layout, environment variables, project settings, and Manage Plugins. See [Settings & Preferences](settings.md). |

--- a/docs/user-guide/processing.md
+++ b/docs/user-guide/processing.md
@@ -1,9 +1,9 @@
 # Processing Tools
 
-The **Processing** menu collects GeoLibre's analysis and conversion tools: vector geometry and overlay tools, raster terrain and clipping tools, format conversion, and the Whitebox toolbox. The [SQL Workspace](sql-workspace.md) also lives here and has its own page.
+The **Processing** menu collects GeoLibre's analysis and conversion tools: vector geometry and overlay tools, raster terrain and clipping tools, format conversion, and the Whitebox toolbox. The [SQL Workspace](sql-workspace.md), [Python Console](python-console.md), and [AI Assistant](ai-assistant.md) also live here and have their own pages.
 
 !!! note "Page order"
-    This page groups the tools by theme. In the menu itself the items appear in a different order: Whitebox, SQL Workspace, Conversion, Vector, Raster, Planetary Computer, Earth Engine.
+    This page groups the tools by theme. In the menu itself the items appear in a different order: AI Assistant (top), Whitebox, SQL Workspace, Python Console, Conversion, Vector, Raster, Planetary Computer, Earth Engine.
 
 ![Vector tools dialog](https://data.geolibre.app/images/geolibre-processing-vector.webp)
 

--- a/e2e/pwa.spec.ts
+++ b/e2e/pwa.spec.ts
@@ -65,11 +65,11 @@ test("registers a service worker and serves the shell offline after first visit"
   // *after* the page's fetch for a chunk resolves — so the map canvas can be
   // visible (the ~13 MB MapLibre chunk ran in-page) while the SW is still
   // persisting that chunk. Going offline in that window leaves the chunk
-  // uncached, so the offline reload can't import MapLibre and never renders the
-  // map. Wait for all first-load requests to finish, then for every heavy
-  // runtime-cached chunk the boot pulled in to be durably stored.
+  // uncached, so the offline reload can't import it and never renders the map.
+  // Wait for all first-load requests to finish, then for every same-origin
+  // build asset the boot pulled in to be durably present in Cache Storage.
   await page.waitForLoadState("networkidle");
-  await waitForHeavyAssetsCached(page);
+  await waitForLoadedAssetsCached(page);
 
   // Drop the network and reload: the precached shell plus the runtime-cached
   // MapLibre chunk must still bring the app up with no connectivity.
@@ -90,40 +90,36 @@ test("registers a service worker and serves the shell offline after first visit"
 });
 
 /**
- * Wait until every heavy runtime-cached asset the first load pulled in is
- * durably present in Cache Storage. Chunks larger than the precache size limit
- * (4 MB — the MapLibre bundle, DuckDB-WASM, etc.) are excluded from the precache
- * and CacheFirst-cached on first fetch; that write completes asynchronously
- * after the page's fetch resolves, so "canvas visible" alone does not guarantee
- * the chunk is on disk. Polling `caches.match()` for each heavy `/assets/` chunk
- * the page actually loaded gives a deterministic "ready to go offline" signal —
- * runtime CacheFirst entries are keyed by plain URL, so the match is reliable
- * (unlike revision-keyed precache entries, which are already durable at SW
- * install and need no wait).
+ * Wait until every same-origin build asset the first load pulled in is durably
+ * present in Cache Storage, so going offline can't strip a chunk the cold boot
+ * needs. Each `/assets/` file is cached either by the revision-keyed precache
+ * (durable at SW install) or by the CacheFirst runtime rule (written
+ * asynchronously *after* the page's fetch resolves — see vite.config.ts). The
+ * runtime write is the race: "canvas visible" can happen while the SW is still
+ * persisting a chunk. Polling every loaded asset (not just the >4 MB ones, which
+ * misses the smaller globIgnored feature chunks) gives a deterministic
+ * "ready to go offline" signal. `ignoreSearch` lets the plain resource URL match
+ * a revision-keyed precache entry (`…?__WB_REVISION__=…`) as well as the
+ * plain-URL runtime entry.
  */
-async function waitForHeavyAssetsCached(page: Page): Promise<void> {
+async function waitForLoadedAssetsCached(page: Page): Promise<void> {
   await page.waitForFunction(
     async () => {
       const origin = location.origin;
-      const heavy = performance
+      const urls = performance
         .getEntriesByType("resource")
-        .filter((entry): entry is PerformanceResourceTiming => {
-          const resource = entry as PerformanceResourceTiming;
-          return (
-            resource.name.startsWith(origin) &&
-            resource.name.includes("/assets/") &&
-            resource.name.endsWith(".js") &&
-            // > 4 MB: globIgnored from the precache, so CacheFirst-cached at
-            // runtime (matches maximumFileSizeToCacheInBytes in vite.config.ts).
-            resource.decodedBodySize > 4 * 1024 * 1024
-          );
-        })
-        .map((resource) => resource.name);
-      // The MapLibre chunk must have loaded for the warm map boot above; if no
-      // heavy chunk is visible yet, keep polling rather than passing vacuously.
-      if (heavy.length === 0) return false;
-      for (const url of heavy) {
-        if (!(await caches.match(url))) return false;
+        .map((entry) => (entry as PerformanceResourceTiming).name)
+        .filter(
+          (name) =>
+            name.startsWith(origin) &&
+            name.includes("/assets/") &&
+            (name.endsWith(".js") || name.endsWith(".css")),
+        );
+      // The shell's JS/CSS must have loaded for the warm boot above; if nothing
+      // is visible yet, keep polling rather than passing vacuously.
+      if (urls.length === 0) return false;
+      for (const url of urls) {
+        if (!(await caches.match(url, { ignoreSearch: true }))) return false;
       }
       return true;
     },

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
       - Processing Tools: user-guide/processing.md
       - SQL Workspace: user-guide/sql-workspace.md
       - Python Console: user-guide/python-console.md
+      - AI Assistant: user-guide/ai-assistant.md
       - Data Integrations: user-guide/data-integrations.md
       - Plugins & Marketplace: user-guide/plugins.md
       - Settings & Preferences: user-guide/settings.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
     "apps/geolibre-desktop": {
       "version": "1.2.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.92.0",
         "@carbonplan/zarr-layer": "^0.5.0",
         "@deck.gl/aggregation-layers": "9.3.3",
         "@deck.gl/core": "^9.3.3",
@@ -47,9 +48,13 @@
         "@geolibre/processing": "*",
         "@geolibre/ui": "*",
         "@geoman-io/maplibre-geoman-free": "^0.7.1",
+        "@google/genai": "^1.52.0",
+        "@modelcontextprotocol/sdk": "^1.25.2",
+        "@opentelemetry/api": "^1.9.0",
         "@osmix/core": "^0.1.8",
         "@osmix/geojson": "^0.0.13",
         "@osmix/pbf": "^0.0.9",
+        "@strands-agents/sdk": "^1.3.0",
         "@tauri-apps/api": "^2.11.0",
         "@tauri-apps/plugin-dialog": "^2.7.1",
         "@tauri-apps/plugin-fs": "^2.5.1",
@@ -79,13 +84,15 @@
         "maplibre-gl-swipe": "^0.7.1",
         "maplibre-gl-time-slider": "^1.0.3",
         "maplibre-gl-vector": "^0.3.0",
+        "openai": "^6.39.0",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-i18next": "^16.6.6",
         "shpjs": "^6.2.0",
         "sql.js": "^1.14.0",
-        "three": "^0.184.0"
+        "three": "^0.184.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.3.0",
@@ -4071,6 +4078,18 @@
         }
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -5671,6 +5690,68 @@
         "@math.gl/core": "4.1.0"
       }
     },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
@@ -5735,6 +5816,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@osmix/change": {
@@ -11289,6 +11379,19 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -11360,6 +11463,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
@@ -11969,6 +12111,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/bowser": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
@@ -12084,6 +12250,15 @@
       "resolved": "https://registry.npmjs.org/but-unzip/-/but-unzip-0.1.10.tgz",
       "integrity": "sha512-hLfQ9WlUimmv/okzsRl6AYG3Ew5HNWhWgUslSR93FsDdeL0MAoQvmC/BJfs35lqEAO5t/QD7Y4vCFcPJtijt3A==",
       "license": "Apache-2.0"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -12595,6 +12770,28 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -12624,6 +12821,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
       }
     },
     "node_modules/copc": {
@@ -12686,6 +12892,23 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cross-fetch": {
       "version": "3.2.0",
@@ -12989,6 +13212,15 @@
       "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
       "license": "Unlicense"
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -13103,6 +13335,12 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/ejs": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
@@ -13145,6 +13383,15 @@
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.23.0",
@@ -13384,6 +13631,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "5.0.0",
@@ -13743,6 +13996,15 @@
         "url": "https://github.com/bgub/eta?sponsor=1"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/ev-store": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/ev-store/-/ev-store-7.0.0.tgz",
@@ -13760,6 +14022,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -13768,6 +14051,76 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/extend": {
@@ -13852,7 +14205,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
       "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14029,6 +14381,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/find-replace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
@@ -14194,6 +14567,24 @@
       },
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fs-extra": {
@@ -15106,6 +15497,15 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
@@ -15127,6 +15527,26 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -15323,6 +15743,24 @@
       "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
       "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
       "license": "MIT"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/irregular-plurals": {
       "version": "3.5.0",
@@ -15671,7 +16109,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-reference": {
@@ -15941,6 +16378,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -16041,6 +16487,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -17520,6 +17972,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/memoize": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/memoize/-/memoize-10.2.0.tgz",
@@ -17534,6 +17995,18 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/memoize?sponsor=1"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge2": {
@@ -17574,6 +18047,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mimic-function": {
@@ -17748,6 +18246,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/next-tick": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
@@ -17864,6 +18371,15 @@
       "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "license": "MIT"
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -17960,6 +18476,27 @@
       "optional": true,
       "dependencies": {
         "quickselect": "^3.0.0"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/openai": {
@@ -18182,6 +18719,15 @@
       "integrity": "sha512-WNjKn/cwgGBkXqQLif+2VMEahcRHkBRU0/RfBWZ7Vj7snRNNW63yW1mVuuHRDyXTRxuGCzAHHBcr/Fn+U/bXjQ==",
       "license": "MIT"
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -18317,6 +18863,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/playwright": {
@@ -18608,6 +19163,19 @@
       "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
       "license": "MIT"
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -18704,6 +19272,30 @@
       "optional": true,
       "dependencies": {
         "performance-now": "^2.1.0"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/rbush": {
@@ -19022,7 +19614,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -19202,6 +19793,32 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -19369,6 +19986,32 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/serialize-error": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
@@ -19406,6 +20049,25 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/set-function-length": {
@@ -19462,6 +20124,12 @@
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -19844,6 +20512,15 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.14"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/std-env": {
@@ -20556,6 +21233,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/topojson-client": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
@@ -20667,6 +21353,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -20918,6 +21635,15 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/unzipit": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unzipit/-/unzipit-2.0.0.tgz",
@@ -21064,6 +21790,15 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/virtual-dom": {
@@ -23005,6 +23740,12 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/write-file-atomic": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-6.0.0.tgz",
@@ -23240,6 +23981,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zod-validation-error": {

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -135,6 +135,7 @@ export interface AppState {
     geocodeOpen: boolean;
     sqlWorkspaceOpen: boolean;
     pythonConsoleOpen: boolean;
+    assistantOpen: boolean;
     attributeTableOpen: boolean;
     storymapPanelOpen: boolean;
     storymapPresenting: boolean;
@@ -170,6 +171,7 @@ export interface AppState {
   setGeocodeOpen: (open: boolean) => void;
   setSqlWorkspaceOpen: (open: boolean) => void;
   setPythonConsoleOpen: (open: boolean) => void;
+  setAssistantOpen: (open: boolean) => void;
   setAttributeTableOpen: (open: boolean) => void;
   setStorymapPanelOpen: (open: boolean) => void;
   setStorymapPresenting: (presenting: boolean) => void;
@@ -357,6 +359,7 @@ export const useAppStore = create<AppState>()(
         geocodeOpen: false,
         sqlWorkspaceOpen: false,
         pythonConsoleOpen: false,
+        assistantOpen: false,
         attributeTableOpen: false,
         storymapPanelOpen: false,
         storymapPresenting: false,
@@ -421,6 +424,8 @@ export const useAppStore = create<AppState>()(
         set((s) => ({ ui: { ...s.ui, sqlWorkspaceOpen: open } })),
       setPythonConsoleOpen: (open) =>
         set((s) => ({ ui: { ...s.ui, pythonConsoleOpen: open } })),
+      setAssistantOpen: (open) =>
+        set((s) => ({ ui: { ...s.ui, assistantOpen: open } })),
       setAttributeTableOpen: (open) =>
         set((s) => ({ ui: { ...s.ui, attributeTableOpen: open } })),
       setStorymapPanelOpen: (open) =>

--- a/tests/assistant-basemaps.test.ts
+++ b/tests/assistant-basemaps.test.ts
@@ -7,18 +7,28 @@ import {
 
 describe("findNamedTileBasemap", () => {
   it("matches by exact id", () => {
-    const basemap = findNamedTileBasemap("google-satellite");
-    assert.equal(basemap?.id, "google-satellite");
+    const basemap = findNamedTileBasemap("esri-imagery");
+    assert.equal(basemap?.id, "esri-imagery");
     assert.match(basemap?.url ?? "", /\{z\}/);
     assert.match(basemap?.url ?? "", /\{x\}/);
     assert.match(basemap?.url ?? "", /\{y\}/);
   });
 
   it("matches by label, case-insensitively and fuzzily", () => {
-    assert.equal(findNamedTileBasemap("Google Satellite")?.id, "google-satellite");
-    assert.equal(findNamedTileBasemap("google satellite")?.id, "google-satellite");
+    assert.equal(findNamedTileBasemap("Esri World Imagery")?.id, "esri-imagery");
     assert.equal(findNamedTileBasemap("esri imagery")?.id, "esri-imagery");
+    assert.equal(findNamedTileBasemap("opentopomap")?.id, "opentopomap");
     assert.equal(findNamedTileBasemap("openstreetmap")?.id, "osm");
+  });
+
+  it("does not include undocumented Google tile endpoints", () => {
+    assert.equal(findNamedTileBasemap("google-satellite"), null);
+    for (const basemap of NAMED_TILE_BASEMAPS) {
+      assert.ok(
+        !/google/i.test(basemap.url),
+        `${basemap.id} should not use a Google endpoint`,
+      );
+    }
   });
 
   it("returns null for unknown or empty references", () => {

--- a/tests/assistant-basemaps.test.ts
+++ b/tests/assistant-basemaps.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  findNamedTileBasemap,
+  NAMED_TILE_BASEMAPS,
+} from "../apps/geolibre-desktop/src/lib/assistant/basemaps";
+
+describe("findNamedTileBasemap", () => {
+  it("matches by exact id", () => {
+    const basemap = findNamedTileBasemap("google-satellite");
+    assert.equal(basemap?.id, "google-satellite");
+    assert.match(basemap?.url ?? "", /\{z\}/);
+    assert.match(basemap?.url ?? "", /\{x\}/);
+    assert.match(basemap?.url ?? "", /\{y\}/);
+  });
+
+  it("matches by label, case-insensitively and fuzzily", () => {
+    assert.equal(findNamedTileBasemap("Google Satellite")?.id, "google-satellite");
+    assert.equal(findNamedTileBasemap("google satellite")?.id, "google-satellite");
+    assert.equal(findNamedTileBasemap("esri imagery")?.id, "esri-imagery");
+    assert.equal(findNamedTileBasemap("openstreetmap")?.id, "osm");
+  });
+
+  it("returns null for unknown or empty references", () => {
+    assert.equal(findNamedTileBasemap("nope-xyz"), null);
+    assert.equal(findNamedTileBasemap("  "), null);
+  });
+
+  it("every registered basemap has a valid XYZ template", () => {
+    for (const basemap of NAMED_TILE_BASEMAPS) {
+      for (const placeholder of ["{z}", "{x}", "{y}"]) {
+        assert.ok(
+          basemap.url.includes(placeholder),
+          `${basemap.id} missing ${placeholder}`,
+        );
+      }
+      assert.ok(basemap.attribution.length > 0, `${basemap.id} missing attribution`);
+    }
+  });
+});

--- a/tests/assistant-provider.test.ts
+++ b/tests/assistant-provider.test.ts
@@ -71,6 +71,53 @@ describe("resolveProviderConfig", () => {
   it("ignores blank key values", () => {
     assert.equal(resolveProviderConfig({ GEMINI_API_KEY: "   " }), null);
   });
+
+  it("selects Ollama from OLLAMA_BASE_URL, normalizing to a /v1 base", () => {
+    const config = resolveProviderConfig({ OLLAMA_BASE_URL: "localhost:11434" });
+    assert.deepEqual(config, {
+      provider: "ollama",
+      apiKey: "ollama",
+      baseURL: "http://localhost:11434/v1",
+      modelId: "llama3.2",
+    });
+  });
+
+  it("selects Bedrock from AWS credentials with a default region", () => {
+    const config = resolveProviderConfig({
+      AWS_ACCESS_KEY_ID: "AKIA",
+      AWS_SECRET_ACCESS_KEY: "secret",
+    });
+    assert.deepEqual(config, {
+      provider: "bedrock",
+      modelId: "global.anthropic.claude-sonnet-4-6",
+      region: "us-east-1",
+      credentials: {
+        accessKeyId: "AKIA",
+        secretAccessKey: "secret",
+        sessionToken: undefined,
+      },
+    });
+  });
+
+  it("requires both a base URL and a model for the custom provider", () => {
+    assert.equal(
+      configForProvider("custom", undefined, {
+        OPENAI_COMPATIBLE_BASE_URL: "https://api.example.com/v1",
+      }),
+      null,
+    );
+    const config = configForProvider("custom", undefined, {
+      OPENAI_COMPATIBLE_BASE_URL: "https://api.example.com/v1/",
+      OPENAI_COMPATIBLE_MODEL: "my-model",
+      OPENAI_COMPATIBLE_API_KEY: "k",
+    });
+    assert.deepEqual(config, {
+      provider: "custom",
+      apiKey: "k",
+      baseURL: "https://api.example.com/v1",
+      modelId: "my-model",
+    });
+  });
 });
 
 describe("availableProviders", () => {

--- a/tests/assistant-provider.test.ts
+++ b/tests/assistant-provider.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  resolveProviderConfig,
+  type RuntimeEnv,
+} from "../apps/geolibre-desktop/src/lib/assistant/provider";
+
+describe("resolveProviderConfig", () => {
+  it("returns null when no provider key is configured", () => {
+    assert.equal(resolveProviderConfig({}), null);
+    assert.equal(resolveProviderConfig({ UNRELATED: "x" } as RuntimeEnv), null);
+  });
+
+  it("selects Google from GEMINI_API_KEY with its default model", () => {
+    const config = resolveProviderConfig({ GEMINI_API_KEY: "g-key" });
+    assert.deepEqual(config, {
+      provider: "google",
+      apiKey: "g-key",
+      modelId: "gemini-2.5-flash",
+    });
+  });
+
+  it("accepts GOOGLE_API_KEY as a Google alias", () => {
+    const config = resolveProviderConfig({ GOOGLE_API_KEY: "g2" });
+    assert.equal(config?.provider, "google");
+    assert.equal(config?.apiKey, "g2");
+  });
+
+  it("selects Anthropic when only its key is present", () => {
+    const config = resolveProviderConfig({ ANTHROPIC_API_KEY: "a-key" });
+    assert.equal(config?.provider, "anthropic");
+    assert.equal(config?.modelId, "claude-opus-4-8");
+  });
+
+  it("prefers Google over others when several keys exist", () => {
+    const config = resolveProviderConfig({
+      OPENAI_API_KEY: "o",
+      ANTHROPIC_API_KEY: "a",
+      GEMINI_API_KEY: "g",
+    });
+    assert.equal(config?.provider, "google");
+  });
+
+  it("honors an explicit provider override", () => {
+    const config = resolveProviderConfig({
+      GEOLIBRE_ASSISTANT_PROVIDER: "anthropic",
+      ANTHROPIC_API_KEY: "a",
+      GEMINI_API_KEY: "g",
+    });
+    assert.equal(config?.provider, "anthropic");
+  });
+
+  it("returns null when the overridden provider has no key", () => {
+    const config = resolveProviderConfig({
+      GEOLIBRE_ASSISTANT_PROVIDER: "openai",
+      GEMINI_API_KEY: "g",
+    });
+    assert.equal(config, null);
+  });
+
+  it("applies a model override", () => {
+    const config = resolveProviderConfig({
+      GEMINI_API_KEY: "g",
+      GEOLIBRE_ASSISTANT_MODEL: "gemini-2.5-pro",
+    });
+    assert.equal(config?.modelId, "gemini-2.5-pro");
+  });
+
+  it("ignores blank key values", () => {
+    assert.equal(resolveProviderConfig({ GEMINI_API_KEY: "   " }), null);
+  });
+});

--- a/tests/assistant-provider.test.ts
+++ b/tests/assistant-provider.test.ts
@@ -18,7 +18,7 @@ describe("resolveProviderConfig", () => {
     assert.deepEqual(config, {
       provider: "google",
       apiKey: "g-key",
-      modelId: "gemini-2.5-flash",
+      modelId: "gemini-3.5-flash",
     });
   });
 

--- a/tests/assistant-provider.test.ts
+++ b/tests/assistant-provider.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  availableProviders,
+  configForProvider,
   resolveProviderConfig,
   type RuntimeEnv,
 } from "../apps/geolibre-desktop/src/lib/assistant/provider";
@@ -68,5 +70,50 @@ describe("resolveProviderConfig", () => {
 
   it("ignores blank key values", () => {
     assert.equal(resolveProviderConfig({ GEMINI_API_KEY: "   " }), null);
+  });
+});
+
+describe("availableProviders", () => {
+  it("lists only providers with a configured key, in preference order", () => {
+    assert.deepEqual(availableProviders({}), []);
+    assert.deepEqual(
+      availableProviders({ OPENAI_API_KEY: "o", GEMINI_API_KEY: "g" }),
+      ["google", "openai"],
+    );
+    assert.deepEqual(availableProviders({ ANTHROPIC_API_KEY: "a" }), [
+      "anthropic",
+    ]);
+  });
+});
+
+describe("configForProvider", () => {
+  it("returns null when the chosen provider has no key", () => {
+    assert.equal(configForProvider("anthropic", undefined, { GEMINI_API_KEY: "g" }), null);
+  });
+
+  it("uses the explicit model when provided", () => {
+    const config = configForProvider("google", "gemini-2.5-pro", {
+      GEMINI_API_KEY: "g",
+    });
+    assert.deepEqual(config, {
+      provider: "google",
+      apiKey: "g",
+      modelId: "gemini-2.5-pro",
+    });
+  });
+
+  it("falls back to the env model override, then the provider default", () => {
+    assert.equal(
+      configForProvider("openai", undefined, {
+        OPENAI_API_KEY: "o",
+        GEOLIBRE_ASSISTANT_MODEL: "gpt-4.1",
+      })?.modelId,
+      "gpt-4.1",
+    );
+    assert.equal(
+      configForProvider("anthropic", undefined, { ANTHROPIC_API_KEY: "a" })
+        ?.modelId,
+      "claude-opus-4-8",
+    );
   });
 });

--- a/tests/assistant-symbology.test.ts
+++ b/tests/assistant-symbology.test.ts
@@ -39,13 +39,26 @@ describe("buildSymbologyStyle", () => {
   });
 
   it("clamps the graduated class count into a sane range", () => {
-    const layer = layerWith("pop", [1, 2, 3, 4]);
+    const layer = layerWith(
+      "pop",
+      Array.from({ length: 30 }, (_, index) => index + 1),
+    );
     const style = buildSymbologyStyle(layer, {
       mode: "graduated",
       property: "pop",
       classCount: 99,
     });
     assert.equal(style.vectorStyleStops?.length, 12);
+  });
+
+  it("never asks for more classes than the data has values", () => {
+    const layer = layerWith("pop", [10, 20, 30]);
+    const style = buildSymbologyStyle(layer, {
+      mode: "graduated",
+      property: "pop",
+      classCount: 8,
+    });
+    assert.equal(style.vectorStyleStops?.length, 3);
   });
 
   it("builds a categorized style with one stop per distinct value", () => {

--- a/tests/assistant-symbology.test.ts
+++ b/tests/assistant-symbology.test.ts
@@ -1,0 +1,87 @@
+import type { GeoLibreLayer } from "@geolibre/core";
+import type { Feature } from "geojson";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { buildSymbologyStyle } from "../apps/geolibre-desktop/src/lib/assistant/symbology";
+
+/** Build a minimal point layer carrying the given property values. */
+function layerWith(property: string, values: unknown[]): GeoLibreLayer {
+  const features: Feature[] = values.map((value) => ({
+    type: "Feature",
+    geometry: { type: "Point", coordinates: [0, 0] },
+    properties: { [property]: value },
+  }));
+  return {
+    id: "layer-1",
+    name: "Test layer",
+    type: "geojson",
+    geojson: { type: "FeatureCollection", features },
+  } as unknown as GeoLibreLayer;
+}
+
+describe("buildSymbologyStyle", () => {
+  it("builds a graduated style from numeric values", () => {
+    const layer = layerWith("pop", [1, 10, 100, 1000, 5000]);
+    const style = buildSymbologyStyle(layer, {
+      mode: "graduated",
+      property: "pop",
+      colorRamp: "reds",
+      classCount: 5,
+    });
+    assert.equal(style.vectorStyleMode, "graduated");
+    assert.equal(style.vectorStyleProperty, "pop");
+    assert.equal(style.vectorStyleColorRamp, "reds");
+    assert.equal(style.vectorStyleStops?.length, 5);
+    for (const stop of style.vectorStyleStops ?? []) {
+      assert.equal(typeof stop.value, "number");
+      assert.match(stop.color, /^#[0-9a-fA-F]{6}$/);
+    }
+  });
+
+  it("clamps the graduated class count into a sane range", () => {
+    const layer = layerWith("pop", [1, 2, 3, 4]);
+    const style = buildSymbologyStyle(layer, {
+      mode: "graduated",
+      property: "pop",
+      classCount: 99,
+    });
+    assert.equal(style.vectorStyleStops?.length, 12);
+  });
+
+  it("builds a categorized style with one stop per distinct value", () => {
+    const layer = layerWith("kind", ["a", "b", "a", "c", "b"]);
+    const style = buildSymbologyStyle(layer, {
+      mode: "categorized",
+      property: "kind",
+    });
+    assert.equal(style.vectorStyleMode, "categorized");
+    assert.equal(style.vectorStyleStops?.length, 3);
+    assert.deepEqual(
+      style.vectorStyleStops?.map((stop) => stop.value),
+      ["a", "b", "c"],
+    );
+  });
+
+  it("defaults the color ramp to viridis", () => {
+    const layer = layerWith("kind", ["x", "y"]);
+    const style = buildSymbologyStyle(layer, {
+      mode: "categorized",
+      property: "kind",
+    });
+    assert.equal(style.vectorStyleColorRamp, "viridis");
+  });
+
+  it("throws when the property has no values", () => {
+    const layer = layerWith("pop", []);
+    assert.throws(() =>
+      buildSymbologyStyle(layer, { mode: "graduated", property: "pop" }),
+    );
+  });
+
+  it("throws when graduated mode is asked for non-numeric data", () => {
+    const layer = layerWith("kind", ["red", "green", "blue"]);
+    assert.throws(() =>
+      buildSymbologyStyle(layer, { mode: "graduated", property: "kind" }),
+    );
+  });
+});


### PR DESCRIPTION
Closes #282 (Phase 1 + agent foundation).

## What this adds

A GeoLibre-native **"chat with your data"** assistant — inspired by [`maplibre-gl-geoagent`](https://github.com/opengeos/maplibre-gl-geoagent) and powered by a **Strands TypeScript agent** (`@strands-agents/sdk`). The agent turns plain-English requests into the app's existing, well-defined operations and applies them **through the store**, the SQL Workspace, and the symbology system — never by mutating MapLibre directly — so every change flows through the normal one-way sync (`MapController.syncLayers`) and is covered by undo/redo.

A new bottom-docked chat panel (modeled on the Python Console) is opened from the toolbar. Tool calls and generated SQL are surfaced in the transcript so the user can see exactly what ran.

## Why a GeoLibre-native agent

The existing GeoAgent plugin wraps the third-party `maplibre-gl-geoagent` library, whose `GeoAgentControl` keeps its `agent`/`tools` private (no hook to inject GeoLibre tools) and mutates MapLibre directly. Rather than fight that boundary, this builds directly on the same Strands SDK with a tool registry that acts through GeoLibre's store/SQL/symbology — the clean realization of the issue's design principles.

## Tools the agent can call

- `list_layers` — layer names, attribute fields, and SQL table names (schema only, never row data)
- `run_sql` — NL → DuckDB Spatial SQL via the existing `runSqlQuery`, with optional add-as-layer
- `add_layer_from_url` / `remove_layer`
- `set_layer_visibility` / `set_layer_opacity` / `set_basemap` / `zoom_to`
- `apply_symbology` — graduated/categorized `LayerStyle` built from the existing color-ramp + break helpers

The registry is shaped so processing-algorithm tools (over `VECTOR_TOOLS`/`RASTER_TOOLS`/`H3_TOOLS`) drop in later without touching the agent core.

## Provider-pluggable

Via `@strands-agents/sdk`: **Gemini** (`@google/genai`, already a trusted dep) by default, with **Anthropic** and **OpenAI** selectable. Keys come from the existing **Settings → Environment** variables (e.g. `GEMINI_API_KEY` / `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`); provider/model can be pinned with `GEOLIBRE_ASSISTANT_PROVIDER` / `GEOLIBRE_ASSISTANT_MODEL`. The panel is disabled with a clear message until a key is configured, and rebuilds the agent on a `geolibre:runtime-env-change` event.

## Key files

- `apps/geolibre-desktop/src/lib/assistant/{provider,tools,symbology,agent}.ts`
- `apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx`
- Wiring: `ui.assistantOpen` in `packages/core/src/store.ts`; toolbar command in `TopToolbar.tsx`; mount in `DesktopShell.tsx`; strings in `i18n/locales/en.json`
- Deps: `@strands-agents/sdk`, `zod`, `@google/genai`, `@anthropic-ai/sdk`, `openai`, plus Strands' required peers `@opentelemetry/api` and `@modelcontextprotocol/sdk`

## Scope / follow-ups

This PR is Phase 1 (NL→SQL) + the agent foundation + map-control / add-remove-data / NL→symbology. NL→processing-pipeline and full NL→Add-Data/STAC are designed-for and deferred.

## Verification

- `npm run build` (full web build incl. dynamic provider imports) — passes
- `npm run test:frontend` — 664 + 15 new tests pass (provider key resolution, symbology builder)
- `npm run lint`, `tsc -b`, and `pre-commit` (incl. npm-build hook) — clean
- Live LLM end-to-end (NL→SQL, "color counties by population", "zoom to Africa", add/remove layer) needs a provider key set in Settings → Environment; not exercised in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “AI Assistant” entry to the Processing toolbar, opening a bottom-docked streaming chat panel with conversation controls, stop/clear/close, and a resizable layout.
  * The assistant can list layers, run read-only SQL, manage layers, switch basemaps, zoom to, and apply graduated/categorized symbology.
* **Documentation**
  * Added English UI strings for the assistant and the new “strip environment variables?” save prompt.
* **Bug Fixes**
  * Improved assistant panel loading behavior by lazy-loading it when opened.
* **Tests**
  * Added unit tests for provider/model resolution and symbology stop generation/validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->