### PR TITLE
fix(settings): restructure the Map constraints panel (#591)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -1017,6 +1017,7 @@ export function SettingsDialog({
                       type="button"
                       size="sm"
                       variant="outline"
+                      title={t("settings.map.useCurrentViewHint")}
                       onClick={applyCurrentViewBounds}
                     >
                       <Crosshair className="h-3.5 w-3.5" />
@@ -1038,7 +1039,7 @@ export function SettingsDialog({
                           className={
                             draftPreferences.map.restrictBounds
                               ? undefined
-                              : "opacity-50"
+                              : "cursor-not-allowed opacity-50"
                           }
                         >
                           {t(labelKey)}

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -988,9 +988,6 @@ export function SettingsDialog({
                       <h3 className="text-sm font-semibold">
                         {t("settings.map.constraintsTitle")}
                       </h3>
-                      <p className="text-xs text-muted-foreground">
-                        {t("settings.map.constraintsDescription")}
-                      </p>
                     </div>
                     <Button
                       type="button"
@@ -1002,19 +999,30 @@ export function SettingsDialog({
                       {t("common.reset")}
                     </Button>
                   </div>
-                  <label className="flex items-center gap-2 text-sm">
-                    <input
-                      className="h-4 w-4"
-                      type="checkbox"
-                      checked={draftPreferences.map.restrictBounds}
-                      onChange={(event) =>
-                        updateMapPreferences({
-                          restrictBounds: event.target.checked,
-                        })
-                      }
-                    />
-                    {t("settings.map.restrictBounds")}
-                  </label>
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <label className="flex items-center gap-2 text-sm">
+                      <input
+                        className="h-4 w-4"
+                        type="checkbox"
+                        checked={draftPreferences.map.restrictBounds}
+                        onChange={(event) =>
+                          updateMapPreferences({
+                            restrictBounds: event.target.checked,
+                          })
+                        }
+                      />
+                      {t("settings.map.restrictBounds")}
+                    </label>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={applyCurrentViewBounds}
+                    >
+                      <Crosshair className="h-3.5 w-3.5" />
+                      {t("settings.map.useCurrentView")}
+                    </Button>
+                  </div>
                   <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
                     {(
                       [
@@ -1025,7 +1033,14 @@ export function SettingsDialog({
                       ] as const
                     ).map(([labelKey, index, min, max]) => (
                       <div key={labelKey} className="space-y-1.5">
-                        <Label htmlFor={`settings-bounds-${index}`}>
+                        <Label
+                          htmlFor={`settings-bounds-${index}`}
+                          className={
+                            draftPreferences.map.restrictBounds
+                              ? undefined
+                              : "opacity-50"
+                          }
+                        >
                           {t(labelKey)}
                         </Label>
                         <Input
@@ -1034,6 +1049,7 @@ export function SettingsDialog({
                           min={min}
                           max={max}
                           step="0.000001"
+                          disabled={!draftPreferences.map.restrictBounds}
                           value={draftPreferences.map.bounds[index as number]}
                           onChange={(event) =>
                             updateBoundsValue(
@@ -1045,15 +1061,6 @@ export function SettingsDialog({
                       </div>
                     ))}
                   </div>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    onClick={applyCurrentViewBounds}
-                  >
-                    <Crosshair className="h-3.5 w-3.5" />
-                    {t("settings.map.useCurrentView")}
-                  </Button>
                   {liveProjection === "globe" ? (
                     <p className="flex items-start gap-1.5 text-xs text-muted-foreground">
                       <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-600 dark:text-amber-400" />

--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -30,7 +30,6 @@
     },
     "map": {
       "constraintsTitle": "Kartenbeschränkungen",
-      "constraintsDescription": "Einschränkungen gelten, solange das Projekt geöffnet ist.",
       "restrictBounds": "Kartenausschnitt einschränken",
       "west": "West",
       "south": "Süd",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -758,6 +758,7 @@
       "east": "East",
       "north": "North",
       "useCurrentView": "Use Current View",
+      "useCurrentViewHint": "Captures the current map extent and turns on Restrict map bounds.",
       "useCurrentViewGlobeHint": "Switch to the Mercator projection before using this. In the Globe projection the map can still drift slightly beyond the captured bounds.",
       "minZoom": "Min zoom",
       "maxZoom": "Max zoom",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -752,7 +752,6 @@
     },
     "map": {
       "constraintsTitle": "Map constraints",
-      "constraintsDescription": "Limits apply while the project is open.",
       "restrictBounds": "Restrict map bounds",
       "west": "West",
       "south": "South",

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -30,7 +30,6 @@
     },
     "map": {
       "constraintsTitle": "Restricciones del mapa",
-      "constraintsDescription": "Las restricciones se aplican mientras el proyecto está abierto.",
       "restrictBounds": "Restringir los límites del mapa",
       "west": "Oeste",
       "south": "Sur",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -30,7 +30,6 @@
     },
     "map": {
       "constraintsTitle": "Contraintes de carte",
-      "constraintsDescription": "Les limites s'appliquent tant que le projet est ouvert.",
       "restrictBounds": "Restreindre l'étendue de la carte",
       "west": "Ouest",
       "south": "Sud",

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -30,7 +30,6 @@
     },
     "map": {
       "constraintsTitle": "मानचित्र सीमाएं",
-      "constraintsDescription": "प्रोजेक्ट खुला रहने के दौरान सीमाएं लागू होती हैं।",
       "restrictBounds": "मानचित्र सीमा प्रतिबंधित करें",
       "west": "पश्चिम",
       "south": "दक्षिण",

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -30,7 +30,6 @@
     },
     "map": {
       "constraintsTitle": "Batasan peta",
-      "constraintsDescription": "Batasan berlaku saat proyek dibuka.",
       "restrictBounds": "Batasi batas peta",
       "west": "Barat",
       "south": "Selatan",

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -30,7 +30,6 @@
     },
     "map": {
       "constraintsTitle": "Vincoli mappa",
-      "constraintsDescription": "I limiti si applicano mentre il progetto è aperto.",
       "restrictBounds": "Limita l'estensione della mappa",
       "west": "Ovest",
       "south": "Sud",

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -30,7 +30,6 @@
     },
     "map": {
       "constraintsTitle": "マップ制約",
-      "constraintsDescription": "制限はプロジェクトが開いている間のみ適用されます。",
       "restrictBounds": "マップ範囲を制限する",
       "west": "西",
       "south": "南",

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -30,7 +30,6 @@
     },
     "map": {
       "constraintsTitle": "지도 제약 조건",
-      "constraintsDescription": "프로젝트가 열려 있는 동안 제한이 적용됩니다.",
       "restrictBounds": "지도 범위 제한",
       "west": "서쪽",
       "south": "남쪽",

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -30,7 +30,6 @@
     },
     "map": {
       "constraintsTitle": "Kaartbeperkingen",
-      "constraintsDescription": "Limieten gelden zolang het project open is.",
       "restrictBounds": "Kaartgrenzen beperken",
       "west": "West",
       "south": "Zuid",

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -30,7 +30,6 @@
     },
     "map": {
       "constraintsTitle": "Restrições do mapa",
-      "constraintsDescription": "Os limites aplicam-se enquanto o projeto estiver aberto.",
       "restrictBounds": "Restringir limites do mapa",
       "west": "Oeste",
       "south": "Sul",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -30,7 +30,6 @@
     },
     "map": {
       "constraintsTitle": "Ограничения карты",
-      "constraintsDescription": "Ограничения применяются, пока проект открыт.",
       "restrictBounds": "Ограничить область карты",
       "west": "Запад",
       "south": "Юг",

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -30,7 +30,6 @@
     },
     "map": {
       "constraintsTitle": "Harita kısıtlamaları",
-      "constraintsDescription": "Kısıtlamalar proje açıkken geçerlidir.",
       "restrictBounds": "Harita sınırlarını kısıtla",
       "west": "Batı",
       "south": "Güney",

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -30,7 +30,6 @@
     },
     "map": {
       "constraintsTitle": "地图约束",
-      "constraintsDescription": "约束在项目打开时生效。",
       "restrictBounds": "限制地图范围",
       "west": "西",
       "south": "南",


### PR DESCRIPTION
## Summary

Restructures the **Map constraints** panel in Settings to address the UI/logic feedback in #591. Implements the three points agreed in the issue thread (the Reset button is intentionally left in place per the discussion).

## Changes

- **Removed the redundant subheader.** The "Limits apply while the project is open." line is gone (and the now-unused `settings.map.constraintsDescription` string was dropped from every locale). The panel already lives under project preferences, so the note added nothing.
- **Conditional field activation.** The West / South / East / North inputs (and their labels) are now disabled and grayed out by default. They only become editable when **Restrict map bounds** is checked, so the active state matches whether the bounds are actually enforced.
- **Relocated "Use Current View".** The button now sits on the same row as the **Restrict map bounds** toggle, above the coordinate fields. This makes the workflow read top to bottom: enable bounds, capture the current view, then fine-tune the values.

## Not changed (per issue discussion)

- The **Reset** button stays in the top-right corner. It resets the zoom and pitch limits in addition to the bounds, so it is not specific to the coordinate fields and keeping it at the panel level is correct.

## Verification

Drove the real web app with Playwright and confirmed in **both light and dark themes**:
- No subheader text under the title.
- Coordinate fields render grayed out/disabled when Restrict map bounds is off, and become editable when it is on.
- "Use Current View" appears beside the toggle, above the fields.

`npm run build` and the scoped `pre-commit` hooks pass.

Fixes #591


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restructured the map constraints interface in settings to improve layout and usability.
  * Integrated the "use current view" action into the constraints header.
  * Input fields now dynamically respond to the "restrict bounds" toggle with visual feedback (opacity and disabled states).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->