### PR TITLE
docs(macos): drop quarantine workaround now that DMGs are notarized

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,14 +91,13 @@ install and update with Homebrew:
 brew tap opengeos/geolibre
 brew trust --cask opengeos/geolibre/geolibre
 brew install --cask geolibre
-xattr -dr com.apple.quarantine "/Applications/GeoLibre Desktop.app"
 ```
 
 `brew trust` is a one-time approval for the non-official tap (skip it on
-Homebrew older than 5.1). The `xattr` step is required because the app is ad-hoc
-signed but not notarized by Apple (Homebrew removed the `--no-quarantine` flag in
-5.1). See [Downloads](docs/downloads.md) for details and the manual install
-steps.
+Homebrew older than 5.1). The macOS app is signed with an Apple Developer ID
+certificate and notarized by Apple, so it launches normally with no quarantine
+workaround. See [Downloads](docs/downloads.md) for details and the manual
+install steps.
 
 To build from source instead:
 

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -11,12 +11,20 @@ Release builds are produced for:
 
 - Linux x64: Debian package, RPM package, and AppImage
 - Windows x64: unsigned desktop binary
-- macOS Apple Silicon: Developer ID signed and notarized DMG and app bundle
-- macOS Intel: Developer ID signed and notarized DMG and app bundle
+- macOS Apple Silicon: Developer ID signed and notarized DMG and app bundle (v1.4.1+)
+- macOS Intel: Developer ID signed and notarized DMG and app bundle (v1.4.1+)
 
 The Windows build is unsigned and may require a platform-specific trust prompt. Check each release note for the exact assets and platform guidance.
 
 ## macOS installation
+
+Signing and notarization apply to **v1.4.1 and later**. For v1.4.0 and earlier
+(ad-hoc signed), remove the quarantine attribute after installing, repeating it
+after each upgrade:
+
+```bash
+xattr -dr com.apple.quarantine "/Applications/GeoLibre Desktop.app"
+```
 
 ### Homebrew (recommended)
 
@@ -52,7 +60,7 @@ by Apple, so Gatekeeper allows them to open without any extra steps:
 1. Download the DMG for your Mac (`aarch64` for Apple Silicon, `x64` for
    Intel).
 2. Open the DMG and drag **GeoLibre Desktop** into **Applications**.
-3. Launch GeoLibre Desktop from Applications as usual.
+3. Launch GeoLibre Desktop from Applications.
 
 ## Build from source
 

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -11,8 +11,8 @@ Release builds are produced for:
 
 - Linux x64: Debian package, RPM package, and AppImage
 - Windows x64: unsigned desktop binary
-- macOS Apple Silicon: ad-hoc signed DMG and app bundle
-- macOS Intel: ad-hoc signed DMG and app bundle
+- macOS Apple Silicon: Developer ID signed and notarized DMG and app bundle
+- macOS Intel: Developer ID signed and notarized DMG and app bundle
 
 The Windows build is unsigned and may require a platform-specific trust prompt. Check each release note for the exact assets and platform guidance.
 
@@ -27,7 +27,6 @@ from a self-hosted tap:
 brew tap opengeos/geolibre
 brew trust --cask opengeos/geolibre/geolibre
 brew install --cask geolibre
-xattr -dr com.apple.quarantine "/Applications/GeoLibre Desktop.app"
 ```
 
 The `brew trust` step is a one-time approval. Homebrew refuses to load casks
@@ -37,53 +36,23 @@ Homebrew release. `brew trust opengeos/geolibre` trusts the whole tap instead of
 just this cask. The command exists in Homebrew 5.1 and later; on older versions
 skip it.
 
-The `xattr` step is required because the DMGs are ad-hoc signed but not
-notarized by Apple, so macOS Gatekeeper would otherwise block the app with a
-"damaged" prompt (see below). It removes the quarantine attribute Homebrew
-attaches on download. Upgrade later with:
+The macOS DMGs are signed with an Apple Developer ID certificate and notarized
+by Apple, so Gatekeeper allows the app to launch normally with no quarantine
+workaround. Upgrade later with:
 
 ```bash
 brew upgrade --cask geolibre
-xattr -dr com.apple.quarantine "/Applications/GeoLibre Desktop.app"
 ```
-
-Re-run the `xattr` command after each upgrade, since it applies to the newly
-installed app bundle.
-
-Homebrew removed the `--no-quarantine` flag in version 5.1, so the manual
-`xattr` step replaces it. The tap is also not the official `homebrew/cask`
-repository, which requires a notarized, Apple-signed app.
 
 ### Manual installation
 
-The macOS builds are not signed with an Apple Developer certificate, so
-Gatekeeper blocks them on first launch. Depending on your macOS version and
-which release you downloaded, the message is one of:
-
-> "GeoLibre Desktop" cannot be opened because the developer cannot be
-> verified.
-
-or:
-
-> "GeoLibre Desktop" is damaged and can't be opened. You should move it to
-> the Bin.
-
-The app is not actually damaged. macOS attaches a quarantine attribute to
-files downloaded from the internet and refuses to open apps that are not
-notarized by Apple. To install:
+The macOS builds are signed with an Apple Developer ID certificate and notarized
+by Apple, so Gatekeeper allows them to open without any extra steps:
 
 1. Download the DMG for your Mac (`aarch64` for Apple Silicon, `x64` for
-   Intel) and drag **GeoLibre Desktop** into **Applications**.
-2. Open **Terminal** and remove the quarantine attribute:
-
-    ```bash
-    xattr -cr "/Applications/GeoLibre Desktop.app"
-    ```
-
+   Intel).
+2. Open the DMG and drag **GeoLibre Desktop** into **Applications**.
 3. Launch GeoLibre Desktop from Applications as usual.
-
-This is a one-time step per installed version. You only need to repeat it
-after installing a new release.
 
 ## Build from source
 

--- a/scripts/render-homebrew-cask.sh
+++ b/scripts/render-homebrew-cask.sh
@@ -4,7 +4,8 @@
 #
 # The macOS DMGs are signed with an Apple Developer ID certificate and notarized
 # by Apple, so they install and launch without a quarantine workaround. The cask
-# is distributed from a self-hosted tap (not the official homebrew/cask repo).
+# is distributed from a self-hosted tap because it has not been submitted to the
+# official homebrew/cask repository.
 #
 # Usage:
 #   VERSION=1.2.0 \

--- a/scripts/render-homebrew-cask.sh
+++ b/scripts/render-homebrew-cask.sh
@@ -2,9 +2,9 @@
 #
 # Render the Homebrew cask for the GeoLibre desktop app.
 #
-# The macOS DMGs are ad-hoc signed but not notarized by Apple, so the cask is
-# meant to be installed from a self-hosted tap with `--no-quarantine`. It is not
-# suitable for the official homebrew/cask repository.
+# The macOS DMGs are signed with an Apple Developer ID certificate and notarized
+# by Apple, so they install and launch without a quarantine workaround. The cask
+# is distributed from a self-hosted tap (not the official homebrew/cask repo).
 #
 # Usage:
 #   VERSION=1.2.0 \
@@ -49,16 +49,6 @@ cask "geolibre" do
   homepage "https://geolibre.app/"
 
   app "GeoLibre Desktop.app"
-
-  # The DMGs are ad-hoc signed but not notarized by Apple, so macOS Gatekeeper
-  # blocks them with a "damaged" prompt. Homebrew removed the --no-quarantine
-  # flag in 5.1, so the user must strip the quarantine attribute by hand.
-  caveats <<~EOS
-    GeoLibre Desktop is not notarized by Apple. Before first launch, remove the
-    quarantine attribute (repeat this after every upgrade):
-
-      xattr -dr com.apple.quarantine "/Applications/GeoLibre Desktop.app"
-  EOS
 
   zap trash: [
     "~/Library/Application Support/org.geolibre.desktop",


### PR DESCRIPTION
## Summary

Follow-up to #577 (Developer ID signing + notarization). The macOS DMGs are now signed and notarized, verified end to end in CI (notarization `status: Accepted` + stapling on both arches), so the `xattr`/quarantine workaround is no longer needed.

## Changes
- **README.md**: remove the `xattr -dr com.apple.quarantine` line from the Homebrew snippet; update the signing note to say the app is Developer ID signed + notarized.
- **docs/downloads.md**: describe assets as Developer ID signed + notarized, drop the `xattr` upgrade step, remove the "damaged"/Gatekeeper manual-workaround section, and simplify manual install to drag-and-drop.
- **scripts/render-homebrew-cask.sh**: update the header comment and remove the quarantine `caveats` block from the generated cask.

The `brew trust` step is kept: it is about trusting the non-official tap, unrelated to notarization.

## Timing note
The currently published release (v1.4.0) is still ad-hoc signed, so these instructions become fully accurate once the first notarized release (v1.4.1+) ships. The Homebrew cask regenerates per-release automatically, so it stays in lockstep; the static docs go live on merge. Recommend merging around the next release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified macOS installation instructions by removing the quarantine workaround requirement for v1.4.1+
  * Clarified that new DMGs are Apple Developer ID signed and notarized
  * Updated Homebrew installation guidance and added cask upgrade instructions
  * Consolidated manual installation documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->