### PR TITLE
fix(notebook): let %pip install work in the desktop kernel

### DIFF
--- a/backend/geolibre_server/pyproject.toml
+++ b/backend/geolibre_server/pyproject.toml
@@ -58,9 +58,16 @@ ml = [
 # the web build embeds the in-browser JupyterLite site instead, so this extra is
 # desktop-only. geopandas/rasterio/etc. install alongside via the relevant extras
 # (or `%pip install` in a cell).
+#
+# `pip` is seeded explicitly: uv-managed environments do not include pip, so a
+# `%pip install` cell (which runs `sys.executable -m pip`) would otherwise fail
+# with "No module named pip", and a bare `!pip install` falls through PATH to the
+# host's system pip (PEP-668 externally-managed -> error). Installing pip into the
+# kernel's own env makes `%pip install` work like a normal Jupyter environment.
 notebook = [
   "jupyterlab>=4.2,<5",
   "jupyter-server>=2.14",
+  "pip>=24",
 ]
 # Future geospatial stack (not required for MVP UI):
 # geo = [


### PR DESCRIPTION
## Summary
- The desktop Notebook panel runs JupyterLab from a uv-managed venv that ships no `pip`, so `%pip install` failed with "No module named pip" and a bare `!pip install` fell through `PATH` to the host's system pip (PEP-668 externally-managed, which errors out).
- Seed `pip` into the `notebook` extra so the kernel's own Python can run `%pip install <pkg>` like a normal Jupyter environment.

## Test plan
- [x] `uv sync --extra notebook` resolves and installs `pip` into the kernel venv
- [x] `python -m pip install --dry-run geopandas` resolves against the kernel venv (geopandas + pyproj + shapely + pyogrio)
- [ ] In the desktop app, open the Notebook panel and run `%pip install geopandas` in a cell, then `import geopandas` after a kernel restart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated notebook environment configuration to ensure `%pip install` commands function correctly within notebook kernels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->