### PR TITLE
fix(segmentation): replace premature HTTP error with neutral status notice

### DIFF
--- a/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
@@ -27,7 +27,13 @@ import {
   Server,
 } from "lucide-react";
 import type { FeatureCollection } from "geojson";
-import { useCallback, useEffect, useState, type ReactElement } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactElement,
+} from "react";
 import { useTranslation } from "react-i18next";
 import { isTauri, openLocalDataFileWithFallback } from "../../lib/tauri-io";
 import { reprojectFeatureCollectionToWgs84 } from "../../lib/duckdb-vector-loader";
@@ -71,32 +77,40 @@ export function SegmentationDialog({
   const [resultMessage, setResultMessage] = useState<string | null>(null);
   const [startingServer, setStartingServer] = useState(false);
 
+  // Monotonic token so a stale probe (e.g. the dialog reopened, or the
+  // post-boot probe in startServer) cannot clobber a newer probe's result or
+  // drop the spinner out from under it.
+  const checkGenRef = useRef(0);
+
   const checkStatus = useCallback(async () => {
+    const gen = ++checkGenRef.current;
     setChecking(true);
     setStatus(null);
     try {
-      setStatus(await fetchMlStatus());
+      const next = await fetchMlStatus();
+      if (gen === checkGenRef.current) setStatus(next);
     } catch (err) {
       // A failed probe (sidecar not started, or no segmentation backend behind
       // the proxy) is an expected "not set up yet" state, not a system failure.
       // Show neutral guidance instead of surfacing the raw HTTP/connection
       // error, so a freshly opened, blank dialog never greets the user with
-      // something like "HTTP 404" (issue #545). Surface anything unexpected
-      // (e.g. a malformed 200 payload) to the dev console so it isn't lost.
-      if (import.meta.env.DEV) {
-        console.warn("SegmentationDialog: ML status probe failed", err);
+      // something like "HTTP 404" (issue #545). Log at debug (matching
+      // sidecarConnectionError) so an unexpected failure stays discoverable in
+      // production without warning-spam for the routine not-set-up case.
+      console.debug("SegmentationDialog: ML status probe failed", err);
+      if (gen === checkGenRef.current) {
+        setStatus({
+          available: false,
+          // Desktop users get the "Start server" button below, so point them at
+          // it; web users have no such button, so tell them the feature needs
+          // the desktop app rather than an action they cannot take.
+          message: isTauri()
+            ? t("segmentation.status.unavailableDesktop")
+            : t("segmentation.status.unavailableWeb"),
+        });
       }
-      setStatus({
-        available: false,
-        // Desktop users get the "Start server" button below, so point them at
-        // it; web users have no such button, so tell them the feature needs the
-        // desktop app rather than an action they cannot take.
-        message: isTauri()
-          ? t("segmentation.status.unavailableDesktop")
-          : t("segmentation.status.unavailableWeb"),
-      });
     } finally {
-      setChecking(false);
+      if (gen === checkGenRef.current) setChecking(false);
     }
   }, [t]);
 

--- a/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
@@ -76,12 +76,16 @@ export function SegmentationDialog({
     setStatus(null);
     try {
       setStatus(await fetchMlStatus());
-    } catch {
+    } catch (err) {
       // A failed probe (sidecar not started, or no segmentation backend behind
       // the proxy) is an expected "not set up yet" state, not a system failure.
       // Show neutral guidance instead of surfacing the raw HTTP/connection
       // error, so a freshly opened, blank dialog never greets the user with
-      // something like "HTTP 404" (issue #545).
+      // something like "HTTP 404" (issue #545). Surface anything unexpected
+      // (e.g. a malformed 200 payload) to the dev console so it isn't lost.
+      if (import.meta.env.DEV) {
+        console.warn("SegmentationDialog: ML status probe failed", err);
+      }
       setStatus({
         available: false,
         message: t("segmentation.status.unavailable"),

--- a/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
@@ -21,6 +21,7 @@ import {
   AlertCircle,
   CheckCircle2,
   FolderOpen,
+  Info,
   Loader2,
   Play,
   Server,
@@ -64,23 +65,29 @@ export function SegmentationDialog({
   const [imageBytes, setImageBytes] = useState<ArrayBuffer | null>(null);
   const [imageName, setImageName] = useState("");
   const [status, setStatus] = useState<MlStatus | null>(null);
+  const [checking, setChecking] = useState(false);
   const [running, setRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [resultMessage, setResultMessage] = useState<string | null>(null);
   const [startingServer, setStartingServer] = useState(false);
 
   const checkStatus = useCallback(async () => {
+    setChecking(true);
     setStatus(null);
     try {
       setStatus(await fetchMlStatus());
-    } catch (err) {
+    } catch {
+      // A failed probe (sidecar not started, or no segmentation backend behind
+      // the proxy) is an expected "not set up yet" state, not a system failure.
+      // Show neutral guidance instead of surfacing the raw HTTP/connection
+      // error, so a freshly opened, blank dialog never greets the user with
+      // something like "HTTP 404" (issue #545).
       setStatus({
         available: false,
-        message:
-          err instanceof Error
-            ? err.message
-            : t("segmentation.error.sidecarUnreachable"),
+        message: t("segmentation.status.unavailable"),
       });
+    } finally {
+      setChecking(false);
     }
   }, [t]);
 
@@ -202,10 +209,17 @@ export function SegmentationDialog({
         </DialogHeader>
 
         <div className="flex flex-col gap-3">
-          {status && !available && (
-            <div className="grid gap-2 rounded-md border border-destructive/40 bg-destructive/5 p-3">
-              <p className="flex items-start gap-2 text-sm text-destructive">
-                <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+          {checking && (
+            <p className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              {t("segmentation.status.checking")}
+            </p>
+          )}
+
+          {!checking && status && !available && (
+            <div className="grid gap-2 rounded-md border border-border bg-muted/40 p-3">
+              <p className="flex items-start gap-2 text-sm text-muted-foreground">
+                <Info className="mt-0.5 h-4 w-4 shrink-0" />
                 {status.message}
               </p>
               {/* Launching the sidecar is a desktop-only (Tauri) capability;

--- a/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
@@ -88,7 +88,12 @@ export function SegmentationDialog({
       }
       setStatus({
         available: false,
-        message: t("segmentation.status.unavailable"),
+        // Desktop users get the "Start server" button below, so point them at
+        // it; web users have no such button, so tell them the feature needs the
+        // desktop app rather than an action they cannot take.
+        message: isTauri()
+          ? t("segmentation.status.unavailableDesktop")
+          : t("segmentation.status.unavailableWeb"),
       });
     } finally {
       setChecking(false);

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1320,10 +1320,13 @@
     "promptPlaceholder": "e.g. trees, buildings, water",
     "confidenceLabel": "Confidence threshold",
     "segment": "Segment",
+    "status": {
+      "checking": "Checking the AI segmentation service…",
+      "unavailable": "The AI segmentation service is not running yet. Start the GeoLibre server with segment-geospatial enabled to use it."
+    },
     "error": {
       "chooseImage": "Choose an image (GeoTIFF) to segment.",
       "enterPrompt": "Enter a text prompt, e.g. “trees” or “buildings”.",
-      "sidecarUnreachable": "Could not reach the GeoLibre sidecar.",
       "startServer": "Could not start GeoLibre sidecar.",
       "failed": "Segmentation failed."
     },

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1322,7 +1322,8 @@
     "segment": "Segment",
     "status": {
       "checking": "Checking the AI segmentation service…",
-      "unavailable": "The AI segmentation service is not running yet. On the desktop app, start the GeoLibre server with segment-geospatial enabled to use it."
+      "unavailableDesktop": "The AI segmentation service is not running yet. Start the GeoLibre server with segment-geospatial enabled to use it.",
+      "unavailableWeb": "AI segmentation isn't available in the browser. Use the GeoLibre desktop app to run it."
     },
     "error": {
       "chooseImage": "Choose an image (GeoTIFF) to segment.",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1322,7 +1322,7 @@
     "segment": "Segment",
     "status": {
       "checking": "Checking the AI segmentation service…",
-      "unavailable": "The AI segmentation service is not running yet. Start the GeoLibre server with segment-geospatial enabled to use it."
+      "unavailable": "The AI segmentation service is not running yet. On the desktop app, start the GeoLibre server with segment-geospatial enabled to use it."
     },
     "error": {
       "chooseImage": "Choose an image (GeoTIFF) to segment.",


### PR DESCRIPTION
## Summary

Opening the **AI Segmentation** dialog immediately showed a prominent red error box reading **"Segmentation status failed: HTTP 404"** on a completely blank form, before any user interaction. The dialog runs a status probe on open, and any failure (the sidecar not started, or no segmentation backend behind the same-origin `/sidecar` proxy on the hosted web build) was surfaced as the raw thrown error in a destructive style. This gives the false impression that the AI infrastructure is offline or broken.

A failed probe is an expected "not set up yet" state, not a system failure.

## Changes

- `checkStatus` no longer surfaces the raw `err.message` (e.g. `HTTP 404` or a verbose connection URL). On any probe failure it shows neutral, actionable guidance instead.
- The status box is downgraded from a destructive red alert to a muted, informational notice (Info icon) so it reads as guidance, not a failure.
- Added a brief "Checking the AI segmentation service…" indicator while the probe is in flight.
- Removed the now-unused `segmentation.error.sidecarUnreachable` string and added `segmentation.status.checking` / `segmentation.status.unavailable`.

The success path and the genuine run/start error reporting (which remain destructive-styled, correctly) are untouched.

## Verification

Reproduced the exact `HTTP 404` in the running web app by pointing the dialog at a local server returning 404 for `/ml/status`, then confirmed the fix with Playwright in both **dark and light** themes: the raw HTTP error is gone, replaced by the muted notice. `npm run` typecheck, the i18n catalog tests, and `pre-commit` (eslint + npm build) all pass.

Fixes #545

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Improved AI segmentation service availability probing by showing a loading indicator while checking.
  * Updated unavailable-service messaging to use a neutral “unavailable” status rather than exposing raw probe errors.
  * Adjusted the UI guidance styling for the sidecar-not-available state to be less alarming.
* **Documentation**
  * Updated English UI strings to include new checking/unavailable status messages for segmentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->