### PR TITLE
fix: resolve raster blob fetch, gpkg thread crash, and invisible non-Web-Mercator COGs (#376)

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -66,7 +66,7 @@
     "maplibre-gl-nasa-earthdata": "^0.1.2",
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.2.0",
+    "maplibre-gl-raster": "^0.2.1",
     "maplibre-gl-streetview": "^0.6.0",
     "maplibre-gl-swipe": "^0.7.1",
     "maplibre-gl-time-slider": "^1.0.3",

--- a/apps/geolibre-desktop/src-tauri/tauri.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' https: http://127.0.0.1:* http://localhost:* wss://collab.geolibre.app ws://127.0.0.1:* ws://localhost:*; img-src 'self' data: blob: https:; media-src 'self' blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net/npm/ https://cdn.jsdelivr.net/pyodide/ https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'",
+      "csp": "default-src 'self'; connect-src 'self' blob: data: https: http://127.0.0.1:* http://localhost:* wss://collab.geolibre.app ws://127.0.0.1:* ws://localhost:*; img-src 'self' data: blob: https:; media-src 'self' blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net/npm/ https://cdn.jsdelivr.net/pyodide/ https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'",
       "capabilities": ["default"]
     }
   },

--- a/apps/geolibre-desktop/src-tauri/tauri.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' blob: data: https: http://127.0.0.1:* http://localhost:* wss://collab.geolibre.app ws://127.0.0.1:* ws://localhost:*; img-src 'self' data: blob: https:; media-src 'self' blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net/npm/ https://cdn.jsdelivr.net/pyodide/ https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'",
+      "csp": "default-src 'self'; connect-src 'self' blob: https: http://127.0.0.1:* http://localhost:* wss://collab.geolibre.app ws://127.0.0.1:* ws://localhost:*; img-src 'self' data: blob: https:; media-src 'self' blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net/npm/ https://cdn.jsdelivr.net/pyodide/ https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'",
       "capabilities": ["default"]
     }
   },

--- a/apps/geolibre-desktop/src/lib/gpkg-ogr-contents.ts
+++ b/apps/geolibre-desktop/src/lib/gpkg-ogr-contents.ts
@@ -156,8 +156,13 @@ export function ensureGpkgFeatureCountSync(
             { ":name": tableName, ":count": count },
           );
         }
-      } catch {
-        // Leave this table to GDAL's normal error path; other tables still get fixed.
+      } catch (error) {
+        // Leave this table to GDAL's normal error path; other tables still get
+        // fixed. Warn so a malformed GeoPackage is diagnosable rather than silent.
+        console.warn(
+          `[GeoLibre] Could not repair gpkg_ogr_contents for table "${tableName}":`,
+          error,
+        );
       }
     }
 

--- a/apps/geolibre-desktop/src/lib/gpkg-ogr-contents.ts
+++ b/apps/geolibre-desktop/src/lib/gpkg-ogr-contents.ts
@@ -80,7 +80,13 @@ export function ensureGpkgFeatureCountSync(
         : []),
     ]) {
       for (const row of db.exec(sql)[0]?.values ?? []) {
-        if (typeof row[0] === "string") featureTables.set(row[0].toLowerCase(), row[0]);
+        // First-seen wins: gpkg_contents is queried first, so its (spec-primary)
+        // spelling is kept as the canonical name even when gpkg_geometry_columns
+        // lists the same table with different casing.
+        const name = row[0];
+        if (typeof name === "string" && !featureTables.has(name.toLowerCase())) {
+          featureTables.set(name.toLowerCase(), name);
+        }
       }
     }
     if (featureTables.size === 0) return bytes;
@@ -98,13 +104,18 @@ export function ensureGpkgFeatureCountSync(
     const tablesWithRow = new Set<string>(); // lowercase keys
     if (hasOgrContents) {
       for (const row of db.exec(
-        "SELECT table_name, typeof(feature_count) FROM gpkg_ogr_contents",
+        "SELECT table_name, typeof(feature_count), feature_count FROM gpkg_ogr_contents",
       )[0]?.values ?? []) {
         const name = row[0];
         if (typeof name !== "string") continue;
         const key = name.toLowerCase();
         tablesWithRow.add(key);
-        if (row[1] === "integer") tablesWithValidCount.add(key);
+        // A valid cached count is a non-negative integer. GDAL uses -1 as a
+        // "dirty/invalid" sentinel and recomputes the count for it (the
+        // multithreaded path that crashes WASM), so a negative value is not safe.
+        if (row[1] === "integer" && (row[2] as number) >= 0) {
+          tablesWithValidCount.add(key);
+        }
       }
     }
 

--- a/apps/geolibre-desktop/src/lib/gpkg-ogr-contents.ts
+++ b/apps/geolibre-desktop/src/lib/gpkg-ogr-contents.ts
@@ -67,7 +67,12 @@ export function ensureGpkgFeatureCountSync(
     // the gpkg_contents row while still registering the geometry column, so
     // relying on gpkg_contents alone misses those tables. lower() so producers
     // writing 'Features'/'FEATURES' still match.
-    const featureTables = new Set<string>();
+    // SQLite identifiers are case-insensitive, but the metadata tables can
+    // disagree on casing (e.g. gpkg_contents says 'Places' while
+    // gpkg_ogr_contents says 'places'). Key everything by the lowercased name so
+    // those resolve to one table — comparing case-sensitively would otherwise
+    // report a false "missing" table and INSERT a duplicate ogr_contents row.
+    const featureTables = new Map<string, string>(); // lowercase key → canonical name
     for (const sql of [
       "SELECT table_name FROM gpkg_contents WHERE lower(data_type)='features'",
       ...(tableExists(db, "gpkg_geometry_columns")
@@ -75,7 +80,7 @@ export function ensureGpkgFeatureCountSync(
         : []),
     ]) {
       for (const row of db.exec(sql)[0]?.values ?? []) {
-        if (typeof row[0] === "string") featureTables.add(row[0]);
+        if (typeof row[0] === "string") featureTables.set(row[0].toLowerCase(), row[0]);
       }
     }
     if (featureTables.size === 0) return bytes;
@@ -89,21 +94,22 @@ export function ensureGpkgFeatureCountSync(
     // gpkg_ogr_contents row but leave feature_count NULL, so checking only for
     // the row's presence (the previous behaviour) let those files through. See
     // issues #258 and #376.
-    const tablesWithValidCount = new Set<string>();
-    const tablesWithRow = new Set<string>();
+    const tablesWithValidCount = new Set<string>(); // lowercase keys
+    const tablesWithRow = new Set<string>(); // lowercase keys
     if (hasOgrContents) {
       for (const row of db.exec(
         "SELECT table_name, typeof(feature_count) FROM gpkg_ogr_contents",
       )[0]?.values ?? []) {
         const name = row[0];
         if (typeof name !== "string") continue;
-        tablesWithRow.add(name);
-        if (row[1] === "integer") tablesWithValidCount.add(name);
+        const key = name.toLowerCase();
+        tablesWithRow.add(key);
+        if (row[1] === "integer") tablesWithValidCount.add(key);
       }
     }
 
-    const needsCount = [...featureTables].filter(
-      (name) => !tablesWithValidCount.has(name),
+    const needsCount = [...featureTables.keys()].filter(
+      (key) => !tablesWithValidCount.has(key),
     );
     if (needsCount.length === 0) return bytes;
 
@@ -115,23 +121,32 @@ export function ensureGpkgFeatureCountSync(
       );
     }
 
-    for (const tableName of needsCount) {
-      const countResult = db.exec(
-        `SELECT count(*) FROM ${quoteIdentifier(tableName)}`,
-      );
-      const count = countResult[0]?.values[0]?.[0] ?? 0;
-      if (tablesWithRow.has(tableName)) {
-        // Repair a stale/NULL count rather than INSERT (which would collide
-        // with the existing primary-key row).
-        db.run(
-          "UPDATE gpkg_ogr_contents SET feature_count = :count WHERE table_name = :name",
-          { ":name": tableName, ":count": count },
+    for (const key of needsCount) {
+      const tableName = featureTables.get(key)!;
+      // Best-effort per table: a malformed GeoPackage can register a view, a
+      // deleted table, or a virtual table that count(*) cannot read. Skipping it
+      // keeps the other feature tables repairable instead of aborting the whole
+      // file (which would leave every table unpatched).
+      try {
+        const countResult = db.exec(
+          `SELECT count(*) FROM ${quoteIdentifier(tableName)}`,
         );
-      } else {
-        db.run(
-          "INSERT INTO gpkg_ogr_contents (table_name, feature_count) VALUES (:name, :count)",
-          { ":name": tableName, ":count": count },
-        );
+        const count = countResult[0]?.values[0]?.[0] ?? 0;
+        if (tablesWithRow.has(key)) {
+          // Repair a stale/NULL count rather than INSERT (which would collide
+          // with the existing primary-key row).
+          db.run(
+            "UPDATE gpkg_ogr_contents SET feature_count = :count WHERE lower(table_name) = :name",
+            { ":name": key, ":count": count },
+          );
+        } else {
+          db.run(
+            "INSERT INTO gpkg_ogr_contents (table_name, feature_count) VALUES (:name, :count)",
+            { ":name": tableName, ":count": count },
+          );
+        }
+      } catch {
+        // Leave this table to GDAL's normal error path; other tables still get fixed.
       }
     }
 

--- a/apps/geolibre-desktop/src/lib/gpkg-ogr-contents.ts
+++ b/apps/geolibre-desktop/src/lib/gpkg-ogr-contents.ts
@@ -14,7 +14,9 @@ import type { Database, SqlJsStatic } from "sql.js";
  *   "thread constructor failed: Resource temporarily unavailable"
  *
  * Injecting `gpkg_ogr_contents` with a cached count keeps GDAL on the fast,
- * single-threaded path. See GitHub issue #258.
+ * single-threaded path. The same crash happens when the row exists but its
+ * `feature_count` is NULL/stale (GDAL recomputes it), so we repair those too.
+ * See GitHub issues #258 and #376.
  */
 
 const SQLITE_MAGIC = "SQLite format 3\0";
@@ -59,33 +61,51 @@ export function ensureGpkgFeatureCountSync(
     // Only touch real GeoPackages; gpkg_contents is mandatory in the spec.
     if (!tableExists(db, "gpkg_contents")) return bytes;
 
-    const featureTablesResult = db.exec(
-      // lower() so out-of-spec producers writing 'Features'/'FEATURES' still match.
+    // The set of feature (vector) tables is the union of two authoritative
+    // sources: gpkg_contents rows typed 'features', and every table listed in
+    // gpkg_geometry_columns. Out-of-spec producers sometimes mistype or omit
+    // the gpkg_contents row while still registering the geometry column, so
+    // relying on gpkg_contents alone misses those tables. lower() so producers
+    // writing 'Features'/'FEATURES' still match.
+    const featureTables = new Set<string>();
+    for (const sql of [
       "SELECT table_name FROM gpkg_contents WHERE lower(data_type)='features'",
-    );
-    if (
-      featureTablesResult.length === 0 ||
-      featureTablesResult[0].values.length === 0
-    ) {
-      return bytes;
+      ...(tableExists(db, "gpkg_geometry_columns")
+        ? ["SELECT table_name FROM gpkg_geometry_columns"]
+        : []),
+    ]) {
+      for (const row of db.exec(sql)[0]?.values ?? []) {
+        if (typeof row[0] === "string") featureTables.add(row[0]);
+      }
     }
-    const featureTables = featureTablesResult[0].values
-      .map((row) => row[0])
-      .filter((name): name is string => typeof name === "string");
+    if (featureTables.size === 0) return bytes;
 
     const hasOgrContents = tableExists(db, "gpkg_ogr_contents");
-    const existingCounts = hasOgrContents
-      ? new Set(
-          (
-            db.exec("SELECT table_name FROM gpkg_ogr_contents")[0]?.values ?? []
-          )
-            .map((row) => row[0])
-            .filter((name): name is string => typeof name === "string"),
-        )
-      : new Set<string>();
+    // A table is only "safe" when its cached count is a real integer. A row
+    // whose feature_count is NULL (or any non-integer) is NOT safe: GDAL treats
+    // it as unknown and recomputes the count on read, which is the multithreaded
+    // path that aborts with "thread constructor failed: Resource temporarily
+    // unavailable" on the single-threaded WASM build. Many writers create the
+    // gpkg_ogr_contents row but leave feature_count NULL, so checking only for
+    // the row's presence (the previous behaviour) let those files through. See
+    // issues #258 and #376.
+    const tablesWithValidCount = new Set<string>();
+    const tablesWithRow = new Set<string>();
+    if (hasOgrContents) {
+      for (const row of db.exec(
+        "SELECT table_name, typeof(feature_count) FROM gpkg_ogr_contents",
+      )[0]?.values ?? []) {
+        const name = row[0];
+        if (typeof name !== "string") continue;
+        tablesWithRow.add(name);
+        if (row[1] === "integer") tablesWithValidCount.add(name);
+      }
+    }
 
-    const missing = featureTables.filter((name) => !existingCounts.has(name));
-    if (missing.length === 0) return bytes;
+    const needsCount = [...featureTables].filter(
+      (name) => !tablesWithValidCount.has(name),
+    );
+    if (needsCount.length === 0) return bytes;
 
     if (!hasOgrContents) {
       db.run(
@@ -95,15 +115,24 @@ export function ensureGpkgFeatureCountSync(
       );
     }
 
-    for (const tableName of missing) {
+    for (const tableName of needsCount) {
       const countResult = db.exec(
         `SELECT count(*) FROM ${quoteIdentifier(tableName)}`,
       );
       const count = countResult[0]?.values[0]?.[0] ?? 0;
-      db.run(
-        "INSERT INTO gpkg_ogr_contents (table_name, feature_count) VALUES (:name, :count)",
-        { ":name": tableName, ":count": count },
-      );
+      if (tablesWithRow.has(tableName)) {
+        // Repair a stale/NULL count rather than INSERT (which would collide
+        // with the existing primary-key row).
+        db.run(
+          "UPDATE gpkg_ogr_contents SET feature_count = :count WHERE table_name = :name",
+          { ":name": tableName, ":count": count },
+        );
+      } else {
+        db.run(
+          "INSERT INTO gpkg_ogr_contents (table_name, feature_count) VALUES (:name, :count)",
+          { ":name": tableName, ":count": count },
+        );
+      }
     }
 
     // sql.js always exports an ArrayBuffer-backed Uint8Array; re-narrow the type.

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
         "maplibre-gl-nasa-earthdata": "^0.1.2",
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.2.0",
+        "maplibre-gl-raster": "^0.2.1",
         "maplibre-gl-streetview": "^0.6.0",
         "maplibre-gl-swipe": "^0.7.1",
         "maplibre-gl-time-slider": "^1.0.3",
@@ -17726,9 +17726,9 @@
       }
     },
     "node_modules/maplibre-gl-raster": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.2.0.tgz",
-      "integrity": "sha512-ng+PaPS1s1Sv2cDoxhk/GEr53WmAYZcwEGmy9Rmuq8TgKskrz4uFaVRLOljKHXrfLsmWjSAinLuTNWgJATM40Q==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.2.1.tgz",
+      "integrity": "sha512-xAMgz1/VlOI7fDj7Rv7QW/Utgeh/dyQBq/sns3rBMMcLsopq25EbUAw2ZGQFV19ula6YmbF+F51evmsGr7icjw==",
       "license": "MIT",
       "dependencies": {
         "@chunkd/middleware": "^11.3.0",
@@ -24229,7 +24229,7 @@
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-overture-maps": "^0.3.0",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.2.0",
+        "maplibre-gl-raster": "^0.2.1",
         "maplibre-gl-streetview": "^0.6.0",
         "maplibre-gl-swipe": "^0.7.1",
         "maplibre-gl-time-slider": "^1.0.3",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -44,7 +44,7 @@
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-overture-maps": "^0.3.0",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.2.0",
+    "maplibre-gl-raster": "^0.2.1",
     "maplibre-gl-streetview": "^0.6.0",
     "maplibre-gl-swipe": "^0.7.1",
     "maplibre-gl-time-slider": "^1.0.3",

--- a/tests/gpkg-ogr-contents.test.ts
+++ b/tests/gpkg-ogr-contents.test.ts
@@ -208,6 +208,37 @@ describe("ensureGpkgFeatureCountSync", () => {
     ]);
   });
 
+  it("updates a NULL count for a table registered only in gpkg_geometry_columns", () => {
+    // Exercises the UPDATE branch of the geometry-columns path: the table is
+    // absent from gpkg_contents but has a NULL-count gpkg_ogr_contents row, so
+    // the repair must UPDATE that row rather than INSERT a duplicate.
+    const db: Database = new SQL.Database();
+    db.run(`
+      CREATE TABLE gpkg_contents (
+        table_name TEXT NOT NULL PRIMARY KEY, data_type TEXT NOT NULL, srs_id INTEGER
+      );
+      CREATE TABLE gpkg_geometry_columns (
+        table_name TEXT NOT NULL, column_name TEXT NOT NULL,
+        geometry_type_name TEXT NOT NULL, srs_id INTEGER NOT NULL, z TINYINT NOT NULL, m TINYINT NOT NULL
+      );
+      CREATE TABLE mounds (fid INTEGER PRIMARY KEY, geom BLOB);
+      INSERT INTO gpkg_geometry_columns VALUES ('mounds', 'geom', 'POLYGON', 4326, 0, 0);
+      INSERT INTO mounds (geom) VALUES (NULL), (NULL), (NULL), (NULL);
+      CREATE TABLE gpkg_ogr_contents (
+        table_name TEXT NOT NULL PRIMARY KEY, feature_count INTEGER
+      );
+      INSERT INTO gpkg_ogr_contents (table_name, feature_count) VALUES ('mounds', NULL);
+    `);
+    const original = db.export();
+    db.close();
+
+    const patched = ensureGpkgFeatureCountSync(SQL, original);
+    assert.notEqual(patched, original);
+    assert.deepEqual(readOgrContents(patched), [
+      { table_name: "mounds", feature_count: 4 },
+    ]);
+  });
+
   it("matches table names case-insensitively across metadata tables", () => {
     // gpkg_contents and gpkg_ogr_contents disagree on casing for the same
     // (case-insensitive) SQLite table. The repair must treat them as one table

--- a/tests/gpkg-ogr-contents.test.ts
+++ b/tests/gpkg-ogr-contents.test.ts
@@ -202,8 +202,36 @@ describe("ensureGpkgFeatureCountSync", () => {
     db.close();
 
     const patched = ensureGpkgFeatureCountSync(SQL, original);
+    assert.notEqual(patched, original);
     assert.deepEqual(readOgrContents(patched), [
       { table_name: "mounds", feature_count: 2 },
+    ]);
+  });
+
+  it("matches table names case-insensitively across metadata tables", () => {
+    // gpkg_contents and gpkg_ogr_contents disagree on casing for the same
+    // (case-insensitive) SQLite table. The repair must treat them as one table
+    // and UPDATE the existing NULL row rather than INSERT a duplicate.
+    const db: Database = new SQL.Database();
+    db.run(`
+      CREATE TABLE gpkg_contents (
+        table_name TEXT NOT NULL PRIMARY KEY, data_type TEXT NOT NULL, srs_id INTEGER
+      );
+      CREATE TABLE "Places" (fid INTEGER PRIMARY KEY, geom BLOB);
+      INSERT INTO gpkg_contents VALUES ('Places', 'features', 4326);
+      INSERT INTO "Places" (geom) VALUES (NULL), (NULL), (NULL);
+      CREATE TABLE gpkg_ogr_contents (
+        table_name TEXT NOT NULL PRIMARY KEY, feature_count INTEGER
+      );
+      INSERT INTO gpkg_ogr_contents (table_name, feature_count) VALUES ('places', NULL);
+    `);
+    const original = db.export();
+    db.close();
+
+    const patched = ensureGpkgFeatureCountSync(SQL, original);
+    assert.notEqual(patched, original);
+    assert.deepEqual(readOgrContents(patched), [
+      { table_name: "places", feature_count: 3 },
     ]);
   });
 

--- a/tests/gpkg-ogr-contents.test.ts
+++ b/tests/gpkg-ogr-contents.test.ts
@@ -235,6 +235,61 @@ describe("ensureGpkgFeatureCountSync", () => {
     ]);
   });
 
+  it("deduplicates a table listed in both gpkg_contents and gpkg_geometry_columns", () => {
+    // A conformant GeoPackage registers each feature table in both tables. The
+    // union must collapse to one entry so only a single gpkg_ogr_contents row is
+    // written, not two.
+    const db: Database = new SQL.Database();
+    db.run(`
+      CREATE TABLE gpkg_contents (
+        table_name TEXT NOT NULL PRIMARY KEY, data_type TEXT NOT NULL, srs_id INTEGER
+      );
+      CREATE TABLE gpkg_geometry_columns (
+        table_name TEXT NOT NULL, column_name TEXT NOT NULL,
+        geometry_type_name TEXT NOT NULL, srs_id INTEGER NOT NULL, z TINYINT NOT NULL, m TINYINT NOT NULL
+      );
+      CREATE TABLE lakes (fid INTEGER PRIMARY KEY, geom BLOB);
+      INSERT INTO gpkg_contents VALUES ('lakes', 'features', 4326);
+      INSERT INTO gpkg_geometry_columns VALUES ('lakes', 'geom', 'POLYGON', 4326, 0, 0);
+      INSERT INTO lakes (geom) VALUES (NULL), (NULL), (NULL);
+    `);
+    const original = db.export();
+    db.close();
+
+    const patched = ensureGpkgFeatureCountSync(SQL, original);
+    assert.notEqual(patched, original);
+    assert.deepEqual(readOgrContents(patched), [
+      { table_name: "lakes", feature_count: 3 },
+    ]);
+  });
+
+  it("recomputes a negative (dirty) feature_count", () => {
+    // GDAL stores -1 as an invalid/dirty sentinel and recomputes the count for
+    // it (the multithreaded path that crashes WASM), so it must be repaired even
+    // though typeof(-1) is 'integer'.
+    const db: Database = new SQL.Database();
+    db.run(`
+      CREATE TABLE gpkg_contents (
+        table_name TEXT NOT NULL PRIMARY KEY, data_type TEXT NOT NULL, srs_id INTEGER
+      );
+      CREATE TABLE swamps (fid INTEGER PRIMARY KEY, geom BLOB);
+      INSERT INTO gpkg_contents VALUES ('swamps', 'features', 4326);
+      INSERT INTO swamps (geom) VALUES (NULL), (NULL);
+      CREATE TABLE gpkg_ogr_contents (
+        table_name TEXT NOT NULL PRIMARY KEY, feature_count INTEGER
+      );
+      INSERT INTO gpkg_ogr_contents (table_name, feature_count) VALUES ('swamps', -1);
+    `);
+    const original = db.export();
+    db.close();
+
+    const patched = ensureGpkgFeatureCountSync(SQL, original);
+    assert.notEqual(patched, original);
+    assert.deepEqual(readOgrContents(patched), [
+      { table_name: "swamps", feature_count: 2 },
+    ]);
+  });
+
   it("leaves a complete GeoPackage untouched", () => {
     const original = buildGpkg({ withOgrContents: true, featureCount: 3 });
     const patched = ensureGpkgFeatureCountSync(SQL, original);

--- a/tests/gpkg-ogr-contents.test.ts
+++ b/tests/gpkg-ogr-contents.test.ts
@@ -154,6 +154,59 @@ describe("ensureGpkgFeatureCountSync", () => {
     ]);
   });
 
+  it("repairs a NULL feature_count (the crash in issue #376)", () => {
+    // A row exists but its count is NULL, so GDAL recomputes it on read and
+    // crashes the single-threaded WASM build. The previous logic saw the row
+    // and skipped the file; the fix must overwrite the NULL with a real count.
+    const db: Database = new SQL.Database();
+    db.run(`
+      CREATE TABLE gpkg_contents (
+        table_name TEXT NOT NULL PRIMARY KEY, data_type TEXT NOT NULL, srs_id INTEGER
+      );
+      CREATE TABLE swamps (fid INTEGER PRIMARY KEY, geom BLOB);
+      INSERT INTO gpkg_contents VALUES ('swamps', 'features', 4326);
+      INSERT INTO swamps (geom) VALUES (NULL), (NULL), (NULL), (NULL), (NULL);
+      CREATE TABLE gpkg_ogr_contents (
+        table_name TEXT NOT NULL PRIMARY KEY, feature_count INTEGER
+      );
+      INSERT INTO gpkg_ogr_contents (table_name, feature_count) VALUES ('swamps', NULL);
+    `);
+    const original = db.export();
+    db.close();
+
+    const patched = ensureGpkgFeatureCountSync(SQL, original);
+    assert.notEqual(patched, original);
+    assert.deepEqual(readOgrContents(patched), [
+      { table_name: "swamps", feature_count: 5 },
+    ]);
+  });
+
+  it("counts a feature table registered only in gpkg_geometry_columns", () => {
+    // Out-of-spec producers sometimes register the geometry column without a
+    // matching gpkg_contents 'features' row; the table is still a feature table
+    // and still triggers the threaded count path, so it must be repaired.
+    const db: Database = new SQL.Database();
+    db.run(`
+      CREATE TABLE gpkg_contents (
+        table_name TEXT NOT NULL PRIMARY KEY, data_type TEXT NOT NULL, srs_id INTEGER
+      );
+      CREATE TABLE gpkg_geometry_columns (
+        table_name TEXT NOT NULL, column_name TEXT NOT NULL,
+        geometry_type_name TEXT NOT NULL, srs_id INTEGER NOT NULL, z TINYINT NOT NULL, m TINYINT NOT NULL
+      );
+      CREATE TABLE mounds (fid INTEGER PRIMARY KEY, geom BLOB);
+      INSERT INTO gpkg_geometry_columns VALUES ('mounds', 'geom', 'POLYGON', 4326, 0, 0);
+      INSERT INTO mounds (geom) VALUES (NULL), (NULL);
+    `);
+    const original = db.export();
+    db.close();
+
+    const patched = ensureGpkgFeatureCountSync(SQL, original);
+    assert.deepEqual(readOgrContents(patched), [
+      { table_name: "mounds", feature_count: 2 },
+    ]);
+  });
+
   it("leaves a complete GeoPackage untouched", () => {
     const original = buildGpkg({ withOgrContents: true, featureCount: 3 });
     const patched = ensureGpkgFeatureCountSync(SQL, original);


### PR DESCRIPTION
## Summary

Fixes all three failures reported in #376 (a follow-up to the closed #258, same reporter): desktop rasters failing with a `blob:` fetch error, some GeoPackages crashing with a thread-constructor error, and a "warped" non-Web-Mercator COG that loaded with no error but was invisible.

### 1. Desktop: every local raster fails with `Failed to fetch: blob:tauri://localhost/<uuid>`
`maplibre-gl-raster` loads a local GeoTIFF by `URL.createObjectURL(file)` and then issues HTTP **Range `fetch()`** calls against that `blob:` URL. The Tauri webview governs `fetch()` with the `connect-src` CSP directive, which did **not** include `blob:` (only `img-src`/`media-src`/`script-src`/`worker-src` did). So the webview blocked the fetch and every local COG/GeoTIFF failed.

Fix: add `blob:` to `connect-src` in `tauri.conf.json`.

### 2. Some GeoPackages crash with `thread constructor failed: Resource temporarily unavailable`
The #258 repair injects `gpkg_ogr_contents` so GDAL does not recompute the feature count via a multithreaded Arrow path that aborts on the single-threaded DuckDB-WASM build. But it only checked whether a **row** existed for each table, not whether its `feature_count` was a valid integer. A row with `feature_count = NULL` (left by many writers, or after triggers are dropped) is treated by GDAL as "unknown" and recomputed, re-triggering the crash even with the repair in place.

Fix in `gpkg-ogr-contents.ts`:
- Treat a table as needing repair when its cached count is NULL/non-integer, not just when the row is absent (UPDATE in place rather than INSERT).
- Detect feature tables registered only in `gpkg_geometry_columns` (out-of-spec producers that omit/mistype the `gpkg_contents` 'features' row).
- Match table names case-insensitively across `gpkg_contents` / `gpkg_geometry_columns` / `gpkg_ogr_contents`, and wrap each per-table repair in try/catch so one unreadable table (a view/virtual/deleted table left in malformed metadata) cannot abort repairs for the others.

### 3. A "warped" non-Web-Mercator COG loads with no error but is invisible
This lived in `maplibre-gl-raster`: COGLayer resolved any non-3857 CRS by fetching `https://epsg.io/<code>.json` at render time, in a parse step that is neither awaited nor caught, so a failed lookup left an invisible layer with no error.

Fixed upstream in opengeos/maplibre-gl-raster#9 (released as **v0.2.1**) and pulled in here by bumping the dependency to `^0.2.1`. EPSG:4326 now resolves offline (no network), other codes are delegated to a configurable resolver, and a resolution failure surfaces as a clear layer error instead of an invisible layer.

## Testing
The reporter's files are shared on a private Google Drive (sign-in required), so I reproduced every failure with synthesized GDAL/rasterio equivalents driven through the real web app with Playwright:

- **gpkg**: a GeoPackage whose `gpkg_ogr_contents.feature_count` is `NULL` reproduces the **exact** error `Invalid Error: thread constructor failed: Resource temporarily unavailable` on the old code, and loads cleanly with the fix. Missing-table, missing-count, large multi-feature, and geometry-columns-only variants all load.
- **raster (with v0.2.1)**: an EPSG:4326 COG renders with epsg.io blocked (0 epsg.io requests); a UTM COG with epsg.io blocked now shows a clear "Could not resolve coordinate system EPSG:26916…" error instead of a silent invisible layer; an online UTM COG renders unchanged.

Unit tests added for the gpkg NULL-count, geometry-columns, and case-insensitive cases. `tsc` clean; `pre-commit run --files ...` (incl. full build) passes.

Closes #376

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GeoPackage feature count synchronization to prevent crashes and ensure accurate metadata across all feature tables.

* **Dependencies**
  * Updated maplibre-gl-raster to version 0.2.1.

* **Security**
  * Enhanced connection security policy to support additional secure connection types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->