### PR TITLE
feat(globe): customizable atmosphere halo and space colors

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -565,7 +565,11 @@ export function DesktopShell({
     // activeByDefault plugins are marked active without activate() being
     // called, so the effects engine must be kicked explicitly to match the
     // restored active state (idempotent).
-    restoreEffects(appAPI, pluginManager.isActive(EFFECTS_PLUGIN_ID));
+    restoreEffects(
+      appAPI,
+      pluginManager.isActive(EFFECTS_PLUGIN_ID),
+      useAppStore.getState().projectPlugins?.settings?.[EFFECTS_PLUGIN_ID],
+    );
     // Rebind the directions tool to the (possibly new) map instance after a
     // map re-init, since restoreProjectState skips an already-active plugin.
     restoreDirections(appAPI, pluginManager.isActive(DIRECTIONS_PLUGIN_ID));

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -166,7 +166,8 @@ export function TopToolbar({
     toggle,
     setMapControlPosition,
     getEffectsSettings,
-    updateEffectsSettings,
+    previewEffectsSettings,
+    commitEffectsSettings,
   } = usePluginRegistry();
   // mapControllerRef is a stable ref object and createAppAPI dereferences
   // `.current` lazily, so memoizing on the ref keeps a single appApi identity
@@ -776,7 +777,8 @@ export function TopToolbar({
         onToggleMapControl={toggleMapControl}
         onToggleEffects={() => toggle(EFFECTS_PLUGIN_ID, appApi)}
         getEffectsSettings={getEffectsSettings}
-        onUpdateEffectsSettings={updateEffectsSettings}
+        onPreviewEffectsSettings={previewEffectsSettings}
+        onCommitEffectsSettings={commitEffectsSettings}
         onToggleDirections={consent.handleToggleDirections}
         onToggleReverseGeocode={consent.handleToggleReverseGeocode}
         onOpenFieldCollection={() => setFieldCollectionOpen(true)}

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -165,6 +165,8 @@ export function TopToolbar({
     getMapControlPosition,
     toggle,
     setMapControlPosition,
+    getEffectsSettings,
+    updateEffectsSettings,
   } = usePluginRegistry();
   // mapControllerRef is a stable ref object and createAppAPI dereferences
   // `.current` lazily, so memoizing on the ref keeps a single appApi identity
@@ -773,6 +775,8 @@ export function TopToolbar({
         reverseGeocodeActive={isActive(REVERSE_GEOCODE_PLUGIN_ID)}
         onToggleMapControl={toggleMapControl}
         onToggleEffects={() => toggle(EFFECTS_PLUGIN_ID, appApi)}
+        getEffectsSettings={getEffectsSettings}
+        onUpdateEffectsSettings={updateEffectsSettings}
         onToggleDirections={consent.handleToggleDirections}
         onToggleReverseGeocode={consent.handleToggleReverseGeocode}
         onOpenFieldCollection={() => setFieldCollectionOpen(true)}

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ControlsMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ControlsMenu.tsx
@@ -209,8 +209,12 @@ function AtmosphereEffectsSubmenu({
       </DropdownMenuSubTrigger>
       <DropdownMenuSubContent className="w-64">
         <DropdownMenuItem
-          onSelect={(e: Event) => e.preventDefault()}
-          onClick={onToggle}
+          // onSelect (not onClick) fires for both mouse and keyboard
+          // (Enter/Space); preventDefault keeps the submenu open after toggling.
+          onSelect={(e: Event) => {
+            e.preventDefault();
+            onToggle();
+          }}
         >
           {t("toolbar.item.atmosphereEnabled")}
           {active ? " ✓" : ""}
@@ -258,9 +262,11 @@ function AtmosphereEffectsSubmenu({
         </div>
         <DropdownMenuSeparator />
         <DropdownMenuItem
-          onSelect={(e: Event) => e.preventDefault()}
-          onClick={() => {
-            // A discrete action: preview the defaults, then commit immediately.
+          // onSelect fires for mouse and keyboard alike. A discrete action:
+          // preview the defaults, then commit immediately. preventDefault keeps
+          // the submenu open so the reset is visible in the controls.
+          onSelect={(e: Event) => {
+            e.preventDefault();
             preview({ ...DEFAULT_EFFECTS_SETTINGS });
             onCommit();
           }}

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ControlsMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ControlsMenu.tsx
@@ -1,13 +1,26 @@
 import {
+  DEFAULT_EFFECTS_SETTINGS,
+  type EffectsSettings,
+  HALO_EXTENT_MAX,
+  HALO_EXTENT_MIN,
+  HALO_OPACITY_MAX,
+  HALO_OPACITY_MIN,
+} from "@geolibre/plugins";
+import {
   Button,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
+  Slider,
 } from "@geolibre/ui";
 import { ClipboardList, SlidersHorizontal } from "lucide-react";
+import { type MouseEvent as ReactMouseEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { ToolbarPanels } from "../../../hooks/useToolbarPanels";
 import {
@@ -25,6 +38,8 @@ interface ControlsMenuProps {
   reverseGeocodeActive: boolean;
   onToggleMapControl: (control: ToolbarMapControl) => void;
   onToggleEffects: () => void;
+  getEffectsSettings: () => EffectsSettings;
+  onUpdateEffectsSettings: (next: Partial<EffectsSettings>) => void;
   onToggleDirections: () => void;
   onToggleReverseGeocode: () => void;
   onOpenFieldCollection: () => void;
@@ -40,6 +55,8 @@ export function ControlsMenu({
   reverseGeocodeActive,
   onToggleMapControl,
   onToggleEffects,
+  getEffectsSettings,
+  onUpdateEffectsSettings,
   onToggleDirections,
   onToggleReverseGeocode,
   onOpenFieldCollection,
@@ -71,10 +88,12 @@ export function ControlsMenu({
             {controlsVisible[control.id] ? " ✓" : ""}
           </DropdownMenuItem>
         ))}
-        <DropdownMenuItem onClick={onToggleEffects}>
-          {t("toolbar.item.atmosphereEffects")}
-          {effectsActive ? " ✓" : ""}
-        </DropdownMenuItem>
+        <AtmosphereEffectsSubmenu
+          active={effectsActive}
+          onToggle={onToggleEffects}
+          getSettings={getEffectsSettings}
+          onUpdate={onUpdateEffectsSettings}
+        />
         <DropdownMenuItem
           title={t("toolbar.item.directionsTooltip")}
           onClick={onToggleDirections}
@@ -129,5 +148,168 @@ export function ControlsMenu({
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
+  );
+}
+
+interface AtmosphereEffectsSubmenuProps {
+  active: boolean;
+  onToggle: () => void;
+  getSettings: () => EffectsSettings;
+  onUpdate: (next: Partial<EffectsSettings>) => void;
+}
+
+/**
+ * Submenu for the globe atmosphere: an on/off toggle plus live controls for the
+ * halo color, how far the halo reaches past the globe (the "floats above the
+ * surface" vs "tight to the surface" look), the halo strength, and the deep
+ * space backdrop color. Edits apply immediately and persist with the project.
+ *
+ * Settings live in module state in the effects plugin, so this keeps a local
+ * mirror seeded each time the submenu opens; every edit updates both the mirror
+ * (for an instant UI response) and the plugin (for the live globe + persistence).
+ */
+function AtmosphereEffectsSubmenu({
+  active,
+  onToggle,
+  getSettings,
+  onUpdate,
+}: AtmosphereEffectsSubmenuProps) {
+  const { t } = useTranslation();
+  const [settings, setSettings] = useState<EffectsSettings>(getSettings);
+
+  const apply = (next: Partial<EffectsSettings>) => {
+    setSettings((prev) => ({ ...prev, ...next }));
+    onUpdate(next);
+  };
+
+  return (
+    <DropdownMenuSub
+      onOpenChange={(open: boolean) => {
+        // Re-seed from the source of truth on open so the controls reflect a
+        // project that loaded new settings while the menu was closed.
+        if (open) setSettings(getSettings());
+      }}
+    >
+      <DropdownMenuSubTrigger>
+        {t("toolbar.item.atmosphereEffects")}
+        {active ? " ✓" : ""}
+      </DropdownMenuSubTrigger>
+      <DropdownMenuSubContent className="w-64">
+        <DropdownMenuItem
+          onSelect={(e: Event) => e.preventDefault()}
+          onClick={onToggle}
+        >
+          {t("toolbar.item.atmosphereEnabled")}
+          {active ? " ✓" : ""}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        {/* Stop key events from reaching the menu's roving-focus/typeahead
+            handlers so sliders respond to arrow keys and the color inputs work. */}
+        <div
+          className="space-y-3 px-2 py-1.5"
+          onKeyDown={(e) => e.stopPropagation()}
+        >
+          <ColorRow
+            label={t("toolbar.atmosphere.haloColor")}
+            value={settings.haloColor}
+            onChange={(haloColor) => apply({ haloColor })}
+          />
+          <SliderRow
+            label={t("toolbar.atmosphere.haloExtent")}
+            hint={t("toolbar.atmosphere.haloExtentHint")}
+            min={HALO_EXTENT_MIN}
+            max={HALO_EXTENT_MAX}
+            step={0.05}
+            value={settings.haloExtent}
+            format={(v) => `${v.toFixed(2)}×`}
+            onChange={(haloExtent) => apply({ haloExtent })}
+          />
+          <SliderRow
+            label={t("toolbar.atmosphere.haloOpacity")}
+            min={HALO_OPACITY_MIN}
+            max={HALO_OPACITY_MAX}
+            step={0.05}
+            value={settings.haloOpacity}
+            format={(v) => `${Math.round(v * 100)}%`}
+            onChange={(haloOpacity) => apply({ haloOpacity })}
+          />
+          <ColorRow
+            label={t("toolbar.atmosphere.spaceColor")}
+            value={settings.spaceColor}
+            onChange={(spaceColor) => apply({ spaceColor })}
+          />
+        </div>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onSelect={(e: Event) => e.preventDefault()}
+          onClick={() => apply({ ...DEFAULT_EFFECTS_SETTINGS })}
+        >
+          {t("toolbar.atmosphere.reset")}
+        </DropdownMenuItem>
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
+  );
+}
+
+interface ColorRowProps {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+}
+
+function ColorRow({ label, value, onChange }: ColorRowProps) {
+  return (
+    <label className="flex items-center justify-between gap-2 text-xs">
+      <span className="text-muted-foreground">{label}</span>
+      <input
+        type="color"
+        aria-label={label}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="h-6 w-10 cursor-pointer rounded border border-input bg-transparent p-0.5"
+      />
+    </label>
+  );
+}
+
+interface SliderRowProps {
+  label: string;
+  hint?: string;
+  min: number;
+  max: number;
+  step: number;
+  value: number;
+  format: (value: number) => string;
+  onChange: (value: number) => void;
+}
+
+function SliderRow({
+  label,
+  hint,
+  min,
+  max,
+  step,
+  value,
+  format,
+  onChange,
+}: SliderRowProps) {
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-xs">
+        <span className="text-muted-foreground" title={hint}>
+          {label}
+        </span>
+        <span className="tabular-nums text-foreground">{format(value)}</span>
+      </div>
+      <Slider
+        aria-label={label}
+        min={min}
+        max={max}
+        step={step}
+        value={[value]}
+        onValueChange={([v]: number[]) => onChange(v ?? value)}
+        onClick={(e: ReactMouseEvent) => e.stopPropagation()}
+      />
+    </div>
   );
 }

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ControlsMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ControlsMenu.tsx
@@ -39,7 +39,8 @@ interface ControlsMenuProps {
   onToggleMapControl: (control: ToolbarMapControl) => void;
   onToggleEffects: () => void;
   getEffectsSettings: () => EffectsSettings;
-  onUpdateEffectsSettings: (next: Partial<EffectsSettings>) => void;
+  onPreviewEffectsSettings: (next: Partial<EffectsSettings>) => void;
+  onCommitEffectsSettings: () => void;
   onToggleDirections: () => void;
   onToggleReverseGeocode: () => void;
   onOpenFieldCollection: () => void;
@@ -56,7 +57,8 @@ export function ControlsMenu({
   onToggleMapControl,
   onToggleEffects,
   getEffectsSettings,
-  onUpdateEffectsSettings,
+  onPreviewEffectsSettings,
+  onCommitEffectsSettings,
   onToggleDirections,
   onToggleReverseGeocode,
   onOpenFieldCollection,
@@ -92,7 +94,8 @@ export function ControlsMenu({
           active={effectsActive}
           onToggle={onToggleEffects}
           getSettings={getEffectsSettings}
-          onUpdate={onUpdateEffectsSettings}
+          onPreview={onPreviewEffectsSettings}
+          onCommit={onCommitEffectsSettings}
         />
         <DropdownMenuItem
           title={t("toolbar.item.directionsTooltip")}
@@ -155,39 +158,49 @@ interface AtmosphereEffectsSubmenuProps {
   active: boolean;
   onToggle: () => void;
   getSettings: () => EffectsSettings;
-  onUpdate: (next: Partial<EffectsSettings>) => void;
+  onPreview: (next: Partial<EffectsSettings>) => void;
+  onCommit: () => void;
 }
 
 /**
  * Submenu for the globe atmosphere: an on/off toggle plus live controls for the
  * halo color, how far the halo reaches past the globe (the "floats above the
  * surface" vs "tight to the surface" look), the halo strength, and the deep
- * space backdrop color. Edits apply immediately and persist with the project.
+ * space backdrop color.
  *
  * Settings live in module state in the effects plugin, so this keeps a local
- * mirror seeded each time the submenu opens; every edit updates both the mirror
- * (for an instant UI response) and the plugin (for the live globe + persistence).
+ * mirror seeded each time the submenu opens. Edits preview live (instant UI +
+ * globe redraw) on every change, and persist only when a gesture ends — a
+ * slider release, a color input blur, a reset, or the submenu closing — so a
+ * color-picker drag doesn't churn the project-dirty flag on every frame.
  */
 function AtmosphereEffectsSubmenu({
   active,
   onToggle,
   getSettings,
-  onUpdate,
+  onPreview,
+  onCommit,
 }: AtmosphereEffectsSubmenuProps) {
   const { t } = useTranslation();
   const [settings, setSettings] = useState<EffectsSettings>(getSettings);
 
-  const apply = (next: Partial<EffectsSettings>) => {
+  const preview = (next: Partial<EffectsSettings>) => {
     setSettings((prev) => ({ ...prev, ...next }));
-    onUpdate(next);
+    onPreview(next);
   };
 
   return (
     <DropdownMenuSub
       onOpenChange={(open: boolean) => {
-        // Re-seed from the source of truth on open so the controls reflect a
-        // project that loaded new settings while the menu was closed.
-        if (open) setSettings(getSettings());
+        if (open) {
+          // Re-seed from the source of truth on open so the controls reflect a
+          // project that loaded new settings while the menu was closed.
+          setSettings(getSettings());
+        } else {
+          // Backstop: persist any previewed change whose gesture-end commit
+          // didn't fire (e.g. a color picked then the menu dismissed).
+          onCommit();
+        }
       }}
     >
       <DropdownMenuSubTrigger>
@@ -212,7 +225,8 @@ function AtmosphereEffectsSubmenu({
           <ColorRow
             label={t("toolbar.atmosphere.haloColor")}
             value={settings.haloColor}
-            onChange={(haloColor) => apply({ haloColor })}
+            onPreview={(haloColor) => preview({ haloColor })}
+            onCommit={onCommit}
           />
           <SliderRow
             label={t("toolbar.atmosphere.haloExtent")}
@@ -222,7 +236,8 @@ function AtmosphereEffectsSubmenu({
             step={0.05}
             value={settings.haloExtent}
             format={(v) => `${v.toFixed(2)}×`}
-            onChange={(haloExtent) => apply({ haloExtent })}
+            onPreview={(haloExtent) => preview({ haloExtent })}
+            onCommit={onCommit}
           />
           <SliderRow
             label={t("toolbar.atmosphere.haloOpacity")}
@@ -231,18 +246,24 @@ function AtmosphereEffectsSubmenu({
             step={0.05}
             value={settings.haloOpacity}
             format={(v) => `${Math.round(v * 100)}%`}
-            onChange={(haloOpacity) => apply({ haloOpacity })}
+            onPreview={(haloOpacity) => preview({ haloOpacity })}
+            onCommit={onCommit}
           />
           <ColorRow
             label={t("toolbar.atmosphere.spaceColor")}
             value={settings.spaceColor}
-            onChange={(spaceColor) => apply({ spaceColor })}
+            onPreview={(spaceColor) => preview({ spaceColor })}
+            onCommit={onCommit}
           />
         </div>
         <DropdownMenuSeparator />
         <DropdownMenuItem
           onSelect={(e: Event) => e.preventDefault()}
-          onClick={() => apply({ ...DEFAULT_EFFECTS_SETTINGS })}
+          onClick={() => {
+            // A discrete action: preview the defaults, then commit immediately.
+            preview({ ...DEFAULT_EFFECTS_SETTINGS });
+            onCommit();
+          }}
         >
           {t("toolbar.atmosphere.reset")}
         </DropdownMenuItem>
@@ -254,10 +275,11 @@ function AtmosphereEffectsSubmenu({
 interface ColorRowProps {
   label: string;
   value: string;
-  onChange: (value: string) => void;
+  onPreview: (value: string) => void;
+  onCommit: () => void;
 }
 
-function ColorRow({ label, value, onChange }: ColorRowProps) {
+function ColorRow({ label, value, onPreview, onCommit }: ColorRowProps) {
   return (
     <label className="flex items-center justify-between gap-2 text-xs">
       <span className="text-muted-foreground">{label}</span>
@@ -265,7 +287,10 @@ function ColorRow({ label, value, onChange }: ColorRowProps) {
         type="color"
         aria-label={label}
         value={value}
-        onChange={(e) => onChange(e.target.value)}
+        // onChange fires continuously while dragging in the picker (preview);
+        // onBlur fires once when the picker closes / focus leaves (commit).
+        onChange={(e) => onPreview(e.target.value)}
+        onBlur={onCommit}
         className="h-6 w-10 cursor-pointer rounded border border-input bg-transparent p-0.5"
       />
     </label>
@@ -280,7 +305,8 @@ interface SliderRowProps {
   step: number;
   value: number;
   format: (value: number) => string;
-  onChange: (value: number) => void;
+  onPreview: (value: number) => void;
+  onCommit: () => void;
 }
 
 function SliderRow({
@@ -291,7 +317,8 @@ function SliderRow({
   step,
   value,
   format,
-  onChange,
+  onPreview,
+  onCommit,
 }: SliderRowProps) {
   return (
     <div className="space-y-1">
@@ -307,7 +334,10 @@ function SliderRow({
         max={max}
         step={step}
         value={[value]}
-        onValueChange={([v]: number[]) => onChange(v ?? value)}
+        // onValueChange streams every scrub frame (preview); onValueCommit
+        // fires once on pointer-up / keyboard commit (persist).
+        onValueChange={([v]: number[]) => onPreview(v ?? value)}
+        onValueCommit={onCommit}
         onClick={(e: ReactMouseEvent) => e.stopPropagation()}
       />
     </div>

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -211,13 +211,30 @@ export function usePluginRegistry() {
       persistProjectPluginState(before);
     },
     getEffectsSettings,
-    // Apply atmosphere appearance changes live and persist them with the
-    // project when they actually change. Mirrors the toggle/reposition flow so
-    // edits flag the project dirty and survive save/reload.
-    updateEffectsSettings: (next: Partial<EffectsSettings>) => {
-      const before = JSON.stringify(projectPluginStateSnapshot());
-      if (!setEffectsSettings(next)) return;
-      persistProjectPluginState(before);
+    // Live preview: push the appearance change straight to the engine for an
+    // instant redraw, but do NOT persist. A color-picker drag or slider scrub
+    // fires this every frame, so keeping persistence out avoids marking the
+    // project dirty and sweeping Zustand subscribers on every pixel of movement.
+    previewEffectsSettings: (next: Partial<EffectsSettings>) => {
+      setEffectsSettings(next);
+    },
+    // Commit: called once when an edit gesture ends (slider release, color
+    // input blur, reset, or the submenu closing). Persists only when the
+    // appearance actually differs from what the project already holds, so a
+    // no-op gesture does not flag the project dirty.
+    commitEffectsSettings: () => {
+      const storedSettings =
+        useAppStore.getState().projectPlugins?.settings?.[
+          maplibreEffectsPlugin.id
+        ];
+      const currentSettings = maplibreEffectsPlugin.getProjectState?.();
+      if (
+        JSON.stringify(storedSettings ?? null) ===
+        JSON.stringify(currentSettings ?? null)
+      ) {
+        return;
+      }
+      useAppStore.getState().setProjectPlugins(projectPluginStateSnapshot());
     },
   };
 }

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -216,25 +216,36 @@ export function usePluginRegistry() {
     // fires this every frame, so keeping persistence out avoids marking the
     // project dirty and sweeping Zustand subscribers on every pixel of movement.
     previewEffectsSettings: (next: Partial<EffectsSettings>) => {
-      setEffectsSettings(next);
+      // Contained like toggle/reposition: setEffectsSettings drives imperative
+      // canvas code (engine.applySettings) that can throw and escape React's
+      // error boundaries; surface it in diagnostics instead of crashing.
+      try {
+        setEffectsSettings(next);
+      } catch (error) {
+        reportPluginError(maplibreEffectsPlugin.id, "preview-effects", error);
+      }
     },
     // Commit: called once when an edit gesture ends (slider release, color
     // input blur, reset, or the submenu closing). Persists only when the
     // appearance actually differs from what the project already holds, so a
     // no-op gesture does not flag the project dirty.
     commitEffectsSettings: () => {
-      const storedSettings =
-        useAppStore.getState().projectPlugins?.settings?.[
-          maplibreEffectsPlugin.id
-        ];
-      const currentSettings = maplibreEffectsPlugin.getProjectState?.();
-      if (
-        JSON.stringify(storedSettings ?? null) ===
-        JSON.stringify(currentSettings ?? null)
-      ) {
-        return;
+      try {
+        const storedSettings =
+          useAppStore.getState().projectPlugins?.settings?.[
+            maplibreEffectsPlugin.id
+          ];
+        const currentSettings = maplibreEffectsPlugin.getProjectState?.();
+        if (
+          JSON.stringify(storedSettings ?? null) ===
+          JSON.stringify(currentSettings ?? null)
+        ) {
+          return;
+        }
+        useAppStore.getState().setProjectPlugins(projectPluginStateSnapshot());
+      } catch (error) {
+        reportPluginError(maplibreEffectsPlugin.id, "commit-effects", error);
       }
-      useAppStore.getState().setProjectPlugins(projectPluginStateSnapshot());
     },
   };
 }

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -9,6 +9,9 @@ import {
   maplibreDeckGlVizPlugin,
   maplibreDirectionsPlugin,
   maplibreEffectsPlugin,
+  getEffectsSettings,
+  setEffectsSettings,
+  type EffectsSettings,
   maplibreEnviroAtlasPlugin,
   maplibreEsriWaybackPlugin,
   maplibreFemaWmsPlugin,
@@ -205,6 +208,15 @@ export function usePluginRegistry() {
         reportPluginError(id, "reposition", error);
         return;
       }
+      persistProjectPluginState(before);
+    },
+    getEffectsSettings,
+    // Apply atmosphere appearance changes live and persist them with the
+    // project when they actually change. Mirrors the toggle/reposition flow so
+    // edits flag the project dirty and survive save/reload.
+    updateEffectsSettings: (next: Partial<EffectsSettings>) => {
+      const before = JSON.stringify(projectPluginStateSnapshot());
+      if (!setEffectsSettings(next)) return;
       persistProjectPluginState(before);
     },
   };

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -574,6 +574,14 @@
       "help": "Help",
       "settings": "Settings"
     },
+    "atmosphere": {
+      "haloColor": "Halo color",
+      "haloExtent": "Halo extent",
+      "haloExtentHint": "How far the atmospheric glow reaches past the globe. Lower keeps data tight to the surface; higher gives a wide, airy halo.",
+      "haloOpacity": "Halo strength",
+      "spaceColor": "Space color",
+      "reset": "Reset to defaults"
+    },
     "commandGroup": {
       "project": "Project",
       "addData": "Add Data",
@@ -811,6 +819,7 @@
       "mapControls": "Map controls",
       "fieldCollection": "Field Collection...",
       "atmosphereEffects": "Atmosphere Effects",
+      "atmosphereEnabled": "Enabled",
       "directions": "Directions",
       "directionsTooltip": "Routing sends your waypoints to the public OSRM demo server (router.project-osrm.org).",
       "search": "Search",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -141,9 +141,17 @@ export {
   type ReverseGeocodeLabels,
 } from "./plugins/maplibre-reverse-geocode";
 export {
+  DEFAULT_EFFECTS_SETTINGS,
   EFFECTS_PLUGIN_ID,
+  type EffectsSettings,
+  getEffectsSettings,
+  HALO_EXTENT_MAX,
+  HALO_EXTENT_MIN,
+  HALO_OPACITY_MAX,
+  HALO_OPACITY_MIN,
   maplibreEffectsPlugin,
   restoreEffects,
+  setEffectsSettings,
 } from "./plugins/maplibre-effects";
 export {
   DECK_VIZ_PLUGIN_ID,

--- a/packages/plugins/src/plugins/maplibre-effects.ts
+++ b/packages/plugins/src/plugins/maplibre-effects.ts
@@ -22,6 +22,43 @@ import type { GeoLibreAppAPI, GeoLibrePlugin } from "../types";
  */
 
 export const EFFECTS_PLUGIN_ID = "maplibre-atmosphere-effects";
+
+/**
+ * User-tunable appearance of the globe atmosphere. Persisted with the project
+ * (see the plugin's getProjectState/applyProjectState) so a styled globe — for
+ * example one prepared for image export — reopens the way it was saved.
+ *
+ * - `haloColor` is the base color of the atmospheric halo; the gradient stops
+ *   are derived from it (lightened toward white near the globe edge, darkened
+ *   in the faint outer falloff).
+ * - `haloExtent` is how far the halo reaches past the globe, as a multiple of
+ *   the globe radius. Lower values pull the glow tight to the surface so data
+ *   reads as painted onto the sphere; higher values give the stylized "air"
+ *   look where the limb floats in a wide blue haze.
+ * - `haloOpacity` scales the whole halo's strength (0 hides it).
+ * - `spaceColor` is the center color of the deep-space radial backdrop; the
+ *   outer edge is a darkened shade of it.
+ */
+export interface EffectsSettings {
+  haloColor: string;
+  haloExtent: number;
+  haloOpacity: number;
+  spaceColor: string;
+}
+
+export const DEFAULT_EFFECTS_SETTINGS: EffectsSettings = {
+  haloColor: "#4d9fe6",
+  haloExtent: 2.8,
+  haloOpacity: 1,
+  spaceColor: "#0c1b33",
+};
+
+// Slider bounds shared by the UI and the settings normalizer.
+export const HALO_EXTENT_MIN = 1.05;
+export const HALO_EXTENT_MAX = 4;
+export const HALO_OPACITY_MIN = 0;
+export const HALO_OPACITY_MAX = 1;
+
 const EFFECTS_MAP_CLASS = "geolibre-effects-map";
 const EFFECTS_OVERLAY_STYLE_ID = "geolibre-effects-maplibre-overlays";
 const MAP_CANVAS_Z_INDEX = "4";
@@ -35,19 +72,117 @@ const STAR_AREA_PER_STAR = 900;
 const STARFIELD_LNG_PERIOD_DEGREES = 360;
 const STARFIELD_LAT_PERIOD_DEGREES = 180;
 
-// Halo radial gradient — color stops are fractions of the gradient span, which
-// runs from the globe edge out to HALO_RADIUS_SCALE × the globe radius.
-const HALO_RADIUS_SCALE = 2.8;
 const HALO_SAMPLE_COUNT = 16;
-const HALO_STOPS: Array<[number, string]> = [
-  [0.0, "rgba(200, 235, 255, 1.0)"],
-  [0.03, "rgba(130, 200, 250, 0.6)"],
-  [0.08, "rgba(70, 150, 230, 0.35)"],
-  [0.18, "rgba(40, 100, 200, 0.15)"],
-  [0.35, "rgba(25, 65, 160, 0.06)"],
-  [0.6, "rgba(15, 40, 110, 0.02)"],
-  [1.0, "rgba(10, 25, 70, 0.0)"],
+
+// Halo radial gradient as a *shape* independent of the chosen color: each stop
+// is [offset, alpha, shade] where offset is the fraction of the gradient span
+// (globe edge → haloExtent × radius), alpha is the base opacity, and shade
+// blends the base color toward white (positive) or black (negative). The
+// defaults reproduce the original light-blue glow when applied to the default
+// haloColor (#4d9fe6): a bright near-white rim falling off to a faint dark blue.
+const HALO_STOP_SHAPE: Array<[number, number, number]> = [
+  [0.0, 1.0, 0.7],
+  [0.03, 0.6, 0.32],
+  [0.08, 0.35, 0.0],
+  [0.18, 0.15, -0.2],
+  [0.35, 0.06, -0.4],
+  [0.6, 0.02, -0.55],
+  [1.0, 0.0, -0.7],
 ];
+
+// The space backdrop runs from spaceColor at the center to this much darker at
+// the edge, matching the original #0c1b33 → #081222 falloff.
+const SPACE_EDGE_DARKEN = 0.33;
+
+interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+/** Parse `#rgb`/`#rrggbb` (defaulting to mid-blue on anything unparseable). */
+function parseHex(hex: string): Rgb {
+  const value = hex.trim().replace(/^#/, "");
+  const expanded =
+    value.length === 3
+      ? value
+          .split("")
+          .map((c) => c + c)
+          .join("")
+      : value;
+  if (!/^[0-9a-fA-F]{6}$/.test(expanded)) return { r: 77, g: 159, b: 230 };
+  return {
+    r: parseInt(expanded.slice(0, 2), 16),
+    g: parseInt(expanded.slice(2, 4), 16),
+    b: parseInt(expanded.slice(4, 6), 16),
+  };
+}
+
+/** Blend `rgb` toward white (shade > 0) or black (shade < 0) by |shade|. */
+function shadeRgb({ r, g, b }: Rgb, shade: number): Rgb {
+  const target = shade >= 0 ? 255 : 0;
+  const t = Math.min(1, Math.abs(shade));
+  return {
+    r: Math.round(r + (target - r) * t),
+    g: Math.round(g + (target - g) * t),
+    b: Math.round(b + (target - b) * t),
+  };
+}
+
+function rgba({ r, g, b }: Rgb, alpha: number): string {
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+/** Clamp `value` into `[min, max]`, falling back to `fallback` if non-finite. */
+function clampNumber(
+  value: unknown,
+  min: number,
+  max: number,
+  fallback: number,
+): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return Math.min(max, Math.max(min, value));
+}
+
+/** Coerce arbitrary persisted/partial input into a complete EffectsSettings. */
+export function normalizeEffectsSettings(
+  value: unknown,
+  base: EffectsSettings = DEFAULT_EFFECTS_SETTINGS,
+): EffectsSettings {
+  const candidate = (value ?? {}) as Partial<EffectsSettings>;
+  const isHex = (v: unknown): v is string =>
+    typeof v === "string" && /^#?[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$/.test(v.trim());
+  const withHash = (v: string) => (v.startsWith("#") ? v : `#${v}`);
+  return {
+    haloColor: isHex(candidate.haloColor)
+      ? withHash(candidate.haloColor.trim())
+      : base.haloColor,
+    haloExtent: clampNumber(
+      candidate.haloExtent,
+      HALO_EXTENT_MIN,
+      HALO_EXTENT_MAX,
+      base.haloExtent,
+    ),
+    haloOpacity: clampNumber(
+      candidate.haloOpacity,
+      HALO_OPACITY_MIN,
+      HALO_OPACITY_MAX,
+      base.haloOpacity,
+    ),
+    spaceColor: isHex(candidate.spaceColor)
+      ? withHash(candidate.spaceColor.trim())
+      : base.spaceColor,
+  };
+}
+
+function effectsSettingsEqual(a: EffectsSettings, b: EffectsSettings): boolean {
+  return (
+    a.haloColor === b.haloColor &&
+    a.haloExtent === b.haloExtent &&
+    a.haloOpacity === b.haloOpacity &&
+    a.spaceColor === b.spaceColor
+  );
+}
 
 interface Star {
   x: number;
@@ -311,12 +446,14 @@ class EffectsEngine {
   private height = 0;
   private dpr = 1;
   private starsDirty = true;
+  private settings: EffectsSettings;
 
   private rafId: number | null = null;
   private destroyed = false;
 
-  constructor(map: MapLibreMap) {
+  constructor(map: MapLibreMap, settings: EffectsSettings) {
     this.map = map;
+    this.settings = settings;
     this.mapCanvas = map.getCanvas();
     this.mapRoot = this.mapCanvas.closest(".maplibregl-map");
     this.previousMapCanvasZIndex = this.mapCanvas.style.zIndex;
@@ -364,6 +501,18 @@ class EffectsEngine {
   /** The map this engine is bound to (used to detect a map re-init). */
   getMapInstance(): MapLibreMap {
     return this.map;
+  }
+
+  /**
+   * Swap in new appearance settings. The space gradient is size-cached, so drop
+   * it to rebuild with the new color on the next frame; the halo is rebuilt
+   * every frame already. Restart the loop in case it idled (a settings change
+   * can arrive while the map sits still in globe mode).
+   */
+  applySettings(settings: EffectsSettings): void {
+    this.settings = settings;
+    this.spaceGradient = null;
+    if (!document.hidden) this.start();
   }
 
   destroy(): void {
@@ -622,8 +771,9 @@ class EffectsEngine {
         this.height / 2,
         Math.max(this.width, this.height) * 0.75,
       );
-      gradient.addColorStop(0, "#0c1b33");
-      gradient.addColorStop(1, "#081222");
+      const space = parseHex(this.settings.spaceColor);
+      gradient.addColorStop(0, rgba(space, 1));
+      gradient.addColorStop(1, rgba(shadeRgb(space, -SPACE_EDGE_DARKEN), 1));
       this.spaceGradient = gradient;
     }
     ctx.save();
@@ -633,8 +783,11 @@ class EffectsEngine {
   }
 
   private drawHalo(disc: GlobeCircle): void {
-    if (disc.radius < 5) return;
+    const { haloExtent, haloOpacity } = this.settings;
+    if (disc.radius < 5 || haloOpacity <= 0 || haloExtent <= 1) return;
     const ctx = this.haloCtx;
+    const base = parseHex(this.settings.haloColor);
+    const outerRadius = disc.radius * haloExtent;
     ctx.save();
     const gradient = ctx.createRadialGradient(
       disc.x,
@@ -642,15 +795,15 @@ class EffectsEngine {
       disc.radius,
       disc.x,
       disc.y,
-      disc.radius * HALO_RADIUS_SCALE,
+      outerRadius,
     );
-    for (const [stop, color] of HALO_STOPS) {
-      gradient.addColorStop(stop, color);
+    for (const [stop, alpha, shade] of HALO_STOP_SHAPE) {
+      gradient.addColorStop(stop, rgba(shadeRgb(base, shade), alpha * haloOpacity));
     }
     ctx.globalCompositeOperation = "screen";
     ctx.fillStyle = gradient;
     ctx.beginPath();
-    ctx.arc(disc.x, disc.y, disc.radius * HALO_RADIUS_SCALE, 0, Math.PI * 2);
+    ctx.arc(disc.x, disc.y, outerRadius, 0, Math.PI * 2);
     ctx.fill();
     ctx.restore();
   }
@@ -688,6 +841,11 @@ class EffectsEngine {
  * is needed here. On by default.
  */
 let engine: EffectsEngine | null = null;
+// Live appearance settings, shared by the engine and the Controls-menu UI.
+// Kept at module scope so they survive the engine being torn down and rebuilt
+// (map re-init, toggle off/on) and so applyProjectState can stage them before
+// the engine exists.
+let currentSettings: EffectsSettings = { ...DEFAULT_EFFECTS_SETTINGS };
 
 function attachEngine(app: GeoLibreAppAPI): boolean {
   const map = app.getMap?.();
@@ -695,7 +853,28 @@ function attachEngine(app: GeoLibreAppAPI): boolean {
   // A map re-init hands back a different MapLibreMap instance; tear down the
   // engine bound to the old map (its canvases/listeners) before rebinding.
   if (engine && engine.getMapInstance() !== map) detachEngine();
-  if (!engine) engine = new EffectsEngine(map);
+  if (!engine) engine = new EffectsEngine(map, currentSettings);
+  return true;
+}
+
+/** Current atmosphere appearance settings (a copy callers may freely mutate). */
+export function getEffectsSettings(): EffectsSettings {
+  return { ...currentSettings };
+}
+
+/**
+ * Update the atmosphere appearance and push it to the live engine if running.
+ * Input is normalized, so partial or out-of-range values are safe. Returns true
+ * when the settings actually changed (callers persist only on a real change).
+ */
+export function setEffectsSettings(next: Partial<EffectsSettings>): boolean {
+  const normalized = normalizeEffectsSettings(
+    { ...currentSettings, ...next },
+    DEFAULT_EFFECTS_SETTINGS,
+  );
+  if (effectsSettingsEqual(normalized, currentSettings)) return false;
+  currentSettings = normalized;
+  engine?.applySettings(currentSettings);
   return true;
 }
 
@@ -713,7 +892,21 @@ function detachEngine(): void {
  * after restoring plugin state — mirroring `restoreRasterLayers` — to bridge
  * that gap. Idempotent: safe to call on every project load / map reinit.
  */
-export function restoreEffects(app: GeoLibreAppAPI, active: boolean): void {
+export function restoreEffects(
+  app: GeoLibreAppAPI,
+  active: boolean,
+  settings?: unknown,
+): void {
+  // Apply the project's saved appearance (or defaults when absent) before
+  // attaching. restoreProjectState only invokes applyProjectState when the
+  // project actually carries effects settings, so a project saved with the
+  // default look would otherwise inherit the previously open project's colors;
+  // resetting here keeps the in-memory appearance in step with what loaded.
+  const next = normalizeEffectsSettings(settings, DEFAULT_EFFECTS_SETTINGS);
+  if (!effectsSettingsEqual(next, currentSettings)) {
+    currentSettings = next;
+    engine?.applySettings(currentSettings);
+  }
   if (active) attachEngine(app);
   else detachEngine();
 }
@@ -725,4 +918,19 @@ export const maplibreEffectsPlugin: GeoLibrePlugin = {
   activeByDefault: true,
   activate: (app: GeoLibreAppAPI) => attachEngine(app),
   deactivate: (_app: GeoLibreAppAPI) => detachEngine(),
+  // Persist the appearance only when it differs from the defaults, so untouched
+  // projects don't carry an effects settings blob.
+  getProjectState: () =>
+    effectsSettingsEqual(currentSettings, DEFAULT_EFFECTS_SETTINGS)
+      ? undefined
+      : { ...currentSettings },
+  applyProjectState: (_app: GeoLibreAppAPI, state: unknown) => {
+    // A project without saved settings (state === undefined) resets to defaults,
+    // matching how applyProjectState is invoked with resetMissingSettings.
+    const next = normalizeEffectsSettings(state, DEFAULT_EFFECTS_SETTINGS);
+    if (effectsSettingsEqual(next, currentSettings)) return false;
+    currentSettings = next;
+    engine?.applySettings(currentSettings);
+    return true;
+  },
 };

--- a/packages/plugins/src/plugins/maplibre-effects.ts
+++ b/packages/plugins/src/plugins/maplibre-effects.ts
@@ -100,8 +100,13 @@ interface Rgb {
   b: number;
 }
 
-/** Parse `#rgb`/`#rrggbb` (defaulting to mid-blue on anything unparseable). */
-function parseHex(hex: string): Rgb {
+/**
+ * Parse `#rgb`/`#rrggbb` into RGB. Inputs reaching here are already validated by
+ * normalizeEffectsSettings, so `fallback` is only for defensive use; pass the
+ * caller's own default (halo vs space) so a corrupt value degrades to the right
+ * neutral color rather than always to halo blue.
+ */
+function parseHex(hex: string, fallback: Rgb = { r: 77, g: 159, b: 230 }): Rgb {
   const value = hex.trim().replace(/^#/, "");
   const expanded =
     value.length === 3
@@ -110,7 +115,7 @@ function parseHex(hex: string): Rgb {
           .map((c) => c + c)
           .join("")
       : value;
-  if (!/^[0-9a-fA-F]{6}$/.test(expanded)) return { r: 77, g: 159, b: 230 };
+  if (!/^[0-9a-fA-F]{6}$/.test(expanded)) return fallback;
   return {
     r: parseInt(expanded.slice(0, 2), 16),
     g: parseInt(expanded.slice(2, 4), 16),
@@ -152,10 +157,16 @@ export function normalizeEffectsSettings(
   const candidate = (value ?? {}) as Partial<EffectsSettings>;
   const isHex = (v: unknown): v is string =>
     typeof v === "string" && /^#?[0-9a-fA-F]{3}([0-9a-fA-F]{3})?$/.test(v.trim());
-  const withHash = (v: string) => (v.startsWith("#") ? v : `#${v}`);
+  // Lowercase so casing never leaks into the equality check: uppercase hex from
+  // a hand-edited project would otherwise read as "non-default" and get
+  // serialized even when the rendered color matches a default exactly.
+  const withHash = (v: string) => {
+    const hex = v.trim().toLowerCase();
+    return hex.startsWith("#") ? hex : `#${hex}`;
+  };
   return {
     haloColor: isHex(candidate.haloColor)
-      ? withHash(candidate.haloColor.trim())
+      ? withHash(candidate.haloColor)
       : base.haloColor,
     haloExtent: clampNumber(
       candidate.haloExtent,
@@ -170,7 +181,7 @@ export function normalizeEffectsSettings(
       base.haloOpacity,
     ),
     spaceColor: isHex(candidate.spaceColor)
-      ? withHash(candidate.spaceColor.trim())
+      ? withHash(candidate.spaceColor)
       : base.spaceColor,
   };
 }
@@ -771,7 +782,7 @@ class EffectsEngine {
         this.height / 2,
         Math.max(this.width, this.height) * 0.75,
       );
-      const space = parseHex(this.settings.spaceColor);
+      const space = parseHex(this.settings.spaceColor, { r: 12, g: 27, b: 51 });
       gradient.addColorStop(0, rgba(space, 1));
       gradient.addColorStop(1, rgba(shadeRgb(space, -SPACE_EDGE_DARKEN), 1));
       this.spaceGradient = gradient;

--- a/tests/effects-settings.test.ts
+++ b/tests/effects-settings.test.ts
@@ -5,6 +5,7 @@ import {
   HALO_EXTENT_MAX,
   HALO_EXTENT_MIN,
   HALO_OPACITY_MAX,
+  HALO_OPACITY_MIN,
   normalizeEffectsSettings,
 } from "../packages/plugins/src/plugins/maplibre-effects";
 
@@ -14,13 +15,14 @@ describe("normalizeEffectsSettings", () => {
     assert.deepEqual(normalizeEffectsSettings({}), DEFAULT_EFFECTS_SETTINGS);
   });
 
-  it("keeps valid hex colors and prefixes a missing '#'", () => {
+  it("prefixes a missing '#' and lowercases hex", () => {
     const result = normalizeEffectsSettings({
       haloColor: "ff0000",
       spaceColor: "#00FF00",
     });
     assert.equal(result.haloColor, "#ff0000");
-    assert.equal(result.spaceColor, "#00FF00");
+    // Uppercase is lowercased so casing can't read as a non-default value.
+    assert.equal(result.spaceColor, "#00ff00");
   });
 
   it("accepts shorthand 3-digit hex", () => {
@@ -36,7 +38,7 @@ describe("normalizeEffectsSettings", () => {
     assert.equal(normalizeEffectsSettings({ haloExtent: 99 }).haloExtent, HALO_EXTENT_MAX);
     assert.equal(normalizeEffectsSettings({ haloExtent: 0 }).haloExtent, HALO_EXTENT_MIN);
     assert.equal(normalizeEffectsSettings({ haloOpacity: 5 }).haloOpacity, HALO_OPACITY_MAX);
-    assert.equal(normalizeEffectsSettings({ haloOpacity: -1 }).haloOpacity, 0);
+    assert.equal(normalizeEffectsSettings({ haloOpacity: -1 }).haloOpacity, HALO_OPACITY_MIN);
   });
 
   it("ignores non-finite numbers, keeping the base value", () => {

--- a/tests/effects-settings.test.ts
+++ b/tests/effects-settings.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  DEFAULT_EFFECTS_SETTINGS,
+  HALO_EXTENT_MAX,
+  HALO_EXTENT_MIN,
+  HALO_OPACITY_MAX,
+  normalizeEffectsSettings,
+} from "../packages/plugins/src/plugins/maplibre-effects";
+
+describe("normalizeEffectsSettings", () => {
+  it("returns the defaults for undefined/empty input", () => {
+    assert.deepEqual(normalizeEffectsSettings(undefined), DEFAULT_EFFECTS_SETTINGS);
+    assert.deepEqual(normalizeEffectsSettings({}), DEFAULT_EFFECTS_SETTINGS);
+  });
+
+  it("keeps valid hex colors and prefixes a missing '#'", () => {
+    const result = normalizeEffectsSettings({
+      haloColor: "ff0000",
+      spaceColor: "#00FF00",
+    });
+    assert.equal(result.haloColor, "#ff0000");
+    assert.equal(result.spaceColor, "#00FF00");
+  });
+
+  it("accepts shorthand 3-digit hex", () => {
+    assert.equal(normalizeEffectsSettings({ haloColor: "#abc" }).haloColor, "#abc");
+  });
+
+  it("falls back to the base color on an invalid hex", () => {
+    const result = normalizeEffectsSettings({ haloColor: "not-a-color" });
+    assert.equal(result.haloColor, DEFAULT_EFFECTS_SETTINGS.haloColor);
+  });
+
+  it("clamps the halo extent and opacity into range", () => {
+    assert.equal(normalizeEffectsSettings({ haloExtent: 99 }).haloExtent, HALO_EXTENT_MAX);
+    assert.equal(normalizeEffectsSettings({ haloExtent: 0 }).haloExtent, HALO_EXTENT_MIN);
+    assert.equal(normalizeEffectsSettings({ haloOpacity: 5 }).haloOpacity, HALO_OPACITY_MAX);
+    assert.equal(normalizeEffectsSettings({ haloOpacity: -1 }).haloOpacity, 0);
+  });
+
+  it("ignores non-finite numbers, keeping the base value", () => {
+    const result = normalizeEffectsSettings({
+      haloExtent: Number.NaN,
+      haloOpacity: Infinity,
+    });
+    assert.equal(result.haloExtent, DEFAULT_EFFECTS_SETTINGS.haloExtent);
+    assert.equal(result.haloOpacity, DEFAULT_EFFECTS_SETTINGS.haloOpacity);
+  });
+
+  it("merges onto a supplied base instead of the defaults", () => {
+    const base = {
+      haloColor: "#111111",
+      haloExtent: 2,
+      haloOpacity: 0.5,
+      spaceColor: "#222222",
+    };
+    const result = normalizeEffectsSettings({ haloExtent: 3 }, base);
+    assert.equal(result.haloExtent, 3);
+    assert.equal(result.haloColor, "#111111");
+    assert.equal(result.spaceColor, "#222222");
+    assert.equal(result.haloOpacity, 0.5);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a Controls menu submenu for the globe Atmosphere Effects: halo color, halo extent (tight to the surface vs an airy haze), halo strength, and space backdrop color.
- Settings apply live and persist with the project under the plugin settings, with a reset to defaults; defaults reproduce the existing look so existing projects are unchanged.
- Resolves the request in #466 for customizable globe colors and control over how much the data sits on the surface vs floating above it.

## Test plan
- [x] `npm run build` and eslint pass via pre-commit
- [x] New unit test for the settings normalizer (clamping, hex validation, defaults)
- [x] Verified live in the app: extent slider tightens/widens the halo, color inputs recolor the halo and space, strength dims the halo, and reset restores defaults
- [x] Verified the menu stays open while adjusting sliders and color inputs
- [x] Verified settings serialize into the saved project and the styled globe returns after reopening

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Atmosphere effects now include a dedicated submenu to edit halo color, halo extent, halo opacity, and space color.
  * Updates support live preview while editing, with changes saved to the project when you finish.
  * Added reset-to-defaults for atmosphere settings.
* **Bug Fixes**
  * Customized atmosphere settings are now restored correctly when reopening projects.
* **Tests**
  * Added unit tests for effects-settings normalization (defaults, validation, clamping, and merging).
* **Documentation**
  * Updated English UI strings for the new atmosphere controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->