### PR TITLE
fix(add-data): simplify the "Insert before" menu (#453)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/add-data/shared.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/shared.tsx
@@ -148,6 +148,8 @@ export function InsertBeforeField({
       {basemapStyleLayerIds.length > 0 && !valueIsBasemapLayer && (
         <button
           type="button"
+          aria-expanded={showBasemapLayers}
+          aria-controls="add-data-before-id"
           className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
           onClick={() => setShowBasemapLayers((prev) => !prev)}
         >

--- a/apps/geolibre-desktop/src/components/layout/add-data/shared.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/shared.tsx
@@ -108,6 +108,13 @@ export function InsertBeforeField({
   // controller once it finishes initialising; the call is a cheap filter.
   const basemapStyleLayerIds =
     mapControllerRef.current?.getBasemapStyleLayerIds() ?? [];
+  // The basemap style exposes dozens of internal layer ids that overwhelm the
+  // dropdown for standard users (issue #453). Keep them behind an opt-in
+  // "advanced" toggle so the default list only shows the user's own layers —
+  // but reveal them automatically if the current value is one of them.
+  const valueIsBasemapLayer = basemapStyleLayerIds.includes(value);
+  const [showBasemapLayers, setShowBasemapLayers] = useState(valueIsBasemapLayer);
+  const basemapLayersVisible = showBasemapLayers || valueIsBasemapLayer;
   return (
     <div className="space-y-1.5">
       <Label htmlFor="add-data-before-id">
@@ -128,7 +135,7 @@ export function InsertBeforeField({
             ))}
           </optgroup>
         )}
-        {basemapStyleLayerIds.length > 0 && (
+        {basemapStyleLayerIds.length > 0 && basemapLayersVisible && (
           <optgroup label={t("addData.shared.basemapLayersGroup")}>
             {basemapStyleLayerIds.map((styleLayerId) => (
               <option key={styleLayerId} value={styleLayerId}>
@@ -138,6 +145,17 @@ export function InsertBeforeField({
           </optgroup>
         )}
       </Select>
+      {basemapStyleLayerIds.length > 0 && !valueIsBasemapLayer && (
+        <button
+          type="button"
+          className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+          onClick={() => setShowBasemapLayers((prev) => !prev)}
+        >
+          {showBasemapLayers
+            ? t("addData.shared.hideBasemapLayers")
+            : t("addData.shared.showBasemapLayers")}
+        </button>
+      )}
     </div>
   );
 }

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -62,6 +62,8 @@
       "insertTop": "Top of layer list (default)",
       "layersGroup": "Layers",
       "basemapLayersGroup": "Basemap layers",
+      "showBasemapLayers": "Show basemap layers (advanced)",
+      "hideBasemapLayers": "Hide basemap layers",
       "addLayer": "Add layer",
       "adding": "Adding…",
       "addError": "Could not add layer."


### PR DESCRIPTION
## Summary

Closes #453.

The Add Data dialog's **Insert before** dropdown listed every raw basemap style-layer id (~112 entries like `background`, `park`, `landuse_residential`, …) alongside the user's own layers, overwhelming standard users who just want to drop a new layer beneath an existing one.

This scopes the default list to what's in the layer menu and tucks the internal style ids behind an opt-in advanced toggle, as the reporter requested.

## Changes

`InsertBeforeField` (`apps/geolibre-desktop/src/components/layout/add-data/shared.tsx`):
- By default shows only **Top of layer list (default)** + the user's own layers (**Layers** optgroup).
- Hides the **Basemap layers** optgroup behind a **"Show basemap layers (advanced)"** toggle (→ **"Hide basemap layers"** when expanded).
- Auto-reveals the basemap group when the current value is itself a basemap layer id, so no selection becomes unreachable.

Adds two i18n keys (`showBasemapLayers`, `hideBasemapLayers`) to `en.json`; other locales fall back to English.

No upstream change to `maplibre-gl-basemap-control` was needed — that package governs basemap switching, not this dropdown. The clutter came from GeoLibre's own `getBasemapStyleLayerIds()`.

## Verification

`npm run test:frontend` (1078 pass / 0 fail) and `tsc -b` clean. Verified in the real app with Playwright:
- Default (no user layers) → only `Top of layer list`; basemap group absent.
- **Show basemap layers (advanced)** → 112 options under **Basemap layers**, label flips to **Hide basemap layers**; clicking it collapses back.
- After adding a real XYZ OSM layer → default dropdown = `Top of layer list` + **Layers › XYZ Layer**, still no basemap clutter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “advanced” toggle in the layer insertion dropdown to show or hide basemap/internal layer options.
  * The dropdown now automatically reveals basemap options when the current selection is already a basemap layer.
  * Updated UI text via new English translations for showing or hiding basemap layers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->