### PR TITLE
chore(deps): bump maplibre-gl-raster to 0.5.0

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -70,7 +70,7 @@
     "maplibre-gl-nasa-earthdata": "^0.1.2",
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.4.0",
+    "maplibre-gl-raster": "^0.5.0",
     "maplibre-gl-streetview": "^0.6.0",
     "maplibre-gl-swipe": "^0.7.1",
     "maplibre-gl-time-slider": "^1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
         "maplibre-gl-nasa-earthdata": "^0.1.2",
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.4.0",
+        "maplibre-gl-raster": "^0.5.0",
         "maplibre-gl-streetview": "^0.6.0",
         "maplibre-gl-swipe": "^0.7.1",
         "maplibre-gl-time-slider": "^1.0.3",
@@ -17756,9 +17756,9 @@
       }
     },
     "node_modules/maplibre-gl-raster": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.4.0.tgz",
-      "integrity": "sha512-cSMtRJdDWGzfamyUUsn/gkxP+vXX4VhjSDBXu8QtbeLYxZyDH8BOkDjGepO05vzpzR85mZYf7kCWPmYhZ7LHHw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.5.0.tgz",
+      "integrity": "sha512-GsdpV7qUopc6Qzto7JDGDe3VkxvRkLXbZHCJI27jmr8aCqieVPuhm5kxG6F82t/pqwEJTldHFDuGl4k8XheAmg==",
       "license": "MIT",
       "dependencies": {
         "@chunkd/middleware": "^11.3.0",
@@ -24293,7 +24293,7 @@
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-overture-maps": "^0.3.0",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.4.0",
+        "maplibre-gl-raster": "^0.5.0",
         "maplibre-gl-streetview": "^0.6.0",
         "maplibre-gl-swipe": "^0.7.1",
         "maplibre-gl-time-slider": "^1.0.3",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -44,7 +44,7 @@
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-overture-maps": "^0.3.0",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.4.0",
+    "maplibre-gl-raster": "^0.5.0",
     "maplibre-gl-streetview": "^0.6.0",
     "maplibre-gl-swipe": "^0.7.1",
     "maplibre-gl-time-slider": "^1.0.3",

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -26,7 +26,7 @@ const DEFAULT_RASTER_URL =
   "https://data.source.coop/giswqs/opengeos/nlcd_2021_land_cover_30m.tif";
 
 // These types mirror undocumented private members of RasterControl from
-// maplibre-gl-raster (verified against v0.2.0). All access is optional (?.)
+// maplibre-gl-raster (verified against v0.5.0). All access is optional (?.)
 // so a rename in a future release degrades to a no-op rather than a crash --
 // re-verify these names AND the .mlr-control-close selector in
 // wireRasterCloseButton when bumping the dependency.
@@ -419,7 +419,7 @@ function createRasterControl(
   });
   // syncRasterLayersToStore re-reads getState().collapsed when these fire.
   // Safe: expand()/collapse() delegate to toggle(), which flips
-  // _state.collapsed BEFORE emitting the event (verified against v0.2.0) --
+  // _state.collapsed BEFORE emitting the event (verified against v0.5.0) --
   // re-verify that ordering when bumping the dependency.
   const panelStateSyncHandler: RasterControlEventHandler = () =>
     syncRasterLayersToStoreForRuntime(control);

--- a/packages/plugins/src/plugins/raster-symbology-texture.ts
+++ b/packages/plugins/src/plugins/raster-symbology-texture.ts
@@ -22,7 +22,7 @@ import {
 import { colormapColors, warmColormapColors } from "./colormap-colors";
 
 // These types mirror undocumented private members of the maplibre-gl-raster
-// LayerManager (verified against v0.2.0) and the deck.gl-raster Colormap
+// LayerManager (verified against v0.5.0) and the deck.gl-raster Colormap
 // module name (deck.gl-raster v0.7.0). Access is feature-detected and falls
 // back to a no-op rather than throwing -- re-verify these names AND the
 // "colormap" module name when bumping either dependency.


### PR DESCRIPTION
Bumps `maplibre-gl-raster` from `^0.4.0` to `^0.5.0` in `packages/plugins` and `apps/geolibre-desktop`, picking up the two raster-rendering fixes released in [maplibre-gl-raster v0.5.0](https://github.com/opengeos/maplibre-gl-raster/releases/tag/v0.5.0) (PR opengeos/maplibre-gl-raster#18).

## Fixes

- **#485 — band selection limited to 4 bands.** A 12-band GeoTIFF could only address bands 1–4; a single-band pseudocolor of band 12 rendered band 1's data (blank). The library now fetches the bands a layer actually samples and exposes every band in the pickers.
- **#444 — global EPSG:4326 COGs render as garbage at the antimeridian.** The CHIRPS precipitation COG (and similar global 4326 rasters) now reproject correctly.

## Verification

Both fixes were verified end-to-end in the real app (Playwright + real data) against the published 0.5.0 build:

- **#485:** a 12-band COG (band 12 = elevation 900–1000) shows all 12 bands in every picker; single-band band 12 renders a correct gray gradient (luminance ramp 131→251) with band 12's own 902–998 auto-rescale.
- **#444:** the real CHIRPS global EPSG:4326 COG renders aligned with the continents across −180→180 with no antimeridian smearing.

`npm run build` (tsc -b + vite build) passes; pre-commit (incl. the npm-build hook) clean.

Closes #485
Closes #444

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the `maplibre-gl-raster` dependency to v0.5.0 across the desktop app and related plugins.
* **Documentation**
  * Refreshed compatibility/verification notes and module comments to align with the v0.5.0 update.
  
No user-facing behavior changes are included in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->