### PR TITLE
feat(layers): grey out layer names hidden by group visibility

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -1075,6 +1075,10 @@ export function LayerPanel({
               ? firstMemberIdByGroup.get(group.id) === layer.id
               : false;
             const groupCollapsed = group?.collapsed ?? false;
+            // When the parent group is hidden, the layer is not rendered even
+            // though its own visibility toggle stays on. Grey the row out as a
+            // cue that the group-level setting is what's hiding it (issue #430).
+            const groupHidden = group ? !group.visible : false;
             const canIdentify =
               layer.type === "geojson" ||
               isDuckDBQueryLayer(layer) ||
@@ -1199,8 +1203,14 @@ export function LayerPanel({
                     />
                   ) : (
                     <span
-                      className="flex-1 truncate text-sm font-medium"
-                      title="Double-click to rename"
+                      className={`flex-1 truncate text-sm font-medium ${
+                        groupHidden ? "text-muted-foreground" : ""
+                      }`}
+                      title={
+                        groupHidden
+                          ? t("layers.hiddenByGroup")
+                          : "Double-click to rename"
+                      }
                       onDoubleClick={(e: ReactMouseEvent) => {
                         e.stopPropagation();
                         beginRename(layer);

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -1075,10 +1075,12 @@ export function LayerPanel({
               ? firstMemberIdByGroup.get(group.id) === layer.id
               : false;
             const groupCollapsed = group?.collapsed ?? false;
-            // When the parent group is hidden, the layer is not rendered even
-            // though its own visibility toggle stays on. Grey the row out as a
-            // cue that the group-level setting is what's hiding it (issue #430).
-            const groupHidden = group ? !group.visible : false;
+            // When the parent group is hidden, a layer whose own visibility
+            // toggle is still on is not rendered — a surprising state. Grey its
+            // name out as a cue that the group-level setting is what's hiding
+            // it (issue #430). If the layer's own toggle is also off, the
+            // EyeOff icon already explains it, so skip the group cue then.
+            const groupHidden = group ? !group.visible && layer.visible : false;
             const canIdentify =
               layer.type === "geojson" ||
               isDuckDBQueryLayer(layer) ||
@@ -1209,7 +1211,7 @@ export function LayerPanel({
                       title={
                         groupHidden
                           ? t("layers.hiddenByGroup")
-                          : "Double-click to rename"
+                          : t("layers.doubleClickToRename")
                       }
                       onDoubleClick={(e: ReactMouseEvent) => {
                         e.stopPropagation();

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -1210,7 +1210,7 @@ export function LayerPanel({
                       }`}
                       title={
                         groupHidden
-                          ? t("layers.hiddenByGroup")
+                          ? `${t("layers.hiddenByGroup")} — ${t("layers.doubleClickToRename")}`
                           : t("layers.doubleClickToRename")
                       }
                       onDoubleClick={(e: ReactMouseEvent) => {

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -898,7 +898,8 @@
     "renameNamed": "Rename {{name}}",
     "newGroupFromLayer": "New group from layer",
     "moveToGroup": "Move to group",
-    "removeFromGroup": "Remove from group"
+    "removeFromGroup": "Remove from group",
+    "hiddenByGroup": "Hidden because its group is not visible"
   },
   "rasterSymbology": {
     "reverseRamp": "Reverse ramp",


### PR DESCRIPTION
## Summary

Closes #430.

When a layer group is set to non-visible, its child layers stop rendering on the map even though each layer's own visibility toggle stays on. The Layers panel previously gave no cue for this, so it looked like the layers should be visible when they weren't.

This greys out (`text-muted-foreground`) each child layer's name when its parent group is hidden, and swaps its tooltip to **"Hidden because its group is not visible"**. The cue clears immediately when the group is shown again. The individual visibility toggle is left untouched, so users can still see/set each layer's own state.

## Changes

- `apps/geolibre-desktop/src/components/panels/LayerPanel.tsx` — compute `groupHidden = group ? !group.visible : false` in the layer render loop and apply the muted class + explanatory tooltip to the layer name span.
- `apps/geolibre-desktop/src/i18n/locales/en.json` — add the `layers.hiddenByGroup` string.

This is presentational only — the group→layer effective-visibility logic (`applyGroupEffects`) is unchanged and already covered by `tests/layer-groups.test.ts`.

## Testing

- `npm run build` (typecheck + build) passes.
- `pre-commit run --files` passes (eslint, npm build, etc.).
- Verified end-to-end in the real app with Playwright using real GeoJSON layers (US states + cities): with the group visible the name span has no muted class and tooltip "Double-click to rename"; after hiding the group the name gains `text-muted-foreground` and tooltip "Hidden because its group is not visible"; showing the group reverts both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Layers now reflect when they’re hidden by their parent group: they use muted styling and show an updated hover tooltip explaining the hidden-by-group reason (along with the rename hint).

* **Localization**
  * Added the new `hiddenByGroup` translation string used by the updated layer tooltip.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->