### PR TITLE
chore(deps): bump maplibre-gl-layer-control to ^0.17.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17628,9 +17628,9 @@
       }
     },
     "node_modules/maplibre-gl-layer-control": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-layer-control/-/maplibre-gl-layer-control-0.16.0.tgz",
-      "integrity": "sha512-6qTuxG39KYlwaA5tp9qgr2+EzWOI0a1R9EeQxZMVaRHRNhYqVyrWsa7i8Q0S8V5N1m8eEqumNMWZtKs0GfM+XQ==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-layer-control/-/maplibre-gl-layer-control-0.17.0.tgz",
+      "integrity": "sha512-rEoWRansid5qeX6mb1NxGNyuL4PYgV4ZkTkpi+CPqB3jmO7x38N6ewCPRLat6N4n2ECpxg7y1pyQ64csMCuX/A==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -24187,7 +24187,7 @@
         "@turf/bbox": "^7.3.5",
         "@turf/helpers": "^7.3.5",
         "maplibre-gl": "^5.24.0",
-        "maplibre-gl-layer-control": "^0.16.0",
+        "maplibre-gl-layer-control": "^0.17.0",
         "pmtiles": "^4.4.1",
         "react": "^19.2.7",
         "react-dom": "^19.2.7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17628,9 +17628,9 @@
       }
     },
     "node_modules/maplibre-gl-layer-control": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-layer-control/-/maplibre-gl-layer-control-0.17.0.tgz",
-      "integrity": "sha512-rEoWRansid5qeX6mb1NxGNyuL4PYgV4ZkTkpi+CPqB3jmO7x38N6ewCPRLat6N4n2ECpxg7y1pyQ64csMCuX/A==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-layer-control/-/maplibre-gl-layer-control-0.17.1.tgz",
+      "integrity": "sha512-R8WlRysDmdzPJKxCDjFcjVA/YeroOyTGWTqYoK4A36CsawvJ9XyJDFmjW/qU/hSBTjNMNOblo2ZffIMnYR1dCQ==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -24187,7 +24187,7 @@
         "@turf/bbox": "^7.3.5",
         "@turf/helpers": "^7.3.5",
         "maplibre-gl": "^5.24.0",
-        "maplibre-gl-layer-control": "^0.17.0",
+        "maplibre-gl-layer-control": "^0.17.1",
         "pmtiles": "^4.4.1",
         "react": "^19.2.7",
         "react-dom": "^19.2.7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17628,9 +17628,9 @@
       }
     },
     "node_modules/maplibre-gl-layer-control": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-layer-control/-/maplibre-gl-layer-control-0.17.1.tgz",
-      "integrity": "sha512-R8WlRysDmdzPJKxCDjFcjVA/YeroOyTGWTqYoK4A36CsawvJ9XyJDFmjW/qU/hSBTjNMNOblo2ZffIMnYR1dCQ==",
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-layer-control/-/maplibre-gl-layer-control-0.17.3.tgz",
+      "integrity": "sha512-vGEaEEvxx/mY+u+egGFRNLoyxnxWr4UYJTNI5lnQsKREWSAl04nc9GnAX7504Y0H56DHGele1uJJIbqjW5gCuA==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -24187,7 +24187,7 @@
         "@turf/bbox": "^7.3.5",
         "@turf/helpers": "^7.3.5",
         "maplibre-gl": "^5.24.0",
-        "maplibre-gl-layer-control": "^0.17.1",
+        "maplibre-gl-layer-control": "^0.17.3",
         "pmtiles": "^4.4.1",
         "react": "^19.2.7",
         "react-dom": "^19.2.7"

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -15,7 +15,7 @@
     "@turf/bbox": "^7.3.5",
     "@turf/helpers": "^7.3.5",
     "maplibre-gl": "^5.24.0",
-    "maplibre-gl-layer-control": "^0.17.0",
+    "maplibre-gl-layer-control": "^0.17.1",
     "pmtiles": "^4.4.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -15,7 +15,7 @@
     "@turf/bbox": "^7.3.5",
     "@turf/helpers": "^7.3.5",
     "maplibre-gl": "^5.24.0",
-    "maplibre-gl-layer-control": "^0.16.0",
+    "maplibre-gl-layer-control": "^0.17.0",
     "pmtiles": "^4.4.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -15,7 +15,7 @@
     "@turf/bbox": "^7.3.5",
     "@turf/helpers": "^7.3.5",
     "maplibre-gl": "^5.24.0",
-    "maplibre-gl-layer-control": "^0.17.1",
+    "maplibre-gl-layer-control": "^0.17.3",
     "pmtiles": "^4.4.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"


### PR DESCRIPTION
Bumps `maplibre-gl-layer-control` from `^0.16.0` to `^0.17.3` in `@geolibre/map`.

### Why
Pulls in the full set of layer-control panel ordering fixes for #449, verified end-to-end against the GeoLibre app with Playwright:

- **0.17.3** ([release](https://github.com/opengeos/maplibre-gl-layer-control/releases/tag/v0.17.3)): layers added **while the control is open** (GeoLibre adds layers through a custom adapter) now appear in correct stacking order instead of being appended below the basemap; and the **Background group is no longer dropped** when the control uses an explicit layer list.
- **0.17.1** ([release](https://github.com/opengeos/maplibre-gl-layer-control/releases/tag/v0.17.1)): custom-adapter layers follow the actual native map stacking order (their logical IDs differ from the underlying `layer-<id>-raster` style IDs).
- **0.17.0** ([release](https://github.com/opengeos/maplibre-gl-layer-control/releases/tag/v0.17.0)): panel order matches the map (basemap at the bottom, top row covers all); drag-to-reorder fixed; width slider removed in favor of edge-drag resizing; panel fills available height; wider default max width.

### Verification
Reproduced the failing flow (open the control, then add an XYZ layer) against the running GeoLibre app: the control now shows user layers on top with `Background` at the bottom, matching the left-hand layer panel. `npm run build` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the map layer control dependency to a newer minor version for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->