### PR TITLE
fix(sql): resolve SQL Workspace/AI Assistant duplicate OGC_FID Binder Error (#499)

### DIFF
--- a/apps/geolibre-desktop/src/lib/duckdb-geometry.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-geometry.ts
@@ -118,7 +118,7 @@ export function geometryGeoJsonSql(
 // result, e.g. a SQL query result added back as a layer or created by the AI
 // assistant — re-reading it makes GDAL emit a *second* `OGC_FID`, so `ST_Read`
 // fails to bind with `duplicate column name "OGC_FID"` (issue #499).
-const GDAL_AUTO_FID_COLUMN = "OGC_FID";
+export const GDAL_AUTO_FID_COLUMN = "OGC_FID";
 
 /**
  * Return a copy of `geojson` with the reserved GDAL FID column

--- a/apps/geolibre-desktop/src/lib/duckdb-geometry.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-geometry.ts
@@ -1,6 +1,7 @@
 // Pure SQL/geometry-column helpers shared by the DuckDB vector loader and the
 // GeoParquet writer. Kept free of `@duckdb/duckdb-wasm` (and its Vite `?url`
 // imports) so the detection logic can be unit-tested under plain Node.
+import type { FeatureCollection } from "geojson";
 
 const TARGET_CRS = "EPSG:4326";
 
@@ -109,4 +110,38 @@ export function geometryGeoJsonSql(
   return `ST_AsGeoJSON(ST_Transform(${geometryExpression}, ${quoteSqlString(
     sourceCrs,
   )}, ${quoteSqlString(TARGET_CRS)}, true))`;
+}
+
+// GDAL's GeoJSON driver (used by `ST_Read`) synthesises an `OGC_FID` column for
+// every feature. When a layer's GeoJSON already carries an `OGC_FID` property —
+// which happens whenever the layer was itself derived from a prior `ST_Read`
+// result, e.g. a SQL query result added back as a layer or created by the AI
+// assistant — re-reading it makes GDAL emit a *second* `OGC_FID`, so `ST_Read`
+// fails to bind with `duplicate column name "OGC_FID"` (issue #499).
+const GDAL_AUTO_FID_COLUMN = "OGC_FID";
+
+/**
+ * Return a copy of `geojson` with the reserved GDAL FID column
+ * (`OGC_FID`) removed from every feature's properties, so re-reading it with
+ * `ST_Read` cannot collide with GDAL's auto-generated FID column. The input is
+ * left untouched and the same object is returned when no feature carries the
+ * property, so unaffected layers pay no allocation cost.
+ *
+ * @param geojson Feature collection about to be handed to `ST_Read`.
+ * @returns The collection without any `OGC_FID` properties.
+ */
+export function stripAutoFidColumn(
+  geojson: FeatureCollection,
+): FeatureCollection {
+  let changed = false;
+  const features = geojson.features.map((feature) => {
+    const props = feature.properties;
+    if (props && GDAL_AUTO_FID_COLUMN in props) {
+      changed = true;
+      const { [GDAL_AUTO_FID_COLUMN]: _omit, ...rest } = props;
+      return { ...feature, properties: rest };
+    }
+    return feature;
+  });
+  return changed ? { ...geojson, features } : geojson;
 }

--- a/apps/geolibre-desktop/src/lib/duckdb-geometry.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-geometry.ts
@@ -133,15 +133,20 @@ const GDAL_AUTO_FID_COLUMN = "OGC_FID";
 export function stripAutoFidColumn(
   geojson: FeatureCollection,
 ): FeatureCollection {
-  let changed = false;
+  // Scan first so the common (no-OGC_FID) path returns the original object
+  // without allocating a throw-away features array or any feature copies.
+  const needsStrip = geojson.features.some(
+    (feature) =>
+      feature.properties != null && GDAL_AUTO_FID_COLUMN in feature.properties,
+  );
+  if (!needsStrip) return geojson;
   const features = geojson.features.map((feature) => {
     const props = feature.properties;
     if (props && GDAL_AUTO_FID_COLUMN in props) {
-      changed = true;
       const { [GDAL_AUTO_FID_COLUMN]: _omit, ...rest } = props;
       return { ...feature, properties: rest };
     }
     return feature;
   });
-  return changed ? { ...geojson, features } : geojson;
+  return { ...geojson, features };
 }

--- a/apps/geolibre-desktop/src/lib/sql-workspace.ts
+++ b/apps/geolibre-desktop/src/lib/sql-workspace.ts
@@ -13,6 +13,7 @@ import {
   quoteSqlString,
   rowsFromResult,
 } from "./duckdb-vector-loader";
+import { stripAutoFidColumn } from "./duckdb-geometry";
 
 // Hidden column appended to the user's query so geometry can be returned as
 // GeoJSON for the "Add as layer" / export paths without disturbing the columns
@@ -253,8 +254,13 @@ export async function registerLayerTables(
   const registered: SqlWorkspaceTable[] = [];
 
   for (const { layer, tableName } of assignTableNames(layers)) {
+    // assignTableNames only yields layers that carry a GeoJSON collection.
+    if (!layer.geojson) continue;
     const fileName = `${filePrefix}__${tableName}.geojson`;
-    await db.registerFileText(fileName, JSON.stringify(layer.geojson));
+    await db.registerFileText(
+      fileName,
+      JSON.stringify(stripAutoFidColumn(layer.geojson)),
+    );
     // Track immediately after registration so a failure in the CREATE TABLE
     // below still leaves this file in the cleanup list.
     registeredFiles?.push(fileName);

--- a/apps/geolibre-desktop/src/lib/sql-workspace.ts
+++ b/apps/geolibre-desktop/src/lib/sql-workspace.ts
@@ -13,7 +13,7 @@ import {
   quoteSqlString,
   rowsFromResult,
 } from "./duckdb-vector-loader";
-import { stripAutoFidColumn } from "./duckdb-geometry";
+import { GDAL_AUTO_FID_COLUMN, stripAutoFidColumn } from "./duckdb-geometry";
 
 // Hidden column appended to the user's query so geometry can be returned as
 // GeoJSON for the "Add as layer" / export paths without disturbing the columns
@@ -596,6 +596,13 @@ export function rowsToFeatureCollection(
     const properties: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(row)) {
       if (key === GEOMETRY_JSON_COLUMN || key === geometryColumn) continue;
+      // Drop GDAL's synthetic FID so a SQL-result layer never carries the
+      // OGC_FID artefact into its attributes/exports — and so re-reading it
+      // can't trigger the duplicate-column Binder Error (issue #499).
+      // stripAutoFidColumn remains the belt-and-braces guard at registration
+      // time for layers that arrive via other paths (drag-drop, project
+      // restore, plugins) and already carry OGC_FID.
+      if (key === GDAL_AUTO_FID_COLUMN) continue;
       if (value instanceof Uint8Array) continue;
       properties[key] = normalizeValue(value);
     }

--- a/apps/geolibre-desktop/src/lib/sql-workspace.ts
+++ b/apps/geolibre-desktop/src/lib/sql-workspace.ts
@@ -254,7 +254,9 @@ export async function registerLayerTables(
   const registered: SqlWorkspaceTable[] = [];
 
   for (const { layer, tableName } of assignTableNames(layers)) {
-    // assignTableNames only yields layers that carry a GeoJSON collection.
+    // assignTableNames already filters out layers without geojson; this guard
+    // narrows the optional `layer.geojson` to FeatureCollection for the call
+    // below (TypeScript does not carry the filter's narrowing across functions).
     if (!layer.geojson) continue;
     const fileName = `${filePrefix}__${tableName}.geojson`;
     await db.registerFileText(

--- a/tests/duckdb-geometry.test.ts
+++ b/tests/duckdb-geometry.test.ts
@@ -170,6 +170,11 @@ describe("stripAutoFidColumn", () => {
     assert.equal(out.features[0].properties, null);
   });
 
+  it("returns the same object for an empty feature collection", () => {
+    const input: FeatureCollection = { type: "FeatureCollection", features: [] };
+    assert.equal(stripAutoFidColumn(input), input);
+  });
+
   it("strips OGC_FID from every feature that has it", () => {
     const input: FeatureCollection = {
       type: "FeatureCollection",

--- a/tests/duckdb-geometry.test.ts
+++ b/tests/duckdb-geometry.test.ts
@@ -175,6 +175,11 @@ describe("stripAutoFidColumn", () => {
     assert.equal(stripAutoFidColumn(input), input);
   });
 
+  it("yields empty-object properties when OGC_FID is the only property", () => {
+    const out = stripAutoFidColumn(collection({ OGC_FID: 7 }));
+    assert.deepEqual(out.features[0].properties, {});
+  });
+
   it("strips OGC_FID from every feature that has it", () => {
     const input: FeatureCollection = {
       type: "FeatureCollection",
@@ -196,10 +201,13 @@ describe("stripAutoFidColumn", () => {
         },
       ],
     };
+    const inputClone = JSON.parse(JSON.stringify(input));
     const out = stripAutoFidColumn(input);
     assert.deepEqual(
       out.features.map((f) => f.properties),
       [{ name: "a" }, { name: "b" }, { name: "c" }],
     );
+    // The original multi-feature collection is left unmodified.
+    assert.deepEqual(input, inputClone);
   });
 });

--- a/tests/duckdb-geometry.test.ts
+++ b/tests/duckdb-geometry.test.ts
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import type { FeatureCollection } from "geojson";
 import {
   detectGeometryColumn,
   geometryExpr,
   geometryGeoJsonSql,
   isGeometryColumnType,
+  stripAutoFidColumn,
 } from "../apps/geolibre-desktop/src/lib/duckdb-geometry";
 
 function describeRow(name: string, type: string) {
@@ -126,6 +128,73 @@ describe("geometryGeoJsonSql", () => {
     assert.equal(
       geometryGeoJsonSql('ST_GeomFromWKB("geometry_wkb")', "EPSG:3857"),
       `ST_AsGeoJSON(ST_Transform(ST_GeomFromWKB("geometry_wkb"), 'EPSG:3857', 'EPSG:4326', true))`,
+    );
+  });
+});
+
+describe("stripAutoFidColumn", () => {
+  function collection(
+    properties: Record<string, unknown> | null,
+  ): FeatureCollection {
+    return {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          properties,
+          geometry: { type: "Point", coordinates: [0, 0] },
+        },
+      ],
+    };
+  }
+
+  it("removes the GDAL-synthesised OGC_FID property (issue #499)", () => {
+    const out = stripAutoFidColumn(collection({ OGC_FID: 5, name: "a" }));
+    assert.deepEqual(out.features[0].properties, { name: "a" });
+    assert.equal(out.features[0].geometry?.type, "Point");
+  });
+
+  it("does not mutate the input collection", () => {
+    const input = collection({ OGC_FID: 5, name: "a" });
+    stripAutoFidColumn(input);
+    assert.deepEqual(input.features[0].properties, { OGC_FID: 5, name: "a" });
+  });
+
+  it("returns the same object when no feature carries OGC_FID", () => {
+    const input = collection({ name: "a" });
+    assert.equal(stripAutoFidColumn(input), input);
+  });
+
+  it("tolerates features with null properties", () => {
+    const out = stripAutoFidColumn(collection(null));
+    assert.equal(out.features[0].properties, null);
+  });
+
+  it("strips OGC_FID from every feature that has it", () => {
+    const input: FeatureCollection = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          properties: { OGC_FID: 1, name: "a" },
+          geometry: { type: "Point", coordinates: [0, 0] },
+        },
+        {
+          type: "Feature",
+          properties: { name: "b" },
+          geometry: { type: "Point", coordinates: [1, 1] },
+        },
+        {
+          type: "Feature",
+          properties: { OGC_FID: 3, name: "c" },
+          geometry: { type: "Point", coordinates: [2, 2] },
+        },
+      ],
+    };
+    const out = stripAutoFidColumn(input);
+    assert.deepEqual(
+      out.features.map((f) => f.properties),
+      [{ name: "a" }, { name: "b" }, { name: "c" }],
     );
   });
 });


### PR DESCRIPTION
Fixes #499.

## Problem

Running a query in the SQL Workspace (or having the AI assistant create layers from an existing layer), **adding the result as a layer**, then running **any** subsequent query failed with an unrecoverable error:

```
Binder Error: table "st_read" has duplicate column name "OGC_FID"
... CREATE OR REPLACE TEMP TABLE "sql_result_..." AS SELECT * FROM ST_Read('__geolibre_sql_..._sql_resu...
```

Reproducible across multiple machines/users.

## Root cause

The SQL Workspace exposes each loaded layer to DuckDB by writing its in-memory GeoJSON to the VFS and running `CREATE TEMP TABLE ... AS SELECT * FROM ST_Read(<file>)` (`registerLayerTables`).

GDAL's GeoJSON driver (which backs `ST_Read`) **synthesises an `OGC_FID` column** for every feature. When a query result is added back as a layer, that synthesised `OGC_FID` is carried into the new layer's GeoJSON **as a regular property**. On the next query, `registerLayerTables` re-reads that GeoJSON, GDAL emits its synthetic `OGC_FID` *again* alongside the existing property, and `ST_Read` produces a relation with two `OGC_FID` columns — which DuckDB rejects at bind time, so the table (and the whole query) fails.

## Fix

Strip the reserved GDAL FID column (`OGC_FID`) from each feature's properties before handing the collection to `ST_Read` in `registerLayerTables`. GDAL's synthetic FID then becomes the only `OGC_FID`, so re-reading round-tripped GeoJSON binds cleanly.

The helper (`stripAutoFidColumn`) lives in the wasm-free `duckdb-geometry` module so it is unit-testable under plain Node; it returns the input unchanged (no allocation) when no feature carries `OGC_FID`, and never mutates the caller's collection.

## Tests

- New `stripAutoFidColumn` unit tests in `tests/duckdb-geometry.test.ts` (strip, no-mutation, identity-when-absent, null-properties, multi-feature).
- Full frontend suite passes (1102 passing); `tsc -b` and pre-commit (incl. npm build) clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved geographic data handling by automatically removing auto-generated `OGC_FID` properties from GeoJSON features when loading and re-registering layers, keeping stored/exported layer data cleaner and avoiding related property duplication issues.
* **Tests**
  * Added unit tests to verify `OGC_FID` is stripped correctly, the original data isn’t mutated, empty collections are unchanged, and edge cases like missing properties are handled safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->