### PR TITLE
feat(map): client-side vector tiling for large local vector layers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24122,6 +24122,8 @@
       "version": "1.2.0",
       "dependencies": {
         "@geolibre/core": "*",
+        "@maplibre/geojson-vt": "^6.1.0",
+        "@maplibre/vt-pbf": "^4.3.0",
         "@turf/bbox": "^7.3.5",
         "@turf/helpers": "^7.3.5",
         "maplibre-gl": "^5.24.0",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -173,6 +173,31 @@ export function styleValue<K extends keyof LayerStyle>(
   return style[key] ?? DEFAULT_LAYER_STYLE[key];
 }
 
+/**
+ * Feature-count threshold above which a local vector (GeoJSON) layer is rendered
+ * through client-side vector tiles (geojson-vt / supercluster served by a custom
+ * MapLibre protocol) instead of one in-memory geojson source pushed via
+ * `setData`. Small layers stay on the simpler inline path. Mirrors the
+ * `MAX_CEREUS_FEATURES` precedent in the desktop SQL engine.
+ */
+export const LARGE_VECTOR_FEATURE_THRESHOLD = 50_000;
+
+/**
+ * Decide whether a GeoJSON layer should use the tiled rendering path.
+ *
+ * @param geojson - The layer's feature collection (may be undefined for
+ *   non-vector layers).
+ * @returns `true` when the collection exceeds
+ *   {@link LARGE_VECTOR_FEATURE_THRESHOLD} features.
+ */
+export function shouldUseTiledRendering(
+  geojson: GeoJSON.FeatureCollection | undefined,
+): boolean {
+  return (
+    (geojson?.features.length ?? 0) > LARGE_VECTOR_FEATURE_THRESHOLD
+  );
+}
+
 export interface GeoLibreLayer {
   id: string;
   name: string;

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -10,6 +10,8 @@
   },
   "dependencies": {
     "@geolibre/core": "*",
+    "@maplibre/geojson-vt": "^6.1.0",
+    "@maplibre/vt-pbf": "^4.3.0",
     "@turf/bbox": "^7.3.5",
     "@turf/helpers": "^7.3.5",
     "maplibre-gl": "^5.24.0",

--- a/packages/map/src/geojson-vt-protocol.ts
+++ b/packages/map/src/geojson-vt-protocol.ts
@@ -29,8 +29,11 @@ export const TILE_SOURCE_LAYER = "data";
 /** Tile extent shared by the index builders and the MVT encoder. */
 const TILE_EXTENT = 4096;
 
-/** Highest zoom the tile index is built for; MapLibre over-zooms beyond it. */
-const TILE_MAX_ZOOM = 16;
+/**
+ * Highest zoom the tile index is built for; MapLibre over-zooms beyond it.
+ * Exported so the vector source's `maxzoom` in `layer-sync.ts` cannot drift.
+ */
+export const TILE_MAX_ZOOM = 16;
 
 interface TileIndex {
   getTile(z: number, x: number, y: number): GeoJSONVTTile | null;
@@ -115,9 +118,14 @@ export function unregisterGeoJsonVtSource(layerId: string): void {
   registry.delete(layerId);
 }
 
+/** Whether a tile index is currently registered for this layer. */
+export function hasGeoJsonVtSource(layerId: string): boolean {
+  return registry.has(layerId);
+}
+
 /** The `tiles` template for a layer's vector source. */
 export function geojsonVtTileUrl(layerId: string): string {
-  return `${GEOJSONVT_PROTOCOL}://${layerId}/{z}/{x}/{y}`;
+  return `${GEOJSONVT_PROTOCOL}://${encodeURIComponent(layerId)}/{z}/{x}/{y}`;
 }
 
 /**
@@ -138,22 +146,30 @@ async function geojsonVtProtocolHandler(
 ): Promise<{ data: ArrayBuffer }> {
   const tile = lookupTile(params.url);
   if (!tile) return { data: new ArrayBuffer(0) };
-  // vt-pbf bundles an older geojson-vt whose tile type differs nominally from
-  // ours; the shapes are runtime-compatible, so cast at the encode boundary.
-  const pbf = fromGeojsonVt(
-    { [TILE_SOURCE_LAYER]: tile } as unknown as Parameters<
-      typeof fromGeojsonVt
-    >[0],
-    { version: 2, extent: TILE_EXTENT },
-  );
-  // Hand MapLibre an exactly-sized ArrayBuffer; `pbf` may be a view into a
-  // larger backing buffer.
-  return {
-    data: pbf.buffer.slice(
-      pbf.byteOffset,
-      pbf.byteOffset + pbf.byteLength,
-    ) as ArrayBuffer,
-  };
+  try {
+    // vt-pbf bundles an older geojson-vt whose tile type differs nominally from
+    // ours; the shapes are runtime-compatible, so cast at the encode boundary.
+    // The try-catch guards against that compatibility ever breaking (a future
+    // vt-pbf release) — return an empty tile rather than leaving MapLibre with
+    // an unhandled rejection that silently blanks the whole layer.
+    const pbf = fromGeojsonVt(
+      { [TILE_SOURCE_LAYER]: tile } as unknown as Parameters<
+        typeof fromGeojsonVt
+      >[0],
+      { version: 2, extent: TILE_EXTENT },
+    );
+    // Hand MapLibre an exactly-sized ArrayBuffer; `pbf` may be a view into a
+    // larger backing buffer.
+    return {
+      data: pbf.buffer.slice(
+        pbf.byteOffset,
+        pbf.byteOffset + pbf.byteLength,
+      ) as ArrayBuffer,
+    };
+  } catch (err) {
+    console.warn("[GeoLibre] geojson-vt tile encode failed", err);
+    return { data: new ArrayBuffer(0) };
+  }
 }
 
 // Parse `geolibre-gjvt://<layerId>/<z>/<x>/<y>` and return the encoded tile, or
@@ -162,7 +178,12 @@ function lookupTile(url: string): GeoJSONVTTile | null {
   const path = url.slice(`${GEOJSONVT_PROTOCOL}://`.length);
   const slash = path.indexOf("/");
   if (slash < 0) return null;
-  const layerId = path.slice(0, slash);
+  let layerId: string;
+  try {
+    layerId = decodeURIComponent(path.slice(0, slash));
+  } catch {
+    return null;
+  }
   const [z, x, y] = path
     .slice(slash + 1)
     .split("/")

--- a/packages/map/src/geojson-vt-protocol.ts
+++ b/packages/map/src/geojson-vt-protocol.ts
@@ -97,6 +97,9 @@ export function registerGeoJsonVtSource(
       radius: options.clusterRadius,
       maxZoom: options.clusterMaxZoom,
       extent: TILE_EXTENT,
+      // Match MapLibre's GeoJSON source clustering default so the tiled and
+      // inline (native) clustering paths aggregate at the same point count.
+      minPoints: 2,
     });
     cluster.load(points);
     index = cluster;
@@ -143,9 +146,13 @@ export function ensureGeoJsonVtProtocol(): void {
 
 async function geojsonVtProtocolHandler(
   params: RequestParameters,
+  abortController?: AbortController,
 ): Promise<{ data: ArrayBuffer }> {
   const tile = lookupTile(params.url);
   if (!tile) return { data: new ArrayBuffer(0) };
+  // MapLibre cancels tiles scrolled off-screen; skip the CPU-heavy encode when
+  // the request was already aborted (the result would be discarded anyway).
+  if (abortController?.signal.aborted) return { data: new ArrayBuffer(0) };
   try {
     // vt-pbf bundles an older geojson-vt whose tile type differs nominally from
     // ours; the shapes are runtime-compatible, so cast at the encode boundary.

--- a/packages/map/src/geojson-vt-protocol.ts
+++ b/packages/map/src/geojson-vt-protocol.ts
@@ -1,0 +1,180 @@
+// Client-side vector tiling for large local vector layers.
+//
+// Above a feature-count threshold (see `shouldUseTiledRendering` in
+// `@geolibre/core`), a local GeoJSON layer is rendered through vector tiles
+// generated in-browser rather than one in-memory geojson source pushed via
+// `setData`. We build a `GeoJSONVT` index (or a `Supercluster` index for
+// clustered point layers — both ship in `@maplibre/geojson-vt`, the same engine
+// MapLibre uses internally), encode requested tiles to MVT with `vt-pbf`, and
+// serve them through a custom MapLibre protocol — mirroring the pmtiles/mbtiles
+// `type:"vector"` pattern already used in `layer-sync.ts`.
+
+import { addProtocol, config, type RequestParameters } from "maplibre-gl";
+import {
+  GeoJSONVT,
+  Supercluster,
+  type GeoJSONVTTile,
+} from "@maplibre/geojson-vt";
+import { fromGeojsonVt } from "@maplibre/vt-pbf";
+
+/** Custom protocol scheme handled by {@link ensureGeoJsonVtProtocol}. */
+export const GEOJSONVT_PROTOCOL = "geolibre-gjvt";
+
+/**
+ * The single source-layer name carried by every generated tile. Render layers
+ * created in `layer-sync.ts` reference this via their `source-layer` key.
+ */
+export const TILE_SOURCE_LAYER = "data";
+
+/** Tile extent shared by the index builders and the MVT encoder. */
+const TILE_EXTENT = 4096;
+
+/** Highest zoom the tile index is built for; MapLibre over-zooms beyond it. */
+const TILE_MAX_ZOOM = 16;
+
+interface TileIndex {
+  getTile(z: number, x: number, y: number): GeoJSONVTTile | null;
+}
+
+interface RegistryEntry {
+  index: TileIndex;
+  /** Reference to the geojson last indexed — used to detect data changes. */
+  geojsonRef: GeoJSON.FeatureCollection;
+  cluster: boolean;
+  clusterRadius: number;
+  clusterMaxZoom: number;
+}
+
+// Keyed by layer id. Module-level rather than on the Zustand record because tile
+// indexes are large, non-serializable objects that must not enter app state or
+// be written to `.geolibre.json`.
+const registry = new Map<string, RegistryEntry>();
+
+export interface GeoJsonVtSourceOptions {
+  cluster: boolean;
+  clusterRadius: number;
+  clusterMaxZoom: number;
+}
+
+/**
+ * Build (or rebuild) the tile index backing a layer's vector source.
+ *
+ * Rebuilds only when there is no existing index, the underlying GeoJSON object
+ * reference changed (the store replaces it on edits), or the clustering
+ * configuration changed.
+ *
+ * @param layerId - The owning layer's id.
+ * @param geojson - The full feature collection to index.
+ * @param options - Clustering configuration for point layers.
+ * @returns `true` when the index was (re)built, so the caller can refresh the
+ *   MapLibre source to evict cached tiles; `false` when reused as-is.
+ */
+export function registerGeoJsonVtSource(
+  layerId: string,
+  geojson: GeoJSON.FeatureCollection,
+  options: GeoJsonVtSourceOptions,
+): boolean {
+  const existing = registry.get(layerId);
+  const unchanged =
+    existing !== undefined &&
+    existing.geojsonRef === geojson &&
+    existing.cluster === options.cluster &&
+    existing.clusterRadius === options.clusterRadius &&
+    existing.clusterMaxZoom === options.clusterMaxZoom;
+  if (unchanged) return false;
+
+  let index: TileIndex;
+  if (options.cluster) {
+    // Supercluster handles points only; non-point features are dropped from a
+    // clustered point layer, matching MapLibre's source-level clustering.
+    const points = geojson.features.filter(
+      (feature) => feature.geometry?.type === "Point",
+    ) as Array<GeoJSON.Feature<GeoJSON.Point>>;
+    const cluster = new Supercluster({
+      radius: options.clusterRadius,
+      maxZoom: options.clusterMaxZoom,
+      extent: TILE_EXTENT,
+    });
+    cluster.load(points);
+    index = cluster;
+  } else {
+    index = new GeoJSONVT(geojson, {
+      maxZoom: TILE_MAX_ZOOM,
+      extent: TILE_EXTENT,
+      buffer: 64,
+      tolerance: 3,
+    });
+  }
+
+  registry.set(layerId, { index, geojsonRef: geojson, ...options });
+  return true;
+}
+
+/** Drop a layer's tile index. Safe to call when none is registered. */
+export function unregisterGeoJsonVtSource(layerId: string): void {
+  registry.delete(layerId);
+}
+
+/** The `tiles` template for a layer's vector source. */
+export function geojsonVtTileUrl(layerId: string): string {
+  return `${GEOJSONVT_PROTOCOL}://${layerId}/{z}/{x}/{y}`;
+}
+
+/**
+ * Register the custom protocol once. Re-registers after `setStyle()` clears
+ * MapLibre's protocol table, detected via its live `REGISTERED_PROTOCOLS`
+ * (mirrors the pmtiles protocol handling in `layer-sync.ts`).
+ */
+export function ensureGeoJsonVtProtocol(): void {
+  const registered = (
+    config as { REGISTERED_PROTOCOLS?: Record<string, unknown> }
+  ).REGISTERED_PROTOCOLS?.[GEOJSONVT_PROTOCOL];
+  if (registered) return;
+  addProtocol(GEOJSONVT_PROTOCOL, geojsonVtProtocolHandler);
+}
+
+async function geojsonVtProtocolHandler(
+  params: RequestParameters,
+): Promise<{ data: ArrayBuffer }> {
+  const tile = lookupTile(params.url);
+  if (!tile) return { data: new ArrayBuffer(0) };
+  // vt-pbf bundles an older geojson-vt whose tile type differs nominally from
+  // ours; the shapes are runtime-compatible, so cast at the encode boundary.
+  const pbf = fromGeojsonVt(
+    { [TILE_SOURCE_LAYER]: tile } as unknown as Parameters<
+      typeof fromGeojsonVt
+    >[0],
+    { version: 2, extent: TILE_EXTENT },
+  );
+  // Hand MapLibre an exactly-sized ArrayBuffer; `pbf` may be a view into a
+  // larger backing buffer.
+  return {
+    data: pbf.buffer.slice(
+      pbf.byteOffset,
+      pbf.byteOffset + pbf.byteLength,
+    ) as ArrayBuffer,
+  };
+}
+
+// Parse `geolibre-gjvt://<layerId>/<z>/<x>/<y>` and return the encoded tile, or
+// null when the layer is unknown or the tile is empty/out of range.
+function lookupTile(url: string): GeoJSONVTTile | null {
+  const path = url.slice(`${GEOJSONVT_PROTOCOL}://`.length);
+  const slash = path.indexOf("/");
+  if (slash < 0) return null;
+  const layerId = path.slice(0, slash);
+  const [z, x, y] = path
+    .slice(slash + 1)
+    .split("/")
+    .map(Number);
+  const entry = registry.get(layerId);
+  if (
+    !entry ||
+    !Number.isFinite(z) ||
+    !Number.isFinite(x) ||
+    !Number.isFinite(y)
+  ) {
+    return null;
+  }
+  return entry.index.getTile(z, x, y);
+}

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -2,11 +2,19 @@ import {
   DEFAULT_LAYER_STYLE,
   type GeoLibreLayer,
   type LayerStyle,
+  shouldUseTiledRendering,
   styleValue,
 } from "@geolibre/core";
 import { addProtocol, config } from "maplibre-gl";
 import type maplibregl from "maplibre-gl";
 import { PMTiles, Protocol } from "pmtiles";
+import {
+  ensureGeoJsonVtProtocol,
+  geojsonVtTileUrl,
+  registerGeoJsonVtSource,
+  TILE_SOURCE_LAYER,
+  unregisterGeoJsonVtSource,
+} from "./geojson-vt-protocol";
 import {
   circleLayerId,
   clusterCountLayerId,
@@ -141,7 +149,11 @@ export function syncLayer(
   if (isPlaceholderLayer(layer)) return;
 
   if (layer.type === "geojson" && layer.geojson) {
-    syncGeoJsonLayer(map, layer, beforeId);
+    if (shouldUseTiledRendering(layer.geojson)) {
+      syncGeoJsonVtLayer(map, layer, beforeId);
+    } else {
+      syncGeoJsonLayer(map, layer, beforeId);
+    }
     return;
   }
 
@@ -978,6 +990,17 @@ function syncGeoJsonLayer(
   const clusterMaxZoom = styleValue(layer.style, "clusterMaxZoom");
   const wantCluster = renderer === "cluster";
 
+  // A layer can drop below the tiling threshold (e.g. a processing tool shrinks
+  // it), leaving behind a vector-tile source from the tiled path. Tear it down
+  // and free its tile index so we can recreate a plain geojson source.
+  const existingSource = map.getSource(src) as maplibregl.Source | undefined;
+  const switchingFromTiled = existingSource?.type === "vector";
+  if (switchingFromTiled) {
+    removeGeoJsonRenderLayers(map, layer.id);
+    map.removeSource(src);
+    unregisterGeoJsonVtSource(layer.id);
+  }
+
   // Clustering is a source-level option, so toggling it (or changing its params)
   // means recreating the source — which first requires dropping every layer that
   // references it. MapLibre forbids removing a source still in use.
@@ -1010,6 +1033,91 @@ function syncGeoJsonLayer(
     (map.getSource(src) as maplibregl.GeoJSONSource).setData(layer.geojson!);
   }
 
+  applyVectorDataRenderLayers(map, layer, src, profile, renderer, beforeId);
+}
+
+/**
+ * Render local vector layers above {@link LARGE_VECTOR_FEATURE_THRESHOLD}
+ * features through client-side vector tiles instead of one in-memory geojson
+ * source. Reuses the same source id and render-layer ids as
+ * {@link syncGeoJsonLayer}; only the source becomes `type:"vector"` (its tiles
+ * served by the geojson-vt protocol) and render layers carry a `source-layer`.
+ */
+function syncGeoJsonVtLayer(
+  map: maplibregl.Map,
+  layer: GeoLibreLayer,
+  beforeId?: string,
+): void {
+  const src = sourceId(layer.id);
+  const profile = detectGeometryProfile(layer.geojson!);
+
+  const pointOnly =
+    profile.hasPoint && !profile.hasLine && !profile.hasPolygon;
+  const renderer = pointOnly ? styleValue(layer.style, "pointRenderer") : "single";
+  const clusterRadius = styleValue(layer.style, "clusterRadius");
+  const clusterMaxZoom = styleValue(layer.style, "clusterMaxZoom");
+  const wantCluster = renderer === "cluster";
+
+  ensureGeoJsonVtProtocol();
+
+  // (Re)build the tile index when the data or clustering config changed. A
+  // rebuild also means cached tiles are stale, so drop the source to force
+  // MapLibre to refetch them.
+  const rebuilt = registerGeoJsonVtSource(layer.id, layer.geojson!, {
+    cluster: wantCluster,
+    clusterRadius,
+    clusterMaxZoom,
+  });
+
+  const existing = map.getSource(src) as maplibregl.Source | undefined;
+  // The source must be recreated when switching in from the inline geojson path
+  // (different source type) or when the index was rebuilt.
+  if (existing && (existing.type !== "vector" || rebuilt)) {
+    removeGeoJsonRenderLayers(map, layer.id);
+    map.removeSource(src);
+  }
+
+  if (!map.getSource(src)) {
+    map.addSource(src, {
+      type: "vector",
+      tiles: [geojsonVtTileUrl(layer.id)],
+      minzoom: 0,
+      maxzoom: 16,
+    });
+  }
+
+  applyVectorDataRenderLayers(
+    map,
+    layer,
+    src,
+    profile,
+    renderer,
+    beforeId,
+    TILE_SOURCE_LAYER,
+  );
+}
+
+/**
+ * Create/update the fill, line, circle, heatmap, cluster, and text render layers
+ * for a vector data layer. Shared by the inline geojson path
+ * ({@link syncGeoJsonLayer}, `sourceLayer` undefined) and the tiled path
+ * ({@link syncGeoJsonVtLayer}, `sourceLayer` set), which differ only in whether
+ * the underlying source is a geojson source or a vector-tile source. When
+ * `sourceLayer` is provided, every render layer references it via `source-layer`.
+ */
+function applyVectorDataRenderLayers(
+  map: maplibregl.Map,
+  layer: GeoLibreLayer,
+  src: string,
+  profile: ReturnType<typeof detectGeometryProfile>,
+  renderer: string,
+  beforeId?: string,
+  sourceLayer?: string,
+): void {
+  const sourceSpec: { source: string; "source-layer"?: string } = sourceLayer
+    ? { source: src, "source-layer": sourceLayer }
+    : { source: src };
+
   const visibility = layer.visible ? "visible" : "none";
   const opacity = layer.opacity;
   const hasTextMarkers = hasTextMarkerFeatures(layer.geojson!);
@@ -1023,7 +1131,7 @@ function syncGeoJsonLayer(
         {
           id: fillExtrusionLayerId(layer.id),
           type: "fill-extrusion",
-          source: src,
+          ...sourceSpec,
           ...styleLayerZoomRange(layer.style),
           filter: [
             "match",
@@ -1045,7 +1153,7 @@ function syncGeoJsonLayer(
         {
           id: fillLayerId(layer.id),
           type: "fill",
-          source: src,
+          ...sourceSpec,
           ...styleLayerZoomRange(layer.style),
           filter: [
             "match",
@@ -1075,7 +1183,7 @@ function syncGeoJsonLayer(
       {
         id: lineLayerId(layer.id),
         type: "line",
-        source: src,
+        ...sourceSpec,
         ...styleLayerZoomRange(layer.style),
         filter: [
           "match",
@@ -1104,7 +1212,7 @@ function syncGeoJsonLayer(
       {
         id: heatmapLayerId(layer.id),
         type: "heatmap",
-        source: src,
+        ...sourceSpec,
         ...styleLayerZoomRange(layer.style),
         // Keep text-marker points out of the density, mirroring single mode;
         // they still render through the text symbol layer below.
@@ -1120,7 +1228,8 @@ function syncGeoJsonLayer(
     renderer === "cluster"
   ) {
     // Cluster renderer: a bubble + count for aggregated clusters, plus a circle
-    // for the individual (unclustered) points. The source carries cluster: true.
+    // for the individual (unclustered) points. The source carries clusters
+    // (geojson source-level clustering, or supercluster tiles on the tiled path).
     removeIfExists(map, heatmapLayerId(layer.id));
     ensureLayer(
       map,
@@ -1128,7 +1237,7 @@ function syncGeoJsonLayer(
       {
         id: clusterLayerId(layer.id),
         type: "circle",
-        source: src,
+        ...sourceSpec,
         ...styleLayerZoomRange(layer.style),
         filter: ["has", "point_count"],
         paint: clusterCirclePaint(layer.style, opacity),
@@ -1142,7 +1251,7 @@ function syncGeoJsonLayer(
       {
         id: clusterCountLayerId(layer.id),
         type: "symbol",
-        source: src,
+        ...sourceSpec,
         ...styleLayerZoomRange(layer.style),
         filter: ["has", "point_count"],
         layout: {
@@ -1166,7 +1275,7 @@ function syncGeoJsonLayer(
       {
         id: circleLayerId(layer.id),
         type: "circle",
-        source: src,
+        ...sourceSpec,
         ...styleLayerZoomRange(layer.style),
         // Unclustered points, excluding text markers (which the symbol layer
         // renders) so they don't also appear as plain circles.
@@ -1187,7 +1296,7 @@ function syncGeoJsonLayer(
       {
         id: circleLayerId(layer.id),
         type: "circle",
-        source: src,
+        ...sourceSpec,
         ...styleLayerZoomRange(layer.style),
         filter: hasTextMarkers ? nonTextMarkerPointFilter : pointGeometryFilter,
         paint: circlePaint(layer.style, opacity),
@@ -1209,7 +1318,7 @@ function syncGeoJsonLayer(
       {
         id: textLayerId(layer.id),
         type: "symbol",
-        source: src,
+        ...sourceSpec,
         ...styleLayerZoomRange(layer.style),
         filter: textMarkerFilter,
         layout: {
@@ -2059,6 +2168,8 @@ export function removeLayerFromMap(
   for (const src of [...getExternalSourceIds(layer), sourceId(layerId)]) {
     if (src && map.getSource(src)) map.removeSource(src);
   }
+  // Free any client-side tile index built for this layer's tiled render path.
+  unregisterGeoJsonVtSource(layerId);
 }
 
 function getExternalNativeLayerIds(layer?: GeoLibreLayer): string[] {

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -11,7 +11,9 @@ import { PMTiles, Protocol } from "pmtiles";
 import {
   ensureGeoJsonVtProtocol,
   geojsonVtTileUrl,
+  hasGeoJsonVtSource,
   registerGeoJsonVtSource,
+  TILE_MAX_ZOOM,
   TILE_SOURCE_LAYER,
   unregisterGeoJsonVtSource,
 } from "./geojson-vt-protocol";
@@ -994,7 +996,10 @@ function syncGeoJsonLayer(
   // it), leaving behind a vector-tile source from the tiled path. Tear it down
   // and free its tile index so we can recreate a plain geojson source.
   const existingSource = map.getSource(src) as maplibregl.Source | undefined;
-  const switchingFromTiled = existingSource?.type === "vector";
+  // Only tear down a vector source we own (the geojson-vt tiled path), never an
+  // unrelated vector source that happens to share the id.
+  const switchingFromTiled =
+    existingSource?.type === "vector" && hasGeoJsonVtSource(layer.id);
   if (switchingFromTiled) {
     removeGeoJsonRenderLayers(map, layer.id);
     map.removeSource(src);
@@ -1082,7 +1087,7 @@ function syncGeoJsonVtLayer(
       type: "vector",
       tiles: [geojsonVtTileUrl(layer.id)],
       minzoom: 0,
-      maxzoom: 16,
+      maxzoom: TILE_MAX_ZOOM,
     });
   }
 

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -975,6 +975,32 @@ function setExternalNativeLayerPaint(
   }
 }
 
+// Resolve the point renderer and clustering parameters from a layer's style.
+// The heatmap and cluster renderers only make sense for point geometry, so the
+// setting is ignored on layers that also carry lines/polygons. Shared by the
+// inline and tiled geojson paths so renderer detection lives in one place.
+function resolveVectorRenderMode(
+  layer: GeoLibreLayer,
+  profile: ReturnType<typeof detectGeometryProfile>,
+): {
+  renderer: string;
+  wantCluster: boolean;
+  clusterRadius: number;
+  clusterMaxZoom: number;
+} {
+  const pointOnly =
+    profile.hasPoint && !profile.hasLine && !profile.hasPolygon;
+  const renderer = pointOnly
+    ? styleValue(layer.style, "pointRenderer")
+    : "single";
+  return {
+    renderer,
+    wantCluster: renderer === "cluster",
+    clusterRadius: styleValue(layer.style, "clusterRadius"),
+    clusterMaxZoom: styleValue(layer.style, "clusterMaxZoom"),
+  };
+}
+
 function syncGeoJsonLayer(
   map: maplibregl.Map,
   layer: GeoLibreLayer,
@@ -982,28 +1008,19 @@ function syncGeoJsonLayer(
 ): void {
   const src = sourceId(layer.id);
   const profile = detectGeometryProfile(layer.geojson!);
-
-  // The heatmap and cluster renderers only make sense for point geometry, so
-  // ignore the setting on layers that also carry lines/polygons.
-  const pointOnly =
-    profile.hasPoint && !profile.hasLine && !profile.hasPolygon;
-  const renderer = pointOnly ? styleValue(layer.style, "pointRenderer") : "single";
-  const clusterRadius = styleValue(layer.style, "clusterRadius");
-  const clusterMaxZoom = styleValue(layer.style, "clusterMaxZoom");
-  const wantCluster = renderer === "cluster";
+  const { renderer, wantCluster, clusterRadius, clusterMaxZoom } =
+    resolveVectorRenderMode(layer, profile);
 
   // A layer can drop below the tiling threshold (e.g. a processing tool shrinks
-  // it), leaving behind a vector-tile source from the tiled path. Tear it down
-  // and free its tile index so we can recreate a plain geojson source.
+  // it), or some other code may have left a non-geojson source under this id.
+  // Either way it must be removed before the inline path's setData runs, since
+  // setData only works on a geojson source. Only free a tile index we actually
+  // own (unregister is otherwise a harmless no-op).
   const existingSource = map.getSource(src) as maplibregl.Source | undefined;
-  // Only tear down a vector source we own (the geojson-vt tiled path), never an
-  // unrelated vector source that happens to share the id.
-  const switchingFromTiled =
-    existingSource?.type === "vector" && hasGeoJsonVtSource(layer.id);
-  if (switchingFromTiled) {
+  if (existingSource && existingSource.type !== "geojson") {
     removeGeoJsonRenderLayers(map, layer.id);
     map.removeSource(src);
-    unregisterGeoJsonVtSource(layer.id);
+    if (hasGeoJsonVtSource(layer.id)) unregisterGeoJsonVtSource(layer.id);
   }
 
   // Clustering is a source-level option, so toggling it (or changing its params)
@@ -1055,13 +1072,8 @@ function syncGeoJsonVtLayer(
 ): void {
   const src = sourceId(layer.id);
   const profile = detectGeometryProfile(layer.geojson!);
-
-  const pointOnly =
-    profile.hasPoint && !profile.hasLine && !profile.hasPolygon;
-  const renderer = pointOnly ? styleValue(layer.style, "pointRenderer") : "single";
-  const clusterRadius = styleValue(layer.style, "clusterRadius");
-  const clusterMaxZoom = styleValue(layer.style, "clusterMaxZoom");
-  const wantCluster = renderer === "cluster";
+  const { renderer, wantCluster, clusterRadius, clusterMaxZoom } =
+    resolveVectorRenderMode(layer, profile);
 
   ensureGeoJsonVtProtocol();
 
@@ -1359,10 +1371,25 @@ function applyVectorDataRenderLayers(
   }
 }
 
+// syncs can fire rapidly (e.g. dragging an opacity slider), and this is an O(n)
+// scan that the tiled path now runs against 50k+ feature collections. Memoize by
+// collection reference — the store replaces the object on every mutation.
+const textMarkerCache = new WeakMap<GeoJSON.FeatureCollection, boolean>();
+
 // Keep this predicate aligned with textMarkerFilter: any text-marker-shaped
 // point routes to the symbol layer, even with empty text, so features are
 // never excluded from the circle layer without a matching symbol entry.
 function hasTextMarkerFeatures(
+  collection: GeoJSON.FeatureCollection,
+): boolean {
+  const cached = textMarkerCache.get(collection);
+  if (cached !== undefined) return cached;
+  const result = computeHasTextMarkerFeatures(collection);
+  textMarkerCache.set(collection, result);
+  return result;
+}
+
+function computeHasTextMarkerFeatures(
   collection: GeoJSON.FeatureCollection,
 ): boolean {
   return collection.features.some((feature) => {

--- a/tests/geojson-vt-tiling.test.ts
+++ b/tests/geojson-vt-tiling.test.ts
@@ -1,0 +1,252 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  DEFAULT_LAYER_STYLE,
+  LARGE_VECTOR_FEATURE_THRESHOLD,
+  shouldUseTiledRendering,
+  type GeoLibreLayer,
+} from "@geolibre/core";
+import { config } from "maplibre-gl";
+import { syncLayer } from "../packages/map/src/layer-sync";
+import {
+  ensureGeoJsonVtProtocol,
+  GEOJSONVT_PROTOCOL,
+  registerGeoJsonVtSource,
+  unregisterGeoJsonVtSource,
+} from "../packages/map/src/geojson-vt-protocol";
+
+type ProtocolHandler = (
+  params: { url: string },
+  abort: AbortController,
+) => Promise<{ data: ArrayBuffer }>;
+
+function protocolHandler(): ProtocolHandler {
+  ensureGeoJsonVtProtocol();
+  const handler = (
+    config as { REGISTERED_PROTOCOLS?: Record<string, ProtocolHandler> }
+  ).REGISTERED_PROTOCOLS?.[GEOJSONVT_PROTOCOL];
+  assert.ok(handler, "geojson-vt protocol should be registered");
+  return handler;
+}
+
+function pointGrid(count: number): GeoJSON.FeatureCollection {
+  const features: GeoJSON.Feature[] = [];
+  for (let i = 0; i < count; i++) {
+    // Spread points across a small region near [0, 0] so a low-zoom tile covers
+    // them all.
+    const lng = (i % 100) * 0.001;
+    const lat = Math.floor(i / 100) * 0.001;
+    features.push({
+      type: "Feature",
+      properties: { idx: i },
+      geometry: { type: "Point", coordinates: [lng, lat] },
+    });
+  }
+  return { type: "FeatureCollection", features };
+}
+
+function largeLayer(
+  count: number,
+  style: Partial<GeoLibreLayer["style"]> = {},
+): GeoLibreLayer {
+  return {
+    id: "big",
+    name: "Big",
+    type: "geojson",
+    source: { type: "geojson" },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE, ...style },
+    metadata: {},
+    geojson: pointGrid(count),
+  };
+}
+
+// Fake MapLibre map that, unlike the shared point-renderer harness, surfaces the
+// stored source `type` from getSource so the tiled/inline switch can be tested.
+function makeMap() {
+  const sources = new Map<string, Record<string, unknown>>();
+  const layers = new Map<string, Record<string, unknown>>();
+  const calls: { method: string; args: unknown[] }[] = [];
+  const map = {
+    getSource: (id: string) => {
+      const spec = sources.get(id);
+      return spec ? { type: spec.type, setData: () => {} } : undefined;
+    },
+    addSource: (id: string, spec: Record<string, unknown>) => {
+      sources.set(id, spec);
+      calls.push({ method: "addSource", args: [id, spec] });
+    },
+    removeSource: (id: string) => {
+      sources.delete(id);
+      calls.push({ method: "removeSource", args: [id] });
+    },
+    getLayer: (id: string) =>
+      layers.has(id) ? { id, ...layers.get(id) } : undefined,
+    addLayer: (spec: Record<string, unknown>, beforeId?: string) => {
+      layers.set(spec.id as string, spec);
+      calls.push({ method: "addLayer", args: [spec, beforeId] });
+    },
+    removeLayer: (id: string) => {
+      layers.delete(id);
+      calls.push({ method: "removeLayer", args: [id] });
+    },
+    getFilter: (id: string) => layers.get(id)?.filter,
+    setFilter: () => {},
+    setPaintProperty: () => {},
+    setLayoutProperty: () => {},
+    setLayerZoomRange: () => {},
+    moveLayer: () => {},
+    getStyle: () => ({
+      layers: [...layers.values()],
+      sources: Object.fromEntries(sources),
+    }),
+    once: () => {},
+  };
+  return { map, sources, layers, calls };
+}
+
+describe("shouldUseTiledRendering", () => {
+  it("switches at the threshold", () => {
+    assert.equal(LARGE_VECTOR_FEATURE_THRESHOLD, 50_000);
+    assert.equal(shouldUseTiledRendering(undefined), false);
+    assert.equal(
+      shouldUseTiledRendering(pointGrid(LARGE_VECTOR_FEATURE_THRESHOLD)),
+      false,
+    );
+    assert.equal(
+      shouldUseTiledRendering(pointGrid(LARGE_VECTOR_FEATURE_THRESHOLD + 1)),
+      true,
+    );
+  });
+});
+
+describe("geojson-vt protocol", () => {
+  it("encodes a covering tile and is empty out of range / for unknown layers", async () => {
+    const handler = protocolHandler();
+    const rebuilt = registerGeoJsonVtSource("L1", pointGrid(10), {
+      cluster: false,
+      clusterRadius: 50,
+      clusterMaxZoom: 14,
+    });
+    assert.equal(rebuilt, true);
+
+    const covering = await handler(
+      { url: `${GEOJSONVT_PROTOCOL}://L1/0/0/0` },
+      new AbortController(),
+    );
+    assert.ok(covering.data.byteLength > 0, "z0 tile should contain features");
+
+    // A far-away tile (near lng ~172, far south) holds no features.
+    const empty = await handler(
+      { url: `${GEOJSONVT_PROTOCOL}://L1/10/1000/1000` },
+      new AbortController(),
+    );
+    assert.equal(empty.data.byteLength, 0);
+
+    // Unknown layer id yields an empty tile rather than throwing.
+    const unknown = await handler(
+      { url: `${GEOJSONVT_PROTOCOL}://nope/0/0/0` },
+      new AbortController(),
+    );
+    assert.equal(unknown.data.byteLength, 0);
+
+    unregisterGeoJsonVtSource("L1");
+    const afterUnregister = await handler(
+      { url: `${GEOJSONVT_PROTOCOL}://L1/0/0/0` },
+      new AbortController(),
+    );
+    assert.equal(afterUnregister.data.byteLength, 0);
+  });
+
+  it("reuses the index until the data or cluster config changes", () => {
+    const fc = pointGrid(5);
+    assert.equal(
+      registerGeoJsonVtSource("L2", fc, {
+        cluster: false,
+        clusterRadius: 50,
+        clusterMaxZoom: 14,
+      }),
+      true,
+    );
+    // Same reference + same options → reused, not rebuilt.
+    assert.equal(
+      registerGeoJsonVtSource("L2", fc, {
+        cluster: false,
+        clusterRadius: 50,
+        clusterMaxZoom: 14,
+      }),
+      false,
+    );
+    // Toggling clustering forces a rebuild.
+    assert.equal(
+      registerGeoJsonVtSource("L2", fc, {
+        cluster: true,
+        clusterRadius: 50,
+        clusterMaxZoom: 14,
+      }),
+      true,
+    );
+    // A new collection reference forces a rebuild.
+    assert.equal(
+      registerGeoJsonVtSource("L2", pointGrid(5), {
+        cluster: true,
+        clusterRadius: 50,
+        clusterMaxZoom: 14,
+      }),
+      true,
+    );
+    unregisterGeoJsonVtSource("L2");
+  });
+
+  it("encodes a clustered tile", async () => {
+    const handler = protocolHandler();
+    registerGeoJsonVtSource("LC", pointGrid(200), {
+      cluster: true,
+      clusterRadius: 50,
+      clusterMaxZoom: 14,
+    });
+    const tile = await handler(
+      { url: `${GEOJSONVT_PROTOCOL}://LC/0/0/0` },
+      new AbortController(),
+    );
+    assert.ok(tile.data.byteLength > 0);
+    unregisterGeoJsonVtSource("LC");
+  });
+});
+
+describe("syncLayer tiled path", () => {
+  it("renders a large layer as a vector source with source-layer'd render layers", () => {
+    const { map, sources, layers } = makeMap();
+    syncLayer(map as never, largeLayer(LARGE_VECTOR_FEATURE_THRESHOLD + 1));
+
+    const src = sources.get("source-big") as Record<string, unknown>;
+    assert.equal(src.type, "vector");
+    assert.deepEqual(src.tiles, [`${GEOJSONVT_PROTOCOL}://big/{z}/{x}/{y}`]);
+
+    const circle = layers.get("layer-big-circle") as Record<string, unknown>;
+    assert.equal(circle.type, "circle");
+    assert.equal(circle["source-layer"], "data");
+    unregisterGeoJsonVtSource("big");
+  });
+
+  it("switches back to an inline geojson source when shrunk below the threshold", () => {
+    const { map, sources, calls } = makeMap();
+    syncLayer(map as never, largeLayer(LARGE_VECTOR_FEATURE_THRESHOLD + 1));
+    assert.equal(
+      (sources.get("source-big") as Record<string, unknown>).type,
+      "vector",
+    );
+
+    syncLayer(map as never, largeLayer(10));
+    assert.ok(
+      calls.some((c) => c.method === "removeSource" && c.args[0] === "source-big"),
+      "the vector source should be torn down",
+    );
+    assert.equal(
+      (sources.get("source-big") as Record<string, unknown>).type,
+      "geojson",
+    );
+    unregisterGeoJsonVtSource("big");
+  });
+});

--- a/tests/geojson-vt-tiling.test.ts
+++ b/tests/geojson-vt-tiling.test.ts
@@ -45,13 +45,18 @@ function pointGrid(count: number): GeoJSON.FeatureCollection {
   return { type: "FeatureCollection", features };
 }
 
+// Unique id per layer keeps the module-level tile-index registry from leaking
+// state between tests if one throws before its cleanup runs.
+let layerIdCounter = 0;
+
 function largeLayer(
   count: number,
+  id: string = `big-${layerIdCounter++}`,
   style: Partial<GeoLibreLayer["style"]> = {},
 ): GeoLibreLayer {
   return {
-    id: "big",
-    name: "Big",
+    id,
+    name: id,
     type: "geojson",
     source: { type: "geojson" },
     visible: true,
@@ -218,35 +223,45 @@ describe("geojson-vt protocol", () => {
 describe("syncLayer tiled path", () => {
   it("renders a large layer as a vector source with source-layer'd render layers", () => {
     const { map, sources, layers } = makeMap();
-    syncLayer(map as never, largeLayer(LARGE_VECTOR_FEATURE_THRESHOLD + 1));
+    const id = "big-render";
+    try {
+      syncLayer(map as never, largeLayer(LARGE_VECTOR_FEATURE_THRESHOLD + 1, id));
 
-    const src = sources.get("source-big") as Record<string, unknown>;
-    assert.equal(src.type, "vector");
-    assert.deepEqual(src.tiles, [`${GEOJSONVT_PROTOCOL}://big/{z}/{x}/{y}`]);
+      const src = sources.get(`source-${id}`) as Record<string, unknown>;
+      assert.equal(src.type, "vector");
+      assert.deepEqual(src.tiles, [`${GEOJSONVT_PROTOCOL}://${id}/{z}/{x}/{y}`]);
 
-    const circle = layers.get("layer-big-circle") as Record<string, unknown>;
-    assert.equal(circle.type, "circle");
-    assert.equal(circle["source-layer"], "data");
-    unregisterGeoJsonVtSource("big");
+      const circle = layers.get(`layer-${id}-circle`) as Record<string, unknown>;
+      assert.equal(circle.type, "circle");
+      assert.equal(circle["source-layer"], "data");
+    } finally {
+      unregisterGeoJsonVtSource(id);
+    }
   });
 
   it("switches back to an inline geojson source when shrunk below the threshold", () => {
     const { map, sources, calls } = makeMap();
-    syncLayer(map as never, largeLayer(LARGE_VECTOR_FEATURE_THRESHOLD + 1));
-    assert.equal(
-      (sources.get("source-big") as Record<string, unknown>).type,
-      "vector",
-    );
+    const id = "big-switch";
+    try {
+      syncLayer(map as never, largeLayer(LARGE_VECTOR_FEATURE_THRESHOLD + 1, id));
+      assert.equal(
+        (sources.get(`source-${id}`) as Record<string, unknown>).type,
+        "vector",
+      );
 
-    syncLayer(map as never, largeLayer(10));
-    assert.ok(
-      calls.some((c) => c.method === "removeSource" && c.args[0] === "source-big"),
-      "the vector source should be torn down",
-    );
-    assert.equal(
-      (sources.get("source-big") as Record<string, unknown>).type,
-      "geojson",
-    );
-    unregisterGeoJsonVtSource("big");
+      syncLayer(map as never, largeLayer(10, id));
+      assert.ok(
+        calls.some(
+          (c) => c.method === "removeSource" && c.args[0] === `source-${id}`,
+        ),
+        "the vector source should be torn down",
+      );
+      assert.equal(
+        (sources.get(`source-${id}`) as Record<string, unknown>).type,
+        "geojson",
+      );
+    } finally {
+      unregisterGeoJsonVtSource(id);
+    }
   });
 });


### PR DESCRIPTION
## Summary

Closes #340.

Local vector layers above **50,000 features** now render through **client-side vector tiles** generated in-browser instead of one in-memory GeoJSON source pushed to MapLibre via `setData` on every sync. Smaller layers keep the existing simple inline path unchanged.

Previously, any local vector file (Shapefile/GeoParquet/GeoJSON) was fully materialized into a single in-memory `FeatureCollection`, stored inline on the layer record, and re-pushed wholesale to MapLibre on every sync — which doesn't scale for large datasets. Only remote PMTiles/MVT were tiled.

## Approach

- **`@geolibre/core`**: new `LARGE_VECTOR_FEATURE_THRESHOLD = 50_000` and `shouldUseTiledRendering(geojson)`.
- **New `packages/map/src/geojson-vt-protocol.ts`**: builds a `GeoJSONVT` index per layer (or the bundled `Supercluster`/`ClusterTileIndex` for clustered point layers — the same engine MapLibre uses internally), encodes requested tiles to MVT with `@maplibre/vt-pbf`, and serves them through a custom `geolibre-gjvt://` MapLibre protocol — mirroring the existing pmtiles/mbtiles `type:"vector"` pattern. Tile indexes live in a module-level registry (non-serializable, kept out of app state).
- **`layer-sync.ts`**: the `geojson` dispatch branches on feature count. The fill/line/circle/heatmap/cluster/text render-layer creation is now shared between the inline and tiled paths via `applyVectorDataRenderLayers` (the tiled path adds a `source-layer`). The **same source id and render-layer ids are reused**, so existing teardown applies; only the tile index needs explicit cleanup. Layers that later drop below the threshold switch back to the inline geojson source.

The layer type stays `"geojson"` (no `.geolibre.json` project-format change). The full GeoJSON remains on the layer record, so the attribute table, identify, processing tools, and serialization are unaffected.

## Trade-offs / follow-up

This fixes the **render/`setData`** bottleneck. Memory footprint is unchanged (the GeoJSON stays in memory); true memory-scaling via DuckDB viewport queries remains a future follow-up (the second option in #340).

## Testing

- New `tests/geojson-vt-tiling.test.ts`: threshold boundary, protocol encoding (covering tile non-empty, out-of-range/unknown-layer empty, unregister), index reuse-vs-rebuild, clustered tiles, and `syncLayer` producing a vector source + `source-layer`'d render layers and switching back below threshold.
- Full gate green: `npm run test:frontend` (704 tests), `npm run typecheck` (build), `npm run test:worker`; `pre-commit` (eslint + npm build) passes.
- **Real-app verification** (Playwright): loaded a 60,000-point GeoJSON; it renders across the continental US and at zoom ~10 individual points render discretely, with no feature-related console errors. Since >50k layers route unconditionally to the tiled `geolibre-gjvt` path (no fallback), successful rendering confirms the protocol/encoding works in real MapLibre.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Large GeoJSON feature collections now automatically use tiled vector rendering when they exceed a configurable feature threshold.
  * Added an in-browser GeoJSON-to-vector-tile pipeline with per-layer caching, including support for clustered and non-clustered rendering.
* **Bug Fixes**
  * Improved layer switching: when a layer no longer meets the threshold, any tiled vector source and cached tiles are removed and the map returns to inline GeoJSON rendering.
* **Tests**
  * Added automated coverage for threshold switching, protocol tile generation/teardown, caching reuse, and clustered output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->