### PR TITLE
refactor(maplibre-effects): render atmosphere behind the globe

### DIFF
--- a/packages/plugins/src/plugins/maplibre-effects.ts
+++ b/packages/plugins/src/plugins/maplibre-effects.ts
@@ -4,73 +4,36 @@ import type { GeoLibreAppAPI, GeoLibrePlugin } from "../types";
 /**
  * GeoLibre atmosphere & particle effects plugin.
  *
- * Stacks a few transparent Canvas 2D overlays over the MapLibre globe to give
- * it a sense of place in space: a deep-space backdrop, a parallax starfield,
+ * Stacks transparent Canvas 2D layers behind the MapLibre globe to give it a
+ * sense of place in space: a deep-space backdrop, tiled parallax starfield,
  * occasional comets (shooting stars), and an atmospheric halo aligned to the
- * projected globe limb. The effects only render in globe projection at low
- * zoom and fade out as you zoom in, so they never interfere with normal map
- * work. A toolbar toggle turns the whole stack on or off, and the on/off state
- * is saved with the project.
+ * projected globe. The effects render only while the map is in globe projection,
+ * so they never interfere with normal map work. A toolbar toggle turns the
+ * whole stack on or off, and the on/off state is saved with the project.
  *
  * The technique and visual design are adapted, with thanks, from Leonel Dias's
  * article "Globe atmosphere, halo, and comets":
  * https://leoneljdias.github.io/posts/globe-atmosphere-halo-comets/
  * — specifically the layered Canvas 2D approach, the halo gradient stops and
  * "screen" blend, and the starfield/comet parameters. Re-implemented for
- * GeoLibre's plugin lifecycle (single on-top canvas that punches out the globe
- * silhouette so the effects show only around the globe regardless of the active
- * basemap).
- *
- * The silhouette is recovered by sampling the *rendered* globe limb (see
- * {@link getGlobeEllipse}) and fitting an ellipse, rather than projecting a fixed
- * great-circle limb from the map center. Under MapLibre's perspective globe the
- * visible silhouette is an ellipse that is smaller than the 90° limb and offset
- * from the screen center under pitch, so the fitted ellipse keeps the halo and
- * punch-out hugging the globe at any zoom, pitch, and bearing.
+ * GeoLibre's plugin lifecycle (background canvases behind the MapLibre canvas
+ * so the effects show through the globe projection's transparent space without
+ * masking the map).
  */
 
 export const EFFECTS_PLUGIN_ID = "maplibre-atmosphere-effects";
 
-// Effects are fully visible at/below ZOOM_FADE_START and fully hidden at/above
-// ZOOM_FADE_END, with a linear fade between (the reference gates around zoom
-// 3.5 — we fade across it so the transition is not abrupt).
-const ZOOM_FADE_START = 2.5;
-const ZOOM_FADE_END = 4.5;
-
 // Roughly one star per this many CSS pixels of starfield area.
 const STAR_AREA_PER_STAR = 900;
-// Extra margin (CSS px) around the viewport for the starfield so a small
-// parallax translation never exposes an unpainted edge.
-const STARFIELD_MARGIN = 80;
-// Pixels of parallax drift applied per degree of map-center movement.
-const PARALLAX_PX_PER_DEGREE = 0.6;
+// Starfield parallax scales exactly like the reference: a full 360° longitude
+// pan shifts one viewport width, and a 180° latitude pan shifts one height.
+const STARFIELD_LNG_PERIOD_DEGREES = 360;
+const STARFIELD_LAT_PERIOD_DEGREES = 180;
 
 // Halo radial gradient — color stops are fractions of the gradient span, which
 // runs from the globe edge out to HALO_RADIUS_SCALE × the globe radius.
 const HALO_RADIUS_SCALE = 2.8;
-// The 2D overlay edge and the WebGL globe edge are rasterized independently, so
-// a hard punch-out at the limb leaves a thin seam wherever the two disagree by a
-// sub-pixel — the dark space gradient bleeds onto the globe rim (a dark line) or
-// the page background shows through (a light one), most visible on HiDPI
-// displays. Rather than insetting the punch-out (which drapes dark space over a
-// zoom-proportional band of the globe that the faded high-zoom halo can't
-// repaint), feather its edge: the destination-out alpha is solid out to
-// PUNCH_FADE_INNER × the limb and ramps to zero by PUNCH_FADE_OUTER × the limb.
-// The globe is revealed in full, and the soft edge straddling the limb hides the
-// sub-pixel mismatch without a visible band. Fractions of the fitted limb, so
-// the feather stays a roughly constant share of the rim at every zoom.
-const PUNCH_FADE_INNER = 0.99;
-const PUNCH_FADE_OUTER = 1.012;
-// Globe-silhouette sampling: rays cast from the projected map center, each
-// bisected to the rendered limb. The silhouette is a conic (a circle top-down,
-// an ellipse under pitch), so a handful of rays over-determine the 3-parameter
-// ellipse fit; the bisection depth pins each limb crossing to sub-pixel.
-const SILHOUETTE_RAYS = 24;
-const SILHOUETTE_BISECTIONS = 18;
-// A screen point is "on the globe" when it round-trips through unproject→project
-// to within this many pixels; points off the globe clamp to the limb and miss by
-// tens to hundreds of pixels, so the threshold is not sensitive.
-const ON_GLOBE_TOLERANCE_PX = 1;
+const HALO_SAMPLE_COUNT = 16;
 const HALO_STOPS: Array<[number, string]> = [
   [0.0, "rgba(200, 235, 255, 1.0)"],
   [0.03, "rgba(130, 200, 250, 0.6)"],
@@ -95,8 +58,15 @@ interface Comet {
   len: number;
   speed: number;
   angle: number;
+  alpha: number;
   life: number;
   maxLife: number;
+}
+
+interface GlobeCircle {
+  x: number;
+  y: number;
+  radius: number;
 }
 
 export interface GlobeEllipse {
@@ -108,10 +78,6 @@ export interface GlobeEllipse {
   ry: number;
   // Rotation of the rx axis, radians.
   angle: number;
-}
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(max, Math.max(min, value));
 }
 
 function isGlobeProjection(map: MapLibreMap): boolean {
@@ -128,98 +94,66 @@ function isGlobeProjection(map: MapLibreMap): boolean {
   }
 }
 
-/**
- * Is this screen point on the rendered globe?
- *
- * MapLibre's `unproject` clamps points outside the globe to the nearest limb
- * location, so an off-globe pixel does not round-trip back to itself through
- * `project`. On-globe pixels round-trip to within a pixel; off-globe pixels miss
- * by tens to hundreds of pixels. This is the only signal we have for the
- * *rendered* silhouette, which (under perspective + pitch) is neither the
- * geometric 90° limb nor centered on the projected map center.
- */
-function isOnGlobe(map: MapLibreMap, x: number, y: number): boolean {
-  const back = map.project(map.unproject([x, y]));
-  return Math.hypot(back.x - x, back.y - y) <= ON_GLOBE_TOLERANCE_PX;
-}
+function getGeoglifyGlobeCircle(map: MapLibreMap): GlobeCircle {
+  const center = map.getCenter();
+  const lngRad = (center.lng * Math.PI) / 180;
+  const latRad = (center.lat * Math.PI) / 180;
+  const points: Array<{ x: number; y: number }> = [];
 
-/**
- * Distance from (cx,cy) along (dx,dy) to the globe limb, by bisection.
- *
- * Assumes the start point is on the globe; expands until a point is off-globe,
- * then bisects the on/off boundary. `maxR` caps the search so a globe larger
- * than the search window (very rare in the effect's low-zoom range) terminates.
- *
- * `seedR` is the previous frame's limb radius. During a pan/zoom the limb moves
- * little between frames, so starting the doubling phase there usually brackets
- * the limb in zero or one steps instead of climbing from 8px — the bisection
- * still pins it to sub-pixel regardless. `lo = 0` (the on-globe center) stays a
- * valid lower bound whether the seed lands inside or outside the limb.
- */
-function rayToLimb(
-  map: MapLibreMap,
-  cx: number,
-  cy: number,
-  dx: number,
-  dy: number,
-  maxR: number,
-  seedR: number,
-): number {
-  let lo = 0;
-  let hi = seedR > 0 ? Math.min(seedR, maxR) : 8;
-  while (hi < maxR && isOnGlobe(map, cx + dx * hi, cy + dy * hi)) {
-    lo = hi;
-    hi *= 2;
-  }
-  if (hi > maxR) hi = maxR;
-  for (let i = 0; i < SILHOUETTE_BISECTIONS; i++) {
-    const mid = (lo + hi) / 2;
-    if (isOnGlobe(map, cx + dx * mid, cy + dy * mid)) lo = mid;
-    else hi = mid;
-  }
-  return lo;
-}
-
-/**
- * The rendered globe silhouette as a screen-space ellipse.
- *
- * Casts {@link SILHOUETTE_RAYS} rays from the projected map center (always
- * inside the silhouette) out to the rendered limb, then fits an ellipse to those
- * limb points. The silhouette of a sphere under a pinhole camera is exactly a
- * conic — a circle when viewed top-down, an ellipse under pitch — so {@link
- * fitEllipse} recovers the center, axes, and rotation exactly. This tracks the
- * globe under any zoom, pitch, and bearing, unlike a fixed great-circle limb
- * measured from the map center. `seedRadius` (the previous frame's limb radius,
- * or 0) just speeds up the ray search. Returns null when the globe is off-screen
- * or larger than the search window.
- */
-function getGlobeEllipse(
-  map: MapLibreMap,
-  seedRadius: number,
-): GlobeEllipse | null {
-  const center = map.project(map.getCenter());
-  const cx = center.x;
-  const cy = center.y;
-  if (!Number.isFinite(cx) || !Number.isFinite(cy)) return null;
-  if (!isOnGlobe(map, cx, cy)) return null;
-
-  const canvas = map.getCanvas();
-  const maxR = Math.max(canvas.clientWidth, canvas.clientHeight) * 8;
-
-  const pts: Array<[number, number]> = [];
-  for (let i = 0; i < SILHOUETTE_RAYS; i++) {
-    const a = (i / SILHOUETTE_RAYS) * 2 * Math.PI;
-    const dx = Math.cos(a);
-    const dy = Math.sin(a);
-    const r = rayToLimb(map, cx, cy, dx, dy, maxR, seedRadius);
-    // A ray that never leaves the globe within the window means the globe is
-    // larger than 8× the viewport (vanishingly rare before the effect fades at
-    // zoom ≈ 4.5). The clustered points would fit a huge bogus ellipse, so bail.
-    if (r >= maxR) return null;
-    pts.push([cx + dx * r, cy + dy * r]);
+  for (let i = 0; i < HALO_SAMPLE_COUNT; i++) {
+    const bearing = (i / HALO_SAMPLE_COUNT) * Math.PI * 2;
+    const angularDistance = Math.PI / 2;
+    const sampleLat = Math.asin(
+      Math.sin(latRad) * Math.cos(angularDistance) +
+        Math.cos(latRad) * Math.sin(angularDistance) * Math.cos(bearing),
+    );
+    const sampleLng =
+      lngRad +
+      Math.atan2(
+        Math.sin(bearing) * Math.sin(angularDistance) * Math.cos(latRad),
+        Math.cos(angularDistance) - Math.sin(latRad) * Math.sin(sampleLat),
+      );
+    const projected = map.project([
+      (sampleLng * 180) / Math.PI,
+      (sampleLat * 180) / Math.PI,
+    ]);
+    if (Number.isFinite(projected.x) && Number.isFinite(projected.y)) {
+      points.push(projected);
+    }
   }
 
-  return fitEllipse(pts);
+  if (points.length < 3) {
+    const projectedCenter = map.project(center);
+    const projectedEdge = map.project([center.lng + 90, 0]);
+    return {
+      x: projectedCenter.x,
+      y: projectedCenter.y,
+      radius: Math.max(
+        Math.hypot(
+          projectedCenter.x - projectedEdge.x,
+          projectedCenter.y - projectedEdge.y,
+        ),
+        1,
+      ),
+    };
+  }
+
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minY = Infinity;
+  let maxY = -Infinity;
+  for (const point of points) {
+    minX = Math.min(minX, point.x);
+    maxX = Math.max(maxX, point.x);
+    minY = Math.min(minY, point.y);
+    maxY = Math.max(maxY, point.y);
+  }
+
+  return {
+    x: (minX + maxX) / 2,
+    y: (minY + maxY) / 2,
+    radius: Math.max(maxX - minX, maxY - minY) / 2,
+  };
 }
 
 /**
@@ -347,9 +281,17 @@ function solveLinear(m: number[][], b: number[]): number[] | null {
 class EffectsEngine {
   private readonly map: MapLibreMap;
   private readonly spaceCanvas: HTMLCanvasElement;
+  private readonly starsCanvas: HTMLCanvasElement;
+  private readonly cometCanvas: HTMLCanvasElement;
   private readonly haloCanvas: HTMLCanvasElement;
   private readonly spaceCtx: CanvasRenderingContext2D;
+  private readonly starsCtx: CanvasRenderingContext2D;
+  private readonly cometCtx: CanvasRenderingContext2D;
   private readonly haloCtx: CanvasRenderingContext2D;
+  private readonly mapCanvas: HTMLCanvasElement;
+  private readonly previousMapCanvasZIndex: string;
+  private readonly controlContainer: HTMLElement | null;
+  private readonly previousControlContainerZIndex: string;
 
   private starfield: HTMLCanvasElement | null = null;
   private starfieldOriginLng = 0;
@@ -361,31 +303,37 @@ class EffectsEngine {
   private width = 0;
   private height = 0;
   private dpr = 1;
-
-  // Cached globe silhouette. Fitting it costs many project/unproject round-trips.
-  // It changes on every camera change — so once per frame during an animated
-  // pan/zoom, since MapLibre fires "move" each frame — but a dirty flag (set by
-  // move/resize) skips the recompute on comet/starfield-only frames where the
-  // camera is stationary.
-  private globeEllipse: GlobeEllipse | null = null;
-  private ellipseDirty = true;
-  // Last fitted mean limb radius, fed back as the ray-search seed so the next
-  // recompute (e.g. the next frame of a drag) brackets the limb almost immediately.
-  private lastLimbRadius = 0;
+  private starsDirty = true;
 
   private rafId: number | null = null;
   private destroyed = false;
 
   constructor(map: MapLibreMap) {
     this.map = map;
+    this.mapCanvas = map.getCanvas();
+    this.previousMapCanvasZIndex = this.mapCanvas.style.zIndex;
+    this.controlContainer =
+      this.mapCanvas
+        .closest(".maplibregl-map")
+        ?.querySelector<HTMLElement>(".maplibregl-control-container") ?? null;
+    this.previousControlContainerZIndex =
+      this.controlContainer?.style.zIndex ?? "";
     this.spaceCanvas = this.createCanvas(0);
-    this.haloCanvas = this.createCanvas(1, "screen");
+    this.starsCanvas = this.createCanvas(1);
+    this.cometCanvas = this.createCanvas(2);
+    this.haloCanvas = this.createCanvas(3);
     this.spaceCtx = this.spaceCanvas.getContext("2d")!;
+    this.starsCtx = this.starsCanvas.getContext("2d")!;
+    this.cometCtx = this.cometCanvas.getContext("2d")!;
     this.haloCtx = this.haloCanvas.getContext("2d")!;
 
     const container = map.getCanvasContainer();
     container.appendChild(this.spaceCanvas);
+    container.appendChild(this.starsCanvas);
+    container.appendChild(this.cometCanvas);
     container.appendChild(this.haloCanvas);
+    this.mapCanvas.style.zIndex = "4";
+    if (this.controlContainer) this.controlContainer.style.zIndex = "5";
 
     this.handleResize = this.handleResize.bind(this);
     this.handleVisibility = this.handleVisibility.bind(this);
@@ -413,11 +361,17 @@ class EffectsEngine {
     this.map.off("resize", this.handleResize);
     this.map.off("move", this.handleMapChange);
     document.removeEventListener("visibilitychange", this.handleVisibility);
+    this.mapCanvas.style.zIndex = this.previousMapCanvasZIndex;
+    if (this.controlContainer) {
+      this.controlContainer.style.zIndex = this.previousControlContainerZIndex;
+    }
     this.spaceCanvas.remove();
+    this.starsCanvas.remove();
+    this.cometCanvas.remove();
     this.haloCanvas.remove();
   }
 
-  private createCanvas(zIndex: number, blendMode?: string): HTMLCanvasElement {
+  private createCanvas(zIndex: number): HTMLCanvasElement {
     const canvas = document.createElement("canvas");
     canvas.className = "geolibre-effects-canvas";
     canvas.style.position = "absolute";
@@ -427,11 +381,6 @@ class EffectsEngine {
     // collapses to 0 height, so a percentage height would resolve to 0.
     canvas.style.pointerEvents = "none";
     canvas.style.zIndex = String(zIndex);
-    // The halo screen-blends against the layers below it (space canvas + map)
-    // at the compositor level. This must be a CSS blend on the element: a 2D
-    // context `globalCompositeOperation` would only blend against this canvas's
-    // own pixels, which are cleared transparent each frame (i.e. a no-op).
-    if (blendMode) canvas.style.mixBlendMode = blendMode;
     return canvas;
   }
 
@@ -443,11 +392,10 @@ class EffectsEngine {
     }
   }
 
-  // A move restarts a loop that stopped because the effects had faded out.
-  // MapLibre's "move" fires for pan, zoom, pitch, and rotate, so this also marks
-  // the cached silhouette stale on any camera change.
+  // A move restarts a loop that stopped because the map was not in globe mode.
+  // MapLibre's "move" fires for pan, zoom, pitch, and rotate.
   private handleMapChange(): void {
-    this.ellipseDirty = true;
+    this.starsDirty = true;
     if (!document.hidden) this.start();
   }
 
@@ -456,12 +404,14 @@ class EffectsEngine {
     const mapCanvas = this.map.getCanvas();
     this.width = mapCanvas.clientWidth;
     this.height = mapCanvas.clientHeight;
-    // Cap the backing-store scale at 2× — beyond that the overlay canvases cost
-    // more to clear/redraw each frame than the extra crispness is worth for a
-    // soft glow, so 3×+ displays render the effect (not the map) at 2×.
-    this.dpr = Math.min(window.devicePixelRatio || 1, 2);
+    this.dpr = window.devicePixelRatio || 1;
 
-    for (const ctx of [this.spaceCtx, this.haloCtx]) {
+    for (const ctx of [
+      this.spaceCtx,
+      this.starsCtx,
+      this.cometCtx,
+      this.haloCtx,
+    ]) {
       const canvas = ctx.canvas;
       canvas.style.width = `${this.width}px`;
       canvas.style.height = `${this.height}px`;
@@ -471,7 +421,7 @@ class EffectsEngine {
     }
     this.starfield = null; // regenerate at the new size on the next frame
     this.spaceGradient = null; // rebuild for the new dimensions
-    this.ellipseDirty = true; // silhouette depends on viewport size
+    this.starsDirty = true;
   }
 
   private start(): void {
@@ -487,14 +437,8 @@ class EffectsEngine {
 
   private clear(): void {
     this.spaceCtx.clearRect(0, 0, this.width, this.height);
+    this.cometCtx.clearRect(0, 0, this.width, this.height);
     this.haloCtx.clearRect(0, 0, this.width, this.height);
-  }
-
-  private alphaForZoom(): number {
-    const zoom = this.map.getZoom();
-    if (zoom <= ZOOM_FADE_START) return 1;
-    if (zoom >= ZOOM_FADE_END) return 0;
-    return 1 - (zoom - ZOOM_FADE_START) / (ZOOM_FADE_END - ZOOM_FADE_START);
   }
 
   private ensureStarfield(): void {
@@ -503,8 +447,8 @@ class EffectsEngine {
     this.starfieldOriginLng = center.lng;
     this.starfieldOriginLat = center.lat;
 
-    const fieldWidth = this.width + STARFIELD_MARGIN * 2;
-    const fieldHeight = this.height + STARFIELD_MARGIN * 2;
+    const fieldWidth = this.width;
+    const fieldHeight = this.height;
     const canvas = document.createElement("canvas");
     canvas.width = Math.round(fieldWidth * this.dpr);
     canvas.height = Math.round(fieldHeight * this.dpr);
@@ -538,83 +482,65 @@ class EffectsEngine {
     if (Math.random() > 0.8) {
       color =
         Math.random() > 0.5
-          ? `hsla(220, 70%, 80%, ${star.alpha})`
-          : `hsla(40, 80%, 80%, ${star.alpha})`;
-    }
-    if (star.glow) {
-      const glow = ctx.createRadialGradient(
-        star.x,
-        star.y,
-        0,
-        star.x,
-        star.y,
-        star.size * 3,
-      );
-      glow.addColorStop(0, color);
-      glow.addColorStop(1, "rgba(255, 255, 255, 0)");
-      ctx.fillStyle = glow;
-      ctx.beginPath();
-      ctx.arc(star.x, star.y, star.size * 3, 0, Math.PI * 2);
-      ctx.fill();
+          ? `hsla(220, 30%, 85%, ${star.alpha})`
+          : `hsla(40, 30%, 85%, ${star.alpha})`;
     }
     ctx.fillStyle = color;
     ctx.beginPath();
     ctx.arc(star.x, star.y, star.size, 0, Math.PI * 2);
     ctx.fill();
+    if (star.glow) {
+      ctx.fillStyle = `rgba(200, 220, 255, ${0.12 * star.alpha})`;
+      ctx.beginPath();
+      ctx.arc(star.x, star.y, star.size * 3, 0, Math.PI * 2);
+      ctx.fill();
+    }
   }
 
-  private drawStarfield(alpha: number): void {
+  private drawStarfield(): void {
+    if (this.width <= 0 || this.height <= 0) return;
     this.ensureStarfield();
     if (!this.starfield) return;
     const center = this.map.getCenter();
-    let offsetX = clamp(
-      (center.lng - this.starfieldOriginLng) * PARALLAX_PX_PER_DEGREE,
-      -STARFIELD_MARGIN,
-      STARFIELD_MARGIN,
-    );
-    let offsetY = clamp(
-      (center.lat - this.starfieldOriginLat) * PARALLAX_PX_PER_DEGREE,
-      -STARFIELD_MARGIN,
-      STARFIELD_MARGIN,
-    );
-    // When drift reaches the margin, regenerate so the field re-centers without
-    // ever revealing an unpainted edge.
-    if (
-      Math.abs(offsetX) >= STARFIELD_MARGIN ||
-      Math.abs(offsetY) >= STARFIELD_MARGIN
-    ) {
-      this.starfield = null;
-      this.ensureStarfield();
-      offsetX = 0;
-      offsetY = 0;
-    }
-
+    const offsetX =
+      ((center.lng - this.starfieldOriginLng) /
+        STARFIELD_LNG_PERIOD_DEGREES) *
+      this.width;
+    const offsetY =
+      ((center.lat - this.starfieldOriginLat) /
+        STARFIELD_LAT_PERIOD_DEGREES) *
+      this.height;
+    const wrappedX = ((offsetX % this.width) + this.width) % this.width;
+    const wrappedY = ((offsetY % this.height) + this.height) % this.height;
     const field = this.starfield;
     if (!field) return;
-    this.spaceCtx.save();
-    this.spaceCtx.globalAlpha = alpha;
-    this.spaceCtx.drawImage(
+    const ctx = this.starsCtx;
+    ctx.clearRect(0, 0, this.width, this.height);
+    ctx.drawImage(field, wrappedX, wrappedY, this.width, this.height);
+    ctx.drawImage(field, wrappedX - this.width, wrappedY, this.width, this.height);
+    ctx.drawImage(field, wrappedX, wrappedY - this.height, this.width, this.height);
+    ctx.drawImage(
       field,
-      -STARFIELD_MARGIN + offsetX,
-      -STARFIELD_MARGIN + offsetY,
-      this.width + STARFIELD_MARGIN * 2,
-      this.height + STARFIELD_MARGIN * 2,
+      wrappedX - this.width,
+      wrappedY - this.height,
+      this.width,
+      this.height,
     );
-    this.spaceCtx.restore();
   }
 
-  private updateAndDrawComets(alpha: number): void {
+  private updateAndDrawComets(): void {
     // One comet at a time, spawned with ~0.5% probability per frame.
     if (this.comets.length === 0 && Math.random() < 0.005) {
       this.comets.push(this.spawnComet());
     }
 
-    const ctx = this.spaceCtx;
+    const ctx = this.cometCtx;
     const survivors: Comet[] = [];
     for (const comet of this.comets) {
+      comet.life += 1;
       comet.x += Math.cos(comet.angle) * comet.speed;
       comet.y += Math.sin(comet.angle) * comet.speed;
-      comet.life += 1;
+      comet.alpha = 1 - comet.life / comet.maxLife;
 
       const offscreen =
         comet.x < -comet.len ||
@@ -624,16 +550,11 @@ class EffectsEngine {
       if (comet.life >= comet.maxLife || offscreen) continue;
       survivors.push(comet);
 
-      // Smooth fade in and out across the comet's lifetime.
-      const lifeAlpha =
-        Math.sin((comet.life / comet.maxLife) * Math.PI) * 0.9 * alpha;
-      if (lifeAlpha <= 0) continue;
-
       const tailX = comet.x - Math.cos(comet.angle) * comet.len;
       const tailY = comet.y - Math.sin(comet.angle) * comet.len;
       const gradient = ctx.createLinearGradient(tailX, tailY, comet.x, comet.y);
       gradient.addColorStop(0, "rgba(255, 255, 255, 0)");
-      gradient.addColorStop(1, `rgba(255, 255, 255, ${lifeAlpha})`);
+      gradient.addColorStop(1, `rgba(255, 255, 255, ${comet.alpha})`);
       ctx.strokeStyle = gradient;
       ctx.lineWidth = 1.5;
       ctx.beginPath();
@@ -641,7 +562,7 @@ class EffectsEngine {
       ctx.lineTo(comet.x, comet.y);
       ctx.stroke();
 
-      ctx.fillStyle = `rgba(200, 220, 255, ${0.5 * lifeAlpha})`;
+      ctx.fillStyle = `rgba(200, 220, 255, ${0.5 * comet.alpha})`;
       ctx.beginPath();
       ctx.arc(comet.x, comet.y, 2, 0, Math.PI * 2);
       ctx.fill();
@@ -650,49 +571,19 @@ class EffectsEngine {
   }
 
   private spawnComet(): Comet {
-    // Enter from the top; angle points down, randomly leaning left or right.
-    const leanRight = Math.random() < 0.5;
-    const base = Math.PI * 0.15 + Math.random() * Math.PI * 0.3;
     return {
       x: Math.random() * this.width,
-      y: Math.random() * this.height * 0.4,
-      len: 150 + Math.random() * 200,
-      speed: 6 + Math.random() * 8,
-      angle: leanRight ? base : Math.PI - base,
+      y: Math.random() * this.height,
+      len: Math.random() * 200 + 150,
+      speed: Math.random() * 8 + 6,
+      angle: Math.random() * Math.PI * 2,
+      alpha: 1,
       life: 0,
-      maxLife: 80 + Math.random() * 40,
+      maxLife: Math.random() * 40 + 80,
     };
   }
 
-  private punchOutGlobe(disc: GlobeEllipse): void {
-    // Remove the deep-space layer over the globe silhouette so the real basemap
-    // globe shows through. Work in the ellipse's normalized frame (unit circle =
-    // limb) so the radial alpha ramp maps to an ellipse under pitch, and feather
-    // the edge across the limb so no hard seam shows against the WebGL globe.
-    const ctx = this.spaceCtx;
-    ctx.save();
-    ctx.globalCompositeOperation = "destination-out";
-    ctx.translate(disc.cx, disc.cy);
-    ctx.rotate(disc.angle);
-    ctx.scale(disc.rx, disc.ry);
-    const gradient = ctx.createRadialGradient(
-      0,
-      0,
-      PUNCH_FADE_INNER,
-      0,
-      0,
-      PUNCH_FADE_OUTER,
-    );
-    gradient.addColorStop(0, "rgba(0, 0, 0, 1)"); // fully remove space (globe shows)
-    gradient.addColorStop(1, "rgba(0, 0, 0, 0)"); // leave space intact beyond the limb
-    ctx.fillStyle = gradient;
-    ctx.beginPath();
-    ctx.arc(0, 0, PUNCH_FADE_OUTER, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.restore();
-  }
-
-  private drawSpaceBackground(alpha: number): void {
+  private drawSpaceBackground(): void {
     const ctx = this.spaceCtx;
     if (!this.spaceGradient) {
       const gradient = ctx.createRadialGradient(
@@ -708,48 +599,30 @@ class EffectsEngine {
       this.spaceGradient = gradient;
     }
     ctx.save();
-    ctx.globalAlpha = alpha;
     ctx.fillStyle = this.spaceGradient;
     ctx.fillRect(0, 0, this.width, this.height);
     ctx.restore();
   }
 
-  private drawHalo(disc: GlobeEllipse, alpha: number): void {
+  private drawHalo(disc: GlobeCircle): void {
+    if (disc.radius < 5) return;
     const ctx = this.haloCtx;
     ctx.save();
-    // Work in a normalized space where the silhouette is the unit circle: shift
-    // to the center, rotate to the ellipse axes, then scale by the semi-axes.
-    // A circular radial gradient and annulus drawn here map to an ellipse that
-    // hugs the globe at any pitch — the halo thickens along the major axis, as a
-    // real atmospheric rim does under perspective.
-    ctx.translate(disc.cx, disc.cy);
-    ctx.rotate(disc.angle);
-    ctx.scale(disc.rx, disc.ry);
-
-    // Start the glow just inside the limb (matching the punch-out feather) so the
-    // bright inner stops sit over the soft edge and blend onto the rim, leaving
-    // no gap between the globe and the glow.
     const gradient = ctx.createRadialGradient(
-      0,
-      0,
-      PUNCH_FADE_INNER,
-      0,
-      0,
-      HALO_RADIUS_SCALE,
+      disc.x,
+      disc.y,
+      disc.radius,
+      disc.x,
+      disc.y,
+      disc.radius * HALO_RADIUS_SCALE,
     );
     for (const [stop, color] of HALO_STOPS) {
       gradient.addColorStop(stop, color);
     }
-    // The screen blend is applied via the canvas element's mix-blend-mode
-    // (set in createCanvas); here we just paint the gradient normally.
-    ctx.globalAlpha = alpha;
+    ctx.globalCompositeOperation = "screen";
     ctx.fillStyle = gradient;
-    // Paint only the annulus around the limb (outer ring CW, inner ring CCW
-    // cancels the winding in the hole — nonzero rule), so the rim glows without
-    // washing out the globe disc.
     ctx.beginPath();
-    ctx.arc(0, 0, HALO_RADIUS_SCALE, 0, Math.PI * 2, false);
-    ctx.arc(0, 0, PUNCH_FADE_INNER, 0, Math.PI * 2, true);
+    ctx.arc(disc.x, disc.y, disc.radius * HALO_RADIUS_SCALE, 0, Math.PI * 2);
     ctx.fill();
     ctx.restore();
   }
@@ -760,29 +633,20 @@ class EffectsEngine {
 
     this.clear();
 
-    const alpha = isGlobeProjection(this.map) ? this.alphaForZoom() : 0;
-    if (alpha <= 0) {
-      // Faded out / not globe: idle without burning frames. A later move/zoom
-      // (handleMapChange) restarts the loop when the globe comes back.
+    if (!isGlobeProjection(this.map)) {
+      this.starsCtx.clearRect(0, 0, this.width, this.height);
+      // Not globe: idle without burning frames. A later move (handleMapChange)
+      // restarts the loop when the globe comes back.
       return;
     }
 
-    if (this.ellipseDirty) {
-      this.globeEllipse = getGlobeEllipse(this.map, this.lastLimbRadius);
-      if (this.globeEllipse) {
-        this.lastLimbRadius =
-          (this.globeEllipse.rx + this.globeEllipse.ry) / 2;
-      }
-      this.ellipseDirty = false;
+    this.drawSpaceBackground();
+    if (this.starsDirty) {
+      this.drawStarfield();
+      this.starsDirty = false;
     }
-    const disc = this.globeEllipse;
-    this.drawSpaceBackground(alpha);
-    this.drawStarfield(alpha);
-    this.updateAndDrawComets(alpha);
-    if (disc) {
-      this.punchOutGlobe(disc);
-      this.drawHalo(disc, alpha);
-    }
+    this.updateAndDrawComets();
+    this.drawHalo(getGeoglifyGlobeCircle(this.map));
 
     this.start();
   }

--- a/packages/plugins/src/plugins/maplibre-effects.ts
+++ b/packages/plugins/src/plugins/maplibre-effects.ts
@@ -22,6 +22,11 @@ import type { GeoLibreAppAPI, GeoLibrePlugin } from "../types";
  */
 
 export const EFFECTS_PLUGIN_ID = "maplibre-atmosphere-effects";
+const EFFECTS_MAP_CLASS = "geolibre-effects-map";
+const EFFECTS_OVERLAY_STYLE_ID = "geolibre-effects-maplibre-overlays";
+const MAP_CANVAS_Z_INDEX = "4";
+const CONTROL_CONTAINER_Z_INDEX = "5";
+const MAPLIBRE_OVERLAY_Z_INDEX = "6";
 
 // Roughly one star per this many CSS pixels of starfield area.
 const STAR_AREA_PER_STAR = 900;
@@ -280,6 +285,7 @@ function solveLinear(m: number[][], b: number[]): number[] | null {
  */
 class EffectsEngine {
   private readonly map: MapLibreMap;
+  private readonly mapRoot: HTMLElement | null;
   private readonly spaceCanvas: HTMLCanvasElement;
   private readonly starsCanvas: HTMLCanvasElement;
   private readonly cometCanvas: HTMLCanvasElement;
@@ -292,6 +298,7 @@ class EffectsEngine {
   private readonly previousMapCanvasZIndex: string;
   private readonly controlContainer: HTMLElement | null;
   private readonly previousControlContainerZIndex: string;
+  private readonly overlayStyle: HTMLStyleElement;
 
   private starfield: HTMLCanvasElement | null = null;
   private starfieldOriginLng = 0;
@@ -311,13 +318,14 @@ class EffectsEngine {
   constructor(map: MapLibreMap) {
     this.map = map;
     this.mapCanvas = map.getCanvas();
+    this.mapRoot = this.mapCanvas.closest(".maplibregl-map");
     this.previousMapCanvasZIndex = this.mapCanvas.style.zIndex;
     this.controlContainer =
-      this.mapCanvas
-        .closest(".maplibregl-map")
-        ?.querySelector<HTMLElement>(".maplibregl-control-container") ?? null;
+      this.mapRoot?.querySelector<HTMLElement>(".maplibregl-control-container") ??
+      null;
     this.previousControlContainerZIndex =
       this.controlContainer?.style.zIndex ?? "";
+    this.overlayStyle = this.ensureOverlayStyle();
     this.spaceCanvas = this.createCanvas(0);
     this.starsCanvas = this.createCanvas(1);
     this.cometCanvas = this.createCanvas(2);
@@ -332,8 +340,11 @@ class EffectsEngine {
     container.appendChild(this.starsCanvas);
     container.appendChild(this.cometCanvas);
     container.appendChild(this.haloCanvas);
-    this.mapCanvas.style.zIndex = "4";
-    if (this.controlContainer) this.controlContainer.style.zIndex = "5";
+    this.mapRoot?.classList.add(EFFECTS_MAP_CLASS);
+    this.mapCanvas.style.zIndex = MAP_CANVAS_Z_INDEX;
+    if (this.controlContainer) {
+      this.controlContainer.style.zIndex = CONTROL_CONTAINER_Z_INDEX;
+    }
 
     this.handleResize = this.handleResize.bind(this);
     this.handleVisibility = this.handleVisibility.bind(this);
@@ -365,10 +376,27 @@ class EffectsEngine {
     if (this.controlContainer) {
       this.controlContainer.style.zIndex = this.previousControlContainerZIndex;
     }
+    this.mapRoot?.classList.remove(EFFECTS_MAP_CLASS);
+    this.overlayStyle.remove();
     this.spaceCanvas.remove();
     this.starsCanvas.remove();
     this.cometCanvas.remove();
     this.haloCanvas.remove();
+  }
+
+  private ensureOverlayStyle(): HTMLStyleElement {
+    const existing = document.getElementById(EFFECTS_OVERLAY_STYLE_ID);
+    if (existing instanceof HTMLStyleElement) return existing;
+
+    const style = document.createElement("style");
+    style.id = EFFECTS_OVERLAY_STYLE_ID;
+    style.textContent = `
+      .${EFFECTS_MAP_CLASS} .maplibregl-boxzoom {
+        z-index: ${MAPLIBRE_OVERLAY_Z_INDEX};
+      }
+    `;
+    document.head.appendChild(style);
+    return style;
   }
 
   private createCanvas(zIndex: number): HTMLCanvasElement {


### PR DESCRIPTION
## Summary
- Render the space backdrop, starfield, comets, and atmospheric halo on background canvases layered behind the MapLibre canvas, so they show through the globe projection's transparent space instead of punching out the globe silhouette on top.
- Remove the per-frame silhouette ellipse fitting (project/unproject ray casting) and the zoom-based fade, replacing them with a tiled parallax starfield and a great-circle halo circle.

## Test plan
- [ ] Enable the atmosphere effects toggle in globe projection and confirm the space, starfield, comets, and halo render around the globe.
- [ ] Pan, zoom, pitch, and rotate the globe and verify the halo and starfield track without seams or masking the basemap.
- [ ] Switch to mercator projection and confirm the effects stop rendering.
- [ ] Toggle effects off and on, and reload a saved project, to confirm the on/off state persists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refreshed globe visuals with a new globe-circle projection for the halo, updated starfield rendering, and improved comet/tail appearance.
  * Enhanced performance by running the effects overlay primarily when the globe projection is active, and by redrawing star effects only when needed.
  * Improved rendering consistency by reorganizing overlay canvas layering so stars, comets, and the halo composite correctly.
* **Maintenance**
  * Improved startup/teardown behavior to properly restore overlay layering and clean up when no longer needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->