### PR TITLE
fix: GeoEditor polygon can't be closed (#481)

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -64,7 +64,7 @@
     "maplibre-gl-enviroatlas": "^0.1.1",
     "maplibre-gl-esri-wayback": "^0.2.0",
     "maplibre-gl-fema-wms": "^0.1.2",
-    "maplibre-gl-geo-editor": "^0.9.0",
+    "maplibre-gl-geo-editor": "^0.9.1",
     "maplibre-gl-geoagent": "^0.4.3",
     "maplibre-gl-lidar": "^0.15.0",
     "maplibre-gl-nasa-earthdata": "^0.1.2",

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -64,7 +64,7 @@
     "maplibre-gl-enviroatlas": "^0.1.1",
     "maplibre-gl-esri-wayback": "^0.2.0",
     "maplibre-gl-fema-wms": "^0.1.2",
-    "maplibre-gl-geo-editor": "^0.8.0",
+    "maplibre-gl-geo-editor": "^0.9.0",
     "maplibre-gl-geoagent": "^0.4.3",
     "maplibre-gl-lidar": "^0.15.0",
     "maplibre-gl-nasa-earthdata": "^0.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,7 @@
         "maplibre-gl-enviroatlas": "^0.1.1",
         "maplibre-gl-esri-wayback": "^0.2.0",
         "maplibre-gl-fema-wms": "^0.1.2",
-        "maplibre-gl-geo-editor": "^0.9.0",
+        "maplibre-gl-geo-editor": "^0.9.1",
         "maplibre-gl-geoagent": "^0.4.3",
         "maplibre-gl-lidar": "^0.15.0",
         "maplibre-gl-nasa-earthdata": "^0.1.2",
@@ -17576,9 +17576,9 @@
       }
     },
     "node_modules/maplibre-gl-geo-editor": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-geo-editor/-/maplibre-gl-geo-editor-0.9.0.tgz",
-      "integrity": "sha512-2k/e8i7bEgT8/4vaxEeQIxmY2qtyU56WHWJoNW6sx3iVP8iTUWwT7KzRrMlYSCrPioKCVDCuSHS/kNGb+TO0Fg==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-geo-editor/-/maplibre-gl-geo-editor-0.9.1.tgz",
+      "integrity": "sha512-YSoBMejy9+j5kRw3HON6P9s//d7WUPz9pC0+7Jo5bgOtJoSS8Kv31EVy8ud5nwCoH5Ie4eyFs9O1pjbtZWrZlQ==",
       "license": "MIT",
       "dependencies": {
         "@turf/turf": "^7.3.4",
@@ -24299,7 +24299,7 @@
         "maplibre-gl-enviroatlas": "^0.1.1",
         "maplibre-gl-esri-wayback": "^0.2.0",
         "maplibre-gl-fema-wms": "^0.1.2",
-        "maplibre-gl-geo-editor": "^0.9.0",
+        "maplibre-gl-geo-editor": "^0.9.1",
         "maplibre-gl-geoagent": "^0.4.3",
         "maplibre-gl-lidar": "^0.15.0",
         "maplibre-gl-nasa-earthdata": "^0.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,7 @@
         "maplibre-gl-enviroatlas": "^0.1.1",
         "maplibre-gl-esri-wayback": "^0.2.0",
         "maplibre-gl-fema-wms": "^0.1.2",
-        "maplibre-gl-geo-editor": "^0.8.0",
+        "maplibre-gl-geo-editor": "^0.9.0",
         "maplibre-gl-geoagent": "^0.4.3",
         "maplibre-gl-lidar": "^0.15.0",
         "maplibre-gl-nasa-earthdata": "^0.1.2",
@@ -17576,9 +17576,9 @@
       }
     },
     "node_modules/maplibre-gl-geo-editor": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-geo-editor/-/maplibre-gl-geo-editor-0.8.0.tgz",
-      "integrity": "sha512-DiMFYZE+94ztPtCvqbfftbBbfvOa5+qaqs7gpKzUjLRenWT8FhCjzjYsQDfUklePzlm8EMKa6BH/2pr8W+MU8A==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-geo-editor/-/maplibre-gl-geo-editor-0.9.0.tgz",
+      "integrity": "sha512-2k/e8i7bEgT8/4vaxEeQIxmY2qtyU56WHWJoNW6sx3iVP8iTUWwT7KzRrMlYSCrPioKCVDCuSHS/kNGb+TO0Fg==",
       "license": "MIT",
       "dependencies": {
         "@turf/turf": "^7.3.4",
@@ -24299,7 +24299,7 @@
         "maplibre-gl-enviroatlas": "^0.1.1",
         "maplibre-gl-esri-wayback": "^0.2.0",
         "maplibre-gl-fema-wms": "^0.1.2",
-        "maplibre-gl-geo-editor": "^0.8.0",
+        "maplibre-gl-geo-editor": "^0.9.0",
         "maplibre-gl-geoagent": "^0.4.3",
         "maplibre-gl-lidar": "^0.15.0",
         "maplibre-gl-nasa-earthdata": "^0.1.2",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -38,7 +38,7 @@
     "maplibre-gl-enviroatlas": "^0.1.1",
     "maplibre-gl-esri-wayback": "^0.2.0",
     "maplibre-gl-fema-wms": "^0.1.2",
-    "maplibre-gl-geo-editor": "^0.8.0",
+    "maplibre-gl-geo-editor": "^0.9.0",
     "maplibre-gl-geoagent": "^0.4.3",
     "maplibre-gl-lidar": "^0.15.0",
     "maplibre-gl-nasa-earthdata": "^0.1.2",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -38,7 +38,7 @@
     "maplibre-gl-enviroatlas": "^0.1.1",
     "maplibre-gl-esri-wayback": "^0.2.0",
     "maplibre-gl-fema-wms": "^0.1.2",
-    "maplibre-gl-geo-editor": "^0.9.0",
+    "maplibre-gl-geo-editor": "^0.9.1",
     "maplibre-gl-geoagent": "^0.4.3",
     "maplibre-gl-lidar": "^0.15.0",
     "maplibre-gl-nasa-earthdata": "^0.1.2",

--- a/packages/plugins/src/plugins/maplibre-effects.ts
+++ b/packages/plugins/src/plugins/maplibre-effects.ts
@@ -64,12 +64,13 @@ const EFFECTS_OVERLAY_STYLE_ID = "geolibre-effects-maplibre-overlays";
 const MAP_CANVAS_Z_INDEX = "4";
 const CONTROL_CONTAINER_Z_INDEX = "5";
 const MAPLIBRE_OVERLAY_Z_INDEX = "6";
-// DOM markers (e.g. Geoman's draw/edit vertex handles) live in the canvas
-// container and normally paint above the map canvas. Raising the map canvas to
-// MAP_CANVAS_Z_INDEX would otherwise bury them — invisible and unclickable, so a
-// drawn polygon's vertices vanish and you can't click the first one to close it.
-// Match the control container's z-index so markers clear the canvas while the
-// controls (later in the DOM) still win the tie and stay on top.
+// All DOM markers (e.g. Geoman's draw/edit vertex handles, plus any custom
+// `new Marker()` the app adds) live in the canvas container and normally paint
+// above the map canvas. Raising the map canvas to MAP_CANVAS_Z_INDEX would
+// otherwise bury them — invisible and unclickable, so a drawn polygon's vertices
+// vanish and you can't click the first one to close it. Match the control
+// container's z-index so markers clear the canvas while the controls (later in
+// the DOM) still win the tie and stay on top.
 const MARKER_Z_INDEX = CONTROL_CONTAINER_Z_INDEX;
 
 // Roughly one star per this many CSS pixels of starfield area.
@@ -562,7 +563,9 @@ class EffectsEngine {
         z-index: ${MAPLIBRE_OVERLAY_Z_INDEX};
       }
       .${EFFECTS_MAP_CLASS} .maplibregl-marker {
-        z-index: ${MARKER_Z_INDEX};
+        /* !important guards against a future Geoman release injecting an inline
+           z-index on vertex markers, which would otherwise outrank this rule. */
+        z-index: ${MARKER_Z_INDEX} !important;
       }
     `;
     document.head.appendChild(style);

--- a/packages/plugins/src/plugins/maplibre-effects.ts
+++ b/packages/plugins/src/plugins/maplibre-effects.ts
@@ -64,6 +64,13 @@ const EFFECTS_OVERLAY_STYLE_ID = "geolibre-effects-maplibre-overlays";
 const MAP_CANVAS_Z_INDEX = "4";
 const CONTROL_CONTAINER_Z_INDEX = "5";
 const MAPLIBRE_OVERLAY_Z_INDEX = "6";
+// DOM markers (e.g. Geoman's draw/edit vertex handles) live in the canvas
+// container and normally paint above the map canvas. Raising the map canvas to
+// MAP_CANVAS_Z_INDEX would otherwise bury them — invisible and unclickable, so a
+// drawn polygon's vertices vanish and you can't click the first one to close it.
+// Match the control container's z-index so markers clear the canvas while the
+// controls (later in the DOM) still win the tie and stay on top.
+const MARKER_Z_INDEX = CONTROL_CONTAINER_Z_INDEX;
 
 // Roughly one star per this many CSS pixels of starfield area.
 const STAR_AREA_PER_STAR = 900;
@@ -553,6 +560,9 @@ class EffectsEngine {
     style.textContent = `
       .${EFFECTS_MAP_CLASS} .maplibregl-boxzoom {
         z-index: ${MAPLIBRE_OVERLAY_Z_INDEX};
+      }
+      .${EFFECTS_MAP_CLASS} .maplibregl-marker {
+        z-index: ${MARKER_Z_INDEX};
       }
     `;
     document.head.appendChild(style);

--- a/packages/plugins/src/plugins/maplibre-effects.ts
+++ b/packages/plugins/src/plugins/maplibre-effects.ts
@@ -68,9 +68,15 @@ const MAPLIBRE_OVERLAY_Z_INDEX = "6";
 // `new Marker()` the app adds) live in the canvas container and normally paint
 // above the map canvas. Raising the map canvas to MAP_CANVAS_Z_INDEX would
 // otherwise bury them — invisible and unclickable, so a drawn polygon's vertices
-// vanish and you can't click the first one to close it. Match the control
-// container's z-index so markers clear the canvas while the controls (later in
-// the DOM) still win the tie and stay on top.
+// vanish and you can't click the first one to close it.
+//
+// Intentionally tied to the control container's z-index: that clears the canvas
+// while the control container — a later sibling of the canvas container in
+// MapLibre's DOM — wins the equal-z-index tie and keeps controls on top. Raising
+// CONTROL_CONTAINER_Z_INDEX later moves markers with it, which is the desired
+// coupling. The rule below is a plain class selector (no `!important`), so a
+// marker that needs its own stacking can still set an inline z-index via
+// `Marker#setZIndex()`.
 const MARKER_Z_INDEX = CONTROL_CONTAINER_Z_INDEX;
 
 // Roughly one star per this many CSS pixels of starfield area.
@@ -563,9 +569,7 @@ class EffectsEngine {
         z-index: ${MAPLIBRE_OVERLAY_Z_INDEX};
       }
       .${EFFECTS_MAP_CLASS} .maplibregl-marker {
-        /* !important guards against a future Geoman release injecting an inline
-           z-index on vertex markers, which would otherwise outrank this rule. */
-        z-index: ${MARKER_Z_INDEX} !important;
+        z-index: ${MARKER_Z_INDEX};
       }
     `;
     document.head.appendChild(style);


### PR DESCRIPTION
Fixes #481, plus two related GeoEditor bugs surfaced while verifying it.

## 1. Polygon couldn't be closed (#481)

Two causes combined:

- **The first vertex was invisible and unclickable.** With the space-effects engine active (the default globe view), the MapLibre canvas is raised to `z-index: 4`. Geoman's vertex DOM markers live in the canvas container at `z-index: auto`, so the raised canvas painted **over** them — you saw the rubber-band line (drawn inside the WebGL canvas) but not the vertices, and clicks meant to close the ring hit the canvas instead of the first vertex.
- **No alternative finish gesture.** Geoman Free only completes a polygon/line when you click the first/last vertex (which, per above, was unreachable).

**Fix:** `maplibre-effects` now lifts `.maplibregl-marker` to the control container's z-index while effects are active (with `!important`), so vertex markers clear the canvas and stay clickable/snappable. And `maplibre-gl-geo-editor` 0.9.x adds a double-click / right-click finish gesture.

## 2. Snapping silently off after selecting a tool

Snapping looked enabled (toolbar lit) but didn't snap until toggled off and on. Root cause was upstream: `disableAllModes()` (run on every tool switch) re-enabled snapping synchronously while geoman's async `disableAllModes()` was still tearing it down, so the teardown landed after the re-enable. Fixed in `maplibre-gl-geo-editor` 0.9.1.

## Dependency

Bumps `maplibre-gl-geo-editor` to **^0.9.1** (double-click/right-click finish + snapping fix; upstream opengeos/maplibre-gl-geo-editor#34, #35).

## Verification (Playwright, real app)

- Invisible vertices: before → `elementFromPoint` over each vertex returned the canvas; after → returns the marker; vertices render and **clicking the first vertex closes the polygon** (commits a MultiPolygon to the Sketches layer). Double-click and right-click finish also verified.
- Snapping: before → `helper__snapping` action instance disappeared after selecting a draw tool; after → it stays present and `isModeEnabled` true across repeated Polygon/Line/Rectangle switches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the `maplibre-gl-geo-editor` dependency to **v0.9.1** in both the desktop app and shared plugins.

* **Bug Fixes**
  * Improved marker visibility and clickability when the atmospheric effects overlay is enabled by ensuring MapLibre/Geoman and app-added markers keep the correct stacking order above the effects-rendered map.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->