### PR TITLE
feat(updates): update status color fix, guided workflow, startup check, and preferences

### DIFF
--- a/apps/geolibre-desktop/src/App.tsx
+++ b/apps/geolibre-desktop/src/App.tsx
@@ -1,11 +1,13 @@
 import { DesktopShell } from "./components/layout/DesktopShell";
 import { OnboardingDialog } from "./components/layout/OnboardingDialog";
+import { UpdateNotificationModal } from "./components/layout/UpdateNotificationModal";
 import { useDesktopSettingsPersistence } from "./hooks/useDesktopSettings";
 import { useLayoutOptions } from "./hooks/useLayoutOptions";
 import { useProjectUrlLoader } from "./hooks/useProjectUrlLoader";
 import { useBeforeUnloadGuard } from "./hooks/useBeforeUnloadGuard";
 import { useRecentProjectsPersistence } from "./hooks/useRecentProjectsPersistence";
 import { useRuntimeEnvironmentVariables } from "./hooks/useRuntimeEnvironmentVariables";
+import { useStartupUpdateCheck } from "./hooks/useStartupUpdateCheck";
 import { useThemeMode } from "./hooks/useThemeMode";
 import { useUiProfileBootstrap } from "./hooks/useUiProfileBootstrap";
 import { useUndoRedoShortcuts } from "./hooks/useUndoRedoShortcuts";
@@ -15,6 +17,11 @@ export default function App() {
   const { themeMode, toggleThemeMode } = useThemeMode();
   const projectUrlLoadState = useProjectUrlLoader();
   const { showOnboarding, dismissOnboarding } = useUiProfileBootstrap();
+  const {
+    pending: pendingUpdate,
+    remindLater,
+    skipVersion,
+  } = useStartupUpdateCheck();
 
   useDesktopSettingsPersistence();
   useRecentProjectsPersistence();
@@ -30,6 +37,11 @@ export default function App() {
         onToggleThemeMode={toggleThemeMode}
       />
       <OnboardingDialog open={showOnboarding} onClose={dismissOnboarding} />
+      <UpdateNotificationModal
+        pending={pendingUpdate}
+        onRemindLater={remindLater}
+        onSkipVersion={skipVersion}
+      />
     </>
   );
 }

--- a/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
@@ -9,31 +9,33 @@ import {
   DialogTrigger,
 } from "@geolibre/ui";
 import { PROJECT_VERSION } from "@geolibre/core";
-import { openUrl } from "@tauri-apps/plugin-opener";
 import { CheckCircle2, ExternalLink, Info, Map, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { openExternalLink } from "../../lib/open-external";
+import {
+  APP_VERSION,
+  compareVersions,
+  fetchLatestRelease,
+  formatVersion,
+  UPDATE_URL,
+  UpdateCheckError,
+} from "../../lib/updates";
+import { ReleaseNotes } from "./ReleaseNotes";
+import { UpdateInstructions } from "./UpdateInstructions";
 
 const LINKS = [
   {
-    label: "Home page",
+    labelKey: "about.homePage",
     href: "https://geolibre.app",
   },
   {
-    label: "GitHub repository",
+    labelKey: "about.githubRepository",
     href: "https://github.com/opengeos/GeoLibre",
   },
-];
-
-const UPDATE_URL = "https://geolibre.app/downloads/";
-const LATEST_RELEASE_URL =
-  "https://api.github.com/repos/opengeos/GeoLibre/releases/latest";
-const APP_VERSION = __GEOLIBRE_VERSION__;
+] as const;
 
 type UpdateStatus = "idle" | "checking" | "current" | "available" | "error";
-
-interface GitHubRelease {
-  tag_name?: unknown;
-}
 
 interface AboutDialogProps {
   checkForUpdatesRequest?: number;
@@ -46,42 +48,6 @@ interface AboutDialogProps {
   showLabels?: boolean;
 }
 
-function isTauri(): boolean {
-  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
-}
-
-async function openExternalLink(url: string) {
-  if (isTauri()) {
-    await openUrl(url);
-    return;
-  }
-  window.open(url, "_blank", "noopener,noreferrer");
-}
-
-function parseVersion(version: string): [number, number, number] | null {
-  const match = version.trim().match(/^v?(\d+)\.(\d+)\.(\d+)$/);
-  if (!match) return null;
-
-  return [Number(match[1]), Number(match[2]), Number(match[3])];
-}
-
-function compareVersions(currentVersion: string, latestVersion: string): number {
-  const current = parseVersion(currentVersion);
-  const latest = parseVersion(latestVersion);
-  if (!current || !latest) return 0;
-
-  for (let index = 0; index < current.length; index += 1) {
-    if (current[index] !== latest[index]) return current[index] - latest[index];
-  }
-
-  return 0;
-}
-
-function formatVersion(version: string): string {
-  const trimmedVersion = version.trim();
-  return trimmedVersion.startsWith("v") ? trimmedVersion : `v${trimmedVersion}`;
-}
-
 export function AboutDialog({
   checkForUpdatesRequest = 0,
   open,
@@ -92,9 +58,12 @@ export function AboutDialog({
   iconClassName,
   showLabels = true,
 }: AboutDialogProps) {
+  const { t } = useTranslation();
   const [internalOpen, setInternalOpen] = useState(false);
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus>("idle");
   const [latestVersion, setLatestVersion] = useState<string | null>(null);
+  const [latestNotes, setLatestNotes] = useState<string>("");
+  const [latestUrl, setLatestUrl] = useState<string>(UPDATE_URL);
   const [updateError, setUpdateError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const handledCheckForUpdatesRequestRef = useRef(0);
@@ -106,8 +75,29 @@ export function AboutDialog({
   const resetUpdateState = useCallback(() => {
     setUpdateStatus("idle");
     setLatestVersion(null);
+    setLatestNotes("");
+    setLatestUrl(UPDATE_URL);
     setUpdateError(null);
   }, []);
+
+  const describeUpdateError = useCallback(
+    (error: unknown): string => {
+      if (error instanceof UpdateCheckError) {
+        switch (error.code) {
+          case "rateLimit":
+            return t("updates.error.rateLimit");
+          case "http":
+            return t("updates.error.http", { status: error.status });
+          case "noTag":
+            return t("updates.error.noTag");
+          default:
+            return t("updates.error.network");
+        }
+      }
+      return t("updates.error.message");
+    },
+    [t],
+  );
 
   const handleCheckForUpdates = async () => {
     abortRef.current?.abort();
@@ -115,39 +105,17 @@ export function AboutDialog({
     abortRef.current = controller;
     setUpdateStatus("checking");
     setLatestVersion(null);
+    setLatestNotes("");
+    setLatestUrl(UPDATE_URL);
     setUpdateError(null);
 
     try {
-      const response = await fetch(LATEST_RELEASE_URL, {
-        headers: {
-          Accept: "application/vnd.github+json",
-          "X-GitHub-Api-Version": "2022-11-28",
-        },
-        signal: controller.signal,
-      });
-
-      if (!response.ok) {
-        if (
-          response.status === 403 &&
-          response.headers.get("X-RateLimit-Remaining") === "0"
-        ) {
-          throw new Error(
-            "GitHub rate limit exceeded. Please try again later.",
-          );
-        }
-        throw new Error(`GitHub returned ${response.status}.`);
-      }
-
-      const release = (await response.json()) as GitHubRelease;
-      if (typeof release.tag_name !== "string" || !release.tag_name.trim()) {
-        throw new Error("The latest release does not include a version tag.");
-      }
-
-      const nextLatestVersion = formatVersion(release.tag_name);
-
-      setLatestVersion(nextLatestVersion);
+      const release = await fetchLatestRelease(controller.signal);
+      setLatestVersion(release.version);
+      setLatestNotes(release.notes);
+      setLatestUrl(release.url);
       setUpdateStatus(
-        compareVersions(APP_VERSION, nextLatestVersion) < 0
+        compareVersions(APP_VERSION, release.version) < 0
           ? "available"
           : "current",
       );
@@ -155,11 +123,7 @@ export function AboutDialog({
       if (error instanceof Error && error.name === "AbortError") return;
       console.error("Failed to check for updates", error);
       setUpdateStatus("error");
-      setUpdateError(
-        error instanceof Error
-          ? error.message
-          : "Could not check for updates.",
-      );
+      setUpdateError(describeUpdateError(error));
     }
   };
 
@@ -201,11 +165,11 @@ export function AboutDialog({
             className={buttonClassName}
             variant="ghost"
             size={buttonSize}
-            aria-label="About"
+            aria-label={t("about.trigger")}
           >
             <Info className={iconClassName ?? "h-3.5 w-3.5 sm:mr-1"} />
             {showLabels ? (
-              <span className="hidden sm:inline">About</span>
+              <span className="hidden sm:inline">{t("about.trigger")}</span>
             ) : null}
           </Button>
         </DialogTrigger>
@@ -214,19 +178,19 @@ export function AboutDialog({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Map className="h-5 w-5 text-primary" />
-            About GeoLibre
+            {t("about.title")}
           </DialogTitle>
-          <DialogDescription>
-            GeoLibre is a lightweight cloud-native desktop GIS.
-          </DialogDescription>
+          <DialogDescription>{t("about.description")}</DialogDescription>
         </DialogHeader>
         <div className="space-y-3 text-sm">
           <div className="flex items-center justify-between rounded-md border bg-muted/30 px-3 py-2">
-            <span className="text-muted-foreground">Version</span>
+            <span className="text-muted-foreground">{t("about.version")}</span>
             <span className="font-mono text-foreground">v{APP_VERSION}</span>
           </div>
           <div className="flex items-center justify-between rounded-md border bg-muted/30 px-3 py-2">
-            <span className="text-muted-foreground">Project format</span>
+            <span className="text-muted-foreground">
+              {t("about.projectFormat")}
+            </span>
             <span className="font-mono text-foreground">{PROJECT_VERSION}</span>
           </div>
           <Button
@@ -243,8 +207,8 @@ export function AboutDialog({
                 }`}
               />
               {updateStatus === "checking"
-                ? "Checking for updates"
-                : "Check for updates"}
+                ? t("about.checking")
+                : t("about.checkForUpdates")}
             </span>
           </Button>
           {updateStatus !== "idle" && updateStatus !== "checking" ? (
@@ -253,24 +217,43 @@ export function AboutDialog({
                 <div className="flex items-center gap-2 text-foreground">
                   <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400" />
                   <span>
-                    You are up to date
-                    {latestVersion ? ` (${latestVersion}).` : "."}
+                    {latestVersion
+                      ? t("about.upToDate", { version: latestVersion })
+                      : t("about.upToDateNoVersion")}
                   </span>
                 </div>
               ) : null}
               {updateStatus === "available" ? (
-                <div className="space-y-2">
-                  <div className="text-foreground">
-                    {latestVersion ?? "A new version"} is available. You are
-                    running {`v${APP_VERSION}`}.
+                <div className="space-y-3">
+                  <div className="font-medium text-foreground">
+                    {t("updates.available.title", {
+                      version: latestVersion ?? t("updates.available.fallback"),
+                    })}
+                  </div>
+                  <div className="text-xs text-muted-foreground">
+                    {t("updates.available.summary", {
+                      current: `v${APP_VERSION}`,
+                    })}
+                  </div>
+                  <div className="space-y-1.5">
+                    <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      {t("updates.changelogTitle")}
+                    </div>
+                    <ReleaseNotes notes={latestNotes} />
+                  </div>
+                  <div className="space-y-1.5">
+                    <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      {t("updates.stepsTitle")}
+                    </div>
+                    <UpdateInstructions />
                   </div>
                   <Button
                     className="w-full justify-between"
-                    onClick={() => void openExternalLink(UPDATE_URL)}
+                    onClick={() => void openExternalLink(latestUrl)}
                     type="button"
                     variant="default"
                   >
-                    <span>Download update</span>
+                    <span>{t("updates.download")}</span>
                     <ExternalLink className="h-3.5 w-3.5" />
                   </Button>
                 </div>
@@ -278,7 +261,7 @@ export function AboutDialog({
               {updateStatus === "error" ? (
                 <div className="space-y-2">
                   <div className="text-foreground">
-                    Could not check for updates.
+                    {t("updates.error.message")}
                   </div>
                   {updateError ? (
                     <div className="text-xs text-muted-foreground">
@@ -291,7 +274,7 @@ export function AboutDialog({
                     type="button"
                     variant="outline"
                   >
-                    <span>View downloads</span>
+                    <span>{t("updates.error.viewDownloads")}</span>
                     <ExternalLink className="h-3.5 w-3.5" />
                   </Button>
                 </div>
@@ -310,7 +293,7 @@ export function AboutDialog({
               rel="noreferrer"
               target="_blank"
             >
-              <span>{link.label}</span>
+              <span>{t(link.labelKey)}</span>
               <span className="inline-flex items-center gap-2 text-muted-foreground">
                 {link.href.replace(/^https?:\/\//, "")}
                 <ExternalLink className="h-3.5 w-3.5" />

--- a/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
@@ -90,11 +90,14 @@ export function AboutDialog({
             return t("updates.error.http", { status: error.status });
           case "noTag":
             return t("updates.error.noTag");
+          case "network":
           default:
             return t("updates.error.network");
         }
       }
-      return t("updates.error.message");
+      // Non-UpdateCheckError (an unexpected failure): reuse the network message
+      // rather than duplicating the generic header string shown above it.
+      return t("updates.error.network");
     },
     [t],
   );

--- a/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
@@ -17,7 +17,6 @@ import {
   APP_VERSION,
   compareVersions,
   fetchLatestRelease,
-  formatVersion,
   UPDATE_URL,
   UpdateCheckError,
 } from "../../lib/updates";

--- a/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
@@ -251,7 +251,7 @@ export function AboutDialog({
             <div className="rounded-md border bg-muted/30 px-3 py-2">
               {updateStatus === "current" ? (
                 <div className="flex items-center gap-2 text-foreground">
-                  <CheckCircle2 className="h-3.5 w-3.5 text-primary" />
+                  <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400" />
                   <span>
                     You are up to date
                     {latestVersion ? ` (${latestVersion}).` : "."}

--- a/apps/geolibre-desktop/src/components/layout/ReleaseNotes.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ReleaseNotes.tsx
@@ -34,8 +34,9 @@ export function ReleaseNotes({ notes }: ReleaseNotesProps) {
         .replace(/^\d+\.\s+/, "")
         // Collapse inline link syntax to its label: [text](url) -> text.
         .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
-        // Strip bold/italic emphasis markers, keeping the wrapped text.
-        .replace(/(\*{1,2}|_{1,2})(.+?)\1/g, "$2")
+        // Strip bold/italic emphasis markers, keeping the wrapped text. The
+        // 1-3 range covers ***bold italic*** without leaving a stray marker.
+        .replace(/(\*{1,3}|_{1,3})(.+?)\1/g, "$2")
         .trim(),
     )
     .filter((line) => line.length > 0);

--- a/apps/geolibre-desktop/src/components/layout/ReleaseNotes.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ReleaseNotes.tsx
@@ -32,8 +32,9 @@ export function ReleaseNotes({ notes }: ReleaseNotesProps) {
         .replace(/^[-*+]\s+/, "")
         // Strip leading ordered-list markers (e.g. "1. ", "42. ").
         .replace(/^\d+\.\s+/, "")
-        // Collapse inline link syntax to its label: [text](url) -> text.
-        .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+        // Collapse inline link syntax to its label: [text](url) -> text, and
+        // drop the leading "!" of an image link (![alt](url) -> alt).
+        .replace(/!?\[([^\]]+)\]\([^)]+\)/g, "$1")
         // Strip bold/italic emphasis markers, keeping the wrapped text. The
         // 1-3 range covers ***bold italic*** without leaving a stray marker.
         .replace(/(\*{1,3}|_{1,3})(.+?)\1/g, "$2")

--- a/apps/geolibre-desktop/src/components/layout/ReleaseNotes.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ReleaseNotes.tsx
@@ -23,11 +23,19 @@ export function ReleaseNotes({ notes }: ReleaseNotesProps) {
     .filter((line) => line.length > 0)
     // Drop the auto-generated footer GitHub appends to generated notes.
     .filter((line) => !/^\*\*full changelog\*\*/i.test(line))
+    // Drop bare horizontal-rule dividers (e.g. "---" between sections).
+    .filter((line) => !/^-{3,}$/.test(line))
     .map((line) =>
       line
         // Strip leading Markdown heading hashes and list markers.
         .replace(/^#{1,6}\s+/, "")
         .replace(/^[-*+]\s+/, "")
+        // Strip leading ordered-list markers (e.g. "1. ", "42. ").
+        .replace(/^\d+\.\s+/, "")
+        // Collapse inline link syntax to its label: [text](url) -> text.
+        .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+        // Strip bold/italic emphasis markers, keeping the wrapped text.
+        .replace(/(\*{1,2}|_{1,2})(.+?)\1/g, "$2")
         .trim(),
     )
     .filter((line) => line.length > 0);

--- a/apps/geolibre-desktop/src/components/layout/ReleaseNotes.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ReleaseNotes.tsx
@@ -35,6 +35,9 @@ export function ReleaseNotes({ notes }: ReleaseNotesProps) {
         // Collapse inline link syntax to its label: [text](url) -> text, and
         // drop the leading "!" of an image link (![alt](url) -> alt).
         .replace(/!?\[([^\]]+)\]\([^)]+\)/g, "$1")
+        // Collapse inline code spans first so backtick-fenced asterisks aren't
+        // misread as emphasis markers by the next pass.
+        .replace(/`([^`]+)`/g, "$1")
         // Strip bold/italic emphasis markers, keeping the wrapped text. The
         // 1-3 range covers ***bold italic*** without leaving a stray marker.
         .replace(/(\*{1,3}|_{1,3})(.+?)\1/g, "$2")

--- a/apps/geolibre-desktop/src/components/layout/ReleaseNotes.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ReleaseNotes.tsx
@@ -1,0 +1,57 @@
+import { useTranslation } from "react-i18next";
+
+interface ReleaseNotesProps {
+  /** Raw release-notes body (Markdown) from the GitHub release. */
+  notes: string;
+}
+
+/**
+ * Render GitHub release notes as a compact, scannable changelog.
+ *
+ * The body is shown as plain text (never as HTML) so untrusted release content
+ * cannot inject markup. Light Markdown cleanup strips heading hashes and bullet
+ * markers and drops the auto-generated "Full Changelog" link line, leaving a
+ * readable list of changes.
+ *
+ * @param notes - The raw Markdown body of the release.
+ */
+export function ReleaseNotes({ notes }: ReleaseNotesProps) {
+  const { t } = useTranslation();
+  const lines = notes
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    // Drop the auto-generated footer GitHub appends to generated notes.
+    .filter((line) => !/^\*\*full changelog\*\*/i.test(line))
+    .map((line) =>
+      line
+        // Strip leading Markdown heading hashes and list markers.
+        .replace(/^#{1,6}\s+/, "")
+        .replace(/^[-*+]\s+/, "")
+        .trim(),
+    )
+    .filter((line) => line.length > 0);
+
+  if (lines.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        {t("updates.noChangelog")}
+      </p>
+    );
+  }
+
+  return (
+    <ul className="max-h-40 space-y-1 overflow-y-auto pr-1 text-xs text-muted-foreground">
+      {lines.map((line, index) => (
+        // Release-note lines have no stable id; index keys are fine for this
+        // static, read-only list.
+        <li key={index} className="flex gap-1.5">
+          <span aria-hidden className="select-none text-muted-foreground/60">
+            •
+          </span>
+          <span className="text-foreground/80">{line}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -1806,8 +1806,14 @@ export function SettingsDialog({
                       }
                       onChange={(event) =>
                         updateDraftUpdateSettings({
-                          notificationLevel: event.target
-                            .value as UpdateNotificationLevel,
+                          // The options are generated from
+                          // UPDATE_NOTIFICATION_LEVELS, but guard the cast so an
+                          // unexpected value can't slip through if they drift.
+                          notificationLevel: UPDATE_NOTIFICATION_LEVELS.includes(
+                            event.target.value as UpdateNotificationLevel,
+                          )
+                            ? (event.target.value as UpdateNotificationLevel)
+                            : DEFAULT_UPDATE_SETTINGS.notificationLevel,
                         })
                       }
                     >

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -36,6 +36,7 @@ import type { MapController } from "@geolibre/map";
 import {
   Braces,
   Crosshair,
+  DownloadCloud,
   Eye,
   EyeOff,
   FolderCog,
@@ -59,14 +60,19 @@ import { Trans, useTranslation } from "react-i18next";
 import {
   DEFAULT_DESKTOP_LAYOUT_SETTINGS,
   DEFAULT_UI_PROFILE_SETTINGS,
+  DEFAULT_UPDATE_SETTINGS,
   EXPERIENCE_LEVELS,
+  UPDATE_NOTIFICATION_LEVELS,
   useDesktopSettingsStore,
   type DesktopSettings,
   type DesktopLayoutSettings,
   type ExperienceLevel,
   type UiProfileSettings,
+  type UpdateSettings,
 } from "../../hooks/useDesktopSettings";
 import { useLanguage } from "../../hooks/useLanguage";
+import { isTauri } from "../../lib/is-tauri";
+import type { UpdateNotificationLevel } from "../../lib/updates";
 import {
   DATA_SOURCE_CATALOG,
   DATA_SOURCE_SECTION_LABEL_KEYS,
@@ -86,7 +92,8 @@ export type SettingsSection =
   | "layout"
   | "interface"
   | "geocoding"
-  | "environment";
+  | "environment"
+  | "updates";
 
 /** Window event letting any panel open Settings at a given section (no prop-drilling). */
 export const OPEN_SETTINGS_EVENT = "geolibre:open-settings";
@@ -134,6 +141,11 @@ const SECTION_ITEMS: Array<{
     labelKey: "settings.section.environment",
     icon: Braces,
   },
+  {
+    id: "updates",
+    labelKey: "settings.section.updates",
+    icon: DownloadCloud,
+  },
 ];
 
 // The menu-item id that gates each Settings section, mirroring the dropdown.
@@ -164,6 +176,7 @@ interface DraftDesktopSettings {
   layout: DesktopLayoutSettings;
   shareToken: string;
   uiProfile: UiProfileSettings;
+  updates: UpdateSettings;
 }
 
 function createDraftId(): string {
@@ -197,6 +210,7 @@ function cloneDesktopSettings(settings: DesktopSettings): DraftDesktopSettings {
       hiddenMenus: [...settings.uiProfile.hiddenMenus],
       hiddenMenuItems: [...settings.uiProfile.hiddenMenuItems],
     },
+    updates: { ...settings.updates },
   };
 }
 
@@ -323,6 +337,9 @@ export function SettingsDialog({
   // (its initial value is "map"), so render the first visible section instead to
   // never expose gated content to a restricted profile.
   const isSectionVisible = (id: SettingsSection) => {
+    // Automated update checks run in the desktop build only, so the section is
+    // hidden on the web where its controls would be inert.
+    if (id === "updates" && !isTauri()) return false;
     const gate = SECTION_GATE[id];
     return gate ? showSettingsItem(gate) : true;
   };
@@ -533,6 +550,18 @@ export function SettingsDialog({
     updateDraftLayoutSettings(DEFAULT_DESKTOP_LAYOUT_SETTINGS);
   };
 
+  const updateDraftUpdateSettings = (patch: Partial<UpdateSettings>) => {
+    setDraftDesktopSettings((current) => ({
+      ...current,
+      updates: { ...current.updates, ...patch },
+    }));
+    setError(null);
+  };
+
+  const resetUpdateSettings = () => {
+    updateDraftUpdateSettings(DEFAULT_UPDATE_SETTINGS);
+  };
+
   // Live updates from the Settings dropdown's Interface submenu (not the draft,
   // which only the dialog commits on Save). Reads the latest state so rapid
   // toggles do not clobber each other.
@@ -704,6 +733,7 @@ export function SettingsDialog({
       layout: draftDesktopSettings.layout,
       shareToken: draftDesktopSettings.shareToken,
       uiProfile: committedUiProfile,
+      updates: draftDesktopSettings.updates,
     });
     setOpen(false);
   };
@@ -914,6 +944,17 @@ export function SettingsDialog({
             >
               <Braces className="mr-2 h-3.5 w-3.5" />
               {t("settings.menu.environmentVariables")}
+            </DropdownMenuItem>
+          )}
+          {isTauri() && (
+            <DropdownMenuItem
+              onSelect={() => {
+                setSection("updates");
+                setOpen(true);
+              }}
+            >
+              <DownloadCloud className="mr-2 h-3.5 w-3.5" />
+              {t("settings.menu.updates")}
             </DropdownMenuItem>
           )}
           {showSettingsItem("settings.managePlugins") && (
@@ -1710,6 +1751,76 @@ export function SettingsDialog({
                       )}
                     </div>
                   )}
+                </div>
+              ) : null}
+              {effectiveSection === "updates" ? (
+                <div className="space-y-5">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <h3 className="text-sm font-semibold">
+                        {t("settings.updates.title")}
+                      </h3>
+                      <p className="text-xs text-muted-foreground">
+                        {t("settings.updates.description")}
+                      </p>
+                    </div>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={resetUpdateSettings}
+                    >
+                      <RotateCcw className="h-3.5 w-3.5" />
+                      {t("common.reset")}
+                    </Button>
+                  </div>
+                  <label className="flex items-start gap-3 rounded-md border p-3 text-sm">
+                    <input
+                      className="mt-0.5 h-4 w-4"
+                      type="checkbox"
+                      checked={draftDesktopSettings.updates.checkOnStartup}
+                      onChange={(event) =>
+                        updateDraftUpdateSettings({
+                          checkOnStartup: event.target.checked,
+                        })
+                      }
+                    />
+                    <span className="space-y-1">
+                      <span className="block">
+                        {t("settings.updates.checkOnStartup")}
+                      </span>
+                      <span className="block text-xs text-muted-foreground">
+                        {t("settings.updates.checkOnStartupHint")}
+                      </span>
+                    </span>
+                  </label>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="settings-update-level">
+                      {t("settings.updates.notificationLevel")}
+                    </Label>
+                    <Select
+                      id="settings-update-level"
+                      value={draftDesktopSettings.updates.notificationLevel}
+                      disabled={
+                        !draftDesktopSettings.updates.checkOnStartup
+                      }
+                      onChange={(event) =>
+                        updateDraftUpdateSettings({
+                          notificationLevel: event.target
+                            .value as UpdateNotificationLevel,
+                        })
+                      }
+                    >
+                      {UPDATE_NOTIFICATION_LEVELS.map((level) => (
+                        <option key={level} value={level}>
+                          {t(`settings.updates.level.${level}`)}
+                        </option>
+                      ))}
+                    </Select>
+                    <p className="text-xs text-muted-foreground">
+                      {t("settings.updates.notificationLevelHint")}
+                    </p>
+                  </div>
                 </div>
               ) : null}
             </div>

--- a/apps/geolibre-desktop/src/components/layout/UpdateInstructions.tsx
+++ b/apps/geolibre-desktop/src/components/layout/UpdateInstructions.tsx
@@ -1,0 +1,28 @@
+import { useTranslation } from "react-i18next";
+
+const STEP_KEYS = [
+  "updates.steps.download",
+  "updates.steps.install",
+  "updates.steps.reopen",
+] as const;
+
+/**
+ * Step-by-step guidance for installing a GeoLibre update without losing local
+ * projects, settings, or API keys. Shared by the About dialog and the startup
+ * update prompt so both surfaces stay in sync.
+ */
+export function UpdateInstructions() {
+  const { t } = useTranslation();
+  return (
+    <ol className="space-y-1.5 text-xs text-muted-foreground">
+      {STEP_KEYS.map((key, index) => (
+        <li key={key} className="flex gap-2">
+          <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-muted text-[10px] font-semibold text-foreground">
+            {index + 1}
+          </span>
+          <span className="text-foreground/80">{t(key)}</span>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/UpdateNotificationModal.tsx
+++ b/apps/geolibre-desktop/src/components/layout/UpdateNotificationModal.tsx
@@ -1,0 +1,125 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@geolibre/ui";
+import { ArrowUpCircle, ExternalLink } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { openExternalLink } from "../../lib/open-external";
+import { APP_VERSION } from "../../lib/updates";
+import type { PendingUpdate } from "../../hooks/useStartupUpdateCheck";
+import { ReleaseNotes } from "./ReleaseNotes";
+import { UpdateInstructions } from "./UpdateInstructions";
+
+interface UpdateNotificationModalProps {
+  /** The pending update to present, or `null` to keep the modal closed. */
+  pending: PendingUpdate | null;
+  /** Dismiss for this session; the prompt may reappear on the next launch. */
+  onRemindLater: () => void;
+  /** Suppress this exact version permanently. */
+  onSkipVersion: () => void;
+}
+
+/**
+ * Startup prompt shown (desktop only) when a notify-worthy newer release is
+ * detected. Surfaces the current and latest versions, a scannable changelog,
+ * step-by-step update guidance, and a primary download action.
+ */
+export function UpdateNotificationModal({
+  pending,
+  onRemindLater,
+  onSkipVersion,
+}: UpdateNotificationModalProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Dialog
+      open={pending !== null}
+      onOpenChange={(open: boolean) => {
+        // Closing via the overlay, Escape, or the X is "remind me later".
+        if (!open) onRemindLater();
+      }}
+    >
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <ArrowUpCircle className="h-5 w-5 text-primary" />
+            {t("updates.startup.title")}
+          </DialogTitle>
+          <DialogDescription>
+            {pending
+              ? t(`updates.severity.${pending.severity}`)
+              : null}
+          </DialogDescription>
+        </DialogHeader>
+        {pending ? (
+          <div className="space-y-3 text-sm">
+            <div className="grid grid-cols-2 gap-2">
+              <div className="rounded-md border bg-muted/30 px-3 py-2">
+                <div className="text-xs text-muted-foreground">
+                  {t("updates.startup.currentVersion")}
+                </div>
+                <div className="font-mono text-foreground">v{APP_VERSION}</div>
+              </div>
+              <div className="rounded-md border bg-muted/30 px-3 py-2">
+                <div className="text-xs text-muted-foreground">
+                  {t("updates.startup.latestVersion")}
+                </div>
+                <div className="font-mono text-foreground">
+                  {pending.release.version}
+                </div>
+              </div>
+            </div>
+            <div className="space-y-1.5">
+              <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                {t("updates.changelogTitle")}
+              </div>
+              <ReleaseNotes notes={pending.release.notes} />
+            </div>
+            <div className="space-y-1.5">
+              <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                {t("updates.stepsTitle")}
+              </div>
+              <UpdateInstructions />
+            </div>
+            <Button
+              className="w-full justify-between"
+              onClick={() => void openExternalLink(pending.release.url)}
+              type="button"
+              variant="default"
+            >
+              <span>{t("updates.startup.download")}</span>
+              <ExternalLink className="h-3.5 w-3.5" />
+            </Button>
+            <div className="flex items-center justify-between gap-2">
+              <Button
+                className="flex-1"
+                onClick={onSkipVersion}
+                type="button"
+                variant="ghost"
+                size="sm"
+              >
+                {t("updates.startup.skipVersion")}
+              </Button>
+              <Button
+                className="flex-1"
+                onClick={onRemindLater}
+                type="button"
+                variant="outline"
+                size="sm"
+              >
+                {t("updates.startup.remindLater")}
+              </Button>
+            </div>
+            <p className="text-center text-xs text-muted-foreground">
+              {t("updates.startup.settingsHint")}
+            </p>
+          </div>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/UpdateNotificationModal.tsx
+++ b/apps/geolibre-desktop/src/components/layout/UpdateNotificationModal.tsx
@@ -39,8 +39,10 @@ export function UpdateNotificationModal({
     <Dialog
       open={pending !== null}
       onOpenChange={(open: boolean) => {
-        // Closing via the overlay, Escape, or the X is "remind me later".
-        if (!open) onRemindLater();
+        // Closing via the overlay, Escape, or the X is "remind me later". The
+        // explicit buttons clear `pending` themselves, so guard on it here to
+        // avoid a redundant onRemindLater after a Skip/Remind click.
+        if (!open && pending !== null) onRemindLater();
       }}
     >
       <DialogContent className="max-w-md">

--- a/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
+++ b/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
@@ -3,6 +3,14 @@ import { useEffect } from "react";
 import { create } from "zustand";
 import { normalizeStringList } from "../lib/string-lists";
 import { DESKTOP_SETTINGS_STORAGE_KEY } from "../lib/storage-keys";
+import type { UpdateNotificationLevel } from "../lib/updates";
+
+/** Notification-granularity options, in order. Single source of truth. */
+export const UPDATE_NOTIFICATION_LEVELS: readonly UpdateNotificationLevel[] = [
+  "all",
+  "minor",
+  "major",
+];
 
 export interface DesktopSettings {
   additionalPluginDirectories: string[];
@@ -31,6 +39,18 @@ export interface DesktopSettings {
    * and an admin lock. See `src/lib/ui-profile.ts` and `docs/ui-profiles.md`.
    */
   uiProfile: UiProfileSettings;
+  /**
+   * Automated software-update preferences. The startup check only runs in the
+   * desktop (Tauri) build; on the web these settings are inert.
+   */
+  updates: UpdateSettings;
+}
+
+export interface UpdateSettings {
+  /** Whether to check for a newer version each time the desktop app starts. */
+  checkOnStartup: boolean;
+  /** Which kinds of releases raise a startup notification. */
+  notificationLevel: UpdateNotificationLevel;
 }
 
 export interface DesktopLayoutSettings {
@@ -98,6 +118,11 @@ export const DEFAULT_UI_PROFILE_SETTINGS: UiProfileSettings = {
   hiddenMenuItems: [],
 };
 
+export const DEFAULT_UPDATE_SETTINGS: UpdateSettings = {
+  checkOnStartup: true,
+  notificationLevel: "all",
+};
+
 const DEFAULT_DESKTOP_SETTINGS: DesktopSettings = {
   additionalPluginDirectories: [],
   language: "",
@@ -105,6 +130,7 @@ const DEFAULT_DESKTOP_SETTINGS: DesktopSettings = {
   pluginManifestUrls: [],
   shareToken: "",
   uiProfile: DEFAULT_UI_PROFILE_SETTINGS,
+  updates: DEFAULT_UPDATE_SETTINGS,
 };
 
 /** The experience-level presets, in order. Single source of truth. */
@@ -135,6 +161,30 @@ function normalizeDesktopSettings(settings: unknown): DesktopSettings {
     shareToken:
       typeof candidate.shareToken === "string" ? candidate.shareToken.trim() : "",
     uiProfile: normalizeUiProfileSettings(candidate.uiProfile),
+    updates: normalizeUpdateSettings(candidate.updates),
+  };
+}
+
+function normalizeUpdateSettings(updates: unknown): UpdateSettings {
+  if (!updates || typeof updates !== "object") {
+    return DEFAULT_UPDATE_SETTINGS;
+  }
+
+  // Require a strict boolean and a known level so tampered localStorage values
+  // cannot smuggle non-boolean / unknown values into the update settings.
+  const candidate = updates as Partial<UpdateSettings>;
+  return {
+    checkOnStartup:
+      typeof candidate.checkOnStartup === "boolean"
+        ? candidate.checkOnStartup
+        : DEFAULT_UPDATE_SETTINGS.checkOnStartup,
+    notificationLevel:
+      typeof candidate.notificationLevel === "string" &&
+      UPDATE_NOTIFICATION_LEVELS.includes(
+        candidate.notificationLevel as UpdateNotificationLevel,
+      )
+        ? (candidate.notificationLevel as UpdateNotificationLevel)
+        : DEFAULT_UPDATE_SETTINGS.notificationLevel,
   };
 }
 

--- a/apps/geolibre-desktop/src/hooks/useStartupUpdateCheck.ts
+++ b/apps/geolibre-desktop/src/hooks/useStartupUpdateCheck.ts
@@ -147,12 +147,12 @@ export function useStartupUpdateCheck() {
   const remindLater = useCallback(() => setPending(null), []);
 
   // Remember the skipped version so the prompt stays hidden until a newer one.
+  // The write lives outside the setPending updater so the updater stays pure
+  // (StrictMode invokes updaters twice).
   const skipVersion = useCallback(() => {
-    setPending((current) => {
-      if (current) writeDismissedVersion(current.release.version);
-      return null;
-    });
-  }, []);
+    if (pending) writeDismissedVersion(pending.release.version);
+    setPending(null);
+  }, [pending]);
 
   return { pending, remindLater, skipVersion };
 }

--- a/apps/geolibre-desktop/src/hooks/useStartupUpdateCheck.ts
+++ b/apps/geolibre-desktop/src/hooks/useStartupUpdateCheck.ts
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useState } from "react";
+import { isTauri } from "../lib/is-tauri";
+import { UPDATE_DISMISSED_VERSION_STORAGE_KEY } from "../lib/storage-keys";
+import {
+  APP_VERSION,
+  fetchLatestRelease,
+  meetsNotificationLevel,
+  releaseSeverity,
+  type LatestRelease,
+  type ReleaseSeverity,
+} from "../lib/updates";
+import { useDesktopSettingsStore } from "./useDesktopSettings";
+
+/** A pending update surfaced by the automated startup check. */
+export interface PendingUpdate {
+  release: LatestRelease;
+  severity: ReleaseSeverity;
+}
+
+function readDismissedVersion(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(UPDATE_DISMISSED_VERSION_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function writeDismissedVersion(version: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(UPDATE_DISMISSED_VERSION_STORAGE_KEY, version);
+  } catch {
+    // Best-effort: ignore quota or disabled-storage errors.
+  }
+}
+
+/**
+ * Run an automated update check once on app startup (desktop build only) and
+ * expose any notify-worthy newer release for the startup prompt.
+ *
+ * The check is skipped entirely on the web build, when the user disabled
+ * "Check for updates on startup", when the latest release is not newer, when it
+ * does not meet the chosen notification granularity, or when the user already
+ * skipped that exact version. Network and parsing failures are swallowed so a
+ * background check never disrupts launch.
+ *
+ * @returns The pending update (or `null`), plus actions to dismiss it for this
+ *   session (`remindLater`) or to suppress it permanently (`skipVersion`).
+ */
+export function useStartupUpdateCheck() {
+  const [pending, setPending] = useState<PendingUpdate | null>(null);
+
+  useEffect(() => {
+    // Automated startup checks are a desktop-only feature; the web build
+    // refreshes to the latest version on reload and needs no prompt.
+    if (!isTauri()) return;
+
+    const settings =
+      useDesktopSettingsStore.getState().desktopSettings.updates;
+    if (!settings.checkOnStartup) return;
+
+    const controller = new AbortController();
+    let cancelled = false;
+
+    void (async () => {
+      try {
+        const release = await fetchLatestRelease(controller.signal);
+        if (cancelled) return;
+
+        const severity = releaseSeverity(APP_VERSION, release.version);
+        if (!severity) return;
+        if (!meetsNotificationLevel(severity, settings.notificationLevel)) {
+          return;
+        }
+        if (readDismissedVersion() === release.version) return;
+
+        setPending({ release, severity });
+      } catch {
+        // Never let a background update check interrupt startup.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, []);
+
+  // Close the prompt for this session; it can reappear on the next launch.
+  const remindLater = useCallback(() => setPending(null), []);
+
+  // Remember the skipped version so the prompt stays hidden until a newer one.
+  const skipVersion = useCallback(() => {
+    setPending((current) => {
+      if (current) writeDismissedVersion(current.release.version);
+      return null;
+    });
+  }, []);
+
+  return { pending, remindLater, skipVersion };
+}

--- a/apps/geolibre-desktop/src/hooks/useStartupUpdateCheck.ts
+++ b/apps/geolibre-desktop/src/hooks/useStartupUpdateCheck.ts
@@ -95,12 +95,11 @@ export function useStartupUpdateCheck() {
     if (!settings.checkOnStartup) return;
 
     // Throttle the network call so frequent relaunches don't burn the GitHub
-    // rate limit. Stamp the time up front so even a server response that fails
-    // (rate limit, HTTP error) counts toward the window and prevents hammering.
+    // rate limit. The timestamp is stamped only after a definitive response,
+    // never up front: an up-front stamp makes React StrictMode's double-invoked
+    // effect early-return on its second run and silently skip the check.
     const now = Date.now();
-    const previousLastCheck = readLastCheck();
-    if (now - previousLastCheck < CHECK_THROTTLE_MS) return;
-    writeLastCheck(now);
+    if (now - readLastCheck() < CHECK_THROTTLE_MS) return;
 
     const controller = new AbortController();
     let cancelled = false;
@@ -109,6 +108,8 @@ export function useStartupUpdateCheck() {
       try {
         const release = await fetchLatestRelease(controller.signal);
         if (cancelled) return;
+        // GitHub was reached and parsed: throttle the next launches.
+        writeLastCheck(now);
 
         const severity = releaseSeverity(APP_VERSION, release.version);
         if (!severity) return;
@@ -119,17 +120,16 @@ export function useStartupUpdateCheck() {
 
         setPending({ release, severity });
       } catch (error) {
-        // Never let a background update check interrupt startup. If GitHub was
-        // never reached (a transient network failure, e.g. the device was still
-        // coming online), roll the timestamp back so the next launch retries
-        // instead of staying silent for the full window. Server responses
-        // (rate limit, HTTP errors) keep the stamp.
+        // Never let a background update check interrupt startup. A server
+        // response that failed (rate limit, HTTP error) still counts toward the
+        // throttle window; an abort or a transient network failure does not, so
+        // the next launch retries instead of staying silent for the full window.
         if (
+          !cancelled &&
           error instanceof UpdateCheckError &&
-          error.code === "network" &&
-          !cancelled
+          error.code !== "network"
         ) {
-          writeLastCheck(previousLastCheck);
+          writeLastCheck(now);
         }
       }
     })();

--- a/apps/geolibre-desktop/src/hooks/useStartupUpdateCheck.ts
+++ b/apps/geolibre-desktop/src/hooks/useStartupUpdateCheck.ts
@@ -108,7 +108,10 @@ export function useStartupUpdateCheck() {
       try {
         const release = await fetchLatestRelease(controller.signal);
         if (cancelled) return;
-        // GitHub was reached and parsed: throttle the next launches.
+        // GitHub was reached and parsed, so throttle the next launches
+        // regardless of the outcome below (up to date, below the chosen level,
+        // or a dismissed version). Bounded staleness is intentional: there is
+        // no benefit to re-querying within the window once we have an answer.
         writeLastCheck(now);
 
         const severity = releaseSeverity(APP_VERSION, release.version);

--- a/apps/geolibre-desktop/src/hooks/useStartupUpdateCheck.ts
+++ b/apps/geolibre-desktop/src/hooks/useStartupUpdateCheck.ts
@@ -9,6 +9,7 @@ import {
   fetchLatestRelease,
   meetsNotificationLevel,
   releaseSeverity,
+  UpdateCheckError,
   type LatestRelease,
   type ReleaseSeverity,
 } from "../lib/updates";
@@ -94,10 +95,11 @@ export function useStartupUpdateCheck() {
     if (!settings.checkOnStartup) return;
 
     // Throttle the network call so frequent relaunches don't burn the GitHub
-    // rate limit. Stamp the time up front so a failed/rate-limited attempt also
-    // counts, preventing repeated hammering within the window.
+    // rate limit. Stamp the time up front so even a server response that fails
+    // (rate limit, HTTP error) counts toward the window and prevents hammering.
     const now = Date.now();
-    if (now - readLastCheck() < CHECK_THROTTLE_MS) return;
+    const previousLastCheck = readLastCheck();
+    if (now - previousLastCheck < CHECK_THROTTLE_MS) return;
     writeLastCheck(now);
 
     const controller = new AbortController();
@@ -116,8 +118,19 @@ export function useStartupUpdateCheck() {
         if (readDismissedVersion() === release.version) return;
 
         setPending({ release, severity });
-      } catch {
-        // Never let a background update check interrupt startup.
+      } catch (error) {
+        // Never let a background update check interrupt startup. If GitHub was
+        // never reached (a transient network failure, e.g. the device was still
+        // coming online), roll the timestamp back so the next launch retries
+        // instead of staying silent for the full window. Server responses
+        // (rate limit, HTTP errors) keep the stamp.
+        if (
+          error instanceof UpdateCheckError &&
+          error.code === "network" &&
+          !cancelled
+        ) {
+          writeLastCheck(previousLastCheck);
+        }
       }
     })();
 

--- a/apps/geolibre-desktop/src/hooks/useStartupUpdateCheck.ts
+++ b/apps/geolibre-desktop/src/hooks/useStartupUpdateCheck.ts
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useState } from "react";
 import { isTauri } from "../lib/is-tauri";
-import { UPDATE_DISMISSED_VERSION_STORAGE_KEY } from "../lib/storage-keys";
+import {
+  UPDATE_DISMISSED_VERSION_STORAGE_KEY,
+  UPDATE_LAST_CHECK_STORAGE_KEY,
+} from "../lib/storage-keys";
 import {
   APP_VERSION,
   fetchLatestRelease,
@@ -15,6 +18,36 @@ import { useDesktopSettingsStore } from "./useDesktopSettings";
 export interface PendingUpdate {
   release: LatestRelease;
   severity: ReleaseSeverity;
+}
+
+/**
+ * Minimum gap between automated startup checks. The unauthenticated GitHub API
+ * allows 60 requests/hour per IP; throttling to a few per day keeps frequent
+ * relaunches from exhausting that quota.
+ */
+const CHECK_THROTTLE_MS = 6 * 60 * 60 * 1000;
+
+function readLastCheck(): number {
+  if (typeof window === "undefined") return 0;
+  try {
+    return Number(
+      window.localStorage.getItem(UPDATE_LAST_CHECK_STORAGE_KEY) ?? 0,
+    );
+  } catch {
+    return 0;
+  }
+}
+
+function writeLastCheck(timestamp: number): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      UPDATE_LAST_CHECK_STORAGE_KEY,
+      String(timestamp),
+    );
+  } catch {
+    // Best-effort: ignore quota or disabled-storage errors.
+  }
 }
 
 function readDismissedVersion(): string | null {
@@ -59,6 +92,13 @@ export function useStartupUpdateCheck() {
     const settings =
       useDesktopSettingsStore.getState().desktopSettings.updates;
     if (!settings.checkOnStartup) return;
+
+    // Throttle the network call so frequent relaunches don't burn the GitHub
+    // rate limit. Stamp the time up front so a failed/rate-limited attempt also
+    // counts, preventing repeated hammering within the window.
+    const now = Date.now();
+    if (now - readLastCheck() < CHECK_THROTTLE_MS) return;
+    writeLastCheck(now);
 
     const controller = new AbortController();
     let cancelled = false;

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1,4 +1,55 @@
 {
+  "about": {
+    "trigger": "About",
+    "title": "About GeoLibre",
+    "description": "GeoLibre is a lightweight cloud-native desktop GIS.",
+    "version": "Version",
+    "projectFormat": "Project format",
+    "checkForUpdates": "Check for updates",
+    "checking": "Checking for updates",
+    "upToDate": "You are up to date ({{version}}).",
+    "upToDateNoVersion": "You are up to date.",
+    "homePage": "Home page",
+    "githubRepository": "GitHub repository"
+  },
+  "updates": {
+    "changelogTitle": "What's new",
+    "noChangelog": "Release notes are not available. See the downloads page for details.",
+    "stepsTitle": "How to update",
+    "download": "Download update",
+    "steps": {
+      "download": "Download the installer for your platform from the downloads page.",
+      "install": "Run the installer. Your local projects, settings, and API keys are kept.",
+      "reopen": "Reopen GeoLibre to finish updating."
+    },
+    "severity": {
+      "major": "Major release",
+      "minor": "Feature update",
+      "patch": "Patch update"
+    },
+    "available": {
+      "title": "{{version}} is available",
+      "fallback": "A new version",
+      "summary": "You are running {{current}}."
+    },
+    "error": {
+      "message": "Could not check for updates.",
+      "rateLimit": "GitHub rate limit exceeded. Please try again later.",
+      "http": "GitHub returned {{status}}.",
+      "noTag": "The latest release does not include a version tag.",
+      "network": "Could not reach GitHub. Check your connection and try again.",
+      "viewDownloads": "View downloads"
+    },
+    "startup": {
+      "title": "Update available",
+      "currentVersion": "Your current version",
+      "latestVersion": "Latest available version",
+      "download": "Download update package",
+      "remindLater": "Remind me later",
+      "skipVersion": "Skip this version",
+      "settingsHint": "You can change update checks in Settings → Updates."
+    }
+  },
   "bookmark": {
     "captureStateLabel": "Include visible layers"
   },
@@ -665,7 +716,8 @@
       "layout": "Layout",
       "interface": "Interface",
       "geocoding": "Geocoding",
-      "environment": "Environment"
+      "environment": "Environment",
+      "updates": "Updates"
     },
     "menu": {
       "mapPreferences": "Map Preferences",
@@ -673,8 +725,22 @@
       "interfaceSettings": "Interface Settings",
       "geocoding": "Geocoding",
       "environmentVariables": "Environment Variables",
+      "updates": "Update Settings",
       "managePlugins": "Manage Plugins",
       "urlOverrideNote": "URL layout parameters override saved settings."
+    },
+    "updates": {
+      "title": "Software Updates",
+      "description": "Control how GeoLibre checks for new versions when the desktop app starts.",
+      "checkOnStartup": "Check for updates on startup",
+      "checkOnStartupHint": "When enabled, GeoLibre checks for a newer version each time the app starts. Turn this off for a fully offline workflow.",
+      "notificationLevel": "Notify me about",
+      "notificationLevelHint": "Choose which kinds of releases trigger a startup notification.",
+      "level": {
+        "all": "All releases (major, minor, and patches)",
+        "minor": "Major and minor releases only",
+        "major": "Major releases only"
+      }
     },
     "map": {
       "constraintsTitle": "Map constraints",

--- a/apps/geolibre-desktop/src/lib/storage-keys.ts
+++ b/apps/geolibre-desktop/src/lib/storage-keys.ts
@@ -7,3 +7,11 @@
 
 /** Persisted desktop settings blob (layout, language, plugin sources, …). */
 export const DESKTOP_SETTINGS_STORAGE_KEY = "geolibre.desktopSettings";
+
+/**
+ * Latest version the user dismissed via "Skip this version" in the automated
+ * startup update prompt. Suppresses the prompt for that one version so it does
+ * not reappear on every launch (desktop only).
+ */
+export const UPDATE_DISMISSED_VERSION_STORAGE_KEY =
+  "geolibre.updateDismissedVersion";

--- a/apps/geolibre-desktop/src/lib/storage-keys.ts
+++ b/apps/geolibre-desktop/src/lib/storage-keys.ts
@@ -15,3 +15,10 @@ export const DESKTOP_SETTINGS_STORAGE_KEY = "geolibre.desktopSettings";
  */
 export const UPDATE_DISMISSED_VERSION_STORAGE_KEY =
   "geolibre.updateDismissedVersion";
+
+/**
+ * Epoch-millisecond timestamp of the last automated startup update check.
+ * Throttles the unauthenticated GitHub API call so frequent relaunches do not
+ * exhaust the per-IP rate limit (desktop only).
+ */
+export const UPDATE_LAST_CHECK_STORAGE_KEY = "geolibre.lastUpdateCheck";

--- a/apps/geolibre-desktop/src/lib/updates.ts
+++ b/apps/geolibre-desktop/src/lib/updates.ts
@@ -199,7 +199,12 @@ export async function fetchLatestRelease(
     typeof release.html_url === "string" ? release.html_url.trim() : "";
   return {
     version: formatVersion(release.tag_name),
-    notes: typeof release.body === "string" ? release.body.trim() : "",
+    // Cap the notes length; GitHub enforces no size limit on release bodies and
+    // 50k is generous for any real changelog while ruling out pathological blobs.
+    notes:
+      typeof release.body === "string"
+        ? release.body.trim().slice(0, 50_000)
+        : "",
     // Only trust a GitHub release URL; fall back to the downloads page so a
     // tampered API response can't redirect the download action to another
     // origin (openExternalLink already blocks non-http(s) schemes).

--- a/apps/geolibre-desktop/src/lib/updates.ts
+++ b/apps/geolibre-desktop/src/lib/updates.ts
@@ -171,9 +171,12 @@ export async function fetchLatestRelease(
   }
 
   if (!response.ok) {
+    // GitHub signals its primary rate limit with 403 + exhausted remaining, and
+    // its secondary rate limit with 429; map both to the actionable message.
     if (
-      response.status === 403 &&
-      response.headers.get("X-RateLimit-Remaining") === "0"
+      (response.status === 403 &&
+        response.headers.get("X-RateLimit-Remaining") === "0") ||
+      response.status === 429
     ) {
       throw new UpdateCheckError("rateLimit", response.status);
     }

--- a/apps/geolibre-desktop/src/lib/updates.ts
+++ b/apps/geolibre-desktop/src/lib/updates.ts
@@ -180,17 +180,26 @@ export async function fetchLatestRelease(
     throw new UpdateCheckError("http", response.status);
   }
 
-  const release = (await response.json()) as GitHubRelease;
+  let release: GitHubRelease;
+  try {
+    release = (await response.json()) as GitHubRelease;
+  } catch {
+    // A malformed 200 body would otherwise throw a plain SyntaxError that
+    // bypasses UpdateCheckError; treat it like any other failed fetch.
+    throw new UpdateCheckError("network");
+  }
   if (typeof release.tag_name !== "string" || !release.tag_name.trim()) {
     throw new UpdateCheckError("noTag");
   }
 
+  const htmlUrl =
+    typeof release.html_url === "string" ? release.html_url.trim() : "";
   return {
     version: formatVersion(release.tag_name),
     notes: typeof release.body === "string" ? release.body.trim() : "",
-    url:
-      typeof release.html_url === "string" && release.html_url.trim()
-        ? release.html_url
-        : UPDATE_URL,
+    // Only trust a GitHub release URL; fall back to the downloads page so a
+    // tampered API response can't redirect the download action to another
+    // origin (openExternalLink already blocks non-http(s) schemes).
+    url: /^https:\/\/github\.com\//i.test(htmlUrl) ? htmlUrl : UPDATE_URL,
   };
 }

--- a/apps/geolibre-desktop/src/lib/updates.ts
+++ b/apps/geolibre-desktop/src/lib/updates.ts
@@ -1,0 +1,196 @@
+/**
+ * Shared logic for checking GeoLibre releases on GitHub. Used by both the
+ * manual "Check for updates" flow in the About dialog and the automated
+ * startup check (desktop only). Keeping the version math and the GitHub fetch
+ * here means the two surfaces classify and compare releases identically.
+ */
+
+/** Page that lists cross-platform installers. */
+export const UPDATE_URL = "https://geolibre.app/downloads/";
+
+/** GitHub REST endpoint for the latest published release. */
+export const LATEST_RELEASE_URL =
+  "https://api.github.com/repos/opengeos/GeoLibre/releases/latest";
+
+/**
+ * The running app version, injected by Vite at build time. Guarded so the pure
+ * helpers below can be imported in a plain Node test (where the define is
+ * absent) without throwing a ReferenceError.
+ */
+export const APP_VERSION: string =
+  typeof __GEOLIBRE_VERSION__ !== "undefined" ? __GEOLIBRE_VERSION__ : "0.0.0";
+
+/**
+ * How a newer release differs from the running version. Used to filter startup
+ * notifications by the user's chosen granularity (see {@link UpdateNotificationLevel}).
+ */
+export type ReleaseSeverity = "major" | "minor" | "patch";
+
+/**
+ * Which releases should trigger an automated startup notification:
+ * - `all`: major, minor, and patch builds
+ * - `minor`: major and minor builds only
+ * - `major`: major builds only
+ */
+export type UpdateNotificationLevel = "all" | "minor" | "major";
+
+/** A normalized view of the latest GitHub release. */
+export interface LatestRelease {
+  /** Formatted version tag, e.g. `"v1.6.0"`. */
+  version: string;
+  /** Raw release-notes body (Markdown). May be an empty string. */
+  notes: string;
+  /** The release page URL, falling back to the downloads page. */
+  url: string;
+}
+
+/** Stable error codes for a failed update check, resolved to i18n at call sites. */
+export type UpdateCheckErrorCode = "rateLimit" | "http" | "noTag" | "network";
+
+/** Error thrown by {@link fetchLatestRelease} for a non-abort failure. */
+export class UpdateCheckError extends Error {
+  readonly code: UpdateCheckErrorCode;
+  readonly status?: number;
+
+  constructor(code: UpdateCheckErrorCode, status?: number) {
+    super(code);
+    this.name = "UpdateCheckError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+/**
+ * Parse a `vX.Y.Z` (or `X.Y.Z`) version into its numeric components.
+ *
+ * @param version - A semantic version string, optionally prefixed with `v`.
+ * @returns A `[major, minor, patch]` tuple, or `null` if it does not match.
+ */
+export function parseVersion(version: string): [number, number, number] | null {
+  const match = version.trim().match(/^v?(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) return null;
+
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+/**
+ * Compare two version strings numerically.
+ *
+ * @returns A negative number if `currentVersion` is older than `latestVersion`,
+ *   positive if newer, and `0` if equal or either is unparseable.
+ */
+export function compareVersions(
+  currentVersion: string,
+  latestVersion: string,
+): number {
+  const current = parseVersion(currentVersion);
+  const latest = parseVersion(latestVersion);
+  if (!current || !latest) return 0;
+
+  for (let index = 0; index < current.length; index += 1) {
+    if (current[index] !== latest[index]) return current[index] - latest[index];
+  }
+
+  return 0;
+}
+
+/**
+ * Ensure a version string carries the leading `v` used throughout the UI.
+ */
+export function formatVersion(version: string): string {
+  const trimmedVersion = version.trim();
+  return trimmedVersion.startsWith("v") ? trimmedVersion : `v${trimmedVersion}`;
+}
+
+/**
+ * Classify how `latestVersion` differs from `currentVersion`.
+ *
+ * @returns `"major"`, `"minor"`, or `"patch"` when `latestVersion` is newer,
+ *   or `null` when it is not newer or either version is unparseable.
+ */
+export function releaseSeverity(
+  currentVersion: string,
+  latestVersion: string,
+): ReleaseSeverity | null {
+  const current = parseVersion(currentVersion);
+  const latest = parseVersion(latestVersion);
+  if (!current || !latest) return null;
+
+  if (latest[0] > current[0]) return "major";
+  if (latest[0] < current[0]) return null;
+  if (latest[1] > current[1]) return "minor";
+  if (latest[1] < current[1]) return null;
+  if (latest[2] > current[2]) return "patch";
+  return null;
+}
+
+/**
+ * Whether a release of the given `severity` should raise a startup
+ * notification under the user's chosen `level`.
+ */
+export function meetsNotificationLevel(
+  severity: ReleaseSeverity,
+  level: UpdateNotificationLevel,
+): boolean {
+  if (level === "all") return true;
+  if (level === "minor") return severity === "major" || severity === "minor";
+  return severity === "major";
+}
+
+interface GitHubRelease {
+  tag_name?: unknown;
+  body?: unknown;
+  html_url?: unknown;
+}
+
+/**
+ * Fetch the latest GeoLibre release from GitHub.
+ *
+ * @param signal - Optional abort signal to cancel the request.
+ * @returns The normalized latest release.
+ * @throws {UpdateCheckError} On rate limiting, an HTTP error, a missing tag, or
+ *   a network failure. An `AbortError` propagates unchanged so callers can
+ *   ignore intentional cancellations.
+ */
+export async function fetchLatestRelease(
+  signal?: AbortSignal,
+): Promise<LatestRelease> {
+  let response: Response;
+  try {
+    response = await fetch(LATEST_RELEASE_URL, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      signal,
+    });
+  } catch (error) {
+    // Let intentional cancellations bubble up so callers can ignore them.
+    if (error instanceof Error && error.name === "AbortError") throw error;
+    throw new UpdateCheckError("network");
+  }
+
+  if (!response.ok) {
+    if (
+      response.status === 403 &&
+      response.headers.get("X-RateLimit-Remaining") === "0"
+    ) {
+      throw new UpdateCheckError("rateLimit", response.status);
+    }
+    throw new UpdateCheckError("http", response.status);
+  }
+
+  const release = (await response.json()) as GitHubRelease;
+  if (typeof release.tag_name !== "string" || !release.tag_name.trim()) {
+    throw new UpdateCheckError("noTag");
+  }
+
+  return {
+    version: formatVersion(release.tag_name),
+    notes: typeof release.body === "string" ? release.body.trim() : "",
+    url:
+      typeof release.html_url === "string" && release.html_url.trim()
+        ? release.html_url
+        : UPDATE_URL,
+  };
+}

--- a/tests/updates.test.ts
+++ b/tests/updates.test.ts
@@ -1,11 +1,14 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { afterEach, describe, it } from "node:test";
 import {
   compareVersions,
+  fetchLatestRelease,
   formatVersion,
   meetsNotificationLevel,
   parseVersion,
   releaseSeverity,
+  UPDATE_URL,
+  UpdateCheckError,
 } from "../apps/geolibre-desktop/src/lib/updates";
 
 describe("update version helpers", () => {
@@ -64,5 +67,80 @@ describe("meetsNotificationLevel", () => {
     assert.equal(meetsNotificationLevel("patch", "major"), false);
     assert.equal(meetsNotificationLevel("minor", "major"), false);
     assert.equal(meetsNotificationLevel("major", "major"), true);
+  });
+});
+
+describe("fetchLatestRelease", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const stubFetch = (response: Response) => {
+    globalThis.fetch = (async () => response) as typeof fetch;
+  };
+
+  it("normalizes a valid release and keeps a GitHub html_url", async () => {
+    stubFetch(
+      new Response(
+        JSON.stringify({
+          tag_name: "1.6.0",
+          body: "  notes  ",
+          html_url: "https://github.com/opengeos/GeoLibre/releases/tag/v1.6.0",
+        }),
+        { status: 200 },
+      ),
+    );
+    const release = await fetchLatestRelease();
+    assert.equal(release.version, "v1.6.0");
+    assert.equal(release.notes, "notes");
+    assert.equal(
+      release.url,
+      "https://github.com/opengeos/GeoLibre/releases/tag/v1.6.0",
+    );
+  });
+
+  it("falls back to the downloads page for a non-GitHub html_url", async () => {
+    stubFetch(
+      new Response(
+        JSON.stringify({ tag_name: "v1.6.0", html_url: "http://evil.example" }),
+        { status: 200 },
+      ),
+    );
+    const release = await fetchLatestRelease();
+    assert.equal(release.url, UPDATE_URL);
+  });
+
+  it("wraps a malformed 200 body as a network error", async () => {
+    stubFetch(new Response("{ not json", { status: 200 }));
+    await assert.rejects(fetchLatestRelease(), (error: unknown) => {
+      assert.ok(error instanceof UpdateCheckError);
+      assert.equal(error.code, "network");
+      return true;
+    });
+  });
+
+  it("reports an exhausted rate limit", async () => {
+    stubFetch(
+      new Response("", {
+        status: 403,
+        headers: { "X-RateLimit-Remaining": "0" },
+      }),
+    );
+    await assert.rejects(fetchLatestRelease(), (error: unknown) => {
+      assert.ok(error instanceof UpdateCheckError);
+      assert.equal(error.code, "rateLimit");
+      return true;
+    });
+  });
+
+  it("flags a missing version tag", async () => {
+    stubFetch(new Response(JSON.stringify({ body: "no tag" }), { status: 200 }));
+    await assert.rejects(fetchLatestRelease(), (error: unknown) => {
+      assert.ok(error instanceof UpdateCheckError);
+      assert.equal(error.code, "noTag");
+      return true;
+    });
   });
 });

--- a/tests/updates.test.ts
+++ b/tests/updates.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  compareVersions,
+  formatVersion,
+  meetsNotificationLevel,
+  parseVersion,
+  releaseSeverity,
+} from "../apps/geolibre-desktop/src/lib/updates";
+
+describe("update version helpers", () => {
+  it("parses semantic versions with and without a v prefix", () => {
+    assert.deepEqual(parseVersion("1.5.0"), [1, 5, 0]);
+    assert.deepEqual(parseVersion("v2.0.3"), [2, 0, 3]);
+    assert.equal(parseVersion("1.5"), null);
+    assert.equal(parseVersion("not-a-version"), null);
+  });
+
+  it("compares versions numerically, not lexically", () => {
+    assert.ok(compareVersions("1.5.0", "1.10.0") < 0);
+    assert.ok(compareVersions("1.5.0", "1.5.0") === 0);
+    assert.ok(compareVersions("2.0.0", "1.9.9") > 0);
+  });
+
+  it("treats unparseable versions as equal so it never falsely reports an update", () => {
+    assert.equal(compareVersions("1.5.0", "garbage"), 0);
+  });
+
+  it("normalizes a version to a leading v", () => {
+    assert.equal(formatVersion("1.5.0"), "v1.5.0");
+    assert.equal(formatVersion("v1.5.0"), "v1.5.0");
+    assert.equal(formatVersion("  1.5.0 "), "v1.5.0");
+  });
+});
+
+describe("releaseSeverity", () => {
+  it("classifies the kind of newer release", () => {
+    assert.equal(releaseSeverity("1.5.0", "2.0.0"), "major");
+    assert.equal(releaseSeverity("1.5.0", "1.6.0"), "minor");
+    assert.equal(releaseSeverity("1.5.0", "1.5.1"), "patch");
+  });
+
+  it("returns null when the candidate is not newer or is unparseable", () => {
+    assert.equal(releaseSeverity("1.5.0", "1.5.0"), null);
+    assert.equal(releaseSeverity("1.5.0", "1.4.9"), null);
+    assert.equal(releaseSeverity("1.5.0", "v1.x"), null);
+  });
+});
+
+describe("meetsNotificationLevel", () => {
+  it("notifies for everything at the 'all' level", () => {
+    assert.equal(meetsNotificationLevel("patch", "all"), true);
+    assert.equal(meetsNotificationLevel("minor", "all"), true);
+    assert.equal(meetsNotificationLevel("major", "all"), true);
+  });
+
+  it("suppresses patches at the 'minor' level", () => {
+    assert.equal(meetsNotificationLevel("patch", "minor"), false);
+    assert.equal(meetsNotificationLevel("minor", "minor"), true);
+    assert.equal(meetsNotificationLevel("major", "minor"), true);
+  });
+
+  it("notifies only for major releases at the 'major' level", () => {
+    assert.equal(meetsNotificationLevel("patch", "major"), false);
+    assert.equal(meetsNotificationLevel("minor", "major"), false);
+    assert.equal(meetsNotificationLevel("major", "major"), true);
+  });
+});

--- a/tests/updates.test.ts
+++ b/tests/updates.test.ts
@@ -112,6 +112,15 @@ describe("fetchLatestRelease", () => {
     assert.equal(release.url, UPDATE_URL);
   });
 
+  it("falls back to the downloads page when html_url is absent", async () => {
+    stubFetch(
+      new Response(JSON.stringify({ tag_name: "v1.6.0" }), { status: 200 }),
+    );
+    const release = await fetchLatestRelease();
+    assert.equal(release.url, UPDATE_URL);
+    assert.equal(release.notes, "");
+  });
+
   it("wraps a malformed 200 body as a network error", async () => {
     stubFetch(new Response("{ not json", { status: 200 }));
     await assert.rejects(fetchLatestRelease(), (error: unknown) => {

--- a/tests/updates.test.ts
+++ b/tests/updates.test.ts
@@ -135,6 +135,15 @@ describe("fetchLatestRelease", () => {
     });
   });
 
+  it("treats a 429 secondary rate limit as a rate limit error", async () => {
+    stubFetch(new Response("", { status: 429 }));
+    await assert.rejects(fetchLatestRelease(), (error: unknown) => {
+      assert.ok(error instanceof UpdateCheckError);
+      assert.equal(error.code, "rateLimit");
+      return true;
+    });
+  });
+
   it("flags a missing version tag", async () => {
     stubFetch(new Response(JSON.stringify({ body: "no tag" }), { status: 200 }));
     await assert.rejects(fetchLatestRelease(), (error: unknown) => {


### PR DESCRIPTION
## Summary

Implements all four parts of #605, building a complete software-update experience.

**Part 1 — Color coding.** The "You are up to date" checkmark in the About dialog now uses the app's standard success color (`text-emerald-600` / `dark:text-emerald-400`) instead of blue (`text-primary`).

**Part 2 — Guided workflow for available updates.** When a newer version is found, the About dialog shows a scannable changelog (from the GitHub release notes) and step-by-step install guidance that reassures users their local projects, settings, and API keys are preserved. The download button links to the specific release page.

**Part 3 — Automated startup check (desktop only).** On launch, the Tauri desktop build checks for a newer release and, when one is found, opens a modal showing the current vs latest version, the changelog, install steps, and a primary "Download update package" action. Users can "Remind me later" (reappears next launch) or "Skip this version" (suppressed until a newer release). Background failures are swallowed so a check never disrupts startup. Per maintainer guidance, this runs in the desktop app only — the web build refreshes to the latest version on reload.

**Part 4 — Update preferences (desktop only).** A new **Settings → Updates** section with a master "Check for updates on startup" toggle and a notification-granularity dropdown:
- All releases (major, minor, and patches)
- Major and minor releases only
- Major releases only

## Implementation notes

- Shared logic (version parse/compare, severity classification, notification-level filtering, GitHub fetch with typed errors) lives in `lib/updates.ts` and has unit tests (`tests/updates.test.ts`).
- Release notes render as plain text (never HTML) so untrusted release content cannot inject markup.
- The About dialog is migrated to i18n; all new user-facing strings use `t()` with keys added to `en.json`.
- The startup check and the Updates settings section are gated behind `isTauri()`.

## Verification

Drove the real app with Playwright, mocking the GitHub releases API, in **both light and dark themes**:
- Part 1: up-to-date checkmark computes to emerald (green) in both themes.
- Part 2: About "available" state renders the changelog, numbered install steps, and download button.
- Part 3: startup modal appears automatically on launch (with `__TAURI_INTERNALS__` injected to exercise the desktop path); "Skip this version" writes `geolibre.updateDismissedVersion` and suppresses the modal on reload.
- Part 4: Settings → Updates renders the toggle and dropdown; turning the toggle off disables the dropdown.

`npm run build`, `npm run test:frontend` (1248 pass), and `pre-commit run --files` all pass.

Fixes #605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a desktop-only startup update notification modal with severity, version details, a compact changelog, and step-by-step download instructions.
  * Added an **Updates** settings section to control “check on startup” and notification scope (all/minor/major), including dismiss/skip behavior.
* **Bug Fixes**
  * Improved update checking reliability and localized update/error messaging, including better rate-limit and missing-release handling.
* **Style**
  * Refined the “up to date” indicator styling for light and dark themes.
* **Documentation**
  * Expanded About/Updates text for complete localization support.
* **Tests**
  * Added coverage for update-fetching and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->