### PR TITLE
fix(toolbar): deactivate Navigation control by default for new projects

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/toolbar/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/constants.ts
@@ -66,7 +66,6 @@ export const MAP_CONTROL_ITEMS: Array<{
 ];
 
 export const NEW_PROJECT_VISIBLE_BUILT_IN_CONTROLS = new Set<BuiltInMapControl>([
-  "navigation",
   "fullscreen",
   "compass",
   "globe",


### PR DESCRIPTION
## Summary

`Project → New` was creating maps with the Navigation control already activated. It should be off by default.

## Root cause

`resetRuntimeControlsForNewProject` forces each built-in control's visibility from the `NEW_PROJECT_VISIBLE_BUILT_IN_CONTROLS` set rather than the controller baseline (`DEFAULT_BUILT_IN_CONTROL_VISIBILITY.navigation`, which is already `false`). That set explicitly listed `"navigation"`, so every new map re-activated the Navigation control.

## Change

Removed `"navigation"` from `NEW_PROJECT_VISIBLE_BUILT_IN_CONTROLS` in `apps/geolibre-desktop/src/components/layout/toolbar/constants.ts`. Since that same set drives both the actual control visibility and the View-menu checkmark, the Navigation control is now off by default for new maps while remaining toggleable from the View menu.

## Testing

- `pre-commit run --files apps/geolibre-desktop/src/components/layout/toolbar/constants.ts` (eslint + npm build) passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default map control visibility settings for new projects. The navigation control is no longer enabled by default when creating a new project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->