### PR TITLE
fix(swipe): bump maplibre-gl-swipe to 0.9.1 to fix Layer Swipe under globe

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -72,7 +72,7 @@
     "maplibre-gl-planetary-computer": "^0.3.0",
     "maplibre-gl-raster": "^0.6.1",
     "maplibre-gl-streetview": "^0.7.0",
-    "maplibre-gl-swipe": "^0.7.1",
+    "maplibre-gl-swipe": "^0.9.1",
     "maplibre-gl-time-slider": "^1.0.3",
     "maplibre-gl-usgs-lidar": "^0.11.0",
     "maplibre-gl-vector": "^0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
         "maplibre-gl-planetary-computer": "^0.3.0",
         "maplibre-gl-raster": "^0.6.1",
         "maplibre-gl-streetview": "^0.7.0",
-        "maplibre-gl-swipe": "^0.7.1",
+        "maplibre-gl-swipe": "^0.9.1",
         "maplibre-gl-time-slider": "^1.0.3",
         "maplibre-gl-usgs-lidar": "^0.11.0",
         "maplibre-gl-vector": "^0.4.0",
@@ -17900,9 +17900,9 @@
       }
     },
     "node_modules/maplibre-gl-swipe": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-swipe/-/maplibre-gl-swipe-0.7.1.tgz",
-      "integrity": "sha512-npJSCnHmf6j/7IfNg6eqaRWJT8S6iS+wKfJjQDmQgjVIVvgHoiAnoOx65XZsZ0i9LtNGaxsE5Z3N51992VQyHQ==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-swipe/-/maplibre-gl-swipe-0.9.1.tgz",
+      "integrity": "sha512-oP8IA1oP0NfEaiKvBWeYcmlfI8oURyzyedD/75siS9ABf3VOoeou/vAxfbhPeOVlXOy+dE1MSaFsGH0rDyNFRw==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -24319,7 +24319,7 @@
         "maplibre-gl-planetary-computer": "^0.3.0",
         "maplibre-gl-raster": "^0.6.1",
         "maplibre-gl-streetview": "^0.7.0",
-        "maplibre-gl-swipe": "^0.7.1",
+        "maplibre-gl-swipe": "^0.9.1",
         "maplibre-gl-time-slider": "^1.0.3",
         "maplibre-gl-usgs-lidar": "^0.11.0",
         "maplibre-gl-vector": "^0.4.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -47,7 +47,7 @@
     "maplibre-gl-planetary-computer": "^0.3.0",
     "maplibre-gl-raster": "^0.6.1",
     "maplibre-gl-streetview": "^0.7.0",
-    "maplibre-gl-swipe": "^0.7.1",
+    "maplibre-gl-swipe": "^0.9.1",
     "maplibre-gl-time-slider": "^1.0.3",
     "maplibre-gl-usgs-lidar": "^0.11.0",
     "maplibre-gl-vector": "^0.4.0",

--- a/packages/plugins/src/plugins/maplibre-swipe.ts
+++ b/packages/plugins/src/plugins/maplibre-swipe.ts
@@ -18,7 +18,7 @@ let unsubscribeBasemap: (() => void) | null = null;
 export const maplibreSwipePlugin: GeoLibrePlugin = {
   id: "maplibre-gl-swipe",
   name: "Layer Swipe",
-  version: "0.7.1",
+  version: "0.9.1",
   activate: (app: GeoLibreAppAPI) => {
     swipeControl = new SwipeControl(
       getSwipeControlOptions(app, savedSwipeState ?? undefined),


### PR DESCRIPTION
## Problem

Activating Layer Swipe under the default **globe** projection showed the same (left-selected) layer on both halves of the map; the right-selected layer never appeared. For example, with the basemap on the left and an XYZ raster on the right, both halves showed the basemap. (It worked correctly in Mercator, which made it look XYZ-specific, but it was projection-related.)

## Root cause

The swipe control renders the "right" layers with a second MapLibre map (a comparison map) overlaid on the main one, inside a clip container. That overlay was hardcoded to `z-index: 1`. Under globe, GeoLibre raises its base map canvas to `z-index: 4` (so its `geolibre-effects-canvas` atmosphere layers stack beneath it), which then painted over the `z-index: 1` overlay and hid the right layers entirely.

## Fix

Bump `maplibre-gl-swipe` `0.7.1 -> 0.9.1`. The upstream fix (opengeos/maplibre-gl-swipe#16, released as 0.9.1) places the comparison overlay just above the host's base-map canvas (derived from the canvas's own z-index) instead of a hardcoded `1`, so the right layers render again. No GeoLibre-side wiring changes were needed.

## Verification

Verified in the running app with the published 0.9.1, using an XYZ raster layer on one side and the vector basemap on the other:

- Globe projection: distinct layers per side (basemap left / XYZ right), in both light and dark themes.
- Mercator projection: unchanged, still works.
- `npm run build` passes (no API changes needed for 0.9.1).