### PR TITLE
fix(style): hide Circle radius for the GeoEditor Sketches layer

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1061,10 +1061,8 @@ export function StylePanel({
     layer.metadata.sourceKind === "maplibre-gl-vector" &&
     layer.metadata.geometryType === "point";
   const supportsPointRenderer = isCoreGeoJsonPoint || isVectorControlPoint;
-  // The GeoEditor's "Sketches" layer mixes point/line/polygon (and circle)
-  // sketches under one style, so "Circle radius" only applies to its point
-  // markers and is misleading for the drawn circle/polygon/line shapes. Hide it
-  // for that layer (see issue #483).
+  // The "Sketches" layer mixes geometry types under one style, so "Circle
+  // radius" only applies to its point markers and is misleading otherwise (#483).
   const isSketchLayer = layer.metadata.sourceKind === SKETCHES_SOURCE_KIND;
   const strokeWidthUnit = styleValue(style, "strokeWidthUnit");
   // The unit only affects line/polygon-outline rendering. Point layers always

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -23,7 +23,7 @@ import {
   Separator,
   Slider,
 } from "@geolibre/ui";
-import { RASTER_SOURCE_KIND } from "@geolibre/plugins";
+import { RASTER_SOURCE_KIND, SKETCHES_SOURCE_KIND } from "@geolibre/plugins";
 import type { MapController } from "@geolibre/map";
 import { RasterSymbologySection } from "./RasterSymbologySection";
 import {
@@ -1061,6 +1061,11 @@ export function StylePanel({
     layer.metadata.sourceKind === "maplibre-gl-vector" &&
     layer.metadata.geometryType === "point";
   const supportsPointRenderer = isCoreGeoJsonPoint || isVectorControlPoint;
+  // The GeoEditor's "Sketches" layer mixes point/line/polygon (and circle)
+  // sketches under one style, so "Circle radius" only applies to its point
+  // markers and is misleading for the drawn circle/polygon/line shapes. Hide it
+  // for that layer (see issue #483).
+  const isSketchLayer = layer.metadata.sourceKind === SKETCHES_SOURCE_KIND;
   const strokeWidthUnit = styleValue(style, "strokeWidthUnit");
   // The unit only affects line/polygon-outline rendering. Point layers always
   // stroke in pixels, so never present meters semantics (label/range/selector)
@@ -1751,15 +1756,17 @@ export function StylePanel({
         value={style.fillOpacity}
         onChange={(fillOpacity) => setLayerStyle(layer.id, { fillOpacity })}
       />
-      <NumericStyleInput
-        id="circleRadius"
-        label="Circle radius"
-        min={1}
-        max={50}
-        step={1}
-        value={style.circleRadius}
-        onChange={(circleRadius) => setLayerStyle(layer.id, { circleRadius })}
-      />
+      {isSketchLayer ? null : (
+        <NumericStyleInput
+          id="circleRadius"
+          label="Circle radius"
+          min={1}
+          max={50}
+          step={1}
+          value={style.circleRadius}
+          onChange={(circleRadius) => setLayerStyle(layer.id, { circleRadius })}
+        />
+      )}
       {hasTextMarkerControls ? (
         <>
           <Separator />

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -996,6 +996,7 @@ function applyGeomanSketchesStyle(
     if (!isGeomanDisplayLayer(layer)) continue;
     applyGeomanDisplayLayerOpacity(map, layer, sketchesLayer.opacity);
     applyGeomanDisplayLayerWidth(map, layer, sketchesLayer.style);
+    applyGeomanDisplayLayerCircleRadius(map, layer, sketchesLayer.style);
     if (!isGeomanTextMarkerLayer(layer)) continue;
     try {
       map.setLayoutProperty(
@@ -1045,6 +1046,52 @@ function applyGeomanDisplayLayerWidth(
   setGeomanPaintProperty(map, layer.id, "line-width", lineWidthValue(style));
 }
 
+/**
+ * The store's default point circle radius and Geoman's default marker icon size.
+ * Used to scale the marker icon proportionally so an editing marker grows with
+ * the layer's circle radius the same way the idle store-rendered circle does.
+ */
+const DEFAULT_POINT_CIRCLE_RADIUS = 6;
+const DEFAULT_GEOMAN_MARKER_ICON_SIZE = 0.18;
+
+/**
+ * Mirror the Sketches layer's circle radius onto Geoman's committed point
+ * display layers. While the draw/edit tools are active the store Sketches layer
+ * is suppressed and Geoman renders the existing features instead, so without this
+ * a point marker's circle radius (which works in the idle store rendering) has no
+ * visible effect during selection/editing. Circle-type point layers take the
+ * radius directly; the default `marker` symbol icon is scaled proportionally so
+ * it grows to match. Editing aids (vertex/center/edge handles, snap guides) and
+ * text markers keep Geoman's defaults so editing stays legible.
+ */
+function applyGeomanDisplayLayerCircleRadius(
+  map: maplibregl.Map,
+  layer: maplibregl.LayerSpecification,
+  style: GeoLibreLayer["style"],
+): void {
+  const id = layer.id.toLowerCase();
+  if (!id.startsWith("gm_main") || id.includes("snap")) return;
+
+  const radius = Math.max(1, styleValue(style, "circleRadius"));
+
+  if (layer.type === "circle") {
+    setGeomanPaintProperty(map, layer.id, "circle-radius", radius);
+    return;
+  }
+
+  // Geoman renders the `marker` geometry as an icon symbol (id `...-marker__…`).
+  // Exclude the `text_marker` symbol (id `...-text_marker__…`), which carries its
+  // own text styling, by skipping ids containing "text".
+  if (layer.type === "symbol" && id.includes("marker") && !id.includes("text")) {
+    setGeomanLayoutProperty(
+      map,
+      layer.id,
+      "icon-size",
+      (radius / DEFAULT_POINT_CIRCLE_RADIUS) * DEFAULT_GEOMAN_MARKER_ICON_SIZE,
+    );
+  }
+}
+
 function applyGeomanDisplayLayerOpacity(
   map: maplibregl.Map,
   layer: maplibregl.LayerSpecification,
@@ -1075,6 +1122,19 @@ function setGeomanPaintProperty(
     map.setPaintProperty(layerId, property, value);
   } catch {
     // Geoman layers are rebuilt often and may not support every paint property.
+  }
+}
+
+function setGeomanLayoutProperty(
+  map: maplibregl.Map,
+  layerId: string,
+  property: string,
+  value: unknown,
+): void {
+  try {
+    map.setLayoutProperty(layerId, property, value);
+  } catch {
+    // Geoman layers are rebuilt often and may not support every layout property.
   }
 }
 

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -996,7 +996,6 @@ function applyGeomanSketchesStyle(
     if (!isGeomanDisplayLayer(layer)) continue;
     applyGeomanDisplayLayerOpacity(map, layer, sketchesLayer.opacity);
     applyGeomanDisplayLayerWidth(map, layer, sketchesLayer.style);
-    applyGeomanDisplayLayerCircleRadius(map, layer, sketchesLayer.style);
     if (!isGeomanTextMarkerLayer(layer)) continue;
     try {
       map.setLayoutProperty(
@@ -1046,61 +1045,6 @@ function applyGeomanDisplayLayerWidth(
   setGeomanPaintProperty(map, layer.id, "line-width", lineWidthValue(style));
 }
 
-/**
- * The store's default point circle radius and Geoman's default marker icon size.
- * Used to scale the marker icon proportionally so an editing marker grows with
- * the layer's circle radius the same way the idle store-rendered circle does.
- *
- * `DEFAULT_GEOMAN_MARKER_ICON_SIZE` mirrors Geoman 0.7.1's default marker
- * `icon-size`; recheck it after upgrading `@geoman-io/maplibre-geoman-free` so
- * the neutral case (radius === DEFAULT_POINT_CIRCLE_RADIUS) keeps matching the
- * idle store rendering.
- */
-const DEFAULT_POINT_CIRCLE_RADIUS = 6;
-const DEFAULT_GEOMAN_MARKER_ICON_SIZE = 0.18;
-
-/**
- * Mirror the Sketches layer's circle radius onto Geoman's committed point
- * display layers. While the draw/edit tools are active the store Sketches layer
- * is suppressed and Geoman renders the existing features instead, so without this
- * a point marker's circle radius (which works in the idle store rendering) has no
- * visible effect during selection/editing. Circle-type point layers take the
- * radius directly; the default `marker` symbol icon is scaled proportionally so
- * it grows to match. Editing aids (vertex/center/edge handles, snap guides) and
- * text markers keep Geoman's defaults so editing stays legible.
- */
-function applyGeomanDisplayLayerCircleRadius(
-  map: maplibregl.Map,
-  layer: maplibregl.LayerSpecification,
-  style: GeoLibreLayer["style"],
-): void {
-  if (layer.type !== "circle" && layer.type !== "symbol") return;
-  const id = layer.id.toLowerCase();
-  if (!id.startsWith("gm_main") || id.includes("snap")) return;
-
-  // Mirror the store rendering, which applies `circleRadius` unclamped, so the
-  // editing view stays consistent with the idle view (e.g. radius 0 hides the
-  // point in both).
-  const radius = styleValue(style, "circleRadius");
-
-  if (layer.type === "circle") {
-    setGeomanPaintProperty(map, layer.id, "circle-radius", radius);
-    return;
-  }
-
-  // Geoman renders the `marker` geometry as an icon symbol (id `...-marker__…`).
-  // Exclude the `text_marker` symbol (id `...-text_marker__…`), which carries its
-  // own text styling.
-  if (id.includes("marker") && !id.includes("text_marker")) {
-    setGeomanLayoutProperty(
-      map,
-      layer.id,
-      "icon-size",
-      (radius / DEFAULT_POINT_CIRCLE_RADIUS) * DEFAULT_GEOMAN_MARKER_ICON_SIZE,
-    );
-  }
-}
-
 function applyGeomanDisplayLayerOpacity(
   map: maplibregl.Map,
   layer: maplibregl.LayerSpecification,
@@ -1131,19 +1075,6 @@ function setGeomanPaintProperty(
     map.setPaintProperty(layerId, property, value);
   } catch {
     // Geoman layers are rebuilt often and may not support every paint property.
-  }
-}
-
-function setGeomanLayoutProperty(
-  map: maplibregl.Map,
-  layerId: string,
-  property: string,
-  value: unknown,
-): void {
-  try {
-    map.setLayoutProperty(layerId, property, value);
-  } catch {
-    // Geoman layers are rebuilt often and may not support every layout property.
   }
 }
 

--- a/packages/plugins/src/plugins/maplibre-geo-editor.ts
+++ b/packages/plugins/src/plugins/maplibre-geo-editor.ts
@@ -1050,6 +1050,11 @@ function applyGeomanDisplayLayerWidth(
  * The store's default point circle radius and Geoman's default marker icon size.
  * Used to scale the marker icon proportionally so an editing marker grows with
  * the layer's circle radius the same way the idle store-rendered circle does.
+ *
+ * `DEFAULT_GEOMAN_MARKER_ICON_SIZE` mirrors Geoman 0.7.1's default marker
+ * `icon-size`; recheck it after upgrading `@geoman-io/maplibre-geoman-free` so
+ * the neutral case (radius === DEFAULT_POINT_CIRCLE_RADIUS) keeps matching the
+ * idle store rendering.
  */
 const DEFAULT_POINT_CIRCLE_RADIUS = 6;
 const DEFAULT_GEOMAN_MARKER_ICON_SIZE = 0.18;
@@ -1069,10 +1074,14 @@ function applyGeomanDisplayLayerCircleRadius(
   layer: maplibregl.LayerSpecification,
   style: GeoLibreLayer["style"],
 ): void {
+  if (layer.type !== "circle" && layer.type !== "symbol") return;
   const id = layer.id.toLowerCase();
   if (!id.startsWith("gm_main") || id.includes("snap")) return;
 
-  const radius = Math.max(1, styleValue(style, "circleRadius"));
+  // Mirror the store rendering, which applies `circleRadius` unclamped, so the
+  // editing view stays consistent with the idle view (e.g. radius 0 hides the
+  // point in both).
+  const radius = styleValue(style, "circleRadius");
 
   if (layer.type === "circle") {
     setGeomanPaintProperty(map, layer.id, "circle-radius", radius);
@@ -1081,8 +1090,8 @@ function applyGeomanDisplayLayerCircleRadius(
 
   // Geoman renders the `marker` geometry as an icon symbol (id `...-marker__…`).
   // Exclude the `text_marker` symbol (id `...-text_marker__…`), which carries its
-  // own text styling, by skipping ids containing "text".
-  if (layer.type === "symbol" && id.includes("marker") && !id.includes("text")) {
+  // own text styling.
+  if (id.includes("marker") && !id.includes("text_marker")) {
     setGeomanLayoutProperty(
       map,
       layer.id,


### PR DESCRIPTION
## Summary
- Resolves #483: the "Circle radius" control was confusing on the GeoEditor "Sketches" layer.
- That layer holds point, line, polygon, and circle sketches under one shared style, so "Circle radius" only affects its point markers and does nothing for the drawn circle/polygon/line shapes (and changing it had no visible effect while a feature was selected or being edited).
- The Style panel now hides the "Circle radius" control for the Sketches layer. It still appears for regular GeoJSON point layers.

## Test plan
- [x] Frontend test suite passes (1085 passed, 1 pre-existing skip)
- [x] Full build / pre-commit passes
- [x] Verified in the running app: drew a marker with the GeoEditor and confirmed "Circle radius" is absent from the Sketches layer style panel, while a dropped GeoJSON point layer still shows it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the “Circle radius” control from the style panel when editing Sketches layers. Sketches can include mixed geometry types, so a single radius option is no longer shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->