### PR TITLE
fix(geoagent): stop data loss when a plugin chunk fails to load

### DIFF
--- a/apps/geolibre-desktop/src/lib/stale-chunk-reload.ts
+++ b/apps/geolibre-desktop/src/lib/stale-chunk-reload.ts
@@ -16,6 +16,8 @@
  * rather than a stale chunk.
  */
 
+import { useAppStore } from "@geolibre/core";
+import { appendDiagnostic } from "./diagnostics";
 import { isTauri } from "./is-tauri";
 
 const RELOAD_TIMESTAMP_KEY = "geolibre:stale-chunk-reload-at";
@@ -36,25 +38,56 @@ export interface StaleChunkReloadDeps {
   setLastReloadAt: (value: number) => void;
   /** Reload the page. */
   reload: () => void;
+  /** Whether the project has unsaved changes that a reload would discard. */
+  hasUnsavedChanges: () => boolean;
 }
 
 /**
- * Reloads the page to recover from a stale chunk, unless a reload happened
- * within the cooldown (in which case the failure is treated as a broken build
- * and left to surface).
+ * The outcome of a stale-chunk recovery attempt.
  *
- * @param deps - Injected clock, persistence, and reload, for testability.
- * @returns True when a reload was triggered, false when suppressed.
+ * - `reloaded` - the page was reloaded to fetch the current build's chunks.
+ * - `deferred-unsaved` - a reload was withheld to protect unsaved work; the
+ *   stale feature stays unloaded and the user is asked to save and reload.
+ * - `suppressed-cooldown` - a reload happened too recently, so the failure is
+ *   treated as a broken build and left to surface.
  */
-export function reloadForStaleChunk(deps: StaleChunkReloadDeps): boolean {
+export type StaleChunkReloadOutcome =
+  | "reloaded"
+  | "deferred-unsaved"
+  | "suppressed-cooldown";
+
+/**
+ * Decides how to recover from a stale chunk. Reloads the page unless that would
+ * discard the user's work (unsaved changes) or a reload happened within the
+ * cooldown.
+ *
+ * A forced reload here re-evaluates the current build's import graph so the
+ * lazy import resolves. But reloading throws away the in-memory project, and
+ * when there are unsaved changes the {@link useBeforeUnloadGuard} also raises
+ * the browser's "Leave site?" prompt, so an accidental reload becomes data
+ * loss. In that case recovery is deferred: the failed feature simply does not
+ * load, and the caller tells the user to save and reload deliberately. When
+ * the project is clean there is nothing to lose, so the reload runs as before.
+ *
+ * @param deps - Injected clock, persistence, reload, and dirty check, for testability.
+ * @returns Which recovery path was taken.
+ */
+export function reloadForStaleChunk(
+  deps: StaleChunkReloadDeps,
+): StaleChunkReloadOutcome {
+  // Never reload out from under unsaved work: it trips the beforeunload guard
+  // and risks losing the user's map. This takes precedence over the cooldown.
+  if (deps.hasUnsavedChanges()) {
+    return "deferred-unsaved";
+  }
   const last = deps.getLastReloadAt();
   const current = deps.now();
   if (last !== null && current - last < STALE_CHUNK_RELOAD_COOLDOWN_MS) {
-    return false;
+    return "suppressed-cooldown";
   }
   deps.setLastReloadAt(current);
   deps.reload();
-  return true;
+  return "reloaded";
 }
 
 /**
@@ -86,9 +119,9 @@ export function installStaleChunkReload(options?: {
     // Vite dispatches a plain Event with the underlying error on `.payload`
     // (not a CustomEvent `.detail`); surface it so a recovery is visible.
     const payload = (event as Event & { payload?: unknown }).payload;
-    let reloaded = false;
+    let outcome: StaleChunkReloadOutcome = "suppressed-cooldown";
     try {
-      reloaded = reloadForStaleChunk({
+      outcome = reloadForStaleChunk({
         now: () => Date.now(),
         getLastReloadAt: () => {
           const raw = window.sessionStorage.getItem(RELOAD_TIMESTAMP_KEY);
@@ -99,6 +132,7 @@ export function installStaleChunkReload(options?: {
         setLastReloadAt: (value) =>
           window.sessionStorage.setItem(RELOAD_TIMESTAMP_KEY, String(value)),
         reload: () => window.location.reload(),
+        hasUnsavedChanges: () => useAppStore.getState().isDirty,
       });
     } catch {
       // sessionStorage can throw when storage is blocked (private modes,
@@ -110,11 +144,26 @@ export function installStaleChunkReload(options?: {
         "[GeoLibre] Stale-chunk reload guard unavailable (storage blocked); leaving the preload error to surface.",
         payload,
       );
+      return;
     }
-    if (reloaded) {
+    if (outcome === "reloaded") {
       // Only suppress Vite's rethrow when we are recovering by reloading; a
       // cooldown-suppressed (broken-build) error should still surface.
       console.warn("[GeoLibre] Reloading to recover from a stale chunk.", payload);
+      event.preventDefault();
+    } else if (outcome === "deferred-unsaved") {
+      // Reloading would discard unsaved work (and raise the "Leave site?"
+      // prompt), so the feature is left unloaded. Record an actionable notice
+      // instead of letting the raw preload error surface, and suppress Vite's
+      // rethrow so it does not read as an unhandled crash.
+      appendDiagnostic({
+        category: "runtime",
+        level: "warning",
+        message:
+          "A component could not be loaded because the app was updated. Save your project, then reload the page to finish loading it.",
+        detail: payload instanceof Error ? payload.message : String(payload),
+        source: "stale-chunk-reload",
+      });
       event.preventDefault();
     }
   };

--- a/apps/geolibre-desktop/src/lib/stale-chunk-reload.ts
+++ b/apps/geolibre-desktop/src/lib/stale-chunk-reload.ts
@@ -17,8 +17,12 @@
  */
 
 import { useAppStore } from "@geolibre/core";
-import { appendDiagnostic } from "./diagnostics";
+import { appendDiagnostic, getDiagnosticsSnapshot } from "./diagnostics";
 import { isTauri } from "./is-tauri";
+
+const DEFERRED_RELOAD_MESSAGE =
+  "A component could not be loaded because the app was updated. Save your project, then reload the page to finish loading it.";
+const STALE_CHUNK_DIAGNOSTIC_SOURCE = "stale-chunk-reload";
 
 const RELOAD_TIMESTAMP_KEY = "geolibre:stale-chunk-reload-at";
 
@@ -155,20 +159,28 @@ export function installStaleChunkReload(options?: {
       // Reloading would discard unsaved work (and raise the "Leave site?"
       // prompt), so the feature is left unloaded. Record an actionable notice
       // instead of letting the raw preload error surface, and suppress Vite's
-      // rethrow so it does not read as an unhandled crash.
-      appendDiagnostic({
-        category: "runtime",
-        level: "warning",
-        message:
-          "A component could not be loaded because the app was updated. Save your project, then reload the page to finish loading it.",
-        detail:
-          payload instanceof Error
-            ? payload.message
-            : payload != null
-              ? String(payload)
-              : undefined,
-        source: "stale-chunk-reload",
-      });
+      // rethrow so it does not read as an unhandled crash. Skip the append when
+      // the same notice is already present so repeated retries (each firing a
+      // fresh preload error) do not stack identical entries in the panel.
+      const alreadyRecorded = getDiagnosticsSnapshot().records.some(
+        (record) =>
+          record.source === STALE_CHUNK_DIAGNOSTIC_SOURCE &&
+          record.message === DEFERRED_RELOAD_MESSAGE,
+      );
+      if (!alreadyRecorded) {
+        appendDiagnostic({
+          category: "runtime",
+          level: "warning",
+          message: DEFERRED_RELOAD_MESSAGE,
+          detail:
+            payload instanceof Error
+              ? payload.message
+              : payload != null
+                ? String(payload)
+                : undefined,
+          source: STALE_CHUNK_DIAGNOSTIC_SOURCE,
+        });
+      }
       event.preventDefault();
     }
   };

--- a/apps/geolibre-desktop/src/lib/stale-chunk-reload.ts
+++ b/apps/geolibre-desktop/src/lib/stale-chunk-reload.ts
@@ -161,7 +161,12 @@ export function installStaleChunkReload(options?: {
         level: "warning",
         message:
           "A component could not be loaded because the app was updated. Save your project, then reload the page to finish loading it.",
-        detail: payload instanceof Error ? payload.message : String(payload),
+        detail:
+          payload instanceof Error
+            ? payload.message
+            : payload != null
+              ? String(payload)
+              : undefined,
         source: "stale-chunk-reload",
       });
       event.preventDefault();

--- a/packages/plugins/src/plugin-manager.ts
+++ b/packages/plugins/src/plugin-manager.ts
@@ -17,6 +17,7 @@ export class PluginManager {
   private inFlightUrlContexts = new Map<string, number>();
   private urlParameterNamesById = new Map<string, string[]>();
   private listeners = new Set<() => void>();
+  private activationGenerations = new Map<string, number>();
   private version = 0;
 
   register(plugin: GeoLibrePlugin): void {
@@ -79,6 +80,7 @@ export class PluginManager {
     this.defaultActive.delete(id);
     this.defaultMapControlPositions.delete(id);
     this.urlParameterNamesById.delete(id);
+    this.activationGenerations.delete(id);
     for (const handled of this.handledUrlParametersByContext.values()) {
       handled.delete(id);
     }
@@ -134,9 +136,10 @@ export class PluginManager {
     if (!plugin || this.active.has(id)) return;
     const activated = plugin.activate(app);
     if (activated === false) return;
+    const generation = this.nextActivationGeneration(id);
     this.active.add(id);
     this.notify();
-    this.watchAsyncActivation(id, activated, app);
+    this.watchAsyncActivation(id, activated, app, generation);
   }
 
   /**
@@ -145,11 +148,16 @@ export class PluginManager {
    * synchronous result is a no-op. Shared by {@link activate} and
    * {@link restoreProjectState}, which both add to `active` before the mount
    * has finished.
+   *
+   * `generation` ties the rollback to this specific activation attempt so a
+   * stale promise from an earlier activate/deactivate cycle cannot revert a
+   * newer activation of the same plugin.
    */
   private watchAsyncActivation(
     id: string,
     activated: boolean | void | PromiseLike<boolean | void>,
     app: GeoLibreAppAPI,
+    generation: number,
   ): void {
     // An async plugin (e.g. one mounted behind a dynamic import) reports
     // failure after the fact by resolving false or rejecting. Roll back so the
@@ -158,22 +166,31 @@ export class PluginManager {
     if (!isThenable(activated)) return;
     void Promise.resolve(activated).then(
       (result) => {
-        if (result === false) this.rollbackFailedActivation(id, app);
+        if (result === false) {
+          this.rollbackFailedActivation(id, app, generation);
+        }
       },
-      (error) => this.rollbackFailedActivation(id, app, error),
+      (error) => this.rollbackFailedActivation(id, app, generation, error),
     );
   }
 
   /**
    * Undo an activation whose async mount ultimately failed. No-op when the
-   * plugin is no longer active (e.g. the user deactivated it in the meantime).
+   * plugin is no longer active, or when a newer activation has superseded this
+   * one (the user deactivated and reactivated while the mount was pending).
    */
   private rollbackFailedActivation(
     id: string,
     app: GeoLibreAppAPI,
+    generation: number,
     error?: unknown,
   ): void {
-    if (!this.active.has(id)) return;
+    if (
+      !this.active.has(id) ||
+      this.activationGenerations.get(id) !== generation
+    ) {
+      return;
+    }
     if (error !== undefined) {
       console.warn(`Plugin '${id}' failed to activate; reverting.`, error);
     } else {
@@ -381,12 +398,13 @@ export class PluginManager {
       if (!plugin) continue;
       const activated = plugin.activate(app);
       if (activated === false) continue;
+      const generation = this.nextActivationGeneration(id);
       this.active.add(id);
       changed = true;
       // Restoring a saved project re-activates plugins the same way the user
       // would, so an async mount that later fails (e.g. a stale chunk after a
       // redeploy) must roll back here too, not just from activate().
-      this.watchAsyncActivation(id, activated, app);
+      this.watchAsyncActivation(id, activated, app, generation);
     }
 
     if (changed) this.notify();
@@ -395,6 +413,17 @@ export class PluginManager {
   private notify(): void {
     this.version += 1;
     for (const listener of this.listeners) listener();
+  }
+
+  /**
+   * Allocate the next activation generation for a plugin. Each activate (or
+   * restore) attempt gets a unique, increasing id so a late async failure can
+   * be matched to the attempt that started it and ignored if superseded.
+   */
+  private nextActivationGeneration(id: string): number {
+    const next = (this.activationGenerations.get(id) ?? 0) + 1;
+    this.activationGenerations.set(id, next);
+    return next;
   }
 }
 

--- a/packages/plugins/src/plugin-manager.ts
+++ b/packages/plugins/src/plugin-manager.ts
@@ -136,6 +136,48 @@ export class PluginManager {
     if (activated === false) return;
     this.active.add(id);
     this.notify();
+    // An async plugin (e.g. one mounted behind a dynamic import) reports
+    // failure after the fact by resolving false or rejecting. Roll back the
+    // optimistic active state so the Plugins menu does not show a plugin that
+    // never mounted (e.g. when its chunk fails to load after a web redeploy).
+    if (isThenable(activated)) {
+      void Promise.resolve(activated).then(
+        (result) => {
+          if (result === false) this.rollbackFailedActivation(id, app);
+        },
+        (error) => this.rollbackFailedActivation(id, app, error),
+      );
+    }
+  }
+
+  /**
+   * Undo an activation whose async mount ultimately failed. No-op when the
+   * plugin is no longer active (e.g. the user deactivated it in the meantime).
+   */
+  private rollbackFailedActivation(
+    id: string,
+    app: GeoLibreAppAPI,
+    error?: unknown,
+  ): void {
+    if (!this.active.has(id)) return;
+    if (error !== undefined) {
+      console.warn(`Plugin '${id}' failed to activate; reverting.`, error);
+    }
+    const plugin = this.plugins.get(id);
+    this.active.delete(id);
+    if (plugin) {
+      try {
+        // Tear down any partial mount. Plugin teardown is written to be safe to
+        // run even when nothing was mounted.
+        plugin.deactivate(app);
+      } catch (deactivateError) {
+        console.warn(
+          `Plugin '${id}' threw while reverting a failed activation.`,
+          deactivateError,
+        );
+      }
+    }
+    this.notify();
   }
 
   deactivate(id: string, app: GeoLibreAppAPI): void {
@@ -339,6 +381,14 @@ export class PluginManager {
 // Retaining several recent contexts (rather than only the latest) keeps dedup
 // intact when fire-and-forget calls with different context keys overlap.
 const MAX_HANDLED_URL_CONTEXTS = 8;
+
+function isThenable(value: unknown): value is PromiseLike<unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { then?: unknown }).then === "function"
+  );
+}
 
 function normalizeUrlParameterNames(names: string[] | undefined): string[] {
   if (!names) return [];

--- a/packages/plugins/src/plugin-manager.ts
+++ b/packages/plugins/src/plugin-manager.ts
@@ -136,18 +136,32 @@ export class PluginManager {
     if (activated === false) return;
     this.active.add(id);
     this.notify();
+    this.watchAsyncActivation(id, activated, app);
+  }
+
+  /**
+   * Watch an async activation result so the optimistic active state can be
+   * rolled back if the mount ultimately fails (resolves false or rejects). A
+   * synchronous result is a no-op. Shared by {@link activate} and
+   * {@link restoreProjectState}, which both add to `active` before the mount
+   * has finished.
+   */
+  private watchAsyncActivation(
+    id: string,
+    activated: boolean | void | PromiseLike<boolean | void>,
+    app: GeoLibreAppAPI,
+  ): void {
     // An async plugin (e.g. one mounted behind a dynamic import) reports
-    // failure after the fact by resolving false or rejecting. Roll back the
-    // optimistic active state so the Plugins menu does not show a plugin that
-    // never mounted (e.g. when its chunk fails to load after a web redeploy).
-    if (isThenable(activated)) {
-      void Promise.resolve(activated).then(
-        (result) => {
-          if (result === false) this.rollbackFailedActivation(id, app);
-        },
-        (error) => this.rollbackFailedActivation(id, app, error),
-      );
-    }
+    // failure after the fact by resolving false or rejecting. Roll back so the
+    // Plugins menu does not show a plugin that never mounted (e.g. when its
+    // chunk fails to load after a web redeploy).
+    if (!isThenable(activated)) return;
+    void Promise.resolve(activated).then(
+      (result) => {
+        if (result === false) this.rollbackFailedActivation(id, app);
+      },
+      (error) => this.rollbackFailedActivation(id, app, error),
+    );
   }
 
   /**
@@ -162,6 +176,8 @@ export class PluginManager {
     if (!this.active.has(id)) return;
     if (error !== undefined) {
       console.warn(`Plugin '${id}' failed to activate; reverting.`, error);
+    } else {
+      console.warn(`Plugin '${id}' activation resolved false; reverting.`);
     }
     const plugin = this.plugins.get(id);
     this.active.delete(id);
@@ -367,6 +383,10 @@ export class PluginManager {
       if (activated === false) continue;
       this.active.add(id);
       changed = true;
+      // Restoring a saved project re-activates plugins the same way the user
+      // would, so an async mount that later fails (e.g. a stale chunk after a
+      // redeploy) must roll back here too, not just from activate().
+      this.watchAsyncActivation(id, activated, app);
     }
 
     if (changed) this.notify();

--- a/packages/plugins/src/plugins/maplibre-geoagent.ts
+++ b/packages/plugins/src/plugins/maplibre-geoagent.ts
@@ -122,7 +122,12 @@ export const maplibreGeoAgentPlugin: GeoLibrePlugin = {
   ) => {
     geoAgentPosition = position;
     if (!geoAgentControl) {
-      if (geoAgentActive) {
+      // Only kick off a mount if one is not already in flight. A mount started
+      // by activate() reads the updated geoAgentPosition when it adds the
+      // control, so starting a second (generation-bumping) mount here would
+      // needlessly invalidate that in-flight attempt and make its host-side
+      // rollback tear the freshly added control back down.
+      if (geoAgentActive && !geoAgentControlPromise) {
         void mountGeoAgentControl(app, ++geoAgentActivationGeneration);
       }
       return;

--- a/packages/plugins/src/plugins/maplibre-geoagent.ts
+++ b/packages/plugins/src/plugins/maplibre-geoagent.ts
@@ -94,7 +94,11 @@ export const maplibreGeoAgentPlugin: GeoLibrePlugin = {
   version: "0.4.2",
   activate: (app: GeoLibreAppAPI) => {
     geoAgentActive = true;
-    void mountGeoAgentControl(app);
+    // Return the mount promise so the host can roll back the Plugins menu when
+    // the GeoAgent chunk fails to load (e.g. a stale chunk after a web
+    // redeploy). It resolves false when the control never mounts, instead of
+    // leaving GeoAgent marked active with no visible panel.
+    return mountGeoAgentControl(app);
   },
   deactivate: (app: GeoLibreAppAPI) => {
     geoAgentActive = false;
@@ -132,19 +136,32 @@ export const maplibreGeoAgentPlugin: GeoLibrePlugin = {
   },
 };
 
-async function mountGeoAgentControl(app: GeoLibreAppAPI): Promise<void> {
-  const control = await loadGeoAgentControl();
-  if (!geoAgentActive) return;
+async function mountGeoAgentControl(app: GeoLibreAppAPI): Promise<boolean> {
+  let control: GeoAgentControl;
+  try {
+    control = await loadGeoAgentControl();
+  } catch (error) {
+    // The dynamic import failed (offline, or a chunk orphaned by a web
+    // redeploy). Clear the active flag and report the failure so the host can
+    // revert the Plugins menu rather than leaving GeoAgent stuck on "active"
+    // with no panel. The stale-chunk recovery (host side) decides whether to
+    // reload; here we only need to surface that the mount did not happen.
+    geoAgentActive = false;
+    console.error("GeoAgent failed to load.", error);
+    return false;
+  }
+  if (!geoAgentActive) return false;
 
   const added = app.addMapControl(control, geoAgentPosition);
   if (!added) {
     if (geoAgentControl === control) geoAgentControl = null;
-    return;
+    return false;
   }
   patchGeoAgentToolRunner(control);
   setTimeout(() => geoAgentControl?.expand(), 0);
   setTimeout(enhanceEarthEngineSignIn, 0);
   preloadEarthEngineAuthLibrary();
+  return true;
 }
 
 async function loadGeoAgentControl(): Promise<GeoAgentControl> {

--- a/packages/plugins/src/plugins/maplibre-geoagent.ts
+++ b/packages/plugins/src/plugins/maplibre-geoagent.ts
@@ -83,6 +83,10 @@ const GEOAGENT_OPTIONS = {
 let geoAgentControl: GeoAgentControl | null = null;
 let geoAgentControlPromise: Promise<GeoAgentControl> | null = null;
 let geoAgentActive = false;
+// Bumped on every (re)mount so a slow async mount from an earlier
+// activate/deactivate cycle cannot resume and mount over a newer one. Only the
+// continuation whose generation still matches the latest is allowed to apply.
+let geoAgentActivationGeneration = 0;
 let earthEngineAccessTokenOverride = "";
 let earthEngineTokenTypeOverride = "Bearer";
 let earthEngineTokenExpiresInOverride = 3600;
@@ -98,7 +102,7 @@ export const maplibreGeoAgentPlugin: GeoLibrePlugin = {
     // the GeoAgent chunk fails to load (e.g. a stale chunk after a web
     // redeploy). It resolves false when the control never mounts, instead of
     // leaving GeoAgent marked active with no visible panel.
-    return mountGeoAgentControl(app);
+    return mountGeoAgentControl(app, ++geoAgentActivationGeneration);
   },
   deactivate: (app: GeoLibreAppAPI) => {
     geoAgentActive = false;
@@ -118,7 +122,9 @@ export const maplibreGeoAgentPlugin: GeoLibrePlugin = {
   ) => {
     geoAgentPosition = position;
     if (!geoAgentControl) {
-      if (geoAgentActive) void mountGeoAgentControl(app);
+      if (geoAgentActive) {
+        void mountGeoAgentControl(app, ++geoAgentActivationGeneration);
+      }
       return;
     }
     app.removeMapControl(geoAgentControl);
@@ -136,7 +142,10 @@ export const maplibreGeoAgentPlugin: GeoLibrePlugin = {
   },
 };
 
-async function mountGeoAgentControl(app: GeoLibreAppAPI): Promise<boolean> {
+async function mountGeoAgentControl(
+  app: GeoLibreAppAPI,
+  activationGeneration: number,
+): Promise<boolean> {
   let control: GeoAgentControl;
   try {
     control = await loadGeoAgentControl();
@@ -145,12 +154,23 @@ async function mountGeoAgentControl(app: GeoLibreAppAPI): Promise<boolean> {
     // redeploy). Clear the active flag and report the failure so the host can
     // revert the Plugins menu rather than leaving GeoAgent stuck on "active"
     // with no panel. The stale-chunk recovery (host side) decides whether to
-    // reload; here we only need to surface that the mount did not happen.
-    geoAgentActive = false;
-    console.error("GeoAgent failed to load.", error);
+    // reload; here we only need to surface that the mount did not happen. Only
+    // clear the flag for the latest attempt so a stale failure does not
+    // deactivate a newer activation that is already in flight.
+    if (activationGeneration === geoAgentActivationGeneration) {
+      geoAgentActive = false;
+    }
+    // warn (not error): the stale-chunk path already records an actionable
+    // diagnostic when the project is dirty, and rollbackFailedActivation cleans
+    // up the active state, so this should not read as a fatal error.
+    console.warn("GeoAgent failed to load.", error);
     return false;
   }
-  if (!geoAgentActive) return false;
+  // Ignore a continuation superseded by a later activate/deactivate cycle so it
+  // cannot mount a stale control on top of the current one.
+  if (!geoAgentActive || activationGeneration !== geoAgentActivationGeneration) {
+    return false;
+  }
 
   const added = app.addMapControl(control, geoAgentPosition);
   if (!added) {

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -170,7 +170,14 @@ export interface GeoLibrePlugin {
   activeByDefault?: boolean;
   /** At least one name is required for handleUrlParameters to be called. */
   urlParameterNames?: string[];
-  activate: (app: GeoLibreAppAPI) => boolean | void;
+  /**
+   * Activate the plugin. Return `false` to refuse activation. A plugin that
+   * mounts asynchronously (e.g. behind a dynamic import) may return a Promise
+   * that resolves to `false` (or rejects) when the mount ultimately fails; the
+   * host then rolls back the optimistic active state so the Plugins menu does
+   * not show a plugin that never came up.
+   */
+  activate: (app: GeoLibreAppAPI) => boolean | void | Promise<boolean | void>;
   deactivate: (app: GeoLibreAppAPI) => void;
   /**
    * Called once per URL context after the map and plugins are ready.

--- a/tests/plugin-manager.test.ts
+++ b/tests/plugin-manager.test.ts
@@ -533,6 +533,41 @@ describe("PluginManager async activation", () => {
     assert.equal(manager.isActive("ok-plugin"), true);
   });
 
+  it("rolls back a restored project's failed async activation", async () => {
+    const manager = new PluginManager();
+    let resolveMount: (value: boolean) => void = () => {};
+
+    manager.register(
+      testPlugin({
+        id: "restored-plugin",
+        activate: () =>
+          new Promise<boolean>((resolve) => {
+            resolveMount = resolve;
+          }),
+      }),
+    );
+
+    // Re-opening a saved project that had the plugin active goes through
+    // restoreProjectState, not the interactive activate() path.
+    manager.restoreProjectState(
+      {
+        manifestUrls: [],
+        activePluginIds: ["restored-plugin"],
+        mapControlPositions: {},
+        settings: {},
+      },
+      app,
+    );
+    assert.equal(manager.isActive("restored-plugin"), true);
+
+    resolveMount(false);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // The chunk failed to mount, so the menu must not keep showing it active.
+    assert.equal(manager.isActive("restored-plugin"), false);
+  });
+
   it("does not revert when the user deactivates before the mount fails", async () => {
     const manager = new PluginManager();
     let resolveMount: (value: boolean) => void = () => {};

--- a/tests/plugin-manager.test.ts
+++ b/tests/plugin-manager.test.ts
@@ -466,3 +466,95 @@ describe("PluginManager URL parameters", () => {
     assert.deepEqual(calls, ["handled"]);
   });
 });
+
+describe("PluginManager async activation", () => {
+  it("rolls back the active state when an async mount resolves false", async () => {
+    const deactivations: string[] = [];
+    const manager = new PluginManager();
+    let resolveMount: (value: boolean) => void = () => {};
+
+    manager.register(
+      testPlugin({
+        id: "async-plugin",
+        activate: () =>
+          new Promise<boolean>((resolve) => {
+            resolveMount = resolve;
+          }),
+        deactivate: () => {
+          deactivations.push("async-plugin");
+        },
+      }),
+    );
+
+    manager.activate("async-plugin", app);
+    // Optimistically active while the mount is in flight.
+    assert.equal(manager.isActive("async-plugin"), true);
+
+    resolveMount(false);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // A failed mount reverts the menu and tears down the partial activation.
+    assert.equal(manager.isActive("async-plugin"), false);
+    assert.deepEqual(deactivations, ["async-plugin"]);
+  });
+
+  it("rolls back the active state when an async mount rejects", async () => {
+    const manager = new PluginManager();
+
+    manager.register(
+      testPlugin({
+        id: "rejecting-plugin",
+        activate: () => Promise.reject(new Error("chunk failed to load")),
+      }),
+    );
+
+    manager.activate("rejecting-plugin", app);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assert.equal(manager.isActive("rejecting-plugin"), false);
+  });
+
+  it("keeps the plugin active when the async mount succeeds", async () => {
+    const manager = new PluginManager();
+
+    manager.register(
+      testPlugin({
+        id: "ok-plugin",
+        activate: () => Promise.resolve(true),
+      }),
+    );
+
+    manager.activate("ok-plugin", app);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assert.equal(manager.isActive("ok-plugin"), true);
+  });
+
+  it("does not revert when the user deactivates before the mount fails", async () => {
+    const manager = new PluginManager();
+    let resolveMount: (value: boolean) => void = () => {};
+
+    manager.register(
+      testPlugin({
+        id: "race-plugin",
+        activate: () =>
+          new Promise<boolean>((resolve) => {
+            resolveMount = resolve;
+          }),
+      }),
+    );
+
+    manager.activate("race-plugin", app);
+    manager.deactivate("race-plugin", app);
+    assert.equal(manager.isActive("race-plugin"), false);
+
+    // A late failure for an already-inactive plugin must be a no-op.
+    resolveMount(false);
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.equal(manager.isActive("race-plugin"), false);
+  });
+});

--- a/tests/plugin-manager.test.ts
+++ b/tests/plugin-manager.test.ts
@@ -491,6 +491,9 @@ describe("PluginManager async activation", () => {
     assert.equal(manager.isActive("async-plugin"), true);
 
     resolveMount(false);
+    // watchAsyncActivation wraps the plugin promise in Promise.resolve().then(),
+    // so two microtask ticks are needed: one for the wrapper, one for the
+    // callback. (The other async tests below flush twice for the same reason.)
     await Promise.resolve();
     await Promise.resolve();
 
@@ -591,5 +594,40 @@ describe("PluginManager async activation", () => {
     await Promise.resolve();
     await Promise.resolve();
     assert.equal(manager.isActive("race-plugin"), false);
+  });
+
+  it("does not let a stale failure revert a newer reactivation", async () => {
+    const manager = new PluginManager();
+    const resolvers: Array<(value: boolean) => void> = [];
+
+    manager.register(
+      testPlugin({
+        id: "reactivated-plugin",
+        activate: () =>
+          new Promise<boolean>((resolve) => {
+            resolvers.push(resolve);
+          }),
+      }),
+    );
+
+    // First activation (its mount is still pending).
+    manager.activate("reactivated-plugin", app);
+    // User deactivates, then reactivates before the first mount settles.
+    manager.deactivate("reactivated-plugin", app);
+    manager.activate("reactivated-plugin", app);
+    assert.equal(manager.isActive("reactivated-plugin"), true);
+
+    // The first (now superseded) activation fails. It must not roll back the
+    // newer activation that is still mounting.
+    resolvers[0](false);
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.equal(manager.isActive("reactivated-plugin"), true);
+
+    // The newer activation then succeeds and stays active.
+    resolvers[1](true);
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.equal(manager.isActive("reactivated-plugin"), true);
   });
 });

--- a/tests/stale-chunk-reload.test.ts
+++ b/tests/stale-chunk-reload.test.ts
@@ -82,15 +82,16 @@ describe("reloadForStaleChunk", () => {
   });
 
   it("prioritizes unsaved work over the cooldown guard", () => {
-    const { state, deps } = makeDeps({
-      now: STALE_CHUNK_RELOAD_COOLDOWN_MS * 10,
-      lastReloadAt: null,
-      dirty: true,
-    });
+    const now = STALE_CHUNK_RELOAD_COOLDOWN_MS * 10;
+    // Seed a prior reload inside the cooldown window so the test would report
+    // "suppressed-cooldown" if the dirty check did not run first.
+    const lastReloadAt = now - STALE_CHUNK_RELOAD_COOLDOWN_MS + 1;
+    const { state, deps } = makeDeps({ now, lastReloadAt, dirty: true });
 
-    // Even well past the cooldown, a dirty project must never be reloaded out
-    // from under the user.
+    // A dirty project must defer rather than reload, even though the cooldown
+    // would otherwise be the deciding branch.
     assert.equal(reloadForStaleChunk(deps), "deferred-unsaved");
     assert.equal(state.reloads, 0);
+    assert.equal(state.lastReloadAt, lastReloadAt);
   });
 });

--- a/tests/stale-chunk-reload.test.ts
+++ b/tests/stale-chunk-reload.test.ts
@@ -5,10 +5,15 @@ import {
   STALE_CHUNK_RELOAD_COOLDOWN_MS,
 } from "../apps/geolibre-desktop/src/lib/stale-chunk-reload";
 
-function makeDeps(initial: { now: number; lastReloadAt: number | null }) {
+function makeDeps(initial: {
+  now: number;
+  lastReloadAt: number | null;
+  dirty?: boolean;
+}) {
   const state = {
     now: initial.now,
     lastReloadAt: initial.lastReloadAt,
+    dirty: initial.dirty ?? false,
     reloads: 0,
   };
   return {
@@ -22,6 +27,7 @@ function makeDeps(initial: { now: number; lastReloadAt: number | null }) {
       reload: () => {
         state.reloads += 1;
       },
+      hasUnsavedChanges: () => state.dirty,
     },
   };
 }
@@ -30,7 +36,7 @@ describe("reloadForStaleChunk", () => {
   it("reloads on the first stale-chunk error and records the timestamp", () => {
     const { state, deps } = makeDeps({ now: 1000, lastReloadAt: null });
 
-    assert.equal(reloadForStaleChunk(deps), true);
+    assert.equal(reloadForStaleChunk(deps), "reloaded");
     assert.equal(state.reloads, 1);
     assert.equal(state.lastReloadAt, 1000);
   });
@@ -38,26 +44,53 @@ describe("reloadForStaleChunk", () => {
   it("suppresses a reload that fires within the cooldown", () => {
     const { state, deps } = makeDeps({ now: 5000, lastReloadAt: null });
 
-    assert.equal(reloadForStaleChunk(deps), true);
+    assert.equal(reloadForStaleChunk(deps), "reloaded");
     state.now += STALE_CHUNK_RELOAD_COOLDOWN_MS - 1;
 
     // A second error right after the reload means the build is broken, not
     // merely stale, so it must not loop.
-    assert.equal(reloadForStaleChunk(deps), false);
+    assert.equal(reloadForStaleChunk(deps), "suppressed-cooldown");
     assert.equal(state.reloads, 1);
   });
 
   it("reloads again once the cooldown has elapsed", () => {
     const { state, deps } = makeDeps({ now: 0, lastReloadAt: null });
 
-    assert.equal(reloadForStaleChunk(deps), true);
+    assert.equal(reloadForStaleChunk(deps), "reloaded");
     // The guard is strict `< cooldown`, so a diff of exactly the cooldown is
     // already past it (the just-expired edge) and reloads again.
     state.now += STALE_CHUNK_RELOAD_COOLDOWN_MS;
 
     // A later redeploy in a long-lived session should recover too.
-    assert.equal(reloadForStaleChunk(deps), true);
+    assert.equal(reloadForStaleChunk(deps), "reloaded");
     assert.equal(state.reloads, 2);
     assert.equal(state.lastReloadAt, STALE_CHUNK_RELOAD_COOLDOWN_MS);
+  });
+
+  it("defers the reload when the project has unsaved changes", () => {
+    const { state, deps } = makeDeps({
+      now: 1000,
+      lastReloadAt: null,
+      dirty: true,
+    });
+
+    // Reloading would discard the user's map and raise the beforeunload prompt,
+    // so recovery is withheld and nothing is reloaded or timestamped.
+    assert.equal(reloadForStaleChunk(deps), "deferred-unsaved");
+    assert.equal(state.reloads, 0);
+    assert.equal(state.lastReloadAt, null);
+  });
+
+  it("prioritizes unsaved work over the cooldown guard", () => {
+    const { state, deps } = makeDeps({
+      now: STALE_CHUNK_RELOAD_COOLDOWN_MS * 10,
+      lastReloadAt: null,
+      dirty: true,
+    });
+
+    // Even well past the cooldown, a dirty project must never be reloaded out
+    // from under the user.
+    assert.equal(reloadForStaleChunk(deps), "deferred-unsaved");
+    assert.equal(state.reloads, 0);
   });
 });


### PR DESCRIPTION
Fixes #624

## Problem

Activating the GeoAgent plugin on the web demo could pop the browser's "Leave site?" confirmation and, if the user left, discard all unsaved work (reported on Safari).

Root cause is in GeoLibre's own recovery handling, not the upstream `maplibre-gl-geoagent` package:

1. GeoAgent loads behind a dynamic `import()`. When that chunk fails to load (a chunk orphaned by a web redeploy, or any load failure), Vite dispatches `vite:preloadError`.
2. `installStaleChunkReload` handled that event by calling `window.location.reload()` **unconditionally**.
3. With unsaved changes, `useBeforeUnloadGuard` turned that reload into the native "Leave site?" prompt. Leaving lost the map; staying left GeoAgent marked active (the menu showed "Deactivate") with no visible panel, because activation optimistically marked the plugin active before the async mount failed.

## Fix (GeoLibre-only, no upstream release needed)

- **`stale-chunk-reload`**: never reload while the project has unsaved changes. Recovery is deferred and an actionable diagnostic is recorded ("save your project, then reload to finish loading it") instead of reloading out from under the user's work. A clean project still reloads to recover from the stale chunk, so the original redeploy-recovery behavior is preserved.
- **`PluginManager`**: roll back the optimistic active state when an async activation ultimately fails (resolves `false` or rejects), so the Plugins menu no longer shows a plugin that never mounted.
- **GeoAgent plugin**: `activate()` now returns its mount promise and resolves `false` on a failed dynamic import, so the rollback above can revert the menu.

## Tests

- New unit tests for the unsaved-work guard (`tests/stale-chunk-reload.test.ts`) and the async-activation rollback (`tests/plugin-manager.test.ts`). Full frontend suite passes (1295 tests).

## Verification

Reproduced and verified against the production web build (`vite build` + `vite preview`) driven with Playwright, firing the real `vite:preloadError` event that the failing GeoAgent chunk emits:

- **Before** (dirty project): preload error -> unconditional reload -> beforeunload "Leave site?" dialog appears (data-loss vector).
- **After** (dirty project): no reload, no leave-page dialog, the project is preserved, and a diagnostic is recorded.
- **After** (clean project): still reloads to recover from the stale chunk.
- GeoAgent happy-path panel still mounts correctly in both light and dark themes (no regression).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugins now support asynchronous activation for more reliable loading.

* **Bug Fixes**
  * App now protects unsaved changes during automatic chunk reload recovery.
  * Failed plugin loads are automatically rolled back to prevent broken state.
  * Improved error handling when plugins fail to initialize, with better diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->