### PR TITLE
test(processing): shared golden fixtures for the vector engines (#352)

### DIFF
--- a/backend/geolibre_server/tests/test_vector_golden.py
+++ b/backend/geolibre_server/tests/test_vector_golden.py
@@ -1,0 +1,196 @@
+"""Run the shared vector-tool golden fixtures against the Python engine.
+
+The fixtures in ``tests/fixtures/vector/cases`` are a language-neutral contract
+shared with the TypeScript/Turf.js client engine (driven by
+``tests/vector-golden.test.ts``). Both engines must satisfy the same cases, so
+divergence between the two hand-synced implementations is caught here in CI.
+
+See ``tests/fixtures/vector/SPEC.md`` for the case schema and the two tiers of
+agreement (exact vs structural). The matcher below mirrors the one in the TS
+harness; keep the two in sync.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any, Optional
+
+import pytest
+
+from geolibre_server import vector_ops
+from geolibre_server.vector_ops import run_vector_tool
+
+try:
+    import geopandas  # noqa: F401
+
+    HAS_GEOPANDAS = True
+except Exception:  # pragma: no cover - depends on the optional extra
+    HAS_GEOPANDAS = False
+
+
+# tests/fixtures/vector/cases relative to the repo root (…/backend/
+# geolibre_server/tests/test_vector_golden.py -> parents[3] is the repo root).
+_CASES_DIR = (
+    Path(__file__).resolve().parents[3] / "tests" / "fixtures" / "vector" / "cases"
+)
+
+
+def _load_cases() -> list[dict]:
+    if not _CASES_DIR.is_dir():
+        return []
+    cases = []
+    for path in sorted(_CASES_DIR.glob("*.json")):
+        with path.open(encoding="utf-8") as fh:
+            case = json.load(fh)
+        case.setdefault("name", path.stem)
+        cases.append(case)
+    return cases
+
+
+_CASES = _load_cases()
+
+
+# --- matcher (mirror of the TS harness) -----------------------------------
+
+
+def _almost_equal(a: Any, b: Any, tol: float) -> bool:
+    """Numbers compare within ``tol``; everything else compares structurally."""
+    if isinstance(a, bool) or isinstance(b, bool):
+        return a == b
+    if isinstance(a, (int, float)) and isinstance(b, (int, float)):
+        if math.isnan(a) and math.isnan(b):
+            return True
+        return abs(a - b) <= tol
+    if isinstance(a, dict) and isinstance(b, dict):
+        if set(a) != set(b):
+            return False
+        return all(_almost_equal(a[k], b[k], tol) for k in a)
+    if isinstance(a, list) and isinstance(b, list):
+        return len(a) == len(b) and all(
+            _almost_equal(x, y, tol) for x, y in zip(a, b)
+        )
+    return a == b
+
+
+def _canonical(value: Any) -> str:
+    """Stable JSON key for order-insensitive multiset comparison."""
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _multiset_equal(actual: list, expected: list, tol: float) -> bool:
+    """Compare two lists ignoring order, matching each element within ``tol``."""
+    if len(actual) != len(expected):
+        return False
+    remaining = list(actual)
+    for want in expected:
+        for i, have in enumerate(remaining):
+            if _almost_equal(have, want, tol):
+                del remaining[i]
+                break
+        else:
+            return False
+    return True
+
+
+def _geometries_equal(a: Optional[dict], b: Optional[dict], tol: float) -> bool:
+    if a is None or b is None:
+        return a == b
+    if a.get("type") != b.get("type"):
+        return False
+    return _almost_equal(a.get("coordinates"), b.get("coordinates"), tol)
+
+
+def _bbox(features: list[dict]) -> Optional[list[float]]:
+    xs: list[float] = []
+    ys: list[float] = []
+
+    def walk(coords: Any) -> None:
+        if (
+            isinstance(coords, list)
+            and len(coords) >= 2
+            and isinstance(coords[0], (int, float))
+            and isinstance(coords[1], (int, float))
+        ):
+            xs.append(float(coords[0]))
+            ys.append(float(coords[1]))
+        elif isinstance(coords, list):
+            for c in coords:
+                walk(c)
+
+    for feat in features:
+        geom = feat.get("geometry")
+        if geom:
+            walk(geom.get("coordinates"))
+    if not xs:
+        return None
+    return [min(xs), min(ys), max(xs), max(ys)]
+
+
+def _assert_match(name: str, result: dict, expect: dict) -> None:
+    tol = float(expect.get("tolerance") or 1e-9)
+    features = result.get("features") or []
+
+    if expect.get("featureCount") is not None:
+        assert len(features) == expect["featureCount"], (
+            f"{name}: featureCount {len(features)} != {expect['featureCount']}"
+        )
+
+    if expect.get("geometryTypes") is not None:
+        actual_types = sorted(
+            (f.get("geometry") or {}).get("type", "null") for f in features
+        )
+        assert actual_types == sorted(expect["geometryTypes"]), (
+            f"{name}: geometryTypes {actual_types} != {sorted(expect['geometryTypes'])}"
+        )
+
+    if expect.get("properties") is not None:
+        actual_props = [f.get("properties") or {} for f in features]
+        assert _multiset_equal(actual_props, expect["properties"], tol), (
+            f"{name}: properties mismatch\n  actual:   {actual_props}\n"
+            f"  expected: {expect['properties']}"
+        )
+
+    if expect.get("geometry") is not None:
+        want = expect["geometry"]
+        assert len(features) == len(want), (
+            f"{name}: geometry length {len(features)} != {len(want)}"
+        )
+        for i, (feat, geom) in enumerate(zip(features, want)):
+            assert _geometries_equal(feat.get("geometry"), geom, tol), (
+                f"{name}: geometry[{i}] mismatch\n  actual:   {feat.get('geometry')}\n"
+                f"  expected: {geom}"
+            )
+
+    if expect.get("bbox") is not None:
+        actual_bbox = _bbox(features)
+        assert actual_bbox is not None, f"{name}: expected a bbox but output is empty"
+        assert all(
+            abs(a - b) <= tol for a, b in zip(actual_bbox, expect["bbox"])
+        ), f"{name}: bbox {actual_bbox} != {expect['bbox']} (tol {tol})"
+
+
+# --- the test -------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _CASES, reason="shared vector fixtures not found")
+@pytest.mark.skipif(not HAS_GEOPANDAS, reason="geopandas optional extra not installed")
+@pytest.mark.parametrize("case", _CASES, ids=lambda c: c["name"])
+def test_vector_golden(case: dict) -> None:
+    name = case["name"]
+    expect = case.get("expect") or {}
+    args = (
+        case["tool"],
+        case.get("input"),
+        case.get("overlay"),
+        case.get("parameters") or {},
+    )
+
+    if expect.get("error"):
+        with pytest.raises((ValueError, vector_ops.VectorInputTooLarge)):
+            run_vector_tool(*args)
+        return
+
+    result, _messages = run_vector_tool(*args)
+    _assert_match(name, result, expect)

--- a/backend/geolibre_server/tests/test_vector_golden.py
+++ b/backend/geolibre_server/tests/test_vector_golden.py
@@ -19,7 +19,6 @@ from typing import Any, Optional
 
 import pytest
 
-from geolibre_server import vector_ops
 from geolibre_server.vector_ops import run_vector_tool
 
 try:
@@ -34,6 +33,17 @@ except Exception:  # pragma: no cover - depends on the optional extra
 # geolibre_server/tests/test_vector_golden.py -> parents[3] is the repo root).
 _CASES_DIR = (
     Path(__file__).resolve().parents[3] / "tests" / "fixtures" / "vector" / "cases"
+)
+
+
+# Fail loudly if the repo layout changes and the parents[3] path no longer
+# resolves, rather than silently skipping the whole suite (green CI, nothing
+# exercised). When the `tests` tree exists but the fixtures dir does not, the
+# path calculation is wrong; when neither exists (e.g. the package is tested in
+# isolation, unpacked away from the JS repo) the suite skips cleanly below.
+assert _CASES_DIR.is_dir() or not _CASES_DIR.parents[2].is_dir(), (
+    f"Expected fixture directory not found: {_CASES_DIR}. "
+    "Check the parents[3] path calculation if this test file was moved."
 )
 
 
@@ -57,8 +67,11 @@ _CASES = _load_cases()
 
 def _almost_equal(a: Any, b: Any, tol: float) -> bool:
     """Numbers compare within ``tol``; everything else compares structurally."""
+    # Treat booleans strictly so this matches the TS harness, where `true === 1`
+    # is `false`. (In Python `bool` subclasses `int`, so a naive `True == 1`
+    # would diverge.) A bool only equals another bool of the same value.
     if isinstance(a, bool) or isinstance(b, bool):
-        return a == b
+        return isinstance(a, bool) and isinstance(b, bool) and a == b
     if isinstance(a, (int, float)) and isinstance(b, (int, float)):
         if math.isnan(a) and math.isnan(b):
             return True
@@ -72,11 +85,6 @@ def _almost_equal(a: Any, b: Any, tol: float) -> bool:
             _almost_equal(x, y, tol) for x, y in zip(a, b)
         )
     return a == b
-
-
-def _canonical(value: Any) -> str:
-    """Stable JSON key for order-insensitive multiset comparison."""
-    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
 
 
 def _multiset_equal(actual: list, expected: list, tol: float) -> bool:
@@ -99,6 +107,15 @@ def _geometries_equal(a: Optional[dict], b: Optional[dict], tol: float) -> bool:
         return a == b
     if a.get("type") != b.get("type"):
         return False
+    # A GeometryCollection has no `coordinates` — recurse into its `geometries`
+    # so nested parts are compared with tolerance too (and two collections are
+    # not silently accepted as equal). Mirrors the TS harness.
+    if a.get("type") == "GeometryCollection":
+        sub_a = a.get("geometries") or []
+        sub_b = b.get("geometries") or []
+        return len(sub_a) == len(sub_b) and all(
+            _geometries_equal(ga, gb, tol) for ga, gb in zip(sub_a, sub_b)
+        )
     return _almost_equal(a.get("coordinates"), b.get("coordinates"), tol)
 
 
@@ -188,7 +205,8 @@ def test_vector_golden(case: dict) -> None:
     )
 
     if expect.get("error"):
-        with pytest.raises((ValueError, vector_ops.VectorInputTooLarge)):
+        # VectorInputTooLarge subclasses ValueError, so ValueError covers both.
+        with pytest.raises(ValueError):
             run_vector_tool(*args)
         return
 

--- a/tests/fixtures/vector/SPEC.md
+++ b/tests/fixtures/vector/SPEC.md
@@ -70,17 +70,25 @@ fixture asserts at the strongest tier the two engines *actually* share:
 - **Exact tier** — tools that are pure attribute/selection logic or carry input
   geometry through untouched (`select-by-value`, `select-by-location`,
   `attribute-join`, `spatial-join`), plus the hand-ported identical Chaikin
-  `smooth` and the deterministic `bounding-box`. These assert `properties`
-  and/or `geometry` exactly. This is where the "kept in sync with the backend"
-  attribute logic lives, so it is asserted the hardest.
-- **Structural tier** — geometry-approximation tools (`buffer`, `dissolve`,
-  `aggregate` geometry, `centroids`, `convex-hull`, `simplify`, `clip`,
-  `intersection`, `difference`, `union`, `voronoi`, `explode`). These assert
-  `featureCount`, `geometryTypes`, and a loose `bbox` — the contract is that
-  both engines agree on *shape and extent*, not on every vertex. `aggregate`
-  additionally asserts its computed statistic `properties` exactly (the pandas
-  numeric semantics are hand-replicated and must match), just not the dissolved
-  geometry.
+  `smooth`. These assert `properties` and/or `geometry` exactly. This is where
+  the "kept in sync with the backend" attribute logic lives, so it is asserted
+  the hardest.
+- **Structural tier** — geometry-approximation tools, which assert
+  `featureCount` and `geometryTypes`, plus a `bbox` *only where the two engines
+  share the output extent*:
+  - **count + type + bbox** — the deterministic set ops and hull whose extent
+    matches across engines: `dissolve`, `clip`, `intersection`, `difference`,
+    `union`, `convex-hull`, `explode` (carries input geometry through), and the
+    deterministic `bounding-box` envelope (its extent is asserted via `bbox`
+    rather than `geometry`, because the two engines emit the identical rectangle
+    but start the ring at a different corner). `aggregate` also lands here and
+    additionally asserts its computed statistic `properties` exactly — the
+    pandas numeric semantics are hand-replicated and must match — while its
+    dissolved geometry is checked only by `bbox`.
+  - **count + type only** — tools whose algorithms differ enough that even the
+    extent diverges: `buffer` (Turf is planar, GeoPandas reprojects to UTM),
+    `centroids` (vertex-mean vs area centroid), `simplify` (different
+    Douglas-Peucker pruning), and `voronoi` (different diagram/clip algorithm).
 
 `reproject`'s client `run` is a deliberate no-op that defers to the Python
 engine, so its fixtures are asserted by the Python harness only; the TS harness

--- a/tests/fixtures/vector/SPEC.md
+++ b/tests/fixtures/vector/SPEC.md
@@ -1,0 +1,87 @@
+# Shared vector-tool golden fixtures
+
+The GeoLibre vector geometry tools are implemented **twice**, in two languages,
+and kept in sync by hand:
+
+- **TypeScript / Turf.js** — `packages/processing/src/vector-tools.ts` (the
+  client engine that runs in the browser main thread).
+- **Python / GeoPandas + Shapely** —
+  `backend/geolibre_server/geolibre_server/vector_ops.py` (the FastAPI sidecar
+  engine). `apps/geolibre-desktop/src/lib/pyodide/vector_ops.generated.py` is an
+  auto-generated verbatim copy of this file, so it is the *same* engine — there
+  are two implementations to keep aligned, not three.
+
+Both expose the same 19 tools and the **same canonical parameter names**, so a
+single set of language-neutral fixtures can drive both. These fixtures are the
+shared contract: each one is an `(input, parameters) → expected` case that both
+engines must satisfy. Drift between the two engines is then caught by CI instead
+of in the field. This directory is the "shared spec / golden fixtures" called
+for by issue #352.
+
+## Files
+
+- `cases/*.json` — one golden case per file (see schema below).
+- TS harness: `tests/vector-golden.test.ts` (run via `npm run test:frontend`).
+- Python harness: `backend/geolibre_server/tests/test_vector_golden.py`
+  (run via `npm run test:backend`).
+
+Add a new shared case by dropping a `.json` file in `cases/`; both harnesses
+glob the directory, so no test code changes are needed.
+
+## Case schema
+
+```jsonc
+{
+  "name": "select-by-value-numeric-gt",   // unique; also the file name
+  "tool": "select-by-value",               // a key of the engines' dispatch table
+  "description": "…",                       // human note, not asserted
+  "input": { "type": "FeatureCollection", "features": [ … ] },   // required
+  "overlay": { … } | null,                  // 2nd layer for clip/overlay/union/join
+  "parameters": { "field": "pop", "operator": "gt", "value": "100" },
+  "expect": {
+    // Every field is optional; only the non-null ones are asserted, so a case
+    // can assert as much or as little as the two engines genuinely agree on.
+    "error": false,                 // when true: both engines must REJECT the
+                                    //   input (TS produces no result layer;
+                                    //   Python raises ValueError). No other
+                                    //   field is checked.
+    "featureCount": 2,              // exact output feature count
+    "geometryTypes": ["Point"],     // multiset of output geometry types
+                                    //   (compared order-insensitively)
+    "properties": [ { … }, … ],     // expected per-feature `properties`,
+                                    //   compared as an order-insensitive
+                                    //   multiset with numeric tolerance
+    "geometry": [ { … }, … ],       // expected per-feature geometry, compared
+                                    //   in order, coordinates within tolerance
+    "bbox": [w, s, e, n],           // expected bbox of the whole output
+    "tolerance": 1e-9               // abs tolerance for geometry/bbox/number
+                                    //   comparison (default 1e-9)
+  }
+}
+```
+
+## Two tiers of agreement
+
+The two engines do **not** compute identical floating-point geometry for every
+tool — Turf buffers in a planar approximation while GeoPandas reprojects to UTM,
+Turf and Shapely use different simplification and Voronoi algorithms, etc. So a
+fixture asserts at the strongest tier the two engines *actually* share:
+
+- **Exact tier** — tools that are pure attribute/selection logic or carry input
+  geometry through untouched (`select-by-value`, `select-by-location`,
+  `attribute-join`, `spatial-join`), plus the hand-ported identical Chaikin
+  `smooth` and the deterministic `bounding-box`. These assert `properties`
+  and/or `geometry` exactly. This is where the "kept in sync with the backend"
+  attribute logic lives, so it is asserted the hardest.
+- **Structural tier** — geometry-approximation tools (`buffer`, `dissolve`,
+  `aggregate` geometry, `centroids`, `convex-hull`, `simplify`, `clip`,
+  `intersection`, `difference`, `union`, `voronoi`, `explode`). These assert
+  `featureCount`, `geometryTypes`, and a loose `bbox` — the contract is that
+  both engines agree on *shape and extent*, not on every vertex. `aggregate`
+  additionally asserts its computed statistic `properties` exactly (the pandas
+  numeric semantics are hand-replicated and must match), just not the dissolved
+  geometry.
+
+`reproject`'s client `run` is a deliberate no-op that defers to the Python
+engine, so its fixtures are asserted by the Python harness only; the TS harness
+skips any tool whose registry entry sets `requiresSidecar`.

--- a/tests/fixtures/vector/cases/aggregate-sum-by-group.json
+++ b/tests/fixtures/vector/cases/aggregate-sum-by-group.json
@@ -1,7 +1,7 @@
 {
   "name": "aggregate-sum-by-group",
   "tool": "aggregate",
-  "description": "Sum of val grouped by grp; geometry is dissolved per group.",
+  "description": "Sum of val grouped by grp; geometry is dissolved per group (both engines share the per-group extent).",
   "input": {
     "type": "FeatureCollection",
     "features": [
@@ -133,6 +133,12 @@
         "val_sum": 5
       }
     ],
-    "tolerance": 1e-09
+    "bbox": [
+      0.0,
+      0.0,
+      12.0,
+      12.0
+    ],
+    "tolerance": 1e-06
   }
 }

--- a/tests/fixtures/vector/cases/aggregate-sum-by-group.json
+++ b/tests/fixtures/vector/cases/aggregate-sum-by-group.json
@@ -1,0 +1,138 @@
+{
+  "name": "aggregate-sum-by-group",
+  "tool": "aggregate",
+  "description": "Sum of val grouped by grp; geometry is dissolved per group.",
+  "input": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "a",
+          "grp": "x",
+          "val": 10
+        },
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                0,
+                0
+              ],
+              [
+                0,
+                2
+              ],
+              [
+                2,
+                2
+              ],
+              [
+                2,
+                0
+              ],
+              [
+                0,
+                0
+              ]
+            ]
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "b",
+          "grp": "x",
+          "val": 30
+        },
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                0.5,
+                0.5
+              ],
+              [
+                0.5,
+                2.5
+              ],
+              [
+                2.5,
+                2.5
+              ],
+              [
+                2.5,
+                0.5
+              ],
+              [
+                0.5,
+                0.5
+              ]
+            ]
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "c",
+          "grp": "y",
+          "val": 5
+        },
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                10,
+                10
+              ],
+              [
+                10,
+                12
+              ],
+              [
+                12,
+                12
+              ],
+              [
+                12,
+                10
+              ],
+              [
+                10,
+                10
+              ]
+            ]
+          ]
+        }
+      }
+    ]
+  },
+  "parameters": {
+    "group_field": "grp",
+    "statistic": "sum",
+    "stat_field": "val"
+  },
+  "expect": {
+    "featureCount": 2,
+    "geometryTypes": [
+      "Polygon",
+      "Polygon"
+    ],
+    "properties": [
+      {
+        "grp": "x",
+        "val_sum": 40
+      },
+      {
+        "grp": "y",
+        "val_sum": 5
+      }
+    ],
+    "tolerance": 1e-09
+  }
+}

--- a/tests/fixtures/vector/cases/attribute-join-left.json
+++ b/tests/fixtures/vector/cases/attribute-join-left.json
@@ -1,0 +1,156 @@
+{
+  "name": "attribute-join-left",
+  "tool": "attribute-join",
+  "description": "Left attribute join brings the matching table row onto each town.",
+  "input": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Raleigh",
+          "pop": 480,
+          "region": "east"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -78.0,
+            35.0
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Charlotte",
+          "pop": 900,
+          "region": "west"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -80.8,
+            35.2
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Asheville",
+          "pop": 95,
+          "region": "west"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -82.5,
+            35.6
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Wilmington",
+          "pop": 120,
+          "region": "east"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77.9,
+            34.2
+          ]
+        }
+      }
+    ]
+  },
+  "overlay": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "region": "east",
+          "gov": "seat"
+        },
+        "geometry": null
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "region": "west",
+          "gov": "hub"
+        },
+        "geometry": null
+      }
+    ]
+  },
+  "parameters": {
+    "target_field": "region",
+    "join_field": "region",
+    "how": "left"
+  },
+  "expect": {
+    "featureCount": 4,
+    "geometry": [
+      {
+        "type": "Point",
+        "coordinates": [
+          -78.0,
+          35.0
+        ]
+      },
+      {
+        "type": "Point",
+        "coordinates": [
+          -80.8,
+          35.2
+        ]
+      },
+      {
+        "type": "Point",
+        "coordinates": [
+          -82.5,
+          35.6
+        ]
+      },
+      {
+        "type": "Point",
+        "coordinates": [
+          -77.9,
+          34.2
+        ]
+      }
+    ],
+    "properties": [
+      {
+        "gov": "seat",
+        "name": "Raleigh",
+        "pop": 480,
+        "region": "east"
+      },
+      {
+        "gov": "hub",
+        "name": "Charlotte",
+        "pop": 900,
+        "region": "west"
+      },
+      {
+        "gov": "hub",
+        "name": "Asheville",
+        "pop": 95,
+        "region": "west"
+      },
+      {
+        "gov": "seat",
+        "name": "Wilmington",
+        "pop": 120,
+        "region": "east"
+      }
+    ],
+    "tolerance": 1e-09
+  }
+}

--- a/tests/fixtures/vector/cases/bounding-box-points.json
+++ b/tests/fixtures/vector/cases/bounding-box-points.json
@@ -1,0 +1,84 @@
+{
+  "name": "bounding-box-points",
+  "tool": "bounding-box",
+  "description": "Envelope of all input features; both engines share its extent.",
+  "input": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Raleigh",
+          "pop": 480,
+          "region": "east"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -78.0,
+            35.0
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Charlotte",
+          "pop": 900,
+          "region": "west"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -80.8,
+            35.2
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Asheville",
+          "pop": 95,
+          "region": "west"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -82.5,
+            35.6
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Wilmington",
+          "pop": 120,
+          "region": "east"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77.9,
+            34.2
+          ]
+        }
+      }
+    ]
+  },
+  "parameters": {},
+  "expect": {
+    "featureCount": 1,
+    "geometryTypes": [
+      "Polygon"
+    ],
+    "bbox": [
+      -82.5,
+      34.2,
+      -77.9,
+      35.6
+    ],
+    "tolerance": 1e-09
+  }
+}

--- a/tests/fixtures/vector/cases/buffer-points-km.json
+++ b/tests/fixtures/vector/cases/buffer-points-km.json
@@ -1,0 +1,83 @@
+{
+  "name": "buffer-points-km",
+  "tool": "buffer",
+  "description": "Buffer each point; Turf is planar, GeoPandas reprojects to UTM, so only count and geometry type are shared.",
+  "input": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Raleigh",
+          "pop": 480,
+          "region": "east"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -78.0,
+            35.0
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Charlotte",
+          "pop": 900,
+          "region": "west"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -80.8,
+            35.2
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Asheville",
+          "pop": 95,
+          "region": "west"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -82.5,
+            35.6
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Wilmington",
+          "pop": 120,
+          "region": "east"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77.9,
+            34.2
+          ]
+        }
+      }
+    ]
+  },
+  "parameters": {
+    "distance": 5,
+    "units": "kilometers"
+  },
+  "expect": {
+    "featureCount": 4,
+    "geometryTypes": [
+      "Polygon",
+      "Polygon",
+      "Polygon",
+      "Polygon"
+    ]
+  }
+}

--- a/tests/fixtures/vector/cases/centroids-polys.json
+++ b/tests/fixtures/vector/cases/centroids-polys.json
@@ -1,0 +1,124 @@
+{
+  "name": "centroids-polys",
+  "tool": "centroids",
+  "description": "One centroid point per polygon (engines use different centroids).",
+  "input": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "a",
+          "grp": "x",
+          "val": 10
+        },
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                0,
+                0
+              ],
+              [
+                0,
+                2
+              ],
+              [
+                2,
+                2
+              ],
+              [
+                2,
+                0
+              ],
+              [
+                0,
+                0
+              ]
+            ]
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "b",
+          "grp": "x",
+          "val": 30
+        },
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                0.5,
+                0.5
+              ],
+              [
+                0.5,
+                2.5
+              ],
+              [
+                2.5,
+                2.5
+              ],
+              [
+                2.5,
+                0.5
+              ],
+              [
+                0.5,
+                0.5
+              ]
+            ]
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "c",
+          "grp": "y",
+          "val": 5
+        },
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                10,
+                10
+              ],
+              [
+                10,
+                12
+              ],
+              [
+                12,
+                12
+              ],
+              [
+                12,
+                10
+              ],
+              [
+                10,
+                10
+              ]
+            ]
+          ]
+        }
+      }
+    ]
+  },
+  "parameters": {},
+  "expect": {
+    "featureCount": 3,
+    "geometryTypes": [
+      "Point",
+      "Point",
+      "Point"
+    ]
+  }
+}

--- a/tests/fixtures/vector/cases/clip-square.json
+++ b/tests/fixtures/vector/cases/clip-square.json
@@ -1,0 +1,169 @@
+{
+  "name": "clip-square",
+  "tool": "clip",
+  "description": "Clip input polygons to the zone extent.",
+  "input": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "a",
+          "grp": "x",
+          "val": 10
+        },
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                0,
+                0
+              ],
+              [
+                0,
+                2
+              ],
+              [
+                2,
+                2
+              ],
+              [
+                2,
+                0
+              ],
+              [
+                0,
+                0
+              ]
+            ]
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "b",
+          "grp": "x",
+          "val": 30
+        },
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                0.5,
+                0.5
+              ],
+              [
+                0.5,
+                2.5
+              ],
+              [
+                2.5,
+                2.5
+              ],
+              [
+                2.5,
+                0.5
+              ],
+              [
+                0.5,
+                0.5
+              ]
+            ]
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "c",
+          "grp": "y",
+          "val": 5
+        },
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                10,
+                10
+              ],
+              [
+                10,
+                12
+              ],
+              [
+                12,
+                12
+              ],
+              [
+                12,
+                10
+              ],
+              [
+                10,
+                10
+              ]
+            ]
+          ]
+        }
+      }
+    ]
+  },
+  "overlay": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "zone": "north",
+          "code": "01"
+        },
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                -1,
+                -1
+              ],
+              [
+                -1,
+                3
+              ],
+              [
+                3,
+                3
+              ],
+              [
+                3,
+                -1
+              ],
+              [
+                -1,
+                -1
+              ]
+            ]
+          ]
+        }
+      }
+    ]
+  },
+  "parameters": {},
+  "expect": {
+    "featureCount": 2,
+    "geometryTypes": [
+      "Polygon",
+      "Polygon"
+    ],
+    "bbox": [
+      0.0,
+      0.0,
+      2.5,
+      2.5
+    ],
+    "tolerance": 1e-06
+  }
+}

--- a/tests/fixtures/vector/cases/convex-hull-points.json
+++ b/tests/fixtures/vector/cases/convex-hull-points.json
@@ -1,0 +1,84 @@
+{
+  "name": "convex-hull-points",
+  "tool": "convex-hull",
+  "description": "Convex hull of the towns; both engines share its extent.",
+  "input": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Raleigh",
+          "pop": 480,
+          "region": "east"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -78.0,
+            35.0
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Charlotte",
+          "pop": 900,
+          "region": "west"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -80.8,
+            35.2
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Asheville",
+          "pop": 95,
+          "region": "west"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -82.5,
+            35.6
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Wilmington",
+          "pop": 120,
+          "region": "east"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77.9,
+            34.2
+          ]
+        }
+      }
+    ]
+  },
+  "parameters": {},
+  "expect": {
+    "featureCount": 1,
+    "geometryTypes": [
+      "Polygon"
+    ],
+    "bbox": [
+      -82.5,
+      34.2,
+      -77.9,
+      35.6
+    ],
+    "tolerance": 1e-06
+  }
+}

--- a/tests/fixtures/vector/cases/difference-overlap.json
+++ b/tests/fixtures/vector/cases/difference-overlap.json
@@ -1,0 +1,95 @@
+{
+  "name": "difference-overlap",
+  "tool": "difference",
+  "description": "Difference subtracts the overlay from the input.",
+  "input": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "a"
+        },
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                0,
+                0
+              ],
+              [
+                0,
+                2
+              ],
+              [
+                2,
+                2
+              ],
+              [
+                2,
+                0
+              ],
+              [
+                0,
+                0
+              ]
+            ]
+          ]
+        }
+      }
+    ]
+  },
+  "overlay": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "b"
+        },
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                1,
+                1
+              ],
+              [
+                1,
+                3
+              ],
+              [
+                3,
+                3
+              ],
+              [
+                3,
+                1
+              ],
+              [
+                1,
+                1
+              ]
+            ]
+          ]
+        }
+      }
+    ]
+  },
+  "parameters": {},
+  "expect": {
+    "featureCount": 1,
+    "geometryTypes": [
+      "Polygon"
+    ],
+    "bbox": [
+      0.0,
+      0.0,
+      2.0,
+      2.0
+    ],
+    "tolerance": 1e-06
+  }
+}

--- a/tests/fixtures/vector/cases/dissolve-by-field.json
+++ b/tests/fixtures/vector/cases/dissolve-by-field.json
@@ -1,0 +1,132 @@
+{
+  "name": "dissolve-by-field",
+  "tool": "dissolve",
+  "description": "Dissolve merges polygons per group; bbox is preserved exactly.",
+  "input": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "a",
+          "grp": "x",
+          "val": 10
+        },
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                0,
+                0
+              ],
+              [
+                0,
+                2
+              ],
+              [
+                2,
+                2
+              ],
+              [
+                2,
+                0
+              ],
+              [
+                0,
+                0
+              ]
+            ]
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "b",
+          "grp": "x",
+          "val": 30
+        },
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                0.5,
+                0.5
+              ],
+              [
+                0.5,
+                2.5
+              ],
+              [
+                2.5,
+                2.5
+              ],
+              [
+                2.5,
+                0.5
+              ],
+              [
+                0.5,
+                0.5
+              ]
+            ]
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "c",
+          "grp": "y",
+          "val": 5
+        },
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                10,
+                10
+              ],
+              [
+                10,
+                12
+              ],
+              [
+                12,
+                12
+              ],
+              [
+                12,
+                10
+              ],
+              [
+                10,
+                10
+              ]
+            ]
+          ]
+        }
+      }
+    ]
+  },
+  "parameters": {
+    "field": "grp"
+  },
+  "expect": {
+    "featureCount": 2,
+    "geometryTypes": [
+      "Polygon",
+      "Polygon"
+    ],
+    "bbox": [
+      0.0,
+      0.0,
+      12.0,
+      12.0
+    ],
+    "tolerance": 1e-06
+  }
+}

--- a/tests/fixtures/vector/cases/error-attribute-join-missing-key.json
+++ b/tests/fixtures/vector/cases/error-attribute-join-missing-key.json
@@ -1,0 +1,98 @@
+{
+  "name": "error-attribute-join-missing-key",
+  "tool": "attribute-join",
+  "description": "A missing target key field is rejected by both engines.",
+  "input": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Raleigh",
+          "pop": 480,
+          "region": "east"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -78.0,
+            35.0
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Charlotte",
+          "pop": 900,
+          "region": "west"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -80.8,
+            35.2
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Asheville",
+          "pop": 95,
+          "region": "west"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -82.5,
+            35.6
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Wilmington",
+          "pop": 120,
+          "region": "east"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77.9,
+            34.2
+          ]
+        }
+      }
+    ]
+  },
+  "overlay": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "region": "east",
+          "gov": "seat"
+        },
+        "geometry": null
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "region": "west",
+          "gov": "hub"
+        },
+        "geometry": null
+      }
+    ]
+  },
+  "parameters": {
+    "join_field": "region",
+    "how": "left"
+  },
+  "expect": {
+    "error": true
+  }
+}

--- a/tests/fixtures/vector/cases/error-select-missing-field.json
+++ b/tests/fixtures/vector/cases/error-select-missing-field.json
@@ -1,0 +1,77 @@
+{
+  "name": "error-select-missing-field",
+  "tool": "select-by-value",
+  "description": "A missing field parameter is rejected by both engines.",
+  "input": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Raleigh",
+          "pop": 480,
+          "region": "east"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -78.0,
+            35.0
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Charlotte",
+          "pop": 900,
+          "region": "west"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -80.8,
+            35.2
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Asheville",
+          "pop": 95,
+          "region": "west"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -82.5,
+            35.6
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Wilmington",
+          "pop": 120,
+          "region": "east"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77.9,
+            34.2
+          ]
+        }
+      }
+    ]
+  },
+  "parameters": {
+    "operator": "eq",
+    "value": "x"
+  },
+  "expect": {
+    "error": true
+  }
+}

--- a/tests/fixtures/vector/cases/error-select-unknown-operator.json
+++ b/tests/fixtures/vector/cases/error-select-unknown-operator.json
@@ -1,0 +1,78 @@
+{
+  "name": "error-select-unknown-operator",
+  "tool": "select-by-value",
+  "description": "An unknown operator is rejected by both engines.",
+  "input": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Raleigh",
+          "pop": 480,
+          "region": "east"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -78.0,
+            35.0
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Charlotte",
+          "pop": 900,
+          "region": "west"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -80.8,
+            35.2
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Asheville",
+          "pop": 95,
+          "region": "west"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -82.5,
+            35.6
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Wilmington",
+          "pop": 120,
+          "region": "east"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77.9,
+            34.2
+          ]
+        }
+      }
+    ]
+  },
+  "parameters": {
+    "field": "pop",
+    "operator": "between",
+    "value": "1"
+  },
+  "expect": {
+    "error": true
+  }
+}

--- a/tests/fixtures/vector/cases/error-spatial-join-bad-how.json
+++ b/tests/fixtures/vector/cases/error-spatial-join-bad-how.json
@@ -1,0 +1,116 @@
+{
+  "name": "error-spatial-join-bad-how",
+  "tool": "spatial-join",
+  "description": "An unsupported join type is rejected by both engines.",
+  "input": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Raleigh",
+          "pop": 480,
+          "region": "east"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -78.0,
+            35.0
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Charlotte",
+          "pop": 900,
+          "region": "west"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -80.8,
+            35.2
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Asheville",
+          "pop": 95,
+          "region": "west"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -82.5,
+            35.6
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Wilmington",
+          "pop": 120,
+          "region": "east"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77.9,
+            34.2
+          ]
+        }
+      }
+    ]
+  },
+  "overlay": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "zone": "coastal",
+          "code": "01"
+        },
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                -78.5,
+                33.5
+              ],
+              [
+                -78.5,
+                35.5
+              ],
+              [
+                -76.5,
+                35.5
+              ],
+              [
+                -76.5,
+                33.5
+              ],
+              [
+                -78.5,
+                33.5
+              ]
+            ]
+          ]
+        }
+      }
+    ]
+  },
+  "parameters": {
+    "predicate": "intersects",
+    "how": "outer"
+  },
+  "expect": {
+    "error": true
+  }
+}

--- a/tests/fixtures/vector/cases/explode-multipolygon.json
+++ b/tests/fixtures/vector/cases/explode-multipolygon.json
@@ -1,7 +1,7 @@
 {
   "name": "explode-multipolygon",
   "tool": "explode",
-  "description": "Explode a multipolygon into its parts.",
+  "description": "Explode a multipolygon into its parts (geometry is carried through, so both engines share the exact extent).",
   "input": {
     "type": "FeatureCollection",
     "features": [
@@ -72,6 +72,13 @@
     "geometryTypes": [
       "Polygon",
       "Polygon"
-    ]
+    ],
+    "bbox": [
+      0.0,
+      0.0,
+      6.0,
+      6.0
+    ],
+    "tolerance": 1e-06
   }
 }

--- a/tests/fixtures/vector/cases/explode-multipolygon.json
+++ b/tests/fixtures/vector/cases/explode-multipolygon.json
@@ -1,0 +1,77 @@
+{
+  "name": "explode-multipolygon",
+  "tool": "explode",
+  "description": "Explode a multipolygon into its parts.",
+  "input": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "multi"
+        },
+        "geometry": {
+          "type": "MultiPolygon",
+          "coordinates": [
+            [
+              [
+                [
+                  0,
+                  0
+                ],
+                [
+                  0,
+                  1
+                ],
+                [
+                  1,
+                  1
+                ],
+                [
+                  1,
+                  0
+                ],
+                [
+                  0,
+                  0
+                ]
+              ]
+            ],
+            [
+              [
+                [
+                  5,
+                  5
+                ],
+                [
+                  5,
+                  6
+                ],
+                [
+                  6,
+                  6
+                ],
+                [
+                  6,
+                  5
+                ],
+                [
+                  5,
+                  5
+                ]
+              ]
+            ]
+          ]
+        }
+      }
+    ]
+  },
+  "parameters": {},
+  "expect": {
+    "featureCount": 2,
+    "geometryTypes": [
+      "Polygon",
+      "Polygon"
+    ]
+  }
+}

--- a/tests/fixtures/vector/cases/intersection-overlap.json
+++ b/tests/fixtures/vector/cases/intersection-overlap.json
@@ -1,0 +1,95 @@
+{
+  "name": "intersection-overlap",
+  "tool": "intersection",
+  "description": "Intersection of two overlapping squares.",
+  "input": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "a"
+        },
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                0,
+                0
+              ],
+              [
+                0,
+                2
+              ],
+              [
+                2,
+                2
+              ],
+              [
+                2,
+                0
+              ],
+              [
+                0,
+                0
+              ]
+            ]
+          ]
+        }
+      }
+    ]
+  },
+  "overlay": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "b"
+        },
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                1,
+                1
+              ],
+              [
+                1,
+                3
+              ],
+              [
+                3,
+                3
+              ],
+              [
+                3,
+                1
+              ],
+              [
+                1,
+                1
+              ]
+            ]
+          ]
+        }
+      }
+    ]
+  },
+  "parameters": {},
+  "expect": {
+    "featureCount": 1,
+    "geometryTypes": [
+      "Polygon"
+    ],
+    "bbox": [
+      1.0,
+      1.0,
+      2.0,
+      2.0
+    ],
+    "tolerance": 1e-06
+  }
+}

--- a/tests/fixtures/vector/cases/reproject-webmercator.json
+++ b/tests/fixtures/vector/cases/reproject-webmercator.json
@@ -1,0 +1,42 @@
+{
+  "name": "reproject-webmercator",
+  "tool": "reproject",
+  "description": "Reinterpret Web Mercator coords and transform to WGS84 (asserted by the Python harness only).",
+  "input": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "p"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -8800000,
+            4200000
+          ]
+        }
+      }
+    ]
+  },
+  "parameters": {
+    "source_crs": "EPSG:3857"
+  },
+  "expect": {
+    "featureCount": 1,
+    "geometryTypes": [
+      "Point"
+    ],
+    "geometry": [
+      {
+        "type": "Point",
+        "coordinates": [
+          -79.05174500251788,
+          35.26535092860737
+        ]
+      }
+    ],
+    "tolerance": 1e-06
+  }
+}

--- a/tests/fixtures/vector/cases/select-by-location-intersects.json
+++ b/tests/fixtures/vector/cases/select-by-location-intersects.json
@@ -1,0 +1,144 @@
+{
+  "name": "select-by-location-intersects",
+  "tool": "select-by-location",
+  "description": "Keeps input features intersecting the filter layer.",
+  "input": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Raleigh",
+          "pop": 480,
+          "region": "east"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -78.0,
+            35.0
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Charlotte",
+          "pop": 900,
+          "region": "west"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -80.8,
+            35.2
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Asheville",
+          "pop": 95,
+          "region": "west"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -82.5,
+            35.6
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Wilmington",
+          "pop": 120,
+          "region": "east"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77.9,
+            34.2
+          ]
+        }
+      }
+    ]
+  },
+  "overlay": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "zone": "coastal",
+          "code": "01"
+        },
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                -78.5,
+                33.5
+              ],
+              [
+                -78.5,
+                35.5
+              ],
+              [
+                -76.5,
+                35.5
+              ],
+              [
+                -76.5,
+                33.5
+              ],
+              [
+                -78.5,
+                33.5
+              ]
+            ]
+          ]
+        }
+      }
+    ]
+  },
+  "parameters": {
+    "predicate": "intersects"
+  },
+  "expect": {
+    "featureCount": 2,
+    "geometry": [
+      {
+        "type": "Point",
+        "coordinates": [
+          -78.0,
+          35.0
+        ]
+      },
+      {
+        "type": "Point",
+        "coordinates": [
+          -77.9,
+          34.2
+        ]
+      }
+    ],
+    "properties": [
+      {
+        "name": "Raleigh",
+        "pop": 480,
+        "region": "east"
+      },
+      {
+        "name": "Wilmington",
+        "pop": 120,
+        "region": "east"
+      }
+    ],
+    "tolerance": 1e-09
+  }
+}

--- a/tests/fixtures/vector/cases/select-by-value-contains-ci.json
+++ b/tests/fixtures/vector/cases/select-by-value-contains-ci.json
@@ -1,0 +1,95 @@
+{
+  "name": "select-by-value-contains-ci",
+  "tool": "select-by-value",
+  "description": "contains is case-insensitive substring match.",
+  "input": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Raleigh",
+          "pop": 480,
+          "region": "east"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -78.0,
+            35.0
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Charlotte",
+          "pop": 900,
+          "region": "west"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -80.8,
+            35.2
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Asheville",
+          "pop": 95,
+          "region": "west"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -82.5,
+            35.6
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Wilmington",
+          "pop": 120,
+          "region": "east"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77.9,
+            34.2
+          ]
+        }
+      }
+    ]
+  },
+  "parameters": {
+    "field": "name",
+    "operator": "contains",
+    "value": "ll"
+  },
+  "expect": {
+    "featureCount": 1,
+    "geometry": [
+      {
+        "type": "Point",
+        "coordinates": [
+          -82.5,
+          35.6
+        ]
+      }
+    ],
+    "properties": [
+      {
+        "name": "Asheville",
+        "pop": 95,
+        "region": "west"
+      }
+    ],
+    "tolerance": 1e-09
+  }
+}

--- a/tests/fixtures/vector/cases/select-by-value-contains-ci.json
+++ b/tests/fixtures/vector/cases/select-by-value-contains-ci.json
@@ -1,7 +1,7 @@
 {
   "name": "select-by-value-contains-ci",
   "tool": "select-by-value",
-  "description": "contains is case-insensitive substring match.",
+  "description": "contains is case-insensitive: uppercase 'LL' still matches the lowercase 'll' in Asheville.",
   "input": {
     "type": "FeatureCollection",
     "features": [
@@ -70,7 +70,7 @@
   "parameters": {
     "field": "name",
     "operator": "contains",
-    "value": "ll"
+    "value": "LL"
   },
   "expect": {
     "featureCount": 1,

--- a/tests/fixtures/vector/cases/select-by-value-numeric-gt.json
+++ b/tests/fixtures/vector/cases/select-by-value-numeric-gt.json
@@ -1,0 +1,119 @@
+{
+  "name": "select-by-value-numeric-gt",
+  "tool": "select-by-value",
+  "description": "Numeric comparison keeps features with pop > 100.",
+  "input": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Raleigh",
+          "pop": 480,
+          "region": "east"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -78.0,
+            35.0
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Charlotte",
+          "pop": 900,
+          "region": "west"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -80.8,
+            35.2
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Asheville",
+          "pop": 95,
+          "region": "west"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -82.5,
+            35.6
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Wilmington",
+          "pop": 120,
+          "region": "east"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77.9,
+            34.2
+          ]
+        }
+      }
+    ]
+  },
+  "parameters": {
+    "field": "pop",
+    "operator": "gt",
+    "value": "100"
+  },
+  "expect": {
+    "featureCount": 3,
+    "geometry": [
+      {
+        "type": "Point",
+        "coordinates": [
+          -78.0,
+          35.0
+        ]
+      },
+      {
+        "type": "Point",
+        "coordinates": [
+          -80.8,
+          35.2
+        ]
+      },
+      {
+        "type": "Point",
+        "coordinates": [
+          -77.9,
+          34.2
+        ]
+      }
+    ],
+    "properties": [
+      {
+        "name": "Raleigh",
+        "pop": 480,
+        "region": "east"
+      },
+      {
+        "name": "Charlotte",
+        "pop": 900,
+        "region": "west"
+      },
+      {
+        "name": "Wilmington",
+        "pop": 120,
+        "region": "east"
+      }
+    ],
+    "tolerance": 1e-09
+  }
+}

--- a/tests/fixtures/vector/cases/select-by-value-string-eq.json
+++ b/tests/fixtures/vector/cases/select-by-value-string-eq.json
@@ -1,0 +1,107 @@
+{
+  "name": "select-by-value-string-eq",
+  "tool": "select-by-value",
+  "description": "String equality is exact and case-sensitive on the raw value.",
+  "input": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Raleigh",
+          "pop": 480,
+          "region": "east"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -78.0,
+            35.0
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Charlotte",
+          "pop": 900,
+          "region": "west"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -80.8,
+            35.2
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Asheville",
+          "pop": 95,
+          "region": "west"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -82.5,
+            35.6
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Wilmington",
+          "pop": 120,
+          "region": "east"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77.9,
+            34.2
+          ]
+        }
+      }
+    ]
+  },
+  "parameters": {
+    "field": "region",
+    "operator": "eq",
+    "value": "west"
+  },
+  "expect": {
+    "featureCount": 2,
+    "geometry": [
+      {
+        "type": "Point",
+        "coordinates": [
+          -80.8,
+          35.2
+        ]
+      },
+      {
+        "type": "Point",
+        "coordinates": [
+          -82.5,
+          35.6
+        ]
+      }
+    ],
+    "properties": [
+      {
+        "name": "Charlotte",
+        "pop": 900,
+        "region": "west"
+      },
+      {
+        "name": "Asheville",
+        "pop": 95,
+        "region": "west"
+      }
+    ],
+    "tolerance": 1e-09
+  }
+}

--- a/tests/fixtures/vector/cases/simplify-line.json
+++ b/tests/fixtures/vector/cases/simplify-line.json
@@ -1,0 +1,54 @@
+{
+  "name": "simplify-line",
+  "tool": "simplify",
+  "description": "Simplify a wiggly line (Douglas-Peucker differs by engine).",
+  "input": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "wiggle"
+        },
+        "geometry": {
+          "type": "LineString",
+          "coordinates": [
+            [
+              0,
+              0
+            ],
+            [
+              1,
+              0.1
+            ],
+            [
+              2,
+              -0.1
+            ],
+            [
+              3,
+              0
+            ],
+            [
+              4,
+              0.05
+            ],
+            [
+              5,
+              0
+            ]
+          ]
+        }
+      }
+    ]
+  },
+  "parameters": {
+    "tolerance": 0.5
+  },
+  "expect": {
+    "featureCount": 1,
+    "geometryTypes": [
+      "LineString"
+    ]
+  }
+}

--- a/tests/fixtures/vector/cases/smooth-line-chaikin.json
+++ b/tests/fixtures/vector/cases/smooth-line-chaikin.json
@@ -1,0 +1,74 @@
+{
+  "name": "smooth-line-chaikin",
+  "tool": "smooth",
+  "description": "One Chaikin iteration; both engines run the identical algorithm.",
+  "input": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "zig"
+        },
+        "geometry": {
+          "type": "LineString",
+          "coordinates": [
+            [
+              0,
+              0
+            ],
+            [
+              2,
+              4
+            ],
+            [
+              4,
+              0
+            ]
+          ]
+        }
+      }
+    ]
+  },
+  "parameters": {
+    "iterations": 1
+  },
+  "expect": {
+    "featureCount": 1,
+    "geometryTypes": [
+      "LineString"
+    ],
+    "geometry": [
+      {
+        "type": "LineString",
+        "coordinates": [
+          [
+            0,
+            0
+          ],
+          [
+            0.5,
+            1.0
+          ],
+          [
+            1.5,
+            3.0
+          ],
+          [
+            2.5,
+            3.0
+          ],
+          [
+            3.5,
+            1.0
+          ],
+          [
+            4,
+            0
+          ]
+        ]
+      }
+    ],
+    "tolerance": 1e-09
+  }
+}

--- a/tests/fixtures/vector/cases/spatial-join-inner-intersects.json
+++ b/tests/fixtures/vector/cases/spatial-join-inner-intersects.json
@@ -1,0 +1,149 @@
+{
+  "name": "spatial-join-inner-intersects",
+  "tool": "spatial-join",
+  "description": "Inner join attaches zone attributes to towns inside the zone.",
+  "input": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Raleigh",
+          "pop": 480,
+          "region": "east"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -78.0,
+            35.0
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Charlotte",
+          "pop": 900,
+          "region": "west"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -80.8,
+            35.2
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Asheville",
+          "pop": 95,
+          "region": "west"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -82.5,
+            35.6
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Wilmington",
+          "pop": 120,
+          "region": "east"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77.9,
+            34.2
+          ]
+        }
+      }
+    ]
+  },
+  "overlay": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "zone": "coastal",
+          "code": "01"
+        },
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                -78.5,
+                33.5
+              ],
+              [
+                -78.5,
+                35.5
+              ],
+              [
+                -76.5,
+                35.5
+              ],
+              [
+                -76.5,
+                33.5
+              ],
+              [
+                -78.5,
+                33.5
+              ]
+            ]
+          ]
+        }
+      }
+    ]
+  },
+  "parameters": {
+    "predicate": "intersects",
+    "how": "inner"
+  },
+  "expect": {
+    "featureCount": 2,
+    "geometry": [
+      {
+        "type": "Point",
+        "coordinates": [
+          -78.0,
+          35.0
+        ]
+      },
+      {
+        "type": "Point",
+        "coordinates": [
+          -77.9,
+          34.2
+        ]
+      }
+    ],
+    "properties": [
+      {
+        "name": "Raleigh",
+        "pop": 480,
+        "region": "east",
+        "zone": "coastal",
+        "code": "01"
+      },
+      {
+        "name": "Wilmington",
+        "pop": 120,
+        "region": "east",
+        "zone": "coastal",
+        "code": "01"
+      }
+    ],
+    "tolerance": 1e-09
+  }
+}

--- a/tests/fixtures/vector/cases/spatial-join-left-null-fill.json
+++ b/tests/fixtures/vector/cases/spatial-join-left-null-fill.json
@@ -1,0 +1,177 @@
+{
+  "name": "spatial-join-left-null-fill",
+  "tool": "spatial-join",
+  "description": "Left join keeps unmatched towns with null-filled join columns.",
+  "input": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Raleigh",
+          "pop": 480,
+          "region": "east"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -78.0,
+            35.0
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Charlotte",
+          "pop": 900,
+          "region": "west"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -80.8,
+            35.2
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Asheville",
+          "pop": 95,
+          "region": "west"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -82.5,
+            35.6
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "Wilmington",
+          "pop": 120,
+          "region": "east"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -77.9,
+            34.2
+          ]
+        }
+      }
+    ]
+  },
+  "overlay": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "zone": "coastal",
+          "code": "01"
+        },
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                -78.5,
+                33.5
+              ],
+              [
+                -78.5,
+                35.5
+              ],
+              [
+                -76.5,
+                35.5
+              ],
+              [
+                -76.5,
+                33.5
+              ],
+              [
+                -78.5,
+                33.5
+              ]
+            ]
+          ]
+        }
+      }
+    ]
+  },
+  "parameters": {
+    "predicate": "intersects",
+    "how": "left"
+  },
+  "expect": {
+    "featureCount": 4,
+    "geometry": [
+      {
+        "type": "Point",
+        "coordinates": [
+          -78.0,
+          35.0
+        ]
+      },
+      {
+        "type": "Point",
+        "coordinates": [
+          -80.8,
+          35.2
+        ]
+      },
+      {
+        "type": "Point",
+        "coordinates": [
+          -82.5,
+          35.6
+        ]
+      },
+      {
+        "type": "Point",
+        "coordinates": [
+          -77.9,
+          34.2
+        ]
+      }
+    ],
+    "properties": [
+      {
+        "name": "Raleigh",
+        "pop": 480,
+        "region": "east",
+        "zone": "coastal",
+        "code": "01"
+      },
+      {
+        "name": "Charlotte",
+        "pop": 900,
+        "region": "west",
+        "zone": null,
+        "code": null
+      },
+      {
+        "name": "Asheville",
+        "pop": 95,
+        "region": "west",
+        "zone": null,
+        "code": null
+      },
+      {
+        "name": "Wilmington",
+        "pop": 120,
+        "region": "east",
+        "zone": "coastal",
+        "code": "01"
+      }
+    ],
+    "tolerance": 1e-09
+  }
+}

--- a/tests/fixtures/vector/cases/union-two-squares.json
+++ b/tests/fixtures/vector/cases/union-two-squares.json
@@ -1,0 +1,95 @@
+{
+  "name": "union-two-squares",
+  "tool": "union",
+  "description": "Union merges both layers into one geometry.",
+  "input": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "a"
+        },
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                0,
+                0
+              ],
+              [
+                0,
+                2
+              ],
+              [
+                2,
+                2
+              ],
+              [
+                2,
+                0
+              ],
+              [
+                0,
+                0
+              ]
+            ]
+          ]
+        }
+      }
+    ]
+  },
+  "overlay": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "b"
+        },
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                1,
+                1
+              ],
+              [
+                1,
+                3
+              ],
+              [
+                3,
+                3
+              ],
+              [
+                3,
+                1
+              ],
+              [
+                1,
+                1
+              ]
+            ]
+          ]
+        }
+      }
+    ]
+  },
+  "parameters": {},
+  "expect": {
+    "featureCount": 1,
+    "geometryTypes": [
+      "Polygon"
+    ],
+    "bbox": [
+      0.0,
+      0.0,
+      3.0,
+      3.0
+    ],
+    "tolerance": 1e-06
+  }
+}

--- a/tests/fixtures/vector/cases/voronoi-points.json
+++ b/tests/fixtures/vector/cases/voronoi-points.json
@@ -1,0 +1,66 @@
+{
+  "name": "voronoi-points",
+  "tool": "voronoi",
+  "description": "Voronoi cells around four points (algorithms differ by engine).",
+  "input": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {},
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            0,
+            0
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {},
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            2,
+            0
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {},
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            1,
+            2
+          ]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {},
+        "geometry": {
+          "type": "Point",
+          "coordinates": [
+            -1,
+            1
+          ]
+        }
+      }
+    ]
+  },
+  "parameters": {
+    "type": "voronoi"
+  },
+  "expect": {
+    "featureCount": 4,
+    "geometryTypes": [
+      "Polygon",
+      "Polygon",
+      "Polygon",
+      "Polygon"
+    ]
+  }
+}

--- a/tests/vector-golden.test.ts
+++ b/tests/vector-golden.test.ts
@@ -1,0 +1,241 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+import { DEFAULT_LAYER_STYLE, type GeoLibreLayer } from "@geolibre/core";
+import { getVectorTool, runAlgorithmCapture } from "@geolibre/processing";
+import type { Feature, FeatureCollection, Geometry } from "geojson";
+
+/**
+ * Run the shared vector-tool golden fixtures against the TypeScript/Turf.js
+ * client engine. The fixtures in `tests/fixtures/vector/cases` are a
+ * language-neutral contract shared with the Python/GeoPandas sidecar engine
+ * (driven by `backend/geolibre_server/tests/test_vector_golden.py`). Both
+ * engines must satisfy the same cases, so divergence between the two
+ * hand-synced implementations is caught here in CI.
+ *
+ * See `tests/fixtures/vector/SPEC.md` for the case schema and the two tiers of
+ * agreement. The matcher below mirrors the one in the Python harness; keep the
+ * two in sync.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const CASES_DIR = join(here, "fixtures", "vector", "cases");
+
+interface Expectation {
+  error?: boolean;
+  featureCount?: number | null;
+  geometryTypes?: string[] | null;
+  properties?: Record<string, unknown>[] | null;
+  geometry?: Geometry[] | null;
+  bbox?: [number, number, number, number] | null;
+  tolerance?: number | null;
+}
+
+interface GoldenCase {
+  name: string;
+  tool: string;
+  description?: string;
+  input?: FeatureCollection;
+  overlay?: FeatureCollection | null;
+  parameters?: Record<string, unknown>;
+  expect?: Expectation;
+}
+
+function loadCases(): GoldenCase[] {
+  let files: string[];
+  try {
+    files = readdirSync(CASES_DIR).filter((f) => f.endsWith(".json"));
+  } catch {
+    return [];
+  }
+  return files.sort().map((file) => {
+    const data = JSON.parse(readFileSync(join(CASES_DIR, file), "utf8"));
+    data.name ??= file.replace(/\.json$/, "");
+    return data as GoldenCase;
+  });
+}
+
+// --- matcher (mirror of the Python harness) -------------------------------
+
+function almostEqual(a: unknown, b: unknown, tol: number): boolean {
+  if (typeof a === "boolean" || typeof b === "boolean") return a === b;
+  if (typeof a === "number" && typeof b === "number") {
+    if (Number.isNaN(a) && Number.isNaN(b)) return true;
+    return Math.abs(a - b) <= tol;
+  }
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((x, i) => almostEqual(x, b[i], tol));
+  }
+  if (a && b && typeof a === "object" && typeof b === "object") {
+    const ak = Object.keys(a as object);
+    const bk = Object.keys(b as object);
+    if (ak.length !== bk.length || !ak.every((k) => bk.includes(k))) return false;
+    return ak.every((k) =>
+      almostEqual(
+        (a as Record<string, unknown>)[k],
+        (b as Record<string, unknown>)[k],
+        tol,
+      ),
+    );
+  }
+  return a === b;
+}
+
+/** Compare two lists ignoring order, matching each element within `tol`. */
+function multisetEqual(actual: unknown[], expected: unknown[], tol: number): boolean {
+  if (actual.length !== expected.length) return false;
+  const remaining = [...actual];
+  for (const want of expected) {
+    const i = remaining.findIndex((have) => almostEqual(have, want, tol));
+    if (i === -1) return false;
+    remaining.splice(i, 1);
+  }
+  return true;
+}
+
+function geometriesEqual(a: Geometry | null, b: Geometry | null, tol: number): boolean {
+  if (!a || !b) return a === b;
+  if (a.type !== b.type) return false;
+  if (a.type === "GeometryCollection" || b.type === "GeometryCollection") {
+    return JSON.stringify(a) === JSON.stringify(b);
+  }
+  return almostEqual(a.coordinates, b.coordinates, tol);
+}
+
+function bboxOf(features: Feature[]): [number, number, number, number] | null {
+  const xs: number[] = [];
+  const ys: number[] = [];
+  const walk = (coords: unknown): void => {
+    if (
+      Array.isArray(coords) &&
+      coords.length >= 2 &&
+      typeof coords[0] === "number" &&
+      typeof coords[1] === "number"
+    ) {
+      xs.push(coords[0]);
+      ys.push(coords[1]);
+    } else if (Array.isArray(coords)) {
+      for (const c of coords) walk(c);
+    }
+  };
+  for (const f of features) {
+    if (f.geometry && "coordinates" in f.geometry) walk(f.geometry.coordinates);
+  }
+  if (!xs.length) return null;
+  return [Math.min(...xs), Math.min(...ys), Math.max(...xs), Math.max(...ys)];
+}
+
+function assertMatch(name: string, result: FeatureCollection, expect: Expectation): void {
+  const tol = expect.tolerance ?? 1e-9;
+  const features = result.features ?? [];
+
+  if (expect.featureCount != null) {
+    assert.equal(
+      features.length,
+      expect.featureCount,
+      `${name}: featureCount ${features.length} != ${expect.featureCount}`,
+    );
+  }
+
+  if (expect.geometryTypes != null) {
+    const actual = features.map((f) => f.geometry?.type ?? "null").sort();
+    assert.deepEqual(
+      actual,
+      [...expect.geometryTypes].sort(),
+      `${name}: geometryTypes mismatch`,
+    );
+  }
+
+  if (expect.properties != null) {
+    const actual = features.map((f) => f.properties ?? {});
+    assert.ok(
+      multisetEqual(actual, expect.properties, tol),
+      `${name}: properties mismatch\n  actual:   ${JSON.stringify(actual)}\n  expected: ${JSON.stringify(expect.properties)}`,
+    );
+  }
+
+  if (expect.geometry != null) {
+    assert.equal(
+      features.length,
+      expect.geometry.length,
+      `${name}: geometry length mismatch`,
+    );
+    expect.geometry.forEach((geom, i) => {
+      assert.ok(
+        geometriesEqual(features[i].geometry, geom, tol),
+        `${name}: geometry[${i}] mismatch\n  actual:   ${JSON.stringify(features[i].geometry)}\n  expected: ${JSON.stringify(geom)}`,
+      );
+    });
+  }
+
+  if (expect.bbox != null) {
+    const actual = bboxOf(features);
+    assert.ok(actual, `${name}: expected a bbox but output is empty`);
+    actual.forEach((v, i) => {
+      assert.ok(
+        Math.abs(v - expect.bbox![i]) <= tol,
+        `${name}: bbox ${JSON.stringify(actual)} != ${JSON.stringify(expect.bbox)} (tol ${tol})`,
+      );
+    });
+  }
+}
+
+// --- the test -------------------------------------------------------------
+
+function makeLayer(id: string, geojson: FeatureCollection): GeoLibreLayer {
+  return {
+    id,
+    name: id,
+    type: "geojson",
+    source: { type: "geojson" },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {},
+    geojson,
+  };
+}
+
+const cases = loadCases();
+
+describe("vector golden fixtures (client engine)", () => {
+  for (const testCase of cases) {
+    const tool = getVectorTool(testCase.tool);
+
+    // reproject's client run defers to the Python engine (requiresSidecar), so
+    // the client engine produces nothing — that tool is asserted by the Python
+    // harness only.
+    const clientDefers = tool?.requiresSidecar === true;
+
+    it(testCase.name, { skip: clientDefers }, async () => {
+      assert.ok(tool, `${testCase.name}: unknown tool ${testCase.tool}`);
+      const layers: GeoLibreLayer[] = [];
+      if (testCase.input) layers.push(makeLayer("input", testCase.input));
+      if (testCase.overlay) layers.push(makeLayer("overlay", testCase.overlay));
+
+      const parameters: Record<string, unknown> = {
+        layer: "input",
+        ...(testCase.overlay ? { overlay: "overlay" } : {}),
+        ...(testCase.parameters ?? {}),
+      };
+
+      const output = await runAlgorithmCapture(tool, parameters, {
+        layers,
+        log: () => {},
+      });
+
+      const expect = testCase.expect ?? {};
+      if (expect.error) {
+        // The client engine logs an error and adds no result layer rather than
+        // throwing, so a null capture is the rejection signal.
+        assert.equal(output, null, `${testCase.name}: expected no result layer`);
+        return;
+      }
+
+      assert.ok(output, `${testCase.name}: tool produced no result layer`);
+      assertMatch(testCase.name, output, expect);
+    });
+  }
+});

--- a/tests/vector-golden.test.ts
+++ b/tests/vector-golden.test.ts
@@ -60,6 +60,8 @@ function loadCases(): GoldenCase[] {
 // --- matcher (mirror of the Python harness) -------------------------------
 
 function almostEqual(a: unknown, b: unknown, tol: number): boolean {
+  // Booleans compare strictly (a bool only equals an equal bool); the Python
+  // harness mirrors this even though Python's `bool` subclasses `int`.
   if (typeof a === "boolean" || typeof b === "boolean") return a === b;
   if (typeof a === "number" && typeof b === "number") {
     if (Number.isNaN(a) && Number.isNaN(b)) return true;
@@ -98,8 +100,14 @@ function multisetEqual(actual: unknown[], expected: unknown[], tol: number): boo
 function geometriesEqual(a: Geometry | null, b: Geometry | null, tol: number): boolean {
   if (!a || !b) return a === b;
   if (a.type !== b.type) return false;
-  if (a.type === "GeometryCollection" || b.type === "GeometryCollection") {
-    return JSON.stringify(a) === JSON.stringify(b);
+  // A GeometryCollection has no `coordinates` — recurse into its `geometries`
+  // so nested parts are compared with tolerance too. Mirrors the Python harness.
+  if (a.type === "GeometryCollection") {
+    const subB = (b as typeof a).geometries;
+    return (
+      a.geometries.length === subB.length &&
+      a.geometries.every((g, i) => geometriesEqual(g, subB[i], tol))
+    );
   }
   return almostEqual(a.coordinates, b.coordinates, tol);
 }


### PR DESCRIPTION
## Problem

Closes #352. The vector geometry tools are implemented **twice**, in two languages, and kept in sync by hand:

- **TypeScript / Turf.js** — `packages/processing/src/vector-tools.ts` (client engine)
- **Python / GeoPandas + Shapely** — `backend/geolibre_server/geolibre_server/vector_ops.py` (sidecar engine; `apps/geolibre-desktop/src/lib/pyodide/vector_ops.generated.py` is an auto-generated verbatim copy, so it is the *same* engine — two implementations to keep aligned, not three)

There was no shared spec, so drift between buffer / dissolve / overlay / spatial-join / attribute-join / aggregate / smooth / voronoi was only discovered in the field.

## What this adds

A language-neutral **golden-fixtures contract** both engines must satisfy:

- `tests/fixtures/vector/cases/*.json` — 26 `(input, parameters, expected)` cases covering all 19 shared tools, including error cases both engines must reject.
- `tests/fixtures/vector/SPEC.md` — the case schema and the **two tiers of agreement**:
  - **Exact** — attribute/selection/carry-through tools (`select-by-value`, `select-by-location`, `attribute-join`, `spatial-join`), the hand-ported identical Chaikin `smooth`, and the deterministic `bounding-box`. These assert `properties`/`geometry` exactly — this is where the "kept in sync with the backend" logic lives, so it is asserted the hardest.
  - **Structural** — geometry-approximation tools (`buffer`, `dissolve`, `clip`, `intersection`, `difference`, `union`, `centroids`, `convex-hull`, `simplify`, `voronoi`, `explode`). These assert `featureCount`, `geometryTypes`, and a loose `bbox`, because Turf (planar) and GeoPandas (UTM/Shapely) legitimately differ at the vertex level. `aggregate` additionally asserts its computed statistic `properties` exactly.
- `tests/vector-golden.test.ts` — runs every fixture through the **client** engine.
- `backend/geolibre_server/tests/test_vector_golden.py` — runs every fixture through the **Python** engine.

Both harnesses glob the same directory and share an **identical matcher**, so adding a shared case is a JSON drop-in — no test code changes. Expected values are generated from the Python source-of-truth engine and independently verified to pass the client engine.

## Notes

- `reproject`'s client `run` deliberately defers to the Python engine, so its fixture is asserted by the Python harness only (the TS harness skips any tool whose registry entry sets `requiresSidecar`).
- The fixtures already demonstrated their value while being authored: an exact-geometry assertion on `bounding-box` caught that the two engines emit the identical rectangle but start the ring at a different corner — a real representational difference, now asserted via the rotation-invariant `bbox` tier.

## Testing

- `npm run test:frontend` — 826 pass, 1 skipped (the `reproject` deferral)
- `npm run test:backend` (golden suite) — 26 passed
- `pre-commit run --files …` — all hooks pass (incl. full `npm build` + eslint)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added golden-fixture test harnesses to validate vector tool results consistently across Python and TypeScript engines.
  * Introduced shared vector test fixtures covering operations like aggregation, spatial joins, selection, buffering, clipping, convex hull, union, and more, including explicit error cases.
  * Implemented tolerance-aware comparisons for geometries, properties, and bounding boxes, with order-insensitive matching where applicable.
* **Documentation**
  * Added a specification describing the shared golden fixture contract and validation tiers used by CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->