### PR TITLE
fix(toolbar): remove non-functional Layers icon from header

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -45,7 +45,6 @@ import {
   FolderOpen,
   Info,
   Keyboard,
-  Layers,
   Link2,
   Map,
   MapPin,
@@ -1061,7 +1060,6 @@ export function TopToolbar({
         </Button>
         {showProjectInfo ? (
           <>
-            <Layers className="mr-1 hidden h-3 w-3 md:inline" />
             <Input
               aria-label={t("toolbar.item.projectName")}
               className="hidden h-7 w-44 border-transparent px-2 text-xs shadow-none focus-visible:border-input md:block"


### PR DESCRIPTION
## Summary

The Layers icon in the top-right header (next to the project-name field) was a purely decorative adornment with no click handler, so clicking it did nothing. As reported in #546, users reasonably expect a standalone icon in the menu bar to be interactive, which made it confusing.

This removes the decorative `Layers` icon (and its now-unused import) so the header no longer presents a misleading, non-functional control. The theme toggle and project-name field next to it are unchanged.

## Verification

- `npm run build` passes
- `pre-commit run --files apps/geolibre-desktop/src/components/layout/TopToolbar.tsx` passes (eslint + build)
- Verified in the running app with Playwright in both light and dark themes: the top-right header renders cleanly with just the theme toggle and project name, and no layout regression.

Fixes #546

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed an unused icon from the project toolbar for a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->