### PR TITLE
fix(map): render generic external raster tile layers from plugins

### DIFF
--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -259,6 +259,9 @@ function syncExternalNativeLayer(
   // none of the handlers above. Honor the documented external-layer contract
   // (a `source` with `tiles` and `type: "raster"`) by building the source and
   // raster layer here instead of dropping through to the GeoJSON path below.
+  // IMPORTANT: this is a structural catch-all, so add any new named raster
+  // handler (new sourceKind) BEFORE this check — placing it after would let a
+  // layer that also has `source.tiles` be intercepted by the generic path.
   if (isExternalRasterTileLayer(layer)) {
     syncExternalRasterTileLayer(map, layer, nativeLayerIds, beforeId);
     return;
@@ -802,6 +805,10 @@ function syncExternalRasterTileLayer(
   const tiles = getSourceTiles(layer);
   if (tiles.length === 0) return;
 
+  // The source is built once and never rebuilt while it exists, matching the
+  // other raster handlers above. A plugin that re-registers the same sourceId
+  // with a different `tiles` array will keep serving the original tiles; to
+  // switch tile URLs it must register under a new sourceId.
   if (!map.getSource(sourceId)) {
     const bounds = boundsSource(layer.source.bounds);
     map.addSource(sourceId, {

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -780,7 +780,11 @@ function isBasemapControlRasterLayer(layer: GeoLibreLayer): boolean {
 // carries no GeoLibre-internal sourceKind, so it is matched structurally: any
 // external raster layer with concrete tiles and no dedicated handler.
 function isExternalRasterTileLayer(layer: GeoLibreLayer): boolean {
-  return layer.type === "raster" && getBasemapControlTiles(layer).length > 0;
+  return (
+    layer.type === "raster" &&
+    layer.metadata.externalNativeLayer === true &&
+    getSourceTiles(layer).length > 0
+  );
 }
 
 // Build the MapLibre source and raster layer for a generic external raster tile
@@ -795,7 +799,7 @@ function syncExternalRasterTileLayer(
 ): void {
   const nativeLayerId = nativeLayerIds[0] ?? layer.id;
   const sourceId = getExternalSourceIds(layer)[0] ?? `${nativeLayerId}-source`;
-  const tiles = getBasemapControlTiles(layer);
+  const tiles = getSourceTiles(layer);
   if (tiles.length === 0) return;
 
   if (!map.getSource(sourceId)) {
@@ -979,14 +983,24 @@ function boundsSource(
     : undefined;
 }
 
-function getBasemapControlTiles(layer: GeoLibreLayer): string[] {
+// Concrete XYZ tile templates from the registration's own `source.tiles`. This
+// is the documented external-raster contract and the only source the generic
+// external-raster path reads — it deliberately does not look at
+// metadata.tileUrl (see getBasemapControlTiles for that basemap-internal key).
+function getSourceTiles(layer: GeoLibreLayer): string[] {
   const tiles = layer.source.tiles;
-  if (Array.isArray(tiles)) {
-    const valid = tiles.filter(
-      (tile): tile is string => typeof tile === "string" && tile.length > 0,
-    );
-    if (valid.length > 0) return valid;
-  }
+  if (!Array.isArray(tiles)) return [];
+  return tiles.filter(
+    (tile): tile is string => typeof tile === "string" && tile.length > 0,
+  );
+}
+
+function getBasemapControlTiles(layer: GeoLibreLayer): string[] {
+  const tiles = getSourceTiles(layer);
+  if (tiles.length > 0) return tiles;
+  // The basemap control stores its single tile template under this internal
+  // metadata key rather than source.tiles; that fallback is specific to the
+  // basemap/web-service paths and intentionally not part of getSourceTiles.
   const tileUrl = stringMetadata(layer.metadata.tileUrl);
   return tileUrl ? [tileUrl] : [];
 }

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -254,6 +254,16 @@ function syncExternalNativeLayer(
     return;
   }
 
+  // Generic external raster tiles registered by third-party plugins (e.g. a
+  // titiler-served XYZ source) carry no recognized sourceKind, so they match
+  // none of the handlers above. Honor the documented external-layer contract
+  // (a `source` with `tiles` and `type: "raster"`) by building the source and
+  // raster layer here instead of dropping through to the GeoJSON path below.
+  if (isExternalRasterTileLayer(layer)) {
+    syncExternalRasterTileLayer(map, layer, nativeLayerIds, beforeId);
+    return;
+  }
+
   ensureExternalGeoJsonNativeLayer(map, layer, nativeLayerIds, beforeId);
 
   const nativeFillLayerSpecs = nativeLayerIds
@@ -761,6 +771,65 @@ function isBasemapControlRasterLayer(layer: GeoLibreLayer): boolean {
     layer.type === "raster" &&
     layer.metadata.sourceKind === "maplibre-basemap-control" &&
     layer.metadata.externalNativeLayer === true
+  );
+}
+
+// A raster layer registered by a third-party plugin through
+// registerExternalNativeLayer that supplies its own XYZ tile template(s) in
+// `source.tiles`. Unlike the basemap/web-service/PMTiles raster paths above it
+// carries no GeoLibre-internal sourceKind, so it is matched structurally: any
+// external raster layer with concrete tiles and no dedicated handler.
+function isExternalRasterTileLayer(layer: GeoLibreLayer): boolean {
+  return layer.type === "raster" && getBasemapControlTiles(layer).length > 0;
+}
+
+// Build the MapLibre source and raster layer for a generic external raster tile
+// registration. Mirrors syncBasemapControlRasterLayer/syncWebServiceTileRasterLayer
+// but reads everything from the registration's own `source`, so any plugin that
+// hands GeoLibre an XYZ raster source renders without needing a bespoke handler.
+function syncExternalRasterTileLayer(
+  map: maplibregl.Map,
+  layer: GeoLibreLayer,
+  nativeLayerIds: string[],
+  beforeId?: string,
+): void {
+  const nativeLayerId = nativeLayerIds[0] ?? layer.id;
+  const sourceId = getExternalSourceIds(layer)[0] ?? `${nativeLayerId}-source`;
+  const tiles = getBasemapControlTiles(layer);
+  if (tiles.length === 0) return;
+
+  if (!map.getSource(sourceId)) {
+    const bounds = boundsSource(layer.source.bounds);
+    map.addSource(sourceId, {
+      type: "raster",
+      tiles,
+      tileSize: numberSource(layer.source.tileSize) ?? 256,
+      ...(numberSource(layer.source.minzoom) !== undefined
+        ? { minzoom: numberSource(layer.source.minzoom) }
+        : {}),
+      ...(numberSource(layer.source.maxzoom) !== undefined
+        ? { maxzoom: numberSource(layer.source.maxzoom) }
+        : {}),
+      ...(bounds ? { bounds } : {}),
+      ...(layer.source.scheme === "tms" ? { scheme: "tms" as const } : {}),
+      ...(stringSource(layer.source.attribution)
+        ? { attribution: stringSource(layer.source.attribution) }
+        : {}),
+    });
+  }
+
+  ensureLayer(
+    map,
+    nativeLayerId,
+    {
+      id: nativeLayerId,
+      type: "raster",
+      source: sourceId,
+      ...styleLayerZoomRange(layer.style),
+      paint: rasterPaint(layer.style, layer.opacity),
+      layout: { visibility: layer.visible ? "visible" : "none" },
+    },
+    beforeId,
   );
 }
 

--- a/tests/external-raster-tile-sync.test.ts
+++ b/tests/external-raster-tile-sync.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { DEFAULT_LAYER_STYLE, type GeoLibreLayer } from "@geolibre/core";
+import { syncLayer } from "../packages/map/src/layer-sync";
+
+// Records the maplibre operations a sync performs so a test can assert that a
+// generic external raster registration actually builds a source and layer.
+interface MapCall {
+  method: string;
+  args: unknown[];
+}
+
+// A fake map where no source/layer exists yet, so syncLayer must create them.
+function makeEmptyMapStub() {
+  const calls: MapCall[] = [];
+  const record =
+    (method: string) =>
+    (...args: unknown[]) => {
+      calls.push({ method, args });
+    };
+  const map = {
+    getStyle: () => ({ layers: [] }),
+    getLayer: () => undefined,
+    getSource: () => undefined,
+    setLayoutProperty: record("setLayoutProperty"),
+    setPaintProperty: record("setPaintProperty"),
+    setLayerZoomRange: record("setLayerZoomRange"),
+    moveLayer: record("moveLayer"),
+    removeLayer: record("removeLayer"),
+    removeSource: record("removeSource"),
+    addLayer: record("addLayer"),
+    addSource: record("addSource"),
+  };
+  return { map, calls };
+}
+
+// The store layer GeoLibre derives (via createExternalNativeStoreLayer) from a
+// third-party plugin's generic raster registration — e.g. the GeoLibre D2S
+// plugin handing the host titiler XYZ tiles. It carries no GeoLibre-internal
+// sourceKind, which is exactly the case that previously rendered nothing.
+function d2sRasterStoreLayer(
+  patch: Partial<GeoLibreLayer> = {},
+): GeoLibreLayer {
+  const id = "d2s-raster-1";
+  return {
+    id,
+    name: "Ortho (RGB)",
+    type: "raster",
+    source: {
+      type: "raster",
+      tiles: ["https://titiler.example.com/tiles/{z}/{x}/{y}.png?url=cog"],
+      tileSize: 256,
+      bounds: [-90, 30, -89, 31],
+      minzoom: 0,
+      maxzoom: 22,
+      sourceId: `${id}-source`,
+    },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {
+      externalNativeLayer: true,
+      nativeLayerIds: [`${id}-layer`],
+      sourceIds: [`${id}-source`],
+      sourceId: `${id}-source`,
+    },
+    ...patch,
+  };
+}
+
+describe("generic external raster tile layers", () => {
+  it("builds a raster source and layer from the registration's own tiles", () => {
+    const { map, calls } = makeEmptyMapStub();
+
+    syncLayer(map as never, d2sRasterStoreLayer());
+
+    const addSource = calls.find((c) => c.method === "addSource");
+    assert.ok(addSource, "expected a raster source to be created");
+    assert.equal(addSource.args[0], "d2s-raster-1-source");
+    const sourceSpec = addSource.args[1] as Record<string, unknown>;
+    assert.equal(sourceSpec.type, "raster");
+    assert.deepEqual(sourceSpec.tiles, [
+      "https://titiler.example.com/tiles/{z}/{x}/{y}.png?url=cog",
+    ]);
+    assert.equal(sourceSpec.tileSize, 256);
+    assert.deepEqual(sourceSpec.bounds, [-90, 30, -89, 31]);
+
+    const addLayer = calls.find((c) => c.method === "addLayer");
+    assert.ok(addLayer, "expected a raster layer to be created");
+    const layerSpec = addLayer.args[0] as Record<string, unknown>;
+    assert.equal(layerSpec.id, "d2s-raster-1-layer");
+    assert.equal(layerSpec.type, "raster");
+    assert.equal(layerSpec.source, "d2s-raster-1-source");
+  });
+
+  it("honors visibility from the store layer", () => {
+    const { map, calls } = makeEmptyMapStub();
+
+    syncLayer(map as never, d2sRasterStoreLayer({ visible: false }));
+
+    const addLayer = calls.find((c) => c.method === "addLayer");
+    assert.ok(addLayer, "expected a raster layer to be created");
+    const layerSpec = addLayer.args[0] as {
+      layout?: { visibility?: string };
+    };
+    assert.equal(layerSpec.layout?.visibility, "none");
+  });
+});

--- a/tests/external-raster-tile-sync.test.ts
+++ b/tests/external-raster-tile-sync.test.ts
@@ -81,7 +81,6 @@ function d2sRasterStoreLayer(
       bounds: [-90, 30, -89, 31],
       minzoom: 0,
       maxzoom: 22,
-      sourceId: `${id}-source`,
     },
     visible: true,
     opacity: 1,
@@ -162,6 +161,9 @@ describe("generic external raster tile layers", () => {
     assert.equal(sourceSpec.scheme, "tms");
   });
 
+  // The source is built once and frozen: a re-sync updates the layer (paint,
+  // visibility, ordering) in place but does not rebuild the source, so tile
+  // URLs registered on the first sync stay fixed for the source's lifetime.
   it("updates the existing layer without recreating the source on re-sync", () => {
     const { map, calls } = makePopulatedMapStub("d2s-raster-1-layer");
 

--- a/tests/external-raster-tile-sync.test.ts
+++ b/tests/external-raster-tile-sync.test.ts
@@ -34,6 +34,34 @@ function makeEmptyMapStub() {
   return { map, calls };
 }
 
+// A fake map where the source and layer already exist (the second sync pass,
+// e.g. after a paint/visibility change), so syncLayer must update the existing
+// layer in place rather than recreating the source.
+function makePopulatedMapStub(layerId: string) {
+  const calls: MapCall[] = [];
+  const record =
+    (method: string) =>
+    (...args: unknown[]) => {
+      calls.push({ method, args });
+    };
+  const map = {
+    getStyle: () => ({ layers: [{ id: layerId }] }),
+    getLayer: (id: string) =>
+      id === layerId ? { id, type: "raster", minzoom: 0, maxzoom: 22 } : undefined,
+    getSource: () => ({ type: "raster" }),
+    getFilter: () => undefined,
+    setLayoutProperty: record("setLayoutProperty"),
+    setPaintProperty: record("setPaintProperty"),
+    setLayerZoomRange: record("setLayerZoomRange"),
+    moveLayer: record("moveLayer"),
+    removeLayer: record("removeLayer"),
+    removeSource: record("removeSource"),
+    addLayer: record("addLayer"),
+    addSource: record("addSource"),
+  };
+  return { map, calls };
+}
+
 // The store layer GeoLibre derives (via createExternalNativeStoreLayer) from a
 // third-party plugin's generic raster registration — e.g. the GeoLibre D2S
 // plugin handing the host titiler XYZ tiles. It carries no GeoLibre-internal
@@ -84,6 +112,8 @@ describe("generic external raster tile layers", () => {
     ]);
     assert.equal(sourceSpec.tileSize, 256);
     assert.deepEqual(sourceSpec.bounds, [-90, 30, -89, 31]);
+    assert.equal(sourceSpec.minzoom, 0);
+    assert.equal(sourceSpec.maxzoom, 22);
 
     const addLayer = calls.find((c) => c.method === "addLayer");
     assert.ok(addLayer, "expected a raster layer to be created");
@@ -104,5 +134,53 @@ describe("generic external raster tile layers", () => {
       layout?: { visibility?: string };
     };
     assert.equal(layerSpec.layout?.visibility, "none");
+  });
+
+  it("forwards attribution from the registration's source", () => {
+    const { map, calls } = makeEmptyMapStub();
+    const layer = d2sRasterStoreLayer();
+    layer.source.attribution = "© Example Imagery";
+
+    syncLayer(map as never, layer);
+
+    const addSource = calls.find((c) => c.method === "addSource");
+    assert.ok(addSource, "expected a raster source to be created");
+    const sourceSpec = addSource.args[1] as Record<string, unknown>;
+    assert.equal(sourceSpec.attribution, "© Example Imagery");
+  });
+
+  it("forwards the tms scheme from the registration's source", () => {
+    const { map, calls } = makeEmptyMapStub();
+    const layer = d2sRasterStoreLayer();
+    layer.source.scheme = "tms";
+
+    syncLayer(map as never, layer);
+
+    const addSource = calls.find((c) => c.method === "addSource");
+    assert.ok(addSource, "expected a raster source to be created");
+    const sourceSpec = addSource.args[1] as Record<string, unknown>;
+    assert.equal(sourceSpec.scheme, "tms");
+  });
+
+  it("updates the existing layer without recreating the source on re-sync", () => {
+    const { map, calls } = makePopulatedMapStub("d2s-raster-1-layer");
+
+    syncLayer(map as never, d2sRasterStoreLayer({ visible: false }));
+
+    assert.equal(
+      calls.find((c) => c.method === "addSource"),
+      undefined,
+      "should not recreate an already-present source",
+    );
+    assert.equal(
+      calls.find((c) => c.method === "addLayer"),
+      undefined,
+      "should not recreate an already-present layer",
+    );
+    const setVisibility = calls.find(
+      (c) => c.method === "setLayoutProperty" && c.args[1] === "visibility",
+    );
+    assert.ok(setVisibility, "expected visibility to be updated in place");
+    assert.equal(setVisibility.args[2], "none");
   });
 });


### PR DESCRIPTION
## Problem

Third-party plugins (e.g. the [GeoLibre D2S plugin](https://github.com/opengeos/geolibre-d2s)) add raster layers by calling `app.registerExternalNativeLayer(...)` with a raster source (`type: "raster"` + `source.tiles`, e.g. titiler XYZ tiles). The plugin **logs in and the layer appears in the Layers panel, but no imagery renders on the map.**

Root cause is in `packages/map/src/layer-sync.ts`. `syncExternalNativeLayer()` only had raster handlers for a fixed allow-list of GeoLibre-internal `sourceKind`s:

- PMTiles (`isPMTilesExternalLayer`)
- Esri Wayback (`isWaybackExternalRasterLayer`)
- Basemap control (`isBasemapControlRasterLayer`)
- Web services — fema-wms, nasa-earthdata, enviroatlas, national-map (`isWebServiceTileRasterLayer`)

A **generic** external raster from a third-party plugin carries none of those `sourceKind`s, so it matched no handler, fell through to `ensureExternalGeoJsonNativeLayer()` (which no-ops without inline `geojson`), and the final loop found no pre-existing native layer — so the host **never created a MapLibre source/layer and zero tiles were requested**. (Inline-GeoJSON vector layers were unaffected; they already had a generic path.)

This is exactly the external-layer contract documented for `registerExternalNativeLayer` (a `source` with `tiles` + `type: "raster"`), which the host was not honoring for plugins outside the built-in set.

## Fix

Add a generic external-raster fallback in `syncExternalNativeLayer`:

- `isExternalRasterTileLayer(layer)` — any external raster layer with concrete `source.tiles` and no dedicated handler.
- `syncExternalRasterTileLayer(...)` — builds the raster source and layer from the registration's own `source` (`tiles`, `tileSize`, `bounds`, `minzoom`/`maxzoom`, `scheme`, `attribution`) and keeps visibility/opacity/ordering in sync.

It mirrors the existing `syncBasemapControlRasterLayer` / `syncWebServiceTileRasterLayer` handlers and reuses the same helpers, so any plugin that hands GeoLibre an XYZ raster source now renders without a bespoke handler.

## Verification

- **Regression test** (`tests/external-raster-tile-sync.test.ts`) reproduces the plugin's raster registration shape and asserts a raster source+layer are created. It **fails on `main`** ("expected a raster layer to be created") and passes with this change.
- **Full frontend suite**: 1087 pass / 0 fail.
- **End-to-end in the running app** with the published GeoLibre D2S plugin (install → activate → log in → add data product): GeoLibre now creates the raster source/layer and fetches the **identical** titiler XYZ tiles as the standalone host, and a real-world RGB ortho (D2S "Workshop Example Citrus Orchard") renders on the map. (A separate 5-band multispectral COG returns titiler 500s for the JPEG driver in *both* the standalone host and GeoLibre — a titiler/data issue, unrelated to this change.)

## Notes

`pre-commit run` (eslint + npm build/typecheck) passes on the changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for generic external raster tile layers by syncing them as raster tile sources/layers, including bounds, zoom constraints, attribution, optional TMS scheme, and visibility updates.
  * Improved tile-template resolution by using layer-provided `source.tiles` when available, with a fallback to existing basemap metadata.

* **Tests**
  * Added coverage for external raster tile layer synchronization, verifying initial creation, re-sync behavior, source/layer wiring, and layout visibility handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->