### PR TITLE
fix(pyodide-console): honor custom VITE_PYODIDE_INDEX_URL via blob URL

### DIFF
--- a/apps/geolibre-desktop/src/lib/pyodide/pyodide-console.ts
+++ b/apps/geolibre-desktop/src/lib/pyodide/pyodide-console.ts
@@ -72,24 +72,56 @@ function emitProgress(phase: string): void {
 
 let scriptPromise: Promise<void> | null = null;
 
-/** Inject the CDN `pyodide.js` once so `window.loadPyodide` is available. */
+/**
+ * Load `pyodide.js` once so `window.loadPyodide` is available.
+ *
+ * We `fetch()` the script and inject it via a `blob:` URL instead of pointing a
+ * `<script src>` straight at `indexURL`. Tauri's `script-src` CSP only allows
+ * the jsDelivr CDN origins, so a custom `VITE_PYODIDE_INDEX_URL` mirror would be
+ * blocked as a direct script source — but `connect-src` permits `https:`
+ * fetches and `script-src` permits `blob:`, so fetch-then-blob reaches any
+ * mirror. The vector-tools worker sidesteps the same CSP via `importScripts`;
+ * this is the main-thread equivalent, mirroring `external-plugins.ts`. Pyodide's
+ * own asset resolution is unaffected because `indexURL` is passed explicitly to
+ * `loadPyodide({ indexURL })`.
+ */
 function loadPyodideScript(indexURL: string): Promise<void> {
-  scriptPromise ??= new Promise<void>((resolve, reject) => {
-    if (window.loadPyodide) {
-      resolve();
-      return;
+  scriptPromise ??= (async () => {
+    if (window.loadPyodide) return;
+    const scriptUrl = `${indexURL}pyodide.js`;
+    let source: string;
+    try {
+      const response = await fetch(scriptUrl);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      source = await response.text();
+    } catch (cause) {
+      throw new Error(
+        `Failed to load the Pyodide runtime script from ${scriptUrl}.`,
+        { cause },
+      );
     }
-    const script = document.createElement("script");
-    script.src = `${indexURL}pyodide.js`;
-    script.onload = () => resolve();
-    // The shared `.catch` below owns resetting scriptPromise on failure; remove
-    // the dead element so a retry doesn't leave orphan <script> tags in <head>.
-    script.onerror = () => {
-      script.remove();
-      reject(new Error("Failed to load the Pyodide runtime script."));
-    };
-    document.head.appendChild(script);
-  }).catch((error) => {
+    const blobUrl = URL.createObjectURL(
+      new Blob([source], { type: "text/javascript" }),
+    );
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const script = document.createElement("script");
+        script.src = blobUrl;
+        script.onload = () => resolve();
+        // The shared `.catch` below owns resetting scriptPromise on failure;
+        // remove the dead element so a retry doesn't leave orphan <script> tags.
+        script.onerror = () => {
+          script.remove();
+          reject(new Error("Failed to load the Pyodide runtime script."));
+        };
+        document.head.appendChild(script);
+      });
+    } finally {
+      URL.revokeObjectURL(blobUrl);
+    }
+  })().catch((error) => {
     scriptPromise = null;
     throw error;
   });

--- a/apps/geolibre-desktop/src/lib/pyodide/pyodide-console.ts
+++ b/apps/geolibre-desktop/src/lib/pyodide/pyodide-console.ts
@@ -109,12 +109,32 @@ function loadPyodideScript(indexURL: string): Promise<void> {
       await new Promise<void>((resolve, reject) => {
         const script = document.createElement("script");
         script.src = blobUrl;
-        script.onload = () => resolve();
+        // `onload` fires when the blob script is parsed and executed, which does
+        // not guarantee it actually exposed `window.loadPyodide` — a mirror can
+        // return a 200 with an HTML error page or corrupted JS. Verify the global
+        // here so a bad payload rejects (and the `.catch` clears the memo for a
+        // re-fetch) instead of resolving and wedging every later retry.
+        script.onload = () => {
+          if (window.loadPyodide) {
+            resolve();
+            return;
+          }
+          script.remove();
+          reject(
+            new Error(
+              `Pyodide script loaded but window.loadPyodide is not defined; the content at ${scriptUrl} may be incorrect.`,
+            ),
+          );
+        };
         // The shared `.catch` below owns resetting scriptPromise on failure;
         // remove the dead element so a retry doesn't leave orphan <script> tags.
         script.onerror = () => {
           script.remove();
-          reject(new Error("Failed to load the Pyodide runtime script."));
+          reject(
+            new Error(
+              `Failed to execute the Pyodide runtime script from ${scriptUrl}.`,
+            ),
+          );
         };
         document.head.appendChild(script);
       });


### PR DESCRIPTION
## Summary

Fixes #416 — the Python Console failed with "Failed to load Pyodide runtime script." when `VITE_PYODIDE_INDEX_URL` pointed at a self-hosted mirror, even though the vector tools (Buffer, Dissolve, …) loaded the same mirror fine.

**Root cause:** the console injected a `<script src>` pointing straight at the configured `indexURL`. Tauri's `script-src` CSP only allows the jsDelivr CDN origins (`https://cdn.jsdelivr.net/npm/`, `https://cdn.jsdelivr.net/pyodide/`, `https://accounts.google.com`), so a custom mirror origin is blocked. The vector-tools worker avoids this because `importScripts` inside a Web Worker bypasses the main-thread CSP.

**Fix:** `fetch()` `pyodide.js` (permitted by `connect-src https:`) and inject it via a `blob:` URL (permitted by `script-src blob:`), the same pattern `external-plugins.ts` already uses for external plugin bundles. `indexURL` is still passed explicitly to `loadPyodide({ indexURL })`, so Pyodide's own asset/wheel resolution is unaffected. The blob URL is revoked after load.

This matches the approach proposed in the issue.

## Testing

- `npx tsc -b apps/geolibre-desktop` — clean
- `pre-commit run --files apps/geolibre-desktop/src/lib/pyodide/pyodide-console.ts` — all hooks pass (incl. eslint + npm build)
- Existing `tests/pyodide-config.test.ts` — pass

No unit test added: the changed code is DOM/`fetch`-dependent and the frontend test harness runs in plain Node with no jsdom (the analogous `external-plugins.ts` blob loader is likewise not unit-tested).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the in-app Pyodide script startup by ensuring the loader validates successful downloads and verifies the expected runtime is available before continuing.
  * Enhanced error handling with clearer, more contextual messages when script download or initialization fails, and improved cleanup to support subsequent retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->