### PR TITLE
docs: reduce sidebar navigation spacing

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -127,17 +127,18 @@
   border-top-color: rgba(255, 255, 255, 0.12);
 }
 
-/* Tighten the left sidebar navigation. The default Material/Zensical link
-   margin/padding leaves a lot of vertical air between items; trim it. Section
-   headers keep their own (higher-specificity) spacing rule above. */
+/* Tighten the left sidebar navigation. The vertical gap between items comes
+   from the theme's default link `margin-top` (~0.625em); override that to trim
+   the air while keeping symmetric, touch-friendly padding. Section headers keep
+   their own (higher-specificity) spacing rule above. */
 .md-nav--primary .md-nav__item {
-  margin-top: 0.1rem;
+  margin-top: 0;
 }
 
 .md-nav--primary .md-nav__link {
-  margin-top: 0.1rem;
-  padding-bottom: 0.2rem;
-  padding-top: 0.2rem;
+  margin-top: 0.2rem;
+  padding-bottom: 0.35rem;
+  padding-top: 0.35rem;
 }
 
 .feature-grid {

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -127,18 +127,17 @@
   border-top-color: rgba(255, 255, 255, 0.12);
 }
 
-/* Tighten the left sidebar navigation. The vertical gap between items comes
-   from the theme's default link `margin-top` (~0.625em) plus generous padding;
-   zero the margin and trim the padding so items sit close together. Section
-   headers keep their own (higher-specificity) spacing rule above. */
-.md-nav--primary .md-nav__item {
-  margin-top: 0;
-}
+/* Tighten the desktop sidebar nav only; the mobile drawer keeps its default touch targets. */
+@media screen and (min-width: 76.25em) {
+  .md-nav--primary .md-nav__item:not(.md-nav__item--section) {
+    margin-top: 0;
+  }
 
-.md-nav--primary .md-nav__link {
-  margin-top: 0;
-  padding-bottom: 0.2rem;
-  padding-top: 0.2rem;
+  .md-nav--primary .md-nav__link {
+    margin-top: 0;
+    padding-bottom: 0.2rem;
+    padding-top: 0.2rem;
+  }
 }
 
 .feature-grid {

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -127,6 +127,19 @@
   border-top-color: rgba(255, 255, 255, 0.12);
 }
 
+/* Tighten the left sidebar navigation. The default Material/Zensical link
+   margin/padding leaves a lot of vertical air between items; trim it. Section
+   headers keep their own (higher-specificity) spacing rule above. */
+.md-nav--primary .md-nav__item {
+  margin-top: 0.1rem;
+}
+
+.md-nav--primary .md-nav__link {
+  margin-top: 0.1rem;
+  padding-bottom: 0.2rem;
+  padding-top: 0.2rem;
+}
+
 .feature-grid {
   display: grid;
   gap: 1rem;

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -128,17 +128,17 @@
 }
 
 /* Tighten the left sidebar navigation. The vertical gap between items comes
-   from the theme's default link `margin-top` (~0.625em); override that to trim
-   the air while keeping symmetric, touch-friendly padding. Section headers keep
-   their own (higher-specificity) spacing rule above. */
+   from the theme's default link `margin-top` (~0.625em) plus generous padding;
+   zero the margin and trim the padding so items sit close together. Section
+   headers keep their own (higher-specificity) spacing rule above. */
 .md-nav--primary .md-nav__item {
   margin-top: 0;
 }
 
 .md-nav--primary .md-nav__link {
-  margin-top: 0.2rem;
-  padding-bottom: 0.35rem;
-  padding-top: 0.35rem;
+  margin-top: 0;
+  padding-bottom: 0.2rem;
+  padding-top: 0.2rem;
 }
 
 .feature-grid {


### PR DESCRIPTION
## Summary
- Trim the default Material/Zensical nav link margin and padding in `docs/stylesheets/extra.css` so the docs left sidebar reads more compactly.
- Section headers (User Guide, Tutorials, Reference) keep their own higher-specificity spacing rule, so those visual breaks stay intact.

## Test plan
- [x] `mkdocs build` completes without errors
- [x] Verified in a browser that sidebar nav items render with tighter vertical spacing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved sidebar navigation layout on desktop with optimized spacing and padding for a more compact, refined appearance. Mobile navigation remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->