### PR TITLE
fix(plugins): keep external native layer style over default-seeded style

### DIFF
--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -1,8 +1,4 @@
-import {
-  DEFAULT_LAYER_STYLE,
-  type GeoLibreLayer,
-  useAppStore,
-} from "@geolibre/core";
+import { useAppStore } from "@geolibre/core";
 import {
   maplibreBasemapControlPlugin,
   maplibreComponentsPlugin,
@@ -53,6 +49,7 @@ import {
   type InstalledWebPlugin,
 } from "../lib/external-plugins";
 import { appendDiagnostic } from "../lib/diagnostics";
+import { createExternalNativeStoreLayer } from "../lib/external-native-layer";
 import { mergeStringLists } from "../lib/string-lists";
 import {
   browserSaveFallsBackToDownload,
@@ -125,46 +122,6 @@ manager.registerAll([
   maplibreDeckGlVizPlugin,
   maplibreComponentsPlugin,
 ]);
-
-function createExternalNativeStoreLayer(
-  registration: GeoLibreExternalNativeLayerRegistration,
-  existing?: GeoLibreLayer,
-): GeoLibreLayer {
-  const sourceIds = registration.sourceIds?.length
-    ? registration.sourceIds
-    : registration.sourceId
-      ? [registration.sourceId]
-      : [];
-  const sourceId = registration.sourceId ?? sourceIds[0];
-
-  return {
-    id: registration.id,
-    name: registration.name,
-    type: registration.type ?? "geojson",
-    source: {
-      ...(registration.source ?? { type: "geojson" }),
-      ...(sourceId ? { sourceId } : {}),
-    },
-    visible: existing?.visible ?? true,
-    opacity: existing?.opacity ?? registration.opacity ?? 1,
-    style: {
-      ...DEFAULT_LAYER_STYLE,
-      ...(registration.style ?? {}),
-      ...(existing?.style ?? {}),
-    } as GeoLibreLayer["style"],
-    metadata: {
-      ...(existing?.metadata ?? {}),
-      ...(registration.metadata ?? {}),
-      externalNativeLayer: true,
-      nativeLayerIds: registration.nativeLayerIds,
-      sourceIds,
-      ...(sourceId ? { sourceId } : {}),
-    },
-    beforeId: registration.beforeId ?? existing?.beforeId,
-    geojson: registration.geojson ?? existing?.geojson,
-    sourcePath: registration.sourcePath ?? existing?.sourcePath,
-  };
-}
 
 let externalPluginsLoaded = false;
 let externalPluginsLoadPromise: Promise<void> | null = null;

--- a/apps/geolibre-desktop/src/lib/external-native-layer.ts
+++ b/apps/geolibre-desktop/src/lib/external-native-layer.ts
@@ -3,11 +3,16 @@ import type { GeoLibreExternalNativeLayerRegistration } from "@geolibre/plugins"
 
 /**
  * Build the store layer record for an external plugin's native GeoJSON layer.
- * The layer is plugin-owned, so the registration's `style`/`opacity` win over
- * an `existing` layer: `addGeoJsonLayer` seeds the layer with the full
- * `DEFAULT_LAYER_STYLE` and `opacity: 1` before the plugin registers its own,
- * so merging the existing values last would clobber the plugin's choices and
- * reset the rendered layer on the next visibility/layer-control change.
+ *
+ * Merge priority for `style`/`opacity` (highest to lowest):
+ *   registration  - plugin always owns the keys it supplies (even over a user edit)
+ *   existing       - preserves user edits for keys the registration omits
+ *   defaults       - DEFAULT_LAYER_STYLE / opacity 1
+ *
+ * `addGeoJsonLayer` seeds the layer with `DEFAULT_LAYER_STYLE` and `opacity: 1`
+ * before the plugin calls `registerExternalNativeLayer`, so the registration
+ * must merge last or the defaults would win and the rendered layer would reset
+ * on the next visibility/layer-control change.
  */
 export function createExternalNativeStoreLayer(
   registration: GeoLibreExternalNativeLayerRegistration,
@@ -24,6 +29,7 @@ export function createExternalNativeStoreLayer(
     id: registration.id,
     name: registration.name,
     type: registration.type ?? "geojson",
+    // Plugin fully owns its source descriptor; existing.source is not merged.
     source: {
       ...(registration.source ?? { type: "geojson" }),
       ...(sourceId ? { sourceId } : {}),

--- a/apps/geolibre-desktop/src/lib/external-native-layer.ts
+++ b/apps/geolibre-desktop/src/lib/external-native-layer.ts
@@ -3,18 +3,11 @@ import type { GeoLibreExternalNativeLayerRegistration } from "@geolibre/plugins"
 
 /**
  * Build the store layer record for an external plugin's native GeoJSON layer.
- *
- * Plugins typically create the rendered layer first with `addGeoJsonLayer`
- * (which seeds it with `DEFAULT_LAYER_STYLE`) and then call
- * `registerExternalNativeLayer` to attach their own style and metadata. The
- * registration's style must therefore win over the existing layer's style:
- * `existing.style` already carries the full default style, so merging it last
- * would silently clobber the plugin's colors with GeoLibre's default blue and
- * reset the rendered paint on the next visibility/layer-control change.
- *
- * @param registration - The plugin-supplied native layer registration.
- * @param existing - The current store layer for this id, if one already exists.
- * @returns The reconciled `GeoLibreLayer` record to add to or update in the store.
+ * The layer is plugin-owned, so the registration's `style`/`opacity` win over
+ * an `existing` layer: `addGeoJsonLayer` seeds the layer with the full
+ * `DEFAULT_LAYER_STYLE` and `opacity: 1` before the plugin registers its own,
+ * so merging the existing values last would clobber the plugin's choices and
+ * reset the rendered layer on the next visibility/layer-control change.
  */
 export function createExternalNativeStoreLayer(
   registration: GeoLibreExternalNativeLayerRegistration,
@@ -36,7 +29,7 @@ export function createExternalNativeStoreLayer(
       ...(sourceId ? { sourceId } : {}),
     },
     visible: existing?.visible ?? true,
-    opacity: existing?.opacity ?? registration.opacity ?? 1,
+    opacity: registration.opacity ?? existing?.opacity ?? 1,
     style: {
       ...DEFAULT_LAYER_STYLE,
       ...(existing?.style ?? {}),

--- a/apps/geolibre-desktop/src/lib/external-native-layer.ts
+++ b/apps/geolibre-desktop/src/lib/external-native-layer.ts
@@ -1,0 +1,57 @@
+import { DEFAULT_LAYER_STYLE, type GeoLibreLayer } from "@geolibre/core";
+import type { GeoLibreExternalNativeLayerRegistration } from "@geolibre/plugins";
+
+/**
+ * Build the store layer record for an external plugin's native GeoJSON layer.
+ *
+ * Plugins typically create the rendered layer first with `addGeoJsonLayer`
+ * (which seeds it with `DEFAULT_LAYER_STYLE`) and then call
+ * `registerExternalNativeLayer` to attach their own style and metadata. The
+ * registration's style must therefore win over the existing layer's style:
+ * `existing.style` already carries the full default style, so merging it last
+ * would silently clobber the plugin's colors with GeoLibre's default blue and
+ * reset the rendered paint on the next visibility/layer-control change.
+ *
+ * @param registration - The plugin-supplied native layer registration.
+ * @param existing - The current store layer for this id, if one already exists.
+ * @returns The reconciled `GeoLibreLayer` record to add to or update in the store.
+ */
+export function createExternalNativeStoreLayer(
+  registration: GeoLibreExternalNativeLayerRegistration,
+  existing?: GeoLibreLayer,
+): GeoLibreLayer {
+  const sourceIds = registration.sourceIds?.length
+    ? registration.sourceIds
+    : registration.sourceId
+      ? [registration.sourceId]
+      : [];
+  const sourceId = registration.sourceId ?? sourceIds[0];
+
+  return {
+    id: registration.id,
+    name: registration.name,
+    type: registration.type ?? "geojson",
+    source: {
+      ...(registration.source ?? { type: "geojson" }),
+      ...(sourceId ? { sourceId } : {}),
+    },
+    visible: existing?.visible ?? true,
+    opacity: existing?.opacity ?? registration.opacity ?? 1,
+    style: {
+      ...DEFAULT_LAYER_STYLE,
+      ...(existing?.style ?? {}),
+      ...(registration.style ?? {}),
+    } as GeoLibreLayer["style"],
+    metadata: {
+      ...(existing?.metadata ?? {}),
+      ...(registration.metadata ?? {}),
+      externalNativeLayer: true,
+      nativeLayerIds: registration.nativeLayerIds,
+      sourceIds,
+      ...(sourceId ? { sourceId } : {}),
+    },
+    beforeId: registration.beforeId ?? existing?.beforeId,
+    geojson: registration.geojson ?? existing?.geojson,
+    sourcePath: registration.sourcePath ?? existing?.sourcePath,
+  };
+}

--- a/tests/external-native-layer.test.ts
+++ b/tests/external-native-layer.test.ts
@@ -118,6 +118,26 @@ describe("createExternalNativeStoreLayer", () => {
     assert.equal(layer.opacity, 0.7);
   });
 
+  it("lets the registration own opacity over a non-default user-edited value", () => {
+    const existing: GeoLibreLayer = {
+      id: "plugin-layer",
+      name: "Plugin Layer",
+      type: "geojson",
+      source: { type: "geojson" },
+      visible: true,
+      opacity: 0.3, // user-edited
+      style: { ...DEFAULT_LAYER_STYLE },
+      metadata: {},
+    };
+
+    const layer = createExternalNativeStoreLayer(
+      baseRegistration({ opacity: 0.8 }),
+      existing,
+    );
+
+    assert.equal(layer.opacity, 0.8);
+  });
+
   it("applies the registration style over defaults for a brand-new layer", () => {
     const layer = createExternalNativeStoreLayer(
       baseRegistration({ style: { fillColor: "#123456" } }),

--- a/tests/external-native-layer.test.ts
+++ b/tests/external-native-layer.test.ts
@@ -131,4 +131,21 @@ describe("createExternalNativeStoreLayer", () => {
       "plugin-layer-outline",
     ]);
   });
+
+  it("preserves existing visibility when false", () => {
+    const existing: GeoLibreLayer = {
+      id: "plugin-layer",
+      name: "Plugin Layer",
+      type: "geojson",
+      source: { type: "geojson" },
+      visible: false,
+      opacity: 1,
+      style: { ...DEFAULT_LAYER_STYLE },
+      metadata: {},
+    };
+
+    const layer = createExternalNativeStoreLayer(baseRegistration(), existing);
+
+    assert.equal(layer.visible, false);
+  });
 });

--- a/tests/external-native-layer.test.ts
+++ b/tests/external-native-layer.test.ts
@@ -24,7 +24,7 @@ describe("createExternalNativeStoreLayer", () => {
       source: { type: "geojson" },
       visible: true,
       opacity: 1,
-      style: { ...DEFAULT_LAYER_STYLE, simpleStyleEnabled: false },
+      style: { ...DEFAULT_LAYER_STYLE },
       metadata: {},
     };
 
@@ -59,6 +59,28 @@ describe("createExternalNativeStoreLayer", () => {
     assert.equal(layer.style.strokeWidth, 5);
   });
 
+  it("lets the registration own overlapping style keys over a user edit", () => {
+    // External native layers are plugin-owned: a re-registration's style wins
+    // even over a non-default user value on the same key, not just over defaults.
+    const existing: GeoLibreLayer = {
+      id: "plugin-layer",
+      name: "Plugin Layer",
+      type: "geojson",
+      source: { type: "geojson" },
+      visible: true,
+      opacity: 1,
+      style: { ...DEFAULT_LAYER_STYLE, fillColor: "#abcdef" },
+      metadata: {},
+    };
+
+    const layer = createExternalNativeStoreLayer(
+      baseRegistration({ style: { fillColor: "#ff0000" } }),
+      existing,
+    );
+
+    assert.equal(layer.style.fillColor, "#ff0000");
+  });
+
   it("keeps the registration opacity over an existing default-seeded opacity", () => {
     const existing: GeoLibreLayer = {
       id: "plugin-layer",
@@ -77,6 +99,23 @@ describe("createExternalNativeStoreLayer", () => {
     );
 
     assert.equal(layer.opacity, 0.5);
+  });
+
+  it("falls back to existing opacity when the registration omits opacity", () => {
+    const existing: GeoLibreLayer = {
+      id: "plugin-layer",
+      name: "Plugin Layer",
+      type: "geojson",
+      source: { type: "geojson" },
+      visible: true,
+      opacity: 0.7,
+      style: { ...DEFAULT_LAYER_STYLE },
+      metadata: {},
+    };
+
+    const layer = createExternalNativeStoreLayer(baseRegistration(), existing);
+
+    assert.equal(layer.opacity, 0.7);
   });
 
   it("applies the registration style over defaults for a brand-new layer", () => {

--- a/tests/external-native-layer.test.ts
+++ b/tests/external-native-layer.test.ts
@@ -59,6 +59,26 @@ describe("createExternalNativeStoreLayer", () => {
     assert.equal(layer.style.strokeWidth, 5);
   });
 
+  it("keeps the registration opacity over an existing default-seeded opacity", () => {
+    const existing: GeoLibreLayer = {
+      id: "plugin-layer",
+      name: "Plugin Layer",
+      type: "geojson",
+      source: { type: "geojson" },
+      visible: true,
+      opacity: 1, // seeded by addGeoJsonLayer
+      style: { ...DEFAULT_LAYER_STYLE },
+      metadata: {},
+    };
+
+    const layer = createExternalNativeStoreLayer(
+      baseRegistration({ opacity: 0.5 }),
+      existing,
+    );
+
+    assert.equal(layer.opacity, 0.5);
+  });
+
   it("applies the registration style over defaults for a brand-new layer", () => {
     const layer = createExternalNativeStoreLayer(
       baseRegistration({ style: { fillColor: "#123456" } }),

--- a/tests/external-native-layer.test.ts
+++ b/tests/external-native-layer.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { DEFAULT_LAYER_STYLE, type GeoLibreLayer } from "@geolibre/core";
+import type { GeoLibreExternalNativeLayerRegistration } from "@geolibre/plugins";
+import { createExternalNativeStoreLayer } from "../apps/geolibre-desktop/src/lib/external-native-layer";
+
+const baseRegistration = (
+  overrides: Partial<GeoLibreExternalNativeLayerRegistration> = {},
+): GeoLibreExternalNativeLayerRegistration => ({
+  id: "plugin-layer",
+  name: "Plugin Layer",
+  nativeLayerIds: ["plugin-layer-fill", "plugin-layer-outline"],
+  ...overrides,
+});
+
+describe("createExternalNativeStoreLayer", () => {
+  it("keeps the registration style over an existing default-seeded style", () => {
+    // addGeoJsonLayer seeds the layer with the full DEFAULT_LAYER_STYLE before
+    // the plugin registers its own colors, so the registration must win.
+    const existing: GeoLibreLayer = {
+      id: "plugin-layer",
+      name: "Plugin Layer",
+      type: "geojson",
+      source: { type: "geojson" },
+      visible: true,
+      opacity: 1,
+      style: { ...DEFAULT_LAYER_STYLE, simpleStyleEnabled: false },
+      metadata: {},
+    };
+
+    const layer = createExternalNativeStoreLayer(
+      baseRegistration({ style: { fillColor: "#ff0000", strokeColor: "#990000" } }),
+      existing,
+    );
+
+    assert.equal(layer.style.fillColor, "#ff0000");
+    assert.equal(layer.style.strokeColor, "#990000");
+    assert.notEqual(layer.style.fillColor, DEFAULT_LAYER_STYLE.fillColor);
+  });
+
+  it("preserves user-edited existing style for keys the registration omits", () => {
+    const existing: GeoLibreLayer = {
+      id: "plugin-layer",
+      name: "Plugin Layer",
+      type: "geojson",
+      source: { type: "geojson" },
+      visible: true,
+      opacity: 1,
+      style: { ...DEFAULT_LAYER_STYLE, strokeWidth: 5 },
+      metadata: {},
+    };
+
+    const layer = createExternalNativeStoreLayer(
+      baseRegistration({ style: { fillColor: "#00ff00" } }),
+      existing,
+    );
+
+    assert.equal(layer.style.fillColor, "#00ff00");
+    assert.equal(layer.style.strokeWidth, 5);
+  });
+
+  it("applies the registration style over defaults for a brand-new layer", () => {
+    const layer = createExternalNativeStoreLayer(
+      baseRegistration({ style: { fillColor: "#123456" } }),
+    );
+
+    assert.equal(layer.style.fillColor, "#123456");
+    assert.equal(layer.style.strokeColor, DEFAULT_LAYER_STYLE.strokeColor);
+    assert.equal(layer.metadata?.externalNativeLayer, true);
+    assert.deepEqual(layer.metadata?.nativeLayerIds, [
+      "plugin-layer-fill",
+      "plugin-layer-outline",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

External plugins that load a styled GeoJSON layer through the plugin API saw their custom MapLibre colors reset to GeoLibre's default blue after a layer visibility/layer-control change, and the native style panel showed default blue values even when the plugin registered a custom style (#691).

## Root cause

A plugin's workflow creates the rendered layer with `addGeoJsonLayer` (which seeds the store layer with the full `DEFAULT_LAYER_STYLE`) and then calls `registerExternalNativeLayer` to attach its own style. `createExternalNativeStoreLayer` merged the styles as:

```
{ ...DEFAULT_LAYER_STYLE, ...registration.style, ...existing.style }
```

Because `existing.style` already contained the full default style and was merged **last**, it always overrode `registration.style`. The store layer therefore kept the default colors, so:

- The style panel reflected default blue fill/outline.
- `syncLayer` (which derives geojson paint from `layer.style`) re-applied the default paint to the rendered MapLibre layers on the next visibility/layer-control change.

## Fix

Merge `registration.style` last so the plugin-supplied style wins over the default-seeded existing style, while still preserving any user-edited keys the registration omits:

```
{ ...DEFAULT_LAYER_STYLE, ...existing.style, ...registration.style }
```

The same default-seeding bug applied to `opacity` (`addGeoJsonLayer` always seeds `opacity: 1`), so the merge now also prefers `registration.opacity ?? existing?.opacity ?? 1`. For these plugin-owned layers the registration's `style`/`opacity` win over an existing value (even a user edit) for the keys it supplies, and fall back to the existing value for keys it omits.

The helper is extracted into a pure `lib/external-native-layer.ts` module so it can be unit-tested directly.

## Verification

- New `tests/external-native-layer.test.ts` regression test (fails under the old merge order, passes now): registration style wins over a default-seeded existing style, user-edited keys are preserved when the registration omits them, and a brand-new layer gets the registration style over defaults.
- Full frontend suite (1340 tests) and `npm run build` pass.

Fixes #691

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Centralized creation logic for external native plugin layers to ensure consistent results across the app.

* **Bug Fixes**
  * Improved reconciliation of external native layer styling, visibility, and opacity with existing user-edited settings (preserving omitted style keys and applying provided overrides).
  * More reliable population of external native layer metadata.

* **Tests**
  * Added automated coverage for external native layer creation, including style precedence, visibility preservation, and expected metadata output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
