### PR TITLE
feat(esri-wayback): add 'only versions with local changes' filter

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -62,7 +62,7 @@
     "maplibre-gl-duckdb": "^0.2.0",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",
-    "maplibre-gl-esri-wayback": "^0.1.1",
+    "maplibre-gl-esri-wayback": "^0.2.0",
     "maplibre-gl-fema-wms": "^0.1.2",
     "maplibre-gl-geo-editor": "^0.8.0",
     "maplibre-gl-geoagent": "^0.4.3",

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -119,3 +119,13 @@ Number, date, and coordinate formatting should continue to use the runtime
 locale via `Intl` APIs (e.g. `new Intl.NumberFormat(undefined, …)` /
 `Intl.DateTimeFormat`) rather than hard-coded formatting, so values render in the
 user's regional conventions.
+
+## Known limitations
+
+Some plugins wrap **third-party MapLibre controls** that render their own UI
+(e.g. the Esri Wayback plugin's `maplibre-gl-esri-wayback` control, with labels
+such as "Only versions with local changes"). Those strings live inside the
+external library and never pass through GeoLibre's `react-i18next` pipeline, so
+they stay English regardless of the selected language. Translating them requires
+an upstream change to the library (or a fork); it can't be done from a locale
+catalog here.

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "maplibre-gl-duckdb": "^0.2.0",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
-        "maplibre-gl-esri-wayback": "^0.1.1",
+        "maplibre-gl-esri-wayback": "^0.2.0",
         "maplibre-gl-fema-wms": "^0.1.2",
         "maplibre-gl-geo-editor": "^0.8.0",
         "maplibre-gl-geoagent": "^0.4.3",
@@ -256,9 +256,9 @@
       }
     },
     "apps/geolibre-desktop/node_modules/maplibre-gl-esri-wayback": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-esri-wayback/-/maplibre-gl-esri-wayback-0.1.1.tgz",
-      "integrity": "sha512-hyvzrHABe/BfvWL7V/EHEOCjUKUDx67CuRW9S+ulH3SMEOW0D1BxzfCTxlymGo89IObWVttVqilc84+MhYE5eA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-esri-wayback/-/maplibre-gl-esri-wayback-0.2.0.tgz",
+      "integrity": "sha512-jxx0yxmrbhO0SPY4yqqMb1dELLq9l7ESVthNIErTis/1XiF3kVPhGWDKN3HBMLeJquCC5kuJqDxrbwRTxe7vtw==",
       "license": "MIT",
       "dependencies": {
         "@esri/wayback-core": ">=1.0.10"
@@ -24284,7 +24284,7 @@
         "maplibre-gl-duckdb": "^0.2.0",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
-        "maplibre-gl-esri-wayback": "^0.1.1",
+        "maplibre-gl-esri-wayback": "^0.2.0",
         "maplibre-gl-fema-wms": "^0.1.2",
         "maplibre-gl-geo-editor": "^0.8.0",
         "maplibre-gl-geoagent": "^0.4.3",
@@ -24388,9 +24388,9 @@
       }
     },
     "packages/plugins/node_modules/maplibre-gl-esri-wayback": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-esri-wayback/-/maplibre-gl-esri-wayback-0.1.1.tgz",
-      "integrity": "sha512-hyvzrHABe/BfvWL7V/EHEOCjUKUDx67CuRW9S+ulH3SMEOW0D1BxzfCTxlymGo89IObWVttVqilc84+MhYE5eA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-esri-wayback/-/maplibre-gl-esri-wayback-0.2.0.tgz",
+      "integrity": "sha512-jxx0yxmrbhO0SPY4yqqMb1dELLq9l7ESVthNIErTis/1XiF3kVPhGWDKN3HBMLeJquCC5kuJqDxrbwRTxe7vtw==",
       "license": "MIT",
       "dependencies": {
         "@esri/wayback-core": ">=1.0.10"

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -35,7 +35,7 @@
     "maplibre-gl-duckdb": "^0.2.0",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",
-    "maplibre-gl-esri-wayback": "^0.1.1",
+    "maplibre-gl-esri-wayback": "^0.2.0",
     "maplibre-gl-fema-wms": "^0.1.2",
     "maplibre-gl-geo-editor": "^0.8.0",
     "maplibre-gl-geoagent": "^0.4.3",

--- a/packages/plugins/src/plugins/maplibre-esri-wayback.ts
+++ b/packages/plugins/src/plugins/maplibre-esri-wayback.ts
@@ -37,7 +37,7 @@ let stateChangeHandler: EsriWaybackControlEventHandler | null = null;
 export const maplibreEsriWaybackPlugin: GeoLibrePlugin = {
   id: "maplibre-gl-esri-wayback",
   name: "Esri Wayback",
-  version: "0.1.0",
+  version: "0.2.0",
   activate: (app: GeoLibreAppAPI) => {
     if (!esriWaybackControl) {
       esriWaybackControl = new EsriWaybackControl(


### PR DESCRIPTION
Closes #486

## Summary

Adds Esri's **"Only versions with local changes"** option to the Esri Wayback plugin. When enabled, the release timeline is limited to the Wayback versions that *actually changed* the imagery at the current map center and zoom — instead of forcing the user to scroll through dozens (sometimes 100+) of identical images to find where change occurred. This mirrors the native option in Esri's [World Imagery Wayback viewer](https://livingatlas.arcgis.com/wayback/).

## Changes

The plugin is a thin wrapper around [`maplibre-gl-esri-wayback`](https://github.com/opengeos/maplibre-gl-esri-wayback), so the feature was implemented upstream ([PR #5](https://github.com/opengeos/maplibre-gl-esri-wayback/pull/5), released in [v0.2.0](https://github.com/opengeos/maplibre-gl-esri-wayback/releases/tag/v0.2.0)). This PR just bumps the dependency:

- `maplibre-gl-esri-wayback` `^0.1.1` → `^0.2.0` in `packages/plugins` and `apps/geolibre-desktop`.

No wrapper code change is needed — the feature is self-contained in the control (a new panel checkbox, the `localChangesOnly` option, and a `setLocalChangesOnly()` method). It uses `@esri/wayback-core`'s change detection, refreshes as the map moves, keeps the selected release in sync with the filtered set, and cancels in-flight requests on toggle/removal.

## Verification

Built the new package, linked it into the app, and drove the **real GeoLibre app** in a browser against **live Esri World Imagery** (Dubai, 55.14363/25.09182 @ z15 — the location from the issue):

| Check | Result |
|---|---|
| Checkbox renders in panel | ✅ "Only versions with local changes" |
| Timeline before filter | **194 of 194** releases |
| Timeline after filter @ Dubai z15 | **14 of 14** — only versions with actual changes |
| Change-detection network calls | 21 requests to the real `.../MapServer/tilemap/{releaseNum}/15/14023/21403` endpoint |
| Selection sync | Reconciled to a release that has changes |
| Toggle off | Restored the full 194-release timeline |

`npm run typecheck` (full build) passes; pre-commit (incl. `npm build`) passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated `maplibre-gl-esri-wayback` dependency to version 0.2.0 for the desktop app and plugins.
  * Bumped the maplibre-esri-wayback plugin version to 0.2.0.
* **Documentation**
  * Added “Known limitations” about third-party MapLibre control UI text not being translated via the app’s i18n system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->