### PR TITLE
fix(i18n): drop inaccurate "public" wording from Open Project from URL dialog

### DIFF
--- a/apps/geolibre-desktop/src/i18n/locales/de.json
+++ b/apps/geolibre-desktop/src/i18n/locales/de.json
@@ -276,7 +276,7 @@
       "webServices": "Webdienste",
       "commandPalette": "Befehlspalette",
       "openProjectFromUrl": "Projekt aus URL öffnen",
-      "openProjectFromUrlDesc": "Ein öffentliches `.geolibre.json`-Projekt laden und zu zuletzt geöffneten Projekten hinzufügen.",
+      "openProjectFromUrlDesc": "Ein `.geolibre.json`-Projekt laden und zu zuletzt geöffneten Projekten hinzufügen.",
       "projectUrl": "Projekt-URL",
       "opening": "Wird geöffnet...",
       "open": "Öffnen",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1183,7 +1183,7 @@
       "webServices": "Web Services",
       "commandPalette": "Command Palette",
       "openProjectFromUrl": "Open project from URL",
-      "openProjectFromUrlDesc": "Load a public `.geolibre.json` project and add it to recent projects.",
+      "openProjectFromUrlDesc": "Load a `.geolibre.json` project and add it to recent projects.",
       "projectUrl": "Project URL",
       "opening": "Opening...",
       "open": "Open",

--- a/apps/geolibre-desktop/src/i18n/locales/es.json
+++ b/apps/geolibre-desktop/src/i18n/locales/es.json
@@ -276,7 +276,7 @@
       "webServices": "Servicios web",
       "commandPalette": "Paleta de comandos",
       "openProjectFromUrl": "Abrir proyecto desde URL",
-      "openProjectFromUrlDesc": "Carga un proyecto `.geolibre.json` público y añádelo a los proyectos recientes.",
+      "openProjectFromUrlDesc": "Carga un proyecto `.geolibre.json` y añádelo a los proyectos recientes.",
       "projectUrl": "URL del proyecto",
       "opening": "Abriendo...",
       "open": "Abrir",

--- a/apps/geolibre-desktop/src/i18n/locales/fr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/fr.json
@@ -276,7 +276,7 @@
       "webServices": "Services web",
       "commandPalette": "Palette de commandes",
       "openProjectFromUrl": "Ouvrir un projet depuis une URL",
-      "openProjectFromUrlDesc": "Charger un projet public `.geolibre.json` et l'ajouter aux projets récents.",
+      "openProjectFromUrlDesc": "Charger un projet `.geolibre.json` et l'ajouter aux projets récents.",
       "projectUrl": "URL du projet",
       "opening": "Ouverture en cours...",
       "open": "Ouvrir",

--- a/apps/geolibre-desktop/src/i18n/locales/hi.json
+++ b/apps/geolibre-desktop/src/i18n/locales/hi.json
@@ -276,7 +276,7 @@
       "webServices": "वेब सेवाएं",
       "commandPalette": "कमांड पैलेट",
       "openProjectFromUrl": "URL से प्रोजेक्ट खोलें",
-      "openProjectFromUrlDesc": "एक सार्वजनिक `.geolibre.json` प्रोजेक्ट लोड करें और इसे हालिया प्रोजेक्ट में जोड़ें।",
+      "openProjectFromUrlDesc": "एक `.geolibre.json` प्रोजेक्ट लोड करें और इसे हालिया प्रोजेक्ट में जोड़ें।",
       "projectUrl": "प्रोजेक्ट URL",
       "opening": "खुल रहा है...",
       "open": "खोलें",

--- a/apps/geolibre-desktop/src/i18n/locales/id.json
+++ b/apps/geolibre-desktop/src/i18n/locales/id.json
@@ -275,7 +275,7 @@
       "webServices": "Layanan Web",
       "commandPalette": "Palet Perintah",
       "openProjectFromUrl": "Buka proyek dari URL",
-      "openProjectFromUrlDesc": "Muat proyek `.geolibre.json` publik dan tambahkan ke proyek terbaru.",
+      "openProjectFromUrlDesc": "Muat proyek `.geolibre.json` dan tambahkan ke proyek terbaru.",
       "projectUrl": "URL Proyek",
       "opening": "Membuka...",
       "open": "Buka",

--- a/apps/geolibre-desktop/src/i18n/locales/it.json
+++ b/apps/geolibre-desktop/src/i18n/locales/it.json
@@ -276,7 +276,7 @@
       "webServices": "Servizi web",
       "commandPalette": "Riquadro comandi",
       "openProjectFromUrl": "Apri progetto da URL",
-      "openProjectFromUrlDesc": "Carica un progetto pubblico `.geolibre.json` e aggiungilo ai progetti recenti.",
+      "openProjectFromUrlDesc": "Carica un progetto `.geolibre.json` e aggiungilo ai progetti recenti.",
       "projectUrl": "URL progetto",
       "opening": "Apertura in corso...",
       "open": "Apri",

--- a/apps/geolibre-desktop/src/i18n/locales/ja.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ja.json
@@ -275,7 +275,7 @@
       "webServices": "ウェブサービス",
       "commandPalette": "コマンドパレット",
       "openProjectFromUrl": "URL からプロジェクトを開く",
-      "openProjectFromUrlDesc": "公開されている `.geolibre.json` プロジェクトを読み込み、最近のプロジェクトに追加します。",
+      "openProjectFromUrlDesc": "`.geolibre.json` プロジェクトを読み込み、最近のプロジェクトに追加します。",
       "projectUrl": "プロジェクト URL",
       "opening": "開いています...",
       "open": "開く",

--- a/apps/geolibre-desktop/src/i18n/locales/ko.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ko.json
@@ -275,7 +275,7 @@
       "webServices": "웹 서비스",
       "commandPalette": "명령 팔레트",
       "openProjectFromUrl": "URL에서 프로젝트 열기",
-      "openProjectFromUrlDesc": "공개 `.geolibre.json` 프로젝트를 로드하고 최근 프로젝트에 추가합니다.",
+      "openProjectFromUrlDesc": "`.geolibre.json` 프로젝트를 로드하고 최근 프로젝트에 추가합니다.",
       "projectUrl": "프로젝트 URL",
       "opening": "여는 중...",
       "open": "열기",

--- a/apps/geolibre-desktop/src/i18n/locales/nl.json
+++ b/apps/geolibre-desktop/src/i18n/locales/nl.json
@@ -276,7 +276,7 @@
       "webServices": "Webservices",
       "commandPalette": "Opdrachtpalet",
       "openProjectFromUrl": "Project openen vanuit URL",
-      "openProjectFromUrlDesc": "Laad een openbaar `.geolibre.json`-project en voeg het toe aan recente projecten.",
+      "openProjectFromUrlDesc": "Laad een `.geolibre.json`-project en voeg het toe aan recente projecten.",
       "projectUrl": "Project-URL",
       "opening": "Openen...",
       "open": "Openen",

--- a/apps/geolibre-desktop/src/i18n/locales/pt.json
+++ b/apps/geolibre-desktop/src/i18n/locales/pt.json
@@ -276,7 +276,7 @@
       "webServices": "Serviços Web",
       "commandPalette": "Paleta de Comandos",
       "openProjectFromUrl": "Abrir projeto a partir de URL",
-      "openProjectFromUrlDesc": "Carrega um projeto público `.geolibre.json` e adiciona-o aos projetos recentes.",
+      "openProjectFromUrlDesc": "Carrega um projeto `.geolibre.json` e adiciona-o aos projetos recentes.",
       "projectUrl": "URL do projeto",
       "opening": "A abrir...",
       "open": "Abrir",

--- a/apps/geolibre-desktop/src/i18n/locales/ru.json
+++ b/apps/geolibre-desktop/src/i18n/locales/ru.json
@@ -278,7 +278,7 @@
       "webServices": "Веб-сервисы",
       "commandPalette": "Палитра команд",
       "openProjectFromUrl": "Открыть проект по URL",
-      "openProjectFromUrlDesc": "Загрузить публичный проект `.geolibre.json` и добавить его в недавние проекты.",
+      "openProjectFromUrlDesc": "Загрузить проект `.geolibre.json` и добавить его в недавние проекты.",
       "projectUrl": "URL проекта",
       "opening": "Открытие...",
       "open": "Открыть",

--- a/apps/geolibre-desktop/src/i18n/locales/tr.json
+++ b/apps/geolibre-desktop/src/i18n/locales/tr.json
@@ -276,7 +276,7 @@
       "webServices": "Web Servisleri",
       "commandPalette": "Komut Paleti",
       "openProjectFromUrl": "URL'den proje aç",
-      "openProjectFromUrlDesc": "Genel bir `.geolibre.json` projesini yükleyin ve son projelere ekleyin.",
+      "openProjectFromUrlDesc": "Bir `.geolibre.json` projesini yükleyin ve son projelere ekleyin.",
       "projectUrl": "Proje URL'si",
       "opening": "Açılıyor...",
       "open": "Aç",

--- a/apps/geolibre-desktop/src/i18n/locales/zh.json
+++ b/apps/geolibre-desktop/src/i18n/locales/zh.json
@@ -275,7 +275,7 @@
       "webServices": "网络服务",
       "commandPalette": "命令面板",
       "openProjectFromUrl": "从 URL 打开项目",
-      "openProjectFromUrlDesc": "加载公开的 `.geolibre.json` 项目并将其添加到最近项目。",
+      "openProjectFromUrlDesc": "加载 `.geolibre.json` 项目并将其添加到最近项目。",
       "projectUrl": "项目 URL",
       "opening": "正在打开...",
       "open": "打开",


### PR DESCRIPTION
Fixes #622

## Problem

The "Open project from URL" modal described the action as *"Load a public `.geolibre.json` project..."*. The word **public** is inaccurate: loading a project via a URL does not imply the file is publicly accessible. The URL could point to a file on a private intranet, a local network share, or a server requiring network-level authentication.

## Change

Remove the word "public" (and its equivalents in each translation) from the `toolbar.item.openProjectFromUrlDesc` string so it reads *"Load a `.geolibre.json` project and add it to recent projects."* Updated across all 14 locale catalogs (en + 13 translations).

## Verification

Drove the real web app with Playwright and opened **Project → Open From → URL...** in both **light** and **dark** themes. The dialog description now reads "Load a `.geolibre.json` project and add it to recent projects." with no "public" qualifier in either theme. `pre-commit run --files` (json checks + npm build) passes.