### PR TITLE
fix(packaging): emit depends_on :macos in official cask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ python/examples/my-map.geolibre.json
 
 # Cloudflare Workers local dev state (wrangler dev / miniflare)
 .wrangler/
+
+# Rendered Homebrew cask, emitted to the working dir by scripts/render-*-cask.sh
+# for submission to a tap / homebrew-cask; not committed to this repo.
+/geolibre.rb

--- a/scripts/render-official-cask.sh
+++ b/scripts/render-official-cask.sh
@@ -122,6 +122,8 @@ cask "geolibre" do
     strategy :github_latest
   end
 
+  depends_on :macos
+
   app "GeoLibre Desktop.app"
 
   zap trash: [


### PR DESCRIPTION
## Summary
While preparing the homebrew/homebrew-cask submission, `brew style --cask geolibre` flagged the rendered cask for a missing `depends_on :macos` (required for macOS-only casks). The official-cask generator now emits it so the output passes `brew style` and `brew audit --new --cask` cleanly, with no manual fixup before opening the homebrew-cask PR.

## Changes
- `scripts/render-official-cask.sh`: add `depends_on :macos` to the rendered cask.
- `.gitignore`: ignore the rendered `/geolibre.rb` that `render-*-cask.sh` writes to the working dir for submission (it belongs in the tap / homebrew-cask PR, not this repo).

## Verification
- `brew style --cask geolibre` → no offenses.
- `brew audit --new --cask geolibre` → passes all checks except the homebrew-cask 30-day repo-age gate (clears 2026-06-26); notability already satisfied (986★ / 136 forks).
- Generator output is byte-identical to the validated cask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to exclude locally-generated files from version control.
  * Enhanced Homebrew cask configuration to explicitly specify macOS as a required dependency for installations via Homebrew.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->