### PR TITLE
fix(vector): show labels for Add Vector Layer layers (#709)

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -76,7 +76,7 @@
     "maplibre-gl-swipe": "^0.9.1",
     "maplibre-gl-time-slider": "^1.1.0",
     "maplibre-gl-usgs-lidar": "^0.11.0",
-    "maplibre-gl-vector": "^0.6.0",
+    "maplibre-gl-vector": "^0.7.0",
     "openai": "^6.39.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
         "maplibre-gl-swipe": "^0.9.1",
         "maplibre-gl-time-slider": "^1.1.0",
         "maplibre-gl-usgs-lidar": "^0.11.0",
-        "maplibre-gl-vector": "^0.6.0",
+        "maplibre-gl-vector": "^0.7.0",
         "openai": "^6.39.0",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.7",
@@ -17963,9 +17963,9 @@
       }
     },
     "node_modules/maplibre-gl-vector": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.6.0.tgz",
-      "integrity": "sha512-UIRcR7eOz1KBHraA5uwrcg9XnVdeiqcwktciw8Gb46j//QifK6P0SQLYKikeLSfg+JHT93x1d9XUgwo41/2FGQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.7.0.tgz",
+      "integrity": "sha512-yaOclG9PjWkd1bHSrU84xCCnipeFEhwYVAmjPrg0x8GWk3zH7ozanyE2tm2OeFGY6XrS4pw6JlDsb5pGe/WBGQ==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"
@@ -24324,7 +24324,7 @@
         "maplibre-gl-swipe": "^0.9.1",
         "maplibre-gl-time-slider": "^1.1.0",
         "maplibre-gl-usgs-lidar": "^0.11.0",
-        "maplibre-gl-vector": "^0.6.0",
+        "maplibre-gl-vector": "^0.7.0",
         "proj4": "^2.20.9",
         "shpjs": "^6.2.0",
         "three": "^0.184.0"

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -51,7 +51,7 @@
     "maplibre-gl-swipe": "^0.9.1",
     "maplibre-gl-time-slider": "^1.1.0",
     "maplibre-gl-usgs-lidar": "^0.11.0",
-    "maplibre-gl-vector": "^0.6.0",
+    "maplibre-gl-vector": "^0.7.0",
     "proj4": "^2.20.9",
     "shpjs": "^6.2.0",
     "three": "^0.184.0"

--- a/packages/plugins/src/plugins/vector-layer-sync.ts
+++ b/packages/plugins/src/plugins/vector-layer-sync.ts
@@ -157,6 +157,12 @@ export function createVectorStoreLayer(
       ...(typeof info.featureCount === "number"
         ? { featureCount: info.featureCount }
         : {}),
+      // Attribute field names, so the Style panel can populate the label field
+      // (and other attribute-driven) dropdowns for a control-managed layer,
+      // which has no layer.geojson to read property keys from.
+      ...(info.fields && info.fields.length > 0
+        ? { fields: [...info.fields] }
+        : {}),
       ...(info.bbox ? { bounds: [...info.bbox] } : {}),
     },
     ...(sourcePath ? { sourcePath } : {}),
@@ -515,6 +521,36 @@ function savedVectorStyle(raw: unknown): Partial<VectorLayerStyle> | null {
     style.circleColorExpression = candidate.circleColorExpression;
   }
 
+  // Attribute labels. The field name is length-capped like the color strings
+  // (a real attribute name is short); the rest reuse the same color/number
+  // guards so a hand-edited project file cannot smuggle blobs into the symbol
+  // layer's paint/layout.
+  if (
+    typeof candidate.labelField === "string" &&
+    candidate.labelField &&
+    candidate.labelField.length <= 200
+  ) {
+    style.labelField = candidate.labelField;
+  }
+  if (positive(candidate.labelSize)) style.labelSize = candidate.labelSize;
+  if (color(candidate.labelColor)) style.labelColor = candidate.labelColor;
+  if (color(candidate.labelHaloColor)) {
+    style.labelHaloColor = candidate.labelHaloColor;
+  }
+  if (
+    typeof candidate.labelHaloWidth === "number" &&
+    Number.isFinite(candidate.labelHaloWidth) &&
+    candidate.labelHaloWidth >= 0
+  ) {
+    style.labelHaloWidth = candidate.labelHaloWidth;
+  }
+  if (candidate.labelPlacement === "point" || candidate.labelPlacement === "line") {
+    style.labelPlacement = candidate.labelPlacement;
+  }
+  if (typeof candidate.labelAllowOverlap === "boolean") {
+    style.labelAllowOverlap = candidate.labelAllowOverlap;
+  }
+
   return Object.keys(style).length > 0 ? style : null;
 }
 
@@ -565,6 +601,20 @@ function layerStyleToVectorStyle(style: LayerStyle): VectorLayerStyle {
     heatmapIntensity: style.heatmapIntensity,
     clusterRadius: style.clusterRadius,
     clusterMaxZoom: style.clusterMaxZoom,
+    // Attribute labels: GeoLibre's LabelStyle maps onto the control's flat
+    // label fields. The control renders the field's value as a symbol layer;
+    // an empty labelField clears it. (The expression-based override is not
+    // mapped — control layers label by field only.)
+    labelField:
+      style.labels.enabled && style.labels.field.trim() !== ""
+        ? style.labels.field
+        : "",
+    labelSize: style.labels.size,
+    labelColor: style.labels.color,
+    labelHaloColor: style.labels.haloColor,
+    labelHaloWidth: style.labels.haloWidth,
+    labelPlacement: style.labels.placement,
+    labelAllowOverlap: style.labels.allowOverlap,
   };
 }
 
@@ -624,6 +674,27 @@ function vectorStyleToLayerStyle(info: VectorLayerInfo): Partial<LayerStyle> {
     seed.clusterMaxZoom = style.clusterMaxZoom;
   }
 
+  // Reflect the control's attribute labels in the panel, so a restored project
+  // (whose label state was seeded into the control via savedVectorState) shows
+  // the Show-labels controls populated rather than reset to the defaults.
+  if (typeof style.labelField === "string" && style.labelField.trim() !== "") {
+    const defaults = DEFAULT_LAYER_STYLE.labels;
+    seed.labels = {
+      ...defaults,
+      enabled: true,
+      field: style.labelField,
+      size: typeof style.labelSize === "number" ? style.labelSize : defaults.size,
+      color: style.labelColor ?? defaults.color,
+      haloColor: style.labelHaloColor ?? defaults.haloColor,
+      haloWidth:
+        typeof style.labelHaloWidth === "number"
+          ? style.labelHaloWidth
+          : defaults.haloWidth,
+      placement: style.labelPlacement === "line" ? "line" : "point",
+      allowOverlap: style.labelAllowOverlap ?? defaults.allowOverlap,
+    };
+  }
+
   return seed;
 }
 
@@ -659,7 +730,17 @@ function vectorStylesEqual(
     left.heatmapRadius === right.heatmapRadius &&
     left.heatmapIntensity === right.heatmapIntensity &&
     left.clusterRadius === right.clusterRadius &&
-    left.clusterMaxZoom === right.clusterMaxZoom
+    left.clusterMaxZoom === right.clusterMaxZoom &&
+    // Label fields: a Show-labels toggle or any label restyle must register as
+    // a change so it is pushed to the control (which adds/updates/removes the
+    // symbol layer).
+    left.labelField === right.labelField &&
+    left.labelSize === right.labelSize &&
+    left.labelColor === right.labelColor &&
+    left.labelHaloColor === right.labelHaloColor &&
+    left.labelHaloWidth === right.labelHaloWidth &&
+    left.labelPlacement === right.labelPlacement &&
+    left.labelAllowOverlap === right.labelAllowOverlap
   );
 }
 

--- a/packages/plugins/src/plugins/vector-layer-sync.ts
+++ b/packages/plugins/src/plugins/vector-layer-sync.ts
@@ -524,7 +524,9 @@ function savedVectorStyle(raw: unknown): Partial<VectorLayerStyle> | null {
   // Attribute labels. The field name is length-capped like the color strings
   // (a real attribute name is short); the rest reuse the same color/number
   // guards so a hand-edited project file cannot smuggle blobs into the symbol
-  // layer's paint/layout.
+  // layer's paint/layout. Only the field-based label fields are persisted —
+  // LabelStyle.expression/.minZoom/.maxZoom are not mapped to the control (see
+  // layerStyleToVectorStyle), so persisting them here would have no effect.
   if (
     typeof candidate.labelField === "string" &&
     candidate.labelField &&
@@ -603,8 +605,15 @@ function layerStyleToVectorStyle(style: LayerStyle): VectorLayerStyle {
     clusterMaxZoom: style.clusterMaxZoom,
     // Attribute labels: GeoLibre's LabelStyle maps onto the control's flat
     // label fields. The control renders the field's value as a symbol layer;
-    // an empty labelField clears it. (The expression-based override is not
-    // mapped — control layers label by field only.)
+    // an empty labelField clears it.
+    //
+    // Only field-based labeling is wired here. LabelStyle.expression,
+    // .minZoom, and .maxZoom have no maplibre-gl-vector@0.7.0 equivalent, so
+    // they are intentionally left out of this mapping, out of vectorStylesEqual,
+    // and out of savedVectorStyle. The shared Style panel still shows those
+    // controls, but for a control-managed layer they are no-ops; adding them
+    // here later means also wiring the equality check, persistence, and the
+    // upstream control option.
     labelField:
       style.labels.enabled && style.labels.field.trim() !== ""
         ? style.labels.field
@@ -683,7 +692,13 @@ function vectorStyleToLayerStyle(info: VectorLayerInfo): Partial<LayerStyle> {
       ...defaults,
       enabled: true,
       field: style.labelField,
-      size: typeof style.labelSize === "number" ? style.labelSize : defaults.size,
+      // Guard with > 0 to match savedVectorStyle's positive() check, so a
+      // (never expected) labelSize of 0 from the control does not round-trip
+      // to an invisible-then-reset size.
+      size:
+        typeof style.labelSize === "number" && style.labelSize > 0
+          ? style.labelSize
+          : defaults.size,
       color: style.labelColor ?? defaults.color,
       haloColor: style.labelHaloColor ?? defaults.haloColor,
       haloWidth:

--- a/tests/vector-layer-sync.test.ts
+++ b/tests/vector-layer-sync.test.ts
@@ -217,6 +217,44 @@ describe("createVectorStoreLayer", () => {
     assert.equal(layer.source.type, "vector");
   });
 
+  it("exposes attribute field names in metadata for the Style panel", () => {
+    const layer = createVectorStoreLayer(
+      vectorInfo({ fields: ["name", "continent", "pop_est"] }),
+    );
+
+    assert.deepEqual(layer.metadata.fields, ["name", "continent", "pop_est"]);
+  });
+
+  it("omits metadata.fields when the control reports none", () => {
+    const layer = createVectorStoreLayer(vectorInfo({ fields: undefined }));
+    assert.equal("fields" in layer.metadata, false);
+  });
+
+  it("seeds the panel labels from the control's label style", () => {
+    const layer = createVectorStoreLayer(
+      vectorInfo({
+        style: vectorStyle({
+          labelField: "name",
+          labelSize: 18,
+          labelColor: "#ff0000",
+          labelPlacement: "line",
+        }),
+      }),
+    );
+
+    assert.equal(layer.style.labels.enabled, true);
+    assert.equal(layer.style.labels.field, "name");
+    assert.equal(layer.style.labels.size, 18);
+    assert.equal(layer.style.labels.color, "#ff0000");
+    assert.equal(layer.style.labels.placement, "line");
+  });
+
+  it("leaves labels disabled when the control has no label field", () => {
+    const layer = createVectorStoreLayer(vectorInfo());
+    assert.equal(layer.style.labels.enabled, false);
+    assert.equal(layer.style.labels.field, "");
+  });
+
   it("persists the load and style state", () => {
     const layer = createVectorStoreLayer(
       vectorInfo({
@@ -552,6 +590,15 @@ describe("wireVectorStoreSync", () => {
       heatmapIntensity: 1,
       clusterRadius: 50,
       clusterMaxZoom: 14,
+      // Label fields default through from DEFAULT_LAYER_STYLE.labels; labelField
+      // is empty because labels start disabled.
+      labelField: "",
+      labelSize: 13,
+      labelColor: "#111827",
+      labelHaloColor: "#ffffff",
+      labelHaloWidth: 1.5,
+      labelPlacement: "point",
+      labelAllowOverlap: false,
     };
     assert.deepEqual(calls, [
       { method: "setLayerStyle", args: ["vector-1", expectedStyle] },
@@ -644,6 +691,44 @@ describe("wireVectorStoreSync", () => {
     assert.equal(reverted.fillColorExpression, undefined);
     assert.equal(reverted.lineColorExpression, undefined);
     assert.equal(reverted.circleColorExpression, undefined);
+  });
+
+  it("pushes a Show-labels toggle through the control", () => {
+    const { control, calls } = fakeControl([vectorInfo()]);
+    syncVectorLayersToStore(control);
+    wireVectorStoreSync(control);
+
+    useAppStore.getState().setLayerStyle("vector-1", {
+      labels: {
+        ...DEFAULT_LAYER_STYLE.labels,
+        enabled: true,
+        field: "name",
+        size: 18,
+      },
+    });
+
+    assert.equal(calls.length, 1);
+    const pushed = calls[0].args[1] as VectorLayerStyle;
+    assert.equal(pushed.labelField, "name");
+    assert.equal(pushed.labelSize, 18);
+  });
+
+  it("clears the control label field when labels are disabled", () => {
+    const { control, calls } = fakeControl([
+      vectorInfo({ style: vectorStyle({ labelField: "name" }) }),
+    ]);
+    syncVectorLayersToStore(control);
+    wireVectorStoreSync(control);
+
+    // The layer was seeded with labels on; turning the checkbox off must push an
+    // empty labelField so the control removes its symbol layer.
+    useAppStore.getState().setLayerStyle("vector-1", {
+      labels: { ...DEFAULT_LAYER_STYLE.labels, enabled: false, field: "name" },
+    });
+
+    assert.equal(calls.length, 1);
+    const pushed = calls[0].args[1] as VectorLayerStyle;
+    assert.equal(pushed.labelField, "");
   });
 
   it("does not touch the control for GeoLibre-only style fields", () => {
@@ -765,6 +850,47 @@ describe("savedVectorState", () => {
     assert.deepEqual(restored.circleColorExpression, matchExpr);
     // No lineColorExpression was persisted, so none is restored.
     assert.equal("lineColorExpression" in restored, false);
+  });
+
+  it("restores attribute label fields from the persisted style", () => {
+    const layer = createVectorStoreLayer(vectorInfo());
+    (layer.metadata.vectorState as Record<string, unknown>).style = {
+      ...vectorStyle(),
+      labelField: "name",
+      labelSize: 18,
+      labelColor: "#ff0000",
+      labelHaloColor: "#000000",
+      labelHaloWidth: 2,
+      labelPlacement: "line",
+      labelAllowOverlap: true,
+    };
+
+    const restored = savedVectorState(layer).style;
+    assert.ok(restored != null);
+    assert.equal(restored.labelField, "name");
+    assert.equal(restored.labelSize, 18);
+    assert.equal(restored.labelColor, "#ff0000");
+    assert.equal(restored.labelHaloColor, "#000000");
+    assert.equal(restored.labelHaloWidth, 2);
+    assert.equal(restored.labelPlacement, "line");
+    assert.equal(restored.labelAllowOverlap, true);
+  });
+
+  it("drops a malformed label field from a hand-edited project file", () => {
+    const layer = createVectorStoreLayer(vectorInfo());
+    (layer.metadata.vectorState as Record<string, unknown>).style = {
+      fillColor: "#123456",
+      labelField: "x".repeat(201),
+      labelPlacement: "diagonal",
+      labelHaloWidth: -3,
+    };
+
+    const restored = savedVectorState(layer).style;
+    assert.ok(restored != null);
+    assert.equal(restored.fillColor, "#123456");
+    assert.equal("labelField" in restored, false);
+    assert.equal("labelPlacement" in restored, false);
+    assert.equal("labelHaloWidth" in restored, false);
   });
 
   it("drops a malformed color expression without throwing", () => {


### PR DESCRIPTION
## Problem

Fixes #709. The Style panel's **Show labels** worked for vector layers added via drag-and-drop (and CSV lat/lon) but did nothing for layers added through **Add Vector Layer** (the Load sample data link, a picked file, or a URL), e.g. the Countries sample.

## Root cause

Add Vector Layer layers are owned by the `maplibre-gl-vector` control. In the store they are marked `externalNativeLayer`, so `syncLayer` routes them to `syncExternalNativeLayer` and they never reach `syncGeoJsonLayer`, which is the only place attribute labels are rendered. On top of that, the label-field dropdown was always empty for these layers: it reads field names from `layer.geojson` (which control layers don't carry) and the control exposed no attribute list.

## Fix

The control owns its layers' paint, so labels belong upstream. `maplibre-gl-vector` **0.7.0** ([opengeos/maplibre-gl-vector#28](https://github.com/opengeos/maplibre-gl-vector/pull/28)) adds an attribute label layer (`labelField` + size/color/halo/placement/overlap) and exposes `VectorLayerInfo.fields`. This PR consumes it:

- **`layerStyleToVectorStyle`** maps the panel's `LabelStyle` onto the control's label fields, and **`vectorStylesEqual`** compares them so a Show-labels toggle or any label restyle is pushed to the control.
- **`createVectorStoreLayer`** surfaces the control's attribute names as `metadata.fields`, so the label-field dropdown (which reads `metadata.fields` when there is no `layer.geojson`) populates.
- **`vectorStyleToLayerStyle`** seeds the panel's `labels` from the control's style, and **`savedVectorStyle`** round-trips the label fields, so a saved project restores labels.
- Bumps `maplibre-gl-vector` to `^0.7.0` in `apps/geolibre-desktop` and `packages/plugins`.

Note: control layers label by **field** (the common case). The advanced expression-based label override is not mapped for these layers.

## Tests

`tests/vector-layer-sync.test.ts` gains coverage for `metadata.fields` exposure, label seeding, the Show-labels push/clear path, and label persistence round-trip (48 passing). Full build and pre-commit pass.

## Verification

Drove the real app with the published `maplibre-gl-vector@0.7.0`: loaded the **Countries** sample via Add Vector Layer, confirmed the label-field dropdown populates from the layer's 71 attributes, selected a field, and confirmed labels render on the map and toggle cleanly with Show labels, in both light and dark themes.