### PR TITLE
perf(history): bound undo memory for large vector layers (#341)

### DIFF
--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -13,6 +13,87 @@ export function getHistoryCoalesceMs(): number {
   return historyCoalesceMs;
 }
 
+/**
+ * Soft budget (in total feature count) for the geometry/attribute payload
+ * retained across undo snapshots. Each in-app edit of a vector layer pushes a
+ * new snapshot that holds the layer's full `geojson`; without a bound, editing
+ * a large layer many times pins several copies of its feature set in memory
+ * (issue #341). When the distinct features across snapshots exceed this budget,
+ * the oldest snapshots are dropped (see {@link trimHistoryBySize}).
+ *
+ * Feature count is a cheap proxy for payload size; it avoids serializing
+ * geometry on every edit. The default is generous enough that ordinary
+ * multi-step editing of small/medium layers keeps the full history depth, while
+ * very large layers trade history depth for a bounded footprint.
+ */
+let maxHistoryFeatureCount = 500_000;
+
+export function setMaxHistoryFeatureCount(count: number): void {
+  maxHistoryFeatureCount = count;
+}
+
+export function getMaxHistoryFeatureCount(): number {
+  return maxHistoryFeatureCount;
+}
+
+/** Structural shape of a partialized undo snapshot, for size accounting. */
+interface HistorySnapshot {
+  layers?: { geojson?: { features?: unknown[] } | null }[];
+}
+
+/**
+ * Sum the feature counts of a snapshot's layer `geojson` payloads, skipping any
+ * payload whose object reference is already in `seen` so feature sets shared
+ * across snapshots (unchanged layers keep the same reference) are counted once.
+ * Mutates `seen` with each newly counted payload.
+ */
+function distinctFeatureCount(
+  snapshot: HistorySnapshot,
+  seen: Set<object>,
+): number {
+  let count = 0;
+  for (const layer of snapshot.layers ?? []) {
+    const geojson = layer?.geojson;
+    const features = geojson?.features;
+    if (!geojson || !Array.isArray(features) || seen.has(geojson)) continue;
+    seen.add(geojson);
+    count += features.length;
+  }
+  return count;
+}
+
+/**
+ * Bound the memory held by undo history by dropping the oldest snapshots whose
+ * combined feature payload exceeds `maxFeatures`.
+ *
+ * Walks newest-to-oldest and keeps the most recent snapshots whose cumulative
+ * distinct feature count fits the budget. The single newest snapshot is always
+ * kept regardless of size, so one-step undo of even a huge edit still works.
+ * Feature sets shared by reference across snapshots (unchanged layers) are
+ * counted once, so retaining many snapshots of small layers stays cheap.
+ *
+ * Returns the original array when nothing needs trimming, or a trimmed slice
+ * (oldest entries removed) otherwise. Pure: never mutates its input.
+ */
+export function trimHistoryBySize<T extends HistorySnapshot>(
+  pastStates: T[],
+  maxFeatures: number,
+): T[] {
+  if (pastStates.length <= 1) return pastStates;
+  const seen = new Set<object>();
+  const lastIndex = pastStates.length - 1;
+  // The newest snapshot is always retained, even if it alone exceeds the budget.
+  let total = distinctFeatureCount(pastStates[lastIndex], seen);
+  let keepFrom = lastIndex;
+  for (let i = lastIndex - 1; i >= 0; i--) {
+    const added = distinctFeatureCount(pastStates[i], seen);
+    if (total + added > maxFeatures) break;
+    total += added;
+    keepFrom = i;
+  }
+  return keepFrom === 0 ? pastStates : pastStates.slice(keepFrom);
+}
+
 /** A debounced function with a `cancel` to clear its in-flight burst window. */
 export type DebouncedFn<A extends unknown[]> = ((...args: A) => void) & {
   /** Clear the active burst timer so the next call fires on its leading edge. */

--- a/packages/core/src/history.ts
+++ b/packages/core/src/history.ts
@@ -29,6 +29,11 @@ export function getHistoryCoalesceMs(): number {
 let maxHistoryFeatureCount = 500_000;
 
 export function setMaxHistoryFeatureCount(count: number): void {
+  if (!Number.isFinite(count) || count < 0) {
+    throw new RangeError(
+      `maxHistoryFeatureCount must be a non-negative finite number, got ${count}`,
+    );
+  }
   maxHistoryFeatureCount = count;
 }
 
@@ -54,10 +59,12 @@ function distinctFeatureCount(
   let count = 0;
   for (const layer of snapshot.layers ?? []) {
     const geojson = layer?.geojson;
-    const features = geojson?.features;
-    if (!geojson || !Array.isArray(features) || seen.has(geojson)) continue;
+    // Dedup the reference first so a payload shared across snapshots is visited
+    // once even when its `features` is missing/malformed (it then contributes 0).
+    if (!geojson || seen.has(geojson)) continue;
     seen.add(geojson);
-    count += features.length;
+    if (!Array.isArray(geojson.features)) continue;
+    count += geojson.features.length;
   }
   return count;
 }
@@ -79,6 +86,11 @@ export function trimHistoryBySize<T extends HistorySnapshot>(
   pastStates: T[],
   maxFeatures: number,
 ): T[] {
+  if (!Number.isFinite(maxFeatures) || maxFeatures < 0) {
+    throw new RangeError(
+      `maxFeatures must be a non-negative finite number, got ${maxFeatures}`,
+    );
+  }
   if (pastStates.length <= 1) return pastStates;
   const seen = new Set<object>();
   const lastIndex = pastStates.length - 1;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,6 +27,9 @@ export {
 export {
   getHistoryCoalesceMs,
   setHistoryCoalesceMs,
+  getMaxHistoryFeatureCount,
+  setMaxHistoryFeatureCount,
+  trimHistoryBySize,
 } from "./history";
 export {
   DEFAULT_FORWARD_GEOCODE_ENDPOINT,

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -335,16 +335,16 @@ let cancelHistoryCoalesce: () => void = () => {};
 /**
  * Drop the oldest undo snapshots once their combined feature payload exceeds the
  * configured budget, bounding the memory held by history when a large vector
- * layer is edited repeatedly (issue #341). Runs after every recorded change.
- * Operates on the temporal store directly; this never touches the main store, so
- * it does not itself record a history entry.
+ * layer is edited repeatedly (issue #341). Called after a snapshot is appended.
+ * Operates on the live temporal store directly; this never touches the main
+ * store, so it does not itself record a history entry.
  */
 function pruneHistoryBySize(): void {
-  const temporal = useAppStore.temporal;
-  const { pastStates } = temporal.getState();
+  const temporalStore = useAppStore.temporal;
+  const { pastStates } = temporalStore.getState();
   const trimmed = trimHistoryBySize(pastStates, getMaxHistoryFeatureCount());
   if (trimmed.length !== pastStates.length) {
-    temporal.setState({ pastStates: trimmed });
+    temporalStore.setState({ pastStates: trimmed });
   }
 }
 
@@ -876,12 +876,17 @@ export const useAppStore = create<AppState>()(
       handleSet: (baseHandleSet) => {
         const debounced = leadingDebounce(baseHandleSet, getHistoryCoalesceMs);
         cancelHistoryCoalesce = debounced.cancel;
-        // After the (leading-edge) save pushes a snapshot, trim history back
-        // under the feature-payload budget so editing large layers can't pin
-        // unbounded copies of their feature sets in memory (issue #341).
+        // Trim history back under the feature-payload budget so editing large
+        // layers can't pin unbounded copies of their feature sets in memory
+        // (issue #341). Only the leading-edge call actually pushes a snapshot;
+        // burst-suppressed calls leave `pastStates` untouched, so skip the scan
+        // unless a new snapshot was appended.
         return (...args: Parameters<typeof debounced>) => {
+          const before = useAppStore.temporal.getState().pastStates;
           debounced(...args);
-          pruneHistoryBySize();
+          if (useAppStore.temporal.getState().pastStates !== before) {
+            pruneHistoryBySize();
+          }
         };
       },
     }

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -3,7 +3,12 @@ import { v4 as uuidv4 } from "uuid";
 import { create } from "zustand";
 import { shallow } from "zustand/shallow";
 import { temporal } from "zundo";
-import { getHistoryCoalesceMs, leadingDebounce } from "./history";
+import {
+  getHistoryCoalesceMs,
+  getMaxHistoryFeatureCount,
+  leadingDebounce,
+  trimHistoryBySize,
+} from "./history";
 import {
   applyProjectToStore,
   type CreateProjectOptions,
@@ -326,6 +331,22 @@ function layerGroupsEqualForHistory(
 
 /** Cancels the active history coalesce window (assigned by zundo's handleSet). */
 let cancelHistoryCoalesce: () => void = () => {};
+
+/**
+ * Drop the oldest undo snapshots once their combined feature payload exceeds the
+ * configured budget, bounding the memory held by history when a large vector
+ * layer is edited repeatedly (issue #341). Runs after every recorded change.
+ * Operates on the temporal store directly; this never touches the main store, so
+ * it does not itself record a history entry.
+ */
+function pruneHistoryBySize(): void {
+  const temporal = useAppStore.temporal;
+  const { pastStates } = temporal.getState();
+  const trimmed = trimHistoryBySize(pastStates, getMaxHistoryFeatureCount());
+  if (trimmed.length !== pastStates.length) {
+    temporal.setState({ pastStates: trimmed });
+  }
+}
 
 export const useAppStore = create<AppState>()(
   temporal(
@@ -855,7 +876,13 @@ export const useAppStore = create<AppState>()(
       handleSet: (baseHandleSet) => {
         const debounced = leadingDebounce(baseHandleSet, getHistoryCoalesceMs);
         cancelHistoryCoalesce = debounced.cancel;
-        return debounced;
+        // After the (leading-edge) save pushes a snapshot, trim history back
+        // under the feature-payload budget so editing large layers can't pin
+        // unbounded copies of their feature sets in memory (issue #341).
+        return (...args: Parameters<typeof debounced>) => {
+          debounced(...args);
+          pruneHistoryBySize();
+        };
       },
     }
   )

--- a/tests/undo-redo.test.ts
+++ b/tests/undo-redo.test.ts
@@ -2,8 +2,11 @@ import assert from "node:assert/strict";
 import { beforeEach, describe, it } from "node:test";
 import {
   getHistoryCoalesceMs,
+  getMaxHistoryFeatureCount,
   leadingDebounce,
   setHistoryCoalesceMs,
+  setMaxHistoryFeatureCount,
+  trimHistoryBySize,
 } from "../packages/core/src/history";
 import { clearHistory, redo, undo, useAppStore } from "../packages/core/src/store";
 import { createEmptyProject } from "../packages/core/src/project";
@@ -66,7 +69,58 @@ describe("history coalesce config", () => {
   });
 });
 
+/** A snapshot with one layer whose geojson holds `n` placeholder features. */
+function snapshot(features: number, geojson?: { features: unknown[] }) {
+  const gj = geojson ?? { features: Array.from({ length: features }) };
+  return { layers: [{ geojson: gj }] };
+}
+
+describe("trimHistoryBySize", () => {
+  it("returns the input unchanged when under the budget", () => {
+    const past = [snapshot(10), snapshot(10), snapshot(10)];
+    assert.equal(trimHistoryBySize(past, 1000), past);
+  });
+
+  it("does not trim a zero- or one-entry history", () => {
+    assert.deepEqual(trimHistoryBySize([], 0), []);
+    const one = [snapshot(10_000)];
+    assert.equal(trimHistoryBySize(one, 1), one);
+  });
+
+  it("drops the oldest snapshots once the budget is exceeded", () => {
+    // Each snapshot carries 100 distinct features; budget 250 keeps the newest 2.
+    const past = [snapshot(100), snapshot(100), snapshot(100), snapshot(100)];
+    const trimmed = trimHistoryBySize(past, 250);
+    assert.deepEqual(trimmed, [past[2], past[3]]);
+  });
+
+  it("always keeps the newest snapshot even if it alone exceeds the budget", () => {
+    const past = [snapshot(100), snapshot(5000)];
+    const trimmed = trimHistoryBySize(past, 250);
+    assert.deepEqual(trimmed, [past[1]]);
+  });
+
+  it("counts feature sets shared by reference only once", () => {
+    // An unchanged layer keeps the same geojson reference across snapshots, so a
+    // long history of shared payloads stays cheap and is never trimmed.
+    const shared = { features: Array.from({ length: 1000 }) };
+    const past = Array.from({ length: 50 }, () => snapshot(0, shared));
+    assert.equal(trimHistoryBySize(past, 1500), past);
+  });
+});
+
 const emptyFC = { type: "FeatureCollection" as const, features: [] };
+
+function bigFC(n: number) {
+  return {
+    type: "FeatureCollection" as const,
+    features: Array.from({ length: n }, (_, i) => ({
+      type: "Feature" as const,
+      geometry: { type: "Point" as const, coordinates: [i, i] },
+      properties: { i },
+    })),
+  };
+}
 
 function pastLen(): number {
   return useAppStore.temporal.getState().pastStates.length;
@@ -101,6 +155,59 @@ describe("store history tracking", () => {
     useAppStore.getState().setPointerCoords([1, 2]);
     useAppStore.getState().setAttributeFilter("abc");
     assert.equal(pastLen(), before);
+  });
+});
+
+describe("history size budget (issue #341)", () => {
+  beforeEach(() => {
+    setHistoryCoalesceMs(0);
+    useAppStore.getState().newProject({ name: "reset" });
+    useAppStore.temporal.getState().clear();
+  });
+
+  it("caps retained snapshots by feature payload for a large layer", () => {
+    const original = getMaxHistoryFeatureCount();
+    setMaxHistoryFeatureCount(250); // budget fits ~2 snapshots of a 100-feature layer
+    try {
+      const id = useAppStore.getState().addGeoJsonLayer("big", bigFC(100));
+      // Each edit replaces the layer's geojson with a fresh 100-feature set, so
+      // every edit would otherwise retain another full copy in history.
+      for (let i = 0; i < 10; i++) {
+        useAppStore.getState().updateLayer(id, { geojson: bigFC(100) });
+      }
+      // Without the budget this would be 11 snapshots (add + 10 edits); the
+      // budget keeps only the newest few whose payload fits ~250 features.
+      assert.ok(pastLen() >= 1 && pastLen() <= 3, `got ${pastLen()} snapshots`);
+      // The most recent edit is still undoable.
+      undo();
+      assert.equal(
+        useAppStore.getState().layers[0].geojson?.features.length,
+        100,
+      );
+    } finally {
+      setMaxHistoryFeatureCount(original);
+    }
+  });
+
+  it("keeps full history depth for small layers under the budget", () => {
+    const original = getMaxHistoryFeatureCount();
+    setMaxHistoryFeatureCount(500_000);
+    try {
+      const id = useAppStore.getState().addGeoJsonLayer("small", bigFC(1));
+      for (let i = 0; i < 10; i++) {
+        useAppStore.getState().updateLayer(id, { geojson: bigFC(1) });
+      }
+      assert.equal(pastLen(), 11); // add + 10 edits, nothing trimmed
+    } finally {
+      setMaxHistoryFeatureCount(original);
+    }
+  });
+
+  it("round-trips the feature-count budget", () => {
+    const original = getMaxHistoryFeatureCount();
+    setMaxHistoryFeatureCount(1234);
+    assert.equal(getMaxHistoryFeatureCount(), 1234);
+    setMaxHistoryFeatureCount(original);
   });
 });
 

--- a/tests/undo-redo.test.ts
+++ b/tests/undo-redo.test.ts
@@ -176,14 +176,14 @@ describe("history size budget (issue #341)", () => {
         useAppStore.getState().updateLayer(id, { geojson: bigFC(100) });
       }
       // Without the budget this would be 11 snapshots (add + 10 edits); the
-      // budget keeps only the newest few whose payload fits ~250 features.
-      assert.ok(pastLen() >= 1 && pastLen() <= 3, `got ${pastLen()} snapshots`);
-      // The most recent edit is still undoable.
+      // budget (250) keeps exactly the newest 2 of the 100-feature snapshots.
+      assert.equal(pastLen(), 2, `got ${pastLen()} snapshots`);
+      // The most recent edit is still undoable: undo swaps in the prior payload.
+      const latestGeojson = useAppStore.getState().layers[0].geojson;
       undo();
-      assert.equal(
-        useAppStore.getState().layers[0].geojson?.features.length,
-        100,
-      );
+      const revertedGeojson = useAppStore.getState().layers[0].geojson;
+      assert.notStrictEqual(revertedGeojson, latestGeojson);
+      assert.equal(revertedGeojson?.features.length, 100);
     } finally {
       setMaxHistoryFeatureCount(original);
     }
@@ -208,6 +208,15 @@ describe("history size budget (issue #341)", () => {
     setMaxHistoryFeatureCount(1234);
     assert.equal(getMaxHistoryFeatureCount(), 1234);
     setMaxHistoryFeatureCount(original);
+  });
+
+  it("rejects non-finite or negative budgets", () => {
+    const original = getMaxHistoryFeatureCount();
+    assert.throws(() => setMaxHistoryFeatureCount(Number.NaN), RangeError);
+    assert.throws(() => setMaxHistoryFeatureCount(-1), RangeError);
+    assert.throws(() => setMaxHistoryFeatureCount(Infinity), RangeError);
+    assert.throws(() => trimHistoryBySize([], Number.NaN), RangeError);
+    assert.equal(getMaxHistoryFeatureCount(), original); // unchanged by failed sets
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #341. The temporal store kept up to 100 undo snapshots, and `partialize` tracked the entire `layers` array, which carries each layer's full `geojson`. Because mutating actions create new layer objects, editing attributes/geometry on a large vector layer pushed new snapshots that retained prior full feature sets, pinning multiples of the dataset in memory.

## Approach

Implements the proposal's "cap snapshot count by total payload size" option with a memory-aware twist:

- New pure helper `trimHistoryBySize(pastStates, maxFeatures)` in `packages/core/src/history.ts` drops the **oldest** snapshots once their combined geojson feature payload exceeds a budget.
- Feature sets shared by reference across snapshots (unchanged layers keep the same `geojson` reference) are counted **once**, so a long history of small/medium layers stays cheap and keeps full depth.
- The single newest snapshot is **always** retained, so one-step undo of even a huge edit still works.
- Feature count is used as a cheap proxy for payload size (no per-edit serialization).
- The budget (default `500_000` features) is runtime-settable via `setMaxHistoryFeatureCount`, mirroring the existing coalesce-window config, and is wired into the store's `handleSet` so it runs after every recorded change. It operates only on the temporal store, so it never records a history entry itself.

## Testing

- `npm run test:frontend` — 706 pass
- New unit tests for `trimHistoryBySize` (budget, always-keep-newest, reference dedup) and integration tests through the store proving large layers get capped history while small layers keep full depth and undo still restores the latest edit.
- `pre-commit run --files ...` (eslint + full npm build) passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable memory budget for undo history when working with large vector layers; once exceeded, older undo snapshots are automatically trimmed while always keeping the newest undo state (default: 500,000 features).
  * Provided public helpers to get/set the history budget and to trim history according to the configured limit.
* **Bug Fixes**
  * Prevents excessive memory growth by enforcing the undo-history cap during temporal edits.
* **Tests**
  * Added coverage for trimming behavior, shared payload counting, and budget getter/setter validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->