### PR TITLE
processing: use geolibre-wasm 0.3.0 for the in-browser tool runner

### DIFF
--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -792,9 +792,12 @@ export default defineConfig({
       "@electric-sql/pglite",
       "@electric-sql/pglite-postgis",
       "@cereusdb/standard",
-      // whitebox-wasm/tools loads its bundled whitebox-cli.wasm via
-      // `new URL("./whitebox-cli.wasm", import.meta.url)`; esbuild pre-bundling
-      // mangles that asset reference, so serve it as-is.
+      // geolibre-wasm/tools loads its bundled geolibre-cli.wasm via
+      // `new URL("./geolibre-cli.wasm", import.meta.url)`; esbuild pre-bundling
+      // mangles that asset reference, so serve it as-is. whitebox-wasm is still
+      // pulled in transitively (cog-tiler-wasm's peer dependency) and loads its
+      // wasm-bindgen asset the same way, so keep it excluded too.
+      "geolibre-wasm",
       "whitebox-wasm",
       // cog-tiler-wasm (the lazy CPU/WASM raster tiler) loads its
       // cog_tiler_wasm_bg.wasm the same wasm-bindgen way; esbuild pre-bundling

--- a/package-lock.json
+++ b/package-lock.json
@@ -14877,6 +14877,15 @@
       "resolved": "workers/viewer",
       "link": true
     },
+    "node_modules/geolibre-wasm": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/geolibre-wasm/-/geolibre-wasm-0.3.0.tgz",
+      "integrity": "sha512-qvCg9ZcYCH7JfUApQ4gFKOlS6Z2UwHZgVv10V3eBQM36YmE6RX8Dx0pmbRhC9vO4FAMIL2LhbyLUSmIMXiJW1g==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@bjorn3/browser_wasi_shim": "^0.4.2"
+      }
+    },
     "node_modules/geotiff": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-3.0.5.tgz",
@@ -22702,6 +22711,7 @@
       "resolved": "https://registry.npmjs.org/whitebox-wasm/-/whitebox-wasm-0.4.0.tgz",
       "integrity": "sha512-MGtesUVK4au7C+11Vb/v/HNA1vl/vU4t29mzsoTosySSkDZoGyTtjQkug7lDcB6tNvxRShpV7iY3cHXrTcqXuA==",
       "license": "MIT OR Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@bjorn3/browser_wasi_shim": "^0.4.2"
       }
@@ -24454,8 +24464,8 @@
         "@turf/tin": "^7.3.5",
         "@turf/union": "^7.3.5",
         "@turf/voronoi": "^7.3.5",
-        "geotiff": "^3.0.5",
-        "whitebox-wasm": "^0.4.0"
+        "geolibre-wasm": "^0.3.0",
+        "geotiff": "^3.0.5"
       },
       "devDependencies": {
         "@types/geojson": "^7946.0.16",

--- a/packages/processing/package.json
+++ b/packages/processing/package.json
@@ -29,8 +29,8 @@
     "@turf/tin": "^7.3.5",
     "@turf/union": "^7.3.5",
     "@turf/voronoi": "^7.3.5",
-    "geotiff": "^3.0.5",
-    "whitebox-wasm": "^0.4.0"
+    "geolibre-wasm": "^0.3.0",
+    "geotiff": "^3.0.5"
   },
   "devDependencies": {
     "@types/geojson": "^7946.0.16",

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -1,9 +1,10 @@
-// Run WhiteboxTools entirely in the browser via WebAssembly - a drop-in
-// alternative to the Python sidecar for the OSS tool set. `whitebox-wasm/tools`
-// executes the same `wbtools_oss` engine (compiled to a WASI binary) through an
-// in-memory WASI filesystem, so no server, no Python, and no native install is
-// required. Same algorithms and outputs as the sidecar; bounded by WASM's ~4 GiB
-// memory and single-threaded execution (use the sidecar for very large data).
+// Run the OSS geospatial tools entirely in the browser via WebAssembly - a
+// drop-in alternative to the Python sidecar. `geolibre-wasm/tools` is a superset
+// of `whitebox-wasm/tools`: the same `wbtools_oss` engine (compiled to a WASI
+// binary) plus GeoLibre-authored tools, run through an in-memory WASI
+// filesystem, so no server, no Python, and no native install is required. Same
+// algorithms and outputs as the sidecar; bounded by WASM's ~4 GiB memory and
+// single-threaded execution (use the sidecar for very large data).
 import type { FeatureCollection } from "geojson";
 import type { RunWhiteboxToolRequest, WhiteboxJob, WhiteboxToolParameter } from "./sidecar-client";
 
@@ -29,7 +30,7 @@ function loadToolsModule(): Promise<ToolsModule> {
   // the next call retries instead of being stuck with a permanently rejected
   // promise for the rest of the session.
   toolsModulePromise ??= (
-    import("whitebox-wasm/tools") as unknown as Promise<ToolsModule>
+    import("geolibre-wasm/tools") as unknown as Promise<ToolsModule>
   ).catch((error) => {
     toolsModulePromise = null;
     throw error;


### PR DESCRIPTION
## Summary

Switches the in-browser WASM tool runner from `whitebox-wasm` to **`geolibre-wasm@0.3.0`**, a byte-compatible superset: the same `wbtools_oss` engine plus GeoLibre-authored tools, including the new lidar DEM depression/mount suite (`extract_sinks`, `delineate_depressions`, `delineate_mounts`, `dem_filter`) with raster-to-GeoJSON polygonization.

The `./tools` API is identical (`listTools(): Promise<string[]>`, `runTool(tool, {args, input}): Promise<{exitCode, stdout, files}>`), verified against the published `geolibre-wasm@0.3.0` type definitions, so this is a drop-in swap.

## Changes
- `packages/processing/package.json`: `whitebox-wasm ^0.4.0` -> `geolibre-wasm ^0.3.0`
- `packages/processing/src/wasm-client.ts`: lazy-import `geolibre-wasm/tools`
- `apps/geolibre-desktop/vite.config.ts`: add `geolibre-wasm` to `optimizeDeps.exclude` (its `geolibre-cli.wasm` is loaded via `new URL(...)`); keep `whitebox-wasm` excluded as well
- `package-lock.json`: regenerated

## Note on whitebox-wasm
`whitebox-wasm` stays installed because `cog-tiler-wasm` (the raster tiler) peer-depends on it. That is independent of the tool runner and unchanged here.

## Verification
- Confirmed `geolibre-wasm@0.3.0` exports `./tools` with the same `listTools`/`runTool` surface and `ToolResult`/`RunToolOptions` shapes the client uses.
- Lockfile resolves `geolibre-wasm@0.3.0` cleanly (integrity verified). Full install/build runs in CI.