### PR TITLE
feat(share): progressive setup with separate website/local token steps (#587)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -398,6 +398,10 @@ export function SettingsDialog({
       // Clear so the stale projection can't flash the Globe hint for a frame
       // on the next open before this effect re-reads it.
       setLiveProjection(null);
+      // Drop any pending focus request too: if the dialog closes before the
+      // focus RAF fires, a leftover target would otherwise fire on a later
+      // open that never asked for it.
+      setPendingFocus(null);
       return;
     }
     setDraftPreferences(clonePreferences(useAppStore.getState().preferences));

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -55,7 +55,7 @@ import {
   TriangleAlert,
   Puzzle,
 } from "lucide-react";
-import { useEffect, useMemo, useState, type RefObject } from "react";
+import { useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import {
   DEFAULT_DESKTOP_LAYOUT_SETTINGS,
@@ -95,14 +95,26 @@ export type SettingsSection =
   | "environment"
   | "updates";
 
+/** A field a deep-link can ask Settings to focus once the section renders. */
+export type SettingsFocusTarget = "shareToken";
+
 /** Window event letting any panel open Settings at a given section (no prop-drilling). */
 export const OPEN_SETTINGS_EVENT = "geolibre:open-settings";
 
-/** Open the Settings dialog at `section` from anywhere in the app. */
-export function openSettingsSection(section: SettingsSection): void {
+/**
+ * Open the Settings dialog at `section` from anywhere in the app, optionally
+ * focusing a specific field once that section renders (e.g. the Share dialog
+ * deep-links into Environment Variables and focuses the share token input).
+ */
+export function openSettingsSection(
+  section: SettingsSection,
+  options?: { focus?: SettingsFocusTarget },
+): void {
   if (typeof window === "undefined") return;
   window.dispatchEvent(
-    new CustomEvent(OPEN_SETTINGS_EVENT, { detail: { section } }),
+    new CustomEvent(OPEN_SETTINGS_EVENT, {
+      detail: { section, focus: options?.focus },
+    }),
   );
 }
 
@@ -333,6 +345,12 @@ export function SettingsDialog({
     isMenuItemVisible(desktopSettings.uiProfile, id);
   const [open, setOpen] = useState(false);
   const [section, setSection] = useState<SettingsSection>("map");
+  // A field a deep-link asked us to focus once its section renders; cleared
+  // after the focus lands so a later open without a focus request stays put.
+  const [pendingFocus, setPendingFocus] = useState<SettingsFocusTarget | null>(
+    null,
+  );
+  const shareTokenInputRef = useRef<HTMLInputElement>(null);
   // A gated section is dropped from the nav, but `section` can still point at one
   // (its initial value is "map"), so render the first visible section instead to
   // never expose gated content to a restricted profile.
@@ -395,8 +413,12 @@ export function SettingsDialog({
   // Assistant onboarding card opens Environment Variables to add a provider key).
   useEffect(() => {
     const onOpenSettings = (event: Event) => {
-      const detail = (event as CustomEvent<{ section?: SettingsSection }>)
-        .detail;
+      const detail = (
+        event as CustomEvent<{
+          section?: SettingsSection;
+          focus?: SettingsFocusTarget;
+        }>
+      ).detail;
       // setSection before setOpen so the section is already in state when React
       // renders the open dialog (effectiveSection derives from it at render
       // time). Only honor the request when the active UI profile actually shows
@@ -404,17 +426,36 @@ export function SettingsDialog({
       // another tab. The profile is read fresh (not via the effect's closure) so
       // a profile change after mount is respected.
       const requested = detail?.section;
+      let sectionShown = true;
       if (requested) {
         const gate = SECTION_GATE[requested];
         const profile =
           useDesktopSettingsStore.getState().desktopSettings.uiProfile;
-        if (!gate || isMenuItemVisible(profile, gate)) setSection(requested);
+        sectionShown = !gate || isMenuItemVisible(profile, gate);
+        if (sectionShown) setSection(requested);
       }
+      // Only queue the focus when its target section is actually shown, so the
+      // request can't strand on a tab the profile hid.
+      setPendingFocus(detail?.focus && sectionShown ? detail.focus : null);
       setOpen(true);
     };
     window.addEventListener(OPEN_SETTINGS_EVENT, onOpenSettings);
     return () => window.removeEventListener(OPEN_SETTINGS_EVENT, onOpenSettings);
   }, []);
+
+  // Focus a deep-linked field once its section has rendered. The token input
+  // only mounts when the Environment section is active, so this waits for the
+  // section to settle rather than focusing on open.
+  useEffect(() => {
+    if (!open || pendingFocus !== "shareToken") return;
+    if (effectiveSection !== "environment") return;
+    const id = window.requestAnimationFrame(() => {
+      shareTokenInputRef.current?.focus();
+      shareTokenInputRef.current?.select();
+      setPendingFocus(null);
+    });
+    return () => window.cancelAnimationFrame(id);
+  }, [open, pendingFocus, effectiveSection]);
 
   const toggleValueVisibility = (id: string) => {
     setRevealedValueIds((current) => {
@@ -1620,6 +1661,7 @@ export function SettingsDialog({
                       />
                     </p>
                     <Input
+                      ref={shareTokenInputRef}
                       aria-label={t("settings.env.tokenTitle")}
                       type="password"
                       autoComplete="new-password"

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -426,7 +426,10 @@ export function SettingsDialog({
       // another tab. The profile is read fresh (not via the effect's closure) so
       // a profile change after mount is respected.
       const requested = detail?.section;
-      let sectionShown = true;
+      // Stays false unless a requested section is actually navigated to, so a
+      // focus request without a (shown) section can't strand on whatever tab
+      // happens to be active.
+      let sectionShown = false;
       if (requested) {
         const gate = SECTION_GATE[requested];
         const profile =

--- a/apps/geolibre-desktop/src/components/layout/ShareProjectDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ShareProjectDialog.tsx
@@ -9,8 +9,9 @@ import {
   Label,
   Select,
 } from "@geolibre/ui";
-import { Check, Copy, ExternalLink, Loader2, Share2 } from "lucide-react";
+import { Check, Copy, ExternalLink, KeyRound, Loader2, Share2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { useDesktopSettingsStore } from "../../hooks/useDesktopSettings";
 import { openExternalLink } from "../../lib/open-external";
 import {
@@ -21,6 +22,7 @@ import {
   type ShareUploadResult,
   type ShareVisibility,
 } from "../../lib/share-geolibre";
+import { openSettingsSection } from "./SettingsDialog";
 
 interface ShareProjectDialogProps {
   open: boolean;
@@ -42,6 +44,7 @@ export function ShareProjectDialog({
   currentTitle,
   getProject,
 }: ShareProjectDialogProps) {
+  const { t } = useTranslation();
   const shareToken = useDesktopSettingsStore((s) => s.desktopSettings.shareToken);
   const [title, setTitle] = useState("");
   const [visibility, setVisibility] = useState<ShareVisibility>("unlisted");
@@ -103,7 +106,7 @@ export function ShareProjectDialog({
       setResult(uploaded);
     } catch (err) {
       if (err instanceof DOMException && err.name === "AbortError") return;
-      setError(err instanceof Error ? err.message : "Could not share the project.");
+      setError(err instanceof Error ? err.message : t("share.errorFallback"));
     } finally {
       // Only the controller that is still current clears state, so an aborted
       // (superseded) request never flips a newer one back to idle.
@@ -112,6 +115,13 @@ export function ShareProjectDialog({
         setStatus("idle");
       }
     }
+  };
+
+  // Close this dialog and deep-link into Settings → Environment Variables with
+  // the share token field focused, so the user can paste the token right away.
+  const handleConfigureToken = () => {
+    onOpenChange(false);
+    openSettingsSection("environment", { focus: "shareToken" });
   };
 
   const handleCopy = () => {
@@ -139,41 +149,50 @@ export function ShareProjectDialog({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Share2 className="h-4 w-4" />
-            Share project
+            {t("share.title")}
           </DialogTitle>
-          <DialogDescription>
-            Upload the current project to share.geolibre.app and get a shareable
-            link.
-          </DialogDescription>
+          <DialogDescription>{t("share.description")}</DialogDescription>
         </DialogHeader>
 
         {!hasToken ? (
-          <div className="space-y-3 text-sm">
-            <p className="text-muted-foreground">
-              Add a share.geolibre.app API token in Settings → Environment
-              Variables before sharing. Create one under Settings → API tokens
-              on the website.
-            </p>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => void openExternalLink(SETTINGS_TOKEN_URL)}
-            >
-              <ExternalLink className="mr-2 h-3.5 w-3.5" />
-              Open share.geolibre.app settings
-            </Button>
+          <div className="space-y-4 text-sm">
+            <p className="text-muted-foreground">{t("share.setupIntro")}</p>
+            <ol className="space-y-3">
+              <li className="space-y-2 rounded-md border p-3">
+                <p className="font-medium">{t("share.step1Title")}</p>
+                <p className="text-muted-foreground">
+                  {t("share.step1Description")}
+                </p>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => void openExternalLink(SETTINGS_TOKEN_URL)}
+                >
+                  <ExternalLink className="mr-2 h-3.5 w-3.5" />
+                  {t("share.getToken")}
+                </Button>
+              </li>
+              <li className="space-y-2 rounded-md border p-3">
+                <p className="font-medium">{t("share.step2Title")}</p>
+                <p className="text-muted-foreground">
+                  {t("share.step2Description")}
+                </p>
+                <Button type="button" onClick={handleConfigureToken}>
+                  <KeyRound className="mr-2 h-3.5 w-3.5" />
+                  {t("share.configureToken")}
+                </Button>
+              </li>
+            </ol>
           </div>
         ) : result ? (
           <div className="space-y-3">
-            <p className="text-sm text-muted-foreground">
-              Your project is live at:
-            </p>
+            <p className="text-sm text-muted-foreground">{t("share.liveAt")}</p>
             <div className="flex gap-2">
               <Input readOnly value={result.projectUrl} className="text-xs" />
               <Button
                 type="button"
                 variant="secondary"
-                aria-label="Copy link"
+                aria-label={t("share.copyLink")}
                 onClick={handleCopy}
               >
                 {copied ? (
@@ -190,34 +209,34 @@ export function ShareProjectDialog({
                 onClick={() => void openExternalLink(result.projectUrl)}
               >
                 <ExternalLink className="mr-2 h-3.5 w-3.5" />
-                Open
+                {t("share.open")}
               </Button>
               <Button type="button" onClick={() => onOpenChange(false)}>
-                Done
+                {t("share.done")}
               </Button>
             </div>
           </div>
         ) : (
           <div className="space-y-4">
             <div className="space-y-1.5">
-              <Label htmlFor="share-title">Project title</Label>
+              <Label htmlFor="share-title">{t("share.projectTitle")}</Label>
               <Input
                 id="share-title"
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
-                placeholder="Name your project"
+                placeholder={t("share.titlePlaceholder")}
                 maxLength={MAX_PROJECT_TITLE_LENGTH}
                 disabled={status === "uploading"}
                 autoFocus={!titleValid}
               />
               {!titleValid && (
                 <p className="text-xs text-muted-foreground">
-                  Enter a project title before sharing.
+                  {t("share.titleRequired")}
                 </p>
               )}
             </div>
             <div className="space-y-1.5">
-              <Label htmlFor="share-visibility">Visibility</Label>
+              <Label htmlFor="share-visibility">{t("share.visibility")}</Label>
               <Select
                 id="share-visibility"
                 value={visibility}
@@ -226,9 +245,9 @@ export function ShareProjectDialog({
                 }
                 disabled={status === "uploading"}
               >
-                <option value="unlisted">Unlisted (anyone with the link)</option>
-                <option value="public">Public (listed in the gallery)</option>
-                <option value="private">Private (only you)</option>
+                <option value="unlisted">{t("share.visibilityUnlisted")}</option>
+                <option value="public">{t("share.visibilityPublic")}</option>
+                <option value="private">{t("share.visibilityPrivate")}</option>
               </Select>
             </div>
 
@@ -246,7 +265,7 @@ export function ShareProjectDialog({
                 variant="outline"
                 onClick={() => onOpenChange(false)}
               >
-                Cancel
+                {t("common.cancel")}
               </Button>
               <Button
                 type="button"
@@ -256,12 +275,12 @@ export function ShareProjectDialog({
                 {status === "uploading" ? (
                   <>
                     <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
-                    Sharing…
+                    {t("share.sharing")}
                   </>
                 ) : (
                   <>
                     <Share2 className="mr-2 h-3.5 w-3.5" />
-                    Share
+                    {t("share.shareButton")}
                   </>
                 )}
               </Button>

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -545,6 +545,31 @@
     "nameRequired": "Enter your name to continue.",
     "codeRequired": "Enter a session code to join."
   },
+  "share": {
+    "title": "Share project",
+    "description": "Upload the current project to share.geolibre.app and get a shareable link.",
+    "setupIntro": "Connect your share.geolibre.app account before uploading.",
+    "step1Title": "1. Get an API token",
+    "step1Description": "Sign in to share.geolibre.app, then create a token under Settings → API tokens.",
+    "getToken": "Get API token",
+    "step2Title": "2. Add the token to GeoLibre",
+    "step2Description": "Paste the token into Settings → Environment Variables on this device.",
+    "configureToken": "Configure local token",
+    "liveAt": "Your project is live at:",
+    "copyLink": "Copy link",
+    "open": "Open",
+    "done": "Done",
+    "projectTitle": "Project title",
+    "titlePlaceholder": "Name your project",
+    "titleRequired": "Enter a project title before sharing.",
+    "visibility": "Visibility",
+    "visibilityUnlisted": "Unlisted (anyone with the link)",
+    "visibilityPublic": "Public (listed in the gallery)",
+    "visibilityPrivate": "Private (only you)",
+    "shareButton": "Share",
+    "sharing": "Sharing…",
+    "errorFallback": "Could not share the project."
+  },
   "language": {
     "label": "Language",
     "description": "Choose the language used for the interface."


### PR DESCRIPTION
Fixes #587

## Problem

The **Share project** dialog's no-token state had the usability issues called out in the proposal:

- It described the upload goal before the user could authorize it (out-of-order workflow).
- It blended the website path (`Settings → API tokens` on share.geolibre.app) and the local app path (`Settings → Environment Variables`) into one dense paragraph.
- The single **Open share.geolibre.app settings** button was ambiguous about whether it opened the website or the local config panel.

## Change

Restructured the no-token state into a clear two-step onboarding:

1. **Get an API token** — an outline button (`Get API token`) that opens share.geolibre.app in the system browser to create a token.
2. **Add the token to GeoLibre** — a primary button (`Configure local token`) that closes the dialog and deep-links into `Settings → Environment Variables` with the share token input focused, so the user can paste it right away.

To support step 2, `openSettingsSection()` now takes an optional focus target, and `SettingsDialog` focuses the token input once the Environment section renders.

The dialog's user-facing strings were also moved to react-i18next under a new `share` catalog block (`en.json`).

## Verification

Drove the real web app with Playwright in **both light and dark themes**:

- The no-token state renders the two bordered steps with the two distinct buttons.
- `Get API token` opens the external token page.
- `Configure local token` closes the Share dialog, opens Settings at Environment Variables, and focuses the token input (confirmed `document.activeElement` is the `Share.GeoLibre API token` field).

`npm run build` (full typecheck) and `pre-commit` on the changed files both pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deep-linking into Settings with automatic focus on specific fields (e.g., the share token input) after the dialog opens.

* **Improvements**
  * Share Project dialog now uses internationalized text for titles, labels, validation, and actions.
  * Sharing now provides a localized fallback message when errors occur.
  * Updated sharing flow to guide directly to the Settings → Environment Variables area for token setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->