### PR TITLE
fix(toolbar): commit project name on Enter key

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -55,7 +55,7 @@ import {
   Workflow,
   Wrench,
 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   createAppAPI,
@@ -186,6 +186,10 @@ export function TopToolbar({
       setCollaborateDialogOpen(true);
     }
   }, [collaboration.enabled]);
+
+  // Tracks an active IME composition so pressing Enter to confirm a CJK
+  // candidate doesn't blur the project-name field mid-composition.
+  const projectNameComposingRef = useRef(false);
 
   const [controlsVisible, setControlsVisible] = useState<
     Record<ToolbarMapControl, boolean>
@@ -920,12 +924,19 @@ export function TopToolbar({
               value={projectName}
               onChange={(event) => setProjectName(event.target.value)}
               onKeyDown={(event) => {
-                // Pressing Enter/Return commits the name and releases focus
-                // so the field no longer stays in an active editing state.
-                if (event.key === "Enter") {
-                  event.preventDefault();
+                if (
+                  event.key === "Enter" &&
+                  !projectNameComposingRef.current &&
+                  !event.nativeEvent.isComposing
+                ) {
                   event.currentTarget.blur();
                 }
+              }}
+              onCompositionStart={() => {
+                projectNameComposingRef.current = true;
+              }}
+              onCompositionEnd={() => {
+                projectNameComposingRef.current = false;
               }}
               onBlur={(event) => {
                 const nextName = event.target.value.trim();

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -919,6 +919,14 @@ export function TopToolbar({
               className="hidden h-7 w-44 border-transparent px-2 text-xs shadow-none focus-visible:border-input md:block"
               value={projectName}
               onChange={(event) => setProjectName(event.target.value)}
+              onKeyDown={(event) => {
+                // Pressing Enter/Return commits the name and releases focus
+                // so the field no longer stays in an active editing state.
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  event.currentTarget.blur();
+                }
+              }}
               onBlur={(event) => {
                 const nextName = event.target.value.trim();
                 // Persist the canonical, locale-independent default name; a


### PR DESCRIPTION
## Summary

Fixes #472. The project name input in the top toolbar had no Enter/Return key handler, so pressing Enter left the field focused and in an active editing state.

## Change

Added an `onKeyDown` handler on the project name `Input` that, on `Enter`, prevents the default and blurs the input. Blurring commits the name (reusing the existing `onBlur` normalization that falls back to the default project name when empty) and releases focus so the field is no longer in an active editing state.

## Testing

- `pre-commit run --files apps/geolibre-desktop/src/components/layout/TopToolbar.tsx` (eslint + full npm build) passes.

## Reproduction (before)

1. Click the project name field in the top toolbar.
2. Type a new name and press Enter/Return.
3. Before: field stays focused/active. After: field commits the name and loses focus.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the project-name input behavior: pressing **Enter** now finalizes the value and exits edit mode correctly, while respecting active IME text composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->