### PR TITLE
fix(overture): dynamic zoom hint instead of a persistent warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17737,9 +17737,9 @@
       }
     },
     "node_modules/maplibre-gl-overture-maps": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-overture-maps/-/maplibre-gl-overture-maps-0.3.0.tgz",
-      "integrity": "sha512-kjdJBt4JFrNz9n67lY3bYvTC7swZhtnjkKq2yN76EVf4PQw909QCzFaLeLTkqow2HBZ3gA5Z5Z7ueHZtTEcT7w==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-overture-maps/-/maplibre-gl-overture-maps-0.3.1.tgz",
+      "integrity": "sha512-JL7a7WE4BXhO367JXqmZyrcVAzEB1Xbh4AVLgqAD6iz1sZJ28yGihN9pBwhp8XUxeekX7rS6OX1lmk4eklEaWA==",
       "license": "MIT",
       "dependencies": {
         "pmtiles": "^4.3.0"
@@ -24315,7 +24315,7 @@
         "maplibre-gl-lidar": "^0.16.0",
         "maplibre-gl-nasa-earthdata": "^0.1.2",
         "maplibre-gl-national-map": "^0.1.1",
-        "maplibre-gl-overture-maps": "^0.3.0",
+        "maplibre-gl-overture-maps": "^0.3.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
         "maplibre-gl-raster": "^0.6.1",
         "maplibre-gl-streetview": "^0.7.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -43,7 +43,7 @@
     "maplibre-gl-lidar": "^0.16.0",
     "maplibre-gl-nasa-earthdata": "^0.1.2",
     "maplibre-gl-national-map": "^0.1.1",
-    "maplibre-gl-overture-maps": "^0.3.0",
+    "maplibre-gl-overture-maps": "^0.3.1",
     "maplibre-gl-planetary-computer": "^0.3.0",
     "maplibre-gl-raster": "^0.6.1",
     "maplibre-gl-streetview": "^0.7.0",


### PR DESCRIPTION
## Summary

Fixes #633. The Overture Maps plugin panel showed a static hint, *"Addresses and places appear at zoom 14+."*, that was written once when the panel opened and never updated. It therefore stayed visible as an outdated warning even after the user zoomed well past zoom 14, cluttering the panel and giving stale feedback.

The hint is now bound to the map's live zoom (fixed upstream in `maplibre-gl-overture-maps`):

- Below the detail-theme threshold it keeps the heads-up.
- At or above the threshold it switches to a positive confirmation, *"✓ Addresses and places active."*, styled in a success green for both light and dark schemes.

The threshold is derived from the theme definitions so it stays in sync with the tileset minzoom.

## Changes

- Bump `maplibre-gl-overture-maps` to `^0.3.1` in `packages/plugins/package.json` (+ lockfile). No GeoLibre wiring changes were needed; the control's public API is unchanged.

Upstream fix: opengeos/maplibre-gl-overture-maps#6 (released as v0.3.1).

## Testing

- `npm run build` succeeds.
- Verified in the running app with the published 0.3.1 package: activated the Overture plugin and stepped zoom across 2 / 13 / 14 / 16 / 18. Below 14 the heads-up shows; at/above 14 it switches to the green "✓ Addresses and places active." confirmation and back. Confirmed in both light (`#1a7f37`) and dark (`#5fd28b`) schemes.