### PR TITLE
fix(raster): optional sample-data dropdown in the Add Raster Layer dialog

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -70,7 +70,7 @@
     "maplibre-gl-nasa-earthdata": "^0.1.4",
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.6.1",
+    "maplibre-gl-raster": "^0.6.2",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.9.1",
     "maplibre-gl-time-slider": "^1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
         "maplibre-gl-nasa-earthdata": "^0.1.4",
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.6.1",
+        "maplibre-gl-raster": "^0.6.2",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.9.1",
         "maplibre-gl-time-slider": "^1.0.3",
@@ -17778,9 +17778,9 @@
       }
     },
     "node_modules/maplibre-gl-raster": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.6.1.tgz",
-      "integrity": "sha512-pEAilfj+aCHVWWh/8mjsn05y2TIAm+kkz6WZoI0qMG9qDYFLE6ndw56l/ZLdyqipI2KrPqiID/FQN4sjKMHdAQ==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-raster/-/maplibre-gl-raster-0.6.2.tgz",
+      "integrity": "sha512-4by13+J3xFvV4OT45ue5oPGDCPpkwvj/kjKvR2e3FG5AGiw3VS4mqf5eXRQGvmzquhkYeFhnO61Cgv7QGy7Dcw==",
       "license": "MIT",
       "dependencies": {
         "@chunkd/middleware": "^11.3.0",
@@ -24317,7 +24317,7 @@
         "maplibre-gl-national-map": "^0.1.1",
         "maplibre-gl-overture-maps": "^0.3.1",
         "maplibre-gl-planetary-computer": "^0.3.0",
-        "maplibre-gl-raster": "^0.6.1",
+        "maplibre-gl-raster": "^0.6.2",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.9.1",
         "maplibre-gl-time-slider": "^1.0.3",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -45,7 +45,7 @@
     "maplibre-gl-national-map": "^0.1.1",
     "maplibre-gl-overture-maps": "^0.3.1",
     "maplibre-gl-planetary-computer": "^0.3.0",
-    "maplibre-gl-raster": "^0.6.1",
+    "maplibre-gl-raster": "^0.6.2",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.9.1",
     "maplibre-gl-time-slider": "^1.0.3",

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -2,6 +2,7 @@ import { useAppStore } from "@geolibre/core";
 import type {
   RasterControl,
   RasterControlEventHandler,
+  RasterSampleDataset,
 } from "maplibre-gl-raster";
 import type { GeoLibreAppAPI, GeoLibreMapControlPosition } from "../types";
 import { ensureMercatorProjection } from "./map-projection-utils";
@@ -22,16 +23,28 @@ import {
 
 const rasterControlPosition: GeoLibreMapControlPosition = "top-left";
 const RASTER_PANEL_CLASS = "geolibre-raster-panel";
-const DEFAULT_RASTER_URL =
-  "https://data.source.coop/giswqs/opengeos/nlcd_2021_land_cover_30m.tif";
 
-// These types mirror undocumented private members of RasterControl from
-// maplibre-gl-raster (re-verified against v0.6.1). All access is optional (?.)
+// One-click sample COGs shown in the panel's "Load sample data" dropdown.
+// Edit this list to offer different (or more) demonstration rasters; loading
+// is opt-in, so an empty list simply hides the dropdown. URLs must be
+// CORS-enabled and range-request capable (source.coop is both).
+const SAMPLE_RASTER_DATASETS: RasterSampleDataset[] = [
+  {
+    label: "Land cover",
+    url: "https://data.source.coop/giswqs/opengeos/nlcd_2021_land_cover_30m.tif",
+  },
+  {
+    label: "Elevation (DEM)",
+    url: "https://data.source.coop/giswqs/opengeos/dem.tif",
+  },
+];
+
+// This type mirrors undocumented private members of RasterControl from
+// maplibre-gl-raster (re-verified against v0.6.2). All access is optional (?.)
 // so a rename in a future release degrades to a no-op rather than a crash --
 // re-verify these names AND the .mlr-control-close selector in
 // wireRasterCloseButton when bumping the dependency.
 type RasterControlInternals = {
-  _clickOutsideHandler?: ((event: MouseEvent) => void) | null;
   _layerManager?: RasterLayerManagerInternals;
   _panel?: HTMLElement;
 };
@@ -113,11 +126,9 @@ export function openRasterLayerPanel(app: GeoLibreAppAPI): void {
         control.expand();
         // Idempotent (guarded by a dataset flag / null checks): retried on
         // every open so the panel chrome stays wired even if a future
-        // upstream release builds the panel DOM (or registers the
-        // click-outside handler) lazily on first expand.
+        // upstream release builds the panel DOM lazily on first expand.
         wireRasterCloseButton(control);
         applyRasterPanelClass(control);
-        disableRasterClickOutsideCollapse(control);
       } catch (error) {
         console.error(
           "[GeoLibre] Failed to open the raster layer panel",
@@ -391,7 +402,6 @@ async function ensureRasterControl(
     // not its constructor.
     activateRasterClassification(rasterControl);
     hideRasterControl(rasterControl);
-    disableRasterClickOutsideCollapse(rasterControl);
     wireRasterCloseButton(rasterControl);
     applyRasterPanelClass(rasterControl);
   }
@@ -429,7 +439,12 @@ function createRasterControl(
   const control = new RasterControlClass({
     className: "geolibre-raster-control",
     collapsed: true,
-    defaultUrl: DEFAULT_RASTER_URL,
+    // Empty input with a generic placeholder; the sample COGs below are the
+    // explicit, opt-in way to load a demonstration raster.
+    sampleData: SAMPLE_RASTER_DATASETS,
+    // The panel doubles as the Add Raster Layer dialog, so it stays open
+    // until the user closes it; clicking the map must not collapse it.
+    closeOnOutsideClick: false,
     interleaved: rasterControlInterleaved,
     panelWidth: 380,
     title: "Add Raster Layer",
@@ -639,7 +654,6 @@ function applyRestoredRasterPanelState(
       control.expand();
       wireRasterCloseButton(control);
       applyRasterPanelClass(control);
-      disableRasterClickOutsideCollapse(control);
     } catch (error) {
       console.error("[GeoLibre] Failed to restore raster panel state", error);
     }
@@ -657,18 +671,6 @@ function rasterPanelCollapsedFromLayers(
   // Older projects did not persist this UI state. Keep them collapsed so
   // loading a raster project does not unexpectedly open the Add Data panel.
   return typeof panelCollapsed === "boolean" ? panelCollapsed : true;
-}
-
-// The control collapses its panel when the user clicks anywhere else on the
-// page, which fights the panel's role as the Add Raster Layer dialog (e.g.
-// panning the map to inspect a loaded COG would close it). Removing the
-// handler keeps the panel open until the user closes it explicitly.
-function disableRasterClickOutsideCollapse(control: RasterControl): void {
-  const internals = control as unknown as RasterControlInternals;
-  const handler = internals._clickOutsideHandler;
-  if (!handler) return;
-  document.removeEventListener("click", handler);
-  internals._clickOutsideHandler = null;
 }
 
 // The upstream stylesheet themes the panel from prefers-color-scheme (the

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -27,7 +27,9 @@ const RASTER_PANEL_CLASS = "geolibre-raster-panel";
 // One-click sample COGs shown in the panel's "Load sample data" dropdown.
 // Edit this list to offer different (or more) demonstration rasters; loading
 // is opt-in, so an empty list simply hides the dropdown. URLs must be
-// CORS-enabled and range-request capable (source.coop is both).
+// CORS-enabled and range-request capable (source.coop is both). Labels are
+// rendered by the upstream control, which exposes no i18n callback, so they
+// stay plain strings (same gap as the vector plugin's sample list).
 const SAMPLE_RASTER_DATASETS: RasterSampleDataset[] = [
   {
     label: "Land cover",
@@ -439,7 +441,8 @@ function createRasterControl(
   const control = new RasterControlClass({
     className: "geolibre-raster-control",
     collapsed: true,
-    // Empty input with a generic placeholder; the sample COGs below are the
+    // No prefilled URL: the input stays empty (the upstream control supplies
+    // a generic COG-URL placeholder), and the sample COGs below are the
     // explicit, opt-in way to load a demonstration raster.
     sampleData: SAMPLE_RASTER_DATASETS,
     // The panel doubles as the Add Raster Layer dialog, so it stays open


### PR DESCRIPTION
## Summary

Applies the Add Vector Layer pattern (#661) to the **Add Raster Layer** dialog. The URL input no longer ships prefilled with a hardcoded sample COG; it starts empty (placeholder only), and the demonstration rasters move into an opt-in **Load sample data** dropdown that fills the input when the user picks one.

### What changed
- **No prefilled URL.** The Add data input starts empty.
- **Load sample data dropdown.** Two source.coop samples: **Land cover** (`nlcd_2021_land_cover_30m.tif`) and **Elevation (DEM)** (`dem.tif`). Easy to edit; an empty list hides the dropdown.
- **Stays open until closed.** Clicking the map no longer collapses the panel; only the header close button does. This replaces the previous private-member click-outside workaround with the upstream `closeOnOutsideClick` option.

### Upstream
Depends on `maplibre-gl-raster@0.6.2` (released to npm), which adds the `sampleData`/`sampleDataLabel` dropdown and `closeOnOutsideClick` option, with a custom (dark-mode-correct) dropdown. Upstream PR: opengeos/maplibre-gl-raster#23.

## Test plan
- `tsc -b`, `pre-commit run --files` (incl. the npm build hook) clean.
- Verified in the running app (light + dark): the input is empty, the dropdown lists Land cover + Elevation, selecting one fills the input, clicking the map keeps the panel open, and the close button dismisses it.

Fixes #662


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a predefined selection of sample raster datasets available for quick access

* **Improvements**
  * The "Add Raster Layer" panel now remains open when clicking outside, providing better control and accessibility
  * Updated maplibre-gl-raster library to version 0.6.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->