### PR TITLE
refactor(desktop): split TopToolbar god-component into menus and hooks (#350)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -337,8 +337,8 @@ export function TopToolbar({
     },
     {
       id: "project.print-layout",
-      title: "Print Layout…",
-      group: "Project",
+      title: t("toolbar.item.printLayoutEllipsis"),
+      group: t("toolbar.commandGroup.project"),
       icon: LayoutTemplate,
       run: () => setPrintLayoutOpen(true),
     },

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -1,122 +1,43 @@
+import { DEFAULT_PROJECT_NAME, useAppStore } from "@geolibre/core";
 import {
-  DEFAULT_PROJECT_NAME,
-  projectFromStore,
-  projectPathLabel,
-  redo,
-  serializeProject,
-  undo,
-  useAppStore,
-} from "@geolibre/core";
-import type {
-  ConversionToolKind,
-  RasterToolKind,
-  VectorToolKind,
-} from "@geolibre/core";
-import {
-  type BuiltInMapControl,
   DEFAULT_BUILT_IN_CONTROL_VISIBILITY,
   type MapController,
 } from "@geolibre/map";
 import {
-  closeBookmarkPanel,
-  closeColorbarPanel,
   closeDuckDBLayerPanel,
   closeEarthEnginePanel,
-  closeHtmlPanel,
-  closeLegendPanel,
   closeMaplibreComponentControls,
-  closeMeasurePanel,
-  closeMinimapPanel,
   closePlanetaryComputerPanel,
-  closePrintPanel,
   closeRasterLayerPanel,
-  closeSearchPlacesPanel,
   closeThreeDTilesLayerPanel,
   closeVectorLayerPanel,
-  closeViewStatePanel,
   openFlatGeobufAddVectorLayerPanel,
   openDuckDBLayerPanel,
-  isBookmarkPanelVisible,
-  isEarthEnginePanelVisible,
-  isColorbarPanelVisible,
-  isHtmlPanelVisible,
-  isLegendPanelVisible,
-  isMeasurePanelVisible,
-  isMinimapPanelVisible,
-  isPrintPanelVisible,
-  isSearchPlacesPanelVisible,
-  isViewStatePanelVisible,
-  openBookmarkPanel,
-  openColorbarPanel,
-  openHtmlPanel,
-  openLegendPanel,
   openLidarLayerPanel,
-  openMeasurePanel,
-  openMinimapPanel,
   openPlanetaryComputerPanel,
   openPMTilesLayerPanel,
-  openPrintPanel,
   openRasterLayerPanel,
-  openSearchPlacesPanel,
   openSplattingLayerPanel,
   openStacSearchLayerPanel,
   openThreeDTilesLayerPanel,
   openVectorLayerPanel,
-  openViewStatePanel,
   openZarrLayerPanel,
-  subscribeBookmarkPanel,
-  subscribeColorbarPanel,
-  subscribeEarthEnginePanel,
-  subscribeHtmlPanel,
-  subscribeLegendPanel,
-  subscribeMeasurePanel,
-  subscribeMinimapPanel,
-  subscribePrintPanel,
-  subscribeSearchPlacesPanel,
-  subscribeViewStatePanel,
-  toggleEarthEnginePanel,
+  setReverseGeocodeLabels,
   DECK_VIZ_PLUGIN_ID,
   DIRECTIONS_PLUGIN_ID,
   REVERSE_GEOCODE_PLUGIN_ID,
-  setReverseGeocodeLabels,
   EFFECTS_PLUGIN_ID,
-  WEB_SERVICE_PLUGIN_IDS,
-  type GeoLibreMapControlPosition,
 } from "@geolibre/plugins";
-import {
-  Button,
-  cn,
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuSeparator,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
-  DropdownMenuTrigger,
-  Input,
-  Label,
-} from "@geolibre/ui";
+import { Button, cn, Input } from "@geolibre/ui";
 import {
   Bug,
-  CircleHelp,
   Database,
   FilePen,
   Share2,
   Users,
   FilePlus2,
-  FileText,
   Folder,
   FolderOpen,
-  History,
   Info,
   Keyboard,
   Layers,
@@ -125,68 +46,28 @@ import {
   MapPin,
   MessageSquare,
   Moon,
-  Pencil,
   Printer,
   LayoutTemplate,
-  BookOpen,
-  Puzzle,
-  Redo2,
   RefreshCw,
   Save,
-  Search,
-  SlidersHorizontal,
   Sparkles,
   Sun,
-  Undo2,
   Workflow,
   Wrench,
-  X,
 } from "lucide-react";
-import { useStore } from "zustand";
-import { openUrl } from "@tauri-apps/plugin-opener";
-import {
-  type FormEvent,
-  useEffect,
-  useRef,
-  useState,
-  useSyncExternalStore,
-} from "react";
-import type { ParseKeys } from "i18next";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   createAppAPI,
   getPluginManager,
   usePluginRegistry,
 } from "../../hooks/usePlugins";
-import { useDesktopSettingsStore } from "../../hooks/useDesktopSettings";
+import { useConsentGatedActions } from "../../hooks/useConsentGatedActions";
+import { useOsmPbfLoader } from "../../hooks/useOsmPbfLoader";
+import { useProjectFileActions } from "../../hooks/useProjectFileActions";
+import { useToolbarPanels } from "../../hooks/useToolbarPanels";
 import type { ThemeMode } from "../../hooks/useThemeMode";
-import {
-  isHttpUrl,
-  isTauri,
-  openLocalDataFileWithFallback,
-  openProjectFile,
-  openRecentProjectFile,
-  RecentProjectGoneError,
-  saveProjectFile,
-  saveProjectFileToPath,
-} from "../../lib/tauri-io";
-import {
-  addOsmPbfLayers,
-  loadOsmPbf,
-  osmPbfBaseName,
-  OSM_PBF_SIZE_WARN_BYTES,
-} from "../../lib/osm-pbf-loader";
-import {
-  hasReverseGeocodeConsent,
-  recordReverseGeocodeConsent,
-} from "../../lib/reverse-geocode-consent";
-import {
-  hasRoutingConsent,
-  recordRoutingConsent,
-} from "../../lib/routing-consent";
-import { mergeStringLists } from "../../lib/string-lists";
-import { normalizeProjectUrl } from "../../lib/urls";
-import { resolveProjectXyzLayers } from "../../lib/xyz-url";
+import { isTauri } from "../../lib/tauri-io";
 import { CommandPalette } from "../command/CommandPalette";
 import { KeyboardShortcutsDialog } from "../command/KeyboardShortcutsDialog";
 import { useGlobalShortcuts } from "../../hooks/useGlobalShortcuts";
@@ -201,6 +82,31 @@ import { CollaborateDialog } from "./CollaborateDialog";
 import { useCollaboration } from "../../hooks/useCollaboration";
 import { SettingsDialog } from "./SettingsDialog";
 import { PrintLayoutDialog } from "./PrintLayoutDialog";
+import { AddDataMenu } from "./toolbar/AddDataMenu";
+import { ConsentNoticeDialogs } from "./toolbar/ConsentNoticeDialogs";
+import { ControlsMenu } from "./toolbar/ControlsMenu";
+import { EditMenu } from "./toolbar/EditMenu";
+import { HelpMenu } from "./toolbar/HelpMenu";
+import { OsmPbfDialogs } from "./toolbar/OsmPbfDialogs";
+import { PluginsMenu } from "./toolbar/PluginsMenu";
+import { ProcessingMenu } from "./toolbar/ProcessingMenu";
+import { ProjectFileDialogs } from "./toolbar/ProjectFileDialogs";
+import { ProjectMenu } from "./toolbar/ProjectMenu";
+import {
+  ADD_DATA_KIND_COMMANDS,
+  ALL_BUILT_IN_CONTROL_IDS,
+  type AddLayerHandlers,
+  CONVERSION_COMMANDS,
+  FEEDBACK_URL,
+  MAP_CONTROL_ITEMS,
+  NEW_PROJECT_VISIBLE_BUILT_IN_CONTROLS,
+  newProjectToolbarControlVisibility,
+  openExternalLink,
+  RASTER_TOOL_COMMANDS,
+  type ToolbarChrome,
+  type ToolbarMapControl,
+  VECTOR_TOOL_COMMANDS,
+} from "./toolbar/constants";
 
 interface TopToolbarProps {
   compact?: boolean;
@@ -211,178 +117,6 @@ interface TopToolbarProps {
   themeMode: ThemeMode;
   onOpenDiagnostics: () => void;
   onToggleThemeMode: () => void;
-}
-
-type ToolbarMapControl = Exclude<BuiltInMapControl, "layer-control">;
-
-const MAP_CONTROL_ITEMS: Array<{
-  id: ToolbarMapControl;
-  labelKey: ParseKeys;
-}> = [
-  { id: "navigation", labelKey: "toolbar.mapControl.navigation" },
-  { id: "fullscreen", labelKey: "toolbar.mapControl.fullscreen" },
-  { id: "geolocate", labelKey: "toolbar.mapControl.geolocate" },
-  { id: "globe", labelKey: "toolbar.mapControl.globe" },
-  { id: "terrain", labelKey: "toolbar.mapControl.terrain" },
-  { id: "scale", labelKey: "toolbar.mapControl.scale" },
-  { id: "attribution", labelKey: "toolbar.mapControl.attribution" },
-  { id: "logo", labelKey: "toolbar.mapControl.logo" },
-];
-
-const NEW_PROJECT_VISIBLE_BUILT_IN_CONTROLS = new Set<BuiltInMapControl>([
-  "navigation",
-  "fullscreen",
-  "globe",
-  "layer-control",
-]);
-
-const ALL_BUILT_IN_CONTROL_IDS: BuiltInMapControl[] = [
-  ...MAP_CONTROL_ITEMS.map(({ id }) => id),
-  "layer-control",
-];
-
-const PLUGIN_POSITION_ITEMS: Array<{
-  value: GeoLibreMapControlPosition;
-  labelKey: ParseKeys;
-}> = [
-  { value: "top-left", labelKey: "toolbar.position.topLeft" },
-  { value: "top-right", labelKey: "toolbar.position.topRight" },
-  { value: "bottom-left", labelKey: "toolbar.position.bottomLeft" },
-  { value: "bottom-right", labelKey: "toolbar.position.bottomRight" },
-];
-
-// Plugins grouped under the "Web Services" submenu of the Plugins menu.
-const WEB_SERVICE_PLUGIN_ID_SET = new Set<string>(WEB_SERVICE_PLUGIN_IDS);
-
-const FEEDBACK_URL = "https://github.com/opengeos/GeoLibre/issues";
-// A small (~350 KB) CORS-enabled Las Vegas Strip sample, so the URL field works
-// out of the box on both the desktop and web builds.
-const DEFAULT_OSM_PBF_URL =
-  "https://data.source.coop/giswqs/opengeos/LasVegas.osm.pbf";
-
-// Static command metadata for the menus that map a single id to a label. These
-// drive the command palette so it stays in sync with the menus without each
-// action being defined twice. The `run` closures are built in the component
-// where the store setters are in scope.
-const ADD_DATA_KIND_COMMANDS: Array<{ kind: AddDataKind; titleKey: ParseKeys }> = [
-  { kind: "delimited-text", titleKey: "toolbar.layerType.delimitedText" },
-  { kind: "gpx", titleKey: "toolbar.layerType.gpx" },
-  { kind: "mbtiles", titleKey: "toolbar.layerType.mbtiles" },
-  { kind: "xyz", titleKey: "toolbar.layerType.xyz" },
-  { kind: "wms", titleKey: "toolbar.layerType.wms" },
-  { kind: "wfs", titleKey: "toolbar.layerType.wfs" },
-  { kind: "wmts", titleKey: "toolbar.layerType.wmts" },
-  { kind: "arcgis", titleKey: "toolbar.layerType.arcgis" },
-  { kind: "video", titleKey: "toolbar.layerType.video" },
-  { kind: "deckgl-viz", titleKey: "toolbar.layerType.deckglViz" },
-  { kind: "postgres", titleKey: "toolbar.layerType.postgres" },
-];
-
-const CONVERSION_COMMANDS: Array<{
-  kind: ConversionToolKind;
-  titleKey: ParseKeys;
-}> = [
-  {
-    kind: "vector-to-geoparquet",
-    titleKey: "toolbar.conversion.vectorToGeoparquet",
-  },
-  {
-    kind: "vector-to-flatgeobuf",
-    titleKey: "toolbar.conversion.vectorToFlatgeobuf",
-  },
-  {
-    kind: "vector-to-shapefile",
-    titleKey: "toolbar.conversion.vectorToShapefile",
-  },
-  {
-    kind: "vector-to-geopackage",
-    titleKey: "toolbar.conversion.vectorToGeopackage",
-  },
-  { kind: "csv-to-geoparquet", titleKey: "toolbar.conversion.csvToGeoparquet" },
-  { kind: "vector-to-pmtiles", titleKey: "toolbar.conversion.vectorToPmtiles" },
-  { kind: "raster-to-cog", titleKey: "toolbar.conversion.rasterToCog" },
-];
-
-const VECTOR_TOOL_COMMANDS: Array<{ kind: VectorToolKind; titleKey: ParseKeys }> =
-  [
-    { kind: "buffer", titleKey: "toolbar.vectorTool.buffer" },
-    { kind: "centroids", titleKey: "toolbar.vectorTool.centroids" },
-    { kind: "convex-hull", titleKey: "toolbar.vectorTool.convexHull" },
-    { kind: "dissolve", titleKey: "toolbar.vectorTool.dissolve" },
-    { kind: "bounding-box", titleKey: "toolbar.vectorTool.boundingBox" },
-    { kind: "simplify", titleKey: "toolbar.vectorTool.simplify" },
-    { kind: "clip", titleKey: "toolbar.vectorTool.clip" },
-    { kind: "intersection", titleKey: "toolbar.vectorTool.intersection" },
-    { kind: "difference", titleKey: "toolbar.vectorTool.difference" },
-    { kind: "union", titleKey: "toolbar.vectorTool.union" },
-    { kind: "spatial-join", titleKey: "toolbar.vectorTool.spatialJoin" },
-    { kind: "attribute-join", titleKey: "toolbar.vectorTool.attributeJoin" },
-    { kind: "select-by-value", titleKey: "toolbar.vectorTool.selectByValue" },
-    {
-      kind: "select-by-location",
-      titleKey: "toolbar.vectorTool.selectByLocation",
-    },
-    { kind: "reproject", titleKey: "toolbar.vectorTool.reproject" },
-    { kind: "explode", titleKey: "toolbar.vectorTool.explode" },
-    { kind: "aggregate", titleKey: "toolbar.vectorTool.aggregate" },
-    { kind: "smooth", titleKey: "toolbar.vectorTool.smooth" },
-    { kind: "grid", titleKey: "toolbar.vectorTool.grid" },
-    { kind: "voronoi", titleKey: "toolbar.vectorTool.voronoi" },
-    { kind: "h3-grid", titleKey: "toolbar.vectorTool.h3Grid" },
-    { kind: "h3-bin-points", titleKey: "toolbar.vectorTool.h3BinPoints" },
-  ];
-
-const RASTER_TOOL_COMMANDS: Array<{ kind: RasterToolKind; titleKey: ParseKeys }> =
-  [
-    { kind: "hillshade", titleKey: "toolbar.rasterTool.hillshade" },
-    { kind: "slope", titleKey: "toolbar.rasterTool.slope" },
-    { kind: "aspect", titleKey: "toolbar.rasterTool.aspect" },
-    { kind: "reproject", titleKey: "toolbar.rasterTool.reproject" },
-    { kind: "resample", titleKey: "toolbar.rasterTool.resample" },
-    { kind: "clip-extent", titleKey: "toolbar.rasterTool.clipExtent" },
-    { kind: "clip-mask", titleKey: "toolbar.rasterTool.clipMask" },
-    { kind: "polygonize", titleKey: "toolbar.rasterTool.polygonize" },
-    { kind: "contour", titleKey: "toolbar.rasterTool.contour" },
-    { kind: "interpolate", titleKey: "toolbar.rasterTool.interpolate" },
-    { kind: "zonal", titleKey: "toolbar.rasterTool.zonal" },
-    { kind: "raster-calc", titleKey: "toolbar.rasterTool.rasterCalc" },
-    { kind: "reclassify", titleKey: "toolbar.rasterTool.reclassify" },
-    { kind: "mosaic", titleKey: "toolbar.rasterTool.mosaic" },
-    { kind: "focal", titleKey: "toolbar.rasterTool.focal" },
-  ];
-
-async function openExternalLink(url: string): Promise<void> {
-  if (isTauri()) {
-    await openUrl(url);
-    return;
-  }
-  window.open(url, "_blank", "noopener,noreferrer");
-}
-
-function formatRecentProjectTime(openedAt: string): string {
-  const openedDate = new Date(openedAt);
-  if (Number.isNaN(openedDate.getTime())) return "";
-
-  return new Intl.DateTimeFormat(undefined, {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  }).format(openedDate);
-}
-
-function newProjectToolbarControlVisibility(): Record<
-  ToolbarMapControl,
-  boolean
-> {
-  return MAP_CONTROL_ITEMS.reduce(
-    (acc, { id }) => {
-      acc[id] = NEW_PROJECT_VISIBLE_BUILT_IN_CONTROLS.has(id);
-      return acc;
-    },
-    {} as Record<ToolbarMapControl, boolean>,
-  );
 }
 
 export function TopToolbar({
@@ -407,12 +141,10 @@ export function TopToolbar({
       failed: t("geocode.reverseFailed"),
     });
   }, [t]);
-  const loadProject = useAppStore((s) => s.loadProject);
+
   const setProcessingOpen = useAppStore((s) => s.setProcessingOpen);
   const setConversionOpen = useAppStore((s) => s.setConversionOpen);
   const setVectorToolOpen = useAppStore((s) => s.setVectorToolOpen);
-  const setNetworkToolOpen = useAppStore((s) => s.setNetworkToolOpen);
-  const setStatisticsToolOpen = useAppStore((s) => s.setStatisticsToolOpen);
   const setGeocodeOpen = useAppStore((s) => s.setGeocodeOpen);
   const setModelBuilderOpen = useAppStore((s) => s.setModelBuilderOpen);
   const setRasterToolOpen = useAppStore((s) => s.setRasterToolOpen);
@@ -420,24 +152,35 @@ export function TopToolbar({
   const setSqlWorkspaceOpen = useAppStore((s) => s.setSqlWorkspaceOpen);
   const setPythonConsoleOpen = useAppStore((s) => s.setPythonConsoleOpen);
   const setAssistantOpen = useAppStore((s) => s.setAssistantOpen);
-  const setStorymapPanelOpen = useAppStore((s) => s.setStorymapPanelOpen);
   const projectName = useAppStore((s) => s.projectName);
   const projectPath = useAppStore((s) => s.projectPath);
-  const recentProjects = useAppStore((s) => s.recentProjects);
-  const setProjectPath = useAppStore((s) => s.setProjectPath);
   const setProjectName = useAppStore((s) => s.setProjectName);
-  const rememberRecentProject = useAppStore((s) => s.rememberRecentProject);
-  const forgetRecentProject = useAppStore((s) => s.forgetRecentProject);
-  const clearRecentProjects = useAppStore((s) => s.clearRecentProjects);
-  const markSaved = useAppStore((s) => s.markSaved);
-  const canUndo = useStore(
-    useAppStore.temporal,
-    (s) => s.pastStates.length > 0,
-  );
-  const canRedo = useStore(
-    useAppStore.temporal,
-    (s) => s.futureStates.length > 0,
-  );
+
+  const {
+    plugins,
+    isActive,
+    getMapControlPosition,
+    toggle,
+    setMapControlPosition,
+  } = usePluginRegistry();
+  const appApi = createAppAPI(mapControllerRef);
+
+  const panels = useToolbarPanels(appApi);
+  const projectFiles = useProjectFileActions(mapControllerRef);
+  const osmPbf = useOsmPbfLoader(appApi, projectFiles.setActionError);
+  const consent = useConsentGatedActions({ appApi, isActive, toggle });
+  const collaboration = useCollaboration(mapControllerRef);
+
+  // When opened via a `?collab=<code>` share link, auto-open the Collaborate
+  // dialog (which prefills the code) so the recipient only picks a name and
+  // joins, instead of having to find the Project menu first.
+  useEffect(() => {
+    if (!collaboration.enabled) return;
+    if (new URLSearchParams(window.location.search).get("collab")) {
+      setCollaborateDialogOpen(true);
+    }
+  }, [collaboration.enabled]);
+
   const [controlsVisible, setControlsVisible] = useState<
     Record<ToolbarMapControl, boolean>
   >(() =>
@@ -457,346 +200,15 @@ export function TopToolbar({
   >(undefined);
   const [netcdfDialogOpen, setNetcdfDialogOpen] = useState(false);
   const [newProjectDialogOpen, setNewProjectDialogOpen] = useState(false);
-  const [projectUrlDialogOpen, setProjectUrlDialogOpen] = useState(false);
   const [managePluginsOpen, setManagePluginsOpen] = useState(false);
   const [shareDialogOpen, setShareDialogOpen] = useState(false);
   const [collaborateDialogOpen, setCollaborateDialogOpen] = useState(false);
-  const collaboration = useCollaboration(mapControllerRef);
-  // When opened via a `?collab=<code>` share link, auto-open the Collaborate
-  // dialog (which prefills the code) so the recipient only picks a name and
-  // joins, instead of having to find the Project menu first.
-  useEffect(() => {
-    if (!collaboration.enabled) return;
-    if (new URLSearchParams(window.location.search).get("collab")) {
-      setCollaborateDialogOpen(true);
-    }
-  }, [collaboration.enabled]);
-  const [projectUrl, setProjectUrl] = useState("");
-  const [projectUrlError, setProjectUrlError] = useState<string | null>(null);
-  const [projectUrlLoading, setProjectUrlLoading] = useState(false);
-  const [actionError, setActionError] = useState<string | null>(null);
-  const [directionsNoticeOpen, setDirectionsNoticeOpen] = useState(false);
-  const [reverseGeocodeNoticeOpen, setReverseGeocodeNoticeOpen] =
-    useState(false);
-  const [routingNoticeOpen, setRoutingNoticeOpen] = useState(false);
-  const [pendingNetworkTool, setPendingNetworkTool] = useState<
-    "isochrone" | "od-matrix" | null
-  >(null);
-  const [osmPbfLoading, setOsmPbfLoading] = useState(false);
-  const osmPbfAbortRef = useRef<AbortController | null>(null);
-  const [osmPbfDialogOpen, setOsmPbfDialogOpen] = useState(false);
-  const [osmPbfUrl, setOsmPbfUrl] = useState(DEFAULT_OSM_PBF_URL);
-  const [osmPbfConfirm, setOsmPbfConfirm] = useState<{
-    data: ArrayBuffer;
-    baseName: string;
-    sourcePath: string;
-    sizeMb: number;
-  } | null>(null);
-  // Pending "strip env vars before saving?" prompt. Holds the count to display
-  // and the resolver that the dialog buttons call to continue the save.
-  const [envStripPrompt, setEnvStripPrompt] = useState<{
-    count: number;
-    resolve: (choice: "strip" | "keep" | "cancel") => void;
-  } | null>(null);
   const [aboutOpen, setAboutOpen] = useState(false);
   const [printLayoutOpen, setPrintLayoutOpen] = useState(false);
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [checkForUpdatesRequest, setCheckForUpdatesRequest] = useState(0);
-  const projectUrlAbortRef = useRef<AbortController | null>(null);
-  const recentAbortRef = useRef<AbortController | null>(null);
 
-  const handleOpenFromFile = async () => {
-    const result = await openProjectFile();
-    if (result) {
-      try {
-        loadProject(
-          await resolveProjectXyzLayers(result.project),
-          result.path,
-          { rememberRecent: isTauri() },
-        );
-      } catch (error) {
-        console.error("Failed to open project", error);
-        setActionError(
-          error instanceof Error
-            ? error.message
-            : t("toolbar.error.couldNotOpenProject"),
-        );
-      }
-    }
-  };
-
-  const handleOpenFromUrl = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const normalizedUrl = normalizeProjectUrl(projectUrl);
-    if (!normalizedUrl) {
-      setProjectUrlError(t("toolbar.error.invalidProjectUrl"));
-      return;
-    }
-
-    projectUrlAbortRef.current?.abort();
-    const controller = new AbortController();
-    projectUrlAbortRef.current = controller;
-
-    setProjectUrlLoading(true);
-    setProjectUrlError(null);
-
-    try {
-      const result = await openRecentProjectFile(
-        normalizedUrl,
-        controller.signal,
-      );
-      const project = await resolveProjectXyzLayers(
-        result.project,
-        controller.signal,
-      );
-      if (controller.signal.aborted) return;
-      loadProject(project, result.path);
-      setProjectUrl("");
-      setProjectUrlDialogOpen(false);
-    } catch (error) {
-      if (controller.signal.aborted) return;
-      console.error("Failed to open project URL", error);
-      setProjectUrlError(
-        error instanceof Error
-          ? error.message
-          : t("toolbar.error.couldNotOpenProjectUrl"),
-      );
-    } finally {
-      if (projectUrlAbortRef.current === controller) {
-        projectUrlAbortRef.current = null;
-      }
-      setProjectUrlLoading(false);
-    }
-  };
-
-  const handleOpenRecent = async (path: string) => {
-    // Cancel any previous in-flight open so rapid clicks cannot race and let a
-    // stale fetch win by resolving last.
-    recentAbortRef.current?.abort();
-    const controller = new AbortController();
-    recentAbortRef.current = controller;
-
-    let result: Awaited<ReturnType<typeof openRecentProjectFile>>;
-
-    try {
-      result = await openRecentProjectFile(path, controller.signal);
-    } catch (error) {
-      if (controller.signal.aborted) return;
-      // Only drop the entry when the project is permanently gone; preserve it
-      // for transient failures (network timeout, 5xx, momentary IO error).
-      if (error instanceof RecentProjectGoneError) {
-        forgetRecentProject(path);
-      }
-      console.error("Failed to open recent project", error);
-      setActionError(
-        error instanceof Error
-          ? error.message
-          : t("toolbar.error.couldNotOpenRecentProject"),
-      );
-      return;
-    }
-
-    try {
-      const project = await resolveProjectXyzLayers(
-        result.project,
-        controller.signal,
-      );
-      if (controller.signal.aborted) return;
-      loadProject(project, result.path);
-    } catch (error) {
-      if (controller.signal.aborted) return;
-      console.error("Failed to load recent project", error);
-      setActionError(
-        error instanceof Error
-          ? error.message
-          : t("toolbar.error.couldNotLoadRecentProject"),
-      );
-    } finally {
-      if (recentAbortRef.current === controller) {
-        recentAbortRef.current = null;
-      }
-    }
-  };
-
-  // Build the current project from live store + map state and serialize it.
-  // Shared by Save/Save As and the Share action so they all capture identical
-  // project content (including the current map view and plugin state).
-  const buildCurrentProject = (nameOverride?: string) => {
-    const state = useAppStore.getState();
-    const defaultProjectName =
-      nameOverride?.trim() || state.projectName.trim() || DEFAULT_PROJECT_NAME;
-    const pluginManifestUrls = mergeStringLists(
-      state.projectPlugins?.manifestUrls ?? [],
-      useDesktopSettingsStore.getState().desktopSettings.pluginManifestUrls,
-    );
-    const project = projectFromStore({
-      projectName: defaultProjectName,
-      mapView: mapControllerRef.current?.readView() ?? state.mapView,
-      basemapStyleUrl: state.basemapStyleUrl,
-      basemapVisible: state.basemapVisible,
-      basemapOpacity: state.basemapOpacity,
-      layers: state.layers,
-      layerGroups: state.layerGroups,
-      preferences: state.preferences,
-      plugins: {
-        ...getPluginManager().getProjectState(),
-        manifestUrls: pluginManifestUrls,
-      },
-      legend: state.legend,
-      storymap: state.storymap,
-      models: state.models,
-      metadata: state.metadata,
-    });
-    return {
-      project,
-      defaultProjectName,
-      content: serializeProject(project),
-      // Expose the path read from this same snapshot so callers don't take a
-      // second `getState()` read that could be misread as a separate instant.
-      projectPath: state.projectPath,
-    };
-  };
-
-  // Ask whether to strip environment variables before writing the file. The
-  // promise resolves when the user picks an option in the dialog.
-  const askStripEnvVars = (count: number) =>
-    new Promise<"strip" | "keep" | "cancel">((resolve) => {
-      setEnvStripPrompt({ count, resolve });
-    });
-
-  const resolveEnvStripPrompt = (choice: "strip" | "keep" | "cancel") => {
-    // Resolve outside the state updater (updaters must be side-effect free).
-    envStripPrompt?.resolve(choice);
-    setEnvStripPrompt(null);
-  };
-
-  const saveProject = async (options?: {
-    saveAs?: boolean;
-  }): Promise<boolean> => {
-    const { project, defaultProjectName, content, projectPath } =
-      buildCurrentProject();
-    // Env vars (possibly API keys) are serialized in plain text. If any are set,
-    // offer to strip them from the saved file before writing.
-    let contentToSave = content;
-    const envVarCount = (project.preferences.environmentVariables ?? []).filter(
-      (variable) => variable.key.trim(),
-    ).length;
-    if (envVarCount > 0) {
-      const choice = await askStripEnvVars(envVarCount);
-      if (choice === "cancel") return false;
-      if (choice === "strip") {
-        contentToSave = serializeProject({
-          ...project,
-          preferences: { ...project.preferences, environmentVariables: [] },
-        });
-      }
-    }
-    // Projects opened from a URL have no writable path, so both Save and
-    // Save As fall back to the save dialog for them.
-    const existingLocalPath =
-      projectPath && !isHttpUrl(projectPath) ? projectPath : null;
-    let path: string | null;
-    try {
-      path =
-        !options?.saveAs && existingLocalPath
-          ? await saveProjectFileToPath(contentToSave, existingLocalPath)
-          : await saveProjectFile(
-              contentToSave,
-              existingLocalPath ?? `${defaultProjectName}.geolibre.json`,
-            );
-    } catch (error) {
-      console.error("Failed to save project", error);
-      setActionError(
-        error instanceof Error
-          ? error.message
-          : t("toolbar.error.couldNotSaveProject"),
-      );
-      return false;
-    }
-    if (!path) return false;
-    setProjectPath(path);
-    rememberRecentProject({
-      path,
-      name: project.name,
-      openedAt: new Date().toISOString(),
-    });
-    markSaved();
-    return true;
-  };
-
-  const handleSave = () => saveProject();
-  const handleSaveAs = () => saveProject({ saveAs: true });
-
-  const {
-    plugins,
-    isActive,
-    getMapControlPosition,
-    toggle,
-    setMapControlPosition,
-  } = usePluginRegistry();
-  const appApi = createAppAPI(mapControllerRef);
-  // Show a one-time consent notice the first time routing is enabled, since it
-  // sends the user's waypoints to a public third-party server. A hover-only
-  // tooltip is invisible on touch, so this is the real disclosure.
-  const handleToggleDirections = () => {
-    if (isActive(DIRECTIONS_PLUGIN_ID)) {
-      toggle(DIRECTIONS_PLUGIN_ID, appApi);
-      return;
-    }
-    let acknowledged = false;
-    try {
-      acknowledged =
-        localStorage.getItem("geolibre:directions-osrm-notice") === "1";
-    } catch {
-      // localStorage unavailable (private mode): fall back to showing the notice.
-    }
-    if (acknowledged) toggle(DIRECTIONS_PLUGIN_ID, appApi);
-    else setDirectionsNoticeOpen(true);
-  };
-  const confirmEnableDirections = () => {
-    try {
-      localStorage.setItem("geolibre:directions-osrm-notice", "1");
-    } catch {
-      // Ignore: the notice will simply show again next time.
-    }
-    setDirectionsNoticeOpen(false);
-    toggle(DIRECTIONS_PLUGIN_ID, appApi);
-  };
-  // Reverse geocode sends the clicked coordinates to a public geocoder, so it
-  // shows the same one-time consent notice as Directions before first enabling.
-  // The consent flag is shared with the project-restore path (DesktopShell), so
-  // every activation path is gated on it.
-  const handleToggleReverseGeocode = () => {
-    if (isActive(REVERSE_GEOCODE_PLUGIN_ID)) {
-      toggle(REVERSE_GEOCODE_PLUGIN_ID, appApi);
-      return;
-    }
-    if (hasReverseGeocodeConsent()) toggle(REVERSE_GEOCODE_PLUGIN_ID, appApi);
-    else setReverseGeocodeNoticeOpen(true);
-  };
-  const confirmEnableReverseGeocode = () => {
-    recordReverseGeocodeConsent();
-    setReverseGeocodeNoticeOpen(false);
-    toggle(REVERSE_GEOCODE_PLUGIN_ID, appApi);
-  };
-  // Network analysis tools send the coordinates of the input points to a public
-  // Valhalla routing server, so they show the same one-time consent notice as
-  // Directions before opening, gated on every activation path (each menu item).
-  const openNetworkTool = (kind: "isochrone" | "od-matrix") => {
-    if (hasRoutingConsent()) {
-      setNetworkToolOpen(kind);
-      return;
-    }
-    setPendingNetworkTool(kind);
-    setRoutingNoticeOpen(true);
-  };
-  const confirmOpenNetworkTool = () => {
-    recordRoutingConsent();
-    setRoutingNoticeOpen(false);
-    if (pendingNetworkTool) setNetworkToolOpen(pendingNetworkTool);
-    setPendingNetworkTool(null);
-  };
   const resetRuntimeControlsForNewProject = () => {
     closeMaplibreComponentControls(appApi);
     closeRasterLayerPanel(appApi);
@@ -820,288 +232,24 @@ export function TopToolbar({
     }
     setControlsVisible(newProjectToolbarControlVisibility());
   };
-  const handleAddFlatGeobufLayer = () => {
-    openFlatGeobufAddVectorLayerPanel(appApi);
+
+  // The appApi-backed "add layer" handlers shared by the Add Data menu and the
+  // command palette so each panel opens identically from both.
+  const addLayer: AddLayerHandlers = {
+    vector: () => openVectorLayerPanel(appApi),
+    raster: () => openRasterLayerPanel(appApi),
+    stac: () => openStacSearchLayerPanel(appApi),
+    flatGeobuf: () => openFlatGeobufAddVectorLayerPanel(appApi),
+    pmtiles: () => openPMTilesLayerPanel(appApi),
+    zarr: () => openZarrLayerPanel(appApi),
+    netcdf: () => setNetcdfDialogOpen(true),
+    lidar: () => openLidarLayerPanel(appApi),
+    splatting: () => openSplattingLayerPanel(appApi),
+    threeDTiles: () => openThreeDTilesLayerPanel(appApi),
+    duckdb: () => openDuckDBLayerPanel(appApi),
   };
-  const handleAddDuckDBLayer = () => {
-    openDuckDBLayerPanel(appApi);
-  };
-  const handleAddPMTilesLayer = () => {
-    openPMTilesLayerPanel(appApi);
-  };
-  const handleAddStacLayer = () => {
-    openStacSearchLayerPanel(appApi);
-  };
-  const handleAddRasterLayer = () => {
-    openRasterLayerPanel(appApi);
-  };
-  const handleAddVectorLayer = () => {
-    openVectorLayerPanel(appApi);
-  };
-  const runOsmPbf = async (
-    data: ArrayBuffer,
-    baseName: string,
-    sourcePath: string,
-  ) => {
-    // Reuse a controller already started for the URL fetch, else make one, so
-    // the loading dialog's Cancel/dismiss can abort the in-flight parse.
-    const controller = osmPbfAbortRef.current ?? new AbortController();
-    osmPbfAbortRef.current = controller;
-    if (controller.signal.aborted) {
-      osmPbfAbortRef.current = null;
-      setOsmPbfLoading(false);
-      return;
-    }
-    setOsmPbfLoading(true);
-    try {
-      const layers = await loadOsmPbf(data, controller.signal);
-      const added = addOsmPbfLayers(
-        appApi.addGeoJsonLayer,
-        baseName,
-        sourcePath,
-        layers,
-      );
-      if (added === 0) {
-        setActionError(t("toolbar.error.osmPbfNoFeatures"));
-      } else if (layers.bounds) {
-        appApi.fitBounds?.(layers.bounds);
-      }
-    } catch (err) {
-      // A user cancel (abort) is not an error.
-      if (err instanceof DOMException && err.name === "AbortError") return;
-      const base =
-        err instanceof Error
-          ? err.message
-          : t("toolbar.error.couldNotLoadOsmPbf");
-      // Bare .pbf is also the Mapbox Vector Tile extension; hint at it on
-      // failure. The message + hint live in one catalog key so each locale
-      // controls how the two sentences join (e.g. no space in CJK).
-      setActionError(
-        t("toolbar.error.osmPbfLoadFailedWithHint", { message: base }),
-      );
-    } finally {
-      setOsmPbfLoading(false);
-      if (osmPbfAbortRef.current === controller) osmPbfAbortRef.current = null;
-    }
-  };
-  const cancelOsmPbf = () => {
-    osmPbfAbortRef.current?.abort();
-    osmPbfAbortRef.current = null;
-    setOsmPbfLoading(false);
-  };
-  // Large extracts can exhaust browser memory; confirm before parsing.
-  const startOsmPbf = (
-    data: ArrayBuffer,
-    baseName: string,
-    sourcePath: string,
-  ) => {
-    if (data.byteLength >= OSM_PBF_SIZE_WARN_BYTES) {
-      setOsmPbfConfirm({
-        data,
-        baseName,
-        sourcePath,
-        sizeMb: Math.round(data.byteLength / (1024 * 1024)),
-      });
-      return;
-    }
-    void runOsmPbf(data, baseName, sourcePath);
-  };
-  const handleChooseOsmPbfFile = async () => {
-    setOsmPbfDialogOpen(false);
-    try {
-      const result = await openLocalDataFileWithFallback({
-        filters: [{ name: "OSM PBF", extensions: ["pbf", "osm.pbf"] }],
-        accept: ".pbf,.osm.pbf",
-        readBinary: true,
-      });
-      if (!result?.data) return;
-      const fileName = result.path.split(/[/\\]/).pop() || "osm";
-      startOsmPbf(result.data, osmPbfBaseName(fileName), result.path);
-    } catch (err) {
-      setActionError(
-        err instanceof Error
-          ? err.message
-          : t("toolbar.error.couldNotOpenOsmPbf"),
-      );
-    }
-  };
-  const handleLoadOsmPbfUrl = async () => {
-    const url = osmPbfUrl.trim();
-    if (!isHttpUrl(url)) {
-      setActionError(t("toolbar.error.invalidOsmPbfUrl"));
-      return;
-    }
-    setOsmPbfDialogOpen(false);
-    // Start the controller before the fetch so a dismiss during download is
-    // honored (the download itself isn't abortable through the shared fetcher,
-    // but we drop the result instead of parsing/adding it).
-    const controller = new AbortController();
-    osmPbfAbortRef.current = controller;
-    setOsmPbfLoading(true);
-    try {
-      const data = await appApi.fetchArrayBuffer?.(url);
-      if (controller.signal.aborted) return;
-      // Surface the user-facing message directly rather than throwing a
-      // translated Error — Error.message also feeds error boundaries and logs,
-      // which should stay locale-independent. The catch below still covers a
-      // genuine fetch failure.
-      if (!data) {
-        setOsmPbfLoading(false);
-        if (osmPbfAbortRef.current === controller) osmPbfAbortRef.current = null;
-        setActionError(t("toolbar.error.couldNotDownloadOsmPbf"));
-        return;
-      }
-      const fileName =
-        url.split("/").pop()?.split("?")[0].split("#")[0] || "osm";
-      // Keep the loading indicator up through the parse for small files
-      // (runOsmPbf re-sets it and clears it in finally); only stop it here when
-      // a large file will instead show the confirm dialog, to avoid a flicker.
-      if (data.byteLength >= OSM_PBF_SIZE_WARN_BYTES) setOsmPbfLoading(false);
-      startOsmPbf(data, osmPbfBaseName(fileName), url);
-    } catch (err) {
-      setOsmPbfLoading(false);
-      if (osmPbfAbortRef.current === controller) osmPbfAbortRef.current = null;
-      setActionError(
-        err instanceof Error
-          ? err.message
-          : t("toolbar.error.couldNotDownloadOsmPbf"),
-      );
-    }
-  };
-  const searchPlacesVisible = useSyncExternalStore(
-    subscribeSearchPlacesPanel,
-    isSearchPlacesPanelVisible,
-    isSearchPlacesPanelVisible,
-  );
-  const handleToggleSearchPlacesPanel = () => {
-    if (searchPlacesVisible) {
-      closeSearchPlacesPanel();
-      return;
-    }
-    openSearchPlacesPanel(appApi);
-  };
-  const printPanelVisible = useSyncExternalStore(
-    subscribePrintPanel,
-    isPrintPanelVisible,
-    isPrintPanelVisible,
-  );
-  const handleTogglePrintPanel = () => {
-    if (printPanelVisible) {
-      closePrintPanel();
-      return;
-    }
-    openPrintPanel(appApi);
-  };
-  const colorbarPanelVisible = useSyncExternalStore(
-    subscribeColorbarPanel,
-    isColorbarPanelVisible,
-    isColorbarPanelVisible,
-  );
-  const handleToggleColorbarPanel = () => {
-    if (colorbarPanelVisible) {
-      closeColorbarPanel(appApi);
-      return;
-    }
-    openColorbarPanel(appApi);
-  };
-  const legendPanelVisible = useSyncExternalStore(
-    subscribeLegendPanel,
-    isLegendPanelVisible,
-    isLegendPanelVisible,
-  );
-  const handleToggleLegendPanel = () => {
-    if (legendPanelVisible) {
-      closeLegendPanel(appApi);
-      return;
-    }
-    openLegendPanel(appApi);
-  };
-  const htmlPanelVisible = useSyncExternalStore(
-    subscribeHtmlPanel,
-    isHtmlPanelVisible,
-    isHtmlPanelVisible,
-  );
-  const handleToggleHtmlPanel = () => {
-    if (htmlPanelVisible) {
-      closeHtmlPanel(appApi);
-      return;
-    }
-    openHtmlPanel(appApi);
-  };
-  const measurePanelVisible = useSyncExternalStore(
-    subscribeMeasurePanel,
-    isMeasurePanelVisible,
-    isMeasurePanelVisible,
-  );
-  const handleToggleMeasurePanel = () => {
-    if (measurePanelVisible) {
-      closeMeasurePanel(appApi);
-      return;
-    }
-    openMeasurePanel(appApi);
-  };
-  const bookmarkPanelVisible = useSyncExternalStore(
-    subscribeBookmarkPanel,
-    isBookmarkPanelVisible,
-    isBookmarkPanelVisible,
-  );
-  const handleToggleBookmarkPanel = () => {
-    if (bookmarkPanelVisible) {
-      closeBookmarkPanel(appApi);
-      return;
-    }
-    openBookmarkPanel(appApi);
-  };
-  const minimapPanelVisible = useSyncExternalStore(
-    subscribeMinimapPanel,
-    isMinimapPanelVisible,
-    isMinimapPanelVisible,
-  );
-  const handleToggleMinimapPanel = () => {
-    if (minimapPanelVisible) {
-      closeMinimapPanel(appApi);
-      return;
-    }
-    openMinimapPanel(appApi);
-  };
-  const viewStatePanelVisible = useSyncExternalStore(
-    subscribeViewStatePanel,
-    isViewStatePanelVisible,
-    isViewStatePanelVisible,
-  );
-  const handleToggleViewStatePanel = () => {
-    if (viewStatePanelVisible) {
-      closeViewStatePanel(appApi);
-      return;
-    }
-    openViewStatePanel(appApi);
-  };
-  const handleAddZarrLayer = () => {
-    openZarrLayerPanel(appApi);
-  };
-  const handleAddNetcdfLayer = () => {
-    setNetcdfDialogOpen(true);
-  };
-  const handleAddLidarLayer = () => {
-    openLidarLayerPanel(appApi);
-  };
-  const handleAddSplattingLayer = () => {
-    openSplattingLayerPanel(appApi);
-  };
-  const handleAddThreeDTilesLayer = () => {
-    openThreeDTilesLayerPanel(appApi);
-  };
-  const handleOpenPlanetaryComputerPanel = () => {
-    openPlanetaryComputerPanel(appApi);
-  };
-  const earthEnginePanelVisible = useSyncExternalStore(
-    subscribeEarthEnginePanel,
-    isEarthEnginePanelVisible,
-    isEarthEnginePanelVisible,
-  );
-  const handleToggleEarthEnginePanel = () => {
-    toggleEarthEnginePanel(appApi);
-  };
+  const handleOpenPlanetaryComputer = () => openPlanetaryComputerPanel(appApi);
+
   const toggleMapControl = (control: ToolbarMapControl) => {
     setControlsVisible((current) => {
       const visible = !current[control];
@@ -1111,6 +259,7 @@ export function TopToolbar({
       return updated ? { ...current, [control]: visible } : current;
     });
   };
+
   // The command registry: the single source of truth shared by the command
   // palette, the global shortcut layer, and the keyboard cheat sheet. Each
   // entry reuses the same handler the matching menu item calls, so behaviour is
@@ -1134,7 +283,7 @@ export function TopToolbar({
       keywords: "load",
       icon: FolderOpen,
       shortcut: { key: "o", mod: true, shift: false },
-      run: () => void handleOpenFromFile(),
+      run: () => void projectFiles.handleOpenFromFile(),
     },
     {
       id: "project.open-url",
@@ -1142,7 +291,7 @@ export function TopToolbar({
       group: t("toolbar.commandGroup.project"),
       keywords: "load",
       icon: Link2,
-      run: () => setProjectUrlDialogOpen(true),
+      run: () => projectFiles.setProjectUrlDialogOpen(true),
     },
     {
       id: "project.save",
@@ -1150,7 +299,7 @@ export function TopToolbar({
       group: t("toolbar.commandGroup.project"),
       icon: Save,
       shortcut: { key: "s", mod: true, shift: false },
-      run: () => void handleSave(),
+      run: () => void projectFiles.handleSave(),
     },
     {
       id: "project.save-as",
@@ -1158,7 +307,7 @@ export function TopToolbar({
       group: t("toolbar.commandGroup.project"),
       icon: FilePen,
       shortcut: { key: "s", mod: true, shift: true },
-      run: () => void handleSaveAs(),
+      run: () => void projectFiles.handleSaveAs(),
     },
     {
       id: "project.share",
@@ -1184,7 +333,7 @@ export function TopToolbar({
       title: t("toolbar.command.projectPrint"),
       group: t("toolbar.commandGroup.project"),
       icon: Printer,
-      run: handleTogglePrintPanel,
+      run: panels.print.toggle,
     },
     {
       id: "project.print-layout",
@@ -1199,20 +348,20 @@ export function TopToolbar({
       title: t("toolbar.command.addVectorLayer"),
       group: t("toolbar.commandGroup.addData"),
       icon: Database,
-      run: handleAddVectorLayer,
+      run: addLayer.vector,
     },
     {
       id: "add.raster",
       title: t("toolbar.command.addRasterLayer"),
       group: t("toolbar.commandGroup.addData"),
       icon: Database,
-      run: handleAddRasterLayer,
+      run: addLayer.raster,
     },
     {
       id: "add.osm-pbf",
       title: t("toolbar.command.addOsmPbfLayer"),
       group: t("toolbar.commandGroup.addData"),
-      run: () => setOsmPbfDialogOpen(true),
+      run: () => osmPbf.setDialogOpen(true),
     },
     ...ADD_DATA_KIND_COMMANDS.map(({ kind, titleKey }) => ({
       id: `add.${kind}`,
@@ -1224,61 +373,61 @@ export function TopToolbar({
       id: "add.stac",
       title: t("toolbar.command.addStacLayer"),
       group: t("toolbar.commandGroup.addData"),
-      run: handleAddStacLayer,
+      run: addLayer.stac,
     },
     {
       id: "add.geoparquet",
       title: t("toolbar.command.addGeoparquetLayer"),
       group: t("toolbar.commandGroup.addData"),
-      run: handleAddVectorLayer,
+      run: addLayer.vector,
     },
     {
       id: "add.flatgeobuf",
       title: t("toolbar.command.addFlatgeobufLayer"),
       group: t("toolbar.commandGroup.addData"),
-      run: handleAddFlatGeobufLayer,
+      run: addLayer.flatGeobuf,
     },
     {
       id: "add.pmtiles",
       title: t("toolbar.command.addPmtilesLayer"),
       group: t("toolbar.commandGroup.addData"),
-      run: handleAddPMTilesLayer,
+      run: addLayer.pmtiles,
     },
     {
       id: "add.zarr",
       title: t("toolbar.command.addZarrLayer"),
       group: t("toolbar.commandGroup.addData"),
-      run: handleAddZarrLayer,
+      run: addLayer.zarr,
     },
     {
       id: "add.netcdf",
       title: t("toolbar.command.addNetcdfLayer"),
       group: t("toolbar.commandGroup.addData"),
-      run: handleAddNetcdfLayer,
+      run: addLayer.netcdf,
     },
     {
       id: "add.lidar",
       title: t("toolbar.command.addLidarLayer"),
       group: t("toolbar.commandGroup.addData"),
-      run: handleAddLidarLayer,
+      run: addLayer.lidar,
     },
     {
       id: "add.splatting",
       title: t("toolbar.command.addSplattingLayer"),
       group: t("toolbar.commandGroup.addData"),
-      run: handleAddSplattingLayer,
+      run: addLayer.splatting,
     },
     {
       id: "add.3d-tiles",
       title: t("toolbar.command.add3dTilesLayer"),
       group: t("toolbar.commandGroup.addData"),
-      run: handleAddThreeDTilesLayer,
+      run: addLayer.threeDTiles,
     },
     {
       id: "add.duckdb",
       title: t("toolbar.command.addDuckdbLayer"),
       group: t("toolbar.commandGroup.addData"),
-      run: handleAddDuckDBLayer,
+      run: addLayer.duckdb,
     },
     // Processing
     {
@@ -1360,13 +509,13 @@ export function TopToolbar({
       id: "proc.planetary-computer",
       title: t("toolbar.command.planetaryComputer"),
       group: t("toolbar.commandGroup.processing"),
-      run: handleOpenPlanetaryComputerPanel,
+      run: handleOpenPlanetaryComputer,
     },
     {
       id: "proc.earth-engine",
       title: t("toolbar.command.earthEngine"),
       group: t("toolbar.commandGroup.processing"),
-      run: handleToggleEarthEnginePanel,
+      run: panels.earthEngine.toggle,
     },
     // Controls
     ...MAP_CONTROL_ITEMS.map((control) => ({
@@ -1388,55 +537,55 @@ export function TopToolbar({
       id: "control.directions",
       title: t("toolbar.command.toggleDirections"),
       group: t("toolbar.commandGroup.controls"),
-      run: handleToggleDirections,
+      run: consent.handleToggleDirections,
     },
     {
       id: "control.search",
       title: t("toolbar.command.toggleSearch"),
       group: t("toolbar.commandGroup.controls"),
-      run: handleToggleSearchPlacesPanel,
+      run: panels.searchPlaces.toggle,
     },
     {
       id: "control.colorbar",
       title: t("toolbar.command.toggleColorbar"),
       group: t("toolbar.commandGroup.controls"),
-      run: handleToggleColorbarPanel,
+      run: panels.colorbar.toggle,
     },
     {
       id: "control.legend",
       title: t("toolbar.command.toggleLegend"),
       group: t("toolbar.commandGroup.controls"),
-      run: handleToggleLegendPanel,
+      run: panels.legend.toggle,
     },
     {
       id: "control.html",
       title: t("toolbar.command.toggleHtmlPanel"),
       group: t("toolbar.commandGroup.controls"),
-      run: handleToggleHtmlPanel,
+      run: panels.html.toggle,
     },
     {
       id: "control.measure",
       title: t("toolbar.command.toggleMeasure"),
       group: t("toolbar.commandGroup.controls"),
-      run: handleToggleMeasurePanel,
+      run: panels.measure.toggle,
     },
     {
       id: "control.bookmark",
       title: t("toolbar.command.toggleBookmark"),
       group: t("toolbar.commandGroup.controls"),
-      run: handleToggleBookmarkPanel,
+      run: panels.bookmark.toggle,
     },
     {
       id: "control.minimap",
       title: t("toolbar.command.toggleMinimap"),
       group: t("toolbar.commandGroup.controls"),
-      run: handleToggleMinimapPanel,
+      run: panels.minimap.toggle,
     },
     {
       id: "control.view-state",
       title: t("toolbar.command.toggleViewState"),
       group: t("toolbar.commandGroup.controls"),
-      run: handleToggleViewStatePanel,
+      run: panels.viewState.toggle,
     },
     // View
     {
@@ -1539,6 +688,13 @@ export function TopToolbar({
   const appTitle = isTauri() ? "GeoLibre Desktop" : "GeoLibre";
   const renderToolbarLabel = (label: string) =>
     showLabels ? <span className="hidden sm:inline">{label}</span> : null;
+  const chrome: ToolbarChrome = {
+    buttonClass: toolbarButtonClass,
+    secondaryButtonClass: toolbarSecondaryButtonClass,
+    buttonSize: toolbarButtonSize,
+    iconClassName: toolbarIconClassName,
+    renderLabel: renderToolbarLabel,
+  };
 
   return (
     <header
@@ -1555,827 +711,65 @@ export function TopToolbar({
           <span className="hidden sm:inline">{appTitle}</span>
         ) : null}
       </span>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            className={toolbarButtonClass}
-            variant="ghost"
-            size={toolbarButtonSize}
-            aria-label={t("toolbar.menu.project")}
-          >
-            <Folder className={toolbarIconClassName} />
-            {renderToolbarLabel(t("toolbar.menu.project"))}
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="w-64">
-          <DropdownMenuLabel>{t("toolbar.menu.project")}</DropdownMenuLabel>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onSelect={() => setNewProjectDialogOpen(true)}>
-            <FilePlus2 className="mr-2 h-3.5 w-3.5" />
-            {t("toolbar.item.newEllipsis")}
-          </DropdownMenuItem>
-          <DropdownMenuSub>
-            <DropdownMenuSubTrigger>
-              <FolderOpen className="mr-2 h-3.5 w-3.5" />
-              {t("toolbar.item.openFrom")}
-            </DropdownMenuSubTrigger>
-            <DropdownMenuSubContent>
-              <DropdownMenuItem onSelect={() => void handleOpenFromFile()}>
-                <FileText className="mr-2 h-3.5 w-3.5" />
-                {t("toolbar.item.fileEllipsis")}
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => setProjectUrlDialogOpen(true)}>
-                <Link2 className="mr-2 h-3.5 w-3.5" />
-                {t("toolbar.item.urlEllipsis")}
-              </DropdownMenuItem>
-            </DropdownMenuSubContent>
-          </DropdownMenuSub>
-          <DropdownMenuSub>
-            <DropdownMenuSubTrigger disabled={recentProjects.length === 0}>
-              <History className="mr-2 h-3.5 w-3.5" />
-              {t("toolbar.item.openRecent")}
-            </DropdownMenuSubTrigger>
-            <DropdownMenuSubContent className="w-80">
-              {recentProjects.length === 0 ? (
-                <DropdownMenuItem disabled>
-                  {t("toolbar.item.noRecentProjects")}
-                </DropdownMenuItem>
-              ) : (
-                recentProjects.map((project) => {
-                  const openedAt = formatRecentProjectTime(project.openedAt);
-                  const label = project.name || projectPathLabel(project.path);
-                  return (
-                    <DropdownMenuItem
-                      key={project.path}
-                      className="flex items-start justify-between gap-2"
-                      onSelect={() => void handleOpenRecent(project.path)}
-                      title={project.path}
-                    >
-                      <span className="flex min-w-0 flex-col items-start gap-0.5">
-                        <span
-                          className="max-w-full truncate font-medium"
-                          title={label}
-                        >
-                          {label}
-                        </span>
-                        <span className="flex max-w-full items-start gap-1 text-xs text-muted-foreground">
-                          <History className="h-3 w-3 shrink-0" />
-                          <span
-                            className="break-all text-left leading-snug"
-                            title={project.path}
-                          >
-                            {openedAt
-                              ? `${openedAt} - ${project.path}`
-                              : project.path}
-                          </span>
-                        </span>
-                      </span>
-                      <button
-                        type="button"
-                        aria-label={t("toolbar.item.removeFromRecent", {
-                          name: label,
-                        })}
-                        className="mt-0.5 shrink-0 rounded p-0.5 text-muted-foreground hover:text-foreground"
-                        onClick={(event) => {
-                          // Keep the menu open and prevent the row's onSelect
-                          // (which would reopen the project) from firing.
-                          event.stopPropagation();
-                          event.preventDefault();
-                          forgetRecentProject(project.path);
-                        }}
-                      >
-                        <X className="h-3.5 w-3.5" />
-                      </button>
-                    </DropdownMenuItem>
-                  );
-                })
-              )}
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                disabled={recentProjects.length === 0}
-                onSelect={clearRecentProjects}
-              >
-                {t("toolbar.item.clearRecentProjects")}
-              </DropdownMenuItem>
-            </DropdownMenuSubContent>
-          </DropdownMenuSub>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onSelect={() => void handleSave()}>
-            <Save className="mr-2 h-3.5 w-3.5" />
-            {t("common.save")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => void handleSaveAs()}>
-            <FilePen className="mr-2 h-3.5 w-3.5" />
-            {t("toolbar.item.saveAsEllipsis")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setShareDialogOpen(true)}>
-            <Share2 className="mr-2 h-3.5 w-3.5" />
-            {t("toolbar.item.shareEllipsis")}
-          </DropdownMenuItem>
-          {collaboration.enabled && (
-            <DropdownMenuItem onSelect={() => setCollaborateDialogOpen(true)}>
-              <Users className="mr-2 h-3.5 w-3.5" />
-              {t("toolbar.item.collaborateEllipsis")}
-            </DropdownMenuItem>
-          )}
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onSelect={handleTogglePrintPanel}>
-            <Printer className="mr-2 h-3.5 w-3.5" />
-            {t("toolbar.item.printEllipsis")}
-            {printPanelVisible ? " ✓" : ""}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setPrintLayoutOpen(true)}>
-            <LayoutTemplate className="mr-2 h-3.5 w-3.5" />
-            Print Layout...
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onSelect={() => setStorymapPanelOpen(true)}>
-            <BookOpen className="mr-2 h-3.5 w-3.5" />
-            {t("toolbar.item.storymapEllipsis")}
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            className={toolbarSecondaryButtonClass}
-            variant="ghost"
-            size={toolbarButtonSize}
-            aria-label={t("toolbar.menu.edit")}
-          >
-            <Pencil className={toolbarIconClassName} />
-            {renderToolbarLabel(t("toolbar.menu.edit"))}
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="w-56">
-          <DropdownMenuLabel>{t("toolbar.menu.edit")}</DropdownMenuLabel>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem disabled={!canUndo} onSelect={undo}>
-            <Undo2 className="mr-2 h-3.5 w-3.5" />
-            {t("toolbar.item.undo")}
-            <span className="ml-auto text-xs text-muted-foreground">
-              Ctrl/Cmd+Z
-            </span>
-          </DropdownMenuItem>
-          <DropdownMenuItem disabled={!canRedo} onSelect={redo}>
-            <Redo2 className="mr-2 h-3.5 w-3.5" />
-            {t("toolbar.item.redo")}
-            <span className="ml-auto text-xs text-muted-foreground">
-              Ctrl/Cmd+Shift+Z / Ctrl+Y
-            </span>
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <ProjectMenu
+        chrome={chrome}
+        collaborationEnabled={collaboration.enabled}
+        printPanel={panels.print}
+        onNewProject={() => setNewProjectDialogOpen(true)}
+        onOpenFromFile={() => void projectFiles.handleOpenFromFile()}
+        onOpenFromUrl={() => projectFiles.setProjectUrlDialogOpen(true)}
+        onOpenRecent={(path) => void projectFiles.handleOpenRecent(path)}
+        onSave={() => void projectFiles.handleSave()}
+        onSaveAs={() => void projectFiles.handleSaveAs()}
+        onShare={() => setShareDialogOpen(true)}
+        onCollaborate={() => setCollaborateDialogOpen(true)}
+        onPrintLayout={() => setPrintLayoutOpen(true)}
+      />
+      <EditMenu chrome={chrome} />
       <NewProjectDialog
         open={newProjectDialogOpen}
         onOpenChange={setNewProjectDialogOpen}
-        onSaveCurrentProject={handleSave}
+        onSaveCurrentProject={projectFiles.handleSave}
         onProjectCreated={resetRuntimeControlsForNewProject}
       />
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            className={toolbarButtonClass}
-            variant="ghost"
-            size={toolbarButtonSize}
-            aria-label={t("toolbar.menu.addData")}
-          >
-            <Database className={toolbarIconClassName} />
-            {renderToolbarLabel(t("toolbar.menu.addData"))}
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="w-64">
-          <DropdownMenuLabel>{t("toolbar.menu.addData")}</DropdownMenuLabel>
-          <DropdownMenuSeparator />
-          <DropdownMenuLabel className="text-xs text-muted-foreground">
-            {t("toolbar.item.sectionFiles")}
-          </DropdownMenuLabel>
-          <DropdownMenuItem onSelect={handleAddVectorLayer}>
-            {t("toolbar.item.vectorLayer")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleAddRasterLayer}>
-            {t("toolbar.item.rasterLayer")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setAddDataKind("delimited-text")}>
-            {t("toolbar.layerType.delimitedText")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setAddDataKind("gpx")}>
-            {t("toolbar.layerType.gpx")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setAddDataKind("mbtiles")}>
-            {t("toolbar.layerType.mbtiles")}
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            disabled={osmPbfLoading || osmPbfConfirm !== null}
-            onSelect={() => setOsmPbfDialogOpen(true)}
-          >
-            {t("toolbar.item.osmPbfLayer")}
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuLabel className="text-xs text-muted-foreground">
-            {t("toolbar.item.sectionWebServices")}
-          </DropdownMenuLabel>
-          <DropdownMenuItem onSelect={() => setAddDataKind("xyz")}>
-            {t("toolbar.layerType.xyz")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setAddDataKind("wms")}>
-            {t("toolbar.layerType.wms")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setAddDataKind("wfs")}>
-            {t("toolbar.layerType.wfs")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setAddDataKind("wmts")}>
-            {t("toolbar.layerType.wmts")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setAddDataKind("arcgis")}>
-            {t("toolbar.layerType.arcgis")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleAddStacLayer}>
-            {t("toolbar.item.stacLayer")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setAddDataKind("video")}>
-            {t("toolbar.layerType.video")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setAddDataKind("deckgl-viz")}>
-            {t("toolbar.layerType.deckglViz")}
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuLabel className="text-xs text-muted-foreground">
-            {t("toolbar.item.sectionCloudFormats")}
-          </DropdownMenuLabel>
-          <DropdownMenuItem onSelect={handleAddVectorLayer}>
-            {t("toolbar.item.geoparquetLayer")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleAddFlatGeobufLayer}>
-            {t("toolbar.item.flatgeobufLayer")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleAddPMTilesLayer}>
-            {t("toolbar.item.pmtilesLayer")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleAddZarrLayer}>
-            {t("toolbar.item.zarrLayer")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleAddNetcdfLayer}>
-            {t("toolbar.item.netcdfHdf")}
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuLabel className="text-xs text-muted-foreground">
-            {t("toolbar.item.section3dLayers")}
-          </DropdownMenuLabel>
-          <DropdownMenuItem onSelect={handleAddLidarLayer}>
-            {t("toolbar.item.lidarLayer")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleAddSplattingLayer}>
-            {t("toolbar.item.splattingLayer")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleAddThreeDTilesLayer}>
-            {t("toolbar.item.threeDTilesLayer")}
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            onSelect={() => {
-              setAddDataDeckVizKind("scenegraph");
-              setAddDataKind("deckgl-viz");
-            }}
-          >
-            {t("toolbar.layerType.gltfModel")}
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuLabel className="text-xs text-muted-foreground">
-            {t("toolbar.item.sectionDatabases")}
-          </DropdownMenuLabel>
-          <DropdownMenuItem onSelect={handleAddDuckDBLayer}>
-            {t("toolbar.item.duckdbLayer")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setAddDataKind("postgres")}>
-            {t("toolbar.layerType.postgres")}
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            className={toolbarButtonClass}
-            variant="ghost"
-            size={toolbarButtonSize}
-            aria-label={t("toolbar.menu.processing")}
-          >
-            <Wrench className={toolbarIconClassName} />
-            {renderToolbarLabel(t("toolbar.menu.processing"))}
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start">
-          <DropdownMenuLabel>{t("toolbar.menu.processing")}</DropdownMenuLabel>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onSelect={() => setAssistantOpen(true)}>
-            {t("toolbar.command.assistant")}
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onSelect={() => setProcessingOpen(true)}>
-            {t("toolbar.item.whitebox")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setSqlWorkspaceOpen(true)}>
-            {t("toolbar.command.sqlWorkspace")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setPythonConsoleOpen(true)}>
-            {t("toolbar.command.pythonConsole")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setGeocodeOpen(true)}>
-            {t("toolbar.item.geocode")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setModelBuilderOpen(true)}>
-            {t("toolbar.item.modelBuilder")}
-          </DropdownMenuItem>
-          <DropdownMenuSub>
-            <DropdownMenuSubTrigger>
-              {t("toolbar.item.conversion")}
-            </DropdownMenuSubTrigger>
-            <DropdownMenuSubContent>
-              <DropdownMenuItem
-                onSelect={() => setConversionOpen("vector-to-geoparquet")}
-              >
-                {t("toolbar.conversion.vectorToGeoparquet")}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() => setConversionOpen("vector-to-flatgeobuf")}
-              >
-                {t("toolbar.conversion.vectorToFlatgeobuf")}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() => setConversionOpen("vector-to-shapefile")}
-              >
-                {t("toolbar.conversion.vectorToShapefile")}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() => setConversionOpen("vector-to-geopackage")}
-              >
-                {t("toolbar.conversion.vectorToGeopackage")}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() => setConversionOpen("csv-to-geoparquet")}
-              >
-                {t("toolbar.conversion.csvToGeoparquet")}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() => setConversionOpen("vector-to-pmtiles")}
-              >
-                {t("toolbar.conversion.vectorToPmtiles")}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() => setConversionOpen("raster-to-cog")}
-              >
-                {t("toolbar.conversion.rasterToCog")}
-              </DropdownMenuItem>
-            </DropdownMenuSubContent>
-          </DropdownMenuSub>
-          <DropdownMenuSub>
-            <DropdownMenuSubTrigger>
-              {t("toolbar.item.vector")}
-            </DropdownMenuSubTrigger>
-            <DropdownMenuSubContent>
-              <DropdownMenuLabel className="text-xs text-muted-foreground">
-                {t("toolbar.item.subGroupGeometry")}
-              </DropdownMenuLabel>
-              <DropdownMenuItem onSelect={() => setVectorToolOpen("buffer")}>
-                {t("toolbar.vectorTool.buffer")}
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => setVectorToolOpen("centroids")}>
-                {t("toolbar.vectorTool.centroids")}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() => setVectorToolOpen("convex-hull")}
-              >
-                {t("toolbar.vectorTool.convexHull")}
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => setVectorToolOpen("dissolve")}>
-                {t("toolbar.vectorTool.dissolve")}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() => setVectorToolOpen("bounding-box")}
-              >
-                {t("toolbar.vectorTool.boundingBox")}
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => setVectorToolOpen("simplify")}>
-                {t("toolbar.vectorTool.simplify")}
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => setVectorToolOpen("reproject")}>
-                {t("toolbar.vectorTool.reproject")}
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => setVectorToolOpen("explode")}>
-                {t("toolbar.vectorTool.explode")}
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => setVectorToolOpen("aggregate")}>
-                {t("toolbar.vectorTool.aggregate")}
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => setVectorToolOpen("smooth")}>
-                {t("toolbar.vectorTool.smooth")}
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => setVectorToolOpen("grid")}>
-                {t("toolbar.vectorTool.grid")}
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => setVectorToolOpen("voronoi")}>
-                {t("toolbar.vectorTool.voronoi")}
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuLabel className="text-xs text-muted-foreground">
-                {t("toolbar.item.subGroupOverlay")}
-              </DropdownMenuLabel>
-              <DropdownMenuItem onSelect={() => setVectorToolOpen("clip")}>
-                {t("toolbar.vectorTool.clip")}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() => setVectorToolOpen("intersection")}
-              >
-                {t("toolbar.vectorTool.intersection")}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() => setVectorToolOpen("difference")}
-              >
-                {t("toolbar.vectorTool.difference")}
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => setVectorToolOpen("union")}>
-                {t("toolbar.vectorTool.union")}
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuLabel className="text-xs text-muted-foreground">
-                {t("toolbar.item.subGroupJoin")}
-              </DropdownMenuLabel>
-              <DropdownMenuItem
-                onSelect={() => setVectorToolOpen("spatial-join")}
-              >
-                {t("toolbar.vectorTool.spatialJoin")}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() => setVectorToolOpen("attribute-join")}
-              >
-                {t("toolbar.vectorTool.attributeJoin")}
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuLabel className="text-xs text-muted-foreground">
-                {t("toolbar.item.subGroupSelect")}
-              </DropdownMenuLabel>
-              <DropdownMenuItem
-                onSelect={() => setVectorToolOpen("select-by-value")}
-              >
-                {t("toolbar.vectorTool.selectByValue")}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() => setVectorToolOpen("select-by-location")}
-              >
-                {t("toolbar.vectorTool.selectByLocation")}
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuLabel className="text-xs text-muted-foreground">
-                {t("toolbar.item.subGroupH3")}
-              </DropdownMenuLabel>
-              <DropdownMenuItem onSelect={() => setVectorToolOpen("h3-grid")}>
-                {t("toolbar.vectorTool.h3Grid")}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() => setVectorToolOpen("h3-bin-points")}
-              >
-                {t("toolbar.vectorTool.h3BinPoints")}
-              </DropdownMenuItem>
-            </DropdownMenuSubContent>
-          </DropdownMenuSub>
-          <DropdownMenuSub>
-            <DropdownMenuSubTrigger>
-              {t("toolbar.item.network")}
-            </DropdownMenuSubTrigger>
-            <DropdownMenuSubContent>
-              <DropdownMenuItem
-                onSelect={() => openNetworkTool("isochrone")}
-              >
-                {t("toolbar.networkTool.isochrone")}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() => openNetworkTool("od-matrix")}
-              >
-                {t("toolbar.networkTool.odMatrix")}
-              </DropdownMenuItem>
-            </DropdownMenuSubContent>
-          </DropdownMenuSub>
-          <DropdownMenuSub>
-            <DropdownMenuSubTrigger>
-              {t("toolbar.item.statistics")}
-            </DropdownMenuSubTrigger>
-            <DropdownMenuSubContent>
-              <DropdownMenuItem
-                onSelect={() => setStatisticsToolOpen("global-morans-i")}
-              >
-                {t("toolbar.statisticsTool.globalMoransI")}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() => setStatisticsToolOpen("local-morans-i")}
-              >
-                {t("toolbar.statisticsTool.localMoransI")}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() => setStatisticsToolOpen("getis-ord-gi")}
-              >
-                {t("toolbar.statisticsTool.getisOrd")}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() =>
-                  setStatisticsToolOpen("average-nearest-neighbor")
-                }
-              >
-                {t("toolbar.statisticsTool.averageNearestNeighbor")}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() => setStatisticsToolOpen("kernel-density")}
-              >
-                {t("toolbar.statisticsTool.kernelDensity")}
-              </DropdownMenuItem>
-            </DropdownMenuSubContent>
-          </DropdownMenuSub>
-          <DropdownMenuSub>
-            <DropdownMenuSubTrigger>
-              {t("toolbar.item.raster")}
-            </DropdownMenuSubTrigger>
-            <DropdownMenuSubContent>
-              <DropdownMenuLabel className="text-xs text-muted-foreground">
-                {t("toolbar.item.subGroupTerrain")}
-              </DropdownMenuLabel>
-              <DropdownMenuItem onSelect={() => setRasterToolOpen("hillshade")}>
-                {t("toolbar.rasterTool.hillshade")}
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => setRasterToolOpen("slope")}>
-                {t("toolbar.rasterTool.slope")}
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => setRasterToolOpen("aspect")}>
-                {t("toolbar.rasterTool.aspect")}
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuLabel className="text-xs text-muted-foreground">
-                {t("toolbar.item.subGroupReproject")}
-              </DropdownMenuLabel>
-              <DropdownMenuItem onSelect={() => setRasterToolOpen("reproject")}>
-                {t("toolbar.rasterTool.reproject")}
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => setRasterToolOpen("resample")}>
-                {t("toolbar.rasterTool.resample")}
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuLabel className="text-xs text-muted-foreground">
-                {t("toolbar.item.subGroupClip")}
-              </DropdownMenuLabel>
-              <DropdownMenuItem
-                onSelect={() => setRasterToolOpen("clip-extent")}
-              >
-                {t("toolbar.rasterTool.clipExtent")}
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => setRasterToolOpen("clip-mask")}>
-                {t("toolbar.rasterTool.clipMask")}
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuLabel className="text-xs text-muted-foreground">
-                {t("toolbar.item.subGroupRasterToVector")}
-              </DropdownMenuLabel>
-              <DropdownMenuItem
-                onSelect={() => setRasterToolOpen("polygonize")}
-              >
-                {t("toolbar.rasterTool.polygonize")}
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => setRasterToolOpen("contour")}>
-                {t("toolbar.rasterTool.contour")}
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuLabel className="text-xs text-muted-foreground">
-                {t("toolbar.item.subGroupVectorToRaster")}
-              </DropdownMenuLabel>
-              <DropdownMenuItem
-                onSelect={() => setRasterToolOpen("interpolate")}
-              >
-                {t("toolbar.rasterTool.interpolate")}
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuLabel className="text-xs text-muted-foreground">
-                {t("toolbar.item.subGroupAnalysis")}
-              </DropdownMenuLabel>
-              <DropdownMenuItem onSelect={() => setRasterToolOpen("zonal")}>
-                {t("toolbar.rasterTool.zonal")}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() => setRasterToolOpen("raster-calc")}
-              >
-                {t("toolbar.rasterTool.rasterCalc")}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() => setRasterToolOpen("reclassify")}
-              >
-                {t("toolbar.rasterTool.reclassify")}
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => setRasterToolOpen("mosaic")}>
-                {t("toolbar.rasterTool.mosaic")}
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => setRasterToolOpen("focal")}>
-                {t("toolbar.rasterTool.focal")}
-              </DropdownMenuItem>
-            </DropdownMenuSubContent>
-          </DropdownMenuSub>
-          <DropdownMenuItem onSelect={() => setSegmentationOpen(true)}>
-            {t("toolbar.command.segmentation")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleOpenPlanetaryComputerPanel}>
-            {t("toolbar.command.planetaryComputer")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleToggleEarthEnginePanel}>
-            {t("toolbar.command.earthEngine")}
-            {earthEnginePanelVisible ? " ✓" : ""}
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            className={toolbarButtonClass}
-            variant="ghost"
-            size={toolbarButtonSize}
-            aria-label={t("toolbar.menu.controls")}
-          >
-            <SlidersHorizontal className={toolbarIconClassName} />
-            {renderToolbarLabel(t("toolbar.menu.controls"))}
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start">
-          <DropdownMenuLabel>{t("toolbar.item.mapControls")}</DropdownMenuLabel>
-          <DropdownMenuSeparator />
-          {MAP_CONTROL_ITEMS.map((control) => (
-            <DropdownMenuItem
-              key={control.id}
-              onClick={() => toggleMapControl(control.id)}
-            >
-              {t(control.labelKey)}
-              {controlsVisible[control.id] ? " ✓" : ""}
-            </DropdownMenuItem>
-          ))}
-          <DropdownMenuItem onClick={() => toggle(EFFECTS_PLUGIN_ID, appApi)}>
-            {t("toolbar.item.atmosphereEffects")}
-            {isActive(EFFECTS_PLUGIN_ID) ? " ✓" : ""}
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            title={t("toolbar.item.directionsTooltip")}
-            onClick={handleToggleDirections}
-          >
-            {t("toolbar.item.directions")}
-            {isActive(DIRECTIONS_PLUGIN_ID) ? " ✓" : ""}
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            title={t("toolbar.item.reverseGeocodeTooltip")}
-            onClick={handleToggleReverseGeocode}
-          >
-            {t("toolbar.item.reverseGeocode")}
-            {isActive(REVERSE_GEOCODE_PLUGIN_ID) ? " ✓" : ""}
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onSelect={handleToggleSearchPlacesPanel}>
-            {t("toolbar.item.search")}
-            {searchPlacesVisible ? " ✓" : ""}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleToggleColorbarPanel}>
-            {t("toolbar.item.colorbar")}
-            {colorbarPanelVisible ? " ✓" : ""}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleToggleLegendPanel}>
-            {t("toolbar.item.legend")}
-            {legendPanelVisible ? " ✓" : ""}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleToggleHtmlPanel}>
-            {t("toolbar.item.html")}
-            {htmlPanelVisible ? " ✓" : ""}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleToggleMeasurePanel}>
-            {t("toolbar.item.measure")}
-            {measurePanelVisible ? " ✓" : ""}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleToggleBookmarkPanel}>
-            {t("toolbar.item.bookmark")}
-            {bookmarkPanelVisible ? " ✓" : ""}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleToggleMinimapPanel}>
-            {t("toolbar.item.minimap")}
-            {minimapPanelVisible ? " ✓" : ""}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={handleToggleViewStatePanel}>
-            {t("toolbar.item.viewState")}
-            {viewStatePanelVisible ? " ✓" : ""}
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            className={toolbarButtonClass}
-            variant="ghost"
-            size={toolbarButtonSize}
-            aria-label={t("toolbar.menu.plugins")}
-          >
-            <Puzzle className={toolbarIconClassName} />
-            {renderToolbarLabel(t("toolbar.menu.plugins"))}
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start">
-          <DropdownMenuLabel>{t("toolbar.item.activatePlugin")}</DropdownMenuLabel>
-          <DropdownMenuSeparator />
-          {(() => {
-            const renderPluginMenuItem = (p: (typeof plugins)[number]) => {
-              const pluginPosition = getMapControlPosition(p.id);
-              if (!pluginPosition) {
-                return (
-                  <DropdownMenuItem
-                    key={p.id}
-                    onClick={() => toggle(p.id, appApi)}
-                  >
-                    {p.name}
-                    {isActive(p.id) ? " ✓" : ""}
-                  </DropdownMenuItem>
-                );
-              }
-
-              return (
-                <DropdownMenuSub key={p.id}>
-                  <DropdownMenuSubTrigger>
-                    {p.name}
-                    {isActive(p.id) ? " ✓" : ""}
-                  </DropdownMenuSubTrigger>
-                  <DropdownMenuSubContent>
-                    <DropdownMenuItem onClick={() => toggle(p.id, appApi)}>
-                      {isActive(p.id)
-                        ? t("toolbar.item.deactivate")
-                        : t("toolbar.item.activate")}
-                    </DropdownMenuItem>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuLabel>
-                      {t("toolbar.item.position")}
-                    </DropdownMenuLabel>
-                    <DropdownMenuRadioGroup
-                      value={pluginPosition}
-                      onValueChange={(position: string) =>
-                        setMapControlPosition(
-                          p.id,
-                          appApi,
-                          position as GeoLibreMapControlPosition,
-                        )
-                      }
-                    >
-                      {PLUGIN_POSITION_ITEMS.map((position) => (
-                        <DropdownMenuRadioItem
-                          key={position.value}
-                          value={position.value}
-                          onSelect={(event: Event) => event.preventDefault()}
-                        >
-                          {t(position.labelKey)}
-                        </DropdownMenuRadioItem>
-                      ))}
-                    </DropdownMenuRadioGroup>
-                  </DropdownMenuSubContent>
-                </DropdownMenuSub>
-              );
-            };
-
-            const webServicePlugins = plugins.filter((p) =>
-              WEB_SERVICE_PLUGIN_ID_SET.has(p.id),
-            );
-            // The web service plugins render as one grouped submenu, placed
-            // where the first of them appears in registration order (just
-            // above Esri Wayback).
-            let webServicesRendered = false;
-            return plugins.map((p) => {
-              // Atmosphere Effects, Directions, and Reverse Geocode are toggled
-              // from the Controls menu instead, so they are omitted here to
-              // avoid a duplicate toggle. The deck.gl viz overlay is an internal
-              // renderer driven by the Add Data → "Deck.gl Layer" dialog, not a
-              // user-facing toggle, so it is hidden here too.
-              if (
-                p.id === EFFECTS_PLUGIN_ID ||
-                p.id === DIRECTIONS_PLUGIN_ID ||
-                p.id === REVERSE_GEOCODE_PLUGIN_ID ||
-                p.id === DECK_VIZ_PLUGIN_ID
-              ) {
-                return null;
-              }
-              if (!WEB_SERVICE_PLUGIN_ID_SET.has(p.id)) {
-                return renderPluginMenuItem(p);
-              }
-              if (webServicesRendered) return null;
-              webServicesRendered = true;
-              return (
-                <DropdownMenuSub key="web-services">
-                  <DropdownMenuSubTrigger>
-                    {t("toolbar.item.webServices")}
-                    {webServicePlugins.some((plugin) => isActive(plugin.id))
-                      ? " ✓"
-                      : ""}
-                  </DropdownMenuSubTrigger>
-                  <DropdownMenuSubContent>
-                    {webServicePlugins.map(renderPluginMenuItem)}
-                  </DropdownMenuSubContent>
-                </DropdownMenuSub>
-              );
-            });
-          })()}
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <AddDataMenu
+        chrome={chrome}
+        addLayer={addLayer}
+        osmPbfBusy={osmPbf.busy}
+        onSetAddDataKind={setAddDataKind}
+        onAddGltfModel={() => {
+          setAddDataDeckVizKind("scenegraph");
+          setAddDataKind("deckgl-viz");
+        }}
+        onOpenOsmPbfDialog={() => osmPbf.setDialogOpen(true)}
+      />
+      <ProcessingMenu
+        chrome={chrome}
+        earthEnginePanel={panels.earthEngine}
+        onOpenNetworkTool={consent.openNetworkTool}
+        onOpenPlanetaryComputer={handleOpenPlanetaryComputer}
+      />
+      <ControlsMenu
+        chrome={chrome}
+        controlsVisible={controlsVisible}
+        panels={panels}
+        effectsActive={isActive(EFFECTS_PLUGIN_ID)}
+        directionsActive={isActive(DIRECTIONS_PLUGIN_ID)}
+        reverseGeocodeActive={isActive(REVERSE_GEOCODE_PLUGIN_ID)}
+        onToggleMapControl={toggleMapControl}
+        onToggleEffects={() => toggle(EFFECTS_PLUGIN_ID, appApi)}
+        onToggleDirections={consent.handleToggleDirections}
+        onToggleReverseGeocode={consent.handleToggleReverseGeocode}
+      />
+      <PluginsMenu
+        chrome={chrome}
+        appApi={appApi}
+        plugins={plugins}
+        isActive={isActive}
+        toggle={toggle}
+        getMapControlPosition={getMapControlPosition}
+        setMapControlPosition={setMapControlPosition}
+      />
       <SettingsDialog
         buttonClassName={toolbarButtonClass}
         buttonSize={toolbarButtonSize}
@@ -2399,7 +793,8 @@ export function TopToolbar({
         onOpenChange={setShareDialogOpen}
         currentTitle={projectName}
         getProject={(title) => {
-          const { content, defaultProjectName } = buildCurrentProject(title);
+          const { content, defaultProjectName } =
+            projectFiles.buildCurrentProject(title);
           // Strip path separators, control chars, and other characters that are
           // illegal in filenames so the server gets a predictable name.
           const safeName = defaultProjectName.replace(
@@ -2419,60 +814,18 @@ export function TopToolbar({
           api={collaboration}
         />
       )}
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            className={toolbarButtonClass}
-            variant="ghost"
-            size={toolbarButtonSize}
-            aria-label={t("toolbar.menu.help")}
-          >
-            <CircleHelp className={toolbarIconClassName} />
-            {renderToolbarLabel(t("toolbar.menu.help"))}
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start">
-          <DropdownMenuLabel>{t("toolbar.menu.help")}</DropdownMenuLabel>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onSelect={() => setCommandPaletteOpen(true)}>
-            <Search className="mr-2 h-3.5 w-3.5" />
-            {t("toolbar.item.commandPalette")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setShortcutsOpen(true)}>
-            <Keyboard className="mr-2 h-3.5 w-3.5" />
-            {t("toolbar.command.keyboardShortcuts")}
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onSelect={onOpenDiagnostics}>
-            <Bug className="mr-2 h-3.5 w-3.5" />
-            {t("toolbar.command.diagnostics")}
-            {diagnosticsErrorCount > 0 ? (
-              <span className="ml-2 rounded bg-destructive px-1.5 py-0.5 text-[10px] leading-none text-destructive-foreground">
-                {diagnosticsErrorCount}
-              </span>
-            ) : null}
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            onSelect={() => void openExternalLink(FEEDBACK_URL)}
-          >
-            <MessageSquare className="mr-2 h-3.5 w-3.5" />
-            {t("toolbar.command.giveFeedback")}
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            onSelect={() => {
-              setAboutOpen(true);
-              setCheckForUpdatesRequest((value) => value + 1);
-            }}
-          >
-            <RefreshCw className="mr-2 h-3.5 w-3.5" />
-            {t("toolbar.command.checkForUpdates")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setAboutOpen(true)}>
-            <Info className="mr-2 h-3.5 w-3.5" />
-            {t("toolbar.command.about")}
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <HelpMenu
+        chrome={chrome}
+        diagnosticsErrorCount={diagnosticsErrorCount}
+        onOpenCommandPalette={() => setCommandPaletteOpen(true)}
+        onOpenShortcuts={() => setShortcutsOpen(true)}
+        onOpenDiagnostics={onOpenDiagnostics}
+        onCheckForUpdates={() => {
+          setAboutOpen(true);
+          setCheckForUpdatesRequest((value) => value + 1);
+        }}
+        onAbout={() => setAboutOpen(true)}
+      />
       <AddDataDialog
         kind={addDataKind}
         mapControllerRef={mapControllerRef}
@@ -2489,300 +842,9 @@ export function TopToolbar({
         appApi={appApi}
         onOpenChange={setNetcdfDialogOpen}
       />
-      <Dialog
-        open={projectUrlDialogOpen}
-        onOpenChange={(open: boolean) => {
-          setProjectUrlDialogOpen(open);
-          if (!open) {
-            projectUrlAbortRef.current?.abort();
-            projectUrlAbortRef.current = null;
-            setProjectUrl("");
-            setProjectUrlError(null);
-            setProjectUrlLoading(false);
-          }
-        }}
-      >
-        <DialogContent className="max-w-lg">
-          <DialogHeader>
-            <DialogTitle>{t("toolbar.item.openProjectFromUrl")}</DialogTitle>
-            <DialogDescription>
-              {t("toolbar.item.openProjectFromUrlDesc")}
-            </DialogDescription>
-          </DialogHeader>
-          <form className="space-y-4" onSubmit={handleOpenFromUrl}>
-            <div className="space-y-2">
-              <Label htmlFor="project-url">{t("toolbar.item.projectUrl")}</Label>
-              <Input
-                id="project-url"
-                placeholder="https://example.com/project.geolibre.json"
-                value={projectUrl}
-                onChange={(event) => {
-                  setProjectUrl(event.target.value);
-                  setProjectUrlError(null);
-                }}
-              />
-              {projectUrlError ? (
-                <p className="text-xs text-destructive">{projectUrlError}</p>
-              ) : null}
-            </div>
-            <div className="flex justify-end gap-2">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => setProjectUrlDialogOpen(false)}
-              >
-                {t("common.cancel")}
-              </Button>
-              <Button type="submit" disabled={projectUrlLoading}>
-                {projectUrlLoading
-                  ? t("toolbar.item.opening")
-                  : t("toolbar.item.open")}
-              </Button>
-            </div>
-          </form>
-        </DialogContent>
-      </Dialog>
-      <Dialog
-        open={actionError !== null}
-        onOpenChange={(open: boolean) => {
-          if (!open) setActionError(null);
-        }}
-      >
-        <DialogContent className="max-w-lg">
-          <DialogHeader>
-            <DialogTitle>{t("toolbar.item.somethingWentWrong")}</DialogTitle>
-            <DialogDescription>{actionError}</DialogDescription>
-          </DialogHeader>
-          <div className="flex justify-end">
-            <Button onClick={() => setActionError(null)}>
-              {t("toolbar.item.dismiss")}
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
-      <Dialog
-        open={envStripPrompt !== null}
-        onOpenChange={(open: boolean) => {
-          if (!open) resolveEnvStripPrompt("cancel");
-        }}
-      >
-        <DialogContent className="max-w-lg">
-          <DialogHeader>
-            <DialogTitle>{t("settings.env.stripPromptTitle")}</DialogTitle>
-            <DialogDescription>
-              {t("settings.env.stripPromptDesc", {
-                count: envStripPrompt?.count ?? 0,
-              })}
-            </DialogDescription>
-          </DialogHeader>
-          <div className="flex justify-end gap-2">
-            <Button
-              variant="outline"
-              onClick={() => resolveEnvStripPrompt("cancel")}
-            >
-              {t("common.cancel")}
-            </Button>
-            <Button
-              variant="outline"
-              onClick={() => resolveEnvStripPrompt("keep")}
-            >
-              {t("settings.env.keepButton")}
-            </Button>
-            <Button onClick={() => resolveEnvStripPrompt("strip")}>
-              {t("settings.env.stripButton")}
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
-      <Dialog
-        open={directionsNoticeOpen}
-        onOpenChange={setDirectionsNoticeOpen}
-      >
-        <DialogContent className="max-w-lg">
-          <DialogHeader>
-            <DialogTitle>
-              {t("toolbar.item.directionsNoticeTitle")}
-            </DialogTitle>
-            <DialogDescription>
-              {t("toolbar.item.directionsNoticeDesc")}
-            </DialogDescription>
-          </DialogHeader>
-          <div className="flex justify-end gap-2">
-            <Button
-              variant="outline"
-              onClick={() => setDirectionsNoticeOpen(false)}
-            >
-              {t("common.cancel")}
-            </Button>
-            <Button onClick={confirmEnableDirections}>
-              {t("toolbar.item.continue")}
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
-      <Dialog
-        open={reverseGeocodeNoticeOpen}
-        onOpenChange={setReverseGeocodeNoticeOpen}
-      >
-        <DialogContent className="max-w-lg">
-          <DialogHeader>
-            <DialogTitle>
-              {t("toolbar.item.reverseGeocodeNoticeTitle")}
-            </DialogTitle>
-            <DialogDescription>
-              {t("toolbar.item.reverseGeocodeNoticeDesc")}
-            </DialogDescription>
-          </DialogHeader>
-          <div className="flex justify-end gap-2">
-            <Button
-              variant="outline"
-              onClick={() => setReverseGeocodeNoticeOpen(false)}
-            >
-              {t("common.cancel")}
-            </Button>
-            <Button onClick={confirmEnableReverseGeocode}>
-              {t("toolbar.item.continue")}
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
-      <Dialog
-        open={routingNoticeOpen}
-        onOpenChange={(open: boolean) => {
-          setRoutingNoticeOpen(open);
-          if (!open) setPendingNetworkTool(null);
-        }}
-      >
-        <DialogContent className="max-w-lg">
-          <DialogHeader>
-            <DialogTitle>
-              {t("toolbar.item.networkNoticeTitle")}
-            </DialogTitle>
-            <DialogDescription>
-              {t("toolbar.item.networkNoticeDesc")}
-            </DialogDescription>
-          </DialogHeader>
-          <div className="flex justify-end gap-2">
-            <Button
-              variant="outline"
-              onClick={() => {
-                setRoutingNoticeOpen(false);
-                setPendingNetworkTool(null);
-              }}
-            >
-              {t("common.cancel")}
-            </Button>
-            <Button onClick={confirmOpenNetworkTool}>
-              {t("toolbar.item.continue")}
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
-      <Dialog
-        open={osmPbfConfirm !== null}
-        onOpenChange={(open: boolean) => {
-          if (!open) setOsmPbfConfirm(null);
-        }}
-      >
-        <DialogContent className="max-w-lg">
-          <DialogHeader>
-            <DialogTitle>{t("toolbar.item.largeOsmPbfTitle")}</DialogTitle>
-            <DialogDescription>
-              {t("toolbar.item.largeOsmPbfDesc", {
-                sizeMb: osmPbfConfirm?.sizeMb,
-              })}
-            </DialogDescription>
-          </DialogHeader>
-          <div className="flex justify-end gap-2">
-            <Button variant="outline" onClick={() => setOsmPbfConfirm(null)}>
-              {t("common.cancel")}
-            </Button>
-            <Button
-              onClick={() => {
-                const pending = osmPbfConfirm;
-                setOsmPbfConfirm(null);
-                if (pending) {
-                  void runOsmPbf(
-                    pending.data,
-                    pending.baseName,
-                    pending.sourcePath,
-                  );
-                }
-              }}
-            >
-              {t("toolbar.item.continue")}
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
-      <Dialog
-        open={osmPbfDialogOpen}
-        onOpenChange={(open: boolean) => setOsmPbfDialogOpen(open)}
-      >
-        <DialogContent className="max-w-lg">
-          <DialogHeader>
-            <DialogTitle>{t("toolbar.item.addOsmPbfLayerTitle")}</DialogTitle>
-            <DialogDescription>
-              {t("toolbar.item.addOsmPbfLayerDesc")}
-            </DialogDescription>
-          </DialogHeader>
-          <form
-            className="space-y-3"
-            onSubmit={(event: FormEvent) => {
-              event.preventDefault();
-              void handleLoadOsmPbfUrl();
-            }}
-          >
-            <div className="space-y-1.5">
-              <Label htmlFor="osm-pbf-url">{t("toolbar.item.urlLabel")}</Label>
-              <Input
-                id="osm-pbf-url"
-                type="url"
-                placeholder={DEFAULT_OSM_PBF_URL}
-                value={osmPbfUrl}
-                onChange={(e) => setOsmPbfUrl(e.target.value)}
-              />
-              <p className="text-xs text-muted-foreground">
-                {t("toolbar.item.osmPbfUrlHint")}
-              </p>
-            </div>
-            <div className="flex items-center justify-between gap-2">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => void handleChooseOsmPbfFile()}
-              >
-                {t("toolbar.item.chooseLocalFile")}
-              </Button>
-              <Button type="submit" disabled={!osmPbfUrl.trim()}>
-                {t("toolbar.item.loadFromUrl")}
-              </Button>
-            </div>
-          </form>
-        </DialogContent>
-      </Dialog>
-      <Dialog
-        open={osmPbfLoading}
-        onOpenChange={(open: boolean) => {
-          // Dismissing (Escape/backdrop) cancels: abort the worker parse and
-          // drop a pending fetch result so no layers are added after dismissal.
-          if (!open) cancelOsmPbf();
-        }}
-      >
-        <DialogContent className="max-w-sm">
-          <DialogHeader>
-            <DialogTitle>{t("toolbar.item.loadingOsmPbf")}</DialogTitle>
-            <DialogDescription>
-              {t("toolbar.item.loadingOsmPbfDesc")}
-            </DialogDescription>
-          </DialogHeader>
-          <div className="flex justify-end">
-            <Button variant="outline" onClick={cancelOsmPbf}>
-              {t("common.cancel")}
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
+      <ProjectFileDialogs projectFiles={projectFiles} />
+      <ConsentNoticeDialogs consent={consent} />
+      <OsmPbfDialogs osmPbf={osmPbf} />
       <AboutDialog
         checkForUpdatesRequest={checkForUpdatesRequest}
         open={aboutOpen}

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -55,7 +55,7 @@ import {
   Workflow,
   Wrench,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   createAppAPI,
@@ -163,7 +163,10 @@ export function TopToolbar({
     toggle,
     setMapControlPosition,
   } = usePluginRegistry();
-  const appApi = createAppAPI(mapControllerRef);
+  // mapControllerRef is a stable ref object and createAppAPI dereferences
+  // `.current` lazily, so memoizing on the ref keeps a single appApi identity
+  // across renders without going stale.
+  const appApi = useMemo(() => createAppAPI(mapControllerRef), [mapControllerRef]);
 
   const panels = useToolbarPanels(appApi);
   const projectFiles = useProjectFileActions(mapControllerRef);

--- a/apps/geolibre-desktop/src/components/layout/toolbar/AddDataMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/AddDataMenu.tsx
@@ -1,0 +1,148 @@
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@geolibre/ui";
+import { Database } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { AddDataKind } from "../AddDataDialog";
+import type { AddLayerHandlers, ToolbarChrome } from "./constants";
+
+interface AddDataMenuProps {
+  chrome: ToolbarChrome;
+  addLayer: AddLayerHandlers;
+  osmPbfBusy: boolean;
+  onSetAddDataKind: (kind: AddDataKind) => void;
+  onAddGltfModel: () => void;
+  onOpenOsmPbfDialog: () => void;
+}
+
+/** The Add Data menu: files, web services, cloud formats, 3D layers, databases. */
+export function AddDataMenu({
+  chrome,
+  addLayer,
+  osmPbfBusy,
+  onSetAddDataKind,
+  onAddGltfModel,
+  onOpenOsmPbfDialog,
+}: AddDataMenuProps) {
+  const { t } = useTranslation();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          className={chrome.buttonClass}
+          variant="ghost"
+          size={chrome.buttonSize}
+          aria-label={t("toolbar.menu.addData")}
+        >
+          <Database className={chrome.iconClassName} />
+          {chrome.renderLabel(t("toolbar.menu.addData"))}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-64">
+        <DropdownMenuLabel>{t("toolbar.menu.addData")}</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel className="text-xs text-muted-foreground">
+          {t("toolbar.item.sectionFiles")}
+        </DropdownMenuLabel>
+        <DropdownMenuItem onSelect={addLayer.vector}>
+          {t("toolbar.item.vectorLayer")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={addLayer.raster}>
+          {t("toolbar.item.rasterLayer")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => onSetAddDataKind("delimited-text")}>
+          {t("toolbar.layerType.delimitedText")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => onSetAddDataKind("gpx")}>
+          {t("toolbar.layerType.gpx")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => onSetAddDataKind("mbtiles")}>
+          {t("toolbar.layerType.mbtiles")}
+        </DropdownMenuItem>
+        <DropdownMenuItem disabled={osmPbfBusy} onSelect={onOpenOsmPbfDialog}>
+          {t("toolbar.item.osmPbfLayer")}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel className="text-xs text-muted-foreground">
+          {t("toolbar.item.sectionWebServices")}
+        </DropdownMenuLabel>
+        <DropdownMenuItem onSelect={() => onSetAddDataKind("xyz")}>
+          {t("toolbar.layerType.xyz")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => onSetAddDataKind("wms")}>
+          {t("toolbar.layerType.wms")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => onSetAddDataKind("wfs")}>
+          {t("toolbar.layerType.wfs")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => onSetAddDataKind("wmts")}>
+          {t("toolbar.layerType.wmts")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => onSetAddDataKind("arcgis")}>
+          {t("toolbar.layerType.arcgis")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={addLayer.stac}>
+          {t("toolbar.item.stacLayer")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => onSetAddDataKind("video")}>
+          {t("toolbar.layerType.video")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => onSetAddDataKind("deckgl-viz")}>
+          {t("toolbar.layerType.deckglViz")}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel className="text-xs text-muted-foreground">
+          {t("toolbar.item.sectionCloudFormats")}
+        </DropdownMenuLabel>
+        <DropdownMenuItem onSelect={addLayer.vector}>
+          {t("toolbar.item.geoparquetLayer")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={addLayer.flatGeobuf}>
+          {t("toolbar.item.flatgeobufLayer")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={addLayer.pmtiles}>
+          {t("toolbar.item.pmtilesLayer")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={addLayer.zarr}>
+          {t("toolbar.item.zarrLayer")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={addLayer.netcdf}>
+          {t("toolbar.item.netcdfHdf")}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel className="text-xs text-muted-foreground">
+          {t("toolbar.item.section3dLayers")}
+        </DropdownMenuLabel>
+        <DropdownMenuItem onSelect={addLayer.lidar}>
+          {t("toolbar.item.lidarLayer")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={addLayer.splatting}>
+          {t("toolbar.item.splattingLayer")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={addLayer.threeDTiles}>
+          {t("toolbar.item.threeDTilesLayer")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={onAddGltfModel}>
+          {t("toolbar.layerType.gltfModel")}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel className="text-xs text-muted-foreground">
+          {t("toolbar.item.sectionDatabases")}
+        </DropdownMenuLabel>
+        <DropdownMenuItem onSelect={addLayer.duckdb}>
+          {t("toolbar.item.duckdbLayer")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => onSetAddDataKind("postgres")}>
+          {t("toolbar.layerType.postgres")}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ConsentNoticeDialogs.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ConsentNoticeDialogs.tsx
@@ -75,8 +75,9 @@ export function ConsentNoticeDialogs({ consent }: ConsentNoticeDialogsProps) {
       <Dialog
         open={consent.routingNoticeOpen}
         onOpenChange={(open: boolean) => {
-          consent.setRoutingNoticeOpen(open);
-          if (!open) consent.setPendingNetworkTool(null);
+          // This dialog is opened programmatically (it has no trigger), so
+          // onOpenChange only ever fires to close it (Escape/overlay).
+          if (!open) consent.dismissRoutingNotice();
         }}
       >
         <DialogContent className="max-w-lg">
@@ -87,13 +88,7 @@ export function ConsentNoticeDialogs({ consent }: ConsentNoticeDialogsProps) {
             </DialogDescription>
           </DialogHeader>
           <div className="flex justify-end gap-2">
-            <Button
-              variant="outline"
-              onClick={() => {
-                consent.setRoutingNoticeOpen(false);
-                consent.setPendingNetworkTool(null);
-              }}
-            >
+            <Button variant="outline" onClick={consent.dismissRoutingNotice}>
               {t("common.cancel")}
             </Button>
             <Button onClick={consent.confirmOpenNetworkTool}>

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ConsentNoticeDialogs.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ConsentNoticeDialogs.tsx
@@ -1,0 +1,107 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@geolibre/ui";
+import { useTranslation } from "react-i18next";
+import type { useConsentGatedActions } from "../../../hooks/useConsentGatedActions";
+
+interface ConsentNoticeDialogsProps {
+  consent: ReturnType<typeof useConsentGatedActions>;
+}
+
+/**
+ * The one-time consent notices shown before enabling features that send user
+ * data to public third-party servers (Directions, reverse geocode, network).
+ */
+export function ConsentNoticeDialogs({ consent }: ConsentNoticeDialogsProps) {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <Dialog
+        open={consent.directionsNoticeOpen}
+        onOpenChange={consent.setDirectionsNoticeOpen}
+      >
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{t("toolbar.item.directionsNoticeTitle")}</DialogTitle>
+            <DialogDescription>
+              {t("toolbar.item.directionsNoticeDesc")}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="outline"
+              onClick={() => consent.setDirectionsNoticeOpen(false)}
+            >
+              {t("common.cancel")}
+            </Button>
+            <Button onClick={consent.confirmEnableDirections}>
+              {t("toolbar.item.continue")}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+      <Dialog
+        open={consent.reverseGeocodeNoticeOpen}
+        onOpenChange={consent.setReverseGeocodeNoticeOpen}
+      >
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>
+              {t("toolbar.item.reverseGeocodeNoticeTitle")}
+            </DialogTitle>
+            <DialogDescription>
+              {t("toolbar.item.reverseGeocodeNoticeDesc")}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="outline"
+              onClick={() => consent.setReverseGeocodeNoticeOpen(false)}
+            >
+              {t("common.cancel")}
+            </Button>
+            <Button onClick={consent.confirmEnableReverseGeocode}>
+              {t("toolbar.item.continue")}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+      <Dialog
+        open={consent.routingNoticeOpen}
+        onOpenChange={(open: boolean) => {
+          consent.setRoutingNoticeOpen(open);
+          if (!open) consent.setPendingNetworkTool(null);
+        }}
+      >
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{t("toolbar.item.networkNoticeTitle")}</DialogTitle>
+            <DialogDescription>
+              {t("toolbar.item.networkNoticeDesc")}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="outline"
+              onClick={() => {
+                consent.setRoutingNoticeOpen(false);
+                consent.setPendingNetworkTool(null);
+              }}
+            >
+              {t("common.cancel")}
+            </Button>
+            <Button onClick={consent.confirmOpenNetworkTool}>
+              {t("toolbar.item.continue")}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ControlsMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ControlsMenu.tsx
@@ -1,0 +1,126 @@
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@geolibre/ui";
+import { SlidersHorizontal } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { ToolbarPanels } from "../../../hooks/useToolbarPanels";
+import {
+  MAP_CONTROL_ITEMS,
+  type ToolbarChrome,
+  type ToolbarMapControl,
+} from "./constants";
+
+interface ControlsMenuProps {
+  chrome: ToolbarChrome;
+  controlsVisible: Record<ToolbarMapControl, boolean>;
+  panels: ToolbarPanels;
+  effectsActive: boolean;
+  directionsActive: boolean;
+  reverseGeocodeActive: boolean;
+  onToggleMapControl: (control: ToolbarMapControl) => void;
+  onToggleEffects: () => void;
+  onToggleDirections: () => void;
+  onToggleReverseGeocode: () => void;
+}
+
+/** The Controls menu: built-in map controls, atmosphere/routing toggles, and panels. */
+export function ControlsMenu({
+  chrome,
+  controlsVisible,
+  panels,
+  effectsActive,
+  directionsActive,
+  reverseGeocodeActive,
+  onToggleMapControl,
+  onToggleEffects,
+  onToggleDirections,
+  onToggleReverseGeocode,
+}: ControlsMenuProps) {
+  const { t } = useTranslation();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          className={chrome.buttonClass}
+          variant="ghost"
+          size={chrome.buttonSize}
+          aria-label={t("toolbar.menu.controls")}
+        >
+          <SlidersHorizontal className={chrome.iconClassName} />
+          {chrome.renderLabel(t("toolbar.menu.controls"))}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        <DropdownMenuLabel>{t("toolbar.item.mapControls")}</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {MAP_CONTROL_ITEMS.map((control) => (
+          <DropdownMenuItem
+            key={control.id}
+            onClick={() => onToggleMapControl(control.id)}
+          >
+            {t(control.labelKey)}
+            {controlsVisible[control.id] ? " ✓" : ""}
+          </DropdownMenuItem>
+        ))}
+        <DropdownMenuItem onClick={onToggleEffects}>
+          {t("toolbar.item.atmosphereEffects")}
+          {effectsActive ? " ✓" : ""}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          title={t("toolbar.item.directionsTooltip")}
+          onClick={onToggleDirections}
+        >
+          {t("toolbar.item.directions")}
+          {directionsActive ? " ✓" : ""}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          title={t("toolbar.item.reverseGeocodeTooltip")}
+          onClick={onToggleReverseGeocode}
+        >
+          {t("toolbar.item.reverseGeocode")}
+          {reverseGeocodeActive ? " ✓" : ""}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={panels.searchPlaces.toggle}>
+          {t("toolbar.item.search")}
+          {panels.searchPlaces.visible ? " ✓" : ""}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={panels.colorbar.toggle}>
+          {t("toolbar.item.colorbar")}
+          {panels.colorbar.visible ? " ✓" : ""}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={panels.legend.toggle}>
+          {t("toolbar.item.legend")}
+          {panels.legend.visible ? " ✓" : ""}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={panels.html.toggle}>
+          {t("toolbar.item.html")}
+          {panels.html.visible ? " ✓" : ""}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={panels.measure.toggle}>
+          {t("toolbar.item.measure")}
+          {panels.measure.visible ? " ✓" : ""}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={panels.bookmark.toggle}>
+          {t("toolbar.item.bookmark")}
+          {panels.bookmark.visible ? " ✓" : ""}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={panels.minimap.toggle}>
+          {t("toolbar.item.minimap")}
+          {panels.minimap.visible ? " ✓" : ""}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={panels.viewState.toggle}>
+          {t("toolbar.item.viewState")}
+          {panels.viewState.visible ? " ✓" : ""}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/toolbar/EditMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/EditMenu.tsx
@@ -1,0 +1,65 @@
+import { redo, undo, useAppStore } from "@geolibre/core";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@geolibre/ui";
+import { Pencil, Redo2, Undo2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { useStore } from "zustand";
+import type { ToolbarChrome } from "./constants";
+
+interface EditMenuProps {
+  chrome: ToolbarChrome;
+}
+
+/** The Edit menu: undo/redo backed by the store's temporal middleware. */
+export function EditMenu({ chrome }: EditMenuProps) {
+  const { t } = useTranslation();
+  const canUndo = useStore(
+    useAppStore.temporal,
+    (s) => s.pastStates.length > 0,
+  );
+  const canRedo = useStore(
+    useAppStore.temporal,
+    (s) => s.futureStates.length > 0,
+  );
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          className={chrome.secondaryButtonClass}
+          variant="ghost"
+          size={chrome.buttonSize}
+          aria-label={t("toolbar.menu.edit")}
+        >
+          <Pencil className={chrome.iconClassName} />
+          {chrome.renderLabel(t("toolbar.menu.edit"))}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-56">
+        <DropdownMenuLabel>{t("toolbar.menu.edit")}</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem disabled={!canUndo} onSelect={undo}>
+          <Undo2 className="mr-2 h-3.5 w-3.5" />
+          {t("toolbar.item.undo")}
+          <span className="ml-auto text-xs text-muted-foreground">
+            Ctrl/Cmd+Z
+          </span>
+        </DropdownMenuItem>
+        <DropdownMenuItem disabled={!canRedo} onSelect={redo}>
+          <Redo2 className="mr-2 h-3.5 w-3.5" />
+          {t("toolbar.item.redo")}
+          <span className="ml-auto text-xs text-muted-foreground">
+            Ctrl/Cmd+Shift+Z / Ctrl+Y
+          </span>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/toolbar/HelpMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/HelpMenu.tsx
@@ -1,0 +1,93 @@
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@geolibre/ui";
+import {
+  Bug,
+  CircleHelp,
+  Info,
+  Keyboard,
+  MessageSquare,
+  RefreshCw,
+  Search,
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { FEEDBACK_URL, openExternalLink, type ToolbarChrome } from "./constants";
+
+interface HelpMenuProps {
+  chrome: ToolbarChrome;
+  diagnosticsErrorCount: number;
+  onOpenCommandPalette: () => void;
+  onOpenShortcuts: () => void;
+  onOpenDiagnostics: () => void;
+  onCheckForUpdates: () => void;
+  onAbout: () => void;
+}
+
+/** The Help menu: command palette, shortcuts, diagnostics, feedback, updates, about. */
+export function HelpMenu({
+  chrome,
+  diagnosticsErrorCount,
+  onOpenCommandPalette,
+  onOpenShortcuts,
+  onOpenDiagnostics,
+  onCheckForUpdates,
+  onAbout,
+}: HelpMenuProps) {
+  const { t } = useTranslation();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          className={chrome.buttonClass}
+          variant="ghost"
+          size={chrome.buttonSize}
+          aria-label={t("toolbar.menu.help")}
+        >
+          <CircleHelp className={chrome.iconClassName} />
+          {chrome.renderLabel(t("toolbar.menu.help"))}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        <DropdownMenuLabel>{t("toolbar.menu.help")}</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={onOpenCommandPalette}>
+          <Search className="mr-2 h-3.5 w-3.5" />
+          {t("toolbar.item.commandPalette")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={onOpenShortcuts}>
+          <Keyboard className="mr-2 h-3.5 w-3.5" />
+          {t("toolbar.command.keyboardShortcuts")}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={onOpenDiagnostics}>
+          <Bug className="mr-2 h-3.5 w-3.5" />
+          {t("toolbar.command.diagnostics")}
+          {diagnosticsErrorCount > 0 ? (
+            <span className="ml-2 rounded bg-destructive px-1.5 py-0.5 text-[10px] leading-none text-destructive-foreground">
+              {diagnosticsErrorCount}
+            </span>
+          ) : null}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => void openExternalLink(FEEDBACK_URL)}>
+          <MessageSquare className="mr-2 h-3.5 w-3.5" />
+          {t("toolbar.command.giveFeedback")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={onCheckForUpdates}>
+          <RefreshCw className="mr-2 h-3.5 w-3.5" />
+          {t("toolbar.command.checkForUpdates")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={onAbout}>
+          <Info className="mr-2 h-3.5 w-3.5" />
+          {t("toolbar.command.about")}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/toolbar/OsmPbfDialogs.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/OsmPbfDialogs.tsx
@@ -1,0 +1,118 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+} from "@geolibre/ui";
+import type { FormEvent } from "react";
+import { useTranslation } from "react-i18next";
+import type { useOsmPbfLoader } from "../../../hooks/useOsmPbfLoader";
+import { DEFAULT_OSM_PBF_URL } from "./constants";
+
+interface OsmPbfDialogsProps {
+  osmPbf: ReturnType<typeof useOsmPbfLoader>;
+}
+
+/** The OSM PBF dialogs: the add dialog, the large-file confirm, and the loading indicator. */
+export function OsmPbfDialogs({ osmPbf }: OsmPbfDialogsProps) {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <Dialog
+        open={osmPbf.confirm !== null}
+        onOpenChange={(open: boolean) => {
+          if (!open) osmPbf.setConfirm(null);
+        }}
+      >
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{t("toolbar.item.largeOsmPbfTitle")}</DialogTitle>
+            <DialogDescription>
+              {t("toolbar.item.largeOsmPbfDesc", {
+                sizeMb: osmPbf.confirm?.sizeMb,
+              })}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" onClick={() => osmPbf.setConfirm(null)}>
+              {t("common.cancel")}
+            </Button>
+            <Button onClick={osmPbf.runConfirmed}>
+              {t("toolbar.item.continue")}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+      <Dialog open={osmPbf.dialogOpen} onOpenChange={osmPbf.setDialogOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{t("toolbar.item.addOsmPbfLayerTitle")}</DialogTitle>
+            <DialogDescription>
+              {t("toolbar.item.addOsmPbfLayerDesc")}
+            </DialogDescription>
+          </DialogHeader>
+          <form
+            className="space-y-3"
+            onSubmit={(event: FormEvent) => {
+              event.preventDefault();
+              void osmPbf.handleLoadUrl();
+            }}
+          >
+            <div className="space-y-1.5">
+              <Label htmlFor="osm-pbf-url">{t("toolbar.item.urlLabel")}</Label>
+              <Input
+                id="osm-pbf-url"
+                type="url"
+                placeholder={DEFAULT_OSM_PBF_URL}
+                value={osmPbf.url}
+                onChange={(e) => osmPbf.setUrl(e.target.value)}
+              />
+              <p className="text-xs text-muted-foreground">
+                {t("toolbar.item.osmPbfUrlHint")}
+              </p>
+            </div>
+            <div className="flex items-center justify-between gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => void osmPbf.handleChooseFile()}
+              >
+                {t("toolbar.item.chooseLocalFile")}
+              </Button>
+              <Button type="submit" disabled={!osmPbf.url.trim()}>
+                {t("toolbar.item.loadFromUrl")}
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+      <Dialog
+        open={osmPbf.loading}
+        onOpenChange={(open: boolean) => {
+          // Dismissing (Escape/backdrop) cancels: abort the worker parse and
+          // drop a pending fetch result so no layers are added after dismissal.
+          if (!open) osmPbf.cancel();
+        }}
+      >
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>{t("toolbar.item.loadingOsmPbf")}</DialogTitle>
+            <DialogDescription>
+              {t("toolbar.item.loadingOsmPbfDesc")}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex justify-end">
+            <Button variant="outline" onClick={osmPbf.cancel}>
+              {t("common.cancel")}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/toolbar/PluginsMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/PluginsMenu.tsx
@@ -1,0 +1,169 @@
+import {
+  DECK_VIZ_PLUGIN_ID,
+  DIRECTIONS_PLUGIN_ID,
+  type GeoLibreMapControlPosition,
+  REVERSE_GEOCODE_PLUGIN_ID,
+  EFFECTS_PLUGIN_ID,
+  WEB_SERVICE_PLUGIN_IDS,
+} from "@geolibre/plugins";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@geolibre/ui";
+import { Puzzle } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { usePluginRegistry } from "../../../hooks/usePlugins";
+import {
+  type AppApi,
+  PLUGIN_POSITION_ITEMS,
+  type ToolbarChrome,
+} from "./constants";
+
+type PluginRegistry = ReturnType<typeof usePluginRegistry>;
+type RegisteredPlugin = PluginRegistry["plugins"][number];
+
+// Plugins grouped under the "Web Services" submenu of the Plugins menu.
+const WEB_SERVICE_PLUGIN_ID_SET = new Set<string>(WEB_SERVICE_PLUGIN_IDS);
+
+interface PluginsMenuProps {
+  chrome: ToolbarChrome;
+  appApi: AppApi;
+  plugins: RegisteredPlugin[];
+  isActive: PluginRegistry["isActive"];
+  toggle: PluginRegistry["toggle"];
+  getMapControlPosition: PluginRegistry["getMapControlPosition"];
+  setMapControlPosition: PluginRegistry["setMapControlPosition"];
+}
+
+/** The Plugins menu: one toggle per registered plugin, with position submenus. */
+export function PluginsMenu({
+  chrome,
+  appApi,
+  plugins,
+  isActive,
+  toggle,
+  getMapControlPosition,
+  setMapControlPosition,
+}: PluginsMenuProps) {
+  const { t } = useTranslation();
+
+  const renderPluginMenuItem = (p: RegisteredPlugin) => {
+    const pluginPosition = getMapControlPosition(p.id);
+    if (!pluginPosition) {
+      return (
+        <DropdownMenuItem key={p.id} onClick={() => toggle(p.id, appApi)}>
+          {p.name}
+          {isActive(p.id) ? " ✓" : ""}
+        </DropdownMenuItem>
+      );
+    }
+
+    return (
+      <DropdownMenuSub key={p.id}>
+        <DropdownMenuSubTrigger>
+          {p.name}
+          {isActive(p.id) ? " ✓" : ""}
+        </DropdownMenuSubTrigger>
+        <DropdownMenuSubContent>
+          <DropdownMenuItem onClick={() => toggle(p.id, appApi)}>
+            {isActive(p.id)
+              ? t("toolbar.item.deactivate")
+              : t("toolbar.item.activate")}
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuLabel>{t("toolbar.item.position")}</DropdownMenuLabel>
+          <DropdownMenuRadioGroup
+            value={pluginPosition}
+            onValueChange={(position: string) =>
+              setMapControlPosition(
+                p.id,
+                appApi,
+                position as GeoLibreMapControlPosition,
+              )
+            }
+          >
+            {PLUGIN_POSITION_ITEMS.map((position) => (
+              <DropdownMenuRadioItem
+                key={position.value}
+                value={position.value}
+                onSelect={(event: Event) => event.preventDefault()}
+              >
+                {t(position.labelKey)}
+              </DropdownMenuRadioItem>
+            ))}
+          </DropdownMenuRadioGroup>
+        </DropdownMenuSubContent>
+      </DropdownMenuSub>
+    );
+  };
+
+  const webServicePlugins = plugins.filter((p) =>
+    WEB_SERVICE_PLUGIN_ID_SET.has(p.id),
+  );
+  // The web service plugins render as one grouped submenu, placed where the
+  // first of them appears in registration order (just above Esri Wayback).
+  let webServicesRendered = false;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          className={chrome.buttonClass}
+          variant="ghost"
+          size={chrome.buttonSize}
+          aria-label={t("toolbar.menu.plugins")}
+        >
+          <Puzzle className={chrome.iconClassName} />
+          {chrome.renderLabel(t("toolbar.menu.plugins"))}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        <DropdownMenuLabel>{t("toolbar.item.activatePlugin")}</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {plugins.map((p) => {
+          // Atmosphere Effects, Directions, and Reverse Geocode are toggled
+          // from the Controls menu instead, so they are omitted here to avoid a
+          // duplicate toggle. The deck.gl viz overlay is an internal renderer
+          // driven by the Add Data → "Deck.gl Layer" dialog, not a user-facing
+          // toggle, so it is hidden here too.
+          if (
+            p.id === EFFECTS_PLUGIN_ID ||
+            p.id === DIRECTIONS_PLUGIN_ID ||
+            p.id === REVERSE_GEOCODE_PLUGIN_ID ||
+            p.id === DECK_VIZ_PLUGIN_ID
+          ) {
+            return null;
+          }
+          if (!WEB_SERVICE_PLUGIN_ID_SET.has(p.id)) {
+            return renderPluginMenuItem(p);
+          }
+          if (webServicesRendered) return null;
+          webServicesRendered = true;
+          return (
+            <DropdownMenuSub key="web-services">
+              <DropdownMenuSubTrigger>
+                {t("toolbar.item.webServices")}
+                {webServicePlugins.some((plugin) => isActive(plugin.id))
+                  ? " ✓"
+                  : ""}
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                {webServicePlugins.map(renderPluginMenuItem)}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
@@ -1,0 +1,360 @@
+import { useAppStore } from "@geolibre/core";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@geolibre/ui";
+import { Wrench } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { ToolbarPanel } from "../../../hooks/useToolbarPanels";
+import type { ToolbarChrome } from "./constants";
+
+interface ProcessingMenuProps {
+  chrome: ToolbarChrome;
+  earthEnginePanel: ToolbarPanel;
+  onOpenNetworkTool: (kind: "isochrone" | "od-matrix") => void;
+  onOpenPlanetaryComputer: () => void;
+}
+
+/** The Processing menu: assistant, toolboxes, conversion/vector/network/statistics/raster submenus. */
+export function ProcessingMenu({
+  chrome,
+  earthEnginePanel,
+  onOpenNetworkTool,
+  onOpenPlanetaryComputer,
+}: ProcessingMenuProps) {
+  const { t } = useTranslation();
+  const setProcessingOpen = useAppStore((s) => s.setProcessingOpen);
+  const setConversionOpen = useAppStore((s) => s.setConversionOpen);
+  const setVectorToolOpen = useAppStore((s) => s.setVectorToolOpen);
+  const setStatisticsToolOpen = useAppStore((s) => s.setStatisticsToolOpen);
+  const setGeocodeOpen = useAppStore((s) => s.setGeocodeOpen);
+  const setModelBuilderOpen = useAppStore((s) => s.setModelBuilderOpen);
+  const setRasterToolOpen = useAppStore((s) => s.setRasterToolOpen);
+  const setSegmentationOpen = useAppStore((s) => s.setSegmentationOpen);
+  const setSqlWorkspaceOpen = useAppStore((s) => s.setSqlWorkspaceOpen);
+  const setPythonConsoleOpen = useAppStore((s) => s.setPythonConsoleOpen);
+  const setAssistantOpen = useAppStore((s) => s.setAssistantOpen);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          className={chrome.buttonClass}
+          variant="ghost"
+          size={chrome.buttonSize}
+          aria-label={t("toolbar.menu.processing")}
+        >
+          <Wrench className={chrome.iconClassName} />
+          {chrome.renderLabel(t("toolbar.menu.processing"))}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        <DropdownMenuLabel>{t("toolbar.menu.processing")}</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={() => setAssistantOpen(true)}>
+          {t("toolbar.command.assistant")}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={() => setProcessingOpen(true)}>
+          {t("toolbar.item.whitebox")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => setSqlWorkspaceOpen(true)}>
+          {t("toolbar.command.sqlWorkspace")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => setPythonConsoleOpen(true)}>
+          {t("toolbar.command.pythonConsole")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => setGeocodeOpen(true)}>
+          {t("toolbar.item.geocode")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => setModelBuilderOpen(true)}>
+          {t("toolbar.item.modelBuilder")}
+        </DropdownMenuItem>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            {t("toolbar.item.conversion")}
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent>
+            <DropdownMenuItem
+              onSelect={() => setConversionOpen("vector-to-geoparquet")}
+            >
+              {t("toolbar.conversion.vectorToGeoparquet")}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() => setConversionOpen("vector-to-flatgeobuf")}
+            >
+              {t("toolbar.conversion.vectorToFlatgeobuf")}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() => setConversionOpen("vector-to-shapefile")}
+            >
+              {t("toolbar.conversion.vectorToShapefile")}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() => setConversionOpen("vector-to-geopackage")}
+            >
+              {t("toolbar.conversion.vectorToGeopackage")}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() => setConversionOpen("csv-to-geoparquet")}
+            >
+              {t("toolbar.conversion.csvToGeoparquet")}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() => setConversionOpen("vector-to-pmtiles")}
+            >
+              {t("toolbar.conversion.vectorToPmtiles")}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() => setConversionOpen("raster-to-cog")}
+            >
+              {t("toolbar.conversion.rasterToCog")}
+            </DropdownMenuItem>
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            {t("toolbar.item.vector")}
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent>
+            <DropdownMenuLabel className="text-xs text-muted-foreground">
+              {t("toolbar.item.subGroupGeometry")}
+            </DropdownMenuLabel>
+            <DropdownMenuItem onSelect={() => setVectorToolOpen("buffer")}>
+              {t("toolbar.vectorTool.buffer")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setVectorToolOpen("centroids")}>
+              {t("toolbar.vectorTool.centroids")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setVectorToolOpen("convex-hull")}>
+              {t("toolbar.vectorTool.convexHull")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setVectorToolOpen("dissolve")}>
+              {t("toolbar.vectorTool.dissolve")}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() => setVectorToolOpen("bounding-box")}
+            >
+              {t("toolbar.vectorTool.boundingBox")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setVectorToolOpen("simplify")}>
+              {t("toolbar.vectorTool.simplify")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setVectorToolOpen("reproject")}>
+              {t("toolbar.vectorTool.reproject")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setVectorToolOpen("explode")}>
+              {t("toolbar.vectorTool.explode")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setVectorToolOpen("aggregate")}>
+              {t("toolbar.vectorTool.aggregate")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setVectorToolOpen("smooth")}>
+              {t("toolbar.vectorTool.smooth")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setVectorToolOpen("grid")}>
+              {t("toolbar.vectorTool.grid")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setVectorToolOpen("voronoi")}>
+              {t("toolbar.vectorTool.voronoi")}
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="text-xs text-muted-foreground">
+              {t("toolbar.item.subGroupOverlay")}
+            </DropdownMenuLabel>
+            <DropdownMenuItem onSelect={() => setVectorToolOpen("clip")}>
+              {t("toolbar.vectorTool.clip")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setVectorToolOpen("intersection")}>
+              {t("toolbar.vectorTool.intersection")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setVectorToolOpen("difference")}>
+              {t("toolbar.vectorTool.difference")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setVectorToolOpen("union")}>
+              {t("toolbar.vectorTool.union")}
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="text-xs text-muted-foreground">
+              {t("toolbar.item.subGroupJoin")}
+            </DropdownMenuLabel>
+            <DropdownMenuItem onSelect={() => setVectorToolOpen("spatial-join")}>
+              {t("toolbar.vectorTool.spatialJoin")}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() => setVectorToolOpen("attribute-join")}
+            >
+              {t("toolbar.vectorTool.attributeJoin")}
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="text-xs text-muted-foreground">
+              {t("toolbar.item.subGroupSelect")}
+            </DropdownMenuLabel>
+            <DropdownMenuItem
+              onSelect={() => setVectorToolOpen("select-by-value")}
+            >
+              {t("toolbar.vectorTool.selectByValue")}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() => setVectorToolOpen("select-by-location")}
+            >
+              {t("toolbar.vectorTool.selectByLocation")}
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="text-xs text-muted-foreground">
+              {t("toolbar.item.subGroupH3")}
+            </DropdownMenuLabel>
+            <DropdownMenuItem onSelect={() => setVectorToolOpen("h3-grid")}>
+              {t("toolbar.vectorTool.h3Grid")}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() => setVectorToolOpen("h3-bin-points")}
+            >
+              {t("toolbar.vectorTool.h3BinPoints")}
+            </DropdownMenuItem>
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            {t("toolbar.item.network")}
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent>
+            <DropdownMenuItem onSelect={() => onOpenNetworkTool("isochrone")}>
+              {t("toolbar.networkTool.isochrone")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => onOpenNetworkTool("od-matrix")}>
+              {t("toolbar.networkTool.odMatrix")}
+            </DropdownMenuItem>
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            {t("toolbar.item.statistics")}
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent>
+            <DropdownMenuItem
+              onSelect={() => setStatisticsToolOpen("global-morans-i")}
+            >
+              {t("toolbar.statisticsTool.globalMoransI")}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() => setStatisticsToolOpen("local-morans-i")}
+            >
+              {t("toolbar.statisticsTool.localMoransI")}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() => setStatisticsToolOpen("getis-ord-gi")}
+            >
+              {t("toolbar.statisticsTool.getisOrd")}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() =>
+                setStatisticsToolOpen("average-nearest-neighbor")
+              }
+            >
+              {t("toolbar.statisticsTool.averageNearestNeighbor")}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() => setStatisticsToolOpen("kernel-density")}
+            >
+              {t("toolbar.statisticsTool.kernelDensity")}
+            </DropdownMenuItem>
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            {t("toolbar.item.raster")}
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent>
+            <DropdownMenuLabel className="text-xs text-muted-foreground">
+              {t("toolbar.item.subGroupTerrain")}
+            </DropdownMenuLabel>
+            <DropdownMenuItem onSelect={() => setRasterToolOpen("hillshade")}>
+              {t("toolbar.rasterTool.hillshade")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setRasterToolOpen("slope")}>
+              {t("toolbar.rasterTool.slope")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setRasterToolOpen("aspect")}>
+              {t("toolbar.rasterTool.aspect")}
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="text-xs text-muted-foreground">
+              {t("toolbar.item.subGroupReproject")}
+            </DropdownMenuLabel>
+            <DropdownMenuItem onSelect={() => setRasterToolOpen("reproject")}>
+              {t("toolbar.rasterTool.reproject")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setRasterToolOpen("resample")}>
+              {t("toolbar.rasterTool.resample")}
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="text-xs text-muted-foreground">
+              {t("toolbar.item.subGroupClip")}
+            </DropdownMenuLabel>
+            <DropdownMenuItem onSelect={() => setRasterToolOpen("clip-extent")}>
+              {t("toolbar.rasterTool.clipExtent")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setRasterToolOpen("clip-mask")}>
+              {t("toolbar.rasterTool.clipMask")}
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="text-xs text-muted-foreground">
+              {t("toolbar.item.subGroupRasterToVector")}
+            </DropdownMenuLabel>
+            <DropdownMenuItem onSelect={() => setRasterToolOpen("polygonize")}>
+              {t("toolbar.rasterTool.polygonize")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setRasterToolOpen("contour")}>
+              {t("toolbar.rasterTool.contour")}
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="text-xs text-muted-foreground">
+              {t("toolbar.item.subGroupVectorToRaster")}
+            </DropdownMenuLabel>
+            <DropdownMenuItem onSelect={() => setRasterToolOpen("interpolate")}>
+              {t("toolbar.rasterTool.interpolate")}
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="text-xs text-muted-foreground">
+              {t("toolbar.item.subGroupAnalysis")}
+            </DropdownMenuLabel>
+            <DropdownMenuItem onSelect={() => setRasterToolOpen("zonal")}>
+              {t("toolbar.rasterTool.zonal")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setRasterToolOpen("raster-calc")}>
+              {t("toolbar.rasterTool.rasterCalc")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setRasterToolOpen("reclassify")}>
+              {t("toolbar.rasterTool.reclassify")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setRasterToolOpen("mosaic")}>
+              {t("toolbar.rasterTool.mosaic")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setRasterToolOpen("focal")}>
+              {t("toolbar.rasterTool.focal")}
+            </DropdownMenuItem>
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+        <DropdownMenuItem onSelect={() => setSegmentationOpen(true)}>
+          {t("toolbar.command.segmentation")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={onOpenPlanetaryComputer}>
+          {t("toolbar.command.planetaryComputer")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={earthEnginePanel.toggle}>
+          {t("toolbar.command.earthEngine")}
+          {earthEnginePanel.visible ? " ✓" : ""}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProjectFileDialogs.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProjectFileDialogs.tsx
@@ -1,0 +1,124 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+} from "@geolibre/ui";
+import { useTranslation } from "react-i18next";
+import type { useProjectFileActions } from "../../../hooks/useProjectFileActions";
+
+interface ProjectFileDialogsProps {
+  projectFiles: ReturnType<typeof useProjectFileActions>;
+}
+
+/** The project-file dialogs: Open-from-URL, the error dialog, and the env-var strip prompt. */
+export function ProjectFileDialogs({ projectFiles }: ProjectFileDialogsProps) {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <Dialog
+        open={projectFiles.projectUrlDialogOpen}
+        onOpenChange={projectFiles.handleProjectUrlDialogOpenChange}
+      >
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{t("toolbar.item.openProjectFromUrl")}</DialogTitle>
+            <DialogDescription>
+              {t("toolbar.item.openProjectFromUrlDesc")}
+            </DialogDescription>
+          </DialogHeader>
+          <form className="space-y-4" onSubmit={projectFiles.handleOpenFromUrl}>
+            <div className="space-y-2">
+              <Label htmlFor="project-url">{t("toolbar.item.projectUrl")}</Label>
+              <Input
+                id="project-url"
+                placeholder="https://example.com/project.geolibre.json"
+                value={projectFiles.projectUrl}
+                onChange={(event) => {
+                  projectFiles.setProjectUrl(event.target.value);
+                  projectFiles.setProjectUrlError(null);
+                }}
+              />
+              {projectFiles.projectUrlError ? (
+                <p className="text-xs text-destructive">
+                  {projectFiles.projectUrlError}
+                </p>
+              ) : null}
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => projectFiles.setProjectUrlDialogOpen(false)}
+              >
+                {t("common.cancel")}
+              </Button>
+              <Button type="submit" disabled={projectFiles.projectUrlLoading}>
+                {projectFiles.projectUrlLoading
+                  ? t("toolbar.item.opening")
+                  : t("toolbar.item.open")}
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+      <Dialog
+        open={projectFiles.actionError !== null}
+        onOpenChange={(open: boolean) => {
+          if (!open) projectFiles.setActionError(null);
+        }}
+      >
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{t("toolbar.item.somethingWentWrong")}</DialogTitle>
+            <DialogDescription>{projectFiles.actionError}</DialogDescription>
+          </DialogHeader>
+          <div className="flex justify-end">
+            <Button onClick={() => projectFiles.setActionError(null)}>
+              {t("toolbar.item.dismiss")}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+      <Dialog
+        open={projectFiles.envStripPrompt !== null}
+        onOpenChange={(open: boolean) => {
+          if (!open) projectFiles.resolveEnvStripPrompt("cancel");
+        }}
+      >
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{t("settings.env.stripPromptTitle")}</DialogTitle>
+            <DialogDescription>
+              {t("settings.env.stripPromptDesc", {
+                count: projectFiles.envStripPrompt?.count ?? 0,
+              })}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="outline"
+              onClick={() => projectFiles.resolveEnvStripPrompt("cancel")}
+            >
+              {t("common.cancel")}
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => projectFiles.resolveEnvStripPrompt("keep")}
+            >
+              {t("settings.env.keepButton")}
+            </Button>
+            <Button onClick={() => projectFiles.resolveEnvStripPrompt("strip")}>
+              {t("settings.env.stripButton")}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProjectMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProjectMenu.tsx
@@ -1,0 +1,213 @@
+import { projectPathLabel, useAppStore } from "@geolibre/core";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@geolibre/ui";
+import {
+  BookOpen,
+  FilePen,
+  FilePlus2,
+  FileText,
+  Folder,
+  FolderOpen,
+  History,
+  LayoutTemplate,
+  Link2,
+  Printer,
+  Save,
+  Share2,
+  Users,
+  X,
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { ToolbarPanel } from "../../../hooks/useToolbarPanels";
+import { formatRecentProjectTime, type ToolbarChrome } from "./constants";
+
+interface ProjectMenuProps {
+  chrome: ToolbarChrome;
+  collaborationEnabled: boolean;
+  printPanel: ToolbarPanel;
+  onNewProject: () => void;
+  onOpenFromFile: () => void;
+  onOpenFromUrl: () => void;
+  onOpenRecent: (path: string) => void;
+  onSave: () => void;
+  onSaveAs: () => void;
+  onShare: () => void;
+  onCollaborate: () => void;
+  onPrintLayout: () => void;
+}
+
+/** The Project menu: new/open/save/share, recent projects, print, and storymap. */
+export function ProjectMenu({
+  chrome,
+  collaborationEnabled,
+  printPanel,
+  onNewProject,
+  onOpenFromFile,
+  onOpenFromUrl,
+  onOpenRecent,
+  onSave,
+  onSaveAs,
+  onShare,
+  onCollaborate,
+  onPrintLayout,
+}: ProjectMenuProps) {
+  const { t } = useTranslation();
+  const projectPath = useAppStore((s) => s.projectPath);
+  const recentProjects = useAppStore((s) => s.recentProjects);
+  const forgetRecentProject = useAppStore((s) => s.forgetRecentProject);
+  const clearRecentProjects = useAppStore((s) => s.clearRecentProjects);
+  const setStorymapPanelOpen = useAppStore((s) => s.setStorymapPanelOpen);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          className={chrome.buttonClass}
+          variant="ghost"
+          size={chrome.buttonSize}
+          aria-label={t("toolbar.menu.project")}
+        >
+          <Folder className={chrome.iconClassName} />
+          {chrome.renderLabel(t("toolbar.menu.project"))}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-64">
+        <DropdownMenuLabel>{t("toolbar.menu.project")}</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={onNewProject}>
+          <FilePlus2 className="mr-2 h-3.5 w-3.5" />
+          {t("toolbar.item.newEllipsis")}
+        </DropdownMenuItem>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            <FolderOpen className="mr-2 h-3.5 w-3.5" />
+            {t("toolbar.item.openFrom")}
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent>
+            <DropdownMenuItem onSelect={onOpenFromFile}>
+              <FileText className="mr-2 h-3.5 w-3.5" />
+              {t("toolbar.item.fileEllipsis")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={onOpenFromUrl}>
+              <Link2 className="mr-2 h-3.5 w-3.5" />
+              {t("toolbar.item.urlEllipsis")}
+            </DropdownMenuItem>
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger disabled={recentProjects.length === 0}>
+            <History className="mr-2 h-3.5 w-3.5" />
+            {t("toolbar.item.openRecent")}
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="w-80">
+            {recentProjects.length === 0 ? (
+              <DropdownMenuItem disabled>
+                {t("toolbar.item.noRecentProjects")}
+              </DropdownMenuItem>
+            ) : (
+              recentProjects.map((project) => {
+                const openedAt = formatRecentProjectTime(project.openedAt);
+                const label = project.name || projectPathLabel(project.path);
+                return (
+                  <DropdownMenuItem
+                    key={project.path}
+                    className="flex items-start justify-between gap-2"
+                    onSelect={() => onOpenRecent(project.path)}
+                    title={project.path}
+                  >
+                    <span className="flex min-w-0 flex-col items-start gap-0.5">
+                      <span
+                        className="max-w-full truncate font-medium"
+                        title={label}
+                      >
+                        {label}
+                      </span>
+                      <span className="flex max-w-full items-start gap-1 text-xs text-muted-foreground">
+                        <History className="h-3 w-3 shrink-0" />
+                        <span
+                          className="break-all text-left leading-snug"
+                          title={project.path}
+                        >
+                          {openedAt
+                            ? `${openedAt} - ${project.path}`
+                            : project.path}
+                        </span>
+                      </span>
+                    </span>
+                    <button
+                      type="button"
+                      aria-label={t("toolbar.item.removeFromRecent", {
+                        name: label,
+                      })}
+                      className="mt-0.5 shrink-0 rounded p-0.5 text-muted-foreground hover:text-foreground"
+                      onClick={(event) => {
+                        // Keep the menu open and prevent the row's onSelect
+                        // (which would reopen the project) from firing.
+                        event.stopPropagation();
+                        event.preventDefault();
+                        forgetRecentProject(project.path);
+                      }}
+                    >
+                      <X className="h-3.5 w-3.5" />
+                    </button>
+                  </DropdownMenuItem>
+                );
+              })
+            )}
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              disabled={recentProjects.length === 0}
+              onSelect={clearRecentProjects}
+            >
+              {t("toolbar.item.clearRecentProjects")}
+            </DropdownMenuItem>
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={onSave}>
+          <Save className="mr-2 h-3.5 w-3.5" />
+          {t("common.save")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={onSaveAs}>
+          <FilePen className="mr-2 h-3.5 w-3.5" />
+          {t("toolbar.item.saveAsEllipsis")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={onShare}>
+          <Share2 className="mr-2 h-3.5 w-3.5" />
+          {t("toolbar.item.shareEllipsis")}
+        </DropdownMenuItem>
+        {collaborationEnabled && (
+          <DropdownMenuItem onSelect={onCollaborate}>
+            <Users className="mr-2 h-3.5 w-3.5" />
+            {t("toolbar.item.collaborateEllipsis")}
+          </DropdownMenuItem>
+        )}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={printPanel.toggle}>
+          <Printer className="mr-2 h-3.5 w-3.5" />
+          {t("toolbar.item.printEllipsis")}
+          {printPanel.visible ? " ✓" : ""}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={onPrintLayout}>
+          <LayoutTemplate className="mr-2 h-3.5 w-3.5" />
+          Print Layout...
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={() => setStorymapPanelOpen(true)}>
+          <BookOpen className="mr-2 h-3.5 w-3.5" />
+          {t("toolbar.item.storymapEllipsis")}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProjectMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProjectMenu.tsx
@@ -200,7 +200,7 @@ export function ProjectMenu({
         </DropdownMenuItem>
         <DropdownMenuItem onSelect={onPrintLayout}>
           <LayoutTemplate className="mr-2 h-3.5 w-3.5" />
-          Print Layout...
+          {t("toolbar.item.printLayoutEllipsis")}
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem onSelect={() => setStorymapPanelOpen(true)}>

--- a/apps/geolibre-desktop/src/components/layout/toolbar/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/constants.ts
@@ -1,0 +1,228 @@
+import type {
+  ConversionToolKind,
+  RasterToolKind,
+  VectorToolKind,
+} from "@geolibre/core";
+import {
+  type BuiltInMapControl,
+  type MapController,
+} from "@geolibre/map";
+import type { GeoLibreMapControlPosition } from "@geolibre/plugins";
+import type { ParseKeys } from "i18next";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import type { createAppAPI } from "../../../hooks/usePlugins";
+import { isTauri } from "../../../lib/tauri-io";
+import type { AddDataKind } from "../AddDataDialog";
+
+/** The live app API surface plugins and panels are driven through. */
+export type AppApi = ReturnType<typeof createAppAPI>;
+
+/** A ref to the live MapController, shared across the toolbar pieces. */
+export type MapControllerRef = React.RefObject<MapController | null>;
+
+/** Built-in map controls that the Controls menu can toggle (all but the layer control). */
+export type ToolbarMapControl = Exclude<BuiltInMapControl, "layer-control">;
+
+/**
+ * The appApi-backed "add layer" handlers shared by the Add Data menu and the
+ * command palette, so each panel is opened the same way from both places.
+ */
+export interface AddLayerHandlers {
+  vector: () => void;
+  raster: () => void;
+  stac: () => void;
+  flatGeobuf: () => void;
+  pmtiles: () => void;
+  zarr: () => void;
+  netcdf: () => void;
+  lidar: () => void;
+  splatting: () => void;
+  threeDTiles: () => void;
+  duckdb: () => void;
+}
+
+/** Shared styling/affordances passed to each toolbar menu's trigger button. */
+export interface ToolbarChrome {
+  buttonClass: string;
+  secondaryButtonClass: string;
+  buttonSize: "icon" | "sm";
+  iconClassName: string;
+  renderLabel: (label: string) => React.ReactNode;
+}
+
+export const MAP_CONTROL_ITEMS: Array<{
+  id: ToolbarMapControl;
+  labelKey: ParseKeys;
+}> = [
+  { id: "navigation", labelKey: "toolbar.mapControl.navigation" },
+  { id: "fullscreen", labelKey: "toolbar.mapControl.fullscreen" },
+  { id: "geolocate", labelKey: "toolbar.mapControl.geolocate" },
+  { id: "globe", labelKey: "toolbar.mapControl.globe" },
+  { id: "terrain", labelKey: "toolbar.mapControl.terrain" },
+  { id: "scale", labelKey: "toolbar.mapControl.scale" },
+  { id: "attribution", labelKey: "toolbar.mapControl.attribution" },
+  { id: "logo", labelKey: "toolbar.mapControl.logo" },
+];
+
+export const NEW_PROJECT_VISIBLE_BUILT_IN_CONTROLS = new Set<BuiltInMapControl>([
+  "navigation",
+  "fullscreen",
+  "globe",
+  "layer-control",
+]);
+
+export const ALL_BUILT_IN_CONTROL_IDS: BuiltInMapControl[] = [
+  ...MAP_CONTROL_ITEMS.map(({ id }) => id),
+  "layer-control",
+];
+
+export const PLUGIN_POSITION_ITEMS: Array<{
+  value: GeoLibreMapControlPosition;
+  labelKey: ParseKeys;
+}> = [
+  { value: "top-left", labelKey: "toolbar.position.topLeft" },
+  { value: "top-right", labelKey: "toolbar.position.topRight" },
+  { value: "bottom-left", labelKey: "toolbar.position.bottomLeft" },
+  { value: "bottom-right", labelKey: "toolbar.position.bottomRight" },
+];
+
+export const FEEDBACK_URL = "https://github.com/opengeos/GeoLibre/issues";
+// A small (~350 KB) CORS-enabled Las Vegas Strip sample, so the URL field works
+// out of the box on both the desktop and web builds.
+export const DEFAULT_OSM_PBF_URL =
+  "https://data.source.coop/giswqs/opengeos/LasVegas.osm.pbf";
+
+// Static command metadata for the menus that map a single id to a label. These
+// drive the command palette so it stays in sync with the menus without each
+// action being defined twice. The `run` closures are built in the component
+// where the store setters are in scope.
+export const ADD_DATA_KIND_COMMANDS: Array<{
+  kind: AddDataKind;
+  titleKey: ParseKeys;
+}> = [
+  { kind: "delimited-text", titleKey: "toolbar.layerType.delimitedText" },
+  { kind: "gpx", titleKey: "toolbar.layerType.gpx" },
+  { kind: "mbtiles", titleKey: "toolbar.layerType.mbtiles" },
+  { kind: "xyz", titleKey: "toolbar.layerType.xyz" },
+  { kind: "wms", titleKey: "toolbar.layerType.wms" },
+  { kind: "wfs", titleKey: "toolbar.layerType.wfs" },
+  { kind: "wmts", titleKey: "toolbar.layerType.wmts" },
+  { kind: "arcgis", titleKey: "toolbar.layerType.arcgis" },
+  { kind: "video", titleKey: "toolbar.layerType.video" },
+  { kind: "deckgl-viz", titleKey: "toolbar.layerType.deckglViz" },
+  { kind: "postgres", titleKey: "toolbar.layerType.postgres" },
+];
+
+export const CONVERSION_COMMANDS: Array<{
+  kind: ConversionToolKind;
+  titleKey: ParseKeys;
+}> = [
+  {
+    kind: "vector-to-geoparquet",
+    titleKey: "toolbar.conversion.vectorToGeoparquet",
+  },
+  {
+    kind: "vector-to-flatgeobuf",
+    titleKey: "toolbar.conversion.vectorToFlatgeobuf",
+  },
+  {
+    kind: "vector-to-shapefile",
+    titleKey: "toolbar.conversion.vectorToShapefile",
+  },
+  {
+    kind: "vector-to-geopackage",
+    titleKey: "toolbar.conversion.vectorToGeopackage",
+  },
+  { kind: "csv-to-geoparquet", titleKey: "toolbar.conversion.csvToGeoparquet" },
+  { kind: "vector-to-pmtiles", titleKey: "toolbar.conversion.vectorToPmtiles" },
+  { kind: "raster-to-cog", titleKey: "toolbar.conversion.rasterToCog" },
+];
+
+export const VECTOR_TOOL_COMMANDS: Array<{
+  kind: VectorToolKind;
+  titleKey: ParseKeys;
+}> = [
+  { kind: "buffer", titleKey: "toolbar.vectorTool.buffer" },
+  { kind: "centroids", titleKey: "toolbar.vectorTool.centroids" },
+  { kind: "convex-hull", titleKey: "toolbar.vectorTool.convexHull" },
+  { kind: "dissolve", titleKey: "toolbar.vectorTool.dissolve" },
+  { kind: "bounding-box", titleKey: "toolbar.vectorTool.boundingBox" },
+  { kind: "simplify", titleKey: "toolbar.vectorTool.simplify" },
+  { kind: "clip", titleKey: "toolbar.vectorTool.clip" },
+  { kind: "intersection", titleKey: "toolbar.vectorTool.intersection" },
+  { kind: "difference", titleKey: "toolbar.vectorTool.difference" },
+  { kind: "union", titleKey: "toolbar.vectorTool.union" },
+  { kind: "spatial-join", titleKey: "toolbar.vectorTool.spatialJoin" },
+  { kind: "attribute-join", titleKey: "toolbar.vectorTool.attributeJoin" },
+  { kind: "select-by-value", titleKey: "toolbar.vectorTool.selectByValue" },
+  {
+    kind: "select-by-location",
+    titleKey: "toolbar.vectorTool.selectByLocation",
+  },
+  { kind: "reproject", titleKey: "toolbar.vectorTool.reproject" },
+  { kind: "explode", titleKey: "toolbar.vectorTool.explode" },
+  { kind: "aggregate", titleKey: "toolbar.vectorTool.aggregate" },
+  { kind: "smooth", titleKey: "toolbar.vectorTool.smooth" },
+  { kind: "grid", titleKey: "toolbar.vectorTool.grid" },
+  { kind: "voronoi", titleKey: "toolbar.vectorTool.voronoi" },
+  { kind: "h3-grid", titleKey: "toolbar.vectorTool.h3Grid" },
+  { kind: "h3-bin-points", titleKey: "toolbar.vectorTool.h3BinPoints" },
+];
+
+export const RASTER_TOOL_COMMANDS: Array<{
+  kind: RasterToolKind;
+  titleKey: ParseKeys;
+}> = [
+  { kind: "hillshade", titleKey: "toolbar.rasterTool.hillshade" },
+  { kind: "slope", titleKey: "toolbar.rasterTool.slope" },
+  { kind: "aspect", titleKey: "toolbar.rasterTool.aspect" },
+  { kind: "reproject", titleKey: "toolbar.rasterTool.reproject" },
+  { kind: "resample", titleKey: "toolbar.rasterTool.resample" },
+  { kind: "clip-extent", titleKey: "toolbar.rasterTool.clipExtent" },
+  { kind: "clip-mask", titleKey: "toolbar.rasterTool.clipMask" },
+  { kind: "polygonize", titleKey: "toolbar.rasterTool.polygonize" },
+  { kind: "contour", titleKey: "toolbar.rasterTool.contour" },
+  { kind: "interpolate", titleKey: "toolbar.rasterTool.interpolate" },
+  { kind: "zonal", titleKey: "toolbar.rasterTool.zonal" },
+  { kind: "raster-calc", titleKey: "toolbar.rasterTool.rasterCalc" },
+  { kind: "reclassify", titleKey: "toolbar.rasterTool.reclassify" },
+  { kind: "mosaic", titleKey: "toolbar.rasterTool.mosaic" },
+  { kind: "focal", titleKey: "toolbar.rasterTool.focal" },
+];
+
+/** Open an external link in the OS browser (Tauri) or a new tab (web). */
+export async function openExternalLink(url: string): Promise<void> {
+  if (isTauri()) {
+    await openUrl(url);
+    return;
+  }
+  window.open(url, "_blank", "noopener,noreferrer");
+}
+
+/** Format a recent-project timestamp for display, or "" if unparseable. */
+export function formatRecentProjectTime(openedAt: string): string {
+  const openedDate = new Date(openedAt);
+  if (Number.isNaN(openedDate.getTime())) return "";
+
+  return new Intl.DateTimeFormat(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(openedDate);
+}
+
+/** Initial toolbar control visibility map applied when a new project is created. */
+export function newProjectToolbarControlVisibility(): Record<
+  ToolbarMapControl,
+  boolean
+> {
+  return MAP_CONTROL_ITEMS.reduce(
+    (acc, { id }) => {
+      acc[id] = NEW_PROJECT_VISIBLE_BUILT_IN_CONTROLS.has(id);
+      return acc;
+    },
+    {} as Record<ToolbarMapControl, boolean>,
+  );
+}

--- a/apps/geolibre-desktop/src/hooks/useConsentGatedActions.ts
+++ b/apps/geolibre-desktop/src/hooks/useConsentGatedActions.ts
@@ -100,6 +100,12 @@ export function useConsentGatedActions({
     if (pendingNetworkTool) setNetworkToolOpen(pendingNetworkTool);
     setPendingNetworkTool(null);
   };
+  // Cancel/dismiss the routing notice, clearing the paired pending-tool state so
+  // callers don't need to know that state exists.
+  const dismissRoutingNotice = () => {
+    setRoutingNoticeOpen(false);
+    setPendingNetworkTool(null);
+  };
 
   return {
     directionsNoticeOpen,
@@ -107,8 +113,7 @@ export function useConsentGatedActions({
     reverseGeocodeNoticeOpen,
     setReverseGeocodeNoticeOpen,
     routingNoticeOpen,
-    setRoutingNoticeOpen,
-    setPendingNetworkTool,
+    dismissRoutingNotice,
     handleToggleDirections,
     confirmEnableDirections,
     handleToggleReverseGeocode,

--- a/apps/geolibre-desktop/src/hooks/useConsentGatedActions.ts
+++ b/apps/geolibre-desktop/src/hooks/useConsentGatedActions.ts
@@ -1,0 +1,119 @@
+import { useAppStore } from "@geolibre/core";
+import {
+  DIRECTIONS_PLUGIN_ID,
+  REVERSE_GEOCODE_PLUGIN_ID,
+} from "@geolibre/plugins";
+import { useState } from "react";
+import {
+  hasReverseGeocodeConsent,
+  recordReverseGeocodeConsent,
+} from "../lib/reverse-geocode-consent";
+import { hasRoutingConsent, recordRoutingConsent } from "../lib/routing-consent";
+import type { AppApi } from "../components/layout/toolbar/constants";
+
+interface UseConsentGatedActionsOptions {
+  appApi: AppApi;
+  isActive: (id: string) => boolean;
+  toggle: (id: string, appApi: AppApi) => void;
+}
+
+/**
+ * Wraps the actions that send user data to public third-party servers
+ * (Directions/OSRM, reverse geocoding, and Valhalla network tools) behind a
+ * one-time consent notice, since a hover-only tooltip is invisible on touch.
+ *
+ * @returns Notice dialog state plus the gated toggle/open handlers.
+ */
+export function useConsentGatedActions({
+  appApi,
+  isActive,
+  toggle,
+}: UseConsentGatedActionsOptions) {
+  const setNetworkToolOpen = useAppStore((s) => s.setNetworkToolOpen);
+  const [directionsNoticeOpen, setDirectionsNoticeOpen] = useState(false);
+  const [reverseGeocodeNoticeOpen, setReverseGeocodeNoticeOpen] =
+    useState(false);
+  const [routingNoticeOpen, setRoutingNoticeOpen] = useState(false);
+  const [pendingNetworkTool, setPendingNetworkTool] = useState<
+    "isochrone" | "od-matrix" | null
+  >(null);
+
+  // Show a one-time consent notice the first time routing is enabled, since it
+  // sends the user's waypoints to a public third-party server.
+  const handleToggleDirections = () => {
+    if (isActive(DIRECTIONS_PLUGIN_ID)) {
+      toggle(DIRECTIONS_PLUGIN_ID, appApi);
+      return;
+    }
+    let acknowledged = false;
+    try {
+      acknowledged =
+        localStorage.getItem("geolibre:directions-osrm-notice") === "1";
+    } catch {
+      // localStorage unavailable (private mode): fall back to showing the notice.
+    }
+    if (acknowledged) toggle(DIRECTIONS_PLUGIN_ID, appApi);
+    else setDirectionsNoticeOpen(true);
+  };
+  const confirmEnableDirections = () => {
+    try {
+      localStorage.setItem("geolibre:directions-osrm-notice", "1");
+    } catch {
+      // Ignore: the notice will simply show again next time.
+    }
+    setDirectionsNoticeOpen(false);
+    toggle(DIRECTIONS_PLUGIN_ID, appApi);
+  };
+
+  // Reverse geocode sends the clicked coordinates to a public geocoder, so it
+  // shows the same one-time consent notice as Directions before first enabling.
+  // The consent flag is shared with the project-restore path (DesktopShell), so
+  // every activation path is gated on it.
+  const handleToggleReverseGeocode = () => {
+    if (isActive(REVERSE_GEOCODE_PLUGIN_ID)) {
+      toggle(REVERSE_GEOCODE_PLUGIN_ID, appApi);
+      return;
+    }
+    if (hasReverseGeocodeConsent()) toggle(REVERSE_GEOCODE_PLUGIN_ID, appApi);
+    else setReverseGeocodeNoticeOpen(true);
+  };
+  const confirmEnableReverseGeocode = () => {
+    recordReverseGeocodeConsent();
+    setReverseGeocodeNoticeOpen(false);
+    toggle(REVERSE_GEOCODE_PLUGIN_ID, appApi);
+  };
+
+  // Network analysis tools send the coordinates of the input points to a public
+  // Valhalla routing server, so they show the same one-time consent notice as
+  // Directions before opening, gated on every activation path (each menu item).
+  const openNetworkTool = (kind: "isochrone" | "od-matrix") => {
+    if (hasRoutingConsent()) {
+      setNetworkToolOpen(kind);
+      return;
+    }
+    setPendingNetworkTool(kind);
+    setRoutingNoticeOpen(true);
+  };
+  const confirmOpenNetworkTool = () => {
+    recordRoutingConsent();
+    setRoutingNoticeOpen(false);
+    if (pendingNetworkTool) setNetworkToolOpen(pendingNetworkTool);
+    setPendingNetworkTool(null);
+  };
+
+  return {
+    directionsNoticeOpen,
+    setDirectionsNoticeOpen,
+    reverseGeocodeNoticeOpen,
+    setReverseGeocodeNoticeOpen,
+    routingNoticeOpen,
+    setRoutingNoticeOpen,
+    setPendingNetworkTool,
+    handleToggleDirections,
+    confirmEnableDirections,
+    handleToggleReverseGeocode,
+    confirmEnableReverseGeocode,
+    openNetworkTool,
+    confirmOpenNetworkTool,
+  };
+}

--- a/apps/geolibre-desktop/src/hooks/useOsmPbfLoader.ts
+++ b/apps/geolibre-desktop/src/hooks/useOsmPbfLoader.ts
@@ -1,0 +1,202 @@
+import { useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  addOsmPbfLayers,
+  loadOsmPbf,
+  osmPbfBaseName,
+  OSM_PBF_SIZE_WARN_BYTES,
+} from "../lib/osm-pbf-loader";
+import { isHttpUrl, openLocalDataFileWithFallback } from "../lib/tauri-io";
+import {
+  type AppApi,
+  DEFAULT_OSM_PBF_URL,
+} from "../components/layout/toolbar/constants";
+
+/** A pending large-file confirmation before parsing an OSM PBF extract. */
+export interface OsmPbfConfirm {
+  data: ArrayBuffer;
+  baseName: string;
+  sourcePath: string;
+  sizeMb: number;
+}
+
+/**
+ * Manages the OSM PBF "Add Data" flow: the URL/file dialog, the large-file
+ * confirmation, the in-flight parse (abortable), and adding the parsed layers.
+ *
+ * @param appApi - The live app API used to add layers and fetch buffers.
+ * @param setActionError - Setter for the shared toolbar error dialog.
+ * @returns Dialog state and handlers consumed by the toolbar.
+ */
+export function useOsmPbfLoader(
+  appApi: AppApi,
+  setActionError: (message: string | null) => void,
+) {
+  const { t } = useTranslation();
+  const [loading, setLoading] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [url, setUrl] = useState(DEFAULT_OSM_PBF_URL);
+  const [confirm, setConfirm] = useState<OsmPbfConfirm | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const runOsmPbf = async (
+    data: ArrayBuffer,
+    baseName: string,
+    sourcePath: string,
+  ) => {
+    // Reuse a controller already started for the URL fetch, else make one, so
+    // the loading dialog's Cancel/dismiss can abort the in-flight parse.
+    const controller = abortRef.current ?? new AbortController();
+    abortRef.current = controller;
+    if (controller.signal.aborted) {
+      abortRef.current = null;
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      const layers = await loadOsmPbf(data, controller.signal);
+      const added = addOsmPbfLayers(
+        appApi.addGeoJsonLayer,
+        baseName,
+        sourcePath,
+        layers,
+      );
+      if (added === 0) {
+        setActionError(t("toolbar.error.osmPbfNoFeatures"));
+      } else if (layers.bounds) {
+        appApi.fitBounds?.(layers.bounds);
+      }
+    } catch (err) {
+      // A user cancel (abort) is not an error.
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      const base =
+        err instanceof Error
+          ? err.message
+          : t("toolbar.error.couldNotLoadOsmPbf");
+      // Bare .pbf is also the Mapbox Vector Tile extension; hint at it on
+      // failure. The message + hint live in one catalog key so each locale
+      // controls how the two sentences join (e.g. no space in CJK).
+      setActionError(
+        t("toolbar.error.osmPbfLoadFailedWithHint", { message: base }),
+      );
+    } finally {
+      setLoading(false);
+      if (abortRef.current === controller) abortRef.current = null;
+    }
+  };
+
+  const cancel = () => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setLoading(false);
+  };
+
+  // Large extracts can exhaust browser memory; confirm before parsing.
+  const startOsmPbf = (
+    data: ArrayBuffer,
+    baseName: string,
+    sourcePath: string,
+  ) => {
+    if (data.byteLength >= OSM_PBF_SIZE_WARN_BYTES) {
+      setConfirm({
+        data,
+        baseName,
+        sourcePath,
+        sizeMb: Math.round(data.byteLength / (1024 * 1024)),
+      });
+      return;
+    }
+    void runOsmPbf(data, baseName, sourcePath);
+  };
+
+  const handleChooseFile = async () => {
+    setDialogOpen(false);
+    try {
+      const result = await openLocalDataFileWithFallback({
+        filters: [{ name: "OSM PBF", extensions: ["pbf", "osm.pbf"] }],
+        accept: ".pbf,.osm.pbf",
+        readBinary: true,
+      });
+      if (!result?.data) return;
+      const fileName = result.path.split(/[/\\]/).pop() || "osm";
+      startOsmPbf(result.data, osmPbfBaseName(fileName), result.path);
+    } catch (err) {
+      setActionError(
+        err instanceof Error
+          ? err.message
+          : t("toolbar.error.couldNotOpenOsmPbf"),
+      );
+    }
+  };
+
+  const handleLoadUrl = async () => {
+    const trimmedUrl = url.trim();
+    if (!isHttpUrl(trimmedUrl)) {
+      setActionError(t("toolbar.error.invalidOsmPbfUrl"));
+      return;
+    }
+    setDialogOpen(false);
+    // Start the controller before the fetch so a dismiss during download is
+    // honored (the download itself isn't abortable through the shared fetcher,
+    // but we drop the result instead of parsing/adding it).
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setLoading(true);
+    try {
+      const data = await appApi.fetchArrayBuffer?.(trimmedUrl);
+      if (controller.signal.aborted) return;
+      // Surface the user-facing message directly rather than throwing a
+      // translated Error — Error.message also feeds error boundaries and logs,
+      // which should stay locale-independent. The catch below still covers a
+      // genuine fetch failure.
+      if (!data) {
+        setLoading(false);
+        if (abortRef.current === controller) abortRef.current = null;
+        setActionError(t("toolbar.error.couldNotDownloadOsmPbf"));
+        return;
+      }
+      const fileName =
+        trimmedUrl.split("/").pop()?.split("?")[0].split("#")[0] || "osm";
+      // Keep the loading indicator up through the parse for small files
+      // (runOsmPbf re-sets it and clears it in finally); only stop it here when
+      // a large file will instead show the confirm dialog, to avoid a flicker.
+      if (data.byteLength >= OSM_PBF_SIZE_WARN_BYTES) setLoading(false);
+      startOsmPbf(data, osmPbfBaseName(fileName), trimmedUrl);
+    } catch (err) {
+      setLoading(false);
+      if (abortRef.current === controller) abortRef.current = null;
+      setActionError(
+        err instanceof Error
+          ? err.message
+          : t("toolbar.error.couldNotDownloadOsmPbf"),
+      );
+    }
+  };
+
+  // Run a confirmed large-file parse and clear the confirmation.
+  const runConfirmed = () => {
+    const pending = confirm;
+    setConfirm(null);
+    if (pending) {
+      void runOsmPbf(pending.data, pending.baseName, pending.sourcePath);
+    }
+  };
+
+  return {
+    loading,
+    dialogOpen,
+    setDialogOpen,
+    url,
+    setUrl,
+    confirm,
+    setConfirm,
+    // True while a load is in flight or a large-file confirm is pending; used to
+    // disable the Add Data menu entry.
+    busy: loading || confirm !== null,
+    handleChooseFile,
+    handleLoadUrl,
+    cancel,
+    runConfirmed,
+  };
+}

--- a/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
@@ -1,0 +1,313 @@
+import {
+  DEFAULT_PROJECT_NAME,
+  projectFromStore,
+  serializeProject,
+  useAppStore,
+} from "@geolibre/core";
+import { type FormEvent, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { getPluginManager } from "./usePlugins";
+import { useDesktopSettingsStore } from "./useDesktopSettings";
+import {
+  isHttpUrl,
+  isTauri,
+  openProjectFile,
+  openRecentProjectFile,
+  RecentProjectGoneError,
+  saveProjectFile,
+  saveProjectFileToPath,
+} from "../lib/tauri-io";
+import { mergeStringLists } from "../lib/string-lists";
+import { normalizeProjectUrl } from "../lib/urls";
+import { resolveProjectXyzLayers } from "../lib/xyz-url";
+import type { MapControllerRef } from "../components/layout/toolbar/constants";
+
+/** A pending "strip env vars before saving?" prompt. */
+export interface EnvStripPrompt {
+  count: number;
+  resolve: (choice: "strip" | "keep" | "cancel") => void;
+}
+
+/**
+ * Bundles every project file action (open from file/URL/recent, save, save as)
+ * along with the related dialog state (Open-from-URL, env-var strip prompt, and
+ * the shared action-error dialog).
+ *
+ * @param mapControllerRef - Ref to the live MapController, read when serializing.
+ * @returns Handlers and state consumed by the toolbar menus and dialogs.
+ */
+export function useProjectFileActions(mapControllerRef: MapControllerRef) {
+  const { t } = useTranslation();
+  const loadProject = useAppStore((s) => s.loadProject);
+  const setProjectPath = useAppStore((s) => s.setProjectPath);
+  const rememberRecentProject = useAppStore((s) => s.rememberRecentProject);
+  const forgetRecentProject = useAppStore((s) => s.forgetRecentProject);
+  const markSaved = useAppStore((s) => s.markSaved);
+
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [projectUrlDialogOpen, setProjectUrlDialogOpen] = useState(false);
+  const [projectUrl, setProjectUrl] = useState("");
+  const [projectUrlError, setProjectUrlError] = useState<string | null>(null);
+  const [projectUrlLoading, setProjectUrlLoading] = useState(false);
+  const [envStripPrompt, setEnvStripPrompt] = useState<EnvStripPrompt | null>(
+    null,
+  );
+  const projectUrlAbortRef = useRef<AbortController | null>(null);
+  const recentAbortRef = useRef<AbortController | null>(null);
+
+  const handleOpenFromFile = async () => {
+    const result = await openProjectFile();
+    if (result) {
+      try {
+        loadProject(
+          await resolveProjectXyzLayers(result.project),
+          result.path,
+          { rememberRecent: isTauri() },
+        );
+      } catch (error) {
+        console.error("Failed to open project", error);
+        setActionError(
+          error instanceof Error
+            ? error.message
+            : t("toolbar.error.couldNotOpenProject"),
+        );
+      }
+    }
+  };
+
+  const handleOpenFromUrl = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const normalizedUrl = normalizeProjectUrl(projectUrl);
+    if (!normalizedUrl) {
+      setProjectUrlError(t("toolbar.error.invalidProjectUrl"));
+      return;
+    }
+
+    projectUrlAbortRef.current?.abort();
+    const controller = new AbortController();
+    projectUrlAbortRef.current = controller;
+
+    setProjectUrlLoading(true);
+    setProjectUrlError(null);
+
+    try {
+      const result = await openRecentProjectFile(
+        normalizedUrl,
+        controller.signal,
+      );
+      const project = await resolveProjectXyzLayers(
+        result.project,
+        controller.signal,
+      );
+      if (controller.signal.aborted) return;
+      loadProject(project, result.path);
+      setProjectUrl("");
+      setProjectUrlDialogOpen(false);
+    } catch (error) {
+      if (controller.signal.aborted) return;
+      console.error("Failed to open project URL", error);
+      setProjectUrlError(
+        error instanceof Error
+          ? error.message
+          : t("toolbar.error.couldNotOpenProjectUrl"),
+      );
+    } finally {
+      if (projectUrlAbortRef.current === controller) {
+        projectUrlAbortRef.current = null;
+      }
+      setProjectUrlLoading(false);
+    }
+  };
+
+  const handleOpenRecent = async (path: string) => {
+    // Cancel any previous in-flight open so rapid clicks cannot race and let a
+    // stale fetch win by resolving last.
+    recentAbortRef.current?.abort();
+    const controller = new AbortController();
+    recentAbortRef.current = controller;
+
+    let result: Awaited<ReturnType<typeof openRecentProjectFile>>;
+
+    try {
+      result = await openRecentProjectFile(path, controller.signal);
+    } catch (error) {
+      if (controller.signal.aborted) return;
+      // Only drop the entry when the project is permanently gone; preserve it
+      // for transient failures (network timeout, 5xx, momentary IO error).
+      if (error instanceof RecentProjectGoneError) {
+        forgetRecentProject(path);
+      }
+      console.error("Failed to open recent project", error);
+      setActionError(
+        error instanceof Error
+          ? error.message
+          : t("toolbar.error.couldNotOpenRecentProject"),
+      );
+      return;
+    }
+
+    try {
+      const project = await resolveProjectXyzLayers(
+        result.project,
+        controller.signal,
+      );
+      if (controller.signal.aborted) return;
+      loadProject(project, result.path);
+    } catch (error) {
+      if (controller.signal.aborted) return;
+      console.error("Failed to load recent project", error);
+      setActionError(
+        error instanceof Error
+          ? error.message
+          : t("toolbar.error.couldNotLoadRecentProject"),
+      );
+    } finally {
+      if (recentAbortRef.current === controller) {
+        recentAbortRef.current = null;
+      }
+    }
+  };
+
+  // Build the current project from live store + map state and serialize it.
+  // Shared by Save/Save As and the Share action so they all capture identical
+  // project content (including the current map view and plugin state).
+  const buildCurrentProject = (nameOverride?: string) => {
+    const state = useAppStore.getState();
+    const defaultProjectName =
+      nameOverride?.trim() || state.projectName.trim() || DEFAULT_PROJECT_NAME;
+    const pluginManifestUrls = mergeStringLists(
+      state.projectPlugins?.manifestUrls ?? [],
+      useDesktopSettingsStore.getState().desktopSettings.pluginManifestUrls,
+    );
+    const project = projectFromStore({
+      projectName: defaultProjectName,
+      mapView: mapControllerRef.current?.readView() ?? state.mapView,
+      basemapStyleUrl: state.basemapStyleUrl,
+      basemapVisible: state.basemapVisible,
+      basemapOpacity: state.basemapOpacity,
+      layers: state.layers,
+      layerGroups: state.layerGroups,
+      preferences: state.preferences,
+      plugins: {
+        ...getPluginManager().getProjectState(),
+        manifestUrls: pluginManifestUrls,
+      },
+      legend: state.legend,
+      storymap: state.storymap,
+      models: state.models,
+      metadata: state.metadata,
+    });
+    return {
+      project,
+      defaultProjectName,
+      content: serializeProject(project),
+      // Expose the path read from this same snapshot so callers don't take a
+      // second `getState()` read that could be misread as a separate instant.
+      projectPath: state.projectPath,
+    };
+  };
+
+  // Ask whether to strip environment variables before writing the file. The
+  // promise resolves when the user picks an option in the dialog.
+  const askStripEnvVars = (count: number) =>
+    new Promise<"strip" | "keep" | "cancel">((resolve) => {
+      setEnvStripPrompt({ count, resolve });
+    });
+
+  const resolveEnvStripPrompt = (choice: "strip" | "keep" | "cancel") => {
+    // Resolve outside the state updater (updaters must be side-effect free).
+    envStripPrompt?.resolve(choice);
+    setEnvStripPrompt(null);
+  };
+
+  const saveProject = async (options?: {
+    saveAs?: boolean;
+  }): Promise<boolean> => {
+    const { project, defaultProjectName, content, projectPath } =
+      buildCurrentProject();
+    // Env vars (possibly API keys) are serialized in plain text. If any are set,
+    // offer to strip them from the saved file before writing.
+    let contentToSave = content;
+    const envVarCount = (project.preferences.environmentVariables ?? []).filter(
+      (variable) => variable.key.trim(),
+    ).length;
+    if (envVarCount > 0) {
+      const choice = await askStripEnvVars(envVarCount);
+      if (choice === "cancel") return false;
+      if (choice === "strip") {
+        contentToSave = serializeProject({
+          ...project,
+          preferences: { ...project.preferences, environmentVariables: [] },
+        });
+      }
+    }
+    // Projects opened from a URL have no writable path, so both Save and
+    // Save As fall back to the save dialog for them.
+    const existingLocalPath =
+      projectPath && !isHttpUrl(projectPath) ? projectPath : null;
+    let path: string | null;
+    try {
+      path =
+        !options?.saveAs && existingLocalPath
+          ? await saveProjectFileToPath(contentToSave, existingLocalPath)
+          : await saveProjectFile(
+              contentToSave,
+              existingLocalPath ?? `${defaultProjectName}.geolibre.json`,
+            );
+    } catch (error) {
+      console.error("Failed to save project", error);
+      setActionError(
+        error instanceof Error
+          ? error.message
+          : t("toolbar.error.couldNotSaveProject"),
+      );
+      return false;
+    }
+    if (!path) return false;
+    setProjectPath(path);
+    rememberRecentProject({
+      path,
+      name: project.name,
+      openedAt: new Date().toISOString(),
+    });
+    markSaved();
+    return true;
+  };
+
+  const handleSave = () => saveProject();
+  const handleSaveAs = () => saveProject({ saveAs: true });
+
+  // Open-change handler for the Open-from-URL dialog; aborts an in-flight fetch
+  // and resets the form when the dialog closes.
+  const handleProjectUrlDialogOpenChange = (open: boolean) => {
+    setProjectUrlDialogOpen(open);
+    if (!open) {
+      projectUrlAbortRef.current?.abort();
+      projectUrlAbortRef.current = null;
+      setProjectUrl("");
+      setProjectUrlError(null);
+      setProjectUrlLoading(false);
+    }
+  };
+
+  return {
+    actionError,
+    setActionError,
+    projectUrlDialogOpen,
+    setProjectUrlDialogOpen,
+    handleProjectUrlDialogOpenChange,
+    projectUrl,
+    setProjectUrl,
+    projectUrlError,
+    setProjectUrlError,
+    projectUrlLoading,
+    envStripPrompt,
+    resolveEnvStripPrompt,
+    handleOpenFromFile,
+    handleOpenFromUrl,
+    handleOpenRecent,
+    buildCurrentProject,
+    handleSave,
+    handleSaveAs,
+  };
+}

--- a/apps/geolibre-desktop/src/hooks/useToolbarPanels.ts
+++ b/apps/geolibre-desktop/src/hooks/useToolbarPanels.ts
@@ -1,0 +1,221 @@
+import {
+  closeBookmarkPanel,
+  closeColorbarPanel,
+  closeHtmlPanel,
+  closeLegendPanel,
+  closeMeasurePanel,
+  closeMinimapPanel,
+  closePrintPanel,
+  closeSearchPlacesPanel,
+  closeViewStatePanel,
+  isBookmarkPanelVisible,
+  isColorbarPanelVisible,
+  isEarthEnginePanelVisible,
+  isHtmlPanelVisible,
+  isLegendPanelVisible,
+  isMeasurePanelVisible,
+  isMinimapPanelVisible,
+  isPrintPanelVisible,
+  isSearchPlacesPanelVisible,
+  isViewStatePanelVisible,
+  openBookmarkPanel,
+  openColorbarPanel,
+  openHtmlPanel,
+  openLegendPanel,
+  openMeasurePanel,
+  openMinimapPanel,
+  openPrintPanel,
+  openSearchPlacesPanel,
+  openViewStatePanel,
+  subscribeBookmarkPanel,
+  subscribeColorbarPanel,
+  subscribeEarthEnginePanel,
+  subscribeHtmlPanel,
+  subscribeLegendPanel,
+  subscribeMeasurePanel,
+  subscribeMinimapPanel,
+  subscribePrintPanel,
+  subscribeSearchPlacesPanel,
+  subscribeViewStatePanel,
+  toggleEarthEnginePanel,
+} from "@geolibre/plugins";
+import { useSyncExternalStore } from "react";
+import type { AppApi } from "../components/layout/toolbar/constants";
+
+/** Visibility flag plus a toggle handler for a single toolbar panel. */
+export interface ToolbarPanel {
+  visible: boolean;
+  toggle: () => void;
+}
+
+/** Visibility + toggle state for every panel surfaced in the toolbar menus. */
+export interface ToolbarPanels {
+  searchPlaces: ToolbarPanel;
+  print: ToolbarPanel;
+  colorbar: ToolbarPanel;
+  legend: ToolbarPanel;
+  html: ToolbarPanel;
+  measure: ToolbarPanel;
+  bookmark: ToolbarPanel;
+  minimap: ToolbarPanel;
+  viewState: ToolbarPanel;
+  earthEngine: ToolbarPanel;
+}
+
+/**
+ * Subscribe to the external panel stores and expose a `{ visible, toggle }`
+ * pair per panel. This collapses the toolbar's many repetitive
+ * `useSyncExternalStore` + handler blocks into one hook.
+ *
+ * @param appApi - The live app API used to open/close panels.
+ * @returns Visibility flags and toggle handlers for each toolbar panel.
+ */
+export function useToolbarPanels(appApi: AppApi): ToolbarPanels {
+  const searchPlacesVisible = useSyncExternalStore(
+    subscribeSearchPlacesPanel,
+    isSearchPlacesPanelVisible,
+    isSearchPlacesPanelVisible,
+  );
+  const printVisible = useSyncExternalStore(
+    subscribePrintPanel,
+    isPrintPanelVisible,
+    isPrintPanelVisible,
+  );
+  const colorbarVisible = useSyncExternalStore(
+    subscribeColorbarPanel,
+    isColorbarPanelVisible,
+    isColorbarPanelVisible,
+  );
+  const legendVisible = useSyncExternalStore(
+    subscribeLegendPanel,
+    isLegendPanelVisible,
+    isLegendPanelVisible,
+  );
+  const htmlVisible = useSyncExternalStore(
+    subscribeHtmlPanel,
+    isHtmlPanelVisible,
+    isHtmlPanelVisible,
+  );
+  const measureVisible = useSyncExternalStore(
+    subscribeMeasurePanel,
+    isMeasurePanelVisible,
+    isMeasurePanelVisible,
+  );
+  const bookmarkVisible = useSyncExternalStore(
+    subscribeBookmarkPanel,
+    isBookmarkPanelVisible,
+    isBookmarkPanelVisible,
+  );
+  const minimapVisible = useSyncExternalStore(
+    subscribeMinimapPanel,
+    isMinimapPanelVisible,
+    isMinimapPanelVisible,
+  );
+  const viewStateVisible = useSyncExternalStore(
+    subscribeViewStatePanel,
+    isViewStatePanelVisible,
+    isViewStatePanelVisible,
+  );
+  const earthEngineVisible = useSyncExternalStore(
+    subscribeEarthEnginePanel,
+    isEarthEnginePanelVisible,
+    isEarthEnginePanelVisible,
+  );
+
+  return {
+    searchPlaces: {
+      visible: searchPlacesVisible,
+      toggle: () => {
+        if (searchPlacesVisible) {
+          closeSearchPlacesPanel();
+          return;
+        }
+        openSearchPlacesPanel(appApi);
+      },
+    },
+    print: {
+      visible: printVisible,
+      toggle: () => {
+        if (printVisible) {
+          closePrintPanel();
+          return;
+        }
+        openPrintPanel(appApi);
+      },
+    },
+    colorbar: {
+      visible: colorbarVisible,
+      toggle: () => {
+        if (colorbarVisible) {
+          closeColorbarPanel(appApi);
+          return;
+        }
+        openColorbarPanel(appApi);
+      },
+    },
+    legend: {
+      visible: legendVisible,
+      toggle: () => {
+        if (legendVisible) {
+          closeLegendPanel(appApi);
+          return;
+        }
+        openLegendPanel(appApi);
+      },
+    },
+    html: {
+      visible: htmlVisible,
+      toggle: () => {
+        if (htmlVisible) {
+          closeHtmlPanel(appApi);
+          return;
+        }
+        openHtmlPanel(appApi);
+      },
+    },
+    measure: {
+      visible: measureVisible,
+      toggle: () => {
+        if (measureVisible) {
+          closeMeasurePanel(appApi);
+          return;
+        }
+        openMeasurePanel(appApi);
+      },
+    },
+    bookmark: {
+      visible: bookmarkVisible,
+      toggle: () => {
+        if (bookmarkVisible) {
+          closeBookmarkPanel(appApi);
+          return;
+        }
+        openBookmarkPanel(appApi);
+      },
+    },
+    minimap: {
+      visible: minimapVisible,
+      toggle: () => {
+        if (minimapVisible) {
+          closeMinimapPanel(appApi);
+          return;
+        }
+        openMinimapPanel(appApi);
+      },
+    },
+    viewState: {
+      visible: viewStateVisible,
+      toggle: () => {
+        if (viewStateVisible) {
+          closeViewStatePanel(appApi);
+          return;
+        }
+        openViewStatePanel(appApi);
+      },
+    },
+    earthEngine: {
+      visible: earthEngineVisible,
+      toggle: () => toggleEarthEnginePanel(appApi),
+    },
+  };
+}

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -362,6 +362,7 @@
       "shareEllipsis": "Share...",
       "collaborateEllipsis": "Collaborate...",
       "printEllipsis": "Print...",
+      "printLayoutEllipsis": "Print Layout...",
       "undo": "Undo",
       "redo": "Redo",
       "sectionFiles": "Files",


### PR DESCRIPTION
## Summary

Addresses the TopToolbar half of #350. `TopToolbar.tsx` was a ~2850-line god-component (~53 hook calls) holding state and JSX for every toolbar menu and dialog. This is a **pure refactor with no behavior change**: it extracts the menus into per-menu components and the cross-cutting logic into hooks, leaving `TopToolbar` as a thin composition root.

`TopToolbar.tsx`: **2851 → 913 lines**. The remaining bulk is the command registry, which is intentionally kept in one place as the single source of truth shared by the command palette, global shortcuts, and the keyboard cheat sheet.

## What moved

**New menu components** (`components/layout/toolbar/`), each pulling its own store setters where possible and receiving the rest via a small typed props bag:
- `ProjectMenu`, `EditMenu`, `AddDataMenu`, `ProcessingMenu`, `ControlsMenu`, `PluginsMenu`, `HelpMenu`

**New dialog components** (cohesive groups, driven by their owning hook):
- `OsmPbfDialogs`, `ConsentNoticeDialogs`, `ProjectFileDialogs`

**New hooks** (`hooks/`):
- `useToolbarPanels` - collapses the ~12 repetitive `useSyncExternalStore` + toggle blocks into one hook returning `{ visible, toggle }` per panel
- `useProjectFileActions` - open from file/URL/recent, save/save-as, `buildCurrentProject`, env-strip prompt, and the shared action-error dialog state
- `useOsmPbfLoader` - the OSM PBF add flow (URL/file dialog, large-file confirm, abortable parse)
- `useConsentGatedActions` - the one-time consent gates for Directions, reverse geocode, and the network tools

**Shared module** `toolbar/constants.ts` - module-level constants, the command-metadata arrays, helper functions, and the shared `ToolbarChrome`/`AddLayerHandlers` types.

## Verification

- `npm run build` - passes
- `tsc -b` typecheck - passes
- `npm run test:frontend` - 826 pass, 0 fail
- `eslint` + full pre-commit - passes

Logic was moved verbatim (handlers, comments, JSX, and the exact command order/ids are preserved), so the command palette, shortcuts, and every menu/dialog behave identically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Add data” support for GeoParquet, FlatGeobuf, PMTiles, Zarr, NetCDF, 3D Tiles, and DuckDB.
  * Introduced consent-based prompts for directions, reverse geocoding, and routing/network tools.
* **Refactor**
  * Reorganized the desktop toolbar into modular menus and dialogs for cleaner interactions and consolidated “Add data,” project, processing, controls, plugins, and help flows.
  * Streamlined project file and OSM PBF loading experiences, including clearer prompts and error handling.
* **Documentation**
  * Added a new print-layout localization string for the toolbar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->