### PR TITLE
fix(basemap): let the resized basemap panel grow past the default size caps (#452)

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -57,7 +57,7 @@
     "mapillary-js": "^4.1.2",
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.1",
-    "maplibre-gl-basemap-control": "^0.4.0",
+    "maplibre-gl-basemap-control": "^0.4.1",
     "maplibre-gl-components": "^0.20.6",
     "maplibre-gl-duckdb": "^0.2.0",
     "maplibre-gl-earth-engine": "^0.4.2",

--- a/apps/geolibre-desktop/src/lib/basemap-style.ts
+++ b/apps/geolibre-desktop/src/lib/basemap-style.ts
@@ -3,6 +3,16 @@ const BASEMAP_SELECT_PROXY_CLASS = "basemap-select-proxy";
 const BASEMAP_SELECT_MENU_CLASS = "basemap-select-menu";
 
 const BASEMAP_SELECT_FIXES = `
+/* Issue #452: once the user drags the panel to an explicit size, drop the
+   upstream default max-width/max-height caps so the panel honours the dragged
+   dimensions (already clamped to the map bounds in JS) instead of snapping back
+   to 420x560. Mirrors the fix in maplibre-gl-basemap-control; remove this
+   override once the bundled version ships it. */
+.basemap-control-panel.is-resized {
+  max-width: none;
+  max-height: none;
+}
+
 .basemap-control-panel .basemap-control-select {
   color: #111827;
   color-scheme: light;

--- a/apps/geolibre-desktop/src/lib/basemap-style.ts
+++ b/apps/geolibre-desktop/src/lib/basemap-style.ts
@@ -3,16 +3,6 @@ const BASEMAP_SELECT_PROXY_CLASS = "basemap-select-proxy";
 const BASEMAP_SELECT_MENU_CLASS = "basemap-select-menu";
 
 const BASEMAP_SELECT_FIXES = `
-/* Issue #452: once the user drags the panel to an explicit size, drop the
-   upstream default max-width/max-height caps so the panel honours the dragged
-   dimensions (already clamped to the map bounds in JS) instead of snapping back
-   to 420x560. Mirrors the fix in maplibre-gl-basemap-control; remove this
-   override once the bundled version ships it. */
-.basemap-control-panel.is-resized {
-  max-width: none;
-  max-height: none;
-}
-
 .basemap-control-panel .basemap-control-select {
   color: #111827;
   color-scheme: light;

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "mapillary-js": "^4.1.2",
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.1",
-        "maplibre-gl-basemap-control": "^0.4.0",
+        "maplibre-gl-basemap-control": "^0.4.1",
         "maplibre-gl-components": "^0.20.6",
         "maplibre-gl-duckdb": "^0.2.0",
         "maplibre-gl-earth-engine": "^0.4.2",
@@ -17354,9 +17354,9 @@
       "license": "MIT"
     },
     "node_modules/maplibre-gl-basemap-control": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-basemap-control/-/maplibre-gl-basemap-control-0.4.0.tgz",
-      "integrity": "sha512-r6ZnFaUskO3KWkuLUdPQ6KBsVPIxGvlWznQ92gRswHvqAEhU8SFDGX/Ys6RenocUiqgYdYJ63FNi+p9PrCT6LQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-basemap-control/-/maplibre-gl-basemap-control-0.4.1.tgz",
+      "integrity": "sha512-cLZMai9qDaKfuA3BTH9MMQAupVBDDIVlk93XU8zVe0Wl2ZKmJHGtJDUOWWDMg79+dRYPs6LuyJ/Yh5heEfBUvw==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -24275,7 +24275,7 @@
         "jspdf": "^4.2.1",
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.1",
-        "maplibre-gl-basemap-control": "^0.4.0",
+        "maplibre-gl-basemap-control": "^0.4.1",
         "maplibre-gl-components": "^0.20.6",
         "maplibre-gl-duckdb": "^0.2.0",
         "maplibre-gl-earth-engine": "^0.4.2",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -30,7 +30,7 @@
     "jspdf": "^4.2.1",
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.1",
-    "maplibre-gl-basemap-control": "^0.4.0",
+    "maplibre-gl-basemap-control": "^0.4.1",
     "maplibre-gl-components": "^0.20.6",
     "maplibre-gl-duckdb": "^0.2.0",
     "maplibre-gl-earth-engine": "^0.4.2",


### PR DESCRIPTION
## Problem

Closes #452.

The basemap panel has a resize handle, but its height/width could only be dragged up to a fixed ~420×560 px even when the map clearly had more room. `maplibre-gl-basemap-control` sets the inline `width`/`height` from the drag (clamped to the map bounds), but its default `max-width: 420px` / `max-height: 560px` caps stayed in effect and visually snapped the panel back down.

## Fix

Root-caused and fixed upstream in opengeos/maplibre-gl-basemap-control#11 (released as **v0.4.1**): the `max-width`/`max-height` caps are lifted once the panel carries the `.is-resized` class, and the narrow-viewport width rule no longer overrides an explicitly resized panel.

This PR bumps `maplibre-gl-basemap-control` to `^0.4.1` in `apps/geolibre-desktop` and `packages/plugins` to consume that fix. (An earlier revision of this PR carried a temporary CSS override mirroring the fix; it's been removed now that the published package ships it.)

## Verification

Drove the real app with Playwright on the published `0.4.1` (no override): activated the Basemaps plugin, opened the panel (default 340×560), dragged the bottom-right handle, and the panel rendered at **684×862** with computed `max-width`/`max-height: none`. Before the fix the same drag was clamped to exactly 420×560.

`pre-commit run --files` (eslint + full npm build) passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated basemap control library dependency to the latest patch version across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->