### PR TITLE
feat(add-data): saved service library for web-service layers

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/add-data/ServiceLibrarySection.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/ServiceLibrarySection.tsx
@@ -1,0 +1,316 @@
+/**
+ * "Saved services" box rendered atop each web-service source in the Add Data
+ * dialog. Lets users save the current form to a cross-project library, reload a
+ * saved (or built-in) service into the form, delete their own entries, and
+ * import/export the library as JSON (issue #417).
+ *
+ * Persistence and validation live in `service-library.ts`; this component owns
+ * only the dialog-scoped UI state.
+ */
+
+import { Button, Input, Label, Select } from "@geolibre/ui";
+import { Bookmark, Download, Save, Trash2, Upload, X } from "lucide-react";
+import { useMemo, useRef, useState } from "react";
+import { saveTextFileWithFallback } from "../../../lib/tauri-io";
+import {
+  createServiceEntry,
+  listServices,
+  mergeImportedServices,
+  parseImportedServices,
+  readUserServices,
+  removeServiceEntry,
+  serializeUserServices,
+  serviceCategories,
+  type ServiceFields,
+  type ServiceLibraryEntry,
+  type ServiceLibraryKind,
+  UNCATEGORIZED_LABEL,
+  upsertServiceEntry,
+  writeUserServices,
+} from "./service-library";
+
+interface ServiceLibrarySectionProps {
+  /** Which web-service source this section belongs to. */
+  kind: ServiceLibraryKind;
+  /** Current layer name, offered as the default when saving. */
+  layerName: string;
+  /** Serialises the current form into a field bag for saving. */
+  getFields: () => ServiceFields;
+  /** Repopulates the form from a chosen entry. */
+  onApply: (entry: ServiceLibraryEntry) => void;
+}
+
+interface CategoryGroup {
+  label: string;
+  entries: ServiceLibraryEntry[];
+}
+
+/** Groups entries by category for the picker, with uncategorised entries last. */
+function groupByCategory(entries: ServiceLibraryEntry[]): CategoryGroup[] {
+  const groups = new Map<string, ServiceLibraryEntry[]>();
+  for (const entry of entries) {
+    const label = entry.category || UNCATEGORIZED_LABEL;
+    const group = groups.get(label);
+    if (group) group.push(entry);
+    else groups.set(label, [entry]);
+  }
+  return Array.from(groups.entries())
+    .sort(([a], [b]) => {
+      if (a === UNCATEGORIZED_LABEL) return 1;
+      if (b === UNCATEGORIZED_LABEL) return -1;
+      return a.localeCompare(b);
+    })
+    .map(([label, entries]) => ({ label, entries }));
+}
+
+export function ServiceLibrarySection({
+  kind,
+  layerName,
+  getFields,
+  onApply,
+}: ServiceLibrarySectionProps) {
+  const [userEntries, setUserEntries] = useState<ServiceLibraryEntry[]>(() =>
+    readUserServices(),
+  );
+  const [selectedId, setSelectedId] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveName, setSaveName] = useState("");
+  const [saveCategory, setSaveCategory] = useState("");
+  const [notice, setNotice] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const importInputRef = useRef<HTMLInputElement>(null);
+  const categoryListId = `service-categories-${kind}`;
+
+  const entries = useMemo(
+    () => listServices(kind, userEntries),
+    [kind, userEntries],
+  );
+  const groups = useMemo(() => groupByCategory(entries), [entries]);
+  const categories = useMemo(
+    () => serviceCategories(entries),
+    [entries],
+  );
+  const selectedEntry = entries.find((entry) => entry.id === selectedId) ?? null;
+  const canDeleteSelected = Boolean(selectedEntry && !selectedEntry.builtin);
+
+  const persist = (next: ServiceLibraryEntry[]) => {
+    setUserEntries(next);
+    writeUserServices(next);
+  };
+
+  const handleSelect = (id: string) => {
+    setSelectedId(id);
+    setError(null);
+    setNotice(null);
+    const entry = entries.find((candidate) => candidate.id === id);
+    if (entry) onApply(entry);
+  };
+
+  const openSaveForm = () => {
+    setSaveName(layerName.trim() || selectedEntry?.name || "");
+    setSaveCategory(selectedEntry?.category ?? "");
+    setError(null);
+    setNotice(null);
+    setIsSaving(true);
+  };
+
+  const handleSave = () => {
+    const name = saveName.trim();
+    if (!name) {
+      setError("Enter a name for the saved service.");
+      return;
+    }
+    const entry = createServiceEntry({
+      name,
+      category: saveCategory,
+      kind,
+      fields: getFields(),
+    });
+    persist(upsertServiceEntry(userEntries, entry));
+    setSelectedId(entry.id);
+    setIsSaving(false);
+    setNotice(`Saved "${name}" to the service library.`);
+  };
+
+  const handleDelete = () => {
+    if (!selectedEntry || selectedEntry.builtin) return;
+    persist(removeServiceEntry(userEntries, selectedEntry.id));
+    setSelectedId("");
+    setNotice(`Removed "${selectedEntry.name}".`);
+  };
+
+  const handleExport = async () => {
+    setError(null);
+    setNotice(null);
+    try {
+      await saveTextFileWithFallback(serializeUserServices(userEntries), {
+        defaultName: "geolibre-service-library.json",
+        filters: [{ name: "JSON", extensions: ["json"] }],
+        browserTypes: [
+          { description: "JSON", accept: { "application/json": [".json"] } },
+        ],
+        mimeType: "application/json",
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not export library.");
+    }
+  };
+
+  const handleImportFile = async (file: File | undefined) => {
+    if (!file) return;
+    setError(null);
+    setNotice(null);
+    try {
+      const imported = parseImportedServices(await file.text());
+      if (imported.length === 0) {
+        setError("No valid services found in that file.");
+        return;
+      }
+      persist(mergeImportedServices(userEntries, imported));
+      setNotice(
+        `Imported ${imported.length} service${imported.length === 1 ? "" : "s"}.`,
+      );
+    } catch {
+      setError("Could not read that file as a service library.");
+    }
+  };
+
+  return (
+    <div className="space-y-2 rounded-md border border-border/60 bg-muted/30 p-3">
+      <div className="flex items-center justify-between gap-2">
+        <span className="flex items-center gap-1.5 text-sm font-medium">
+          <Bookmark className="h-3.5 w-3.5" />
+          Saved services
+        </span>
+        <div className="flex items-center gap-1">
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            onClick={openSaveForm}
+          >
+            <Save className="mr-1.5 h-3.5 w-3.5" />
+            Save current
+          </Button>
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            title="Import library from JSON"
+            onClick={() => importInputRef.current?.click()}
+          >
+            <Upload className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            title="Export library to JSON"
+            disabled={userEntries.length === 0}
+            onClick={handleExport}
+          >
+            <Download className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      </div>
+
+      {entries.length > 0 ? (
+        <div className="flex items-center gap-2">
+          <Select
+            aria-label="Load a saved service"
+            className="flex-1"
+            value={selectedId}
+            onChange={(event) => handleSelect(event.target.value)}
+          >
+            <option value="">Load a saved service…</option>
+            {groups.map((group) => (
+              <optgroup key={group.label} label={group.label}>
+                {group.entries.map((entry) => (
+                  <option key={entry.id} value={entry.id}>
+                    {entry.name}
+                    {entry.builtin ? " (built-in)" : ""}
+                  </option>
+                ))}
+              </optgroup>
+            ))}
+          </Select>
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            title="Delete saved service"
+            disabled={!canDeleteSelected}
+            onClick={handleDelete}
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          No saved services yet — fill in the form and choose “Save current”.
+        </p>
+      )}
+
+      {isSaving ? (
+        <div className="space-y-2 rounded-md border border-border/60 bg-background p-2">
+          <div className="grid gap-2 sm:grid-cols-2">
+            <div className="space-y-1">
+              <Label htmlFor={`service-save-name-${kind}`}>Name</Label>
+              <Input
+                id={`service-save-name-${kind}`}
+                value={saveName}
+                onChange={(event) => setSaveName(event.target.value)}
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor={`service-save-category-${kind}`}>Category</Label>
+              <Input
+                id={`service-save-category-${kind}`}
+                list={categoryListId}
+                placeholder="Optional (e.g. country, theme)"
+                value={saveCategory}
+                onChange={(event) => setSaveCategory(event.target.value)}
+              />
+              <datalist id={categoryListId}>
+                {categories.map((category) => (
+                  <option key={category} value={category} />
+                ))}
+              </datalist>
+            </div>
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={() => setIsSaving(false)}
+            >
+              <X className="mr-1.5 h-3.5 w-3.5" />
+              Cancel
+            </Button>
+            <Button type="button" size="sm" onClick={handleSave}>
+              <Save className="mr-1.5 h-3.5 w-3.5" />
+              Save
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      {error ? <p className="text-xs text-destructive">{error}</p> : null}
+      {notice ? (
+        <p className="text-xs text-muted-foreground">{notice}</p>
+      ) : null}
+
+      <input
+        ref={importInputRef}
+        type="file"
+        accept="application/json,.json"
+        className="hidden"
+        onChange={(event) => {
+          void handleImportFile(event.target.files?.[0]);
+          event.target.value = "";
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/add-data/ServiceLibrarySection.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/ServiceLibrarySection.tsx
@@ -129,6 +129,7 @@ export function ServiceLibrarySection({
     persist(upsertServiceEntry(userEntries, entry));
     setSelectedId(entry.id);
     setIsSaving(false);
+    setError(null);
     setNotice(`Saved "${name}" to the service library.`);
   };
 
@@ -136,6 +137,7 @@ export function ServiceLibrarySection({
     if (!selectedEntry || selectedEntry.builtin) return;
     persist(removeServiceEntry(userEntries, selectedEntry.id));
     setSelectedId("");
+    setError(null);
     setNotice(`Removed "${selectedEntry.name}".`);
   };
 
@@ -166,9 +168,17 @@ export function ServiceLibrarySection({
         setError("No valid services found in that file.");
         return;
       }
-      persist(mergeImportedServices(userEntries, imported));
+      // mergeImportedServices caps the combined list at MAX_SAVED_SERVICES, so
+      // report the count actually kept rather than the count in the file.
+      const before = userEntries.length;
+      const next = mergeImportedServices(userEntries, imported);
+      persist(next);
+      const added = next.length - before;
+      const dropped = imported.length - added;
       setNotice(
-        `Imported ${imported.length} service${imported.length === 1 ? "" : "s"}.`,
+        `Imported ${added} service${added === 1 ? "" : "s"}${
+          dropped > 0 ? ` (${dropped} skipped — library full)` : ""
+        }.`,
       );
     } catch {
       setError("Could not read that file as a service library.");

--- a/apps/geolibre-desktop/src/components/layout/add-data/ServiceLibrarySection.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/ServiceLibrarySection.tsx
@@ -29,6 +29,9 @@ import {
   writeUserServices,
 } from "./service-library";
 
+/** Upper bound for an imported library file; a real one is only a few KB. */
+const MAX_IMPORT_BYTES = 5 * 1024 * 1024;
+
 interface ServiceLibrarySectionProps {
   /** Which web-service source this section belongs to. */
   kind: ServiceLibraryKind;
@@ -162,6 +165,12 @@ export function ServiceLibrarySection({
     if (!file) return;
     setError(null);
     setNotice(null);
+    // A library JSON is tiny; guard against accidentally reading a huge file
+    // fully into memory (the entry cap only applies after parsing).
+    if (file.size > MAX_IMPORT_BYTES) {
+      setError("File is too large to import (max 5 MB).");
+      return;
+    }
     try {
       const imported = parseImportedServices(await file.text());
       if (imported.length === 0) {

--- a/apps/geolibre-desktop/src/components/layout/add-data/ServiceLibrarySection.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/ServiceLibrarySection.tsx
@@ -10,7 +10,7 @@
 
 import { Button, Input, Label, Select } from "@geolibre/ui";
 import { Bookmark, Download, Save, Trash2, Upload, X } from "lucide-react";
-import { useMemo, useRef, useState } from "react";
+import { type KeyboardEvent, useMemo, useRef, useState } from "react";
 import { saveTextFileWithFallback } from "../../../lib/tauri-io";
 import {
   createServiceEntry,
@@ -123,7 +123,11 @@ export function ServiceLibrarySection({
       setError("Enter a name for the saved service.");
       return;
     }
+    // Update the selected entry in place when it's a user-owned service;
+    // otherwise (nothing or a built-in selected) mint a new one.
     const entry = createServiceEntry({
+      id:
+        selectedEntry && !selectedEntry.builtin ? selectedEntry.id : undefined,
       name,
       category: saveCategory,
       kind,
@@ -134,6 +138,18 @@ export function ServiceLibrarySection({
     setIsSaving(false);
     setError(null);
     setNotice(`Saved "${name}" to the service library.`);
+  };
+
+  // The save-form inputs live inside AddDataSourceForm's <form>, so a bare
+  // Enter would submit it (adding a layer). Intercept Enter to save instead;
+  // forms can't be nested, so this is the keyboard path for the save form.
+  const handleSaveFieldKeyDown = (
+    event: KeyboardEvent<HTMLInputElement>,
+  ) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      handleSave();
+    }
   };
 
   const handleDelete = () => {
@@ -279,6 +295,7 @@ export function ServiceLibrarySection({
                 id={`service-save-name-${kind}`}
                 value={saveName}
                 onChange={(event) => setSaveName(event.target.value)}
+                onKeyDown={handleSaveFieldKeyDown}
               />
             </div>
             <div className="space-y-1">
@@ -289,6 +306,7 @@ export function ServiceLibrarySection({
                 placeholder="Optional (e.g. country, theme)"
                 value={saveCategory}
                 onChange={(event) => setSaveCategory(event.target.value)}
+                onKeyDown={handleSaveFieldKeyDown}
               />
               <datalist id={categoryListId}>
                 {categories.map((category) => (

--- a/apps/geolibre-desktop/src/components/layout/add-data/ServiceLibrarySection.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/ServiceLibrarySection.tsx
@@ -235,6 +235,7 @@ export function ServiceLibrarySection({
             type="button"
             size="icon"
             variant="ghost"
+            aria-label="Import library from JSON"
             title="Import library from JSON"
             onClick={() => importInputRef.current?.click()}
           >
@@ -244,6 +245,7 @@ export function ServiceLibrarySection({
             type="button"
             size="icon"
             variant="ghost"
+            aria-label="Export library to JSON"
             title="Export library to JSON"
             disabled={userEntries.length === 0}
             onClick={handleExport}
@@ -277,6 +279,7 @@ export function ServiceLibrarySection({
             type="button"
             size="icon"
             variant="ghost"
+            aria-label="Delete saved service"
             title="Delete saved service"
             disabled={!canDeleteSelected}
             onClick={handleDelete}

--- a/apps/geolibre-desktop/src/components/layout/add-data/ServiceLibrarySection.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/ServiceLibrarySection.tsx
@@ -193,11 +193,15 @@ export function ServiceLibrarySection({
         setError("No valid services found in that file.");
         return;
       }
+      // Merge against the freshly-persisted list rather than the closed-over
+      // `userEntries`, which may be stale after the `await file.text()` if the
+      // user saved/deleted in the meantime.
       // mergeImportedServices caps the combined list at MAX_SAVED_SERVICES, so
       // report the count actually kept rather than the count in the file.
-      const before = userEntries.length;
-      const next = mergeImportedServices(userEntries, imported);
+      const current = readUserServices();
+      const next = mergeImportedServices(current, imported);
       persist(next);
+      const before = current.length;
       const added = next.length - before;
       const dropped = imported.length - added;
       setNotice(

--- a/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
@@ -85,6 +85,10 @@ export const GPX_PROXY_PATH = "/__geolibre_gpx_proxy";
 export const POSTGRES_CONNECTIONS_STORAGE_KEY =
   "geolibre.postgres.connectionStrings";
 export const MAX_SAVED_POSTGRES_CONNECTIONS = 10;
+// Cross-project catalog of reusable web-service layer definitions (see
+// service-library.ts). Bumping the key would orphan a user's saved services.
+export const SERVICE_LIBRARY_STORAGE_KEY = "geolibre.serviceLibrary";
+export const MAX_SAVED_SERVICES = 200;
 export const DELIMITED_TEXT_DELIMITERS: Record<
   Exclude<DelimitedTextDelimiter, "custom">,
   string

--- a/apps/geolibre-desktop/src/components/layout/add-data/service-library.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/service-library.ts
@@ -127,7 +127,7 @@ function normalizeEntry(value: unknown): ServiceLibraryEntry | null {
   if (Object.keys(fields).length === 0) return null;
   const id =
     typeof record.id === "string" && record.id.trim()
-      ? record.id
+      ? record.id.trim()
       : createServiceId();
   const category =
     typeof record.category === "string" ? record.category.trim() : "";

--- a/apps/geolibre-desktop/src/components/layout/add-data/service-library.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/service-library.ts
@@ -1,0 +1,363 @@
+/**
+ * Saved service library: a cross-project, localStorage-backed catalog of
+ * reusable web-service layer definitions (WMS / WFS / WMTS / XYZ / ArcGIS).
+ *
+ * The Add Data dialog's web-service sources let users save the current form as
+ * a named, categorised entry and reload it later — including across projects —
+ * so they don't have to keep a separate database of service URLs (issue #417).
+ *
+ * Entries are plain `string | number | boolean` field bags so they serialise
+ * cleanly to JSON (localStorage + import/export) and repopulate the source
+ * forms directly. Built-in presets seed the library: they are always listed but
+ * never persisted, so they stay fresh across releases and can't be deleted.
+ */
+
+import {
+  DEFAULT_ARCGIS_FEATURE_URL,
+  DEFAULT_WFS_ENDPOINT,
+  DEFAULT_WFS_TYPE_NAME,
+  DEFAULT_WMS_ENDPOINT,
+  DEFAULT_WMS_LAYERS,
+  DEFAULT_WMTS_URL,
+  DEFAULT_XYZ_URL,
+  MAX_SAVED_SERVICES,
+  SERVICE_LIBRARY_STORAGE_KEY,
+} from "./constants";
+
+/** The web-service source kinds that participate in the saved library. */
+export type ServiceLibraryKind = "wms" | "wfs" | "wmts" | "xyz" | "arcgis";
+
+export type ServiceFieldValue = string | number | boolean;
+
+export type ServiceFields = Record<string, ServiceFieldValue>;
+
+export interface ServiceLibraryEntry {
+  /** Stable unique id. */
+  id: string;
+  /** User-facing name; also offered as the layer name when applied. */
+  name: string;
+  /** User-defined group (country, theme, …). Empty string = uncategorised. */
+  category: string;
+  /** Which web-service source this entry belongs to. */
+  kind: ServiceLibraryKind;
+  /** Source-form field values, applied verbatim when the entry is loaded. */
+  fields: ServiceFields;
+  /** True for built-in presets: always listed, read-only, never persisted. */
+  builtin?: boolean;
+}
+
+const SERVICE_KINDS: readonly ServiceLibraryKind[] = [
+  "wms",
+  "wfs",
+  "wmts",
+  "xyz",
+  "arcgis",
+];
+
+/** Label used for entries that have no category set. */
+export const UNCATEGORIZED_LABEL = "Uncategorized";
+
+/** The wrapped JSON shape produced by {@link serializeUserServices}. */
+const EXPORT_FORMAT = "geolibre-service-library";
+
+function createServiceId(): string {
+  return typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+/** Reads a string field, coercing numbers/booleans, with a fallback. */
+export function serviceFieldString(
+  fields: ServiceFields,
+  key: string,
+  fallback = "",
+): string {
+  const value = fields[key];
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return fallback;
+}
+
+/** Reads a boolean field, with a fallback when absent or non-boolean. */
+export function serviceFieldBoolean(
+  fields: ServiceFields,
+  key: string,
+  fallback = false,
+): boolean {
+  const value = fields[key];
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function isServiceKind(value: unknown): value is ServiceLibraryKind {
+  return (
+    typeof value === "string" &&
+    (SERVICE_KINDS as readonly string[]).includes(value)
+  );
+}
+
+function normalizeFields(value: unknown): ServiceFields {
+  if (!value || typeof value !== "object") return {};
+  const result: ServiceFields = {};
+  for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
+    if (
+      typeof raw === "string" ||
+      typeof raw === "number" ||
+      typeof raw === "boolean"
+    ) {
+      result[key] = raw;
+    }
+  }
+  return result;
+}
+
+/**
+ * Validates and sanitises one parsed object into a `ServiceLibraryEntry`,
+ * returning `null` when it is unusable. The `builtin` flag is intentionally
+ * dropped — user/imported entries are never treated as read-only presets.
+ */
+function normalizeEntry(value: unknown): ServiceLibraryEntry | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+  if (!isServiceKind(record.kind)) return null;
+  const name = typeof record.name === "string" ? record.name.trim() : "";
+  if (!name) return null;
+  const fields = normalizeFields(record.fields);
+  if (Object.keys(fields).length === 0) return null;
+  const id =
+    typeof record.id === "string" && record.id.trim()
+      ? record.id
+      : createServiceId();
+  const category =
+    typeof record.category === "string" ? record.category.trim() : "";
+  return { id, name, category, kind: record.kind, fields };
+}
+
+/**
+ * Validates an arbitrary parsed value into a clean entry list: drops invalid
+ * items, re-ids duplicates so each id stays unique, and caps the length.
+ */
+export function normalizeServiceEntries(value: unknown): ServiceLibraryEntry[] {
+  if (!Array.isArray(value)) return [];
+  const entries: ServiceLibraryEntry[] = [];
+  const seenIds = new Set<string>();
+  for (const item of value) {
+    const entry = normalizeEntry(item);
+    if (!entry) continue;
+    if (seenIds.has(entry.id)) entry.id = createServiceId();
+    seenIds.add(entry.id);
+    entries.push(entry);
+    if (entries.length >= MAX_SAVED_SERVICES) break;
+  }
+  return entries;
+}
+
+/** Reads the user's saved services from localStorage (best-effort). */
+export function readUserServices(): ServiceLibraryEntry[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const value = window.localStorage.getItem(SERVICE_LIBRARY_STORAGE_KEY);
+    if (!value) return [];
+    return normalizeServiceEntries(JSON.parse(value));
+  } catch {
+    return [];
+  }
+}
+
+/** Persists the user's saved services to localStorage (best-effort). */
+export function writeUserServices(entries: ServiceLibraryEntry[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      SERVICE_LIBRARY_STORAGE_KEY,
+      JSON.stringify(entries.slice(0, MAX_SAVED_SERVICES)),
+    );
+  } catch {
+    // Best-effort persistence: a quota/private-mode failure must not break the
+    // Add Data dialog (mirrors readUserServices' guard).
+  }
+}
+
+/**
+ * Builds a fresh, unsaved entry from the current form. Callers persist the
+ * result via {@link upsertServiceEntry} + {@link writeUserServices}.
+ */
+export function createServiceEntry(input: {
+  name: string;
+  category: string;
+  kind: ServiceLibraryKind;
+  fields: ServiceFields;
+}): ServiceLibraryEntry {
+  return {
+    id: createServiceId(),
+    name: input.name.trim(),
+    category: input.category.trim(),
+    kind: input.kind,
+    fields: input.fields,
+  };
+}
+
+/** Inserts or replaces an entry by id, newest first, capped at the limit. */
+export function upsertServiceEntry(
+  entries: ServiceLibraryEntry[],
+  entry: ServiceLibraryEntry,
+): ServiceLibraryEntry[] {
+  const without = entries.filter((existing) => existing.id !== entry.id);
+  return [entry, ...without].slice(0, MAX_SAVED_SERVICES);
+}
+
+/** Removes the entry with the given id. */
+export function removeServiceEntry(
+  entries: ServiceLibraryEntry[],
+  id: string,
+): ServiceLibraryEntry[] {
+  return entries.filter((entry) => entry.id !== id);
+}
+
+/** Serialises the user's services to a portable JSON document for export. */
+export function serializeUserServices(entries: ServiceLibraryEntry[]): string {
+  return JSON.stringify(
+    {
+      type: EXPORT_FORMAT,
+      version: 1,
+      services: entries.map(({ builtin: _builtin, ...rest }) => rest),
+    },
+    null,
+    2,
+  );
+}
+
+/**
+ * Parses an exported document (or a bare entry array) into clean entries.
+ * Throws on invalid JSON so the caller can surface a parse error.
+ */
+export function parseImportedServices(text: string): ServiceLibraryEntry[] {
+  const parsed = JSON.parse(text) as unknown;
+  const list = Array.isArray(parsed)
+    ? parsed
+    : parsed && typeof parsed === "object"
+      ? (parsed as { services?: unknown }).services
+      : undefined;
+  return normalizeServiceEntries(list);
+}
+
+/**
+ * Merges imported entries into the existing list, assigning fresh ids on
+ * collision so an import never silently overwrites a saved service.
+ */
+export function mergeImportedServices(
+  existing: ServiceLibraryEntry[],
+  imported: ServiceLibraryEntry[],
+): ServiceLibraryEntry[] {
+  const merged = [...existing];
+  const seen = new Set(existing.map((entry) => entry.id));
+  for (const entry of imported) {
+    const id = seen.has(entry.id) ? createServiceId() : entry.id;
+    seen.add(id);
+    merged.push({ ...entry, id });
+  }
+  return merged.slice(0, MAX_SAVED_SERVICES);
+}
+
+/**
+ * Lists every entry for a kind — built-in presets first, then the user's saved
+ * services — for the source picker.
+ */
+export function listServices(
+  kind: ServiceLibraryKind,
+  userEntries: ServiceLibraryEntry[],
+): ServiceLibraryEntry[] {
+  return [
+    ...BUILTIN_SERVICES.filter((entry) => entry.kind === kind),
+    ...userEntries.filter((entry) => entry.kind === kind),
+  ];
+}
+
+/** The distinct, sorted categories present in a list of entries. */
+export function serviceCategories(entries: ServiceLibraryEntry[]): string[] {
+  const categories = new Set<string>();
+  for (const entry of entries) {
+    if (entry.category) categories.add(entry.category);
+  }
+  return Array.from(categories).sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Built-in starter presets so the library is useful on first run. They reuse
+ * the same defaults the source forms ship with, and stay read-only.
+ */
+export const BUILTIN_SERVICES: readonly ServiceLibraryEntry[] = [
+  {
+    id: "builtin-wms-usgs-naip",
+    name: "USGS NAIP Imagery",
+    category: "Imagery",
+    kind: "wms",
+    builtin: true,
+    fields: {
+      endpoint: DEFAULT_WMS_ENDPOINT,
+      layers: DEFAULT_WMS_LAYERS,
+      styles: "",
+      format: "image/png",
+      transparent: true,
+      tileSize: "256",
+    },
+  },
+  {
+    id: "builtin-xyz-usgs-imagery",
+    name: "USGS Imagery",
+    category: "Imagery",
+    kind: "xyz",
+    builtin: true,
+    fields: { url: DEFAULT_XYZ_URL, tileSize: "256", shortUrl: false },
+  },
+  {
+    id: "builtin-xyz-osm",
+    name: "OpenStreetMap",
+    category: "Basemaps",
+    kind: "xyz",
+    builtin: true,
+    fields: {
+      url: "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
+      tileSize: "256",
+      shortUrl: false,
+    },
+  },
+  {
+    id: "builtin-wmts-world-imagery",
+    name: "Esri World Imagery (Wayback)",
+    category: "Imagery",
+    kind: "wmts",
+    builtin: true,
+    fields: { url: DEFAULT_WMTS_URL, tileSize: "256" },
+  },
+  {
+    id: "builtin-wfs-states",
+    name: "US States (GeoServer demo)",
+    category: "Demo data",
+    kind: "wfs",
+    builtin: true,
+    fields: {
+      endpoint: DEFAULT_WFS_ENDPOINT,
+      typeName: DEFAULT_WFS_TYPE_NAME,
+      version: "2.0.0",
+      outputFormat: "application/json",
+      srsName: "EPSG:4326",
+      maxFeatures: "1000",
+    },
+  },
+  {
+    id: "builtin-arcgis-usa-cities",
+    name: "USA Major Cities",
+    category: "Demo data",
+    kind: "arcgis",
+    builtin: true,
+    fields: {
+      layerType: "feature",
+      sourceType: "url",
+      url: DEFAULT_ARCGIS_FEATURE_URL,
+      itemId: "",
+      portalUrl: "",
+    },
+  },
+];

--- a/apps/geolibre-desktop/src/components/layout/add-data/service-library.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/service-library.ts
@@ -184,13 +184,15 @@ export function writeUserServices(entries: ServiceLibraryEntry[]): void {
  * result via {@link upsertServiceEntry} + {@link writeUserServices}.
  */
 export function createServiceEntry(input: {
+  /** Reuse an existing id to update in place; omit to mint a new entry. */
+  id?: string;
   name: string;
   category: string;
   kind: ServiceLibraryKind;
   fields: ServiceFields;
 }): ServiceLibraryEntry {
   return {
-    id: createServiceId(),
+    id: input.id ?? createServiceId(),
     name: input.name.trim(),
     category: input.category.trim(),
     kind: input.kind,

--- a/apps/geolibre-desktop/src/components/layout/add-data/service-library.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/service-library.ts
@@ -251,7 +251,13 @@ export function mergeImportedServices(
   imported: ServiceLibraryEntry[],
 ): ServiceLibraryEntry[] {
   const merged = [...existing];
-  const seen = new Set(existing.map((entry) => entry.id));
+  // Reserve built-in ids too: an imported entry reusing one (e.g.
+  // "builtin-xyz-osm") would otherwise be shadowed by the preset in
+  // listServices and become unreachable/non-deletable.
+  const seen = new Set([
+    ...BUILTIN_SERVICES.map((entry) => entry.id),
+    ...existing.map((entry) => entry.id),
+  ]);
   for (const entry of imported) {
     const id = seen.has(entry.id) ? createServiceId() : entry.id;
     seen.add(id);

--- a/apps/geolibre-desktop/src/components/layout/add-data/service-library.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/service-library.ts
@@ -136,12 +136,16 @@ function normalizeEntry(value: unknown): ServiceLibraryEntry | null {
 
 /**
  * Validates an arbitrary parsed value into a clean entry list: drops invalid
- * items, re-ids duplicates so each id stays unique, and caps the length.
+ * items, re-ids duplicates (and any clash with a built-in id) so each id stays
+ * unique, and caps the length.
  */
 export function normalizeServiceEntries(value: unknown): ServiceLibraryEntry[] {
   if (!Array.isArray(value)) return [];
   const entries: ServiceLibraryEntry[] = [];
-  const seenIds = new Set<string>();
+  // Seed with built-in ids so a stored/imported entry reusing one (e.g.
+  // "builtin-xyz-osm") is re-assigned rather than being shadowed by the preset
+  // in listServices and becoming unreachable/non-deletable.
+  const seenIds = new Set<string>(BUILTIN_SERVICES.map((entry) => entry.id));
   for (const item of value) {
     const entry = normalizeEntry(item);
     if (!entry) continue;

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/ArcGISSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/ArcGISSource.tsx
@@ -52,6 +52,9 @@ export function ArcGISSource() {
     setArcgisUrl(serviceFieldString(fields, "url", DEFAULT_ARCGIS_FEATURE_URL));
     setArcgisItemId(serviceFieldString(fields, "itemId"));
     setArcgisPortalUrl(serviceFieldString(fields, "portalUrl"));
+    // Tokens are never saved, so clear any token typed for a previous entry to
+    // avoid sending it to the newly selected service's endpoint.
+    setArcgisAccessToken("");
   };
 
   const handleArcgisLayerTypeChange = (nextLayerType: ArcGISLayerType) => {

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/ArcGISSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/ArcGISSource.tsx
@@ -10,6 +10,11 @@ import {
   DEFAULT_ARCGIS_FEATURE_URL,
   DEFAULT_ARCGIS_URLS,
 } from "../constants";
+import { ServiceLibrarySection } from "../ServiceLibrarySection";
+import {
+  serviceFieldString,
+  type ServiceFields,
+} from "../service-library";
 import { AddDataSourceForm, useAddDataSource } from "../shared";
 
 export function ArcGISSource() {
@@ -22,6 +27,32 @@ export function ArcGISSource() {
   const [arcgisItemId, setArcgisItemId] = useState("");
   const [arcgisPortalUrl, setArcgisPortalUrl] = useState("");
   const [arcgisAccessToken, setArcgisAccessToken] = useState("");
+
+  // The access token is intentionally excluded from saved fields — credentials
+  // must not be persisted to the shared, exportable service library.
+  const getFields = (): ServiceFields => ({
+    layerType: arcgisLayerType,
+    sourceType: arcgisSourceType,
+    url: arcgisUrl,
+    itemId: arcgisItemId,
+    portalUrl: arcgisPortalUrl,
+  });
+
+  const applyFields = (fields: ServiceFields) => {
+    setArcgisLayerType(
+      serviceFieldString(fields, "layerType") === "vector-tile"
+        ? "vector-tile"
+        : "feature",
+    );
+    setArcgisSourceType(
+      serviceFieldString(fields, "sourceType") === "portal-item"
+        ? "portal-item"
+        : "url",
+    );
+    setArcgisUrl(serviceFieldString(fields, "url", DEFAULT_ARCGIS_FEATURE_URL));
+    setArcgisItemId(serviceFieldString(fields, "itemId"));
+    setArcgisPortalUrl(serviceFieldString(fields, "portalUrl"));
+  };
 
   const handleArcgisLayerTypeChange = (nextLayerType: ArcGISLayerType) => {
     const currentUrl = arcgisUrl.trim();
@@ -57,6 +88,15 @@ export function ArcGISSource() {
       submitDisabled={source.isSubmitting}
     >
       <div className="space-y-3">
+        <ServiceLibrarySection
+          kind="arcgis"
+          layerName={source.layerName}
+          getFields={getFields}
+          onApply={(entry) => {
+            source.setLayerName(entry.name);
+            applyFields(entry.fields);
+          }}
+        />
         <div className="grid gap-3 sm:grid-cols-2">
           <div className="space-y-1.5">
             <Label htmlFor="arcgis-layer-type">Layer type</Label>

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
@@ -6,6 +6,11 @@ import {
 } from "../../../../lib/layer-refresh";
 import { DEFAULT_WFS_ENDPOINT, DEFAULT_WFS_TYPE_NAME } from "../constants";
 import { createBaseLayer, parseOptionalNumber } from "../helpers";
+import { ServiceLibrarySection } from "../ServiceLibrarySection";
+import {
+  serviceFieldString,
+  type ServiceFields,
+} from "../service-library";
 import { AddDataSourceForm, useAddDataSource } from "../shared";
 
 export function WfsSource() {
@@ -16,6 +21,26 @@ export function WfsSource() {
   const [wfsOutputFormat, setWfsOutputFormat] = useState("application/json");
   const [wfsSrsName, setWfsSrsName] = useState("EPSG:4326");
   const [wfsMaxFeatures, setWfsMaxFeatures] = useState("1000");
+
+  const getFields = (): ServiceFields => ({
+    endpoint: wfsEndpoint,
+    typeName: wfsTypeName,
+    version: wfsVersion,
+    outputFormat: wfsOutputFormat,
+    srsName: wfsSrsName,
+    maxFeatures: wfsMaxFeatures,
+  });
+
+  const applyFields = (fields: ServiceFields) => {
+    setWfsEndpoint(serviceFieldString(fields, "endpoint", DEFAULT_WFS_ENDPOINT));
+    setWfsTypeName(serviceFieldString(fields, "typeName", DEFAULT_WFS_TYPE_NAME));
+    setWfsVersion(serviceFieldString(fields, "version", "2.0.0"));
+    setWfsOutputFormat(
+      serviceFieldString(fields, "outputFormat", "application/json"),
+    );
+    setWfsSrsName(serviceFieldString(fields, "srsName", "EPSG:4326"));
+    setWfsMaxFeatures(serviceFieldString(fields, "maxFeatures", "1000"));
+  };
 
   const handleSubmit = source.runSubmit(async () => {
     const name = source.layerName.trim() || "WFS Layer";
@@ -79,6 +104,15 @@ export function WfsSource() {
       useServiceIcon
     >
       <div className="space-y-3">
+        <ServiceLibrarySection
+          kind="wfs"
+          layerName={source.layerName}
+          getFields={getFields}
+          onApply={(entry) => {
+            source.setLayerName(entry.name);
+            applyFields(entry.fields);
+          }}
+        />
         <div className="space-y-1.5">
           <Label htmlFor="wfs-endpoint">Service URL</Label>
           <Input

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
@@ -2,6 +2,12 @@ import { Input, Label, Select } from "@geolibre/ui";
 import { useState } from "react";
 import { DEFAULT_WMS_ENDPOINT, DEFAULT_WMS_LAYERS } from "../constants";
 import { createBaseLayer, createWmsTileUrl } from "../helpers";
+import { ServiceLibrarySection } from "../ServiceLibrarySection";
+import {
+  serviceFieldBoolean,
+  serviceFieldString,
+  type ServiceFields,
+} from "../service-library";
 import { AddDataSourceForm, useAddDataSource } from "../shared";
 
 export function WmsSource() {
@@ -12,6 +18,24 @@ export function WmsSource() {
   const [wmsFormat, setWmsFormat] = useState("image/png");
   const [wmsTransparent, setWmsTransparent] = useState(true);
   const [wmsTileSize, setWmsTileSize] = useState("256");
+
+  const getFields = (): ServiceFields => ({
+    endpoint: wmsEndpoint,
+    layers: wmsLayers,
+    styles: wmsStyles,
+    format: wmsFormat,
+    transparent: wmsTransparent,
+    tileSize: wmsTileSize,
+  });
+
+  const applyFields = (fields: ServiceFields) => {
+    setWmsEndpoint(serviceFieldString(fields, "endpoint", DEFAULT_WMS_ENDPOINT));
+    setWmsLayers(serviceFieldString(fields, "layers", DEFAULT_WMS_LAYERS));
+    setWmsStyles(serviceFieldString(fields, "styles"));
+    setWmsFormat(serviceFieldString(fields, "format", "image/png"));
+    setWmsTransparent(serviceFieldBoolean(fields, "transparent", true));
+    setWmsTileSize(serviceFieldString(fields, "tileSize", "256"));
+  };
 
   const handleSubmit = source.runSubmit(() => {
     const name = source.layerName.trim() || "WMS Layer";
@@ -59,6 +83,15 @@ export function WmsSource() {
       useServiceIcon
     >
       <div className="space-y-3">
+        <ServiceLibrarySection
+          kind="wms"
+          layerName={source.layerName}
+          getFields={getFields}
+          onApply={(entry) => {
+            source.setLayerName(entry.name);
+            applyFields(entry.fields);
+          }}
+        />
         <div className="space-y-1.5">
           <Label htmlFor="wms-endpoint">Service URL</Label>
           <Input

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WmtsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WmtsSource.tsx
@@ -2,12 +2,27 @@ import { Input, Label } from "@geolibre/ui";
 import { useState } from "react";
 import { DEFAULT_WMTS_URL } from "../constants";
 import { createBaseLayer } from "../helpers";
+import { ServiceLibrarySection } from "../ServiceLibrarySection";
+import {
+  serviceFieldString,
+  type ServiceFields,
+} from "../service-library";
 import { AddDataSourceForm, useAddDataSource } from "../shared";
 
 export function WmtsSource() {
   const source = useAddDataSource("WMTS Layer");
   const [wmtsUrl, setWmtsUrl] = useState(DEFAULT_WMTS_URL);
   const [wmtsTileSize, setWmtsTileSize] = useState("256");
+
+  const getFields = (): ServiceFields => ({
+    url: wmtsUrl,
+    tileSize: wmtsTileSize,
+  });
+
+  const applyFields = (fields: ServiceFields) => {
+    setWmtsUrl(serviceFieldString(fields, "url", DEFAULT_WMTS_URL));
+    setWmtsTileSize(serviceFieldString(fields, "tileSize", "256"));
+  };
 
   const handleSubmit = source.runSubmit(() => {
     const name = source.layerName.trim() || "WMTS Layer";
@@ -40,24 +55,35 @@ export function WmtsSource() {
       submitDisabled={source.isSubmitting}
       useServiceIcon
     >
-      <div className="grid gap-3 sm:grid-cols-[1fr_7rem]">
-        <div className="space-y-1.5">
-          <Label htmlFor="wmts-url">Tile URL template</Label>
-          <Input
-            id="wmts-url"
-            placeholder="https://example.com/wmts/{z}/{y}/{x}.png"
-            value={wmtsUrl}
-            onChange={(event) => setWmtsUrl(event.target.value)}
-          />
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="wmts-tile-size">Tile size</Label>
-          <Input
-            id="wmts-tile-size"
-            inputMode="numeric"
-            value={wmtsTileSize}
-            onChange={(event) => setWmtsTileSize(event.target.value)}
-          />
+      <div className="space-y-3">
+        <ServiceLibrarySection
+          kind="wmts"
+          layerName={source.layerName}
+          getFields={getFields}
+          onApply={(entry) => {
+            source.setLayerName(entry.name);
+            applyFields(entry.fields);
+          }}
+        />
+        <div className="grid gap-3 sm:grid-cols-[1fr_7rem]">
+          <div className="space-y-1.5">
+            <Label htmlFor="wmts-url">Tile URL template</Label>
+            <Input
+              id="wmts-url"
+              placeholder="https://example.com/wmts/{z}/{y}/{x}.png"
+              value={wmtsUrl}
+              onChange={(event) => setWmtsUrl(event.target.value)}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="wmts-tile-size">Tile size</Label>
+            <Input
+              id="wmts-tile-size"
+              inputMode="numeric"
+              value={wmtsTileSize}
+              onChange={(event) => setWmtsTileSize(event.target.value)}
+            />
+          </div>
         </div>
       </div>
     </AddDataSourceForm>

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/XyzSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/XyzSource.tsx
@@ -7,6 +7,12 @@ import {
 } from "../../../../lib/xyz-url";
 import { DEFAULT_XYZ_URL } from "../constants";
 import { createBaseLayer } from "../helpers";
+import { ServiceLibrarySection } from "../ServiceLibrarySection";
+import {
+  serviceFieldBoolean,
+  serviceFieldString,
+  type ServiceFields,
+} from "../service-library";
 import { AddDataSourceForm, useAddDataSource } from "../shared";
 
 export function XyzSource() {
@@ -14,6 +20,18 @@ export function XyzSource() {
   const [xyzUrl, setXyzUrl] = useState(DEFAULT_XYZ_URL);
   const [xyzTileSize, setXyzTileSize] = useState("256");
   const [xyzShortUrl, setXyzShortUrl] = useState(false);
+
+  const getFields = (): ServiceFields => ({
+    url: xyzUrl,
+    tileSize: xyzTileSize,
+    shortUrl: xyzShortUrl,
+  });
+
+  const applyFields = (fields: ServiceFields) => {
+    setXyzUrl(serviceFieldString(fields, "url", DEFAULT_XYZ_URL));
+    setXyzTileSize(serviceFieldString(fields, "tileSize", "256"));
+    setXyzShortUrl(serviceFieldBoolean(fields, "shortUrl", false));
+  };
 
   const handleSubmit = source.runSubmit(async () => {
     const name = source.layerName.trim() || "XYZ Layer";
@@ -52,6 +70,15 @@ export function XyzSource() {
       submitDisabled={source.isSubmitting}
     >
       <div className="space-y-3">
+        <ServiceLibrarySection
+          kind="xyz"
+          layerName={source.layerName}
+          getFields={getFields}
+          onApply={(entry) => {
+            source.setLayerName(entry.name);
+            applyFields(entry.fields);
+          }}
+        />
         <div className="grid gap-3 sm:grid-cols-[1fr_7rem]">
           <div className="space-y-1.5">
             <Label htmlFor="xyz-url">Tile URL template</Label>

--- a/tests/service-library.test.ts
+++ b/tests/service-library.test.ts
@@ -166,4 +166,12 @@ describe("import / export round-trip", () => {
       ["Existing", "Imported"],
     );
   });
+
+  it("re-ids an imported entry that collides with a built-in id", () => {
+    const builtinId = BUILTIN_SERVICES[0].id;
+    const imported = [makeEntry({ id: builtinId, name: "Imported" })];
+    const merged = mergeImportedServices([], imported);
+    assert.equal(merged.length, 1);
+    assert.notEqual(merged[0].id, builtinId);
+  });
 });

--- a/tests/service-library.test.ts
+++ b/tests/service-library.test.ts
@@ -80,6 +80,26 @@ describe("normalizeServiceEntries", () => {
   });
 });
 
+describe("createServiceEntry", () => {
+  it("reuses a provided id (update in place) or mints a new one", () => {
+    const updated = createServiceEntry({
+      id: "keep-me",
+      name: "Updated",
+      category: "Imagery",
+      kind: "wms",
+      fields: { endpoint: "https://x.test" },
+    });
+    assert.equal(updated.id, "keep-me");
+    const fresh = createServiceEntry({
+      name: "Fresh",
+      category: "",
+      kind: "wms",
+      fields: { endpoint: "https://x.test" },
+    });
+    assert.ok(fresh.id && fresh.id !== "keep-me");
+  });
+});
+
 describe("upsert / remove", () => {
   it("prepends a new entry and replaces by id", () => {
     const a = makeEntry({ id: "a", name: "A" });

--- a/tests/service-library.test.ts
+++ b/tests/service-library.test.ts
@@ -74,6 +74,12 @@ describe("normalizeServiceEntries", () => {
     assert.deepEqual(entry.fields, { endpoint: "https://x.test" });
   });
 
+  it("re-ids an entry whose id collides with a built-in id", () => {
+    const builtinId = BUILTIN_SERVICES[0].id;
+    const [entry] = normalizeServiceEntries([makeEntry({ id: builtinId })]);
+    assert.notEqual(entry.id, builtinId);
+  });
+
   it("returns an empty list for non-array input", () => {
     assert.deepEqual(normalizeServiceEntries({ services: [] }), []);
     assert.deepEqual(normalizeServiceEntries(null), []);

--- a/tests/service-library.test.ts
+++ b/tests/service-library.test.ts
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  BUILTIN_SERVICES,
+  createServiceEntry,
+  listServices,
+  mergeImportedServices,
+  normalizeServiceEntries,
+  parseImportedServices,
+  removeServiceEntry,
+  serializeUserServices,
+  serviceCategories,
+  serviceFieldBoolean,
+  serviceFieldString,
+  type ServiceLibraryEntry,
+  upsertServiceEntry,
+} from "../apps/geolibre-desktop/src/components/layout/add-data/service-library";
+
+function makeEntry(
+  overrides: Partial<ServiceLibraryEntry> = {},
+): ServiceLibraryEntry {
+  return {
+    id: overrides.id ?? "id-1",
+    name: overrides.name ?? "Example WMS",
+    category: overrides.category ?? "Imagery",
+    kind: overrides.kind ?? "wms",
+    fields: overrides.fields ?? { endpoint: "https://x.test/wms" },
+  };
+}
+
+describe("service field accessors", () => {
+  it("coerces string/number/boolean and falls back when absent", () => {
+    const fields = { a: "x", b: 256, c: true };
+    assert.equal(serviceFieldString(fields, "a"), "x");
+    assert.equal(serviceFieldString(fields, "b"), "256");
+    assert.equal(serviceFieldString(fields, "c"), "true");
+    assert.equal(serviceFieldString(fields, "missing", "fallback"), "fallback");
+    assert.equal(serviceFieldBoolean(fields, "c"), true);
+    assert.equal(serviceFieldBoolean(fields, "a", true), true);
+  });
+});
+
+describe("normalizeServiceEntries", () => {
+  it("keeps valid entries and drops invalid ones", () => {
+    const entries = normalizeServiceEntries([
+      makeEntry(),
+      { kind: "wms", name: "", fields: { a: "b" } }, // empty name
+      { kind: "bogus", name: "Nope", fields: { a: "b" } }, // bad kind
+      { kind: "wfs", name: "No fields", fields: {} }, // no usable fields
+      "not an object",
+    ]);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].name, "Example WMS");
+  });
+
+  it("re-ids duplicate ids so each entry stays unique", () => {
+    const entries = normalizeServiceEntries([
+      makeEntry({ id: "dup" }),
+      makeEntry({ id: "dup", name: "Second" }),
+    ]);
+    assert.equal(entries.length, 2);
+    assert.notEqual(entries[0].id, entries[1].id);
+  });
+
+  it("strips a non-string field and an injected builtin flag", () => {
+    const [entry] = normalizeServiceEntries([
+      {
+        ...makeEntry(),
+        builtin: true,
+        fields: { endpoint: "https://x.test", bad: { nested: 1 } },
+      },
+    ]);
+    assert.equal(entry.builtin, undefined);
+    assert.deepEqual(entry.fields, { endpoint: "https://x.test" });
+  });
+
+  it("returns an empty list for non-array input", () => {
+    assert.deepEqual(normalizeServiceEntries({ services: [] }), []);
+    assert.deepEqual(normalizeServiceEntries(null), []);
+  });
+});
+
+describe("upsert / remove", () => {
+  it("prepends a new entry and replaces by id", () => {
+    const a = makeEntry({ id: "a", name: "A" });
+    const b = makeEntry({ id: "b", name: "B" });
+    let list = upsertServiceEntry([a], b);
+    assert.deepEqual(
+      list.map((e) => e.id),
+      ["b", "a"],
+    );
+    list = upsertServiceEntry(list, makeEntry({ id: "a", name: "A2" }));
+    assert.equal(list.length, 2);
+    assert.equal(list.find((e) => e.id === "a")?.name, "A2");
+  });
+
+  it("removes by id", () => {
+    const list = removeServiceEntry([makeEntry({ id: "a" })], "a");
+    assert.deepEqual(list, []);
+  });
+});
+
+describe("listServices", () => {
+  it("lists built-ins first, then user entries of that kind", () => {
+    const user = makeEntry({ id: "u1", kind: "wms", name: "My WMS" });
+    const wms = listServices("wms", [user]);
+    const builtinWms = BUILTIN_SERVICES.filter((e) => e.kind === "wms");
+    assert.equal(wms.length, builtinWms.length + 1);
+    assert.ok(wms[0].builtin);
+    assert.equal(wms[wms.length - 1].name, "My WMS");
+    // A user XYZ entry must not appear under the wms kind.
+    assert.equal(
+      listServices("wms", [makeEntry({ kind: "xyz", id: "x" })]).some(
+        (e) => e.id === "x",
+      ),
+      false,
+    );
+  });
+});
+
+describe("serviceCategories", () => {
+  it("returns distinct, sorted, non-empty categories", () => {
+    const cats = serviceCategories([
+      makeEntry({ id: "1", category: "Theme" }),
+      makeEntry({ id: "2", category: "Country" }),
+      makeEntry({ id: "3", category: "Theme" }),
+      makeEntry({ id: "4", category: "" }),
+    ]);
+    assert.deepEqual(cats, ["Country", "Theme"]);
+  });
+});
+
+describe("import / export round-trip", () => {
+  it("serializes user entries (without builtin flag) and re-parses them", () => {
+    const entry = createServiceEntry({
+      name: "Round trip",
+      category: "Demo",
+      kind: "wfs",
+      fields: { endpoint: "https://x.test/wfs", maxFeatures: "10" },
+    });
+    const json = serializeUserServices([entry]);
+    assert.ok(!json.includes("builtin"));
+    const parsed = parseImportedServices(json);
+    assert.equal(parsed.length, 1);
+    assert.equal(parsed[0].name, "Round trip");
+    assert.deepEqual(parsed[0].fields, entry.fields);
+  });
+
+  it("accepts a bare entry array as well as the wrapped format", () => {
+    const parsed = parseImportedServices(JSON.stringify([makeEntry()]));
+    assert.equal(parsed.length, 1);
+  });
+
+  it("throws on invalid JSON", () => {
+    assert.throws(() => parseImportedServices("{not json"));
+  });
+
+  it("merges imported entries and re-ids collisions", () => {
+    const existing = [makeEntry({ id: "shared", name: "Existing" })];
+    const imported = [makeEntry({ id: "shared", name: "Imported" })];
+    const merged = mergeImportedServices(existing, imported);
+    assert.equal(merged.length, 2);
+    assert.equal(new Set(merged.map((e) => e.id)).size, 2);
+    assert.deepEqual(
+      merged.map((e) => e.name),
+      ["Existing", "Imported"],
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Implements the feature request in #417: a **cross-project library of reusable web-service layers**. Users can save a configured WMS/WFS/WMTS/XYZ/ArcGIS service once — with a user-defined **category** (country, theme, …) — and reload it into any project, instead of maintaining a separate database of service URLs.

The library lives inside the **Add Data dialog**: each web-service source now shows a *"Saved services"* box at the top of its form.

### What you can do
- **Load** a saved (or built-in) service → the form fields repopulate instantly.
- **Save current** → name + optional category; entries are grouped by category via `<optgroup>`.
- **Delete** your own entries (built-in presets are read-only).
- **Import / Export** the whole library as JSON (share/back up across machines), runtime-aware via the existing `saveTextFileWithFallback` (native dialog under Tauri, download on web).
- **Built-in presets** seed the library so it's useful on first run (USGS NAIP, USGS Imagery, OpenStreetMap, Esri World Imagery, GeoServer states demo, ArcGIS USA cities).

Persistence mirrors the established pattern (Zustand/localStorage + a defensive normalizer) using a new `geolibre.serviceLibrary` key. Built-in presets are always listed but never persisted, so they stay fresh across releases.

### Scope decisions
- All five web-service kinds (WMS, WFS, WMTS, XYZ, ArcGIS) supported in v1.
- Entries are kind-scoped — a saved WMS service only appears under WMS.
- **ArcGIS access tokens are deliberately excluded** from saved/exported fields (no credentials in the shared library).

## Files
- New `add-data/service-library.ts` — data layer (types, validation, storage, import/export, presets, category helpers). Dependency-light and unit-tested.
- New `add-data/ServiceLibrarySection.tsx` — the shared UI box.
- `add-data/constants.ts` — `SERVICE_LIBRARY_STORAGE_KEY` + `MAX_SAVED_SERVICES`.
- The 5 source components wired up with `getFields`/`applyFields`.
- `tests/service-library.test.ts` — 13 unit tests.

## Testing
- `npm run test:frontend` — 1056 pass (incl. 13 new). ✓
- `npm run build` (full `tsc -b` typecheck + vite) ✓
- `pre-commit run --files …` (eslint + npm build) ✓
- **Verified in the real app with Playwright:** built-ins appear grouped per kind; selecting one repopulates the form; Save current creates a new category group and persists to localStorage; XYZ built-ins show under Basemaps/Imagery; WMS-saved entries don't leak into the XYZ picker.

## Follow-ups (not in this PR)
- WMS/WFS GetCapabilities discovery (there's no capabilities parsing in GeoLibre's own code today) could let users pick layer names instead of typing them.

Closes #417.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable “Saved services” service library to the Add Data flow for WMS, WFS, WMTS, XYZ, and ArcGIS.
  * Users can save entries with categories, select from grouped lists, delete their saved items, and reuse saved configurations.
  * Added JSON import/export to transfer saved services between sessions.
  * Included built-in starter presets; only user entries can be updated or deleted (ArcGIS credentials are not persisted).
* **Tests**
  * Added automated tests covering validation, normalization, persistence, import/export, merging, and listing/category behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->