### PR TITLE
feat(bookmark): capture layers, selectable export, resizable/reorderable panel, save-as name prompt

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -58,7 +58,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.1",
     "maplibre-gl-basemap-control": "^0.4.0",
-    "maplibre-gl-components": "^0.20.6",
+    "maplibre-gl-components": "^0.21.0",
     "maplibre-gl-duckdb": "^0.2.0",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -2,6 +2,7 @@ import { useAppStore, type GeoLibreLayer } from "@geolibre/core";
 import type { FeatureCollection } from "geojson";
 import type { MapController, MapDiagnosticEvent } from "@geolibre/map";
 import { MapCanvas, setExternalDeckLayerOrderHandler } from "@geolibre/map";
+import { useTranslation } from "react-i18next";
 import {
   addRasterToMap,
   applyRasterLayerOrder,
@@ -18,6 +19,7 @@ import {
   restoreRasterLayers,
   restoreThreeDTilesLayers,
   restoreVectorLayers,
+  setBookmarkCaptureLabel,
   startLayerGeometryEdit,
   subscribeGeometryEdit,
 } from "@geolibre/plugins";
@@ -72,6 +74,7 @@ import { StylePanel } from "../panels/StylePanel";
 import { StoryMapPanel } from "../storymap/StoryMapPanel";
 import { StoryMapPresenter } from "../storymap/StoryMapPresenter";
 import { DiagnosticsDialog } from "./DiagnosticsDialog";
+import { FileNamePromptDialog } from "./FileNamePromptDialog";
 import { StatusBar } from "./StatusBar";
 import { TopToolbar } from "./TopToolbar";
 import type { LayoutOptions } from "../../hooks/useLayoutOptions";
@@ -340,8 +343,16 @@ export function DesktopShell({
   themeMode,
   onToggleThemeMode,
 }: DesktopShellProps) {
+  const { t } = useTranslation();
   const shellRef = useRef<HTMLDivElement>(null);
   const verticalResizeGuideRef = useRef<HTMLDivElement>(null);
+  // Push the translated bookmark capture-checkbox label into the
+  // framework-agnostic plugins package (which can't call t() itself). Done here
+  // rather than in TopToolbar so it still applies when the toolbar is hidden
+  // (e.g. `?maponly`), where the BookmarkControl overlay is still present.
+  useEffect(() => {
+    setBookmarkCaptureLabel(t("bookmark.captureStateLabel"));
+  }, [t]);
   // Teardown for an in-progress panel resize, so a pointercancel or an unmount
   // mid-drag still detaches the global listeners and restores document.body.
   const activeResizeCleanupRef = useRef<(() => void) | null>(null);
@@ -1271,6 +1282,9 @@ export function DesktopShell({
         open={diagnosticsOpen}
         onOpenChange={setDiagnosticsOpen}
       />
+      {/* Mounted in the always-rendered shell (not the toolbar) so the bookmark
+          export name prompt works even when the toolbar is hidden (`?maponly`). */}
+      <FileNamePromptDialog />
       <Suspense fallback={null}>
         <ProcessingDialog
           mapControllerRef={mapControllerRef}

--- a/apps/geolibre-desktop/src/components/layout/FileNamePromptDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/FileNamePromptDialog.tsx
@@ -31,10 +31,6 @@ export function FileNamePromptDialog() {
     submit();
   };
 
-  const title = request?.typeLabel
-    ? t("fileNamePrompt.titleTyped", { type: request.typeLabel })
-    : t("fileNamePrompt.title");
-
   return (
     <Dialog
       open={request !== null}
@@ -44,7 +40,7 @@ export function FileNamePromptDialog() {
     >
       <DialogContent className="max-w-lg">
         <DialogHeader>
-          <DialogTitle>{title}</DialogTitle>
+          <DialogTitle>{t("fileNamePrompt.title")}</DialogTitle>
           <DialogDescription>{t("fileNamePrompt.description")}</DialogDescription>
         </DialogHeader>
         <form className="space-y-4" onSubmit={handleSubmit}>
@@ -55,6 +51,9 @@ export function FileNamePromptDialog() {
             <Input
               id="file-name-prompt-input"
               autoFocus
+              maxLength={255}
+              spellCheck={false}
+              autoComplete="off"
               value={value}
               onChange={(event) => setValue(event.target.value)}
             />

--- a/apps/geolibre-desktop/src/components/layout/FileNamePromptDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/FileNamePromptDialog.tsx
@@ -55,7 +55,11 @@ export function FileNamePromptDialog() {
               spellCheck={false}
               autoComplete="off"
               value={value}
-              onChange={(event) => setValue(event.target.value)}
+              // Strip path separators so a typed name like "2024/bookmarks"
+              // isn't silently truncated to "bookmarks" by the browser saver.
+              onChange={(event) =>
+                setValue(event.target.value.replace(/[/\\]/g, ""))
+              }
             />
           </div>
           <div className="flex justify-end gap-2">

--- a/apps/geolibre-desktop/src/components/layout/FileNamePromptDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/FileNamePromptDialog.tsx
@@ -1,0 +1,74 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+} from "@geolibre/ui";
+import type { FormEvent } from "react";
+import { useTranslation } from "react-i18next";
+import { useFileNamePrompt } from "../../hooks/useFileNamePrompt";
+
+/**
+ * App-wide "choose a file name" dialog backing {@link useFileNamePrompt}. Shown
+ * when a text-file export must fall back to a browser download (no native save
+ * picker), so the user can still name the file. Renders nothing until a prompt
+ * is requested.
+ */
+export function FileNamePromptDialog() {
+  const { t } = useTranslation();
+  const request = useFileNamePrompt((state) => state.request);
+  const value = useFileNamePrompt((state) => state.value);
+  const setValue = useFileNamePrompt((state) => state.setValue);
+  const submit = useFileNamePrompt((state) => state.submit);
+  const cancel = useFileNamePrompt((state) => state.cancel);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    submit();
+  };
+
+  const title = request?.typeLabel
+    ? t("fileNamePrompt.titleTyped", { type: request.typeLabel })
+    : t("fileNamePrompt.title");
+
+  return (
+    <Dialog
+      open={request !== null}
+      onOpenChange={(open: boolean) => {
+        if (!open) cancel();
+      }}
+    >
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{t("fileNamePrompt.description")}</DialogDescription>
+        </DialogHeader>
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="space-y-2">
+            <Label htmlFor="file-name-prompt-input">
+              {t("fileNamePrompt.label")}
+            </Label>
+            <Input
+              id="file-name-prompt-input"
+              autoFocus
+              value={value}
+              onChange={(event) => setValue(event.target.value)}
+            />
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="outline" onClick={() => cancel()}>
+              {t("common.cancel")}
+            </Button>
+            <Button type="submit" disabled={!value.trim()}>
+              {t("common.save")}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -22,6 +22,7 @@ import {
   openThreeDTilesLayerPanel,
   openVectorLayerPanel,
   openZarrLayerPanel,
+  setBookmarkCaptureLabel,
   setReverseGeocodeLabels,
   DECK_VIZ_PLUGIN_ID,
   DIRECTIONS_PLUGIN_ID,
@@ -134,9 +135,9 @@ export function TopToolbar({
   onToggleThemeMode,
 }: TopToolbarProps) {
   const { t } = useTranslation();
-  // The reverse-geocode plugin lives in the framework-agnostic plugins package
-  // and cannot call t() itself, so push the translated popup strings into it
-  // here and refresh them whenever the active language changes.
+  // The reverse-geocode plugin and the bookmark control live in the
+  // framework-agnostic plugins package and cannot call t() themselves, so push
+  // the translated strings into them here and refresh on language change.
   useEffect(() => {
     setReverseGeocodeLabels({
       lookingUp: t("geocode.reverseLookingUp"),
@@ -144,6 +145,7 @@ export function TopToolbar({
       copyAddress: t("geocode.reverseCopyAddress"),
       failed: t("geocode.reverseFailed"),
     });
+    setBookmarkCaptureLabel(t("bookmark.captureStateLabel"));
   }, [t]);
 
   const setProcessingOpen = useAppStore((s) => s.setProcessingOpen);

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -91,6 +91,7 @@ import { ControlsMenu } from "./toolbar/ControlsMenu";
 import { EditMenu } from "./toolbar/EditMenu";
 import { HelpMenu } from "./toolbar/HelpMenu";
 import { OsmPbfDialogs } from "./toolbar/OsmPbfDialogs";
+import { FileNamePromptDialog } from "./FileNamePromptDialog";
 import { PluginsMenu } from "./toolbar/PluginsMenu";
 import { ProcessingMenu } from "./toolbar/ProcessingMenu";
 import { ProjectFileDialogs } from "./toolbar/ProjectFileDialogs";
@@ -870,6 +871,7 @@ export function TopToolbar({
         onOpenChange={setNetcdfDialogOpen}
       />
       <ProjectFileDialogs projectFiles={projectFiles} />
+      <FileNamePromptDialog />
       <ConsentNoticeDialogs consent={consent} />
       <OsmPbfDialogs osmPbf={osmPbf} />
       <AboutDialog

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -22,7 +22,6 @@ import {
   openThreeDTilesLayerPanel,
   openVectorLayerPanel,
   openZarrLayerPanel,
-  setBookmarkCaptureLabel,
   setReverseGeocodeLabels,
   DECK_VIZ_PLUGIN_ID,
   DIRECTIONS_PLUGIN_ID,
@@ -92,7 +91,6 @@ import { ControlsMenu } from "./toolbar/ControlsMenu";
 import { EditMenu } from "./toolbar/EditMenu";
 import { HelpMenu } from "./toolbar/HelpMenu";
 import { OsmPbfDialogs } from "./toolbar/OsmPbfDialogs";
-import { FileNamePromptDialog } from "./FileNamePromptDialog";
 import { PluginsMenu } from "./toolbar/PluginsMenu";
 import { ProcessingMenu } from "./toolbar/ProcessingMenu";
 import { ProjectFileDialogs } from "./toolbar/ProjectFileDialogs";
@@ -135,9 +133,9 @@ export function TopToolbar({
   onToggleThemeMode,
 }: TopToolbarProps) {
   const { t } = useTranslation();
-  // The reverse-geocode plugin and the bookmark control live in the
-  // framework-agnostic plugins package and cannot call t() themselves, so push
-  // the translated strings into them here and refresh on language change.
+  // The reverse-geocode plugin lives in the framework-agnostic plugins package
+  // and cannot call t() itself, so push the translated popup strings into it
+  // here and refresh them whenever the active language changes.
   useEffect(() => {
     setReverseGeocodeLabels({
       lookingUp: t("geocode.reverseLookingUp"),
@@ -145,7 +143,6 @@ export function TopToolbar({
       copyAddress: t("geocode.reverseCopyAddress"),
       failed: t("geocode.reverseFailed"),
     });
-    setBookmarkCaptureLabel(t("bookmark.captureStateLabel"));
   }, [t]);
 
   const setProcessingOpen = useAppStore((s) => s.setProcessingOpen);
@@ -877,7 +874,6 @@ export function TopToolbar({
         onOpenChange={setNetcdfDialogOpen}
       />
       <ProjectFileDialogs projectFiles={projectFiles} />
-      <FileNamePromptDialog />
       <ConsentNoticeDialogs consent={consent} />
       <OsmPbfDialogs osmPbf={osmPbf} />
       <AboutDialog

--- a/apps/geolibre-desktop/src/hooks/useFileNamePrompt.ts
+++ b/apps/geolibre-desktop/src/hooks/useFileNamePrompt.ts
@@ -1,0 +1,61 @@
+import { create } from "zustand";
+
+/**
+ * Options describing a single file-name prompt request.
+ */
+export interface FileNamePromptRequest {
+  /** Suggested file name, pre-filled in the input. */
+  defaultName: string;
+  /**
+   * Human-readable file-type label (e.g. "Bookmarks"), interpolated into the
+   * dialog title. Optional.
+   */
+  typeLabel?: string;
+}
+
+interface FileNamePromptState {
+  /** The in-flight request, or null when no prompt is open. */
+  request: FileNamePromptRequest | null;
+  /** Current value of the name input. */
+  value: string;
+  /** Resolver for the active prompt promise. */
+  resolve: ((name: string | null) => void) | null;
+  setValue: (value: string) => void;
+  /**
+   * Open the prompt and resolve with the chosen name, or null if cancelled.
+   * A prompt already in flight is cancelled (resolves null) before the new one
+   * opens, so overlapping callers cannot leak a pending promise.
+   */
+  prompt: (request: FileNamePromptRequest) => Promise<string | null>;
+  submit: () => void;
+  cancel: () => void;
+}
+
+/**
+ * App-wide store backing a single reusable "choose a file name" dialog. Used by
+ * the plugin host's text-file export when the browser cannot show a native save
+ * picker (Firefox, Safari), so the user can still name the downloaded file.
+ */
+export const useFileNamePrompt = create<FileNamePromptState>((set, get) => ({
+  request: null,
+  value: "",
+  resolve: null,
+  setValue: (value) => set({ value }),
+  prompt: (request) => {
+    get().resolve?.(null);
+    return new Promise<string | null>((resolve) => {
+      set({ request, value: request.defaultName, resolve });
+    });
+  },
+  submit: () => {
+    const { resolve, value } = get();
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    resolve?.(trimmed);
+    set({ request: null, value: "", resolve: null });
+  },
+  cancel: () => {
+    get().resolve?.(null);
+    set({ request: null, value: "", resolve: null });
+  },
+}));

--- a/apps/geolibre-desktop/src/hooks/useFileNamePrompt.ts
+++ b/apps/geolibre-desktop/src/hooks/useFileNamePrompt.ts
@@ -6,11 +6,6 @@ import { create } from "zustand";
 export interface FileNamePromptRequest {
   /** Suggested file name, pre-filled in the input. */
   defaultName: string;
-  /**
-   * Human-readable file-type label (e.g. "Bookmarks"), interpolated into the
-   * dialog title. Optional.
-   */
-  typeLabel?: string;
 }
 
 interface FileNamePromptState {

--- a/apps/geolibre-desktop/src/hooks/useFileNamePrompt.ts
+++ b/apps/geolibre-desktop/src/hooks/useFileNamePrompt.ts
@@ -31,7 +31,10 @@ interface FileNamePromptState {
 
 // Resolver for the active prompt promise. Kept in a module-scoped closure rather
 // than in the store state: it is an implementation detail of the promise/dialog
-// handshake, not part of the public store contract the dialog consumes.
+// handshake, not part of the public store contract the dialog consumes. Being a
+// module singleton, tests that exercise prompt() without reaching submit/cancel
+// should reset it (or the store) in beforeEach so a leftover resolver from one
+// test cannot resolve the next test's promise.
 let activeResolve: ((name: string | null) => void) | null = null;
 
 /**

--- a/apps/geolibre-desktop/src/hooks/useFileNamePrompt.ts
+++ b/apps/geolibre-desktop/src/hooks/useFileNamePrompt.ts
@@ -18,8 +18,6 @@ interface FileNamePromptState {
   request: FileNamePromptRequest | null;
   /** Current value of the name input. */
   value: string;
-  /** Resolver for the active prompt promise. */
-  resolve: ((name: string | null) => void) | null;
   setValue: (value: string) => void;
   /**
    * Open the prompt and resolve with the chosen name, or null if cancelled.
@@ -31,6 +29,11 @@ interface FileNamePromptState {
   cancel: () => void;
 }
 
+// Resolver for the active prompt promise. Kept in a module-scoped closure rather
+// than in the store state: it is an implementation detail of the promise/dialog
+// handshake, not part of the public store contract the dialog consumes.
+let activeResolve: ((name: string | null) => void) | null = null;
+
 /**
  * App-wide store backing a single reusable "choose a file name" dialog. Used by
  * the plugin host's text-file export when the browser cannot show a native save
@@ -39,23 +42,29 @@ interface FileNamePromptState {
 export const useFileNamePrompt = create<FileNamePromptState>((set, get) => ({
   request: null,
   value: "",
-  resolve: null,
   setValue: (value) => set({ value }),
   prompt: (request) => {
-    get().resolve?.(null);
+    activeResolve?.(null);
     return new Promise<string | null>((resolve) => {
-      set({ request, value: request.defaultName, resolve });
+      activeResolve = resolve;
+      set({ request, value: request.defaultName });
     });
   },
+  // Clear store state before invoking the resolver so a handler that
+  // synchronously re-enters the store (e.g. opens another prompt) sees a clean
+  // slate and cannot trigger a double-resolve.
   submit: () => {
-    const { resolve, value } = get();
-    const trimmed = value.trim();
+    const trimmed = get().value.trim();
     if (!trimmed) return;
+    const resolve = activeResolve;
+    activeResolve = null;
+    set({ request: null, value: "" });
     resolve?.(trimmed);
-    set({ request: null, value: "", resolve: null });
   },
   cancel: () => {
-    get().resolve?.(null);
-    set({ request: null, value: "", resolve: null });
+    const resolve = activeResolve;
+    activeResolve = null;
+    set({ request: null, value: "" });
+    resolve?.(null);
   },
 }));

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -400,7 +400,6 @@ export function createAppAPI(
         if (options?.promptName && browserSaveFallsBackToDownload()) {
           const chosen = await useFileNamePrompt.getState().prompt({
             defaultName: filename,
-            typeLabel: options?.description,
           });
           if (chosen === null) return;
           defaultName = ensureFileExtension(chosen, extensions);

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -47,10 +47,26 @@ import {
 import { appendDiagnostic } from "../lib/diagnostics";
 import { mergeStringLists } from "../lib/string-lists";
 import {
+  browserSaveFallsBackToDownload,
   openLocalDataFileWithFallback,
   saveTextFileWithFallback,
 } from "../lib/tauri-io";
 import { useDesktopSettingsStore } from "./useDesktopSettings";
+import { useFileNamePrompt } from "./useFileNamePrompt";
+
+/**
+ * Append the first allowed extension to a user-entered file name when it lacks
+ * one, so a name like "my-bookmarks" becomes "my-bookmarks.json".
+ */
+function ensureFileExtension(name: string, extensions: string[]): string {
+  const ext = extensions[0];
+  if (!ext) return name;
+  const lower = name.toLowerCase();
+  if (extensions.some((e) => lower.endsWith(`.${e.toLowerCase()}`))) {
+    return name;
+  }
+  return `${name}.${ext}`;
+}
 
 const RASTER_PROXY_PATH = "/__geolibre_raster_proxy";
 
@@ -375,17 +391,31 @@ export function createAppAPI(
       const description = options?.description ?? "GeoJSON";
       const extensions = options?.extensions ?? ["geojson", "json"];
       const mimeType = options?.mimeType ?? "application/geo+json";
-      void saveTextFileWithFallback(content, {
-        defaultName: filename,
-        filters: [{ name: description, extensions }],
-        browserTypes: [
-          {
-            description,
-            accept: { [mimeType]: extensions.map((ext) => `.${ext}`) },
-          },
-        ],
-        mimeType,
-      }).catch((error) => {
+      void (async () => {
+        let defaultName = filename;
+        // Browsers without the File System Access picker can only download under
+        // a fixed name. When the caller opts in, prompt so the user can choose
+        // it (Tauri and Chromium already offer a name via their save dialogs).
+        if (options?.promptName && browserSaveFallsBackToDownload()) {
+          const chosen = await useFileNamePrompt.getState().prompt({
+            defaultName: filename,
+            typeLabel: options?.description,
+          });
+          if (chosen === null) return;
+          defaultName = ensureFileExtension(chosen, extensions);
+        }
+        await saveTextFileWithFallback(content, {
+          defaultName,
+          filters: [{ name: description, extensions }],
+          browserTypes: [
+            {
+              description,
+              accept: { [mimeType]: extensions.map((ext) => `.${ext}`) },
+            },
+          ],
+          mimeType,
+        });
+      })().catch((error) => {
         console.error(`Could not export ${filename}.`, error);
       });
     },

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -65,7 +65,8 @@ function ensureFileExtension(name: string, extensions: string[]): string {
   if (extensions.some((e) => lower.endsWith(`.${e.toLowerCase()}`))) {
     return name;
   }
-  return `${name}.${ext}`;
+  // Strip any trailing dots first so "my-bookmarks." doesn't become a double dot.
+  return `${name.replace(/\.+$/, "")}.${ext}`;
 }
 
 const RASTER_PROXY_PATH = "/__geolibre_raster_proxy";

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1,4 +1,7 @@
 {
+  "bookmark": {
+    "captureStateLabel": "Include visible layers"
+  },
   "fileNamePrompt": {
     "title": "Save file as",
     "titleTyped": "Save {{type}} as",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1,4 +1,10 @@
 {
+  "fileNamePrompt": {
+    "title": "Save file as",
+    "titleTyped": "Save {{type}} as",
+    "description": "Choose a file name. The file downloads to your browser's downloads folder.",
+    "label": "File name"
+  },
   "common": {
     "save": "Save",
     "cancel": "Cancel",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -4,7 +4,6 @@
   },
   "fileNamePrompt": {
     "title": "Save file as",
-    "titleTyped": "Save {{type}} as",
     "description": "Choose a file name. The file downloads to your browser's downloads folder.",
     "label": "File name"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.1",
         "maplibre-gl-basemap-control": "^0.4.0",
-        "maplibre-gl-components": "^0.20.6",
+        "maplibre-gl-components": "^0.21.0",
         "maplibre-gl-duckdb": "^0.2.0",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -185,9 +185,9 @@
       "license": "MIT"
     },
     "apps/geolibre-desktop/node_modules/maplibre-gl-components": {
-      "version": "0.20.6",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.20.6.tgz",
-      "integrity": "sha512-Ge5F84jXHnTwS+lHoj3k0uflGll65a1uGavTRiTFEsjqC45xOcL0G1LPj04PUKurlthVX1PXG/7sh1zzfEvPTg==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.21.0.tgz",
+      "integrity": "sha512-4dL7ZlA8V1UFLXC6J0YFVfHl2F/Ko6luDqvBgkEtYzy+Ahdi/ZQBqxnGhuHGx6mx3xwlSh3Iw/Q/OdhNmc660w==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",
@@ -24276,7 +24276,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.1",
         "maplibre-gl-basemap-control": "^0.4.0",
-        "maplibre-gl-components": "^0.20.6",
+        "maplibre-gl-components": "^0.21.0",
         "maplibre-gl-duckdb": "^0.2.0",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -24313,9 +24313,9 @@
       }
     },
     "packages/plugins/node_modules/maplibre-gl-components": {
-      "version": "0.20.6",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.20.6.tgz",
-      "integrity": "sha512-Ge5F84jXHnTwS+lHoj3k0uflGll65a1uGavTRiTFEsjqC45xOcL0G1LPj04PUKurlthVX1PXG/7sh1zzfEvPTg==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.21.0.tgz",
+      "integrity": "sha512-4dL7ZlA8V1UFLXC6J0YFVfHl2F/Ko6luDqvBgkEtYzy+Ahdi/ZQBqxnGhuHGx6mx3xwlSh3Iw/Q/OdhNmc660w==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -31,7 +31,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.1",
     "maplibre-gl-basemap-control": "^0.4.0",
-    "maplibre-gl-components": "^0.20.6",
+    "maplibre-gl-components": "^0.21.0",
     "maplibre-gl-duckdb": "^0.2.0",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -49,6 +49,7 @@ export {
   openZarrLayerPanel,
   addCloudNetcdfLayer,
   type CloudNetcdfLayerOptions,
+  setBookmarkCaptureLabel,
   subscribeBookmarkPanel,
   subscribeColorbarPanel,
   subscribeHtmlPanel,

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -309,12 +309,19 @@ function restoreVisibleLayers(
   const wanted = new Set(
     ids.filter((id): id is string => typeof id === "string"),
   );
-  const { layers, setLayerVisibility } = useAppStore.getState();
-  for (const layer of layers) {
+  const { layers } = useAppStore.getState();
+  // Apply every visibility change in one store update (instead of one per layer)
+  // so restoring a bookmark triggers a single re-render and layer-sync pass.
+  // Unchanged layers keep their identity so the sync skips them.
+  let changed = false;
+  const next = layers.map((layer) => {
     const shouldShow = wanted.has(layer.id);
-    if (layer.visible !== shouldShow) {
-      setLayerVisibility(layer.id, shouldShow);
-    }
+    if (layer.visible === shouldShow) return layer;
+    changed = true;
+    return { ...layer, visible: shouldShow };
+  });
+  if (changed) {
+    useAppStore.setState({ layers: next, isDirty: true });
   }
   const present = new Set(layers.map((layer) => layer.id));
   const missing = [...wanted].filter((id) => !present.has(id)).length;
@@ -334,9 +341,8 @@ const BOOKMARK_OPTIONS = {
   panelWidth: 280,
   position: bookmarkControlPosition,
   storageKey: "geolibre-bookmarks",
-  // Resizable panel (#468) and drag reordering (#471) are on by default
-  // upstream; enable per-bookmark export selection (#470) and layer capture
-  // (#467) here.
+  // Resizable panel and drag reordering are on by default upstream; enable
+  // per-bookmark export selection and visible-layer capture here.
   selectable: true,
   captureState: captureVisibleLayers,
   restoreState: restoreVisibleLayers,
@@ -2612,7 +2618,7 @@ function routeBookmarkFileIoThroughHost(
     extensions: ["json"],
     mimeType: "application/json",
     // Let the user name the export when the browser has no native save picker
-    // (Firefox, Safari); Tauri and Chromium already prompt for a name (#469).
+    // (Firefox, Safari); Tauri and Chromium already prompt for a name.
     promptName: true,
   };
 

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -284,13 +284,24 @@ const MEASURE_OPTIONS = {
 } satisfies MeasureControlOptions;
 
 /**
+ * Label for the bookmark "capture state" checkbox. Default is English; the
+ * desktop shell pushes a translated value via {@link setBookmarkCaptureLabel}
+ * since this package is framework-agnostic and has no react-i18next access.
+ */
+let bookmarkCaptureLabel = "Include visible layers";
+
+/** Override the bookmark capture-state checkbox label with translated text. */
+export function setBookmarkCaptureLabel(label: string): void {
+  if (label) bookmarkCaptureLabel = label;
+}
+
+/**
  * Capture which layers are currently visible so a bookmark can restore the same
- * displayed set later. Returns `undefined` when no layers are loaded, so an
- * empty capture never hides everything on restore.
+ * displayed set later. Always records the set (empty when no layers are
+ * visible) so the restore faithfully reproduces the displayed state.
  */
 function captureVisibleLayers(): Record<string, unknown> | undefined {
   const { layers } = useAppStore.getState();
-  if (layers.length === 0) return undefined;
   return {
     visibleLayerIds: layers.filter((layer) => layer.visible).map((l) => l.id),
   };
@@ -342,11 +353,12 @@ const BOOKMARK_OPTIONS = {
   position: bookmarkControlPosition,
   storageKey: "geolibre-bookmarks",
   // Resizable panel and drag reordering are on by default upstream; enable
-  // per-bookmark export selection and visible-layer capture here.
+  // per-bookmark export selection and visible-layer capture here. The
+  // capture-checkbox label is applied per-instance in createBookmarkControl so
+  // it can pick up the translated string.
   selectable: true,
   captureState: captureVisibleLayers,
   restoreState: restoreVisibleLayers,
-  captureStateLabel: "Include visible layers",
 } satisfies BookmarkControlOptions;
 
 const MINIMAP_OPTIONS = {
@@ -2570,7 +2582,10 @@ function createBookmarkControl(
   BookmarkControlClass: BookmarkControlConstructor,
   app: GeoLibreAppAPI,
 ): BookmarkControl {
-  const control = new BookmarkControlClass(BOOKMARK_OPTIONS);
+  const control = new BookmarkControlClass({
+    ...BOOKMARK_OPTIONS,
+    captureStateLabel: bookmarkCaptureLabel,
+  });
   control.on("collapse", () => {
     if (control !== bookmarkControl) return;
     setTimeout(() => {

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -283,6 +283,48 @@ const MEASURE_OPTIONS = {
   position: measureControlPosition,
 } satisfies MeasureControlOptions;
 
+/**
+ * Capture which layers are currently visible so a bookmark can restore the same
+ * displayed set later. Returns `undefined` when no layers are loaded, so an
+ * empty capture never hides everything on restore.
+ */
+function captureVisibleLayers(): Record<string, unknown> | undefined {
+  const { layers } = useAppStore.getState();
+  if (layers.length === 0) return undefined;
+  return {
+    visibleLayerIds: layers.filter((layer) => layer.visible).map((l) => l.id),
+  };
+}
+
+/**
+ * Restore the visible-layer set captured with a bookmark: show the layers that
+ * were visible, hide the rest. Captured layers that no longer exist are skipped
+ * (they cannot be re-added from a view bookmark).
+ */
+function restoreVisibleLayers(
+  extra: Record<string, unknown> | undefined,
+): void {
+  const ids = extra?.visibleLayerIds;
+  if (!Array.isArray(ids)) return;
+  const wanted = new Set(
+    ids.filter((id): id is string => typeof id === "string"),
+  );
+  const { layers, setLayerVisibility } = useAppStore.getState();
+  for (const layer of layers) {
+    const shouldShow = wanted.has(layer.id);
+    if (layer.visible !== shouldShow) {
+      setLayerVisibility(layer.id, shouldShow);
+    }
+  }
+  const present = new Set(layers.map((layer) => layer.id));
+  const missing = [...wanted].filter((id) => !present.has(id)).length;
+  if (missing > 0) {
+    console.info(
+      `BookmarkControl: ${missing} captured layer(s) are no longer present and were skipped.`,
+    );
+  }
+}
+
 const BOOKMARK_OPTIONS = {
   backgroundColor: "hsl(var(--popover))",
   className: "geolibre-bookmark-control",
@@ -292,6 +334,13 @@ const BOOKMARK_OPTIONS = {
   panelWidth: 280,
   position: bookmarkControlPosition,
   storageKey: "geolibre-bookmarks",
+  // Resizable panel (#468) and drag reordering (#471) are on by default
+  // upstream; enable per-bookmark export selection (#470) and layer capture
+  // (#467) here.
+  selectable: true,
+  captureState: captureVisibleLayers,
+  restoreState: restoreVisibleLayers,
+  captureStateLabel: "Include visible layers",
 } satisfies BookmarkControlOptions;
 
 const MINIMAP_OPTIONS = {
@@ -2539,7 +2588,7 @@ function routeBookmarkFileIoThroughHost(
   app: GeoLibreAppAPI,
 ): void {
   // `_exportToFile`/`_importFromFile` are private (underscore-prefixed) members
-  // of BookmarkControl as of maplibre-gl-components@0.20.1. If a future version
+  // of BookmarkControl as of maplibre-gl-components@0.21.0. If a future version
   // renames them, the overrides below silently stop being called and file I/O
   // regresses to the WebView-incompatible Blob/file-input path — so warn loudly
   // to flag it when bumping the dependency.
@@ -2562,6 +2611,9 @@ function routeBookmarkFileIoThroughHost(
     description: "Bookmarks",
     extensions: ["json"],
     mimeType: "application/json",
+    // Let the user name the export when the browser has no native save picker
+    // (Firefox, Safari); Tauri and Chromium already prompt for a name (#469).
+    promptName: true,
   };
 
   io._exportToFile = () => {

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -300,7 +300,7 @@ export function setBookmarkCaptureLabel(label: string): void {
  * displayed set later. Always records the set (empty when no layers are
  * visible) so the restore faithfully reproduces the displayed state.
  */
-function captureVisibleLayers(): Record<string, unknown> | undefined {
+function captureVisibleLayers(): Record<string, unknown> {
   const { layers } = useAppStore.getState();
   return {
     visibleLayerIds: layers.filter((layer) => layer.visible).map((l) => l.id),

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -47,6 +47,14 @@ export interface GeoLibreFileDialogOptions {
   extensions?: string[];
   /** MIME type used for the browser download blob. */
   mimeType?: string;
+  /**
+   * For {@link GeoLibreAppAPI.exportTextFile}: when true, ask the user for a
+   * file name first in browsers that cannot show a native save picker (Firefox,
+   * Safari), where the export would otherwise download under a fixed name. Has
+   * no effect under Tauri or in browsers with the File System Access picker,
+   * which already let the user choose the name.
+   */
+  promptName?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements the five bookmark feature requests (#467, #468, #469, #470, #471) by adopting `maplibre-gl-components@0.21.0` (opengeos/maplibre-gl-components#100) and wiring its new `BookmarkControl` capabilities into GeoLibre.

- **#467 - capture layers:** bookmarks can record which layers were visible. A new "Include visible layers" checkbox in the add form opts in (on by default); opening the bookmark restores that displayed layer set (shows the captured layers, hides the rest). Captured layers that no longer exist are skipped. Implemented with the upstream `captureState`/`restoreState` hooks and `setLayerVisibility`.
- **#468 - resizable panel:** the bookmark panel can be resized by dragging its corner (upstream default).
- **#469 - save-as with file name:** adds an app-wide "choose a file name" prompt (`useFileNamePrompt` store + `FileNamePromptDialog`) used by `exportTextFile` when the browser has no native save picker (Firefox, Safari), where the export would otherwise download under a fixed name. The bookmark export opts in via the new `promptName` dialog option. Tauri and Chromium browsers already let the user name the file via their save dialogs.
- **#470 - export selected:** per-bookmark export checkboxes; Export writes only the ticked subset (all when none selected).
- **#471 - reorderable:** bookmarks can be reordered by dragging their grip handle (upstream default); the order persists.

## Changes
- `packages/plugins`: `captureVisibleLayers`/`restoreVisibleLayers` + new `BOOKMARK_OPTIONS` (`selectable`, `captureState`, `restoreState`, `captureStateLabel`); `promptName` added to `GeoLibreFileDialogOptions`; bookmark export opts into the name prompt.
- `apps/geolibre-desktop`: `exportTextFile` prompts for a name when the browser lacks a save picker; new `useFileNamePrompt` store and `FileNamePromptDialog` (mounted in `TopToolbar`); `fileNamePrompt.*` i18n strings.
- Dependency bumped to `maplibre-gl-components@^0.21.0`.

## Test plan
- [x] `npm run build` (typecheck + web build)
- [x] `npm run test:frontend` (1078 pass)
- [x] `pre-commit run --files <changed>` (eslint + npm build pass)
- [ ] Manual: capture a bookmark with layers, toggle layers, reopen to confirm restore; resize the panel; reorder via grip; export a selected subset; in Firefox confirm the name prompt appears on export

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File export now prompts for filename with automatic file extension handling to ensure proper format validation
  * Bookmark feature now includes option to capture and restore the state of currently visible layers
  * Improved file naming workflow with validation for exported files
<!-- end of auto-generated comment: release notes by coderabbit.ai -->