### PR TITLE
fix(offline): conditional failure text + retry action for failed offline tiles

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/OfflineManagerDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/OfflineManagerDialog.tsx
@@ -7,15 +7,19 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
+  Input,
   ScrollArea,
   Separator,
 } from "@geolibre/ui";
 import {
+  Check,
   HardDrive,
   Loader2,
+  Pencil,
   RefreshCw,
   Trash2,
   WifiOff,
+  X,
 } from "lucide-react";
 import { hasActiveServiceWorker, warmUrls } from "../../lib/offline-tiles";
 import {
@@ -26,6 +30,7 @@ import {
   measureRegionBytes,
   type OfflineRegion,
   regionAllUrls,
+  renameOfflineRegion,
 } from "../../lib/offline-regions";
 
 interface OfflineManagerDialogProps {
@@ -74,6 +79,9 @@ export function OfflineManagerDialog({
   });
   // Two-step inline delete confirmation: first click arms, second deletes.
   const [confirmId, setConfirmId] = useState<string | null>(null);
+  // Inline rename: the region id being edited and its draft name.
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [draftName, setDraftName] = useState("");
   const [swActive, setSwActive] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
   // Mirror `regions` in a ref so the async `update` finally block re-measures
@@ -107,6 +115,7 @@ export function OfflineManagerDialog({
     }
     setSwActive(hasActiveServiceWorker());
     setConfirmId(null);
+    setEditingId(null);
     setBusyId(null);
     setProgress({ done: 0, total: 0 });
     const list = loadOfflineRegions();
@@ -154,6 +163,23 @@ export function OfflineManagerDialog({
     [refreshSizes],
   );
 
+  const startRename = useCallback((region: OfflineRegion) => {
+    setConfirmId(null);
+    setEditingId(region.id);
+    setDraftName(region.name);
+  }, []);
+
+  const cancelRename = useCallback(() => setEditingId(null), []);
+
+  // Persist the trimmed draft as the region's name. An empty draft just cancels
+  // (a region always keeps a non-empty label).
+  const commitRename = useCallback(() => {
+    if (editingId === null) return;
+    const name = draftName.trim();
+    if (name) setRegions(renameOfflineRegion(editingId, name));
+    setEditingId(null);
+  }, [editingId, draftName]);
+
   const totalBytes = Object.values(sizes).reduce((sum, b) => sum + b, 0);
   const busy = busyId !== null;
 
@@ -189,10 +215,26 @@ export function OfflineManagerDialog({
                     className="rounded-md border border-border p-3"
                   >
                     <div className="flex items-start justify-between gap-2">
-                      <div className="min-w-0">
-                        <p className="truncate text-sm font-medium">
-                          {region.name}
-                        </p>
+                      <div className="min-w-0 flex-1">
+                        {editingId === region.id ? (
+                          <Input
+                            autoFocus
+                            value={draftName}
+                            aria-label={t("offlineManager.nameLabel")}
+                            className="mb-1 h-7 text-sm"
+                            onChange={(event) =>
+                              setDraftName(event.target.value)
+                            }
+                            onKeyDown={(event) => {
+                              if (event.key === "Enter") commitRename();
+                              else if (event.key === "Escape") cancelRename();
+                            }}
+                          />
+                        ) : (
+                          <p className="truncate text-sm font-medium">
+                            {region.name}
+                          </p>
+                        )}
                         <p className="text-xs text-muted-foreground">
                           {t("offlineManager.zoomRange", {
                             min: region.minZoom,
@@ -214,7 +256,26 @@ export function OfflineManagerDialog({
                         </p>
                       </div>
                       <div className="flex shrink-0 items-center gap-1">
-                        {confirmId === region.id ? (
+                        {editingId === region.id ? (
+                          <>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              title={t("common.save")}
+                              onClick={commitRename}
+                            >
+                              <Check className="h-4 w-4" />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              title={t("common.cancel")}
+                              onClick={cancelRename}
+                            >
+                              <X className="h-4 w-4" />
+                            </Button>
+                          </>
+                        ) : confirmId === region.id ? (
                           <>
                             <Button
                               variant="ghost"
@@ -233,6 +294,15 @@ export function OfflineManagerDialog({
                           </>
                         ) : (
                           <>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              title={t("offlineManager.rename")}
+                              disabled={busy}
+                              onClick={() => startRename(region)}
+                            >
+                              <Pencil className="h-4 w-4" />
+                            </Button>
                             <Button
                               variant="ghost"
                               size="icon"

--- a/apps/geolibre-desktop/src/components/layout/OfflineManagerDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/OfflineManagerDialog.tsx
@@ -1,0 +1,308 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  ScrollArea,
+  Separator,
+} from "@geolibre/ui";
+import {
+  HardDrive,
+  Loader2,
+  RefreshCw,
+  Trash2,
+  WifiOff,
+} from "lucide-react";
+import { hasActiveServiceWorker, warmUrls } from "../../lib/offline-tiles";
+import {
+  deleteOfflineRegion,
+  formatBytes,
+  getStorageEstimate,
+  loadOfflineRegions,
+  measureRegionBytes,
+  type OfflineRegion,
+  regionAllUrls,
+} from "../../lib/offline-regions";
+
+interface OfflineManagerDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/** Sentinel busy id for the "update all" bulk action. */
+const ALL = "__all__";
+
+function formatDate(epochMs: number): string {
+  try {
+    return new Date(epochMs).toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Dashboard for the basemap regions the user has downloaded offline. Lists each
+ * region with its bounds, zoom range, tile count, on-disk size, and date, and
+ * lets the user re-warm (update) a region or delete it to reclaim space. Reads
+ * the manifest persisted by the Download Offline Area flow (see
+ * lib/offline-regions.ts).
+ */
+export function OfflineManagerDialog({
+  open,
+  onOpenChange,
+}: OfflineManagerDialogProps) {
+  const { t } = useTranslation();
+  const [regions, setRegions] = useState<OfflineRegion[]>([]);
+  const [sizes, setSizes] = useState<Record<string, number>>({});
+  const [estimate, setEstimate] = useState<{
+    usage: number;
+    quota: number;
+  } | null>(null);
+  // The region id currently updating (or ALL), with its live warm progress.
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [progress, setProgress] = useState<{ done: number; total: number }>({
+    done: 0,
+    total: 0,
+  });
+  // Two-step inline delete confirmation: first click arms, second deletes.
+  const [confirmId, setConfirmId] = useState<string | null>(null);
+  const [swActive, setSwActive] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Measure each region's cache footprint (async) and refresh the storage
+  // estimate. Called on open and after any update/delete.
+  const refreshSizes = useCallback(async (list: OfflineRegion[]) => {
+    setEstimate(await getStorageEstimate());
+    const entries = await Promise.all(
+      list.map(async (r) => [r.id, await measureRegionBytes(r)] as const),
+    );
+    setSizes(Object.fromEntries(entries));
+  }, []);
+
+  // Load the manifest whenever the dialog opens.
+  useEffect(() => {
+    if (!open) {
+      abortRef.current?.abort();
+      return;
+    }
+    setSwActive(hasActiveServiceWorker());
+    setConfirmId(null);
+    const list = loadOfflineRegions();
+    setRegions(list);
+    void refreshSizes(list);
+  }, [open, refreshSizes]);
+
+  // Abort any in-flight update if the dialog unmounts.
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  // Re-warm one or all regions, then re-measure footprints.
+  const update = useCallback(
+    async (targets: OfflineRegion[], busy: string) => {
+      const urls = [...new Set(targets.flatMap(regionAllUrls))];
+      if (urls.length === 0) return;
+      const controller = new AbortController();
+      abortRef.current = controller;
+      setBusyId(busy);
+      setProgress({ done: 0, total: urls.length });
+      try {
+        await warmUrls(urls, {
+          signal: controller.signal,
+          onProgress: (p) => setProgress({ done: p.done, total: p.total }),
+        });
+      } catch {
+        // Partial updates are fine; failures leave existing cache untouched.
+      } finally {
+        if (abortRef.current === controller) abortRef.current = null;
+        if (!controller.signal.aborted) {
+          setBusyId(null);
+          await refreshSizes(regions);
+        }
+      }
+    },
+    [regions, refreshSizes],
+  );
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      setConfirmId(null);
+      const { regions: remaining } = await deleteOfflineRegion(id);
+      setRegions(remaining);
+      await refreshSizes(remaining);
+    },
+    [refreshSizes],
+  );
+
+  const totalBytes = Object.values(sizes).reduce((sum, b) => sum + b, 0);
+  const busy = busyId !== null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{t("offlineManager.title")}</DialogTitle>
+          <DialogDescription>
+            {t("offlineManager.description")}
+          </DialogDescription>
+        </DialogHeader>
+
+        {!swActive && (
+          <p className="flex items-start gap-2 rounded-md bg-amber-500/10 p-2 text-sm text-amber-700 dark:text-amber-400">
+            <WifiOff className="mt-0.5 h-4 w-4 shrink-0" />
+            {t("offlineManager.noServiceWorker")}
+          </p>
+        )}
+
+        {regions.length === 0 ? (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            {t("offlineManager.empty")}
+          </p>
+        ) : (
+          <ScrollArea className="max-h-[52vh] pr-3">
+            <ul className="space-y-2">
+              {regions.map((region) => {
+                const isBusy = busyId === region.id || busyId === ALL;
+                return (
+                  <li
+                    key={region.id}
+                    className="rounded-md border border-border p-3"
+                  >
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-medium">
+                          {region.name}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          {t("offlineManager.zoomRange", {
+                            min: region.minZoom,
+                            max: region.maxZoom,
+                          })}{" "}
+                          ·{" "}
+                          {t("offlineManager.tilesCount", {
+                            count: region.tileCount,
+                          })}{" "}
+                          · {formatBytes(sizes[region.id] ?? 0)}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          {t("offlineManager.savedOn", {
+                            date: formatDate(region.updatedAt),
+                          })}
+                          {region.hosts.length > 0
+                            ? ` · ${region.hosts.join(", ")}`
+                            : ""}
+                        </p>
+                      </div>
+                      <div className="flex shrink-0 items-center gap-1">
+                        {confirmId === region.id ? (
+                          <>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => setConfirmId(null)}
+                            >
+                              {t("common.cancel")}
+                            </Button>
+                            <Button
+                              variant="destructive"
+                              size="sm"
+                              onClick={() => void handleDelete(region.id)}
+                            >
+                              {t("offlineManager.confirmDelete")}
+                            </Button>
+                          </>
+                        ) : (
+                          <>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              title={t("offlineManager.update")}
+                              disabled={busy || !swActive}
+                              onClick={() => void update([region], region.id)}
+                            >
+                              {busyId === region.id ? (
+                                <Loader2 className="h-4 w-4 animate-spin" />
+                              ) : (
+                                <RefreshCw className="h-4 w-4" />
+                              )}
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              title={t("offlineManager.delete")}
+                              disabled={busy}
+                              onClick={() => setConfirmId(region.id)}
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          </>
+                        )}
+                      </div>
+                    </div>
+                    {isBusy && (
+                      <p className="mt-2 text-xs text-muted-foreground tabular-nums">
+                        {t("offlineManager.updating", {
+                          done: progress.done,
+                          total: progress.total,
+                        })}
+                      </p>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          </ScrollArea>
+        )}
+
+        {regions.length > 0 && (
+          <>
+            <Separator />
+            <div className="flex items-center justify-between text-sm">
+              <span className="flex items-center gap-2 text-muted-foreground">
+                <HardDrive className="h-4 w-4" />
+                {t("offlineManager.totalFootprint", {
+                  size: formatBytes(totalBytes),
+                  count: regions.length,
+                })}
+              </span>
+              {estimate && estimate.quota > 0 && (
+                <span className="tabular-nums text-muted-foreground">
+                  {t("offlineManager.deviceUsage", {
+                    usage: formatBytes(estimate.usage),
+                    quota: formatBytes(estimate.quota),
+                  })}
+                </span>
+              )}
+            </div>
+          </>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {t("common.close")}
+          </Button>
+          {regions.length > 0 && (
+            <Button
+              variant="outline"
+              disabled={busy || !swActive}
+              onClick={() => void update(regions, ALL)}
+            >
+              {busyId === ALL ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <RefreshCw className="mr-2 h-4 w-4" />
+              )}
+              {t("offlineManager.updateAll")}
+            </Button>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/OfflineManagerDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/OfflineManagerDialog.tsx
@@ -76,6 +76,11 @@ export function OfflineManagerDialog({
   const [confirmId, setConfirmId] = useState<string | null>(null);
   const [swActive, setSwActive] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
+  // Mirror `regions` in a ref so the async `update` finally block re-measures
+  // against the current list rather than the one captured when it started
+  // (which may be stale if a delete landed while the update was in flight).
+  const regionsRef = useRef(regions);
+  regionsRef.current = regions;
 
   // Measure each region's cache footprint (async) and refresh the storage
   // estimate. Called on open and after any update/delete.
@@ -90,11 +95,20 @@ export function OfflineManagerDialog({
   // Load the manifest whenever the dialog opens.
   useEffect(() => {
     if (!open) {
+      // Abort any in-flight update and clear busy state — the `update` finally
+      // block skips `setBusyId(null)` when aborted, so without this a refresh
+      // interrupted by closing the dialog would leave every button disabled on
+      // reopen.
       abortRef.current?.abort();
+      abortRef.current = null;
+      setBusyId(null);
+      setProgress({ done: 0, total: 0 });
       return;
     }
     setSwActive(hasActiveServiceWorker());
     setConfirmId(null);
+    setBusyId(null);
+    setProgress({ done: 0, total: 0 });
     const list = loadOfflineRegions();
     setRegions(list);
     void refreshSizes(list);
@@ -123,11 +137,11 @@ export function OfflineManagerDialog({
         if (abortRef.current === controller) abortRef.current = null;
         if (!controller.signal.aborted) {
           setBusyId(null);
-          await refreshSizes(regions);
+          await refreshSizes(regionsRef.current);
         }
       }
     },
-    [regions, refreshSizes],
+    [refreshSizes],
   );
 
   const handleDelete = useCallback(

--- a/apps/geolibre-desktop/src/components/layout/OfflineRegionDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/OfflineRegionDialog.tsx
@@ -75,6 +75,12 @@ export function OfflineRegionDialog({
     failedUrls: [],
   });
   const abortRef = useRef<AbortController | null>(null);
+  // Mirror `progress` in a ref so `handleRetry` can read the latest failed URLs
+  // without listing `progress` as a dependency — otherwise the callback would be
+  // recreated on every settled tile, since each `onProgress` emits a fresh
+  // `failedUrls` array.
+  const progressRef = useRef(progress);
+  progressRef.current = progress;
 
   // Snapshot the view when the dialog opens; re-reading live would let the
   // estimate drift while the user is interacting with the dialog.
@@ -172,7 +178,7 @@ export function OfflineRegionDialog({
   // download (e.g. after a transient network blip) without re-fetching the
   // whole region. The failure message then reflects this retry batch.
   const handleRetry = useCallback(async () => {
-    const failedUrls = progress.failedUrls;
+    const failedUrls = progressRef.current.failedUrls;
     if (failedUrls.length === 0) return;
     const controller = new AbortController();
     abortRef.current = controller;
@@ -195,7 +201,7 @@ export function OfflineRegionDialog({
     } finally {
       if (abortRef.current === controller) abortRef.current = null;
     }
-  }, [progress.failedUrls]);
+  }, []);
 
   const handleCancel = useCallback(() => {
     abortRef.current?.abort();
@@ -338,7 +344,17 @@ export function OfflineRegionDialog({
           )}
           <Button
             onClick={handleDownload}
-            disabled={phase === "running" || tileCount === 0 || !swActive}
+            // Disabled while failures are outstanding so the user resolves them
+            // via Retry first. This also removes the race where clicking Retry
+            // then Download in quick succession (before phase flips to
+            // "running") would start two concurrent warmUrls runs and clobber
+            // abortRef. Retry clears the count, re-enabling a full re-download.
+            disabled={
+              phase === "running" ||
+              tileCount === 0 ||
+              !swActive ||
+              (phase === "done" && progress.failed > 0)
+            }
           >
             {phase === "running" ? (
               <Loader2 className="mr-2 h-4 w-4 animate-spin" />

--- a/apps/geolibre-desktop/src/components/layout/OfflineRegionDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/OfflineRegionDialog.tsx
@@ -271,11 +271,16 @@ export function OfflineRegionDialog({
               </div>
               <p className="text-xs text-muted-foreground tabular-nums">
                 {phase === "done"
-                  ? t("offline.complete", {
-                      done: progress.done - progress.failed,
-                      total: progress.total,
-                      failed: progress.failed,
-                    })
+                  ? t(
+                      progress.failed > 0
+                        ? "offline.completeWithFailures"
+                        : "offline.complete",
+                      {
+                        done: progress.done - progress.failed,
+                        total: progress.total,
+                        failed: progress.failed,
+                      },
+                    )
                   : t("offline.progress", {
                       done: progress.done,
                       total: progress.total,

--- a/apps/geolibre-desktop/src/components/layout/OfflineRegionDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/OfflineRegionDialog.tsx
@@ -8,11 +8,19 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
+  Input,
   Label,
   Separator,
   Slider,
 } from "@geolibre/ui";
-import { Download, Loader2, RotateCw, WifiOff } from "lucide-react";
+import {
+  ChevronDown,
+  ChevronRight,
+  Download,
+  Loader2,
+  RotateCw,
+  WifiOff,
+} from "lucide-react";
 import {
   type Bbox,
   collectOfflineUrls,
@@ -42,6 +50,12 @@ const CACHED_TILE_HOST = /(?:^|\.)(?:openfreemap\.org|cartocdn\.com)$/;
 const AVG_TILE_BYTES = 30 * 1024;
 
 const MAX_EXTRA_LEVELS = 5;
+
+/** Default and bounds for the advanced concurrency control. */
+const DEFAULT_CONCURRENCY = 6;
+const MAX_CONCURRENCY = 8;
+/** Bounds (seconds) for the advanced per-request timeout; 0 means no timeout. */
+const MAX_TIMEOUT_SEC = 120;
 
 /**
  * The basemap service-worker cache cap (geolibre-basemaps maxEntries in
@@ -74,6 +88,12 @@ export function OfflineRegionDialog({
   // Default off, so the dialog starts scoped to the current view's zoom only.
   const [includeExtra, setIncludeExtra] = useState(false);
   const [extraLevels, setExtraLevels] = useState(1);
+  // Advanced network controls (collapsed by default): power users can lower
+  // concurrency to slip past server rate limiting, or raise the per-request
+  // timeout for slow links. See #564.
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [concurrency, setConcurrency] = useState(DEFAULT_CONCURRENCY);
+  const [timeoutSec, setTimeoutSec] = useState(0);
   const [phase, setPhase] = useState<Phase>("idle");
   const [progress, setProgress] = useState<WarmProgress>({
     done: 0,
@@ -144,6 +164,9 @@ export function OfflineRegionDialog({
       setProgress({ done: 0, total: 0, failed: 0, failedUrls: [] });
       setIncludeExtra(false);
       setExtraLevels(1);
+      setShowAdvanced(false);
+      setConcurrency(DEFAULT_CONCURRENCY);
+      setTimeoutSec(0);
     } else {
       abortRef.current?.abort();
     }
@@ -152,11 +175,16 @@ export function OfflineRegionDialog({
   // Abort any in-flight download if the dialog unmounts.
   useEffect(() => () => abortRef.current?.abort(), []);
 
+  // Full (re-)download of the whole region — also serves as "Retry all tiles".
   const handleDownload = useCallback(async () => {
     const map = mapControllerRef.current?.getMap();
     if (!map || !bbox) return;
+    // Abort any in-flight run first so a "Retry all" issued while a previous
+    // batch is settling can't leave two concurrent warmUrls runs racing.
+    abortRef.current?.abort();
     const controller = new AbortController();
     abortRef.current = controller;
+    const timeoutMs = timeoutSec > 0 ? timeoutSec * 1000 : undefined;
     setPhase("running");
     setProgress({ done: 0, total: 0, failed: 0, failedUrls: [] });
     try {
@@ -169,6 +197,8 @@ export function OfflineRegionDialog({
       );
       setProgress({ done: 0, total: urls.length, failed: 0, failedUrls: [] });
       const result = await warmUrls(urls, {
+        concurrency,
+        timeoutMs,
         signal: controller.signal,
         onProgress: setProgress,
       });
@@ -207,7 +237,7 @@ export function OfflineRegionDialog({
       // cancel-then-redownload may have already installed a newer controller.
       if (abortRef.current === controller) abortRef.current = null;
     }
-  }, [mapControllerRef, bbox, baseZoom, maxZoom]);
+  }, [mapControllerRef, bbox, baseZoom, maxZoom, concurrency, timeoutSec]);
 
   // Re-warm only the URLs that failed, so the user can recover a partial
   // download (e.g. after a transient network blip) without re-fetching the
@@ -215,8 +245,10 @@ export function OfflineRegionDialog({
   const handleRetry = useCallback(async () => {
     const failedUrls = progressRef.current.failedUrls;
     if (failedUrls.length === 0) return;
+    abortRef.current?.abort();
     const controller = new AbortController();
     abortRef.current = controller;
+    const timeoutMs = timeoutSec > 0 ? timeoutSec * 1000 : undefined;
     setPhase("running");
     setProgress({
       done: 0,
@@ -226,6 +258,8 @@ export function OfflineRegionDialog({
     });
     try {
       const result = await warmUrls(failedUrls, {
+        concurrency,
+        timeoutMs,
         signal: controller.signal,
         onProgress: setProgress,
       });
@@ -236,7 +270,7 @@ export function OfflineRegionDialog({
     } finally {
       if (abortRef.current === controller) abortRef.current = null;
     }
-  }, []);
+  }, [concurrency, timeoutSec]);
 
   const handleCancel = useCallback(() => {
     abortRef.current?.abort();
@@ -245,6 +279,9 @@ export function OfflineRegionDialog({
 
   const percent =
     progress.total > 0 ? Math.round((progress.done / progress.total) * 100) : 0;
+  // After a partial download the primary action becomes "Retry all tiles" (a
+  // full re-warm from scratch), shown alongside the targeted "Retry failed".
+  const hasFailures = phase === "done" && progress.failed > 0;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -314,6 +351,76 @@ export function OfflineRegionDialog({
             </p>
           )}
 
+          <div className="space-y-3">
+            <button
+              type="button"
+              className="flex items-center gap-1 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+              aria-expanded={showAdvanced}
+              onClick={() => setShowAdvanced((value) => !value)}
+            >
+              {showAdvanced ? (
+                <ChevronDown className="h-4 w-4" />
+              ) : (
+                <ChevronRight className="h-4 w-4" />
+              )}
+              {t("offline.advanced")}
+            </button>
+
+            {showAdvanced && (
+              <div className="space-y-4 rounded-md border border-border p-3">
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <Label>{t("offline.concurrency")}</Label>
+                    <span className="text-sm tabular-nums text-muted-foreground">
+                      {concurrency}
+                    </span>
+                  </div>
+                  <Slider
+                    aria-label={t("offline.concurrency")}
+                    min={1}
+                    max={MAX_CONCURRENCY}
+                    step={1}
+                    value={[concurrency]}
+                    onValueChange={(value: number[]) =>
+                      setConcurrency(value[0])
+                    }
+                    disabled={phase === "running"}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    {t("offline.concurrencyHint")}
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="offline-timeout">
+                    {t("offline.timeout")}
+                  </Label>
+                  <Input
+                    id="offline-timeout"
+                    type="number"
+                    min={0}
+                    max={MAX_TIMEOUT_SEC}
+                    value={timeoutSec}
+                    disabled={phase === "running"}
+                    onChange={(event) => {
+                      const next = Math.round(Number(event.target.value));
+                      setTimeoutSec(
+                        Number.isFinite(next)
+                          ? Math.min(MAX_TIMEOUT_SEC, Math.max(0, next))
+                          : 0,
+                      );
+                    }}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    {timeoutSec > 0
+                      ? t("offline.timeoutHint", { seconds: timeoutSec })
+                      : t("offline.timeoutDisabled")}
+                  </p>
+                </div>
+              </div>
+            )}
+          </div>
+
           <Separator />
 
           <div className="flex justify-between text-sm">
@@ -371,32 +478,27 @@ export function OfflineRegionDialog({
               {t("common.close")}
             </Button>
           )}
-          {phase === "done" && progress.failed > 0 && (
+          {hasFailures && (
             <Button variant="outline" onClick={handleRetry}>
               <RotateCw className="mr-2 h-4 w-4" />
               {t("offline.retryFailed", { count: progress.failed })}
             </Button>
           )}
           <Button
+            // "Retry all" and "Download" share this handler (a full re-warm);
+            // handleDownload aborts any in-flight run first, so it is safe to
+            // keep enabled even while failures are outstanding.
             onClick={handleDownload}
-            // Disabled while failures are outstanding so the user resolves them
-            // via Retry first. This also removes the race where clicking Retry
-            // then Download in quick succession (before phase flips to
-            // "running") would start two concurrent warmUrls runs and clobber
-            // abortRef. Retry clears the count, re-enabling a full re-download.
-            disabled={
-              phase === "running" ||
-              tileCount === 0 ||
-              !swActive ||
-              (phase === "done" && progress.failed > 0)
-            }
+            disabled={phase === "running" || tileCount === 0 || !swActive}
           >
             {phase === "running" ? (
               <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : hasFailures ? (
+              <RotateCw className="mr-2 h-4 w-4" />
             ) : (
               <Download className="mr-2 h-4 w-4" />
             )}
-            {t("offline.download")}
+            {hasFailures ? t("offline.retryAll") : t("offline.download")}
           </Button>
         </div>
       </DialogContent>

--- a/apps/geolibre-desktop/src/components/layout/OfflineRegionDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/OfflineRegionDialog.tsx
@@ -24,7 +24,7 @@ import {
 import {
   type Bbox,
   collectOfflineUrls,
-  countTiles,
+  countOfflineTiles,
   hasActiveServiceWorker,
   warmUrls,
   type WarmProgress,
@@ -115,10 +115,33 @@ export function OfflineRegionDialog({
   const maxZoom = Math.min(22, baseZoom + effectiveExtra);
   const bbox = (view?.bbox ?? null) as Bbox | null;
 
-  const tileCount = useMemo(
-    () => (bbox ? countTiles(bbox, baseZoom, maxZoom) : 0),
-    [bbox, baseZoom, maxZoom],
-  );
+  // Tile count is resolved asynchronously: it clamps each source to its own
+  // maxzoom (the vector source's bound lives in a TileJSON we have to fetch), so
+  // the estimate matches what actually downloads instead of counting tiles past
+  // a source's maxzoom that would 404.
+  const [tileCount, setTileCount] = useState(0);
+  useEffect(() => {
+    const map = mapControllerRef.current?.getMap();
+    if (!open || !bbox || !map) {
+      setTileCount(0);
+      return;
+    }
+    const controller = new AbortController();
+    let active = true;
+    countOfflineTiles(map, bbox, baseZoom, maxZoom, {
+      signal: controller.signal,
+    })
+      .then((count) => {
+        if (active) setTileCount(count);
+      })
+      .catch(() => {
+        // Discovery failed (e.g. aborted); leave the last known count.
+      });
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, [open, bbox, baseZoom, maxZoom, mapControllerRef]);
 
   const { cacheableHosts, uncacheableHosts } = useMemo(() => {
     const map = mapControllerRef.current?.getMap();
@@ -481,7 +504,7 @@ export function OfflineRegionDialog({
           )}
         </div>
 
-        <div className="flex justify-end gap-2">
+        <div className="flex flex-wrap justify-end gap-2">
           {phase === "running" ? (
             <Button variant="outline" onClick={handleCancel}>
               {t("offline.cancel")}

--- a/apps/geolibre-desktop/src/components/layout/OfflineRegionDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/OfflineRegionDialog.tsx
@@ -12,7 +12,7 @@ import {
   Separator,
   Slider,
 } from "@geolibre/ui";
-import { Download, Loader2, WifiOff } from "lucide-react";
+import { Download, Loader2, RotateCw, WifiOff } from "lucide-react";
 import {
   type Bbox,
   collectOfflineUrls,
@@ -72,6 +72,7 @@ export function OfflineRegionDialog({
     done: 0,
     total: 0,
     failed: 0,
+    failedUrls: [],
   });
   const abortRef = useRef<AbortController | null>(null);
 
@@ -127,7 +128,7 @@ export function OfflineRegionDialog({
   useEffect(() => {
     if (open) {
       setPhase("idle");
-      setProgress({ done: 0, total: 0, failed: 0 });
+      setProgress({ done: 0, total: 0, failed: 0, failedUrls: [] });
       setIncludeExtra(false);
       setExtraLevels(1);
     } else {
@@ -144,12 +145,12 @@ export function OfflineRegionDialog({
     const controller = new AbortController();
     abortRef.current = controller;
     setPhase("running");
-    setProgress({ done: 0, total: 0, failed: 0 });
+    setProgress({ done: 0, total: 0, failed: 0, failedUrls: [] });
     try {
       const urls = await collectOfflineUrls(map, bbox, baseZoom, maxZoom, {
         signal: controller.signal,
       });
-      setProgress({ done: 0, total: urls.length, failed: 0 });
+      setProgress({ done: 0, total: urls.length, failed: 0, failedUrls: [] });
       const result = await warmUrls(urls, {
         signal: controller.signal,
         onProgress: setProgress,
@@ -166,6 +167,35 @@ export function OfflineRegionDialog({
       if (abortRef.current === controller) abortRef.current = null;
     }
   }, [mapControllerRef, bbox, baseZoom, maxZoom]);
+
+  // Re-warm only the URLs that failed, so the user can recover a partial
+  // download (e.g. after a transient network blip) without re-fetching the
+  // whole region. The failure message then reflects this retry batch.
+  const handleRetry = useCallback(async () => {
+    const failedUrls = progress.failedUrls;
+    if (failedUrls.length === 0) return;
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setPhase("running");
+    setProgress({
+      done: 0,
+      total: failedUrls.length,
+      failed: 0,
+      failedUrls: [],
+    });
+    try {
+      const result = await warmUrls(failedUrls, {
+        signal: controller.signal,
+        onProgress: setProgress,
+      });
+      setProgress(result);
+      if (!controller.signal.aborted) setPhase("done");
+    } catch {
+      if (!controller.signal.aborted) setPhase("idle");
+    } finally {
+      if (abortRef.current === controller) abortRef.current = null;
+    }
+  }, [progress.failedUrls]);
 
   const handleCancel = useCallback(() => {
     abortRef.current?.abort();
@@ -298,6 +328,12 @@ export function OfflineRegionDialog({
           ) : (
             <Button variant="outline" onClick={() => onOpenChange(false)}>
               {t("common.close")}
+            </Button>
+          )}
+          {phase === "done" && progress.failed > 0 && (
+            <Button variant="outline" onClick={handleRetry}>
+              <RotateCw className="mr-2 h-4 w-4" />
+              {t("offline.retryFailed", { count: progress.failed })}
             </Button>
           )}
           <Button

--- a/apps/geolibre-desktop/src/components/layout/OfflineRegionDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/OfflineRegionDialog.tsx
@@ -31,8 +31,10 @@ import {
 } from "../../lib/offline-tiles";
 import {
   describeBboxCenter,
+  formatBytes,
   type OfflineRegion,
   regionId,
+  touchOfflineRegion,
   upsertOfflineRegion,
   urlHosts,
 } from "../../lib/offline-regions";
@@ -65,14 +67,6 @@ const MAX_TIMEOUT_SEC = 120;
 const MAX_CACHE_ENTRIES = 8000;
 
 type Phase = "idle" | "running" | "done";
-
-function formatBytes(bytes: number): string {
-  if (bytes >= 1024 * 1024 * 1024) {
-    return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
-  }
-  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(0)} MB`;
-  return `${Math.max(1, Math.round(bytes / 1024))} KB`;
-}
 
 /**
  * Lets the user pre-download the current map area (across a zoom range) into the
@@ -211,6 +205,12 @@ export function OfflineRegionDialog({
         if (result.done - result.failed > 0) {
           const tileSet = new Set(tileUrls);
           const assetUrls = urls.filter((u) => !tileSet.has(u));
+          // tileCount reflects tiles actually cached, not attempted, so a
+          // partial download's count matches what the manager can measure.
+          const failedSet = new Set(result.failedUrls);
+          const cachedTileCount = tileUrls.filter(
+            (u) => !failedSet.has(u),
+          ).length;
           const now = Date.now();
           const region: OfflineRegion = {
             id: regionId(bbox, baseZoom, maxZoom),
@@ -220,12 +220,17 @@ export function OfflineRegionDialog({
             maxZoom,
             tileUrls,
             assetUrls,
-            tileCount: tileUrls.length,
+            tileCount: cachedTileCount,
             hosts: urlHosts(tileUrls),
             createdAt: now,
             updatedAt: now,
           };
-          upsertOfflineRegion(region);
+          const { persisted } = upsertOfflineRegion(region);
+          if (!persisted) {
+            console.warn(
+              "[GeoLibre] offline region manifest could not be saved (storage full?)",
+            );
+          }
         }
       }
     } catch {
@@ -264,13 +269,21 @@ export function OfflineRegionDialog({
         onProgress: setProgress,
       });
       setProgress(result);
-      if (!controller.signal.aborted) setPhase("done");
+      if (!controller.signal.aborted) {
+        setPhase("done");
+        // Bump the manifest's updatedAt so the Offline Manager reflects this
+        // recovery instead of the original (partial) download's date. The stored
+        // URL list already covers every tile, so no other field changes.
+        if (bbox && result.done - result.failed > 0) {
+          touchOfflineRegion(regionId(bbox, baseZoom, maxZoom), Date.now());
+        }
+      }
     } catch {
       if (!controller.signal.aborted) setPhase("idle");
     } finally {
       if (abortRef.current === controller) abortRef.current = null;
     }
-  }, [concurrency, timeoutSec]);
+  }, [concurrency, timeoutSec, bbox, baseZoom, maxZoom]);
 
   const handleCancel = useCallback(() => {
     abortRef.current?.abort();

--- a/apps/geolibre-desktop/src/components/layout/OfflineRegionDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/OfflineRegionDialog.tsx
@@ -21,6 +21,13 @@ import {
   warmUrls,
   type WarmProgress,
 } from "../../lib/offline-tiles";
+import {
+  describeBboxCenter,
+  type OfflineRegion,
+  regionId,
+  upsertOfflineRegion,
+  urlHosts,
+} from "../../lib/offline-regions";
 
 interface OfflineRegionDialogProps {
   open: boolean;
@@ -153,16 +160,44 @@ export function OfflineRegionDialog({
     setPhase("running");
     setProgress({ done: 0, total: 0, failed: 0, failedUrls: [] });
     try {
-      const urls = await collectOfflineUrls(map, bbox, baseZoom, maxZoom, {
-        signal: controller.signal,
-      });
+      const { urls, tileUrls } = await collectOfflineUrls(
+        map,
+        bbox,
+        baseZoom,
+        maxZoom,
+        { signal: controller.signal },
+      );
       setProgress({ done: 0, total: urls.length, failed: 0, failedUrls: [] });
       const result = await warmUrls(urls, {
         signal: controller.signal,
         onProgress: setProgress,
       });
       setProgress(result);
-      if (!controller.signal.aborted) setPhase("done");
+      if (!controller.signal.aborted) {
+        setPhase("done");
+        // Record the download in the offline manifest so the Offline Manager can
+        // list, re-warm, and delete it later. Skip if every tile failed — there
+        // is nothing cached to manage.
+        if (result.done - result.failed > 0) {
+          const tileSet = new Set(tileUrls);
+          const assetUrls = urls.filter((u) => !tileSet.has(u));
+          const now = Date.now();
+          const region: OfflineRegion = {
+            id: regionId(bbox, baseZoom, maxZoom),
+            name: describeBboxCenter(bbox),
+            bbox,
+            minZoom: baseZoom,
+            maxZoom,
+            tileUrls,
+            assetUrls,
+            tileCount: tileUrls.length,
+            hosts: urlHosts(tileUrls),
+            createdAt: now,
+            updatedAt: now,
+          };
+          upsertOfflineRegion(region);
+        }
+      }
     } catch {
       // collectOfflineUrls swallows TileJSON errors, but guard the rare throw
       // (e.g. getStyle failing) so the UI doesn't show a false "done" state.

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -100,6 +100,7 @@ import { PrintLayoutDialog } from "./PrintLayoutDialog";
 import { FieldCollectionDialog } from "./FieldCollectionDialog";
 import { GeoreferencerDialog } from "./GeoreferencerDialog";
 import { OfflineRegionDialog } from "./OfflineRegionDialog";
+import { OfflineManagerDialog } from "./OfflineManagerDialog";
 import { AddDataMenu } from "./toolbar/AddDataMenu";
 import { ConsentNoticeDialogs } from "./toolbar/ConsentNoticeDialogs";
 import { ControlsMenu } from "./toolbar/ControlsMenu";
@@ -272,6 +273,7 @@ export function TopToolbar({
   const [aboutOpen, setAboutOpen] = useState(false);
   const [printLayoutOpen, setPrintLayoutOpen] = useState(false);
   const [offlineRegionOpen, setOfflineRegionOpen] = useState(false);
+  const [offlineManagerOpen, setOfflineManagerOpen] = useState(false);
   const [fieldCollectionOpen, setFieldCollectionOpen] = useState(false);
   const [georeferencerOpen, setGeoreferencerOpen] = useState(false);
   const [setViewOpen, setSetViewOpen] = useState(false);
@@ -852,6 +854,7 @@ export function TopToolbar({
           onCollaborate={() => setCollaborateDialogOpen(true)}
           onPrintLayout={() => setPrintLayoutOpen(true)}
           onDownloadOffline={() => setOfflineRegionOpen(true)}
+          onManageOffline={() => setOfflineManagerOpen(true)}
         />
       )}
       {isMenuVisible(uiProfile, "edit") && <EditMenu chrome={chrome} />}
@@ -949,6 +952,10 @@ export function TopToolbar({
         open={offlineRegionOpen}
         onOpenChange={setOfflineRegionOpen}
         mapControllerRef={mapControllerRef}
+      />
+      <OfflineManagerDialog
+        open={offlineManagerOpen}
+        onOpenChange={setOfflineManagerOpen}
       />
       <FieldCollectionDialog
         open={fieldCollectionOpen}

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProjectMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProjectMenu.tsx
@@ -18,6 +18,7 @@ import {
   FileText,
   Folder,
   FolderOpen,
+  HardDrive,
   HardDriveDownload,
   History,
   LayoutTemplate,
@@ -48,6 +49,7 @@ interface ProjectMenuProps {
   onCollaborate: () => void;
   onPrintLayout: () => void;
   onDownloadOffline: () => void;
+  onManageOffline: () => void;
 }
 
 /** The Project menu: new/open/save/share, recent projects, print, and storymap. */
@@ -65,6 +67,7 @@ export function ProjectMenu({
   onCollaborate,
   onPrintLayout,
   onDownloadOffline,
+  onManageOffline,
 }: ProjectMenuProps) {
   const { t } = useTranslation();
   const projectPath = useAppStore((s) => s.projectPath);
@@ -84,7 +87,8 @@ export function ProjectMenu({
   const showPrintGroup =
     show("project.print") ||
     show("project.printLayout") ||
-    show("project.offlineRegion");
+    show("project.offlineRegion") ||
+    show("project.offlineManager");
 
   return (
     <DropdownMenu>
@@ -240,6 +244,12 @@ export function ProjectMenu({
           <DropdownMenuItem onSelect={onDownloadOffline}>
             <HardDriveDownload className="mr-2 h-3.5 w-3.5" />
             {t("toolbar.item.offlineRegionEllipsis")}
+          </DropdownMenuItem>
+        )}
+        {show("project.offlineManager") && (
+          <DropdownMenuItem onSelect={onManageOffline}>
+            <HardDrive className="mr-2 h-3.5 w-3.5" />
+            {t("toolbar.item.offlineManagerEllipsis")}
           </DropdownMenuItem>
         )}
         {show("project.storymap") && (

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -319,7 +319,8 @@
     "download": "Download",
     "cancel": "Cancel",
     "progress": "Downloading {{done}} / {{total}}…",
-    "complete": "Saved {{done}} of {{total}} tiles ({{failed}} failed)."
+    "complete": "Saved {{done}} of {{total}} tiles.",
+    "completeWithFailures": "Saved {{done}} of {{total}} tiles ({{failed}} failed)."
   },
   "fieldCollection": {
     "title": "Field Collection",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -320,7 +320,9 @@
     "cancel": "Cancel",
     "progress": "Downloading {{done}} / {{total}}…",
     "complete": "Saved {{done}} of {{total}} tiles.",
-    "completeWithFailures": "Saved {{done}} of {{total}} tiles ({{failed}} failed)."
+    "completeWithFailures": "Saved {{done}} of {{total}} tiles ({{failed}} failed).",
+    "retryFailed_one": "Retry {{count}} failed tile",
+    "retryFailed_other": "Retry {{count}} failed tiles"
   },
   "fieldCollection": {
     "title": "Field Collection",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -324,6 +324,24 @@
     "retryFailed_one": "Retry {{count}} failed tile",
     "retryFailed_other": "Retry {{count}} failed tiles"
   },
+  "offlineManager": {
+    "title": "Manage Offline Areas",
+    "description": "Review the basemap areas you've downloaded for offline use, refresh them, or delete them to reclaim storage.",
+    "noServiceWorker": "Offline caching needs the installed web app. Refreshing areas won't save tiles for offline use in this build.",
+    "empty": "No offline areas yet. Use \"Download Offline Area\" to save the current map view for offline use.",
+    "zoomRange": "Zoom {{min}}–{{max}}",
+    "tilesCount_one": "{{count}} tile",
+    "tilesCount_other": "{{count}} tiles",
+    "savedOn": "Saved {{date}}",
+    "update": "Refresh this area",
+    "delete": "Delete this area",
+    "confirmDelete": "Delete",
+    "updateAll": "Refresh all",
+    "updating": "Refreshing {{done}} / {{total}}…",
+    "totalFootprint_one": "{{size}} across {{count}} area",
+    "totalFootprint_other": "{{size}} across {{count}} areas",
+    "deviceUsage": "{{usage}} of {{quota}} used"
+  },
   "fieldCollection": {
     "title": "Field Collection",
     "description": "Capture point, line, or polygon observations against a custom form, placing geometry by GPS or by drawing on the map.",
@@ -926,6 +944,7 @@
       "printEllipsis": "Print...",
       "printLayoutEllipsis": "Print Layout...",
       "offlineRegionEllipsis": "Download Offline Area...",
+      "offlineManagerEllipsis": "Manage Offline Areas...",
       "undo": "Undo",
       "redo": "Redo",
       "previousView": "Previous View",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -340,6 +340,8 @@
     "tilesCount_one": "{{count}} tile",
     "tilesCount_other": "{{count}} tiles",
     "savedOn": "Saved {{date}}",
+    "rename": "Rename this area",
+    "nameLabel": "Area name",
     "update": "Refresh this area",
     "delete": "Delete this area",
     "confirmDelete": "Delete",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -322,7 +322,14 @@
     "complete": "Saved {{done}} of {{total}} tiles.",
     "completeWithFailures": "Saved {{done}} of {{total}} tiles ({{failed}} failed).",
     "retryFailed_one": "Retry {{count}} failed tile",
-    "retryFailed_other": "Retry {{count}} failed tiles"
+    "retryFailed_other": "Retry {{count}} failed tiles",
+    "retryAll": "Retry all tiles",
+    "advanced": "Advanced options",
+    "concurrency": "Concurrent requests",
+    "concurrencyHint": "Lower this to ease off servers that rate-limit rapid tile requests.",
+    "timeout": "Request timeout (seconds)",
+    "timeoutHint": "Each tile request is given up to {{seconds}}s before it counts as failed.",
+    "timeoutDisabled": "No timeout — requests use the browser default. Raise it for slow connections."
   },
   "offlineManager": {
     "title": "Manage Offline Areas",

--- a/apps/geolibre-desktop/src/lib/offline-regions.ts
+++ b/apps/geolibre-desktop/src/lib/offline-regions.ts
@@ -1,0 +1,306 @@
+/**
+ * Offline-region manifest: a device-local catalogue of the basemap areas the
+ * user has downloaded for offline use (see lib/offline-tiles.ts for the
+ * download mechanism).
+ *
+ * The service worker's `geolibre-basemaps` cache stores tiles keyed by URL and
+ * keeps no metadata about *which region* a tile belongs to, so there is nothing
+ * to list, size, update, or delete after the fact. This module fills that gap by
+ * persisting one record per download — its bounds, zoom range, and the exact
+ * URLs it warmed — in `localStorage`. From those records the Offline Manager can
+ * show each region's footprint, re-warm it (bulk update), and delete it to
+ * reclaim space.
+ *
+ * Records are device-scoped, not part of the `.geolibre.json` project: they
+ * mirror the SW cache on *this* device and would be meaningless elsewhere.
+ *
+ * Deletion safety: a region stores `tileUrls` (its own raster/vector tiles)
+ * separately from `assetUrls` (style/sprite/glyphs). Only tile URLs that no
+ * *other* retained region also references are evicted; shared assets are never
+ * deleted, so removing one region can never break another or the base app.
+ */
+
+import type { Bbox } from "./offline-tiles";
+
+/** The Workbox runtime cache that holds basemap tiles (see vite.config.ts). */
+export const BASEMAP_CACHE_NAME = "geolibre-basemaps";
+
+/** localStorage key for the persisted region manifest (versioned for migrations). */
+export const OFFLINE_REGIONS_KEY = "geolibre.offlineRegions.v1";
+
+export interface OfflineRegion {
+  /** Stable id; derived from bounds + zoom so re-downloading an area updates it. */
+  id: string;
+  /** User-facing label (editable); defaults to the region's center coordinates. */
+  name: string;
+  bbox: Bbox;
+  minZoom: number;
+  maxZoom: number;
+  /**
+   * Region-specific tile URLs (raster/vector). Safe to evict on delete when no
+   * other region references them. Excludes shared style/sprite/glyph assets.
+   */
+  tileUrls: string[];
+  /** Shared assets (style, sprite, glyphs) re-warmed on update, never deleted. */
+  assetUrls: string[];
+  /** Tile count at download time (cheaper than tileUrls.length for display). */
+  tileCount: number;
+  /** Distinct tile hosts (for display, e.g. "openfreemap.org"). */
+  hosts: string[];
+  /** Epoch ms when first downloaded. */
+  createdAt: number;
+  /** Epoch ms of the most recent download/update. */
+  updatedAt: number;
+}
+
+/** Every URL a region warmed: its tiles plus the shared assets it depends on. */
+export function regionAllUrls(region: OfflineRegion): string[] {
+  return [...region.tileUrls, ...region.assetUrls];
+}
+
+/**
+ * A deterministic id for a region so downloading the same area + zoom range
+ * twice updates the existing record instead of creating a duplicate. Bbox
+ * coordinates are rounded to ~1e-4° (≈10 m) so trivial viewport jitter between
+ * downloads still maps to the same region.
+ */
+export function regionId(bbox: Bbox, minZoom: number, maxZoom: number): string {
+  const key = bbox.map((n) => n.toFixed(4)).join(",");
+  return `${key}@${minZoom}-${maxZoom}`;
+}
+
+/** Distinct hostnames present in a list of URLs (unparseable entries ignored). */
+export function urlHosts(urls: string[]): string[] {
+  const hosts = new Set<string>();
+  for (const url of urls) {
+    try {
+      hosts.add(new URL(url).hostname);
+    } catch {
+      // Ignore unparseable URLs.
+    }
+  }
+  return [...hosts];
+}
+
+/**
+ * Tile URLs of `region` that no other region in `others` references, i.e. the
+ * ones safe to evict from the cache when `region` is deleted. Shared tiles
+ * (common to an overlapping region) are retained.
+ */
+export function exclusiveTileUrls(
+  region: OfflineRegion,
+  others: OfflineRegion[],
+): string[] {
+  const keep = new Set<string>();
+  for (const other of others) {
+    if (other.id === region.id) continue;
+    for (const url of other.tileUrls) keep.add(url);
+  }
+  return region.tileUrls.filter((url) => !keep.has(url));
+}
+
+function getStorage(storage?: Storage): Storage | null {
+  if (storage) return storage;
+  try {
+    return globalThis.localStorage ?? null;
+  } catch {
+    // Accessing localStorage can throw (e.g. disabled cookies/storage).
+    return null;
+  }
+}
+
+/** Whether a parsed value is a structurally valid persisted region record. */
+function isOfflineRegion(value: unknown): value is OfflineRegion {
+  if (!value || typeof value !== "object") return false;
+  const r = value as Record<string, unknown>;
+  return (
+    typeof r.id === "string" &&
+    typeof r.name === "string" &&
+    Array.isArray(r.bbox) &&
+    r.bbox.length === 4 &&
+    Array.isArray(r.tileUrls) &&
+    Array.isArray(r.assetUrls)
+  );
+}
+
+/**
+ * Load the persisted region manifest, newest first. Returns an empty list when
+ * storage is unavailable or the stored value is missing/corrupt (never throws).
+ */
+export function loadOfflineRegions(storage?: Storage): OfflineRegion[] {
+  const store = getStorage(storage);
+  if (!store) return [];
+  let raw: string | null;
+  try {
+    raw = store.getItem(OFFLINE_REGIONS_KEY);
+  } catch {
+    return [];
+  }
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter(isOfflineRegion)
+      .sort((a, b) => b.updatedAt - a.updatedAt);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Persist the manifest. Returns false if storage is unavailable or the write is
+ * rejected (e.g. QuotaExceededError when many large regions are stored) so the
+ * caller can warn the user rather than silently losing the record.
+ */
+export function persistOfflineRegions(
+  regions: OfflineRegion[],
+  storage?: Storage,
+): boolean {
+  const store = getStorage(storage);
+  if (!store) return false;
+  try {
+    store.setItem(OFFLINE_REGIONS_KEY, JSON.stringify(regions));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Insert or update a region (matched by id), preserving the existing record's
+ * `name` and `createdAt` when present so a re-download keeps the user's label
+ * and original download date. Returns the new list and whether it persisted.
+ */
+export function upsertOfflineRegion(
+  region: OfflineRegion,
+  storage?: Storage,
+): { regions: OfflineRegion[]; persisted: boolean } {
+  const existing = loadOfflineRegions(storage);
+  const prior = existing.find((r) => r.id === region.id);
+  const merged: OfflineRegion = {
+    ...region,
+    name: prior?.name ?? region.name,
+    createdAt: prior?.createdAt ?? region.createdAt,
+  };
+  const regions = [merged, ...existing.filter((r) => r.id !== region.id)].sort(
+    (a, b) => b.updatedAt - a.updatedAt,
+  );
+  return { regions, persisted: persistOfflineRegions(regions, storage) };
+}
+
+/** Rename a region in place. Returns the updated list. */
+export function renameOfflineRegion(
+  id: string,
+  name: string,
+  storage?: Storage,
+): OfflineRegion[] {
+  const regions = loadOfflineRegions(storage).map((r) =>
+    r.id === id ? { ...r, name } : r,
+  );
+  persistOfflineRegions(regions, storage);
+  return regions;
+}
+
+/** Open the basemap cache, or null if the Cache Storage API is unavailable. */
+async function openBasemapCache(): Promise<Cache | null> {
+  if (typeof caches === "undefined") return null;
+  try {
+    return await caches.open(BASEMAP_CACHE_NAME);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Sum the on-disk size (in bytes) of a region's tiles currently in the cache.
+ * Only tiles are measured — shared assets are common to all regions, so
+ * attributing them to one would double-count. Evicted/missing tiles contribute
+ * zero. Returns 0 when the cache is unavailable.
+ */
+export async function measureRegionBytes(region: OfflineRegion): Promise<number> {
+  const cache = await openBasemapCache();
+  if (!cache) return 0;
+  let bytes = 0;
+  for (const url of region.tileUrls) {
+    try {
+      const res = await cache.match(url);
+      if (res) bytes += (await res.blob()).size;
+    } catch {
+      // Skip unreadable entries.
+    }
+  }
+  return bytes;
+}
+
+/**
+ * Delete a region from the manifest and evict its exclusive tiles from the
+ * cache (tiles no other retained region references). Returns the remaining
+ * regions and how many cache entries were removed.
+ */
+export async function deleteOfflineRegion(
+  id: string,
+  storage?: Storage,
+): Promise<{ regions: OfflineRegion[]; deleted: number }> {
+  const existing = loadOfflineRegions(storage);
+  const target = existing.find((r) => r.id === id);
+  const remaining = existing.filter((r) => r.id !== id);
+  let deleted = 0;
+  if (target) {
+    const cache = await openBasemapCache();
+    if (cache) {
+      for (const url of exclusiveTileUrls(target, remaining)) {
+        try {
+          if (await cache.delete(url)) deleted++;
+        } catch {
+          // Skip entries that can't be deleted.
+        }
+      }
+    }
+  }
+  persistOfflineRegions(remaining, storage);
+  return { regions: remaining, deleted };
+}
+
+/**
+ * Best-effort browser storage usage/quota in bytes (Storage Manager API), or
+ * null when unavailable. Covers all origin storage, not just basemaps, but is
+ * the only quota signal the browser exposes.
+ */
+export async function getStorageEstimate(): Promise<{
+  usage: number;
+  quota: number;
+} | null> {
+  try {
+    if (typeof navigator === "undefined" || !navigator.storage?.estimate) {
+      return null;
+    }
+    const { usage = 0, quota = 0 } = await navigator.storage.estimate();
+    return { usage, quota };
+  } catch {
+    return null;
+  }
+}
+
+/** Human-readable byte size (KB/MB/GB) for footprint displays. */
+export function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+  }
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(0)} MB`;
+  if (bytes <= 0) return "0 KB";
+  return `${Math.max(1, Math.round(bytes / 1024))} KB`;
+}
+
+/**
+ * A short, human-readable label for a region's center, e.g. "12.34°N, 56.78°W".
+ * Used as the default name when a region is first downloaded.
+ */
+export function describeBboxCenter(bbox: Bbox): string {
+  const [west, south, east, north] = bbox;
+  const lat = (south + north) / 2;
+  const lng = (west + east) / 2;
+  const ns = lat >= 0 ? "N" : "S";
+  const ew = lng >= 0 ? "E" : "W";
+  return `${Math.abs(lat).toFixed(2)}°${ns}, ${Math.abs(lng).toFixed(2)}°${ew}`;
+}

--- a/apps/geolibre-desktop/src/lib/offline-regions.ts
+++ b/apps/geolibre-desktop/src/lib/offline-regions.ts
@@ -113,13 +113,27 @@ function getStorage(storage?: Storage): Storage | null {
 function isOfflineRegion(value: unknown): value is OfflineRegion {
   if (!value || typeof value !== "object") return false;
   const r = value as Record<string, unknown>;
+  const isNum = (v: unknown) => typeof v === "number" && Number.isFinite(v);
+  const isStrArray = (v: unknown) =>
+    Array.isArray(v) && v.every((x) => typeof x === "string");
+  // Validate every field, including numeric and array-element invariants: a
+  // tampered or older record that slips through here is cast to a trusted
+  // OfflineRegion and would surface as a corrupt id (`regionId` → "NaN…"),
+  // bad sort order, or a crash on `region.hosts.length` in the manager.
   return (
     typeof r.id === "string" &&
     typeof r.name === "string" &&
     Array.isArray(r.bbox) &&
     r.bbox.length === 4 &&
-    Array.isArray(r.tileUrls) &&
-    Array.isArray(r.assetUrls)
+    r.bbox.every(isNum) &&
+    isNum(r.minZoom) &&
+    isNum(r.maxZoom) &&
+    isStrArray(r.tileUrls) &&
+    isStrArray(r.assetUrls) &&
+    isNum(r.tileCount) &&
+    isStrArray(r.hosts) &&
+    isNum(r.createdAt) &&
+    isNum(r.updatedAt)
   );
 }
 
@@ -202,6 +216,23 @@ export function renameOfflineRegion(
   return regions;
 }
 
+/**
+ * Bump a region's `updatedAt` to `updatedAt` (epoch ms), e.g. after a successful
+ * partial retry re-warms its failed tiles. No-ops if the region isn't found.
+ */
+export function touchOfflineRegion(
+  id: string,
+  updatedAt: number,
+  storage?: Storage,
+): void {
+  const existing = loadOfflineRegions(storage);
+  if (!existing.some((r) => r.id === id)) return;
+  const regions = existing
+    .map((r) => (r.id === id ? { ...r, updatedAt } : r))
+    .sort((a, b) => b.updatedAt - a.updatedAt);
+  persistOfflineRegions(regions, storage);
+}
+
 /** Open the basemap cache, or null if the Cache Storage API is unavailable. */
 async function openBasemapCache(): Promise<Cache | null> {
   if (typeof caches === "undefined") return null;
@@ -221,30 +252,48 @@ async function openBasemapCache(): Promise<Cache | null> {
 export async function measureRegionBytes(region: OfflineRegion): Promise<number> {
   const cache = await openBasemapCache();
   if (!cache) return 0;
-  let bytes = 0;
-  for (const url of region.tileUrls) {
-    try {
-      const res = await cache.match(url);
-      if (res) bytes += (await res.blob()).size;
-    } catch {
-      // Skip unreadable entries.
-    }
-  }
-  return bytes;
+  // Look tiles up concurrently; a large region can hold hundreds of entries and
+  // a sequential loop would block the dialog noticeably on open. Prefer the
+  // cheap Content-Length header and fall back to reading the body only when it
+  // is absent (e.g. opaque responses), so we never deserialize megabytes of
+  // tile data just to total their size.
+  const sizes = await Promise.all(
+    region.tileUrls.map(async (url) => {
+      try {
+        const res = await cache.match(url);
+        if (!res) return 0;
+        const length = res.headers.get("content-length");
+        if (length !== null) {
+          const parsed = Number.parseInt(length, 10);
+          if (Number.isFinite(parsed) && parsed > 0) return parsed;
+        }
+        return (await res.blob()).size;
+      } catch {
+        return 0;
+      }
+    }),
+  );
+  return sizes.reduce((sum, n) => sum + n, 0);
 }
 
 /**
  * Delete a region from the manifest and evict its exclusive tiles from the
- * cache (tiles no other retained region references). Returns the remaining
- * regions and how many cache entries were removed.
+ * cache (tiles no other retained region references). Persists the manifest
+ * *before* touching the cache so a failed write can't leave the manifest still
+ * listing a region whose tiles are already gone. Returns the remaining regions,
+ * how many cache entries were removed, and whether the manifest persisted.
  */
 export async function deleteOfflineRegion(
   id: string,
   storage?: Storage,
-): Promise<{ regions: OfflineRegion[]; deleted: number }> {
+): Promise<{ regions: OfflineRegion[]; deleted: number; persisted: boolean }> {
   const existing = loadOfflineRegions(storage);
   const target = existing.find((r) => r.id === id);
   const remaining = existing.filter((r) => r.id !== id);
+  const persisted = persistOfflineRegions(remaining, storage);
+  // Bail before evicting if the manifest couldn't be updated, otherwise the
+  // cache and the manifest would diverge (tiles gone but region still listed).
+  if (!persisted) return { regions: existing, deleted: 0, persisted: false };
   let deleted = 0;
   if (target) {
     const cache = await openBasemapCache();
@@ -258,8 +307,7 @@ export async function deleteOfflineRegion(
       }
     }
   }
-  persistOfflineRegions(remaining, storage);
-  return { regions: remaining, deleted };
+  return { regions: remaining, deleted, persisted: true };
 }
 
 /**
@@ -284,11 +332,11 @@ export async function getStorageEstimate(): Promise<{
 
 /** Human-readable byte size (KB/MB/GB) for footprint displays. */
 export function formatBytes(bytes: number): string {
+  if (bytes <= 0) return "0 KB";
   if (bytes >= 1024 * 1024 * 1024) {
     return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
   }
   if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(0)} MB`;
-  if (bytes <= 0) return "0 KB";
   return `${Math.max(1, Math.round(bytes / 1024))} KB`;
 }
 

--- a/apps/geolibre-desktop/src/lib/offline-tiles.ts
+++ b/apps/geolibre-desktop/src/lib/offline-tiles.ts
@@ -199,7 +199,11 @@ interface RasterTileJson {
  *     before warming starts).
  *
  * Returns:
- *   A de-duplicated list of absolute URLs to fetch.
+ *   `urls` — every de-duplicated absolute URL to fetch (tiles + shared assets).
+ *   `tileUrls` — the region-specific raster/vector tile URLs only. Shared assets
+ *   (style, sprite, glyphs) are excluded here because they are common to every
+ *   region and must never be deleted when one region is removed; the offline
+ *   manifest stores this subset so it can size and delete a region safely.
  */
 export async function collectOfflineUrls(
   map: MapLibreMap,
@@ -207,10 +211,11 @@ export async function collectOfflineUrls(
   minZoom: number,
   maxZoom: number,
   options: { glyphRanges?: string[]; signal?: AbortSignal } = {},
-): Promise<string[]> {
+): Promise<{ urls: string[]; tileUrls: string[] }> {
   const { glyphRanges = ["0-255", "256-511"], signal } = options;
   const style = map.getStyle();
   const urls = new Set<string>();
+  const tileUrls = new Set<string>();
 
   // Tile sources.
   for (const source of Object.values(style.sources ?? {})) {
@@ -238,7 +243,9 @@ export async function collectOfflineUrls(
 
     const template = templates[0];
     for (const tile of enumerateTiles(bbox, minZoom, maxZoom)) {
-      urls.add(absolute(expandTileUrl(template, tile, spec.subdomains)));
+      const url = absolute(expandTileUrl(template, tile, spec.subdomains));
+      urls.add(url);
+      tileUrls.add(url);
     }
   }
 
@@ -285,7 +292,7 @@ export async function collectOfflineUrls(
     }
   }
 
-  return [...urls];
+  return { urls: [...urls], tileUrls: [...tileUrls] };
 }
 
 export interface WarmProgress {

--- a/apps/geolibre-desktop/src/lib/offline-tiles.ts
+++ b/apps/geolibre-desktop/src/lib/offline-tiles.ts
@@ -292,6 +292,11 @@ export interface WarmProgress {
   done: number;
   total: number;
   failed: number;
+  /**
+   * URLs that failed to warm (non-OK response or network error). Lets callers
+   * offer a "retry failed tiles" action without re-fetching the whole region.
+   */
+  failedUrls: string[];
 }
 
 /**
@@ -317,7 +322,12 @@ export async function warmUrls(
   } = {},
 ): Promise<WarmProgress> {
   const { concurrency = 6, signal, onProgress } = options;
-  const progress: WarmProgress = { done: 0, total: urls.length, failed: 0 };
+  const progress: WarmProgress = {
+    done: 0,
+    total: urls.length,
+    failed: 0,
+    failedUrls: [],
+  };
   let cursor = 0;
 
   async function worker(): Promise<void> {
@@ -328,10 +338,14 @@ export async function warmUrls(
         // CacheFirst means already-cached URLs return instantly; new ones hit
         // the network and are stored by the SW. We discard the body.
         const res = await fetch(url, { signal, cache: "no-cache" });
-        if (!res.ok) progress.failed++;
+        if (!res.ok) {
+          progress.failed++;
+          progress.failedUrls.push(url);
+        }
       } catch {
         if (signal?.aborted) return;
         progress.failed++;
+        progress.failedUrls.push(url);
       } finally {
         // `finally` runs even after the `return` above, so only count requests
         // that actually settled — not ones interrupted by an abort.

--- a/apps/geolibre-desktop/src/lib/offline-tiles.ts
+++ b/apps/geolibre-desktop/src/lib/offline-tiles.ts
@@ -351,7 +351,11 @@ export async function warmUrls(
         // that actually settled — not ones interrupted by an abort.
         if (!signal?.aborted) {
           progress.done++;
-          onProgress?.({ ...progress });
+          // Copy `failedUrls` so each snapshot is independent — a shallow
+          // `{ ...progress }` would share the one array reference across every
+          // emitted snapshot, and later `push()`es would mutate state React
+          // already holds (unsafe under Strict Mode / concurrent rendering).
+          onProgress?.({ ...progress, failedUrls: [...progress.failedUrls] });
         }
       }
     }

--- a/apps/geolibre-desktop/src/lib/offline-tiles.ts
+++ b/apps/geolibre-desktop/src/lib/offline-tiles.ts
@@ -176,6 +176,120 @@ function absolute(url: string): string {
 
 interface RasterTileJson {
   tiles?: string[];
+  minzoom?: number;
+  maxzoom?: number;
+}
+
+interface ResolvedTileSource {
+  template: string;
+  subdomains?: string[];
+  /** Source coverage bounds; undefined when the source/TileJSON omits them. */
+  minzoom?: number;
+  maxzoom?: number;
+}
+
+/**
+ * Clamp a requested `[minZoom, maxZoom]` range to a source's coverage
+ * `[srcMin, srcMax]`, returning the zoom range to actually warm — or `null` when
+ * there is nothing to warm.
+ *
+ * The point is to never request a tile **beyond the source's maxzoom**: those
+ * 404 (e.g. OpenFreeMap's `ne2_shaded` raster stops at z6 and its vector tiles
+ * at z14), which is what made over-zoomed offline downloads fail wholesale.
+ * When the *entire* requested range sits above the source maxzoom (the user is
+ * zoomed past it), we warm just the deepest available level — MapLibre overzooms
+ * those tiles to render the higher zooms, so they still work offline.
+ */
+export function clampZoomRange(
+  minZoom: number,
+  maxZoom: number,
+  srcMin?: number,
+  srcMax?: number,
+): { minZoom: number; maxZoom: number } | null {
+  const lo = typeof srcMin === "number" ? srcMin : 0;
+  const hi = typeof srcMax === "number" ? srcMax : maxZoom;
+  // Requested range is entirely below where this source has data.
+  if (maxZoom < lo) return null;
+  // Over-zoomed past the source: warm only its deepest level for overzoom.
+  if (minZoom > hi) return { minZoom: hi, maxZoom: hi };
+  const z0 = Math.max(minZoom, lo);
+  const z1 = Math.min(maxZoom, hi);
+  if (z1 < z0) return null;
+  return { minZoom: z0, maxZoom: z1 };
+}
+
+/**
+ * Resolve every vector/raster source in the active style to a single tile-URL
+ * template plus its coverage bounds, fetching the TileJSON for sources that
+ * declare their tiles via a `url` (e.g. OpenFreeMap's vector source). Sources
+ * with no usable template are dropped.
+ */
+async function resolveTileSources(
+  map: MapLibreMap,
+  signal?: AbortSignal,
+): Promise<ResolvedTileSource[]> {
+  const style = map.getStyle();
+  const resolved: ResolvedTileSource[] = [];
+  for (const source of Object.values(style.sources ?? {})) {
+    const spec = source as {
+      type?: string;
+      tiles?: string[];
+      url?: string;
+      subdomains?: string[];
+      minzoom?: number;
+      maxzoom?: number;
+    };
+    if (spec.type !== "vector" && spec.type !== "raster") continue;
+
+    let templates = spec.tiles;
+    let minzoom = spec.minzoom;
+    let maxzoom = spec.maxzoom;
+    if ((!templates || templates.length === 0) && spec.url) {
+      try {
+        const res = await fetch(absolute(spec.url), { signal });
+        if (res.ok) {
+          const tilejson = (await res.json()) as RasterTileJson;
+          templates = tilejson.tiles;
+          // The style spec wins; fall back to the TileJSON's declared bounds.
+          if (minzoom === undefined) minzoom = tilejson.minzoom;
+          if (maxzoom === undefined) maxzoom = tilejson.maxzoom;
+        }
+      } catch {
+        // Unreachable TileJSON: skip this source rather than abort the whole run.
+      }
+    }
+    if (!templates || templates.length === 0) continue;
+    resolved.push({
+      template: templates[0],
+      subdomains: spec.subdomains,
+      minzoom,
+      maxzoom,
+    });
+  }
+  return resolved;
+}
+
+/**
+ * Count the tiles an offline download would actually warm for `bbox` across
+ * `[minZoom, maxZoom]`, per source and clamped to each source's coverage. This
+ * is the preview-accurate count: it matches the tiles `collectOfflineUrls`
+ * produces (so the dialog's estimate agrees with the final "Saved N of N"),
+ * unlike a naive `countTiles` that ignores source maxzoom and over-counts.
+ */
+export async function countOfflineTiles(
+  map: MapLibreMap,
+  bbox: Bbox,
+  minZoom: number,
+  maxZoom: number,
+  options: { signal?: AbortSignal } = {},
+): Promise<number> {
+  let total = 0;
+  for (const src of await resolveTileSources(map, options.signal)) {
+    const range = clampZoomRange(minZoom, maxZoom, src.minzoom, src.maxzoom);
+    if (!range) continue;
+    total += countTiles(bbox, range.minZoom, range.maxZoom);
+  }
+  return total;
 }
 
 /**
@@ -217,33 +331,14 @@ export async function collectOfflineUrls(
   const urls = new Set<string>();
   const tileUrls = new Set<string>();
 
-  // Tile sources.
-  for (const source of Object.values(style.sources ?? {})) {
-    const spec = source as {
-      type?: string;
-      tiles?: string[];
-      url?: string;
-      subdomains?: string[];
-    };
-    if (spec.type !== "vector" && spec.type !== "raster") continue;
-
-    let templates = spec.tiles;
-    if ((!templates || templates.length === 0) && spec.url) {
-      try {
-        const res = await fetch(absolute(spec.url), { signal });
-        if (res.ok) {
-          const tilejson = (await res.json()) as RasterTileJson;
-          templates = tilejson.tiles;
-        }
-      } catch {
-        // Unreachable TileJSON: skip this source rather than abort the whole run.
-      }
-    }
-    if (!templates || templates.length === 0) continue;
-
-    const template = templates[0];
-    for (const tile of enumerateTiles(bbox, minZoom, maxZoom)) {
-      const url = absolute(expandTileUrl(template, tile, spec.subdomains));
+  // Tile sources: enumerate each one only within its own coverage so we never
+  // request tiles past a source's maxzoom (those 404 and would fail the whole
+  // download — see clampZoomRange).
+  for (const src of await resolveTileSources(map, signal)) {
+    const range = clampZoomRange(minZoom, maxZoom, src.minzoom, src.maxzoom);
+    if (!range) continue;
+    for (const tile of enumerateTiles(bbox, range.minZoom, range.maxZoom)) {
+      const url = absolute(expandTileUrl(src.template, tile, src.subdomains));
       urls.add(url);
       tileUrls.add(url);
     }

--- a/apps/geolibre-desktop/src/lib/offline-tiles.ts
+++ b/apps/geolibre-desktop/src/lib/offline-tiles.ts
@@ -313,7 +313,13 @@ export interface WarmProgress {
  *
  * Args:
  *   urls: Absolute URLs to warm.
- *   options.concurrency: Max simultaneous requests (default 6).
+ *   options.concurrency: Max simultaneous requests (default 6). Lowering this
+ *     reduces the network footprint, which can get past aggressive server-side
+ *     rate limiting that otherwise causes tiles to fail.
+ *   options.timeoutMs: Per-request timeout in ms. A request that exceeds it is
+ *     aborted and counted as a failure (so it lands in `failedUrls` and can be
+ *     retried), without cancelling the rest of the run. 0 / undefined disables
+ *     it (the browser default applies). Raising it helps slow connections.
  *   options.signal: Abort signal to cancel in-flight and pending fetches.
  *   options.onProgress: Called after each request settles.
  *
@@ -324,11 +330,21 @@ export async function warmUrls(
   urls: string[],
   options: {
     concurrency?: number;
+    timeoutMs?: number;
     signal?: AbortSignal;
     onProgress?: (progress: WarmProgress) => void;
   } = {},
 ): Promise<WarmProgress> {
-  const { concurrency = 6, signal, onProgress } = options;
+  const { concurrency = 6, timeoutMs, signal, onProgress } = options;
+
+  // Per-request signal: the parent cancel signal combined with a fresh timeout
+  // (one timer per request). A timeout abort leaves the parent signal
+  // un-aborted, so the catch below counts it as a failure rather than a cancel.
+  const requestSignal = (): AbortSignal | undefined => {
+    if (!timeoutMs || timeoutMs <= 0) return signal;
+    const timeout = AbortSignal.timeout(timeoutMs);
+    return signal ? AbortSignal.any([signal, timeout]) : timeout;
+  };
   const progress: WarmProgress = {
     done: 0,
     total: urls.length,
@@ -344,7 +360,10 @@ export async function warmUrls(
       try {
         // CacheFirst means already-cached URLs return instantly; new ones hit
         // the network and are stored by the SW. We discard the body.
-        const res = await fetch(url, { signal, cache: "no-cache" });
+        const res = await fetch(url, {
+          signal: requestSignal(),
+          cache: "no-cache",
+        });
         if (!res.ok) {
           progress.failed++;
           progress.failedUrls.push(url);

--- a/apps/geolibre-desktop/src/lib/offline-tiles.ts
+++ b/apps/geolibre-desktop/src/lib/offline-tiles.ts
@@ -343,7 +343,13 @@ export async function warmUrls(
   const requestSignal = (): AbortSignal | undefined => {
     if (!timeoutMs || timeoutMs <= 0) return signal;
     const timeout = AbortSignal.timeout(timeoutMs);
-    return signal ? AbortSignal.any([signal, timeout]) : timeout;
+    if (!signal) return timeout;
+    // AbortSignal.any shipped in Chrome 116 / Firefox 124 / Safari 17.4. On
+    // older engines fall back to the timeout alone so the request still times
+    // out (it just won't also abort on the parent cancel signal).
+    return typeof AbortSignal.any === "function"
+      ? AbortSignal.any([signal, timeout])
+      : timeout;
   };
   const progress: WarmProgress = {
     done: 0,

--- a/apps/geolibre-desktop/src/lib/ui-profile.ts
+++ b/apps/geolibre-desktop/src/lib/ui-profile.ts
@@ -205,6 +205,7 @@ export const MENU_ITEM_CATALOG: readonly MenuItemCatalogEntry[] = [
   // deliverable, so it stays visible for every profile (GH #529).
   { id: "project.printLayout", menuId: "project", labelKey: "toolbar.item.printLayoutEllipsis", tier: "basic" },
   { id: "project.offlineRegion", menuId: "project", labelKey: "toolbar.item.offlineRegionEllipsis", tier: "advanced" },
+  { id: "project.offlineManager", menuId: "project", labelKey: "toolbar.item.offlineManagerEllipsis", tier: "advanced" },
   { id: "project.storymap", menuId: "project", labelKey: "toolbar.item.storymapEllipsis", tier: "advanced" },
   // Edit
   { id: "edit.undo", menuId: "edit", labelKey: "toolbar.item.undo", tier: "basic" },

--- a/tests/offline-regions.test.ts
+++ b/tests/offline-regions.test.ts
@@ -10,6 +10,7 @@ import {
   regionAllUrls,
   regionId,
   renameOfflineRegion,
+  touchOfflineRegion,
   upsertOfflineRegion,
   urlHosts,
 } from "../apps/geolibre-desktop/src/lib/offline-regions";
@@ -178,6 +179,44 @@ describe("persistence round-trip", () => {
       loaded.map((r) => r.id),
       ["ok"],
     );
+  });
+
+  it("drops records with non-numeric bbox or missing numeric fields", () => {
+    storage.setItem(
+      "geolibre.offlineRegions.v1",
+      JSON.stringify([
+        makeRegion({ id: "bad-bbox", bbox: [null, "a", {}, 1] as never }),
+        { ...makeRegion({ id: "no-hosts" }), hosts: undefined },
+        { ...makeRegion({ id: "no-updated" }), updatedAt: undefined },
+        makeRegion({ id: "good" }),
+      ]),
+    );
+    assert.deepEqual(
+      loadOfflineRegions(storage).map((r) => r.id),
+      ["good"],
+    );
+  });
+});
+
+describe("touchOfflineRegion", () => {
+  it("bumps updatedAt and reorders newest-first", () => {
+    const storage = fakeStorage();
+    upsertOfflineRegion(makeRegion({ id: "a", updatedAt: 1 }), storage);
+    upsertOfflineRegion(makeRegion({ id: "b", updatedAt: 2 }), storage);
+    touchOfflineRegion("a", 100, storage);
+    const loaded = loadOfflineRegions(storage);
+    assert.deepEqual(
+      loaded.map((r) => r.id),
+      ["a", "b"],
+    );
+    assert.equal(loaded[0].updatedAt, 100);
+  });
+
+  it("no-ops for an unknown id", () => {
+    const storage = fakeStorage();
+    upsertOfflineRegion(makeRegion({ id: "a", updatedAt: 1 }), storage);
+    touchOfflineRegion("missing", 100, storage);
+    assert.equal(loadOfflineRegions(storage)[0].updatedAt, 1);
   });
 });
 

--- a/tests/offline-regions.test.ts
+++ b/tests/offline-regions.test.ts
@@ -1,0 +1,218 @@
+import assert from "node:assert/strict";
+import { beforeEach, describe, it } from "node:test";
+import {
+  deleteOfflineRegion,
+  describeBboxCenter,
+  exclusiveTileUrls,
+  formatBytes,
+  loadOfflineRegions,
+  type OfflineRegion,
+  regionAllUrls,
+  regionId,
+  renameOfflineRegion,
+  upsertOfflineRegion,
+  urlHosts,
+} from "../apps/geolibre-desktop/src/lib/offline-regions";
+
+/** Minimal in-memory Storage for testing persistence without a browser. */
+function fakeStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear: () => map.clear(),
+    getItem: (k) => map.get(k) ?? null,
+    key: (i) => [...map.keys()][i] ?? null,
+    removeItem: (k) => map.delete(k),
+    setItem: (k, v) => {
+      map.set(k, v);
+    },
+  };
+}
+
+function makeRegion(over: Partial<OfflineRegion> = {}): OfflineRegion {
+  return {
+    id: "r1",
+    name: "Region 1",
+    bbox: [-10, -10, 10, 10],
+    minZoom: 4,
+    maxZoom: 6,
+    tileUrls: ["https://openfreemap.org/4/1/1.pbf"],
+    assetUrls: ["https://openfreemap.org/style.json"],
+    tileCount: 1,
+    hosts: ["openfreemap.org"],
+    createdAt: 1000,
+    updatedAt: 1000,
+    ...over,
+  };
+}
+
+describe("regionId", () => {
+  it("is stable for the same bounds and zoom range", () => {
+    const a = regionId([-10, -10, 10, 10], 4, 6);
+    const b = regionId([-10, -10, 10, 10], 4, 6);
+    assert.equal(a, b);
+  });
+
+  it("collapses sub-10m viewport jitter to the same id", () => {
+    const a = regionId([-10, -10, 10, 10], 4, 6);
+    const b = regionId([-10.00001, -10.00001, 10.00001, 10.00001], 4, 6);
+    assert.equal(a, b);
+  });
+
+  it("differs when the zoom range differs", () => {
+    assert.notEqual(
+      regionId([-10, -10, 10, 10], 4, 6),
+      regionId([-10, -10, 10, 10], 4, 7),
+    );
+  });
+});
+
+describe("urlHosts", () => {
+  it("returns distinct hostnames and ignores unparseable URLs", () => {
+    const hosts = urlHosts([
+      "https://a.openfreemap.org/x",
+      "https://a.openfreemap.org/y",
+      "not a url",
+      "https://b.cartocdn.com/z",
+    ]);
+    assert.deepEqual(hosts.sort(), ["a.openfreemap.org", "b.cartocdn.com"]);
+  });
+});
+
+describe("exclusiveTileUrls", () => {
+  it("returns all tiles when no other region overlaps", () => {
+    const region = makeRegion({ tileUrls: ["t1", "t2"] });
+    assert.deepEqual(exclusiveTileUrls(region, []), ["t1", "t2"]);
+  });
+
+  it("excludes tiles shared with another retained region", () => {
+    const region = makeRegion({ id: "r1", tileUrls: ["t1", "t2", "t3"] });
+    const other = makeRegion({ id: "r2", tileUrls: ["t2"] });
+    assert.deepEqual(exclusiveTileUrls(region, [other]), ["t1", "t3"]);
+  });
+
+  it("ignores the region's own entry in the others list", () => {
+    const region = makeRegion({ id: "r1", tileUrls: ["t1"] });
+    assert.deepEqual(exclusiveTileUrls(region, [region]), ["t1"]);
+  });
+});
+
+describe("regionAllUrls", () => {
+  it("concatenates tile and asset URLs", () => {
+    const region = makeRegion({ tileUrls: ["t1"], assetUrls: ["a1"] });
+    assert.deepEqual(regionAllUrls(region), ["t1", "a1"]);
+  });
+});
+
+describe("persistence round-trip", () => {
+  let storage: Storage;
+  beforeEach(() => {
+    storage = fakeStorage();
+  });
+
+  it("returns an empty list when nothing is stored", () => {
+    assert.deepEqual(loadOfflineRegions(storage), []);
+  });
+
+  it("upserts and loads a region, newest first", () => {
+    upsertOfflineRegion(makeRegion({ id: "old", updatedAt: 1 }), storage);
+    upsertOfflineRegion(makeRegion({ id: "new", updatedAt: 2 }), storage);
+    const loaded = loadOfflineRegions(storage);
+    assert.deepEqual(
+      loaded.map((r) => r.id),
+      ["new", "old"],
+    );
+  });
+
+  it("replaces an existing region by id without duplicating", () => {
+    upsertOfflineRegion(makeRegion({ id: "r1", tileCount: 1 }), storage);
+    upsertOfflineRegion(
+      makeRegion({ id: "r1", tileCount: 5, updatedAt: 2000 }),
+      storage,
+    );
+    const loaded = loadOfflineRegions(storage);
+    assert.equal(loaded.length, 1);
+    assert.equal(loaded[0].tileCount, 5);
+  });
+
+  it("preserves a custom name and original createdAt on re-download", () => {
+    upsertOfflineRegion(
+      makeRegion({ id: "r1", name: "My City", createdAt: 100 }),
+      storage,
+    );
+    upsertOfflineRegion(
+      makeRegion({
+        id: "r1",
+        name: "auto-generated",
+        createdAt: 999,
+        updatedAt: 2000,
+      }),
+      storage,
+    );
+    const loaded = loadOfflineRegions(storage);
+    assert.equal(loaded[0].name, "My City");
+    assert.equal(loaded[0].createdAt, 100);
+    assert.equal(loaded[0].updatedAt, 2000);
+  });
+
+  it("renames a region in place", () => {
+    upsertOfflineRegion(makeRegion({ id: "r1", name: "Old" }), storage);
+    renameOfflineRegion("r1", "New", storage);
+    assert.equal(loadOfflineRegions(storage)[0].name, "New");
+  });
+
+  it("ignores a corrupt stored value", () => {
+    storage.setItem("geolibre.offlineRegions.v1", "{ not json");
+    assert.deepEqual(loadOfflineRegions(storage), []);
+  });
+
+  it("drops structurally invalid records", () => {
+    storage.setItem(
+      "geolibre.offlineRegions.v1",
+      JSON.stringify([{ id: "x" }, makeRegion({ id: "ok" })]),
+    );
+    const loaded = loadOfflineRegions(storage);
+    assert.deepEqual(
+      loaded.map((r) => r.id),
+      ["ok"],
+    );
+  });
+});
+
+describe("deleteOfflineRegion", () => {
+  it("removes the record from the manifest", async () => {
+    const storage = fakeStorage();
+    upsertOfflineRegion(makeRegion({ id: "r1" }), storage);
+    upsertOfflineRegion(makeRegion({ id: "r2", updatedAt: 2 }), storage);
+    const { regions } = await deleteOfflineRegion("r1", storage);
+    assert.deepEqual(
+      regions.map((r) => r.id),
+      ["r2"],
+    );
+    assert.deepEqual(
+      loadOfflineRegions(storage).map((r) => r.id),
+      ["r2"],
+    );
+  });
+});
+
+describe("describeBboxCenter", () => {
+  it("formats the center with hemisphere suffixes", () => {
+    assert.equal(describeBboxCenter([10, 20, 30, 40]), "30.00°N, 20.00°E");
+  });
+
+  it("uses S/W for negative hemispheres", () => {
+    assert.equal(describeBboxCenter([-30, -40, -10, -20]), "30.00°S, 20.00°W");
+  });
+});
+
+describe("formatBytes", () => {
+  it("formats KB, MB, and GB", () => {
+    assert.equal(formatBytes(0), "0 KB");
+    assert.equal(formatBytes(2048), "2 KB");
+    assert.equal(formatBytes(5 * 1024 * 1024), "5 MB");
+    assert.equal(formatBytes(3 * 1024 * 1024 * 1024), "3.0 GB");
+  });
+});

--- a/tests/offline-tiles.test.ts
+++ b/tests/offline-tiles.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { afterEach, describe, it } from "node:test";
 import {
   countTiles,
   enumerateTiles,
@@ -7,6 +7,7 @@ import {
   lngLatToTile,
   tileRangeForBbox,
   tileToQuadkey,
+  warmUrls,
   type Bbox,
 } from "../apps/geolibre-desktop/src/lib/offline-tiles";
 
@@ -127,5 +128,64 @@ describe("tileToQuadkey", () => {
 
   it("produces a key of length z", () => {
     assert.equal(tileToQuadkey({ z: 7, x: 10, y: 20 }).length, 7);
+  });
+});
+
+describe("warmUrls", () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  /** A fetch that resolves after `delayMs`, but rejects early if aborted. */
+  function deferredFetch(delayMs: number): typeof fetch {
+    return ((_url: string, init?: { signal?: AbortSignal }) =>
+      new Promise<Response>((resolve, reject) => {
+        const signal = init?.signal;
+        const timer = setTimeout(
+          () => resolve(new Response("ok", { status: 200 })),
+          delayMs,
+        );
+        const onAbort = () => {
+          clearTimeout(timer);
+          reject(new DOMException("aborted", "AbortError"));
+        };
+        if (signal?.aborted) onAbort();
+        else signal?.addEventListener("abort", onAbort);
+      })) as typeof fetch;
+  }
+
+  it("warms every URL when requests succeed", async () => {
+    globalThis.fetch = deferredFetch(0);
+    const result = await warmUrls(["a", "b", "c"], { concurrency: 2 });
+    assert.equal(result.done, 3);
+    assert.equal(result.failed, 0);
+    assert.deepEqual(result.failedUrls, []);
+  });
+
+  it("counts a request exceeding timeoutMs as failed, not a cancel", async () => {
+    // Requests take 1s but the timeout is 10ms, so every one times out.
+    globalThis.fetch = deferredFetch(1000);
+    const result = await warmUrls(["a", "b"], {
+      concurrency: 2,
+      timeoutMs: 10,
+    });
+    assert.equal(result.done, 2);
+    assert.equal(result.failed, 2);
+    assert.deepEqual(result.failedUrls.sort(), ["a", "b"]);
+  });
+
+  it("stops settling new work once the parent signal is aborted", async () => {
+    globalThis.fetch = deferredFetch(1000);
+    const controller = new AbortController();
+    const promise = warmUrls(["a", "b", "c"], {
+      concurrency: 1,
+      signal: controller.signal,
+    });
+    controller.abort();
+    const result = await promise;
+    // An abort short-circuits counting, so nothing is recorded as done/failed.
+    assert.equal(result.done, 0);
+    assert.equal(result.failed, 0);
   });
 });

--- a/tests/offline-tiles.test.ts
+++ b/tests/offline-tiles.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
 import {
+  clampZoomRange,
   countTiles,
   enumerateTiles,
   expandTileUrl,
@@ -128,6 +129,33 @@ describe("tileToQuadkey", () => {
 
   it("produces a key of length z", () => {
     assert.equal(tileToQuadkey({ z: 7, x: 10, y: 20 }).length, 7);
+  });
+});
+
+describe("clampZoomRange", () => {
+  it("returns the full range when the source has no bounds", () => {
+    assert.deepEqual(clampZoomRange(2, 10), { minZoom: 2, maxZoom: 10 });
+  });
+
+  it("clamps the upper bound to the source maxzoom", () => {
+    // OpenFreeMap vector tiles stop at z14: a z2–18 request warms z2–14.
+    assert.deepEqual(clampZoomRange(2, 18, undefined, 14), {
+      minZoom: 2,
+      maxZoom: 14,
+    });
+  });
+
+  it("warms only the deepest level when over-zoomed past the source", () => {
+    // ne2_shaded raster stops at z6; a z10–15 request warms just z6 (overzoom).
+    assert.deepEqual(clampZoomRange(10, 15, 0, 6), { minZoom: 6, maxZoom: 6 });
+  });
+
+  it("raises the lower bound to the source minzoom", () => {
+    assert.deepEqual(clampZoomRange(2, 10, 5, 14), { minZoom: 5, maxZoom: 10 });
+  });
+
+  it("returns null when the request is entirely below coverage", () => {
+    assert.equal(clampZoomRange(2, 4, 6, 14), null);
   });
 });
 


### PR DESCRIPTION
## Summary

Addresses the offline-download feedback raised in #564 (the original report plus renevandervelde's follow-up remarks), covering all of its asks.

### 1. Conditional completion text

The **Download Offline Area** completion message always appended `(N failed)`, so a flawless download read "Saved 22 of 22 tiles (0 failed)." The bracketed zero is non-information on a success state and desensitizes users to genuine failure notices.

- **No failures:** `Saved 34 of 34 tiles.`
- **One or more failures:** `Saved 18 of 22 tiles (4 failed).`

### 2. Recovery options for failed tiles

`warmUrls` collects the URLs that failed (non-OK response, network error, or timeout) and returns them in `WarmProgress`. After a partial download the dialog offers:

- **Retry N failed tiles** — re-warms only the failed URLs (a delta retry), so a transient blip is recovered without re-fetching the whole region.
- **Retry all tiles** — a full re-warm of the region from scratch.
- **Advanced options** (collapsible): a **concurrency** slider (lower it to ease off servers that rate-limit rapid requests) and a per-request **timeout** (raise it for slow links). Both apply to the download and to both retry paths. A request that exceeds the timeout is aborted and counted as a failure (so it can be retried) without cancelling the rest of the run.

### 3. Offline Areas management dashboard

Implements renevandervelde's long-term wishlist item: a centralized layer for managing downloaded tiles. The service worker's `geolibre-basemaps` cache keeps no metadata about *which region* a tile belongs to, so this adds a device-local manifest and a dashboard on top of it.

- **`offline-regions.ts` (new):** a `localStorage`-backed manifest (load/persist/upsert/rename/delete), cache-bound size measurement and **exclusive-tile eviction** — only tiles no *other* retained region references are deleted; shared style/sprite/glyph assets are never deleted, so removing one region can't break another — plus a Storage Manager estimate.
- **`OfflineRegionDialog`** records each successful download into the manifest (deterministic id from bbox + zoom; preserves a custom name and original date on re-download).
- **`OfflineManagerDialog` (new):** lists each region (bounds, zoom range, tile count, measured on-disk size, date, host), with per-region **Refresh** + **Delete**, **Refresh all**, a total footprint + device storage usage line, and an empty state.
- Wired via a new `project.offlineManager` UI-profile flag and a **Project → Manage Offline Areas…** menu item.

## Changes

- `offline-tiles.ts`: `WarmProgress` gains `failedUrls`; `warmUrls` records failed URLs and gains a per-request `timeoutMs`; `collectOfflineUrls` returns `{ urls, tileUrls }`.
- `offline-regions.ts`: new manifest + cache management module (unit-tested).
- `OfflineRegionDialog.tsx`: conditional completion key, Retry failed / Retry all, Advanced options (concurrency + timeout), records downloads into the manifest.
- `OfflineManagerDialog.tsx`: new management dashboard.
- `ui-profile.ts`, `ProjectMenu.tsx`, `TopToolbar.tsx`: menu wiring.
- `en.json`: completion/retry/advanced strings and the `offlineManager.*` catalog (other locales fall back to en).

## Verification

Verified in the real web app (production build via `vite preview`, PWA service worker active) in **both light and dark themes**:

- **Completion text** — real download: "Saved 34 of 34 tiles." (no `(0 failed)`). Routing the tile host to 404 → "Saved 0 of 22 tiles (22 failed)." with both **Retry 22 failed tiles** and **Retry all tiles** shown; clearing the route and clicking **Retry all tiles** → "Saved 34 of 34 tiles." and the retry buttons clear.
- **Advanced options** — concurrency slider and timeout input render; the timeout hint updates ("Each tile request is given up to 30s…").
- **Manifest** — a download records one region (`localStorage`) with correct bbox-center name, zoom range, tile/asset URL split, and host.
- **Dashboard** — lists the region with its **measured** footprint, date, and host; total footprint and device storage line; **Refresh** re-warms; **Delete** (two-step confirm) clears the record and returns to the empty state. No console errors.

Unit tests cover the manifest logic and the `warmUrls` timeout/abort behavior. `npm run test:frontend` (1175 tests) and `pre-commit run --files` (eslint + build) pass.

Fixes #564


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an offline manager to view, update, rename, and delete cached offline map regions
  * Added advanced offline download controls (concurrency and per-request timeout)
  * Added storage usage tracking with device quota display
* **Improvements**
  * Offline downloads now track partial failures, show “with failures” completion messaging, and offer “retry failed” plus “retry all”
  * Bulk updates warm multiple regions and safely handle cancellation of any in-progress warm work
* **Bug Fixes**
  * Improved offline caching persistence to only keep manifests when at least one tile is successfully cached
<!-- end of auto-generated comment: release notes by coderabbit.ai -->