### PR TITLE
fix(dashboard): clarify empty-state copy on adding layers (#724)

### DIFF
--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1430,7 +1430,7 @@
     "widgetCount_one": "{{count}} widget",
     "widgetCount_other": "{{count}} widgets",
     "empty": "No widgets yet. Add a chart to summarize a layer.",
-    "emptyNoLayers": "Add a vector or DuckDB query layer to start building charts.",
+    "emptyNoLayers": "No compatible layers found. Add a vector or DuckDB query layer to your project using the Add Data menu above, then return here to start building charts.",
     "noLayersHint": "Add a vector or DuckDB query layer first.",
     "layerMissing": "Layer unavailable",
     "noData": "This layer has no chartable attributes.",


### PR DESCRIPTION
## Summary

The Dashboard panel's empty state previously showed "Add a vector or DuckDB query layer to start building charts.", which did not make clear that layers must be added via the main **Add Data** menu (not from inside the dashboard). Users could waste time looking for an import button in the dashboard that does not exist.

This updates the `dashboard.emptyNoLayers` copy to separate the data-loading step (Add Data menu) from the chart-building step (dashboard):

> No compatible layers found. Add a vector or DuckDB query layer to your project using the Add Data menu above, then return here to start building charts.

## Testing

- `node --import tsx --test tests/i18n-catalogs.test.ts` passes
- `pre-commit run --files apps/geolibre-desktop/src/i18n/locales/en.json` passes (includes npm build)

Fixes #724

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced the Dashboard's empty-state message to provide clearer instructions for adding vector or DuckDB query layers via the Add Data menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->