### PR TITLE
feat(processing): add sequential route (directions) network tool

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ProcessingMenu.tsx
@@ -1,4 +1,4 @@
-import { useAppStore } from "@geolibre/core";
+import { type NetworkToolKind, useAppStore } from "@geolibre/core";
 import {
   Button,
   DropdownMenu,
@@ -23,7 +23,7 @@ import type { ToolbarChrome } from "./constants";
 interface ProcessingMenuProps {
   chrome: ToolbarChrome;
   earthEnginePanel: ToolbarPanel;
-  onOpenNetworkTool: (kind: "isochrone" | "od-matrix") => void;
+  onOpenNetworkTool: (kind: NetworkToolKind) => void;
   onOpenPlanetaryComputer: () => void;
   onOpenGeoreferencer: () => void;
 }
@@ -278,6 +278,11 @@ export function ProcessingMenu({
             </DropdownMenuItem>
             <DropdownMenuItem onSelect={() => onOpenNetworkTool("od-matrix")}>
               {t("toolbar.networkTool.odMatrix")}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() => onOpenNetworkTool("sequential-route")}
+            >
+              {t("toolbar.networkTool.sequentialRoute")}
             </DropdownMenuItem>
           </DropdownMenuSubContent>
         </DropdownMenuSub>

--- a/apps/geolibre-desktop/src/components/processing/NetworkToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/NetworkToolsDialog.tsx
@@ -3,6 +3,7 @@ import { detectGeometryProfile, type MapController } from "@geolibre/map";
 import {
   NETWORK_TOOLS,
   getNetworkTool,
+  type AlgorithmParameter,
   type GeometryFamily,
   type ProcessingContext,
 } from "@geolibre/processing";
@@ -112,6 +113,36 @@ export function NetworkToolsDialog({
     [layers],
   );
 
+  // Attribute-field names per layer, memoized on the layer set (and the dialog
+  // being open). GeoJSON is schemaless, so sample the first FIELD_SCAN_SAMPLE
+  // features rather than scanning a whole large layer on the React commit path.
+  const fieldsByLayer = useMemo(() => {
+    const FIELD_SCAN_SAMPLE = 1000;
+    const map = new Map<string, string[]>();
+    if (!open) return map;
+    for (const layer of layers) {
+      if (layer.type !== "geojson" || !layer.geojson) continue;
+      const keys = new Set<string>();
+      for (const feature of layer.geojson.features.slice(0, FIELD_SCAN_SAMPLE)) {
+        for (const key of Object.keys(feature.properties ?? {})) keys.add(key);
+      }
+      map.set(layer.id, [...keys]);
+    }
+    return map;
+  }, [layers, open]);
+
+  // Attribute-field options for a `type: "field"` parameter, read from the layer
+  // chosen in its `fieldSource` parameter (default "layer").
+  const fieldOptions = useCallback(
+    (param: AlgorithmParameter): string[] => {
+      const sourceId = params[param.fieldSource ?? "layer"] as
+        | string
+        | undefined;
+      return (sourceId && fieldsByLayer.get(sourceId)) || [];
+    },
+    [fieldsByLayer, params],
+  );
+
   const addResultLayer = useCallback(
     (name: string, fc: FeatureCollection) => {
       if (!fc.features.length) {
@@ -127,9 +158,23 @@ export function NetworkToolsDialog({
     [addGeoJsonLayer, appendLog, mapControllerRef],
   );
 
-  const handleParamChange = useCallback((id: string, value: unknown) => {
-    setParams((prev) => ({ ...prev, [id]: value }));
-  }, []);
+  // Update a parameter. When a layer parameter changes, also clear any
+  // `type: "field"` parameter that draws its options from it, so the field
+  // dropdown never keeps a value from the previous layer.
+  const handleParamChange = useCallback(
+    (id: string, value: unknown) => {
+      setParams((prev) => {
+        const next = { ...prev, [id]: value };
+        for (const param of tool.parameters) {
+          if (param.type === "field" && (param.fieldSource ?? "layer") === id) {
+            next[param.id] = undefined;
+          }
+        }
+        return next;
+      });
+    },
+    [tool],
+  );
 
   const handleRun = useCallback(async () => {
     setLog([]);
@@ -225,6 +270,9 @@ export function NetworkToolsDialog({
                   param={param}
                   value={params[param.id]}
                   layerOptions={layerOptions(param.geometryFilter)}
+                  fieldOptions={
+                    param.type === "field" ? fieldOptions(param) : undefined
+                  }
                   onChange={(value) => handleParamChange(param.id, value)}
                 />
               ))}

--- a/apps/geolibre-desktop/src/hooks/useConsentGatedActions.ts
+++ b/apps/geolibre-desktop/src/hooks/useConsentGatedActions.ts
@@ -1,4 +1,4 @@
-import { useAppStore } from "@geolibre/core";
+import { type NetworkToolKind, useAppStore } from "@geolibre/core";
 import {
   DIRECTIONS_PLUGIN_ID,
   REVERSE_GEOCODE_PLUGIN_ID,
@@ -34,9 +34,8 @@ export function useConsentGatedActions({
   const [reverseGeocodeNoticeOpen, setReverseGeocodeNoticeOpen] =
     useState(false);
   const [routingNoticeOpen, setRoutingNoticeOpen] = useState(false);
-  const [pendingNetworkTool, setPendingNetworkTool] = useState<
-    "isochrone" | "od-matrix" | null
-  >(null);
+  const [pendingNetworkTool, setPendingNetworkTool] =
+    useState<NetworkToolKind | null>(null);
 
   // Show a one-time consent notice the first time routing is enabled, since it
   // sends the user's waypoints to a public third-party server.
@@ -86,7 +85,7 @@ export function useConsentGatedActions({
   // Network analysis tools send the coordinates of the input points to a public
   // Valhalla routing server, so they show the same one-time consent notice as
   // Directions before opening, gated on every activation path (each menu item).
-  const openNetworkTool = (kind: "isochrone" | "od-matrix") => {
+  const openNetworkTool = (kind: NetworkToolKind) => {
     if (hasRoutingConsent()) {
       setNetworkToolOpen(kind);
       return;

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -838,7 +838,8 @@
     },
     "networkTool": {
       "isochrone": "Isochrone / service area",
-      "odMatrix": "OD cost matrix"
+      "odMatrix": "OD cost matrix",
+      "sequentialRoute": "Sequential route (directions)"
     },
     "statisticsTool": {
       "globalMoransI": "Global Moran's I",
@@ -1009,7 +1010,7 @@
       "reverseGeocodeNoticeTitle": "Reverse Geocode uses an external service",
       "reverseGeocodeNoticeDesc": "Turning on Reverse Geocode sends the coordinates of each point you click to the configured geocoding provider (the public Nominatim service by default) to resolve an address — your coordinates leave your device for those requests. You can choose a different provider in Settings → Geocoding.",
       "networkNoticeTitle": "Network analysis uses a public routing server",
-      "networkNoticeDesc": "Running a Network analysis tool sends the coordinates of your input points to the public Valhalla routing server (valhalla1.openstreetmap.de) to compute isochrones and cost matrices — your coordinates leave your device for those requests. The public server is rate-limited; point it at your own server (Settings → Environment Variables, VITE_ROUTING_ENDPOINT) for heavy use.",
+      "networkNoticeDesc": "Running a Network analysis tool sends the coordinates of your input points to the public Valhalla routing server (valhalla1.openstreetmap.de) to compute isochrones, cost matrices, and routes. Your coordinates leave your device for those requests. The public server is rate-limited; point it at your own server (Settings → Environment Variables, VITE_ROUTING_ENDPOINT) for heavy use.",
       "continue": "Continue",
       "largeOsmPbfTitle": "Large OSM PBF file",
       "largeOsmPbfDesc": "This file is about {{sizeMb}} MB. Parsing it converts every feature to GeoJSON in memory, which can be slow and may use a lot of memory in the browser. Continue?",

--- a/packages/core/src/routing.ts
+++ b/packages/core/src/routing.ts
@@ -241,6 +241,172 @@ export function matrixResponseToFeatures(
   return out;
 }
 
+export interface RouteRequestBody {
+  locations: { lon: number; lat: number }[];
+  costing: RoutingMode;
+  directions_options: { units: "kilometers" };
+}
+
+/**
+ * Builds a Valhalla `/route` request body that visits the points in the given
+ * order. Valhalla snaps each location to the nearest routable edge, so points
+ * that are off the road network (cell sites, sensors) still route cleanly.
+ *
+ * @param points - The waypoints in visiting order (at least two).
+ * @param mode - The travel mode (costing model).
+ * @returns The request body.
+ */
+export function buildRouteRequest(
+  points: RoutingPoint[],
+  mode: RoutingMode,
+): RouteRequestBody {
+  return {
+    locations: points.map((p) => ({ lon: p.lon, lat: p.lat })),
+    costing: mode,
+    directions_options: { units: "kilometers" },
+  };
+}
+
+/**
+ * Decodes an encoded-polyline string into `[lon, lat]` coordinate pairs.
+ * Valhalla encodes route geometry with 6 digits of precision (factor 1e6),
+ * unlike Google's 5-digit polylines, so `precision` defaults to 6.
+ *
+ * @param encoded - The encoded polyline string.
+ * @param precision - Number of decimal digits the encoder used (6 for Valhalla).
+ * @returns The decoded `[lon, lat]` coordinates in order.
+ */
+export function decodePolyline(
+  encoded: string,
+  precision = 6,
+): [number, number][] {
+  const factor = 10 ** precision;
+  const coordinates: [number, number][] = [];
+  let index = 0;
+  let lat = 0;
+  let lon = 0;
+  while (index < encoded.length) {
+    let shift = 0;
+    let result = 0;
+    let byte: number;
+    do {
+      byte = encoded.charCodeAt(index++) - 63;
+      result |= (byte & 0x1f) << shift;
+      shift += 5;
+    } while (byte >= 0x20);
+    lat += result & 1 ? ~(result >> 1) : result >> 1;
+
+    shift = 0;
+    result = 0;
+    do {
+      byte = encoded.charCodeAt(index++) - 63;
+      result |= (byte & 0x1f) << shift;
+      shift += 5;
+    } while (byte >= 0x20);
+    lon += result & 1 ? ~(result >> 1) : result >> 1;
+
+    coordinates.push([lon / factor, lat / factor]);
+  }
+  return coordinates;
+}
+
+type RouteLeg = {
+  shape?: string;
+  summary?: { time?: number; length?: number };
+};
+
+type RouteFeatureProps = {
+  leg_index: number;
+  from_id: string | number;
+  to_id: string | number;
+  time_s: number;
+  distance_km: number;
+  mode: RoutingMode;
+};
+
+/**
+ * Converts a Valhalla `/route` response into one LineString per leg (the road
+ * path between two consecutive waypoints), carrying the leg's travel time and
+ * distance. Legs without a decodable shape are dropped.
+ *
+ * @param response - The Valhalla `/route` response.
+ * @param points - The waypoints passed to the request, indexing the legs.
+ * @param ctx - The travel mode to tag onto each leg.
+ * @returns One LineString feature per routed leg.
+ */
+export function routeResponseToFeatures(
+  response: unknown,
+  points: RoutingPoint[],
+  ctx: { mode: RoutingMode },
+): Feature<LineString, RouteFeatureProps>[] {
+  const legs = (response as { trip?: { legs?: RouteLeg[] } } | null)?.trip?.legs;
+  if (!Array.isArray(legs)) return [];
+  const out: Feature<LineString, RouteFeatureProps>[] = [];
+  legs.forEach((leg, index) => {
+    if (typeof leg?.shape !== "string") return;
+    const coordinates = decodePolyline(leg.shape);
+    if (coordinates.length < 2) return;
+    const from = points[index];
+    const to = points[index + 1];
+    out.push({
+      type: "Feature",
+      geometry: { type: "LineString", coordinates },
+      properties: {
+        leg_index: index,
+        from_id: from?.id ?? index,
+        to_id: to?.id ?? index + 1,
+        time_s: typeof leg.summary?.time === "number" ? leg.summary.time : 0,
+        distance_km:
+          typeof leg.summary?.length === "number" ? leg.summary.length : 0,
+        mode: ctx.mode,
+      },
+    });
+  });
+  return out;
+}
+
+/**
+ * Comparator for ordering route waypoints by a chosen attribute value. Numeric
+ * strings and timestamps (anything `Date.parse` understands, e.g. ISO 8601)
+ * sort chronologically/numerically; values that parse this way sort before
+ * free-form text, which falls back to a locale string comparison. Empty/missing
+ * values sort last so unlabeled points trail the ordered ones.
+ *
+ * @param a - The first value.
+ * @param b - The second value.
+ * @returns A negative, zero, or positive number for ascending order.
+ */
+export function compareSequenceValues(a: unknown, b: unknown): number {
+  const aMissing = isMissingValue(a);
+  const bMissing = isMissingValue(b);
+  if (aMissing && bMissing) return 0;
+  if (aMissing) return 1;
+  if (bMissing) return -1;
+  const an = toComparableNumber(a);
+  const bn = toComparableNumber(b);
+  if (an !== null && bn !== null) return an - bn;
+  if (an !== null) return -1;
+  if (bn !== null) return 1;
+  return String(a).localeCompare(String(b));
+}
+
+function isMissingValue(value: unknown): boolean {
+  return value == null || (typeof value === "string" && value.trim() === "");
+}
+
+function toComparableNumber(value: unknown): number | null {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed === "") return null;
+    const num = Number(trimmed);
+    if (Number.isFinite(num)) return num;
+    const parsed = Date.parse(trimmed);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
 async function postJson(
   url: string,
   body: unknown,
@@ -294,4 +460,20 @@ export function requestMatrix(
     body,
     signal,
   );
+}
+
+/**
+ * Requests a route through ordered waypoints from the Valhalla server.
+ *
+ * @param endpoint - The Valhalla base URL.
+ * @param body - The request body from {@link buildRouteRequest}.
+ * @param signal - Optional abort signal.
+ * @returns The Valhalla `/route` response.
+ */
+export function requestRoute(
+  endpoint: string,
+  body: RouteRequestBody,
+  signal?: AbortSignal,
+): Promise<unknown> {
+  return postJson(`${stripTrailingSlash(endpoint)}/route`, body, signal);
 }

--- a/packages/core/src/routing.ts
+++ b/packages/core/src/routing.ts
@@ -405,8 +405,12 @@ function toComparableNumber(value: unknown): number | null {
   if (typeof value === "string") {
     const trimmed = value.trim();
     if (trimmed === "") return null;
-    const num = Number(trimmed);
-    if (Number.isFinite(num)) return num;
+    // Only treat plain decimal/scientific notation as numeric, so hex ("0x1A")
+    // and other Number()-coercible forms sort as text rather than by their
+    // surprising numeric value.
+    if (/^[+-]?\d+(\.\d+)?([eE][+-]?\d+)?$/.test(trimmed)) {
+      return Number(trimmed);
+    }
     const parsed = Date.parse(trimmed);
     if (Number.isFinite(parsed)) return parsed;
   }

--- a/packages/core/src/routing.ts
+++ b/packages/core/src/routing.ts
@@ -298,7 +298,9 @@ export function decodePolyline(
       result |= (byte & 0x1f) << shift;
       shift += 5;
     } while (byte >= 0x20);
-    lat += result & 1 ? ~(result >> 1) : result >> 1;
+    // Unsigned shift (>>>) so the zigzag decode is correct even if the
+    // accumulator's bit 31 is set, rather than sign-extending.
+    lat += result & 1 ? ~(result >>> 1) : result >>> 1;
 
     shift = 0;
     result = 0;
@@ -308,7 +310,7 @@ export function decodePolyline(
       result |= (byte & 0x1f) << shift;
       shift += 5;
     } while (byte >= 0x20);
-    lon += result & 1 ? ~(result >> 1) : result >> 1;
+    lon += result & 1 ? ~(result >>> 1) : result >>> 1;
 
     coordinates.push([lon / factor, lat / factor]);
   }

--- a/packages/core/src/routing.ts
+++ b/packages/core/src/routing.ts
@@ -372,6 +372,12 @@ export function routeResponseToFeatures(
  * free-form text, which falls back to a locale string comparison. Empty/missing
  * values sort last so unlabeled points trail the ordered ones.
  *
+ * Numeric parsing is tried before date parsing, so a single column is expected
+ * to use one convention: a column mixing plain integers with ISO timestamps
+ * would compare them on the same numeric axis (epoch millis dwarf small
+ * integers), which is not a meaningful ordering. Real sequence/time columns use
+ * one convention, so this is acceptable in practice.
+ *
  * @param a - The first value.
  * @param b - The second value.
  * @returns A negative, zero, or positive number for ascending order.

--- a/packages/core/src/routing.ts
+++ b/packages/core/src/routing.ts
@@ -281,15 +281,19 @@ export function decodePolyline(
   precision = 6,
 ): [number, number][] {
   const factor = 10 ** precision;
+  const len = encoded.length;
   const coordinates: [number, number][] = [];
   let index = 0;
   let lat = 0;
   let lon = 0;
-  while (index < encoded.length) {
+  while (index < len) {
     let shift = 0;
     let result = 0;
     let byte: number;
     do {
+      // Truncated input: stop cleanly rather than reading NaN past the end and
+      // pushing a garbage coordinate.
+      if (index >= len) return coordinates;
       byte = encoded.charCodeAt(index++) - 63;
       result |= (byte & 0x1f) << shift;
       shift += 5;
@@ -299,6 +303,7 @@ export function decodePolyline(
     shift = 0;
     result = 0;
     do {
+      if (index >= len) return coordinates;
       byte = encoded.charCodeAt(index++) - 63;
       result |= (byte & 0x1f) << shift;
       shift += 5;
@@ -417,6 +422,21 @@ function toComparableNumber(value: unknown): number | null {
   return null;
 }
 
+/**
+ * Error thrown when a Valhalla request returns a non-2xx response. Carries the
+ * HTTP status so callers can branch on it (e.g. a 4xx rejection) without
+ * pattern-matching the message string.
+ */
+export class RoutingRequestError extends Error {
+  readonly status: number;
+
+  constructor(status: number, statusText: string) {
+    super(`Routing request failed (${status} ${statusText})`);
+    this.name = "RoutingRequestError";
+    this.status = status;
+  }
+}
+
 async function postJson(
   url: string,
   body: unknown,
@@ -429,9 +449,7 @@ async function postJson(
     signal,
   });
   if (!response.ok) {
-    throw new Error(
-      `Routing request failed (${response.status} ${response.statusText})`,
-    );
+    throw new RoutingRequestError(response.status, response.statusText);
   }
   return response.json();
 }

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -87,7 +87,7 @@ export type VectorToolKind =
   | "h3-bin-points";
 
 /** Identifiers of the network-analysis tools (`NETWORK_TOOLS` ids). */
-export type NetworkToolKind = "isochrone" | "od-matrix";
+export type NetworkToolKind = "isochrone" | "od-matrix" | "sequential-route";
 
 /** Identifiers of the spatial-statistics tools (`STATISTICS_TOOLS` ids). */
 export type StatisticsToolKind =

--- a/packages/processing/src/index.ts
+++ b/packages/processing/src/index.ts
@@ -13,7 +13,11 @@ export {
   type ModelStepResult,
   type RunModelOptions,
 } from "./runner";
-export { NETWORK_TOOLS, getNetworkTool } from "./network-tools";
+export {
+  NETWORK_TOOLS,
+  getNetworkTool,
+  layerToSequencedPoints,
+} from "./network-tools";
 export {
   STATISTICS_TOOLS,
   getStatisticsTool,

--- a/packages/processing/src/network-tools.ts
+++ b/packages/processing/src/network-tools.ts
@@ -7,6 +7,7 @@ import {
   type RoutingPoint,
   buildIsochroneRequest,
   buildMatrixRequest,
+  RoutingRequestError,
   buildRouteRequest,
   compareSequenceValues,
   getRoutingConfig,
@@ -406,11 +407,14 @@ export const sequentialRouteTool: ProcessingAlgorithm = {
     } catch (error) {
       if (ctx.signal?.aborted) return;
       const message = error instanceof Error ? error.message : String(error);
-      // A 4xx from postJson ("Routing request failed (4xx …)") means the server
-      // rejected the request (most often "Exceeded max locations"); point the
-      // user at the actionable fix. Matching the request-failed prefix avoids
-      // false-positiving on a stray number in a network-level error message.
-      const hint = /request failed \(4\d\d/.test(message)
+      // A 4xx means the server rejected the request (most often "Exceeded max
+      // locations"); point the user at the actionable fix. The typed status
+      // avoids depending on the wording of the error message.
+      const isClientError =
+        error instanceof RoutingRequestError &&
+        error.status >= 400 &&
+        error.status < 500;
+      const hint = isClientError
         ? " The routing server rejected the request — reduce the number of points or use your own server (Settings → Environment Variables, VITE_ROUTING_ENDPOINT)."
         : "";
       ctx.log(`Routing failed: ${message}.${hint}`);

--- a/packages/processing/src/network-tools.ts
+++ b/packages/processing/src/network-tools.ts
@@ -376,7 +376,7 @@ export const sequentialRouteTool: ProcessingAlgorithm = {
     const used = points.slice(0, MAX_ROUTE_POINTS);
     if (points.length > used.length) {
       ctx.log(
-        `Using the first ${used.length} of ${points.length} points (server-load cap).`,
+        `Using the first ${used.length} of ${points.length} points (server limit: ${MAX_ROUTE_POINTS} locations per request).`,
       );
     }
     const mode = (ctx.parameters.mode as RoutingMode) || "auto";
@@ -406,10 +406,12 @@ export const sequentialRouteTool: ProcessingAlgorithm = {
     } catch (error) {
       if (ctx.signal?.aborted) return;
       const message = error instanceof Error ? error.message : String(error);
-      // A 4xx usually means the public server rejected the request (most often
-      // "Exceeded max locations"); point the user at the actionable fix.
-      const hint = /\b4\d\d\b/.test(message)
-        ? " The routing server may have rejected the request — reduce the number of points or use your own server (Settings → Environment Variables, VITE_ROUTING_ENDPOINT)."
+      // A 4xx from postJson ("Routing request failed (4xx …)") means the server
+      // rejected the request (most often "Exceeded max locations"); point the
+      // user at the actionable fix. Matching the request-failed prefix avoids
+      // false-positiving on a stray number in a network-level error message.
+      const hint = /request failed \(4\d\d/.test(message)
+        ? " The routing server rejected the request — reduce the number of points or use your own server (Settings → Environment Variables, VITE_ROUTING_ENDPOINT)."
         : "";
       ctx.log(`Routing failed: ${message}.${hint}`);
     }

--- a/packages/processing/src/network-tools.ts
+++ b/packages/processing/src/network-tools.ts
@@ -7,12 +7,16 @@ import {
   type RoutingPoint,
   buildIsochroneRequest,
   buildMatrixRequest,
+  buildRouteRequest,
+  compareSequenceValues,
   getRoutingConfig,
   isochroneResponseToFeatures,
   matrixResponseToFeatures,
   parseContours,
   requestIsochrone,
   requestMatrix,
+  requestRoute,
+  routeResponseToFeatures,
 } from "@geolibre/core";
 import type { ProcessingAlgorithm, ProcessingContext } from "./types";
 
@@ -29,6 +33,9 @@ const MAX_ISOCHRONE_POINTS = 25;
 const MAX_ISOCHRONE_CONTOURS = 4;
 /** Cap on OD matrix cells (origins × destinations) per run. */
 const MAX_MATRIX_CELLS = 2500;
+/** Cap on waypoints per sequential route, to stay within the public server's
+ *  per-request location limit and avoid overloading it. */
+const MAX_ROUTE_POINTS = 50;
 
 const MODE_OPTIONS = [
   { value: "auto", label: "Driving" },
@@ -44,6 +51,22 @@ function getLayer(
   return ctx.layers.find((layer) => layer.id === layerId);
 }
 
+/** Derives a stable point id from the feature id, an `id`/`name` property, or
+ *  the feature index. */
+function pointId(
+  feature: Feature,
+  index: number,
+): string | number {
+  const props = feature.properties ?? {};
+  return (
+    (feature.id as string | number | undefined) ??
+    (props.id as string | number | undefined) ??
+    (props.ID as string | number | undefined) ??
+    (props.name as string | undefined) ??
+    index
+  );
+}
+
 /**
  * Extracts routing points from a layer's Point features, deriving a stable id
  * from the feature id, an `id`/`name` property, or the feature index. Non-point
@@ -56,16 +79,42 @@ function layerToRoutingPoints(layer: GeoLibreLayer | undefined): RoutingPoint[] 
     if (feature.geometry?.type !== "Point") return;
     const [lon, lat] = (feature.geometry as Point).coordinates;
     if (!Number.isFinite(lon) || !Number.isFinite(lat)) return;
-    const props = feature.properties ?? {};
-    const id =
-      (feature.id as string | number | undefined) ??
-      (props.id as string | number | undefined) ??
-      (props.ID as string | number | undefined) ??
-      (props.name as string | undefined) ??
-      index;
-    points.push({ id, lon, lat });
+    points.push({ id: pointId(feature, index), lon, lat });
   });
   return points;
+}
+
+/**
+ * Extracts routing points in visiting order. With no `orderField`, points keep
+ * the layer's feature order. With an `orderField`, points are sorted by that
+ * attribute (numbers or timestamps sort chronologically; see
+ * {@link compareSequenceValues}), keeping feature order as a stable tiebreaker.
+ * Non-point geometries are skipped.
+ */
+function layerToSequencedPoints(
+  layer: GeoLibreLayer | undefined,
+  orderField: string,
+): RoutingPoint[] {
+  const features = layer?.geojson?.features ?? [];
+  const entries: { point: RoutingPoint; order: unknown; index: number }[] = [];
+  features.forEach((feature, index) => {
+    if (feature.geometry?.type !== "Point") return;
+    const [lon, lat] = (feature.geometry as Point).coordinates;
+    if (!Number.isFinite(lon) || !Number.isFinite(lat)) return;
+    const props = feature.properties ?? {};
+    entries.push({
+      point: { id: pointId(feature, index), lon, lat },
+      order: orderField ? props[orderField] : index,
+      index,
+    });
+  });
+  if (orderField) {
+    entries.sort((a, b) => {
+      const cmp = compareSequenceValues(a.order, b.order);
+      return cmp !== 0 ? cmp : a.index - b.index;
+    });
+  }
+  return entries.map((entry) => entry.point);
 }
 
 function resolveEndpoint(ctx: ProcessingContext): string {
@@ -276,7 +325,99 @@ export const odMatrixTool: ProcessingAlgorithm = {
   },
 };
 
-export const NETWORK_TOOLS: ProcessingAlgorithm[] = [isochroneTool, odMatrixTool];
+export const sequentialRouteTool: ProcessingAlgorithm = {
+  id: "sequential-route",
+  name: "Sequential route (directions)",
+  description:
+    "Connect points in sequence along the road network into a route. Each point is snapped to the nearest road, so off-road coordinates (cell sites, sensors) still route. Order follows the chosen field (e.g. a timestamp) or the layer's feature order.",
+  group: "Network",
+  parameters: [
+    {
+      id: "layer",
+      label: "Input points",
+      type: "layer",
+      required: true,
+      geometryFilter: ["point"],
+    },
+    {
+      id: "order_field",
+      label: "Order by field (optional)",
+      type: "field",
+      fieldSource: "layer",
+      description:
+        "Sort points by this field (numbers or timestamps) before routing. Leave empty to use the layer's feature order.",
+    },
+    {
+      id: "mode",
+      label: "Travel mode",
+      type: "select",
+      default: "auto",
+      options: MODE_OPTIONS,
+    },
+    {
+      id: "endpoint",
+      label: "Routing server (Valhalla)",
+      type: "string",
+      // Left empty so the live routing config is resolved when the tool runs
+      // (or seeded by the dialog), not baked in at module-import time. See
+      // resolveEndpoint, which falls back to getRoutingConfig().endpoint.
+      default: "",
+    },
+  ],
+  run: async (ctx) => {
+    const orderField =
+      (ctx.parameters.order_field as string | undefined)?.trim() || "";
+    const points = layerToSequencedPoints(getLayer(ctx, "layer"), orderField);
+    if (points.length < 2) {
+      ctx.log("Error: at least two point features are required to build a route");
+      return;
+    }
+    const used = points.slice(0, MAX_ROUTE_POINTS);
+    if (points.length > used.length) {
+      ctx.log(
+        `Using the first ${used.length} of ${points.length} points (server-load cap).`,
+      );
+    }
+    const mode = (ctx.parameters.mode as RoutingMode) || "auto";
+    const endpoint = resolveEndpoint(ctx);
+
+    try {
+      const response = await requestRoute(
+        endpoint,
+        buildRouteRequest(used, mode),
+        ctx.signal,
+      );
+      const features = routeResponseToFeatures(response, used, { mode });
+      if (!features.length) {
+        ctx.log(
+          "No route was returned. The points may be unroutable for this travel mode.",
+        );
+        return;
+      }
+      const totalKm = features.reduce(
+        (sum, feature) => sum + (feature.properties.distance_km || 0),
+        0,
+      );
+      ctx.log(
+        `Built a route through ${used.length} point(s): ${features.length} leg(s), ${totalKm.toFixed(2)} km total.`,
+      );
+      ctx.addResultLayer?.("Route", featureCollection(features));
+    } catch (error) {
+      if (ctx.signal?.aborted) return;
+      ctx.log(
+        `Routing failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  },
+};
+
+export const NETWORK_TOOLS: ProcessingAlgorithm[] = [
+  isochroneTool,
+  odMatrixTool,
+  sequentialRouteTool,
+];
 
 export function getNetworkTool(id: string): ProcessingAlgorithm | undefined {
   return NETWORK_TOOLS.find((tool) => tool.id === id);

--- a/packages/processing/src/network-tools.ts
+++ b/packages/processing/src/network-tools.ts
@@ -33,9 +33,10 @@ const MAX_ISOCHRONE_POINTS = 25;
 const MAX_ISOCHRONE_CONTOURS = 4;
 /** Cap on OD matrix cells (origins × destinations) per run. */
 const MAX_MATRIX_CELLS = 2500;
-/** Cap on waypoints per sequential route, to stay within the public server's
- *  per-request location limit and avoid overloading it. */
-const MAX_ROUTE_POINTS = 50;
+/** Cap on waypoints per sequential route. The public FOSSGIS server enforces
+ *  `max_locations: 20` on `/route` (error_code 150), so requests above this are
+ *  rejected outright; keep the cap at that limit and truncate with a log line. */
+const MAX_ROUTE_POINTS = 20;
 
 const MODE_OPTIONS = [
   { value: "auto", label: "Driving" },
@@ -395,7 +396,7 @@ export const sequentialRouteTool: ProcessingAlgorithm = {
         return;
       }
       const totalKm = features.reduce(
-        (sum, feature) => sum + (feature.properties.distance_km || 0),
+        (sum, feature) => sum + feature.properties.distance_km,
         0,
       );
       ctx.log(
@@ -404,11 +405,13 @@ export const sequentialRouteTool: ProcessingAlgorithm = {
       ctx.addResultLayer?.("Route", featureCollection(features));
     } catch (error) {
       if (ctx.signal?.aborted) return;
-      ctx.log(
-        `Routing failed: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
+      const message = error instanceof Error ? error.message : String(error);
+      // A 4xx usually means the public server rejected the request (most often
+      // "Exceeded max locations"); point the user at the actionable fix.
+      const hint = /\b4\d\d\b/.test(message)
+        ? " The routing server may have rejected the request — reduce the number of points or use your own server (Settings → Environment Variables, VITE_ROUTING_ENDPOINT)."
+        : "";
+      ctx.log(`Routing failed: ${message}.${hint}`);
     }
   },
 };

--- a/packages/processing/src/network-tools.ts
+++ b/packages/processing/src/network-tools.ts
@@ -93,7 +93,7 @@ function layerToRoutingPoints(layer: GeoLibreLayer | undefined): RoutingPoint[] 
  * {@link compareSequenceValues}), keeping feature order as a stable tiebreaker.
  * Non-point geometries are skipped.
  */
-function layerToSequencedPoints(
+export function layerToSequencedPoints(
   layer: GeoLibreLayer | undefined,
   orderField: string,
 ): RoutingPoint[] {

--- a/tests/network-tools.test.ts
+++ b/tests/network-tools.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { DEFAULT_LAYER_STYLE, type GeoLibreLayer } from "@geolibre/core";
+import { layerToSequencedPoints } from "@geolibre/processing";
+import type { Feature, FeatureCollection } from "geojson";
+
+function pointLayer(features: Feature[]): GeoLibreLayer {
+  return {
+    id: "layer-a",
+    name: "Points",
+    type: "geojson",
+    source: { type: "geojson" },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {},
+    geojson: { type: "FeatureCollection", features } as FeatureCollection,
+  };
+}
+
+function point(coords: [number, number], props: Record<string, unknown>): Feature {
+  return {
+    type: "Feature",
+    properties: props,
+    geometry: { type: "Point", coordinates: coords },
+  };
+}
+
+describe("layerToSequencedPoints", () => {
+  it("keeps feature order when no order field is given", () => {
+    const layer = pointLayer([
+      point([-77.05, 38.88], { name: "Lincoln" }),
+      point([-77.01, 38.89], { name: "Capitol" }),
+    ]);
+    const ids = layerToSequencedPoints(layer, "").map((p) => p.id);
+    assert.deepEqual(ids, ["Lincoln", "Capitol"]);
+  });
+
+  it("sorts by a timestamp field before routing", () => {
+    const layer = pointLayer([
+      point([-77.01, 38.89], { name: "Capitol", t: "2026-06-19T12:00:00Z" }),
+      point([-77.05, 38.88], { name: "Lincoln", t: "2026-06-19T09:00:00Z" }),
+      point([-77.03, 38.89], { name: "Monument", t: "2026-06-19T10:00:00Z" }),
+    ]);
+    const ids = layerToSequencedPoints(layer, "t").map((p) => p.id);
+    assert.deepEqual(ids, ["Lincoln", "Monument", "Capitol"]);
+  });
+
+  it("skips non-point and invalid-coordinate features", () => {
+    const layer = pointLayer([
+      point([-77.05, 38.88], { name: "ok" }),
+      {
+        type: "Feature",
+        properties: { name: "line" },
+        geometry: { type: "LineString", coordinates: [[0, 0], [1, 1]] },
+      },
+      point([Number.NaN, 38.9], { name: "bad-coord" }),
+    ]);
+    const ids = layerToSequencedPoints(layer, "").map((p) => p.id);
+    assert.deepEqual(ids, ["ok"]);
+  });
+
+  it("preserves feature order for equal order values (stable sort)", () => {
+    const layer = pointLayer([
+      point([-77.01, 38.89], { name: "first", seq: 1 }),
+      point([-77.02, 38.89], { name: "second", seq: 1 }),
+      point([-77.03, 38.89], { name: "third", seq: 0 }),
+    ]);
+    const ids = layerToSequencedPoints(layer, "seq").map((p) => p.id);
+    assert.deepEqual(ids, ["third", "first", "second"]);
+  });
+
+  it("falls back to the feature index as id when no id/name property exists", () => {
+    const layer = pointLayer([
+      point([-77.05, 38.88], {}),
+      point([-77.01, 38.89], {}),
+    ]);
+    const ids = layerToSequencedPoints(layer, "").map((p) => p.id);
+    assert.deepEqual(ids, [0, 1]);
+  });
+});

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -183,6 +183,15 @@ describe("decodePolyline", () => {
     ]);
   });
 
+  it("decodes a Valhalla precision-6 polyline at the default precision", () => {
+    // Encodes [[-77.05, 38.88], [-77.04, 38.89], [-77.02, 38.9]] at precision 6.
+    assert.deepEqual(decodePolyline("_o`diA~gw}qC_pR_pR_pR_af@"), [
+      [-77.05, 38.88],
+      [-77.04, 38.89],
+      [-77.02, 38.9],
+    ]);
+  });
+
   it("returns an empty array for an empty string", () => {
     assert.deepEqual(decodePolyline(""), []);
   });
@@ -248,6 +257,11 @@ describe("compareSequenceValues", () => {
     const values = ["zeta", "", "2", "10"];
     const sorted = [...values].sort(compareSequenceValues);
     assert.deepEqual(sorted, ["2", "10", "zeta", ""]);
+  });
+
+  it("treats hex strings as text, not their Number() value", () => {
+    // "0x1A" must not sort as 26; it is text, so it trails the numeric 5.
+    assert.ok(compareSequenceValues("0x1A", 5) > 0);
   });
 });
 

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -193,13 +193,14 @@ describe("routeResponseToFeatures", () => {
     { id: "p0", lon: 0, lat: 0 },
     { id: "p1", lon: 1, lat: 1 },
   ];
+  // A real Valhalla precision-6 polyline encoding the three [lon, lat] points
+  // [[-77.05, 38.88], [-77.04, 38.89], [-77.02, 38.9]], so the test asserts the
+  // decode runs at precision 6 (not Google's 5) and yields the right values.
   const response = {
     trip: {
       legs: [
         {
-          // precision-5 shape decoded here only to exercise the parser shape;
-          // length/time carry the leg cost.
-          shape: "_p~iF~ps|U_ulLnnqC",
+          shape: "_o`diA~gw}qC_pR_pR_pR_af@",
           summary: { time: 540, length: 8.2 },
         },
       ],
@@ -211,7 +212,11 @@ describe("routeResponseToFeatures", () => {
     assert.equal(features.length, 1);
     const [feature] = features;
     assert.equal(feature.geometry.type, "LineString");
-    assert.equal(feature.geometry.coordinates.length, 2);
+    assert.deepEqual(feature.geometry.coordinates, [
+      [-77.05, 38.88],
+      [-77.04, 38.89],
+      [-77.02, 38.9],
+    ]);
     assert.deepEqual(feature.properties, {
       leg_index: 0,
       from_id: "p0",

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -195,6 +195,14 @@ describe("decodePolyline", () => {
   it("returns an empty array for an empty string", () => {
     assert.deepEqual(decodePolyline(""), []);
   });
+
+  it("drops a truncated trailing chunk instead of emitting a garbage coord", () => {
+    // The full string above with its last coordinate cut off mid-chunk.
+    assert.deepEqual(decodePolyline("_o`diA~gw}qC_pR_pR_p"), [
+      [-77.05, 38.88],
+      [-77.04, 38.89],
+    ]);
+  });
 });
 
 describe("routeResponseToFeatures", () => {

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -4,10 +4,14 @@ import {
   DEFAULT_ROUTING_ENDPOINT,
   buildIsochroneRequest,
   buildMatrixRequest,
+  buildRouteRequest,
+  compareSequenceValues,
+  decodePolyline,
   getRoutingConfig,
   isochroneResponseToFeatures,
   matrixResponseToFeatures,
   parseContours,
+  routeResponseToFeatures,
   type RoutingPoint,
 } from "../packages/core/src/routing";
 
@@ -147,6 +151,98 @@ describe("matrixResponseToFeatures", () => {
       matrixResponseToFeatures({}, origins, targets, { mode: "auto" }),
       [],
     );
+  });
+});
+
+describe("buildRouteRequest", () => {
+  it("maps ordered points to Valhalla locations with km units", () => {
+    const points: RoutingPoint[] = [
+      { id: "a", lon: -83, lat: 40 },
+      { id: "b", lon: -82, lat: 41 },
+    ];
+    assert.deepEqual(buildRouteRequest(points, "pedestrian"), {
+      locations: [
+        { lon: -83, lat: 40 },
+        { lon: -82, lat: 41 },
+      ],
+      costing: "pedestrian",
+      directions_options: { units: "kilometers" },
+    });
+  });
+});
+
+describe("decodePolyline", () => {
+  it("decodes the canonical Google precision-5 example to [lon, lat] pairs", () => {
+    // Canonical example from Google's encoded-polyline algorithm docs:
+    // (38.5, -120.2), (40.7, -120.95), (43.252, -126.453).
+    const coords = decodePolyline("_p~iF~ps|U_ulLnnqC_mqNvxq`@", 5);
+    assert.deepEqual(coords, [
+      [-120.2, 38.5],
+      [-120.95, 40.7],
+      [-126.453, 43.252],
+    ]);
+  });
+
+  it("returns an empty array for an empty string", () => {
+    assert.deepEqual(decodePolyline(""), []);
+  });
+});
+
+describe("routeResponseToFeatures", () => {
+  const points: RoutingPoint[] = [
+    { id: "p0", lon: 0, lat: 0 },
+    { id: "p1", lon: 1, lat: 1 },
+  ];
+  const response = {
+    trip: {
+      legs: [
+        {
+          // precision-5 shape decoded here only to exercise the parser shape;
+          // length/time carry the leg cost.
+          shape: "_p~iF~ps|U_ulLnnqC",
+          summary: { time: 540, length: 8.2 },
+        },
+      ],
+    },
+  };
+
+  it("emits one LineString per leg with from/to ids and cost", () => {
+    const features = routeResponseToFeatures(response, points, { mode: "auto" });
+    assert.equal(features.length, 1);
+    const [feature] = features;
+    assert.equal(feature.geometry.type, "LineString");
+    assert.equal(feature.geometry.coordinates.length, 2);
+    assert.deepEqual(feature.properties, {
+      leg_index: 0,
+      from_id: "p0",
+      to_id: "p1",
+      time_s: 540,
+      distance_km: 8.2,
+      mode: "auto",
+    });
+  });
+
+  it("returns an empty array for a malformed response", () => {
+    assert.deepEqual(routeResponseToFeatures({}, points, { mode: "auto" }), []);
+  });
+});
+
+describe("compareSequenceValues", () => {
+  it("orders numeric and numeric-string values ascending", () => {
+    assert.ok(compareSequenceValues(1, 2) < 0);
+    assert.ok(compareSequenceValues("10", "2") > 0);
+  });
+
+  it("orders ISO timestamps chronologically", () => {
+    assert.ok(
+      compareSequenceValues("2026-01-02T00:00:00Z", "2026-01-01T00:00:00Z") > 0,
+    );
+  });
+
+  it("sorts parseable values before free-form text and empties last", () => {
+    const values = ["zeta", "", "2", "10"];
+    const sorted = [...values].sort(compareSequenceValues);
+    assert.deepEqual(sorted, ["2", "10", "zeta", ""]);
   });
 });
 


### PR DESCRIPTION
## Summary

Implements the feature requested in #528: a sequential routing ("Directions") tool in the Processing tab. It takes a point layer and builds a route that follows the road network through the points in order, snapping off-road coordinates (cell sites, sensors) to the nearest road first.

The tool lives under **Processing → Network → Sequential route (directions)** alongside the existing isochrone and OD cost matrix tools, reusing the same Valhalla routing backend and one-time consent notice.

## What it does

- **Ordering:** points are visited in the layer's feature order, or sorted by a chosen field. The field comparator handles numeric sequences and timestamps (anything `Date.parse` understands, e.g. ISO 8601), with empty/missing values trailing.
- **Snap to road:** Valhalla snaps each waypoint to the nearest routable edge, so points that are not on a road still route cleanly.
- **Output:** one `LineString` per leg (the road path between two consecutive waypoints), each carrying `leg_index`, `from_id`, `to_id`, `time_s`, `distance_km`, and `mode`.
- Travel mode (driving / walking / cycling) and the routing server are configurable, matching the other Network tools.

## Changes

- `packages/core/src/routing.ts`: pure, unit-tested helpers `buildRouteRequest`, `decodePolyline` (Valhalla precision-6 polylines), `routeResponseToFeatures`, `requestRoute`, and `compareSequenceValues`.
- `packages/processing/src/network-tools.ts`: `sequentialRouteTool`, registered in `NETWORK_TOOLS`.
- `NetworkToolsDialog`: populate `type: "field"` parameter options from the selected layer (so the "Order by field" dropdown works), and clear stale field selections when the layer changes.
- `ProcessingMenu` + `NetworkToolKind` + the routing consent hook: expose the tool in the Network submenu, gated by the existing consent notice. The notice copy now mentions routes.

## Verification

Verified in the running web app with Playwright using a 4-point dataset (DC landmarks) with an out-of-order timestamp field:

- Ordering by the timestamp field produced the correct chronological route (4 points, 3 legs, 8.16 km following roads).
- The result `Route` layer renders on the map in both light and dark themes; the dialog renders correctly in both themes.
- New pure helpers covered by unit tests in `tests/routing.test.ts`; full frontend suite passes (1164 passing). `npm run build` is green.

Fixes #528


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sequential route (directions) analysis to network tools, including an option in the network dropdown.
* **Enhancements**
  * Improved network tool dialogs with dynamic attribute field options per selected layer.
* **Bug Fixes**
  * Prevented stale field selections when switching the source layer for network routing inputs.
  * Added clearer guidance when route requests fail due to location limits.
* **Documentation**
  * Updated network analysis descriptions to include route computation alongside isochrones and cost matrices.
* **Tests**
  * Expanded routing and network-tool coverage for request building, polyline decoding, and sequencing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->