### PR TITLE
feat(raster): reverse + custom ramps, and the full colormap list (maplibre-gl-raster 0.3.0)

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -70,7 +70,7 @@
     "maplibre-gl-nasa-earthdata": "^0.1.2",
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.2.4",
+    "maplibre-gl-raster": "^0.3.0",
     "maplibre-gl-streetview": "^0.6.0",
     "maplibre-gl-swipe": "^0.7.1",
     "maplibre-gl-time-slider": "^1.0.3",

--- a/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
+++ b/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
@@ -19,6 +19,7 @@ import {
 import { Input, Label, Select, Separator, Textarea } from "@geolibre/ui";
 import { COLORMAP_OPTIONS } from "maplibre-gl-raster";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 
 type RasterStateRecord = {
   mode: "single" | "rgb";
@@ -56,6 +57,17 @@ const SORTED_COLORMAPS = [...COLORMAP_OPTIONS].sort((a, b) =>
   a.label.localeCompare(b.label, "en", { sensitivity: "base" }),
 );
 
+/** True when a pre-migration project stored `reversed` on rasterSymbology. */
+function legacyReversed(layer: GeoLibreLayer): boolean {
+  const sym = layer.metadata.rasterSymbology;
+  return (
+    typeof sym === "object" &&
+    sym !== null &&
+    !Array.isArray(sym) &&
+    (sym as Record<string, unknown>).reversed === true
+  );
+}
+
 function readRasterState(layer: GeoLibreLayer): RasterStateRecord {
   const raw =
     layer.metadata.rasterState &&
@@ -77,7 +89,9 @@ function readRasterState(layer: GeoLibreLayer): RasterStateRecord {
     mode: raw.mode === "rgb" ? "rgb" : "single",
     bands: bands.length > 0 ? bands : [1],
     colormap: typeof raw.colormap === "string" ? raw.colormap : DEFAULT_RAMP,
-    reversed: raw.reversed === true,
+    // Reverse lives on rasterState now; migrate projects saved before that move
+    // (the flag used to live on rasterSymbology) so they keep their reversal.
+    reversed: raw.reversed === true || legacyReversed(layer),
     rescale,
     nodata:
       raw.nodata === "off" || typeof raw.nodata === "number"
@@ -127,6 +141,7 @@ function rangeFromBreaks(breaks: number[]): [number, number][] {
  * @param props.layer - The selected raster store layer.
  */
 export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
+  const { t } = useTranslation();
   const updateLayer = useAppStore((s) => s.updateLayer);
   const state = readRasterState(layer);
   const bandCount = readBandCount(layer);
@@ -449,7 +464,9 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
               {colormap.label}
             </option>
           ))}
-          <option value={CUSTOM_RAMP_VALUE}>Custom…</option>
+          <option value={CUSTOM_RAMP_VALUE}>
+            {t("rasterSymbology.customRamp")}
+          </option>
         </Select>
         <div
           aria-hidden="true"
@@ -476,7 +493,7 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
           checked={reversed}
           onChange={(event) => setReversed(event.target.checked)}
         />
-        Reverse ramp
+        {t("rasterSymbology.reverseRamp")}
       </label>
 
       <label className="flex items-center gap-2 text-xs">
@@ -814,6 +831,7 @@ function CustomColorsField({
   colors: string[];
   onCommit: (colors: string[]) => void;
 }) {
+  const { t } = useTranslation();
   // `colors` is a fresh array each parent render (savedRasterSymbology rebuilds
   // it), so sync the draft off its content, not its reference -- otherwise an
   // unrelated re-render (e.g. band stats loading) would wipe what the user is
@@ -828,7 +846,7 @@ function CustomColorsField({
   return (
     <div className="space-y-1">
       <Label htmlFor="rasterCustomColors" className="text-xs">
-        Custom colors
+        {t("rasterSymbology.customColors")}
       </Label>
       <Textarea
         id="rasterCustomColors"
@@ -844,8 +862,8 @@ function CustomColorsField({
       />
       <p className="text-[10px] text-muted-foreground">
         {valid
-          ? `${parsed.length} colors, low to high. Use Reverse to flip.`
-          : "Enter at least two hex codes, separated by commas or spaces."}
+          ? t("rasterSymbology.customColorsValid", { count: parsed.length })
+          : t("rasterSymbology.customColorsHint")}
       </p>
     </div>
   );

--- a/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
+++ b/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
@@ -1,7 +1,5 @@
 import {
   type GeoLibreLayer,
-  VECTOR_COLOR_RAMPS,
-  getVectorColorRamp,
   parseHexColorList,
   useAppStore,
 } from "@geolibre/core";
@@ -11,11 +9,14 @@ import {
   type RasterBandStats,
   type RasterClassificationMethod,
   type RasterSymbology,
+  colormapColors,
   computeRasterBreaks,
   getRasterBandStats,
   savedRasterSymbology,
+  warmColormapColors,
 } from "@geolibre/plugins";
 import { Input, Label, Select, Separator, Textarea } from "@geolibre/ui";
+import { COLORMAP_OPTIONS } from "maplibre-gl-raster";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 type RasterStateRecord = {
@@ -44,11 +45,12 @@ const CUSTOM_RAMP_VALUE = "__custom__";
 /** A custom ramp needs at least this many colors to interpolate. */
 const MIN_CUSTOM_COLORS = 2;
 /**
- * Named ramps sorted by label for the dropdown. A copy is sorted (not the
- * source array) so `getVectorColorRamp`'s first-ramp fallback stays viridis.
+ * Every renderer colormap (the same list the maplibre-gl-raster panel offers),
+ * sorted by display label for the dropdown. Labels use matplotlib casing
+ * (RdBu, YlOrBr, …); the value is the lowercase colormap key.
  */
-const SORTED_COLOR_RAMPS = [...VECTOR_COLOR_RAMPS].sort((a, b) =>
-  a.label.localeCompare(b.label),
+const SORTED_COLORMAPS = [...COLORMAP_OPTIONS].sort((a, b) =>
+  a.label.toLowerCase().localeCompare(b.label.toLowerCase()),
 );
 
 function readRasterState(layer: GeoLibreLayer): RasterStateRecord {
@@ -176,6 +178,38 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
     });
   }, [bandCount, bandNames]);
 
+  // Colors for the ramp preview gradient. Custom ramps use their own colors;
+  // built-in ramps resolve synchronously; other (sprite) colormaps are sampled
+  // from the renderer's sprite asynchronously and cached. Declared here (before
+  // the RGB early return) so the hook order stays stable.
+  const previewRamp = symbology?.ramp ?? state.colormap ?? DEFAULT_RAMP;
+  const previewCustom =
+    (symbology?.customColors?.length ?? 0) >= MIN_CUSTOM_COLORS
+      ? (symbology?.customColors as string[])
+      : null;
+  const [rampPreview, setRampPreview] = useState<readonly string[]>([]);
+  const previewCustomKey = previewCustom?.join(",") ?? "";
+  useEffect(() => {
+    if (previewCustom) {
+      setRampPreview(previewCustom);
+      return;
+    }
+    const known = colormapColors(previewRamp);
+    if (known) {
+      setRampPreview(known);
+      return;
+    }
+    let cancelled = false;
+    void warmColormapColors(previewRamp).then((colors) => {
+      if (!cancelled && colors) setRampPreview(colors);
+    });
+    return () => {
+      cancelled = true;
+    };
+    // previewCustomKey captures the custom-colors identity for the deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [previewRamp, previewCustomKey]);
+
   function commit(options: {
     statePatch?: Partial<RasterStateRecord>;
     symbology?: RasterSymbology | null;
@@ -282,12 +316,9 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
   const reversed = symbology?.reversed ?? false;
   const customColors = symbology?.customColors;
   const isCustom = (customColors?.length ?? 0) >= MIN_CUSTOM_COLORS;
-  // A custom ramp interpolates the user's colors; otherwise the named ramp's
-  // anchors. The preview mirrors the reverse toggle either way.
-  const baseColors = isCustom
-    ? (customColors as string[])
-    : getVectorColorRamp(ramp).colors;
-  const orderedPreview = reversed ? [...baseColors].reverse() : baseColors;
+  // rampPreview (resolved above) holds the ramp's colors; mirror the reverse
+  // toggle for the preview gradient.
+  const orderedPreview = reversed ? [...rampPreview].reverse() : rampPreview;
   const rampSelectValue = isCustom ? CUSTOM_RAMP_VALUE : ramp;
 
   // Reverse and custom colors are GeoLibre extensions the upstream control
@@ -407,24 +438,32 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
           onChange={(event) => {
             const value = event.target.value;
             if (value === CUSTOM_RAMP_VALUE) {
-              // Seed the editable list from the current named ramp's anchors so
-              // the user starts from a sensible, valid (>= 2 color) ramp.
-              setCustomColors([...getVectorColorRamp(ramp).colors]);
+              // Seed the editable list from the current ramp's resolved colors
+              // so the user starts from a sensible, valid (>= 2 color) ramp.
+              const seed = colormapColors(ramp) ?? rampPreview;
+              if (seed.length >= MIN_CUSTOM_COLORS) {
+                setCustomColors([...seed]);
+              } else {
+                void warmColormapColors(ramp).then((colors) => {
+                  if (colors && colors.length >= MIN_CUSTOM_COLORS) {
+                    setCustomColors([...colors]);
+                  }
+                });
+              }
             } else {
               selectNamedRamp(value);
             }
           }}
         >
-          {/* A raster may arrive with any upstream colormap name (e.g. the
-              control's "gray"/"palette" default); surface it so the select
-              reflects what is actually rendered instead of silently showing
-              the first ramp. */}
-          {!isCustom && !VECTOR_COLOR_RAMPS.some((r) => r.value === ramp) && (
+          {/* A raster may arrive with a colormap name not in the list (e.g. the
+              control's "palette" default); surface it so the select reflects
+              what is actually rendered instead of silently showing the first. */}
+          {!isCustom && !COLORMAP_OPTIONS.some((o) => o.name === ramp) && (
             <option value={ramp}>{ramp}</option>
           )}
-          {SORTED_COLOR_RAMPS.map((colorRamp) => (
-            <option key={colorRamp.value} value={colorRamp.value}>
-              {colorRamp.label}
+          {SORTED_COLORMAPS.map((colormap) => (
+            <option key={colormap.name} value={colormap.name}>
+              {colormap.label}
             </option>
           ))}
           <option value={CUSTOM_RAMP_VALUE}>Custom…</option>
@@ -433,7 +472,11 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
           aria-hidden="true"
           className="h-4 rounded-sm border"
           style={{
-            background: `linear-gradient(90deg, ${orderedPreview.join(", ")})`,
+            // Empty while a sprite colormap is still being sampled.
+            background:
+              orderedPreview.length >= 2
+                ? `linear-gradient(90deg, ${orderedPreview.join(", ")})`
+                : undefined,
           }}
         />
         {isCustom && (

--- a/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
+++ b/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
@@ -2,6 +2,7 @@ import {
   type GeoLibreLayer,
   VECTOR_COLOR_RAMPS,
   getVectorColorRamp,
+  parseHexColorList,
   useAppStore,
 } from "@geolibre/core";
 import {
@@ -14,7 +15,7 @@ import {
   getRasterBandStats,
   savedRasterSymbology,
 } from "@geolibre/plugins";
-import { Input, Label, Select, Separator } from "@geolibre/ui";
+import { Input, Label, Select, Separator, Textarea } from "@geolibre/ui";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 type RasterStateRecord = {
@@ -38,6 +39,17 @@ const CLASSIFICATION_METHODS: {
 
 const DEFAULT_RAMP = "viridis";
 const DEFAULT_CLASS_COUNT = 5;
+/** Sentinel `<Select>` value that switches the ramp to a user-defined list. */
+const CUSTOM_RAMP_VALUE = "__custom__";
+/** A custom ramp needs at least this many colors to interpolate. */
+const MIN_CUSTOM_COLORS = 2;
+/**
+ * Named ramps sorted by label for the dropdown. A copy is sorted (not the
+ * source array) so `getVectorColorRamp`'s first-ramp fallback stays viridis.
+ */
+const SORTED_COLOR_RAMPS = [...VECTOR_COLOR_RAMPS].sort((a, b) =>
+  a.label.localeCompare(b.label),
+);
 
 function readRasterState(layer: GeoLibreLayer): RasterStateRecord {
   const raw =
@@ -181,7 +193,10 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
   }
 
   function recomputeSymbology(
-    next: Pick<RasterSymbology, "ramp" | "reversed" | "method" | "classCount">,
+    next: Pick<
+      RasterSymbology,
+      "ramp" | "reversed" | "method" | "classCount" | "customColors"
+    >,
     overrides: { range?: [number, number]; manualBreaks?: number[] } = {},
   ): void {
     // Reusing the prior histogram here is safe: a range override only happens
@@ -196,9 +211,21 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
       next.classCount,
       overrides.manualBreaks ?? symbology?.breaks,
     );
+    const custom =
+      (next.customColors?.length ?? 0) >= MIN_CUSTOM_COLORS
+        ? next.customColors
+        : undefined;
     commit({
       statePatch: { colormap: next.ramp, rescale: rangeFromBreaks(breaks) },
-      symbology: { classified: true, ...next, breaks },
+      symbology: {
+        classified: true,
+        ramp: next.ramp,
+        reversed: next.reversed,
+        method: next.method,
+        classCount: next.classCount,
+        breaks,
+        ...(custom ? { customColors: custom } : {}),
+      },
     });
   }
 
@@ -252,7 +279,97 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
   const classified = symbology?.classified ?? false;
   const classCount = symbology?.classCount ?? DEFAULT_CLASS_COUNT;
   const method = symbology?.method ?? "equal-interval";
-  const previewColors = getVectorColorRamp(ramp).colors;
+  const reversed = symbology?.reversed ?? false;
+  const customColors = symbology?.customColors;
+  const isCustom = (customColors?.length ?? 0) >= MIN_CUSTOM_COLORS;
+  // A custom ramp interpolates the user's colors; otherwise the named ramp's
+  // anchors. The preview mirrors the reverse toggle either way.
+  const baseColors = isCustom
+    ? (customColors as string[])
+    : getVectorColorRamp(ramp).colors;
+  const orderedPreview = reversed ? [...baseColors].reverse() : baseColors;
+  const rampSelectValue = isCustom ? CUSTOM_RAMP_VALUE : ramp;
+
+  // Reverse and custom colors are GeoLibre extensions the upstream control
+  // can't express; a continuous (unclassified) layer carries them in a
+  // classified:false record the render injection reads, or none at all when
+  // both are off (the plain upstream colormap renders on its own). Breaks are
+  // required by the record but unused while continuous, so seed them from
+  // whatever range is known.
+  function continuousSymbology(opts: {
+    ramp: string;
+    reversed: boolean;
+    customColors?: string[];
+  }): RasterSymbology | null {
+    const custom =
+      (opts.customColors?.length ?? 0) >= MIN_CUSTOM_COLORS
+        ? opts.customColors
+        : undefined;
+    if (!opts.reversed && !custom) return null;
+    return {
+      classified: false,
+      ramp: opts.ramp,
+      reversed: opts.reversed,
+      method,
+      classCount,
+      breaks: computeRasterBreaks(method, stats, classCount),
+      ...(custom ? { customColors: custom } : {}),
+    };
+  }
+
+  // Reverse applies to both render paths. Classified bakes the flip into the
+  // injected texture, so toggling only rewrites the symbology (breaks unchanged).
+  function setReversed(next: boolean): void {
+    if (classified && symbology) {
+      commit({ symbology: { ...symbology, reversed: next } });
+    } else {
+      commit({
+        symbology: continuousSymbology({ ramp, reversed: next, customColors }),
+      });
+    }
+  }
+
+  // Switch to / edit / clear a user-defined ramp. `next` is the parsed color
+  // list (>= 2 colors) or undefined to drop back to the named ramp.
+  function setCustomColors(next: string[] | undefined): void {
+    if (classified && symbology) {
+      recomputeSymbology({
+        ramp,
+        reversed,
+        method,
+        classCount,
+        customColors: next,
+      });
+    } else {
+      commit({
+        symbology: continuousSymbology({ ramp, reversed, customColors: next }),
+      });
+    }
+  }
+
+  // Select a built-in named ramp (clears any custom colors). Classified
+  // recomputes through the named ramp; continuous pushes the colormap to the
+  // control and keeps only the reverse extra (if any).
+  function selectNamedRamp(value: string): void {
+    if (classified && symbology) {
+      recomputeSymbology({
+        ramp: value,
+        reversed,
+        method,
+        classCount,
+        customColors: undefined,
+      });
+    } else {
+      commit({
+        statePatch: { colormap: value },
+        symbology: continuousSymbology({
+          ramp: value,
+          reversed,
+          customColors: undefined,
+        }),
+      });
+    }
+  }
 
   return (
     <div className="space-y-3">
@@ -286,13 +403,15 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
         <Label htmlFor="rasterRamp">Color ramp</Label>
         <Select
           id="rasterRamp"
-          value={ramp}
+          value={rampSelectValue}
           onChange={(event) => {
             const value = event.target.value;
-            if (classified && symbology) {
-              recomputeSymbology({ ...symbology, ramp: value });
+            if (value === CUSTOM_RAMP_VALUE) {
+              // Seed the editable list from the current named ramp's anchors so
+              // the user starts from a sensible, valid (>= 2 color) ramp.
+              setCustomColors([...getVectorColorRamp(ramp).colors]);
             } else {
-              commit({ statePatch: { colormap: value } });
+              selectNamedRamp(value);
             }
           }}
         >
@@ -300,23 +419,39 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
               control's "gray"/"palette" default); surface it so the select
               reflects what is actually rendered instead of silently showing
               the first ramp. */}
-          {!VECTOR_COLOR_RAMPS.some((r) => r.value === ramp) && (
+          {!isCustom && !VECTOR_COLOR_RAMPS.some((r) => r.value === ramp) && (
             <option value={ramp}>{ramp}</option>
           )}
-          {VECTOR_COLOR_RAMPS.map((colorRamp) => (
+          {SORTED_COLOR_RAMPS.map((colorRamp) => (
             <option key={colorRamp.value} value={colorRamp.value}>
               {colorRamp.label}
             </option>
           ))}
+          <option value={CUSTOM_RAMP_VALUE}>Custom…</option>
         </Select>
         <div
           aria-hidden="true"
           className="h-4 rounded-sm border"
           style={{
-            background: `linear-gradient(90deg, ${previewColors.join(", ")})`,
+            background: `linear-gradient(90deg, ${orderedPreview.join(", ")})`,
           }}
         />
+        {isCustom && (
+          <CustomColorsField
+            colors={customColors as string[]}
+            onCommit={(colors) => setCustomColors(colors)}
+          />
+        )}
       </div>
+
+      <label className="flex items-center gap-2 text-xs">
+        <input
+          type="checkbox"
+          checked={reversed}
+          onChange={(event) => setReversed(event.target.checked)}
+        />
+        Reverse ramp
+      </label>
 
       <label className="flex items-center gap-2 text-xs">
         <input
@@ -326,12 +461,16 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
             if (event.target.checked) {
               recomputeSymbology({
                 ramp,
-                reversed: symbology?.reversed ?? false,
+                reversed,
                 method,
                 classCount,
+                customColors,
               });
             } else {
-              commit({ symbology: null });
+              // Drop classification but keep any reversed / custom ramp extras.
+              commit({
+                symbology: continuousSymbology({ ramp, reversed, customColors }),
+              });
             }
           }}
         />
@@ -347,9 +486,6 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
           }
           onClassCount={(count) =>
             recomputeSymbology({ ...symbology, classCount: count })
-          }
-          onReversed={(reversed) =>
-            commit({ symbology: { ...symbology, reversed } })
           }
           onManualBreaks={(breaks) => {
             // Keep edges ascending: savedRasterSymbology rejects unsorted
@@ -463,7 +599,6 @@ function ClassificationControls({
   stats,
   onMethod,
   onClassCount,
-  onReversed,
   onManualBreaks,
   onRange,
 }: {
@@ -471,7 +606,6 @@ function ClassificationControls({
   stats: RasterBandStats | null;
   onMethod: (method: RasterClassificationMethod) => void;
   onClassCount: (count: number) => void;
-  onReversed: (reversed: boolean) => void;
   onManualBreaks: (breaks: number[]) => void;
   onRange: (range: [number, number]) => void;
 }) {
@@ -552,15 +686,6 @@ function ClassificationControls({
           ))}
         </div>
       )}
-
-      <label className="flex items-center gap-2 text-xs">
-        <input
-          type="checkbox"
-          checked={symbology.reversed}
-          onChange={(event) => onReversed(event.target.checked)}
-        />
-        Reverse ramp
-      </label>
 
       {symbology.method !== "manual" && !stats && (
         <p className="text-[10px] text-muted-foreground">
@@ -648,6 +773,53 @@ function NodataControl({
           onCommit={(value) => onChange(value)}
         />
       )}
+    </div>
+  );
+}
+
+/**
+ * Free-text editor for a user-defined color ramp: a list of hex codes parsed
+ * into the ramp's anchor colors. Edits are committed on blur, and only when
+ * they yield a usable ramp (>= 2 valid colors) so the layer never lands in an
+ * invalid state; an unusable draft is reverted to the last good list.
+ *
+ * @param props.colors - The current custom colors.
+ * @param props.onCommit - Receives the parsed colors when the draft is valid.
+ */
+function CustomColorsField({
+  colors,
+  onCommit,
+}: {
+  colors: string[];
+  onCommit: (colors: string[]) => void;
+}) {
+  const [draft, setDraft] = useState(colors.join(", "));
+  useEffect(() => {
+    setDraft(colors.join(", "));
+  }, [colors]);
+  const parsed = parseHexColorList(draft);
+  const valid = parsed.length >= MIN_CUSTOM_COLORS;
+  return (
+    <div className="space-y-1">
+      <Label htmlFor="rasterCustomColors" className="text-xs">
+        Custom colors
+      </Label>
+      <Textarea
+        id="rasterCustomColors"
+        rows={2}
+        value={draft}
+        placeholder="#440154, #21908c, #fde725"
+        onChange={(event) => setDraft(event.target.value)}
+        onBlur={() => {
+          if (valid) onCommit(parsed);
+          else setDraft(colors.join(", "));
+        }}
+      />
+      <p className="text-[10px] text-muted-foreground">
+        {valid
+          ? `${parsed.length} colors, low to high. Use Reverse to flip.`
+          : "Enter at least two hex codes, separated by commas or spaces."}
+      </p>
     </div>
   );
 }

--- a/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
+++ b/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
@@ -23,6 +23,7 @@ type RasterStateRecord = {
   mode: "single" | "rgb";
   bands: number[];
   colormap: string;
+  reversed: boolean;
   rescale: [number, number][] | null;
   nodata: number | "auto" | "off";
   stretch: "linear" | "log" | "sqrt";
@@ -74,6 +75,7 @@ function readRasterState(layer: GeoLibreLayer): RasterStateRecord {
     mode: raw.mode === "rgb" ? "rgb" : "single",
     bands: bands.length > 0 ? bands : [1],
     colormap: typeof raw.colormap === "string" ? raw.colormap : DEFAULT_RAMP,
+    reversed: raw.reversed === true,
     rescale,
     nodata:
       raw.nodata === "off" || typeof raw.nodata === "number"
@@ -229,7 +231,7 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
   function recomputeSymbology(
     next: Pick<
       RasterSymbology,
-      "ramp" | "reversed" | "method" | "classCount" | "customColors"
+      "ramp" | "method" | "classCount" | "customColors"
     >,
     overrides: { range?: [number, number]; manualBreaks?: number[] } = {},
   ): void {
@@ -254,7 +256,6 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
       symbology: {
         classified: true,
         ramp: next.ramp,
-        reversed: next.reversed,
         method: next.method,
         classCount: next.classCount,
         breaks,
@@ -313,7 +314,9 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
   const classified = symbology?.classified ?? false;
   const classCount = symbology?.classCount ?? DEFAULT_CLASS_COUNT;
   const method = symbology?.method ?? "equal-interval";
-  const reversed = symbology?.reversed ?? false;
+  // Reverse lives on rasterState: the control renders it for built-in
+  // colormaps, and the injected texture bakes it for classified / custom.
+  const reversed = state.reversed;
   const customColors = symbology?.customColors;
   const isCustom = (customColors?.length ?? 0) >= MIN_CUSTOM_COLORS;
   // rampPreview (resolved above) holds the ramp's colors; mirror the reverse
@@ -321,71 +324,54 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
   const orderedPreview = reversed ? [...rampPreview].reverse() : rampPreview;
   const rampSelectValue = isCustom ? CUSTOM_RAMP_VALUE : ramp;
 
-  // Reverse and custom colors are GeoLibre extensions the upstream control
-  // can't express; a continuous (unclassified) layer carries them in a
-  // classified:false record the render injection reads, or none at all when
-  // both are off (the plain upstream colormap renders on its own). Breaks are
-  // required by the record but unused while continuous, so seed them from
-  // whatever range is known.
+  // A custom ramp is the only thing the upstream control can't express for a
+  // continuous layer, so it carries a classified:false symbology record the
+  // render injection reads; otherwise no record is needed (the control renders
+  // the named colormap, reversal included). Breaks are required by the record
+  // but unused while continuous, so seed them from whatever range is known.
   function continuousSymbology(opts: {
     ramp: string;
-    reversed: boolean;
     customColors?: string[];
   }): RasterSymbology | null {
     const custom =
       (opts.customColors?.length ?? 0) >= MIN_CUSTOM_COLORS
         ? opts.customColors
         : undefined;
-    if (!opts.reversed && !custom) return null;
+    if (!custom) return null;
     return {
       classified: false,
       ramp: opts.ramp,
-      reversed: opts.reversed,
       method,
       classCount,
       breaks: computeRasterBreaks(method, stats, classCount),
-      ...(custom ? { customColors: custom } : {}),
+      customColors: custom,
     };
   }
 
-  // Reverse applies to both render paths. Classified bakes the flip into the
-  // injected texture, so toggling only rewrites the symbology (breaks unchanged).
+  // Reverse is a single rasterState flag for every mode: the control reverses
+  // built-in colormaps natively, and the injected texture reads it to bake the
+  // flip for classified / custom ramps.
   function setReversed(next: boolean): void {
-    if (classified && symbology) {
-      commit({ symbology: { ...symbology, reversed: next } });
-    } else {
-      commit({
-        symbology: continuousSymbology({ ramp, reversed: next, customColors }),
-      });
-    }
+    commit({ statePatch: { reversed: next } });
   }
 
   // Switch to / edit / clear a user-defined ramp. `next` is the parsed color
   // list (>= 2 colors) or undefined to drop back to the named ramp.
   function setCustomColors(next: string[] | undefined): void {
     if (classified && symbology) {
-      recomputeSymbology({
-        ramp,
-        reversed,
-        method,
-        classCount,
-        customColors: next,
-      });
+      recomputeSymbology({ ramp, method, classCount, customColors: next });
     } else {
-      commit({
-        symbology: continuousSymbology({ ramp, reversed, customColors: next }),
-      });
+      commit({ symbology: continuousSymbology({ ramp, customColors: next }) });
     }
   }
 
   // Select a built-in named ramp (clears any custom colors). Classified
   // recomputes through the named ramp; continuous pushes the colormap to the
-  // control and keeps only the reverse extra (if any).
+  // control (which renders it, reversal included) and drops any custom record.
   function selectNamedRamp(value: string): void {
     if (classified && symbology) {
       recomputeSymbology({
         ramp: value,
-        reversed,
         method,
         classCount,
         customColors: undefined,
@@ -393,11 +379,7 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
     } else {
       commit({
         statePatch: { colormap: value },
-        symbology: continuousSymbology({
-          ramp: value,
-          reversed,
-          customColors: undefined,
-        }),
+        symbology: continuousSymbology({ ramp: value, customColors: undefined }),
       });
     }
   }
@@ -502,17 +484,12 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
           checked={classified}
           onChange={(event) => {
             if (event.target.checked) {
-              recomputeSymbology({
-                ramp,
-                reversed,
-                method,
-                classCount,
-                customColors,
-              });
+              recomputeSymbology({ ramp, method, classCount, customColors });
             } else {
-              // Drop classification but keep any reversed / custom ramp extras.
+              // Drop classification but keep a custom ramp (reverse lives on
+              // rasterState and is untouched here).
               commit({
-                symbology: continuousSymbology({ ramp, reversed, customColors }),
+                symbology: continuousSymbology({ ramp, customColors }),
               });
             }
           }}

--- a/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
+++ b/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
@@ -6,6 +6,7 @@ import {
 import {
   RASTER_MAX_CLASSES,
   RASTER_MIN_CLASSES,
+  RASTER_MIN_CUSTOM_COLORS,
   type RasterBandStats,
   type RasterClassificationMethod,
   type RasterSymbology,
@@ -44,14 +45,15 @@ const DEFAULT_CLASS_COUNT = 5;
 /** Sentinel `<Select>` value that switches the ramp to a user-defined list. */
 const CUSTOM_RAMP_VALUE = "__custom__";
 /** A custom ramp needs at least this many colors to interpolate. */
-const MIN_CUSTOM_COLORS = 2;
+const MIN_CUSTOM_COLORS = RASTER_MIN_CUSTOM_COLORS;
 /**
  * Every renderer colormap (the same list the maplibre-gl-raster panel offers),
  * sorted by display label for the dropdown. Labels use matplotlib casing
- * (RdBu, YlOrBr, …); the value is the lowercase colormap key.
+ * (RdBu, YlOrBr, …); the value is the lowercase colormap key. A fixed "en"
+ * locale keeps the order identical across browsers.
  */
 const SORTED_COLORMAPS = [...COLORMAP_OPTIONS].sort((a, b) =>
-  a.label.toLowerCase().localeCompare(b.label.toLowerCase()),
+  a.label.localeCompare(b.label, "en", { sensitivity: "base" }),
 );
 
 function readRasterState(layer: GeoLibreLayer): RasterStateRecord {
@@ -420,18 +422,17 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
           onChange={(event) => {
             const value = event.target.value;
             if (value === CUSTOM_RAMP_VALUE) {
-              // Seed the editable list from the current ramp's resolved colors
-              // so the user starts from a sensible, valid (>= 2 color) ramp.
+              // Seed the editable list synchronously from the current ramp's
+              // resolved colors (or the already-resolved preview), falling back
+              // to viridis so custom mode always activates with a valid (>= 2
+              // color) ramp -- no async warm, so switching away can't be
+              // clobbered by a late callback.
               const seed = colormapColors(ramp) ?? rampPreview;
-              if (seed.length >= MIN_CUSTOM_COLORS) {
-                setCustomColors([...seed]);
-              } else {
-                void warmColormapColors(ramp).then((colors) => {
-                  if (colors && colors.length >= MIN_CUSTOM_COLORS) {
-                    setCustomColors([...colors]);
-                  }
-                });
-              }
+              const colors =
+                seed.length >= MIN_CUSTOM_COLORS
+                  ? seed
+                  : (colormapColors("viridis") ?? []);
+              setCustomColors([...colors]);
             } else {
               selectNamedRamp(value);
             }
@@ -813,11 +814,16 @@ function CustomColorsField({
   colors: string[];
   onCommit: (colors: string[]) => void;
 }) {
-  const [draft, setDraft] = useState(colors.join(", "));
+  // `colors` is a fresh array each parent render (savedRasterSymbology rebuilds
+  // it), so sync the draft off its content, not its reference -- otherwise an
+  // unrelated re-render (e.g. band stats loading) would wipe what the user is
+  // typing.
+  const committed = colors.join(", ");
+  const [draft, setDraft] = useState(committed);
   useEffect(() => {
-    setDraft(colors.join(", "));
-  }, [colors]);
-  const parsed = parseHexColorList(draft);
+    setDraft(committed);
+  }, [committed]);
+  const parsed = useMemo(() => parseHexColorList(draft), [draft]);
   const valid = parsed.length >= MIN_CUSTOM_COLORS;
   return (
     <div className="space-y-1">
@@ -831,8 +837,9 @@ function CustomColorsField({
         placeholder="#440154, #21908c, #fde725"
         onChange={(event) => setDraft(event.target.value)}
         onBlur={() => {
-          if (valid) onCommit(parsed);
-          else setDraft(colors.join(", "));
+          // Only commit a usable, actually-changed ramp; otherwise restore.
+          if (valid && parsed.join(",") !== colors.join(",")) onCommit(parsed);
+          else setDraft(committed);
         }}
       />
       <p className="text-[10px] text-muted-foreground">

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -891,5 +891,12 @@
     "newGroupFromLayer": "New group from layer",
     "moveToGroup": "Move to group",
     "removeFromGroup": "Remove from group"
+  },
+  "rasterSymbology": {
+    "reverseRamp": "Reverse ramp",
+    "customRamp": "Custom…",
+    "customColors": "Custom colors",
+    "customColorsValid": "{{count}} colors, low to high. Use Reverse to flip.",
+    "customColorsHint": "Enter at least two hex codes, separated by commas or spaces."
   }
 }

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1107,6 +1107,40 @@ body,
   color: hsl(var(--foreground));
 }
 
+/*
+ * Make the Colorbar / Legend / HTML plugin GUI panels resizable in both width
+ * and height, in any map corner. Each panel is anchored to its toggle button:
+ * `.right` opens rightward (CSS left-anchored), `.left` opens leftward (CSS
+ * right-anchored). A left-anchored panel resizes naturally from the native
+ * bottom-right grip. A right-anchored panel sets `direction: rtl` so the grip
+ * moves to the inward bottom-left corner and the panel grows toward the map
+ * interior instead of off-screen; its content is reset to LTR. Both grow
+ * downward from `top: 0`, which suits the top corners.
+ */
+.geolibre-colorbar-control .colorbar-gui-panel,
+.geolibre-legend-control .legend-gui-panel,
+.geolibre-html-control .html-gui-panel {
+  resize: both;
+  overflow: auto;
+  min-width: 220px;
+  min-height: 140px;
+  max-width: min(90vw, 720px);
+  /* Override the library's inline max-height so the panel can grow taller. */
+  max-height: min(85vh, 720px) !important;
+}
+
+.geolibre-colorbar-control .colorbar-gui-panel.left,
+.geolibre-legend-control .legend-gui-panel.left,
+.geolibre-html-control .html-gui-panel.left {
+  direction: rtl;
+}
+
+.geolibre-colorbar-control .colorbar-gui-panel.left > *,
+.geolibre-legend-control .legend-gui-panel.left > *,
+.geolibre-html-control .html-gui-panel.left > * {
+  direction: ltr;
+}
+
 .geolibre-components-control input[type="radio"] {
   appearance: none;
   background-color: #fff;

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1107,40 +1107,6 @@ body,
   color: hsl(var(--foreground));
 }
 
-/*
- * Make the Colorbar / Legend / HTML plugin GUI panels resizable in both width
- * and height, in any map corner. Each panel is anchored to its toggle button:
- * `.right` opens rightward (CSS left-anchored), `.left` opens leftward (CSS
- * right-anchored). A left-anchored panel resizes naturally from the native
- * bottom-right grip. A right-anchored panel sets `direction: rtl` so the grip
- * moves to the inward bottom-left corner and the panel grows toward the map
- * interior instead of off-screen; its content is reset to LTR. Both grow
- * downward from `top: 0`, which suits the top corners.
- */
-.geolibre-colorbar-control .colorbar-gui-panel,
-.geolibre-legend-control .legend-gui-panel,
-.geolibre-html-control .html-gui-panel {
-  resize: both;
-  overflow: auto;
-  min-width: 220px;
-  min-height: 140px;
-  max-width: min(90vw, 720px);
-  /* Override the library's inline max-height so the panel can grow taller. */
-  max-height: min(85vh, 720px) !important;
-}
-
-.geolibre-colorbar-control .colorbar-gui-panel.left,
-.geolibre-legend-control .legend-gui-panel.left,
-.geolibre-html-control .html-gui-panel.left {
-  direction: rtl;
-}
-
-.geolibre-colorbar-control .colorbar-gui-panel.left > *,
-.geolibre-legend-control .legend-gui-panel.left > *,
-.geolibre-html-control .html-gui-panel.left > * {
-  direction: ltr;
-}
-
 .geolibre-components-control input[type="radio"] {
   appearance: none;
   background-color: #fff;

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
         "maplibre-gl-nasa-earthdata": "^0.1.2",
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.2.4",
+        "maplibre-gl-raster": "^0.3.0",
         "maplibre-gl-streetview": "^0.6.0",
         "maplibre-gl-swipe": "^0.7.1",
         "maplibre-gl-time-slider": "^1.0.3",
@@ -17750,9 +17750,9 @@
       }
     },
     "node_modules/maplibre-gl-raster": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.2.4.tgz",
-      "integrity": "sha512-02GkznVgyw4FU0fQzk6ssAHOOlmGXqYI+t4mYRy3JXGpDQw3Gc/KhSll+0nq1VHOematbtgllCce9uCSSoh41A==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.3.0.tgz",
+      "integrity": "sha512-0023xM+yVRaMoYCLPhdbVuLPdClxbJ5v+J6xxlNa0HgBIZ8egRQwvwo9Le7Enhlq3Gb/pAi9v4unS43cWc8UUg==",
       "license": "MIT",
       "dependencies": {
         "@chunkd/middleware": "^11.3.0",
@@ -24274,7 +24274,7 @@
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-overture-maps": "^0.3.0",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.2.1",
+        "maplibre-gl-raster": "^0.3.0",
         "maplibre-gl-streetview": "^0.6.0",
         "maplibre-gl-swipe": "^0.7.1",
         "maplibre-gl-time-slider": "^1.0.3",

--- a/packages/core/src/color-ramp.ts
+++ b/packages/core/src/color-ramp.ts
@@ -161,7 +161,8 @@ export function interpolateColors(
   count: number,
 ): string[] {
   const anchors = colors.length > 0 ? colors : ["#000000"];
-  if (count <= 1) return [anchors[anchors.length - 1]];
+  if (count <= 0) return [];
+  if (count === 1) return [anchors[anchors.length - 1]];
   if (anchors.length === 1) {
     return Array.from({ length: count }, () => anchors[0]);
   }

--- a/packages/core/src/color-ramp.ts
+++ b/packages/core/src/color-ramp.ts
@@ -144,15 +144,73 @@ export function interpolateRampColors(
   colorRamp: string,
   count: number,
 ): string[] {
-  const colors = getVectorColorRamp(colorRamp).colors;
-  if (count <= 1) return [colors[colors.length - 1]];
+  return interpolateColors(getVectorColorRamp(colorRamp).colors, count);
+}
+
+/**
+ * Samples an explicit list of anchor colors into `count` evenly spaced hex
+ * colors by linear interpolation. Backs both the named ramps and user-defined
+ * custom ramps, so a list of hex codes is sampled identically to a built-in.
+ *
+ * @param colors - The anchor colors (at least one).
+ * @param count - Number of colors to produce.
+ * @returns An array of `count` hex colors (a single end color when count <= 1).
+ */
+export function interpolateColors(
+  colors: readonly string[],
+  count: number,
+): string[] {
+  const anchors = colors.length > 0 ? colors : ["#000000"];
+  if (count <= 1) return [anchors[anchors.length - 1]];
+  if (anchors.length === 1) {
+    return Array.from({ length: count }, () => anchors[0]);
+  }
   return Array.from({ length: count }, (_, index) => {
-    const scaled = (index / (count - 1)) * (colors.length - 1);
+    const scaled = (index / (count - 1)) * (anchors.length - 1);
     const lowerIndex = Math.floor(scaled);
-    const upperIndex = Math.min(colors.length - 1, Math.ceil(scaled));
+    const upperIndex = Math.min(anchors.length - 1, Math.ceil(scaled));
     const ratio = scaled - lowerIndex;
-    return interpolateHexColor(colors[lowerIndex], colors[upperIndex], ratio);
+    return interpolateHexColor(anchors[lowerIndex], anchors[upperIndex], ratio);
   });
+}
+
+/**
+ * Normalizes a single user-entered color token into a canonical `#rrggbb`
+ * lowercase hex string, or null when it is not a valid 3- or 6-digit hex
+ * color. Accepts values with or without a leading `#` and expands shorthand
+ * (`#abc` → `#aabbcc`).
+ *
+ * @param token - A raw color token (e.g. "FF0000", "#f00", " #AaBbCc ").
+ * @returns The canonical `#rrggbb` color, or null when invalid.
+ */
+export function normalizeHexColor(token: string): string | null {
+  let value = token.trim().toLowerCase();
+  if (value === "") return null;
+  if (!value.startsWith("#")) value = `#${value}`;
+  if (/^#[0-9a-f]{3}$/.test(value)) {
+    value = `#${value
+      .slice(1)
+      .split("")
+      .map((channel) => channel + channel)
+      .join("")}`;
+  }
+  return /^#[0-9a-f]{6}$/.test(value) ? value : null;
+}
+
+/**
+ * Parses a free-text list of hex color codes into canonical `#rrggbb` colors,
+ * for the custom color-ramp inputs. Tokens may be separated by commas,
+ * semicolons, or any whitespace (including newlines); invalid tokens are
+ * dropped so a partial paste still yields the colors it can.
+ *
+ * @param input - The raw text the user entered.
+ * @returns The valid, normalized colors in input order.
+ */
+export function parseHexColorList(input: string): string[] {
+  return input
+    .split(/[\s,;]+/)
+    .map(normalizeHexColor)
+    .filter((color): color is string => color !== null);
 }
 
 /**

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -44,7 +44,7 @@
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-overture-maps": "^0.3.0",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.2.1",
+    "maplibre-gl-raster": "^0.3.0",
     "maplibre-gl-streetview": "^0.6.0",
     "maplibre-gl-swipe": "^0.7.1",
     "maplibre-gl-time-slider": "^1.0.3",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -105,6 +105,7 @@ export {
 export {
   RASTER_MAX_CLASSES,
   RASTER_MIN_CLASSES,
+  RASTER_MIN_CUSTOM_COLORS,
   type RasterBandStats,
   type RasterClassificationMethod,
   type RasterSymbology,

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -117,6 +117,7 @@ export {
   RASTER_SOURCE_KIND,
   getRasterBandStats,
 } from "./plugins/raster-symbology-texture";
+export { colormapColors, warmColormapColors } from "./plugins/colormap-colors";
 export {
   closeVectorLayerPanel,
   openVectorLayerPanel,

--- a/packages/plugins/src/plugins/colormap-colors.ts
+++ b/packages/plugins/src/plugins/colormap-colors.ts
@@ -47,14 +47,19 @@ export function warmColormapColors(
   if (!pending) {
     pending = sampleColormapStops(name, ANCHOR_STOPS, false)
       .then((stops) => {
+        // Clear the in-flight marker only after the cache is written, so a
+        // re-entrant call in the same microtask can't miss both.
+        inflight.delete(name);
         if (stops.length >= 2) {
           anchorCache.set(name, stops);
-          return stops;
+          return stops as readonly string[];
         }
         return null;
       })
-      .catch(() => null)
-      .finally(() => inflight.delete(name));
+      .catch(() => {
+        inflight.delete(name);
+        return null;
+      });
     inflight.set(name, pending);
   }
   return pending;

--- a/packages/plugins/src/plugins/colormap-colors.ts
+++ b/packages/plugins/src/plugins/colormap-colors.ts
@@ -8,9 +8,11 @@ const ANCHOR_STOPS = 32;
 const anchorCache = new Map<string, readonly string[]>();
 const inflight = new Map<string, Promise<readonly string[] | null>>();
 
+const BUILT_IN_RAMP_NAMES = new Set(VECTOR_COLOR_RAMPS.map((ramp) => ramp.value));
+
 /** Whether GeoLibre ships exact JS anchor colors for this ramp (its curated set). */
 function isBuiltInRamp(name: string): boolean {
-  return VECTOR_COLOR_RAMPS.some((ramp) => ramp.value === name);
+  return BUILT_IN_RAMP_NAMES.has(name);
 }
 
 /**

--- a/packages/plugins/src/plugins/colormap-colors.ts
+++ b/packages/plugins/src/plugins/colormap-colors.ts
@@ -1,0 +1,59 @@
+import { VECTOR_COLOR_RAMPS, getVectorColorRamp } from "@geolibre/core";
+import { sampleColormapStops } from "maplibre-gl-raster";
+
+// Anchor stops sampled from the renderer's colormap sprite -- enough to
+// interpolate down to any class count or a smooth preview gradient.
+const ANCHOR_STOPS = 32;
+
+const anchorCache = new Map<string, readonly string[]>();
+const inflight = new Map<string, Promise<readonly string[] | null>>();
+
+/** Whether GeoLibre ships exact JS anchor colors for this ramp (its curated set). */
+function isBuiltInRamp(name: string): boolean {
+  return VECTOR_COLOR_RAMPS.some((ramp) => ramp.value === name);
+}
+
+/**
+ * Anchor colors for a colormap, used to build the classified stepped texture
+ * and the Style-panel preview. Built-in GeoLibre ramps return their exact JS
+ * colors synchronously; any other (sprite) colormap returns its cached sampled
+ * colors, or null until {@link warmColormapColors} has sampled it.
+ *
+ * @param name - The colormap name (a `VECTOR_COLOR_RAMPS` value or sprite key).
+ * @returns The anchor colors, or null when a sprite colormap is not yet sampled.
+ */
+export function colormapColors(name: string): readonly string[] | null {
+  if (isBuiltInRamp(name)) return getVectorColorRamp(name).colors;
+  return anchorCache.get(name) ?? null;
+}
+
+/**
+ * Samples (once, then caches) a sprite colormap's colors so a later
+ * {@link colormapColors} call resolves synchronously. Resolves immediately for
+ * built-in ramps, and yields null when sampling is unavailable (e.g. headless)
+ * or the name is unknown.
+ *
+ * @param name - The colormap name.
+ * @returns The resolved colors, or null on failure.
+ */
+export function warmColormapColors(
+  name: string,
+): Promise<readonly string[] | null> {
+  const known = colormapColors(name);
+  if (known) return Promise.resolve(known);
+  let pending = inflight.get(name);
+  if (!pending) {
+    pending = sampleColormapStops(name, ANCHOR_STOPS, false)
+      .then((stops) => {
+        if (stops.length >= 2) {
+          anchorCache.set(name, stops);
+          return stops;
+        }
+        return null;
+      })
+      .catch(() => null)
+      .finally(() => inflight.delete(name));
+    inflight.set(name, pending);
+  }
+  return pending;
+}

--- a/packages/plugins/src/plugins/raster-layer-sync.ts
+++ b/packages/plugins/src/plugins/raster-layer-sync.ts
@@ -257,6 +257,7 @@ const SYNCED_RASTER_STATE_KEYS = [
   "mode",
   "bands",
   "colormap",
+  "reversed",
   "rescale",
   "nodata",
   "stretch",
@@ -419,6 +420,9 @@ export function savedRasterState(
   // than throwing on restore.
   if (typeof candidate.colormap === "string" && candidate.colormap) {
     state.colormap = candidate.colormap;
+  }
+  if (typeof candidate.reversed === "boolean") {
+    state.reversed = candidate.reversed;
   }
   if (
     candidate.nodata === "off" ||

--- a/packages/plugins/src/plugins/raster-symbology-texture.ts
+++ b/packages/plugins/src/plugins/raster-symbology-texture.ts
@@ -7,6 +7,7 @@ import {
 } from "maplibre-gl-raster";
 import {
   COLORMAP_TEXTURE_WIDTH,
+  RASTER_MIN_CUSTOM_COLORS,
   type RasterBandStats,
   type RasterSymbology,
   buildContinuousColormapRgba,
@@ -19,11 +20,6 @@ import {
   isRasterStoreSyncSuspended,
 } from "./raster-layer-sync";
 import { colormapColors, warmColormapColors } from "./colormap-colors";
-
-/** Whether a symbology carries user-entered custom colors (>= 2). */
-function hasCustomRamp(symbology: RasterSymbology): boolean {
-  return (symbology.customColors?.length ?? 0) >= 2;
-}
 
 // These types mirror undocumented private members of the maplibre-gl-raster
 // LayerManager (verified against v0.2.0) and the deck.gl-raster Colormap
@@ -68,9 +64,9 @@ type ClassificationEntry = {
   texture?: GpuTexture;
 };
 
-/** Whether a symbology carries a usable custom color ramp (>= 2 colors). */
+/** Whether a symbology carries a usable custom color ramp. */
 function hasCustomColors(symbology: RasterSymbology): boolean {
-  return (symbology.customColors?.length ?? 0) >= 2;
+  return (symbology.customColors?.length ?? 0) >= RASTER_MIN_CUSTOM_COLORS;
 }
 
 /**
@@ -207,7 +203,12 @@ function ensureTexture(
     // colors come from the warmed cache; until it resolves, colormapColors is
     // null and buildSteppedColormapRgba falls back (reconcile rebuilds on warm).
     const custom =
-      customColors && customColors.length >= 2 ? customColors : undefined;
+      customColors && customColors.length >= RASTER_MIN_CUSTOM_COLORS
+        ? customColors
+        : undefined;
+    // The continuous branch only runs for a custom ramp (needsTexture), so
+    // `custom` is set; the grayscale fallback just keeps the contract explicit
+    // rather than producing a silent all-black gradient.
     const rgba = classified
       ? buildSteppedColormapRgba(
           breaks,
@@ -215,7 +216,7 @@ function ensureTexture(
           reversed,
           custom ?? colormapColors(ramp) ?? undefined,
         )
-      : buildContinuousColormapRgba(customColors ?? [], reversed);
+      : buildContinuousColormapRgba(custom ?? ["#000000", "#ffffff"], reversed);
     // The DOM ImageData ctor types its buffer as ArrayBuffer (not the wider
     // ArrayBufferLike the Uint8ClampedArray generic carries); the runtime
     // buffer is a plain ArrayBuffer, so narrow it for the type checker.
@@ -290,7 +291,7 @@ function reconcile(control: unknown): void {
     // re-render. symbologyKey can't see the async colors, so invalidate here.
     if (
       symbology.classified &&
-      !hasCustomRamp(symbology) &&
+      !hasCustomColors(symbology) &&
       colormapColors(symbology.ramp) === null
     ) {
       const id = layer.id;

--- a/packages/plugins/src/plugins/raster-symbology-texture.ts
+++ b/packages/plugins/src/plugins/raster-symbology-texture.ts
@@ -18,6 +18,12 @@ import {
   isRasterControlStoreLayer,
   isRasterStoreSyncSuspended,
 } from "./raster-layer-sync";
+import { colormapColors, warmColormapColors } from "./colormap-colors";
+
+/** Whether a symbology carries user-entered custom colors (>= 2). */
+function hasCustomRamp(symbology: RasterSymbology): boolean {
+  return (symbology.customColors?.length ?? 0) >= 2;
+}
 
 // These types mirror undocumented private members of the maplibre-gl-raster
 // LayerManager (verified against v0.2.0) and the deck.gl-raster Colormap
@@ -194,9 +200,18 @@ function ensureTexture(
     const { classified, breaks, ramp, reversed, customColors } = entry.symbology;
     // Classified ramps step through the class breaks; a custom continuous ramp
     // is a smooth gradient of the user's colors. (A built-in continuous ramp
-    // never reaches here -- it has no texture.)
+    // never reaches here -- it has no texture.) For a named sprite colormap the
+    // colors come from the warmed cache; until it resolves, colormapColors is
+    // null and buildSteppedColormapRgba falls back (reconcile rebuilds on warm).
+    const custom =
+      customColors && customColors.length >= 2 ? customColors : undefined;
     const rgba = classified
-      ? buildSteppedColormapRgba(breaks, ramp, reversed, customColors)
+      ? buildSteppedColormapRgba(
+          breaks,
+          ramp,
+          reversed,
+          custom ?? colormapColors(ramp) ?? undefined,
+        )
       : buildContinuousColormapRgba(customColors ?? [], reversed);
     // The DOM ImageData ctor types its buffer as ArrayBuffer (not the wider
     // ArrayBufferLike the Uint8ClampedArray generic carries); the runtime
@@ -263,6 +278,27 @@ function reconcile(control: unknown): void {
       existing.symbology = symbology;
       // Texture rebuilt lazily on next render via ensureTexture's key check.
       changed = true;
+    }
+
+    // A classified sprite colormap (named, not a built-in ramp, no custom
+    // colors) needs its colors sampled from the renderer's sprite. Warm the
+    // cache and, once the colors arrive, drop the stale fallback texture and
+    // re-render. symbologyKey can't see the async colors, so invalidate here.
+    if (
+      symbology.classified &&
+      !hasCustomRamp(symbology) &&
+      colormapColors(symbology.ramp) === null
+    ) {
+      const id = layer.id;
+      const ramp = symbology.ramp;
+      void warmColormapColors(ramp).then((colors) => {
+        if (!colors) return;
+        const current = entries.get(id);
+        if (!current || current.symbology.ramp !== ramp) return;
+        current.texture?.destroy?.();
+        current.texture = undefined;
+        manager._rebuild?.();
+      });
     }
   }
 

--- a/packages/plugins/src/plugins/raster-symbology-texture.ts
+++ b/packages/plugins/src/plugins/raster-symbology-texture.ts
@@ -9,6 +9,7 @@ import {
   COLORMAP_TEXTURE_WIDTH,
   type RasterBandStats,
   type RasterSymbology,
+  buildContinuousColormapRgba,
   buildSteppedColormapRgba,
   savedRasterSymbology,
 } from "./raster-symbology";
@@ -53,10 +54,25 @@ type RasterInfoLike = {
 
 type ClassificationEntry = {
   symbology: RasterSymbology;
-  /** Cache key for the built texture (breaks + ramp + reversed). */
+  /** Cache key for the built texture (breaks + ramp + customColors + reversed). */
   key: string;
   texture?: GpuTexture;
 };
+
+/** Whether a symbology carries a usable custom color ramp (>= 2 colors). */
+function hasCustomColors(symbology: RasterSymbology): boolean {
+  return (symbology.customColors?.length ?? 0) >= 2;
+}
+
+/**
+ * Whether a single-band layer needs a GeoLibre-injected colormap texture: a
+ * stepped lookup when classified, or a smooth gradient when a custom ramp is
+ * applied to a continuous layer. A built-in continuous ramp renders through
+ * the upstream sprite (reversal aside) and needs no texture.
+ */
+function needsTexture(symbology: RasterSymbology): boolean {
+  return symbology.classified || hasCustomColors(symbology);
+}
 
 // Per-layer classification state and built GPU textures. Module-global to
 // match the single mounted raster control (see maplibre-raster.ts).
@@ -70,16 +86,23 @@ const statsInflight = new Map<string, AbortController>();
 let storeUnsubscribe: (() => void) | null = null;
 
 function symbologyKey(symbology: RasterSymbology): string {
-  return JSON.stringify([symbology.breaks, symbology.ramp, symbology.reversed]);
+  return JSON.stringify([
+    symbology.breaks,
+    symbology.ramp,
+    symbology.customColors ?? null,
+    symbology.reversed,
+  ]);
 }
 
 /**
- * Installs the per-layer classification injection on a raster control. Wraps
- * the LayerManager's `_renderTileFor` so that a classified single-band layer
- * renders through the unchanged upstream pipeline (composite / nodata /
- * rescale / stretch) but samples a custom stepped colormap texture instead of
- * the shared named-colormap sprite. Idempotent and feature-detected: if the
- * private surface is missing it warns once and leaves the control untouched.
+ * Installs the per-layer symbology injection on a raster control. Wraps the
+ * LayerManager's `_renderTileFor` so a single-band layer renders through the
+ * unchanged upstream pipeline (composite / nodata / rescale / stretch) but,
+ * when classified, samples a custom stepped colormap texture instead of the
+ * shared named-colormap sprite, and, when its continuous ramp is reversed,
+ * flips the colormap module's `reversed` shader uniform. Idempotent and
+ * feature-detected: if the private surface is missing it warns once and
+ * leaves the control untouched.
  *
  * @param control - The mounted maplibre-gl-raster control.
  */
@@ -102,9 +125,16 @@ export function installRasterClassification(control: unknown): void {
     manager._renderTileFor = (layer: RasterLayerLike): RenderTileFn => {
       const renderTile = originalRenderTileFor(layer);
       const entry = entries.get(layer.id);
+      // A texture is injected for classified / custom ramps; a built-in
+      // continuous ramp is only patched to reverse it via the shader uniform.
+      // Everything else renders straight through the upstream pipeline.
+      const usesTexture = entry ? needsTexture(entry.symbology) : false;
+      const reverseBuiltIn =
+        !usesTexture && (entry?.symbology.reversed ?? false);
       if (
         layer.state?.mode !== "single" ||
-        !entry?.symbology.classified ||
+        !entry ||
+        (!usesTexture && !reverseBuiltIn) ||
         !manager._device
       ) {
         return renderTile;
@@ -113,25 +143,34 @@ export function installRasterClassification(control: unknown): void {
         const result = renderTile(data);
         const pipeline = result?.renderPipeline;
         if (!Array.isArray(pipeline)) return result;
-        const texture = ensureTexture(manager, entry);
-        if (!texture) return result;
-        // Swap ONLY the trailing colormap module's texture; every other
-        // module (composite, nodata, rescale, stretch, gamma) is reused as
-        // built upstream, so nodata transparency and the rescale window
-        // behave identically to the named-colormap path.
+        // Texture-backed ramps sample an injected lookup; bail if it could not
+        // be built. The reverse-only path keeps the upstream texture.
+        const texture = usesTexture ? ensureTexture(manager, entry) : null;
+        if (usesTexture && !texture) return result;
+        // Touch ONLY the trailing colormap module; every other module
+        // (composite, nodata, rescale, stretch, gamma) is reused as built
+        // upstream, so nodata transparency and the rescale window behave
+        // identically to the named-colormap path.
         const patched = pipeline.map((mod) =>
           mod?.module?.name === "colormap"
             ? {
                 ...mod,
-                props: {
-                  ...mod.props,
-                  colormapTexture: texture,
-                  colormapIndex: 0,
-                  // The reversal is already baked into the texture's class
-                  // colors (buildSteppedColormapRgba), so the shader uniform
-                  // must stay false or the two cancel out.
-                  reversed: false,
-                },
+                props: usesTexture
+                  ? {
+                      ...mod.props,
+                      colormapTexture: texture,
+                      colormapIndex: 0,
+                      // Any reversal is already baked into the injected
+                      // texture's colors, so the shader uniform must stay false
+                      // or the two cancel out.
+                      reversed: false,
+                    }
+                  : {
+                      // Keep the upstream named colormap; just flip the shader
+                      // uniform so the result mirrors the forward ramp exactly.
+                      ...mod.props,
+                      reversed: true,
+                    },
               }
             : mod,
         );
@@ -152,11 +191,13 @@ function ensureTexture(
   if (entry.texture && entry.key === key) return entry.texture;
   entry.texture?.destroy?.();
   try {
-    const rgba = buildSteppedColormapRgba(
-      entry.symbology.breaks,
-      entry.symbology.ramp,
-      entry.symbology.reversed,
-    );
+    const { classified, breaks, ramp, reversed, customColors } = entry.symbology;
+    // Classified ramps step through the class breaks; a custom continuous ramp
+    // is a smooth gradient of the user's colors. (A built-in continuous ramp
+    // never reaches here -- it has no texture.)
+    const rgba = classified
+      ? buildSteppedColormapRgba(breaks, ramp, reversed, customColors)
+      : buildContinuousColormapRgba(customColors ?? [], reversed);
     // The DOM ImageData ctor types its buffer as ArrayBuffer (not the wider
     // ArrayBufferLike the Uint8ClampedArray generic carries); the runtime
     // buffer is a plain ArrayBuffer, so narrow it for the type checker.
@@ -199,7 +240,13 @@ function reconcile(control: unknown): void {
     const symbology = savedRasterSymbology(layer);
     const existing = entries.get(layer.id);
 
-    if (!symbology || !symbology.classified) {
+    // Track the layer while it needs custom rendering: a classified or custom
+    // texture, or a reversed built-in continuous ramp. A plain built-in
+    // continuous ramp needs none of these, so drop any stale entry.
+    if (
+      !symbology ||
+      (!needsTexture(symbology) && !symbology.reversed)
+    ) {
       if (existing) {
         existing.texture?.destroy?.();
         entries.delete(layer.id);

--- a/packages/plugins/src/plugins/raster-symbology-texture.ts
+++ b/packages/plugins/src/plugins/raster-symbology-texture.ts
@@ -1,4 +1,4 @@
-import { useAppStore } from "@geolibre/core";
+import { type GeoLibreLayer, useAppStore } from "@geolibre/core";
 import { createColormapTexture } from "@developmentseed/deck.gl-raster/gpu-modules";
 import {
   type AutoStats,
@@ -60,6 +60,9 @@ type RasterInfoLike = {
 
 type ClassificationEntry = {
   symbology: RasterSymbology;
+  /** Whether the ramp is reversed (from `rasterState.reversed`); baked into
+   * the injected texture. */
+  reversed: boolean;
   /** Cache key for the built texture (breaks + ramp + customColors + reversed). */
   key: string;
   texture?: GpuTexture;
@@ -74,10 +77,21 @@ function hasCustomColors(symbology: RasterSymbology): boolean {
  * Whether a single-band layer needs a GeoLibre-injected colormap texture: a
  * stepped lookup when classified, or a smooth gradient when a custom ramp is
  * applied to a continuous layer. A built-in continuous ramp renders through
- * the upstream sprite (reversal aside) and needs no texture.
+ * the upstream sprite (including its native `reversed`), so it needs no texture.
  */
 function needsTexture(symbology: RasterSymbology): boolean {
   return symbology.classified || hasCustomColors(symbology);
+}
+
+/** Reads `rasterState.reversed` from a store layer's metadata. */
+function readRasterReversed(layer: GeoLibreLayer): boolean {
+  const raw = layer.metadata.rasterState;
+  return (
+    !!raw &&
+    typeof raw === "object" &&
+    !Array.isArray(raw) &&
+    (raw as Record<string, unknown>).reversed === true
+  );
 }
 
 // Per-layer classification state and built GPU textures. Module-global to
@@ -91,12 +105,12 @@ const statsCache = new Map<string, AutoStats>();
 const statsInflight = new Map<string, AbortController>();
 let storeUnsubscribe: (() => void) | null = null;
 
-function symbologyKey(symbology: RasterSymbology): string {
+function symbologyKey(symbology: RasterSymbology, reversed: boolean): string {
   return JSON.stringify([
     symbology.breaks,
     symbology.ramp,
     symbology.customColors ?? null,
-    symbology.reversed,
+    reversed,
   ]);
 }
 
@@ -104,11 +118,12 @@ function symbologyKey(symbology: RasterSymbology): string {
  * Installs the per-layer symbology injection on a raster control. Wraps the
  * LayerManager's `_renderTileFor` so a single-band layer renders through the
  * unchanged upstream pipeline (composite / nodata / rescale / stretch) but,
- * when classified, samples a custom stepped colormap texture instead of the
- * shared named-colormap sprite, and, when its continuous ramp is reversed,
- * flips the colormap module's `reversed` shader uniform. Idempotent and
- * feature-detected: if the private surface is missing it warns once and
- * leaves the control untouched.
+ * when classified or using a custom ramp, samples a GeoLibre-built colormap
+ * texture instead of the shared named-colormap sprite (reversal baked in).
+ * Built-in continuous ramps -- including their reversal via
+ * `rasterState.reversed` -- render through the upstream control untouched.
+ * Idempotent and feature-detected: if the private surface is missing it warns
+ * once and leaves the control untouched.
  *
  * @param control - The mounted maplibre-gl-raster control.
  */
@@ -131,16 +146,13 @@ export function installRasterClassification(control: unknown): void {
     manager._renderTileFor = (layer: RasterLayerLike): RenderTileFn => {
       const renderTile = originalRenderTileFor(layer);
       const entry = entries.get(layer.id);
-      // A texture is injected for classified / custom ramps; a built-in
-      // continuous ramp is only patched to reverse it via the shader uniform.
-      // Everything else renders straight through the upstream pipeline.
-      const usesTexture = entry ? needsTexture(entry.symbology) : false;
-      const reverseBuiltIn =
-        !usesTexture && (entry?.symbology.reversed ?? false);
+      // A texture is injected only for classified / custom ramps. A built-in
+      // continuous ramp (including its reversal) renders through the upstream
+      // sprite via rasterState.reversed, so it has no entry and passes through.
       if (
         layer.state?.mode !== "single" ||
         !entry ||
-        (!usesTexture && !reverseBuiltIn) ||
+        !needsTexture(entry.symbology) ||
         !manager._device
       ) {
         return renderTile;
@@ -149,34 +161,24 @@ export function installRasterClassification(control: unknown): void {
         const result = renderTile(data);
         const pipeline = result?.renderPipeline;
         if (!Array.isArray(pipeline)) return result;
-        // Texture-backed ramps sample an injected lookup; bail if it could not
-        // be built. The reverse-only path keeps the upstream texture.
-        const texture = usesTexture ? ensureTexture(manager, entry) : null;
-        if (usesTexture && !texture) return result;
-        // Touch ONLY the trailing colormap module; every other module
+        const texture = ensureTexture(manager, entry);
+        if (!texture) return result;
+        // Swap ONLY the trailing colormap module's texture; every other module
         // (composite, nodata, rescale, stretch, gamma) is reused as built
         // upstream, so nodata transparency and the rescale window behave
-        // identically to the named-colormap path.
+        // identically to the named-colormap path. Any reversal is already baked
+        // into the injected texture, so the shader uniform must stay false or
+        // the two cancel out.
         const patched = pipeline.map((mod) =>
           mod?.module?.name === "colormap"
             ? {
                 ...mod,
-                props: usesTexture
-                  ? {
-                      ...mod.props,
-                      colormapTexture: texture,
-                      colormapIndex: 0,
-                      // Any reversal is already baked into the injected
-                      // texture's colors, so the shader uniform must stay false
-                      // or the two cancel out.
-                      reversed: false,
-                    }
-                  : {
-                      // Keep the upstream named colormap; just flip the shader
-                      // uniform so the result mirrors the forward ramp exactly.
-                      ...mod.props,
-                      reversed: true,
-                    },
+                props: {
+                  ...mod.props,
+                  colormapTexture: texture,
+                  colormapIndex: 0,
+                  reversed: false,
+                },
               }
             : mod,
         );
@@ -193,11 +195,12 @@ function ensureTexture(
   manager: RasterLayerManager,
   entry: ClassificationEntry,
 ): GpuTexture | null {
-  const key = symbologyKey(entry.symbology);
+  const key = symbologyKey(entry.symbology, entry.reversed);
   if (entry.texture && entry.key === key) return entry.texture;
   entry.texture?.destroy?.();
   try {
-    const { classified, breaks, ramp, reversed, customColors } = entry.symbology;
+    const { classified, breaks, ramp, customColors } = entry.symbology;
+    const reversed = entry.reversed;
     // Classified ramps step through the class breaks; a custom continuous ramp
     // is a smooth gradient of the user's colors. (A built-in continuous ramp
     // never reaches here -- it has no texture.) For a named sprite colormap the
@@ -255,13 +258,10 @@ function reconcile(control: unknown): void {
     const symbology = savedRasterSymbology(layer);
     const existing = entries.get(layer.id);
 
-    // Track the layer while it needs custom rendering: a classified or custom
-    // texture, or a reversed built-in continuous ramp. A plain built-in
-    // continuous ramp needs none of these, so drop any stale entry.
-    if (
-      !symbology ||
-      (!needsTexture(symbology) && !symbology.reversed)
-    ) {
+    // Track the layer only while it needs an injected texture (classified or a
+    // custom ramp). A built-in continuous ramp -- reversed or not -- renders
+    // through the upstream sprite, so drop any stale entry.
+    if (!symbology || !needsTexture(symbology)) {
       if (existing) {
         existing.texture?.destroy?.();
         entries.delete(layer.id);
@@ -270,12 +270,16 @@ function reconcile(control: unknown): void {
       continue;
     }
 
-    const key = symbologyKey(symbology);
+    // Reverse lives on rasterState (the control renders it for built-in ramps;
+    // the injected texture bakes it here for classified / custom).
+    const reversed = readRasterReversed(layer);
+    const key = symbologyKey(symbology, reversed);
     if (!existing) {
-      entries.set(layer.id, { symbology, key });
+      entries.set(layer.id, { symbology, reversed, key });
       changed = true;
     } else if (existing.key !== key) {
       existing.symbology = symbology;
+      existing.reversed = reversed;
       // Texture rebuilt lazily on next render via ensureTexture's key check.
       changed = true;
     }

--- a/packages/plugins/src/plugins/raster-symbology.ts
+++ b/packages/plugins/src/plugins/raster-symbology.ts
@@ -51,6 +51,9 @@ export const RASTER_MAX_CLASSES = 12;
 /** Number of columns in a colormap lookup texture (matches deck.gl-raster). */
 export const COLORMAP_TEXTURE_WIDTH = 256;
 
+/** Minimum colors that make a usable custom ramp (fewer can't interpolate). */
+export const RASTER_MIN_CUSTOM_COLORS = 2;
+
 /** A single band's statistics, as produced by `computeAutoStats`. */
 export type RasterBandStats = {
   min: number;
@@ -166,7 +169,7 @@ export function rampBaseColors(
   ramp: string,
   customColors?: readonly string[],
 ): readonly string[] {
-  return customColors && customColors.length >= 2
+  return customColors && customColors.length >= RASTER_MIN_CUSTOM_COLORS
     ? customColors
     : getVectorColorRamp(ramp).colors;
 }
@@ -312,7 +315,7 @@ export function savedRasterSymbology(
       .filter((color): color is string => typeof color === "string")
       .map(normalizeHexColor)
       .filter((color): color is string => color !== null);
-    if (normalized.length >= 2) customColors = normalized;
+    if (normalized.length >= RASTER_MIN_CUSTOM_COLORS) customColors = normalized;
   }
 
   return {

--- a/packages/plugins/src/plugins/raster-symbology.ts
+++ b/packages/plugins/src/plugins/raster-symbology.ts
@@ -17,12 +17,12 @@ export type RasterClassificationMethod = "equal-interval" | "quantile" | "manual
 /**
  * GeoLibre-owned raster symbology, stored at `metadata.rasterSymbology`. The
  * upstream `maplibre-gl-raster` control owns the continuous render state
- * (`metadata.rasterState`: mode/bands/colormap/rescale/nodata/stretch/gamma);
- * this record adds what the control cannot express: discrete classification
- * and a reversed color ramp. When `classified` is true the stepped colormap
- * drives color and `rasterState.colormap` is ignored; when only `reversed` is
- * true the continuous named colormap is kept but sampled back-to-front. When
- * neither is set the record is unnecessary (the control renders on its own).
+ * (`metadata.rasterState`: mode/bands/colormap/reversed/rescale/…); this record
+ * adds what the control cannot express: discrete classification and custom
+ * color ramps. When `classified` is true the stepped colormap drives color and
+ * `rasterState.colormap` is ignored; otherwise the record is needed only for a
+ * custom ramp. Reverse lives on `rasterState.reversed` (the control renders it
+ * for built-in colormaps; the injected texture reads it for classified/custom).
  */
 export type RasterSymbology = {
   /** Whether the single band is rendered as discrete classes. */
@@ -36,13 +36,6 @@ export type RasterSymbology = {
    * classified, a smooth gradient when continuous.
    */
   customColors?: string[];
-  /**
-   * Sample the ramp in reverse. For classified and custom-continuous layers
-   * the reversal is baked into the injected texture; for a built-in continuous
-   * colormap it flips the deck.gl-raster colormap module's `reversed` shader
-   * uniform, so the result is the exact mirror of the forward ramp.
-   */
-  reversed: boolean;
   /** How the class edges are derived. */
   method: RasterClassificationMethod;
   /** Number of classes, clamped to [2, 12]. */
@@ -326,7 +319,6 @@ export function savedRasterSymbology(
     classified: candidate.classified,
     ramp: candidate.ramp,
     ...(customColors ? { customColors } : {}),
-    reversed: candidate.reversed === true,
     method: candidate.method,
     classCount,
     breaks,
@@ -349,7 +341,6 @@ export function defaultRasterSymbology(
   return {
     classified: false,
     ramp,
-    reversed: false,
     method: "equal-interval",
     classCount,
     breaks: computeRasterBreaks("equal-interval", stats, classCount),

--- a/packages/plugins/src/plugins/raster-symbology.ts
+++ b/packages/plugins/src/plugins/raster-symbology.ts
@@ -1,7 +1,9 @@
 import {
   type GeoLibreLayer,
   createEqualIntervalBreaks,
-  interpolateRampColors,
+  getVectorColorRamp,
+  interpolateColors,
+  normalizeHexColor,
   parseHexColor,
 } from "@geolibre/core";
 
@@ -16,16 +18,30 @@ export type RasterClassificationMethod = "equal-interval" | "quantile" | "manual
  * GeoLibre-owned raster symbology, stored at `metadata.rasterSymbology`. The
  * upstream `maplibre-gl-raster` control owns the continuous render state
  * (`metadata.rasterState`: mode/bands/colormap/rescale/nodata/stretch/gamma);
- * this record adds discrete classification that the control cannot express.
- * When `classified` is true the stepped colormap drives color and
- * `rasterState.colormap` is ignored.
+ * this record adds what the control cannot express: discrete classification
+ * and a reversed color ramp. When `classified` is true the stepped colormap
+ * drives color and `rasterState.colormap` is ignored; when only `reversed` is
+ * true the continuous named colormap is kept but sampled back-to-front. When
+ * neither is set the record is unnecessary (the control renders on its own).
  */
 export type RasterSymbology = {
   /** Whether the single band is rendered as discrete classes. */
   classified: boolean;
   /** Color ramp name (a `VECTOR_COLOR_RAMPS` value / deck.gl-raster colormap). */
   ramp: string;
-  /** Sample the ramp in reverse (classified-only; continuous path can't reverse). */
+  /**
+   * User-defined anchor colors (`#rrggbb`) overriding the named ramp when set
+   * (length >= 2). The upstream control only renders its built-in colormaps,
+   * so a custom ramp is always injected as a texture: a stepped lookup when
+   * classified, a smooth gradient when continuous.
+   */
+  customColors?: string[];
+  /**
+   * Sample the ramp in reverse. For classified and custom-continuous layers
+   * the reversal is baked into the injected texture; for a built-in continuous
+   * colormap it flips the deck.gl-raster colormap module's `reversed` shader
+   * uniform, so the result is the exact mirror of the forward ramp.
+   */
   reversed: boolean;
   /** How the class edges are derived. */
   method: RasterClassificationMethod;
@@ -146,6 +162,23 @@ export function computeRasterBreaks(
 }
 
 /**
+ * Resolves the anchor colors a symbology samples: the custom colors when at
+ * least two were supplied, otherwise the named ramp's colors.
+ *
+ * @param ramp - The named color ramp value.
+ * @param customColors - Optional user-defined anchor colors.
+ * @returns The anchor colors to interpolate.
+ */
+export function rampBaseColors(
+  ramp: string,
+  customColors?: readonly string[],
+): readonly string[] {
+  return customColors && customColors.length >= 2
+    ? customColors
+    : getVectorColorRamp(ramp).colors;
+}
+
+/**
  * Builds a 256-wide RGBA lookup row for a classified single-band raster. Each
  * column is colored by the class its normalized position (within
  * `[breaks[0], breaks[last]]`) falls into, so the deck.gl-raster `Colormap`
@@ -156,17 +189,19 @@ export function computeRasterBreaks(
  * @param breaks - Class edges, ascending, length `classCount + 1`.
  * @param ramp - The color ramp name.
  * @param reversed - Whether to reverse the class colors.
+ * @param customColors - Optional user-defined anchor colors overriding `ramp`.
  * @returns A 256x1 RGBA buffer (length COLORMAP_TEXTURE_WIDTH * 4).
  */
 export function buildSteppedColormapRgba(
   breaks: number[],
   ramp: string,
   reversed = false,
+  customColors?: readonly string[],
 ): Uint8ClampedArray {
   const width = COLORMAP_TEXTURE_WIDTH;
   const rgba = new Uint8ClampedArray(width * 4);
   const classCount = Math.max(1, breaks.length - 1);
-  const colors = interpolateRampColors(ramp, classCount);
+  const colors = interpolateColors(rampBaseColors(ramp, customColors), classCount);
   const orderedColors = reversed ? [...colors].reverse() : colors;
 
   const min = breaks[0];
@@ -191,6 +226,37 @@ export function buildSteppedColormapRgba(
     const color = parseHexColor(
       orderedColors[classIndex] ?? orderedColors.at(-1) ?? "#000000",
     );
+    const offset = column * 4;
+    rgba[offset] = color.r;
+    rgba[offset + 1] = color.g;
+    rgba[offset + 2] = color.b;
+    rgba[offset + 3] = 255;
+  }
+  return rgba;
+}
+
+/**
+ * Builds a 256-wide RGBA lookup row that interpolates custom anchor colors
+ * smoothly across the rescaled [0, 1] data window, for a continuous
+ * (unclassified) single-band raster whose ramp is user-defined. The upstream
+ * control renders only its named colormaps, so a custom continuous ramp is
+ * injected as this texture. Returned as a flat `Uint8ClampedArray` so it is
+ * constructible and testable without a DOM.
+ *
+ * @param colors - The custom anchor colors (at least one).
+ * @param reversed - Whether to sample the colors back-to-front.
+ * @returns A 256x1 RGBA buffer (length COLORMAP_TEXTURE_WIDTH * 4).
+ */
+export function buildContinuousColormapRgba(
+  colors: readonly string[],
+  reversed = false,
+): Uint8ClampedArray {
+  const width = COLORMAP_TEXTURE_WIDTH;
+  const rgba = new Uint8ClampedArray(width * 4);
+  const ordered = reversed ? [...colors].reverse() : colors;
+  const sampled = interpolateColors(ordered, width);
+  for (let column = 0; column < width; column += 1) {
+    const color = parseHexColor(sampled[column] ?? "#000000");
     const offset = column * 4;
     rgba[offset] = color.r;
     rgba[offset + 1] = color.g;
@@ -244,9 +310,22 @@ export function savedRasterSymbology(
     if (breaks[index] < breaks[index - 1]) return null;
   }
 
+  // A custom ramp needs at least two valid colors; drop malformed entries so a
+  // hand-edited project silently falls back to the named ramp rather than
+  // rendering a broken texture.
+  let customColors: string[] | undefined;
+  if (Array.isArray(candidate.customColors)) {
+    const normalized = candidate.customColors
+      .filter((color): color is string => typeof color === "string")
+      .map(normalizeHexColor)
+      .filter((color): color is string => color !== null);
+    if (normalized.length >= 2) customColors = normalized;
+  }
+
   return {
     classified: candidate.classified,
     ramp: candidate.ramp,
+    ...(customColors ? { customColors } : {}),
     reversed: candidate.reversed === true,
     method: candidate.method,
     classCount,

--- a/tests/color-ramp.test.ts
+++ b/tests/color-ramp.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  interpolateColors,
+  normalizeHexColor,
+  parseHexColorList,
+} from "../packages/core/src/color-ramp";
+
+describe("normalizeHexColor", () => {
+  it("canonicalizes valid 3- and 6-digit hex, with or without #", () => {
+    assert.equal(normalizeHexColor("#FF0000"), "#ff0000");
+    assert.equal(normalizeHexColor("00ff00"), "#00ff00");
+    assert.equal(normalizeHexColor("  #AaBbCc "), "#aabbcc");
+    assert.equal(normalizeHexColor("#f00"), "#ff0000");
+    assert.equal(normalizeHexColor("abc"), "#aabbcc");
+  });
+
+  it("returns null for malformed input", () => {
+    assert.equal(normalizeHexColor(""), null);
+    assert.equal(normalizeHexColor("#ff"), null);
+    assert.equal(normalizeHexColor("#ggffaa"), null);
+    assert.equal(normalizeHexColor("red"), null);
+    assert.equal(normalizeHexColor("#12345"), null);
+  });
+});
+
+describe("parseHexColorList", () => {
+  it("splits on commas, semicolons, and whitespace and drops invalid tokens", () => {
+    assert.deepEqual(
+      parseHexColorList("#ff0000, #00ff00 #0000ff"),
+      ["#ff0000", "#00ff00", "#0000ff"],
+    );
+    assert.deepEqual(
+      parseHexColorList("ff0000; not-a-color\n#0f0"),
+      ["#ff0000", "#00ff00"],
+    );
+    assert.deepEqual(parseHexColorList("   "), []);
+  });
+
+  it("preserves order and keeps duplicates", () => {
+    assert.deepEqual(
+      parseHexColorList("#000, #000, #fff"),
+      ["#000000", "#000000", "#ffffff"],
+    );
+  });
+});
+
+describe("interpolateColors", () => {
+  it("returns the two endpoints and a midpoint for a 2-color ramp", () => {
+    assert.deepEqual(interpolateColors(["#000000", "#ffffff"], 3), [
+      "#000000",
+      "#808080",
+      "#ffffff",
+    ]);
+  });
+
+  it("returns the last color when count <= 1", () => {
+    assert.deepEqual(interpolateColors(["#111111", "#222222"], 1), ["#222222"]);
+  });
+
+  it("repeats a single anchor color across the requested count", () => {
+    assert.deepEqual(interpolateColors(["#abcdef"], 3), [
+      "#abcdef",
+      "#abcdef",
+      "#abcdef",
+    ]);
+  });
+});

--- a/tests/colormap-colors.test.ts
+++ b/tests/colormap-colors.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { getVectorColorRamp } from "@geolibre/core";
+import {
+  colormapColors,
+  warmColormapColors,
+} from "../packages/plugins/src/plugins/colormap-colors";
+
+describe("colormapColors", () => {
+  it("returns a built-in ramp's exact colors synchronously", () => {
+    assert.deepEqual(
+      colormapColors("viridis"),
+      getVectorColorRamp("viridis").colors,
+    );
+  });
+
+  it("returns null for a sprite colormap that has not been sampled", () => {
+    // 'ylorbr' is a renderer sprite colormap, not one of GeoLibre's built-ins.
+    assert.equal(colormapColors("ylorbr"), null);
+  });
+});
+
+describe("warmColormapColors", () => {
+  it("resolves a built-in ramp immediately to its colors", async () => {
+    assert.deepEqual(
+      await warmColormapColors("plasma"),
+      getVectorColorRamp("plasma").colors,
+    );
+  });
+
+  it("yields null when sampling is unavailable (no DOM canvas)", async () => {
+    // Under node --test there is no document, so sprite sampling returns [].
+    assert.equal(await warmColormapColors("ylorbr"), null);
+  });
+});

--- a/tests/raster-symbology-texture.test.ts
+++ b/tests/raster-symbology-texture.test.ts
@@ -25,8 +25,8 @@ type PipelineModule = { module?: { name?: string }; props?: Record<string, unkno
 /**
  * Minimal stand-in for the maplibre-gl-raster LayerManager + RasterControl
  * surface the symbology injection patches. `_renderTileFor` returns a render
- * pipeline whose trailing "colormap" module starts with `reversed: false`,
- * mirroring the upstream default the patch is expected to flip.
+ * pipeline whose trailing "colormap" module starts with the upstream defaults
+ * (`reversed: false`, a named-colormap texture/index).
  */
 function fakeControl() {
   const manager: Record<string, unknown> = {
@@ -64,7 +64,7 @@ function renderColormapProps(
 
 function rasterLayer(
   id: string,
-  rasterSymbology?: Record<string, unknown>,
+  opts: { rasterSymbology?: Record<string, unknown>; reversed?: boolean } = {},
 ): GeoLibreLayer {
   return {
     id,
@@ -78,21 +78,19 @@ function rasterLayer(
     metadata: {
       sourceKind: RASTER_SOURCE_KIND,
       externalNativeLayer: true,
-      ...(rasterSymbology ? { rasterSymbology } : {}),
+      // Reverse lives on rasterState now (the control renders it for built-in
+      // colormaps; the injected texture reads it for classified / custom).
+      rasterState: {
+        mode: "single",
+        colormap: "viridis",
+        reversed: opts.reversed ?? false,
+      },
+      ...(opts.rasterSymbology ? { rasterSymbology: opts.rasterSymbology } : {}),
     },
   } as GeoLibreLayer;
 }
 
-const CONTINUOUS_REVERSED = {
-  classified: false,
-  ramp: "viridis",
-  reversed: true,
-  method: "equal-interval",
-  classCount: 5,
-  breaks: [0, 0.2, 0.4, 0.6, 0.8, 1],
-};
-
-describe("raster symbology render injection (continuous reverse)", () => {
+describe("raster symbology render injection", () => {
   beforeEach(() => {
     useAppStore.setState({ layers: [] });
   });
@@ -102,19 +100,20 @@ describe("raster symbology render injection (continuous reverse)", () => {
     useAppStore.setState({ layers: [] });
   });
 
-  it("flips the colormap module's reversed uniform for a reversed continuous layer", () => {
-    useAppStore.getState().addLayer(rasterLayer("r1", CONTINUOUS_REVERSED));
+  it("leaves a built-in continuous ramp to the upstream control, reversed or not", () => {
+    // A built-in colormap (even reversed) renders through the control via
+    // rasterState.reversed; GeoLibre injects nothing and the patch is a no-op.
+    useAppStore.getState().addLayer(rasterLayer("r1", { reversed: true }));
     const control = fakeControl();
     activateRasterClassification(control);
 
     const props = renderColormapProps(control, "r1");
-    assert.equal(props?.reversed, true);
-    // The upstream named colormap is preserved; only the uniform changes.
-    assert.equal(props?.colormapTexture, "upstream");
+    assert.equal(props?.reversed, false); // patch did not touch the uniform
+    assert.equal(props?.colormapTexture, "upstream"); // upstream colormap kept
     assert.equal(props?.colormapIndex, 4);
   });
 
-  it("leaves the pipeline untouched for a plain (non-reversed) continuous layer", () => {
+  it("leaves the pipeline untouched for a plain continuous layer", () => {
     useAppStore.getState().addLayer(rasterLayer("r1"));
     const control = fakeControl();
     activateRasterClassification(control);
@@ -125,13 +124,14 @@ describe("raster symbology render injection (continuous reverse)", () => {
   it("injects a gradient texture for a custom continuous ramp", () => {
     useAppStore.getState().addLayer(
       rasterLayer("r1", {
-        classified: false,
-        ramp: "viridis",
-        customColors: ["#ff0000", "#0000ff"],
-        reversed: false,
-        method: "equal-interval",
-        classCount: 5,
-        breaks: [0, 1, 2, 3, 4, 5],
+        rasterSymbology: {
+          classified: false,
+          ramp: "viridis",
+          customColors: ["#ff0000", "#0000ff"],
+          method: "equal-interval",
+          classCount: 5,
+          breaks: [0, 1, 2, 3, 4, 5],
+        },
       }),
     );
     const control = fakeControl();
@@ -154,18 +154,5 @@ describe("raster symbology render injection (continuous reverse)", () => {
     assert.ok(props?.colormapTexture, "expected an injected colormap texture");
     assert.equal(created.length >= 1, true);
     assert.equal(created[0]?.opts.width, 256);
-  });
-
-  it("stops reversing once the reverse flag is cleared", () => {
-    useAppStore.getState().addLayer(rasterLayer("r1", CONTINUOUS_REVERSED));
-    const control = fakeControl();
-    activateRasterClassification(control);
-    assert.equal(renderColormapProps(control, "r1")?.reversed, true);
-
-    // Clearing the symbology (reverse off) drops the entry; the patch should
-    // then pass the upstream pipeline straight through.
-    const cleared = rasterLayer("r1");
-    useAppStore.getState().updateLayer("r1", { metadata: cleared.metadata });
-    assert.equal(renderColormapProps(control, "r1")?.reversed, false);
   });
 });

--- a/tests/raster-symbology-texture.test.ts
+++ b/tests/raster-symbology-texture.test.ts
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { type GeoLibreLayer, useAppStore } from "@geolibre/core";
+import {
+  RASTER_SOURCE_KIND,
+  activateRasterClassification,
+  disposeAllRasterClassification,
+} from "../packages/plugins/src/plugins/raster-symbology-texture";
+
+type PipelineModule = { module?: { name?: string }; props?: Record<string, unknown> };
+
+// Minimal ImageData polyfill so the texture builder can run headless; the real
+// createColormapTexture only reads width/height/data off it.
+(globalThis as { ImageData?: unknown }).ImageData ??= class {
+  data: Uint8ClampedArray;
+  width: number;
+  height: number;
+  constructor(data: Uint8ClampedArray, width: number, height: number) {
+    this.data = data;
+    this.width = width;
+    this.height = height;
+  }
+};
+
+/**
+ * Minimal stand-in for the maplibre-gl-raster LayerManager + RasterControl
+ * surface the symbology injection patches. `_renderTileFor` returns a render
+ * pipeline whose trailing "colormap" module starts with `reversed: false`,
+ * mirroring the upstream default the patch is expected to flip.
+ */
+function fakeControl() {
+  const manager: Record<string, unknown> = {
+    _device: {},
+    _deps: {},
+    _rebuild: () => {},
+    _renderTileFor:
+      (_layer: unknown) =>
+      (_data: unknown): { renderPipeline: PipelineModule[] } => ({
+        renderPipeline: [
+          { module: { name: "composite" }, props: {} },
+          {
+            module: { name: "colormap" },
+            props: { reversed: false, colormapIndex: 4, colormapTexture: "upstream" },
+          },
+        ],
+      }),
+  };
+  return { _layerManager: manager } as { _layerManager: Record<string, unknown> };
+}
+
+/** Renders a single-band tile through the patched manager and returns the
+ * colormap module's props. */
+function renderColormapProps(
+  control: { _layerManager: Record<string, unknown> },
+  layerId: string,
+): Record<string, unknown> | undefined {
+  const renderTileFor = control._layerManager._renderTileFor as (
+    layer: unknown,
+  ) => (data: unknown) => { renderPipeline: PipelineModule[] } | null;
+  const result = renderTileFor({ id: layerId, state: { mode: "single" } })({});
+  return result?.renderPipeline.find((mod) => mod.module?.name === "colormap")
+    ?.props;
+}
+
+function rasterLayer(
+  id: string,
+  rasterSymbology?: Record<string, unknown>,
+): GeoLibreLayer {
+  return {
+    id,
+    name: id,
+    type: "cog",
+    source: { type: "raster", url: `https://example.com/${id}.tif` },
+    visible: true,
+    opacity: 1,
+    style: {},
+    sourcePath: id,
+    metadata: {
+      sourceKind: RASTER_SOURCE_KIND,
+      externalNativeLayer: true,
+      ...(rasterSymbology ? { rasterSymbology } : {}),
+    },
+  } as GeoLibreLayer;
+}
+
+const CONTINUOUS_REVERSED = {
+  classified: false,
+  ramp: "viridis",
+  reversed: true,
+  method: "equal-interval",
+  classCount: 5,
+  breaks: [0, 0.2, 0.4, 0.6, 0.8, 1],
+};
+
+describe("raster symbology render injection (continuous reverse)", () => {
+  beforeEach(() => {
+    useAppStore.setState({ layers: [] });
+  });
+
+  afterEach(() => {
+    disposeAllRasterClassification();
+    useAppStore.setState({ layers: [] });
+  });
+
+  it("flips the colormap module's reversed uniform for a reversed continuous layer", () => {
+    useAppStore.getState().addLayer(rasterLayer("r1", CONTINUOUS_REVERSED));
+    const control = fakeControl();
+    activateRasterClassification(control);
+
+    const props = renderColormapProps(control, "r1");
+    assert.equal(props?.reversed, true);
+    // The upstream named colormap is preserved; only the uniform changes.
+    assert.equal(props?.colormapTexture, "upstream");
+    assert.equal(props?.colormapIndex, 4);
+  });
+
+  it("leaves the pipeline untouched for a plain (non-reversed) continuous layer", () => {
+    useAppStore.getState().addLayer(rasterLayer("r1"));
+    const control = fakeControl();
+    activateRasterClassification(control);
+
+    assert.equal(renderColormapProps(control, "r1")?.reversed, false);
+  });
+
+  it("injects a gradient texture for a custom continuous ramp", () => {
+    useAppStore.getState().addLayer(
+      rasterLayer("r1", {
+        classified: false,
+        ramp: "viridis",
+        customColors: ["#ff0000", "#0000ff"],
+        reversed: false,
+        method: "equal-interval",
+        classCount: 5,
+        breaks: [0, 1, 2, 3, 4, 5],
+      }),
+    );
+    const control = fakeControl();
+    // Swap in a device that can build textures (the default fake device can't).
+    const created: { opts: { width?: number } }[] = [];
+    control._layerManager._device = {
+      createTexture: (opts: { width?: number }) => {
+        const texture = { destroy() {}, opts };
+        created.push(texture);
+        return texture;
+      },
+    };
+    activateRasterClassification(control);
+
+    const props = renderColormapProps(control, "r1");
+    // A custom ramp samples an injected texture, so the shader uniform stays
+    // false (reversal, if any, is baked into the texture colors).
+    assert.equal(props?.reversed, false);
+    assert.equal(props?.colormapIndex, 0);
+    assert.ok(props?.colormapTexture, "expected an injected colormap texture");
+    assert.equal(created.length >= 1, true);
+    assert.equal(created[0]?.opts.width, 256);
+  });
+
+  it("stops reversing once the reverse flag is cleared", () => {
+    useAppStore.getState().addLayer(rasterLayer("r1", CONTINUOUS_REVERSED));
+    const control = fakeControl();
+    activateRasterClassification(control);
+    assert.equal(renderColormapProps(control, "r1")?.reversed, true);
+
+    // Clearing the symbology (reverse off) drops the entry; the patch should
+    // then pass the upstream pipeline straight through.
+    const cleared = rasterLayer("r1");
+    useAppStore.getState().updateLayer("r1", { metadata: cleared.metadata });
+    assert.equal(renderColormapProps(control, "r1")?.reversed, false);
+  });
+});

--- a/tests/raster-symbology.test.ts
+++ b/tests/raster-symbology.test.ts
@@ -175,7 +175,6 @@ describe("savedRasterSymbology", () => {
       layerWith({
         classified: true,
         ramp: "plasma",
-        reversed: true,
         method: "quantile",
         classCount: 99,
         // classCount clamps to 12, so breaks must have 13 edges.
@@ -185,7 +184,6 @@ describe("savedRasterSymbology", () => {
     assert.ok(result);
     assert.equal(result.classCount, 12);
     assert.equal(result.method, "quantile");
-    assert.equal(result.reversed, true);
   });
 
   it("keeps and normalizes custom colors with >= 2 valid entries", () => {

--- a/tests/raster-symbology.test.ts
+++ b/tests/raster-symbology.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import type { GeoLibreLayer } from "@geolibre/core";
 import {
+  buildContinuousColormapRgba,
   buildSteppedColormapRgba,
   clampRasterClassCount,
   computeRasterBreaks,
@@ -124,6 +125,42 @@ describe("buildSteppedColormapRgba", () => {
     assert.equal(rgba.length, 256 * 4);
     assert.deepEqual([rgba[0], rgba[255 * 4]], [rgba[0], rgba[0]]);
   });
+
+  it("uses custom colors over the named ramp when supplied", () => {
+    // Two custom classes: pure red then pure blue, ignoring "viridis".
+    const rgba = buildSteppedColormapRgba([0, 1, 2], "viridis", false, [
+      "#ff0000",
+      "#0000ff",
+    ]);
+    assert.deepEqual([rgba[0], rgba[1], rgba[2]], [255, 0, 0]);
+    assert.deepEqual(
+      [rgba[255 * 4], rgba[255 * 4 + 1], rgba[255 * 4 + 2]],
+      [0, 0, 255],
+    );
+  });
+});
+
+describe("buildContinuousColormapRgba", () => {
+  it("interpolates a smooth gradient across the row", () => {
+    const rgba = buildContinuousColormapRgba(["#000000", "#ffffff"], false);
+    assert.equal(rgba.length, 256 * 4);
+    // Endpoints are the anchor colors; the middle is a midpoint gray.
+    assert.deepEqual([rgba[0], rgba[1], rgba[2]], [0, 0, 0]);
+    assert.deepEqual(
+      [rgba[255 * 4], rgba[255 * 4 + 1], rgba[255 * 4 + 2]],
+      [255, 255, 255],
+    );
+    assert.ok(rgba[128 * 4] > 0 && rgba[128 * 4] < 255);
+  });
+
+  it("flips the gradient when reversed", () => {
+    const rgba = buildContinuousColormapRgba(["#000000", "#ffffff"], true);
+    assert.deepEqual([rgba[0], rgba[1], rgba[2]], [255, 255, 255]);
+    assert.deepEqual(
+      [rgba[255 * 4], rgba[255 * 4 + 1], rgba[255 * 4 + 2]],
+      [0, 0, 0],
+    );
+  });
 });
 
 describe("savedRasterSymbology", () => {
@@ -149,6 +186,38 @@ describe("savedRasterSymbology", () => {
     assert.equal(result.classCount, 12);
     assert.equal(result.method, "quantile");
     assert.equal(result.reversed, true);
+  });
+
+  it("keeps and normalizes custom colors with >= 2 valid entries", () => {
+    const result = savedRasterSymbology(
+      layerWith({
+        classified: false,
+        ramp: "viridis",
+        customColors: ["#F00", "00ff00", "garbage"],
+        reversed: false,
+        method: "equal-interval",
+        classCount: 5,
+        breaks: [0, 1, 2, 3, 4, 5],
+      }),
+    );
+    assert.ok(result);
+    assert.deepEqual(result.customColors, ["#ff0000", "#00ff00"]);
+  });
+
+  it("drops custom colors that resolve to fewer than two valid entries", () => {
+    const result = savedRasterSymbology(
+      layerWith({
+        classified: false,
+        ramp: "viridis",
+        customColors: ["#ff0000", "nope"],
+        reversed: false,
+        method: "equal-interval",
+        classCount: 5,
+        breaks: [0, 1, 2, 3, 4, 5],
+      }),
+    );
+    assert.ok(result);
+    assert.equal(result.customColors, undefined);
   });
 
   it("rejects non-ascending or wrong-length breaks", () => {


### PR DESCRIPTION
## Summary

Extends raster symbology so a single-band color ramp can be **reversed** and **defined from a custom list of hex codes**, for both the continuous and classified render paths. Also sorts the color-ramp dropdown alphabetically.

## Reverse color ramp

Previously reverse worked only for *classified* rasters. Now it works on the continuous path too:

- **Continuous built-in ramps** reverse by flipping the deck.gl-raster colormap module's existing `reversed` shader uniform (via the same `_renderTileFor` injection the classified path uses), so the result is the *exact mirror* of the forward ramp (no sprite-vs-interpolation mismatch).
- **Classified rasters** keep baking the flip into the stepped texture.
- The "Reverse ramp" checkbox moved under the Color ramp picker so it applies to both paths; the gradient preview reflects it.

## Custom color ramp

A **Custom…** option in the dropdown reveals a textarea for hex codes (`#440154, #21908c, #fde725`; with/without `#`, 3- or 6-digit, any separators). The upstream control only renders named colormaps, so custom ramps are injected as a texture: a **stepped** lookup when classified, a **smooth gradient** when continuous. Stored in `metadata.rasterSymbology.customColors`, validated on load (>= 2 valid colors), and persisted in projects.

## Alphabetical dropdown

Ramps sorted by label — a sorted *copy*, so `getVectorColorRamp`'s first-ramp fallback stays viridis.

## Implementation

- `@geolibre/core`: `interpolateColors`, `normalizeHexColor`, `parseHexColorList`.
- `@geolibre/plugins`: `RasterSymbology.customColors`; `buildContinuousColormapRgba`; `buildSteppedColormapRgba` and the render injection now resolve custom colors and handle the continuous reverse-uniform / custom-gradient cases.
- Desktop UI: reverse toggle + custom-colors field in `RasterSymbologySection`.

## Tests

New `tests/color-ramp.test.ts`; added continuous-reverse and custom-gradient injection cases in `raster-symbology(-texture).test.ts`. Full suite: **1031 frontend tests pass**, `npm run typecheck` (full build) green, eslint + pre-commit clean.

## Follow-up

The continuous built-in reverse currently flips the shader uniform via a private-API patch. A companion PR to `opengeos/maplibre-gl-raster` adds `reversed` to `RasterLayerState`; once that releases and the dep is bumped here, that branch can be replaced with a plain `setRasterState({ reversed })`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added custom raster color ramp anchors (hex list) for both classified and continuous rendering, including gradient/stepped previews and validation.
  * Continuous custom ramps now generate smooth colormap textures; classified custom ramps override named ramp colors.
  * Reverse ramp behavior is applied consistently, preserving custom ramp settings when switching classification.
* **Bug Fixes**
  * Improved custom-ramp state persistence across continuous/discrete toggling.
* **Tests**
  * Added/extended coverage for hex parsing, ramp interpolation, custom symbology, colormap-color resolution, and texture injection.
* **Chores**
  * Updated `maplibre-gl-raster` to `0.3.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



---

## Also: full colormap list in the raster Style panel

Bumps `maplibre-gl-raster` to `^0.3.0` and switches the raster symbology dropdown from GeoLibre's curated `VECTOR_COLOR_RAMPS` to the renderer's **full colormap set** (matplotlib-cased labels like `RdBu`/`YlOrBr`, lowercase keys), matching the maplibre-gl-raster panel.

- Continuous pseudocolor renders any sprite colormap directly (name pushed to the control).
- Preview gradient + classified stepped texture sample non-built-in colormaps from the renderer sprite via a new `colormap-colors` cache (`sampleColormapStops`), warmed async; built-in ramps keep exact JS colors.

Verified in the app: 109 colormaps listed; selecting a sprite colormap (RdBu) renders the map and shows its preview gradient. This is the GeoLibre side of the now-released maplibre-gl-raster 0.3.0 (reversed colormaps, Colorbar, etc.).
