### PR TITLE
feat(segmentation): interactive sidecar help banner on server start failure

### DIFF
--- a/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
@@ -38,6 +38,11 @@ import { useTranslation } from "react-i18next";
 import { isTauri, openLocalDataFileWithFallback } from "../../lib/tauri-io";
 import { reprojectFeatureCollectionToWgs84 } from "../../lib/duckdb-vector-loader";
 import { startGeoLibreSidecar } from "../../lib/sidecar";
+import {
+  SidecarHelpBanner,
+  SIDECAR_PORT,
+  SIDECAR_URL,
+} from "./SidecarHelpBanner";
 
 interface SegmentationDialogProps {
   mapControllerRef: React.RefObject<MapController | null>;
@@ -74,6 +79,10 @@ export function SegmentationDialog({
   const [checking, setChecking] = useState(false);
   const [running, setRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // A failed "Start server" attempt is tracked separately from validation/run
+  // errors so it can surface as the interactive troubleshooting banner instead
+  // of a dead-end static error line (issue #594).
+  const [serverError, setServerError] = useState<string | null>(null);
   const [resultMessage, setResultMessage] = useState<string | null>(null);
   const [startingServer, setStartingServer] = useState(false);
 
@@ -119,6 +128,7 @@ export function SegmentationDialog({
     // Reset transient state so a re-opened dialog never shows a stale error,
     // result, or a `running` spinner left over from a previous session.
     setError(null);
+    setServerError(null);
     setResultMessage(null);
     setRunning(false);
     setImageBytes(null);
@@ -142,11 +152,14 @@ export function SegmentationDialog({
   const startServer = useCallback(async () => {
     setStartingServer(true);
     setError(null);
+    setServerError(null);
     try {
       await startGeoLibreSidecar();
       await checkStatus();
     } catch (err) {
-      setError(
+      // Route the failure into serverError so the bottom of the dialog renders
+      // the interactive troubleshooting banner rather than a static error line.
+      setServerError(
         err instanceof Error
           ? err.message
           : t("segmentation.error.startServer"),
@@ -366,11 +379,35 @@ export function SegmentationDialog({
             </Button>
           </div>
 
-          {error && (
-            <p className="flex items-center gap-2 text-sm text-destructive">
-              <AlertCircle className="h-4 w-4" />
-              {error}
-            </p>
+          {/* A failed "Start server" attempt becomes an interactive
+              troubleshooting banner (issue #594). Segmentation has no WASM
+              fallback, so the banner omits the "Run locally" switch and uses
+              segmentation-specific copy (no Whitebox/WASM mentions). Validation
+              and run errors keep the plain static line. */}
+          {serverError ? (
+            <SidecarHelpBanner
+              isDesktop={isTauri()}
+              error={serverError}
+              title={t("segmentation.sidecar.title")}
+              intro={t("segmentation.sidecar.intro", {
+                sidecarUrl: SIDECAR_URL,
+              })}
+              steps={[
+                isTauri()
+                  ? t("segmentation.sidecar.stepStartServerDesktop")
+                  : t("segmentation.sidecar.stepStartServerBrowser"),
+                t("segmentation.sidecar.stepInstall"),
+                t("processing.sidecar.stepCheckPort", { port: SIDECAR_PORT }),
+                t("processing.sidecar.stepRestart"),
+              ]}
+            />
+          ) : (
+            error && (
+              <p className="flex items-center gap-2 text-sm text-destructive">
+                <AlertCircle className="h-4 w-4" />
+                {error}
+              </p>
+            )
           )}
           {resultMessage && !error && (
             <p className="flex items-center gap-2 text-sm text-emerald-700">

--- a/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
@@ -393,15 +393,18 @@ export function SegmentationDialog({
               intro={t("segmentation.sidecar.intro", {
                 sidecarUrl: SIDECAR_URL,
               })}
+              troubleshootingTitle={t(
+                "segmentation.sidecar.troubleshootingTitle",
+              )}
+              // The banner only renders after a failed "Start server", which is
+              // desktop-only, so the start step is always the desktop one.
               // Install first: a missing segment-geospatial backend is the most
-              // likely reason "Start server" failed, so leading with it (rather
-              // than re-clicking Start, which would fail the same way) keeps the
-              // path self-consistent.
+              // likely reason it failed, so leading with it (rather than
+              // re-clicking Start, which would fail the same way) keeps the path
+              // self-consistent.
               steps={[
                 t("segmentation.sidecar.stepInstall"),
-                isTauri()
-                  ? t("segmentation.sidecar.stepStartServerDesktop")
-                  : t("segmentation.sidecar.stepStartServerBrowser"),
+                t("segmentation.sidecar.stepStartServerDesktop"),
                 t("processing.sidecar.stepCheckPort", { port: SIDECAR_PORT }),
                 t("processing.sidecar.stepRestart"),
               ]}

--- a/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
@@ -171,6 +171,8 @@ export function SegmentationDialog({
 
   const handleRun = useCallback(async () => {
     setError(null);
+    // Defensive: serverError is normally null by the time Segment is enabled;
+    // clearing it keeps the success path from coexisting with a stale banner.
     setServerError(null);
     setResultMessage(null);
     if (!imageBytes) {

--- a/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
@@ -171,6 +171,7 @@ export function SegmentationDialog({
 
   const handleRun = useCallback(async () => {
     setError(null);
+    setServerError(null);
     setResultMessage(null);
     if (!imageBytes) {
       setError(t("segmentation.error.chooseImage"));
@@ -392,11 +393,15 @@ export function SegmentationDialog({
               intro={t("segmentation.sidecar.intro", {
                 sidecarUrl: SIDECAR_URL,
               })}
+              // Install first: a missing segment-geospatial backend is the most
+              // likely reason "Start server" failed, so leading with it (rather
+              // than re-clicking Start, which would fail the same way) keeps the
+              // path self-consistent.
               steps={[
+                t("segmentation.sidecar.stepInstall"),
                 isTauri()
                   ? t("segmentation.sidecar.stepStartServerDesktop")
                   : t("segmentation.sidecar.stepStartServerBrowser"),
-                t("segmentation.sidecar.stepInstall"),
                 t("processing.sidecar.stepCheckPort", { port: SIDECAR_PORT }),
                 t("processing.sidecar.stepRestart"),
               ]}
@@ -409,7 +414,7 @@ export function SegmentationDialog({
               </p>
             )
           )}
-          {resultMessage && !error && (
+          {resultMessage && !error && !serverError && (
             <p className="flex items-center gap-2 text-sm text-emerald-700">
               <CheckCircle2 className="h-4 w-4" />
               {resultMessage}

--- a/apps/geolibre-desktop/src/components/processing/SidecarHelpBanner.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SidecarHelpBanner.tsx
@@ -6,9 +6,11 @@ import { useTranslation } from "react-i18next";
 // The local loopback address the Python sidecar listens on. Kept out of the
 // translatable strings (injected via interpolation) so translators can't garble
 // it and a future change to the address only touches one place. The port is
-// derived from the URL so the two can never drift apart.
-const SIDECAR_URL = "http://127.0.0.1:8765";
-const SIDECAR_PORT = new URL(SIDECAR_URL).port;
+// derived from the URL so the two can never drift apart. Exported so callers
+// that supply their own intro/steps copy can interpolate the same values
+// instead of duplicating the address.
+export const SIDECAR_URL = "http://127.0.0.1:8765";
+export const SIDECAR_PORT = new URL(SIDECAR_URL).port;
 
 interface SidecarHelpBannerProps {
   /**
@@ -28,6 +30,25 @@ interface SidecarHelpBannerProps {
    * set (Whitebox), in which case the banner offers a one-click switch.
    */
   onRunLocally?: () => void;
+  /**
+   * Override the banner title. Defaults to the generic "processing server isn't
+   * available" line. Tools whose server failure is more specific (e.g. AI
+   * segmentation) can supply their own.
+   */
+  title?: string;
+  /**
+   * Override the descriptive intro paragraph. Defaults to the Whitebox-flavored
+   * copy that mentions the WebAssembly fallback. Tools without a WASM runner
+   * should pass their own so the banner doesn't promise a fallback that doesn't
+   * exist. Interpolate {@link SIDECAR_URL} as needed.
+   */
+  intro?: string;
+  /**
+   * Override the ordered troubleshooting steps. Defaults to the generic
+   * start-server / check-port / restart sequence. Interpolate
+   * {@link SIDECAR_PORT} as needed.
+   */
+  steps?: string[];
 }
 
 /**
@@ -41,12 +62,29 @@ export function SidecarHelpBanner({
   isDesktop,
   error,
   onRunLocally,
+  title,
+  intro,
+  steps,
 }: SidecarHelpBannerProps) {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
   // A unique id keeps the aria-controls association valid even if two banners
   // are ever rendered on the same page (a hardcoded id would collide).
   const helpId = useId();
+
+  const resolvedTitle = title ?? t("processing.sidecar.unavailableTitle");
+  const resolvedIntro =
+    intro ?? t("processing.sidecar.intro", { sidecarUrl: SIDECAR_URL });
+  // Default to the generic start-server / check-port / restart sequence. The
+  // first step branches on desktop vs. browser because only the desktop build
+  // can launch the server.
+  const resolvedSteps = steps ?? [
+    isDesktop
+      ? t("processing.sidecar.stepStartServerDesktop")
+      : t("processing.sidecar.stepStartServerBrowser"),
+    t("processing.sidecar.stepCheckPort", { port: SIDECAR_PORT }),
+    t("processing.sidecar.stepRestart"),
+  ];
 
   return (
     <div className="rounded-md border border-amber-500/40 bg-amber-500/10 text-sm">
@@ -65,7 +103,7 @@ export function SidecarHelpBanner({
         />
         <span className="min-w-0 flex-1">
           <span className="block font-medium text-foreground">
-            {t("processing.sidecar.unavailableTitle")}
+            {resolvedTitle}
           </span>
           {error && (
             <span className="mt-0.5 block break-words text-xs text-destructive">
@@ -97,7 +135,7 @@ export function SidecarHelpBanner({
           className="grid gap-3 border-t border-amber-500/30 px-3 py-3"
         >
           <p className="text-xs leading-relaxed text-muted-foreground">
-            {t("processing.sidecar.intro", { sidecarUrl: SIDECAR_URL })}
+            {resolvedIntro}
           </p>
 
           {onRunLocally && (
@@ -130,13 +168,12 @@ export function SidecarHelpBanner({
               {t("processing.sidecar.troubleshootingTitle")}
             </p>
             <ol className="grid list-decimal gap-1 pl-5 text-xs text-muted-foreground">
-              <li>
-                {isDesktop
-                  ? t("processing.sidecar.stepStartServerDesktop")
-                  : t("processing.sidecar.stepStartServerBrowser")}
-              </li>
-              <li>{t("processing.sidecar.stepCheckPort", { port: SIDECAR_PORT })}</li>
-              <li>{t("processing.sidecar.stepRestart")}</li>
+              {resolvedSteps.map((step, index) => (
+                // Steps are a fixed, ordered list authored by the caller (or the
+                // defaults above); their order is stable, so the index is a safe
+                // key here.
+                <li key={index}>{step}</li>
+              ))}
             </ol>
           </div>
         </div>

--- a/apps/geolibre-desktop/src/components/processing/SidecarHelpBanner.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SidecarHelpBanner.tsx
@@ -93,6 +93,8 @@ export function SidecarHelpBanner({
     t("processing.sidecar.stepCheckPort", { port: SIDECAR_PORT }),
     t("processing.sidecar.stepRestart"),
   ];
+  const resolvedTroubleshootingTitle =
+    troubleshootingTitle ?? t("processing.sidecar.troubleshootingTitle");
 
   return (
     <div className="rounded-md border border-amber-500/40 bg-amber-500/10 text-sm">
@@ -173,8 +175,7 @@ export function SidecarHelpBanner({
 
           <div className="grid gap-1.5">
             <p className="text-xs font-medium text-foreground">
-              {troubleshootingTitle ??
-                t("processing.sidecar.troubleshootingTitle")}
+              {resolvedTroubleshootingTitle}
             </p>
             <ol className="grid list-decimal gap-1 pl-5 text-xs text-muted-foreground">
               {resolvedSteps.map((step, index) => (

--- a/apps/geolibre-desktop/src/components/processing/SidecarHelpBanner.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SidecarHelpBanner.tsx
@@ -49,6 +49,13 @@ interface SidecarHelpBannerProps {
    * {@link SIDECAR_PORT} as needed.
    */
   steps?: string[];
+  /**
+   * Override the heading above the troubleshooting steps. Defaults to "Still
+   * want to use the server?", which fits tools that have a WASM fallback. Tools
+   * where the server is mandatory (e.g. AI segmentation) should pass copy that
+   * doesn't imply the server is optional.
+   */
+  troubleshootingTitle?: string;
 }
 
 /**
@@ -65,6 +72,7 @@ export function SidecarHelpBanner({
   title,
   intro,
   steps,
+  troubleshootingTitle,
 }: SidecarHelpBannerProps) {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
@@ -165,7 +173,8 @@ export function SidecarHelpBanner({
 
           <div className="grid gap-1.5">
             <p className="text-xs font-medium text-foreground">
-              {t("processing.sidecar.troubleshootingTitle")}
+              {troubleshootingTitle ??
+                t("processing.sidecar.troubleshootingTitle")}
             </p>
             <ol className="grid list-decimal gap-1 pl-5 text-xs text-muted-foreground">
               {resolvedSteps.map((step, index) => (

--- a/apps/geolibre-desktop/src/components/processing/SidecarHelpBanner.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SidecarHelpBanner.tsx
@@ -169,9 +169,7 @@ export function SidecarHelpBanner({
             </p>
             <ol className="grid list-decimal gap-1 pl-5 text-xs text-muted-foreground">
               {resolvedSteps.map((step, index) => (
-                // Steps are a fixed, ordered list authored by the caller (or the
-                // defaults above); their order is stable, so the index is a safe
-                // key here.
+                // index is a safe key: caller-authored fixed list, never reordered
                 <li key={index}>{step}</li>
               ))}
             </ol>

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1549,7 +1549,7 @@
     "layerNameDefault": "Segmentation",
     "sidecar": {
       "title": "Couldn't start the AI segmentation server.",
-      "intro": "AI segmentation runs in an optional local server ({{sidecarUrl}}) that hosts the SAM3 model from segment-geospatial. It runs Python in the background, separate from the app, and isn't part of the browser build.",
+      "intro": "AI segmentation runs in a local helper server ({{sidecarUrl}}) that hosts the SAM3 model from segment-geospatial. It runs Python in the background, separate from the app, and isn't part of the browser build.",
       "troubleshootingTitle": "How to get the server running",
       "stepInstall": "Make sure the GeoLibre server is installed with the segment-geospatial backend enabled, so the segmentation model is available.",
       "stepStartServerDesktop": "Click \"Start server\" above to launch it, then wait a few seconds for the model to come online."

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1550,9 +1550,9 @@
     "sidecar": {
       "title": "Couldn't start the AI segmentation server.",
       "intro": "AI segmentation runs in an optional local server ({{sidecarUrl}}) that hosts the SAM3 model from segment-geospatial. It runs Python in the background, separate from the app, and isn't part of the browser build.",
+      "troubleshootingTitle": "How to get the server running",
       "stepInstall": "Make sure the GeoLibre server is installed with the segment-geospatial backend enabled, so the segmentation model is available.",
-      "stepStartServerDesktop": "Click \"Start server\" above to launch it, then wait a few seconds for the model to come online.",
-      "stepStartServerBrowser": "The server can only be started from the GeoLibre desktop app; AI segmentation isn't available in the browser build."
+      "stepStartServerDesktop": "Click \"Start server\" above to launch it, then wait a few seconds for the model to come online."
     }
   },
   "style": {

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1546,7 +1546,14 @@
     "noObjects": "No objects found.",
     "added": "Added {{count}} feature(s) as “{{name}}”.",
     "layerName": "Segmentation: {{prompt}}",
-    "layerNameDefault": "Segmentation"
+    "layerNameDefault": "Segmentation",
+    "sidecar": {
+      "title": "Couldn't start the AI segmentation server.",
+      "intro": "AI segmentation runs in an optional local server ({{sidecarUrl}}) that hosts the SAM3 model from segment-geospatial. It runs Python in the background, separate from the app, and isn't part of the browser build.",
+      "stepInstall": "Make sure the GeoLibre server is installed with the segment-geospatial backend enabled, so the segmentation model is available.",
+      "stepStartServerDesktop": "Click \"Start server\" above to launch it, then wait a few seconds for the model to come online.",
+      "stepStartServerBrowser": "The server can only be started from the GeoLibre desktop app; AI segmentation isn't available in the browser build."
+    }
   },
   "style": {
     "labels": {


### PR DESCRIPTION
## Summary

Closes the dead-end in the **AI Segmentation** panel reported in #594. When the user clicks **Start server** and the local Python sidecar fails to launch, the dialog previously rendered a single static red line:

> ⚠️ Could not start GeoLibre sidecar.

…with no context and no path forward. It now renders the interactive, expandable `SidecarHelpBanner` (the same component introduced for the Whitebox toolbox in #617): a collapsed summary that still surfaces the original error, plus a disclosure that expands to plain-language context and a step-by-step resolution path.

## What changed

- **`SidecarHelpBanner`** is generalized to accept optional `title` / `intro` / `steps` overrides, defaulting to the existing Whitebox copy so the Whitebox usage is unchanged. The sidecar URL/port constants are now exported so both call sites share one source of truth.
- **`SegmentationDialog`** tracks a failed "Start server" attempt in a dedicated `serverError` state (separate from validation/run errors, which keep the plain static line) and renders the banner for it.
- Segmentation has **no in-browser WASM fallback**, so its banner omits the "Run locally" switch and uses segmentation-specific copy that mentions the `segment-geospatial` backend instead of WebAssembly.
- New translatable strings under `segmentation.sidecar.*` in `en.json` (the shared check-port / restart steps reuse the existing `processing.sidecar.*` keys).

## Verification

Drove the real web app with Playwright and confirmed the banner renders correctly **collapsed and expanded in both light and dark themes**: the collapsed state shows the title plus the original error and a "Show what this means" disclosure; the expanded state shows the segmentation-specific intro (no WASM mention), no "Run locally" button, and the tailored troubleshooting steps (start server / install segment-geospatial / check port / restart).

`npx tsc -b`, `eslint`, and the full `npm build` pre-commit hook all pass.

Fixes #594

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Segmentation dialog now distinguishes server startup failures from validation errors, displaying dedicated troubleshooting guidance when the AI server fails to start.
  * Added server-specific help instructions with clearer resolution steps to guide users through addressing desktop server configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->