### PR TITLE
chore(deps): bump maplibre-gl-esri-wayback to 0.1.1

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -62,7 +62,7 @@
     "maplibre-gl-duckdb": "^0.2.0",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",
-    "maplibre-gl-esri-wayback": "^0.1.0",
+    "maplibre-gl-esri-wayback": "^0.1.1",
     "maplibre-gl-fema-wms": "^0.1.2",
     "maplibre-gl-geo-editor": "^0.8.0",
     "maplibre-gl-geoagent": "^0.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "maplibre-gl-duckdb": "^0.2.0",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
-        "maplibre-gl-esri-wayback": "^0.1.0",
+        "maplibre-gl-esri-wayback": "^0.1.1",
         "maplibre-gl-fema-wms": "^0.1.2",
         "maplibre-gl-geo-editor": "^0.8.0",
         "maplibre-gl-geoagent": "^0.4.2",
@@ -251,6 +251,28 @@
           "optional": true
         },
         "three": {
+          "optional": true
+        }
+      }
+    },
+    "apps/geolibre-desktop/node_modules/maplibre-gl-esri-wayback": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-esri-wayback/-/maplibre-gl-esri-wayback-0.1.1.tgz",
+      "integrity": "sha512-hyvzrHABe/BfvWL7V/EHEOCjUKUDx67CuRW9S+ulH3SMEOW0D1BxzfCTxlymGo89IObWVttVqilc84+MhYE5eA==",
+      "license": "MIT",
+      "dependencies": {
+        "@esri/wayback-core": ">=1.0.10"
+      },
+      "peerDependencies": {
+        "maplibre-gl": ">=5.24.0",
+        "react": ">=19.2.6",
+        "react-dom": ">=19.2.6"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
           "optional": true
         }
       }
@@ -17522,28 +17544,6 @@
         }
       }
     },
-    "node_modules/maplibre-gl-esri-wayback": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-esri-wayback/-/maplibre-gl-esri-wayback-0.1.0.tgz",
-      "integrity": "sha512-lJpqPZBQ0nNpoyAhHbJ5iQ6MOsunGUY2gOsKeHz6EaThzR/y41DkPdJU5VhaKFvIFSSKIEUyWoaZSTgW7B39yQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@esri/wayback-core": ">=1.0.10"
-      },
-      "peerDependencies": {
-        "maplibre-gl": ">=5.24.0",
-        "react": ">=19.2.6",
-        "react-dom": ">=19.2.6"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/maplibre-gl-fema-wms": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/maplibre-gl-fema-wms/-/maplibre-gl-fema-wms-0.1.2.tgz",
@@ -24280,7 +24280,7 @@
         "maplibre-gl-duckdb": "^0.2.0",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
-        "maplibre-gl-esri-wayback": "^0.1.0",
+        "maplibre-gl-esri-wayback": "^0.1.1",
         "maplibre-gl-fema-wms": "^0.1.2",
         "maplibre-gl-geo-editor": "^0.8.0",
         "maplibre-gl-geoagent": "^0.4.2",
@@ -24379,6 +24379,28 @@
           "optional": true
         },
         "three": {
+          "optional": true
+        }
+      }
+    },
+    "packages/plugins/node_modules/maplibre-gl-esri-wayback": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-esri-wayback/-/maplibre-gl-esri-wayback-0.1.1.tgz",
+      "integrity": "sha512-hyvzrHABe/BfvWL7V/EHEOCjUKUDx67CuRW9S+ulH3SMEOW0D1BxzfCTxlymGo89IObWVttVqilc84+MhYE5eA==",
+      "license": "MIT",
+      "dependencies": {
+        "@esri/wayback-core": ">=1.0.10"
+      },
+      "peerDependencies": {
+        "maplibre-gl": ">=5.24.0",
+        "react": ">=19.2.6",
+        "react-dom": ">=19.2.6"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
           "optional": true
         }
       }

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -35,7 +35,7 @@
     "maplibre-gl-duckdb": "^0.2.0",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",
-    "maplibre-gl-esri-wayback": "^0.1.0",
+    "maplibre-gl-esri-wayback": "^0.1.1",
     "maplibre-gl-fema-wms": "^0.1.2",
     "maplibre-gl-geo-editor": "^0.8.0",
     "maplibre-gl-geoagent": "^0.4.2",


### PR DESCRIPTION
Upstream `maplibre-gl-esri-wayback` v0.1.1 addresses the Esri Wayback menu UX issues reported in #414:

- Free-floating / repositionable plugin window
- Adjustable scroll-button size
- Collapsible / minimizable timeline

Bumps the dependency from `^0.1.0` to `^0.1.1` in both `apps/geolibre-desktop` and `packages/plugins`, and updates the lockfile (resolves to 0.1.1).

Closes #414

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to improve stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->