### PR TITLE
fix(layers): dismiss layer actions menu after "New group from layer"

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -1111,8 +1111,8 @@ export function LayerPanel({
                 {t("layers.renameGroup")}
               </DropdownMenuItem>
               {/* Action items below omit preventDefault so Radix dismisses the
-                  menu on select; only the rename item above keeps it (to avoid
-                  racing its input autofocus). See issue #668. */}
+                  menu on select; only the rename item above keeps it, so the
+                  menu's close does not race its input autofocus. */}
               <DropdownMenuItem
                 disabled={!canReorderGroup}
                 onSelect={() => {
@@ -1611,10 +1611,11 @@ export function LayerPanel({
                         Rename
                       </DropdownMenuItem>
                       <DropdownMenuSeparator />
-                      {/* Action items below intentionally omit preventDefault:
-                          unlike Rename there is nothing to autofocus, so Radix
-                          closes the menu on select instead of leaving it pinned
-                          open (issue #668). */}
+                      {/* The Rename item above keeps preventDefault so the
+                          menu's close does not race its input autofocus. Every
+                          action item below has no such focus target, so each
+                          lets Radix dismiss the menu on select rather than
+                          leaving it pinned open. */}
                       <DropdownMenuItem
                         onSelect={() => {
                           addLayerGroup(undefined, [layer.id]);
@@ -1658,8 +1659,7 @@ export function LayerPanel({
                       {canMaterializeDuckDB && (
                         <>
                           <DropdownMenuItem
-                            onSelect={(e: Event) => {
-                              e.preventDefault();
+                            onSelect={() => {
                               onMaterializeDuckDBLayer(layer);
                             }}
                           >
@@ -1672,8 +1672,7 @@ export function LayerPanel({
                       {(canEditGeometry || geometryEditActive) && (
                         <DropdownMenuItem
                           disabled={geometryEditElsewhere}
-                          onSelect={(e: Event) => {
-                            e.preventDefault();
+                          onSelect={() => {
                             selectLayer(layer.id);
                             if (identifyActive) setIdentifyLayer(null);
                             onToggleGeometryEdit(layer.id);
@@ -1687,8 +1686,7 @@ export function LayerPanel({
                       )}
                       {canOpenAttributeTable && (
                         <DropdownMenuItem
-                          onSelect={(e: Event) => {
-                            e.preventDefault();
+                          onSelect={() => {
                             selectLayer(layer.id);
                             setAttributeTableOpen(true);
                           }}
@@ -1699,8 +1697,7 @@ export function LayerPanel({
                       )}
                       {canBindTimeSlider && (
                         <DropdownMenuItem
-                          onSelect={(e: Event) => {
-                            e.preventDefault();
+                          onSelect={() => {
                             if (timeBinding) {
                               handleUnbindTimeSlider(layer);
                             } else {
@@ -1722,40 +1719,35 @@ export function LayerPanel({
                           </DropdownMenuSubTrigger>
                           <DropdownMenuSubContent>
                             <DropdownMenuItem
-                              onSelect={(e: Event) => {
-                                e.preventDefault();
+                              onSelect={() => {
                                 void handleExportLayer(layer, "geojson");
                               }}
                             >
                               GeoJSON
                             </DropdownMenuItem>
                             <DropdownMenuItem
-                              onSelect={(e: Event) => {
-                                e.preventDefault();
+                              onSelect={() => {
                                 void handleExportLayer(layer, "geoparquet");
                               }}
                             >
                               GeoParquet
                             </DropdownMenuItem>
                             <DropdownMenuItem
-                              onSelect={(e: Event) => {
-                                e.preventDefault();
+                              onSelect={() => {
                                 void handleExportLayer(layer, "geopackage");
                               }}
                             >
                               GeoPackage
                             </DropdownMenuItem>
                             <DropdownMenuItem
-                              onSelect={(e: Event) => {
-                                e.preventDefault();
+                              onSelect={() => {
                                 void handleExportLayer(layer, "shapefile");
                               }}
                             >
                               Shapefile (zipped)
                             </DropdownMenuItem>
                             <DropdownMenuItem
-                              onSelect={(e: Event) => {
-                                e.preventDefault();
+                              onSelect={() => {
                                 void handleExportLayer(layer, "csv");
                               }}
                             >
@@ -1766,8 +1758,7 @@ export function LayerPanel({
                       )}
                       {canEditRasterStyle && (
                         <DropdownMenuItem
-                          onSelect={(e: Event) => {
-                            e.preventDefault();
+                          onSelect={() => {
                             selectLayer(layer.id);
                             onOpenRasterStylePanel();
                           }}
@@ -1784,8 +1775,7 @@ export function LayerPanel({
                           </DropdownMenuSubTrigger>
                           <DropdownMenuSubContent>
                             <DropdownMenuItem
-                              onSelect={(e: Event) => {
-                                e.preventDefault();
+                              onSelect={() => {
                                 void handleExportRasterLayer(layer);
                               }}
                             >
@@ -1796,8 +1786,7 @@ export function LayerPanel({
                       )}
                       <DropdownMenuItem
                         disabled={!canRefresh || isRefreshing}
-                        onSelect={(e: Event) => {
-                          e.preventDefault();
+                        onSelect={() => {
                           void handleRefreshLayer(layer);
                         }}
                       >
@@ -1810,8 +1799,7 @@ export function LayerPanel({
                       </DropdownMenuItem>
                       <DropdownMenuItem
                         disabled={!canRefresh}
-                        onSelect={(e: Event) => {
-                          e.preventDefault();
+                        onSelect={() => {
                           setRefreshSettingsLayerId(layer.id);
                         }}
                       >

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -1612,9 +1612,12 @@ export function LayerPanel({
                         Rename
                       </DropdownMenuItem>
                       <DropdownMenuSeparator />
+                      {/* Let the menu close on its own after creating the
+                          group — there is no rename input to autofocus here, so
+                          no preventDefault is needed (and keeping it would leave
+                          the menu pinned open). */}
                       <DropdownMenuItem
-                        onSelect={(e: Event) => {
-                          e.preventDefault();
+                        onSelect={() => {
                           addLayerGroup(undefined, [layer.id]);
                         }}
                       >

--- a/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/LayerPanel.tsx
@@ -1110,10 +1110,12 @@ export function LayerPanel({
                 <Pencil className="mr-2 h-3.5 w-3.5" />
                 {t("layers.renameGroup")}
               </DropdownMenuItem>
+              {/* Action items below omit preventDefault so Radix dismisses the
+                  menu on select; only the rename item above keeps it (to avoid
+                  racing its input autofocus). See issue #668. */}
               <DropdownMenuItem
                 disabled={!canReorderGroup}
-                onSelect={(e: Event) => {
-                  e.preventDefault();
+                onSelect={() => {
                   reorderLayerGroup(group.id, "up");
                 }}
               >
@@ -1122,8 +1124,7 @@ export function LayerPanel({
               </DropdownMenuItem>
               <DropdownMenuItem
                 disabled={!canReorderGroup}
-                onSelect={(e: Event) => {
-                  e.preventDefault();
+                onSelect={() => {
                   reorderLayerGroup(group.id, "down");
                 }}
               >
@@ -1132,8 +1133,7 @@ export function LayerPanel({
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem
-                onSelect={(e: Event) => {
-                  e.preventDefault();
+                onSelect={() => {
                   removeLayerGroup(group.id);
                 }}
               >
@@ -1142,8 +1142,7 @@ export function LayerPanel({
               </DropdownMenuItem>
               <DropdownMenuItem
                 className="text-destructive"
-                onSelect={(e: Event) => {
-                  e.preventDefault();
+                onSelect={() => {
                   removeLayerGroup(group.id, { removeChildren: true });
                 }}
               >
@@ -1612,10 +1611,10 @@ export function LayerPanel({
                         Rename
                       </DropdownMenuItem>
                       <DropdownMenuSeparator />
-                      {/* Let the menu close on its own after creating the
-                          group — there is no rename input to autofocus here, so
-                          no preventDefault is needed (and keeping it would leave
-                          the menu pinned open). */}
+                      {/* Action items below intentionally omit preventDefault:
+                          unlike Rename there is nothing to autofocus, so Radix
+                          closes the menu on select instead of leaving it pinned
+                          open (issue #668). */}
                       <DropdownMenuItem
                         onSelect={() => {
                           addLayerGroup(undefined, [layer.id]);
@@ -1635,8 +1634,7 @@ export function LayerPanel({
                               <DropdownMenuItem
                                 key={g.id}
                                 disabled={layer.groupId === g.id}
-                                onSelect={(e: Event) => {
-                                  e.preventDefault();
+                                onSelect={() => {
                                   moveLayerToGroup(layer.id, g.id);
                                 }}
                               >
@@ -1648,8 +1646,7 @@ export function LayerPanel({
                       )}
                       {layer.groupId && (
                         <DropdownMenuItem
-                          onSelect={(e: Event) => {
-                            e.preventDefault();
+                          onSelect={() => {
                             moveLayerToGroup(layer.id, null);
                           }}
                         >


### PR DESCRIPTION
## Summary

The layer actions context menu stayed open after selecting **"New group from layer"**, forcing an extra click elsewhere to dismiss the lingering dropdown.

The item's `onSelect` handler called `e.preventDefault()`, which suppresses Radix's default menu-close behavior. That `preventDefault` is intentional for the **Rename** item (it keeps the menu's default close from racing the rename input's `autoFocus`), but "New group from layer" has nothing to focus afterward, so the only effect was leaving the menu pinned open. Removing the `preventDefault` lets the dropdown collapse instantly on select, returning focus to the layers sidebar.

## Testing

Verified in the running web app with a real GeoJSON layer (`us_cities.geojson`) in **both light and dark themes**: opening the layer actions menu and clicking "New group from layer" now creates the group and dismisses the menu in one click, with no lingering overlay.

Fixes #668

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed dropdown menu behavior in the Layer Panel—when creating a new group from a layer, the menu now closes properly after the action is completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->