### PR TITLE
feat(basemaps): support stacking multiple raster basemaps

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -57,7 +57,7 @@
     "mapillary-js": "^4.1.2",
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.1",
-    "maplibre-gl-basemap-control": "^0.3.0",
+    "maplibre-gl-basemap-control": "^0.4.0",
     "maplibre-gl-components": "^0.20.6",
     "maplibre-gl-duckdb": "^0.2.0",
     "maplibre-gl-earth-engine": "^0.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "mapillary-js": "^4.1.2",
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.1",
-        "maplibre-gl-basemap-control": "^0.3.0",
+        "maplibre-gl-basemap-control": "^0.4.0",
         "maplibre-gl-components": "^0.20.6",
         "maplibre-gl-duckdb": "^0.2.0",
         "maplibre-gl-earth-engine": "^0.4.2",
@@ -17354,9 +17354,9 @@
       "license": "MIT"
     },
     "node_modules/maplibre-gl-basemap-control": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-basemap-control/-/maplibre-gl-basemap-control-0.3.0.tgz",
-      "integrity": "sha512-iJfRSYiSy9TRhiXcjSup3BIhETEkWOh0znez5cPZTHvWVjQNDkU+dxeK8/yhNPPaJw0e9zIRlj7vnBHkQ+3r2g==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-basemap-control/-/maplibre-gl-basemap-control-0.4.0.tgz",
+      "integrity": "sha512-r6ZnFaUskO3KWkuLUdPQ6KBsVPIxGvlWznQ92gRswHvqAEhU8SFDGX/Ys6RenocUiqgYdYJ63FNi+p9PrCT6LQ==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -24275,7 +24275,7 @@
         "jspdf": "^4.2.1",
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.1",
-        "maplibre-gl-basemap-control": "^0.3.0",
+        "maplibre-gl-basemap-control": "^0.4.0",
         "maplibre-gl-components": "^0.20.6",
         "maplibre-gl-duckdb": "^0.2.0",
         "maplibre-gl-earth-engine": "^0.4.2",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -30,7 +30,7 @@
     "jspdf": "^4.2.1",
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.1",
-    "maplibre-gl-basemap-control": "^0.3.0",
+    "maplibre-gl-basemap-control": "^0.4.0",
     "maplibre-gl-components": "^0.20.6",
     "maplibre-gl-duckdb": "^0.2.0",
     "maplibre-gl-earth-engine": "^0.4.2",

--- a/packages/plugins/src/plugins/maplibre-basemap-control.ts
+++ b/packages/plugins/src/plugins/maplibre-basemap-control.ts
@@ -16,7 +16,9 @@ import type {
 let basemapControlPosition: GeoLibreMapControlPosition = "top-left";
 
 let basemapControl: BasemapControl | null = null;
-let registeredRasterLayerId: string | null = null;
+// GeoLibre layer ids of registered raster basemaps, keyed by basemap id. In
+// multiple mode several raster basemaps can be registered at once.
+const registeredRasterLayers = new Map<string, string>();
 
 export const maplibreBasemapControlPlugin: GeoLibrePlugin = {
   id: "maplibre-gl-basemap-control",
@@ -27,6 +29,9 @@ export const maplibreBasemapControlPlugin: GeoLibrePlugin = {
       basemapControl = new BasemapControl(getBasemapControlOptions(app));
       basemapControl.on("basemapchange", (event) => {
         handleBasemapChange(app, event);
+      });
+      basemapControl.on("basemapremove", (event) => {
+        handleBasemapRemove(app, event);
       });
     }
 
@@ -41,15 +46,15 @@ export const maplibreBasemapControlPlugin: GeoLibrePlugin = {
     basemapControl.setState({
       activeBasemapId: getBasemapIdForStyleUrl(app.getActiveBasemap()),
     });
-    // Re-link a raster basemap layer restored from a reopened project so that a
-    // later switch to a style basemap can unregister it (the module state does
-    // not survive a new session).
-    relinkRestoredRasterBasemap();
+    // Re-link raster basemap layers restored from a reopened project so that a
+    // later switch to a style basemap or a removal can unregister them (the
+    // module state does not survive a new session).
+    relinkRestoredRasterBasemaps();
     setTimeout(() => basemapControl?.expand(), 0);
   },
   deactivate: (app: GeoLibreAppAPI) => {
     if (!basemapControl) return;
-    unregisterActiveRasterBasemap(app);
+    unregisterAllRasterBasemaps(app);
     app.removeMapControl(basemapControl);
     basemapControl = null;
   },
@@ -91,11 +96,22 @@ function handleBasemapChange(
     return;
   }
   // Any non-raster basemap (including an unrecognized future source type)
-  // clears a previously registered raster layer so it does not linger in the
-  // layer manager.
-  unregisterActiveRasterBasemap(app);
+  // replaces the whole map style, which drops every managed raster overlay, so
+  // clear them all from the layer manager too.
+  unregisterAllRasterBasemaps(app);
   if (source.type !== "style" && source.type !== "vector-style") return;
   app.setBasemap(source.url);
+}
+
+function handleBasemapRemove(
+  app: GeoLibreAppAPI,
+  event: BasemapControlEventPayload,
+): void {
+  if (event.type !== "basemapremove") return;
+  const layerId = registeredRasterLayers.get(event.basemap.id);
+  if (!layerId) return;
+  app.unregisterExternalNativeLayer?.(layerId);
+  registeredRasterLayers.delete(event.basemap.id);
 }
 
 function registerRasterBasemap(
@@ -108,8 +124,10 @@ function registerRasterBasemap(
   if (!managedRaster || !app.registerExternalNativeLayer) return;
 
   const layerId = `basemap-${basemap.id}`;
-  if (registeredRasterLayerId && registeredRasterLayerId !== layerId) {
-    app.unregisterExternalNativeLayer?.(registeredRasterLayerId);
+  // In replace mode the control keeps a single raster basemap, so drop any
+  // other registered raster basemaps. In add mode they stack, so keep them.
+  if (event.mode !== "add") {
+    unregisterRasterBasemapsExcept(app, basemap.id);
   }
 
   app.registerExternalNativeLayer({
@@ -144,23 +162,40 @@ function registerRasterBasemap(
         basemap.source.tiles.length > 0 ? basemap.source.tiles[0] : undefined,
     },
   });
-  registeredRasterLayerId = layerId;
+  registeredRasterLayers.set(basemap.id, layerId);
 }
 
-function unregisterActiveRasterBasemap(app: GeoLibreAppAPI): void {
-  if (!registeredRasterLayerId) return;
-  app.unregisterExternalNativeLayer?.(registeredRasterLayerId);
-  registeredRasterLayerId = null;
+function unregisterAllRasterBasemaps(app: GeoLibreAppAPI): void {
+  for (const layerId of registeredRasterLayers.values()) {
+    app.unregisterExternalNativeLayer?.(layerId);
+  }
+  registeredRasterLayers.clear();
 }
 
-function relinkRestoredRasterBasemap(): void {
-  if (registeredRasterLayerId) return;
+function unregisterRasterBasemapsExcept(
+  app: GeoLibreAppAPI,
+  keepBasemapId: string,
+): void {
+  for (const [basemapId, layerId] of [...registeredRasterLayers.entries()]) {
+    if (basemapId === keepBasemapId) continue;
+    app.unregisterExternalNativeLayer?.(layerId);
+    registeredRasterLayers.delete(basemapId);
+  }
+}
+
+function relinkRestoredRasterBasemaps(): void {
+  if (registeredRasterLayers.size > 0) return;
   const restored = useAppStore
     .getState()
-    .layers.find(
+    .layers.filter(
       (layer) => layer.metadata?.sourceKind === "maplibre-basemap-control",
     );
-  if (restored) registeredRasterLayerId = restored.id;
+  for (const layer of restored) {
+    const basemapId = layer.metadata?.basemapId;
+    if (typeof basemapId === "string") {
+      registeredRasterLayers.set(basemapId, layer.id);
+    }
+  }
 }
 
 function getManagedRaster(

--- a/packages/plugins/src/plugins/maplibre-basemap-control.ts
+++ b/packages/plugins/src/plugins/maplibre-basemap-control.ts
@@ -89,17 +89,19 @@ function handleBasemapChange(
   app: GeoLibreAppAPI,
   event: BasemapControlEventPayload,
 ): void {
+  // Narrows the BasemapControlEventPayload union so event.basemap is accessible.
   if (event.type !== "basemapchange") return;
   const { source } = event.basemap;
   if (source.type === "raster") {
     registerRasterBasemap(app, event.basemap, event);
     return;
   }
-  // Any non-raster basemap (including an unrecognized future source type)
-  // replaces the whole map style, which drops every managed raster overlay, so
-  // clear them all from the layer manager too.
-  unregisterAllRasterBasemaps(app);
+  // Only a style/vector-style basemap actually replaces the whole map style
+  // (and so drops every managed raster overlay). Bail out on any other type
+  // before touching the layer manager, so an unrecognized future source type
+  // does not evict the raster overlays without replacing the style.
   if (source.type !== "style" && source.type !== "vector-style") return;
+  unregisterAllRasterBasemaps(app);
   app.setBasemap(source.url);
 }
 
@@ -107,6 +109,7 @@ function handleBasemapRemove(
   app: GeoLibreAppAPI,
   event: BasemapControlEventPayload,
 ): void {
+  // Narrows the BasemapControlEventPayload union so event.basemap is accessible.
   if (event.type !== "basemapremove") return;
   const layerId = registeredRasterLayers.get(event.basemap.id);
   if (!layerId) return;
@@ -180,6 +183,7 @@ function unregisterRasterBasemapsExcept(
   app: GeoLibreAppAPI,
   keepBasemapId: string,
 ): void {
+  // Snapshot the entries so deleting from the Map mid-loop is safe.
   for (const [basemapId, layerId] of [...registeredRasterLayers.entries()]) {
     if (basemapId === keepBasemapId) continue;
     app.unregisterExternalNativeLayer?.(layerId);

--- a/packages/plugins/src/plugins/maplibre-basemap-control.ts
+++ b/packages/plugins/src/plugins/maplibre-basemap-control.ts
@@ -125,9 +125,13 @@ function registerRasterBasemap(
 
   const layerId = `basemap-${basemap.id}`;
   // In replace mode the control keeps a single raster basemap, so drop any
-  // other registered raster basemaps. In add mode they stack, so keep them.
+  // other registered raster basemaps. In add mode they stack, so keep them; if
+  // this basemap is already registered (a duplicate add event), there is
+  // nothing to do.
   if (event.mode !== "add") {
     unregisterRasterBasemapsExcept(app, basemap.id);
+  } else if (registeredRasterLayers.has(basemap.id)) {
+    return;
   }
 
   app.registerExternalNativeLayer({
@@ -194,6 +198,11 @@ function relinkRestoredRasterBasemaps(): void {
     const basemapId = layer.metadata?.basemapId;
     if (typeof basemapId === "string") {
       registeredRasterLayers.set(basemapId, layer.id);
+    } else if (layer.id.startsWith("basemap-")) {
+      // Fallback for projects saved before basemapId was stored in metadata.
+      // The layer id is deterministic (`basemap-${basemap.id}`), so the
+      // original basemap id can be recovered by stripping the prefix.
+      registeredRasterLayers.set(layer.id.slice("basemap-".length), layer.id);
     }
   }
 }


### PR DESCRIPTION
Closes #420.

## Summary
Lets users keep several raster basemaps on the map at once and switch between them by toggling entries in the Basemaps panel, instead of each selection replacing the previous one.

This consumes the new `maplibre-gl-basemap-control@0.4.0` (opengeos/maplibre-gl-basemap-control#10), which adds:
- an `allowMultiple` mode (add vs. replace),
- a visible in-panel **Add basemaps (stack instead of replace)** toggle,
- a resizable panel (drag either bottom corner),
- a fix so rapid basemap switching no longer sticks on a wait cursor.

## Changes here
- Bump `maplibre-gl-basemap-control` to `^0.4.0` in `apps/geolibre-desktop` and `packages/plugins`.
- Basemaps plugin now tracks **multiple** registered raster basemaps (keyed by basemap id) rather than a single one:
  - on an `add`, keep the existing raster basemaps; on a `replace`, drop the others;
  - handle the new `basemapremove` event so toggling a raster off removes its layer from the layer manager;
  - relink all restored raster basemaps when reopening a project.

## Verification
Driven in the running web app with real OpenStreetMap/Esri raster tiles via Playwright:
- enabling the toggle and selecting two rasters registered **both** as separate layers in the Layers panel;
- toggling one off removed it (active set 3 to 2, layer gone);
- both resize handles resize the panel;
- rapid-clicking several basemaps left no stuck wait cursor.

## Note
Requires `maplibre-gl-basemap-control@0.4.0` to be published to npm before a clean install resolves the bumped dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the basemap control library dependency to version 0.4.0 in desktop and plugin packages.
* **Bug Fixes**
  * Improved basemap handling for raster overlays, including correct management when basemaps are changed, removed, or added.
  * Enhanced session restore so previously used raster basemaps are properly re-linked and maintained across runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->