### PR TITLE
feat(geocoding): surface Google CORS hint and broaden API-key warning

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -951,6 +951,11 @@ export function SettingsDialog({
                                 ? t("settings.geocoding.optionalKey")
                                 : t("settings.geocoding.noKey")}
                           </p>
+                          {provider.browserCorsRestricted ? (
+                            <p className="text-xs text-amber-600 dark:text-amber-500">
+                              {t("settings.geocoding.corsNote")}
+                            </p>
+                          ) : null}
                         </div>
 
                         {provider.acceptsApiKey ? (

--- a/apps/geolibre-desktop/src/components/processing/GeocodeDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/GeocodeDialog.tsx
@@ -357,6 +357,12 @@ export function GeocodeDialog({
             </p>
           ) : null}
 
+          {provider.browserCorsRestricted ? (
+            <p className="text-xs text-amber-600 dark:text-amber-500">
+              {t("geocode.corsNote")}
+            </p>
+          ) : null}
+
           {csv ? (
             <div className="flex flex-col gap-1">
               <Label className="text-xs">{t("geocode.addressColumn")}</Label>

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -151,7 +151,8 @@
       "email": "Contact email (optional)",
       "emailPlaceholder": "you@example.org",
       "emailHint": "Sent to identify the client to Nominatim, per its usage policy.",
-      "secretsWarning": "Keys are stored in plain text in the project file and may be exposed when the project is shared."
+      "secretsWarning": "Keys are stored in plain text in the project file and may be exposed when the project is shared. They are also sent as query parameters, so they appear in geocoding request URLs visible in browser DevTools and any proxy logs.",
+      "corsNote": "Google does not officially allow browser requests to its Geocoding API, so requests may be blocked unless served through a same-origin proxy."
     },
     "project": {
       "title": "Project",
@@ -484,6 +485,7 @@
     "provider": "Geocoding provider",
     "providerHint": "Configure provider API keys and endpoints in Settings.",
     "apiKeyRequired": "{{provider}} needs an API key. Add one in Settings to get results.",
+    "corsNote": "Google does not officially allow browser requests to its Geocoding API; requests may be blocked unless served through a same-origin proxy.",
     "addressColumn": "Address column",
     "run": "Geocode",
     "cancel": "Cancel",

--- a/packages/core/src/geocoding.ts
+++ b/packages/core/src/geocoding.ts
@@ -123,6 +123,12 @@ export interface GeocodingProvider {
    * geocode.earth endpoint needs a key, a self-hosted instance does not).
    */
   acceptsApiKey: boolean;
+  /**
+   * Whether the provider's API blocks browser cross-origin requests, so it
+   * needs a same-origin proxy to work in the webview. The UI surfaces a hint
+   * when true. Only set for Google's Geocoding API today.
+   */
+  browserCorsRestricted?: boolean;
   /** Default forward endpoint used when the project does not override it. */
   defaultForwardEndpoint: string;
   /** Default reverse endpoint used when the project does not override it. */
@@ -565,6 +571,7 @@ const googleProvider: GeocodingProvider = {
   reverse: true,
   requiresApiKey: true,
   acceptsApiKey: true,
+  browserCorsRestricted: true,
   defaultForwardEndpoint: "https://maps.googleapis.com/maps/api/geocode/json",
   defaultReverseEndpoint: "https://maps.googleapis.com/maps/api/geocode/json",
   // The Geocoding API has no result-count parameter, so the batch loop's


### PR DESCRIPTION
## Summary

Follow-up to #361. These three changes were made during the #346 review round but landed on the branch **after** #361 was squash-merged (at the round-2 commit), so they never reached `main`. This PR re-applies them.

- **`geocoding.ts`:** add an optional `browserCorsRestricted` flag on the provider interface, set for Google (its Geocoding API does not officially allow browser cross-origin requests).
- **Settings → Geocoding and the Geocode Addresses dialog:** show a CORS/proxy hint when a `browserCorsRestricted` provider (Google) is selected, so users are not left with a silent network failure.
- **`en.json`:** expand the geocoding `secretsWarning` to note API keys are sent as query parameters and therefore appear in geocoding request URLs (browser DevTools, proxy logs), not just the project file.

## Verification

`npm run typecheck` (full build) and `npm run test:frontend` (766 pass) both clean on top of current `main`; pre-commit clean.

These correspond to two CodeRabbit/Claude review threads that were resolved on #361 citing a commit that did not end up in the merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved geocoding provider settings with CORS restriction notices. Users will now see helpful warnings displayed in both the settings and geocoding configuration dialogs when a provider restricts browser cross-origin requests. These informational notices explain the cross-origin limitations users may encounter and detail available same-origin proxy workarounds and solutions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->