### PR TITLE
fix(vector): embed path-less Add Vector Layer layers in "Save file references"

### DIFF
--- a/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectFileActions.ts
@@ -411,18 +411,32 @@ export function useProjectFileActions(mapControllerRef: MapControllerRef) {
     }
 
     // "noembed": on the web this saves without the local data (those layers are
-    // lost on reopen); on desktop it saves file references that reload from
-    // disk, so flag the plain-GeoJSON local layers (prepareLayerForSave then
-    // drops their embedded copy; Add Vector Layer layers already carry a path).
+    // lost on reopen). On desktop it saves file references — but only for layers
+    // that actually have a re-readable path; the rest (e.g. an Add Vector Layer
+    // file restored from an embedded copy on a machine without the original) are
+    // embedded as a fallback, since referencing them would save no data at all.
     if (!isTauri()) return {};
     let changed = false;
     const layers = useAppStore.getState().layers.map((layer) => {
-      if (!isReloadableLocalFileLayer(layer)) return layer;
-      changed = true;
-      return {
-        ...layer,
-        metadata: { ...layer.metadata, localFileReloadable: true },
-      };
+      // Plain GeoJSON with an absolute path → reference (drop the embedded copy).
+      if (isReloadableLocalFileLayer(layer)) {
+        changed = true;
+        return {
+          ...layer,
+          metadata: { ...layer.metadata, localFileReloadable: true },
+        };
+      }
+      // An Add Vector Layer control layer already carrying a path references it
+      // as-is; one without a path can't be referenced, so embed its features.
+      const collection = embeddable.get(layer.id);
+      if (collection && layer.metadata.localFileReloadable !== true) {
+        changed = true;
+        return {
+          ...layer,
+          metadata: { ...layer.metadata, embeddedGeoJSON: collection },
+        };
+      }
+      return layer;
     });
     return changed ? { layers } : {};
   };

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -697,12 +697,13 @@ export async function readVectorFileWithSidecars(
 }
 
 export function isAbsoluteLocalPath(path: string): boolean {
-  const trimmed = path.trim();
-  // Accept POSIX paths and Windows drive-letter paths only. UNC paths
-  // (\\server\share) are deliberately rejected: reading one can make Windows
-  // auto-authenticate against a remote host (NTLM hash capture), and a remote
-  // share is not a supported local data source.
-  return trimmed.startsWith("/") || /^[a-z]:[\\/]/i.test(trimmed);
+  // Match the raw path (not a trimmed copy): a whitespace-padded value would
+  // pass a trimmed check but reach `readFile` unchanged and fail there, so
+  // reject it up front instead. Accept POSIX paths and Windows drive-letter
+  // paths only. UNC paths (\\server\share) are deliberately rejected: reading
+  // one can make Windows auto-authenticate against a remote host (NTLM hash
+  // capture), and a remote share is not a supported local data source.
+  return path.startsWith("/") || /^[a-z]:[\\/]/i.test(path);
 }
 
 async function loadTauriVectorFile(


### PR DESCRIPTION
Follow-up to #689, fixing a bug found in that PR's final review round (the PR was merged before the fix landed).

## Problem

When a shared or embedded project is reopened on desktop, an Add Vector Layer file restored from its embedded copy has **no original path** (`localFileReloadable` is unset on this machine). Saving with **"Save file references"** only flagged plain-GeoJSON layers with an absolute path, so that Add Vector Layer layer was left with no URL, no path, and no embedded data — and `restoreVectorLayers` dropped it on the next reopen.

## Fix

"Save file references" now references only layers that actually have a re-readable path; any local vector layer **without** one (e.g. an embedded-origin Add Vector Layer layer) is **embedded** as a fallback instead of saved with no data.

Also: `isAbsoluteLocalPath` no longer trims, so a whitespace-padded `sourcePath` is rejected up front rather than passing the check and failing later at `readFile`.

## Verification

Typecheck, frontend tests, and production build pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of layer data when saving projects on desktop with better fallback support for certain layer types
  * Enhanced file path validation to correctly reject whitespace-padded paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->