### PR TITLE
feat(appearance): add accent color schemes beyond light/dark

### DIFF
--- a/apps/geolibre-desktop/src/App.tsx
+++ b/apps/geolibre-desktop/src/App.tsx
@@ -9,6 +9,7 @@ import { useRecentProjectsPersistence } from "./hooks/useRecentProjectsPersisten
 import { useRuntimeEnvironmentVariables } from "./hooks/useRuntimeEnvironmentVariables";
 import { useStartupUpdateCheck } from "./hooks/useStartupUpdateCheck";
 import { useThemeMode } from "./hooks/useThemeMode";
+import { useThemeScheme } from "./hooks/useThemeScheme";
 import { useUiProfileBootstrap } from "./hooks/useUiProfileBootstrap";
 import { useUndoRedoShortcuts } from "./hooks/useUndoRedoShortcuts";
 
@@ -24,6 +25,7 @@ export default function App() {
   } = useStartupUpdateCheck();
 
   useDesktopSettingsPersistence();
+  useThemeScheme();
   useRecentProjectsPersistence();
   useRuntimeEnvironmentVariables();
   useUndoRedoShortcuts();

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -617,6 +617,16 @@ export function SettingsDialog({
     setDesktopSettings({ ...current, theme: { ...current.theme, scheme } });
   };
 
+  // Picking a custom color both stores the color and activates the custom scheme,
+  // so editing the swatch immediately previews it.
+  const updateSavedThemeCustomColor = (customColor: string) => {
+    const current = useDesktopSettingsStore.getState().desktopSettings;
+    setDesktopSettings({
+      ...current,
+      theme: { ...current.theme, scheme: "custom", customColor },
+    });
+  };
+
   const updateDraftUpdateSettings = (patch: Partial<UpdateSettings>) => {
     setDraftDesktopSettings((current) => ({
       ...current,
@@ -986,6 +996,17 @@ export function SettingsDialog({
                     {t(scheme.labelKey)}
                   </DropdownMenuRadioItem>
                 ))}
+                <DropdownMenuRadioItem
+                  value="custom"
+                  onSelect={(event: Event) => event.preventDefault()}
+                >
+                  <span
+                    aria-hidden
+                    className="mr-2 h-3.5 w-3.5 shrink-0 rounded-full border"
+                    style={{ backgroundColor: desktopSettings.theme.customColor }}
+                  />
+                  {t("settings.appearance.custom")}
+                </DropdownMenuRadioItem>
               </DropdownMenuRadioGroup>
               <DropdownMenuSeparator />
               <DropdownMenuItem
@@ -1399,7 +1420,49 @@ export function SettingsDialog({
                           </button>
                         );
                       })}
+                      <button
+                        type="button"
+                        aria-pressed={
+                          desktopSettings.theme.scheme === "custom"
+                        }
+                        onClick={() => updateSavedThemeScheme("custom")}
+                        className={cn(
+                          "flex items-center gap-2.5 rounded-md border p-3 text-sm transition-colors",
+                          desktopSettings.theme.scheme === "custom"
+                            ? "border-primary ring-2 ring-ring"
+                            : "hover:bg-accent",
+                        )}
+                      >
+                        <span
+                          aria-hidden
+                          className="h-5 w-5 shrink-0 rounded-full border"
+                          style={{
+                            backgroundColor: desktopSettings.theme.customColor,
+                          }}
+                        />
+                        <span>{t("settings.appearance.custom")}</span>
+                        {desktopSettings.theme.scheme === "custom" ? (
+                          <Check className="ml-auto h-4 w-4 text-primary" />
+                        ) : null}
+                      </button>
                     </div>
+                    {desktopSettings.theme.scheme === "custom" ? (
+                      <label className="flex items-center gap-3 rounded-md border p-3 text-sm">
+                        <input
+                          type="color"
+                          className="h-8 w-12 shrink-0 cursor-pointer rounded border bg-transparent p-0.5"
+                          value={desktopSettings.theme.customColor}
+                          onChange={(event) =>
+                            updateSavedThemeCustomColor(event.target.value)
+                          }
+                          aria-label={t("settings.appearance.customColor")}
+                        />
+                        <span>{t("settings.appearance.customColor")}</span>
+                        <code className="ml-auto text-xs uppercase text-muted-foreground">
+                          {desktopSettings.theme.customColor}
+                        </code>
+                      </label>
+                    ) : null}
                     <p className="text-xs text-muted-foreground">
                       {t("settings.appearance.modeNote")}
                     </p>

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -31,10 +31,12 @@ import {
   Input,
   Label,
   Select,
+  cn,
 } from "@geolibre/ui";
 import type { MapController } from "@geolibre/map";
 import {
   Braces,
+  Check,
   Crosshair,
   DownloadCloud,
   Eye,
@@ -44,6 +46,7 @@ import {
   Locate,
   MapPinned,
   LayoutPanelTop,
+  Palette,
   PanelLeft,
   PanelRight,
   Plus,
@@ -72,6 +75,7 @@ import {
 } from "../../hooks/useDesktopSettings";
 import { useLanguage } from "../../hooks/useLanguage";
 import { isTauri } from "../../lib/is-tauri";
+import { THEME_SCHEMES, type ThemeScheme } from "../../lib/theme-schemes";
 import type { UpdateNotificationLevel } from "../../lib/updates";
 import {
   DATA_SOURCE_CATALOG,
@@ -90,6 +94,7 @@ import {
 export type SettingsSection =
   | "map"
   | "layout"
+  | "appearance"
   | "interface"
   | "geocoding"
   | "environment"
@@ -142,6 +147,11 @@ const SECTION_ITEMS: Array<{
 }> = [
   { id: "map", labelKey: "settings.section.map", icon: MapPinned },
   { id: "layout", labelKey: "settings.section.layout", icon: LayoutPanelTop },
+  {
+    id: "appearance",
+    labelKey: "settings.section.appearance",
+    icon: Palette,
+  },
   {
     id: "interface",
     labelKey: "settings.section.interface",
@@ -598,6 +608,15 @@ export function SettingsDialog({
     updateDraftLayoutSettings(DEFAULT_DESKTOP_LAYOUT_SETTINGS);
   };
 
+  // The accent scheme applies live (instant preview) rather than waiting for
+  // Save, mirroring the Interface profile toggles. Reads the latest state so a
+  // rapid click after another live change does not clobber it with a stale
+  // render-closure snapshot.
+  const updateSavedThemeScheme = (scheme: ThemeScheme) => {
+    const current = useDesktopSettingsStore.getState().desktopSettings;
+    setDesktopSettings({ ...current, theme: { ...current.theme, scheme } });
+  };
+
   const updateDraftUpdateSettings = (patch: Partial<UpdateSettings>) => {
     setDraftDesktopSettings((current) => ({
       ...current,
@@ -936,6 +955,47 @@ export function SettingsDialog({
               <DropdownMenuLabel className="px-2 py-1 text-xs font-normal text-muted-foreground">
                 {t("settings.menu.urlOverrideNote")}
               </DropdownMenuLabel>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              <Palette className="h-3.5 w-3.5" />
+              {t("settings.section.appearance")}
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent className="w-56">
+              <DropdownMenuLabel className="px-2 py-1 text-xs font-normal text-muted-foreground">
+                {t("settings.appearance.accentColor")}
+              </DropdownMenuLabel>
+              <DropdownMenuRadioGroup
+                value={desktopSettings.theme.scheme}
+                onValueChange={(value: string) =>
+                  updateSavedThemeScheme(value as ThemeScheme)
+                }
+              >
+                {THEME_SCHEMES.map((scheme) => (
+                  <DropdownMenuRadioItem
+                    key={scheme.id}
+                    value={scheme.id}
+                    onSelect={(event: Event) => event.preventDefault()}
+                  >
+                    <span
+                      aria-hidden
+                      className="mr-2 h-3.5 w-3.5 shrink-0 rounded-full border"
+                      style={{ backgroundColor: scheme.swatch }}
+                    />
+                    {t(scheme.labelKey)}
+                  </DropdownMenuRadioItem>
+                ))}
+              </DropdownMenuRadioGroup>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onSelect={() => {
+                  setSection("appearance");
+                  setOpen(true);
+                }}
+              >
+                {t("settings.menu.appearanceSettings")}
+              </DropdownMenuItem>
             </DropdownMenuSubContent>
           </DropdownMenuSub>
           <DropdownMenuSub>
@@ -1294,6 +1354,56 @@ export function SettingsDialog({
                       {t("settings.layout.urlParamsNote")}
                     </div>
                   ) : null}
+                </div>
+              ) : null}
+              {effectiveSection === "appearance" ? (
+                <div className="space-y-5">
+                  <div>
+                    <h3 className="text-sm font-semibold">
+                      {t("settings.appearance.title")}
+                    </h3>
+                    <p className="text-xs text-muted-foreground">
+                      {t("settings.appearance.description")}
+                    </p>
+                  </div>
+                  <div className="space-y-3">
+                    <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      {t("settings.appearance.accentColor")}
+                    </h4>
+                    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                      {THEME_SCHEMES.map((scheme) => {
+                        const active =
+                          desktopSettings.theme.scheme === scheme.id;
+                        return (
+                          <button
+                            key={scheme.id}
+                            type="button"
+                            aria-pressed={active}
+                            onClick={() => updateSavedThemeScheme(scheme.id)}
+                            className={cn(
+                              "flex items-center gap-2.5 rounded-md border p-3 text-sm transition-colors",
+                              active
+                                ? "border-primary ring-2 ring-ring"
+                                : "hover:bg-accent",
+                            )}
+                          >
+                            <span
+                              aria-hidden
+                              className="h-5 w-5 shrink-0 rounded-full border"
+                              style={{ backgroundColor: scheme.swatch }}
+                            />
+                            <span>{t(scheme.labelKey)}</span>
+                            {active ? (
+                              <Check className="ml-auto h-4 w-4 text-primary" />
+                            ) : null}
+                          </button>
+                        );
+                      })}
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      {t("settings.appearance.modeNote")}
+                    </p>
+                  </div>
                 </div>
               ) : null}
               {effectiveSection === "interface" ? (

--- a/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
+++ b/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
@@ -3,6 +3,11 @@ import { useEffect } from "react";
 import { create } from "zustand";
 import { normalizeStringList } from "../lib/string-lists";
 import { DESKTOP_SETTINGS_STORAGE_KEY } from "../lib/storage-keys";
+import {
+  DEFAULT_THEME_SCHEME,
+  isThemeScheme,
+  type ThemeScheme,
+} from "../lib/theme-schemes";
 import type { UpdateNotificationLevel } from "../lib/updates";
 
 /** Notification-granularity options, in order. Single source of truth. */
@@ -34,6 +39,11 @@ export interface DesktopSettings {
    */
   shareToken: string;
   /**
+   * Appearance preferences (the accent color scheme). The light/dark mode is
+   * handled separately by `useThemeMode` (it tracks the OS / embed preference).
+   */
+  theme: ThemeSettings;
+  /**
    * Customizable UI profile: which data sources / web services / plugins are
    * visible, an optional experience-level preset, first-launch onboarding state,
    * and an admin lock. See `src/lib/ui-profile.ts` and `docs/ui-profiles.md`.
@@ -44,6 +54,11 @@ export interface DesktopSettings {
    * desktop (Tauri) build; on the web these settings are inert.
    */
   updates: UpdateSettings;
+}
+
+export interface ThemeSettings {
+  /** Accent color scheme applied via a `data-theme` attribute on <html>. */
+  scheme: ThemeScheme;
 }
 
 export interface UpdateSettings {
@@ -123,12 +138,17 @@ export const DEFAULT_UPDATE_SETTINGS: UpdateSettings = {
   notificationLevel: "all",
 };
 
+export const DEFAULT_THEME_SETTINGS: ThemeSettings = {
+  scheme: DEFAULT_THEME_SCHEME,
+};
+
 const DEFAULT_DESKTOP_SETTINGS: DesktopSettings = {
   additionalPluginDirectories: [],
   language: "",
   layout: DEFAULT_DESKTOP_LAYOUT_SETTINGS,
   pluginManifestUrls: [],
   shareToken: "",
+  theme: DEFAULT_THEME_SETTINGS,
   uiProfile: DEFAULT_UI_PROFILE_SETTINGS,
   updates: DEFAULT_UPDATE_SETTINGS,
 };
@@ -160,8 +180,24 @@ function normalizeDesktopSettings(settings: unknown): DesktopSettings {
     ),
     shareToken:
       typeof candidate.shareToken === "string" ? candidate.shareToken.trim() : "",
+    theme: normalizeThemeSettings(candidate.theme),
     uiProfile: normalizeUiProfileSettings(candidate.uiProfile),
     updates: normalizeUpdateSettings(candidate.updates),
+  };
+}
+
+function normalizeThemeSettings(theme: unknown): ThemeSettings {
+  if (!theme || typeof theme !== "object") {
+    return DEFAULT_THEME_SETTINGS;
+  }
+
+  // Require a known scheme id so tampered localStorage values cannot smuggle an
+  // unknown scheme into the `data-theme` attribute.
+  const candidate = theme as Partial<ThemeSettings>;
+  return {
+    scheme: isThemeScheme(candidate.scheme)
+      ? candidate.scheme
+      : DEFAULT_THEME_SETTINGS.scheme,
   };
 }
 

--- a/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
+++ b/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
@@ -204,8 +204,10 @@ function normalizeThemeSettings(theme: unknown): ThemeSettings {
     scheme: isThemeScheme(candidate.scheme)
       ? candidate.scheme
       : DEFAULT_THEME_SETTINGS.scheme,
+    // Normalize so the value bound to `<input type="color">` is exactly
+    // `#rrggbb` lowercase (isHexColor already requires the leading `#`).
     customColor: isHexColor(candidate.customColor)
-      ? candidate.customColor
+      ? candidate.customColor.trim().toLowerCase()
       : DEFAULT_THEME_SETTINGS.customColor,
   };
 }

--- a/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
+++ b/apps/geolibre-desktop/src/hooks/useDesktopSettings.ts
@@ -4,7 +4,9 @@ import { create } from "zustand";
 import { normalizeStringList } from "../lib/string-lists";
 import { DESKTOP_SETTINGS_STORAGE_KEY } from "../lib/storage-keys";
 import {
+  DEFAULT_CUSTOM_COLOR,
   DEFAULT_THEME_SCHEME,
+  isHexColor,
   isThemeScheme,
   type ThemeScheme,
 } from "../lib/theme-schemes";
@@ -57,8 +59,10 @@ export interface DesktopSettings {
 }
 
 export interface ThemeSettings {
-  /** Accent color scheme applied via a `data-theme` attribute on <html>. */
+  /** Accent color scheme. Presets set a `data-theme` attribute on <html>. */
   scheme: ThemeScheme;
+  /** Hex color backing the "custom" scheme (ignored by the presets). */
+  customColor: string;
 }
 
 export interface UpdateSettings {
@@ -140,6 +144,7 @@ export const DEFAULT_UPDATE_SETTINGS: UpdateSettings = {
 
 export const DEFAULT_THEME_SETTINGS: ThemeSettings = {
   scheme: DEFAULT_THEME_SCHEME,
+  customColor: DEFAULT_CUSTOM_COLOR,
 };
 
 const DEFAULT_DESKTOP_SETTINGS: DesktopSettings = {
@@ -191,13 +196,17 @@ function normalizeThemeSettings(theme: unknown): ThemeSettings {
     return DEFAULT_THEME_SETTINGS;
   }
 
-  // Require a known scheme id so tampered localStorage values cannot smuggle an
-  // unknown scheme into the `data-theme` attribute.
+  // Require a known scheme id and a valid hex color so tampered localStorage
+  // values cannot smuggle an unknown scheme into the `data-theme` attribute or an
+  // arbitrary string into the inline custom-color tokens.
   const candidate = theme as Partial<ThemeSettings>;
   return {
     scheme: isThemeScheme(candidate.scheme)
       ? candidate.scheme
       : DEFAULT_THEME_SETTINGS.scheme,
+    customColor: isHexColor(candidate.customColor)
+      ? candidate.customColor
+      : DEFAULT_THEME_SETTINGS.customColor,
   };
 }
 

--- a/apps/geolibre-desktop/src/hooks/useThemeScheme.ts
+++ b/apps/geolibre-desktop/src/hooks/useThemeScheme.ts
@@ -1,0 +1,18 @@
+import { useLayoutEffect } from "react";
+import { applyThemeScheme } from "../lib/theme-schemes";
+import { useDesktopSettingsStore } from "./useDesktopSettings";
+
+/**
+ * Keeps the document's `data-theme` attribute in sync with the persisted accent
+ * scheme. Pairs with `useThemeMode` (light/dark): mode toggles the `.dark` class,
+ * this hook sets the accent scheme on top of it.
+ */
+export function useThemeScheme(): void {
+  const scheme = useDesktopSettingsStore(
+    (state) => state.desktopSettings.theme.scheme,
+  );
+
+  useLayoutEffect(() => {
+    applyThemeScheme(scheme);
+  }, [scheme]);
+}

--- a/apps/geolibre-desktop/src/hooks/useThemeScheme.ts
+++ b/apps/geolibre-desktop/src/hooks/useThemeScheme.ts
@@ -11,8 +11,11 @@ export function useThemeScheme(): void {
   const scheme = useDesktopSettingsStore(
     (state) => state.desktopSettings.theme.scheme,
   );
+  const customColor = useDesktopSettingsStore(
+    (state) => state.desktopSettings.theme.customColor,
+  );
 
   useLayoutEffect(() => {
-    applyThemeScheme(scheme);
-  }, [scheme]);
+    applyThemeScheme(scheme, customColor);
+  }, [scheme, customColor]);
 }

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -749,6 +749,7 @@
     "section": {
       "map": "Map",
       "layout": "Layout",
+      "appearance": "Appearance",
       "interface": "Interface",
       "geocoding": "Geocoding",
       "environment": "Environment",
@@ -757,6 +758,7 @@
     "menu": {
       "mapPreferences": "Map Preferences",
       "layoutSettings": "Layout Settings",
+      "appearanceSettings": "Appearance Settings",
       "interfaceSettings": "Interface Settings",
       "geocoding": "Geocoding",
       "environmentVariables": "Environment Variables",
@@ -805,6 +807,19 @@
       "showStylePanel": "Show Style panel",
       "showAttributePanel": "Show Attribute panel",
       "urlParamsNote": "URL layout parameters still apply when present in shared viewer links."
+    },
+    "appearance": {
+      "title": "Appearance",
+      "description": "Choose an accent color. It applies on top of the light or dark mode, which you can toggle from the toolbar.",
+      "accentColor": "Accent color",
+      "modeNote": "Use the Sun/Moon button in the toolbar to switch between light and dark mode.",
+      "scheme": {
+        "blue": "Blue",
+        "violet": "Violet",
+        "emerald": "Emerald",
+        "rose": "Rose",
+        "amber": "Amber"
+      }
     },
     "interface": {
       "title": "Interface profile",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -812,6 +812,8 @@
       "title": "Appearance",
       "description": "Choose an accent color. It applies on top of the light or dark mode, which you can toggle from the toolbar.",
       "accentColor": "Accent color",
+      "custom": "Custom",
+      "customColor": "Custom color",
       "modeNote": "Use the Sun/Moon button in the toolbar to switch between light and dark mode.",
       "scheme": {
         "blue": "Blue",

--- a/apps/geolibre-desktop/src/lib/theme-schemes.ts
+++ b/apps/geolibre-desktop/src/lib/theme-schemes.ts
@@ -1,18 +1,31 @@
 /**
  * Accent color schemes layered on top of the light/dark mode. A scheme only
  * re-tints the accent-bearing tokens (`--primary`, `--primary-foreground`,
- * `--ring`); the neutral base (background, border, muted) is shared. The actual
- * token values live in `packages/ui/src/globals.css` under `[data-theme="<id>"]`
- * selectors. This module is the single source of truth for the valid scheme ids
- * and the picker UI (label key + representative swatch color).
+ * `--ring`); the neutral base (background, border, muted) is shared.
+ *
+ * Preset schemes have their token values baked into `packages/ui/src/globals.css`
+ * under `[data-theme="<id>"]` selectors and are selected via a `data-theme`
+ * attribute on <html>. The "custom" scheme instead derives its tokens from a
+ * user-picked hex color at runtime and injects them as inline styles on <html>
+ * (which override the stylesheet in both light and dark mode). This module is the
+ * single source of truth for the valid scheme ids and the picker UI.
  */
-export type ThemeScheme = "blue" | "violet" | "emerald" | "rose" | "amber";
+export type ThemeScheme =
+  | "blue"
+  | "violet"
+  | "emerald"
+  | "rose"
+  | "amber"
+  | "custom";
 
 /**
  * The default scheme matches the base `:root` / `.dark` tokens already shipped in
  * `globals.css`, so no `data-theme` attribute is set for it.
  */
 export const DEFAULT_THEME_SCHEME: ThemeScheme = "blue";
+
+/** Seed color for the custom picker before the user changes it (a teal-cyan). */
+export const DEFAULT_CUSTOM_COLOR = "#0ea5e9";
 
 export interface ThemeSchemeOption {
   id: ThemeScheme;
@@ -27,7 +40,10 @@ export interface ThemeSchemeOption {
   swatch: string;
 }
 
-/** Selectable accent schemes, in picker order. Single source of truth. */
+/**
+ * Selectable preset schemes, in picker order. The "custom" scheme is handled
+ * separately (its swatch is the live picked color), so it is not listed here.
+ */
 export const THEME_SCHEMES: readonly ThemeSchemeOption[] = [
   {
     id: "blue",
@@ -56,23 +72,148 @@ export const THEME_SCHEMES: readonly ThemeSchemeOption[] = [
   },
 ];
 
-/** Type guard for persisted/tampered values. */
+const HEX_COLOR = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i;
+
+/** Type guard for persisted/tampered scheme values. */
 export function isThemeScheme(value: unknown): value is ThemeScheme {
   return (
-    typeof value === "string" &&
-    THEME_SCHEMES.some((scheme) => scheme.id === value)
+    value === "custom" ||
+    (typeof value === "string" &&
+      THEME_SCHEMES.some((scheme) => scheme.id === value))
   );
 }
 
+/** Whether `value` is a 3- or 6-digit hex color (with or without a leading #). */
+export function isHexColor(value: unknown): value is string {
+  return typeof value === "string" && HEX_COLOR.test(value.trim());
+}
+
+/** Expand a validated hex string to its six lowercase digits (no `#`). */
+function expandHex(hex: string): string {
+  const digits = HEX_COLOR.exec(hex.trim())?.[1]?.toLowerCase();
+  if (!digits) return "";
+  return digits.length === 3
+    ? digits
+        .split("")
+        .map((channel) => channel + channel)
+        .join("")
+    : digits;
+}
+
 /**
- * Apply (or clear) the active accent scheme on the document root. The default
- * scheme removes the attribute so the base `:root` / `.dark` tokens apply.
+ * Convert a hex color to the bare HSL channels (`"H S% L%"`) the design tokens
+ * expect. Returns null for invalid input.
+ *
+ * @param hex - A 3- or 6-digit hex color, with or without a leading `#`.
+ */
+export function hexToHslChannels(hex: string): string | null {
+  const digits = expandHex(hex);
+  if (!digits) return null;
+
+  const r = parseInt(digits.slice(0, 2), 16) / 255;
+  const g = parseInt(digits.slice(2, 4), 16) / 255;
+  const b = parseInt(digits.slice(4, 6), 16) / 255;
+
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const lightness = (max + min) / 2;
+  const delta = max - min;
+
+  let hue = 0;
+  let saturation = 0;
+  if (delta !== 0) {
+    saturation = delta / (1 - Math.abs(2 * lightness - 1));
+    if (max === r) {
+      hue = ((g - b) / delta) % 6;
+    } else if (max === g) {
+      hue = (b - r) / delta + 2;
+    } else {
+      hue = (r - g) / delta + 4;
+    }
+    hue *= 60;
+    if (hue < 0) hue += 360;
+  }
+
+  const round = (value: number) => Math.round(value * 10) / 10;
+  return `${round(hue)} ${round(saturation * 100)}% ${round(lightness * 100)}%`;
+}
+
+/**
+ * Pick a readable foreground (white or near-black, as HSL channels) for text
+ * placed on `hex`, choosing whichever has the higher WCAG contrast ratio.
+ *
+ * @param hex - The background color the foreground sits on.
+ */
+export function foregroundForHex(hex: string): string {
+  const digits = expandHex(hex);
+  // Fall back to white for invalid input (matches the default light-on-accent).
+  if (!digits) return "0 0% 100%";
+
+  const linearize = (value: number) => {
+    const channel = value / 255;
+    return channel <= 0.03928
+      ? channel / 12.92
+      : ((channel + 0.055) / 1.055) ** 2.4;
+  };
+  const luminance =
+    0.2126 * linearize(parseInt(digits.slice(0, 2), 16)) +
+    0.7152 * linearize(parseInt(digits.slice(2, 4), 16)) +
+    0.0722 * linearize(parseInt(digits.slice(4, 6), 16));
+
+  const contrastWithWhite = 1.05 / (luminance + 0.05);
+  const contrastWithBlack = (luminance + 0.05) / 0.05;
+  // White text, or the palette's near-black foreground.
+  return contrastWithWhite >= contrastWithBlack
+    ? "0 0% 100%"
+    : "222.2 47.4% 11.2%";
+}
+
+/** Accent tokens the custom scheme overrides inline (cleared on other schemes). */
+const CUSTOM_TOKEN_PROPERTIES = [
+  "--primary",
+  "--primary-foreground",
+  "--ring",
+] as const;
+
+/**
+ * Apply (or clear) the active accent scheme on the document root.
+ *
+ * - Presets set a `data-theme` attribute (the default scheme sets none, matching
+ *   the base `:root` / `.dark` tokens).
+ * - The custom scheme injects accent tokens derived from `customColor` as inline
+ *   styles, which override the stylesheet in both light and dark mode.
  *
  * @param scheme - The accent scheme to activate.
+ * @param customColor - The hex color backing the "custom" scheme.
  */
-export function applyThemeScheme(scheme: ThemeScheme): void {
+export function applyThemeScheme(
+  scheme: ThemeScheme,
+  customColor?: string,
+): void {
   if (typeof document === "undefined") return;
   const root = document.documentElement;
+
+  // Always clear any inline tokens from a previous custom selection first, so
+  // switching back to a preset/default does not leave the custom color stuck.
+  for (const property of CUSTOM_TOKEN_PROPERTIES) {
+    root.style.removeProperty(property);
+  }
+
+  if (scheme === "custom") {
+    const channels = customColor ? hexToHslChannels(customColor) : null;
+    root.removeAttribute("data-theme");
+    if (channels) {
+      root.style.setProperty("--primary", channels);
+      root.style.setProperty(
+        "--primary-foreground",
+        foregroundForHex(customColor as string),
+      );
+      root.style.setProperty("--ring", channels);
+    }
+    // An invalid/empty custom color leaves the base tokens in place.
+    return;
+  }
+
   if (scheme === DEFAULT_THEME_SCHEME) {
     root.removeAttribute("data-theme");
   } else {

--- a/apps/geolibre-desktop/src/lib/theme-schemes.ts
+++ b/apps/geolibre-desktop/src/lib/theme-schemes.ts
@@ -1,0 +1,81 @@
+/**
+ * Accent color schemes layered on top of the light/dark mode. A scheme only
+ * re-tints the accent-bearing tokens (`--primary`, `--primary-foreground`,
+ * `--ring`); the neutral base (background, border, muted) is shared. The actual
+ * token values live in `packages/ui/src/globals.css` under `[data-theme="<id>"]`
+ * selectors. This module is the single source of truth for the valid scheme ids
+ * and the picker UI (label key + representative swatch color).
+ */
+export type ThemeScheme = "blue" | "violet" | "emerald" | "rose" | "amber";
+
+/**
+ * The default scheme matches the base `:root` / `.dark` tokens already shipped in
+ * `globals.css`, so no `data-theme` attribute is set for it.
+ */
+export const DEFAULT_THEME_SCHEME: ThemeScheme = "blue";
+
+export interface ThemeSchemeOption {
+  id: ThemeScheme;
+  /** i18n key for the display label (typed so `t()` accepts it directly). */
+  labelKey:
+    | "settings.appearance.scheme.blue"
+    | "settings.appearance.scheme.violet"
+    | "settings.appearance.scheme.emerald"
+    | "settings.appearance.scheme.rose"
+    | "settings.appearance.scheme.amber";
+  /** Representative swatch color (`hsl()`) shown as the picker dot. */
+  swatch: string;
+}
+
+/** Selectable accent schemes, in picker order. Single source of truth. */
+export const THEME_SCHEMES: readonly ThemeSchemeOption[] = [
+  {
+    id: "blue",
+    labelKey: "settings.appearance.scheme.blue",
+    swatch: "hsl(221.2 83.2% 53.3%)",
+  },
+  {
+    id: "violet",
+    labelKey: "settings.appearance.scheme.violet",
+    swatch: "hsl(262.1 83.3% 57.8%)",
+  },
+  {
+    id: "emerald",
+    labelKey: "settings.appearance.scheme.emerald",
+    swatch: "hsl(142.1 76.2% 36.3%)",
+  },
+  {
+    id: "rose",
+    labelKey: "settings.appearance.scheme.rose",
+    swatch: "hsl(346.8 77.2% 49.8%)",
+  },
+  {
+    id: "amber",
+    labelKey: "settings.appearance.scheme.amber",
+    swatch: "hsl(24.6 95% 53.1%)",
+  },
+];
+
+/** Type guard for persisted/tampered values. */
+export function isThemeScheme(value: unknown): value is ThemeScheme {
+  return (
+    typeof value === "string" &&
+    THEME_SCHEMES.some((scheme) => scheme.id === value)
+  );
+}
+
+/**
+ * Apply (or clear) the active accent scheme on the document root. The default
+ * scheme removes the attribute so the base `:root` / `.dark` tokens apply.
+ *
+ * @param scheme - The accent scheme to activate.
+ */
+export function applyThemeScheme(scheme: ThemeScheme): void {
+  if (typeof document === "undefined") return;
+  const root = document.documentElement;
+  if (scheme === DEFAULT_THEME_SCHEME) {
+    root.removeAttribute("data-theme");
+  } else {
+    root.setAttribute("data-theme", scheme);
+  }
+}

--- a/apps/geolibre-desktop/src/lib/theme-schemes.ts
+++ b/apps/geolibre-desktop/src/lib/theme-schemes.ts
@@ -10,32 +10,41 @@
  * (which override the stylesheet in both light and dark mode). This module is the
  * single source of truth for the valid scheme ids and the picker UI.
  */
-export type ThemeScheme =
-  | "blue"
-  | "violet"
-  | "emerald"
-  | "rose"
-  | "amber"
-  | "custom";
+/**
+ * Preset scheme ids, the single source of truth. Each one has a matching
+ * `[data-theme="<id>"]` block in `globals.css` and an entry in `THEME_SCHEMES`.
+ * Deriving the type from this array keeps the three in sync: adding an id here
+ * without a `THEME_SCHEMES` entry is a compile error (the array is typed against
+ * the derived id), so persisted values can't silently fall back to the default.
+ */
+const PRESET_SCHEME_IDS = [
+  "blue",
+  "violet",
+  "emerald",
+  "rose",
+  "amber",
+] as const;
+
+type PresetScheme = (typeof PRESET_SCHEME_IDS)[number];
+
+/** A preset scheme, or "custom" (a user-picked hex color applied inline). */
+export type ThemeScheme = PresetScheme | "custom";
 
 /**
  * The default scheme matches the base `:root` / `.dark` tokens already shipped in
- * `globals.css`, so no `data-theme` attribute is set for it.
+ * `globals.css`, so no `data-theme` attribute is set for it. Invariant: if this
+ * ever changes to another preset, add a `[data-theme="<old default>"]` block in
+ * `globals.css` for the now-non-default scheme (see `applyThemeScheme`).
  */
-export const DEFAULT_THEME_SCHEME: ThemeScheme = "blue";
+export const DEFAULT_THEME_SCHEME: PresetScheme = "blue";
 
 /** Seed color for the custom picker before the user changes it (a teal-cyan). */
 export const DEFAULT_CUSTOM_COLOR = "#0ea5e9";
 
 export interface ThemeSchemeOption {
-  id: ThemeScheme;
+  id: PresetScheme;
   /** i18n key for the display label (typed so `t()` accepts it directly). */
-  labelKey:
-    | "settings.appearance.scheme.blue"
-    | "settings.appearance.scheme.violet"
-    | "settings.appearance.scheme.emerald"
-    | "settings.appearance.scheme.rose"
-    | "settings.appearance.scheme.amber";
+  labelKey: `settings.appearance.scheme.${PresetScheme}`;
   /** Representative swatch color (`hsl()`) shown as the picker dot. */
   swatch: string;
 }
@@ -72,18 +81,19 @@ export const THEME_SCHEMES: readonly ThemeSchemeOption[] = [
   },
 ];
 
-const HEX_COLOR = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i;
+// Requires a leading `#`: the stored value is bound to `<input type="color">`,
+// which only accepts exact `#rrggbb`/`#rgb` and resets to black otherwise.
+const HEX_COLOR = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i;
 
 /** Type guard for persisted/tampered scheme values. */
 export function isThemeScheme(value: unknown): value is ThemeScheme {
   return (
     value === "custom" ||
-    (typeof value === "string" &&
-      THEME_SCHEMES.some((scheme) => scheme.id === value))
+    (PRESET_SCHEME_IDS as readonly string[]).includes(value as string)
   );
 }
 
-/** Whether `value` is a 3- or 6-digit hex color (with or without a leading #). */
+/** Whether `value` is a 3- or 6-digit hex color with a leading `#`. */
 export function isHexColor(value: unknown): value is string {
   return typeof value === "string" && HEX_COLOR.test(value.trim());
 }
@@ -104,7 +114,7 @@ function expandHex(hex: string): string {
  * Convert a hex color to the bare HSL channels (`"H S% L%"`) the design tokens
  * expect. Returns null for invalid input.
  *
- * @param hex - A 3- or 6-digit hex color, with or without a leading `#`.
+ * @param hex - A 3- or 6-digit hex color with a leading `#`.
  */
 export function hexToHslChannels(hex: string): string | null {
   const digits = expandHex(hex);
@@ -151,7 +161,7 @@ export function foregroundForHex(hex: string): string {
 
   const linearize = (value: number) => {
     const channel = value / 255;
-    return channel <= 0.03928
+    return channel <= 0.04045
       ? channel / 12.92
       : ((channel + 0.055) / 1.055) ** 2.4;
   };
@@ -200,20 +210,22 @@ export function applyThemeScheme(
   }
 
   if (scheme === "custom") {
-    const channels = customColor ? hexToHslChannels(customColor) : null;
     root.removeAttribute("data-theme");
-    if (channels) {
+    // Guard on `customColor` (not just the parsed channels) so TypeScript knows
+    // it is a string when computing the foreground, no cast needed.
+    const channels = customColor ? hexToHslChannels(customColor) : null;
+    if (customColor && channels) {
       root.style.setProperty("--primary", channels);
-      root.style.setProperty(
-        "--primary-foreground",
-        foregroundForHex(customColor as string),
-      );
+      root.style.setProperty("--primary-foreground", foregroundForHex(customColor));
       root.style.setProperty("--ring", channels);
     }
     // An invalid/empty custom color leaves the base tokens in place.
     return;
   }
 
+  // The default scheme has no `[data-theme]` block — its tokens equal the base
+  // `:root` / `.dark` rules, so clearing the attribute applies them (see the
+  // invariant on DEFAULT_THEME_SCHEME). Every other preset has a matching block.
   if (scheme === DEFAULT_THEME_SCHEME) {
     root.removeAttribute("data-theme");
   } else {

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -49,6 +49,55 @@
     --ring: 224.3 76.3% 48%;
   }
 
+  /* Accent color schemes. Each scheme overrides only the accent-bearing tokens
+     (primary / its foreground / focus ring); the neutral base inherited from
+     :root and .dark is left untouched. Selected via a `data-theme` attribute on
+     <html> (see apps/.../lib/theme-schemes.ts). The default "blue" scheme needs
+     no block here because it equals the base :root / .dark values above. */
+  [data-theme="violet"] {
+    --primary: 262.1 83.3% 57.8%;
+    --primary-foreground: 210 20% 98%;
+    --ring: 262.1 83.3% 57.8%;
+  }
+  [data-theme="violet"].dark {
+    --primary: 263.4 70% 50.4%;
+    --primary-foreground: 210 20% 98%;
+    --ring: 263.4 70% 50.4%;
+  }
+
+  [data-theme="emerald"] {
+    --primary: 142.1 76.2% 36.3%;
+    --primary-foreground: 355.7 100% 97.3%;
+    --ring: 142.1 76.2% 36.3%;
+  }
+  [data-theme="emerald"].dark {
+    --primary: 142.1 70.6% 45.3%;
+    --primary-foreground: 144.9 80.4% 10%;
+    --ring: 142.4 71.8% 29.2%;
+  }
+
+  [data-theme="rose"] {
+    --primary: 346.8 77.2% 49.8%;
+    --primary-foreground: 355.7 100% 97.3%;
+    --ring: 346.8 77.2% 49.8%;
+  }
+  [data-theme="rose"].dark {
+    --primary: 346.8 77.2% 49.8%;
+    --primary-foreground: 355.7 100% 97.3%;
+    --ring: 346.8 77.2% 49.8%;
+  }
+
+  [data-theme="amber"] {
+    --primary: 24.6 95% 53.1%;
+    --primary-foreground: 60 9.1% 97.8%;
+    --ring: 24.6 95% 53.1%;
+  }
+  [data-theme="amber"].dark {
+    --primary: 20.5 90.2% 48.2%;
+    --primary-foreground: 60 9.1% 97.8%;
+    --ring: 20.5 90.2% 48.2%;
+  }
+
   * {
     @apply border-border;
   }

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -81,20 +81,26 @@
     --primary-foreground: 355.7 100% 97.3%;
     --ring: 346.8 77.2% 49.8%;
   }
+  /* Rose intentionally shares one mid-lightness accent across light and dark
+     (matching the upstream shadcn rose palette); 49.8% L reads on both, so
+     unlike the other schemes the dark block is deliberately not adjusted. */
   [data-theme="rose"].dark {
     --primary: 346.8 77.2% 49.8%;
     --primary-foreground: 355.7 100% 97.3%;
     --ring: 346.8 77.2% 49.8%;
   }
 
+  /* Amber's primary is a mid-brightness orange, so foreground text uses a dark
+     brown (not near-white) to meet contrast on the primary surface in both
+     modes — consistent with the contrast-maximizing pick in foregroundForHex. */
   [data-theme="amber"] {
     --primary: 24.6 95% 53.1%;
-    --primary-foreground: 60 9.1% 97.8%;
+    --primary-foreground: 26 83.3% 14.1%;
     --ring: 24.6 95% 53.1%;
   }
   [data-theme="amber"].dark {
     --primary: 20.5 90.2% 48.2%;
-    --primary-foreground: 60 9.1% 97.8%;
+    --primary-foreground: 26 83.3% 14.1%;
     --ring: 20.5 90.2% 48.2%;
   }
 


### PR DESCRIPTION
## Summary

Adds **accent color schemes** on top of the existing light/dark mode, so the app can ship a more modern, customizable look. Five presets, **Blue** (default), **Violet**, **Emerald**, **Rose**, **Amber**, plus a **Custom** option where the user picks any hex color.

Presets re-tint only the accent-bearing tokens (`--primary`, `--primary-foreground`, `--ring`) via a `data-theme` attribute on `<html>`, stacking with the existing `.dark` class so every preset has both light and dark values. The Custom option derives those same tokens from the picked hex at runtime (HSL channels for `--primary`/`--ring`, a WCAG-contrast-maximizing `--primary-foreground`) and injects them inline, overriding the stylesheet in both modes; switching back to a preset clears the inline override. The neutral base (backgrounds, borders, muted) is untouched so contrast stays safe, and because every component already consumes `hsl(var(--primary))`, the whole UI re-tints with no component changes.

## How to use

- **Settings dialog → Appearance**: swatch-grid picker, including a Custom tile with a native color input.
- **Settings dropdown → Appearance**: quick swatch radio group (presets + Custom) and a link into the dialog for editing the custom color.

Both apply **live** (instant preview), mirroring the Interface profile toggles. The choice is persisted in `desktopSettings.theme` (`scheme` + `customColor`, localStorage) and survives reload. Light/dark stays a separate axis, toggled from the toolbar as before.

## Changes

- `packages/ui/src/globals.css` — per-preset `[data-theme="..."]` / `[data-theme="..."].dark` token blocks.
- `apps/geolibre-desktop/src/lib/theme-schemes.ts` *(new)* — single source of truth: scheme ids, labels, swatch colors, hex validation, hex→HSL + foreground helpers, and the apply/inject logic.
- `apps/geolibre-desktop/src/hooks/useThemeScheme.ts` *(new)* — syncs the persisted scheme + custom color to the DOM (in `useLayoutEffect`, so no flash on reload).
- `apps/geolibre-desktop/src/hooks/useDesktopSettings.ts` — persisted `theme: { scheme, customColor }` with tamper-resistant normalization.
- `apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx` — Appearance section + dropdown submenu.
- `apps/geolibre-desktop/src/i18n/locales/en.json` — English strings (other locales fall back to English).

## Testing

- `npm run typecheck` (full build) passes; all 1289 frontend tests pass.
- `pre-commit run --files <changed>` passes (eslint, npm build, etc.).
- Verified in a real browser (Playwright):
  - Preset picker renders; Blue active by default; selecting a preset flips `--primary` instantly (e.g. Emerald → `142.1 76.2% 36.3%`).
  - Dark + scheme stacks correctly: `.dark[data-theme="emerald"]` → dark emerald token `142.1 70.6% 45.3%`.
  - Dropdown submenu radio group applies live (Violet → `262.1 83.3% 57.8%`).
  - Custom: `#0ea5e9` → `--primary: 198.6 88.7% 48.4%`; `#ff0000` → `0 100% 50%` with a dark foreground (higher contrast than white on saturated red). Persists across reload; switching back to a preset clears the inline tokens so the CSS block takes over.

## Notes / follow-ups

- Custom currently uses one color for both light and dark (WYSIWYG); per-mode tuning could be a future refinement.
- Palette is easy to extend (just `theme-schemes.ts` + a CSS block per preset).
- Possible future polish: auto-switch the basemap to a matching light/dark style, or a per-project theme in `.geolibre.json`.
