### PR TITLE
feat(time-slider): default an unspecified end date to the current date

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -74,7 +74,7 @@
     "maplibre-gl-raster": "^0.6.2",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.9.1",
-    "maplibre-gl-time-slider": "^1.0.3",
+    "maplibre-gl-time-slider": "^1.1.0",
     "maplibre-gl-usgs-lidar": "^0.11.0",
     "maplibre-gl-vector": "^0.6.0",
     "openai": "^6.39.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.9.1",
-        "maplibre-gl-time-slider": "^1.0.3",
+        "maplibre-gl-time-slider": "^1.1.0",
         "maplibre-gl-usgs-lidar": "^0.11.0",
         "maplibre-gl-vector": "^0.6.0",
         "openai": "^6.39.0",
@@ -17920,9 +17920,9 @@
       }
     },
     "node_modules/maplibre-gl-time-slider": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-time-slider/-/maplibre-gl-time-slider-1.0.3.tgz",
-      "integrity": "sha512-LvbNJXubbmuJvhSTnfQLHY2WMRdlglMV5rxHfD21HL9vzWTSAVAznFgTZfONjSN9t203JWrKq+/AKVFLskhLpQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-time-slider/-/maplibre-gl-time-slider-1.1.0.tgz",
+      "integrity": "sha512-x3NExYOo6UsDXRjmc4SUEjZj2YmcPtYasJ7D1wTQjVdFy+4lyTRkS6JLKcExqlPDHfM7CfqfNAaANbtgVy0tsw==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=5.14.0",
@@ -24322,7 +24322,7 @@
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
         "maplibre-gl-swipe": "^0.9.1",
-        "maplibre-gl-time-slider": "^1.0.3",
+        "maplibre-gl-time-slider": "^1.1.0",
         "maplibre-gl-usgs-lidar": "^0.11.0",
         "maplibre-gl-vector": "^0.6.0",
         "proj4": "^2.20.9",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -49,7 +49,7 @@
     "maplibre-gl-raster": "^0.6.2",
     "maplibre-gl-streetview": "^0.7.0",
     "maplibre-gl-swipe": "^0.9.1",
-    "maplibre-gl-time-slider": "^1.0.3",
+    "maplibre-gl-time-slider": "^1.1.0",
     "maplibre-gl-usgs-lidar": "^0.11.0",
     "maplibre-gl-vector": "^0.6.0",
     "proj4": "^2.20.9",

--- a/packages/plugins/src/plugins/maplibre-time-slider.ts
+++ b/packages/plugins/src/plugins/maplibre-time-slider.ts
@@ -280,8 +280,9 @@ function normalizeConfig(state: unknown): TimeSliderConfig | null {
     typeof candidate.startDate !== "string" ||
     // endDate is optional: an "open" range (defaulted to the current date) is
     // saved without it so reopening re-resolves the end to today. Reject only a
-    // present-but-non-string value.
-    (candidate.endDate !== undefined && typeof candidate.endDate !== "string") ||
+    // present, non-null value that is not a string (treat both an absent key and
+    // an explicit null as the open-end sentinel).
+    (candidate.endDate != null && typeof candidate.endDate !== "string") ||
     typeof candidate.granularity !== "string" ||
     (candidate.currentDate !== undefined &&
       typeof candidate.currentDate !== "string") ||
@@ -353,9 +354,10 @@ let lastBoundRangeKey: string | null = null;
 // their own range across a bind/unbind cycle.
 let preBindingRange: {
   start: string;
-  // null when the captured range had an "open" end (auto, defaulting to today);
-  // restored as null so setRange re-opens it instead of pinning the save value.
-  end: string | null;
+  // undefined when the captured range had an "open" end (auto, defaulting to
+  // today); restored as-is so setRange re-opens it instead of pinning the saved
+  // value (setRange treats a null/undefined end as open).
+  end: string | undefined;
   granularity: TimeBinding["granularity"];
 } | null = null;
 // Guards our own timeFilter writes from re-entering the store subscription.
@@ -467,7 +469,7 @@ function reconcileBoundLayers(control: TimeSliderControl): void {
         const config = control.getConfig();
         preBindingRange = {
           start: config.startDate,
-          end: config.endDate ?? null,
+          end: config.endDate,
           granularity: config.granularity,
         };
       }

--- a/packages/plugins/src/plugins/maplibre-time-slider.ts
+++ b/packages/plugins/src/plugins/maplibre-time-slider.ts
@@ -278,7 +278,10 @@ function normalizeConfig(state: unknown): TimeSliderConfig | null {
   const candidate = state as Partial<TimeSliderConfig>;
   if (
     typeof candidate.startDate !== "string" ||
-    typeof candidate.endDate !== "string" ||
+    // endDate is optional: an "open" range (defaulted to the current date) is
+    // saved without it so reopening re-resolves the end to today. Reject only a
+    // present-but-non-string value.
+    (candidate.endDate !== undefined && typeof candidate.endDate !== "string") ||
     typeof candidate.granularity !== "string" ||
     (candidate.currentDate !== undefined &&
       typeof candidate.currentDate !== "string") ||
@@ -350,7 +353,9 @@ let lastBoundRangeKey: string | null = null;
 // their own range across a bind/unbind cycle.
 let preBindingRange: {
   start: string;
-  end: string;
+  // null when the captured range had an "open" end (auto, defaulting to today);
+  // restored as null so setRange re-opens it instead of pinning the save value.
+  end: string | null;
   granularity: TimeBinding["granularity"];
 } | null = null;
 // Guards our own timeFilter writes from re-entering the store subscription.
@@ -462,7 +467,7 @@ function reconcileBoundLayers(control: TimeSliderControl): void {
         const config = control.getConfig();
         preBindingRange = {
           start: config.startDate,
-          end: config.endDate,
+          end: config.endDate ?? null,
           granularity: config.granularity,
         };
       }

--- a/packages/plugins/src/plugins/maplibre-time-slider.ts
+++ b/packages/plugins/src/plugins/maplibre-time-slider.ts
@@ -311,7 +311,10 @@ function normalizeConfig(state: unknown): TimeSliderConfig | null {
   ) {
     return null;
   }
-  return candidate as TimeSliderConfig;
+  // Normalize an open end to `undefined` (never `null`) so the open-end sentinel
+  // the library expects (`endDate?: string`) is honored even if a hand-edited
+  // project carried `"endDate": null`, rather than leaking null past the cast.
+  return { ...candidate, endDate: candidate.endDate ?? undefined } as TimeSliderConfig;
 }
 
 // Only sourceadd/sourceremove change the store's layer set. statechange also

--- a/tests/time-slider-config.test.ts
+++ b/tests/time-slider-config.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { maplibreTimeSliderPlugin } from "../packages/plugins/src/plugins/maplibre-time-slider";
+
+// applyProjectState / getProjectState touch no app methods while no control is
+// active (the plugin is never activated here), so a bare stub satisfies the type.
+const app = {} as Parameters<
+  NonNullable<typeof maplibreTimeSliderPlugin.applyProjectState>
+>[0];
+
+const apply = (state: unknown): boolean =>
+  maplibreTimeSliderPlugin.applyProjectState?.(app, state) ?? false;
+const saved = (): Record<string, unknown> | undefined =>
+  maplibreTimeSliderPlugin.getProjectState?.() as
+    | Record<string, unknown>
+    | undefined;
+
+function baseConfig(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    startDate: "2020-01-01T00:00:00.000Z",
+    interval: 1,
+    granularity: "year",
+    currentDate: "2020-01-01T00:00:00.000Z",
+    speed: 800,
+    loop: true,
+    sources: [],
+    ...overrides,
+  };
+}
+
+// Clear the plugin's persisted config between tests (no control is active, so a
+// null state simply resets savedConfig to null).
+afterEach(() => {
+  apply(null);
+});
+
+describe("Time Slider open-ended end date persistence", () => {
+  it("accepts a config with no endDate (open range) and saves it without one", () => {
+    assert.equal(apply(baseConfig()), true);
+    const config = saved();
+    assert.ok(config);
+    assert.equal("endDate" in config, false);
+  });
+
+  it("preserves an explicit endDate through a save round-trip", () => {
+    assert.equal(apply(baseConfig({ endDate: "2024-12-31T00:00:00.000Z" })), true);
+    assert.equal(saved()?.endDate, "2024-12-31T00:00:00.000Z");
+  });
+
+  it("treats an explicit null endDate as open and drops it on save", () => {
+    assert.equal(apply(baseConfig({ endDate: null })), true);
+    const config = saved();
+    assert.ok(config);
+    assert.equal("endDate" in config, false);
+  });
+
+  it("rejects a config whose endDate is present but not a string", () => {
+    assert.equal(apply(baseConfig({ endDate: 42 })), false);
+  });
+
+  it("rejects a config missing a startDate", () => {
+    const config = baseConfig();
+    delete config.startDate;
+    assert.equal(apply(config), false);
+  });
+});


### PR DESCRIPTION
## Summary

Makes the Time Slider's **end date optional**: when it is not specified, the timeline range now defaults to the **current date**, so users always see the most up-to-date imagery in a time series.

Critically, an unspecified end is persisted as **open** (not hardcoded). A saved `.geolibre.json` omits the `endDate`, and reopening the project **re-resolves the end to the then-current date** rather than the date it was saved. A published time-series project therefore keeps showing the latest data without ever being re-saved.

An end date the user **explicitly** sets (typed into the dock's Timeline form) is still treated as a fixed value and saved as before.

## Changes

- Bump `maplibre-gl-time-slider` to `^1.1.0` (opengeos/maplibre-gl-time-slider#21, released as [v1.1.0](https://github.com/opengeos/maplibre-gl-time-slider/releases/tag/v1.1.0)), which adds the optional/open-ended end date and a tooltip on the dock's "End date" field.
- `normalizeConfig`: accept a restored config with a missing `endDate` (the open range) instead of rejecting it.
- `preBindingRange`: carry an open (`null`) end through a Time-Slider bind/unbind cycle so a bound layer doesn't pin a previously open range to a concrete date.

## Verification

Drove the real app with Playwright (Time Slider plugin, both light and dark themes):

- Cleared the dock's "End date" field → the field stays blank (open) and the timeline axis now extends to **2026** (today).
- Round-tripped the plugin config (deactivate captures `getConfig()`, reactivate rebuilds) → the end stays open and re-resolves to 2026, confirming a saved project would re-resolve to the current date on reload.
- No console errors; the new End-date tooltip ("Leave blank to track the current date") renders.

Local gate: plugins package typechecks, `tests/time-slider-binding.test.ts` (17) passes, and `pre-commit run --files` (eslint + full `npm build`) passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated time slider component to better handle open-ended date ranges, improving reliability when restoring project configurations without specified end dates.
  * Upgraded underlying time slider library for enhanced functionality and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->