### PR TITLE
fix(print-layout): exclude control colorbar canvases from map capture

### DIFF
--- a/apps/geolibre-desktop/src/lib/print-capture.ts
+++ b/apps/geolibre-desktop/src/lib/print-capture.ts
@@ -17,7 +17,8 @@
  * capture loop stretches them to fill the whole page and clobbers the map with,
  * for example, a horizontal colormap ramp.
  *
- * @param canvas - A candidate canvas (only its dimensions are read).
+ * @param canvas - A candidate canvas, kept if it is the base by identity or
+ *   matches the base size.
  * @param base - The MapLibre base canvas, used as the reference size.
  * @returns True for the base canvas and any other canvas at least 90% of the
  *   base's width and height; false for the smaller control/preview canvases.
@@ -27,7 +28,9 @@ export function isFullViewportMapCanvas(
   base: { width: number; height: number },
 ): boolean {
   if (canvas === base) return true;
-  // If the base size is unknown, be permissive rather than drop everything.
-  if (base.width === 0 || base.height === 0) return true;
+  // If the base size is unknown, keep only the base itself: compositing other
+  // canvases into a 0-sized output is a no-op anyway, and returning true here
+  // would let a control's colorbar canvas through and reintroduce the bug.
+  if (base.width === 0 || base.height === 0) return false;
   return canvas.width >= base.width * 0.9 && canvas.height >= base.height * 0.9;
 }

--- a/apps/geolibre-desktop/src/lib/print-capture.ts
+++ b/apps/geolibre-desktop/src/lib/print-capture.ts
@@ -1,0 +1,33 @@
+/**
+ * Pure helpers for the Print Layout map capture.
+ *
+ * Kept dependency-free (no DOM, Tauri, or canvas APIs) so the decision logic can
+ * be unit tested in isolation from {@link ./print-layout-export}, which pulls in
+ * jsPDF and the Tauri filesystem bridge.
+ */
+
+/**
+ * Decide whether a `<canvas>` found inside the map container is a full-viewport
+ * map render surface that should be composited into the snapshot.
+ *
+ * The map container holds the MapLibre base canvas and, on desktop, a deck.gl
+ * overlay canvas (both sized to the full viewport). It can also hold small UI
+ * canvases that map controls render: the raster control's colorbar/colormap
+ * previews and the lidar profile chart. Those must be skipped, otherwise the
+ * capture loop stretches them to fill the whole page and clobbers the map with,
+ * for example, a horizontal colormap ramp.
+ *
+ * @param canvas - A candidate canvas (only its dimensions are read).
+ * @param base - The MapLibre base canvas, used as the reference size.
+ * @returns True for the base canvas and any other canvas at least 90% of the
+ *   base's width and height; false for the smaller control/preview canvases.
+ */
+export function isFullViewportMapCanvas(
+  canvas: { width: number; height: number },
+  base: { width: number; height: number },
+): boolean {
+  if (canvas === base) return true;
+  // If the base size is unknown, be permissive rather than drop everything.
+  if (base.width === 0 || base.height === 0) return true;
+  return canvas.width >= base.width * 0.9 && canvas.height >= base.height * 0.9;
+}

--- a/apps/geolibre-desktop/src/lib/print-capture.ts
+++ b/apps/geolibre-desktop/src/lib/print-capture.ts
@@ -17,6 +17,16 @@
  * capture loop stretches them to fill the whole page and clobbers the map with,
  * for example, a horizontal colormap ramp.
  *
+ * This is a size heuristic, not an allow-list: it assumes the only
+ * full-viewport canvases in the container are map render surfaces, and that
+ * control/preview canvases are comfortably smaller than 90% of the base in at
+ * least one dimension (today's previews are ~280x24, so they are). Two edges to
+ * keep in mind if that assumption ever changes: a deck.gl overlay rendered at
+ * under 90% of the base (e.g. a different device-pixel-ratio) would be dropped
+ * from the snapshot, and a future near-full-screen widget canvas (e.g. a 95%
+ * minimap) would be composited over the map. Prefer an explicit allow-list keyed
+ * on the overlay canvas if either case becomes real.
+ *
  * @param canvas - A candidate canvas, kept if it is the base by identity or
  *   matches the base size.
  * @param base - The MapLibre base canvas, used as the reference size.

--- a/apps/geolibre-desktop/src/lib/print-layout-export.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout-export.ts
@@ -6,6 +6,7 @@
  * export helpers rasterize {@link drawLayout} at print resolution.
  */
 import jsPDF from "jspdf";
+import { isFullViewportMapCanvas } from "./print-capture";
 import {
   drawLayout,
   pageDimensionsMm,
@@ -61,6 +62,12 @@ export function captureMapImage(map: MapLike): CapturedMap {
   }
   const canvases = map.getContainer().querySelectorAll("canvas");
   canvases.forEach((c) => {
+    // Composite only the full-viewport render surfaces (the MapLibre base
+    // canvas and any deck.gl overlay). Map controls also add canvases to the
+    // container -- the raster colorbar/colormap previews, the lidar profile
+    // chart -- and stretching one of those over the page would overwrite the
+    // map with, for example, a horizontal colormap ramp.
+    if (!isFullViewportMapCanvas(c, base)) return;
     try {
       ctx.drawImage(c, 0, 0, out.width, out.height);
     } catch (err) {

--- a/tests/print-capture.test.ts
+++ b/tests/print-capture.test.ts
@@ -1,0 +1,49 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isFullViewportMapCanvas } from "../apps/geolibre-desktop/src/lib/print-capture";
+
+describe("isFullViewportMapCanvas", () => {
+  const base = { width: 1920, height: 1080 };
+
+  it("always keeps the base canvas itself", () => {
+    assert.equal(isFullViewportMapCanvas(base, base), true);
+  });
+
+  it("keeps a full-size deck.gl overlay canvas", () => {
+    assert.equal(
+      isFullViewportMapCanvas({ width: 1920, height: 1080 }, base),
+      true,
+    );
+  });
+
+  it("keeps a canvas within the 90% size tolerance", () => {
+    assert.equal(
+      isFullViewportMapCanvas({ width: 1900, height: 1000 }, base),
+      true,
+    );
+  });
+
+  it("drops a small raster colorbar/colormap preview canvas", () => {
+    // The raster control renders a horizontal colormap ramp into a small canvas
+    // (createLinearGradient(0, 0, width, 0)); stretching it over the page was
+    // the bug that filled the whole map with a rainbow gradient.
+    assert.equal(
+      isFullViewportMapCanvas({ width: 280, height: 24 }, base),
+      false,
+    );
+  });
+
+  it("drops a canvas that is wide but short", () => {
+    assert.equal(
+      isFullViewportMapCanvas({ width: 1920, height: 24 }, base),
+      false,
+    );
+  });
+
+  it("is permissive when the base size is unknown", () => {
+    assert.equal(
+      isFullViewportMapCanvas({ width: 280, height: 24 }, { width: 0, height: 0 }),
+      true,
+    );
+  });
+});

--- a/tests/print-capture.test.ts
+++ b/tests/print-capture.test.ts
@@ -23,8 +23,16 @@ describe("isFullViewportMapCanvas", () => {
     );
   });
 
+  it("keeps a canvas exactly at the 90% boundary", () => {
+    // The threshold is inclusive (>=): 1920 * 0.9 = 1728, 1080 * 0.9 = 972.
+    assert.equal(
+      isFullViewportMapCanvas({ width: 1728, height: 972 }, base),
+      true,
+    );
+  });
+
   it("drops a canvas just below the 90% threshold in height", () => {
-    // 1920 * 0.9 = 1728 (pass), 1080 * 0.9 = 972 -> 971 should fail.
+    // 1920 passes width; 971 < 972 (1080 * 0.9) fails height -> overall false.
     assert.equal(
       isFullViewportMapCanvas({ width: 1920, height: 971 }, base),
       false,
@@ -44,6 +52,14 @@ describe("isFullViewportMapCanvas", () => {
   it("drops a canvas that is wide but short", () => {
     assert.equal(
       isFullViewportMapCanvas({ width: 1920, height: 24 }, base),
+      false,
+    );
+  });
+
+  it("drops a canvas that is tall but narrow", () => {
+    // 1727 < 1728 (1920 * 0.9) fails width; height passes -> overall false.
+    assert.equal(
+      isFullViewportMapCanvas({ width: 1727, height: 1080 }, base),
       false,
     );
   });

--- a/tests/print-capture.test.ts
+++ b/tests/print-capture.test.ts
@@ -23,6 +23,14 @@ describe("isFullViewportMapCanvas", () => {
     );
   });
 
+  it("drops a canvas just below the 90% threshold in height", () => {
+    // 1920 * 0.9 = 1728 (pass), 1080 * 0.9 = 972 -> 971 should fail.
+    assert.equal(
+      isFullViewportMapCanvas({ width: 1920, height: 971 }, base),
+      false,
+    );
+  });
+
   it("drops a small raster colorbar/colormap preview canvas", () => {
     // The raster control renders a horizontal colormap ramp into a small canvas
     // (createLinearGradient(0, 0, width, 0)); stretching it over the page was
@@ -40,10 +48,15 @@ describe("isFullViewportMapCanvas", () => {
     );
   });
 
-  it("is permissive when the base size is unknown", () => {
+  it("keeps only the base when the base size is unknown", () => {
+    const unknownBase = { width: 0, height: 0 };
+    // The base itself is still kept (by identity)...
+    assert.equal(isFullViewportMapCanvas(unknownBase, unknownBase), true);
+    // ...but other canvases are dropped, so a 0x0 base cannot reintroduce the
+    // colorbar-clobbering bug.
     assert.equal(
-      isFullViewportMapCanvas({ width: 280, height: 24 }, { width: 0, height: 0 }),
-      true,
+      isFullViewportMapCanvas({ width: 280, height: 24 }, unknownBase),
+      false,
     );
   });
 });


### PR DESCRIPTION
## Problem

Opening the **Print Layout** with a raster on the map produced a preview where the entire map area was a smooth horizontal rainbow gradient instead of the actual map, even though the live map rendered correctly.

![bug: print preview shows a horizontal colormap ramp instead of the map]

## Root cause

`captureMapImage` (`apps/geolibre-desktop/src/lib/print-layout-export.ts`) composited the snapshot by drawing **every** `<canvas>` inside the map container, each stretched to fill the whole page:

```ts
const canvases = map.getContainer().querySelectorAll("canvas");
canvases.forEach((c) => ctx.drawImage(c, 0, 0, out.width, out.height));
```

The MapLibre raster control adds a small **colorbar/colormap preview** canvas to that same container, filled with a horizontal gradient (`_colorbarCanvas` … `createLinearGradient(0, 0, t, 0)` in `maplibre-gl-components`). That tiny canvas (~280×24) got stretched over the full A4 page and overwrote the real map with a rainbow ramp.

This is why the live map looked fine and the issue showed on the web build: on web the raster is interleaved into MapLibre's own base canvas, so the only stray full-stretch canvas is the colorbar preview.

## Fix

Composite only full-viewport render surfaces (the MapLibre base canvas and, on desktop, the deck.gl overlay), skipping the small control/preview canvases:

- **New** `apps/geolibre-desktop/src/lib/print-capture.ts` — dependency-free `isFullViewportMapCanvas(canvas, base)` helper (keeps a canvas only if it is the base, or ≥90% of the base width and height).
- `print-layout-export.ts` — `captureMapImage` early-returns for any canvas that fails that check.
- **New** `tests/print-capture.test.ts` — unit tests (base kept, full-size deck overlay kept, within-tolerance kept, small colorbar preview dropped, wide-but-short dropped, permissive when base size is unknown).

The helper lives in its own module so it stays unit-testable without pulling jsPDF / the Tauri filesystem bridge through `print-layout-export`.

## Testing

- `node --import tsx --test tests/print-capture.test.ts` — 6/6 pass.
- Existing `tests/print-layout.test.ts`, `tests/print-legend.test.ts`, `tests/layout-options.test.ts` — 37/37 pass.
- `pre-commit run --files …` — all hooks pass, including the full `npm build`.

## Notes

- Separate, pre-existing minor limitation (not addressed here): the print **legend** still shows a single neutral gray swatch for raster layers rather than the colormap ramp.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map image export (PNG/PDF) to composite only the full-viewport map render canvas, preventing non-map canvases such as controls, previews/colormaps, and charts from overwriting or polluting the final snapshot.

* **Tests**
  * Added coverage for the canvas-selection logic, including identity handling for the base canvas and boundary checks for “near full-viewport” sizing and unknown base dimensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->