### PR TITLE
feat(add-data): standardize sample loading across Add Data dialogs

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/AddNetcdfDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddNetcdfDialog.tsx
@@ -19,6 +19,7 @@ import {
   Select,
 } from "@geolibre/ui";
 import { Boxes } from "lucide-react";
+import { SampleDataSelect } from "./add-data/shared";
 
 // A real sample: NOAA NCEP/NCAR Reanalysis surface air temperature, stored as a
 // Cloud-Optimized NetCDF and served from Source Cooperative (CORS-enabled,
@@ -44,7 +45,7 @@ export function AddNetcdfDialog({
   appApi,
   onOpenChange,
 }: AddNetcdfDialogProps) {
-  const [url, setUrl] = useState(SAMPLE_URL);
+  const [url, setUrl] = useState("");
   const [variables, setVariables] = useState<KerchunkVariable[]>([]);
   const [variable, setVariable] = useState("");
   // The normalized reference from the last successful load, reused on submit so
@@ -69,7 +70,7 @@ export function AddNetcdfDialog({
 
   const reset = () => {
     opGen.current += 1;
-    setUrl(SAMPLE_URL);
+    setUrl("");
     setVariables([]);
     setVariable("");
     setLoadedRefs(null);
@@ -178,6 +179,18 @@ export function AddNetcdfDialog({
         </DialogHeader>
 
         <form className="space-y-4" onSubmit={handleSubmit}>
+          <SampleDataSelect
+            samples={[{ label: "Air temperature", value: SAMPLE_URL }]}
+            onSelect={(sampleUrl) => {
+              setUrl(sampleUrl);
+              // Invalidate any variables loaded from a previous URL.
+              setVariables([]);
+              setVariable("");
+              setLoadedRefs(null);
+              setStatus(null);
+              setError(null);
+            }}
+          />
           <div className="space-y-1.5">
             <Label htmlFor="netcdf-url">Kerchunk reference URL</Label>
             <div className="grid gap-2 sm:grid-cols-[1fr_auto]">
@@ -205,8 +218,8 @@ export function AddNetcdfDialog({
               </Button>
             </div>
             <p className="text-xs text-muted-foreground">
-              Pre-filled with a sample NOAA air-temperature dataset. Click Load
-              variables to try it, or paste your own kerchunk reference URL.
+              Choose a sample dataset above, or paste your own kerchunk
+              reference URL, then click Load variables.
             </p>
           </div>
 

--- a/apps/geolibre-desktop/src/components/layout/AddNetcdfDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddNetcdfDialog.tsx
@@ -85,6 +85,25 @@ export function AddNetcdfDialog({
     setAdding(false);
   };
 
+  // Invalidate everything tied to the previously loaded manifest when the URL
+  // changes (sample pick or manual edit), and bump opGen so an in-flight
+  // variable load for the old URL cannot write back into state. Bumping opGen
+  // makes that load's finally skip its own setLoadingVars(false), so the flags
+  // are cleared here too (otherwise Load variables stays disabled).
+  const invalidateLoadedManifest = () => {
+    opGen.current += 1;
+    setVariables([]);
+    setVariable("");
+    setLoadedRefs(null);
+    setDimIndex({});
+    setClimMin("");
+    setClimMax("");
+    setStatus(null);
+    setError(null);
+    setLoadingVars(false);
+    setAdding(false);
+  };
+
   const handleLoadVariables = async () => {
     const gen = opGen.current;
     setError(null);
@@ -184,15 +203,8 @@ export function AddNetcdfDialog({
           <SampleDataSelect
             samples={[{ label: t("addData.netcdf.sampleLabel"), value: SAMPLE_URL }]}
             onSelect={(sampleUrl) => {
-              // Cancel any in-flight variable load for the previous URL.
-              opGen.current += 1;
+              invalidateLoadedManifest();
               setUrl(sampleUrl);
-              // Invalidate any variables loaded from a previous URL.
-              setVariables([]);
-              setVariable("");
-              setLoadedRefs(null);
-              setStatus(null);
-              setError(null);
             }}
           />
           <div className="space-y-1.5">
@@ -203,15 +215,8 @@ export function AddNetcdfDialog({
                 placeholder="https://example.com/data.kerchunk.json"
                 value={url}
                 onChange={(event) => {
-                  // Cancel any in-flight variable load for the previous URL.
-                  opGen.current += 1;
+                  invalidateLoadedManifest();
                   setUrl(event.target.value);
-                  // Invalidate variables loaded from a different URL.
-                  setVariables([]);
-                  setVariable("");
-                  setLoadedRefs(null);
-                  setStatus(null);
-                  setError(null);
                 }}
               />
               <Button
@@ -223,6 +228,9 @@ export function AddNetcdfDialog({
                 {loadingVars ? "Loading..." : "Load variables"}
               </Button>
             </div>
+            {/* This dialog's prose is intentionally left in English for now:
+                it predates the Add Data i18n catalog and is out of scope for
+                this PR (only the new sample label is routed through t()). */}
             <p className="text-xs text-muted-foreground">
               Choose a sample dataset above, or paste your own kerchunk
               reference URL, then click Load variables.

--- a/apps/geolibre-desktop/src/components/layout/AddNetcdfDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddNetcdfDialog.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState, type FormEvent } from "react";
+import { useTranslation } from "react-i18next";
 import {
   addCloudNetcdfLayer,
   listKerchunkVariables,
@@ -45,6 +46,7 @@ export function AddNetcdfDialog({
   appApi,
   onOpenChange,
 }: AddNetcdfDialogProps) {
+  const { t } = useTranslation();
   const [url, setUrl] = useState("");
   const [variables, setVariables] = useState<KerchunkVariable[]>([]);
   const [variable, setVariable] = useState("");
@@ -180,7 +182,7 @@ export function AddNetcdfDialog({
 
         <form className="space-y-4" onSubmit={handleSubmit}>
           <SampleDataSelect
-            samples={[{ label: "Air temperature", value: SAMPLE_URL }]}
+            samples={[{ label: t("addData.netcdf.sampleLabel"), value: SAMPLE_URL }]}
             onSelect={(sampleUrl) => {
               setUrl(sampleUrl);
               // Invalidate any variables loaded from a previous URL.

--- a/apps/geolibre-desktop/src/components/layout/AddNetcdfDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddNetcdfDialog.tsx
@@ -184,6 +184,8 @@ export function AddNetcdfDialog({
           <SampleDataSelect
             samples={[{ label: t("addData.netcdf.sampleLabel"), value: SAMPLE_URL }]}
             onSelect={(sampleUrl) => {
+              // Cancel any in-flight variable load for the previous URL.
+              opGen.current += 1;
               setUrl(sampleUrl);
               // Invalidate any variables loaded from a previous URL.
               setVariables([]);
@@ -201,6 +203,8 @@ export function AddNetcdfDialog({
                 placeholder="https://example.com/data.kerchunk.json"
                 value={url}
                 onChange={(event) => {
+                  // Cancel any in-flight variable load for the previous URL.
+                  opGen.current += 1;
                   setUrl(event.target.value);
                   // Invalidate variables loaded from a different URL.
                   setVariables([]);

--- a/apps/geolibre-desktop/src/components/layout/add-data/shared.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/shared.tsx
@@ -103,8 +103,9 @@ export function SampleDataSelect<T>({
         id={selectId}
         value=""
         onChange={(event) => {
-          // Guard the placeholder's "" value: Number("") is 0, which would
-          // otherwise pick the first sample on a programmatic change event.
+          // Safety net: the disabled placeholder ("") should never reach here
+          // through real interaction, but ignore an empty value anyway so it
+          // can't coerce (Number("") === 0) to the first sample.
           const raw = event.target.value;
           if (!raw) return;
           const sample = samples[Number(raw)];
@@ -115,7 +116,7 @@ export function SampleDataSelect<T>({
           {t("addData.shared.loadSampleData")}
         </option>
         {samples.map((sample, index) => (
-          <option key={index} value={index}>
+          <option key={sample.label} value={String(index)}>
             {sample.label}
           </option>
         ))}

--- a/apps/geolibre-desktop/src/components/layout/add-data/shared.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/shared.tsx
@@ -103,7 +103,11 @@ export function SampleDataSelect<T>({
         id={selectId}
         value=""
         onChange={(event) => {
-          const sample = samples[Number(event.target.value)];
+          // Guard the placeholder's "" value: Number("") is 0, which would
+          // otherwise pick the first sample on a programmatic change event.
+          const raw = event.target.value;
+          if (!raw) return;
+          const sample = samples[Number(raw)];
           if (sample) onSelect(sample.value);
         }}
       >

--- a/apps/geolibre-desktop/src/components/layout/add-data/shared.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/shared.tsx
@@ -75,6 +75,51 @@ export function useAddDataSource(defaultLayerName: string) {
   };
 }
 
+/**
+ * A "Load sample data" dropdown for the Add Data sources. Each entry is a
+ * named preset that fills the source's fields, so a source can ship an empty
+ * input (placeholder only) instead of a prefilled sample URL. Renders nothing
+ * when no samples are supplied, and snaps back to the placeholder after a pick
+ * so it reads as an action menu rather than a sticky selection.
+ *
+ * @param samples - The named presets to offer.
+ * @param onSelect - Applies the chosen preset's value to the source's fields.
+ */
+export function SampleDataSelect<T>({
+  samples,
+  onSelect,
+}: {
+  samples: readonly { label: string; value: T }[];
+  onSelect: (value: T) => void;
+}) {
+  const { t } = useTranslation();
+  if (samples.length === 0) return null;
+  const placeholder = t("addData.shared.loadSampleData");
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor="add-data-sample">{t("addData.shared.sampleData")}</Label>
+      <Select
+        id="add-data-sample"
+        aria-label={placeholder}
+        value=""
+        onChange={(event) => {
+          const sample = samples[Number(event.target.value)];
+          if (sample) onSelect(sample.value);
+        }}
+      >
+        <option value="" disabled>
+          {placeholder}
+        </option>
+        {samples.map((sample, index) => (
+          <option key={sample.label} value={index}>
+            {sample.label}
+          </option>
+        ))}
+      </Select>
+    </div>
+  );
+}
+
 export function LayerNameField({
   value,
   onChange,

--- a/apps/geolibre-desktop/src/components/layout/add-data/shared.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/shared.tsx
@@ -111,7 +111,7 @@ export function SampleDataSelect<T>({
           {t("addData.shared.loadSampleData")}
         </option>
         {samples.map((sample, index) => (
-          <option key={sample.label} value={index}>
+          <option key={index} value={index}>
             {sample.label}
           </option>
         ))}

--- a/apps/geolibre-desktop/src/components/layout/add-data/shared.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/shared.tsx
@@ -10,6 +10,7 @@ import { Globe2, Map as MapIcon } from "lucide-react";
 import {
   type FormEvent,
   type ReactNode,
+  useId,
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
@@ -93,14 +94,13 @@ export function SampleDataSelect<T>({
   onSelect: (value: T) => void;
 }) {
   const { t } = useTranslation();
+  const selectId = useId();
   if (samples.length === 0) return null;
-  const placeholder = t("addData.shared.loadSampleData");
   return (
     <div className="space-y-1.5">
-      <Label htmlFor="add-data-sample">{t("addData.shared.sampleData")}</Label>
+      <Label htmlFor={selectId}>{t("addData.shared.sampleData")}</Label>
       <Select
-        id="add-data-sample"
-        aria-label={placeholder}
+        id={selectId}
         value=""
         onChange={(event) => {
           const sample = samples[Number(event.target.value)];
@@ -108,7 +108,7 @@ export function SampleDataSelect<T>({
         }}
       >
         <option value="" disabled>
-          {placeholder}
+          {t("addData.shared.loadSampleData")}
         </option>
         {samples.map((sample, index) => (
           <option key={sample.label} value={index}>

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/ArcGISSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/ArcGISSource.tsx
@@ -97,23 +97,21 @@ export function ArcGISSource() {
             {
               label: t("addData.arcgis.sampleFeatureLabel"),
               value: {
-                layerType: "feature" as ArcGISLayerType,
+                layerType: "feature",
+                sourceType: "url",
                 url: DEFAULT_ARCGIS_URLS.feature,
               },
             },
             {
               label: t("addData.arcgis.sampleVectorTileLabel"),
               value: {
-                layerType: "vector-tile" as ArcGISLayerType,
+                layerType: "vector-tile",
+                sourceType: "url",
                 url: DEFAULT_ARCGIS_URLS["vector-tile"],
               },
             },
           ]}
-          onSelect={(sample) => {
-            setArcgisLayerType(sample.layerType);
-            setArcgisSourceType("url");
-            setArcgisUrl(sample.url);
-          }}
+          onSelect={applyFields}
         />
         <ServiceLibrarySection
           kind="arcgis"

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/ArcGISSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/ArcGISSource.tsx
@@ -7,16 +7,13 @@ import { Input, Label, Select } from "@geolibre/ui";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { createAppAPI } from "../../../../hooks/usePlugins";
-import {
-  DEFAULT_ARCGIS_FEATURE_URL,
-  DEFAULT_ARCGIS_URLS,
-} from "../constants";
+import { DEFAULT_ARCGIS_URLS } from "../constants";
 import { ServiceLibrarySection } from "../ServiceLibrarySection";
 import {
   serviceFieldString,
   type ServiceFields,
 } from "../service-library";
-import { AddDataSourceForm, useAddDataSource } from "../shared";
+import { AddDataSourceForm, SampleDataSelect, useAddDataSource } from "../shared";
 
 export function ArcGISSource() {
   const { t } = useTranslation();
@@ -25,7 +22,7 @@ export function ArcGISSource() {
     useState<ArcGISLayerType>("feature");
   const [arcgisSourceType, setArcgisSourceType] =
     useState<ArcGISSourceType>("url");
-  const [arcgisUrl, setArcgisUrl] = useState(DEFAULT_ARCGIS_FEATURE_URL);
+  const [arcgisUrl, setArcgisUrl] = useState("");
   const [arcgisItemId, setArcgisItemId] = useState("");
   const [arcgisPortalUrl, setArcgisPortalUrl] = useState("");
   const [arcgisAccessToken, setArcgisAccessToken] = useState("");
@@ -51,7 +48,7 @@ export function ArcGISSource() {
         ? "portal-item"
         : "url",
     );
-    setArcgisUrl(serviceFieldString(fields, "url", DEFAULT_ARCGIS_FEATURE_URL));
+    setArcgisUrl(serviceFieldString(fields, "url"));
     setArcgisItemId(serviceFieldString(fields, "itemId"));
     setArcgisPortalUrl(serviceFieldString(fields, "portalUrl"));
     // Tokens are never saved, so clear any token typed for a previous entry to
@@ -62,7 +59,9 @@ export function ArcGISSource() {
   const handleArcgisLayerTypeChange = (nextLayerType: ArcGISLayerType) => {
     const currentUrl = arcgisUrl.trim();
     setArcgisLayerType(nextLayerType);
-    if (!currentUrl || Object.values(DEFAULT_ARCGIS_URLS).includes(currentUrl)) {
+    // Keep a loaded sample URL in sync with the layer type, but leave an
+    // empty input (or the user's own URL) untouched so nothing is prefilled.
+    if (currentUrl && Object.values(DEFAULT_ARCGIS_URLS).includes(currentUrl)) {
       setArcgisUrl(DEFAULT_ARCGIS_URLS[nextLayerType]);
     }
   };
@@ -93,6 +92,29 @@ export function ArcGISSource() {
       submitDisabled={source.isSubmitting}
     >
       <div className="space-y-3">
+        <SampleDataSelect
+          samples={[
+            {
+              label: t("addData.arcgis.sampleFeatureLabel"),
+              value: {
+                layerType: "feature" as ArcGISLayerType,
+                url: DEFAULT_ARCGIS_URLS.feature,
+              },
+            },
+            {
+              label: t("addData.arcgis.sampleVectorTileLabel"),
+              value: {
+                layerType: "vector-tile" as ArcGISLayerType,
+                url: DEFAULT_ARCGIS_URLS["vector-tile"],
+              },
+            },
+          ]}
+          onSelect={(sample) => {
+            setArcgisLayerType(sample.layerType);
+            setArcgisSourceType("url");
+            setArcgisUrl(sample.url);
+          }}
+        />
         <ServiceLibrarySection
           kind="arcgis"
           layerName={source.layerName}

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/DelimitedTextSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/DelimitedTextSource.tsx
@@ -262,6 +262,10 @@ export function DelimitedTextSource() {
             setDelimitedTextMode("url");
             setSelectedDelimitedText(null);
             resetDelimitedTextColumns();
+            // The sample is a comma-delimited CSV, so reset the delimiter too;
+            // otherwise a previously chosen delimiter would misparse it.
+            setDelimitedTextDelimiter("comma");
+            setDelimitedTextCustomDelimiter("");
             setDelimitedTextUrl(url);
           }}
         />

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/DelimitedTextSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/DelimitedTextSource.tsx
@@ -20,7 +20,7 @@ import {
   layerNameFromPath,
   resolveDelimitedTextDelimiter,
 } from "../helpers";
-import { AddDataSourceForm, useAddDataSource } from "../shared";
+import { AddDataSourceForm, SampleDataSelect, useAddDataSource } from "../shared";
 import type { DelimitedTextDelimiter, DelimitedTextMode } from "../types";
 
 export function DelimitedTextSource() {
@@ -31,9 +31,7 @@ export function DelimitedTextSource() {
   const source = useAddDataSource(defaultName);
   const [delimitedTextMode, setDelimitedTextMode] =
     useState<DelimitedTextMode>("url");
-  const [delimitedTextUrl, setDelimitedTextUrl] = useState(
-    DEFAULT_DELIMITED_TEXT_URL,
-  );
+  const [delimitedTextUrl, setDelimitedTextUrl] = useState("");
   const [delimitedTextDelimiter, setDelimitedTextDelimiter] =
     useState<DelimitedTextDelimiter>("comma");
   const [delimitedTextCustomDelimiter, setDelimitedTextCustomDelimiter] =
@@ -65,9 +63,6 @@ export function DelimitedTextSource() {
     setDelimitedTextMode(mode);
     setSelectedDelimitedText(null);
     resetDelimitedTextColumns();
-    if (mode === "url" && !delimitedTextUrl.trim()) {
-      setDelimitedTextUrl(DEFAULT_DELIMITED_TEXT_URL);
-    }
   };
 
   const readDelimitedTextSource = async (): Promise<{
@@ -259,6 +254,17 @@ export function DelimitedTextSource() {
       }
     >
       <div className="space-y-3">
+        <SampleDataSelect
+          samples={[
+            { label: t("addData.delimitedText.sampleLabel"), value: DEFAULT_DELIMITED_TEXT_URL },
+          ]}
+          onSelect={(url) => {
+            setDelimitedTextMode("url");
+            setSelectedDelimitedText(null);
+            resetDelimitedTextColumns();
+            setDelimitedTextUrl(url);
+          }}
+        />
         <div className="space-y-1.5">
           <Label htmlFor="delimited-text-mode">
             {t("addData.common.sourceType")}

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/GpxSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/GpxSource.tsx
@@ -14,7 +14,7 @@ import {
   layerNameFromPath,
   proxyGpxRequestUrl,
 } from "../helpers";
-import { AddDataSourceForm, useAddDataSource } from "../shared";
+import { AddDataSourceForm, SampleDataSelect, useAddDataSource } from "../shared";
 import type { GpxLayerKind, GpxMode } from "../types";
 
 export function GpxSource() {
@@ -24,7 +24,7 @@ export function GpxSource() {
   const [defaultName] = useState(() => t("addData.gpx.defaultName"));
   const source = useAddDataSource(defaultName);
   const [gpxMode, setGpxMode] = useState<GpxMode>("url");
-  const [gpxUrl, setGpxUrl] = useState(DEFAULT_GPX_URL);
+  const [gpxUrl, setGpxUrl] = useState("");
   const [selectedGpx, setSelectedGpx] = useState<{
     path: string;
     text: string;
@@ -44,9 +44,6 @@ export function GpxSource() {
   const handleGpxModeChange = (mode: GpxMode) => {
     setGpxMode(mode);
     setSelectedGpx(null);
-    if (mode === "url" && !gpxUrl.trim()) {
-      setGpxUrl(DEFAULT_GPX_URL);
-    }
   };
 
   const setGpxLayerKindSelected = (
@@ -210,6 +207,14 @@ export function GpxSource() {
       submitDisabled={source.isSubmitting || !hasSelectedGpxLayerKind}
     >
       <div className="space-y-3">
+        <SampleDataSelect
+          samples={[{ label: t("addData.gpx.sampleLabel"), value: DEFAULT_GPX_URL }]}
+          onSelect={(url) => {
+            setGpxMode("url");
+            setSelectedGpx(null);
+            setGpxUrl(url);
+          }}
+        />
         <div className="space-y-1.5">
           <Label htmlFor="gpx-mode">{t("addData.common.sourceType")}</Label>
           <Select

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/VideoSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/VideoSource.tsx
@@ -10,21 +10,17 @@ import {
   DEFAULT_VIDEO_WEBM_URL,
 } from "../constants";
 import { createBaseLayer } from "../helpers";
-import { AddDataSourceForm, useAddDataSource } from "../shared";
+import { AddDataSourceForm, SampleDataSelect, useAddDataSource } from "../shared";
 
 export function VideoSource() {
   const { t } = useTranslation();
   const source = useAddDataSource(t("addData.video.defaultName"));
-  const [videoMp4Url, setVideoMp4Url] = useState(DEFAULT_VIDEO_MP4_URL);
-  const [videoWebmUrl, setVideoWebmUrl] = useState(DEFAULT_VIDEO_WEBM_URL);
-  const [videoTopLeft, setVideoTopLeft] = useState(DEFAULT_VIDEO_TOP_LEFT);
-  const [videoTopRight, setVideoTopRight] = useState(DEFAULT_VIDEO_TOP_RIGHT);
-  const [videoBottomRight, setVideoBottomRight] = useState(
-    DEFAULT_VIDEO_BOTTOM_RIGHT,
-  );
-  const [videoBottomLeft, setVideoBottomLeft] = useState(
-    DEFAULT_VIDEO_BOTTOM_LEFT,
-  );
+  const [videoMp4Url, setVideoMp4Url] = useState("");
+  const [videoWebmUrl, setVideoWebmUrl] = useState("");
+  const [videoTopLeft, setVideoTopLeft] = useState("");
+  const [videoTopRight, setVideoTopRight] = useState("");
+  const [videoBottomRight, setVideoBottomRight] = useState("");
+  const [videoBottomLeft, setVideoBottomLeft] = useState("");
 
   // Local, translated equivalent of helpers' parseVideoCorner: parses a
   // "longitude, latitude" corner into a [lng, lat] pair and throws localized
@@ -108,6 +104,29 @@ export function VideoSource() {
       submitDisabled={source.isSubmitting}
     >
       <div className="space-y-3">
+        <SampleDataSelect
+          samples={[
+            {
+              label: t("addData.video.sampleLabel"),
+              value: {
+                mp4: DEFAULT_VIDEO_MP4_URL,
+                webm: DEFAULT_VIDEO_WEBM_URL,
+                topLeft: DEFAULT_VIDEO_TOP_LEFT,
+                topRight: DEFAULT_VIDEO_TOP_RIGHT,
+                bottomRight: DEFAULT_VIDEO_BOTTOM_RIGHT,
+                bottomLeft: DEFAULT_VIDEO_BOTTOM_LEFT,
+              },
+            },
+          ]}
+          onSelect={(sample) => {
+            setVideoMp4Url(sample.mp4);
+            setVideoWebmUrl(sample.webm);
+            setVideoTopLeft(sample.topLeft);
+            setVideoTopRight(sample.topRight);
+            setVideoBottomRight(sample.bottomRight);
+            setVideoBottomLeft(sample.bottomLeft);
+          }}
+        />
         <div className="space-y-1.5">
           <Label htmlFor="video-mp4-url">{t("addData.video.primaryUrl")}</Label>
           <Input

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
@@ -115,10 +115,7 @@ export function WfsSource() {
               value: { endpoint: DEFAULT_WFS_ENDPOINT, typeName: DEFAULT_WFS_TYPE_NAME },
             },
           ]}
-          onSelect={(sample) => {
-            setWfsEndpoint(sample.endpoint);
-            setWfsTypeName(sample.typeName);
-          }}
+          onSelect={applyFields}
         />
         <ServiceLibrarySection
           kind="wfs"

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
@@ -12,13 +12,13 @@ import {
   serviceFieldString,
   type ServiceFields,
 } from "../service-library";
-import { AddDataSourceForm, useAddDataSource } from "../shared";
+import { AddDataSourceForm, SampleDataSelect, useAddDataSource } from "../shared";
 
 export function WfsSource() {
   const { t } = useTranslation();
   const source = useAddDataSource(t("addData.wfs.defaultName"));
-  const [wfsEndpoint, setWfsEndpoint] = useState(DEFAULT_WFS_ENDPOINT);
-  const [wfsTypeName, setWfsTypeName] = useState(DEFAULT_WFS_TYPE_NAME);
+  const [wfsEndpoint, setWfsEndpoint] = useState("");
+  const [wfsTypeName, setWfsTypeName] = useState("");
   const [wfsVersion, setWfsVersion] = useState("2.0.0");
   const [wfsOutputFormat, setWfsOutputFormat] = useState("application/json");
   const [wfsSrsName, setWfsSrsName] = useState("EPSG:4326");
@@ -34,8 +34,8 @@ export function WfsSource() {
   });
 
   const applyFields = (fields: ServiceFields) => {
-    setWfsEndpoint(serviceFieldString(fields, "endpoint", DEFAULT_WFS_ENDPOINT));
-    setWfsTypeName(serviceFieldString(fields, "typeName", DEFAULT_WFS_TYPE_NAME));
+    setWfsEndpoint(serviceFieldString(fields, "endpoint"));
+    setWfsTypeName(serviceFieldString(fields, "typeName"));
     setWfsVersion(serviceFieldString(fields, "version", "2.0.0"));
     setWfsOutputFormat(
       serviceFieldString(fields, "outputFormat", "application/json"),
@@ -108,6 +108,18 @@ export function WfsSource() {
       useServiceIcon
     >
       <div className="space-y-3">
+        <SampleDataSelect
+          samples={[
+            {
+              label: t("addData.wfs.sampleLabel"),
+              value: { endpoint: DEFAULT_WFS_ENDPOINT, typeName: DEFAULT_WFS_TYPE_NAME },
+            },
+          ]}
+          onSelect={(sample) => {
+            setWfsEndpoint(sample.endpoint);
+            setWfsTypeName(sample.typeName);
+          }}
+        />
         <ServiceLibrarySection
           kind="wfs"
           layerName={source.layerName}

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
@@ -92,10 +92,7 @@ export function WmsSource() {
               value: { endpoint: DEFAULT_WMS_ENDPOINT, layers: DEFAULT_WMS_LAYERS },
             },
           ]}
-          onSelect={(sample) => {
-            setWmsEndpoint(sample.endpoint);
-            setWmsLayers(sample.layers);
-          }}
+          onSelect={applyFields}
         />
         <ServiceLibrarySection
           kind="wms"

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
@@ -9,13 +9,13 @@ import {
   serviceFieldString,
   type ServiceFields,
 } from "../service-library";
-import { AddDataSourceForm, useAddDataSource } from "../shared";
+import { AddDataSourceForm, SampleDataSelect, useAddDataSource } from "../shared";
 
 export function WmsSource() {
   const { t } = useTranslation();
   const source = useAddDataSource(t("addData.wms.defaultName"));
-  const [wmsEndpoint, setWmsEndpoint] = useState(DEFAULT_WMS_ENDPOINT);
-  const [wmsLayers, setWmsLayers] = useState(DEFAULT_WMS_LAYERS);
+  const [wmsEndpoint, setWmsEndpoint] = useState("");
+  const [wmsLayers, setWmsLayers] = useState("");
   const [wmsStyles, setWmsStyles] = useState("");
   const [wmsFormat, setWmsFormat] = useState("image/png");
   const [wmsTransparent, setWmsTransparent] = useState(true);
@@ -31,8 +31,8 @@ export function WmsSource() {
   });
 
   const applyFields = (fields: ServiceFields) => {
-    setWmsEndpoint(serviceFieldString(fields, "endpoint", DEFAULT_WMS_ENDPOINT));
-    setWmsLayers(serviceFieldString(fields, "layers", DEFAULT_WMS_LAYERS));
+    setWmsEndpoint(serviceFieldString(fields, "endpoint"));
+    setWmsLayers(serviceFieldString(fields, "layers"));
     setWmsStyles(serviceFieldString(fields, "styles"));
     setWmsFormat(serviceFieldString(fields, "format", "image/png"));
     setWmsTransparent(serviceFieldBoolean(fields, "transparent", true));
@@ -85,6 +85,18 @@ export function WmsSource() {
       useServiceIcon
     >
       <div className="space-y-3">
+        <SampleDataSelect
+          samples={[
+            {
+              label: t("addData.wms.sampleLabel"),
+              value: { endpoint: DEFAULT_WMS_ENDPOINT, layers: DEFAULT_WMS_LAYERS },
+            },
+          ]}
+          onSelect={(sample) => {
+            setWmsEndpoint(sample.endpoint);
+            setWmsLayers(sample.layers);
+          }}
+        />
         <ServiceLibrarySection
           kind="wms"
           layerName={source.layerName}

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WmtsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WmtsSource.tsx
@@ -8,12 +8,12 @@ import {
   serviceFieldString,
   type ServiceFields,
 } from "../service-library";
-import { AddDataSourceForm, useAddDataSource } from "../shared";
+import { AddDataSourceForm, SampleDataSelect, useAddDataSource } from "../shared";
 
 export function WmtsSource() {
   const { t } = useTranslation();
   const source = useAddDataSource(t("addData.wmts.defaultName"));
-  const [wmtsUrl, setWmtsUrl] = useState(DEFAULT_WMTS_URL);
+  const [wmtsUrl, setWmtsUrl] = useState("");
   const [wmtsTileSize, setWmtsTileSize] = useState("256");
 
   const getFields = (): ServiceFields => ({
@@ -22,7 +22,7 @@ export function WmtsSource() {
   });
 
   const applyFields = (fields: ServiceFields) => {
-    setWmtsUrl(serviceFieldString(fields, "url", DEFAULT_WMTS_URL));
+    setWmtsUrl(serviceFieldString(fields, "url"));
     setWmtsTileSize(serviceFieldString(fields, "tileSize", "256"));
   };
 
@@ -58,6 +58,10 @@ export function WmtsSource() {
       useServiceIcon
     >
       <div className="space-y-3">
+        <SampleDataSelect
+          samples={[{ label: t("addData.wmts.sampleLabel"), value: DEFAULT_WMTS_URL }]}
+          onSelect={setWmtsUrl}
+        />
         <ServiceLibrarySection
           kind="wmts"
           layerName={source.layerName}

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WmtsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WmtsSource.tsx
@@ -59,8 +59,10 @@ export function WmtsSource() {
     >
       <div className="space-y-3">
         <SampleDataSelect
-          samples={[{ label: t("addData.wmts.sampleLabel"), value: DEFAULT_WMTS_URL }]}
-          onSelect={setWmtsUrl}
+          samples={[
+            { label: t("addData.wmts.sampleLabel"), value: { url: DEFAULT_WMTS_URL } },
+          ]}
+          onSelect={applyFields}
         />
         <ServiceLibrarySection
           kind="wmts"

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/XyzSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/XyzSource.tsx
@@ -30,7 +30,7 @@ export function XyzSource() {
   });
 
   const applyFields = (fields: ServiceFields) => {
-    setXyzUrl(serviceFieldString(fields, "url", ""));
+    setXyzUrl(serviceFieldString(fields, "url"));
     setXyzTileSize(serviceFieldString(fields, "tileSize", "256"));
     setXyzShortUrl(serviceFieldBoolean(fields, "shortUrl", false));
   };

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/XyzSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/XyzSource.tsx
@@ -14,12 +14,12 @@ import {
   serviceFieldString,
   type ServiceFields,
 } from "../service-library";
-import { AddDataSourceForm, useAddDataSource } from "../shared";
+import { AddDataSourceForm, SampleDataSelect, useAddDataSource } from "../shared";
 
 export function XyzSource() {
   const { t } = useTranslation();
   const source = useAddDataSource(t("addData.xyz.defaultName"));
-  const [xyzUrl, setXyzUrl] = useState(DEFAULT_XYZ_URL);
+  const [xyzUrl, setXyzUrl] = useState("");
   const [xyzTileSize, setXyzTileSize] = useState("256");
   const [xyzShortUrl, setXyzShortUrl] = useState(false);
 
@@ -30,7 +30,7 @@ export function XyzSource() {
   });
 
   const applyFields = (fields: ServiceFields) => {
-    setXyzUrl(serviceFieldString(fields, "url", DEFAULT_XYZ_URL));
+    setXyzUrl(serviceFieldString(fields, "url", ""));
     setXyzTileSize(serviceFieldString(fields, "tileSize", "256"));
     setXyzShortUrl(serviceFieldBoolean(fields, "shortUrl", false));
   };
@@ -72,6 +72,10 @@ export function XyzSource() {
       submitDisabled={source.isSubmitting}
     >
       <div className="space-y-3">
+        <SampleDataSelect
+          samples={[{ label: t("addData.xyz.sampleLabel"), value: DEFAULT_XYZ_URL }]}
+          onSelect={setXyzUrl}
+        />
         <ServiceLibrarySection
           kind="xyz"
           layerName={source.layerName}

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/XyzSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/XyzSource.tsx
@@ -73,8 +73,10 @@ export function XyzSource() {
     >
       <div className="space-y-3">
         <SampleDataSelect
-          samples={[{ label: t("addData.xyz.sampleLabel"), value: DEFAULT_XYZ_URL }]}
-          onSelect={setXyzUrl}
+          samples={[
+            { label: t("addData.xyz.sampleLabel"), value: { url: DEFAULT_XYZ_URL } },
+          ]}
+          onSelect={applyFields}
         />
         <ServiceLibrarySection
           kind="xyz"

--- a/apps/geolibre-desktop/src/components/layout/toolbar/OsmPbfDialogs.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/OsmPbfDialogs.tsx
@@ -11,6 +11,7 @@ import {
 import type { FormEvent } from "react";
 import { useTranslation } from "react-i18next";
 import type { useOsmPbfLoader } from "../../../hooks/useOsmPbfLoader";
+import { SampleDataSelect } from "../add-data/shared";
 import { DEFAULT_OSM_PBF_URL } from "./constants";
 
 interface OsmPbfDialogsProps {
@@ -63,12 +64,21 @@ export function OsmPbfDialogs({ osmPbf }: OsmPbfDialogsProps) {
               void osmPbf.handleLoadUrl();
             }}
           >
+            <SampleDataSelect
+              samples={[
+                {
+                  label: t("toolbar.item.osmPbfSampleLabel"),
+                  value: DEFAULT_OSM_PBF_URL,
+                },
+              ]}
+              onSelect={(sampleUrl) => osmPbf.setUrl(sampleUrl)}
+            />
             <div className="space-y-1.5">
               <Label htmlFor="osm-pbf-url">{t("toolbar.item.urlLabel")}</Label>
               <Input
                 id="osm-pbf-url"
                 type="url"
-                placeholder={DEFAULT_OSM_PBF_URL}
+                placeholder={t("toolbar.item.osmPbfUrlPlaceholder")}
                 value={osmPbf.url}
                 onChange={(e) => osmPbf.setUrl(e.target.value)}
               />

--- a/apps/geolibre-desktop/src/hooks/useOsmPbfLoader.ts
+++ b/apps/geolibre-desktop/src/hooks/useOsmPbfLoader.ts
@@ -9,10 +9,7 @@ import {
   type OsmPbfProgress,
 } from "../lib/osm-pbf-loader";
 import { isHttpUrl, openLocalDataFileWithFallback } from "../lib/tauri-io";
-import {
-  type AppApi,
-  DEFAULT_OSM_PBF_URL,
-} from "../components/layout/toolbar/constants";
+import { type AppApi } from "../components/layout/toolbar/constants";
 
 /** A pending large-file confirmation before parsing an OSM PBF extract. */
 export interface OsmPbfConfirm {
@@ -38,7 +35,7 @@ export function useOsmPbfLoader(
   const [loading, setLoading] = useState(false);
   const [progress, setProgress] = useState<OsmPbfProgress | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
-  const [url, setUrl] = useState(DEFAULT_OSM_PBF_URL);
+  const [url, setUrl] = useState("");
   const [confirm, setConfirm] = useState<OsmPbfConfirm | null>(null);
   const abortRef = useRef<AbortController | null>(null);
 

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -139,7 +139,9 @@
       "showBasemapLayers": "Show basemap layers (advanced)",
       "addLayer": "Add layer",
       "adding": "Adding…",
-      "addError": "Could not add layer."
+      "addError": "Could not add layer.",
+      "sampleData": "Sample data",
+      "loadSampleData": "Load sample data…"
     },
     "common": {
       "serviceUrl": "Service URL",
@@ -183,6 +185,7 @@
     },
     "xyz": {
       "defaultName": "XYZ Layer",
+      "sampleLabel": "USGS imagery",
       "errorUrl": "Enter an XYZ tile URL template.",
       "urlPlaceholder": "https://example.com/{z}/{x}/{y}.png",
       "shortUrlPlaceholder": "https://go.example.com/layer",
@@ -190,6 +193,7 @@
     },
     "wms": {
       "defaultName": "WMS Layer",
+      "sampleLabel": "USGS NAIP imagery",
       "errorUrl": "Enter a WMS service URL.",
       "errorLayers": "Enter one or more WMS layer names.",
       "urlPlaceholder": "https://example.com/geoserver/wms",
@@ -199,6 +203,7 @@
     },
     "wfs": {
       "defaultName": "WFS Layer",
+      "sampleLabel": "US states (GeoServer)",
       "errorUrl": "Enter a WFS service URL.",
       "errorTypeName": "Enter a WFS feature type name.",
       "errorOutputFormat": "Enter a WFS output format.",
@@ -212,11 +217,14 @@
     },
     "wmts": {
       "defaultName": "WMTS Layer",
+      "sampleLabel": "World imagery (Wayback)",
       "errorUrl": "Enter a WMTS tile URL template.",
       "urlPlaceholder": "https://example.com/wmts/{z}/{y}/{x}.png"
     },
     "arcgis": {
       "defaultName": "ArcGIS Layer",
+      "sampleFeatureLabel": "US major cities (feature)",
+      "sampleVectorTileLabel": "Santa Monica parcels (vector tiles)",
       "featureLayer": "Feature layer",
       "vectorTileLayer": "Vector tile layer",
       "portalItemId": "Portal item ID",
@@ -228,6 +236,7 @@
     },
     "gpx": {
       "defaultName": "GPX Layer",
+      "sampleLabel": "Fells Loop trail",
       "errorFileMissing": "GPX file data is missing.",
       "readError": "Could not read GPX file.",
       "errorChooseFile": "Choose a GPX file.",
@@ -244,6 +253,7 @@
     },
     "delimitedText": {
       "defaultName": "Delimited Text Layer",
+      "sampleLabel": "US cities",
       "errorChooseFile": "Choose a delimited text file.",
       "errorUrl": "Enter a delimited text URL.",
       "errorFileMissing": "Delimited text file data is missing.",
@@ -306,6 +316,7 @@
     },
     "video": {
       "defaultName": "Video Layer",
+      "sampleLabel": "Drone over San Francisco",
       "errorUrl": "Enter a video URL.",
       "errorHttps": "Video URLs must start with https://.",
       "cornerTopLeft": "top-left",
@@ -1236,6 +1247,8 @@
       "addOsmPbfLayerTitle": "Add OSM PBF Layer",
       "addOsmPbfLayerDesc": "Load an OpenStreetMap .osm.pbf file. It is parsed in your browser and split into separate point, line, and polygon layers.",
       "urlLabel": "URL",
+      "osmPbfUrlPlaceholder": "https://example.com/region.osm.pbf",
+      "osmPbfSampleLabel": "Las Vegas",
       "osmPbfUrlHint": "Remote URLs load in the desktop app; in the browser the server must allow cross-origin requests (CORS).",
       "chooseLocalFile": "Choose local file…",
       "loadFromUrl": "Load from URL",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -337,6 +337,9 @@
       "bottomLeft": "Bottom-left (lng, lat)",
       "cornersNote": "The four corners georeference the video on the map. The video must be served over HTTPS and the host must allow cross-origin requests (CORS) for the frames to render."
     },
+    "netcdf": {
+      "sampleLabel": "Air temperature"
+    },
     "deckViz": {
       "defaultName": "Deck.gl Layer",
       "errorChooseFile": "Choose a CSV, JSON, or GeoJSON file.",


### PR DESCRIPTION
## Summary

Follow-up to #661 (Add Vector Layer): applies the same "no prefilled URL, opt-in **Load sample data** dropdown" pattern to the remaining GeoLibre-local Add Data dialogs. Each dialog now starts with an empty input (placeholder only); a dropdown fills the fields when the user picks a sample and snaps back to its placeholder, so nothing ships a hardcoded URL in the input box.

### What changed
- New shared **`SampleDataSelect`** dropdown in `add-data/shared.tsx` (each entry is a named preset that fills the source's fields).
- Converted the `AddDataDialog` sources: **XYZ, WMS, WFS, WMTS, ArcGIS, GPX, Delimited Text, Video** — empty inputs + the sample dropdown. ArcGIS offers two samples (feature / vector tiles) and sets the layer type accordingly; Video's sample fills all six fields.
- Converted the two standalone dialogs that bypass the shared scaffolding: **NetCDF** and **OSM PBF** (empty input, generic placeholder, sample dropdown).
- New i18n keys (`addData.shared.sampleData`, `addData.shared.loadSampleData`, per-source sample labels); `en.json` stays the source of truth.

### Sample data sources
The data-file dialogs load from `source.coop/giswqs/opengeos` (GPX `fells_loop.gpx`, Delimited Text `us_cities.csv`, NetCDF `air-temperature.kerchunk.json`, OSM PBF `LasVegas.osm.pbf`). The service dialogs (XYZ/WMS/WFS/WMTS/ArcGIS/Video) keep real protocol endpoints as samples, since source.coop does not serve tile/WMS/WFS/video endpoints.

### Scope
GeoLibre-local dialogs only. The upstream `maplibre-gl-*` panels (Raster #662, LiDAR, PMTiles, FlatGeobuf, Zarr, Splatting, DuckDB, 3D Tiles) prefill via a constructor option and need a `sampleData` option + npm release per package, like Vector did — deferred to follow-ups.

## Test plan
- `pre-commit run --files` (incl. the npm build hook) and `tsc -b` are clean.
- Verified in the running app: XYZ, Video, ArcGIS, NetCDF, and OSM PBF all start empty, the dropdown fills the fields on selection (ArcGIS also switches layer type; Video fills all six corners), and the dropdown snaps back to its placeholder.

Closes #663
Closes #664
Closes #665


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a **“Load Sample Data”** dropdown across data source dialogs (XYZ, WMS, WMTS, WFS, ArcGIS, GPX, Delimited Text, Video, Netcdf, OSM PBF).
  * Selecting a sample now auto-populates the relevant URL and related fields for each layer type.
* **Bug Fixes**
  * Improved behavior when switching between input modes so sample data selection and manual inputs don’t unexpectedly carry over.
  * URL field help text was updated to reflect the new sample-based workflow (no longer assumes a prefilled dataset).
* **Behavior Changes**
  * URL inputs now start empty instead of prefilled with a default dataset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->