### PR TITLE
fix(parquet): load Parquet with non-standard WKB geometry column (#336)

### DIFF
--- a/apps/geolibre-desktop/src/lib/duckdb-geometry.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-geometry.ts
@@ -59,9 +59,15 @@ export function detectGeometryColumn(
   if (typeof native === "string") {
     return { column: native, isWkb: false };
   }
+  // Require the WKB candidate to be a binary/blob type. Matching on name alone
+  // would route a same-named non-binary column (e.g. a VARCHAR "geometry")
+  // through ST_GeomFromWKB and surface an opaque DuckDB error instead of the
+  // clear "no geometry column" message callers expect.
   const wkb = description.find(
     (row) =>
       typeof row.column_name === "string" &&
+      typeof row.column_type === "string" &&
+      /^(BLOB|BINARY|VARBINARY)/i.test(row.column_type) &&
       WKB_GEOMETRY_COLUMN_NAMES.has(row.column_name.toLowerCase()),
   )?.column_name;
   if (typeof wkb === "string") {
@@ -82,18 +88,25 @@ export function geometryExpr(detected: DetectedGeometry): string {
 /**
  * Wrap a geometry SQL expression in ST_AsGeoJSON, transforming to WGS84 when a
  * source CRS is known.
+ *
+ * @param geometryExpression A fully-formed SQL expression for the geometry
+ *   value, e.g. `"geom"` or `ST_GeomFromWKB("geometry_wkb")` (use
+ *   {@link geometryExpr}). The caller owns identifier quoting; a bare column
+ *   name passed here produces broken SQL.
+ * @param sourceCrs The source CRS as `AUTHORITY:CODE`, or null to skip the
+ *   reprojection to WGS84.
  */
 export function geometryGeoJsonSql(
-  geometrySql: string,
+  geometryExpression: string,
   sourceCrs: string | null,
 ): string {
   if (!sourceCrs) {
-    return `ST_AsGeoJSON(${geometrySql})`;
+    return `ST_AsGeoJSON(${geometryExpression})`;
   }
   // Transform even for EPSG:4326 sources: always_xy=true normalises axis order
   // to lon/lat, which a no-op EPSG:4326 -> EPSG:4326 transform guarantees for
   // formats that may store data as lat/lon.
-  return `ST_AsGeoJSON(ST_Transform(${geometrySql}, ${quoteSqlString(
+  return `ST_AsGeoJSON(ST_Transform(${geometryExpression}, ${quoteSqlString(
     sourceCrs,
   )}, ${quoteSqlString(TARGET_CRS)}, true))`;
 }

--- a/apps/geolibre-desktop/src/lib/duckdb-geometry.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-geometry.ts
@@ -1,0 +1,99 @@
+// Pure SQL/geometry-column helpers shared by the DuckDB vector loader and the
+// GeoParquet writer. Kept free of `@duckdb/duckdb-wasm` (and its Vite `?url`
+// imports) so the detection logic can be unit-tested under plain Node.
+
+const TARGET_CRS = "EPSG:4326";
+
+// Well-known WKB geometry column names used when a Parquet input lacks a
+// GEOMETRY-typed column (e.g. plain Parquet carrying geometry as a WKB blob,
+// or a GeoParquet whose CRS metadata DuckDB cannot read). The geometry is
+// rebuilt with ST_GeomFromWKB so ST_AsGeoJSON / ST_Hilbert can use it.
+// Mirrors the sidecar's vector conversion fallback. See issue #336.
+export const WKB_GEOMETRY_COLUMN_NAMES = new Set([
+  "geometry",
+  "geom",
+  "wkb_geometry",
+  "geometry_wkb",
+  "geom_wkb",
+  "wkb",
+]);
+
+export function quoteSqlString(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+export function quoteIdentifier(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`;
+}
+
+// DuckDB Spatial reports CRS-annotated geometry types such as
+// GEOMETRY('EPSG:4326'), so match on the prefix rather than equality.
+export function isGeometryColumnType(columnType: unknown): boolean {
+  return (
+    typeof columnType === "string" &&
+    columnType.toUpperCase().startsWith("GEOMETRY")
+  );
+}
+
+export interface DetectedGeometry {
+  column: string;
+  /** True when the column is a raw WKB blob that needs ST_GeomFromWKB. */
+  isWkb: boolean;
+}
+
+/**
+ * Find the geometry column in a DESCRIBE result. Prefers a native GEOMETRY-typed
+ * column; otherwise falls back to a well-known WKB blob column name so plain
+ * Parquet files (and GeoParquet files DuckDB does not decode natively) load.
+ *
+ * @param description Rows from `DESCRIBE <query>` (column_name / column_type).
+ * @returns The detected geometry column and whether it is a raw WKB blob, or
+ *   null when no geometry column can be identified.
+ */
+export function detectGeometryColumn(
+  description: Record<string, unknown>[],
+): DetectedGeometry | null {
+  const native = description.find((row) =>
+    isGeometryColumnType(row.column_type),
+  )?.column_name;
+  if (typeof native === "string") {
+    return { column: native, isWkb: false };
+  }
+  const wkb = description.find(
+    (row) =>
+      typeof row.column_name === "string" &&
+      WKB_GEOMETRY_COLUMN_NAMES.has(row.column_name.toLowerCase()),
+  )?.column_name;
+  if (typeof wkb === "string") {
+    return { column: wkb, isWkb: true };
+  }
+  return null;
+}
+
+/**
+ * Build a SQL expression that yields the geometry to read. A native GEOMETRY
+ * column is referenced directly; a raw WKB blob is decoded with ST_GeomFromWKB.
+ */
+export function geometryExpr(detected: DetectedGeometry): string {
+  const column = quoteIdentifier(detected.column);
+  return detected.isWkb ? `ST_GeomFromWKB(${column})` : column;
+}
+
+/**
+ * Wrap a geometry SQL expression in ST_AsGeoJSON, transforming to WGS84 when a
+ * source CRS is known.
+ */
+export function geometryGeoJsonSql(
+  geometrySql: string,
+  sourceCrs: string | null,
+): string {
+  if (!sourceCrs) {
+    return `ST_AsGeoJSON(${geometrySql})`;
+  }
+  // Transform even for EPSG:4326 sources: always_xy=true normalises axis order
+  // to lon/lat, which a no-op EPSG:4326 -> EPSG:4326 transform guarantees for
+  // formats that may store data as lat/lon.
+  return `ST_AsGeoJSON(ST_Transform(${geometrySql}, ${quoteSqlString(
+    sourceCrs,
+  )}, ${quoteSqlString(TARGET_CRS)}, true))`;
+}

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -4,13 +4,28 @@ import ehWorker from "@duckdb/duckdb-wasm/dist/duckdb-browser-eh.worker.js?url";
 import duckdbWasmMvp from "@duckdb/duckdb-wasm/dist/duckdb-mvp.wasm?url";
 import mvpWorker from "@duckdb/duckdb-wasm/dist/duckdb-browser-mvp.worker.js?url";
 import type { Feature, FeatureCollection, Geometry } from "geojson";
+import {
+  detectGeometryColumn,
+  geometryExpr,
+  geometryGeoJsonSql,
+  isGeometryColumnType,
+  quoteIdentifier,
+  quoteSqlString,
+} from "./duckdb-geometry";
 import { ensureGpkgFeatureCount } from "./gpkg-ogr-contents";
 import { getSpatialExtensionPath } from "./spatial-extension-config";
+
+// Re-exported for existing importers (sql-workspace, geopackage-writer, etc.)
+// that reach for these helpers via this module.
+export {
+  isGeometryColumnType,
+  quoteIdentifier,
+  quoteSqlString,
+} from "./duckdb-geometry";
 
 const GEOMETRY_JSON_COLUMN = "__geolibre_geometry_geojson";
 const EXPORT_GEOJSON_EXTENSION = "geojson";
 const EXPORT_GEOPARQUET_EXTENSION = "parquet";
-const TARGET_CRS = "EPSG:4326";
 
 const MANUAL_BUNDLES: duckdb.DuckDBBundles = {
   mvp: {
@@ -142,14 +157,6 @@ async function createDatabase(): Promise<duckdb.AsyncDuckDB> {
   return db;
 }
 
-export function quoteSqlString(value: string): string {
-  return `'${value.replaceAll("'", "''")}'`;
-}
-
-export function quoteIdentifier(value: string): string {
-  return `"${value.replaceAll('"', '""')}"`;
-}
-
 function exportBaseName(): string {
   const suffix = Math.random().toString(36).slice(2);
   return `__geolibre_export_${Date.now()}_${suffix}`;
@@ -158,15 +165,6 @@ function exportBaseName(): string {
 export function rowsFromResult(result: { toArray: () => DuckDbRow[] }) {
   return result.toArray().map((row) =>
     typeof row.toJSON === "function" ? row.toJSON() : { ...row },
-  );
-}
-
-// DuckDB Spatial reports CRS-annotated geometry types such as
-// GEOMETRY('EPSG:4326'), so match on the prefix rather than equality.
-export function isGeometryColumnType(columnType: unknown): boolean {
-  return (
-    typeof columnType === "string" &&
-    columnType.toUpperCase().startsWith("GEOMETRY")
   );
 }
 
@@ -241,22 +239,6 @@ async function readSourceCrs(
   }
 }
 
-function geometryGeoJsonSql(
-  geometryColumn: string,
-  sourceCrs: string | null,
-): string {
-  const geometrySql = quoteIdentifier(geometryColumn);
-  if (!sourceCrs) {
-    return `ST_AsGeoJSON(${geometrySql})`;
-  }
-  // Transform even for EPSG:4326 sources: always_xy=true normalises axis order
-  // to lon/lat, which a no-op EPSG:4326 -> EPSG:4326 transform guarantees for
-  // formats that may store data as lat/lon.
-  return `ST_AsGeoJSON(ST_Transform(${geometrySql}, ${quoteSqlString(
-    sourceCrs,
-  )}, ${quoteSqlString(TARGET_CRS)}, true))`;
-}
-
 function toFeatureCollection(
   rows: Record<string, unknown>[],
 ): FeatureCollection<Geometry | null> {
@@ -320,16 +302,17 @@ export async function loadDuckDbVectorFile(
     const description = rowsFromResult(
       await connection.query(`DESCRIBE ${sql}`),
     );
-    const geometryColumn = description.find((row) =>
-      isGeometryColumnType(row.column_type),
-    )?.column_name;
+    const detected = detectGeometryColumn(description);
 
-    if (typeof geometryColumn !== "string") {
-      throw new Error("DuckDB did not find a GEOMETRY column in this file.");
+    if (!detected) {
+      throw new Error("DuckDB did not find a geometry column in this file.");
     }
 
     const sourceCrs = await readSourceCrs(connection, file);
-    const geometryJsonSql = geometryGeoJsonSql(geometryColumn, sourceCrs);
+    const geometryJsonSql = geometryGeoJsonSql(
+      geometryExpr(detected),
+      sourceCrs,
+    );
     const result = await connection.query(
       `SELECT *, ${geometryJsonSql} AS ${quoteIdentifier(
         GEOMETRY_JSON_COLUMN,
@@ -393,10 +376,6 @@ const GEOPARQUET_COMPRESSIONS = new Set([
 const DEFAULT_GEOPARQUET_COMPRESSION = "zstd";
 const DEFAULT_GEOPARQUET_ROW_GROUP_SIZE = 30000;
 
-// Well-known WKB geometry column names used when a plain Parquet input lacks
-// a GEOMETRY-typed column. Mirrors the sidecar's vector conversion fallback.
-const WKB_GEOMETRY_COLUMN_NAMES = new Set(["geometry", "geom", "wkb_geometry"]);
-
 /**
  * Convert an in-memory vector file to a Hilbert-sorted, compressed GeoParquet
  * entirely inside DuckDB-WASM. Rows are ordered by ST_Hilbert over the
@@ -447,28 +426,17 @@ export async function convertDuckDbVectorToGeoParquet(
       const description = rowsFromResult(
         await connection.query(`DESCRIBE ${sql}`),
       );
-      let detected = description.find((row) =>
-        isGeometryColumnType(row.column_type),
-      )?.column_name;
-      let geometryIsNative = true;
-      if (typeof detected !== "string") {
-        // Plain Parquet files may carry geometry as a WKB blob; rebuild it as a
-        // GEOMETRY column so ST_Hilbert and the GeoParquet writer can use it.
-        detected = description.find(
-          (row) =>
-            typeof row.column_name === "string" &&
-            WKB_GEOMETRY_COLUMN_NAMES.has(row.column_name.toLowerCase()),
-        )?.column_name as string | undefined;
-        geometryIsNative = false;
-      }
-      if (typeof detected !== "string") {
+      const detected = detectGeometryColumn(description);
+      if (!detected) {
         throw new Error("DuckDB did not find a geometry column in this file.");
       }
-      geometryColumn = detected;
+      geometryColumn = detected.column;
       const geometrySql = quoteIdentifier(geometryColumn);
-      source = geometryIsNative
-        ? sql
-        : `SELECT * REPLACE (ST_GeomFromWKB(${geometrySql}) AS ${geometrySql}) FROM (${sql}) AS data`;
+      // Plain Parquet files may carry geometry as a WKB blob; rebuild it as a
+      // GEOMETRY column so ST_Hilbert and the GeoParquet writer can use it.
+      source = detected.isWkb
+        ? `SELECT * REPLACE (ST_GeomFromWKB(${geometrySql}) AS ${geometrySql}) FROM (${sql}) AS data`
+        : sql;
     }
 
     const geometrySql = quoteIdentifier(geometryColumn);

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -15,7 +15,7 @@ import {
 import { ensureGpkgFeatureCount } from "./gpkg-ogr-contents";
 import { getSpatialExtensionPath } from "./spatial-extension-config";
 
-// Re-exported for existing importers (sql-workspace, geopackage-writer, etc.)
+// Re-exported for existing importers (sql-workspace, duckdb-processing, etc.)
 // that reach for these helpers via this module.
 export {
   isGeometryColumnType,

--- a/tests/duckdb-geometry.test.ts
+++ b/tests/duckdb-geometry.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  detectGeometryColumn,
+  geometryExpr,
+  geometryGeoJsonSql,
+  isGeometryColumnType,
+} from "../apps/geolibre-desktop/src/lib/duckdb-geometry";
+
+function describeRow(name: string, type: string) {
+  return { column_name: name, column_type: type };
+}
+
+describe("isGeometryColumnType", () => {
+  it("matches plain and CRS-annotated GEOMETRY types", () => {
+    assert.equal(isGeometryColumnType("GEOMETRY"), true);
+    assert.equal(isGeometryColumnType("geometry"), true);
+    assert.equal(isGeometryColumnType("GEOMETRY('EPSG:4326')"), true);
+  });
+
+  it("rejects non-geometry types", () => {
+    assert.equal(isGeometryColumnType("BLOB"), false);
+    assert.equal(isGeometryColumnType("VARCHAR"), false);
+    assert.equal(isGeometryColumnType(undefined), false);
+  });
+});
+
+describe("detectGeometryColumn", () => {
+  it("prefers a native GEOMETRY column", () => {
+    const detected = detectGeometryColumn([
+      describeRow("id", "BIGINT"),
+      describeRow("geom", "GEOMETRY"),
+    ]);
+    assert.deepEqual(detected, { column: "geom", isWkb: false });
+  });
+
+  it("prefers a native GEOMETRY column even when a WKB name exists", () => {
+    const detected = detectGeometryColumn([
+      describeRow("geometry_wkb", "BLOB"),
+      describeRow("the_geom", "GEOMETRY('EPSG:4326')"),
+    ]);
+    assert.deepEqual(detected, { column: "the_geom", isWkb: false });
+  });
+
+  it("falls back to a geometry_wkb blob column (issue #336)", () => {
+    const detected = detectGeometryColumn([
+      describeRow("id", "VARCHAR"),
+      describeRow("lat", "DOUBLE"),
+      describeRow("lon", "DOUBLE"),
+      describeRow("geometry_wkb", "BLOB"),
+    ]);
+    assert.deepEqual(detected, { column: "geometry_wkb", isWkb: true });
+  });
+
+  it("matches well-known WKB names case-insensitively", () => {
+    for (const name of [
+      "geometry",
+      "geom",
+      "wkb_geometry",
+      "GEOMETRY_WKB",
+      "Geom_WKB",
+      "WKB",
+    ]) {
+      const detected = detectGeometryColumn([
+        describeRow("id", "BIGINT"),
+        describeRow(name, "BLOB"),
+      ]);
+      assert.deepEqual(detected, { column: name, isWkb: true });
+    }
+  });
+
+  it("returns null when no geometry column is present", () => {
+    const detected = detectGeometryColumn([
+      describeRow("id", "BIGINT"),
+      describeRow("name", "VARCHAR"),
+    ]);
+    assert.equal(detected, null);
+  });
+});
+
+describe("geometryExpr", () => {
+  it("references a native geometry column directly", () => {
+    assert.equal(geometryExpr({ column: "geom", isWkb: false }), '"geom"');
+  });
+
+  it("decodes a WKB blob column with ST_GeomFromWKB", () => {
+    assert.equal(
+      geometryExpr({ column: "geometry_wkb", isWkb: true }),
+      'ST_GeomFromWKB("geometry_wkb")',
+    );
+  });
+
+  it("quotes identifiers safely", () => {
+    assert.equal(
+      geometryExpr({ column: 'odd"name', isWkb: false }),
+      '"odd""name"',
+    );
+  });
+});
+
+describe("geometryGeoJsonSql", () => {
+  it("emits ST_AsGeoJSON without a CRS transform when unknown", () => {
+    assert.equal(geometryGeoJsonSql('"geom"', null), 'ST_AsGeoJSON("geom")');
+  });
+
+  it("wraps the expression in ST_Transform when a source CRS is given", () => {
+    assert.equal(
+      geometryGeoJsonSql('ST_GeomFromWKB("geometry_wkb")', "EPSG:3857"),
+      `ST_AsGeoJSON(ST_Transform(ST_GeomFromWKB("geometry_wkb"), 'EPSG:3857', 'EPSG:4326', true))`,
+    );
+  });
+});

--- a/tests/duckdb-geometry.test.ts
+++ b/tests/duckdb-geometry.test.ts
@@ -69,6 +69,25 @@ describe("detectGeometryColumn", () => {
     }
   });
 
+  it("matches VARBINARY/BINARY WKB columns", () => {
+    assert.deepEqual(
+      detectGeometryColumn([describeRow("geom", "VARBINARY")]),
+      { column: "geom", isWkb: true },
+    );
+    assert.deepEqual(detectGeometryColumn([describeRow("wkb", "BINARY")]), {
+      column: "wkb",
+      isWkb: true,
+    });
+  });
+
+  it("ignores a WKB-named column that is not a binary type", () => {
+    const detected = detectGeometryColumn([
+      describeRow("id", "BIGINT"),
+      describeRow("geometry", "VARCHAR"),
+    ]);
+    assert.equal(detected, null);
+  });
+
   it("returns null when no geometry column is present", () => {
     const detected = detectGeometryColumn([
       describeRow("id", "BIGINT"),


### PR DESCRIPTION
## Summary

Fixes #336. Loading a GeoParquet/Parquet file failed when the geometry column was stored as a WKB blob under a name other than the DuckDB default (the reporter's column was `geometry_wkb`).

`loadDuckDbVectorFile` only detected native `GEOMETRY`-typed columns and threw `DuckDB did not find a GEOMETRY column in this file.` otherwise. The GeoParquet writer (`convertDuckDbVectorToGeoParquet`) already carried a WKB-blob fallback, but the loader did not, so these files could never be added to the map.

## Changes

- Extract the geometry-column detection and SQL builders into a new pure `apps/geolibre-desktop/src/lib/duckdb-geometry.ts` module shared by the loader and the writer (no `@duckdb/duckdb-wasm` `?url` imports, so it is unit-testable under plain Node).
- Broaden the well-known WKB geometry column names to include `geometry_wkb`, `geom_wkb`, and `wkb` (in addition to `geometry`, `geom`, `wkb_geometry`).
- On the load path, decode WKB blob columns with `ST_GeomFromWKB` before `ST_AsGeoJSON`, mirroring the writer.
- Native `GEOMETRY` columns are still preferred when present, so existing behavior is unchanged.

## Tests

- New `tests/duckdb-geometry.test.ts` covers native vs WKB detection, case-insensitive name matching, the `geometry_wkb` case from the issue, identifier quoting, and CRS-transform SQL.
- Full frontend suite passes (661 tests). `pre-commit run --files ...` (including the npm build) passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Features**
  * Enhanced DuckDB vector import/export by improving geometry column detection, including automatic fallback for WKB-encoded geometries.
  * GeoJSON generation now correctly handles optional source CRS by applying reprojection when provided.

* **Refactor**
  * Centralized geometry SQL helper logic to consistently produce safe, correct geometry expressions across import and conversion flows.

* **Tests**
  * Added comprehensive automated tests for geometry detection and SQL generation, including CRS and quoting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->