### PR TITLE
fix(swipe): pre-select visible layers and grow the panel to fit (#616)

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -72,7 +72,7 @@
     "maplibre-gl-planetary-computer": "^0.3.0",
     "maplibre-gl-raster": "^0.6.1",
     "maplibre-gl-streetview": "^0.7.0",
-    "maplibre-gl-swipe": "^0.8.1",
+    "maplibre-gl-swipe": "^0.9.0",
     "maplibre-gl-time-slider": "^1.0.3",
     "maplibre-gl-usgs-lidar": "^0.11.0",
     "maplibre-gl-vector": "^0.4.0",

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -72,7 +72,7 @@
     "maplibre-gl-planetary-computer": "^0.3.0",
     "maplibre-gl-raster": "^0.6.1",
     "maplibre-gl-streetview": "^0.7.0",
-    "maplibre-gl-swipe": "^0.7.1",
+    "maplibre-gl-swipe": "^0.8.1",
     "maplibre-gl-time-slider": "^1.0.3",
     "maplibre-gl-usgs-lidar": "^0.11.0",
     "maplibre-gl-vector": "^0.4.0",

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -72,7 +72,7 @@
     "maplibre-gl-planetary-computer": "^0.3.0",
     "maplibre-gl-raster": "^0.6.1",
     "maplibre-gl-streetview": "^0.7.0",
-    "maplibre-gl-swipe": "^0.9.0",
+    "maplibre-gl-swipe": "^0.9.1",
     "maplibre-gl-time-slider": "^1.0.3",
     "maplibre-gl-usgs-lidar": "^0.11.0",
     "maplibre-gl-vector": "^0.4.0",

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -804,6 +804,18 @@ body,
 }
 
 /*
+ * The Layer Swipe comparison map paints its clipped half at `z-index: 5`
+ * (raised in maplibre-gl-swipe 0.9.1 so it sits above the Effects plugin's z-4
+ * map canvas). That ties with the control container, which the Effects plugin
+ * also pins to `z-index: 5` inline, so the comparison map ends up covering the
+ * top-right controls. Lift the controls above the comparison map. The
+ * `!important` is needed to beat the Effects plugin's inline z-index.
+ */
+.maplibregl-control-container {
+  z-index: 7 !important;
+}
+
+/*
  * The Measure, Bookmark and View State controls theme themselves purely via
  * `@media (prefers-color-scheme)`, so they follow the OS preference instead of
  * GeoLibre's in-app light/dark toggle (the `.dark` class on <html>). When the

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
         "maplibre-gl-planetary-computer": "^0.3.0",
         "maplibre-gl-raster": "^0.6.1",
         "maplibre-gl-streetview": "^0.7.0",
-        "maplibre-gl-swipe": "^0.8.1",
+        "maplibre-gl-swipe": "^0.9.0",
         "maplibre-gl-time-slider": "^1.0.3",
         "maplibre-gl-usgs-lidar": "^0.11.0",
         "maplibre-gl-vector": "^0.4.0",
@@ -17900,9 +17900,9 @@
       }
     },
     "node_modules/maplibre-gl-swipe": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-swipe/-/maplibre-gl-swipe-0.8.1.tgz",
-      "integrity": "sha512-P2Sh3Tll42NIU8xkysZ+Wj+/cxOuAlZRdGvZEBco4ww1IFt3Ari8egiovzYhSo/GFisZEIFNWaJ9u4usR/q4fA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-swipe/-/maplibre-gl-swipe-0.9.0.tgz",
+      "integrity": "sha512-i4qUypktP+gO52WVa12j6VkACGtY8IAVkQBMWeJFnXMxdmxeXNjjkuRcGINAEtyhQsczYzO5gQVJss9TiiOSQA==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -24319,7 +24319,7 @@
         "maplibre-gl-planetary-computer": "^0.3.0",
         "maplibre-gl-raster": "^0.6.1",
         "maplibre-gl-streetview": "^0.7.0",
-        "maplibre-gl-swipe": "^0.8.1",
+        "maplibre-gl-swipe": "^0.9.0",
         "maplibre-gl-time-slider": "^1.0.3",
         "maplibre-gl-usgs-lidar": "^0.11.0",
         "maplibre-gl-vector": "^0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
         "maplibre-gl-planetary-computer": "^0.3.0",
         "maplibre-gl-raster": "^0.6.1",
         "maplibre-gl-streetview": "^0.7.0",
-        "maplibre-gl-swipe": "^0.9.0",
+        "maplibre-gl-swipe": "^0.9.1",
         "maplibre-gl-time-slider": "^1.0.3",
         "maplibre-gl-usgs-lidar": "^0.11.0",
         "maplibre-gl-vector": "^0.4.0",
@@ -17900,9 +17900,9 @@
       }
     },
     "node_modules/maplibre-gl-swipe": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-swipe/-/maplibre-gl-swipe-0.9.0.tgz",
-      "integrity": "sha512-i4qUypktP+gO52WVa12j6VkACGtY8IAVkQBMWeJFnXMxdmxeXNjjkuRcGINAEtyhQsczYzO5gQVJss9TiiOSQA==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-swipe/-/maplibre-gl-swipe-0.9.1.tgz",
+      "integrity": "sha512-oP8IA1oP0NfEaiKvBWeYcmlfI8oURyzyedD/75siS9ABf3VOoeou/vAxfbhPeOVlXOy+dE1MSaFsGH0rDyNFRw==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -24319,7 +24319,7 @@
         "maplibre-gl-planetary-computer": "^0.3.0",
         "maplibre-gl-raster": "^0.6.1",
         "maplibre-gl-streetview": "^0.7.0",
-        "maplibre-gl-swipe": "^0.9.0",
+        "maplibre-gl-swipe": "^0.9.1",
         "maplibre-gl-time-slider": "^1.0.3",
         "maplibre-gl-usgs-lidar": "^0.11.0",
         "maplibre-gl-vector": "^0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
         "maplibre-gl-planetary-computer": "^0.3.0",
         "maplibre-gl-raster": "^0.6.1",
         "maplibre-gl-streetview": "^0.7.0",
-        "maplibre-gl-swipe": "^0.7.1",
+        "maplibre-gl-swipe": "^0.8.1",
         "maplibre-gl-time-slider": "^1.0.3",
         "maplibre-gl-usgs-lidar": "^0.11.0",
         "maplibre-gl-vector": "^0.4.0",
@@ -17900,9 +17900,9 @@
       }
     },
     "node_modules/maplibre-gl-swipe": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-swipe/-/maplibre-gl-swipe-0.7.1.tgz",
-      "integrity": "sha512-npJSCnHmf6j/7IfNg6eqaRWJT8S6iS+wKfJjQDmQgjVIVvgHoiAnoOx65XZsZ0i9LtNGaxsE5Z3N51992VQyHQ==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-swipe/-/maplibre-gl-swipe-0.8.1.tgz",
+      "integrity": "sha512-P2Sh3Tll42NIU8xkysZ+Wj+/cxOuAlZRdGvZEBco4ww1IFt3Ari8egiovzYhSo/GFisZEIFNWaJ9u4usR/q4fA==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -24319,7 +24319,7 @@
         "maplibre-gl-planetary-computer": "^0.3.0",
         "maplibre-gl-raster": "^0.6.1",
         "maplibre-gl-streetview": "^0.7.0",
-        "maplibre-gl-swipe": "^0.7.1",
+        "maplibre-gl-swipe": "^0.8.1",
         "maplibre-gl-time-slider": "^1.0.3",
         "maplibre-gl-usgs-lidar": "^0.11.0",
         "maplibre-gl-vector": "^0.4.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -47,7 +47,7 @@
     "maplibre-gl-planetary-computer": "^0.3.0",
     "maplibre-gl-raster": "^0.6.1",
     "maplibre-gl-streetview": "^0.7.0",
-    "maplibre-gl-swipe": "^0.9.0",
+    "maplibre-gl-swipe": "^0.9.1",
     "maplibre-gl-time-slider": "^1.0.3",
     "maplibre-gl-usgs-lidar": "^0.11.0",
     "maplibre-gl-vector": "^0.4.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -47,7 +47,7 @@
     "maplibre-gl-planetary-computer": "^0.3.0",
     "maplibre-gl-raster": "^0.6.1",
     "maplibre-gl-streetview": "^0.7.0",
-    "maplibre-gl-swipe": "^0.7.1",
+    "maplibre-gl-swipe": "^0.8.1",
     "maplibre-gl-time-slider": "^1.0.3",
     "maplibre-gl-usgs-lidar": "^0.11.0",
     "maplibre-gl-vector": "^0.4.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -47,7 +47,7 @@
     "maplibre-gl-planetary-computer": "^0.3.0",
     "maplibre-gl-raster": "^0.6.1",
     "maplibre-gl-streetview": "^0.7.0",
-    "maplibre-gl-swipe": "^0.8.1",
+    "maplibre-gl-swipe": "^0.9.0",
     "maplibre-gl-time-slider": "^1.0.3",
     "maplibre-gl-usgs-lidar": "^0.11.0",
     "maplibre-gl-vector": "^0.4.0",

--- a/packages/plugins/src/plugins/maplibre-swipe.ts
+++ b/packages/plugins/src/plugins/maplibre-swipe.ts
@@ -104,17 +104,12 @@ function getSwipeControlOptions(
     collapsed: previousState?.collapsed ?? false,
     title: "Layer Swipe",
     panelWidth: 300,
-    // Upper bound only; the control also shrinks the panel to fit the available
-    // map height, so this lets it grow with the layer list instead of clamping
-    // to a small fixed height.
+    // Upper bound only; the control also shrinks the panel to the available map height.
     maxHeight: 900,
     active: previousState?.active ?? true,
     leftLayers: previousState?.leftLayers ?? [],
     rightLayers: previousState?.rightLayers ?? [],
-    // On a fresh activation (no saved state) pre-select every visible layer on
-    // both sides so the panel checkboxes match what is rendered, rather than
-    // showing an empty checklist over a populated map. Restored/persisted state
-    // keeps the user's own selection.
+    // True only on first activation; restoring saved/project state keeps the user's selection.
     selectVisibleByDefault: previousState === undefined,
     basemapStyle: app.getActiveBasemap(),
     excludeLayers: ["gl-draw-*", "measure-*", "geolibre-highlight-*"],

--- a/packages/plugins/src/plugins/maplibre-swipe.ts
+++ b/packages/plugins/src/plugins/maplibre-swipe.ts
@@ -104,12 +104,20 @@ function getSwipeControlOptions(
     collapsed: previousState?.collapsed ?? false,
     title: "Layer Swipe",
     panelWidth: 300,
-    maxHeight: 480,
+    // Upper bound only; the control also shrinks the panel to fit the available
+    // map height, so this lets it grow with the layer list instead of clamping
+    // to a small fixed height.
+    maxHeight: 900,
     active: previousState?.active ?? true,
     leftLayers: previousState?.leftLayers ?? [],
     rightLayers: previousState?.rightLayers ?? [],
+    // On a fresh activation (no saved state) pre-select every visible layer on
+    // both sides so the panel checkboxes match what is rendered, rather than
+    // showing an empty checklist over a populated map. Restored/persisted state
+    // keeps the user's own selection.
+    selectVisibleByDefault: previousState === undefined,
     basemapStyle: app.getActiveBasemap(),
-    excludeLayers: ["gl-draw-*", "measure-*"],
+    excludeLayers: ["gl-draw-*", "measure-*", "geolibre-highlight-*"],
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes the Layer Swipe state, comparison, and sizing problems reported in #616.

On launch the swipe panel showed an empty checklist while the map rendered every layer, the two halves were identical so the swipe appeared to do nothing, and the panel was clamped to a small fixed height (and dismissed itself on any outside click).

The root cause is in the upstream `maplibre-gl-swipe` control, fixed across [opengeos/maplibre-gl-swipe#13](https://github.com/opengeos/maplibre-gl-swipe/pull/13) and [#15](https://github.com/opengeos/maplibre-gl-swipe/pull/15) and released as **v0.9.0**. This PR consumes that release.

## Changes

- Bump `maplibre-gl-swipe` to `^0.9.0` in `apps/geolibre-desktop` and `packages/plugins`.
- Pass `selectVisibleByDefault` on a fresh activation. In 0.9.0 this preselects **all visible layers on the left and only the basemap on the right**, so the panel matches the rendered map *and* the swipe shows an immediate overlay-vs-basemap comparison instead of two identical halves. Restored/persisted project state keeps the user's own selection.
- The panel now grows with the layer list (shrinking to fit the available map height) and only collapses via its × button — `closeOnOutsideClick` defaults to off, so clicking the map no longer dismisses it.
- Exclude internal `geolibre-highlight-*` layers from the swipe layer list.

Note: issue #616 also flags the panel's Top/Bottom "View 1/View 2" labels. That was already resolved in a prior release; the current panel uses spatially aligned "Left Layers"/"Right Layers" and "Vertical (Left/Right)" labels. The proposed dual-panel redesign is out of scope here.

## Testing

- `npm run build` green; `pre-commit run --files` green.
- Verified in the running app with the published 0.9.0 in both light and dark themes: a fresh activation with an XYZ imagery layer shows imagery on the left and basemap on the right; clicking the map or the theme toggle no longer collapses the panel while the × button still does; the panel grows on tall windows and shrinks without overflow on short ones.

Fixes #616

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced swipe tool with improved layer visibility controls for a more intuitive experience.

* **Improvements**
  * Increased swipe control panel height capacity for better accessibility and usability.
  * Refined layer handling in swipe mode for smoother layer switching.

* **Chores**
  * Updated maplibre-gl-swipe library to version 0.9.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->