### PR TITLE
fix(add-data): clarify Saved services bar and basemap toggle

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/add-data/ServiceLibrarySection.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/ServiceLibrarySection.tsx
@@ -9,7 +9,7 @@
  */
 
 import { Button, Input, Label, Select } from "@geolibre/ui";
-import { Bookmark, Download, Save, Trash2, Upload, X } from "lucide-react";
+import { Bookmark, Download, Save, Trash2, Upload } from "lucide-react";
 import { type KeyboardEvent, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { saveTextFileWithFallback } from "../../../lib/tauri-io";
@@ -245,6 +245,10 @@ export function ServiceLibrarySection({
             <Save className="mr-1.5 h-3.5 w-3.5" />
             {t("addData.serviceLibrary.saveCurrent")}
           </Button>
+          {/* Separate the per-service "Save current" action from the
+              whole-library import/export icons so the group does not read as a
+              single ambiguous control (issue #530). */}
+          <span aria-hidden className="mx-0.5 h-5 w-px bg-border" />
           <Button
             type="button"
             size="icon"
@@ -357,7 +361,6 @@ export function ServiceLibrarySection({
               variant="ghost"
               onClick={() => setIsSaving(false)}
             >
-              <X className="mr-1.5 h-3.5 w-3.5" />
               {t("common.cancel")}
             </Button>
             <Button type="button" size="sm" onClick={handleSave}>

--- a/apps/geolibre-desktop/src/components/layout/add-data/shared.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/shared.tsx
@@ -146,17 +146,15 @@ export function InsertBeforeField({
         )}
       </Select>
       {basemapStyleLayerIds.length > 0 && !valueIsBasemapLayer && (
-        <button
-          type="button"
-          aria-expanded={showBasemapLayers}
-          aria-controls="add-data-before-id"
-          className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
-          onClick={() => setShowBasemapLayers((prev) => !prev)}
-        >
-          {showBasemapLayers
-            ? t("addData.shared.hideBasemapLayers")
-            : t("addData.shared.showBasemapLayers")}
-        </button>
+        <label className="flex items-center gap-2 text-xs text-muted-foreground">
+          <input
+            type="checkbox"
+            aria-controls="add-data-before-id"
+            checked={showBasemapLayers}
+            onChange={(event) => setShowBasemapLayers(event.target.checked)}
+          />
+          {t("addData.shared.showBasemapLayers")}
+        </label>
       )}
     </div>
   );

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -78,7 +78,6 @@
       "layersGroup": "Layers",
       "basemapLayersGroup": "Basemap layers",
       "showBasemapLayers": "Show basemap layers (advanced)",
-      "hideBasemapLayers": "Hide basemap layers",
       "addLayer": "Add layer",
       "adding": "Adding…",
       "addError": "Could not add layer."


### PR DESCRIPTION
## Summary

Addresses the UX confusion reported in #530 for the **Add WMS Layer** dialog. All three elements live in shared Add Data components (`ServiceLibrarySection`, `shared.tsx`), so the fixes also benefit the other web-service sources (WMTS/XYZ/ArcGIS/WFS).

1. **Saved services bar grouping.** Added a thin vertical divider between the per-service "Save current" button and the whole-library import/export icon buttons, so the group no longer reads as one ambiguous control. (The import/export icons already carry `title`/`aria-label` hover tooltips.)
2. **"Show basemap layers (advanced)" toggle.** Replaced the plain muted-text button with an explicit checkbox so its interactivity is discoverable, matching the issue's proposed solution and the existing "Transparent background" checkbox pattern. Removed the now-unused `hideBasemapLayers` string.
3. **Stray Cancel X.** Removed the `X` icon from the save form's Cancel button so it matches the icon-less Cancel button in the dialog footer.

This is a GeoLibre-only change; no upstream package or release was involved.

## Verification

- `npm run build` passes; `pre-commit` (eslint + build) passes on the changed files.
- Drove the running app with Playwright in **both light and dark themes**: the checkbox and divider render correctly in each, the footer-consistent Cancel has no icon, and toggling the new checkbox still reveals the "Basemap layers" group in the "Insert before" dropdown (same behavior as the old text toggle).

Fixes #530

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Added visual separator in dialog header for improved layout organization.
  * Updated cancel button to display text label instead of icon.
  * Changed basemap layers toggle from button to checkbox control.
  * Updated labels and translations for basemap layer visibility options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->