### PR TITLE
chore(deps): bump maplibre-gl-layer-control to 0.15.1

### DIFF
--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1430,6 +1430,29 @@ body,
   background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='22' fill='none' stroke='%2333b5e5' viewBox='0 0 22 22'%3E%3Ccircle cx='11' cy='11' r='8.5'/%3E%3Cpath d='M17.5 11c0 4.819-3.02 8.5-6.5 8.5S4.5 15.819 4.5 11 7.52 2.5 11 2.5s6.5 3.681 6.5 8.5Z'/%3E%3Cpath d='M13.5 11c0 2.447-.331 4.64-.853 6.206-.262.785-.562 1.384-.872 1.777-.314.399-.58.517-.775.517s-.461-.118-.775-.517c-.31-.393-.61-.992-.872-1.777C8.831 15.64 8.5 13.446 8.5 11s.331-4.64.853-6.206c.262-.785.562-1.384.872-1.777.314-.399.58-.517.775-.517s.461.118.775.517c.31.393.61.992.872 1.777.522 1.565.853 3.76.853 6.206Z'/%3E%3Cpath d='M11 7.5c-1.909 0-3.622-.166-4.845-.428-.616-.132-1.08-.283-1.379-.434a1.3 1.3 0 0 1-.224-.138q.07-.058.224-.138c.299-.151.763-.302 1.379-.434C7.378 5.666 9.091 5.5 11 5.5s3.622.166 4.845.428c.616.132 1.08.283 1.379.434.105.053.177.1.224.138q-.07.058-.224.138c-.299.151-.763.302-1.379.434-1.223.262-2.936.428-4.845.428ZM4.486 6.436ZM11 16.5c-1.909 0-3.622-.166-4.845-.428-.616-.132-1.08-.283-1.379-.434a1.3 1.3 0 0 1-.224-.138 1.3 1.3 0 0 1 .224-.138c.299-.151.763-.302 1.379-.434C7.378 14.666 9.091 14.5 11 14.5s3.622.166 4.845.428c.616.132 1.08.283 1.379.434.105.053.177.1.224.138a1.3 1.3 0 0 1-.224.138c-.299.151-.763.302-1.379.434-1.223.262-2.936.428-4.845.428Zm-6.514-1.064ZM11 12.5c-2.46 0-4.672-.222-6.255-.574-.796-.177-1.406-.38-1.805-.59a1.5 1.5 0 0 1-.39-.272.3.3 0 0 1-.047-.064.3.3 0 0 1 .048-.064c.066-.073.189-.167.389-.272.399-.21 1.009-.413 1.805-.59C6.328 9.722 8.54 9.5 11 9.5s4.672.222 6.256.574c.795.177 1.405.38 1.804.59.2.105.323.2.39.272a.3.3 0 0 1 .047.064.3.3 0 0 1-.048.064 1.4 1.4 0 0 1-.389.272c-.399.21-1.009.413-1.804.59-1.584.352-3.796.574-6.256.574Zm-8.501-1.51v.002zm0 .018v.002zm17.002.002v-.002zm0-.018v-.002z'/%3E%3C/svg%3E");
 }
 
+/* maplibre-gl-layer-control toggle button icon.
+   The library (>=0.15.0) intentionally leaves the icon's size/color to the host
+   so map themes can style it. GeoLibre keeps map controls light in both light
+   and dark mode, so pin the inline SVG to a fixed dark color (matching the
+   other controls) and cap its size — otherwise it inherits the dark-mode text
+   color (white-on-white, invisible) and renders oversized. */
+.maplibregl-ctrl-layer-control .layer-control-icon {
+  align-items: center;
+  color: #1f2a37;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  line-height: 0;
+  width: 100%;
+}
+
+.maplibregl-ctrl-layer-control .layer-control-icon svg {
+  fill: none;
+  height: 22px;
+  stroke: currentColor;
+  width: 22px;
+}
+
 .geolibre-identify-popup .maplibregl-popup-content {
   background: hsl(var(--popover));
   border: 1px solid hsl(var(--border));

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1496,6 +1496,7 @@ body,
   .geolibre-pmtiles-control .maplibre-gl-pmtiles-layer-panel,
   .geolibre-zarr-control .maplibre-gl-zarr-layer-panel,
   .maplibregl-map .pc-control-panel,
+  .maplibregl-map .layer-control-panel,
   .duckdb-control-panel {
     box-sizing: border-box;
     /* 96px clears the mobile top toolbar plus the panel's own top offset */

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1430,27 +1430,14 @@ body,
   background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='22' fill='none' stroke='%2333b5e5' viewBox='0 0 22 22'%3E%3Ccircle cx='11' cy='11' r='8.5'/%3E%3Cpath d='M17.5 11c0 4.819-3.02 8.5-6.5 8.5S4.5 15.819 4.5 11 7.52 2.5 11 2.5s6.5 3.681 6.5 8.5Z'/%3E%3Cpath d='M13.5 11c0 2.447-.331 4.64-.853 6.206-.262.785-.562 1.384-.872 1.777-.314.399-.58.517-.775.517s-.461-.118-.775-.517c-.31-.393-.61-.992-.872-1.777C8.831 15.64 8.5 13.446 8.5 11s.331-4.64.853-6.206c.262-.785.562-1.384.872-1.777.314-.399.58-.517.775-.517s.461.118.775.517c.31.393.61.992.872 1.777.522 1.565.853 3.76.853 6.206Z'/%3E%3Cpath d='M11 7.5c-1.909 0-3.622-.166-4.845-.428-.616-.132-1.08-.283-1.379-.434a1.3 1.3 0 0 1-.224-.138q.07-.058.224-.138c.299-.151.763-.302 1.379-.434C7.378 5.666 9.091 5.5 11 5.5s3.622.166 4.845.428c.616.132 1.08.283 1.379.434.105.053.177.1.224.138q-.07.058-.224.138c-.299.151-.763.302-1.379.434-1.223.262-2.936.428-4.845.428ZM4.486 6.436ZM11 16.5c-1.909 0-3.622-.166-4.845-.428-.616-.132-1.08-.283-1.379-.434a1.3 1.3 0 0 1-.224-.138 1.3 1.3 0 0 1 .224-.138c.299-.151.763-.302 1.379-.434C7.378 14.666 9.091 14.5 11 14.5s3.622.166 4.845.428c.616.132 1.08.283 1.379.434.105.053.177.1.224.138a1.3 1.3 0 0 1-.224.138c-.299.151-.763.302-1.379.434-1.223.262-2.936.428-4.845.428Zm-6.514-1.064ZM11 12.5c-2.46 0-4.672-.222-6.255-.574-.796-.177-1.406-.38-1.805-.59a1.5 1.5 0 0 1-.39-.272.3.3 0 0 1-.047-.064.3.3 0 0 1 .048-.064c.066-.073.189-.167.389-.272.399-.21 1.009-.413 1.805-.59C6.328 9.722 8.54 9.5 11 9.5s4.672.222 6.256.574c.795.177 1.405.38 1.804.59.2.105.323.2.39.272a.3.3 0 0 1 .047.064.3.3 0 0 1-.048.064 1.4 1.4 0 0 1-.389.272c-.399.21-1.009.413-1.804.59-1.584.352-3.796.574-6.256.574Zm-8.501-1.51v.002zm0 .018v.002zm17.002.002v-.002zm0-.018v-.002z'/%3E%3C/svg%3E");
 }
 
-/* maplibre-gl-layer-control toggle button icon.
-   The library (>=0.15.0) intentionally leaves the icon's size/color to the host
-   so map themes can style it. GeoLibre keeps map controls light in both light
-   and dark mode, so pin the inline SVG to a fixed dark color (matching the
-   other controls) and cap its size — otherwise it inherits the dark-mode text
-   color (white-on-white, invisible) and renders oversized. */
+/* maplibre-gl-layer-control toggle button icon color.
+   The library (>=0.15.1) sizes the icon itself but leaves its color to the host
+   theme (the SVG uses stroke="currentColor"). GeoLibre keeps map controls light
+   in both light and dark mode, so pin the icon to a fixed dark color matching
+   the other controls — otherwise it inherits the dark-mode text color and goes
+   white-on-white over the white control background. */
 .maplibregl-ctrl-layer-control .layer-control-icon {
-  align-items: center;
   color: #1f2a37;
-  display: flex;
-  height: 100%;
-  justify-content: center;
-  line-height: 0;
-  width: 100%;
-}
-
-.maplibregl-ctrl-layer-control .layer-control-icon svg {
-  fill: none;
-  height: 22px;
-  stroke: currentColor;
-  width: 22px;
 }
 
 .geolibre-identify-popup .maplibregl-popup-content {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17628,9 +17628,9 @@
       }
     },
     "node_modules/maplibre-gl-layer-control": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-layer-control/-/maplibre-gl-layer-control-0.14.1.tgz",
-      "integrity": "sha512-WnhDdq7vyp+r+ICErg9wW6Y8dBXxNtkPRCPiAgOjupngapeL8THFLs0qBiQYJtYMsc07wRwlmP4/5g8OroGosg==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-layer-control/-/maplibre-gl-layer-control-0.15.0.tgz",
+      "integrity": "sha512-eOn9ZqJhMniAcWDGP9xM126TK0jIC/8cxVW8UsaEVgMVmWigVMjzNgvnQmWw2uZp/bjIiJmTKTDAPXwf4Q7uKw==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -24187,7 +24187,7 @@
         "@turf/bbox": "^7.3.5",
         "@turf/helpers": "^7.3.5",
         "maplibre-gl": "^5.24.0",
-        "maplibre-gl-layer-control": "^0.14.1",
+        "maplibre-gl-layer-control": "^0.15.0",
         "pmtiles": "^4.4.1",
         "react": "^19.2.7",
         "react-dom": "^19.2.7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17628,9 +17628,9 @@
       }
     },
     "node_modules/maplibre-gl-layer-control": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-layer-control/-/maplibre-gl-layer-control-0.15.0.tgz",
-      "integrity": "sha512-eOn9ZqJhMniAcWDGP9xM126TK0jIC/8cxVW8UsaEVgMVmWigVMjzNgvnQmWw2uZp/bjIiJmTKTDAPXwf4Q7uKw==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-layer-control/-/maplibre-gl-layer-control-0.15.1.tgz",
+      "integrity": "sha512-osV/SuRXrBCOjJf4AzvOefTFxllBVC52FKtt6qDg7Gl7wvA+LFOcXSUv8pBnGtzWC/z4g690fUjnWSfdUKho1A==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -24187,7 +24187,7 @@
         "@turf/bbox": "^7.3.5",
         "@turf/helpers": "^7.3.5",
         "maplibre-gl": "^5.24.0",
-        "maplibre-gl-layer-control": "^0.15.0",
+        "maplibre-gl-layer-control": "^0.15.1",
         "pmtiles": "^4.4.1",
         "react": "^19.2.7",
         "react-dom": "^19.2.7"

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -15,7 +15,7 @@
     "@turf/bbox": "^7.3.5",
     "@turf/helpers": "^7.3.5",
     "maplibre-gl": "^5.24.0",
-    "maplibre-gl-layer-control": "^0.14.1",
+    "maplibre-gl-layer-control": "^0.15.0",
     "pmtiles": "^4.4.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -15,7 +15,7 @@
     "@turf/bbox": "^7.3.5",
     "@turf/helpers": "^7.3.5",
     "maplibre-gl": "^5.24.0",
-    "maplibre-gl-layer-control": "^0.15.0",
+    "maplibre-gl-layer-control": "^0.15.1",
     "pmtiles": "^4.4.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"


### PR DESCRIPTION
Bumps `maplibre-gl-layer-control` (used by `@geolibre/map`) from 0.14.1 to **0.15.1**, bringing two requested layer-panel features into GeoLibre:

- **Exact opacity %** (#426): double-click a layer's opacity slider to type an exact value (0–100%).
- **Drag-to-resize the panel** (#428): drag either edge of the layer panel to resize it, like a normal window.

It also fixes a latent issue: GeoLibre configures `panelMaxWidth: 450`, but the library previously hardcoded `max-width: 420px` in CSS, silently capping the panel. 0.15.x removes that cap, so the panel now honors the configured width and the new edge-resize.

### Toggle-icon fix
0.15.0 dropped the library's own toggle-button icon CSS (upstream PR #47, for a different map theme). In GeoLibre that left the layers icon **oversized** and, in **dark mode**, **white-on-white** (the inline SVG inherited the dark-mode text color over the white control background).

- The **size** regression is fixed upstream in **0.15.1** (the library sizes the icon again, theme-agnostically).
- The **color** is left to the host theme by design, so GeoLibre adds a small scoped `index.css` override pinning the icon to a fixed dark color that reads on the light control button in both themes.

## Testing
- `npm run build` passes; pre-commit (incl. npm-build) passes.
- Verified end-to-end in the running GeoLibre app with Playwright in **both light and dark mode**: the layer panel renders both resize handles, double-clicking the opacity slider opens the exact-% input, dragging the edge resizes the panel (up to 450px), and the toggle icon is correctly sized (22×22, from the library) with good contrast (dark, from the override). No console errors.

Closes #426
Closes #428

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Map layer control library dependency to version **0.15.1**.
* **Style**
  * Improved MapLibre layer-control toggle icon styling by fixing the icon color for consistent contrast across themes.
  * Extended the mobile styling rules to also apply to the layer-control panel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->