### PR TITLE
perf(attribute-table): virtualize rows for large layers (#338)

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -39,6 +39,7 @@
     "@osmix/geojson": "^0.0.13",
     "@osmix/pbf": "^0.0.9",
     "@strands-agents/sdk": "^1.3.0",
+    "@tanstack/react-virtual": "^3.14.2",
     "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-fs": "^2.5.1",

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -33,6 +33,7 @@ import {
   TableHeader,
   TableRow,
 } from "@geolibre/ui";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import type { Feature, FeatureCollection } from "geojson";
 import {
   ArrowDown,
@@ -113,6 +114,10 @@ const MIN_FEATURE_ID_COLUMN_WIDTH = 48;
 const MAX_FEATURE_ID_COLUMN_WIDTH = 180;
 const MIN_ATTRIBUTE_COLUMN_WIDTH = 72;
 const MAX_ATTRIBUTE_COLUMN_WIDTH = 520;
+// Estimated row height used to size the virtualizer before real rows are
+// measured. View-mode rows are ~37px; edit-mode rows (with an Input) are taller
+// and are corrected by measureElement once rendered.
+const ESTIMATED_ROW_HEIGHT = 37;
 const DEFAULT_TABLE_HEIGHT = 192;
 const MIN_TABLE_HEIGHT = 96;
 const MAX_TABLE_HEIGHT = 520;
@@ -248,6 +253,8 @@ interface AttributeTableProps {
 export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
   const tableSectionRef = useRef<HTMLElement>(null);
   const tableResizeGuideRef = useRef<HTMLDivElement>(null);
+  // The Radix ScrollArea viewport, used as the virtualizer's scroll container.
+  const scrollViewportRef = useRef<HTMLDivElement>(null);
   const selectedLayerId = useAppStore((s) => s.selectedLayerId);
   const layers = useAppStore((s) => s.layers);
   const attributeFilter = useAppStore((s) => s.attributeFilter);
@@ -416,6 +423,21 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     setCalcSelectedOnly(false);
   }, [selectedLayerId, hasLayer, isGeometryEditing]);
 
+  // Bring the selected feature's row into view. With virtualization the row may
+  // be unmounted (e.g. when a feature is picked on the map), so a plain CSS
+  // highlight would be invisible; scroll the virtualizer to it instead. "auto"
+  // alignment leaves an already-visible row untouched.
+  useEffect(() => {
+    if (!selectedFeatureId) return;
+    const index = sorted.findIndex(
+      (row) => row.featureId === selectedFeatureId,
+    );
+    if (index >= 0) rowVirtualizer.scrollToIndex(index, { align: "auto" });
+    // `sorted`/`rowVirtualizer` are rebuilt every render; depend only on the
+    // selection (and the layer, so a layer switch re-runs against fresh rows).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedFeatureId, selectedLayerId]);
+
   // If the selected feature is cleared while the calculator is open, drop the
   // "selected only" flag too: leaving it checked-but-disabled would mislead the
   // user, and the submit guard would silently widen the scope to all features.
@@ -441,6 +463,29 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     const result = compareAttributeValues(aValue, bValue);
     return sort.direction === "asc" ? result : -result;
   });
+
+  // Row virtualization: only the rows in (and just around) the viewport are
+  // mounted, so opening the table on a layer with tens of thousands of features
+  // no longer builds that many DOM nodes at once. Sorting/filtering above still
+  // operate over the full data model; the virtualizer only governs rendering.
+  const rowVirtualizer = useVirtualizer({
+    count: sorted.length,
+    getScrollElement: () => scrollViewportRef.current,
+    estimateSize: () => ESTIMATED_ROW_HEIGHT,
+    // Key by feature id so measured heights stay attached to the right row when
+    // the sort/filter reorders the list.
+    getItemKey: (index) => sorted[index]?.featureId ?? index,
+    overscan: 12,
+  });
+  const virtualRows = rowVirtualizer.getVirtualItems();
+  const virtualTotalSize = rowVirtualizer.getTotalSize();
+  // Spacer rows above/below the rendered window reserve the scroll height of the
+  // off-screen rows while keeping the native <table> column layout intact.
+  const paddingTop = virtualRows.length > 0 ? virtualRows[0].start : 0;
+  const paddingBottom =
+    virtualRows.length > 0
+      ? virtualTotalSize - virtualRows[virtualRows.length - 1].end
+      : 0;
 
   const propKeys = new Set<string>();
   for (const row of attributeRows) {
@@ -1396,6 +1441,7 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
       */}
       <ScrollArea
         type="always"
+        viewportRef={scrollViewportRef}
         className="flex-1 [&_[data-orientation=vertical]]:!top-11 [&_[data-orientation=vertical]]:!h-[calc(100%-3.625rem)]"
       >
         {!hasAttributeSource ? (
@@ -1428,11 +1474,19 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {sorted.map(({ featureId, properties }) => {
+              {paddingTop > 0 ? (
+                <tr aria-hidden="true">
+                  <td colSpan={tableColumns.length} style={{ height: paddingTop }} />
+                </tr>
+              ) : null}
+              {virtualRows.map((virtualRow) => {
+                const { featureId, properties } = sorted[virtualRow.index];
                 const selected = selectedFeatureId === featureId;
                 return (
                   <TableRow
                     key={featureId}
+                    data-index={virtualRow.index}
+                    ref={rowVirtualizer.measureElement}
                     data-state={selected ? "selected" : undefined}
                     className="cursor-pointer"
                     onClick={() => {
@@ -1486,6 +1540,14 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
                   </TableRow>
                 );
               })}
+              {paddingBottom > 0 ? (
+                <tr aria-hidden="true">
+                  <td
+                    colSpan={tableColumns.length}
+                    style={{ height: paddingBottom }}
+                  />
+                </tr>
+              ) : null}
             </TableBody>
           </table>
         )}

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -477,8 +477,10 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
   // be unmounted (e.g. when a feature is picked on the map), so a plain CSS
   // highlight would be invisible; scroll the virtualizer to it instead. "auto"
   // alignment leaves an already-visible row untouched. Re-runs when the table
-  // opens (the viewport is null while closed, so scrollToIndex is a no-op then)
-  // and when the sort changes (which can move the selected row off-screen).
+  // opens (the viewport is null while closed, so scrollToIndex is a no-op then),
+  // when the sort changes (which can move the selected row off-screen), and when
+  // the row count changes — so the scroll fires once rows materialize
+  // asynchronously (Add Vector Layer layers) and after a filter is cleared.
   useEffect(() => {
     if (!attributeTableOpen || !selectedFeatureId) return;
     const index = sorted.findIndex(
@@ -486,10 +488,17 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     );
     if (index >= 0) rowVirtualizer.scrollToIndex(index, { align: "auto" });
     // `sorted`/`rowVirtualizer` are rebuilt every render and so are intentionally
-    // excluded; the effect re-runs on the selection/layer/open/sort changes that
-    // actually warrant a scroll.
+    // excluded; `sorted.length` is a primitive that stands in for "the row set
+    // changed". The effect re-runs only on the selection/layer/open/sort/count
+    // changes that actually warrant a scroll.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedFeatureId, selectedLayerId, attributeTableOpen, sort]);
+  }, [
+    selectedFeatureId,
+    selectedLayerId,
+    attributeTableOpen,
+    sort,
+    sorted.length,
+  ]);
 
   const propKeys = new Set<string>();
   for (const row of attributeRows) {

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -423,21 +423,6 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     setCalcSelectedOnly(false);
   }, [selectedLayerId, hasLayer, isGeometryEditing]);
 
-  // Bring the selected feature's row into view. With virtualization the row may
-  // be unmounted (e.g. when a feature is picked on the map), so a plain CSS
-  // highlight would be invisible; scroll the virtualizer to it instead. "auto"
-  // alignment leaves an already-visible row untouched.
-  useEffect(() => {
-    if (!selectedFeatureId) return;
-    const index = sorted.findIndex(
-      (row) => row.featureId === selectedFeatureId,
-    );
-    if (index >= 0) rowVirtualizer.scrollToIndex(index, { align: "auto" });
-    // `sorted`/`rowVirtualizer` are rebuilt every render; depend only on the
-    // selection (and the layer, so a layer switch re-runs against fresh rows).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedFeatureId, selectedLayerId]);
-
   // If the selected feature is cleared while the calculator is open, drop the
   // "selected only" flag too: leaving it checked-but-disabled would mislead the
   // user, and the submit guard would silently widen the scope to all features.
@@ -473,8 +458,9 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     getScrollElement: () => scrollViewportRef.current,
     estimateSize: () => ESTIMATED_ROW_HEIGHT,
     // Key by feature id so measured heights stay attached to the right row when
-    // the sort/filter reorders the list.
-    getItemKey: (index) => sorted[index]?.featureId ?? index,
+    // the sort/filter reorders the list. getItemKey is only called with indices
+    // in [0, count), so sorted[index] is always defined.
+    getItemKey: (index) => sorted[index].featureId,
     overscan: 12,
   });
   const virtualRows = rowVirtualizer.getVirtualItems();
@@ -486,6 +472,24 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     virtualRows.length > 0
       ? virtualTotalSize - virtualRows[virtualRows.length - 1].end
       : 0;
+
+  // Bring the selected feature's row into view. With virtualization the row may
+  // be unmounted (e.g. when a feature is picked on the map), so a plain CSS
+  // highlight would be invisible; scroll the virtualizer to it instead. "auto"
+  // alignment leaves an already-visible row untouched. Re-runs when the table
+  // opens (the viewport is null while closed, so scrollToIndex is a no-op then)
+  // and when the sort changes (which can move the selected row off-screen).
+  useEffect(() => {
+    if (!attributeTableOpen || !selectedFeatureId) return;
+    const index = sorted.findIndex(
+      (row) => row.featureId === selectedFeatureId,
+    );
+    if (index >= 0) rowVirtualizer.scrollToIndex(index, { align: "auto" });
+    // `sorted`/`rowVirtualizer` are rebuilt every render and so are intentionally
+    // excluded; the effect re-runs on the selection/layer/open/sort changes that
+    // actually warrant a scroll.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedFeatureId, selectedLayerId, attributeTableOpen, sort]);
 
   const propKeys = new Set<string>();
   for (const row of attributeRows) {

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -461,7 +461,11 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     // the sort/filter reorders the list. getItemKey is only called with indices
     // in [0, count), so sorted[index] is always defined.
     getItemKey: (index) => sorted[index].featureId,
-    overscan: 12,
+    // A small cushion of off-screen rows: enough to cover the sticky header's
+    // ~1-row offset (the virtualizer measures from the scroll container top) and
+    // to avoid blank gaps during fast scrolling, without keeping many extra rows
+    // mounted.
+    overscan: 8,
   });
   const virtualRows = rowVirtualizer.getVirtualItems();
   const virtualTotalSize = rowVirtualizer.getTotalSize();
@@ -476,11 +480,13 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
   // Bring the selected feature's row into view. With virtualization the row may
   // be unmounted (e.g. when a feature is picked on the map), so a plain CSS
   // highlight would be invisible; scroll the virtualizer to it instead. "auto"
-  // alignment leaves an already-visible row untouched. Re-runs when the table
-  // opens (the viewport is null while closed, so scrollToIndex is a no-op then),
-  // when the sort changes (which can move the selected row off-screen), and when
-  // the row count changes — so the scroll fires once rows materialize
-  // asynchronously (Add Vector Layer layers) and after a filter is cleared.
+  // alignment leaves an already-visible row untouched, so this stays unobtrusive
+  // even when it re-runs on every filter keystroke. Re-runs when the table opens
+  // (the viewport is null while closed, so scrollToIndex is a no-op then), when
+  // the sort changes, when the row count changes (so the scroll fires once rows
+  // materialize asynchronously for Add Vector Layer layers), and when the filter
+  // text changes (two different filters can yield the same row count yet a
+  // different position for the selected row).
   useEffect(() => {
     if (!attributeTableOpen || !selectedFeatureId) return;
     const index = sorted.findIndex(
@@ -488,9 +494,8 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     );
     if (index >= 0) rowVirtualizer.scrollToIndex(index, { align: "auto" });
     // `sorted`/`rowVirtualizer` are rebuilt every render and so are intentionally
-    // excluded; `sorted.length` is a primitive that stands in for "the row set
-    // changed". The effect re-runs only on the selection/layer/open/sort/count
-    // changes that actually warrant a scroll.
+    // excluded; the dependencies below are the inputs that actually change which
+    // row (if any) the selected feature occupies and warrant a re-scroll.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     selectedFeatureId,
@@ -498,6 +503,7 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     attributeTableOpen,
     sort,
     sorted.length,
+    attributeFilter,
   ]);
 
   const propKeys = new Set<string>();

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "@osmix/geojson": "^0.0.13",
         "@osmix/pbf": "^0.0.9",
         "@strands-agents/sdk": "^1.3.0",
+        "@tanstack/react-virtual": "^3.14.2",
         "@tauri-apps/api": "^2.11.0",
         "@tauri-apps/plugin-dialog": "^2.7.1",
         "@tauri-apps/plugin-fs": "^2.5.1",
@@ -8327,6 +8328,33 @@
         "@tailwindcss/oxide": "4.3.0",
         "postcss": "^8.5.10",
         "tailwindcss": "4.3.0"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.2.tgz",
+      "integrity": "sha512-IpWnmCLvuymRfeeLNVXIzNEYBFLpd3drVIS91sqV78VTZFyldlChkOocZRCPp1B+Wnk09bcLNme8WaMU/9/9bQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.0.tgz",
+      "integrity": "sha512-gOxY/hFkPh/XQYhnThBHzkbkX3Ed+z/iushyz+R+JAr213aXxUDgQoTgTdrDpBSRsjFM73P/KfUyWmaF9WHMkQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tauri-apps/api": {

--- a/packages/ui/src/components/scroll-area.tsx
+++ b/packages/ui/src/components/scroll-area.tsx
@@ -2,16 +2,29 @@ import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
 import * as React from "react";
 import { cn } from "../lib/utils";
 
+export type ScrollAreaProps = React.ComponentPropsWithoutRef<
+  typeof ScrollAreaPrimitive.Root
+> & {
+  /**
+   * Ref to the scrollable viewport element. Exposed so consumers (e.g. a
+   * virtualized list) can use it as their scroll container.
+   */
+  viewportRef?: React.Ref<HTMLDivElement>;
+};
+
 export const ScrollArea = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
->(({ className, children, ...props }, ref) => (
+  ScrollAreaProps
+>(({ className, children, viewportRef, ...props }, ref) => (
   <ScrollAreaPrimitive.Root
     ref={ref}
     className={cn("relative overflow-hidden", className)}
     {...props}
   >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+    <ScrollAreaPrimitive.Viewport
+      ref={viewportRef}
+      className="h-full w-full rounded-[inherit]"
+    >
       {children}
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />

--- a/packages/ui/src/components/scroll-area.tsx
+++ b/packages/ui/src/components/scroll-area.tsx
@@ -7,9 +7,11 @@ export type ScrollAreaProps = React.ComponentPropsWithoutRef<
 > & {
   /**
    * Ref to the scrollable viewport element. Exposed so consumers (e.g. a
-   * virtualized list) can use it as their scroll container.
+   * virtualized list) can use it as their scroll container. Typed as a
+   * RefObject because that is what scroll-container consumers need (a callback
+   * ref would not give them a stable element to read).
    */
-  viewportRef?: React.Ref<HTMLDivElement>;
+  viewportRef?: React.RefObject<HTMLDivElement | null>;
 };
 
 export const ScrollArea = React.forwardRef<

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -6,7 +6,7 @@ export { Select } from "./components/select";
 export { Label } from "./components/label";
 export { Slider } from "./components/slider";
 export { Separator } from "./components/separator";
-export { ScrollArea } from "./components/scroll-area";
+export { ScrollArea, type ScrollAreaProps } from "./components/scroll-area";
 export {
   Dialog,
   DialogTrigger,


### PR DESCRIPTION
## Summary

Closes #338.

The attribute table rendered one `<tr>` per feature with no virtualization (`AttributeTable.tsx` mapped every row in `sorted`), so opening it on a layer with tens of thousands of features built that many DOM nodes synchronously and froze the UI.

This adds row virtualization with `@tanstack/react-virtual`: only the rows in (and just around) the viewport are mounted. Spacer `<tr>` rows above and below the rendered window reserve the scroll height of the off-screen rows, which keeps the native `<table>` layout, sticky header, `colgroup` widths, and column resize all working unchanged. Sort and filter continue to operate over the full data model, not the DOM.

## Changes

- **`@geolibre/ui` ScrollArea**: expose the Radix viewport via a new optional `viewportRef` prop so a virtualized child can use it as its scroll container. (Existing usages are unaffected.)
- **`AttributeTable`**: virtualize the body rows with `useVirtualizer`, keyed by feature id so measured heights follow rows across re-sorts; rows are measured dynamically (`measureElement`) so edit-mode (taller `Input`) and view-mode rows are sized correctly.
- **Scroll-to-selection**: a map-driven feature selection may target an unmounted row, so the selected row is scrolled into view (`align: "auto"`, leaving an already-visible row untouched).
- Add `@tanstack/react-virtual` to `geolibre-desktop`.

## Testing

- `npm run build` — passes
- `npm run test:frontend` — 698/698 pass
- `npx playwright test e2e/smoke.spec.ts` — passes (the smoke test asserts the rendered `tbody tr` count; small layers render with no spacer rows)
- `pre-commit run --files ...` — passes

## Real-app verification

Drove the running dev server in a browser (Playwright) with real public data: the **US Counties GeoJSON** (`plotly/datasets`, 3221 features), dropped onto the map via the real drag-and-drop pipeline. Known-truth values were computed independently from the file.

| Check | Result | Against known truth |
|---|---|---|
| **Virtualization** | Only **16 data rows** (+1 spacer `<tr>`) in the DOM | vs 3221 features — windowed, not all materialized |
| **Full count preserved** | reserved scroll height ÷ measured row height = **3221** | = 3221 counties |
| **Scroll** | scrolling to the bottom swapped Alabama (`01xxx`) for Puerto Rico, last row `72153` | = true max FIPS |
| **Sort (over full model)** | NAME asc top = **Abbeville**, desc top = **Ziebach** (sort arrow flips) | = true global first/last names |
| **Filter** | "Yellowstone" → **1** row; "Washington" → **31**; cleared → **3221** | = 1 / 31 / 3221 |

Sort and filter surfaced global extremes and exact counts that are not present in the rendered 16-row window, confirming both operate over the full data model while only visible rows are mounted. No console errors during the session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `viewportRef` to the Scroll Area component so consumers can access the underlying scroll viewport.
* **Performance**
  * Improved attribute table rendering by virtualizing rows to reduce work while maintaining correct total scroll height.
* **User Experience**
  * The attribute table now keeps the selected row in view when the table opens and when selection/sorting changes.
* **Chores**
  * Added `@tanstack/react-virtual` to support row virtualization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
