### PR TITLE
fix(plugins): distinct icon for the NASA Earthdata control

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -67,7 +67,7 @@
     "maplibre-gl-geo-editor": "^0.9.1",
     "maplibre-gl-geoagent": "^0.4.4",
     "maplibre-gl-lidar": "^0.16.0",
-    "maplibre-gl-nasa-earthdata": "^0.1.2",
+    "maplibre-gl-nasa-earthdata": "^0.1.4",
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-planetary-computer": "^0.3.0",
     "maplibre-gl-raster": "^0.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "maplibre-gl-geo-editor": "^0.9.1",
         "maplibre-gl-geoagent": "^0.4.4",
         "maplibre-gl-lidar": "^0.16.0",
-        "maplibre-gl-nasa-earthdata": "^0.1.2",
+        "maplibre-gl-nasa-earthdata": "^0.1.4",
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
         "maplibre-gl-raster": "^0.6.1",
@@ -17699,9 +17699,9 @@
       }
     },
     "node_modules/maplibre-gl-nasa-earthdata": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-nasa-earthdata/-/maplibre-gl-nasa-earthdata-0.1.2.tgz",
-      "integrity": "sha512-EOyK6//BbNVR6nGVx2sNbaK7UsLCbC5rGCCDY0kR1Q7KJc6qoyCpxpr0svNlEArmqchoRiqmOTz9tNea1P1itA==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-nasa-earthdata/-/maplibre-gl-nasa-earthdata-0.1.4.tgz",
+      "integrity": "sha512-SAkAv2D8GHiHWGF0+e0udwemFAO6KlfmeGbsQWmZ1Y7HcgiCk9yX9kiQ9DiEFG1U6t00FpMKZ/sEO0ImEC99FQ==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -24313,7 +24313,7 @@
         "maplibre-gl-geo-editor": "^0.9.1",
         "maplibre-gl-geoagent": "^0.4.4",
         "maplibre-gl-lidar": "^0.16.0",
-        "maplibre-gl-nasa-earthdata": "^0.1.2",
+        "maplibre-gl-nasa-earthdata": "^0.1.4",
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-overture-maps": "^0.3.1",
         "maplibre-gl-planetary-computer": "^0.3.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -41,7 +41,7 @@
     "maplibre-gl-geo-editor": "^0.9.1",
     "maplibre-gl-geoagent": "^0.4.4",
     "maplibre-gl-lidar": "^0.16.0",
-    "maplibre-gl-nasa-earthdata": "^0.1.2",
+    "maplibre-gl-nasa-earthdata": "^0.1.4",
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-overture-maps": "^0.3.1",
     "maplibre-gl-planetary-computer": "^0.3.0",

--- a/packages/plugins/src/plugins/maplibre-nasa-earthdata.ts
+++ b/packages/plugins/src/plugins/maplibre-nasa-earthdata.ts
@@ -173,7 +173,7 @@ const nasaEarthdataStoreSync = createWebServiceStoreSync(nasaEarthdataAdapter);
 export const maplibreNasaEarthdataPlugin: GeoLibrePlugin = {
   id: "maplibre-gl-nasa-earthdata",
   name: "NASA Earthdata",
-  version: "0.1.2",
+  version: "0.1.4",
   activate: (app: GeoLibreAppAPI) => {
     if (!nasaEarthdataControl) {
       nasaEarthdataControl = new NasaEarthdataControl(


### PR DESCRIPTION
## Summary

The NASA Earthdata plugin's toggle button used a generic **globe** icon, which collided visually with the globe GeoLibre uses for core map functionality (issue #632). The duplicate icon made the button's purpose ambiguous at a glance.

The icon lives in the upstream `maplibre-gl-nasa-earthdata` package, so the fix was made there. An initial swap to a satellite icon turned out to match the sibling **NASA OPERA** control's icon, so the final icon is a **satellite-dish**, which is distinct from both the core globe and the OPERA satellite, reflects NASA Earthdata's Earth-observation data access, and carries no agency branding (per the maintainer's note on the issue). Released upstream as **0.1.4**.

This PR bumps the dependency to consume that release.

## Changes

- `apps/geolibre-desktop/package.json`, `packages/plugins/package.json`: `maplibre-gl-nasa-earthdata` `^0.1.2` -> `^0.1.4`.
- `package-lock.json`: regenerated for the bump.

## Testing

- `npm run build` ✓
- `pre-commit run --files <changed>` ✓
- Verified in the running app with the published build: activated the NASA Earthdata plugin and confirmed the toggle renders the **satellite-dish** icon (not a globe, not the OPERA satellite) in **both light and dark themes**. The control still mounts and the panel opens as before.

Upstream PRs: opengeos/maplibre-gl-nasa-earthdata#5 and opengeos/maplibre-gl-nasa-earthdata#7 (released as v0.1.4)

Fixes #632