### PR TITLE
fix(vector): render GeoPackages without GDAL's WASM thread crash (#393)

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -67,7 +67,7 @@
     "maplibre-gl-nasa-earthdata": "^0.1.2",
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.2.3",
+    "maplibre-gl-raster": "^0.2.4",
     "maplibre-gl-streetview": "^0.6.0",
     "maplibre-gl-swipe": "^0.7.1",
     "maplibre-gl-time-slider": "^1.0.3",

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -67,7 +67,7 @@
     "maplibre-gl-nasa-earthdata": "^0.1.2",
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.2.2",
+    "maplibre-gl-raster": "^0.2.3",
     "maplibre-gl-streetview": "^0.6.0",
     "maplibre-gl-swipe": "^0.7.1",
     "maplibre-gl-time-slider": "^1.0.3",

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -67,7 +67,7 @@
     "maplibre-gl-nasa-earthdata": "^0.1.2",
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.2.1",
+    "maplibre-gl-raster": "^0.2.2",
     "maplibre-gl-streetview": "^0.6.0",
     "maplibre-gl-swipe": "^0.7.1",
     "maplibre-gl-time-slider": "^1.0.3",

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -1,9 +1,10 @@
 import { useAppStore, type GeoLibreLayer } from "@geolibre/core";
 import type { FeatureCollection } from "geojson";
 import type { MapController, MapDiagnosticEvent } from "@geolibre/map";
-import { MapCanvas } from "@geolibre/map";
+import { MapCanvas, setExternalDeckLayerOrderHandler } from "@geolibre/map";
 import {
   addRasterToMap,
+  applyRasterLayerOrder,
   DECK_VIZ_PLUGIN_ID,
   DIRECTIONS_PLUGIN_ID,
   EFFECTS_PLUGIN_ID,
@@ -515,6 +516,10 @@ export function DesktopShell({
     restoreThreeDTilesLayers(appAPI);
     restoreRasterLayers(appAPI);
     restoreVectorLayers(appAPI);
+    // Let layer-sync push the store-derived beforeId into the raster control so
+    // deck.gl COG rasters interleave with vector layers instead of always
+    // drawing on top.
+    setExternalDeckLayerOrderHandler(applyRasterLayerOrder);
     // activeByDefault plugins are marked active without activate() being
     // called, so the effects engine must be kicked explicitly to match the
     // restored active state (idempotent).

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -17,6 +17,11 @@ import {
   type DuckDbVectorLoadOptions,
 } from "./duckdb-vector-guard";
 import { ensureGpkgFeatureCount } from "./gpkg-ogr-contents";
+import {
+  countGeoPackageFeatures,
+  isGeoPackage,
+  loadGeoPackageVectorFile,
+} from "./gpkg-reader";
 import { getSpatialExtensionPath } from "./spatial-extension-config";
 
 // Re-exported for existing importers (sql-workspace, duckdb-processing, etc.)
@@ -312,10 +317,55 @@ async function countFeatures(
   return typeof raw === "bigint" ? Number(raw) : Number(raw ?? 0);
 }
 
+/**
+ * Read a GeoPackage with sql.js + {@link decodeWkb} instead of DuckDB's
+ * `ST_Read`, which crashes on the single-threaded WASM build for all but the
+ * smallest layers (GDAL fills Arrow batches on a background thread). The
+ * geometries are reprojected to WGS84 via the shared DuckDB-based path when the
+ * layer is not already in EPSG:4326. See `gpkg-reader.ts` and issue #393.
+ */
+async function loadGeoPackageVector(
+  file: DuckDbVectorFile,
+  options: DuckDbVectorLoadOptions,
+): Promise<FeatureCollection> {
+  if (options.onLargeDataset) {
+    const counted = await countGeoPackageFeatures(file.data);
+    if (counted) {
+      await confirmLargeDataset(
+        { name: file.name, featureCount: counted.featureCount },
+        options.onLargeDataset,
+      );
+    }
+  }
+
+  const { featureCollection, epsgCode } = await loadGeoPackageVectorFile(
+    file.data,
+  );
+  if (epsgCode == null) {
+    return featureCollection as FeatureCollection;
+  }
+
+  // Tag the collection with its source CRS and reproject to WGS84 through the
+  // shared DuckDB ST_Transform path (the GeoJSON reader it uses is not affected
+  // by the GeoPackage threading bug).
+  const tagged = {
+    ...featureCollection,
+    crs: { type: "name", properties: { name: `EPSG:${epsgCode}` } },
+  } as FeatureCollection;
+  return reprojectFeatureCollectionToWgs84(tagged);
+}
+
 export async function loadDuckDbVectorFile(
   file: DuckDbVectorFile,
   options: DuckDbVectorLoadOptions = {},
 ): Promise<FeatureCollection> {
+  // GeoPackages are read without GDAL to avoid the single-threaded-WASM thread
+  // crash in DuckDB's ST_Read (issue #393). A file mislabelled `.gpkg` that is
+  // not actually SQLite falls through to the generic ST_Read path below.
+  if (file.extension === "gpkg" && isGeoPackage(file.data)) {
+    return loadGeoPackageVector(file, options);
+  }
+
   const db = await getDatabase();
   const connection = await db.connect();
 

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -17,7 +17,7 @@ import {
   type DuckDbVectorLoadOptions,
 } from "./duckdb-vector-guard";
 import { ensureGpkgFeatureCount } from "./gpkg-ogr-contents";
-import { isGeoPackage, loadGeoPackageVectorFile } from "./gpkg-reader";
+import { isLikelyGeoPackage, loadGeoPackageVectorFile } from "./gpkg-reader";
 import { getSpatialExtensionPath } from "./spatial-extension-config";
 
 // Re-exported for existing importers (sql-workspace, duckdb-processing, etc.)
@@ -359,7 +359,7 @@ export async function loadDuckDbVectorFile(
   // GeoPackages are read without GDAL to avoid the single-threaded-WASM thread
   // crash in DuckDB's ST_Read (issue #393). A file mislabelled `.gpkg` that is
   // not actually SQLite falls through to the generic ST_Read path below.
-  if (file.extension === "gpkg" && isGeoPackage(file.data)) {
+  if (file.extension === "gpkg" && isLikelyGeoPackage(file.data)) {
     return loadGeoPackageVector(file, options);
   }
 

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -17,11 +17,7 @@ import {
   type DuckDbVectorLoadOptions,
 } from "./duckdb-vector-guard";
 import { ensureGpkgFeatureCount } from "./gpkg-ogr-contents";
-import {
-  countGeoPackageFeatures,
-  isGeoPackage,
-  loadGeoPackageVectorFile,
-} from "./gpkg-reader";
+import { isGeoPackage, loadGeoPackageVectorFile } from "./gpkg-reader";
 import { getSpatialExtensionPath } from "./spatial-extension-config";
 
 // Re-exported for existing importers (sql-workspace, duckdb-processing, etc.)
@@ -328,18 +324,19 @@ async function loadGeoPackageVector(
   file: DuckDbVectorFile,
   options: DuckDbVectorLoadOptions,
 ): Promise<FeatureCollection> {
-  if (options.onLargeDataset) {
-    const counted = await countGeoPackageFeatures(file.data);
-    if (counted) {
-      await confirmLargeDataset(
-        { name: file.name, featureCount: counted.featureCount },
-        options.onLargeDataset,
-      );
-    }
-  }
+  // Guard large datasets on the single GeoPackage open: the count is taken
+  // before the rows are read, so the file is not parsed twice.
+  const onBeforeRead = options.onLargeDataset
+    ? ({ featureCount }: { featureCount: number }) =>
+        confirmLargeDataset(
+          { name: file.name, featureCount },
+          options.onLargeDataset,
+        )
+    : undefined;
 
   const { featureCollection, epsgCode } = await loadGeoPackageVectorFile(
     file.data,
+    onBeforeRead,
   );
   if (epsgCode == null) {
     return featureCollection as FeatureCollection;

--- a/apps/geolibre-desktop/src/lib/geometry-wkb.ts
+++ b/apps/geolibre-desktop/src/lib/geometry-wkb.ts
@@ -131,6 +131,140 @@ export function encodeWkb(geometry: Geometry): Uint8Array {
   return writer.bytes();
 }
 
+const WKB_TYPE_NAME: Record<number, Geometry["type"]> = {
+  1: "Point",
+  2: "LineString",
+  3: "Polygon",
+  4: "MultiPoint",
+  5: "MultiLineString",
+  6: "MultiPolygon",
+  7: "GeometryCollection",
+};
+
+/**
+ * Decode a standalone WKB (Well-Known Binary) buffer into a GeoJSON geometry.
+ *
+ * The inverse of {@link encodeWkb}, used to read GeoPackage geometry blobs
+ * without GDAL (see `gpkg-reader.ts`). Handles mixed byte order, ISO WKB
+ * dimensionality (Z/M, where the type code is offset by 1000/2000/3000) and the
+ * PostGIS EWKB Z/M/SRID high-bit flags. The M ordinate is dropped; Z is kept so
+ * a `[x, y, z]` position survives. Throws on the curved geometry types
+ * (CircularString and friends, codes 8-12) that GeoJSON cannot represent.
+ *
+ * @param bytes The WKB buffer (no GeoPackage header).
+ * @returns The decoded GeoJSON geometry.
+ */
+export function decodeWkb(bytes: Uint8Array): Geometry {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let offset = 0;
+
+  function readGeometry(): Geometry {
+    const little = view.getUint8(offset) === 1;
+    offset += 1;
+    const rawType = view.getUint32(offset, little);
+    offset += 4;
+
+    // PostGIS EWKB encodes Z/M/SRID in the high bits; ISO WKB encodes Z/M by
+    // offsetting the type code (1000 = Z, 2000 = M, 3000 = ZM). Support both so
+    // any standards-conformant GeoPackage geometry blob decodes.
+    const hasEwkbZ = (rawType & 0x80000000) !== 0;
+    const hasEwkbM = (rawType & 0x40000000) !== 0;
+    const hasSrid = (rawType & 0x20000000) !== 0;
+    const baseType = rawType & 0xffff;
+    const isoGroup = Math.floor((baseType % 4000) / 1000);
+    const code = baseType % 1000;
+    const hasZ = hasEwkbZ || isoGroup === 1 || isoGroup === 3;
+    const hasM = hasEwkbM || isoGroup === 2 || isoGroup === 3;
+    const dimensions = 2 + (hasZ ? 1 : 0) + (hasM ? 1 : 0);
+
+    // An EWKB SRID prefix precedes the coordinates; skip it (the layer CRS is
+    // taken from the GeoPackage metadata, not the per-geometry SRID).
+    if (hasSrid) offset += 4;
+
+    const readPosition = (): Position => {
+      const x = view.getFloat64(offset, little);
+      offset += 8;
+      const y = view.getFloat64(offset, little);
+      offset += 8;
+      let z: number | undefined;
+      if (hasZ) {
+        z = view.getFloat64(offset, little);
+        offset += 8;
+      }
+      if (hasM) offset += 8; // M is not represented in GeoJSON.
+      return z === undefined ? [x, y] : [x, y, z];
+    };
+
+    const readPositions = (): Position[] => {
+      const count = view.getUint32(offset, little);
+      offset += 4;
+      const positions: Position[] = [];
+      for (let i = 0; i < count; i += 1) positions.push(readPosition());
+      return positions;
+    };
+
+    const readRings = (): Position[][] => {
+      const count = view.getUint32(offset, little);
+      offset += 4;
+      const rings: Position[][] = [];
+      for (let i = 0; i < count; i += 1) rings.push(readPositions());
+      return rings;
+    };
+
+    const readChildren = (): Geometry[] => {
+      const count = view.getUint32(offset, little);
+      offset += 4;
+      const children: Geometry[] = [];
+      for (let i = 0; i < count; i += 1) children.push(readGeometry());
+      return children;
+    };
+
+    switch (code) {
+      case 1:
+        return { type: "Point", coordinates: readPosition() };
+      case 2:
+        return { type: "LineString", coordinates: readPositions() };
+      case 3:
+        return { type: "Polygon", coordinates: readRings() };
+      case 4: {
+        const points = readChildren();
+        return {
+          type: "MultiPoint",
+          coordinates: points.map((p) => (p as { coordinates: Position }).coordinates),
+        };
+      }
+      case 5: {
+        const lines = readChildren();
+        return {
+          type: "MultiLineString",
+          coordinates: lines.map(
+            (l) => (l as { coordinates: Position[] }).coordinates,
+          ),
+        };
+      }
+      case 6: {
+        const polygons = readChildren();
+        return {
+          type: "MultiPolygon",
+          coordinates: polygons.map(
+            (p) => (p as { coordinates: Position[][] }).coordinates,
+          ),
+        };
+      }
+      case 7:
+        return { type: "GeometryCollection", geometries: readChildren() };
+      default:
+        throw new Error(
+          `Unsupported WKB geometry type ${code}${
+            WKB_TYPE_NAME[code] ? "" : " (curved geometries are not supported)"
+          }.`,
+        );
+    }
+  }
+
+  return readGeometry();
+}
+
 export interface BoundingBox {
   minX: number;
   minY: number;

--- a/apps/geolibre-desktop/src/lib/geometry-wkb.ts
+++ b/apps/geolibre-desktop/src/lib/geometry-wkb.ts
@@ -131,16 +131,6 @@ export function encodeWkb(geometry: Geometry): Uint8Array {
   return writer.bytes();
 }
 
-const WKB_TYPE_NAME: Record<number, Geometry["type"]> = {
-  1: "Point",
-  2: "LineString",
-  3: "Polygon",
-  4: "MultiPoint",
-  5: "MultiLineString",
-  6: "MultiPolygon",
-  7: "GeometryCollection",
-};
-
 /**
  * Decode a standalone WKB (Well-Known Binary) buffer into a GeoJSON geometry.
  *
@@ -175,7 +165,6 @@ export function decodeWkb(bytes: Uint8Array): Geometry {
     const code = baseType % 1000;
     const hasZ = hasEwkbZ || isoGroup === 1 || isoGroup === 3;
     const hasM = hasEwkbM || isoGroup === 2 || isoGroup === 3;
-    const dimensions = 2 + (hasZ ? 1 : 0) + (hasM ? 1 : 0);
 
     // An EWKB SRID prefix precedes the coordinates; skip it (the layer CRS is
     // taken from the GeoPackage metadata, not the per-geometry SRID).
@@ -254,9 +243,13 @@ export function decodeWkb(bytes: Uint8Array): Geometry {
       case 7:
         return { type: "GeometryCollection", geometries: readChildren() };
       default:
+        // Codes 8-12 are the curved geometries (CircularString, CompoundCurve,
+        // CurvePolygon, MultiCurve, MultiSurface) that GeoJSON cannot represent.
         throw new Error(
           `Unsupported WKB geometry type ${code}${
-            WKB_TYPE_NAME[code] ? "" : " (curved geometries are not supported)"
+            code >= 8 && code <= 12
+              ? " (curved geometries are not supported)"
+              : ""
           }.`,
         );
     }

--- a/apps/geolibre-desktop/src/lib/gpkg-ogr-contents.ts
+++ b/apps/geolibre-desktop/src/lib/gpkg-ogr-contents.ts
@@ -30,11 +30,13 @@ export function looksLikeSqlite(bytes: Uint8Array): boolean {
   return true;
 }
 
-function quoteIdentifier(value: string): string {
+/** Quote a SQLite identifier (table/column name) by doubling embedded quotes. */
+export function quoteIdentifier(value: string): string {
   return `"${value.replaceAll('"', '""')}"`;
 }
 
-function tableExists(db: Database, name: string): boolean {
+/** Whether a table of the given name exists in the SQLite database. */
+export function tableExists(db: Database, name: string): boolean {
   const result = db.exec(
     "SELECT 1 FROM sqlite_master WHERE type='table' AND name=:name",
     { ":name": name },

--- a/apps/geolibre-desktop/src/lib/gpkg-reader.ts
+++ b/apps/geolibre-desktop/src/lib/gpkg-reader.ts
@@ -1,0 +1,226 @@
+import type { Feature, FeatureCollection, Geometry } from "geojson";
+import type { Database, SqlJsStatic } from "sql.js";
+import { decodeWkb } from "./geometry-wkb";
+import { loadSqlJs, looksLikeSqlite } from "./gpkg-ogr-contents";
+
+/**
+ * Read GeoPackages with sql.js (SQLite/WASM) instead of DuckDB's `ST_Read`.
+ *
+ * GDAL's GeoPackage driver fills Arrow result batches on a background thread
+ * once a layer is more than a few features long. The single-threaded DuckDB-WASM
+ * `eh` bundle the app loads has no pthread support, so that read aborts with
+ * "thread constructor failed: Resource temporarily unavailable" — many valid
+ * GeoPackages never render, while tiny ones happen to slip under the threshold.
+ * Repairing `gpkg_ogr_contents` (see `gpkg-ogr-contents.ts`) fixes the related
+ * feature-count crash but not this one, and no DuckDB-reachable GDAL config
+ * disables the threading. Reading the SQLite tables directly sidesteps GDAL
+ * entirely: sql.js is already bundled for the count repair, GeoPackage geometry
+ * blobs are a thin "GP" header over standard WKB, and {@link decodeWkb} turns
+ * that WKB into GeoJSON. See GitHub issue #393.
+ */
+
+/** A selected feature layer plus the metadata needed to read its rows. */
+interface GeoPackageLayer {
+  table: string;
+  geometryColumn: string;
+  srsId: number | null;
+  /** The INTEGER PRIMARY KEY column, excluded from feature properties. */
+  idColumn: string | null;
+}
+
+export interface GeoPackageReadResult {
+  featureCollection: FeatureCollection<Geometry | null>;
+  /**
+   * The EPSG code the geometries are stored in, or null when they are already
+   * WGS84 lon/lat (or the CRS is undefined). The caller reprojects when set.
+   */
+  epsgCode: number | null;
+}
+
+function quoteIdentifier(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`;
+}
+
+/**
+ * Strip the GeoPackage geometry-blob header, returning the standard WKB inside.
+ *
+ * The header is the "GP" magic, a version byte, a flags byte, a 4-byte srs_id,
+ * and an optional envelope whose size is encoded in flag bits 1-3. A blob that
+ * is already bare WKB (first byte a 0x00/0x01 byte-order marker) is returned
+ * unchanged so non-conformant producers still read.
+ */
+export function stripGeoPackageHeader(blob: Uint8Array): Uint8Array {
+  // 'G','P' magic identifies a GeoPackage geometry blob; otherwise assume the
+  // value is already standalone WKB (byte-order byte 0x00 or 0x01).
+  if (blob.length < 2 || blob[0] !== 0x47 || blob[1] !== 0x50) return blob;
+  const flags = blob[3];
+  const envelopeIndicator = (flags >> 1) & 0x07;
+  // Envelope byte sizes by indicator: 0=none, 1=XY, 2=XYZ, 3=XYM, 4=XYZM.
+  const envelopeBytes = [0, 32, 48, 48, 64, 0, 0, 0][envelopeIndicator];
+  const headerLength = 8 + envelopeBytes;
+  return blob.subarray(headerLength);
+}
+
+function tableExists(db: Database, name: string): boolean {
+  const result = db.exec(
+    "SELECT 1 FROM sqlite_master WHERE type='table' AND name=:name",
+    { ":name": name },
+  );
+  return result.length > 0 && result[0].values.length > 0;
+}
+
+/**
+ * Pick the layer to read: the first `features` row in `gpkg_contents` that has a
+ * registered geometry column. Mirrors GDAL's "first layer" default (no `layer=`
+ * argument), which is what the previous `ST_Read` path used.
+ */
+function selectLayer(db: Database): GeoPackageLayer | null {
+  if (!tableExists(db, "gpkg_geometry_columns")) return null;
+  const result = db.exec(
+    `SELECT g.table_name, g.column_name, g.srs_id
+     FROM gpkg_geometry_columns g
+     JOIN gpkg_contents c ON c.table_name = g.table_name
+     WHERE lower(c.data_type) = 'features'
+     ORDER BY c.rowid
+     LIMIT 1`,
+  );
+  const row = result[0]?.values[0];
+  if (!row) return null;
+  const table = String(row[0]);
+  const geometryColumn = String(row[1]);
+  const srsId = row[2] == null ? null : Number(row[2]);
+
+  let idColumn: string | null = null;
+  for (const info of db.exec(
+    `PRAGMA table_info(${quoteIdentifier(table)})`,
+  )[0]?.values ?? []) {
+    // table_info columns: cid, name, type, notnull, dflt_value, pk.
+    if (info[5] === 1) idColumn = String(info[1]);
+  }
+  return { table, geometryColumn, srsId, idColumn };
+}
+
+/**
+ * Resolve the layer's SRS to an EPSG code, or null when it is WGS84 lon/lat or
+ * undefined (srs_id 0 = undefined geographic, -1 = undefined cartesian). Only
+ * EPSG-organization rows are reprojectable here.
+ */
+// EPSG codes whose horizontal axes are already WGS84 lon/lat, so reprojecting
+// to 4326 is a no-op: 4326 (2D) and 4979 (3D geographic, same lat/lon).
+const WGS84_EPSG_CODES = new Set([4326, 4979]);
+
+function resolveEpsgCode(db: Database, srsId: number | null): number | null {
+  // srs_id 0 = undefined geographic, -1 = undefined cartesian (GeoPackage spec).
+  if (srsId == null || srsId === 0 || srsId === -1 || WGS84_EPSG_CODES.has(srsId)) {
+    return null;
+  }
+  if (!tableExists(db, "gpkg_spatial_ref_sys")) return null;
+  const row = db.exec(
+    `SELECT organization, organization_coordsys_id
+     FROM gpkg_spatial_ref_sys WHERE srs_id = :id`,
+    { ":id": srsId },
+  )[0]?.values[0];
+  if (!row) return null;
+  const organization = String(row[0] ?? "").toUpperCase();
+  const code = row[1] == null ? null : Number(row[1]);
+  if (organization !== "EPSG" || code == null) return null;
+  return WGS84_EPSG_CODES.has(code) ? null : code;
+}
+
+/** Count the layer's rows for the large-dataset guard without materializing them. */
+export function countGeoPackageFeaturesSync(
+  SQL: SqlJsStatic,
+  bytes: Uint8Array,
+): { name: string; featureCount: number } | null {
+  const db = new SQL.Database(bytes);
+  try {
+    const layer = selectLayer(db);
+    if (!layer) return null;
+    const row = db.exec(
+      `SELECT count(*) FROM ${quoteIdentifier(layer.table)}`,
+    )[0]?.values[0];
+    return { name: layer.table, featureCount: Number(row?.[0] ?? 0) };
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Synchronous core of {@link loadGeoPackageVectorFile}: read every feature of
+ * the first layer into a GeoJSON FeatureCollection. Separated so it can be
+ * unit-tested with an already-initialised sql.js factory.
+ */
+export function readGeoPackageSync(
+  SQL: SqlJsStatic,
+  bytes: Uint8Array,
+): GeoPackageReadResult {
+  const db = new SQL.Database(bytes);
+  try {
+    const layer = selectLayer(db);
+    if (!layer) {
+      throw new Error("No vector feature layer found in this GeoPackage.");
+    }
+    const epsgCode = resolveEpsgCode(db, layer.srsId);
+
+    const result = db.exec(`SELECT * FROM ${quoteIdentifier(layer.table)}`);
+    const features: Feature<Geometry | null>[] = [];
+    if (result.length > 0) {
+      const columns = result[0].columns;
+      const geometryIndex = columns.indexOf(layer.geometryColumn);
+      const idIndex = layer.idColumn ? columns.indexOf(layer.idColumn) : -1;
+
+      for (const row of result[0].values) {
+        const properties: Record<string, unknown> = {};
+        for (let i = 0; i < columns.length; i += 1) {
+          if (i === geometryIndex || i === idIndex) continue;
+          const value = row[i];
+          // sql.js returns BLOB columns as Uint8Array; binary attributes are not
+          // JSON-serialisable, so drop them (matching the ST_Read path).
+          if (value instanceof Uint8Array) continue;
+          properties[columns[i]] = value;
+        }
+
+        const rawGeometry = row[geometryIndex];
+        let geometry: Geometry | null = null;
+        if (rawGeometry instanceof Uint8Array && rawGeometry.length > 0) {
+          const wkb = stripGeoPackageHeader(rawGeometry);
+          // A GeoPackage "empty geometry" header carries no WKB body.
+          geometry = wkb.length > 0 ? decodeWkb(wkb) : null;
+        }
+        features.push({ type: "Feature", geometry, properties });
+      }
+    }
+
+    return {
+      featureCollection: { type: "FeatureCollection", features },
+      epsgCode,
+    };
+  } finally {
+    db.close();
+  }
+}
+
+/** Whether {@link loadGeoPackageVectorFile} can handle these bytes (a SQLite file). */
+export function isGeoPackage(bytes: Uint8Array): boolean {
+  return looksLikeSqlite(bytes);
+}
+
+/**
+ * Read a GeoPackage buffer into a GeoJSON FeatureCollection via sql.js,
+ * bypassing GDAL. Returns the collection plus the source EPSG code (null when
+ * already WGS84) so the caller can reproject. Loads sql.js on demand.
+ */
+export async function loadGeoPackageVectorFile(
+  bytes: Uint8Array,
+): Promise<GeoPackageReadResult> {
+  const SQL = await loadSqlJs();
+  return readGeoPackageSync(SQL, bytes);
+}
+
+/** Count a GeoPackage's first-layer features, loading sql.js on demand. */
+export async function countGeoPackageFeatures(
+  bytes: Uint8Array,
+): Promise<{ name: string; featureCount: number } | null> {
+  const SQL = await loadSqlJs();
+  return countGeoPackageFeaturesSync(SQL, bytes);
+}

--- a/apps/geolibre-desktop/src/lib/gpkg-reader.ts
+++ b/apps/geolibre-desktop/src/lib/gpkg-reader.ts
@@ -90,9 +90,13 @@ function selectLayer(db: Database): GeoPackageLayer | null {
   if (!tableExists(db, "gpkg_geometry_columns")) return null;
   if (!tableExists(db, "gpkg_contents")) return null;
   const result = db.exec(
+    // COLLATE NOCASE: SQLite's default BINARY collation makes the join
+    // case-sensitive, but a producer can spell the same table differently in
+    // gpkg_contents and gpkg_geometry_columns (SQLite table names are
+    // case-insensitive). gpkg-ogr-contents.ts handles the same mismatch.
     `SELECT g.table_name, g.column_name, g.srs_id
      FROM gpkg_geometry_columns g
-     JOIN gpkg_contents c ON c.table_name = g.table_name
+     JOIN gpkg_contents c ON c.table_name = g.table_name COLLATE NOCASE
      WHERE lower(c.data_type) = 'features'
      ORDER BY c.rowid
      LIMIT 1`,

--- a/apps/geolibre-desktop/src/lib/gpkg-reader.ts
+++ b/apps/geolibre-desktop/src/lib/gpkg-reader.ts
@@ -1,7 +1,12 @@
 import type { Feature, FeatureCollection, Geometry } from "geojson";
 import type { Database, SqlJsStatic } from "sql.js";
 import { decodeWkb } from "./geometry-wkb";
-import { loadSqlJs, looksLikeSqlite } from "./gpkg-ogr-contents";
+import {
+  loadSqlJs,
+  looksLikeSqlite,
+  quoteIdentifier,
+  tableExists,
+} from "./gpkg-ogr-contents";
 
 /**
  * Read GeoPackages with sql.js (SQLite/WASM) instead of DuckDB's `ST_Read`.
@@ -37,9 +42,9 @@ export interface GeoPackageReadResult {
   epsgCode: number | null;
 }
 
-function quoteIdentifier(value: string): string {
-  return `"${value.replaceAll('"', '""')}"`;
-}
+// Envelope byte sizes by GeoPackage envelope indicator: 0=none, 1=XY, 2=XYZ,
+// 3=XYM, 4=XYZM. Indicators 5-7 are reserved/invalid (OGC 12-128r18, Table 1).
+const ENVELOPE_BYTES = [0, 32, 48, 48, 64];
 
 /**
  * Strip the GeoPackage geometry-blob header, returning the standard WKB inside.
@@ -47,26 +52,30 @@ function quoteIdentifier(value: string): string {
  * The header is the "GP" magic, a version byte, a flags byte, a 4-byte srs_id,
  * and an optional envelope whose size is encoded in flag bits 1-3. A blob that
  * is already bare WKB (first byte a 0x00/0x01 byte-order marker) is returned
- * unchanged so non-conformant producers still read.
+ * unchanged so non-conformant producers still read. A blob that claims the "GP"
+ * magic but is truncated or carries a reserved envelope indicator throws, so a
+ * malformed geometry surfaces as an explicit error instead of decoding from the
+ * wrong offset into a silently wrong (or null) geometry.
  */
 export function stripGeoPackageHeader(blob: Uint8Array): Uint8Array {
   // 'G','P' magic identifies a GeoPackage geometry blob; otherwise assume the
   // value is already standalone WKB (byte-order byte 0x00 or 0x01).
   if (blob.length < 2 || blob[0] !== 0x47 || blob[1] !== 0x50) return blob;
+  if (blob.length < 8) {
+    throw new Error("Invalid GeoPackage geometry blob: truncated header.");
+  }
   const flags = blob[3];
   const envelopeIndicator = (flags >> 1) & 0x07;
-  // Envelope byte sizes by indicator: 0=none, 1=XY, 2=XYZ, 3=XYM, 4=XYZM.
-  const envelopeBytes = [0, 32, 48, 48, 64, 0, 0, 0][envelopeIndicator];
-  const headerLength = 8 + envelopeBytes;
+  if (envelopeIndicator >= ENVELOPE_BYTES.length) {
+    throw new Error(
+      `Invalid GeoPackage geometry blob: reserved envelope indicator ${envelopeIndicator}.`,
+    );
+  }
+  const headerLength = 8 + ENVELOPE_BYTES[envelopeIndicator];
+  if (blob.length < headerLength) {
+    throw new Error("Invalid GeoPackage geometry blob: truncated envelope.");
+  }
   return blob.subarray(headerLength);
-}
-
-function tableExists(db: Database, name: string): boolean {
-  const result = db.exec(
-    "SELECT 1 FROM sqlite_master WHERE type='table' AND name=:name",
-    { ":name": name },
-  );
-  return result.length > 0 && result[0].values.length > 0;
 }
 
 /**
@@ -127,22 +136,68 @@ function resolveEpsgCode(db: Database, srsId: number | null): number | null {
   return WGS84_EPSG_CODES.has(code) ? null : code;
 }
 
-/** Count the layer's rows for the large-dataset guard without materializing them. */
-export function countGeoPackageFeaturesSync(
-  SQL: SqlJsStatic,
-  bytes: Uint8Array,
-): { name: string; featureCount: number } | null {
-  const db = new SQL.Database(bytes);
-  try {
-    const layer = selectLayer(db);
-    if (!layer) return null;
-    const row = db.exec(
-      `SELECT count(*) FROM ${quoteIdentifier(layer.table)}`,
-    )[0]?.values[0];
-    return { name: layer.table, featureCount: Number(row?.[0] ?? 0) };
-  } finally {
-    db.close();
+/** Count a layer's rows without materializing them (for the large-dataset guard). */
+function countLayerRows(db: Database, table: string): number {
+  const row = db.exec(`SELECT count(*) FROM ${quoteIdentifier(table)}`)[0]
+    ?.values[0];
+  return Number(row?.[0] ?? 0);
+}
+
+/** Read every feature of `layer` from an open database into a FeatureCollection. */
+function readLayerFeatures(
+  db: Database,
+  layer: GeoPackageLayer,
+): FeatureCollection<Geometry | null> {
+  const result = db.exec(`SELECT * FROM ${quoteIdentifier(layer.table)}`);
+  const features: Feature<Geometry | null>[] = [];
+  if (result.length > 0) {
+    const columns = result[0].columns;
+    const geometryIndex = columns.indexOf(layer.geometryColumn);
+    // The geometry column is declared in gpkg_geometry_columns; if SELECT * does
+    // not return it, the file is inconsistent. Fail loudly rather than emit every
+    // feature with a silent null geometry.
+    if (geometryIndex < 0) {
+      throw new Error(
+        `GeoPackage layer "${layer.table}" is missing its declared geometry ` +
+          `column "${layer.geometryColumn}".`,
+      );
+    }
+    const idIndex = layer.idColumn ? columns.indexOf(layer.idColumn) : -1;
+
+    for (const row of result[0].values) {
+      const properties: Record<string, unknown> = {};
+      for (let i = 0; i < columns.length; i += 1) {
+        if (i === geometryIndex || i === idIndex) continue;
+        const value = row[i];
+        // sql.js returns BLOB columns as Uint8Array; binary attributes are not
+        // JSON-serialisable, so drop them (matching the ST_Read path).
+        if (value instanceof Uint8Array) continue;
+        properties[columns[i]] = value;
+      }
+
+      const rawGeometry = row[geometryIndex];
+      let geometry: Geometry | null = null;
+      if (rawGeometry instanceof Uint8Array && rawGeometry.length > 0) {
+        const wkb = stripGeoPackageHeader(rawGeometry);
+        // A GeoPackage "empty geometry" header carries no WKB body.
+        geometry = wkb.length > 0 ? decodeWkb(wkb) : null;
+      }
+      features.push({ type: "Feature", geometry, properties });
+    }
   }
+  return { type: "FeatureCollection", features };
+}
+
+/** Read the first feature layer of an open GeoPackage database. */
+function readGeoPackage(db: Database): GeoPackageReadResult {
+  const layer = selectLayer(db);
+  if (!layer) {
+    throw new Error("No vector feature layer found in this GeoPackage.");
+  }
+  return {
+    featureCollection: readLayerFeatures(db, layer),
+    epsgCode: resolveEpsgCode(db, layer.srsId),
+  };
 }
 
 /**
@@ -156,45 +211,7 @@ export function readGeoPackageSync(
 ): GeoPackageReadResult {
   const db = new SQL.Database(bytes);
   try {
-    const layer = selectLayer(db);
-    if (!layer) {
-      throw new Error("No vector feature layer found in this GeoPackage.");
-    }
-    const epsgCode = resolveEpsgCode(db, layer.srsId);
-
-    const result = db.exec(`SELECT * FROM ${quoteIdentifier(layer.table)}`);
-    const features: Feature<Geometry | null>[] = [];
-    if (result.length > 0) {
-      const columns = result[0].columns;
-      const geometryIndex = columns.indexOf(layer.geometryColumn);
-      const idIndex = layer.idColumn ? columns.indexOf(layer.idColumn) : -1;
-
-      for (const row of result[0].values) {
-        const properties: Record<string, unknown> = {};
-        for (let i = 0; i < columns.length; i += 1) {
-          if (i === geometryIndex || i === idIndex) continue;
-          const value = row[i];
-          // sql.js returns BLOB columns as Uint8Array; binary attributes are not
-          // JSON-serialisable, so drop them (matching the ST_Read path).
-          if (value instanceof Uint8Array) continue;
-          properties[columns[i]] = value;
-        }
-
-        const rawGeometry = row[geometryIndex];
-        let geometry: Geometry | null = null;
-        if (rawGeometry instanceof Uint8Array && rawGeometry.length > 0) {
-          const wkb = stripGeoPackageHeader(rawGeometry);
-          // A GeoPackage "empty geometry" header carries no WKB body.
-          geometry = wkb.length > 0 ? decodeWkb(wkb) : null;
-        }
-        features.push({ type: "Feature", geometry, properties });
-      }
-    }
-
-    return {
-      featureCollection: { type: "FeatureCollection", features },
-      epsgCode,
-    };
+    return readGeoPackage(db);
   } finally {
     db.close();
   }
@@ -205,22 +222,51 @@ export function isGeoPackage(bytes: Uint8Array): boolean {
   return looksLikeSqlite(bytes);
 }
 
+/** First-layer feature count, passed to {@link LargeGeoPackageGuard}. */
+export interface GeoPackageLayerCount {
+  name: string;
+  featureCount: number;
+}
+
+/**
+ * Invoked with the first layer's feature count before its rows are read, so a
+ * caller can prompt about a large dataset. Throw (or reject) to abort the load.
+ */
+export type LargeGeoPackageGuard = (
+  count: GeoPackageLayerCount,
+) => void | Promise<void>;
+
 /**
  * Read a GeoPackage buffer into a GeoJSON FeatureCollection via sql.js,
  * bypassing GDAL. Returns the collection plus the source EPSG code (null when
  * already WGS84) so the caller can reproject. Loads sql.js on demand.
+ *
+ * The database is opened once: when `onBeforeRead` is supplied, the layer's
+ * feature count is taken on that same open and passed to the guard before the
+ * rows are materialized, so a counted load does not parse the file twice.
  */
 export async function loadGeoPackageVectorFile(
   bytes: Uint8Array,
+  onBeforeRead?: LargeGeoPackageGuard,
 ): Promise<GeoPackageReadResult> {
   const SQL = await loadSqlJs();
-  return readGeoPackageSync(SQL, bytes);
-}
-
-/** Count a GeoPackage's first-layer features, loading sql.js on demand. */
-export async function countGeoPackageFeatures(
-  bytes: Uint8Array,
-): Promise<{ name: string; featureCount: number } | null> {
-  const SQL = await loadSqlJs();
-  return countGeoPackageFeaturesSync(SQL, bytes);
+  const db = new SQL.Database(bytes);
+  try {
+    const layer = selectLayer(db);
+    if (!layer) {
+      throw new Error("No vector feature layer found in this GeoPackage.");
+    }
+    if (onBeforeRead) {
+      await onBeforeRead({
+        name: layer.table,
+        featureCount: countLayerRows(db, layer.table),
+      });
+    }
+    return {
+      featureCollection: readLayerFeatures(db, layer),
+      epsgCode: resolveEpsgCode(db, layer.srsId),
+    };
+  } finally {
+    db.close();
+  }
 }

--- a/apps/geolibre-desktop/src/lib/gpkg-reader.ts
+++ b/apps/geolibre-desktop/src/lib/gpkg-reader.ts
@@ -136,7 +136,12 @@ function resolveEpsgCode(db: Database, srsId: number | null): number | null {
   if (!row) return null;
   const organization = String(row[0] ?? "").toUpperCase();
   const code = row[1] == null ? null : Number(row[1]);
-  if (organization !== "EPSG" || code == null) return null;
+  // A non-numeric organization_coordsys_id yields NaN, which is not null; guard
+  // it so a malformed row is treated as "no reprojection" instead of tagging the
+  // collection "EPSG:NaN" (which silently fails to reproject and misrenders).
+  if (organization !== "EPSG" || code == null || !Number.isFinite(code)) {
+    return null;
+  }
   return WGS84_EPSG_CODES.has(code) ? null : code;
 }
 
@@ -232,8 +237,16 @@ export function readGeoPackageSync(
   }
 }
 
-/** Whether {@link loadGeoPackageVectorFile} can handle these bytes (a SQLite file). */
-export function isGeoPackage(bytes: Uint8Array): boolean {
+/**
+ * Cheap pre-check: whether these bytes are a SQLite file (a GeoPackage is one).
+ *
+ * Only the SQLite magic is inspected, so a non-GeoPackage SQLite database with a
+ * `.gpkg` name also passes; such a file then fails in {@link readGeoPackageSync}
+ * with "No vector feature layer found" rather than falling through to `ST_Read`.
+ * That is acceptable: `ST_Read` cannot read a SQLite file with no feature layer
+ * either, and full GeoPackage validation only happens once the tables are read.
+ */
+export function isLikelyGeoPackage(bytes: Uint8Array): boolean {
   return looksLikeSqlite(bytes);
 }
 

--- a/apps/geolibre-desktop/src/lib/gpkg-reader.ts
+++ b/apps/geolibre-desktop/src/lib/gpkg-reader.ts
@@ -84,7 +84,11 @@ export function stripGeoPackageHeader(blob: Uint8Array): Uint8Array {
  * argument), which is what the previous `ST_Read` path used.
  */
 function selectLayer(db: Database): GeoPackageLayer | null {
+  // Both tables are referenced by the JOIN below. gpkg_contents is mandatory in
+  // the spec, but guard it too so a malformed file returns null (no layer) here
+  // rather than throwing an opaque sql.js error from the JOIN.
   if (!tableExists(db, "gpkg_geometry_columns")) return null;
+  if (!tableExists(db, "gpkg_contents")) return null;
   const result = db.exec(
     `SELECT g.table_name, g.column_name, g.srs_id
      FROM gpkg_geometry_columns g
@@ -178,9 +182,20 @@ function readLayerFeatures(
       const rawGeometry = row[geometryIndex];
       let geometry: Geometry | null = null;
       if (rawGeometry instanceof Uint8Array && rawGeometry.length > 0) {
-        const wkb = stripGeoPackageHeader(rawGeometry);
-        // A GeoPackage "empty geometry" header carries no WKB body.
-        geometry = wkb.length > 0 ? decodeWkb(wkb) : null;
+        try {
+          const wkb = stripGeoPackageHeader(rawGeometry);
+          // A GeoPackage "empty geometry" header carries no WKB body.
+          geometry = wkb.length > 0 ? decodeWkb(wkb) : null;
+        } catch (error) {
+          // One unreadable geometry (malformed header, truncated WKB, or an
+          // unsupported curved type) must not abort the whole layer. Keep the
+          // feature with a null geometry and warn so the loss is diagnosable
+          // rather than silent.
+          console.warn(
+            `[GeoLibre] Skipped an unreadable geometry in GeoPackage layer "${layer.table}":`,
+            error,
+          );
+        }
       }
       features.push({ type: "Feature", geometry, properties });
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
         "maplibre-gl-nasa-earthdata": "^0.1.2",
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.2.3",
+        "maplibre-gl-raster": "^0.2.4",
         "maplibre-gl-streetview": "^0.6.0",
         "maplibre-gl-swipe": "^0.7.1",
         "maplibre-gl-time-slider": "^1.0.3",
@@ -17743,9 +17743,9 @@
       }
     },
     "node_modules/maplibre-gl-raster": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.2.3.tgz",
-      "integrity": "sha512-dwqifTJruHzt3exNKuaKNIJ+6vdANkRtJ+kfv81p1/HPzKEOsAIQzE5Cetlqjg57nRT6Kdnz6ITuWi6YYqfemQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.2.4.tgz",
+      "integrity": "sha512-02GkznVgyw4FU0fQzk6ssAHOOlmGXqYI+t4mYRy3JXGpDQw3Gc/KhSll+0nq1VHOematbtgllCce9uCSSoh41A==",
       "license": "MIT",
       "dependencies": {
         "@chunkd/middleware": "^11.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
         "maplibre-gl-nasa-earthdata": "^0.1.2",
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.2.1",
+        "maplibre-gl-raster": "^0.2.2",
         "maplibre-gl-streetview": "^0.6.0",
         "maplibre-gl-swipe": "^0.7.1",
         "maplibre-gl-time-slider": "^1.0.3",
@@ -17743,9 +17743,9 @@
       }
     },
     "node_modules/maplibre-gl-raster": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.2.1.tgz",
-      "integrity": "sha512-xAMgz1/VlOI7fDj7Rv7QW/Utgeh/dyQBq/sns3rBMMcLsopq25EbUAw2ZGQFV19ula6YmbF+F51evmsGr7icjw==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.2.2.tgz",
+      "integrity": "sha512-DWvKYHFF0XEIRG1hUd7tLv4I4DlZNjWLB0mauXSOhjSCXSni4NUqfXw1x4jDDTp2vx2C3v66iEM6sGEX5+SqOA==",
       "license": "MIT",
       "dependencies": {
         "@chunkd/middleware": "^11.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
         "maplibre-gl-nasa-earthdata": "^0.1.2",
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.2.2",
+        "maplibre-gl-raster": "^0.2.3",
         "maplibre-gl-streetview": "^0.6.0",
         "maplibre-gl-swipe": "^0.7.1",
         "maplibre-gl-time-slider": "^1.0.3",
@@ -17743,9 +17743,9 @@
       }
     },
     "node_modules/maplibre-gl-raster": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.2.2.tgz",
-      "integrity": "sha512-DWvKYHFF0XEIRG1hUd7tLv4I4DlZNjWLB0mauXSOhjSCXSni4NUqfXw1x4jDDTp2vx2C3v66iEM6sGEX5+SqOA==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.2.3.tgz",
+      "integrity": "sha512-dwqifTJruHzt3exNKuaKNIJ+6vdANkRtJ+kfv81p1/HPzKEOsAIQzE5Cetlqjg57nRT6Kdnz6ITuWi6YYqfemQ==",
       "license": "MIT",
       "dependencies": {
         "@chunkd/middleware": "^11.3.0",

--- a/packages/map/src/index.ts
+++ b/packages/map/src/index.ts
@@ -18,3 +18,4 @@ export {
   circleLayerId,
 } from "./geojson-loader";
 export { isPlaceholderLayer, placeholderMessage } from "./placeholders";
+export { setExternalDeckLayerOrderHandler } from "./layer-sync";

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -40,6 +40,24 @@ import {
   rasterPaint,
 } from "./style-mapper";
 
+/**
+ * Notified of the computed `beforeId` for a deck.gl-backed external custom layer
+ * (a `maplibre-gl-raster` COG) whenever layers are synced. Such a layer is not a
+ * real MapLibre style layer — `@deck.gl/mapbox` groups it by a `beforeId` prop —
+ * so `moveLayer` cannot reorder it; the host registers a handler that pushes the
+ * `beforeId` into the owning control instead. See issue #393 follow-up.
+ */
+let externalDeckLayerOrderHandler:
+  | ((layerId: string, beforeId: string | undefined) => void)
+  | null = null;
+
+/** Register (or clear with `null`) the deck-layer order handler. */
+export function setExternalDeckLayerOrderHandler(
+  handler: ((layerId: string, beforeId: string | undefined) => void) | null,
+): void {
+  externalDeckLayerOrderHandler = handler;
+}
+
 const WMS_PROXY_PATH = "/__geolibre_wms_proxy";
 const PMTILES_PROTOCOL = "pmtiles";
 const PMTILES_PROTOCOL_GLOBAL_KEY = "__geolibrePMTilesProtocol";
@@ -211,6 +229,12 @@ function syncExternalNativeLayer(
   if (isExternalCustomLayer(layer)) {
     for (const nativeLayerId of nativeLayerIds) {
       moveLayer(map, nativeLayerId, beforeId);
+    }
+    // A deck.gl raster has no real MapLibre style layer to move (it renders in a
+    // `deck-layer-group-*` keyed by its beforeId prop), so forward the computed
+    // beforeId to the control that owns it.
+    if (layer.metadata.externalDeckLayer === true) {
+      externalDeckLayerOrderHandler?.(layer.id, beforeId);
     }
     return;
   }

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -97,6 +97,7 @@ export {
 } from "./plugins/maplibre-3d-tiles";
 export {
   addRasterToMap,
+  applyRasterLayerOrder,
   closeRasterLayerPanel,
   openRasterLayerPanel,
   restoreRasterLayers,

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -147,6 +147,25 @@ export async function addRasterToMap(
   await control.addRaster(source, { name: options.name, zoomTo: true });
 }
 
+/**
+ * Pushes a layer's interleave position into the raster control: draw the raster
+ * (a deck.gl COG) beneath `beforeId`, or on top when `beforeId` is undefined.
+ *
+ * `@geolibre/map`'s layer-sync computes the beforeId from the store order but
+ * cannot move the deck layer itself (it has no real MapLibre style layer), so
+ * the desktop shell wires this as its deck-layer order handler. A no-op for any
+ * id the raster control does not own.
+ *
+ * @param layerId - The store/raster layer id.
+ * @param beforeId - The MapLibre style layer id to draw beneath, or undefined.
+ */
+export function applyRasterLayerOrder(
+  layerId: string,
+  beforeId: string | undefined,
+): void {
+  rasterControl?.setRasterBeforeId(layerId, beforeId ?? null);
+}
+
 export function closeRasterLayerPanel(app: GeoLibreAppAPI): void {
   if (restorePanelExpandTimeout !== null) {
     window.clearTimeout(restorePanelExpandTimeout);

--- a/tests/external-deck-order.test.ts
+++ b/tests/external-deck-order.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { DEFAULT_LAYER_STYLE, type GeoLibreLayer } from "@geolibre/core";
+import {
+  setExternalDeckLayerOrderHandler,
+  syncLayer,
+} from "../packages/map/src/layer-sync";
+
+// A deck.gl raster (maplibre-gl-raster COG) registers as an external custom
+// layer but has no real MapLibre style layer to move, so layer-sync forwards
+// the computed beforeId to a handler that pushes it into the owning control.
+
+function makeMapStub() {
+  const map = {
+    getStyle: () => ({ layers: [{ id: "vector-line", type: "line" }] }),
+    getLayer: (id: string) =>
+      id === "vector-line" ? { id, type: "line" } : undefined,
+    getSource: () => undefined,
+    setLayoutProperty: () => {},
+    setPaintProperty: () => {},
+    moveLayer: () => {},
+    removeLayer: () => {},
+    addLayer: () => {},
+    addSource: () => {},
+  };
+  return map;
+}
+
+function rasterDeckLayer(): GeoLibreLayer {
+  return {
+    id: "raster-1",
+    name: "cog.tif",
+    type: "cog",
+    source: { type: "raster" },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {
+      customLayerType: "raster",
+      externalDeckLayer: true,
+      externalNativeLayer: true,
+      nativeLayerIds: ["raster-1"],
+      sourceIds: [],
+    },
+  };
+}
+
+afterEach(() => setExternalDeckLayerOrderHandler(null));
+
+describe("external deck-layer order handler", () => {
+  it("forwards the computed beforeId for a deck raster layer", () => {
+    const calls: Array<[string, string | undefined]> = [];
+    setExternalDeckLayerOrderHandler((id, beforeId) =>
+      calls.push([id, beforeId]),
+    );
+
+    syncLayer(makeMapStub() as never, rasterDeckLayer(), "vector-line");
+
+    assert.deepEqual(calls, [["raster-1", "vector-line"]]);
+  });
+
+  it("forwards undefined when the raster is on top (no beforeId)", () => {
+    const calls: Array<[string, string | undefined]> = [];
+    setExternalDeckLayerOrderHandler((id, beforeId) =>
+      calls.push([id, beforeId]),
+    );
+
+    syncLayer(makeMapStub() as never, rasterDeckLayer());
+
+    assert.deepEqual(calls, [["raster-1", undefined]]);
+  });
+
+  it("does not fire for a non-deck external custom layer", () => {
+    const calls: unknown[] = [];
+    setExternalDeckLayerOrderHandler((id, beforeId) =>
+      calls.push([id, beforeId]),
+    );
+
+    const layer = rasterDeckLayer();
+    // A 3D-tiles-style custom layer is external custom but not a deck raster.
+    layer.metadata = {
+      customLayerType: "3d-tiles",
+      externalNativeLayer: true,
+      nativeLayerIds: ["raster-1"],
+      sourceIds: [],
+    };
+    syncLayer(makeMapStub() as never, layer, "vector-line");
+
+    assert.deepEqual(calls, []);
+  });
+});

--- a/tests/geometry-wkb-decode.test.ts
+++ b/tests/geometry-wkb-decode.test.ts
@@ -72,6 +72,21 @@ describe("decodeWkb", () => {
     assert.deepEqual(decoded, { type: "Point", coordinates: [-85.6, 42.9, 100] });
   });
 
+  it("skips the EWKB SRID prefix", () => {
+    // EWKB POINT with the SRID flag (0x20000000): byte order, type, 4-byte SRID,
+    // then x,y. The SRID is skipped (the CRS comes from GeoPackage metadata).
+    const writer = new DataView(new ArrayBuffer(1 + 4 + 4 + 8 + 8));
+    writer.setUint8(0, 1); // little-endian
+    writer.setUint32(1, 0x20000001, true); // Point + SRID flag
+    writer.setUint32(5, 4326, true); // SRID (skipped)
+    writer.setFloat64(9, -85.6, true);
+    writer.setFloat64(17, 42.9, true);
+    assert.deepEqual(decodeWkb(new Uint8Array(writer.buffer)), {
+      type: "Point",
+      coordinates: [-85.6, 42.9],
+    });
+  });
+
   it("throws on unsupported curved geometry types", () => {
     // Type code 8 = CircularString, which GeoJSON cannot represent.
     const bytes = new Uint8Array([0x01, 0x08, 0x00, 0x00, 0x00]);

--- a/tests/geometry-wkb-decode.test.ts
+++ b/tests/geometry-wkb-decode.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { Geometry } from "geojson";
+import { decodeWkb, encodeWkb } from "../apps/geolibre-desktop/src/lib/geometry-wkb";
+
+/**
+ * decodeWkb is the inverse of encodeWkb (used to read GeoPackage geometry blobs
+ * without GDAL). Round-tripping every standard geometry type proves the decoder
+ * matches the encoder the rest of the app already relies on.
+ */
+const GEOMETRIES: Geometry[] = [
+  { type: "Point", coordinates: [-85.6, 42.9] },
+  { type: "LineString", coordinates: [[-85.6, 42.9], [-85.5, 43.0], [-85.4, 43.1]] },
+  {
+    type: "Polygon",
+    coordinates: [
+      [[-85.6, 42.9], [-85.5, 42.9], [-85.5, 43.0], [-85.6, 43.0], [-85.6, 42.9]],
+    ],
+  },
+  { type: "MultiPoint", coordinates: [[-85.6, 42.9], [-85.5, 43.0]] },
+  {
+    type: "MultiLineString",
+    coordinates: [
+      [[-85.6, 42.9], [-85.5, 43.0]],
+      [[-85.4, 43.1], [-85.3, 43.2]],
+    ],
+  },
+  {
+    type: "MultiPolygon",
+    coordinates: [
+      [[[-85.6, 42.9], [-85.5, 42.9], [-85.5, 43.0], [-85.6, 42.9]]],
+      [[[-85.4, 42.8], [-85.3, 42.8], [-85.3, 42.9], [-85.4, 42.8]]],
+    ],
+  },
+  {
+    type: "GeometryCollection",
+    geometries: [
+      { type: "Point", coordinates: [-85.6, 42.9] },
+      { type: "LineString", coordinates: [[-85.6, 42.9], [-85.5, 43.0]] },
+    ],
+  },
+];
+
+describe("decodeWkb", () => {
+  for (const geometry of GEOMETRIES) {
+    it(`round-trips a ${geometry.type}`, () => {
+      const decoded = decodeWkb(encodeWkb(geometry));
+      assert.deepEqual(decoded, geometry);
+    });
+  }
+
+  it("reads big-endian WKB", () => {
+    // Hand-encode POINT(1 2) big-endian: 00, type 00000001, x=1.0, y=2.0.
+    const bytes = new Uint8Array([
+      0x00, 0x00, 0x00, 0x00, 0x01,
+      0x3f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ]);
+    assert.deepEqual(decodeWkb(bytes), { type: "Point", coordinates: [1, 2] });
+  });
+
+  it("keeps Z and drops M for ISO XYZM points", () => {
+    // ISO PointZM has type code 3001; coordinates x,y,z,m.
+    const writer = new DataView(new ArrayBuffer(1 + 4 + 8 * 4));
+    writer.setUint8(0, 1); // little-endian
+    writer.setUint32(1, 3001, true); // PointZM
+    writer.setFloat64(5, -85.6, true);
+    writer.setFloat64(13, 42.9, true);
+    writer.setFloat64(21, 100, true); // Z (kept)
+    writer.setFloat64(29, 7, true); // M (dropped)
+    const decoded = decodeWkb(new Uint8Array(writer.buffer));
+    assert.deepEqual(decoded, { type: "Point", coordinates: [-85.6, 42.9, 100] });
+  });
+
+  it("throws on unsupported curved geometry types", () => {
+    // Type code 8 = CircularString, which GeoJSON cannot represent.
+    const bytes = new Uint8Array([0x01, 0x08, 0x00, 0x00, 0x00]);
+    assert.throws(() => decodeWkb(bytes), /Unsupported WKB geometry type 8/);
+  });
+});

--- a/tests/gpkg-reader.test.ts
+++ b/tests/gpkg-reader.test.ts
@@ -209,9 +209,10 @@ describe("readGeoPackageSync", () => {
     );
   });
 
-  it("throws on a malformed geometry blob", () => {
-    // A 'GP' blob with a reserved envelope indicator cannot be located, so the
-    // feature surfaces as an explicit error rather than a silent null geometry.
+  it("keeps the feature but drops an unreadable geometry blob, warning once", () => {
+    // A 'GP' blob with a reserved envelope indicator cannot be located. The bad
+    // feature must not abort the layer: it is kept with a null geometry (and the
+    // good feature still loads), with a warning rather than a silent drop.
     const badBlob = new Uint8Array(16);
     badBlob[0] = 0x47;
     badBlob[1] = 0x50;
@@ -224,13 +225,38 @@ describe("readGeoPackageSync", () => {
       INSERT INTO gpkg_contents VALUES ('places','features',4326);
       INSERT INTO gpkg_geometry_columns VALUES ('places','geom','GEOMETRY',4326,0,0);
     `);
-    db.run("INSERT INTO places (geom, name) VALUES (:g, 'a')", { ":g": badBlob });
+    db.run("INSERT INTO places (geom, name) VALUES (:g, 'bad')", { ":g": badBlob });
+    db.run("INSERT INTO places (geom, name) VALUES (:g, 'good')", {
+      ":g": geoPackageBlob({ type: "Point", coordinates: [1, 2] }),
+    });
     const bytes = db.export();
     db.close();
-    assert.throws(
-      () => readGeoPackageSync(SQL, bytes),
-      /reserved envelope indicator 6/,
+
+    const warnings: unknown[][] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => warnings.push(args);
+    try {
+      const { featureCollection } = readGeoPackageSync(SQL, bytes);
+      assert.equal(featureCollection.features.length, 2);
+      assert.equal(featureCollection.features[0].geometry, null);
+      assert.deepEqual(featureCollection.features[0].properties, { name: "bad" });
+      assert.equal(featureCollection.features[1].geometry?.type, "Point");
+    } finally {
+      console.warn = originalWarn;
+    }
+    assert.equal(warnings.length, 1);
+  });
+
+  it("returns null (no layer) when gpkg_contents is missing", () => {
+    // A malformed file with gpkg_geometry_columns but no gpkg_contents must not
+    // throw an opaque sql.js error from the JOIN.
+    const db = new SQL.Database();
+    db.run(
+      "CREATE TABLE gpkg_geometry_columns (table_name TEXT, column_name TEXT, geometry_type_name TEXT, srs_id INTEGER, z TINYINT, m TINYINT)",
     );
+    const bytes = db.export();
+    db.close();
+    assert.throws(() => readGeoPackageSync(SQL, bytes), /No vector feature layer/);
   });
 });
 

--- a/tests/gpkg-reader.test.ts
+++ b/tests/gpkg-reader.test.ts
@@ -6,7 +6,7 @@ import initSqlJs from "sql.js";
 import type { Database, SqlJsStatic } from "sql.js";
 import { encodeWkb } from "../apps/geolibre-desktop/src/lib/geometry-wkb";
 import {
-  isGeoPackage,
+  isLikelyGeoPackage,
   readGeoPackageSync,
   stripGeoPackageHeader,
 } from "../apps/geolibre-desktop/src/lib/gpkg-reader";
@@ -180,6 +180,27 @@ describe("readGeoPackageSync", () => {
     assert.equal(readGeoPackageSync(SQL, bytes).epsgCode, null);
   });
 
+  it("treats a non-numeric EPSG code as no reprojection (not EPSG:NaN)", () => {
+    // organization_coordsys_id has no column affinity here, so the text value is
+    // stored verbatim; Number(...) yields NaN, which must resolve to null.
+    const db = new SQL.Database();
+    db.run(`
+      CREATE TABLE gpkg_spatial_ref_sys (srs_name TEXT, srs_id INTEGER PRIMARY KEY, organization TEXT, organization_coordsys_id, definition TEXT, description TEXT);
+      CREATE TABLE gpkg_contents (table_name TEXT PRIMARY KEY, data_type TEXT, srs_id INTEGER);
+      CREATE TABLE gpkg_geometry_columns (table_name TEXT, column_name TEXT, geometry_type_name TEXT, srs_id INTEGER, z TINYINT, m TINYINT);
+      CREATE TABLE "places" (fid INTEGER PRIMARY KEY, geom BLOB, name TEXT);
+      INSERT INTO gpkg_spatial_ref_sys VALUES ('custom', 9999, 'EPSG', 'not-a-number', '', '');
+      INSERT INTO gpkg_contents VALUES ('places','features',9999);
+      INSERT INTO gpkg_geometry_columns VALUES ('places','geom','GEOMETRY',9999,0,0);
+    `);
+    db.run("INSERT INTO places (geom, name) VALUES (:g, 'a')", {
+      ":g": geoPackageBlob({ type: "Point", coordinates: [1, 2] }, 9999),
+    });
+    const bytes = db.export();
+    db.close();
+    assert.equal(readGeoPackageSync(SQL, bytes).epsgCode, null);
+  });
+
   it("throws when there is no feature layer", () => {
     const db = new SQL.Database();
     db.run(
@@ -260,9 +281,9 @@ describe("readGeoPackageSync", () => {
   });
 });
 
-describe("isGeoPackage", () => {
+describe("isLikelyGeoPackage", () => {
   it("recognises a SQLite/GeoPackage buffer", () => {
-    assert.equal(isGeoPackage(buildGpkg([])), true);
-    assert.equal(isGeoPackage(new Uint8Array([1, 2, 3, 4])), false);
+    assert.equal(isLikelyGeoPackage(buildGpkg([])), true);
+    assert.equal(isLikelyGeoPackage(new Uint8Array([1, 2, 3, 4])), false);
   });
 });

--- a/tests/gpkg-reader.test.ts
+++ b/tests/gpkg-reader.test.ts
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { before, describe, it } from "node:test";
+import type { Geometry } from "geojson";
+import initSqlJs from "sql.js";
+import type { Database, SqlJsStatic } from "sql.js";
+import { encodeWkb } from "../apps/geolibre-desktop/src/lib/geometry-wkb";
+import {
+  countGeoPackageFeaturesSync,
+  isGeoPackage,
+  readGeoPackageSync,
+  stripGeoPackageHeader,
+} from "../apps/geolibre-desktop/src/lib/gpkg-reader";
+
+const require = createRequire(import.meta.url);
+let SQL: SqlJsStatic;
+
+before(async () => {
+  const wasmPath = require.resolve("sql.js/dist/sql-wasm.wasm");
+  SQL = await initSqlJs({ locateFile: () => wasmPath });
+});
+
+/** Wrap WKB in a minimal little-endian GeoPackage geometry blob (no envelope). */
+function geoPackageBlob(geometry: Geometry, srsId = 4326): Uint8Array {
+  const wkb = encodeWkb(geometry);
+  const blob = new Uint8Array(8 + wkb.length);
+  const view = new DataView(blob.buffer);
+  blob[0] = 0x47; // 'G'
+  blob[1] = 0x50; // 'P'
+  blob[2] = 0x00; // version
+  blob[3] = 0x01; // flags: little-endian header, no envelope
+  view.setInt32(4, srsId, true);
+  blob.set(wkb, 8);
+  return blob;
+}
+
+interface FeatureSpec {
+  geometry: Geometry | null;
+  name: string;
+}
+
+/** Build a single-layer GeoPackage with a geom + name column from specs. */
+function buildGpkg(
+  features: FeatureSpec[],
+  options: { srsId?: number; srs?: { id: number; org: string; code: number } } = {},
+): Uint8Array {
+  const srsId = options.srsId ?? 4326;
+  const db: Database = new SQL.Database();
+  db.run(`
+    CREATE TABLE gpkg_spatial_ref_sys (
+      srs_name TEXT NOT NULL, srs_id INTEGER NOT NULL PRIMARY KEY,
+      organization TEXT NOT NULL, organization_coordsys_id INTEGER NOT NULL,
+      definition TEXT NOT NULL, description TEXT
+    );
+    CREATE TABLE gpkg_contents (
+      table_name TEXT NOT NULL PRIMARY KEY, data_type TEXT NOT NULL,
+      identifier TEXT, description TEXT,
+      min_x DOUBLE, min_y DOUBLE, max_x DOUBLE, max_y DOUBLE, srs_id INTEGER
+    );
+    CREATE TABLE gpkg_geometry_columns (
+      table_name TEXT NOT NULL, column_name TEXT NOT NULL,
+      geometry_type_name TEXT NOT NULL, srs_id INTEGER NOT NULL, z TINYINT, m TINYINT
+    );
+    CREATE TABLE "places" (fid INTEGER PRIMARY KEY, geom BLOB, name TEXT);
+  `);
+  db.run(
+    "INSERT INTO gpkg_contents (table_name, data_type, srs_id) VALUES ('places','features',:s)",
+    { ":s": srsId },
+  );
+  db.run(
+    "INSERT INTO gpkg_geometry_columns VALUES ('places','geom','GEOMETRY',:s,0,0)",
+    { ":s": srsId },
+  );
+  if (options.srs) {
+    db.run(
+      "INSERT INTO gpkg_spatial_ref_sys VALUES (:n,:id,:org,:code,'','')",
+      { ":n": "custom", ":id": options.srs.id, ":org": options.srs.org, ":code": options.srs.code },
+    );
+  }
+  for (const feature of features) {
+    db.run("INSERT INTO places (geom, name) VALUES (:g, :n)", {
+      ":g": feature.geometry ? geoPackageBlob(feature.geometry, srsId) : null,
+      ":n": feature.name,
+    });
+  }
+  const bytes = db.export();
+  db.close();
+  return bytes;
+}
+
+describe("stripGeoPackageHeader", () => {
+  it("strips the GP header and returns the inner WKB", () => {
+    const geometry: Geometry = { type: "Point", coordinates: [1, 2] };
+    const wkb = encodeWkb(geometry);
+    const stripped = stripGeoPackageHeader(geoPackageBlob(geometry));
+    assert.deepEqual([...stripped], [...wkb]);
+  });
+
+  it("accounts for an XY envelope (32 bytes)", () => {
+    const wkb = encodeWkb({ type: "Point", coordinates: [1, 2] });
+    const blob = new Uint8Array(8 + 32 + wkb.length);
+    blob[0] = 0x47;
+    blob[1] = 0x50;
+    blob[3] = 0b0000_0010; // envelope indicator 1 (XY) in bits 1-3
+    blob.set(wkb, 8 + 32);
+    assert.deepEqual([...stripGeoPackageHeader(blob)], [...wkb]);
+  });
+
+  it("returns bare WKB unchanged", () => {
+    const wkb = encodeWkb({ type: "Point", coordinates: [1, 2] });
+    assert.deepEqual([...stripGeoPackageHeader(wkb)], [...wkb]);
+  });
+});
+
+describe("readGeoPackageSync", () => {
+  it("reads features with geometry and properties, excluding the id column", () => {
+    const bytes = buildGpkg([
+      { geometry: { type: "Point", coordinates: [-85.6, 42.9] }, name: "a" },
+      {
+        geometry: { type: "LineString", coordinates: [[-85.6, 42.9], [-85.5, 43]] },
+        name: "b",
+      },
+    ]);
+    const { featureCollection, epsgCode } = readGeoPackageSync(SQL, bytes);
+    assert.equal(epsgCode, null); // 4326 → no reprojection
+    assert.equal(featureCollection.features.length, 2);
+    assert.deepEqual(featureCollection.features[0], {
+      type: "Feature",
+      geometry: { type: "Point", coordinates: [-85.6, 42.9] },
+      properties: { name: "a" }, // fid excluded
+    });
+    assert.equal(featureCollection.features[1].geometry?.type, "LineString");
+  });
+
+  it("keeps a null geometry as a null-geometry feature", () => {
+    const bytes = buildGpkg([{ geometry: null, name: "empty" }]);
+    const { featureCollection } = readGeoPackageSync(SQL, bytes);
+    assert.equal(featureCollection.features.length, 1);
+    assert.equal(featureCollection.features[0].geometry, null);
+    assert.deepEqual(featureCollection.features[0].properties, { name: "empty" });
+  });
+
+  it("reports a non-WGS84 EPSG code for reprojection", () => {
+    const bytes = buildGpkg(
+      [{ geometry: { type: "Point", coordinates: [1, 2] }, name: "a" }],
+      { srsId: 3857, srs: { id: 3857, org: "EPSG", code: 3857 } },
+    );
+    assert.equal(readGeoPackageSync(SQL, bytes).epsgCode, 3857);
+  });
+
+  it("treats WGS84 3D (EPSG:4979) as needing no reprojection", () => {
+    const bytes = buildGpkg(
+      [{ geometry: { type: "Point", coordinates: [1, 2] }, name: "a" }],
+      { srsId: 4979, srs: { id: 4979, org: "EPSG", code: 4979 } },
+    );
+    assert.equal(readGeoPackageSync(SQL, bytes).epsgCode, null);
+  });
+
+  it("throws when there is no feature layer", () => {
+    const db = new SQL.Database();
+    db.run(
+      "CREATE TABLE gpkg_contents (table_name TEXT PRIMARY KEY, data_type TEXT, srs_id INTEGER)",
+    );
+    const bytes = db.export();
+    db.close();
+    assert.throws(() => readGeoPackageSync(SQL, bytes), /No vector feature layer/);
+  });
+});
+
+describe("countGeoPackageFeaturesSync / isGeoPackage", () => {
+  it("counts the first layer's features", () => {
+    const bytes = buildGpkg([
+      { geometry: { type: "Point", coordinates: [0, 0] }, name: "a" },
+      { geometry: { type: "Point", coordinates: [1, 1] }, name: "b" },
+      { geometry: { type: "Point", coordinates: [2, 2] }, name: "c" },
+    ]);
+    assert.deepEqual(countGeoPackageFeaturesSync(SQL, bytes), {
+      name: "places",
+      featureCount: 3,
+    });
+  });
+
+  it("recognises a SQLite/GeoPackage buffer", () => {
+    assert.equal(isGeoPackage(buildGpkg([])), true);
+    assert.equal(isGeoPackage(new Uint8Array([1, 2, 3, 4])), false);
+  });
+});

--- a/tests/gpkg-reader.test.ts
+++ b/tests/gpkg-reader.test.ts
@@ -6,7 +6,6 @@ import initSqlJs from "sql.js";
 import type { Database, SqlJsStatic } from "sql.js";
 import { encodeWkb } from "../apps/geolibre-desktop/src/lib/geometry-wkb";
 import {
-  countGeoPackageFeaturesSync,
   isGeoPackage,
   readGeoPackageSync,
   stripGeoPackageHeader,
@@ -110,6 +109,31 @@ describe("stripGeoPackageHeader", () => {
     const wkb = encodeWkb({ type: "Point", coordinates: [1, 2] });
     assert.deepEqual([...stripGeoPackageHeader(wkb)], [...wkb]);
   });
+
+  it("throws on a reserved envelope indicator (5-7)", () => {
+    const blob = new Uint8Array(16);
+    blob[0] = 0x47;
+    blob[1] = 0x50;
+    blob[3] = 5 << 1; // envelope indicator 5 (reserved) in bits 1-3
+    assert.throws(
+      () => stripGeoPackageHeader(blob),
+      /reserved envelope indicator 5/,
+    );
+  });
+
+  it("throws on a truncated header", () => {
+    // 'GP' magic but fewer than the 8 mandatory header bytes.
+    const blob = new Uint8Array([0x47, 0x50, 0x00, 0x01]);
+    assert.throws(() => stripGeoPackageHeader(blob), /truncated header/);
+  });
+
+  it("throws on a truncated envelope", () => {
+    const blob = new Uint8Array(10); // declares an XY envelope (needs 8 + 32)
+    blob[0] = 0x47;
+    blob[1] = 0x50;
+    blob[3] = 0b0000_0010; // envelope indicator 1 (XY)
+    assert.throws(() => stripGeoPackageHeader(blob), /truncated envelope/);
+  });
 });
 
 describe("readGeoPackageSync", () => {
@@ -165,21 +189,52 @@ describe("readGeoPackageSync", () => {
     db.close();
     assert.throws(() => readGeoPackageSync(SQL, bytes), /No vector feature layer/);
   });
-});
 
-describe("countGeoPackageFeaturesSync / isGeoPackage", () => {
-  it("counts the first layer's features", () => {
-    const bytes = buildGpkg([
-      { geometry: { type: "Point", coordinates: [0, 0] }, name: "a" },
-      { geometry: { type: "Point", coordinates: [1, 1] }, name: "b" },
-      { geometry: { type: "Point", coordinates: [2, 2] }, name: "c" },
-    ]);
-    assert.deepEqual(countGeoPackageFeaturesSync(SQL, bytes), {
-      name: "places",
-      featureCount: 3,
-    });
+  it("throws when the declared geometry column is missing from the table", () => {
+    // gpkg_geometry_columns declares "geom" but the table column is "shape".
+    const db = new SQL.Database();
+    db.run(`
+      CREATE TABLE gpkg_contents (table_name TEXT PRIMARY KEY, data_type TEXT, srs_id INTEGER);
+      CREATE TABLE gpkg_geometry_columns (table_name TEXT, column_name TEXT, geometry_type_name TEXT, srs_id INTEGER, z TINYINT, m TINYINT);
+      CREATE TABLE "places" (fid INTEGER PRIMARY KEY, shape BLOB, name TEXT);
+      INSERT INTO gpkg_contents VALUES ('places','features',4326);
+      INSERT INTO gpkg_geometry_columns VALUES ('places','geom','GEOMETRY',4326,0,0);
+      INSERT INTO "places" (name) VALUES ('a');
+    `);
+    const bytes = db.export();
+    db.close();
+    assert.throws(
+      () => readGeoPackageSync(SQL, bytes),
+      /missing its declared geometry column "geom"/,
+    );
   });
 
+  it("throws on a malformed geometry blob", () => {
+    // A 'GP' blob with a reserved envelope indicator cannot be located, so the
+    // feature surfaces as an explicit error rather than a silent null geometry.
+    const badBlob = new Uint8Array(16);
+    badBlob[0] = 0x47;
+    badBlob[1] = 0x50;
+    badBlob[3] = 6 << 1; // reserved envelope indicator 6
+    const db = new SQL.Database();
+    db.run(`
+      CREATE TABLE gpkg_contents (table_name TEXT PRIMARY KEY, data_type TEXT, srs_id INTEGER);
+      CREATE TABLE gpkg_geometry_columns (table_name TEXT, column_name TEXT, geometry_type_name TEXT, srs_id INTEGER, z TINYINT, m TINYINT);
+      CREATE TABLE "places" (fid INTEGER PRIMARY KEY, geom BLOB, name TEXT);
+      INSERT INTO gpkg_contents VALUES ('places','features',4326);
+      INSERT INTO gpkg_geometry_columns VALUES ('places','geom','GEOMETRY',4326,0,0);
+    `);
+    db.run("INSERT INTO places (geom, name) VALUES (:g, 'a')", { ":g": badBlob });
+    const bytes = db.export();
+    db.close();
+    assert.throws(
+      () => readGeoPackageSync(SQL, bytes),
+      /reserved envelope indicator 6/,
+    );
+  });
+});
+
+describe("isGeoPackage", () => {
   it("recognises a SQLite/GeoPackage buffer", () => {
     assert.equal(isGeoPackage(buildGpkg([])), true);
     assert.equal(isGeoPackage(new Uint8Array([1, 2, 3, 4])), false);


### PR DESCRIPTION
## Problem

Closes #393. Many valid GeoPackages fail to render in the web app (a few small ones happen to work). Loading them throws:

```
Invalid Error: thread constructor failed: Resource temporarily unavailable
```

### Root cause

DuckDB-WASM's `ST_Read` (GDAL) reads a GeoPackage layer by filling Arrow result batches on a **background thread** once the layer crosses a small data threshold. The single-threaded DuckDB-WASM `eh` bundle the app loads has no pthread support, so `std::thread` aborts with EAGAIN. I reproduced this with the exact deployed `@duckdb/duckdb-wasm@1.33.1-dev45.0` + spatial extension: `DESCRIBE` and `ST_Read_Meta` succeed, but any feature read (`LIMIT 1`, `count(*)`, `SELECT *`) crashes once the result is more than a few features.

The existing `gpkg_ogr_contents` repair (#258/#376) fixes the related feature-**count** path, but not this feature-**read** path, and these files already carry valid counts. No DuckDB-reachable GDAL config (open options, `max_batch_size`, `keep_wkb`, `threads`) disables the threading.

## Fix

Read GeoPackages directly from their SQLite tables with **sql.js** (already bundled for the count repair) instead of going through GDAL:

- A new `decodeWkb` (the exact inverse of the existing `encodeWkb`) decodes the standard WKB inside each GeoPackage geometry blob to GeoJSON. Handles mixed byte order, ISO Z/M dimensionality, and EWKB flags; throws clearly on curved types GeoJSON cannot represent.
- `gpkg-reader.ts` selects the first feature layer, strips the `GP` blob header, decodes each geometry, and excludes the integer primary key from properties.
- Non-WGS84 layers are reprojected to WGS84 through the **existing** DuckDB `ST_Transform` path, whose GeoJSON reader is not affected by the threading bug (verified at 300 features).
- The large-dataset guard is preserved (counts rows first).

`ST_Read` is still used for every other vector format and for the GeoParquet conversion path; a file mislabelled `.gpkg` that is not actually SQLite falls through to `ST_Read`.

## Verification

- **Clean-room repro** of the crash using the deployed DuckDB-WASM + spatial versions.
- **Byte-identical geometry**: the new reader's output matches `ogr2ogr` ground truth with 0 geometry and 0 property mismatches across all four files in the issue (17 LineStrings, 182 + 19 Polygons, 275 LineStrings), plus MultiPolygon, 3D (Z), and EPSG:3857 cases.
- **End to end in the real app** (production build + drag-and-drop): all four GeoPackages render their geometry on the map with populated attribute tables and no console errors.
- 959 frontend tests pass (20 new for the decoder and reader); typecheck and scoped `pre-commit` (eslint + npm build) pass.

## Notes

The warped COG from the issue is unrelated to this rendering path and the reporter said it is out of scope for now, so it is not addressed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated GeoPackage (.gpkg) loading with automatic layer detection, direct table reads, WKB-to-GeoJSON decoding, property cleanup, and EPSG resolution with optional reprojection.
  * Added WKB decoding for common geometry types with correct endianness/dimensionality handling and explicit errors for unsupported curved types.
  * Added guards for large GeoPackage datasets during reads.
* **Tests**
  * Added unit tests for WKB decoding and GeoPackage reading, including envelope/header edge cases and malformed blobs.
* **Chores**
  * Updated the raster map dependency to the latest patch version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Also in this PR: the warped COG from #393

Issue #393 also reported one COG (`warped1868mapv1testexport1COG.tif`) that would not render while the others did. Root cause: its `GTModelTypeGeoKey` is `32767` ("user-defined") even though the projection is fully described by the geo-keys (it is an ArcGIS export of the ESRI `WGS_1984_Web_Mercator` auxiliary-sphere Mercator, which carries no EPSG code). The CRS parser threw `Unsupported GeoTIFF model type: 32767`, so the layer never drew.

That fix lives in the `maplibre-gl-raster` package (opengeos/maplibre-gl-raster#10, released as `0.2.2`): `loadGeoTIFF` now normalises a user-defined model type to "projected" when a projection method is present, so the CRS is built from the keys already in the file. The fix is projection-agnostic.

This PR bumps `maplibre-gl-raster` to `^0.2.2` so GeoLibre picks it up. Verified end to end: the previously invisible warped COG now renders at the correct location.
