### PR TITLE
feat(map): add lock-icon indicator when map bounds are restricted (#504)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/BoundsRestrictionIndicator.tsx
+++ b/apps/geolibre-desktop/src/components/layout/BoundsRestrictionIndicator.tsx
@@ -1,0 +1,36 @@
+import { useAppStore } from "@geolibre/core";
+import { Lock } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+/**
+ * Subtle corner badge that appears on the map only while the project's
+ * "Restrict map bounds" preference is enabled. It gives users a visible cue
+ * that panning/zooming is intentionally constrained (rather than the app being
+ * frozen), with a tooltip pointing them back to Settings to change it.
+ */
+export function BoundsRestrictionIndicator() {
+  const { t } = useTranslation();
+  const restrictBounds = useAppStore((s) => s.preferences.map.restrictBounds);
+
+  if (!restrictBounds) {
+    return null;
+  }
+
+  const tooltip = t("map.boundsRestrictedTooltip");
+
+  return (
+    <div
+      className="pointer-events-auto absolute left-2 top-2 z-10 flex items-center gap-1 rounded-md border bg-background/90 px-2 py-1 text-xs font-medium text-foreground shadow-sm backdrop-blur-sm"
+      role="status"
+      aria-label={tooltip}
+      title={tooltip}
+      data-testid="bounds-restriction-indicator"
+    >
+      <Lock
+        className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400"
+        aria-hidden="true"
+      />
+      <span>{t("map.boundsRestricted")}</span>
+    </div>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/BoundsRestrictionIndicator.tsx
+++ b/apps/geolibre-desktop/src/components/layout/BoundsRestrictionIndicator.tsx
@@ -22,7 +22,6 @@ export function BoundsRestrictionIndicator() {
     <div
       className="pointer-events-auto absolute left-2 top-2 z-10 flex items-center gap-1 rounded-md border bg-background/90 px-2 py-1 text-xs font-medium text-foreground shadow-sm backdrop-blur-sm"
       role="status"
-      aria-label={tooltip}
       title={tooltip}
       data-testid="bounds-restriction-indicator"
     >
@@ -31,6 +30,9 @@ export function BoundsRestrictionIndicator() {
         aria-hidden="true"
       />
       <span>{t("map.boundsRestricted")}</span>
+      {/* Full description for assistive tech; the live region announces this
+          along with the visible label, while sighted users get it via title. */}
+      <span className="sr-only">{tooltip}</span>
     </div>
   );
 }

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -62,6 +62,7 @@ import { registerMbtilesProtocol } from "../../lib/mbtiles";
 import { hasReverseGeocodeConsent } from "../../lib/reverse-geocode-consent";
 import { registerXyzTileProtocol } from "../../lib/xyz-url";
 import { useEmbedBridge } from "../../hooks/useEmbedBridge";
+import { BoundsRestrictionIndicator } from "./BoundsRestrictionIndicator";
 import { RemoteCursorsOverlay } from "./RemoteCursorsOverlay";
 import { useCommandBridge } from "../../hooks/useCommandBridge";
 import {
@@ -1261,6 +1262,7 @@ export function DesktopShell({
               onControllerReady={handleMapControllerReady}
             />
             <RemoteCursorsOverlay mapControllerRef={mapControllerRef} />
+            <BoundsRestrictionIndicator />
           </SectionErrorBoundary>
         </main>
         {/* The notebook claims the workspace's right half, so the Style panel

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -479,6 +479,10 @@
       "hideEntry": "Hide entry"
     }
   },
+  "map": {
+    "boundsRestricted": "Bounds locked",
+    "boundsRestrictedTooltip": "Map bounds are restricted. You can change this in Settings."
+  },
   "settings": {
     "title": "Settings",
     "description": "Configure project preferences and runtime settings.",


### PR DESCRIPTION
## Summary
- Add a subtle lock badge ("Bounds locked") in the top-left corner of the map that appears only while the project's "Restrict map bounds" preference is enabled, closing the feedback gap described in #504.
- The badge carries a tooltip ("Map bounds are restricted. You can change this in Settings.") and exposes a `status` role for assistive tech; nothing is shown in the default unrestricted state.
- New `BoundsRestrictionIndicator` component reads `preferences.map.restrictBounds` from the store and renders inside the map `<main>` alongside the existing canvas overlays. New i18n strings added under a `map` namespace in `en.json`.

## Test plan
- [x] Default project (restriction off): no badge on the canvas.
- [x] Enable "Restrict map bounds" in Settings -> Map Preferences and save: lock badge appears top-left with the correct label and tooltip.
- [x] Disable and save: badge disappears.
- [x] `pre-commit run --files` (eslint + npm build) passes.

Closes #504

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a map status badge that appears when map bounds restriction is enabled, featuring a lock icon and a localized tooltip for restricted boundaries.
* **UI / Accessibility**
  * Badge includes accessible status semantics and assistive-text tooltip content.
* **Localization**
  * Introduced new English translation strings for the badge label and tooltip.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->