### PR TITLE
perf(desktop): CDN-load the CereusDB wasm to shrink the build by ~9 MB

### DIFF
--- a/apps/geolibre-desktop/src/lib/cereus-loader.cdn.ts
+++ b/apps/geolibre-desktop/src/lib/cereus-loader.cdn.ts
@@ -1,0 +1,53 @@
+// CDN CereusDB loader: the default for every build (web, desktop, embed). A Vite
+// alias swaps it in for `./cereus-loader` (see vite.config.ts, gated on
+// GEOLIBRE_CEREUS_CDN) so the ~40 MB wasm blob is never emitted into dist and so
+// never embedded into the Tauri binary (it was ~8.6 MB brotli — the entire
+// 27 → 36 MB v1.3 installer growth).
+//
+// Only the wasm URL differs from the bundled loader: the JS engine is still
+// dynamically imported the same way (it is small and lives in its own lazy
+// chunk), but its WebAssembly module is fetched from jsDelivr at runtime via the
+// `wasmUrl` option instead of from a vendored `?url` asset. The URL is injected
+// by vite.config.ts, pinned to the installed package version.
+
+import type { CereusInstance } from "./cereus-loader";
+
+export type { CereusInstance };
+
+interface CereusModule {
+  CereusDB: {
+    create(options?: { wasmUrl?: string }): Promise<CereusInstance>;
+  };
+}
+
+/**
+ * Dynamically import CereusDB and initialise it with the CDN-hosted wasm.
+ *
+ * @returns An initialised CereusDB instance.
+ */
+export async function loadCereusDb(): Promise<CereusInstance> {
+  // Injected (non-null) only in the CDN build that swaps this module in. Fail
+  // fast with a clear message if this loader is somehow reached without it,
+  // rather than calling create() with an undefined wasmUrl.
+  if (!__CEREUS_WASM_CDN_URL__) {
+    throw new Error(
+      "CereusDB wasm CDN URL was not injected. This loader is only meant for " +
+        "the default build (GEOLIBRE_CEREUS_CDN=1).",
+    );
+  }
+  // The JS glue is bundled, so this import resolves to a local chunk; the network
+  // fetch happens inside create() when it loads the wasm from the CDN URL.
+  const mod = (await import("@cereusdb/standard")) as unknown as CereusModule;
+  try {
+    return await mod.CereusDB.create({ wasmUrl: __CEREUS_WASM_CDN_URL__ });
+  } catch (err) {
+    // No network, jsDelivr unreachable, or a strict CSP blocking the fetch.
+    throw new Error(
+      "Could not load the Apache Sedona SQL engine from the CDN. GeoLibre " +
+        "fetches the CereusDB WebAssembly module from jsDelivr on first use, " +
+        "so this engine needs network access and a Content-Security-Policy " +
+        "that allows connecting to cdn.jsdelivr.net.",
+      { cause: err },
+    );
+  }
+}

--- a/apps/geolibre-desktop/src/lib/cereus-loader.cdn.ts
+++ b/apps/geolibre-desktop/src/lib/cereus-loader.cdn.ts
@@ -37,6 +37,10 @@ export async function loadCereusDb(): Promise<CereusInstance> {
   }
   // The JS glue is bundled, so this import resolves to a local chunk; the network
   // fetch happens inside create() when it loads the wasm from the CDN URL.
+  // Version-pinned but not integrity-checked: the package fetches the wasm with
+  // no `integrity` option, so there is no SRI guard on the CDN binary. Accepted
+  // risk (the same trade-off as PGlite/Pyodide) — the wasm runs inside the
+  // WebAssembly sandbox and the jsDelivr URL is version-immutable.
   const mod = (await import("@cereusdb/standard")) as unknown as CereusModule;
   try {
     return await mod.CereusDB.create({ wasmUrl: __CEREUS_WASM_CDN_URL__ });

--- a/apps/geolibre-desktop/src/lib/cereus-loader.ts
+++ b/apps/geolibre-desktop/src/lib/cereus-loader.ts
@@ -1,5 +1,6 @@
-// Lazy loader for CereusDB — a WebAssembly build of Apache SedonaDB (Rust /
-// DataFusion / Arrow) that runs Sedona spatial SQL entirely in the browser.
+// Bundled (offline) loader for CereusDB — a WebAssembly build of Apache SedonaDB
+// (Rust / DataFusion / Arrow) that runs Sedona spatial SQL entirely in the
+// browser.
 //
 // The `standard` tier bundles a large (~40 MB unpacked) WASM module, so the
 // package is imported *dynamically* and lives in its own Vite chunk: it is only
@@ -10,6 +11,15 @@
 // same approach the DuckDB loader uses) and handed to `CereusDB.create` via its
 // `wasmUrl` option, so loading does not rely on `import.meta.url` resolution
 // inside the published package.
+//
+// By default this module is NOT used: a Vite alias swaps it for
+// `cereus-loader.cdn.ts` (see vite.config.ts, gated on GEOLIBRE_CEREUS_CDN) so
+// the ~40 MB `?url` wasm is dropped from the graph and never embedded into the
+// Tauri binary (it was ~8.6 MB brotli — the whole 27 → 36 MB v1.3 installer
+// growth). This bundled variant is reached only for a fully offline build
+// (GEOLIBRE_CEREUS_CDN=0). A bundler emits the asset for every `?url` import it
+// parses regardless of reachability, so the CDN/bundled choice must be a module
+// swap, not an `if` inside one module.
 
 // The WASM asset, emitted as a hashed file and referenced by URL by the bundler.
 import cereusWasmUrl from "@cereusdb/standard/wasm?url";

--- a/apps/geolibre-desktop/src/vite-env.d.ts
+++ b/apps/geolibre-desktop/src/vite-env.d.ts
@@ -10,6 +10,13 @@ declare const __GEOLIBRE_VERSION__: string;
 declare const __PGLITE_CDN_URL__: string | null;
 declare const __PGLITE_POSTGIS_CDN_URL__: string | null;
 
+// jsDelivr URL for the CereusDB (Apache Sedona) WASM blob, injected by
+// vite.config.ts and read by cereus-loader.cdn.ts. By default every build
+// (web/desktop/embed) CDN-loads it so the ~40 MB wasm never lands in dist; the
+// value is null only when GEOLIBRE_CEREUS_CDN=0 force-bundles it via the `?url`
+// import in cereus-loader.ts.
+declare const __CEREUS_WASM_CDN_URL__: string | null;
+
 declare module "virtual:bundled-plugins" {
   // Manifest paths (base-relative, no leading slash) for plugins dropped into
   // public/plugins/<id>/, discovered at build time by the bundledPlugins() Vite

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -73,25 +73,32 @@ function esmEntry(manifest: Record<string, unknown>): string {
   if (typeof importDefault === "string") return importDefault;
   return "dist/index.js";
 }
-// The PGlite packages do not expose "./package.json" via their `exports`, so
-// resolve the package entry and walk up to its package.json to read the
-// installed version and ESM entry path (so the CDN URL tracks the lockfile and
-// any future dist restructuring instead of hardcoding `/dist/index.js`).
-function installedPackage(pkg: string): { version: string; entry: string } {
-  let dir = path.dirname(pgliteCdnRequire.resolve(pkg));
+// These packages do not expose "./package.json" via their `exports`, so resolve
+// a known file inside the package and walk up to the owning package.json (the
+// one whose `name` matches) to read the installed version and entry paths — so a
+// CDN URL tracks the lockfile and any future dist restructuring instead of
+// hardcoding paths.
+function findPackageManifest(
+  startFile: string,
+  pkg: string,
+): { dir: string; manifest: Record<string, unknown> } {
+  let dir = path.dirname(startFile);
   while (dir !== path.dirname(dir)) {
-    const manifest = path.join(dir, "package.json");
     try {
-      const parsed = JSON.parse(readFileSync(manifest, "utf8"));
-      if (parsed.name === pkg) {
-        return { version: parsed.version as string, entry: esmEntry(parsed) };
-      }
+      const parsed = JSON.parse(
+        readFileSync(path.join(dir, "package.json"), "utf8"),
+      );
+      if (parsed.name === pkg) return { dir, manifest: parsed };
     } catch {
       // Not this directory's package.json; keep walking up.
     }
     dir = path.dirname(dir);
   }
   throw new Error(`Could not resolve installed version of ${pkg}`);
+}
+function installedPackage(pkg: string): { version: string; entry: string } {
+  const { manifest } = findPackageManifest(pgliteCdnRequire.resolve(pkg), pkg);
+  return { version: manifest.version as string, entry: esmEntry(manifest) };
 }
 function pgliteCdnUrl(pkg: string): string | null {
   if (!PGLITE_CDN) return null;
@@ -122,22 +129,9 @@ function cereusWasmCdnUrl(): string | null {
   // owning package.json for the installed version and the file's package-relative
   // path, so the URL tracks the lockfile and any future dist restructuring.
   const wasmFile = pgliteCdnRequire.resolve(`${pkg}/wasm`);
-  let dir = path.dirname(wasmFile);
-  while (dir !== path.dirname(dir)) {
-    try {
-      const parsed = JSON.parse(
-        readFileSync(path.join(dir, "package.json"), "utf8"),
-      );
-      if (parsed.name === pkg) {
-        const rel = path.relative(dir, wasmFile).split(path.sep).join("/");
-        return `https://cdn.jsdelivr.net/npm/${pkg}@${parsed.version}/${rel}`;
-      }
-    } catch {
-      // Not this directory's package.json; keep walking up.
-    }
-    dir = path.dirname(dir);
-  }
-  throw new Error(`Could not resolve installed version of ${pkg}`);
+  const { dir, manifest } = findPackageManifest(wasmFile, pkg);
+  const rel = path.relative(dir, wasmFile).split(path.sep).join("/");
+  return `https://cdn.jsdelivr.net/npm/${pkg}@${manifest.version}/${rel}`;
 }
 const CEREUS_WASM_CDN_URL = cereusWasmCdnUrl();
 const WMS_PROXY_PATH = "/__geolibre_wms_proxy";
@@ -420,13 +414,27 @@ function cereusCdnLoaderPlugin(): Plugin {
     },
     transform(code, id) {
       const file = id.split("?")[0].replaceAll("\\", "/");
-      if (!file.endsWith(CEREUS_WASM_GLUE) || !code.includes(CEREUS_DEFAULT_WASM_URL)) {
+      if (!file.endsWith(CEREUS_WASM_GLUE)) return null;
+      if (!code.includes(CEREUS_DEFAULT_WASM_URL)) {
+        // The glue is here but the expected expression is gone — most likely a
+        // new @cereusdb/standard shipped a different wasm-bindgen string or dist
+        // path. Warn loudly instead of silently returning null, which would let
+        // Vite re-emit the 40 MB wasm into dist with no error and a green CI.
+        this.warn(
+          `${CEREUS_WASM_GLUE} no longer contains the expected default wasm URL ` +
+            `expression; the ~40 MB wasm may be silently re-emitted into dist. ` +
+            `Update CEREUS_WASM_GLUE / CEREUS_DEFAULT_WASM_URL in vite.config.ts.`,
+        );
         return null;
       }
       // Replace the dead default-path expression so Vite never sees the asset.
-      // If the branch is somehow reached (init with no wasmUrl), throw clearly.
+      // replaceAll: wasm-bindgen can emit the pattern more than once (sync + async
+      // init paths). If the branch is somehow reached (init with no wasmUrl),
+      // throw clearly. map:null is fine — the replacement adds no newlines, so
+      // only columns on this one line shift; per-line stepping stays correct, and
+      // sourcemaps are off anyway unless TAURI_DEBUG.
       return {
-        code: code.replace(
+        code: code.replaceAll(
           CEREUS_DEFAULT_WASM_URL,
           "(()=>{throw new Error('CereusDB must be initialised with an explicit wasmUrl (GEOLIBRE_CEREUS_CDN build)')})()",
         ),

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -102,6 +102,44 @@ function pgliteCdnUrl(pkg: string): string | null {
 }
 const PGLITE_CDN_URL = pgliteCdnUrl("@electric-sql/pglite");
 const PGLITE_POSTGIS_CDN_URL = pgliteCdnUrl("@electric-sql/pglite-postgis");
+
+// CereusDB (Apache Sedona spatial SQL, compiled to WASM) ships a ~40 MB wasm
+// blob that brotli only shrinks to ~8.6 MB — the entire 27 → 36 MB desktop
+// installer growth in v1.3. Like PGlite above, fetch the wasm from jsDelivr at
+// runtime for every target (web, desktop, embed) so it never inflates any build
+// output; the small JS glue stays bundled and lazy-chunked. Override with
+// GEOLIBRE_CEREUS_CDN=0 to force-bundle the wasm for a fully offline build. The
+// URL is pinned to the installed version (so it tracks the lockfile) and jsDelivr
+// is already an allowed connect-src in both the web (docker/nginx.conf) and
+// desktop (tauri.conf.json) CSPs. Trade-off: the Sedona engine needs network on
+// first use (the desktop app already fetches PGlite, Pyodide, tiles, and the
+// DuckDB spatial extension the same way).
+const CEREUS_CDN = process.env.GEOLIBRE_CEREUS_CDN !== "0";
+function cereusWasmCdnUrl(): string | null {
+  if (!CEREUS_CDN) return null;
+  const pkg = "@cereusdb/standard";
+  // The "./wasm" export resolves straight to the .wasm file; walk up to the
+  // owning package.json for the installed version and the file's package-relative
+  // path, so the URL tracks the lockfile and any future dist restructuring.
+  const wasmFile = pgliteCdnRequire.resolve(`${pkg}/wasm`);
+  let dir = path.dirname(wasmFile);
+  while (dir !== path.dirname(dir)) {
+    try {
+      const parsed = JSON.parse(
+        readFileSync(path.join(dir, "package.json"), "utf8"),
+      );
+      if (parsed.name === pkg) {
+        const rel = path.relative(dir, wasmFile).split(path.sep).join("/");
+        return `https://cdn.jsdelivr.net/npm/${pkg}@${parsed.version}/${rel}`;
+      }
+    } catch {
+      // Not this directory's package.json; keep walking up.
+    }
+    dir = path.dirname(dir);
+  }
+  throw new Error(`Could not resolve installed version of ${pkg}`);
+}
+const CEREUS_WASM_CDN_URL = cereusWasmCdnUrl();
 const WMS_PROXY_PATH = "/__geolibre_wms_proxy";
 const WFS_PROXY_PATH = "/__geolibre_wfs_proxy";
 const GPX_PROXY_PATH = "/__geolibre_gpx_proxy";
@@ -358,6 +396,46 @@ function pgliteCdnLoaderPlugin(): Plugin {
   };
 }
 
+// Keep the ~40 MB CereusDB wasm out of `dist` (and out of the Tauri binary) in
+// two places, both required:
+//   1. Swap the bundled loader for the CDN one so cereus-loader.ts's
+//      `@cereusdb/standard/wasm?url` import is dropped from the module graph (a
+//      bundler emits the asset for every `?url` import it parses, so this must be
+//      a module swap, not an `if` inside one module — same reasoning as PGlite).
+//   2. Neutralize wasm-bindgen's own default `new URL('cereusdb_bg.wasm',
+//      import.meta.url)` inside the package glue. We always init CereusDB with an
+//      explicit `wasmUrl` (the CDN), so that default branch is dead at runtime —
+//      but Vite statically emits the asset from the `new URL(..., import.meta.url)`
+//      pattern regardless of reachability, which re-introduced the 40 MB file.
+const CEREUS_WASM_GLUE = "@cereusdb/standard/dist/wasm/cereusdb.js";
+const CEREUS_DEFAULT_WASM_URL = "new URL('cereusdb_bg.wasm', import.meta.url)";
+function cereusCdnLoaderPlugin(): Plugin {
+  const cdnLoader = path.resolve(__dirname, "src/lib/cereus-loader.cdn.ts");
+  return {
+    name: "geolibre-cereus-cdn-loader",
+    enforce: "pre",
+    resolveId(source) {
+      // Match `./cereus-loader` (and `.ts`) but never `cereus-loader.cdn`.
+      return /(?:^|\/)cereus-loader(?:\.ts)?$/.test(source) ? cdnLoader : null;
+    },
+    transform(code, id) {
+      const file = id.split("?")[0].replaceAll("\\", "/");
+      if (!file.endsWith(CEREUS_WASM_GLUE) || !code.includes(CEREUS_DEFAULT_WASM_URL)) {
+        return null;
+      }
+      // Replace the dead default-path expression so Vite never sees the asset.
+      // If the branch is somehow reached (init with no wasmUrl), throw clearly.
+      return {
+        code: code.replace(
+          CEREUS_DEFAULT_WASM_URL,
+          "(()=>{throw new Error('CereusDB must be initialised with an explicit wasmUrl (GEOLIBRE_CEREUS_CDN build)')})()",
+        ),
+        map: null,
+      };
+    },
+  };
+}
+
 function projectUrlQueryPlugin(): Plugin {
   return {
     name: "geolibre-project-url-query",
@@ -549,22 +627,24 @@ function pwaPlugin(): Plugin[] {
           },
         },
         {
-          // CDN-loaded heavy engines: Pyodide (the Python runtime + its wheels)
-          // and PGlite/PostGIS, both served version-pinned from jsDelivr (see
-          // PGLITE_CDN_URL and pyodide-config.ts). Their URLs embed the exact
-          // package version, so a redeploy/upgrade mints new URLs and CacheFirst
-          // never serves a stale engine. Caching them here is what lets the
-          // browser SQL (PostGIS) and Python features work OFFLINE after their
-          // first online use — closing the gap noted at the top of this file.
-          // jsDelivr sends permissive CORS headers, so these come back as normal
-          // (non-opaque) 200s and can be revalidated/evicted like any cache
-          // entry. When GEOLIBRE_PGLITE_CDN=0, PGlite is bundled under /assets/
-          // instead and this rule simply never matches it (Pyodide is always
-          // CDN-loaded regardless).
+          // CDN-loaded heavy engines: Pyodide (the Python runtime + its wheels),
+          // PGlite/PostGIS, and the CereusDB (Apache Sedona) wasm — all served
+          // version-pinned from jsDelivr (see PGLITE_CDN_URL, CEREUS_WASM_CDN_URL,
+          // and pyodide-config.ts). Their URLs embed the exact package version, so
+          // a redeploy/upgrade mints new URLs and CacheFirst never serves a stale
+          // engine. Caching them here is what lets the browser SQL (PostGIS),
+          // Sedona SQL, and Python features work OFFLINE after their first online
+          // use — closing the gap noted at the top of this file. jsDelivr sends
+          // permissive CORS headers, so these come back as normal (non-opaque)
+          // 200s and can be revalidated/evicted like any cache entry. When
+          // GEOLIBRE_PGLITE_CDN=0 / GEOLIBRE_CEREUS_CDN=0, those engines are
+          // bundled under /assets/ instead and this rule simply never matches them
+          // (Pyodide is always CDN-loaded regardless).
           urlPattern: ({ url }: { url: URL }) =>
             url.hostname === "cdn.jsdelivr.net" &&
             (url.pathname.startsWith("/pyodide/") ||
-              url.pathname.startsWith("/npm/@electric-sql/")),
+              url.pathname.startsWith("/npm/@electric-sql/") ||
+              url.pathname.startsWith("/npm/@cereusdb/")),
           handler: "CacheFirst",
           options: {
             cacheName: "geolibre-cdn-engines",
@@ -602,6 +682,7 @@ export default defineConfig({
   base: APP_BASE,
   plugins: [
     ...(PGLITE_CDN ? [pgliteCdnLoaderPlugin()] : []),
+    ...(CEREUS_CDN ? [cereusCdnLoaderPlugin()] : []),
     stripDuckDbWorkerSourcemapPlugin(),
     projectUrlQueryPlugin(),
     bundledPlugins(path.resolve(__dirname, "public/plugins")),
@@ -622,6 +703,7 @@ export default defineConfig({
     __GEOLIBRE_VERSION__: JSON.stringify(APP_VERSION),
     __PGLITE_CDN_URL__: JSON.stringify(PGLITE_CDN_URL),
     __PGLITE_POSTGIS_CDN_URL__: JSON.stringify(PGLITE_POSTGIS_CDN_URL),
+    __CEREUS_WASM_CDN_URL__: JSON.stringify(CEREUS_WASM_CDN_URL),
   },
   server: {
     port: 5173,


### PR DESCRIPTION
## Why

The v1.3 desktop installer grew from **27 MB → 36 MB** versus v1.2. The cause is a single asset: the Apache Sedona SQL engine (`@cereusdb/standard`, added in #353) ships a **40.6 MB WASM blob**. Vite emitted it into `dist/` and Tauri embedded the whole `dist/`, brotli-compressing the blob to ~8.6 MB — which is essentially the entire 9 MB regression.

## What

Fetch the CereusDB wasm from **jsDelivr at runtime** instead of bundling it — the same pattern PGlite and Pyodide already use — so it never lands in any build output. The small JS glue stays bundled and lazy-chunked; only the wasm binary moves to the CDN.

Two changes were both required to actually drop the asset:

1. **Loader swap.** A Vite alias plugin swaps the bundled `cereus-loader.ts` (kept as the offline fallback) for a new `cereus-loader.cdn.ts`, removing the `@cereusdb/standard/wasm?url` import from the module graph.
2. **Neutralize wasm-bindgen's default path.** The package glue contains `new URL('cereusdb_bg.wasm', import.meta.url)`. We always init with an explicit `wasmUrl`, so that branch is dead — but Vite statically emits the asset from the `new URL(..., import.meta.url)` pattern regardless of reachability, which re-introduced the 40 MB file. A `pre` transform replaces the dead expression.

## Notes

- The CDN URL is **pinned to the installed package version** (tracks the lockfile).
- jsDelivr is already an allowed `connect-src` in both the web (`docker/nginx.conf`) and desktop (`tauri.conf.json`) CSPs — no new origin.
- The web PWA's `geolibre-cdn-engines` CacheFirst rule now covers `/npm/@cereusdb/`, so the Sedona engine still works **offline after first use** (parity with PGlite/Pyodide).
- Trade-off: the Sedona engine needs network on first use (the app already fetches PGlite, Pyodide, tiles, and the DuckDB spatial extension the same way). Override with `GEOLIBRE_CEREUS_CDN=0` to force-bundle for a fully offline build.

## Verification

- `dist/` drops **148 MB → 108 MB**; the 40.6 MB `cereusdb_bg.wasm` is no longer emitted, and the pinned jsDelivr URL is injected into the build.
- `npm run build` (tsc + vite), eslint, and pre-commit all pass.
- Frontend test suite: 868 passed, 1 skipped, 0 failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CDN-based loading for the CereusDB (Apache Sedona) engine, reducing bundled application size.
  * When the CDN option is enabled, the app fetches the WebAssembly from a version-pinned CDN URL; when disabled, it uses the offline bundled version.
* **Performance / Reliability**
  * Improved service worker caching for CDN-loaded CereusDB resources for faster subsequent loads.
  * Added clearer error messaging if the CDN WebAssembly URL is unavailable or initialization fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->