### PR TITLE
fix(docker): allow local HTTP data sources in browser-build CSP

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -32,11 +32,15 @@ server {
         # Mirrors the Tauri desktop CSP. 'unsafe-eval' is required by the
         # @google/earthengine and maplibre-gl-geoagent bundles; connect-src
         # stays broad because users connect to arbitrary tile/WMS endpoints.
+        # The http://localhost:* / http://127.0.0.1:* (and ws:// equivalents)
+        # allowances let users load PMTiles/COGs and other local test data from
+        # a dev server on another port (e.g. http://localhost:8081) even though
+        # the app itself is served from a different origin (issue #387).
         # The jsDelivr script-src allowances are path-scoped: /npm/ covers
         # maplibre-gl-vector's DuckDB-WASM + geojson-vt/vt-pbf (Add Vector
         # Layer) loaded via dynamic import()/importScripts(), and /pyodide/
         # covers the Pyodide vector engine.
-        add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https: data: blob:; img-src 'self' data: blob: https:; media-src 'self' blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net/npm/ https://cdn.jsdelivr.net/pyodide/ https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'" always;
+        add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https: data: blob: http://127.0.0.1:* http://localhost:* wss://collab.geolibre.app ws://127.0.0.1:* ws://localhost:*; img-src 'self' data: blob: https:; media-src 'self' blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net/npm/ https://cdn.jsdelivr.net/pyodide/ https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'" always;
     }
 
     # The service worker has a stable filename, so it must always revalidate;

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -29,13 +29,19 @@ server {
         add_header Cache-Control "no-cache, must-revalidate" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        # Mirrors the Tauri desktop CSP. 'unsafe-eval' is required by the
+        # Closely mirrors the Tauri desktop CSP (the browser build additionally
+        # permits data: URIs in connect-src). 'unsafe-eval' is required by the
         # @google/earthengine and maplibre-gl-geoagent bundles; connect-src
         # stays broad because users connect to arbitrary tile/WMS endpoints.
         # The http://localhost:* / http://127.0.0.1:* (and ws:// equivalents)
         # allowances let users load PMTiles/COGs and other local test data from
         # a dev server on another port (e.g. http://localhost:8081) even though
-        # the app itself is served from a different origin (issue #387).
+        # the app itself is served from a different origin (issue #387). NOTE:
+        # this Docker image is intended for local/single-user use. If it is ever
+        # deployed to a shared or internet-facing host, the localhost allowances
+        # let the served JS probe each visitor's own loopback (from the browser,
+        # localhost is the visitor's machine, not the server) -- drop them if
+        # you publish the image publicly.
         # The jsDelivr script-src allowances are path-scoped: /npm/ covers
         # maplibre-gl-vector's DuckDB-WASM + geojson-vt/vt-pbf (Add Vector
         # Layer) loaded via dynamic import()/importScripts(), and /pyodide/


### PR DESCRIPTION
Fixes #387.

## Problem

When running GeoLibre via Docker/Podman at `http://localhost:8080`, adding a PMTiles (or COG) layer from a local dev server on another port such as `http://localhost:8081/data/outputs/vulnerability_map.pmtiles` fails with `Failed to fetch`, even though the file is valid and serves CORS + HTTP byte ranges.

The browser build's `connect-src` was `'self' https: data: blob:`, so any `http://localhost:<other-port>` origin was blocked by CSP. The same file worked only when same-origin or served over HTTPS.

## Fix

The nginx CSP comment claimed it "mirrors the Tauri desktop CSP", but the desktop CSP already allowed `http://localhost:*` and `http://127.0.0.1:*` (plus the `ws://` equivalents and the collab `wss://` host) while the Docker CSP did not. This aligns the nginx `connect-src` with the desktop one, so local development data workflows behave identically in the browser build and the desktop app.

`data:` is retained (it is used by the browser build for data URIs).

## Testing

- `pre-commit run --files docker/nginx.conf` passes (includes the npm build hook).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the security policy to permit WebSocket and HTTP connections to common localhost addresses for local development/testing.
  * Kept the existing allowed remote collaboration endpoint unchanged.
  * Added an inline note clarifying the localhost/local-test-data exception and intended single-user/deployment conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->