### PR TITLE
fix(parquet): warm up read_parquet before LOAD spatial on drag and drop

### DIFF
--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -205,6 +205,34 @@ function sourceSql(fileName: string, extension: string): string {
   return `SELECT * FROM ST_Read(${quotedName})`;
 }
 
+/**
+ * Build a {@link ensureSpatialExtension} `beforeLoad` warm-up that reads the
+ * Parquet file once before the spatial extension is loaded, or `undefined` for
+ * non-Parquet inputs.
+ *
+ * duckdb-wasm 1.33.1-dev45 breaks `read_parquet` on any connection that runs
+ * `LOAD spatial` itself unless that connection has already read the file at
+ * least once: the read then throws `Invalid Error: stoi: no conversion`. A
+ * Parquet dropped as the first vector file is exactly that case, because its
+ * connection is the one that triggers the singleton `LOAD spatial`. Reading the
+ * file before the load primes the connection so the later `DESCRIBE`/`SELECT`
+ * succeed. Later Parquet loads reuse the already-loaded extension, so their
+ * connections never run `LOAD` and need no warm-up. This mirrors the remote
+ * warm-up in `sql-workspace.ts`.
+ */
+function parquetWarmUp(
+  connection: duckdb.AsyncDuckDBConnection,
+  extension: string,
+  fileName: string,
+): (() => Promise<void>) | undefined {
+  if (!isParquetExtension(extension)) return undefined;
+  return async () => {
+    await connection.query(
+      `SELECT 1 FROM read_parquet(${quoteSqlString(fileName)}) LIMIT 0`,
+    );
+  };
+}
+
 function crsSql(fileName: string): string {
   return `
     SELECT
@@ -368,7 +396,10 @@ export async function loadDuckDbVectorFile(
 
   try {
     await registerVectorFileBuffers(db, file);
-    await ensureSpatialExtension(connection);
+    await ensureSpatialExtension(
+      connection,
+      parquetWarmUp(connection, file.extension, file.name),
+    );
 
     const sql = sourceSql(file.name, file.extension);
     const description = rowsFromResult(
@@ -569,7 +600,12 @@ export async function convertDuckDbVectorToGeoParquet(
 
   try {
     await registerVectorFileBuffers(db, file);
-    await ensureSpatialExtension(connection);
+    // Warm up the Parquet read path before LOAD spatial (see `parquetWarmUp`);
+    // the CSV branch reads via `read_csv_auto` and is unaffected.
+    await ensureSpatialExtension(
+      connection,
+      options.csv ? undefined : parquetWarmUp(connection, file.extension, file.name),
+    );
 
     let geometryColumn: string;
     let source: string;

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -104,9 +104,10 @@ export async function ensureSpatialExtension(
         await beforeLoad();
       } catch (error) {
         // Warm-up is best-effort; a failure here must not block spatial
-        // loading. Logged so a genuinely corrupt/mislabelled file is still
-        // diagnosable in DevTools instead of only surfacing later.
-        console.debug("[GeoLibre] spatial warm-up failed (ignored)", error);
+        // loading. Warn (not debug, which DevTools hides by default) so a
+        // genuinely corrupt/mislabelled file surfaces its real cause here
+        // instead of only as a later "stoi: no conversion" on DESCRIBE.
+        console.warn("[GeoLibre] spatial warm-up failed (ignored)", error);
       }
     }
 
@@ -607,9 +608,9 @@ export async function convertDuckDbVectorToGeoParquet(
   try {
     await registerVectorFileBuffers(db, file);
     // Warm up the Parquet read path before LOAD spatial (see `parquetWarmUp`).
-    // `parquetWarmUp` already returns undefined for non-Parquet extensions; the
-    // `options.csv` guard is an extra short-circuit for the CSV branch, which
-    // reads via `read_csv_auto` and is unaffected by the Parquet bug.
+    // CSV input uses `read_csv_auto` and non-Parquet vector files use `ST_Read`,
+    // neither affected by the bug; `parquetWarmUp` returns undefined for both,
+    // and the `options.csv` guard short-circuits the CSV branch before calling it.
     await ensureSpatialExtension(
       connection,
       options.csv ? undefined : parquetWarmUp(connection, file.extension, file.name),

--- a/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
+++ b/apps/geolibre-desktop/src/lib/duckdb-vector-loader.ts
@@ -93,6 +93,23 @@ export async function ensureSpatialExtension(
   beforeLoad?: () => Promise<void>,
 ): Promise<void> {
   spatialExtensionPromise ??= (async () => {
+    // duckdb-wasm 1.33.1-dev45 breaks read_parquet on any connection that runs
+    // LOAD spatial itself before it has read a Parquet file. `beforeLoad` lets
+    // the caller warm up that path (a pre-spatial read) before any LOAD,
+    // including the custom-path branch below, which is the only thing that
+    // initialises it. Runs before the branch split so a custom extension path
+    // (VITE_DUCKDB_SPATIAL_EXTENSION_PATH) gets the same warm-up.
+    if (beforeLoad) {
+      try {
+        await beforeLoad();
+      } catch (error) {
+        // Warm-up is best-effort; a failure here must not block spatial
+        // loading. Logged so a genuinely corrupt/mislabelled file is still
+        // diagnosable in DevTools instead of only surfacing later.
+        console.debug("[GeoLibre] spatial warm-up failed (ignored)", error);
+      }
+    }
+
     const customPath = getSpatialExtensionPath();
     if (customPath) {
       const normalizedPath = customPath.replace(/\\/g, "/");
@@ -100,17 +117,6 @@ export async function ensureSpatialExtension(
       return;
     }
 
-    // duckdb-wasm 1.33.1-dev45 breaks remote read_parquet if the spatial
-    // extension is loaded before the first remote HTTP read on the database.
-    // `beforeLoad` lets the caller warm up that path (a pre-spatial remote read)
-    // before INSTALL/LOAD, which is the only thing that initialises it.
-    if (beforeLoad) {
-      try {
-        await beforeLoad();
-      } catch {
-        // Warm-up is best-effort; a failure here must not block spatial loading.
-      }
-    }
     await connection.query("INSTALL spatial");
     await connection.query("LOAD spatial");
   })();
@@ -600,8 +606,10 @@ export async function convertDuckDbVectorToGeoParquet(
 
   try {
     await registerVectorFileBuffers(db, file);
-    // Warm up the Parquet read path before LOAD spatial (see `parquetWarmUp`);
-    // the CSV branch reads via `read_csv_auto` and is unaffected.
+    // Warm up the Parquet read path before LOAD spatial (see `parquetWarmUp`).
+    // `parquetWarmUp` already returns undefined for non-Parquet extensions; the
+    // `options.csv` guard is an extra short-circuit for the CSV branch, which
+    // reads via `read_csv_auto` and is unaffected by the Parquet bug.
     await ensureSpatialExtension(
       connection,
       options.csv ? undefined : parquetWarmUp(connection, file.extension, file.name),

--- a/package-lock.json
+++ b/package-lock.json
@@ -14878,10 +14878,10 @@
       "link": true
     },
     "node_modules/geolibre-wasm": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/geolibre-wasm/-/geolibre-wasm-0.3.0.tgz",
-      "integrity": "sha512-qvCg9ZcYCH7JfUApQ4gFKOlS6Z2UwHZgVv10V3eBQM36YmE6RX8Dx0pmbRhC9vO4FAMIL2LhbyLUSmIMXiJW1g==",
-      "license": "MIT OR Apache-2.0",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/geolibre-wasm/-/geolibre-wasm-0.4.1.tgz",
+      "integrity": "sha512-9hoagPlZkzrWes+f2Kneb9mXy1Ht1XnBGz8bnhuGUgYQdbkKzNk6StG7gV47TxflB8T2OXVvpW1D+j+QW2p8HA==",
+      "license": "MIT",
       "dependencies": {
         "@bjorn3/browser_wasi_shim": "^0.4.2"
       }
@@ -24464,7 +24464,7 @@
         "@turf/tin": "^7.3.5",
         "@turf/union": "^7.3.5",
         "@turf/voronoi": "^7.3.5",
-        "geolibre-wasm": "^0.3.0",
+        "geolibre-wasm": "^0.4.1",
         "geotiff": "^3.0.5"
       },
       "devDependencies": {

--- a/packages/processing/package.json
+++ b/packages/processing/package.json
@@ -29,7 +29,7 @@
     "@turf/tin": "^7.3.5",
     "@turf/union": "^7.3.5",
     "@turf/voronoi": "^7.3.5",
-    "geolibre-wasm": "^0.3.0",
+    "geolibre-wasm": "^0.4.1",
     "geotiff": "^3.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
## Problem

Dragging a GeoParquet file onto the map failed with:

```
Invalid Error: stoi: no conversion
LINE 1: DESCRIBE SELECT * FROM read_parquet('countriess.parquet')
                               ^
```

## Root cause

In `duckdb-wasm` 1.33.1-dev45, a connection that executes `LOAD spatial` **itself** can no longer run `read_parquet` unless that connection has already read the file at least once *before* the load. The read otherwise throws `stoi: no conversion`.

`loadDuckDbVectorFile` creates a fresh connection per load and calls `ensureSpatialExtension(connection)`, which on the **first** vector file ever loaded runs `LOAD spatial` on that very connection, then immediately does `DESCRIBE read_parquet(...)`. That ordering is what trips the bug. This is why it only reproduced for a Parquet dropped as the *first* layer: later Parquet loads reuse the already-loaded extension on connections that never run `LOAD`, so they read fine.

## Fix

Prime the connection with a single `read_parquet(...) LIMIT 0` **before** `LOAD spatial`, using the existing `beforeLoad` hook on `ensureSpatialExtension`. This mirrors the remote warm-up already used in `sql-workspace.ts` for the same class of bug. Applied to both `loadDuckDbVectorFile` and `convertDuckDbVectorToGeoParquet` (the CSV conversion branch reads via `read_csv_auto` and is left untouched).

## Verification

Driven in a real browser (Playwright) against the dev server with the actual `https://data.source.coop/giswqs/opengeos/countries.parquet`:

- Before: `stoi: no conversion`, no layer added.
- After: layer renders correctly on the map, no error.
- Regression: projected (EPSG:3857) and GeoParquet 1.1 (bbox) files still load; the geojson-first-then-Parquet sequence loads both layers with no error.
- `npm run test:frontend` (1219 pass) and `npm run typecheck` (full build) green; pre-commit clean.

Note: `loadDuckDbVectorFile` has no node unit test because the module's `?url` wasm imports and the duckdb-wasm worker cannot run under the `tsx` node test loader; this path is verified in-browser, where duckdb-wasm actually executes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reliability issues when loading Parquet and GeoParquet vector files with spatial extensions. The update optimizes the initialization process to prevent a known failure pattern during data loading, ensuring improved stability and consistency for all spatial data operations with these vector file formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->