### PR TITLE
feat(layers): inspect COG pixel values from the Identify icon

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -70,7 +70,7 @@
     "maplibre-gl-nasa-earthdata": "^0.1.2",
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.5.0",
+    "maplibre-gl-raster": "^0.6.0",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.7.1",
     "maplibre-gl-time-slider": "^1.0.3",

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -62,6 +62,7 @@ import { registerMbtilesProtocol } from "../../lib/mbtiles";
 import { hasReverseGeocodeConsent } from "../../lib/reverse-geocode-consent";
 import { registerXyzTileProtocol } from "../../lib/xyz-url";
 import { useEmbedBridge } from "../../hooks/useEmbedBridge";
+import { useRasterIdentify } from "../../hooks/useRasterIdentify";
 import { BoundsRestrictionIndicator } from "./BoundsRestrictionIndicator";
 import { RemoteCursorsOverlay } from "./RemoteCursorsOverlay";
 import { useCommandBridge } from "../../hooks/useCommandBridge";
@@ -391,6 +392,9 @@ export function DesktopShell({
   // Request/reply + event channel backing the Python scripting API (live
   // queries, processing, map events). Also inert when not embedded.
   useCommandBridge(mapControllerRef);
+  // Routes the Layers-panel Identify action to the raster pixel inspector for
+  // COG layers (read band values on click). Inert until a COG is identified.
+  useRasterIdentify();
   const [layerPanelWidth, setLayerPanelWidth] = useState(
     DEFAULT_SIDE_PANEL_WIDTH,
   );

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -1264,8 +1264,14 @@ export function LayerPanel({
               layer.type === "vector-tiles" ||
               (layer.type === "mbtiles" &&
                 layer.metadata.tileType === "vector") ||
+              // COG layers identify pixel values via the raster control's pixel
+              // inspector (see useRasterIdentify), not the vector feature query.
+              layer.type === "cog" ||
               hasNativeIdentifyLayers(layer);
             const identifyActive = identifyLayerId === layer.id;
+            // COGs inspect raw pixel/band values rather than vector features, so
+            // the icon's tooltip reflects that distinct action.
+            const isPixelIdentify = layer.type === "cog";
             const canEditGeometry = canEditLayerGeometry(layer);
             const geometryEditActive = geometryEditLayerId === layer.id;
             const geometryEditElsewhere =
@@ -1523,16 +1529,24 @@ export function LayerPanel({
                     title={
                       canIdentify
                         ? identifyActive
-                          ? "Deactivate identify"
-                          : "Identify features"
-                        : "Identify is only available for vector and WMS layers"
+                          ? isPixelIdentify
+                            ? "Stop inspecting pixel values"
+                            : "Deactivate identify"
+                          : isPixelIdentify
+                            ? "Inspect pixel values"
+                            : "Identify features"
+                        : "Identify is only available for vector, WMS, and COG layers"
                     }
                     aria-label={
                       canIdentify
                         ? identifyActive
-                          ? "Deactivate identify"
-                          : "Identify features"
-                        : "Identify is only available for vector and WMS layers"
+                          ? isPixelIdentify
+                            ? "Stop inspecting pixel values"
+                            : "Deactivate identify"
+                          : isPixelIdentify
+                            ? "Inspect pixel values"
+                            : "Identify features"
+                        : "Identify is only available for vector, WMS, and COG layers"
                     }
                     disabled={!canIdentify || geometryEditActive}
                     onClick={(e) => {

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -1272,6 +1272,16 @@ export function LayerPanel({
             // COGs inspect raw pixel/band values rather than vector features, so
             // the icon's tooltip reflects that distinct action.
             const isPixelIdentify = layer.type === "cog";
+            // Shared by the button's title and aria-label so they can't diverge.
+            const identifyLabel = canIdentify
+              ? identifyActive
+                ? isPixelIdentify
+                  ? "Stop inspecting pixel values"
+                  : "Deactivate identify"
+                : isPixelIdentify
+                  ? "Inspect pixel values"
+                  : "Identify features"
+              : "Identify is only available for vector, WMS, and COG layers";
             const canEditGeometry = canEditLayerGeometry(layer);
             const geometryEditActive = geometryEditLayerId === layer.id;
             const geometryEditElsewhere =
@@ -1526,28 +1536,8 @@ export function LayerPanel({
                         ? "border border-primary bg-primary text-primary-foreground shadow-xs hover:bg-primary/90 hover:text-primary-foreground"
                         : ""
                     }`}
-                    title={
-                      canIdentify
-                        ? identifyActive
-                          ? isPixelIdentify
-                            ? "Stop inspecting pixel values"
-                            : "Deactivate identify"
-                          : isPixelIdentify
-                            ? "Inspect pixel values"
-                            : "Identify features"
-                        : "Identify is only available for vector, WMS, and COG layers"
-                    }
-                    aria-label={
-                      canIdentify
-                        ? identifyActive
-                          ? isPixelIdentify
-                            ? "Stop inspecting pixel values"
-                            : "Deactivate identify"
-                          : isPixelIdentify
-                            ? "Inspect pixel values"
-                            : "Identify features"
-                        : "Identify is only available for vector, WMS, and COG layers"
-                    }
+                    title={identifyLabel}
+                    aria-label={identifyLabel}
                     disabled={!canIdentify || geometryEditActive}
                     onClick={(e) => {
                       e.stopPropagation();

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -1276,12 +1276,12 @@ export function LayerPanel({
             const identifyLabel = canIdentify
               ? identifyActive
                 ? isPixelIdentify
-                  ? "Stop inspecting pixel values"
-                  : "Deactivate identify"
+                  ? t("layers.identifyStopInspectPixels")
+                  : t("layers.identifyDeactivate")
                 : isPixelIdentify
-                  ? "Inspect pixel values"
-                  : "Identify features"
-              : "Identify is only available for vector, WMS, and COG layers";
+                  ? t("layers.identifyInspectPixels")
+                  : t("layers.identifyFeatures")
+              : t("layers.identifyUnavailable");
             const canEditGeometry = canEditLayerGeometry(layer);
             const geometryEditActive = geometryEditLayerId === layer.id;
             const geometryEditElsewhere =

--- a/apps/geolibre-desktop/src/hooks/useRasterIdentify.ts
+++ b/apps/geolibre-desktop/src/hooks/useRasterIdentify.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect } from "react";
 import { useAppStore } from "@geolibre/core";
 import { setRasterPixelInspect } from "@geolibre/plugins";
 
@@ -15,14 +15,13 @@ import { setRasterPixelInspect } from "@geolibre/plugins";
  * are open.
  */
 export function useRasterIdentify(): void {
-  const identifyLayerId = useAppStore((s) => s.identifyLayerId);
-  const layers = useAppStore((s) => s.layers);
-
-  const activeCogId = useMemo(() => {
-    if (!identifyLayerId) return null;
-    const layer = layers.find((item) => item.id === identifyLayerId);
+  // One selector returning a primitive: Zustand re-renders only when the
+  // resolved id changes, not on every unrelated layer mutation.
+  const activeCogId = useAppStore((s) => {
+    if (!s.identifyLayerId) return null;
+    const layer = s.layers.find((item) => item.id === s.identifyLayerId);
     return layer?.type === "cog" ? layer.id : null;
-  }, [identifyLayerId, layers]);
+  });
 
   useEffect(() => {
     if (!activeCogId) return;

--- a/apps/geolibre-desktop/src/hooks/useRasterIdentify.ts
+++ b/apps/geolibre-desktop/src/hooks/useRasterIdentify.ts
@@ -1,0 +1,32 @@
+import { useEffect, useMemo } from "react";
+import { useAppStore } from "@geolibre/core";
+import { setRasterPixelInspect } from "@geolibre/plugins";
+
+/**
+ * Bridges the store's `identifyLayerId` to the raster control's pixel inspector.
+ *
+ * When the active identify target is a COG layer, the Layers-panel Identify icon
+ * reads its source pixel/band values on map click — the same behavior as the
+ * raster panel's Inspect button. Vector/WMS/DuckDB identify is handled in
+ * MapCanvas; this hook drives only the raster path, and MapCanvas bails for
+ * raster/COG layers, so the two never both register a map-click handler.
+ *
+ * Mounted once at the app shell so it stays active regardless of which panels
+ * are open.
+ */
+export function useRasterIdentify(): void {
+  const identifyLayerId = useAppStore((s) => s.identifyLayerId);
+  const layers = useAppStore((s) => s.layers);
+
+  const activeCogId = useMemo(() => {
+    if (!identifyLayerId) return null;
+    const layer = layers.find((item) => item.id === identifyLayerId);
+    return layer?.type === "cog" ? layer.id : null;
+  }, [identifyLayerId, layers]);
+
+  useEffect(() => {
+    if (!activeCogId) return;
+    setRasterPixelInspect(activeCogId, true);
+    return () => setRasterPixelInspect(activeCogId, false);
+  }, [activeCogId]);
+}

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1370,6 +1370,11 @@
     "layerNameDefault": "Segmentation"
   },
   "layers": {
+    "identifyFeatures": "Identify features",
+    "identifyDeactivate": "Deactivate identify",
+    "identifyInspectPixels": "Inspect pixel values",
+    "identifyStopInspectPixels": "Stop inspecting pixel values",
+    "identifyUnavailable": "Identify is only available for vector, WMS, and COG layers",
     "exportGeoTiff": "GeoTIFF (COG)",
     "bindToTimeSlider": "Bind to Time Slider…",
     "unbindFromTimeSlider": "Unbind from Time Slider",

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
         "maplibre-gl-nasa-earthdata": "^0.1.2",
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.5.0",
+        "maplibre-gl-raster": "^0.6.0",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.7.1",
         "maplibre-gl-time-slider": "^1.0.3",
@@ -17778,9 +17778,9 @@
       }
     },
     "node_modules/maplibre-gl-raster": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.5.0.tgz",
-      "integrity": "sha512-GsdpV7qUopc6Qzto7JDGDe3VkxvRkLXbZHCJI27jmr8aCqieVPuhm5kxG6F82t/pqwEJTldHFDuGl4k8XheAmg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.6.0.tgz",
+      "integrity": "sha512-6Bt4AaHlJ/uUTLzKx2YABoWnSYlUBlqYIp3o9Oxa4X5DzrCxOTJ9zV2i2VxQj778t6QwOnAKMm1zglDfvBEJmQ==",
       "license": "MIT",
       "dependencies": {
         "@chunkd/middleware": "^11.3.0",
@@ -24317,7 +24317,7 @@
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-overture-maps": "^0.3.0",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.5.0",
+        "maplibre-gl-raster": "^0.6.0",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.7.1",
         "maplibre-gl-time-slider": "^1.0.3",

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -816,6 +816,12 @@ export const MapCanvas = memo(function MapCanvas({
       return;
     }
 
+    // Raster/COG layers are identified by the raster control's pixel inspector
+    // (driven by useRasterIdentify in the desktop app), not this vector/WMS
+    // feature-query handler. Bail so the two don't both register a map-click
+    // handler for the same layer.
+    if (layer.type === "cog" || layer.type === "raster") return;
+
     map.getCanvas().style.cursor = "crosshair";
 
     let wmsIdentifyAbortController: AbortController | null = null;

--- a/packages/map/src/MapCanvas.tsx
+++ b/packages/map/src/MapCanvas.tsx
@@ -816,11 +816,11 @@ export const MapCanvas = memo(function MapCanvas({
       return;
     }
 
-    // Raster/COG layers are identified by the raster control's pixel inspector
-    // (driven by useRasterIdentify in the desktop app), not this vector/WMS
-    // feature-query handler. Bail so the two don't both register a map-click
-    // handler for the same layer.
-    if (layer.type === "cog" || layer.type === "raster") return;
+    // COG layers are identified by the raster control's pixel inspector (driven
+    // by useRasterIdentify in the desktop app), not this vector/WMS feature
+    // query. Bail so the two don't both register a map-click handler. (Only
+    // "cog" is identify-enabled; plain "raster" never reaches here.)
+    if (layer.type === "cog") return;
 
     map.getCanvas().style.cursor = "crosshair";
 

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -45,7 +45,7 @@
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-overture-maps": "^0.3.0",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.5.0",
+    "maplibre-gl-raster": "^0.6.0",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.7.1",
     "maplibre-gl-time-slider": "^1.0.3",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -111,6 +111,7 @@ export {
   closeRasterLayerPanel,
   openRasterLayerPanel,
   restoreRasterLayers,
+  setRasterPixelInspect,
 } from "./plugins/maplibre-raster";
 export {
   RASTER_MAX_CLASSES,

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -51,6 +51,8 @@ type MapboxOverlayConstructor = new (
   props: Record<string, unknown>,
 ) => OverlayLike;
 type RasterLayerManagerInternals = {
+  /** The currently selected raster id (read to restore it after inspect). */
+  selectedId?: string | null;
   _deps?: {
     createOverlay?: (
       map: MapControlHost,
@@ -213,23 +215,37 @@ export function closeRasterLayerPanel(app: GeoLibreAppAPI): void {
   rasterControlMounted = false;
 }
 
+// The panel selection in effect before inspect stole focus, so it can be
+// restored when inspect stops (see setRasterPixelInspect).
+let rasterInspectPriorSelection: string | null = null;
+
 /**
  * Drives the raster control's pixel-inspect mode for a raster/COG layer so the
  * Layers-panel Identify action can read source band values on map click — the
  * same behavior as the raster panel's Inspect button. Selects the target raster
- * before enabling so the inspector reads the right layer. No-ops when the
- * control isn't mounted (no raster layer exists yet).
+ * before enabling so the inspector reads the right layer, then restores the
+ * panel's prior selection when inspect stops so it doesn't silently steal focus
+ * from a raster the user had selected for editing. No-ops when the control
+ * isn't mounted (no raster layer exists yet).
  *
  * @param layerId - The raster/COG layer id to inspect.
  * @param enabled - True to start inspecting, false to stop.
  */
 export function setRasterPixelInspect(layerId: string, enabled: boolean): void {
   if (!rasterControl) return;
+  const manager = (rasterControl as unknown as RasterControlInternals)
+    ._layerManager;
   if (enabled) {
+    rasterInspectPriorSelection = manager?.selectedId ?? null;
     rasterControl.selectRaster(layerId);
     rasterControl.setInspect(true);
   } else {
     rasterControl.setInspect(false);
+    // Restore the prior selection only if inspect actually changed it.
+    if (rasterInspectPriorSelection !== layerId) {
+      rasterControl.selectRaster(rasterInspectPriorSelection);
+    }
+    rasterInspectPriorSelection = null;
   }
 }
 

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -214,6 +214,26 @@ export function closeRasterLayerPanel(app: GeoLibreAppAPI): void {
 }
 
 /**
+ * Drives the raster control's pixel-inspect mode for a raster/COG layer so the
+ * Layers-panel Identify action can read source band values on map click — the
+ * same behavior as the raster panel's Inspect button. Selects the target raster
+ * before enabling so the inspector reads the right layer. No-ops when the
+ * control isn't mounted (no raster layer exists yet).
+ *
+ * @param layerId - The raster/COG layer id to inspect.
+ * @param enabled - True to start inspecting, false to stop.
+ */
+export function setRasterPixelInspect(layerId: string, enabled: boolean): void {
+  if (!rasterControl) return;
+  if (enabled) {
+    rasterControl.selectRaster(layerId);
+    rasterControl.setInspect(true);
+  } else {
+    rasterControl.setInspect(false);
+  }
+}
+
+/**
  * Replays URL-backed rasters from the loaded project into the control and
  * drops control rasters the project does not contain. Called by the desktop
  * shell whenever a project is loaded or the map is reinitialised, mirroring

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -26,7 +26,7 @@ const DEFAULT_RASTER_URL =
   "https://data.source.coop/giswqs/opengeos/nlcd_2021_land_cover_30m.tif";
 
 // These types mirror undocumented private members of RasterControl from
-// maplibre-gl-raster (verified against v0.5.0). All access is optional (?.)
+// maplibre-gl-raster (re-verified against v0.6.0). All access is optional (?.)
 // so a rename in a future release degrades to a no-op rather than a crash --
 // re-verify these names AND the .mlr-control-close selector in
 // wireRasterCloseButton when bumping the dependency.


### PR DESCRIPTION
## Summary

The Layers-panel **Identify** icon was grayed out for COG layers, even though the **Add Raster Layer** panel already has an **Inspect** button that reads pixel values. This makes the Identify icon offer that same functionality for COGs: activate it, then click the map to read the source band values at that point.

## How it works

The pixel inspector lives in `maplibre-gl-raster`. This PR consumes its new public API (shipped in **maplibre-gl-raster 0.6.0**, opengeos/maplibre-gl-raster#19): `RasterControl.setInspect(enabled)` / `isInspecting()`.

- **`maplibre-raster.ts`**: exports `setRasterPixelInspect(layerId, enabled)` — selects the raster and toggles the control's pixel inspector.
- **`LayerPanel.tsx`**: `canIdentify` now includes `cog`, with a pixel-inspect-specific tooltip ("Inspect pixel values").
- **`useRasterIdentify.ts`** (new, mounted in `DesktopShell`): bridges the store's `identifyLayerId` to the raster inspector for COG layers. Routing COG identify through the same store flag keeps the icon's active highlight and the "one identify active at a time" semantics uniform with vector identify.
- **`MapCanvas.tsx`**: the vector/WMS/DuckDB identify effect bails for raster/COG layers, so it never registers a competing map-click handler.
- Bumps `maplibre-gl-raster` to `^0.6.0`.

## Verification

Verified in the real web app (production build), **light and dark themes**, with the public NLCD COG (`nlcd_2021_land_cover_30m.tif`):

- Loaded the COG; its Layers-panel Identify icon is **enabled** and reads "Inspect pixel values".
- Clicking it sets the crosshair cursor and **syncs the raster panel's own Inspect button** (`aria-pressed=true`).
- Clicking the map shows a pixel popup, e.g. `Band 1 (Layer_1): 52` at `-86.31, 35.73` (NLCD class 52 = Shrub/Scrub) in light, and `82` (Cultivated Crops) in dark — values consistent with the data.
- Clicking off-extent shows "No data at this location."; toggling the icon off restores the cursor, removes the popup, and unpresses the panel button.

`npm run test:frontend`, `npm run build`, and `pre-commit` (eslint + build) all pass.

Depends on opengeos/maplibre-gl-raster#19 (released as 0.6.0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Raster layers (Cloud Optimized GeoTIFFs) can now be identified through the Layers panel to inspect pixel values and band data, extending identification capabilities beyond vector features.

* **Dependencies**
  * Updated maplibre-gl-raster dependency to v0.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->