### PR TITLE
feat(map): add reset pitch & bearing control with rotation indicator

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -660,11 +660,12 @@ export function DesktopShell({
     setMapReadyGeneration((generation) => generation + 1);
   }, []);
 
-  // Keep the on-map reset-pitch/bearing control's tooltip translated. Re-runs
-  // when the controller (re)initialises (mapReadyGeneration) and on language
-  // change (t identity changes), since that native control lives outside React.
+  // Keep the on-map compass (reset pitch/bearing) control's tooltip translated.
+  // Re-runs when the controller (re)initialises (mapReadyGeneration) and on
+  // language change (t identity changes), since that native control lives
+  // outside React.
   useEffect(() => {
-    mapControllerRef.current?.setResetBearingLabel(
+    mapControllerRef.current?.setCompassLabel(
       t("toolbar.item.resetPitchBearing"),
     );
   }, [t, mapReadyGeneration]);

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -660,6 +660,15 @@ export function DesktopShell({
     setMapReadyGeneration((generation) => generation + 1);
   }, []);
 
+  // Keep the on-map reset-pitch/bearing control's tooltip translated. Re-runs
+  // when the controller (re)initialises (mapReadyGeneration) and on language
+  // change (t identity changes), since that native control lives outside React.
+  useEffect(() => {
+    mapControllerRef.current?.setResetBearingLabel(
+      t("toolbar.item.resetPitchBearing"),
+    );
+  }, [t, mapReadyGeneration]);
+
   const handleMapDiagnosticEvent = useCallback((event: MapDiagnosticEvent) => {
     appendDiagnostic({
       category: "map",

--- a/apps/geolibre-desktop/src/components/layout/toolbar/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/constants.ts
@@ -56,6 +56,7 @@ export const MAP_CONTROL_ITEMS: Array<{
 }> = [
   { id: "navigation", labelKey: "toolbar.mapControl.navigation" },
   { id: "fullscreen", labelKey: "toolbar.mapControl.fullscreen" },
+  { id: "compass", labelKey: "toolbar.mapControl.compass" },
   { id: "geolocate", labelKey: "toolbar.mapControl.geolocate" },
   { id: "globe", labelKey: "toolbar.mapControl.globe" },
   { id: "terrain", labelKey: "toolbar.mapControl.terrain" },
@@ -67,6 +68,7 @@ export const MAP_CONTROL_ITEMS: Array<{
 export const NEW_PROJECT_VISIBLE_BUILT_IN_CONTROLS = new Set<BuiltInMapControl>([
   "navigation",
   "fullscreen",
+  "compass",
   "globe",
   "layer-control",
 ]);

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -830,6 +830,7 @@
     "mapControl": {
       "navigation": "Navigation",
       "fullscreen": "Fullscreen",
+      "compass": "Compass",
       "geolocate": "Geolocate",
       "globe": "Globe",
       "terrain": "Terrain",

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1461,6 +1461,45 @@ body,
   background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='22' fill='none' stroke='%2333b5e5' viewBox='0 0 22 22'%3E%3Ccircle cx='11' cy='11' r='8.5'/%3E%3Cpath d='M17.5 11c0 4.819-3.02 8.5-6.5 8.5S4.5 15.819 4.5 11 7.52 2.5 11 2.5s6.5 3.681 6.5 8.5Z'/%3E%3Cpath d='M13.5 11c0 2.447-.331 4.64-.853 6.206-.262.785-.562 1.384-.872 1.777-.314.399-.58.517-.775.517s-.461-.118-.775-.517c-.31-.393-.61-.992-.872-1.777C8.831 15.64 8.5 13.446 8.5 11s.331-4.64.853-6.206c.262-.785.562-1.384.872-1.777.314-.399.58-.517.775-.517s.461.118.775.517c.31.393.61.992.872 1.777.522 1.565.853 3.76.853 6.206Z'/%3E%3Cpath d='M11 7.5c-1.909 0-3.622-.166-4.845-.428-.616-.132-1.08-.283-1.379-.434a1.3 1.3 0 0 1-.224-.138q.07-.058.224-.138c.299-.151.763-.302 1.379-.434C7.378 5.666 9.091 5.5 11 5.5s3.622.166 4.845.428c.616.132 1.08.283 1.379.434.105.053.177.1.224.138q-.07.058-.224.138c-.299.151-.763.302-1.379.434-1.223.262-2.936.428-4.845.428ZM4.486 6.436ZM11 16.5c-1.909 0-3.622-.166-4.845-.428-.616-.132-1.08-.283-1.379-.434a1.3 1.3 0 0 1-.224-.138 1.3 1.3 0 0 1 .224-.138c.299-.151.763-.302 1.379-.434C7.378 14.666 9.091 14.5 11 14.5s3.622.166 4.845.428c.616.132 1.08.283 1.379.434.105.053.177.1.224.138a1.3 1.3 0 0 1-.224.138c-.299.151-.763.302-1.379.434-1.223.262-2.936.428-4.845.428Zm-6.514-1.064ZM11 12.5c-2.46 0-4.672-.222-6.255-.574-.796-.177-1.406-.38-1.805-.59a1.5 1.5 0 0 1-.39-.272.3.3 0 0 1-.047-.064.3.3 0 0 1 .048-.064c.066-.073.189-.167.389-.272.399-.21 1.009-.413 1.805-.59C6.328 9.722 8.54 9.5 11 9.5s4.672.222 6.256.574c.795.177 1.405.38 1.804.59.2.105.323.2.39.272a.3.3 0 0 1 .047.064.3.3 0 0 1-.048.064 1.4 1.4 0 0 1-.389.272c-.399.21-1.009.413-1.804.59-1.584.352-3.796.574-6.256.574Zm-8.501-1.51v.002zm0 .018v.002zm17.002.002v-.002zm0-.018v-.002z'/%3E%3C/svg%3E");
 }
 
+/* Reset Pitch & Bearing control (issue #508). Sits directly below the
+   Fullscreen button. The compass needle tracks the live bearing and its north
+   half turns red the moment the map is rotated or tilted, so a skewed view is
+   unmistakable; while north-up and flat the button is disabled and muted since
+   there is nothing to reset. The button inherits its size/background from the
+   default maplibregl-ctrl-group button styling. */
+.geolibre-reset-bearing-button {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+}
+
+.geolibre-reset-bearing-needle {
+  height: 20px;
+  transform-origin: 50% 50%;
+  width: 20px;
+}
+
+.geolibre-reset-bearing-needle-north {
+  fill: #6b7280;
+  transition: fill 150ms ease;
+}
+
+.geolibre-reset-bearing-needle-south {
+  fill: #c7ccd4;
+}
+
+.geolibre-reset-bearing-button--active .geolibre-reset-bearing-needle-north {
+  fill: hsl(var(--destructive));
+}
+
+.geolibre-reset-bearing-button:disabled {
+  cursor: default;
+}
+
+.geolibre-reset-bearing-button:disabled .geolibre-reset-bearing-needle {
+  opacity: 0.55;
+}
+
 /* maplibre-gl-layer-control toggle button icon color.
    The library (>=0.15.1) sizes the icon itself but leaves its color to the host
    theme (the SVG uses stroke="currentColor"). GeoLibre keeps map controls light

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1461,43 +1461,42 @@ body,
   background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='22' fill='none' stroke='%2333b5e5' viewBox='0 0 22 22'%3E%3Ccircle cx='11' cy='11' r='8.5'/%3E%3Cpath d='M17.5 11c0 4.819-3.02 8.5-6.5 8.5S4.5 15.819 4.5 11 7.52 2.5 11 2.5s6.5 3.681 6.5 8.5Z'/%3E%3Cpath d='M13.5 11c0 2.447-.331 4.64-.853 6.206-.262.785-.562 1.384-.872 1.777-.314.399-.58.517-.775.517s-.461-.118-.775-.517c-.31-.393-.61-.992-.872-1.777C8.831 15.64 8.5 13.446 8.5 11s.331-4.64.853-6.206c.262-.785.562-1.384.872-1.777.314-.399.58-.517.775-.517s.461.118.775.517c.31.393.61.992.872 1.777.522 1.565.853 3.76.853 6.206Z'/%3E%3Cpath d='M11 7.5c-1.909 0-3.622-.166-4.845-.428-.616-.132-1.08-.283-1.379-.434a1.3 1.3 0 0 1-.224-.138q.07-.058.224-.138c.299-.151.763-.302 1.379-.434C7.378 5.666 9.091 5.5 11 5.5s3.622.166 4.845.428c.616.132 1.08.283 1.379.434.105.053.177.1.224.138q-.07.058-.224.138c-.299.151-.763.302-1.379.434-1.223.262-2.936.428-4.845.428ZM4.486 6.436ZM11 16.5c-1.909 0-3.622-.166-4.845-.428-.616-.132-1.08-.283-1.379-.434a1.3 1.3 0 0 1-.224-.138 1.3 1.3 0 0 1 .224-.138c.299-.151.763-.302 1.379-.434C7.378 14.666 9.091 14.5 11 14.5s3.622.166 4.845.428c.616.132 1.08.283 1.379.434.105.053.177.1.224.138a1.3 1.3 0 0 1-.224.138c-.299.151-.763.302-1.379.434-1.223.262-2.936.428-4.845.428Zm-6.514-1.064ZM11 12.5c-2.46 0-4.672-.222-6.255-.574-.796-.177-1.406-.38-1.805-.59a1.5 1.5 0 0 1-.39-.272.3.3 0 0 1-.047-.064.3.3 0 0 1 .048-.064c.066-.073.189-.167.389-.272.399-.21 1.009-.413 1.805-.59C6.328 9.722 8.54 9.5 11 9.5s4.672.222 6.256.574c.795.177 1.405.38 1.804.59.2.105.323.2.39.272a.3.3 0 0 1 .047.064.3.3 0 0 1-.048.064 1.4 1.4 0 0 1-.389.272c-.399.21-1.009.413-1.804.59-1.584.352-3.796.574-6.256.574Zm-8.501-1.51v.002zm0 .018v.002zm17.002.002v-.002zm0-.018v-.002z'/%3E%3C/svg%3E");
 }
 
-/* Reset Pitch & Bearing control (issue #508). Sits directly below the
-   Fullscreen button. The compass needle tracks the live bearing and its north
-   half turns red the moment the map is rotated or tilted, so a skewed view is
-   unmistakable; while north-up and flat the button is disabled and muted since
-   there is nothing to reset. The button inherits its size/background from the
-   default maplibregl-ctrl-group button styling. */
-.geolibre-reset-bearing-button {
+/* Compass control (issue #508). Sits directly below the Fullscreen button. The
+   needle tracks the live bearing and its north half turns red the moment the
+   map is rotated or tilted, so a skewed view is unmistakable; while north-up
+   and flat the button is disabled (nothing to reset) but stays high-contrast,
+   since that is its resting appearance. GeoLibre keeps map controls light
+   (white) in both themes, so the needle uses dark fills that stay legible in
+   light and dark mode alike. The button selector carries two classes so it
+   outranks maplibre's equally-specific `.maplibregl-ctrl-group button { display:
+   block }` (which loads later and would otherwise left-align the needle). */
+.geolibre-reset-bearing-ctrl .geolibre-reset-bearing-button {
   align-items: center;
   display: flex;
   justify-content: center;
 }
 
 .geolibre-reset-bearing-needle {
-  height: 20px;
+  height: 24px;
   transform-origin: 50% 50%;
-  width: 20px;
+  width: 24px;
 }
 
 .geolibre-reset-bearing-needle-north {
-  fill: #6b7280;
+  fill: #334155;
   transition: fill 150ms ease;
 }
 
 .geolibre-reset-bearing-needle-south {
-  fill: #c7ccd4;
+  fill: #64748b;
 }
 
 .geolibre-reset-bearing-button--active .geolibre-reset-bearing-needle-north {
   fill: hsl(var(--destructive));
 }
 
-.geolibre-reset-bearing-button:disabled {
+.geolibre-reset-bearing-ctrl .geolibre-reset-bearing-button:disabled {
   cursor: default;
-}
-
-.geolibre-reset-bearing-button:disabled .geolibre-reset-bearing-needle {
-  opacity: 0.55;
 }
 
 /* maplibre-gl-layer-control toggle button icon color.

--- a/apps/geolibre-desktop/src/lib/admin-profile.ts
+++ b/apps/geolibre-desktop/src/lib/admin-profile.ts
@@ -13,6 +13,7 @@ import {
   type ExperienceLevel,
   type UiProfileSettings,
 } from "../hooks/useDesktopSettings";
+import { OPTIONAL_RESOURCE_HEADER } from "./diagnostics";
 import { isTauri } from "./is-tauri";
 import { normalizeStringList } from "./string-lists";
 import { presetHiddenSets } from "./ui-profile";
@@ -81,7 +82,12 @@ async function readAdminProfileFile(): Promise<AdminProfileFile | null> {
   }
 
   try {
-    const response = await fetch(`${import.meta.env.BASE_URL}admin-profile.json`);
+    // The admin file is optional; a 404 here is the normal "no admin profile"
+    // case, so flag the request benign to keep it out of the error diagnostics.
+    const response = await fetch(
+      `${import.meta.env.BASE_URL}admin-profile.json`,
+      { headers: { [OPTIONAL_RESOURCE_HEADER]: "1" } },
+    );
     if (!response.ok) return null;
     return parseAdminProfile(await response.text());
   } catch {

--- a/apps/geolibre-desktop/src/lib/diagnostics.ts
+++ b/apps/geolibre-desktop/src/lib/diagnostics.ts
@@ -61,6 +61,42 @@ const FETCH_FAILURE_MESSAGES = ["Failed to fetch", "Load failed"];
 const TAURI_IPC_FALLBACK_WARNING =
   "IPC custom protocol failed, Tauri will now use the postMessage interface instead";
 
+// Request header that flags a fetch whose failure (typically a 404) is expected
+// and harmless — e.g. an optional config file that may simply be absent. A
+// non-ok response to such a request is recorded at info level instead of error,
+// so it does not surface as a problem in the diagnostics panel (issue follow-up
+// to #500: the optional admin-profile.json 404 on every load).
+export const OPTIONAL_RESOURCE_HEADER = "x-geolibre-optional-resource";
+
+/** Read a single header value across the Headers/array/record init shapes. */
+function readHeader(headers: HeadersInit | undefined, name: string): string | null {
+  if (!headers) return null;
+  const target = name.toLowerCase();
+  if (headers instanceof Headers) return headers.get(name);
+  if (Array.isArray(headers)) {
+    for (const [key, value] of headers) {
+      if (key.toLowerCase() === target) return value;
+    }
+    return null;
+  }
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === target) return value;
+  }
+  return null;
+}
+
+/** Whether a request opted out of error-level logging for benign failures. */
+function isOptionalResourceRequest(
+  input: Parameters<typeof fetch>[0],
+  init: Parameters<typeof fetch>[1],
+): boolean {
+  if (readHeader(init?.headers, OPTIONAL_RESOURCE_HEADER) != null) return true;
+  return (
+    input instanceof Request &&
+    input.headers.get(OPTIONAL_RESOURCE_HEADER) != null
+  );
+}
+
 function looksLikeFetchFailure(reason: unknown): boolean {
   const message =
     reason instanceof Error
@@ -310,11 +346,15 @@ export function installDiagnosticsCapture(): () => void {
     const method = requestMethod(input, init);
     const url = requestUrl(input);
 
+    // A request may declare that a non-ok response (e.g. a 404 for an optional
+    // file) is expected, so it is logged as info rather than flagged an error.
+    const optional = isOptionalResourceRequest(input, init);
+
     try {
       const response = await originalFetch(input, init);
       appendDiagnostic({
         category: "network",
-        level: response.ok ? "info" : "error",
+        level: response.ok || optional ? "info" : "error",
         message: `${method} ${response.status} ${response.statusText}`.trim(),
         durationMs: Math.round(performance.now() - startedAt),
         method,

--- a/apps/geolibre-desktop/src/lib/diagnostics.ts
+++ b/apps/geolibre-desktop/src/lib/diagnostics.ts
@@ -122,6 +122,35 @@ function isOptionalResourceRequest(
   );
 }
 
+/**
+ * Remove the optional-resource marker before the request leaves the app. It is a
+ * client-side diagnostics hint with no meaning to any server; forwarding it
+ * would, on a cross-origin request, turn it into a non-simple header that forces
+ * a CORS preflight the server would have to allow.
+ */
+function stripOptionalResourceHeader(
+  input: Parameters<typeof fetch>[0],
+  init: Parameters<typeof fetch>[1],
+): { input: Parameters<typeof fetch>[0]; init: Parameters<typeof fetch>[1] } {
+  // init.headers, when present, is what actually gets sent (it replaces a
+  // Request input's headers), so strip it there.
+  if (init?.headers !== undefined) {
+    if (readHeader(init.headers, OPTIONAL_RESOURCE_HEADER) == null) {
+      return { input, init };
+    }
+    const headers = new Headers(init.headers);
+    headers.delete(OPTIONAL_RESOURCE_HEADER);
+    return { input, init: { ...init, headers } };
+  }
+  // Otherwise a Request input may carry it; rebuild without the marker.
+  if (input instanceof Request && input.headers.has(OPTIONAL_RESOURCE_HEADER)) {
+    const headers = new Headers(input.headers);
+    headers.delete(OPTIONAL_RESOURCE_HEADER);
+    return { input: new Request(input, { headers }), init };
+  }
+  return { input, init };
+}
+
 function looksLikeFetchFailure(reason: unknown): boolean {
   const message =
     reason instanceof Error
@@ -373,11 +402,13 @@ export function installDiagnosticsCapture(): () => void {
 
     // A request may declare that a failure (a non-ok response such as a 404, or
     // a thrown network error) is expected — e.g. an optional config file that
-    // may be absent — so it is logged as info rather than flagged an error.
+    // may be absent — so it is logged as info rather than flagged an error. The
+    // marker is read here, then stripped so it never reaches the server.
     const optional = isOptionalResourceRequest(input, init);
+    const forwarded = stripOptionalResourceHeader(input, init);
 
     try {
-      const response = await originalFetch(input, init);
+      const response = await originalFetch(forwarded.input, forwarded.init);
       appendDiagnostic({
         category: "network",
         level: response.ok || optional ? "info" : "error",

--- a/apps/geolibre-desktop/src/lib/diagnostics.ts
+++ b/apps/geolibre-desktop/src/lib/diagnostics.ts
@@ -72,7 +72,7 @@ export const OPTIONAL_RESOURCE_HEADER = "x-geolibre-optional-resource";
 function readHeader(headers: HeadersInit | undefined, name: string): string | null {
   if (!headers) return null;
   const target = name.toLowerCase();
-  if (headers instanceof Headers) return headers.get(name);
+  if (headers instanceof Headers) return headers.get(target);
   if (Array.isArray(headers)) {
     for (const [key, value] of headers) {
       if (key.toLowerCase() === target) return value;
@@ -346,8 +346,9 @@ export function installDiagnosticsCapture(): () => void {
     const method = requestMethod(input, init);
     const url = requestUrl(input);
 
-    // A request may declare that a non-ok response (e.g. a 404 for an optional
-    // file) is expected, so it is logged as info rather than flagged an error.
+    // A request may declare that a failure (a non-ok response such as a 404, or
+    // a thrown network error) is expected — e.g. an optional config file that
+    // may be absent — so it is logged as info rather than flagged an error.
     const optional = isOptionalResourceRequest(input, init);
 
     try {
@@ -368,7 +369,7 @@ export function installDiagnosticsCapture(): () => void {
         error.name === "AbortError";
       appendDiagnostic({
         category: "network",
-        level: isAbort ? "info" : "error",
+        level: isAbort || optional ? "info" : "error",
         message: isAbort ? `${method} aborted` : `${method} request failed`,
         detail: isAbort ? undefined : formatUnknown(error),
         durationMs: Math.round(performance.now() - startedAt),

--- a/apps/geolibre-desktop/src/lib/diagnostics.ts
+++ b/apps/geolibre-desktop/src/lib/diagnostics.ts
@@ -90,7 +90,13 @@ function isOptionalResourceRequest(
   input: Parameters<typeof fetch>[0],
   init: Parameters<typeof fetch>[1],
 ): boolean {
-  if (readHeader(init?.headers, OPTIONAL_RESOURCE_HEADER) != null) return true;
+  // Per the fetch spec, when init.headers is provided it replaces a Request
+  // input's headers entirely, so only fall back to the Request's own headers
+  // when init omits them — otherwise an init that drops the marker would still
+  // be treated as optional.
+  if (init?.headers !== undefined) {
+    return readHeader(init.headers, OPTIONAL_RESOURCE_HEADER) != null;
+  }
   return (
     input instanceof Request &&
     input.headers.get(OPTIONAL_RESOURCE_HEADER) != null

--- a/apps/geolibre-desktop/src/lib/diagnostics.ts
+++ b/apps/geolibre-desktop/src/lib/diagnostics.ts
@@ -65,7 +65,7 @@ const TAURI_IPC_FALLBACK_WARNING =
 // inertia of a rotate/tilt gesture, double-click zoom, etc.) while the globe
 // projection is active — globe simply ignores the around-point and the camera
 // still moves correctly. It is harmless but fires on routine interaction, so it
-// is dropped from diagnostics entirely rather than echoed on every gesture.
+// is kept out of the diagnostics panel (still echoed to the console for devs).
 const BENIGN_CONSOLE_WARNINGS = [
   "Easing around a point is not supported under globe projection.",
 ];
@@ -450,9 +450,13 @@ export function installDiagnosticsCapture(): () => void {
 
   console.warn = (...args: unknown[]) => {
     // Known-benign third-party warnings (e.g. MapLibre's globe easing notice on
-    // every rotate/tilt gesture) are dropped entirely — neither recorded nor
-    // echoed — so they do not clutter diagnostics or the console.
-    if (isBenignConsoleWarning(args)) return;
+    // every rotate/tilt gesture) are echoed to the console so a contributor
+    // debugging map animations still sees them, but kept out of the diagnostics
+    // panel, where they would clutter the log on routine interaction.
+    if (isBenignConsoleWarning(args)) {
+      originalConsoleWarn(...args);
+      return;
+    }
     const isTauriIpcFallback =
       inStartupWindow() &&
       typeof args[0] === "string" &&

--- a/apps/geolibre-desktop/src/lib/diagnostics.ts
+++ b/apps/geolibre-desktop/src/lib/diagnostics.ts
@@ -61,6 +61,25 @@ const FETCH_FAILURE_MESSAGES = ["Failed to fetch", "Load failed"];
 const TAURI_IPC_FALLBACK_WARNING =
   "IPC custom protocol failed, Tauri will now use the postMessage interface instead";
 
+// MapLibre warns this every time a camera animation eases around a point (the
+// inertia of a rotate/tilt gesture, double-click zoom, etc.) while the globe
+// projection is active — globe simply ignores the around-point and the camera
+// still moves correctly. It is harmless but fires on routine interaction, so it
+// is dropped from diagnostics entirely rather than echoed on every gesture.
+const BENIGN_CONSOLE_WARNINGS = [
+  "Easing around a point is not supported under globe projection.",
+];
+
+/** Whether a console.warn message is a known-benign warning to drop entirely. */
+function isBenignConsoleWarning(args: unknown[]): boolean {
+  return (
+    typeof args[0] === "string" &&
+    BENIGN_CONSOLE_WARNINGS.some((needle) =>
+      (args[0] as string).includes(needle),
+    )
+  );
+}
+
 // Request header that flags a fetch whose failure (typically a 404) is expected
 // and harmless — e.g. an optional config file that may simply be absent. A
 // non-ok response to such a request is recorded at info level instead of error,
@@ -399,6 +418,10 @@ export function installDiagnosticsCapture(): () => void {
   };
 
   console.warn = (...args: unknown[]) => {
+    // Known-benign third-party warnings (e.g. MapLibre's globe easing notice on
+    // every rotate/tilt gesture) are dropped entirely — neither recorded nor
+    // echoed — so they do not clutter diagnostics or the console.
+    if (isBenignConsoleWarning(args)) return;
     const isTauriIpcFallback =
       inStartupWindow() &&
       typeof args[0] === "string" &&

--- a/apps/geolibre-desktop/src/lib/ui-profile.ts
+++ b/apps/geolibre-desktop/src/lib/ui-profile.ts
@@ -235,6 +235,9 @@ export const MENU_ITEM_CATALOG: readonly MenuItemCatalogEntry[] = [
   // Controls — built-in map controls
   { id: "controls.mapControl.navigation", menuId: "controls", labelKey: "toolbar.mapControl.navigation", tier: "basic" },
   { id: "controls.mapControl.fullscreen", menuId: "controls", labelKey: "toolbar.mapControl.fullscreen", tier: "basic" },
+  // Shown on the map by default, so toggleable at every level (a beginner must
+  // be able to turn it off).
+  { id: "controls.mapControl.compass", menuId: "controls", labelKey: "toolbar.mapControl.compass", tier: "basic" },
   { id: "controls.mapControl.geolocate", menuId: "controls", labelKey: "toolbar.mapControl.geolocate", tier: "intermediate" },
   // Globe, Scale, and Attribution are shown on the map by default, so they must
   // be toggleable at every level (otherwise a beginner sees them with no way to

--- a/packages/map/src/index.ts
+++ b/packages/map/src/index.ts
@@ -17,5 +17,6 @@ export {
   lineLayerId,
   circleLayerId,
 } from "./geojson-loader";
+export { ResetBearingControl } from "./reset-bearing-control";
 export { isPlaceholderLayer, placeholderMessage } from "./placeholders";
 export { setExternalDeckLayerOrderHandler } from "./layer-sync";

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -1616,8 +1616,8 @@ export class MapController {
 
   /**
    * Update the reset-bearing control's tooltip/aria label, e.g. after a UI
-   * language change. The label is stored so a control recreated later (style
-   * reload) picks up the latest translation.
+   * language change. The label is cached so a control re-added after a full
+   * map reinitialisation picks up the latest translation without an extra call.
    */
   setResetBearingLabel(label: string): void {
     this.resetBearingLabel = label;

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -38,6 +38,7 @@ import {
   syncLayer,
   vectorTileStyleLayerIds,
 } from "./layer-sync";
+import { ResetBearingControl } from "./reset-bearing-control";
 
 const DEFAULT_PROJECTION: maplibregl.ProjectionSpecification = {
   type: "globe",
@@ -201,6 +202,8 @@ export class MapController {
   private map: maplibregl.Map | null = null;
   private navigationControl: maplibregl.NavigationControl | null = null;
   private fullscreenControl: maplibregl.FullscreenControl | null = null;
+  private resetBearingControl: ResetBearingControl | null = null;
+  private resetBearingLabel = "Reset pitch & bearing";
   private geolocateControl: maplibregl.GeolocateControl | null = null;
   private globeControl: maplibregl.GlobeControl | null = null;
   private terrainControl: maplibregl.TerrainControl | null = null;
@@ -282,6 +285,9 @@ export class MapController {
     // control cluster, matching the universal placement users expect (issue
     // #512). MapLibre stacks controls in insertion order within a corner.
     this.addFullscreenControl();
+    // Stacks directly below the fullscreen toggle, the placement requested in
+    // issue #508. MapLibre orders controls by insertion within a corner.
+    this.addResetBearingControl();
     this.addNavigationControl();
     this.addGeolocateControl();
     this.addGlobeControl();
@@ -537,6 +543,7 @@ export class MapController {
   destroy(): void {
     this.removeNavigationControl();
     this.removeFullscreenControl();
+    this.removeResetBearingControl();
     this.removeGeolocateControl();
     this.removeGlobeControl();
     this.removeTerrainControl();
@@ -1589,6 +1596,32 @@ export class MapController {
     if (!this.fullscreenControl) return;
     this.removeControl(this.fullscreenControl);
     this.fullscreenControl = null;
+  }
+
+  private addResetBearingControl(): boolean {
+    if (!this.map || this.resetBearingControl) return false;
+    this.resetBearingControl = new ResetBearingControl({
+      label: this.resetBearingLabel,
+    });
+    // Always top-right so it sits with (and just under) the fullscreen toggle.
+    this.map.addControl(this.resetBearingControl, "top-right");
+    return true;
+  }
+
+  private removeResetBearingControl(): void {
+    if (!this.resetBearingControl) return;
+    this.removeControl(this.resetBearingControl);
+    this.resetBearingControl = null;
+  }
+
+  /**
+   * Update the reset-bearing control's tooltip/aria label, e.g. after a UI
+   * language change. The label is stored so a control recreated later (style
+   * reload) picks up the latest translation.
+   */
+  setResetBearingLabel(label: string): void {
+    this.resetBearingLabel = label;
+    this.resetBearingControl?.setLabel(label);
   }
 
   private addGeolocateControl(): boolean {

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -1589,6 +1589,14 @@ export class MapController {
       this.fullscreenControl,
       this.controlPositions.fullscreen,
     );
+    // Re-stack the reset control immediately after fullscreen so it stays
+    // directly below it when fullscreen is repositioned (MapLibre orders
+    // controls by insertion within a corner). Skipped on first init, when the
+    // reset control has not been created yet (it is added just after).
+    if (this.resetBearingControl) {
+      this.removeResetBearingControl();
+      this.addResetBearingControl();
+    }
     return true;
   }
 
@@ -1603,8 +1611,12 @@ export class MapController {
     this.resetBearingControl = new ResetBearingControl({
       label: this.resetBearingLabel,
     });
-    // Always top-right so it sits with (and just under) the fullscreen toggle.
-    this.map.addControl(this.resetBearingControl, "top-right");
+    // Share the fullscreen control's corner so it sits just under the toggle,
+    // tracking it if fullscreen is repositioned.
+    this.map.addControl(
+      this.resetBearingControl,
+      this.controlPositions.fullscreen,
+    );
     return true;
   }
 

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -160,6 +160,7 @@ interface GeoLibreLayerLabelWindow extends Window {
 export type BuiltInMapControl =
   | "navigation"
   | "fullscreen"
+  | "compass"
   | "geolocate"
   | "globe"
   | "terrain"
@@ -174,6 +175,7 @@ export const DEFAULT_BUILT_IN_CONTROL_VISIBILITY: Record<
 > = {
   navigation: false,
   fullscreen: true,
+  compass: true,
   geolocate: false,
   globe: true,
   terrain: false,
@@ -189,6 +191,7 @@ export const DEFAULT_BUILT_IN_CONTROL_POSITIONS: Record<
 > = {
   navigation: "top-right",
   fullscreen: "top-right",
+  compass: "top-right",
   geolocate: "top-right",
   globe: "top-right",
   terrain: "top-right",
@@ -202,8 +205,8 @@ export class MapController {
   private map: maplibregl.Map | null = null;
   private navigationControl: maplibregl.NavigationControl | null = null;
   private fullscreenControl: maplibregl.FullscreenControl | null = null;
-  private resetBearingControl: ResetBearingControl | null = null;
-  private resetBearingLabel = "Reset pitch & bearing";
+  private compassControl: ResetBearingControl | null = null;
+  private compassLabel = "Reset pitch & bearing";
   private geolocateControl: maplibregl.GeolocateControl | null = null;
   private globeControl: maplibregl.GlobeControl | null = null;
   private terrainControl: maplibregl.TerrainControl | null = null;
@@ -285,9 +288,11 @@ export class MapController {
     // control cluster, matching the universal placement users expect (issue
     // #512). MapLibre stacks controls in insertion order within a corner.
     this.addFullscreenControl();
-    // Stacks directly below the fullscreen toggle, the placement requested in
-    // issue #508. MapLibre orders controls by insertion within a corner.
-    this.addResetBearingControl();
+    // Added right after fullscreen so, with both at their default top-right
+    // position, the compass stacks directly below the fullscreen toggle (the
+    // placement requested in issue #508). MapLibre orders controls by insertion
+    // within a corner.
+    this.addCompassControl();
     this.addNavigationControl();
     this.addGeolocateControl();
     this.addGlobeControl();
@@ -502,6 +507,7 @@ export class MapController {
     if (visible) {
       if (control === "navigation") return this.addNavigationControl();
       if (control === "fullscreen") return this.addFullscreenControl();
+      if (control === "compass") return this.addCompassControl();
       if (control === "geolocate") return this.addGeolocateControl();
       if (control === "globe") return this.addGlobeControl();
       if (control === "terrain") return this.addTerrainControl();
@@ -513,6 +519,7 @@ export class MapController {
 
     if (control === "navigation") this.removeNavigationControl();
     else if (control === "fullscreen") this.removeFullscreenControl();
+    else if (control === "compass") this.removeCompassControl();
     else if (control === "geolocate") this.removeGeolocateControl();
     else if (control === "globe") this.removeGlobeControl();
     else if (control === "terrain") this.removeTerrainControl();
@@ -543,7 +550,7 @@ export class MapController {
   destroy(): void {
     this.removeNavigationControl();
     this.removeFullscreenControl();
-    this.removeResetBearingControl();
+    this.removeCompassControl();
     this.removeGeolocateControl();
     this.removeGlobeControl();
     this.removeTerrainControl();
@@ -1589,14 +1596,6 @@ export class MapController {
       this.fullscreenControl,
       this.controlPositions.fullscreen,
     );
-    // Re-stack the reset control immediately after fullscreen so it stays
-    // directly below it when fullscreen is repositioned (MapLibre orders
-    // controls by insertion within a corner). Skipped on first init, when the
-    // reset control has not been created yet (it is added just after).
-    if (this.resetBearingControl) {
-      this.removeResetBearingControl();
-      this.addResetBearingControl();
-    }
     return true;
   }
 
@@ -1606,34 +1605,31 @@ export class MapController {
     this.fullscreenControl = null;
   }
 
-  private addResetBearingControl(): boolean {
-    if (!this.map || this.resetBearingControl) return false;
-    this.resetBearingControl = new ResetBearingControl({
-      label: this.resetBearingLabel,
+  private addCompassControl(): boolean {
+    if (!this.map || this.compassControl || !this.controlVisibility.compass) {
+      return false;
+    }
+    this.compassControl = new ResetBearingControl({
+      label: this.compassLabel,
     });
-    // Share the fullscreen control's corner so it sits just under the toggle,
-    // tracking it if fullscreen is repositioned.
-    this.map.addControl(
-      this.resetBearingControl,
-      this.controlPositions.fullscreen,
-    );
+    this.map.addControl(this.compassControl, this.controlPositions.compass);
     return true;
   }
 
-  private removeResetBearingControl(): void {
-    if (!this.resetBearingControl) return;
-    this.removeControl(this.resetBearingControl);
-    this.resetBearingControl = null;
+  private removeCompassControl(): void {
+    if (!this.compassControl) return;
+    this.removeControl(this.compassControl);
+    this.compassControl = null;
   }
 
   /**
-   * Update the reset-bearing control's tooltip/aria label, e.g. after a UI
-   * language change. The label is cached so a control re-added after a full
-   * map reinitialisation picks up the latest translation without an extra call.
+   * Update the compass control's tooltip/aria label, e.g. after a UI language
+   * change. The label is cached so a control re-added after a full map
+   * reinitialisation picks up the latest translation without an extra call.
    */
-  setResetBearingLabel(label: string): void {
-    this.resetBearingLabel = label;
-    this.resetBearingControl?.setLabel(label);
+  setCompassLabel(label: string): void {
+    this.compassLabel = label;
+    this.compassControl?.setLabel(label);
   }
 
   private addGeolocateControl(): boolean {
@@ -1754,6 +1750,7 @@ export class MapController {
   private addBuiltInControl(control: BuiltInMapControl): boolean {
     if (control === "navigation") return this.addNavigationControl();
     if (control === "fullscreen") return this.addFullscreenControl();
+    if (control === "compass") return this.addCompassControl();
     if (control === "geolocate") return this.addGeolocateControl();
     if (control === "globe") return this.addGlobeControl();
     if (control === "terrain") return this.addTerrainControl();
@@ -1766,6 +1763,7 @@ export class MapController {
   private removeBuiltInControl(control: BuiltInMapControl): void {
     if (control === "navigation") this.removeNavigationControl();
     else if (control === "fullscreen") this.removeFullscreenControl();
+    else if (control === "compass") this.removeCompassControl();
     else if (control === "geolocate") this.removeGeolocateControl();
     else if (control === "globe") this.removeGlobeControl();
     else if (control === "terrain") this.removeTerrainControl();

--- a/packages/map/src/reset-bearing-control.ts
+++ b/packages/map/src/reset-bearing-control.ts
@@ -1,0 +1,141 @@
+import type maplibregl from "maplibre-gl";
+
+/**
+ * Bearing/pitch below this magnitude is treated as "north-up and flat", so a
+ * float that never settles to exactly 0 after an animated reset does not leave
+ * the control stuck in its rotated (active) state.
+ */
+const NORTH_EPSILON = 0.5;
+
+/**
+ * Derive the reset-bearing control's display state from the live camera.
+ *
+ * Exposed so the threshold/rotation logic can be unit-tested without a DOM.
+ *
+ * @param bearing Current map bearing in degrees (clockwise positive).
+ * @param pitch Current map pitch in degrees.
+ * @returns `isNorthUp` (whether the view is north-up and flat, so there is
+ *   nothing to reset) and `needleRotation` (degrees to rotate the compass
+ *   needle so its north tip keeps pointing to true north).
+ */
+export function resetBearingState(
+  bearing: number,
+  pitch: number,
+): { isNorthUp: boolean; needleRotation: number } {
+  return {
+    isNorthUp:
+      Math.abs(bearing) < NORTH_EPSILON && Math.abs(pitch) < NORTH_EPSILON,
+    // `+ 0` normalises the -0 produced by negating a 0 bearing to 0.
+    needleRotation: -bearing + 0,
+  };
+}
+
+/**
+ * A MapLibre control that resets the map's bearing and pitch back to north-up
+ * and flat in a single click, mirroring the "Reset Pitch & Bearing" command.
+ *
+ * The button is meant to sit directly below the Fullscreen control. It is a
+ * passive affordance while the map is north-up and flat (disabled, neutral
+ * colour) and turns active — a red, rotating compass needle that tracks the
+ * live bearing — the moment the view is rotated or tilted, giving beginners an
+ * unmistakable cue that the map is no longer north-up (issue #508).
+ */
+export class ResetBearingControl implements maplibregl.IControl {
+  private map: maplibregl.Map | null = null;
+  private container: HTMLDivElement | null = null;
+  private button: HTMLButtonElement | null = null;
+  private needle: SVGSVGElement | null = null;
+  private label = "Reset pitch & bearing";
+
+  constructor(options: { label?: string } = {}) {
+    if (options.label) this.label = options.label;
+  }
+
+  /** Tracks the live camera so the needle and active state stay in sync. */
+  private readonly handleCameraChange = () => this.update();
+
+  onAdd(map: maplibregl.Map): HTMLElement {
+    this.map = map;
+
+    const container = document.createElement("div");
+    container.className =
+      "maplibregl-ctrl maplibregl-ctrl-group geolibre-reset-bearing-ctrl";
+
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "geolibre-reset-bearing-button";
+    button.addEventListener("click", () => {
+      // resetNorthPitch animates bearing and pitch back to 0 together while
+      // leaving center and zoom untouched, matching the menu command.
+      this.map?.resetNorthPitch();
+    });
+
+    const needle = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "svg",
+    );
+    needle.setAttribute("viewBox", "0 0 24 24");
+    needle.setAttribute("aria-hidden", "true");
+    needle.classList.add("geolibre-reset-bearing-needle");
+    // The north half is what turns red when the view is rotated; the south half
+    // stays muted so the needle reads as a compass rather than a solid arrow.
+    needle.innerHTML =
+      '<polygon class="geolibre-reset-bearing-needle-north" points="12,3 8,13 12,11 16,13" />' +
+      '<polygon class="geolibre-reset-bearing-needle-south" points="12,21 8,11 12,13 16,11" />';
+    button.appendChild(needle);
+
+    container.appendChild(button);
+    this.container = container;
+    this.button = button;
+    this.needle = needle;
+
+    map.on("rotate", this.handleCameraChange);
+    map.on("pitch", this.handleCameraChange);
+    this.applyLabel();
+    this.update();
+
+    return container;
+  }
+
+  onRemove(): void {
+    if (this.map) {
+      this.map.off("rotate", this.handleCameraChange);
+      this.map.off("pitch", this.handleCameraChange);
+    }
+    this.container?.remove();
+    this.container = null;
+    this.button = null;
+    this.needle = null;
+    this.map = null;
+  }
+
+  /** Update the tooltip/aria label, e.g. after a UI language change. */
+  setLabel(label: string): void {
+    this.label = label;
+    this.applyLabel();
+  }
+
+  private applyLabel(): void {
+    if (!this.button) return;
+    this.button.title = this.label;
+    this.button.setAttribute("aria-label", this.label);
+  }
+
+  private update(): void {
+    if (!this.map || !this.button || !this.needle) return;
+    const { isNorthUp, needleRotation } = resetBearingState(
+      this.map.getBearing(),
+      this.map.getPitch(),
+    );
+
+    // Rotate the needle so north keeps pointing to true north as the map turns.
+    this.needle.style.transform = `rotate(${needleRotation}deg)`;
+    // Nothing to reset when already north-up and flat: grey the button out and
+    // drop the alert colour so it reads as inactive.
+    this.button.disabled = isNorthUp;
+    this.button.classList.toggle(
+      "geolibre-reset-bearing-button--active",
+      !isNorthUp,
+    );
+  }
+}

--- a/packages/map/src/reset-bearing-control.ts
+++ b/packages/map/src/reset-bearing-control.ts
@@ -80,8 +80,8 @@ export class ResetBearingControl implements maplibregl.IControl {
     // The north half is what turns red when the view is rotated; the south half
     // stays muted so the needle reads as a compass rather than a solid arrow.
     needle.innerHTML =
-      '<polygon class="geolibre-reset-bearing-needle-north" points="12,3 8,13 12,11 16,13" />' +
-      '<polygon class="geolibre-reset-bearing-needle-south" points="12,21 8,11 12,13 16,11" />';
+      '<polygon class="geolibre-reset-bearing-needle-north" points="12,2 6.5,14 12,11.5 17.5,14" />' +
+      '<polygon class="geolibre-reset-bearing-needle-south" points="12,22 6.5,10 12,12.5 17.5,10" />';
     button.appendChild(needle);
 
     container.appendChild(button);

--- a/packages/map/src/reset-bearing-control.ts
+++ b/packages/map/src/reset-bearing-control.ts
@@ -48,7 +48,7 @@ export class ResetBearingControl implements maplibregl.IControl {
   private label = "Reset pitch & bearing";
 
   constructor(options: { label?: string } = {}) {
-    if (options.label) this.label = options.label;
+    if (options.label !== undefined) this.label = options.label;
   }
 
   /** Tracks the live camera so the needle and active state stay in sync. */

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -14,6 +14,11 @@ const storage = new Map<string, string>();
       storage.delete(key);
     },
   },
+  // Stubs so installDiagnosticsCapture (which patches window.fetch and adds
+  // window error listeners) can run under node --test.
+  fetch: (() => Promise.resolve(new Response())) as typeof fetch,
+  addEventListener: () => {},
+  removeEventListener: () => {},
 };
 
 type DiagnosticsModule =
@@ -22,6 +27,8 @@ let appendDiagnostic: DiagnosticsModule["appendDiagnostic"];
 let clearDiagnostics: DiagnosticsModule["clearDiagnostics"];
 let getDiagnosticsSnapshot: DiagnosticsModule["getDiagnosticsSnapshot"];
 let setCaptureNetworkInfo: DiagnosticsModule["setCaptureNetworkInfo"];
+let installDiagnosticsCapture: DiagnosticsModule["installDiagnosticsCapture"];
+let OPTIONAL_RESOURCE_HEADER: DiagnosticsModule["OPTIONAL_RESOURCE_HEADER"];
 
 before(async () => {
   ({
@@ -29,6 +36,8 @@ before(async () => {
     clearDiagnostics,
     getDiagnosticsSnapshot,
     setCaptureNetworkInfo,
+    installDiagnosticsCapture,
+    OPTIONAL_RESOURCE_HEADER,
   } = await import("../apps/geolibre-desktop/src/lib/diagnostics"));
 });
 
@@ -259,5 +268,38 @@ describe("diagnostics startup transient suppression", () => {
     install();
     console.warn("a normal warning");
     assert.deepEqual(echoed, ["a normal warning"]);
+  });
+
+  it("flags an unmarked non-ok response as an error", async () => {
+    win.fetch = (() =>
+      Promise.resolve(
+        new Response(null, { status: 404, statusText: "Not Found" }),
+      )) as unknown as typeof fetch;
+    install();
+    await (win.fetch as typeof fetch)("/missing.json");
+    const [record] = getDiagnosticsSnapshot().records;
+    assert.equal(record.category, "network");
+    assert.equal(record.level, "error");
+  });
+
+  it("downgrades a non-ok response on an optional-resource request", async () => {
+    setCaptureNetworkInfo(true);
+    try {
+      win.fetch = (() =>
+        Promise.resolve(
+          new Response(null, { status: 404, statusText: "Not Found" }),
+        )) as unknown as typeof fetch;
+      install();
+      await (win.fetch as typeof fetch)("/admin-profile.json", {
+        headers: { [OPTIONAL_RESOURCE_HEADER]: "1" },
+      });
+      const [record] = getDiagnosticsSnapshot().records;
+      assert.equal(record.category, "network");
+      // Marked optional, so the 404 is informational rather than an error.
+      assert.equal(record.level, "info");
+      assert.equal(getDiagnosticsSnapshot().errorCount, 0);
+    } finally {
+      setCaptureNetworkInfo(false);
+    }
   });
 });

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -270,6 +270,20 @@ describe("diagnostics startup transient suppression", () => {
     assert.deepEqual(echoed, ["a normal warning"]);
   });
 
+  it("drops the benign globe easing warning entirely", () => {
+    let echoed: unknown[] | null = null;
+    console.warn = (...args: unknown[]) => {
+      echoed = args;
+    };
+    install();
+    console.warn(
+      "Easing around a point is not supported under globe projection.",
+    );
+    // Neither echoed to the console nor recorded in diagnostics.
+    assert.equal(echoed, null);
+    assert.equal(getDiagnosticsSnapshot().totalCount, 0);
+  });
+
   it("flags an unmarked non-ok response as an error", async () => {
     win.fetch = (() =>
       Promise.resolve(

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -294,6 +294,7 @@ describe("diagnostics startup transient suppression", () => {
     const [record] = getDiagnosticsSnapshot().records;
     assert.equal(record.category, "network");
     assert.equal(record.level, "error");
+    assert.equal(getDiagnosticsSnapshot().errorCount, 1);
   });
 
   it("downgrades a non-ok response on an optional-resource request", async () => {
@@ -336,5 +337,24 @@ describe("diagnostics startup transient suppression", () => {
     assert.equal(record.category, "network");
     assert.equal(record.level, "error");
     assert.equal(getDiagnosticsSnapshot().errorCount, 1);
+  });
+
+  it("downgrades a thrown network error on an optional-resource request", async () => {
+    setCaptureNetworkInfo(true);
+    try {
+      win.fetch = (() =>
+        Promise.reject(new TypeError("Failed to fetch"))) as unknown as typeof fetch;
+      install();
+      await (win.fetch as typeof fetch)("/admin-profile.json", {
+        headers: { [OPTIONAL_RESOURCE_HEADER]: "1" },
+      }).catch(() => {});
+      const [record] = getDiagnosticsSnapshot().records;
+      assert.equal(record.category, "network");
+      // Optional, so even a thrown failure is informational rather than an error.
+      assert.equal(record.level, "info");
+      assert.equal(getDiagnosticsSnapshot().errorCount, 0);
+    } finally {
+      setCaptureNetworkInfo(false);
+    }
   });
 });

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -302,4 +302,25 @@ describe("diagnostics startup transient suppression", () => {
       setCaptureNetworkInfo(false);
     }
   });
+
+  it("treats init.headers as replacing a Request's optional marker", async () => {
+    win.fetch = (() =>
+      Promise.resolve(
+        new Response(null, { status: 404, statusText: "Not Found" }),
+      )) as unknown as typeof fetch;
+    install();
+    // The Request carries the optional marker, but init.headers replaces the
+    // Request's headers entirely (fetch spec), dropping it — so the 404 is a
+    // real error.
+    await (win.fetch as typeof fetch)(
+      new Request("http://localhost/admin-profile.json", {
+        headers: { [OPTIONAL_RESOURCE_HEADER]: "1" },
+      }),
+      { headers: {} },
+    );
+    const [record] = getDiagnosticsSnapshot().records;
+    assert.equal(record.category, "network");
+    assert.equal(record.level, "error");
+    assert.equal(getDiagnosticsSnapshot().errorCount, 1);
+  });
 });

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -270,17 +270,17 @@ describe("diagnostics startup transient suppression", () => {
     assert.deepEqual(echoed, ["a normal warning"]);
   });
 
-  it("drops the benign globe easing warning entirely", () => {
+  it("keeps the benign globe easing warning out of diagnostics but echoes it", () => {
     let echoed: unknown[] | null = null;
     console.warn = (...args: unknown[]) => {
       echoed = args;
     };
     install();
-    console.warn(
-      "Easing around a point is not supported under globe projection.",
-    );
-    // Neither echoed to the console nor recorded in diagnostics.
-    assert.equal(echoed, null);
+    const message =
+      "Easing around a point is not supported under globe projection.";
+    console.warn(message);
+    // Echoed to the console for contributors, but not recorded in the panel.
+    assert.deepEqual(echoed, [message]);
     assert.equal(getDiagnosticsSnapshot().totalCount, 0);
   });
 

--- a/tests/reset-bearing-control.test.ts
+++ b/tests/reset-bearing-control.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { resetBearingState } from "../packages/map/src/reset-bearing-control";
+
+describe("resetBearingState", () => {
+  it("treats an exactly north-up, flat view as nothing to reset", () => {
+    const state = resetBearingState(0, 0);
+    assert.equal(state.isNorthUp, true);
+    assert.equal(state.needleRotation, 0);
+  });
+
+  it("tolerates sub-degree drift so an animated reset settles to inactive", () => {
+    assert.equal(resetBearingState(0.2, 0.1).isNorthUp, true);
+    assert.equal(resetBearingState(-0.3, 0).isNorthUp, true);
+  });
+
+  it("is active once the map is rotated past the threshold", () => {
+    assert.equal(resetBearingState(45, 0).isNorthUp, false);
+    assert.equal(resetBearingState(-90, 0).isNorthUp, false);
+  });
+
+  it("is active when the map is tilted even if bearing is north", () => {
+    assert.equal(resetBearingState(0, 60).isNorthUp, false);
+  });
+
+  it("counter-rotates the needle so its north tip tracks true north", () => {
+    assert.equal(resetBearingState(90, 0).needleRotation, -90);
+    assert.equal(resetBearingState(-30, 0).needleRotation, 30);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds an on-map button directly below the Fullscreen control that resets the map to north-up and flat in one click (issue #508). The compass needle counter-rotates to track true north and its north half turns red while the view is rotated or tilted; the button is disabled and muted while there is nothing to reset.
- Stops the optional admin-profile.json fetch from surfacing its expected 404 as a network error. A request can now flag itself benign, so a non-ok response is recorded at info level instead of error.

## Test plan
- [x] `npm run typecheck` (full build) passes
- [x] `npm run test:frontend` passes, including new tests for the bearing-state logic and the optional-resource diagnostics downgrade
- [x] Verified in the real app with Playwright: button sits directly below Fullscreen; disabled and muted at north-up; after setting bearing 120 deg / pitch 55 deg it becomes enabled and active with a red, rotated needle; clicking it resets the camera to bearing 0 / pitch 0 and the button returns to its muted disabled state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Compass” map control that resets bearing and pitch back to a north-up, flat view, with an interactive compass needle.
  * Enabled by default (top-right) and included in the map control UI, new-project defaults, and settings toggle.
* **Style**
  * Added styling for the compass control, including active and disabled states.
* **Bug Fixes / Chores**
  * Network diagnostics now treat explicitly marked optional resource failures as info-level, and suppress a known benign globe-projection console warning.
  * Compass label updates correctly when the app language changes.
* **Tests**
  * Added unit tests for reset-bearing behavior and expanded diagnostics tests for optional-marker/header behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->