### PR TITLE
feat(plugins): install external plugins from an uploaded zip (desktop + web)

### DIFF
--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -517,14 +517,31 @@ fn load_external_plugin_archive(
     let file = File::open(path).map_err(|error| format!("Could not open zip: {error}"))?;
     let mut archive =
         zip::ZipArchive::new(file).map_err(|error| format!("Could not read zip: {error}"))?;
-    let manifest_text = read_zip_text_entry(&mut archive, "plugin.json", "plugin manifest")?;
+    // Tolerate a wrapping folder (`my-plugin/plugin.json`) as produced by zipping
+    // a plugin directory, not just a root `plugin.json`. The entry/style paths
+    // then resolve against the manifest's own directory.
+    let manifest_path = find_zip_manifest_path(&archive)
+        .ok_or_else(|| "Plugin archive is missing a plugin.json".to_string())?;
+    let prefix = manifest_path
+        .strip_suffix("plugin.json")
+        .unwrap_or("")
+        .to_string();
+    let manifest_text = read_zip_text_entry(&mut archive, &manifest_path, "plugin manifest")?;
     let manifest: ExternalPluginManifest = serde_json::from_str(&manifest_text)
         .map_err(|error| format!("Could not parse plugin.json: {error}"))?;
     validate_external_plugin_manifest(&manifest)?;
 
-    let entry_source = read_zip_text_entry(&mut archive, &manifest.entry, "plugin entry")?;
+    let entry_source = read_zip_text_entry(
+        &mut archive,
+        &format!("{prefix}{}", manifest.entry),
+        "plugin entry",
+    )?;
     let style_source = match manifest.style.as_deref() {
-        Some(style) => Some(read_zip_text_entry(&mut archive, style, "plugin style")?),
+        Some(style) => Some(read_zip_text_entry(
+            &mut archive,
+            &format!("{prefix}{style}"),
+            "plugin style",
+        )?),
         None => None,
     };
 
@@ -534,6 +551,32 @@ fn load_external_plugin_archive(
         entry_source,
         style_source,
     })
+}
+
+/// Find plugin.json inside a zip, tolerating a single wrapping folder. Prefers a
+/// root `plugin.json`, otherwise returns the shallowest `*/plugin.json`, ignoring
+/// the `__MACOSX/` metadata folder macOS adds to archives. Returns the manifest's
+/// full path within the archive, or None when no plugin.json is present.
+fn find_zip_manifest_path<R: Read + std::io::Seek>(
+    archive: &zip::ZipArchive<R>,
+) -> Option<String> {
+    let names: Vec<&str> = archive.file_names().collect();
+    if names.iter().any(|name| *name == "plugin.json") {
+        return Some("plugin.json".to_string());
+    }
+    let mut best: Option<&str> = None;
+    let mut best_depth = usize::MAX;
+    for name in names {
+        if name.starts_with("__MACOSX/") || !name.ends_with("/plugin.json") {
+            continue;
+        }
+        let depth = name.matches('/').count();
+        if depth < best_depth || (depth == best_depth && best.is_none_or(|b| name < b)) {
+            best = Some(name);
+            best_depth = depth;
+        }
+    }
+    best.map(str::to_string)
 }
 
 fn load_external_plugin_directory(
@@ -2269,7 +2312,60 @@ fn configure_linux_webkit() {}
 
 #[cfg(test)]
 mod tests {
-    use super::plugin_archive_file_name;
+    use super::{find_zip_manifest_path, plugin_archive_file_name};
+    use std::io::{Cursor, Write};
+
+    fn zip_with_names(names: &[&str]) -> Vec<u8> {
+        let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+        let options =
+            zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+        for name in names {
+            writer.start_file(*name, options).unwrap();
+            writer.write_all(b"x").unwrap();
+        }
+        writer.finish().unwrap().into_inner()
+    }
+
+    fn manifest_path(names: &[&str]) -> Option<String> {
+        let bytes = zip_with_names(names);
+        let archive = zip::ZipArchive::new(Cursor::new(bytes)).unwrap();
+        find_zip_manifest_path(&archive)
+    }
+
+    #[test]
+    fn finds_root_manifest() {
+        assert_eq!(
+            manifest_path(&["plugin.json", "dist/plugin.js"]).as_deref(),
+            Some("plugin.json")
+        );
+    }
+
+    #[test]
+    fn finds_manifest_inside_a_wrapping_folder() {
+        assert_eq!(
+            manifest_path(&["my-plugin/plugin.json", "my-plugin/dist/plugin.js"]).as_deref(),
+            Some("my-plugin/plugin.json")
+        );
+    }
+
+    #[test]
+    fn prefers_root_and_ignores_macosx_metadata() {
+        // A root manifest wins over a deeper one.
+        assert_eq!(
+            manifest_path(&["wrap/plugin.json", "plugin.json"]).as_deref(),
+            Some("plugin.json")
+        );
+        // The __MACOSX folder is skipped, so the real wrapped manifest is found.
+        assert_eq!(
+            manifest_path(&["__MACOSX/wrap/._plugin.json", "wrap/plugin.json"]).as_deref(),
+            Some("wrap/plugin.json")
+        );
+    }
+
+    #[test]
+    fn returns_none_without_a_manifest() {
+        assert_eq!(manifest_path(&["dist/plugin.js"]), None);
+    }
 
     #[test]
     fn keeps_safe_plugin_ids() {

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -178,6 +178,7 @@ pub fn run() {
             close_oauth_popups,
             ensure_martin_binary,
             fetch_url_bytes,
+            install_external_plugin_archive,
             load_external_plugin_bundles,
             read_admin_profile,
             read_project_file,
@@ -275,6 +276,93 @@ fn fetch_url_bytes_blocking(url: String) -> Result<Vec<u8>, String> {
         .bytes()
         .map(|bytes| bytes.to_vec())
         .map_err(|error| format!("Could not read response body: {error}"))
+}
+
+/// Install a packaged plugin from a local `.zip` archive into GeoLibre's
+/// app-data `plugins/` directory so it persists across restarts and is picked up
+/// by the regular plugin scan. The archive is validated first (parsing
+/// `plugin.json`, enforcing the manifest rules, and confirming the entry and
+/// optional style are present and within the size limit), so only a loadable
+/// plugin lands in the plugins directory. Returns the installed plugin id.
+#[tauri::command]
+async fn install_external_plugin_archive(
+    app: tauri::AppHandle,
+    source_path: String,
+) -> Result<String, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        install_external_plugin_archive_blocking(&app, source_path)
+    })
+    .await
+    .map_err(|error| format!("Plugin install task failed: {error}"))?
+}
+
+fn install_external_plugin_archive_blocking(
+    app: &tauri::AppHandle,
+    source_path: String,
+) -> Result<String, String> {
+    let source = PathBuf::from(&source_path);
+    if !is_zip_path(&source) {
+        return Err("Plugin file must be a .zip archive".to_string());
+    }
+
+    // Validate the archive up front by loading it the same way the startup scan
+    // does; this rejects a malformed manifest, a missing/oversized entry, or an
+    // unsafe asset path before any file is written.
+    let bundle = load_external_plugin_archive(&source, &source_path)?;
+    let plugin_id = bundle.manifest.id;
+
+    let plugins_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|error| format!("Could not resolve app data directory: {error}"))?
+        .join("plugins");
+    fs::create_dir_all(&plugins_dir)
+        .map_err(|error| format!("Could not create plugins directory: {error}"))?;
+
+    let destination = plugins_dir.join(plugin_archive_file_name(&plugin_id));
+
+    // Reinstalling from a file already inside the plugins directory (e.g. the
+    // user re-selects the installed copy) would otherwise truncate the source
+    // mid-copy. Treat the no-op copy as a successful install.
+    let same_file = source
+        .canonicalize()
+        .ok()
+        .zip(destination.canonicalize().ok())
+        .map(|(from, to)| from == to)
+        .unwrap_or(false);
+    if !same_file {
+        fs::copy(&source, &destination)
+            .map_err(|error| format!("Could not install plugin archive: {error}"))?;
+    }
+
+    Ok(plugin_id)
+}
+
+/// Build a filesystem-safe `<id>.zip` name for an installed plugin archive.
+///
+/// The manifest `id` is validated for emptiness and whitespace but not for
+/// filesystem safety, so any character outside `[A-Za-z0-9._-]` is replaced with
+/// `_` and leading dots are stripped to keep the name from escaping the plugins
+/// directory or producing a hidden file. Using the id as the file name gives a
+/// reinstall natural overwrite semantics.
+fn plugin_archive_file_name(id: &str) -> String {
+    let sanitized: String = id
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric()
+                || character == '-'
+                || character == '_'
+                || character == '.'
+            {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let trimmed = sanitized.trim_start_matches('.');
+    let safe = if trimmed.is_empty() { "plugin" } else { trimmed };
+    format!("{safe}.zip")
 }
 
 #[tauri::command]
@@ -2178,3 +2266,26 @@ fn configure_linux_webkit() {
 
 #[cfg(not(target_os = "linux"))]
 fn configure_linux_webkit() {}
+
+#[cfg(test)]
+mod tests {
+    use super::plugin_archive_file_name;
+
+    #[test]
+    fn keeps_safe_plugin_ids() {
+        assert_eq!(plugin_archive_file_name("maplibre-foo"), "maplibre-foo.zip");
+        assert_eq!(plugin_archive_file_name("foo.bar_2"), "foo.bar_2.zip");
+    }
+
+    #[test]
+    fn sanitizes_unsafe_characters_and_traversal() {
+        // Path separators and other characters cannot escape the plugins dir;
+        // leading dots are then stripped, so "../evil" collapses to "_evil".
+        assert_eq!(plugin_archive_file_name("../evil"), "_evil.zip");
+        assert_eq!(plugin_archive_file_name("a/b"), "a_b.zip");
+        // Leading dots are stripped so the archive is never hidden.
+        assert_eq!(plugin_archive_file_name("..hidden"), "hidden.zip");
+        // A name that sanitizes away entirely falls back to a fixed stem.
+        assert_eq!(plugin_archive_file_name("..."), "plugin.zip");
+    }
+}

--- a/apps/geolibre-desktop/src/components/layout/ManagePluginsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ManagePluginsDialog.tsx
@@ -22,6 +22,7 @@ import {
   RefreshCw,
   Search,
   Trash2,
+  Upload,
 } from "lucide-react";
 import {
   useCallback,
@@ -32,7 +33,15 @@ import {
   type RefObject,
 } from "react";
 import { useDesktopSettingsStore } from "../../hooks/useDesktopSettings";
-import { getPluginManager, upgradeExternalPlugin } from "../../hooks/usePlugins";
+import {
+  getPluginManager,
+  installPluginArchive,
+  installPluginArchiveFromFile,
+  listPluginArchivesFromFile,
+  uninstallPluginArchiveFromFile,
+  upgradeExternalPlugin,
+} from "../../hooks/usePlugins";
+import type { InstalledWebPlugin } from "../../lib/external-plugins";
 import {
   fetchPluginRegistry,
   isNewerVersion,
@@ -40,7 +49,11 @@ import {
   type PluginRegistryEntry,
 } from "../../lib/plugin-registry";
 import { mergeStringLists } from "../../lib/string-lists";
-import { pickLocalPathWithFallback } from "../../lib/tauri-io";
+import {
+  isTauri,
+  openLocalDataFileWithFallback,
+  pickLocalPathWithFallback,
+} from "../../lib/tauri-io";
 import { openExternalLink } from "../../lib/open-external";
 
 type ManageSection =
@@ -98,6 +111,27 @@ export function ManagePluginsDialog({
   const [newDirectory, setNewDirectory] = useState("");
   const [newManifestUrl, setNewManifestUrl] = useState("");
   const [settingsError, setSettingsError] = useState<string | null>(null);
+  const [installing, setInstalling] = useState(false);
+  const [installError, setInstallError] = useState<string | null>(null);
+  const [installNotice, setInstallNotice] = useState<string | null>(null);
+  const [webPlugins, setWebPlugins] = useState<InstalledWebPlugin[]>([]);
+
+  // Plugins installed from a file on the web build live in IndexedDB, so the
+  // dialog tracks them separately from the registry-driven list. Desktop file
+  // installs persist on disk and are not listed here.
+  const refreshWebPlugins = useCallback(async () => {
+    if (isTauri()) return;
+    try {
+      setWebPlugins(await listPluginArchivesFromFile());
+    } catch {
+      setWebPlugins([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    void refreshWebPlugins();
+  }, [open, refreshWebPlugins]);
 
   useEffect(() => {
     if (!open) return;
@@ -105,6 +139,8 @@ export function ManagePluginsDialog({
     const abortController = new AbortController();
     setRegistry({ status: "loading" });
     setConfirmRemoveId(null);
+    setInstallError(null);
+    setInstallNotice(null);
     // Don't reset busyId here: an in-flight upgrade's finally block owns it.
     // Clearing it on Refresh would re-enable the Update button mid-flight and
     // could start a second concurrent upgrade for the same manifest URL.
@@ -283,6 +319,65 @@ export function ManagePluginsDialog({
     }
   }, [addDirectory]);
 
+  const installFromFile = useCallback(async () => {
+    setInstallError(null);
+    setInstallNotice(null);
+    try {
+      if (isTauri()) {
+        // Desktop: pick a path and let the backend validate and copy the zip
+        // into the app-data plugins directory (persisted via the startup scan).
+        const path = await pickLocalPathWithFallback({
+          filters: [{ name: "GeoLibre plugin", extensions: ["zip"] }],
+        });
+        if (!path) return;
+        setInstalling(true);
+        const id = await installPluginArchive(path, mapControllerRef);
+        setInstallNotice(`Installed plugin "${id}".`);
+      } else {
+        // Web: read the uploaded bytes, unpack and register client-side, and
+        // persist the bundle in IndexedDB so it reloads on the next visit.
+        const picked = await openLocalDataFileWithFallback({
+          accept: ".zip",
+          filters: [{ name: "GeoLibre plugin", extensions: ["zip"] }],
+          readBinary: true,
+        });
+        if (!picked?.data) return;
+        setInstalling(true);
+        const id = await installPluginArchiveFromFile(
+          picked.path,
+          new Uint8Array(picked.data),
+          mapControllerRef,
+        );
+        setInstallNotice(`Installed plugin "${id}".`);
+        await refreshWebPlugins();
+      }
+    } catch (error) {
+      setInstallError(
+        error instanceof Error ? error.message : "Could not install the plugin.",
+      );
+    } finally {
+      setInstalling(false);
+    }
+  }, [mapControllerRef, refreshWebPlugins]);
+
+  const removeWebPlugin = useCallback(
+    async (id: string) => {
+      setInstallError(null);
+      setInstallNotice(null);
+      try {
+        await uninstallPluginArchiveFromFile(id, mapControllerRef);
+        await refreshWebPlugins();
+      } catch (error) {
+        setInstallError(
+          error instanceof Error
+            ? error.message
+            : "Could not uninstall the plugin.",
+        );
+      }
+    },
+    [mapControllerRef, refreshWebPlugins],
+  );
+
   const addManifestUrl = useCallback(() => {
     const trimmed = newManifestUrl.trim();
     if (!trimmed) return;
@@ -395,6 +490,12 @@ export function ManagePluginsDialog({
                 newDirectory={newDirectory}
                 newManifestUrl={newManifestUrl}
                 error={settingsError}
+                installing={installing}
+                installError={installError}
+                installNotice={installNotice}
+                installedFromFile={webPlugins}
+                onInstallFromFile={() => void installFromFile()}
+                onUninstallFromFile={(id) => void removeWebPlugin(id)}
                 onNewDirectoryChange={setNewDirectory}
                 onNewManifestUrlChange={(value) => {
                   setNewManifestUrl(value);
@@ -649,6 +750,12 @@ interface SettingsTabProps {
   newDirectory: string;
   newManifestUrl: string;
   error: string | null;
+  installing: boolean;
+  installError: string | null;
+  installNotice: string | null;
+  installedFromFile: InstalledWebPlugin[];
+  onInstallFromFile: () => void;
+  onUninstallFromFile: (id: string) => void;
   onNewDirectoryChange: (value: string) => void;
   onNewManifestUrlChange: (value: string) => void;
   onAddDirectory: () => void;
@@ -664,6 +771,12 @@ function SettingsTab({
   newDirectory,
   newManifestUrl,
   error,
+  installing,
+  installError,
+  installNotice,
+  installedFromFile,
+  onInstallFromFile,
+  onUninstallFromFile,
   onNewDirectoryChange,
   onNewManifestUrlChange,
   onAddDirectory,
@@ -675,9 +788,80 @@ function SettingsTab({
   return (
     <div className="space-y-5">
       <div className="rounded-md border bg-muted/40 p-3 text-xs text-muted-foreground">
-        GeoLibre always scans its app data plugins directory. Additional local
-        directories are desktop-only. Manifest URLs (including marketplace
-        installs) are loaded over the network; changes here apply immediately.
+        GeoLibre always scans its app data plugins directory. Install a packaged
+        plugin (.zip) from a file, or add additional local directories
+        (desktop-only). Manifest URLs (including marketplace installs) are loaded
+        over the network; changes here apply immediately.
+      </div>
+
+      <div className="space-y-3">
+        <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Install from file
+        </h4>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="shrink-0"
+            disabled={installing}
+            onClick={onInstallFromFile}
+          >
+            {installing ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Upload className="h-3.5 w-3.5" />
+            )}
+            Choose .zip…
+          </Button>
+          <p className="text-xs text-muted-foreground">
+            {isTauri()
+              ? "Copy a packaged plugin archive into GeoLibre's plugins directory."
+              : "Load a packaged plugin archive; it is stored in your browser and reloads on your next visit."}
+          </p>
+        </div>
+        {installError ? (
+          <p className="text-xs text-destructive">{installError}</p>
+        ) : null}
+        {installNotice ? (
+          <p className="text-xs text-emerald-600 dark:text-emerald-400">
+            {installNotice}
+          </p>
+        ) : null}
+        {installedFromFile.length > 0 ? (
+          <div className="space-y-2">
+            {installedFromFile.map((plugin) => (
+              <div
+                key={plugin.id}
+                className="flex items-center gap-2 rounded-md border p-2"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate text-xs font-medium">
+                      {plugin.name}
+                    </span>
+                    <span className="shrink-0 text-[11px] text-muted-foreground">
+                      v{plugin.version}
+                    </span>
+                  </div>
+                  <span className="truncate text-[11px] text-muted-foreground">
+                    {plugin.archiveName}
+                  </span>
+                </div>
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="ghost"
+                  className="h-8 w-8 shrink-0"
+                  aria-label={`Uninstall ${plugin.name}`}
+                  onClick={() => onUninstallFromFile(plugin.id)}
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            ))}
+          </div>
+        ) : null}
       </div>
 
       <div className="space-y-3">

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -42,10 +42,15 @@ import type { RefObject } from "react";
 import { useEffect, useSyncExternalStore } from "react";
 import { bundledPluginManifestPaths } from "virtual:bundled-plugins";
 import {
+  installWebPluginArchive,
+  listInstalledWebPlugins,
   loadExternalPlugins,
   reloadExternalUrlPlugin,
   resolvePluginAssetUrlForLoadedPlugin,
+  uninstallWebPlugin,
+  unloadFilesystemPlugin,
   unloadRemovedUrlPlugins,
+  type InstalledWebPlugin,
 } from "../lib/external-plugins";
 import { appendDiagnostic } from "../lib/diagnostics";
 import { mergeStringLists } from "../lib/string-lists";
@@ -181,6 +186,72 @@ export async function upgradeExternalPlugin(
     manifestUrl,
     createAppAPI(mapControllerRef),
   );
+}
+
+// Install a plugin from a local `.zip` archive (desktop only). The Rust backend
+// validates the archive and copies it into GeoLibre's app-data plugins
+// directory so it persists across restarts; the plugins directory is then
+// re-scanned so the new plugin loads without a reload. A reinstall of an
+// already-loaded plugin id is unloaded first so the updated archive replaces it
+// instead of being skipped by the loaded-source dedup. Returns the installed
+// plugin id.
+export async function installPluginArchive(
+  sourcePath: string,
+  mapControllerRef: RefObject<MapController | null>,
+): Promise<string> {
+  if (!isTauriRuntime()) {
+    throw new Error("Installing plugin archives requires the desktop app.");
+  }
+  const pluginId = await invoke<string>("install_external_plugin_archive", {
+    sourcePath,
+  });
+  const app = createAppAPI(mapControllerRef);
+  // The archive was overwritten in place for a reinstall; drop the loaded copy
+  // so the forced re-scan re-registers the updated version under the same id.
+  unloadFilesystemPlugin(manager, pluginId, app);
+  const desktopSettings = useDesktopSettingsStore.getState().desktopSettings;
+  const projectManifestUrls =
+    useAppStore.getState().projectPlugins?.manifestUrls ??
+    EMPTY_PLUGIN_MANIFEST_URLS;
+  await ensureExternalPluginsLoadedWithSettings(
+    desktopSettings,
+    projectManifestUrls,
+    app,
+    { force: true },
+  );
+  return pluginId;
+}
+
+// Install a plugin from an uploaded `.zip` in the browser (web build). The
+// archive is unpacked and validated client-side, registered immediately, and
+// persisted in IndexedDB so it reloads on the next visit. On desktop, use
+// installPluginArchive instead (it copies the zip onto disk via the backend).
+// Returns the installed plugin id.
+export async function installPluginArchiveFromFile(
+  fileName: string,
+  bytes: Uint8Array,
+  mapControllerRef: RefObject<MapController | null>,
+): Promise<string> {
+  return installWebPluginArchive(
+    manager,
+    fileName,
+    bytes,
+    createAppAPI(mapControllerRef),
+  );
+}
+
+// Uninstall a plugin that was installed from a file in the browser.
+export async function uninstallPluginArchiveFromFile(
+  pluginId: string,
+  mapControllerRef: RefObject<MapController | null>,
+): Promise<void> {
+  await uninstallWebPlugin(manager, pluginId, createAppAPI(mapControllerRef));
+}
+
+// List plugins installed from a file (browser IndexedDB), for the Manage
+// Plugins UI. Returns an empty list on desktop and where IndexedDB is absent.
+export function listPluginArchivesFromFile(): Promise<InstalledWebPlugin[]> {
+  return listInstalledWebPlugins();
 }
 
 export function usePluginRegistry() {
@@ -325,6 +396,7 @@ function ensureExternalPluginsLoadedWithSettings(
   >["desktopSettings"],
   projectPluginManifestUrls: string[],
   app: ReturnType<typeof createAppAPI>,
+  options?: { force?: boolean },
 ): Promise<void> {
   const pluginManifestUrls = mergeStringLists(
     bundledPluginManifestUrls(),
@@ -335,10 +407,18 @@ function ensureExternalPluginsLoadedWithSettings(
     additionalPluginDirectories: desktopSettings.additionalPluginDirectories,
     pluginManifestUrls,
   });
-  if (externalPluginsLoaded && externalPluginsLoadKey === loadKey) {
+  // `force` re-scans even when the merged settings are unchanged. Installing a
+  // zip writes a new archive into the app-data plugins directory without
+  // touching the settings that make up loadKey, so the cache-key short-circuits
+  // below would otherwise skip loading the freshly installed plugin.
+  if (!options?.force && externalPluginsLoaded && externalPluginsLoadKey === loadKey) {
     return Promise.resolve();
   }
-  if (externalPluginsLoadPromise && externalPluginsLoadKey === loadKey) {
+  if (
+    !options?.force &&
+    externalPluginsLoadPromise &&
+    externalPluginsLoadKey === loadKey
+  ) {
     return externalPluginsLoadPromise;
   }
 
@@ -389,7 +469,12 @@ function ensureExternalPluginsLoadedWithSettings(
       // A settings change can start a new load while this one is in flight.
       // Only the load that still owns the current key may mark plugins ready.
       if (externalPluginsLoadKey !== loadKey) return;
-      externalPluginsLoadPromise = null;
+      // A forced re-scan (install) chains a second load onto this one under the
+      // SAME key, so guard the clear by identity: only null the slot when it
+      // still points at this promise, never at the newer in-flight load.
+      if (externalPluginsLoadPromise === loadPromise) {
+        externalPluginsLoadPromise = null;
+      }
       setExternalPluginsLoaded(true);
     });
 

--- a/apps/geolibre-desktop/src/lib/external-plugins.ts
+++ b/apps/geolibre-desktop/src/lib/external-plugins.ts
@@ -6,18 +6,23 @@ import type {
 } from "@geolibre/plugins";
 import { invoke } from "@tauri-apps/api/core";
 import {
+  deletePluginArchive,
+  getAllPluginArchives,
+  putPluginArchive,
+  type StoredPluginArchive,
+} from "./plugin-archive-store";
+import {
+  bundleFromZipBytes,
+  type ExternalPluginBundle,
+  isExternalPluginManifest,
+  MAX_PLUGIN_ASSET_BYTES,
+} from "./plugin-archive-unpack";
+import {
   isManagedUrlSource,
   pluginAssetUrlFromSource,
   resolvePluginAssetUrl,
 } from "./plugin-asset-url";
 import { isTauri } from "./tauri-io";
-
-interface ExternalPluginBundle {
-  archiveName: string;
-  manifest: GeoLibreExternalPluginManifest;
-  entrySource: string;
-  styleSource?: string | null;
-}
 
 interface ExternalPluginBundleError {
   archiveName: string;
@@ -63,9 +68,12 @@ export async function loadExternalPlugins(
   pluginManifestUrls: string[] = [],
 ): Promise<ExternalPluginLoadResult> {
   const issues: ExternalPluginLoadIssue[] = [];
-  // The filesystem scan (Tauri IPC + disk) and the manifest URL fetches
-  // (network) are independent, so overlap them.
-  const [filesystemResult, urlBundles] = await Promise.all([
+  // The filesystem scan (Tauri IPC + disk), the manifest URL fetches (network),
+  // and the IndexedDB read (web-installed archives) are independent, so overlap
+  // them. Web-installed archives are the browser counterpart of the desktop
+  // filesystem scan: the desktop build copies an installed zip onto disk and
+  // re-scans it, while the web build replays the unpacked bundle stored here.
+  const [filesystemResult, urlBundles, webBundles] = await Promise.all([
     isTauri()
       ? loadFilesystemPluginBundles(additionalPluginDirectories)
       : Promise.resolve<ExternalPluginBundleLoadResult>({
@@ -74,6 +82,7 @@ export async function loadExternalPlugins(
           errors: [],
         }),
     loadPluginUrlBundles(pluginManifestUrls, issues),
+    loadWebInstalledPluginBundles(),
   ]);
   for (const error of filesystemResult.errors) {
     issues.push({
@@ -86,7 +95,11 @@ export async function loadExternalPlugins(
     manager.list().map((plugin) => plugin.id),
   );
 
-  for (const bundle of [...filesystemResult.bundles, ...urlBundles]) {
+  for (const bundle of [
+    ...filesystemResult.bundles,
+    ...urlBundles,
+    ...webBundles,
+  ]) {
     try {
       const loadedFrom = externallyLoadedPluginSources.get(bundle.manifest.id);
       if (loadedFrom !== undefined) {
@@ -212,10 +225,6 @@ async function loadPluginUrlBundle(
   };
 }
 
-// Mirrors MAX_PLUGIN_ENTRY_BYTES in the Rust filesystem loader so URL-loaded
-// plugin assets cannot buffer an unbounded response into memory.
-const MAX_PLUGIN_ASSET_BYTES = 50 * 1024 * 1024;
-
 async function fetchPluginText(
   url: string,
   label: string,
@@ -266,32 +275,6 @@ async function fetchPluginText(
     offset += chunk.byteLength;
   }
   return new TextDecoder().decode(merged);
-}
-
-// Matches the Rust validate_required_manifest_string: non-empty with no
-// leading or trailing whitespace.
-function isRequiredManifestString(value: unknown): value is string {
-  return (
-    typeof value === "string" && value.length > 0 && value.trim() === value
-  );
-}
-
-function isExternalPluginManifest(
-  value: unknown,
-): value is GeoLibreExternalPluginManifest {
-  if (!value || typeof value !== "object") return false;
-  const manifest = value as Partial<GeoLibreExternalPluginManifest>;
-  return (
-    isRequiredManifestString(manifest.id) &&
-    isRequiredManifestString(manifest.name) &&
-    isRequiredManifestString(manifest.version) &&
-    isRequiredManifestString(manifest.entry) &&
-    (manifest.entry.endsWith(".js") || manifest.entry.endsWith(".mjs")) &&
-    (manifest.description === undefined ||
-      typeof manifest.description === "string") &&
-    (manifest.style === undefined ||
-      (typeof manifest.style === "string" && manifest.style.endsWith(".css")))
-  );
 }
 
 async function importExternalPlugin(
@@ -369,6 +352,140 @@ function removeExternalPluginStyle(pluginId: string): void {
     ?.remove();
 }
 
+// ---------------------------------------------------------------------------
+// Web "install from file": unpack an uploaded .zip in the browser, register the
+// plugin, and persist the unpacked bundle in IndexedDB so it reloads on the next
+// visit. This is the web counterpart of the desktop Tauri install command, which
+// copies the zip onto disk for the startup filesystem scan instead.
+// ---------------------------------------------------------------------------
+
+export interface InstalledWebPlugin {
+  id: string;
+  name: string;
+  version: string;
+  archiveName: string;
+}
+
+// Synthetic source recorded in externallyLoadedPluginSources for an
+// IndexedDB-installed plugin. It is intentionally not an http(s)/tauri URL so
+// unloadRemovedUrlPlugins (which only touches managed URL sources) leaves it
+// alone, and it is stable per id so a re-scan dedupes the same plugin.
+function webPluginSource(pluginId: string): string {
+  return `indexeddb:${pluginId}`;
+}
+
+async function loadWebInstalledPluginBundles(): Promise<ExternalPluginBundle[]> {
+  let records: StoredPluginArchive[];
+  try {
+    records = await getAllPluginArchives();
+  } catch {
+    // IndexedDB unavailable (private mode, blocked storage); the scan continues
+    // with the other sources rather than failing entirely.
+    return [];
+  }
+  return records.map((record) => ({
+    archiveName: webPluginSource(record.id),
+    manifest: record.manifest,
+    entrySource: record.entrySource,
+    styleSource: record.styleSource,
+  }));
+}
+
+/**
+ * Install a plugin from an uploaded `.zip` in the browser: validate it, persist
+ * the unpacked bundle in IndexedDB, and register it immediately (no re-scan).
+ * Reinstalling the same id overwrites the stored copy and reloads the plugin,
+ * preserving its active state. A collision with a built-in or otherwise already
+ * registered plugin id is rejected. Returns the installed plugin id.
+ */
+export async function installWebPluginArchive(
+  manager: PluginManager,
+  fileName: string,
+  bytes: Uint8Array,
+  app: GeoLibreAppAPI,
+): Promise<string> {
+  const bundle = await bundleFromZipBytes(fileName, bytes);
+  // importExternalPlugin validates the exported plugin, that it matches the
+  // manifest id/name/version, and rejects activeByDefault.
+  const plugin = await importExternalPlugin(bundle);
+
+  const existingSource = externallyLoadedPluginSources.get(plugin.id);
+  if (existingSource === undefined) {
+    // No record of loading this id from any external source; a clash with a
+    // built-in (or a not-yet-tracked plugin) must not be silently overwritten.
+    if (manager.list().some((registered) => registered.id === plugin.id)) {
+      throw new Error(`Plugin id '${plugin.id}' is already registered.`);
+    }
+  }
+
+  await putPluginArchive({
+    id: plugin.id,
+    archiveName: fileName,
+    manifest: bundle.manifest,
+    entrySource: bundle.entrySource,
+    styleSource: bundle.styleSource ?? null,
+    installedAt: pluginInstallTimestamp(),
+  });
+
+  const wasActive =
+    existingSource !== undefined && manager.isActive(plugin.id);
+  if (existingSource !== undefined) {
+    manager.unregister(plugin.id, app);
+    removeExternalPluginStyle(plugin.id);
+    externallyLoadedPluginSources.delete(plugin.id);
+  }
+
+  manager.register(plugin);
+  externallyLoadedPluginSources.set(plugin.id, webPluginSource(plugin.id));
+  if (bundle.styleSource) {
+    injectExternalPluginStyle(plugin.id, bundle.styleSource);
+  }
+  if (wasActive) manager.activate(plugin.id, app);
+
+  return plugin.id;
+}
+
+/**
+ * Uninstall a web-installed plugin: remove it from IndexedDB, unregister it
+ * (tearing down any map control), and drop its injected style. A no-op for ids
+ * that were not installed from a file.
+ */
+export async function uninstallWebPlugin(
+  manager: PluginManager,
+  pluginId: string,
+  app: GeoLibreAppAPI,
+): Promise<void> {
+  await deletePluginArchive(pluginId);
+  const source = externallyLoadedPluginSources.get(pluginId);
+  if (source === webPluginSource(pluginId)) {
+    manager.unregister(pluginId, app);
+    removeExternalPluginStyle(pluginId);
+    externallyLoadedPluginSources.delete(pluginId);
+  }
+}
+
+/** List plugins installed from a file (for the Manage Plugins UI). */
+export async function listInstalledWebPlugins(): Promise<InstalledWebPlugin[]> {
+  let records: StoredPluginArchive[];
+  try {
+    records = await getAllPluginArchives();
+  } catch {
+    return [];
+  }
+  return records.map((record) => ({
+    id: record.id,
+    name: record.manifest.name,
+    version: record.manifest.version,
+    archiveName: record.archiveName,
+  }));
+}
+
+// new Date()/Date.now() are awkward to stub in tests; isolate the one timestamp
+// read so the install flow stays deterministic if a test needs to override it.
+function pluginInstallTimestamp(): number {
+  return Date.now();
+}
+
 /**
  * Resolve a fetchable URL for an asset shipped alongside a loaded plugin's
  * manifest (e.g. sample data bundled in the plugin folder). The plugin's
@@ -416,6 +533,29 @@ export function unloadRemovedUrlPlugins(
     externallyLoadedPluginSources.delete(pluginId);
   }
   return toRemove;
+}
+
+/**
+ * Forget a plugin previously loaded from the desktop filesystem so the next scan
+ * re-registers it from its (possibly updated) archive. Used when a plugin is
+ * reinstalled from a zip: the archive is overwritten in place under the same id,
+ * so without dropping the loaded-source record the re-scan would treat the id as
+ * already loaded and skip it. Managed URL and bundled plugins are left untouched
+ * (their lifecycle runs through unloadRemovedUrlPlugins / reloadExternalUrlPlugin).
+ * Deactivates the plugin (removing any map control) and drops its injected style.
+ * Returns true when a filesystem plugin was unloaded.
+ */
+export function unloadFilesystemPlugin(
+  manager: PluginManager,
+  pluginId: string,
+  app: GeoLibreAppAPI,
+): boolean {
+  const source = externallyLoadedPluginSources.get(pluginId);
+  if (source === undefined || isManagedUrlSource(source)) return false;
+  manager.unregister(pluginId, app);
+  removeExternalPluginStyle(pluginId);
+  externallyLoadedPluginSources.delete(pluginId);
+  return true;
 }
 
 /**

--- a/apps/geolibre-desktop/src/lib/plugin-archive-store.ts
+++ b/apps/geolibre-desktop/src/lib/plugin-archive-store.ts
@@ -1,0 +1,100 @@
+// IndexedDB persistence for plugins installed from an uploaded `.zip` on the web
+// build. The desktop build persists installed archives on disk (the Rust loader
+// re-scans the app-data `plugins/` directory at startup); the browser has no
+// such directory, so the unpacked bundle is stored here and replayed on load by
+// the external-plugin loader. Kept free of other imports so it stays a thin,
+// self-contained wrapper around IndexedDB.
+
+import type { GeoLibreExternalPluginManifest } from "@geolibre/plugins";
+
+export interface StoredPluginArchive {
+  // The plugin id, used as the IndexedDB key so a reinstall overwrites the
+  // previous copy rather than accumulating duplicates.
+  id: string;
+  // The original uploaded file name, kept only for display in the UI.
+  archiveName: string;
+  manifest: GeoLibreExternalPluginManifest;
+  entrySource: string;
+  styleSource: string | null;
+  installedAt: number;
+}
+
+const DB_NAME = "geolibre-plugins";
+const DB_VERSION = 1;
+const STORE_NAME = "archives";
+
+function pluginArchiveStorageAvailable(): boolean {
+  return typeof indexedDB !== "undefined";
+}
+
+function openDatabase(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: "id" });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () =>
+      reject(request.error ?? new Error("Could not open the plugin database."));
+  });
+}
+
+function promisifyRequest<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () =>
+      reject(request.error ?? new Error("Plugin database request failed."));
+  });
+}
+
+/** Persist (or overwrite) an installed plugin archive. */
+export async function putPluginArchive(
+  record: StoredPluginArchive,
+): Promise<void> {
+  if (!pluginArchiveStorageAvailable()) {
+    throw new Error("Installing plugins from a file is not supported here.");
+  }
+  const db = await openDatabase();
+  try {
+    const transaction = db.transaction(STORE_NAME, "readwrite");
+    const done = promisifyRequest(transaction.objectStore(STORE_NAME).put(record));
+    await done;
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Read every persisted plugin archive. Returns an empty list when IndexedDB is
+ * unavailable (e.g. a private-browsing context or a non-browser environment) so
+ * the plugin loader degrades gracefully instead of failing the whole scan.
+ */
+export async function getAllPluginArchives(): Promise<StoredPluginArchive[]> {
+  if (!pluginArchiveStorageAvailable()) return [];
+  const db = await openDatabase();
+  try {
+    const transaction = db.transaction(STORE_NAME, "readonly");
+    return await promisifyRequest(
+      transaction.objectStore(STORE_NAME).getAll() as IDBRequest<
+        StoredPluginArchive[]
+      >,
+    );
+  } finally {
+    db.close();
+  }
+}
+
+/** Remove a persisted plugin archive by id. */
+export async function deletePluginArchive(id: string): Promise<void> {
+  if (!pluginArchiveStorageAvailable()) return;
+  const db = await openDatabase();
+  try {
+    const transaction = db.transaction(STORE_NAME, "readwrite");
+    await promisifyRequest(transaction.objectStore(STORE_NAME).delete(id));
+  } finally {
+    db.close();
+  }
+}

--- a/apps/geolibre-desktop/src/lib/plugin-archive-unpack.ts
+++ b/apps/geolibre-desktop/src/lib/plugin-archive-unpack.ts
@@ -1,0 +1,127 @@
+// Pure, browser/Node-safe helpers for turning a plugin `.zip` into a validated
+// bundle. Kept free of Tauri and DOM imports so it stays unit-testable and can
+// be shared by the URL loader (manifest validation) and the web "install from
+// file" flow (in-browser unzip). The heavier external-plugin loader re-exports
+// what it needs from here.
+
+import type { GeoLibreExternalPluginManifest } from "@geolibre/plugins";
+import { unzip } from "fflate";
+
+export interface ExternalPluginBundle {
+  archiveName: string;
+  manifest: GeoLibreExternalPluginManifest;
+  entrySource: string;
+  styleSource?: string | null;
+}
+
+// Mirrors MAX_PLUGIN_ENTRY_BYTES in the Rust filesystem loader so plugin assets
+// (whether fetched, read from disk, or unzipped in the browser) cannot buffer an
+// unbounded amount of data into memory.
+export const MAX_PLUGIN_ASSET_BYTES = 50 * 1024 * 1024;
+
+// Matches the Rust validate_required_manifest_string: non-empty with no leading
+// or trailing whitespace.
+function isRequiredManifestString(value: unknown): value is string {
+  return (
+    typeof value === "string" && value.length > 0 && value.trim() === value
+  );
+}
+
+export function isExternalPluginManifest(
+  value: unknown,
+): value is GeoLibreExternalPluginManifest {
+  if (!value || typeof value !== "object") return false;
+  const manifest = value as Partial<GeoLibreExternalPluginManifest>;
+  return (
+    isRequiredManifestString(manifest.id) &&
+    isRequiredManifestString(manifest.name) &&
+    isRequiredManifestString(manifest.version) &&
+    isRequiredManifestString(manifest.entry) &&
+    (manifest.entry.endsWith(".js") || manifest.entry.endsWith(".mjs")) &&
+    (manifest.description === undefined ||
+      typeof manifest.description === "string") &&
+    (manifest.style === undefined ||
+      (typeof manifest.style === "string" && manifest.style.endsWith(".css")))
+  );
+}
+
+function unzipToRecord(bytes: Uint8Array): Promise<Record<string, Uint8Array>> {
+  return new Promise((resolve, reject) => {
+    unzip(bytes, (error, files) => {
+      if (error) reject(error);
+      else resolve(files);
+    });
+  });
+}
+
+// Decode a zip entry to text, enforcing the 50 MB cap so a malicious archive
+// cannot exhaust memory.
+function decodePluginText(bytes: Uint8Array, label: string): string {
+  if (bytes.byteLength > MAX_PLUGIN_ASSET_BYTES) {
+    throw new Error(`Could not read ${label}: exceeds the 50 MB size limit.`);
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+// Mirror the Rust validate_external_plugin_path rules so a manifest entry/style
+// path cannot reference anything outside the archive's own files.
+function assertSafeArchivePath(field: string, value: string): void {
+  if (
+    value.startsWith("/") ||
+    value.includes("\\") ||
+    value.includes(":") ||
+    value.split("/").some((part) => !part || part === "." || part === "..")
+  ) {
+    throw new Error(`Plugin manifest ${field} must be a relative safe path.`);
+  }
+}
+
+/**
+ * Unzip an uploaded plugin archive in the browser and validate it into an
+ * ExternalPluginBundle: reads the root plugin.json, enforces the manifest rules
+ * and safe relative paths, and pulls the entry (and optional style) out of the
+ * archive. Does NOT execute the entry; the caller imports and registers it.
+ */
+export async function bundleFromZipBytes(
+  archiveName: string,
+  bytes: Uint8Array,
+): Promise<ExternalPluginBundle> {
+  const files = await unzipToRecord(bytes);
+  const manifestBytes = files["plugin.json"];
+  if (!manifestBytes) {
+    throw new Error("Plugin archive is missing a root plugin.json.");
+  }
+
+  let manifest: unknown;
+  try {
+    manifest = JSON.parse(decodePluginText(manifestBytes, "plugin manifest"));
+  } catch {
+    throw new Error("Could not parse plugin.json.");
+  }
+  if (!isExternalPluginManifest(manifest)) {
+    throw new Error("Plugin manifest is invalid.");
+  }
+
+  assertSafeArchivePath("entry", manifest.entry);
+  const entryBytes = files[manifest.entry];
+  if (!entryBytes) {
+    throw new Error(
+      `Plugin entry '${manifest.entry}' is missing from the archive.`,
+    );
+  }
+  const entrySource = decodePluginText(entryBytes, "plugin entry");
+
+  let styleSource: string | null = null;
+  if (manifest.style) {
+    assertSafeArchivePath("style", manifest.style);
+    const styleBytes = files[manifest.style];
+    if (!styleBytes) {
+      throw new Error(
+        `Plugin style '${manifest.style}' is missing from the archive.`,
+      );
+    }
+    styleSource = decodePluginText(styleBytes, "plugin style");
+  }
+
+  return { archiveName, manifest, entrySource, styleSource };
+}

--- a/apps/geolibre-desktop/src/lib/plugin-archive-unpack.ts
+++ b/apps/geolibre-desktop/src/lib/plugin-archive-unpack.ts
@@ -76,25 +76,53 @@ function assertSafeArchivePath(field: string, value: string): void {
   }
 }
 
+// Locate plugin.json inside the archive, tolerating a wrapping folder: zipping a
+// plugin directory commonly yields `my-plugin/plugin.json` rather than a root
+// `plugin.json`. Prefer a root manifest, otherwise pick the shallowest
+// `*/plugin.json`, ignoring the `__MACOSX/` metadata folder macOS adds. Returns
+// the manifest's full key, or null when no plugin.json is present. The entry and
+// style paths in the manifest resolve against the manifest's own directory.
+function findManifestPath(
+  files: Record<string, Uint8Array>,
+): string | null {
+  if (files["plugin.json"]) return "plugin.json";
+  let best: string | null = null;
+  let bestDepth = Number.POSITIVE_INFINITY;
+  for (const key of Object.keys(files)) {
+    if (key.startsWith("__MACOSX/")) continue;
+    if (!key.endsWith("/plugin.json")) continue;
+    const depth = key.split("/").length;
+    if (depth < bestDepth || (depth === bestDepth && (best === null || key < best))) {
+      best = key;
+      bestDepth = depth;
+    }
+  }
+  return best;
+}
+
 /**
  * Unzip an uploaded plugin archive in the browser and validate it into an
- * ExternalPluginBundle: reads the root plugin.json, enforces the manifest rules
- * and safe relative paths, and pulls the entry (and optional style) out of the
- * archive. Does NOT execute the entry; the caller imports and registers it.
+ * ExternalPluginBundle: locates plugin.json (at the root or inside a single
+ * wrapping folder), enforces the manifest rules and safe relative paths, and
+ * pulls the entry (and optional style) out of the archive relative to the
+ * manifest's directory. Does NOT execute the entry; the caller imports it.
  */
 export async function bundleFromZipBytes(
   archiveName: string,
   bytes: Uint8Array,
 ): Promise<ExternalPluginBundle> {
   const files = await unzipToRecord(bytes);
-  const manifestBytes = files["plugin.json"];
-  if (!manifestBytes) {
-    throw new Error("Plugin archive is missing a root plugin.json.");
+  const manifestPath = findManifestPath(files);
+  if (!manifestPath) {
+    throw new Error("Plugin archive is missing a plugin.json.");
   }
+  // The directory that contains plugin.json ("" at the root, or "my-plugin/"
+  // for a wrapped archive); entry/style resolve against it.
+  const prefix = manifestPath.slice(0, manifestPath.length - "plugin.json".length);
 
   let manifest: unknown;
   try {
-    manifest = JSON.parse(decodePluginText(manifestBytes, "plugin manifest"));
+    manifest = JSON.parse(decodePluginText(files[manifestPath], "plugin manifest"));
   } catch {
     throw new Error("Could not parse plugin.json.");
   }
@@ -103,7 +131,7 @@ export async function bundleFromZipBytes(
   }
 
   assertSafeArchivePath("entry", manifest.entry);
-  const entryBytes = files[manifest.entry];
+  const entryBytes = files[prefix + manifest.entry];
   if (!entryBytes) {
     throw new Error(
       `Plugin entry '${manifest.entry}' is missing from the archive.`,
@@ -114,7 +142,7 @@ export async function bundleFromZipBytes(
   let styleSource: string | null = null;
   if (manifest.style) {
     assertSafeArchivePath("style", manifest.style);
-    const styleBytes = files[manifest.style];
+    const styleBytes = files[prefix + manifest.style];
     if (!styleBytes) {
       throw new Error(
         `Plugin style '${manifest.style}' is missing from the archive.`,

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -193,9 +193,14 @@ GeoLibre Desktop loads external plugins from the app data `plugins/` directory a
 - An unpacked directory with a root `plugin.json`.
 - A HTTPS `plugin.json` manifest URL.
 
+The fastest way to install a `.zip` is **Manage Plugins > Settings > Install from file**: pick a packaged plugin archive and GeoLibre validates it (parsing `plugin.json`, enforcing the manifest rules, and checking the entry/style are present and within the size limit) before installing it. The plugin loads immediately and persists; reinstalling the same id replaces the previous copy and reloads the updated version. Persistence differs by build:
+
+- **Desktop** copies the archive into the app data `plugins/` directory as `<plugin-id>.zip`, where the startup scan re-loads it.
+- **Web** unpacks the archive in the browser and stores the bundle in IndexedDB, replaying it on the next visit. Web-installed plugins are listed under **Install from file** with an uninstall control (the desktop copies live on disk and are managed there).
+
 The Plugins settings section can also add local development directories outside the app data folder. Each configured directory can contain plugin zips, unpacked plugin bundle folders, or be a single unpacked plugin bundle itself. Configured development directories are scanned before the app data `plugins/` directory, so a development copy can override an installed external plugin with the same ID. Built-in plugins still take precedence over all external plugins.
 
-For the web app, use manifest URLs. GeoLibre fetches the manifest, resolves `entry` and `style` relative to the manifest URL, then loads the bundled ESM entry. Browser loading requires HTTPS except for `localhost` and depends on the host allowing CORS.
+For the web app, use manifest URLs or **Install from file** (above). Manifest URLs: GeoLibre fetches the manifest, resolves `entry` and `style` relative to the manifest URL, then loads the bundled ESM entry. Browser loading requires HTTPS except for `localhost` and depends on the host allowing CORS. Install-from-file unpacks the uploaded zip in the browser (no network or CORS) and persists it in IndexedDB. Both paths execute the bundled ESM entry the same way (a `blob:` `import()`, allowed by the web build's `script-src`), so external plugins remain trusted code regardless of how they were installed.
 
 ### Bundled plugins (baked into the build)
 
@@ -239,7 +244,7 @@ When using the template, update `geolibre-plugin/plugin.json` and `src/geolibre.
 
 ### Plugin marketplace
 
-The Settings menu's **Manage Plugins** entry opens a standalone dialog (modeled on QGIS's plugin manager) with **All**, **Installed**, **Not installed**, **Upgradeable**, and **Settings** sections. The first four list curated registry plugins so users can install, update, and uninstall them without hand-entering manifest URLs; the Settings section manages additional local plugin directories and manual manifest URLs. Actions apply immediately (install/uninstall/update are live; uninstall asks for confirmation). It is a thin layer over the manifest-URL loader above: installing an entry records its manifest URL in the plugin manifest URL list, and the existing loader fetches and registers it. It introduces no new trust path.
+The Settings menu's **Manage Plugins** entry opens a standalone dialog (modeled on QGIS's plugin manager) with **All**, **Installed**, **Not installed**, **Upgradeable**, and **Settings** sections. The first four list curated registry plugins so users can install, update, and uninstall them without hand-entering manifest URLs; the Settings section installs a plugin from a local `.zip` and manages additional local plugin directories and manual manifest URLs. Actions apply immediately (install/uninstall/update are live; uninstall asks for confirmation). It is a thin layer over the manifest-URL loader above: installing an entry records its manifest URL in the plugin manifest URL list, and the existing loader fetches and registers it. It introduces no new trust path.
 
 The registry is JSON, fetched from `VITE_GEOLIBRE_PLUGIN_REGISTRY_URL` or, by default, the hosted registry at `https://plugins.geolibre.app/plugin-registry.json` (the [opengeos/geolibre-plugins](https://github.com/opengeos/geolibre-plugins) repo, published to GitHub Pages with CORS enabled). It is an array, or an object with a `plugins` array, of entries:
 

--- a/e2e/plugin-install.spec.ts
+++ b/e2e/plugin-install.spec.ts
@@ -26,10 +26,13 @@ const ENTRY_SOURCE = `const plugin = {
 export default plugin;
 `;
 
+// Wrap the plugin in a top-level folder (as produced by zipping a plugin
+// directory) so this exercises the wrapping-folder path, not just a root
+// plugin.json.
 function buildPluginZip(): Buffer {
   const archive = zipSync({
-    "plugin.json": strToU8(JSON.stringify(MANIFEST)),
-    "plugin.js": strToU8(ENTRY_SOURCE),
+    "e2e-sample-plugin/plugin.json": strToU8(JSON.stringify(MANIFEST)),
+    "e2e-sample-plugin/plugin.js": strToU8(ENTRY_SOURCE),
   });
   return Buffer.from(archive);
 }

--- a/e2e/plugin-install.spec.ts
+++ b/e2e/plugin-install.spec.ts
@@ -1,0 +1,110 @@
+import { expect, test, type Page } from "@playwright/test";
+import { strToU8, zipSync } from "fflate";
+
+// A minimal but valid external GeoLibre plugin: the entry is a self-contained
+// ESM module exporting a GeoLibrePlugin whose id/name/version match the
+// manifest. activate/deactivate are no-ops so the plugin registers without
+// needing a live map control.
+const PLUGIN_ID = "e2e-sample-plugin";
+const PLUGIN_NAME = "E2E Sample Plugin";
+const PLUGIN_VERSION = "1.0.0";
+
+const MANIFEST = {
+  id: PLUGIN_ID,
+  name: PLUGIN_NAME,
+  version: PLUGIN_VERSION,
+  entry: "plugin.js",
+};
+
+const ENTRY_SOURCE = `const plugin = {
+  id: ${JSON.stringify(PLUGIN_ID)},
+  name: ${JSON.stringify(PLUGIN_NAME)},
+  version: ${JSON.stringify(PLUGIN_VERSION)},
+  activate() {},
+  deactivate() {},
+};
+export default plugin;
+`;
+
+function buildPluginZip(): Buffer {
+  const archive = zipSync({
+    "plugin.json": strToU8(JSON.stringify(MANIFEST)),
+    "plugin.js": strToU8(ENTRY_SOURCE),
+  });
+  return Buffer.from(archive);
+}
+
+/** Open Manage Plugins from the Settings dropdown and switch to its Settings tab. */
+async function openManagePluginsSettings(page: Page) {
+  await page.getByRole("button", { name: "Settings", exact: true }).click();
+  await page.getByRole("menuitem", { name: "Manage Plugins" }).click();
+  const dialog = page.getByRole("dialog");
+  await expect(dialog.getByText("Manage Plugins")).toBeVisible();
+  await dialog.getByRole("button", { name: "Settings", exact: true }).click();
+  return dialog;
+}
+
+test("installs a plugin from an uploaded zip, persists it across reload, and uninstalls it", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(page.getByTestId("map-canvas")).toBeVisible();
+  // The Settings dropdown trigger is part of the toolbar; wait for it before
+  // driving the menu.
+  await expect(
+    page.getByRole("button", { name: "Settings", exact: true }),
+  ).toBeVisible();
+
+  // 1. Install from file: the web path reads the uploaded bytes, unpacks and
+  //    registers the plugin client-side, and persists it in IndexedDB.
+  let dialog = await openManagePluginsSettings(page);
+  const [fileChooser] = await Promise.all([
+    page.waitForEvent("filechooser"),
+    dialog.getByRole("button", { name: /Choose \.zip/ }).click(),
+  ]);
+  await fileChooser.setFiles({
+    name: `${PLUGIN_ID}.zip`,
+    mimeType: "application/zip",
+    buffer: buildPluginZip(),
+  });
+
+  // Success notice + the plugin appears in the "installed from file" list.
+  await expect(
+    dialog.getByText(`Installed plugin "${PLUGIN_ID}".`),
+  ).toBeVisible();
+  await expect(dialog.getByText(PLUGIN_NAME)).toBeVisible();
+  await expect(
+    dialog.getByRole("button", { name: `Uninstall ${PLUGIN_NAME}` }),
+  ).toBeVisible();
+
+  // Close the dialog and confirm the plugin registered (it shows in the
+  // toolbar's Plugins menu, which lists registered plugins by name).
+  await page.keyboard.press("Escape");
+  await page.getByRole("button", { name: "Plugins", exact: true }).click();
+  await expect(page.getByRole("menu").getByText(PLUGIN_NAME)).toBeVisible();
+  await page.keyboard.press("Escape");
+
+  // 2. Persistence: reload the app. The startup loader replays the bundle from
+  //    IndexedDB, so the plugin is registered again and still listed.
+  await page.reload();
+  await expect(page.getByTestId("map-canvas")).toBeVisible();
+  await page.getByRole("button", { name: "Plugins", exact: true }).click();
+  await expect(page.getByRole("menu").getByText(PLUGIN_NAME)).toBeVisible();
+  await page.keyboard.press("Escape");
+
+  dialog = await openManagePluginsSettings(page);
+  await expect(dialog.getByText(PLUGIN_NAME)).toBeVisible();
+
+  // 3. Uninstall: removes it from IndexedDB and unregisters it.
+  await dialog
+    .getByRole("button", { name: `Uninstall ${PLUGIN_NAME}` })
+    .click();
+  await expect(
+    dialog.getByRole("button", { name: `Uninstall ${PLUGIN_NAME}` }),
+  ).toHaveCount(0);
+
+  // It no longer appears in the Plugins menu either.
+  await page.keyboard.press("Escape");
+  await page.getByRole("button", { name: "Plugins", exact: true }).click();
+  await expect(page.getByRole("menu").getByText(PLUGIN_NAME)).toHaveCount(0);
+});

--- a/tests/plugin-archive-unpack.test.ts
+++ b/tests/plugin-archive-unpack.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { strToU8, zipSync } from "fflate";
+import { bundleFromZipBytes } from "../apps/geolibre-desktop/src/lib/plugin-archive-unpack";
+
+const VALID_MANIFEST = {
+  id: "demo-plugin",
+  name: "Demo Plugin",
+  version: "1.0.0",
+  entry: "dist/plugin.js",
+  style: "dist/plugin.css",
+};
+
+function makeZip(files: Record<string, string>): Uint8Array {
+  const entries: Record<string, Uint8Array> = {};
+  for (const [name, contents] of Object.entries(files)) {
+    entries[name] = strToU8(contents);
+  }
+  return zipSync(entries);
+}
+
+describe("bundleFromZipBytes", () => {
+  it("unpacks a valid archive with entry and style", async () => {
+    const zip = makeZip({
+      "plugin.json": JSON.stringify(VALID_MANIFEST),
+      "dist/plugin.js": "export default {};",
+      "dist/plugin.css": ".demo {}",
+    });
+    const bundle = await bundleFromZipBytes("demo.zip", zip);
+    assert.equal(bundle.archiveName, "demo.zip");
+    assert.equal(bundle.manifest.id, "demo-plugin");
+    assert.equal(bundle.entrySource, "export default {};");
+    assert.equal(bundle.styleSource, ".demo {}");
+  });
+
+  it("returns a null style when the manifest omits one", async () => {
+    const { style: _style, ...manifest } = VALID_MANIFEST;
+    const zip = makeZip({
+      "plugin.json": JSON.stringify(manifest),
+      "dist/plugin.js": "export default {};",
+    });
+    const bundle = await bundleFromZipBytes("demo.zip", zip);
+    assert.equal(bundle.styleSource, null);
+  });
+
+  it("rejects an archive without a root plugin.json", async () => {
+    const zip = makeZip({ "dist/plugin.js": "export default {};" });
+    await assert.rejects(bundleFromZipBytes("demo.zip", zip), /missing a root plugin\.json/);
+  });
+
+  it("rejects an invalid manifest (entry not a .js/.mjs file)", async () => {
+    const zip = makeZip({
+      "plugin.json": JSON.stringify({ ...VALID_MANIFEST, entry: "dist/plugin.txt", style: undefined }),
+      "dist/plugin.txt": "nope",
+    });
+    await assert.rejects(bundleFromZipBytes("demo.zip", zip), /manifest is invalid/);
+  });
+
+  it("rejects an entry path that escapes the archive", async () => {
+    const zip = makeZip({
+      "plugin.json": JSON.stringify({ ...VALID_MANIFEST, entry: "../evil.js", style: undefined }),
+      "../evil.js": "export default {};",
+    });
+    await assert.rejects(bundleFromZipBytes("demo.zip", zip), /must be a relative safe path/);
+  });
+
+  it("rejects when the manifest entry is missing from the archive", async () => {
+    const zip = makeZip({
+      "plugin.json": JSON.stringify({ ...VALID_MANIFEST, style: undefined }),
+    });
+    await assert.rejects(bundleFromZipBytes("demo.zip", zip), /entry 'dist\/plugin\.js' is missing/);
+  });
+});

--- a/tests/plugin-archive-unpack.test.ts
+++ b/tests/plugin-archive-unpack.test.ts
@@ -33,6 +33,29 @@ describe("bundleFromZipBytes", () => {
     assert.equal(bundle.styleSource, ".demo {}");
   });
 
+  it("unpacks an archive wrapped in a single folder", async () => {
+    const zip = makeZip({
+      "my-plugin/plugin.json": JSON.stringify(VALID_MANIFEST),
+      "my-plugin/dist/plugin.js": "export default {};",
+      "my-plugin/dist/plugin.css": ".demo {}",
+    });
+    const bundle = await bundleFromZipBytes("my-plugin.zip", zip);
+    assert.equal(bundle.manifest.id, "demo-plugin");
+    assert.equal(bundle.entrySource, "export default {};");
+    assert.equal(bundle.styleSource, ".demo {}");
+  });
+
+  it("ignores the __MACOSX metadata folder and prefers a root plugin.json", async () => {
+    const zip = makeZip({
+      "__MACOSX/._plugin.json": "junk",
+      "plugin.json": JSON.stringify({ ...VALID_MANIFEST, style: undefined }),
+      "dist/plugin.js": "export default {};",
+    });
+    const bundle = await bundleFromZipBytes("demo.zip", zip);
+    assert.equal(bundle.manifest.id, "demo-plugin");
+    assert.equal(bundle.entrySource, "export default {};");
+  });
+
   it("returns a null style when the manifest omits one", async () => {
     const { style: _style, ...manifest } = VALID_MANIFEST;
     const zip = makeZip({
@@ -43,9 +66,9 @@ describe("bundleFromZipBytes", () => {
     assert.equal(bundle.styleSource, null);
   });
 
-  it("rejects an archive without a root plugin.json", async () => {
+  it("rejects an archive without any plugin.json", async () => {
     const zip = makeZip({ "dist/plugin.js": "export default {};" });
-    await assert.rejects(bundleFromZipBytes("demo.zip", zip), /missing a root plugin\.json/);
+    await assert.rejects(bundleFromZipBytes("demo.zip", zip), /missing a plugin\.json/);
   });
 
   it("rejects an invalid manifest (entry not a .js/.mjs file)", async () => {


### PR DESCRIPTION
## Summary

Adds an **Install from file** action to **Manage Plugins → Settings** so users can install a packaged plugin `.zip` directly, without hand-entering a manifest URL. Works on both the desktop and web builds, each persisting the plugin in a platform-appropriate way.

### Desktop
- New Tauri command `install_external_plugin_archive` validates the archive (reusing the startup scan's `plugin.json`/entry/style checks and the 50 MB cap) and copies it into the app-data `plugins/` directory as `<plugin-id>.zip`, where the existing scan already loads it.
- The plugin loads immediately via a forced re-scan and persists across restarts. Reinstalling the same id overwrites the archive in place and reloads it.
- Filenames are sanitized from the plugin id so a hostile id cannot escape the plugins directory.

### Web
- The archive is unpacked and validated in the browser with `fflate`, registered client-side through the existing blob-URL `import()` path (already allowed by the web `script-src`), and persisted in **IndexedDB** so it replays on the next visit.
- Web-installed plugins are listed under Install from file with an uninstall control; uninstall removes the IndexedDB record and unregisters the plugin.

### Structure
- The unzip + validate core is factored into a pure, Tauri/DOM-free module (`plugin-archive-unpack.ts`) shared with the URL loader, plus an IndexedDB wrapper (`plugin-archive-store.ts`).
- Docs updated in `docs/plugin-api.md`.

## Testing
- `cargo check` + `cargo test` (new unit tests for the filename sanitizer): pass
- Full web build (`tsc -b && vite build`): pass
- Frontend unit tests (incl. 6 new for `bundleFromZipBytes`): **1231 pass**
- ESLint + pre-commit hooks: pass
- Playwright e2e: **11/11 pass**, including a new `plugin-install.spec.ts` that drives the full web lifecycle in real Chromium — install from an uploaded zip, confirm it registers, reload and confirm it re-registers from IndexedDB, then uninstall.