### PR TITLE
feat(notebook): split workspace 50/50 with map and collapse Style panel

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -320,6 +320,10 @@ type ImportedVectorLayer = Awaited<
 const DEFAULT_SIDE_PANEL_WIDTH = 256;
 const MIN_SIDE_PANEL_WIDTH = 180;
 const MAX_SIDE_PANEL_WIDTH = 460;
+// Width of a side panel's collapsed rail (`md:w-11` = 2.75rem). The Style panel
+// stays mounted (collapsed) beside the notebook, so its rail still occupies this
+// much of the row when computing the map/notebook 50/50 split.
+const COLLAPSED_PANEL_RAIL_WIDTH = 44;
 // The notebook panel hosts a full Jupyter UI, so it needs far more room than
 // the layer/style side panels.
 const DEFAULT_NOTEBOOK_PANEL_WIDTH = 480;
@@ -397,9 +401,10 @@ export function DesktopShell({
   );
   // Opening the notebook (Processing → Jupyter Notebook) splits the workspace
   // 50/50 between the map and the notebook: we size the notebook to half of the
-  // space it shares with the map (the row width minus the layer panel, if
-  // shown), while the Style panel is hidden (see its render gate below). Fire
-  // only on the closed→open transition so a later manual resize is preserved.
+  // space it shares with the map (the row width minus the layer panel and the
+  // Style panel's collapsed rail, when shown), while the Style panel collapses
+  // to that rail (see `autoCollapse` below). Fire only on the closed→open
+  // transition so a later manual resize is preserved.
   const notebookWasOpenRef = useRef(notebookOpen);
   useEffect(() => {
     const wasOpen = notebookWasOpenRef.current;
@@ -408,9 +413,17 @@ export function DesktopShell({
     const shellWidth = shellRef.current?.getBoundingClientRect().width ?? 0;
     if (shellWidth <= 0) return;
     const layerWidth = layoutOptions.layerPanelVisible ? layerPanelWidth : 0;
-    const half = Math.round((shellWidth - layerWidth) / 2);
+    const styleRailWidth = layoutOptions.stylePanelVisible
+      ? COLLAPSED_PANEL_RAIL_WIDTH
+      : 0;
+    const half = Math.round((shellWidth - layerWidth - styleRailWidth) / 2);
     setNotebookPanelWidth(Math.max(MIN_NOTEBOOK_PANEL_WIDTH, half));
-  }, [notebookOpen, layoutOptions.layerPanelVisible, layerPanelWidth]);
+  }, [
+    notebookOpen,
+    layoutOptions.layerPanelVisible,
+    layoutOptions.stylePanelVisible,
+    layerPanelWidth,
+  ]);
   const deferPanelResize = isTauri();
   const shellStyle: ShellStyle = {
     "--layer-panel-width": `${layerPanelWidth}px`,
@@ -1246,13 +1259,14 @@ export function DesktopShell({
           </SectionErrorBoundary>
         </main>
         {/* The notebook claims the workspace's right half, so the Style panel
-            is hidden while it is open (Processing → Jupyter Notebook). It
-            returns, respecting the persisted setting, once the notebook closes. */}
-        {layoutOptions.stylePanelVisible && !notebookOpen ? (
+            collapses to its rail while the notebook is open (Processing →
+            Jupyter Notebook) rather than unmounting; the user can re-expand it. */}
+        {layoutOptions.stylePanelVisible ? (
           <SectionErrorBoundary label="Style panel">
             <StylePanel
               mapControllerRef={mapControllerRef}
               onResizeStart={startStylePanelResize}
+              autoCollapse={notebookOpen}
             />
           </SectionErrorBoundary>
         ) : null}

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -395,6 +395,22 @@ export function DesktopShell({
   const [notebookPanelWidth, setNotebookPanelWidth] = useState(
     DEFAULT_NOTEBOOK_PANEL_WIDTH,
   );
+  // Opening the notebook (Processing → Jupyter Notebook) splits the workspace
+  // 50/50 between the map and the notebook: we size the notebook to half of the
+  // space it shares with the map (the row width minus the layer panel, if
+  // shown), while the Style panel is hidden (see its render gate below). Fire
+  // only on the closed→open transition so a later manual resize is preserved.
+  const notebookWasOpenRef = useRef(notebookOpen);
+  useEffect(() => {
+    const wasOpen = notebookWasOpenRef.current;
+    notebookWasOpenRef.current = notebookOpen;
+    if (!notebookOpen || wasOpen) return;
+    const shellWidth = shellRef.current?.getBoundingClientRect().width ?? 0;
+    if (shellWidth <= 0) return;
+    const layerWidth = layoutOptions.layerPanelVisible ? layerPanelWidth : 0;
+    const half = Math.round((shellWidth - layerWidth) / 2);
+    setNotebookPanelWidth(Math.max(MIN_NOTEBOOK_PANEL_WIDTH, half));
+  }, [notebookOpen, layoutOptions.layerPanelVisible, layerPanelWidth]);
   const deferPanelResize = isTauri();
   const shellStyle: ShellStyle = {
     "--layer-panel-width": `${layerPanelWidth}px`,
@@ -1229,7 +1245,10 @@ export function DesktopShell({
             <RemoteCursorsOverlay mapControllerRef={mapControllerRef} />
           </SectionErrorBoundary>
         </main>
-        {layoutOptions.stylePanelVisible ? (
+        {/* The notebook claims the workspace's right half, so the Style panel
+            is hidden while it is open (Processing → Jupyter Notebook). It
+            returns, respecting the persisted setting, once the notebook closes. */}
+        {layoutOptions.stylePanelVisible && !notebookOpen ? (
           <SectionErrorBoundary label="Style panel">
             <StylePanel
               mapControllerRef={mapControllerRef}

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -417,7 +417,12 @@ export function DesktopShell({
       ? COLLAPSED_PANEL_RAIL_WIDTH
       : 0;
     const half = Math.round((shellWidth - layerWidth - styleRailWidth) / 2);
-    setNotebookPanelWidth(Math.max(MIN_NOTEBOOK_PANEL_WIDTH, half));
+    // Honor the same min/max bounds as the drag-resize handler so the auto-size
+    // and manual-resize paths cannot diverge (an ultrawide shell would otherwise
+    // initialize past MAX, a width the user could never drag back to).
+    setNotebookPanelWidth(
+      clamp(half, MIN_NOTEBOOK_PANEL_WIDTH, MAX_NOTEBOOK_PANEL_WIDTH),
+    );
   }, [
     notebookOpen,
     layoutOptions.layerPanelVisible,

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -821,13 +821,23 @@ export function StylePanel({
   const moveLayer = useAppStore((s) => s.moveLayer);
   const [isCollapsed, setIsCollapsed] = useState(getIsMobileViewport);
   // Collapse to the rail when `autoCollapse` flips on (e.g. the notebook opens),
-  // but only on that transition so the user can re-expand while it stays on.
+  // and restore the prior expand/collapse state when it flips back off (notebook
+  // closes). Both act only on the transition so the user can still toggle the
+  // panel manually while `autoCollapse` stays on. `isCollapsed` is in the deps
+  // only to keep the captured value fresh; the guards make pure `isCollapsed`
+  // changes a no-op while `autoCollapse` is stable.
   const prevAutoCollapse = useRef(autoCollapse);
+  const collapsedBeforeAuto = useRef(isCollapsed);
   useEffect(() => {
     const wasAuto = prevAutoCollapse.current;
     prevAutoCollapse.current = autoCollapse;
-    if (autoCollapse && !wasAuto) setIsCollapsed(true);
-  }, [autoCollapse]);
+    if (autoCollapse && !wasAuto) {
+      collapsedBeforeAuto.current = isCollapsed;
+      setIsCollapsed(true);
+    } else if (!autoCollapse && wasAuto) {
+      setIsCollapsed(collapsedBeforeAuto.current);
+    }
+  }, [autoCollapse, isCollapsed]);
   const [draftBeforeId, setDraftBeforeId] = useState("");
   const [draftColorExpression, setDraftColorExpression] = useState("");
   const [draftHeightExpression, setDraftHeightExpression] = useState("");

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -40,6 +40,7 @@ import {
   type RefObject,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { getIsMobileViewport } from "../../hooks/useIsMobileViewport";
@@ -47,6 +48,12 @@ import { getIsMobileViewport } from "../../hooks/useIsMobileViewport";
 interface StylePanelProps {
   mapControllerRef: RefObject<MapController | null>;
   onResizeStart: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  /**
+   * When this flips to `true` the panel collapses to its thin rail (it is not
+   * unmounted). Used to clear room when the notebook opens beside the map; the
+   * user can still expand it again.
+   */
+  autoCollapse?: boolean;
 }
 
 function isRasterPaintLayer(type: LayerType): boolean {
@@ -804,6 +811,7 @@ function RasterStyleSlider({
 export function StylePanel({
   mapControllerRef,
   onResizeStart,
+  autoCollapse = false,
 }: StylePanelProps) {
   const selectedLayerId = useAppStore((s) => s.selectedLayerId);
   const layers = useAppStore((s) => s.layers);
@@ -812,6 +820,14 @@ export function StylePanel({
   const updateLayer = useAppStore((s) => s.updateLayer);
   const moveLayer = useAppStore((s) => s.moveLayer);
   const [isCollapsed, setIsCollapsed] = useState(getIsMobileViewport);
+  // Collapse to the rail when `autoCollapse` flips on (e.g. the notebook opens),
+  // but only on that transition so the user can re-expand while it stays on.
+  const prevAutoCollapse = useRef(autoCollapse);
+  useEffect(() => {
+    const wasAuto = prevAutoCollapse.current;
+    prevAutoCollapse.current = autoCollapse;
+    if (autoCollapse && !wasAuto) setIsCollapsed(true);
+  }, [autoCollapse]);
   const [draftBeforeId, setDraftBeforeId] = useState("");
   const [draftColorExpression, setDraftColorExpression] = useState("");
   const [draftHeightExpression, setDraftHeightExpression] = useState("");


### PR DESCRIPTION
## Summary
- Opening Processing -> Jupyter Notebook now sizes the notebook panel so the map and notebook each take 50% of the space they share (row width minus the layer panel and the Style panel's collapsed rail, when shown).
- The Style panel collapses to its thin rail while the notebook is open instead of being unmounted, so the user can re-expand it at any time. It returns to its previous state once the notebook closes.
- The 50/50 sizing fires only on the closed-to-open transition, so a later manual resize of the notebook is preserved.

## Test plan
- [x] Typecheck passes (tsc -b)
- [x] eslint and npm build pass via pre-commit
- [x] Verified in the running app (1600x900): initial Style panel 256px / map 1088px; after opening the notebook the Style panel collapses to a 44px rail and map = notebook = 650px (exactly 50/50 of the 1300px shared space)
- [x] Confirmed the collapsed Style rail can be re-expanded back to 256px while the notebook stays open

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Style panel now automatically collapses when the notebook is opened, freeing up workspace
  * Notebook panel width is intelligently recalculated during state transitions to optimize screen space usage
  * Style panel state is preserved and restored when the notebook closes, maintaining your preferences

<!-- end of auto-generated comment: release notes by coderabbit.ai -->