### PR TITLE
chore(deps): bump maplibre-gl-components to 0.20.5

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -58,7 +58,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.1",
     "maplibre-gl-basemap-control": "^0.3.0",
-    "maplibre-gl-components": "^0.20.4",
+    "maplibre-gl-components": "^0.20.5",
     "maplibre-gl-duckdb": "^0.2.0",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.1",
         "maplibre-gl-basemap-control": "^0.3.0",
-        "maplibre-gl-components": "^0.20.4",
+        "maplibre-gl-components": "^0.20.5",
         "maplibre-gl-duckdb": "^0.2.0",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -185,9 +185,9 @@
       "license": "MIT"
     },
     "apps/geolibre-desktop/node_modules/maplibre-gl-components": {
-      "version": "0.20.4",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.20.4.tgz",
-      "integrity": "sha512-19ppFw9uCT58TjqujiqHwuyHi02eC/CCTD3XGKrAklQ+wxJz/tvelENxyS8Lt9C/q6cT/QTSFqyt3e3aHSMICg==",
+      "version": "0.20.5",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.20.5.tgz",
+      "integrity": "sha512-WRvHEFay5aFoBjlWSqEnCU3sd/q0eEchngT7a+a6p1wKKJcxVBro+epmmSlfk/KVrwPdk/Zy1HQ3KV81zYIyKg==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",
@@ -24276,7 +24276,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.1",
         "maplibre-gl-basemap-control": "^0.3.0",
-        "maplibre-gl-components": "^0.20.4",
+        "maplibre-gl-components": "^0.20.5",
         "maplibre-gl-duckdb": "^0.2.0",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -24313,9 +24313,9 @@
       }
     },
     "packages/plugins/node_modules/maplibre-gl-components": {
-      "version": "0.20.4",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.20.4.tgz",
-      "integrity": "sha512-19ppFw9uCT58TjqujiqHwuyHi02eC/CCTD3XGKrAklQ+wxJz/tvelENxyS8Lt9C/q6cT/QTSFqyt3e3aHSMICg==",
+      "version": "0.20.5",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.20.5.tgz",
+      "integrity": "sha512-WRvHEFay5aFoBjlWSqEnCU3sd/q0eEchngT7a+a6p1wKKJcxVBro+epmmSlfk/KVrwPdk/Zy1HQ3KV81zYIyKg==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -31,7 +31,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.1",
     "maplibre-gl-basemap-control": "^0.3.0",
-    "maplibre-gl-components": "^0.20.4",
+    "maplibre-gl-components": "^0.20.5",
     "maplibre-gl-duckdb": "^0.2.0",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",


### PR DESCRIPTION
## Summary

Bumps `maplibre-gl-components` from 0.20.4 → **0.20.5** in both `packages/plugins` and `apps/geolibre-desktop`, and refreshes `package-lock.json`.

This pulls in the upstream MeasureControl fix: the idle instruction now reads **"Click Start, then click the map to add points. Double-click to finish."** instead of "Click on the map to start measuring…", which misled users into clicking the map before pressing the panel's **Start** button.

- Upstream PR: opengeos/maplibre-gl-components#98
- Upstream release: [v0.20.5](https://github.com/opengeos/maplibre-gl-components/releases/tag/v0.20.5)

Closes #415.

## Testing

- `npm run build` ✓
- `pre-commit run --files …` (incl. npm build hook) ✓
- Verified the bundled control in `node_modules` now ships the updated instruction text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated maplibre-gl-components dependency to the latest patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->