### PR TITLE
fix(ci): build JupyterLite for the GitHub Pages demo

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,6 +34,12 @@ jobs:
       - name: Install documentation dependencies
         run: python -m pip install -r requirements-docs.txt
 
+      - name: Install JupyterLite build dependencies
+        # Lets the web build's `prebuild` hook generate the self-hosted
+        # JupyterLite site (served in the Notebook panel); without these the step
+        # skips and the demo's notebook 404s on the published site.
+        run: python -m pip install -r apps/geolibre-desktop/jupyterlite/requirements.txt
+
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
@@ -62,6 +68,7 @@ jobs:
           mkdir -p site/demo
           cp -R apps/geolibre-desktop/dist/. site/demo/
           test -f site/demo/index.html
+          test -f site/demo/jupyterlite/lab/index.html
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,9 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
-          cache-dependency-path: requirements-docs.txt
+          cache-dependency-path: |
+            requirements-docs.txt
+            apps/geolibre-desktop/jupyterlite/requirements.txt
 
       - name: Install documentation dependencies
         run: python -m pip install -r requirements-docs.txt


### PR DESCRIPTION
## Summary
- Production `geolibre.app` is served by GitHub Pages (`pages.yml`), not Netlify. That workflow built the web demo without the JupyterLite build dependencies, so the prebuild hook skipped and the Notebook panel 404'd on the published `/demo/`.
- Install `apps/geolibre-desktop/jupyterlite/requirements.txt` before the build (mirroring the earlier `netlify.toml` fix) so the prebuild generates the self-hosted JupyterLite site, and guard the demo copy step on `jupyterlite/lab/index.html` so a missing build fails CI instead of shipping a 404.

## Test plan
- [ ] Pages build succeeds with the new guard passing.
- [ ] After deploy, https://geolibre.app/demo/ opens the Notebook panel and JupyterLite loads (no 404).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the GitHub Pages site build by caching and installing the additional JupyterLite build requirements needed for the desktop app demo.
  * Added a stronger validation step to ensure the generated JupyterLite lab entrypoint exists before uploading the site artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->