### PR TITLE
docs: migrate documentation build from MkDocs to Zensical

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -63,7 +63,7 @@ jobs:
           VITE_GEOLIBRE_COLLAB_URL: wss://collab.geolibre.app
 
       - name: Build documentation
-        run: mkdocs build --strict --site-dir site
+        run: zensical build --strict
 
       - name: Add web demo to site
         run: |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -152,16 +152,17 @@ uploads its report as an artifact on failure.
 
 ## Documentation
 
-The site is built with [MkDocs Material](https://squidfunk.github.io/mkdocs-material/).
-To preview your changes locally:
+The site is built with [Zensical](https://zensical.org), the successor to
+MkDocs Material from the same team. It reads the existing `mkdocs.yml`
+configuration directly. To preview your changes locally:
 
 ```bash
 python -m pip install -r requirements-docs.txt
-mkdocs serve
+zensical serve
 ```
 
 Open <http://localhost:8000>. When you add a new page, add it to the `nav` in
-`mkdocs.yml`. The site is built with `mkdocs build --strict` in CI, so broken
+`mkdocs.yml`. The site is built with `zensical build --strict` in CI, so broken
 links and pages left out of the navigation fail the build. Link to other docs
 pages with a relative path (for example `architecture.md`), and link to files
 outside `docs/` with a full GitHub URL.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -106,8 +106,8 @@
 }
 
 /* Sidebar section headers (User Guide, Tutorials, Reference).
-   Targets internal Material for MkDocs nav classes; tested against
-   mkdocs-material 9.x. Re-verify these selectors after a major theme upgrade. */
+   Targets the internal Material nav classes that Zensical emits; tested against
+   zensical 0.0.x. Re-verify these selectors after a major theme upgrade. */
 .md-nav--primary .md-nav__item--section > .md-nav__link {
   border-top: 1px solid var(--md-default-fg-color--lightest);
   color: var(--md-primary-fg-color);

--- a/docs/user-guide/plugins.md
+++ b/docs/user-guide/plugins.md
@@ -22,7 +22,7 @@ Open **Settings → Manage Plugins** to browse the marketplace. The dialog is mo
 Compatibility is checked against each entry's `minGeoLibreVersion`, so incompatible plugins are flagged rather than installed.
 
 !!! note "Trust model"
-    The registry is a curated allowlist, manifests require HTTPS (or HTTP on localhost, 127.0.0.1, or [::1] for development), and every install requires explicit consent, because plugins run as trusted code. The curated registry and the install confirmation are the primary safeguards.
+    The registry is a curated allowlist, manifests require HTTPS (or HTTP on localhost, 127.0.0.1, or `[::1]` for development), and every install requires explicit consent, because plugins run as trusted code. The curated registry and the install confirmation are the primary safeguards.
 
 ## Where plugins come from
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,10 @@ site_url: https://geolibre.app
 repo_name: opengeos/GeoLibre
 repo_url: https://github.com/opengeos/GeoLibre
 edit_uri: edit/main/docs/
+# Output directory, set explicitly so the build target stays pinned to `site/`
+# (matching the Pages/Netlify upload paths) rather than relying on the tool's
+# default, which a Zensical 0.0.x patch could shift.
+site_dir: site
 
 theme:
   name: material

--- a/netlify.toml
+++ b/netlify.toml
@@ -22,7 +22,7 @@
     && python -m pip install -r apps/geolibre-desktop/jupyterlite/requirements.txt \
     && npm ci \
     && npm run build -w geolibre-desktop \
-    && mkdocs build --strict --site-dir site \
+    && zensical build --strict \
     && mkdir -p site/demo \
     && cp -R apps/geolibre-desktop/dist/. site/demo/ \
     && test -f site/demo/index.html \

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,1 +1,1 @@
-mkdocs-material>=9.5,<10
+zensical

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,1 +1,1 @@
-zensical
+zensical>=0.0.45,<0.1


### PR DESCRIPTION
## Summary

Closes #441.

MkDocs and Material for MkDocs are now in maintenance mode; the same team's successor is [Zensical](https://zensical.org). Zensical natively reads the existing `mkdocs.yml`, so this migration swaps the build toolchain with no theme/nav/content rewrite.

## Changes

- **`requirements-docs.txt`** — replace `mkdocs-material` with `zensical`.
- **`.github/workflows/pages.yml`** and **`netlify.toml`** — build with `zensical build --strict` instead of `mkdocs build --strict --site-dir site`. Zensical's default `site_dir` is already `site`, and it auto-discovers `mkdocs.yml`, so no extra flags are needed; the downstream `site/demo` bundling steps are unchanged.
- **`docs/contributing.md`** — document `zensical serve` / `zensical build --strict` (still `mkdocs.yml`, still `localhost:8000`).
- **`docs/user-guide/plugins.md`** — wrap the `[::1]` IPv6 literal in backticks so Zensical's stricter link checker no longer treats it as an unresolved link reference (the only issue strict mode surfaced).
- **`docs/stylesheets/extra.css`** — refresh the sidebar-nav comment to note the selectors target Zensical's output (it emits the same `.md-nav` classes, so the CSS still applies).

`mkdocs.yml` is kept as-is — Zensical reads it directly and that path is officially supported going forward.

## Verification

Built locally with `zensical build --strict` (zensical 0.0.45): **clean strict build, no issues**. Verified the generated `site/` includes the search index, `extra.css`, logo asset, full nav (including the `/demo/` link and GitHub social link), palette toggle, and Mermaid-rendered architecture page. `pre-commit run --files <changed>` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added “Trust model” guidance for plugins, including curated allowlisting, HTTPS manifest requirements (with localhost/loopback exceptions), and explicit user consent before installation
  * Updated local preview and build instructions to use Zensical
* **Chores**
  * Updated documentation build and deployment pipelines to use Zensical strict builds for the published site output
  * Refreshed related documentation styling notes for Zensical theme navigation targeting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->