### PR TITLE
feat(ingestion): warn before loading very large vector files (#339)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -42,6 +42,7 @@ import {
   type DroppedRaster,
 } from "../../lib/tauri-io";
 import type { LargeVectorDataset } from "../../lib/duckdb-vector-guard";
+import i18n from "../../i18n";
 import {
   addOsmPbfLayers,
   isOsmPbfFileName,
@@ -85,9 +86,10 @@ import type { ProjectUrlLoadState } from "../../hooks/useProjectUrlLoader";
  */
 function confirmLargeVectorDataset({ name, featureCount }: LargeVectorDataset) {
   return window.confirm(
-    `${name} has about ${featureCount.toLocaleString()} features. ` +
-      "Loading it converts every feature to GeoJSON in memory and may slow " +
-      "down or freeze the app. Continue?",
+    i18n.t("toolbar.item.largeVectorDesc", {
+      name,
+      count: featureCount.toLocaleString(),
+    }),
   );
 }
 

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -41,6 +41,7 @@ import {
   loadDroppedVectorPaths,
   type DroppedRaster,
 } from "../../lib/tauri-io";
+import type { LargeVectorDataset } from "../../lib/duckdb-vector-guard";
 import {
   addOsmPbfLayers,
   isOsmPbfFileName,
@@ -75,6 +76,20 @@ import { TopToolbar } from "./TopToolbar";
 import type { LayoutOptions } from "../../hooks/useLayoutOptions";
 import type { ThemeMode } from "../../hooks/useThemeMode";
 import type { ProjectUrlLoadState } from "../../hooks/useProjectUrlLoader";
+
+/**
+ * Confirm loading a vector source whose feature count tripped the loader's
+ * large-dataset guard. Mirrors the OSM PBF drop guard's blocking
+ * `window.confirm` (see the handlers below): a `false` return aborts that one
+ * file's load without affecting the rest of a multi-file drop.
+ */
+function confirmLargeVectorDataset({ name, featureCount }: LargeVectorDataset) {
+  return window.confirm(
+    `${name} has about ${featureCount.toLocaleString()} features. ` +
+      "Loading it converts every feature to GeoJSON in memory and may slow " +
+      "down or freeze the app. Continue?",
+  );
+}
 
 const ProcessingDialog = lazy(() =>
   import("../processing/ProcessingDialog")
@@ -668,7 +683,9 @@ export function DesktopShell({
               const rasterCount = await addDroppedRasters(
                 await loadDroppedRasterPaths(otherPaths),
               );
-              const importedLayers = await loadDroppedVectorPaths(otherPaths);
+              const importedLayers = await loadDroppedVectorPaths(otherPaths, {
+                onLargeDataset: confirmLargeVectorDataset,
+              });
               // See the browser handler: skip finishDrop's empty-input error
               // when PBF files were present (even if rejected/failed).
               if (
@@ -795,7 +812,9 @@ export function DesktopShell({
           const rasterCount = await addDroppedRasters(
             loadDroppedRasterFiles(otherFiles),
           );
-          const importedLayers = await loadDroppedVectorFiles(otherFiles);
+          const importedLayers = await loadDroppedVectorFiles(otherFiles, {
+            onLargeDataset: confirmLargeVectorDataset,
+          });
           // Call finishDrop (which reports success or throws the empty-input
           // error) only when the other files produced something, or when the
           // drop contained no PBF files at all. If PBF files were present —

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -390,6 +390,7 @@
       "continue": "Continue",
       "largeOsmPbfTitle": "Large OSM PBF file",
       "largeOsmPbfDesc": "This file is about {{sizeMb}} MB. Parsing it converts every feature to GeoJSON in memory, which can be slow and may use a lot of memory in the browser. Continue?",
+      "largeVectorDesc": "{{name}} has about {{count}} features. Loading it converts every feature to GeoJSON in memory and may slow down or freeze the app. Continue?",
       "addOsmPbfLayerTitle": "Add OSM PBF Layer",
       "addOsmPbfLayerDesc": "Load an OpenStreetMap .osm.pbf file. It is parsed in your browser and split into separate point, line, and polygon layers.",
       "urlLabel": "URL",

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-guard.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-guard.ts
@@ -1,0 +1,71 @@
+/**
+ * Large-dataset guard for the DuckDB vector ingestion path.
+ *
+ * Kept in its own module — free of the DuckDB-WASM `?url` imports that
+ * `duckdb-vector-loader.ts` carries — so the threshold, types, and decision
+ * logic can be imported by the eagerly-loaded UI shell and unit-tested under
+ * `node --test` without pulling the WASM engine into the bundle/test.
+ */
+
+/**
+ * Sources whose feature (row) count reaches this threshold prompt a
+ * confirmation before {@link loadDuckDbVectorFile} materializes every row as a
+ * GeoJSON Feature in memory — each row is JSON-parsed and turned into its own
+ * object, so a multi-million-row file can exhaust browser memory or wedge the
+ * tab. This is the DuckDB ingestion counterpart to `OSM_PBF_SIZE_WARN_BYTES`
+ * (`osm-pbf-loader.ts`); unlike a raw byte size it is accurate for compressed
+ * formats like GeoParquet, where a small file can hold millions of rows.
+ */
+export const DUCKDB_VECTOR_FEATURE_WARN_COUNT = 500_000;
+
+/** Details passed to {@link DuckDbVectorLoadOptions.onLargeDataset}. */
+export interface LargeVectorDataset {
+  /** The file/layer name shown to the user. */
+  name: string;
+  /** Total feature (row) count DuckDB reported for the source. */
+  featureCount: number;
+}
+
+export interface DuckDbVectorLoadOptions {
+  /**
+   * Invoked when the source's feature count is at least
+   * {@link DUCKDB_VECTOR_FEATURE_WARN_COUNT}, before the expensive GeoJSON
+   * materialization. Return `false` (or a promise resolving to `false`) to
+   * abort the load — the loader then throws {@link VectorLoadCancelledError},
+   * which callers can catch to skip the file. When this callback is omitted,
+   * large datasets load without prompting; this preserves the non-interactive
+   * behaviour relied on by KMZ sub-loads and tests, and keeps the load
+   * single-pass (the extra `COUNT(*)` is only run when a guard is attached).
+   */
+  onLargeDataset?: (dataset: LargeVectorDataset) => boolean | Promise<boolean>;
+}
+
+/**
+ * Thrown by {@link loadDuckDbVectorFile} when the user declines to load a file
+ * whose feature count exceeds {@link DUCKDB_VECTOR_FEATURE_WARN_COUNT}. Callers
+ * iterating over several dropped files catch this to skip the declined file
+ * without aborting the rest of the batch.
+ */
+export class VectorLoadCancelledError extends Error {
+  constructor(message = "Vector load cancelled by the user.") {
+    super(message);
+    this.name = "VectorLoadCancelledError";
+  }
+}
+
+/**
+ * Run the large-dataset guard: when `featureCount` meets the warn threshold and
+ * a callback is supplied, ask whether to proceed and throw
+ * {@link VectorLoadCancelledError} if the user declines. A no-op below the
+ * threshold or when no callback is attached. Pure (no DuckDB) so the guard
+ * logic can be unit-tested directly.
+ */
+export async function confirmLargeDataset(
+  dataset: LargeVectorDataset,
+  onLargeDataset: DuckDbVectorLoadOptions["onLargeDataset"],
+): Promise<void> {
+  if (!onLargeDataset) return;
+  if (dataset.featureCount < DUCKDB_VECTOR_FEATURE_WARN_COUNT) return;
+  const proceed = await onLargeDataset(dataset);
+  if (!proceed) throw new VectorLoadCancelledError();
+}

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -12,6 +12,10 @@ import {
   quoteIdentifier,
   quoteSqlString,
 } from "./duckdb-geometry";
+import {
+  confirmLargeDataset,
+  type DuckDbVectorLoadOptions,
+} from "./duckdb-vector-guard";
 import { ensureGpkgFeatureCount } from "./gpkg-ogr-contents";
 import { getSpatialExtensionPath } from "./spatial-extension-config";
 
@@ -23,9 +27,20 @@ export {
   quoteSqlString,
 } from "./duckdb-geometry";
 
+// Re-exported so callers can keep importing the guard surface from the loader.
+export {
+  confirmLargeDataset,
+  DUCKDB_VECTOR_FEATURE_WARN_COUNT,
+  VectorLoadCancelledError,
+  type DuckDbVectorLoadOptions,
+  type LargeVectorDataset,
+} from "./duckdb-vector-guard";
+
 const GEOMETRY_JSON_COLUMN = "__geolibre_geometry_geojson";
 const EXPORT_GEOJSON_EXTENSION = "geojson";
 const EXPORT_GEOPARQUET_EXTENSION = "parquet";
+
+const FEATURE_COUNT_COLUMN = "__geolibre_feature_count";
 
 const MANUAL_BUNDLES: duckdb.DuckDBBundles = {
   mvp: {
@@ -288,8 +303,28 @@ function normalizePropertyValue(value: unknown): unknown {
   return value;
 }
 
+/**
+ * Count the rows a source SQL statement would return. DuckDB answers this from
+ * Parquet metadata without a scan and, for `ST_Read` formats, far more cheaply
+ * than the full `SELECT *, ST_AsGeoJSON(...)` materialization, so it is a sound
+ * up-front guard against runaway feature counts.
+ */
+async function countFeatures(
+  connection: duckdb.AsyncDuckDBConnection,
+  sql: string,
+): Promise<number> {
+  const row = rowsFromResult(
+    await connection.query(
+      `SELECT count(*) AS ${quoteIdentifier(FEATURE_COUNT_COLUMN)} FROM (${sql}) AS data`,
+    ),
+  )[0];
+  const raw = row?.[FEATURE_COUNT_COLUMN];
+  return typeof raw === "bigint" ? Number(raw) : Number(raw ?? 0);
+}
+
 export async function loadDuckDbVectorFile(
   file: DuckDbVectorFile,
+  options: DuckDbVectorLoadOptions = {},
 ): Promise<FeatureCollection> {
   const db = await getDatabase();
   const connection = await db.connect();
@@ -306,6 +341,14 @@ export async function loadDuckDbVectorFile(
 
     if (!detected) {
       throw new Error("DuckDB did not find a geometry column in this file.");
+    }
+
+    // Guard against very large files before the expensive GeoJSON
+    // materialization. Only counted when a callback is attached, so the
+    // common (non-interactive) path stays single-pass.
+    if (options.onLargeDataset) {
+      const featureCount = await countFeatures(connection, sql);
+      await confirmLargeDataset({ name: file.name, featureCount }, options.onLargeDataset);
     }
 
     const sourceCrs = await readSourceCrs(connection, file);

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -13,6 +13,7 @@ import type { FeatureCollection } from "geojson";
 import shp from "shpjs";
 import { parseDelimitedTextFields } from "./delimited-text";
 import type { DuckDbVectorFile } from "./duckdb-vector-loader";
+import type { DuckDbVectorLoadOptions } from "./duckdb-vector-guard";
 import { parseGpxLayer } from "./gpx";
 import { isTauri } from "./is-tauri";
 
@@ -295,15 +296,33 @@ async function readKmzKmlFiles(
 
 async function parseKmz(
   data: ArrayBuffer | Uint8Array,
+  options?: DuckDbVectorLoadOptions,
 ): Promise<FeatureCollection> {
   const kmlFiles = await readKmzKmlFiles(data);
-  const collections = await Promise.all(kmlFiles.map(loadDuckDbVector));
+  const collections = await Promise.all(
+    kmlFiles.map((file) => loadDuckDbVector(file, options)),
+  );
   return mergeFeatureCollections(collections);
 }
 
-async function loadDuckDbVector(file: DuckDbVectorFile) {
+async function loadDuckDbVector(
+  file: DuckDbVectorFile,
+  options?: DuckDbVectorLoadOptions,
+) {
   const { loadDuckDbVectorFile } = await import("./duckdb-vector-loader");
-  return loadDuckDbVectorFile(file);
+  return loadDuckDbVectorFile(file, options);
+}
+
+/**
+ * Whether an error is the {@link VectorLoadCancelledError} thrown when the user
+ * declines a large-file load. Matched by `name` rather than `instanceof` so the
+ * heavy `duckdb-vector-loader` module (and its DuckDB-WASM imports) stays a
+ * lazy dynamic import instead of being pulled into this module's chunk.
+ */
+function isVectorLoadCancelled(error: unknown): boolean {
+  return (
+    error instanceof Error && error.name === "VectorLoadCancelledError"
+  );
 }
 
 async function fileToDuckDbVectorFile(file: File): Promise<DuckDbVectorFile> {
@@ -317,6 +336,7 @@ async function fileToDuckDbVectorFile(file: File): Promise<DuckDbVectorFile> {
 async function loadBrowserVectorFile(
   file: File,
   siblingFiles: DuckDbVectorFile[] = [],
+  options?: DuckDbVectorLoadOptions,
 ): Promise<LoadedVectorLayer> {
   const extension = fileExtension(file.name);
   if (extension === "geojson" || extension === "json") {
@@ -344,7 +364,7 @@ async function loadBrowserVectorFile(
 
   if (extension === "kmz") {
     return {
-      data: await parseKmz(await file.arrayBuffer()),
+      data: await parseKmz(await file.arrayBuffer(), options),
       path: file.name,
     };
   }
@@ -357,17 +377,22 @@ async function loadBrowserVectorFile(
   }
 
   return {
-    data: await loadDuckDbVector({
-      name: file.name,
-      extension,
-      data: new Uint8Array(await file.arrayBuffer()),
-      siblingFiles,
-    }),
+    data: await loadDuckDbVector(
+      {
+        name: file.name,
+        extension,
+        data: new Uint8Array(await file.arrayBuffer()),
+        siblingFiles,
+      },
+      options,
+    ),
     path: file.name,
   };
 }
 
-async function openVectorFileBrowser(): Promise<{
+async function openVectorFileBrowser(
+  options?: DuckDbVectorLoadOptions,
+): Promise<{
   data: FeatureCollection;
   path: string;
 } | null> {
@@ -382,7 +407,7 @@ async function openVectorFileBrowser(): Promise<{
           return;
         }
 
-        resolve(await loadBrowserVectorFile(file));
+        resolve(await loadBrowserVectorFile(file, [], options));
       } catch (error) {
         reject(error);
       }
@@ -391,7 +416,9 @@ async function openVectorFileBrowser(): Promise<{
   });
 }
 
-async function openVectorFileTauri(): Promise<{
+async function openVectorFileTauri(
+  options?: DuckDbVectorLoadOptions,
+): Promise<{
   data: FeatureCollection;
   path: string;
 } | null> {
@@ -399,10 +426,13 @@ async function openVectorFileTauri(): Promise<{
     multiple: false,
   });
   if (!selected || typeof selected !== "string") return null;
-  return loadTauriVectorFile(selected);
+  return loadTauriVectorFile(selected, options);
 }
 
-async function loadTauriVectorFile(path: string): Promise<{
+async function loadTauriVectorFile(
+  path: string,
+  options?: DuckDbVectorLoadOptions,
+): Promise<{
   data: FeatureCollection;
   path: string;
 }> {
@@ -433,10 +463,11 @@ async function loadTauriVectorFile(path: string): Promise<{
   if (extension === "kmz") {
     try {
       return {
-        data: await parseKmz(await readFile(path)),
+        data: await parseKmz(await readFile(path), options),
         path,
       };
     } catch (error) {
+      if (isVectorLoadCancelled(error)) throw error;
       const detail = error instanceof Error ? error.message : "Unknown error";
       throw new Error(`Could not read this KMZ file. ${detail}`);
     }
@@ -458,15 +489,19 @@ async function loadTauriVectorFile(path: string): Promise<{
     const siblingFiles =
       extension === "shp" ? await readShapefileSiblings(path) : [];
     return {
-      data: await loadDuckDbVector({
-        name: browserSafeFileName(path),
-        extension,
-        data: await readFile(path),
-        siblingFiles,
-      }),
+      data: await loadDuckDbVector(
+        {
+          name: browserSafeFileName(path),
+          extension,
+          data: await readFile(path),
+          siblingFiles,
+        },
+        options,
+      ),
       path,
     };
   } catch (error) {
+    if (isVectorLoadCancelled(error)) throw error;
     const detail = error instanceof Error ? error.message : "Unknown error";
     throw new Error(
       `Could not convert this vector file with DuckDB-WASM. ${detail}`,
@@ -971,16 +1006,19 @@ export async function openGeoJsonFileWithFallback(): Promise<{
   return openGeoJsonFileBrowser();
 }
 
-export async function openVectorFileWithFallback(): Promise<{
+export async function openVectorFileWithFallback(
+  options?: DuckDbVectorLoadOptions,
+): Promise<{
   data: FeatureCollection;
   path: string;
 } | null> {
-  if (isTauri()) return openVectorFileTauri();
-  return openVectorFileBrowser();
+  if (isTauri()) return openVectorFileTauri(options);
+  return openVectorFileBrowser(options);
 }
 
 export async function loadDroppedVectorFiles(
   droppedFiles: FileList | File[],
+  options?: DuckDbVectorLoadOptions,
 ): Promise<LoadedVectorLayer[]> {
   const droppedFileArray = Array.from(droppedFiles);
   const files = droppedFileArray.filter((file) => isVectorFileName(file.name));
@@ -1021,7 +1059,14 @@ export async function loadDroppedVectorFiles(
               .map(fileToDuckDbVectorFile),
           )
         : [];
-    layers.push(await loadBrowserVectorFile(file, siblingFiles));
+    try {
+      layers.push(await loadBrowserVectorFile(file, siblingFiles, options));
+    } catch (error) {
+      // The user declined this oversized file: skip it without abandoning the
+      // rest of the dropped batch.
+      if (isVectorLoadCancelled(error)) continue;
+      throw error;
+    }
   }
 
   return layers;
@@ -1072,6 +1117,7 @@ export async function loadDroppedRasterPaths(
 
 export async function loadDroppedVectorPaths(
   paths: string[],
+  options?: DuckDbVectorLoadOptions,
 ): Promise<LoadedVectorLayer[]> {
   const vectorPaths = paths.filter(isVectorFileName);
   if (!vectorPaths.length) return [];
@@ -1089,7 +1135,14 @@ export async function loadDroppedVectorPaths(
       }
       continue;
     }
-    layers.push(await loadTauriVectorFile(path));
+    try {
+      layers.push(await loadTauriVectorFile(path, options));
+    } catch (error) {
+      // The user declined this oversized file: skip it without abandoning the
+      // rest of the dropped batch.
+      if (isVectorLoadCancelled(error)) continue;
+      throw error;
+    }
   }
 
   return layers;

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -299,9 +299,28 @@ async function parseKmz(
   options?: DuckDbVectorLoadOptions,
 ): Promise<FeatureCollection> {
   const kmlFiles = await readKmzKmlFiles(data);
-  const collections = await Promise.all(
-    kmlFiles.map((file) => loadDuckDbVector(file, options)),
+  // Load each KML independently so declining one large KML inside a multi-KML
+  // archive drops just that layer instead of failing the whole KMZ (Promise.all
+  // is fail-fast). Real load errors still reject and abort the archive.
+  let cancellation: unknown;
+  const settled = await Promise.all(
+    kmlFiles.map((file) =>
+      loadDuckDbVector(file, options).then(
+        (collection): FeatureCollection | null => collection,
+        (error): null => {
+          if (!isVectorLoadCancelled(error)) throw error;
+          cancellation = error;
+          return null;
+        },
+      ),
+    ),
   );
+  const collections = settled.filter(
+    (collection): collection is FeatureCollection => collection !== null,
+  );
+  // Every KML was declined: propagate the cancellation so the caller skips the
+  // whole archive rather than adding an empty layer.
+  if (collections.length === 0 && cancellation) throw cancellation;
   return mergeFeatureCollections(collections);
 }
 

--- a/tests/duckdb-vector-guard.test.ts
+++ b/tests/duckdb-vector-guard.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  confirmLargeDataset,
+  DUCKDB_VECTOR_FEATURE_WARN_COUNT,
+  VectorLoadCancelledError,
+} from "../apps/geolibre-desktop/src/lib/duckdb-vector-guard";
+
+describe("confirmLargeDataset", () => {
+  it("does nothing when no callback is supplied", async () => {
+    await assert.doesNotReject(
+      confirmLargeDataset(
+        { name: "huge.parquet", featureCount: 10_000_000 },
+        undefined,
+      ),
+    );
+  });
+
+  it("skips the callback below the warn threshold", async () => {
+    let called = false;
+    await confirmLargeDataset(
+      { name: "small.gpkg", featureCount: DUCKDB_VECTOR_FEATURE_WARN_COUNT - 1 },
+      () => {
+        called = true;
+        return false;
+      },
+    );
+    assert.equal(called, false);
+  });
+
+  it("invokes the callback at the threshold with the dataset details", async () => {
+    const seen: unknown[] = [];
+    await confirmLargeDataset(
+      { name: "edge.fgb", featureCount: DUCKDB_VECTOR_FEATURE_WARN_COUNT },
+      (dataset) => {
+        seen.push(dataset);
+        return true;
+      },
+    );
+    assert.deepEqual(seen, [
+      { name: "edge.fgb", featureCount: DUCKDB_VECTOR_FEATURE_WARN_COUNT },
+    ]);
+  });
+
+  it("resolves when the user proceeds", async () => {
+    await assert.doesNotReject(
+      confirmLargeDataset(
+        { name: "big.shp", featureCount: 2_000_000 },
+        () => true,
+      ),
+    );
+  });
+
+  it("throws VectorLoadCancelledError when the user declines", async () => {
+    await assert.rejects(
+      confirmLargeDataset(
+        { name: "big.shp", featureCount: 2_000_000 },
+        () => false,
+      ),
+      VectorLoadCancelledError,
+    );
+  });
+
+  it("awaits an async callback decision", async () => {
+    await assert.rejects(
+      confirmLargeDataset(
+        { name: "big.shp", featureCount: 2_000_000 },
+        () => Promise.resolve(false),
+      ),
+      VectorLoadCancelledError,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #339.

Local vector files (Shapefile, GeoParquet, GeoPackage, FlatGeobuf, KMZ) are ingested through `loadDuckDbVectorFile`, which ran `SELECT *, ST_AsGeoJSON(...)` over the whole file and materialized one `Feature` object per row — no row-count check, no warning. The only large-data safeguard anywhere was the 50 MB warning on the OSM PBF path; the far more common DuckDB ingestion path had nothing.

This mirrors the OSM PBF guard, but keys on **feature count** rather than byte size, since byte size is a poor proxy for compressed GeoParquet (a small file can hold millions of rows). DuckDB answers `COUNT(*)` from Parquet metadata without a scan and far more cheaply than the full materialization.

## Changes

- **New `duckdb-vector-guard.ts`** (wasm-free): `DUCKDB_VECTOR_FEATURE_WARN_COUNT` (500k), `DuckDbVectorLoadOptions.onLargeDataset` callback, the `VectorLoadCancelledError` sentinel, and a pure `confirmLargeDataset` helper. Kept separate from the loader so it can be imported by the eagerly-loaded UI shell and unit-tested under `node --test` without pulling in DuckDB-WASM.
- **`loadDuckDbVectorFile`** runs a cheap `COUNT(*)` and prompts before the expensive GeoJSON materialization — **only when a callback is attached**, so the non-interactive path (KMZ sub-loads, conversions, tests) stays single-pass.
- **`tauri-io.ts`**: threads the optional callback through the ingestion functions; dropped-file batches catch the cancellation sentinel so declining one oversized file skips just that file without aborting the rest of the drop. Cancellation is matched by `name` (not `instanceof`) to keep the heavy loader a lazy dynamic import.
- **`DesktopShell.tsx`** drop handlers pass a blocking `window.confirm` guard, matching the existing OSM PBF drop UX. The guard module is imported type-only here so DuckDB-WASM stays out of the shell chunk.

## Notes

The issue also mentions *decimate* and *tiled-path* options. The tiled path is explicitly a companion to the client-side vector tiling issue (out of scope here); the `onLargeDataset` callback API is shaped so a richer dialog offering those can be layered on later without touching the loader.

## Testing

- `tests/duckdb-vector-guard.test.ts` — 6 unit tests covering the guard decision logic (no callback, below/at threshold, proceed, decline, async decline).
- `npm run test:frontend` — 704 tests pass.
- `npm run typecheck` (full build) passes; the `duckdb` chunk remains separate (dynamic import preserved).
- `pre-commit run --files <changed>` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a confirmation prompt when importing large vector datasets, showing the dataset name and approximate feature count, with an option to proceed or skip before processing begins.
  * Batch vector imports now handle user-declined oversized datasets by skipping only the affected file/layer and continuing the rest of the batch.

* **Bug Fixes**
  * Oversized-load cancellation is now consistently respected across both browser and Tauri import flows, including KMZ processing, without failing the entire import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->