### PR TITLE
feat(add-data): internationalize the Add Data dialog (#427)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -9,8 +9,9 @@ import {
 } from "@geolibre/ui";
 import { Database } from "lucide-react";
 import { useCallback, useMemo, useState, type RefObject } from "react";
+import { useTranslation } from "react-i18next";
 import { AddDataShellProvider } from "./add-data/context";
-import { KIND_DESCRIPTIONS, KIND_LABELS } from "./add-data/constants";
+import { KIND_I18N_KEY } from "./add-data/constants";
 import { ArcGISSource } from "./add-data/sources/ArcGISSource";
 import { DeckVizSource } from "./add-data/sources/DeckVizSource";
 import { DelimitedTextSource } from "./add-data/sources/DelimitedTextSource";
@@ -86,14 +87,19 @@ export function AddDataDialog({
   onOpenChange,
   initialDeckVizKind,
 }: AddDataDialogProps) {
+  const { t } = useTranslation();
   const open = kind !== null;
   const addLayer = useAppStore((s) => s.addLayer);
   const existingLayers = useAppStore((s) => s.layers);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const martin = useMartinConnection();
 
-  const title = kind ? KIND_LABELS[kind] : "Add Data";
-  const description = kind ? KIND_DESCRIPTIONS[kind] : "";
+  const title = kind
+    ? t(`addData.kind.${KIND_I18N_KEY[kind]}.label`)
+    : t("addData.title");
+  const description = kind
+    ? t(`addData.kind.${KIND_I18N_KEY[kind]}.description`)
+    : "";
 
   const closeDialog = useCallback(() => {
     martin.stopTransient();

--- a/apps/geolibre-desktop/src/components/layout/add-data/ServiceLibrarySection.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/ServiceLibrarySection.tsx
@@ -212,12 +212,16 @@ export function ServiceLibrarySection({
       const before = current.length;
       const added = next.length - before;
       const dropped = imported.length - added;
-      const suffix =
-        dropped > 0
-          ? t("addData.serviceLibrary.importedDropped", { dropped })
-          : "";
+      // Two self-contained plural keys (rather than a concatenated suffix) so
+      // translators get a complete sentence and can place the "(N skipped)"
+      // clause wherever their language needs it.
       setNotice(
-        t("addData.serviceLibrary.imported", { count: added, suffix }),
+        dropped > 0
+          ? t("addData.serviceLibrary.importedWithDropped", {
+              count: added,
+              dropped,
+            })
+          : t("addData.serviceLibrary.imported", { count: added }),
       );
     } catch {
       setError(t("addData.serviceLibrary.errorRead"));

--- a/apps/geolibre-desktop/src/components/layout/add-data/ServiceLibrarySection.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/ServiceLibrarySection.tsx
@@ -214,7 +214,7 @@ export function ServiceLibrarySection({
       const dropped = imported.length - added;
       const suffix =
         dropped > 0
-          ? t("addData.serviceLibrary.importedDropped", { count: dropped })
+          ? t("addData.serviceLibrary.importedDropped", { dropped })
           : "";
       setNotice(
         t("addData.serviceLibrary.imported", { count: added, suffix }),

--- a/apps/geolibre-desktop/src/components/layout/add-data/ServiceLibrarySection.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/ServiceLibrarySection.tsx
@@ -11,6 +11,7 @@
 import { Button, Input, Label, Select } from "@geolibre/ui";
 import { Bookmark, Download, Save, Trash2, Upload, X } from "lucide-react";
 import { type KeyboardEvent, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { saveTextFileWithFallback } from "../../../lib/tauri-io";
 import {
   createServiceEntry,
@@ -72,6 +73,7 @@ export function ServiceLibrarySection({
   getFields,
   onApply,
 }: ServiceLibrarySectionProps) {
+  const { t } = useTranslation();
   const [userEntries, setUserEntries] = useState<ServiceLibraryEntry[]>(() =>
     readUserServices(),
   );
@@ -120,7 +122,7 @@ export function ServiceLibrarySection({
   const handleSave = () => {
     const name = saveName.trim();
     if (!name) {
-      setError("Enter a name for the saved service.");
+      setError(t("addData.serviceLibrary.errorName"));
       return;
     }
     // Update the selected entry in place when it's a user-owned service;
@@ -137,7 +139,7 @@ export function ServiceLibrarySection({
     setSelectedId(entry.id);
     setIsSaving(false);
     setError(null);
-    setNotice(`Saved "${name}" to the service library.`);
+    setNotice(t("addData.serviceLibrary.saved", { name }));
   };
 
   // The save-form inputs live inside AddDataSourceForm's <form>, so a bare
@@ -157,7 +159,9 @@ export function ServiceLibrarySection({
     persist(removeServiceEntry(userEntries, selectedEntry.id));
     setSelectedId("");
     setError(null);
-    setNotice(`Removed "${selectedEntry.name}".`);
+    setNotice(
+      t("addData.serviceLibrary.removed", { name: selectedEntry.name }),
+    );
   };
 
   const handleExport = async () => {
@@ -173,7 +177,11 @@ export function ServiceLibrarySection({
         mimeType: "application/json",
       });
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Could not export library.");
+      setError(
+        err instanceof Error
+          ? err.message
+          : t("addData.serviceLibrary.errorExport"),
+      );
     }
   };
 
@@ -184,13 +192,13 @@ export function ServiceLibrarySection({
     // A library JSON is tiny; guard against accidentally reading a huge file
     // fully into memory (the entry cap only applies after parsing).
     if (file.size > MAX_IMPORT_BYTES) {
-      setError("File is too large to import (max 5 MB).");
+      setError(t("addData.serviceLibrary.errorTooLarge"));
       return;
     }
     try {
       const imported = parseImportedServices(await file.text());
       if (imported.length === 0) {
-        setError("No valid services found in that file.");
+        setError(t("addData.serviceLibrary.errorNoServices"));
         return;
       }
       // Merge against the freshly-persisted list rather than the closed-over
@@ -204,13 +212,15 @@ export function ServiceLibrarySection({
       const before = current.length;
       const added = next.length - before;
       const dropped = imported.length - added;
+      const suffix =
+        dropped > 0
+          ? t("addData.serviceLibrary.importedDropped", { count: dropped })
+          : "";
       setNotice(
-        `Imported ${added} service${added === 1 ? "" : "s"}${
-          dropped > 0 ? ` (${dropped} skipped — library full)` : ""
-        }.`,
+        t("addData.serviceLibrary.imported", { count: added, suffix }),
       );
     } catch {
-      setError("Could not read that file as a service library.");
+      setError(t("addData.serviceLibrary.errorRead"));
     }
   };
 
@@ -219,7 +229,7 @@ export function ServiceLibrarySection({
       <div className="flex items-center justify-between gap-2">
         <span className="flex items-center gap-1.5 text-sm font-medium">
           <Bookmark className="h-3.5 w-3.5" />
-          Saved services
+          {t("addData.serviceLibrary.title")}
         </span>
         <div className="flex items-center gap-1">
           <Button
@@ -229,14 +239,14 @@ export function ServiceLibrarySection({
             onClick={openSaveForm}
           >
             <Save className="mr-1.5 h-3.5 w-3.5" />
-            Save current
+            {t("addData.serviceLibrary.saveCurrent")}
           </Button>
           <Button
             type="button"
             size="icon"
             variant="ghost"
-            aria-label="Import library from JSON"
-            title="Import library from JSON"
+            aria-label={t("addData.serviceLibrary.importLibrary")}
+            title={t("addData.serviceLibrary.importLibrary")}
             onClick={() => importInputRef.current?.click()}
           >
             <Upload className="h-3.5 w-3.5" />
@@ -245,8 +255,8 @@ export function ServiceLibrarySection({
             type="button"
             size="icon"
             variant="ghost"
-            aria-label="Export library to JSON"
-            title="Export library to JSON"
+            aria-label={t("addData.serviceLibrary.exportLibrary")}
+            title={t("addData.serviceLibrary.exportLibrary")}
             disabled={userEntries.length === 0}
             onClick={handleExport}
           >
@@ -258,18 +268,28 @@ export function ServiceLibrarySection({
       {entries.length > 0 ? (
         <div className="flex items-center gap-2">
           <Select
-            aria-label="Load a saved service"
+            aria-label={t("addData.serviceLibrary.loadAria")}
             className="flex-1"
             value={selectedId}
             onChange={(event) => handleSelect(event.target.value)}
           >
-            <option value="">Load a saved service…</option>
+            <option value="">
+              {t("addData.serviceLibrary.loadPlaceholder")}
+            </option>
             {groups.map((group) => (
-              <optgroup key={group.label} label={group.label}>
+              <optgroup
+                key={group.label}
+                label={
+                  group.label === UNCATEGORIZED_LABEL
+                    ? t("addData.serviceLibrary.uncategorized")
+                    : group.label
+                }
+              >
                 {group.entries.map((entry) => (
                   <option key={entry.id} value={entry.id}>
-                    {entry.name}
-                    {entry.builtin ? " (built-in)" : ""}
+                    {entry.builtin
+                      ? t("addData.serviceLibrary.builtin", { name: entry.name })
+                      : entry.name}
                   </option>
                 ))}
               </optgroup>
@@ -279,8 +299,8 @@ export function ServiceLibrarySection({
             type="button"
             size="icon"
             variant="ghost"
-            aria-label="Delete saved service"
-            title="Delete saved service"
+            aria-label={t("addData.serviceLibrary.deleteAria")}
+            title={t("addData.serviceLibrary.deleteAria")}
             disabled={!canDeleteSelected}
             onClick={handleDelete}
           >
@@ -289,7 +309,7 @@ export function ServiceLibrarySection({
         </div>
       ) : (
         <p className="text-xs text-muted-foreground">
-          No saved services yet — fill in the form and choose “Save current”.
+          {t("addData.serviceLibrary.empty")}
         </p>
       )}
 
@@ -297,7 +317,9 @@ export function ServiceLibrarySection({
         <div className="space-y-2 rounded-md border border-border/60 bg-background p-2">
           <div className="grid gap-2 sm:grid-cols-2">
             <div className="space-y-1">
-              <Label htmlFor={`service-save-name-${kind}`}>Name</Label>
+              <Label htmlFor={`service-save-name-${kind}`}>
+                {t("addData.serviceLibrary.name")}
+              </Label>
               <Input
                 id={`service-save-name-${kind}`}
                 value={saveName}
@@ -306,11 +328,13 @@ export function ServiceLibrarySection({
               />
             </div>
             <div className="space-y-1">
-              <Label htmlFor={`service-save-category-${kind}`}>Category</Label>
+              <Label htmlFor={`service-save-category-${kind}`}>
+                {t("addData.serviceLibrary.category")}
+              </Label>
               <Input
                 id={`service-save-category-${kind}`}
                 list={categoryListId}
-                placeholder="Optional (e.g. country, theme)"
+                placeholder={t("addData.serviceLibrary.categoryPlaceholder")}
                 value={saveCategory}
                 onChange={(event) => setSaveCategory(event.target.value)}
                 onKeyDown={handleSaveFieldKeyDown}
@@ -330,11 +354,11 @@ export function ServiceLibrarySection({
               onClick={() => setIsSaving(false)}
             >
               <X className="mr-1.5 h-3.5 w-3.5" />
-              Cancel
+              {t("common.cancel")}
             </Button>
             <Button type="button" size="sm" onClick={handleSave}>
               <Save className="mr-1.5 h-3.5 w-3.5" />
-              Save
+              {t("common.save")}
             </Button>
           </div>
         </div>

--- a/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
@@ -12,37 +12,38 @@ import type {
 // not block) when a very large payload would bloat saved projects.
 export const DECK_VIZ_SIZE_WARN_BYTES = 10 * 1024 * 1024;
 
-export const KIND_LABELS: Record<AddDataKind, string> = {
-  xyz: "Add XYZ Layer",
-  wms: "Add WMS Layer",
-  wfs: "Add WFS Layer",
-  wmts: "Add WMTS Layer",
-  gpx: "Add GPX Layer",
-  "delimited-text": "Add Delimited Text Layer",
-  mbtiles: "Add MBTiles Layer",
-  arcgis: "Add ArcGIS Layer",
-  postgres: "Add PostgreSQL Layer",
-  "deckgl-viz": "Add Deck.gl Layer",
-  video: "Add Video Layer",
-};
+/** The `addData.kind.<key>` segments, kept as a literal union so the dialog's
+ * `t(\`addData.kind.${key}.label\`)` lookups stay type-checked against en.json. */
+export type KindI18nKey =
+  | "xyz"
+  | "wms"
+  | "wfs"
+  | "wmts"
+  | "gpx"
+  | "delimitedText"
+  | "mbtiles"
+  | "arcgis"
+  | "postgres"
+  | "deckglViz"
+  | "video";
 
-export const KIND_DESCRIPTIONS: Record<AddDataKind, string> = {
-  xyz: "Add a raster tile template using x, y, and z placeholders.",
-  wms: "Add a WMS GetMap service as a tiled raster layer.",
-  wfs: "Add WFS features by requesting GeoJSON from a GetFeature service.",
-  wmts: "Add a WMTS tile URL template as a raster layer.",
-  gpx: "Add GPX waypoints, routes, and tracks as one or more vector layers.",
-  "delimited-text":
-    "Add a delimited text file or URL as a point layer using longitude and latitude fields.",
-  mbtiles: "Add a local MBTiles file as a raster or vector tile layer.",
-  arcgis:
-    "Add an ArcGIS FeatureServer layer, VectorTileServer layer, or portal item.",
-  postgres:
-    "Start Martin locally, discover PostGIS sources, and add a source as vector tiles.",
-  video:
-    "Add a georeferenced video overlay by supplying an MP4 URL and four corner coordinates.",
-  "deckgl-viz":
-    "Pick a deck.gl layer type, then load the example data or upload a CSV/JSON/GeoJSON file or URL.",
+/**
+ * Maps each Add Data kind to its `addData.kind.<key>` i18n segment. The dialog
+ * title and description are resolved via `t()` from these keys; `en.json` is the
+ * source of truth (see `i18n/locales/en.json`).
+ */
+export const KIND_I18N_KEY: Record<AddDataKind, KindI18nKey> = {
+  xyz: "xyz",
+  wms: "wms",
+  wfs: "wfs",
+  wmts: "wmts",
+  gpx: "gpx",
+  "delimited-text": "delimitedText",
+  mbtiles: "mbtiles",
+  arcgis: "arcgis",
+  postgres: "postgres",
+  "deckgl-viz": "deckglViz",
+  video: "video",
 };
 
 export const DEFAULT_XYZ_URL =

--- a/apps/geolibre-desktop/src/components/layout/add-data/shared.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/shared.tsx
@@ -12,6 +12,7 @@ import {
   type ReactNode,
   useState,
 } from "react";
+import { useTranslation } from "react-i18next";
 import { useAddDataShell } from "./context";
 import { errorMessage } from "./helpers";
 
@@ -23,6 +24,7 @@ import { errorMessage } from "./helpers";
  * @param defaultLayerName - The initial layer name for this source.
  */
 export function useAddDataSource(defaultLayerName: string) {
+  const { t } = useTranslation();
   const shell = useAddDataShell();
   const [layerName, setLayerName] = useState(defaultLayerName);
   const [beforeLayerId, setBeforeLayerId] = useState("");
@@ -52,7 +54,7 @@ export function useAddDataSource(defaultLayerName: string) {
       try {
         await action();
       } catch (err) {
-        setError(errorMessage(err, "Could not add layer."));
+        setError(errorMessage(err, t("addData.shared.addError")));
       } finally {
         shell.setIsSubmitting(false);
       }
@@ -80,9 +82,10 @@ export function LayerNameField({
   value: string;
   onChange: (value: string) => void;
 }) {
+  const { t } = useTranslation();
   return (
     <div className="space-y-1.5">
-      <Label htmlFor="add-data-layer-name">Layer name</Label>
+      <Label htmlFor="add-data-layer-name">{t("addData.shared.layerName")}</Label>
       <Input
         id="add-data-layer-name"
         value={value}
@@ -99,6 +102,7 @@ export function InsertBeforeField({
   value: string;
   onChange: (value: string) => void;
 }) {
+  const { t } = useTranslation();
   const { existingLayers, mapControllerRef } = useAddDataShell();
   // Computed during render (not memoized) so the list picks up the map
   // controller once it finishes initialising; the call is a cheap filter.
@@ -106,15 +110,17 @@ export function InsertBeforeField({
     mapControllerRef.current?.getBasemapStyleLayerIds() ?? [];
   return (
     <div className="space-y-1.5">
-      <Label htmlFor="add-data-before-id">Insert before</Label>
+      <Label htmlFor="add-data-before-id">
+        {t("addData.shared.insertBefore")}
+      </Label>
       <Select
         id="add-data-before-id"
         value={value}
         onChange={(event) => onChange(event.target.value)}
       >
-        <option value="">Top of layer list (default)</option>
+        <option value="">{t("addData.shared.insertTop")}</option>
         {existingLayers.length > 0 && (
-          <optgroup label="Layers">
+          <optgroup label={t("addData.shared.layersGroup")}>
             {[...existingLayers].reverse().map((existingLayer) => (
               <option key={existingLayer.id} value={existingLayer.id}>
                 {existingLayer.name}
@@ -123,7 +129,7 @@ export function InsertBeforeField({
           </optgroup>
         )}
         {basemapStyleLayerIds.length > 0 && (
-          <optgroup label="Basemap layers">
+          <optgroup label={t("addData.shared.basemapLayersGroup")}>
             {basemapStyleLayerIds.map((styleLayerId) => (
               <option key={styleLayerId} value={styleLayerId}>
                 {styleLayerId}
@@ -146,6 +152,7 @@ export function AddDataFooter({
   submitDisabled: boolean;
   useServiceIcon?: boolean;
 }) {
+  const { t } = useTranslation();
   const { isSubmitting, closeDialog } = useAddDataShell();
   return (
     <>
@@ -158,7 +165,7 @@ export function AddDataFooter({
           onClick={closeDialog}
           disabled={isSubmitting}
         >
-          Cancel
+          {t("common.cancel")}
         </Button>
         <Button type="submit" disabled={submitDisabled}>
           {!isSubmitting ? (
@@ -168,7 +175,7 @@ export function AddDataFooter({
               <MapIcon className="mr-2 h-3.5 w-3.5" />
             )
           ) : null}
-          {isSubmitting ? "Adding…" : "Add layer"}
+          {isSubmitting ? t("addData.shared.adding") : t("addData.shared.addLayer")}
         </Button>
       </div>
     </>

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/ArcGISSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/ArcGISSource.tsx
@@ -5,6 +5,7 @@ import {
 } from "@geolibre/plugins";
 import { Input, Label, Select } from "@geolibre/ui";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { createAppAPI } from "../../../../hooks/usePlugins";
 import {
   DEFAULT_ARCGIS_FEATURE_URL,
@@ -18,7 +19,8 @@ import {
 import { AddDataSourceForm, useAddDataSource } from "../shared";
 
 export function ArcGISSource() {
-  const source = useAddDataSource("ArcGIS Layer");
+  const { t } = useTranslation();
+  const source = useAddDataSource(t("addData.arcgis.defaultName"));
   const [arcgisLayerType, setArcgisLayerType] =
     useState<ArcGISLayerType>("feature");
   const [arcgisSourceType, setArcgisSourceType] =
@@ -66,7 +68,7 @@ export function ArcGISSource() {
   };
 
   const handleSubmit = source.runSubmit(async () => {
-    const name = source.layerName.trim() || "ArcGIS Layer";
+    const name = source.layerName.trim() || t("addData.arcgis.defaultName");
     await addArcGISLayer(createAppAPI(source.shell.mapControllerRef), {
       beforeLayerId: source.beforeLayer,
       itemId: arcgisItemId.trim() || undefined,
@@ -102,7 +104,7 @@ export function ArcGISSource() {
         />
         <div className="grid gap-3 sm:grid-cols-2">
           <div className="space-y-1.5">
-            <Label htmlFor="arcgis-layer-type">Layer type</Label>
+            <Label htmlFor="arcgis-layer-type">{t("addData.common.layerType")}</Label>
             <Select
               id="arcgis-layer-type"
               value={arcgisLayerType}
@@ -112,12 +114,12 @@ export function ArcGISSource() {
                 )
               }
             >
-              <option value="feature">Feature layer</option>
-              <option value="vector-tile">Vector tile layer</option>
+              <option value="feature">{t("addData.arcgis.featureLayer")}</option>
+              <option value="vector-tile">{t("addData.arcgis.vectorTileLayer")}</option>
             </Select>
           </div>
           <div className="space-y-1.5">
-            <Label htmlFor="arcgis-source-type">Source type</Label>
+            <Label htmlFor="arcgis-source-type">{t("addData.common.sourceType")}</Label>
             <Select
               id="arcgis-source-type"
               value={arcgisSourceType}
@@ -125,20 +127,20 @@ export function ArcGISSource() {
                 setArcgisSourceType(event.target.value as ArcGISSourceType)
               }
             >
-              <option value="url">Service URL</option>
-              <option value="portal-item">Portal item ID</option>
+              <option value="url">{t("addData.common.serviceUrl")}</option>
+              <option value="portal-item">{t("addData.arcgis.portalItemId")}</option>
             </Select>
           </div>
         </div>
         {arcgisSourceType === "url" ? (
           <div className="space-y-1.5">
-            <Label htmlFor="arcgis-url">Service URL</Label>
+            <Label htmlFor="arcgis-url">{t("addData.common.serviceUrl")}</Label>
             <Input
               id="arcgis-url"
               placeholder={
                 arcgisLayerType === "feature"
-                  ? "https://services.arcgis.com/.../FeatureServer/0"
-                  : "https://.../arcgis/rest/services/.../VectorTileServer"
+                  ? t("addData.arcgis.featureUrlPlaceholder")
+                  : t("addData.arcgis.vectorTileUrlPlaceholder")
               }
               value={arcgisUrl}
               onChange={(event) => setArcgisUrl(event.target.value)}
@@ -146,7 +148,7 @@ export function ArcGISSource() {
           </div>
         ) : (
           <div className="space-y-1.5">
-            <Label htmlFor="arcgis-item-id">Portal item ID</Label>
+            <Label htmlFor="arcgis-item-id">{t("addData.arcgis.portalItemId")}</Label>
             <Input
               id="arcgis-item-id"
               value={arcgisItemId}
@@ -155,21 +157,21 @@ export function ArcGISSource() {
           </div>
         )}
         <div className="space-y-1.5">
-          <Label htmlFor="arcgis-portal-url">Portal URL</Label>
+          <Label htmlFor="arcgis-portal-url">{t("addData.arcgis.portalUrl")}</Label>
           <Input
             id="arcgis-portal-url"
-            placeholder="https://www.arcgis.com/sharing/rest"
+            placeholder={t("addData.arcgis.portalUrlPlaceholder")}
             value={arcgisPortalUrl}
             onChange={(event) => setArcgisPortalUrl(event.target.value)}
           />
         </div>
         <div className="space-y-1.5">
-          <Label htmlFor="arcgis-access-token">Access token</Label>
+          <Label htmlFor="arcgis-access-token">{t("addData.arcgis.accessToken")}</Label>
           <Input
             id="arcgis-access-token"
             type="password"
             autoComplete="off"
-            placeholder="Optional"
+            placeholder={t("addData.common.optional")}
             value={arcgisAccessToken}
             onChange={(event) => setArcgisAccessToken(event.target.value)}
           />

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/DeckVizSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/DeckVizSource.tsx
@@ -307,11 +307,12 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
       setDeckVizStatus(
         parsed.format === "geojson"
           ? t("addData.deckViz.loadedFeatures", { count: parsed.rowCount })
-          : `${t("addData.deckViz.loadedRows", {
-              count: parsed.rowCount,
-            })} · ${t("addData.deckViz.loadedColumns", {
-              count: parsed.columns.length,
-            })}.`,
+          : t("addData.deckViz.loadedTabular", {
+              rows: t("addData.deckViz.loadedRows", { count: parsed.rowCount }),
+              columns: t("addData.deckViz.loadedColumns", {
+                count: parsed.columns.length,
+              }),
+            }),
       );
     } catch (err) {
       source.setError(errorMessage(err, t("addData.deckViz.errorLoad")));

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/DeckVizSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/DeckVizSource.tsx
@@ -42,7 +42,7 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
   const [startLng, startLat] = startExample?.scenegraphLocation ?? ["", ""];
 
   const source = useAddDataSource(
-    getDeckVizLayerDef(startKind)?.label ?? "Deck.gl Layer",
+    getDeckVizLayerDef(startKind)?.label ?? t("addData.deckViz.defaultName"),
   );
 
   const [deckVizKind, setDeckVizKind] = useState(startKind);
@@ -100,7 +100,7 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
     source.setError(null);
     setDeckVizStyle({ ...DEFAULT_DECK_VIZ_STYLE });
     const nextDef = getDeckVizLayerDef(nextKind);
-    source.setLayerName(nextDef?.label ?? "Deck.gl Layer");
+    source.setLayerName(nextDef?.label ?? t("addData.deckViz.defaultName"));
     // Pre-fill the scenegraph model URL and transform from the bundled example
     // so the user can place a model immediately (and tweak from there).
     const exampleSg = nextDef?.example.scenegraph;
@@ -154,15 +154,15 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
         readText: true,
       });
       if (!selected?.text) {
-        throw new Error("Choose a CSV, JSON, or GeoJSON file.");
+        throw new Error(t("addData.deckViz.errorChooseFile"));
       }
       result = { sourcePath: selected.path, text: selected.text };
     } else {
       const sourcePath = deckVizUrl.trim();
-      if (!sourcePath) throw new Error("Enter a data URL.");
+      if (!sourcePath) throw new Error(t("addData.deckViz.errorUrl"));
       const response = await fetch(sourcePath);
       if (!response.ok) {
-        throw new Error(`Request failed with status ${response.status}`);
+        throw new Error(t("addData.common.requestFailed", { status: response.status }));
       }
       result = { sourcePath, text: await response.text() };
     }
@@ -186,7 +186,7 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
     scenegraph?: DeckVizScenegraphConfig;
   }) => {
     const def = getDeckVizLayerDef(deckVizKind);
-    if (!def) throw new Error("Unknown layer type.");
+    if (!def) throw new Error(t("addData.deckViz.errorUnknownType"));
     // The model URL is already enforced by the submit handler and the disabled
     // state of the Add button, and the example path always supplies one, so no
     // redundant guard is needed here.
@@ -212,10 +212,10 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
     }
 
     if (def.format === "geojson" && parsed.format !== "geojson") {
-      throw new Error(`${def.label} needs a GeoJSON file.`);
+      throw new Error(t("addData.deckViz.needsGeojson", { label: def.label }));
     }
     if (def.format !== "geojson" && parsed.format === "geojson") {
-      throw new Error(`${def.label} needs tabular CSV/JSON data, not GeoJSON.`);
+      throw new Error(t("addData.deckViz.needsTabular", { label: def.label }));
     }
     const missing = def.roles.filter(
       (role) =>
@@ -224,9 +224,10 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
     );
     if (missing.length > 0) {
       throw new Error(
-        `Map the required field${missing.length > 1 ? "s" : ""}: ${missing
-          .map((role) => role.label)
-          .join(", ")}.`,
+        t("addData.deckViz.mapRequiredFields", {
+          count: missing.length,
+          fields: missing.map((role) => role.label).join(", "),
+        }),
       );
     }
 
@@ -268,7 +269,7 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
     try {
       const response = await fetch(def.example.url);
       if (!response.ok) {
-        throw new Error(`Request failed with status ${response.status}`);
+        throw new Error(t("addData.common.requestFailed", { status: response.status }));
       }
       const parsed = detectAndParseDeckVizInput(await response.text());
       finalizeDeckVizLayer({
@@ -279,7 +280,7 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
         scenegraph: def.example.scenegraph,
       });
     } catch (err) {
-      source.setError(errorMessage(err, "Could not load the example data."));
+      source.setError(errorMessage(err, t("addData.deckViz.errorExample")));
     } finally {
       setIsLoadingDeckViz(false);
     }
@@ -295,27 +296,25 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
       const { sourcePath, text } = await readDeckVizSource();
       const parsed = detectAndParseDeckVizInput(text);
       if (def.format === "geojson" && parsed.format !== "geojson") {
-        throw new Error(`${def.label} needs a GeoJSON file.`);
+        throw new Error(t("addData.deckViz.needsGeojson", { label: def.label }));
       }
       if (def.format !== "geojson" && parsed.format === "geojson") {
-        throw new Error(
-          `${def.label} needs tabular CSV/JSON data, not GeoJSON.`,
-        );
+        throw new Error(t("addData.deckViz.needsTabular", { label: def.label }));
       }
       setDeckVizParsed(parsed);
       setDeckVizSourcePath(sourcePath);
       setDeckVizMapping(autoDetectFieldMapping(def.roles, parsed.columns));
       setDeckVizStatus(
         parsed.format === "geojson"
-          ? `Loaded ${parsed.rowCount} feature${parsed.rowCount === 1 ? "" : "s"}.`
-          : `Loaded ${parsed.rowCount} row${
-              parsed.rowCount === 1 ? "" : "s"
-            } · ${parsed.columns.length} column${
-              parsed.columns.length === 1 ? "" : "s"
-            }.`,
+          ? t("addData.deckViz.loadedFeatures", { count: parsed.rowCount })
+          : `${t("addData.deckViz.loadedRows", {
+              count: parsed.rowCount,
+            })} · ${t("addData.deckViz.loadedColumns", {
+              count: parsed.columns.length,
+            })}.`,
       );
     } catch (err) {
-      source.setError(errorMessage(err, "Could not load the data."));
+      source.setError(errorMessage(err, t("addData.deckViz.errorLoad")));
       setDeckVizParsed(null);
     } finally {
       setIsLoadingDeckViz(false);
@@ -378,7 +377,7 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
       return;
     }
     if (!deckVizParsed) {
-      throw new Error("Load the example data, or a file/URL, first.");
+      throw new Error(t("addData.deckViz.errorLoadFirst"));
     }
     finalizeDeckVizLayer({
       parsed: deckVizParsed,
@@ -408,7 +407,7 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
     >
       <div className="space-y-3">
         <div className="space-y-1.5">
-          <Label htmlFor="deckviz-kind">Layer type</Label>
+          <Label htmlFor="deckviz-kind">{t("addData.common.layerType")}</Label>
           <Select
             id="deckviz-kind"
             value={deckVizKind}
@@ -447,7 +446,7 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
               </Label>
               <Input
                 id="deckviz-model-url"
-                placeholder="https://example.com/model.glb"
+                placeholder={t("addData.deckViz.modelUrlPlaceholder")}
                 value={deckVizModelUrl}
                 onChange={(event) => setDeckVizModelUrl(event.target.value)}
               />
@@ -555,11 +554,11 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
               disabled={isLoadingDeckViz}
             >
               <Globe2 className="mr-2 h-3.5 w-3.5" />
-              {isLoadingDeckViz ? "Loading..." : "Use example data"}
+              {isLoadingDeckViz ? t("addData.common.loading") : t("addData.deckViz.useExample")}
             </Button>
 
             <div className="space-y-1.5">
-              <Label htmlFor="deckviz-mode">Or load your own</Label>
+              <Label htmlFor="deckviz-mode">{t("addData.deckViz.loadYourOwn")}</Label>
               <Select
                 id="deckviz-mode"
                 value={deckVizMode}
@@ -571,17 +570,17 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
                   setIsLoadingDeckViz(false);
                 }}
               >
-                <option value="url">Data URL</option>
-                <option value="file">Local file</option>
+                <option value="url">{t("addData.deckViz.dataUrl")}</option>
+                <option value="file">{t("addData.deckViz.localFile")}</option>
               </Select>
             </div>
 
             {deckVizMode === "url" ? (
               <div className="space-y-1.5">
-                <Label htmlFor="deckviz-url">Data URL</Label>
+                <Label htmlFor="deckviz-url">{t("addData.deckViz.dataUrl")}</Label>
                 <Input
                   id="deckviz-url"
-                  placeholder="https://example.com/data.csv"
+                  placeholder={t("addData.deckViz.urlPlaceholder")}
                   value={deckVizUrl}
                   onChange={(event) => {
                     setDeckVizUrl(event.target.value);
@@ -605,10 +604,10 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
                 <Columns3 className="mr-2 h-3.5 w-3.5" />
               )}
               {isLoadingDeckViz
-                ? "Loading..."
+                ? t("addData.common.loading")
                 : deckVizMode === "file"
-                  ? "Choose file & load"
-                  : "Load data"}
+                  ? t("addData.deckViz.chooseFileLoad")
+                  : t("addData.deckViz.loadData")}
             </Button>
             {deckVizStatus ? (
               <p className="text-xs text-muted-foreground">{deckVizStatus}</p>
@@ -629,7 +628,7 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
                       }
                     >
                       <option value="">
-                        {role.required ? "— select —" : "(none)"}
+                        {role.required ? t("addData.deckViz.selectRole") : t("addData.deckViz.roleNone")}
                       </option>
                       {deckVizParsed.columns.map((column) => (
                         <option
@@ -651,7 +650,7 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
           <div className="grid gap-3 sm:grid-cols-2">
             {deckVizDef.styleControls.includes("color") ? (
               <div className="space-y-1.5">
-                <Label htmlFor="deckviz-color">Color</Label>
+                <Label htmlFor="deckviz-color">{t("addData.deckViz.color")}</Label>
                 <input
                   id="deckviz-color"
                   type="color"
@@ -668,7 +667,7 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
             ) : null}
             {deckVizDef.styleControls.includes("radius") ? (
               <div className="space-y-1.5">
-                <Label htmlFor="deckviz-radius">Point size</Label>
+                <Label htmlFor="deckviz-radius">{t("addData.deckViz.pointSize")}</Label>
                 <Input
                   id="deckviz-radius"
                   inputMode="numeric"
@@ -686,7 +685,7 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
             ) : null}
             {deckVizDef.styleControls.includes("cellSize") ? (
               <div className="space-y-1.5">
-                <Label htmlFor="deckviz-cellsize">Cell size</Label>
+                <Label htmlFor="deckviz-cellsize">{t("addData.deckViz.cellSize")}</Label>
                 <Input
                   id="deckviz-cellsize"
                   inputMode="numeric"
@@ -704,7 +703,7 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
             ) : null}
             {deckVizDef.styleControls.includes("lineWidth") ? (
               <div className="space-y-1.5">
-                <Label htmlFor="deckviz-linewidth">Line width</Label>
+                <Label htmlFor="deckviz-linewidth">{t("addData.deckViz.lineWidth")}</Label>
                 <Input
                   id="deckviz-linewidth"
                   inputMode="numeric"
@@ -732,7 +731,7 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
                     }))
                   }
                 />
-                3D extrusion
+                {t("addData.deckViz.extrusion")}
               </label>
             ) : null}
           </div>

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/DeckVizSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/DeckVizSource.tsx
@@ -307,7 +307,13 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
       setDeckVizStatus(
         parsed.format === "geojson"
           ? t("addData.deckViz.loadedFeatures", { count: parsed.rowCount })
-          : t("addData.deckViz.loadedTabular", {
+          : // `loadedTabular` interpolates {{rows}} and {{columns}} as already-
+            // pluralized fragments ("3 rows", "2 columns") from loadedRows/
+            // loadedColumns. Composing this way keeps each count on its own
+            // i18next plural rules (correct for languages with >2 plural forms),
+            // while loadedTabular still owns the "Loaded …", the separator, and
+            // the trailing period so translators control order and punctuation.
+            t("addData.deckViz.loadedTabular", {
               rows: t("addData.deckViz.loadedRows", { count: parsed.rowCount }),
               columns: t("addData.deckViz.loadedColumns", {
                 count: parsed.columns.length,

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/DelimitedTextSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/DelimitedTextSource.tsx
@@ -25,7 +25,10 @@ import type { DelimitedTextDelimiter, DelimitedTextMode } from "../types";
 
 export function DelimitedTextSource() {
   const { t } = useTranslation();
-  const source = useAddDataSource(t("addData.delimitedText.defaultName"));
+  // Captured once on mount so the "did the user rename it?" comparisons below
+  // stay stable even if the UI language changes while the dialog is open.
+  const [defaultName] = useState(() => t("addData.delimitedText.defaultName"));
+  const source = useAddDataSource(defaultName);
   const [delimitedTextMode, setDelimitedTextMode] =
     useState<DelimitedTextMode>("url");
   const [delimitedTextUrl, setDelimitedTextUrl] = useState(
@@ -118,12 +121,11 @@ export function DelimitedTextSource() {
       });
       resetDelimitedTextColumns();
       source.setLayerName((current) =>
-        current.trim() &&
-        current !== t("addData.delimitedText.defaultName")
+        current.trim() && current !== defaultName
           ? current
           : layerNameFromPath(
               result.path,
-              t("addData.delimitedText.defaultName"),
+              defaultName,
             ),
       );
     } catch (err) {
@@ -181,7 +183,7 @@ export function DelimitedTextSource() {
 
   const handleSubmit = source.runSubmit(async () => {
     const name =
-      source.layerName.trim() || t("addData.delimitedText.defaultName");
+      source.layerName.trim() || defaultName;
     const delimiter = resolveDelimitedTextDelimiter(
       delimitedTextDelimiter,
       delimitedTextCustomDelimiter,

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/DelimitedTextSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/DelimitedTextSource.tsx
@@ -1,6 +1,7 @@
 import { Button, Input, Label, Select } from "@geolibre/ui";
 import { Columns3, FileUp } from "lucide-react";
 import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
 import {
   parseDelimitedTextFields,
   parseDelimitedTextLayer,
@@ -23,7 +24,8 @@ import { AddDataSourceForm, useAddDataSource } from "../shared";
 import type { DelimitedTextDelimiter, DelimitedTextMode } from "../types";
 
 export function DelimitedTextSource() {
-  const source = useAddDataSource("Delimited Text Layer");
+  const { t } = useTranslation();
+  const source = useAddDataSource(t("addData.delimitedText.defaultName"));
   const [delimitedTextMode, setDelimitedTextMode] =
     useState<DelimitedTextMode>("url");
   const [delimitedTextUrl, setDelimitedTextUrl] = useState(
@@ -71,7 +73,7 @@ export function DelimitedTextSource() {
   }> => {
     if (delimitedTextMode === "file") {
       if (!selectedDelimitedText) {
-        throw new Error("Choose a delimited text file.");
+        throw new Error(t("addData.delimitedText.errorChooseFile"));
       }
       return {
         sourcePath: selectedDelimitedText.path,
@@ -80,11 +82,13 @@ export function DelimitedTextSource() {
     }
 
     const sourcePath = delimitedTextUrl.trim();
-    if (!sourcePath) throw new Error("Enter a delimited text URL.");
+    if (!sourcePath) throw new Error(t("addData.delimitedText.errorUrl"));
 
     const response = await fetch(sourcePath);
     if (!response.ok) {
-      throw new Error(`Request failed with status ${response.status}`);
+      throw new Error(
+        t("addData.common.requestFailed", { status: response.status }),
+      );
     }
     return {
       sourcePath,
@@ -106,19 +110,26 @@ export function DelimitedTextSource() {
         readText: true,
       });
       if (!result) return;
-      if (!result.text) throw new Error("Delimited text file data is missing.");
+      if (!result.text)
+        throw new Error(t("addData.delimitedText.errorFileMissing"));
       setSelectedDelimitedText({
         path: result.path,
         text: result.text,
       });
       resetDelimitedTextColumns();
       source.setLayerName((current) =>
-        current.trim() && current !== "Delimited Text Layer"
+        current.trim() &&
+        current !== t("addData.delimitedText.defaultName")
           ? current
-          : layerNameFromPath(result.path, "Delimited Text Layer"),
+          : layerNameFromPath(
+              result.path,
+              t("addData.delimitedText.defaultName"),
+            ),
       );
     } catch (err) {
-      source.setError(errorMessage(err, "Could not read delimited text file."));
+      source.setError(
+        errorMessage(err, t("addData.delimitedText.readError")),
+      );
     }
   };
 
@@ -156,10 +167,12 @@ export function DelimitedTextSource() {
         ]),
       );
       setDelimitedTextColumnsStatus(
-        `Retrieved ${fields.length} column${fields.length === 1 ? "" : "s"}.`,
+        t("addData.delimitedText.retrievedColumns", { count: fields.length }),
       );
     } catch (err) {
-      source.setError(errorMessage(err, "Could not retrieve column names."));
+      source.setError(
+        errorMessage(err, t("addData.delimitedText.errorRetrieveColumns")),
+      );
       setDelimitedTextFields([]);
     } finally {
       setIsRetrievingDelimitedTextColumns(false);
@@ -167,13 +180,14 @@ export function DelimitedTextSource() {
   };
 
   const handleSubmit = source.runSubmit(async () => {
-    const name = source.layerName.trim() || "Delimited Text Layer";
+    const name =
+      source.layerName.trim() || t("addData.delimitedText.defaultName");
     const delimiter = resolveDelimitedTextDelimiter(
       delimitedTextDelimiter,
       delimitedTextCustomDelimiter,
     );
     const { sourcePath, text } = await readDelimitedTextSource();
-    if (!text) throw new Error("Delimited text data is missing.");
+    if (!text) throw new Error(t("addData.delimitedText.errorDataMissing"));
 
     const result = parseDelimitedTextLayer(text, {
       delimiter,
@@ -244,7 +258,9 @@ export function DelimitedTextSource() {
     >
       <div className="space-y-3">
         <div className="space-y-1.5">
-          <Label htmlFor="delimited-text-mode">Source type</Label>
+          <Label htmlFor="delimited-text-mode">
+            {t("addData.common.sourceType")}
+          </Label>
           <Select
             id="delimited-text-mode"
             value={delimitedTextMode}
@@ -254,8 +270,8 @@ export function DelimitedTextSource() {
               )
             }
           >
-            <option value="url">Delimited text URL</option>
-            <option value="file">Delimited text file</option>
+            <option value="url">{t("addData.delimitedText.url")}</option>
+            <option value="file">{t("addData.delimitedText.file")}</option>
           </Select>
         </div>
 
@@ -267,20 +283,22 @@ export function DelimitedTextSource() {
               onClick={handleChooseDelimitedText}
             >
               <FileUp className="mr-2 h-3.5 w-3.5" />
-              Choose file
+              {t("addData.common.chooseFile")}
             </Button>
             <span className="min-w-0 truncate text-xs text-muted-foreground">
               {selectedDelimitedText
                 ? fileNameFromPath(selectedDelimitedText.path)
-                : "No file selected"}
+                : t("addData.common.noFileSelected")}
             </span>
           </div>
         ) : (
           <div className="space-y-1.5">
-            <Label htmlFor="delimited-text-url">Delimited text URL</Label>
+            <Label htmlFor="delimited-text-url">
+              {t("addData.delimitedText.url")}
+            </Label>
             <Input
               id="delimited-text-url"
-              placeholder="https://example.com/data.csv"
+              placeholder={t("addData.delimitedText.urlPlaceholder")}
               value={delimitedTextUrl}
               onChange={(event) => {
                 setDelimitedTextUrl(event.target.value);
@@ -304,8 +322,8 @@ export function DelimitedTextSource() {
         >
           <Columns3 className="mr-2 h-3.5 w-3.5" />
           {isRetrievingDelimitedTextColumns
-            ? "Retrieving..."
-            : "Retrieve columns"}
+            ? t("addData.delimitedText.retrieving")
+            : t("addData.delimitedText.retrieveColumns")}
         </Button>
         {delimitedTextColumnsStatus ? (
           <p className="text-xs text-muted-foreground">
@@ -315,7 +333,9 @@ export function DelimitedTextSource() {
 
         <div className="grid gap-3 sm:grid-cols-2">
           <div className="space-y-1.5">
-            <Label htmlFor="delimited-text-delimiter">Delimiter</Label>
+            <Label htmlFor="delimited-text-delimiter">
+              {t("addData.delimitedText.delimiter")}
+            </Label>
             <Select
               id="delimited-text-delimiter"
               value={delimitedTextDelimiter}
@@ -326,17 +346,27 @@ export function DelimitedTextSource() {
                 resetDelimitedTextColumns();
               }}
             >
-              <option value="comma">Comma</option>
-              <option value="tab">Tab</option>
-              <option value="semicolon">Semicolon</option>
-              <option value="pipe">Pipe</option>
-              <option value="custom">Custom</option>
+              <option value="comma">
+                {t("addData.delimitedText.delimiterComma")}
+              </option>
+              <option value="tab">
+                {t("addData.delimitedText.delimiterTab")}
+              </option>
+              <option value="semicolon">
+                {t("addData.delimitedText.delimiterSemicolon")}
+              </option>
+              <option value="pipe">
+                {t("addData.delimitedText.delimiterPipe")}
+              </option>
+              <option value="custom">
+                {t("addData.delimitedText.delimiterCustom")}
+              </option>
             </Select>
           </div>
           {delimitedTextDelimiter === "custom" ? (
             <div className="space-y-1.5">
               <Label htmlFor="delimited-text-custom-delimiter">
-                Custom delimiter
+                {t("addData.delimitedText.customDelimiter")}
               </Label>
               <Input
                 id="delimited-text-custom-delimiter"
@@ -352,7 +382,9 @@ export function DelimitedTextSource() {
 
         <div className="grid gap-3 sm:grid-cols-2">
           <div className="space-y-1.5">
-            <Label htmlFor="delimited-text-longitude">Longitude field</Label>
+            <Label htmlFor="delimited-text-longitude">
+              {t("addData.delimitedText.longitudeField")}
+            </Label>
             <Select
               id="delimited-text-longitude"
               value={delimitedTextLongitudeField}
@@ -368,7 +400,9 @@ export function DelimitedTextSource() {
             </Select>
           </div>
           <div className="space-y-1.5">
-            <Label htmlFor="delimited-text-latitude">Latitude field</Label>
+            <Label htmlFor="delimited-text-latitude">
+              {t("addData.delimitedText.latitudeField")}
+            </Label>
             <Select
               id="delimited-text-latitude"
               value={delimitedTextLatitudeField}

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/GpxSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/GpxSource.tsx
@@ -3,6 +3,7 @@ import { Button, Input, Label, Select } from "@geolibre/ui";
 import type { FeatureCollection } from "geojson";
 import { FileUp } from "lucide-react";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { parseGpxLayer } from "../../../../lib/gpx";
 import { openLocalDataFileWithFallback } from "../../../../lib/tauri-io";
 import { DEFAULT_GPX_URL } from "../constants";
@@ -17,7 +18,8 @@ import { AddDataSourceForm, useAddDataSource } from "../shared";
 import type { GpxLayerKind, GpxMode } from "../types";
 
 export function GpxSource() {
-  const source = useAddDataSource("GPX Layer");
+  const { t } = useTranslation();
+  const source = useAddDataSource(t("addData.gpx.defaultName"));
   const [gpxMode, setGpxMode] = useState<GpxMode>("url");
   const [gpxUrl, setGpxUrl] = useState(DEFAULT_GPX_URL);
   const [selectedGpx, setSelectedGpx] = useState<{
@@ -68,18 +70,18 @@ export function GpxSource() {
         readText: true,
       });
       if (!result) return;
-      if (!result.text) throw new Error("GPX file data is missing.");
+      if (!result.text) throw new Error(t("addData.gpx.errorFileMissing"));
       setSelectedGpx({
         path: result.path,
         text: result.text,
       });
       source.setLayerName((current) =>
-        current.trim() && current !== "GPX Layer"
+        current.trim() && current !== t("addData.gpx.defaultName")
           ? current
-          : layerNameFromPath(result.path, "GPX Layer"),
+          : layerNameFromPath(result.path, t("addData.gpx.defaultName")),
       );
     } catch (err) {
-      source.setError(errorMessage(err, "Could not read GPX file."));
+      source.setError(errorMessage(err, t("addData.gpx.readError")));
     }
   };
 
@@ -88,7 +90,7 @@ export function GpxSource() {
     text: string;
   }> => {
     if (gpxMode === "file") {
-      if (!selectedGpx) throw new Error("Choose a GPX file.");
+      if (!selectedGpx) throw new Error(t("addData.gpx.errorChooseFile"));
       return {
         sourcePath: selectedGpx.path,
         text: selectedGpx.text,
@@ -96,11 +98,13 @@ export function GpxSource() {
     }
 
     const sourcePath = gpxUrl.trim();
-    if (!sourcePath) throw new Error("Enter a GPX URL.");
+    if (!sourcePath) throw new Error(t("addData.gpx.errorUrl"));
 
     const response = await fetch(proxyGpxRequestUrl(sourcePath));
     if (!response.ok) {
-      throw new Error(`Request failed with status ${response.status}`);
+      throw new Error(
+        t("addData.common.requestFailed", { status: response.status }),
+      );
     }
     return {
       sourcePath,
@@ -109,9 +113,9 @@ export function GpxSource() {
   };
 
   const handleSubmit = source.runSubmit(async () => {
-    const name = source.layerName.trim() || "GPX Layer";
+    const name = source.layerName.trim() || t("addData.gpx.defaultName");
     if (!hasSelectedGpxLayerKind) {
-      throw new Error("Select at least one GPX layer type.");
+      throw new Error(t("addData.gpx.errorSelectType"));
     }
 
     const { sourcePath, text } = await readGpxSource();
@@ -124,17 +128,17 @@ export function GpxSource() {
       {
         featureCollection: result.waypoints,
         kind: "waypoints",
-        label: "Waypoints",
+        label: t("addData.gpx.waypoints"),
       },
       {
         featureCollection: result.tracks,
         kind: "tracks",
-        label: "Tracks",
+        label: t("addData.gpx.tracks"),
       },
       {
         featureCollection: result.routes,
         kind: "routes",
-        label: "Routes",
+        label: t("addData.gpx.routes"),
       },
     ];
     const layers = gpxLayerGroups
@@ -165,7 +169,7 @@ export function GpxSource() {
       }));
 
     if (layers.length === 0) {
-      throw new Error("The selected GPX layer types were not found.");
+      throw new Error(t("addData.gpx.errorNotFound"));
     }
 
     for (const layer of layers) {
@@ -204,7 +208,7 @@ export function GpxSource() {
     >
       <div className="space-y-3">
         <div className="space-y-1.5">
-          <Label htmlFor="gpx-mode">Source type</Label>
+          <Label htmlFor="gpx-mode">{t("addData.common.sourceType")}</Label>
           <Select
             id="gpx-mode"
             value={gpxMode}
@@ -212,8 +216,8 @@ export function GpxSource() {
               handleGpxModeChange(event.target.value as GpxMode)
             }
           >
-            <option value="url">GPX URL</option>
-            <option value="file">GPX file</option>
+            <option value="url">{t("addData.gpx.url")}</option>
+            <option value="file">{t("addData.gpx.file")}</option>
           </Select>
         </div>
 
@@ -221,20 +225,20 @@ export function GpxSource() {
           <div className="flex flex-wrap items-center gap-2">
             <Button type="button" variant="outline" onClick={handleChooseGpx}>
               <FileUp className="mr-2 h-3.5 w-3.5" />
-              Choose file
+              {t("addData.common.chooseFile")}
             </Button>
             <span className="min-w-0 truncate text-xs text-muted-foreground">
               {selectedGpx
                 ? fileNameFromPath(selectedGpx.path)
-                : "No file selected"}
+                : t("addData.common.noFileSelected")}
             </span>
           </div>
         ) : (
           <div className="space-y-1.5">
-            <Label htmlFor="gpx-url">GPX URL</Label>
+            <Label htmlFor="gpx-url">{t("addData.gpx.url")}</Label>
             <Input
               id="gpx-url"
-              placeholder="https://example.com/route.gpx"
+              placeholder={t("addData.gpx.urlPlaceholder")}
               value={gpxUrl}
               onChange={(event) => setGpxUrl(event.target.value)}
             />
@@ -242,7 +246,7 @@ export function GpxSource() {
         )}
 
         <div className="space-y-2">
-          <Label>Layer types</Label>
+          <Label>{t("addData.gpx.layerTypes")}</Label>
           <div className="grid gap-2 sm:grid-cols-3">
             <label className="flex items-center gap-2 text-sm">
               <input
@@ -252,7 +256,7 @@ export function GpxSource() {
                   setGpxLayerKindSelected("waypoints", event.target.checked)
                 }
               />
-              Waypoints
+              {t("addData.gpx.waypoints")}
             </label>
             <label className="flex items-center gap-2 text-sm">
               <input
@@ -262,7 +266,7 @@ export function GpxSource() {
                   setGpxLayerKindSelected("tracks", event.target.checked)
                 }
               />
-              Tracks
+              {t("addData.gpx.tracks")}
             </label>
             <label className="flex items-center gap-2 text-sm">
               <input
@@ -272,7 +276,7 @@ export function GpxSource() {
                   setGpxLayerKindSelected("routes", event.target.checked)
                 }
               />
-              Routes
+              {t("addData.gpx.routes")}
             </label>
           </div>
         </div>

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/GpxSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/GpxSource.tsx
@@ -19,7 +19,10 @@ import type { GpxLayerKind, GpxMode } from "../types";
 
 export function GpxSource() {
   const { t } = useTranslation();
-  const source = useAddDataSource(t("addData.gpx.defaultName"));
+  // Captured once on mount so the "did the user rename it?" comparisons below
+  // stay stable even if the UI language changes while the dialog is open.
+  const [defaultName] = useState(() => t("addData.gpx.defaultName"));
+  const source = useAddDataSource(defaultName);
   const [gpxMode, setGpxMode] = useState<GpxMode>("url");
   const [gpxUrl, setGpxUrl] = useState(DEFAULT_GPX_URL);
   const [selectedGpx, setSelectedGpx] = useState<{
@@ -76,9 +79,9 @@ export function GpxSource() {
         text: result.text,
       });
       source.setLayerName((current) =>
-        current.trim() && current !== t("addData.gpx.defaultName")
+        current.trim() && current !== defaultName
           ? current
-          : layerNameFromPath(result.path, t("addData.gpx.defaultName")),
+          : layerNameFromPath(result.path, defaultName),
       );
     } catch (err) {
       source.setError(errorMessage(err, t("addData.gpx.readError")));
@@ -113,7 +116,7 @@ export function GpxSource() {
   };
 
   const handleSubmit = source.runSubmit(async () => {
-    const name = source.layerName.trim() || t("addData.gpx.defaultName");
+    const name = source.layerName.trim() || defaultName;
     if (!hasSelectedGpxLayerKind) {
       throw new Error(t("addData.gpx.errorSelectType"));
     }

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/MbtilesSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/MbtilesSource.tsx
@@ -1,6 +1,7 @@
 import { Button, Input, Label } from "@geolibre/ui";
 import { FileUp } from "lucide-react";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import {
   mbtilesTileUrl,
   readMbtilesMetadata,
@@ -17,7 +18,8 @@ import {
 import { AddDataSourceForm, useAddDataSource } from "../shared";
 
 export function MbtilesSource() {
-  const source = useAddDataSource("MBTiles Layer");
+  const { t } = useTranslation();
+  const source = useAddDataSource(t("addData.mbtiles.defaultName"));
   const [selectedMbtiles, setSelectedMbtiles] = useState<{
     metadata: MbtilesMetadata;
     path: string;
@@ -41,18 +43,20 @@ export function MbtilesSource() {
       setSelectedMbtiles({ metadata, path: result.path });
       setMbtilesSourceLayers(metadata.sourceLayers.join(", "));
       source.setLayerName((current) =>
-        current.trim() && current !== "MBTiles Layer"
+        current.trim() && current !== t("addData.mbtiles.defaultName")
           ? current
-          : metadata.name || layerNameFromPath(result.path, "MBTiles Layer"),
+          : metadata.name ||
+            layerNameFromPath(result.path, t("addData.mbtiles.defaultName")),
       );
     } catch (err) {
-      source.setError(errorMessage(err, "Could not read MBTiles file."));
+      source.setError(errorMessage(err, t("addData.mbtiles.readError")));
     }
   };
 
   const handleSubmit = source.runSubmit(() => {
-    const name = source.layerName.trim() || "MBTiles Layer";
-    if (!selectedMbtiles) throw new Error("Choose an MBTiles file.");
+    const name = source.layerName.trim() || t("addData.mbtiles.defaultName");
+    if (!selectedMbtiles)
+      throw new Error(t("addData.mbtiles.errorChooseFile"));
     registerMbtilesProtocol();
 
     const { metadata, path } = selectedMbtiles;
@@ -61,7 +65,7 @@ export function MbtilesSource() {
       .map((sourceLayer) => sourceLayer.trim())
       .filter(Boolean);
     if (metadata.tileType === "vector" && sourceLayers.length === 0) {
-      throw new Error("Enter at least one vector source layer.");
+      throw new Error(t("addData.mbtiles.errorSourceLayers"));
     }
 
     const minzoom = metadata.minZoom ?? undefined;
@@ -112,24 +116,24 @@ export function MbtilesSource() {
             onClick={handleChooseMbtilesFile}
           >
             <FileUp className="mr-2 h-3.5 w-3.5" />
-            Choose file
+            {t("addData.common.chooseFile")}
           </Button>
           <span className="min-w-0 truncate text-xs text-muted-foreground">
             {selectedMbtiles
               ? fileNameFromPath(selectedMbtiles.path)
-              : "No file selected"}
+              : t("addData.common.noFileSelected")}
           </span>
         </div>
         {selectedMbtiles && (
           <div className="grid gap-3 sm:grid-cols-2">
             <div className="space-y-1.5">
-              <Label>Tile type</Label>
+              <Label>{t("addData.mbtiles.tileType")}</Label>
               <div className="rounded-md border bg-muted/30 px-3 py-2 text-sm">
                 {selectedMbtiles.metadata.tileType}
               </div>
             </div>
             <div className="space-y-1.5">
-              <Label>Format</Label>
+              <Label>{t("addData.common.format")}</Label>
               <div className="rounded-md border bg-muted/30 px-3 py-2 text-sm">
                 {selectedMbtiles.metadata.format}
               </div>
@@ -138,10 +142,12 @@ export function MbtilesSource() {
         )}
         {selectedMbtiles?.metadata.tileType === "vector" && (
           <div className="space-y-1.5">
-            <Label htmlFor="mbtiles-source-layers">Source layers</Label>
+            <Label htmlFor="mbtiles-source-layers">
+              {t("addData.mbtiles.sourceLayers")}
+            </Label>
             <Input
               id="mbtiles-source-layers"
-              placeholder="building, place, water"
+              placeholder={t("addData.mbtiles.sourceLayersPlaceholder")}
               value={mbtilesSourceLayers}
               onChange={(event) => setMbtilesSourceLayers(event.target.value)}
             />

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/MbtilesSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/MbtilesSource.tsx
@@ -19,7 +19,10 @@ import { AddDataSourceForm, useAddDataSource } from "../shared";
 
 export function MbtilesSource() {
   const { t } = useTranslation();
-  const source = useAddDataSource(t("addData.mbtiles.defaultName"));
+  // Captured once on mount so the "did the user rename it?" comparison below
+  // stays stable even if the UI language changes while the dialog is open.
+  const [defaultName] = useState(() => t("addData.mbtiles.defaultName"));
+  const source = useAddDataSource(defaultName);
   const [selectedMbtiles, setSelectedMbtiles] = useState<{
     metadata: MbtilesMetadata;
     path: string;
@@ -43,10 +46,9 @@ export function MbtilesSource() {
       setSelectedMbtiles({ metadata, path: result.path });
       setMbtilesSourceLayers(metadata.sourceLayers.join(", "));
       source.setLayerName((current) =>
-        current.trim() && current !== t("addData.mbtiles.defaultName")
+        current.trim() && current !== defaultName
           ? current
-          : metadata.name ||
-            layerNameFromPath(result.path, t("addData.mbtiles.defaultName")),
+          : metadata.name || layerNameFromPath(result.path, defaultName),
       );
     } catch (err) {
       source.setError(errorMessage(err, t("addData.mbtiles.readError")));
@@ -54,7 +56,7 @@ export function MbtilesSource() {
   };
 
   const handleSubmit = source.runSubmit(() => {
-    const name = source.layerName.trim() || t("addData.mbtiles.defaultName");
+    const name = source.layerName.trim() || defaultName;
     if (!selectedMbtiles)
       throw new Error(t("addData.mbtiles.errorChooseFile"));
     registerMbtilesProtocol();

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/PostgresSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/PostgresSource.tsx
@@ -1,5 +1,6 @@
 import { Button, Input, Label, Select } from "@geolibre/ui";
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import {
   ensureMartinBinary,
   fetchMartinCatalog,
@@ -19,7 +20,8 @@ import {
 import { AddDataSourceForm, useAddDataSource } from "../shared";
 
 export function PostgresSource() {
-  const source = useAddDataSource("PostgreSQL Layer");
+  const { t } = useTranslation();
+  const source = useAddDataSource(t("addData.postgres.defaultName"));
   const { martin } = source.shell;
   const [postgresConnectionString, setPostgresConnectionString] = useState(
     () => readSavedPostgresConnections()[0] ?? "",
@@ -48,19 +50,19 @@ export function PostgresSource() {
 
     try {
       if (!isTauri()) {
-        throw new Error("PostgreSQL layers require GeoLibre Desktop.");
+        throw new Error(t("addData.postgres.errorDesktopOnly"));
       }
       if (!postgresConnectionString.trim()) {
-        throw new Error("Enter a PostgreSQL connection string.");
+        throw new Error(t("addData.postgres.errorConnectionString"));
       }
       const connectionString = postgresConnectionString.trim();
 
-      martin.setStatus("Checking Martin binary...");
+      martin.setStatus(t("addData.postgres.statusCheckingBinary"));
       const binary = await ensureMartinBinary();
       martin.setStatus(
         binary.downloaded
-          ? "Martin downloaded. Starting local server..."
-          : "Starting local Martin server...",
+          ? t("addData.postgres.statusDownloaded")
+          : t("addData.postgres.statusStarting"),
       );
       const server = await startMartinServer({
         connectionString,
@@ -68,19 +70,21 @@ export function PostgresSource() {
       });
       setSavedPostgresConnections(rememberPostgresConnection(connectionString));
       martin.setServer(server);
-      martin.setStatus("Reading Martin catalog...");
+      martin.setStatus(t("addData.postgres.statusReadingCatalog"));
 
       const sources = await fetchMartinCatalog(server);
       martin.setSources(sources);
       martin.setSelectedSourceId(sources[0]?.id ?? "");
       martin.setStatus(
         sources.length > 0
-          ? `Found ${sources.length} source${sources.length === 1 ? "" : "s"}.`
-          : "Martin is running, but no compatible PostGIS sources were found.",
+          ? t("addData.postgres.statusFound", { count: sources.length })
+          : t("addData.postgres.statusNoSources"),
       );
     } catch (err) {
       martin.setServer(null);
-      source.setError(errorMessage(err, "Could not connect to PostgreSQL."));
+      source.setError(
+        errorMessage(err, t("addData.postgres.errorConnect")),
+      );
       martin.setStatus(null);
     } finally {
       source.shell.setIsSubmitting(false);
@@ -95,9 +99,9 @@ export function PostgresSource() {
       martin.setServer(null);
       martin.setSources([]);
       martin.setSelectedSourceId("");
-      martin.setStatus("Martin stopped.");
+      martin.setStatus(t("addData.postgres.statusStopped"));
     } catch (err) {
-      source.setError(errorMessage(err, "Could not stop Martin."));
+      source.setError(errorMessage(err, t("addData.postgres.errorStop")));
     } finally {
       source.shell.setIsSubmitting(false);
     }
@@ -105,12 +109,12 @@ export function PostgresSource() {
 
   const addMartinSource = async (sourceId: string) => {
     const server = martin.server;
-    if (!server) throw new Error("Connect to PostgreSQL first.");
+    if (!server) throw new Error(t("addData.postgres.errorConnectFirst"));
     const tilejson = await fetchMartinTileJson(server, sourceId);
     const vectorLayers = tilejson.vector_layers ?? tilejson.vectorLayers ?? [];
     const sourceLayer = vectorLayers[0]?.id;
     if (!sourceLayer) {
-      throw new Error("The selected Martin source has no vector layers.");
+      throw new Error(t("addData.postgres.errorNoVectorLayers"));
     }
 
     const summary = martin.sources.find(
@@ -152,10 +156,10 @@ export function PostgresSource() {
 
   const handleSubmit = source.runSubmit(async () => {
     if (!martin.server) {
-      throw new Error("Connect to PostgreSQL first.");
+      throw new Error(t("addData.postgres.errorConnectFirst"));
     }
     if (!martin.selectedSourceId) {
-      throw new Error("Select a Martin source to add.");
+      throw new Error(t("addData.postgres.errorSelectSource"));
     }
     await addMartinSource(martin.selectedSourceId);
   });
@@ -175,14 +179,14 @@ export function PostgresSource() {
       <div className="space-y-3">
         {!isTauri() ? (
           <p className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
-            PostgreSQL layers are only available in GeoLibre Desktop. This
-            feature runs a local Martin tile server, which the web app cannot
-            launch.
+            {t("addData.postgres.desktopOnlyNotice")}
           </p>
         ) : null}
         {savedPostgresConnections.length > 0 ? (
           <div className="space-y-1.5">
-            <Label htmlFor="postgres-saved-connection">Saved connection</Label>
+            <Label htmlFor="postgres-saved-connection">
+              {t("addData.postgres.savedConnection")}
+            </Label>
             <Select
               id="postgres-saved-connection"
               value={
@@ -194,7 +198,9 @@ export function PostgresSource() {
                 setPostgresConnectionString(event.target.value)
               }
             >
-              <option value="">Select saved connection</option>
+              <option value="">
+                {t("addData.postgres.selectSavedConnection")}
+              </option>
               {savedPostgresConnections.map((connection) => (
                 <option key={connection} value={connection}>
                   {savedPostgresConnectionLabel(connection)}
@@ -205,13 +211,13 @@ export function PostgresSource() {
         ) : null}
         <div className="space-y-1.5">
           <Label htmlFor="postgres-connection">
-            PostgreSQL connection string
+            {t("addData.postgres.connectionString")}
           </Label>
           <Input
             id="postgres-connection"
             type="password"
             autoComplete="off"
-            placeholder="postgres://user:password@host:5432/database"
+            placeholder={t("addData.postgres.connectionStringPlaceholder")}
             value={postgresConnectionString}
             onChange={(event) =>
               setPostgresConnectionString(event.target.value)
@@ -220,11 +226,13 @@ export function PostgresSource() {
         </div>
         <div className="grid gap-3 sm:grid-cols-[1fr_auto]">
           <div className="space-y-1.5">
-            <Label htmlFor="postgres-default-srid">Default SRID</Label>
+            <Label htmlFor="postgres-default-srid">
+              {t("addData.postgres.defaultSrid")}
+            </Label>
             <Input
               id="postgres-default-srid"
               inputMode="numeric"
-              placeholder="Optional"
+              placeholder={t("addData.common.optional")}
               value={postgresDefaultSrid}
               onChange={(event) => setPostgresDefaultSrid(event.target.value)}
             />
@@ -237,7 +245,7 @@ export function PostgresSource() {
                 onClick={handleConnectPostgres}
                 disabled={source.isSubmitting || !isTauri()}
               >
-                Connect
+                {t("addData.postgres.connect")}
               </Button>
               {martin.server ? (
                 <Button
@@ -246,7 +254,7 @@ export function PostgresSource() {
                   onClick={handleStopMartin}
                   disabled={source.isSubmitting}
                 >
-                  Stop
+                  {t("addData.postgres.stop")}
                 </Button>
               ) : null}
             </div>
@@ -257,7 +265,9 @@ export function PostgresSource() {
         ) : null}
         {martin.sources.length > 0 ? (
           <div className="space-y-1.5">
-            <Label htmlFor="martin-source">Martin source</Label>
+            <Label htmlFor="martin-source">
+              {t("addData.postgres.martinSource")}
+            </Label>
             <Select
               id="martin-source"
               value={martin.selectedSourceId}
@@ -275,7 +285,7 @@ export function PostgresSource() {
         ) : null}
         {martin.server ? (
           <p className="text-xs text-muted-foreground">
-            Martin is running on port {martin.server.port}.
+            {t("addData.postgres.runningOnPort", { port: martin.server.port })}
           </p>
         ) : null}
       </div>

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/VideoSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/VideoSource.tsx
@@ -9,7 +9,7 @@ import {
   DEFAULT_VIDEO_TOP_RIGHT,
   DEFAULT_VIDEO_WEBM_URL,
 } from "../constants";
-import { createBaseLayer, parseVideoCorner } from "../helpers";
+import { createBaseLayer } from "../helpers";
 import { AddDataSourceForm, useAddDataSource } from "../shared";
 
 export function VideoSource() {
@@ -25,6 +25,28 @@ export function VideoSource() {
   const [videoBottomLeft, setVideoBottomLeft] = useState(
     DEFAULT_VIDEO_BOTTOM_LEFT,
   );
+
+  // Local, translated equivalent of helpers' parseVideoCorner: parses a
+  // "longitude, latitude" corner into a [lng, lat] pair and throws localized
+  // validation errors (the shared helper stays English for its unit tests).
+  const parseCorner = (value: string, corner: string): [number, number] => {
+    const parts = value.split(",").map((part) => part.trim());
+    if (parts.length !== 2) {
+      throw new Error(t("addData.video.errorCornerFormat", { corner }));
+    }
+    const lng = Number(parts[0]);
+    const lat = Number(parts[1]);
+    if (!Number.isFinite(lng) || !Number.isFinite(lat)) {
+      throw new Error(t("addData.video.errorCornerNumber", { corner }));
+    }
+    if (lng < -180 || lng > 180) {
+      throw new Error(t("addData.video.errorCornerLng", { corner }));
+    }
+    if (lat < -90 || lat > 90) {
+      throw new Error(t("addData.video.errorCornerLat", { corner }));
+    }
+    return [lng, lat];
+  };
 
   const handleSubmit = source.runSubmit(() => {
     const name = source.layerName.trim() || t("addData.video.defaultName");
@@ -46,10 +68,10 @@ export function VideoSource() {
       [number, number],
       [number, number],
     ] = [
-      parseVideoCorner(videoTopLeft, "top-left"),
-      parseVideoCorner(videoTopRight, "top-right"),
-      parseVideoCorner(videoBottomRight, "bottom-right"),
-      parseVideoCorner(videoBottomLeft, "bottom-left"),
+      parseCorner(videoTopLeft, t("addData.video.cornerTopLeft")),
+      parseCorner(videoTopRight, t("addData.video.cornerTopRight")),
+      parseCorner(videoBottomRight, t("addData.video.cornerBottomRight")),
+      parseCorner(videoBottomLeft, t("addData.video.cornerBottomLeft")),
     ];
     const lngs = coordinates.map((corner) => corner[0]);
     const lats = coordinates.map((corner) => corner[1]);

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/VideoSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/VideoSource.tsx
@@ -1,5 +1,6 @@
 import { Input, Label } from "@geolibre/ui";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import {
   DEFAULT_VIDEO_BOTTOM_LEFT,
   DEFAULT_VIDEO_BOTTOM_RIGHT,
@@ -12,7 +13,8 @@ import { createBaseLayer, parseVideoCorner } from "../helpers";
 import { AddDataSourceForm, useAddDataSource } from "../shared";
 
 export function VideoSource() {
-  const source = useAddDataSource("Video Layer");
+  const { t } = useTranslation();
+  const source = useAddDataSource(t("addData.video.defaultName"));
   const [videoMp4Url, setVideoMp4Url] = useState(DEFAULT_VIDEO_MP4_URL);
   const [videoWebmUrl, setVideoWebmUrl] = useState(DEFAULT_VIDEO_WEBM_URL);
   const [videoTopLeft, setVideoTopLeft] = useState(DEFAULT_VIDEO_TOP_LEFT);
@@ -25,10 +27,10 @@ export function VideoSource() {
   );
 
   const handleSubmit = source.runSubmit(() => {
-    const name = source.layerName.trim() || "Video Layer";
+    const name = source.layerName.trim() || t("addData.video.defaultName");
     const primary = videoMp4Url.trim();
     if (!primary) {
-      throw new Error("Enter a video URL.");
+      throw new Error(t("addData.video.errorUrl"));
     }
     const urls = [primary];
     const webm = videoWebmUrl.trim();
@@ -36,7 +38,7 @@ export function VideoSource() {
     // The media-src CSP is HTTPS-only, so an http:// URL would be silently
     // blocked — reject it up front with a clear message.
     if (urls.some((url) => !/^https:\/\//i.test(url))) {
-      throw new Error("Video URLs must start with https://.");
+      throw new Error(t("addData.video.errorHttps"));
     }
     const coordinates: [
       [number, number],
@@ -85,26 +87,28 @@ export function VideoSource() {
     >
       <div className="space-y-3">
         <div className="space-y-1.5">
-          <Label htmlFor="video-mp4-url">Primary video URL</Label>
+          <Label htmlFor="video-mp4-url">{t("addData.video.primaryUrl")}</Label>
           <Input
             id="video-mp4-url"
-            placeholder="https://example.com/clip.mp4"
+            placeholder={t("addData.video.primaryUrlPlaceholder")}
             value={videoMp4Url}
             onChange={(event) => setVideoMp4Url(event.target.value)}
           />
         </div>
         <div className="space-y-1.5">
-          <Label htmlFor="video-webm-url">Fallback video URL (optional)</Label>
+          <Label htmlFor="video-webm-url">
+            {t("addData.video.fallbackUrl")}
+          </Label>
           <Input
             id="video-webm-url"
-            placeholder="https://example.com/clip.webm"
+            placeholder={t("addData.video.fallbackUrlPlaceholder")}
             value={videoWebmUrl}
             onChange={(event) => setVideoWebmUrl(event.target.value)}
           />
         </div>
         <div className="grid gap-3 sm:grid-cols-2">
           <div className="space-y-1.5">
-            <Label htmlFor="video-top-left">Top-left (lng, lat)</Label>
+            <Label htmlFor="video-top-left">{t("addData.video.topLeft")}</Label>
             <Input
               id="video-top-left"
               value={videoTopLeft}
@@ -112,7 +116,9 @@ export function VideoSource() {
             />
           </div>
           <div className="space-y-1.5">
-            <Label htmlFor="video-top-right">Top-right (lng, lat)</Label>
+            <Label htmlFor="video-top-right">
+              {t("addData.video.topRight")}
+            </Label>
             <Input
               id="video-top-right"
               value={videoTopRight}
@@ -120,7 +126,9 @@ export function VideoSource() {
             />
           </div>
           <div className="space-y-1.5">
-            <Label htmlFor="video-bottom-right">Bottom-right (lng, lat)</Label>
+            <Label htmlFor="video-bottom-right">
+              {t("addData.video.bottomRight")}
+            </Label>
             <Input
               id="video-bottom-right"
               value={videoBottomRight}
@@ -128,7 +136,9 @@ export function VideoSource() {
             />
           </div>
           <div className="space-y-1.5">
-            <Label htmlFor="video-bottom-left">Bottom-left (lng, lat)</Label>
+            <Label htmlFor="video-bottom-left">
+              {t("addData.video.bottomLeft")}
+            </Label>
             <Input
               id="video-bottom-left"
               value={videoBottomLeft}
@@ -137,9 +147,7 @@ export function VideoSource() {
           </div>
         </div>
         <p className="text-xs text-muted-foreground">
-          The four corners georeference the video on the map. The video must be
-          served over HTTPS and the host must allow cross-origin requests (CORS)
-          for the frames to render.
+          {t("addData.video.cornersNote")}
         </p>
       </div>
     </AddDataSourceForm>

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
@@ -1,5 +1,6 @@
 import { Input, Label, Select } from "@geolibre/ui";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import {
   createWfsGetFeatureUrl,
   fetchGeoJsonFeatureCollection,
@@ -14,7 +15,8 @@ import {
 import { AddDataSourceForm, useAddDataSource } from "../shared";
 
 export function WfsSource() {
-  const source = useAddDataSource("WFS Layer");
+  const { t } = useTranslation();
+  const source = useAddDataSource(t("addData.wfs.defaultName"));
   const [wfsEndpoint, setWfsEndpoint] = useState(DEFAULT_WFS_ENDPOINT);
   const [wfsTypeName, setWfsTypeName] = useState(DEFAULT_WFS_TYPE_NAME);
   const [wfsVersion, setWfsVersion] = useState("2.0.0");
@@ -43,13 +45,13 @@ export function WfsSource() {
   };
 
   const handleSubmit = source.runSubmit(async () => {
-    const name = source.layerName.trim() || "WFS Layer";
-    if (!wfsEndpoint.trim()) throw new Error("Enter a WFS service URL.");
+    const name = source.layerName.trim() || t("addData.wfs.defaultName");
+    if (!wfsEndpoint.trim()) throw new Error(t("addData.wfs.errorUrl"));
     if (!wfsTypeName.trim()) {
-      throw new Error("Enter a WFS feature type name.");
+      throw new Error(t("addData.wfs.errorTypeName"));
     }
     if (!wfsOutputFormat.trim()) {
-      throw new Error("Enter a WFS output format.");
+      throw new Error(t("addData.wfs.errorOutputFormat"));
     }
     parseOptionalNumber(wfsMaxFeatures, "max features");
 
@@ -114,26 +116,26 @@ export function WfsSource() {
           }}
         />
         <div className="space-y-1.5">
-          <Label htmlFor="wfs-endpoint">Service URL</Label>
+          <Label htmlFor="wfs-endpoint">{t("addData.common.serviceUrl")}</Label>
           <Input
             id="wfs-endpoint"
-            placeholder="https://example.com/geoserver/wfs"
+            placeholder={t("addData.wfs.urlPlaceholder")}
             value={wfsEndpoint}
             onChange={(event) => setWfsEndpoint(event.target.value)}
           />
         </div>
         <div className="grid gap-3 sm:grid-cols-2">
           <div className="space-y-1.5">
-            <Label htmlFor="wfs-type-name">Feature type</Label>
+            <Label htmlFor="wfs-type-name">{t("addData.wfs.featureType")}</Label>
             <Input
               id="wfs-type-name"
-              placeholder="workspace:layer"
+              placeholder={t("addData.common.workspaceLayerPlaceholder")}
               value={wfsTypeName}
               onChange={(event) => setWfsTypeName(event.target.value)}
             />
           </div>
           <div className="space-y-1.5">
-            <Label htmlFor="wfs-version">Version</Label>
+            <Label htmlFor="wfs-version">{t("addData.wfs.version")}</Label>
             <Select
               id="wfs-version"
               value={wfsVersion}
@@ -145,7 +147,9 @@ export function WfsSource() {
             </Select>
           </div>
           <div className="space-y-1.5">
-            <Label htmlFor="wfs-output-format">Output format</Label>
+            <Label htmlFor="wfs-output-format">
+              {t("addData.wfs.outputFormat")}
+            </Label>
             <Input
               id="wfs-output-format"
               value={wfsOutputFormat}
@@ -153,20 +157,22 @@ export function WfsSource() {
             />
           </div>
           <div className="space-y-1.5">
-            <Label htmlFor="wfs-srs-name">SRS name</Label>
+            <Label htmlFor="wfs-srs-name">{t("addData.wfs.srsName")}</Label>
             <Input
               id="wfs-srs-name"
-              placeholder="Optional"
+              placeholder={t("addData.common.optional")}
               value={wfsSrsName}
               onChange={(event) => setWfsSrsName(event.target.value)}
             />
           </div>
           <div className="space-y-1.5">
-            <Label htmlFor="wfs-max-features">Max features</Label>
+            <Label htmlFor="wfs-max-features">
+              {t("addData.wfs.maxFeatures")}
+            </Label>
             <Input
               id="wfs-max-features"
               inputMode="numeric"
-              placeholder="Optional"
+              placeholder={t("addData.common.optional")}
               value={wfsMaxFeatures}
               onChange={(event) => setWfsMaxFeatures(event.target.value)}
             />

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
@@ -6,7 +6,7 @@ import {
   fetchGeoJsonFeatureCollection,
 } from "../../../../lib/layer-refresh";
 import { DEFAULT_WFS_ENDPOINT, DEFAULT_WFS_TYPE_NAME } from "../constants";
-import { createBaseLayer, parseOptionalNumber } from "../helpers";
+import { createBaseLayer } from "../helpers";
 import { ServiceLibrarySection } from "../ServiceLibrarySection";
 import {
   serviceFieldString,
@@ -53,7 +53,9 @@ export function WfsSource() {
     if (!wfsOutputFormat.trim()) {
       throw new Error(t("addData.wfs.errorOutputFormat"));
     }
-    parseOptionalNumber(wfsMaxFeatures, "max features");
+    if (wfsMaxFeatures.trim() && !Number.isFinite(Number(wfsMaxFeatures))) {
+      throw new Error(t("addData.wfs.errorMaxFeaturesNumeric"));
+    }
 
     const featureUrl = createWfsGetFeatureUrl({
       endpoint: wfsEndpoint.trim(),

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
@@ -1,5 +1,6 @@
 import { Input, Label, Select } from "@geolibre/ui";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { DEFAULT_WMS_ENDPOINT, DEFAULT_WMS_LAYERS } from "../constants";
 import { createBaseLayer, createWmsTileUrl } from "../helpers";
 import { ServiceLibrarySection } from "../ServiceLibrarySection";
@@ -11,7 +12,8 @@ import {
 import { AddDataSourceForm, useAddDataSource } from "../shared";
 
 export function WmsSource() {
-  const source = useAddDataSource("WMS Layer");
+  const { t } = useTranslation();
+  const source = useAddDataSource(t("addData.wms.defaultName"));
   const [wmsEndpoint, setWmsEndpoint] = useState(DEFAULT_WMS_ENDPOINT);
   const [wmsLayers, setWmsLayers] = useState(DEFAULT_WMS_LAYERS);
   const [wmsStyles, setWmsStyles] = useState("");
@@ -38,10 +40,10 @@ export function WmsSource() {
   };
 
   const handleSubmit = source.runSubmit(() => {
-    const name = source.layerName.trim() || "WMS Layer";
-    if (!wmsEndpoint.trim()) throw new Error("Enter a WMS service URL.");
+    const name = source.layerName.trim() || t("addData.wms.defaultName");
+    if (!wmsEndpoint.trim()) throw new Error(t("addData.wms.errorUrl"));
     if (!wmsLayers.trim()) {
-      throw new Error("Enter one or more WMS layer names.");
+      throw new Error(t("addData.wms.errorLayers"));
     }
     const tileSize = Number(wmsTileSize) || 256;
     const tileUrl = createWmsTileUrl({
@@ -93,26 +95,26 @@ export function WmsSource() {
           }}
         />
         <div className="space-y-1.5">
-          <Label htmlFor="wms-endpoint">Service URL</Label>
+          <Label htmlFor="wms-endpoint">{t("addData.common.serviceUrl")}</Label>
           <Input
             id="wms-endpoint"
-            placeholder="https://example.com/geoserver/wms"
+            placeholder={t("addData.wms.urlPlaceholder")}
             value={wmsEndpoint}
             onChange={(event) => setWmsEndpoint(event.target.value)}
           />
         </div>
         <div className="grid gap-3 sm:grid-cols-2">
           <div className="space-y-1.5">
-            <Label htmlFor="wms-layers">Layers</Label>
+            <Label htmlFor="wms-layers">{t("addData.wms.layers")}</Label>
             <Input
               id="wms-layers"
-              placeholder="workspace:layer"
+              placeholder={t("addData.common.workspaceLayerPlaceholder")}
               value={wmsLayers}
               onChange={(event) => setWmsLayers(event.target.value)}
             />
           </div>
           <div className="space-y-1.5">
-            <Label htmlFor="wms-styles">Styles</Label>
+            <Label htmlFor="wms-styles">{t("addData.wms.styles")}</Label>
             <Input
               id="wms-styles"
               value={wmsStyles}
@@ -120,7 +122,7 @@ export function WmsSource() {
             />
           </div>
           <div className="space-y-1.5">
-            <Label htmlFor="wms-format">Format</Label>
+            <Label htmlFor="wms-format">{t("addData.common.format")}</Label>
             <Select
               id="wms-format"
               value={wmsFormat}
@@ -131,7 +133,7 @@ export function WmsSource() {
             </Select>
           </div>
           <div className="space-y-1.5">
-            <Label htmlFor="wms-tile-size">Tile size</Label>
+            <Label htmlFor="wms-tile-size">{t("addData.common.tileSize")}</Label>
             <Input
               id="wms-tile-size"
               inputMode="numeric"
@@ -146,7 +148,7 @@ export function WmsSource() {
             checked={wmsTransparent}
             onChange={(event) => setWmsTransparent(event.target.checked)}
           />
-          Transparent background
+          {t("addData.wms.transparent")}
         </label>
       </div>
     </AddDataSourceForm>

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WmtsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WmtsSource.tsx
@@ -1,5 +1,6 @@
 import { Input, Label } from "@geolibre/ui";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { DEFAULT_WMTS_URL } from "../constants";
 import { createBaseLayer } from "../helpers";
 import { ServiceLibrarySection } from "../ServiceLibrarySection";
@@ -10,7 +11,8 @@ import {
 import { AddDataSourceForm, useAddDataSource } from "../shared";
 
 export function WmtsSource() {
-  const source = useAddDataSource("WMTS Layer");
+  const { t } = useTranslation();
+  const source = useAddDataSource(t("addData.wmts.defaultName"));
   const [wmtsUrl, setWmtsUrl] = useState(DEFAULT_WMTS_URL);
   const [wmtsTileSize, setWmtsTileSize] = useState("256");
 
@@ -25,9 +27,9 @@ export function WmtsSource() {
   };
 
   const handleSubmit = source.runSubmit(() => {
-    const name = source.layerName.trim() || "WMTS Layer";
+    const name = source.layerName.trim() || t("addData.wmts.defaultName");
     if (!wmtsUrl.trim()) {
-      throw new Error("Enter a WMTS tile URL template.");
+      throw new Error(t("addData.wmts.errorUrl"));
     }
     source.addAndClose(
       createBaseLayer(
@@ -67,16 +69,16 @@ export function WmtsSource() {
         />
         <div className="grid gap-3 sm:grid-cols-[1fr_7rem]">
           <div className="space-y-1.5">
-            <Label htmlFor="wmts-url">Tile URL template</Label>
+            <Label htmlFor="wmts-url">{t("addData.common.tileUrlTemplate")}</Label>
             <Input
               id="wmts-url"
-              placeholder="https://example.com/wmts/{z}/{y}/{x}.png"
+              placeholder={t("addData.wmts.urlPlaceholder")}
               value={wmtsUrl}
               onChange={(event) => setWmtsUrl(event.target.value)}
             />
           </div>
           <div className="space-y-1.5">
-            <Label htmlFor="wmts-tile-size">Tile size</Label>
+            <Label htmlFor="wmts-tile-size">{t("addData.common.tileSize")}</Label>
             <Input
               id="wmts-tile-size"
               inputMode="numeric"

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/XyzSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/XyzSource.tsx
@@ -1,5 +1,6 @@
 import { Input, Label } from "@geolibre/ui";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import {
   createXyzTileUrlTemplate,
   registerXyzTileProtocol,
@@ -16,7 +17,8 @@ import {
 import { AddDataSourceForm, useAddDataSource } from "../shared";
 
 export function XyzSource() {
-  const source = useAddDataSource("XYZ Layer");
+  const { t } = useTranslation();
+  const source = useAddDataSource(t("addData.xyz.defaultName"));
   const [xyzUrl, setXyzUrl] = useState(DEFAULT_XYZ_URL);
   const [xyzTileSize, setXyzTileSize] = useState("256");
   const [xyzShortUrl, setXyzShortUrl] = useState(false);
@@ -34,8 +36,8 @@ export function XyzSource() {
   };
 
   const handleSubmit = source.runSubmit(async () => {
-    const name = source.layerName.trim() || "XYZ Layer";
-    if (!xyzUrl.trim()) throw new Error("Enter an XYZ tile URL template.");
+    const name = source.layerName.trim() || t("addData.xyz.defaultName");
+    if (!xyzUrl.trim()) throw new Error(t("addData.xyz.errorUrl"));
     if (xyzShortUrl) registerXyzTileProtocol();
     const tileUrl = xyzShortUrl
       ? await resolveXyzTileUrlTemplate(xyzUrl)
@@ -81,20 +83,20 @@ export function XyzSource() {
         />
         <div className="grid gap-3 sm:grid-cols-[1fr_7rem]">
           <div className="space-y-1.5">
-            <Label htmlFor="xyz-url">Tile URL template</Label>
+            <Label htmlFor="xyz-url">{t("addData.common.tileUrlTemplate")}</Label>
             <Input
               id="xyz-url"
               placeholder={
                 xyzShortUrl
-                  ? "https://go.example.com/layer"
-                  : "https://example.com/{z}/{x}/{y}.png"
+                  ? t("addData.xyz.shortUrlPlaceholder")
+                  : t("addData.xyz.urlPlaceholder")
               }
               value={xyzUrl}
               onChange={(event) => setXyzUrl(event.target.value)}
             />
           </div>
           <div className="space-y-1.5">
-            <Label htmlFor="xyz-tile-size">Tile size</Label>
+            <Label htmlFor="xyz-tile-size">{t("addData.common.tileSize")}</Label>
             <Input
               id="xyz-tile-size"
               inputMode="numeric"
@@ -109,7 +111,7 @@ export function XyzSource() {
             checked={xyzShortUrl}
             onChange={(event) => setXyzShortUrl(event.target.checked)}
           />
-          Short URL
+          {t("addData.xyz.shortUrl")}
         </label>
       </div>
     </AddDataSourceForm>

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -101,9 +101,10 @@
       "errorTooLarge": "File is too large to import (max 5 MB).",
       "errorNoServices": "No valid services found in that file.",
       "errorRead": "Could not read that file as a service library.",
-      "imported_one": "Imported {{count}} service{{suffix}}.",
-      "imported_other": "Imported {{count}} services{{suffix}}.",
-      "importedDropped": " ({{dropped}} skipped — library full)"
+      "imported_one": "Imported {{count}} service.",
+      "imported_other": "Imported {{count}} services.",
+      "importedWithDropped_one": "Imported {{count}} service ({{dropped}} skipped — library full).",
+      "importedWithDropped_other": "Imported {{count}} services ({{dropped}} skipped — library full)."
     },
     "xyz": {
       "defaultName": "XYZ Layer",
@@ -131,7 +132,8 @@
       "version": "Version",
       "outputFormat": "Output format",
       "srsName": "SRS name",
-      "maxFeatures": "Max features"
+      "maxFeatures": "Max features",
+      "errorMaxFeaturesNumeric": "Enter a numeric max features value."
     },
     "wmts": {
       "defaultName": "WMTS Layer",
@@ -231,6 +233,14 @@
       "defaultName": "Video Layer",
       "errorUrl": "Enter a video URL.",
       "errorHttps": "Video URLs must start with https://.",
+      "cornerTopLeft": "top-left",
+      "cornerTopRight": "top-right",
+      "cornerBottomRight": "bottom-right",
+      "cornerBottomLeft": "bottom-left",
+      "errorCornerFormat": "Enter the {{corner}} corner as \"longitude, latitude\".",
+      "errorCornerNumber": "Enter a numeric {{corner}} longitude and latitude.",
+      "errorCornerLng": "{{corner}} longitude must be between -180 and 180.",
+      "errorCornerLat": "{{corner}} latitude must be between -90 and 90.",
       "primaryUrl": "Primary video URL",
       "primaryUrlPlaceholder": "https://example.com/clip.mp4",
       "fallbackUrl": "Fallback video URL (optional)",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -103,7 +103,7 @@
       "errorRead": "Could not read that file as a service library.",
       "imported_one": "Imported {{count}} service{{suffix}}.",
       "imported_other": "Imported {{count}} services{{suffix}}.",
-      "importedDropped": " ({{count}} skipped — library full)"
+      "importedDropped": " ({{dropped}} skipped — library full)"
     },
     "xyz": {
       "defaultName": "XYZ Layer",
@@ -253,10 +253,11 @@
       "errorExample": "Could not load the example data.",
       "loadedFeatures_one": "Loaded {{count}} feature.",
       "loadedFeatures_other": "Loaded {{count}} features.",
-      "loadedRows_one": "Loaded {{count}} row",
-      "loadedRows_other": "Loaded {{count}} rows",
+      "loadedRows_one": "{{count}} row",
+      "loadedRows_other": "{{count}} rows",
       "loadedColumns_one": "{{count}} column",
       "loadedColumns_other": "{{count}} columns",
+      "loadedTabular": "Loaded {{rows}} · {{columns}}.",
       "errorLoad": "Could not load the data.",
       "errorLoadFirst": "Load the example data, or a file/URL, first.",
       "useExample": "Use example data",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -8,6 +8,274 @@
     "add": "Add",
     "ok": "OK"
   },
+  "addData": {
+    "title": "Add Data",
+    "kind": {
+      "xyz": {
+        "label": "Add XYZ Layer",
+        "description": "Add a raster tile template using x, y, and z placeholders."
+      },
+      "wms": {
+        "label": "Add WMS Layer",
+        "description": "Add a WMS GetMap service as a tiled raster layer."
+      },
+      "wfs": {
+        "label": "Add WFS Layer",
+        "description": "Add WFS features by requesting GeoJSON from a GetFeature service."
+      },
+      "wmts": {
+        "label": "Add WMTS Layer",
+        "description": "Add a WMTS tile URL template as a raster layer."
+      },
+      "gpx": {
+        "label": "Add GPX Layer",
+        "description": "Add GPX waypoints, routes, and tracks as one or more vector layers."
+      },
+      "delimitedText": {
+        "label": "Add Delimited Text Layer",
+        "description": "Add a delimited text file or URL as a point layer using longitude and latitude fields."
+      },
+      "mbtiles": {
+        "label": "Add MBTiles Layer",
+        "description": "Add a local MBTiles file as a raster or vector tile layer."
+      },
+      "arcgis": {
+        "label": "Add ArcGIS Layer",
+        "description": "Add an ArcGIS FeatureServer layer, VectorTileServer layer, or portal item."
+      },
+      "postgres": {
+        "label": "Add PostgreSQL Layer",
+        "description": "Start Martin locally, discover PostGIS sources, and add a source as vector tiles."
+      },
+      "deckglViz": {
+        "label": "Add Deck.gl Layer",
+        "description": "Pick a deck.gl layer type, then load the example data or upload a CSV/JSON/GeoJSON file or URL."
+      },
+      "video": {
+        "label": "Add Video Layer",
+        "description": "Add a georeferenced video overlay by supplying an MP4 URL and four corner coordinates."
+      }
+    },
+    "shared": {
+      "layerName": "Layer name",
+      "insertBefore": "Insert before",
+      "insertTop": "Top of layer list (default)",
+      "layersGroup": "Layers",
+      "basemapLayersGroup": "Basemap layers",
+      "addLayer": "Add layer",
+      "adding": "Adding…",
+      "addError": "Could not add layer."
+    },
+    "common": {
+      "serviceUrl": "Service URL",
+      "tileSize": "Tile size",
+      "tileUrlTemplate": "Tile URL template",
+      "sourceType": "Source type",
+      "layerType": "Layer type",
+      "format": "Format",
+      "optional": "Optional",
+      "chooseFile": "Choose file",
+      "noFileSelected": "No file selected",
+      "loading": "Loading...",
+      "workspaceLayerPlaceholder": "workspace:layer",
+      "requestFailed": "Request failed with status {{status}}"
+    },
+    "serviceLibrary": {
+      "title": "Saved services",
+      "saveCurrent": "Save current",
+      "importLibrary": "Import library from JSON",
+      "exportLibrary": "Export library to JSON",
+      "loadAria": "Load a saved service",
+      "loadPlaceholder": "Load a saved service…",
+      "builtin": "{{name}} (built-in)",
+      "deleteAria": "Delete saved service",
+      "empty": "No saved services yet — fill in the form and choose “Save current”.",
+      "name": "Name",
+      "category": "Category",
+      "categoryPlaceholder": "Optional (e.g. country, theme)",
+      "uncategorized": "Uncategorized",
+      "errorName": "Enter a name for the saved service.",
+      "saved": "Saved \"{{name}}\" to the service library.",
+      "removed": "Removed \"{{name}}\".",
+      "errorExport": "Could not export library.",
+      "errorTooLarge": "File is too large to import (max 5 MB).",
+      "errorNoServices": "No valid services found in that file.",
+      "errorRead": "Could not read that file as a service library.",
+      "imported_one": "Imported {{count}} service{{suffix}}.",
+      "imported_other": "Imported {{count}} services{{suffix}}.",
+      "importedDropped": " ({{count}} skipped — library full)"
+    },
+    "xyz": {
+      "defaultName": "XYZ Layer",
+      "errorUrl": "Enter an XYZ tile URL template.",
+      "urlPlaceholder": "https://example.com/{z}/{x}/{y}.png",
+      "shortUrlPlaceholder": "https://go.example.com/layer",
+      "shortUrl": "Short URL"
+    },
+    "wms": {
+      "defaultName": "WMS Layer",
+      "errorUrl": "Enter a WMS service URL.",
+      "errorLayers": "Enter one or more WMS layer names.",
+      "urlPlaceholder": "https://example.com/geoserver/wms",
+      "layers": "Layers",
+      "styles": "Styles",
+      "transparent": "Transparent background"
+    },
+    "wfs": {
+      "defaultName": "WFS Layer",
+      "errorUrl": "Enter a WFS service URL.",
+      "errorTypeName": "Enter a WFS feature type name.",
+      "errorOutputFormat": "Enter a WFS output format.",
+      "urlPlaceholder": "https://example.com/geoserver/wfs",
+      "featureType": "Feature type",
+      "version": "Version",
+      "outputFormat": "Output format",
+      "srsName": "SRS name",
+      "maxFeatures": "Max features"
+    },
+    "wmts": {
+      "defaultName": "WMTS Layer",
+      "errorUrl": "Enter a WMTS tile URL template.",
+      "urlPlaceholder": "https://example.com/wmts/{z}/{y}/{x}.png"
+    },
+    "arcgis": {
+      "defaultName": "ArcGIS Layer",
+      "featureLayer": "Feature layer",
+      "vectorTileLayer": "Vector tile layer",
+      "portalItemId": "Portal item ID",
+      "featureUrlPlaceholder": "https://services.arcgis.com/.../FeatureServer/0",
+      "vectorTileUrlPlaceholder": "https://.../arcgis/rest/services/.../VectorTileServer",
+      "portalUrl": "Portal URL",
+      "portalUrlPlaceholder": "https://www.arcgis.com/sharing/rest",
+      "accessToken": "Access token"
+    },
+    "gpx": {
+      "defaultName": "GPX Layer",
+      "errorFileMissing": "GPX file data is missing.",
+      "readError": "Could not read GPX file.",
+      "errorChooseFile": "Choose a GPX file.",
+      "errorUrl": "Enter a GPX URL.",
+      "errorSelectType": "Select at least one GPX layer type.",
+      "errorNotFound": "The selected GPX layer types were not found.",
+      "waypoints": "Waypoints",
+      "tracks": "Tracks",
+      "routes": "Routes",
+      "url": "GPX URL",
+      "file": "GPX file",
+      "urlPlaceholder": "https://example.com/route.gpx",
+      "layerTypes": "Layer types"
+    },
+    "delimitedText": {
+      "defaultName": "Delimited Text Layer",
+      "errorChooseFile": "Choose a delimited text file.",
+      "errorUrl": "Enter a delimited text URL.",
+      "errorFileMissing": "Delimited text file data is missing.",
+      "readError": "Could not read delimited text file.",
+      "errorDataMissing": "Delimited text data is missing.",
+      "retrievedColumns_one": "Retrieved {{count}} column.",
+      "retrievedColumns_other": "Retrieved {{count}} columns.",
+      "errorRetrieveColumns": "Could not retrieve column names.",
+      "url": "Delimited text URL",
+      "file": "Delimited text file",
+      "urlPlaceholder": "https://example.com/data.csv",
+      "retrieving": "Retrieving...",
+      "retrieveColumns": "Retrieve columns",
+      "delimiter": "Delimiter",
+      "delimiterComma": "Comma",
+      "delimiterTab": "Tab",
+      "delimiterSemicolon": "Semicolon",
+      "delimiterPipe": "Pipe",
+      "delimiterCustom": "Custom",
+      "customDelimiter": "Custom delimiter",
+      "longitudeField": "Longitude field",
+      "latitudeField": "Latitude field"
+    },
+    "mbtiles": {
+      "defaultName": "MBTiles Layer",
+      "readError": "Could not read MBTiles file.",
+      "errorChooseFile": "Choose an MBTiles file.",
+      "errorSourceLayers": "Enter at least one vector source layer.",
+      "tileType": "Tile type",
+      "sourceLayers": "Source layers",
+      "sourceLayersPlaceholder": "building, place, water"
+    },
+    "postgres": {
+      "defaultName": "PostgreSQL Layer",
+      "errorDesktopOnly": "PostgreSQL layers require GeoLibre Desktop.",
+      "errorConnectionString": "Enter a PostgreSQL connection string.",
+      "statusCheckingBinary": "Checking Martin binary...",
+      "statusDownloaded": "Martin downloaded. Starting local server...",
+      "statusStarting": "Starting local Martin server...",
+      "statusReadingCatalog": "Reading Martin catalog...",
+      "statusFound_one": "Found {{count}} source.",
+      "statusFound_other": "Found {{count}} sources.",
+      "statusNoSources": "Martin is running, but no compatible PostGIS sources were found.",
+      "errorConnect": "Could not connect to PostgreSQL.",
+      "statusStopped": "Martin stopped.",
+      "errorStop": "Could not stop Martin.",
+      "errorConnectFirst": "Connect to PostgreSQL first.",
+      "errorNoVectorLayers": "The selected Martin source has no vector layers.",
+      "errorSelectSource": "Select a Martin source to add.",
+      "desktopOnlyNotice": "PostgreSQL layers are only available in GeoLibre Desktop. This feature runs a local Martin tile server, which the web app cannot launch.",
+      "savedConnection": "Saved connection",
+      "selectSavedConnection": "Select saved connection",
+      "connectionString": "PostgreSQL connection string",
+      "connectionStringPlaceholder": "postgres://user:password@host:5432/database",
+      "defaultSrid": "Default SRID",
+      "connect": "Connect",
+      "stop": "Stop",
+      "martinSource": "Martin source",
+      "runningOnPort": "Martin is running on port {{port}}."
+    },
+    "video": {
+      "defaultName": "Video Layer",
+      "errorUrl": "Enter a video URL.",
+      "errorHttps": "Video URLs must start with https://.",
+      "primaryUrl": "Primary video URL",
+      "primaryUrlPlaceholder": "https://example.com/clip.mp4",
+      "fallbackUrl": "Fallback video URL (optional)",
+      "fallbackUrlPlaceholder": "https://example.com/clip.webm",
+      "topLeft": "Top-left (lng, lat)",
+      "topRight": "Top-right (lng, lat)",
+      "bottomRight": "Bottom-right (lng, lat)",
+      "bottomLeft": "Bottom-left (lng, lat)",
+      "cornersNote": "The four corners georeference the video on the map. The video must be served over HTTPS and the host must allow cross-origin requests (CORS) for the frames to render."
+    },
+    "deckViz": {
+      "defaultName": "Deck.gl Layer",
+      "errorChooseFile": "Choose a CSV, JSON, or GeoJSON file.",
+      "errorUrl": "Enter a data URL.",
+      "errorUnknownType": "Unknown layer type.",
+      "needsGeojson": "{{label}} needs a GeoJSON file.",
+      "needsTabular": "{{label}} needs tabular CSV/JSON data, not GeoJSON.",
+      "mapRequiredFields_one": "Map the required field: {{fields}}.",
+      "mapRequiredFields_other": "Map the required fields: {{fields}}.",
+      "errorExample": "Could not load the example data.",
+      "loadedFeatures_one": "Loaded {{count}} feature.",
+      "loadedFeatures_other": "Loaded {{count}} features.",
+      "loadedRows_one": "Loaded {{count}} row",
+      "loadedRows_other": "Loaded {{count}} rows",
+      "loadedColumns_one": "{{count}} column",
+      "loadedColumns_other": "{{count}} columns",
+      "errorLoad": "Could not load the data.",
+      "errorLoadFirst": "Load the example data, or a file/URL, first.",
+      "useExample": "Use example data",
+      "loadYourOwn": "Or load your own",
+      "dataUrl": "Data URL",
+      "localFile": "Local file",
+      "urlPlaceholder": "https://example.com/data.csv",
+      "chooseFileLoad": "Choose file & load",
+      "loadData": "Load data",
+      "selectRole": "— select —",
+      "roleNone": "(none)",
+      "color": "Color",
+      "pointSize": "Point size",
+      "cellSize": "Cell size",
+      "lineWidth": "Line width",
+      "extrusion": "3D extrusion",
+      "modelUrlPlaceholder": "https://example.com/model.glb"
+    }
+  },
   "offline": {
     "title": "Download Offline Area",
     "description": "Save the current map view's basemap tiles so this area keeps working without a network connection.",

--- a/tests/add-data-i18n.test.ts
+++ b/tests/add-data-i18n.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+
+import { KIND_I18N_KEY } from "../apps/geolibre-desktop/src/components/layout/add-data/constants";
+
+// The Add Data dialog resolves its title/description with a runtime-interpolated
+// key (`t(`addData.kind.${KIND_I18N_KEY[kind]}.label`)`), which TypeScript and
+// i18next's typed `t` cannot validate against en.json. Guard the full key shape
+// here so a renamed/removed `addData.kind.*` subtree fails CI instead of
+// silently rendering the raw key at runtime.
+const en = JSON.parse(
+  readFileSync(
+    fileURLToPath(
+      new URL("../apps/geolibre-desktop/src/i18n/locales/en.json", import.meta.url),
+    ),
+    "utf8",
+  ),
+) as { addData: { kind: Record<string, { label?: string; description?: string }> } };
+
+describe("Add Data dialog kind i18n keys", () => {
+  for (const [kind, key] of Object.entries(KIND_I18N_KEY)) {
+    it(`${kind}: addData.kind.${key} has a label and description`, () => {
+      const entry = en.addData.kind[key];
+      assert.ok(entry, `addData.kind.${key} is missing from en.json`);
+      assert.equal(
+        typeof entry.label,
+        "string",
+        `addData.kind.${key}.label is missing or not a string`,
+      );
+      assert.ok(entry.label, `addData.kind.${key}.label is empty`);
+      assert.equal(
+        typeof entry.description,
+        "string",
+        `addData.kind.${key}.description is missing or not a string`,
+      );
+      assert.ok(entry.description, `addData.kind.${key}.description is empty`);
+    });
+  }
+});

--- a/tests/add-data-i18n.test.ts
+++ b/tests/add-data-i18n.test.ts
@@ -29,13 +29,19 @@ describe("Add Data dialog kind i18n keys", () => {
         "string",
         `addData.kind.${key}.label is missing or not a string`,
       );
-      assert.ok(entry.label, `addData.kind.${key}.label is empty`);
+      assert.ok(
+        entry.label.trim().length > 0,
+        `addData.kind.${key}.label is empty`,
+      );
       assert.equal(
         typeof entry.description,
         "string",
         `addData.kind.${key}.description is missing or not a string`,
       );
-      assert.ok(entry.description, `addData.kind.${key}.description is empty`);
+      assert.ok(
+        entry.description.trim().length > 0,
+        `addData.kind.${key}.description is empty`,
+      );
     });
   }
 });


### PR DESCRIPTION
## Summary

Internationalizes the **entire Add Data dialog** as one consistent unit (per the maintainer decision in #427), moving every hardcoded English string to `react-i18next` under a new `addData.*` namespace. `en.json` is the source of truth; other locales fall back to English until translated.

Follow-up to #423 / #417.

## What changed

- **Shell** (`AddDataDialog.tsx` + `constants.ts`): replaced `KIND_LABELS` / `KIND_DESCRIPTIONS` with a `KIND_I18N_KEY` map; the title/description now resolve via `t("addData.kind.<key>.{label,description}")`.
- **Shared chrome** (`shared.tsx`): layer name, insert-before (incl. optgroup labels and the default option), and footer (`Add layer` / `Adding…` / reused `common.cancel`).
- **Service library** (`ServiceLibrarySection.tsx`): title, buttons, aria/title labels, the saved/removed/imported notices (with plural + interpolation), and the `Uncategorized` grouping label. The `UNCATEGORIZED_LABEL` constant stays as an internal grouping sentinel and is translated only at render.
- **All 11 source forms** (`Xyz`, `Wms`, `Wfs`, `Wmts`, `ArcGIS`, `Gpx`, `DelimitedText`, `Mbtiles`, `Postgres`, `Video`, `DeckViz`): labels, placeholders, select options, button states, status notices, and the validation errors thrown in each submit handler. Shared strings (`Service URL`, `Tile size`, `Source type`, `Choose file`, `Optional`, `Request failed with status {{status}}`, …) live under `addData.common.*`; reuses `common.save` / `common.cancel`.

## Notes / scope

- Default layer names (e.g. `"WMS Layer"`) now resolve through `t()`, so newly added layers get a localized default name (still user-editable).
- Pure helpers in `helpers.ts` (`parseRequiredNumber`, `parseVideoCorner`, …) are intentionally left as-is: they are technical, framework-agnostic, and covered by unit tests asserting their English messages. The web-service format identifiers (`PNG`/`JPEG`) and numeric coordinate example placeholders are also left verbatim.
- Typing is automatic via `i18next.d.ts` (keys checked against `en.json`).

## Testing

- `npm run typecheck` — no new type errors from this change. (There are 5 pre-existing, unrelated errors in `packages/plugins/src/plugins/maplibre-basemap-control.ts` about a `basemapremove` event not present in `maplibre-gl-layer-control@0.16.0`'s types; confirmed identical on a clean `main`, so not introduced here.)
- `node --test` over `add-data-helpers`, `service-library`, `web-service-sync` — **51/51 pass**.
- eslint: 0 errors in the touched files; pre-commit formatting hooks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full internationalization for the “Add Data” workflow, including the dialog title/description, layer “kind” picker, all data source configuration screens (XYZ, WMS, WFS, WMTS, GPX, Delimited Text, MBTiles, ArcGIS, PostgreSQL, Video, Deck.gl), and the Saved Services library (headings, controls, notices, and validation/error messages).
* **Tests**
  * Added a CI test that verifies the English i18n entries for every layer kind have non-empty `label` and `description` text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->