### PR TITLE
feat(python): split_map, add_legend, and add_colorbar helpers (#347)

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -81,6 +81,22 @@ m.add_choropleth(
 )
 ```
 
+Add a legend, a colorbar, and a swipe (split-map) comparison:
+
+```python
+# A built-in land-cover legend, or your own {label: color} dict.
+m.add_legend(builtin="nlcd")
+m.add_legend(legend_dict={"Water": "#0000ff", "Land": "#00ff00"})
+
+# A colorbar for a continuous raster.
+m.add_colorbar(colormap="terrain", vmin=0, vmax=4000, label="Elevation", units="m")
+
+# Compare two layers (or a layer against the basemap) with a swipe slider.
+before = m.add_cog("https://example.com/before.tif", name="Before")
+after = m.add_cog("https://example.com/after.tif", name="After")
+m.split_map(before, after)
+```
+
 ## Two-way sync
 
 Because the project syncs both ways, you can pan or zoom the map in the UI and
@@ -198,6 +214,10 @@ m.on_layer_change(lambda e: print("layers", e["layerIds"]))
 | `add_3d_tiles(url, name=, altitude_offset=, request_headers=, **style)` | Add a 3D Tiles `tileset.json`. |
 | `add_video(urls, coordinates, name=, **style)` | Add a georeferenced video (four `[lng, lat]` corners). |
 | `add_basemap(basemap)` | Set the background basemap. |
+| `split_map(left_layers=None, right_layers=None, orientation=, position=, control_position=)` | Add a swipe (split-map) comparison slider between two layer sets. |
+| `add_legend(title=None, legend_dict=, labels=, colors=, builtin=, position=, shape=)` | Add a legend from a `{label: color}` dict, parallel `labels`/`colors`, or a `builtin` preset (`"nlcd"`, `"esa_worldcover"`). |
+| `add_colorbar(colormap=, vmin=, vmax=, label=, units=, colors=, orientation=, position=)` | Add a colorbar for a continuous raster, from a named colormap or custom `colors`. |
+| `add_colormap(colormap, vmin=, vmax=, label=, **kwargs)` | Add a colorbar from a named colormap (leafmap-style alias of `add_colorbar`). |
 | `set_center(lng, lat, zoom=None)` | Center (and optionally zoom) the map. |
 | `set_center_zoom(lng, lat, zoom=None)` | Alias of `set_center` (leafmap compatibility). |
 | `remove_layer(layer_id)` / `clear_layers()` | Remove layers. |

--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -20,6 +20,7 @@ from . import project as _project
 from ._server import app_port, register_local_file, serve_app
 from .basemaps import resolve_basemap
 from .color_ramp import graduated_stops
+from .legends import get_builtin_legend
 
 _HERE = pathlib.Path(__file__).parent
 _STATIC_APP = _HERE / "static" / "app"
@@ -28,6 +29,14 @@ _STATIC_APP = _HERE / "static" / "app"
 # a typo surfaces immediately instead of silently falling back in the front-end.
 _VALID_LAYOUTS = frozenset({"embed", "full", "maponly"})
 _VALID_THEMES = frozenset({"light", "dark"})
+
+# Accepted values for the split-map / legend / colorbar helpers, validated up
+# front so a typo surfaces in Python instead of silently falling back in the app.
+_VALID_CONTROL_POSITIONS = frozenset(
+    {"top-left", "top-right", "bottom-left", "bottom-right"}
+)
+_VALID_ORIENTATIONS = frozenset({"vertical", "horizontal"})
+_VALID_LEGEND_SHAPES = frozenset({"square", "circle", "line"})
 
 
 def _read_local_vector(path: Any, data_format: str | None = None) -> dict[str, Any]:
@@ -1521,6 +1530,312 @@ class Map(anywidget.AnyWidget):
 
     # leafmap compatibility alias for set_center
     set_center_zoom = set_center
+
+    # -- map controls: split map / legend / colorbar --------------------
+
+    @staticmethod
+    def _coerce_layer_ids(value: Any) -> list[str]:
+        """Coerce a layer-id input into a list of layer-id strings.
+
+        Accepts ``None`` (empty), a single layer id string, a :class:`Layer`, or
+        an iterable of those. The literal ``"__basemap__"`` is a valid id (the
+        basemap entry the swipe control recognizes).
+
+        Args:
+            value: The layer input in one of the supported forms.
+
+        Returns:
+            A list of layer-id strings.
+
+        Raises:
+            ValueError: If an entry is neither a string nor a :class:`Layer`.
+        """
+        if value is None:
+            return []
+        if isinstance(value, (str, Layer)):
+            value = [value]
+        ids: list[str] = []
+        for entry in value:
+            if isinstance(entry, Layer):
+                ids.append(entry.id)
+            elif isinstance(entry, str):
+                ids.append(entry)
+            else:
+                raise ValueError(
+                    "Layer reference must be a layer id string or a Layer; got "
+                    f"{entry!r}"
+                )
+        return ids
+
+    def split_map(
+        self,
+        left_layers: Any = None,
+        right_layers: Any = None,
+        *,
+        orientation: str = "vertical",
+        position: float = 50,
+        control_position: str = "top-left",
+    ) -> None:
+        """Add a swipe (split-map) comparison slider between two layer sets.
+
+        Enables the Layer Swipe control, which clips the left/top layers to one
+        side of a draggable slider and the right/bottom layers to the other, for
+        before/after comparisons. Drives the app's built-in swipe plugin through
+        the project, so it appears with no reload.
+
+        Args:
+            left_layers: Layer(s) shown on the left/top of the slider, as a layer
+                id, a :class:`Layer`, or a list of those. The string
+                ``"__basemap__"`` selects the basemap.
+            right_layers: Layer(s) shown on the right/bottom of the slider, in the
+                same forms as ``left_layers``.
+            orientation: ``"vertical"`` (slider moves left/right) or
+                ``"horizontal"`` (slider moves up/down).
+            position: Initial slider position as a percentage in ``[0, 100]``.
+            control_position: Corner for the swipe panel; one of ``"top-left"``,
+                ``"top-right"``, ``"bottom-left"``, ``"bottom-right"``.
+
+        Raises:
+            ValueError: If ``orientation``, ``control_position``, or a layer
+                reference is invalid.
+        """
+        if orientation not in _VALID_ORIENTATIONS:
+            raise ValueError(
+                f"orientation must be one of {sorted(_VALID_ORIENTATIONS)}, "
+                f"got {orientation!r}"
+            )
+        if control_position not in _VALID_CONTROL_POSITIONS:
+            raise ValueError(
+                "control_position must be one of "
+                f"{sorted(_VALID_CONTROL_POSITIONS)}, got {control_position!r}"
+            )
+        left = self._coerce_layer_ids(left_layers)
+        right = self._coerce_layer_ids(right_layers)
+        clamped = min(100.0, max(0.0, float(position)))
+        state = _project.swipe_state(
+            left_layers=left,
+            right_layers=right,
+            orientation=orientation,
+            position=clamped,
+        )
+
+        def mutate(p: dict[str, Any]) -> None:
+            _project.set_plugin_state(
+                p,
+                _project.SWIPE_PLUGIN_ID,
+                state,
+                position=control_position,
+            )
+
+        self._update_project(mutate)
+
+    def _update_components_state(
+        self, key: str, entry_state_builder: Callable[[Any], dict[str, Any]]
+    ) -> None:
+        """Merge one feature's state into the Components plugin settings.
+
+        The Components plugin (legend / colorbar / html) stores all its features
+        under a single settings blob keyed by feature name, so a new legend must
+        be merged in without dropping an existing colorbar (and vice versa).
+
+        Args:
+            key: The feature key (``"legend"`` or ``"colorbar"``).
+            entry_state_builder: Called with the feature's current state (or
+                ``None``) and returns its new state.
+        """
+
+        def mutate(p: dict[str, Any]) -> None:
+            plugins = _project.ensure_plugins_block(p)
+            current = plugins["settings"].get(_project.COMPONENTS_PLUGIN_ID)
+            components = dict(current) if isinstance(current, dict) else {}
+            components[key] = entry_state_builder(components.get(key))
+            # The legend/colorbar restore from their settings blob alone, so the
+            # plugin is configured but not added to activePluginIds (activating
+            # it would also mount the full Components toolbar).
+            _project.set_plugin_state(
+                p,
+                _project.COMPONENTS_PLUGIN_ID,
+                components,
+                activate=False,
+            )
+
+        self._update_project(mutate)
+
+    def add_legend(
+        self,
+        title: str | None = None,
+        *,
+        legend_dict: dict[str, str] | None = None,
+        labels: list[str] | None = None,
+        colors: list[str] | None = None,
+        builtin: str | None = None,
+        position: str = "bottom-left",
+        shape: str = "square",
+    ) -> None:
+        """Add a legend to the map.
+
+        Supply the legend entries one of three ways: a built-in preset
+        (``builtin``), a ``{label: color}`` mapping (``legend_dict``), or parallel
+        ``labels`` and ``colors`` lists. Each call adds another legend, so a map
+        can carry several at once.
+
+        Args:
+            title: Legend title. Defaults to ``"Legend"``, or the preset's title
+                when ``builtin`` is given and no title is passed.
+            legend_dict: A mapping of label to CSS color (preserves order).
+            labels: Item labels, paired position-wise with ``colors``.
+            colors: Item CSS colors, paired position-wise with ``labels``.
+            builtin: A built-in preset name (e.g. ``"nlcd"``,
+                ``"esa_worldcover"``). See
+                :func:`geolibre.legends.builtin_legend_names`.
+            position: Corner for the legend; one of ``"top-left"``,
+                ``"top-right"``, ``"bottom-left"``, ``"bottom-right"``.
+            shape: Swatch shape for every item; ``"square"``, ``"circle"``, or
+                ``"line"``.
+
+        Raises:
+            ValueError: If no entries are supplied, ``labels``/``colors`` lengths
+                differ, or ``position``/``shape``/``builtin`` is invalid.
+        """
+        if position not in _VALID_CONTROL_POSITIONS:
+            raise ValueError(
+                f"position must be one of {sorted(_VALID_CONTROL_POSITIONS)}, "
+                f"got {position!r}"
+            )
+        if shape not in _VALID_LEGEND_SHAPES:
+            raise ValueError(
+                f"shape must be one of {sorted(_VALID_LEGEND_SHAPES)}, "
+                f"got {shape!r}"
+            )
+
+        pairs: list[tuple[str, str]]
+        if builtin is not None:
+            preset = get_builtin_legend(builtin)
+            pairs = list(preset["items"])  # type: ignore[arg-type]
+            if title is None:
+                title = str(preset["title"])
+        elif legend_dict is not None:
+            pairs = [(str(label), str(color)) for label, color in legend_dict.items()]
+        elif labels is not None or colors is not None:
+            if labels is None or colors is None:
+                raise ValueError("labels and colors must be provided together")
+            if len(labels) != len(colors):
+                raise ValueError(
+                    "labels and colors must have the same length "
+                    f"({len(labels)} != {len(colors)})"
+                )
+            pairs = [(str(label), str(color)) for label, color in zip(labels, colors)]
+        else:
+            raise ValueError(
+                "Provide legend entries via builtin=, legend_dict=, or "
+                "labels= and colors=."
+            )
+        if not pairs:
+            raise ValueError("Legend has no items")
+
+        items = [
+            {"label": label, "color": color, "shape": shape}
+            for label, color in pairs
+        ]
+        entry = _project.legend_gui_entry(title or "Legend", items, position)
+        self._update_components_state(
+            "legend",
+            lambda existing: _project.legend_gui_state(entry, existing=existing),
+        )
+
+    def add_colorbar(
+        self,
+        *,
+        colormap: str = "viridis",
+        vmin: float = 0.0,
+        vmax: float = 1.0,
+        label: str = "",
+        units: str = "",
+        colors: list[str] | None = None,
+        orientation: str = "vertical",
+        position: str = "bottom-right",
+    ) -> None:
+        """Add a colorbar for a continuous (single-band) raster.
+
+        Renders a gradient with min/max ticks, from either a named colormap or an
+        explicit list of CSS colors. Each call adds another colorbar.
+
+        Args:
+            colormap: A named colormap (e.g. ``"viridis"``, ``"plasma"``,
+                ``"inferno"``, ``"magma"``, ``"cividis"``, ``"turbo"``,
+                ``"terrain"``). Ignored when ``colors`` is given.
+            vmin: Value at the low end of the colorbar.
+            vmax: Value at the high end of the colorbar.
+            label: Title shown alongside the colorbar.
+            units: Units suffix shown with the values.
+            colors: Optional list of CSS colors defining a custom gradient; when
+                given, the colorbar uses these instead of ``colormap``.
+            orientation: ``"vertical"`` or ``"horizontal"``.
+            position: Corner for the colorbar; one of ``"top-left"``,
+                ``"top-right"``, ``"bottom-left"``, ``"bottom-right"``.
+
+        Raises:
+            ValueError: If ``orientation`` or ``position`` is invalid, or
+                ``colors`` is given but empty.
+        """
+        if orientation not in _VALID_ORIENTATIONS:
+            raise ValueError(
+                f"orientation must be one of {sorted(_VALID_ORIENTATIONS)}, "
+                f"got {orientation!r}"
+            )
+        if position not in _VALID_CONTROL_POSITIONS:
+            raise ValueError(
+                f"position must be one of {sorted(_VALID_CONTROL_POSITIONS)}, "
+                f"got {position!r}"
+            )
+        if colors is not None:
+            if not colors:
+                raise ValueError("colors must be a non-empty list when provided")
+            mode = "custom"
+            custom_colors = ", ".join(str(color) for color in colors)
+        else:
+            mode = "named"
+            custom_colors = ""
+        entry = _project.colorbar_gui_entry(
+            mode=mode,
+            colormap=colormap,
+            custom_colors=custom_colors,
+            vmin=float(vmin),
+            vmax=float(vmax),
+            label=label,
+            units=units,
+            orientation=orientation,
+            position=position,
+        )
+        self._update_components_state(
+            "colorbar",
+            lambda existing: _project.colorbar_gui_state(entry, existing=existing),
+        )
+
+    def add_colormap(
+        self,
+        colormap: str = "viridis",
+        *,
+        vmin: float = 0.0,
+        vmax: float = 1.0,
+        label: str = "",
+        **kwargs: Any,
+    ) -> None:
+        """Add a colorbar from a named colormap (alias of :meth:`add_colorbar`).
+
+        Provided for leafmap parity; ``colormap`` is positional here.
+
+        Args:
+            colormap: A named colormap (see :meth:`add_colorbar`).
+            vmin: Value at the low end of the colorbar.
+            vmax: Value at the high end of the colorbar.
+            label: Title shown alongside the colorbar.
+            **kwargs: Forwarded to :meth:`add_colorbar` (e.g. ``units``,
+                ``orientation``, ``position``).
+        """
+        self.add_colorbar(
+            colormap=colormap, vmin=vmin, vmax=vmax, label=label, **kwargs
+        )
 
     # -- project I/O -----------------------------------------------------
 

--- a/python/src/geolibre/legends.py
+++ b/python/src/geolibre/legends.py
@@ -1,0 +1,92 @@
+"""Built-in legend presets for :meth:`geolibre.Map.add_legend`.
+
+Each preset is a list of ``(label, color)`` pairs in display order, mirroring the
+land-cover legends shipped by leafmap/geemap so the embedded Legend control can
+render a recognizable legend (e.g. NLCD, ESA WorldCover) from a single name.
+"""
+
+from __future__ import annotations
+
+# Each value is an ordered list of (label, hex color) pairs. Colors follow the
+# official product color tables (NLCD legend, ESA WorldCover class palette).
+BUILTIN_LEGENDS: dict[str, dict[str, object]] = {
+    "nlcd": {
+        "title": "NLCD Land Cover",
+        "items": [
+            ("Open Water", "#466b9f"),
+            ("Perennial Ice/Snow", "#d1def8"),
+            ("Developed, Open Space", "#dec5c5"),
+            ("Developed, Low Intensity", "#d99282"),
+            ("Developed, Medium Intensity", "#eb0000"),
+            ("Developed, High Intensity", "#ab0000"),
+            ("Barren Land", "#b3ac9f"),
+            ("Deciduous Forest", "#68ab5f"),
+            ("Evergreen Forest", "#1c5f2c"),
+            ("Mixed Forest", "#b5c58f"),
+            ("Dwarf Scrub", "#af963c"),
+            ("Shrub/Scrub", "#ccb879"),
+            ("Grassland/Herbaceous", "#dfdfc2"),
+            ("Sedge/Herbaceous", "#d1d182"),
+            ("Lichens", "#a3cc51"),
+            ("Moss", "#82ba9e"),
+            ("Pasture/Hay", "#dcd939"),
+            ("Cultivated Crops", "#ab6c28"),
+            ("Woody Wetlands", "#b8d9eb"),
+            ("Emergent Herbaceous Wetlands", "#6c9fb8"),
+        ],
+    },
+    "esa_worldcover": {
+        "title": "ESA WorldCover",
+        "items": [
+            ("Tree cover", "#006400"),
+            ("Shrubland", "#ffbb22"),
+            ("Grassland", "#ffff4c"),
+            ("Cropland", "#f096ff"),
+            ("Built-up", "#fa0000"),
+            ("Bare / sparse vegetation", "#b4b4b4"),
+            ("Snow and ice", "#f0f0f0"),
+            ("Permanent water bodies", "#0064c8"),
+            ("Herbaceous wetland", "#0096a0"),
+            ("Mangroves", "#00cf75"),
+            ("Moss and lichen", "#fae6a0"),
+        ],
+    },
+}
+
+# Friendly aliases so common names resolve to a canonical preset key.
+_LEGEND_ALIASES: dict[str, str] = {
+    "esa": "esa_worldcover",
+    "worldcover": "esa_worldcover",
+    "esa_world_cover": "esa_worldcover",
+    "nlcd_land_cover": "nlcd",
+}
+
+
+def builtin_legend_names() -> list[str]:
+    """Return the available built-in legend preset names (canonical keys)."""
+    return sorted(BUILTIN_LEGENDS)
+
+
+def get_builtin_legend(name: str) -> dict[str, object]:
+    """Return a built-in legend preset by name.
+
+    Args:
+        name: A preset name (e.g. ``"nlcd"``, ``"esa_worldcover"``, ``"esa"``).
+            Matching is case-insensitive and a small set of aliases is accepted.
+
+    Returns:
+        A dict with ``"title"`` (str) and ``"items"`` (a list of
+        ``(label, color)`` pairs).
+
+    Raises:
+        ValueError: If no preset matches ``name``.
+    """
+    key = str(name).strip().lower()
+    key = _LEGEND_ALIASES.get(key, key)
+    preset = BUILTIN_LEGENDS.get(key)
+    if preset is None:
+        raise ValueError(
+            f"Unknown built-in legend {name!r}. Available presets: "
+            f"{builtin_legend_names()}"
+        )
+    return preset

--- a/python/src/geolibre/project.py
+++ b/python/src/geolibre/project.py
@@ -835,3 +835,220 @@ def load_featurecollection(data: Any) -> dict[str, Any]:
         "type": "FeatureCollection",
         "features": [{"type": "Feature", "properties": {}, "geometry": data}],
     }
+
+
+# -- plugin (map control) state -----------------------------------------------
+# The split-map (swipe), legend, and colorbar helpers are thin wrappers over the
+# app's built-in map-control plugins, configured through the project's `plugins`
+# block. The shapes here mirror the plugin project-state interfaces in
+# packages/plugins/src/plugins/* (maplibre-swipe.ts, maplibre-components.ts), so
+# the app replays them via PluginManager.restoreProjectState on load.
+
+# The four corners every map control accepts (CONTROL_POSITIONS in
+# maplibre-components.ts; PROJECT_PLUGIN_CONTROL_POSITIONS in core).
+CONTROL_POSITIONS = frozenset(
+    {"top-left", "top-right", "bottom-left", "bottom-right"}
+)
+
+# Plugin ids registered in apps/geolibre-desktop/src/hooks/usePlugins.ts.
+SWIPE_PLUGIN_ID = "maplibre-gl-swipe"
+COMPONENTS_PLUGIN_ID = "maplibre-gl-components"
+
+# Plugins the app activates by default (``activeByDefault: true`` in
+# packages/plugins/src/plugins/*). When a project carries a `plugins` block,
+# PluginManager.restoreProjectState deactivates any active plugin missing from
+# `activePluginIds`, so a block built from Python must seed these or it would
+# tear down the layer control and the deck.gl overlay that backs raster
+# rendering. Kept in sync with EFFECTS_PLUGIN_ID / DECK_VIZ_PLUGIN_ID and
+# layer-control.ts.
+DEFAULT_ACTIVE_PLUGIN_IDS = (
+    "maplibre-layer-control",
+    "maplibre-deckgl-viz",
+    "maplibre-atmosphere-effects",
+)
+
+
+def ensure_plugins_block(project: dict[str, Any]) -> dict[str, Any]:
+    """Return the project's ``plugins`` block, creating it if absent.
+
+    Mirrors ``normalizeProjectPlugins`` in ``packages/core/src/project.ts``: the
+    block always carries ``manifestUrls``, ``activePluginIds``,
+    ``mapControlPositions``, and ``settings``. A freshly created block is seeded
+    with :data:`DEFAULT_ACTIVE_PLUGIN_IDS` so adding a control from Python does
+    not deactivate the app's default plugins (an existing block is left as-is,
+    honouring whatever the user/app already chose).
+
+    Args:
+        project: The project dict to read/extend in place.
+
+    Returns:
+        The (possibly newly created) ``plugins`` block dict.
+    """
+    if "plugins" not in project:
+        project["plugins"] = {
+            "manifestUrls": [],
+            "activePluginIds": list(DEFAULT_ACTIVE_PLUGIN_IDS),
+            "mapControlPositions": {},
+            "settings": {},
+        }
+    plugins = project["plugins"]
+    plugins.setdefault("manifestUrls", [])
+    plugins.setdefault("activePluginIds", [])
+    plugins.setdefault("mapControlPositions", {})
+    plugins.setdefault("settings", {})
+    return plugins
+
+
+def set_plugin_state(
+    project: dict[str, Any],
+    plugin_id: str,
+    settings: dict[str, Any],
+    *,
+    position: str | None = None,
+    activate: bool = True,
+) -> None:
+    """Store a map-control plugin's project state in place, optionally activating.
+
+    Writes the settings blob and records the control corner; with
+    ``activate=True`` it also adds ``plugin_id`` to ``activePluginIds``. The
+    Components plugin (legend/colorbar) restores from its settings alone, so it
+    passes ``activate=False`` to avoid mounting the full Components toolbar.
+
+    Args:
+        project: The project dict to mutate.
+        plugin_id: The plugin id (e.g. ``"maplibre-gl-swipe"``).
+        settings: The plugin's project-state settings blob.
+        position: Optional control corner; one of :data:`CONTROL_POSITIONS`.
+        activate: Whether to add ``plugin_id`` to ``activePluginIds``.
+    """
+    plugins = ensure_plugins_block(project)
+    if activate and plugin_id not in plugins["activePluginIds"]:
+        plugins["activePluginIds"].append(plugin_id)
+    if position is not None:
+        plugins["mapControlPositions"][plugin_id] = position
+    plugins["settings"][plugin_id] = settings
+
+
+def swipe_state(
+    *,
+    left_layers: list[str],
+    right_layers: list[str],
+    orientation: str = "vertical",
+    position: float = 50,
+) -> dict[str, Any]:
+    """Build the Layer Swipe plugin state (``SwipeState`` in maplibre-swipe.ts).
+
+    Args:
+        left_layers: Layer ids shown on the left/top of the slider. The string
+            ``"__basemap__"`` selects the basemap.
+        right_layers: Layer ids shown on the right/bottom of the slider.
+        orientation: ``"vertical"`` or ``"horizontal"``.
+        position: Slider position as a percentage in ``[0, 100]``.
+
+    Returns:
+        A swipe-state dict for the project's plugin settings.
+    """
+    return {
+        "orientation": orientation,
+        "position": position,
+        "collapsed": False,
+        "active": True,
+        "leftLayers": list(left_layers),
+        "rightLayers": list(right_layers),
+        "isDragging": False,
+    }
+
+
+def legend_gui_entry(
+    title: str,
+    items: list[dict[str, Any]],
+    position: str,
+) -> dict[str, Any]:
+    """Build one legend entry (``ComponentLegendGuiEntryState``)."""
+    return {"title": title, "items": items, "legendPosition": position}
+
+
+def legend_gui_state(
+    entry: dict[str, Any],
+    *,
+    existing: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the Legend control state, appending ``entry`` to any existing one.
+
+    The control renders one on-map legend per item in its ``legends`` array
+    (see ``LegendGuiControl.setState`` in maplibre-gl-components), so each call
+    appends rather than replaces, and the top-level fields mirror the latest
+    entry for the editing form.
+
+    Args:
+        entry: A legend entry from :func:`legend_gui_entry`.
+        existing: The current ``legend`` state to append to, if any.
+
+    Returns:
+        A ``ComponentLegendGuiState`` dict.
+    """
+    prior = existing.get("legends", []) if isinstance(existing, dict) else []
+    legends = [*prior, entry]
+    return {
+        **entry,
+        "visible": True,
+        "collapsed": False,
+        "hasLegend": True,
+        "selectedLegendIndex": len(legends) - 1,
+        "legends": legends,
+    }
+
+
+def colorbar_gui_entry(
+    *,
+    mode: str,
+    colormap: str,
+    custom_colors: str,
+    vmin: float,
+    vmax: float,
+    label: str,
+    units: str,
+    orientation: str,
+    position: str,
+) -> dict[str, Any]:
+    """Build one colorbar entry (``ComponentColorbarGuiEntryState``)."""
+    return {
+        "mode": mode,
+        "colormap": colormap,
+        "customColors": custom_colors,
+        "vmin": vmin,
+        "vmax": vmax,
+        "label": label,
+        "units": units,
+        "orientation": orientation,
+        "colorbarPosition": position,
+    }
+
+
+def colorbar_gui_state(
+    entry: dict[str, Any],
+    *,
+    existing: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the Colorbar control state, appending ``entry`` to any existing one.
+
+    Like :func:`legend_gui_state`, the control renders one colorbar per item in
+    its ``colorbars`` array, so calls accumulate.
+
+    Args:
+        entry: A colorbar entry from :func:`colorbar_gui_entry`.
+        existing: The current ``colorbar`` state to append to, if any.
+
+    Returns:
+        A ``ComponentColorbarGuiState`` dict.
+    """
+    prior = existing.get("colorbars", []) if isinstance(existing, dict) else []
+    colorbars = [*prior, entry]
+    return {
+        **entry,
+        "visible": True,
+        "collapsed": False,
+        "hasColorbar": True,
+        "selectedColorbarIndex": len(colorbars) - 1,
+        "colorbars": colorbars,
+    }

--- a/python/tests/test_map.py
+++ b/python/tests/test_map.py
@@ -341,3 +341,185 @@ def test_add_data_without_column_is_plain_geojson(m):
 def test_add_data_with_column_is_choropleth(m):
     m.add_data(_choropleth_fc(), column="pop")
     assert _last_layer(m)["style"]["vectorStyleMode"] == "graduated"
+
+
+# -- split map / legend / colorbar -------------------------------------------
+
+
+def _plugins(widget):
+    return widget.project.get("plugins", {})
+
+
+def test_split_map_activates_swipe_plugin(m):
+    a = m.add_geojson(_choropleth_fc(), name="A")
+    b = m.add_geojson(_choropleth_fc(), name="B")
+    m.split_map(a, b, position=40, control_position="bottom-right")
+    plugins = _plugins(m)
+    assert "maplibre-gl-swipe" in plugins["activePluginIds"]
+    assert plugins["mapControlPositions"]["maplibre-gl-swipe"] == "bottom-right"
+    swipe = plugins["settings"]["maplibre-gl-swipe"]
+    assert swipe["leftLayers"] == [a]
+    assert swipe["rightLayers"] == [b]
+    assert swipe["position"] == 40
+    assert swipe["active"] is True
+
+
+def test_plugins_block_seeds_default_active(m):
+    # A fresh plugins block must keep the app's default plugins active, else
+    # restoreProjectState would tear down the layer control / deck.gl overlay.
+    m.split_map()
+    active = _plugins(m)["activePluginIds"]
+    for plugin_id in (
+        "maplibre-layer-control",
+        "maplibre-deckgl-viz",
+        "maplibre-atmosphere-effects",
+    ):
+        assert plugin_id in active
+
+
+def test_split_map_accepts_layer_objects_and_lists(m):
+    a = m.add_geojson(_choropleth_fc(), name="A")
+    layer = m.get_layer(a)
+    m.split_map(layer, ["__basemap__"])
+    swipe = _plugins(m)["settings"]["maplibre-gl-swipe"]
+    assert swipe["leftLayers"] == [a]
+    assert swipe["rightLayers"] == ["__basemap__"]
+
+
+def test_split_map_clamps_position(m):
+    m.split_map(position=999)
+    assert _plugins(m)["settings"]["maplibre-gl-swipe"]["position"] == 100
+
+
+def test_split_map_rejects_bad_orientation(m):
+    with pytest.raises(ValueError, match="orientation"):
+        m.split_map(orientation="diagonal")
+
+
+def test_split_map_rejects_bad_layer_reference(m):
+    with pytest.raises(ValueError, match="layer id"):
+        m.split_map([123])
+
+
+def test_existing_plugins_block_is_not_reseeded(m):
+    # A project that already carries a plugins block reflects deliberate choices,
+    # so adding a control must not inject the default-active ids into it.
+    project = m.to_project()
+    project["plugins"] = {
+        "manifestUrls": [],
+        "activePluginIds": ["maplibre-layer-control"],
+        "mapControlPositions": {},
+        "settings": {},
+    }
+    m.load_project(project)
+    m.add_legend(legend_dict={"a": "#111"})
+    assert _plugins(m)["activePluginIds"] == ["maplibre-layer-control"]
+
+
+def _components(widget):
+    return _plugins(widget)["settings"]["maplibre-gl-components"]
+
+
+def test_add_legend_from_dict(m):
+    m.add_legend("Cover", legend_dict={"Water": "#0000ff", "Land": "#00ff00"})
+    # The Components plugin restores from settings alone; it is not added to
+    # activePluginIds (that would mount the full Components toolbar).
+    assert "maplibre-gl-components" not in _plugins(m)["activePluginIds"]
+    legend = _components(m)["legend"]
+    assert legend["visible"] is True
+    assert legend["title"] == "Cover"
+    assert legend["hasLegend"] is True
+    assert legend["selectedLegendIndex"] == 0
+    assert legend["legends"][0]["items"] == [
+        {"label": "Water", "color": "#0000ff", "shape": "square"},
+        {"label": "Land", "color": "#00ff00", "shape": "square"},
+    ]
+
+
+def test_add_legend_from_labels_and_colors(m):
+    m.add_legend(labels=["a", "b"], colors=["#111", "#222"], shape="circle")
+    items = _components(m)["legend"]["legends"][0]["items"]
+    assert [i["label"] for i in items] == ["a", "b"]
+    assert all(i["shape"] == "circle" for i in items)
+
+
+def test_add_legend_builtin_nlcd(m):
+    m.add_legend(builtin="nlcd")
+    legend = _components(m)["legend"]
+    assert legend["title"] == "NLCD Land Cover"
+    labels = [i["label"] for i in legend["legends"][0]["items"]]
+    assert "Open Water" in labels
+
+
+def test_add_legend_builtin_esa_alias(m):
+    m.add_legend(builtin="esa")
+    assert _components(m)["legend"]["title"] == "ESA WorldCover"
+
+
+def test_add_legend_unknown_builtin_raises(m):
+    with pytest.raises(ValueError, match="Unknown built-in legend"):
+        m.add_legend(builtin="nope")
+
+
+def test_add_legend_requires_entries(m):
+    with pytest.raises(ValueError, match="Provide legend entries"):
+        m.add_legend("Empty")
+
+
+def test_add_legend_mismatched_labels_colors(m):
+    with pytest.raises(ValueError, match="same length"):
+        m.add_legend(labels=["a", "b"], colors=["#111"])
+
+
+def test_add_legend_appends_multiple(m):
+    m.add_legend(legend_dict={"a": "#111"})
+    m.add_legend(legend_dict={"b": "#222"}, position="top-right")
+    legend = _components(m)["legend"]
+    assert len(legend["legends"]) == 2
+    assert legend["selectedLegendIndex"] == 1
+    assert legend["legends"][1]["legendPosition"] == "top-right"
+
+
+def test_add_colorbar_named(m):
+    m.add_colorbar(colormap="plasma", vmin=0, vmax=255, label="Elevation", units="m")
+    colorbar = _components(m)["colorbar"]
+    assert colorbar["visible"] is True
+    assert colorbar["mode"] == "named"
+    assert colorbar["colormap"] == "plasma"
+    assert colorbar["vmin"] == 0
+    assert colorbar["vmax"] == 255
+    assert colorbar["colorbars"][0]["label"] == "Elevation"
+
+
+def test_add_colorbar_custom_colors(m):
+    m.add_colorbar(colors=["#000000", "#ffffff"])
+    colorbar = _components(m)["colorbar"]
+    assert colorbar["mode"] == "custom"
+    assert colorbar["customColors"] == "#000000, #ffffff"
+
+
+def test_add_colorbar_empty_custom_colors_raises(m):
+    with pytest.raises(ValueError, match="non-empty"):
+        m.add_colorbar(colors=[])
+
+
+def test_add_colorbar_bad_position_raises(m):
+    with pytest.raises(ValueError, match="position"):
+        m.add_colorbar(position="middle")
+
+
+def test_add_colormap_is_colorbar_alias(m):
+    m.add_colormap("inferno", vmin=1, vmax=9, units="K")
+    colorbar = _components(m)["colorbar"]
+    assert colorbar["colormap"] == "inferno"
+    assert colorbar["vmin"] == 1
+    assert colorbar["vmax"] == 9
+
+
+def test_legend_and_colorbar_coexist(m):
+    m.add_legend(legend_dict={"a": "#111"})
+    m.add_colorbar(colormap="viridis")
+    components = _components(m)
+    # Adding a colorbar must not drop the existing legend, and vice versa.
+    assert "legend" in components
+    assert "colorbar" in components


### PR DESCRIPTION
Closes #347.

## What

Adds three leafmap/geemap-style helpers to the `geolibre` Jupyter `Map` API, each a thin wrapper over an existing built-in map-control plugin, configured through the synced project dict (no new RPC commands):

- **`Map.split_map(left_layers, right_layers, ...)`** - enable the Layer Swipe comparison slider between two layer sets. Accepts layer ids, `Layer` objects, or lists; the literal `"__basemap__"` selects the basemap. `orientation`, `position` (0-100), and `control_position` are supported.
- **`Map.add_legend(title=None, legend_dict=, labels=, colors=, builtin=, position=, shape=)`** - add a legend from a `{label: color}` mapping, parallel `labels`/`colors` lists, or a builtin preset. Multiple calls accumulate. Builtin presets ship in a new `geolibre/legends.py` (`nlcd`, `esa_worldcover`, with aliases like `esa`).
- **`Map.add_colorbar(...)`** and the leafmap-parity alias **`Map.add_colormap(colormap, ...)`** - add a colorbar for a continuous raster, from a named colormap or a custom list of colors.

## How it works

All three drive the app's existing plugins via the project's `plugins` block, which the app replays through `PluginManager.restoreProjectState` on every project sync, so controls appear with no reload:

- Swipe state -> `settings["maplibre-gl-swipe"]` + activation.
- Legend/colorbar -> `settings["maplibre-gl-components"]` under the `legend` / `colorbar` keys. These restore from their settings blob alone (`applyProjectState` runs whenever the settings key is present), so the plugin is configured but **not** added to `activePluginIds` (activating it would also mount the full Components toolbar). A new legend/colorbar is merged in without dropping the other.
- A freshly created `plugins` block is seeded with the app's default-active plugin ids (`maplibre-layer-control`, `maplibre-deckgl-viz`, `maplibre-atmosphere-effects`) so adding a control from Python does not deactivate the layer control or the deck.gl overlay that backs raster rendering. An existing block is left untouched.

## Tests

23 new unit tests in `python/tests/test_map.py` cover layer-id coercion, position clamping/validation, builtin presets and aliases, legend/colorbar accumulation and coexistence, default-active seeding, and that an existing plugins block is not re-seeded. Full Python suite passes (148 tests); `ruff check` and the `pre-commit` `npm-build` hook pass. Docs updated in `docs/python.md`.

Verification is at the code/unit level: the compiled `maplibre-gl-components` bundle confirms `LegendGuiControl.setState`/`ColorbarGuiControl.setState` render one on-map control per entry in the `legends`/`colorbars` arrays, and the embed bridge -> `loadProject` -> `restoreProjectState` path was traced to confirm mid-session project syncs re-apply plugin state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added split-map (swipe) comparison functionality between two map layers with configurable orientation and position.
  * Added legend overlay support with built-in presets (NLCD, ESA WorldCover) and custom label-color mappings.
  * Added colorbar overlay for data visualization with named or custom color schemes and configurable ranges.

* **Documentation**
  * Updated quickstart section with usage examples for map overlay features.

* **Tests**
  * Added comprehensive test coverage for map overlays and plugin integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->