### PR TITLE
feat(drop): explain global file drop and name the added layer (#666)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -766,21 +766,19 @@ export function DesktopShell({
         );
         return;
       }
-      const parts: string[] = [];
-      if (importedLayers.length) {
-        parts.push(
-          t("toolbar.fileDrop.vectorLayers", { count: importedLayers.length }),
-        );
-      }
-      if (rasterCount) {
-        parts.push(
-          t("toolbar.fileDrop.rasterLayers", { count: rasterCount }),
-        );
-      }
+      // Full-sentence keys (rather than a JS-assembled summary) keep word
+      // order and pluralization inside the translation catalog.
       setDropMessage(
-        t("toolbar.fileDrop.added", {
-          summary: parts.join(` ${t("toolbar.fileDrop.and")} `),
-        }),
+        importedLayers.length && rasterCount
+          ? t("toolbar.fileDrop.addedBoth", {
+              vectorCount: importedLayers.length,
+              rasterCount,
+            })
+          : importedLayers.length
+            ? t("toolbar.fileDrop.addedVectorLayers", {
+                count: importedLayers.length,
+              })
+            : t("toolbar.fileDrop.addedRasterLayers", { count: rasterCount }),
       );
     },
     [addImportedVectorLayers, t],

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -759,20 +759,27 @@ export function DesktopShell({
       // stays open (opengeos/GeoLibre#666).
       if (importedLayers.length === 1 && !rasterCount) {
         const only = importedLayers[0];
+        // `||` (not `??`) so an empty-string name also falls back to the path.
         setDropMessage(
           t("toolbar.fileDrop.addedLayer", {
-            name: only.name ?? layerNameFromPath(only.path),
+            name: only.name || layerNameFromPath(only.path),
           }),
         );
         return;
       }
       // Full-sentence keys (rather than a JS-assembled summary) keep word
-      // order and pluralization inside the translation catalog.
+      // order and the connector inside the translation catalog. The mixed
+      // case composes two independently pluralized noun phrases into its
+      // sentence, since one i18next key can pluralize only a single count.
       setDropMessage(
         importedLayers.length && rasterCount
           ? t("toolbar.fileDrop.addedBoth", {
-              vectorCount: importedLayers.length,
-              rasterCount,
+              vector: t("toolbar.fileDrop.bothVectorLayers", {
+                count: importedLayers.length,
+              }),
+              raster: t("toolbar.fileDrop.bothRasterLayers", {
+                count: rasterCount,
+              }),
             })
           : importedLayers.length
             ? t("toolbar.fileDrop.addedVectorLayers", {

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -753,20 +753,37 @@ export function DesktopShell({
         throw new Error("Drop a supported vector or raster file.");
       }
       if (importedLayers.length) addImportedVectorLayers(importedLayers);
+      // Name the layer when a single vector file was dropped (the common case)
+      // so the confirmation echoes what the user just added, instead of a bare
+      // count that can read like "nothing happened" while the source panel
+      // stays open (opengeos/GeoLibre#666).
+      if (importedLayers.length === 1 && !rasterCount) {
+        const only = importedLayers[0];
+        setDropMessage(
+          t("toolbar.fileDrop.addedLayer", {
+            name: only.name ?? layerNameFromPath(only.path),
+          }),
+        );
+        return;
+      }
       const parts: string[] = [];
       if (importedLayers.length) {
         parts.push(
-          `${importedLayers.length} vector layer${
-            importedLayers.length === 1 ? "" : "s"
-          }`,
+          t("toolbar.fileDrop.vectorLayers", { count: importedLayers.length }),
         );
       }
       if (rasterCount) {
-        parts.push(`${rasterCount} raster layer${rasterCount === 1 ? "" : "s"}`);
+        parts.push(
+          t("toolbar.fileDrop.rasterLayers", { count: rasterCount }),
+        );
       }
-      setDropMessage(`Added ${parts.join(" and ")}.`);
+      setDropMessage(
+        t("toolbar.fileDrop.added", {
+          summary: parts.join(` ${t("toolbar.fileDrop.and")} `),
+        }),
+      );
     },
-    [addImportedVectorLayers],
+    [addImportedVectorLayers, t],
   );
 
   useEffect(() => {
@@ -1437,8 +1454,13 @@ export function DesktopShell({
       />
       {isDraggingFiles ? (
         <div className="pointer-events-none absolute inset-0 z-50 flex items-center justify-center bg-background/70 backdrop-blur-sm">
-          <div className="rounded-md border bg-background px-4 py-3 text-sm font-medium shadow-lg">
-            Drop vector or raster files to add layers
+          <div className="max-w-sm rounded-md border bg-background px-4 py-3 text-center shadow-lg">
+            <p className="text-sm font-medium">
+              {t("toolbar.fileDrop.overlayTitle")}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {t("toolbar.fileDrop.overlaySubtext")}
+            </p>
           </div>
         </div>
       ) : null}

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -720,8 +720,10 @@ export function DesktopShell({
     (importedLayers: ImportedVectorLayer[]) => {
       let lastLayerId: string | null = null;
       for (const layer of importedLayers) {
+        // `||` (not `??`) so an empty-string name falls back to the path, and
+        // matches the name shown in the drop confirmation toast.
         lastLayerId = addGeoJsonLayer(
-          layer.name ?? layerNameFromPath(layer.path),
+          layer.name || layerNameFromPath(layer.path),
           layer.data,
           layer.path,
         );

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1253,7 +1253,11 @@
       "addedVectorLayers_other": "Added {{count}} vector layers to the Layers panel.",
       "addedRasterLayers_one": "Added {{count}} raster layer to the Layers panel.",
       "addedRasterLayers_other": "Added {{count}} raster layers to the Layers panel.",
-      "addedBoth": "Added {{vectorCount}} vector and {{rasterCount}} raster layers to the Layers panel."
+      "addedBoth": "Added {{vector}} and {{raster}} to the Layers panel.",
+      "bothVectorLayers_one": "{{count}} vector layer",
+      "bothVectorLayers_other": "{{count}} vector layers",
+      "bothRasterLayers_one": "{{count}} raster layer",
+      "bothRasterLayers_other": "{{count}} raster layers"
     },
     "error": {
       "couldNotOpenProject": "Could not open project.",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1247,7 +1247,7 @@
     },
     "fileDrop": {
       "overlayTitle": "Drop vector or raster files here to add layers",
-      "overlaySubtext": "Your data is added instantly as a new layer in the Layers panel.",
+      "overlaySubtext": "Your data is added instantly to the Layers panel.",
       "addedLayer": "Added \"{{name}}\" to the Layers panel.",
       "addedVectorLayers_one": "Added {{count}} vector layer to the Layers panel.",
       "addedVectorLayers_other": "Added {{count}} vector layers to the Layers panel.",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1245,6 +1245,17 @@
       "projectName": "Project name",
       "storymapEllipsis": "Story Map..."
     },
+    "fileDrop": {
+      "overlayTitle": "Drop vector or raster files here to add layers",
+      "overlaySubtext": "Your data is added instantly as a new layer in the Layers panel on the left.",
+      "addedLayer": "Added \"{{name}}\" to the Layers panel.",
+      "added": "Added {{summary}} to the Layers panel.",
+      "vectorLayers_one": "{{count}} vector layer",
+      "vectorLayers_other": "{{count}} vector layers",
+      "rasterLayers_one": "{{count}} raster layer",
+      "rasterLayers_other": "{{count}} raster layers",
+      "and": "and"
+    },
     "error": {
       "couldNotOpenProject": "Could not open project.",
       "invalidProjectUrl": "Enter a valid HTTP or HTTPS project URL.",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1247,14 +1247,13 @@
     },
     "fileDrop": {
       "overlayTitle": "Drop vector or raster files here to add layers",
-      "overlaySubtext": "Your data is added instantly as a new layer in the Layers panel on the left.",
+      "overlaySubtext": "Your data is added instantly as a new layer in the Layers panel.",
       "addedLayer": "Added \"{{name}}\" to the Layers panel.",
-      "added": "Added {{summary}} to the Layers panel.",
-      "vectorLayers_one": "{{count}} vector layer",
-      "vectorLayers_other": "{{count}} vector layers",
-      "rasterLayers_one": "{{count}} raster layer",
-      "rasterLayers_other": "{{count}} raster layers",
-      "and": "and"
+      "addedVectorLayers_one": "Added {{count}} vector layer to the Layers panel.",
+      "addedVectorLayers_other": "Added {{count}} vector layers to the Layers panel.",
+      "addedRasterLayers_one": "Added {{count}} raster layer to the Layers panel.",
+      "addedRasterLayers_other": "Added {{count}} raster layers to the Layers panel.",
+      "addedBoth": "Added {{vectorCount}} vector and {{rasterCount}} raster layers to the Layers panel."
     },
     "error": {
       "couldNotOpenProject": "Could not open project.",


### PR DESCRIPTION
## Summary

Improves the on-screen guidance and success feedback for GeoLibre's global drag-and-drop file import, addressing the usability gaps reported in #666.

Previously the global drop overlay only showed a single line ("Drop vector or raster files to add layers") with no explanation of what happens after a drop. When a source panel (for example Add Vector Layer) stayed open after a successful import, the result could read like "nothing happened," tempting users to drop the same file again.

### Changes

- **Explanatory overlay subtext.** The drag overlay now shows a title plus a subtext line that tells users where their data lands: "Your data is added instantly as a new layer in the Layers panel on the left."
- **Named success confirmation.** When a single vector file is dropped (the common case), the success toast names it, for example `Added "us_cities" to the Layers panel.`, instead of a generic count, so the confirmation echoes what was just added.
- **Translatable strings.** The overlay title/subtext and the drop summary now go through `t()` with a new `toolbar.fileDrop` i18n block in `en.json` (counts use i18next pluralization).

### Verification

Drove the real app in a browser with Playwright using a GeoJSON dataset, in **both light and dark themes**:

- The overlay renders the title and the readable muted subtext in both themes.
- Dropping a GeoJSON file adds the layer to the Layers panel and shows `Added "us_cities" to the Layers panel.`

`npm run build` and scoped `pre-commit` both pass.

Fixes #666