### PR TITLE
fix(gpkg): repair case-mismatched and non-ASCII gpkg_ogr_contents rows (#376 follow-up)

### DIFF
--- a/apps/geolibre-desktop/src/lib/gpkg-ogr-contents.ts
+++ b/apps/geolibre-desktop/src/lib/gpkg-ogr-contents.ts
@@ -101,7 +101,7 @@ export function ensureGpkgFeatureCountSync(
     // the row's presence (the previous behaviour) let those files through. See
     // issues #258 and #376.
     const tablesWithValidCount = new Set<string>(); // lowercase keys
-    const tablesWithRow = new Set<string>(); // lowercase keys
+    const tablesWithRow = new Map<string, string>(); // lowercase key → name as stored
     if (hasOgrContents) {
       for (const row of db.exec(
         "SELECT table_name, typeof(feature_count), feature_count FROM gpkg_ogr_contents",
@@ -109,7 +109,7 @@ export function ensureGpkgFeatureCountSync(
         const name = row[0];
         if (typeof name !== "string") continue;
         const key = name.toLowerCase();
-        tablesWithRow.add(key);
+        tablesWithRow.set(key, name);
         // A valid cached count is a non-negative integer. GDAL uses -1 as a
         // "dirty/invalid" sentinel and recomputes the count for it (the
         // multithreaded path that crashes WASM), so a negative value is not safe.
@@ -143,12 +143,18 @@ export function ensureGpkgFeatureCountSync(
           `SELECT count(*) FROM ${quoteIdentifier(tableName)}`,
         );
         const count = countResult[0]?.values[0]?.[0] ?? 0;
-        if (tablesWithRow.has(key)) {
+        const storedName = tablesWithRow.get(key);
+        if (storedName !== undefined) {
           // Repair a stale/NULL count rather than INSERT (which would collide
-          // with the existing primary-key row).
+          // with the existing primary-key row). Match on the exact stored name
+          // (SQLite's lower() is ASCII-only, so a `lower(table_name) = :key`
+          // predicate would miss non-ASCII names) and normalise table_name to
+          // the canonical (gpkg_contents) casing: GDAL looks the row up with a
+          // case-sensitive `table_name = <name from gpkg_contents>`, so a
+          // wrong-cased row would not be found and would still crash.
           db.run(
-            "UPDATE gpkg_ogr_contents SET feature_count = :count WHERE lower(table_name) = :name",
-            { ":name": key, ":count": count },
+            "UPDATE gpkg_ogr_contents SET feature_count = :count, table_name = :canonical WHERE table_name = :stored",
+            { ":canonical": tableName, ":stored": storedName, ":count": count },
           );
         } else {
           db.run(

--- a/tests/gpkg-ogr-contents.test.ts
+++ b/tests/gpkg-ogr-contents.test.ts
@@ -239,10 +239,12 @@ describe("ensureGpkgFeatureCountSync", () => {
     ]);
   });
 
-  it("matches table names case-insensitively across metadata tables", () => {
+  it("matches table names case-insensitively and normalises to the canonical casing", () => {
     // gpkg_contents and gpkg_ogr_contents disagree on casing for the same
-    // (case-insensitive) SQLite table. The repair must treat them as one table
-    // and UPDATE the existing NULL row rather than INSERT a duplicate.
+    // (case-insensitive) SQLite table. The repair must treat them as one table,
+    // UPDATE the existing NULL row rather than INSERT a duplicate, and rewrite
+    // table_name to the gpkg_contents spelling so GDAL's case-sensitive lookup
+    // finds it.
     const db: Database = new SQL.Database();
     db.run(`
       CREATE TABLE gpkg_contents (
@@ -262,7 +264,34 @@ describe("ensureGpkgFeatureCountSync", () => {
     const patched = ensureGpkgFeatureCountSync(SQL, original);
     assert.notEqual(patched, original);
     assert.deepEqual(readOgrContents(patched), [
-      { table_name: "places", feature_count: 3 },
+      { table_name: "Places", feature_count: 3 },
+    ]);
+  });
+
+  it("repairs a non-ASCII table name whose count is NULL", () => {
+    // SQLite's lower() is ASCII-only, so a `lower(table_name) = :key` predicate
+    // would never match a non-ASCII name; matching on the exact stored name
+    // keeps the UPDATE working here.
+    const db: Database = new SQL.Database();
+    db.run(`
+      CREATE TABLE gpkg_contents (
+        table_name TEXT NOT NULL PRIMARY KEY, data_type TEXT NOT NULL, srs_id INTEGER
+      );
+      CREATE TABLE "Über" (fid INTEGER PRIMARY KEY, geom BLOB);
+      INSERT INTO gpkg_contents VALUES ('Über', 'features', 4326);
+      INSERT INTO "Über" (geom) VALUES (NULL), (NULL);
+      CREATE TABLE gpkg_ogr_contents (
+        table_name TEXT NOT NULL PRIMARY KEY, feature_count INTEGER
+      );
+      INSERT INTO gpkg_ogr_contents (table_name, feature_count) VALUES ('Über', NULL);
+    `);
+    const original = db.export();
+    db.close();
+
+    const patched = ensureGpkgFeatureCountSync(SQL, original);
+    assert.notEqual(patched, original);
+    assert.deepEqual(readOgrContents(patched), [
+      { table_name: "Über", feature_count: 2 },
     ]);
   });
 
@@ -318,6 +347,31 @@ describe("ensureGpkgFeatureCountSync", () => {
     assert.notEqual(patched, original);
     assert.deepEqual(readOgrContents(patched), [
       { table_name: "swamps", feature_count: 2 },
+    ]);
+  });
+
+  it("skips an unreadable phantom table and still repairs the others", () => {
+    // gpkg_contents lists a table that does not exist as a real SQLite table
+    // (a deleted/virtual/view entry). count(*) on it throws; the repair must
+    // skip it and still patch the readable feature table.
+    const db: Database = new SQL.Database();
+    db.run(`
+      CREATE TABLE gpkg_contents (
+        table_name TEXT NOT NULL PRIMARY KEY, data_type TEXT NOT NULL, srs_id INTEGER
+      );
+      CREATE TABLE real_table (fid INTEGER PRIMARY KEY, geom BLOB);
+      INSERT INTO gpkg_contents VALUES ('real_table', 'features', 4326);
+      INSERT INTO gpkg_contents VALUES ('ghost_table', 'features', 4326);
+      INSERT INTO real_table (geom) VALUES (NULL), (NULL);
+    `);
+    const original = db.export();
+    db.close();
+
+    const patched = ensureGpkgFeatureCountSync(SQL, original);
+    assert.notEqual(patched, original);
+    // ghost_table is silently skipped; real_table is repaired.
+    assert.deepEqual(readOgrContents(patched), [
+      { table_name: "real_table", feature_count: 2 },
     ]);
   });
 


### PR DESCRIPTION
Follow-up to #379 (merged), addressing the review comments that arrived just as it merged. Two are genuine bugs in the case-insensitive `gpkg_ogr_contents` repair from that PR.

## Fixes

- **Case-sensitive UPDATE left the wrong-cased `table_name`.** When `gpkg_ogr_contents` stored a row whose casing disagreed with the canonical `gpkg_contents` name (e.g. `places` vs `Places`), the repair set `feature_count` but kept the lowercased name. GDAL looks the row up with a **case-sensitive** `WHERE table_name = <name from gpkg_contents>`, so it would not find the repaired row and would fall back to the multithreaded count path that crashes the single-threaded WASM build, the original #376 crash. The UPDATE now also normalises `table_name` to the canonical casing.
- **`lower(table_name)` is ASCII-only in SQLite.** The match predicate used `WHERE lower(table_name) = :key`, but `key` is built with JS `String.toLowerCase()` (Unicode-aware). For a non-ASCII name (e.g. `Über`), SQLite's `lower()` leaves it unchanged, the predicate never matches, the UPDATE affects 0 rows, and the count stays NULL → crash. The UPDATE now matches on the **exact stored name** (captured when scanning `gpkg_ogr_contents`), avoiding `lower()` in SQL entirely.

## Tests
- Case-insensitive repair now asserts the stored name is normalised to the canonical `Places`.
- New: a non-ASCII (`Über`) NULL-count repair.
- New: a phantom-table case (a `gpkg_contents` entry with no real table) is skipped while the readable table is still repaired.

15 tests pass; `tsc`/eslint/build clean via pre-commit.

Note: two of the review comments were CSP security *notes* on `connect-src blob:` (informational, no change needed, the directive is required for `maplibre-gl-raster`'s blob Range fetches), and one re-flagged the silent `catch` that #379 already fixed with a `console.warn`.

Refs #376

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed GeoPackage metadata synchronization to correctly handle table names with different letter casing, preventing synchronization errors when updating feature counts.
  * Improved robustness when syncing metadata for non-ASCII table names.

* **Tests**
  * Enhanced test coverage for database metadata repair scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->