### PR TITLE
chore(deps): bump maplibre-gl-raster to 0.4.0

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -70,7 +70,7 @@
     "maplibre-gl-nasa-earthdata": "^0.1.2",
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.3.1",
+    "maplibre-gl-raster": "^0.4.0",
     "maplibre-gl-streetview": "^0.6.0",
     "maplibre-gl-swipe": "^0.7.1",
     "maplibre-gl-time-slider": "^1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
         "maplibre-gl-nasa-earthdata": "^0.1.2",
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.3.1",
+        "maplibre-gl-raster": "^0.4.0",
         "maplibre-gl-streetview": "^0.6.0",
         "maplibre-gl-swipe": "^0.7.1",
         "maplibre-gl-time-slider": "^1.0.3",
@@ -17756,9 +17756,9 @@
       }
     },
     "node_modules/maplibre-gl-raster": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.3.1.tgz",
-      "integrity": "sha512-ziblcMQGiPRaXeMuD4nhk11ULaU7a00mHGf1geivICYSyTGyhKegF3XG82raS15BUlgBXk5BOrHuHDCy1ivm4A==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.4.0.tgz",
+      "integrity": "sha512-cSMtRJdDWGzfamyUUsn/gkxP+vXX4VhjSDBXu8QtbeLYxZyDH8BOkDjGepO05vzpzR85mZYf7kCWPmYhZ7LHHw==",
       "license": "MIT",
       "dependencies": {
         "@chunkd/middleware": "^11.3.0",
@@ -17779,11 +17779,15 @@
         "@deck.gl/mesh-layers": "^9.3.2",
         "@luma.gl/core": "^9.3.3",
         "@luma.gl/shadertools": "^9.3.3",
+        "cog-tiler-wasm": ">=0.2.0",
         "maplibre-gl": ">=3.0.0",
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"
       },
       "peerDependenciesMeta": {
+        "cog-tiler-wasm": {
+          "optional": true
+        },
         "react": {
           "optional": true
         },
@@ -24289,7 +24293,7 @@
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-overture-maps": "^0.3.0",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.3.1",
+        "maplibre-gl-raster": "^0.4.0",
         "maplibre-gl-streetview": "^0.6.0",
         "maplibre-gl-swipe": "^0.7.1",
         "maplibre-gl-time-slider": "^1.0.3",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -44,7 +44,7 @@
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-overture-maps": "^0.3.0",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.3.1",
+    "maplibre-gl-raster": "^0.4.0",
     "maplibre-gl-streetview": "^0.6.0",
     "maplibre-gl-swipe": "^0.7.1",
     "maplibre-gl-time-slider": "^1.0.3",


### PR DESCRIPTION
Updates the `maplibre-gl-raster` dependency from `^0.3.1` to `^0.4.0` in `apps/geolibre-desktop` and `packages/plugins`, with the lockfile regenerated.

Local `npm run typecheck` (full `tsc -b && vite build`) passes. The plugins package touches some private internals of this library (see `raster-symbology-texture.ts`), so the build is the relevant smoke test here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated the mapping library dependency in both the desktop application and plugins packages to the latest compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->