### PR TITLE
fix(style): add screen eyedropper to color fields (#489)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/DeckVizSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/DeckVizSource.tsx
@@ -11,7 +11,7 @@ import {
   type DeckVizScenegraphConfig,
   type DeckVizStyle,
 } from "@geolibre/plugins";
-import { Button, Input, Label, Select } from "@geolibre/ui";
+import { Button, ColorField, Input, Label, Select } from "@geolibre/ui";
 import { Columns3, FileUp, Globe2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -658,15 +658,14 @@ export function DeckVizSource({ initialDeckVizKind }: DeckVizSourceProps) {
             {deckVizDef.styleControls.includes("color") ? (
               <div className="space-y-1.5">
                 <Label htmlFor="deckviz-color">{t("addData.deckViz.color")}</Label>
-                <input
+                <ColorField
                   id="deckviz-color"
-                  type="color"
-                  className="h-9 w-full rounded-md border border-input bg-background"
+                  eyedropperLabel={t("common.pickColorFromScreen")}
                   value={deckVizStyle.color}
-                  onChange={(event) =>
+                  onChange={(color) =>
                     setDeckVizStyle((style) => ({
                       ...style,
-                      color: event.target.value,
+                      color,
                     }))
                   }
                 />

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ControlsMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ControlsMenu.tsx
@@ -8,6 +8,7 @@ import {
 } from "@geolibre/plugins";
 import {
   Button,
+  ColorField,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -289,15 +290,19 @@ function ColorRow({ label, value, onPreview, onCommit }: ColorRowProps) {
   return (
     <label className="flex items-center justify-between gap-2 text-xs">
       <span className="text-muted-foreground">{label}</span>
-      <input
-        type="color"
+      <ColorField
+        fill={false}
         aria-label={label}
+        eyedropperLabel={label}
         value={value}
         // onChange fires continuously while dragging in the picker (preview);
-        // onBlur fires once when the picker closes / focus leaves (commit).
-        onChange={(e) => onPreview(e.target.value)}
+        // onBlur fires once when the picker closes / focus leaves (commit). The
+        // eyedropper has no blur, so ColorField commits via onCommit instead.
+        onChange={onPreview}
+        onCommit={onCommit}
         onBlur={onCommit}
-        className="h-6 w-10 cursor-pointer rounded border border-input bg-transparent p-0.5"
+        className="h-6 w-10 cursor-pointer p-0.5"
+        buttonClassName="h-6 w-6"
       />
     </label>
   );

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1541,16 +1541,18 @@ export function StylePanel({
             {draftVectorStyleStops.map((stop, index) => (
               <div
                 key={index}
-                className="grid grid-cols-[2.25rem_1fr_2rem] items-center gap-2"
+                className="grid grid-cols-[auto_1fr_2rem] items-center gap-2"
               >
-                <Input
-                  type="color"
+                <ColorField
+                  fill={false}
                   aria-label={`Class ${index + 1} color`}
-                  className="h-9 p-1"
+                  eyedropperLabel={`Pick class ${index + 1} color from the screen`}
+                  className="h-9 w-9 p-1"
+                  buttonClassName="h-9 w-9"
                   value={stop.color}
-                  onChange={(event) =>
+                  onChange={(color) =>
                     updateDraftVectorStyleStop(index, {
-                      color: event.target.value,
+                      color,
                     })
                   }
                 />

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -15,6 +15,7 @@ import {
 } from "@geolibre/core";
 import {
   Button,
+  ColorField,
   Input,
   Label,
   ScrollArea,
@@ -1690,25 +1691,19 @@ export function StylePanel({
       {draftVectorStyleMode === "single" ? (
         <div className="space-y-2">
           <Label htmlFor="fillColor">Fill color</Label>
-          <Input
+          <ColorField
             id="fillColor"
-            type="color"
             value={style.fillColor}
-            onChange={(e) =>
-              setLayerStyle(layer.id, { fillColor: e.target.value })
-            }
+            onChange={(fillColor) => setLayerStyle(layer.id, { fillColor })}
           />
         </div>
       ) : null}
       <div className="space-y-2">
         <Label htmlFor="strokeColor">Outline color</Label>
-        <Input
+        <ColorField
           id="strokeColor"
-          type="color"
           value={style.strokeColor}
-          onChange={(e) =>
-            setLayerStyle(layer.id, { strokeColor: e.target.value })
-          }
+          onChange={(strokeColor) => setLayerStyle(layer.id, { strokeColor })}
         />
       </div>
       <NumericStyleInput
@@ -1768,12 +1763,11 @@ export function StylePanel({
           <Separator />
           <div className="space-y-2">
             <Label htmlFor="textColor">Text color</Label>
-            <Input
+            <ColorField
               id="textColor"
-              type="color"
               value={styleValue(style, "textColor")}
-              onChange={(e) =>
-                setLayerStyle(layer.id, { textColor: e.target.value })
+              onChange={(textColor) =>
+                setLayerStyle(layer.id, { textColor })
               }
             />
           </div>
@@ -1788,12 +1782,11 @@ export function StylePanel({
           />
           <div className="space-y-2">
             <Label htmlFor="textHaloColor">Text halo color</Label>
-            <Input
+            <ColorField
               id="textHaloColor"
-              type="color"
               value={styleValue(style, "textHaloColor")}
-              onChange={(e) =>
-                setLayerStyle(layer.id, { textHaloColor: e.target.value })
+              onChange={(textHaloColor) =>
+                setLayerStyle(layer.id, { textHaloColor })
               }
             />
           </div>
@@ -1819,11 +1812,10 @@ export function StylePanel({
       {draftVectorStyleMode === "single" ? (
         <div className="space-y-2">
           <Label htmlFor="extrusionColor">Extrusion color</Label>
-          <Input
+          <ColorField
             id="extrusionColor"
-            type="color"
             value={draftExtrusionColor}
-            onChange={(event) => setDraftExtrusionColor(event.target.value)}
+            onChange={(color) => setDraftExtrusionColor(color)}
           />
         </div>
       ) : null}

--- a/apps/geolibre-desktop/src/components/panels/WidgetEditorDialog.tsx
+++ b/apps/geolibre-desktop/src/components/panels/WidgetEditorDialog.tsx
@@ -1,6 +1,7 @@
 import type { DashboardWidget } from "@geolibre/core";
 import {
   Button,
+  ColorField,
   Dialog,
   DialogContent,
   DialogDescription,
@@ -337,14 +338,16 @@ export function WidgetEditorDialog({
             <div className="grid gap-1.5">
               <Label htmlFor="widget-color">{t("dashboard.editor.color")}</Label>
               <div className="flex items-center gap-2">
-                <input
+                <ColorField
                   id="widget-color"
-                  type="color"
-                  className="h-8 w-12 cursor-pointer rounded border border-input bg-background p-0.5"
+                  eyedropperLabel={t("common.pickColorFromScreen")}
+                  fill={false}
+                  className="h-8 w-12 cursor-pointer p-0.5"
+                  buttonClassName="h-8 w-8"
                   // Native color inputs need a concrete value; show a neutral
                   // swatch while no custom color is set.
                   value={color || "#3fb1ce"}
-                  onChange={(event) => setColor(event.target.value)}
+                  onChange={(next) => setColor(next)}
                 />
                 {color ? (
                   <Button

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
@@ -19,6 +19,7 @@ import {
 import type { MapController } from "@geolibre/map";
 import {
   Button,
+  ColorField,
   Dialog,
   DialogContent,
   DialogDescription,
@@ -451,12 +452,14 @@ function StorySettings({
           {t("storymap.field.showMarkers")}
         </label>
         {story.showMarkers ? (
-          <input
-            type="color"
+          <ColorField
+            fill={false}
             aria-label={t("storymap.field.markerColor")}
+            eyedropperLabel={t("storymap.field.markerColor")}
             value={story.markerColor}
-            onChange={(e) => onChange({ markerColor: e.target.value })}
-            className="h-7 w-10 cursor-pointer rounded border"
+            onChange={(markerColor) => onChange({ markerColor })}
+            className="h-7 w-10 cursor-pointer p-0.5"
+            buttonClassName="h-7 w-7"
           />
         ) : null}
         <label className="flex items-center gap-2">

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -8,6 +8,7 @@
     "label": "File name"
   },
   "common": {
+    "pickColorFromScreen": "Pick a color from the screen",
     "save": "Save",
     "cancel": "Cancel",
     "close": "Close",

--- a/packages/ui/src/components/color-field.tsx
+++ b/packages/ui/src/components/color-field.tsx
@@ -35,8 +35,31 @@ export interface ColorFieldProps
   value: string;
   /** Called with the new `#rrggbb` hex string from the swatch or eyedropper. */
   onChange: (hex: string) => void;
-  /** Accessible label for the screen eyedropper button. */
+  /**
+   * Called once after a screen-eyedropper pick commits a color. Callers using a
+   * preview-while-dragging / commit-on-blur model (where `onChange` only
+   * previews) should commit here, since the eyedropper never fires a blur.
+   */
+  onCommit?: () => void;
+  /**
+   * Accessible label for the screen eyedropper button. The English default is a
+   * fallback for this i18n-free primitive package; app call-sites that support
+   * react-i18next should pass a `t()`-translated value.
+   */
   eyedropperLabel?: string;
+  /**
+   * When true (default), the swatch grows to fill the available width and the
+   * field is a block-level flex row — suited to full-width form fields. Set
+   * false for compact inline swatches that should keep their own width.
+   */
+  fill?: boolean;
+  /**
+   * Classes applied to the inner color swatch `<input>` (not the wrapper). Use
+   * to size the swatch; pair with `buttonClassName` to match the eyedropper.
+   */
+  className?: string;
+  /** Classes sizing the eyedropper button; match the swatch for compact rows. */
+  buttonClassName?: string;
 }
 
 /**
@@ -52,9 +75,12 @@ export const ColorField = React.forwardRef<HTMLInputElement, ColorFieldProps>(
     {
       value,
       onChange,
+      onCommit,
       className,
       disabled,
       eyedropperLabel = "Pick a color from the screen",
+      fill = true,
+      buttonClassName = "h-9 w-9",
       ...props
     },
     ref,
@@ -62,33 +88,49 @@ export const ColorField = React.forwardRef<HTMLInputElement, ColorFieldProps>(
     // Feature-detect after mount so the rendered output stays deterministic
     // across environments that prerender the build.
     const [supportsEyeDropper, setSupportsEyeDropper] = React.useState(false);
+    // Abort any in-flight pick when the field unmounts so a late resolution
+    // doesn't call onChange on a gone parent.
+    const abortRef = React.useRef<AbortController | null>(null);
     React.useEffect(() => {
       setSupportsEyeDropper(
         typeof window !== "undefined" && typeof window.EyeDropper === "function",
       );
+      return () => abortRef.current?.abort();
     }, []);
 
     const pickFromScreen = React.useCallback(async () => {
       if (typeof window === "undefined" || typeof window.EyeDropper !== "function") {
         return;
       }
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
       try {
-        const result = await new window.EyeDropper().open();
-        if (result?.sRGBHex) onChange(result.sRGBHex);
-      } catch {
-        // The user dismissed the eyedropper (Escape or click-away); ignore.
+        const result = await new window.EyeDropper().open({
+          signal: controller.signal,
+        });
+        if (result?.sRGBHex) {
+          onChange(result.sRGBHex);
+          onCommit?.();
+        }
+      } catch (err) {
+        // AbortError = the user dismissed the picker (Escape / click-away) or
+        // the field unmounted mid-pick; anything else is unexpected, so re-throw
+        // to surface it in the browser console instead of swallowing silently.
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        throw err;
       }
-    }, [onChange]);
+    }, [onChange, onCommit]);
 
     return (
-      <div className="flex items-center gap-2">
+      <div className={cn("flex items-center gap-2", !fill && "inline-flex")}>
         <Input
           ref={ref}
           type="color"
           value={value}
           disabled={disabled}
           onChange={(event) => onChange(event.target.value)}
-          className={cn(supportsEyeDropper && "flex-1", className)}
+          className={cn(supportsEyeDropper && fill && "flex-1", className)}
           {...props}
         />
         {supportsEyeDropper ? (
@@ -98,7 +140,10 @@ export const ColorField = React.forwardRef<HTMLInputElement, ColorFieldProps>(
             disabled={disabled}
             aria-label={eyedropperLabel}
             title={eyedropperLabel}
-            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-input bg-transparent text-muted-foreground shadow-xs transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:border-2 focus-visible:border-ring focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+            className={cn(
+              "flex shrink-0 items-center justify-center rounded-md border border-input bg-transparent text-muted-foreground shadow-xs transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:border-2 focus-visible:border-ring focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
+              buttonClassName,
+            )}
           >
             <Pipette className="h-4 w-4" aria-hidden="true" />
           </button>

--- a/packages/ui/src/components/color-field.tsx
+++ b/packages/ui/src/components/color-field.tsx
@@ -1,0 +1,110 @@
+import * as React from "react";
+import { Pipette } from "lucide-react";
+import { cn } from "../lib/utils";
+import { Input } from "./input";
+
+// The EyeDropper API is not yet part of TypeScript's DOM lib, so declare the
+// minimal surface we use. Unlike the native color input's built-in eyedropper
+// (whose magnifier can render *behind* the picker popup in some browsers), the
+// EyeDropper API draws its magnifier as a top-level browser overlay above all
+// page content, so any visible color can be sampled.
+interface EyeDropperResult {
+  sRGBHex: string;
+}
+
+interface EyeDropperInstance {
+  open: (options?: { signal?: AbortSignal }) => Promise<EyeDropperResult>;
+}
+
+interface EyeDropperConstructor {
+  new (): EyeDropperInstance;
+}
+
+declare global {
+  interface Window {
+    EyeDropper?: EyeDropperConstructor;
+  }
+}
+
+export interface ColorFieldProps
+  extends Omit<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    "type" | "value" | "onChange"
+  > {
+  /** The current color as a `#rrggbb` hex string. */
+  value: string;
+  /** Called with the new `#rrggbb` hex string from the swatch or eyedropper. */
+  onChange: (hex: string) => void;
+  /** Accessible label for the screen eyedropper button. */
+  eyedropperLabel?: string;
+}
+
+/**
+ * A color input pairing the native color swatch with a screen eyedropper.
+ *
+ * The eyedropper button is shown only when the browser exposes the
+ * `EyeDropper` API; its magnifier overlays the whole screen, so colors shown
+ * inside the picker UI itself can be sampled — unlike the native color input's
+ * built-in eyedropper, which can render behind the picker popup.
+ */
+export const ColorField = React.forwardRef<HTMLInputElement, ColorFieldProps>(
+  (
+    {
+      value,
+      onChange,
+      className,
+      disabled,
+      eyedropperLabel = "Pick a color from the screen",
+      ...props
+    },
+    ref,
+  ) => {
+    // Feature-detect after mount so the rendered output stays deterministic
+    // across environments that prerender the build.
+    const [supportsEyeDropper, setSupportsEyeDropper] = React.useState(false);
+    React.useEffect(() => {
+      setSupportsEyeDropper(
+        typeof window !== "undefined" && typeof window.EyeDropper === "function",
+      );
+    }, []);
+
+    const pickFromScreen = React.useCallback(async () => {
+      if (typeof window === "undefined" || typeof window.EyeDropper !== "function") {
+        return;
+      }
+      try {
+        const result = await new window.EyeDropper().open();
+        if (result?.sRGBHex) onChange(result.sRGBHex);
+      } catch {
+        // The user dismissed the eyedropper (Escape or click-away); ignore.
+      }
+    }, [onChange]);
+
+    return (
+      <div className="flex items-center gap-2">
+        <Input
+          ref={ref}
+          type="color"
+          value={value}
+          disabled={disabled}
+          onChange={(event) => onChange(event.target.value)}
+          className={cn(supportsEyeDropper && "flex-1", className)}
+          {...props}
+        />
+        {supportsEyeDropper ? (
+          <button
+            type="button"
+            onClick={pickFromScreen}
+            disabled={disabled}
+            aria-label={eyedropperLabel}
+            title={eyedropperLabel}
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-input bg-transparent text-muted-foreground shadow-xs transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:border-2 focus-visible:border-ring focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Pipette className="h-4 w-4" aria-hidden="true" />
+          </button>
+        ) : null}
+      </div>
+    );
+  },
+);
+ColorField.displayName = "ColorField";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,6 +1,7 @@
 export { cn } from "./lib/utils";
 export { Button, type ButtonProps } from "./components/button";
 export { Input } from "./components/input";
+export { ColorField, type ColorFieldProps } from "./components/color-field";
 export { Textarea } from "./components/textarea";
 export { Select } from "./components/select";
 export { Label } from "./components/label";


### PR DESCRIPTION
## Summary

Fixes #489 (reported by @renevandervelde). In the Style panel's color fields (e.g. **Outline color**), the native `<input type="color">` picker's built-in eyedropper renders **behind** the picker popup on some browsers (reported on Windows/Edge), so colors shown inside the picker UI itself cannot be sampled.

This adds a dedicated screen eyedropper that we control, so the magnifier always sits on top:

- New reusable **`ColorField`** component in `@geolibre/ui` — the native color swatch plus an eyedropper button backed by the [`EyeDropper` API](https://developer.mozilla.org/en-US/docs/Web/API/EyeDropper_API). The EyeDropper API draws its magnifier as a top-level browser overlay above all page content, so any visible color (including colors in the app's own UI) can be sampled.
- The eyedropper button is **feature-detected** and only shown when the browser exposes `window.EyeDropper` (Chromium/Edge/WebView2); it degrades to the plain swatch elsewhere (e.g. Firefox/Safari).
- Wired into the Style panel's single-color fields: **fill, outline, text, text halo, and extrusion**. The compact per-class swatches in categorized/graduated mode keep the native input (no room for a button in the fixed-width grid cell).

## Testing

- `npm run test:frontend` — 1085 passing.
- `tsc -b` and the pre-commit `npm build` hook pass.
- **Verified in the real app** with Playwright against a loaded vector layer: the eyedropper button renders next to the Fill and Outline color fields, and clicking it drives the `EyeDropper` API — the Outline color updated from `#3388ff` to the sampled color and the map outlines re-rendered accordingly.

Closes #489.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Color picker controls now support an eyedropper to pick colors from the screen when your browser allows it.

* **Improvements**
  * Standardized the color-picking UI across the desktop app for vector fill/stroke, text markers, class stop colors, and 3D extrusion to provide a consistent experience.
  * Enhanced interaction behavior to better separate live preview from final selection, improving responsiveness during editing.

* **Documentation**
  * Added an English UI text string for the “pick a color from the screen” label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->