### PR TITLE
feat(processing): interactive sidecar help banner for the Whitebox toolbox

### DIFF
--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -61,6 +61,7 @@ import {
 } from "../../lib/tauri-io";
 import { fetchableUrl } from "../../lib/url-utils";
 import { startGeoLibreSidecar, stopGeoLibreSidecar } from "../../lib/sidecar";
+import { SidecarHelpBanner } from "./SidecarHelpBanner";
 
 interface ProcessingDialogProps {
   mapControllerRef: React.RefObject<MapController | null>;
@@ -1096,11 +1097,23 @@ export function ProcessingDialog({
             </ScrollArea>
 
             <div className="grid gap-2 border-t pt-3">
-              {error && (
-                <p className="flex items-center gap-2 text-sm text-destructive">
-                  <AlertCircle className="h-4 w-4" />
-                  {error}
-                </p>
+              {/* Sidecar mode but the server is unreachable: show interactive
+                  troubleshooting with a one-click switch to the WASM runner.
+                  Otherwise fall back to a plain error line (e.g. a parameter or
+                  tool-run error that has nothing to do with the sidecar). */}
+              {!runLocal && runtimeAvailable === false ? (
+                <SidecarHelpBanner
+                  isDesktop={isTauri()}
+                  error={error}
+                  onRunLocally={() => setRunLocal(true)}
+                />
+              ) : (
+                error && (
+                  <p className="flex items-center gap-2 text-sm text-destructive">
+                    <AlertCircle className="h-4 w-4" />
+                    {error}
+                  </p>
+                )
               )}
               {job && (
                 <JobOutputPanel job={job} />

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -1105,7 +1105,13 @@ export function ProcessingDialog({
                 <SidecarHelpBanner
                   isDesktop={isTauri()}
                   error={error}
-                  onRunLocally={() => setRunLocal(true)}
+                  onRunLocally={() => {
+                    // Clear the stale sidecar error in the same batch as the
+                    // mode switch, so it cannot flash as a plain error line on
+                    // the render before loadWhitebox resets it.
+                    setError(null);
+                    setRunLocal(true);
+                  }}
                 />
               ) : (
                 error && (

--- a/apps/geolibre-desktop/src/components/processing/SidecarHelpBanner.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SidecarHelpBanner.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@geolibre/ui";
 import { AlertTriangle, ChevronDown, ChevronRight, Zap } from "lucide-react";
-import { useState } from "react";
+import { useId, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 // The local loopback address the Python sidecar listens on. Kept out of the
@@ -44,6 +44,9 @@ export function SidecarHelpBanner({
 }: SidecarHelpBannerProps) {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
+  // A unique id keeps the aria-controls association valid even if two banners
+  // are ever rendered on the same page (a hardcoded id would collide).
+  const helpId = useId();
 
   return (
     <div className="rounded-md border border-amber-500/40 bg-amber-500/10 text-sm">
@@ -51,10 +54,13 @@ export function SidecarHelpBanner({
         type="button"
         className="flex w-full items-start gap-2 px-3 py-2 text-left"
         aria-expanded={expanded}
-        aria-controls="sidecar-help-details"
+        aria-controls={helpId}
         onClick={() => setExpanded((value) => !value)}
       >
-        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+        <AlertTriangle
+          aria-hidden="true"
+          className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400"
+        />
         <span className="min-w-0 flex-1">
           <span className="block font-medium text-foreground">
             {t("processing.sidecar.unavailableTitle")}
@@ -71,15 +77,21 @@ export function SidecarHelpBanner({
           </span>
         </span>
         {expanded ? (
-          <ChevronDown className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+          <ChevronDown
+            aria-hidden="true"
+            className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground"
+          />
         ) : (
-          <ChevronRight className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+          <ChevronRight
+            aria-hidden="true"
+            className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground"
+          />
         )}
       </button>
 
       {expanded && (
         <div
-          id="sidecar-help-details"
+          id={helpId}
           className="grid gap-3 border-t border-amber-500/30 px-3 py-3"
         >
           <p className="text-xs leading-relaxed text-muted-foreground">

--- a/apps/geolibre-desktop/src/components/processing/SidecarHelpBanner.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SidecarHelpBanner.tsx
@@ -54,7 +54,9 @@ export function SidecarHelpBanner({
         type="button"
         className="flex w-full items-start gap-2 px-3 py-2 text-left"
         aria-expanded={expanded}
-        aria-controls={helpId}
+        // Only reference the panel while it is in the DOM; the collapsed banner
+        // doesn't render it, and aria-controls must point at an existing node.
+        aria-controls={expanded ? helpId : undefined}
         onClick={() => setExpanded((value) => !value)}
       >
         <AlertTriangle
@@ -101,7 +103,10 @@ export function SidecarHelpBanner({
           {onRunLocally && (
             <div className="grid gap-2 rounded-md border border-border bg-background/60 p-2.5">
               <p className="flex items-center gap-1.5 text-xs font-medium text-foreground">
-                <Zap className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400" />
+                <Zap
+                  aria-hidden="true"
+                  className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400"
+                />
                 {t("processing.sidecar.wasmTipTitle")}
               </p>
               <p className="text-xs text-muted-foreground">
@@ -114,7 +119,7 @@ export function SidecarHelpBanner({
                 className="justify-self-start"
                 onClick={onRunLocally}
               >
-                <Zap className="h-3.5 w-3.5" />
+                <Zap aria-hidden="true" className="h-3.5 w-3.5" />
                 {t("processing.sidecar.runLocallyButton")}
               </Button>
             </div>

--- a/apps/geolibre-desktop/src/components/processing/SidecarHelpBanner.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SidecarHelpBanner.tsx
@@ -3,6 +3,12 @@ import { AlertTriangle, ChevronDown, ChevronRight, Zap } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
+// The local loopback address the Python sidecar listens on. Kept out of the
+// translatable strings (injected via interpolation) so translators can't garble
+// it and a future change to the address only touches one place.
+const SIDECAR_URL = "http://127.0.0.1:8765";
+const SIDECAR_PORT = "8765";
+
 interface SidecarHelpBannerProps {
   /**
    * Whether the app runs under Tauri (the desktop build). The processing
@@ -44,6 +50,7 @@ export function SidecarHelpBanner({
         type="button"
         className="flex w-full items-start gap-2 px-3 py-2 text-left"
         aria-expanded={expanded}
+        aria-controls="sidecar-help-details"
         onClick={() => setExpanded((value) => !value)}
       >
         <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
@@ -70,9 +77,12 @@ export function SidecarHelpBanner({
       </button>
 
       {expanded && (
-        <div className="grid gap-3 border-t border-amber-500/30 px-3 py-3">
+        <div
+          id="sidecar-help-details"
+          className="grid gap-3 border-t border-amber-500/30 px-3 py-3"
+        >
           <p className="text-xs leading-relaxed text-muted-foreground">
-            {t("processing.sidecar.intro")}
+            {t("processing.sidecar.intro", { sidecarUrl: SIDECAR_URL })}
           </p>
 
           {onRunLocally && (
@@ -107,7 +117,7 @@ export function SidecarHelpBanner({
                   ? t("processing.sidecar.stepStartServerDesktop")
                   : t("processing.sidecar.stepStartServerBrowser")}
               </li>
-              <li>{t("processing.sidecar.stepCheckPort")}</li>
+              <li>{t("processing.sidecar.stepCheckPort", { port: SIDECAR_PORT })}</li>
               <li>{t("processing.sidecar.stepRestart")}</li>
             </ol>
           </div>

--- a/apps/geolibre-desktop/src/components/processing/SidecarHelpBanner.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SidecarHelpBanner.tsx
@@ -5,9 +5,10 @@ import { useTranslation } from "react-i18next";
 
 // The local loopback address the Python sidecar listens on. Kept out of the
 // translatable strings (injected via interpolation) so translators can't garble
-// it and a future change to the address only touches one place.
+// it and a future change to the address only touches one place. The port is
+// derived from the URL so the two can never drift apart.
 const SIDECAR_URL = "http://127.0.0.1:8765";
-const SIDECAR_PORT = "8765";
+const SIDECAR_PORT = new URL(SIDECAR_URL).port;
 
 interface SidecarHelpBannerProps {
   /**

--- a/apps/geolibre-desktop/src/components/processing/SidecarHelpBanner.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SidecarHelpBanner.tsx
@@ -1,0 +1,118 @@
+import { Button } from "@geolibre/ui";
+import { AlertTriangle, ChevronDown, ChevronRight, Zap } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+interface SidecarHelpBannerProps {
+  /**
+   * Whether the app runs under Tauri (the desktop build). The processing
+   * server can only be launched from the desktop app, so the troubleshooting
+   * steps differ between desktop and the browser.
+   */
+  isDesktop: boolean;
+  /**
+   * The most recent action error (e.g. a failed "Start server"), surfaced as
+   * extra context above the troubleshooting steps. Optional.
+   */
+  error?: string | null;
+  /**
+   * Switch the dialog to the in-browser WebAssembly runner, which needs no
+   * processing server. Provided only when a WASM fallback exists for the tool
+   * set (Whitebox), in which case the banner offers a one-click switch.
+   */
+  onRunLocally?: () => void;
+}
+
+/**
+ * Interactive help banner shown when a processing tool needs the optional
+ * Python sidecar but it is unavailable. Instead of a single static error line,
+ * it explains in plain language what the sidecar is and expands to a
+ * step-by-step resolution path, including a one-click switch to the WebAssembly
+ * runner that needs no sidecar at all.
+ */
+export function SidecarHelpBanner({
+  isDesktop,
+  error,
+  onRunLocally,
+}: SidecarHelpBannerProps) {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="rounded-md border border-amber-500/40 bg-amber-500/10 text-sm">
+      <button
+        type="button"
+        className="flex w-full items-start gap-2 px-3 py-2 text-left"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((value) => !value)}
+      >
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+        <span className="min-w-0 flex-1">
+          <span className="block font-medium text-foreground">
+            {t("processing.sidecar.unavailableTitle")}
+          </span>
+          {error && (
+            <span className="mt-0.5 block break-words text-xs text-destructive">
+              {error}
+            </span>
+          )}
+          <span className="mt-0.5 block text-xs text-muted-foreground">
+            {expanded
+              ? t("processing.sidecar.hideHelp")
+              : t("processing.sidecar.showHelp")}
+          </span>
+        </span>
+        {expanded ? (
+          <ChevronDown className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+        )}
+      </button>
+
+      {expanded && (
+        <div className="grid gap-3 border-t border-amber-500/30 px-3 py-3">
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            {t("processing.sidecar.intro")}
+          </p>
+
+          {onRunLocally && (
+            <div className="grid gap-2 rounded-md border border-border bg-background/60 p-2.5">
+              <p className="flex items-center gap-1.5 text-xs font-medium text-foreground">
+                <Zap className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400" />
+                {t("processing.sidecar.wasmTipTitle")}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {t("processing.sidecar.wasmTip")}
+              </p>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="justify-self-start"
+                onClick={onRunLocally}
+              >
+                <Zap className="h-3.5 w-3.5" />
+                {t("processing.sidecar.runLocallyButton")}
+              </Button>
+            </div>
+          )}
+
+          <div className="grid gap-1.5">
+            <p className="text-xs font-medium text-foreground">
+              {t("processing.sidecar.troubleshootingTitle")}
+            </p>
+            <ol className="grid list-decimal gap-1 pl-5 text-xs text-muted-foreground">
+              <li>
+                {isDesktop
+                  ? t("processing.sidecar.stepStartServerDesktop")
+                  : t("processing.sidecar.stepStartServerBrowser")}
+              </li>
+              <li>{t("processing.sidecar.stepCheckPort")}</li>
+              <li>{t("processing.sidecar.stepRestart")}</li>
+            </ol>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1475,6 +1475,20 @@
       "allSources": "All sources",
       "geolibreTools": "GeoLibre tools",
       "whiteboxTools": "Whitebox tools"
+    },
+    "sidecar": {
+      "unavailableTitle": "The processing server isn't available.",
+      "showHelp": "Show what this means and how to fix it",
+      "hideHelp": "Hide details",
+      "intro": "The processing server is an optional local helper (http://127.0.0.1:8765) that runs heavier Python-backed tools in the background, separate from the app. Most Whitebox tools don't need it: they can run entirely in your browser with WebAssembly.",
+      "wasmTipTitle": "Run without the server",
+      "wasmTip": "Enable \"Run locally (WASM)\" to run Whitebox tools in your browser. No server, install, or setup required.",
+      "runLocallyButton": "Run locally (WASM)",
+      "troubleshootingTitle": "Still want to use the server?",
+      "stepStartServerDesktop": "Click \"Start server\" above to launch it, then wait a few seconds for it to come online.",
+      "stepStartServerBrowser": "The server can only be started from the GeoLibre desktop app. In the browser, keep \"Run locally (WASM)\" enabled instead.",
+      "stepCheckPort": "Make sure a firewall, antivirus, or network policy isn't blocking local port 8765.",
+      "stepRestart": "If the server stopped unexpectedly, restart the app and reopen this dialog."
     }
   },
   "segmentation": {

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1480,14 +1480,14 @@
       "unavailableTitle": "The processing server isn't available.",
       "showHelp": "Show what this means and how to fix it",
       "hideHelp": "Hide details",
-      "intro": "The processing server is an optional local helper (http://127.0.0.1:8765) that runs heavier Python-backed tools in the background, separate from the app. Most Whitebox tools don't need it: they can run entirely in your browser with WebAssembly.",
+      "intro": "The processing server is an optional local helper ({{sidecarUrl}}) that runs heavier Python-backed tools in the background, separate from the app. Most Whitebox tools don't need it: they can run entirely in your browser with WebAssembly.",
       "wasmTipTitle": "Run without the server",
       "wasmTip": "Enable \"Run locally (WASM)\" to run Whitebox tools in your browser. No server, install, or setup required.",
       "runLocallyButton": "Run locally (WASM)",
       "troubleshootingTitle": "Still want to use the server?",
-      "stepStartServerDesktop": "Click \"Start server\" above to launch it, then wait a few seconds for it to come online.",
+      "stepStartServerDesktop": "Click \"Start server\" in the tool list panel to launch it, then wait a few seconds for it to come online.",
       "stepStartServerBrowser": "The server can only be started from the GeoLibre desktop app. In the browser, keep \"Run locally (WASM)\" enabled instead.",
-      "stepCheckPort": "Make sure a firewall, antivirus, or network policy isn't blocking local port 8765.",
+      "stepCheckPort": "Make sure a firewall, antivirus, or network policy isn't blocking local port {{port}}.",
       "stepRestart": "If the server stopped unexpectedly, restart the app and reopen this dialog."
     }
   },

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1488,7 +1488,7 @@
       "stepStartServerDesktop": "Click \"Start server\" in the tool list panel to launch it, then wait a few seconds for it to come online.",
       "stepStartServerBrowser": "The server can only be started from the GeoLibre desktop app. In the browser, keep \"Run locally (WASM)\" enabled instead.",
       "stepCheckPort": "Make sure a firewall, antivirus, or network policy isn't blocking local port {{port}}.",
-      "stepRestart": "If the server stopped unexpectedly, restart the app and reopen this dialog."
+      "stepRestart": "If the server stopped unexpectedly, restart the GeoLibre desktop app and reopen this dialog."
     }
   },
   "segmentation": {


### PR DESCRIPTION
## Summary

Addresses #586. When the Whitebox toolbox needs the optional Python processing server (sidecar) but it is unavailable, the dialog used to show a single static error line ("Could not connect to the GeoLibre sidecar..." / "Could not start GeoLibre sidecar."). This replaces that with an **interactive, expandable help banner**.

Since WASM is now the default runner and most Whitebox tools need no sidecar at all, the banner leads with the most useful action: a one-click **Run locally (WASM)** switch that resolves the problem immediately, then offers a plain-language explanation and a step-by-step resolution path.

## What changed

- New `SidecarHelpBanner` component: a clickable banner that expands to show
  - a plain-language explanation of what the processing server is (`http://127.0.0.1:8765`, optional, for heavier Python-backed tools),
  - a highlighted "Run without the server" tip with a one-click **Run locally (WASM)** button, and
  - numbered troubleshooting steps tailored to **desktop vs. browser** (Start server is desktop-only; port 8765 firewall check; restart).
- `ProcessingDialog` shows the banner only when sidecar mode is active and the runtime is unavailable (`!runLocal && runtimeAvailable === false`); ordinary parameter/tool-run errors still render as the plain error line.
- All new strings added to `en.json` (typed via `i18next.d.ts`); other locales fall back to English.

## Verification

Drove the real app with Playwright (web build) in both **light and dark** themes:

- Default state runs locally with WASM, so no banner appears.
- Unchecking "Run locally (WASM)" with no server reachable shows the new banner; expanding it reveals the explanation, the WASM tip, and the browser-specific troubleshooting steps.
- Clicking **Run locally (WASM)** switches back to the WASM runner and clears the banner ("Running locally with WebAssembly. No sidecar required.").

The desktop-specific step ("Click Start server above...") is the same component with `isDesktop` true; the browser path was exercised end to end.

`npm run build` and `pre-commit run --files <changed paths>` both pass.

Fixes #586


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an expandable help banner shown when the required processing sidecar/server is unreachable, replacing the plain error message.
  * Included a “run locally” option to switch to WebAssembly-based processing and clear the current error.
  * Added a troubleshooting checklist with desktop vs browser specific guidance and local port (8765) instructions.

* **Localization / UX Improvements**
  * Expanded English translations with clearer setup, connectivity/firewall troubleshooting, and restart guidance when the sidecar stops unexpectedly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->