### PR TITLE
fix(msix): declare a language and allow Store identity overrides

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
         id: build_msix
         if: runner.os == 'Windows'
         shell: pwsh
-        run: ./scripts/build-msix.ps1
+        run: ./packaging/msix/build-msix.ps1
 
       - name: Upload MSIX release asset
         if: runner.os == 'Windows'

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "tauri": "npm run tauri -w geolibre-desktop",
     "tauri:dev": "npm run tauri dev -w geolibre-desktop",
     "tauri:build": "node scripts/tauri-build.mjs",
-    "msix:build": "pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/build-msix.ps1"
+    "msix:build": "pwsh -NoProfile -ExecutionPolicy Bypass -File packaging/msix/build-msix.ps1"
   },
   "engines": {
     "node": ">=22"

--- a/packaging/msix/README.md
+++ b/packaging/msix/README.md
@@ -45,6 +45,12 @@ pwsh ./packaging/msix/build-msix.ps1 `
 The package family name is derived automatically from `-Name` + `-Publisher`, so
 it will match once those are correct.
 
+`-DisplayName` sets only the package display name (`Properties/DisplayName`, used
+for the Store listing). The Start-menu / taskbar name
+(`Applications/.../VisualElements/@DisplayName`) deliberately stays the Tauri
+product name ("GeoLibre Desktop"); the two are allowed to differ, and a Store
+submission with this split passed validation.
+
 ## `runFullTrust`
 
 The manifest declares the `runFullTrust` restricted capability, which a packaged

--- a/packaging/msix/README.md
+++ b/packaging/msix/README.md
@@ -1,0 +1,52 @@
+# MSIX packaging (`build-msix.ps1`)
+
+[`build-msix.ps1`](build-msix.ps1) builds an MSIX package for GeoLibre Desktop
+from a finished Windows Tauri release build. It generates the `AppxManifest.xml`,
+copies the binary + Python sidecar + logo assets, and runs `MakeAppx.exe`. It
+**requires Windows** and the Windows SDK MSIX packaging tools.
+
+There are two distinct targets, both produced by this one script:
+
+1. The **self-signed / winget MSIX** attached to each GitHub release (the
+   `release.yml` "Build MSIX package" step runs the script with its defaults:
+   `Publisher = CN=GeoLibre`, identity from the Tauri config).
+2. A **Microsoft Store** MSIX, built manually with your Partner Center identity
+   (see below). The Store re-signs the package, so you do not sign it yourself.
+
+## Build (defaults, for winget / direct download)
+
+```powershell
+npm run msix:build
+# or: pwsh ./packaging/msix/build-msix.ps1
+```
+
+## Build for the Microsoft Store
+
+The Store validates the package identity against the values reserved for the app
+in Partner Center (**Product management -> Product Identity**). Pass them as
+parameters; the Store-required fields differ from the defaults:
+
+```powershell
+pwsh ./packaging/msix/build-msix.ps1 `
+  -Name "OpenGeospatialSolutions.GeoLibre" `        # Package/Identity/Name
+  -Publisher "CN=E6AE8172-DC4F-4F79-844B-9D84204BF95A" `  # Package/Identity/Publisher
+  -PublisherDisplayName "Open Geospatial Solutions" `     # your publisher display name
+  -DisplayName "GeoLibre"                            # a name reserved in Partner Center
+```
+
+| Parameter | Default | Why override for the Store |
+| --- | --- | --- |
+| `-Name` | Tauri identifier (`org.geolibre.desktop`) | Must be the reserved `Package/Identity/Name` |
+| `-Publisher` | `CN=GeoLibre` | Must be your seller `CN=<GUID>` |
+| `-PublisherDisplayName` | `GeoLibre` | Must match your publisher display name |
+| `-DisplayName` | Tauri `productName` (`GeoLibre Desktop`) | `Properties/DisplayName` must be a **reserved** name |
+| `-Language` | `en-us` | Every MSIX must declare a language |
+
+The package family name is derived automatically from `-Name` + `-Publisher`, so
+it will match once those are correct.
+
+## `runFullTrust`
+
+The manifest declares the `runFullTrust` restricted capability, which a packaged
+Win32 (Tauri) desktop app requires. The Store flags it as a **warning**, not an
+error; it is reviewed and granted during certification. Do not remove it.

--- a/packaging/msix/build-msix.ps1
+++ b/packaging/msix/build-msix.ps1
@@ -14,6 +14,7 @@ param(
   # in Partner Center (e.g. "GeoLibre"), which may differ from the product name.
   [string] $DisplayName = "",
   # Default package language. Required by the Store; every MSIX must declare one.
+  [ValidatePattern('^[a-zA-Z]{2,8}(-[a-zA-Z0-9]{1,8})*$')]
   [string] $Language = "en-us"
 )
 
@@ -68,9 +69,9 @@ $iconsDir = Join-Path $tauriDir "icons"
 
 $config = Get-Content -Raw $configPath | ConvertFrom-Json
 $productName = [string] $config.productName
-if (-not $DisplayName) { $DisplayName = $productName }
+if ([string]::IsNullOrWhiteSpace($DisplayName)) { $DisplayName = $productName }
 $identifier = [string] $config.identifier
-if (-not $Name) { $Name = $identifier }
+if ([string]::IsNullOrWhiteSpace($Name)) { $Name = $identifier }
 $version = ConvertTo-MsixVersion ([string] $config.version)
 
 $cargo = Get-Content -Raw $cargoPath

--- a/packaging/msix/build-msix.ps1
+++ b/packaging/msix/build-msix.ps1
@@ -9,6 +9,10 @@ param(
   # package name from Partner Center (Product Identity) for a Microsoft Store
   # submission.
   [string] $Name = "",
+  # Package display name (Properties/DisplayName). Defaults to the Tauri
+  # productName; for a Microsoft Store submission it must be a name you reserved
+  # in Partner Center (e.g. "GeoLibre"), which may differ from the product name.
+  [string] $DisplayName = "",
   # Default package language. Required by the Store; every MSIX must declare one.
   [string] $Language = "en-us"
 )
@@ -51,7 +55,7 @@ function ConvertTo-XmlText([string] $Value) {
   return [System.Security.SecurityElement]::Escape($Value)
 }
 
-$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
 $appRoot = Resolve-Path (Join-Path $repoRoot $AppDir)
 $tauriDir = Join-Path $appRoot "src-tauri"
 $targetDir = Join-Path $tauriDir "target\$Configuration"
@@ -64,6 +68,7 @@ $iconsDir = Join-Path $tauriDir "icons"
 
 $config = Get-Content -Raw $configPath | ConvertFrom-Json
 $productName = [string] $config.productName
+if (-not $DisplayName) { $DisplayName = $productName }
 $identifier = [string] $config.identifier
 if (-not $Name) { $Name = $identifier }
 $version = ConvertTo-MsixVersion ([string] $config.version)
@@ -118,7 +123,7 @@ $manifest = @"
     Version="$(ConvertTo-XmlText $version)"
     ProcessorArchitecture="$(ConvertTo-XmlText $Architecture)" />
   <Properties>
-    <DisplayName>$(ConvertTo-XmlText $productName)</DisplayName>
+    <DisplayName>$(ConvertTo-XmlText $DisplayName)</DisplayName>
     <PublisherDisplayName>$(ConvertTo-XmlText $PublisherDisplayName)</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>

--- a/scripts/build-msix.ps1
+++ b/scripts/build-msix.ps1
@@ -4,7 +4,13 @@ param(
   [ValidateSet("x64", "x86", "arm64", "arm", "neutral")]
   [string] $Architecture = "x64",
   [string] $Publisher = "CN=GeoLibre",
-  [string] $PublisherDisplayName = "GeoLibre"
+  [string] $PublisherDisplayName = "GeoLibre",
+  # Identity Name. Defaults to the Tauri identifier; override with the reserved
+  # package name from Partner Center (Product Identity) for a Microsoft Store
+  # submission.
+  [string] $Name = "",
+  # Default package language. Required by the Store; every MSIX must declare one.
+  [string] $Language = "en-us"
 )
 
 $ErrorActionPreference = "Stop"
@@ -59,6 +65,7 @@ $iconsDir = Join-Path $tauriDir "icons"
 $config = Get-Content -Raw $configPath | ConvertFrom-Json
 $productName = [string] $config.productName
 $identifier = [string] $config.identifier
+if (-not $Name) { $Name = $identifier }
 $version = ConvertTo-MsixVersion ([string] $config.version)
 
 $cargo = Get-Content -Raw $cargoPath
@@ -106,7 +113,7 @@ $manifest = @"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   IgnorableNamespaces="uap rescap">
   <Identity
-    Name="$(ConvertTo-XmlText $identifier)"
+    Name="$(ConvertTo-XmlText $Name)"
     Publisher="$(ConvertTo-XmlText $Publisher)"
     Version="$(ConvertTo-XmlText $version)"
     ProcessorArchitecture="$(ConvertTo-XmlText $Architecture)" />
@@ -115,6 +122,9 @@ $manifest = @"
     <PublisherDisplayName>$(ConvertTo-XmlText $PublisherDisplayName)</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
+  <Resources>
+    <Resource Language="$(ConvertTo-XmlText $Language)" />
+  </Resources>
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.26100.0" />
   </Dependencies>


### PR DESCRIPTION
## Summary

Fixes the Microsoft Store / Partner Center package-acceptance errors on the MSIX.

The generated `AppxManifest.xml` had **no `<Resources>` element**, so the Store rejected the package with:
- "must declare support for at least one language"
- "specifies an unsupported default language"

This adds `<Resources><Resource Language="en-us" /></Resources>` (overridable via `-Language`).

It also adds a **`-Name`** parameter so the `Identity Name` can be set to the reserved package name from Partner Center for a Store submission (it still defaults to the Tauri identifier for the self-signed / winget MSIX). `Publisher` and `PublisherDisplayName` were already parameters.

## Store build example

```powershell
pwsh ./scripts/build-msix.ps1 `
  -Name "<Package/Identity/Name from Partner Center>" `
  -Publisher "<Package/Identity/Publisher, e.g. CN=ABCD...>" `
  -PublisherDisplayName "Open Geospatial Solutions"
```

(The self-signed/winget MSIX built in `release.yml` is unchanged: defaults still produce `CN=GeoLibre` / the Tauri identifier, now with the required language declaration.)

## Note

`build-msix.ps1` runs only on Windows (it needs `MakeAppx.exe`), so it can't be exercised in this Linux CI; the change is a manifest-content fix verified against the Store's validation messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added MSIX build usage documentation for the new packaging script, including build targets, required Store validation parameter overrides, and localization/certification notes.

* **New Features**
  * Expanded MSIX packaging inputs for publisher display name, package identity name, package display name, and Store language; improved manifest population and added localized resources to the generated manifest.

* **Chores**
  * Updated the Windows workflow and `msix:build` command to run the MSIX script from its new location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->