### PR TITLE
feat(layer-control): save & reuse basemap element visibility presets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17628,9 +17628,9 @@
       }
     },
     "node_modules/maplibre-gl-layer-control": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-layer-control/-/maplibre-gl-layer-control-0.15.1.tgz",
-      "integrity": "sha512-osV/SuRXrBCOjJf4AzvOefTFxllBVC52FKtt6qDg7Gl7wvA+LFOcXSUv8pBnGtzWC/z4g690fUjnWSfdUKho1A==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-layer-control/-/maplibre-gl-layer-control-0.16.0.tgz",
+      "integrity": "sha512-6qTuxG39KYlwaA5tp9qgr2+EzWOI0a1R9EeQxZMVaRHRNhYqVyrWsa7i8Q0S8V5N1m8eEqumNMWZtKs0GfM+XQ==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -24187,7 +24187,7 @@
         "@turf/bbox": "^7.3.5",
         "@turf/helpers": "^7.3.5",
         "maplibre-gl": "^5.24.0",
-        "maplibre-gl-layer-control": "^0.15.1",
+        "maplibre-gl-layer-control": "^0.16.0",
         "pmtiles": "^4.4.1",
         "react": "^19.2.7",
         "react-dom": "^19.2.7"

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -15,7 +15,7 @@
     "@turf/bbox": "^7.3.5",
     "@turf/helpers": "^7.3.5",
     "maplibre-gl": "^5.24.0",
-    "maplibre-gl-layer-control": "^0.15.1",
+    "maplibre-gl-layer-control": "^0.16.0",
     "pmtiles": "^4.4.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"

--- a/packages/plugins/src/plugins/layer-control.ts
+++ b/packages/plugins/src/plugins/layer-control.ts
@@ -9,7 +9,7 @@ let layerControlPosition: GeoLibreMapControlPosition = "top-right";
 export const maplibreLayerControlPlugin: GeoLibrePlugin = {
   id: "maplibre-layer-control",
   name: "Layer Control",
-  version: "0.14.1",
+  version: "0.16.0",
   activeByDefault: true,
   activate: (app: GeoLibreAppAPI) =>
     app.setBuiltInMapControlVisible("layer-control", true),


### PR DESCRIPTION
## Summary

Closes #425.

Users can now save which basemap elements (water, roads, labels, buildings, …) are toggled on/off as a **named preset** and re-apply it with a single click. Presets persist in `localStorage`, so they survive restarts and apply to any project — no more re-toggling every time.

The basemap-element toggling lives entirely in the `maplibre-gl-layer-control` "Background Layers" panel, so the feature was implemented upstream and is pulled in here via a version bump.

## Changes

- Bump `maplibre-gl-layer-control` `^0.15.1` → **`^0.16.0`** (`packages/map`).
- Bump the Layer Control plugin's `version` string to `0.16.0` to match.
- Refresh `package-lock.json`.

The feature is enabled by default, so no other GeoLibre code change is required.

## What's in 0.16.0

A "Saved configurations" section in the Background Layers panel (preset dropdown + Apply/Delete, plus a name field + Save), backed by `localStorage`. Upstream PR: [opengeos/maplibre-gl-layer-control#56](https://github.com/opengeos/maplibre-gl-layer-control/pull/56) · [release v0.16.0](https://github.com/opengeos/maplibre-gl-layer-control/releases/tag/v0.16.0).

## Verification

- `npm run build` passes; `pre-commit run --files …` (incl. the npm-build hook) passes.
- Verified end-to-end in the real app with Playwright before the upstream release: opened the Background Layers panel → toggled a basemap element off → saved a preset → confirmed it persisted to `localStorage` → reloaded the page (preset survived) → **Apply** restored the saved visibility on the live map.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated layer control dependency and synchronized plugin version to 0.16.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->