### PR TITLE
fix: legend/colorbar config panels auto-fit viewport (no forced scrollbar)

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -58,7 +58,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.1",
     "maplibre-gl-basemap-control": "^0.3.0",
-    "maplibre-gl-components": "^0.20.5",
+    "maplibre-gl-components": "^0.20.6",
     "maplibre-gl-duckdb": "^0.2.0",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.1",
         "maplibre-gl-basemap-control": "^0.3.0",
-        "maplibre-gl-components": "^0.20.5",
+        "maplibre-gl-components": "^0.20.6",
         "maplibre-gl-duckdb": "^0.2.0",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -185,9 +185,9 @@
       "license": "MIT"
     },
     "apps/geolibre-desktop/node_modules/maplibre-gl-components": {
-      "version": "0.20.5",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.20.5.tgz",
-      "integrity": "sha512-WRvHEFay5aFoBjlWSqEnCU3sd/q0eEchngT7a+a6p1wKKJcxVBro+epmmSlfk/KVrwPdk/Zy1HQ3KV81zYIyKg==",
+      "version": "0.20.6",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.20.6.tgz",
+      "integrity": "sha512-Ge5F84jXHnTwS+lHoj3k0uflGll65a1uGavTRiTFEsjqC45xOcL0G1LPj04PUKurlthVX1PXG/7sh1zzfEvPTg==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",
@@ -24276,7 +24276,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.1",
         "maplibre-gl-basemap-control": "^0.3.0",
-        "maplibre-gl-components": "^0.20.5",
+        "maplibre-gl-components": "^0.20.6",
         "maplibre-gl-duckdb": "^0.2.0",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -24313,9 +24313,9 @@
       }
     },
     "packages/plugins/node_modules/maplibre-gl-components": {
-      "version": "0.20.5",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.20.5.tgz",
-      "integrity": "sha512-WRvHEFay5aFoBjlWSqEnCU3sd/q0eEchngT7a+a6p1wKKJcxVBro+epmmSlfk/KVrwPdk/Zy1HQ3KV81zYIyKg==",
+      "version": "0.20.6",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.20.6.tgz",
+      "integrity": "sha512-Ge5F84jXHnTwS+lHoj3k0uflGll65a1uGavTRiTFEsjqC45xOcL0G1LPj04PUKurlthVX1PXG/7sh1zzfEvPTg==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -31,7 +31,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.1",
     "maplibre-gl-basemap-control": "^0.3.0",
-    "maplibre-gl-components": "^0.20.5",
+    "maplibre-gl-components": "^0.20.6",
     "maplibre-gl-duckdb": "^0.2.0",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -346,7 +346,10 @@ const COLORBAR_OPTIONS = {
   className: "geolibre-colorbar-control",
   collapsed: false,
   fontColor: "hsl(var(--popover-foreground))",
-  maxHeight: 520,
+  // Omit maxHeight so the control auto-fits the available viewport height
+  // (maplibre-gl-components >= 0.20.6). A fixed cap forced an unnecessary
+  // scrollbar even on tall screens, because the panel starts expanded and so
+  // never fires the "expand" event that constrainGuiPanelToViewport hooks.
   panelWidth: 320,
   position: colorbarControlPosition,
 } satisfies ColorbarGuiControlOptions;
@@ -356,7 +359,8 @@ const LEGEND_OPTIONS = {
   className: "geolibre-legend-control",
   collapsed: false,
   fontColor: "hsl(var(--popover-foreground))",
-  maxHeight: 520,
+  // Omit maxHeight so the control auto-fits the available viewport height
+  // (maplibre-gl-components >= 0.20.6); see COLORBAR_OPTIONS above.
   panelWidth: 320,
   position: legendControlPosition,
 } satisfies LegendGuiControlOptions;


### PR DESCRIPTION
## Summary

Fixes #422: the legend and colorbar configuration panels showed a vertical scrollbar and hid the place/Add button even on tall screens with plenty of room.

### Root cause (two parts)
1. **Upstream** (`maplibre-gl-components`) capped the panel at a fixed 500px with `overflowY: auto`, regardless of screen size. Fixed in opengeos/maplibre-gl-components#99 → released as [v0.20.6](https://github.com/opengeos/maplibre-gl-components/releases/tag/v0.20.6): the panel now sizes to the available viewport height on show and on resize.
2. **GeoLibre** passed an explicit `maxHeight: 520` to both controls, which *defeated* the new auto-fit. The existing `constrainGuiPanelToViewport` fallback only runs on the control's `"expand"` event, but these panels start expanded (`collapsed: false`) and so never fire it on first open — leaving the 520px cap in place.

### Changes
- Bump `maplibre-gl-components` `^0.20.5` → `^0.20.6` (`apps/geolibre-desktop`, `packages/plugins`, lockfile).
- Drop the explicit `maxHeight: 520` from `LEGEND_OPTIONS` and `COLORBAR_OPTIONS` so the upstream auto-fit default applies.

## Testing

Verified in the **real app** with Playwright (not mocks):

| Viewport | Legend | Colorbar | Result |
|---|---|---|---|
| 1900px tall | content 661px, maxHeight 1884px | content 608px, maxHeight 1884px | `scrollHeight === clientHeight` → **no scrollbar**, Add button visible |
| 600px tall | capped to 530px | capped to 491px | scrolls (correct — genuinely no room), panel stays on-screen |

Content (608–661px) exceeds the old 520px cap, confirming the previous behavior would have scrolled. Also: `npm run build` clean; `pre-commit` on changed files passes.

Closes #422