### PR TITLE
fix(layout): widen default side panel and raise resize cap (#682)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -340,19 +340,16 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
 
-// Seed width for the Layers/Style side panels. On narrow desktop windows the
-// full default would let two open panels crowd out the map (two 320px panels
+// Seed width for the Layers/Style side panels. The full default would let two
+// open panels crowd out the map on narrow desktop windows (two 320px panels
 // leave only 128px at the 768px `md` breakpoint), so cap the initial width at
-// ~30% of the viewport there. On wider screens this is a no-op and the full
-// default applies; users can still drag up to MAX_SIDE_PANEL_WIDTH either way.
+// ~30% of the viewport. The cap only lowers the width below ~1067px (where 30%
+// of the viewport drops under the default); wider windows get the full default.
+// Users can still drag up to MAX_SIDE_PANEL_WIDTH either way.
 function initialSidePanelWidth(): number {
   if (typeof window === "undefined") return DEFAULT_SIDE_PANEL_WIDTH;
   const cap = Math.round(window.innerWidth * 0.3);
-  return clamp(
-    Math.min(DEFAULT_SIDE_PANEL_WIDTH, cap),
-    MIN_SIDE_PANEL_WIDTH,
-    DEFAULT_SIDE_PANEL_WIDTH,
-  );
+  return clamp(cap, MIN_SIDE_PANEL_WIDTH, DEFAULT_SIDE_PANEL_WIDTH);
 }
 
 type ShellStyle = CSSProperties &

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -321,9 +321,9 @@ type ImportedVectorLayer = Awaited<
   ReturnType<typeof loadDroppedVectorFiles>
 >[number];
 
-const DEFAULT_SIDE_PANEL_WIDTH = 256;
+const DEFAULT_SIDE_PANEL_WIDTH = 320;
 const MIN_SIDE_PANEL_WIDTH = 180;
-const MAX_SIDE_PANEL_WIDTH = 460;
+const MAX_SIDE_PANEL_WIDTH = 560;
 // Width of a side panel's collapsed rail (`md:w-11` = 2.75rem). The Style panel
 // stays mounted (collapsed) beside the notebook, so its rail still occupies this
 // much of the row when computing the map/notebook 50/50 split.

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -340,6 +340,21 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
 
+// Seed width for the Layers/Style side panels. On narrow desktop windows the
+// full default would let two open panels crowd out the map (two 320px panels
+// leave only 128px at the 768px `md` breakpoint), so cap the initial width at
+// ~30% of the viewport there. On wider screens this is a no-op and the full
+// default applies; users can still drag up to MAX_SIDE_PANEL_WIDTH either way.
+function initialSidePanelWidth(): number {
+  if (typeof window === "undefined") return DEFAULT_SIDE_PANEL_WIDTH;
+  const cap = Math.round(window.innerWidth * 0.3);
+  return clamp(
+    Math.min(DEFAULT_SIDE_PANEL_WIDTH, cap),
+    MIN_SIDE_PANEL_WIDTH,
+    DEFAULT_SIDE_PANEL_WIDTH,
+  );
+}
+
 type ShellStyle = CSSProperties &
   Record<
     "--layer-panel-width" | "--style-panel-width" | "--notebook-panel-width",
@@ -425,12 +440,8 @@ export function DesktopShell({
   // Routes the Layers-panel Identify action to the raster pixel inspector for
   // COG layers (read band values on click). Inert until a COG is identified.
   useRasterIdentify();
-  const [layerPanelWidth, setLayerPanelWidth] = useState(
-    DEFAULT_SIDE_PANEL_WIDTH,
-  );
-  const [stylePanelWidth, setStylePanelWidth] = useState(
-    DEFAULT_SIDE_PANEL_WIDTH,
-  );
+  const [layerPanelWidth, setLayerPanelWidth] = useState(initialSidePanelWidth);
+  const [stylePanelWidth, setStylePanelWidth] = useState(initialSidePanelWidth);
   const [notebookPanelWidth, setNotebookPanelWidth] = useState(
     DEFAULT_NOTEBOOK_PANEL_WIDTH,
   );


### PR DESCRIPTION
## Summary

Issue #682 reports that loading a basemap via the basemap plugin truncates layer controls in the left Layers panel, and asks for a wider default panel.

The specific premise in the report (a 485px "system basemap" card vs. a 560px "plugin basemap" card) does not match the code: the Layers panel is a single, user-resizable element driven by one CSS variable (`--layer-panel-width`), and every layer card shares that width. There is no per-layer width and no 485/560 mismatch. The real, actionable part of the request is that the default panel is narrow, so cards can feel cramped out of the box.

This PR addresses that directly:

- Bump `DEFAULT_SIDE_PANEL_WIDTH` from **256 to 320**, so the Layers and Style panels show their layer cards, controls, and opacity sliders comfortably without manual resizing.
- Raise `MAX_SIDE_PANEL_WIDTH` from **460 to 560**, so users who want an even wider panel can drag it out to the width the issue describes.

`MIN_SIDE_PANEL_WIDTH` is unchanged (180). The width is shared by both the Layers and Style side panels, keeping them consistent.

## Verification

Drove the running app in a real browser:

- `--layer-panel-width` now resolves to `320px` and the Layers panel renders at 320px by default.
- Background layer entry and opacity slider are fully visible without truncation.
- Confirmed in both light and dark themes.

Fixes #682


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Expanded Layers/Style side panel sizing for more workspace and improved readability.
  * Updated initial side panel width behavior to scale with the window size on the client while keeping a sensible default during server rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->