### PR TITLE
feat(storymap): Reset button + auto-collapse side panels while presenting

### DIFF
--- a/apps/geolibre-desktop/src/App.tsx
+++ b/apps/geolibre-desktop/src/App.tsx
@@ -1,5 +1,3 @@
-import { useMemo } from "react";
-import { useAppStore } from "@geolibre/core";
 import { DesktopShell } from "./components/layout/DesktopShell";
 import { OnboardingDialog } from "./components/layout/OnboardingDialog";
 import { UpdateNotificationModal } from "./components/layout/UpdateNotificationModal";
@@ -16,23 +14,7 @@ import { useUiProfileBootstrap } from "./hooks/useUiProfileBootstrap";
 import { useUndoRedoShortcuts } from "./hooks/useUndoRedoShortcuts";
 
 export default function App() {
-  const baseLayoutOptions = useLayoutOptions();
-  // While a story map is presenting, collapse the Layers and Style side panels
-  // so the presentation has the full map canvas to itself. This is a derived
-  // override (not a persisted setting), so exiting the presentation restores the
-  // user's panel layout automatically.
-  const storymapPresenting = useAppStore((s) => s.ui.storymapPresenting);
-  const layoutOptions = useMemo(
-    () =>
-      storymapPresenting
-        ? {
-            ...baseLayoutOptions,
-            layerPanelVisible: false,
-            stylePanelVisible: false,
-          }
-        : baseLayoutOptions,
-    [baseLayoutOptions, storymapPresenting],
-  );
+  const layoutOptions = useLayoutOptions();
   const { themeMode, toggleThemeMode } = useThemeMode();
   const projectUrlLoadState = useProjectUrlLoader();
   const { showOnboarding, dismissOnboarding } = useUiProfileBootstrap();

--- a/apps/geolibre-desktop/src/App.tsx
+++ b/apps/geolibre-desktop/src/App.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from "react";
+import { useAppStore } from "@geolibre/core";
 import { DesktopShell } from "./components/layout/DesktopShell";
 import { OnboardingDialog } from "./components/layout/OnboardingDialog";
 import { UpdateNotificationModal } from "./components/layout/UpdateNotificationModal";
@@ -14,7 +16,23 @@ import { useUiProfileBootstrap } from "./hooks/useUiProfileBootstrap";
 import { useUndoRedoShortcuts } from "./hooks/useUndoRedoShortcuts";
 
 export default function App() {
-  const layoutOptions = useLayoutOptions();
+  const baseLayoutOptions = useLayoutOptions();
+  // While a story map is presenting, collapse the Layers and Style side panels
+  // so the presentation has the full map canvas to itself. This is a derived
+  // override (not a persisted setting), so exiting the presentation restores the
+  // user's panel layout automatically.
+  const storymapPresenting = useAppStore((s) => s.ui.storymapPresenting);
+  const layoutOptions = useMemo(
+    () =>
+      storymapPresenting
+        ? {
+            ...baseLayoutOptions,
+            layerPanelVisible: false,
+            stylePanelVisible: false,
+          }
+        : baseLayoutOptions,
+    [baseLayoutOptions, storymapPresenting],
+  );
   const { themeMode, toggleThemeMode } = useThemeMode();
   const projectUrlLoadState = useProjectUrlLoader();
   const { showOnboarding, dismissOnboarding } = useUiProfileBootstrap();

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -402,6 +402,7 @@ export function DesktopShell({
   const projectGeneration = useAppStore((s) => s.projectGeneration);
   const pythonConsoleOpen = useAppStore((s) => s.ui.pythonConsoleOpen);
   const notebookOpen = useAppStore((s) => s.ui.notebookOpen);
+  const storymapPresenting = useAppStore((s) => s.ui.storymapPresenting);
   const assistantOpen = useAppStore((s) => s.ui.assistantOpen);
   const dashboardOpen = useAppStore((s) => s.ui.dashboardOpen);
   const geometryEditLayerId = useSyncExternalStore(
@@ -1291,6 +1292,7 @@ export function DesktopShell({
               onOpenRasterStylePanel={() =>
                 openRasterLayerPanel(createAppAPI(mapControllerRef))
               }
+              autoCollapse={storymapPresenting}
             />
           </SectionErrorBoundary>
         ) : null}
@@ -1320,13 +1322,14 @@ export function DesktopShell({
         </main>
         {/* The notebook claims the workspace's right half, so the Style panel
             collapses to its rail while the notebook is open (Processing →
-            Jupyter Notebook) rather than unmounting; the user can re-expand it. */}
+            Jupyter Notebook) rather than unmounting; the user can re-expand it.
+            A story map presentation collapses it for the same reason. */}
         {layoutOptions.stylePanelVisible ? (
           <SectionErrorBoundary label="Style panel">
             <StylePanel
               mapControllerRef={mapControllerRef}
               onResizeStart={startStylePanelResize}
-              autoCollapse={notebookOpen}
+              autoCollapse={notebookOpen || storymapPresenting}
             />
           </SectionErrorBoundary>
         ) : null}

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -277,8 +277,10 @@ export function LayerPanel({
   // off. Both act only on the transition so the user can still toggle the panel
   // manually while `autoCollapse` stays on. `isCollapsed` is in the deps only to
   // keep the captured value fresh; the guards make pure `isCollapsed` changes a
-  // no-op while `autoCollapse` is stable. Mirrors StylePanel's behavior.
-  const prevAutoCollapse = useRef(autoCollapse);
+  // no-op while `autoCollapse` is stable. Mirrors StylePanel's behavior. The
+  // ref starts as null (not `autoCollapse`) so a mount with `autoCollapse`
+  // already true reads as a null→true transition and still collapses.
+  const prevAutoCollapse = useRef<boolean | null>(null);
   const collapsedBeforeAuto = useRef(isCollapsed);
   useEffect(() => {
     const wasAuto = prevAutoCollapse.current;

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -117,6 +117,12 @@ interface LayerPanelProps {
   onMaterializeDuckDBLayer: (layer: GeoLibreLayer) => void;
   /** Open the floating Add Raster Layer panel for advanced raster styling. */
   onOpenRasterStylePanel: () => void;
+  /**
+   * When this flips to `true` the panel collapses to its thin rail (it is not
+   * unmounted). Used to clear room for a story map presentation; the user can
+   * still expand it again, and the prior state is restored when it flips off.
+   */
+  autoCollapse?: boolean;
 }
 
 const BACKGROUND_SELECTION_ID = "__geolibre-background__";
@@ -192,6 +198,7 @@ export function LayerPanel({
   onCancelGeometryEdit,
   onMaterializeDuckDBLayer,
   onOpenRasterStylePanel,
+  autoCollapse = false,
 }: LayerPanelProps) {
   const { t } = useTranslation();
   const uiProfile = useDesktopSettingsStore((s) => s.desktopSettings.uiProfile);
@@ -265,6 +272,24 @@ export function LayerPanel({
   const { isActive: isPluginActive, toggle: togglePlugin } =
     usePluginRegistry();
   const [isCollapsed, setIsCollapsed] = useState(getIsMobileViewport);
+  // Collapse to the rail when `autoCollapse` flips on (a story map starts
+  // presenting), and restore the prior expand/collapse state when it flips back
+  // off. Both act only on the transition so the user can still toggle the panel
+  // manually while `autoCollapse` stays on. `isCollapsed` is in the deps only to
+  // keep the captured value fresh; the guards make pure `isCollapsed` changes a
+  // no-op while `autoCollapse` is stable. Mirrors StylePanel's behavior.
+  const prevAutoCollapse = useRef(autoCollapse);
+  const collapsedBeforeAuto = useRef(isCollapsed);
+  useEffect(() => {
+    const wasAuto = prevAutoCollapse.current;
+    prevAutoCollapse.current = autoCollapse;
+    if (autoCollapse && !wasAuto) {
+      collapsedBeforeAuto.current = isCollapsed;
+      setIsCollapsed(true);
+    } else if (!autoCollapse && wasAuto) {
+      setIsCollapsed(collapsedBeforeAuto.current);
+    }
+  }, [autoCollapse, isCollapsed]);
   const [draggedLayerId, setDraggedLayerId] = useState<string | null>(null);
   const [dropTargetLayerId, setDropTargetLayerId] = useState<string | null>(
     null,

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -929,8 +929,10 @@ export function StylePanel({
   // closes). Both act only on the transition so the user can still toggle the
   // panel manually while `autoCollapse` stays on. `isCollapsed` is in the deps
   // only to keep the captured value fresh; the guards make pure `isCollapsed`
-  // changes a no-op while `autoCollapse` is stable.
-  const prevAutoCollapse = useRef(autoCollapse);
+  // changes a no-op while `autoCollapse` is stable. The ref starts as null (not
+  // `autoCollapse`) so a mount with `autoCollapse` already true reads as a
+  // null→true transition and still collapses.
+  const prevAutoCollapse = useRef<boolean | null>(null);
   const collapsedBeforeAuto = useRef(isCollapsed);
   useEffect(() => {
     const wasAuto = prevAutoCollapse.current;

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
@@ -94,6 +94,13 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
 
   const story: StoryMap = storymap ?? DEFAULT_STORY_MAP;
   const chapters = story.chapters;
+  // Reset has something to clear when there are chapters or any story metadata
+  // set, so it stays disabled in the empty state (where "Load sample story" is
+  // the relevant action) even if a stale `storymap` object lingers after the
+  // last chapter was deleted manually.
+  const hasStoryContent =
+    chapters.length > 0 ||
+    Boolean(story.title || story.subtitle || story.byline || story.footer);
 
   const handleAddChapter = useCallback(() => {
     const view = mapControllerRef.current?.readView();
@@ -333,7 +340,7 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
               <Button
                 size="sm"
                 variant="outline"
-                disabled={!storymap}
+                disabled={!hasStoryContent}
                 title={t("storymap.resetTitle")}
                 onClick={handleReset}
               >

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
@@ -8,6 +8,7 @@ import {
   parseStoryMapJson,
   serializeStoryMapCsv,
   serializeStoryMapJson,
+  storyMapHasContent,
   useAppStore,
   type StoryChapter,
   type StoryChapterAlignment,
@@ -94,13 +95,13 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
 
   const story: StoryMap = storymap ?? DEFAULT_STORY_MAP;
   const chapters = story.chapters;
-  // Reset has something to clear when there are chapters or any story metadata
-  // set, so it stays disabled in the empty state (where "Load sample story" is
-  // the relevant action) even if a stale `storymap` object lingers after the
-  // last chapter was deleted manually.
-  const hasStoryContent =
-    chapters.length > 0 ||
-    Boolean(story.title || story.subtitle || story.byline || story.footer);
+  // Reset has something to clear when the story carries chapters or any
+  // non-default setting, so it stays disabled in the empty state (where "Load
+  // sample story" is the relevant action) even if a stale `storymap` object
+  // lingers after the last chapter was deleted manually. Reuse the canonical
+  // check from @geolibre/core so this stays in sync with how the project layer
+  // decides a story is worth persisting.
+  const hasStoryContent = storyMapHasContent(story);
 
   const handleAddChapter = useCallback(() => {
     const view = mapControllerRef.current?.readView();

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
@@ -45,6 +45,7 @@ import {
   MapPin,
   Play,
   Plus,
+  RotateCcw,
   Sparkles,
   Trash2,
   Upload,
@@ -126,6 +127,15 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
     const first = sample.chapters[0];
     if (first) mapControllerRef.current?.flyToView(first.location);
   }, [mapControllerRef, setStorymap]);
+
+  const handleReset = useCallback(() => {
+    if (!window.confirm(t("storymap.resetConfirm"))) return;
+    // Clearing the story drops back to the empty default (the panel falls back
+    // to DEFAULT_STORY_MAP when `storymap` is null), so the empty state with the
+    // "Load sample story" button reappears and users can build their own.
+    setStorymap(null);
+    setExpandedId(null);
+  }, [setStorymap, t]);
 
   const handleCaptureView = useCallback(
     (id: string) => {
@@ -319,6 +329,16 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
               <Button size="sm" variant="outline" onClick={handleAddChapter}>
                 <Plus className="mr-1 h-4 w-4" />
                 {t("storymap.addChapter")}
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={!storymap}
+                title={t("storymap.resetTitle")}
+                onClick={handleReset}
+              >
+                <RotateCcw className="mr-1 h-4 w-4" />
+                {t("storymap.reset")}
               </Button>
             </div>
           </div>

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1493,7 +1493,10 @@
     "importCsv": "Import CSV…",
     "exportData": "Export",
     "exportJson": "Export JSON",
-    "exportCsv": "Export CSV"
+    "exportCsv": "Export CSV",
+    "reset": "Reset",
+    "resetTitle": "Clear the story and start over",
+    "resetConfirm": "Clear this story map? All chapters and settings will be removed so you can start your own."
   },
   "network": {
     "title": "Network analysis",

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -269,7 +269,7 @@ export function normalizeStoryMap(storymap: unknown): StoryMap | null {
 }
 
 /** Whether a story map carries chapters or any non-default setting. */
-function storyMapHasContent(story: StoryMap): boolean {
+export function storyMapHasContent(story: StoryMap): boolean {
   if (story.chapters.length > 0) return true;
   return (
     story.title.trim() !== "" ||

--- a/packages/core/src/storymap-sample.ts
+++ b/packages/core/src/storymap-sample.ts
@@ -87,7 +87,7 @@ export function createSampleStoryMap(): StoryMap {
         image: `${SAMPLE_ASSET_BASE}/sydney.jpg`,
         description:
           "Sydney, capital of New South Wales and one of Australia's largest cities, is best known for its harbourfront Sydney Opera House, with a distinctive sail-like design. <br><br>Massive Darling Harbour and the smaller Circular Quay port are hubs of waterside life, with the arched Harbour Bridge and esteemed Royal Botanic Garden nearby.",
-        alignment: "center",
+        alignment: "right",
         hidden: false,
         location: {
           center: [151.2093, -33.8688],
@@ -106,7 +106,7 @@ export function createSampleStoryMap(): StoryMap {
         image: `${SAMPLE_ASSET_BASE}/cape-town.jpg`,
         description:
           "Cape Town is a port city on South Africa's southwest coast, on a peninsula beneath the imposing Table Mountain. Slowly rotating cable cars climb to the mountain's flat top, from which there are sweeping views of the city, the busy harbor and boats headed for Robben Island, the infamous prison that once held Nelson Mandela. <br><br>You can add as many chapters as you need to tell your story.",
-        alignment: "full",
+        alignment: "left",
         hidden: false,
         location: {
           center: [18.4241, -33.9249],


### PR DESCRIPTION
Addresses two of the actionable points from #615 (the others are by-design / user-configurable or larger features tracked separately).

## What changed

### Reset/clear button (point #7)
The Story Map authoring panel had no way to clear a loaded story, leaving users stuck with the sample. This adds a **Reset** button next to **Add chapter** that clears the current story (all chapters and settings) so users can start their own.

- Confirms before clearing (`window.confirm`, matching the app's existing destructive-action pattern).
- Disabled when there is nothing to clear, so the empty state with **Load sample story** reappears afterward.

### Collapse side panels while presenting (point #1 / #11)
While a story map is presenting, the **Layers** and **Style** side panels now collapse automatically so the presentation gets the full map canvas. The override is derived from the presenting state (not a persisted setting), so exiting the presentation restores the user's previous panel layout.

## Verification
Drove the real app with Playwright in **both light and dark themes**:
- Reset is disabled on an empty story, enabled after Load sample (5 chapters), and clears back to the empty state on confirm.
- Presenting hides both side panels (full-width canvas); exiting restores both.

New user-facing strings added to `en.json` via `t()`.

Refs #615

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* **Reset Button**: Added a reset button to story maps with confirmation dialog, enabling users to clear the story and start fresh.
* **Smart Panel Collapse**: Panels now automatically collapse during story map presentation mode for a cleaner viewing experience.

## Chores
* Updated sample story map chapter alignment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->