### PR TITLE
feat(style): label vector features by attribute (label engine)

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -26,6 +26,7 @@ import {
 } from "@geolibre/ui";
 import { RASTER_SOURCE_KIND, SKETCHES_SOURCE_KIND } from "@geolibre/plugins";
 import type { MapController } from "@geolibre/map";
+import { useTranslation } from "react-i18next";
 import { RasterSymbologySection } from "./RasterSymbologySection";
 import {
   ChevronDown,
@@ -814,6 +815,7 @@ export function StylePanel({
   onResizeStart,
   autoCollapse = false,
 }: StylePanelProps) {
+  const { t } = useTranslation();
   const selectedLayerId = useAppStore((s) => s.selectedLayerId);
   const layers = useAppStore((s) => s.layers);
   const setLayerOpacity = useAppStore((s) => s.setLayerOpacity);
@@ -1659,12 +1661,12 @@ export function StylePanel({
           checked={labels.enabled}
           onChange={(event) => updateLabels({ enabled: event.target.checked })}
         />
-        Show labels
+        {t("style.labels.show")}
       </label>
       {labels.enabled ? (
         <>
           <div className="space-y-2">
-            <Label htmlFor="labelField">Label field</Label>
+            <Label htmlFor="labelField">{t("style.labels.field")}</Label>
             <Select
               id="labelField"
               value={labels.field}
@@ -1672,10 +1674,10 @@ export function StylePanel({
               onChange={(event) => updateLabels({ field: event.target.value })}
             >
               {vectorStylePropertyOptions.length === 0 ? (
-                <option value="">No attributes found</option>
+                <option value="">{t("style.labels.noAttributes")}</option>
               ) : (
                 <>
-                  <option value="">Select a field…</option>
+                  <option value="">{t("style.labels.selectField")}</option>
                   {vectorStylePropertyOptions.map((property) => (
                     <option key={property} value={property}>
                       {property}
@@ -1686,7 +1688,9 @@ export function StylePanel({
             </Select>
           </div>
           <div className="space-y-2">
-            <Label htmlFor="labelPlacement">Placement</Label>
+            <Label htmlFor="labelPlacement">
+              {t("style.labels.placement")}
+            </Label>
             <Select
               id="labelPlacement"
               value={labels.placement}
@@ -1696,14 +1700,14 @@ export function StylePanel({
                 })
               }
             >
-              <option value="point">Centroid / point</option>
-              <option value="line">Along line</option>
+              <option value="point">{t("style.labels.placementPoint")}</option>
+              <option value="line">{t("style.labels.placementLine")}</option>
             </Select>
           </div>
           <div className="grid grid-cols-2 gap-3">
             <NumericStyleInput
               id="labelSize"
-              label="Text size"
+              label={t("style.labels.textSize")}
               min={6}
               max={48}
               step={1}
@@ -1712,7 +1716,7 @@ export function StylePanel({
             />
             <NumericStyleInput
               id="labelHaloWidth"
-              label="Halo width"
+              label={t("style.labels.haloWidth")}
               min={0}
               max={8}
               step={0.5}
@@ -1722,7 +1726,9 @@ export function StylePanel({
           </div>
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-2">
-              <Label htmlFor="labelColor">Text color</Label>
+              <Label htmlFor="labelColor">
+                {t("style.labels.textColor")}
+              </Label>
               <ColorField
                 id="labelColor"
                 value={labels.color}
@@ -1730,7 +1736,9 @@ export function StylePanel({
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="labelHaloColor">Halo color</Label>
+              <Label htmlFor="labelHaloColor">
+                {t("style.labels.haloColor")}
+              </Label>
               <ColorField
                 id="labelHaloColor"
                 value={labels.haloColor}
@@ -1741,21 +1749,25 @@ export function StylePanel({
           <div className="grid grid-cols-2 gap-3">
             <NumericStyleInput
               id="labelMinZoom"
-              label="Min zoom"
+              label={t("style.labels.minZoom")}
               min={0}
-              max={24}
+              max={labels.maxZoom}
               step={1}
               value={labels.minZoom}
-              onChange={(minZoom) => updateLabels({ minZoom })}
+              onChange={(minZoom) =>
+                updateLabels({ minZoom: Math.min(minZoom, labels.maxZoom) })
+              }
             />
             <NumericStyleInput
               id="labelMaxZoom"
-              label="Max zoom"
-              min={0}
+              label={t("style.labels.maxZoom")}
+              min={labels.minZoom}
               max={24}
               step={1}
               value={labels.maxZoom}
-              onChange={(maxZoom) => updateLabels({ maxZoom })}
+              onChange={(maxZoom) =>
+                updateLabels({ maxZoom: Math.max(maxZoom, labels.minZoom) })
+              }
             />
           </div>
           <label
@@ -1770,10 +1782,12 @@ export function StylePanel({
                 updateLabels({ allowOverlap: event.target.checked })
               }
             />
-            Allow labels to overlap
+            {t("style.labels.allowOverlap")}
           </label>
           <div className="space-y-2">
-            <Label htmlFor="labelExpression">Expression (optional)</Label>
+            <Label htmlFor="labelExpression">
+              {t("style.labels.expression")}
+            </Label>
             <textarea
               id="labelExpression"
               className="min-h-16 w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-xs placeholder:text-muted-foreground focus-visible:border-2 focus-visible:border-ring focus-visible:outline-none focus-visible:ring-0"
@@ -1784,7 +1798,7 @@ export function StylePanel({
               }
             />
             <p className="text-xs text-muted-foreground">
-              A MapLibre expression (JSON). Overrides the field when set.
+              {t("style.labels.expressionHint")}
             </p>
           </div>
         </>
@@ -2295,7 +2309,9 @@ export function StylePanel({
           {!extrusionEnabled && pointRenderer !== "heatmap" ? (
             <>
               <Separator />
-              <p className="text-sm font-semibold">Labels</p>
+              <p className="text-sm font-semibold">
+                {t("style.labels.heading")}
+              </p>
               {labelControls}
             </>
           ) : null}

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1,5 +1,6 @@
 import {
   DEFAULT_LAYER_STYLE,
+  type LabelStyle,
   type LayerType,
   type PointRenderer,
   type StrokeWidthUnit,
@@ -1100,6 +1101,12 @@ export function StylePanel({
   const extrusionEnabled = styleValue(style, "extrusionEnabled");
   const extrusionHeightPropertyOptions = getAttributePropertyNames(layer);
   const vectorStylePropertyOptions = extrusionHeightPropertyOptions;
+  const labels: LabelStyle = {
+    ...DEFAULT_LAYER_STYLE.labels,
+    ...styleValue(style, "labels"),
+  };
+  const updateLabels = (patch: Partial<LabelStyle>) =>
+    setLayerStyle(layer.id, { labels: { ...labels, ...patch } });
   const extrusionHeightProperties = extrusionHeightPropertyOptions.includes(
     draftExtrusionHeightProperty,
   )
@@ -1640,6 +1647,150 @@ export function StylePanel({
       )}
     </div>
   );
+  const labelControls = (
+    <div className="space-y-3">
+      <label
+        htmlFor="labelsEnabled"
+        className="flex items-center gap-2 text-sm font-medium"
+      >
+        <input
+          id="labelsEnabled"
+          type="checkbox"
+          checked={labels.enabled}
+          onChange={(event) => updateLabels({ enabled: event.target.checked })}
+        />
+        Show labels
+      </label>
+      {labels.enabled ? (
+        <>
+          <div className="space-y-2">
+            <Label htmlFor="labelField">Label field</Label>
+            <Select
+              id="labelField"
+              value={labels.field}
+              disabled={vectorStylePropertyOptions.length === 0}
+              onChange={(event) => updateLabels({ field: event.target.value })}
+            >
+              {vectorStylePropertyOptions.length === 0 ? (
+                <option value="">No attributes found</option>
+              ) : (
+                <>
+                  <option value="">Select a field…</option>
+                  {vectorStylePropertyOptions.map((property) => (
+                    <option key={property} value={property}>
+                      {property}
+                    </option>
+                  ))}
+                </>
+              )}
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="labelPlacement">Placement</Label>
+            <Select
+              id="labelPlacement"
+              value={labels.placement}
+              onChange={(event) =>
+                updateLabels({
+                  placement: event.target.value as "point" | "line",
+                })
+              }
+            >
+              <option value="point">Centroid / point</option>
+              <option value="line">Along line</option>
+            </Select>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <NumericStyleInput
+              id="labelSize"
+              label="Text size"
+              min={6}
+              max={48}
+              step={1}
+              value={labels.size}
+              onChange={(size) => updateLabels({ size })}
+            />
+            <NumericStyleInput
+              id="labelHaloWidth"
+              label="Halo width"
+              min={0}
+              max={8}
+              step={0.5}
+              value={labels.haloWidth}
+              onChange={(haloWidth) => updateLabels({ haloWidth })}
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-2">
+              <Label htmlFor="labelColor">Text color</Label>
+              <ColorField
+                id="labelColor"
+                value={labels.color}
+                onChange={(color) => updateLabels({ color })}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="labelHaloColor">Halo color</Label>
+              <ColorField
+                id="labelHaloColor"
+                value={labels.haloColor}
+                onChange={(haloColor) => updateLabels({ haloColor })}
+              />
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <NumericStyleInput
+              id="labelMinZoom"
+              label="Min zoom"
+              min={0}
+              max={24}
+              step={1}
+              value={labels.minZoom}
+              onChange={(minZoom) => updateLabels({ minZoom })}
+            />
+            <NumericStyleInput
+              id="labelMaxZoom"
+              label="Max zoom"
+              min={0}
+              max={24}
+              step={1}
+              value={labels.maxZoom}
+              onChange={(maxZoom) => updateLabels({ maxZoom })}
+            />
+          </div>
+          <label
+            htmlFor="labelAllowOverlap"
+            className="flex items-center gap-2 text-sm font-medium"
+          >
+            <input
+              id="labelAllowOverlap"
+              type="checkbox"
+              checked={labels.allowOverlap}
+              onChange={(event) =>
+                updateLabels({ allowOverlap: event.target.checked })
+              }
+            />
+            Allow labels to overlap
+          </label>
+          <div className="space-y-2">
+            <Label htmlFor="labelExpression">Expression (optional)</Label>
+            <textarea
+              id="labelExpression"
+              className="min-h-16 w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-xs placeholder:text-muted-foreground focus-visible:border-2 focus-visible:border-ring focus-visible:outline-none focus-visible:ring-0"
+              placeholder={'["concat", ["get", "name"], " (", ["get", "pop"], ")"]'}
+              value={labels.expression}
+              onChange={(event) =>
+                updateLabels({ expression: event.target.value })
+              }
+            />
+            <p className="text-xs text-muted-foreground">
+              A MapLibre expression (JSON). Overrides the field when set.
+            </p>
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
   const twoDimensionalControls = (
     <>
       {supportsPointRenderer ? (
@@ -2139,6 +2290,15 @@ export function StylePanel({
           ) : (
             extrusionControls
           )}
+          {/* Attribute labels apply to vector features, not the heatmap density
+              surface or the 3D extrusion render. */}
+          {!extrusionEnabled && pointRenderer !== "heatmap" ? (
+            <>
+              <Separator />
+              <p className="text-sm font-semibold">Labels</p>
+              {labelControls}
+            </>
+          ) : null}
         </div>
       </ScrollArea>
       <Separator />

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1109,6 +1109,18 @@ export function StylePanel({
   };
   const updateLabels = (patch: Partial<LabelStyle>) =>
     setLayerStyle(layer.id, { labels: { ...labels, ...patch } });
+  // The label expression must be a JSON array (a MapLibre expression). Flag a
+  // non-empty value that does not round-trip as an array so the user sees that
+  // it is ignored (layer-sync falls back to the field / no label) instead of
+  // silently producing nothing.
+  const labelExpressionInvalid = (() => {
+    if (!labels.expression.trim()) return false;
+    try {
+      return !Array.isArray(JSON.parse(labels.expression));
+    } catch {
+      return true;
+    }
+  })();
   const extrusionHeightProperties = extrusionHeightPropertyOptions.includes(
     draftExtrusionHeightProperty,
   )
@@ -1790,15 +1802,28 @@ export function StylePanel({
             </Label>
             <textarea
               id="labelExpression"
-              className="min-h-16 w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-xs placeholder:text-muted-foreground focus-visible:border-2 focus-visible:border-ring focus-visible:outline-none focus-visible:ring-0"
+              aria-invalid={labelExpressionInvalid}
+              className={[
+                "min-h-16 w-full rounded-md border bg-background px-3 py-2 font-mono text-xs placeholder:text-muted-foreground focus-visible:border-2 focus-visible:border-ring focus-visible:outline-none focus-visible:ring-0",
+                labelExpressionInvalid ? "border-destructive" : "border-input",
+              ].join(" ")}
               placeholder={'["concat", ["get", "name"], " (", ["get", "pop"], ")"]'}
               value={labels.expression}
               onChange={(event) =>
                 updateLabels({ expression: event.target.value })
               }
             />
-            <p className="text-xs text-muted-foreground">
-              {t("style.labels.expressionHint")}
+            <p
+              className={[
+                "text-xs",
+                labelExpressionInvalid
+                  ? "text-destructive"
+                  : "text-muted-foreground",
+              ].join(" ")}
+            >
+              {labelExpressionInvalid
+                ? t("style.labels.expressionInvalid")
+                : t("style.labels.expressionHint")}
             </p>
           </div>
         </>

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1432,6 +1432,27 @@
     "layerName": "Segmentation: {{prompt}}",
     "layerNameDefault": "Segmentation"
   },
+  "style": {
+    "labels": {
+      "heading": "Labels",
+      "show": "Show labels",
+      "field": "Label field",
+      "noAttributes": "No attributes found",
+      "selectField": "Select a field…",
+      "placement": "Placement",
+      "placementPoint": "Centroid / point",
+      "placementLine": "Along line",
+      "textSize": "Text size",
+      "haloWidth": "Halo width",
+      "textColor": "Text color",
+      "haloColor": "Halo color",
+      "minZoom": "Min zoom",
+      "maxZoom": "Max zoom",
+      "allowOverlap": "Allow labels to overlap",
+      "expression": "Expression (optional)",
+      "expressionHint": "A MapLibre expression (JSON). Overrides the field when set."
+    }
+  },
   "layers": {
     "identifyFeatures": "Identify features",
     "identifyDeactivate": "Deactivate identify",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1441,7 +1441,7 @@
       "selectField": "Select a field…",
       "placement": "Placement",
       "placementPoint": "Centroid / point",
-      "placementLine": "Along line",
+      "placementLine": "Along line / polygon edge",
       "textSize": "Text size",
       "haloWidth": "Halo width",
       "textColor": "Text color",
@@ -1450,7 +1450,8 @@
       "maxZoom": "Max zoom",
       "allowOverlap": "Allow labels to overlap",
       "expression": "Expression (optional)",
-      "expressionHint": "A MapLibre expression (JSON). Overrides the field when set."
+      "expressionHint": "A MapLibre expression (JSON). Overrides the field when set.",
+      "expressionInvalid": "Not a valid MapLibre expression (must be a JSON array). This value is ignored."
     }
   },
   "layers": {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -101,6 +101,30 @@ export interface VectorStyleStop {
   label?: string;
 }
 
+/** Attribute-driven labeling for a vector layer (rendered as a MapLibre symbol layer). */
+export interface LabelStyle {
+  /** Whether labels are shown for the layer. */
+  enabled: boolean;
+  /** Attribute field whose value becomes the label text. */
+  field: string;
+  /**
+   * Optional MapLibre expression (JSON string) for the label text, which
+   * overrides {@link field} when non-empty (e.g. concatenating several fields).
+   */
+  expression: string;
+  /** `"point"` labels at the feature/centroid; `"line"` places them along lines. */
+  placement: "point" | "line";
+  size: number;
+  color: string;
+  haloColor: string;
+  haloWidth: number;
+  /** Scale range for labels; `0` / `24` inherit the layer's own zoom range. */
+  minZoom: number;
+  maxZoom: number;
+  /** Let labels overlap instead of hiding colliding ones. */
+  allowOverlap: boolean;
+}
+
 export interface LayerStyle {
   minZoom: number;
   maxZoom: number;
@@ -124,6 +148,7 @@ export interface LayerStyle {
   textHaloColor: string;
   textHaloWidth: number;
   textSize: number;
+  labels: LabelStyle;
   extrusionEnabled: boolean;
   extrusionColor: string;
   extrusionOpacity: number;
@@ -174,6 +199,19 @@ export const DEFAULT_LAYER_STYLE: LayerStyle = {
   textHaloColor: "#ffffff",
   textHaloWidth: 2,
   textSize: 16,
+  labels: {
+    enabled: false,
+    field: "",
+    expression: "",
+    placement: "point",
+    size: 13,
+    color: "#111827",
+    haloColor: "#ffffff",
+    haloWidth: 1.5,
+    minZoom: 0,
+    maxZoom: 24,
+    allowOverlap: false,
+  },
   extrusionEnabled: false,
   extrusionColor: "#3b82f6",
   extrusionOpacity: 0.8,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -114,9 +114,13 @@ export interface LabelStyle {
   expression: string;
   /** `"point"` labels at the feature/centroid; `"line"` places them along lines. */
   placement: "point" | "line";
+  /** Label text size in pixels. */
   size: number;
+  /** CSS color string for the label text. */
   color: string;
+  /** CSS color string for the text halo drawn behind the label. */
   haloColor: string;
+  /** Width of the text halo in pixels. */
   haloWidth: number;
   /** Scale range for labels; `0` / `24` inherit the layer's own zoom range. */
   minZoom: number;

--- a/packages/map/src/geojson-loader.ts
+++ b/packages/map/src/geojson-loader.ts
@@ -89,6 +89,10 @@ export function textLayerId(layerId: string): string {
   return `layer-${layerId}-text`;
 }
 
+export function labelLayerId(layerId: string): string {
+  return `layer-${layerId}-label`;
+}
+
 export function highlightSourceId(): string {
   return "geolibre-highlight-source";
 }

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -25,6 +25,7 @@ import {
   fillExtrusionLayerId,
   fillLayerId,
   heatmapLayerId,
+  labelLayerId,
   lineLayerId,
   sourceId,
   textLayerId,
@@ -1637,6 +1638,76 @@ function applyVectorDataRenderLayers(
   } else {
     removeIfExists(map, textLayerId(layer.id));
   }
+
+  // Attribute-driven labels: a symbol layer that renders the configured field
+  // (or expression) for every feature. Distinct from the geoman text-marker
+  // layer above, which only renders annotation features.
+  const labels = {
+    ...DEFAULT_LAYER_STYLE.labels,
+    ...styleValue(layer.style, "labels"),
+  };
+  if (
+    !layer.style.extrusionEnabled &&
+    renderer !== "heatmap" &&
+    labels.enabled &&
+    (labels.expression.trim() || labels.field)
+  ) {
+    let textField: maplibregl.ExpressionSpecification | string;
+    try {
+      textField = labels.expression.trim()
+        ? (JSON.parse(labels.expression) as maplibregl.ExpressionSpecification)
+        : (["to-string", ["coalesce", ["get", labels.field], ""]] as unknown as maplibregl.ExpressionSpecification);
+    } catch {
+      // A typo'd expression must not break the whole layer sync: fall back to
+      // the field (or empty text) instead.
+      textField = labels.field
+        ? (["to-string", ["coalesce", ["get", labels.field], ""]] as unknown as maplibregl.ExpressionSpecification)
+        : "";
+    }
+    const labelZoom = intersectZoomRange(
+      {
+        minzoom: clampLayerZoom(labels.minZoom, MIN_LAYER_ZOOM),
+        maxzoom: clampLayerZoom(labels.maxZoom, MAX_LAYER_ZOOM),
+      },
+      layer.style,
+    );
+    // Skip geoman text-marker points (they carry their own annotation text);
+    // the coalesce defaults to "" for normal features so they all pass.
+    const nonMarkerFilter = [
+      "!=",
+      ["coalesce", ["get", GEOMAN_SHAPE_PROPERTY], ["get", "shape"], ""],
+      TEXT_MARKER_SHAPE,
+    ] as unknown as maplibregl.FilterSpecification;
+    ensureLayer(
+      map,
+      labelLayerId(layer.id),
+      {
+        id: labelLayerId(layer.id),
+        type: "symbol",
+        ...sourceSpec,
+        ...labelZoom,
+        filter: withTimeFilter(layer, nonMarkerFilter),
+        layout: {
+          "text-field": textField,
+          "text-font": textFontForMapStyle(map),
+          "text-size": Math.max(1, labels.size),
+          "symbol-placement": labels.placement === "line" ? "line" : "point",
+          "text-allow-overlap": labels.allowOverlap,
+          "text-ignore-placement": labels.allowOverlap,
+          visibility,
+        },
+        paint: {
+          "text-color": labels.color,
+          "text-halo-color": labels.haloColor,
+          "text-halo-width": Math.max(0, labels.haloWidth),
+          "text-opacity": opacity,
+        },
+      },
+      beforeId,
+    );
+  } else {
+    removeIfExists(map, labelLayerId(layer.id));
+  }
 }
 
 // syncs can fire rapidly (e.g. dragging an opacity slider), and this is an O(n)
@@ -2464,6 +2535,7 @@ function removeGeoJsonRenderLayers(map: maplibregl.Map, layerId: string): void {
     clusterLayerId(layerId),
     clusterCountLayerId(layerId),
     textLayerId(layerId),
+    labelLayerId(layerId),
   ]) {
     removeIfExists(map, id);
   }
@@ -2500,6 +2572,7 @@ export function removeLayerFromMap(
     clusterLayerId(layerId),
     clusterCountLayerId(layerId),
     textLayerId(layerId),
+    labelLayerId(layerId),
     `layer-${layerId}-raster`,
     `layer-${layerId}-video`,
     `layer-${layerId}-image`,

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -1652,17 +1652,26 @@ function applyVectorDataRenderLayers(
     labels.enabled &&
     (labels.expression.trim() || labels.field)
   ) {
+    const fieldTextField = (
+      labels.field
+        ? ["to-string", ["coalesce", ["get", labels.field], ""]]
+        : ""
+    ) as unknown as maplibregl.ExpressionSpecification | string;
     let textField: maplibregl.ExpressionSpecification | string;
     try {
-      textField = labels.expression.trim()
-        ? (JSON.parse(labels.expression) as maplibregl.ExpressionSpecification)
-        : (["to-string", ["coalesce", ["get", labels.field], ""]] as unknown as maplibregl.ExpressionSpecification);
+      if (labels.expression.trim()) {
+        const parsed = JSON.parse(labels.expression);
+        // JSON.parse accepts non-expressions (numbers, objects, null); only an
+        // array is a usable MapLibre expression, so reject anything else and
+        // fall back to the field.
+        if (!Array.isArray(parsed)) throw new Error("not an expression");
+        textField = parsed as maplibregl.ExpressionSpecification;
+      } else {
+        textField = fieldTextField;
+      }
     } catch {
-      // A typo'd expression must not break the whole layer sync: fall back to
-      // the field (or empty text) instead.
-      textField = labels.field
-        ? (["to-string", ["coalesce", ["get", labels.field], ""]] as unknown as maplibregl.ExpressionSpecification)
-        : "";
+      // A typo'd or non-expression value must not break the whole layer sync.
+      textField = fieldTextField;
     }
     const labelZoom = intersectZoomRange(
       {
@@ -1671,12 +1680,11 @@ function applyVectorDataRenderLayers(
       },
       layer.style,
     );
-    // Skip geoman text-marker points (they carry their own annotation text);
-    // the coalesce defaults to "" for normal features so they all pass.
+    // Skip geoman text-marker points (they carry their own annotation text),
+    // reusing the same two-property predicate the circle/text layers use.
     const nonMarkerFilter = [
-      "!=",
-      ["coalesce", ["get", GEOMAN_SHAPE_PROPERTY], ["get", "shape"], ""],
-      TEXT_MARKER_SHAPE,
+      "!",
+      textMarkerShapeFilter,
     ] as unknown as maplibregl.FilterSpecification;
     ensureLayer(
       map,

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -1673,46 +1673,53 @@ function applyVectorDataRenderLayers(
       // A typo'd or non-expression value must not break the whole layer sync.
       textField = fieldTextField;
     }
-    const labelZoom = intersectZoomRange(
-      {
-        minzoom: clampLayerZoom(labels.minZoom, MIN_LAYER_ZOOM),
-        maxzoom: clampLayerZoom(labels.maxZoom, MAX_LAYER_ZOOM),
-      },
-      layer.style,
-    );
-    // Skip geoman text-marker points (they carry their own annotation text),
-    // reusing the same two-property predicate the circle/text layers use.
-    const nonMarkerFilter = [
-      "!",
-      textMarkerShapeFilter,
-    ] as unknown as maplibregl.FilterSpecification;
-    ensureLayer(
-      map,
-      labelLayerId(layer.id),
-      {
-        id: labelLayerId(layer.id),
-        type: "symbol",
-        ...sourceSpec,
-        ...labelZoom,
-        filter: withTimeFilter(layer, nonMarkerFilter),
-        layout: {
-          "text-field": textField,
-          "text-font": textFontForMapStyle(map),
-          "text-size": Math.max(1, labels.size),
-          "symbol-placement": labels.placement === "line" ? "line" : "point",
-          "text-allow-overlap": labels.allowOverlap,
-          "text-ignore-placement": labels.allowOverlap,
-          visibility,
+    if (textField === "") {
+      // An invalid expression with no field falls back to an empty text-field,
+      // which would create an invisible label layer that still consumes
+      // renderer resources. Remove it instead of adding an empty one.
+      removeIfExists(map, labelLayerId(layer.id));
+    } else {
+      const labelZoom = intersectZoomRange(
+        {
+          minzoom: clampLayerZoom(labels.minZoom, MIN_LAYER_ZOOM),
+          maxzoom: clampLayerZoom(labels.maxZoom, MAX_LAYER_ZOOM),
         },
-        paint: {
-          "text-color": labels.color,
-          "text-halo-color": labels.haloColor,
-          "text-halo-width": Math.max(0, labels.haloWidth),
-          "text-opacity": opacity,
+        layer.style,
+      );
+      // Skip geoman text-marker points (they carry their own annotation text),
+      // reusing the same two-property predicate the circle/text layers use.
+      const nonMarkerFilter = [
+        "!",
+        textMarkerShapeFilter,
+      ] as unknown as maplibregl.FilterSpecification;
+      ensureLayer(
+        map,
+        labelLayerId(layer.id),
+        {
+          id: labelLayerId(layer.id),
+          type: "symbol",
+          ...sourceSpec,
+          ...labelZoom,
+          filter: withTimeFilter(layer, nonMarkerFilter),
+          layout: {
+            "text-field": textField,
+            "text-font": textFontForMapStyle(map),
+            "text-size": Math.max(1, labels.size),
+            "symbol-placement": labels.placement === "line" ? "line" : "point",
+            "text-allow-overlap": labels.allowOverlap,
+            "text-ignore-placement": labels.allowOverlap,
+            visibility,
+          },
+          paint: {
+            "text-color": labels.color,
+            "text-halo-color": labels.haloColor,
+            "text-halo-width": Math.max(0, labels.haloWidth),
+            "text-opacity": opacity,
+          },
         },
-      },
-      beforeId,
-    );
+        beforeId,
+      );
+    }
   } else {
     removeIfExists(map, labelLayerId(layer.id));
   }

--- a/tests/label-sync.test.ts
+++ b/tests/label-sync.test.ts
@@ -162,6 +162,29 @@ describe("label sync", () => {
     ]);
   });
 
+  it("does not create a label layer when the expression is invalid and no field is set", () => {
+    const { map, layers } = makeMap();
+    // Invalid expression + empty field would fall back to an empty text-field;
+    // the layer must be skipped rather than added with invisible text.
+    syncLayer(
+      map as never,
+      labeledLayer({ enabled: true, field: "", expression: "{not json" }),
+    );
+    assert.ok(!layers.has(LABEL_ID));
+  });
+
+  it("removes an existing label layer when the expression becomes invalid with no field", () => {
+    const { map, layers } = makeMap();
+    syncLayer(map as never, labeledLayer({ enabled: true, field: "name" }));
+    assert.ok(layers.has(LABEL_ID));
+
+    syncLayer(
+      map as never,
+      labeledLayer({ enabled: true, field: "", expression: "{not json" }),
+    );
+    assert.ok(!layers.has(LABEL_ID));
+  });
+
   it("places labels along the line when placement is line", () => {
     const { map, layers } = makeMap();
     syncLayer(

--- a/tests/label-sync.test.ts
+++ b/tests/label-sync.test.ts
@@ -147,6 +147,21 @@ describe("label sync", () => {
     ]);
   });
 
+  it("falls back to the field when the expression is valid JSON but not an array", () => {
+    const { map, layers } = makeMap();
+    // `42` / `{"k":1}` parse cleanly but are not MapLibre expressions.
+    syncLayer(
+      map as never,
+      labeledLayer({ enabled: true, field: "name", expression: '{"k":1}' }),
+    );
+
+    const label = layers.get(LABEL_ID) as { layout: Record<string, unknown> };
+    assert.deepEqual(label.layout["text-field"], [
+      "to-string",
+      ["coalesce", ["get", "name"], ""],
+    ]);
+  });
+
   it("places labels along the line when placement is line", () => {
     const { map, layers } = makeMap();
     syncLayer(

--- a/tests/label-sync.test.ts
+++ b/tests/label-sync.test.ts
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  DEFAULT_LAYER_STYLE,
+  type GeoLibreLayer,
+  type LabelStyle,
+} from "@geolibre/core";
+import { syncLayer } from "../packages/map/src/layer-sync";
+
+// Stateful fake MapLibre map (mirrors point-renderer-sync.test.ts) so a test can
+// assert which native layers a labels config produces.
+function makeMap() {
+  const sources = new Map<string, Record<string, unknown>>();
+  const layers = new Map<string, Record<string, unknown>>();
+  const map = {
+    getSource: (id: string) =>
+      sources.has(id) ? { setData: () => {} } : undefined,
+    addSource: (id: string, spec: Record<string, unknown>) => {
+      sources.set(id, spec);
+    },
+    removeSource: (id: string) => sources.delete(id),
+    getLayer: (id: string) =>
+      layers.has(id) ? { id, ...layers.get(id) } : undefined,
+    addLayer: (spec: Record<string, unknown>) => {
+      layers.set(spec.id as string, spec);
+    },
+    removeLayer: (id: string) => layers.delete(id),
+    getFilter: (id: string) => layers.get(id)?.filter,
+    setFilter: () => {},
+    setPaintProperty: () => {},
+    setLayoutProperty: () => {},
+    setLayerZoomRange: () => {},
+    moveLayer: () => {},
+    getStyle: () => ({
+      layers: [{ type: "symbol", layout: { "text-field": ["get", "x"] } }],
+      sources: Object.fromEntries(sources),
+    }),
+    once: () => {},
+  };
+  return { map, layers };
+}
+
+type Geom = "point" | "line";
+
+function labeledLayer(
+  labelPatch: Partial<LabelStyle>,
+  geometry: Geom = "point",
+): GeoLibreLayer {
+  const coords =
+    geometry === "line"
+      ? {
+          type: "LineString" as const,
+          coordinates: [
+            [0, 0],
+            [1, 1],
+          ],
+        }
+      : { type: "Point" as const, coordinates: [0, 0] };
+  return {
+    id: "lyr",
+    name: "Layer",
+    type: "geojson",
+    source: { type: "geojson" },
+    visible: true,
+    opacity: 1,
+    style: {
+      ...DEFAULT_LAYER_STYLE,
+      labels: { ...DEFAULT_LAYER_STYLE.labels, ...labelPatch },
+    },
+    metadata: {},
+    geojson: {
+      type: "FeatureCollection",
+      features: [
+        { type: "Feature", properties: { name: "A", pop: 5 }, geometry: coords },
+      ],
+    },
+  };
+}
+
+const LABEL_ID = "layer-lyr-label";
+
+describe("label sync", () => {
+  it("creates a label symbol layer from the configured field", () => {
+    const { map, layers } = makeMap();
+    syncLayer(map as never, labeledLayer({ enabled: true, field: "name" }));
+
+    const label = layers.get(LABEL_ID) as {
+      type: string;
+      layout: Record<string, unknown>;
+    };
+    assert.ok(label, "label layer should exist");
+    assert.equal(label.type, "symbol");
+    assert.deepEqual(label.layout["text-field"], [
+      "to-string",
+      ["coalesce", ["get", "name"], ""],
+    ]);
+    assert.equal(label.layout["symbol-placement"], "point");
+  });
+
+  it("does not create a label layer when labels are disabled", () => {
+    const { map, layers } = makeMap();
+    syncLayer(map as never, labeledLayer({ enabled: false, field: "name" }));
+    assert.ok(!layers.has(LABEL_ID));
+  });
+
+  it("does not create a label layer when no field or expression is set", () => {
+    const { map, layers } = makeMap();
+    syncLayer(map as never, labeledLayer({ enabled: true, field: "" }));
+    assert.ok(!layers.has(LABEL_ID));
+  });
+
+  it("removes the label layer when labels are turned off", () => {
+    const { map, layers } = makeMap();
+    syncLayer(map as never, labeledLayer({ enabled: true, field: "name" }));
+    assert.ok(layers.has(LABEL_ID));
+
+    syncLayer(map as never, labeledLayer({ enabled: false, field: "name" }));
+    assert.ok(!layers.has(LABEL_ID));
+  });
+
+  it("uses the expression, overriding the field", () => {
+    const { map, layers } = makeMap();
+    syncLayer(
+      map as never,
+      labeledLayer({
+        enabled: true,
+        field: "name",
+        expression: '["get", "pop"]',
+      }),
+    );
+
+    const label = layers.get(LABEL_ID) as { layout: Record<string, unknown> };
+    assert.deepEqual(label.layout["text-field"], ["get", "pop"]);
+  });
+
+  it("falls back to the field when the expression is invalid JSON", () => {
+    const { map, layers } = makeMap();
+    syncLayer(
+      map as never,
+      labeledLayer({ enabled: true, field: "name", expression: "{not json" }),
+    );
+
+    const label = layers.get(LABEL_ID) as { layout: Record<string, unknown> };
+    assert.deepEqual(label.layout["text-field"], [
+      "to-string",
+      ["coalesce", ["get", "name"], ""],
+    ]);
+  });
+
+  it("places labels along the line when placement is line", () => {
+    const { map, layers } = makeMap();
+    syncLayer(
+      map as never,
+      labeledLayer({ enabled: true, field: "name", placement: "line" }, "line"),
+    );
+
+    const label = layers.get(LABEL_ID) as { layout: Record<string, unknown> };
+    assert.equal(label.layout["symbol-placement"], "line");
+  });
+
+  it("applies the label appearance and scale range", () => {
+    const { map, layers } = makeMap();
+    syncLayer(
+      map as never,
+      labeledLayer({
+        enabled: true,
+        field: "name",
+        size: 20,
+        color: "#ff0000",
+        minZoom: 5,
+        maxZoom: 12,
+      }),
+    );
+
+    const label = layers.get(LABEL_ID) as {
+      layout: Record<string, unknown>;
+      paint: Record<string, unknown>;
+      minzoom: number;
+      maxzoom: number;
+    };
+    assert.equal(label.layout["text-size"], 20);
+    assert.equal(label.paint["text-color"], "#ff0000");
+    // The label's scale range is intersected with the layer's own zoom range
+    // (default 0-24), so the tighter 5-12 wins.
+    assert.equal(label.minzoom, 5);
+    assert.equal(label.maxzoom, 12);
+  });
+});


### PR DESCRIPTION
## Summary

Vector layers could style label *text* (`textColor`/`textSize`/...) but had no way to actually **label features by an attribute field** — the single biggest gap in GeoLibre's styling stack versus QGIS (Labels tab) and ArcGIS (Label Classes). This adds an attribute-driven label engine.

## Changes

- **`@geolibre/core`** — `LayerStyle` gains a `labels: LabelStyle` config: `enabled`, `field`, `expression` (JSON, overrides the field), `placement` (`point`/`line`), `size`, `color`, `haloColor`, `haloWidth`, `minZoom`/`maxZoom`, `allowOverlap`, with defaults. It persists in `.geolibre.json`, and old projects without it degrade gracefully via `styleValue`'s default fallback.
- **`@geolibre/map`** — a paired `layer-<id>-label` **symbol** layer in `applyVectorDataRenderLayers` (the shared geojson render path) renders the field, or a JSON expression that overrides it, for every feature. Centroid/point vs along-line placement; the label scale range is intersected with the layer's own; halo + collision; removed on layer teardown. An invalid expression falls back to the field so a typo can't break the whole layer sync. Geoman text-marker points are excluded (they carry their own annotation text).
- **StylePanel** — a **Labels** section: enable toggle, field dropdown, placement, text size, text/halo colors, halo width, min/max zoom, allow-overlap, and an advanced expression box.

## Acceptance criteria (from #582)

- [x] Enable labels + pick a field → labels render
- [x] Expression-based labels (overrides the field)
- [x] Line layers label along the line; point/polygon at the centroid
- [x] Scale-based visibility (min/max zoom)
- [x] Round-trips through project save/load (it is a `LayerStyle` field)

## Verification

- New `tests/label-sync.test.ts` (8 cases) deterministically drives `syncLayer` against a fake map: label layer created from the field; expression override; invalid-expression fallback; not created when disabled / no field; removed when turned off; along-line placement; appearance + scale-range intersection.
- Confirmed the Style panel **Labels** section in the running app: it renders for vector layers, the enable toggle reveals the controls, and the field dropdown populates from the layer's attributes.
- `npm run test:frontend` (1233 tests), `npm run build`, and `pre-commit` all pass.

Fixes #582

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added attribute-driven vector label styling to the desktop style panel, including a “Show labels” toggle, field/expression selection, point/line placement, text + halo styling, min/max zoom limits, and overlap control.
  * Automatically adds dedicated Map labels for eligible vector layers (2D mode, not heatmap) when labels are enabled and a valid field/expression is provided.
* **Bug Fixes**
  * Improved label expression validation with clear error feedback; invalid expressions safely fall back to a derived text-field.
* **Tests**
  * Added automated tests for label layer creation/removal, placement mapping, expression handling, and zoom clamping.
* **Documentation**
  * Updated English UI translations for the new label controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->