### PR TITLE
feat(settings): customizable UI profiles / data source filtering (#500)

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,7 @@ Full documentation, including the User Guide and Tutorials, is published at
   - [Android](docs/android.md)
   - [Project format](docs/project-format.md)
   - [Plugin API](docs/plugin-api.md)
+  - [UI Profiles](docs/ui-profiles.md)
   - [Python package (Jupyter)](docs/python.md)
   - [Roadmap](docs/roadmap.md)
 

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -179,6 +179,7 @@ pub fn run() {
             ensure_martin_binary,
             fetch_url_bytes,
             load_external_plugin_bundles,
+            read_admin_profile,
             read_project_file,
             resolve_url_redirect,
             read_mbtiles_metadata,
@@ -203,6 +204,25 @@ pub fn run() {
 #[tauri::command]
 fn read_project_file(path: String) -> Result<String, String> {
     fs::read_to_string(&path).map_err(|error| format!("Could not read project file: {error}"))
+}
+
+/// Read the optional admin UI-profile file (`<app_config_dir>/admin-profile.json`).
+///
+/// Returns `Ok(None)` when the file is absent so a missing file is not an error;
+/// administrators drop one in to pre-configure and optionally lock the UI profile
+/// for a deployment. See `docs/ui-profiles.md`.
+#[tauri::command]
+fn read_admin_profile(app: tauri::AppHandle) -> Result<Option<String>, String> {
+    let config_dir = app
+        .path()
+        .app_config_dir()
+        .map_err(|error| format!("Could not resolve config directory: {error}"))?;
+    let path = config_dir.join("admin-profile.json");
+    match fs::read_to_string(&path) {
+        Ok(contents) => Ok(Some(contents)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(format!("Could not read admin profile: {error}")),
+    }
 }
 
 #[tauri::command]

--- a/apps/geolibre-desktop/src/App.tsx
+++ b/apps/geolibre-desktop/src/App.tsx
@@ -1,4 +1,5 @@
 import { DesktopShell } from "./components/layout/DesktopShell";
+import { OnboardingDialog } from "./components/layout/OnboardingDialog";
 import { useDesktopSettingsPersistence } from "./hooks/useDesktopSettings";
 import { useLayoutOptions } from "./hooks/useLayoutOptions";
 import { useProjectUrlLoader } from "./hooks/useProjectUrlLoader";
@@ -6,12 +7,14 @@ import { useBeforeUnloadGuard } from "./hooks/useBeforeUnloadGuard";
 import { useRecentProjectsPersistence } from "./hooks/useRecentProjectsPersistence";
 import { useRuntimeEnvironmentVariables } from "./hooks/useRuntimeEnvironmentVariables";
 import { useThemeMode } from "./hooks/useThemeMode";
+import { useUiProfileBootstrap } from "./hooks/useUiProfileBootstrap";
 import { useUndoRedoShortcuts } from "./hooks/useUndoRedoShortcuts";
 
 export default function App() {
   const layoutOptions = useLayoutOptions();
   const { themeMode, toggleThemeMode } = useThemeMode();
   const projectUrlLoadState = useProjectUrlLoader();
+  const { showOnboarding, dismissOnboarding } = useUiProfileBootstrap();
 
   useDesktopSettingsPersistence();
   useRecentProjectsPersistence();
@@ -19,11 +22,14 @@ export default function App() {
   useUndoRedoShortcuts();
   useBeforeUnloadGuard();
   return (
-    <DesktopShell
-      layoutOptions={layoutOptions}
-      projectUrlLoadState={projectUrlLoadState}
-      themeMode={themeMode}
-      onToggleThemeMode={toggleThemeMode}
-    />
+    <>
+      <DesktopShell
+        layoutOptions={layoutOptions}
+        projectUrlLoadState={projectUrlLoadState}
+        themeMode={themeMode}
+        onToggleThemeMode={toggleThemeMode}
+      />
+      <OnboardingDialog open={showOnboarding} onClose={dismissOnboarding} />
+    </>
   );
 }

--- a/apps/geolibre-desktop/src/components/layout/OnboardingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/OnboardingDialog.tsx
@@ -7,6 +7,7 @@ import {
 } from "@geolibre/ui";
 import { useTranslation } from "react-i18next";
 import {
+  EXPERIENCE_LEVELS,
   useDesktopSettingsStore,
   type ExperienceLevel,
 } from "../../hooks/useDesktopSettings";
@@ -17,12 +18,6 @@ interface OnboardingDialogProps {
   open: boolean;
   onClose: () => void;
 }
-
-const LEVELS: readonly ExperienceLevel[] = [
-  "beginner",
-  "intermediate",
-  "advanced",
-];
 
 /**
  * First-launch wizard (issue #500) that lets the user pick an experience level,
@@ -76,7 +71,7 @@ export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
           <DialogDescription>{t("onboarding.description")}</DialogDescription>
         </DialogHeader>
         <div className="space-y-2">
-          {LEVELS.map((level) => (
+          {EXPERIENCE_LEVELS.map((level) => (
             <button
               key={level}
               type="button"

--- a/apps/geolibre-desktop/src/components/layout/OnboardingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/OnboardingDialog.tsx
@@ -1,0 +1,105 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@geolibre/ui";
+import { useTranslation } from "react-i18next";
+import {
+  useDesktopSettingsStore,
+  type ExperienceLevel,
+} from "../../hooks/useDesktopSettings";
+import { usePluginRegistry } from "../../hooks/usePlugins";
+import { presetHiddenSets } from "../../lib/ui-profile";
+
+interface OnboardingDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const LEVELS: readonly ExperienceLevel[] = [
+  "beginner",
+  "intermediate",
+  "advanced",
+];
+
+/**
+ * First-launch wizard (issue #500) that lets the user pick an experience level,
+ * seeding the UI profile so beginners start with a decluttered interface. Shown
+ * only when no admin file is present and onboarding has not been completed.
+ */
+export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
+  const { t } = useTranslation();
+  const { plugins } = usePluginRegistry();
+  const setDesktopSettings = useDesktopSettingsStore(
+    (state) => state.setDesktopSettings,
+  );
+
+  // Apply a level preset (or "show everything" when level is null) and mark
+  // onboarding complete so the wizard does not reappear.
+  const choose = (level: ExperienceLevel | null) => {
+    const current = useDesktopSettingsStore.getState().desktopSettings;
+    const sets =
+      level !== null
+        ? presetHiddenSets(
+            level,
+            plugins.map((plugin) => plugin.id),
+          )
+        : { hiddenDataSources: [], hiddenPlugins: [] };
+    setDesktopSettings({
+      ...current,
+      uiProfile: {
+        ...current.uiProfile,
+        enabled: level !== null,
+        level,
+        onboarded: true,
+        hiddenDataSources: sets.hiddenDataSources,
+        hiddenPlugins: sets.hiddenPlugins,
+      },
+    });
+    onClose();
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next: boolean) => {
+        // Dismissing without a choice keeps the full interface but records that
+        // onboarding was seen so it is not shown again.
+        if (!next) choose(null);
+      }}
+    >
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{t("onboarding.title")}</DialogTitle>
+          <DialogDescription>{t("onboarding.description")}</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2">
+          {LEVELS.map((level) => (
+            <button
+              key={level}
+              type="button"
+              className="w-full rounded-md border p-3 text-left transition hover:bg-accent"
+              onClick={() => choose(level)}
+            >
+              <span className="block text-sm font-semibold">
+                {t(`onboarding.level.${level}.title`)}
+              </span>
+              <span className="block text-xs text-muted-foreground">
+                {t(`onboarding.level.${level}.description`)}
+              </span>
+            </button>
+          ))}
+        </div>
+        <button
+          type="button"
+          className="text-xs text-muted-foreground underline-offset-2 hover:underline"
+          onClick={() => choose(null)}
+        >
+          {t("onboarding.showEverything")}
+        </button>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/OnboardingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/OnboardingDialog.tsx
@@ -12,7 +12,7 @@ import {
   type ExperienceLevel,
 } from "../../hooks/useDesktopSettings";
 import { usePluginRegistry } from "../../hooks/usePlugins";
-import { presetHiddenSets } from "../../lib/ui-profile";
+import { presetHiddenSets, toggleablePluginIds } from "../../lib/ui-profile";
 
 interface OnboardingDialogProps {
   open: boolean;
@@ -37,10 +37,7 @@ export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
     const current = useDesktopSettingsStore.getState().desktopSettings;
     const sets =
       level !== null
-        ? presetHiddenSets(
-            level,
-            plugins.map((plugin) => plugin.id),
-          )
+        ? presetHiddenSets(level, toggleablePluginIds(plugins))
         : {
             hiddenDataSources: [],
             hiddenPlugins: [],

--- a/apps/geolibre-desktop/src/components/layout/OnboardingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/OnboardingDialog.tsx
@@ -41,7 +41,12 @@ export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
             level,
             plugins.map((plugin) => plugin.id),
           )
-        : { hiddenDataSources: [], hiddenPlugins: [] };
+        : {
+            hiddenDataSources: [],
+            hiddenPlugins: [],
+            hiddenMenus: [],
+            hiddenMenuItems: [],
+          };
     setDesktopSettings({
       ...current,
       uiProfile: {
@@ -49,8 +54,7 @@ export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
         enabled: level !== null,
         level,
         onboarded: true,
-        hiddenDataSources: sets.hiddenDataSources,
-        hiddenPlugins: sets.hiddenPlugins,
+        ...sets,
       },
     });
     onClose();

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -471,6 +471,30 @@ export function SettingsDialog({
     updateDraftLayoutSettings(DEFAULT_DESKTOP_LAYOUT_SETTINGS);
   };
 
+  // Live updates from the Settings dropdown's Interface submenu (not the draft,
+  // which only the dialog commits on Save). Reads the latest state so rapid
+  // toggles do not clobber each other.
+  const updateSavedUiProfile = (patch: Partial<UiProfileSettings>) => {
+    const current = useDesktopSettingsStore.getState().desktopSettings;
+    setDesktopSettings({
+      ...current,
+      uiProfile: { ...current.uiProfile, ...patch },
+    });
+  };
+
+  const applySavedExperiencePreset = (level: ExperienceLevel) => {
+    const { hiddenDataSources, hiddenPlugins } = presetHiddenSets(
+      level,
+      profilePlugins.map((plugin) => plugin.id),
+    );
+    updateSavedUiProfile({
+      enabled: true,
+      level,
+      hiddenDataSources,
+      hiddenPlugins,
+    });
+  };
+
   const updateShareToken = (value: string) => {
     // Kept in the draft and only committed on Save, so editing the token and
     // then closing the dialog without saving discards the change (a secret
@@ -705,6 +729,57 @@ export function SettingsDialog({
               <DropdownMenuLabel className="px-2 py-1 text-xs font-normal text-muted-foreground">
                 {t("settings.menu.urlOverrideNote")}
               </DropdownMenuLabel>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              <SlidersHorizontal className="mr-2 h-3.5 w-3.5" />
+              {t("settings.section.interface")}
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent className="w-56">
+              <DropdownMenuCheckboxItem
+                checked={desktopSettings.uiProfile.enabled}
+                disabled={desktopSettings.uiProfile.locked}
+                onCheckedChange={(checked: boolean) =>
+                  updateSavedUiProfile({ enabled: checked === true })
+                }
+                onSelect={(event: Event) => event.preventDefault()}
+              >
+                {t("settings.interface.enable")}
+              </DropdownMenuCheckboxItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuLabel className="px-2 py-1 text-xs font-normal text-muted-foreground">
+                {t("settings.interface.presets")}
+              </DropdownMenuLabel>
+              <DropdownMenuRadioGroup
+                value={desktopSettings.uiProfile.level ?? ""}
+                onValueChange={(value: string) =>
+                  applySavedExperiencePreset(value as ExperienceLevel)
+                }
+              >
+                {EXPERIENCE_LEVELS.map((level) => (
+                  <DropdownMenuRadioItem
+                    key={level}
+                    value={level}
+                    disabled={
+                      desktopSettings.uiProfile.locked ||
+                      !desktopSettings.uiProfile.enabled
+                    }
+                    onSelect={(event: Event) => event.preventDefault()}
+                  >
+                    {t(`settings.interface.level.${level}`)}
+                  </DropdownMenuRadioItem>
+                ))}
+              </DropdownMenuRadioGroup>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onSelect={() => {
+                  setSection("interface");
+                  setOpen(true);
+                }}
+              >
+                {t("settings.menu.interfaceSettings")}
+              </DropdownMenuItem>
             </DropdownMenuSubContent>
           </DropdownMenuSub>
           <DropdownMenuItem

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -809,9 +809,14 @@ export function SettingsDialog({
               </DropdownMenuLabel>
               <DropdownMenuRadioGroup
                 value={desktopSettings.uiProfile.level ?? ""}
-                onValueChange={(value: string) =>
-                  applySavedExperiencePreset(value as ExperienceLevel)
-                }
+                onValueChange={(value: string) => {
+                  // Guard the cast: the group's value is `level ?? ""`, and no
+                  // radio item carries an empty value, but make the invariant
+                  // explicit so a stray value can't reach presetHiddenSets.
+                  if ((EXPERIENCE_LEVELS as readonly string[]).includes(value)) {
+                    applySavedExperiencePreset(value as ExperienceLevel);
+                  }
+                }}
               >
                 {EXPERIENCE_LEVELS.map((level) => (
                   <DropdownMenuRadioItem

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -72,6 +72,10 @@ import {
   DATA_SOURCE_CATALOG,
   DATA_SOURCE_SECTION_LABEL_KEYS,
   DATA_SOURCE_SECTION_ORDER,
+  MENU_ITEM_CATALOG,
+  MENU_ITEM_GROUPS,
+  TOP_LEVEL_MENUS,
+  isMenuItemVisible,
   presetHiddenSets,
 } from "../../lib/ui-profile";
 
@@ -170,6 +174,8 @@ function cloneDesktopSettings(settings: DesktopSettings): DraftDesktopSettings {
       ...settings.uiProfile,
       hiddenDataSources: [...settings.uiProfile.hiddenDataSources],
       hiddenPlugins: [...settings.uiProfile.hiddenPlugins],
+      hiddenMenus: [...settings.uiProfile.hiddenMenus],
+      hiddenMenuItems: [...settings.uiProfile.hiddenMenuItems],
     },
   };
 }
@@ -286,6 +292,11 @@ export function SettingsDialog({
   const setDesktopSettings = useDesktopSettingsStore(
     (s) => s.setDesktopSettings,
   );
+  // Visibility of the Settings dropdown items under the active UI profile. The
+  // Language/Layout/Interface entries are always shown so the profile UI stays
+  // reachable.
+  const showSettingsItem = (id: string) =>
+    isMenuItemVisible(desktopSettings.uiProfile, id);
   const projectName = useAppStore((s) => s.projectName);
   const projectPath = useAppStore((s) => s.projectPath);
   const setProjectName = useAppStore((s) => s.setProjectName);
@@ -483,16 +494,11 @@ export function SettingsDialog({
   };
 
   const applySavedExperiencePreset = (level: ExperienceLevel) => {
-    const { hiddenDataSources, hiddenPlugins } = presetHiddenSets(
+    const sets = presetHiddenSets(
       level,
       profilePlugins.map((plugin) => plugin.id),
     );
-    updateSavedUiProfile({
-      enabled: true,
-      level,
-      hiddenDataSources,
-      hiddenPlugins,
-    });
+    updateSavedUiProfile({ enabled: true, level, ...sets });
   };
 
   const updateShareToken = (value: string) => {
@@ -513,11 +519,11 @@ export function SettingsDialog({
   // Applying an experience-level preset overwrites the hidden lists from tiers
   // and turns the profile on. Plugin tiers consider the toggleable plugin ids.
   const applyExperiencePreset = (level: ExperienceLevel) => {
-    const { hiddenDataSources, hiddenPlugins } = presetHiddenSets(
+    const sets = presetHiddenSets(
       level,
       profilePlugins.map((plugin) => plugin.id),
     );
-    updateUiProfile({ enabled: true, level, hiddenDataSources, hiddenPlugins });
+    updateUiProfile({ enabled: true, level, ...sets });
   };
 
   // Toggling a single item makes the selection "custom" (level = null).
@@ -549,6 +555,36 @@ export function SettingsDialog({
           ...current.uiProfile,
           level: null,
           hiddenPlugins: [...hidden],
+        },
+      };
+    });
+    setError(null);
+  };
+
+  const toggleMenuHidden = (id: string, visible: boolean) => {
+    setDraftDesktopSettings((current) => {
+      const hidden = new Set(current.uiProfile.hiddenMenus);
+      if (visible) hidden.delete(id);
+      else hidden.add(id);
+      return {
+        ...current,
+        uiProfile: { ...current.uiProfile, level: null, hiddenMenus: [...hidden] },
+      };
+    });
+    setError(null);
+  };
+
+  const toggleMenuItemHidden = (id: string, visible: boolean) => {
+    setDraftDesktopSettings((current) => {
+      const hidden = new Set(current.uiProfile.hiddenMenuItems);
+      if (visible) hidden.delete(id);
+      else hidden.add(id);
+      return {
+        ...current,
+        uiProfile: {
+          ...current.uiProfile,
+          level: null,
+          hiddenMenuItems: [...hidden],
         },
       };
     });
@@ -658,15 +694,17 @@ export function SettingsDialog({
             </DropdownMenuSubContent>
           </DropdownMenuSub>
           <DropdownMenuSeparator />
-          <DropdownMenuItem
-            onSelect={() => {
-              setSection("map");
-              setOpen(true);
-            }}
-          >
-            <MapPinned className="mr-2 h-3.5 w-3.5" />
-            {t("settings.menu.mapPreferences")}
-          </DropdownMenuItem>
+          {showSettingsItem("settings.mapPreferences") && (
+            <DropdownMenuItem
+              onSelect={() => {
+                setSection("map");
+                setOpen(true);
+              }}
+            >
+              <MapPinned className="mr-2 h-3.5 w-3.5" />
+              {t("settings.menu.mapPreferences")}
+            </DropdownMenuItem>
+          )}
           <DropdownMenuSub>
             <DropdownMenuSubTrigger>
               <LayoutPanelTop className="mr-2 h-3.5 w-3.5" />
@@ -782,37 +820,45 @@ export function SettingsDialog({
               </DropdownMenuItem>
             </DropdownMenuSubContent>
           </DropdownMenuSub>
-          <DropdownMenuItem
-            onSelect={() => {
-              setSection("geocoding");
-              setOpen(true);
-            }}
-          >
-            <Locate className="mr-2 h-3.5 w-3.5" />
-            {t("settings.menu.geocoding")}
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            onSelect={() => {
-              setSection("environment");
-              setOpen(true);
-            }}
-          >
-            <Braces className="mr-2 h-3.5 w-3.5" />
-            {t("settings.menu.environmentVariables")}
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            onSelect={() => {
-              setSection("project");
-              setOpen(true);
-            }}
-          >
-            <FolderCog className="mr-2 h-3.5 w-3.5" />
-            {t("settings.menu.projectSettings")}
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => onOpenManagePlugins()}>
-            <Puzzle className="mr-2 h-3.5 w-3.5" />
-            {t("settings.menu.managePlugins")}
-          </DropdownMenuItem>
+          {showSettingsItem("settings.geocoding") && (
+            <DropdownMenuItem
+              onSelect={() => {
+                setSection("geocoding");
+                setOpen(true);
+              }}
+            >
+              <Locate className="mr-2 h-3.5 w-3.5" />
+              {t("settings.menu.geocoding")}
+            </DropdownMenuItem>
+          )}
+          {showSettingsItem("settings.environment") && (
+            <DropdownMenuItem
+              onSelect={() => {
+                setSection("environment");
+                setOpen(true);
+              }}
+            >
+              <Braces className="mr-2 h-3.5 w-3.5" />
+              {t("settings.menu.environmentVariables")}
+            </DropdownMenuItem>
+          )}
+          {showSettingsItem("settings.projectSettings") && (
+            <DropdownMenuItem
+              onSelect={() => {
+                setSection("project");
+                setOpen(true);
+              }}
+            >
+              <FolderCog className="mr-2 h-3.5 w-3.5" />
+              {t("settings.menu.projectSettings")}
+            </DropdownMenuItem>
+          )}
+          {showSettingsItem("settings.managePlugins") && (
+            <DropdownMenuItem onSelect={() => onOpenManagePlugins()}>
+              <Puzzle className="mr-2 h-3.5 w-3.5" />
+              {t("settings.menu.managePlugins")}
+            </DropdownMenuItem>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
       <Dialog open={open} onOpenChange={setOpen}>
@@ -1216,6 +1262,72 @@ export function SettingsDialog({
                       </div>
                     </div>
                   ) : null}
+                  <div className="space-y-3">
+                    <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      {t("settings.interface.menus")}
+                    </h4>
+                    <div className="grid gap-1.5 sm:grid-cols-2">
+                      {TOP_LEVEL_MENUS.map((menu) => (
+                        <label
+                          key={menu.id}
+                          className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm"
+                        >
+                          <input
+                            className="h-4 w-4"
+                            type="checkbox"
+                            checked={
+                              !draftDesktopSettings.uiProfile.hiddenMenus.includes(
+                                menu.id,
+                              )
+                            }
+                            disabled={
+                              draftDesktopSettings.uiProfile.locked ||
+                              !draftDesktopSettings.uiProfile.enabled
+                            }
+                            onChange={(event) =>
+                              toggleMenuHidden(menu.id, event.target.checked)
+                            }
+                          />
+                          <span>{t(menu.labelKey)}</span>
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                  {MENU_ITEM_GROUPS.map((group) => (
+                    <div key={group.menuId} className="space-y-1.5">
+                      <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        {t(group.labelKey)}
+                      </h4>
+                      <div className="grid gap-1.5 sm:grid-cols-2">
+                        {MENU_ITEM_CATALOG.filter(
+                          (entry) => entry.menuId === group.menuId,
+                        ).map((entry) => (
+                          <label
+                            key={entry.id}
+                            className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm"
+                          >
+                            <input
+                              className="h-4 w-4"
+                              type="checkbox"
+                              checked={
+                                !draftDesktopSettings.uiProfile.hiddenMenuItems.includes(
+                                  entry.id,
+                                )
+                              }
+                              disabled={
+                                draftDesktopSettings.uiProfile.locked ||
+                                !draftDesktopSettings.uiProfile.enabled
+                              }
+                              onChange={(event) =>
+                                toggleMenuItemHidden(entry.id, event.target.checked)
+                              }
+                            />
+                            <span>{t(entry.labelKey)}</span>
+                          </label>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
                 </div>
               ) : null}
               {section === "geocoding" ? (

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -49,6 +49,7 @@ import {
   Plus,
   RotateCcw,
   Settings,
+  SlidersHorizontal,
   Type,
   Trash2,
   TriangleAlert,
@@ -58,18 +59,34 @@ import { useEffect, useMemo, useState, type RefObject } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import {
   DEFAULT_DESKTOP_LAYOUT_SETTINGS,
+  DEFAULT_UI_PROFILE_SETTINGS,
   useDesktopSettingsStore,
   type DesktopSettings,
   type DesktopLayoutSettings,
+  type ExperienceLevel,
+  type UiProfileSettings,
 } from "../../hooks/useDesktopSettings";
 import { useLanguage } from "../../hooks/useLanguage";
+import {
+  DATA_SOURCE_CATALOG,
+  DATA_SOURCE_SECTION_LABEL_KEYS,
+  DATA_SOURCE_SECTION_ORDER,
+  presetHiddenSets,
+} from "../../lib/ui-profile";
 
 type SettingsSection =
   | "map"
   | "layout"
+  | "interface"
   | "geocoding"
   | "environment"
   | "project";
+
+/** A plugin offered as a visibility toggle in the Interface section. */
+export interface ProfilePlugin {
+  id: string;
+  name: string;
+}
 
 interface SettingsDialogProps {
   buttonClassName?: string;
@@ -78,6 +95,8 @@ interface SettingsDialogProps {
   mapControllerRef: RefObject<MapController | null>;
   showLabels?: boolean;
   onOpenManagePlugins: () => void;
+  /** Toggleable plugins for the Interface (UI profile) section (issue #500). */
+  profilePlugins: ProfilePlugin[];
 }
 
 const SECTION_ITEMS: Array<{
@@ -87,6 +106,11 @@ const SECTION_ITEMS: Array<{
 }> = [
   { id: "map", labelKey: "settings.section.map", icon: MapPinned },
   { id: "layout", labelKey: "settings.section.layout", icon: LayoutPanelTop },
+  {
+    id: "interface",
+    labelKey: "settings.section.interface",
+    icon: SlidersHorizontal,
+  },
   { id: "geocoding", labelKey: "settings.section.geocoding", icon: Locate },
   {
     id: "environment",
@@ -114,6 +138,7 @@ interface DraftPreferences {
 interface DraftDesktopSettings {
   layout: DesktopLayoutSettings;
   shareToken: string;
+  uiProfile: UiProfileSettings;
 }
 
 function createDraftId(): string {
@@ -140,6 +165,11 @@ function cloneDesktopSettings(settings: DesktopSettings): DraftDesktopSettings {
   return {
     layout: { ...settings.layout },
     shareToken: settings.shareToken,
+    uiProfile: {
+      ...settings.uiProfile,
+      hiddenDataSources: [...settings.uiProfile.hiddenDataSources],
+      hiddenPlugins: [...settings.uiProfile.hiddenPlugins],
+    },
   };
 }
 
@@ -241,6 +271,7 @@ export function SettingsDialog({
   mapControllerRef,
   showLabels = true,
   onOpenManagePlugins,
+  profilePlugins,
 }: SettingsDialogProps) {
   const { t } = useTranslation();
   const {
@@ -446,6 +477,70 @@ export function SettingsDialog({
     setDraftDesktopSettings((current) => ({ ...current, shareToken: value }));
   };
 
+  const updateUiProfile = (patch: Partial<UiProfileSettings>) => {
+    setDraftDesktopSettings((current) => ({
+      ...current,
+      uiProfile: { ...current.uiProfile, ...patch },
+    }));
+    setError(null);
+  };
+
+  // Applying an experience-level preset overwrites the hidden lists from tiers
+  // and turns the profile on. Plugin tiers consider the toggleable plugin ids.
+  const applyExperiencePreset = (level: ExperienceLevel) => {
+    const { hiddenDataSources, hiddenPlugins } = presetHiddenSets(
+      level,
+      profilePlugins.map((plugin) => plugin.id),
+    );
+    updateUiProfile({ enabled: true, level, hiddenDataSources, hiddenPlugins });
+  };
+
+  // Toggling a single item makes the selection "custom" (level = null).
+  const toggleDataSourceHidden = (id: string, visible: boolean) => {
+    setDraftDesktopSettings((current) => {
+      const hidden = new Set(current.uiProfile.hiddenDataSources);
+      if (visible) hidden.delete(id);
+      else hidden.add(id);
+      return {
+        ...current,
+        uiProfile: {
+          ...current.uiProfile,
+          level: null,
+          hiddenDataSources: [...hidden],
+        },
+      };
+    });
+    setError(null);
+  };
+
+  const togglePluginHidden = (id: string, visible: boolean) => {
+    setDraftDesktopSettings((current) => {
+      const hidden = new Set(current.uiProfile.hiddenPlugins);
+      if (visible) hidden.delete(id);
+      else hidden.add(id);
+      return {
+        ...current,
+        uiProfile: {
+          ...current.uiProfile,
+          level: null,
+          hiddenPlugins: [...hidden],
+        },
+      };
+    });
+    setError(null);
+  };
+
+  // Reset clears the profile to "show everything" but preserves the admin lock
+  // and the onboarding flag.
+  const resetUiProfile = () => {
+    updateUiProfile({
+      enabled: DEFAULT_UI_PROFILE_SETTINGS.enabled,
+      level: DEFAULT_UI_PROFILE_SETTINGS.level,
+      hiddenDataSources: [],
+      hiddenPlugins: [],
+    });
+  };
+
   const saveSettings = () => {
     const normalized = normalizePreferences(draftPreferences);
     const validationError = validateEnvironmentVariables(
@@ -470,6 +565,7 @@ export function SettingsDialog({
       ...useDesktopSettingsStore.getState().desktopSettings,
       layout: draftDesktopSettings.layout,
       shareToken: draftDesktopSettings.shareToken,
+      uiProfile: draftDesktopSettings.uiProfile,
     });
     setOpen(false);
   };
@@ -897,6 +993,155 @@ export function SettingsDialog({
                   <div className="rounded-md border bg-muted/40 p-3 text-xs text-muted-foreground">
                     {t("settings.layout.urlParamsNote")}
                   </div>
+                </div>
+              ) : null}
+              {section === "interface" ? (
+                <div className="space-y-5">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <h3 className="text-sm font-semibold">
+                        {t("settings.interface.title")}
+                      </h3>
+                      <p className="text-xs text-muted-foreground">
+                        {t("settings.interface.description")}
+                      </p>
+                    </div>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      disabled={draftDesktopSettings.uiProfile.locked}
+                      onClick={resetUiProfile}
+                    >
+                      <RotateCcw className="h-3.5 w-3.5" />
+                      {t("common.reset")}
+                    </Button>
+                  </div>
+                  {draftDesktopSettings.uiProfile.locked ? (
+                    <div className="rounded-md border bg-muted/40 p-3 text-xs text-muted-foreground">
+                      {t("settings.interface.lockedNote")}
+                    </div>
+                  ) : null}
+                  <label className="flex items-center gap-3 rounded-md border p-3 text-sm">
+                    <input
+                      className="h-4 w-4"
+                      type="checkbox"
+                      checked={draftDesktopSettings.uiProfile.enabled}
+                      disabled={draftDesktopSettings.uiProfile.locked}
+                      onChange={(event) =>
+                        updateUiProfile({ enabled: event.target.checked })
+                      }
+                    />
+                    <SlidersHorizontal className="h-4 w-4 text-muted-foreground" />
+                    <span>{t("settings.interface.enable")}</span>
+                  </label>
+                  <div className="space-y-2">
+                    <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      {t("settings.interface.presets")}
+                    </h4>
+                    <div className="flex flex-wrap gap-2">
+                      {(
+                        ["beginner", "intermediate", "advanced"] as const
+                      ).map((level) => (
+                        <Button
+                          key={level}
+                          type="button"
+                          size="sm"
+                          variant={
+                            draftDesktopSettings.uiProfile.level === level
+                              ? "secondary"
+                              : "outline"
+                          }
+                          disabled={
+                            draftDesktopSettings.uiProfile.locked ||
+                            !draftDesktopSettings.uiProfile.enabled
+                          }
+                          onClick={() => applyExperiencePreset(level)}
+                        >
+                          {t(`settings.interface.level.${level}`)}
+                        </Button>
+                      ))}
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      {t("settings.interface.presetsHint")}
+                    </p>
+                  </div>
+                  <div className="space-y-3">
+                    <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      {t("settings.interface.dataSources")}
+                    </h4>
+                    {DATA_SOURCE_SECTION_ORDER.map((sectionId) => (
+                      <div key={sectionId} className="space-y-1.5">
+                        <h5 className="text-xs font-medium text-muted-foreground">
+                          {t(DATA_SOURCE_SECTION_LABEL_KEYS[sectionId])}
+                        </h5>
+                        <div className="grid gap-1.5 sm:grid-cols-2">
+                          {DATA_SOURCE_CATALOG.filter(
+                            (entry) => entry.section === sectionId,
+                          ).map((entry) => (
+                            <label
+                              key={entry.id}
+                              className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm"
+                            >
+                              <input
+                                className="h-4 w-4"
+                                type="checkbox"
+                                checked={
+                                  !draftDesktopSettings.uiProfile.hiddenDataSources.includes(
+                                    entry.id,
+                                  )
+                                }
+                                disabled={
+                                  draftDesktopSettings.uiProfile.locked ||
+                                  !draftDesktopSettings.uiProfile.enabled
+                                }
+                                onChange={(event) =>
+                                  toggleDataSourceHidden(
+                                    entry.id,
+                                    event.target.checked,
+                                  )
+                                }
+                              />
+                              <span>{t(entry.labelKey)}</span>
+                            </label>
+                          ))}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                  {profilePlugins.length > 0 ? (
+                    <div className="space-y-1.5">
+                      <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        {t("settings.interface.plugins")}
+                      </h4>
+                      <div className="grid gap-1.5 sm:grid-cols-2">
+                        {profilePlugins.map((plugin) => (
+                          <label
+                            key={plugin.id}
+                            className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm"
+                          >
+                            <input
+                              className="h-4 w-4"
+                              type="checkbox"
+                              checked={
+                                !draftDesktopSettings.uiProfile.hiddenPlugins.includes(
+                                  plugin.id,
+                                )
+                              }
+                              disabled={
+                                draftDesktopSettings.uiProfile.locked ||
+                                !draftDesktopSettings.uiProfile.enabled
+                              }
+                              onChange={(event) =>
+                                togglePluginHidden(plugin.id, event.target.checked)
+                              }
+                            />
+                            <span>{plugin.name}</span>
+                          </label>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
                 </div>
               ) : null}
               {section === "geocoding" ? (

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -599,6 +599,8 @@ export function SettingsDialog({
       level: DEFAULT_UI_PROFILE_SETTINGS.level,
       hiddenDataSources: [],
       hiddenPlugins: [],
+      hiddenMenus: [],
+      hiddenMenuItems: [],
     });
   };
 
@@ -620,13 +622,29 @@ export function SettingsDialog({
     const nextProjectName = draftProjectName.trim() || "Untitled Project";
     if (nextProjectName !== projectName) setProjectName(nextProjectName);
     setPreferences(normalized);
+    // When a level preset is still active, recompute its hidden lists from the
+    // current plugin registry at save time. The draft was snapshotted when the
+    // dialog opened, so this picks up any external plugins that loaded since
+    // (and keeps the result identical to applying the preset). A custom profile
+    // (level === null) carries the user's explicit toggles through unchanged.
+    const draftProfile = draftDesktopSettings.uiProfile;
+    const committedUiProfile =
+      draftProfile.level !== null
+        ? {
+            ...draftProfile,
+            ...presetHiddenSets(
+              draftProfile.level,
+              profilePlugins.map((plugin) => plugin.id),
+            ),
+          }
+        : draftProfile;
     // Plugin sources are managed live in the Manage Plugins dialog; preserve the
     // current store values and only update the layout from this dialog.
     setDesktopSettings({
       ...useDesktopSettingsStore.getState().desktopSettings,
       layout: draftDesktopSettings.layout,
       shareToken: draftDesktopSettings.shareToken,
-      uiProfile: draftDesktopSettings.uiProfile,
+      uiProfile: committedUiProfile,
     });
     setOpen(false);
   };
@@ -707,7 +725,7 @@ export function SettingsDialog({
           )}
           <DropdownMenuSub>
             <DropdownMenuSubTrigger>
-              <LayoutPanelTop className="mr-2 h-3.5 w-3.5" />
+              <LayoutPanelTop className="h-3.5 w-3.5" />
               {t("settings.section.layout")}
             </DropdownMenuSubTrigger>
             <DropdownMenuSubContent className="geolibre-layout-submenu w-40 sm:w-72">
@@ -771,7 +789,7 @@ export function SettingsDialog({
           </DropdownMenuSub>
           <DropdownMenuSub>
             <DropdownMenuSubTrigger>
-              <SlidersHorizontal className="mr-2 h-3.5 w-3.5" />
+              <SlidersHorizontal className="h-3.5 w-3.5" />
               {t("settings.section.interface")}
             </DropdownMenuSubTrigger>
             <DropdownMenuSubContent className="w-56">

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -60,6 +60,7 @@ import { Trans, useTranslation } from "react-i18next";
 import {
   DEFAULT_DESKTOP_LAYOUT_SETTINGS,
   DEFAULT_UI_PROFILE_SETTINGS,
+  EXPERIENCE_LEVELS,
   useDesktopSettingsStore,
   type DesktopSettings,
   type DesktopLayoutSettings,
@@ -1040,9 +1041,7 @@ export function SettingsDialog({
                       {t("settings.interface.presets")}
                     </h4>
                     <div className="flex flex-wrap gap-2">
-                      {(
-                        ["beginner", "intermediate", "advanced"] as const
-                      ).map((level) => (
+                      {EXPERIENCE_LEVELS.map((level) => (
                         <Button
                           key={level}
                           type="button"

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -69,7 +69,11 @@ import { useToolbarPanels } from "../../hooks/useToolbarPanels";
 import type { ThemeMode } from "../../hooks/useThemeMode";
 import { isTauri } from "../../lib/tauri-io";
 import { useDesktopSettingsStore } from "../../hooks/useDesktopSettings";
-import { isMenuVisible, isPluginVisible } from "../../lib/ui-profile";
+import {
+  MENU_MANAGED_PLUGIN_IDS,
+  isMenuVisible,
+  isPluginVisible,
+} from "../../lib/ui-profile";
 import { CommandPalette } from "../command/CommandPalette";
 import { KeyboardShortcutsDialog } from "../command/KeyboardShortcutsDialog";
 import { useGlobalShortcuts } from "../../hooks/useGlobalShortcuts";
@@ -192,13 +196,7 @@ export function TopToolbar({
   const profilePlugins = useMemo(
     () =>
       plugins
-        .filter(
-          (plugin) =>
-            plugin.id !== EFFECTS_PLUGIN_ID &&
-            plugin.id !== DIRECTIONS_PLUGIN_ID &&
-            plugin.id !== REVERSE_GEOCODE_PLUGIN_ID &&
-            plugin.id !== DECK_VIZ_PLUGIN_ID,
-        )
+        .filter((plugin) => !MENU_MANAGED_PLUGIN_IDS.has(plugin.id))
         .map((plugin) => ({ id: plugin.id, name: plugin.name })),
     [plugins],
   );

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -69,7 +69,7 @@ import { useToolbarPanels } from "../../hooks/useToolbarPanels";
 import type { ThemeMode } from "../../hooks/useThemeMode";
 import { isTauri } from "../../lib/tauri-io";
 import { useDesktopSettingsStore } from "../../hooks/useDesktopSettings";
-import { isPluginVisible } from "../../lib/ui-profile";
+import { isMenuVisible, isPluginVisible } from "../../lib/ui-profile";
 import { CommandPalette } from "../command/CommandPalette";
 import { KeyboardShortcutsDialog } from "../command/KeyboardShortcutsDialog";
 import { useGlobalShortcuts } from "../../hooks/useGlobalShortcuts";
@@ -760,72 +760,82 @@ export function TopToolbar({
           <span className="hidden sm:inline">{appTitle}</span>
         ) : null}
       </span>
-      <ProjectMenu
-        chrome={chrome}
-        collaborationEnabled={collaboration.enabled}
-        printPanel={panels.print}
-        onNewProject={() => setNewProjectDialogOpen(true)}
-        onOpenFromFile={() => void projectFiles.handleOpenFromFile()}
-        onOpenFromUrl={() => projectFiles.setProjectUrlDialogOpen(true)}
-        onOpenRecent={(path) => void projectFiles.handleOpenRecent(path)}
-        onSave={() => void projectFiles.handleSave()}
-        onSaveAs={() => void projectFiles.handleSaveAs()}
-        onShare={() => setShareDialogOpen(true)}
-        onCollaborate={() => setCollaborateDialogOpen(true)}
-        onPrintLayout={() => setPrintLayoutOpen(true)}
-        onDownloadOffline={() => setOfflineRegionOpen(true)}
-      />
-      <EditMenu chrome={chrome} />
+      {isMenuVisible(uiProfile, "project") && (
+        <ProjectMenu
+          chrome={chrome}
+          collaborationEnabled={collaboration.enabled}
+          printPanel={panels.print}
+          onNewProject={() => setNewProjectDialogOpen(true)}
+          onOpenFromFile={() => void projectFiles.handleOpenFromFile()}
+          onOpenFromUrl={() => projectFiles.setProjectUrlDialogOpen(true)}
+          onOpenRecent={(path) => void projectFiles.handleOpenRecent(path)}
+          onSave={() => void projectFiles.handleSave()}
+          onSaveAs={() => void projectFiles.handleSaveAs()}
+          onShare={() => setShareDialogOpen(true)}
+          onCollaborate={() => setCollaborateDialogOpen(true)}
+          onPrintLayout={() => setPrintLayoutOpen(true)}
+          onDownloadOffline={() => setOfflineRegionOpen(true)}
+        />
+      )}
+      {isMenuVisible(uiProfile, "edit") && <EditMenu chrome={chrome} />}
       <NewProjectDialog
         open={newProjectDialogOpen}
         onOpenChange={setNewProjectDialogOpen}
         onSaveCurrentProject={projectFiles.handleSave}
         onProjectCreated={resetRuntimeControlsForNewProject}
       />
-      <AddDataMenu
-        chrome={chrome}
-        addLayer={addLayer}
-        osmPbfBusy={osmPbf.busy}
-        onSetAddDataKind={setAddDataKind}
-        onAddGltfModel={() => {
-          setAddDataDeckVizKind("scenegraph");
-          setAddDataKind("deckgl-viz");
-        }}
-        onOpenOsmPbfDialog={() => osmPbf.setDialogOpen(true)}
-      />
-      <ProcessingMenu
-        chrome={chrome}
-        earthEnginePanel={panels.earthEngine}
-        onOpenNetworkTool={consent.openNetworkTool}
-        onOpenPlanetaryComputer={handleOpenPlanetaryComputer}
-        onOpenGeoreferencer={() => setGeoreferencerOpen(true)}
-      />
-      <ControlsMenu
-        chrome={chrome}
-        controlsVisible={controlsVisible}
-        panels={panels}
-        effectsActive={isActive(EFFECTS_PLUGIN_ID)}
-        directionsActive={isActive(DIRECTIONS_PLUGIN_ID)}
-        reverseGeocodeActive={isActive(REVERSE_GEOCODE_PLUGIN_ID)}
-        onToggleMapControl={toggleMapControl}
-        onToggleEffects={() => toggle(EFFECTS_PLUGIN_ID, appApi)}
-        getEffectsSettings={getEffectsSettings}
-        onPreviewEffectsSettings={previewEffectsSettings}
-        onCommitEffectsSettings={commitEffectsSettings}
-        onToggleDirections={consent.handleToggleDirections}
-        onToggleReverseGeocode={consent.handleToggleReverseGeocode}
-        onOpenFieldCollection={() => setFieldCollectionOpen(true)}
-      />
-      <PluginsMenu
-        chrome={chrome}
-        appApi={appApi}
-        plugins={plugins}
-        isActive={isActive}
-        toggle={toggle}
-        getMapControlPosition={getMapControlPosition}
-        setMapControlPosition={setMapControlPosition}
-        hiddenPluginIds={hiddenPluginIds}
-      />
+      {isMenuVisible(uiProfile, "addData") && (
+        <AddDataMenu
+          chrome={chrome}
+          addLayer={addLayer}
+          osmPbfBusy={osmPbf.busy}
+          onSetAddDataKind={setAddDataKind}
+          onAddGltfModel={() => {
+            setAddDataDeckVizKind("scenegraph");
+            setAddDataKind("deckgl-viz");
+          }}
+          onOpenOsmPbfDialog={() => osmPbf.setDialogOpen(true)}
+        />
+      )}
+      {isMenuVisible(uiProfile, "processing") && (
+        <ProcessingMenu
+          chrome={chrome}
+          earthEnginePanel={panels.earthEngine}
+          onOpenNetworkTool={consent.openNetworkTool}
+          onOpenPlanetaryComputer={handleOpenPlanetaryComputer}
+          onOpenGeoreferencer={() => setGeoreferencerOpen(true)}
+        />
+      )}
+      {isMenuVisible(uiProfile, "controls") && (
+        <ControlsMenu
+          chrome={chrome}
+          controlsVisible={controlsVisible}
+          panels={panels}
+          effectsActive={isActive(EFFECTS_PLUGIN_ID)}
+          directionsActive={isActive(DIRECTIONS_PLUGIN_ID)}
+          reverseGeocodeActive={isActive(REVERSE_GEOCODE_PLUGIN_ID)}
+          onToggleMapControl={toggleMapControl}
+          onToggleEffects={() => toggle(EFFECTS_PLUGIN_ID, appApi)}
+          getEffectsSettings={getEffectsSettings}
+          onPreviewEffectsSettings={previewEffectsSettings}
+          onCommitEffectsSettings={commitEffectsSettings}
+          onToggleDirections={consent.handleToggleDirections}
+          onToggleReverseGeocode={consent.handleToggleReverseGeocode}
+          onOpenFieldCollection={() => setFieldCollectionOpen(true)}
+        />
+      )}
+      {isMenuVisible(uiProfile, "plugins") && (
+        <PluginsMenu
+          chrome={chrome}
+          appApi={appApi}
+          plugins={plugins}
+          isActive={isActive}
+          toggle={toggle}
+          getMapControlPosition={getMapControlPosition}
+          setMapControlPosition={setMapControlPosition}
+          hiddenPluginIds={hiddenPluginIds}
+        />
+      )}
       <SettingsDialog
         buttonClassName={toolbarButtonClass}
         buttonSize={toolbarButtonSize}
@@ -886,18 +896,20 @@ export function TopToolbar({
           api={collaboration}
         />
       )}
-      <HelpMenu
-        chrome={chrome}
-        diagnosticsErrorCount={diagnosticsErrorCount}
-        onOpenCommandPalette={() => setCommandPaletteOpen(true)}
-        onOpenShortcuts={() => setShortcutsOpen(true)}
-        onOpenDiagnostics={onOpenDiagnostics}
-        onCheckForUpdates={() => {
-          setAboutOpen(true);
-          setCheckForUpdatesRequest((value) => value + 1);
-        }}
-        onAbout={() => setAboutOpen(true)}
-      />
+      {isMenuVisible(uiProfile, "help") && (
+        <HelpMenu
+          chrome={chrome}
+          diagnosticsErrorCount={diagnosticsErrorCount}
+          onOpenCommandPalette={() => setCommandPaletteOpen(true)}
+          onOpenShortcuts={() => setShortcutsOpen(true)}
+          onOpenDiagnostics={onOpenDiagnostics}
+          onCheckForUpdates={() => {
+            setAboutOpen(true);
+            setCheckForUpdatesRequest((value) => value + 1);
+          }}
+          onAbout={() => setAboutOpen(true)}
+        />
+      )}
       <AddDataDialog
         kind={addDataKind}
         mapControllerRef={mapControllerRef}

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -68,6 +68,8 @@ import { useProjectFileActions } from "../../hooks/useProjectFileActions";
 import { useToolbarPanels } from "../../hooks/useToolbarPanels";
 import type { ThemeMode } from "../../hooks/useThemeMode";
 import { isTauri } from "../../lib/tauri-io";
+import { useDesktopSettingsStore } from "../../hooks/useDesktopSettings";
+import { isPluginVisible } from "../../lib/ui-profile";
 import { CommandPalette } from "../command/CommandPalette";
 import { KeyboardShortcutsDialog } from "../command/KeyboardShortcutsDialog";
 import { useGlobalShortcuts } from "../../hooks/useGlobalShortcuts";
@@ -169,6 +171,37 @@ export function TopToolbar({
     previewEffectsSettings,
     commitEffectsSettings,
   } = usePluginRegistry();
+  // Plugin ids hidden by the active UI profile (issue #500). Recompute only when
+  // the profile changes so the Plugins menu can drop them.
+  const uiProfile = useDesktopSettingsStore(
+    (state) => state.desktopSettings.uiProfile,
+  );
+  const hiddenPluginIds = useMemo(
+    () =>
+      new Set(
+        plugins
+          .filter((plugin) => !isPluginVisible(uiProfile, plugin.id))
+          .map((plugin) => plugin.id),
+      ),
+    [plugins, uiProfile],
+  );
+  // Plugins the user can toggle from the Plugins menu, offered as visibility
+  // checkboxes in Settings → Interface. Excludes the four plugins that are
+  // toggled elsewhere (Effects/Directions/Reverse Geocode via Controls, deck.gl
+  // viz via Add Data), matching PluginsMenu's skip list.
+  const profilePlugins = useMemo(
+    () =>
+      plugins
+        .filter(
+          (plugin) =>
+            plugin.id !== EFFECTS_PLUGIN_ID &&
+            plugin.id !== DIRECTIONS_PLUGIN_ID &&
+            plugin.id !== REVERSE_GEOCODE_PLUGIN_ID &&
+            plugin.id !== DECK_VIZ_PLUGIN_ID,
+        )
+        .map((plugin) => ({ id: plugin.id, name: plugin.name })),
+    [plugins],
+  );
   // mapControllerRef is a stable ref object and createAppAPI dereferences
   // `.current` lazily, so memoizing on the ref keeps a single appApi identity
   // across renders without going stale.
@@ -791,6 +824,7 @@ export function TopToolbar({
         toggle={toggle}
         getMapControlPosition={getMapControlPosition}
         setMapControlPosition={setMapControlPosition}
+        hiddenPluginIds={hiddenPluginIds}
       />
       <SettingsDialog
         buttonClassName={toolbarButtonClass}
@@ -799,6 +833,7 @@ export function TopToolbar({
         mapControllerRef={mapControllerRef}
         showLabels={showLabels}
         onOpenManagePlugins={() => setManagePluginsOpen(true)}
+        profilePlugins={profilePlugins}
       />
       <ManagePluginsDialog
         open={managePluginsOpen}

--- a/apps/geolibre-desktop/src/components/layout/toolbar/AddDataMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/AddDataMenu.tsx
@@ -70,6 +70,8 @@ export function AddDataMenu({
     stac: { onSelect: addLayer.stac },
     video: { onSelect: () => onSetAddDataKind("video") },
     "deckgl-viz": { onSelect: () => onSetAddDataKind("deckgl-viz") },
+    // GeoParquet loads through the same vector file picker as "vector"; keep
+    // both pointing at addLayer.vector if that handler ever changes.
     geoparquet: { onSelect: addLayer.vector },
     flatgeobuf: { onSelect: addLayer.flatGeobuf },
     pmtiles: { onSelect: addLayer.pmtiles },

--- a/apps/geolibre-desktop/src/components/layout/toolbar/AddDataMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/AddDataMenu.tsx
@@ -8,10 +8,17 @@ import {
   DropdownMenuTrigger,
 } from "@geolibre/ui";
 import { Database } from "lucide-react";
-import { useMemo } from "react";
+import { Fragment, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import type { AddDataKind } from "../AddDataDialog";
 import { isMobile } from "../../../lib/is-mobile";
+import { useDesktopSettingsStore } from "../../../hooks/useDesktopSettings";
+import {
+  DATA_SOURCE_CATALOG,
+  DATA_SOURCE_SECTION_LABEL_KEYS,
+  DATA_SOURCE_SECTION_ORDER,
+  isDataSourceVisible,
+} from "../../../lib/ui-profile";
 import type { AddLayerHandlers, ToolbarChrome } from "./constants";
 
 interface AddDataMenuProps {
@@ -21,6 +28,11 @@ interface AddDataMenuProps {
   onSetAddDataKind: (kind: AddDataKind) => void;
   onAddGltfModel: () => void;
   onOpenOsmPbfDialog: () => void;
+}
+
+interface AddDataItem {
+  onSelect: () => void;
+  disabled?: boolean;
 }
 
 /** The Add Data menu: files, web services, cloud formats, 3D layers, databases. */
@@ -33,10 +45,56 @@ export function AddDataMenu({
   onOpenOsmPbfDialog,
 }: AddDataMenuProps) {
   const { t } = useTranslation();
+  const uiProfile = useDesktopSettingsStore(
+    (state) => state.desktopSettings.uiProfile,
+  );
   // PostgreSQL layers are served through the Martin tile server, a local helper
   // binary with no Android build, so hide the source on mobile.
   // The user agent is stable for the session, so evaluate once.
   const mobile = useMemo(() => isMobile(), []);
+
+  // Map each catalog id to its dispatch. Kept here (not in the catalog) so the
+  // handlers stay in scope; the catalog only owns ids, sections, and tiers.
+  const handlers: Record<string, AddDataItem> = {
+    vector: { onSelect: addLayer.vector },
+    raster: { onSelect: addLayer.raster },
+    "delimited-text": { onSelect: () => onSetAddDataKind("delimited-text") },
+    gpx: { onSelect: () => onSetAddDataKind("gpx") },
+    mbtiles: { onSelect: () => onSetAddDataKind("mbtiles") },
+    "osm-pbf": { onSelect: onOpenOsmPbfDialog, disabled: osmPbfBusy },
+    xyz: { onSelect: () => onSetAddDataKind("xyz") },
+    wms: { onSelect: () => onSetAddDataKind("wms") },
+    wfs: { onSelect: () => onSetAddDataKind("wfs") },
+    wmts: { onSelect: () => onSetAddDataKind("wmts") },
+    arcgis: { onSelect: () => onSetAddDataKind("arcgis") },
+    stac: { onSelect: addLayer.stac },
+    video: { onSelect: () => onSetAddDataKind("video") },
+    "deckgl-viz": { onSelect: () => onSetAddDataKind("deckgl-viz") },
+    geoparquet: { onSelect: addLayer.vector },
+    flatgeobuf: { onSelect: addLayer.flatGeobuf },
+    pmtiles: { onSelect: addLayer.pmtiles },
+    zarr: { onSelect: addLayer.zarr },
+    netcdf: { onSelect: addLayer.netcdf },
+    lidar: { onSelect: addLayer.lidar },
+    splatting: { onSelect: addLayer.splatting },
+    "3d-tiles": { onSelect: addLayer.threeDTiles },
+    "gltf-model": { onSelect: onAddGltfModel },
+    duckdb: { onSelect: addLayer.duckdb },
+    postgres: { onSelect: () => onSetAddDataKind("postgres") },
+  };
+
+  // Each rendered section is the catalog entries it owns, filtered by the UI
+  // profile (and the mobile rule for postgres). Sections with no visible items
+  // are dropped along with their header/separator.
+  const sections = DATA_SOURCE_SECTION_ORDER.map((section) => ({
+    section,
+    entries: DATA_SOURCE_CATALOG.filter(
+      (entry) =>
+        entry.section === section &&
+        isDataSourceVisible(uiProfile, entry.id) &&
+        !(entry.id === "postgres" && mobile),
+    ),
+  })).filter((group) => group.entries.length > 0);
 
   return (
     <DropdownMenu>
@@ -54,102 +112,27 @@ export function AddDataMenu({
       <DropdownMenuContent align="start" className="w-64">
         <DropdownMenuLabel>{t("toolbar.menu.addData")}</DropdownMenuLabel>
         <DropdownMenuSeparator />
-        <DropdownMenuLabel className="text-xs text-muted-foreground">
-          {t("toolbar.item.sectionFiles")}
-        </DropdownMenuLabel>
-        <DropdownMenuItem onSelect={addLayer.vector}>
-          {t("toolbar.item.vectorLayer")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={addLayer.raster}>
-          {t("toolbar.item.rasterLayer")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={() => onSetAddDataKind("delimited-text")}>
-          {t("toolbar.layerType.delimitedText")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={() => onSetAddDataKind("gpx")}>
-          {t("toolbar.layerType.gpx")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={() => onSetAddDataKind("mbtiles")}>
-          {t("toolbar.layerType.mbtiles")}
-        </DropdownMenuItem>
-        <DropdownMenuItem disabled={osmPbfBusy} onSelect={onOpenOsmPbfDialog}>
-          {t("toolbar.item.osmPbfLayer")}
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuLabel className="text-xs text-muted-foreground">
-          {t("toolbar.item.sectionWebServices")}
-        </DropdownMenuLabel>
-        <DropdownMenuItem onSelect={() => onSetAddDataKind("xyz")}>
-          {t("toolbar.layerType.xyz")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={() => onSetAddDataKind("wms")}>
-          {t("toolbar.layerType.wms")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={() => onSetAddDataKind("wfs")}>
-          {t("toolbar.layerType.wfs")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={() => onSetAddDataKind("wmts")}>
-          {t("toolbar.layerType.wmts")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={() => onSetAddDataKind("arcgis")}>
-          {t("toolbar.layerType.arcgis")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={addLayer.stac}>
-          {t("toolbar.item.stacLayer")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={() => onSetAddDataKind("video")}>
-          {t("toolbar.layerType.video")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={() => onSetAddDataKind("deckgl-viz")}>
-          {t("toolbar.layerType.deckglViz")}
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuLabel className="text-xs text-muted-foreground">
-          {t("toolbar.item.sectionCloudFormats")}
-        </DropdownMenuLabel>
-        <DropdownMenuItem onSelect={addLayer.vector}>
-          {t("toolbar.item.geoparquetLayer")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={addLayer.flatGeobuf}>
-          {t("toolbar.item.flatgeobufLayer")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={addLayer.pmtiles}>
-          {t("toolbar.item.pmtilesLayer")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={addLayer.zarr}>
-          {t("toolbar.item.zarrLayer")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={addLayer.netcdf}>
-          {t("toolbar.item.netcdfHdf")}
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuLabel className="text-xs text-muted-foreground">
-          {t("toolbar.item.section3dLayers")}
-        </DropdownMenuLabel>
-        <DropdownMenuItem onSelect={addLayer.lidar}>
-          {t("toolbar.item.lidarLayer")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={addLayer.splatting}>
-          {t("toolbar.item.splattingLayer")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={addLayer.threeDTiles}>
-          {t("toolbar.item.threeDTilesLayer")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={onAddGltfModel}>
-          {t("toolbar.layerType.gltfModel")}
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuLabel className="text-xs text-muted-foreground">
-          {t("toolbar.item.sectionDatabases")}
-        </DropdownMenuLabel>
-        <DropdownMenuItem onSelect={addLayer.duckdb}>
-          {t("toolbar.item.duckdbLayer")}
-        </DropdownMenuItem>
-        {!mobile && (
-          <DropdownMenuItem onSelect={() => onSetAddDataKind("postgres")}>
-            {t("toolbar.layerType.postgres")}
-          </DropdownMenuItem>
-        )}
+        {sections.map((group, index) => (
+          <Fragment key={group.section}>
+            {index > 0 ? <DropdownMenuSeparator /> : null}
+            <DropdownMenuLabel className="text-xs text-muted-foreground">
+              {t(DATA_SOURCE_SECTION_LABEL_KEYS[group.section])}
+            </DropdownMenuLabel>
+            {group.entries.map((entry) => {
+              const item = handlers[entry.id];
+              if (!item) return null;
+              return (
+                <DropdownMenuItem
+                  key={entry.id}
+                  disabled={item.disabled}
+                  onSelect={item.onSelect}
+                >
+                  {t(entry.labelKey)}
+                </DropdownMenuItem>
+              );
+            })}
+          </Fragment>
+        ))}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ControlsMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ControlsMenu.tsx
@@ -24,6 +24,8 @@ import { ClipboardList, SlidersHorizontal } from "lucide-react";
 import { type MouseEvent as ReactMouseEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { ToolbarPanels } from "../../../hooks/useToolbarPanels";
+import { useDesktopSettingsStore } from "../../../hooks/useDesktopSettings";
+import { isMenuItemVisible } from "../../../lib/ui-profile";
 import {
   MAP_CONTROL_ITEMS,
   type ToolbarChrome,
@@ -65,6 +67,8 @@ export function ControlsMenu({
   onOpenFieldCollection,
 }: ControlsMenuProps) {
   const { t } = useTranslation();
+  const uiProfile = useDesktopSettingsStore((s) => s.desktopSettings.uiProfile);
+  const show = (id: string) => isMenuItemVisible(uiProfile, id);
 
   return (
     <DropdownMenu>
@@ -82,7 +86,9 @@ export function ControlsMenu({
       <DropdownMenuContent align="start">
         <DropdownMenuLabel>{t("toolbar.item.mapControls")}</DropdownMenuLabel>
         <DropdownMenuSeparator />
-        {MAP_CONTROL_ITEMS.map((control) => (
+        {MAP_CONTROL_ITEMS.filter((control) =>
+          show(`controls.mapControl.${control.id}`),
+        ).map((control) => (
           <DropdownMenuItem
             key={control.id}
             onClick={() => onToggleMapControl(control.id)}
@@ -91,65 +97,91 @@ export function ControlsMenu({
             {controlsVisible[control.id] ? " ✓" : ""}
           </DropdownMenuItem>
         ))}
-        <AtmosphereEffectsSubmenu
-          active={effectsActive}
-          onToggle={onToggleEffects}
-          getSettings={getEffectsSettings}
-          onPreview={onPreviewEffectsSettings}
-          onCommit={onCommitEffectsSettings}
-        />
-        <DropdownMenuItem
-          title={t("toolbar.item.directionsTooltip")}
-          onClick={onToggleDirections}
-        >
-          {t("toolbar.item.directions")}
-          {directionsActive ? " ✓" : ""}
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          title={t("toolbar.item.reverseGeocodeTooltip")}
-          onClick={onToggleReverseGeocode}
-        >
-          {t("toolbar.item.reverseGeocode")}
-          {reverseGeocodeActive ? " ✓" : ""}
-        </DropdownMenuItem>
+        {show("controls.atmosphereEffects") && (
+          <AtmosphereEffectsSubmenu
+            active={effectsActive}
+            onToggle={onToggleEffects}
+            getSettings={getEffectsSettings}
+            onPreview={onPreviewEffectsSettings}
+            onCommit={onCommitEffectsSettings}
+          />
+        )}
+        {show("controls.directions") && (
+          <DropdownMenuItem
+            title={t("toolbar.item.directionsTooltip")}
+            onClick={onToggleDirections}
+          >
+            {t("toolbar.item.directions")}
+            {directionsActive ? " ✓" : ""}
+          </DropdownMenuItem>
+        )}
+        {show("controls.reverseGeocode") && (
+          <DropdownMenuItem
+            title={t("toolbar.item.reverseGeocodeTooltip")}
+            onClick={onToggleReverseGeocode}
+          >
+            {t("toolbar.item.reverseGeocode")}
+            {reverseGeocodeActive ? " ✓" : ""}
+          </DropdownMenuItem>
+        )}
         <DropdownMenuSeparator />
-        <DropdownMenuItem onSelect={panels.searchPlaces.toggle}>
-          {t("toolbar.item.search")}
-          {panels.searchPlaces.visible ? " ✓" : ""}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={panels.colorbar.toggle}>
-          {t("toolbar.item.colorbar")}
-          {panels.colorbar.visible ? " ✓" : ""}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={panels.legend.toggle}>
-          {t("toolbar.item.legend")}
-          {panels.legend.visible ? " ✓" : ""}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={panels.html.toggle}>
-          {t("toolbar.item.html")}
-          {panels.html.visible ? " ✓" : ""}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={panels.measure.toggle}>
-          {t("toolbar.item.measure")}
-          {panels.measure.visible ? " ✓" : ""}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={panels.bookmark.toggle}>
-          {t("toolbar.item.bookmark")}
-          {panels.bookmark.visible ? " ✓" : ""}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={panels.minimap.toggle}>
-          {t("toolbar.item.minimap")}
-          {panels.minimap.visible ? " ✓" : ""}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={panels.viewState.toggle}>
-          {t("toolbar.item.viewState")}
-          {panels.viewState.visible ? " ✓" : ""}
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem onSelect={onOpenFieldCollection}>
-          <ClipboardList className="mr-2 h-3.5 w-3.5" />
-          {t("toolbar.item.fieldCollection")}
-        </DropdownMenuItem>
+        {show("controls.search") && (
+          <DropdownMenuItem onSelect={panels.searchPlaces.toggle}>
+            {t("toolbar.item.search")}
+            {panels.searchPlaces.visible ? " ✓" : ""}
+          </DropdownMenuItem>
+        )}
+        {show("controls.colorbar") && (
+          <DropdownMenuItem onSelect={panels.colorbar.toggle}>
+            {t("toolbar.item.colorbar")}
+            {panels.colorbar.visible ? " ✓" : ""}
+          </DropdownMenuItem>
+        )}
+        {show("controls.legend") && (
+          <DropdownMenuItem onSelect={panels.legend.toggle}>
+            {t("toolbar.item.legend")}
+            {panels.legend.visible ? " ✓" : ""}
+          </DropdownMenuItem>
+        )}
+        {show("controls.html") && (
+          <DropdownMenuItem onSelect={panels.html.toggle}>
+            {t("toolbar.item.html")}
+            {panels.html.visible ? " ✓" : ""}
+          </DropdownMenuItem>
+        )}
+        {show("controls.measure") && (
+          <DropdownMenuItem onSelect={panels.measure.toggle}>
+            {t("toolbar.item.measure")}
+            {panels.measure.visible ? " ✓" : ""}
+          </DropdownMenuItem>
+        )}
+        {show("controls.bookmark") && (
+          <DropdownMenuItem onSelect={panels.bookmark.toggle}>
+            {t("toolbar.item.bookmark")}
+            {panels.bookmark.visible ? " ✓" : ""}
+          </DropdownMenuItem>
+        )}
+        {show("controls.minimap") && (
+          <DropdownMenuItem onSelect={panels.minimap.toggle}>
+            {t("toolbar.item.minimap")}
+            {panels.minimap.visible ? " ✓" : ""}
+          </DropdownMenuItem>
+        )}
+        {show("controls.viewState") && (
+          <DropdownMenuItem onSelect={panels.viewState.toggle}>
+            {t("toolbar.item.viewState")}
+            {panels.viewState.visible ? " ✓" : ""}
+          </DropdownMenuItem>
+        )}
+        {show("controls.fieldCollection") && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={onOpenFieldCollection}>
+              <ClipboardList className="mr-2 h-3.5 w-3.5" />
+              {t("toolbar.item.fieldCollection")}
+            </DropdownMenuItem>
+          </>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ControlsMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ControlsMenu.tsx
@@ -69,6 +69,15 @@ export function ControlsMenu({
   const { t } = useTranslation();
   const uiProfile = useDesktopSettingsStore((s) => s.desktopSettings.uiProfile);
   const show = (id: string) => isMenuItemVisible(uiProfile, id);
+  // Whether the first group (built-in controls + atmosphere/routing toggles) has
+  // any visible item, so the separator below it isn't left orphaned.
+  const anyTopControls =
+    MAP_CONTROL_ITEMS.some((control) =>
+      show(`controls.mapControl.${control.id}`),
+    ) ||
+    show("controls.atmosphereEffects") ||
+    show("controls.directions") ||
+    show("controls.reverseGeocode");
 
   return (
     <DropdownMenu>
@@ -124,7 +133,7 @@ export function ControlsMenu({
             {reverseGeocodeActive ? " ✓" : ""}
           </DropdownMenuItem>
         )}
-        <DropdownMenuSeparator />
+        {anyTopControls && <DropdownMenuSeparator />}
         {show("controls.search") && (
           <DropdownMenuItem onSelect={panels.searchPlaces.toggle}>
             {t("toolbar.item.search")}

--- a/apps/geolibre-desktop/src/components/layout/toolbar/EditMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/EditMenu.tsx
@@ -12,6 +12,8 @@ import {
 import { Pencil, Redo2, Undo2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useStore } from "zustand";
+import { useDesktopSettingsStore } from "../../../hooks/useDesktopSettings";
+import { isMenuItemVisible } from "../../../lib/ui-profile";
 import type { ToolbarChrome } from "./constants";
 
 interface EditMenuProps {
@@ -29,6 +31,8 @@ export function EditMenu({ chrome }: EditMenuProps) {
     useAppStore.temporal,
     (s) => s.futureStates.length > 0,
   );
+  const uiProfile = useDesktopSettingsStore((s) => s.desktopSettings.uiProfile);
+  const show = (id: string) => isMenuItemVisible(uiProfile, id);
 
   return (
     <DropdownMenu>
@@ -46,16 +50,22 @@ export function EditMenu({ chrome }: EditMenuProps) {
       <DropdownMenuContent align="start" className="min-w-56">
         <DropdownMenuLabel>{t("toolbar.menu.edit")}</DropdownMenuLabel>
         <DropdownMenuSeparator />
-        <DropdownMenuItem disabled={!canUndo} onSelect={undo}>
-          <Undo2 className="mr-2 h-3.5 w-3.5 shrink-0" />
-          <span className="whitespace-nowrap">{t("toolbar.item.undo")}</span>
-          <DropdownMenuShortcut>Ctrl/Cmd+Z</DropdownMenuShortcut>
-        </DropdownMenuItem>
-        <DropdownMenuItem disabled={!canRedo} onSelect={redo}>
-          <Redo2 className="mr-2 h-3.5 w-3.5 shrink-0" />
-          <span className="whitespace-nowrap">{t("toolbar.item.redo")}</span>
-          <DropdownMenuShortcut>Ctrl/Cmd+Shift+Z / Ctrl+Y</DropdownMenuShortcut>
-        </DropdownMenuItem>
+        {show("edit.undo") && (
+          <DropdownMenuItem disabled={!canUndo} onSelect={undo}>
+            <Undo2 className="mr-2 h-3.5 w-3.5 shrink-0" />
+            <span className="whitespace-nowrap">{t("toolbar.item.undo")}</span>
+            <DropdownMenuShortcut>Ctrl/Cmd+Z</DropdownMenuShortcut>
+          </DropdownMenuItem>
+        )}
+        {show("edit.redo") && (
+          <DropdownMenuItem disabled={!canRedo} onSelect={redo}>
+            <Redo2 className="mr-2 h-3.5 w-3.5 shrink-0" />
+            <span className="whitespace-nowrap">{t("toolbar.item.redo")}</span>
+            <DropdownMenuShortcut>
+              Ctrl/Cmd+Shift+Z / Ctrl+Y
+            </DropdownMenuShortcut>
+          </DropdownMenuItem>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/geolibre-desktop/src/components/layout/toolbar/HelpMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/HelpMenu.tsx
@@ -17,6 +17,8 @@ import {
   Search,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { useDesktopSettingsStore } from "../../../hooks/useDesktopSettings";
+import { isMenuItemVisible } from "../../../lib/ui-profile";
 import { FEEDBACK_URL, openExternalLink, type ToolbarChrome } from "./constants";
 
 interface HelpMenuProps {
@@ -40,6 +42,8 @@ export function HelpMenu({
   onAbout,
 }: HelpMenuProps) {
   const { t } = useTranslation();
+  const uiProfile = useDesktopSettingsStore((s) => s.desktopSettings.uiProfile);
+  const show = (id: string) => isMenuItemVisible(uiProfile, id);
 
   return (
     <DropdownMenu>
@@ -57,36 +61,48 @@ export function HelpMenu({
       <DropdownMenuContent align="start">
         <DropdownMenuLabel>{t("toolbar.menu.help")}</DropdownMenuLabel>
         <DropdownMenuSeparator />
-        <DropdownMenuItem onSelect={onOpenCommandPalette}>
-          <Search className="mr-2 h-3.5 w-3.5" />
-          {t("toolbar.item.commandPalette")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={onOpenShortcuts}>
-          <Keyboard className="mr-2 h-3.5 w-3.5" />
-          {t("toolbar.command.keyboardShortcuts")}
-        </DropdownMenuItem>
+        {show("help.commandPalette") && (
+          <DropdownMenuItem onSelect={onOpenCommandPalette}>
+            <Search className="mr-2 h-3.5 w-3.5" />
+            {t("toolbar.item.commandPalette")}
+          </DropdownMenuItem>
+        )}
+        {show("help.keyboardShortcuts") && (
+          <DropdownMenuItem onSelect={onOpenShortcuts}>
+            <Keyboard className="mr-2 h-3.5 w-3.5" />
+            {t("toolbar.command.keyboardShortcuts")}
+          </DropdownMenuItem>
+        )}
         <DropdownMenuSeparator />
-        <DropdownMenuItem onSelect={onOpenDiagnostics}>
-          <Bug className="mr-2 h-3.5 w-3.5" />
-          {t("toolbar.command.diagnostics")}
-          {diagnosticsErrorCount > 0 ? (
-            <span className="ml-2 rounded bg-destructive px-1.5 py-0.5 text-[10px] leading-none text-destructive-foreground">
-              {diagnosticsErrorCount}
-            </span>
-          ) : null}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={() => void openExternalLink(FEEDBACK_URL)}>
-          <MessageSquare className="mr-2 h-3.5 w-3.5" />
-          {t("toolbar.command.giveFeedback")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={onCheckForUpdates}>
-          <RefreshCw className="mr-2 h-3.5 w-3.5" />
-          {t("toolbar.command.checkForUpdates")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={onAbout}>
-          <Info className="mr-2 h-3.5 w-3.5" />
-          {t("toolbar.command.about")}
-        </DropdownMenuItem>
+        {show("help.diagnostics") && (
+          <DropdownMenuItem onSelect={onOpenDiagnostics}>
+            <Bug className="mr-2 h-3.5 w-3.5" />
+            {t("toolbar.command.diagnostics")}
+            {diagnosticsErrorCount > 0 ? (
+              <span className="ml-2 rounded bg-destructive px-1.5 py-0.5 text-[10px] leading-none text-destructive-foreground">
+                {diagnosticsErrorCount}
+              </span>
+            ) : null}
+          </DropdownMenuItem>
+        )}
+        {show("help.feedback") && (
+          <DropdownMenuItem onSelect={() => void openExternalLink(FEEDBACK_URL)}>
+            <MessageSquare className="mr-2 h-3.5 w-3.5" />
+            {t("toolbar.command.giveFeedback")}
+          </DropdownMenuItem>
+        )}
+        {show("help.checkForUpdates") && (
+          <DropdownMenuItem onSelect={onCheckForUpdates}>
+            <RefreshCw className="mr-2 h-3.5 w-3.5" />
+            {t("toolbar.command.checkForUpdates")}
+          </DropdownMenuItem>
+        )}
+        {show("help.about") && (
+          <DropdownMenuItem onSelect={onAbout}>
+            <Info className="mr-2 h-3.5 w-3.5" />
+            {t("toolbar.command.about")}
+          </DropdownMenuItem>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/geolibre-desktop/src/components/layout/toolbar/HelpMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/HelpMenu.tsx
@@ -73,7 +73,9 @@ export function HelpMenu({
             {t("toolbar.command.keyboardShortcuts")}
           </DropdownMenuItem>
         )}
-        <DropdownMenuSeparator />
+        {(show("help.commandPalette") || show("help.keyboardShortcuts")) && (
+          <DropdownMenuSeparator />
+        )}
         {show("help.diagnostics") && (
           <DropdownMenuItem onSelect={onOpenDiagnostics}>
             <Bug className="mr-2 h-3.5 w-3.5" />

--- a/apps/geolibre-desktop/src/components/layout/toolbar/PluginsMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/PluginsMenu.tsx
@@ -154,8 +154,10 @@ export function PluginsMenu({
           if (!WEB_SERVICE_PLUGIN_ID_SET.has(p.id)) {
             return renderPluginMenuItem(p);
           }
-          // All web service plugins hidden ⇒ skip the grouped submenu entirely.
-          if (webServicePlugins.length === 0) return null;
+          // Reaching here means `p` is a visible web service plugin, so the
+          // submenu has at least one entry. When all web service plugins are
+          // hidden no plugin reaches this branch and the submenu simply never
+          // renders.
           if (webServicesRendered) return null;
           webServicesRendered = true;
           return (

--- a/apps/geolibre-desktop/src/components/layout/toolbar/PluginsMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/PluginsMenu.tsx
@@ -43,6 +43,8 @@ interface PluginsMenuProps {
   toggle: PluginRegistry["toggle"];
   getMapControlPosition: PluginRegistry["getMapControlPosition"];
   setMapControlPosition: PluginRegistry["setMapControlPosition"];
+  /** Plugin ids hidden by the active UI profile (issue #500). */
+  hiddenPluginIds: Set<string>;
 }
 
 /** The Plugins menu: one toggle per registered plugin, with position submenus. */
@@ -54,6 +56,7 @@ export function PluginsMenu({
   toggle,
   getMapControlPosition,
   setMapControlPosition,
+  hiddenPluginIds,
 }: PluginsMenuProps) {
   const { t } = useTranslation();
 
@@ -107,8 +110,8 @@ export function PluginsMenu({
     );
   };
 
-  const webServicePlugins = plugins.filter((p) =>
-    WEB_SERVICE_PLUGIN_ID_SET.has(p.id),
+  const webServicePlugins = plugins.filter(
+    (p) => WEB_SERVICE_PLUGIN_ID_SET.has(p.id) && !hiddenPluginIds.has(p.id),
   );
   // The web service plugins render as one grouped submenu, placed where the
   // first of them appears in registration order (just above Esri Wayback).
@@ -144,9 +147,15 @@ export function PluginsMenu({
           ) {
             return null;
           }
+          // Hidden by the active UI profile (issue #500).
+          if (hiddenPluginIds.has(p.id)) {
+            return null;
+          }
           if (!WEB_SERVICE_PLUGIN_ID_SET.has(p.id)) {
             return renderPluginMenuItem(p);
           }
+          // All web service plugins hidden ⇒ skip the grouped submenu entirely.
+          if (webServicePlugins.length === 0) return null;
           if (webServicesRendered) return null;
           webServicesRendered = true;
           return (

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
@@ -77,11 +77,13 @@ export function ProcessingMenu({
         <DropdownMenuLabel>{t("toolbar.menu.processing")}</DropdownMenuLabel>
         <DropdownMenuSeparator />
         {show("processing.assistant") && (
-          <DropdownMenuItem onSelect={() => setAssistantOpen(true)}>
-            {t("toolbar.command.assistant")}
-          </DropdownMenuItem>
+          <>
+            <DropdownMenuItem onSelect={() => setAssistantOpen(true)}>
+              {t("toolbar.command.assistant")}
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+          </>
         )}
-        <DropdownMenuSeparator />
         {!mobile && show("processing.whitebox") && (
           <DropdownMenuItem onSelect={() => setProcessingOpen(true)}>
             {t("toolbar.item.whitebox")}

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
@@ -16,6 +16,8 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import type { ToolbarPanel } from "../../../hooks/useToolbarPanels";
 import { isMobile } from "../../../lib/is-mobile";
+import { useDesktopSettingsStore } from "../../../hooks/useDesktopSettings";
+import { isMenuItemVisible } from "../../../lib/ui-profile";
 import type { ToolbarChrome } from "./constants";
 
 interface ProcessingMenuProps {
@@ -55,6 +57,8 @@ export function ProcessingMenu({
   // (Pyodide), geocode, statistics, and the assistant run client-side and stay.
   // The user agent is stable for the session, so evaluate once.
   const mobile = useMemo(() => isMobile(), []);
+  const uiProfile = useDesktopSettingsStore((s) => s.desktopSettings.uiProfile);
+  const show = (id: string) => isMenuItemVisible(uiProfile, id);
 
   return (
     <DropdownMenu>
@@ -72,34 +76,48 @@ export function ProcessingMenu({
       <DropdownMenuContent align="start">
         <DropdownMenuLabel>{t("toolbar.menu.processing")}</DropdownMenuLabel>
         <DropdownMenuSeparator />
-        <DropdownMenuItem onSelect={() => setAssistantOpen(true)}>
-          {t("toolbar.command.assistant")}
-        </DropdownMenuItem>
+        {show("processing.assistant") && (
+          <DropdownMenuItem onSelect={() => setAssistantOpen(true)}>
+            {t("toolbar.command.assistant")}
+          </DropdownMenuItem>
+        )}
         <DropdownMenuSeparator />
-        {!mobile && (
+        {!mobile && show("processing.whitebox") && (
           <DropdownMenuItem onSelect={() => setProcessingOpen(true)}>
             {t("toolbar.item.whitebox")}
           </DropdownMenuItem>
         )}
-        <DropdownMenuItem onSelect={() => setSqlWorkspaceOpen(true)}>
-          {t("toolbar.command.sqlWorkspace")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={() => setPythonConsoleOpen(true)}>
-          {t("toolbar.command.pythonConsole")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={() => setNotebookOpen(true)}>
-          {t("toolbar.command.notebook")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={() => setDashboardOpen(true)}>
-          {t("toolbar.command.dashboard")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={() => setGeocodeOpen(true)}>
-          {t("toolbar.item.geocode")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={() => setModelBuilderOpen(true)}>
-          {t("toolbar.item.modelBuilder")}
-        </DropdownMenuItem>
-        {!mobile && (
+        {show("processing.sqlWorkspace") && (
+          <DropdownMenuItem onSelect={() => setSqlWorkspaceOpen(true)}>
+            {t("toolbar.command.sqlWorkspace")}
+          </DropdownMenuItem>
+        )}
+        {show("processing.pythonConsole") && (
+          <DropdownMenuItem onSelect={() => setPythonConsoleOpen(true)}>
+            {t("toolbar.command.pythonConsole")}
+          </DropdownMenuItem>
+        )}
+        {show("processing.notebook") && (
+          <DropdownMenuItem onSelect={() => setNotebookOpen(true)}>
+            {t("toolbar.command.notebook")}
+          </DropdownMenuItem>
+        )}
+        {show("processing.dashboard") && (
+          <DropdownMenuItem onSelect={() => setDashboardOpen(true)}>
+            {t("toolbar.command.dashboard")}
+          </DropdownMenuItem>
+        )}
+        {show("processing.geocode") && (
+          <DropdownMenuItem onSelect={() => setGeocodeOpen(true)}>
+            {t("toolbar.item.geocode")}
+          </DropdownMenuItem>
+        )}
+        {show("processing.modelBuilder") && (
+          <DropdownMenuItem onSelect={() => setModelBuilderOpen(true)}>
+            {t("toolbar.item.modelBuilder")}
+          </DropdownMenuItem>
+        )}
+        {!mobile && show("processing.conversion") && (
         <DropdownMenuSub>
           <DropdownMenuSubTrigger>
             {t("toolbar.item.conversion")}
@@ -143,6 +161,7 @@ export function ProcessingMenu({
           </DropdownMenuSubContent>
         </DropdownMenuSub>
         )}
+        {show("processing.vector") && (
         <DropdownMenuSub>
           <DropdownMenuSubTrigger>
             {t("toolbar.item.vector")}
@@ -245,6 +264,8 @@ export function ProcessingMenu({
             </DropdownMenuItem>
           </DropdownMenuSubContent>
         </DropdownMenuSub>
+        )}
+        {show("processing.network") && (
         <DropdownMenuSub>
           <DropdownMenuSubTrigger>
             {t("toolbar.item.network")}
@@ -258,6 +279,8 @@ export function ProcessingMenu({
             </DropdownMenuItem>
           </DropdownMenuSubContent>
         </DropdownMenuSub>
+        )}
+        {show("processing.statistics") && (
         <DropdownMenuSub>
           <DropdownMenuSubTrigger>
             {t("toolbar.item.statistics")}
@@ -292,7 +315,8 @@ export function ProcessingMenu({
             </DropdownMenuItem>
           </DropdownMenuSubContent>
         </DropdownMenuSub>
-        {!mobile && (
+        )}
+        {!mobile && show("processing.raster") && (
         <DropdownMenuSub>
           <DropdownMenuSubTrigger>
             {t("toolbar.item.raster")}
@@ -376,18 +400,22 @@ export function ProcessingMenu({
           </DropdownMenuSubContent>
         </DropdownMenuSub>
         )}
-        {!mobile && (
+        {!mobile && show("processing.segmentation") && (
           <DropdownMenuItem onSelect={() => setSegmentationOpen(true)}>
             {t("toolbar.command.segmentation")}
           </DropdownMenuItem>
         )}
-        <DropdownMenuItem onSelect={onOpenPlanetaryComputer}>
-          {t("toolbar.command.planetaryComputer")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={earthEnginePanel.toggle}>
-          {t("toolbar.command.earthEngine")}
-          {earthEnginePanel.visible ? " ✓" : ""}
-        </DropdownMenuItem>
+        {show("processing.planetaryComputer") && (
+          <DropdownMenuItem onSelect={onOpenPlanetaryComputer}>
+            {t("toolbar.command.planetaryComputer")}
+          </DropdownMenuItem>
+        )}
+        {show("processing.earthEngine") && (
+          <DropdownMenuItem onSelect={earthEnginePanel.toggle}>
+            {t("toolbar.command.earthEngine")}
+            {earthEnginePanel.visible ? " ✓" : ""}
+          </DropdownMenuItem>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProjectMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProjectMenu.tsx
@@ -30,6 +30,8 @@ import {
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { ToolbarPanel } from "../../../hooks/useToolbarPanels";
+import { useDesktopSettingsStore } from "../../../hooks/useDesktopSettings";
+import { isMenuItemVisible } from "../../../lib/ui-profile";
 import { formatRecentProjectTime, type ToolbarChrome } from "./constants";
 
 interface ProjectMenuProps {
@@ -70,6 +72,8 @@ export function ProjectMenu({
   const forgetRecentProject = useAppStore((s) => s.forgetRecentProject);
   const clearRecentProjects = useAppStore((s) => s.clearRecentProjects);
   const setStorymapPanelOpen = useAppStore((s) => s.setStorymapPanelOpen);
+  const uiProfile = useDesktopSettingsStore((s) => s.desktopSettings.uiProfile);
+  const show = (id: string) => isMenuItemVisible(uiProfile, id);
 
   return (
     <DropdownMenu>
@@ -87,26 +91,31 @@ export function ProjectMenu({
       <DropdownMenuContent align="start" className="w-64">
         <DropdownMenuLabel>{t("toolbar.menu.project")}</DropdownMenuLabel>
         <DropdownMenuSeparator />
-        <DropdownMenuItem onSelect={onNewProject}>
-          <FilePlus2 className="mr-2 h-3.5 w-3.5" />
-          {t("toolbar.item.newEllipsis")}
-        </DropdownMenuItem>
-        <DropdownMenuSub>
-          <DropdownMenuSubTrigger>
-            <FolderOpen className="mr-2 h-3.5 w-3.5" />
-            {t("toolbar.item.openFrom")}
-          </DropdownMenuSubTrigger>
-          <DropdownMenuSubContent>
-            <DropdownMenuItem onSelect={onOpenFromFile}>
-              <FileText className="mr-2 h-3.5 w-3.5" />
-              {t("toolbar.item.fileEllipsis")}
-            </DropdownMenuItem>
-            <DropdownMenuItem onSelect={onOpenFromUrl}>
-              <Link2 className="mr-2 h-3.5 w-3.5" />
-              {t("toolbar.item.urlEllipsis")}
-            </DropdownMenuItem>
-          </DropdownMenuSubContent>
-        </DropdownMenuSub>
+        {show("project.new") && (
+          <DropdownMenuItem onSelect={onNewProject}>
+            <FilePlus2 className="mr-2 h-3.5 w-3.5" />
+            {t("toolbar.item.newEllipsis")}
+          </DropdownMenuItem>
+        )}
+        {show("project.openFrom") && (
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              <FolderOpen className="mr-2 h-3.5 w-3.5" />
+              {t("toolbar.item.openFrom")}
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              <DropdownMenuItem onSelect={onOpenFromFile}>
+                <FileText className="mr-2 h-3.5 w-3.5" />
+                {t("toolbar.item.fileEllipsis")}
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={onOpenFromUrl}>
+                <Link2 className="mr-2 h-3.5 w-3.5" />
+                {t("toolbar.item.urlEllipsis")}
+              </DropdownMenuItem>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        )}
+        {show("project.openRecent") && (
         <DropdownMenuSub>
           <DropdownMenuSubTrigger disabled={recentProjects.length === 0}>
             <History className="mr-2 h-3.5 w-3.5" />
@@ -176,44 +185,61 @@ export function ProjectMenu({
             </DropdownMenuItem>
           </DropdownMenuSubContent>
         </DropdownMenuSub>
+        )}
         <DropdownMenuSeparator />
-        <DropdownMenuItem onSelect={onSave}>
-          <Save className="mr-2 h-3.5 w-3.5" />
-          {t("common.save")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={onSaveAs}>
-          <FilePen className="mr-2 h-3.5 w-3.5" />
-          {t("toolbar.item.saveAsEllipsis")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={onShare}>
-          <Share2 className="mr-2 h-3.5 w-3.5" />
-          {t("toolbar.item.shareEllipsis")}
-        </DropdownMenuItem>
-        {collaborationEnabled && (
+        {show("project.save") && (
+          <DropdownMenuItem onSelect={onSave}>
+            <Save className="mr-2 h-3.5 w-3.5" />
+            {t("common.save")}
+          </DropdownMenuItem>
+        )}
+        {show("project.saveAs") && (
+          <DropdownMenuItem onSelect={onSaveAs}>
+            <FilePen className="mr-2 h-3.5 w-3.5" />
+            {t("toolbar.item.saveAsEllipsis")}
+          </DropdownMenuItem>
+        )}
+        {show("project.share") && (
+          <DropdownMenuItem onSelect={onShare}>
+            <Share2 className="mr-2 h-3.5 w-3.5" />
+            {t("toolbar.item.shareEllipsis")}
+          </DropdownMenuItem>
+        )}
+        {collaborationEnabled && show("project.collaborate") && (
           <DropdownMenuItem onSelect={onCollaborate}>
             <Users className="mr-2 h-3.5 w-3.5" />
             {t("toolbar.item.collaborateEllipsis")}
           </DropdownMenuItem>
         )}
         <DropdownMenuSeparator />
-        <DropdownMenuItem onSelect={printPanel.toggle}>
-          <Printer className="mr-2 h-3.5 w-3.5" />
-          {t("toolbar.item.printEllipsis")}
-          {printPanel.visible ? " ✓" : ""}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={onPrintLayout}>
-          <LayoutTemplate className="mr-2 h-3.5 w-3.5" />
-          {t("toolbar.item.printLayoutEllipsis")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={onDownloadOffline}>
-          <HardDriveDownload className="mr-2 h-3.5 w-3.5" />
-          {t("toolbar.item.offlineRegionEllipsis")}
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem onSelect={() => setStorymapPanelOpen(true)}>
-          <BookOpen className="mr-2 h-3.5 w-3.5" />
-          {t("toolbar.item.storymapEllipsis")}
-        </DropdownMenuItem>
+        {show("project.print") && (
+          <DropdownMenuItem onSelect={printPanel.toggle}>
+            <Printer className="mr-2 h-3.5 w-3.5" />
+            {t("toolbar.item.printEllipsis")}
+            {printPanel.visible ? " ✓" : ""}
+          </DropdownMenuItem>
+        )}
+        {show("project.printLayout") && (
+          <DropdownMenuItem onSelect={onPrintLayout}>
+            <LayoutTemplate className="mr-2 h-3.5 w-3.5" />
+            {t("toolbar.item.printLayoutEllipsis")}
+          </DropdownMenuItem>
+        )}
+        {show("project.offlineRegion") && (
+          <DropdownMenuItem onSelect={onDownloadOffline}>
+            <HardDriveDownload className="mr-2 h-3.5 w-3.5" />
+            {t("toolbar.item.offlineRegionEllipsis")}
+          </DropdownMenuItem>
+        )}
+        {show("project.storymap") && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={() => setStorymapPanelOpen(true)}>
+              <BookOpen className="mr-2 h-3.5 w-3.5" />
+              {t("toolbar.item.storymapEllipsis")}
+            </DropdownMenuItem>
+          </>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProjectMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProjectMenu.tsx
@@ -74,6 +74,17 @@ export function ProjectMenu({
   const setStorymapPanelOpen = useAppStore((s) => s.setStorymapPanelOpen);
   const uiProfile = useDesktopSettingsStore((s) => s.desktopSettings.uiProfile);
   const show = (id: string) => isMenuItemVisible(uiProfile, id);
+  // Group-visibility flags so the separators between groups aren't left orphaned
+  // when a whole group is hidden by the active profile.
+  const showSaveGroup =
+    show("project.save") ||
+    show("project.saveAs") ||
+    show("project.share") ||
+    (collaborationEnabled && show("project.collaborate"));
+  const showPrintGroup =
+    show("project.print") ||
+    show("project.printLayout") ||
+    show("project.offlineRegion");
 
   return (
     <DropdownMenu>
@@ -186,7 +197,7 @@ export function ProjectMenu({
           </DropdownMenuSubContent>
         </DropdownMenuSub>
         )}
-        <DropdownMenuSeparator />
+        {showSaveGroup && <DropdownMenuSeparator />}
         {show("project.save") && (
           <DropdownMenuItem onSelect={onSave}>
             <Save className="mr-2 h-3.5 w-3.5" />
@@ -211,7 +222,7 @@ export function ProjectMenu({
             {t("toolbar.item.collaborateEllipsis")}
           </DropdownMenuItem>
         )}
-        <DropdownMenuSeparator />
+        {showPrintGroup && <DropdownMenuSeparator />}
         {show("project.print") && (
           <DropdownMenuItem onSelect={printPanel.toggle}>
             <Printer className="mr-2 h-3.5 w-3.5" />

--- a/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
+++ b/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
@@ -25,6 +25,12 @@ export interface DesktopSettings {
    * hardening (see PR #190 review).
    */
   shareToken: string;
+  /**
+   * Customizable UI profile: which data sources / web services / plugins are
+   * visible, an optional experience-level preset, first-launch onboarding state,
+   * and an admin lock. See `src/lib/ui-profile.ts` and `docs/ui-profiles.md`.
+   */
+  uiProfile: UiProfileSettings;
 }
 
 export interface DesktopLayoutSettings {
@@ -32,6 +38,34 @@ export interface DesktopLayoutSettings {
   showProjectInfo: boolean;
   stylePanelVisible: boolean;
   toolbarLabels: boolean;
+}
+
+/** Experience-level presets offered by the onboarding wizard and Settings. */
+export type ExperienceLevel = "beginner" | "intermediate" | "advanced";
+
+export interface UiProfileSettings {
+  /**
+   * When false, every data source and plugin is visible regardless of the hidden
+   * lists below. This is the back-compat default so existing users see no change
+   * until they opt in via onboarding, the Settings dialog, or an admin file.
+   */
+  enabled: boolean;
+  /**
+   * The experience-level preset last applied, or null for a custom selection
+   * (the user manually toggled an item). Only used to highlight the active preset.
+   */
+  level: ExperienceLevel | null;
+  /** Whether the first-launch onboarding wizard has been completed or dismissed. */
+  onboarded: boolean;
+  /**
+   * Set by an admin config file (`docs/ui-profiles.md`). When true the profile is
+   * managed centrally and the Settings controls are disabled.
+   */
+  locked: boolean;
+  /** Data-source catalog ids hidden from the Add Data menu. */
+  hiddenDataSources: string[];
+  /** Plugin ids hidden from the Plugins menu. */
+  hiddenPlugins: string[];
 }
 
 interface DesktopSettingsState {
@@ -46,13 +80,29 @@ export const DEFAULT_DESKTOP_LAYOUT_SETTINGS: DesktopLayoutSettings = {
   toolbarLabels: true,
 };
 
+export const DEFAULT_UI_PROFILE_SETTINGS: UiProfileSettings = {
+  enabled: false,
+  level: null,
+  onboarded: false,
+  locked: false,
+  hiddenDataSources: [],
+  hiddenPlugins: [],
+};
+
 const DEFAULT_DESKTOP_SETTINGS: DesktopSettings = {
   additionalPluginDirectories: [],
   language: "",
   layout: DEFAULT_DESKTOP_LAYOUT_SETTINGS,
   pluginManifestUrls: [],
   shareToken: "",
+  uiProfile: DEFAULT_UI_PROFILE_SETTINGS,
 };
+
+const EXPERIENCE_LEVELS: readonly ExperienceLevel[] = [
+  "beginner",
+  "intermediate",
+  "advanced",
+];
 
 function normalizeDesktopSettings(settings: unknown): DesktopSettings {
   if (!settings || typeof settings !== "object") {
@@ -74,6 +124,38 @@ function normalizeDesktopSettings(settings: unknown): DesktopSettings {
     ),
     shareToken:
       typeof candidate.shareToken === "string" ? candidate.shareToken.trim() : "",
+    uiProfile: normalizeUiProfileSettings(candidate.uiProfile),
+  };
+}
+
+function normalizeUiProfileSettings(profile: unknown): UiProfileSettings {
+  if (!profile || typeof profile !== "object") {
+    return DEFAULT_UI_PROFILE_SETTINGS;
+  }
+
+  // Require strict booleans and a known level so tampered localStorage values
+  // cannot smuggle non-boolean / unknown values into the profile.
+  const candidate = profile as Partial<UiProfileSettings>;
+  return {
+    enabled:
+      typeof candidate.enabled === "boolean"
+        ? candidate.enabled
+        : DEFAULT_UI_PROFILE_SETTINGS.enabled,
+    level:
+      typeof candidate.level === "string" &&
+      EXPERIENCE_LEVELS.includes(candidate.level as ExperienceLevel)
+        ? (candidate.level as ExperienceLevel)
+        : null,
+    onboarded:
+      typeof candidate.onboarded === "boolean"
+        ? candidate.onboarded
+        : DEFAULT_UI_PROFILE_SETTINGS.onboarded,
+    locked:
+      typeof candidate.locked === "boolean"
+        ? candidate.locked
+        : DEFAULT_UI_PROFILE_SETTINGS.locked,
+    hiddenDataSources: normalizeStringList(candidate.hiddenDataSources),
+    hiddenPlugins: normalizeStringList(candidate.hiddenPlugins),
   };
 }
 

--- a/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
+++ b/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
@@ -66,6 +66,13 @@ export interface UiProfileSettings {
   hiddenDataSources: string[];
   /** Plugin ids hidden from the Plugins menu. */
   hiddenPlugins: string[];
+  /** Top-level toolbar menu ids hidden entirely (e.g. `processing`, `help`). */
+  hiddenMenus: string[];
+  /**
+   * Menu-item catalog ids hidden from their menu (Project/Edit/Processing/
+   * Controls/Settings/Help). Add Data and Plugins use the two lists above.
+   */
+  hiddenMenuItems: string[];
 }
 
 interface DesktopSettingsState {
@@ -87,6 +94,8 @@ export const DEFAULT_UI_PROFILE_SETTINGS: UiProfileSettings = {
   locked: false,
   hiddenDataSources: [],
   hiddenPlugins: [],
+  hiddenMenus: [],
+  hiddenMenuItems: [],
 };
 
 const DEFAULT_DESKTOP_SETTINGS: DesktopSettings = {
@@ -157,6 +166,8 @@ function normalizeUiProfileSettings(profile: unknown): UiProfileSettings {
         : DEFAULT_UI_PROFILE_SETTINGS.locked,
     hiddenDataSources: normalizeStringList(candidate.hiddenDataSources),
     hiddenPlugins: normalizeStringList(candidate.hiddenPlugins),
+    hiddenMenus: normalizeStringList(candidate.hiddenMenus),
+    hiddenMenuItems: normalizeStringList(candidate.hiddenMenuItems),
   };
 }
 

--- a/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
+++ b/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
@@ -98,7 +98,8 @@ const DEFAULT_DESKTOP_SETTINGS: DesktopSettings = {
   uiProfile: DEFAULT_UI_PROFILE_SETTINGS,
 };
 
-const EXPERIENCE_LEVELS: readonly ExperienceLevel[] = [
+/** The experience-level presets, in order. Single source of truth. */
+export const EXPERIENCE_LEVELS: readonly ExperienceLevel[] = [
   "beginner",
   "intermediate",
   "advanced",

--- a/apps/geolibre-desktop/src/hooks/useUiProfileBootstrap.ts
+++ b/apps/geolibre-desktop/src/hooks/useUiProfileBootstrap.ts
@@ -1,7 +1,7 @@
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 import { create } from "zustand";
 import { loadAdminProfile } from "../lib/admin-profile";
-import { presetHiddenSets } from "../lib/ui-profile";
+import { presetHiddenSets, toggleablePluginIds } from "../lib/ui-profile";
 import { usePluginRegistry } from "./usePlugins";
 import { useDesktopSettingsStore } from "./useDesktopSettings";
 
@@ -52,10 +52,12 @@ export function useUiProfileBootstrap(): {
     if (bootstrapStarted) return;
     bootstrapStarted = true;
 
-    const pluginIds = plugins.map((plugin) => plugin.id);
+    const pluginIds = toggleablePluginIds(plugins);
     void (async () => {
       try {
         const patch = await loadAdminProfile(pluginIds);
+        // Re-read the latest store state after the await so a concurrent update
+        // is not clobbered.
         const current = useDesktopSettingsStore.getState().desktopSettings;
         if (patch) {
           useDesktopSettingsStore.getState().setDesktopSettings({
@@ -93,7 +95,7 @@ export function useUiProfileBootstrap(): {
 
     const { hiddenPlugins } = presetHiddenSets(
       profile.level,
-      plugins.map((plugin) => plugin.id),
+      toggleablePluginIds(plugins),
     );
     const missing = hiddenPlugins.filter(
       (id) => !profile.hiddenPlugins.includes(id),
@@ -115,14 +117,17 @@ export function useUiProfileBootstrap(): {
   const showOnboarding =
     adminChecked && !uiProfile.onboarded && !uiProfile.locked;
 
-  const dismissOnboarding = () => {
+  // Marks onboarding complete when the wizard is dismissed without a choice
+  // (Escape/overlay). The wizard's own buttons set `onboarded` first, so this is
+  // a defensive backstop. Memoised so it stays referentially stable for callers.
+  const dismissOnboarding = useCallback(() => {
     const current = useDesktopSettingsStore.getState().desktopSettings;
     if (current.uiProfile.onboarded) return;
     useDesktopSettingsStore.getState().setDesktopSettings({
       ...current,
       uiProfile: { ...current.uiProfile, onboarded: true },
     });
-  };
+  }, []);
 
   return { showOnboarding, dismissOnboarding };
 }

--- a/apps/geolibre-desktop/src/hooks/useUiProfileBootstrap.ts
+++ b/apps/geolibre-desktop/src/hooks/useUiProfileBootstrap.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { create } from "zustand";
 import { loadAdminProfile } from "../lib/admin-profile";
+import { presetHiddenSets } from "../lib/ui-profile";
 import { usePluginRegistry } from "./usePlugins";
 import { useDesktopSettingsStore } from "./useDesktopSettings";
 
@@ -25,9 +26,12 @@ let bootstrapStarted = false;
  * Bootstrap the customizable UI profile (issue #500) on startup:
  *
  * 1. Look for an admin config file. If present, apply it to the stored profile
- *    (and skip onboarding — an admin-managed deployment is pre-configured).
+ *    (and skip onboarding — an admin-managed deployment is pre-configured). If
+ *    absent, release any lock a previously-applied file left behind.
  * 2. Otherwise, show the first-launch onboarding wizard when it has not yet been
  *    completed.
+ * 3. Keep a level preset's hidden plugin list in sync as external/bundled
+ *    plugins finish loading after startup.
  *
  * @returns Whether to show the onboarding wizard, and a callback to dismiss it.
  */
@@ -41,23 +45,70 @@ export function useUiProfileBootstrap(): {
     (state) => state.desktopSettings.uiProfile,
   );
 
+  // One-time admin-profile check. Built-in plugins are registered synchronously
+  // at module load, so they are all present here; externally-loaded plugins are
+  // reconciled by the effect below as the registry settles.
   useEffect(() => {
     if (bootstrapStarted) return;
     bootstrapStarted = true;
 
     const pluginIds = plugins.map((plugin) => plugin.id);
     void (async () => {
-      const patch = await loadAdminProfile(pluginIds);
-      if (patch) {
+      try {
+        const patch = await loadAdminProfile(pluginIds);
         const current = useDesktopSettingsStore.getState().desktopSettings;
-        useDesktopSettingsStore.getState().setDesktopSettings({
-          ...current,
-          uiProfile: { ...current.uiProfile, ...patch },
-        });
+        if (patch) {
+          useDesktopSettingsStore.getState().setDesktopSettings({
+            ...current,
+            uiProfile: { ...current.uiProfile, ...patch },
+          });
+        } else if (current.uiProfile.locked) {
+          // The admin file is gone — release a lock a previous deployment left
+          // behind so the machine is not stuck locked forever (docs/ui-profiles.md).
+          useDesktopSettingsStore.getState().setDesktopSettings({
+            ...current,
+            uiProfile: { ...current.uiProfile, locked: false },
+          });
+        }
+      } finally {
+        // Always unblock onboarding, even if the admin check threw unexpectedly,
+        // so a failed profile read can never strand the user on a blank screen.
+        useBootstrapStore.getState().markChecked();
       }
-      useBootstrapStore.getState().markChecked();
     })();
-  }, [plugins]);
+    // Intentionally runs once: `plugins` is snapshotted, not reactive. Late
+    // external plugins are handled by the reconcile effect below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // While a level preset is active, add any tier-hidden plugins that were not in
+  // the registry when the preset was applied (external/bundled drop-ins load
+  // asynchronously). Add-only, so it never removes an admin's or the user's
+  // explicit entries, and a custom selection (level === null) is left untouched.
+  useEffect(() => {
+    if (!adminChecked) return;
+    const { uiProfile: profile } =
+      useDesktopSettingsStore.getState().desktopSettings;
+    if (!profile.enabled || profile.level === null) return;
+
+    const { hiddenPlugins } = presetHiddenSets(
+      profile.level,
+      plugins.map((plugin) => plugin.id),
+    );
+    const missing = hiddenPlugins.filter(
+      (id) => !profile.hiddenPlugins.includes(id),
+    );
+    if (missing.length === 0) return;
+
+    const current = useDesktopSettingsStore.getState().desktopSettings;
+    useDesktopSettingsStore.getState().setDesktopSettings({
+      ...current,
+      uiProfile: {
+        ...current.uiProfile,
+        hiddenPlugins: [...current.uiProfile.hiddenPlugins, ...missing],
+      },
+    });
+  }, [plugins, adminChecked]);
 
   // Derived from store state so completing/dismissing onboarding (which sets
   // `onboarded`) hides the wizard without extra local state.

--- a/apps/geolibre-desktop/src/hooks/useUiProfileBootstrap.ts
+++ b/apps/geolibre-desktop/src/hooks/useUiProfileBootstrap.ts
@@ -1,0 +1,77 @@
+import { useEffect } from "react";
+import { create } from "zustand";
+import { loadAdminProfile } from "../lib/admin-profile";
+import { usePluginRegistry } from "./usePlugins";
+import { useDesktopSettingsStore } from "./useDesktopSettings";
+
+// Whether the one-time admin-profile check has finished. Kept in its own store
+// so any live component instance observes the result — robust to React 18
+// StrictMode mounting effects twice in development.
+interface BootstrapState {
+  adminChecked: boolean;
+  markChecked: () => void;
+}
+
+const useBootstrapStore = create<BootstrapState>((set) => ({
+  adminChecked: false,
+  markChecked: () => set({ adminChecked: true }),
+}));
+
+// Module-level so the admin check runs exactly once per page load, even though
+// StrictMode mounts/unmounts the effect twice in development.
+let bootstrapStarted = false;
+
+/**
+ * Bootstrap the customizable UI profile (issue #500) on startup:
+ *
+ * 1. Look for an admin config file. If present, apply it to the stored profile
+ *    (and skip onboarding — an admin-managed deployment is pre-configured).
+ * 2. Otherwise, show the first-launch onboarding wizard when it has not yet been
+ *    completed.
+ *
+ * @returns Whether to show the onboarding wizard, and a callback to dismiss it.
+ */
+export function useUiProfileBootstrap(): {
+  showOnboarding: boolean;
+  dismissOnboarding: () => void;
+} {
+  const { plugins } = usePluginRegistry();
+  const adminChecked = useBootstrapStore((state) => state.adminChecked);
+  const uiProfile = useDesktopSettingsStore(
+    (state) => state.desktopSettings.uiProfile,
+  );
+
+  useEffect(() => {
+    if (bootstrapStarted) return;
+    bootstrapStarted = true;
+
+    const pluginIds = plugins.map((plugin) => plugin.id);
+    void (async () => {
+      const patch = await loadAdminProfile(pluginIds);
+      if (patch) {
+        const current = useDesktopSettingsStore.getState().desktopSettings;
+        useDesktopSettingsStore.getState().setDesktopSettings({
+          ...current,
+          uiProfile: { ...current.uiProfile, ...patch },
+        });
+      }
+      useBootstrapStore.getState().markChecked();
+    })();
+  }, [plugins]);
+
+  // Derived from store state so completing/dismissing onboarding (which sets
+  // `onboarded`) hides the wizard without extra local state.
+  const showOnboarding =
+    adminChecked && !uiProfile.onboarded && !uiProfile.locked;
+
+  const dismissOnboarding = () => {
+    const current = useDesktopSettingsStore.getState().desktopSettings;
+    if (current.uiProfile.onboarded) return;
+    useDesktopSettingsStore.getState().setDesktopSettings({
+      ...current,
+      uiProfile: { ...current.uiProfile, onboarded: true },
+    });
+  };
+
+  return { showOnboarding, dismissOnboarding };
+}

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -517,6 +517,7 @@
     "menu": {
       "mapPreferences": "Map Preferences",
       "layoutSettings": "Layout Settings",
+      "interfaceSettings": "Interface Settings",
       "geocoding": "Geocoding",
       "environmentVariables": "Environment Variables",
       "projectSettings": "Project Settings",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -566,6 +566,7 @@
       },
       "dataSources": "Data sources",
       "plugins": "Plugins",
+      "menus": "Menus",
       "lockedNote": "This interface profile is managed by your administrator and cannot be changed."
     },
     "env": {

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -483,6 +483,25 @@
     "boundsRestricted": "Bounds locked",
     "boundsRestrictedTooltip": "Map bounds are restricted. You can change this in Settings."
   },
+  "onboarding": {
+    "title": "Welcome to GeoLibre",
+    "description": "Choose your experience level to tailor the interface. You can change this any time in Settings → Interface.",
+    "level": {
+      "beginner": {
+        "title": "Beginner",
+        "description": "Show only the essential data sources and tools."
+      },
+      "intermediate": {
+        "title": "Intermediate",
+        "description": "Show common data sources, services, and plugins."
+      },
+      "advanced": {
+        "title": "Advanced",
+        "description": "Show everything GeoLibre has to offer."
+      }
+    },
+    "showEverything": "Skip — show everything"
+  },
   "settings": {
     "title": "Settings",
     "description": "Configure project preferences and runtime settings.",
@@ -490,6 +509,7 @@
     "section": {
       "map": "Map",
       "layout": "Layout",
+      "interface": "Interface",
       "geocoding": "Geocoding",
       "environment": "Environment",
       "project": "Project"
@@ -531,6 +551,21 @@
       "showStylePanel": "Show Style panel",
       "showAttributePanel": "Show Attribute panel",
       "urlParamsNote": "URL layout parameters still apply when present in shared viewer links."
+    },
+    "interface": {
+      "title": "Interface profile",
+      "description": "Hide data sources and plugins to simplify the interface. Nothing is removed — re-enable items here at any time.",
+      "enable": "Simplify the interface",
+      "presets": "Experience level",
+      "presetsHint": "Pick a level to show items suited to that experience, then fine-tune below.",
+      "level": {
+        "beginner": "Beginner",
+        "intermediate": "Intermediate",
+        "advanced": "Advanced"
+      },
+      "dataSources": "Data sources",
+      "plugins": "Plugins",
+      "lockedNote": "This interface profile is managed by your administrator and cannot be changed."
     },
     "env": {
       "tokenTitle": "Share.GeoLibre API token",

--- a/apps/geolibre-desktop/src/lib/admin-profile.ts
+++ b/apps/geolibre-desktop/src/lib/admin-profile.ts
@@ -26,6 +26,8 @@ interface AdminProfileFile {
   /** Explicit hidden ids (override the preset when present). */
   hiddenDataSources?: string[];
   hiddenPlugins?: string[];
+  hiddenMenus?: string[];
+  hiddenMenuItems?: string[];
   /** When true, the user cannot change the profile from Settings. */
   lock?: boolean;
 }
@@ -91,12 +93,13 @@ export function resolveAdminProfile(
 
   // A level seeds the hidden lists; explicit lists override per dimension.
   const preset = level ? presetHiddenSets(level, pluginIds) : null;
-  const hiddenDataSources = Array.isArray(file.hiddenDataSources)
-    ? normalizeStringList(file.hiddenDataSources)
-    : (preset?.hiddenDataSources ?? []);
-  const hiddenPlugins = Array.isArray(file.hiddenPlugins)
-    ? normalizeStringList(file.hiddenPlugins)
-    : (preset?.hiddenPlugins ?? []);
+  const resolveList = (
+    explicit: string[] | undefined,
+    fromPreset: string[] | undefined,
+  ): string[] =>
+    Array.isArray(explicit)
+      ? normalizeStringList(explicit)
+      : (fromPreset ?? []);
 
   return {
     // An admin file enables filtering unless it explicitly opts out.
@@ -105,7 +108,12 @@ export function resolveAdminProfile(
     locked: file.lock === true,
     // An admin-managed profile should not also prompt the onboarding wizard.
     onboarded: true,
-    hiddenDataSources,
-    hiddenPlugins,
+    hiddenDataSources: resolveList(
+      file.hiddenDataSources,
+      preset?.hiddenDataSources,
+    ),
+    hiddenPlugins: resolveList(file.hiddenPlugins, preset?.hiddenPlugins),
+    hiddenMenus: resolveList(file.hiddenMenus, preset?.hiddenMenus),
+    hiddenMenuItems: resolveList(file.hiddenMenuItems, preset?.hiddenMenuItems),
   };
 }

--- a/apps/geolibre-desktop/src/lib/admin-profile.ts
+++ b/apps/geolibre-desktop/src/lib/admin-profile.ts
@@ -48,15 +48,23 @@ export async function loadAdminProfile(
 }
 
 async function readAdminProfileFile(): Promise<AdminProfileFile | null> {
-  // On desktop the OS config-dir file is authoritative; fall back to the bundled
-  // file only if the command yields nothing.
+  // On desktop the OS config-dir file is authoritative; only fall back to the
+  // bundled web file when that file is absent (or the command itself fails).
   if (isTauri()) {
     try {
       const contents = await invoke<string | null>("read_admin_profile");
-      const parsed = parseAdminProfile(contents);
-      if (parsed) return parsed;
-    } catch {
-      // Ignore and try the bundled file below.
+      // A non-null result means the desktop file exists, so use its parse result
+      // (even if it is null because the file is malformed) rather than silently
+      // letting the web file override an admin-managed deployment. A null result
+      // means no desktop file, so fall through to the web file below.
+      if (contents !== null) return parseAdminProfile(contents);
+    } catch (error) {
+      // The command failed (not registered, permission denied, …). Fall back to
+      // the bundled web file, but surface the error in development so a
+      // misconfiguration is not invisible.
+      if (import.meta.env.DEV) {
+        console.warn("[admin-profile] read_admin_profile failed:", error);
+      }
     }
   }
 

--- a/apps/geolibre-desktop/src/lib/admin-profile.ts
+++ b/apps/geolibre-desktop/src/lib/admin-profile.ts
@@ -8,19 +8,14 @@
 // See `docs/ui-profiles.md`.
 
 import { invoke } from "@tauri-apps/api/core";
-import type {
-  ExperienceLevel,
-  UiProfileSettings,
+import {
+  EXPERIENCE_LEVELS,
+  type ExperienceLevel,
+  type UiProfileSettings,
 } from "../hooks/useDesktopSettings";
 import { isTauri } from "./is-tauri";
 import { normalizeStringList } from "./string-lists";
 import { presetHiddenSets } from "./ui-profile";
-
-const EXPERIENCE_LEVELS: readonly ExperienceLevel[] = [
-  "beginner",
-  "intermediate",
-  "advanced",
-];
 
 /** The raw shape an admin may author in `admin-profile.json`. */
 interface AdminProfileFile {

--- a/apps/geolibre-desktop/src/lib/admin-profile.ts
+++ b/apps/geolibre-desktop/src/lib/admin-profile.ts
@@ -57,7 +57,19 @@ async function readAdminProfileFile(): Promise<AdminProfileFile | null> {
       // (even if it is null because the file is malformed) rather than silently
       // letting the web file override an admin-managed deployment. A null result
       // means no desktop file, so fall through to the web file below.
-      if (contents !== null) return parseAdminProfile(contents);
+      if (contents !== null) {
+        const parsed = parseAdminProfile(contents);
+        // The desktop file is expected to be valid JSON; surface a parse failure
+        // in development so an admin can spot a malformed file. (The web fetch
+        // below legitimately returns non-JSON when no file exists, so parse
+        // warnings live here rather than inside parseAdminProfile.)
+        if (parsed === null && import.meta.env.DEV) {
+          console.warn(
+            "[admin-profile] desktop admin-profile.json is not valid JSON; ignoring.",
+          );
+        }
+        return parsed;
+      }
     } catch (error) {
       // The command failed (not registered, permission denied, …). Fall back to
       // the bundled web file, but surface the error in development so a

--- a/apps/geolibre-desktop/src/lib/admin-profile.ts
+++ b/apps/geolibre-desktop/src/lib/admin-profile.ts
@@ -1,0 +1,116 @@
+// Admin UI-profile config file (issue #500).
+//
+// Administrators can pre-configure (and optionally lock) the UI profile for a
+// deployment by providing an `admin-profile.json` file:
+//   - Web / embed: served from the app root (e.g. nginx docroot). 404 ⇒ ignored.
+//   - Desktop: read from `<app_config_dir>/admin-profile.json` via the Tauri
+//     `read_admin_profile` command, which takes precedence over the bundled file.
+// See `docs/ui-profiles.md`.
+
+import { invoke } from "@tauri-apps/api/core";
+import type {
+  ExperienceLevel,
+  UiProfileSettings,
+} from "../hooks/useDesktopSettings";
+import { isTauri } from "./is-tauri";
+import { normalizeStringList } from "./string-lists";
+import { presetHiddenSets } from "./ui-profile";
+
+const EXPERIENCE_LEVELS: readonly ExperienceLevel[] = [
+  "beginner",
+  "intermediate",
+  "advanced",
+];
+
+/** The raw shape an admin may author in `admin-profile.json`. */
+interface AdminProfileFile {
+  /** Whether profile filtering is active. Defaults to true for an admin file. */
+  enabled?: boolean;
+  /** An experience-level preset to seed the hidden lists from. */
+  level?: ExperienceLevel;
+  /** Explicit hidden ids (override the preset when present). */
+  hiddenDataSources?: string[];
+  hiddenPlugins?: string[];
+  /** When true, the user cannot change the profile from Settings. */
+  lock?: boolean;
+}
+
+/**
+ * Resolve the admin profile into the parts of {@link UiProfileSettings} it
+ * controls, or null when no (valid) admin file is present.
+ *
+ * @param pluginIds - Registered plugin ids, used to expand a `level` preset.
+ * @returns A patch to merge into the stored UI profile, or null.
+ */
+export async function loadAdminProfile(
+  pluginIds: readonly string[],
+): Promise<Partial<UiProfileSettings> | null> {
+  const file = await readAdminProfileFile();
+  if (!file) return null;
+  return resolveAdminProfile(file, pluginIds);
+}
+
+async function readAdminProfileFile(): Promise<AdminProfileFile | null> {
+  // On desktop the OS config-dir file is authoritative; fall back to the bundled
+  // file only if the command yields nothing.
+  if (isTauri()) {
+    try {
+      const contents = await invoke<string | null>("read_admin_profile");
+      const parsed = parseAdminProfile(contents);
+      if (parsed) return parsed;
+    } catch {
+      // Ignore and try the bundled file below.
+    }
+  }
+
+  try {
+    const response = await fetch(`${import.meta.env.BASE_URL}admin-profile.json`);
+    if (!response.ok) return null;
+    return parseAdminProfile(await response.text());
+  } catch {
+    return null;
+  }
+}
+
+function parseAdminProfile(contents: string | null): AdminProfileFile | null {
+  if (!contents) return null;
+  try {
+    const parsed = JSON.parse(contents) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+    return parsed as AdminProfileFile;
+  } catch {
+    return null;
+  }
+}
+
+/** Validate and normalize a raw admin file into a UI-profile patch. */
+export function resolveAdminProfile(
+  file: AdminProfileFile,
+  pluginIds: readonly string[],
+): Partial<UiProfileSettings> {
+  const level =
+    typeof file.level === "string" &&
+    EXPERIENCE_LEVELS.includes(file.level as ExperienceLevel)
+      ? (file.level as ExperienceLevel)
+      : null;
+
+  // A level seeds the hidden lists; explicit lists override per dimension.
+  const preset = level ? presetHiddenSets(level, pluginIds) : null;
+  const hiddenDataSources = Array.isArray(file.hiddenDataSources)
+    ? normalizeStringList(file.hiddenDataSources)
+    : (preset?.hiddenDataSources ?? []);
+  const hiddenPlugins = Array.isArray(file.hiddenPlugins)
+    ? normalizeStringList(file.hiddenPlugins)
+    : (preset?.hiddenPlugins ?? []);
+
+  return {
+    // An admin file enables filtering unless it explicitly opts out.
+    enabled: typeof file.enabled === "boolean" ? file.enabled : true,
+    level,
+    locked: file.lock === true,
+    // An admin-managed profile should not also prompt the onboarding wizard.
+    onboarded: true,
+    hiddenDataSources,
+    hiddenPlugins,
+  };
+}

--- a/apps/geolibre-desktop/src/lib/ui-profile.ts
+++ b/apps/geolibre-desktop/src/lib/ui-profile.ts
@@ -14,6 +14,31 @@ import type {
 
 export type ComplexityTier = "basic" | "intermediate" | "advanced";
 
+/**
+ * Plugins toggled from other menus (Effects/Directions/Reverse Geocode via the
+ * Controls menu, deck.gl viz via Add Data), so they are excluded from the
+ * Plugins menu and from the UI-profile plugin lists. Keep in sync with
+ * `PluginsMenu`'s skip list. Literal ids (mirroring `EFFECTS_PLUGIN_ID` etc.
+ * from `@geolibre/plugins`) so this module stays free of the heavy plugin
+ * barrel and can be unit-tested in Node.
+ */
+export const MENU_MANAGED_PLUGIN_IDS = new Set<string>([
+  "maplibre-atmosphere-effects", // EFFECTS_PLUGIN_ID
+  "maplibre-gl-directions", // DIRECTIONS_PLUGIN_ID
+  "maplibre-reverse-geocode", // REVERSE_GEOCODE_PLUGIN_ID
+  "maplibre-deckgl-viz", // DECK_VIZ_PLUGIN_ID
+]);
+
+/** The plugin ids that participate in the UI profile (excludes the menu-managed
+ * plugins above), used when computing presets. */
+export function toggleablePluginIds(
+  plugins: ReadonlyArray<{ id: string }>,
+): string[] {
+  return plugins
+    .filter((plugin) => !MENU_MANAGED_PLUGIN_IDS.has(plugin.id))
+    .map((plugin) => plugin.id);
+}
+
 /** Section groupings shared with the Add Data menu and the Settings checklist. */
 export type DataSourceSection =
   | "files"
@@ -146,10 +171,14 @@ export const TOP_LEVEL_MENUS: readonly TopLevelMenuEntry[] = [
   { id: "help", labelKey: "toolbar.menu.help", tier: "basic" },
 ];
 
+/** The menu a catalog item belongs to: a hideable top-level menu, or Settings
+ * (whose dropdown items are toggleable even though the menu itself always shows). */
+export type MenuOwnerId = TopLevelMenuId | "settings";
+
 export interface MenuItemCatalogEntry {
   id: string;
   /** Owning menu id, used to group the Settings checklist. */
-  menuId: string;
+  menuId: MenuOwnerId;
   labelKey: ParseKeys;
   tier: ComplexityTier;
 }
@@ -235,7 +264,10 @@ export const MENU_ITEM_CATALOG: readonly MenuItemCatalogEntry[] = [
 ];
 
 /** Group order + header label key for the per-menu item checklists in Settings. */
-export const MENU_ITEM_GROUPS: ReadonlyArray<{ menuId: string; labelKey: ParseKeys }> = [
+export const MENU_ITEM_GROUPS: ReadonlyArray<{
+  menuId: MenuOwnerId;
+  labelKey: ParseKeys;
+}> = [
   { menuId: "project", labelKey: "toolbar.menu.project" },
   { menuId: "edit", labelKey: "toolbar.menu.edit" },
   { menuId: "processing", labelKey: "toolbar.menu.processing" },

--- a/apps/geolibre-desktop/src/lib/ui-profile.ts
+++ b/apps/geolibre-desktop/src/lib/ui-profile.ts
@@ -85,7 +85,7 @@ export const DATA_SOURCE_CATALOG: readonly DataSourceCatalogEntry[] = [
   { id: "3d-tiles", section: "threeD", labelKey: "toolbar.item.threeDTilesLayer", tier: "advanced" },
   { id: "gltf-model", section: "threeD", labelKey: "toolbar.layerType.gltfModel", tier: "advanced" },
   // Databases
-  { id: "duckdb", section: "databases", labelKey: "toolbar.item.duckdbLayer", tier: "basic" },
+  { id: "duckdb", section: "databases", labelKey: "toolbar.item.duckdbLayer", tier: "intermediate" },
   { id: "postgres", section: "databases", labelKey: "toolbar.layerType.postgres", tier: "advanced" },
 ];
 
@@ -175,7 +175,7 @@ export const MENU_ITEM_CATALOG: readonly MenuItemCatalogEntry[] = [
   { id: "edit.undo", menuId: "edit", labelKey: "toolbar.item.undo", tier: "basic" },
   { id: "edit.redo", menuId: "edit", labelKey: "toolbar.item.redo", tier: "basic" },
   // Processing
-  { id: "processing.assistant", menuId: "processing", labelKey: "toolbar.command.assistant", tier: "basic" },
+  { id: "processing.assistant", menuId: "processing", labelKey: "toolbar.command.assistant", tier: "intermediate" },
   { id: "processing.whitebox", menuId: "processing", labelKey: "toolbar.item.whitebox", tier: "advanced" },
   { id: "processing.sqlWorkspace", menuId: "processing", labelKey: "toolbar.command.sqlWorkspace", tier: "intermediate" },
   { id: "processing.pythonConsole", menuId: "processing", labelKey: "toolbar.command.pythonConsole", tier: "advanced" },
@@ -208,7 +208,7 @@ export const MENU_ITEM_CATALOG: readonly MenuItemCatalogEntry[] = [
   { id: "controls.reverseGeocode", menuId: "controls", labelKey: "toolbar.item.reverseGeocode", tier: "intermediate" },
   { id: "controls.search", menuId: "controls", labelKey: "toolbar.item.search", tier: "basic" },
   { id: "controls.colorbar", menuId: "controls", labelKey: "toolbar.item.colorbar", tier: "intermediate" },
-  { id: "controls.legend", menuId: "controls", labelKey: "toolbar.item.legend", tier: "basic" },
+  { id: "controls.legend", menuId: "controls", labelKey: "toolbar.item.legend", tier: "intermediate" },
   { id: "controls.html", menuId: "controls", labelKey: "toolbar.item.html", tier: "advanced" },
   { id: "controls.measure", menuId: "controls", labelKey: "toolbar.item.measure", tier: "intermediate" },
   { id: "controls.bookmark", menuId: "controls", labelKey: "toolbar.item.bookmark", tier: "intermediate" },
@@ -218,9 +218,8 @@ export const MENU_ITEM_CATALOG: readonly MenuItemCatalogEntry[] = [
   // Settings (the Settings menu and its Language/Layout/Interface entries always show)
   { id: "settings.mapPreferences", menuId: "settings", labelKey: "settings.menu.mapPreferences", tier: "intermediate" },
   { id: "settings.geocoding", menuId: "settings", labelKey: "settings.menu.geocoding", tier: "advanced" },
-  // The AI Assistant (basic) reads its API key from environment variables, so
-  // keep this reachable at the beginner level too.
-  { id: "settings.environment", menuId: "settings", labelKey: "settings.menu.environmentVariables", tier: "basic" },
+  // Kept in step with the AI Assistant (which reads its API key from here).
+  { id: "settings.environment", menuId: "settings", labelKey: "settings.menu.environmentVariables", tier: "intermediate" },
   { id: "settings.projectSettings", menuId: "settings", labelKey: "settings.menu.projectSettings", tier: "intermediate" },
   { id: "settings.managePlugins", menuId: "settings", labelKey: "settings.menu.managePlugins", tier: "intermediate" },
   // Help

--- a/apps/geolibre-desktop/src/lib/ui-profile.ts
+++ b/apps/geolibre-desktop/src/lib/ui-profile.ts
@@ -135,7 +135,9 @@ export const TOP_LEVEL_MENUS: readonly TopLevelMenuEntry[] = [
   { id: "project", labelKey: "toolbar.menu.project", tier: "basic" },
   { id: "edit", labelKey: "toolbar.menu.edit", tier: "basic" },
   { id: "addData", labelKey: "toolbar.menu.addData", tier: "basic" },
-  { id: "processing", labelKey: "toolbar.menu.processing", tier: "basic" },
+  // Processing exposes analysis tools aimed at intermediate+ users; hide the
+  // whole menu for beginners.
+  { id: "processing", labelKey: "toolbar.menu.processing", tier: "intermediate" },
   { id: "controls", labelKey: "toolbar.menu.controls", tier: "basic" },
   // The Layer Control and Basemap plugins are active by default, so the Plugins
   // menu must stay reachable at every level to toggle them; the advanced plugins
@@ -195,12 +197,13 @@ export const MENU_ITEM_CATALOG: readonly MenuItemCatalogEntry[] = [
   { id: "controls.mapControl.navigation", menuId: "controls", labelKey: "toolbar.mapControl.navigation", tier: "basic" },
   { id: "controls.mapControl.fullscreen", menuId: "controls", labelKey: "toolbar.mapControl.fullscreen", tier: "basic" },
   { id: "controls.mapControl.geolocate", menuId: "controls", labelKey: "toolbar.mapControl.geolocate", tier: "intermediate" },
-  // Globe and Scale are shown on the map by default, so they must be toggleable
-  // at every level (otherwise a beginner sees them with no way to turn them off).
+  // Globe, Scale, and Attribution are shown on the map by default, so they must
+  // be toggleable at every level (otherwise a beginner sees them with no way to
+  // turn them off).
   { id: "controls.mapControl.globe", menuId: "controls", labelKey: "toolbar.mapControl.globe", tier: "basic" },
   { id: "controls.mapControl.terrain", menuId: "controls", labelKey: "toolbar.mapControl.terrain", tier: "intermediate" },
   { id: "controls.mapControl.scale", menuId: "controls", labelKey: "toolbar.mapControl.scale", tier: "basic" },
-  { id: "controls.mapControl.attribution", menuId: "controls", labelKey: "toolbar.mapControl.attribution", tier: "advanced" },
+  { id: "controls.mapControl.attribution", menuId: "controls", labelKey: "toolbar.mapControl.attribution", tier: "basic" },
   { id: "controls.mapControl.logo", menuId: "controls", labelKey: "toolbar.mapControl.logo", tier: "advanced" },
   // Controls — overlays and panels
   { id: "controls.atmosphereEffects", menuId: "controls", labelKey: "toolbar.item.atmosphereEffects", tier: "advanced" },

--- a/apps/geolibre-desktop/src/lib/ui-profile.ts
+++ b/apps/geolibre-desktop/src/lib/ui-profile.ts
@@ -1,0 +1,179 @@
+// Customizable UI profiles / data-source filtering (issue #500).
+//
+// A single complexity *tier* drives everything. Each filterable item (a data
+// source in the Add Data menu, or a plugin in the Plugins menu) is assigned a
+// tier; an experience-level preset shows every item at or below the chosen
+// level. Presets compute concrete hidden-id lists, which is all the runtime
+// filters on. See `docs/ui-profiles.md`.
+
+import type { ParseKeys } from "i18next";
+import type {
+  ExperienceLevel,
+  UiProfileSettings,
+} from "../hooks/useDesktopSettings";
+
+export type ComplexityTier = "basic" | "intermediate" | "advanced";
+
+/** Section groupings shared with the Add Data menu and the Settings checklist. */
+export type DataSourceSection =
+  | "files"
+  | "webServices"
+  | "cloud"
+  | "threeD"
+  | "databases";
+
+export interface DataSourceCatalogEntry {
+  /** Stable id used in the hidden list and as the Add Data menu handler key. */
+  id: string;
+  section: DataSourceSection;
+  labelKey: ParseKeys;
+  tier: ComplexityTier;
+}
+
+/** i18n label key for each data-source section header. */
+export const DATA_SOURCE_SECTION_LABEL_KEYS: Record<
+  DataSourceSection,
+  ParseKeys
+> = {
+  files: "toolbar.item.sectionFiles",
+  webServices: "toolbar.item.sectionWebServices",
+  cloud: "toolbar.item.sectionCloudFormats",
+  threeD: "toolbar.item.section3dLayers",
+  databases: "toolbar.item.sectionDatabases",
+};
+
+/** Section render order, matching the Add Data menu. */
+export const DATA_SOURCE_SECTION_ORDER: readonly DataSourceSection[] = [
+  "files",
+  "webServices",
+  "cloud",
+  "threeD",
+  "databases",
+];
+
+/**
+ * Every Add Data menu item, in menu order. The `id` is the contract between the
+ * menu (which maps ids to handlers), the Settings checklist, and the persisted
+ * hidden list. Keep this in sync with `AddDataMenu.tsx`.
+ */
+export const DATA_SOURCE_CATALOG: readonly DataSourceCatalogEntry[] = [
+  // Files
+  { id: "vector", section: "files", labelKey: "toolbar.item.vectorLayer", tier: "basic" },
+  { id: "raster", section: "files", labelKey: "toolbar.item.rasterLayer", tier: "basic" },
+  { id: "delimited-text", section: "files", labelKey: "toolbar.layerType.delimitedText", tier: "basic" },
+  { id: "gpx", section: "files", labelKey: "toolbar.layerType.gpx", tier: "intermediate" },
+  { id: "mbtiles", section: "files", labelKey: "toolbar.layerType.mbtiles", tier: "basic" },
+  { id: "osm-pbf", section: "files", labelKey: "toolbar.item.osmPbfLayer", tier: "advanced" },
+  // Web services
+  { id: "xyz", section: "webServices", labelKey: "toolbar.layerType.xyz", tier: "basic" },
+  { id: "wms", section: "webServices", labelKey: "toolbar.layerType.wms", tier: "basic" },
+  { id: "wfs", section: "webServices", labelKey: "toolbar.layerType.wfs", tier: "intermediate" },
+  { id: "wmts", section: "webServices", labelKey: "toolbar.layerType.wmts", tier: "intermediate" },
+  { id: "arcgis", section: "webServices", labelKey: "toolbar.layerType.arcgis", tier: "intermediate" },
+  { id: "stac", section: "webServices", labelKey: "toolbar.item.stacLayer", tier: "advanced" },
+  { id: "video", section: "webServices", labelKey: "toolbar.layerType.video", tier: "advanced" },
+  { id: "deckgl-viz", section: "webServices", labelKey: "toolbar.layerType.deckglViz", tier: "advanced" },
+  // Cloud formats
+  { id: "geoparquet", section: "cloud", labelKey: "toolbar.item.geoparquetLayer", tier: "basic" },
+  { id: "flatgeobuf", section: "cloud", labelKey: "toolbar.item.flatgeobufLayer", tier: "intermediate" },
+  { id: "pmtiles", section: "cloud", labelKey: "toolbar.item.pmtilesLayer", tier: "intermediate" },
+  { id: "zarr", section: "cloud", labelKey: "toolbar.item.zarrLayer", tier: "advanced" },
+  { id: "netcdf", section: "cloud", labelKey: "toolbar.item.netcdfHdf", tier: "advanced" },
+  // 3D layers
+  { id: "lidar", section: "threeD", labelKey: "toolbar.item.lidarLayer", tier: "advanced" },
+  { id: "splatting", section: "threeD", labelKey: "toolbar.item.splattingLayer", tier: "advanced" },
+  { id: "3d-tiles", section: "threeD", labelKey: "toolbar.item.threeDTilesLayer", tier: "advanced" },
+  { id: "gltf-model", section: "threeD", labelKey: "toolbar.layerType.gltfModel", tier: "advanced" },
+  // Databases
+  { id: "duckdb", section: "databases", labelKey: "toolbar.item.duckdbLayer", tier: "basic" },
+  { id: "postgres", section: "databases", labelKey: "toolbar.layerType.postgres", tier: "advanced" },
+];
+
+/**
+ * Complexity tier per plugin id (the stable ids defined in
+ * `packages/plugins/src/plugins/*`). Plugins not listed here default to
+ * `intermediate`, so they are visible at Intermediate and Advanced but hidden
+ * for Beginners.
+ */
+export const PLUGIN_TIERS: Record<string, ComplexityTier> = {
+  "maplibre-layer-control": "basic",
+  "maplibre-gl-basemap-control": "basic",
+  "maplibre-gl-geo-editor": "basic",
+  // Advanced web services and specialist tools.
+  "maplibre-gl-fema-wms": "advanced",
+  "maplibre-gl-nasa-earthdata": "advanced",
+  "maplibre-gl-enviroatlas": "advanced",
+  "maplibre-gl-national-map": "advanced",
+  "maplibre-gl-esri-wayback": "advanced",
+  "maplibre-gl-geoagent": "advanced",
+  "maplibre-gl-lidar": "advanced",
+  "maplibre-gl-overture-maps": "advanced",
+  "maplibre-gl-time-slider": "advanced",
+  "maplibre-gl-components": "advanced",
+  "maplibre-gl-streetview": "advanced",
+};
+
+const DEFAULT_PLUGIN_TIER: ComplexityTier = "intermediate";
+
+const TIER_RANK: Record<ComplexityTier, number> = {
+  basic: 0,
+  intermediate: 1,
+  advanced: 2,
+};
+
+const LEVEL_RANK: Record<ExperienceLevel, number> = {
+  beginner: 0,
+  intermediate: 1,
+  advanced: 2,
+};
+
+/** Whether the given experience level reveals items of the given tier. */
+export function levelAllowsTier(
+  level: ExperienceLevel,
+  tier: ComplexityTier,
+): boolean {
+  return TIER_RANK[tier] <= LEVEL_RANK[level];
+}
+
+/** The tier for a plugin id, falling back to the default for unlisted plugins. */
+export function pluginTier(pluginId: string): ComplexityTier {
+  return PLUGIN_TIERS[pluginId] ?? DEFAULT_PLUGIN_TIER;
+}
+
+/**
+ * Compute the hidden data-source and plugin id lists for an experience-level
+ * preset. Used by the onboarding wizard, the Settings preset buttons, and the
+ * admin config loader.
+ *
+ * @param level - The chosen experience level.
+ * @param pluginIds - All currently registered plugin ids to tier.
+ * @returns The hidden id lists to store on {@link UiProfileSettings}.
+ */
+export function presetHiddenSets(
+  level: ExperienceLevel,
+  pluginIds: readonly string[],
+): { hiddenDataSources: string[]; hiddenPlugins: string[] } {
+  const hiddenDataSources = DATA_SOURCE_CATALOG.filter(
+    (entry) => !levelAllowsTier(level, entry.tier),
+  ).map((entry) => entry.id);
+  const hiddenPlugins = pluginIds.filter(
+    (id) => !levelAllowsTier(level, pluginTier(id)),
+  );
+  return { hiddenDataSources, hiddenPlugins };
+}
+
+/** Whether a data-source id should be shown in the Add Data menu. */
+export function isDataSourceVisible(
+  profile: UiProfileSettings,
+  id: string,
+): boolean {
+  return !profile.enabled || !profile.hiddenDataSources.includes(id);
+}
+
+/** Whether a plugin id should be shown in the Plugins menu. */
+export function isPluginVisible(
+  profile: UiProfileSettings,
+  id: string,
+): boolean {
+  return !profile.enabled || !profile.hiddenPlugins.includes(id);
+}

--- a/apps/geolibre-desktop/src/lib/ui-profile.ts
+++ b/apps/geolibre-desktop/src/lib/ui-profile.ts
@@ -113,6 +113,128 @@ export const PLUGIN_TIERS: Record<string, ComplexityTier> = {
   "maplibre-gl-streetview": "advanced",
 };
 
+/** Top-level toolbar menus that can be hidden as a whole (Settings is excluded
+ * so the profile UI can never be locked away). */
+export type TopLevelMenuId =
+  | "project"
+  | "edit"
+  | "addData"
+  | "processing"
+  | "controls"
+  | "plugins"
+  | "help";
+
+export interface TopLevelMenuEntry {
+  id: TopLevelMenuId;
+  labelKey: ParseKeys;
+  tier: ComplexityTier;
+}
+
+/** Hideable top-level menus, in toolbar order. */
+export const TOP_LEVEL_MENUS: readonly TopLevelMenuEntry[] = [
+  { id: "project", labelKey: "toolbar.menu.project", tier: "basic" },
+  { id: "edit", labelKey: "toolbar.menu.edit", tier: "basic" },
+  { id: "addData", labelKey: "toolbar.menu.addData", tier: "basic" },
+  { id: "processing", labelKey: "toolbar.menu.processing", tier: "basic" },
+  { id: "controls", labelKey: "toolbar.menu.controls", tier: "basic" },
+  { id: "plugins", labelKey: "toolbar.menu.plugins", tier: "intermediate" },
+  { id: "help", labelKey: "toolbar.menu.help", tier: "basic" },
+];
+
+export interface MenuItemCatalogEntry {
+  id: string;
+  /** Owning menu id, used to group the Settings checklist. */
+  menuId: string;
+  labelKey: ParseKeys;
+  tier: ComplexityTier;
+}
+
+/**
+ * Individually toggleable items across the Project, Edit, Processing, Controls,
+ * Settings, and Help menus. Submenus (Conversion, Vector, Raster, …) are single
+ * toggles, not per-tool. Add Data items and plugins use `DATA_SOURCE_CATALOG`
+ * and `PLUGIN_TIERS` instead. Keep ids in sync with the menu components.
+ */
+export const MENU_ITEM_CATALOG: readonly MenuItemCatalogEntry[] = [
+  // Project
+  { id: "project.new", menuId: "project", labelKey: "toolbar.item.newEllipsis", tier: "basic" },
+  { id: "project.openFrom", menuId: "project", labelKey: "toolbar.item.openFrom", tier: "basic" },
+  { id: "project.openRecent", menuId: "project", labelKey: "toolbar.item.openRecent", tier: "basic" },
+  { id: "project.save", menuId: "project", labelKey: "common.save", tier: "basic" },
+  { id: "project.saveAs", menuId: "project", labelKey: "toolbar.item.saveAsEllipsis", tier: "basic" },
+  { id: "project.share", menuId: "project", labelKey: "toolbar.item.shareEllipsis", tier: "intermediate" },
+  { id: "project.collaborate", menuId: "project", labelKey: "toolbar.item.collaborateEllipsis", tier: "advanced" },
+  { id: "project.print", menuId: "project", labelKey: "toolbar.item.printEllipsis", tier: "intermediate" },
+  { id: "project.printLayout", menuId: "project", labelKey: "toolbar.item.printLayoutEllipsis", tier: "advanced" },
+  { id: "project.offlineRegion", menuId: "project", labelKey: "toolbar.item.offlineRegionEllipsis", tier: "advanced" },
+  { id: "project.storymap", menuId: "project", labelKey: "toolbar.item.storymapEllipsis", tier: "advanced" },
+  // Edit
+  { id: "edit.undo", menuId: "edit", labelKey: "toolbar.item.undo", tier: "basic" },
+  { id: "edit.redo", menuId: "edit", labelKey: "toolbar.item.redo", tier: "basic" },
+  // Processing
+  { id: "processing.assistant", menuId: "processing", labelKey: "toolbar.command.assistant", tier: "basic" },
+  { id: "processing.whitebox", menuId: "processing", labelKey: "toolbar.item.whitebox", tier: "advanced" },
+  { id: "processing.sqlWorkspace", menuId: "processing", labelKey: "toolbar.command.sqlWorkspace", tier: "intermediate" },
+  { id: "processing.pythonConsole", menuId: "processing", labelKey: "toolbar.command.pythonConsole", tier: "advanced" },
+  { id: "processing.notebook", menuId: "processing", labelKey: "toolbar.command.notebook", tier: "advanced" },
+  { id: "processing.dashboard", menuId: "processing", labelKey: "toolbar.command.dashboard", tier: "intermediate" },
+  { id: "processing.geocode", menuId: "processing", labelKey: "toolbar.item.geocode", tier: "intermediate" },
+  { id: "processing.modelBuilder", menuId: "processing", labelKey: "toolbar.item.modelBuilder", tier: "advanced" },
+  { id: "processing.conversion", menuId: "processing", labelKey: "toolbar.item.conversion", tier: "intermediate" },
+  { id: "processing.vector", menuId: "processing", labelKey: "toolbar.item.vector", tier: "intermediate" },
+  { id: "processing.network", menuId: "processing", labelKey: "toolbar.item.network", tier: "advanced" },
+  { id: "processing.statistics", menuId: "processing", labelKey: "toolbar.item.statistics", tier: "advanced" },
+  { id: "processing.raster", menuId: "processing", labelKey: "toolbar.item.raster", tier: "advanced" },
+  { id: "processing.segmentation", menuId: "processing", labelKey: "toolbar.command.segmentation", tier: "advanced" },
+  { id: "processing.planetaryComputer", menuId: "processing", labelKey: "toolbar.command.planetaryComputer", tier: "advanced" },
+  { id: "processing.earthEngine", menuId: "processing", labelKey: "toolbar.command.earthEngine", tier: "advanced" },
+  // Controls — built-in map controls
+  { id: "controls.mapControl.navigation", menuId: "controls", labelKey: "toolbar.mapControl.navigation", tier: "basic" },
+  { id: "controls.mapControl.fullscreen", menuId: "controls", labelKey: "toolbar.mapControl.fullscreen", tier: "basic" },
+  { id: "controls.mapControl.geolocate", menuId: "controls", labelKey: "toolbar.mapControl.geolocate", tier: "intermediate" },
+  { id: "controls.mapControl.globe", menuId: "controls", labelKey: "toolbar.mapControl.globe", tier: "intermediate" },
+  { id: "controls.mapControl.terrain", menuId: "controls", labelKey: "toolbar.mapControl.terrain", tier: "intermediate" },
+  { id: "controls.mapControl.scale", menuId: "controls", labelKey: "toolbar.mapControl.scale", tier: "intermediate" },
+  { id: "controls.mapControl.attribution", menuId: "controls", labelKey: "toolbar.mapControl.attribution", tier: "advanced" },
+  { id: "controls.mapControl.logo", menuId: "controls", labelKey: "toolbar.mapControl.logo", tier: "advanced" },
+  // Controls — overlays and panels
+  { id: "controls.atmosphereEffects", menuId: "controls", labelKey: "toolbar.item.atmosphereEffects", tier: "advanced" },
+  { id: "controls.directions", menuId: "controls", labelKey: "toolbar.item.directions", tier: "intermediate" },
+  { id: "controls.reverseGeocode", menuId: "controls", labelKey: "toolbar.item.reverseGeocode", tier: "intermediate" },
+  { id: "controls.search", menuId: "controls", labelKey: "toolbar.item.search", tier: "basic" },
+  { id: "controls.colorbar", menuId: "controls", labelKey: "toolbar.item.colorbar", tier: "intermediate" },
+  { id: "controls.legend", menuId: "controls", labelKey: "toolbar.item.legend", tier: "basic" },
+  { id: "controls.html", menuId: "controls", labelKey: "toolbar.item.html", tier: "advanced" },
+  { id: "controls.measure", menuId: "controls", labelKey: "toolbar.item.measure", tier: "intermediate" },
+  { id: "controls.bookmark", menuId: "controls", labelKey: "toolbar.item.bookmark", tier: "intermediate" },
+  { id: "controls.minimap", menuId: "controls", labelKey: "toolbar.item.minimap", tier: "intermediate" },
+  { id: "controls.viewState", menuId: "controls", labelKey: "toolbar.item.viewState", tier: "advanced" },
+  { id: "controls.fieldCollection", menuId: "controls", labelKey: "toolbar.item.fieldCollection", tier: "advanced" },
+  // Settings (the Settings menu and its Language/Layout/Interface entries always show)
+  { id: "settings.mapPreferences", menuId: "settings", labelKey: "settings.menu.mapPreferences", tier: "intermediate" },
+  { id: "settings.geocoding", menuId: "settings", labelKey: "settings.menu.geocoding", tier: "advanced" },
+  { id: "settings.environment", menuId: "settings", labelKey: "settings.menu.environmentVariables", tier: "advanced" },
+  { id: "settings.projectSettings", menuId: "settings", labelKey: "settings.menu.projectSettings", tier: "intermediate" },
+  { id: "settings.managePlugins", menuId: "settings", labelKey: "settings.menu.managePlugins", tier: "intermediate" },
+  // Help
+  { id: "help.commandPalette", menuId: "help", labelKey: "toolbar.item.commandPalette", tier: "basic" },
+  { id: "help.keyboardShortcuts", menuId: "help", labelKey: "toolbar.command.keyboardShortcuts", tier: "intermediate" },
+  { id: "help.diagnostics", menuId: "help", labelKey: "toolbar.command.diagnostics", tier: "advanced" },
+  { id: "help.feedback", menuId: "help", labelKey: "toolbar.command.giveFeedback", tier: "intermediate" },
+  { id: "help.checkForUpdates", menuId: "help", labelKey: "toolbar.command.checkForUpdates", tier: "intermediate" },
+  { id: "help.about", menuId: "help", labelKey: "toolbar.command.about", tier: "basic" },
+];
+
+/** Group order + header label key for the per-menu item checklists in Settings. */
+export const MENU_ITEM_GROUPS: ReadonlyArray<{ menuId: string; labelKey: ParseKeys }> = [
+  { menuId: "project", labelKey: "toolbar.menu.project" },
+  { menuId: "edit", labelKey: "toolbar.menu.edit" },
+  { menuId: "processing", labelKey: "toolbar.menu.processing" },
+  { menuId: "controls", labelKey: "toolbar.menu.controls" },
+  { menuId: "settings", labelKey: "settings.title" },
+  { menuId: "help", labelKey: "toolbar.menu.help" },
+];
+
 const DEFAULT_PLUGIN_TIER: ComplexityTier = "intermediate";
 
 const TIER_RANK: Record<ComplexityTier, number> = {
@@ -149,17 +271,30 @@ export function pluginTier(pluginId: string): ComplexityTier {
  * @param pluginIds - All currently registered plugin ids to tier.
  * @returns The hidden id lists to store on {@link UiProfileSettings}.
  */
+export interface HiddenSets {
+  hiddenDataSources: string[];
+  hiddenPlugins: string[];
+  hiddenMenus: string[];
+  hiddenMenuItems: string[];
+}
+
 export function presetHiddenSets(
   level: ExperienceLevel,
   pluginIds: readonly string[],
-): { hiddenDataSources: string[]; hiddenPlugins: string[] } {
+): HiddenSets {
   const hiddenDataSources = DATA_SOURCE_CATALOG.filter(
     (entry) => !levelAllowsTier(level, entry.tier),
   ).map((entry) => entry.id);
   const hiddenPlugins = pluginIds.filter(
     (id) => !levelAllowsTier(level, pluginTier(id)),
   );
-  return { hiddenDataSources, hiddenPlugins };
+  const hiddenMenus = TOP_LEVEL_MENUS.filter(
+    (menu) => !levelAllowsTier(level, menu.tier),
+  ).map((menu) => menu.id);
+  const hiddenMenuItems = MENU_ITEM_CATALOG.filter(
+    (entry) => !levelAllowsTier(level, entry.tier),
+  ).map((entry) => entry.id);
+  return { hiddenDataSources, hiddenPlugins, hiddenMenus, hiddenMenuItems };
 }
 
 /** Whether a data-source id should be shown in the Add Data menu. */
@@ -176,4 +311,20 @@ export function isPluginVisible(
   id: string,
 ): boolean {
   return !profile.enabled || !profile.hiddenPlugins.includes(id);
+}
+
+/** Whether a top-level toolbar menu should be shown. */
+export function isMenuVisible(
+  profile: UiProfileSettings,
+  menuId: string,
+): boolean {
+  return !profile.enabled || !profile.hiddenMenus.includes(menuId);
+}
+
+/** Whether a menu-item catalog id should be shown in its menu. */
+export function isMenuItemVisible(
+  profile: UiProfileSettings,
+  itemId: string,
+): boolean {
+  return !profile.enabled || !profile.hiddenMenuItems.includes(itemId);
 }

--- a/apps/geolibre-desktop/src/lib/ui-profile.ts
+++ b/apps/geolibre-desktop/src/lib/ui-profile.ts
@@ -137,7 +137,10 @@ export const TOP_LEVEL_MENUS: readonly TopLevelMenuEntry[] = [
   { id: "addData", labelKey: "toolbar.menu.addData", tier: "basic" },
   { id: "processing", labelKey: "toolbar.menu.processing", tier: "basic" },
   { id: "controls", labelKey: "toolbar.menu.controls", tier: "basic" },
-  { id: "plugins", labelKey: "toolbar.menu.plugins", tier: "intermediate" },
+  // The Layer Control and Basemap plugins are active by default, so the Plugins
+  // menu must stay reachable at every level to toggle them; the advanced plugins
+  // inside are still hidden per their own tier.
+  { id: "plugins", labelKey: "toolbar.menu.plugins", tier: "basic" },
   { id: "help", labelKey: "toolbar.menu.help", tier: "basic" },
 ];
 
@@ -192,9 +195,11 @@ export const MENU_ITEM_CATALOG: readonly MenuItemCatalogEntry[] = [
   { id: "controls.mapControl.navigation", menuId: "controls", labelKey: "toolbar.mapControl.navigation", tier: "basic" },
   { id: "controls.mapControl.fullscreen", menuId: "controls", labelKey: "toolbar.mapControl.fullscreen", tier: "basic" },
   { id: "controls.mapControl.geolocate", menuId: "controls", labelKey: "toolbar.mapControl.geolocate", tier: "intermediate" },
-  { id: "controls.mapControl.globe", menuId: "controls", labelKey: "toolbar.mapControl.globe", tier: "intermediate" },
+  // Globe and Scale are shown on the map by default, so they must be toggleable
+  // at every level (otherwise a beginner sees them with no way to turn them off).
+  { id: "controls.mapControl.globe", menuId: "controls", labelKey: "toolbar.mapControl.globe", tier: "basic" },
   { id: "controls.mapControl.terrain", menuId: "controls", labelKey: "toolbar.mapControl.terrain", tier: "intermediate" },
-  { id: "controls.mapControl.scale", menuId: "controls", labelKey: "toolbar.mapControl.scale", tier: "intermediate" },
+  { id: "controls.mapControl.scale", menuId: "controls", labelKey: "toolbar.mapControl.scale", tier: "basic" },
   { id: "controls.mapControl.attribution", menuId: "controls", labelKey: "toolbar.mapControl.attribution", tier: "advanced" },
   { id: "controls.mapControl.logo", menuId: "controls", labelKey: "toolbar.mapControl.logo", tier: "advanced" },
   // Controls — overlays and panels
@@ -213,7 +218,9 @@ export const MENU_ITEM_CATALOG: readonly MenuItemCatalogEntry[] = [
   // Settings (the Settings menu and its Language/Layout/Interface entries always show)
   { id: "settings.mapPreferences", menuId: "settings", labelKey: "settings.menu.mapPreferences", tier: "intermediate" },
   { id: "settings.geocoding", menuId: "settings", labelKey: "settings.menu.geocoding", tier: "advanced" },
-  { id: "settings.environment", menuId: "settings", labelKey: "settings.menu.environmentVariables", tier: "advanced" },
+  // The AI Assistant (basic) reads its API key from environment variables, so
+  // keep this reachable at the beginner level too.
+  { id: "settings.environment", menuId: "settings", labelKey: "settings.menu.environmentVariables", tier: "basic" },
   { id: "settings.projectSettings", menuId: "settings", labelKey: "settings.menu.projectSettings", tier: "intermediate" },
   { id: "settings.managePlugins", menuId: "settings", labelKey: "settings.menu.managePlugins", tier: "intermediate" },
   // Help

--- a/docs/ui-profiles.md
+++ b/docs/ui-profiles.md
@@ -61,7 +61,7 @@ wizard is skipped, and — if `lock` is set — the Interface settings are read-
 | --- | --- | --- |
 | `enabled` | boolean | Whether filtering is active. Defaults to `true` for an admin file. |
 | `level` | `"beginner" \| "intermediate" \| "advanced"` | Seeds the hidden lists from each item's tier. Optional. |
-| `lock` | boolean | When `true`, users cannot change the profile from Settings. |
+| `lock` | boolean | When `true`, users cannot change the profile from Settings. Removing the file (or serving one without `lock`) releases the lock on the next launch. |
 | `hiddenDataSources` | string[] | Explicit data-source ids to hide. Overrides the preset when present. |
 | `hiddenPlugins` | string[] | Explicit plugin ids to hide. Overrides the preset when present. |
 
@@ -69,3 +69,7 @@ Data-source ids are the catalog ids in
 `apps/geolibre-desktop/src/lib/ui-profile.ts` (e.g. `vector`, `xyz`, `mbtiles`,
 `postgres`). Plugin ids are the stable ids defined in
 `packages/plugins/src/plugins/*` (e.g. `maplibre-gl-geoagent`).
+
+When a `level` preset is active, external/bundled drop-in plugins (which load
+asynchronously after startup) are folded into the hidden set as they appear, so
+a beginner profile keeps hiding advanced plugins even when they load late.

--- a/docs/ui-profiles.md
+++ b/docs/ui-profiles.md
@@ -1,0 +1,71 @@
+# UI Profiles & Data Source Filtering
+
+GeoLibre can hide data sources, web services, and plugins to simplify the
+interface for beginners or to standardize a deployment across a team. Hiding is
+**non-destructive** — nothing is removed, and any item can be re-enabled at any
+time. Profile preferences are stored locally in the browser/app and never travel
+inside a saved `.geolibre.json` project.
+
+## For users
+
+### Onboarding
+
+On first launch (when no administrator profile is present) GeoLibre asks for an
+experience level:
+
+- **Beginner** — only the essential data sources and tools.
+- **Intermediate** — common data sources, services, and plugins.
+- **Advanced** — everything GeoLibre offers.
+
+Choosing *Skip — show everything* keeps the full interface. The wizard appears
+only once; you can revisit the choice later in **Settings → Interface**.
+
+### Settings → Interface
+
+Open **Settings → Interface** to:
+
+- Toggle **Simplify the interface** on or off. When off, everything is visible
+  regardless of the lists below.
+- Apply an **experience-level** preset (Beginner / Intermediate / Advanced),
+  which fills the checklists from each item's complexity.
+- Check or uncheck individual **data sources** and **plugins**. Editing an item
+  makes the selection *custom* (no preset highlighted).
+
+## For administrators
+
+A deployment can be pre-configured (and optionally locked) with an
+`admin-profile.json` file. When present, it is applied on startup, the onboarding
+wizard is skipped, and — if `lock` is set — the Interface settings are read-only.
+
+### File location
+
+- **Web / embed:** serve `admin-profile.json` from the application root (for the
+  Docker/nginx build, the served document root). A missing file is ignored.
+- **Desktop:** place `admin-profile.json` in the app config directory
+  (`read_admin_profile` reads `<app_config_dir>/admin-profile.json`). The desktop
+  file takes precedence over a bundled web file.
+
+### File format
+
+```json
+{
+  "enabled": true,
+  "level": "intermediate",
+  "lock": true,
+  "hiddenDataSources": ["postgres", "video"],
+  "hiddenPlugins": ["maplibre-gl-geoagent"]
+}
+```
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `enabled` | boolean | Whether filtering is active. Defaults to `true` for an admin file. |
+| `level` | `"beginner" \| "intermediate" \| "advanced"` | Seeds the hidden lists from each item's tier. Optional. |
+| `lock` | boolean | When `true`, users cannot change the profile from Settings. |
+| `hiddenDataSources` | string[] | Explicit data-source ids to hide. Overrides the preset when present. |
+| `hiddenPlugins` | string[] | Explicit plugin ids to hide. Overrides the preset when present. |
+
+Data-source ids are the catalog ids in
+`apps/geolibre-desktop/src/lib/ui-profile.ts` (e.g. `vector`, `xyz`, `mbtiles`,
+`postgres`). Plugin ids are the stable ids defined in
+`packages/plugins/src/plugins/*` (e.g. `maplibre-gl-geoagent`).

--- a/docs/ui-profiles.md
+++ b/docs/ui-profiles.md
@@ -28,8 +28,13 @@ Open **Settings → Interface** to:
   regardless of the lists below.
 - Apply an **experience-level** preset (Beginner / Intermediate / Advanced),
   which fills the checklists from each item's complexity.
-- Check or uncheck individual **data sources** and **plugins**. Editing an item
-  makes the selection *custom* (no preset highlighted).
+- Check or uncheck individual **data sources**, **plugins**, whole **menus**
+  (Project, Edit, Add Data, Processing, Controls, Plugins, Help), and the items
+  within the Project, Edit, Processing, Controls, Settings, and Help menus.
+  Editing an item makes the selection *custom* (no preset highlighted).
+
+The **Settings** menu itself, and its Language / Layout / Interface entries, are
+always shown so the profile UI can never be hidden away.
 
 ## For administrators
 
@@ -64,11 +69,15 @@ wizard is skipped, and — if `lock` is set — the Interface settings are read-
 | `lock` | boolean | When `true`, users cannot change the profile from Settings. Removing the file (or serving one without `lock`) releases the lock on the next launch. |
 | `hiddenDataSources` | string[] | Explicit data-source ids to hide. Overrides the preset when present. |
 | `hiddenPlugins` | string[] | Explicit plugin ids to hide. Overrides the preset when present. |
+| `hiddenMenus` | string[] | Top-level menu ids to hide (`project`, `edit`, `addData`, `processing`, `controls`, `plugins`, `help`). |
+| `hiddenMenuItems` | string[] | Menu-item ids to hide (e.g. `processing.raster`, `help.diagnostics`, `controls.minimap`). |
 
 Data-source ids are the catalog ids in
 `apps/geolibre-desktop/src/lib/ui-profile.ts` (e.g. `vector`, `xyz`, `mbtiles`,
 `postgres`). Plugin ids are the stable ids defined in
-`packages/plugins/src/plugins/*` (e.g. `maplibre-gl-geoagent`).
+`packages/plugins/src/plugins/*` (e.g. `maplibre-gl-geoagent`). Menu and
+menu-item ids are the catalog ids in the same `ui-profile.ts`
+(`TOP_LEVEL_MENUS`, `MENU_ITEM_CATALOG`).
 
 When a `level` preset is active, external/bundled drop-in plugins (which load
 asynchronously after startup) are folded into the hidden set as they appear, so

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
       - Android: android.md
       - Project Format: project-format.md
       - Plugin API: plugin-api.md
+      - UI Profiles: ui-profiles.md
       - Internationalization: i18n.md
       - Python Package: python.md
       - Notebook Panel: notebook.md

--- a/tests/ui-profile.test.ts
+++ b/tests/ui-profile.test.ts
@@ -85,17 +85,20 @@ describe("menu presets and predicates", () => {
     assert.deepEqual(sets.hiddenMenuItems, []);
   });
 
-  it("beginner hides the intermediate plugins menu and advanced items", () => {
+  it("beginner keeps all top-level menus but hides advanced items", () => {
     const sets = presetHiddenSets("beginner", []);
-    // The Plugins top-level menu is intermediate-tier → hidden for beginners.
-    assert.ok(sets.hiddenMenus.includes("plugins"));
-    // A basic menu like Project stays.
-    assert.ok(!sets.hiddenMenus.includes("project"));
+    // Every top-level menu is basic-tier (decluttering happens at the item
+    // level), so no whole menu is hidden by the beginner preset.
+    assert.deepEqual(sets.hiddenMenus, []);
     // Advanced items are hidden; basic ones are not.
     assert.ok(sets.hiddenMenuItems.includes("processing.raster"));
     assert.ok(sets.hiddenMenuItems.includes("help.diagnostics"));
     assert.ok(!sets.hiddenMenuItems.includes("project.save"));
     assert.ok(!sets.hiddenMenuItems.includes("edit.undo"));
+    // Default-on controls and the Assistant's API-key settings stay reachable.
+    assert.ok(!sets.hiddenMenuItems.includes("controls.mapControl.globe"));
+    assert.ok(!sets.hiddenMenuItems.includes("controls.mapControl.scale"));
+    assert.ok(!sets.hiddenMenuItems.includes("settings.environment"));
   });
 
   it("never hides the Settings menu (excluded from TOP_LEVEL_MENUS)", () => {

--- a/tests/ui-profile.test.ts
+++ b/tests/ui-profile.test.ts
@@ -85,11 +85,11 @@ describe("menu presets and predicates", () => {
     assert.deepEqual(sets.hiddenMenuItems, []);
   });
 
-  it("beginner keeps all top-level menus but hides advanced items", () => {
+  it("beginner hides the Processing menu and advanced items", () => {
     const sets = presetHiddenSets("beginner", []);
-    // Every top-level menu is basic-tier (decluttering happens at the item
-    // level), so no whole menu is hidden by the beginner preset.
-    assert.deepEqual(sets.hiddenMenus, []);
+    // The Processing menu is intermediate-tier, so beginners don't see it.
+    assert.deepEqual(sets.hiddenMenus, ["processing"]);
+    assert.ok(!sets.hiddenMenus.includes("project"));
     // Advanced items are hidden; basic ones are not.
     assert.ok(sets.hiddenMenuItems.includes("processing.raster"));
     assert.ok(sets.hiddenMenuItems.includes("help.diagnostics"));
@@ -98,6 +98,7 @@ describe("menu presets and predicates", () => {
     // Default-on controls stay reachable for beginners.
     assert.ok(!sets.hiddenMenuItems.includes("controls.mapControl.globe"));
     assert.ok(!sets.hiddenMenuItems.includes("controls.mapControl.scale"));
+    assert.ok(!sets.hiddenMenuItems.includes("controls.mapControl.attribution"));
     // Items intentionally kept out of the beginner set.
     assert.ok(sets.hiddenMenuItems.includes("processing.assistant"));
     assert.ok(sets.hiddenMenuItems.includes("controls.legend"));

--- a/tests/ui-profile.test.ts
+++ b/tests/ui-profile.test.ts
@@ -8,7 +8,11 @@ import {
 } from "../apps/geolibre-desktop/src/hooks/useDesktopSettings";
 import {
   DATA_SOURCE_CATALOG,
+  MENU_ITEM_CATALOG,
+  TOP_LEVEL_MENUS,
   isDataSourceVisible,
+  isMenuItemVisible,
+  isMenuVisible,
   isPluginVisible,
   levelAllowsTier,
   pluginTier,
@@ -71,6 +75,51 @@ describe("presetHiddenSets", () => {
     assert.deepEqual(sets.hiddenPlugins, ["maplibre-gl-geoagent"]);
     assert.ok(sets.hiddenDataSources.includes("zarr")); // advanced
     assert.ok(!sets.hiddenDataSources.includes("wfs")); // intermediate
+  });
+});
+
+describe("menu presets and predicates", () => {
+  it("advanced hides no menus or items", () => {
+    const sets = presetHiddenSets("advanced", []);
+    assert.deepEqual(sets.hiddenMenus, []);
+    assert.deepEqual(sets.hiddenMenuItems, []);
+  });
+
+  it("beginner hides the intermediate plugins menu and advanced items", () => {
+    const sets = presetHiddenSets("beginner", []);
+    // The Plugins top-level menu is intermediate-tier → hidden for beginners.
+    assert.ok(sets.hiddenMenus.includes("plugins"));
+    // A basic menu like Project stays.
+    assert.ok(!sets.hiddenMenus.includes("project"));
+    // Advanced items are hidden; basic ones are not.
+    assert.ok(sets.hiddenMenuItems.includes("processing.raster"));
+    assert.ok(sets.hiddenMenuItems.includes("help.diagnostics"));
+    assert.ok(!sets.hiddenMenuItems.includes("project.save"));
+    assert.ok(!sets.hiddenMenuItems.includes("edit.undo"));
+  });
+
+  it("never hides the Settings menu (excluded from TOP_LEVEL_MENUS)", () => {
+    assert.ok(!TOP_LEVEL_MENUS.some((menu) => menu.id === "settings"));
+  });
+
+  it("never hides the Settings Interface entry", () => {
+    assert.ok(
+      !MENU_ITEM_CATALOG.some((entry) => entry.id === "settings.interface"),
+    );
+  });
+
+  it("respects enabled for menu and item predicates", () => {
+    const disabled = profile({ enabled: false, hiddenMenus: ["help"] });
+    assert.equal(isMenuVisible(disabled, "help"), true);
+    const enabled = profile({
+      enabled: true,
+      hiddenMenus: ["help"],
+      hiddenMenuItems: ["processing.raster"],
+    });
+    assert.equal(isMenuVisible(enabled, "help"), false);
+    assert.equal(isMenuVisible(enabled, "project"), true);
+    assert.equal(isMenuItemVisible(enabled, "processing.raster"), false);
+    assert.equal(isMenuItemVisible(enabled, "processing.vector"), true);
   });
 });
 

--- a/tests/ui-profile.test.ts
+++ b/tests/ui-profile.test.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  DEFAULT_UI_PROFILE_SETTINGS,
+  useDesktopSettingsStore,
+  type DesktopSettings,
+  type UiProfileSettings,
+} from "../apps/geolibre-desktop/src/hooks/useDesktopSettings";
+import {
+  DATA_SOURCE_CATALOG,
+  isDataSourceVisible,
+  isPluginVisible,
+  levelAllowsTier,
+  pluginTier,
+  presetHiddenSets,
+} from "../apps/geolibre-desktop/src/lib/ui-profile";
+
+function profile(patch: Partial<UiProfileSettings>): UiProfileSettings {
+  return { ...DEFAULT_UI_PROFILE_SETTINGS, ...patch };
+}
+
+describe("ui-profile tiers", () => {
+  it("reveals lower tiers as the level rises", () => {
+    assert.equal(levelAllowsTier("beginner", "basic"), true);
+    assert.equal(levelAllowsTier("beginner", "intermediate"), false);
+    assert.equal(levelAllowsTier("beginner", "advanced"), false);
+    assert.equal(levelAllowsTier("intermediate", "intermediate"), true);
+    assert.equal(levelAllowsTier("intermediate", "advanced"), false);
+    assert.equal(levelAllowsTier("advanced", "advanced"), true);
+  });
+
+  it("defaults unlisted plugins to intermediate", () => {
+    assert.equal(pluginTier("some-unknown-plugin"), "intermediate");
+    assert.equal(pluginTier("maplibre-layer-control"), "basic");
+    assert.equal(pluginTier("maplibre-gl-geoagent"), "advanced");
+  });
+});
+
+describe("presetHiddenSets", () => {
+  const pluginIds = [
+    "maplibre-layer-control", // basic
+    "maplibre-gl-swipe", // intermediate (default)
+    "maplibre-gl-geoagent", // advanced
+  ];
+
+  it("advanced hides nothing", () => {
+    const sets = presetHiddenSets("advanced", pluginIds);
+    assert.deepEqual(sets.hiddenDataSources, []);
+    assert.deepEqual(sets.hiddenPlugins, []);
+  });
+
+  it("beginner hides every non-basic item", () => {
+    const sets = presetHiddenSets("beginner", pluginIds);
+    const basicIds = DATA_SOURCE_CATALOG.filter(
+      (entry) => entry.tier === "basic",
+    ).map((entry) => entry.id);
+    for (const id of sets.hiddenDataSources) {
+      assert.ok(!basicIds.includes(id), `${id} should stay visible`);
+    }
+    // A known advanced source is hidden; a known basic source is not.
+    assert.ok(sets.hiddenDataSources.includes("postgres"));
+    assert.ok(!sets.hiddenDataSources.includes("vector"));
+    assert.deepEqual(sets.hiddenPlugins, [
+      "maplibre-gl-swipe",
+      "maplibre-gl-geoagent",
+    ]);
+  });
+
+  it("intermediate keeps basic + intermediate, hides advanced", () => {
+    const sets = presetHiddenSets("intermediate", pluginIds);
+    assert.deepEqual(sets.hiddenPlugins, ["maplibre-gl-geoagent"]);
+    assert.ok(sets.hiddenDataSources.includes("zarr")); // advanced
+    assert.ok(!sets.hiddenDataSources.includes("wfs")); // intermediate
+  });
+});
+
+describe("visibility predicates", () => {
+  it("shows everything when the profile is disabled", () => {
+    const disabled = profile({ enabled: false, hiddenDataSources: ["postgres"] });
+    assert.equal(isDataSourceVisible(disabled, "postgres"), true);
+  });
+
+  it("hides listed ids only when enabled", () => {
+    const enabled = profile({
+      enabled: true,
+      hiddenDataSources: ["postgres"],
+      hiddenPlugins: ["maplibre-gl-geoagent"],
+    });
+    assert.equal(isDataSourceVisible(enabled, "postgres"), false);
+    assert.equal(isDataSourceVisible(enabled, "vector"), true);
+    assert.equal(isPluginVisible(enabled, "maplibre-gl-geoagent"), false);
+    assert.equal(isPluginVisible(enabled, "maplibre-layer-control"), true);
+  });
+});
+
+describe("normalizeUiProfileSettings (via the store)", () => {
+  function normalized(uiProfile: unknown): UiProfileSettings {
+    useDesktopSettingsStore.getState().setDesktopSettings({
+      uiProfile,
+    } as unknown as DesktopSettings);
+    return useDesktopSettingsStore.getState().desktopSettings.uiProfile;
+  }
+
+  it("defaults to everything visible for legacy settings", () => {
+    assert.deepEqual(normalized(undefined), DEFAULT_UI_PROFILE_SETTINGS);
+  });
+
+  it("rejects tampered non-boolean and unknown-level values", () => {
+    const result = normalized({
+      enabled: "yes",
+      level: "expert",
+      onboarded: 1,
+      locked: "true",
+      hiddenDataSources: ["postgres", 42, "postgres", ""],
+      hiddenPlugins: "nope",
+    });
+    assert.equal(result.enabled, false);
+    assert.equal(result.level, null);
+    assert.equal(result.onboarded, false);
+    assert.equal(result.locked, false);
+    // Non-strings dropped, duplicates/blank removed.
+    assert.deepEqual(result.hiddenDataSources, ["postgres"]);
+    assert.deepEqual(result.hiddenPlugins, []);
+  });
+
+  it("preserves valid values", () => {
+    const result = normalized({
+      enabled: true,
+      level: "beginner",
+      onboarded: true,
+      locked: true,
+      hiddenDataSources: ["postgres"],
+      hiddenPlugins: ["maplibre-gl-geoagent"],
+    });
+    assert.equal(result.enabled, true);
+    assert.equal(result.level, "beginner");
+    assert.equal(result.locked, true);
+    assert.deepEqual(result.hiddenPlugins, ["maplibre-gl-geoagent"]);
+  });
+});

--- a/tests/ui-profile.test.ts
+++ b/tests/ui-profile.test.ts
@@ -95,10 +95,14 @@ describe("menu presets and predicates", () => {
     assert.ok(sets.hiddenMenuItems.includes("help.diagnostics"));
     assert.ok(!sets.hiddenMenuItems.includes("project.save"));
     assert.ok(!sets.hiddenMenuItems.includes("edit.undo"));
-    // Default-on controls and the Assistant's API-key settings stay reachable.
+    // Default-on controls stay reachable for beginners.
     assert.ok(!sets.hiddenMenuItems.includes("controls.mapControl.globe"));
     assert.ok(!sets.hiddenMenuItems.includes("controls.mapControl.scale"));
-    assert.ok(!sets.hiddenMenuItems.includes("settings.environment"));
+    // Items intentionally kept out of the beginner set.
+    assert.ok(sets.hiddenMenuItems.includes("processing.assistant"));
+    assert.ok(sets.hiddenMenuItems.includes("controls.legend"));
+    assert.ok(sets.hiddenMenuItems.includes("settings.environment"));
+    assert.ok(sets.hiddenDataSources.includes("duckdb"));
   });
 
   it("never hides the Settings menu (excluded from TOP_LEVEL_MENUS)", () => {


### PR DESCRIPTION
Closes #500.

Adds an opt-in **UI profile** system so beginners and organizational deployments can declutter the interface by hiding data sources, web services, and plugins. Hiding is **non-destructive and fully reversible** — items can be re-enabled at any time.

## What's included

All four parts of the request:

1. **Checkbox visibility toggles** for data sources / web services / plugins (Settings → Interface).
2. **Experience-level presets** — Beginner / Intermediate / Advanced.
3. **First-launch onboarding wizard** that picks a profile when none exists.
4. **Admin config file** (`admin-profile.json`) that pre-configures and can *lock* the profile for a team.

## Design

A single complexity **tier** (`basic | intermediate | advanced`) drives everything. Each Add Data item and plugin is assigned a tier in one place (`apps/geolibre-desktop/src/lib/ui-profile.ts`); a preset shows every item at or below the chosen level and computes concrete hidden-id lists, which is all the runtime filters on. Manually toggling a checkbox makes the selection "custom".

Preferences are **machine-local** — stored in the existing `useDesktopSettings` localStorage store, never in `.geolibre.json`. The default is "everything visible", so existing users see no change.

## Key files

- `hooks/useDesktopSettings.ts` — `uiProfile` model + strict normalizer
- `lib/ui-profile.ts` — catalog, tiers, presets, visibility predicates
- `lib/admin-profile.ts` + `src-tauri/src/lib.rs` (`read_admin_profile`) — admin config loader
- `toolbar/AddDataMenu.tsx`, `toolbar/PluginsMenu.tsx` — menu filtering
- `SettingsDialog.tsx` — Interface section
- `OnboardingDialog.tsx` + `hooks/useUiProfileBootstrap.ts` — first-launch wizard
- `docs/ui-profiles.md` — user + admin documentation

## Verification

- `npm run typecheck`, `npm run check:rust`, `npm run test:frontend` (1114 pass) — all green.
- New unit tests cover the tier math, presets, visibility predicates, and settings normalization (back-compat default + tampered-value rejection).
- **Driven in the real app with Playwright**: fresh launch shows the wizard → picking Beginner filters the Add Data menu to the 8 basic items (empty sections collapse) → Settings → Interface renders with correct checkbox states → switching to Advanced + Save restores all 25 items, persisted across reload.


## Notes

- Plugin hiding is menu-level only (it does not force-deactivate already-placed map controls) to avoid fighting project-state restore.
- Tiers live in one module, so curating which items appear at each level is a single-file edit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
- Added first-launch onboarding to select an interface experience level (Beginner/Intermediate/Advanced) or “Skip” to show everything.
- Added **Settings → Interface** to enable/lock the profile, pick presets, and customize hidden data sources, plugins, menus, and menu items.

**UI Profiles (Admin)**
- Added support for administrator-provided `admin-profile.json` to preset (and optionally lock) the interface profile.

**Bug Fixes / Improvements**
- Menus and toolbars now dynamically hide items based on the active UI profile.

**Documentation & Tests**
- Added UI Profiles documentation and reference navigation, plus automated tests for profile behavior and settings normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->