### PR TITLE
feat(map): replace ambiguous compass icon with a distinct north arrow

### DIFF
--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1520,16 +1520,28 @@ body,
   width: 24px;
 }
 
-.geolibre-reset-bearing-needle-north {
-  fill: #334155;
+.geolibre-reset-bearing-needle-label {
+  fill: #1e293b;
+  font-family:
+    ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  font-size: 8px;
+  font-weight: 700;
   transition: fill 150ms ease;
 }
 
-.geolibre-reset-bearing-needle-south {
-  fill: #64748b;
+.geolibre-reset-bearing-needle-north {
+  fill: #1e293b;
+  transition: fill 150ms ease;
 }
 
-.geolibre-reset-bearing-button--active .geolibre-reset-bearing-needle-north {
+/* Light, slim south tail so the upward north needle stays the single dominant
+   pointer (issue #537) — the two halves must not read as equal triangles. */
+.geolibre-reset-bearing-needle-south {
+  fill: #cbd5e1;
+}
+
+.geolibre-reset-bearing-button--active .geolibre-reset-bearing-needle-north,
+.geolibre-reset-bearing-button--active .geolibre-reset-bearing-needle-label {
   fill: hsl(var(--destructive));
 }
 

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -1526,7 +1526,11 @@ body,
     ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
   font-size: 8px;
   font-weight: 700;
+  /* The label is a real SVG text node: stop it from being text-selected on a
+     click-drag and from firing the native text context menu on right-click. */
+  pointer-events: none;
   transition: fill 150ms ease;
+  user-select: none;
 }
 
 .geolibre-reset-bearing-needle-north {

--- a/packages/map/src/reset-bearing-control.ts
+++ b/packages/map/src/reset-bearing-control.ts
@@ -46,9 +46,11 @@ export class ResetBearingControl implements maplibregl.IControl {
   private button: HTMLButtonElement | null = null;
   private needle: SVGSVGElement | null = null;
   private label = "Reset pitch & bearing";
+  private northLabel = "N";
 
-  constructor(options: { label?: string } = {}) {
+  constructor(options: { label?: string; northLabel?: string } = {}) {
     if (options.label !== undefined) this.label = options.label;
+    if (options.northLabel !== undefined) this.northLabel = options.northLabel;
   }
 
   /** Tracks the live camera so the needle and active state stay in sync. */
@@ -81,11 +83,19 @@ export class ResetBearingControl implements maplibregl.IControl {
     // the control reads unambiguously as "north" at a glance (issue #537). The
     // solid north needle is what turns red when the view is rotated; the south
     // tail stays light and slim so the arrow keeps one clear destination point
-    // instead of two mirrored triangles of equal weight.
+    // instead of two mirrored triangles of equal weight. The apex sits at y=9
+    // (just below the "N" baseline at y=8) so the glyph never crowds the tip
+    // even on fonts with taller cap metrics.
     needle.innerHTML =
-      '<text class="geolibre-reset-bearing-needle-label" x="12" y="8" text-anchor="middle">N</text>' +
-      '<polygon class="geolibre-reset-bearing-needle-north" points="12,8.5 9,19 12,16 15,19" />' +
+      '<text class="geolibre-reset-bearing-needle-label" x="12" y="8" text-anchor="middle"></text>' +
+      '<polygon class="geolibre-reset-bearing-needle-north" points="12,9 9,19 12,16 15,19" />' +
       '<polygon class="geolibre-reset-bearing-needle-south" points="12,22.5 9.6,19 14.4,19" />';
+    // Set the cardinal letter via textContent (not interpolated into innerHTML)
+    // so a caller-supplied northLabel can't inject markup into the SVG.
+    const labelEl = needle.querySelector(
+      ".geolibre-reset-bearing-needle-label",
+    );
+    if (labelEl) labelEl.textContent = this.northLabel;
     button.appendChild(needle);
 
     container.appendChild(button);

--- a/packages/map/src/reset-bearing-control.ts
+++ b/packages/map/src/reset-bearing-control.ts
@@ -83,7 +83,7 @@ export class ResetBearingControl implements maplibregl.IControl {
     // tail stays light and slim so the arrow keeps one clear destination point
     // instead of two mirrored triangles of equal weight.
     needle.innerHTML =
-      '<text class="geolibre-reset-bearing-needle-label" x="12" y="5.6" text-anchor="middle">N</text>' +
+      '<text class="geolibre-reset-bearing-needle-label" x="12" y="6.5" text-anchor="middle">N</text>' +
       '<polygon class="geolibre-reset-bearing-needle-north" points="12,7 9,19 12,16 15,19" />' +
       '<polygon class="geolibre-reset-bearing-needle-south" points="12,22.5 9.6,19 12,17 14.4,19" />';
     button.appendChild(needle);

--- a/packages/map/src/reset-bearing-control.ts
+++ b/packages/map/src/reset-bearing-control.ts
@@ -85,7 +85,7 @@ export class ResetBearingControl implements maplibregl.IControl {
     needle.innerHTML =
       '<text class="geolibre-reset-bearing-needle-label" x="12" y="8" text-anchor="middle">N</text>' +
       '<polygon class="geolibre-reset-bearing-needle-north" points="12,8.5 9,19 12,16 15,19" />' +
-      '<polygon class="geolibre-reset-bearing-needle-south" points="12,22.5 9.6,19 12,17 14.4,19" />';
+      '<polygon class="geolibre-reset-bearing-needle-south" points="12,22.5 9.6,19 12,19 14.4,19" />';
     button.appendChild(needle);
 
     container.appendChild(button);

--- a/packages/map/src/reset-bearing-control.ts
+++ b/packages/map/src/reset-bearing-control.ts
@@ -85,7 +85,7 @@ export class ResetBearingControl implements maplibregl.IControl {
     needle.innerHTML =
       '<text class="geolibre-reset-bearing-needle-label" x="12" y="8" text-anchor="middle">N</text>' +
       '<polygon class="geolibre-reset-bearing-needle-north" points="12,8.5 9,19 12,16 15,19" />' +
-      '<polygon class="geolibre-reset-bearing-needle-south" points="12,22.5 9.6,19 12,19 14.4,19" />';
+      '<polygon class="geolibre-reset-bearing-needle-south" points="12,22.5 9.6,19 14.4,19" />';
     button.appendChild(needle);
 
     container.appendChild(button);

--- a/packages/map/src/reset-bearing-control.ts
+++ b/packages/map/src/reset-bearing-control.ts
@@ -77,11 +77,15 @@ export class ResetBearingControl implements maplibregl.IControl {
     needle.setAttribute("viewBox", "0 0 24 24");
     needle.setAttribute("aria-hidden", "true");
     needle.classList.add("geolibre-reset-bearing-needle");
-    // The north half is what turns red when the view is rotated; the south half
-    // stays muted so the needle reads as a compass rather than a solid arrow.
+    // A classic north arrow: an "N" cap over a single dominant upward needle so
+    // the control reads unambiguously as "north" at a glance (issue #537). The
+    // solid north needle is what turns red when the view is rotated; the south
+    // tail stays light and slim so the arrow keeps one clear destination point
+    // instead of two mirrored triangles of equal weight.
     needle.innerHTML =
-      '<polygon class="geolibre-reset-bearing-needle-north" points="12,2 6.5,14 12,11.5 17.5,14" />' +
-      '<polygon class="geolibre-reset-bearing-needle-south" points="12,22 6.5,10 12,12.5 17.5,10" />';
+      '<text class="geolibre-reset-bearing-needle-label" x="12" y="5.6" text-anchor="middle">N</text>' +
+      '<polygon class="geolibre-reset-bearing-needle-north" points="12,7 9,19 12,16 15,19" />' +
+      '<polygon class="geolibre-reset-bearing-needle-south" points="12,22.5 9.6,19 12,17 14.4,19" />';
     button.appendChild(needle);
 
     container.appendChild(button);

--- a/packages/map/src/reset-bearing-control.ts
+++ b/packages/map/src/reset-bearing-control.ts
@@ -83,8 +83,8 @@ export class ResetBearingControl implements maplibregl.IControl {
     // tail stays light and slim so the arrow keeps one clear destination point
     // instead of two mirrored triangles of equal weight.
     needle.innerHTML =
-      '<text class="geolibre-reset-bearing-needle-label" x="12" y="6.5" text-anchor="middle">N</text>' +
-      '<polygon class="geolibre-reset-bearing-needle-north" points="12,7 9,19 12,16 15,19" />' +
+      '<text class="geolibre-reset-bearing-needle-label" x="12" y="8" text-anchor="middle">N</text>' +
+      '<polygon class="geolibre-reset-bearing-needle-north" points="12,8.5 9,19 12,16 15,19" />' +
       '<polygon class="geolibre-reset-bearing-needle-south" points="12,22.5 9.6,19 12,17 14.4,19" />';
     button.appendChild(needle);
 


### PR DESCRIPTION
## Summary

Closes #537.

The reset pitch & bearing (Compass) control used two mirrored triangles of nearly equal visual weight. As reported in #537, this made it ambiguous — it was hard to tell at a glance that the icon represents north or which way north points.

This redesigns it as a classic, instantly recognizable north arrow:

- An **"N" cap** over a **single dominant upward needle** (the primary recommendation in the issue), so the arrow has one clear destination point.
- A **light, slim south tail** (`#cbd5e1`) so the bottom half no longer competes with the top — the high-contrast dark north needle stays the focus.
- The north needle **and** the "N" still turn red (`--destructive`) while the view is rotated or tilted, and the whole arrow keeps counter-rotating to track true north.

All existing rotation/active-state behavior (`resetBearingState`) is unchanged; only the SVG markup and its styling changed.

## Behavior note: the icon rotates as a compass

The "N" and arrow live inside the SVG that gets `transform: rotate(-bearing)`, so the whole assembly turns to keep pointing at true north — exactly like MapLibre's built-in compass. This means at a bearing near 180° the "N" is rendered inverted at the bottom (the arrow points down because north is now down on screen). This is the intended, accepted trade-off: the rotating "N" is the most informative indicator of where north actually is, and it was confirmed as the desired behavior. Manually checked the render at 0° / 90° / 135° / 180° — the arrow points the correct way in every orientation and the "N" stays legible (just rotated).

## Visual

| State | Look |
|---|---|
| North-up (resting/disabled) | dark "N" + dark up arrow, light tail |
| Rotated (active) | red "N" + red arrow, counter-rotated to point at true north |

## Testing

- `node --import tsx --test tests/reset-bearing-control.test.ts` — passes (rotation logic untouched)
- `pre-commit run --files …` — passes (eslint + full npm build)
- Rendered the SVG in a browser at 0° / 45° / 90° / 135° / 180°, at 1× and 2× DPR, to confirm it reads as a north arrow with no overlap seam and the "N" clears the viewBox on tall-cap fonts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an optional directional “N” label to the Compass reset-bearing needle for clearer orientation.

* **Style**
  * Refined the compass reset-bearing needle’s “north” and “south” coloring and improved the label’s typography and transition.
  * Updated the needle/arrow SVG geometry for better prominence and readability.
  * Expanded the active-state styling so the active button highlights both the needle and its label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->