### PR TITLE
feat(basemap): swap the core basemap via double-click in the layer panel

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
@@ -1,12 +1,15 @@
 import {
   BLANK_BASEMAP,
   createDefaultMapView,
-  getProtomapsStyleUrl,
   OPENFREEMAP_BASEMAPS,
   PROTOMAPS_BASEMAPS,
   useAppStore,
   type MapViewState,
 } from "@geolibre/core";
+import {
+  resolveProtomapsPresets,
+  type PresetBasemap,
+} from "../../lib/basemap-presets";
 import {
   Button,
   cn,
@@ -42,25 +45,6 @@ type BasemapChoice =
   | (typeof PROTOMAPS_BASEMAPS)[number]["id"]
   | typeof CUSTOM_BASEMAP_ID
   | typeof BLANK_BASEMAP_ID;
-
-interface PresetBasemap {
-  id: BasemapChoice;
-  name: string;
-  styleUrl: string;
-}
-
-/**
- * Resolves the selectable Protomaps basemaps for the current runtime
- * environment. Returns an empty list when no `VITE_PROTOMAPS_API_KEY` is
- * configured (build-time or via Settings → Environment variables), in which
- * case the Protomaps section is hidden.
- */
-function resolveProtomapsPresets(): PresetBasemap[] {
-  return PROTOMAPS_BASEMAPS.flatMap((basemap) => {
-    const styleUrl = getProtomapsStyleUrl(basemap.flavor);
-    return styleUrl ? [{ id: basemap.id, name: basemap.name, styleUrl }] : [];
-  });
-}
 
 interface BasemapButtonProps {
   id: BasemapChoice;

--- a/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/NewProjectDialog.tsx
@@ -7,6 +7,7 @@ import {
   type MapViewState,
 } from "@geolibre/core";
 import {
+  LIBERTY_3D_ID,
   resolveProtomapsPresets,
   type PresetBasemap,
 } from "../../lib/basemap-presets";
@@ -166,7 +167,7 @@ export function NewProjectDialog({
       name: projectName.trim() || DEFAULT_PROJECT_NAME,
       basemapStyleUrl,
       mapView:
-        selectedBasemapId === "liberty-3d"
+        selectedBasemapId === LIBERTY_3D_ID
           ? THREE_D_MAP_VIEW
           : createDefaultMapView(),
     });

--- a/apps/geolibre-desktop/src/components/panels/BasemapPickerDialog.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BasemapPickerDialog.tsx
@@ -1,0 +1,237 @@
+import { BLANK_BASEMAP, useAppStore } from "@geolibre/core";
+import {
+  Button,
+  cn,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+} from "@geolibre/ui";
+import type { FormEvent } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  getOpenFreeMapPresets,
+  resolveProtomapsPresets,
+  type PresetBasemap,
+} from "../../lib/basemap-presets";
+
+// The id of the OpenFreeMap "Liberty 3D" preset. Picking it applies the Liberty
+// style and tilts the current camera into a 3D perspective in place (matching
+// the New Project dialog, which pairs that preset with a 3D map view).
+const LIBERTY_3D_ID = "liberty-3d";
+const THREE_D_PITCH = 60;
+
+const BLANK_CHOICE = "__blank__";
+const CUSTOM_CHOICE = "__custom__";
+
+interface PresetButtonProps {
+  name: string;
+  selected: boolean;
+  onSelect: () => void;
+}
+
+function PresetButton({ name, selected, onSelect }: PresetButtonProps) {
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      className={cn(
+        "h-10 rounded-md border px-3 text-sm font-medium transition-colors",
+        "hover:bg-accent hover:text-accent-foreground",
+        selected
+          ? "border-primary bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground"
+          : "border-input bg-background",
+      )}
+      onClick={onSelect}
+    >
+      {name}
+    </button>
+  );
+}
+
+interface BasemapPickerDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Quick picker for swapping the active core basemap from the layer panel's
+ * Background row. Offers the same predefined basemaps as the New Project dialog
+ * (OpenFreeMap, Protomaps when an API key is configured, a blank background, or
+ * a custom style URL) and applies the selection instantly via the store. The
+ * current camera is preserved, so only the underlying map style changes.
+ */
+export function BasemapPickerDialog({
+  open,
+  onOpenChange,
+}: BasemapPickerDialogProps) {
+  const { t } = useTranslation();
+  const basemapStyleUrl = useAppStore((s) => s.basemapStyleUrl);
+  const setBasemapStyleUrl = useAppStore((s) => s.setBasemapStyleUrl);
+  const setMapView = useAppStore((s) => s.setMapView);
+
+  const openFreeMapPresets = useMemo(() => getOpenFreeMapPresets(), []);
+  // Protomaps styles need an API key (VITE_PROTOMAPS_API_KEY). It can come from
+  // the build or from Settings → Environment variables, so re-resolve when the
+  // dialog opens and whenever the runtime env changes; an absent key hides the
+  // section.
+  const [protomapsPresets, setProtomapsPresets] = useState<PresetBasemap[]>(
+    resolveProtomapsPresets,
+  );
+  useEffect(() => {
+    if (!open) return;
+    const refresh = () => setProtomapsPresets(resolveProtomapsPresets());
+    refresh();
+    window.addEventListener("geolibre:runtime-env-change", refresh);
+    return () =>
+      window.removeEventListener("geolibre:runtime-env-change", refresh);
+  }, [open]);
+
+  const allPresets = useMemo(
+    () => [...openFreeMapPresets, ...protomapsPresets],
+    [openFreeMapPresets, protomapsPresets],
+  );
+
+  // The currently active choice, used to highlight a single button. Match on the
+  // style URL; "Liberty 3D" shares Liberty's URL, so the first match (Liberty)
+  // wins and only one button highlights.
+  const activeChoice = useMemo(() => {
+    if (basemapStyleUrl === BLANK_BASEMAP) return BLANK_CHOICE;
+    const preset = allPresets.find((p) => p.styleUrl === basemapStyleUrl);
+    return preset ? preset.id : CUSTOM_CHOICE;
+  }, [allPresets, basemapStyleUrl]);
+
+  // Seed the custom URL field with the active style when it is not one of the
+  // known presets (i.e. the project was created from a custom style URL).
+  const [customUrl, setCustomUrl] = useState("");
+  useEffect(() => {
+    if (!open) return;
+    setCustomUrl(activeChoice === CUSTOM_CHOICE ? basemapStyleUrl : "");
+    // Re-seed only when the dialog opens, not on every store change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const customStyleUrl = customUrl.trim();
+  const isCustomUrlValid = useMemo(() => {
+    if (!customStyleUrl) return false;
+    try {
+      const url = new URL(customStyleUrl);
+      return url.protocol === "http:" || url.protocol === "https:";
+    } catch {
+      return false;
+    }
+  }, [customStyleUrl]);
+
+  const applyPreset = (preset: PresetBasemap) => {
+    setBasemapStyleUrl(preset.styleUrl);
+    if (preset.id === LIBERTY_3D_ID) {
+      // Tilt the current view into 3D in place, preserving center and zoom.
+      setMapView({ pitch: THREE_D_PITCH }, true);
+    }
+    onOpenChange(false);
+  };
+
+  const applyBlank = () => {
+    setBasemapStyleUrl(BLANK_BASEMAP);
+    onOpenChange(false);
+  };
+
+  const applyCustom = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!isCustomUrlValid) return;
+    setBasemapStyleUrl(customStyleUrl);
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle>{t("basemapPicker.title")}</DialogTitle>
+          <DialogDescription>
+            {protomapsPresets.length > 0
+              ? t("newProject.basemapDescription")
+              : t("newProject.basemapDescriptionNoProtomaps")}
+          </DialogDescription>
+        </DialogHeader>
+
+        <form className="space-y-5" onSubmit={applyCustom}>
+          <div className="space-y-2">
+            <p className="text-xs font-medium text-muted-foreground">
+              {t("newProject.sectionOpenFreeMap")}
+            </p>
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+              {openFreeMapPresets.map((basemap) => (
+                <PresetButton
+                  key={basemap.id}
+                  name={basemap.name}
+                  selected={activeChoice === basemap.id}
+                  onSelect={() => applyPreset(basemap)}
+                />
+              ))}
+            </div>
+          </div>
+
+          {protomapsPresets.length > 0 ? (
+            <div className="space-y-2">
+              <p className="text-xs font-medium text-muted-foreground">
+                {t("newProject.sectionProtomaps")}
+              </p>
+              <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                {protomapsPresets.map((basemap) => (
+                  <PresetButton
+                    key={basemap.id}
+                    name={basemap.name}
+                    selected={activeChoice === basemap.id}
+                    onSelect={() => applyPreset(basemap)}
+                  />
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          <div className="space-y-2">
+            <p className="text-xs font-medium text-muted-foreground">
+              {t("newProject.sectionOther")}
+            </p>
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+              <PresetButton
+                name="Blank"
+                selected={activeChoice === BLANK_CHOICE}
+                onSelect={applyBlank}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="basemap-picker-custom-url">
+              {t("newProject.customUrlButton")}
+            </Label>
+            <div className="flex gap-2">
+              <Input
+                id="basemap-picker-custom-url"
+                type="url"
+                inputMode="url"
+                placeholder="https://example.com/style.json"
+                value={customUrl}
+                onChange={(event) => setCustomUrl(event.target.value)}
+              />
+              <Button type="submit" disabled={!isCustomUrlValid}>
+                {t("basemapPicker.applyCustom")}
+              </Button>
+            </div>
+            {customStyleUrl && !isCustomUrlValid ? (
+              <p className="text-xs text-destructive">
+                {t("basemapPicker.invalidUrl")}
+              </p>
+            ) : null}
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/geolibre-desktop/src/components/panels/BasemapPickerDialog.tsx
+++ b/apps/geolibre-desktop/src/components/panels/BasemapPickerDialog.tsx
@@ -15,14 +15,14 @@ import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   getOpenFreeMapPresets,
+  LIBERTY_3D_ID,
   resolveProtomapsPresets,
   type PresetBasemap,
 } from "../../lib/basemap-presets";
 
-// The id of the OpenFreeMap "Liberty 3D" preset. Picking it applies the Liberty
-// style and tilts the current camera into a 3D perspective in place (matching
-// the New Project dialog, which pairs that preset with a 3D map view).
-const LIBERTY_3D_ID = "liberty-3d";
+// Picking the "Liberty 3D" preset applies the Liberty style and tilts the
+// current camera into a 3D perspective in place (matching the New Project
+// dialog, which pairs that preset with a 3D map view).
 const THREE_D_PITCH = 60;
 
 const BLANK_CHOICE = "__blank__";

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -102,6 +102,7 @@ import {
   shapefileFieldWarnings,
   type VectorExportFormat,
 } from "../../lib/vector-export";
+import { BasemapPickerDialog } from "./BasemapPickerDialog";
 
 interface LayerPanelProps {
   mapControllerRef: RefObject<MapController | null>;
@@ -223,6 +224,7 @@ export function LayerPanel({
   const setAttributeTableOpen = useAppStore((s) => s.setAttributeTableOpen);
   const [editingLayerId, setEditingLayerId] = useState<string | null>(null);
   const [editingName, setEditingName] = useState("");
+  const [basemapPickerOpen, setBasemapPickerOpen] = useState(false);
   const [metadataLayer, setMetadataLayer] = useState<GeoLibreLayer | null>(
     null,
   );
@@ -1840,7 +1842,9 @@ export function LayerPanel({
                 ? "border-primary bg-primary/5"
                 : "border-border bg-background hover:border-muted-foreground/40 hover:bg-muted/20"
             }`}
+            title={t("layers.doubleClickToChangeBasemap")}
             onClick={() => selectLayer(BACKGROUND_SELECTION_ID)}
+            onDoubleClick={() => setBasemapPickerOpen(true)}
             onKeyDown={(e) => {
               if (e.key === "Enter") selectLayer(BACKGROUND_SELECTION_ID);
             }}
@@ -1910,6 +1914,10 @@ export function LayerPanel({
           {t("layers.advancedFormatsNote")}
         </p>
       ) : null}
+      <BasemapPickerDialog
+        open={basemapPickerOpen}
+        onOpenChange={setBasemapPickerOpen}
+      />
       <Dialog
         open={!!bindTimeSliderLayerId}
         onOpenChange={(open: boolean) => {

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -1847,6 +1847,12 @@ export function LayerPanel({
             onDoubleClick={() => setBasemapPickerOpen(true)}
             onKeyDown={(e) => {
               if (e.key === "Enter") selectLayer(BACKGROUND_SELECTION_ID);
+              // Keyboard equivalent of the double-click: Space opens the basemap
+              // picker (preventDefault stops the panel from scrolling).
+              if (e.key === " ") {
+                e.preventDefault();
+                setBasemapPickerOpen(true);
+              }
             }}
             role="button"
             tabIndex={0}

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -66,6 +66,11 @@
     "sectionOther": "Other",
     "customUrlButton": "Custom URL"
   },
+  "basemapPicker": {
+    "title": "Change basemap",
+    "applyCustom": "Apply",
+    "invalidUrl": "Enter a valid HTTP or HTTPS style URL."
+  },
   "common": {
     "pickColorFromScreen": "Pick a color from the screen",
     "save": "Save",
@@ -1675,6 +1680,7 @@
     "groupOpacity": "Opacity",
     "groupOpacityAria": "{{name}} group opacity",
     "doubleClickToRename": "Double-click to rename",
+    "doubleClickToChangeBasemap": "Double-click to change the basemap",
     "renameNamed": "Rename {{name}}",
     "newGroupFromLayer": "New group from layer",
     "moveToGroup": "Move to group",

--- a/apps/geolibre-desktop/src/lib/basemap-presets.ts
+++ b/apps/geolibre-desktop/src/lib/basemap-presets.ts
@@ -20,6 +20,15 @@ export interface PresetBasemap {
   styleUrl: string;
 }
 
+/**
+ * The OpenFreeMap "Liberty 3D" preset id. It shares Liberty's style URL but
+ * additionally tilts the camera into a 3D view, so callers special-case it. The
+ * `satisfies` constraint keeps this literal in sync with `OPENFREEMAP_BASEMAPS`:
+ * renaming the id there turns this into a compile error rather than a silently
+ * dead branch.
+ */
+export const LIBERTY_3D_ID = "liberty-3d" satisfies PresetBasemapId;
+
 /** The OpenFreeMap presets, always available (no API key required). */
 export function getOpenFreeMapPresets(): PresetBasemap[] {
   return OPENFREEMAP_BASEMAPS.map((basemap) => ({

--- a/apps/geolibre-desktop/src/lib/basemap-presets.ts
+++ b/apps/geolibre-desktop/src/lib/basemap-presets.ts
@@ -1,0 +1,43 @@
+import {
+  getProtomapsStyleUrl,
+  OPENFREEMAP_BASEMAPS,
+  PROTOMAPS_BASEMAPS,
+} from "@geolibre/core";
+
+/**
+ * Ids of the predefined basemaps that resolve to a ready-to-use style URL
+ * (OpenFreeMap plus the Protomaps flavors). Excludes the dialog-only sentinels
+ * for the blank background and a custom URL.
+ */
+export type PresetBasemapId =
+  | (typeof OPENFREEMAP_BASEMAPS)[number]["id"]
+  | (typeof PROTOMAPS_BASEMAPS)[number]["id"];
+
+/** A predefined basemap reduced to the fields the pickers need. */
+export interface PresetBasemap {
+  id: PresetBasemapId;
+  name: string;
+  styleUrl: string;
+}
+
+/** The OpenFreeMap presets, always available (no API key required). */
+export function getOpenFreeMapPresets(): PresetBasemap[] {
+  return OPENFREEMAP_BASEMAPS.map((basemap) => ({
+    id: basemap.id,
+    name: basemap.name,
+    styleUrl: basemap.styleUrl,
+  }));
+}
+
+/**
+ * Resolves the selectable Protomaps basemaps for the current runtime
+ * environment. Returns an empty list when no `VITE_PROTOMAPS_API_KEY` is
+ * configured (build-time or via Settings → Environment variables), in which
+ * case the Protomaps section is hidden.
+ */
+export function resolveProtomapsPresets(): PresetBasemap[] {
+  return PROTOMAPS_BASEMAPS.flatMap((basemap) => {
+    const styleUrl = getProtomapsStyleUrl(basemap.flavor);
+    return styleUrl ? [{ id: basemap.id, name: basemap.name, styleUrl }] : [];
+  });
+}


### PR DESCRIPTION
## Summary

Implements the feature requested in #623: a quick way to swap the core (foundation) basemap directly from the layer panel, instead of stacking a second basemap on top and hiding the original.

Double-clicking the **Background** row at the bottom of the layer panel now opens a "Change basemap" picker offering the same predefined basemaps as the New Project dialog:

- OpenFreeMap presets (Liberty, Liberty 3D, Positron, Bright, Dark, Fiord)
- Protomaps presets (only when a `VITE_PROTOMAPS_API_KEY` is configured)
- A blank background
- A custom MapLibre style URL

Selecting a preset applies it **instantly** and closes the picker. The current camera (center/zoom) is preserved, so only the underlying map style changes. The **Liberty 3D** preset additionally tilts the view into a 3D perspective in place, matching how that preset behaves in New Project. The picker highlights whichever basemap is currently active.

## Implementation notes

- New `BasemapPickerDialog` component (`apps/geolibre-desktop/src/components/panels/`), wired to the Background row's new `onDoubleClick` in `LayerPanel`. The swap goes through the existing `setBasemapStyleUrl` store action, so `MapCanvas` re-styles and re-syncs layers automatically. No changes were needed in `@geolibre/map`.
- The Protomaps preset resolution that the New Project dialog used is extracted into a shared `lib/basemap-presets` helper so both dialogs draw from a single source of truth.
- New user-facing strings added to `en.json` (`basemapPicker.*`, `layers.doubleClickToChangeBasemap`).

## Verification

Drove the real app in the browser with Playwright using a fresh project:

- Double-click Background opens the picker with the active basemap highlighted.
- Swapped to Positron (light style), Blank (empty), and a custom style URL: each applies instantly and closes the picker.
- Liberty 3D swaps to the Liberty style and tilts to pitch 60 while keeping the same center/zoom.
- The active highlight tracks the current basemap after each swap.
- Confirmed the picker renders correctly in **both light and dark themes**, with no console errors.

`npm run build` and scoped `pre-commit` (eslint + npm build) both pass.

Fixes #623