### PR TITLE
fix(streetview): surface credential errors and guard premature map clicks (#562, #563)

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -71,7 +71,7 @@
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-planetary-computer": "^0.3.0",
     "maplibre-gl-raster": "^0.5.0",
-    "maplibre-gl-streetview": "^0.6.0",
+    "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.7.1",
     "maplibre-gl-time-slider": "^1.0.3",
     "maplibre-gl-usgs-lidar": "^0.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,7 @@
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
         "maplibre-gl-raster": "^0.5.0",
-        "maplibre-gl-streetview": "^0.6.0",
+        "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.7.1",
         "maplibre-gl-time-slider": "^1.0.3",
         "maplibre-gl-usgs-lidar": "^0.11.0",
@@ -17869,9 +17869,9 @@
       "license": "MIT"
     },
     "node_modules/maplibre-gl-streetview": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-streetview/-/maplibre-gl-streetview-0.6.0.tgz",
-      "integrity": "sha512-hDJFbtD75J8sN5/PPGm1HCRhhhV3H7Uw1rqMEgtQJPq9JAApPScjEeHJtuoZNFLzNkaxBcWVEJSDjq4ig2Wlrg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-streetview/-/maplibre-gl-streetview-0.7.0.tgz",
+      "integrity": "sha512-lGjLiMD0AhcBybeZwzIcBAxFP49yeobsFf/ez8I8KnxUOgQ/ZUv4EOtrMcpbku+VKc8lWCIiv1potfGQ1Ts3eg==",
       "license": "MIT",
       "dependencies": {
         "mapillary-js": "^4.1.2"
@@ -24308,7 +24308,7 @@
         "maplibre-gl-overture-maps": "^0.3.0",
         "maplibre-gl-planetary-computer": "^0.3.0",
         "maplibre-gl-raster": "^0.5.0",
-        "maplibre-gl-streetview": "^0.6.0",
+        "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.7.1",
         "maplibre-gl-time-slider": "^1.0.3",
         "maplibre-gl-usgs-lidar": "^0.11.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -46,7 +46,7 @@
     "maplibre-gl-overture-maps": "^0.3.0",
     "maplibre-gl-planetary-computer": "^0.3.0",
     "maplibre-gl-raster": "^0.5.0",
-    "maplibre-gl-streetview": "^0.6.0",
+    "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.7.1",
     "maplibre-gl-time-slider": "^1.0.3",
     "maplibre-gl-usgs-lidar": "^0.11.0",


### PR DESCRIPTION
## Summary

Fixes two credential-handling issues in the Street View plugin by bumping `maplibre-gl-streetview` to **0.7.0** (which carries the actual fix, released from opengeos/maplibre-gl-streetview#14):

- **Fixes #563** — An invalid Mapillary token (or rejected Google key) was caught and reported as **"No Street View Coverage,"** so users assumed the imagery did not exist rather than that their credentials were wrong. The plugin now shows an **"Authentication failed"** card with an *Open Keys* shortcut. Note Mapillary's Graph API returns **HTTP 400 with an `OAuthException`** for a bad token (not 401/403), so the upstream fix classifies auth failures by the response body, not just the status code.
- **Fixes #562** — With no provider configured, the panel showed "Click anywhere on the map," and clicking dead-ended in a generic error. The panel now shows a **setup-required card** ("API key required" + *Add API key*) and guards map clicks so they no longer trigger a guaranteed-to-fail request.

## Changes

- `maplibre-gl-streetview`: `^0.6.0` → `^0.7.0` in `apps/geolibre-desktop/package.json` and `packages/plugins/package.json`, plus `package-lock.json`.

No GeoLibre-side wiring changes are needed; the new behavior is internal to the control and the existing `showApiKeyInputs` Keys tab provides the credential-entry surface.

## Testing

- `npm run build` and `pre-commit run --files` pass.
- Verified end to end in the running app (Playwright) in both light and dark themes, using the published 0.7.0 package:
  - Activate Street View with no key → setup card "API key required"; clicking the map keeps the setup card (no dead-end); *Add API key* opens the Keys panel.
  - Enter an invalid Mapillary token → click the map → "Authentication failed — Your Mapillary access token was rejected (HTTP 400). Open the Keys tab to update it." with a working *Open Keys* button.

> The issue also notes that the Street View plugin stores credentials in its own Keys tab rather than the central GeoLibre Settings page. Unifying credential storage across plugins is a larger change and is intentionally out of scope for this fix.
