### PR TITLE
fix(geoagent): show real configuration state instead of always-Ready badge

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -65,7 +65,7 @@
     "maplibre-gl-esri-wayback": "^0.2.2",
     "maplibre-gl-fema-wms": "^0.1.2",
     "maplibre-gl-geo-editor": "^0.9.1",
-    "maplibre-gl-geoagent": "^0.4.3",
+    "maplibre-gl-geoagent": "^0.4.4",
     "maplibre-gl-lidar": "^0.16.0",
     "maplibre-gl-nasa-earthdata": "^0.1.2",
     "maplibre-gl-national-map": "^0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "maplibre-gl-esri-wayback": "^0.2.2",
         "maplibre-gl-fema-wms": "^0.1.2",
         "maplibre-gl-geo-editor": "^0.9.1",
-        "maplibre-gl-geoagent": "^0.4.3",
+        "maplibre-gl-geoagent": "^0.4.4",
         "maplibre-gl-lidar": "^0.16.0",
         "maplibre-gl-nasa-earthdata": "^0.1.2",
         "maplibre-gl-national-map": "^0.1.1",
@@ -17621,9 +17621,9 @@
       }
     },
     "node_modules/maplibre-gl-geoagent": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-geoagent/-/maplibre-gl-geoagent-0.4.3.tgz",
-      "integrity": "sha512-A79WpSWwVnXs5aY/QIqRJ87Jy0qwejXIYmklBF8eM+Dau51ZyQnEbIDr3oL88r7cGWwKHeVD82V3sMx7rvGNAQ==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-geoagent/-/maplibre-gl-geoagent-0.4.4.tgz",
+      "integrity": "sha512-CGZxZO6lcais5Edmojy22eJ/WAA6LFUw8BV8VuchAdBW+l+NWF1RWRpWYvzWMPkXCNH8NbmhX3FsTfnhhcxaVw==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",
@@ -24311,7 +24311,7 @@
         "maplibre-gl-esri-wayback": "^0.2.2",
         "maplibre-gl-fema-wms": "^0.1.2",
         "maplibre-gl-geo-editor": "^0.9.1",
-        "maplibre-gl-geoagent": "^0.4.3",
+        "maplibre-gl-geoagent": "^0.4.4",
         "maplibre-gl-lidar": "^0.16.0",
         "maplibre-gl-nasa-earthdata": "^0.1.2",
         "maplibre-gl-national-map": "^0.1.1",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -39,7 +39,7 @@
     "maplibre-gl-esri-wayback": "^0.2.2",
     "maplibre-gl-fema-wms": "^0.1.2",
     "maplibre-gl-geo-editor": "^0.9.1",
-    "maplibre-gl-geoagent": "^0.4.3",
+    "maplibre-gl-geoagent": "^0.4.4",
     "maplibre-gl-lidar": "^0.16.0",
     "maplibre-gl-nasa-earthdata": "^0.1.2",
     "maplibre-gl-national-map": "^0.1.1",


### PR DESCRIPTION
## Problem

The GeoAgent + Earth Engine panel always showed a green **Ready** badge and logged "Browser-only Strands MapLibre agent ready." on startup, even with no API key configured. Since the **Send** button is disabled until credentials are present, the panel claimed to be operational while nothing worked, and the user had no explanation for why they could type a prompt but not send it.

Fixes #626.

## Fix

This is an upstream fix in `maplibre-gl-geoagent`, released as **0.4.4** (opengeos/maplibre-gl-geoagent#21). This PR bumps the dependency to consume it.

With 0.4.4 the GeoAgent panel:

- Derives the status badge from the current provider's configuration. It reads **Setup required** (amber) until an API key, a model, and (for Bedrock) a region are present, then flips to **Ready** (green). Transient run statuses (Running, Cancelled, Error) are untouched.
- Reflects the same state in the startup system-log message and names the missing fields, e.g. "Browser-only Strands MapLibre agent loaded. Add your OpenAI API Key to start."
- Adds a tooltip on the disabled **Send** button explaining what to add.

The badge updates live as credentials are entered or cleared.

## Verification

- Drove the real app with Playwright using the published 0.4.4 package. With no API key the panel shows the amber **Setup required** badge, the accurate system message, and the explanatory Send tooltip; typing a key flips it to **Ready**. Verified in both light and dark themes.
- `npm run build` passes; pre-commit clean on the changed files.