### PR TITLE
ci(android): attach release-signed APKs to GitHub Release

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -9,8 +9,10 @@ on:
     types: [published]
   workflow_dispatch:
 
+# contents: write so the release job can attach signed APKs to the GitHub
+# Release. workflow_dispatch runs (no release) only upload a CI artifact.
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: android-${{ github.ref }}
@@ -101,9 +103,12 @@ jobs:
           VITE_GEE_OAUTH_CLIENT_ID: ${{ secrets.VITE_GEE_OAUTH_CLIENT_ID }}
 
       - name: Sign APKs
+        id: sign
         # With release-keystore secrets set, the APKs are signed for distribution.
         # Without them, they're signed with a throwaway debug keystore so the CI
         # artifacts are still installable for testing (do NOT publish those).
+        # Emits signed=release|debug so the release-upload step can refuse to
+        # attach debug-signed APKs to a public GitHub Release.
         env:
           KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
           KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
@@ -127,8 +132,10 @@ jobs:
             printf '%s' "$KEYSTORE_PASSWORD" > "$store_pass_file"
             printf '%s' "${KEY_PASSWORD:-$KEYSTORE_PASSWORD}" > "$key_pass_file"
             alias="$KEY_ALIAS"
+            echo "signed=release" >> "$GITHUB_OUTPUT"
           else
             echo "::warning::No ANDROID_KEYSTORE_BASE64 secret set — signing with a throwaway debug keystore. Installable for testing only, NOT for distribution."
+            echo "signed=debug" >> "$GITHUB_OUTPUT"
             keystore="$RUNNER_TEMP/debug.jks"
             "$JAVA_HOME/bin/keytool" -genkeypair -v -keystore "$keystore" \
               -storepass android -keypass android -alias androiddebugkey \
@@ -168,3 +175,20 @@ jobs:
           path: ${{ runner.temp }}/apks/*.apk
           if-no-files-found: error
           retention-days: 14
+
+      - name: Attach APKs to GitHub Release
+        # Only on a published release, and only when the APKs were signed with the
+        # real release keystore — never publish debug-signed builds as official
+        # downloads. workflow_dispatch runs still get the CI artifact above.
+        if: github.event_name == 'release' && steps.sign.outputs.signed == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: gh release upload "$TAG" "$RUNNER_TEMP"/apks/*.apk --clobber
+
+      - name: Note skipped release upload
+        # Surface why a release run did not attach APKs (missing keystore secrets),
+        # so it does not look like a silent failure.
+        if: github.event_name == 'release' && steps.sign.outputs.signed != 'release'
+        run: |
+          echo "::warning::APKs were debug-signed (no ANDROID_KEYSTORE_BASE64 secret) and were NOT attached to the release. They are available as the CI artifact for testing only."

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -9,10 +9,10 @@ on:
     types: [published]
   workflow_dispatch:
 
-# contents: write so the release job can attach signed APKs to the GitHub
-# Release. workflow_dispatch runs (no release) only upload a CI artifact.
+# Least privilege at the workflow level; the build job below elevates to
+# contents: write only where it needs to attach release assets.
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: android-${{ github.ref }}
@@ -29,6 +29,10 @@ jobs:
   build:
     name: Build Android APK (release)
     runs-on: ubuntu-22.04
+    # Elevated here (not workflow-level) so only this job can write release
+    # assets; workflow_dispatch runs never attach but the grant is harmless.
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -132,10 +136,10 @@ jobs:
             printf '%s' "$KEYSTORE_PASSWORD" > "$store_pass_file"
             printf '%s' "${KEY_PASSWORD:-$KEYSTORE_PASSWORD}" > "$key_pass_file"
             alias="$KEY_ALIAS"
-            echo "signed=release" >> "$GITHUB_OUTPUT"
+            sign_mode=release
           else
             echo "::warning::No ANDROID_KEYSTORE_BASE64 secret set — signing with a throwaway debug keystore. Installable for testing only, NOT for distribution."
-            echo "signed=debug" >> "$GITHUB_OUTPUT"
+            sign_mode=debug
             keystore="$RUNNER_TEMP/debug.jks"
             "$JAVA_HOME/bin/keytool" -genkeypair -v -keystore "$keystore" \
               -storepass android -keypass android -alias androiddebugkey \
@@ -167,6 +171,9 @@ jobs:
           if [ "$found" -eq 0 ]; then
             echo "::error::No release-unsigned APKs found"; exit 1
           fi
+          # Emit the outcome only after every APK has signed and verified, so a
+          # downstream always() step can never read signed=release on a failure.
+          echo "signed=$sign_mode" >> "$GITHUB_OUTPUT"
 
       - name: Upload signed APKs
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Why

The `Android` workflow already builds APKs on every published release, but it only uploads them as an **ephemeral CI artifact** (14-day retention). They never appear on the Releases page next to the desktop installers — which is why **v1.3.0 looked like it produced no APKs** even though the build succeeded.

## What this does

- Adds an **Attach APKs to GitHub Release** step that uploads the signed APKs to the release via `gh release upload`.
- **Gated on release-signing**: the Sign step now emits `signed=release|debug`, and the attach step only runs when the build was signed with the real release keystore. Debug-signed builds are never published as official downloads (they still get the CI artifact for testing).
- Bumps `permissions` to `contents: write` (needed to upload release assets).
- Adds a warning step so a release run that skips the upload (missing keystore secrets) is visible, not silent.
- `workflow_dispatch` runs are unaffected — still artifact-only.

## Notes

The `ANDROID_KEYSTORE_BASE64` / `ANDROID_KEYSTORE_PASSWORD` / `ANDROID_KEY_ALIAS` / `ANDROID_KEY_PASSWORD` secrets are now configured on the repo, so the next published release will auto-sign and auto-attach APKs.

v1.3.0's APKs were re-signed with the release keystore and uploaded to that release manually; this change makes it automatic going forward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Android CI release workflow to automatically attach APKs to GitHub Releases when signing is performed with the release key.
  * Added clearer signing verification and conditional publish behavior, including warnings when APKs were signed with a debug key so release attachments are skipped and artifacts are available via the CI upload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->