### PR TITLE
docs(msix): placeholder publisher GUID and tighten language pattern

### DIFF
--- a/packaging/msix/README.md
+++ b/packaging/msix/README.md
@@ -29,7 +29,7 @@ parameters; the Store-required fields differ from the defaults:
 ```powershell
 pwsh ./packaging/msix/build-msix.ps1 `
   -Name "OpenGeospatialSolutions.GeoLibre" `        # Package/Identity/Name
-  -Publisher "CN=E6AE8172-DC4F-4F79-844B-9D84204BF95A" `  # Package/Identity/Publisher
+  -Publisher "CN=XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" `  # Package/Identity/Publisher (your seller GUID)
   -PublisherDisplayName "Open Geospatial Solutions" `     # your publisher display name
   -DisplayName "GeoLibre"                            # a name reserved in Partner Center
 ```

--- a/packaging/msix/build-msix.ps1
+++ b/packaging/msix/build-msix.ps1
@@ -14,7 +14,7 @@ param(
   # in Partner Center (e.g. "GeoLibre"), which may differ from the product name.
   [string] $DisplayName = "",
   # Default package language. Required by the Store; every MSIX must declare one.
-  [ValidatePattern('^[a-zA-Z]{2,8}(-[a-zA-Z0-9]{1,8})*$')]
+  [ValidatePattern('^[a-zA-Z]{2,3}(-[a-zA-Z0-9]{1,8})*$')]
   [string] $Language = "en-us"
 )
 


### PR DESCRIPTION
## Summary

Two small follow-ups to #653 (review comments that arrived after it merged):

1. **Replace the real publisher GUID** in the `packaging/msix/README.md` Store-build example with a placeholder (`CN=XXXXXXXX-...`). The merged README carried a specific Partner Center seller identity, which contributors could copy by mistake.
2. **Tighten the `-Language` `ValidatePattern`** primary subtag to `{2,3}` (ISO 639), matching BCP 47 — longer codes belong in later subtags.

Both are doc/validation-only; the script behavior is unchanged for valid tags like `en-us`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Microsoft Store build instructions to use a placeholder publisher GUID instead of a hardcoded default value.

* **Chores**
  * Tightened validation for the application name parameter in the build script, now requiring 2–3 leading letters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->