### PR TITLE
ci: add Cloudflare Pages PR deploy previews

### DIFF
--- a/.github/workflows/cloudflare-preview.yml
+++ b/.github/workflows/cloudflare-preview.yml
@@ -42,6 +42,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          # Match ci.yml: don't leave the GITHUB_TOKEN in .git/config where an
+          # npm lifecycle script during `npm ci`/`npm run build` could read it.
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -72,7 +76,6 @@ jobs:
         run: npm run build -w geolibre-desktop
         env:
           GEOLIBRE_APP_BASE: ./
-          NODE_OPTIONS: --max-old-space-size=4096
           VITE_GEE_OAUTH_CLIENT_ID: ${{ secrets.VITE_GEE_OAUTH_CLIENT_ID }}
           VITE_PROTOMAPS_API_KEY: ${{ secrets.VITE_PROTOMAPS_API_KEY }}
           VITE_GEOLIBRE_COLLAB_URL: wss://collab.geolibre.app
@@ -133,21 +136,23 @@ jobs:
           command: >-
             pages deploy site
             --project-name=geolibre-preview
-            --branch=${{ github.head_ref || github.ref_name }}
+            --branch="${{ github.head_ref || github.ref_name }}"
             --commit-dirty=true
 
       - name: Comment preview URL on PR
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
+        env:
+          DEPLOY_URL: ${{ steps.deploy.outputs.deployment-url }}
         with:
           script: |
-            const url = ${{ toJSON(steps.deploy.outputs.deployment-url) }};
+            const url = process.env.DEPLOY_URL;
             if (!url) return;
             const marker = '<!-- cloudflare-preview -->';
             const body = `${marker}\n### ⚡ Cloudflare Pages preview\n\n| Item | Value |\n| --- | --- |\n| Preview | ${url} |\n| Demo app | ${url}/demo/ |\n| Commit | \`${context.sha.slice(0, 7)}\` |`;
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
-            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number, per_page: 100 });
             const existing = comments.find((c) => c.body && c.body.includes(marker));
             if (existing) {
               await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });

--- a/.github/workflows/cloudflare-preview.yml
+++ b/.github/workflows/cloudflare-preview.yml
@@ -87,6 +87,41 @@ jobs:
           test -f site/demo/index.html
           test -f site/demo/jupyterlite/lab/index.html
 
+      - name: Offload oversized DuckDB WASM to CDN
+        # Cloudflare Pages rejects any single file > 25 MiB. The bundled DuckDB
+        # WASM modules (duckdb-eh ~35 MiB, duckdb-mvp ~40 MiB) exceed that, so we
+        # drop the local copies and redirect their hashed URLs to jsDelivr at the
+        # exact pinned version (byte-identical to the bundled file). This only
+        # affects the Cloudflare preview; GitHub Pages still serves them locally.
+        # Any OTHER oversized file is a hard error so we never ship a broken site.
+        run: |
+          set -euo pipefail
+          version=$(node -e "console.log(require('./node_modules/@duckdb/duckdb-wasm/package.json').version)")
+          echo "duckdb-wasm version: $version"
+          redirects=site/_redirects
+          touch "$redirects"
+          moved=0
+          # 26214400 bytes = 25 MiB, Cloudflare Pages' exact per-file limit.
+          while IFS= read -r -d '' f; do
+            rel=${f#site}
+            base=$(basename "$f")
+            case "$base" in
+              duckdb-eh-*)  cdn=duckdb-eh.wasm ;;
+              duckdb-mvp-*) cdn=duckdb-mvp.wasm ;;
+              duckdb-coi-*) cdn=duckdb-coi.wasm ;;
+              *)
+                echo "::error::Oversized file not handled by CDN redirect: $rel ($(du -h "$f" | cut -f1)). Cloudflare Pages rejects files > 25 MiB."
+                exit 1 ;;
+            esac
+            echo "$rel https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@${version}/dist/${cdn} 302" >> "$redirects"
+            rm "$f"
+            echo "redirect: $rel -> $cdn"
+            moved=$((moved + 1))
+          done < <(find site -type f -size +26214400c -print0)
+          echo "offloaded $moved oversized file(s)"
+          echo "----- site/_redirects -----"
+          cat "$redirects"
+
       - name: Deploy to Cloudflare Pages
         id: deploy
         uses: cloudflare/wrangler-action@v3

--- a/.github/workflows/cloudflare-preview.yml
+++ b/.github/workflows/cloudflare-preview.yml
@@ -1,0 +1,121 @@
+name: Cloudflare preview
+
+# Builds the docs site + web demo for every pull request and uploads it to a
+# Cloudflare Pages project as a *preview* deployment, then comments the URL on
+# the PR. This replaces the old Netlify Deploy Previews.
+#
+# The build mirrors .github/workflows/pages.yml (the GitHub Pages production
+# deploy) so previews match what ships:
+#   docs deps -> jupyterlite deps -> npm ci -> web demo build -> docs build ->
+#   bundle demo into site/demo.
+#
+# NOTE on fork PRs: the `pull_request` event does NOT expose repository secrets
+# to PRs opened from forks, so previews only run for branches pushed to this
+# repo (maintainers and collaborators). External fork PRs are skipped — the job
+# guard below short-circuits them instead of failing with a missing token.
+#
+# Required repository secrets (already present for the Workers deploys):
+#   CLOUDFLARE_API_TOKEN   - needs the "Cloudflare Pages: Edit" permission
+#   CLOUDFLARE_ACCOUNT_ID
+# Optional (baked into the client bundle, same as pages.yml):
+#   VITE_GEE_OAUTH_CLIENT_ID, VITE_PROTOMAPS_API_KEY
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: cf-preview-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    name: Build and deploy preview
+    runs-on: ubuntu-latest
+    # Skip fork PRs: secrets are unavailable there, so the deploy would fail.
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            requirements-docs.txt
+            apps/geolibre-desktop/jupyterlite/requirements.txt
+
+      - name: Install documentation dependencies
+        run: python -m pip install -r requirements-docs.txt
+
+      - name: Install JupyterLite build dependencies
+        run: python -m pip install -r apps/geolibre-desktop/jupyterlite/requirements.txt
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Build web demo
+        run: npm run build -w geolibre-desktop
+        env:
+          GEOLIBRE_APP_BASE: ./
+          NODE_OPTIONS: --max-old-space-size=4096
+          VITE_GEE_OAUTH_CLIENT_ID: ${{ secrets.VITE_GEE_OAUTH_CLIENT_ID }}
+          VITE_PROTOMAPS_API_KEY: ${{ secrets.VITE_PROTOMAPS_API_KEY }}
+          VITE_GEOLIBRE_COLLAB_URL: wss://collab.geolibre.app
+
+      - name: Build documentation
+        run: zensical build --strict
+
+      - name: Add web demo to site
+        run: |
+          mkdir -p site/demo
+          cp -R apps/geolibre-desktop/dist/. site/demo/
+          test -f site/demo/index.html
+          test -f site/demo/jupyterlite/lab/index.html
+
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # --branch is anything other than the project's production branch, so
+          # every run here is a preview deployment with its own URL.
+          command: >-
+            pages deploy site
+            --project-name=geolibre-preview
+            --branch=${{ github.head_ref || github.ref_name }}
+            --commit-dirty=true
+
+      - name: Comment preview URL on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = ${{ toJSON(steps.deploy.outputs.deployment-url) }};
+            if (!url) return;
+            const marker = '<!-- cloudflare-preview -->';
+            const body = `${marker}\n### ⚡ Cloudflare Pages preview\n\n| Item | Value |\n| --- | --- |\n| Preview | ${url} |\n| Demo app | ${url}/demo/ |\n| Commit | \`${context.sha.slice(0, 7)}\` |`;
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }


### PR DESCRIPTION
## What

Adds `.github/workflows/cloudflare-preview.yml`, replacing the Netlify Deploy Previews that are unavailable while the Netlify account is out of credits.

The workflow runs on every PR to `main` (and manual dispatch), builds the docs site + web demo using the **same steps as `pages.yml`** (docs deps → JupyterLite deps → `npm ci` → web demo build → `zensical build --strict` → bundle demo into `site/demo`), then uploads `site/` to a Cloudflare Pages project as a **preview** deployment via `cloudflare/wrangler-action`. It posts/updates a sticky comment on the PR with the preview URL and a direct link to `…/demo/`.

## One-time setup required before this works

1. **Create the Pages project** (once):
   ```
   npx wrangler pages project create geolibre-preview --production-branch=production
   ```
   The `production` branch never exists, so every workflow run lands as a preview deployment.
2. **Token scope:** the existing `CLOUDFLARE_API_TOKEN` secret (used for the Workers deploys) must also include the **`Cloudflare Pages: Edit`** permission. `CLOUDFLARE_ACCOUNT_ID` is reused as-is. No new secrets needed.

## Notes

- **Fork PRs are skipped** — `pull_request` does not expose secrets to PRs from forks, so the job guard short-circuits external contributors' PRs (they won't fail, just won't get a preview). Branches pushed to this repo get previews normally.
- `netlify.toml` is intentionally left in place so Netlify CD resumes when credits return; consider disabling the Netlify site in its dashboard meanwhile to avoid failed-build noise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated preview deployments now available for all pull requests
  * Preview URLs are automatically posted to pull requests for easy access
  * Preview deployments include full documentation and demo workspace

<!-- end of auto-generated comment: release notes by coderabbit.ai -->