### PR TITLE
feat(basemap): add Protomaps basemaps to New map dialog

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -57,6 +57,10 @@ jobs:
         env:
           GEOLIBRE_APP_BASE: ./
           VITE_GEE_OAUTH_CLIENT_ID: ${{ secrets.VITE_GEE_OAUTH_CLIENT_ID }}
+          # Protomaps API key, baked into the client bundle so the New map
+          # dialog can offer Protomaps basemaps. When unset, those options are
+          # hidden (see getProtomapsStyleUrl in @geolibre/core).
+          VITE_PROTOMAPS_API_KEY: ${{ secrets.VITE_PROTOMAPS_API_KEY }}
           # Public relay URL (baked into the client bundle), not a secret. Lights
           # up live collaboration; requires the workers/collab relay to be
           # deployed (see docs/collaboration.md).

--- a/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
@@ -1,7 +1,9 @@
 import {
   BLANK_BASEMAP,
   createDefaultMapView,
+  getProtomapsStyleUrl,
   OPENFREEMAP_BASEMAPS,
+  PROTOMAPS_BASEMAPS,
   useAppStore,
   type MapViewState,
 } from "@geolibre/core";
@@ -17,7 +19,7 @@ import {
   Label,
 } from "@geolibre/ui";
 import type { FormEvent } from "react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 const DEFAULT_BASEMAP_ID = "liberty";
 const CUSTOM_BASEMAP_ID = "custom";
@@ -31,11 +33,26 @@ const THREE_D_MAP_VIEW: MapViewState = {
   pitch: 60,
 };
 
-type PresetBasemapId = (typeof OPENFREEMAP_BASEMAPS)[number]["id"];
-type BasemapChoice =
-  | PresetBasemapId
-  | typeof CUSTOM_BASEMAP_ID
-  | typeof BLANK_BASEMAP_ID;
+interface PresetBasemap {
+  id: string;
+  name: string;
+  styleUrl: string;
+}
+
+/**
+ * Resolves the selectable Protomaps basemaps for the current runtime
+ * environment. Returns an empty list when no `VITE_PROTOMAPS_API_KEY` is
+ * configured (build-time or via Settings → Environment variables), in which
+ * case the Protomaps section is hidden.
+ */
+function resolveProtomapsPresets(): PresetBasemap[] {
+  return PROTOMAPS_BASEMAPS.flatMap((basemap) => {
+    const styleUrl = getProtomapsStyleUrl(basemap.flavor);
+    return styleUrl ? [{ id: basemap.id, name: basemap.name, styleUrl }] : [];
+  });
+}
+
+type BasemapChoice = string;
 
 interface NewProjectDialogProps {
   open: boolean;
@@ -62,8 +79,26 @@ export function NewProjectDialog({
   const customStyleUrl = customUrl.trim();
   const isCustomSelected = selectedBasemapId === CUSTOM_BASEMAP_ID;
   const isBlankSelected = selectedBasemapId === BLANK_BASEMAP_ID;
-  const selectedPreset = OPENFREEMAP_BASEMAPS.find(
-    (basemap) => basemap.id === selectedBasemapId,
+  // Protomaps styles need an API key (VITE_PROTOMAPS_API_KEY). It can come from
+  // the build or from Settings → Environment variables, so re-resolve when the
+  // dialog opens and whenever the runtime env changes; an absent key hides the
+  // section.
+  const [protomapsPresets, setProtomapsPresets] = useState<PresetBasemap[]>(
+    resolveProtomapsPresets,
+  );
+  useEffect(() => {
+    const refresh = () => setProtomapsPresets(resolveProtomapsPresets());
+    refresh();
+    window.addEventListener("geolibre:runtime-env-change", refresh);
+    return () =>
+      window.removeEventListener("geolibre:runtime-env-change", refresh);
+  }, [open]);
+  const selectedPreset = useMemo<PresetBasemap | undefined>(
+    () =>
+      [...OPENFREEMAP_BASEMAPS, ...protomapsPresets].find(
+        (basemap) => basemap.id === selectedBasemapId,
+      ),
+    [protomapsPresets, selectedBasemapId],
   );
   const isCustomUrlValid = useMemo(() => {
     if (!customStyleUrl) return false;
@@ -138,6 +173,24 @@ export function NewProjectDialog({
     }
   };
 
+  const renderBasemapButton = (id: string, name: string) => (
+    <button
+      key={id}
+      type="button"
+      aria-pressed={selectedBasemapId === id}
+      className={cn(
+        "h-10 rounded-md border px-3 text-sm font-medium transition-colors",
+        "hover:bg-accent hover:text-accent-foreground",
+        selectedBasemapId === id
+          ? "border-primary bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground"
+          : "border-input bg-background",
+      )}
+      onClick={() => setSelectedBasemapId(id)}
+    >
+      {name}
+    </button>
+  );
+
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-xl">
@@ -181,8 +234,8 @@ export function NewProjectDialog({
             <DialogHeader>
               <DialogTitle>New map</DialogTitle>
               <DialogDescription>
-                Choose a blank background, an OpenFreeMap basemap, or a MapLibre
-                style URL.
+                Choose an OpenFreeMap or Protomaps basemap, a blank background,
+                or a MapLibre style URL.
               </DialogDescription>
             </DialogHeader>
             <form className="space-y-5" onSubmit={handleCreate}>
@@ -196,40 +249,40 @@ export function NewProjectDialog({
                 />
               </div>
 
-              <div className="space-y-2">
+              <div className="space-y-4">
                 <Label>Basemap</Label>
-                <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-                  {OPENFREEMAP_BASEMAPS.map((basemap) => (
-                    <button
-                      key={basemap.id}
-                      type="button"
-                      aria-pressed={selectedBasemapId === basemap.id}
-                      className={cn(
-                        "h-10 rounded-md border px-3 text-sm font-medium transition-colors",
-                        "hover:bg-accent hover:text-accent-foreground",
-                        selectedBasemapId === basemap.id
-                          ? "border-primary bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground"
-                          : "border-input bg-background",
-                      )}
-                      onClick={() => setSelectedBasemapId(basemap.id)}
-                    >
-                      {basemap.name}
-                    </button>
-                  ))}
-                  <button
-                    type="button"
-                    aria-pressed={isBlankSelected}
-                    className={cn(
-                      "h-10 rounded-md border px-3 text-sm font-medium transition-colors",
-                      "hover:bg-accent hover:text-accent-foreground",
-                      isBlankSelected
-                        ? "border-primary bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground"
-                        : "border-input bg-background",
+
+                <div className="space-y-2">
+                  <p className="text-xs font-medium text-muted-foreground">
+                    OpenFreeMap
+                  </p>
+                  <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                    {OPENFREEMAP_BASEMAPS.map((basemap) =>
+                      renderBasemapButton(basemap.id, basemap.name),
                     )}
-                    onClick={() => setSelectedBasemapId(BLANK_BASEMAP_ID)}
-                  >
-                    Blank
-                  </button>
+                  </div>
+                </div>
+
+                {protomapsPresets.length > 0 ? (
+                  <div className="space-y-2">
+                    <p className="text-xs font-medium text-muted-foreground">
+                      Protomaps
+                    </p>
+                    <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                      {protomapsPresets.map((basemap) =>
+                        renderBasemapButton(basemap.id, basemap.name),
+                      )}
+                    </div>
+                  </div>
+                ) : null}
+
+                <div className="space-y-2">
+                  <p className="text-xs font-medium text-muted-foreground">
+                    Other
+                  </p>
+                  <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                    {renderBasemapButton(BLANK_BASEMAP_ID, "Blank")}
+                  </div>
                 </div>
               </div>
 

--- a/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
@@ -20,6 +20,7 @@ import {
 } from "@geolibre/ui";
 import type { FormEvent } from "react";
 import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
 
 const DEFAULT_BASEMAP_ID = "liberty";
 const CUSTOM_BASEMAP_ID = "custom";
@@ -33,8 +34,17 @@ const THREE_D_MAP_VIEW: MapViewState = {
   pitch: 60,
 };
 
+// Well-known basemap ids stay type-checked. Protomaps ids are still dynamic
+// (only present when a key is configured), but they come from the const array,
+// so the union catches typos and stale sentinel values.
+type BasemapChoice =
+  | (typeof OPENFREEMAP_BASEMAPS)[number]["id"]
+  | (typeof PROTOMAPS_BASEMAPS)[number]["id"]
+  | typeof CUSTOM_BASEMAP_ID
+  | typeof BLANK_BASEMAP_ID;
+
 interface PresetBasemap {
-  id: string;
+  id: BasemapChoice;
   name: string;
   styleUrl: string;
 }
@@ -52,7 +62,31 @@ function resolveProtomapsPresets(): PresetBasemap[] {
   });
 }
 
-type BasemapChoice = string;
+interface BasemapButtonProps {
+  id: BasemapChoice;
+  name: string;
+  selected: boolean;
+  onSelect: (id: BasemapChoice) => void;
+}
+
+function BasemapButton({ id, name, selected, onSelect }: BasemapButtonProps) {
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      className={cn(
+        "h-10 rounded-md border px-3 text-sm font-medium transition-colors",
+        "hover:bg-accent hover:text-accent-foreground",
+        selected
+          ? "border-primary bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground"
+          : "border-input bg-background",
+      )}
+      onClick={() => onSelect(id)}
+    >
+      {name}
+    </button>
+  );
+}
 
 interface NewProjectDialogProps {
   open: boolean;
@@ -67,6 +101,7 @@ export function NewProjectDialog({
   onSaveCurrentProject,
   onProjectCreated,
 }: NewProjectDialogProps) {
+  const { t } = useTranslation();
   const newProject = useAppStore((s) => s.newProject);
   const isDirty = useAppStore((s) => s.isDirty);
   const [selectedBasemapId, setSelectedBasemapId] =
@@ -87,6 +122,7 @@ export function NewProjectDialog({
     resolveProtomapsPresets,
   );
   useEffect(() => {
+    if (!open) return;
     const refresh = () => setProtomapsPresets(resolveProtomapsPresets());
     refresh();
     window.addEventListener("geolibre:runtime-env-change", refresh);
@@ -173,24 +209,6 @@ export function NewProjectDialog({
     }
   };
 
-  const renderBasemapButton = (id: string, name: string) => (
-    <button
-      key={id}
-      type="button"
-      aria-pressed={selectedBasemapId === id}
-      className={cn(
-        "h-10 rounded-md border px-3 text-sm font-medium transition-colors",
-        "hover:bg-accent hover:text-accent-foreground",
-        selectedBasemapId === id
-          ? "border-primary bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground"
-          : "border-input bg-background",
-      )}
-      onClick={() => setSelectedBasemapId(id)}
-    >
-      {name}
-    </button>
-  );
-
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-xl">
@@ -234,8 +252,7 @@ export function NewProjectDialog({
             <DialogHeader>
               <DialogTitle>New map</DialogTitle>
               <DialogDescription>
-                Choose an OpenFreeMap or Protomaps basemap, a blank background,
-                or a MapLibre style URL.
+                {t("newProject.basemapDescription")}
               </DialogDescription>
             </DialogHeader>
             <form className="space-y-5" onSubmit={handleCreate}>
@@ -254,34 +271,51 @@ export function NewProjectDialog({
 
                 <div className="space-y-2">
                   <p className="text-xs font-medium text-muted-foreground">
-                    OpenFreeMap
+                    {t("newProject.sectionOpenFreeMap")}
                   </p>
                   <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-                    {OPENFREEMAP_BASEMAPS.map((basemap) =>
-                      renderBasemapButton(basemap.id, basemap.name),
-                    )}
+                    {OPENFREEMAP_BASEMAPS.map((basemap) => (
+                      <BasemapButton
+                        key={basemap.id}
+                        id={basemap.id}
+                        name={basemap.name}
+                        selected={selectedBasemapId === basemap.id}
+                        onSelect={setSelectedBasemapId}
+                      />
+                    ))}
                   </div>
                 </div>
 
                 {protomapsPresets.length > 0 ? (
                   <div className="space-y-2">
                     <p className="text-xs font-medium text-muted-foreground">
-                      Protomaps
+                      {t("newProject.sectionProtomaps")}
                     </p>
                     <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-                      {protomapsPresets.map((basemap) =>
-                        renderBasemapButton(basemap.id, basemap.name),
-                      )}
+                      {protomapsPresets.map((basemap) => (
+                        <BasemapButton
+                          key={basemap.id}
+                          id={basemap.id}
+                          name={basemap.name}
+                          selected={selectedBasemapId === basemap.id}
+                          onSelect={setSelectedBasemapId}
+                        />
+                      ))}
                     </div>
                   </div>
                 ) : null}
 
                 <div className="space-y-2">
                   <p className="text-xs font-medium text-muted-foreground">
-                    Other
+                    {t("newProject.sectionOther")}
                   </p>
                   <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-                    {renderBasemapButton(BLANK_BASEMAP_ID, "Blank")}
+                    <BasemapButton
+                      id={BLANK_BASEMAP_ID}
+                      name="Blank"
+                      selected={selectedBasemapId === BLANK_BASEMAP_ID}
+                      onSelect={setSelectedBasemapId}
+                    />
                   </div>
                 </div>
               </div>

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -7,6 +7,12 @@
     "description": "Choose a file name. The file downloads to your browser's downloads folder.",
     "label": "File name"
   },
+  "newProject": {
+    "basemapDescription": "Choose an OpenFreeMap or Protomaps basemap, a blank background, or a MapLibre style URL.",
+    "sectionOpenFreeMap": "OpenFreeMap",
+    "sectionProtomaps": "Protomaps",
+    "sectionOther": "Other"
+  },
   "common": {
     "pickColorFromScreen": "Pick a color from the screen",
     "save": "Save",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -112,6 +112,22 @@ For Google Street View, enable the Maps Embed API for the key in Google Cloud. F
 
 Restart `npm run dev` or `npm run tauri:dev` after changing environment variables.
 
+## Optional basemap credentials
+
+The **New map** dialog offers [Protomaps](https://protomaps.com) basemaps (Light, Dark, White, Grayscale, Black) when a Protomaps API key is configured. Without a key these options are hidden, and you can still use the OpenFreeMap basemaps or a custom style URL.
+
+Use your own key — create one in the [Protomaps dashboard](https://protomaps.com). Set it one of two ways:
+
+- **For your own deployment** — bake it into the build with the `VITE_PROTOMAPS_API_KEY` environment variable, for example in `apps/geolibre-desktop/.env.local`:
+
+  ```env
+  VITE_PROTOMAPS_API_KEY=your_protomaps_api_key
+  ```
+
+  In CI/CD, pass it as a build-time environment variable (the GitHub Pages workflow reads it from the `VITE_PROTOMAPS_API_KEY` repository secret). The resulting style URL is `https://api.protomaps.com/styles/v5/<flavor>/en.json?key=<your_key>`.
+
+- **At runtime, no rebuild** — add an environment variable named `VITE_PROTOMAPS_API_KEY` in **Settings → Environment Variables**. The Protomaps basemaps appear as soon as the key is enabled. See [Settings](user-guide/settings.md#environment-variables).
+
 ## Optional Python sidecar
 
 The optional FastAPI sidecar is reserved for heavier processing workflows and is not required for the desktop UI.

--- a/docs/user-guide/settings.md
+++ b/docs/user-guide/settings.md
@@ -38,6 +38,9 @@ Panels also auto-hide on small screens for a responsive layout.
 !!! tip "Where credentials go"
     Provider credentials for integrations like Earth Engine, Street View, or other keyed services belong here. See [Data Integrations](data-integrations.md) and [Getting Started](../getting-started.md#optional-imagery-credentials).
 
+!!! tip "Protomaps basemaps"
+    To use the [Protomaps](https://protomaps.com) basemaps in the **New map** dialog, add an environment variable named `VITE_PROTOMAPS_API_KEY` with your own Protomaps API key. The Protomaps options appear in the dialog as soon as the key is enabled — no restart needed. When no key is set, the Protomaps section is hidden. See [Getting Started](../getting-started.md#optional-basemap-credentials) for setting the key at build time for a self-hosted deployment.
+
 ## Project Settings
 
 **Settings → Project Settings** (the **Project** tab) holds project-level options saved with the `.geolibre.json` file:

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -71,4 +71,9 @@ export {
   type GeocodeRequest,
   type ReverseGeocodeDisplay,
 } from "./geocoding";
-export { getRuntimeEnvironment, getSpatialExtensionPath } from "./runtime-env";
+export {
+  getProtomapsApiKey,
+  getProtomapsStyleUrl,
+  getRuntimeEnvironment,
+  getSpatialExtensionPath,
+} from "./runtime-env";

--- a/packages/core/src/runtime-env.ts
+++ b/packages/core/src/runtime-env.ts
@@ -85,7 +85,7 @@ export function getProtomapsStyleUrl(
 ): string | undefined {
   const key = getProtomapsApiKey(env);
   if (!key) return undefined;
-  return `https://api.protomaps.com/styles/v5/${flavor}/en.json?key=${encodeURIComponent(
-    key,
-  )}`;
+  return `https://api.protomaps.com/styles/v5/${encodeURIComponent(
+    flavor,
+  )}/en.json?key=${encodeURIComponent(key)}`;
 }

--- a/packages/core/src/runtime-env.ts
+++ b/packages/core/src/runtime-env.ts
@@ -49,3 +49,43 @@ export function getSpatialExtensionPath(
   const trimmed = runtimeEnv.VITE_DUCKDB_SPATIAL_EXTENSION_PATH?.trim();
   return trimmed || undefined;
 }
+
+/**
+ * Resolves the Protomaps API key from the runtime environment.
+ *
+ * Protomaps' hosted styles require an API key embedded in the style URL. The
+ * key is supplied via `VITE_PROTOMAPS_API_KEY` (baked in at build time for the
+ * web demo; see the deploy workflow). When unset, the Protomaps basemaps are
+ * unavailable and should be hidden from the UI.
+ *
+ * @param env - Environment record (defaults to the runtime environment);
+ *   injectable for testing.
+ * @returns The trimmed API key, or undefined when unset.
+ */
+export function getProtomapsApiKey(
+  env?: Record<string, string | undefined>,
+): string | undefined {
+  const runtimeEnv = env ?? getRuntimeEnvironment();
+  const trimmed = runtimeEnv.VITE_PROTOMAPS_API_KEY?.trim();
+  return trimmed || undefined;
+}
+
+/**
+ * Builds a full Protomaps v5 style URL for a flavor, injecting the API key.
+ *
+ * @param flavor - The Protomaps flavor name (e.g. `light`, `dark`, `white`,
+ *   `grayscale`, `black`).
+ * @param env - Environment record (defaults to the runtime environment);
+ *   injectable for testing.
+ * @returns The resolved style URL, or undefined when no API key is configured.
+ */
+export function getProtomapsStyleUrl(
+  flavor: string,
+  env?: Record<string, string | undefined>,
+): string | undefined {
+  const key = getProtomapsApiKey(env);
+  if (!key) return undefined;
+  return `https://api.protomaps.com/styles/v5/${flavor}/en.json?key=${encodeURIComponent(
+    key,
+  )}`;
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -7,6 +7,11 @@ export const OPENFREEMAP_BASEMAPS = [
     styleUrl: "https://tiles.openfreemap.org/styles/liberty",
   },
   {
+    id: "liberty-3d",
+    name: "Liberty 3D",
+    styleUrl: "https://tiles.openfreemap.org/styles/liberty",
+  },
+  {
     id: "positron",
     name: "Positron",
     styleUrl: "https://tiles.openfreemap.org/styles/positron",
@@ -26,11 +31,21 @@ export const OPENFREEMAP_BASEMAPS = [
     name: "Fiord",
     styleUrl: "https://tiles.openfreemap.org/styles/fiord",
   },
-  {
-    id: "liberty-3d",
-    name: "3D",
-    styleUrl: "https://tiles.openfreemap.org/styles/liberty",
-  },
+] as const;
+
+/**
+ * Protomaps v5 basemap flavors. These are resolved to full style URLs at use
+ * time by `getProtomapsStyleUrl`, which injects the `VITE_PROTOMAPS_API_KEY`
+ * runtime env var. The key is only present in builds configured with it (e.g.
+ * the GitHub Pages web demo), so consumers should hide these options when no
+ * key is available.
+ */
+export const PROTOMAPS_BASEMAPS = [
+  { id: "protomaps-light", name: "Light", flavor: "light" },
+  { id: "protomaps-dark", name: "Dark", flavor: "dark" },
+  { id: "protomaps-white", name: "White", flavor: "white" },
+  { id: "protomaps-grayscale", name: "Grayscale", flavor: "grayscale" },
+  { id: "protomaps-black", name: "Black", flavor: "black" },
 ] as const;
 
 export const DEFAULT_BASEMAP = "https://tiles.openfreemap.org/styles/liberty";

--- a/tests/protomaps-basemap.test.ts
+++ b/tests/protomaps-basemap.test.ts
@@ -36,6 +36,13 @@ describe("getProtomapsStyleUrl", () => {
     );
   });
 
+  it("encodes the flavor path segment", () => {
+    assert.equal(
+      getProtomapsStyleUrl("a/b?c", { VITE_PROTOMAPS_API_KEY: "key" }),
+      "https://api.protomaps.com/styles/v5/a%2Fb%3Fc/en.json?key=key",
+    );
+  });
+
   it("resolves a URL for every advertised flavor", () => {
     for (const basemap of PROTOMAPS_BASEMAPS) {
       const url = getProtomapsStyleUrl(basemap.flavor, {

--- a/tests/protomaps-basemap.test.ts
+++ b/tests/protomaps-basemap.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  getProtomapsApiKey,
+  getProtomapsStyleUrl,
+  PROTOMAPS_BASEMAPS,
+} from "@geolibre/core";
+
+describe("getProtomapsApiKey", () => {
+  it("returns undefined when env is missing or empty", () => {
+    assert.equal(getProtomapsApiKey({}), undefined);
+    assert.equal(getProtomapsApiKey({ VITE_PROTOMAPS_API_KEY: "" }), undefined);
+    assert.equal(
+      getProtomapsApiKey({ VITE_PROTOMAPS_API_KEY: "   " }),
+      undefined,
+    );
+  });
+
+  it("returns the trimmed key when set", () => {
+    assert.equal(
+      getProtomapsApiKey({ VITE_PROTOMAPS_API_KEY: "  abc123  " }),
+      "abc123",
+    );
+  });
+});
+
+describe("getProtomapsStyleUrl", () => {
+  it("returns undefined when no API key is configured", () => {
+    assert.equal(getProtomapsStyleUrl("light", {}), undefined);
+  });
+
+  it("builds the v5 style URL with the encoded key", () => {
+    assert.equal(
+      getProtomapsStyleUrl("dark", { VITE_PROTOMAPS_API_KEY: "k e/y" }),
+      "https://api.protomaps.com/styles/v5/dark/en.json?key=k%20e%2Fy",
+    );
+  });
+
+  it("resolves a URL for every advertised flavor", () => {
+    for (const basemap of PROTOMAPS_BASEMAPS) {
+      const url = getProtomapsStyleUrl(basemap.flavor, {
+        VITE_PROTOMAPS_API_KEY: "key",
+      });
+      assert.equal(
+        url,
+        `https://api.protomaps.com/styles/v5/${basemap.flavor}/en.json?key=key`,
+      );
+    }
+  });
+});
+
+describe("PROTOMAPS_BASEMAPS", () => {
+  it("offers the five Protomaps v5 flavors", () => {
+    assert.deepEqual(
+      PROTOMAPS_BASEMAPS.map((b) => b.flavor),
+      ["light", "dark", "white", "grayscale", "black"],
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Reorganize the New map basemap picker into labeled sections: OpenFreeMap (Liberty, Liberty 3D, Positron, Bright, Dark, Fiord), Protomaps, and Blank, plus the existing custom style URL field.
- Add Protomaps v5 basemaps (Light, Dark, White, Grayscale, Black). The section appears only when a Protomaps API key is configured, and reacts live to runtime env changes so a key set in Settings takes effect without a reload.
- Resolve the key from VITE_PROTOMAPS_API_KEY: bake it in at build time (the GitHub Pages workflow reads it from a repository secret) or set it at runtime in Settings, Environment Variables. Deployments can supply their own key.
- Document both paths in the Getting Started and Settings guides.

## Test plan
- [x] New unit tests cover the key resolver and style URL builder (tests/protomaps-basemap.test.ts)
- [x] Full frontend test suite passes
- [x] Production build passes (tsc and vite), with no key baked into the bundle when unset
- [x] Verified in the running app: Protomaps section hidden without a key, appears when the key is added at runtime, and hides again when removed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Protomaps basemap support to the “New map” dialog, with five new styles (light, dark, white, grayscale, black).
  * Protomaps options now appear only when an API key is configured, and they update immediately during the dialog session.
  * Added “Liberty 3D” to available basemaps.

* **Documentation**
  * Updated Getting Started and Settings guides with setup instructions for Protomaps credentials.

* **Tests**
  * Added automated tests for Protomaps API key and style URL generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->