### PR TITLE
feat(dashboard): add a Dashboard panel of chart widgets (#401)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -262,6 +262,19 @@ const AssistantPanel = lazy(() =>
     }),
 );
 
+const DashboardPanel = lazy(() =>
+  import("../panels/DashboardPanel")
+    .then((module) => ({
+      default: module.DashboardPanel,
+    }))
+    .catch((error) => {
+      // Same chunk-load fallback rationale as the dialogs above.
+      console.error("Failed to load DashboardPanel", error);
+      const Fallback = (() =>
+        null) as unknown as typeof import("../panels/DashboardPanel").DashboardPanel;
+      return { default: Fallback };
+    }),
+);
 const PythonConsolePanel = lazy(() =>
   import("../panels/PythonConsolePanel")
     .then((module) => ({
@@ -342,6 +355,7 @@ export function DesktopShell({
   const pythonConsoleOpen = useAppStore((s) => s.ui.pythonConsoleOpen);
   const notebookOpen = useAppStore((s) => s.ui.notebookOpen);
   const assistantOpen = useAppStore((s) => s.ui.assistantOpen);
+  const dashboardOpen = useAppStore((s) => s.ui.dashboardOpen);
   const geometryEditLayerId = useSyncExternalStore(
     subscribeGeometryEdit,
     getGeometryEditTargetLayerId,
@@ -1217,6 +1231,13 @@ export function DesktopShell({
       {layoutOptions.attributePanelVisible ? (
         <SectionErrorBoundary label="Attribute table">
           <AttributeTable mapControllerRef={mapControllerRef} />
+        </SectionErrorBoundary>
+      ) : null}
+      {dashboardOpen ? (
+        <SectionErrorBoundary label="Dashboard">
+          <Suspense fallback={null}>
+            <DashboardPanel />
+          </Suspense>
         </SectionErrorBoundary>
       ) : null}
       {pythonConsoleOpen ? (

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -275,6 +275,7 @@ const DashboardPanel = lazy(() =>
       return { default: Fallback };
     }),
 );
+
 const PythonConsolePanel = lazy(() =>
   import("../panels/PythonConsolePanel")
     .then((module) => ({

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
@@ -47,6 +47,7 @@ export function ProcessingMenu({
   const setPythonConsoleOpen = useAppStore((s) => s.setPythonConsoleOpen);
   const setNotebookOpen = useAppStore((s) => s.setNotebookOpen);
   const setAssistantOpen = useAppStore((s) => s.setAssistantOpen);
+  const setDashboardOpen = useAppStore((s) => s.setDashboardOpen);
 
   // Whitebox, format Conversion, Raster tools, and AI Segmentation all require
   // the Python sidecar, which cannot run on Android/iOS — hide them on mobile so
@@ -88,6 +89,9 @@ export function ProcessingMenu({
         </DropdownMenuItem>
         <DropdownMenuItem onSelect={() => setNotebookOpen(true)}>
           {t("toolbar.command.notebook")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => setDashboardOpen(true)}>
+          {t("toolbar.command.dashboard")}
         </DropdownMenuItem>
         <DropdownMenuItem onSelect={() => setGeocodeOpen(true)}>
           {t("toolbar.item.geocode")}

--- a/apps/geolibre-desktop/src/components/panels/AttributeChartDialog.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeChartDialog.tsx
@@ -14,26 +14,27 @@ import {
   Select,
 } from "@geolibre/ui";
 import { Download } from "lucide-react";
-import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { downloadChartPng, downloadChartSvg } from "../../lib/chart-export";
 import { sanitizeExportFileName } from "../../lib/vector-export";
 import {
   categoricalColumns,
-  computeBar,
-  computeBox,
-  computeHistogram,
-  computeLine,
-  computeScatter,
   DEFAULT_HISTOGRAM_BINS,
-  formatAxisValue,
   MAX_HISTOGRAM_BINS,
   MIN_HISTOGRAM_BINS,
   numericColumns,
-  numericValues,
   type BarAggregation,
   type ChartRow,
   type ChartType,
 } from "../../lib/attribute-charts";
+import {
+  CHART_H,
+  CHART_W,
+  ChartView,
+  chartResultHasData,
+  computeChart,
+  type ChartSpec,
+} from "./charts/chart-view";
 
 interface AttributeChartDialogProps {
   open: boolean;
@@ -41,27 +42,6 @@ interface AttributeChartDialogProps {
   rows: ChartRow[];
   columns: string[];
   layerName: string;
-}
-
-// SVG geometry. The chart scales to its container via viewBox/width=100%.
-const CHART_W = 560;
-const CHART_H = 300;
-const MARGIN = { top: 16, right: 16, bottom: 52, left: 52 };
-const INNER_W = CHART_W - MARGIN.left - MARGIN.right;
-const INNER_H = CHART_H - MARGIN.top - MARGIN.bottom;
-
-const AXIS = "hsl(var(--border))";
-const TICK = "hsl(var(--muted-foreground))";
-const SERIES = "hsl(var(--primary))";
-
-/** Map a value within [min, max] to a 0..1 fraction, centering a flat range. */
-function fraction(value: number, min: number, max: number): number {
-  if (max === min) return 0.5;
-  return (value - min) / (max - min);
-}
-
-function truncateLabel(label: string, max = 14): string {
-  return label.length > max ? `${label.slice(0, max - 1)}…` : label;
 }
 
 export function AttributeChartDialog({
@@ -112,44 +92,27 @@ export function AttributeChartDialog({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
-  const histogram = useMemo(() => {
-    if (chartType !== "histogram" || !field) return null;
-    return computeHistogram(numericValues(rows, field), bins);
-  }, [chartType, field, rows, bins]);
-
-  const scatter = useMemo(() => {
-    if (chartType !== "scatter" || !xField || !yField) return null;
-    return computeScatter(rows, xField, yField);
-  }, [chartType, xField, yField, rows]);
-
-  const bar = useMemo(() => {
-    if (chartType !== "bar" || !catField) return null;
-    return computeBar(
-      rows,
-      catField,
-      barAgg,
-      barAgg === "count" ? null : barValueField,
-    );
-  }, [chartType, catField, barAgg, barValueField, rows]);
-
-  const line = useMemo(() => {
-    if (chartType !== "line" || !field) return null;
-    return computeLine(rows, field);
-  }, [chartType, field, rows]);
-
-  const box = useMemo(() => {
-    if (chartType !== "box" || !field) return null;
-    return computeBox(numericValues(rows, field));
-  }, [chartType, field, rows]);
+  const spec = useMemo<ChartSpec>(
+    () => ({
+      type: chartType,
+      field,
+      xField,
+      yField,
+      bins,
+      category: catField,
+      aggregation: barAgg,
+      valueField: barValueField,
+    }),
+    [chartType, field, xField, yField, bins, catField, barAgg, barValueField],
+  );
+  const chartResult = useMemo(() => computeChart(rows, spec), [rows, spec]);
 
   const hasNumeric = numericCols.length > 0;
   const hasCategory = categoryCols.length > 0;
   const hasChartable = hasNumeric || hasCategory;
   // A chart is only downloadable when the active type produced a result (an SVG
   // is on screen); empty states render no <svg>.
-  const chartRendered = Boolean(
-    histogram || scatter || bar || line || box,
-  );
+  const chartRendered = chartResultHasData(chartResult);
 
   const downloadChart = (format: "svg" | "png") => {
     const svg = chartRef.current?.querySelector("svg");
@@ -327,23 +290,7 @@ export function AttributeChartDialog({
             </div>
 
             <div ref={chartRef} className="rounded-md border bg-background p-2">
-              {chartType === "histogram" && (
-                <HistogramChart result={histogram} field={field} />
-              )}
-              {chartType === "scatter" && (
-                <ScatterChart result={scatter} xField={xField} yField={yField} />
-              )}
-              {chartType === "bar" && (
-                <BarChart
-                  result={bar}
-                  aggregation={barAgg}
-                  category={catField}
-                />
-              )}
-              {chartType === "line" && (
-                <LineChart result={line} field={field} />
-              )}
-              {chartType === "box" && <BoxChart result={box} field={field} />}
+              <ChartView result={chartResult} />
             </div>
           </div>
         )}
@@ -410,443 +357,5 @@ function FieldSelect({
         ))}
       </Select>
     </div>
-  );
-}
-
-function ChartFrame({
-  label,
-  children,
-}: {
-  label: string;
-  children: ReactNode;
-}) {
-  return (
-    <svg
-      viewBox={`0 0 ${CHART_W} ${CHART_H}`}
-      width="100%"
-      role="img"
-      aria-label={label}
-      className="h-auto w-full"
-      preserveAspectRatio="xMidYMid meet"
-    >
-      <line
-        x1={MARGIN.left}
-        y1={MARGIN.top}
-        x2={MARGIN.left}
-        y2={MARGIN.top + INNER_H}
-        stroke={AXIS}
-      />
-      <line
-        x1={MARGIN.left}
-        y1={MARGIN.top + INNER_H}
-        x2={MARGIN.left + INNER_W}
-        y2={MARGIN.top + INNER_H}
-        stroke={AXIS}
-      />
-      {children}
-    </svg>
-  );
-}
-
-function tickText(
-  x: number,
-  y: number,
-  text: string,
-  anchor: "start" | "middle" | "end",
-  baseline: "middle" | "auto" = "auto",
-) {
-  return (
-    <text
-      x={x}
-      y={y}
-      textAnchor={anchor}
-      dominantBaseline={baseline}
-      fontSize={10}
-      fill={TICK}
-    >
-      {text}
-    </text>
-  );
-}
-
-function axisTitle(text: string) {
-  return (
-    <text
-      x={MARGIN.left + INNER_W / 2}
-      y={CHART_H - 4}
-      textAnchor="middle"
-      fontSize={11}
-      fill={TICK}
-    >
-      {text}
-    </text>
-  );
-}
-
-function yAxisTitle(text: string) {
-  const cy = MARGIN.top + INNER_H / 2;
-  return (
-    <text
-      x={12}
-      y={cy}
-      textAnchor="middle"
-      fontSize={11}
-      fill={TICK}
-      transform={`rotate(-90 12 ${cy})`}
-    >
-      {text}
-    </text>
-  );
-}
-
-function EmptyChart({ message }: { message: string }) {
-  return (
-    <p className="py-10 text-center text-sm text-muted-foreground">{message}</p>
-  );
-}
-
-function Caption({ children }: { children: ReactNode }) {
-  return (
-    <p className="mt-1 text-center text-xs text-muted-foreground">{children}</p>
-  );
-}
-
-function HistogramChart({
-  result,
-  field,
-}: {
-  result: ReturnType<typeof computeHistogram>;
-  field: string;
-}) {
-  if (!result) return <EmptyChart message="No numeric values to plot." />;
-
-  const { bins, maxCount, min, max, total } = result;
-  const slot = INNER_W / bins.length;
-  const gap = Math.min(4, slot * 0.15);
-
-  return (
-    <>
-      <ChartFrame label={`Histogram of ${field}`}>
-        {tickText(MARGIN.left - 6, MARGIN.top + INNER_H, "0", "end", "middle")}
-        {tickText(MARGIN.left - 6, MARGIN.top, String(maxCount), "end", "middle")}
-        {bins.map((bin, index) => {
-          const height = maxCount === 0 ? 0 : (bin.count / maxCount) * INNER_H;
-          return (
-            <rect
-              key={index}
-              x={MARGIN.left + index * slot + gap / 2}
-              y={MARGIN.top + INNER_H - height}
-              width={Math.max(1, slot - gap)}
-              height={height}
-              fill={SERIES}
-              opacity={0.85}
-            >
-              <title>{`[${formatAxisValue(bin.x0)}, ${formatAxisValue(bin.x1)}${
-                index === bins.length - 1 ? "]" : ")"
-              }: ${bin.count}`}</title>
-            </rect>
-          );
-        })}
-        {/* A collapsed (min === max) histogram spans the full width, so show a
-            single centered label instead of identical min/max labels. */}
-        {min === max ? (
-          tickText(MARGIN.left + INNER_W / 2, MARGIN.top + INNER_H + 14, formatAxisValue(min), "middle")
-        ) : (
-          <>
-            {tickText(MARGIN.left, MARGIN.top + INNER_H + 14, formatAxisValue(min), "start")}
-            {tickText(MARGIN.left + INNER_W, MARGIN.top + INNER_H + 14, formatAxisValue(max), "end")}
-          </>
-        )}
-        {axisTitle(field)}
-      </ChartFrame>
-      <Caption>
-        {total.toLocaleString()} value{total === 1 ? "" : "s"} · count on y
-      </Caption>
-    </>
-  );
-}
-
-function ScatterChart({
-  result,
-  xField,
-  yField,
-}: {
-  result: ReturnType<typeof computeScatter>;
-  xField: string;
-  yField: string;
-}) {
-  if (!result) {
-    return <EmptyChart message="No rows have both fields set to a number." />;
-  }
-
-  const { points, total, xMin, xMax, yMin, yMax } = result;
-  const sampled = total > points.length;
-
-  return (
-    <>
-      <ChartFrame label={`Scatter plot of ${yField} versus ${xField}`}>
-        {/* Single centered tick when an axis is flat (all values identical),
-            mirroring the histogram, rather than the same value at both ends. */}
-        {yMin === yMax ? (
-          tickText(MARGIN.left - 6, MARGIN.top + INNER_H / 2, formatAxisValue(yMin), "end", "middle")
-        ) : (
-          <>
-            {tickText(MARGIN.left - 6, MARGIN.top, formatAxisValue(yMax), "end", "middle")}
-            {tickText(MARGIN.left - 6, MARGIN.top + INNER_H, formatAxisValue(yMin), "end", "middle")}
-          </>
-        )}
-        {points.map((point, index) => {
-          const cx = MARGIN.left + fraction(point.x, xMin, xMax) * INNER_W;
-          const cy =
-            MARGIN.top + INNER_H - fraction(point.y, yMin, yMax) * INNER_H;
-          return (
-            <circle key={index} cx={cx} cy={cy} r={3} fill={SERIES} opacity={0.6}>
-              <title>{`${xField}: ${formatAxisValue(point.x)}, ${yField}: ${formatAxisValue(point.y)}`}</title>
-            </circle>
-          );
-        })}
-        {xMin === xMax ? (
-          tickText(MARGIN.left + INNER_W / 2, MARGIN.top + INNER_H + 14, formatAxisValue(xMin), "middle")
-        ) : (
-          <>
-            {tickText(MARGIN.left, MARGIN.top + INNER_H + 14, formatAxisValue(xMin), "start")}
-            {tickText(MARGIN.left + INNER_W, MARGIN.top + INNER_H + 14, formatAxisValue(xMax), "end")}
-          </>
-        )}
-        {axisTitle(xField)}
-        {yAxisTitle(yField)}
-      </ChartFrame>
-      <Caption>
-        {total.toLocaleString()} point{total === 1 ? "" : "s"} · {yField} vs{" "}
-        {xField}
-        {sampled ? ` · showing ${points.length.toLocaleString()} sampled` : ""}
-      </Caption>
-    </>
-  );
-}
-
-function BarChart({
-  result,
-  aggregation,
-  category,
-}: {
-  result: ReturnType<typeof computeBar>;
-  aggregation: BarAggregation;
-  category: string;
-}) {
-  if (!result) return <EmptyChart message="No rows to group." />;
-
-  const { bars, maxValue, minValue, truncated } = result;
-  const domainMin = Math.min(0, minValue);
-  // Keep 0 as the top of the scale when every bar is <= 0 (possible for
-  // sum/mean); only fall back to 1 when the domain would otherwise be zero-width
-  // (all bars exactly 0). `Math.max(0, maxValue) || 1` wrongly made an
-  // all-negative domain top out at 1.
-  const domainMax = maxValue > 0 ? maxValue : minValue < 0 ? 0 : 1;
-  const slot = INNER_W / bars.length;
-  const gap = Math.min(6, slot * 0.2);
-  const scaleY = (value: number) =>
-    MARGIN.top + INNER_H - fraction(value, domainMin, domainMax) * INNER_H;
-  const baselineY = scaleY(0);
-
-  return (
-    <>
-      <ChartFrame label={`Bar chart of ${aggregation} by ${category}`}>
-        {/* Top tick only when the domain extends above 0; when all bars are
-            <= 0 the domain tops at 0 and the baseline tick already labels it. */}
-        {domainMax > 0
-          ? tickText(MARGIN.left - 6, MARGIN.top, formatAxisValue(domainMax), "end", "middle")
-          : null}
-        {tickText(MARGIN.left - 6, baselineY, "0", "end", "middle")}
-        {/* Lower-bound tick when bars go negative (sum/mean of negative values). */}
-        {minValue < 0
-          ? tickText(MARGIN.left - 6, MARGIN.top + INNER_H, formatAxisValue(domainMin), "end", "middle")
-          : null}
-        {bars.map((datum, index) => {
-          const top = Math.min(baselineY, scaleY(datum.value));
-          const height = Math.abs(scaleY(datum.value) - baselineY);
-          const cx = MARGIN.left + index * slot + slot / 2;
-          return (
-            <g key={datum.label}>
-              <rect
-                x={MARGIN.left + index * slot + gap / 2}
-                y={top}
-                width={Math.max(1, slot - gap)}
-                height={Math.max(0, height)}
-                fill={SERIES}
-                opacity={0.85}
-              >
-                <title>{`${datum.label}: ${formatAxisValue(datum.value)} (${datum.count} row${datum.count === 1 ? "" : "s"})`}</title>
-              </rect>
-              <text
-                x={cx}
-                y={MARGIN.top + INNER_H + 12}
-                textAnchor="end"
-                fontSize={9}
-                fill={TICK}
-                transform={`rotate(-40 ${cx} ${MARGIN.top + INNER_H + 12})`}
-              >
-                {truncateLabel(datum.label)}
-              </text>
-            </g>
-          );
-        })}
-      </ChartFrame>
-      <Caption>
-        {aggregation === "count"
-          ? "row count"
-          : aggregation === "sum"
-            ? "sum on y"
-            : "average on y"}
-        {truncated > 0 ? ` · top ${bars.length} (${truncated} more hidden)` : ""}
-      </Caption>
-    </>
-  );
-}
-
-function LineChart({
-  result,
-  field,
-}: {
-  result: ReturnType<typeof computeLine>;
-  field: string;
-}) {
-  if (!result) return <EmptyChart message="No numeric values to plot." />;
-
-  const { points, min, max, length } = result;
-  const scaleX = (index: number) =>
-    MARGIN.left + (length > 1 ? index / (length - 1) : 0.5) * INNER_W;
-  const scaleY = (value: number) =>
-    MARGIN.top + INNER_H - fraction(value, min, max) * INNER_H;
-  const path = points
-    .map((p, i) => {
-      // Break the line (start a new subpath) when rows are non-consecutive, so
-      // a gap from skipped (non-numeric) rows shows as a gap rather than a
-      // straight segment across it.
-      const command =
-        i === 0 || p.index !== points[i - 1].index + 1 ? "M" : "L";
-      return `${command}${scaleX(p.index)} ${scaleY(p.value)}`;
-    })
-    .join(" ");
-
-  return (
-    <>
-      <ChartFrame label={`Line chart of ${field} by feature order`}>
-        {tickText(MARGIN.left - 6, MARGIN.top, formatAxisValue(max), "end", "middle")}
-        {tickText(MARGIN.left - 6, MARGIN.top + INNER_H, formatAxisValue(min), "end", "middle")}
-        <path d={path} fill="none" stroke={SERIES} strokeWidth={1.5} />
-        {points.length <= 80
-          ? points.map((p) => (
-              <circle
-                key={p.index}
-                cx={scaleX(p.index)}
-                cy={scaleY(p.value)}
-                r={2}
-                fill={SERIES}
-              >
-                <title>{`#${p.index}: ${formatAxisValue(p.value)}`}</title>
-              </circle>
-            ))
-          : null}
-        {/* A single-feature layer has only index 0; show one centered label
-            instead of "0" at both ends. */}
-        {length <= 1 ? (
-          tickText(MARGIN.left + INNER_W / 2, MARGIN.top + INNER_H + 14, "0", "middle")
-        ) : (
-          <>
-            {tickText(MARGIN.left, MARGIN.top + INNER_H + 14, "0", "start")}
-            {tickText(MARGIN.left + INNER_W, MARGIN.top + INNER_H + 14, String(length - 1), "end")}
-          </>
-        )}
-        {axisTitle("feature order")}
-      </ChartFrame>
-      <Caption>
-        {points.length.toLocaleString()} value{points.length === 1 ? "" : "s"} ·{" "}
-        {field} by feature order
-      </Caption>
-    </>
-  );
-}
-
-function BoxChart({
-  result,
-  field,
-}: {
-  result: ReturnType<typeof computeBox>;
-  field: string;
-}) {
-  if (!result) return <EmptyChart message="No numeric values to plot." />;
-
-  const { min, q1, median, q3, max, count } = result;
-  const centerX = MARGIN.left + INNER_W / 2;
-  const boxWidth = 96;
-  const scaleY = (value: number) =>
-    MARGIN.top + INNER_H - fraction(value, min, max) * INNER_H;
-
-  const stats: [string, number][] = [
-    ["max", max],
-    ["Q3", q3],
-    ["median", median],
-    ["Q1", q1],
-    ["min", min],
-  ];
-
-  return (
-    <>
-      <ChartFrame label={`Box plot of ${field}`}>
-        {/* whisker */}
-        <line x1={centerX} y1={scaleY(min)} x2={centerX} y2={scaleY(max)} stroke={AXIS} />
-        <line x1={centerX - 20} y1={scaleY(max)} x2={centerX + 20} y2={scaleY(max)} stroke={AXIS} />
-        <line x1={centerX - 20} y1={scaleY(min)} x2={centerX + 20} y2={scaleY(min)} stroke={AXIS} />
-        {/* box */}
-        <rect
-          x={centerX - boxWidth / 2}
-          y={scaleY(q3)}
-          width={boxWidth}
-          height={Math.max(1, scaleY(q1) - scaleY(q3))}
-          fill={SERIES}
-          opacity={0.25}
-          stroke={SERIES}
-        />
-        <line
-          x1={centerX - boxWidth / 2}
-          y1={scaleY(median)}
-          x2={centerX + boxWidth / 2}
-          y2={scaleY(median)}
-          stroke={SERIES}
-          strokeWidth={2}
-        />
-        {/* When every value is identical the five stats share one y position;
-            show a single label instead of five overlapping ones. */}
-        {min === max ? (
-          tickText(
-            centerX + boxWidth / 2 + 8,
-            scaleY(median),
-            `all = ${formatAxisValue(median)}`,
-            "start",
-            "middle",
-          )
-        ) : (
-          stats.map(([label, value]) => (
-            <text
-              key={label}
-              x={centerX + boxWidth / 2 + 8}
-              y={scaleY(value)}
-              textAnchor="start"
-              dominantBaseline="middle"
-              fontSize={10}
-              fill={TICK}
-            >
-              {`${label} ${formatAxisValue(value)}`}
-            </text>
-          ))
-        )}
-        {axisTitle(field)}
-      </ChartFrame>
-      <Caption>
-        {count.toLocaleString()} value{count === 1 ? "" : "s"} · five-number
-        summary
-      </Caption>
-    </>
   );
 }

--- a/apps/geolibre-desktop/src/components/panels/AttributeChartDialog.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeChartDialog.tsx
@@ -178,6 +178,9 @@ export function AttributeChartDialog({
                   <option value="box" disabled={!hasNumeric}>
                     Box plot
                   </option>
+                  <option value="pie" disabled={!hasCategory}>
+                    Pie
+                  </option>
                 </Select>
               </div>
 
@@ -248,7 +251,7 @@ export function AttributeChartDialog({
                 </>
               )}
 
-              {chartType === "bar" && (
+              {(chartType === "bar" || chartType === "pie") && (
                 <>
                   <FieldSelect
                     id="chart-category"
@@ -271,9 +274,12 @@ export function AttributeChartDialog({
                       <option value="sum" disabled={!hasNumeric}>
                         Sum
                       </option>
-                      <option value="mean" disabled={!hasNumeric}>
-                        Average
-                      </option>
+                      {/* Averaging parts of a whole is meaningless for a pie. */}
+                      {chartType !== "pie" && (
+                        <option value="mean" disabled={!hasNumeric}>
+                          Average
+                        </option>
+                      )}
                     </Select>
                   </div>
                   {barAgg !== "count" && (

--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -45,6 +45,7 @@ import {
   Columns3,
   Download,
   EyeOff,
+  LayoutDashboard,
   MoreHorizontal,
   Pencil,
   PanelBottomClose,
@@ -264,6 +265,7 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
   const selectFeature = useAppStore((s) => s.selectFeature);
   const attributeTableOpen = useAppStore((s) => s.ui.attributeTableOpen);
   const setAttributeTableOpen = useAppStore((s) => s.setAttributeTableOpen);
+  const setDashboardOpen = useAppStore((s) => s.setDashboardOpen);
   const updateLayer = useAppStore((s) => s.updateLayer);
   const zoomToSelectedFeature = useAppStore(
     (s) => s.ui.zoomToSelectedFeature,
@@ -1381,6 +1383,19 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
           >
             <ChartColumn className="h-3.5 w-3.5" />
             <span className="hidden sm:inline">Charts</span>
+          </Button>
+        ) : null}
+        {!isEditing ? (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 px-2"
+            title="Open the dashboard to build chart widgets"
+            aria-label="Dashboard"
+            onClick={() => setDashboardOpen(true)}
+          >
+            <LayoutDashboard className="h-3.5 w-3.5" />
+            <span className="hidden sm:inline">Dashboard</span>
           </Button>
         ) : null}
         <DropdownMenu>

--- a/apps/geolibre-desktop/src/components/panels/DashboardPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/DashboardPanel.tsx
@@ -376,7 +376,7 @@ function WidgetCard({
       </div>
 
       {data.hasData ? (
-        <ChartView result={result} />
+        <ChartView result={result} color={widget.color} />
       ) : (
         <p className="py-8 text-center text-xs text-muted-foreground">
           {t("dashboard.noData")}

--- a/apps/geolibre-desktop/src/components/panels/DashboardPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/DashboardPanel.tsx
@@ -1,6 +1,10 @@
 import type { DashboardWidget } from "@geolibre/core";
-import { useAppStore } from "@geolibre/core";
-import { Button } from "@geolibre/ui";
+import {
+  MAX_DASHBOARD_COLUMNS,
+  MIN_DASHBOARD_COLUMNS,
+  useAppStore,
+} from "@geolibre/core";
+import { Button, Select } from "@geolibre/ui";
 import {
   ChevronLeft,
   ChevronRight,
@@ -57,11 +61,22 @@ export function DashboardPanel() {
   const { t } = useTranslation();
   const widgets = useAppStore((s) => s.widgets);
   const layers = useAppStore((s) => s.layers);
+  const columns = useAppStore((s) => s.dashboardColumns);
   const setDashboardOpen = useAppStore((s) => s.setDashboardOpen);
+  const setDashboardColumns = useAppStore((s) => s.setDashboardColumns);
   const addWidget = useAppStore((s) => s.addWidget);
   const updateWidget = useAppStore((s) => s.updateWidget);
   const removeWidget = useAppStore((s) => s.removeWidget);
   const moveWidget = useAppStore((s) => s.moveWidget);
+
+  // Choices for the column-count picker, derived from the supported range.
+  const columnOptions = useMemo(() => {
+    const values: number[] = [];
+    for (let n = MIN_DASHBOARD_COLUMNS; n <= MAX_DASHBOARD_COLUMNS; n += 1) {
+      values.push(n);
+    }
+    return values;
+  }, []);
 
   const sectionRef = useRef<HTMLElement>(null);
   const resizeCleanupRef = useRef<(() => void) | null>(null);
@@ -165,7 +180,26 @@ export function DashboardPanel() {
         <span className="text-xs text-muted-foreground">
           {t("dashboard.widgetCount", { count: widgets.length })}
         </span>
-        <div className="ml-auto flex items-center gap-1">
+        <div className="ml-auto flex items-center gap-2">
+          {widgets.length > 0 ? (
+            <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <span className="hidden sm:inline">{t("dashboard.columns")}</span>
+              <Select
+                aria-label={t("dashboard.columns")}
+                className="h-8 w-16"
+                value={String(columns)}
+                onChange={(event) =>
+                  setDashboardColumns(Number(event.target.value))
+                }
+              >
+                {columnOptions.map((n) => (
+                  <option key={n} value={n}>
+                    {n}
+                  </option>
+                ))}
+              </Select>
+            </label>
+          ) : null}
           <Button
             variant="outline"
             size="sm"
@@ -204,7 +238,12 @@ export function DashboardPanel() {
             </p>
           </div>
         ) : (
-          <div className="grid grid-cols-1 gap-3 lg:grid-cols-2 xl:grid-cols-3">
+          <div
+            className="grid gap-3"
+            style={{
+              gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+            }}
+          >
             {widgets.map((widget, index) => (
               <WidgetCard
                 key={widget.id}
@@ -274,6 +313,8 @@ function WidgetCard({
         return `${t("dashboard.chartType.line")} · ${widget.field ?? ""}`;
       case "box":
         return `${t("dashboard.chartType.box")} · ${widget.field ?? ""}`;
+      case "pie":
+        return `${t("dashboard.chartType.pie")} · ${widget.category ?? ""}`;
     }
   }
 

--- a/apps/geolibre-desktop/src/components/panels/DashboardPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/DashboardPanel.tsx
@@ -291,10 +291,8 @@ function WidgetCard({
     () => computeChart(data.rows, widgetToSpec(widget)),
     [data.rows, widget],
   );
-  const title = widget.title?.trim() || defaultWidgetTitle();
-
-  /** A readable title from the widget's chart type and fields when untitled. */
-  function defaultWidgetTitle(): string {
+  // A readable title from the widget's chart type and fields when untitled.
+  const defaultWidgetTitle = (): string => {
     switch (widget.type) {
       case "histogram":
         return `${t("dashboard.chartType.histogram")} · ${widget.field ?? ""}`;
@@ -316,7 +314,8 @@ function WidgetCard({
       case "pie":
         return `${t("dashboard.chartType.pie")} · ${widget.category ?? ""}`;
     }
-  }
+  };
+  const title = widget.title?.trim() || defaultWidgetTitle();
 
   return (
     <div className="flex flex-col gap-2 rounded-md border bg-background p-3">

--- a/apps/geolibre-desktop/src/components/panels/DashboardPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/DashboardPanel.tsx
@@ -171,8 +171,24 @@ export function DashboardPanel() {
         role="separator"
         aria-orientation="horizontal"
         aria-label={t("dashboard.resize")}
-        className="absolute -top-1 left-0 right-0 z-20 h-2 cursor-row-resize select-none border-t border-transparent hover:border-primary"
+        aria-valuenow={Math.round(height)}
+        aria-valuemin={MIN_DASHBOARD_HEIGHT}
+        aria-valuemax={MAX_DASHBOARD_HEIGHT}
+        tabIndex={0}
+        className="absolute -top-1 left-0 right-0 z-20 h-2 cursor-row-resize select-none border-t border-transparent hover:border-primary focus-visible:border-primary focus-visible:outline-none"
         onMouseDown={startResize}
+        onKeyDown={(event) => {
+          // Arrow keys resize for keyboard-only users (Shift = larger step).
+          const step = event.shiftKey ? 24 : 8;
+          if (event.key === "ArrowUp") {
+            setHeight((h) => Math.min(MAX_DASHBOARD_HEIGHT, h + step));
+          } else if (event.key === "ArrowDown") {
+            setHeight((h) => Math.max(MIN_DASHBOARD_HEIGHT, h - step));
+          } else {
+            return;
+          }
+          event.preventDefault();
+        }}
       />
       <div className="flex items-center gap-2 border-b px-3 py-1.5">
         <LayoutDashboard className="h-4 w-4 text-muted-foreground" />

--- a/apps/geolibre-desktop/src/components/panels/DashboardPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/DashboardPanel.tsx
@@ -1,0 +1,346 @@
+import type { DashboardWidget } from "@geolibre/core";
+import { useAppStore } from "@geolibre/core";
+import { Button } from "@geolibre/ui";
+import {
+  ChevronLeft,
+  ChevronRight,
+  LayoutDashboard,
+  Pencil,
+  Plus,
+  Trash2,
+  X,
+} from "lucide-react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
+import { useTranslation } from "react-i18next";
+import { isChartableLayer, useLayerChartData } from "../../hooks/useLayerChartData";
+import {
+  ChartView,
+  computeChart,
+  type ChartSpec,
+} from "./charts/chart-view";
+import { WidgetEditorDialog } from "./WidgetEditorDialog";
+
+const PANEL_RESIZE_START_EVENT = "geolibre:panel-resize-start";
+const PANEL_RESIZE_END_EVENT = "geolibre:panel-resize-end";
+const MIN_DASHBOARD_HEIGHT = 160;
+const MAX_DASHBOARD_HEIGHT = 720;
+const DEFAULT_DASHBOARD_HEIGHT = 360;
+
+/** Turn a stored widget into the render-side {@link ChartSpec}. */
+function widgetToSpec(widget: DashboardWidget): ChartSpec {
+  return {
+    type: widget.type,
+    field: widget.field,
+    xField: widget.xField,
+    yField: widget.yField,
+    bins: widget.bins,
+    category: widget.category,
+    aggregation: widget.aggregation,
+    valueField: widget.valueField,
+  };
+}
+
+/**
+ * The Dashboard panel: a bottom-docked, resizable strip of chart widgets, each
+ * bound to a layer and field(s), in the spirit of CARTO Builder / Foursquare
+ * Studio (issue #401). Widgets are stored in the project, so a dashboard
+ * reopens intact. Rendered only while open. Charts are read-only summaries
+ * here; cross-filtering the map is intentionally out of scope for now.
+ */
+export function DashboardPanel() {
+  const { t } = useTranslation();
+  const widgets = useAppStore((s) => s.widgets);
+  const layers = useAppStore((s) => s.layers);
+  const setDashboardOpen = useAppStore((s) => s.setDashboardOpen);
+  const addWidget = useAppStore((s) => s.addWidget);
+  const updateWidget = useAppStore((s) => s.updateWidget);
+  const removeWidget = useAppStore((s) => s.removeWidget);
+  const moveWidget = useAppStore((s) => s.moveWidget);
+
+  const sectionRef = useRef<HTMLElement>(null);
+  const resizeCleanupRef = useRef<(() => void) | null>(null);
+  const [height, setHeight] = useState(DEFAULT_DASHBOARD_HEIGHT);
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [editing, setEditing] = useState<DashboardWidget | null>(null);
+
+  // Layers that expose chartable attributes, for the editor's layer picker.
+  const chartableLayers = useMemo(
+    () =>
+      layers
+        .filter((layer) => isChartableLayer(layer))
+        .map((layer) => ({ id: layer.id, name: layer.name })),
+    [layers],
+  );
+
+  const startResize = (event: ReactMouseEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const startY = event.clientY;
+    const startHeight = height;
+    let nextHeight = startHeight;
+    let frame: number | null = null;
+    const prevCursor = document.body.style.cursor;
+    const prevSelect = document.body.style.userSelect;
+    document.body.style.cursor = "row-resize";
+    document.body.style.userSelect = "none";
+    window.dispatchEvent(new Event(PANEL_RESIZE_START_EVENT));
+
+    const onMove = (moveEvent: MouseEvent) => {
+      const available = Math.max(MIN_DASHBOARD_HEIGHT, window.innerHeight - 180);
+      const maxHeight = Math.min(MAX_DASHBOARD_HEIGHT, available);
+      nextHeight = Math.min(
+        maxHeight,
+        Math.max(MIN_DASHBOARD_HEIGHT, startHeight + startY - moveEvent.clientY),
+      );
+      if (frame !== null) return;
+      frame = window.requestAnimationFrame(() => {
+        frame = null;
+        if (sectionRef.current) {
+          sectionRef.current.style.height = `${nextHeight}px`;
+        }
+      });
+    };
+
+    const cleanup = () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+      if (frame !== null) window.cancelAnimationFrame(frame);
+      window.dispatchEvent(new Event(PANEL_RESIZE_END_EVENT));
+      document.body.style.cursor = prevCursor;
+      document.body.style.userSelect = prevSelect;
+    };
+    const onUp = () => {
+      cleanup();
+      resizeCleanupRef.current = null;
+      setHeight(nextHeight);
+    };
+
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+    resizeCleanupRef.current = cleanup;
+  };
+
+  // Tear down an in-flight drag if the panel unmounts mid-resize.
+  useEffect(() => () => resizeCleanupRef.current?.(), []);
+
+  const openAdd = () => {
+    setEditing(null);
+    setEditorOpen(true);
+  };
+  const openEdit = (widget: DashboardWidget) => {
+    setEditing(widget);
+    setEditorOpen(true);
+  };
+  const handleSave = (widget: DashboardWidget) => {
+    if (widgets.some((w) => w.id === widget.id)) {
+      const { id: _id, ...patch } = widget;
+      updateWidget(widget.id, patch);
+    } else {
+      addWidget(widget);
+    }
+  };
+
+  return (
+    <section
+      ref={sectionRef}
+      style={{ height }}
+      className="relative flex shrink-0 flex-col border-t bg-card"
+    >
+      <div
+        role="separator"
+        aria-orientation="horizontal"
+        aria-label={t("dashboard.resize")}
+        className="absolute -top-1 left-0 right-0 z-20 h-2 cursor-row-resize select-none border-t border-transparent hover:border-primary"
+        onMouseDown={startResize}
+      />
+      <div className="flex items-center gap-2 border-b px-3 py-1.5">
+        <LayoutDashboard className="h-4 w-4 text-muted-foreground" />
+        <span className="text-sm font-semibold">{t("dashboard.title")}</span>
+        <span className="text-xs text-muted-foreground">
+          {t("dashboard.widgetCount", { count: widgets.length })}
+        </span>
+        <div className="ml-auto flex items-center gap-1">
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 px-2"
+            onClick={openAdd}
+            disabled={chartableLayers.length === 0}
+            title={
+              chartableLayers.length === 0
+                ? t("dashboard.noLayersHint")
+                : t("dashboard.addWidget")
+            }
+          >
+            <Plus className="h-3.5 w-3.5" />
+            <span className="hidden sm:inline">{t("dashboard.addWidget")}</span>
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            aria-label={t("dashboard.close")}
+            title={t("dashboard.close")}
+            onClick={() => setDashboardOpen(false)}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto p-3">
+        {widgets.length === 0 ? (
+          <div className="flex h-full flex-col items-center justify-center gap-1 text-center">
+            <p className="text-sm text-muted-foreground">
+              {chartableLayers.length === 0
+                ? t("dashboard.emptyNoLayers")
+                : t("dashboard.empty")}
+            </p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-3 lg:grid-cols-2 xl:grid-cols-3">
+            {widgets.map((widget, index) => (
+              <WidgetCard
+                key={widget.id}
+                widget={widget}
+                index={index}
+                count={widgets.length}
+                onEdit={() => openEdit(widget)}
+                onRemove={() => removeWidget(widget.id)}
+                onMove={(toIndex) => moveWidget(widget.id, toIndex)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <WidgetEditorDialog
+        open={editorOpen}
+        onOpenChange={setEditorOpen}
+        widget={editing}
+        layers={chartableLayers}
+        onSave={handleSave}
+      />
+    </section>
+  );
+}
+
+function WidgetCard({
+  widget,
+  index,
+  count,
+  onEdit,
+  onRemove,
+  onMove,
+}: {
+  widget: DashboardWidget;
+  index: number;
+  count: number;
+  onEdit: () => void;
+  onRemove: () => void;
+  onMove: (toIndex: number) => void;
+}) {
+  const { t } = useTranslation();
+  const data = useLayerChartData(widget.layerId);
+  const result = useMemo(
+    () => computeChart(data.rows, widgetToSpec(widget)),
+    [data.rows, widget],
+  );
+  const title = widget.title?.trim() || defaultWidgetTitle();
+
+  /** A readable title from the widget's chart type and fields when untitled. */
+  function defaultWidgetTitle(): string {
+    switch (widget.type) {
+      case "histogram":
+        return `${t("dashboard.chartType.histogram")} · ${widget.field ?? ""}`;
+      case "scatter":
+        return `${widget.yField ?? ""} / ${widget.xField ?? ""}`;
+      case "bar": {
+        const agg =
+          widget.aggregation === "sum"
+            ? t("dashboard.aggregate.sum")
+            : widget.aggregation === "mean"
+              ? t("dashboard.aggregate.mean")
+              : t("dashboard.aggregate.count");
+        return `${agg} · ${widget.category ?? ""}`;
+      }
+      case "line":
+        return `${t("dashboard.chartType.line")} · ${widget.field ?? ""}`;
+      case "box":
+        return `${t("dashboard.chartType.box")} · ${widget.field ?? ""}`;
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2 rounded-md border bg-background p-3">
+      <div className="flex items-center gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-medium" title={title}>
+            {title}
+          </div>
+          <div className="truncate text-xs text-muted-foreground" title={data.layerName}>
+            {data.hasData ? data.layerName : t("dashboard.layerMissing")}
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            aria-label={t("dashboard.moveBack")}
+            title={t("dashboard.moveBack")}
+            disabled={index === 0}
+            onClick={() => onMove(index - 1)}
+          >
+            <ChevronLeft className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            aria-label={t("dashboard.moveForward")}
+            title={t("dashboard.moveForward")}
+            disabled={index === count - 1}
+            onClick={() => onMove(index + 1)}
+          >
+            <ChevronRight className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            aria-label={t("dashboard.editWidget")}
+            title={t("dashboard.editWidget")}
+            onClick={onEdit}
+          >
+            <Pencil className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            aria-label={t("dashboard.removeWidget")}
+            title={t("dashboard.removeWidget")}
+            onClick={onRemove}
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      </div>
+
+      {data.hasData ? (
+        <ChartView result={result} />
+      ) : (
+        <p className="py-8 text-center text-xs text-muted-foreground">
+          {t("dashboard.noData")}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/geolibre-desktop/src/components/panels/WidgetEditorDialog.tsx
+++ b/apps/geolibre-desktop/src/components/panels/WidgetEditorDialog.tsx
@@ -1,0 +1,350 @@
+import type { DashboardWidget } from "@geolibre/core";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+  Select,
+} from "@geolibre/ui";
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  categoricalColumns,
+  DEFAULT_HISTOGRAM_BINS,
+  MAX_HISTOGRAM_BINS,
+  MIN_HISTOGRAM_BINS,
+  numericColumns,
+  type BarAggregation,
+  type ChartType,
+} from "../../lib/attribute-charts";
+import { useLayerChartData } from "../../hooks/useLayerChartData";
+
+interface WidgetEditorDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** The widget being edited, or null to create a new one. */
+  widget: DashboardWidget | null;
+  /** Chartable layers to choose from. */
+  layers: { id: string; name: string }[];
+  /** Called with the assembled widget when the user saves. */
+  onSave: (widget: DashboardWidget) => void;
+}
+
+/** Keep a chosen field valid for the active layer: fall back to the first
+ * available option when the saved value is not among them. */
+function pick(value: string, options: string[]): string {
+  return options.includes(value) ? value : (options[0] ?? "");
+}
+
+/**
+ * Add or edit a dashboard chart widget: pick a layer, a chart type, and the
+ * field(s) to plot. The field choices follow the selected layer and the chart
+ * type, mirroring the attribute Charts dialog. A new id is minted on save for a
+ * new widget; editing preserves the existing id.
+ */
+export function WidgetEditorDialog({
+  open,
+  onOpenChange,
+  widget,
+  layers,
+  onSave,
+}: WidgetEditorDialogProps) {
+  const { t } = useTranslation();
+  const [layerId, setLayerId] = useState("");
+  const [type, setType] = useState<ChartType>("histogram");
+  const [field, setField] = useState("");
+  const [xField, setXField] = useState("");
+  const [yField, setYField] = useState("");
+  const [bins, setBins] = useState(DEFAULT_HISTOGRAM_BINS);
+  const [category, setCategory] = useState("");
+  const [aggregation, setAggregation] = useState<BarAggregation>("count");
+  const [valueField, setValueField] = useState("");
+  const [title, setTitle] = useState("");
+
+  // Seed the form when it opens, from the edited widget or sensible defaults.
+  useEffect(() => {
+    if (!open) return;
+    setLayerId(widget?.layerId ?? layers[0]?.id ?? "");
+    setType(widget?.type ?? "histogram");
+    setField(widget?.field ?? "");
+    setXField(widget?.xField ?? "");
+    setYField(widget?.yField ?? "");
+    setBins(widget?.bins ?? DEFAULT_HISTOGRAM_BINS);
+    setCategory(widget?.category ?? "");
+    setAggregation(widget?.aggregation ?? "count");
+    setValueField(widget?.valueField ?? "");
+    setTitle(widget?.title ?? "");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, widget]);
+
+  const data = useLayerChartData(layerId);
+  const numericCols = useMemo(
+    () => numericColumns(data.rows, data.columns),
+    [data],
+  );
+  const categoryCols = useMemo(
+    () => categoricalColumns(data.rows, data.columns),
+    [data],
+  );
+  const hasNumeric = numericCols.length > 0;
+  const hasCategory = categoryCols.length > 0;
+  const hasChartable = hasNumeric || hasCategory;
+
+  // A widget can only be saved when its chart type has the fields it needs in
+  // the chosen layer (bar needs a category; the rest need a numeric field).
+  const canSave =
+    layerId !== "" && (type === "bar" ? hasCategory : hasNumeric);
+
+  const save = () => {
+    if (!canSave) return;
+    const next: DashboardWidget = {
+      id: widget?.id ?? crypto.randomUUID(),
+      layerId,
+      type,
+    };
+    const trimmedTitle = title.trim();
+    if (trimmedTitle) next.title = trimmedTitle;
+    if (type === "histogram" || type === "line" || type === "box") {
+      next.field = pick(field, numericCols);
+    }
+    if (type === "histogram") next.bins = bins;
+    if (type === "scatter") {
+      next.xField = pick(xField, numericCols);
+      next.yField = pick(yField, numericCols);
+    }
+    if (type === "bar") {
+      next.category = pick(category, categoryCols);
+      next.aggregation = aggregation;
+      if (aggregation !== "count") next.valueField = pick(valueField, numericCols);
+    }
+    onSave(next);
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>
+            {widget ? t("dashboard.editor.editTitle") : t("dashboard.editor.addTitle")}
+          </DialogTitle>
+          <DialogDescription>{t("dashboard.editor.description")}</DialogDescription>
+        </DialogHeader>
+
+        {layers.length === 0 ? (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            {t("dashboard.editor.noLayers")}
+          </p>
+        ) : (
+          <div className="grid gap-3 py-1">
+            <div className="grid gap-1.5">
+              <Label htmlFor="widget-layer">{t("dashboard.editor.layer")}</Label>
+              <Select
+                id="widget-layer"
+                value={layerId}
+                onChange={(event) => setLayerId(event.target.value)}
+              >
+                {layers.map((layer) => (
+                  <option key={layer.id} value={layer.id}>
+                    {layer.name}
+                  </option>
+                ))}
+              </Select>
+            </div>
+
+            {!hasChartable ? (
+              <p className="text-sm text-muted-foreground">
+                {t("dashboard.editor.noFields")}
+              </p>
+            ) : (
+              <div className="flex flex-wrap items-end gap-3">
+                <div className="grid gap-1.5">
+                  <Label htmlFor="widget-type">{t("dashboard.editor.chartType")}</Label>
+                  <Select
+                    id="widget-type"
+                    className="w-36"
+                    value={type}
+                    onChange={(event) => setType(event.target.value as ChartType)}
+                  >
+                    <option value="histogram" disabled={!hasNumeric}>
+                      {t("dashboard.chartType.histogram")}
+                    </option>
+                    <option value="scatter" disabled={!hasNumeric}>
+                      {t("dashboard.chartType.scatter")}
+                    </option>
+                    <option value="bar" disabled={!hasCategory}>
+                      {t("dashboard.chartType.bar")}
+                    </option>
+                    <option value="line" disabled={!hasNumeric}>
+                      {t("dashboard.chartType.line")}
+                    </option>
+                    <option value="box" disabled={!hasNumeric}>
+                      {t("dashboard.chartType.box")}
+                    </option>
+                  </Select>
+                </div>
+
+                {(type === "histogram" || type === "line" || type === "box") && (
+                  <FieldSelect
+                    id="widget-field"
+                    label={t("dashboard.editor.field")}
+                    value={pick(field, numericCols)}
+                    options={numericCols}
+                    onChange={setField}
+                  />
+                )}
+
+                {type === "histogram" && (
+                  <div className="grid gap-1.5">
+                    <Label htmlFor="widget-bins">{t("dashboard.editor.bins")}</Label>
+                    <Input
+                      id="widget-bins"
+                      type="number"
+                      className="w-24"
+                      min={MIN_HISTOGRAM_BINS}
+                      max={MAX_HISTOGRAM_BINS}
+                      value={bins === 0 ? "" : bins}
+                      onChange={(event) => {
+                        const raw = event.target.value;
+                        if (raw === "") {
+                          setBins(0);
+                          return;
+                        }
+                        const value = Number(raw);
+                        if (Number.isFinite(value)) {
+                          setBins(
+                            Math.max(
+                              MIN_HISTOGRAM_BINS,
+                              Math.min(MAX_HISTOGRAM_BINS, Math.trunc(value)),
+                            ),
+                          );
+                        }
+                      }}
+                      onBlur={() => {
+                        if (bins < MIN_HISTOGRAM_BINS) setBins(MIN_HISTOGRAM_BINS);
+                      }}
+                    />
+                  </div>
+                )}
+
+                {type === "scatter" && (
+                  <>
+                    <FieldSelect
+                      id="widget-x"
+                      label={t("dashboard.editor.xAxis")}
+                      value={pick(xField, numericCols)}
+                      options={numericCols}
+                      onChange={setXField}
+                    />
+                    <FieldSelect
+                      id="widget-y"
+                      label={t("dashboard.editor.yAxis")}
+                      value={pick(yField, numericCols)}
+                      options={numericCols}
+                      onChange={setYField}
+                    />
+                  </>
+                )}
+
+                {type === "bar" && (
+                  <>
+                    <FieldSelect
+                      id="widget-category"
+                      label={t("dashboard.editor.category")}
+                      value={pick(category, categoryCols)}
+                      options={categoryCols}
+                      onChange={setCategory}
+                    />
+                    <div className="grid gap-1.5">
+                      <Label htmlFor="widget-agg">{t("dashboard.editor.aggregate")}</Label>
+                      <Select
+                        id="widget-agg"
+                        className="w-32"
+                        value={aggregation}
+                        onChange={(event) =>
+                          setAggregation(event.target.value as BarAggregation)
+                        }
+                      >
+                        <option value="count">{t("dashboard.aggregate.count")}</option>
+                        <option value="sum" disabled={!hasNumeric}>
+                          {t("dashboard.aggregate.sum")}
+                        </option>
+                        <option value="mean" disabled={!hasNumeric}>
+                          {t("dashboard.aggregate.mean")}
+                        </option>
+                      </Select>
+                    </div>
+                    {aggregation !== "count" && (
+                      <FieldSelect
+                        id="widget-value"
+                        label={t("dashboard.editor.value")}
+                        value={pick(valueField, numericCols)}
+                        options={numericCols}
+                        onChange={setValueField}
+                      />
+                    )}
+                  </>
+                )}
+              </div>
+            )}
+
+            <div className="grid gap-1.5">
+              <Label htmlFor="widget-title">{t("dashboard.editor.titleLabel")}</Label>
+              <Input
+                id="widget-title"
+                value={title}
+                placeholder={t("dashboard.editor.titlePlaceholder")}
+                onChange={(event) => setTitle(event.target.value)}
+              />
+            </div>
+          </div>
+        )}
+
+        <div className="flex items-center justify-end gap-2">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {t("dashboard.editor.cancel")}
+          </Button>
+          <Button onClick={save} disabled={!canSave}>
+            {t("dashboard.editor.save")}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function FieldSelect({
+  id,
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  options: string[];
+  onChange: (next: string) => void;
+}) {
+  return (
+    <div className="grid gap-1.5">
+      <Label htmlFor={id}>{label}</Label>
+      <Select
+        id={id}
+        className="w-44"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+      >
+        {options.map((col) => (
+          <option key={col} value={col}>
+            {col}
+          </option>
+        ))}
+      </Select>
+    </div>
+  );
+}

--- a/apps/geolibre-desktop/src/components/panels/WidgetEditorDialog.tsx
+++ b/apps/geolibre-desktop/src/components/panels/WidgetEditorDialog.tsx
@@ -98,9 +98,14 @@ export function WidgetEditorDialog({
   const hasChartable = hasNumeric || hasCategory;
 
   // A widget can only be saved when its chart type has the fields it needs in
-  // the chosen layer (bar/pie need a category; the rest need a numeric field).
+  // the chosen layer: bar/pie need a category (and a numeric field too when they
+  // sum/average rather than count); the rest need a numeric field.
   const isCategorical = type === "bar" || type === "pie";
-  const canSave = layerId !== "" && (isCategorical ? hasCategory : hasNumeric);
+  const canSave =
+    layerId !== "" &&
+    (isCategorical
+      ? hasCategory && (aggregation === "count" || hasNumeric)
+      : hasNumeric);
 
   const save = () => {
     if (!canSave) return;
@@ -115,7 +120,11 @@ export function WidgetEditorDialog({
     if (type === "histogram" || type === "line" || type === "box") {
       next.field = pick(field, numericCols);
     }
-    if (type === "histogram") next.bins = bins;
+    // Clicking Save can skip the bins input's onBlur, so guard the cleared/0
+    // sentinel here rather than persisting an invalid bin count.
+    if (type === "histogram") {
+      next.bins = Math.max(MIN_HISTOGRAM_BINS, bins || MIN_HISTOGRAM_BINS);
+    }
     if (type === "scatter") {
       next.xField = pick(xField, numericCols);
       next.yField = pick(yField, numericCols);
@@ -174,7 +183,15 @@ export function WidgetEditorDialog({
                     id="widget-type"
                     className="w-36"
                     value={type}
-                    onChange={(event) => setType(event.target.value as ChartType)}
+                    onChange={(event) => {
+                      const nextType = event.target.value as ChartType;
+                      setType(nextType);
+                      // Pie has no "average"; drop a carried-over mean so the
+                      // select doesn't show a stale value with no matching option.
+                      if (nextType === "pie" && aggregation === "mean") {
+                        setAggregation("count");
+                      }
+                    }}
                   >
                     <option value="histogram" disabled={!hasNumeric}>
                       {t("dashboard.chartType.histogram")}

--- a/apps/geolibre-desktop/src/components/panels/WidgetEditorDialog.tsx
+++ b/apps/geolibre-desktop/src/components/panels/WidgetEditorDialog.tsx
@@ -95,9 +95,9 @@ export function WidgetEditorDialog({
   const hasChartable = hasNumeric || hasCategory;
 
   // A widget can only be saved when its chart type has the fields it needs in
-  // the chosen layer (bar needs a category; the rest need a numeric field).
-  const canSave =
-    layerId !== "" && (type === "bar" ? hasCategory : hasNumeric);
+  // the chosen layer (bar/pie need a category; the rest need a numeric field).
+  const isCategorical = type === "bar" || type === "pie";
+  const canSave = layerId !== "" && (isCategorical ? hasCategory : hasNumeric);
 
   const save = () => {
     if (!canSave) return;
@@ -116,10 +116,12 @@ export function WidgetEditorDialog({
       next.xField = pick(xField, numericCols);
       next.yField = pick(yField, numericCols);
     }
-    if (type === "bar") {
+    if (type === "bar" || type === "pie") {
       next.category = pick(category, categoryCols);
-      next.aggregation = aggregation;
-      if (aggregation !== "count") next.valueField = pick(valueField, numericCols);
+      // A pie shows parts of a whole, so it only counts or sums (no average).
+      const agg = type === "pie" && aggregation === "mean" ? "sum" : aggregation;
+      next.aggregation = agg;
+      if (agg !== "count") next.valueField = pick(valueField, numericCols);
     }
     onSave(next);
     onOpenChange(false);
@@ -184,6 +186,9 @@ export function WidgetEditorDialog({
                     </option>
                     <option value="box" disabled={!hasNumeric}>
                       {t("dashboard.chartType.box")}
+                    </option>
+                    <option value="pie" disabled={!hasCategory}>
+                      {t("dashboard.chartType.pie")}
                     </option>
                   </Select>
                 </div>
@@ -250,7 +255,7 @@ export function WidgetEditorDialog({
                   </>
                 )}
 
-                {type === "bar" && (
+                {(type === "bar" || type === "pie") && (
                   <>
                     <FieldSelect
                       id="widget-category"
@@ -273,9 +278,12 @@ export function WidgetEditorDialog({
                         <option value="sum" disabled={!hasNumeric}>
                           {t("dashboard.aggregate.sum")}
                         </option>
-                        <option value="mean" disabled={!hasNumeric}>
-                          {t("dashboard.aggregate.mean")}
-                        </option>
+                        {/* Averaging parts of a whole is meaningless for a pie. */}
+                        {type !== "pie" && (
+                          <option value="mean" disabled={!hasNumeric}>
+                            {t("dashboard.aggregate.mean")}
+                          </option>
+                        )}
                       </Select>
                     </div>
                     {aggregation !== "count" && (

--- a/apps/geolibre-desktop/src/components/panels/WidgetEditorDialog.tsx
+++ b/apps/geolibre-desktop/src/components/panels/WidgetEditorDialog.tsx
@@ -64,6 +64,8 @@ export function WidgetEditorDialog({
   const [aggregation, setAggregation] = useState<BarAggregation>("count");
   const [valueField, setValueField] = useState("");
   const [title, setTitle] = useState("");
+  // "" means no custom color: fall back to the theme primary / palette.
+  const [color, setColor] = useState("");
 
   // Seed the form when it opens, from the edited widget or sensible defaults.
   useEffect(() => {
@@ -78,6 +80,7 @@ export function WidgetEditorDialog({
     setAggregation(widget?.aggregation ?? "count");
     setValueField(widget?.valueField ?? "");
     setTitle(widget?.title ?? "");
+    setColor(widget?.color ?? "");
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, widget]);
 
@@ -108,6 +111,7 @@ export function WidgetEditorDialog({
     };
     const trimmedTitle = title.trim();
     if (trimmedTitle) next.title = trimmedTitle;
+    if (color) next.color = color;
     if (type === "histogram" || type === "line" || type === "box") {
       next.field = pick(field, numericCols);
     }
@@ -308,6 +312,36 @@ export function WidgetEditorDialog({
                 placeholder={t("dashboard.editor.titlePlaceholder")}
                 onChange={(event) => setTitle(event.target.value)}
               />
+            </div>
+
+            <div className="grid gap-1.5">
+              <Label htmlFor="widget-color">{t("dashboard.editor.color")}</Label>
+              <div className="flex items-center gap-2">
+                <input
+                  id="widget-color"
+                  type="color"
+                  className="h-8 w-12 cursor-pointer rounded border border-input bg-background p-0.5"
+                  // Native color inputs need a concrete value; show a neutral
+                  // swatch while no custom color is set.
+                  value={color || "#3fb1ce"}
+                  onChange={(event) => setColor(event.target.value)}
+                />
+                {color ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-8 px-2 text-xs"
+                    onClick={() => setColor("")}
+                  >
+                    {t("dashboard.editor.colorReset")}
+                  </Button>
+                ) : (
+                  <span className="text-xs text-muted-foreground">
+                    {t("dashboard.editor.colorDefault")}
+                  </span>
+                )}
+              </div>
             </div>
           </div>
         )}

--- a/apps/geolibre-desktop/src/components/panels/WidgetEditorDialog.tsx
+++ b/apps/geolibre-desktop/src/components/panels/WidgetEditorDialog.tsx
@@ -99,13 +99,16 @@ export function WidgetEditorDialog({
 
   // A widget can only be saved when its chart type has the fields it needs in
   // the chosen layer: bar/pie need a category (and a numeric field too when they
-  // sum/average rather than count); the rest need a numeric field.
+  // sum/average rather than count); scatter needs two numeric fields so x and y
+  // aren't forced to the same column; the rest need one numeric field.
   const isCategorical = type === "bar" || type === "pie";
   const canSave =
     layerId !== "" &&
     (isCategorical
       ? hasCategory && (aggregation === "count" || hasNumeric)
-      : hasNumeric);
+      : type === "scatter"
+        ? numericCols.length >= 2
+        : hasNumeric);
 
   const save = () => {
     if (!canSave) return;

--- a/apps/geolibre-desktop/src/components/panels/charts/chart-colors.ts
+++ b/apps/geolibre-desktop/src/components/panels/charts/chart-colors.ts
@@ -1,0 +1,91 @@
+/**
+ * Pure color helpers for charts. Provides the default categorical palette and,
+ * when a widget picks a custom color, a monochromatic ramp derived from it so
+ * bar/pie marks stay distinguishable. Kept React-free so it can be unit-tested.
+ */
+
+/**
+ * Categorical color palette for charts whose marks are distinct categories
+ * (bar, pie) when no custom color is chosen. Fixed hues (not theme CSS vars) so
+ * each category reads as its own color on both light and dark backgrounds, à la
+ * Foursquare/CARTO dashboards.
+ */
+export const CHART_PALETTE = [
+  "#3fb1ce", // teal
+  "#f4a259", // orange
+  "#8b5cf6", // violet
+  "#22c55e", // green
+  "#eab308", // amber
+  "#ef4444", // red
+  "#0ea5e9", // sky
+  "#ec4899", // pink
+];
+
+/** The palette color for the category at `index`, cycling when it overflows. */
+export function paletteColor(index: number): string {
+  return CHART_PALETTE[index % CHART_PALETTE.length];
+}
+
+/** A 3- or 6-digit hex color (with leading `#`), the format we accept and store. */
+const HEX_COLOR = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+
+/** Whether `value` is a hex color string we can use as an SVG fill. */
+export function isHexColor(value: unknown): value is string {
+  return typeof value === "string" && HEX_COLOR.test(value.trim());
+}
+
+/** Parse a #rgb or #rrggbb string into [r, g, b] (0-255), or null when invalid. */
+function parseHex(color: string): [number, number, number] | null {
+  const hex = color.trim().replace(/^#/, "");
+  const full =
+    hex.length === 3
+      ? hex
+          .split("")
+          .map((c) => c + c)
+          .join("")
+      : hex;
+  if (full.length !== 6) return null;
+  const value = Number.parseInt(full, 16);
+  if (!Number.isFinite(value)) return null;
+  return [(value >> 16) & 255, (value >> 8) & 255, value & 255];
+}
+
+function toHex(channel: number): string {
+  return Math.max(0, Math.min(255, Math.round(channel)))
+    .toString(16)
+    .padStart(2, "0");
+}
+
+/**
+ * Build `count` shades of `base`, from the base color toward a lighter tint, so
+ * a single chosen color yields a readable monochromatic scheme across
+ * categories. Returns the base repeated when it can't be parsed.
+ *
+ * @param base A hex color (#rgb or #rrggbb).
+ * @param count How many shades to produce (>= 1).
+ * @returns `count` hex color strings, darkest (the base) first.
+ */
+export function shadeRamp(base: string, count: number): string[] {
+  const n = Math.max(1, count);
+  const rgb = parseHex(base);
+  if (!rgb) return Array.from({ length: n }, () => base);
+  const [r, g, b] = rgb;
+  return Array.from({ length: n }, (_, i) => {
+    // Lighten progressively up to 60% toward white; a lone shade stays the base.
+    const factor = n <= 1 ? 0 : (i / (n - 1)) * 0.6;
+    const mix = (c: number) => c + (255 - c) * factor;
+    return `#${toHex(mix(r))}${toHex(mix(g))}${toHex(mix(b))}`;
+  });
+}
+
+/**
+ * Colors for a categorical chart's `count` marks: a monochromatic ramp of the
+ * chosen `color`, or the multi-color palette when no valid color is given.
+ */
+export function categoryColors(
+  color: string | null | undefined,
+  count: number,
+): string[] {
+  if (isHexColor(color)) return shadeRamp(color, count);
+  return Array.from({ length: count }, (_, i) => paletteColor(i));
+}

--- a/apps/geolibre-desktop/src/components/panels/charts/chart-spec.ts
+++ b/apps/geolibre-desktop/src/components/panels/charts/chart-spec.ts
@@ -1,0 +1,139 @@
+/**
+ * Pure (no-React) chart specification and compute dispatch shared by the
+ * attribute Charts dialog and the Dashboard panel. Turns a {@link ChartSpec}
+ * (chart type plus the field(s) it plots) into a typed {@link ChartResult} by
+ * delegating to the field-level helpers in `attribute-charts`. Kept free of any
+ * rendering so it can be unit-tested in isolation; the SVG drawing lives in
+ * `chart-view`.
+ */
+import {
+  computeBar,
+  computeBox,
+  computeHistogram,
+  computeLine,
+  computeScatter,
+  DEFAULT_HISTOGRAM_BINS,
+  numericValues,
+  type BarAggregation,
+  type BarResult,
+  type BoxResult,
+  type ChartRow,
+  type ChartType,
+  type HistogramResult,
+  type LineResult,
+  type ScatterResult,
+} from "../../../lib/attribute-charts";
+
+/** A chart type plus the field(s)/options it needs. Which keys apply depends on
+ * `type`; unused keys are ignored. This is the render-side shape a dashboard
+ * widget or the Charts dialog builds before computing. */
+export interface ChartSpec {
+  type: ChartType;
+  /** Value field for histogram/line/box. */
+  field?: string;
+  /** X/Y fields for scatter. */
+  xField?: string;
+  yField?: string;
+  /** Histogram bin count. */
+  bins?: number;
+  /** Category field for bar. */
+  category?: string;
+  /** Bar aggregation (default `count`). */
+  aggregation?: BarAggregation;
+  /** Value field a bar's sum/mean reduces. */
+  valueField?: string;
+}
+
+/** The computed, ready-to-draw result for each chart type. `result` is null
+ * when the spec's fields produced nothing to plot (an empty state is shown). */
+export type ChartResult =
+  | { type: "histogram"; result: HistogramResult | null; field: string }
+  | {
+      type: "scatter";
+      result: ScatterResult | null;
+      xField: string;
+      yField: string;
+    }
+  | {
+      type: "bar";
+      result: BarResult | null;
+      aggregation: BarAggregation;
+      category: string;
+    }
+  | { type: "line"; result: LineResult | null; field: string }
+  | { type: "box"; result: BoxResult | null; field: string };
+
+/**
+ * Compute a chart from `rows` and a {@link ChartSpec}. Pure (no React); the
+ * Charts dialog and dashboard widgets both memoize over it. Returns a typed
+ * result whose `result` is null when the chosen fields yield nothing to draw.
+ *
+ * @param rows The attribute rows to chart.
+ * @param spec The chart type and field selections.
+ * @returns A typed result for the chart type, ready for `ChartView`.
+ */
+export function computeChart(rows: ChartRow[], spec: ChartSpec): ChartResult {
+  switch (spec.type) {
+    case "histogram": {
+      const field = spec.field ?? "";
+      return {
+        type: "histogram",
+        field,
+        result: field
+          ? computeHistogram(
+              numericValues(rows, field),
+              spec.bins ?? DEFAULT_HISTOGRAM_BINS,
+            )
+          : null,
+      };
+    }
+    case "scatter": {
+      const xField = spec.xField ?? "";
+      const yField = spec.yField ?? "";
+      return {
+        type: "scatter",
+        xField,
+        yField,
+        result: xField && yField ? computeScatter(rows, xField, yField) : null,
+      };
+    }
+    case "bar": {
+      const category = spec.category ?? "";
+      const aggregation = spec.aggregation ?? "count";
+      return {
+        type: "bar",
+        category,
+        aggregation,
+        result: category
+          ? computeBar(
+              rows,
+              category,
+              aggregation,
+              aggregation === "count" ? null : (spec.valueField ?? ""),
+            )
+          : null,
+      };
+    }
+    case "line": {
+      const field = spec.field ?? "";
+      return {
+        type: "line",
+        field,
+        result: field ? computeLine(rows, field) : null,
+      };
+    }
+    case "box": {
+      const field = spec.field ?? "";
+      return {
+        type: "box",
+        field,
+        result: field ? computeBox(numericValues(rows, field)) : null,
+      };
+    }
+  }
+}
+
+/** Whether a computed chart actually produced something to draw (an `<svg>`). */
+export function chartResultHasData(result: ChartResult): boolean {
+  return result.result !== null;
+}

--- a/apps/geolibre-desktop/src/components/panels/charts/chart-spec.ts
+++ b/apps/geolibre-desktop/src/components/panels/charts/chart-spec.ts
@@ -11,6 +11,7 @@ import {
   computeBox,
   computeHistogram,
   computeLine,
+  computePie,
   computeScatter,
   DEFAULT_HISTOGRAM_BINS,
   numericValues,
@@ -21,6 +22,7 @@ import {
   type ChartType,
   type HistogramResult,
   type LineResult,
+  type PieResult,
   type ScatterResult,
 } from "../../../lib/attribute-charts";
 
@@ -61,7 +63,13 @@ export type ChartResult =
       category: string;
     }
   | { type: "line"; result: LineResult | null; field: string }
-  | { type: "box"; result: BoxResult | null; field: string };
+  | { type: "box"; result: BoxResult | null; field: string }
+  | {
+      type: "pie";
+      result: PieResult | null;
+      category: string;
+      aggregation: BarAggregation;
+    };
 
 /**
  * Compute a chart from `rows` and a {@link ChartSpec}. Pure (no React); the
@@ -128,6 +136,23 @@ export function computeChart(rows: ChartRow[], spec: ChartSpec): ChartResult {
         type: "box",
         field,
         result: field ? computeBox(numericValues(rows, field)) : null,
+      };
+    }
+    case "pie": {
+      const category = spec.category ?? "";
+      const aggregation = spec.aggregation ?? "count";
+      return {
+        type: "pie",
+        category,
+        aggregation,
+        result: category
+          ? computePie(
+              rows,
+              category,
+              aggregation,
+              aggregation === "count" ? null : (spec.valueField ?? ""),
+            )
+          : null,
       };
     }
   }

--- a/apps/geolibre-desktop/src/components/panels/charts/chart-view.tsx
+++ b/apps/geolibre-desktop/src/components/panels/charts/chart-view.tsx
@@ -1,0 +1,512 @@
+/**
+ * Shared chart rendering for the attribute Charts dialog and the Dashboard
+ * panel. A {@link ChartSpec} (chart type plus the field(s) it plots) is turned
+ * into a typed {@link ChartResult} by {@link computeChart}, which {@link
+ * ChartView} draws as a self-scaling inline SVG. Kept dependency-free (no
+ * charting library) and themed via CSS variables so both surfaces look the same.
+ */
+import { type ReactNode } from "react";
+import {
+  formatAxisValue,
+  type BarAggregation,
+  type BarResult,
+  type BoxResult,
+  type HistogramResult,
+  type LineResult,
+  type ScatterResult,
+} from "../../../lib/attribute-charts";
+import { type ChartResult } from "./chart-spec";
+
+export {
+  chartResultHasData,
+  computeChart,
+  type ChartResult,
+  type ChartSpec,
+} from "./chart-spec";
+
+/** Render a computed {@link ChartResult} as an inline SVG with a caption. */
+export function ChartView({ result }: { result: ChartResult }) {
+  switch (result.type) {
+    case "histogram":
+      return <HistogramChart result={result.result} field={result.field} />;
+    case "scatter":
+      return (
+        <ScatterChart
+          result={result.result}
+          xField={result.xField}
+          yField={result.yField}
+        />
+      );
+    case "bar":
+      return (
+        <BarChart
+          result={result.result}
+          aggregation={result.aggregation}
+          category={result.category}
+        />
+      );
+    case "line":
+      return <LineChart result={result.result} field={result.field} />;
+    case "box":
+      return <BoxChart result={result.result} field={result.field} />;
+  }
+}
+
+// SVG geometry. The chart scales to its container via viewBox/width=100%.
+export const CHART_W = 560;
+export const CHART_H = 300;
+const MARGIN = { top: 16, right: 16, bottom: 52, left: 52 };
+const INNER_W = CHART_W - MARGIN.left - MARGIN.right;
+const INNER_H = CHART_H - MARGIN.top - MARGIN.bottom;
+
+const AXIS = "hsl(var(--border))";
+const TICK = "hsl(var(--muted-foreground))";
+const SERIES = "hsl(var(--primary))";
+
+/** Map a value within [min, max] to a 0..1 fraction, centering a flat range. */
+function fraction(value: number, min: number, max: number): number {
+  if (max === min) return 0.5;
+  return (value - min) / (max - min);
+}
+
+function truncateLabel(label: string, max = 14): string {
+  return label.length > max ? `${label.slice(0, max - 1)}…` : label;
+}
+
+function ChartFrame({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <svg
+      viewBox={`0 0 ${CHART_W} ${CHART_H}`}
+      width="100%"
+      role="img"
+      aria-label={label}
+      className="h-auto w-full"
+      preserveAspectRatio="xMidYMid meet"
+    >
+      <line
+        x1={MARGIN.left}
+        y1={MARGIN.top}
+        x2={MARGIN.left}
+        y2={MARGIN.top + INNER_H}
+        stroke={AXIS}
+      />
+      <line
+        x1={MARGIN.left}
+        y1={MARGIN.top + INNER_H}
+        x2={MARGIN.left + INNER_W}
+        y2={MARGIN.top + INNER_H}
+        stroke={AXIS}
+      />
+      {children}
+    </svg>
+  );
+}
+
+function tickText(
+  x: number,
+  y: number,
+  text: string,
+  anchor: "start" | "middle" | "end",
+  baseline: "middle" | "auto" = "auto",
+) {
+  return (
+    <text
+      x={x}
+      y={y}
+      textAnchor={anchor}
+      dominantBaseline={baseline}
+      fontSize={10}
+      fill={TICK}
+    >
+      {text}
+    </text>
+  );
+}
+
+function axisTitle(text: string) {
+  return (
+    <text
+      x={MARGIN.left + INNER_W / 2}
+      y={CHART_H - 4}
+      textAnchor="middle"
+      fontSize={11}
+      fill={TICK}
+    >
+      {text}
+    </text>
+  );
+}
+
+function yAxisTitle(text: string) {
+  const cy = MARGIN.top + INNER_H / 2;
+  return (
+    <text
+      x={12}
+      y={cy}
+      textAnchor="middle"
+      fontSize={11}
+      fill={TICK}
+      transform={`rotate(-90 12 ${cy})`}
+    >
+      {text}
+    </text>
+  );
+}
+
+function EmptyChart({ message }: { message: string }) {
+  return (
+    <p className="py-10 text-center text-sm text-muted-foreground">{message}</p>
+  );
+}
+
+function Caption({ children }: { children: ReactNode }) {
+  return (
+    <p className="mt-1 text-center text-xs text-muted-foreground">{children}</p>
+  );
+}
+
+function HistogramChart({
+  result,
+  field,
+}: {
+  result: HistogramResult | null;
+  field: string;
+}) {
+  if (!result) return <EmptyChart message="No numeric values to plot." />;
+
+  const { bins, maxCount, min, max, total } = result;
+  const slot = INNER_W / bins.length;
+  const gap = Math.min(4, slot * 0.15);
+
+  return (
+    <>
+      <ChartFrame label={`Histogram of ${field}`}>
+        {tickText(MARGIN.left - 6, MARGIN.top + INNER_H, "0", "end", "middle")}
+        {tickText(MARGIN.left - 6, MARGIN.top, String(maxCount), "end", "middle")}
+        {bins.map((bin, index) => {
+          const height = maxCount === 0 ? 0 : (bin.count / maxCount) * INNER_H;
+          return (
+            <rect
+              key={index}
+              x={MARGIN.left + index * slot + gap / 2}
+              y={MARGIN.top + INNER_H - height}
+              width={Math.max(1, slot - gap)}
+              height={height}
+              fill={SERIES}
+              opacity={0.85}
+            >
+              <title>{`[${formatAxisValue(bin.x0)}, ${formatAxisValue(bin.x1)}${
+                index === bins.length - 1 ? "]" : ")"
+              }: ${bin.count}`}</title>
+            </rect>
+          );
+        })}
+        {/* A collapsed (min === max) histogram spans the full width, so show a
+            single centered label instead of identical min/max labels. */}
+        {min === max ? (
+          tickText(MARGIN.left + INNER_W / 2, MARGIN.top + INNER_H + 14, formatAxisValue(min), "middle")
+        ) : (
+          <>
+            {tickText(MARGIN.left, MARGIN.top + INNER_H + 14, formatAxisValue(min), "start")}
+            {tickText(MARGIN.left + INNER_W, MARGIN.top + INNER_H + 14, formatAxisValue(max), "end")}
+          </>
+        )}
+        {axisTitle(field)}
+      </ChartFrame>
+      <Caption>
+        {total.toLocaleString()} value{total === 1 ? "" : "s"} · count on y
+      </Caption>
+    </>
+  );
+}
+
+function ScatterChart({
+  result,
+  xField,
+  yField,
+}: {
+  result: ScatterResult | null;
+  xField: string;
+  yField: string;
+}) {
+  if (!result) {
+    return <EmptyChart message="No rows have both fields set to a number." />;
+  }
+
+  const { points, total, xMin, xMax, yMin, yMax } = result;
+  const sampled = total > points.length;
+
+  return (
+    <>
+      <ChartFrame label={`Scatter plot of ${yField} versus ${xField}`}>
+        {/* Single centered tick when an axis is flat (all values identical),
+            mirroring the histogram, rather than the same value at both ends. */}
+        {yMin === yMax ? (
+          tickText(MARGIN.left - 6, MARGIN.top + INNER_H / 2, formatAxisValue(yMin), "end", "middle")
+        ) : (
+          <>
+            {tickText(MARGIN.left - 6, MARGIN.top, formatAxisValue(yMax), "end", "middle")}
+            {tickText(MARGIN.left - 6, MARGIN.top + INNER_H, formatAxisValue(yMin), "end", "middle")}
+          </>
+        )}
+        {points.map((point, index) => {
+          const cx = MARGIN.left + fraction(point.x, xMin, xMax) * INNER_W;
+          const cy =
+            MARGIN.top + INNER_H - fraction(point.y, yMin, yMax) * INNER_H;
+          return (
+            <circle key={index} cx={cx} cy={cy} r={3} fill={SERIES} opacity={0.6}>
+              <title>{`${xField}: ${formatAxisValue(point.x)}, ${yField}: ${formatAxisValue(point.y)}`}</title>
+            </circle>
+          );
+        })}
+        {xMin === xMax ? (
+          tickText(MARGIN.left + INNER_W / 2, MARGIN.top + INNER_H + 14, formatAxisValue(xMin), "middle")
+        ) : (
+          <>
+            {tickText(MARGIN.left, MARGIN.top + INNER_H + 14, formatAxisValue(xMin), "start")}
+            {tickText(MARGIN.left + INNER_W, MARGIN.top + INNER_H + 14, formatAxisValue(xMax), "end")}
+          </>
+        )}
+        {axisTitle(xField)}
+        {yAxisTitle(yField)}
+      </ChartFrame>
+      <Caption>
+        {total.toLocaleString()} point{total === 1 ? "" : "s"} · {yField} vs{" "}
+        {xField}
+        {sampled ? ` · showing ${points.length.toLocaleString()} sampled` : ""}
+      </Caption>
+    </>
+  );
+}
+
+function BarChart({
+  result,
+  aggregation,
+  category,
+}: {
+  result: BarResult | null;
+  aggregation: BarAggregation;
+  category: string;
+}) {
+  if (!result) return <EmptyChart message="No rows to group." />;
+
+  const { bars, maxValue, minValue, truncated } = result;
+  const domainMin = Math.min(0, minValue);
+  // Keep 0 as the top of the scale when every bar is <= 0 (possible for
+  // sum/mean); only fall back to 1 when the domain would otherwise be zero-width
+  // (all bars exactly 0). `Math.max(0, maxValue) || 1` wrongly made an
+  // all-negative domain top out at 1.
+  const domainMax = maxValue > 0 ? maxValue : minValue < 0 ? 0 : 1;
+  const slot = INNER_W / bars.length;
+  const gap = Math.min(6, slot * 0.2);
+  const scaleY = (value: number) =>
+    MARGIN.top + INNER_H - fraction(value, domainMin, domainMax) * INNER_H;
+  const baselineY = scaleY(0);
+
+  return (
+    <>
+      <ChartFrame label={`Bar chart of ${aggregation} by ${category}`}>
+        {/* Top tick only when the domain extends above 0; when all bars are
+            <= 0 the domain tops at 0 and the baseline tick already labels it. */}
+        {domainMax > 0
+          ? tickText(MARGIN.left - 6, MARGIN.top, formatAxisValue(domainMax), "end", "middle")
+          : null}
+        {tickText(MARGIN.left - 6, baselineY, "0", "end", "middle")}
+        {/* Lower-bound tick when bars go negative (sum/mean of negative values). */}
+        {minValue < 0
+          ? tickText(MARGIN.left - 6, MARGIN.top + INNER_H, formatAxisValue(domainMin), "end", "middle")
+          : null}
+        {bars.map((datum, index) => {
+          const top = Math.min(baselineY, scaleY(datum.value));
+          const height = Math.abs(scaleY(datum.value) - baselineY);
+          const cx = MARGIN.left + index * slot + slot / 2;
+          return (
+            <g key={datum.label}>
+              <rect
+                x={MARGIN.left + index * slot + gap / 2}
+                y={top}
+                width={Math.max(1, slot - gap)}
+                height={Math.max(0, height)}
+                fill={SERIES}
+                opacity={0.85}
+              >
+                <title>{`${datum.label}: ${formatAxisValue(datum.value)} (${datum.count} row${datum.count === 1 ? "" : "s"})`}</title>
+              </rect>
+              <text
+                x={cx}
+                y={MARGIN.top + INNER_H + 12}
+                textAnchor="end"
+                fontSize={9}
+                fill={TICK}
+                transform={`rotate(-40 ${cx} ${MARGIN.top + INNER_H + 12})`}
+              >
+                {truncateLabel(datum.label)}
+              </text>
+            </g>
+          );
+        })}
+      </ChartFrame>
+      <Caption>
+        {aggregation === "count"
+          ? "row count"
+          : aggregation === "sum"
+            ? "sum on y"
+            : "average on y"}
+        {truncated > 0 ? ` · top ${bars.length} (${truncated} more hidden)` : ""}
+      </Caption>
+    </>
+  );
+}
+
+function LineChart({
+  result,
+  field,
+}: {
+  result: LineResult | null;
+  field: string;
+}) {
+  if (!result) return <EmptyChart message="No numeric values to plot." />;
+
+  const { points, min, max, length } = result;
+  const scaleX = (index: number) =>
+    MARGIN.left + (length > 1 ? index / (length - 1) : 0.5) * INNER_W;
+  const scaleY = (value: number) =>
+    MARGIN.top + INNER_H - fraction(value, min, max) * INNER_H;
+  const path = points
+    .map((p, i) => {
+      // Break the line (start a new subpath) when rows are non-consecutive, so
+      // a gap from skipped (non-numeric) rows shows as a gap rather than a
+      // straight segment across it.
+      const command =
+        i === 0 || p.index !== points[i - 1].index + 1 ? "M" : "L";
+      return `${command}${scaleX(p.index)} ${scaleY(p.value)}`;
+    })
+    .join(" ");
+
+  return (
+    <>
+      <ChartFrame label={`Line chart of ${field} by feature order`}>
+        {tickText(MARGIN.left - 6, MARGIN.top, formatAxisValue(max), "end", "middle")}
+        {tickText(MARGIN.left - 6, MARGIN.top + INNER_H, formatAxisValue(min), "end", "middle")}
+        <path d={path} fill="none" stroke={SERIES} strokeWidth={1.5} />
+        {points.length <= 80
+          ? points.map((p) => (
+              <circle
+                key={p.index}
+                cx={scaleX(p.index)}
+                cy={scaleY(p.value)}
+                r={2}
+                fill={SERIES}
+              >
+                <title>{`#${p.index}: ${formatAxisValue(p.value)}`}</title>
+              </circle>
+            ))
+          : null}
+        {/* A single-feature layer has only index 0; show one centered label
+            instead of "0" at both ends. */}
+        {length <= 1 ? (
+          tickText(MARGIN.left + INNER_W / 2, MARGIN.top + INNER_H + 14, "0", "middle")
+        ) : (
+          <>
+            {tickText(MARGIN.left, MARGIN.top + INNER_H + 14, "0", "start")}
+            {tickText(MARGIN.left + INNER_W, MARGIN.top + INNER_H + 14, String(length - 1), "end")}
+          </>
+        )}
+        {axisTitle("feature order")}
+      </ChartFrame>
+      <Caption>
+        {points.length.toLocaleString()} value{points.length === 1 ? "" : "s"} ·{" "}
+        {field} by feature order
+      </Caption>
+    </>
+  );
+}
+
+function BoxChart({
+  result,
+  field,
+}: {
+  result: BoxResult | null;
+  field: string;
+}) {
+  if (!result) return <EmptyChart message="No numeric values to plot." />;
+
+  const { min, q1, median, q3, max, count } = result;
+  const centerX = MARGIN.left + INNER_W / 2;
+  const boxWidth = 96;
+  const scaleY = (value: number) =>
+    MARGIN.top + INNER_H - fraction(value, min, max) * INNER_H;
+
+  const stats: [string, number][] = [
+    ["max", max],
+    ["Q3", q3],
+    ["median", median],
+    ["Q1", q1],
+    ["min", min],
+  ];
+
+  return (
+    <>
+      <ChartFrame label={`Box plot of ${field}`}>
+        {/* whisker */}
+        <line x1={centerX} y1={scaleY(min)} x2={centerX} y2={scaleY(max)} stroke={AXIS} />
+        <line x1={centerX - 20} y1={scaleY(max)} x2={centerX + 20} y2={scaleY(max)} stroke={AXIS} />
+        <line x1={centerX - 20} y1={scaleY(min)} x2={centerX + 20} y2={scaleY(min)} stroke={AXIS} />
+        {/* box */}
+        <rect
+          x={centerX - boxWidth / 2}
+          y={scaleY(q3)}
+          width={boxWidth}
+          height={Math.max(1, scaleY(q1) - scaleY(q3))}
+          fill={SERIES}
+          opacity={0.25}
+          stroke={SERIES}
+        />
+        <line
+          x1={centerX - boxWidth / 2}
+          y1={scaleY(median)}
+          x2={centerX + boxWidth / 2}
+          y2={scaleY(median)}
+          stroke={SERIES}
+          strokeWidth={2}
+        />
+        {/* When every value is identical the five stats share one y position;
+            show a single label instead of five overlapping ones. */}
+        {min === max ? (
+          tickText(
+            centerX + boxWidth / 2 + 8,
+            scaleY(median),
+            `all = ${formatAxisValue(median)}`,
+            "start",
+            "middle",
+          )
+        ) : (
+          stats.map(([label, value]) => (
+            <text
+              key={label}
+              x={centerX + boxWidth / 2 + 8}
+              y={scaleY(value)}
+              textAnchor="start"
+              dominantBaseline="middle"
+              fontSize={10}
+              fill={TICK}
+            >
+              {`${label} ${formatAxisValue(value)}`}
+            </text>
+          ))
+        )}
+        {axisTitle(field)}
+      </ChartFrame>
+      <Caption>
+        {count.toLocaleString()} value{count === 1 ? "" : "s"} · five-number
+        summary
+      </Caption>
+    </>
+  );
+}

--- a/apps/geolibre-desktop/src/components/panels/charts/chart-view.tsx
+++ b/apps/geolibre-desktop/src/components/panels/charts/chart-view.tsx
@@ -17,28 +17,7 @@ import {
   type ScatterResult,
 } from "../../../lib/attribute-charts";
 import { type ChartResult } from "./chart-spec";
-
-/**
- * Categorical color palette for charts whose marks are distinct categories
- * (bar, pie). Fixed hues (not theme CSS vars) so each category reads as its own
- * color on both light and dark backgrounds, à la Foursquare/CARTO dashboards.
- * Single-series charts (histogram/line/scatter/box) keep the theme primary.
- */
-export const CHART_PALETTE = [
-  "#3fb1ce", // teal
-  "#f4a259", // orange
-  "#8b5cf6", // violet
-  "#22c55e", // green
-  "#eab308", // amber
-  "#ef4444", // red
-  "#0ea5e9", // sky
-  "#ec4899", // pink
-];
-
-/** The palette color for the category at `index`, cycling when it overflows. */
-function paletteColor(index: number): string {
-  return CHART_PALETTE[index % CHART_PALETTE.length];
-}
+import { categoryColors, isHexColor } from "./chart-colors";
 
 export {
   chartResultHasData,
@@ -47,17 +26,35 @@ export {
   type ChartSpec,
 } from "./chart-spec";
 
-/** Render a computed {@link ChartResult} as an inline SVG with a caption. */
-export function ChartView({ result }: { result: ChartResult }) {
+/**
+ * Render a computed {@link ChartResult} as an inline SVG with a caption.
+ * `color` (a hex string) customizes the marks: it is the series color for
+ * single-series charts (histogram/line/scatter/box) and the base of a
+ * monochromatic ramp for categorical charts (bar/pie). When unset, single-series
+ * charts use the theme primary and categorical charts use the multi-color
+ * palette.
+ */
+export function ChartView({
+  result,
+  color,
+}: {
+  result: ChartResult;
+  color?: string;
+}) {
+  // Effective single-series color: the chosen hex, else the theme primary.
+  const series = isHexColor(color) ? color : SERIES;
   switch (result.type) {
     case "histogram":
-      return <HistogramChart result={result.result} field={result.field} />;
+      return (
+        <HistogramChart result={result.result} field={result.field} color={series} />
+      );
     case "scatter":
       return (
         <ScatterChart
           result={result.result}
           xField={result.xField}
           yField={result.yField}
+          color={series}
         />
       );
     case "bar":
@@ -66,18 +63,22 @@ export function ChartView({ result }: { result: ChartResult }) {
           result={result.result}
           aggregation={result.aggregation}
           category={result.category}
+          color={color}
         />
       );
     case "line":
-      return <LineChart result={result.result} field={result.field} />;
+      return (
+        <LineChart result={result.result} field={result.field} color={series} />
+      );
     case "box":
-      return <BoxChart result={result.result} field={result.field} />;
+      return <BoxChart result={result.result} field={result.field} color={series} />;
     case "pie":
       return (
         <PieChart
           result={result.result}
           aggregation={result.aggregation}
           category={result.category}
+          color={color}
         />
       );
   }
@@ -205,9 +206,11 @@ function Caption({ children }: { children: ReactNode }) {
 function HistogramChart({
   result,
   field,
+  color,
 }: {
   result: HistogramResult | null;
   field: string;
+  color: string;
 }) {
   if (!result) return <EmptyChart message="No numeric values to plot." />;
 
@@ -229,7 +232,7 @@ function HistogramChart({
               y={MARGIN.top + INNER_H - height}
               width={Math.max(1, slot - gap)}
               height={height}
-              fill={SERIES}
+              fill={color}
               opacity={0.85}
             >
               <title>{`[${formatAxisValue(bin.x0)}, ${formatAxisValue(bin.x1)}${
@@ -261,10 +264,12 @@ function ScatterChart({
   result,
   xField,
   yField,
+  color,
 }: {
   result: ScatterResult | null;
   xField: string;
   yField: string;
+  color: string;
 }) {
   if (!result) {
     return <EmptyChart message="No rows have both fields set to a number." />;
@@ -291,7 +296,7 @@ function ScatterChart({
           const cy =
             MARGIN.top + INNER_H - fraction(point.y, yMin, yMax) * INNER_H;
           return (
-            <circle key={index} cx={cx} cy={cy} r={3} fill={SERIES} opacity={0.6}>
+            <circle key={index} cx={cx} cy={cy} r={3} fill={color} opacity={0.6}>
               <title>{`${xField}: ${formatAxisValue(point.x)}, ${yField}: ${formatAxisValue(point.y)}`}</title>
             </circle>
           );
@@ -320,14 +325,17 @@ function BarChart({
   result,
   aggregation,
   category,
+  color,
 }: {
   result: BarResult | null;
   aggregation: BarAggregation;
   category: string;
+  color?: string;
 }) {
   if (!result) return <EmptyChart message="No rows to group." />;
 
   const { bars, maxValue, minValue, truncated } = result;
+  const colors = categoryColors(color, bars.length);
   const domainMin = Math.min(0, minValue);
   // Keep 0 as the top of the scale when every bar is <= 0 (possible for
   // sum/mean); only fall back to 1 when the domain would otherwise be zero-width
@@ -364,7 +372,7 @@ function BarChart({
                 y={top}
                 width={Math.max(1, slot - gap)}
                 height={Math.max(0, height)}
-                fill={paletteColor(index)}
+                fill={colors[index]}
                 opacity={0.9}
               >
                 <title>{`${datum.label}: ${formatAxisValue(datum.value)} (${datum.count} row${datum.count === 1 ? "" : "s"})`}</title>
@@ -398,9 +406,11 @@ function BarChart({
 function LineChart({
   result,
   field,
+  color,
 }: {
   result: LineResult | null;
   field: string;
+  color: string;
 }) {
   if (!result) return <EmptyChart message="No numeric values to plot." />;
 
@@ -425,7 +435,7 @@ function LineChart({
       <ChartFrame label={`Line chart of ${field} by feature order`}>
         {tickText(MARGIN.left - 6, MARGIN.top, formatAxisValue(max), "end", "middle")}
         {tickText(MARGIN.left - 6, MARGIN.top + INNER_H, formatAxisValue(min), "end", "middle")}
-        <path d={path} fill="none" stroke={SERIES} strokeWidth={1.5} />
+        <path d={path} fill="none" stroke={color} strokeWidth={1.5} />
         {points.length <= 80
           ? points.map((p) => (
               <circle
@@ -433,7 +443,7 @@ function LineChart({
                 cx={scaleX(p.index)}
                 cy={scaleY(p.value)}
                 r={2}
-                fill={SERIES}
+                fill={color}
               >
                 <title>{`#${p.index}: ${formatAxisValue(p.value)}`}</title>
               </circle>
@@ -462,9 +472,11 @@ function LineChart({
 function BoxChart({
   result,
   field,
+  color,
 }: {
   result: BoxResult | null;
   field: string;
+  color: string;
 }) {
   if (!result) return <EmptyChart message="No numeric values to plot." />;
 
@@ -495,16 +507,16 @@ function BoxChart({
           y={scaleY(q3)}
           width={boxWidth}
           height={Math.max(1, scaleY(q1) - scaleY(q3))}
-          fill={SERIES}
+          fill={color}
           opacity={0.25}
-          stroke={SERIES}
+          stroke={color}
         />
         <line
           x1={centerX - boxWidth / 2}
           y1={scaleY(median)}
           x2={centerX + boxWidth / 2}
           y2={scaleY(median)}
-          stroke={SERIES}
+          stroke={color}
           strokeWidth={2}
         />
         {/* When every value is identical the five stats share one y position;
@@ -546,14 +558,17 @@ function PieChart({
   result,
   aggregation,
   category,
+  color,
 }: {
   result: PieResult | null;
   aggregation: BarAggregation;
   category: string;
+  color?: string;
 }) {
   if (!result) return <EmptyChart message="No positive values to chart." />;
 
   const { slices, total } = result;
+  const colors = categoryColors(color, slices.length);
   const radius = INNER_H / 2 - 6;
   const cx = MARGIN.left + radius;
   const cy = MARGIN.top + INNER_H / 2;
@@ -578,7 +593,7 @@ function PieChart({
       slices.length === 1
         ? `M ${cx - radius} ${cy} A ${radius} ${radius} 0 1 1 ${cx + radius} ${cy} A ${radius} ${radius} 0 1 1 ${cx - radius} ${cy} Z`
         : `M ${cx} ${cy} L ${x0} ${y0} A ${radius} ${radius} 0 ${largeArc} 1 ${x1} ${y1} Z`;
-    return { d, color: paletteColor(index), slice, fraction };
+    return { d, color: colors[index], slice, fraction };
   });
 
   return (

--- a/apps/geolibre-desktop/src/components/panels/charts/chart-view.tsx
+++ b/apps/geolibre-desktop/src/components/panels/charts/chart-view.tsx
@@ -6,6 +6,7 @@
  * charting library) and themed via CSS variables so both surfaces look the same.
  */
 import { type ReactNode } from "react";
+import { useTranslation } from "react-i18next";
 import {
   formatAxisValue,
   type BarAggregation,
@@ -212,7 +213,9 @@ function HistogramChart({
   field: string;
   color: string;
 }) {
-  if (!result) return <EmptyChart message="No numeric values to plot." />;
+  const { t } = useTranslation();
+  if (!result)
+    return <EmptyChart message={t("dashboard.chart.emptyNumeric")} />;
 
   const { bins, maxCount, min, max, total } = result;
   const slot = INNER_W / bins.length;
@@ -271,8 +274,9 @@ function ScatterChart({
   yField: string;
   color: string;
 }) {
+  const { t } = useTranslation();
   if (!result) {
-    return <EmptyChart message="No rows have both fields set to a number." />;
+    return <EmptyChart message={t("dashboard.chart.emptyScatter")} />;
   }
 
   const { points, total, xMin, xMax, yMin, yMax } = result;
@@ -332,7 +336,8 @@ function BarChart({
   category: string;
   color?: string;
 }) {
-  if (!result) return <EmptyChart message="No rows to group." />;
+  const { t } = useTranslation();
+  if (!result) return <EmptyChart message={t("dashboard.chart.emptyBar")} />;
 
   const { bars, maxValue, minValue, truncated } = result;
   const colors = categoryColors(color, bars.length);
@@ -412,7 +417,9 @@ function LineChart({
   field: string;
   color: string;
 }) {
-  if (!result) return <EmptyChart message="No numeric values to plot." />;
+  const { t } = useTranslation();
+  if (!result)
+    return <EmptyChart message={t("dashboard.chart.emptyNumeric")} />;
 
   const { points, min, max, length } = result;
   const scaleX = (index: number) =>
@@ -478,7 +485,9 @@ function BoxChart({
   field: string;
   color: string;
 }) {
-  if (!result) return <EmptyChart message="No numeric values to plot." />;
+  const { t } = useTranslation();
+  if (!result)
+    return <EmptyChart message={t("dashboard.chart.emptyNumeric")} />;
 
   const { min, q1, median, q3, max, count } = result;
   const centerX = MARGIN.left + INNER_W / 2;
@@ -565,7 +574,8 @@ function PieChart({
   category: string;
   color?: string;
 }) {
-  if (!result) return <EmptyChart message="No positive values to chart." />;
+  const { t } = useTranslation();
+  if (!result) return <EmptyChart message={t("dashboard.chart.emptyPie")} />;
 
   const { slices, total } = result;
   const colors = categoryColors(color, slices.length);
@@ -633,8 +643,12 @@ function PieChart({
         })}
       </svg>
       <Caption>
-        {aggregation === "count" ? "row count" : "sum"} · {slices.length}{" "}
-        {slices.length === 1 ? "category" : "categories"}
+        {t(
+          aggregation === "count"
+            ? "dashboard.chart.pieCaptionCount"
+            : "dashboard.chart.pieCaptionSum",
+          { count: slices.length },
+        )}
       </Caption>
     </>
   );

--- a/apps/geolibre-desktop/src/components/panels/charts/chart-view.tsx
+++ b/apps/geolibre-desktop/src/components/panels/charts/chart-view.tsx
@@ -13,9 +13,32 @@ import {
   type BoxResult,
   type HistogramResult,
   type LineResult,
+  type PieResult,
   type ScatterResult,
 } from "../../../lib/attribute-charts";
 import { type ChartResult } from "./chart-spec";
+
+/**
+ * Categorical color palette for charts whose marks are distinct categories
+ * (bar, pie). Fixed hues (not theme CSS vars) so each category reads as its own
+ * color on both light and dark backgrounds, à la Foursquare/CARTO dashboards.
+ * Single-series charts (histogram/line/scatter/box) keep the theme primary.
+ */
+export const CHART_PALETTE = [
+  "#3fb1ce", // teal
+  "#f4a259", // orange
+  "#8b5cf6", // violet
+  "#22c55e", // green
+  "#eab308", // amber
+  "#ef4444", // red
+  "#0ea5e9", // sky
+  "#ec4899", // pink
+];
+
+/** The palette color for the category at `index`, cycling when it overflows. */
+function paletteColor(index: number): string {
+  return CHART_PALETTE[index % CHART_PALETTE.length];
+}
 
 export {
   chartResultHasData,
@@ -49,6 +72,14 @@ export function ChartView({ result }: { result: ChartResult }) {
       return <LineChart result={result.result} field={result.field} />;
     case "box":
       return <BoxChart result={result.result} field={result.field} />;
+    case "pie":
+      return (
+        <PieChart
+          result={result.result}
+          aggregation={result.aggregation}
+          category={result.category}
+        />
+      );
   }
 }
 
@@ -333,8 +364,8 @@ function BarChart({
                 y={top}
                 width={Math.max(1, slot - gap)}
                 height={Math.max(0, height)}
-                fill={SERIES}
-                opacity={0.85}
+                fill={paletteColor(index)}
+                opacity={0.9}
               >
                 <title>{`${datum.label}: ${formatAxisValue(datum.value)} (${datum.count} row${datum.count === 1 ? "" : "s"})`}</title>
               </rect>
@@ -506,6 +537,88 @@ function BoxChart({
       <Caption>
         {count.toLocaleString()} value{count === 1 ? "" : "s"} · five-number
         summary
+      </Caption>
+    </>
+  );
+}
+
+function PieChart({
+  result,
+  aggregation,
+  category,
+}: {
+  result: PieResult | null;
+  aggregation: BarAggregation;
+  category: string;
+}) {
+  if (!result) return <EmptyChart message="No positive values to chart." />;
+
+  const { slices, total } = result;
+  const radius = INNER_H / 2 - 6;
+  const cx = MARGIN.left + radius;
+  const cy = MARGIN.top + INNER_H / 2;
+  const legendX = cx + radius + 24;
+  const legendStep = Math.min(22, INNER_H / Math.max(slices.length, 1));
+
+  // Accumulate slice angles from the top (12 o'clock), clockwise.
+  let angle = -Math.PI / 2;
+  const arcs = slices.map((slice, index) => {
+    const fraction = slice.value / total;
+    const start = angle;
+    const end = angle + fraction * Math.PI * 2;
+    angle = end;
+    const x0 = cx + radius * Math.cos(start);
+    const y0 = cy + radius * Math.sin(start);
+    const x1 = cx + radius * Math.cos(end);
+    const y1 = cy + radius * Math.sin(end);
+    const largeArc = end - start > Math.PI ? 1 : 0;
+    // A lone slice is a full circle, which a single arc cannot express; draw it
+    // as two half-circle arcs instead.
+    const d =
+      slices.length === 1
+        ? `M ${cx - radius} ${cy} A ${radius} ${radius} 0 1 1 ${cx + radius} ${cy} A ${radius} ${radius} 0 1 1 ${cx - radius} ${cy} Z`
+        : `M ${cx} ${cy} L ${x0} ${y0} A ${radius} ${radius} 0 ${largeArc} 1 ${x1} ${y1} Z`;
+    return { d, color: paletteColor(index), slice, fraction };
+  });
+
+  return (
+    <>
+      <svg
+        viewBox={`0 0 ${CHART_W} ${CHART_H}`}
+        width="100%"
+        role="img"
+        aria-label={`Pie chart of ${aggregation} by ${category}`}
+        className="h-auto w-full"
+        preserveAspectRatio="xMidYMid meet"
+      >
+        {arcs.map(({ d, color, slice }) => (
+          <path key={slice.label} d={d} fill={color} stroke="hsl(var(--background))" strokeWidth={1}>
+            <title>{`${slice.label}: ${formatAxisValue(slice.value)} (${Math.round(
+              (slice.value / total) * 100,
+            )}%)`}</title>
+          </path>
+        ))}
+        {arcs.map(({ color, slice, fraction }, index) => {
+          const y = MARGIN.top + index * legendStep;
+          return (
+            <g key={`legend-${slice.label}`}>
+              <rect x={legendX} y={y} width={10} height={10} rx={2} fill={color} />
+              <text
+                x={legendX + 16}
+                y={y + 5}
+                dominantBaseline="middle"
+                fontSize={11}
+                fill={TICK}
+              >
+                {`${truncateLabel(slice.label, 18)} · ${Math.round(fraction * 100)}%`}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+      <Caption>
+        {aggregation === "count" ? "row count" : "sum"} · {slices.length} categor
+        {slices.length === 1 ? "y" : "ies"}
       </Caption>
     </>
   );

--- a/apps/geolibre-desktop/src/components/panels/charts/chart-view.tsx
+++ b/apps/geolibre-desktop/src/components/panels/charts/chart-view.tsx
@@ -585,14 +585,18 @@ function PieChart({
   const legendX = cx + radius + 24;
   const legendStep = Math.min(22, INNER_H / Math.max(slices.length, 1));
 
-  // Accumulate slice angles from the top (12 o'clock), clockwise.
-  let angle = -Math.PI / 2;
+  // Slice angles run from the top (12 o'clock) clockwise. Each start angle is
+  // derived from the prefix sum of prior slice values, so the map stays pure
+  // (no mutation of an outer accumulator). Slice counts are tiny (<= 8).
+  const START = -Math.PI / 2;
   const arcs = slices.map((slice, index) => {
     // `share` (not `fraction`) so it doesn't shadow the module-level helper.
     const share = slice.value / total;
-    const start = angle;
-    const end = angle + share * Math.PI * 2;
-    angle = end;
+    const prior = slices
+      .slice(0, index)
+      .reduce((sum, s) => sum + s.value, 0);
+    const start = START + (prior / total) * Math.PI * 2;
+    const end = start + share * Math.PI * 2;
     const x0 = cx + radius * Math.cos(start);
     const y0 = cy + radius * Math.sin(start);
     const x1 = cx + radius * Math.cos(end);
@@ -617,18 +621,18 @@ function PieChart({
         className="h-auto w-full"
         preserveAspectRatio="xMidYMid meet"
       >
-        {arcs.map(({ d, color, slice }) => (
-          <path key={slice.label} d={d} fill={color} stroke="hsl(var(--background))" strokeWidth={1}>
+        {arcs.map(({ d, color: fill, slice }) => (
+          <path key={slice.label} d={d} fill={fill} stroke="hsl(var(--background))" strokeWidth={1}>
             <title>{`${slice.label}: ${formatAxisValue(slice.value)} (${Math.round(
               (slice.value / total) * 100,
             )}%)`}</title>
           </path>
         ))}
-        {arcs.map(({ color, slice, share }, index) => {
+        {arcs.map(({ color: fill, slice, share }, index) => {
           const y = MARGIN.top + index * legendStep;
           return (
             <g key={`legend-${slice.label}`}>
-              <rect x={legendX} y={y} width={10} height={10} rx={2} fill={color} />
+              <rect x={legendX} y={y} width={10} height={10} rx={2} fill={fill} />
               <text
                 x={legendX + 16}
                 y={y + 5}

--- a/apps/geolibre-desktop/src/components/panels/charts/chart-view.tsx
+++ b/apps/geolibre-desktop/src/components/panels/charts/chart-view.tsx
@@ -578,9 +578,10 @@ function PieChart({
   // Accumulate slice angles from the top (12 o'clock), clockwise.
   let angle = -Math.PI / 2;
   const arcs = slices.map((slice, index) => {
-    const fraction = slice.value / total;
+    // `share` (not `fraction`) so it doesn't shadow the module-level helper.
+    const share = slice.value / total;
     const start = angle;
-    const end = angle + fraction * Math.PI * 2;
+    const end = angle + share * Math.PI * 2;
     angle = end;
     const x0 = cx + radius * Math.cos(start);
     const y0 = cy + radius * Math.sin(start);
@@ -593,7 +594,7 @@ function PieChart({
       slices.length === 1
         ? `M ${cx - radius} ${cy} A ${radius} ${radius} 0 1 1 ${cx + radius} ${cy} A ${radius} ${radius} 0 1 1 ${cx - radius} ${cy} Z`
         : `M ${cx} ${cy} L ${x0} ${y0} A ${radius} ${radius} 0 ${largeArc} 1 ${x1} ${y1} Z`;
-    return { d, color: colors[index], slice, fraction };
+    return { d, color: colors[index], slice, share };
   });
 
   return (
@@ -613,7 +614,7 @@ function PieChart({
             )}%)`}</title>
           </path>
         ))}
-        {arcs.map(({ color, slice, fraction }, index) => {
+        {arcs.map(({ color, slice, share }, index) => {
           const y = MARGIN.top + index * legendStep;
           return (
             <g key={`legend-${slice.label}`}>
@@ -625,15 +626,15 @@ function PieChart({
                 fontSize={11}
                 fill={TICK}
               >
-                {`${truncateLabel(slice.label, 18)} · ${Math.round(fraction * 100)}%`}
+                {`${truncateLabel(slice.label, 18)} · ${Math.round(share * 100)}%`}
               </text>
             </g>
           );
         })}
       </svg>
       <Caption>
-        {aggregation === "count" ? "row count" : "sum"} · {slices.length} categor
-        {slices.length === 1 ? "y" : "ies"}
+        {aggregation === "count" ? "row count" : "sum"} · {slices.length}{" "}
+        {slices.length === 1 ? "category" : "categories"}
       </Caption>
     </>
   );

--- a/apps/geolibre-desktop/src/hooks/useLayerChartData.ts
+++ b/apps/geolibre-desktop/src/hooks/useLayerChartData.ts
@@ -1,0 +1,76 @@
+import {
+  isDuckDBQueryLayer,
+  useAppStore,
+  type GeoLibreLayer,
+} from "@geolibre/core";
+import { getDuckDBLayerRows } from "@geolibre/plugins";
+import { useMemo } from "react";
+import type { ChartRow } from "../lib/attribute-charts";
+
+export interface LayerChartData {
+  /** Attribute rows for charting (just the property bag each chart needs). */
+  rows: ChartRow[];
+  /** Distinct property keys discovered across the rows, in first-seen order. */
+  columns: string[];
+  /** The layer's display name (empty when the layer is missing). */
+  layerName: string;
+  /** True when the layer exists and exposes attribute rows we can chart. */
+  hasData: boolean;
+}
+
+const EMPTY: LayerChartData = {
+  rows: [],
+  columns: [],
+  layerName: "",
+  hasData: false,
+};
+
+/**
+ * Whether a layer exposes the attribute rows a chart widget needs: a
+ * GeoJSON-backed vector layer or a DuckDB query layer. Tile/service/raster
+ * layers have no per-feature attributes to chart.
+ */
+export function isChartableLayer(layer: GeoLibreLayer | null | undefined): boolean {
+  return Boolean(layer && (isDuckDBQueryLayer(layer) || layer.geojson));
+}
+
+function buildLayerChartData(layer: GeoLibreLayer | null): LayerChartData {
+  if (!layer) return EMPTY;
+  // Mirror the attribute table's two row sources: DuckDB query layers fetch
+  // their rows from the plugin's cache, every other vector layer reads its
+  // features straight off `layer.geojson`.
+  const rows: ChartRow[] = isDuckDBQueryLayer(layer)
+    ? getDuckDBLayerRows(layer.id).map((row) => ({ properties: row.properties }))
+    : (layer.geojson?.features ?? []).map((feature) => ({
+        properties: (feature.properties ?? {}) as Record<string, unknown>,
+      }));
+
+  const keys = new Set<string>();
+  for (const row of rows) {
+    for (const key of Object.keys(row.properties)) keys.add(key);
+  }
+
+  return {
+    rows,
+    columns: Array.from(keys),
+    layerName: layer.name,
+    hasData: isChartableLayer(layer),
+  };
+}
+
+/**
+ * Resolve a layer id to the rows, columns, and name a chart widget renders
+ * from. Recomputes when the layer record changes (e.g. attribute edits replace
+ * `layer.geojson`). DuckDB query rows come from the plugin cache and are read
+ * once per layer-identity change, matching the attribute table's behavior.
+ *
+ * @param layerId The layer to chart, or null for an empty result.
+ * @returns The layer's chart data, or an empty result when it is missing or has
+ *   no chartable attributes.
+ */
+export function useLayerChartData(layerId: string | null): LayerChartData {
+  const layer = useAppStore((s) =>
+    layerId ? (s.layers.find((l) => l.id === layerId) ?? null) : null,
+  );
+  return useMemo(() => buildLayerChartData(layer), [layer]);
+}

--- a/apps/geolibre-desktop/src/hooks/useLayerChartData.ts
+++ b/apps/geolibre-desktop/src/hooks/useLayerChartData.ts
@@ -54,7 +54,10 @@ function buildLayerChartData(layer: GeoLibreLayer | null): LayerChartData {
     rows,
     columns: Array.from(keys),
     layerName: layer.name,
-    hasData: isChartableLayer(layer),
+    // Require actual rows, not just a chartable layer type: a DuckDB layer whose
+    // query cache is still empty has no rows yet, and the widget should show its
+    // own "no data" fallback rather than an empty chart.
+    hasData: isChartableLayer(layer) && rows.length > 0,
   };
 }
 

--- a/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
@@ -196,6 +196,7 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
       storymap: state.storymap,
       models: state.models,
       widgets: state.widgets,
+      dashboardColumns: state.dashboardColumns,
       metadata: state.metadata,
     });
     return {

--- a/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
@@ -195,6 +195,7 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
       legend: state.legend,
       storymap: state.storymap,
       models: state.models,
+      widgets: state.widgets,
       metadata: state.metadata,
     });
     return {

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -707,6 +707,16 @@
       "sum": "Sum",
       "mean": "Average"
     },
+    "chart": {
+      "emptyNumeric": "No numeric values to plot.",
+      "emptyScatter": "No rows have both fields set to a number.",
+      "emptyBar": "No rows to group.",
+      "emptyPie": "No positive values to chart.",
+      "pieCaptionCount_one": "row count · {{count}} category",
+      "pieCaptionCount_other": "row count · {{count}} categories",
+      "pieCaptionSum_one": "sum · {{count}} category",
+      "pieCaptionSum_other": "sum · {{count}} categories"
+    },
     "editor": {
       "addTitle": "Add widget",
       "editTitle": "Edit widget",
@@ -726,7 +736,7 @@
       "titlePlaceholder": "Optional title",
       "color": "Color",
       "colorReset": "Reset",
-      "colorDefault": "Default palette",
+      "colorDefault": "Default chart colors",
       "cancel": "Cancel",
       "save": "Save"
     }

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -681,6 +681,7 @@
     "title": "Dashboard",
     "resize": "Resize dashboard panel",
     "close": "Close dashboard",
+    "columns": "Columns",
     "addWidget": "Add widget",
     "widgetCount_one": "{{count}} widget",
     "widgetCount_other": "{{count}} widgets",
@@ -698,7 +699,8 @@
       "scatter": "Scatter",
       "bar": "Bar",
       "line": "Line",
-      "box": "Box plot"
+      "box": "Box plot",
+      "pie": "Pie"
     },
     "aggregate": {
       "count": "Count",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -724,6 +724,9 @@
       "value": "Value",
       "titleLabel": "Title",
       "titlePlaceholder": "Optional title",
+      "color": "Color",
+      "colorReset": "Reset",
+      "colorDefault": "Default palette",
       "cancel": "Cancel",
       "save": "Save"
     }

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -332,6 +332,7 @@
       "sqlWorkspace": "SQL Workspace",
       "pythonConsole": "Python Console",
       "notebook": "Jupyter Notebook",
+      "dashboard": "Dashboard",
       "assistant": "AI Assistant",
       "geocode": "Geocode Addresses",
       "modelBuilder": "Batch & Models",
@@ -675,6 +676,55 @@
     "close": "Close notebook",
     "loading": "Loading notebook…",
     "loadFailed": "Failed to load the notebook."
+  },
+  "dashboard": {
+    "title": "Dashboard",
+    "resize": "Resize dashboard panel",
+    "close": "Close dashboard",
+    "addWidget": "Add widget",
+    "widgetCount_one": "{{count}} widget",
+    "widgetCount_other": "{{count}} widgets",
+    "empty": "No widgets yet. Add a chart to summarize a layer.",
+    "emptyNoLayers": "Add a vector or DuckDB query layer to start building charts.",
+    "noLayersHint": "Add a vector or DuckDB query layer first.",
+    "layerMissing": "Layer unavailable",
+    "noData": "This layer has no chartable attributes.",
+    "moveBack": "Move back",
+    "moveForward": "Move forward",
+    "editWidget": "Edit widget",
+    "removeWidget": "Remove widget",
+    "chartType": {
+      "histogram": "Histogram",
+      "scatter": "Scatter",
+      "bar": "Bar",
+      "line": "Line",
+      "box": "Box plot"
+    },
+    "aggregate": {
+      "count": "Count",
+      "sum": "Sum",
+      "mean": "Average"
+    },
+    "editor": {
+      "addTitle": "Add widget",
+      "editTitle": "Edit widget",
+      "description": "Choose a layer, a chart type, and the fields to plot.",
+      "noLayers": "No chartable layers. Add a vector or DuckDB query layer first.",
+      "noFields": "This layer has no numeric or categorical fields to chart.",
+      "layer": "Layer",
+      "chartType": "Chart type",
+      "field": "Field",
+      "bins": "Bins",
+      "xAxis": "X axis",
+      "yAxis": "Y axis",
+      "category": "Category",
+      "aggregate": "Aggregate",
+      "value": "Value",
+      "titleLabel": "Title",
+      "titlePlaceholder": "Optional title",
+      "cancel": "Cancel",
+      "save": "Save"
+    }
   },
   "assistant": {
     "title": "AI Assistant",

--- a/apps/geolibre-desktop/src/lib/attribute-charts.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-charts.ts
@@ -410,7 +410,12 @@ export function computePie(
     const tail = all.slice(limit - 1);
     const otherValue = tail.reduce((sum, slice) => sum + slice.value, 0);
     otherCount = tail.reduce((sum, slice) => sum + slice.count, 0);
-    slices = [...head, { label: "(other)", value: otherValue, count: otherCount }];
+    // Avoid a duplicate label (and a React key collision) if the data already
+    // has a real "(other)" category among the shown slices.
+    const foldLabel = head.some((slice) => slice.label === "(other)")
+      ? "(other categories)"
+      : "(other)";
+    slices = [...head, { label: foldLabel, value: otherValue, count: otherCount }];
   }
   const total = slices.reduce((sum, slice) => sum + slice.value, 0);
   if (total <= 0) return null;

--- a/apps/geolibre-desktop/src/lib/attribute-charts.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-charts.ts
@@ -402,7 +402,9 @@ export function computePie(
   if (all.length === 0) return null;
   all.sort((a, b) => b.value - a.value);
 
-  const limit = Math.max(1, maxSlices);
+  // Floor at 2 so there is always a named slice plus the overflow bucket; a
+  // limit of 1 would put every row under "(other)", which is meaningless.
+  const limit = Math.max(2, maxSlices);
   let slices: PieSlice[] = all;
   let otherCount = 0;
   if (all.length > limit) {

--- a/apps/geolibre-desktop/src/lib/attribute-charts.ts
+++ b/apps/geolibre-desktop/src/lib/attribute-charts.ts
@@ -6,7 +6,13 @@
  * already builds for both GeoJSON and DuckDB query layers.
  */
 
-export type ChartType = "histogram" | "scatter" | "bar" | "line" | "box";
+export type ChartType =
+  | "histogram"
+  | "scatter"
+  | "bar"
+  | "line"
+  | "box"
+  | "pie";
 
 /** A row as seen by the chart helpers — only its property bag matters. */
 export interface ChartRow {
@@ -21,6 +27,8 @@ export const DEFAULT_HISTOGRAM_BINS = 10;
 export const MAX_CATEGORY_CARDINALITY = 50;
 /** The bar chart renders at most this many categories (top-N by value). */
 export const MAX_BAR_CATEGORIES = 20;
+/** The pie chart renders at most this many slices; the rest fold into "(other)". */
+export const MAX_PIE_SLICES = 8;
 
 /**
  * Parse a value into a finite number, or null when it cannot be one. Numeric
@@ -336,6 +344,77 @@ export function computeBar(
     if (bar.value < minValue) minValue = bar.value;
   }
   return { bars, maxValue, minValue, truncated: Math.max(0, all.length - bars.length) };
+}
+
+export interface PieSlice {
+  label: string;
+  /** The slice's share of the whole (count, or summed value). */
+  value: number;
+  /** How many rows fell into this slice. */
+  count: number;
+}
+
+export interface PieResult {
+  slices: PieSlice[];
+  /** Sum of every slice value (the whole the slices divide). */
+  total: number;
+  /** Rows folded into the trailing "(other)" slice (0 when none). */
+  otherCount: number;
+}
+
+/**
+ * Group rows by a category field into pie slices. `count` tallies rows per
+ * category; any other aggregation sums the finite values of `valueKey`. Because
+ * a pie shows parts of a whole, only positive contributions are kept (negative
+ * or zero sums are dropped). Slices are sorted by value descending and capped at
+ * `maxSlices`; the remainder is merged into a single "(other)" slice rather than
+ * dropped. Null/blank category values bucket as "(blank)". Returns null when no
+ * positive slice survives.
+ */
+export function computePie(
+  rows: ChartRow[],
+  categoryKey: string,
+  aggregation: BarAggregation,
+  valueKey: string | null,
+  maxSlices: number = MAX_PIE_SLICES,
+): PieResult | null {
+  const groups = new Map<string, { count: number; sum: number }>();
+  for (const row of rows) {
+    const raw = row.properties[categoryKey];
+    const label = raw == null || raw === "" ? "(blank)" : String(raw);
+    const group = groups.get(label) ?? { count: 0, sum: 0 };
+    group.count += 1;
+    if (aggregation !== "count" && valueKey) {
+      const value = toFiniteNumber(row.properties[valueKey]);
+      if (value !== null) group.sum += value;
+    }
+    groups.set(label, group);
+  }
+  if (groups.size === 0) return null;
+
+  const all = [...groups.entries()]
+    .map(([label, group]) => ({
+      label,
+      value: aggregation === "count" ? group.count : group.sum,
+      count: group.count,
+    }))
+    .filter((slice) => slice.value > 0);
+  if (all.length === 0) return null;
+  all.sort((a, b) => b.value - a.value);
+
+  const limit = Math.max(1, maxSlices);
+  let slices: PieSlice[] = all;
+  let otherCount = 0;
+  if (all.length > limit) {
+    const head = all.slice(0, limit - 1);
+    const tail = all.slice(limit - 1);
+    const otherValue = tail.reduce((sum, slice) => sum + slice.value, 0);
+    otherCount = tail.reduce((sum, slice) => sum + slice.count, 0);
+    slices = [...head, { label: "(other)", value: otherValue, count: otherCount }];
+  }
+  const total = slices.reduce((sum, slice) => sum + slice.value, 0);
+  if (total <= 0) return null;
+  return { slices, total, otherCount };
 }
 
 export interface LinePoint {

--- a/apps/geolibre-desktop/src/lib/build-project-snapshot.ts
+++ b/apps/geolibre-desktop/src/lib/build-project-snapshot.ts
@@ -41,6 +41,7 @@ export function buildProjectSnapshot(
     storymap: state.storymap,
     models: state.models,
     widgets: state.widgets,
+    dashboardColumns: state.dashboardColumns,
     metadata: state.metadata,
   });
 }

--- a/apps/geolibre-desktop/src/lib/build-project-snapshot.ts
+++ b/apps/geolibre-desktop/src/lib/build-project-snapshot.ts
@@ -40,6 +40,7 @@ export function buildProjectSnapshot(
     legend: state.legend,
     storymap: state.storymap,
     models: state.models,
+    widgets: state.widgets,
     metadata: state.metadata,
   });
 }

--- a/docs/project-format.md
+++ b/docs/project-format.md
@@ -18,6 +18,7 @@ Projects are saved as **`.geolibre.json`** files.
 | `legend`          | object  | Optional Print Layout legend customizations (title, grouping, ordering, per-item rename/hide)                |
 | `storymap`        | object  | Optional scroll-driven story map (chapters and presentation settings); omitted when there are no chapters    |
 | `widgets`         | array   | Optional Dashboard panel chart widgets (see below); omitted when there are none                              |
+| `dashboardColumns`| number  | Optional Dashboard widget-grid column count (1-6, default 2); omitted when default                          |
 | `metadata`        | object  | Free-form project metadata                                                                                   |
 
 ## Plugin state

--- a/docs/project-format.md
+++ b/docs/project-format.md
@@ -17,6 +17,7 @@ Projects are saved as **`.geolibre.json`** files.
 | `plugins`         | object  | Optional external plugin manifest URLs, active plugin IDs, plugin map-control positions, and plugin settings |
 | `legend`          | object  | Optional Print Layout legend customizations (title, grouping, ordering, per-item rename/hide)                |
 | `storymap`        | object  | Optional scroll-driven story map (chapters and presentation settings); omitted when there are no chapters    |
+| `widgets`         | array   | Optional Dashboard panel chart widgets (see below); omitted when there are none                              |
 | `metadata`        | object  | Free-form project metadata                                                                                   |
 
 ## Plugin state
@@ -114,6 +115,26 @@ enter/exit. The section is omitted entirely when the project has no chapters.
 `flyTo`, `easeTo`, or `jumpTo`. Layer opacity changes reference project layer
 ids. Build and present story maps from **Project → Story Map**, or export a
 self-contained HTML page for static hosting.
+
+## Dashboard widgets
+
+```json
+{
+  "widgets": [
+    { "id": "w1", "layerId": "layer-a", "type": "histogram", "field": "pop", "bins": 12 },
+    { "id": "w2", "layerId": "layer-a", "type": "bar", "category": "kind", "aggregation": "sum", "valueField": "pop", "title": "Population by kind" }
+  ]
+}
+```
+
+Each widget binds a chart to a layer's attributes. `type` is one of `histogram`,
+`scatter`, `bar`, `line`, or `box`. Which other keys apply depends on the type:
+`field` (histogram/line/box), `xField`/`yField` (scatter), `category` +
+`aggregation` (`count`/`sum`/`mean`) + `valueField` (bar), `bins` (histogram).
+`title` is an optional label; unused keys are ignored. Build them in the
+**Dashboard** panel (Tools → Dashboard). Charts read from GeoJSON-backed vector
+layers and DuckDB query layers; widgets bound to a missing or non-attribute
+layer are shown as empty.
 
 ## Layer object
 

--- a/docs/project-format.md
+++ b/docs/project-format.md
@@ -134,7 +134,7 @@ type: `field` (histogram/line/box), `xField`/`yField` (scatter), `category` +
 `count`/`sum`/`mean`; pie is `count`/`sum` only. `title` is an optional label;
 unused keys are ignored. The Dashboard panel (Tools → Dashboard, or the
 **Dashboard** button in the attribute table) also stores `dashboardColumns`, the
-widget-grid column count (1-4, default 2), at the top level of the project.
+widget-grid column count (1-6, default 2), at the top level of the project.
 Charts read from GeoJSON-backed vector layers and DuckDB query layers; widgets
 bound to a missing or non-attribute layer are shown as empty.
 

--- a/docs/project-format.md
+++ b/docs/project-format.md
@@ -128,13 +128,15 @@ self-contained HTML page for static hosting.
 ```
 
 Each widget binds a chart to a layer's attributes. `type` is one of `histogram`,
-`scatter`, `bar`, `line`, or `box`. Which other keys apply depends on the type:
-`field` (histogram/line/box), `xField`/`yField` (scatter), `category` +
-`aggregation` (`count`/`sum`/`mean`) + `valueField` (bar), `bins` (histogram).
-`title` is an optional label; unused keys are ignored. Build them in the
-**Dashboard** panel (Tools → Dashboard). Charts read from GeoJSON-backed vector
-layers and DuckDB query layers; widgets bound to a missing or non-attribute
-layer are shown as empty.
+`scatter`, `bar`, `line`, `box`, or `pie`. Which other keys apply depends on the
+type: `field` (histogram/line/box), `xField`/`yField` (scatter), `category` +
+`aggregation` + `valueField` (bar/pie), `bins` (histogram). Bar `aggregation` is
+`count`/`sum`/`mean`; pie is `count`/`sum` only. `title` is an optional label;
+unused keys are ignored. The Dashboard panel (Tools → Dashboard, or the
+**Dashboard** button in the attribute table) also stores `dashboardColumns`, the
+widget-grid column count (1-4, default 2), at the top level of the project.
+Charts read from GeoJSON-backed vector layers and DuckDB query layers; widgets
+bound to a missing or non-attribute layer are shown as empty.
 
 ## Layer object
 

--- a/docs/project-format.md
+++ b/docs/project-format.md
@@ -131,8 +131,10 @@ Each widget binds a chart to a layer's attributes. `type` is one of `histogram`,
 `scatter`, `bar`, `line`, `box`, or `pie`. Which other keys apply depends on the
 type: `field` (histogram/line/box), `xField`/`yField` (scatter), `category` +
 `aggregation` + `valueField` (bar/pie), `bins` (histogram). Bar `aggregation` is
-`count`/`sum`/`mean`; pie is `count`/`sum` only. `title` is an optional label;
-unused keys are ignored. The Dashboard panel (Tools → Dashboard, or the
+`count`/`sum`/`mean`; pie is `count`/`sum` only. `title` is an optional label and
+`color` an optional hex (`#rgb`/`#rrggbb`) for the chart's marks (the series
+color for single-series charts; the base of a monochromatic ramp for bar/pie).
+Unused keys are ignored. The Dashboard panel (Tools → Dashboard, or the
 **Dashboard** button in the attribute table) also stores `dashboardColumns`, the
 widget-grid column count (1-6, default 2), at the top level of the project.
 Charts read from GeoJSON-backed vector layers and DuckDB query layers; widgets

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -402,6 +402,9 @@ export function normalizeModels(value: unknown): ProcessingModel[] | null {
   return models.length > 0 ? models : null;
 }
 
+/** A 3- or 6-digit hex color, the only widget color format we persist. */
+const HEX_COLOR = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+
 const DASHBOARD_WIDGET_TYPES: readonly DashboardWidgetType[] = [
   "histogram",
   "scatter",
@@ -443,6 +446,8 @@ export function normalizeWidgets(value: unknown): DashboardWidget[] | null {
     const widget: DashboardWidget = { id, layerId, type };
     const title = normalizeString(candidate.title).trim();
     if (title) widget.title = title;
+    const color = normalizeString(candidate.color).trim();
+    if (HEX_COLOR.test(color)) widget.color = color;
     const field = normalizeString(candidate.field).trim();
     if (field) widget.field = field;
     const xField = normalizeString(candidate.xField).trim();

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -5,6 +5,9 @@ import {
   DEFAULT_PROJECT_PREFERENCES,
   DEFAULT_STORY_MAP,
   PROJECT_VERSION,
+  type DashboardWidget,
+  type DashboardWidgetAggregation,
+  type DashboardWidgetType,
   type GeoLibreLayer,
   type GeoLibreProject,
   type LayerGroup,
@@ -100,6 +103,7 @@ export function parseProject(json: string): GeoLibreProject {
     legend: normalizeLegendConfig(data.legend),
     storymap: normalizeStoryMap(data.storymap) ?? undefined,
     models: normalizeModels(data.models) ?? undefined,
+    widgets: normalizeWidgets(data.widgets) ?? undefined,
     metadata: data.metadata ?? {},
   };
 }
@@ -392,6 +396,70 @@ export function normalizeModels(value: unknown): ProcessingModel[] | null {
   return models.length > 0 ? models : null;
 }
 
+const DASHBOARD_WIDGET_TYPES: readonly DashboardWidgetType[] = [
+  "histogram",
+  "scatter",
+  "bar",
+  "line",
+  "box",
+];
+const DASHBOARD_WIDGET_AGGREGATIONS: readonly DashboardWidgetAggregation[] = [
+  "count",
+  "sum",
+  "mean",
+];
+
+/**
+ * Coerce an untrusted (possibly hand-edited) `widgets` array into valid
+ * {@link DashboardWidget} records. Drops widgets without a usable id, layer id,
+ * or recognized chart type, de-duplicates by id, and keeps only the optional
+ * keys that are present and well-typed (the Dashboard panel falls back to
+ * sensible defaults for anything missing). Returns `null` when there is nothing
+ * worth persisting, so a widget-less project stays free of the key.
+ *
+ * @param value Raw `widgets` value from the project JSON.
+ * @returns Normalized widgets, or `null` when none survive.
+ */
+export function normalizeWidgets(value: unknown): DashboardWidget[] | null {
+  if (!Array.isArray(value)) return null;
+  const widgets: DashboardWidget[] = [];
+  const seen = new Set<string>();
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") continue;
+    const candidate = entry as Partial<DashboardWidget>;
+    const id = normalizeString(candidate.id).trim();
+    const layerId = normalizeString(candidate.layerId).trim();
+    if (!id || !layerId || seen.has(id)) continue;
+    const type = candidate.type;
+    if (!type || !DASHBOARD_WIDGET_TYPES.includes(type)) continue;
+    seen.add(id);
+    const widget: DashboardWidget = { id, layerId, type };
+    const title = normalizeString(candidate.title).trim();
+    if (title) widget.title = title;
+    const field = normalizeString(candidate.field).trim();
+    if (field) widget.field = field;
+    const xField = normalizeString(candidate.xField).trim();
+    if (xField) widget.xField = xField;
+    const yField = normalizeString(candidate.yField).trim();
+    if (yField) widget.yField = yField;
+    if (typeof candidate.bins === "number" && Number.isFinite(candidate.bins)) {
+      widget.bins = Math.trunc(candidate.bins);
+    }
+    const category = normalizeString(candidate.category).trim();
+    if (category) widget.category = category;
+    if (
+      candidate.aggregation &&
+      DASHBOARD_WIDGET_AGGREGATIONS.includes(candidate.aggregation)
+    ) {
+      widget.aggregation = candidate.aggregation;
+    }
+    const valueField = normalizeString(candidate.valueField).trim();
+    if (valueField) widget.valueField = valueField;
+    widgets.push(widget);
+  }
+  return widgets.length > 0 ? widgets : null;
+}
+
 function normalizeProjectPreferences(preferences: unknown): ProjectPreferences {
   if (!preferences || typeof preferences !== "object") {
     return DEFAULT_PROJECT_PREFERENCES;
@@ -674,6 +742,7 @@ export function projectFromStore(state: {
   legend?: LegendConfig | null;
   storymap?: StoryMap | null;
   models?: ProcessingModel[] | null;
+  widgets?: DashboardWidget[] | null;
   metadata: Record<string, unknown>;
 }): GeoLibreProject {
   const styles: Record<string, LayerStyle> = {};
@@ -684,6 +753,7 @@ export function projectFromStore(state: {
   const legend = normalizeLegendConfig(state.legend);
   const storymap = normalizeStoryMap(state.storymap);
   const models = normalizeModels(state.models);
+  const widgets = normalizeWidgets(state.widgets);
   // Persist every group (including empty folders, which the UI supports). The
   // key is spread only when non-empty so legacy readers that don't recognise it
   // are unaffected; normalizeLayerGroups round-trips them back on load.
@@ -703,6 +773,7 @@ export function projectFromStore(state: {
     ...(legend ? { legend } : {}),
     ...(storymap ? { storymap } : {}),
     ...(models ? { models } : {}),
+    ...(widgets ? { widgets } : {}),
     metadata: state.metadata,
   };
 }
@@ -776,6 +847,7 @@ export function applyProjectToStore(project: GeoLibreProject): {
   legend: LegendConfig;
   storymap: StoryMap | null;
   models: ProcessingModel[];
+  widgets: DashboardWidget[];
   metadata: Record<string, unknown>;
 } {
   const layers = project.layers.map((layer) => ({
@@ -814,6 +886,7 @@ export function applyProjectToStore(project: GeoLibreProject): {
     legend: normalizeLegendConfig(project.legend) ?? { ...DEFAULT_LEGEND_CONFIG },
     storymap: normalizeStoryMap(project.storymap),
     models: normalizeModels(project.models) ?? [],
+    widgets: normalizeWidgets(project.widgets) ?? [],
     metadata: project.metadata,
   };
 }

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -405,6 +405,10 @@ export function normalizeModels(value: unknown): ProcessingModel[] | null {
 /** A 3- or 6-digit hex color, the only widget color format we persist. */
 const HEX_COLOR = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
 
+/** Upper bound for a persisted histogram bin count, mirroring the chart
+ * renderer's clamp (`MAX_HISTOGRAM_BINS` in the desktop app's chart helpers). */
+const MAX_PERSISTED_BINS = 50;
+
 const DASHBOARD_WIDGET_TYPES: readonly DashboardWidgetType[] = [
   "histogram",
   "scatter",
@@ -455,13 +459,19 @@ export function normalizeWidgets(value: unknown): DashboardWidget[] | null {
     const yField = normalizeString(candidate.yField).trim();
     if (yField) widget.yField = yField;
     if (typeof candidate.bins === "number" && Number.isFinite(candidate.bins)) {
-      widget.bins = Math.trunc(candidate.bins);
+      // Persist only a sane positive bin count; the histogram renderer clamps to
+      // [1, 50], so mirror that here rather than round-tripping 0 or huge values.
+      const bins = Math.trunc(candidate.bins);
+      if (bins >= 1) widget.bins = Math.min(MAX_PERSISTED_BINS, bins);
     }
     const category = normalizeString(candidate.category).trim();
     if (category) widget.category = category;
     if (
       candidate.aggregation &&
-      DASHBOARD_WIDGET_AGGREGATIONS.includes(candidate.aggregation)
+      DASHBOARD_WIDGET_AGGREGATIONS.includes(candidate.aggregation) &&
+      // A pie has no "average"; the renderer would silently treat mean as sum,
+      // so drop it here and let the default (count) stand for hand-edited files.
+      !(type === "pie" && candidate.aggregation === "mean")
     ) {
       widget.aggregation = candidate.aggregation;
     }

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -3,7 +3,10 @@ import {
   DEFAULT_LAYER_STYLE,
   DEFAULT_LEGEND_CONFIG,
   DEFAULT_PROJECT_PREFERENCES,
+  DEFAULT_DASHBOARD_COLUMNS,
   DEFAULT_STORY_MAP,
+  MAX_DASHBOARD_COLUMNS,
+  MIN_DASHBOARD_COLUMNS,
   PROJECT_VERSION,
   type DashboardWidget,
   type DashboardWidgetAggregation,
@@ -104,6 +107,9 @@ export function parseProject(json: string): GeoLibreProject {
     storymap: normalizeStoryMap(data.storymap) ?? undefined,
     models: normalizeModels(data.models) ?? undefined,
     widgets: normalizeWidgets(data.widgets) ?? undefined,
+    ...(data.dashboardColumns === undefined
+      ? {}
+      : { dashboardColumns: normalizeDashboardColumns(data.dashboardColumns) }),
     metadata: data.metadata ?? {},
   };
 }
@@ -402,6 +408,7 @@ const DASHBOARD_WIDGET_TYPES: readonly DashboardWidgetType[] = [
   "bar",
   "line",
   "box",
+  "pie",
 ];
 const DASHBOARD_WIDGET_AGGREGATIONS: readonly DashboardWidgetAggregation[] = [
   "count",
@@ -458,6 +465,23 @@ export function normalizeWidgets(value: unknown): DashboardWidget[] | null {
     widgets.push(widget);
   }
   return widgets.length > 0 ? widgets : null;
+}
+
+/**
+ * Clamp an untrusted dashboard column count into the supported range, falling
+ * back to the default for a missing or non-finite value.
+ *
+ * @param value Raw `dashboardColumns` value from the project JSON.
+ * @returns An integer column count within [MIN, MAX].
+ */
+export function normalizeDashboardColumns(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_DASHBOARD_COLUMNS;
+  }
+  return Math.max(
+    MIN_DASHBOARD_COLUMNS,
+    Math.min(MAX_DASHBOARD_COLUMNS, Math.trunc(value)),
+  );
 }
 
 function normalizeProjectPreferences(preferences: unknown): ProjectPreferences {
@@ -743,6 +767,7 @@ export function projectFromStore(state: {
   storymap?: StoryMap | null;
   models?: ProcessingModel[] | null;
   widgets?: DashboardWidget[] | null;
+  dashboardColumns?: number;
   metadata: Record<string, unknown>;
 }): GeoLibreProject {
   const styles: Record<string, LayerStyle> = {};
@@ -754,6 +779,12 @@ export function projectFromStore(state: {
   const storymap = normalizeStoryMap(state.storymap);
   const models = normalizeModels(state.models);
   const widgets = normalizeWidgets(state.widgets);
+  // Persist a non-default column count only; a default-layout dashboard (or a
+  // widget-less project) stays free of the key for legacy readers.
+  const dashboardColumns =
+    state.dashboardColumns === undefined
+      ? DEFAULT_DASHBOARD_COLUMNS
+      : normalizeDashboardColumns(state.dashboardColumns);
   // Persist every group (including empty folders, which the UI supports). The
   // key is spread only when non-empty so legacy readers that don't recognise it
   // are unaffected; normalizeLayerGroups round-trips them back on load.
@@ -774,6 +805,7 @@ export function projectFromStore(state: {
     ...(storymap ? { storymap } : {}),
     ...(models ? { models } : {}),
     ...(widgets ? { widgets } : {}),
+    ...(dashboardColumns !== DEFAULT_DASHBOARD_COLUMNS ? { dashboardColumns } : {}),
     metadata: state.metadata,
   };
 }
@@ -848,6 +880,7 @@ export function applyProjectToStore(project: GeoLibreProject): {
   storymap: StoryMap | null;
   models: ProcessingModel[];
   widgets: DashboardWidget[];
+  dashboardColumns: number;
   metadata: Record<string, unknown>;
 } {
   const layers = project.layers.map((layer) => ({
@@ -887,6 +920,7 @@ export function applyProjectToStore(project: GeoLibreProject): {
     storymap: normalizeStoryMap(project.storymap),
     models: normalizeModels(project.models) ?? [],
     widgets: normalizeWidgets(project.widgets) ?? [],
+    dashboardColumns: normalizeDashboardColumns(project.dashboardColumns),
     metadata: project.metadata,
   };
 }

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -22,10 +22,13 @@ import {
 } from "./layer-groups";
 import {
   DEFAULT_BASEMAP,
+  DEFAULT_DASHBOARD_COLUMNS,
   DEFAULT_LAYER_STYLE,
   DEFAULT_LEGEND_CONFIG,
   DEFAULT_PROJECT_PREFERENCES,
   DEFAULT_STORY_MAP,
+  MAX_DASHBOARD_COLUMNS,
+  MIN_DASHBOARD_COLUMNS,
   type CollaborationParticipant,
   type CollaborationPresence,
   type CollaborationState,
@@ -135,6 +138,8 @@ export interface AppState {
   models: ProcessingModel[];
   /** Saved Dashboard panel chart widgets (issue #401). */
   widgets: DashboardWidget[];
+  /** Number of columns in the Dashboard widget grid. */
+  dashboardColumns: number;
   selectedLayerId: string | null;
   selectedFeatureId: string | null;
   identifyLayerId: string | null;
@@ -220,6 +225,8 @@ export interface AppState {
   removeWidget: (id: string) => void;
   /** Move a widget to a new index, clamped into range, preserving the rest. */
   moveWidget: (id: string, toIndex: number) => void;
+  /** Set the Dashboard widget-grid column count (clamped into range). */
+  setDashboardColumns: (columns: number) => void;
 
   setStorymap: (storymap: StoryMap | null) => void;
   updateStorymapSettings: (
@@ -404,6 +411,7 @@ export const useAppStore = create<AppState>()(
       storymap: null,
       models: [],
       widgets: [],
+      dashboardColumns: DEFAULT_DASHBOARD_COLUMNS,
       selectedLayerId: null,
       selectedFeatureId: null,
       identifyLayerId: null,
@@ -554,6 +562,14 @@ export const useAppStore = create<AppState>()(
           const [moved] = widgets.splice(from, 1);
           widgets.splice(target, 0, moved);
           return { widgets, isDirty: true };
+        }),
+      setDashboardColumns: (columns) =>
+        set({
+          dashboardColumns: Math.max(
+            MIN_DASHBOARD_COLUMNS,
+            Math.min(MAX_DASHBOARD_COLUMNS, Math.trunc(columns)),
+          ),
+          isDirty: true,
         }),
 
       setStorymap: (storymap) => set({ storymap, isDirty: true }),

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -535,7 +535,12 @@ export const useAppStore = create<AppState>()(
         })),
 
       addWidget: (widget) =>
-        set((s) => ({ widgets: [...s.widgets, widget], isDirty: true })),
+        set((s) => {
+          // Ignore a duplicate id so updateWidget/removeWidget stay unambiguous
+          // and a later entry isn't silently dropped when normalized on save.
+          if (s.widgets.some((w) => w.id === widget.id)) return s;
+          return { widgets: [...s.widgets, widget], isDirty: true };
+        }),
       updateWidget: (id, patch) =>
         set((s) => {
           const exists = s.widgets.some((w) => w.id === id);
@@ -564,12 +569,16 @@ export const useAppStore = create<AppState>()(
           return { widgets, isDirty: true };
         }),
       setDashboardColumns: (columns) =>
-        set({
-          dashboardColumns: Math.max(
-            MIN_DASHBOARD_COLUMNS,
-            Math.min(MAX_DASHBOARD_COLUMNS, Math.trunc(columns)),
-          ),
-          isDirty: true,
+        set((s) => {
+          // Guard non-finite input so the clamp can't yield NaN columns.
+          if (!Number.isFinite(columns)) return s;
+          return {
+            dashboardColumns: Math.max(
+              MIN_DASHBOARD_COLUMNS,
+              Math.min(MAX_DASHBOARD_COLUMNS, Math.trunc(columns)),
+            ),
+            isDirty: true,
+          };
         }),
 
       setStorymap: (storymap) => set({ storymap, isDirty: true }),

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -29,6 +29,7 @@ import {
   type CollaborationParticipant,
   type CollaborationPresence,
   type CollaborationState,
+  type DashboardWidget,
   type GeoLibreLayer,
   type GeoLibreProject,
   type LayerGroup,
@@ -132,6 +133,8 @@ export interface AppState {
   storymap: StoryMap | null;
   /** Saved processing pipelines (batch/model chaining; issue #344). */
   models: ProcessingModel[];
+  /** Saved Dashboard panel chart widgets (issue #401). */
+  widgets: DashboardWidget[];
   selectedLayerId: string | null;
   selectedFeatureId: string | null;
   identifyLayerId: string | null;
@@ -157,6 +160,7 @@ export interface AppState {
     notebookOpen: boolean;
     assistantOpen: boolean;
     attributeTableOpen: boolean;
+    dashboardOpen: boolean;
     storymapPanelOpen: boolean;
     storymapPresenting: boolean;
     modelBuilderOpen: boolean;
@@ -197,6 +201,7 @@ export interface AppState {
   setNotebookOpen: (open: boolean) => void;
   setAssistantOpen: (open: boolean) => void;
   setAttributeTableOpen: (open: boolean) => void;
+  setDashboardOpen: (open: boolean) => void;
   setStorymapPanelOpen: (open: boolean) => void;
   setStorymapPresenting: (presenting: boolean) => void;
   setModelBuilderOpen: (open: boolean) => void;
@@ -206,6 +211,15 @@ export interface AppState {
   saveModel: (model: ProcessingModel) => void;
   /** Remove a saved model by id. */
   deleteModel: (id: string) => void;
+
+  /** Append a new dashboard widget. */
+  addWidget: (widget: DashboardWidget) => void;
+  /** Patch an existing dashboard widget by id (no-op if absent). */
+  updateWidget: (id: string, patch: Partial<Omit<DashboardWidget, "id">>) => void;
+  /** Remove a dashboard widget by id. */
+  removeWidget: (id: string) => void;
+  /** Move a widget to a new index, clamped into range, preserving the rest. */
+  moveWidget: (id: string, toIndex: number) => void;
 
   setStorymap: (storymap: StoryMap | null) => void;
   updateStorymapSettings: (
@@ -389,6 +403,7 @@ export const useAppStore = create<AppState>()(
       legend: { ...DEFAULT_LEGEND_CONFIG },
       storymap: null,
       models: [],
+      widgets: [],
       selectedLayerId: null,
       selectedFeatureId: null,
       identifyLayerId: null,
@@ -411,6 +426,7 @@ export const useAppStore = create<AppState>()(
         notebookOpen: false,
         assistantOpen: false,
         attributeTableOpen: false,
+        dashboardOpen: false,
         storymapPanelOpen: false,
         storymapPresenting: false,
         modelBuilderOpen: false,
@@ -485,6 +501,8 @@ export const useAppStore = create<AppState>()(
         set((s) => ({ ui: { ...s.ui, assistantOpen: open } })),
       setAttributeTableOpen: (open) =>
         set((s) => ({ ui: { ...s.ui, attributeTableOpen: open } })),
+      setDashboardOpen: (open) =>
+        set((s) => ({ ui: { ...s.ui, dashboardOpen: open } })),
       setStorymapPanelOpen: (open) =>
         set((s) => ({ ui: { ...s.ui, storymapPanelOpen: open } })),
       setStorymapPresenting: (presenting) =>
@@ -507,6 +525,36 @@ export const useAppStore = create<AppState>()(
           models: s.models.filter((m) => m.id !== id),
           isDirty: true,
         })),
+
+      addWidget: (widget) =>
+        set((s) => ({ widgets: [...s.widgets, widget], isDirty: true })),
+      updateWidget: (id, patch) =>
+        set((s) => {
+          const exists = s.widgets.some((w) => w.id === id);
+          if (!exists) return s;
+          return {
+            widgets: s.widgets.map((w) =>
+              w.id === id ? { ...w, ...patch, id: w.id } : w,
+            ),
+            isDirty: true,
+          };
+        }),
+      removeWidget: (id) =>
+        set((s) => ({
+          widgets: s.widgets.filter((w) => w.id !== id),
+          isDirty: true,
+        })),
+      moveWidget: (id, toIndex) =>
+        set((s) => {
+          const from = s.widgets.findIndex((w) => w.id === id);
+          if (from < 0) return s;
+          const target = Math.max(0, Math.min(s.widgets.length - 1, toIndex));
+          if (target === from) return s;
+          const widgets = [...s.widgets];
+          const [moved] = widgets.splice(from, 1);
+          widgets.splice(target, 0, moved);
+          return { widgets, isDirty: true };
+        }),
 
       setStorymap: (storymap) => set({ storymap, isDirty: true }),
       updateStorymapSettings: (patch) =>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -543,6 +543,11 @@ export interface ProcessingModel {
   steps: ProcessingModelStep[];
 }
 
+/** Column-count bounds for the Dashboard panel's widget grid. */
+export const MIN_DASHBOARD_COLUMNS = 1;
+export const MAX_DASHBOARD_COLUMNS = 4;
+export const DEFAULT_DASHBOARD_COLUMNS = 2;
+
 /** The chart a {@link DashboardWidget} draws. Mirrors the attribute Charts
  * panel's types so a widget reuses the same rendering. */
 export type DashboardWidgetType =
@@ -550,7 +555,8 @@ export type DashboardWidgetType =
   | "scatter"
   | "bar"
   | "line"
-  | "box";
+  | "box"
+  | "pie";
 
 /** How a bar widget reduces its category groups. */
 export type DashboardWidgetAggregation = "count" | "sum" | "mean";
@@ -608,6 +614,8 @@ export interface GeoLibreProject {
   models?: ProcessingModel[];
   /** Saved Dashboard panel chart widgets (issue #401). */
   widgets?: DashboardWidget[];
+  /** Number of columns in the Dashboard widget grid; omitted when default. */
+  dashboardColumns?: number;
   metadata: Record<string, unknown>;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -545,7 +545,7 @@ export interface ProcessingModel {
 
 /** Column-count bounds for the Dashboard panel's widget grid. */
 export const MIN_DASHBOARD_COLUMNS = 1;
-export const MAX_DASHBOARD_COLUMNS = 4;
+export const MAX_DASHBOARD_COLUMNS = 6;
 export const DEFAULT_DASHBOARD_COLUMNS = 2;
 
 /** The chart a {@link DashboardWidget} draws. Mirrors the attribute Charts

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -543,6 +543,51 @@ export interface ProcessingModel {
   steps: ProcessingModelStep[];
 }
 
+/** The chart a {@link DashboardWidget} draws. Mirrors the attribute Charts
+ * panel's types so a widget reuses the same rendering. */
+export type DashboardWidgetType =
+  | "histogram"
+  | "scatter"
+  | "bar"
+  | "line"
+  | "box";
+
+/** How a bar widget reduces its category groups. */
+export type DashboardWidgetAggregation = "count" | "sum" | "mean";
+
+/**
+ * One chart in the Dashboard panel: a chart type bound to a layer and the
+ * field(s) it plots. Which `field*`/`category`/`aggregation` keys apply depends
+ * on `type` (histogram/line/box use `field`; scatter uses `xField`/`yField`;
+ * bar uses `category` + `aggregation` and, for sum/mean, `valueField`). Unused
+ * keys are simply ignored, so the record stays flat and easy to hand-edit.
+ * Saved in the project file so a dashboard reopens with its widgets intact.
+ */
+export interface DashboardWidget {
+  /** Stable id, unique within the project (React key and store key). */
+  id: string;
+  /** The layer whose features feed this widget. */
+  layerId: string;
+  /** The chart to draw. */
+  type: DashboardWidgetType;
+  /** Optional custom title; the panel derives a label from the fields if absent. */
+  title?: string;
+  /** Value field for histogram/line/box. */
+  field?: string;
+  /** X-axis field for scatter. */
+  xField?: string;
+  /** Y-axis field for scatter. */
+  yField?: string;
+  /** Number of bins for a histogram. */
+  bins?: number;
+  /** Category field for a bar chart. */
+  category?: string;
+  /** Aggregation for a bar chart (default `count`). */
+  aggregation?: DashboardWidgetAggregation;
+  /** Value field a bar chart's sum/mean reduces (ignored for `count`). */
+  valueField?: string;
+}
+
 export interface GeoLibreProject {
   version: string;
   name: string;
@@ -561,6 +606,8 @@ export interface GeoLibreProject {
   storymap?: StoryMap;
   /** Saved processing pipelines (batch/model chaining; issue #344). */
   models?: ProcessingModel[];
+  /** Saved Dashboard panel chart widgets (issue #401). */
+  widgets?: DashboardWidget[];
   metadata: Record<string, unknown>;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -578,6 +578,10 @@ export interface DashboardWidget {
   type: DashboardWidgetType;
   /** Optional custom title; the panel derives a label from the fields if absent. */
   title?: string;
+  /** Optional hex color (`#rgb`/`#rrggbb`) for the chart's marks. Single-series
+   * charts use it as the series color; bar/pie use it as the base of a
+   * monochromatic ramp. Defaults to the theme primary / multi-color palette. */
+  color?: string;
   /** Value field for histogram/line/box. */
   field?: string;
   /** X-axis field for scatter. */

--- a/tests/attribute-charts.test.ts
+++ b/tests/attribute-charts.test.ts
@@ -356,4 +356,21 @@ describe("computePie", () => {
       null,
     );
   });
+
+  it("renames the overflow slice when a real (other) category exists", () => {
+    const data = rows(
+      { kind: "(other)" },
+      { kind: "(other)" },
+      { kind: "a" },
+      { kind: "b" },
+      { kind: "c" },
+    );
+    // Cap at 2 slices: one real category plus the folded remainder. The real
+    // "(other)" category is the largest, so the fold must use a distinct label.
+    const result = computePie(data, "kind", "count", null, 2);
+    assert.ok(result);
+    const labels = result.slices.map((s) => s.label);
+    assert.equal(new Set(labels).size, labels.length); // no duplicate labels
+    assert.ok(labels.includes("(other categories)"));
+  });
 });

--- a/tests/attribute-charts.test.ts
+++ b/tests/attribute-charts.test.ts
@@ -6,6 +6,7 @@ import {
   computeBox,
   computeHistogram,
   computeLine,
+  computePie,
   computeScatter,
   formatAxisValue,
   numericColumns,
@@ -303,5 +304,56 @@ describe("formatAxisValue", () => {
     assert.equal(formatAxisValue(-0.0001), "-1.0e-4");
     // very large integers switch to exponential so labels stay short
     assert.equal(formatAxisValue(9007199254740991), "9.0e+15");
+  });
+});
+
+describe("computePie", () => {
+  it("counts rows per category and totals the whole", () => {
+    const data = rows(
+      { kind: "a" },
+      { kind: "a" },
+      { kind: "b" },
+      { kind: null },
+    );
+    const result = computePie(data, "kind", "count", null);
+    assert.ok(result);
+    assert.equal(result.total, 4);
+    assert.equal(result.slices.length, 3); // a, b, (blank)
+    assert.equal(result.slices[0].label, "a");
+    assert.equal(result.slices[0].value, 2);
+  });
+
+  it("sums a value field and keeps only positive contributions", () => {
+    const data = rows(
+      { kind: "a", amt: 10 },
+      { kind: "b", amt: -5 },
+      { kind: "c", amt: 0 },
+    );
+    const result = computePie(data, "kind", "sum", "amt");
+    assert.ok(result);
+    // Only "a" has a positive sum; non-positive slices are dropped.
+    assert.equal(result.slices.length, 1);
+    assert.equal(result.total, 10);
+  });
+
+  it("folds categories beyond the cap into an (other) slice", () => {
+    const data = rows(
+      ...Array.from({ length: 12 }, (_, i) => ({ kind: `k${i}` })),
+    );
+    const result = computePie(data, "kind", "count", null, 4);
+    assert.ok(result);
+    assert.equal(result.slices.length, 4);
+    assert.equal(result.slices[3].label, "(other)");
+    // 12 unique singletons; the top 3 are shown, the other 9 fold together.
+    assert.equal(result.otherCount, 9);
+    assert.equal(result.total, 12);
+  });
+
+  it("returns null when there is nothing positive to chart", () => {
+    assert.equal(computePie(rows(), "kind", "count", null), null);
+    assert.equal(
+      computePie(rows({ kind: "a", amt: -1 }), "kind", "sum", "amt"),
+      null,
+    );
   });
 });

--- a/tests/dashboard-widgets.test.ts
+++ b/tests/dashboard-widgets.test.ts
@@ -2,7 +2,9 @@ import assert from "node:assert/strict";
 import { beforeEach, describe, it } from "node:test";
 import {
   DEFAULT_BASEMAP,
+  DEFAULT_DASHBOARD_COLUMNS,
   createEmptyProject,
+  normalizeDashboardColumns,
   normalizeWidgets,
   parseProject,
   projectFromStore,
@@ -47,7 +49,7 @@ describe("normalizeWidgets", () => {
     const result = normalizeWidgets([
       { id: "", layerId: "a", type: "bar" },
       { id: "x", layerId: "", type: "bar" },
-      { id: "y", layerId: "a", type: "pie" },
+      { id: "y", layerId: "a", type: "donut" },
       widget({ id: "good", layerId: "a", type: "box", field: "pop" }),
     ] as never);
     assert.deepEqual(
@@ -109,6 +111,28 @@ describe("widgets in the project file", () => {
     assert.deepEqual(reparsed.widgets, widgets);
   });
 
+  it("persists a non-default column count and omits the default", () => {
+    const base = {
+      projectName: "Widgets",
+      mapView: { center: [0, 0] as [number, number], zoom: 2, bearing: 0, pitch: 0 },
+      basemapStyleUrl: DEFAULT_BASEMAP,
+      basemapVisible: true,
+      basemapOpacity: 1,
+      layers: [],
+      preferences: createEmptyProject().preferences,
+      metadata: {},
+    };
+    const custom = projectFromStore({ ...base, dashboardColumns: 3 });
+    assert.equal(custom.dashboardColumns, 3);
+    assert.equal(parseProject(serializeProject(custom)).dashboardColumns, 3);
+
+    const defaulted = projectFromStore({
+      ...base,
+      dashboardColumns: DEFAULT_DASHBOARD_COLUMNS,
+    });
+    assert.equal("dashboardColumns" in defaulted, false);
+  });
+
   it("omits the widgets key when none are valid", () => {
     const project = projectFromStore({
       projectName: "Widgets",
@@ -122,6 +146,17 @@ describe("widgets in the project file", () => {
       metadata: {},
     });
     assert.equal("widgets" in project, false);
+  });
+});
+
+describe("normalizeDashboardColumns", () => {
+  it("clamps into range and falls back to the default", () => {
+    assert.equal(normalizeDashboardColumns(3), 3);
+    assert.equal(normalizeDashboardColumns(0), 1);
+    assert.equal(normalizeDashboardColumns(99), 4);
+    assert.equal(normalizeDashboardColumns(2.9), 2);
+    assert.equal(normalizeDashboardColumns(undefined), DEFAULT_DASHBOARD_COLUMNS);
+    assert.equal(normalizeDashboardColumns("x"), DEFAULT_DASHBOARD_COLUMNS);
   });
 });
 
@@ -169,6 +204,15 @@ describe("app store widget actions", () => {
       ["a"],
     );
   });
+
+  it("clamps the dashboard column count", () => {
+    useAppStore.getState().setDashboardColumns(3);
+    assert.equal(useAppStore.getState().dashboardColumns, 3);
+    useAppStore.getState().setDashboardColumns(99);
+    assert.equal(useAppStore.getState().dashboardColumns, 4);
+    useAppStore.getState().setDashboardColumns(0);
+    assert.equal(useAppStore.getState().dashboardColumns, 1);
+  });
 });
 
 describe("computeChart", () => {
@@ -194,6 +238,19 @@ describe("computeChart", () => {
     assert.equal(result.type, "bar");
     if (result.type === "bar") {
       assert.equal(result.result?.bars.length, 2);
+    }
+  });
+
+  it("dispatches a pie of category shares that sum to the whole", () => {
+    const result = computeChart(rows, {
+      type: "pie",
+      category: "kind",
+      aggregation: "count",
+    });
+    assert.equal(result.type, "pie");
+    if (result.type === "pie") {
+      assert.equal(result.result?.total, 3);
+      assert.equal(result.result?.slices.length, 2);
     }
   });
 

--- a/tests/dashboard-widgets.test.ts
+++ b/tests/dashboard-widgets.test.ts
@@ -1,0 +1,204 @@
+import assert from "node:assert/strict";
+import { beforeEach, describe, it } from "node:test";
+import {
+  DEFAULT_BASEMAP,
+  createEmptyProject,
+  normalizeWidgets,
+  parseProject,
+  projectFromStore,
+  serializeProject,
+  useAppStore,
+  type DashboardWidget,
+} from "@geolibre/core";
+import {
+  computeChart,
+  chartResultHasData,
+} from "../apps/geolibre-desktop/src/components/panels/charts/chart-spec";
+import type { ChartRow } from "../apps/geolibre-desktop/src/lib/attribute-charts";
+
+function widget(patch: Partial<DashboardWidget> = {}): DashboardWidget {
+  return {
+    id: "w1",
+    layerId: "layer-a",
+    type: "histogram",
+    field: "pop",
+    bins: 10,
+    ...patch,
+  };
+}
+
+describe("normalizeWidgets", () => {
+  it("keeps a valid widget with all of its options", () => {
+    const widgets: DashboardWidget[] = [
+      {
+        id: "bar-1",
+        layerId: "layer-a",
+        type: "bar",
+        category: "kind",
+        aggregation: "sum",
+        valueField: "pop",
+        title: "By kind",
+      },
+    ];
+    assert.deepEqual(normalizeWidgets(widgets), widgets);
+  });
+
+  it("drops widgets without an id, layer id, or known type", () => {
+    const result = normalizeWidgets([
+      { id: "", layerId: "a", type: "bar" },
+      { id: "x", layerId: "", type: "bar" },
+      { id: "y", layerId: "a", type: "pie" },
+      widget({ id: "good", layerId: "a", type: "box", field: "pop" }),
+    ] as never);
+    assert.deepEqual(
+      result?.map((w) => w.id),
+      ["good"],
+    );
+  });
+
+  it("de-duplicates widgets by id, keeping the first", () => {
+    const result = normalizeWidgets([
+      widget({ id: "dup", title: "first" }),
+      widget({ id: "dup", title: "second" }),
+    ]);
+    assert.equal(result?.length, 1);
+    assert.equal(result?.[0].title, "first");
+  });
+
+  it("coerces bins to an integer and drops a bad aggregation", () => {
+    const result = normalizeWidgets([
+      { id: "a", layerId: "l", type: "histogram", field: "pop", bins: 7.9 },
+      {
+        id: "b",
+        layerId: "l",
+        type: "bar",
+        category: "kind",
+        aggregation: "median",
+      },
+    ] as never);
+    assert.equal(result?.[0].bins, 7);
+    assert.equal("aggregation" in (result?.[1] ?? {}), false);
+  });
+
+  it("returns null for a non-array or an all-invalid list", () => {
+    assert.equal(normalizeWidgets(undefined), null);
+    assert.equal(normalizeWidgets("nope"), null);
+    assert.equal(normalizeWidgets([{ id: "", layerId: "" }] as never), null);
+  });
+});
+
+describe("widgets in the project file", () => {
+  it("round-trips through projectFromStore and parseProject", () => {
+    const widgets: DashboardWidget[] = [
+      { id: "w1", layerId: "layer-a", type: "histogram", field: "pop", bins: 12 },
+      { id: "w2", layerId: "layer-a", type: "scatter", xField: "pop", yField: "area" },
+    ];
+    const project = projectFromStore({
+      projectName: "Widgets",
+      mapView: { center: [0, 0], zoom: 2, bearing: 0, pitch: 0 },
+      basemapStyleUrl: DEFAULT_BASEMAP,
+      basemapVisible: true,
+      basemapOpacity: 1,
+      layers: [],
+      preferences: createEmptyProject().preferences,
+      widgets,
+      metadata: {},
+    });
+    assert.deepEqual(project.widgets, widgets);
+    const reparsed = parseProject(serializeProject(project));
+    assert.deepEqual(reparsed.widgets, widgets);
+  });
+
+  it("omits the widgets key when none are valid", () => {
+    const project = projectFromStore({
+      projectName: "Widgets",
+      mapView: { center: [0, 0], zoom: 2, bearing: 0, pitch: 0 },
+      basemapStyleUrl: DEFAULT_BASEMAP,
+      basemapVisible: true,
+      basemapOpacity: 1,
+      layers: [],
+      preferences: createEmptyProject().preferences,
+      widgets: [{ id: "", layerId: "", type: "bar" }] as never,
+      metadata: {},
+    });
+    assert.equal("widgets" in project, false);
+  });
+});
+
+describe("app store widget actions", () => {
+  beforeEach(() => {
+    useAppStore.getState().newProject({ name: "Test Project" });
+  });
+
+  it("adds, updates, moves, and removes widgets", () => {
+    const store = useAppStore.getState();
+    store.addWidget(widget({ id: "a" }));
+    store.addWidget(widget({ id: "b", type: "box", field: "area" }));
+    assert.deepEqual(
+      useAppStore.getState().widgets.map((w) => w.id),
+      ["a", "b"],
+    );
+    assert.equal(useAppStore.getState().isDirty, true);
+
+    useAppStore.getState().updateWidget("a", { title: "Renamed", bins: 20 });
+    const a = useAppStore.getState().widgets.find((w) => w.id === "a");
+    assert.equal(a?.title, "Renamed");
+    assert.equal(a?.bins, 20);
+    assert.equal(a?.id, "a");
+
+    // Move "b" to the front; clamps and reorders.
+    useAppStore.getState().moveWidget("b", 0);
+    assert.deepEqual(
+      useAppStore.getState().widgets.map((w) => w.id),
+      ["b", "a"],
+    );
+
+    useAppStore.getState().removeWidget("a");
+    assert.deepEqual(
+      useAppStore.getState().widgets.map((w) => w.id),
+      ["b"],
+    );
+  });
+
+  it("ignores updates and moves for an unknown widget id", () => {
+    useAppStore.getState().addWidget(widget({ id: "a" }));
+    useAppStore.getState().updateWidget("missing", { title: "x" });
+    useAppStore.getState().moveWidget("missing", 3);
+    assert.deepEqual(
+      useAppStore.getState().widgets.map((w) => w.id),
+      ["a"],
+    );
+  });
+});
+
+describe("computeChart", () => {
+  const rows: ChartRow[] = [
+    { properties: { pop: 10, kind: "a" } },
+    { properties: { pop: 20, kind: "a" } },
+    { properties: { pop: 30, kind: "b" } },
+  ];
+
+  it("dispatches a histogram and reports it has data", () => {
+    const result = computeChart(rows, { type: "histogram", field: "pop", bins: 4 });
+    assert.equal(result.type, "histogram");
+    assert.ok(chartResultHasData(result));
+    if (result.type === "histogram") assert.equal(result.result?.total, 3);
+  });
+
+  it("dispatches a bar count grouped by a category", () => {
+    const result = computeChart(rows, {
+      type: "bar",
+      category: "kind",
+      aggregation: "count",
+    });
+    assert.equal(result.type, "bar");
+    if (result.type === "bar") {
+      assert.equal(result.result?.bars.length, 2);
+    }
+  });
+
+  it("returns an empty result when the required field is missing", () => {
+    const result = computeChart(rows, { type: "histogram" });
+    assert.equal(chartResultHasData(result), false);
+  });
+});

--- a/tests/dashboard-widgets.test.ts
+++ b/tests/dashboard-widgets.test.ts
@@ -16,6 +16,12 @@ import {
   computeChart,
   chartResultHasData,
 } from "../apps/geolibre-desktop/src/components/panels/charts/chart-spec";
+import {
+  CHART_PALETTE,
+  categoryColors,
+  isHexColor,
+  shadeRamp,
+} from "../apps/geolibre-desktop/src/components/panels/charts/chart-colors";
 import type { ChartRow } from "../apps/geolibre-desktop/src/lib/attribute-charts";
 
 function widget(patch: Partial<DashboardWidget> = {}): DashboardWidget {
@@ -65,6 +71,17 @@ describe("normalizeWidgets", () => {
     ]);
     assert.equal(result?.length, 1);
     assert.equal(result?.[0].title, "first");
+  });
+
+  it("keeps a valid hex color and drops an invalid one", () => {
+    const result = normalizeWidgets([
+      widget({ id: "a", color: "#ff0000" }),
+      widget({ id: "b", color: "red" }),
+      widget({ id: "c", color: "#abc" }),
+    ]);
+    assert.equal(result?.find((w) => w.id === "a")?.color, "#ff0000");
+    assert.equal("color" in (result?.find((w) => w.id === "b") ?? {}), false);
+    assert.equal(result?.find((w) => w.id === "c")?.color, "#abc");
   });
 
   it("coerces bins to an integer and drops a bad aggregation", () => {
@@ -146,6 +163,32 @@ describe("widgets in the project file", () => {
       metadata: {},
     });
     assert.equal("widgets" in project, false);
+  });
+});
+
+describe("chart colors", () => {
+  it("recognizes hex colors and rejects other strings", () => {
+    assert.equal(isHexColor("#fff"), true);
+    assert.equal(isHexColor("#3fb1ce"), true);
+    assert.equal(isHexColor("blue"), false);
+    assert.equal(isHexColor("#12"), false);
+    assert.equal(isHexColor(undefined), false);
+  });
+
+  it("builds a ramp that starts at the base and lightens", () => {
+    const ramp = shadeRamp("#000000", 3);
+    assert.equal(ramp.length, 3);
+    assert.equal(ramp[0], "#000000");
+    // Later shades are lighter than the base.
+    assert.notEqual(ramp[2], "#000000");
+  });
+
+  it("falls back to the palette when no valid color is given", () => {
+    const palette = categoryColors(undefined, 3);
+    assert.deepEqual(palette, CHART_PALETTE.slice(0, 3));
+    const ramp = categoryColors("#3fb1ce", 4);
+    assert.equal(ramp.length, 4);
+    assert.equal(ramp[0], "#3fb1ce");
   });
 });
 

--- a/tests/dashboard-widgets.test.ts
+++ b/tests/dashboard-widgets.test.ts
@@ -99,6 +99,24 @@ describe("normalizeWidgets", () => {
     assert.equal("aggregation" in (result?.[1] ?? {}), false);
   });
 
+  it("drops a non-positive bin count and caps a huge one", () => {
+    const result = normalizeWidgets([
+      { id: "a", layerId: "l", type: "histogram", field: "pop", bins: 0 },
+      { id: "b", layerId: "l", type: "histogram", field: "pop", bins: 999 },
+    ] as never);
+    assert.equal("bins" in (result?.find((w) => w.id === "a") ?? {}), false);
+    assert.equal(result?.find((w) => w.id === "b")?.bins, 50);
+  });
+
+  it("drops a mean aggregation on a pie widget", () => {
+    const result = normalizeWidgets([
+      { id: "p", layerId: "l", type: "pie", category: "kind", aggregation: "mean" },
+      { id: "b", layerId: "l", type: "bar", category: "kind", aggregation: "mean" },
+    ] as never);
+    assert.equal("aggregation" in (result?.find((w) => w.id === "p") ?? {}), false);
+    assert.equal(result?.find((w) => w.id === "b")?.aggregation, "mean");
+  });
+
   it("returns null for a non-array or an all-invalid list", () => {
     assert.equal(normalizeWidgets(undefined), null);
     assert.equal(normalizeWidgets("nope"), null);
@@ -238,6 +256,14 @@ describe("app store widget actions", () => {
     );
   });
 
+  it("ignores a duplicate widget id in addWidget", () => {
+    useAppStore.getState().addWidget(widget({ id: "a", title: "first" }));
+    useAppStore.getState().addWidget(widget({ id: "a", title: "second" }));
+    const widgets = useAppStore.getState().widgets;
+    assert.equal(widgets.length, 1);
+    assert.equal(widgets[0].title, "first");
+  });
+
   it("ignores updates and moves for an unknown widget id", () => {
     useAppStore.getState().addWidget(widget({ id: "a" }));
     useAppStore.getState().updateWidget("missing", { title: "x" });
@@ -254,6 +280,9 @@ describe("app store widget actions", () => {
     useAppStore.getState().setDashboardColumns(99);
     assert.equal(useAppStore.getState().dashboardColumns, 6);
     useAppStore.getState().setDashboardColumns(0);
+    assert.equal(useAppStore.getState().dashboardColumns, 1);
+    // Non-finite input is ignored, leaving the last valid value intact.
+    useAppStore.getState().setDashboardColumns(Number.NaN);
     assert.equal(useAppStore.getState().dashboardColumns, 1);
   });
 });

--- a/tests/dashboard-widgets.test.ts
+++ b/tests/dashboard-widgets.test.ts
@@ -153,7 +153,7 @@ describe("normalizeDashboardColumns", () => {
   it("clamps into range and falls back to the default", () => {
     assert.equal(normalizeDashboardColumns(3), 3);
     assert.equal(normalizeDashboardColumns(0), 1);
-    assert.equal(normalizeDashboardColumns(99), 4);
+    assert.equal(normalizeDashboardColumns(99), 6);
     assert.equal(normalizeDashboardColumns(2.9), 2);
     assert.equal(normalizeDashboardColumns(undefined), DEFAULT_DASHBOARD_COLUMNS);
     assert.equal(normalizeDashboardColumns("x"), DEFAULT_DASHBOARD_COLUMNS);
@@ -209,7 +209,7 @@ describe("app store widget actions", () => {
     useAppStore.getState().setDashboardColumns(3);
     assert.equal(useAppStore.getState().dashboardColumns, 3);
     useAppStore.getState().setDashboardColumns(99);
-    assert.equal(useAppStore.getState().dashboardColumns, 4);
+    assert.equal(useAppStore.getState().dashboardColumns, 6);
     useAppStore.getState().setDashboardColumns(0);
     assert.equal(useAppStore.getState().dashboardColumns, 1);
   });


### PR DESCRIPTION
## Summary

Implements the **charts/widgets** request in #401 (the column explorer, the issue's other item, shipped in #402). Adds a CARTO Builder / Foursquare Studio style **Dashboard** panel: a bottom-docked, resizable strip of chart widgets, each bound to a layer and its field(s), saved in the project so a dashboard reopens intact.

Open it from **Tools → Dashboard**, then **Add widget** to pick a layer, a chart type (histogram / scatter / bar / line / box), and the field(s) to plot. Widgets can be retitled, reordered, edited, and removed.

## What's included

- **Core schema/store**: new `DashboardWidget` type + `GeoLibreProject.widgets`, a `normalizeWidgets` hardening boundary, and a `widgets` store slice (`addWidget`/`updateWidget`/`removeWidget`/`moveWidget`) plus `ui.dashboardOpen`. Mirrors the existing `models` precedent: persisted in the project, dirty-tracked, not part of undo history.
- **Reused charting**: factored the SVG chart rendering out of `AttributeChartDialog` into a reusable `ChartView` (`chart-view.tsx`) over a pure `ChartSpec` / `computeChart` dispatch (`chart-spec.ts`), shared by the dialog and the dashboard. **No new charting dependency** — reuses the existing histogram/scatter/bar/line/box math.
- **Desktop UI**: `DashboardPanel` + `WidgetEditorDialog` + a `useLayerChartData` hook (handles GeoJSON-backed and DuckDB query layers), wired into `DesktopShell` and the Tools menu, with widgets serialized in both project-snapshot paths (save and collaboration/embed).
- **i18n**: new `dashboard.*` catalog in `en.json` and `toolbar.command.dashboard`.
- **Docs**: documented the `widgets` section in `docs/project-format.md`.

## Scope

Cross-filtering the map from a widget (clicking a bar to filter features) is intentionally **out of scope** for this first pass — widgets are read-only summaries. It is a natural follow-up once a multi-feature selection/filter state exists.

## Testing

- New `tests/dashboard-widgets.test.ts`: `normalizeWidgets`, project round-trip through `projectFromStore`/`parseProject`, store actions, and `computeChart` dispatch.
- Full frontend suite green (987 pass), `npm run typecheck`/build green, worker typecheck green, pre-commit (eslint + build) clean on changed files.

Closes #401.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Dashboard panel for creating and managing customizable chart widgets, including **pie** charts.
  * Added a Widget Editor dialog to configure widget chart type, layer fields, aggregations, optional value settings, and titles.
  * Widgets now support add/edit/remove, reordering, and bottom resizing with configurable dashboard column count.
  * Added quick access to the Dashboard from the **Processing** menu and the **Attribute table** header.
* **Bug Fixes**
  * Improved dashboard/chart rendering behavior with safer loading and centralized chart computation.
* **Documentation**
  * Updated project format documentation to include dashboard widgets schema and dashboard column configuration.
* **Tests**
  * Added unit tests covering widget normalization, persistence, dashboard column clamping, and pie chart computation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->