### PR TITLE
fix(layout): keep confirmation dialogs above map-control panels (#451)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -1190,12 +1190,7 @@ export function DesktopShell({
           </SectionErrorBoundary>
         ) : null}
         <main
-          // `isolate` makes the map area its own stacking context so map-control
-          // panels appended to the map container (e.g. the basemap control's
-          // panel at z-index:1000, and others) stay contained below the modal
-          // layer. Without it those z-indexes escape to the root stacking
-          // context and cover body-portaled dialogs like the layer-removal
-          // confirmation (z-50). See issue #451.
+          // `isolate` creates a stacking context so map-panel z-indexes (up to 10000) stay below body-portaled dialogs. See #451.
           className={`relative isolate min-w-0 flex-1 overflow-hidden ${
             layoutOptions.compact ? "min-h-0" : "min-h-72 md:min-h-0"
           }`}

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -1190,7 +1190,13 @@ export function DesktopShell({
           </SectionErrorBoundary>
         ) : null}
         <main
-          className={`relative min-w-0 flex-1 overflow-hidden ${
+          // `isolate` makes the map area its own stacking context so map-control
+          // panels appended to the map container (e.g. the basemap control's
+          // panel at z-index:1000, and others) stay contained below the modal
+          // layer. Without it those z-indexes escape to the root stacking
+          // context and cover body-portaled dialogs like the layer-removal
+          // confirmation (z-50). See issue #451.
+          className={`relative isolate min-w-0 flex-1 overflow-hidden ${
             layoutOptions.compact ? "min-h-0" : "min-h-72 md:min-h-0"
           }`}
         >


### PR DESCRIPTION
## Summary

Fixes #451. When a map-control panel is open (the reporter hit it with the basemap control), the layer-removal confirmation dialog renders **behind** the panel, leaving part of the text unreadable.

## Root cause

Map-control packages (e.g. `maplibre-gl-basemap-control`) append their panel to the **map container** — `map.getContainer().appendChild(panel)` — with `position: absolute; z-index: 1000`. The map area `<main>` was only `position: relative` (not an isolating stacking context), so that `z-index: 1000` escaped to the **root** stacking context and beat the body-portaled shadcn `Dialog` (`z-50`). The `.maplibregl-control-container` (z-index: 2) does not help here because the panel is appended to the map container directly, not the control container.

## Fix

Add `isolation: isolate` to `<main>` so it becomes its own stacking context. Every map-control panel appended to the map container is then contained below the modal layer. This fixes the whole class of map-panel-over-dialog conflicts without touching the shadcn z-index scale (so Radix popovers/selects nested **inside** dialogs keep working). `<main>` already has `overflow-hidden`, so nothing relied on panels escaping it.

## Verification

Drove the real running app with Playwright and ran a causal stacking test against the **actual** `.maplibregl-map` container (the node the basemap control appends to) and the real `<main>`:

| Condition | Topmost element at the overlap point |
| --- | --- |
| With fix (`main` isolated) | **dialog** (z-50) ✅ |
| Pre-fix simulated (`main.style.isolation='auto'`) | panel (z-1000) — reproduces the bug |

Confirmed `<main>` is now the only stacking context between the map container and `<body>`. Pre-commit (eslint + full build) passes; app renders with no layout regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where map control panels could overlap with and obscure dialog elements (for example, confirmation dialogs), ensuring dialogs remain properly visible and interactive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->