### PR TITLE
docs(architecture): note WebKitGTK map render limits on Linux

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -93,3 +93,37 @@ The container does not run the Tauri desktop shell or the optional Python sideca
 
 - Tauri CSP allowlists tile and style hosts (OpenFreeMap, CARTO).
 - File access uses dialog-selected paths only.
+
+## Performance: map rendering on Linux (WebKitGTK)
+
+The desktop app uses the system WebView. On Linux that is **WebKitGTK**, whose
+WebGL/JavaScript pipeline is materially slower than the Chromium engine the
+browser build runs in. The most visible effect is **map panning at low zoom**:
+
+- A blank map (no tile layer) pans at a steady 60 FPS at any zoom.
+- With any tile layer (vector **or** raster XYZ), FPS collapses to single
+  digits **while tiles are loading**, then snaps back to 60 once loading stops,
+  at the same zoom. Low zoom only makes it constant because panning across the
+  whole world loads tiles continuously and the cache never settles.
+
+The cost is WebKitGTK integrating each newly-loaded tile on the main thread
+(GPU upload plus the per-tile bucket build and fade-in repaints). Each
+tile-integration render measured ~125 ms in WebKitGTK's JavaScriptCore versus a
+few ms in Chromium's V8. This is a WebView-engine limitation, not a bug in
+GeoLibre, and it does not affect the browser build or (untested) the
+macOS/Windows WebViews.
+
+Ruled out during diagnosis (so future investigation does not repeat them):
+software rendering (the GPU is used, Intel i915 confirmed), GPU saturation (the
+render engine stays ~20% idle), the Tauri IPC file read (~126 ms for a 22 MB
+GeoJSON), `JSON.parse` (~36 ms), KWin compositor latency, `renderWorldCopies`,
+the globe vs. mercator projection, and `preserveDrawingBuffer`.
+
+To reproduce the measurement: temporarily log MapLibre `render` events,
+`dataloading` (tile) events, and a `requestAnimationFrame` counter once per
+second; FPS tracks tile-load count inversely.
+
+Mitigations (reduce *how many* tiles load during a pan, since per-tile cost is
+fixed by the engine) are not yet implemented: a larger `maxTileCacheSize`,
+512px raster tiles instead of 256px, and `fadeDuration: 0`, ideally gated to
+WebKitGTK so the Chromium-based builds keep full fidelity.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -106,12 +106,16 @@ browser build runs in. The most visible effect is **map panning at low zoom**:
   at the same zoom. Low zoom only makes it constant because panning across the
   whole world loads tiles continuously and the cache never settles.
 
-The cost is WebKitGTK integrating each newly-loaded tile on the main thread
-(GPU upload plus the per-tile bucket build and fade-in repaints). Each
-tile-integration render measured ~125 ms in WebKitGTK's JavaScriptCore versus a
-few ms in Chromium's V8. This is a WebView-engine limitation, not a bug in
-GeoLibre, and it does not affect the browser build or (untested) the
-macOS/Windows WebViews.
+The cost is WebKitGTK processing each newly-loaded tile on the main thread: the
+GPU upload of its texture (raster) or vertex buffers (vector) via synchronous
+WebGL calls, plus the subsequent fade-in repaint frames. Vector tile parsing and
+bucket building run in MapLibre's Web Workers, so they are not the bottleneck
+here. Each tile-integration render cycle measured ~125 ms wall-clock in
+WebKitGTK versus a few ms in Chromium. The gap is in WebKitGTK's WebGL
+implementation and compositor pipeline (driver command-stream flush, TextureMapper
+GL surface composition), not solely its JavaScriptCore JS engine. This is a
+WebView-engine limitation, not a bug in GeoLibre, and it does not affect the
+browser build or (untested) the macOS/Windows WebViews.
 
 Ruled out during diagnosis (so future investigation does not repeat them):
 software rendering (the GPU is used, Intel i915 confirmed), GPU saturation (the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -121,7 +121,13 @@ the globe vs. mercator projection, and `preserveDrawingBuffer`.
 
 To reproduce the measurement: temporarily log MapLibre `render` events,
 `dataloading` (tile) events, and a `requestAnimationFrame` counter once per
-second; FPS tracks tile-load count inversely.
+second; FPS tracks tile-load count inversely. The quickest check is this
+frame-rate meter pasted into the WebView devtools console, then pan while
+watching the logged FPS:
+
+```js
+let f=0,t=performance.now();(function loop(n){f++;if(n-t>=1000){console.log('FPS',f);f=0;t=n;}requestAnimationFrame(loop);})(t);
+```
 
 Mitigations (reduce *how many* tiles load during a pan, since per-tile cost is
 fixed by the engine) are not yet implemented: a larger `maxTileCacheSize`,


### PR DESCRIPTION
## Summary
- Document why low-zoom map panning is slow in the Linux desktop build: WebKitGTK integrates each newly loaded tile on the main thread far slower than Chromium, so FPS tracks tile loading and recovers to 60 once tiles settle.
- Record the hypotheses ruled out during diagnosis (software rendering, GPU saturation, IPC read, JSON.parse, KWin latency, renderWorldCopies, projection, preserveDrawingBuffer) and how to reproduce the measurement, so the investigation is not repeated.
- List candidate mitigations (larger tile cache, 512px raster tiles, fadeDuration 0) without implementing them yet.

## Test plan
- [ ] Docs-only change. Confirm the new "Performance: map rendering on Linux (WebKitGTK)" section renders correctly in the docs site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new architecture section explaining Linux (WebKitGTK) map rendering performance, including observed FPS drops during tile loading, the suspected main-thread bottleneck, ruled-out factors, and a step-by-step reproduction/measurement approach using MapLibre render/loading events and an FPS meter. Also outlines potential mitigations targeted to this environment (e.g., cache/tile sizing and fade behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->