### PR TITLE
fix(desktop): silence benign Tauri IPC startup transients in console (#332)

### DIFF
--- a/apps/geolibre-desktop/src/lib/diagnostics.ts
+++ b/apps/geolibre-desktop/src/lib/diagnostics.ts
@@ -1,4 +1,5 @@
 import { useSyncExternalStore } from "react";
+import { isTauri } from "./is-tauri";
 
 export type DiagnosticCategory = "console" | "map" | "network" | "runtime";
 export type DiagnosticLevel = "error" | "info" | "warning";
@@ -35,6 +36,33 @@ const MAX_DIAGNOSTIC_RECORDS = 500;
 const MAX_FIELD_LENGTH = 3000;
 const CAPTURE_NETWORK_INFO_STORAGE_KEY =
   "geolibre.diagnostics.captureNetworkInfo";
+
+// On some WebView2 (Windows) and WKWebView (macOS) builds the first requests to
+// Tauri's custom IPC/asset protocols can momentarily fail while those schemes
+// are still being registered, surfacing as a `TypeError: Failed to fetch` (or
+// `Load failed` on WebKit). Tauri's IPC layer logs the warning below once and
+// transparently retries every call over its postMessage interface, and MapLibre
+// recovers and renders the map, so these are benign startup transients. They are
+// still recorded as diagnostics, but kept out of the developer console where
+// they read as fatal errors (see GitHub issue #332). Scoped to the desktop
+// runtime and a short post-launch window so genuine later fetch failures are
+// untouched.
+const STARTUP_FETCH_GRACE_MS = 15_000;
+const FETCH_FAILURE_MESSAGES = ["Failed to fetch", "Load failed"];
+// Logged verbatim by Tauri's runtime-injected ipc-protocol.js (tauri 2.x) the
+// first time the custom-protocol IPC falls back to postMessage.
+const TAURI_IPC_FALLBACK_WARNING =
+  "IPC custom protocol failed, Tauri will now use the postMessage interface instead";
+
+function looksLikeFetchFailure(reason: unknown): boolean {
+  const message =
+    reason instanceof Error
+      ? reason.message
+      : typeof reason === "string"
+        ? reason
+        : "";
+  return FETCH_FAILURE_MESSAGES.some((needle) => message.includes(needle));
+}
 
 // Note: called once at module import, so the initial value is frozen for the
 // lifetime of the module. Tests that need a different starting state must
@@ -254,9 +282,17 @@ export function installDiagnosticsCapture(): () => void {
     };
   }
 
+  const installedAt = Date.now();
   const originalFetch = window.fetch.bind(window);
   const originalConsoleError = console.error;
   const originalConsoleWarn = console.warn;
+
+  // Within the startup window, a desktop "Failed to fetch" rejection/warning is
+  // the Tauri custom-protocol fallback warming up rather than a real failure.
+  const isBenignStartupFetch = (reason: unknown): boolean =>
+    isTauri() &&
+    Date.now() - installedAt <= STARTUP_FETCH_GRACE_MS &&
+    looksLikeFetchFailure(reason);
 
   const patchedFetch: typeof fetch = async (input, init) => {
     const startedAt = performance.now();
@@ -305,6 +341,10 @@ export function installDiagnosticsCapture(): () => void {
   };
 
   console.warn = (...args: unknown[]) => {
+    const isTauriIpcFallback =
+      isTauri() &&
+      typeof args[0] === "string" &&
+      args[0].includes(TAURI_IPC_FALLBACK_WARNING);
     try {
       appendDiagnostic({
         category: "console",
@@ -312,7 +352,10 @@ export function installDiagnosticsCapture(): () => void {
         message: formatConsoleArgs(args) || "console.warn",
       });
     } finally {
-      originalConsoleWarn(...args);
+      // Record Tauri's one-time IPC-fallback notice but don't echo it to the
+      // console: the fallback is automatic and harmless, and the warning only
+      // alarms users inspecting the console at startup (issue #332).
+      if (!isTauriIpcFallback) originalConsoleWarn(...args);
     }
   };
 
@@ -329,12 +372,19 @@ export function installDiagnosticsCapture(): () => void {
   };
 
   const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
+    const benign = isBenignStartupFetch(event.reason);
     appendDiagnostic({
-      category: "runtime",
-      level: "error",
-      message: "Unhandled promise rejection",
+      category: benign ? "network" : "runtime",
+      level: benign ? "warning" : "error",
+      message: benign
+        ? "Benign startup fetch rejection (Tauri custom-protocol warm-up)"
+        : "Unhandled promise rejection",
       detail: formatUnknown(event.reason),
     });
+    // MapLibre and Tauri both recover from the custom-protocol warm-up failure,
+    // so swallow the rejection to keep an "Uncaught (in promise) TypeError:
+    // Failed to fetch" out of the console (issue #332). It stays in diagnostics.
+    if (benign) event.preventDefault();
   };
 
   window.fetch = patchedFetch;

--- a/apps/geolibre-desktop/src/lib/diagnostics.ts
+++ b/apps/geolibre-desktop/src/lib/diagnostics.ts
@@ -47,6 +47,13 @@ const CAPTURE_NETWORK_INFO_STORAGE_KEY =
 // they read as fatal errors (see GitHub issue #332). Scoped to the desktop
 // runtime and a short post-launch window so genuine later fetch failures are
 // untouched.
+//
+// Tradeoff: the match is on the generic message text, not the failing origin.
+// MapLibre's rejection is a plain `Failed to fetch` with no `ipc.localhost` in
+// the message, so narrowing to that origin would miss the very rejection this
+// targets. The cost is that a genuine plugin/network fetch that rejects within
+// the startup window is also downgraded from error to warning — acceptable
+// because the window is short and the event is still recorded in diagnostics.
 const STARTUP_FETCH_GRACE_MS = 15_000;
 const FETCH_FAILURE_MESSAGES = ["Failed to fetch", "Load failed"];
 // Logged verbatim by Tauri's runtime-injected ipc-protocol.js (tauri 2.x) the
@@ -287,12 +294,16 @@ export function installDiagnosticsCapture(): () => void {
   const originalConsoleError = console.error;
   const originalConsoleWarn = console.warn;
 
+  // Suppression only applies to the desktop runtime during the post-launch
+  // window; a Tauri IPC fallback that happens later (e.g. after an OS
+  // suspend/resume) stays console-visible rather than being silently swallowed.
+  const inStartupWindow = (): boolean =>
+    isTauri() && Date.now() - installedAt <= STARTUP_FETCH_GRACE_MS;
+
   // Within the startup window, a desktop "Failed to fetch" rejection/warning is
   // the Tauri custom-protocol fallback warming up rather than a real failure.
   const isBenignStartupFetch = (reason: unknown): boolean =>
-    isTauri() &&
-    Date.now() - installedAt <= STARTUP_FETCH_GRACE_MS &&
-    looksLikeFetchFailure(reason);
+    inStartupWindow() && looksLikeFetchFailure(reason);
 
   const patchedFetch: typeof fetch = async (input, init) => {
     const startedAt = performance.now();
@@ -342,7 +353,7 @@ export function installDiagnosticsCapture(): () => void {
 
   console.warn = (...args: unknown[]) => {
     const isTauriIpcFallback =
-      isTauri() &&
+      inStartupWindow() &&
       typeof args[0] === "string" &&
       args[0].includes(TAURI_IPC_FALLBACK_WARNING);
     try {

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -122,6 +122,14 @@ describe("diagnostics startup transient suppression", () => {
   let installCapture: DiagnosticsModule["installDiagnosticsCapture"];
   let realWarn: typeof console.warn;
   let realError: typeof console.error;
+  const realDateNow = Date.now;
+  // Tracked so afterEach can tear down the interceptors even if an assertion
+  // throws mid-test, keeping the module-level capture ref-count clean.
+  let activeCleanup: (() => void) | null = null;
+
+  function install(): void {
+    activeCleanup = installCapture();
+  }
 
   before(async () => {
     ({ installDiagnosticsCapture: installCapture } = await import(
@@ -145,8 +153,11 @@ describe("diagnostics startup transient suppression", () => {
   });
 
   afterEach(() => {
+    activeCleanup?.();
+    activeCleanup = null;
     console.warn = realWarn;
     console.error = realError;
+    Date.now = realDateNow;
   });
 
   function rejectionEvent(reason: unknown) {
@@ -164,7 +175,7 @@ describe("diagnostics startup transient suppression", () => {
 
   it("swallows a benign startup fetch rejection under Tauri", () => {
     win.__TAURI_INTERNALS__ = {};
-    const cleanup = installCapture();
+    install();
     const { event, wasPrevented } = rejectionEvent(
       new TypeError("Failed to fetch"),
     );
@@ -173,11 +184,10 @@ describe("diagnostics startup transient suppression", () => {
     const [record] = getDiagnosticsSnapshot().records;
     assert.equal(record.level, "warning");
     assert.equal(record.category, "network");
-    cleanup();
   });
 
   it("leaves a fetch rejection alone outside the Tauri runtime", () => {
-    const cleanup = installCapture();
+    install();
     const { event, wasPrevented } = rejectionEvent(
       new TypeError("Failed to fetch"),
     );
@@ -186,17 +196,29 @@ describe("diagnostics startup transient suppression", () => {
     const [record] = getDiagnosticsSnapshot().records;
     assert.equal(record.level, "error");
     assert.equal(record.category, "runtime");
-    cleanup();
+  });
+
+  it("does not swallow a fetch rejection after the startup window", () => {
+    win.__TAURI_INTERNALS__ = {};
+    install();
+    // installedAt is captured at install; jump past the grace window so the
+    // rejection no longer counts as a startup transient.
+    Date.now = () => realDateNow() + 60_000;
+    const { event, wasPrevented } = rejectionEvent(
+      new TypeError("Failed to fetch"),
+    );
+    listeners.get("unhandledrejection")?.(event);
+    assert.equal(wasPrevented(), false);
+    assert.equal(getDiagnosticsSnapshot().records[0]?.level, "error");
   });
 
   it("does not swallow a non-fetch rejection under Tauri", () => {
     win.__TAURI_INTERNALS__ = {};
-    const cleanup = installCapture();
+    install();
     const { event, wasPrevented } = rejectionEvent(new Error("boom"));
     listeners.get("unhandledrejection")?.(event);
     assert.equal(wasPrevented(), false);
     assert.equal(getDiagnosticsSnapshot().records[0]?.level, "error");
-    cleanup();
   });
 
   it("records but does not echo Tauri's IPC fallback warning", () => {
@@ -205,14 +227,27 @@ describe("diagnostics startup transient suppression", () => {
     console.warn = (...args: unknown[]) => {
       echoed = args;
     };
-    const cleanup = installCapture();
+    install();
     console.warn(
       "IPC custom protocol failed, Tauri will now use the postMessage interface instead",
       new TypeError("Failed to fetch"),
     );
     assert.equal(echoed, null);
     assert.equal(getDiagnosticsSnapshot().records[0]?.level, "warning");
-    cleanup();
+  });
+
+  it("echoes the IPC fallback warning after the startup window", () => {
+    win.__TAURI_INTERNALS__ = {};
+    let echoed: unknown[] | null = null;
+    console.warn = (...args: unknown[]) => {
+      echoed = args;
+    };
+    install();
+    Date.now = () => realDateNow() + 60_000;
+    const message =
+      "IPC custom protocol failed, Tauri will now use the postMessage interface instead";
+    console.warn(message);
+    assert.deepEqual(echoed, [message]);
   });
 
   it("still echoes ordinary warnings under Tauri", () => {
@@ -221,9 +256,8 @@ describe("diagnostics startup transient suppression", () => {
     console.warn = (...args: unknown[]) => {
       echoed = args;
     };
-    const cleanup = installCapture();
+    install();
     console.warn("a normal warning");
     assert.deepEqual(echoed, ["a normal warning"]);
-    cleanup();
   });
 });

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { before, beforeEach, describe, it } from "node:test";
+import { afterEach, before, beforeEach, describe, it } from "node:test";
 
 // diagnostics.ts reads localStorage at import time, so the window stub must
 // be installed before the module is loaded; hence the dynamic import below.
@@ -112,5 +112,118 @@ describe("diagnostics network info capture", () => {
     assert.equal(getDiagnosticsSnapshot().captureNetworkInfo, false);
     setCaptureNetworkInfo(true);
     assert.equal(getDiagnosticsSnapshot().captureNetworkInfo, true);
+  });
+});
+
+describe("diagnostics startup transient suppression", () => {
+  type Listener = (event: unknown) => void;
+  const listeners = new Map<string, Listener>();
+  const win = (globalThis as { window?: Record<string, unknown> }).window!;
+  let installCapture: DiagnosticsModule["installDiagnosticsCapture"];
+  let realWarn: typeof console.warn;
+  let realError: typeof console.error;
+
+  before(async () => {
+    ({ installDiagnosticsCapture: installCapture } = await import(
+      "../apps/geolibre-desktop/src/lib/diagnostics"
+    ));
+  });
+
+  beforeEach(() => {
+    listeners.clear();
+    clearDiagnostics();
+    realWarn = console.warn;
+    realError = console.error;
+    win.fetch = (() => Promise.resolve()) as unknown as typeof fetch;
+    win.addEventListener = (type: string, listener: Listener) => {
+      listeners.set(type, listener);
+    };
+    win.removeEventListener = (type: string) => {
+      listeners.delete(type);
+    };
+    delete win.__TAURI_INTERNALS__;
+  });
+
+  afterEach(() => {
+    console.warn = realWarn;
+    console.error = realError;
+  });
+
+  function rejectionEvent(reason: unknown) {
+    let prevented = false;
+    return {
+      event: {
+        reason,
+        preventDefault: () => {
+          prevented = true;
+        },
+      },
+      wasPrevented: () => prevented,
+    };
+  }
+
+  it("swallows a benign startup fetch rejection under Tauri", () => {
+    win.__TAURI_INTERNALS__ = {};
+    const cleanup = installCapture();
+    const { event, wasPrevented } = rejectionEvent(
+      new TypeError("Failed to fetch"),
+    );
+    listeners.get("unhandledrejection")?.(event);
+    assert.equal(wasPrevented(), true);
+    const [record] = getDiagnosticsSnapshot().records;
+    assert.equal(record.level, "warning");
+    assert.equal(record.category, "network");
+    cleanup();
+  });
+
+  it("leaves a fetch rejection alone outside the Tauri runtime", () => {
+    const cleanup = installCapture();
+    const { event, wasPrevented } = rejectionEvent(
+      new TypeError("Failed to fetch"),
+    );
+    listeners.get("unhandledrejection")?.(event);
+    assert.equal(wasPrevented(), false);
+    const [record] = getDiagnosticsSnapshot().records;
+    assert.equal(record.level, "error");
+    assert.equal(record.category, "runtime");
+    cleanup();
+  });
+
+  it("does not swallow a non-fetch rejection under Tauri", () => {
+    win.__TAURI_INTERNALS__ = {};
+    const cleanup = installCapture();
+    const { event, wasPrevented } = rejectionEvent(new Error("boom"));
+    listeners.get("unhandledrejection")?.(event);
+    assert.equal(wasPrevented(), false);
+    assert.equal(getDiagnosticsSnapshot().records[0]?.level, "error");
+    cleanup();
+  });
+
+  it("records but does not echo Tauri's IPC fallback warning", () => {
+    win.__TAURI_INTERNALS__ = {};
+    let echoed: unknown[] | null = null;
+    console.warn = (...args: unknown[]) => {
+      echoed = args;
+    };
+    const cleanup = installCapture();
+    console.warn(
+      "IPC custom protocol failed, Tauri will now use the postMessage interface instead",
+      new TypeError("Failed to fetch"),
+    );
+    assert.equal(echoed, null);
+    assert.equal(getDiagnosticsSnapshot().records[0]?.level, "warning");
+    cleanup();
+  });
+
+  it("still echoes ordinary warnings under Tauri", () => {
+    win.__TAURI_INTERNALS__ = {};
+    let echoed: unknown[] | null = null;
+    console.warn = (...args: unknown[]) => {
+      echoed = args;
+    };
+    const cleanup = installCapture();
+    console.warn("a normal warning");
+    assert.deepEqual(echoed, ["a normal warning"]);
+    cleanup();
   });
 });


### PR DESCRIPTION
Fixes #332.

## Root cause

On WebView2 149 (and some WKWebView builds) the **first** request to Tauri's custom IPC/asset protocols races scheme registration and fails with `TypeError: Failed to fetch`. Tauri's runtime-injected `ipc-protocol.js` logs a warning once, sets `customProtocolIpcFailed = true`, and **transparently retries every call over postMessage** — so the app keeps working and the map renders. All three startup diagnostics in the issue stem from this single transient.

| Item from issue | Verdict |
|------|---------|
| **#1** Tauri `console.warn` "IPC custom protocol failed…" | Benign; suppressible from JS |
| **#2** red `POST http://ipc.localhost/load_external_plugin_bundles` line | Emitted by WebView2's **network stack itself**, not JS — not suppressible from the frontend. The `invoke` is already `.catch`-handled in `usePlugins.ts`, so it is **not** a real uncaught JS error; the call succeeds via the postMessage fallback. |
| **#3** MapLibre `staticInitialize` unhandled rejection | Benign; `preventDefault()`-able |

There is no Tauri config lever to disable the custom-protocol IPC, so #2 cannot be removed from the web layer without hacking Tauri internals; it is harmless and is now captured in the in-app diagnostics panel.

## Change

Scoped entirely to the existing global handlers in `apps/geolibre-desktop/src/lib/diagnostics.ts`, gated on **desktop runtime + a 15s post-launch window** so genuine later failures are untouched. Everything is **still recorded** in the diagnostics panel — only the console echo is removed:

- **#3:** the `unhandledrejection` handler detects a benign startup fetch failure and calls `event.preventDefault()`, removing the `Uncaught (in promise) TypeError: Failed to fetch`.
- **#1:** the `console.warn` interceptor records Tauri's one-time IPC-fallback notice but no longer re-echoes it to the console.

## Tests

Added 5 cases in `tests/diagnostics.test.ts`: benign suppression under Tauri, no suppression outside Tauri, no suppression of non-fetch rejections, warn record-but-don't-echo, and a control that ordinary warnings still echo.

- `node --test tests/diagnostics.test.ts` → 12/12 pass
- `npm run test:frontend` → 654/654 pass
- `pre-commit run --files …` (eslint + full npm build) → pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop startup resilience by treating certain short-lived “fetch/load failed” errors as benign transients in the Tauri environment, preventing noisy unhandled rejection errors while still recording diagnostics.
  * Reduced misleading startup console noise (including specific runtime fallback warnings) by recording them for troubleshooting without unnecessarily echoing them early in startup.
* **Tests**
  * Added targeted automated coverage to verify transient suppression, diagnostics severity/category, and console warning/echo behavior across startup windows and non-benign cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->