### PR TITLE
fix(new-project): correct title, drop phantom Protomaps mention, make custom URL exclusive

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
@@ -326,7 +326,7 @@ export function NewProjectDialog({
                     />
                     <BasemapButton
                       id={CUSTOM_BASEMAP_ID}
-                      name="Custom URL"
+                      name={t("newProject.customUrlButton")}
                       selected={isCustomSelected}
                       onSelect={setSelectedBasemapId}
                     />

--- a/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
@@ -19,7 +19,7 @@ import {
   Label,
 } from "@geolibre/ui";
 import type { FormEvent } from "react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 const DEFAULT_BASEMAP_ID = "liberty";
@@ -110,6 +110,7 @@ export function NewProjectDialog({
   const [customUrl, setCustomUrl] = useState("");
   const [showSavePrompt, setShowSavePrompt] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  const customUrlRef = useRef<HTMLInputElement>(null);
 
   const customStyleUrl = customUrl.trim();
   const isCustomSelected = selectedBasemapId === CUSTOM_BASEMAP_ID;
@@ -129,6 +130,11 @@ export function NewProjectDialog({
     return () =>
       window.removeEventListener("geolibre:runtime-env-change", refresh);
   }, [open]);
+  // Move focus into the custom URL field the moment the user selects the
+  // "Custom URL" basemap, so the now-unlocked input is ready to type into.
+  useEffect(() => {
+    if (isCustomSelected) customUrlRef.current?.focus();
+  }, [isCustomSelected]);
   const selectedPreset = useMemo<PresetBasemap | undefined>(
     () =>
       [...OPENFREEMAP_BASEMAPS, ...protomapsPresets].find(
@@ -218,7 +224,7 @@ export function NewProjectDialog({
               <DialogTitle>Save current project?</DialogTitle>
               <DialogDescription>
                 The current project has unsaved changes. Save them before
-                creating a new map?
+                creating a new project?
               </DialogDescription>
             </DialogHeader>
             <div className="flex justify-end gap-2">
@@ -250,9 +256,11 @@ export function NewProjectDialog({
         ) : (
           <>
             <DialogHeader>
-              <DialogTitle>New map</DialogTitle>
+              <DialogTitle>New project</DialogTitle>
               <DialogDescription>
-                {t("newProject.basemapDescription")}
+                {protomapsPresets.length > 0
+                  ? t("newProject.basemapDescription")
+                  : t("newProject.basemapDescriptionNoProtomaps")}
               </DialogDescription>
             </DialogHeader>
             <form className="space-y-5" onSubmit={handleCreate}>
@@ -316,22 +324,30 @@ export function NewProjectDialog({
                       selected={selectedBasemapId === BLANK_BASEMAP_ID}
                       onSelect={setSelectedBasemapId}
                     />
+                    <BasemapButton
+                      id={CUSTOM_BASEMAP_ID}
+                      name="Custom URL"
+                      selected={isCustomSelected}
+                      onSelect={setSelectedBasemapId}
+                    />
                   </div>
                 </div>
               </div>
 
+              {/* The custom URL is a mutually exclusive basemap choice: the
+                  field unlocks only when "Custom URL" is selected above, so it
+                  can never compete with a highlighted preset button. */}
               <div className="space-y-2">
                 <Label htmlFor="custom-basemap-url">Custom URL</Label>
                 <Input
                   id="custom-basemap-url"
+                  ref={customUrlRef}
                   type="url"
                   inputMode="url"
                   placeholder="https://example.com/style.json"
                   value={customUrl}
-                  onChange={(event) => {
-                    setCustomUrl(event.target.value);
-                    setSelectedBasemapId(CUSTOM_BASEMAP_ID);
-                  }}
+                  disabled={!isCustomSelected}
+                  onChange={(event) => setCustomUrl(event.target.value)}
                 />
                 {isCustomSelected && customStyleUrl && !isCustomUrlValid ? (
                   <p className="text-xs text-destructive">

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -60,6 +60,7 @@
   },
   "newProject": {
     "basemapDescription": "Choose an OpenFreeMap or Protomaps basemap, a blank background, or a MapLibre style URL.",
+    "basemapDescriptionNoProtomaps": "Choose an OpenFreeMap basemap, a blank background, or a MapLibre style URL.",
     "sectionOpenFreeMap": "OpenFreeMap",
     "sectionProtomaps": "Protomaps",
     "sectionOther": "Other"

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -63,7 +63,8 @@
     "basemapDescriptionNoProtomaps": "Choose an OpenFreeMap basemap, a blank background, or a MapLibre style URL.",
     "sectionOpenFreeMap": "OpenFreeMap",
     "sectionProtomaps": "Protomaps",
-    "sectionOther": "Other"
+    "sectionOther": "Other",
+    "customUrlButton": "Custom URL"
   },
   "common": {
     "pickColorFromScreen": "Pick a color from the screen",


### PR DESCRIPTION
## Summary

Addresses #606. Three terminology / workflow rough edges in the **New Project** dialog:

1. **Title said "New map".** The dialog is opened by Project → New, so the header now reads **New project** (and the unsaved-changes prompt now says "creating a new project").
2. **Phantom Protomaps option.** The description always invited the user to "Choose an OpenFreeMap or Protomaps basemap...", but the Protomaps section only renders when a Protomaps API key is configured (`VITE_PROTOMAPS_API_KEY`). When that section is hidden, the description now drops the Protomaps mention, so users no longer hunt for an option that isn't there.
3. **Ambiguous Custom URL state.** The Custom URL field used to be editable while a preset basemap (e.g. "Liberty") stayed highlighted, with no indication which one wins. It is now a mutually exclusive choice: a new **Custom URL** button in the "Other" section unlocks (and focuses) the field, and selecting any preset locks the field again.

The reporter also asked to reorder the fields so the project name comes first. That is already the case in the current code (the name field is the first input), so no change was needed there.

## Verification

Drove the real app with Playwright (web build) in both **light and dark** themes:

- Title shows "New project"; description reads "Choose an OpenFreeMap basemap, a blank background, or a MapLibre style URL." (no Protomaps, since no key is configured).
- The Custom URL input is disabled while "Liberty" is selected.
- Clicking the new "Custom URL" button deselects the preset, enables and focuses the field; entering a valid URL enables Create; selecting a preset again disables and clears the highlight. Mutual exclusivity holds both directions.

`npm run build` and `pre-commit run --files <changed paths>` both pass.

Fixes #606


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added "Custom URL" basemap option to the new project dialog, allowing users to specify custom basemap URLs
  - Custom URL input field automatically receives focus when this option is selected

* **Improvements**
  - Updated the new project creation confirmation prompt text
  - Project creation dialog description now conditionally displays based on available basemap options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->