### PR TITLE
fix(statistics): disable Run until required fields set, add asterisk legend

### DIFF
--- a/apps/geolibre-desktop/src/components/processing/StatisticsToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/StatisticsToolsDialog.tsx
@@ -196,12 +196,12 @@ export function StatisticsToolsDialog({
     [params],
   );
 
-  // Visible required parameters that are still empty. Drives the disabled Run
-  // button (and the asterisk legend only shows when there is something to mark).
+  // All required parameters; used for the asterisk legend condition.
   const requiredParams = useMemo(
     () => tool.parameters.filter((param) => param.required),
     [tool],
   );
+  // Visible required params that are still unset — disables the Run button.
   const missingRequired = useMemo(
     () =>
       requiredParams.some(
@@ -308,7 +308,7 @@ export function StatisticsToolsDialog({
               ))}
             </div>
 
-            {requiredParams.length > 0 ? (
+            {requiredParams.some(isParamVisible) ? (
               <p className="text-xs text-muted-foreground">
                 <span className="text-destructive">*</span>{" "}
                 {t("statistics.requiredFieldLegend")}

--- a/apps/geolibre-desktop/src/components/processing/StatisticsToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/StatisticsToolsDialog.tsx
@@ -310,7 +310,9 @@ export function StatisticsToolsDialog({
 
             {requiredParams.some(isParamVisible) ? (
               <p className="text-xs text-muted-foreground">
-                <span className="text-destructive">*</span>{" "}
+                <span className="text-destructive" aria-hidden="true">
+                  *
+                </span>{" "}
                 {t("statistics.requiredFieldLegend")}
               </p>
             ) : null}

--- a/apps/geolibre-desktop/src/components/processing/StatisticsToolsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/StatisticsToolsDialog.tsx
@@ -35,6 +35,25 @@ interface StatisticsToolsDialogProps {
 }
 
 /**
+ * Whether a parameter value counts as unset, used both to disable the Run
+ * button and to validate on run. Numbers must be a real (non-NaN) value.
+ *
+ * @param param - Parameter definition (its `type` drives the NaN check).
+ * @param value - Current value held for the parameter.
+ * @returns True when the value is missing or, for numbers, NaN.
+ */
+function isValueEmpty(param: AlgorithmParameter, value: unknown): boolean {
+  return (
+    value === undefined ||
+    value === "" ||
+    value === null ||
+    (param.type === "number" &&
+      typeof value === "number" &&
+      Number.isNaN(value))
+  );
+}
+
+/**
  * Processing → Spatial Statistics dialog: Moran's I (global + local/LISA),
  * Getis-Ord Gi* hotspots, kernel density, and average nearest neighbor. Every
  * tool runs client-side in TypeScript (no sidecar/engine selector), so this is
@@ -177,19 +196,26 @@ export function StatisticsToolsDialog({
     [params],
   );
 
+  // Visible required parameters that are still empty. Drives the disabled Run
+  // button (and the asterisk legend only shows when there is something to mark).
+  const requiredParams = useMemo(
+    () => tool.parameters.filter((param) => param.required),
+    [tool],
+  );
+  const missingRequired = useMemo(
+    () =>
+      requiredParams.some(
+        (param) =>
+          isParamVisible(param) && isValueEmpty(param, params[param.id]),
+      ),
+    [requiredParams, isParamVisible, params],
+  );
+
   const handleRun = useCallback(async () => {
     setLog([]);
     for (const param of tool.parameters) {
       if (!param.required || !isParamVisible(param)) continue;
-      const value = params[param.id];
-      if (
-        value === undefined ||
-        value === "" ||
-        value === null ||
-        (param.type === "number" &&
-          typeof value === "number" &&
-          Number.isNaN(value))
-      ) {
+      if (isValueEmpty(param, params[param.id])) {
         appendLog(`Error: "${param.label}" is required`);
         return;
       }
@@ -282,8 +308,19 @@ export function StatisticsToolsDialog({
               ))}
             </div>
 
+            {requiredParams.length > 0 ? (
+              <p className="text-xs text-muted-foreground">
+                <span className="text-destructive">*</span>{" "}
+                {t("statistics.requiredFieldLegend")}
+              </p>
+            ) : null}
+
             <div>
-              <Button onClick={handleRun} disabled={running} className="gap-2">
+              <Button
+                onClick={handleRun}
+                disabled={running || missingRequired}
+                className="gap-2"
+              >
                 {running ? (
                   <Loader2 className="h-4 w-4 animate-spin" />
                 ) : (

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1562,6 +1562,7 @@
     "description": "Spatial autocorrelation, hotspot analysis, and density measures. Every tool runs client-side on your GeoJSON layers.",
     "heading": "Spatial Statistics",
     "run": "Run",
+    "requiredFieldLegend": "Indicates a required field",
     "outputPlaceholder": "Output will appear here."
   },
   "processing": {


### PR DESCRIPTION
## Summary

Fixes #679. The **Spatial Statistics** dialog (Processing → Spatial Statistics) had two usability problems reported against tools like *Global Moran's I* and *Kernel density (heatmap)*:

1. The **Run** button stayed in its active blue state even when required inputs (Layer, Value field, Search radius, Cell size) were empty. Clicking it only surfaced an inline error after the fact instead of preventing the bad run.
2. Required fields were marked with a red asterisk, but nothing explained what the asterisk meant.

## Changes

- **Disable Run until required fields are filled.** The button is now disabled whenever any *visible* required parameter is unset (respecting `visibleWhen`, so hidden conditional fields never block it). The post-click validation still runs as a safety net.
- **Add a required-field legend.** A `* Indicates a required field` line now renders below the form (with the asterisk in the same red as the field markers), shown only when the selected tool has required parameters.
- Extracted the empty-value check into a shared `isValueEmpty` helper reused by both the button state and the run-time validation, so the two never drift.
- New i18n string `statistics.requiredFieldLegend` in `en.json`.

## Verification

Drove the real app in a browser with Playwright using a real dataset (`us_cities.geojson`), in **both dark and light themes**:

- With no layer selected, **Run** is `disabled` (was enabled before).
- After selecting a layer **and** value field, **Run** enables.
- The `* Indicates a required field` legend renders correctly and the asterisks match its red.

`npm run build` and `pre-commit run` (eslint + npm build) both pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced validation in the Statistics dialog to better detect empty required parameters.
  * Run button now properly disables when any visible required field is empty.
  * Required field indicator legend displays conditionally based on form state, reducing UI clutter.
  * Added localization support for required field messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->