### PR TITLE
feat(onboarding): suppress welcome wizard for embeds (?url= deep links and ?welcome=0)

### DIFF
--- a/apps/geolibre-desktop/src/hooks/useProjectUrlLoader.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectUrlLoader.ts
@@ -88,7 +88,7 @@ async function loadProjectFromUrl(projectUrl: string, signal: AbortSignal) {
   return parseProject(await response.text());
 }
 
-function projectUrlFromLocation(): string | null {
+export function projectUrlFromLocation(): string | null {
   if (typeof window === "undefined") return null;
 
   const search = window.location.search;

--- a/apps/geolibre-desktop/src/hooks/useProjectUrlLoader.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectUrlLoader.ts
@@ -1,14 +1,12 @@
 import { parseProject, useAppStore } from "@geolibre/core";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { normalizeProjectUrl } from "../lib/urls";
+import { projectUrlFromLocation } from "../lib/project-url";
 import { resolveProjectXyzLayers } from "../lib/xyz-url";
 
 export type ProjectUrlLoadState =
   | { error: null; message: null; status: "idle" }
   | { error: null; message: string; status: "loading" | "loaded" }
   | { error: string; message: null; status: "error" };
-
-const PROJECT_URL_PARAMS = ["url", "project", "projectUrl", "project_url"];
 
 export function useProjectUrlLoader(): ProjectUrlLoadState {
   const loadProject = useAppStore((state) => state.loadProject);
@@ -86,31 +84,4 @@ async function loadProjectFromUrl(projectUrl: string, signal: AbortSignal) {
   }
 
   return parseProject(await response.text());
-}
-
-export function projectUrlFromLocation(): string | null {
-  if (typeof window === "undefined") return null;
-
-  const search = window.location.search;
-  const params = new URLSearchParams(search);
-  for (const key of PROJECT_URL_PARAMS) {
-    const value = params.get(key);
-    const url = normalizeProjectUrl(value);
-    if (url) return url;
-  }
-
-  const bareQuery = search.startsWith("?")
-    ? safeDecodeURIComponent(search.slice(1)).trim()
-    : "";
-  return /^https?:\/\//i.test(bareQuery)
-    ? normalizeProjectUrl(bareQuery)
-    : null;
-}
-
-function safeDecodeURIComponent(value: string): string {
-  try {
-    return decodeURIComponent(value);
-  } catch {
-    return value;
-  }
 }

--- a/apps/geolibre-desktop/src/hooks/useUiProfileBootstrap.ts
+++ b/apps/geolibre-desktop/src/hooks/useUiProfileBootstrap.ts
@@ -46,10 +46,17 @@ export function useUiProfileBootstrap(): {
     (state) => state.desktopSettings.uiProfile,
   );
 
-  // A `?url=` deep link (e.g. the viewer.geolibre.app embed) opens straight into
-  // a shared project, so the first-launch onboarding wizard would just get in
-  // the way. Computed once: the location does not change during a session.
-  const hasProjectDeepLink = useMemo(() => projectUrlFromLocation() !== null, []);
+  // Suppress the first-launch onboarding wizard when the app is opened as an
+  // embed/deep link, where the modal would just cover the map:
+  //   - a `?url=` deep link (e.g. viewer.geolibre.app) opens straight into a
+  //     shared project, or
+  //   - an explicit `?welcome=0` (also `false`/`off`/`no`) opts out, for embeds
+  //     that don't load a project URL but still want a clean first paint.
+  // Computed once: the location does not change during a session.
+  const suppressOnboarding = useMemo(
+    () => projectUrlFromLocation() !== null || welcomeDisabledByParam(),
+    [],
+  );
 
   // One-time admin-profile check. Built-in plugins are registered synchronously
   // at module load, so they are all present here; externally-loaded plugins are
@@ -124,7 +131,7 @@ export function useUiProfileBootstrap(): {
     adminChecked &&
     !uiProfile.onboarded &&
     !uiProfile.locked &&
-    !hasProjectDeepLink;
+    !suppressOnboarding;
 
   // Marks onboarding complete when the wizard is dismissed without a choice
   // (Escape/overlay). The wizard's own buttons set `onboarded` first, so this is
@@ -139,4 +146,20 @@ export function useUiProfileBootstrap(): {
   }, []);
 
   return { showOnboarding, dismissOnboarding };
+}
+
+// Values of `?welcome=` that turn the first-launch wizard off.
+const WELCOME_DISABLED_VALUES = new Set(["0", "false", "off", "no"]);
+
+/**
+ * Whether the URL explicitly opts out of the first-launch onboarding wizard via
+ * `?welcome=0` (also `false`, `off`, or `no`). Lets an embed suppress the modal
+ * without depending on a `?url=` project deep link.
+ *
+ * @returns True when a falsy `welcome` query parameter is present.
+ */
+function welcomeDisabledByParam(): boolean {
+  if (typeof window === "undefined") return false;
+  const value = new URLSearchParams(window.location.search).get("welcome");
+  return value !== null && WELCOME_DISABLED_VALUES.has(value.trim().toLowerCase());
 }

--- a/apps/geolibre-desktop/src/hooks/useUiProfileBootstrap.ts
+++ b/apps/geolibre-desktop/src/hooks/useUiProfileBootstrap.ts
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useMemo } from "react";
 import { create } from "zustand";
 import { loadAdminProfile } from "../lib/admin-profile";
+import { shouldSuppressOnboarding } from "../lib/onboarding-suppression";
 import { presetHiddenSets, toggleablePluginIds } from "../lib/ui-profile";
 import { usePluginRegistry } from "./usePlugins";
-import { projectUrlFromLocation } from "./useProjectUrlLoader";
 import { useDesktopSettingsStore } from "./useDesktopSettings";
 
 // Whether the one-time admin-profile check has finished. Kept in its own store
@@ -47,16 +47,9 @@ export function useUiProfileBootstrap(): {
   );
 
   // Suppress the first-launch onboarding wizard when the app is opened as an
-  // embed/deep link, where the modal would just cover the map:
-  //   - a `?url=` deep link (e.g. viewer.geolibre.app) opens straight into a
-  //     shared project, or
-  //   - an explicit `?welcome=0` (also `false`/`off`/`no`) opts out, for embeds
-  //     that don't load a project URL but still want a clean first paint.
-  // Computed once: the location does not change during a session.
-  const suppressOnboarding = useMemo(
-    () => projectUrlFromLocation() !== null || welcomeDisabledByParam(),
-    [],
-  );
+  // embed/deep link (see `shouldSuppressOnboarding`). Computed once: the
+  // location does not change during a session.
+  const suppressOnboarding = useMemo(() => shouldSuppressOnboarding(), []);
 
   // One-time admin-profile check. Built-in plugins are registered synchronously
   // at module load, so they are all present here; externally-loaded plugins are
@@ -146,20 +139,4 @@ export function useUiProfileBootstrap(): {
   }, []);
 
   return { showOnboarding, dismissOnboarding };
-}
-
-// Values of `?welcome=` that turn the first-launch wizard off.
-const WELCOME_DISABLED_VALUES = new Set(["0", "false", "off", "no"]);
-
-/**
- * Whether the URL explicitly opts out of the first-launch onboarding wizard via
- * `?welcome=0` (also `false`, `off`, or `no`). Lets an embed suppress the modal
- * without depending on a `?url=` project deep link.
- *
- * @returns True when a falsy `welcome` query parameter is present.
- */
-function welcomeDisabledByParam(): boolean {
-  if (typeof window === "undefined") return false;
-  const value = new URLSearchParams(window.location.search).get("welcome");
-  return value !== null && WELCOME_DISABLED_VALUES.has(value.trim().toLowerCase());
 }

--- a/apps/geolibre-desktop/src/hooks/useUiProfileBootstrap.ts
+++ b/apps/geolibre-desktop/src/hooks/useUiProfileBootstrap.ts
@@ -1,8 +1,9 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { create } from "zustand";
 import { loadAdminProfile } from "../lib/admin-profile";
 import { presetHiddenSets, toggleablePluginIds } from "../lib/ui-profile";
 import { usePluginRegistry } from "./usePlugins";
+import { projectUrlFromLocation } from "./useProjectUrlLoader";
 import { useDesktopSettingsStore } from "./useDesktopSettings";
 
 // Whether the one-time admin-profile check has finished. Kept in its own store
@@ -44,6 +45,11 @@ export function useUiProfileBootstrap(): {
   const uiProfile = useDesktopSettingsStore(
     (state) => state.desktopSettings.uiProfile,
   );
+
+  // A `?url=` deep link (e.g. the viewer.geolibre.app embed) opens straight into
+  // a shared project, so the first-launch onboarding wizard would just get in
+  // the way. Computed once: the location does not change during a session.
+  const hasProjectDeepLink = useMemo(() => projectUrlFromLocation() !== null, []);
 
   // One-time admin-profile check. Built-in plugins are registered synchronously
   // at module load, so they are all present here; externally-loaded plugins are
@@ -115,7 +121,10 @@ export function useUiProfileBootstrap(): {
   // Derived from store state so completing/dismissing onboarding (which sets
   // `onboarded`) hides the wizard without extra local state.
   const showOnboarding =
-    adminChecked && !uiProfile.onboarded && !uiProfile.locked;
+    adminChecked &&
+    !uiProfile.onboarded &&
+    !uiProfile.locked &&
+    !hasProjectDeepLink;
 
   // Marks onboarding complete when the wizard is dismissed without a choice
   // (Escape/overlay). The wizard's own buttons set `onboarded` first, so this is

--- a/apps/geolibre-desktop/src/lib/onboarding-suppression.ts
+++ b/apps/geolibre-desktop/src/lib/onboarding-suppression.ts
@@ -1,0 +1,33 @@
+import { projectUrlFromLocation } from "./project-url";
+
+// Values of `?welcome=` that turn the first-launch wizard off.
+const WELCOME_DISABLED_VALUES = new Set(["0", "false", "off", "no"]);
+
+/**
+ * Whether to suppress the first-launch onboarding wizard because the app is
+ * opened as an embed/deep link, where the modal would just cover the map:
+ *   - a `?url=` deep link (e.g. viewer.geolibre.app) opens straight into a
+ *     shared project, or
+ *   - an explicit `?welcome=0` (also `false`/`off`/`no`) opts out, for embeds
+ *     that don't load a project URL but still want a clean first paint.
+ *
+ * @returns True when the onboarding wizard should not be shown.
+ */
+export function shouldSuppressOnboarding(): boolean {
+  return projectUrlFromLocation() !== null || welcomeDisabledByParam();
+}
+
+/**
+ * Whether the URL explicitly opts out of the first-launch onboarding wizard via
+ * `?welcome=0` (also `false`, `off`, or `no`). Lets an embed suppress the modal
+ * without depending on a `?url=` project deep link.
+ *
+ * @returns True when a falsy `welcome` query parameter is present.
+ */
+function welcomeDisabledByParam(): boolean {
+  if (typeof window === "undefined") return false;
+  const value = new URLSearchParams(window.location.search).get("welcome");
+  return (
+    value !== null && WELCOME_DISABLED_VALUES.has(value.trim().toLowerCase())
+  );
+}

--- a/apps/geolibre-desktop/src/lib/onboarding-suppression.ts
+++ b/apps/geolibre-desktop/src/lib/onboarding-suppression.ts
@@ -1,4 +1,4 @@
-import { projectUrlFromLocation } from "./project-url";
+import { PROJECT_URL_PARAMS, projectUrlFromLocation } from "./project-url";
 
 // Values of `?welcome=` that turn the first-launch wizard off.
 const WELCOME_DISABLED_VALUES = new Set(["0", "false", "off", "no"]);
@@ -6,15 +6,31 @@ const WELCOME_DISABLED_VALUES = new Set(["0", "false", "off", "no"]);
 /**
  * Whether to suppress the first-launch onboarding wizard because the app is
  * opened as an embed/deep link, where the modal would just cover the map:
- *   - a `?url=` deep link (e.g. viewer.geolibre.app) opens straight into a
- *     shared project, or
+ *   - a project deep link (e.g. viewer.geolibre.app `?url=`) opens straight
+ *     into a shared project, or
  *   - an explicit `?welcome=0` (also `false`/`off`/`no`) opts out, for embeds
  *     that don't load a project URL but still want a clean first paint.
  *
  * @returns True when the onboarding wizard should not be shown.
  */
 export function shouldSuppressOnboarding(): boolean {
-  return projectUrlFromLocation() !== null || welcomeDisabledByParam();
+  return hasProjectDeepLinkIntent() || welcomeDisabledByParam();
+}
+
+/**
+ * Whether the URL signals an intent to open a project deep link. A recognized
+ * project-URL param key (`?url=`, `?project=`, ...) counts even when its value
+ * fails to resolve, so the onboarding modal never layers on top of the load
+ * error `useProjectUrlLoader` shows for a bad link; otherwise a valid bare
+ * `?https://...` project URL also counts.
+ *
+ * @returns True when a project deep link was requested.
+ */
+function hasProjectDeepLinkIntent(): boolean {
+  if (typeof window === "undefined") return false;
+  const params = new URLSearchParams(window.location.search);
+  if (PROJECT_URL_PARAMS.some((key) => params.has(key))) return true;
+  return projectUrlFromLocation() !== null;
 }
 
 /**

--- a/apps/geolibre-desktop/src/lib/project-url.ts
+++ b/apps/geolibre-desktop/src/lib/project-url.ts
@@ -1,0 +1,41 @@
+import { normalizeProjectUrl } from "./urls";
+
+// Query parameters that carry a `.geolibre.json` project URL deep link. A bare
+// `?https://...` query (no key) is also accepted by `projectUrlFromLocation`.
+export const PROJECT_URL_PARAMS = ["url", "project", "projectUrl", "project_url"];
+
+/**
+ * Reads a `.geolibre.json` project URL from the current `window.location` query
+ * string, if one is present.
+ *
+ * Accepts any of {@link PROJECT_URL_PARAMS} or a bare `?https://...` query, and
+ * normalizes the value via `normalizeProjectUrl` (absolute http/https only).
+ *
+ * @returns The normalized project URL, or `null` when none is present or valid.
+ */
+export function projectUrlFromLocation(): string | null {
+  if (typeof window === "undefined") return null;
+
+  const search = window.location.search;
+  const params = new URLSearchParams(search);
+  for (const key of PROJECT_URL_PARAMS) {
+    const value = params.get(key);
+    const url = normalizeProjectUrl(value);
+    if (url) return url;
+  }
+
+  const bareQuery = search.startsWith("?")
+    ? safeDecodeURIComponent(search.slice(1)).trim()
+    : "";
+  return /^https?:\/\//i.test(bareQuery)
+    ? normalizeProjectUrl(bareQuery)
+    : null;
+}
+
+function safeDecodeURIComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}

--- a/docs/user-guide/embedding.md
+++ b/docs/user-guide/embedding.md
@@ -28,6 +28,7 @@ A chrome-free `maponly` embed shows only the map, as in this shared 3D Tiles pro
 | `panels` | `panels=none` | Hides the Layers, Style, and Attribute table panels. `hidden`, `hide`, and `off` are aliases. |
 | `hidePanels` | `hidePanels=true` | Alternative way to hide those panels. |
 | `maponly` | `maponly` | Hides all chrome (toolbar, panels, and status bar), leaving only the map. The bare flag or `true`, `1`, `yes`, `on` enable it. |
+| `welcome` | `welcome=0` | Hides the first-launch welcome wizard. Accepts `0`, `false`, `off`, or `no`. A `url=` deep link already suppresses it automatically. |
 | `theme` | `theme=dark` | Sets the initial color theme, overriding the OS preference. Accepts `dark` or `light`; the in-app toggle still works afterward. |
 
 Parameters combine. For a narrow, chrome-free, dark embed of a shared project:

--- a/tests/onboarding-suppression.test.ts
+++ b/tests/onboarding-suppression.test.ts
@@ -44,10 +44,12 @@ describe("shouldSuppressOnboarding", () => {
     }
   });
 
-  it("keeps the wizard for truthy or absent welcome values", () => {
-    for (const value of ["1", "true", "on", "yes"]) {
-      withSearch(`?welcome=${value}`);
-      assert.equal(shouldSuppressOnboarding(), false, `welcome=${value}`);
+  it("keeps the wizard for truthy, empty, or bare welcome values", () => {
+    // An empty `?welcome=` or a bare `?welcome` flag is a no-op (unlike
+    // `?maponly`), so the wizard still shows.
+    for (const search of ["?welcome=1", "?welcome=true", "?welcome=on", "?welcome=yes", "?welcome=", "?welcome"]) {
+      withSearch(search);
+      assert.equal(shouldSuppressOnboarding(), false, search);
     }
   });
 

--- a/tests/onboarding-suppression.test.ts
+++ b/tests/onboarding-suppression.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { shouldSuppressOnboarding } from "../apps/geolibre-desktop/src/lib/onboarding-suppression";
+
+const originalWindow = (globalThis as { window?: unknown }).window;
+
+function withSearch(search: string): void {
+  (globalThis as { window?: unknown }).window = {
+    location: { search },
+  };
+}
+
+afterEach(() => {
+  if (originalWindow === undefined) {
+    delete (globalThis as { window?: unknown }).window;
+  } else {
+    (globalThis as { window?: unknown }).window = originalWindow;
+  }
+});
+
+describe("shouldSuppressOnboarding", () => {
+  it("shows the wizard with no query params", () => {
+    withSearch("");
+    assert.equal(shouldSuppressOnboarding(), false);
+  });
+
+  it("suppresses the wizard for every deep-link param form", () => {
+    const project = "https://example.com/foo.geolibre.json";
+    for (const key of ["url", "project", "projectUrl", "project_url"]) {
+      withSearch(`?${key}=${encodeURIComponent(project)}`);
+      assert.equal(shouldSuppressOnboarding(), true, key);
+    }
+  });
+
+  it("suppresses the wizard for a bare URL query", () => {
+    withSearch(`?${encodeURIComponent("https://example.com/foo.geolibre.json")}`);
+    assert.equal(shouldSuppressOnboarding(), true);
+  });
+
+  it("suppresses the wizard for falsy welcome values", () => {
+    for (const value of ["0", "false", "off", "no", "FALSE", " off "]) {
+      withSearch(`?welcome=${encodeURIComponent(value)}`);
+      assert.equal(shouldSuppressOnboarding(), true, `welcome=${value}`);
+    }
+  });
+
+  it("keeps the wizard for truthy or absent welcome values", () => {
+    for (const value of ["1", "true", "on", "yes"]) {
+      withSearch(`?welcome=${value}`);
+      assert.equal(shouldSuppressOnboarding(), false, `welcome=${value}`);
+    }
+  });
+
+  it("shows the wizard when window is undefined (SSR)", () => {
+    delete (globalThis as { window?: unknown }).window;
+    assert.equal(shouldSuppressOnboarding(), false);
+  });
+});

--- a/tests/onboarding-suppression.test.ts
+++ b/tests/onboarding-suppression.test.ts
@@ -37,6 +37,21 @@ describe("shouldSuppressOnboarding", () => {
     assert.equal(shouldSuppressOnboarding(), true);
   });
 
+  it("suppresses the wizard when a deep-link param key holds an invalid URL", () => {
+    // The intent to open a project (a recognized key is present) suppresses
+    // onboarding even if the value does not resolve, so the wizard never layers
+    // on top of the load error useProjectUrlLoader shows for a bad link.
+    for (const search of ["?url=not-a-valid-url", "?project=", "?projectUrl=ftp://x"]) {
+      withSearch(search);
+      assert.equal(shouldSuppressOnboarding(), true, search);
+    }
+  });
+
+  it("keeps the wizard for an invalid bare query with no recognized key", () => {
+    withSearch("?not-a-url");
+    assert.equal(shouldSuppressOnboarding(), false);
+  });
+
   it("suppresses the wizard for falsy welcome values", () => {
     for (const value of ["0", "false", "off", "no", "FALSE", " off "]) {
       withSearch(`?welcome=${encodeURIComponent(value)}`);


### PR DESCRIPTION
## Summary

The first-launch onboarding/welcome wizard is noise when the app is opened as an embed. This PR suppresses it in two cases:

1. **Automatically for `?url=` deep links** (e.g. `https://viewer.geolibre.app/?url=https://share.geolibre.app/giswqs/3d-tiles.geolibre.json`) — these load straight into a shared project, so the wizard would just cover the map.
2. **Explicitly via `?welcome=0`** (also `false`/`off`/`no`) — for embeds that don't load a project URL but still want a clean first paint.

## Changes

- `useProjectUrlLoader.ts` — export the existing `projectUrlFromLocation()` detector so the deep-link check lives in one place.
- `useUiProfileBootstrap.ts` — add `!suppressOnboarding` to the `showOnboarding` condition, where `suppressOnboarding` is true for a `?url=` deep link or a falsy `?welcome=` param.
- `docs/user-guide/embedding.md` — document the `welcome` parameter in the URL parameters table.

`projectUrlFromLocation()` already recognizes `url`, `project`, `projectUrl`, `project_url`, and a bare `?https://...` query. `viewer.geolibre.app` proxies 1:1 to `geolibre.app/demo`, so the query reaches the React app unchanged.

## Notes

- Only *display* is suppressed; onboarding is **not** marked complete, so a later normal visit still shows the wizard as expected.
- `useMemo([])` matches the existing pattern in `useProjectUrlLoader`; the location does not change during a session.

## Testing

- `pre-commit run --files <changed files>` passes (eslint + npm build).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the first-launch onboarding/welcome wizard from appearing when opening via shared project deep links.
  * Added support for a `welcome` URL parameter to suppress onboarding when set to `0`, `false`, `off`, or `no`.
* **Documentation**
  * Updated the embedding URL parameters guide to include `welcome`, its supported values, and how it interacts with `url=` deep links.
* **Refactor**
  * Improved centralized URL parsing and onboarding-suppression detection.
* **Tests**
  * Added automated tests covering deep-link, `welcome` parameter, and SSR-safe scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->