### PR TITLE
feat(python): typed read-back of selected/drawn features and to_html export

### DIFF
--- a/apps/geolibre-desktop/src/lib/scripting/scriptingApi.ts
+++ b/apps/geolibre-desktop/src/lib/scripting/scriptingApi.ts
@@ -7,7 +7,8 @@ import {
   type ProcessingAlgorithm,
   type ProcessingContext,
 } from "@geolibre/processing";
-import type { FeatureCollection } from "geojson";
+import { SKETCHES_SOURCE_KIND } from "@geolibre/plugins";
+import type { Feature, FeatureCollection } from "geojson";
 import type { MapController } from "@geolibre/map";
 import { captureMapImage } from "../print-layout-export";
 
@@ -88,6 +89,33 @@ export function createScriptingHandlers(deps: ScriptingDeps): ScriptingHandlers 
         .layers.find((item) => item.id === layerId);
       if (!layer) throw new Error(`No layer with id "${layerId}"`);
       return layer.geojson?.features ?? [];
+    },
+    getSelectedFeatures: () => {
+      // Selection is a single layer+feature pair in the store; return it as a
+      // (0-or-1 element) list so the shape is forward-compatible with
+      // multi-select and matches getLayerFeatures/getDrawnFeatures.
+      const state = useAppStore.getState();
+      const { selectedLayerId, selectedFeatureId } = state;
+      if (!selectedLayerId || !selectedFeatureId) return [];
+      const layer = state.layers.find((item) => item.id === selectedLayerId);
+      const features = layer?.geojson?.features ?? [];
+      // Mirror the controller's id convention (String(feature.id ?? index)) so a
+      // selectedFeatureId derived from an index still resolves.
+      const match = features.find(
+        (feature, index) => String(feature.id ?? index) === selectedFeatureId,
+      );
+      return match ? [match] : [];
+    },
+    getDrawnFeatures: () => {
+      // Features the user drew with the Geo Editor land in store layers tagged
+      // with the Sketches source kind; gather every such layer's features.
+      const features: Feature[] = [];
+      for (const layer of useAppStore.getState().layers) {
+        if (layer.metadata.sourceKind === SKETCHES_SOURCE_KIND) {
+          features.push(...(layer.geojson?.features ?? []));
+        }
+      }
+      return features;
     },
     listLayers: () =>
       useAppStore.getState().layers.map((layer) => ({

--- a/docs/python.md
+++ b/docs/python.md
@@ -137,7 +137,14 @@ features = m.layers[0].get_features()   # list of GeoJSON Feature objects
 m.list_algorithms()
 m.run_algorithm("buffer", {"layer": layer_id, "distance": 1000})
 
+# Read back what the user selected or drew on the map
+m.get_selected_features()      # the clicked feature(s) as Feature objects
+m.get_drawn_features()         # features sketched with the Geo Editor
+m.user_rois                    # the drawn ROIs as a GeoJSON FeatureCollection
+m.get_drawn_features(as_gdf=True)   # the same, as a GeoDataFrame (needs GeoPandas)
+
 png = m.to_image()             # PNG bytes (or m.to_image("map.png"))
+m.to_html("map.html")          # standalone HTML embedding the live project
 ```
 
 React to user interaction with event callbacks:
@@ -164,10 +171,13 @@ m.on_layer_change(lambda e: print("layers", e["layerIds"]))
 | `fit_bounds([w, s, e, n])` | Fit the camera to a bounding box. |
 | `identify(lng, lat, layer_id=None)` | Query rendered features at a point. |
 | `get_features(layer_id)` | A layer's features as `Feature` objects. |
+| `get_selected_features(as_gdf=False)` | The feature(s) selected in the app, as `Feature` objects (or a GeoDataFrame). |
+| `get_drawn_features(as_gdf=False)` / `user_rois` | Features drawn with the Geo Editor; `user_rois` returns them as a FeatureCollection. |
 | `layers` / `get_layer(id)` | `Layer` handles (read state; set `name`/`visible`/`opacity`, `set_style`, `get_features`, `zoom_to`, `remove`). |
 | `list_algorithms()` | Available processing algorithms (`id`, `parameters`, …). |
 | `run_algorithm(id, parameters=None, timeout=)` | Run an algorithm; returns `{logs, resultLayerIds}`. |
 | `to_image(path=None, timeout=)` | Capture the map as PNG bytes, or write to `path`. |
+| `to_html(path=None, title=, width=, height=, app_url=)` | Export a standalone HTML page that embeds the current project; returns the HTML or writes to `path`. |
 | `on(event, cb)` / `on_click` / `on_selection_change` / `on_layer_change` | Register event callbacks; returns an unsubscribe function. |
 | `request(method, params=None, timeout=)` | Low-level command primitive behind the methods above. |
 

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -176,6 +176,7 @@ export { maplibreFemaWmsPlugin } from "./plugins/maplibre-fema-wms";
 export {
   maplibreGeoEditorPlugin,
   canEditLayerGeometry,
+  SKETCHES_SOURCE_KIND,
   startLayerGeometryEdit,
   endLayerGeometryEdit,
   getGeometryEditTargetLayerId,

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -15,7 +15,10 @@ import type {
   GeoLibrePlugin,
 } from "../types";
 
-export { canEditLayerGeometry } from "./geo-editor-geometry";
+export {
+  canEditLayerGeometry,
+  SKETCHES_SOURCE_KIND,
+} from "./geo-editor-geometry";
 
 const SKETCHES_LAYER_NAME = "Sketches";
 const SKETCHES_SOURCE_PATH = "geoeditor://sketches";

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import copy
+import html as _html
 import json
 import math
 import os
@@ -85,6 +86,60 @@ def _read_local_vector(path: Any, data_format: str | None = None) -> dict[str, A
             f"Vector file exceeds the 50 MB GeoJSON size limit after conversion: {path}"
         )
     return json.loads(geojson)
+
+
+def _html_escape(value: str) -> str:
+    """Escape a string for safe interpolation into HTML attributes/text."""
+    return _html.escape(str(value), quote=True)
+
+
+# Standalone export shell: an iframe hosting the GeoLibre app plus a script that
+# replays the inlined project into it once the app announces it is ready, using
+# the same postMessage protocol useEmbedBridge/useCommandBridge speak. The
+# project is carried in a JSON <script> block rather than a JS string literal so
+# it needs no JS-string escaping. {0}-style fields are filled by str.format, so
+# literal CSS/JS braces are doubled.
+_HTML_EXPORT_TEMPLATE = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>{title}</title>
+<style>
+  html, body {{ margin: 0; padding: 0; height: 100%; }}
+  #geolibre-frame {{ border: 0; display: block; width: {width}; height: {height}; }}
+</style>
+</head>
+<body>
+<iframe id="geolibre-frame" src="{iframe_src}" allow="fullscreen" allowfullscreen></iframe>
+<script type="application/json" id="geolibre-project">{project_json}</script>
+<script>
+(function () {{
+  var frame = document.getElementById("geolibre-frame");
+  var project = JSON.parse(
+    document.getElementById("geolibre-project").textContent
+  );
+  var loaded = false;
+  function load() {{
+    if (loaded || !frame.contentWindow) return;
+    loaded = true;
+    frame.contentWindow.postMessage(
+      {{ type: "geolibre:load-project", project: project, seq: 1 }},
+      "*"
+    );
+  }}
+  // The app posts "geolibre:ready" once mounted; reply with the project. Guard
+  // on the frame as the source so an unrelated message cannot trigger the load.
+  window.addEventListener("message", function (event) {{
+    if (event.source !== frame.contentWindow) return;
+    var data = event.data;
+    if (data && data.type === "geolibre:ready") load();
+  }});
+}})();
+</script>
+</body>
+</html>
+"""
 
 
 class Map(anywidget.AnyWidget):
@@ -553,6 +608,88 @@ class Map(anywidget.AnyWidget):
         )
         return [Feature(f) for f in features or []]
 
+    @staticmethod
+    def _features_to_gdf(features: list[Feature]) -> Any:
+        """Build an EPSG:4326 GeoDataFrame from GeoJSON features.
+
+        Args:
+            features: The features to wrap (each a GeoJSON Feature mapping).
+
+        Returns:
+            A ``geopandas.GeoDataFrame`` in EPSG:4326.
+
+        Raises:
+            ImportError: If GeoPandas is not installed.
+        """
+        try:
+            import geopandas
+        except ImportError as exc:
+            raise ImportError(
+                "Returning features as a GeoDataFrame requires GeoPandas. Install "
+                "it with `pip install geopandas`, or omit as_gdf=True to get a list "
+                "of Feature objects instead."
+            ) from exc
+        # from_features accepts plain GeoJSON mappings (Feature is a dict subclass)
+        # and yields an empty frame for an empty list, so no special-casing.
+        return geopandas.GeoDataFrame.from_features(features, crs="EPSG:4326")
+
+    def get_selected_features(
+        self, *, as_gdf: bool = False, timeout: float = 10.0
+    ) -> list[Feature] | Any:
+        """Return the features currently selected in the app.
+
+        Reads the live selection (the layer/feature highlighted by clicking a
+        feature in the UI). Selection is a single feature, so the result is a
+        list of zero or one :class:`Feature`; the list shape leaves room for
+        future multi-select.
+
+        Args:
+            as_gdf: Return a ``geopandas.GeoDataFrame`` instead of a list of
+                :class:`Feature` objects (requires GeoPandas).
+            timeout: Seconds to wait for the reply.
+
+        Returns:
+            A list of :class:`Feature` objects, or a ``GeoDataFrame`` when
+            ``as_gdf`` is true.
+        """
+        features = self.request("getSelectedFeatures", timeout=timeout)
+        feats = [Feature(f) for f in features or []]
+        return self._features_to_gdf(feats) if as_gdf else feats
+
+    def get_drawn_features(
+        self, *, as_gdf: bool = False, timeout: float = 10.0
+    ) -> list[Feature] | Any:
+        """Return the features the user drew with the Geo Editor.
+
+        Gathers the features from the app's "Sketches" layer(s) (the regions of
+        interest drawn with the drawing tools), so a notebook can read back what
+        was sketched on the map without knowing which layer it landed in.
+
+        Args:
+            as_gdf: Return a ``geopandas.GeoDataFrame`` instead of a list of
+                :class:`Feature` objects (requires GeoPandas).
+            timeout: Seconds to wait for the reply.
+
+        Returns:
+            A list of :class:`Feature` objects, or a ``GeoDataFrame`` when
+            ``as_gdf`` is true.
+        """
+        features = self.request("getDrawnFeatures", timeout=timeout)
+        feats = [Feature(f) for f in features or []]
+        return self._features_to_gdf(feats) if as_gdf else feats
+
+    @property
+    def user_rois(self) -> dict[str, Any]:
+        """The user-drawn regions of interest as a GeoJSON FeatureCollection.
+
+        A leafmap-style accessor over :meth:`get_drawn_features`; reading it
+        round-trips to the running app, so display the map first.
+        """
+        return {
+            "type": "FeatureCollection",
+            "features": [dict(f) for f in self.get_drawn_features()],
+        }
+
     def list_algorithms(self, *, timeout: float = 10.0) -> list[dict[str, Any]]:
         """List the available client-side processing algorithms.
 
@@ -612,6 +749,75 @@ class Map(anywidget.AnyWidget):
             out.write_bytes(png)
             return None
         return png
+
+    # Hosted GeoLibre viewer used as the default to_html() app, so an exported
+    # file is portable (loads the app over the network instead of the
+    # session-bound localhost bundle).
+    _DEFAULT_HTML_APP_URL = "https://viewer.geolibre.app/"
+
+    def to_html(
+        self,
+        path: str | None = None,
+        *,
+        title: str = "GeoLibre Map",
+        width: str = "100%",
+        height: str | None = None,
+        app_url: str | None = None,
+    ) -> str | None:
+        """Export the current map as a standalone HTML page.
+
+        The page embeds the GeoLibre app in an ``<iframe>`` and injects the
+        current project into it over the same ``postMessage`` bridge the widget
+        uses, so it renders the map exactly as configured here. Unlike
+        :meth:`to_image` this needs no running kernel to view; by default it
+        loads the hosted GeoLibre app over the network so the file stays
+        portable.
+
+        Args:
+            path: If given, write the HTML here (parent dirs are created) and
+                return ``None``. Otherwise return the HTML string.
+            title: The exported page's ``<title>``.
+            width: CSS width of the embedded map (e.g. ``"100%"`` or ``"800px"``).
+            height: CSS height of the embedded map; defaults to this map's
+                :attr:`height`.
+            app_url: Base URL of the GeoLibre app to embed. Defaults to the
+                hosted viewer so the export is portable. Pass a self-hosted
+                deployment URL to pin a specific version, or this map's live
+                ``_app_url`` to embed the session-bound localhost bundle.
+
+        Returns:
+            The HTML string, or ``None`` when written to ``path``.
+
+        Note:
+            Layers backed by kernel-side local files (e.g. a local GeoTIFF added
+            via :meth:`add_cog`) are served only for this kernel session, so the
+            exported page cannot reach them once the kernel stops. Use hosted
+            URLs or tile sources for a fully self-contained export.
+        """
+        base_url = app_url or self._DEFAULT_HTML_APP_URL
+        # Force the embed bridge on (isEmbedded() honours ?embed=1), appending
+        # with the right separator so an app_url that already carries a query
+        # string still parses.
+        separator = "&" if "?" in base_url else "?"
+        iframe_src = f"{base_url}{separator}embed=1"
+        frame_height = height or self.height
+        # Inline the project inside a JSON <script> block and escape "<" so a
+        # property value can never break out of the script element; "<" is
+        # valid JSON that JSON.parse restores to "<".
+        project_json = json.dumps(self.project).replace("<", "\\u003c")
+        html = _HTML_EXPORT_TEMPLATE.format(
+            title=_html_escape(title),
+            width=_html_escape(width),
+            height=_html_escape(frame_height),
+            iframe_src=_html_escape(iframe_src),
+            project_json=project_json,
+        )
+        if path is not None:
+            out = pathlib.Path(path).expanduser()
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(html, encoding="utf-8")
+            return None
+        return html
 
     # -- layer object model ---------------------------------------------
 

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -9,6 +9,7 @@ import json
 import math
 import os
 import pathlib
+import re
 import time
 import uuid
 import warnings
@@ -91,6 +92,12 @@ def _read_local_vector(path: Any, data_format: str | None = None) -> dict[str, A
 def _html_escape(value: str) -> str:
     """Escape a string for safe interpolation into HTML attributes/text."""
     return _html.escape(str(value), quote=True)
+
+
+# A CSS length/percentage value (e.g. "100%", "800px", "calc(100% - 2rem)"). The
+# allowed set deliberately excludes the structural CSS characters ("{};:") so a
+# to_html() width/height cannot close the <style> rule and inject CSS.
+_CSS_DIMENSION_RE = re.compile(r"^[\w%.+\-\s()]+$")
 
 
 # Standalone export shell: an iframe hosting the GeoLibre app plus a script that
@@ -651,6 +658,11 @@ class Map(anywidget.AnyWidget):
         Returns:
             A list of :class:`Feature` objects, or a ``GeoDataFrame`` when
             ``as_gdf`` is true.
+
+        Note:
+            Only features in vector (GeoJSON) layers can be read back. A feature
+            selected in a tile or service layer carries no inline geometry, so
+            the result is an empty list; use :meth:`identify` for those layers.
         """
         features = self.request("getSelectedFeatures", timeout=timeout)
         feats = [Feature(f) for f in features or []]
@@ -795,12 +807,23 @@ class Map(anywidget.AnyWidget):
             URLs or tile sources for a fully self-contained export.
         """
         base_url = app_url or self._DEFAULT_HTML_APP_URL
-        # Force the embed bridge on (isEmbedded() honours ?embed=1), appending
-        # with the right separator so an app_url that already carries a query
-        # string still parses.
-        separator = "&" if "?" in base_url else "?"
-        iframe_src = f"{base_url}{separator}embed=1"
+        # Force the embed bridge on (isEmbedded() honours ?embed=1). Insert the
+        # parameter into the query string *before* any URL fragment: a "#..."
+        # fragment would otherwise swallow a trailing "?embed=1" (browsers read
+        # it as part of the fragment), so the app never sees the flag. partition
+        # keeps the fragment and its "#" intact when present and yields "" when
+        # absent.
+        base, hash_sep, fragment = base_url.partition("#")
+        separator = "&" if "?" in base else "?"
+        iframe_src = f"{base}{separator}embed=1{hash_sep}{fragment}"
+        # width/height land inside a <style> rule; _html_escape does not neutralise
+        # CSS metacharacters like "}" or ";", so validate them as plain CSS
+        # dimensions to keep a stray value from closing the rule and injecting CSS.
         frame_height = height or self.height
+        if not _CSS_DIMENSION_RE.match(width):
+            raise ValueError(f"to_html: invalid CSS width value {width!r}")
+        if not _CSS_DIMENSION_RE.match(frame_height):
+            raise ValueError(f"to_html: invalid CSS height value {frame_height!r}")
         # Inline the project inside a JSON <script> block and escape "<" so a
         # property value can never break out of the script element; "<" is
         # valid JSON that JSON.parse restores to "<".

--- a/python/tests/test_scripting.py
+++ b/python/tests/test_scripting.py
@@ -212,6 +212,92 @@ def test_get_features_wraps_in_feature(m, monkeypatch):
     assert feats[0].properties == {"a": 1}
 
 
+def test_get_selected_features_wraps_in_feature(m, monkeypatch):
+    monkeypatch.setattr(
+        m,
+        "request",
+        lambda method, params=None, **_k: [
+            {"type": "Feature", "properties": {"sel": 1}, "geometry": None}
+        ]
+        if method == "getSelectedFeatures"
+        else [],
+    )
+    feats = m.get_selected_features()
+    assert isinstance(feats[0], Feature)
+    assert feats[0].properties == {"sel": 1}
+
+
+def test_get_drawn_features_wraps_in_feature(m, monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        m,
+        "request",
+        lambda method, params=None, **_k: captured.update(method=method)
+        or [{"type": "Feature", "properties": {"roi": 1}, "geometry": None}],
+    )
+    feats = m.get_drawn_features()
+    assert captured["method"] == "getDrawnFeatures"
+    assert isinstance(feats[0], Feature)
+    assert feats[0].properties == {"roi": 1}
+
+
+def test_user_rois_returns_featurecollection(m, monkeypatch):
+    monkeypatch.setattr(
+        m,
+        "request",
+        lambda *_a, **_k: [
+            {"type": "Feature", "properties": {}, "geometry": None}
+        ],
+    )
+    fc = m.user_rois
+    assert fc["type"] == "FeatureCollection"
+    assert len(fc["features"]) == 1
+    # Plain dicts, not Feature instances, so the result is a clean GeoJSON value.
+    assert type(fc["features"][0]) is dict
+
+
+def test_get_drawn_features_as_gdf(m, monkeypatch):
+    geopandas = pytest.importorskip("geopandas")
+    monkeypatch.setattr(
+        m,
+        "request",
+        lambda *_a, **_k: [
+            {
+                "type": "Feature",
+                "properties": {"roi": 1},
+                "geometry": {"type": "Point", "coordinates": [1, 2]},
+            }
+        ],
+    )
+    gdf = m.get_drawn_features(as_gdf=True)
+    assert isinstance(gdf, geopandas.GeoDataFrame)
+    assert len(gdf) == 1
+    assert gdf.crs is not None
+
+
+def test_to_html_returns_string_with_project(m):
+    html = m.to_html()
+    assert "<iframe" in html
+    assert "embed=1" in html
+    assert "geolibre:load-project" in html
+    # The project rides inside the JSON <script> block.
+    assert '"mapView"' in html
+
+
+def test_to_html_writes_path(m, tmp_path):
+    out = tmp_path / "nested" / "map.html"
+    assert m.to_html(str(out)) is None
+    text = out.read_text(encoding="utf-8")
+    assert "<iframe" in text
+
+
+def test_to_html_app_url_query_separator(m):
+    # An app_url that already carries a query string must keep parsing, so the
+    # embed flag is appended with "&", not a second "?".
+    html = m.to_html(app_url="https://example.com/app?foo=bar")
+    assert "https://example.com/app?foo=bar&amp;embed=1" in html
+
+
 def test_to_image_decodes_base64(m, monkeypatch):
     png = b"\x89PNG\r\n\x1a\n fake"
     data_url = "data:image/png;base64," + base64.b64encode(png).decode()

--- a/python/tests/test_scripting.py
+++ b/python/tests/test_scripting.py
@@ -227,6 +227,24 @@ def test_get_selected_features_wraps_in_feature(m, monkeypatch):
     assert feats[0].properties == {"sel": 1}
 
 
+def test_get_selected_features_as_gdf(m, monkeypatch):
+    geopandas = pytest.importorskip("geopandas")
+    monkeypatch.setattr(
+        m,
+        "request",
+        lambda *_a, **_k: [
+            {
+                "type": "Feature",
+                "properties": {"sel": 1},
+                "geometry": {"type": "Point", "coordinates": [0, 0]},
+            }
+        ],
+    )
+    gdf = m.get_selected_features(as_gdf=True)
+    assert isinstance(gdf, geopandas.GeoDataFrame)
+    assert len(gdf) == 1
+
+
 def test_get_drawn_features_wraps_in_feature(m, monkeypatch):
     captured = {}
     monkeypatch.setattr(
@@ -296,6 +314,18 @@ def test_to_html_app_url_query_separator(m):
     # embed flag is appended with "&", not a second "?".
     html = m.to_html(app_url="https://example.com/app?foo=bar")
     assert "https://example.com/app?foo=bar&amp;embed=1" in html
+
+
+def test_to_html_inserts_embed_before_fragment(m):
+    # embed=1 must land in the query string, before any "#fragment", or the
+    # browser folds it into the fragment and the iframe never sees the flag.
+    html = m.to_html(app_url="https://example.com/app#section")
+    assert "https://example.com/app?embed=1#section" in html
+
+
+def test_to_html_rejects_css_injection_dimensions(m):
+    with pytest.raises(ValueError, match="invalid CSS width"):
+        m.to_html(width="100%; } body { background: red; }")
 
 
 def test_to_image_decodes_base64(m, monkeypatch):


### PR DESCRIPTION
Closes #349.

## What

Closes the last mile of the two-way sync design by adding ergonomic, typed read-back of user interactions plus a standalone HTML export to the `geolibre` Jupyter widget.

### Python API (`python/src/geolibre/geolibre.py`)
- `get_selected_features(as_gdf=False)` — the feature(s) currently selected in the app (returned as `Feature` objects, or a GeoDataFrame).
- `get_drawn_features(as_gdf=False)` — features the user sketched with the Geo Editor, gathered from the "Sketches" layer(s) so the caller need not know which layer they landed in.
- `user_rois` — leafmap-style property returning the drawn ROIs as a GeoJSON `FeatureCollection`.
- `to_html(path=None, title=, width=, height=, app_url=)` — exports a standalone HTML page that embeds the GeoLibre app in an iframe and injects the current project over the same `postMessage` bridge the widget uses. Defaults to the hosted viewer so the file is portable.

### Frontend (`scriptingApi.ts`)
- New `getSelectedFeatures` and `getDrawnFeatures` scripting commands, shared by the notebook bridge and the in-app Python console.
- Exported `SKETCHES_SOURCE_KIND` from `@geolibre/plugins` so the drawn-feature lookup uses a single source of truth for the Sketches metadata contract.

## Tests
- New Python tests covering the feature shaping, `user_rois`, `as_gdf`, and `to_html` (string + file + query-separator).
- Full Python suite: 126 passed, 8 skipped.
- `npm run typecheck` (full build) and scoped `pre-commit` pass.

## Notes
Layers backed by kernel-side local files are only served for the session, so a `to_html` export cannot reach them once the kernel stops; documented on the method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scripting commands and Python API methods to retrieve selected features and all drawn features from the live map.
  * Introduced `user_rois` for accessing drawn regions as GeoJSON FeatureCollections.
  * Added standalone `to_html()` export for portable map pages, including optional `app_url` embedding.
  * Exposed `SKETCHES_SOURCE_KIND` for sketch-based layer identification.
* **Documentation**
  * Added interactive Python examples and API reference updates for selections, drawn features, and HTML export.
* **Tests**
  * Expanded coverage for feature retrieval, GeoPandas conversion, `user_rois`, and `to_html()` output/validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->