### PR TITLE
feat(map): add multi-map grid with synchronized views

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -64,6 +64,7 @@ import { registerXyzTileProtocol } from "../../lib/xyz-url";
 import { useEmbedBridge } from "../../hooks/useEmbedBridge";
 import { useRasterIdentify } from "../../hooks/useRasterIdentify";
 import { BoundsRestrictionIndicator } from "./BoundsRestrictionIndicator";
+import { MapGrid } from "./MapGrid";
 import { RemoteCursorsOverlay } from "./RemoteCursorsOverlay";
 import { useCommandBridge } from "../../hooks/useCommandBridge";
 import {
@@ -1271,13 +1272,15 @@ export function DesktopShell({
               is not flagged as content outside a landmark. */}
           <h1 className="sr-only">GeoLibre map workspace</h1>
           <SectionErrorBoundary label="Map" fallbackClassName="h-full w-full">
-            <MapCanvas
-              controllerRef={mapControllerRef}
-              onMapDiagnosticEvent={handleMapDiagnosticEvent}
-              onControllerReady={handleMapControllerReady}
-            />
-            <RemoteCursorsOverlay mapControllerRef={mapControllerRef} />
-            <BoundsRestrictionIndicator />
+            <MapGrid>
+              <MapCanvas
+                controllerRef={mapControllerRef}
+                onMapDiagnosticEvent={handleMapDiagnosticEvent}
+                onControllerReady={handleMapControllerReady}
+              />
+              <RemoteCursorsOverlay mapControllerRef={mapControllerRef} />
+              <BoundsRestrictionIndicator />
+            </MapGrid>
           </SectionErrorBoundary>
         </main>
         {/* The notebook claims the workspace's right half, so the Style panel

--- a/apps/geolibre-desktop/src/components/layout/MapGrid.tsx
+++ b/apps/geolibre-desktop/src/components/layout/MapGrid.tsx
@@ -1,12 +1,16 @@
-import {
-  BLANK_BASEMAP,
-  OPENFREEMAP_BASEMAPS,
-  useAppStore,
-} from "@geolibre/core";
+import { useAppStore } from "@geolibre/core";
 import { SecondaryMapCanvas } from "@geolibre/map";
-import { Select } from "@geolibre/ui";
-import { X } from "lucide-react";
-import { type ReactNode, useMemo } from "react";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@geolibre/ui";
+import { Layers, X } from "lucide-react";
+import { type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
 interface MapGridProps {
@@ -20,9 +24,11 @@ interface MapGridProps {
  * With a single pane (the default) it renders the primary map untouched, so the
  * normal single-map DOM and behavior are unchanged. With a larger grid it tiles
  * the primary map plus one {@link SecondaryMapCanvas} per `secondaryMapViews`
- * entry into a CSS grid, each secondary pane carrying its own basemap picker and
- * a button to drop it. Camera sync between panes is handled inside the canvases
- * (via the shared global `mapView`); this component only owns layout and chrome.
+ * entry into a CSS grid. Every pane shares the primary's basemap and layers;
+ * each secondary pane carries a layer-visibility toggle so it can show a
+ * different subset of the shared layers, plus a button to drop the pane. Camera
+ * sync between panes is handled inside the canvases (via the shared global
+ * `mapView`); this component only owns layout and chrome.
  */
 export function MapGrid({ children }: MapGridProps) {
   const rows = useAppStore((s) => s.mapLayout.rows);
@@ -60,44 +66,13 @@ interface SecondaryMapPaneProps {
 
 function SecondaryMapPane({ viewId, index }: SecondaryMapPaneProps) {
   const { t } = useTranslation();
-  const setSecondaryBasemap = useAppStore((s) => s.setSecondaryBasemap);
   const removeSecondaryMapView = useAppStore((s) => s.removeSecondaryMapView);
-  const basemapStyleUrl = useAppStore(
-    (s) => s.secondaryMapViews.find((p) => p.id === viewId)?.basemapStyleUrl,
-  );
-
-  // Dedupe basemaps by style URL: two presets can share a style (e.g. Liberty
-  // and Liberty 3D), and duplicate <option> values would be indistinguishable.
-  const basemapOptions = useMemo(() => {
-    const seen = new Set<string>();
-    const options: { value: string; name: string }[] = [];
-    for (const basemap of OPENFREEMAP_BASEMAPS) {
-      if (seen.has(basemap.styleUrl)) continue;
-      seen.add(basemap.styleUrl);
-      options.push({ value: basemap.styleUrl, name: basemap.name });
-    }
-    return options;
-  }, []);
 
   return (
     <div className="relative isolate min-h-0 min-w-0 overflow-hidden bg-background">
       <SecondaryMapCanvas viewId={viewId} />
-      <div className="pointer-events-none absolute left-2 top-2 z-10 flex items-center gap-1.5">
-        <Select
-          className="pointer-events-auto w-36 shadow-sm"
-          aria-label={t("mapGrid.basemapLabel", { number: index + 2 })}
-          value={basemapStyleUrl ?? ""}
-          onChange={(event) =>
-            setSecondaryBasemap(viewId, { basemapStyleUrl: event.target.value })
-          }
-        >
-          {basemapOptions.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.name}
-            </option>
-          ))}
-          <option value={BLANK_BASEMAP}>{t("mapGrid.basemapBlank")}</option>
-        </Select>
+      <div className="absolute left-2 top-2 z-10">
+        <PaneLayerToggle viewId={viewId} index={index} />
       </div>
       <button
         type="button"
@@ -108,5 +83,69 @@ function SecondaryMapPane({ viewId, index }: SecondaryMapPaneProps) {
         <X className="h-4 w-4" />
       </button>
     </div>
+  );
+}
+
+interface PaneLayerToggleProps {
+  viewId: string;
+  index: number;
+}
+
+/**
+ * A dropdown of the shared layers with a checkbox each, controlling which layers
+ * are visible in this pane. A layer's checkbox reflects its effective visibility
+ * (the pane's override, or the primary map's visibility when not overridden).
+ */
+function PaneLayerToggle({ viewId, index }: PaneLayerToggleProps) {
+  const { t } = useTranslation();
+  const layers = useAppStore((s) => s.layers);
+  const layerVisibility = useAppStore(
+    (s) => s.secondaryMapViews.find((p) => p.id === viewId)?.layerVisibility,
+  );
+  const setSecondaryLayerVisibility = useAppStore(
+    (s) => s.setSecondaryLayerVisibility,
+  );
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-7 gap-1.5 bg-background/90 px-2 shadow-sm"
+          aria-label={t("mapGrid.layersLabel", { number: index + 2 })}
+        >
+          <Layers className="h-3.5 w-3.5" />
+          {t("mapGrid.layers")}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="max-h-80 w-56 overflow-auto">
+        <DropdownMenuLabel>{t("mapGrid.layers")}</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {layers.length === 0 ? (
+          <div className="px-2 py-1.5 text-sm text-muted-foreground">
+            {t("mapGrid.noLayers")}
+          </div>
+        ) : (
+          layers.map((layer) => {
+            const override = layerVisibility?.[layer.id];
+            const visible = override === undefined ? layer.visible : override;
+            return (
+              <DropdownMenuCheckboxItem
+                key={layer.id}
+                checked={visible}
+                onCheckedChange={(checked: boolean) =>
+                  setSecondaryLayerVisibility(viewId, layer.id, checked)
+                }
+                // Keep the menu open so several layers can be toggled at once.
+                onSelect={(event: Event) => event.preventDefault()}
+              >
+                <span className="truncate">{layer.name}</span>
+              </DropdownMenuCheckboxItem>
+            );
+          })
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/apps/geolibre-desktop/src/components/layout/MapGrid.tsx
+++ b/apps/geolibre-desktop/src/components/layout/MapGrid.tsx
@@ -76,7 +76,7 @@ function SecondaryMapPane({ viewId, index }: SecondaryMapPaneProps) {
       </div>
       <button
         type="button"
-        className="absolute right-2 top-2 z-10 flex h-7 w-7 items-center justify-center rounded-md border border-input bg-background/90 text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground"
+        className="absolute bottom-2 left-2 z-10 flex h-7 w-7 items-center justify-center rounded-md border border-input bg-background/90 text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground"
         aria-label={t("mapGrid.removePane", { number: index + 2 })}
         onClick={() => removeSecondaryMapView(viewId)}
       >

--- a/apps/geolibre-desktop/src/components/layout/MapGrid.tsx
+++ b/apps/geolibre-desktop/src/components/layout/MapGrid.tsx
@@ -1,0 +1,112 @@
+import {
+  BLANK_BASEMAP,
+  OPENFREEMAP_BASEMAPS,
+  useAppStore,
+} from "@geolibre/core";
+import { SecondaryMapCanvas } from "@geolibre/map";
+import { Select } from "@geolibre/ui";
+import { X } from "lucide-react";
+import { type ReactNode, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+interface MapGridProps {
+  /** The primary map pane (MapCanvas plus its overlays), rendered in cell 0. */
+  children: ReactNode;
+}
+
+/**
+ * Lays out the workspace's map panes.
+ *
+ * With a single pane (the default) it renders the primary map untouched, so the
+ * normal single-map DOM and behavior are unchanged. With a larger grid it tiles
+ * the primary map plus one {@link SecondaryMapCanvas} per `secondaryMapViews`
+ * entry into a CSS grid, each secondary pane carrying its own basemap picker and
+ * a button to drop it. Camera sync between panes is handled inside the canvases
+ * (via the shared global `mapView`); this component only owns layout and chrome.
+ */
+export function MapGrid({ children }: MapGridProps) {
+  const rows = useAppStore((s) => s.mapLayout.rows);
+  const cols = useAppStore((s) => s.mapLayout.cols);
+  const secondaryMapViews = useAppStore((s) => s.secondaryMapViews);
+
+  if (rows * cols <= 1) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div
+      className="grid h-full w-full gap-0.5 bg-border"
+      style={{
+        gridTemplateRows: `repeat(${rows}, minmax(0, 1fr))`,
+        gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`,
+      }}
+      data-testid="map-grid"
+    >
+      <div className="relative isolate min-h-0 min-w-0 overflow-hidden bg-background">
+        {children}
+      </div>
+      {secondaryMapViews.map((pane, index) => (
+        <SecondaryMapPane key={pane.id} viewId={pane.id} index={index} />
+      ))}
+    </div>
+  );
+}
+
+interface SecondaryMapPaneProps {
+  viewId: string;
+  /** Zero-based index among secondary panes, shown in the pane label. */
+  index: number;
+}
+
+function SecondaryMapPane({ viewId, index }: SecondaryMapPaneProps) {
+  const { t } = useTranslation();
+  const setSecondaryBasemap = useAppStore((s) => s.setSecondaryBasemap);
+  const removeSecondaryMapView = useAppStore((s) => s.removeSecondaryMapView);
+  const basemapStyleUrl = useAppStore(
+    (s) => s.secondaryMapViews.find((p) => p.id === viewId)?.basemapStyleUrl,
+  );
+
+  // Dedupe basemaps by style URL: two presets can share a style (e.g. Liberty
+  // and Liberty 3D), and duplicate <option> values would be indistinguishable.
+  const basemapOptions = useMemo(() => {
+    const seen = new Set<string>();
+    const options: { value: string; name: string }[] = [];
+    for (const basemap of OPENFREEMAP_BASEMAPS) {
+      if (seen.has(basemap.styleUrl)) continue;
+      seen.add(basemap.styleUrl);
+      options.push({ value: basemap.styleUrl, name: basemap.name });
+    }
+    return options;
+  }, []);
+
+  return (
+    <div className="relative isolate min-h-0 min-w-0 overflow-hidden bg-background">
+      <SecondaryMapCanvas viewId={viewId} />
+      <div className="pointer-events-none absolute left-2 top-2 z-10 flex items-center gap-1.5">
+        <Select
+          className="pointer-events-auto w-36 shadow-sm"
+          aria-label={t("mapGrid.basemapLabel", { number: index + 2 })}
+          value={basemapStyleUrl ?? ""}
+          onChange={(event) =>
+            setSecondaryBasemap(viewId, { basemapStyleUrl: event.target.value })
+          }
+        >
+          {basemapOptions.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.name}
+            </option>
+          ))}
+          <option value={BLANK_BASEMAP}>{t("mapGrid.basemapBlank")}</option>
+        </Select>
+      </div>
+      <button
+        type="button"
+        className="absolute right-2 top-2 z-10 flex h-7 w-7 items-center justify-center rounded-md border border-input bg-background/90 text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground"
+        aria-label={t("mapGrid.removePane", { number: index + 2 })}
+        onClick={() => removeSecondaryMapView(viewId)}
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/MapGrid.tsx
+++ b/apps/geolibre-desktop/src/components/layout/MapGrid.tsx
@@ -13,6 +13,37 @@ import { Layers, X } from "lucide-react";
 import { type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
+/**
+ * An editable label shown centered at the top of a map pane. Empty by default;
+ * users type a custom name (e.g. a date or scenario) to tell panes apart.
+ */
+function PaneLabel({
+  value,
+  onChange,
+  ariaLabel,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  ariaLabel: string;
+}) {
+  const { t } = useTranslation();
+  return (
+    // The wrapper is click-through so it never blocks map interaction; only the
+    // centered field itself is interactive. `max-w` keeps it clear of the
+    // top-left and top-right control clusters.
+    <div className="pointer-events-none absolute inset-x-0 top-2 z-10 flex justify-center">
+      <input
+        type="text"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        aria-label={ariaLabel}
+        placeholder={t("mapGrid.labelPlaceholder")}
+        className="pointer-events-auto h-7 w-32 max-w-[40%] rounded-md border border-input bg-background/90 px-2 text-center text-sm text-foreground shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:outline-none"
+      />
+    </div>
+  );
+}
+
 interface MapGridProps {
   /** The primary map pane (MapCanvas plus its overlays), rendered in cell 0. */
   children: ReactNode;
@@ -31,9 +62,12 @@ interface MapGridProps {
  * `mapView`); this component only owns layout and chrome.
  */
 export function MapGrid({ children }: MapGridProps) {
+  const { t } = useTranslation();
   const rows = useAppStore((s) => s.mapLayout.rows);
   const cols = useAppStore((s) => s.mapLayout.cols);
   const secondaryMapViews = useAppStore((s) => s.secondaryMapViews);
+  const primaryMapLabel = useAppStore((s) => s.primaryMapLabel);
+  const setPrimaryMapLabel = useAppStore((s) => s.setPrimaryMapLabel);
 
   if (rows * cols <= 1) {
     return <>{children}</>;
@@ -50,6 +84,11 @@ export function MapGrid({ children }: MapGridProps) {
     >
       <div className="relative isolate min-h-0 min-w-0 overflow-hidden bg-background">
         {children}
+        <PaneLabel
+          value={primaryMapLabel}
+          onChange={setPrimaryMapLabel}
+          ariaLabel={t("mapGrid.labelLabel", { number: 1 })}
+        />
       </div>
       {secondaryMapViews.map((pane, index) => (
         <SecondaryMapPane key={pane.id} viewId={pane.id} index={index} />
@@ -67,10 +106,19 @@ interface SecondaryMapPaneProps {
 function SecondaryMapPane({ viewId, index }: SecondaryMapPaneProps) {
   const { t } = useTranslation();
   const removeSecondaryMapView = useAppStore((s) => s.removeSecondaryMapView);
+  const setSecondaryMapLabel = useAppStore((s) => s.setSecondaryMapLabel);
+  const label = useAppStore(
+    (s) => s.secondaryMapViews.find((p) => p.id === viewId)?.label ?? "",
+  );
 
   return (
     <div className="relative isolate min-h-0 min-w-0 overflow-hidden bg-background">
       <SecondaryMapCanvas viewId={viewId} />
+      <PaneLabel
+        value={label}
+        onChange={(value) => setSecondaryMapLabel(viewId, value)}
+        ariaLabel={t("mapGrid.labelLabel", { number: index + 2 })}
+      />
       <div className="absolute left-2 top-2 z-10 flex items-center gap-1.5">
         <PaneLayerToggle viewId={viewId} index={index} />
         <button

--- a/apps/geolibre-desktop/src/components/layout/MapGrid.tsx
+++ b/apps/geolibre-desktop/src/components/layout/MapGrid.tsx
@@ -71,17 +71,17 @@ function SecondaryMapPane({ viewId, index }: SecondaryMapPaneProps) {
   return (
     <div className="relative isolate min-h-0 min-w-0 overflow-hidden bg-background">
       <SecondaryMapCanvas viewId={viewId} />
-      <div className="absolute left-2 top-2 z-10">
+      <div className="absolute left-2 top-2 z-10 flex items-center gap-1.5">
         <PaneLayerToggle viewId={viewId} index={index} />
+        <button
+          type="button"
+          className="flex h-7 w-7 items-center justify-center rounded-md border border-input bg-background/90 text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground"
+          aria-label={t("mapGrid.removePane", { number: index + 2 })}
+          onClick={() => removeSecondaryMapView(viewId)}
+        >
+          <X className="h-4 w-4" />
+        </button>
       </div>
-      <button
-        type="button"
-        className="absolute bottom-2 left-2 z-10 flex h-7 w-7 items-center justify-center rounded-md border border-input bg-background/90 text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground"
-        aria-label={t("mapGrid.removePane", { number: index + 2 })}
-        onClick={() => removeSecondaryMapView(viewId)}
-      >
-        <X className="h-4 w-4" />
-      </button>
     </div>
   );
 }

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ViewMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ViewMenu.tsx
@@ -1,27 +1,51 @@
 import {
   Button,
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@geolibre/ui";
+import { useAppStore } from "@geolibre/core";
 import {
   ArrowLeft,
   ArrowRight,
   Compass,
   Crosshair,
   Eye,
+  LayoutGrid,
+  Link2,
   Mountain,
   ZoomIn,
   ZoomOut,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import type { ParseKeys } from "i18next";
 import { useDesktopSettingsStore } from "../../../hooks/useDesktopSettings";
 import type { ViewportHistory } from "../../../hooks/useViewportHistory";
 import { isMenuItemVisible } from "../../../lib/ui-profile";
 import type { ToolbarChrome } from "./constants";
+
+/** Selectable map-grid presets offered in the Split View submenu. */
+const SPLIT_VIEW_PRESETS: ReadonlyArray<{
+  rows: number;
+  cols: number;
+  labelKey: ParseKeys;
+}> = [
+  { rows: 1, cols: 1, labelKey: "toolbar.item.splitViewSingle" },
+  { rows: 1, cols: 2, labelKey: "toolbar.item.splitViewTwoColumns" },
+  { rows: 2, cols: 1, labelKey: "toolbar.item.splitViewTwoRows" },
+  { rows: 2, cols: 2, labelKey: "toolbar.item.splitViewGrid2x2" },
+  { rows: 2, cols: 3, labelKey: "toolbar.item.splitViewGrid2x3" },
+  { rows: 3, cols: 3, labelKey: "toolbar.item.splitViewGrid3x3" },
+];
 
 interface ViewMenuProps {
   chrome: ToolbarChrome;
@@ -55,16 +79,29 @@ export function ViewMenu({
 }: ViewMenuProps) {
   const { t } = useTranslation();
   const uiProfile = useDesktopSettingsStore((s) => s.desktopSettings.uiProfile);
+  const mapLayout = useAppStore((s) => s.mapLayout);
+  const setMapGrid = useAppStore((s) => s.setMapGrid);
+  const setSyncView = useAppStore((s) => s.setSyncView);
   const show = (id: string) => isMenuItemVisible(uiProfile, id);
   const showZoom = show("view.zoomIn") || show("view.zoomOut");
   const showNavigation =
     show("view.previousView") || show("view.nextView");
   const showReset = show("view.resetNorth") || show("view.resetPitchBearing");
   const showSetView = show("view.setView");
+  const showSplitView = show("view.splitView");
+  const paneCount = mapLayout.rows * mapLayout.cols;
+  const gridKey = `${mapLayout.rows}x${mapLayout.cols}`;
   // A custom profile could hide every item; render nothing rather than a menu
   // whose dropdown is an empty shell. (TopToolbar's isMenuVisible guard normally
   // hides the menu first, but don't rely on that invariant here.)
-  if (!showZoom && !showNavigation && !showReset && !showSetView) return null;
+  if (
+    !showZoom &&
+    !showNavigation &&
+    !showReset &&
+    !showSetView &&
+    !showSplitView
+  )
+    return null;
 
   return (
     <DropdownMenu>
@@ -150,6 +187,54 @@ export function ViewMenu({
               {t("toolbar.item.setView")}
             </span>
           </DropdownMenuItem>
+        )}
+        {(showZoom || showNavigation || showReset || showSetView) &&
+          showSplitView && <DropdownMenuSeparator />}
+        {showSplitView && (
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              <LayoutGrid className="mr-2 h-3.5 w-3.5 shrink-0" />
+              <span className="whitespace-nowrap">
+                {t("toolbar.item.splitView")}
+              </span>
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent className="min-w-48">
+              <DropdownMenuRadioGroup
+                value={gridKey}
+                onValueChange={(value: string) => {
+                  const [rows, cols] = value.split("x").map(Number);
+                  setMapGrid(rows, cols);
+                }}
+              >
+                {SPLIT_VIEW_PRESETS.map((preset) => (
+                  <DropdownMenuRadioItem
+                    key={`${preset.rows}x${preset.cols}`}
+                    value={`${preset.rows}x${preset.cols}`}
+                  >
+                    <span className="whitespace-nowrap">
+                      {t(preset.labelKey)}
+                    </span>
+                  </DropdownMenuRadioItem>
+                ))}
+              </DropdownMenuRadioGroup>
+              <DropdownMenuSeparator />
+              <DropdownMenuCheckboxItem
+                checked={mapLayout.syncView}
+                disabled={paneCount <= 1}
+                onCheckedChange={(checked: boolean) =>
+                  setSyncView(Boolean(checked))
+                }
+                // Radix closes the menu on item select by default; keep it open
+                // so toggling sync doesn't dismiss the submenu mid-comparison.
+                onSelect={(event: Event) => event.preventDefault()}
+              >
+                <Link2 className="mr-2 h-3.5 w-3.5 shrink-0" />
+                <span className="whitespace-nowrap">
+                  {t("toolbar.item.splitViewSync")}
+                </span>
+              </DropdownMenuCheckboxItem>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
         )}
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ViewMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ViewMenu.tsx
@@ -193,7 +193,7 @@ export function ViewMenu({
         {showSplitView && (
           <DropdownMenuSub>
             <DropdownMenuSubTrigger>
-              <LayoutGrid className="mr-2 h-3.5 w-3.5 shrink-0" />
+              <LayoutGrid className="h-3.5 w-3.5 shrink-0" />
               <span className="whitespace-nowrap">
                 {t("toolbar.item.splitView")}
               </span>
@@ -216,6 +216,18 @@ export function ViewMenu({
                     </span>
                   </DropdownMenuRadioItem>
                 ))}
+                {/* A grid loaded from a hand-edited project file (e.g. 4x4) may
+                    not match any preset; surface it so the radio group still
+                    shows the active layout as selected rather than blank. */}
+                {!SPLIT_VIEW_PRESETS.some(
+                  (preset) => `${preset.rows}x${preset.cols}` === gridKey,
+                ) && (
+                  <DropdownMenuRadioItem value={gridKey}>
+                    <span className="whitespace-nowrap">
+                      {`${mapLayout.rows} × ${mapLayout.cols}`}
+                    </span>
+                  </DropdownMenuRadioItem>
+                )}
               </DropdownMenuRadioGroup>
               <DropdownMenuSeparator />
               <DropdownMenuCheckboxItem

--- a/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
@@ -230,6 +230,8 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
       models: state.models,
       widgets: state.widgets,
       dashboardColumns: state.dashboardColumns,
+      mapLayout: state.mapLayout,
+      secondaryMapViews: state.secondaryMapViews,
       metadata: state.metadata,
     });
     return {

--- a/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
@@ -232,6 +232,7 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
       dashboardColumns: state.dashboardColumns,
       mapLayout: state.mapLayout,
       secondaryMapViews: state.secondaryMapViews,
+      primaryMapLabel: state.primaryMapLabel,
       metadata: state.metadata,
     });
     return {

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -641,6 +641,8 @@
     "layers": "Layers",
     "layersLabel": "Layer visibility for map {{number}}",
     "noLayers": "No layers yet",
+    "labelPlaceholder": "Label",
+    "labelLabel": "Label for map {{number}}",
     "removePane": "Remove map {{number}}"
   },
   "onboarding": {

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -638,8 +638,9 @@
     "boundsRestrictedTooltip": "Map bounds are restricted. You can change this in Settings."
   },
   "mapGrid": {
-    "basemapLabel": "Basemap for map {{number}}",
-    "basemapBlank": "Blank",
+    "layers": "Layers",
+    "layersLabel": "Layer visibility for map {{number}}",
+    "noLayers": "No layers yet",
     "removePane": "Remove map {{number}}"
   },
   "onboarding": {

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -637,6 +637,11 @@
     "boundsRestricted": "Bounds locked",
     "boundsRestrictedTooltip": "Map bounds are restricted. You can change this in Settings."
   },
+  "mapGrid": {
+    "basemapLabel": "Basemap for map {{number}}",
+    "basemapBlank": "Blank",
+    "removePane": "Remove map {{number}}"
+  },
   "onboarding": {
     "title": "Welcome to GeoLibre",
     "description": "Choose your experience level to tailor the interface. You can change this any time in Settings → Interface.",
@@ -1021,6 +1026,14 @@
       "resetNorth": "Reset North",
       "resetPitchBearing": "Reset Pitch & Bearing",
       "setView": "Set View…",
+      "splitView": "Split View",
+      "splitViewSingle": "Single map",
+      "splitViewTwoColumns": "Two columns",
+      "splitViewTwoRows": "Two rows",
+      "splitViewGrid2x2": "2 × 2 grid",
+      "splitViewGrid2x3": "2 × 3 grid",
+      "splitViewGrid3x3": "3 × 3 grid",
+      "splitViewSync": "Sync views",
       "zoomIn": "Zoom In",
       "zoomOut": "Zoom Out",
       "sectionFiles": "Files",

--- a/apps/geolibre-desktop/src/lib/build-project-snapshot.ts
+++ b/apps/geolibre-desktop/src/lib/build-project-snapshot.ts
@@ -44,6 +44,7 @@ export function buildProjectSnapshot(
     dashboardColumns: state.dashboardColumns,
     mapLayout: state.mapLayout,
     secondaryMapViews: state.secondaryMapViews,
+    primaryMapLabel: state.primaryMapLabel,
     metadata: state.metadata,
   });
 }

--- a/apps/geolibre-desktop/src/lib/build-project-snapshot.ts
+++ b/apps/geolibre-desktop/src/lib/build-project-snapshot.ts
@@ -42,6 +42,8 @@ export function buildProjectSnapshot(
     models: state.models,
     widgets: state.widgets,
     dashboardColumns: state.dashboardColumns,
+    mapLayout: state.mapLayout,
+    secondaryMapViews: state.secondaryMapViews,
     metadata: state.metadata,
   });
 }

--- a/apps/geolibre-desktop/src/lib/ui-profile.ts
+++ b/apps/geolibre-desktop/src/lib/ui-profile.ts
@@ -218,6 +218,7 @@ export const MENU_ITEM_CATALOG: readonly MenuItemCatalogEntry[] = [
   { id: "view.resetNorth", menuId: "view", labelKey: "toolbar.item.resetNorth", tier: "basic" },
   { id: "view.resetPitchBearing", menuId: "view", labelKey: "toolbar.item.resetPitchBearing", tier: "basic" },
   { id: "view.setView", menuId: "view", labelKey: "toolbar.item.setView", tier: "intermediate" },
+  { id: "view.splitView", menuId: "view", labelKey: "toolbar.item.splitView", tier: "intermediate" },
   // Processing
   { id: "processing.assistant", menuId: "processing", labelKey: "toolbar.command.assistant", tier: "intermediate" },
   { id: "processing.whitebox", menuId: "processing", labelKey: "toolbar.item.whitebox", tier: "advanced" },

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -4,8 +4,10 @@ import {
   DEFAULT_LEGEND_CONFIG,
   DEFAULT_PROJECT_PREFERENCES,
   DEFAULT_DASHBOARD_COLUMNS,
+  DEFAULT_MAP_GRID_LAYOUT,
   DEFAULT_STORY_MAP,
   MAX_DASHBOARD_COLUMNS,
+  MAX_MAP_GRID_DIM,
   MIN_DASHBOARD_COLUMNS,
   PROJECT_VERSION,
   type DashboardWidget,
@@ -17,8 +19,10 @@ import {
   type LayerStyle,
   type LegendConfig,
   type LegendItemOverride,
+  type MapGridLayout,
   type MapViewState,
   type ProcessingModel,
+  type SecondaryMapView,
   type ProcessingModelStep,
   type ProjectPluginControlPosition,
   type ProjectPluginState,
@@ -91,13 +95,21 @@ export function parseProject(json: string): GeoLibreProject {
         ? { ...layer, groupId: undefined }
         : layer,
     );
+  const basemapStyleUrl = data.basemapStyleUrl ?? DEFAULT_BASEMAP;
+  const basemapVisible = data.basemapVisible ?? true;
+  const basemapOpacity = data.basemapOpacity ?? 1;
+  const { mapLayout, secondaryMapViews } = resolveMapGrid(
+    normalizeMapLayout(data.mapLayout),
+    normalizeSecondaryMapViews(data.secondaryMapViews),
+    { mapView: data.mapView, basemapStyleUrl, basemapVisible, basemapOpacity },
+  );
   return {
     version: data.version,
     name: data.name,
     mapView: data.mapView,
-    basemapStyleUrl: data.basemapStyleUrl ?? DEFAULT_BASEMAP,
-    basemapVisible: data.basemapVisible ?? true,
-    basemapOpacity: data.basemapOpacity ?? 1,
+    basemapStyleUrl,
+    basemapVisible,
+    basemapOpacity,
     layers,
     ...(layerGroups.length > 0 ? { layerGroups } : {}),
     styles: data.styles ?? {},
@@ -110,6 +122,11 @@ export function parseProject(json: string): GeoLibreProject {
     ...(data.dashboardColumns === undefined
       ? {}
       : { dashboardColumns: normalizeDashboardColumns(data.dashboardColumns) }),
+    // Only persist the grid when it is larger than a single pane, so default
+    // single-map projects serialize byte-identically to before this feature.
+    ...(mapLayout.rows * mapLayout.cols > 1
+      ? { mapLayout, secondaryMapViews }
+      : {}),
     metadata: data.metadata ?? {},
   };
 }
@@ -400,6 +417,138 @@ export function normalizeModels(value: unknown): ProcessingModel[] | null {
     models.push({ id, name: normalizeString(candidate.name), steps });
   }
   return models.length > 0 ? models : null;
+}
+
+/**
+ * Coerce an untrusted (possibly hand-edited) camera object into a valid
+ * {@link MapViewState}, falling back to the default view for missing parts.
+ */
+export function normalizeMapViewState(value: unknown): MapViewState {
+  const fallback = createDefaultMapView();
+  if (!value || typeof value !== "object") return fallback;
+  const candidate = value as Partial<MapViewState>;
+  const center = Array.isArray(candidate.center)
+    ? candidate.center
+    : fallback.center;
+  const view: MapViewState = {
+    center: [
+      normalizeNumber(center[0], fallback.center[0]),
+      normalizeNumber(center[1], fallback.center[1]),
+    ],
+    zoom: normalizeNumber(candidate.zoom, fallback.zoom),
+    bearing: normalizeNumber(candidate.bearing, fallback.bearing),
+    pitch: normalizeNumber(candidate.pitch, fallback.pitch),
+  };
+  if (
+    Array.isArray(candidate.bbox) &&
+    candidate.bbox.length === 4 &&
+    candidate.bbox.every((n) => Number.isFinite(n))
+  ) {
+    view.bbox = [
+      Number(candidate.bbox[0]),
+      Number(candidate.bbox[1]),
+      Number(candidate.bbox[2]),
+      Number(candidate.bbox[3]),
+    ];
+  }
+  return view;
+}
+
+/**
+ * Coerce an untrusted `mapLayout` into a valid {@link MapGridLayout}. Returns
+ * null when absent or effectively single-pane so default projects stay
+ * byte-identical (the field is only written when the grid is larger than 1x1).
+ */
+export function normalizeMapLayout(value: unknown): MapGridLayout | null {
+  if (!value || typeof value !== "object") return null;
+  const candidate = value as Partial<MapGridLayout>;
+  const rows = clamp(
+    Math.floor(normalizeNumber(candidate.rows, 1)),
+    1,
+    MAX_MAP_GRID_DIM,
+  );
+  const cols = clamp(
+    Math.floor(normalizeNumber(candidate.cols, 1)),
+    1,
+    MAX_MAP_GRID_DIM,
+  );
+  if (rows * cols <= 1) return null;
+  return {
+    rows,
+    cols,
+    syncView: normalizeBoolean(candidate.syncView, DEFAULT_MAP_GRID_LAYOUT.syncView),
+  };
+}
+
+/**
+ * Coerce an untrusted `secondaryMapViews` array into valid
+ * {@link SecondaryMapView} records, dropping entries without a usable id and
+ * de-duplicating by id. Returns null when none are valid.
+ */
+export function normalizeSecondaryMapViews(
+  value: unknown,
+): SecondaryMapView[] | null {
+  if (!Array.isArray(value)) return null;
+  const views: SecondaryMapView[] = [];
+  const seen = new Set<string>();
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") continue;
+    const candidate = entry as Partial<SecondaryMapView>;
+    const id = normalizeString(candidate.id).trim();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    views.push({
+      id,
+      view: normalizeMapViewState(candidate.view),
+      basemapStyleUrl: normalizeString(candidate.basemapStyleUrl) || DEFAULT_BASEMAP,
+      basemapVisible: normalizeBoolean(candidate.basemapVisible, true),
+      basemapOpacity: clamp(normalizeNumber(candidate.basemapOpacity, 1), 0, 1),
+    });
+  }
+  return views.length > 0 ? views : null;
+}
+
+/**
+ * Reconcile a parsed grid layout with its secondary panes so the store invariant
+ * holds: `secondaryMapViews.length === rows * cols - 1`. Surplus panes are
+ * dropped; missing panes are filled by cloning the primary map. A null/absent
+ * layout (or a 1x1 grid) collapses to the single-map default.
+ */
+export function resolveMapGrid(
+  layout: MapGridLayout | null,
+  secondaryViews: SecondaryMapView[] | null,
+  primary: {
+    mapView: MapViewState;
+    basemapStyleUrl: string;
+    basemapVisible: boolean;
+    basemapOpacity: number;
+  },
+): { mapLayout: MapGridLayout; secondaryMapViews: SecondaryMapView[] } {
+  if (!layout) {
+    return { mapLayout: { ...DEFAULT_MAP_GRID_LAYOUT }, secondaryMapViews: [] };
+  }
+  const desired = layout.rows * layout.cols - 1;
+  let views = secondaryViews ?? [];
+  if (views.length > desired) {
+    views = views.slice(0, desired);
+  } else if (views.length < desired) {
+    const seen = new Set(views.map((v) => v.id));
+    const additions: SecondaryMapView[] = [];
+    for (let i = views.length; i < desired; i++) {
+      let id = `secondary-${i}`;
+      while (seen.has(id)) id = `${id}-x`;
+      seen.add(id);
+      additions.push({
+        id,
+        view: { ...primary.mapView },
+        basemapStyleUrl: primary.basemapStyleUrl,
+        basemapVisible: primary.basemapVisible,
+        basemapOpacity: primary.basemapOpacity,
+      });
+    }
+    views = [...views, ...additions];
+  }
+  return { mapLayout: layout, secondaryMapViews: views };
 }
 
 /** A 3- or 6-digit hex color, the only widget color format we persist. */
@@ -783,6 +932,8 @@ export function projectFromStore(state: {
   models?: ProcessingModel[] | null;
   widgets?: DashboardWidget[] | null;
   dashboardColumns?: number;
+  mapLayout?: MapGridLayout;
+  secondaryMapViews?: SecondaryMapView[];
   metadata: Record<string, unknown>;
 }): GeoLibreProject {
   const styles: Record<string, LayerStyle> = {};
@@ -804,6 +955,20 @@ export function projectFromStore(state: {
   // key is spread only when non-empty so legacy readers that don't recognise it
   // are unaffected; normalizeLayerGroups round-trips them back on load.
   const layerGroups = state.layerGroups ?? [];
+  // Persist the grid only when it is more than a single pane; default single-map
+  // projects stay byte-identical and unaffected by this feature. The reconcile
+  // keeps `secondaryMapViews` exactly `rows * cols - 1` long even if state drifted.
+  const { mapLayout, secondaryMapViews } = resolveMapGrid(
+    normalizeMapLayout(state.mapLayout),
+    normalizeSecondaryMapViews(state.secondaryMapViews),
+    {
+      mapView: state.mapView,
+      basemapStyleUrl: state.basemapStyleUrl,
+      basemapVisible: state.basemapVisible,
+      basemapOpacity: state.basemapOpacity,
+    },
+  );
+  const persistGrid = mapLayout.rows * mapLayout.cols > 1;
   return {
     version: PROJECT_VERSION,
     name: state.projectName,
@@ -821,6 +986,7 @@ export function projectFromStore(state: {
     ...(models ? { models } : {}),
     ...(widgets ? { widgets } : {}),
     ...(dashboardColumns !== DEFAULT_DASHBOARD_COLUMNS ? { dashboardColumns } : {}),
+    ...(persistGrid ? { mapLayout, secondaryMapViews } : {}),
     metadata: state.metadata,
   };
 }
@@ -906,6 +1072,8 @@ export function applyProjectToStore(project: GeoLibreProject): {
   models: ProcessingModel[];
   widgets: DashboardWidget[];
   dashboardColumns: number;
+  mapLayout: MapGridLayout;
+  secondaryMapViews: SecondaryMapView[];
   metadata: Record<string, unknown>;
 } {
   const layers = project.layers.map((layer) => ({
@@ -931,12 +1099,22 @@ export function applyProjectToStore(project: GeoLibreProject): {
         : layer,
     ),
   );
+  const basemapStyleUrl = project.basemapStyleUrl;
+  const basemapVisible = project.basemapVisible ?? true;
+  const basemapOpacity = project.basemapOpacity ?? 1;
+  // Reconcile the (possibly hand-edited or programmatic) grid so the store's
+  // invariant `secondaryMapViews.length === rows * cols - 1` always holds.
+  const { mapLayout, secondaryMapViews } = resolveMapGrid(
+    normalizeMapLayout(project.mapLayout),
+    normalizeSecondaryMapViews(project.secondaryMapViews),
+    { mapView: project.mapView, basemapStyleUrl, basemapVisible, basemapOpacity },
+  );
   return {
     projectName: project.name,
     mapView: project.mapView,
-    basemapStyleUrl: project.basemapStyleUrl,
-    basemapVisible: project.basemapVisible ?? true,
-    basemapOpacity: project.basemapOpacity ?? 1,
+    basemapStyleUrl,
+    basemapVisible,
+    basemapOpacity,
     layers: normalizedLayers,
     layerGroups,
     preferences: normalizeProjectPreferences(project.preferences),
@@ -946,6 +1124,8 @@ export function applyProjectToStore(project: GeoLibreProject): {
     models: normalizeModels(project.models) ?? [],
     widgets: normalizeWidgets(project.widgets) ?? [],
     dashboardColumns: normalizeDashboardColumns(project.dashboardColumns),
+    mapLayout,
+    secondaryMapViews,
     metadata: project.metadata,
   };
 }

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -125,7 +125,13 @@ export function parseProject(json: string): GeoLibreProject {
     // Only persist the grid when it is larger than a single pane, so default
     // single-map projects serialize byte-identically to before this feature.
     ...(mapLayout.rows * mapLayout.cols > 1
-      ? { mapLayout, secondaryMapViews }
+      ? {
+          mapLayout,
+          secondaryMapViews,
+          ...(normalizeString(data.primaryMapLabel)
+            ? { primaryMapLabel: normalizeString(data.primaryMapLabel) }
+            : {}),
+        }
       : {}),
     metadata: data.metadata ?? {},
   };
@@ -497,9 +503,11 @@ export function normalizeSecondaryMapViews(
     const id = normalizeString(candidate.id).trim();
     if (!id || seen.has(id)) continue;
     seen.add(id);
+    const label = normalizeString(candidate.label);
     views.push({
       id,
       view: normalizeMapViewState(candidate.view),
+      ...(label ? { label } : {}),
       layerVisibility: normalizeLayerVisibility(candidate.layerVisibility),
     });
   }
@@ -935,6 +943,7 @@ export function projectFromStore(state: {
   dashboardColumns?: number;
   mapLayout?: MapGridLayout;
   secondaryMapViews?: SecondaryMapView[];
+  primaryMapLabel?: string;
   metadata: Record<string, unknown>;
 }): GeoLibreProject {
   const styles: Record<string, LayerStyle> = {};
@@ -982,7 +991,15 @@ export function projectFromStore(state: {
     ...(models ? { models } : {}),
     ...(widgets ? { widgets } : {}),
     ...(dashboardColumns !== DEFAULT_DASHBOARD_COLUMNS ? { dashboardColumns } : {}),
-    ...(persistGrid ? { mapLayout, secondaryMapViews } : {}),
+    ...(persistGrid
+      ? {
+          mapLayout,
+          secondaryMapViews,
+          ...(normalizeString(state.primaryMapLabel)
+            ? { primaryMapLabel: normalizeString(state.primaryMapLabel) }
+            : {}),
+        }
+      : {}),
     metadata: state.metadata,
   };
 }
@@ -1070,6 +1087,7 @@ export function applyProjectToStore(project: GeoLibreProject): {
   dashboardColumns: number;
   mapLayout: MapGridLayout;
   secondaryMapViews: SecondaryMapView[];
+  primaryMapLabel: string;
   metadata: Record<string, unknown>;
 } {
   const layers = project.layers.map((layer) => ({
@@ -1122,6 +1140,7 @@ export function applyProjectToStore(project: GeoLibreProject): {
     dashboardColumns: normalizeDashboardColumns(project.dashboardColumns),
     mapLayout,
     secondaryMapViews,
+    primaryMapLabel: normalizeString(project.primaryMapLabel),
     metadata: project.metadata,
   };
 }

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -101,7 +101,7 @@ export function parseProject(json: string): GeoLibreProject {
   const { mapLayout, secondaryMapViews } = resolveMapGrid(
     normalizeMapLayout(data.mapLayout),
     normalizeSecondaryMapViews(data.secondaryMapViews),
-    { mapView: data.mapView, basemapStyleUrl, basemapVisible, basemapOpacity },
+    { mapView: data.mapView },
   );
   return {
     version: data.version,
@@ -500,12 +500,20 @@ export function normalizeSecondaryMapViews(
     views.push({
       id,
       view: normalizeMapViewState(candidate.view),
-      basemapStyleUrl: normalizeString(candidate.basemapStyleUrl) || DEFAULT_BASEMAP,
-      basemapVisible: normalizeBoolean(candidate.basemapVisible, true),
-      basemapOpacity: clamp(normalizeNumber(candidate.basemapOpacity, 1), 0, 1),
+      layerVisibility: normalizeLayerVisibility(candidate.layerVisibility),
     });
   }
   return views.length > 0 ? views : null;
+}
+
+/** Coerce an untrusted per-layer visibility map into `Record<string, boolean>`. */
+function normalizeLayerVisibility(value: unknown): Record<string, boolean> {
+  if (!value || typeof value !== "object") return {};
+  const result: Record<string, boolean> = {};
+  for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof raw === "boolean") result[key] = raw;
+  }
+  return result;
 }
 
 /**
@@ -517,12 +525,7 @@ export function normalizeSecondaryMapViews(
 export function resolveMapGrid(
   layout: MapGridLayout | null,
   secondaryViews: SecondaryMapView[] | null,
-  primary: {
-    mapView: MapViewState;
-    basemapStyleUrl: string;
-    basemapVisible: boolean;
-    basemapOpacity: number;
-  },
+  primary: { mapView: MapViewState },
 ): { mapLayout: MapGridLayout; secondaryMapViews: SecondaryMapView[] } {
   if (!layout) {
     return { mapLayout: { ...DEFAULT_MAP_GRID_LAYOUT }, secondaryMapViews: [] };
@@ -541,9 +544,7 @@ export function resolveMapGrid(
       additions.push({
         id,
         view: { ...primary.mapView },
-        basemapStyleUrl: primary.basemapStyleUrl,
-        basemapVisible: primary.basemapVisible,
-        basemapOpacity: primary.basemapOpacity,
+        layerVisibility: {},
       });
     }
     views = [...views, ...additions];
@@ -961,12 +962,7 @@ export function projectFromStore(state: {
   const { mapLayout, secondaryMapViews } = resolveMapGrid(
     normalizeMapLayout(state.mapLayout),
     normalizeSecondaryMapViews(state.secondaryMapViews),
-    {
-      mapView: state.mapView,
-      basemapStyleUrl: state.basemapStyleUrl,
-      basemapVisible: state.basemapVisible,
-      basemapOpacity: state.basemapOpacity,
-    },
+    { mapView: state.mapView },
   );
   const persistGrid = mapLayout.rows * mapLayout.cols > 1;
   return {
@@ -1107,7 +1103,7 @@ export function applyProjectToStore(project: GeoLibreProject): {
   const { mapLayout, secondaryMapViews } = resolveMapGrid(
     normalizeMapLayout(project.mapLayout),
     normalizeSecondaryMapViews(project.secondaryMapViews),
-    { mapView: project.mapView, basemapStyleUrl, basemapVisible, basemapOpacity },
+    { mapView: project.mapView },
   );
   return {
     projectName: project.name,

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -436,14 +436,19 @@ export function normalizeMapViewState(value: unknown): MapViewState {
   const center = Array.isArray(candidate.center)
     ? candidate.center
     : fallback.center;
+  // Clamp to MapLibre's valid ranges (matching normalizeStoryChapter) so a
+  // hand-edited project file can't store an out-of-range camera that jumpTo
+  // would silently clamp or reject, leaving the saved state inconsistent with
+  // what lands on screen. Bearing wraps into [0, 360).
   const view: MapViewState = {
     center: [
-      normalizeNumber(center[0], fallback.center[0]),
-      normalizeNumber(center[1], fallback.center[1]),
+      clampCoordinate(normalizeNumber(center[0], fallback.center[0]), -180, 180),
+      clampCoordinate(normalizeNumber(center[1], fallback.center[1]), -90, 90),
     ],
-    zoom: normalizeNumber(candidate.zoom, fallback.zoom),
-    bearing: normalizeNumber(candidate.bearing, fallback.bearing),
-    pitch: normalizeNumber(candidate.pitch, fallback.pitch),
+    zoom: clamp(normalizeNumber(candidate.zoom, fallback.zoom), 0, 24),
+    bearing:
+      ((normalizeNumber(candidate.bearing, fallback.bearing) % 360) + 360) % 360,
+    pitch: clamp(normalizeNumber(candidate.pitch, fallback.pitch), 0, 85),
   };
   if (
     Array.isArray(candidate.bbox) &&
@@ -547,7 +552,10 @@ export function resolveMapGrid(
     const additions: SecondaryMapView[] = [];
     for (let i = views.length; i < desired; i++) {
       let id = `secondary-${i}`;
-      while (seen.has(id)) id = `${id}-x`;
+      // Append a counter (rather than growing the string) so a crafted file
+      // with colliding ids resolves in O(1) per attempt instead of O(n).
+      let suffix = 0;
+      while (seen.has(id)) id = `secondary-${i}-${++suffix}`;
       seen.add(id);
       additions.push({
         id,

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -156,6 +156,8 @@ export interface AppState {
    * exactly `rows * cols - 1` entries in sync with `mapLayout`.
    */
   secondaryMapViews: SecondaryMapView[];
+  /** User-entered label for the primary pane (shown only in multi-map mode). */
+  primaryMapLabel: string;
   selectedLayerId: string | null;
   selectedFeatureId: string | null;
   identifyLayerId: string | null;
@@ -220,6 +222,10 @@ export interface AppState {
     layerId: string,
     visible: boolean
   ) => void;
+  /** Set the primary pane's custom label. */
+  setPrimaryMapLabel: (label: string) => void;
+  /** Set one secondary pane's custom label (no-op if the id is unknown). */
+  setSecondaryMapLabel: (id: string, label: string) => void;
   /** Remove one secondary pane and collapse the grid back toward 1x1. */
   removeSecondaryMapView: (id: string) => void;
   setBasemapStyleUrl: (url: string) => void;
@@ -486,6 +492,7 @@ export const useAppStore = create<AppState>()(
       dashboardColumns: DEFAULT_DASHBOARD_COLUMNS,
       mapLayout: { ...DEFAULT_MAP_GRID_LAYOUT },
       secondaryMapViews: [],
+      primaryMapLabel: "",
       selectedLayerId: null,
       selectedFeatureId: null,
       identifyLayerId: null,
@@ -599,6 +606,19 @@ export const useAppStore = create<AppState>()(
               ...pane,
               layerVisibility: { ...pane.layerVisibility, [layerId]: visible },
             };
+          });
+          if (!changed) return s;
+          return { secondaryMapViews, isDirty: true };
+        }),
+      setPrimaryMapLabel: (label) =>
+        set({ primaryMapLabel: label, isDirty: true }),
+      setSecondaryMapLabel: (id, label) =>
+        set((s) => {
+          let changed = false;
+          const secondaryMapViews = s.secondaryMapViews.map((pane) => {
+            if (pane.id !== id) return pane;
+            changed = true;
+            return { ...pane, label };
           });
           if (!changed) return s;
           return { secondaryMapViews, isDirty: true };

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -210,15 +210,15 @@ export interface AppState {
     view: Partial<MapViewState>,
     markDirty?: boolean
   ) => void;
-  /** Patch one secondary pane's basemap by id (no-op if the id is unknown). */
-  setSecondaryBasemap: (
+  /**
+   * Override a layer's visibility in one secondary pane (no-op if the pane id is
+   * unknown). The override forces the layer visible/hidden in that pane only,
+   * independent of the primary map's visibility.
+   */
+  setSecondaryLayerVisibility: (
     id: string,
-    patch: Partial<
-      Pick<
-        SecondaryMapView,
-        "basemapStyleUrl" | "basemapVisible" | "basemapOpacity"
-      >
-    >
+    layerId: string,
+    visible: boolean
   ) => void;
   /** Remove one secondary pane and collapse the grid back toward 1x1. */
   removeSecondaryMapView: (id: string) => void;
@@ -549,14 +549,13 @@ export const useAppStore = create<AppState>()(
           } else if (desiredSecondary > secondaryMapViews.length) {
             const additions: SecondaryMapView[] = [];
             for (let i = secondaryMapViews.length; i < desiredSecondary; i++) {
-              // New panes start as a clone of the primary map so the comparison
-              // begins from the same camera and basemap the user is looking at.
+              // New panes start as a clone of the primary map's camera and (by
+              // having no overrides) inherit its layer visibility, so the
+              // comparison begins from the same view the user is looking at.
               additions.push({
                 id: uuidv4(),
                 view: { ...s.mapView },
-                basemapStyleUrl: s.basemapStyleUrl,
-                basemapVisible: s.basemapVisible,
-                basemapOpacity: s.basemapOpacity,
+                layerVisibility: {},
               });
             }
             secondaryMapViews = [...secondaryMapViews, ...additions];
@@ -590,13 +589,16 @@ export const useAppStore = create<AppState>()(
             isDirty: markDirty || s.isDirty,
           };
         }),
-      setSecondaryBasemap: (id, patch) =>
+      setSecondaryLayerVisibility: (id, layerId, visible) =>
         set((s) => {
           let changed = false;
           const secondaryMapViews = s.secondaryMapViews.map((pane) => {
             if (pane.id !== id) return pane;
             changed = true;
-            return { ...pane, ...patch };
+            return {
+              ...pane,
+              layerVisibility: { ...pane.layerVisibility, [layerId]: visible },
+            };
           });
           if (!changed) return s;
           return { secondaryMapViews, isDirty: true };

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -25,7 +25,9 @@ import {
   DEFAULT_DASHBOARD_COLUMNS,
   DEFAULT_LAYER_STYLE,
   DEFAULT_LEGEND_CONFIG,
+  DEFAULT_MAP_GRID_LAYOUT,
   DEFAULT_PROJECT_PREFERENCES,
+  MAX_MAP_GRID_DIM,
   DEFAULT_STORY_MAP,
   MAX_DASHBOARD_COLUMNS,
   MIN_DASHBOARD_COLUMNS,
@@ -38,8 +40,10 @@ import {
   type LayerGroup,
   type LayerStyle,
   type LegendConfig,
+  type MapGridLayout,
   type MapViewState,
   type ProcessingModel,
+  type SecondaryMapView,
   type ProjectPluginState,
   type ProjectPreferences,
   type RecentProjectEntry,
@@ -141,6 +145,17 @@ export interface AppState {
   widgets: DashboardWidget[];
   /** Number of columns in the Dashboard widget grid. */
   dashboardColumns: number;
+  /**
+   * Multi-map grid layout (issue: split/grid view). A 1x1 grid is the normal
+   * single-map workspace. `rows * cols` panes are shown; pane 0 is the primary
+   * map driven by `mapView` / `basemap*`, panes 1.. are `secondaryMapViews`.
+   */
+  mapLayout: MapGridLayout;
+  /**
+   * Secondary map panes (everything past the primary pane). The store keeps
+   * exactly `rows * cols - 1` entries in sync with `mapLayout`.
+   */
+  secondaryMapViews: SecondaryMapView[];
   selectedLayerId: string | null;
   selectedFeatureId: string | null;
   identifyLayerId: string | null;
@@ -181,6 +196,32 @@ export interface AppState {
   ) => void;
   resetCollaboration: () => void;
   setMapView: (view: Partial<MapViewState>, markDirty?: boolean) => void;
+  /**
+   * Resize the map grid. Clamps `rows`/`cols` into range and grows/shrinks
+   * `secondaryMapViews` so it always holds `rows * cols - 1` panes; new panes
+   * clone the primary map's current camera and basemap.
+   */
+  setMapGrid: (rows: number, cols: number) => void;
+  /** Toggle synchronized camera across all panes. */
+  setSyncView: (syncView: boolean) => void;
+  /** Patch one secondary pane's camera by id (no-op if the id is unknown). */
+  setSecondaryMapView: (
+    id: string,
+    view: Partial<MapViewState>,
+    markDirty?: boolean
+  ) => void;
+  /** Patch one secondary pane's basemap by id (no-op if the id is unknown). */
+  setSecondaryBasemap: (
+    id: string,
+    patch: Partial<
+      Pick<
+        SecondaryMapView,
+        "basemapStyleUrl" | "basemapVisible" | "basemapOpacity"
+      >
+    >
+  ) => void;
+  /** Remove one secondary pane and collapse the grid back toward 1x1. */
+  removeSecondaryMapView: (id: string) => void;
   setBasemapStyleUrl: (url: string) => void;
   setBasemapVisible: (visible: boolean) => void;
   setBasemapOpacity: (opacity: number) => void;
@@ -374,6 +415,36 @@ function layerGroupsEqualForHistory(
   return true;
 }
 
+/** Clamp a requested grid row/column count into the supported [1, MAX] range. */
+function clampGridDim(value: number): number {
+  if (!Number.isFinite(value)) return 1;
+  return Math.max(1, Math.min(MAX_MAP_GRID_DIM, Math.floor(value)));
+}
+
+/**
+ * Pick a gap-free grid that holds exactly `total` panes, preferring a column
+ * count close to (and, on ties, no smaller than) `preferredCols` so removing a
+ * pane keeps the layout's orientation without leaving an empty cell. Used when
+ * collapsing the grid after a pane is removed.
+ */
+function fitGrid(
+  total: number,
+  preferredCols: number,
+): { rows: number; cols: number } {
+  if (total <= 1) return { rows: 1, cols: 1 };
+  let best = { rows: total, cols: 1, score: Number.POSITIVE_INFINITY };
+  for (let cols = 1; cols <= total; cols++) {
+    if (total % cols !== 0) continue;
+    const score = Math.abs(cols - preferredCols);
+    // `<=` lets a larger, equally-close column count win ties, favoring wider
+    // (side-by-side) layouts over tall ones.
+    if (score <= best.score) {
+      best = { rows: total / cols, cols, score };
+    }
+  }
+  return { rows: best.rows, cols: best.cols };
+}
+
 /** Cancels the active history coalesce window (assigned by zundo's handleSet). */
 let cancelHistoryCoalesce: () => void = () => {};
 
@@ -413,6 +484,8 @@ export const useAppStore = create<AppState>()(
       models: [],
       widgets: [],
       dashboardColumns: DEFAULT_DASHBOARD_COLUMNS,
+      mapLayout: { ...DEFAULT_MAP_GRID_LAYOUT },
+      secondaryMapViews: [],
       selectedLayerId: null,
       selectedFeatureId: null,
       identifyLayerId: null,
@@ -465,6 +538,87 @@ export const useAppStore = create<AppState>()(
           mapView: { ...s.mapView, ...view },
           isDirty: markDirty || s.isDirty,
         })),
+      setMapGrid: (rows, cols) =>
+        set((s) => {
+          const clampedRows = clampGridDim(rows);
+          const clampedCols = clampGridDim(cols);
+          const desiredSecondary = clampedRows * clampedCols - 1;
+          let secondaryMapViews = s.secondaryMapViews;
+          if (desiredSecondary < secondaryMapViews.length) {
+            secondaryMapViews = secondaryMapViews.slice(0, desiredSecondary);
+          } else if (desiredSecondary > secondaryMapViews.length) {
+            const additions: SecondaryMapView[] = [];
+            for (let i = secondaryMapViews.length; i < desiredSecondary; i++) {
+              // New panes start as a clone of the primary map so the comparison
+              // begins from the same camera and basemap the user is looking at.
+              additions.push({
+                id: uuidv4(),
+                view: { ...s.mapView },
+                basemapStyleUrl: s.basemapStyleUrl,
+                basemapVisible: s.basemapVisible,
+                basemapOpacity: s.basemapOpacity,
+              });
+            }
+            secondaryMapViews = [...secondaryMapViews, ...additions];
+          }
+          return {
+            mapLayout: {
+              ...s.mapLayout,
+              rows: clampedRows,
+              cols: clampedCols,
+            },
+            secondaryMapViews,
+            isDirty: true,
+          };
+        }),
+      setSyncView: (syncView) =>
+        set((s) => ({
+          mapLayout: { ...s.mapLayout, syncView },
+          isDirty: true,
+        })),
+      setSecondaryMapView: (id, view, markDirty = false) =>
+        set((s) => {
+          let changed = false;
+          const secondaryMapViews = s.secondaryMapViews.map((pane) => {
+            if (pane.id !== id) return pane;
+            changed = true;
+            return { ...pane, view: { ...pane.view, ...view } };
+          });
+          if (!changed) return s;
+          return {
+            secondaryMapViews,
+            isDirty: markDirty || s.isDirty,
+          };
+        }),
+      setSecondaryBasemap: (id, patch) =>
+        set((s) => {
+          let changed = false;
+          const secondaryMapViews = s.secondaryMapViews.map((pane) => {
+            if (pane.id !== id) return pane;
+            changed = true;
+            return { ...pane, ...patch };
+          });
+          if (!changed) return s;
+          return { secondaryMapViews, isDirty: true };
+        }),
+      removeSecondaryMapView: (id) =>
+        set((s) => {
+          const secondaryMapViews = s.secondaryMapViews.filter(
+            (pane) => pane.id !== id
+          );
+          if (secondaryMapViews.length === s.secondaryMapViews.length) {
+            return s;
+          }
+          // Collapse to a gap-free grid that fits the remaining panes, keeping
+          // the layout's orientation as close as possible to the current one.
+          const total = secondaryMapViews.length + 1;
+          const { rows, cols } = fitGrid(total, s.mapLayout.cols);
+          return {
+            secondaryMapViews,
+            mapLayout: { ...s.mapLayout, rows, cols },
+            isDirty: true,
+          };
+        }),
       setBasemapStyleUrl: (url) => set({ basemapStyleUrl: url, isDirty: true }),
       setBasemapVisible: (visible) =>
         set({ basemapVisible: visible, isDirty: true }),

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -421,6 +421,17 @@ function layerGroupsEqualForHistory(
   return true;
 }
 
+/** True when two camera states have identical center/zoom/bearing/pitch. */
+function sameCamera(a: MapViewState, b: MapViewState): boolean {
+  return (
+    a.center[0] === b.center[0] &&
+    a.center[1] === b.center[1] &&
+    a.zoom === b.zoom &&
+    a.bearing === b.bearing &&
+    a.pitch === b.pitch
+  );
+}
+
 /** Clamp a requested grid row/column count into the supported [1, MAX] range. */
 function clampGridDim(value: number): number {
   if (!Number.isFinite(value)) return 1;
@@ -428,27 +439,44 @@ function clampGridDim(value: number): number {
 }
 
 /**
- * Pick a gap-free grid that holds exactly `total` panes, preferring a column
- * count close to (and, on ties, no smaller than) `preferredCols` so removing a
- * pane keeps the layout's orientation without leaving an empty cell. Used when
+ * Pick a grid that holds at least `total` panes within the supported
+ * `MAX_MAP_GRID_DIM x MAX_MAP_GRID_DIM` bound, minimizing empty cells first and
+ * then preferring a column count close to (and, on ties, no smaller than)
+ * `preferredCols` so removing a pane keeps the layout's orientation. Used when
  * collapsing the grid after a pane is removed.
+ *
+ * Bounding both dimensions matters: a prime `total` (e.g. 5 panes left after
+ * removing one from a 2x3 grid) has no gap-free factor pair inside the bound, so
+ * the only gap-free options (1x5 / 5x1) would exceed `MAX_MAP_GRID_DIM`. In that
+ * case we accept the smallest bounded grid with one empty trailing cell (2x3)
+ * rather than returning an out-of-range dimension.
  */
 function fitGrid(
   total: number,
   preferredCols: number,
 ): { rows: number; cols: number } {
   if (total <= 1) return { rows: 1, cols: 1 };
-  let best = { rows: total, cols: 1, score: Number.POSITIVE_INFINITY };
-  for (let cols = 1; cols <= total; cols++) {
-    if (total % cols !== 0) continue;
-    const score = Math.abs(cols - preferredCols);
-    // `<=` lets a larger, equally-close column count win ties, favoring wider
-    // (side-by-side) layouts over tall ones.
-    if (score <= best.score) {
-      best = { rows: total / cols, cols, score };
+  let best: { rows: number; cols: number; empty: number; score: number } | null =
+    null;
+  for (let rows = 1; rows <= MAX_MAP_GRID_DIM; rows++) {
+    for (let cols = 1; cols <= MAX_MAP_GRID_DIM; cols++) {
+      const capacity = rows * cols;
+      if (capacity < total) continue;
+      const empty = capacity - total;
+      const score = Math.abs(cols - preferredCols);
+      // Fewest empty cells wins; then the column count closest to
+      // preferredCols; then, on a tie, the larger column count (favoring wider,
+      // side-by-side layouts over tall ones).
+      const better =
+        best === null ||
+        empty < best.empty ||
+        (empty === best.empty &&
+          (score < best.score ||
+            (score === best.score && cols > best.cols)));
+      if (better) best = { rows, cols, empty, score };
     }
   }
-  return { rows: best.rows, cols: best.cols };
+  return best ? { rows: best.rows, cols: best.cols } : { rows: 1, cols: 1 };
 }
 
 /** Cancels the active history coalesce window (assigned by zundo's handleSet). */
@@ -587,8 +615,14 @@ export const useAppStore = create<AppState>()(
           let changed = false;
           const secondaryMapViews = s.secondaryMapViews.map((pane) => {
             if (pane.id !== id) return pane;
+            const merged = { ...pane.view, ...view };
+            // Skip value-identical writes: a programmatic `applyView` (camera
+            // sync, initial load) fires "moveend" too, so without this guard
+            // each pane re-stores the same camera it was just given, churning a
+            // new `secondaryMapViews` array and re-rendering every subscriber.
+            if (sameCamera(pane.view, merged)) return pane;
             changed = true;
-            return { ...pane, view: { ...pane.view, ...view } };
+            return { ...pane, view: merged };
           });
           if (!changed) return s;
           return {
@@ -865,6 +899,13 @@ export const useAppStore = create<AppState>()(
       removeLayer: (id) =>
         set((s) => ({
           layers: s.layers.filter((l) => l.id !== id),
+          // Drop any per-pane visibility override for the removed layer so stale
+          // ids don't accumulate (and serialize) in secondary panes over time.
+          secondaryMapViews: s.secondaryMapViews.map((pane) => {
+            if (!(id in pane.layerVisibility)) return pane;
+            const { [id]: _removed, ...rest } = pane.layerVisibility;
+            return { ...pane, layerVisibility: rest };
+          }),
           selectedLayerId:
             s.selectedLayerId === id
               ? s.layers.find((l) => l.id !== id)?.id ?? null

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -318,6 +318,44 @@ export interface MapViewState {
 }
 
 /**
+ * Multi-map (split/grid) support. The workspace can show several map panes in a
+ * `rows x cols` grid. Pane 0 is always the *primary* map: it keeps the existing
+ * single-map wiring (the global `mapView` + `basemap*` fields, the layer/style
+ * panels, plugins, deck.gl). Panes 1..N are *secondary* maps described by
+ * `SecondaryMapView` records: they render the same shared `layers` but each owns
+ * its basemap and camera. When `syncView` is on, panning/zooming any pane mirrors
+ * the camera to every other pane.
+ */
+export interface MapGridLayout {
+  /** Grid rows (>= 1). */
+  rows: number;
+  /** Grid columns (>= 1). `rows * cols` is the total number of panes. */
+  cols: number;
+  /** When true, all panes share a synchronized camera. */
+  syncView: boolean;
+}
+
+/** A non-primary map pane: shared layers, its own basemap and camera. */
+export interface SecondaryMapView {
+  /** Stable id, used as the React key and the sync-group registration id. */
+  id: string;
+  view: MapViewState;
+  basemapStyleUrl: string;
+  basemapVisible: boolean;
+  basemapOpacity: number;
+}
+
+/** The default single-map grid (one pane, sync enabled so it turns on cleanly). */
+export const DEFAULT_MAP_GRID_LAYOUT: MapGridLayout = {
+  rows: 1,
+  cols: 1,
+  syncView: true,
+};
+
+/** Maximum rows or columns in the map grid (so at most a 4x4 = 16-pane grid). */
+export const MAX_MAP_GRID_DIM = 4;
+
+/**
  * Live multi-user collaboration (issue #307). These types describe the
  * *ephemeral* session state the store holds while a live session is active. It
  * is intentionally never written to the `.geolibre.json` project file (the
@@ -675,6 +713,17 @@ export interface GeoLibreProject {
   widgets?: DashboardWidget[];
   /** Number of columns in the Dashboard widget grid; omitted when default. */
   dashboardColumns?: number;
+  /**
+   * Multi-map grid layout; omitted (single 1x1 pane) for default projects so
+   * legacy readers and single-map files are unaffected.
+   */
+  mapLayout?: MapGridLayout;
+  /**
+   * Secondary map panes (everything past the primary pane). Omitted when the
+   * grid is a single pane. The primary pane uses the top-level `mapView` /
+   * `basemap*` fields.
+   */
+  secondaryMapViews?: SecondaryMapView[];
   metadata: Record<string, unknown>;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -322,9 +322,10 @@ export interface MapViewState {
  * `rows x cols` grid. Pane 0 is always the *primary* map: it keeps the existing
  * single-map wiring (the global `mapView` + `basemap*` fields, the layer/style
  * panels, plugins, deck.gl). Panes 1..N are *secondary* maps described by
- * `SecondaryMapView` records: they render the same shared `layers` but each owns
- * its basemap and camera. When `syncView` is on, panning/zooming any pane mirrors
- * the camera to every other pane.
+ * `SecondaryMapView` records: every pane shares the same basemap and the same
+ * `layers`, but each secondary pane may override which layers are visible so
+ * different panes can show different layers. When `syncView` is on,
+ * panning/zooming any pane mirrors the camera to every other pane.
  */
 export interface MapGridLayout {
   /** Grid rows (>= 1). */
@@ -335,14 +336,20 @@ export interface MapGridLayout {
   syncView: boolean;
 }
 
-/** A non-primary map pane: shared layers, its own basemap and camera. */
+/**
+ * A non-primary map pane: shares the primary map's basemap and layers, with its
+ * own camera and per-layer visibility overrides.
+ */
 export interface SecondaryMapView {
   /** Stable id, used as the React key and the sync-group registration id. */
   id: string;
   view: MapViewState;
-  basemapStyleUrl: string;
-  basemapVisible: boolean;
-  basemapOpacity: number;
+  /**
+   * Per-layer visibility overrides keyed by layer id. A layer absent from this
+   * map inherits the primary map's visibility (`layer.visible`); an entry forces
+   * the layer visible (`true`) or hidden (`false`) in this pane only.
+   */
+  layerVisibility: Record<string, boolean>;
 }
 
 /** The default single-map grid (one pane, sync enabled so it turns on cleanly). */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -344,6 +344,8 @@ export interface SecondaryMapView {
   /** Stable id, used as the React key and the sync-group registration id. */
   id: string;
   view: MapViewState;
+  /** Optional user-entered label shown on the pane (e.g. a date or scenario). */
+  label?: string;
   /**
    * Per-layer visibility overrides keyed by layer id. A layer absent from this
    * map inherits the primary map's visibility (`layer.visible`); an entry forces
@@ -731,6 +733,8 @@ export interface GeoLibreProject {
    * `basemap*` fields.
    */
   secondaryMapViews?: SecondaryMapView[];
+  /** User-entered label for the primary pane; omitted when empty. */
+  primaryMapLabel?: string;
   metadata: Record<string, unknown>;
 }
 

--- a/packages/map/src/SecondaryMapCanvas.tsx
+++ b/packages/map/src/SecondaryMapCanvas.tsx
@@ -1,9 +1,10 @@
 import {
   applyGroupEffects,
   useAppStore,
+  type GeoLibreLayer,
   type MapViewState,
 } from "@geolibre/core";
-import { memo, useEffect, useRef } from "react";
+import { memo, useEffect, useMemo, useRef } from "react";
 import { createMapController, type MapController } from "./map-controller";
 import "maplibre-gl/dist/maplibre-gl.css";
 
@@ -19,10 +20,15 @@ export interface SecondaryMapCanvasProps {
 
 /**
  * A non-primary map pane in the multi-map grid. It renders the *shared* store
- * layers with its own basemap and camera, deliberately omitting the heavy
+ * layers on the *shared* (global) basemap, deliberately omitting the heavy
  * single-map wiring (identify, highlight, draw, deck.gl, the layer control) that
  * lives on the primary {@link MapCanvas}. The layer control is suppressed so the
  * pane never writes the shared layer/basemap state back to the global store.
+ *
+ * Each pane may override which layers are visible: a layer's effective
+ * visibility here is `secondaryMapViews[i].layerVisibility[layerId]` when set,
+ * otherwise the primary map's `layer.visible`. This lets different panes show
+ * different layers over the same data.
  *
  * Camera synchronization is intentionally routed through the global `mapView`:
  * when `mapLayout.syncView` is on, this pane mirrors the global camera (which the
@@ -48,13 +54,27 @@ export const SecondaryMapCanvas = memo(function SecondaryMapCanvas({
   const layers = useAppStore((s) => s.layers);
   const layerGroups = useAppStore((s) => s.layerGroups);
 
+  // The basemap is shared with the primary map (the global store fields).
+  const basemapStyleUrl = useAppStore((s) => s.basemapStyleUrl);
+  const basemapVisible = useAppStore((s) => s.basemapVisible);
+  const basemapOpacity = useAppStore((s) => s.basemapOpacity);
+
   // Camera primitives, split out so the apply effects depend on values rather
   // than object identity (a new `mapView` object with equal values is a no-op).
   const globalView = useAppStore((s) => s.mapView);
   const entryView = entry?.view;
-  const basemapStyleUrl = entry?.basemapStyleUrl;
-  const basemapVisible = entry?.basemapVisible ?? true;
-  const basemapOpacity = entry?.basemapOpacity ?? 1;
+  const layerVisibility = entry?.layerVisibility;
+
+  // The shared layers with this pane's per-layer visibility overrides applied.
+  const paneLayers = useMemo<GeoLibreLayer[]>(() => {
+    if (!layerVisibility) return layers;
+    return layers.map((layer) => {
+      const override = layerVisibility[layer.id];
+      return override === undefined || override === layer.visible
+        ? layer
+        : { ...layer, visible: override };
+    });
+  }, [layers, layerVisibility]);
 
   // Create the map exactly once. The deps are intentionally empty; everything
   // it reads is captured from the latest store state at mount time.
@@ -70,7 +90,7 @@ export const SecondaryMapCanvas = memo(function SecondaryMapCanvas({
 
     const mc = createMapController();
     const map = mc.init(containerRef.current, {
-      styleUrl: pane?.basemapStyleUrl,
+      styleUrl: state.basemapStyleUrl,
       mapView: initialView,
       mapPreferences: state.preferences.map,
       // No layer control: the shared layers/basemap are owned by the primary
@@ -97,12 +117,19 @@ export const SecondaryMapCanvas = memo(function SecondaryMapCanvas({
 
     map.on("load", () => {
       const live = useAppStore.getState();
-      mc.waitAndSyncLayers(applyGroupEffects(live.layers, live.layerGroups));
-      const current = live.secondaryMapViews.find(
+      const pane = live.secondaryMapViews.find(
         (p) => p.id === viewIdRef.current,
       );
-      mc.setBasemapVisible(current?.basemapVisible ?? true);
-      mc.setBasemapOpacity(current?.basemapOpacity ?? 1);
+      const visibility = pane?.layerVisibility ?? {};
+      const withOverrides = live.layers.map((layer) => {
+        const override = visibility[layer.id];
+        return override === undefined || override === layer.visible
+          ? layer
+          : { ...layer, visible: override };
+      });
+      mc.waitAndSyncLayers(applyGroupEffects(withOverrides, live.layerGroups));
+      mc.setBasemapVisible(live.basemapVisible);
+      mc.setBasemapOpacity(live.basemapOpacity);
     });
 
     let resizeFrame: number | null = null;
@@ -126,17 +153,17 @@ export const SecondaryMapCanvas = memo(function SecondaryMapCanvas({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Reconcile the shared layers onto this pane whenever they change.
+  // Reconcile the shared layers (with this pane's overrides) whenever they or
+  // the overrides change.
   useEffect(() => {
     controller.current?.waitAndSyncLayers(
-      applyGroupEffects(layers, layerGroups),
+      applyGroupEffects(paneLayers, layerGroups),
     );
-  }, [layers, layerGroups]);
+  }, [paneLayers, layerGroups]);
 
-  // Per-pane basemap.
+  // Basemap is shared with the primary map; follow the global store fields.
   const prevBasemap = useRef(basemapStyleUrl);
   useEffect(() => {
-    if (basemapStyleUrl === undefined) return;
     if (prevBasemap.current !== basemapStyleUrl) {
       prevBasemap.current = basemapStyleUrl;
       controller.current?.setStyle(basemapStyleUrl);

--- a/packages/map/src/SecondaryMapCanvas.tsx
+++ b/packages/map/src/SecondaryMapCanvas.tsx
@@ -11,11 +11,6 @@ import "maplibre-gl/dist/maplibre-gl.css";
 export interface SecondaryMapCanvasProps {
   /** Id of the `secondaryMapViews` entry this pane renders. */
   viewId: string;
-  /**
-   * Optional ref handed back the live controller, so the surrounding grid can
-   * reach the map (e.g. to resize it when the layout changes).
-   */
-  controllerRef?: React.MutableRefObject<MapController | null>;
 }
 
 /**
@@ -37,7 +32,6 @@ export interface SecondaryMapCanvasProps {
  */
 export const SecondaryMapCanvas = memo(function SecondaryMapCanvas({
   viewId,
-  controllerRef,
 }: SecondaryMapCanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const controller = useRef<MapController | null>(null);
@@ -98,36 +92,39 @@ export const SecondaryMapCanvas = memo(function SecondaryMapCanvas({
       controlVisibility: { "layer-control": false },
     });
     controller.current = mc;
-    if (controllerRef) controllerRef.current = mc;
+
+    const sameCamera = (a: MapViewState, b: MapViewState) =>
+      a.center[0] === b.center[0] &&
+      a.center[1] === b.center[1] &&
+      a.zoom === b.zoom &&
+      a.bearing === b.bearing &&
+      a.pitch === b.pitch;
 
     const updateView = (event?: { originalEvent?: unknown }) => {
       const view = mc.readView();
       const userDriven = Boolean(event?.originalEvent);
       const live = useAppStore.getState();
-      if (live.mapLayout.syncView) {
+      // A programmatic `applyView` (camera sync / initial load) fires "moveend"
+      // with the same camera it was just given. Skip the global write when the
+      // value is unchanged so a synced pane's echo doesn't cascade back through
+      // every sibling pane's sync effect.
+      if (live.mapLayout.syncView && !sameCamera(view, live.mapView)) {
         // The shared camera lives in the global mapView; mirror this pane's move
         // there so the primary and sibling panes follow.
         live.setMapView(view, userDriven);
       }
       // Always keep this pane's own saved camera current so turning sync off (or
-      // saving the project) preserves where the pane is looking.
+      // saving the project) preserves where the pane is looking. The store skips
+      // value-identical writes, so a programmatic echo here is a no-op.
       live.setSecondaryMapView(viewIdRef.current, view, userDriven);
     };
     map.on("moveend", updateView);
 
+    // Only the basemap visibility/opacity needs to wait for the style here; the
+    // layer-sync effect below already defers its own work to the style load, so
+    // syncing layers here too would just duplicate that pass.
     map.on("load", () => {
       const live = useAppStore.getState();
-      const pane = live.secondaryMapViews.find(
-        (p) => p.id === viewIdRef.current,
-      );
-      const visibility = pane?.layerVisibility ?? {};
-      const withOverrides = live.layers.map((layer) => {
-        const override = visibility[layer.id];
-        return override === undefined || override === layer.visible
-          ? layer
-          : { ...layer, visible: override };
-      });
-      mc.waitAndSyncLayers(applyGroupEffects(withOverrides, live.layerGroups));
       mc.setBasemapVisible(live.basemapVisible);
       mc.setBasemapOpacity(live.basemapOpacity);
     });
@@ -148,7 +145,6 @@ export const SecondaryMapCanvas = memo(function SecondaryMapCanvas({
       if (resizeFrame !== null) window.cancelAnimationFrame(resizeFrame);
       mc.destroy();
       controller.current = null;
-      if (controllerRef) controllerRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -175,6 +171,13 @@ export const SecondaryMapCanvas = memo(function SecondaryMapCanvas({
   useEffect(() => {
     controller.current?.setBasemapOpacity(basemapOpacity);
   }, [basemapOpacity]);
+
+  // Map preferences (projection, zoom/pitch limits, bounds) are shared with the
+  // primary map; re-apply them when they change so a pane doesn't keep the
+  // values captured at mount.
+  useEffect(() => {
+    controller.current?.applyMapPreferences(mapPreferences);
+  }, [mapPreferences]);
 
   // Synced: follow the global (shared) camera. Depend on primitives so an
   // equal-valued mapView object does not re-apply.

--- a/packages/map/src/SecondaryMapCanvas.tsx
+++ b/packages/map/src/SecondaryMapCanvas.tsx
@@ -1,0 +1,189 @@
+import {
+  applyGroupEffects,
+  useAppStore,
+  type MapViewState,
+} from "@geolibre/core";
+import { memo, useEffect, useRef } from "react";
+import { createMapController, type MapController } from "./map-controller";
+import "maplibre-gl/dist/maplibre-gl.css";
+
+export interface SecondaryMapCanvasProps {
+  /** Id of the `secondaryMapViews` entry this pane renders. */
+  viewId: string;
+  /**
+   * Optional ref handed back the live controller, so the surrounding grid can
+   * reach the map (e.g. to resize it when the layout changes).
+   */
+  controllerRef?: React.MutableRefObject<MapController | null>;
+}
+
+/**
+ * A non-primary map pane in the multi-map grid. It renders the *shared* store
+ * layers with its own basemap and camera, deliberately omitting the heavy
+ * single-map wiring (identify, highlight, draw, deck.gl, the layer control) that
+ * lives on the primary {@link MapCanvas}. The layer control is suppressed so the
+ * pane never writes the shared layer/basemap state back to the global store.
+ *
+ * Camera synchronization is intentionally routed through the global `mapView`:
+ * when `mapLayout.syncView` is on, this pane mirrors the global camera (which the
+ * primary map already reads and writes), so panning any pane moves them all.
+ * When sync is off, the pane uses its own saved camera (`secondaryMapViews[i]`).
+ */
+export const SecondaryMapCanvas = memo(function SecondaryMapCanvas({
+  viewId,
+  controllerRef,
+}: SecondaryMapCanvasProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const controller = useRef<MapController | null>(null);
+  // Read the current viewId through a ref so the setup effect can stay
+  // dependency-free (recreating the map on every render would lose its camera).
+  const viewIdRef = useRef(viewId);
+  viewIdRef.current = viewId;
+
+  const entry = useAppStore((s) =>
+    s.secondaryMapViews.find((pane) => pane.id === viewId),
+  );
+  const syncView = useAppStore((s) => s.mapLayout.syncView);
+  const mapPreferences = useAppStore((s) => s.preferences.map);
+  const layers = useAppStore((s) => s.layers);
+  const layerGroups = useAppStore((s) => s.layerGroups);
+
+  // Camera primitives, split out so the apply effects depend on values rather
+  // than object identity (a new `mapView` object with equal values is a no-op).
+  const globalView = useAppStore((s) => s.mapView);
+  const entryView = entry?.view;
+  const basemapStyleUrl = entry?.basemapStyleUrl;
+  const basemapVisible = entry?.basemapVisible ?? true;
+  const basemapOpacity = entry?.basemapOpacity ?? 1;
+
+  // Create the map exactly once. The deps are intentionally empty; everything
+  // it reads is captured from the latest store state at mount time.
+  useEffect(() => {
+    if (!containerRef.current || controller.current) return;
+    const state = useAppStore.getState();
+    const pane = state.secondaryMapViews.find(
+      (p) => p.id === viewIdRef.current,
+    );
+    const initialView: MapViewState | undefined = state.mapLayout.syncView
+      ? state.mapView
+      : pane?.view;
+
+    const mc = createMapController();
+    const map = mc.init(containerRef.current, {
+      styleUrl: pane?.basemapStyleUrl,
+      mapView: initialView,
+      mapPreferences: state.preferences.map,
+      // No layer control: the shared layers/basemap are owned by the primary
+      // map and the global store, so a second control here would fight them.
+      controlVisibility: { "layer-control": false },
+    });
+    controller.current = mc;
+    if (controllerRef) controllerRef.current = mc;
+
+    const updateView = (event?: { originalEvent?: unknown }) => {
+      const view = mc.readView();
+      const userDriven = Boolean(event?.originalEvent);
+      const live = useAppStore.getState();
+      if (live.mapLayout.syncView) {
+        // The shared camera lives in the global mapView; mirror this pane's move
+        // there so the primary and sibling panes follow.
+        live.setMapView(view, userDriven);
+      }
+      // Always keep this pane's own saved camera current so turning sync off (or
+      // saving the project) preserves where the pane is looking.
+      live.setSecondaryMapView(viewIdRef.current, view, userDriven);
+    };
+    map.on("moveend", updateView);
+
+    map.on("load", () => {
+      const live = useAppStore.getState();
+      mc.waitAndSyncLayers(applyGroupEffects(live.layers, live.layerGroups));
+      const current = live.secondaryMapViews.find(
+        (p) => p.id === viewIdRef.current,
+      );
+      mc.setBasemapVisible(current?.basemapVisible ?? true);
+      mc.setBasemapOpacity(current?.basemapOpacity ?? 1);
+    });
+
+    let resizeFrame: number | null = null;
+    const resizeMap = () => {
+      if (resizeFrame !== null) window.cancelAnimationFrame(resizeFrame);
+      resizeFrame = window.requestAnimationFrame(() => {
+        resizeFrame = null;
+        mc.getMap()?.resize();
+      });
+    };
+    const resizeObserver = new ResizeObserver(resizeMap);
+    resizeObserver.observe(containerRef.current);
+
+    return () => {
+      resizeObserver.disconnect();
+      if (resizeFrame !== null) window.cancelAnimationFrame(resizeFrame);
+      mc.destroy();
+      controller.current = null;
+      if (controllerRef) controllerRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Reconcile the shared layers onto this pane whenever they change.
+  useEffect(() => {
+    controller.current?.waitAndSyncLayers(
+      applyGroupEffects(layers, layerGroups),
+    );
+  }, [layers, layerGroups]);
+
+  // Per-pane basemap.
+  const prevBasemap = useRef(basemapStyleUrl);
+  useEffect(() => {
+    if (basemapStyleUrl === undefined) return;
+    if (prevBasemap.current !== basemapStyleUrl) {
+      prevBasemap.current = basemapStyleUrl;
+      controller.current?.setStyle(basemapStyleUrl);
+    }
+  }, [basemapStyleUrl]);
+  useEffect(() => {
+    controller.current?.setBasemapVisible(basemapVisible);
+  }, [basemapVisible]);
+  useEffect(() => {
+    controller.current?.setBasemapOpacity(basemapOpacity);
+  }, [basemapOpacity]);
+
+  // Synced: follow the global (shared) camera. Depend on primitives so an
+  // equal-valued mapView object does not re-apply.
+  useEffect(() => {
+    if (!syncView) return;
+    controller.current?.applyView(globalView);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    syncView,
+    globalView.center[0],
+    globalView.center[1],
+    globalView.zoom,
+    globalView.bearing,
+    globalView.pitch,
+  ]);
+
+  // Not synced: follow this pane's own saved camera (e.g. external edits).
+  useEffect(() => {
+    if (syncView || !entryView) return;
+    controller.current?.applyView(entryView);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    syncView,
+    entryView?.center[0],
+    entryView?.center[1],
+    entryView?.zoom,
+    entryView?.bearing,
+    entryView?.pitch,
+  ]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="h-full w-full"
+      data-testid="secondary-map-canvas"
+      data-view-id={viewId}
+    />
+  );
+});

--- a/packages/map/src/index.ts
+++ b/packages/map/src/index.ts
@@ -4,6 +4,10 @@ export {
   type MapDiagnosticEvent,
 } from "./MapCanvas";
 export {
+  SecondaryMapCanvas,
+  type SecondaryMapCanvasProps,
+} from "./SecondaryMapCanvas";
+export {
   MapController,
   createMapController,
   type BuiltInMapControl,

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -239,9 +239,22 @@ export class MapController {
       styleUrl?: string;
       mapView?: MapViewState;
       mapPreferences?: MapPreferences;
+      /**
+       * Override built-in control visibility before the controls are added.
+       * Secondary (split/grid) map panes pass `{ "layer-control": false }` so
+       * they don't mount a second layer control that would write the shared
+       * layer/basemap state back to the global store.
+       */
+      controlVisibility?: Partial<Record<BuiltInMapControl, boolean>>;
     },
   ): maplibregl.Map {
     const view = options.mapView;
+    if (options.controlVisibility) {
+      this.controlVisibility = {
+        ...this.controlVisibility,
+        ...options.controlVisibility,
+      };
+    }
     const mapPreferences = options.mapPreferences ?? this.mapPreferences;
     const minZoom = clampNumber(mapPreferences.minZoom, 0, 24);
     const maxZoom = Math.max(minZoom, clampNumber(mapPreferences.maxZoom, 0, 24));

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -340,11 +340,12 @@ describe("multi-map grid persistence", () => {
     assert.equal(project.secondaryMapViews, undefined);
   });
 
-  it("round-trips a 2x2 grid with per-pane layer visibility", () => {
+  it("round-trips a 2x2 grid with per-pane layer visibility and labels", () => {
     const secondaryMapViews = [
       {
         id: "pane-1",
         view: { center: [10, 20], zoom: 5, bearing: 0, pitch: 0 },
+        label: "2024",
         layerVisibility: { "layer-a": false, "layer-b": true },
       },
       {
@@ -368,13 +369,16 @@ describe("multi-map grid persistence", () => {
       preferences: createEmptyProject().preferences,
       mapLayout: { rows: 2, cols: 2, syncView: false },
       secondaryMapViews,
+      primaryMapLabel: "2020",
       metadata: {},
     });
     assert.deepEqual(project.mapLayout, { rows: 2, cols: 2, syncView: false });
     assert.deepEqual(project.secondaryMapViews, secondaryMapViews);
+    assert.equal(project.primaryMapLabel, "2020");
     const reparsed = parseProject(serializeProject(project));
     assert.deepEqual(reparsed.mapLayout, { rows: 2, cols: 2, syncView: false });
     assert.deepEqual(reparsed.secondaryMapViews, secondaryMapViews);
+    assert.equal(reparsed.primaryMapLabel, "2020");
   });
 
   it("reconciles surplus secondary panes down to rows * cols - 1", () => {
@@ -839,6 +843,20 @@ describe("story map import/export", () => {
       "layer-a": false,
       "layer-b": true,
     });
+  });
+
+  it("sets the primary and secondary pane labels", () => {
+    useAppStore.getState().setMapGrid(1, 2);
+    const paneId = useAppStore.getState().secondaryMapViews[0].id;
+
+    useAppStore.getState().setPrimaryMapLabel("Before");
+    useAppStore.getState().setSecondaryMapLabel(paneId, "After");
+
+    assert.equal(useAppStore.getState().primaryMapLabel, "Before");
+    assert.equal(
+      useAppStore.getState().secondaryMapViews[0].label,
+      "After",
+    );
   });
 
   it("removes a secondary pane and collapses the grid", () => {

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -324,6 +324,120 @@ describe("project parsing", () => {
   });
 });
 
+describe("multi-map grid persistence", () => {
+  it("omits the grid keys for a default single-map project", () => {
+    const project = projectFromStore({
+      projectName: "Single",
+      mapView: { center: [0, 0], zoom: 2, bearing: 0, pitch: 0 },
+      basemapStyleUrl: DEFAULT_BASEMAP,
+      basemapVisible: true,
+      basemapOpacity: 1,
+      layers: [],
+      preferences: createEmptyProject().preferences,
+      metadata: {},
+    });
+    assert.equal(project.mapLayout, undefined);
+    assert.equal(project.secondaryMapViews, undefined);
+  });
+
+  it("round-trips a 2x2 grid with per-pane basemaps", () => {
+    const secondaryMapViews = [
+      {
+        id: "pane-1",
+        view: { center: [10, 20], zoom: 5, bearing: 0, pitch: 0 },
+        basemapStyleUrl: "https://tiles.openfreemap.org/styles/dark",
+        basemapVisible: true,
+        basemapOpacity: 0.8,
+      },
+      {
+        id: "pane-2",
+        view: { center: [0, 0], zoom: 2, bearing: 0, pitch: 0 },
+        basemapStyleUrl: "https://tiles.openfreemap.org/styles/positron",
+        basemapVisible: false,
+        basemapOpacity: 1,
+      },
+      {
+        id: "pane-3",
+        view: { center: [0, 0], zoom: 2, bearing: 0, pitch: 0 },
+        basemapStyleUrl: DEFAULT_BASEMAP,
+        basemapVisible: true,
+        basemapOpacity: 1,
+      },
+    ];
+    const project = projectFromStore({
+      projectName: "Grid",
+      mapView: { center: [0, 0], zoom: 2, bearing: 0, pitch: 0 },
+      basemapStyleUrl: DEFAULT_BASEMAP,
+      basemapVisible: true,
+      basemapOpacity: 1,
+      layers: [],
+      preferences: createEmptyProject().preferences,
+      mapLayout: { rows: 2, cols: 2, syncView: false },
+      secondaryMapViews,
+      metadata: {},
+    });
+    assert.deepEqual(project.mapLayout, { rows: 2, cols: 2, syncView: false });
+    assert.deepEqual(project.secondaryMapViews, secondaryMapViews);
+    const reparsed = parseProject(serializeProject(project));
+    assert.deepEqual(reparsed.mapLayout, { rows: 2, cols: 2, syncView: false });
+    assert.deepEqual(reparsed.secondaryMapViews, secondaryMapViews);
+  });
+
+  it("reconciles surplus secondary panes down to rows * cols - 1", () => {
+    const reparsed = parseProject(
+      JSON.stringify({
+        version: "0.2.0",
+        name: "Too many",
+        mapView: { center: [0, 0], zoom: 2, bearing: 0, pitch: 0 },
+        mapLayout: { rows: 1, cols: 2, syncView: true },
+        secondaryMapViews: [
+          { id: "a", view: { center: [1, 1], zoom: 3, bearing: 0, pitch: 0 } },
+          { id: "b", view: { center: [2, 2], zoom: 4, bearing: 0, pitch: 0 } },
+          { id: "c", view: { center: [3, 3], zoom: 5, bearing: 0, pitch: 0 } },
+        ],
+      }),
+    );
+    // A 1x2 grid has exactly one secondary pane; surplus entries are dropped.
+    assert.equal(reparsed.secondaryMapViews?.length, 1);
+    assert.equal(reparsed.secondaryMapViews?.[0].id, "a");
+  });
+
+  it("fills missing secondary panes by cloning the primary map", () => {
+    const reparsed = parseProject(
+      JSON.stringify({
+        version: "0.2.0",
+        name: "Too few",
+        mapView: { center: [7, 8], zoom: 6, bearing: 0, pitch: 0 },
+        basemapStyleUrl: "https://tiles.openfreemap.org/styles/dark",
+        mapLayout: { rows: 2, cols: 2, syncView: true },
+        secondaryMapViews: [
+          { id: "a", view: { center: [1, 1], zoom: 3, bearing: 0, pitch: 0 } },
+        ],
+      }),
+    );
+    // A 2x2 grid needs three secondary panes; the two missing ones clone primary.
+    assert.equal(reparsed.secondaryMapViews?.length, 3);
+    assert.deepEqual(reparsed.secondaryMapViews?.[1].view.center, [7, 8]);
+    assert.equal(
+      reparsed.secondaryMapViews?.[1].basemapStyleUrl,
+      "https://tiles.openfreemap.org/styles/dark",
+    );
+  });
+
+  it("ignores a 1x1 grid so single-map files stay clean", () => {
+    const reparsed = parseProject(
+      JSON.stringify({
+        version: "0.2.0",
+        name: "One pane",
+        mapView: { center: [0, 0], zoom: 2, bearing: 0, pitch: 0 },
+        mapLayout: { rows: 1, cols: 1, syncView: true },
+      }),
+    );
+    assert.equal(reparsed.mapLayout, undefined);
+    assert.equal(reparsed.secondaryMapViews, undefined);
+  });
+});
+
 describe("app store", () => {
   beforeEach(() => {
     useAppStore.getState().newProject({ name: "Test Project" });
@@ -676,5 +790,71 @@ describe("story map import/export", () => {
     // Missing ids are generated.
     assert.ok(restored.chapters[0].id);
     assert.notEqual(restored.chapters[0].id, restored.chapters[1].id);
+  });
+
+  it("grows and shrinks the secondary panes when the grid resizes", () => {
+    const store = useAppStore.getState();
+    assert.equal(store.secondaryMapViews.length, 0);
+
+    store.setMapGrid(2, 2);
+    // A 2x2 grid keeps three secondary panes (pane 0 is the primary map).
+    assert.equal(useAppStore.getState().secondaryMapViews.length, 3);
+    assert.deepEqual(useAppStore.getState().mapLayout, {
+      rows: 2,
+      cols: 2,
+      syncView: true,
+    });
+
+    useAppStore.getState().setMapGrid(1, 2);
+    assert.equal(useAppStore.getState().secondaryMapViews.length, 1);
+
+    useAppStore.getState().setMapGrid(1, 1);
+    assert.equal(useAppStore.getState().secondaryMapViews.length, 0);
+  });
+
+  it("clamps grid dimensions into the supported range", () => {
+    useAppStore.getState().setMapGrid(99, 0);
+    const { mapLayout } = useAppStore.getState();
+    assert.equal(mapLayout.rows, 4);
+    assert.equal(mapLayout.cols, 1);
+  });
+
+  it("toggles synchronized views", () => {
+    useAppStore.getState().setSyncView(false);
+    assert.equal(useAppStore.getState().mapLayout.syncView, false);
+    useAppStore.getState().setSyncView(true);
+    assert.equal(useAppStore.getState().mapLayout.syncView, true);
+  });
+
+  it("patches a secondary pane's camera and basemap by id", () => {
+    useAppStore.getState().setMapGrid(1, 2);
+    const paneId = useAppStore.getState().secondaryMapViews[0].id;
+
+    useAppStore
+      .getState()
+      .setSecondaryMapView(paneId, { zoom: 9, center: [5, 6] });
+    useAppStore
+      .getState()
+      .setSecondaryBasemap(paneId, { basemapStyleUrl: "https://example/dark" });
+
+    const pane = useAppStore
+      .getState()
+      .secondaryMapViews.find((p) => p.id === paneId);
+    assert.equal(pane?.view.zoom, 9);
+    assert.deepEqual(pane?.view.center, [5, 6]);
+    assert.equal(pane?.basemapStyleUrl, "https://example/dark");
+  });
+
+  it("removes a secondary pane and collapses the grid", () => {
+    useAppStore.getState().setMapGrid(2, 2);
+    const target = useAppStore.getState().secondaryMapViews[1].id;
+
+    useAppStore.getState().removeSecondaryMapView(target);
+
+    const state = useAppStore.getState();
+    assert.equal(state.secondaryMapViews.length, 2);
+    assert.ok(!state.secondaryMapViews.some((p) => p.id === target));
+    // Three panes total now (primary + 2 secondary); the grid shrank to fit.
+    assert.equal(state.mapLayout.rows * state.mapLayout.cols, 3);
   });
 });

--- a/tests/core-project.test.ts
+++ b/tests/core-project.test.ts
@@ -340,28 +340,22 @@ describe("multi-map grid persistence", () => {
     assert.equal(project.secondaryMapViews, undefined);
   });
 
-  it("round-trips a 2x2 grid with per-pane basemaps", () => {
+  it("round-trips a 2x2 grid with per-pane layer visibility", () => {
     const secondaryMapViews = [
       {
         id: "pane-1",
         view: { center: [10, 20], zoom: 5, bearing: 0, pitch: 0 },
-        basemapStyleUrl: "https://tiles.openfreemap.org/styles/dark",
-        basemapVisible: true,
-        basemapOpacity: 0.8,
+        layerVisibility: { "layer-a": false, "layer-b": true },
       },
       {
         id: "pane-2",
         view: { center: [0, 0], zoom: 2, bearing: 0, pitch: 0 },
-        basemapStyleUrl: "https://tiles.openfreemap.org/styles/positron",
-        basemapVisible: false,
-        basemapOpacity: 1,
+        layerVisibility: { "layer-a": true },
       },
       {
         id: "pane-3",
         view: { center: [0, 0], zoom: 2, bearing: 0, pitch: 0 },
-        basemapStyleUrl: DEFAULT_BASEMAP,
-        basemapVisible: true,
-        basemapOpacity: 1,
+        layerVisibility: {},
       },
     ];
     const project = projectFromStore({
@@ -418,10 +412,8 @@ describe("multi-map grid persistence", () => {
     // A 2x2 grid needs three secondary panes; the two missing ones clone primary.
     assert.equal(reparsed.secondaryMapViews?.length, 3);
     assert.deepEqual(reparsed.secondaryMapViews?.[1].view.center, [7, 8]);
-    assert.equal(
-      reparsed.secondaryMapViews?.[1].basemapStyleUrl,
-      "https://tiles.openfreemap.org/styles/dark",
-    );
+    // Cloned panes start with no visibility overrides (they inherit the primary).
+    assert.deepEqual(reparsed.secondaryMapViews?.[1].layerVisibility, {});
   });
 
   it("ignores a 1x1 grid so single-map files stay clean", () => {
@@ -826,7 +818,7 @@ describe("story map import/export", () => {
     assert.equal(useAppStore.getState().mapLayout.syncView, true);
   });
 
-  it("patches a secondary pane's camera and basemap by id", () => {
+  it("patches a secondary pane's camera and per-layer visibility by id", () => {
     useAppStore.getState().setMapGrid(1, 2);
     const paneId = useAppStore.getState().secondaryMapViews[0].id;
 
@@ -835,14 +827,18 @@ describe("story map import/export", () => {
       .setSecondaryMapView(paneId, { zoom: 9, center: [5, 6] });
     useAppStore
       .getState()
-      .setSecondaryBasemap(paneId, { basemapStyleUrl: "https://example/dark" });
+      .setSecondaryLayerVisibility(paneId, "layer-a", false);
+    useAppStore.getState().setSecondaryLayerVisibility(paneId, "layer-b", true);
 
     const pane = useAppStore
       .getState()
       .secondaryMapViews.find((p) => p.id === paneId);
     assert.equal(pane?.view.zoom, 9);
     assert.deepEqual(pane?.view.center, [5, 6]);
-    assert.equal(pane?.basemapStyleUrl, "https://example/dark");
+    assert.deepEqual(pane?.layerVisibility, {
+      "layer-a": false,
+      "layer-b": true,
+    });
   });
 
   it("removes a secondary pane and collapses the grid", () => {


### PR DESCRIPTION
## Summary
- Add a **View -> Split View** menu with grid presets (single, 2 columns, 2 rows, 2x2, 2x3, 3x3) and a **Sync views** toggle, so users can show several map panes at once.
- Pane 0 stays the existing primary map (panels, plugins, deck.gl, identify all unchanged). Every pane shares the **same basemap and the same layers**; each secondary pane has a **layer-visibility toggle** so it can show a different subset of the shared layers (a per-layer override that defaults to inheriting the primary map's visibility).
- Camera sync is routed through the existing global view state, with a toggle to decouple panes.
- Persist the grid layout and per-pane camera/layer-visibility overrides in `.geolibre.json` via additive optional fields, so single-map projects serialize identically to before.

## Test plan
- [x] `npm run test:frontend` (1235 pass; new tests cover grid persistence round-trip, pane reconcile, and the store actions)
- [x] `pre-commit run` (eslint + full `npm build` pass)
- [x] Manual browser check: two XYZ layers loaded, 1x2 split, hiding one layer in the secondary pane shows different layers per pane while both share the basemap, synced panning moves all panes, sync-off decouples them, removing a pane collapses to a gap-free grid, and returning to Single map restores the original single-map view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added split-view/multi-map grid workspace (up to 4×4) with preset layouts and synchronized camera option.
  * Added pane management with editable pane labels, per-pane layer visibility overrides, and the ability to remove secondary panes.
  * Persisted grid layout, pane configuration, labels, and layer visibility in saved/shared projects.
* **Tests**
  * Added automated coverage for grid parsing/normalization and end-to-end persistence, including growth/shrink behavior and secondary pane removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->