### PR TITLE
feat(plugins): sort the Manage Plugins list alphabetically (#589)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/ManagePluginsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ManagePluginsDialog.tsx
@@ -340,9 +340,12 @@ export function ManagePluginsDialog({
             return true;
         }
       })
-      // Present the list alphabetically by display name so it stays predictable
-      // and scannable as the registry grows, regardless of registry file order.
-      // Case-insensitive, locale-aware; falls back to id on a name tie.
+      // Locale-aware, case-insensitive sort; plugin id breaks name ties.
+      .sort(
+        (a, b) =>
+          a.name.localeCompare(b.name, undefined, { sensitivity: "base" }) ||
+          a.id.localeCompare(b.id),
+      );
       .sort(
         (a, b) =>
           a.name.localeCompare(b.name, undefined, { sensitivity: "base" }) ||

--- a/apps/geolibre-desktop/src/components/layout/ManagePluginsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ManagePluginsDialog.tsx
@@ -326,19 +326,28 @@ export function ManagePluginsDialog({
       [entry.name, entry.id, entry.description, ...(entry.categories ?? [])]
         .filter((field): field is string => Boolean(field))
         .some((field) => field.toLowerCase().includes(term));
-    return entries.filter((entry) => {
-      if (!matches(entry)) return false;
-      switch (section) {
-        case "installed":
-          return isInstalled(entry);
-        case "not-installed":
-          return !isInstalled(entry);
-        case "upgradeable":
-          return isUpgradeable(entry);
-        default:
-          return true;
-      }
-    });
+    return entries
+      .filter((entry) => {
+        if (!matches(entry)) return false;
+        switch (section) {
+          case "installed":
+            return isInstalled(entry);
+          case "not-installed":
+            return !isInstalled(entry);
+          case "upgradeable":
+            return isUpgradeable(entry);
+          default:
+            return true;
+        }
+      })
+      // Present the list alphabetically by display name so it stays predictable
+      // and scannable as the registry grows, regardless of registry file order.
+      // Case-insensitive, locale-aware; falls back to id on a name tie.
+      .sort(
+        (a, b) =>
+          a.name.localeCompare(b.name, undefined, { sensitivity: "base" }) ||
+          a.id.localeCompare(b.id),
+      );
   }, [entries, isInstalled, isUpgradeable, query, section]);
 
   return (

--- a/apps/geolibre-desktop/src/components/layout/ManagePluginsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ManagePluginsDialog.tsx
@@ -346,11 +346,6 @@ export function ManagePluginsDialog({
           a.name.localeCompare(b.name, undefined, { sensitivity: "base" }) ||
           a.id.localeCompare(b.id),
       );
-      .sort(
-        (a, b) =>
-          a.name.localeCompare(b.name, undefined, { sensitivity: "base" }) ||
-          a.id.localeCompare(b.id),
-      );
   }, [entries, isInstalled, isUpgradeable, query, section]);
 
   return (


### PR DESCRIPTION
## Summary

Addresses #589.

### 1. Alphabetical sorting (implemented)

The plugin marketplace rendered entries in registry-file order, so the list read unpredictably (the issue's screenshot shows *Sample Plugin* above *Elevation Profile*). The visible entries are now sorted by display name, case-insensitive and locale-aware, with the plugin id as a tie-breaker. The sort runs on the already-filtered copy, so the search box and the Installed / Not installed / Upgradeable section filters are unaffected, and the section counts are unchanged.

### 2. Documentation vs repository links (no app change)

The external-link icon next to each plugin opens `entry.homepage`, a value supplied by the curated plugin registry (the `geolibre-plugins` repo), not hard-coded in the app. So pointing users at a friendly documentation page rather than a raw GitHub repo is a matter of updating each entry's `homepage` in the registry data; the app already renders whatever URL the registry provides. There is no app-side code change to make here, so this PR leaves that half to a registry-content update. Happy to split it into a separate tracking issue against the registry if you'd like.

## Verification

Ran the real web app and drove it with Playwright in **both light and dark themes**. With the live registry, the list now renders in order:

**Data to Science (D2S) → Elevation Profile → NASA OPERA → Sample Plugin**

i.e. fully alphabetical, in both themes. Also ran `npm run build` (clean).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Plugin lists in the Manage Plugins dialog are now sorted alphabetically (locale-aware and case-insensitive) to make plugins easier to locate across all sections.
  * Existing include/exclude filtering remains unchanged—only the displayed order of the resulting plugins has been updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->