### PR TITLE
fix(desktop): tidy About dialog layout and update-error view

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
@@ -8,7 +8,6 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@geolibre/ui";
-import { PROJECT_VERSION } from "@geolibre/core";
 import { CheckCircle2, ExternalLink, Info, Map, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -309,10 +308,6 @@ export function AboutDialog({
                 </span>
               </a>
             ))}
-          </div>
-          <div className="pt-1 text-center text-xs text-muted-foreground">
-            {t("about.projectFormat")}{" "}
-            <span className="font-mono">{PROJECT_VERSION}</span>
           </div>
         </div>
       </DialogContent>

--- a/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
@@ -266,18 +266,22 @@ export function AboutDialog({
                       {updateError}
                     </div>
                   ) : null}
-                  <div className="text-xs text-muted-foreground">
-                    {t("updates.error.viewDownloadsHint")}
+                  {/* Group the hint with its button and divide it from the error
+                      message above so the two muted lines do not read as one. */}
+                  <div className="space-y-1.5 border-t pt-2">
+                    <div className="text-xs text-muted-foreground">
+                      {t("updates.error.viewDownloadsHint")}
+                    </div>
+                    <Button
+                      className="w-full justify-between"
+                      onClick={() => void openExternalLink(UPDATE_URL)}
+                      type="button"
+                      variant="outline"
+                    >
+                      <span>{t("updates.error.viewDownloads")}</span>
+                      <ExternalLink className="h-3.5 w-3.5" />
+                    </Button>
                   </div>
-                  <Button
-                    className="w-full justify-between"
-                    onClick={() => void openExternalLink(UPDATE_URL)}
-                    type="button"
-                    variant="outline"
-                  >
-                    <span>{t("updates.error.viewDownloads")}</span>
-                    <ExternalLink className="h-3.5 w-3.5" />
-                  </Button>
                 </div>
               ) : null}
             </div>

--- a/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
@@ -307,7 +307,8 @@ export function AboutDialog({
             ))}
           </div>
           <div className="pt-1 text-center text-xs text-muted-foreground">
-            {t("about.projectFormat")} {PROJECT_VERSION}
+            {t("about.projectFormat")}{" "}
+            <span className="font-mono">{PROJECT_VERSION}</span>
           </div>
         </div>
       </DialogContent>

--- a/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AboutDialog.tsx
@@ -189,12 +189,6 @@ export function AboutDialog({
             <span className="text-muted-foreground">{t("about.version")}</span>
             <span className="font-mono text-foreground">v{APP_VERSION}</span>
           </div>
-          <div className="flex items-center justify-between rounded-md border bg-muted/30 px-3 py-2">
-            <span className="text-muted-foreground">
-              {t("about.projectFormat")}
-            </span>
-            <span className="font-mono text-foreground">{PROJECT_VERSION}</span>
-          </div>
           <Button
             className="w-full justify-between"
             disabled={updateStatus === "checking"}
@@ -210,7 +204,9 @@ export function AboutDialog({
               />
               {updateStatus === "checking"
                 ? t("about.checking")
-                : t("about.checkForUpdates")}
+                : updateStatus === "error"
+                  ? t("about.tryAgain")
+                  : t("about.checkForUpdates")}
             </span>
           </Button>
           {updateStatus !== "idle" && updateStatus !== "checking" ? (
@@ -270,6 +266,9 @@ export function AboutDialog({
                       {updateError}
                     </div>
                   ) : null}
+                  <div className="text-xs text-muted-foreground">
+                    {t("updates.error.viewDownloadsHint")}
+                  </div>
                   <Button
                     className="w-full justify-between"
                     onClick={() => void openExternalLink(UPDATE_URL)}
@@ -283,25 +282,33 @@ export function AboutDialog({
               ) : null}
             </div>
           ) : null}
-          {LINKS.map((link) => (
-            <a
-              key={link.href}
-              className="flex items-center justify-between rounded-md border px-3 py-2 text-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
-              href={link.href}
-              onClick={(event) => {
-                event.preventDefault();
-                void openExternalLink(link.href);
-              }}
-              rel="noreferrer"
-              target="_blank"
-            >
-              <span>{t(link.labelKey)}</span>
-              <span className="inline-flex items-center gap-2 text-muted-foreground">
-                {link.href.replace(/^https?:\/\//, "")}
-                <ExternalLink className="h-3.5 w-3.5" />
-              </span>
-            </a>
-          ))}
+          <div className="space-y-2 border-t pt-3">
+            <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {t("about.generalSectionTitle")}
+            </div>
+            {LINKS.map((link) => (
+              <a
+                key={link.href}
+                className="flex items-center justify-between rounded-md border px-3 py-2 text-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+                href={link.href}
+                onClick={(event) => {
+                  event.preventDefault();
+                  void openExternalLink(link.href);
+                }}
+                rel="noreferrer"
+                target="_blank"
+              >
+                <span>{t(link.labelKey)}</span>
+                <span className="inline-flex items-center gap-2 text-muted-foreground">
+                  {link.href.replace(/^https?:\/\//, "")}
+                  <ExternalLink className="h-3.5 w-3.5" />
+                </span>
+              </a>
+            ))}
+          </div>
+          <div className="pt-1 text-center text-xs text-muted-foreground">
+            {t("about.projectFormat")} {PROJECT_VERSION}
+          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -6,9 +6,11 @@
     "version": "Version",
     "projectFormat": "Project format",
     "checkForUpdates": "Check for updates",
+    "tryAgain": "Try again",
     "checking": "Checking for updates",
     "upToDate": "You are up to date ({{version}}).",
     "upToDateNoVersion": "You are up to date.",
+    "generalSectionTitle": "General",
     "homePage": "Home page",
     "githubRepository": "GitHub repository"
   },
@@ -38,7 +40,8 @@
       "http": "GitHub returned {{status}}.",
       "noTag": "The latest release does not include a version tag.",
       "network": "Could not reach GitHub. Check your connection and try again.",
-      "viewDownloads": "View downloads"
+      "viewDownloads": "View downloads",
+      "viewDownloadsHint": "Opens the GeoLibre downloads page in your browser so you can check the latest version manually."
     },
     "startup": {
       "title": "Update available",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -4,7 +4,6 @@
     "title": "About GeoLibre",
     "description": "GeoLibre is a lightweight cloud-native desktop GIS.",
     "version": "Version",
-    "projectFormat": "Project format",
     "checkForUpdates": "Check for updates",
     "tryAgain": "Try again",
     "checking": "Checking for updates",


### PR DESCRIPTION
## Summary

Fixes #658. Fixes #659.

Two layout/UX reports against the **About GeoLibre** dialog, both addressed here since they touch the same component.

### #658 — "Project format" card misplaced
The read-only `Project format` card is **removed from the About dialog entirely** (issue #658's primary recommendation). It is application/file-level schema metadata that does not belong in the high-level About card, which is now just: application version, the update utility, and general links. The now-unused `about.projectFormat` string and `PROJECT_VERSION` import are dropped too.

### #659 — update-error view
- The general `Home page` / `GitHub repository` links are grouped under a `General` section header with a top divider, so they read as general links rather than part of the update workflow.
- On an update-check failure, the primary button relabels from `Check for updates` to `Try again`.
- A one-line hint clarifies that `View downloads` opens the GeoLibre downloads **web page** (not a local Downloads folder) to check the latest version manually; the hint and its button are grouped under a divider so they don't blend into the error message above.

New i18n keys (en.json, source of truth): `about.tryAgain`, `about.generalSectionTitle`, `updates.error.viewDownloadsHint`.

## Testing

Verified in the running web app with Playwright in **both light and dark themes**:
- Default view: no Project format anywhere; `General` section divides the links.
- Forced network-error view (GitHub API aborted): button shows `Try again`, the `View downloads` hint renders under its own divider, and the layout segmentation holds.

`npm run build` and `npm run test:frontend` (1313 passing) both green.