### PR TITLE
fix(desktop): downgrade benign Tauri startup fetch failures in diagnostics

### DIFF
--- a/apps/geolibre-desktop/src/lib/diagnostics.ts
+++ b/apps/geolibre-desktop/src/lib/diagnostics.ts
@@ -423,10 +423,23 @@ export function installDiagnosticsCapture(): () => void {
       const isAbort =
         (error instanceof DOMException || error instanceof Error) &&
         error.name === "AbortError";
+      // A "Failed to fetch"/"Load failed" thrown during the desktop startup
+      // window is the Tauri custom-protocol IPC warming up: the call is retried
+      // over postMessage and the app recovers. Record it as a benign warning
+      // rather than a critical network error so it does not surface as an
+      // alarming failure to a user inspecting the panel at launch (issue #657).
+      // It mirrors the unhandled-rejection downgrade below; genuine failures
+      // outside the window are still flagged as errors.
+      const benignStartup = !isAbort && !optional && isBenignStartupFetch(error);
       appendDiagnostic({
         category: "network",
-        level: isAbort || optional ? "info" : "error",
-        message: isAbort ? `${method} aborted` : `${method} request failed`,
+        level:
+          isAbort || optional ? "info" : benignStartup ? "warning" : "error",
+        message: isAbort
+          ? `${method} aborted`
+          : benignStartup
+            ? `${method} request failed (benign Tauri custom-protocol warm-up)`
+            : `${method} request failed`,
         detail: isAbort ? undefined : formatUnknown(error),
         durationMs: Math.round(performance.now() - startedAt),
         method,

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -357,4 +357,48 @@ describe("diagnostics startup transient suppression", () => {
       setCaptureNetworkInfo(false);
     }
   });
+
+  it("downgrades a benign startup fetch failure under Tauri to a warning", async () => {
+    win.__TAURI_INTERNALS__ = {};
+    win.fetch = (() =>
+      Promise.reject(new TypeError("Load failed"))) as unknown as typeof fetch;
+    install();
+    await (win.fetch as typeof fetch)("http://ipc.localhost/main").catch(
+      () => {},
+    );
+    const [record] = getDiagnosticsSnapshot().records;
+    assert.equal(record.category, "network");
+    // The Tauri custom-protocol warm-up at launch retries over postMessage, so
+    // it is a benign transient rather than a critical error (issue #657).
+    assert.equal(record.level, "warning");
+    assert.equal(getDiagnosticsSnapshot().errorCount, 0);
+  });
+
+  it("keeps a startup fetch failure outside the Tauri runtime as an error", async () => {
+    win.fetch = (() =>
+      Promise.reject(new TypeError("Failed to fetch"))) as unknown as typeof fetch;
+    install();
+    await (win.fetch as typeof fetch)("https://example.com/data").catch(
+      () => {},
+    );
+    const [record] = getDiagnosticsSnapshot().records;
+    assert.equal(record.category, "network");
+    assert.equal(record.level, "error");
+    assert.equal(getDiagnosticsSnapshot().errorCount, 1);
+  });
+
+  it("flags a fetch failure after the startup window as an error under Tauri", async () => {
+    win.__TAURI_INTERNALS__ = {};
+    win.fetch = (() =>
+      Promise.reject(new TypeError("Load failed"))) as unknown as typeof fetch;
+    install();
+    // Jump past the grace window so the failure is no longer a startup transient.
+    Date.now = () => realDateNow() + 60_000;
+    await (win.fetch as typeof fetch)("http://ipc.localhost/main").catch(
+      () => {},
+    );
+    const [record] = getDiagnosticsSnapshot().records;
+    assert.equal(record.level, "error");
+    assert.equal(getDiagnosticsSnapshot().errorCount, 1);
+  });
 });

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -375,6 +375,8 @@ describe("diagnostics startup transient suppression", () => {
     // it is a benign transient rather than a critical error (issue #657).
     assert.equal(record.level, "warning");
     assert.equal(getDiagnosticsSnapshot().errorCount, 0);
+    // The panel badge reads warningCount, so assert it tracks the downgrade.
+    assert.equal(getDiagnosticsSnapshot().warningCount, 1);
   });
 
   it("keeps a startup fetch failure outside the Tauri runtime as an error", async () => {

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -363,6 +363,9 @@ describe("diagnostics startup transient suppression", () => {
     win.fetch = (() =>
       Promise.reject(new TypeError("Load failed"))) as unknown as typeof fetch;
     install();
+    // The URL is illustrative of the real warm-up failure (a call to the Tauri
+    // IPC endpoint); the benign-startup downgrade keys off the error message,
+    // not the URL, so any URL would produce the same result here.
     await (win.fetch as typeof fetch)("http://ipc.localhost/main").catch(
       () => {},
     );


### PR DESCRIPTION
## Summary

Fixes #657.

On macOS WKWebView (and some WebView2 builds) the first POST requests over Tauri's custom IPC protocol can momentarily fail with `Load failed` / `Failed to fetch` while the scheme is still registering. Tauri retries every call over its `postMessage` interface and the app recovers, so these are benign startup transients (already documented in `diagnostics.ts`, see #332).

The diagnostics panel already:
- downgraded the matching **unhandled rejection** to a warning, and
- silenced Tauri's IPC-fallback **console warning**.

But caught fetch failures inside the patched `fetch` were still recorded at **error** level, so on launch they surfaced as the "critical network errors" the issue reports.

## Change

Apply the same startup-window downgrade in the patched-fetch `catch`: a benign warm-up failure within the grace window (desktop runtime only) is recorded as a **warning** with a self-explanatory message instead of an error. Genuine failures outside the grace window, abort, and optional-resource handling are untouched.

## Testing

- Added three unit tests covering: benign startup failure under Tauri downgraded to warning, the same failure outside the Tauri runtime still an error, and a failure after the grace window still an error.
- `npm run test:frontend` (1313 passing) and `npm run build` both green.

Note: the underlying transient only occurs on the macOS/Windows desktop webview, so the fix is covered by unit tests against the diagnostics capture logic rather than a live repro on Linux.