### PR TITLE
feat(desktop): make attribute table on-demand, hidden by default

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -48,7 +48,6 @@ import {
   Plus,
   RotateCcw,
   Settings,
-  TableProperties,
   Type,
   Trash2,
   TriangleAlert,
@@ -583,17 +582,6 @@ export function SettingsDialog({
               >
                 {t("settings.layout.showStylePanel")}
               </DropdownMenuCheckboxItem>
-              <DropdownMenuCheckboxItem
-                checked={desktopSettings.layout.attributePanelVisible}
-                onCheckedChange={(checked: boolean) =>
-                  updateSavedLayoutSettings({
-                    attributePanelVisible: checked === true,
-                  })
-                }
-                onSelect={(event: Event) => event.preventDefault()}
-              >
-                {t("settings.layout.showAttributePanel")}
-              </DropdownMenuCheckboxItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem
                 onSelect={() => {
@@ -885,22 +873,6 @@ export function SettingsDialog({
                       />
                       <PanelRight className="h-4 w-4 text-muted-foreground" />
                       <span>{t("settings.layout.showStylePanel")}</span>
-                    </label>
-                    <label className="flex items-center gap-3 rounded-md border p-3 text-sm">
-                      <input
-                        className="h-4 w-4"
-                        type="checkbox"
-                        checked={
-                          draftDesktopSettings.layout.attributePanelVisible
-                        }
-                        onChange={(event) =>
-                          updateDraftLayoutSettings({
-                            attributePanelVisible: event.target.checked,
-                          })
-                        }
-                      />
-                      <TableProperties className="h-4 w-4 text-muted-foreground" />
-                      <span>{t("settings.layout.showAttributePanel")}</span>
                     </label>
                   </div>
                   <div className="rounded-md border bg-muted/40 p-3 text-xs text-muted-foreground">

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -1149,8 +1149,8 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
   };
 
   // Hidden by default: render nothing when closed. The panel is opened on
-  // demand via the "Open attribute table" action in a vector layer's context
-  // menu (LayerPanel), which sets attributeTableOpen to true.
+  // demand from a vector layer's context menu, which sets attributeTableOpen
+  // to true.
   if (!attributeTableOpen) {
     return null;
   }

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -48,7 +48,6 @@ import {
   MoreHorizontal,
   Pencil,
   PanelBottomClose,
-  PanelBottomOpen,
   Plus,
   RotateCcw,
   Save,
@@ -1149,25 +1148,11 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
     );
   };
 
+  // Hidden by default: render nothing when closed. The panel is opened on
+  // demand via the "Open attribute table" action in a vector layer's context
+  // menu (LayerPanel), which sets attributeTableOpen to true.
   if (!attributeTableOpen) {
-    return (
-      <section className="flex h-11 shrink-0 items-center gap-2 border-t bg-card px-2">
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8"
-          title="Expand attribute table"
-          aria-label="Expand attribute table"
-          onClick={() => setAttributeTableOpen(true)}
-        >
-          <PanelBottomOpen className="h-4 w-4" />
-        </Button>
-        <TableProperties className="h-4 w-4 text-muted-foreground" />
-        <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-          Attribute table
-        </span>
-      </section>
-    );
+    return null;
   }
 
   return (

--- a/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
+++ b/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
@@ -28,7 +28,6 @@ export interface DesktopSettings {
 }
 
 export interface DesktopLayoutSettings {
-  attributePanelVisible: boolean;
   layerPanelVisible: boolean;
   showProjectInfo: boolean;
   stylePanelVisible: boolean;
@@ -41,7 +40,6 @@ interface DesktopSettingsState {
 }
 
 export const DEFAULT_DESKTOP_LAYOUT_SETTINGS: DesktopLayoutSettings = {
-  attributePanelVisible: true,
   layerPanelVisible: true,
   showProjectInfo: true,
   stylePanelVisible: true,
@@ -90,10 +88,6 @@ function normalizeDesktopLayoutSettings(
   // cannot smuggle non-boolean values into the layout settings.
   const candidate = layout as Partial<DesktopLayoutSettings>;
   return {
-    attributePanelVisible:
-      typeof candidate.attributePanelVisible === "boolean"
-        ? candidate.attributePanelVisible
-        : DEFAULT_DESKTOP_LAYOUT_SETTINGS.attributePanelVisible,
     layerPanelVisible:
       typeof candidate.layerPanelVisible === "boolean"
         ? candidate.layerPanelVisible

--- a/apps/geolibre-desktop/src/hooks/useLayoutOptions.ts
+++ b/apps/geolibre-desktop/src/hooks/useLayoutOptions.ts
@@ -38,6 +38,7 @@ export function layoutOptionsFromLocation(
 ): LayoutOptions {
   if (typeof window === "undefined") {
     return {
+      attributePanelVisible: true,
       compact: false,
       statusBarVisible: true,
       toolbarVisible: true,
@@ -75,9 +76,10 @@ export function layoutOptionsFromLocation(
   const stylePanelVisible = panelsHidden
     ? false
     : layoutSettings.stylePanelVisible;
-  const attributePanelVisible = panelsHidden
-    ? false
-    : layoutSettings.attributePanelVisible;
+  // The attribute table is hidden by default and opened on demand from a
+  // vector layer's context menu, so it has no persisted settings toggle; it
+  // only needs to be unmounted when the embed chrome is hidden.
+  const attributePanelVisible = !panelsHidden;
 
   return {
     attributePanelVisible,


### PR DESCRIPTION
## Summary

The attribute table panel is now **hidden by default** and only opens when a user picks **"Open attribute table"** from a vector layer's context menu.

## Changes

- **`AttributeTable.tsx`**: when the table is closed (`attributeTableOpen === false`), the component now renders `null` instead of a persistent collapsed bar at the bottom of the GUI. Removed the now-unused `PanelBottomOpen` icon import.
- **`SettingsDialog.tsx`**: removed the now-redundant **"Show attribute panel"** toggle from both the quick Settings menu and the Layout settings section. It could leave the checkbox checked while nothing was visible, and unchecking it would silently break the context-menu action. Removed the now-unused `TableProperties` import.

## Notes

- The `attributePanelVisible` flag is retained (defaults to `true`) so the panel still mounts and the context-menu action works; it remains honored for URL-param embed control (`?maponly`, `?panels=hidden`).
- The `showAttributePanel` i18n strings are left in the locale files (harmless when unused).
- The existing **"Open attribute table"** context-menu action in `LayerPanel.tsx` (GeoJSON / DuckDB query layers) already wires this up; no change needed there.

## Testing

- `pre-commit run --files ...` passed (includes full npm build + eslint).
- `tsc -b` on the desktop app: clean.
- `tests/layout-options.test.ts`: green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed the attribute panel toggle from the layout settings dialog and layout dropdown options.
  * Updated attribute panel behavior so the attribute table is fully hidden when the panel is closed (no collapsed/expand header).
  * Adjusted layout settings handling so attribute panel visibility is determined consistently when loading layouts, including non-browser scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->