### PR TITLE
fix(wayback): bump esri-wayback to 0.2.1 so metadata panel scrolls

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -62,7 +62,7 @@
     "maplibre-gl-duckdb": "^0.2.0",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",
-    "maplibre-gl-esri-wayback": "^0.2.0",
+    "maplibre-gl-esri-wayback": "^0.2.1",
     "maplibre-gl-fema-wms": "^0.1.2",
     "maplibre-gl-geo-editor": "^0.9.1",
     "maplibre-gl-geoagent": "^0.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "maplibre-gl-duckdb": "^0.2.0",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
-        "maplibre-gl-esri-wayback": "^0.2.0",
+        "maplibre-gl-esri-wayback": "^0.2.1",
         "maplibre-gl-fema-wms": "^0.1.2",
         "maplibre-gl-geo-editor": "^0.9.1",
         "maplibre-gl-geoagent": "^0.4.3",
@@ -257,9 +257,9 @@
       }
     },
     "apps/geolibre-desktop/node_modules/maplibre-gl-esri-wayback": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-esri-wayback/-/maplibre-gl-esri-wayback-0.2.0.tgz",
-      "integrity": "sha512-jxx0yxmrbhO0SPY4yqqMb1dELLq9l7ESVthNIErTis/1XiF3kVPhGWDKN3HBMLeJquCC5kuJqDxrbwRTxe7vtw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-esri-wayback/-/maplibre-gl-esri-wayback-0.2.1.tgz",
+      "integrity": "sha512-08CGUiJIGH532lURQeDPrpV6o6aZCI7T7OJhQTClQcC0b6cjpyi4Eei/eIvkpRjtjDK2qSOWkNziX4pQj1kI8g==",
       "license": "MIT",
       "dependencies": {
         "@esri/wayback-core": ">=1.0.10"
@@ -24298,7 +24298,7 @@
         "maplibre-gl-duckdb": "^0.2.0",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
-        "maplibre-gl-esri-wayback": "^0.2.0",
+        "maplibre-gl-esri-wayback": "^0.2.1",
         "maplibre-gl-fema-wms": "^0.1.2",
         "maplibre-gl-geo-editor": "^0.9.1",
         "maplibre-gl-geoagent": "^0.4.3",
@@ -24403,9 +24403,9 @@
       }
     },
     "packages/plugins/node_modules/maplibre-gl-esri-wayback": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-esri-wayback/-/maplibre-gl-esri-wayback-0.2.0.tgz",
-      "integrity": "sha512-jxx0yxmrbhO0SPY4yqqMb1dELLq9l7ESVthNIErTis/1XiF3kVPhGWDKN3HBMLeJquCC5kuJqDxrbwRTxe7vtw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-esri-wayback/-/maplibre-gl-esri-wayback-0.2.1.tgz",
+      "integrity": "sha512-08CGUiJIGH532lURQeDPrpV6o6aZCI7T7OJhQTClQcC0b6cjpyi4Eei/eIvkpRjtjDK2qSOWkNziX4pQj1kI8g==",
       "license": "MIT",
       "dependencies": {
         "@esri/wayback-core": ">=1.0.10"

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -36,7 +36,7 @@
     "maplibre-gl-duckdb": "^0.2.0",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",
-    "maplibre-gl-esri-wayback": "^0.2.0",
+    "maplibre-gl-esri-wayback": "^0.2.1",
     "maplibre-gl-fema-wms": "^0.1.2",
     "maplibre-gl-geo-editor": "^0.9.1",
     "maplibre-gl-geoagent": "^0.4.3",


### PR DESCRIPTION
## Problem

Fixes #548. When inspecting historical imagery with the **Esri Wayback**
tool, the **Location metadata** shown after clicking the map is sliced off
mid-attribute (e.g. *Accuracy*), with no scrollbar to reach the rest —
despite plenty of empty space below the panel.

Root cause: the bundled `maplibre-gl-esri-wayback` control caps its content
region with `overflow: hidden`, so tall metadata overflows the fixed height
and is clipped.

## Fix

The fix lives upstream in **maplibre-gl-esri-wayback 0.2.1**
(opengeos/maplibre-gl-esri-wayback#6):

- `.esri-wayback-control-panel.expanded` is now a flex column so the header
  stays put and the content region flexes within the panel height.
- `.esri-wayback-control-content` flexes and scrolls vertically
  (`overflow-y: auto`) instead of clipping at a fixed `max-height`.

So the panel grows with the metadata up to its max-height (dynamic height
scaling), then shows a scrollbar (overflow fallback) — both remedies the
issue asked for.

This PR just bumps the dependency to `^0.2.1` in both workspaces to pick up
that release.

## Testing

- `pre-commit run --files …` (incl. the `npm build` hook) passes.
- Verified the published `0.2.1` bundle in `node_modules` carries the
  flex/scroll CSS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `maplibre-gl-esri-wayback` dependency to version 0.2.1 across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->