### PR TITLE
feat(winget): add Windows Package Manager packaging (OpenGeos.GeoLibre)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,3 +309,32 @@ jobs:
           [[ -n "$srpm" ]] || { echo "::error::rpmbuild produced no SRPM path"; exit 1; }
           echo "Built SRPM: $srpm"
           copr-cli build --nowait "$COPR_PROJECT" "$srpm"
+
+  winget:
+    name: Publish to winget
+    needs: build
+    runs-on: ubuntu-latest
+    # Isolated like the AUR/COPR jobs: only needs build for the release assets,
+    # nothing depends on it, continue-on-error keeps a winget hiccup from
+    # failing the release, and it skips itself when WINGET_TOKEN is unset (forks,
+    # or before the maintainer configures it).
+    continue-on-error: true
+    concurrency:
+      group: winget-publish
+      cancel-in-progress: false
+    # Only publish for full releases, not prereleases.
+    if: ${{ !github.event.release.prerelease }}
+    env:
+      WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+    steps:
+      - name: Submit OpenGeos.GeoLibre to winget-pkgs
+        if: ${{ env.WINGET_TOKEN != '' }}
+        # Pinned to a commit SHA (not the mutable v2 tag) because this step
+        # receives a token with access to the winget-pkgs fork. winget-releaser
+        # derives the version from the release tag and uses komac under the hood.
+        uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
+        with:
+          identifier: OpenGeos.GeoLibre
+          installers-regex: '_x64-setup\.exe$'
+          fork-user: giswqs
+          token: ${{ env.WINGET_TOKEN }}

--- a/packaging/winget/OpenGeos.GeoLibre.installer.yaml
+++ b/packaging/winget/OpenGeos.GeoLibre.installer.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: OpenGeos.GeoLibre
+PackageVersion: 1.5.0
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - silent
+  - silentWithProgress
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/opengeos/GeoLibre/releases/download/v1.5.0/GeoLibre.Desktop_1.5.0_x64-setup.exe
+    InstallerSha256: 94079516D877DEAC4F96B82F4B46D1EF607B7D4D996340556C6B902FFFC2F9C7
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/packaging/winget/OpenGeos.GeoLibre.locale.en-US.yaml
+++ b/packaging/winget/OpenGeos.GeoLibre.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: OpenGeos.GeoLibre
+PackageVersion: 1.5.0
+PackageLocale: en-US
+Publisher: OpenGeos
+PublisherUrl: https://github.com/opengeos
+PublisherSupportUrl: https://github.com/opengeos/GeoLibre/issues
+Author: GeoLibre Contributors
+PackageName: GeoLibre Desktop
+PackageUrl: https://geolibre.app/
+License: MIT
+LicenseUrl: https://github.com/opengeos/GeoLibre/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Qiusheng Wu
+ShortDescription: Lightweight, cloud-native GIS platform for visualizing and analyzing geospatial data
+Description: |-
+  GeoLibre is a lightweight, cloud-native desktop GIS for visualizing and
+  analyzing geospatial data, built on MapLibre with deck.gl for 3D and
+  point-cloud overlays. It loads vector and raster files, web services, 3D
+  Tiles, MBTiles, and cloud-native formats, and is extensible through a plugin
+  ecosystem.
+Moniker: geolibre
+Tags:
+  - gis
+  - geospatial
+  - map
+  - maplibre
+  - raster
+  - vector
+ReleaseNotesUrl: https://github.com/opengeos/GeoLibre/releases/tag/v1.5.0
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/packaging/winget/OpenGeos.GeoLibre.yaml
+++ b/packaging/winget/OpenGeos.GeoLibre.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: OpenGeos.GeoLibre
+PackageVersion: 1.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -1,0 +1,58 @@
+# winget packaging (`OpenGeos.GeoLibre`)
+
+GeoLibre is published to the [Windows Package Manager](https://learn.microsoft.com/windows/package-manager/)
+(winget) as **`OpenGeos.GeoLibre`**, so Windows users can install it with:
+
+```powershell
+winget install OpenGeos.GeoLibre
+```
+
+The package wraps the official Tauri-built **NSIS** installer (winget type
+`nullsoft`) from the GitHub release, x64, per-user scope (Tauri's NSIS default).
+winget hosts no binaries itself: it stores YAML manifests in the community repo
+[`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs) and downloads
+the installer from the release URL.
+
+## Files
+
+The three manifests here are **reference copies** of what is submitted to
+`winget-pkgs` (under `manifests/o/OpenGeos/GeoLibre/<version>/`), validated
+against the v1.6.0 JSON schemas:
+
+- `OpenGeos.GeoLibre.yaml` (version manifest)
+- `OpenGeos.GeoLibre.installer.yaml` (installer: URL, sha256, `nullsoft`, x64)
+- `OpenGeos.GeoLibre.locale.en-US.yaml` (name, publisher, description, license)
+
+## One-time setup (maintainer)
+
+The release workflow submits new versions automatically with
+[`winget-releaser`](https://github.com/vedantmgoyal9/winget-releaser) (which uses
+[`komac`](https://github.com/russellbanks/Komac)). It needs:
+
+1. A fork of `microsoft/winget-pkgs` under your account (`giswqs/winget-pkgs`).
+2. A **classic** Personal Access Token with the `public_repo` scope, added as the
+   repo secret **`WINGET_TOKEN`** (Settings -> Secrets and variables -> Actions).
+   The action uses it to push to your fork and open the PR to `winget-pkgs`.
+   Without the secret the `winget` job skips itself, so forks are unaffected.
+
+The very first submission (a new package) is done manually; subsequent versions
+are automated by the `winget` job.
+
+## How CI keeps it current
+
+On every published, non-prerelease release, the isolated `winget` job in
+[`.github/workflows/release.yml`](../../.github/workflows/release.yml) runs
+`winget-releaser`, which downloads the release's `*_x64-setup.exe`, regenerates
+the manifests for the new version, and opens a PR to `microsoft/winget-pkgs`. The
+job is `continue-on-error` and independent of the asset build and the other
+publish targets.
+
+## Maintenance notes
+
+- **Installer:** the `installers-regex` (`_x64-setup\.exe$`) selects the NSIS
+  setup. To switch to the MSI, change the regex and set `InstallerType: wix`.
+- **Scope:** `user` reflects Tauri's NSIS default (`currentUser`). If a future
+  build switches to per-machine, update `Scope` to `machine`.
+- **Schema:** validate edits with the official schemas, e.g.
+  `winget validate --manifest <dir>` on Windows, or against
+  `https://aka.ms/winget-manifest.installer.1.6.0.schema.json`.


### PR DESCRIPTION
## Summary

Adds **winget** (Windows Package Manager) support, the biggest untapped channel after Linux. Windows users will be able to:

```powershell
winget install OpenGeos.GeoLibre
```

winget hosts manifests (not binaries) in `microsoft/winget-pkgs` and downloads the installer from the GitHub release. This wraps the official Tauri **NSIS** installer (winget type `nullsoft`), x64, per-user scope (Tauri's NSIS default).

## Changes

- `packaging/winget/` — the three manifests (`version`, `installer`, `locale.en-US`), **validated against the winget v1.6.0 JSON schemas** (the schema check caught that NSIS is `nullsoft`, not `nsis`, in winget).
- `.github/workflows/release.yml` — an isolated `winget` job using `winget-releaser` (pinned to a commit SHA since it receives a token; gated on `WINGET_TOKEN`; `continue-on-error`) that submits each new version to `winget-pkgs`.
- `packaging/winget/README.md` — `WINGET_TOKEN`/fork setup and maintenance notes.

## Failure isolation (same as AUR/COPR)

The `winget` job only `needs: build`, nothing depends on it, it skips itself when `WINGET_TOKEN` is unset, and `continue-on-error` keeps a winget failure from reddening the release.

## Initial submission (already opened)

The first package submission to `microsoft/winget-pkgs` was opened manually: **microsoft/winget-pkgs#391085**. Once it merges, CI handles future versions.

## Follow-up before CI can auto-update

Add the `WINGET_TOKEN` secret (a classic PAT with `public_repo` scope) per `packaging/winget/README.md`. Until then the job no-ops safely.