### PR TITLE
ci(macos): Developer ID sign and notarize release DMGs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,10 @@ jobs:
             args: --no-sign
             rust-targets: ""
 
-          # macOS bundles are ad-hoc signed (bundle > macOS > signingIdentity
-          # in tauri.conf.json); users must still remove the quarantine attribute
-          # to bypass Gatekeeper. Do not pass --no-sign here.
+          # macOS bundles are Developer ID signed and notarized via the
+          # APPLE_* secrets wired into the tauri-action step below, so users can
+          # open the DMG without stripping the quarantine attribute. Do not pass
+          # --no-sign here.
           - name: macOS Apple Silicon
             os: macos-latest
             args: --target aarch64-apple-darwin
@@ -87,6 +88,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_OPTIONS: --max-old-space-size=4096
           VITE_GEE_OAUTH_CLIENT_ID: ${{ secrets.VITE_GEE_OAUTH_CLIENT_ID }}
+          # macOS Developer ID signing + notarization. These are read only by
+          # the macOS runners; other platforms ignore them. When the signing
+          # vars are empty (e.g. on a fork without secrets), tauri-action falls
+          # back to ad-hoc signing instead of failing the build.
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           projectPath: apps/geolibre-desktop
           releaseId: ${{ github.event.release.id }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,16 +88,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_OPTIONS: --max-old-space-size=4096
           VITE_GEE_OAUTH_CLIENT_ID: ${{ secrets.VITE_GEE_OAUTH_CLIENT_ID }}
-          # macOS Developer ID signing + notarization. These are read only by
-          # the macOS runners; other platforms ignore them. When the signing
-          # vars are empty (e.g. on a fork without secrets), tauri-action falls
-          # back to ad-hoc signing instead of failing the build.
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # macOS Developer ID signing + notarization. The secrets only resolve
+          # to real values on macOS runners; Linux/Windows get empty strings so
+          # the credentials are never placed in their process environment.
+          # APPLE_SIGNING_IDENTITY defaults to "-" when the secret is absent
+          # (e.g. a fork without secrets) so macOS still ad-hoc signs rather
+          # than failing the build now that tauri.conf.json no longer pins it.
+          APPLE_CERTIFICATE: ${{ runner.os == 'macOS' && secrets.APPLE_CERTIFICATE || '' }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ runner.os == 'macOS' && secrets.APPLE_CERTIFICATE_PASSWORD || '' }}
+          APPLE_SIGNING_IDENTITY: ${{ runner.os == 'macOS' && (secrets.APPLE_SIGNING_IDENTITY || '-') || '' }}
+          APPLE_ID: ${{ runner.os == 'macOS' && secrets.APPLE_ID || '' }}
+          APPLE_PASSWORD: ${{ runner.os == 'macOS' && secrets.APPLE_PASSWORD || '' }}
+          APPLE_TEAM_ID: ${{ runner.os == 'macOS' && secrets.APPLE_TEAM_ID || '' }}
         with:
           projectPath: apps/geolibre-desktop
           releaseId: ${{ github.event.release.id }}

--- a/apps/geolibre-desktop/src-tauri/tauri.conf.json
+++ b/apps/geolibre-desktop/src-tauri/tauri.conf.json
@@ -36,9 +36,6 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ],
-    "macOS": {
-      "signingIdentity": "-"
-    }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Switches the macOS desktop release builds from **ad-hoc** signing to proper **Developer ID signing + notarization**, so users can open the DMG without stripping the quarantine attribute (`xattr -cr`).

## Changes
- **`tauri.conf.json`**: removed `bundle.macOS.signingIdentity: "-"` (forced ad-hoc) so the real identity from the `APPLE_SIGNING_IDENTITY` env var takes effect.
- **`release.yml`**: wired the `APPLE_*` signing + notarization secrets into the `tauri-action` step; updated the stale ad-hoc comment. Vars are macOS-only and fall back to ad-hoc signing when unset (e.g. on forks), so non-mac builds and fork CI are unaffected.

## Required repo secrets
Signing (set): `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_SIGNING_IDENTITY`, `APPLE_TEAM_ID`.
Notarization (app-specific password path): `APPLE_ID`, `APPLE_PASSWORD` **(still to add)**.

## Testing
Verified by publishing a prerelease and confirming the macOS jobs sign + notarize + staple in the tauri-action logs (homebrew tap job skips prereleases). 

> Note: the repo's `npm-build` pre-commit hook currently fails on an unrelated pre-existing TypeScript error (`RasterControl.setInspect` from #576). This PR only touches a JSON config and a YAML workflow, neither of which affects the TS build.