### PR TITLE
fix(basemaps): confirm before a style basemap clears stacked basemaps and surface actionable credential errors

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -57,7 +57,7 @@
     "mapillary-js": "^4.1.2",
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.1",
-    "maplibre-gl-basemap-control": "^0.4.1",
+    "maplibre-gl-basemap-control": "^0.5.0",
     "maplibre-gl-components": "^0.22.0",
     "maplibre-gl-duckdb": "^0.2.0",
     "maplibre-gl-earth-engine": "^0.4.2",

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -22,6 +22,7 @@ import {
   openThreeDTilesLayerPanel,
   openVectorLayerPanel,
   openZarrLayerPanel,
+  setBasemapControlLabels,
   setReverseGeocodeLabels,
   DECK_VIZ_PLUGIN_ID,
   DIRECTIONS_PLUGIN_ID,
@@ -160,6 +161,10 @@ export function TopToolbar({
       noAddress: t("geocode.reverseNoAddress"),
       copyAddress: t("geocode.reverseCopyAddress"),
       failed: t("geocode.reverseFailed"),
+    });
+    setBasemapControlLabels({
+      confirmStyleReplace: (name, count) =>
+        t("basemaps.confirmStyleReplace", { name, count }),
     });
   }, [t]);
 

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1027,6 +1027,10 @@
     "reverseCopyAddress": "Copy address",
     "reverseFailed": "Reverse geocoding failed."
   },
+  "basemaps": {
+    "confirmStyleReplace_one": "Switching to \"{{name}}\" replaces the whole map style and will remove the {{count}} stacked basemap you added. Continue?",
+    "confirmStyleReplace_other": "Switching to \"{{name}}\" replaces the whole map style and will remove the {{count}} stacked basemaps you added. Continue?"
+  },
   "pythonConsole": {
     "title": "Python Console",
     "resize": "Resize Python console",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1028,7 +1028,7 @@
     "reverseFailed": "Reverse geocoding failed."
   },
   "basemaps": {
-    "confirmStyleReplace_one": "Switching to \"{{name}}\" replaces the whole map style and will remove the {{count}} stacked basemap you added. Continue?",
+    "confirmStyleReplace_one": "Switching to \"{{name}}\" replaces the whole map style and will remove the stacked basemap you added. Continue?",
     "confirmStyleReplace_other": "Switching to \"{{name}}\" replaces the whole map style and will remove the {{count}} stacked basemaps you added. Continue?"
   },
   "pythonConsole": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "mapillary-js": "^4.1.2",
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.1",
-        "maplibre-gl-basemap-control": "^0.4.1",
+        "maplibre-gl-basemap-control": "^0.5.0",
         "maplibre-gl-components": "^0.22.0",
         "maplibre-gl-duckdb": "^0.2.0",
         "maplibre-gl-earth-engine": "^0.4.2",
@@ -17367,9 +17367,9 @@
       "license": "MIT"
     },
     "node_modules/maplibre-gl-basemap-control": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-basemap-control/-/maplibre-gl-basemap-control-0.4.1.tgz",
-      "integrity": "sha512-cLZMai9qDaKfuA3BTH9MMQAupVBDDIVlk93XU8zVe0Wl2ZKmJHGtJDUOWWDMg79+dRYPs6LuyJ/Yh5heEfBUvw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-basemap-control/-/maplibre-gl-basemap-control-0.5.0.tgz",
+      "integrity": "sha512-Tp3D2Lsj1l9o8uZvoOa1SNIfeCG/HKqZPd0D+CnymJXh59x4NEhcLzyeSPDE4YhbNvnnCGnSTqRzIRdJkkFr5w==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -24293,7 +24293,7 @@
         "jspdf": "^4.2.1",
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.1",
-        "maplibre-gl-basemap-control": "^0.4.1",
+        "maplibre-gl-basemap-control": "^0.5.0",
         "maplibre-gl-components": "^0.22.0",
         "maplibre-gl-duckdb": "^0.2.0",
         "maplibre-gl-earth-engine": "^0.4.2",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -31,7 +31,7 @@
     "jspdf": "^4.2.1",
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.1",
-    "maplibre-gl-basemap-control": "^0.4.1",
+    "maplibre-gl-basemap-control": "^0.5.0",
     "maplibre-gl-components": "^0.22.0",
     "maplibre-gl-duckdb": "^0.2.0",
     "maplibre-gl-earth-engine": "^0.4.2",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -3,7 +3,11 @@ export { PluginManager } from "./plugin-manager";
 export { maplibreLayerControlPlugin } from "./plugins/layer-control";
 export { osmBasemapPlugin } from "./plugins/osm-basemap";
 export { cartoLightPlugin } from "./plugins/carto-light";
-export { maplibreBasemapControlPlugin } from "./plugins/maplibre-basemap-control";
+export {
+  maplibreBasemapControlPlugin,
+  setBasemapControlLabels,
+  type BasemapControlLabels,
+} from "./plugins/maplibre-basemap-control";
 export {
   addArcGISLayer,
   type ArcGISLayerOptions,

--- a/packages/plugins/src/plugins/maplibre-basemap-control.ts
+++ b/packages/plugins/src/plugins/maplibre-basemap-control.ts
@@ -15,6 +15,35 @@ import type {
 
 let basemapControlPosition: GeoLibreMapControlPosition = "top-left";
 
+/**
+ * User-facing strings the panel cannot translate itself. Defaults are English;
+ * the desktop shell pushes translated values via {@link setBasemapControlLabels}
+ * since this package is framework-agnostic and has no direct access to
+ * react-i18next.
+ */
+export interface BasemapControlLabels {
+  /**
+   * Builds the confirmation shown before a style basemap replaces the stacked
+   * raster basemaps, given the style basemap name and how many will be removed
+   * (always at least one).
+   */
+  confirmStyleReplace: (basemapName: string, count: number) => string;
+}
+
+let labels: BasemapControlLabels = {
+  confirmStyleReplace: (basemapName, count) =>
+    count === 1
+      ? `Switching to "${basemapName}" replaces the whole map style and will remove the 1 stacked basemap you added. Continue?`
+      : `Switching to "${basemapName}" replaces the whole map style and will remove the ${count} stacked basemaps you added. Continue?`,
+};
+
+/** Override the panel strings (called from the app layer with translated text). */
+export function setBasemapControlLabels(
+  next: Partial<BasemapControlLabels>,
+): void {
+  labels = { ...labels, ...next };
+}
+
 let basemapControl: BasemapControl | null = null;
 // GeoLibre layer ids of registered raster basemaps, keyed by basemap id. In
 // multiple mode several raster basemaps can be registered at once.
@@ -88,11 +117,9 @@ function getBasemapControlOptions(
     // issue #551.
     confirmStyleReplace: ({ basemap, replacedBasemapIds }) => {
       const count = replacedBasemapIds.length;
-      const message =
-        count === 1
-          ? `Switching to "${basemap.name}" replaces the whole map style and will remove the 1 stacked basemap you added. Continue?`
-          : `Switching to "${basemap.name}" replaces the whole map style and will remove the ${count} stacked basemaps you added. Continue?`;
-      return window.confirm(message);
+      // Nothing stacked to lose: never prompt (and avoids a "remove 0" message).
+      if (count === 0) return true;
+      return window.confirm(labels.confirmStyleReplace(basemap.name, count));
     },
   };
 }

--- a/packages/plugins/src/plugins/maplibre-basemap-control.ts
+++ b/packages/plugins/src/plugins/maplibre-basemap-control.ts
@@ -119,6 +119,10 @@ function getBasemapControlOptions(
       const count = replacedBasemapIds.length;
       // Nothing stacked to lose: never prompt (and avoids a "remove 0" message).
       if (count === 0) return true;
+      // Native dialog, matching the existing window.confirm usage in the shell.
+      // In a sandboxed cross-origin iframe (e.g. the Jupyter embed) confirm is
+      // suppressed and returns false, so the switch is simply blocked there.
+      // That fails safe: the stacked basemaps are kept and nothing is lost.
       return window.confirm(labels.confirmStyleReplace(basemap.name, count));
     },
   };

--- a/packages/plugins/src/plugins/maplibre-basemap-control.ts
+++ b/packages/plugins/src/plugins/maplibre-basemap-control.ts
@@ -82,6 +82,18 @@ function getBasemapControlOptions(
     collapsed: false,
     position: basemapControlPosition,
     title: "Basemaps",
+    // A style basemap (e.g. OpenFreeMap 3D) swaps the whole map style and so
+    // discards every stacked raster basemap. In stack mode that silently wiped
+    // a carefully assembled stack, so confirm before the rasters are lost. See
+    // issue #551.
+    confirmStyleReplace: ({ basemap, replacedBasemapIds }) => {
+      const count = replacedBasemapIds.length;
+      const message =
+        count === 1
+          ? `Switching to "${basemap.name}" replaces the whole map style and will remove the 1 stacked basemap you added. Continue?`
+          : `Switching to "${basemap.name}" replaces the whole map style and will remove the ${count} stacked basemaps you added. Continue?`;
+      return window.confirm(message);
+    },
   };
 }
 

--- a/packages/plugins/src/plugins/maplibre-basemap-control.ts
+++ b/packages/plugins/src/plugins/maplibre-basemap-control.ts
@@ -33,7 +33,7 @@ export interface BasemapControlLabels {
 let labels: BasemapControlLabels = {
   confirmStyleReplace: (basemapName, count) =>
     count === 1
-      ? `Switching to "${basemapName}" replaces the whole map style and will remove the 1 stacked basemap you added. Continue?`
+      ? `Switching to "${basemapName}" replaces the whole map style and will remove the stacked basemap you added. Continue?`
       : `Switching to "${basemapName}" replaces the whole map style and will remove the ${count} stacked basemaps you added. Continue?`,
 };
 


### PR DESCRIPTION
## Summary

Two basemap-panel papercuts, both rooted in `maplibre-gl-basemap-control` and fixed upstream in [v0.5.0](https://github.com/opengeos/maplibre-gl-basemap-control/releases/tag/v0.5.0) (PR opengeos/maplibre-gl-basemap-control#14), then consumed here.

### #551 — Adding "OpenFreeMap 3D" wiped stacked basemaps with no warning

A GL-style basemap (OpenFreeMap 3D) is a full MapLibre style, so applying it swaps the whole style and necessarily discards every stacked raster basemap. In stack mode ("Add basemaps (stack instead of replace)") this silently destroyed a carefully assembled stack with a single click.

The control now exposes a `confirmStyleReplace` hook, wired here to a confirmation:

> Switching to "OpenFreeMap 3D" replaces the whole map style and will remove the 3 stacked basemaps you added. Continue?

Cancel keeps the stack intact; Accept proceeds as before. Only fires in stack mode when rasters are stacked, so normal single-basemap switching is unaffected.

### #549 — Amazon credential error was a dead end

`Enter an Amazon API key before applying this basemap.` offered no next step. The 0.5.0 panel now renders a **"Get an Amazon API key"** link (provider-specific, also MapTiler/Mapbox) and **auto-expands the Provider settings** section so the key input is visible in context.

## Changes

- Bump `maplibre-gl-basemap-control` to `^0.5.0` in `apps/geolibre-desktop` and `packages/plugins`.
- Wire `confirmStyleReplace` in the basemap-control plugin with a clear, correctly pluralized message.

## Verification

Driven in the real app with Playwright using the live basemap catalog, in **both light and dark themes**:
- #549: error shows the help link and the Provider settings inputs auto-expand.
- #551: confirm dialog appears before replacing; Cancel preserves all stacked basemaps, Accept switches to the style basemap.

`npm run build` and `pre-commit` on the changed files pass.

Fixes #549
Fixes #551

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a confirmation prompt when switching basemap styles to warn that the map style will be replaced and stacked raster basemaps will be removed (with correct pluralized counts).
  * Added localized basemap confirmation text that updates automatically when the app language changes.
* **Chores**
  * Updated the `maplibre-gl-basemap-control` dependency to version `0.5.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->