### PR TITLE
fix(vector): load loose shapefiles (maplibre-gl-vector 0.5.1) + desktop sidecar auto-discovery (#680)

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -75,7 +75,7 @@
     "maplibre-gl-swipe": "^0.9.1",
     "maplibre-gl-time-slider": "^1.0.3",
     "maplibre-gl-usgs-lidar": "^0.11.0",
-    "maplibre-gl-vector": "^0.5.0",
+    "maplibre-gl-vector": "^0.5.1",
     "openai": "^6.39.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.7",

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -75,7 +75,7 @@
     "maplibre-gl-swipe": "^0.9.1",
     "maplibre-gl-time-slider": "^1.0.3",
     "maplibre-gl-usgs-lidar": "^0.11.0",
-    "maplibre-gl-vector": "^0.4.1",
+    "maplibre-gl-vector": "^0.5.0",
     "openai": "^6.39.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.7",

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -182,6 +182,7 @@ pub fn run() {
             load_external_plugin_bundles,
             read_admin_profile,
             read_project_file,
+            read_shapefile_siblings,
             resolve_url_redirect,
             read_mbtiles_metadata,
             read_mbtiles_tile,
@@ -205,6 +206,75 @@ pub fn run() {
 #[tauri::command]
 fn read_project_file(path: String) -> Result<String, String> {
     fs::read_to_string(&path).map_err(|error| format!("Could not read project file: {error}"))
+}
+
+/// Shapefile sidecar extensions read alongside a `.shp` (lowercased, no dot).
+const SHAPEFILE_SIDECAR_EXTENSIONS: [&str; 16] = [
+    "shx", "dbf", "prj", "cpg", "sbn", "sbx", "qix", "qpj", "cst", "aih", "ain", "atx", "ixs",
+    "mxs", "fbn", "fbx",
+];
+
+#[derive(Serialize)]
+struct ShapefileSibling {
+    /// `<shp base>.<lowercased sidecar extension>`, matching the `.shp` base name
+    /// so GDAL resolves the sidecar when reading the `.shp` directly.
+    name: String,
+    data: Vec<u8>,
+}
+
+/// Read a shapefile's sidecar files (`.shx`, `.dbf`, `.prj`, `.cpg`, ...) sitting
+/// next to the given `.shp`, so a loose `.shp` can be loaded without the user
+/// selecting every component.
+///
+/// The JS `fs` plugin can only read paths the user explicitly picked or dropped,
+/// so it cannot reach a sidecar that was not selected; this reads them directly.
+/// It is scoped to shapefile sidecar extensions, so it cannot read arbitrary
+/// files. The directory is matched case-insensitively (handling `.SHX`/`.DBF` and
+/// mixed-case base names), and each sidecar is returned under the `.shp`'s base
+/// name with a lowercased extension so the registered names line up. Missing
+/// siblings are skipped; an unreadable directory yields an empty list.
+#[tauri::command]
+fn read_shapefile_siblings(path: String) -> Result<Vec<ShapefileSibling>, String> {
+    let shp = Path::new(&path);
+    let Some(parent) = shp.parent() else {
+        return Ok(Vec::new());
+    };
+    let Some(stem) = shp.file_stem().and_then(|stem| stem.to_str()) else {
+        return Ok(Vec::new());
+    };
+    let entries = match fs::read_dir(parent) {
+        Ok(entries) => entries,
+        Err(_) => return Ok(Vec::new()),
+    };
+    let mut siblings = Vec::new();
+    for entry in entries.flatten() {
+        let entry_path = entry.path();
+        if !entry_path.is_file() {
+            continue;
+        }
+        let (Some(entry_stem), Some(extension)) = (
+            entry_path.file_stem().and_then(|stem| stem.to_str()),
+            entry_path
+                .extension()
+                .and_then(|extension| extension.to_str()),
+        ) else {
+            continue;
+        };
+        if !entry_stem.eq_ignore_ascii_case(stem) {
+            continue;
+        }
+        let extension = extension.to_ascii_lowercase();
+        if !SHAPEFILE_SIDECAR_EXTENSIONS.contains(&extension.as_str()) {
+            continue;
+        }
+        if let Ok(data) = fs::read(&entry_path) {
+            siblings.push(ShapefileSibling {
+                name: format!("{stem}.{extension}"),
+                data,
+            });
+        }
+    }
+    Ok(siblings)
 }
 
 /// Read the optional admin UI-profile file (`<app_config_dir>/admin-profile.json`).

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -57,6 +57,7 @@ import { mergeStringLists } from "../lib/string-lists";
 import {
   browserSaveFallsBackToDownload,
   openLocalDataFileWithFallback,
+  pickVectorFilesWithSidecars,
   saveTextFileWithFallback,
 } from "../lib/tauri-io";
 import { useDesktopSettingsStore } from "./useDesktopSettings";
@@ -509,6 +510,12 @@ export function createAppAPI(
       mapControllerRef?.current?.fitBounds(bounds),
     getMap: () => mapControllerRef?.current?.getMap() ?? null,
     pickLocalDirectoryFiles,
+    // Present only on desktop (filesystem access); the Vector panel keys off its
+    // presence to auto-discover shapefile sidecars instead of forcing the user
+    // to select every component.
+    pickVectorFilesWithSidecars: isTauriRuntime()
+      ? pickVectorFilesWithSidecars
+      : undefined,
     exportTextFile: (
       filename: string,
       content: string,

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -545,6 +545,55 @@ async function openVectorFileTauri(
   return loadTauriVectorFile(selected, options);
 }
 
+/** A vector file picked from the desktop dialog, with any shapefile sidecars. */
+export interface PickedVectorFile {
+  /** The main vector file (the `.shp` for a shapefile). */
+  file: File;
+  /**
+   * Sidecar files for a shapefile (`.shx`, `.dbf`, `.prj`, `.cpg`) read from the
+   * same directory; empty for any other format.
+   */
+  companionFiles: File[];
+}
+
+/**
+ * Opens the native file dialog to pick one or more vector files and reads each
+ * into a browser `File`. For a `.shp`, its sidecar files in the same directory
+ * are read too, so a host with filesystem access can load a loose `.shp` without
+ * the user selecting every component. Sidecar files are skipped as standalone
+ * picks (they ride along with their `.shp` via `companionFiles`).
+ *
+ * Used by the Add Data > Vector panel on desktop, which feeds each result to the
+ * control's `addData(file, { companionFiles })`. Resolves to an empty array when
+ * the dialog is cancelled.
+ *
+ * @returns The picked vector files, each with its shapefile sidecars.
+ */
+export async function pickVectorFilesWithSidecars(): Promise<PickedVectorFile[]> {
+  const selected = await open({ multiple: true });
+  if (!selected) return [];
+  // `isVectorFileName` drops rasters, project files, and shapefile sidecars, so
+  // a sidecar picked on its own never becomes its own (unreadable) layer.
+  const paths = (Array.isArray(selected) ? selected : [selected]).filter(
+    isVectorFileName,
+  );
+  const picked: PickedVectorFile[] = [];
+  for (const path of paths) {
+    const file = new File(
+      [toArrayBuffer(await readFile(path))],
+      browserSafeFileName(path),
+    );
+    const companionFiles =
+      fileExtension(path) === "shp"
+        ? (await readShapefileSiblings(path)).map(
+            (sibling) => new File([toArrayBuffer(sibling.data)], sibling.name),
+          )
+        : [];
+    picked.push({ file, companionFiles });
+  }
+  return picked;
+}
+
 async function loadTauriVectorFile(
   path: string,
   options?: DuckDbVectorLoadOptions,

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -125,6 +125,7 @@ const NON_VECTOR_SIDECAR_EXTENSIONS = [
   "sbx",
   "qix",
   "qpj",
+  "cst",
   "aih",
   "ain",
   "atx",
@@ -579,17 +580,23 @@ export async function pickVectorFilesWithSidecars(): Promise<PickedVectorFile[]>
   );
   const picked: PickedVectorFile[] = [];
   for (const path of paths) {
-    const file = new File(
-      [toArrayBuffer(await readFile(path))],
-      browserSafeFileName(path),
-    );
-    const companionFiles =
-      fileExtension(path) === "shp"
-        ? (await readShapefileSiblings(path)).map(
-            (sibling) => new File([toArrayBuffer(sibling.data)], sibling.name),
-          )
-        : [];
-    picked.push({ file, companionFiles });
+    // Read each pick independently so one unreadable file (e.g. moved between
+    // pick and read, or an unreadable sidecar) does not abandon the rest.
+    try {
+      const file = new File(
+        [toArrayBuffer(await readFile(path))],
+        browserSafeFileName(path),
+      );
+      const companionFiles =
+        fileExtension(path) === "shp"
+          ? (await readShapefileSiblings(path)).map(
+              (sibling) => new File([toArrayBuffer(sibling.data)], sibling.name),
+            )
+          : [];
+      picked.push({ file, companionFiles });
+    } catch (error) {
+      console.warn(`Could not read the selected file "${path}".`, error);
+    }
   }
   return picked;
 }

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -697,25 +697,21 @@ async function loadTauriVectorFile(
 async function readShapefileSiblings(
   path: string,
 ): Promise<DuckDbVectorFile[]> {
-  const basePath = pathWithoutExtension(path);
-  const siblings = await Promise.all(
-    SHAPEFILE_SIDECAR_EXTENSIONS.map(async (extension) => {
-      const siblingPath = `${basePath}.${extension}`;
-      try {
-        return {
-          name: browserSafeFileName(siblingPath),
-          extension,
-          data: await readFile(siblingPath),
-        };
-      } catch {
-        return null;
-      }
-    }),
+  // Read the sidecars through a Tauri command rather than the JS `fs` plugin:
+  // `fs` can only read paths the user explicitly picked or dropped, so a sidecar
+  // that was not selected (the whole point of auto-discovery) is forbidden. The
+  // command reads them directly and case-insensitively, returning each under the
+  // `.shp`'s base name with a lowercased extension. Returns [] off the desktop.
+  if (!isTauri()) return [];
+  const siblings = await invoke<Array<{ name: string; data: number[] }>>(
+    "read_shapefile_siblings",
+    { path },
   );
-
-  return siblings.filter(
-    (sibling): sibling is DuckDbVectorFile => sibling !== null,
-  );
+  return siblings.map((sibling) => ({
+    name: sibling.name,
+    extension: fileExtension(sibling.name),
+    data: new Uint8Array(sibling.data),
+  }));
 }
 
 async function openProjectFileBrowser(): Promise<{

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,7 @@
         "maplibre-gl-swipe": "^0.9.1",
         "maplibre-gl-time-slider": "^1.0.3",
         "maplibre-gl-usgs-lidar": "^0.11.0",
-        "maplibre-gl-vector": "^0.5.0",
+        "maplibre-gl-vector": "^0.5.1",
         "openai": "^6.39.0",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.7",
@@ -17962,9 +17962,9 @@
       }
     },
     "node_modules/maplibre-gl-vector": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.5.0.tgz",
-      "integrity": "sha512-BAO6cFlU1By4Wpvy+/2rMuBKAEAXnFwYbe2q8Zcm+FyXtFdidhEAhmWdIAjv+dA194r/DpG0adZlqTZNQ6e7Ig==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.5.1.tgz",
+      "integrity": "sha512-nH2qlQP61oZqdiOaGrzsZHQoxcqQLQP6Ywr7H0iuW7EcBp9SeNorT0SEkjFTdlM1xKb6IcNruKnYfvZWD171Ig==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"
@@ -24322,7 +24322,7 @@
         "maplibre-gl-swipe": "^0.9.1",
         "maplibre-gl-time-slider": "^1.0.3",
         "maplibre-gl-usgs-lidar": "^0.11.0",
-        "maplibre-gl-vector": "^0.5.0",
+        "maplibre-gl-vector": "^0.5.1",
         "proj4": "^2.20.9",
         "shpjs": "^6.2.0",
         "three": "^0.184.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,7 @@
         "maplibre-gl-swipe": "^0.9.1",
         "maplibre-gl-time-slider": "^1.0.3",
         "maplibre-gl-usgs-lidar": "^0.11.0",
-        "maplibre-gl-vector": "^0.4.1",
+        "maplibre-gl-vector": "^0.5.0",
         "openai": "^6.39.0",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.7",
@@ -17962,9 +17962,9 @@
       }
     },
     "node_modules/maplibre-gl-vector": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.4.1.tgz",
-      "integrity": "sha512-DrUDIq+DZZmBlBaWPYHcf3/uK32j3N6cl2eRtzHF9tFl9HXgAAMxR3rvnEu0ChENhXTU8xxtL7R7Xvy8YTPOhQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.5.0.tgz",
+      "integrity": "sha512-BAO6cFlU1By4Wpvy+/2rMuBKAEAXnFwYbe2q8Zcm+FyXtFdidhEAhmWdIAjv+dA194r/DpG0adZlqTZNQ6e7Ig==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"
@@ -24322,7 +24322,7 @@
         "maplibre-gl-swipe": "^0.9.1",
         "maplibre-gl-time-slider": "^1.0.3",
         "maplibre-gl-usgs-lidar": "^0.11.0",
-        "maplibre-gl-vector": "^0.4.1",
+        "maplibre-gl-vector": "^0.5.0",
         "proj4": "^2.20.9",
         "shpjs": "^6.2.0",
         "three": "^0.184.0"

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -50,7 +50,7 @@
     "maplibre-gl-swipe": "^0.9.1",
     "maplibre-gl-time-slider": "^1.0.3",
     "maplibre-gl-usgs-lidar": "^0.11.0",
-    "maplibre-gl-vector": "^0.5.0",
+    "maplibre-gl-vector": "^0.5.1",
     "proj4": "^2.20.9",
     "shpjs": "^6.2.0",
     "three": "^0.184.0"

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -50,7 +50,7 @@
     "maplibre-gl-swipe": "^0.9.1",
     "maplibre-gl-time-slider": "^1.0.3",
     "maplibre-gl-usgs-lidar": "^0.11.0",
-    "maplibre-gl-vector": "^0.4.1",
+    "maplibre-gl-vector": "^0.5.0",
     "proj4": "^2.20.9",
     "shpjs": "^6.2.0",
     "three": "^0.184.0"

--- a/packages/plugins/src/plugins/maplibre-vector.ts
+++ b/packages/plugins/src/plugins/maplibre-vector.ts
@@ -532,17 +532,16 @@ export type VectorDataSink = Pick<VectorControl, "addData">;
 /**
  * Loads files picked through {@link GeoLibreAppAPI.pickVectorFilesWithSidecars}
  * into a vector control, passing a shapefile's sidecars as `companionFiles` so a
- * loose `.shp` loads as a single layer. Each file is added independently; a
- * `null` pick (cancelled dialog) loads nothing.
+ * loose `.shp` loads as a single layer. Each file is added independently; an
+ * empty list (e.g. a cancelled dialog) loads nothing.
  *
  * @param control - The vector control (or anything with `addData`).
- * @param picked - The picked files, or null when the dialog was cancelled.
+ * @param picked - The picked files (empty when the dialog was cancelled).
  */
 export async function addPickedVectorFiles(
   control: VectorDataSink,
-  picked: GeoLibrePickedVectorFile[] | null,
+  picked: GeoLibrePickedVectorFile[],
 ): Promise<void> {
-  if (!picked) return;
   for (const { file, companionFiles } of picked) {
     await control.addData(
       file,

--- a/packages/plugins/src/plugins/maplibre-vector.ts
+++ b/packages/plugins/src/plugins/maplibre-vector.ts
@@ -5,7 +5,11 @@ import type {
   VectorLayerInfo,
   VectorSampleDataset,
 } from "maplibre-gl-vector";
-import type { GeoLibreAppAPI, GeoLibreMapControlPosition } from "../types";
+import type {
+  GeoLibreAppAPI,
+  GeoLibreMapControlPosition,
+  GeoLibrePickedVectorFile,
+} from "../types";
 import {
   isVectorControlStoreLayer,
   resetVectorStoreSyncSuspension,
@@ -97,6 +101,7 @@ export function openVectorLayerPanel(app: GeoLibreAppAPI): void {
         // upstream release builds the panel DOM lazily on first expand.
         wireVectorCloseButton(control);
         applyVectorPanelClass(control);
+        wireDesktopFilePicker(control, app);
       } catch (error) {
         console.error(
           "[GeoLibre] Failed to open the vector layer panel",
@@ -289,6 +294,7 @@ async function ensureVectorControl(
     hideVectorControl(vectorControl);
     wireVectorCloseButton(vectorControl);
     applyVectorPanelClass(vectorControl);
+    wireDesktopFilePicker(vectorControl, app);
   }
 
   return vectorControl;
@@ -478,4 +484,69 @@ function wireVectorCloseButton(control: VectorControl): void {
   }
   closeButton.dataset.geolibreCloseWired = "true";
   closeButton.addEventListener("click", () => hideVectorControl(control));
+}
+
+// On desktop the host can read a chosen `.shp`'s sidecar files from the same
+// directory, so a loose `.shp` loads without the user selecting every component
+// (.shx, .dbf, .prj, ...). The upstream panel's file input yields sandboxed File
+// objects with no filesystem path, so intercept its click and route through the
+// host's native picker (which returns the sidecars via companionFiles), then
+// hand the result back to the panel so the layer stays panel-managed. No-op on
+// the web, where `pickVectorFilesWithSidecars` is absent and the native input is
+// the only way to read files. The selector mirrors the upstream panel's file
+// input (verified against v0.5.1) -- re-verify when bumping the dependency.
+function wireDesktopFilePicker(
+  control: VectorControl,
+  app: GeoLibreAppAPI,
+): void {
+  const pickFiles = app.pickVectorFilesWithSidecars;
+  if (!pickFiles) return;
+  const panel = (control as unknown as VectorControlInternals)._panel;
+  const fileInput = panel?.querySelector<HTMLInputElement>(
+    'input[type="file"]',
+  );
+  if (!fileInput || fileInput.dataset.geolibreDesktopPickerWired === "true") {
+    return;
+  }
+  fileInput.dataset.geolibreDesktopPickerWired = "true";
+  fileInput.addEventListener("click", (event) => {
+    // Suppress the sandboxed picker (no path) in favor of the host dialog. Also
+    // covers the "click to browse" drop zone, which delegates to this input.
+    event.preventDefault();
+    void (async () => {
+      try {
+        await addPickedVectorFiles(control, await pickFiles());
+      } catch (error) {
+        console.error(
+          "[GeoLibre] Failed to load vector files from the desktop picker",
+          error,
+        );
+      }
+    })();
+  });
+}
+
+/** The subset of VectorControl used to load picked files (eases testing). */
+export type VectorDataSink = Pick<VectorControl, "addData">;
+
+/**
+ * Loads files picked through {@link GeoLibreAppAPI.pickVectorFilesWithSidecars}
+ * into a vector control, passing a shapefile's sidecars as `companionFiles` so a
+ * loose `.shp` loads as a single layer. Each file is added independently; a
+ * `null` pick (cancelled dialog) loads nothing.
+ *
+ * @param control - The vector control (or anything with `addData`).
+ * @param picked - The picked files, or null when the dialog was cancelled.
+ */
+export async function addPickedVectorFiles(
+  control: VectorDataSink,
+  picked: GeoLibrePickedVectorFile[] | null,
+): Promise<void> {
+  if (!picked) return;
+  for (const { file, companionFiles } of picked) {
+    await control.addData(
+      file,
+      companionFiles.length > 0 ? { companionFiles } : {},
+    );
+  }
 }

--- a/packages/plugins/src/plugins/maplibre-vector.ts
+++ b/packages/plugins/src/plugins/maplibre-vector.ts
@@ -49,7 +49,7 @@ const SAMPLE_VECTOR_DATASETS: VectorSampleDataset[] = [
 ];
 
 // This type mirrors an undocumented private member of VectorControl from
-// maplibre-gl-vector (verified against v0.4.1). Access is optional (?.) so a
+// maplibre-gl-vector (verified against v0.5.1). Access is optional (?.) so a
 // rename in a future release degrades to a no-op rather than a crash --
 // re-verify this name AND the .vector-control-close selector in
 // wireVectorCloseButton when bumping the dependency.
@@ -338,7 +338,7 @@ function createVectorControl(
   }
   // syncVectorLayersToStore re-reads getState().collapsed when these fire.
   // Safe: expand()/collapse() delegate to toggle(), which flips
-  // _state.collapsed BEFORE emitting the event (verified against v0.2.0) --
+  // _state.collapsed BEFORE emitting the event (verified against v0.5.1) --
   // re-verify that ordering when bumping the dependency.
   const panelStateSyncHandler: VectorControlEventHandler = () =>
     syncVectorLayersToStore(control);

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -130,7 +130,7 @@ export interface GeoLibreAppAPI {
    * (browsers cannot read sibling files), so its presence doubles as a desktop
    * capability check. Resolves to an empty array when the dialog is cancelled.
    */
-  pickVectorFilesWithSidecars?: () => Promise<GeoLibrePickedVectorFile[] | null>;
+  pickVectorFilesWithSidecars?: () => Promise<GeoLibrePickedVectorFile[]>;
   /**
    * Save text content to a file chosen by the user. The host handles the
    * platform specifics (a native save dialog under Tauri, a browser download

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -77,6 +77,21 @@ export interface GeoLibreDeckGL {
   mapbox: typeof import("@deck.gl/mapbox");
 }
 
+/**
+ * A vector file picked through {@link GeoLibreAppAPI.pickVectorFilesWithSidecars},
+ * with any shapefile sidecars the host found alongside it.
+ */
+export interface GeoLibrePickedVectorFile {
+  /** The main vector file (the `.shp` for a shapefile). */
+  file: File;
+  /**
+   * Shapefile sidecar files (`.shx`, `.dbf`, `.prj`, `.cpg`) discovered next to
+   * a `.shp`; empty for any other format. Pass these to a vector control's
+   * `addData(file, { companionFiles })` so a loose `.shp` loads as one layer.
+   */
+  companionFiles: File[];
+}
+
 export interface GeoLibreAppAPI {
   setBasemap: (styleUrl: string) => void;
   addGeoJsonLayer: (
@@ -106,6 +121,16 @@ export interface GeoLibreAppAPI {
   fitBounds?: (bounds: [number, number, number, number]) => void;
   getMap?: () => MapLibreMap | null;
   pickLocalDirectoryFiles?: () => Promise<File[] | null>;
+  /**
+   * Prompt the user (desktop only) to pick one or more vector files via the
+   * native dialog, returning each with any shapefile sidecars discovered in the
+   * same directory. This lets a host with filesystem access load a loose `.shp`
+   * without the user selecting every component (`.shx`, `.dbf`, ...). Present
+   * only on hosts with filesystem access (the desktop build); absent on the web
+   * (browsers cannot read sibling files), so its presence doubles as a desktop
+   * capability check. Resolves to an empty array when the dialog is cancelled.
+   */
+  pickVectorFilesWithSidecars?: () => Promise<GeoLibrePickedVectorFile[] | null>;
   /**
    * Save text content to a file chosen by the user. The host handles the
    * platform specifics (a native save dialog under Tauri, a browser download

--- a/tests/vector-desktop-picker.test.ts
+++ b/tests/vector-desktop-picker.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  addPickedVectorFiles,
+  type VectorDataSink,
+} from "../packages/plugins/src/plugins/maplibre-vector";
+import type { GeoLibrePickedVectorFile } from "../packages/plugins/src/types";
+
+function createSink() {
+  const calls: Array<{ name: string; companionFiles?: string[] }> = [];
+  const sink = {
+    addData: async (
+      source: File,
+      options?: { companionFiles?: File[] },
+    ) => {
+      calls.push({
+        name: source.name,
+        companionFiles: options?.companionFiles?.map((file) => file.name),
+      });
+      return {} as never;
+    },
+  } as unknown as VectorDataSink;
+  return { sink, calls };
+}
+
+describe("addPickedVectorFiles", () => {
+  it("passes a shapefile's sidecars as companionFiles", async () => {
+    const { sink, calls } = createSink();
+    const picked: GeoLibrePickedVectorFile[] = [
+      {
+        file: new File(["shp"], "cities.shp"),
+        companionFiles: [
+          new File(["shx"], "cities.shx"),
+          new File(["dbf"], "cities.dbf"),
+        ],
+      },
+    ];
+
+    await addPickedVectorFiles(sink, picked);
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].name, "cities.shp");
+    assert.deepEqual(calls[0].companionFiles, ["cities.shx", "cities.dbf"]);
+  });
+
+  it("omits companionFiles for non-shapefile picks", async () => {
+    const { sink, calls } = createSink();
+
+    await addPickedVectorFiles(sink, [
+      { file: new File(["x"], "a.geojson"), companionFiles: [] },
+      { file: new File(["x"], "b.parquet"), companionFiles: [] },
+    ]);
+
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].companionFiles, undefined);
+    assert.equal(calls[1].companionFiles, undefined);
+  });
+
+  it("loads nothing when the dialog was cancelled (null)", async () => {
+    const { sink, calls } = createSink();
+
+    await addPickedVectorFiles(sink, null);
+
+    assert.equal(calls.length, 0);
+  });
+});

--- a/tests/vector-desktop-picker.test.ts
+++ b/tests/vector-desktop-picker.test.ts
@@ -56,10 +56,10 @@ describe("addPickedVectorFiles", () => {
     assert.equal(calls[1].companionFiles, undefined);
   });
 
-  it("loads nothing when the dialog was cancelled (null)", async () => {
+  it("loads nothing when the dialog was cancelled (empty list)", async () => {
     const { sink, calls } = createSink();
 
-    await addPickedVectorFiles(sink, null);
+    await addPickedVectorFiles(sink, []);
 
     assert.equal(calls.length, 0);
   });


### PR DESCRIPTION
## Summary

Loading a shapefile through Add Data -> Vector Layer failed with `IO Error: GDAL Error (1): GDALOpen() called on x.shp recursively`, because the upstream `maplibre-gl-vector` panel registered each selected file independently and read each as its own layer (the `.shp`'s `.shx`/`.dbf` siblings were never registered under a shared base name for GDAL).

This PR fixes the loading path and improves the experience on both web and desktop.

## Upstream (`maplibre-gl-vector`), consumed via the `^0.4.1` -> `^0.5.1` bump

- **0.5.0** (opengeos/maplibre-gl-vector#22): groups loose shapefile components selected together so a `.shp` loads as one layer with its sidecars registered under a shared base name; sidecars no longer load as their own layers. Adds a `companionFiles` option to `addData`.
- **0.5.1** (opengeos/maplibre-gl-vector#24): when only a `.shp` (or one missing `.shx`/`.dbf`) is selected, shows an actionable message instead of the opaque GDAL error.

## GeoLibre-side: desktop sidecar auto-discovery

On desktop, picking only a `.shp` in the Vector panel now loads the whole shapefile automatically. The panel's file input yields sandboxed `File` objects with no path, so on desktop GeoLibre intercepts the input and routes through the native dialog (`pickVectorFilesWithSidecars`), which returns real paths; the `.shp`'s `.shx`/`.dbf`/`.prj`/`.cpg` siblings are read from the same directory and passed to the control as `companionFiles`. The layer stays panel-managed.

- New `GeoLibreAppAPI.pickVectorFilesWithSidecars` (present only on hosts with filesystem access; its presence is the desktop capability check).
- The interception is a no-op on the web, where the native input remains the only way to read files.

## Behavior matrix

| Context | Select `.shp` + sidecars together | Select only `.shp` |
|---|---|---|
| Web | Loads as one layer | Actionable "select companion files / use .zip" message |
| Desktop (Vector panel) | Loads as one layer | Auto-discovers siblings from the folder and loads |
| Desktop (drag-drop) | Loads as one layer | Auto-discovers siblings from the folder and loads |

## Verification

- Web (real app, both light and dark themes): `.shp`+sidecars loads as one layer; only-`.shp` shows the actionable message; confirmed the desktop interception is absent on web (native input still works).
- Unit test for the picked-files -> `addData` mapping (`companionFiles` passed for shapefiles, omitted otherwise, no-op on cancel). Full frontend suite (1316 tests), build, and pre-commit pass.
- The desktop native-dialog path could not be exercised by the automated suite (no display for `tauri:dev` and Playwright cannot drive the OS dialog); it needs a manual check in a desktop build.

Fixes #680


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a desktop-only vector file picker that can include Shapefile sidecar companion files with the selected `.shp`.
  * Updated the VectorControl flow so picked files are loaded together, with companion files only sent when available.
* **Chores**
  * Updated the vector mapping library dependency to a newer compatible version.
* **Tests**
  * Added coverage for how picked Shapefile sidecars (and cancel/no-result cases) are handled when adding vector data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->