### PR TITLE
fix(python): address review feedback on split_map/add_legend/add_colorbar

### DIFF
--- a/python/src/geolibre/geolibre.py
+++ b/python/src/geolibre/geolibre.py
@@ -34,9 +34,8 @@ _VALID_THEMES = frozenset({"light", "dark"})
 
 # Accepted values for the split-map / legend / colorbar helpers, validated up
 # front so a typo surfaces in Python instead of silently falling back in the app.
-_VALID_CONTROL_POSITIONS = frozenset(
-    {"top-left", "top-right", "bottom-left", "bottom-right"}
-)
+# Reuse the canonical corner set from project.py so the two cannot drift.
+_VALID_CONTROL_POSITIONS = _project.CONTROL_POSITIONS
 _VALID_ORIENTATIONS = frozenset({"vertical", "horizontal"})
 _VALID_LEGEND_SHAPES = frozenset({"square", "circle", "line"})
 
@@ -1777,12 +1776,20 @@ class Map(anywidget.AnyWidget):
             A list of layer-id strings.
 
         Raises:
-            ValueError: If an entry is neither a string nor a :class:`Layer`.
+            ValueError: If ``value`` (or an entry within it) is neither a string
+                nor a :class:`Layer`.
         """
         if value is None:
             return []
         if isinstance(value, (str, Layer)):
             value = [value]
+        elif not isinstance(value, (list, tuple)):
+            # A bare non-iterable (e.g. split_map(123)) would raise an opaque
+            # TypeError from the loop below; surface the documented ValueError.
+            raise ValueError(
+                "Layer reference must be a layer id string, a Layer, or a list "
+                f"of those; got {value!r}"
+            )
         ids: list[str] = []
         for entry in value:
             if isinstance(entry, Layer):
@@ -1937,12 +1944,25 @@ class Map(anywidget.AnyWidget):
                 f"got {shape!r}"
             )
 
+        # The three ways to supply entries are mutually exclusive; reject a
+        # combination rather than silently letting one win by check order.
+        sources = (
+            builtin is not None,
+            legend_dict is not None,
+            labels is not None or colors is not None,
+        )
+        if sum(sources) > 1:
+            raise ValueError(
+                "Provide legend entries via exactly one of: builtin=, "
+                "legend_dict=, or labels= and colors=."
+            )
+
         pairs: list[tuple[str, str]]
         if builtin is not None:
             preset = get_builtin_legend(builtin)
-            pairs = list(preset["items"])  # type: ignore[arg-type]
+            pairs = list(preset["items"])
             if title is None:
-                title = str(preset["title"])
+                title = preset["title"]
         elif legend_dict is not None:
             pairs = [(str(label), str(color)) for label, color in legend_dict.items()]
         elif labels is not None or colors is not None:
@@ -2004,8 +2024,9 @@ class Map(anywidget.AnyWidget):
                 ``"top-right"``, ``"bottom-left"``, ``"bottom-right"``.
 
         Raises:
-            ValueError: If ``orientation`` or ``position`` is invalid, or
-                ``colors`` is given but empty.
+            ValueError: If ``orientation`` or ``position`` is invalid,
+                ``vmin`` is not less than ``vmax``, or ``colors`` is given but
+                empty.
         """
         if orientation not in _VALID_ORIENTATIONS:
             raise ValueError(
@@ -2017,6 +2038,11 @@ class Map(anywidget.AnyWidget):
                 f"position must be one of {sorted(_VALID_CONTROL_POSITIONS)}, "
                 f"got {position!r}"
             )
+        vmin_f, vmax_f = float(vmin), float(vmax)
+        # The app's normalizer only fixes vmin == vmax; an inverted range would
+        # otherwise render a reversed gradient, so reject it here.
+        if vmin_f >= vmax_f:
+            raise ValueError(f"vmin ({vmin_f}) must be less than vmax ({vmax_f})")
         if colors is not None:
             if not colors:
                 raise ValueError("colors must be a non-empty list when provided")
@@ -2029,8 +2055,8 @@ class Map(anywidget.AnyWidget):
             mode=mode,
             colormap=colormap,
             custom_colors=custom_colors,
-            vmin=float(vmin),
-            vmax=float(vmax),
+            vmin=vmin_f,
+            vmax=vmax_f,
             label=label,
             units=units,
             orientation=orientation,

--- a/python/src/geolibre/legends.py
+++ b/python/src/geolibre/legends.py
@@ -7,9 +7,19 @@ render a recognizable legend (e.g. NLCD, ESA WorldCover) from a single name.
 
 from __future__ import annotations
 
+from typing import TypedDict
+
+
+class _LegendPreset(TypedDict):
+    """A built-in legend preset: a title and ordered (label, color) pairs."""
+
+    title: str
+    items: list[tuple[str, str]]
+
+
 # Each value is an ordered list of (label, hex color) pairs. Colors follow the
 # official product color tables (NLCD legend, ESA WorldCover class palette).
-BUILTIN_LEGENDS: dict[str, dict[str, object]] = {
+BUILTIN_LEGENDS: dict[str, _LegendPreset] = {
     "nlcd": {
         "title": "NLCD Land Cover",
         "items": [
@@ -67,7 +77,7 @@ def builtin_legend_names() -> list[str]:
     return sorted(BUILTIN_LEGENDS)
 
 
-def get_builtin_legend(name: str) -> dict[str, object]:
+def get_builtin_legend(name: str) -> _LegendPreset:
     """Return a built-in legend preset by name.
 
     Args:

--- a/python/tests/test_map.py
+++ b/python/tests/test_map.py
@@ -401,6 +401,12 @@ def test_split_map_rejects_bad_layer_reference(m):
         m.split_map([123])
 
 
+def test_split_map_rejects_bare_non_iterable(m):
+    # A bare non-iterable must raise the documented ValueError, not TypeError.
+    with pytest.raises(ValueError, match="layer id"):
+        m.split_map(123)
+
+
 def test_existing_plugins_block_is_not_reseeded(m):
     # A project that already carries a plugins block reflects deliberate choices,
     # so adding a control must not inject the default-active ids into it.
@@ -471,6 +477,12 @@ def test_add_legend_mismatched_labels_colors(m):
         m.add_legend(labels=["a", "b"], colors=["#111"])
 
 
+def test_add_legend_rejects_combined_sources(m):
+    # The three entry sources are mutually exclusive.
+    with pytest.raises(ValueError, match="exactly one of"):
+        m.add_legend(builtin="nlcd", legend_dict={"a": "#111"})
+
+
 def test_add_legend_appends_multiple(m):
     m.add_legend(legend_dict={"a": "#111"})
     m.add_legend(legend_dict={"b": "#222"}, position="top-right")
@@ -506,6 +518,11 @@ def test_add_colorbar_empty_custom_colors_raises(m):
 def test_add_colorbar_bad_position_raises(m):
     with pytest.raises(ValueError, match="position"):
         m.add_colorbar(position="middle")
+
+
+def test_add_colorbar_rejects_inverted_range(m):
+    with pytest.raises(ValueError, match="must be less than"):
+        m.add_colorbar(vmin=100, vmax=0)
 
 
 def test_add_colormap_is_colorbar_alias(m):


### PR DESCRIPTION
Follow-up to #366 (merged) addressing the 5 unresolved Claude review-bot comments on the Python map-control helpers.

| Comment | Fix |
| --- | --- |
| `split_map(123)` raises `TypeError` not `ValueError` | `_coerce_layer_ids` rejects a bare non-iterable with the documented `ValueError`. |
| Inverted colorbar (`vmin >= vmax`) accepted silently | `add_colorbar` raises `ValueError`; the app's normalizer only fixes the equal case. |
| `_VALID_CONTROL_POSITIONS` duplicates `project.CONTROL_POSITIONS` | Reuse the canonical set so they cannot drift. |
| `add_legend` silently prefers `builtin` when sources combined | Reject combining `builtin` / `legend_dict` / `labels`+`colors`. |
| `legends.py` value type too broad, forces `# type: ignore` | Add `_LegendPreset` `TypedDict`; drop the suppression. |

Adds tests for the bare-non-iterable, inverted-range, and combined-source cases. Full Python suite passes (161), `ruff check` and the pre-commit `npm-build` hook pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened input validation for layer configuration with clearer error messages when incorrect input types are provided
  * Added mutual exclusivity checks for legend sources, raising informative errors when conflicting options are specified simultaneously
  * Enhanced colorbar range validation to enforce minimum < maximum constraints with automatic type conversion
  * Improved type definitions for legend presets to prevent configuration drift

<!-- end of auto-generated comment: release notes by coderabbit.ai -->