### PR TITLE
chore(deps): bump maplibre-gl-3d-tiles to ^0.5.1

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -52,7 +52,7 @@
     "jspdf": "^4.2.1",
     "mapillary-js": "^4.1.2",
     "maplibre-gl": "^5.24.0",
-    "maplibre-gl-3d-tiles": "^0.5.0",
+    "maplibre-gl-3d-tiles": "^0.5.1",
     "maplibre-gl-basemap-control": "^0.3.0",
     "maplibre-gl-components": "^0.20.4",
     "maplibre-gl-duckdb": "^0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "jspdf": "^4.2.1",
         "mapillary-js": "^4.1.2",
         "maplibre-gl": "^5.24.0",
-        "maplibre-gl-3d-tiles": "^0.5.0",
+        "maplibre-gl-3d-tiles": "^0.5.1",
         "maplibre-gl-basemap-control": "^0.3.0",
         "maplibre-gl-components": "^0.20.4",
         "maplibre-gl-duckdb": "^0.2.0",
@@ -17227,9 +17227,9 @@
       }
     },
     "node_modules/maplibre-gl-3d-tiles": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-3d-tiles/-/maplibre-gl-3d-tiles-0.5.0.tgz",
-      "integrity": "sha512-fa0ilRsJwdwHywV1vpBp8gHqRaANVHTK3/RrNN6TWjdSSWTMUhajf9jDpM2i7kCt4p9leRE19Vd/wXGu2n/tsw==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-3d-tiles/-/maplibre-gl-3d-tiles-0.5.1.tgz",
+      "integrity": "sha512-ExGmeGSK+wAQEvQEgu1VJqDK8BHxBUmwArA/8eeAqGveXwMpDOIaSeS5EIDSXNA/lyu0fu8d7D/sigj33fnXag==",
       "license": "MIT",
       "dependencies": {
         "3d-tiles-renderer": "^0.4.27",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24214,7 +24214,7 @@
         "geotiff": "^3.0.5",
         "jspdf": "^4.2.1",
         "maplibre-gl": "^5.24.0",
-        "maplibre-gl-3d-tiles": "^0.5.0",
+        "maplibre-gl-3d-tiles": "^0.5.1",
         "maplibre-gl-basemap-control": "^0.3.0",
         "maplibre-gl-components": "^0.20.4",
         "maplibre-gl-duckdb": "^0.2.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -29,7 +29,7 @@
     "geotiff": "^3.0.5",
     "jspdf": "^4.2.1",
     "maplibre-gl": "^5.24.0",
-    "maplibre-gl-3d-tiles": "^0.5.0",
+    "maplibre-gl-3d-tiles": "^0.5.1",
     "maplibre-gl-basemap-control": "^0.3.0",
     "maplibre-gl-components": "^0.20.4",
     "maplibre-gl-duckdb": "^0.2.0",


### PR DESCRIPTION
Bumps `maplibre-gl-3d-tiles` to `^0.5.1`, which includes the Android glTF texture `crossOrigin` fix (opengeos/maplibre-gl-3d-tiles#10, fixes #9): same-origin `blob:` textures now load without `crossOrigin`, so 3D Tiles / glTF models render textured in the Android WebView instead of failing with `THREE.GLTFLoader: Couldn't load texture blob:…`. http(s) textures keep CORS (no regression).

Verified: `pre-commit` (incl. `npm build`) passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the `maplibre-gl-3d-tiles` dependency to version 0.5.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->