### PR TITLE
feat(dashboard): make the dashboard panel collapsible (#459)

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/DashboardPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/DashboardPanel.tsx
@@ -9,6 +9,8 @@ import {
   ChevronLeft,
   ChevronRight,
   LayoutDashboard,
+  PanelBottomClose,
+  PanelBottomOpen,
   Pencil,
   Plus,
   Trash2,
@@ -81,6 +83,10 @@ export function DashboardPanel() {
   const sectionRef = useRef<HTMLElement>(null);
   const resizeCleanupRef = useRef<(() => void) | null>(null);
   const [height, setHeight] = useState(DEFAULT_DASHBOARD_HEIGHT);
+  // Collapse the panel to just its header bar for a full map view, without
+  // losing the last height (issue #459). The height is kept in state so an
+  // expand restores the panel to exactly the size the user last dragged it to.
+  const [isCollapsed, setIsCollapsed] = useState(false);
   const [editorOpen, setEditorOpen] = useState(false);
   const [editing, setEditing] = useState<DashboardWidget | null>(null);
 
@@ -164,32 +170,34 @@ export function DashboardPanel() {
   return (
     <section
       ref={sectionRef}
-      style={{ height }}
+      style={isCollapsed ? undefined : { height }}
       className="relative flex shrink-0 flex-col border-t bg-card"
     >
-      <div
-        role="separator"
-        aria-orientation="horizontal"
-        aria-label={t("dashboard.resize")}
-        aria-valuenow={Math.round(height)}
-        aria-valuemin={MIN_DASHBOARD_HEIGHT}
-        aria-valuemax={MAX_DASHBOARD_HEIGHT}
-        tabIndex={0}
-        className="absolute -top-1 left-0 right-0 z-20 h-2 cursor-row-resize select-none border-t border-transparent hover:border-primary focus-visible:border-primary focus-visible:outline-none"
-        onMouseDown={startResize}
-        onKeyDown={(event) => {
-          // Arrow keys resize for keyboard-only users (Shift = larger step).
-          const step = event.shiftKey ? 24 : 8;
-          if (event.key === "ArrowUp") {
-            setHeight((h) => Math.min(MAX_DASHBOARD_HEIGHT, h + step));
-          } else if (event.key === "ArrowDown") {
-            setHeight((h) => Math.max(MIN_DASHBOARD_HEIGHT, h - step));
-          } else {
-            return;
-          }
-          event.preventDefault();
-        }}
-      />
+      {!isCollapsed ? (
+        <div
+          role="separator"
+          aria-orientation="horizontal"
+          aria-label={t("dashboard.resize")}
+          aria-valuenow={Math.round(height)}
+          aria-valuemin={MIN_DASHBOARD_HEIGHT}
+          aria-valuemax={MAX_DASHBOARD_HEIGHT}
+          tabIndex={0}
+          className="absolute -top-1 left-0 right-0 z-20 h-2 cursor-row-resize select-none border-t border-transparent hover:border-primary focus-visible:border-primary focus-visible:outline-none"
+          onMouseDown={startResize}
+          onKeyDown={(event) => {
+            // Arrow keys resize for keyboard-only users (Shift = larger step).
+            const step = event.shiftKey ? 24 : 8;
+            if (event.key === "ArrowUp") {
+              setHeight((h) => Math.min(MAX_DASHBOARD_HEIGHT, h + step));
+            } else if (event.key === "ArrowDown") {
+              setHeight((h) => Math.max(MIN_DASHBOARD_HEIGHT, h - step));
+            } else {
+              return;
+            }
+            event.preventDefault();
+          }}
+        />
+      ) : null}
       <div className="flex items-center gap-2 border-b px-3 py-1.5">
         <LayoutDashboard className="h-4 w-4 text-muted-foreground" />
         <span className="text-sm font-semibold">{t("dashboard.title")}</span>
@@ -197,7 +205,7 @@ export function DashboardPanel() {
           {t("dashboard.widgetCount", { count: widgets.length })}
         </span>
         <div className="ml-auto flex items-center gap-2">
-          {widgets.length > 0 ? (
+          {!isCollapsed && widgets.length > 0 ? (
             <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
               <span className="hidden sm:inline">{t("dashboard.columns")}</span>
               <Select
@@ -216,20 +224,42 @@ export function DashboardPanel() {
               </Select>
             </label>
           ) : null}
+          {!isCollapsed ? (
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-8 px-2"
+              onClick={openAdd}
+              disabled={chartableLayers.length === 0}
+              title={
+                chartableLayers.length === 0
+                  ? t("dashboard.noLayersHint")
+                  : t("dashboard.addWidget")
+              }
+            >
+              <Plus className="h-3.5 w-3.5" />
+              <span className="hidden sm:inline">
+                {t("dashboard.addWidget")}
+              </span>
+            </Button>
+          ) : null}
           <Button
-            variant="outline"
-            size="sm"
-            className="h-8 px-2"
-            onClick={openAdd}
-            disabled={chartableLayers.length === 0}
-            title={
-              chartableLayers.length === 0
-                ? t("dashboard.noLayersHint")
-                : t("dashboard.addWidget")
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            aria-label={
+              isCollapsed ? t("dashboard.expand") : t("dashboard.collapse")
             }
+            title={
+              isCollapsed ? t("dashboard.expand") : t("dashboard.collapse")
+            }
+            onClick={() => setIsCollapsed((c) => !c)}
           >
-            <Plus className="h-3.5 w-3.5" />
-            <span className="hidden sm:inline">{t("dashboard.addWidget")}</span>
+            {isCollapsed ? (
+              <PanelBottomOpen className="h-4 w-4" />
+            ) : (
+              <PanelBottomClose className="h-4 w-4" />
+            )}
           </Button>
           <Button
             variant="ghost"
@@ -244,36 +274,38 @@ export function DashboardPanel() {
         </div>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-auto p-3">
-        {widgets.length === 0 ? (
-          <div className="flex h-full flex-col items-center justify-center gap-1 text-center">
-            <p className="text-sm text-muted-foreground">
-              {chartableLayers.length === 0
-                ? t("dashboard.emptyNoLayers")
-                : t("dashboard.empty")}
-            </p>
-          </div>
-        ) : (
-          <div
-            className="grid gap-3"
-            style={{
-              gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
-            }}
-          >
-            {widgets.map((widget, index) => (
-              <WidgetCard
-                key={widget.id}
-                widget={widget}
-                index={index}
-                count={widgets.length}
-                onEdit={() => openEdit(widget)}
-                onRemove={() => removeWidget(widget.id)}
-                onMove={(toIndex) => moveWidget(widget.id, toIndex)}
-              />
-            ))}
-          </div>
-        )}
-      </div>
+      {!isCollapsed ? (
+        <div className="min-h-0 flex-1 overflow-auto p-3">
+          {widgets.length === 0 ? (
+            <div className="flex h-full flex-col items-center justify-center gap-1 text-center">
+              <p className="text-sm text-muted-foreground">
+                {chartableLayers.length === 0
+                  ? t("dashboard.emptyNoLayers")
+                  : t("dashboard.empty")}
+              </p>
+            </div>
+          ) : (
+            <div
+              className="grid gap-3"
+              style={{
+                gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+              }}
+            >
+              {widgets.map((widget, index) => (
+                <WidgetCard
+                  key={widget.id}
+                  widget={widget}
+                  index={index}
+                  count={widgets.length}
+                  onEdit={() => openEdit(widget)}
+                  onRemove={() => removeWidget(widget.id)}
+                  onMove={(toIndex) => moveWidget(widget.id, toIndex)}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      ) : null}
 
       <WidgetEditorDialog
         open={editorOpen}

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -963,6 +963,8 @@
   "dashboard": {
     "title": "Dashboard",
     "resize": "Resize dashboard panel",
+    "collapse": "Collapse dashboard",
+    "expand": "Expand dashboard",
     "close": "Close dashboard",
     "columns": "Columns",
     "addWidget": "Add widget",


### PR DESCRIPTION
## Summary

Closes #459. The Dashboard panel can now be collapsed to a thin header bar at the bottom of the screen with a single click, reclaiming the full map view, and expanded back to its previous height — no more deactivating it via the menu or dragging the divider to the bottom.

- Added a collapse/expand toggle to the dashboard header (using the `PanelBottomClose` / `PanelBottomOpen` icons), placed beside the close button.
- When collapsed, the resize handle, column picker, **Add widget** button, and widget grid are hidden; only the header bar remains docked at the bottom.
- The last height is kept in component state, so expanding restores the panel to exactly the size it was last resized to (the issue's requested behavior).
- New i18n strings `dashboard.collapse` / `dashboard.expand` in `en.json` (the typed source of truth; other locales fall back to English).

Mirrors the existing collapse pattern in `NotebookPanel`.

## Testing

- `npm run typecheck` (full build) passes.
- `pre-commit run --files …` passes (eslint + npm build).
- Verified end-to-end in the real app with Playwright against a real US-states GeoJSON layer:
  - Resized the expanded panel to 480px via keyboard.
  - **Collapse** → panel height dropped to 46px (header only); resize separator and Add widget button removed; button relabeled "Expand dashboard".
  - **Expand** → panel restored to exactly **480px** with all controls back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard panel now supports collapsing into a header-only view with new collapse/expand button visuals.
  * Widget list and add widget button are hidden when the panel is collapsed and shown when expanded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->