### PR TITLE
feat(packaging): add official homebrew/cask cask generator

### DIFF
--- a/scripts/render-official-cask.sh
+++ b/scripts/render-official-cask.sh
@@ -28,10 +28,17 @@
 set -euo pipefail
 
 REPO="${REPO:-opengeos/GeoLibre}"
+# REPO is interpolated verbatim into the generated cask's url/verified lines, so
+# guard its shape (the default is safe; this only matters on a fork override).
+[[ "$REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || {
+  echo "REPO must be in owner/repo format (e.g. opengeos/GeoLibre): '$REPO'" >&2
+  exit 1
+}
 
-# Resolve the version: an explicit VERSION wins, otherwise use the latest
-# published release tag (gh excludes drafts; it includes prereleases, so pin
-# VERSION when the latest tag is a prerelease).
+# Resolve the version: an explicit VERSION wins, otherwise use the latest full
+# release. `gh release view` with no tag calls GitHub's /releases/latest, which
+# already excludes prereleases and drafts; pin VERSION only to target an older
+# tag. (The X.Y.Z check below is a belt-and-suspenders guard regardless.)
 if [[ -z "${VERSION:-}" ]]; then
   tag="$(gh release view --repo "$REPO" --json tagName --jq .tagName)"
   VERSION="${tag#v}"
@@ -58,15 +65,24 @@ if [[ -z "${SHA256_ARM:-}" || -z "${SHA256_INTEL:-}" ]]; then
   [[ -n "${SHA256_INTEL:-}" ]] || gh release download "v${VERSION}" --repo "$REPO" \
     --pattern "$intel_dmg" --dir "$tmp"
 
+  # Fail loudly if the expected DMG is missing (e.g. a partial download): the
+  # awk pipe alone would mask the hash binary's failure and yield an empty
+  # string, surfacing only as a cryptic format error further down.
   sha256_of() {
+    [[ -f "$1" ]] || {
+      echo "expected DMG not found (download failed?): $1" >&2
+      return 1
+    }
     if command -v sha256sum >/dev/null 2>&1; then
       sha256sum "$1" | awk '{print $1}'
     else
       shasum -a 256 "$1" | awk '{print $1}'
     fi
   }
-  SHA256_ARM="${SHA256_ARM:-$(sha256_of "$tmp/$arm_dmg")}"
-  SHA256_INTEL="${SHA256_INTEL:-$(sha256_of "$tmp/$intel_dmg")}"
+  # Plain `||` assignments (not a ${:-} default) so a hashing failure aborts the
+  # script under `set -e` instead of silently producing an empty hash.
+  [[ -n "${SHA256_ARM:-}" ]] || SHA256_ARM="$(sha256_of "$tmp/$arm_dmg")"
+  [[ -n "${SHA256_INTEL:-}" ]] || SHA256_INTEL="$(sha256_of "$tmp/$intel_dmg")"
 fi
 
 # Normalise to lowercase so a hash pasted from a tool that emits uppercase (e.g.

--- a/scripts/render-official-cask.sh
+++ b/scripts/render-official-cask.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# Render the cask for submission to the official homebrew/homebrew-cask repo.
+#
+# Unlike scripts/render-homebrew-cask.sh (which renders the self-hosted-tap cask
+# consumed by the release workflow), this emits the cask intended for the
+# official repository as Casks/g/geolibre.rb. It uses the `arch` helper and a
+# `livecheck` block so Homebrew's BrewTestBot can auto-bump the version on each
+# new GitHub release.
+#
+# The official tap rejects unsigned/non-notarized apps, so this is only valid
+# for Developer ID signed and notarized DMGs (v1.4.1 and later).
+#
+# Usage:
+#   # auto: resolve the latest release, download both DMGs, compute sha256
+#   scripts/render-official-cask.sh > geolibre.rb
+#
+#   # pin a version (still downloads that release's DMGs to hash them):
+#   VERSION=1.4.1 scripts/render-official-cask.sh > geolibre.rb
+#
+#   # supply the hashes directly (skips the download entirely):
+#   VERSION=1.4.1 SHA256_ARM=<hex> SHA256_INTEL=<hex> \
+#     scripts/render-official-cask.sh > geolibre.rb
+#
+# Requires: gh (for the auto-download path) and sha256sum or shasum. The
+# rendered cask is written to stdout. Run `brew audit --new --cask geolibre`
+# and `brew install --cask ./geolibre.rb` on a Mac before opening the PR.
+set -euo pipefail
+
+REPO="${REPO:-opengeos/GeoLibre}"
+
+# Resolve the version: an explicit VERSION wins, otherwise use the latest
+# published release tag (gh excludes drafts; it includes prereleases, so pin
+# VERSION when the latest tag is a prerelease).
+if [[ -z "${VERSION:-}" ]]; then
+  tag="$(gh release view --repo "$REPO" --json tagName --jq .tagName)"
+  VERSION="${tag#v}"
+fi
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]] || {
+  echo "VERSION does not look like a semver string: '$VERSION'" >&2
+  exit 1
+}
+
+arm_dmg="GeoLibre.Desktop_${VERSION}_aarch64.dmg"
+intel_dmg="GeoLibre.Desktop_${VERSION}_x64.dmg"
+
+# Download and hash the DMGs unless both hashes were supplied.
+if [[ -z "${SHA256_ARM:-}" || -z "${SHA256_INTEL:-}" ]]; then
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+  gh release download "v${VERSION}" --repo "$REPO" \
+    --pattern "$arm_dmg" --pattern "$intel_dmg" --dir "$tmp"
+
+  sha256_of() {
+    if command -v sha256sum >/dev/null 2>&1; then
+      sha256sum "$1" | awk '{print $1}'
+    else
+      shasum -a 256 "$1" | awk '{print $1}'
+    fi
+  }
+  SHA256_ARM="${SHA256_ARM:-$(sha256_of "$tmp/$arm_dmg")}"
+  SHA256_INTEL="${SHA256_INTEL:-$(sha256_of "$tmp/$intel_dmg")}"
+fi
+
+# Validate the hashes so a truncated value can't produce a cask that only fails
+# at `brew install` time.
+[[ "$SHA256_ARM" =~ ^[0-9a-f]{64}$ ]] || {
+  echo "SHA256_ARM is not a 64-char sha256 hex string" >&2
+  exit 1
+}
+[[ "$SHA256_INTEL" =~ ^[0-9a-f]{64}$ ]] || {
+  echo "SHA256_INTEL is not a 64-char sha256 hex string" >&2
+  exit 1
+}
+
+cat <<RUBY
+cask "geolibre" do
+  arch arm: "aarch64", intel: "x64"
+
+  version "${VERSION}"
+  sha256 arm:   "${SHA256_ARM}",
+         intel: "${SHA256_INTEL}"
+
+  url "https://github.com/${REPO}/releases/download/v#{version}/GeoLibre.Desktop_#{version}_#{arch}.dmg",
+      verified: "github.com/${REPO}/"
+  name "GeoLibre Desktop"
+  desc "Lightweight, cloud-native GIS platform"
+  homepage "https://geolibre.app/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  app "GeoLibre Desktop.app"
+
+  zap trash: [
+    "~/Library/Application Support/org.geolibre.desktop",
+    "~/Library/Caches/org.geolibre.desktop",
+    "~/Library/Preferences/org.geolibre.desktop.plist",
+    "~/Library/Saved Application State/org.geolibre.desktop.savedState",
+    "~/Library/WebKit/org.geolibre.desktop",
+  ]
+end
+RUBY

--- a/scripts/render-official-cask.sh
+++ b/scripts/render-official-cask.sh
@@ -36,8 +36,11 @@ if [[ -z "${VERSION:-}" ]]; then
   tag="$(gh release view --repo "$REPO" --json tagName --jq .tagName)"
   VERSION="${tag#v}"
 fi
-[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]] || {
-  echo "VERSION does not look like a semver string: '$VERSION'" >&2
+# Anchor both ends: the official tap takes only final X.Y.Z releases, so a
+# prerelease tag (1.2.3-rc.1) or any trailing junk must be rejected, not just
+# matched as a prefix.
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+  echo "VERSION does not look like a final X.Y.Z release: '$VERSION'" >&2
   exit 1
 }
 
@@ -48,8 +51,12 @@ intel_dmg="GeoLibre.Desktop_${VERSION}_x64.dmg"
 if [[ -z "${SHA256_ARM:-}" || -z "${SHA256_INTEL:-}" ]]; then
   tmp="$(mktemp -d)"
   trap 'rm -rf "$tmp"' EXIT
-  gh release download "v${VERSION}" --repo "$REPO" \
-    --pattern "$arm_dmg" --pattern "$intel_dmg" --dir "$tmp"
+  # Fetch only the DMG(s) whose hash is still unknown, so supplying one hash
+  # does not pull the other ~100 MB file needlessly.
+  [[ -n "${SHA256_ARM:-}" ]] || gh release download "v${VERSION}" --repo "$REPO" \
+    --pattern "$arm_dmg" --dir "$tmp"
+  [[ -n "${SHA256_INTEL:-}" ]] || gh release download "v${VERSION}" --repo "$REPO" \
+    --pattern "$intel_dmg" --dir "$tmp"
 
   sha256_of() {
     if command -v sha256sum >/dev/null 2>&1; then
@@ -61,6 +68,13 @@ if [[ -z "${SHA256_ARM:-}" || -z "${SHA256_INTEL:-}" ]]; then
   SHA256_ARM="${SHA256_ARM:-$(sha256_of "$tmp/$arm_dmg")}"
   SHA256_INTEL="${SHA256_INTEL:-$(sha256_of "$tmp/$intel_dmg")}"
 fi
+
+# Normalise to lowercase so a hash pasted from a tool that emits uppercase (e.g.
+# `openssl dgst -sha256`) still validates; sha256sum/shasum already emit
+# lowercase. `tr` keeps this working on macOS's default Bash 3.2, where the
+# `${var,,}` lowercase expansion is unavailable.
+SHA256_ARM="$(printf '%s' "$SHA256_ARM" | tr '[:upper:]' '[:lower:]')"
+SHA256_INTEL="$(printf '%s' "$SHA256_INTEL" | tr '[:upper:]' '[:lower:]')"
 
 # Validate the hashes so a truncated value can't produce a cask that only fails
 # at `brew install` time.


### PR DESCRIPTION
## Summary

Adds `scripts/render-official-cask.sh`, which renders the cask for submission to the **official** `homebrew/homebrew-cask` repository (`Casks/g/geolibre.rb`). This complements the existing `scripts/render-homebrew-cask.sh`, which renders the **self-hosted-tap** cask consumed by the release workflow.

Now that the macOS DMGs are Developer ID signed and notarized (#577), GeoLibre is eligible for the official tap, so users could eventually `brew install --cask geolibre` with no custom tap.

## What it does
- Resolves the version from the latest GitHub release (or an explicit `VERSION`), downloads both DMGs, and computes their `sha256` (or accepts the hashes directly to skip the download).
- Emits the official-repo cask format: the `arch` helper for the aarch64/x64 DMGs and a `livecheck` block so Homebrew's BrewTestBot auto-bumps the version on each release.
- Validates the hashes so a truncated value can't produce a cask that only fails at install time.

## Why a second script
The two repos want different cask shapes. The self-hosted-tap cask uses `on_arm`/`on_intel` blocks and (previously) a quarantine `caveats` note; the official cask uses `arch` + `livecheck` and no caveats. Keeping them separate avoids overloading one script with two output modes.

## Not included (deliberately)
- The rendered `geolibre.rb` itself (it belongs in a homebrew-cask fork, not this repo).
- Deprecating the self-hosted tap and updating docs to the no-tap install. Those should land only **after** the official cask PR is actually merged, and against the first notarized release (v1.4.1+).

## Testing
`bash -n` syntax-checked; rendered against real v1.4.0 hashes and the dummy-hash path to confirm the Ruby `#{version}`/`#{arch}` interpolations pass through literally. The final `brew audit --new --cask geolibre` + `brew install` test must be run on a Mac before opening the homebrew-cask PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated tooling for generating Homebrew Cask installation specifications. Includes support for multi-architecture builds (ARM and Intel), automatic release version detection, package integrity verification, complete metadata generation, and simplified creation of distribution packages compatible with the official Homebrew package repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->