### PR TITLE
feat(print-layout): fix preview rendering and add size/title/footer controls

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -26,11 +26,13 @@ import {
 } from "lucide-react";
 import {
   drawLayout,
-  pageDimensionsMm,
   PAPER_SIZES,
+  resolvePageSize,
+  type CustomSize,
   type LayoutOptions,
   type Orientation,
   type PaperSizeId,
+  type SizeUnit,
 } from "../../lib/print-layout";
 import {
   applyLegendConfig,
@@ -89,7 +91,7 @@ function ToggleField({ id, label, checked, onChange }: ToggleFieldProps) {
 /**
  * Print Layout composer dialog: captures the current map view and composes it
  * with a title, legend, scale bar, north arrow, and footer onto a chosen paper
- * size, then exports the result to PNG or PDF.
+ * or screen size, then exports the result to PNG or PDF.
  */
 export function PrintLayoutDialog({
   open,
@@ -104,19 +106,49 @@ export function PrintLayoutDialog({
 
   const [title, setTitle] = useState("");
   const [subtitle, setSubtitle] = useState("");
+  const [titlePlacement, setTitlePlacement] = useState<"outside" | "inside">(
+    "outside",
+  );
+  const [titleAlign, setTitleAlign] = useState<"left" | "center" | "right">(
+    "center",
+  );
   const [paperSize, setPaperSize] = useState<PaperSizeId>("a4");
   const [orientation, setOrientation] = useState<Orientation>("landscape");
+  const [customWidth, setCustomWidth] = useState(1280);
+  const [customHeight, setCustomHeight] = useState(720);
+  const [customUnit, setCustomUnit] = useState<SizeUnit>("px");
   const [showTitle, setShowTitle] = useState(true);
+  const [showSubtitle, setShowSubtitle] = useState(true);
   const [showLegend, setShowLegend] = useState(true);
   const [showScaleBar, setShowScaleBar] = useState(true);
   const [showNorthArrow, setShowNorthArrow] = useState(true);
-  const [showFooter, setShowFooter] = useState(true);
+  const [navigationGrouped, setNavigationGrouped] = useState(true);
+  const [showFooter, setShowFooter] = useState(false);
   const [footerText, setFooterText] = useState("");
+  const [showDate, setShowDate] = useState(true);
+  const [dateText, setDateText] = useState("");
+  const [showAttribution, setShowAttribution] = useState(true);
+  const [pageMargin, setPageMargin] = useState<"normal" | "narrow" | "none">(
+    "normal",
+  );
+  const [showPageBorder, setShowPageBorder] = useState(false);
+  const [pageBorderColor, setPageBorderColor] = useState("#111827");
+  const [pageBorderWidth, setPageBorderWidth] = useState(2);
   const [captured, setCaptured] = useState<CapturedMap | null>(null);
   const [exporting, setExporting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const previewRef = useRef<HTMLCanvasElement | null>(null);
   const wasOpenRef = useRef(false);
+
+  const isCustom = paperSize === "custom";
+  const paperOptions = useMemo(
+    () => PAPER_SIZES.filter((p) => p.group === "paper"),
+    [],
+  );
+  const screenOptions = useMemo(
+    () => PAPER_SIZES.filter((p) => p.group === "screen" && p.id !== "custom"),
+    [],
+  );
 
   const baseLegend = useMemo(() => buildLegend(layers), [layers]);
   const legend = useMemo(
@@ -145,7 +177,7 @@ export function PrintLayoutDialog({
   const recapture = useCallback(() => {
     const map = mapControllerRef.current?.getMap();
     if (!map) {
-      setError("Map is not ready yet. Try again in a moment.");
+      setError(t("printLayout.errors.mapNotReady"));
       setCaptured(null);
       return;
     }
@@ -153,10 +185,10 @@ export function PrintLayoutDialog({
       setCaptured(captureMapImage(map));
       setError(null);
     } catch {
-      setError("Could not capture the map image.");
+      setError(t("printLayout.errors.captureFailed"));
       setCaptured(null);
     }
-  }, [mapControllerRef]);
+  }, [mapControllerRef, t]);
 
   // Capture the map and seed defaults only on the closed -> open transition, so
   // a background project-name change while the dialog is open does not replace
@@ -165,14 +197,19 @@ export function PrintLayoutDialog({
     if (open && !wasOpenRef.current) {
       setError(null);
       setTitle((prev) => prev || (projectName ?? "").trim());
-      setFooterText(
-        (prev) =>
-          prev || `Created with GeoLibre · ${new Date().toLocaleDateString()}`,
-      );
+      setDateText((prev) => prev || new Date().toLocaleDateString());
       recapture();
     }
     wasOpenRef.current = open;
   }, [open, projectName, recapture]);
+
+  const customSize = useMemo<CustomSize | null>(
+    () =>
+      isCustom
+        ? { width: customWidth, height: customHeight, unit: customUnit }
+        : null,
+    [isCustom, customWidth, customHeight, customUnit],
+  );
 
   const options = useMemo<LayoutOptions>(
     () => ({
@@ -180,12 +217,24 @@ export function PrintLayoutDialog({
       subtitle,
       paperSize,
       orientation,
+      customSize,
       showTitle,
+      showSubtitle,
+      titlePlacement,
+      titleAlign,
       showLegend,
       showScaleBar,
       showNorthArrow,
+      navigationGrouped,
       showFooter,
       footerText,
+      showDate,
+      dateText,
+      showAttribution,
+      pageMargin,
+      showPageBorder,
+      pageBorderColor,
+      pageBorderWidth,
       legend,
       legendTitle: legendConfig.title,
       legendGroupByLayer: legendConfig.groupByLayer,
@@ -200,38 +249,61 @@ export function PrintLayoutDialog({
       subtitle,
       paperSize,
       orientation,
+      customSize,
       showTitle,
+      showSubtitle,
+      titlePlacement,
+      titleAlign,
       showLegend,
       showScaleBar,
       showNorthArrow,
+      navigationGrouped,
       showFooter,
       footerText,
+      showDate,
+      dateText,
+      showAttribution,
+      pageMargin,
+      showPageBorder,
+      pageBorderColor,
+      pageBorderWidth,
       legend,
       legendConfig,
       captured,
     ],
   );
 
-  // Redraw the preview whenever the layout options change.
+  // Redraw the preview whenever the layout options change. Drawing is scheduled
+  // on an animation frame and retries until the canvas exists: the dialog mounts
+  // its content in a portal, so on the open transition the first effect pass can
+  // run before the canvas is committed -- without the retry the preview stayed
+  // blank until the user clicked "Recapture map" (GH #521).
   useEffect(() => {
     if (!open) return;
-    const canvas = previewRef.current;
-    if (!canvas) return;
-    const { widthMm, heightMm } = pageDimensionsMm(
-      options.paperSize,
-      options.orientation,
-    );
-    const aspect = widthMm / heightMm;
-    const pw = aspect >= 1 ? PREVIEW_LONG_EDGE : Math.round(PREVIEW_LONG_EDGE * aspect);
-    const ph = aspect >= 1 ? Math.round(PREVIEW_LONG_EDGE / aspect) : PREVIEW_LONG_EDGE;
-    canvas.width = pw;
-    canvas.height = ph;
-    drawLayout(canvas, options);
+    let raf = 0;
+    const draw = () => {
+      const canvas = previewRef.current;
+      if (!canvas) {
+        raf = requestAnimationFrame(draw);
+        return;
+      }
+      const size = resolvePageSize(options);
+      const aspect = size.width / size.height;
+      const pw =
+        aspect >= 1 ? PREVIEW_LONG_EDGE : Math.round(PREVIEW_LONG_EDGE * aspect);
+      const ph =
+        aspect >= 1 ? Math.round(PREVIEW_LONG_EDGE / aspect) : PREVIEW_LONG_EDGE;
+      canvas.width = pw;
+      canvas.height = ph;
+      drawLayout(canvas, options);
+    };
+    raf = requestAnimationFrame(draw);
+    return () => cancelAnimationFrame(raf);
   }, [open, options]);
 
   const handleExport = async (kind: "png" | "pdf") => {
     if (!captured) {
-      setError("Capture the map before exporting.");
+      setError(t("printLayout.errors.captureFirst"));
       return;
     }
     setExporting(true);
@@ -244,7 +316,7 @@ export function PrintLayoutDialog({
         await exportLayoutPdf(options, `${base}.pdf`);
       }
     } catch {
-      setError(`Failed to export ${kind.toUpperCase()}.`);
+      setError(t("printLayout.errors.exportFailed", { format: kind.toUpperCase() }));
     } finally {
       setExporting(false);
     }
@@ -254,109 +326,297 @@ export function PrintLayoutDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-5xl">
         <DialogHeader>
-          <DialogTitle>Print Layout</DialogTitle>
-          <DialogDescription>
-            Compose a print-ready map with a title, legend, scale bar, and north
-            arrow, then export it to PNG or PDF.
-          </DialogDescription>
+          <DialogTitle>{t("printLayout.title")}</DialogTitle>
+          <DialogDescription>{t("printLayout.description")}</DialogDescription>
         </DialogHeader>
 
         <div className="grid gap-6 md:grid-cols-[320px_1fr]">
           {/* Controls */}
-          <div className="space-y-4">
+          <div className="max-h-[60vh] space-y-4 overflow-y-auto pr-1">
             <div className="space-y-1.5">
-              <Label htmlFor="layout-title">Title</Label>
+              <Label htmlFor="layout-title">{t("printLayout.titleLabel")}</Label>
               <Input
                 id="layout-title"
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
-                placeholder="Map title"
+                placeholder={t("printLayout.titlePlaceholder")}
               />
             </div>
             <div className="space-y-1.5">
-              <Label htmlFor="layout-subtitle">Subtitle</Label>
+              <Label htmlFor="layout-subtitle">
+                {t("printLayout.subtitleLabel")}
+              </Label>
               <Input
                 id="layout-subtitle"
                 value={subtitle}
                 onChange={(e) => setSubtitle(e.target.value)}
-                placeholder="Optional subtitle"
+                placeholder={t("printLayout.subtitlePlaceholder")}
               />
             </div>
 
             <div className="grid grid-cols-2 gap-3">
               <div className="space-y-1.5">
-                <Label htmlFor="layout-paper">Paper size</Label>
+                <Label htmlFor="layout-title-placement">
+                  {t("printLayout.titlePlacement")}
+                </Label>
                 <Select
-                  id="layout-paper"
-                  value={paperSize}
-                  onChange={(e) => setPaperSize(e.target.value as PaperSizeId)}
+                  id="layout-title-placement"
+                  value={titlePlacement}
+                  onChange={(e) =>
+                    setTitlePlacement(e.target.value as "outside" | "inside")
+                  }
                 >
-                  {PAPER_SIZES.map((p) => (
-                    <option key={p.id} value={p.id}>
-                      {p.label}
-                    </option>
-                  ))}
+                  <option value="outside">
+                    {t("printLayout.placement.outside")}
+                  </option>
+                  <option value="inside">
+                    {t("printLayout.placement.inside")}
+                  </option>
                 </Select>
               </div>
               <div className="space-y-1.5">
-                <Label htmlFor="layout-orientation">Orientation</Label>
+                <Label htmlFor="layout-title-align">
+                  {t("printLayout.alignment")}
+                </Label>
                 <Select
-                  id="layout-orientation"
-                  value={orientation}
+                  id="layout-title-align"
+                  value={titleAlign}
                   onChange={(e) =>
-                    setOrientation(e.target.value as Orientation)
+                    setTitleAlign(e.target.value as "left" | "center" | "right")
                   }
                 >
-                  <option value="portrait">Portrait</option>
-                  <option value="landscape">Landscape</option>
+                  <option value="left">{t("printLayout.align.left")}</option>
+                  <option value="center">{t("printLayout.align.center")}</option>
+                  <option value="right">{t("printLayout.align.right")}</option>
                 </Select>
               </div>
             </div>
 
             <Separator />
 
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="layout-paper">{t("printLayout.size")}</Label>
+                <Select
+                  id="layout-paper"
+                  value={paperSize}
+                  onChange={(e) => setPaperSize(e.target.value as PaperSizeId)}
+                >
+                  <optgroup label={t("printLayout.sizeGroup.paper")}>
+                    {paperOptions.map((p) => (
+                      <option key={p.id} value={p.id}>
+                        {p.label}
+                      </option>
+                    ))}
+                  </optgroup>
+                  <optgroup label={t("printLayout.sizeGroup.screen")}>
+                    {screenOptions.map((p) => (
+                      <option key={p.id} value={p.id}>
+                        {p.label}
+                      </option>
+                    ))}
+                  </optgroup>
+                  <option value="custom">{t("printLayout.sizeCustom")}</option>
+                </Select>
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="layout-orientation">
+                  {t("printLayout.orientation")}
+                </Label>
+                <Select
+                  id="layout-orientation"
+                  value={orientation}
+                  disabled={isCustom}
+                  onChange={(e) =>
+                    setOrientation(e.target.value as Orientation)
+                  }
+                >
+                  <option value="portrait">{t("printLayout.portrait")}</option>
+                  <option value="landscape">{t("printLayout.landscape")}</option>
+                </Select>
+              </div>
+            </div>
+
+            {isCustom && (
+              <div className="grid grid-cols-3 gap-3">
+                <div className="space-y-1.5">
+                  <Label htmlFor="layout-custom-w">
+                    {t("printLayout.width")}
+                  </Label>
+                  <Input
+                    id="layout-custom-w"
+                    type="number"
+                    min={1}
+                    value={customWidth}
+                    onChange={(e) =>
+                      setCustomWidth(Math.max(1, Number(e.target.value) || 0))
+                    }
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="layout-custom-h">
+                    {t("printLayout.height")}
+                  </Label>
+                  <Input
+                    id="layout-custom-h"
+                    type="number"
+                    min={1}
+                    value={customHeight}
+                    onChange={(e) =>
+                      setCustomHeight(Math.max(1, Number(e.target.value) || 0))
+                    }
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="layout-custom-unit">&nbsp;</Label>
+                  <Select
+                    id="layout-custom-unit"
+                    value={customUnit}
+                    onChange={(e) => setCustomUnit(e.target.value as SizeUnit)}
+                  >
+                    <option value="px">px</option>
+                    <option value="mm">mm</option>
+                  </Select>
+                </div>
+              </div>
+            )}
+
+            <div className="space-y-1.5">
+              <Label htmlFor="layout-margin">{t("printLayout.margin")}</Label>
+              <Select
+                id="layout-margin"
+                value={pageMargin}
+                onChange={(e) =>
+                  setPageMargin(e.target.value as "normal" | "narrow" | "none")
+                }
+              >
+                <option value="normal">
+                  {t("printLayout.marginOption.normal")}
+                </option>
+                <option value="narrow">
+                  {t("printLayout.marginOption.narrow")}
+                </option>
+                <option value="none">
+                  {t("printLayout.marginOption.none")}
+                </option>
+              </Select>
+            </div>
+
+            <Separator />
+
             <div className="space-y-2">
-              <p className="text-sm font-medium">Map elements</p>
+              <p className="text-sm font-medium">
+                {t("printLayout.mapElements")}
+              </p>
               <ToggleField
                 id="el-title"
-                label="Title block"
+                label={t("printLayout.element.title")}
                 checked={showTitle}
                 onChange={setShowTitle}
               />
               <ToggleField
+                id="el-subtitle"
+                label={t("printLayout.element.subtitle")}
+                checked={showSubtitle}
+                onChange={setShowSubtitle}
+              />
+              <ToggleField
                 id="el-legend"
-                label="Legend"
+                label={t("printLayout.element.legend")}
                 checked={showLegend}
                 onChange={setShowLegend}
               />
               <ToggleField
                 id="el-scale"
-                label="Scale bar"
+                label={t("printLayout.element.scaleBar")}
                 checked={showScaleBar}
                 onChange={setShowScaleBar}
               />
               <ToggleField
                 id="el-north"
-                label="North arrow"
+                label={t("printLayout.element.northArrow")}
                 checked={showNorthArrow}
                 onChange={setShowNorthArrow}
               />
+              {showScaleBar && showNorthArrow && (
+                <ToggleField
+                  id="el-nav-group"
+                  label={t("printLayout.element.groupNavigation")}
+                  checked={navigationGrouped}
+                  onChange={setNavigationGrouped}
+                />
+              )}
+              <ToggleField
+                id="el-date"
+                label={t("printLayout.element.date")}
+                checked={showDate}
+                onChange={setShowDate}
+              />
+              <ToggleField
+                id="el-attribution"
+                label={t("printLayout.element.attribution")}
+                checked={showAttribution}
+                onChange={setShowAttribution}
+              />
               <ToggleField
                 id="el-footer"
-                label="Footer"
+                label={t("printLayout.element.footer")}
                 checked={showFooter}
                 onChange={setShowFooter}
+              />
+              <ToggleField
+                id="el-border"
+                label={t("printLayout.element.pageBorder")}
+                checked={showPageBorder}
+                onChange={setShowPageBorder}
               />
             </div>
 
             {showFooter && (
               <div className="space-y-1.5">
-                <Label htmlFor="layout-footer">Footer text</Label>
+                <Label htmlFor="layout-footer">
+                  {t("printLayout.footerTextLabel")}
+                </Label>
                 <Input
                   id="layout-footer"
                   value={footerText}
+                  placeholder={t("printLayout.footerPlaceholder")}
                   onChange={(e) => setFooterText(e.target.value)}
                 />
+              </div>
+            )}
+
+            {showPageBorder && (
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1.5">
+                  <Label htmlFor="layout-border-color">
+                    {t("printLayout.borderColor")}
+                  </Label>
+                  <input
+                    id="layout-border-color"
+                    type="color"
+                    className="h-9 w-full cursor-pointer rounded-md border border-input bg-background"
+                    value={pageBorderColor}
+                    onChange={(e) => setPageBorderColor(e.target.value)}
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="layout-border-width">
+                    {t("printLayout.borderWidth")}
+                  </Label>
+                  <Input
+                    id="layout-border-width"
+                    type="number"
+                    min={1}
+                    max={10}
+                    value={pageBorderWidth}
+                    onChange={(e) =>
+                      setPageBorderWidth(
+                        Math.max(1, Math.min(10, Number(e.target.value) || 1)),
+                      )
+                    }
+                  />
+                </div>
               </div>
             )}
 
@@ -504,17 +764,27 @@ export function PrintLayoutDialog({
           {/* Preview */}
           <div className="flex flex-col items-center justify-start gap-3">
             <div className="flex w-full items-center justify-between">
-              <span className="text-sm text-muted-foreground">Preview</span>
+              <span className="text-sm text-muted-foreground">
+                {t("printLayout.preview")}
+              </span>
               <Button variant="ghost" size="sm" onClick={recapture}>
                 <RefreshCw className="mr-2 h-3.5 w-3.5" />
-                Recapture map
+                {t("printLayout.recapture")}
               </Button>
             </div>
-            <div className="flex max-h-[420px] w-full items-center justify-center overflow-auto rounded-md border bg-muted/30 p-3">
+            {/* Fit the whole page in view: the canvas scales down to honour both
+                max constraints without ever showing a scrollbar (GH #520). */}
+            <div className="flex w-full flex-1 items-center justify-center rounded-md border bg-muted/30 p-3">
               <canvas
                 ref={previewRef}
-                className="max-w-full shadow-md"
-                style={{ imageRendering: "auto" }}
+                className="shadow-md"
+                style={{
+                  maxWidth: "100%",
+                  maxHeight: "min(60vh, 460px)",
+                  width: "auto",
+                  height: "auto",
+                  imageRendering: "auto",
+                }}
               />
             </div>
             {error && <p className="text-sm text-destructive">{error}</p>}
@@ -523,22 +793,25 @@ export function PrintLayoutDialog({
 
         <div className="flex items-center justify-end gap-2 pt-2">
           <Button variant="ghost" onClick={() => onOpenChange(false)}>
-            Close
+            {t("common.close")}
           </Button>
+          {/* Equal-weight export buttons: neither format is the "primary" one
+              (GH #520). */}
           <Button
             variant="outline"
             disabled={exporting || !captured}
             onClick={() => void handleExport("png")}
           >
             <FileImage className="mr-2 h-4 w-4" />
-            Export PNG
+            {t("printLayout.exportPng")}
           </Button>
           <Button
+            variant="outline"
             disabled={exporting || !captured}
             onClick={() => void handleExport("pdf")}
           >
             <FileText className="mr-2 h-4 w-4" />
-            Export PDF
+            {t("printLayout.exportPdf")}
           </Button>
         </div>
       </DialogContent>

--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -281,10 +281,13 @@ export function PrintLayoutDialog({
   useEffect(() => {
     if (!open) return;
     let raf = 0;
+    // Cap the retries so a canvas that never attaches (e.g. a portal render
+    // error) cannot spin the loop at ~60 fps until the next state change.
+    let retries = 0;
     const draw = () => {
       const canvas = previewRef.current;
       if (!canvas) {
-        raf = requestAnimationFrame(draw);
+        if (retries++ < 20) raf = requestAnimationFrame(draw);
         return;
       }
       const size = resolvePageSize(options);
@@ -468,9 +471,15 @@ export function PrintLayoutDialog({
                   />
                 </div>
                 <div className="space-y-1.5">
-                  <Label htmlFor="layout-custom-unit">&nbsp;</Label>
+                  <Label htmlFor="layout-custom-unit" className="sr-only">
+                    {t("printLayout.unit")}
+                  </Label>
+                  <span aria-hidden="true" className="block h-5">
+                    &nbsp;
+                  </span>
                   <Select
                     id="layout-custom-unit"
+                    aria-label={t("printLayout.unit")}
                     value={customUnit}
                     onChange={(e) => setCustomUnit(e.target.value as SizeUnit)}
                   >

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -487,6 +487,7 @@
     "landscape": "Landscape",
     "width": "Width",
     "height": "Height",
+    "unit": "Unit",
     "titlePlacement": "Title placement",
     "placement": {
       "outside": "Outside map frame",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -466,6 +466,67 @@
     "description": "Choose the language used for the interface."
   },
   "printLayout": {
+    "title": "Print Layout",
+    "description": "Compose a print-ready map with a title, legend, scale bar, and north arrow, then export it to PNG or PDF.",
+    "preview": "Preview",
+    "recapture": "Recapture map",
+    "exportPng": "Export PNG",
+    "exportPdf": "Export PDF",
+    "titleLabel": "Title",
+    "titlePlaceholder": "Map title",
+    "subtitleLabel": "Subtitle",
+    "subtitlePlaceholder": "Optional subtitle",
+    "size": "Size",
+    "sizeGroup": {
+      "paper": "Paper",
+      "screen": "Screen / digital"
+    },
+    "sizeCustom": "Custom…",
+    "orientation": "Orientation",
+    "portrait": "Portrait",
+    "landscape": "Landscape",
+    "width": "Width",
+    "height": "Height",
+    "titlePlacement": "Title placement",
+    "placement": {
+      "outside": "Outside map frame",
+      "inside": "Inside map frame"
+    },
+    "alignment": "Alignment",
+    "align": {
+      "left": "Left",
+      "center": "Center",
+      "right": "Right"
+    },
+    "mapElements": "Map elements",
+    "element": {
+      "title": "Title",
+      "subtitle": "Subtitle",
+      "legend": "Legend",
+      "scaleBar": "Scale bar",
+      "northArrow": "North arrow",
+      "groupNavigation": "Group north arrow & scale bar",
+      "footer": "Footer text",
+      "date": "Date",
+      "attribution": "Include GeoLibre attribution",
+      "pageBorder": "Page border"
+    },
+    "footerTextLabel": "Footer text",
+    "footerPlaceholder": "Custom footer text",
+    "margin": "Margin",
+    "marginOption": {
+      "normal": "Normal",
+      "narrow": "Narrow",
+      "none": "None (borderless)"
+    },
+    "borderColor": "Border color",
+    "borderWidth": "Border width",
+    "errors": {
+      "mapNotReady": "Map is not ready yet. Try again in a moment.",
+      "captureFailed": "Could not capture the map image.",
+      "captureFirst": "Capture the map before exporting.",
+      "exportFailed": "Failed to export {{format}}."
+    },
     "legend": {
       "section": "Legend",
       "titleLabel": "Legend title",

--- a/apps/geolibre-desktop/src/lib/print-layout-export.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout-export.ts
@@ -9,7 +9,9 @@ import jsPDF from "jspdf";
 import { isFullViewportMapCanvas } from "./print-capture";
 import {
   drawLayout,
-  pageDimensionsMm,
+  pageMm,
+  pagePx,
+  resolvePageSize,
   type LayoutOptions,
 } from "./print-layout";
 import { saveBinaryFileWithFallback } from "./tauri-io";
@@ -38,6 +40,8 @@ interface MapLike {
   getContainer(): HTMLElement;
   getBearing(): number;
   unproject(point: [number, number]): { lng: number; lat: number };
+  /** Force a synchronous redraw so the preserved drawing buffer is current. */
+  redraw?(): void;
 }
 
 /**
@@ -50,6 +54,17 @@ interface MapLike {
  *   render a scale bar and north arrow.
  */
 export function captureMapImage(map: MapLike): CapturedMap {
+  // Force a synchronous render first. MapLibre only paints on demand, so when
+  // the Print Layout modal opens without any recent camera movement the
+  // preserved drawing buffer can be stale or cleared -- which surfaced as a
+  // blank map (only the cartographic furniture rendered). redraw() guarantees
+  // the latest frame, including all active layers, is in the buffer we read.
+  try {
+    map.redraw?.();
+  } catch {
+    // A redraw failure (e.g. a transient GL state issue) must not block the
+    // capture; fall through and read whatever is in the buffer.
+  }
   const base = map.getCanvas();
   const out = document.createElement("canvas");
   out.width = base.width;
@@ -114,16 +129,16 @@ function haversineMeters(
   return 2 * R * Math.asin(Math.min(1, Math.sqrt(h)));
 }
 
-/** Rasterize a layout to an offscreen canvas at the given DPI. */
+/**
+ * Rasterize a layout to an offscreen canvas. Millimetre paper sizes render at
+ * the given DPI; pixel/screen sizes render at their exact pixel dimensions.
+ */
 function renderToCanvas(opts: LayoutOptions, dpi: number): HTMLCanvasElement {
-  const { widthMm, heightMm } = pageDimensionsMm(
-    opts.paperSize,
-    opts.orientation,
-  );
-  const pxPerMm = dpi / 25.4;
+  const size = resolvePageSize(opts);
+  const { width, height } = pagePx(size, dpi);
   const canvas = document.createElement("canvas");
-  canvas.width = Math.round(widthMm * pxPerMm);
-  canvas.height = Math.round(heightMm * pxPerMm);
+  canvas.width = width;
+  canvas.height = height;
   drawLayout(canvas, opts);
   return canvas;
 }
@@ -174,16 +189,16 @@ export async function exportLayoutPdf(
   filename: string,
   dpi = 150,
 ): Promise<string | null> {
-  const { widthMm, heightMm } = pageDimensionsMm(
-    opts.paperSize,
-    opts.orientation,
-  );
+  const size = resolvePageSize(opts);
+  const { widthMm, heightMm } = pageMm(size);
   const canvas = renderToCanvas(opts, dpi);
-  // Pass the orientation explicitly: jsPDF normalizes the format array to match
-  // the orientation (portrait forces width <= height), so an oriented format
-  // alone would be rotated back to portrait.
+  // Derive the orientation from the resolved dimensions rather than opts: custom
+  // sizes ignore the orientation toggle, and pixel presets are stored portrait-
+  // first, so the toggle alone can disagree with the actual page shape. jsPDF
+  // normalizes the format array to match the orientation (portrait forces
+  // width <= height), so the two must be consistent or the page gets rotated.
   const pdf = new jsPDF({
-    orientation: opts.orientation,
+    orientation: widthMm >= heightMm ? "landscape" : "portrait",
     unit: "mm",
     format: [widthMm, heightMm],
   });

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -237,6 +237,10 @@ export function drawLayout(
   const hasTitleBlock = hasTitleText || hasSubtitleText;
 
   // Footer row slots: attribution (left), footer text (centre), date (right).
+  // Attribution is opt-out (on unless explicitly disabled), deliberately unlike
+  // the other new booleans: GH #526 wants a pre-checked "Created with GeoLibre"
+  // credit so it survives a user replacing the footer text. Callers that omit
+  // the field therefore get the branding by design.
   const attributionText =
     opts.showAttribution !== false && (opts.attributionText ?? "Created with GeoLibre").trim();
   const footerText = opts.showFooter && opts.footerText.trim();
@@ -284,7 +288,9 @@ export function drawLayout(
     ctx.fillStyle = MUTED;
     ctx.font = `400 ${footSize}px system-ui, -apple-system, sans-serif`;
     ctx.textBaseline = "middle";
-    const slotMax = W - margin * 2;
+    // Give each of the three slots a third of the printable width so a long
+    // left attribution cannot visually bleed into the centred footer text.
+    const slotMax = (W - margin * 2) / 3;
     if (attributionText) {
       ctx.textAlign = "left";
       ctx.fillText(attributionText, margin, baselineY, slotMax);
@@ -352,7 +358,10 @@ export function drawLayout(
     const titleSize = unit * 4;
     const subtitleSize = unit * 2.2;
     const padY = unit * 2;
-    let y = bodyY + padY + titleSize;
+    // Seed the baseline at the first line that is actually drawn: when the title
+    // is hidden, the subtitle takes the top slot rather than being pushed a full
+    // title-height down (which dropped it below the backing rect). GH #526.
+    let y = bodyY + padY + (hasTitleText ? titleSize : subtitleSize);
     const insetX = unit * 2;
     const tx =
       titleAlign === "left"
@@ -361,7 +370,9 @@ export function drawLayout(
           ? bodyX + bodyW - insetX
           : bodyX + bodyW / 2;
     const blockH =
-      padY * 2 + (hasTitleText ? titleSize : 0) + (hasSubtitleText ? subtitleSize * 1.6 : 0);
+      padY * 2 +
+      (hasTitleText ? titleSize : 0) +
+      (hasSubtitleText ? (hasTitleText ? subtitleSize * 1.6 : subtitleSize * 1.2) : 0);
     ctx.fillStyle = "rgba(255,255,255,0.7)";
     ctx.fillRect(bodyX, bodyY, bodyW, blockH);
     if (hasTitleText) {
@@ -372,7 +383,8 @@ export function drawLayout(
       ctx.fillText(opts.title.trim(), tx, y, bodyW - insetX * 2);
     }
     if (hasSubtitleText) {
-      y += subtitleSize * 1.4;
+      // Only advance past the title line when one was drawn.
+      if (hasTitleText) y += subtitleSize * 1.4;
       ctx.fillStyle = MUTED;
       ctx.font = `400 ${subtitleSize}px system-ui, -apple-system, sans-serif`;
       ctx.textAlign = titleAlign;
@@ -600,7 +612,10 @@ function drawScaleBar(
 /** Format a representative fraction as "1:N" with thousands separators. */
 function formatScaleRatio(ratio: number): string {
   const rounded = Math.round(ratio);
-  return `1:${rounded.toLocaleString("en-US")}`;
+  // No explicit locale tag: a 1:N scale prints on the exported artefact, so it
+  // should follow the host environment's thousands separator (e.g. dots/spaces
+  // for de/fr) rather than being pinned to US commas.
+  return `1:${rounded.toLocaleString()}`;
 }
 
 /** Draw a legend box anchored at its top-left corner. */

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -8,43 +8,122 @@
  * (PNG / PDF), so the preview is faithful to the output.
  */
 
-export type PaperSizeId = "a4" | "a3" | "letter" | "legal" | "tabloid";
+export type PaperSizeId =
+  | "a4"
+  | "a3"
+  | "letter"
+  | "legal"
+  | "tabloid"
+  | "fullhd"
+  | "hd"
+  | "uhd4k"
+  | "square"
+  | "custom";
 export type Orientation = "portrait" | "landscape";
+/** How a size's width/height are expressed: physical millimetres or screen pixels. */
+export type SizeUnit = "mm" | "px";
 
 export interface PaperSize {
   id: PaperSizeId;
   label: string;
-  /** Width in millimetres in portrait orientation. */
-  widthMm: number;
-  /** Height in millimetres in portrait orientation. */
-  heightMm: number;
+  /** Width in {@link unit}, in portrait orientation (width ≤ height). */
+  width: number;
+  /** Height in {@link unit}, in portrait orientation. */
+  height: number;
+  unit: SizeUnit;
+  /** Grouping used by the size dropdown: physical paper vs digital screen. */
+  group: "paper" | "screen";
 }
 
-/** Standard paper sizes, expressed in their portrait dimensions. */
+/**
+ * Selectable output sizes. Physical paper formats are expressed in their
+ * portrait millimetre dimensions; digital/screen presets are expressed in
+ * pixels, also stored portrait-first so the shared orientation swap applies.
+ * The "Custom…" entry is a placeholder whose real dimensions come from
+ * {@link LayoutOptions.customSize}.
+ */
 export const PAPER_SIZES: PaperSize[] = [
-  { id: "a4", label: "A4 (210 × 297 mm)", widthMm: 210, heightMm: 297 },
-  { id: "a3", label: "A3 (297 × 420 mm)", widthMm: 297, heightMm: 420 },
-  { id: "letter", label: "Letter (8.5 × 11 in)", widthMm: 215.9, heightMm: 279.4 },
-  { id: "legal", label: "Legal (8.5 × 14 in)", widthMm: 215.9, heightMm: 355.6 },
-  { id: "tabloid", label: "Tabloid (11 × 17 in)", widthMm: 279.4, heightMm: 431.8 },
+  { id: "a4", label: "A4 (210 × 297 mm)", width: 210, height: 297, unit: "mm", group: "paper" },
+  { id: "a3", label: "A3 (297 × 420 mm)", width: 297, height: 420, unit: "mm", group: "paper" },
+  { id: "letter", label: "Letter (8.5 × 11 in)", width: 215.9, height: 279.4, unit: "mm", group: "paper" },
+  { id: "legal", label: "Legal (8.5 × 14 in)", width: 215.9, height: 355.6, unit: "mm", group: "paper" },
+  { id: "tabloid", label: "Tabloid (11 × 17 in)", width: 279.4, height: 431.8, unit: "mm", group: "paper" },
+  { id: "fullhd", label: "Full HD (1920 × 1080 px)", width: 1080, height: 1920, unit: "px", group: "screen" },
+  { id: "hd", label: "HD (1280 × 720 px)", width: 720, height: 1280, unit: "px", group: "screen" },
+  { id: "uhd4k", label: "4K UHD (3840 × 2160 px)", width: 2160, height: 3840, unit: "px", group: "screen" },
+  { id: "square", label: "Square (1080 × 1080 px)", width: 1080, height: 1080, unit: "px", group: "screen" },
+  { id: "custom", label: "Custom…", width: 1280, height: 720, unit: "px", group: "screen" },
 ];
 
 export function getPaperSize(id: PaperSizeId): PaperSize {
   return PAPER_SIZES.find((p) => p.id === id) ?? PAPER_SIZES[0];
 }
 
+/** A page size already resolved for a specific orientation. */
+export interface ResolvedPageSize {
+  width: number;
+  height: number;
+  unit: SizeUnit;
+}
+
+/** Custom user-defined dimensions, used when {@link LayoutOptions.paperSize} is "custom". */
+export interface CustomSize {
+  width: number;
+  height: number;
+  unit: SizeUnit;
+}
+
+/** CSS reference pixels per millimetre (96 dpi), used to bridge px ↔ mm sizes. */
+const PX_PER_MM_96 = 96 / 25.4;
+
 /**
- * Page dimensions in millimetres for a paper size and orientation, with the
- * width/height swapped for landscape.
+ * Resolve the effective page dimensions for a layout, applying the orientation
+ * swap to preset sizes. Custom sizes are taken verbatim (the dialog disables the
+ * orientation control for them) so the numbers the user typed are honoured.
  */
-export function pageDimensionsMm(
-  id: PaperSizeId,
-  orientation: Orientation,
-): { widthMm: number; heightMm: number } {
-  const paper = getPaperSize(id);
-  return orientation === "landscape"
-    ? { widthMm: paper.heightMm, heightMm: paper.widthMm }
-    : { widthMm: paper.widthMm, heightMm: paper.heightMm };
+export function resolvePageSize(opts: {
+  paperSize: PaperSizeId;
+  orientation: Orientation;
+  customSize?: CustomSize | null;
+}): ResolvedPageSize {
+  if (opts.paperSize === "custom") {
+    const c = opts.customSize;
+    if (c && c.width > 0 && c.height > 0) {
+      return { width: c.width, height: c.height, unit: c.unit };
+    }
+    return { width: 1280, height: 720, unit: "px" };
+  }
+  const paper = getPaperSize(opts.paperSize);
+  return opts.orientation === "landscape"
+    ? { width: paper.height, height: paper.width, unit: paper.unit }
+    : { width: paper.width, height: paper.height, unit: paper.unit };
+}
+
+/** Convert a resolved page size to millimetres (screen px treated as 96 dpi). */
+export function pageMm(size: ResolvedPageSize): {
+  widthMm: number;
+  heightMm: number;
+} {
+  if (size.unit === "mm") return { widthMm: size.width, heightMm: size.height };
+  return { widthMm: size.width / PX_PER_MM_96, heightMm: size.height / PX_PER_MM_96 };
+}
+
+/**
+ * Convert a resolved page size to output pixels at the given dpi. Pixel-unit
+ * sizes are exact (dpi is ignored); millimetre sizes scale by dpi/25.4.
+ */
+export function pagePx(
+  size: ResolvedPageSize,
+  dpi: number,
+): { width: number; height: number } {
+  if (size.unit === "px") {
+    return { width: Math.round(size.width), height: Math.round(size.height) };
+  }
+  const pxPerMm = dpi / 25.4;
+  return {
+    width: Math.round(size.width * pxPerMm),
+    height: Math.round(size.height * pxPerMm),
+  };
 }
 
 /** A single swatch in a legend entry (one color, with an optional label). */
@@ -65,12 +144,41 @@ export interface LayoutOptions {
   subtitle: string;
   paperSize: PaperSizeId;
   orientation: Orientation;
+  /** Explicit dimensions used when {@link paperSize} is "custom". */
+  customSize?: CustomSize | null;
   showTitle: boolean;
+  /** Whether the subtitle line is drawn (independent of {@link showTitle}). */
+  showSubtitle?: boolean;
+  /** Where the title/subtitle render: above the map (default) or overlaid inside it. */
+  titlePlacement?: "outside" | "inside";
+  /** Horizontal alignment of the title/subtitle text. */
+  titleAlign?: "left" | "center" | "right";
   showLegend: boolean;
   showScaleBar: boolean;
   showNorthArrow: boolean;
+  /**
+   * Group the north arrow directly above the scale bar in the lower-right
+   * corner (the cartographic "navigation duo"). When false they fall back to
+   * isolated anchors: north arrow top-right, scale bar bottom-right.
+   */
+  navigationGrouped?: boolean;
   showFooter: boolean;
   footerText: string;
+  /** Draw the production date (right side of the footer row). */
+  showDate?: boolean;
+  /** The formatted date string drawn when {@link showDate} is true. */
+  dateText?: string;
+  /** Draw the "Created with GeoLibre" attribution (left side of the footer row). */
+  showAttribution?: boolean;
+  /** Attribution text; defaults to "Created with GeoLibre" when omitted. */
+  attributionText?: string;
+  /** Outer page padding preset: full margins, narrow, or borderless. */
+  pageMargin?: "normal" | "narrow" | "none";
+  /** Draw a customizable border around the whole page (useful for PNG export). */
+  showPageBorder?: boolean;
+  pageBorderColor?: string;
+  /** Page border thickness on a 1–10 scale (relative to page size). */
+  pageBorderWidth?: number;
   legend: LegendEntry[];
   /** Heading drawn above the legend entries. */
   legendTitle: string;
@@ -117,7 +225,23 @@ export function drawLayout(
   // Scale furniture relative to the page's shorter side so output looks the
   // same at any resolution / paper size.
   const unit = Math.min(W, H) / 100;
-  const margin = unit * 5;
+  const marginScale =
+    opts.pageMargin === "none" ? 0 : opts.pageMargin === "narrow" ? 0.5 : 1;
+  const margin = unit * 5 * marginScale;
+
+  const titleAlign = opts.titleAlign ?? "center";
+  const titleInside = opts.titlePlacement === "inside";
+  const showSubtitle = opts.showSubtitle ?? true;
+  const hasTitleText = opts.showTitle && opts.title.trim().length > 0;
+  const hasSubtitleText = showSubtitle && opts.subtitle.trim().length > 0;
+  const hasTitleBlock = hasTitleText || hasSubtitleText;
+
+  // Footer row slots: attribution (left), footer text (centre), date (right).
+  const attributionText =
+    opts.showAttribution !== false && (opts.attributionText ?? "Created with GeoLibre").trim();
+  const footerText = opts.showFooter && opts.footerText.trim();
+  const dateText = opts.showDate && (opts.dateText ?? "").trim();
+  const hasFooterRow = Boolean(attributionText || footerText || dateText);
 
   ctx.save();
   ctx.fillStyle = PAGE_BACKGROUND;
@@ -126,42 +250,53 @@ export function drawLayout(
   let bodyTop = margin;
   let bodyBottom = H - margin;
 
-  // --- Title block -------------------------------------------------------
-  if (opts.showTitle && (opts.title.trim() || opts.subtitle.trim())) {
+  // X anchor + canvas textAlign for the chosen title alignment.
+  const titleX =
+    titleAlign === "left" ? margin : titleAlign === "right" ? W - margin : W / 2;
+
+  // --- Title block (outside the map) -------------------------------------
+  if (hasTitleBlock && !titleInside) {
     const titleSize = unit * 4.5;
     const subtitleSize = unit * 2.4;
     let y = margin + titleSize;
-    if (opts.title.trim()) {
+    if (hasTitleText) {
       ctx.fillStyle = INK;
       ctx.font = `600 ${titleSize}px system-ui, -apple-system, sans-serif`;
-      ctx.textAlign = "center";
+      ctx.textAlign = titleAlign;
       ctx.textBaseline = "alphabetic";
-      ctx.fillText(opts.title.trim(), W / 2, y, W - margin * 2);
+      ctx.fillText(opts.title.trim(), titleX, y, W - margin * 2);
     }
-    if (opts.subtitle.trim()) {
+    if (hasSubtitleText) {
       y += subtitleSize * 1.4;
       ctx.fillStyle = MUTED;
       ctx.font = `400 ${subtitleSize}px system-ui, -apple-system, sans-serif`;
-      ctx.textAlign = "center";
-      ctx.fillText(opts.subtitle.trim(), W / 2, y, W - margin * 2);
+      ctx.textAlign = titleAlign;
+      ctx.fillText(opts.subtitle.trim(), titleX, y, W - margin * 2);
     }
     bodyTop = y + unit * 3;
   }
 
-  // --- Footer ------------------------------------------------------------
-  if (opts.showFooter && opts.footerText.trim()) {
+  // --- Footer row --------------------------------------------------------
+  if (hasFooterRow) {
     const footSize = unit * 2.2;
     bodyBottom = H - margin - footSize * 1.8;
+    const baselineY = H - margin - footSize * 0.6;
     ctx.fillStyle = MUTED;
     ctx.font = `400 ${footSize}px system-ui, -apple-system, sans-serif`;
-    ctx.textAlign = "center";
     ctx.textBaseline = "middle";
-    ctx.fillText(
-      opts.footerText.trim(),
-      W / 2,
-      H - margin - footSize * 0.6,
-      W - margin * 2,
-    );
+    const slotMax = W - margin * 2;
+    if (attributionText) {
+      ctx.textAlign = "left";
+      ctx.fillText(attributionText, margin, baselineY, slotMax);
+    }
+    if (footerText) {
+      ctx.textAlign = "center";
+      ctx.fillText(footerText, W / 2, baselineY, slotMax);
+    }
+    if (dateText) {
+      ctx.textAlign = "right";
+      ctx.fillText(dateText, W - margin, baselineY, slotMax);
+    }
   }
 
   // --- Map body ----------------------------------------------------------
@@ -181,6 +316,9 @@ export function drawLayout(
   ctx.fillRect(bodyX, bodyY, bodyW, bodyH);
 
   // Draw the map image with "cover" scaling (fill the body, crop overflow).
+  // Guard the draw: a tainted/broken capture must not abort the whole layout,
+  // otherwise a single bad basemap (e.g. cross-origin OpenTopo tiles) would wipe
+  // out every cartographic element too, not just the map image.
   let coverScale = 1;
   if (opts.mapImage && opts.mapImageWidth > 0 && opts.mapImageHeight > 0) {
     coverScale = Math.max(
@@ -191,7 +329,11 @@ export function drawLayout(
     const drawH = opts.mapImageHeight * coverScale;
     const dx = bodyX + (bodyW - drawW) / 2;
     const dy = bodyY + (bodyH - drawH) / 2;
-    ctx.drawImage(opts.mapImage, dx, dy, drawW, drawH);
+    try {
+      ctx.drawImage(opts.mapImage, dx, dy, drawW, drawH);
+    } catch {
+      // Leave the grey placeholder; the rest of the layout still renders.
+    }
   }
   ctx.restore();
 
@@ -200,38 +342,99 @@ export function drawLayout(
   ctx.lineWidth = Math.max(1, unit * 0.2);
   ctx.strokeRect(bodyX, bodyY, bodyW, bodyH);
 
+  // --- Title block (inside the map) --------------------------------------
+  // Overlaid at the top of the map body with a translucent backing for legibility.
+  if (hasTitleBlock && titleInside) {
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(bodyX, bodyY, bodyW, bodyH);
+    ctx.clip();
+    const titleSize = unit * 4;
+    const subtitleSize = unit * 2.2;
+    const padY = unit * 2;
+    let y = bodyY + padY + titleSize;
+    const insetX = unit * 2;
+    const tx =
+      titleAlign === "left"
+        ? bodyX + insetX
+        : titleAlign === "right"
+          ? bodyX + bodyW - insetX
+          : bodyX + bodyW / 2;
+    const blockH =
+      padY * 2 + (hasTitleText ? titleSize : 0) + (hasSubtitleText ? subtitleSize * 1.6 : 0);
+    ctx.fillStyle = "rgba(255,255,255,0.7)";
+    ctx.fillRect(bodyX, bodyY, bodyW, blockH);
+    if (hasTitleText) {
+      ctx.fillStyle = INK;
+      ctx.font = `600 ${titleSize}px system-ui, -apple-system, sans-serif`;
+      ctx.textAlign = titleAlign;
+      ctx.textBaseline = "alphabetic";
+      ctx.fillText(opts.title.trim(), tx, y, bodyW - insetX * 2);
+    }
+    if (hasSubtitleText) {
+      y += subtitleSize * 1.4;
+      ctx.fillStyle = MUTED;
+      ctx.font = `400 ${subtitleSize}px system-ui, -apple-system, sans-serif`;
+      ctx.textAlign = titleAlign;
+      ctx.fillText(opts.subtitle.trim(), tx, y, bodyW - insetX * 2);
+    }
+    ctx.restore();
+  }
+
   const inset = unit * 2;
   // Metres per pixel in the *output* image after cover scaling.
   const outputMpp = opts.metersPerPixel / (coverScale || 1);
-
-  // --- North arrow (top-right inside the map) ---------------------------
-  if (opts.showNorthArrow) {
-    const arrowRadius = unit * 2.6;
-    const discRadius = arrowRadius * 1.5;
-    // The "N" label extends above the arrow tip, so the disc is not the top
-    // extent; account for both so nothing is clipped by the map edge.
-    const topExtent = arrowRadius + unit * 2.4;
-    const arrowMargin = unit * 3;
-    drawNorthArrow(
-      ctx,
-      bodyX + bodyW - arrowMargin - discRadius,
-      bodyY + arrowMargin + topExtent,
-      arrowRadius,
-      opts.bearingDeg,
-      unit,
-    );
+  const hasScale =
+    opts.showScaleBar && outputMpp > 0 && Number.isFinite(outputMpp);
+  // Representative fraction (1:N), only meaningful for physical paper sizes.
+  const page = resolvePageSize(opts);
+  let scaleRatio = 0;
+  if (hasScale && page.unit === "mm" && W > 0) {
+    const mmPerPx = pageMm(page).widthMm / W;
+    if (mmPerPx > 0) scaleRatio = (outputMpp * 1000) / mmPerPx;
   }
+  const navGrouped = opts.navigationGrouped ?? true;
+  const groupNav = navGrouped && opts.showNorthArrow && hasScale;
 
-  // --- Scale bar (bottom-right inside the map) --------------------------
-  if (opts.showScaleBar && outputMpp > 0 && Number.isFinite(outputMpp)) {
-    drawScaleBar(
+  // --- Scale bar + north arrow ------------------------------------------
+  let scaleTopY = bodyY + bodyH - inset;
+  if (hasScale) {
+    scaleTopY = drawScaleBar(
       ctx,
       bodyX + bodyW - inset,
       bodyY + bodyH - inset,
       bodyW * 0.28,
       outputMpp,
       unit,
+      scaleRatio,
     );
+  }
+  if (opts.showNorthArrow) {
+    const arrowRadius = unit * 2.6;
+    const discRadius = arrowRadius * 1.5;
+    if (groupNav) {
+      // Stack the north arrow directly above the scale bar (the "navigation duo").
+      drawNorthArrow(
+        ctx,
+        bodyX + bodyW - inset - discRadius,
+        scaleTopY - unit * 1.4 - discRadius,
+        arrowRadius,
+        opts.bearingDeg,
+        unit,
+      );
+    } else {
+      // Isolated fallback: top-right corner inside the map.
+      const topExtent = arrowRadius + unit * 2.4;
+      const arrowMargin = unit * 3;
+      drawNorthArrow(
+        ctx,
+        bodyX + bodyW - arrowMargin - discRadius,
+        bodyY + arrowMargin + topExtent,
+        arrowRadius,
+        opts.bearingDeg,
+        unit,
+      );
+    }
   }
 
   // --- Legend (bottom-left inside the map) ------------------------------
@@ -247,6 +450,15 @@ export function drawLayout(
       groupByLayer: opts.legendGroupByLayer,
     });
     ctx.restore();
+  }
+
+  // --- Page border -------------------------------------------------------
+  if (opts.showPageBorder) {
+    const widthScale = Math.max(1, Math.min(10, opts.pageBorderWidth ?? 2));
+    const lw = Math.max(1, unit * 0.2 * widthScale);
+    ctx.strokeStyle = opts.pageBorderColor ?? INK;
+    ctx.lineWidth = lw;
+    ctx.strokeRect(lw / 2, lw / 2, W - lw, H - lw);
   }
 
   ctx.restore();
@@ -320,7 +532,14 @@ function formatDistance(meters: number): string {
   return `${Math.round(meters * 100)} cm`;
 }
 
-/** Draw a scale bar anchored at its bottom-right corner. */
+/**
+ * Draw a scale bar anchored at its bottom-right corner. When `scaleRatio` is a
+ * positive value, a representative-fraction label (e.g. "1:25,000") is drawn
+ * above the distance label.
+ *
+ * @returns The top Y of the scale bar's backing box, so a caller can stack the
+ *   north arrow directly above it without overlapping.
+ */
 function drawScaleBar(
   ctx: CanvasRenderingContext2D,
   rightX: number,
@@ -328,7 +547,8 @@ function drawScaleBar(
   maxWidthPx: number,
   metersPerPixel: number,
   unit: number,
-): void {
+  scaleRatio = 0,
+): number {
   const maxMeters = maxWidthPx * metersPerPixel;
   const distance = niceDistance(maxMeters);
   const barWidth = distance / metersPerPixel;
@@ -336,15 +556,27 @@ function drawScaleBar(
   const x0 = rightX - barWidth;
   const y0 = bottomY - barHeight;
 
+  const hasRatio = scaleRatio > 0 && Number.isFinite(scaleRatio);
+  const ratioGap = hasRatio ? unit * 2.2 : 0;
+  const backingTop = y0 - unit * 2.4 - ratioGap;
+
   ctx.save();
   // Backing for legibility.
   ctx.fillStyle = "rgba(255,255,255,0.78)";
   ctx.fillRect(
     x0 - unit * 0.8,
-    y0 - unit * 2.4,
+    backingTop,
     barWidth + unit * 1.6,
-    barHeight + unit * 3.2,
+    bottomY - backingTop + unit * 0.8,
   );
+
+  if (hasRatio) {
+    ctx.fillStyle = INK;
+    ctx.font = `600 ${unit * 1.7}px system-ui, sans-serif`;
+    ctx.textAlign = "right";
+    ctx.textBaseline = "bottom";
+    ctx.fillText(formatScaleRatio(scaleRatio), rightX, y0 - unit * 2.4);
+  }
 
   // Two-tone bar.
   const half = barWidth / 2;
@@ -362,6 +594,13 @@ function drawScaleBar(
   ctx.textBaseline = "bottom";
   ctx.fillText(formatDistance(distance), rightX, y0 - unit * 0.5);
   ctx.restore();
+  return backingTop;
+}
+
+/** Format a representative fraction as "1:N" with thousands separators. */
+function formatScaleRatio(ratio: number): string {
+  const rounded = Math.round(ratio);
+  return `1:${rounded.toLocaleString("en-US")}`;
 }
 
 /** Draw a legend box anchored at its top-left corner. */

--- a/apps/geolibre-desktop/src/lib/ui-profile.ts
+++ b/apps/geolibre-desktop/src/lib/ui-profile.ts
@@ -201,7 +201,9 @@ export const MENU_ITEM_CATALOG: readonly MenuItemCatalogEntry[] = [
   { id: "project.share", menuId: "project", labelKey: "toolbar.item.shareEllipsis", tier: "intermediate" },
   { id: "project.collaborate", menuId: "project", labelKey: "toolbar.item.collaborateEllipsis", tier: "advanced" },
   { id: "project.print", menuId: "project", labelKey: "toolbar.item.printEllipsis", tier: "intermediate" },
-  { id: "project.printLayout", menuId: "project", labelKey: "toolbar.item.printLayoutEllipsis", tier: "advanced" },
+  // Print Layout is the primary way any user turns a map into a shareable PDF/PNG
+  // deliverable, so it stays visible for every profile (GH #529).
+  { id: "project.printLayout", menuId: "project", labelKey: "toolbar.item.printLayoutEllipsis", tier: "basic" },
   { id: "project.offlineRegion", menuId: "project", labelKey: "toolbar.item.offlineRegionEllipsis", tier: "advanced" },
   { id: "project.storymap", menuId: "project", labelKey: "toolbar.item.storymapEllipsis", tier: "advanced" },
   // Edit

--- a/tests/print-layout.test.ts
+++ b/tests/print-layout.test.ts
@@ -2,6 +2,9 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
   drawLayout,
+  pageMm,
+  pagePx,
+  resolvePageSize,
   type LayoutOptions,
   type LegendEntry,
 } from "../apps/geolibre-desktop/src/lib/print-layout";
@@ -134,5 +137,133 @@ describe("drawLayout legend rendering", () => {
     const label = fills.find((f) => f.text === "Roads");
     assert.ok(label, "expected the legend row label to be drawn");
     assert.equal(label.textAlign, "left");
+  });
+});
+
+describe("resolvePageSize", () => {
+  it("swaps width/height for landscape preset paper", () => {
+    const portrait = resolvePageSize({ paperSize: "a4", orientation: "portrait" });
+    assert.deepEqual(portrait, { width: 210, height: 297, unit: "mm" });
+    const landscape = resolvePageSize({ paperSize: "a4", orientation: "landscape" });
+    assert.deepEqual(landscape, { width: 297, height: 210, unit: "mm" });
+  });
+
+  it("resolves a pixel screen preset to its oriented pixel dimensions", () => {
+    const landscape = resolvePageSize({ paperSize: "fullhd", orientation: "landscape" });
+    assert.deepEqual(landscape, { width: 1920, height: 1080, unit: "px" });
+  });
+
+  it("takes custom dimensions verbatim, ignoring orientation", () => {
+    const size = resolvePageSize({
+      paperSize: "custom",
+      orientation: "landscape",
+      customSize: { width: 800, height: 600, unit: "px" },
+    });
+    assert.deepEqual(size, { width: 800, height: 600, unit: "px" });
+  });
+
+  it("falls back to a sane default for an incomplete custom size", () => {
+    const size = resolvePageSize({
+      paperSize: "custom",
+      orientation: "portrait",
+      customSize: { width: 0, height: 0, unit: "px" },
+    });
+    assert.deepEqual(size, { width: 1280, height: 720, unit: "px" });
+  });
+});
+
+describe("pageMm / pagePx", () => {
+  it("passes millimetre sizes through and scales by dpi for pixels", () => {
+    assert.deepEqual(pageMm({ width: 210, height: 297, unit: "mm" }), {
+      widthMm: 210,
+      heightMm: 297,
+    });
+    assert.deepEqual(pagePx({ width: 1920, height: 1080, unit: "px" }, 150), {
+      width: 1920,
+      height: 1080,
+    });
+    // A4 portrait at 150 dpi: 210 mm * 150 / 25.4 ≈ 1240 px.
+    assert.deepEqual(pagePx({ width: 210, height: 297, unit: "mm" }, 150), {
+      width: 1240,
+      height: 1754,
+    });
+  });
+
+  it("treats screen pixels as 96-dpi millimetres", () => {
+    const { widthMm } = pageMm({ width: 96, height: 96, unit: "px" });
+    assert.ok(Math.abs(widthMm - 25.4) < 1e-6, "96 px at 96 dpi is one inch");
+  });
+});
+
+describe("drawLayout cartographic furniture", () => {
+  it("right-aligns the title when titleAlign is right", () => {
+    const { canvas, fills } = recordingCanvas();
+    drawLayout(canvas, baseOptions({ title: "Atlas", titleAlign: "right" }));
+    const title = fills.find((f) => f.text === "Atlas");
+    assert.ok(title, "expected the title to be drawn");
+    assert.equal(title.textAlign, "right");
+  });
+
+  it("draws the attribution and date in the footer row independently", () => {
+    const { canvas, fills } = recordingCanvas();
+    drawLayout(
+      canvas,
+      baseOptions({
+        showAttribution: true,
+        showDate: true,
+        dateText: "2026-06-19",
+        showFooter: true,
+        footerText: "My Org",
+      }),
+    );
+    const attribution = fills.find((f) => f.text === "Created with GeoLibre");
+    assert.ok(attribution, "expected the attribution to be drawn");
+    assert.equal(attribution.textAlign, "left");
+    const date = fills.find((f) => f.text === "2026-06-19");
+    assert.ok(date, "expected the date to be drawn");
+    assert.equal(date.textAlign, "right");
+    const footer = fills.find((f) => f.text === "My Org");
+    assert.ok(footer, "expected the custom footer text to be drawn");
+    assert.equal(footer.textAlign, "center");
+  });
+
+  it("omits the attribution when showAttribution is false", () => {
+    const { canvas, fills } = recordingCanvas();
+    drawLayout(canvas, baseOptions({ showAttribution: false }));
+    assert.ok(!fills.some((f) => f.text === "Created with GeoLibre"));
+  });
+
+  it("draws a 1:N scale ratio for a millimetre paper size", () => {
+    const { canvas, fills } = recordingCanvas();
+    drawLayout(
+      canvas,
+      baseOptions({
+        showScaleBar: true,
+        metersPerPixel: 10,
+        mapImage: {} as CanvasImageSource,
+        mapImageWidth: 400,
+        mapImageHeight: 400,
+      }),
+    );
+    assert.ok(
+      fills.some((f) => /^1:/.test(f.text)),
+      "expected a representative-fraction label",
+    );
+  });
+
+  it("does not draw a scale ratio for a pixel screen size", () => {
+    const { canvas, fills } = recordingCanvas();
+    drawLayout(
+      canvas,
+      baseOptions({
+        paperSize: "fullhd",
+        showScaleBar: true,
+        metersPerPixel: 10,
+        mapImage: {} as CanvasImageSource,
+        mapImageWidth: 400,
+        mapImageHeight: 400,
+      }),
+    );
+    assert.ok(!fills.some((f) => /^1:/.test(f.text)));
   });
 });


### PR DESCRIPTION
Resolves the cluster of open **Print Layout** issues in a single PR.

## Bugs fixed
- **#520** — The preview now scales the whole page to fit the pane with **no scrollbar** (the original A4-portrait complaint is gone). Export **PNG/PDF** are now equal-weight buttons (both `outline`) instead of PDF being styled as the primary action.
- **#521** — The captured map rendered **blank**. Fixes:
  - Force a synchronous `map.redraw()` before reading the canvas so the preserved drawing buffer is current.
  - Guard the map-image draw inside `drawLayout` so a tainted/broken basemap (e.g. cross-origin OpenTopo tiles) can no longer abort the whole layout — the cartographic furniture always renders.
  - Redraw the preview via `requestAnimationFrame` (retrying until the portal-mounted canvas exists) so it renders correctly **on open** without a manual *Recapture map*.
- **#529** — Print Layout is now visible for **every** user profile (tier `basic`), so beginners can export a deliverable.

## Features added
- **#525** — "Paper size" → **"Size"**, grouped into **Paper** and **Screen / digital** (Full HD, HD, 4K UHD, Square) plus a **Custom** width×height/unit option. Added a **Margin** preset (Normal/Narrow/None) and a customizable **Page border** (color + width) for presentation-ready PNGs.
- **#526** — Split the single "Title block" toggle into independent **Title** and **Subtitle** toggles; added a standalone **Date** element and an **"Include GeoLibre attribution"** checkbox. The footer row now lays out attribution (left) · custom footer text (center) · date (right), so a user's footer text no longer overwrites the GeoLibre credit. Added **title placement** (outside vs. inside the map frame) and **left/center/right alignment**.
- **#524** — The north arrow is grouped directly above the scale bar by default (the cartographic **"navigation duo"**), with a toggle to fall back to isolated anchors (north top-right, scale bottom-right).

## Partial / deferred (per scope agreement)
- **#522** — *Partial:* the layout now shows the **representative-fraction scale (1:N)** above the scale bar for physical paper sizes (hidden for pixel/screen sizes, where it's meaningless). Full two-way numeric-scale sync and the structured bottom-right title block remain follow-up work.
- **#523** — Interactive **draw-extent bounding-box** tool deferred to a follow-up (it's a new main-canvas interaction subsystem, out of scope for this PR).

## i18n
All new dialog strings are translatable (`en.json`); existing hardcoded dialog strings were converted to `t()`.

## Tests & verification
- Added unit tests for `resolvePageSize` / `pageMm` / `pagePx` and the new `drawLayout` furniture (title alignment, footer/attribution/date slots, scale-ratio gating). Full frontend suite + typecheck + production build pass; pre-commit (incl. npm build + eslint) passes.
- Verified end-to-end in the real app with Playwright: Print Layout visible under the Beginner profile; map renders in the preview on open; A4 portrait fits with no scrollbar; Size dropdown groups + Full HD 16:9 + Custom; inside/outside title placement + alignment; page border; navigation duo; attribution + date footer row.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded Print Layout dialog: title placement/alignment, custom page dimensions, page margins, and optional page borders.
  * Added screen-size presets plus footer controls (date and attribution) and extended map element toggles.
  * Print Layout is now available for basic experience levels.
* **Bug Fixes**
  * Improved preview/export rendering so page orientation and dimensions stay consistent, with more reliable redraw/capture.
* **Localization**
  * Updated print layout UI text and translated export/capture error messages.
* **Tests**
  * Added coverage for page sizing (mm/px), conversions, and layout rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->