### PR TITLE
feat: allow runtime env overrides for Pyodide and DuckDB Spatial URLs

### DIFF
--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -74,16 +74,6 @@ export function getDatabase(): Promise<duckdb.AsyncDuckDB> {
 
 let spatialExtensionPromise: Promise<void> | null = null;
 
-function configuredSpatialExtensionPath(): string | undefined {
-  try {
-    const env = (import.meta as { env?: Record<string, string | undefined> })
-      .env;
-    return getSpatialExtensionPath(env);
-  } catch {
-    return undefined;
-  }
-}
-
 /**
  * Install and load the DuckDB spatial extension once per database instance.
  * `getDatabase` returns a memoized singleton, so the extension persists across
@@ -102,7 +92,7 @@ export async function ensureSpatialExtension(
   beforeLoad?: () => Promise<void>,
 ): Promise<void> {
   spatialExtensionPromise ??= (async () => {
-    const customPath = configuredSpatialExtensionPath();
+    const customPath = getSpatialExtensionPath();
     if (customPath) {
       const normalizedPath = customPath.replace(/\\/g, "/");
       await connection.query(`LOAD ${quoteSqlString(normalizedPath)}`);

--- a/apps/geolibre-desktop/src/lib/pyodide/pyodide-config.ts
+++ b/apps/geolibre-desktop/src/lib/pyodide/pyodide-config.ts
@@ -5,6 +5,8 @@
 //
 // As of Pyodide 0.27.x, geopandas/shapely/pyproj (with PROJ data) ship in the
 // distribution, so a single loadPackage("geopandas") pulls the whole graph.
+import { getRuntimeEnvironment } from "@geolibre/core";
+
 export const PYODIDE_VERSION = "0.27.7";
 
 const DEFAULT_INDEX_URL = `https://cdn.jsdelivr.net/pyodide/v${PYODIDE_VERSION}/full/`;
@@ -24,7 +26,7 @@ const DEFAULT_INDEX_URL = `https://cdn.jsdelivr.net/pyodide/v${PYODIDE_VERSION}/
  *   The indexURL string, guaranteed to end with a slash.
  */
 export function getPyodideIndexUrl(
-  env: Record<string, string | undefined> = import.meta.env,
+  env: Record<string, string | undefined> = getRuntimeEnvironment(),
 ): string {
   const override = env.VITE_PYODIDE_INDEX_URL?.trim();
   const url = override || DEFAULT_INDEX_URL;

--- a/apps/geolibre-desktop/src/lib/spatial-extension-config.ts
+++ b/apps/geolibre-desktop/src/lib/spatial-extension-config.ts
@@ -1,6 +1,9 @@
+import { getRuntimeEnvironment } from "@geolibre/core";
+
 export function getSpatialExtensionPath(
   env?: Record<string, string | undefined>,
 ): string | undefined {
-  const value = env?.VITE_DUCKDB_SPATIAL_EXTENSION_PATH;
+  const runtimeEnv = env ?? getRuntimeEnvironment();
+  const value = runtimeEnv.VITE_DUCKDB_SPATIAL_EXTENSION_PATH;
   return value && value.trim() ? value.trim() : undefined;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -71,3 +71,4 @@ export {
   type GeocodeRequest,
   type ReverseGeocodeDisplay,
 } from "./geocoding";
+export { getRuntimeEnvironment } from "./runtime-env";


### PR DESCRIPTION
Closes https://github.com/opengeos/GeoLibre/issues/390

Make VITE_PYODIDE_INDEX_URL and VITE_DUCKDB_SPATIAL_EXTENSION_PATH configurable at runtime via the existing getRuntimeEnvironment() system, so users in air-gapped or corporate environments can point to internal mirrors without rebuilding the app.

- Export getRuntimeEnvironment from @geolibre/core
- Update getPyodideIndexUrl to default to getRuntimeEnvironment()
- Update getSpatialExtensionPath to fallback to getRuntimeEnvironment()
- Remove manual import.meta.env wrapper in duckdb-vector-loader.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal environment variable handling for spatial and runtime configurations to enhance code maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->