### PR TITLE
fix(map): maximize the whole workspace on fullscreen so panels don't overlap the map

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -1229,7 +1229,7 @@ export function DesktopShell({
       // panels + map) rather than just the map container, so the side panels lay
       // out instead of overlapping the map on WebKit. See map-controller's
       // addFullscreenControl and opengeos/GeoLibre#611.
-      data-fullscreen-root=""
+      data-geolibre-fullscreen-root=""
       className="relative flex h-full min-w-0 flex-col overflow-hidden bg-background"
       style={shellStyle}
       onDragEnter={handleDragEnter}

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -1225,6 +1225,11 @@ export function DesktopShell({
   return (
     <div
       ref={shellRef}
+      // The map's Fullscreen control maximizes this whole workspace (toolbar +
+      // panels + map) rather than just the map container, so the side panels lay
+      // out instead of overlapping the map on WebKit. See map-controller's
+      // addFullscreenControl and opengeos/GeoLibre#611.
+      data-fullscreen-root=""
       className="relative flex h-full min-w-0 flex-col overflow-hidden bg-background"
       style={shellStyle}
       onDragEnter={handleDragEnter}

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -361,6 +361,33 @@ export function DesktopShell({
   useEffect(() => {
     setBookmarkCaptureLabel(t("bookmark.captureStateLabel"));
   }, [t]);
+  // The map's Fullscreen control maximizes the map *canvas* (it calls
+  // requestFullscreen on the map container). Chromium promotes that element to
+  // the browser top layer, so the toolbar and side panels are hidden for free.
+  // WebKit (the Tauri desktop webview) does not: it grows the map container to
+  // fill the window but leaves the surrounding chrome painted around and on top
+  // of it (opengeos/GeoLibre#611). Mirror the fullscreen state onto the shell as
+  // `data-map-fullscreen` so CSS can hide that chrome on every engine, leaving a
+  // clean map-only view. document.fullscreenElement is set even on WebKit.
+  useEffect(() => {
+    const shell = shellRef.current;
+    if (!shell) return;
+    const sync = () => {
+      const fsEl =
+        document.fullscreenElement ??
+        (document as Document & { webkitFullscreenElement?: Element | null })
+          .webkitFullscreenElement ??
+        null;
+      shell.toggleAttribute("data-map-fullscreen", !!fsEl && shell.contains(fsEl));
+    };
+    document.addEventListener("fullscreenchange", sync);
+    document.addEventListener("webkitfullscreenchange", sync);
+    sync();
+    return () => {
+      document.removeEventListener("fullscreenchange", sync);
+      document.removeEventListener("webkitfullscreenchange", sync);
+    };
+  }, []);
   // Teardown for an in-progress panel resize, so a pointercancel or an unmount
   // mid-drag still detaches the global listeners and restores document.body.
   const activeResizeCleanupRef = useRef<(() => void) | null>(null);
@@ -1225,11 +1252,6 @@ export function DesktopShell({
   return (
     <div
       ref={shellRef}
-      // The map's Fullscreen control maximizes this whole workspace (toolbar +
-      // panels + map) rather than just the map container, so the side panels lay
-      // out instead of overlapping the map on WebKit. See map-controller's
-      // addFullscreenControl and opengeos/GeoLibre#611.
-      data-geolibre-fullscreen-root=""
       className="relative flex h-full min-w-0 flex-col overflow-hidden bg-background"
       style={shellStyle}
       onDragEnter={handleDragEnter}
@@ -1252,7 +1274,10 @@ export function DesktopShell({
           />
         </SectionErrorBoundary>
       ) : null}
-      <div className="relative flex min-h-0 flex-1 flex-col md:flex-row">
+      <div
+        data-workspace-row=""
+        className="relative flex min-h-0 flex-1 flex-col md:flex-row"
+      >
         {layoutOptions.layerPanelVisible ? (
           <SectionErrorBoundary label="Layer panel">
             <LayerPanel

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -2249,3 +2249,25 @@ html.dark .maplibregl-popup-anchor-right:has(.vector-control-popup) .maplibregl-
 .dark .overture-popup-content.overture-popup-content.overture-popup-content {
   color-scheme: dark;
 }
+
+/* Map-only fullscreen (opengeos/GeoLibre#611).
+ *
+ * The map Fullscreen control maximizes the map canvas (requestFullscreen on the
+ * map container). Chromium pulls that element into the browser top layer, so the
+ * workspace chrome is hidden automatically. WebKit (the Tauri desktop webview)
+ * does not, leaving the toolbar and side panels painted around and on top of the
+ * map. DesktopShell mirrors the fullscreen state onto the shell as
+ * `data-map-fullscreen`; collapse everything except the map so the canvas owns
+ * the whole window on every engine.
+ *
+ * The shell is `flex flex-col`: its direct children are the toolbar, the
+ * workspace row (Layers + map + Style), the attribute table, and the status bar.
+ * Hide all of them except the row, then within the row hide everything except
+ * the `<main>` map landmark, which flexes to fill. */
+[data-map-fullscreen] > *:not([data-workspace-row]) {
+  display: none !important;
+}
+
+[data-map-fullscreen] [data-workspace-row] > *:not(main) {
+  display: none !important;
+}

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -1591,7 +1591,22 @@ export class MapController {
     ) {
       return false;
     }
-    this.fullscreenControl = new maplibregl.FullscreenControl();
+    // Fullscreen the whole workspace shell (toolbar + side panels + map), not
+    // just the map container. MapLibre's default container is `map.getContainer()`,
+    // a div nested inside `<main>`; the Layers/Style panels are `<aside>` siblings
+    // of `<main>`. Chromium promotes the fullscreen element to the top layer so the
+    // sibling panels are hidden, but WebKit (WKWebView on macOS, WebKitGTK on Linux,
+    // i.e. the Tauri desktop webview) does not, leaving the panels painted on top of
+    // and overlapping the maximized map (opengeos/GeoLibre#611). Targeting an ancestor
+    // that contains the panels lets flexbox lay everything out with no overlap on
+    // every engine. The shell marks itself with `data-fullscreen-root`; fall back to
+    // the map container when no such ancestor exists (e.g. a bare embed).
+    const mapContainer = this.map.getContainer();
+    const fullscreenContainer =
+      mapContainer.closest<HTMLElement>("[data-fullscreen-root]") ?? mapContainer;
+    this.fullscreenControl = new maplibregl.FullscreenControl({
+      container: fullscreenContainer,
+    });
     this.map.addControl(
       this.fullscreenControl,
       this.controlPositions.fullscreen,

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -1599,11 +1599,15 @@ export class MapController {
     // i.e. the Tauri desktop webview) does not, leaving the panels painted on top of
     // and overlapping the maximized map (opengeos/GeoLibre#611). Targeting an ancestor
     // that contains the panels lets flexbox lay everything out with no overlap on
-    // every engine. The shell marks itself with `data-fullscreen-root`; fall back to
-    // the map container when no such ancestor exists (e.g. a bare embed).
+    // every engine. The shell marks itself with `data-geolibre-fullscreen-root`;
+    // fall back to the map container when no such ancestor exists (e.g. a bare
+    // embed). The attribute is namespaced so a plugin rendering DOM between the
+    // map container and the shell can't accidentally match and short-circuit
+    // `closest()` to the wrong ancestor.
     const mapContainer = this.map.getContainer();
     const fullscreenContainer =
-      mapContainer.closest<HTMLElement>("[data-fullscreen-root]") ?? mapContainer;
+      mapContainer.closest<HTMLElement>("[data-geolibre-fullscreen-root]") ??
+      mapContainer;
     this.fullscreenControl = new maplibregl.FullscreenControl({
       container: fullscreenContainer,
     });

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -1591,26 +1591,14 @@ export class MapController {
     ) {
       return false;
     }
-    // Fullscreen the whole workspace shell (toolbar + side panels + map), not
-    // just the map container. MapLibre's default container is `map.getContainer()`,
-    // a div nested inside `<main>`; the Layers/Style panels are `<aside>` siblings
-    // of `<main>`. Chromium promotes the fullscreen element to the top layer so the
-    // sibling panels are hidden, but WebKit (WKWebView on macOS, WebKitGTK on Linux,
-    // i.e. the Tauri desktop webview) does not, leaving the panels painted on top of
-    // and overlapping the maximized map (opengeos/GeoLibre#611). Targeting an ancestor
-    // that contains the panels lets flexbox lay everything out with no overlap on
-    // every engine. The shell marks itself with `data-geolibre-fullscreen-root`;
-    // fall back to the map container when no such ancestor exists (e.g. a bare
-    // embed). The attribute is namespaced so a plugin rendering DOM between the
-    // map container and the shell can't accidentally match and short-circuit
-    // `closest()` to the wrong ancestor.
-    const mapContainer = this.map.getContainer();
-    const fullscreenContainer =
-      mapContainer.closest<HTMLElement>("[data-geolibre-fullscreen-root]") ??
-      mapContainer;
-    this.fullscreenControl = new maplibregl.FullscreenControl({
-      container: fullscreenContainer,
-    });
+    // Fullscreen the map container so only the map canvas (and its floating
+    // controls) fills the screen. MapLibre defaults to `map.getContainer()`,
+    // which is what we want here. The surrounding workspace chrome (toolbar and
+    // side panels) is hidden by the app while fullscreen is active: Chromium
+    // promotes the fullscreen element to the top layer so the chrome is hidden
+    // automatically, but WebKit (the Tauri desktop webview) leaves it painted
+    // around the map, so the app hides it via CSS. See opengeos/GeoLibre#611.
+    this.fullscreenControl = new maplibregl.FullscreenControl();
     this.map.addControl(
       this.fullscreenControl,
       this.controlPositions.fullscreen,


### PR DESCRIPTION
## Summary

Fixes #611 — the Fullscreen ("Maximize View") map control left the right Style sidebar (and toolbar) painted over the maximized map. With the sidebar collapsed, its rail text bled over the map; with it expanded, the panel covered the map controls.

Clicking Fullscreen now gives a clean **map-only** view: the map canvas fills the window with its floating controls, and the toolbar and side panels are hidden.

## Root cause

The MapLibre `FullscreenControl` fullscreens the map container (`map.getContainer()`). Chromium promotes that element to the browser top layer, which hides the surrounding chrome, so the web build looked fine. WebKit (WKWebView on macOS, WebKitGTK on Linux — the Tauri desktop webview the reporter was on) does **not**: it grows the map container to fill the window but leaves the toolbar and `<aside>` side panels painted around and on top of it.

## Fix

Keep fullscreening the map canvas. `DesktopShell` now mirrors the fullscreen state onto the shell as `data-map-fullscreen` (from `document` `fullscreenchange`/`webkitfullscreenchange`, which is set even on WebKit), and CSS collapses everything except the map's `<main>` landmark. This produces a clean map-only canvas on every engine; the chrome restores on exit.

Files: `packages/map/src/map-controller.ts` (comment only — control unchanged), `apps/geolibre-desktop/src/components/layout/DesktopShell.tsx` (fullscreen listener + `data-workspace-row` marker), `apps/geolibre-desktop/src/index.css` (map-only rules).

## Verification

Drove the real app with Playwright in **light and dark** themes:

- Clicking Fullscreen fullscreens the map container and sets `data-map-fullscreen`; toolbar and both side panels (collapsed rail and expanded Style panel) are hidden — only the map canvas and its floating controls remain.
- Simulated the WebKit case (set `data-map-fullscreen` without the top layer): CSS alone hides all chrome, confirming the fix is engine-independent.
- Exiting fullscreen restores the toolbar and panels.

`npm run build` and `pre-commit run --files` both pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fullscreen map mode now hides all surrounding UI elements (toolbars, panels, status bar, attribute table) for an immersive viewing experience
  * Browser fullscreen state properly syncs with the application interface across all platforms

* **Documentation**
  * Added technical documentation explaining fullscreen behavior and platform-specific implementation details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->