### PR TITLE
feat(style): scale-proportional (meters) stroke width unit

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1060,6 +1060,12 @@ export function StylePanel({
     layer.metadata.sourceKind === "maplibre-gl-vector" &&
     layer.metadata.geometryType === "point";
   const supportsPointRenderer = isCoreGeoJsonPoint || isVectorControlPoint;
+  const strokeWidthUnit = styleValue(style, "strokeWidthUnit");
+  // The unit only affects line/polygon-outline rendering. Point layers always
+  // stroke in pixels, so never present meters semantics (label/range/selector)
+  // for them, even if a hand-edited project set "meters".
+  const strokeWidthInMeters =
+    strokeWidthUnit === "meters" && !supportsPointRenderer;
   const pointRenderer = styleValue(style, "pointRenderer");
   const extrusionEnabled = styleValue(style, "extrusionEnabled");
   const extrusionHeightPropertyOptions = getAttributePropertyNames(layer);
@@ -1707,28 +1713,32 @@ export function StylePanel({
       </div>
       <NumericStyleInput
         id="strokeWidth"
-        label={
-          styleValue(style, "strokeWidthUnit") === "meters"
-            ? "Stroke width (meters)"
-            : "Stroke width"
-        }
+        label={strokeWidthInMeters ? "Stroke width (meters)" : "Stroke width"}
         min={0}
-        max={styleValue(style, "strokeWidthUnit") === "meters" ? 100000 : 20}
-        step={styleValue(style, "strokeWidthUnit") === "meters" ? 1 : 0.5}
+        max={strokeWidthInMeters ? 100000 : 20}
+        step={strokeWidthInMeters ? 1 : 0.5}
         value={style.strokeWidth}
         onChange={(strokeWidth) => setLayerStyle(layer.id, { strokeWidth })}
       />
-      {isPointOnly ? null : (
+      {supportsPointRenderer ? null : (
         <div className="space-y-2">
           <Label htmlFor="strokeWidthUnit">Stroke width unit</Label>
           <Select
             id="strokeWidthUnit"
-            value={styleValue(style, "strokeWidthUnit")}
-            onChange={(event) =>
+            value={strokeWidthUnit}
+            onChange={(event) => {
+              const nextUnit = event.target.value as StrokeWidthUnit;
+              // Meters and pixels are not freely convertible (pixel size
+              // depends on zoom), so a large meters width would render as a
+              // map-filling pixel width when switched back. Reset to the pixel
+              // default when leaving meters with an out-of-range value.
               setLayerStyle(layer.id, {
-                strokeWidthUnit: event.target.value as StrokeWidthUnit,
-              })
-            }
+                strokeWidthUnit: nextUnit,
+                ...(nextUnit === "pixels" && style.strokeWidth > 20
+                  ? { strokeWidth: DEFAULT_LAYER_STYLE.strokeWidth }
+                  : {}),
+              });
+            }}
           >
             <option value="pixels">Pixels (constant on screen)</option>
             <option value="meters">Meters (scales with map)</option>

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -2,6 +2,7 @@ import {
   DEFAULT_LAYER_STYLE,
   type LayerType,
   type PointRenderer,
+  type StrokeWidthUnit,
   VECTOR_COLOR_RAMPS,
   type VectorStyleMode,
   type VectorStyleStop,
@@ -1706,13 +1707,34 @@ export function StylePanel({
       </div>
       <NumericStyleInput
         id="strokeWidth"
-        label="Stroke width"
+        label={
+          styleValue(style, "strokeWidthUnit") === "meters"
+            ? "Stroke width (meters)"
+            : "Stroke width"
+        }
         min={0}
-        max={20}
-        step={0.5}
+        max={styleValue(style, "strokeWidthUnit") === "meters" ? 100000 : 20}
+        step={styleValue(style, "strokeWidthUnit") === "meters" ? 1 : 0.5}
         value={style.strokeWidth}
         onChange={(strokeWidth) => setLayerStyle(layer.id, { strokeWidth })}
       />
+      {isPointOnly ? null : (
+        <div className="space-y-2">
+          <Label htmlFor="strokeWidthUnit">Stroke width unit</Label>
+          <Select
+            id="strokeWidthUnit"
+            value={styleValue(style, "strokeWidthUnit")}
+            onChange={(event) =>
+              setLayerStyle(layer.id, {
+                strokeWidthUnit: event.target.value as StrokeWidthUnit,
+              })
+            }
+          >
+            <option value="pixels">Pixels (constant on screen)</option>
+            <option value="meters">Meters (scales with map)</option>
+          </Select>
+        </div>
+      )}
       <NumericStyleInput
         id="fillOpacity"
         label="Fill opacity"

--- a/docs/project-format.md
+++ b/docs/project-format.md
@@ -157,6 +157,7 @@ bound to a missing or non-attribute layer are shown as empty.
     "fillColor": "#3b82f6",
     "strokeColor": "#1e40af",
     "strokeWidth": 2,
+    "strokeWidthUnit": "pixels",
     "fillOpacity": 0.6,
     "circleRadius": 6,
     "rasterBrightnessMin": 0,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -73,6 +73,13 @@ export type VectorStyleMode =
  */
 export type PointRenderer = "single" | "heatmap" | "cluster";
 
+/**
+ * Unit a stroke/line width is measured in. `"pixels"` is constant screen space;
+ * `"meters"` is ground distance, so the rendered width scales with the map
+ * scale (zoom). See {@link LayerStyle.strokeWidthUnit}.
+ */
+export type StrokeWidthUnit = "pixels" | "meters";
+
 export interface VectorStyleStop {
   value: string | number;
   color: string;
@@ -85,6 +92,17 @@ export interface LayerStyle {
   fillColor: string;
   strokeColor: string;
   strokeWidth: number;
+  /**
+   * Unit the {@link strokeWidth} value is expressed in.
+   *
+   * - `"pixels"` (default): a constant screen-space width that never changes
+   *   with zoom — the historical behavior.
+   * - `"meters"`: a ground-distance width, so the rendered line stays
+   *   proportional to the map scale (thicker zoomed in, thinner zoomed out),
+   *   matching QGIS "map units". Only affects line/polygon-outline rendering;
+   *   point/circle outlines remain pixel-based.
+   */
+  strokeWidthUnit: StrokeWidthUnit;
   fillOpacity: number;
   circleRadius: number;
   textColor: string;
@@ -134,6 +152,7 @@ export const DEFAULT_LAYER_STYLE: LayerStyle = {
   fillColor: "#3b82f6",
   strokeColor: "#1e40af",
   strokeWidth: 2,
+  strokeWidthUnit: "pixels",
   fillOpacity: 0.6,
   circleRadius: 6,
   textColor: "#111827",

--- a/packages/core/src/vector-color.ts
+++ b/packages/core/src/vector-color.ts
@@ -80,6 +80,73 @@ export function simpleStyleNumberValue(
   return ["to-number", ["get", property], base];
 }
 
+// Ground resolution (meters per pixel) at MapLibre zoom 0 on the equator, for
+// the Web Mercator projection: earth circumference (2*pi*6378137) over the
+// 512px world at zoom 0. Resolution halves with every zoom level.
+const MERCATOR_METERS_PER_PIXEL_AT_ZOOM_0 = (2 * Math.PI * 6378137) / 512;
+
+// Largest zoom MapLibre renders; used as the upper interpolation stop.
+const MAX_MERCATOR_ZOOM = 24;
+
+/**
+ * Build a zoom-driven width expression that keeps a stroke proportional to the
+ * map scale, so a width given in ground meters renders thicker when zoomed in
+ * and thinner when zoomed out (QGIS "map units" behavior).
+ *
+ * In Web Mercator the pixels-per-meter ratio doubles with each zoom level, so
+ * an `["exponential", 2]` interpolation between two stops one zoom apart is
+ * exact across the whole range. The conversion is referenced to the equator;
+ * because Mercator stretches distances toward the poles, the on-screen width at
+ * higher latitudes is correspondingly larger, matching how the underlying map
+ * is itself stretched.
+ *
+ * Typed maplibre-agnostically (`unknown[]`); consumers cast to the concrete
+ * `PropertyValueSpecification<number>` where the MapLibre types are in scope.
+ *
+ * @param meters - The stroke width in ground meters.
+ * @returns A MapLibre `interpolate` expression array.
+ */
+export function metersWidthExpression(meters: number): unknown[] {
+  const widthAtZoom0 = meters / MERCATOR_METERS_PER_PIXEL_AT_ZOOM_0;
+  return [
+    "interpolate",
+    ["exponential", 2],
+    ["zoom"],
+    0,
+    widthAtZoom0,
+    MAX_MERCATOR_ZOOM,
+    widthAtZoom0 * 2 ** MAX_MERCATOR_ZOOM,
+  ];
+}
+
+/**
+ * Resolve the `line-width` paint value for a layer style, honoring the
+ * {@link LayerStyle.strokeWidthUnit}:
+ *
+ * - `"meters"`: a zoom-driven {@link metersWidthExpression} from the flat
+ *   `strokeWidth`, so the stroke scales with the map. A per-feature pixel
+ *   `stroke-width` override no longer applies in this mode.
+ * - `"pixels"` (default): the constant pixel width, still honoring any
+ *   per-feature simplestyle `stroke-width`.
+ *
+ * Shared by the map style-mapper and the geo-editor plugin so the Sketches
+ * store layer and Geoman's interaction display layers render an identical
+ * width.
+ *
+ * @param style - The layer style.
+ * @returns A number (constant pixels) or a MapLibre expression array.
+ */
+export function lineWidthValue(style: LayerStyle): number | unknown[] {
+  if (styleValue(style, "strokeWidthUnit") === "meters") {
+    return metersWidthExpression(styleValue(style, "strokeWidth"));
+  }
+  return simpleStyleNumberValue(
+    style,
+    "stroke-width",
+    styleValue(style, "strokeWidth"),
+  );
+}
+
 /**
  * Whether a FeatureCollection carries per-feature simplestyle-spec properties
  * worth honoring: at least one feature with a valid hex color in a color key

--- a/packages/map/src/style-mapper.ts
+++ b/packages/map/src/style-mapper.ts
@@ -20,6 +20,41 @@ function styleValue<K extends keyof LayerStyle>(
   return style[key] ?? DEFAULT_LAYER_STYLE[key];
 }
 
+// Ground resolution (meters per pixel) at MapLibre zoom 0 on the equator, for
+// the Web Mercator projection: earth circumference (2*pi*6378137) over the
+// 512px world at zoom 0. Resolution halves with every zoom level.
+const MERCATOR_METERS_PER_PIXEL_AT_ZOOM_0 = (2 * Math.PI * 6378137) / 512;
+
+// Largest zoom MapLibre renders; used as the upper interpolation stop.
+const MAX_MERCATOR_ZOOM = 24;
+
+/**
+ * Build a zoom-driven `line-width` value that keeps a stroke proportional to
+ * the map scale, so a width given in ground meters renders thicker when zoomed
+ * in and thinner when zoomed out (QGIS "map units" behavior).
+ *
+ * In Web Mercator the pixels-per-meter ratio doubles with each zoom level, so
+ * an `["exponential", 2]` interpolation between two stops one zoom apart is
+ * exact across the whole range. The conversion is referenced to the equator;
+ * because Mercator stretches distances toward the poles, the on-screen width at
+ * higher latitudes is correspondingly larger, matching how the underlying map
+ * is itself stretched.
+ */
+export function metersWidthExpression(
+  meters: number,
+): ExpressionSpecification {
+  const widthAtZoom0 = meters / MERCATOR_METERS_PER_PIXEL_AT_ZOOM_0;
+  return [
+    "interpolate",
+    ["exponential", 2],
+    ["zoom"],
+    0,
+    widthAtZoom0,
+    MAX_MERCATOR_ZOOM,
+    widthAtZoom0 * 2 ** MAX_MERCATOR_ZOOM,
+  ];
+}
+
 // Fold the layer's opacity multiplier into a paint value that may itself be a
 // data-driven (simplestyle) expression rather than a plain number.
 function scaleByOpacity(
@@ -94,15 +129,25 @@ export function fillExtrusionPaint(style: LayerStyle, opacity: number) {
 }
 
 export function linePaint(style: LayerStyle, opacity: number) {
+  // In "meters" mode the width is a ground distance, so it must scale with the
+  // map and a per-feature pixel stroke-width override no longer applies; emit a
+  // zoom expression from the flat width. Otherwise keep the existing pixel
+  // width (which still honors any per-feature simplestyle stroke-width).
+  const lineWidth =
+    styleValue(style, "strokeWidthUnit") === "meters"
+      ? (metersWidthExpression(
+          styleValue(style, "strokeWidth"),
+        ) as unknown as PropertyValueSpecification<number>)
+      : (simpleStyleNumberValue(
+          style,
+          "stroke-width",
+          styleValue(style, "strokeWidth"),
+        ) as unknown as PropertyValueSpecification<number>);
   return {
     "line-color": vectorLineColorValue(
       style,
     ) as PropertyValueSpecification<string>,
-    "line-width": simpleStyleNumberValue(
-      style,
-      "stroke-width",
-      styleValue(style, "strokeWidth"),
-    ) as unknown as PropertyValueSpecification<number>,
+    "line-width": lineWidth,
     "line-opacity": scaleByOpacity(
       simpleStyleNumberValue(style, "stroke-opacity", 1),
       opacity,

--- a/packages/map/src/style-mapper.ts
+++ b/packages/map/src/style-mapper.ts
@@ -1,5 +1,7 @@
 import {
   DEFAULT_LAYER_STYLE,
+  lineWidthValue,
+  metersWidthExpression,
   parseJsonExpression,
   simpleStyleNumberValue,
   vectorCircleColorValue,
@@ -20,40 +22,10 @@ function styleValue<K extends keyof LayerStyle>(
   return style[key] ?? DEFAULT_LAYER_STYLE[key];
 }
 
-// Ground resolution (meters per pixel) at MapLibre zoom 0 on the equator, for
-// the Web Mercator projection: earth circumference (2*pi*6378137) over the
-// 512px world at zoom 0. Resolution halves with every zoom level.
-const MERCATOR_METERS_PER_PIXEL_AT_ZOOM_0 = (2 * Math.PI * 6378137) / 512;
-
-// Largest zoom MapLibre renders; used as the upper interpolation stop.
-const MAX_MERCATOR_ZOOM = 24;
-
-/**
- * Build a zoom-driven `line-width` value that keeps a stroke proportional to
- * the map scale, so a width given in ground meters renders thicker when zoomed
- * in and thinner when zoomed out (QGIS "map units" behavior).
- *
- * In Web Mercator the pixels-per-meter ratio doubles with each zoom level, so
- * an `["exponential", 2]` interpolation between two stops one zoom apart is
- * exact across the whole range. The conversion is referenced to the equator;
- * because Mercator stretches distances toward the poles, the on-screen width at
- * higher latitudes is correspondingly larger, matching how the underlying map
- * is itself stretched.
- */
-export function metersWidthExpression(
-  meters: number,
-): ExpressionSpecification {
-  const widthAtZoom0 = meters / MERCATOR_METERS_PER_PIXEL_AT_ZOOM_0;
-  return [
-    "interpolate",
-    ["exponential", 2],
-    ["zoom"],
-    0,
-    widthAtZoom0,
-    MAX_MERCATOR_ZOOM,
-    widthAtZoom0 * 2 ** MAX_MERCATOR_ZOOM,
-  ];
-}
+// Re-exported for consumers and tests that import the Web Mercator width
+// expression from the map style-mapper; the implementation lives in
+// `@geolibre/core` so the geo-editor plugin can share it.
+export { metersWidthExpression };
 
 // Fold the layer's opacity multiplier into a paint value that may itself be a
 // data-driven (simplestyle) expression rather than a plain number.
@@ -129,25 +101,13 @@ export function fillExtrusionPaint(style: LayerStyle, opacity: number) {
 }
 
 export function linePaint(style: LayerStyle, opacity: number) {
-  // In "meters" mode the width is a ground distance, so it must scale with the
-  // map and a per-feature pixel stroke-width override no longer applies; emit a
-  // zoom expression from the flat width. Otherwise keep the existing pixel
-  // width (which still honors any per-feature simplestyle stroke-width).
-  const lineWidth =
-    styleValue(style, "strokeWidthUnit") === "meters"
-      ? (metersWidthExpression(
-          styleValue(style, "strokeWidth"),
-        ) as unknown as PropertyValueSpecification<number>)
-      : (simpleStyleNumberValue(
-          style,
-          "stroke-width",
-          styleValue(style, "strokeWidth"),
-        ) as unknown as PropertyValueSpecification<number>);
   return {
     "line-color": vectorLineColorValue(
       style,
     ) as PropertyValueSpecification<string>,
-    "line-width": lineWidth,
+    "line-width": lineWidthValue(
+      style,
+    ) as unknown as PropertyValueSpecification<number>,
     "line-opacity": scaleByOpacity(
       simpleStyleNumberValue(style, "stroke-opacity", 1),
       opacity,

--- a/packages/map/src/style-mapper.ts
+++ b/packages/map/src/style-mapper.ts
@@ -1,7 +1,6 @@
 import {
   DEFAULT_LAYER_STYLE,
   lineWidthValue,
-  metersWidthExpression,
   parseJsonExpression,
   simpleStyleNumberValue,
   vectorCircleColorValue,
@@ -21,11 +20,6 @@ function styleValue<K extends keyof LayerStyle>(
 ): LayerStyle[K] {
   return style[key] ?? DEFAULT_LAYER_STYLE[key];
 }
-
-// Re-exported for consumers and tests that import the Web Mercator width
-// expression from the map style-mapper; the implementation lives in
-// `@geolibre/core` so the geo-editor plugin can share it.
-export { metersWidthExpression };
 
 // Fold the layer's opacity multiplier into a paint value that may itself be a
 // data-driven (simplestyle) expression rather than a plain number.

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -1,4 +1,9 @@
-import { type GeoLibreLayer, styleValue, useAppStore } from "@geolibre/core";
+import {
+  type GeoLibreLayer,
+  lineWidthValue,
+  styleValue,
+  useAppStore,
+} from "@geolibre/core";
 import { Geoman, defaultLayerStyles } from "@geoman-io/maplibre-geoman-free";
 import type { Feature, FeatureCollection } from "geojson";
 import type maplibregl from "maplibre-gl";
@@ -990,6 +995,7 @@ function applyGeomanSketchesStyle(
   for (const layer of style.layers) {
     if (!isGeomanDisplayLayer(layer)) continue;
     applyGeomanDisplayLayerOpacity(map, layer, sketchesLayer.opacity);
+    applyGeomanDisplayLayerWidth(map, layer, sketchesLayer.style);
     if (!isGeomanTextMarkerLayer(layer)) continue;
     try {
       map.setLayoutProperty(
@@ -1017,6 +1023,26 @@ function applyGeomanSketchesStyle(
       // Geoman may rebuild its temporary layers while an interaction is active.
     }
   }
+}
+
+/**
+ * Mirror the Sketches layer's stroke width onto Geoman's committed-feature
+ * display line layers. While the draw/edit tools are active the store Sketches
+ * layer is suppressed and Geoman renders the existing features instead; without
+ * this, those features fall back to Geoman's fixed default width, so a custom
+ * (or scale-proportional "meters") stroke width would visibly revert. The
+ * transient drawing aids (in-progress `gm_temporary-*` geometry and snap
+ * guides) keep Geoman's defaults so editing stays legible.
+ */
+function applyGeomanDisplayLayerWidth(
+  map: maplibregl.Map,
+  layer: maplibregl.LayerSpecification,
+  style: GeoLibreLayer["style"],
+): void {
+  if (layer.type !== "line") return;
+  const id = layer.id.toLowerCase();
+  if (!id.startsWith("gm_main") || id.includes("snap")) return;
+  setGeomanPaintProperty(map, layer.id, "line-width", lineWidthValue(style));
 }
 
 function applyGeomanDisplayLayerOpacity(

--- a/tests/stroke-width-unit.test.ts
+++ b/tests/stroke-width-unit.test.ts
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { DEFAULT_LAYER_STYLE, type LayerStyle } from "@geolibre/core";
-import { linePaint, metersWidthExpression } from "../packages/map/src/style-mapper";
+import {
+  DEFAULT_LAYER_STYLE,
+  lineWidthValue,
+  metersWidthExpression,
+  type LayerStyle,
+} from "@geolibre/core";
+import { linePaint } from "../packages/map/src/style-mapper";
 
 function style(patch: Partial<LayerStyle> = {}): LayerStyle {
   return { ...DEFAULT_LAYER_STYLE, ...patch };
@@ -50,6 +55,27 @@ describe("linePaint with meter stroke width", () => {
     // A pixel-based per-feature override would surface as a ["to-number", ...]
     // expression; meters mode must instead keep the scale-proportional one.
     assert.equal((paint["line-width"] as unknown[])[0], "interpolate");
+  });
+});
+
+describe("lineWidthValue (shared by map + geo-editor plugin)", () => {
+  it("returns a constant pixel width by default", () => {
+    assert.equal(lineWidthValue(style({ strokeWidth: 3 })), 3);
+  });
+
+  it("returns the per-feature simplestyle override when enabled (pixels)", () => {
+    assert.deepEqual(
+      lineWidthValue(style({ strokeWidth: 3, simpleStyleEnabled: true })),
+      ["to-number", ["get", "stroke-width"], 3],
+    );
+  });
+
+  it("returns the meters expression in meters mode, ignoring simplestyle", () => {
+    const value = lineWidthValue(
+      style({ strokeWidth: 80, strokeWidthUnit: "meters", simpleStyleEnabled: true }),
+    ) as unknown[];
+    assert.equal(value[0], "interpolate");
+    assert.deepEqual(value, metersWidthExpression(80));
   });
 });
 

--- a/tests/stroke-width-unit.test.ts
+++ b/tests/stroke-width-unit.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { DEFAULT_LAYER_STYLE, type LayerStyle } from "@geolibre/core";
+import { linePaint, metersWidthExpression } from "../packages/map/src/style-mapper";
+
+function style(patch: Partial<LayerStyle> = {}): LayerStyle {
+  return { ...DEFAULT_LAYER_STYLE, ...patch };
+}
+
+// Ground resolution (m/px) at zoom 0 on the equator for the 512px Web Mercator
+// world — must match the constant used inside style-mapper.
+const METERS_PER_PIXEL_AT_ZOOM_0 = (2 * Math.PI * 6378137) / 512;
+
+describe("strokeWidthUnit default", () => {
+  it("defaults to pixels", () => {
+    assert.equal(DEFAULT_LAYER_STYLE.strokeWidthUnit, "pixels");
+  });
+});
+
+describe("linePaint with pixel stroke width (default)", () => {
+  it("emits a constant numeric width", () => {
+    assert.equal(
+      linePaint(style({ strokeWidth: 4 }), 1)["line-width"],
+      4,
+    );
+  });
+});
+
+describe("linePaint with meter stroke width", () => {
+  it("emits a zoom-driven exponential interpolation", () => {
+    const meters = 100;
+    const paint = linePaint(style({ strokeWidth: meters, strokeWidthUnit: "meters" }), 1);
+    const widthAtZoom0 = meters / METERS_PER_PIXEL_AT_ZOOM_0;
+    assert.deepEqual(paint["line-width"], [
+      "interpolate",
+      ["exponential", 2],
+      ["zoom"],
+      0,
+      widthAtZoom0,
+      24,
+      widthAtZoom0 * 2 ** 24,
+    ]);
+  });
+
+  it("ignores per-feature simplestyle stroke-width in meters mode", () => {
+    const paint = linePaint(
+      style({ strokeWidth: 50, strokeWidthUnit: "meters", simpleStyleEnabled: true }),
+      1,
+    );
+    // A pixel-based per-feature override would surface as a ["to-number", ...]
+    // expression; meters mode must instead keep the scale-proportional one.
+    assert.equal((paint["line-width"] as unknown[])[0], "interpolate");
+  });
+});
+
+describe("metersWidthExpression", () => {
+  it("scales the width so it doubles each zoom level (Web Mercator)", () => {
+    const expr = metersWidthExpression(METERS_PER_PIXEL_AT_ZOOM_0) as unknown[];
+    // 1px wide at zoom 0 by construction (width == one pixel of ground).
+    assert.equal(expr[3], 0);
+    assert.equal(expr[4], 1);
+    // ...and 2^24 px wide at zoom 24.
+    assert.equal(expr[5], 24);
+    assert.equal(expr[6], 2 ** 24);
+  });
+});

--- a/tests/stroke-width-unit.test.ts
+++ b/tests/stroke-width-unit.test.ts
@@ -82,10 +82,11 @@ describe("lineWidthValue (shared by map + geo-editor plugin)", () => {
 describe("metersWidthExpression", () => {
   it("scales the width so it doubles each zoom level (Web Mercator)", () => {
     const expr = metersWidthExpression(METERS_PER_PIXEL_AT_ZOOM_0) as unknown[];
-    // 1px wide at zoom 0 by construction (width == one pixel of ground).
+    // First stop: zoom level 0 (expr[3]) with a 1px width (expr[4]), because the
+    // input meters == MERCATOR_METERS_PER_PIXEL_AT_ZOOM_0 by construction.
     assert.equal(expr[3], 0);
     assert.equal(expr[4], 1);
-    // ...and 2^24 px wide at zoom 24.
+    // Last stop: zoom level 24 (expr[5]) with a 2^24 px width (expr[6]).
     assert.equal(expr[5], 24);
     assert.equal(expr[6], 2 ** 24);
   });


### PR DESCRIPTION
## Summary

Closes #424.

Adds a per-layer **Stroke width unit** option (Pixels or Meters) in the Style panel so line and polygon-outline thickness can stay proportional to the map scale, matching QGIS "map units".

- **Pixels** (default, unchanged): constant on-screen width at every zoom.
- **Meters**: a ground-distance width that scales with zoom, so strokes render thicker when zoomed in and thinner when zoomed out.

Because drawn sketches render through the standard vector layer pipeline, this works for drawn lines/shapes as well as any other vector layer, with no changes needed in the geo-editor.

## How it works

In meters mode the flat `strokeWidth` is converted to a zoom-driven `line-width` expression. In Web Mercator the pixels-per-meter ratio doubles each zoom level, so an `["interpolate", ["exponential", 2], ["zoom"], ...]` between two stops is exact across the whole zoom range. The conversion is referenced to the equator; toward the poles the on-screen width grows in step with how Mercator itself stretches the map.

The unit applies to `line-width` (lines and polygon outlines, i.e. the "line or shape" thickness in the issue). Point/circle outlines stay pixel-based, and the unit selector is hidden for point-only layers.

## Changes

- `@geolibre/core`: new `StrokeWidthUnit` type and `LayerStyle.strokeWidthUnit` field (defaults to `"pixels"`; round-trips through `.geolibre.json`).
- `@geolibre/map`: `metersWidthExpression()` helper; `linePaint` emits the zoom expression in meters mode.
- Desktop Style panel: unit dropdown next to Stroke width (label/range adapt to the unit).
- Docs + a new test file covering the paint output and the Mercator math.

## Testing

- `npm run test:frontend` — 1065 tests pass (added `tests/stroke-width-unit.test.ts`).
- `npm run typecheck` (full build) passes.
- `pre-commit` passes on the changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Stroke width unit” option for vector layers (pixels or meters).
  * When set to meters, stroke widths scale dynamically with zoom for line/polygon outlines.
  * The configured stroke-width behavior is now applied consistently to relevant editor display layers.
* **Documentation**
  * Updated the Layer JSON schema example to include `style.strokeWidthUnit`.
* **Tests**
  * Added automated coverage for default unit behavior, pixel vs. meter rendering, zoom-scaling logic, and integration expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->