### PR TITLE
chore(deps): bump maplibre-gl-raster to ^0.3.1 (fixes COG rendering #444)

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -70,7 +70,7 @@
     "maplibre-gl-nasa-earthdata": "^0.1.2",
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.3.0",
+    "maplibre-gl-raster": "^0.3.1",
     "maplibre-gl-streetview": "^0.6.0",
     "maplibre-gl-swipe": "^0.7.1",
     "maplibre-gl-time-slider": "^1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
         "maplibre-gl-nasa-earthdata": "^0.1.2",
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.3.0",
+        "maplibre-gl-raster": "^0.3.1",
         "maplibre-gl-streetview": "^0.6.0",
         "maplibre-gl-swipe": "^0.7.1",
         "maplibre-gl-time-slider": "^1.0.3",
@@ -17756,9 +17756,9 @@
       }
     },
     "node_modules/maplibre-gl-raster": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.3.0.tgz",
-      "integrity": "sha512-0023xM+yVRaMoYCLPhdbVuLPdClxbJ5v+J6xxlNa0HgBIZ8egRQwvwo9Le7Enhlq3Gb/pAi9v4unS43cWc8UUg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.3.1.tgz",
+      "integrity": "sha512-ziblcMQGiPRaXeMuD4nhk11ULaU7a00mHGf1geivICYSyTGyhKegF3XG82raS15BUlgBXk5BOrHuHDCy1ivm4A==",
       "license": "MIT",
       "dependencies": {
         "@chunkd/middleware": "^11.3.0",
@@ -24289,7 +24289,7 @@
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-overture-maps": "^0.3.0",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.3.0",
+        "maplibre-gl-raster": "^0.3.1",
         "maplibre-gl-streetview": "^0.6.0",
         "maplibre-gl-swipe": "^0.7.1",
         "maplibre-gl-time-slider": "^1.0.3",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -44,7 +44,7 @@
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-overture-maps": "^0.3.0",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.3.0",
+    "maplibre-gl-raster": "^0.3.1",
     "maplibre-gl-streetview": "^0.6.0",
     "maplibre-gl-swipe": "^0.7.1",
     "maplibre-gl-time-slider": "^1.0.3",


### PR DESCRIPTION
## What

Bumps `maplibre-gl-raster` `^0.3.0` → `^0.3.1` in `apps/geolibre-desktop` and `packages/plugins`, and refreshes `package-lock.json` to `0.3.1`.

## Why

Closes #444. A global COG **already in EPSG:3857** whose extent reaches the antimeridian (e.g. VIIRS nighttime lights, X bounds ±20038000 m, just past the valid ±20037508.34 m) rendered as garbage with a flood of:

```
RasterReprojector: mesh refinement did not converge after 10001 iterations (maxError=0.125, currentError=2503.938561250837)
```

Root cause was upstream in `@developmentseed/deck.gl-geotiff`: it reprojected the source→EPSG:3857 through proj4 even when the source was already 3857, and proj4's mercator round-trip normalizes longitude into (−180°, 180°], wrapping the COG's edge (and every padded partial edge tile) to the opposite hemisphere. The per-tile Delatin reprojection mesh then spanned ~40,000 km and never converged.

`maplibre-gl-raster@0.3.1` ([opengeos/maplibre-gl-raster#16](https://github.com/opengeos/maplibre-gl-raster/pull/16)) fixes this by drawing a Web Mercator source with an identity source→3857 reprojection — exact, wrap-free, and faster.

## Verification

- `npm run build` green; `npm run test:frontend` 1078 pass / 0 fail.
- End-to-end in the real app (Playwright): loaded the exact reported COG (`https://storage.googleapis.com/spatialthoughts-public-data/ntl/viirs/viirs_ntl_2021_global.tif`) → renders correctly geo-aligned (nighttime-light clusters over the right continents), **zero "did not converge" warnings, zero console errors**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated maplibre-gl-raster dependency to the latest patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->