### PR TITLE
fix(dashboard): resize chart contents to the panel height (#728)

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/DashboardPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/DashboardPanel.tsx
@@ -37,6 +37,11 @@ const PANEL_RESIZE_END_EVENT = "geolibre:panel-resize-end";
 const MIN_DASHBOARD_HEIGHT = 160;
 const MAX_DASHBOARD_HEIGHT = 720;
 const DEFAULT_DASHBOARD_HEIGHT = 360;
+// When widgets wrap onto more than one row, each row is allowed to shrink only
+// down to this height before the panel scrolls vertically instead of crushing
+// the charts to nothing. A single row of widgets has no floor, so it always
+// fills (and resizes with) the panel height (issue #728).
+const MIN_DASHBOARD_ROW_HEIGHT = 200;
 
 /** Turn a stored widget into the render-side {@link ChartSpec}. */
 function widgetToSpec(widget: DashboardWidget): ChartSpec {
@@ -286,9 +291,19 @@ export function DashboardPanel() {
             </div>
           ) : (
             <div
-              className="grid gap-3"
+              className="grid h-full gap-3"
               style={{
                 gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+                // Rows divide the available height equally and shrink with the
+                // panel so charts resize instead of overflowing (issue #728).
+                gridAutoRows: "minmax(0, 1fr)",
+                // Once widgets wrap onto multiple rows, give each row a floor so
+                // they scroll rather than collapse; a single row stays unbounded
+                // and fills the panel.
+                minHeight:
+                  Math.ceil(widgets.length / columns) > 1
+                    ? `${Math.ceil(widgets.length / columns) * MIN_DASHBOARD_ROW_HEIGHT}px`
+                    : undefined,
               }}
             >
               {widgets.map((widget, index) => (
@@ -366,8 +381,8 @@ function WidgetCard({
   const title = widget.title?.trim() || defaultWidgetTitle();
 
   return (
-    <div className="flex flex-col gap-2 rounded-md border bg-background p-3">
-      <div className="flex items-center gap-2">
+    <div className="flex min-h-0 flex-col gap-2 overflow-hidden rounded-md border bg-background p-3">
+      <div className="flex shrink-0 items-center gap-2">
         <div className="min-w-0 flex-1">
           <div className="truncate text-sm font-medium" title={title}>
             {title}
@@ -422,13 +437,19 @@ function WidgetCard({
         </div>
       </div>
 
-      {data.hasData ? (
-        <ChartView result={result} color={widget.color} />
-      ) : (
-        <p className="py-8 text-center text-xs text-muted-foreground">
-          {t("dashboard.noData")}
-        </p>
-      )}
+      {/* The chart fills the card's remaining height and scales down with it:
+          the SVG becomes a flex child (min-h-0 lets it shrink past its
+          intrinsic aspect-ratio height) and its preserveAspectRatio letterboxes
+          rather than overflowing the panel (issue #728). */}
+      <div className="flex min-h-0 flex-1 flex-col [&_svg]:min-h-0 [&_svg]:flex-1">
+        {data.hasData ? (
+          <ChartView result={result} color={widget.color} />
+        ) : (
+          <p className="flex flex-1 items-center justify-center py-4 text-center text-xs text-muted-foreground">
+            {t("dashboard.noData")}
+          </p>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/geolibre-desktop/src/components/panels/DashboardPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/DashboardPanel.tsx
@@ -178,7 +178,8 @@ export function DashboardPanel() {
   const rowCount = Math.max(1, Math.ceil(widgets.length / Math.max(1, columns)));
   const gridMinHeight =
     rowCount > 1
-      ? `calc(${rowCount} * ${MIN_DASHBOARD_ROW_HEIGHT}px + ${rowCount - 1} * 0.75rem)`
+      ? // 0.75rem is gap-3; keep in sync if the grid's gap class changes.
+        `calc(${rowCount} * ${MIN_DASHBOARD_ROW_HEIGHT}px + ${rowCount - 1} * 0.75rem)`
       : undefined;
 
   return (
@@ -439,9 +440,10 @@ function WidgetCard({
         </div>
       </div>
 
-      {/* The chart SVG (a direct child) flexes to fill (min-h-0 lets it shrink
-          past its intrinsic aspect-ratio height); preserveAspectRatio
-          letterboxes it (issue #728). */}
+      {/* [&>svg] targets ChartView's chart SVG, which is a direct DOM child
+          (React Fragments emit no nodes): it flexes to fill, min-h-0 lets it
+          shrink past its intrinsic aspect-ratio height, and preserveAspectRatio
+          letterboxes it. Update this if a chart ever wraps its SVG (issue #728). */}
       <div className="flex min-h-0 flex-1 flex-col [&>svg]:min-h-0 [&>svg]:flex-1">
         {data.hasData ? (
           <ChartView result={result} color={widget.color} />

--- a/apps/geolibre-desktop/src/components/panels/DashboardPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/DashboardPanel.tsx
@@ -37,11 +37,11 @@ const PANEL_RESIZE_END_EVENT = "geolibre:panel-resize-end";
 const MIN_DASHBOARD_HEIGHT = 160;
 const MAX_DASHBOARD_HEIGHT = 720;
 const DEFAULT_DASHBOARD_HEIGHT = 360;
-// When widgets wrap onto more than one row, each row is allowed to shrink only
-// down to this height before the panel scrolls vertically instead of crushing
-// the charts to nothing. A single row of widgets has no floor, so it always
-// fills (and resizes with) the panel height (issue #728).
+// Per-row floor once widgets wrap onto multiple rows; below it the panel
+// scrolls instead of crushing the charts. A single row has no floor, so it
+// fills and resizes with the panel height (issue #728).
 const MIN_DASHBOARD_ROW_HEIGHT = 200;
+const DASHBOARD_ROW_GAP = 12; // matches the grid's gap-3 (0.75rem)
 
 /** Turn a stored widget into the render-side {@link ChartSpec}. */
 function widgetToSpec(widget: DashboardWidget): ChartSpec {
@@ -172,6 +172,15 @@ export function DashboardPanel() {
     }
   };
 
+  // When widgets wrap onto multiple rows, floor the grid height (rows plus the
+  // gaps between them) so it scrolls rather than crushing the charts; a single
+  // row stays unbounded and fills the panel (issue #728).
+  const rowCount = Math.max(1, Math.ceil(widgets.length / Math.max(1, columns)));
+  const gridMinHeight =
+    rowCount > 1
+      ? `${rowCount * MIN_DASHBOARD_ROW_HEIGHT + (rowCount - 1) * DASHBOARD_ROW_GAP}px`
+      : undefined;
+
   return (
     <section
       ref={sectionRef}
@@ -294,16 +303,9 @@ export function DashboardPanel() {
               className="grid h-full gap-3"
               style={{
                 gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
-                // Rows divide the available height equally and shrink with the
-                // panel so charts resize instead of overflowing (issue #728).
+                // Equal-height rows that shrink with the panel (issue #728).
                 gridAutoRows: "minmax(0, 1fr)",
-                // Once widgets wrap onto multiple rows, give each row a floor so
-                // they scroll rather than collapse; a single row stays unbounded
-                // and fills the panel.
-                minHeight:
-                  Math.ceil(widgets.length / columns) > 1
-                    ? `${Math.ceil(widgets.length / columns) * MIN_DASHBOARD_ROW_HEIGHT}px`
-                    : undefined,
+                minHeight: gridMinHeight,
               }}
             >
               {widgets.map((widget, index) => (
@@ -437,10 +439,8 @@ function WidgetCard({
         </div>
       </div>
 
-      {/* The chart fills the card's remaining height and scales down with it:
-          the SVG becomes a flex child (min-h-0 lets it shrink past its
-          intrinsic aspect-ratio height) and its preserveAspectRatio letterboxes
-          rather than overflowing the panel (issue #728). */}
+      {/* The SVG flexes to fill (min-h-0 lets it shrink past its intrinsic
+          aspect-ratio height); preserveAspectRatio letterboxes it (issue #728). */}
       <div className="flex min-h-0 flex-1 flex-col [&_svg]:min-h-0 [&_svg]:flex-1">
         {data.hasData ? (
           <ChartView result={result} color={widget.color} />

--- a/apps/geolibre-desktop/src/components/panels/DashboardPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/DashboardPanel.tsx
@@ -41,7 +41,9 @@ const DEFAULT_DASHBOARD_HEIGHT = 360;
 // scrolls instead of crushing the charts. A single row has no floor, so it
 // fills and resizes with the panel height (issue #728).
 const MIN_DASHBOARD_ROW_HEIGHT = 200;
-const DASHBOARD_ROW_GAP = 12; // matches the grid's gap-3 (0.75rem)
+// gap-3 = 0.75rem (12px at the default 16px root font); only nudges the
+// scroll-activation threshold, so an approximate px value is fine.
+const DASHBOARD_ROW_GAP = 12;
 
 /** Turn a stored widget into the render-side {@link ChartSpec}. */
 function widgetToSpec(widget: DashboardWidget): ChartSpec {

--- a/apps/geolibre-desktop/src/components/panels/DashboardPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/DashboardPanel.tsx
@@ -41,9 +41,6 @@ const DEFAULT_DASHBOARD_HEIGHT = 360;
 // scrolls instead of crushing the charts. A single row has no floor, so it
 // fills and resizes with the panel height (issue #728).
 const MIN_DASHBOARD_ROW_HEIGHT = 200;
-// gap-3 = 0.75rem (12px at the default 16px root font); only nudges the
-// scroll-activation threshold, so an approximate px value is fine.
-const DASHBOARD_ROW_GAP = 12;
 
 /** Turn a stored widget into the render-side {@link ChartSpec}. */
 function widgetToSpec(widget: DashboardWidget): ChartSpec {
@@ -175,12 +172,13 @@ export function DashboardPanel() {
   };
 
   // When widgets wrap onto multiple rows, floor the grid height (rows plus the
-  // gaps between them) so it scrolls rather than crushing the charts; a single
-  // row stays unbounded and fills the panel (issue #728).
+  // gap-3 gaps between them) so it scrolls rather than crushing the charts; a
+  // single row stays unbounded and fills the panel (issue #728). calc() lets
+  // the browser resolve 0.75rem so the gap tracks the root font size.
   const rowCount = Math.max(1, Math.ceil(widgets.length / Math.max(1, columns)));
   const gridMinHeight =
     rowCount > 1
-      ? `${rowCount * MIN_DASHBOARD_ROW_HEIGHT + (rowCount - 1) * DASHBOARD_ROW_GAP}px`
+      ? `calc(${rowCount} * ${MIN_DASHBOARD_ROW_HEIGHT}px + ${rowCount - 1} * 0.75rem)`
       : undefined;
 
   return (
@@ -441,9 +439,10 @@ function WidgetCard({
         </div>
       </div>
 
-      {/* The SVG flexes to fill (min-h-0 lets it shrink past its intrinsic
-          aspect-ratio height); preserveAspectRatio letterboxes it (issue #728). */}
-      <div className="flex min-h-0 flex-1 flex-col [&_svg]:min-h-0 [&_svg]:flex-1">
+      {/* The chart SVG (a direct child) flexes to fill (min-h-0 lets it shrink
+          past its intrinsic aspect-ratio height); preserveAspectRatio
+          letterboxes it (issue #728). */}
+      <div className="flex min-h-0 flex-1 flex-col [&>svg]:min-h-0 [&>svg]:flex-1">
         {data.hasData ? (
           <ChartView result={result} color={widget.color} />
         ) : (

--- a/apps/geolibre-desktop/src/components/panels/charts/chart-view.tsx
+++ b/apps/geolibre-desktop/src/components/panels/charts/chart-view.tsx
@@ -193,8 +193,9 @@ function yAxisTitle(text: string) {
 }
 
 function EmptyChart({ message }: { message: string }) {
-  // flex-1 centering matches the Dashboard's own no-data state so chart-level
-  // empty results center in a flexed card; it is a no-op in the Charts dialog.
+  // flex-1 only acts when the element grows (in the Dashboard's flexed card),
+  // where it centers the message like the panel's own no-data state; in the
+  // Charts dialog the <p> is simply a flex box around a single text node.
   return (
     <p className="flex flex-1 items-center justify-center py-10 text-center text-sm text-muted-foreground">
       {message}

--- a/apps/geolibre-desktop/src/components/panels/charts/chart-view.tsx
+++ b/apps/geolibre-desktop/src/components/panels/charts/chart-view.tsx
@@ -193,8 +193,12 @@ function yAxisTitle(text: string) {
 }
 
 function EmptyChart({ message }: { message: string }) {
+  // flex-1 centering matches the Dashboard's own no-data state so chart-level
+  // empty results center in a flexed card; it is a no-op in the Charts dialog.
   return (
-    <p className="py-10 text-center text-sm text-muted-foreground">{message}</p>
+    <p className="flex flex-1 items-center justify-center py-10 text-center text-sm text-muted-foreground">
+      {message}
+    </p>
   );
 }
 

--- a/apps/geolibre-desktop/src/components/panels/charts/chart-view.tsx
+++ b/apps/geolibre-desktop/src/components/panels/charts/chart-view.tsx
@@ -199,8 +199,12 @@ function EmptyChart({ message }: { message: string }) {
 }
 
 function Caption({ children }: { children: ReactNode }) {
+  // shrink-0 keeps the caption legible when the Dashboard flexes the chart SVG
+  // to fill a short panel; it is a no-op in the non-flex Charts dialog.
   return (
-    <p className="mt-1 text-center text-xs text-muted-foreground">{children}</p>
+    <p className="mt-1 shrink-0 text-center text-xs text-muted-foreground">
+      {children}
+    </p>
   );
 }
 


### PR DESCRIPTION
Fixes #728

## Problem

Dashboard chart widgets did not resize relative to the panel height. Each chart is an inline SVG with `h-auto`, so its height was derived from its width via the viewBox aspect ratio and never responded to the panel's height. Dragging the panel shorter clipped the charts to their tops and left the panel scrolling vertically instead of the charts shrinking to fit.

## Fix

- Each widget card is now a height-bounded flex column (`min-h-0 overflow-hidden`), and the chart SVG flexes to fill (and shrink within) the card. `preserveAspectRatio="xMidYMid meet"` (already on every chart) letterboxes the chart so it stays undistorted as it scales.
- The widget grid fills the panel with equal-height rows (`grid-auto-rows: minmax(0, 1fr)`), so a single row of charts resizes smoothly with the panel.
- When widgets wrap onto multiple rows, each row keeps a minimum height and the panel scrolls vertically rather than crushing the charts to nothing.

Most of the change is in `DashboardPanel.tsx`. Two small tweaks in the shared `chart-view.tsx` (a `shrink-0` on `Caption` and `flex flex-1 items-center justify-center` on `EmptyChart`) are designed as no-ops in the non-flex Charts dialog (`flex-1`/`shrink-0` only act on flex items/containers), so the dialog's intrinsic chart sizing is preserved.

## Verification

Drove the real app with Playwright using `us_cities.geojson` (histogram, box plot, and line widgets), in both light and dark themes:

- At normal/default panel heights the charts now fully fit and resize as the panel is dragged (no clipping, no overflow scroll).
- Single-row layout resizes down with the panel; multi-row layout (e.g. 1 column) keeps legible chart heights and scrolls.
- No new console errors. `npm run typecheck` (full build) and `pre-commit` (eslint + build) pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dashboard widget grid sizing so, when widgets wrap onto multiple rows, charts no longer vertically compress; the panel maintains proper scrolling behavior on smaller screens.
  * Improved widget card chart scaling so the chart SVG can shrink and fit reliably within the card layout.
  * Refined dashboard chart empty-state styling to center the placeholder more consistently and let it occupy available chart area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->