### PR TITLE
fix(vector): optional sample-data dropdown and resizable Add Vector Layer dialog

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -75,7 +75,7 @@
     "maplibre-gl-swipe": "^0.9.1",
     "maplibre-gl-time-slider": "^1.0.3",
     "maplibre-gl-usgs-lidar": "^0.11.0",
-    "maplibre-gl-vector": "^0.4.0",
+    "maplibre-gl-vector": "^0.4.1",
     "openai": "^6.39.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,7 @@
         "maplibre-gl-swipe": "^0.9.1",
         "maplibre-gl-time-slider": "^1.0.3",
         "maplibre-gl-usgs-lidar": "^0.11.0",
-        "maplibre-gl-vector": "^0.4.0",
+        "maplibre-gl-vector": "^0.4.1",
         "openai": "^6.39.0",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.7",
@@ -17962,9 +17962,9 @@
       }
     },
     "node_modules/maplibre-gl-vector": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.4.0.tgz",
-      "integrity": "sha512-fvZHskdqjdDF8/Ky3bWW9P6t4tnm6VPO2mMlMIejoJG8m4o8wsschLaDYDatUjHjse9Zc/+byiWoCX91G2GAAQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.4.1.tgz",
+      "integrity": "sha512-DrUDIq+DZZmBlBaWPYHcf3/uK32j3N6cl2eRtzHF9tFl9HXgAAMxR3rvnEu0ChENhXTU8xxtL7R7Xvy8YTPOhQ==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"
@@ -24322,7 +24322,7 @@
         "maplibre-gl-swipe": "^0.9.1",
         "maplibre-gl-time-slider": "^1.0.3",
         "maplibre-gl-usgs-lidar": "^0.11.0",
-        "maplibre-gl-vector": "^0.4.0",
+        "maplibre-gl-vector": "^0.4.1",
         "proj4": "^2.20.9",
         "shpjs": "^6.2.0",
         "three": "^0.184.0"

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -50,7 +50,7 @@
     "maplibre-gl-swipe": "^0.9.1",
     "maplibre-gl-time-slider": "^1.0.3",
     "maplibre-gl-usgs-lidar": "^0.11.0",
-    "maplibre-gl-vector": "^0.4.0",
+    "maplibre-gl-vector": "^0.4.1",
     "proj4": "^2.20.9",
     "shpjs": "^6.2.0",
     "three": "^0.184.0"

--- a/packages/plugins/src/plugins/maplibre-vector.ts
+++ b/packages/plugins/src/plugins/maplibre-vector.ts
@@ -3,6 +3,7 @@ import type {
   VectorControl,
   VectorControlEventHandler,
   VectorLayerInfo,
+  VectorSampleDataset,
 } from "maplibre-gl-vector";
 import type { GeoLibreAppAPI, GeoLibreMapControlPosition } from "../types";
 import {
@@ -18,16 +19,38 @@ import {
 
 const vectorControlPosition: GeoLibreMapControlPosition = "top-left";
 const VECTOR_PANEL_CLASS = "geolibre-vector-panel";
-const DEFAULT_VECTOR_URL =
-  "https://data.source.coop/giswqs/opengeos/countries.parquet";
 
-// These types mirror undocumented private members of VectorControl from
-// maplibre-gl-vector (verified against v0.2.0). All access is optional (?.)
-// so a rename in a future release degrades to a no-op rather than a crash --
-// re-verify these names AND the .vector-control-close selector in
+// Generic, non-loading watermark for the URL input. The real demonstration
+// links live in SAMPLE_VECTOR_DATASETS below, so the input no longer ships
+// prefilled with a live URL (see opengeos/GeoLibre#661).
+const VECTOR_URL_PLACEHOLDER = "https://example.com/data.geojson";
+
+// One-click sample datasets shown under the URL input. Edit this list to
+// offer different (or more) demonstration layers; loading is opt-in, so an
+// empty list simply hides the row.
+// URLs must be CORS-enabled to load in the browser build (source.coop and
+// raw.githubusercontent.com both send `Access-Control-Allow-Origin: *`).
+const SAMPLE_VECTOR_DATASETS: VectorSampleDataset[] = [
+  {
+    label: "Countries",
+    url: "https://data.source.coop/giswqs/opengeos/countries.parquet",
+  },
+  {
+    label: "US cities",
+    url: "https://raw.githubusercontent.com/opengeos/leafmap/master/examples/data/us_cities.geojson",
+  },
+  {
+    label: "World cities",
+    url: "https://raw.githubusercontent.com/opengeos/leafmap/master/examples/data/world_cities.geojson",
+  },
+];
+
+// This type mirrors an undocumented private member of VectorControl from
+// maplibre-gl-vector (verified against v0.4.1). Access is optional (?.) so a
+// rename in a future release degrades to a no-op rather than a crash --
+// re-verify this name AND the .vector-control-close selector in
 // wireVectorCloseButton when bumping the dependency.
 type VectorControlInternals = {
-  _clickOutsideHandler?: ((event: MouseEvent) => void) | null;
   _panel?: HTMLElement;
 };
 
@@ -68,11 +91,9 @@ export function openVectorLayerPanel(app: GeoLibreAppAPI): void {
         control.expand();
         // Idempotent (guarded by a dataset flag / null checks): retried on
         // every open so the panel chrome stays wired even if a future
-        // upstream release builds the panel DOM (or registers the
-        // click-outside handler) lazily on first expand.
+        // upstream release builds the panel DOM lazily on first expand.
         wireVectorCloseButton(control);
         applyVectorPanelClass(control);
-        disableVectorClickOutsideCollapse(control);
       } catch (error) {
         console.error(
           "[GeoLibre] Failed to open the vector layer panel",
@@ -263,7 +284,6 @@ async function ensureVectorControl(
     // The control mounts hidden: project restore must not surface a map
     // button the user never asked for. openVectorLayerPanel shows it.
     hideVectorControl(vectorControl);
-    disableVectorClickOutsideCollapse(vectorControl);
     wireVectorCloseButton(vectorControl);
     applyVectorPanelClass(vectorControl);
   }
@@ -294,13 +314,17 @@ function createVectorControl(
   const control = new VectorControlClass({
     className: "geolibre-vector-control",
     collapsed: true,
-    // Prefilled but not autoLoad: the control also mounts hidden during
-    // project restore, where auto-loading the sample would inject it
-    // into every restored project.
-    defaultUrl: DEFAULT_VECTOR_URL,
     panelWidth: 380,
     title: "Add Vector Layer",
-    urlPlaceholder: DEFAULT_VECTOR_URL,
+    // Empty input with a generic watermark; the sample datasets below are
+    // the explicit, opt-in way to load a demonstration layer.
+    urlPlaceholder: VECTOR_URL_PLACEHOLDER,
+    sampleData: SAMPLE_VECTOR_DATASETS,
+    // Let the user resize the dialog from its bottom corners.
+    resizable: true,
+    // The panel doubles as the Add Vector Layer dialog, so it stays open
+    // until the user closes it; clicking the map must not collapse it.
+    closeOnOutsideClick: false,
     // Skip the remote spatial-extension install in offline/sandboxed
     // environments when a local extension path is configured.
     spatialExtensionPath: getSpatialExtensionPath(),
@@ -409,7 +433,6 @@ function applyRestoredVectorPanelState(
       control.expand();
       wireVectorCloseButton(control);
       applyVectorPanelClass(control);
-      disableVectorClickOutsideCollapse(control);
     } catch (error) {
       console.error("[GeoLibre] Failed to restore vector panel state", error);
     }
@@ -427,18 +450,6 @@ function vectorPanelCollapsedFromLayers(
   // Projects without this UI state stay collapsed so loading a vector
   // project does not unexpectedly open the Add Data panel.
   return typeof panelCollapsed === "boolean" ? panelCollapsed : true;
-}
-
-// The control collapses its panel when the user clicks anywhere else on the
-// page, which fights the panel's role as the Add Vector Layer dialog (e.g.
-// panning the map to inspect a loaded layer would close it). Removing the
-// handler keeps the panel open until the user closes it explicitly.
-function disableVectorClickOutsideCollapse(control: VectorControl): void {
-  const internals = control as unknown as VectorControlInternals;
-  const handler = internals._clickOutsideHandler;
-  if (!handler) return;
-  document.removeEventListener("click", handler);
-  internals._clickOutsideHandler = null;
 }
 
 // The upstream stylesheet themes the panel from prefers-color-scheme (the

--- a/packages/plugins/src/plugins/maplibre-vector.ts
+++ b/packages/plugins/src/plugins/maplibre-vector.ts
@@ -27,9 +27,8 @@ const VECTOR_URL_PLACEHOLDER = "https://example.com/data.geojson";
 
 // One-click sample datasets shown under the URL input. Edit this list to
 // offer different (or more) demonstration layers; loading is opt-in, so an
-// empty list simply hides the row.
-// URLs must be CORS-enabled to load in the browser build (source.coop and
-// raw.githubusercontent.com both send `Access-Control-Allow-Origin: *`).
+// empty list simply hides the row. URLs must be CORS-enabled to load in the
+// browser build; source.coop sends `Access-Control-Allow-Origin: *`.
 const SAMPLE_VECTOR_DATASETS: VectorSampleDataset[] = [
   {
     label: "Countries",
@@ -37,11 +36,15 @@ const SAMPLE_VECTOR_DATASETS: VectorSampleDataset[] = [
   },
   {
     label: "US cities",
-    url: "https://raw.githubusercontent.com/opengeos/leafmap/master/examples/data/us_cities.geojson",
+    url: "https://data.source.coop/giswqs/opengeos/us_cities.geojson",
   },
   {
     label: "World cities",
-    url: "https://raw.githubusercontent.com/opengeos/leafmap/master/examples/data/world_cities.geojson",
+    url: "https://data.source.coop/giswqs/opengeos/world_cities.geojson",
+  },
+  {
+    label: "Las Vegas buildings",
+    url: "https://data.source.coop/giswqs/opengeos/las-vegas-buildings.geojson",
   },
 ];
 


### PR DESCRIPTION
## Summary

Reworks the **Add Vector Layer** dialog so it no longer prefills the URL input with a live sample URL (which read as a required setting and masked that the field accepts custom cloud-native links). The input now shows a generic placeholder, and the demonstration datasets move into an opt-in **Load sample data** dropdown.

This is the first of the Add Data dialogs to adopt the pattern; the others will follow in later PRs.

### What changed
- **No prefilled URL.** The URL input starts empty with a generic `https://example.com/data.geojson` placeholder.
- **Load sample data dropdown.** A configurable, multi-entry dropdown below the URL input offers Countries (GeoParquet), US cities, and World cities (GeoJSON). Picking one fills the input and loads it. The list is easy to edit (or empty out to hide).
- **Resizable dialog.** The panel can be dragged larger from its bottom-left and bottom-right corners.
- **Stays open until closed.** Clicking the map no longer collapses the panel; only the header close button does. This replaces the previous private-member click-outside workaround with the upstream `closeOnOutsideClick` option.

### Upstream
Depends on `maplibre-gl-vector@0.4.1` (released to npm), which adds the `sampleData`, `sampleDataLabel`, `resizable`, and `closeOnOutsideClick` options and a fully themed (dark-mode-correct) sample dropdown. Upstream PR: opengeos/maplibre-gl-vector#20.

## Test plan
- `npm run build` and the frontend vector tests pass; `pre-commit run --files` (incl. the npm build hook) is clean.
- Verified in the running app (light and dark themes): the input is empty with a placeholder, the dropdown lists three samples, selecting US cities and Countries fills the input and loads the layer, the dialog resizes from both bottom corners, clicking the map keeps the panel open, and the close button dismisses it.

Fixes #661


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated `maplibre-gl-vector` dependency to version `0.4.1` (desktop and plugins).

* **New Features**
  * Vector Layer panel now uses a generic URL placeholder and offers a one-click list of curated sample datasets.

* **Bug Fixes**
  * Improved Vector Layer panel open/close behavior by adjusting how it responds to outside clicks while preserving explicit close actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->