### PR TITLE
fix(toolbar): keep Redo shortcut on one line in Edit menu (#511)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/toolbar/EditMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/EditMenu.tsx
@@ -42,20 +42,20 @@ export function EditMenu({ chrome }: EditMenuProps) {
           {chrome.renderLabel(t("toolbar.menu.edit"))}
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="w-56">
+      <DropdownMenuContent align="start" className="min-w-56">
         <DropdownMenuLabel>{t("toolbar.menu.edit")}</DropdownMenuLabel>
         <DropdownMenuSeparator />
         <DropdownMenuItem disabled={!canUndo} onSelect={undo}>
-          <Undo2 className="mr-2 h-3.5 w-3.5" />
-          {t("toolbar.item.undo")}
-          <span className="ml-auto text-xs text-muted-foreground">
+          <Undo2 className="mr-2 h-3.5 w-3.5 shrink-0" />
+          <span className="whitespace-nowrap">{t("toolbar.item.undo")}</span>
+          <span className="ml-auto shrink-0 whitespace-nowrap pl-4 text-xs text-muted-foreground">
             Ctrl/Cmd+Z
           </span>
         </DropdownMenuItem>
         <DropdownMenuItem disabled={!canRedo} onSelect={redo}>
-          <Redo2 className="mr-2 h-3.5 w-3.5" />
-          {t("toolbar.item.redo")}
-          <span className="ml-auto text-xs text-muted-foreground">
+          <Redo2 className="mr-2 h-3.5 w-3.5 shrink-0" />
+          <span className="whitespace-nowrap">{t("toolbar.item.redo")}</span>
+          <span className="ml-auto shrink-0 whitespace-nowrap pl-4 text-xs text-muted-foreground">
             Ctrl/Cmd+Shift+Z / Ctrl+Y
           </span>
         </DropdownMenuItem>

--- a/apps/geolibre-desktop/src/components/layout/toolbar/EditMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/EditMenu.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
+  DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from "@geolibre/ui";
 import { Pencil, Redo2, Undo2 } from "lucide-react";
@@ -48,16 +49,12 @@ export function EditMenu({ chrome }: EditMenuProps) {
         <DropdownMenuItem disabled={!canUndo} onSelect={undo}>
           <Undo2 className="mr-2 h-3.5 w-3.5 shrink-0" />
           <span className="whitespace-nowrap">{t("toolbar.item.undo")}</span>
-          <span className="ml-auto shrink-0 whitespace-nowrap pl-4 text-xs text-muted-foreground">
-            Ctrl/Cmd+Z
-          </span>
+          <DropdownMenuShortcut>Ctrl/Cmd+Z</DropdownMenuShortcut>
         </DropdownMenuItem>
         <DropdownMenuItem disabled={!canRedo} onSelect={redo}>
           <Redo2 className="mr-2 h-3.5 w-3.5 shrink-0" />
           <span className="whitespace-nowrap">{t("toolbar.item.redo")}</span>
-          <span className="ml-auto shrink-0 whitespace-nowrap pl-4 text-xs text-muted-foreground">
-            Ctrl/Cmd+Shift+Z / Ctrl+Y
-          </span>
+          <DropdownMenuShortcut>Ctrl/Cmd+Shift+Z / Ctrl+Y</DropdownMenuShortcut>
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -176,3 +176,17 @@ export const DropdownMenuSeparator = React.forwardRef<
 ));
 DropdownMenuSeparator.displayName =
   DropdownMenuPrimitive.Separator.displayName;
+
+export const DropdownMenuShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => (
+  <span
+    className={cn(
+      "ml-auto shrink-0 whitespace-nowrap pl-4 text-xs text-muted-foreground",
+      className,
+    )}
+    {...props}
+  />
+);
+DropdownMenuShortcut.displayName = "DropdownMenuShortcut";

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -34,6 +34,7 @@ export {
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
+  DropdownMenuShortcut,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,


### PR DESCRIPTION
Fixes #511.

## Problem
In the Edit menu, the Redo item's keyboard-shortcut hint (`Ctrl/Cmd+Shift+Z / Ctrl+Y`) was long enough to wrap onto a second line and overlap the "Redo" label, breaking the menu's alignment.

## Fix
- Let the menu auto-size with `min-w-56` instead of a fixed `w-56`, so it grows to fit the longest row.
- Wrap the Undo/Redo labels and mark the shortcut spans `shrink-0 whitespace-nowrap` (with `pl-4` for spacing) so each row stays on a single line and stays aligned.
- Add `shrink-0` to the icons.

## Verification
Drove the running app with Playwright, opened the Edit menu, and confirmed the Redo row renders on a single line with the full shortcut visible and no overflow/overlap. Measured `scrollWidth === clientWidth` (no clipping) and a single client rect for the row.

Before vs after:

| Before | After |
| --- | --- |
| Shortcut wraps and overlaps the "Redo" label | Single line, fully visible, aligned |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent keyboard shortcut hint rendering for dropdown menu items (improves clarity and alignment).
* **Refactor**
  * Refined the Edit menu undo/redo dropdown layout and styling, including more reliable spacing and disabled-state behavior.
* **Documentation**
  * Updated the public UI dropdown-menu exports to include the new shortcut-hint component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->