### PR TITLE
chore(docker): cross-reference Tauri CSP and warn about localhost allowances

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,11 @@ ENV GEOLIBRE_CONVERSION_PYTHON=/usr/local/bin/python \
     GEOLIBRE_CONVERSION_ROOTS=/data
 RUN mkdir -p /data
 
+# WARNING: docker/nginx.conf's CSP allows http://localhost:* / ws://localhost:*
+# in connect-src for local-dev data sources (PMTiles/COGs from a dev server on
+# another port). This image is intended for local/single-user use; on a public
+# host those allowances let the served JS probe each visitor's loopback. Drop
+# them from the CSP before publishing publicly.
 COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,11 +71,11 @@ ENV GEOLIBRE_CONVERSION_PYTHON=/usr/local/bin/python \
     GEOLIBRE_CONVERSION_ROOTS=/data
 RUN mkdir -p /data
 
-# WARNING: docker/nginx.conf's CSP allows http://localhost:* / ws://localhost:*
-# in connect-src for local-dev data sources (PMTiles/COGs from a dev server on
-# another port). This image is intended for local/single-user use; on a public
-# host those allowances let the served JS probe each visitor's loopback. Drop
-# them from the CSP before publishing publicly.
+# WARNING: docker/nginx.conf's CSP allows http://localhost:* / http://127.0.0.1:*
+# (and ws:// equivalents) in connect-src for local-dev data sources (PMTiles/COGs
+# from a dev server on another port). This image is intended for local/single-user
+# use; on a public host those allowances let the served JS probe each visitor's
+# loopback. Drop them from the CSP before publishing publicly.
 COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -46,6 +46,9 @@ server {
         # maplibre-gl-vector's DuckDB-WASM + geojson-vt/vt-pbf (Add Vector
         # Layer) loaded via dynamic import()/importScripts(), and /pyodide/
         # covers the Pyodide vector engine.
+        # Keep connect-src in sync with the Tauri CSP in
+        # apps/geolibre-desktop/src-tauri/tauri.conf.json -- the collab host
+        # (wss://collab.geolibre.app) and tile endpoints must match in both.
         add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https: data: blob: http://127.0.0.1:* http://localhost:* wss://collab.geolibre.app ws://127.0.0.1:* ws://localhost:*; img-src 'self' data: blob: https:; media-src 'self' blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net/npm/ https://cdn.jsdelivr.net/pyodide/ https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'" always;
     }
 

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -46,9 +46,12 @@ server {
         # maplibre-gl-vector's DuckDB-WASM + geojson-vt/vt-pbf (Add Vector
         # Layer) loaded via dynamic import()/importScripts(), and /pyodide/
         # covers the Pyodide vector engine.
-        # Keep connect-src in sync with the Tauri CSP in
-        # apps/geolibre-desktop/src-tauri/tauri.conf.json -- the collab host
-        # (wss://collab.geolibre.app) and tile endpoints must match in both.
+        # When adding a new *named* host to connect-src (e.g. a collaboration
+        # server or a specific tile CDN), add it to the Tauri CSP in
+        # apps/geolibre-desktop/src-tauri/tauri.conf.json as well --
+        # wss://collab.geolibre.app is an example of a host duplicated in both.
+        # (The browser build intentionally adds data: to connect-src; that
+        # difference is documented in the "Closely mirrors" note above.)
         add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https: data: blob: http://127.0.0.1:* http://localhost:* wss://collab.geolibre.app ws://127.0.0.1:* ws://localhost:*; img-src 'self' data: blob: https:; media-src 'self' blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' blob: 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net/npm/ https://cdn.jsdelivr.net/pyodide/ https://accounts.google.com; child-src 'self' https://accounts.google.com https://www.google.com; frame-src 'self' https://accounts.google.com https://www.google.com; worker-src blob: 'self'" always;
     }
 

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -46,9 +46,9 @@ server {
         # maplibre-gl-vector's DuckDB-WASM + geojson-vt/vt-pbf (Add Vector
         # Layer) loaded via dynamic import()/importScripts(), and /pyodide/
         # covers the Pyodide vector engine.
-        # When adding a new *named* host to any CSP directive (e.g. a
+        # When adding or removing a *named* host from any CSP directive (e.g. a
         # collaboration server in connect-src, or a new CDN in script-src),
-        # add it to the Tauri CSP in
+        # mirror the change in the Tauri CSP in
         # apps/geolibre-desktop/src-tauri/tauri.conf.json as well --
         # wss://collab.geolibre.app is an example of a host duplicated in both.
         # (The browser build intentionally adds data: to connect-src; that

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -46,8 +46,9 @@ server {
         # maplibre-gl-vector's DuckDB-WASM + geojson-vt/vt-pbf (Add Vector
         # Layer) loaded via dynamic import()/importScripts(), and /pyodide/
         # covers the Pyodide vector engine.
-        # When adding a new *named* host to connect-src (e.g. a collaboration
-        # server or a specific tile CDN), add it to the Tauri CSP in
+        # When adding a new *named* host to any CSP directive (e.g. a
+        # collaboration server in connect-src, or a new CDN in script-src),
+        # add it to the Tauri CSP in
         # apps/geolibre-desktop/src-tauri/tauri.conf.json as well --
         # wss://collab.geolibre.app is an example of a host duplicated in both.
         # (The browser build intentionally adds data: to connect-src; that


### PR DESCRIPTION
Follow-up to #388 (issue #387), addressing two low/medium-severity Claude review comments that landed just before #388 merged.

## Changes

- **docker/nginx.conf**: add a comment noting that `connect-src` must stay in sync with the Tauri CSP in `apps/geolibre-desktop/src-tauri/tauri.conf.json` — the collab host (`wss://collab.geolibre.app`) and tile endpoints are duplicated across both configs, so a rotation must update both.
- **Dockerfile**: add a `WARNING` comment above the `COPY docker/nginx.conf` line so operators who only read the Dockerfile are warned that the CSP's `http://localhost:*` / `ws://localhost:*` allowances make the image local/single-user only and should be dropped before any public deployment.

Comment-only changes; no CSP value or runtime behavior change.

## Testing

- `pre-commit run --files docker/nginx.conf Dockerfile` passes (includes the npm build hook).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added multi-line warnings in the container/web server configuration clarifying the current CSP `connect-src` allowances for local development (including `localhost`/`127.0.0.1` over HTTP and WebSocket), and noting the image is intended for local/single-user use.
  * Documented that any future additions of named hosts in CSP directives must also be mirrored in the desktop CSP configuration.
  * Reconfirmed that the browser build’s existing `data:` handling in `connect-src` is intentional and unchanged.

**Note:** No end-user functionality is affected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->