### PR TITLE
fix(wayback): grow the Esri Wayback panel into available map height

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -62,7 +62,7 @@
     "maplibre-gl-duckdb": "^0.2.0",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",
-    "maplibre-gl-esri-wayback": "^0.2.1",
+    "maplibre-gl-esri-wayback": "^0.2.2",
     "maplibre-gl-fema-wms": "^0.1.2",
     "maplibre-gl-geo-editor": "^0.9.1",
     "maplibre-gl-geoagent": "^0.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "maplibre-gl-duckdb": "^0.2.0",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
-        "maplibre-gl-esri-wayback": "^0.2.1",
+        "maplibre-gl-esri-wayback": "^0.2.2",
         "maplibre-gl-fema-wms": "^0.1.2",
         "maplibre-gl-geo-editor": "^0.9.1",
         "maplibre-gl-geoagent": "^0.4.3",
@@ -257,9 +257,9 @@
       }
     },
     "apps/geolibre-desktop/node_modules/maplibre-gl-esri-wayback": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-esri-wayback/-/maplibre-gl-esri-wayback-0.2.1.tgz",
-      "integrity": "sha512-08CGUiJIGH532lURQeDPrpV6o6aZCI7T7OJhQTClQcC0b6cjpyi4Eei/eIvkpRjtjDK2qSOWkNziX4pQj1kI8g==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-esri-wayback/-/maplibre-gl-esri-wayback-0.2.2.tgz",
+      "integrity": "sha512-qcaFrUahmznzFc334LdDNQl2iTDArLGaxRB2U+mwvR0NVfxVyb4C5yUAJ2jGuBtNB7ek6YKbrnMhAzRudPa1+Q==",
       "license": "MIT",
       "dependencies": {
         "@esri/wayback-core": ">=1.0.10"
@@ -24298,7 +24298,7 @@
         "maplibre-gl-duckdb": "^0.2.0",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
-        "maplibre-gl-esri-wayback": "^0.2.1",
+        "maplibre-gl-esri-wayback": "^0.2.2",
         "maplibre-gl-fema-wms": "^0.1.2",
         "maplibre-gl-geo-editor": "^0.9.1",
         "maplibre-gl-geoagent": "^0.4.3",
@@ -24403,9 +24403,9 @@
       }
     },
     "packages/plugins/node_modules/maplibre-gl-esri-wayback": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-esri-wayback/-/maplibre-gl-esri-wayback-0.2.1.tgz",
-      "integrity": "sha512-08CGUiJIGH532lURQeDPrpV6o6aZCI7T7OJhQTClQcC0b6cjpyi4Eei/eIvkpRjtjDK2qSOWkNziX4pQj1kI8g==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-esri-wayback/-/maplibre-gl-esri-wayback-0.2.2.tgz",
+      "integrity": "sha512-qcaFrUahmznzFc334LdDNQl2iTDArLGaxRB2U+mwvR0NVfxVyb4C5yUAJ2jGuBtNB7ek6YKbrnMhAzRudPa1+Q==",
       "license": "MIT",
       "dependencies": {
         "@esri/wayback-core": ">=1.0.10"

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -36,7 +36,7 @@
     "maplibre-gl-duckdb": "^0.2.0",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",
-    "maplibre-gl-esri-wayback": "^0.2.1",
+    "maplibre-gl-esri-wayback": "^0.2.2",
     "maplibre-gl-fema-wms": "^0.1.2",
     "maplibre-gl-geo-editor": "^0.9.1",
     "maplibre-gl-geoagent": "^0.4.3",


### PR DESCRIPTION
## Problem

Follow-up to #550 / #548. After the `0.2.1` bump the **Esri Wayback** panel
scrolls instead of clipping, but it still clamps to a fixed height and shows
a scrollbar even when the map is much taller — leaving plenty of empty space
beneath the panel.

## Fix

Bump `maplibre-gl-esri-wayback` to **0.2.2**
(opengeos/maplibre-gl-esri-wayback#7), which sizes the panel's `max-height`
to the room between its anchor and the opposite map edge. The panel now
grows with the metadata up to the available map height and only scrolls when
the content genuinely exceeds it.

## Testing

Verified in the real app with Playwright (1600×1200 viewport, Esri Wayback
activated, panel expanded):

- Panel `max-height` is now **1074px** (map height 1128 − top offset 44 −
  10px margin), not the old fixed 540px.
- Empty panel stays compact at **480px** (only as tall as its content).
- With a metadata payload that exceeds the old 540px cap, the panel grows to
  **762px with no scrollbar**, using the available vertical space.
- With content taller than the available height, it caps at 1074px and
  scrolls.

`pre-commit run --files …` (incl. the `npm build` hook) passes.