### PR TITLE
feat(raster): add Spectral Index toolbox (NDVI, NDWI, EVI, …)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
@@ -349,6 +349,9 @@ export function ProcessingMenu({
             <DropdownMenuItem onSelect={() => setRasterToolOpen("raster-calc")}>
               {t("toolbar.rasterTool.rasterCalc")}
             </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => setRasterToolOpen("spectral-index")}>
+              {t("toolbar.rasterTool.spectralIndex")}
+            </DropdownMenuItem>
             <DropdownMenuItem onSelect={() => setRasterToolOpen("reclassify")}>
               {t("toolbar.rasterTool.reclassify")}
             </DropdownMenuItem>

--- a/apps/geolibre-desktop/src/components/layout/toolbar/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/constants.ts
@@ -185,6 +185,7 @@ export const RASTER_TOOL_COMMANDS: Array<{
   { kind: "interpolate", titleKey: "toolbar.rasterTool.interpolate" },
   { kind: "zonal", titleKey: "toolbar.rasterTool.zonal" },
   { kind: "raster-calc", titleKey: "toolbar.rasterTool.rasterCalc" },
+  { kind: "spectral-index", titleKey: "toolbar.rasterTool.spectralIndex" },
   { kind: "reclassify", titleKey: "toolbar.rasterTool.reclassify" },
   { kind: "mosaic", titleKey: "toolbar.rasterTool.mosaic" },
   { kind: "focal", titleKey: "toolbar.rasterTool.focal" },

--- a/apps/geolibre-desktop/src/components/processing/RasterToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/RasterToolsDialog.tsx
@@ -351,7 +351,11 @@ export function RasterToolsDialog({
           expression: buildSpectralIndexExpression(params).expression,
         };
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Invalid spectral index.");
+        setError(
+          err instanceof Error
+            ? err.message
+            : t("toolbar.rasterTool.invalidSpectralIndex"),
+        );
         return;
       }
     }
@@ -369,7 +373,7 @@ export function RasterToolsDialog({
         err instanceof Error ? err.message : "Could not start raster tool.",
       );
     }
-  }, [tool, inputPath, outputPath, params, validateParams]);
+  }, [tool, inputPath, outputPath, params, validateParams, t]);
 
   const runClient = useCallback(async () => {
     setError(null);

--- a/apps/geolibre-desktop/src/components/processing/RasterToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/RasterToolsDialog.tsx
@@ -9,6 +9,7 @@ import {
   runRasterTool,
   readRasterData,
   runRasterToolClient,
+  buildSpectralIndexExpression,
   type AlgorithmParameter,
   type ConversionJob,
   type RasterTool,
@@ -340,13 +341,27 @@ export function RasterToolsDialog({
       setError(invalid);
       return;
     }
+    // The Spectral Index tool compiles to a band-math expression the sidecar's
+    // `raster-calc` script evaluates, so inject it into the request params.
+    let sidecarParams = params;
+    if (tool.id === "spectral-index") {
+      try {
+        sidecarParams = {
+          ...params,
+          expression: buildSpectralIndexExpression(params).expression,
+        };
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Invalid spectral index.");
+        return;
+      }
+    }
     try {
       setJob(
         await runRasterTool({
           tool_id: tool.id,
           input_path: inputPath.trim(),
           output_path: outputPath.trim(),
-          parameters: params,
+          parameters: sidecarParams,
         }),
       );
     } catch (err) {

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -430,6 +430,7 @@
       "zonal": "Zonal statistics",
       "rasterCalc": "Raster calculator",
       "spectralIndex": "Spectral index",
+      "invalidSpectralIndex": "Invalid spectral index.",
       "reclassify": "Reclassify",
       "mosaic": "Mosaic / merge",
       "focal": "Focal statistics",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -429,6 +429,7 @@
       "interpolate": "Interpolation (IDW / Kriging)",
       "zonal": "Zonal statistics",
       "rasterCalc": "Raster calculator",
+      "spectralIndex": "Spectral index",
       "reclassify": "Reclassify",
       "mosaic": "Mosaic / merge",
       "focal": "Focal statistics",

--- a/backend/geolibre_server/geolibre_server/app/raster.py
+++ b/backend/geolibre_server/geolibre_server/app/raster.py
@@ -1030,6 +1030,15 @@ try:
 except SystemExit:
     raise
 except Exception as exc:
+    # A bare `A<n>` reference past the input's band count surfaces as an opaque
+    # NameError; hint at the real cause (e.g. a spectral index whose band layout
+    # exceeds the raster) instead of the raw "name 'A4' is not defined".
+    band_ref = re.search(r"name '(A\\d+)' is not defined", str(exc))
+    if band_ref:
+        raise SystemExit(
+            f"Expression references band {band_ref.group(1)}, which the input "
+            "raster does not have. Check the band layout / sensor preset."
+        )
     raise SystemExit(f"Failed to evaluate expression: {exc}")
 
 result = np.asarray(result, dtype="float64")
@@ -1347,6 +1356,12 @@ _EXTRA_INPUTS: dict[str, list[tuple[str, str, set[str], bool]]] = {
     "clip-mask": [("mask_path", "Mask layer", _GEOJSON_EXTS, True)],
     "zonal": [("zones_path", "Zones layer", _GEOJSON_EXTS, True)],
     "raster-calc": [
+        ("b_path", "Raster B", _GEOTIFF_EXTS, False),
+        ("c_path", "Raster C", _GEOTIFF_EXTS, False),
+    ],
+    # Spectral index reuses _RASTER_CALC_SCRIPT, which honors b_path/c_path, so
+    # those auxiliary paths must clear the same allowlist/extension checks.
+    "spectral-index": [
         ("b_path", "Raster B", _GEOTIFF_EXTS, False),
         ("c_path", "Raster C", _GEOTIFF_EXTS, False),
     ],

--- a/backend/geolibre_server/geolibre_server/app/raster.py
+++ b/backend/geolibre_server/geolibre_server/app/raster.py
@@ -1321,6 +1321,9 @@ _RASTER_TOOL_SCRIPTS: dict[str, str] = {
     "interpolate": _INTERPOLATE_SCRIPT,
     "zonal": _ZONAL_STATS_SCRIPT,
     "raster-calc": _RASTER_CALC_SCRIPT,
+    # The Spectral Index tool compiles to a band-math expression on the client
+    # and reuses the raster calculator to evaluate it over the input's bands.
+    "spectral-index": _RASTER_CALC_SCRIPT,
     "reclassify": _RECLASSIFY_SCRIPT,
     "mosaic": _MOSAIC_SCRIPT,
     "focal": _FOCAL_SCRIPT,

--- a/backend/geolibre_server/geolibre_server/app/raster.py
+++ b/backend/geolibre_server/geolibre_server/app/raster.py
@@ -1359,8 +1359,12 @@ _EXTRA_INPUTS: dict[str, list[tuple[str, str, set[str], bool]]] = {
         ("b_path", "Raster B", _GEOTIFF_EXTS, False),
         ("c_path", "Raster C", _GEOTIFF_EXTS, False),
     ],
-    # Spectral index reuses _RASTER_CALC_SCRIPT, which honors b_path/c_path, so
-    # those auxiliary paths must clear the same allowlist/extension checks.
+    # Spectral index is single-input in the UI (the compiled expression only
+    # references A<n> bands), but it reuses _RASTER_CALC_SCRIPT, which opens
+    # b_path/c_path whenever they are present in the request. These entries are a
+    # defense-in-depth guard: a hand-crafted request to the local sidecar that
+    # smuggles in b_path/c_path still has those paths checked against the
+    # allowlist/extensions, rather than opened unvalidated. Not multi-raster.
     "spectral-index": [
         ("b_path", "Raster B", _GEOTIFF_EXTS, False),
         ("c_path", "Raster C", _GEOTIFF_EXTS, False),

--- a/backend/geolibre_server/tests/test_raster.py
+++ b/backend/geolibre_server/tests/test_raster.py
@@ -26,6 +26,7 @@ EXPECTED_TOOL_IDS = {
     "interpolate",
     "zonal",
     "raster-calc",
+    "spectral-index",
     "reclassify",
     "mosaic",
     "focal",

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -110,6 +110,7 @@ export type RasterToolKind =
   | "interpolate"
   | "zonal"
   | "raster-calc"
+  | "spectral-index"
   | "reclassify"
   | "mosaic"
   | "focal";

--- a/packages/processing/src/index.ts
+++ b/packages/processing/src/index.ts
@@ -37,6 +37,17 @@ export {
   type FileFilter,
 } from "./raster-tools";
 export {
+  SPECTRAL_INDICES,
+  SENSOR_IDS,
+  SENSOR_PRESETS,
+  getSpectralIndex,
+  buildSpectralIndexExpression,
+  type SpectralIndex,
+  type BandName,
+  type BandLayout,
+  type BuiltSpectralIndex,
+} from "./spectral-indices";
+export {
   CLIENT_RASTER_TOOL_IDS,
   TERRAIN_NODATA,
   supportsClientRaster,

--- a/packages/processing/src/raster-client.ts
+++ b/packages/processing/src/raster-client.ts
@@ -1,5 +1,6 @@
 import { fromArrayBuffer, writeArrayBuffer } from "geotiff";
 import type { RasterToolId } from "./raster-tools";
+import { buildSpectralIndexExpression } from "./spectral-indices";
 
 /**
  * In-browser raster processing engine.
@@ -50,6 +51,7 @@ export const CLIENT_RASTER_TOOL_IDS: ReadonlySet<RasterToolId> = new Set<RasterT
   "clip-extent",
   "reclassify",
   "raster-calc",
+  "spectral-index",
   "focal",
 ]);
 
@@ -694,6 +696,19 @@ export function runRasterToolClient(
     case "raster-calc":
       raster = rasterCalc(input, { expression: String(parameters.expression ?? "") });
       break;
+    case "spectral-index": {
+      const { expression, bands } = buildSpectralIndexExpression(parameters);
+      const maxBand = Math.max(...bands);
+      if (maxBand > input.bands.length) {
+        throw new Error(
+          `This index needs band ${maxBand}, but the raster has only ${input.bands.length} band(s). ` +
+            "Check the sensor preset or set band numbers with the Custom sensor.",
+        );
+      }
+      messages.push(`Index expression: ${expression}`);
+      raster = rasterCalc(input, { expression });
+      break;
+    }
     case "focal":
       raster = focalStatistics(input, {
         band: num("band", 1),

--- a/packages/processing/src/raster-client.ts
+++ b/packages/processing/src/raster-client.ts
@@ -698,6 +698,9 @@ export function runRasterToolClient(
       break;
     case "spectral-index": {
       const { expression, bands } = buildSpectralIndexExpression(parameters);
+      if (bands.length === 0) {
+        throw new Error("Spectral index produced no band references.");
+      }
       const maxBand = Math.max(...bands);
       if (maxBand > input.bands.length) {
         throw new Error(

--- a/packages/processing/src/raster-tools.ts
+++ b/packages/processing/src/raster-tools.ts
@@ -558,7 +558,9 @@ export const spectralIndexTool: RasterTool = {
       label: "Reflectance scale",
       type: "number",
       default: 1,
-      min: 0,
+      // Must stay > 0 to match buildSpectralIndexExpression's guard; a tiny
+      // floor still permits sub-0.0001 scales (e.g. Landsat C2's 0.0000275).
+      min: 0.000001,
       step: 0.0001,
       description:
         "Multiplier converting pixel values to reflectance (0–1). Leave at 1 for normalized-difference indices; set it for EVI/SAVI on integer-DN imagery (e.g. 0.0001 for Sentinel-2 L2A).",

--- a/packages/processing/src/raster-tools.ts
+++ b/packages/processing/src/raster-tools.ts
@@ -1,4 +1,5 @@
 import type { AlgorithmParameter } from "./types";
+import { SENSOR_IDS, SPECTRAL_INDICES } from "./spectral-indices";
 
 /**
  * Identifiers of the raster processing tools. Kept in sync by hand with the
@@ -17,6 +18,7 @@ export type RasterToolId =
   | "interpolate"
   | "zonal"
   | "raster-calc"
+  | "spectral-index"
   | "reclassify"
   | "mosaic"
   | "focal";
@@ -484,6 +486,86 @@ export const rasterCalculatorTool: RasterTool = {
   ],
 };
 
+const SENSOR_LABELS: Record<(typeof SENSOR_IDS)[number], string> = {
+  sentinel2: "Sentinel-2 (B2, B3, B4, B8, B11, B12)",
+  landsat89: "Landsat 8/9 (B1–B7)",
+  naip: "NAIP (R, G, B, NIR)",
+  custom: "Custom (set band numbers below)",
+};
+
+/** A custom-only band-number input, gated on the "custom" sensor. */
+function bandParam(id: string, label: string): AlgorithmParameter {
+  return {
+    id,
+    label,
+    type: "number",
+    min: 1,
+    step: 1,
+    visibleWhen: { param: "sensor", in: ["custom"] },
+  };
+}
+
+export const spectralIndexTool: RasterTool = {
+  id: "spectral-index",
+  name: "Spectral index",
+  description:
+    "Compute a named spectral index (NDVI, NDWI, EVI, …) from a multiband raster. Pick a sensor preset for the band layout, or set band numbers manually with the Custom sensor.",
+  group: "Analysis",
+  outputKind: "raster",
+  defaultOutputName: "index.tif",
+  inputFilters: GEOTIFF_INPUT,
+  outputFilters: GEOTIFF_OUTPUT,
+  supportsClient: true,
+  parameters: [
+    {
+      id: "index",
+      label: "Index",
+      type: "select",
+      default: SPECTRAL_INDICES[0].id,
+      options: SPECTRAL_INDICES.map((index) => ({
+        value: index.id,
+        label: index.name,
+      })),
+    },
+    {
+      id: "sensor",
+      label: "Sensor / band layout",
+      type: "select",
+      default: SENSOR_IDS[0],
+      options: SENSOR_IDS.map((id) => ({ value: id, label: SENSOR_LABELS[id] })),
+      description:
+        "Preset band numbers for common sensors. Choose Custom to map bands by hand for a differently stacked GeoTIFF.",
+    },
+    bandParam("red", "Red band number"),
+    bandParam("green", "Green band number"),
+    bandParam("blue", "Blue band number"),
+    bandParam("nir", "NIR band number"),
+    bandParam("swir1", "SWIR1 band number"),
+    bandParam("swir2", "SWIR2 band number"),
+    {
+      id: "L",
+      label: "Soil factor (L)",
+      type: "number",
+      default: 0.5,
+      min: 0,
+      max: 1,
+      step: 0.1,
+      visibleWhen: { param: "index", in: ["savi"] },
+      description: "SAVI soil-brightness correction (0 dense cover → 1 bare soil).",
+    },
+    {
+      id: "scale",
+      label: "Reflectance scale",
+      type: "number",
+      default: 1,
+      min: 0,
+      step: 0.0001,
+      description:
+        "Multiplier converting pixel values to reflectance (0–1). Leave at 1 for normalized-difference indices; set it for EVI/SAVI on integer-DN imagery (e.g. 0.0001 for Sentinel-2 L2A).",
+    },
+  ],
+};
+
 export const reclassifyTool: RasterTool = {
   id: "reclassify",
   name: "Reclassify",
@@ -625,6 +707,7 @@ export const RASTER_TOOLS: RasterTool[] = [
   interpolateTool,
   zonalStatisticsTool,
   rasterCalculatorTool,
+  spectralIndexTool,
   reclassifyTool,
   mosaicTool,
   focalStatisticsTool,

--- a/packages/processing/src/spectral-indices.ts
+++ b/packages/processing/src/spectral-indices.ts
@@ -211,8 +211,9 @@ export function buildSpectralIndexExpression(
   const tok = (name: BandName): string => {
     const band = resolveBand(name, sensor, params);
     if (!used.includes(band)) used.push(band);
-    // The ratio cancels a multiplicative scale, so only emit it when it differs
-    // from 1 (EVI/SAVI's additive constants need true reflectance units).
+    // When scale=1, s*A = A so we emit the bare reference. When scale != 1 we
+    // wrap every band uniformly — for ratio indices the scale cancels anyway;
+    // for EVI/SAVI the additive constants require true reflectance values.
     return scale === 1 ? `A${band}` : `(${scale} * A${band})`;
   };
 

--- a/packages/processing/src/spectral-indices.ts
+++ b/packages/processing/src/spectral-indices.ts
@@ -1,0 +1,222 @@
+/**
+ * Spectral index catalog and band-math expression builder.
+ *
+ * A spectral index is a normalized ratio of reflectance bands (NDVI, NDWI, …).
+ * Rather than implement a new raster kernel, this module compiles an index +
+ * a band layout into the same single-input NumPy/JS band-math expression the
+ * raster calculator already evaluates — `rasterCalc` in the browser and the
+ * `raster-calc` sidecar script. The Spectral Index tool is therefore a
+ * preset-driven front end over the existing calculator.
+ *
+ * Band numbers are 1-indexed to match the calculator's `A1, A2, …` references
+ * and GDAL/rasterio band numbering. Sensor presets supply common band layouts;
+ * the "custom" sensor lets the user map bands by hand for arbitrarily stacked
+ * GeoTIFFs.
+ */
+
+import type { AlgorithmParameter } from "./types";
+
+/** Canonical reflectance bands an index formula can reference. */
+export type BandName = "blue" | "green" | "red" | "nir" | "swir1" | "swir2";
+
+/** Map of band name to its 1-indexed band number within a raster. */
+export type BandLayout = Partial<Record<BandName, number>>;
+
+/** A named spectral index and how to compute it. */
+export interface SpectralIndex {
+  id: string;
+  /** Human-readable name shown in the select. */
+  name: string;
+  /** Bands the formula references (also drives which inputs the user supplies). */
+  bands: BandName[];
+  /** Expected value range, for default styling of the output. */
+  range: [number, number];
+  /** A suggested colormap name for styling the output. */
+  colormap: string;
+  /**
+   * Build the band-math expression. `tok(name)` yields the (scale-applied)
+   * token for a band; `p` carries index-specific numeric params (e.g. SAVI L).
+   */
+  expr: (tok: (name: BandName) => string, p: Record<string, number>) => string;
+}
+
+/** A normalized difference `(a - b) / (a + b)`, the shape most indices share. */
+function normalizedDifference(a: BandName, b: BandName) {
+  return (tok: (name: BandName) => string) => {
+    const x = tok(a);
+    const y = tok(b);
+    return `(${x} - ${y}) / (${x} + ${y})`;
+  };
+}
+
+/** The built-in spectral indices, in display order. */
+export const SPECTRAL_INDICES: SpectralIndex[] = [
+  {
+    id: "ndvi",
+    name: "NDVI (vegetation)",
+    bands: ["red", "nir"],
+    range: [-1, 1],
+    colormap: "RdYlGn",
+    expr: normalizedDifference("nir", "red"),
+  },
+  {
+    id: "gndvi",
+    name: "GNDVI (green vegetation)",
+    bands: ["green", "nir"],
+    range: [-1, 1],
+    colormap: "RdYlGn",
+    expr: normalizedDifference("nir", "green"),
+  },
+  {
+    id: "ndwi",
+    name: "NDWI (water, McFeeters)",
+    bands: ["green", "nir"],
+    range: [-1, 1],
+    colormap: "Blues",
+    expr: normalizedDifference("green", "nir"),
+  },
+  {
+    id: "ndmi",
+    name: "NDMI (moisture)",
+    bands: ["nir", "swir1"],
+    range: [-1, 1],
+    colormap: "BrBG",
+    expr: normalizedDifference("nir", "swir1"),
+  },
+  {
+    id: "ndbi",
+    name: "NDBI (built-up)",
+    bands: ["nir", "swir1"],
+    range: [-1, 1],
+    colormap: "RdBu",
+    expr: normalizedDifference("swir1", "nir"),
+  },
+  {
+    id: "nbr",
+    name: "NBR (burn ratio)",
+    bands: ["nir", "swir2"],
+    range: [-1, 1],
+    colormap: "RdYlGn",
+    expr: normalizedDifference("nir", "swir2"),
+  },
+  {
+    id: "evi",
+    name: "EVI (enhanced vegetation)",
+    bands: ["blue", "red", "nir"],
+    range: [-1, 1],
+    colormap: "RdYlGn",
+    // EVI's additive constants assume surface reflectance (0–1); set the scale
+    // factor for integer-DN imagery (e.g. 0.0001 for Sentinel-2 L2A).
+    expr: (tok) => {
+      const nir = tok("nir");
+      const red = tok("red");
+      const blue = tok("blue");
+      return `2.5 * ((${nir} - ${red}) / (${nir} + 6 * ${red} - 7.5 * ${blue} + 1))`;
+    },
+  },
+  {
+    id: "savi",
+    name: "SAVI (soil-adjusted vegetation)",
+    bands: ["red", "nir"],
+    range: [-1, 1],
+    colormap: "RdYlGn",
+    expr: (tok, p) => {
+      const nir = tok("nir");
+      const red = tok("red");
+      const L = p.L ?? 0.5;
+      return `((${nir} - ${red}) / (${nir} + ${red} + ${L})) * (1 + ${L})`;
+    },
+  },
+];
+
+/** Look up an index by id. */
+export function getSpectralIndex(id: string): SpectralIndex | undefined {
+  return SPECTRAL_INDICES.find((index) => index.id === id);
+}
+
+/**
+ * Built-in sensor band layouts. Band numbers follow the most common
+ * surface-reflectance stack order for each sensor; they are editable via the
+ * "custom" sensor when a file is stacked differently.
+ */
+export const SENSOR_PRESETS: Record<string, BandLayout> = {
+  // Sentinel-2 6-band reflectance stack [B2, B3, B4, B8, B11, B12].
+  sentinel2: { blue: 1, green: 2, red: 3, nir: 4, swir1: 5, swir2: 6 },
+  // Landsat 8/9 (OLI) Collection 2 surface reflectance bands B1–B7.
+  landsat89: { blue: 2, green: 3, red: 4, nir: 5, swir1: 6, swir2: 7 },
+  // NAIP 4-band imagery (no SWIR bands).
+  naip: { red: 1, green: 2, blue: 3, nir: 4 },
+  custom: {},
+};
+
+/** Sensor ids that ship with a preset, in display order. */
+export const SENSOR_IDS = ["sentinel2", "landsat89", "naip", "custom"] as const;
+
+/** Result of compiling a spectral index for an engine. */
+export interface BuiltSpectralIndex {
+  /** The band-math expression over `A1, A2, …`. */
+  expression: string;
+  /** The 1-indexed band numbers the expression references. */
+  bands: number[];
+  index: SpectralIndex;
+}
+
+function asNumber(value: unknown): number | undefined {
+  if (value === "" || value == null) return undefined;
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+/** Resolve the 1-indexed band number for a band name from tool parameters. */
+function resolveBand(
+  name: BandName,
+  sensor: string,
+  params: Record<string, unknown>,
+): number {
+  const fromParam = asNumber(params[name]);
+  const fromPreset = SENSOR_PRESETS[sensor]?.[name];
+  const band = sensor === "custom" ? fromParam : (fromParam ?? fromPreset);
+  if (band == null) {
+    throw new Error(
+      `Band "${name}" is required for this index — set it under the band numbers.`,
+    );
+  }
+  if (!Number.isInteger(band) || band < 1) {
+    throw new Error(`Band "${name}" must be a whole number ≥ 1 (got ${band}).`);
+  }
+  return band;
+}
+
+/**
+ * Compile a spectral index into a band-math expression from the tool's
+ * parameters (`index`, `sensor`, per-band numbers, `scale`, and index-specific
+ * knobs such as SAVI `L`). Throws a user-facing error if a required band is
+ * missing or invalid.
+ */
+export function buildSpectralIndexExpression(
+  params: Record<string, unknown>,
+): BuiltSpectralIndex {
+  const indexId = String(params.index ?? "");
+  const index = getSpectralIndex(indexId);
+  if (!index) throw new Error(`Unknown spectral index: "${indexId}".`);
+
+  const sensor = String(params.sensor ?? "custom");
+  const scale = asNumber(params.scale) ?? 1;
+  if (scale <= 0) throw new Error("Reflectance scale must be greater than 0.");
+
+  const used: number[] = [];
+  const tok = (name: BandName): string => {
+    const band = resolveBand(name, sensor, params);
+    if (!used.includes(band)) used.push(band);
+    // The ratio cancels a multiplicative scale, so only emit it when it differs
+    // from 1 (EVI/SAVI's additive constants need true reflectance units).
+    return scale === 1 ? `A${band}` : `(${scale} * A${band})`;
+  };
+
+  const numericParams: Record<string, number> = {};
+  const L = asNumber(params.L);
+  if (L !== undefined) numericParams.L = L;
+
+  const expression = index.expr(tok, numericParams);
+  return { expression, bands: used, index };
+}

--- a/packages/processing/src/spectral-indices.ts
+++ b/packages/processing/src/spectral-indices.ts
@@ -14,8 +14,6 @@
  * GeoTIFFs.
  */
 
-import type { AlgorithmParameter } from "./types";
-
 /** Canonical reflectance bands an index formula can reference. */
 export type BandName = "blue" | "green" | "red" | "nir" | "swir1" | "swir2";
 
@@ -139,7 +137,7 @@ export function getSpectralIndex(id: string): SpectralIndex | undefined {
  * surface-reflectance stack order for each sensor; they are editable via the
  * "custom" sensor when a file is stacked differently.
  */
-export const SENSOR_PRESETS: Record<string, BandLayout> = {
+export const SENSOR_PRESETS: Record<(typeof SENSOR_IDS)[number], BandLayout> = {
   // Sentinel-2 6-band reflectance stack [B2, B3, B4, B8, B11, B12].
   sentinel2: { blue: 1, green: 2, red: 3, nir: 4, swir1: 5, swir2: 6 },
   // Landsat 8/9 (OLI) Collection 2 surface reflectance bands B1–B7.
@@ -173,12 +171,17 @@ function resolveBand(
   sensor: string,
   params: Record<string, unknown>,
 ): number {
-  const fromParam = asNumber(params[name]);
-  const fromPreset = SENSOR_PRESETS[sensor]?.[name];
-  const band = sensor === "custom" ? fromParam : (fromParam ?? fromPreset);
+  // Preset sensors always use their preset band layout; only the Custom sensor
+  // reads the manual band-number params. (Mixing the two would let a stale
+  // hidden custom value override a freshly selected preset.)
+  const preset = SENSOR_PRESETS[sensor as (typeof SENSOR_IDS)[number]];
+  const band = sensor === "custom" ? asNumber(params[name]) : preset?.[name];
   if (band == null) {
     throw new Error(
-      `Band "${name}" is required for this index — set it under the band numbers.`,
+      sensor === "custom"
+        ? `Band "${name}" is required for this index — enter a band number above.`
+        : `The ${sensor} preset does not include the "${name}" band this index needs. ` +
+          `Switch to a sensor that has it, or select Custom to enter a band number.`,
     );
   }
   if (!Number.isInteger(band) || band < 1) {

--- a/tests/raster-tools.test.ts
+++ b/tests/raster-tools.test.ts
@@ -15,6 +15,7 @@ const EXPECTED_IDS = [
   "interpolate",
   "zonal",
   "raster-calc",
+  "spectral-index",
   "reclassify",
   "mosaic",
   "focal",

--- a/tests/spectral-indices.test.ts
+++ b/tests/spectral-indices.test.ts
@@ -35,7 +35,7 @@ describe("spectral index expression builder", () => {
     assert.equal(supportsClientRaster("spectral-index"), true);
   });
 
-  it("builds NDVI from the Sentinel-2 preset (red B3, NIR B4)", () => {
+  it("builds NDVI from the Sentinel-2 preset (red at stack pos 3, NIR at stack pos 4)", () => {
     const { expression, bands, index } = buildSpectralIndexExpression({
       index: "ndvi",
       sensor: "sentinel2",

--- a/tests/spectral-indices.test.ts
+++ b/tests/spectral-indices.test.ts
@@ -112,6 +112,14 @@ describe("spectral index expression builder", () => {
     );
   });
 
+  it("throws when the sensor preset lacks a required band (NAIP + NDMI)", () => {
+    // NAIP carries only R/G/B/NIR, so a SWIR-dependent index can't resolve.
+    assert.throws(
+      () => buildSpectralIndexExpression({ index: "ndmi", sensor: "naip" }),
+      /naip preset does not include the "swir1" band/i,
+    );
+  });
+
   it("rejects an unknown index id", () => {
     assert.throws(
       () => buildSpectralIndexExpression({ index: "nope", sensor: "sentinel2" }),

--- a/tests/spectral-indices.test.ts
+++ b/tests/spectral-indices.test.ts
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  buildSpectralIndexExpression,
+  getSpectralIndex,
+  runRasterToolClient,
+  supportsClientRaster,
+  SPECTRAL_INDICES,
+  type RasterData,
+} from "@geolibre/processing";
+
+/** Build a small in-memory raster for tests (top-left origin, 1-unit pixels). */
+function makeRaster(
+  bands: number[][],
+  width = 1,
+  height = 1,
+  overrides: Partial<RasterData> = {},
+): RasterData {
+  return {
+    bands: bands.map((b) => Float32Array.from(b)),
+    width,
+    height,
+    originX: 0,
+    originY: height,
+    resX: 1,
+    resY: 1,
+    nodata: null,
+    geoKeys: { GTModelTypeGeoKey: 2, GeographicTypeGeoKey: 4326 },
+    ...overrides,
+  };
+}
+
+describe("spectral index expression builder", () => {
+  it("registers the tool as client-capable", () => {
+    assert.equal(supportsClientRaster("spectral-index"), true);
+  });
+
+  it("builds NDVI from the Sentinel-2 preset (red B3, NIR B4)", () => {
+    const { expression, bands, index } = buildSpectralIndexExpression({
+      index: "ndvi",
+      sensor: "sentinel2",
+    });
+    assert.equal(expression, "(A4 - A3) / (A4 + A3)");
+    assert.deepEqual(bands, [4, 3]);
+    assert.equal(index.id, "ndvi");
+  });
+
+  it("builds NDVI from the Landsat 8/9 preset (red B4, NIR B5)", () => {
+    const { expression } = buildSpectralIndexExpression({
+      index: "ndvi",
+      sensor: "landsat89",
+    });
+    assert.equal(expression, "(A5 - A4) / (A5 + A4)");
+  });
+
+  it("orders NDWI as (green - nir)", () => {
+    const { expression } = buildSpectralIndexExpression({
+      index: "ndwi",
+      sensor: "sentinel2",
+    });
+    assert.equal(expression, "(A2 - A4) / (A2 + A4)");
+  });
+
+  it("threads the SAVI soil factor into the formula", () => {
+    const { expression } = buildSpectralIndexExpression({
+      index: "savi",
+      sensor: "sentinel2",
+      L: 0.25,
+    });
+    assert.equal(expression, "((A4 - A3) / (A4 + A3 + 0.25)) * (1 + 0.25)");
+  });
+
+  it("applies the reflectance scale to EVI's additive constants", () => {
+    const { expression, bands } = buildSpectralIndexExpression({
+      index: "evi",
+      sensor: "sentinel2",
+      scale: 0.0001,
+    });
+    assert.equal(
+      expression,
+      "2.5 * (((0.0001 * A4) - (0.0001 * A3)) / " +
+        "((0.0001 * A4) + 6 * (0.0001 * A3) - 7.5 * (0.0001 * A1) + 1))",
+    );
+    assert.deepEqual(bands, [4, 3, 1]);
+  });
+
+  it("omits the scale factor when it is 1 (ratio cancels it)", () => {
+    const { expression } = buildSpectralIndexExpression({
+      index: "ndvi",
+      sensor: "sentinel2",
+      scale: 1,
+    });
+    assert.ok(!expression.includes("*"), expression);
+  });
+
+  it("resolves bands from manual inputs with the custom sensor", () => {
+    const { expression, bands } = buildSpectralIndexExpression({
+      index: "ndvi",
+      sensor: "custom",
+      red: 1,
+      nir: 2,
+    });
+    assert.equal(expression, "(A2 - A1) / (A2 + A1)");
+    assert.deepEqual(bands, [2, 1]);
+  });
+
+  it("throws when a required band is missing in custom mode", () => {
+    assert.throws(
+      () =>
+        buildSpectralIndexExpression({ index: "ndvi", sensor: "custom", red: 1 }),
+      /Band "nir" is required/,
+    );
+  });
+
+  it("rejects an unknown index id", () => {
+    assert.throws(
+      () => buildSpectralIndexExpression({ index: "nope", sensor: "sentinel2" }),
+      /Unknown spectral index/,
+    );
+  });
+
+  it("exposes a value range and colormap for every index", () => {
+    for (const index of SPECTRAL_INDICES) {
+      assert.ok(index.range[0] < index.range[1], index.id);
+      assert.ok(index.colormap.length > 0, index.id);
+    }
+    assert.equal(getSpectralIndex("ndvi")?.name.startsWith("NDVI"), true);
+  });
+});
+
+describe("spectral index client compute", () => {
+  it("computes NDVI over a multiband raster", () => {
+    // 4 bands; band 3 = red = 2000, band 4 = nir = 6000 → (6000-2000)/8000 = 0.5
+    const raster = makeRaster([[0], [0], [2000], [6000]]);
+    const { raster: out, messages } = runRasterToolClient(
+      "spectral-index",
+      raster,
+      { index: "ndvi", sensor: "sentinel2" },
+    );
+    assert.equal(out.bands.length, 1);
+    assert.ok(Math.abs(out.bands[0][0] - 0.5) < 1e-6);
+    assert.ok(messages.some((m) => m.includes("(A4 - A3)")));
+  });
+
+  it("errors when the index needs a band the raster lacks", () => {
+    const raster = makeRaster([[1], [2]]); // only 2 bands
+    assert.throws(
+      () =>
+        runRasterToolClient("spectral-index", raster, {
+          index: "ndvi",
+          sensor: "sentinel2", // needs band 4
+        }),
+      /only 2 band/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds a **Spectral Index** tool under **Processing → Raster → Analysis** that computes named spectral indices from a multiband raster. It's a preset-driven front end over the existing raster calculator: a chosen index + sensor band layout is compiled into the same single-input band-math expression that `rasterCalc` (browser) and the `raster-calc` sidecar script already evaluate — so there's **no new compute kernel**, and band-math validation + add-to-map plumbing are reused.

This is the first piece of the remote-sensing/imagery-analysis gap (the platform can ingest imagery from Planetary Computer / Earth Engine / STAC / COGs but couldn't analyze it).

## Indices

NDVI, GNDVI, NDWI (McFeeters), NDMI, NDBI, NBR, EVI, SAVI.

## Band layouts

Sensor presets (**Sentinel-2**, **Landsat 8/9**, **NAIP**) prefill band numbers; **Custom** lets you map bands by hand for arbitrarily stacked GeoTIFFs. A **reflectance scale** knob handles EVI/SAVI on integer-DN imagery (e.g. `0.0001` for Sentinel-2 L2A); normalized-difference indices are scale-independent and leave it at 1.

## Engines

- **Client (browser):** builds the expression and runs `rasterCalc` via geotiff.js — works with no sidecar, validates that referenced bands exist.
- **Sidecar (rasterio):** the dialog injects the compiled expression and reuses the `raster-calc` script (`spectral-index` aliased to it in `_RASTER_TOOL_SCRIPTS`).

## Files

- `packages/processing/src/spectral-indices.ts` (new) — index catalog, sensor presets, and `buildSpectralIndexExpression` (single source of truth for both engines)
- `packages/processing/src/raster-tools.ts` — registry entry + params; `raster-client.ts` — client dispatch; `index.ts` — exports
- `packages/core/src/store.ts` — `RasterToolKind` union
- `apps/.../toolbar/{constants,ProcessingMenu}.tsx` + `RasterToolsDialog.tsx` + `i18n/locales/en.json` — menu wiring, sidecar expression injection, string
- `backend/.../raster.py` — `spectral-index` reuses the raster-calc script

## Tests

- `tests/spectral-indices.test.ts` (new, 13 cases): expression generation per index/sensor/scale, custom-band resolution, missing-band errors, and an NDVI compute over a synthetic 4-band raster.
- Updated the hardcoded tool-id lists in `tests/raster-tools.test.ts` and `backend/.../tests/test_raster.py`.

Full frontend suite: 937 pass / 0 fail · backend raster: 30/30 · `npm run typecheck` (full build) ✓ · pre-commit (eslint + npm build) ✓.

## Follow-ups (out of scope)

Native `spectral_index` sidecar op for nodata-correct masking on large rasters; default output colormap/range styling; band auto-detection from GeoTIFF/STAC band descriptions; a `Map.add_spectral_index()` entry in the `geolibre` Python widget.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Spectral Index raster processing tool (NDVI, GNDVI, NDWI, NDMI, NDBI, NBR, EVI, SAVI) and a Raster submenu option (desktop, non-mobile).
  * Provides sensor presets (Sentinel-2, Landsat 8/9, NAIP) plus custom band mapping.
  * Supports optional SAVI soil factor (L) and reflectance scaling.
* **Bug Fixes**
  * Improved messaging and validation for missing required bands and invalid spectral index inputs.
* **Tests**
  * Added/extended spectral index expression and client-side computation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->