### PR TITLE
feat(add-data): accept comma decimals and drag-drop CSV files (#527)

### DIFF
--- a/apps/geolibre-desktop/src/lib/delimited-text.ts
+++ b/apps/geolibre-desktop/src/lib/delimited-text.ts
@@ -307,8 +307,15 @@ export function detectDelimitedTextDelimiter(text: string): string {
 export function detectCoordinateFields(
   fields: string[],
 ): { longitudeField: string; latitudeField: string } | null {
-  const match = (candidates: string[]) =>
-    fields.find((field) => candidates.includes(field.trim().toLowerCase()));
+  // Match in candidate-priority order so a more specific name (e.g.
+  // "longitude") wins over a generic one (e.g. "x") regardless of column order.
+  const match = (candidates: string[]) => {
+    for (const candidate of candidates) {
+      const field = fields.find((f) => f.trim().toLowerCase() === candidate);
+      if (field) return field;
+    }
+    return undefined;
+  };
   const longitudeField = match(LONGITUDE_FIELD_CANDIDATES);
   const latitudeField = match(LATITUDE_FIELD_CANDIDATES);
   if (!longitudeField || !latitudeField) return null;

--- a/apps/geolibre-desktop/src/lib/delimited-text.ts
+++ b/apps/geolibre-desktop/src/lib/delimited-text.ts
@@ -240,7 +240,7 @@ export function parseCoordinate(value: string | undefined): number {
   const normalized = trimmed
     .split(groupingSeparator)
     .join("")
-    .replace(decimalSeparator, ".");
+    .replaceAll(decimalSeparator, ".");
   return Number(normalized);
 }
 
@@ -277,7 +277,7 @@ const DELIMITER_CANDIDATES = [",", "\t", ";", "|"];
  * @returns The detected delimiter; defaults to a comma when none stands out.
  */
 export function detectDelimitedTextDelimiter(text: string): string {
-  const header = text.replace(/^﻿/, "").split(/\r?\n/, 1)[0] ?? "";
+  const header = text.replace(/^\uFEFF/, "").split(/\r?\n/, 1)[0] ?? "";
   let best = ",";
   let bestCount = 0;
   for (const delimiter of DELIMITER_CANDIDATES) {

--- a/apps/geolibre-desktop/src/lib/delimited-text.ts
+++ b/apps/geolibre-desktop/src/lib/delimited-text.ts
@@ -63,8 +63,8 @@ export function parseDelimitedTextLayer(
   const features: Feature<Point, GeoJsonProperties>[] = [];
 
   for (const row of rows.slice(1)) {
-    const latitude = Number(row[latitudeIndex]);
-    const longitude = Number(row[longitudeIndex]);
+    const latitude = parseCoordinate(row[latitudeIndex]);
+    const longitude = parseCoordinate(row[longitudeIndex]);
     if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
       skippedRows += 1;
       continue;
@@ -213,4 +213,104 @@ function findFieldIndex(fields: string[], fieldName: string): number {
   return fields.findIndex(
     (field) => field.trim().toLowerCase() === normalizedFieldName,
   );
+}
+
+/**
+ * Parses a coordinate string to a number, accepting a comma as the decimal
+ * separator in addition to a dot. Many locales (e.g. most of Europe) write
+ * `4,35` for `4.35`, and JavaScript's `Number()` returns `NaN` for those, so
+ * delimited files exported under such locales would otherwise drop every row.
+ *
+ * When both `,` and `.` appear, the right-most one is treated as the decimal
+ * separator and the other as a thousands grouping separator (which is removed).
+ *
+ * @param value - The raw coordinate field (may include surrounding whitespace).
+ * @returns The parsed number, or `NaN` when the value is empty or unparsable.
+ */
+export function parseCoordinate(value: string | undefined): number {
+  const trimmed = (value ?? "").trim();
+  if (!trimmed) return Number.NaN;
+
+  const lastComma = trimmed.lastIndexOf(",");
+  const lastDot = trimmed.lastIndexOf(".");
+  if (lastComma < 0 && lastDot < 0) return Number(trimmed);
+
+  const decimalSeparator = lastComma > lastDot ? "," : ".";
+  const groupingSeparator = decimalSeparator === "," ? "." : ",";
+  const normalized = trimmed
+    .split(groupingSeparator)
+    .join("")
+    .replace(decimalSeparator, ".");
+  return Number(normalized);
+}
+
+/** Header names that, case-insensitively, identify a longitude column. */
+export const LONGITUDE_FIELD_CANDIDATES = [
+  "longitude",
+  "lon",
+  "lng",
+  "long",
+  "x",
+  "xcoord",
+  "x_coord",
+];
+
+/** Header names that, case-insensitively, identify a latitude column. */
+export const LATITUDE_FIELD_CANDIDATES = [
+  "latitude",
+  "lat",
+  "y",
+  "ycoord",
+  "y_coord",
+];
+
+/** Delimiters tried, in order, when auto-detecting a delimited file's format. */
+const DELIMITER_CANDIDATES = [",", "\t", ";", "|"];
+
+/**
+ * Guesses the field delimiter of a delimited text file by parsing its header
+ * row with each candidate delimiter and keeping the one that yields the most
+ * columns. Quoting is respected, so a quoted field containing a delimiter does
+ * not skew the guess.
+ *
+ * @param text - The delimited text, optionally starting with a BOM.
+ * @returns The detected delimiter; defaults to a comma when none stands out.
+ */
+export function detectDelimitedTextDelimiter(text: string): string {
+  const header = text.replace(/^﻿/, "").split(/\r?\n/, 1)[0] ?? "";
+  let best = ",";
+  let bestCount = 0;
+  for (const delimiter of DELIMITER_CANDIDATES) {
+    try {
+      const fields = parseDelimitedTextFields(header, delimiter).filter(
+        (field) => field.trim().length > 0,
+      );
+      if (fields.length > bestCount) {
+        bestCount = fields.length;
+        best = delimiter;
+      }
+    } catch {
+      // No usable header for this delimiter; try the next candidate.
+    }
+  }
+  return best;
+}
+
+/**
+ * Picks the longitude and latitude columns from a list of header names using
+ * the well-known coordinate column names. Returns `null` when either cannot be
+ * found, so callers can fall back to asking the user instead of guessing.
+ *
+ * @param fields - The header column names.
+ * @returns The matched longitude/latitude field names, or `null`.
+ */
+export function detectCoordinateFields(
+  fields: string[],
+): { longitudeField: string; latitudeField: string } | null {
+  const match = (candidates: string[]) =>
+    fields.find((field) => candidates.includes(field.trim().toLowerCase()));
+  const longitudeField = match(LONGITUDE_FIELD_CANDIDATES);
+  const latitudeField = match(LATITUDE_FIELD_CANDIDATES);
+  if (!longitudeField || !latitudeField) return null;
+  return { longitudeField, latitudeField };
 }

--- a/apps/geolibre-desktop/src/lib/delimited-text.ts
+++ b/apps/geolibre-desktop/src/lib/delimited-text.ts
@@ -223,6 +223,9 @@ function findFieldIndex(fields: string[], fieldName: string): number {
  *
  * When both `,` and `.` appear, the right-most one is treated as the decimal
  * separator and the other as a thousands grouping separator (which is removed).
+ * When only one appears, it is treated as the decimal separator (so `"1,234"`
+ * parses to `1.234`); this is unambiguous for WGS84 coordinates, where a
+ * thousands grouping never occurs within the valid +/-180 range.
  *
  * @param value - The raw coordinate field (may include surrounding whitespace).
  * @returns The parsed number, or `NaN` when the value is empty or unparsable.

--- a/apps/geolibre-desktop/src/lib/delimited-text.ts
+++ b/apps/geolibre-desktop/src/lib/delimited-text.ts
@@ -265,7 +265,7 @@ export const LATITUDE_FIELD_CANDIDATES = [
 ];
 
 /** Delimiters tried, in order, when auto-detecting a delimited file's format. */
-const DELIMITER_CANDIDATES = [",", "\t", ";", "|"];
+export const DELIMITER_CANDIDATES = [",", "\t", ";", "|"];
 
 /**
  * Guesses the field delimiter of a delimited text file by parsing its header

--- a/apps/geolibre-desktop/src/lib/delimited-text.ts
+++ b/apps/geolibre-desktop/src/lib/delimited-text.ts
@@ -244,12 +244,17 @@ export function parseCoordinate(value: string | undefined): number {
   return Number(normalized);
 }
 
-/** Header names that, case-insensitively, identify a longitude column. */
+/**
+ * Header names that, case-insensitively, identify a longitude column when
+ * auto-detecting coordinates. `"long"` is deliberately excluded here: it is a
+ * common non-geographic column name (e.g. a length field), and a false match
+ * would silently build wrong points. The Add Data dialog still offers it as a
+ * manual option where the user confirms the column.
+ */
 export const LONGITUDE_FIELD_CANDIDATES = [
   "longitude",
   "lon",
   "lng",
-  "long",
   "x",
   "xcoord",
   "x_coord",

--- a/apps/geolibre-desktop/src/lib/delimited-text.ts
+++ b/apps/geolibre-desktop/src/lib/delimited-text.ts
@@ -12,6 +12,14 @@ export interface DelimitedTextLayerResult {
   totalRows: number;
 }
 
+/**
+ * Thrown by {@link parseDelimitedTextLayer} when the chosen columns parse but no
+ * row holds a valid WGS84 coordinate. Exported so callers can recognize this
+ * specific failure without matching a duplicated literal string.
+ */
+export const NO_VALID_COORDINATES_MESSAGE =
+  "No rows contained valid longitude and latitude values.";
+
 export function parseDelimitedTextFields(
   text: string,
   delimiter: string,
@@ -90,7 +98,7 @@ export function parseDelimitedTextLayer(
   }
 
   if (features.length === 0) {
-    throw new Error("No rows contained valid longitude and latitude values.");
+    throw new Error(NO_VALID_COORDINATES_MESSAGE);
   }
 
   return {

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -13,6 +13,7 @@ import type { FeatureCollection } from "geojson";
 import shp from "shpjs";
 import {
   DELIMITER_CANDIDATES,
+  NO_VALID_COORDINATES_MESSAGE,
   detectCoordinateFields,
   detectDelimitedTextDelimiter,
   parseDelimitedTextFields,
@@ -256,13 +257,18 @@ function isDelimitedTextFileName(path: string): boolean {
 
 /**
  * Parses dropped/opened delimited text into a point FeatureCollection by
- * auto-detecting the delimiter and the longitude/latitude columns. Throws a
- * helpful error (pointing at the Add Data dialog) when the coordinate columns
- * cannot be identified or the auto-detected columns hold no usable WGS84
- * coordinates (e.g. a CSV whose `x`/`y` columns are actually projected), so the
- * column picker stays the way to handle ambiguous files.
+ * auto-detecting the delimiter and the longitude/latitude columns.
+ *
+ * Returns `null` when no longitude/latitude columns can be identified, so the
+ * caller can fall back to the DuckDB path and still load spatial CSV variants
+ * (e.g. a CSV with a WKT geometry column). Throws a helpful error (pointing at
+ * the Add Data dialog) when the file is empty or the auto-detected columns hold
+ * no usable WGS84 coordinates (e.g. a CSV whose `x`/`y` columns are projected).
  */
-function parseDelimitedTextFile(text: string, path: string): FeatureCollection {
+function parseDelimitedTextFile(
+  text: string,
+  path: string,
+): FeatureCollection | null {
   const name = browserSafeFileName(path);
   const pickColumns = `Use Add Data → Delimited Text to choose the coordinate columns for ${name}.`;
   const delimiter = detectDelimitedTextDelimiter(text);
@@ -275,11 +281,7 @@ function parseDelimitedTextFile(text: string, path: string): FeatureCollection {
   }
   const fields = parseDelimitedTextFields(headerLine, delimiter);
   const coordinateFields = detectCoordinateFields(fields);
-  if (!coordinateFields) {
-    throw new Error(
-      `Could not find longitude and latitude columns in ${name}. ${pickColumns}`,
-    );
-  }
+  if (!coordinateFields) return null;
   try {
     return parseDelimitedTextLayer(text, {
       delimiter,
@@ -292,9 +294,7 @@ function parseDelimitedTextFile(text: string, path: string): FeatureCollection {
     // (e.g. the auto-detected columns are actually projected x/y); append the
     // column-picker hint just for that case. Other errors (e.g. a header with
     // no data rows) are already self-explanatory, so surface them unchanged.
-    const isCoordinateError = detail.includes(
-      "No rows contained valid longitude and latitude",
-    );
+    const isCoordinateError = detail === NO_VALID_COORDINATES_MESSAGE;
     throw new Error(isCoordinateError ? `${detail} ${pickColumns}` : detail);
   }
 }
@@ -484,10 +484,12 @@ async function loadBrowserVectorFile(
   }
 
   if (isDelimitedTextFileName(file.name)) {
-    return {
-      data: parseDelimitedTextFile(await file.text(), file.name),
-      path: file.name,
-    };
+    const points = parseDelimitedTextFile(await file.text(), file.name);
+    // No lon/lat columns: fall through to DuckDB so spatial CSV variants
+    // (e.g. a WKT geometry column) still load.
+    if (points) {
+      return { data: points, path: file.name };
+    }
   }
 
   return {
@@ -611,10 +613,12 @@ async function loadTauriVectorFile(
   }
 
   if (isDelimitedTextFileName(path)) {
-    return {
-      data: parseDelimitedTextFile(await readTextFile(path), path),
-      path,
-    };
+    const points = parseDelimitedTextFile(await readTextFile(path), path);
+    // No lon/lat columns: fall through to DuckDB so spatial CSV variants
+    // (e.g. a WKT geometry column) still load.
+    if (points) {
+      return { data: points, path };
+    }
   }
 
   try {

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -12,6 +12,7 @@ import { unzip } from "fflate";
 import type { FeatureCollection } from "geojson";
 import shp from "shpjs";
 import {
+  DELIMITER_CANDIDATES,
   detectCoordinateFields,
   detectDelimitedTextDelimiter,
   parseDelimitedTextFields,
@@ -1295,11 +1296,13 @@ export function parseCsvHeaderLine(line: string): string[] {
   const header = line.replace(/^﻿/, "").replace(/[\r\n]+$/, "");
   if (!header) return [];
   // Reuse the project's quote-aware delimited-text parser for each candidate
-  // delimiter (comma, tab, semicolon) and keep the one that yields the most
-  // columns. Quoting is respected, so a quoted field containing the delimiter
-  // (e.g. "city,state") neither skews detection nor splits the header.
+  // delimiter and keep the one that yields the most columns. The candidate set
+  // is shared with the drag-and-drop loader so both detect the same formats
+  // (comma, tab, semicolon, pipe). Quoting is respected, so a quoted field
+  // containing the delimiter (e.g. "city,state") neither skews detection nor
+  // splits the header.
   let best: string[] = [];
-  for (const delimiter of [",", "\t", ";"]) {
+  for (const delimiter of DELIMITER_CANDIDATES) {
     try {
       const fields = parseDelimitedTextFields(header, delimiter).filter(
         (name) => name.trim().length > 0,

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -270,6 +270,9 @@ function parseDelimitedTextFile(text: string, path: string): FeatureCollection {
   // parseDelimitedTextLayer re-reads the header internally, so parsing the
   // whole file here just to recover the column names would double the work.
   const headerLine = text.replace(/^\uFEFF/, "").split(/\r?\n/, 1)[0] ?? "";
+  if (!headerLine.trim()) {
+    throw new Error(`${name} appears to be empty. ${pickColumns}`);
+  }
   const fields = parseDelimitedTextFields(headerLine, delimiter);
   const coordinateFields = detectCoordinateFields(fields);
   if (!coordinateFields) {

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -287,11 +287,15 @@ function parseDelimitedTextFile(text: string, path: string): FeatureCollection {
       latitudeField: coordinateFields.latitudeField,
     }).data;
   } catch (error) {
-    // The columns matched a coordinate name but held no valid lon/lat values
-    // (e.g. projected x/y). Point the user at the dialog instead of surfacing
-    // the lower-level "no valid coordinates" message.
     const detail = error instanceof Error ? error.message : String(error);
-    throw new Error(`${detail} ${pickColumns}`);
+    // Only the "no valid coordinates" failure points to the wrong columns
+    // (e.g. the auto-detected columns are actually projected x/y); append the
+    // column-picker hint just for that case. Other errors (e.g. a header with
+    // no data rows) are already self-explanatory, so surface them unchanged.
+    const isCoordinateError = detail.includes(
+      "No rows contained valid longitude and latitude",
+    );
+    throw new Error(isCoordinateError ? `${detail} ${pickColumns}` : detail);
   }
 }
 

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -257,25 +257,34 @@ function isDelimitedTextFileName(path: string): boolean {
  * Parses dropped/opened delimited text into a point FeatureCollection by
  * auto-detecting the delimiter and the longitude/latitude columns. Throws a
  * helpful error (pointing at the Add Data dialog) when the coordinate columns
- * cannot be identified, so the column picker stays the way to handle ambiguous
- * files.
+ * cannot be identified or the auto-detected columns hold no usable WGS84
+ * coordinates (e.g. a CSV whose `x`/`y` columns are actually projected), so the
+ * column picker stays the way to handle ambiguous files.
  */
 function parseDelimitedTextFile(text: string, path: string): FeatureCollection {
   const name = browserSafeFileName(path);
+  const pickColumns = `Use Add Data → Delimited Text to choose the coordinate columns for ${name}.`;
   const delimiter = detectDelimitedTextDelimiter(text);
   const fields = parseDelimitedTextFields(text, delimiter);
   const coordinateFields = detectCoordinateFields(fields);
   if (!coordinateFields) {
     throw new Error(
-      `Could not find longitude and latitude columns in ${name}. ` +
-        "Use Add Data → Delimited Text to choose the coordinate columns.",
+      `Could not find longitude and latitude columns in ${name}. ${pickColumns}`,
     );
   }
-  return parseDelimitedTextLayer(text, {
-    delimiter,
-    longitudeField: coordinateFields.longitudeField,
-    latitudeField: coordinateFields.latitudeField,
-  }).data;
+  try {
+    return parseDelimitedTextLayer(text, {
+      delimiter,
+      longitudeField: coordinateFields.longitudeField,
+      latitudeField: coordinateFields.latitudeField,
+    }).data;
+  } catch (error) {
+    // The columns matched a coordinate name but held no valid lon/lat values
+    // (e.g. projected x/y). Point the user at the dialog instead of surfacing
+    // the lower-level "no valid coordinates" message.
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`${detail} ${pickColumns}`);
+  }
 }
 
 async function parseShapefileZip(

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -265,7 +265,11 @@ function parseDelimitedTextFile(text: string, path: string): FeatureCollection {
   const name = browserSafeFileName(path);
   const pickColumns = `Use Add Data → Delimited Text to choose the coordinate columns for ${name}.`;
   const delimiter = detectDelimitedTextDelimiter(text);
-  const fields = parseDelimitedTextFields(text, delimiter);
+  // Detect the coordinate columns from the header slice only;
+  // parseDelimitedTextLayer re-reads the header internally, so parsing the
+  // whole file here just to recover the column names would double the work.
+  const headerLine = text.replace(/^\uFEFF/, "").split(/\r?\n/, 1)[0] ?? "";
+  const fields = parseDelimitedTextFields(headerLine, delimiter);
   const coordinateFields = detectCoordinateFields(fields);
   if (!coordinateFields) {
     throw new Error(

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -11,7 +11,12 @@ import {
 import { unzip } from "fflate";
 import type { FeatureCollection } from "geojson";
 import shp from "shpjs";
-import { parseDelimitedTextFields } from "./delimited-text";
+import {
+  detectCoordinateFields,
+  detectDelimitedTextDelimiter,
+  parseDelimitedTextFields,
+  parseDelimitedTextLayer,
+} from "./delimited-text";
 import type { DuckDbVectorFile } from "./duckdb-vector-loader";
 import type { DuckDbVectorLoadOptions } from "./duckdb-vector-guard";
 import { parseGpxLayer } from "./gpx";
@@ -240,6 +245,39 @@ function parseGpxTextLayers(text: string, path: string): LoadedVectorLayer[] {
     }));
 }
 
+/** Delimited text formats the drag-and-drop / open path loads as points. */
+const DELIMITED_TEXT_DROP_EXTENSIONS = ["csv", "tsv"];
+
+/** Whether a filename looks like a delimited text table (CSV/TSV). */
+function isDelimitedTextFileName(path: string): boolean {
+  return DELIMITED_TEXT_DROP_EXTENSIONS.includes(fileExtension(path));
+}
+
+/**
+ * Parses dropped/opened delimited text into a point FeatureCollection by
+ * auto-detecting the delimiter and the longitude/latitude columns. Throws a
+ * helpful error (pointing at the Add Data dialog) when the coordinate columns
+ * cannot be identified, so the column picker stays the way to handle ambiguous
+ * files.
+ */
+function parseDelimitedTextFile(text: string, path: string): FeatureCollection {
+  const name = browserSafeFileName(path);
+  const delimiter = detectDelimitedTextDelimiter(text);
+  const fields = parseDelimitedTextFields(text, delimiter);
+  const coordinateFields = detectCoordinateFields(fields);
+  if (!coordinateFields) {
+    throw new Error(
+      `Could not find longitude and latitude columns in ${name}. ` +
+        "Use Add Data → Delimited Text to choose the coordinate columns.",
+    );
+  }
+  return parseDelimitedTextLayer(text, {
+    delimiter,
+    longitudeField: coordinateFields.longitudeField,
+    latitudeField: coordinateFields.latitudeField,
+  }).data;
+}
+
 async function parseShapefileZip(
   data: ArrayBuffer | Uint8Array,
 ): Promise<FeatureCollection> {
@@ -424,6 +462,13 @@ async function loadBrowserVectorFile(
     };
   }
 
+  if (isDelimitedTextFileName(file.name)) {
+    return {
+      data: parseDelimitedTextFile(await file.text(), file.name),
+      path: file.name,
+    };
+  }
+
   return {
     data: await loadDuckDbVector(
       {
@@ -542,6 +587,13 @@ async function loadTauriVectorFile(
       const detail = error instanceof Error ? error.message : "Unknown error";
       throw new Error(`Could not read this GPX file. ${detail}`);
     }
+  }
+
+  if (isDelimitedTextFileName(path)) {
+    return {
+      data: parseDelimitedTextFile(await readTextFile(path), path),
+      path,
+    };
   }
 
   try {

--- a/tests/data-parsing.test.ts
+++ b/tests/data-parsing.test.ts
@@ -103,6 +103,11 @@ describe("parseCoordinate", () => {
     assert.equal(parseCoordinate("1,234.56"), 1234.56);
   });
 
+  it("treats a lone separator as the decimal point", () => {
+    assert.equal(parseCoordinate("1,234"), 1.234);
+    assert.equal(parseCoordinate("1.234"), 1.234);
+  });
+
   it("returns NaN for empty or unparsable values", () => {
     assert.ok(Number.isNaN(parseCoordinate("")));
     assert.ok(Number.isNaN(parseCoordinate(undefined)));

--- a/tests/data-parsing.test.ts
+++ b/tests/data-parsing.test.ts
@@ -120,6 +120,11 @@ describe("delimited text auto-detection", () => {
     assert.equal(detectDelimitedTextDelimiter("a;b;c\n1;2;3"), ";");
     assert.equal(detectDelimitedTextDelimiter("a\tb\tc\n1\t2\t3"), "\t");
     assert.equal(detectDelimitedTextDelimiter("a,b,c\n1,2,3"), ",");
+    assert.equal(detectDelimitedTextDelimiter("a|b|c\n1|2|3"), "|");
+  });
+
+  it("falls back to a comma for single-column files", () => {
+    assert.equal(detectDelimitedTextDelimiter("name\nAlice\nBob"), ",");
   });
 
   it("matches common longitude/latitude column names", () => {

--- a/tests/data-parsing.test.ts
+++ b/tests/data-parsing.test.ts
@@ -128,6 +128,13 @@ describe("delimited text auto-detection", () => {
     });
   });
 
+  it("prefers a specific name over a generic one regardless of order", () => {
+    assert.deepEqual(detectCoordinateFields(["x", "y", "longitude", "latitude"]), {
+      longitudeField: "longitude",
+      latitudeField: "latitude",
+    });
+  });
+
   it("returns null when coordinate columns are missing", () => {
     assert.equal(detectCoordinateFields(["name", "value", "category"]), null);
   });

--- a/tests/data-parsing.test.ts
+++ b/tests/data-parsing.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  detectCoordinateFields,
+  detectDelimitedTextDelimiter,
+  parseCoordinate,
   parseDelimitedTextFields,
   parseDelimitedTextLayer,
 } from "../apps/geolibre-desktop/src/lib/delimited-text";
@@ -72,6 +75,61 @@ describe("delimited text parsing", () => {
         }),
       /No rows contained valid longitude and latitude values/,
     );
+  });
+
+  it("accepts comma decimal separators for coordinates", () => {
+    const result = parseDelimitedTextLayer(
+      ["name;longitude;latitude", "Amsterdam;4,90;52,37"].join("\n"),
+      {
+        delimiter: ";",
+        longitudeField: "longitude",
+        latitudeField: "latitude",
+      },
+    );
+
+    assert.equal(result.data.features.length, 1);
+    assert.deepEqual(result.data.features[0].geometry.coordinates, [4.9, 52.37]);
+  });
+});
+
+describe("parseCoordinate", () => {
+  it("parses dot and comma decimals identically", () => {
+    assert.equal(parseCoordinate("-78.638"), -78.638);
+    assert.equal(parseCoordinate("-78,638"), -78.638);
+  });
+
+  it("treats the right-most separator as the decimal point", () => {
+    assert.equal(parseCoordinate("1.234,56"), 1234.56);
+    assert.equal(parseCoordinate("1,234.56"), 1234.56);
+  });
+
+  it("returns NaN for empty or unparsable values", () => {
+    assert.ok(Number.isNaN(parseCoordinate("")));
+    assert.ok(Number.isNaN(parseCoordinate(undefined)));
+    assert.ok(Number.isNaN(parseCoordinate("not-a-number")));
+  });
+});
+
+describe("delimited text auto-detection", () => {
+  it("detects the delimiter that yields the most columns", () => {
+    assert.equal(detectDelimitedTextDelimiter("a;b;c\n1;2;3"), ";");
+    assert.equal(detectDelimitedTextDelimiter("a\tb\tc\n1\t2\t3"), "\t");
+    assert.equal(detectDelimitedTextDelimiter("a,b,c\n1,2,3"), ",");
+  });
+
+  it("matches common longitude/latitude column names", () => {
+    assert.deepEqual(detectCoordinateFields(["name", "Lon", "Lat"]), {
+      longitudeField: "Lon",
+      latitudeField: "Lat",
+    });
+    assert.deepEqual(detectCoordinateFields(["X", "Y", "value"]), {
+      longitudeField: "X",
+      latitudeField: "Y",
+    });
+  });
+
+  it("returns null when coordinate columns are missing", () => {
+    assert.equal(detectCoordinateFields(["name", "value", "category"]), null);
   });
 });
 


### PR DESCRIPTION
## Summary

Addresses the two asks in #527 for users outside the US locale:

1. **Comma decimal separators** in delimited text (CSV) coordinate fields. `parseDelimitedTextLayer` parsed coordinates with `Number()`, which returns `NaN` for values like `4,90`, so files exported under locales that use a comma as the decimal separator dropped every row. Coordinates now accept a comma or a dot. When both separators appear, the right-most one is treated as the decimal point and the other as a thousands grouping separator (so `1.234,56` and `1,234.56` both parse to `1234.56`).

2. **Drag-and-drop (and Open) for CSV/TSV files.** Dropped CSVs previously routed to the DuckDB `ST_Read` path, which finds no geometry column in a plain table and failed. CSV/TSV files now load directly as point layers by auto-detecting the delimiter and the longitude/latitude columns. When the coordinate columns cannot be identified, a clear error points the user at Add Data to Delimited Text to pick the columns.

## Changes

- `apps/geolibre-desktop/src/lib/delimited-text.ts`: add `parseCoordinate` (locale-tolerant number parse), `detectDelimitedTextDelimiter`, and `detectCoordinateFields`; use the new coordinate parse in `parseDelimitedTextLayer`.
- `apps/geolibre-desktop/src/lib/tauri-io.ts`: load dropped/opened CSV and TSV files through the delimited-text parser in both the browser and Tauri vector paths.
- `tests/data-parsing.test.ts`: cover comma decimals, the right-most-separator rule, delimiter detection, and coordinate-column detection.

## Verification

Verified in the running web app with Playwright in both light and dark themes using real CSV data:

- Add Data to Delimited Text with a semicolon-delimited, comma-decimal CSV (Amsterdam, Berlin, Paris, Madrid): layer loaded and the map fit to Europe.
- Drag-and-drop of a dot-decimal CSV (Raleigh, Austin, Seattle): layer loaded and the map fit to the continental US.
- Full frontend test suite (1136 passing), production build, and pre-commit all pass.

Fixes #527


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CSV/TSV files can now be dragged and dropped to import point layers.
  * Enhanced coordinate parsing to support both comma and period decimal separators.
  * Automatic detection of delimiters and longitude/latitude column names during import.
* **Bug Fixes**
  * Improve handling of coordinate inputs that include thousands separators and mixed separators.
  * Provide clearer errors when header data is present but no valid coordinates can be found.
* **Tests**
  * Added coverage for comma-decimal coordinates and edge cases for coordinate parsing logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->