### PR TITLE
fix(settings): remove redundant project status indicators (#590)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
@@ -8,6 +8,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@geolibre/ui";
+import { PROJECT_VERSION } from "@geolibre/core";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { CheckCircle2, ExternalLink, Info, Map, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -223,6 +224,10 @@ export function AboutDialog({
           <div className="flex items-center justify-between rounded-md border bg-muted/30 px-3 py-2">
             <span className="text-muted-foreground">Version</span>
             <span className="font-mono text-foreground">v{APP_VERSION}</span>
+          </div>
+          <div className="flex items-center justify-between rounded-md border bg-muted/30 px-3 py-2">
+            <span className="text-muted-foreground">Project format</span>
+            <span className="font-mono text-foreground">{PROJECT_VERSION}</span>
           </div>
           <Button
             className="w-full justify-between"

--- a/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
@@ -12,6 +12,7 @@ import { PROJECT_VERSION } from "@geolibre/core";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { CheckCircle2, ExternalLink, Info, Map, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 
 const LINKS = [
   {
@@ -92,6 +93,7 @@ export function AboutDialog({
   iconClassName,
   showLabels = true,
 }: AboutDialogProps) {
+  const { t } = useTranslation();
   const [internalOpen, setInternalOpen] = useState(false);
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus>("idle");
   const [latestVersion, setLatestVersion] = useState<string | null>(null);
@@ -226,7 +228,9 @@ export function AboutDialog({
             <span className="font-mono text-foreground">v{APP_VERSION}</span>
           </div>
           <div className="flex items-center justify-between rounded-md border bg-muted/30 px-3 py-2">
-            <span className="text-muted-foreground">Project format</span>
+            <span className="text-muted-foreground">
+              {t("about.projectFormat")}
+            </span>
             <span className="font-mono text-foreground">{PROJECT_VERSION}</span>
           </div>
           <Button

--- a/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
@@ -12,7 +12,6 @@ import { PROJECT_VERSION } from "@geolibre/core";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { CheckCircle2, ExternalLink, Info, Map, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useTranslation } from "react-i18next";
 
 const LINKS = [
   {
@@ -93,7 +92,6 @@ export function AboutDialog({
   iconClassName,
   showLabels = true,
 }: AboutDialogProps) {
-  const { t } = useTranslation();
   const [internalOpen, setInternalOpen] = useState(false);
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus>("idle");
   const [latestVersion, setLatestVersion] = useState<string | null>(null);
@@ -228,9 +226,7 @@ export function AboutDialog({
             <span className="font-mono text-foreground">v{APP_VERSION}</span>
           </div>
           <div className="flex items-center justify-between rounded-md border bg-muted/30 px-3 py-2">
-            <span className="text-muted-foreground">
-              {t("about.projectFormat")}
-            </span>
+            <span className="text-muted-foreground">Project format</span>
             <span className="font-mono text-foreground">{PROJECT_VERSION}</span>
           </div>
           <Button

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -3,7 +3,6 @@ import {
   GEOCODING_PROVIDERS,
   getGeocodingProvider,
   normalizeGeocodingProviderId,
-  PROJECT_VERSION,
   useAppStore,
   type MapPreferences,
   type MapProjection,
@@ -87,8 +86,7 @@ export type SettingsSection =
   | "layout"
   | "interface"
   | "geocoding"
-  | "environment"
-  | "project";
+  | "environment";
 
 /** Window event letting any panel open Settings at a given section (no prop-drilling). */
 export const OPEN_SETTINGS_EVENT = "geolibre:open-settings";
@@ -136,7 +134,6 @@ const SECTION_ITEMS: Array<{
     labelKey: "settings.section.environment",
     icon: Braces,
   },
-  { id: "project", labelKey: "settings.section.project", icon: FolderCog },
 ];
 
 // The menu-item id that gates each Settings section, mirroring the dropdown.
@@ -146,7 +143,6 @@ const SECTION_GATE: Partial<Record<SettingsSection, string>> = {
   map: "settings.mapPreferences",
   geocoding: "settings.geocoding",
   environment: "settings.environment",
-  project: "settings.projectSettings",
 };
 
 const VARIABLE_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
@@ -321,7 +317,6 @@ export function SettingsDialog({
   // reachable.
   const showSettingsItem = (id: string) =>
     isMenuItemVisible(desktopSettings.uiProfile, id);
-  const projectPath = useAppStore((s) => s.projectPath);
   const [open, setOpen] = useState(false);
   const [section, setSection] = useState<SettingsSection>("map");
   // A gated section is dropped from the nav, but `section` can still point at one
@@ -919,17 +914,6 @@ export function SettingsDialog({
             >
               <Braces className="mr-2 h-3.5 w-3.5" />
               {t("settings.menu.environmentVariables")}
-            </DropdownMenuItem>
-          )}
-          {showSettingsItem("settings.projectSettings") && (
-            <DropdownMenuItem
-              onSelect={() => {
-                setSection("project");
-                setOpen(true);
-              }}
-            >
-              <FolderCog className="mr-2 h-3.5 w-3.5" />
-              {t("settings.menu.projectSettings")}
             </DropdownMenuItem>
           )}
           {showSettingsItem("settings.managePlugins") && (
@@ -1726,32 +1710,6 @@ export function SettingsDialog({
                       )}
                     </div>
                   )}
-                </div>
-              ) : null}
-              {effectiveSection === "project" ? (
-                <div className="space-y-5">
-                  <div>
-                    <h3 className="text-sm font-semibold">
-                      {t("settings.project.title")}
-                    </h3>
-                    <p className="text-xs text-muted-foreground">
-                      {t("settings.project.description")}
-                    </p>
-                  </div>
-                  <div className="grid gap-3 sm:grid-cols-2">
-                    <div className="space-y-1.5">
-                      <Label>{t("settings.project.file")}</Label>
-                      <div className="min-h-9 truncate rounded-md border bg-muted px-3 py-2 text-sm text-muted-foreground">
-                        {projectPath ?? t("settings.project.notSaved")}
-                      </div>
-                    </div>
-                    <div className="space-y-1.5">
-                      <Label>{t("settings.project.format")}</Label>
-                      <div className="min-h-9 rounded-md border bg-muted px-3 py-2 text-sm text-muted-foreground">
-                        {PROJECT_VERSION}
-                      </div>
-                    </div>
-                  </div>
                 </div>
               ) : null}
             </div>

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -19,14 +19,12 @@
     "section": {
       "map": "Karte",
       "layout": "Layout",
-      "environment": "Umgebung",
-      "project": "Projekt"
+      "environment": "Umgebung"
     },
     "menu": {
       "mapPreferences": "Karteneinstellungen",
       "layoutSettings": "Layout-Einstellungen",
       "environmentVariables": "Umgebungsvariablen",
-      "projectSettings": "Projekteinstellungen",
       "managePlugins": "Plugins verwalten",
       "urlOverrideNote": "URL-Layout-Parameter überschreiben gespeicherte Einstellungen."
     },
@@ -80,12 +78,6 @@
       "removeAria": "{{name}} entfernen",
       "errorNamePattern": "Namen von Umgebungsvariablen müssen mit einem Buchstaben oder Unterstrich beginnen und dürfen nur Buchstaben, Zahlen und Unterstriche enthalten.",
       "errorDuplicate": "Die Umgebungsvariable \"{{name}}\" ist doppelt vorhanden."
-    },
-    "project": {
-      "title": "Projekt",
-      "file": "Projektdatei",
-      "notSaved": "Nicht gespeichert",
-      "format": "Projektformat"
     }
   },
   "toolbar": {

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -665,8 +665,7 @@
       "layout": "Layout",
       "interface": "Interface",
       "geocoding": "Geocoding",
-      "environment": "Environment",
-      "project": "Project"
+      "environment": "Environment"
     },
     "menu": {
       "mapPreferences": "Map Preferences",
@@ -674,7 +673,6 @@
       "interfaceSettings": "Interface Settings",
       "geocoding": "Geocoding",
       "environmentVariables": "Environment Variables",
-      "projectSettings": "Project Settings",
       "managePlugins": "Manage Plugins",
       "urlOverrideNote": "URL layout parameters override saved settings."
     },
@@ -766,13 +764,6 @@
       "emailHint": "Sent to identify the client to Nominatim, per its usage policy.",
       "secretsWarning": "Keys are stored in plain text in the project file and may be exposed when the project is shared. They are also sent as query parameters, so they appear in geocoding request URLs visible in browser DevTools and any proxy logs.",
       "corsNote": "Google does not officially allow browser requests to its Geocoding API, so requests may be blocked unless served through a same-origin proxy."
-    },
-    "project": {
-      "title": "Project",
-      "description": "These preferences are stored inside the project. Saving here applies them to the current session; use Project > Save to write them to the .geolibre.json file on disk.",
-      "file": "Project file",
-      "notSaved": "Not saved",
-      "format": "Project format"
     }
   },
   "toolbar": {

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1480,8 +1480,5 @@
     "customColors": "Custom colors",
     "customColorsValid": "{{count}} colors, low to high. Use Reverse to flip.",
     "customColorsHint": "Enter at least two hex codes, separated by commas or spaces."
-  },
-  "about": {
-    "projectFormat": "Project format"
   }
 }

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1480,5 +1480,8 @@
     "customColors": "Custom colors",
     "customColorsValid": "{{count}} colors, low to high. Use Reverse to flip.",
     "customColorsHint": "Enter at least two hex codes, separated by commas or spaces."
+  },
+  "about": {
+    "projectFormat": "Project format"
   }
 }

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -19,14 +19,12 @@
     "section": {
       "map": "Mapa",
       "layout": "Disposición",
-      "environment": "Entorno",
-      "project": "Proyecto"
+      "environment": "Entorno"
     },
     "menu": {
       "mapPreferences": "Preferencias del mapa",
       "layoutSettings": "Ajustes de disposición",
       "environmentVariables": "Variables de entorno",
-      "projectSettings": "Ajustes del proyecto",
       "managePlugins": "Gestionar complementos",
       "urlOverrideNote": "Los parámetros de disposición de la URL anulan los ajustes guardados."
     },
@@ -80,12 +78,6 @@
       "removeAria": "Quitar {{name}}",
       "errorNamePattern": "Los nombres de las variables de entorno deben empezar por una letra o un guion bajo y contener solo letras, números y guiones bajos.",
       "errorDuplicate": "La variable de entorno «{{name}}» está duplicada."
-    },
-    "project": {
-      "title": "Proyecto",
-      "file": "Archivo del proyecto",
-      "notSaved": "Sin guardar",
-      "format": "Formato del proyecto"
     }
   },
   "toolbar": {

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -19,14 +19,12 @@
     "section": {
       "map": "Carte",
       "layout": "Disposition",
-      "environment": "Environnement",
-      "project": "Projet"
+      "environment": "Environnement"
     },
     "menu": {
       "mapPreferences": "Préférences de carte",
       "layoutSettings": "Paramètres de disposition",
       "environmentVariables": "Variables d'environnement",
-      "projectSettings": "Paramètres du projet",
       "managePlugins": "Gérer les extensions",
       "urlOverrideNote": "Les paramètres de disposition dans l'URL remplacent les paramètres enregistrés."
     },
@@ -80,12 +78,6 @@
       "removeAria": "Supprimer {{name}}",
       "errorNamePattern": "Les noms de variables d'environnement doivent commencer par une lettre ou un tiret bas et ne contenir que des lettres, des chiffres et des tirets bas.",
       "errorDuplicate": "La variable d'environnement \"{{name}}\" est dupliquée."
-    },
-    "project": {
-      "title": "Projet",
-      "file": "Fichier de projet",
-      "notSaved": "Non enregistré",
-      "format": "Format du projet"
     }
   },
   "toolbar": {

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -19,14 +19,12 @@
     "section": {
       "map": "मानचित्र",
       "layout": "लेआउट",
-      "environment": "परिवेश",
-      "project": "प्रोजेक्ट"
+      "environment": "परिवेश"
     },
     "menu": {
       "mapPreferences": "मानचित्र प्राथमिकताएं",
       "layoutSettings": "लेआउट सेटिंग्स",
       "environmentVariables": "परिवेश चर",
-      "projectSettings": "प्रोजेक्ट सेटिंग्स",
       "managePlugins": "प्लगइन प्रबंधित करें",
       "urlOverrideNote": "URL लेआउट पैरामीटर सहेजी गई सेटिंग्स को ओवरराइड करते हैं।"
     },
@@ -80,12 +78,6 @@
       "removeAria": "{{name}} हटाएं",
       "errorNamePattern": "परिवेश चर के नाम किसी अक्षर या अंडरस्कोर से शुरू होने चाहिए और केवल अक्षर, संख्याएं और अंडरस्कोर हो सकते हैं।",
       "errorDuplicate": "परिवेश चर \"{{name}}\" दोहराया गया है।"
-    },
-    "project": {
-      "title": "प्रोजेक्ट",
-      "file": "प्रोजेक्ट फ़ाइल",
-      "notSaved": "सहेजा नहीं गया",
-      "format": "प्रोजेक्ट प्रारूप"
     }
   },
   "toolbar": {

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -19,14 +19,12 @@
     "section": {
       "map": "Peta",
       "layout": "Tata Letak",
-      "environment": "Lingkungan",
-      "project": "Proyek"
+      "environment": "Lingkungan"
     },
     "menu": {
       "mapPreferences": "Preferensi Peta",
       "layoutSettings": "Pengaturan Tata Letak",
       "environmentVariables": "Variabel Lingkungan",
-      "projectSettings": "Pengaturan Proyek",
       "managePlugins": "Kelola Plugin",
       "urlOverrideNote": "Parameter tata letak URL menimpa pengaturan yang tersimpan."
     },
@@ -79,12 +77,6 @@
       "removeAria": "Hapus {{name}}",
       "errorNamePattern": "Nama variabel lingkungan harus diawali huruf atau garis bawah dan hanya boleh mengandung huruf, angka, dan garis bawah.",
       "errorDuplicate": "Variabel lingkungan \"{{name}}\" terduplikasi."
-    },
-    "project": {
-      "title": "Proyek",
-      "file": "Berkas proyek",
-      "notSaved": "Belum disimpan",
-      "format": "Format proyek"
     }
   },
   "toolbar": {

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -19,14 +19,12 @@
     "section": {
       "map": "Mappa",
       "layout": "Layout",
-      "environment": "Ambiente",
-      "project": "Progetto"
+      "environment": "Ambiente"
     },
     "menu": {
       "mapPreferences": "Preferenze mappa",
       "layoutSettings": "Impostazioni layout",
       "environmentVariables": "Variabili d'ambiente",
-      "projectSettings": "Impostazioni progetto",
       "managePlugins": "Gestisci plugin",
       "urlOverrideNote": "I parametri di layout URL sovrascrivono le impostazioni salvate."
     },
@@ -80,12 +78,6 @@
       "removeAria": "Rimuovi {{name}}",
       "errorNamePattern": "I nomi delle variabili d'ambiente devono iniziare con una lettera o un underscore e contenere solo lettere, numeri e underscore.",
       "errorDuplicate": "La variabile d'ambiente \"{{name}}\" è duplicata."
-    },
-    "project": {
-      "title": "Progetto",
-      "file": "File di progetto",
-      "notSaved": "Non salvato",
-      "format": "Formato progetto"
     }
   },
   "toolbar": {

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -19,14 +19,12 @@
     "section": {
       "map": "マップ",
       "layout": "レイアウト",
-      "environment": "環境",
-      "project": "プロジェクト"
+      "environment": "環境"
     },
     "menu": {
       "mapPreferences": "マップ設定",
       "layoutSettings": "レイアウト設定",
       "environmentVariables": "環境変数",
-      "projectSettings": "プロジェクト設定",
       "managePlugins": "プラグイン管理",
       "urlOverrideNote": "URL のレイアウトパラメーターは保存済みの設定より優先されます。"
     },
@@ -79,12 +77,6 @@
       "removeAria": "{{name}} を削除する",
       "errorNamePattern": "環境変数名は文字またはアンダースコアで始まり、文字・数字・アンダースコアのみを含める必要があります。",
       "errorDuplicate": "環境変数 \"{{name}}\" が重複しています。"
-    },
-    "project": {
-      "title": "プロジェクト",
-      "file": "プロジェクトファイル",
-      "notSaved": "未保存",
-      "format": "プロジェクト形式"
     }
   },
   "toolbar": {

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -19,14 +19,12 @@
     "section": {
       "map": "지도",
       "layout": "레이아웃",
-      "environment": "환경",
-      "project": "프로젝트"
+      "environment": "환경"
     },
     "menu": {
       "mapPreferences": "지도 기본 설정",
       "layoutSettings": "레이아웃 설정",
       "environmentVariables": "환경 변수",
-      "projectSettings": "프로젝트 설정",
       "managePlugins": "플러그인 관리",
       "urlOverrideNote": "URL 레이아웃 매개변수는 저장된 설정보다 우선합니다."
     },
@@ -79,12 +77,6 @@
       "removeAria": "{{name}} 제거",
       "errorNamePattern": "환경 변수 이름은 문자 또는 밑줄로 시작해야 하며 문자, 숫자, 밑줄만 포함해야 합니다.",
       "errorDuplicate": "환경 변수 \"{{name}}\"이(가) 중복되었습니다."
-    },
-    "project": {
-      "title": "프로젝트",
-      "file": "프로젝트 파일",
-      "notSaved": "저장되지 않음",
-      "format": "프로젝트 형식"
     }
   },
   "toolbar": {

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -19,14 +19,12 @@
     "section": {
       "map": "Kaart",
       "layout": "Indeling",
-      "environment": "Omgeving",
-      "project": "Project"
+      "environment": "Omgeving"
     },
     "menu": {
       "mapPreferences": "Kaartvoorkeuren",
       "layoutSettings": "Indelingsinstellingen",
       "environmentVariables": "Omgevingsvariabelen",
-      "projectSettings": "Projectinstellingen",
       "managePlugins": "Plug-ins beheren",
       "urlOverrideNote": "URL-indelingsparameters overschrijven opgeslagen instellingen."
     },
@@ -80,12 +78,6 @@
       "removeAria": "{{name}} verwijderen",
       "errorNamePattern": "Namen van omgevingsvariabelen moeten beginnen met een letter of onderstrepingsteken en mogen alleen letters, cijfers en onderstrepingstekens bevatten.",
       "errorDuplicate": "Omgevingsvariabele \"{{name}}\" is gedupliceerd."
-    },
-    "project": {
-      "title": "Project",
-      "file": "Projectbestand",
-      "notSaved": "Niet opgeslagen",
-      "format": "Projectformaat"
     }
   },
   "toolbar": {

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -19,14 +19,12 @@
     "section": {
       "map": "Mapa",
       "layout": "Disposição",
-      "environment": "Ambiente",
-      "project": "Projeto"
+      "environment": "Ambiente"
     },
     "menu": {
       "mapPreferences": "Preferências do Mapa",
       "layoutSettings": "Definições de Disposição",
       "environmentVariables": "Variáveis de Ambiente",
-      "projectSettings": "Definições do Projeto",
       "managePlugins": "Gerir Plugins",
       "urlOverrideNote": "Os parâmetros de disposição do URL substituem as definições guardadas."
     },
@@ -80,12 +78,6 @@
       "removeAria": "Remover {{name}}",
       "errorNamePattern": "Os nomes de variáveis de ambiente devem começar com uma letra ou sublinhado e conter apenas letras, números e sublinhados.",
       "errorDuplicate": "A variável de ambiente \"{{name}}\" está duplicada."
-    },
-    "project": {
-      "title": "Projeto",
-      "file": "Ficheiro do projeto",
-      "notSaved": "Não guardado",
-      "format": "Formato do projeto"
     }
   },
   "toolbar": {

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -19,14 +19,12 @@
     "section": {
       "map": "Карта",
       "layout": "Макет",
-      "environment": "Среда",
-      "project": "Проект"
+      "environment": "Среда"
     },
     "menu": {
       "mapPreferences": "Параметры карты",
       "layoutSettings": "Параметры макета",
       "environmentVariables": "Переменные среды",
-      "projectSettings": "Параметры проекта",
       "managePlugins": "Управление плагинами",
       "urlOverrideNote": "Параметры макета URL переопределяют сохранённые настройки."
     },
@@ -82,12 +80,6 @@
       "removeAria": "Удалить {{name}}",
       "errorNamePattern": "Имена переменных среды должны начинаться с буквы или символа подчёркивания и содержать только буквы, цифры и символы подчёркивания.",
       "errorDuplicate": "Переменная среды «{{name}}» продублирована."
-    },
-    "project": {
-      "title": "Проект",
-      "file": "Файл проекта",
-      "notSaved": "Не сохранён",
-      "format": "Формат проекта"
     }
   },
   "toolbar": {

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -19,14 +19,12 @@
     "section": {
       "map": "Harita",
       "layout": "Düzen",
-      "environment": "Ortam",
-      "project": "Proje"
+      "environment": "Ortam"
     },
     "menu": {
       "mapPreferences": "Harita Tercihleri",
       "layoutSettings": "Düzen Ayarları",
       "environmentVariables": "Ortam Değişkenleri",
-      "projectSettings": "Proje Ayarları",
       "managePlugins": "Eklentileri Yönet",
       "urlOverrideNote": "URL düzen parametreleri kayıtlı ayarları geçersiz kılar."
     },
@@ -80,12 +78,6 @@
       "removeAria": "{{name}} öğesini kaldır",
       "errorNamePattern": "Ortam değişkeni adları bir harf veya alt çizgi ile başlamalı; yalnızca harf, rakam ve alt çizgi içermelidir.",
       "errorDuplicate": "\"{{name}}\" ortam değişkeni yinelendi."
-    },
-    "project": {
-      "title": "Proje",
-      "file": "Proje dosyası",
-      "notSaved": "Kaydedilmedi",
-      "format": "Proje biçimi"
     }
   },
   "toolbar": {

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -19,14 +19,12 @@
     "section": {
       "map": "地图",
       "layout": "布局",
-      "environment": "环境",
-      "project": "项目"
+      "environment": "环境"
     },
     "menu": {
       "mapPreferences": "地图首选项",
       "layoutSettings": "布局设置",
       "environmentVariables": "环境变量",
-      "projectSettings": "项目设置",
       "managePlugins": "管理插件",
       "urlOverrideNote": "URL 布局参数会覆盖已保存的设置。"
     },
@@ -79,12 +77,6 @@
       "removeAria": "移除 {{name}}",
       "errorNamePattern": "环境变量名称必须以字母或下划线开头，且只能包含字母、数字和下划线。",
       "errorDuplicate": "环境变量“{{name}}”重复。"
-    },
-    "project": {
-      "title": "项目",
-      "file": "项目文件",
-      "notSaved": "未保存",
-      "format": "项目格式"
     }
   },
   "toolbar": {

--- a/apps/geolibre-desktop/src/lib/ui-profile.ts
+++ b/apps/geolibre-desktop/src/lib/ui-profile.ts
@@ -271,7 +271,6 @@ export const MENU_ITEM_CATALOG: readonly MenuItemCatalogEntry[] = [
   { id: "settings.geocoding", menuId: "settings", labelKey: "settings.menu.geocoding", tier: "advanced" },
   // Kept in step with the AI Assistant (which reads its API key from here).
   { id: "settings.environment", menuId: "settings", labelKey: "settings.menu.environmentVariables", tier: "intermediate" },
-  { id: "settings.projectSettings", menuId: "settings", labelKey: "settings.menu.projectSettings", tier: "intermediate" },
   { id: "settings.managePlugins", menuId: "settings", labelKey: "settings.menu.managePlugins", tier: "intermediate" },
   // Help
   { id: "help.commandPalette", menuId: "help", labelKey: "toolbar.item.commandPalette", tier: "basic" },


### PR DESCRIPTION
## Summary

Fixes #590.

The **Settings → Project** tab held only two read-only indicators, "Project file" (showing *Not saved*) and "Project format", neither of which a user can act on inside a preferences modal. As the issue notes, surfacing an unsaved-file warning in a preferences dialog is a workflow contradiction, and a schema version number belongs with other app/version metadata rather than in active settings.

## Changes

- Removed the **Project** section from the Settings dialog: the left-nav entry, its visibility gate, the "Project Settings" dropdown menu item, the render block (both read-only fields), and the now-dead `settings.project.*` / `settings.section.project` / `settings.menu.projectSettings` keys across every locale catalog.
- Removed the `settings.projectSettings` entry from the UI-profile menu registry.
- Relocated the project schema version to the **About** dialog as a "Project format" row, alongside the existing app "Version" row, so the information still has a logical home.

## Verification

Ran the real web app and drove it with Playwright in **both light and dark themes**:

- Settings menu no longer lists "Project Settings".
- Settings dialog nav no longer shows a "Project" tab (Map / Layout / Interface / Geocoding / Environment remain).
- About dialog shows **Project format: 0.2.0** under **Version: v1.5.0**, rendering cleanly in both themes.

Also ran `npm run build` (clean) and the i18n catalog parity test (`tests/i18n-catalogs.test.ts`, 28/28 pass) since locale files changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Project format” to the About dialog.
* **Changes / UI**
  * Removed the “Project” section from the Settings dialog and its related submenu.
  * Updated settings navigation so project-related options are no longer shown.
* **Localization**
  * Updated all supported languages to remove “Project” settings strings and the related translation entries.
* **Refactor**
  * Removed the project settings catalog item from UI visibility/toggle logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->