### PR TITLE
feat(whitebox): in-browser WASM runtime with raster I/O

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -1271,7 +1271,15 @@ export function DesktopShell({
         onOpenChange={setDiagnosticsOpen}
       />
       <Suspense fallback={null}>
-        <ProcessingDialog mapControllerRef={mapControllerRef} />
+        <ProcessingDialog
+          mapControllerRef={mapControllerRef}
+          onAddRaster={async (bytes, name) => {
+            const file = new File([bytes as BlobPart], `${name}.tif`, {
+              type: "image/tiff",
+            });
+            await addRasterToMap(createAppAPI(mapControllerRef), file, { name });
+          }}
+        />
       </Suspense>
       <Suspense fallback={null}>
         <ConversionDialog />

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -1274,6 +1274,8 @@ export function DesktopShell({
         <ProcessingDialog
           mapControllerRef={mapControllerRef}
           onAddRaster={async (bytes, name) => {
+            // Cast required: TS types Uint8Array as Uint8Array<ArrayBufferLike>,
+            // which is not directly assignable to BlobPart under this lib.
             const file = new File([bytes as BlobPart], `${name}.tif`, {
               type: "image/tiff",
             });

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -554,6 +554,7 @@ export function LayerPanel({
 
   const handleExportRasterLayer = useCallback(
     async (layer: GeoLibreLayer) => {
+      clearRefreshStatusTimer(layer.id);
       try {
         const savedPath = await exportRasterLayer(
           layer,
@@ -579,7 +580,7 @@ export function LayerPanel({
         scheduleStatusClear(layer.id);
       }
     },
-    [scheduleStatusClear],
+    [clearRefreshStatusTimer, scheduleStatusClear],
   );
 
   // Read through a ref inside interval callbacks so long-lived timers never

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -78,6 +78,10 @@ import {
   setLayerRefreshConfig,
 } from "../../lib/layer-refresh";
 import {
+  canExportRasterLayer,
+  exportRasterLayer,
+} from "../../lib/raster-export";
+import {
   exportVectorLayer,
   geojsonVectorSourceId,
   resolveLayerGeojson,
@@ -546,6 +550,36 @@ export function LayerPanel({
       }
     },
     [clearRefreshStatusTimer, mapControllerRef, scheduleStatusClear],
+  );
+
+  const handleExportRasterLayer = useCallback(
+    async (layer: GeoLibreLayer) => {
+      try {
+        const savedPath = await exportRasterLayer(
+          layer,
+          sanitizeExportFileName(layer.name),
+        );
+        // A null path means the user cancelled the save dialog, so no note.
+        if (savedPath !== null) {
+          setRefreshStatuses((current) => ({
+            ...current,
+            [layer.id]: { type: "success", message: "Raster exported." },
+          }));
+          scheduleStatusClear(layer.id);
+        }
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Could not export this raster.";
+        setRefreshStatuses((current) => ({
+          ...current,
+          [layer.id]: { type: "error", message },
+        }));
+        scheduleStatusClear(layer.id);
+      }
+    },
+    [scheduleStatusClear],
   );
 
   // Read through a ref inside interval callbacks so long-lived timers never
@@ -1067,6 +1101,9 @@ export function LayerPanel({
             // Export writes the layer's GeoJSON features to disk; only
             // geojson-backed vector layers carry those features.
             const canExportLayer = layer.type === "geojson";
+            // Raster/COG layers backed by a downloadable file (a retained
+            // local-bytes blob URL or a source URL) export to GeoTIFF.
+            const canExportRaster = canExportRasterLayer(layer);
             const canRefresh = isRefreshableLayer(layer);
             const refreshConfig = getLayerRefreshConfig(layer);
             const refreshStatus = refreshStatuses[layer.id];
@@ -1479,6 +1516,24 @@ export function LayerPanel({
                               }}
                             >
                               CSV (attributes only)
+                            </DropdownMenuItem>
+                          </DropdownMenuSubContent>
+                        </DropdownMenuSub>
+                      )}
+                      {canExportRaster && (
+                        <DropdownMenuSub>
+                          <DropdownMenuSubTrigger>
+                            <Download className="h-3.5 w-3.5" />
+                            Export
+                          </DropdownMenuSubTrigger>
+                          <DropdownMenuSubContent>
+                            <DropdownMenuItem
+                              onSelect={(e: Event) => {
+                                e.preventDefault();
+                                void handleExportRasterLayer(layer);
+                              }}
+                            >
+                              GeoTIFF (COG)
                             </DropdownMenuItem>
                           </DropdownMenuSubContent>
                         </DropdownMenuSub>

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -564,7 +564,10 @@ export function LayerPanel({
         if (savedPath !== null) {
           setRefreshStatuses((current) => ({
             ...current,
-            [layer.id]: { type: "success", message: "Raster exported." },
+            [layer.id]: {
+              type: "success",
+              message: t("layers.exportRasterSuccess"),
+            },
           }));
           scheduleStatusClear(layer.id);
         }
@@ -572,7 +575,7 @@ export function LayerPanel({
         const message =
           error instanceof Error
             ? error.message
-            : "Could not export this raster.";
+            : t("layers.exportRasterError");
         setRefreshStatuses((current) => ({
           ...current,
           [layer.id]: { type: "error", message },
@@ -580,7 +583,7 @@ export function LayerPanel({
         scheduleStatusClear(layer.id);
       }
     },
-    [clearRefreshStatusTimer, scheduleStatusClear],
+    [clearRefreshStatusTimer, scheduleStatusClear, t],
   );
 
   // Read through a ref inside interval callbacks so long-lived timers never
@@ -1534,7 +1537,7 @@ export function LayerPanel({
                                 void handleExportRasterLayer(layer);
                               }}
                             >
-                              GeoTIFF (COG)
+                              {t("layers.exportGeoTiff")}
                             </DropdownMenuItem>
                           </DropdownMenuSubContent>
                         </DropdownMenuSub>

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -57,6 +57,7 @@ import {
   pickSavePathWithFallback,
   type FileDialogFilter,
 } from "../../lib/tauri-io";
+import { fetchableUrl } from "../../lib/url-utils";
 import { startGeoLibreSidecar, stopGeoLibreSidecar } from "../../lib/sidecar";
 
 interface ProcessingDialogProps {
@@ -235,16 +236,6 @@ function layerPath(layer: GeoLibreLayer): string {
   const tiles = layer.source.tiles;
   if (Array.isArray(tiles) && typeof tiles[0] === "string") return tiles[0];
   return "";
-}
-
-// Resolve a fetchable http/blob/data URL from a layer source value, stripping a
-// MapLibre custom protocol prefix (e.g. "cog://https://..." or "cog://blob:...").
-function fetchableUrl(value: unknown): string | null {
-  if (typeof value !== "string" || value.length === 0) return null;
-  if (/^(https?|blob|data|file):/i.test(value)) return value;
-  const inner = value.match(/^[a-z][\w+.-]*:\/\/(.+)$/i);
-  if (inner && /^(https?|blob|data):/i.test(inner[1])) return inner[1];
-  return null;
 }
 
 // Fetch a raster/LiDAR layer's underlying bytes for the in-browser WASM runner.
@@ -684,7 +675,10 @@ export function ProcessingDialog({
           };
         } else if (runLocal && (kind === "raster_in" || kind === "lidar_in")) {
           // WASM runs in-browser: pass the layer's actual bytes (fetched here),
-          // not a path. Fall back to a path/the sidecar when not fetchable.
+          // not a path. When the bytes are not fetchable in the browser (e.g. a
+          // desktop file path), fall back to the path: the WASM runner tries to
+          // fetch it as a URL and, failing that, surfaces a clear "data is not
+          // fetchable here; turn off Run locally" error (see wasm-client.ts).
           const bytes = await fetchLayerBytes(layer);
           if (bytes) {
             layerInputs[param.name] = { name: layer.name, kind, bytes };

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -518,6 +518,9 @@ export function ProcessingDialog({
 
   useEffect(() => {
     setValues(createDefaultValues(selectedTool));
+    // Drop any browsed input bytes from the previous tool so they cannot be
+    // silently reused by a same-named parameter on the new tool.
+    browsedInputsRef.current.clear();
     setJob(null);
     importedJobIdRef.current = null;
   }, [selectedTool?.id]);

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -50,6 +50,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { useTranslation } from "react-i18next";
 import {
   isTauri,
   openLocalDataFileWithFallback,
@@ -349,6 +350,7 @@ export function ProcessingDialog({
   mapControllerRef,
   onAddRaster,
 }: ProcessingDialogProps) {
+  const { t } = useTranslation();
   const open = useAppStore((s) => s.ui.processingOpen);
   const setProcessingOpen = useAppStore((s) => s.setProcessingOpen);
   const layers = useAppStore((s) => s.layers);
@@ -362,8 +364,10 @@ export function ProcessingDialog({
   const [loadingTools, setLoadingTools] = useState(false);
   const [runtimeMessage, setRuntimeMessage] = useState("");
   const [runtimeAvailable, setRuntimeAvailable] = useState<boolean | null>(null);
-  // Run tools locally in WebAssembly (no Python sidecar). Default on.
-  const [runLocal, setRunLocal] = useState(true);
+  // Run tools locally in WebAssembly (no Python sidecar). Default on in the
+  // browser, where there is no sidecar; off under Tauri, where the sidecar is
+  // available and can read native file paths that the WASM runner cannot fetch.
+  const [runLocal, setRunLocal] = useState(!isTauri());
   const [error, setError] = useState<string | null>(null);
   const [startingServer, setStartingServer] = useState(false);
   const [stoppingServer, setStoppingServer] = useState(false);
@@ -449,7 +453,7 @@ export function ProcessingDialog({
     // parameter UI.
     if (runLocal) {
       await applyRemoteCatalogSnapshot(
-        "Running locally with WebAssembly. No sidecar required.",
+        t("processing.whitebox.runningLocally"),
         false,
       );
       setLoadingTools(false);
@@ -509,7 +513,7 @@ export function ProcessingDialog({
     } finally {
       setLoadingTools(false);
     }
-  }, [runLocal]);
+  }, [runLocal, t]);
 
   useEffect(() => {
     if (!open) return;
@@ -886,7 +890,7 @@ export function ProcessingDialog({
                 </div>
                 <label
                   className="flex items-center gap-1.5 text-xs text-muted-foreground"
-                  title="Run locally in WebAssembly (no Python sidecar)"
+                  title={t("processing.whitebox.runLocalHint")}
                 >
                   <input
                     type="checkbox"
@@ -894,7 +898,7 @@ export function ProcessingDialog({
                     checked={runLocal}
                     onChange={(e) => setRunLocal(e.target.checked)}
                   />
-                  Run locally (WASM)
+                  {t("processing.whitebox.runLocal")}
                 </label>
                 <Button
                   type="button"

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -372,6 +372,10 @@ export function ProcessingDialog({
   const [startingServer, setStartingServer] = useState(false);
   const [stoppingServer, setStoppingServer] = useState(false);
   const [job, setJob] = useState<WhiteboxJob | null>(null);
+  // True while a run is in flight. The WASM runner resolves straight to a
+  // terminal job (never "pending"/"running"), so without this flag the Run
+  // button would stay enabled mid-execution and allow concurrent runs.
+  const [runningLocal, setRunningLocal] = useState(false);
   const importedJobIdRef = useRef<string | null>(null);
   // Bytes of input files the user browsed from disk (web build, where the
   // browser cannot expose a real path). Keyed by parameter name; consumed by
@@ -701,6 +705,7 @@ export function ProcessingDialog({
     }
 
     try {
+      setRunningLocal(true);
       const request = {
         tool_id: selectedTool.id,
         parameters,
@@ -716,6 +721,8 @@ export function ProcessingDialog({
       setError(
         err instanceof Error ? err.message : "Could not start Whitebox tool.",
       );
+    } finally {
+      setRunningLocal(false);
     }
   };
 
@@ -751,7 +758,8 @@ export function ProcessingDialog({
     }
   };
 
-  const running = Boolean(job && RUNNING_JOB_STATUSES.has(job.status));
+  const running =
+    runningLocal || Boolean(job && RUNNING_JOB_STATUSES.has(job.status));
   const serverBusy = loadingTools || startingServer || stoppingServer;
 
   return (

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -8,6 +8,7 @@ import {
   fetchWhiteboxStatus,
   fetchWhiteboxTools,
   runWhiteboxTool,
+  runWhiteboxToolWasm,
   type WhiteboxJob,
   type WhiteboxLayerInput,
   type WhiteboxTool,
@@ -50,6 +51,8 @@ import {
   useState,
 } from "react";
 import {
+  isTauri,
+  openLocalDataFileWithFallback,
   pickLocalPathWithFallback,
   pickSavePathWithFallback,
   type FileDialogFilter,
@@ -58,6 +61,10 @@ import { startGeoLibreSidecar, stopGeoLibreSidecar } from "../../lib/sidecar";
 
 interface ProcessingDialogProps {
   mapControllerRef: React.RefObject<MapController | null>;
+  // Renders a raster tool output (a Cloud Optimized GeoTIFF, from the WASM
+  // runner) as a new map layer. Wired by the desktop shell, which owns the
+  // raster control / app API.
+  onAddRaster?: (bytes: Uint8Array, name: string) => Promise<void> | void;
 }
 
 type ParameterValues = Record<string, unknown>;
@@ -230,6 +237,46 @@ function layerPath(layer: GeoLibreLayer): string {
   return "";
 }
 
+// Resolve a fetchable http/blob/data URL from a layer source value, stripping a
+// MapLibre custom protocol prefix (e.g. "cog://https://..." or "cog://blob:...").
+function fetchableUrl(value: unknown): string | null {
+  if (typeof value !== "string" || value.length === 0) return null;
+  if (/^(https?|blob|data|file):/i.test(value)) return value;
+  const inner = value.match(/^[a-z][\w+.-]*:\/\/(.+)$/i);
+  if (inner && /^(https?|blob|data):/i.test(inner[1])) return inner[1];
+  return null;
+}
+
+// Fetch a raster/LiDAR layer's underlying bytes for the in-browser WASM runner.
+// Returns null when the data is not directly fetchable (e.g. a desktop file
+// path or a tile template), in which case the caller falls back to the sidecar.
+async function fetchLayerBytes(layer: GeoLibreLayer): Promise<Uint8Array | null> {
+  const src = layer.source as Record<string, unknown>;
+  const tiles = Array.isArray(src.tiles) ? src.tiles : [];
+  // localBytesUrl is a blob URL retaining a File-loaded raster's bytes (see
+  // addRasterToMap); prefer it so locally dropped rasters are WASM-runnable.
+  const candidates = [
+    layer.metadata.localBytesUrl,
+    src.url,
+    tiles[0],
+    layer.sourcePath,
+  ];
+  for (const candidate of candidates) {
+    const url = fetchableUrl(candidate);
+    if (!url) continue;
+    try {
+      const res = await fetch(url);
+      if (!res.ok) continue;
+      const bytes = new Uint8Array(await res.arrayBuffer());
+      if (bytes.length === 0 || bytes[0] === 0x3c) continue; // 0x3c '<' = HTML
+      return bytes;
+    } catch {
+      // try the next candidate
+    }
+  }
+  return null;
+}
+
 function canUseLayerForParameter(
   layer: GeoLibreLayer,
   param: WhiteboxToolParameter,
@@ -309,6 +356,7 @@ function jobStatusTone(job: WhiteboxJob | null): string {
 
 export function ProcessingDialog({
   mapControllerRef,
+  onAddRaster,
 }: ProcessingDialogProps) {
   const open = useAppStore((s) => s.ui.processingOpen);
   const setProcessingOpen = useAppStore((s) => s.setProcessingOpen);
@@ -323,11 +371,20 @@ export function ProcessingDialog({
   const [loadingTools, setLoadingTools] = useState(false);
   const [runtimeMessage, setRuntimeMessage] = useState("");
   const [runtimeAvailable, setRuntimeAvailable] = useState<boolean | null>(null);
+  // Run tools locally in WebAssembly (no Python sidecar). Default on.
+  const [runLocal, setRunLocal] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [startingServer, setStartingServer] = useState(false);
   const [stoppingServer, setStoppingServer] = useState(false);
   const [job, setJob] = useState<WhiteboxJob | null>(null);
   const importedJobIdRef = useRef<string | null>(null);
+  // Bytes of input files the user browsed from disk (web build, where the
+  // browser cannot expose a real path). Keyed by parameter name; consumed by
+  // the in-browser WASM runner. GeoJSON files are parsed up front so vector
+  // tools receive a FeatureCollection, matching the layer-input path.
+  const browsedInputsRef = useRef<
+    Map<string, { name: string; bytes: Uint8Array; geojson?: FeatureCollection }>
+  >(new Map());
 
   const selectedTool = useMemo(
     () => tools.find((tool) => tool.id === selectedToolId) ?? tools[0] ?? null,
@@ -395,6 +452,19 @@ export function ProcessingDialog({
       }
     };
 
+    // In WASM mode the tools run in-browser, so skip the Python sidecar probe
+    // entirely (on the web build that request 404s to the SPA index.html, which
+    // is the "Unexpected token '<'" JSON error). Just load the catalog for the
+    // parameter UI.
+    if (runLocal) {
+      await applyRemoteCatalogSnapshot(
+        "Running locally with WebAssembly. No sidecar required.",
+        false,
+      );
+      setLoadingTools(false);
+      return;
+    }
+
     try {
       const status = await fetchWhiteboxStatus();
       setRuntimeAvailable(status.available);
@@ -448,7 +518,7 @@ export function ProcessingDialog({
     } finally {
       setLoadingTools(false);
     }
-  }, []);
+  }, [runLocal]);
 
   useEffect(() => {
     if (!open) return;
@@ -489,18 +559,44 @@ export function ProcessingDialog({
   }, [job]);
 
   const updateValue = (name: string, value: unknown) => {
+    // Any manual change (typing a path, picking a layer) invalidates a
+    // previously browsed file's bytes for this parameter.
+    browsedInputsRef.current.delete(name);
     setValues((prev) => ({ ...prev, [name]: value }));
   };
+
+  // Stash a browsed input file's bytes and show its name in the field. Used by
+  // the path-browse button in the web build, where the WASM runner reads bytes
+  // directly instead of a (non-existent in the browser) filesystem path.
+  const handlePickInputFile = useCallback(
+    (paramName: string, fileName: string, bytes: Uint8Array) => {
+      let geojson: FeatureCollection | undefined;
+      if (/\.(geojson|json)$/i.test(fileName)) {
+        try {
+          const parsed = JSON.parse(new TextDecoder().decode(bytes));
+          if (isFeatureCollection(parsed)) geojson = parsed;
+        } catch {
+          // not valid JSON; fall back to raw bytes
+        }
+      }
+      browsedInputsRef.current.set(paramName, { name: fileName, bytes, geojson });
+      setValues((prev) => ({ ...prev, [paramName]: fileName }));
+    },
+    [],
+  );
 
   const importGeoJsonOutputs = useCallback(
     async (nextJob: WhiteboxJob) => {
       if (importedJobIdRef.current === nextJob.id) return;
       importedJobIdRef.current = nextJob.id;
-      const entries = Object.entries(nextJob.outputs)
-        .map(([name, value]) => [name, outputPath(value)] as const)
-        .filter((entry): entry is readonly [string, string] =>
-          Boolean(entry[1] && isJsonOutputPath(entry[1])),
-        );
+      // The sidecar returns output paths (fetched over HTTP); the WASM runner
+      // returns the GeoJSON inline. Handle both: keep inline FeatureCollections,
+      // else keep JSON output paths to fetch.
+      const entries = Object.entries(nextJob.outputs).filter(([, value]) => {
+        if (isFeatureCollection(value)) return true;
+        const path = outputPath(value);
+        return Boolean(path && isJsonOutputPath(path));
+      });
       // Resolve the producing tool from the job itself, not the live
       // `selectedTool`, so switching tools while a job finishes does not
       // mislabel the imported layer.
@@ -508,21 +604,33 @@ export function ProcessingDialog({
       const jobToolLabel = jobTool
         ? toolLabel(jobTool)
         : humanize(nextJob.tool_id);
-      for (const [name, path] of entries) {
-        const data = await fetchWhiteboxJsonOutput(path);
+      for (const [name, value] of entries) {
+        const path = isFeatureCollection(value) ? "" : (outputPath(value) ?? "");
+        const data = isFeatureCollection(value)
+          ? value
+          : await fetchWhiteboxJsonOutput(path);
         if (!isFeatureCollection(data)) continue;
         const layerId = addGeoJsonLayer(
           `${jobToolLabel} ${humanize(name)}`,
           data,
-          path,
+          path || undefined,
         );
         const layer = useAppStore
           .getState()
           .layers.find((item) => item.id === layerId);
         if (layer) mapControllerRef.current?.fitLayer(layer);
       }
+
+      // Raster outputs come back from the WASM runner as inline COG bytes.
+      // Render each as a new raster layer through the shell-provided handler.
+      if (onAddRaster) {
+        for (const [name, value] of Object.entries(nextJob.outputs)) {
+          if (!(value instanceof Uint8Array)) continue;
+          await onAddRaster(value, `${jobToolLabel} ${humanize(name)}`);
+        }
+      }
     },
-    [addGeoJsonLayer, mapControllerRef, tools],
+    [addGeoJsonLayer, mapControllerRef, onAddRaster, tools],
   );
 
   useEffect(() => {
@@ -552,16 +660,37 @@ export function ProcessingDialog({
         return;
       }
 
+      // A file browsed from disk in the web build: feed its bytes (or parsed
+      // GeoJSON) straight to the WASM runner instead of an unresolvable path.
+      const browsed = browsedInputsRef.current.get(param.name);
+      if (browsed && isDataInputParameter(param)) {
+        const kind = parameterKind(param);
+        layerInputs[param.name] = browsed.geojson
+          ? { name: browsed.name, kind, geojson: browsed.geojson }
+          : { name: browsed.name, kind, bytes: browsed.bytes };
+        continue;
+      }
+
       if (typeof value === "string" && value.startsWith(LAYER_TOKEN_PREFIX)) {
         const layerId = value.slice(LAYER_TOKEN_PREFIX.length);
         const layer = layers.find((item) => item.id === layerId);
         if (!layer) continue;
-        if (layer.geojson && parameterKind(param) === "vector_in") {
+        const kind = parameterKind(param);
+        if (layer.geojson && kind === "vector_in") {
           layerInputs[param.name] = {
             name: layer.name,
-            kind: parameterKind(param),
+            kind,
             geojson: layer.geojson,
           };
+        } else if (runLocal && (kind === "raster_in" || kind === "lidar_in")) {
+          // WASM runs in-browser: pass the layer's actual bytes (fetched here),
+          // not a path. Fall back to a path/the sidecar when not fetchable.
+          const bytes = await fetchLayerBytes(layer);
+          if (bytes) {
+            layerInputs[param.name] = { name: layer.name, kind, bytes };
+          } else {
+            parameters[param.name] = layerPath(layer);
+          }
         } else {
           parameters[param.name] = layerPath(layer);
         }
@@ -571,15 +700,16 @@ export function ProcessingDialog({
     }
 
     try {
+      const request = {
+        tool_id: selectedTool.id,
+        parameters,
+        tool: selectedTool,
+        layer_inputs: layerInputs,
+        include_pro: false,
+        tier: "open",
+      };
       setJob(
-        await runWhiteboxTool({
-          tool_id: selectedTool.id,
-          parameters,
-          tool: selectedTool,
-          layer_inputs: layerInputs,
-          include_pro: false,
-          tier: "open",
-        }),
+        await (runLocal ? runWhiteboxToolWasm(request) : runWhiteboxTool(request)),
       );
     } catch (err) {
       setError(
@@ -757,6 +887,18 @@ export function ProcessingDialog({
                       : ""}
                   </p>
                 </div>
+                <label
+                  className="flex items-center gap-1.5 text-xs text-muted-foreground"
+                  title="Run locally in WebAssembly (no Python sidecar)"
+                >
+                  <input
+                    type="checkbox"
+                    data-testid="whitebox-run-local"
+                    checked={runLocal}
+                    onChange={(e) => setRunLocal(e.target.checked)}
+                  />
+                  Run locally (WASM)
+                </label>
                 <Button
                   type="button"
                   onClick={runSelectedTool}
@@ -764,7 +906,7 @@ export function ProcessingDialog({
                     !selectedTool ||
                     selectedTool.locked ||
                     running ||
-                    runtimeAvailable !== true
+                    (!runLocal && runtimeAvailable !== true)
                   }
                 >
                   {running ? (
@@ -803,6 +945,9 @@ export function ProcessingDialog({
                       toolId={selectedTool.id}
                       value={values[param.name]}
                       onChange={(value) => updateValue(param.name, value)}
+                      onPickFile={(fileName, bytes) =>
+                        handlePickInputFile(param.name, fileName, bytes)
+                      }
                     />
                   ))
                 )}
@@ -869,6 +1014,7 @@ interface ParameterFieldProps {
   param: WhiteboxToolParameter;
   layers: GeoLibreLayer[];
   onChange: (value: unknown) => void;
+  onPickFile?: (fileName: string, bytes: Uint8Array) => void;
   toolId: string;
   value: unknown;
 }
@@ -877,6 +1023,7 @@ function ParameterField({
   param,
   layers,
   onChange,
+  onPickFile,
   toolId,
   value,
 }: ParameterFieldProps) {
@@ -927,6 +1074,7 @@ function ParameterField({
           param={param}
           value={valueText}
           onChange={onChange}
+          onPickFile={onPickFile}
         />
       ) : isPathParameter(param) ? (
         <PathPickerInput
@@ -935,6 +1083,7 @@ function ParameterField({
           toolId={toolId}
           value={valueText}
           onChange={onChange}
+          onPickFile={onPickFile}
         />
       ) : kind === "int" || kind === "double" ? (
         <NumberStepperInput
@@ -1018,6 +1167,7 @@ interface LayerOrPathInputProps {
   id: string;
   layers: GeoLibreLayer[];
   onChange: (value: unknown) => void;
+  onPickFile?: (fileName: string, bytes: Uint8Array) => void;
   param: WhiteboxToolParameter;
   value: string;
 }
@@ -1026,6 +1176,7 @@ function LayerOrPathInput({
   id,
   layers,
   onChange,
+  onPickFile,
   param,
   value,
 }: LayerOrPathInputProps) {
@@ -1055,6 +1206,7 @@ function LayerOrPathInput({
         mode="open"
         param={param}
         onPick={(path) => onChange(path)}
+        onPickFile={onPickFile}
       />
     </div>
   );
@@ -1063,6 +1215,7 @@ function LayerOrPathInput({
 interface PathPickerInputProps {
   id: string;
   onChange: (value: unknown) => void;
+  onPickFile?: (fileName: string, bytes: Uint8Array) => void;
   param: WhiteboxToolParameter;
   toolId: string;
   value: string;
@@ -1071,6 +1224,7 @@ interface PathPickerInputProps {
 function PathPickerInput({
   id,
   onChange,
+  onPickFile,
   param,
   toolId,
   value,
@@ -1088,6 +1242,7 @@ function PathPickerInput({
         param={param}
         toolId={toolId}
         onPick={(path) => onChange(path)}
+        onPickFile={onPickFile}
       />
     </div>
   );
@@ -1097,6 +1252,7 @@ interface PathBrowseButtonProps {
   disabled?: boolean;
   mode: "open" | "save";
   onPick: (path: string) => void;
+  onPickFile?: (fileName: string, bytes: Uint8Array) => void;
   param: WhiteboxToolParameter;
   toolId?: string;
 }
@@ -1105,23 +1261,45 @@ function PathBrowseButton({
   disabled = false,
   mode,
   onPick,
+  onPickFile,
   param,
   toolId = "whitebox",
 }: PathBrowseButtonProps) {
   const pickPath = async () => {
     const filters = pathFiltersForParameter(param);
-    const path =
-      mode === "save"
-        ? await pickSavePathWithFallback({
-            defaultName: defaultOutputName(toolId, param),
-            filters,
-          })
-        : await pickLocalPathWithFallback({
-            accept: acceptForParameter(param),
-            directory: isDirectoryParameter(param),
-            filters,
-          });
-    if (path) onPick(path);
+    if (mode === "save") {
+      const path = await pickSavePathWithFallback({
+        defaultName: defaultOutputName(toolId, param),
+        filters,
+      });
+      if (path) onPick(path);
+      return;
+    }
+
+    const path = await pickLocalPathWithFallback({
+      accept: acceptForParameter(param),
+      directory: isDirectoryParameter(param),
+      filters,
+    });
+    if (path) {
+      onPick(path);
+      return;
+    }
+
+    // The browser cannot expose a real filesystem path, so pickLocalPath returns
+    // null there. Fall back to reading the chosen file's bytes for the in-browser
+    // WASM runner. (Skipped under Tauri, where null just means the user
+    // cancelled the native dialog, and for directory parameters.)
+    if (!isTauri() && onPickFile && !isDirectoryParameter(param)) {
+      const picked = await openLocalDataFileWithFallback({
+        accept: acceptForParameter(param),
+        filters,
+        readBinary: true,
+      });
+      if (picked?.data) {
+        onPickFile(picked.path, new Uint8Array(picked.data));
+      }
+    }
   };
 
   return (

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -844,6 +844,11 @@
       "selectLayer": "Select a layer...",
       "selectField": "Select a field...",
       "selectLayerFirst": "Select a layer first"
+    },
+    "whitebox": {
+      "runLocal": "Run locally (WASM)",
+      "runLocalHint": "Run locally in WebAssembly (no Python sidecar)",
+      "runningLocally": "Running locally with WebAssembly. No sidecar required."
     }
   },
   "segmentation": {
@@ -873,6 +878,9 @@
     "layerNameDefault": "Segmentation"
   },
   "layers": {
+    "exportGeoTiff": "GeoTIFF (COG)",
+    "exportRasterSuccess": "Raster exported.",
+    "exportRasterError": "Could not export this raster.",
     "newGroup": "New group",
     "collapseGroup": "Collapse group",
     "expandGroup": "Expand group",

--- a/apps/geolibre-desktop/src/lib/raster-export.ts
+++ b/apps/geolibre-desktop/src/lib/raster-export.ts
@@ -1,0 +1,74 @@
+import type { GeoLibreLayer } from "@geolibre/core";
+
+import { saveBinaryFileWithFallback } from "./tauri-io";
+
+// Accept http(s)/blob/data/file URLs and unwrap a `cog://`-style wrapper, the
+// same scheme handling the Processing dialog uses to read raster bytes.
+function fetchableUrl(value: unknown): string | null {
+  if (typeof value !== "string" || value.length === 0) return null;
+  if (/^(https?|blob|data|file):/i.test(value)) return value;
+  const inner = value.match(/^[a-z][\w+.-]*:\/\/(.+)$/i);
+  if (inner && /^(https?|blob|data):/i.test(inner[1])) return inner[1];
+  return null;
+}
+
+/**
+ * A fetchable URL for a raster layer's underlying GeoTIFF/COG bytes, or null.
+ *
+ * Prefers the retained local-bytes blob URL (File-loaded rasters and Whitebox
+ * tool outputs carry one on `metadata.localBytesUrl`), then the layer's source
+ * URL. Tile-template rasters have no single file to export, so they return null.
+ *
+ * @param layer - The raster store layer.
+ * @returns A URL whose bytes are a single GeoTIFF/COG, or null.
+ */
+export function rasterExportUrl(layer: GeoLibreLayer): string | null {
+  const src = layer.source as Record<string, unknown>;
+  return fetchableUrl(layer.metadata.localBytesUrl) ?? fetchableUrl(src.url);
+}
+
+/**
+ * Whether a raster layer can be exported to a single GeoTIFF file.
+ *
+ * @param layer - The layer to test.
+ * @returns True for raster/COG layers backed by a downloadable file.
+ */
+export function canExportRasterLayer(layer: GeoLibreLayer): boolean {
+  return (
+    (layer.type === "cog" || layer.type === "raster") &&
+    rasterExportUrl(layer) !== null
+  );
+}
+
+/**
+ * Save a raster layer's GeoTIFF/COG bytes to disk through the native (Tauri) or
+ * browser save dialog. Whitebox already writes Cloud Optimized GeoTIFFs, so the
+ * bytes are saved as-is.
+ *
+ * @param layer - The raster store layer to export.
+ * @param baseName - A sanitized base file name (without extension).
+ * @returns The saved path, or null if the user cancelled the save dialog.
+ * @throws If the raster has no downloadable source or its bytes cannot be read.
+ */
+export async function exportRasterLayer(
+  layer: GeoLibreLayer,
+  baseName: string,
+): Promise<string | null> {
+  const url = rasterExportUrl(layer);
+  if (!url) {
+    throw new Error("This raster has no downloadable source file.");
+  }
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error("Could not read the raster's data for export.");
+  }
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  return saveBinaryFileWithFallback(bytes, {
+    defaultName: `${baseName}.tif`,
+    filters: [{ name: "GeoTIFF", extensions: ["tif", "tiff"] }],
+    browserTypes: [
+      { description: "GeoTIFF", accept: { "image/tiff": [".tif", ".tiff"] } },
+    ],
+    mimeType: "image/tiff",
+  });
+}

--- a/apps/geolibre-desktop/src/lib/raster-export.ts
+++ b/apps/geolibre-desktop/src/lib/raster-export.ts
@@ -1,16 +1,7 @@
 import type { GeoLibreLayer } from "@geolibre/core";
 
 import { saveBinaryFileWithFallback } from "./tauri-io";
-
-// Accept http(s)/blob/data/file URLs and unwrap a `cog://`-style wrapper, the
-// same scheme handling the Processing dialog uses to read raster bytes.
-function fetchableUrl(value: unknown): string | null {
-  if (typeof value !== "string" || value.length === 0) return null;
-  if (/^(https?|blob|data|file):/i.test(value)) return value;
-  const inner = value.match(/^[a-z][\w+.-]*:\/\/(.+)$/i);
-  if (inner && /^(https?|blob|data):/i.test(inner[1])) return inner[1];
-  return null;
-}
+import { fetchableUrl } from "./url-utils";
 
 /**
  * A fetchable URL for a raster layer's underlying GeoTIFF/COG bytes, or null.

--- a/apps/geolibre-desktop/src/lib/url-utils.ts
+++ b/apps/geolibre-desktop/src/lib/url-utils.ts
@@ -1,19 +1,19 @@
 /**
  * A browser-fetchable URL for a layer source value, or null.
  *
- * Accepts direct `http(s)`, `blob:`, `data:`, and `file:` URLs, and unwraps a
- * single `scheme://`-prefixed wrapper (e.g. a `cog://https://.../x.tif` COG
- * reference) when the inner value is itself web-fetchable. Wrapped `file://`
- * URLs are intentionally not unwrapped: the wrapper forms only ever carry a
- * remote, range-fetchable inner URL, so a wrapped local path would not be
- * readable by `fetch()` anyway.
+ * Accepts direct `http(s)`, `blob:`, and `data:` URLs, and unwraps a single
+ * `scheme://`-prefixed wrapper (e.g. a `cog://https://.../x.tif` COG reference)
+ * when the inner value is itself web-fetchable. `file:` URLs are deliberately
+ * excluded: `fetch("file://...")` throws in a standard browser and is blocked
+ * in the Tauri WebView, so treating them as fetchable would make callers (e.g.
+ * the raster export menu) offer actions that then fail.
  *
  * @param value - A candidate source value (often `unknown` from layer metadata).
  * @returns The fetchable URL string, or null when the value is not fetchable.
  */
 export function fetchableUrl(value: unknown): string | null {
   if (typeof value !== "string" || value.length === 0) return null;
-  if (/^(https?|blob|data|file):/i.test(value)) return value;
+  if (/^(https?|blob|data):/i.test(value)) return value;
   const inner = value.match(/^[a-z][\w+.-]*:\/\/(.+)$/i);
   if (inner && /^(https?|blob|data):/i.test(inner[1])) return inner[1];
   return null;

--- a/apps/geolibre-desktop/src/lib/url-utils.ts
+++ b/apps/geolibre-desktop/src/lib/url-utils.ts
@@ -1,0 +1,20 @@
+/**
+ * A browser-fetchable URL for a layer source value, or null.
+ *
+ * Accepts direct `http(s)`, `blob:`, `data:`, and `file:` URLs, and unwraps a
+ * single `scheme://`-prefixed wrapper (e.g. a `cog://https://.../x.tif` COG
+ * reference) when the inner value is itself web-fetchable. Wrapped `file://`
+ * URLs are intentionally not unwrapped: the wrapper forms only ever carry a
+ * remote, range-fetchable inner URL, so a wrapped local path would not be
+ * readable by `fetch()` anyway.
+ *
+ * @param value - A candidate source value (often `unknown` from layer metadata).
+ * @returns The fetchable URL string, or null when the value is not fetchable.
+ */
+export function fetchableUrl(value: unknown): string | null {
+  if (typeof value !== "string" || value.length === 0) return null;
+  if (/^(https?|blob|data|file):/i.test(value)) return value;
+  const inner = value.match(/^[a-z][\w+.-]*:\/\/(.+)$/i);
+  if (inner && /^(https?|blob|data):/i.test(inner[1])) return inner[1];
+  return null;
+}

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -785,6 +785,10 @@ export default defineConfig({
       "@electric-sql/pglite",
       "@electric-sql/pglite-postgis",
       "@cereusdb/standard",
+      // whitebox-wasm/tools loads its bundled whitebox-cli.wasm via
+      // `new URL("./whitebox-cli.wasm", import.meta.url)`; esbuild pre-bundling
+      // mangles that asset reference, so serve it as-is.
+      "whitebox-wasm",
     ],
   },
   build: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2441,6 +2441,12 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bjorn3/browser_wasi_shim": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@bjorn3/browser_wasi_shim/-/browser_wasi_shim-0.4.2.tgz",
+      "integrity": "sha512-/iHkCVUG3VbcbmEHn5iIUpIrh7a7WPiwZ3sHy4HZKZzBdSadwdddYDZAII2zBvQYV0Lfi8naZngPCN7WPHI/hA==",
+      "license": "MIT OR Apache-2.0"
+    },
     "node_modules/@carbonplan/zarr-layer": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@carbonplan/zarr-layer/-/zarr-layer-0.5.0.tgz",
@@ -22674,6 +22680,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/whitebox-wasm": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/whitebox-wasm/-/whitebox-wasm-0.4.0.tgz",
+      "integrity": "sha512-MGtesUVK4au7C+11Vb/v/HNA1vl/vU4t29mzsoTosySSkDZoGyTtjQkug7lDcB6tNvxRShpV7iY3cHXrTcqXuA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@bjorn3/browser_wasi_shim": "^0.4.2"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -24378,6 +24393,7 @@
       "name": "@geolibre/processing",
       "version": "1.4.0",
       "dependencies": {
+        "@bjorn3/browser_wasi_shim": "^0.4.2",
         "@geolibre/core": "*",
         "@turf/area": "^7.3.5",
         "@turf/bbox": "^7.3.5",
@@ -24397,7 +24413,8 @@
         "@turf/tin": "^7.3.5",
         "@turf/union": "^7.3.5",
         "@turf/voronoi": "^7.3.5",
-        "geotiff": "^3.0.5"
+        "geotiff": "^3.0.5",
+        "whitebox-wasm": "^0.4.0"
       },
       "devDependencies": {
         "@types/geojson": "^7946.0.16",

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -161,6 +161,10 @@ export async function addRasterToMap(
     const store = useAppStore.getState();
     const layer = store.layers.find((current) => current.id === id);
     if (layer) {
+      // Defensive: if this id ever reused an existing entry, revoke the old
+      // blob URL before replacing it so it cannot leak.
+      const previous = localBytesUrls.get(id);
+      if (previous) URL.revokeObjectURL(previous);
       const blobUrl = URL.createObjectURL(source);
       localBytesUrls.set(id, blobUrl);
       store.updateLayer(id, {

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -144,7 +144,27 @@ export async function addRasterToMap(
   if (!control) {
     throw new Error("The raster control could not be initialized.");
   }
-  await control.addRaster(source, { name: options.name, zoomTo: true });
+  const id = await control.addRaster(source, {
+    name: options.name,
+    zoomTo: true,
+  });
+  // Retain the source bytes for File-backed rasters. The store layer only
+  // records the file name (no fetchable URL), so in-browser tools (the WASM
+  // Whitebox runner) could not read it back. Stamp a blob URL onto the layer
+  // so the data stays runnable for the lifetime of the session. The raster
+  // store sync preserves this key across its metadata rebuilds.
+  if (typeof source !== "string") {
+    const store = useAppStore.getState();
+    const layer = store.layers.find((current) => current.id === id);
+    if (layer) {
+      store.updateLayer(id, {
+        metadata: {
+          ...layer.metadata,
+          localBytesUrl: URL.createObjectURL(source),
+        },
+      });
+    }
+  }
 }
 
 /**

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -83,6 +83,10 @@ let rasterControl: RasterControl | null = null;
 let rasterControlMounted = false;
 let restorePanelExpandTimeout: number | null = null;
 let rasterControlInterleaved = true;
+// Blob URLs minted for File-backed rasters (see addRasterToMap), keyed by
+// raster layer id. Tracked here so they can be revoked when the raster is
+// removed; otherwise each would leak until the page unloads.
+const localBytesUrls = new Map<string, string>();
 
 /**
  * Opens the maplibre-gl-raster panel, mounting the control on first use.
@@ -157,10 +161,12 @@ export async function addRasterToMap(
     const store = useAppStore.getState();
     const layer = store.layers.find((current) => current.id === id);
     if (layer) {
+      const blobUrl = URL.createObjectURL(source);
+      localBytesUrls.set(id, blobUrl);
       store.updateLayer(id, {
         metadata: {
           ...layer.metadata,
-          localBytesUrl: URL.createObjectURL(source),
+          localBytesUrl: blobUrl,
         },
       });
     }
@@ -396,9 +402,16 @@ function createRasterControl(
   for (const event of ["rasteradd", "rasterchange", "rasterremove"] as const) {
     control.on(event, () => syncRasterLayersToStoreForRuntime(control));
   }
-  // Free the per-layer classification GPU texture when its raster is dropped.
+  // Free the per-layer classification GPU texture, and revoke any retained
+  // local-bytes blob URL, when its raster is dropped.
   control.on("rasterremove", (event) => {
-    if (event.layerId) disposeRasterClassification(event.layerId);
+    if (!event.layerId) return;
+    disposeRasterClassification(event.layerId);
+    const blobUrl = localBytesUrls.get(event.layerId);
+    if (blobUrl) {
+      URL.revokeObjectURL(blobUrl);
+      localBytesUrls.delete(event.layerId);
+    }
   });
   // syncRasterLayersToStore re-reads getState().collapsed when these fire.
   // Safe: expand()/collapse() delegate to toggle(), which flips

--- a/packages/plugins/src/plugins/raster-layer-sync.ts
+++ b/packages/plugins/src/plugins/raster-layer-sync.ts
@@ -164,15 +164,22 @@ export function syncRasterLayersToStoreWithOptions(
         continue;
       }
 
-      // rasterSymbology (discrete classification) is GeoLibre-owned and not
-      // present on RasterLayerInfo, so carry it forward across the wholesale
-      // metadata rebuild instead of letting every control event wipe it.
+      // rasterSymbology (discrete classification) and localBytesUrl (a blob URL
+      // retaining a File-loaded raster's bytes for in-browser tools) are
+      // GeoLibre-owned and absent from RasterLayerInfo, so carry them forward
+      // across the wholesale metadata rebuild instead of letting every control
+      // event wipe them.
+      const preserved = {
+        ...(existing.metadata.rasterSymbology !== undefined
+          ? { rasterSymbology: existing.metadata.rasterSymbology }
+          : {}),
+        ...(existing.metadata.localBytesUrl !== undefined
+          ? { localBytesUrl: existing.metadata.localBytesUrl }
+          : {}),
+      };
       const metadata =
-        existing.metadata.rasterSymbology !== undefined
-          ? {
-              ...layer.metadata,
-              rasterSymbology: existing.metadata.rasterSymbology,
-            }
+        Object.keys(preserved).length > 0
+          ? { ...layer.metadata, ...preserved }
           : layer.metadata;
 
       if (

--- a/packages/processing/package.json
+++ b/packages/processing/package.json
@@ -9,11 +9,10 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
+    "@bjorn3/browser_wasi_shim": "^0.4.2",
     "@geolibre/core": "*",
     "@turf/area": "^7.3.5",
     "@turf/bbox": "^7.3.5",
-    "@turf/tin": "^7.3.5",
-    "@turf/voronoi": "^7.3.5",
     "@turf/boolean-contains": "^7.3.5",
     "@turf/boolean-intersects": "^7.3.5",
     "@turf/boolean-within": "^7.3.5",
@@ -27,8 +26,11 @@
     "@turf/helpers": "^7.3.5",
     "@turf/intersect": "^7.3.5",
     "@turf/simplify": "^7.3.5",
+    "@turf/tin": "^7.3.5",
     "@turf/union": "^7.3.5",
-    "geotiff": "^3.0.5"
+    "@turf/voronoi": "^7.3.5",
+    "geotiff": "^3.0.5",
+    "whitebox-wasm": "^0.4.0"
   },
   "devDependencies": {
     "@types/geojson": "^7946.0.16",

--- a/packages/processing/src/index.ts
+++ b/packages/processing/src/index.ts
@@ -131,3 +131,8 @@ export {
   type WhiteboxTool,
   type WhiteboxToolParameter,
 } from "./sidecar-client";
+export {
+  runWhiteboxToolWasm,
+  whiteboxWasmAvailable,
+  listWhiteboxWasmTools,
+} from "./wasm-client";

--- a/packages/processing/src/sidecar-client.ts
+++ b/packages/processing/src/sidecar-client.ts
@@ -124,6 +124,9 @@ export interface WhiteboxLayerInput {
   name: string;
   kind: string;
   geojson?: FeatureCollection;
+  /** Raw bytes for non-vector inputs (e.g. a GeoTIFF for a raster_in); used by
+   *  the in-browser WASM runner, ignored by the sidecar. */
+  bytes?: Uint8Array;
 }
 
 export interface RunWhiteboxToolRequest {

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -1,0 +1,207 @@
+// Run WhiteboxTools entirely in the browser via WebAssembly - a drop-in
+// alternative to the Python sidecar for the OSS tool set. `whitebox-wasm/tools`
+// executes the same `wbtools_oss` engine (compiled to a WASI binary) through an
+// in-memory WASI filesystem, so no server, no Python, and no native install is
+// required. Same algorithms and outputs as the sidecar; bounded by WASM's ~4 GiB
+// memory and single-threaded execution (use the sidecar for very large data).
+import type { FeatureCollection } from "geojson";
+import type { RunWhiteboxToolRequest, WhiteboxJob, WhiteboxToolParameter } from "./sidecar-client";
+
+interface ToolRunResult {
+  exitCode: number;
+  stdout: string[];
+  files: Record<string, Uint8Array>;
+}
+
+interface ToolsModule {
+  initTools: (source?: unknown) => Promise<unknown>;
+  listTools: () => Promise<string[]>;
+  runTool: (
+    tool: string,
+    opts: { args?: string[]; input?: Record<string, Uint8Array> },
+  ) => Promise<ToolRunResult>;
+}
+
+let toolsModulePromise: Promise<ToolsModule> | null = null;
+
+function loadToolsModule(): Promise<ToolsModule> {
+  // Lazy import: the ~5 MB (gzipped) WASI runtime only downloads on first use.
+  toolsModulePromise ??= import("whitebox-wasm/tools") as unknown as Promise<ToolsModule>;
+  return toolsModulePromise;
+}
+
+/** Whether the in-browser WASM tool runner can be loaded in this build. */
+export async function whiteboxWasmAvailable(): Promise<boolean> {
+  try {
+    await loadToolsModule();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** List every tool id available in the WASM runner (733 of them). */
+export async function listWhiteboxWasmTools(): Promise<string[]> {
+  const { listTools } = await loadToolsModule();
+  return listTools();
+}
+
+function paramKind(p: WhiteboxToolParameter): string {
+  return String(p.kind ?? p.data_kind ?? p.io_role ?? p.type ?? "").toLowerCase();
+}
+
+function isFeatureCollection(value: unknown): value is FeatureCollection {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      (value as { type?: unknown }).type === "FeatureCollection",
+  );
+}
+
+/** TIFF magic: "II*\0" (little-endian) or "MM\0*" (big-endian). */
+function isTiff(b: Uint8Array): boolean {
+  return (
+    b.length >= 4 &&
+    ((b[0] === 0x49 && b[1] === 0x49 && b[2] === 0x2a && b[3] === 0x00) ||
+      (b[0] === 0x4d && b[1] === 0x4d && b[2] === 0x00 && b[3] === 0x2a))
+  );
+}
+
+function describeBytes(b: Uint8Array): string {
+  const head = String.fromCharCode(...b.slice(0, 14));
+  if (/^\s*<(!doctype|html|\?xml)/i.test(head)) return "an HTML/XML page";
+  return `bytes starting with [${Array.from(b.slice(0, 4))
+    .map((n) => n.toString(16).padStart(2, "0"))
+    .join(" ")}]`;
+}
+
+async function fetchBytes(source: unknown): Promise<Uint8Array | null> {
+  if (typeof source !== "string" || source.length === 0) return null;
+  try {
+    const res = await fetch(source);
+    if (!res.ok) return null;
+    return new Uint8Array(await res.arrayBuffer());
+  } catch {
+    return null;
+  }
+}
+
+function job(
+  toolId: string,
+  status: WhiteboxJob["status"],
+  messages: string[],
+  outputs: Record<string, unknown>,
+  error: string | null,
+): WhiteboxJob {
+  const ts = new Date().toISOString();
+  return {
+    id: `wasm-${Date.now().toString(36)}`,
+    status,
+    tool_id: toolId,
+    created_at: ts,
+    updated_at: ts,
+    messages,
+    outputs,
+    result: null,
+    error,
+  };
+}
+
+/**
+ * Run a Whitebox tool in the browser via WASM. Mirrors `runWhiteboxTool` but
+ * executes locally and returns an already-completed {@link WhiteboxJob}. Output
+ * values are inline: a `FeatureCollection` for `vector_out`, or a `Uint8Array`
+ * (Cloud Optimized GeoTIFF) for `raster_out` - never a server path.
+ */
+export async function runWhiteboxToolWasm(
+  request: RunWhiteboxToolRequest,
+): Promise<WhiteboxJob> {
+  const { runTool } = await loadToolsModule();
+  const encoder = new TextEncoder();
+  const input: Record<string, Uint8Array> = {};
+  const args: string[] = [];
+  const outputs: { name: string; file: string; raster: boolean }[] = [];
+
+  for (const param of request.tool?.params ?? []) {
+    const kind = paramKind(param);
+    const name = param.name;
+
+    if (kind === "vector_in") {
+      const geojson = request.layer_inputs?.[name]?.geojson;
+      if (!geojson) throw new Error(`Missing vector input for "${name}"`);
+      const file = `${name}.geojson`;
+      input[file] = encoder.encode(JSON.stringify(geojson));
+      args.push(`--${name}=/work/${file}`);
+    } else if (kind === "raster_in" || kind === "lidar_in") {
+      // Prefer bytes the caller resolved (the dialog fetches the layer's data);
+      // otherwise try to fetch the parameter as a URL.
+      const bytes =
+        request.layer_inputs?.[name]?.bytes ??
+        (await fetchBytes(request.parameters[name]));
+      if (!bytes) {
+        throw new Error(
+          `Could not read raster/LiDAR input "${name}" in the browser. Its data is not fetchable here (only available via the sidecar); turn off "Run locally (WASM)" to use the sidecar.`,
+        );
+      }
+      if (kind === "raster_in" && !isTiff(bytes)) {
+        throw new Error(
+          `Input "${name}" is not a readable GeoTIFF in the browser (received ${describeBytes(bytes)}). Load the raster as a COG/GeoTIFF, or use the sidecar.`,
+        );
+      }
+      const ext = kind === "lidar_in" ? "las" : "tif";
+      const file = `${name}.${ext}`;
+      input[file] = bytes;
+      args.push(`--${name}=/work/${file}`);
+    } else if (kind === "vector_out") {
+      const file = `${name}.geojson`;
+      outputs.push({ name, file, raster: false });
+      args.push(`--${name}=/work/${file}`);
+    } else if (kind === "raster_out") {
+      const file = `${name}.tif`;
+      outputs.push({ name, file, raster: true });
+      args.push(`--${name}=/work/${file}`);
+    } else {
+      const value = request.parameters[name];
+      if (value !== undefined && value !== null && value !== "") {
+        args.push(`--${name}=${value}`);
+      }
+    }
+  }
+
+  const { exitCode, stdout, files } = await runTool(request.tool_id, { args, input });
+  if (exitCode !== 0) {
+    return job(
+      request.tool_id,
+      "failed",
+      stdout,
+      {},
+      stdout.join("\n") || `Tool exited with code ${exitCode}`,
+    );
+  }
+
+  const out: Record<string, unknown> = {};
+  for (const entry of outputs) {
+    const bytes = files[entry.file];
+    if (!bytes) continue;
+    out[entry.name] = entry.raster
+      ? bytes
+      : (JSON.parse(new TextDecoder().decode(bytes)) as FeatureCollection);
+  }
+  return job(request.tool_id, "succeeded", stdout, out, null);
+}
+
+export { isFeatureCollection as isWhiteboxFeatureCollection };
+
+// Dev-only hook so end-to-end tests can drive the WASM runner directly in a real
+// browser without clicking through the UI. Tree-shaken out of production builds.
+if (
+  typeof window !== "undefined" &&
+  typeof import.meta !== "undefined" &&
+  (import.meta as unknown as { env?: { DEV?: boolean } }).env?.DEV
+) {
+  (window as unknown as Record<string, unknown>).__geolibreWhiteboxWasm = {
+    runWhiteboxToolWasm,
+    listWhiteboxWasmTools,
+    whiteboxWasmAvailable,
+  };
+}

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -26,7 +26,15 @@ let toolsModulePromise: Promise<ToolsModule> | null = null;
 
 function loadToolsModule(): Promise<ToolsModule> {
   // Lazy import: the ~5 MB (gzipped) WASI runtime only downloads on first use.
-  toolsModulePromise ??= import("whitebox-wasm/tools") as unknown as Promise<ToolsModule>;
+  // Reset the memoized promise on failure (e.g. a transient network error) so
+  // the next call retries instead of being stuck with a permanently rejected
+  // promise for the rest of the session.
+  toolsModulePromise ??= (
+    import("whitebox-wasm/tools") as unknown as Promise<ToolsModule>
+  ).catch((error) => {
+    toolsModulePromise = null;
+    throw error;
+  });
   return toolsModulePromise;
 }
 

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -102,6 +102,17 @@ function isTiff(b: Uint8Array): boolean {
   return magic === 0x2a || magic === 0x2b;
 }
 
+// LAS/LAZ magic: every LAS and LAZ file begins with the signature "LASF".
+function isLas(b: Uint8Array): boolean {
+  return (
+    b.length >= 4 &&
+    b[0] === 0x4c &&
+    b[1] === 0x41 &&
+    b[2] === 0x53 &&
+    b[3] === 0x46
+  );
+}
+
 function describeBytes(b: Uint8Array): string {
   const head = String.fromCharCode(...b.slice(0, 14));
   if (/^\s*<(!doctype|html|\?xml)/i.test(head)) return "an HTML/XML page";
@@ -167,7 +178,11 @@ export async function runWhiteboxToolWasm(
       const file = `${name}.geojson`;
       input[file] = encoder.encode(JSON.stringify(geojson));
       args.push(`--${name}=/work/${file}`);
-    } else if (kind === "raster_in" || kind === "lidar_in") {
+    } else if (
+      kind === "raster_in" ||
+      kind === "lidar_in" ||
+      kind === "file_in"
+    ) {
       // Prefer bytes the caller resolved (the dialog fetches the layer's data);
       // otherwise try to fetch the parameter as a URL.
       const bytes =
@@ -175,7 +190,7 @@ export async function runWhiteboxToolWasm(
         (await fetchBytes(request.parameters[name]));
       if (!bytes) {
         throw new Error(
-          `Could not read raster/LiDAR input "${name}" in the browser. Its data is not fetchable here (only available via the sidecar); turn off "Run locally (WASM)" to use the sidecar.`,
+          `Could not read input "${name}" in the browser. Its data is not fetchable here (only available via the sidecar); turn off "Run locally (WASM)" to use the sidecar.`,
         );
       }
       if (kind === "raster_in" && !isTiff(bytes)) {
@@ -183,7 +198,13 @@ export async function runWhiteboxToolWasm(
           `Input "${name}" is not a readable GeoTIFF in the browser (received ${describeBytes(bytes)}). Load the raster as a COG/GeoTIFF, or use the sidecar.`,
         );
       }
-      const ext = kind === "lidar_in" ? "las" : "tif";
+      if (kind === "lidar_in" && !isLas(bytes)) {
+        throw new Error(
+          `Input "${name}" is not a readable LAS/LAZ file in the browser (received ${describeBytes(bytes)}). Load a LAS/LAZ file, or use the sidecar.`,
+        );
+      }
+      const ext =
+        kind === "lidar_in" ? "las" : kind === "file_in" ? "dat" : "tif";
       const file = `${name}.${ext}`;
       input[file] = bytes;
       args.push(`--${name}=/work/${file}`);
@@ -191,8 +212,11 @@ export async function runWhiteboxToolWasm(
       const file = `${name}.geojson`;
       outputs.push({ name, file, raster: false });
       args.push(`--${name}=/work/${file}`);
-    } else if (kind === "raster_out") {
-      const file = `${name}.tif`;
+    } else if (kind === "raster_out" || kind === "file_out") {
+      // file_out is treated as an opaque binary output (no GeoJSON parsing),
+      // mirroring how raster outputs are returned as raw bytes.
+      const ext = kind === "file_out" ? "dat" : "tif";
+      const file = `${name}.${ext}`;
       outputs.push({ name, file, raster: true });
       args.push(`--${name}=/work/${file}`);
     } else {
@@ -222,18 +246,16 @@ export async function runWhiteboxToolWasm(
       out[entry.name] = bytes;
       continue;
     }
-    // Skip a vector output whose JSON is malformed (e.g. a tool that crashed
-    // mid-write) rather than letting one bad file reject the whole job and lose
+    // Skip a vector output that is not a valid FeatureCollection - malformed
+    // JSON (e.g. a tool that crashed mid-write) or valid JSON of the wrong
+    // shape - rather than letting one bad file reject the whole job and lose
     // every other output. Matches the sidecar path's tolerant handling.
     try {
-      out[entry.name] = JSON.parse(
-        new TextDecoder().decode(bytes),
-      ) as FeatureCollection;
+      const parsed: unknown = JSON.parse(new TextDecoder().decode(bytes));
+      if (isFeatureCollection(parsed)) out[entry.name] = parsed;
     } catch {
       // leave this output out
     }
   }
   return job(request.tool_id, "succeeded", stdout, out, null);
 }
-
-export { isFeatureCollection as isWhiteboxFeatureCollection };

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -14,7 +14,6 @@ interface ToolRunResult {
 }
 
 interface ToolsModule {
-  initTools: (source?: unknown) => Promise<unknown>;
   listTools: () => Promise<string[]>;
   runTool: (
     tool: string,
@@ -54,8 +53,33 @@ export async function listWhiteboxWasmTools(): Promise<string[]> {
   return listTools();
 }
 
+function datasetParameterKind(dataKind: string, suffix: "in" | "out"): string {
+  return ["raster", "vector", "lidar", "file"].includes(dataKind)
+    ? `${dataKind}_${suffix}`
+    : `file_${suffix}`;
+}
+
+// Mirror ProcessingDialog's parameterKind: prefer an explicit `kind`, otherwise
+// resolve it from the parameter schema (`schema.dataset.kind` + `io_role`).
+// Without the schema branch, tools that express their kind only through the
+// schema would have their raster/vector/lidar inputs misrouted as scalars.
 function paramKind(p: WhiteboxToolParameter): string {
-  return String(p.kind ?? p.data_kind ?? p.io_role ?? p.type ?? "").toLowerCase();
+  if (p.kind) return String(p.kind).toLowerCase();
+  const schema =
+    p.schema && typeof p.schema === "object"
+      ? (p.schema as Record<string, unknown>)
+      : {};
+  const dataset =
+    schema.dataset && typeof schema.dataset === "object"
+      ? (schema.dataset as Record<string, unknown>)
+      : {};
+  const dataKind = String(
+    p.data_kind ?? dataset.kind ?? p.type ?? "",
+  ).toLowerCase();
+  const role = String(p.io_role ?? schema.kind ?? "").toLowerCase();
+  if (role === "input") return datasetParameterKind(dataKind, "in");
+  if (role === "output") return datasetParameterKind(dataKind, "out");
+  return dataKind;
 }
 
 function isFeatureCollection(value: unknown): value is FeatureCollection {
@@ -66,13 +90,16 @@ function isFeatureCollection(value: unknown): value is FeatureCollection {
   );
 }
 
-/** TIFF magic: "II*\0" (little-endian) or "MM\0*" (big-endian). */
+// TIFF magic: "II" (little-endian) or "MM" (big-endian) followed by the version
+// number in the byte-order's own endianness - 42 (0x2a) for classic TIFF or 43
+// (0x2b) for BigTIFF (rasters larger than 4 GiB).
 function isTiff(b: Uint8Array): boolean {
-  return (
-    b.length >= 4 &&
-    ((b[0] === 0x49 && b[1] === 0x49 && b[2] === 0x2a && b[3] === 0x00) ||
-      (b[0] === 0x4d && b[1] === 0x4d && b[2] === 0x00 && b[3] === 0x2a))
-  );
+  if (b.length < 4) return false;
+  const le = b[0] === 0x49 && b[1] === 0x49;
+  const be = b[0] === 0x4d && b[1] === 0x4d;
+  if (!le && !be) return false;
+  const magic = le ? b[2] : b[3];
+  return magic === 0x2a || magic === 0x2b;
 }
 
 function describeBytes(b: Uint8Array): string {
@@ -191,25 +218,22 @@ export async function runWhiteboxToolWasm(
   for (const entry of outputs) {
     const bytes = files[entry.file];
     if (!bytes) continue;
-    out[entry.name] = entry.raster
-      ? bytes
-      : (JSON.parse(new TextDecoder().decode(bytes)) as FeatureCollection);
+    if (entry.raster) {
+      out[entry.name] = bytes;
+      continue;
+    }
+    // Skip a vector output whose JSON is malformed (e.g. a tool that crashed
+    // mid-write) rather than letting one bad file reject the whole job and lose
+    // every other output. Matches the sidecar path's tolerant handling.
+    try {
+      out[entry.name] = JSON.parse(
+        new TextDecoder().decode(bytes),
+      ) as FeatureCollection;
+    } catch {
+      // leave this output out
+    }
   }
   return job(request.tool_id, "succeeded", stdout, out, null);
 }
 
 export { isFeatureCollection as isWhiteboxFeatureCollection };
-
-// Dev-only hook so end-to-end tests can drive the WASM runner directly in a real
-// browser without clicking through the UI. Tree-shaken out of production builds.
-if (
-  typeof window !== "undefined" &&
-  typeof import.meta !== "undefined" &&
-  (import.meta as unknown as { env?: { DEV?: boolean } }).env?.DEV
-) {
-  (window as unknown as Record<string, unknown>).__geolibreWhiteboxWasm = {
-    runWhiteboxToolWasm,
-    listWhiteboxWasmTools,
-    whiteboxWasmAvailable,
-  };
-}


### PR DESCRIPTION
## Summary
- Add an in-browser WebAssembly runtime for Whitebox tools so the Processing toolbox runs without the Python sidecar, sharing the same engine and outputs.
- Retain local raster/LiDAR bytes on their layers and let the web file picker read bytes directly, so locally loaded data is runnable in the browser; render raster tool outputs back to the map.
- Add a GeoTIFF (COG) export option for raster layers in the Layers panel, mirroring the existing vector export.

## Test plan
- [ ] Drop a local GeoTIFF, open Processing > Whitebox, run a raster tool (e.g. Slope) with "Run locally (WASM)" on, and confirm the output renders as a new map layer.
- [ ] Run a vector tool (e.g. Minimum Convex Hull) locally and confirm the GeoJSON output is added to the map.
- [ ] In the web build, use the input folder button to pick a file and confirm the tool reads its bytes.
- [ ] Export a raster layer via the Layers panel dropdown and confirm a valid GeoTIFF is saved.
- [ ] Run the local gate (lint + build) and confirm it passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export raster/COG-backed layers as GeoTIFF from the layer actions menu.
  * Run Whitebox tools in-browser via WebAssembly with a “Run locally (WASM)” option.
  * Allow direct file selection in processing dialogs (including non-vector inputs).
* **Improvements**
  * Enhanced handling of WebAssembly tool outputs, including importing inline raster results into the map.
  * Persist locally added raster bytes for the current session, with proper cleanup when rasters are removed.
  * Improved per-layer export availability and clearer, translated export status messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->