### PR TITLE
feat(processing): surface GeoLibre WASM tools in the Whitebox toolbox

### DIFF
--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -130,6 +130,28 @@ function isOutputParameter(param: WhiteboxToolParameter): boolean {
   return parameterKind(param).endsWith("_out");
 }
 
+/** Best-effort extension for a `file_out` blob, sniffed from its magic bytes. */
+function fileOutputExtension(bytes: Uint8Array): string {
+  const matches = (sig: number[]) => sig.every((b, i) => bytes[i] === b);
+  if (matches([0x50, 0x41, 0x52, 0x31])) return "parquet"; // "PAR1"
+  if (matches([0x89, 0x50, 0x4e, 0x47])) return "png";
+  // "PMTiles"
+  if (matches([0x50, 0x4d, 0x54, 0x69, 0x6c, 0x65, 0x73])) return "pmtiles";
+  return "bin";
+}
+
+/** Save bytes to the user's downloads via a transient object URL. */
+function downloadBytes(bytes: Uint8Array, filename: string): void {
+  const url = URL.createObjectURL(new Blob([bytes as BlobPart]));
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}
+
 function isDataInputParameter(param: WhiteboxToolParameter): boolean {
   return ["raster_in", "vector_in", "lidar_in", "file_in"].includes(
     parameterKind(param),
@@ -394,14 +416,6 @@ export function ProcessingDialog({
     [selectedToolId, tools],
   );
 
-  const categories = useMemo(() => {
-    const unique = Array.from(
-      new Set(tools.map((tool) => tool.category || "General")),
-    );
-    unique.sort((a, b) => a.localeCompare(b));
-    return ["All", ...unique];
-  }, [tools]);
-
   // Whether any GeoLibre-authored tools are present (WASM mode), gating the
   // source filter — pointless when every tool is from Whitebox.
   const hasGeolibreTools = useMemo(
@@ -409,18 +423,46 @@ export function ProcessingDialog({
     [tools],
   );
 
+  // Ignore the source filter when no GeoLibre tools are present (e.g. sidecar
+  // mode), so a stale "geolibre" selection can't empty the whole list.
+  const matchesSource = useCallback(
+    (tool: WhiteboxTool) => {
+      if (source === "All" || !hasGeolibreTools) return true;
+      return (tool.source === "geolibre" ? "geolibre" : "whitebox") === source;
+    },
+    [source, hasGeolibreTools],
+  );
+
+  // Category options labelled with the number of tools in each (within the
+  // active source filter), e.g. "Conversion (37)".
+  const categories = useMemo(() => {
+    const counts = new Map<string, number>();
+    let total = 0;
+    for (const tool of tools) {
+      if (!matchesSource(tool)) continue;
+      total += 1;
+      const name = tool.category || "General";
+      counts.set(name, (counts.get(name) ?? 0) + 1);
+    }
+    const sorted = [...counts.entries()].sort((a, b) =>
+      a[0].localeCompare(b[0]),
+    );
+    return [
+      { value: "All", label: `All (${total})` },
+      ...sorted.map(([name, count]) => ({
+        value: name,
+        label: `${name} (${count})`,
+      })),
+    ];
+  }, [tools, matchesSource]);
+
   const filteredTools = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
     return tools.filter((tool) => {
       if (category !== "All" && (tool.category || "General") !== category) {
         return false;
       }
-      // Ignore the source filter when no GeoLibre tools are present (e.g. sidecar
-      // mode), so a stale "geolibre" selection can't empty the whole list.
-      if (source !== "All" && hasGeolibreTools) {
-        const toolSource = tool.source === "geolibre" ? "geolibre" : "whitebox";
-        if (toolSource !== source) return false;
-      }
+      if (!matchesSource(tool)) return false;
       if (!normalizedQuery) return true;
       return [
         tool.id,
@@ -432,11 +474,14 @@ export function ProcessingDialog({
         .toLowerCase()
         .includes(normalizedQuery);
     });
-  }, [category, source, hasGeolibreTools, query, tools]);
+  }, [category, matchesSource, query, tools]);
 
   const loadWhitebox = useCallback(async () => {
     setLoadingTools(true);
     setError(null);
+    // Reset the source filter so a stale "geolibre" selection from a previous
+    // mode doesn't silently hide tools after a reload / mode switch.
+    setSource("All");
     // Drop the in-memory snapshot so a fresh load reflects upstream catalog
     // changes; calls within this load still dedup once it is repopulated.
     clearRemoteWhiteboxCatalogSnapshotCache();
@@ -485,10 +530,12 @@ export function ProcessingDialog({
         const geolibreTools = await listGeolibreWasmTools();
         if (geolibreTools.length > 0) {
           setTools((current) => {
-            const seen = new Set(current.map((tool) => tool.id));
+            // On an id collision, prefer the GeoLibre manifest (it carries the
+            // richer param schemas) over a catalog stub.
+            const geolibreIds = new Set(geolibreTools.map((tool) => tool.id));
             return [
-              ...current,
-              ...geolibreTools.filter((tool) => !seen.has(tool.id)),
+              ...current.filter((tool) => !geolibreIds.has(tool.id)),
+              ...geolibreTools,
             ];
           });
           // Select the first GeoLibre tool if the snapshot was empty (otherwise
@@ -662,11 +709,17 @@ export function ProcessingDialog({
         if (layer) mapControllerRef.current?.fitLayer(layer);
       }
 
-      // Raster outputs come back from the WASM runner as inline COG bytes.
-      // Render each as a new raster layer through the shell-provided handler.
-      if (onAddRaster) {
-        for (const [name, value] of Object.entries(nextJob.outputs)) {
-          if (!(value instanceof Uint8Array)) continue;
+      // Binary outputs come back from the WASM runner inline. Raster (COG) bytes
+      // become a new raster layer; a `file_out` (e.g. write_geoparquet .parquet,
+      // a rendered .png, a .pmtiles) is not a GeoTIFF, so download it instead of
+      // handing it to the raster loader.
+      for (const [name, value] of Object.entries(nextJob.outputs)) {
+        if (!(value instanceof Uint8Array)) continue;
+        const param = jobTool?.params?.find((item) => item.name === name);
+        if (param && parameterKind(param) === "file_out") {
+          const label = `${jobToolLabel} ${humanize(name)}`.replace(/\s+/g, "_");
+          downloadBytes(value, `${label}.${fileOutputExtension(value)}`);
+        } else if (onAddRaster) {
           await onAddRaster(value, `${jobToolLabel} ${humanize(name)}`);
         }
       }
@@ -878,8 +931,8 @@ export function ProcessingDialog({
 
             <Select value={category} onChange={(e) => setCategory(e.target.value)}>
               {categories.map((item) => (
-                <option key={item} value={item}>
-                  {item}
+                <option key={item.value} value={item.value}>
+                  {item.label}
                 </option>
               ))}
             </Select>

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -130,7 +130,12 @@ function isOutputParameter(param: WhiteboxToolParameter): boolean {
   return parameterKind(param).endsWith("_out");
 }
 
-/** Best-effort extension for a `file_out` blob, sniffed from its magic bytes. */
+/**
+ * Best-effort extension for a `file_out` blob, sniffed from its magic bytes.
+ * Covers the formats GeoLibre `file_out` tools emit today (GeoParquet, PNG,
+ * PMTiles); a genuinely opaque output falls back to `.bin`. Extend the sniff
+ * here if a future tool writes a recognizable text format.
+ */
 function fileOutputExtension(bytes: Uint8Array): string {
   const matches = (sig: number[]) => sig.every((b, i) => bytes[i] === b);
   if (matches([0x50, 0x41, 0x52, 0x31])) return "parquet"; // "PAR1"
@@ -142,6 +147,8 @@ function fileOutputExtension(bytes: Uint8Array): string {
 
 /** Save bytes to the user's downloads via a transient object URL. */
 function downloadBytes(bytes: Uint8Array, filename: string): void {
+  // Cast required: TS types Uint8Array as Uint8Array<ArrayBufferLike>, which is
+  // not directly assignable to BlobPart under this lib (mirrors DesktopShell).
   const url = URL.createObjectURL(new Blob([bytes as BlobPart]));
   const anchor = document.createElement("a");
   anchor.href = url;

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -362,6 +362,9 @@ export function ProcessingDialog({
   const [values, setValues] = useState<ParameterValues>({});
   const [query, setQuery] = useState("");
   const [category, setCategory] = useState("All");
+  // Tool provenance filter: "All" | "geolibre" | "whitebox". Only meaningful in
+  // WASM mode, where GeoLibre-authored tools are mixed into the catalog.
+  const [source, setSource] = useState("All");
   const [loadingTools, setLoadingTools] = useState(false);
   const [runtimeMessage, setRuntimeMessage] = useState("");
   const [runtimeAvailable, setRuntimeAvailable] = useState<boolean | null>(null);
@@ -399,11 +402,24 @@ export function ProcessingDialog({
     return ["All", ...unique];
   }, [tools]);
 
+  // Whether any GeoLibre-authored tools are present (WASM mode), gating the
+  // source filter — pointless when every tool is from Whitebox.
+  const hasGeolibreTools = useMemo(
+    () => tools.some((tool) => tool.source === "geolibre"),
+    [tools],
+  );
+
   const filteredTools = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
     return tools.filter((tool) => {
       if (category !== "All" && (tool.category || "General") !== category) {
         return false;
+      }
+      // Ignore the source filter when no GeoLibre tools are present (e.g. sidecar
+      // mode), so a stale "geolibre" selection can't empty the whole list.
+      if (source !== "All" && hasGeolibreTools) {
+        const toolSource = tool.source === "geolibre" ? "geolibre" : "whitebox";
+        if (toolSource !== source) return false;
       }
       if (!normalizedQuery) return true;
       return [
@@ -416,7 +432,7 @@ export function ProcessingDialog({
         .toLowerCase()
         .includes(normalizedQuery);
     });
-  }, [category, query, tools]);
+  }, [category, source, hasGeolibreTools, query, tools]);
 
   const loadWhitebox = useCallback(async () => {
     setLoadingTools(true);
@@ -863,6 +879,18 @@ export function ProcessingDialog({
                 </option>
               ))}
             </Select>
+
+            {hasGeolibreTools && (
+              <Select
+                value={source}
+                onChange={(e) => setSource(e.target.value)}
+                aria-label="Filter by source"
+              >
+                <option value="All">All sources</option>
+                <option value="geolibre">GeoLibre tools</option>
+                <option value="whitebox">Whitebox tools</option>
+              </Select>
+            )}
 
             <ScrollArea className="min-h-0 flex-1 rounded-md border">
               <div className="divide-y">

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -888,11 +888,17 @@ export function ProcessingDialog({
               <Select
                 value={source}
                 onChange={(e) => setSource(e.target.value)}
-                aria-label="Filter by source"
+                aria-label={t("processing.whitebox.filterBySource")}
               >
-                <option value="All">All sources</option>
-                <option value="geolibre">GeoLibre tools</option>
-                <option value="whitebox">Whitebox tools</option>
+                <option value="All">
+                  {t("processing.whitebox.allSources")}
+                </option>
+                <option value="geolibre">
+                  {t("processing.whitebox.geolibreTools")}
+                </option>
+                <option value="whitebox">
+                  {t("processing.whitebox.whiteboxTools")}
+                </option>
               </Select>
             )}
 

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -433,6 +433,14 @@ export function ProcessingDialog({
     [source, hasGeolibreTools],
   );
 
+  // Total tool count per source, for the source-filter labels.
+  const sourceCounts = useMemo(() => {
+    const geolibre = tools.filter(
+      (tool) => tool.source === "geolibre",
+    ).length;
+    return { all: tools.length, geolibre, whitebox: tools.length - geolibre };
+  }, [tools]);
+
   // Category options labelled with the number of tools in each (within the
   // active source filter), e.g. "Conversion (37)".
   const categories = useMemo(() => {
@@ -940,17 +948,24 @@ export function ProcessingDialog({
             {hasGeolibreTools && (
               <Select
                 value={source}
-                onChange={(e) => setSource(e.target.value)}
+                // Reset the category too: a category with no tools in the newly
+                // chosen source would otherwise leave the list empty.
+                onChange={(e) => {
+                  setSource(e.target.value);
+                  setCategory("All");
+                }}
                 aria-label={t("processing.whitebox.filterBySource")}
               >
                 <option value="All">
-                  {t("processing.whitebox.allSources")}
+                  {t("processing.whitebox.allSources")} ({sourceCounts.all})
                 </option>
                 <option value="geolibre">
-                  {t("processing.whitebox.geolibreTools")}
+                  {t("processing.whitebox.geolibreTools")} (
+                  {sourceCounts.geolibre})
                 </option>
                 <option value="whitebox">
-                  {t("processing.whitebox.whiteboxTools")}
+                  {t("processing.whitebox.whiteboxTools")} (
+                  {sourceCounts.whitebox})
                 </option>
               </Select>
             )}

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -491,9 +491,13 @@ export function ProcessingDialog({
               ...geolibreTools.filter((tool) => !seen.has(tool.id)),
             ];
           });
+          // Select the first GeoLibre tool if the snapshot was empty (otherwise
+          // applyRemoteCatalogSnapshot already picked a selection).
+          setSelectedToolId((current) => current || geolibreTools[0].id);
         }
-      } catch {
+      } catch (err) {
         // Non-fatal: the catalog tools still load if the WASM enumeration fails.
+        console.warn("[GeoLibre] Could not enumerate WASM GeoLibre tools:", err);
       }
       setLoadingTools(false);
       return;

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -7,6 +7,7 @@ import {
   fetchRemoteWhiteboxCatalogSnapshot,
   fetchWhiteboxStatus,
   fetchWhiteboxTools,
+  listGeolibreWasmTools,
   runWhiteboxTool,
   runWhiteboxToolWasm,
   type WhiteboxJob,
@@ -460,6 +461,24 @@ export function ProcessingDialog({
         t("processing.whitebox.runningLocally"),
         false,
       );
+      // The GeoLibre-authored tools (write_geoparquet, delineate_depressions, …)
+      // aren't in the Whitebox catalog snapshot, so append them from the WASM
+      // binary's own manifests. WASM-only: they have no Python sidecar
+      // equivalent, hence only in the runLocal branch.
+      try {
+        const geolibreTools = await listGeolibreWasmTools();
+        if (geolibreTools.length > 0) {
+          setTools((current) => {
+            const seen = new Set(current.map((tool) => tool.id));
+            return [
+              ...current,
+              ...geolibreTools.filter((tool) => !seen.has(tool.id)),
+            ];
+          });
+        }
+      } catch {
+        // Non-fatal: the catalog tools still load if the WASM enumeration fails.
+      }
       setLoadingTools(false);
       return;
     }

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1395,7 +1395,11 @@
     "whitebox": {
       "runLocal": "Run locally (WASM)",
       "runLocalHint": "Run locally in WebAssembly (no Python sidecar)",
-      "runningLocally": "Running locally with WebAssembly. No sidecar required."
+      "runningLocally": "Running locally with WebAssembly. No sidecar required.",
+      "filterBySource": "Filter by source",
+      "allSources": "All sources",
+      "geolibreTools": "GeoLibre tools",
+      "whiteboxTools": "Whitebox tools"
     }
   },
   "segmentation": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14878,9 +14878,9 @@
       "link": true
     },
     "node_modules/geolibre-wasm": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/geolibre-wasm/-/geolibre-wasm-0.4.1.tgz",
-      "integrity": "sha512-9hoagPlZkzrWes+f2Kneb9mXy1Ht1XnBGz8bnhuGUgYQdbkKzNk6StG7gV47TxflB8T2OXVvpW1D+j+QW2p8HA==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/geolibre-wasm/-/geolibre-wasm-0.4.4.tgz",
+      "integrity": "sha512-C9Yo3kMIR1PL6hgrN2vNIyZ1gLCniZv9NuCMyEcrMzR7siAScgcdoMjFwOLZSHJCV28lw7+d1/AI6+kHUpENPw==",
       "license": "MIT",
       "dependencies": {
         "@bjorn3/browser_wasi_shim": "^0.4.2"
@@ -24464,7 +24464,7 @@
         "@turf/tin": "^7.3.5",
         "@turf/union": "^7.3.5",
         "@turf/voronoi": "^7.3.5",
-        "geolibre-wasm": "^0.4.1",
+        "geolibre-wasm": "^0.4.4",
         "geotiff": "^3.0.5"
       },
       "devDependencies": {

--- a/packages/processing/package.json
+++ b/packages/processing/package.json
@@ -29,7 +29,7 @@
     "@turf/tin": "^7.3.5",
     "@turf/union": "^7.3.5",
     "@turf/voronoi": "^7.3.5",
-    "geolibre-wasm": "^0.4.1",
+    "geolibre-wasm": "^0.4.4",
     "geotiff": "^3.0.5"
   },
   "devDependencies": {

--- a/packages/processing/src/index.ts
+++ b/packages/processing/src/index.ts
@@ -139,4 +139,5 @@ export {
   runWhiteboxToolWasm,
   whiteboxWasmAvailable,
   listWhiteboxWasmTools,
+  listGeolibreWasmTools,
 } from "./wasm-client";

--- a/packages/processing/src/sidecar-client.ts
+++ b/packages/processing/src/sidecar-client.ts
@@ -99,6 +99,8 @@ export interface WhiteboxTool {
   locked_reason?: string | null;
   params?: WhiteboxToolParameter[];
   return_type?: string;
+  /** Tool provenance: "geolibre" for GeoLibre-authored WASM tools, else Whitebox. */
+  source?: string;
 }
 
 export interface WhiteboxStatus {

--- a/packages/processing/src/sidecar-client.ts
+++ b/packages/processing/src/sidecar-client.ts
@@ -99,8 +99,8 @@ export interface WhiteboxTool {
   locked_reason?: string | null;
   params?: WhiteboxToolParameter[];
   return_type?: string;
-  /** Tool provenance: "geolibre" for GeoLibre-authored WASM tools, else Whitebox. */
-  source?: string;
+  /** Tool provenance: "geolibre" for GeoLibre-authored WASM tools, else unset (Whitebox). */
+  source?: "geolibre";
 }
 
 export interface WhiteboxStatus {

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -105,6 +105,7 @@ export async function listGeolibreWasmTools(): Promise<WhiteboxTool[]> {
       summary: manifest.summary,
       category: manifest.category,
       license_tier: manifest.license_tier,
+      source: "geolibre",
       params: (manifest.params ?? []).map((param) => {
         const mapped: WhiteboxToolParameter = {
           name: param.name,

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -98,7 +98,7 @@ export async function listGeolibreWasmTools(): Promise<WhiteboxTool[]> {
   const { listManifests } = await loadToolsModule();
   const manifests = await listManifests();
   return manifests
-    .filter((manifest) => manifest.source === "geolibre")
+    .filter((manifest) => manifest.source?.toLowerCase() === "geolibre")
     .map((manifest) => ({
       id: manifest.id,
       display_name: manifest.display_name,

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -115,9 +115,13 @@ export async function listGeolibreWasmTools(): Promise<WhiteboxTool[]> {
           schema: param.schema,
         };
         if (param.schema?.kind === "enum" && Array.isArray(param.schema.options)) {
+          // Coerce to strings (not filter to strings): an enum with numeric or
+          // boolean values would otherwise drop to an empty list and render as a
+          // plain text input instead of a dropdown.
           mapped.options = param.schema.options
             .map((option) => option?.value)
-            .filter((value): value is string => typeof value === "string");
+            .filter((value) => value != null)
+            .map(String);
         }
         return mapped;
       }),

--- a/packages/processing/src/wasm-client.ts
+++ b/packages/processing/src/wasm-client.ts
@@ -6,7 +6,12 @@
 // algorithms and outputs as the sidecar; bounded by WASM's ~4 GiB memory and
 // single-threaded execution (use the sidecar for very large data).
 import type { FeatureCollection } from "geojson";
-import type { RunWhiteboxToolRequest, WhiteboxJob, WhiteboxToolParameter } from "./sidecar-client";
+import type {
+  RunWhiteboxToolRequest,
+  WhiteboxJob,
+  WhiteboxTool,
+  WhiteboxToolParameter,
+} from "./sidecar-client";
 
 interface ToolRunResult {
   exitCode: number;
@@ -14,8 +19,32 @@ interface ToolRunResult {
   files: Record<string, Uint8Array>;
 }
 
+/** One tool's manifest as emitted by `geolibre manifests` (geolibre-wasm). */
+interface ToolManifest {
+  id: string;
+  display_name?: string;
+  summary?: string;
+  category?: string;
+  license_tier?: string;
+  /** "geolibre" for GeoLibre-authored tools, "whitebox" otherwise. */
+  source?: string;
+  params?: Array<{
+    name: string;
+    description?: string;
+    required?: boolean;
+    io_role?: string;
+    data_kind?: string;
+    schema?: {
+      kind?: string;
+      options?: Array<{ value?: unknown }>;
+      [key: string]: unknown;
+    };
+  }>;
+}
+
 interface ToolsModule {
   listTools: () => Promise<string[]>;
+  listManifests: () => Promise<ToolManifest[]>;
   runTool: (
     tool: string,
     opts: { args?: string[]; input?: Record<string, Uint8Array> },
@@ -52,6 +81,47 @@ export async function whiteboxWasmAvailable(): Promise<boolean> {
 export async function listWhiteboxWasmTools(): Promise<string[]> {
   const { listTools } = await loadToolsModule();
   return listTools();
+}
+
+/**
+ * The GeoLibre-authored tools (`source: "geolibre"`) the WASM runner adds on top
+ * of the Whitebox suite — e.g. `write_geoparquet`, `delineate_depressions` —
+ * mapped to {@link WhiteboxTool} so the Processing toolbox can list and run them
+ * alongside the catalog tools. These aren't in the Whitebox catalog snapshot, so
+ * the toolbox can only discover them from the binary's own manifests.
+ *
+ * Each manifest param already carries `io_role`/`data_kind`/`schema`, which the
+ * dialog's `parameterKind` reads directly; we additionally flatten an enum
+ * schema's choices to `options` so the param renders as a dropdown.
+ */
+export async function listGeolibreWasmTools(): Promise<WhiteboxTool[]> {
+  const { listManifests } = await loadToolsModule();
+  const manifests = await listManifests();
+  return manifests
+    .filter((manifest) => manifest.source === "geolibre")
+    .map((manifest) => ({
+      id: manifest.id,
+      display_name: manifest.display_name,
+      summary: manifest.summary,
+      category: manifest.category,
+      license_tier: manifest.license_tier,
+      params: (manifest.params ?? []).map((param) => {
+        const mapped: WhiteboxToolParameter = {
+          name: param.name,
+          description: param.description,
+          required: param.required,
+          io_role: param.io_role,
+          data_kind: param.data_kind,
+          schema: param.schema,
+        };
+        if (param.schema?.kind === "enum" && Array.isArray(param.schema.options)) {
+          mapped.options = param.schema.options
+            .map((option) => option?.value)
+            .filter((value): value is string => typeof value === "string");
+        }
+        return mapped;
+      }),
+    }));
 }
 
 function datasetParameterKind(dataKind: string, suffix: "in" | "out"): string {


### PR DESCRIPTION
## Summary

Processing → Whitebox built its tool **list** only from the Whitebox catalog snapshot (`opengeos/Whitebox-Next-Gen-ArcGIS`), which has no knowledge of the GeoLibre-authored tools the WASM runner adds. So `write_geoparquet`, `delineate_depressions`, `reproject_raster`, `spectral_index`, `vector_convert`, etc. never appeared in the toolbox — even though the binary can run them.

The blocker was that the WASM `manifests` output was *lean* (params had only name/description/required), so even enumerating them produced unusable dialogs. **geolibre-wasm 0.4.4** ([opengeos/geolibre-rust#16](https://github.com/opengeos/geolibre-rust/pull/16)) now emits **self-describing** manifests — each param carries `io_role`/`data_kind`/`schema`. This PR consumes them:

- **`wasm-client.ts`**: `listGeolibreWasmTools()` maps `source == "geolibre"` manifests to `WhiteboxTool`, flattening an enum schema's choices to `options` for dropdowns. The dialog's existing `parameterKind` already reads `io_role`/`data_kind`/`schema`.
- **`ProcessingDialog.loadWhitebox`**: in WASM (`runLocal`) mode, append the GeoLibre tools to the catalog list. WASM-only — they have no Python sidecar equivalent.
- Bumps `geolibre-wasm` to `^0.4.4`.

## Verification (real app, production build, WASM mode)

- **All 14 GeoLibre tools appear** in the toolbox (Write GeoParquet, Read GeoParquet, Spectral Index, Vector Convert, Reproject Raster, Render Raster/Vector to PNG, Delineate Depressions/Mounts, Extract Sinks, Raster to XYZ Tiles, Raster to PMTiles, …).
- **Correct widgets** — Write GeoParquet renders `input` as a `vector_in` layer picker, `output` as `file_out`, `compression` as an **enum dropdown** (`zstd`/`snappy`/`gzip`/`uncompressed`), and `hilbert_sort` as a **bool checkbox**. (Previously these would have mis-rendered — e.g. `hilbert_sort` demanding a layer.)
- **Runs end-to-end** — loaded a GeoJSON, selected it for Vector Convert, ran it in-browser: `{"feature_count":2,"output":"/work/output.geojson"}` (2 features in → 2 out).

`npm run test:frontend`, `npm run build`, and `pre-commit` (eslint + build) pass.

Depends on geolibre-wasm 0.4.4 (released).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In web/local mode, the processing catalog now loads additional GeoLibre-authored WASM tools with deduplication by tool ID; discovery failures no longer block catalog loading.
  * Added a tool “source” filter in the processing dialog (All / geolibre / whitebox), shown only when GeoLibre tools exist.
* **Bug Fixes**
  * Improved output import for WASM runs: binary `file_out` results are now downloaded as artifacts instead of being treated as raster layers.
* **Chores**
  * Updated the processing package to a newer `geolibre-wasm` version.
  * Exposed utilities to enumerate available GeoLibre-authored WASM tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->