### PR TITLE
feat(map): refine default top-right map controls (#512)

### DIFF
--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -171,7 +171,7 @@ export const DEFAULT_BUILT_IN_CONTROL_VISIBILITY: Record<
   BuiltInMapControl,
   boolean
 > = {
-  navigation: true,
+  navigation: false,
   fullscreen: true,
   geolocate: false,
   globe: true,

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -278,8 +278,11 @@ export class MapController {
     this.map.on("style.load", handleStyleReady);
     this.map.once("load", handleStyleReady);
     this.map.once("idle", () => this.enforceProjection());
-    this.addNavigationControl();
+    // Add the fullscreen toggle first so it anchors the top of the top-right
+    // control cluster, matching the universal placement users expect (issue
+    // #512). MapLibre stacks controls in insertion order within a corner.
     this.addFullscreenControl();
+    this.addNavigationControl();
     this.addGeolocateControl();
     this.addGlobeControl();
     this.addTerrainControl();


### PR DESCRIPTION
## Summary

- Move the fullscreen toggle so it anchors the top of the top-right control cluster (above where the zoom buttons sit), matching the universal top-right placement for window-management actions. Closes #512.
- Hide the navigation control (zoom +/- and compass) by default for a cleaner initial control cluster. It remains toggleable from the map controls toolbar.

Both are driven by the single source of truth in `packages/map/src/map-controller.ts`: control insertion order at init plus `DEFAULT_BUILT_IN_CONTROL_VISIBILITY`. MapLibre stacks controls in insertion order within a corner, and the toolbar toggle reads the same default map.

## Test plan

- [x] `npm run test:frontend` (1104 passing, 0 failing)
- [x] `tsc -b` and pre-commit (eslint + npm build) pass
- [x] Drove the running app with Playwright: top-right DOM order is `[fullscreen, globe, layer-control]` with `hasNavigation: false`, confirming the fullscreen toggle anchors the cluster and the zoom buttons are hidden by default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default visibility of the built-in map navigation control to be disabled.
  * Adjusted the top-right stacking order so the fullscreen control appears above the navigation controls for clearer interface layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->