### PR TITLE
docs: add CITATION.cff with Zenodo concept DOI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,37 @@ jobs:
             test-results/
           retention-days: 7
 
+  citation:
+    name: Validate CITATION.cff
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install cffconvert
+        run: python -m pip install cffconvert
+
+      - name: Validate CITATION.cff against the CFF schema
+        run: cffconvert --validate -i CITATION.cff
+
+      - name: Ensure version matches package.json
+        run: |
+          cff_version="$(sed -n 's/^version: *//p' CITATION.cff | tr -d '"' | head -n1)"
+          pkg_version="$(python -c "import json; print(json.load(open('package.json'))['version'])")"
+          echo "CITATION.cff version: $cff_version"
+          echo "package.json version: $pkg_version"
+          if [ "$cff_version" != "$pkg_version" ]; then
+            echo "::error file=CITATION.cff::version ($cff_version) does not match package.json ($pkg_version). Update CITATION.cff version and date-released when bumping the release version."
+            exit 1
+          fi
+
   checks:
     name: Build and test
     runs-on: ubuntu-22.04

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,24 @@
+cff-version: 1.2.0
+title: GeoLibre
+message: "If you use this software, please cite it using the metadata from this file."
+type: software
+abstract: "GeoLibre is a free and open-source, lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data across web browsers, desktop applications, mobile devices, and Jupyter notebooks while keeping data local and private."
+authors:
+  - given-names: Qiusheng
+    family-names: Wu
+    email: giswqs@gmail.com
+    affiliation: "University of Tennessee, Knoxville, USA"
+    orcid: "https://orcid.org/0000-0001-5437-4073"
+version: 1.5.0
+date-released: 2026-06-20
+doi: 10.5281/zenodo.20785400
+repository-code: "https://github.com/opengeos/GeoLibre"
+url: "https://geolibre.app"
+license: MIT
+keywords:
+  - GIS
+  - geospatial
+  - remote sensing
+  - data visualization
+  - MapLibre
+  - Python

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Open in CodeSandbox](https://img.shields.io/badge/Open%20in-CodeSandbox-blue?logo=codesandbox)](https://codesandbox.io/p/github/opengeos/geolibre)
 [![Open in StackBlitz](https://img.shields.io/badge/Open%20in-StackBlitz-blue?logo=stackblitz)](https://stackblitz.com/github/opengeos/geolibre)
 [![image](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20785400.svg)](https://doi.org/10.5281/zenodo.20785400)
 
 
 A lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data across desktop, web, and Android, with a responsive layout for mobile screens.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20785400.svg)](https://doi.org/10.5281/zenodo.20785400)
 
 
-A lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data across desktop, web, and Android, with a responsive layout for mobile screens.
+A free and open-source, lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data. It runs everywhere you do, in the web browser, on the desktop, on mobile, and inside Jupyter notebooks, all while keeping your data local and private.
 
 GeoLibre is built with **Tauri v2**, **React**, **TypeScript**, **MapLibre GL JS**, **DuckDB-WASM Spatial**, and **deck.gl**. The same workspace runs as a native desktop app, a native Android app, in any modern web browser, and adapts responsively to mobile and small screens.
 

--- a/apps/geolibre-desktop/index.html
+++ b/apps/geolibre-desktop/index.html
@@ -14,7 +14,7 @@
     />
     <meta
       name="description"
-      content="A lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data."
+      content="A free and open-source, lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data, running in the browser, on the desktop, on mobile, and inside Jupyter notebooks while keeping your data local and private."
     />
     <meta name="theme-color" content="#2f8f85" />
     <meta name="mobile-web-app-capable" content="yes" />

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -610,7 +610,7 @@ function pwaPlugin(): Plugin[] {
       name: "GeoLibre",
       short_name: "GeoLibre",
       description:
-        "A lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data.",
+        "A free and open-source, lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data, running in the browser, on the desktop, on mobile, and inside Jupyter notebooks while keeping your data local and private.",
       theme_color: "#2f8f85",
       background_color: "#ffffff",
       display: "standalone",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-GeoLibre is a lightweight, cloud-native GIS platform that runs across desktop and web environments, with a responsive layout for mobile screens, all from a single npm workspaces monorepo. The UI is a React app that ships as a native desktop app hosted by Tauri v2 and as a browser-based web app, adapting responsively to mobile and small screens. Map rendering uses MapLibre GL JS in the browser webview, with deck.gl used for advanced raster, point cloud, and 3D overlays. Application state lives in a Zustand store (`@geolibre/core`).
+GeoLibre is a free and open-source, lightweight, cloud-native GIS platform that runs in the web browser, on the desktop, on mobile, and inside Jupyter notebooks, all from a single npm workspaces monorepo. The UI is a React app that ships as a native desktop app hosted by Tauri v2 and as a browser-based web app, adapting responsively to mobile and small screens. Map rendering uses MapLibre GL JS in the browser webview, with deck.gl used for advanced raster, point cloud, and 3D overlays. Application state lives in a Zustand store (`@geolibre/core`).
 
 ```mermaid
 flowchart LR

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,7 +12,7 @@
 [![image](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20785400.svg)](https://doi.org/10.5281/zenodo.20785400)
 
-GeoLibre is a lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data across desktop and web environments, with a responsive layout for mobile screens. It is an npm workspaces monorepo: the main app lives in `apps/geolibre-desktop` and is built with Tauri, React, TypeScript, and MapLibre GL JS. The same workspace runs as a native desktop app and as a browser-based web app, and adapts responsively to mobile and small screens.
+GeoLibre is a free and open-source, lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data. It runs everywhere you do, in the web browser, on the desktop, on mobile, and inside Jupyter notebooks, all while keeping your data local and private. It is an npm workspaces monorepo: the main app lives in `apps/geolibre-desktop` and is built with Tauri, React, TypeScript, and MapLibre GL JS.
 
 ## Video tutorial
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,6 +10,7 @@
 [![Open in CodeSandbox](https://img.shields.io/badge/Open%20in-CodeSandbox-blue?logo=codesandbox)](https://codesandbox.io/p/github/opengeos/geolibre)
 [![Open in StackBlitz](https://img.shields.io/badge/Open%20in-StackBlitz-blue?logo=stackblitz)](https://stackblitz.com/github/opengeos/geolibre)
 [![image](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20785400.svg)](https://doi.org/10.5281/zenodo.20785400)
 
 GeoLibre is a lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data across desktop and web environments, with a responsive layout for mobile screens. It is an npm workspaces monorepo: the main app lives in `apps/geolibre-desktop` and is built with Tauri, React, TypeScript, and MapLibre GL JS. The same workspace runs as a native desktop app and as a browser-based web app, and adapts responsively to mobile and small screens.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,13 +6,13 @@ hide:
 <section class="hero">
   <div class="hero__content">
     <p class="eyebrow">Cloud-native GIS platform</p>
-    <h1>A lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data.</h1>
+    <h1>A free and open-source, lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data.</h1>
     <p class="hero__lead">
-      GeoLibre is built with Tauri, React, TypeScript, MapLibre GL JS,
-      DuckDB-WASM Spatial, and deck.gl. The same workspace runs across desktop
-      and web environments, adapting responsively to mobile screens, with fast
-      local and cloud-native data work, project files, styling, plugins, and
-      modern geospatial workflows.
+      GeoLibre runs everywhere you do, in the web browser, on the desktop, on
+      mobile, and inside Jupyter notebooks, all while keeping your data local
+      and private. It is built with Tauri, React, TypeScript, MapLibre GL JS,
+      DuckDB-WASM Spatial, and deck.gl, with fast local and cloud-native data
+      work, project files, styling, plugins, and modern geospatial workflows.
     </p>
     <div class="hero__actions">
       <a class="md-button md-button--primary" href="https://viewer.geolibre.app/">Open live demo</a>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "geolibre",
   "private": true,
   "version": "1.5.0",
-  "description": "GeoLibre: a lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data across desktop and web environments, with a responsive layout for mobile screens",
+  "description": "GeoLibre: a free and open-source, lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data. It runs in the web browser, on the desktop, on mobile, and inside Jupyter notebooks, all while keeping your data local and private",
   "workspaces": [
     "apps/*",
     "packages/*",


### PR DESCRIPTION
## Summary

Adds a `CITATION.cff` (Citation File Format 1.2.0) file at the repository root so GeoLibre can be cited with standard scientific tooling. GitHub renders a "Cite this repository" button from this file, and reference managers (Zotero, etc.) can import it directly.

The `doi` field points to the Zenodo **concept DOI** (`10.5281/zenodo.20785400`), which resolves to all versions of the record. As noted in the issue, the concept DOI does not need to be updated for each release.

Metadata (title, version, release date, author, ORCID, license, keywords, abstract) is sourced from the Zenodo record at https://doi.org/10.5281/zenodo.20785401.

The file validates against CFF schema 1.2.0 (`cffconvert --validate`).

Fixes #656

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added project citation metadata (authors, release/version details, license, keywords) for proper attribution.
  * Added Zenodo DOI badges to the README and Getting Started documentation for easier access to archived releases.
  * Refreshed docs and website/hero text to better describe GeoLibre’s “free and open-source” positioning, supported runtime environments (web, desktop, mobile, Jupyter), and local/private data focus.
* **Chores**
  * Updated application manifest and desktop page metadata descriptions to align with the new product messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->