### PR TITLE
docs: add a How to Cite page with DOI and citation formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,6 +569,7 @@ Full documentation, including the User Guide and Tutorials, is published at
   - [UI Profiles](docs/ui-profiles.md)
   - [Python package (Jupyter)](docs/python.md)
   - [Roadmap](docs/roadmap.md)
+  - [How to Cite](docs/citation.md)
 
 ## Acknowledgements
 
@@ -577,6 +578,16 @@ GeoLibre is built on the free and open-source geospatial and web communities —
 - The **Atmosphere Effects** plugin (deep-space backdrop, parallax starfield, comets, and the globe atmosphere halo) adapts the technique and visual design from [Leonel Dias](https://leoneljdias.github.io/)'s article [*Globe atmosphere, halo, and comets*](https://leoneljdias.github.io/posts/globe-atmosphere-halo-comets/) — the layered Canvas 2D approach, the halo gradient and "screen" blend, the limb-sampling that keeps the halo aligned under pitch, and the starfield/comet parameters.
 - **Community contributors** — thanks to [**Ryanphoenix**](https://github.com/Ryanphoenix) for many valued contributions, including issue reports, feedback, and improvements.
 - **Beta testers** — thanks to [**René van der Velde**](https://github.com/renevandervelde) (Netherlands) for early testing, detailed bug reports, and feature requests.
+
+## Citation
+
+If you use GeoLibre in your work, please cite it. GeoLibre is archived on [Zenodo](https://zenodo.org/), which mints a DOI for every release. The concept DOI below always resolves to the latest version.
+
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20785400.svg)](https://doi.org/10.5281/zenodo.20785400)
+
+> Wu, Q. GeoLibre: A free and open-source, lightweight, cloud-native GIS platform. Zenodo. https://doi.org/10.5281/zenodo.20785400
+
+You can also use GitHub's **"Cite this repository"** button (which reads [`CITATION.cff`](CITATION.cff)) to copy a ready-made APA or BibTeX entry. See the [How to Cite](https://geolibre.app/citation/) page for more formats.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -585,7 +585,7 @@ If you use GeoLibre in your work, please cite it. GeoLibre is archived on [Zenod
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20785400.svg)](https://doi.org/10.5281/zenodo.20785400)
 
-> Wu, Q. GeoLibre: A free and open-source, lightweight, cloud-native GIS platform. Zenodo. https://doi.org/10.5281/zenodo.20785400
+> Wu, Q. (2026). GeoLibre: A free and open-source, lightweight, cloud-native GIS platform. Zenodo. <https://doi.org/10.5281/zenodo.20785400>
 
 You can also use GitHub's **"Cite this repository"** button (which reads [`CITATION.cff`](CITATION.cff)) to copy a ready-made APA or BibTeX entry. See the [How to Cite](https://geolibre.app/citation/) page for more formats.
 

--- a/README.md
+++ b/README.md
@@ -585,7 +585,7 @@ If you use GeoLibre in your work, please cite it. GeoLibre is archived on [Zenod
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20785400.svg)](https://doi.org/10.5281/zenodo.20785400)
 
-> Wu, Q. (2026). GeoLibre: A free and open-source, lightweight, cloud-native GIS platform. Zenodo. <https://doi.org/10.5281/zenodo.20785400>
+> Wu, Q. (2026). GeoLibre: A lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data. Zenodo. <https://doi.org/10.5281/zenodo.20785400>
 
 You can also use GitHub's **"Cite this repository"** button (which reads [`CITATION.cff`](CITATION.cff)) to copy a ready-made APA or BibTeX entry. See the [How to Cite](https://geolibre.app/citation/) page for more formats.
 

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -1,0 +1,53 @@
+# How to Cite
+
+If you use GeoLibre in your research, teaching, software, or other work, please
+cite it. Citations help others find the project, recognize the contributors,
+and support the continued development of free and open-source geospatial
+software.
+
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20785400.svg)](https://doi.org/10.5281/zenodo.20785400)
+
+GeoLibre is archived on [Zenodo](https://zenodo.org/), which mints a Digital
+Object Identifier (DOI) for every release. The DOI above is the **concept DOI**:
+it always resolves to the latest version. To cite a specific version instead,
+open the [Zenodo record](https://doi.org/10.5281/zenodo.20785400) and copy the
+DOI shown for that release.
+
+## Recommended citation
+
+> Wu, Q. GeoLibre: A free and open-source, lightweight, cloud-native GIS
+> platform. Zenodo. <https://doi.org/10.5281/zenodo.20785400>
+
+## BibTeX
+
+```bibtex
+@software{wu_geolibre,
+  author    = {Wu, Qiusheng},
+  title     = {{GeoLibre: A free and open-source, lightweight, cloud-native GIS platform}},
+  publisher = {Zenodo},
+  doi       = {10.5281/zenodo.20785400},
+  url       = {https://doi.org/10.5281/zenodo.20785400}
+}
+```
+
+## APA
+
+> Wu, Q. GeoLibre: A free and open-source, lightweight, cloud-native GIS
+> platform [Computer software]. Zenodo.
+> <https://doi.org/10.5281/zenodo.20785400>
+
+## Citation metadata file
+
+The repository ships a [`CITATION.cff`](https://github.com/opengeos/GeoLibre/blob/main/CITATION.cff)
+file, so you can also use GitHub's **"Cite this repository"** button (in the
+sidebar of the [repository page](https://github.com/opengeos/GeoLibre)) to copy
+a ready-made APA or BibTeX entry. Reference managers such as Zotero and tools
+like [`cffconvert`](https://github.com/citation-file-format/cffconvert) can read
+the same file.
+
+## Citing dependencies
+
+GeoLibre builds on many open-source projects. If your work relies heavily on a
+particular component, please consider citing it as well. See the
+[Acknowledgements](acknowledgements.md) page for the full list of projects that
+make GeoLibre possible.

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -15,7 +15,7 @@ DOI shown for that release.
 
 ## Recommended citation
 
-> Wu, Q. GeoLibre: A free and open-source, lightweight, cloud-native GIS
+> Wu, Q. (2026). GeoLibre: A free and open-source, lightweight, cloud-native GIS
 > platform. Zenodo. <https://doi.org/10.5281/zenodo.20785400>
 
 ## BibTeX
@@ -24,6 +24,7 @@ DOI shown for that release.
 @software{wu_geolibre,
   author    = {Wu, Qiusheng},
   title     = {{GeoLibre: A free and open-source, lightweight, cloud-native GIS platform}},
+  year      = {2026},
   publisher = {Zenodo},
   doi       = {10.5281/zenodo.20785400},
   url       = {https://doi.org/10.5281/zenodo.20785400}
@@ -32,7 +33,7 @@ DOI shown for that release.
 
 ## APA
 
-> Wu, Q. GeoLibre: A free and open-source, lightweight, cloud-native GIS
+> Wu, Q. (2026). GeoLibre: A free and open-source, lightweight, cloud-native GIS
 > platform [Computer software]. Zenodo.
 > <https://doi.org/10.5281/zenodo.20785400>
 

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -15,15 +15,16 @@ DOI shown for that release.
 
 ## Recommended citation
 
-> Wu, Q. (2026). GeoLibre: A free and open-source, lightweight, cloud-native GIS
-> platform. Zenodo. <https://doi.org/10.5281/zenodo.20785400>
+> Wu, Q. (2026). GeoLibre: A lightweight, cloud-native GIS platform for
+> visualizing, exploring, and analyzing geospatial data. Zenodo.
+> <https://doi.org/10.5281/zenodo.20785400>
 
 ## BibTeX
 
 ```bibtex
 @software{wu_geolibre,
   author    = {Wu, Qiusheng},
-  title     = {{GeoLibre: A free and open-source, lightweight, cloud-native GIS platform}},
+  title     = {{GeoLibre: A lightweight, cloud-native GIS platform for visualizing, exploring, and analyzing geospatial data}},
   year      = {2026},
   publisher = {Zenodo},
   doi       = {10.5281/zenodo.20785400},
@@ -33,9 +34,9 @@ DOI shown for that release.
 
 ## APA
 
-> Wu, Q. (2026). GeoLibre: A free and open-source, lightweight, cloud-native GIS
-> platform [Computer software]. Zenodo.
-> <https://doi.org/10.5281/zenodo.20785400>
+> Wu, Q. (2026). GeoLibre: A lightweight, cloud-native GIS platform for
+> visualizing, exploring, and analyzing geospatial data [Computer software].
+> Zenodo. <https://doi.org/10.5281/zenodo.20785400>
 
 ## Citation metadata file
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
       - Notebook Panel: notebook.md
       - Roadmap: roadmap.md
       - Contributing: contributing.md
+      - How to Cite: citation.md
       - Acknowledgements: acknowledgements.md
       - Privacy Policy: privacy.md
 


### PR DESCRIPTION
## Summary

Adds a citation section to the online documentation, as requested in #701. Previously the docs had no guidance on how to cite GeoLibre, even though the project is archived on Zenodo with a concept DOI.

## Changes

- **New `docs/citation.md` ("How to Cite")** page covering:
  - The Zenodo concept DOI badge (`10.5281/zenodo.20785400`), which always resolves to the latest version, with a note on how to cite a specific version instead.
  - Recommended citation text, plus **BibTeX** and **APA** formats.
  - A pointer to the existing [`CITATION.cff`](../blob/main/CITATION.cff) so users can use GitHub's "Cite this repository" button.
  - A note on citing dependencies, linking to the Acknowledgements page.
- Wired the page into the mkdocs **Reference** nav.
- Added a matching **Citation** section to the README (badge + short citation + link to the docs page), and a reference link in the README docs list.

## Verification

- `zensical build --strict` passes with no issues; the new page renders at `/citation/` and the nav link appears site-wide.
- `pre-commit run --files README.md mkdocs.yml docs/citation.md` passes.

Thanks to @ploewe for the suggestion and the citation-format examples.

Fixes #701

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added citation guidance, including Zenodo DOI behavior (concept DOI resolving to the latest release) and clear instructions for using version-specific DOIs
  * Added a new “Citation” section with ready-to-use example citation text (plain text, BibTeX, and APA) and a Zenodo DOI badge
  * Introduced a dedicated “How to Cite” page and linked it in the documentation navigation
  * Included pointers for dependency acknowledgements and where to find the full project list
<!-- end of auto-generated comment: release notes by coderabbit.ai -->