### PR TITLE
fix(assistant): clarify the no-LLM placeholder and fix the settings path

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/ShareProjectDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ShareProjectDialog.tsx
@@ -151,8 +151,8 @@ export function ShareProjectDialog({
           <div className="space-y-3 text-sm">
             <p className="text-muted-foreground">
               Add a share.geolibre.app API token in Settings → Environment
-              Variables before sharing. Create one under Settings &gt; API
-              tokens on the website.
+              Variables before sharing. Create one under Settings → API tokens
+              on the website.
             </p>
             <Button
               type="button"

--- a/apps/geolibre-desktop/src/components/layout/ShareProjectDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ShareProjectDialog.tsx
@@ -150,9 +150,9 @@ export function ShareProjectDialog({
         {!hasToken ? (
           <div className="space-y-3 text-sm">
             <p className="text-muted-foreground">
-              Add a share.geolibre.app API token in Settings &gt; Environment
-              before sharing. Create one under Settings &gt; API tokens on the
-              website.
+              Add a share.geolibre.app API token in Settings → Environment
+              Variables before sharing. Create one under Settings &gt; API
+              tokens on the website.
             </p>
             <Button
               type="button"

--- a/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
@@ -512,9 +512,13 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
       </div>
 
       {!hasKey ? (
-        <p className="border-t bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
-          {t("assistant.needsKey")}
-        </p>
+        <div className="space-y-1 border-t bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+          <p className="font-medium text-foreground">
+            {t("assistant.needsKeyTitle")}
+          </p>
+          <p>{t("assistant.needsKeyStatus")}</p>
+          <p>{t("assistant.needsKeyAction")}</p>
+        </div>
       ) : null}
 
       <div className="flex items-end gap-2 border-t px-3 py-2">

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1068,7 +1068,7 @@
     "intro": "Chat with your data. I can run Spatial SQL, add or remove layers, restyle them, and move the map — every change is undoable. Try \"color the countries by population with a graduated red ramp\".",
     "needsKeyTitle": "No AI provider configured",
     "needsKeyStatus": "The assistant is inactive because no LLM provider or API key was detected.",
-    "needsKeyAction": "To enable it, open Settings → Environment Variables and add your provider credentials: an API key (GEMINI_API_KEY, ANTHROPIC_API_KEY, or OPENAI_API_KEY), AWS credentials for Bedrock, a local Ollama URL (OLLAMA_BASE_URL), or a custom OpenAI-compatible endpoint (OPENAI_COMPATIBLE_BASE_URL).",
+    "needsKeyAction": "To enable it, open Settings → Environment Variables and add your provider credentials: an API key (GEMINI_API_KEY, GOOGLE_API_KEY, ANTHROPIC_API_KEY, or OPENAI_API_KEY), AWS credentials for Bedrock, a local Ollama URL (OLLAMA_BASE_URL), or a custom OpenAI-compatible endpoint (OPENAI_COMPATIBLE_BASE_URL).",
     "thinking": "Working…",
     "toolError": "failed",
     "provider": "LLM provider",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -875,7 +875,7 @@
       "reverseGeocodeNoticeTitle": "Reverse Geocode uses an external service",
       "reverseGeocodeNoticeDesc": "Turning on Reverse Geocode sends the coordinates of each point you click to the configured geocoding provider (the public Nominatim service by default) to resolve an address — your coordinates leave your device for those requests. You can choose a different provider in Settings → Geocoding.",
       "networkNoticeTitle": "Network analysis uses a public routing server",
-      "networkNoticeDesc": "Running a Network analysis tool sends the coordinates of your input points to the public Valhalla routing server (valhalla1.openstreetmap.de) to compute isochrones and cost matrices — your coordinates leave your device for those requests. The public server is rate-limited; point it at your own server (Settings → Environment, VITE_ROUTING_ENDPOINT) for heavy use.",
+      "networkNoticeDesc": "Running a Network analysis tool sends the coordinates of your input points to the public Valhalla routing server (valhalla1.openstreetmap.de) to compute isochrones and cost matrices — your coordinates leave your device for those requests. The public server is rate-limited; point it at your own server (Settings → Environment Variables, VITE_ROUTING_ENDPOINT) for heavy use.",
       "continue": "Continue",
       "largeOsmPbfTitle": "Large OSM PBF file",
       "largeOsmPbfDesc": "This file is about {{sizeMb}} MB. Parsing it converts every feature to GeoJSON in memory, which can be slow and may use a lot of memory in the browser. Continue?",
@@ -1066,7 +1066,9 @@
     "stop": "Stop",
     "placeholder": "Ask about your data, e.g. \"show countries with population over 50 million\" · Ctrl/Cmd+Enter to send",
     "intro": "Chat with your data. I can run Spatial SQL, add or remove layers, restyle them, and move the map — every change is undoable. Try \"color the countries by population with a graduated red ramp\".",
-    "needsKey": "Configure an LLM provider in Settings → Environment to enable the assistant — an API key (GEMINI_API_KEY, ANTHROPIC_API_KEY, OPENAI_API_KEY), AWS credentials for Bedrock, a local Ollama (OLLAMA_BASE_URL), or a custom OpenAI-compatible endpoint (OPENAI_COMPATIBLE_BASE_URL).",
+    "needsKeyTitle": "No AI provider configured",
+    "needsKeyStatus": "The assistant is inactive because no LLM provider or API key was detected.",
+    "needsKeyAction": "To enable it, open Settings → Environment Variables and add your provider credentials: an API key (GEMINI_API_KEY, ANTHROPIC_API_KEY, or OPENAI_API_KEY), AWS credentials for Bedrock, a local Ollama URL (OLLAMA_BASE_URL), or a custom OpenAI-compatible endpoint (OPENAI_COMPATIBLE_BASE_URL).",
     "thinking": "Working…",
     "toolError": "failed",
     "provider": "LLM provider",
@@ -1145,7 +1147,7 @@
     "heading": "Network",
     "run": "Run",
     "outputPlaceholder": "Output will appear here.",
-    "endpointNotice": "Point coordinates are sent to the routing server ({{endpoint}}). The default is a shared public Valhalla server (FOSSGIS) with usage limits — point it at your own server (Settings → Environment, VITE_ROUTING_ENDPOINT) for heavy use."
+    "endpointNotice": "Point coordinates are sent to the routing server ({{endpoint}}). The default is a shared public Valhalla server (FOSSGIS) with usage limits — point it at your own server (Settings → Environment Variables, VITE_ROUTING_ENDPOINT) for heavy use."
   },
   "statistics": {
     "title": "Spatial statistics",

--- a/apps/geolibre-desktop/src/lib/assistant/agent.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/agent.ts
@@ -87,8 +87,8 @@ export class AssistantSession {
       const pinned = this.selection?.provider;
       throw new Error(
         pinned
-          ? `No API key for the selected provider "${pinned}". Add its key in Settings → Environment, or pick another provider.`
-          : "No LLM API key is configured. Add GEMINI_API_KEY, ANTHROPIC_API_KEY, or OPENAI_API_KEY in Settings → Environment.",
+          ? `No API key for the selected provider "${pinned}". Add its key in Settings → Environment Variables, or pick another provider.`
+          : "No LLM API key is configured. Add GEMINI_API_KEY, ANTHROPIC_API_KEY, or OPENAI_API_KEY in Settings → Environment Variables.",
       );
     }
     const model = await createModel(config);

--- a/apps/geolibre-desktop/src/lib/assistant/agent.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/agent.ts
@@ -88,7 +88,7 @@ export class AssistantSession {
       throw new Error(
         pinned
           ? `No API key for the selected provider "${pinned}". Add its key in Settings → Environment Variables, or pick another provider.`
-          : "No LLM API key is configured. Add GEMINI_API_KEY, ANTHROPIC_API_KEY, or OPENAI_API_KEY in Settings → Environment Variables.",
+          : "No LLM API key is configured. Add GEMINI_API_KEY, GOOGLE_API_KEY, ANTHROPIC_API_KEY, or OPENAI_API_KEY in Settings → Environment Variables.",
       );
     }
     const model = await createModel(config);

--- a/apps/geolibre-desktop/src/lib/assistant/tools.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/tools.ts
@@ -510,7 +510,7 @@ export function createAssistantTools(
         // search is unavailable so it can fall back gracefully.
         return json({
           error:
-            "Web search is unavailable from the browser. Configure TAVILY_API_KEY in Settings → Environment for reliable search.",
+            "Web search is unavailable from the browser. Configure TAVILY_API_KEY in Settings → Environment Variables for reliable search.",
           detail: error instanceof Error ? error.message : String(error),
           results: [],
         });

--- a/docs/user-guide/ai-assistant.md
+++ b/docs/user-guide/ai-assistant.md
@@ -19,7 +19,7 @@ data leaves your machine until you add a key and send a prompt.
 
 The assistant is **provider-pluggable** — it uses the
 [Strands Agents](https://strandsagents.com) SDK. Configure one (or more)
-providers in **Settings → Environment** as environment variables:
+providers in **Settings → Environment Variables** as environment variables:
 
 | Provider | Environment variable(s) | Default model |
 | --- | --- | --- |


### PR DESCRIPTION
Closes #501

## Summary
- Rework the AI Assistant placeholder shown when no LLM is configured into a status-then-action empty state that matches other panels (Layers, etc.): a bold "No AI provider configured" heading, a one-line status explaining why the assistant is inactive, and a single action sentence telling the user where to add credentials.
- Fix the inaccurate navigation path "Settings -> Environment" (a menu that does not exist) to the correct "Settings -> Environment Variables" everywhere it appeared: the placeholder, the assistant no-key and web-search error messages, the Network and routing endpoint notices, and the AI Assistant doc.
- Split the single placeholder string into `assistant.needsKeyTitle` / `needsKeyStatus` / `needsKeyAction` keys in the en.json catalog.

## Before
> Configure an LLM provider in Settings -> Environment to enable the assistant - an API key (GEMINI_API_KEY, ANTHROPIC_API_KEY, OPENAI_API_KEY), AWS credentials for Bedrock, a local Ollama (OLLAMA_BASE_URL), or a custom OpenAI-compatible endpoint (OPENAI_COMPATIBLE_BASE_URL).

## After
> **No AI provider configured**
> The assistant is inactive because no LLM provider or API key was detected.
> To enable it, open Settings -> Environment Variables and add your provider credentials: an API key (GEMINI_API_KEY, ANTHROPIC_API_KEY, or OPENAI_API_KEY), AWS credentials for Bedrock, a local Ollama URL (OLLAMA_BASE_URL), or a custom OpenAI-compatible endpoint (OPENAI_COMPATIBLE_BASE_URL).

## Test plan
- [x] Production build passes (tsc and vite); the removed key and new keys are type-checked against en.json
- [x] Full frontend test suite passes
- [x] Verified in the running app: opened the assistant with no LLM key configured and confirmed the new heading, status, and corrected menu path render with no raw i18n key leakage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refreshed the AI Assistant “needs API key” empty state with clearer, structured title/status/action text.

* **Bug Fixes**
  * Corrected user-facing guidance to direct credential setup to **Settings → Environment Variables** (including network notices and browser search configuration messages).

* **Documentation**
  * Updated the AI Assistant setup guide to reference **Settings → Environment Variables**.

* **UI Copy**
  * Improved “no token” sharing instructions by using **Settings → API tokens** for readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->