### PR TITLE
fix(processing): hide Start/Stop server buttons in the web Whitebox toolbox

### DIFF
--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -399,7 +399,7 @@ export function ProcessingDialog({
   const [runtimeMessage, setRuntimeMessage] = useState("");
   const [runtimeAvailable, setRuntimeAvailable] = useState<boolean | null>(null);
   // Cache the desktop check once, matching the sibling processing dialogs
-  // (ConversionDialog, RasterToolsDialog, SegmentationDialog).
+  // (ConversionDialog, RasterToolsDialog).
   const desktop = isTauri();
   // Run tools locally in WebAssembly (no Python sidecar). Default on in the
   // browser, where there is no sidecar; off under Tauri, where the sidecar is
@@ -1110,7 +1110,7 @@ export function ProcessingDialog({
                   tool-run error that has nothing to do with the sidecar). */}
               {!runLocal && runtimeAvailable === false ? (
                 <SidecarHelpBanner
-                  isDesktop={isTauri()}
+                  isDesktop={desktop}
                   error={error}
                   onRunLocally={() => {
                     // Clear the stale sidecar error in the same batch as the

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -913,7 +913,11 @@ export function ProcessingDialog({
               </Button>
             </div>
 
-            {runtimeAvailable !== true && (
+            {/* The processing server is a local Python process that only the
+                desktop app can spawn or stop. In the browser these buttons
+                would always fail, and a same-origin sidecar (when deployed) is
+                auto-detected without them, so gate both on the desktop build. */}
+            {isTauri() && runtimeAvailable !== true && (
               <Button
                 type="button"
                 variant="outline"
@@ -929,7 +933,7 @@ export function ProcessingDialog({
               </Button>
             )}
 
-            {runtimeAvailable === true && (
+            {isTauri() && runtimeAvailable === true && (
               <Button
                 type="button"
                 variant="outline"

--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -398,10 +398,13 @@ export function ProcessingDialog({
   const [loadingTools, setLoadingTools] = useState(false);
   const [runtimeMessage, setRuntimeMessage] = useState("");
   const [runtimeAvailable, setRuntimeAvailable] = useState<boolean | null>(null);
+  // Cache the desktop check once, matching the sibling processing dialogs
+  // (ConversionDialog, RasterToolsDialog, SegmentationDialog).
+  const desktop = isTauri();
   // Run tools locally in WebAssembly (no Python sidecar). Default on in the
   // browser, where there is no sidecar; off under Tauri, where the sidecar is
   // available and can read native file paths that the WASM runner cannot fetch.
-  const [runLocal, setRunLocal] = useState(!isTauri());
+  const [runLocal, setRunLocal] = useState(!desktop);
   const [error, setError] = useState<string | null>(null);
   const [startingServer, setStartingServer] = useState(false);
   const [stoppingServer, setStoppingServer] = useState(false);
@@ -917,7 +920,7 @@ export function ProcessingDialog({
                 desktop app can spawn or stop. In the browser these buttons
                 would always fail, and a same-origin sidecar (when deployed) is
                 auto-detected without them, so gate both on the desktop build. */}
-            {isTauri() && runtimeAvailable !== true && (
+            {desktop && runtimeAvailable !== true && (
               <Button
                 type="button"
                 variant="outline"
@@ -933,7 +936,7 @@ export function ProcessingDialog({
               </Button>
             )}
 
-            {isTauri() && runtimeAvailable === true && (
+            {desktop && runtimeAvailable === true && (
               <Button
                 type="button"
                 variant="outline"


### PR DESCRIPTION
## Summary

The Whitebox toolbox (Processing → Whitebox) showed a **Start server** button whenever the sidecar runtime was unavailable, regardless of platform. In the web build, clicking it failed immediately with *"Starting the processing server requires GeoLibre Desktop."* because only the desktop app can spawn (or stop) the local Python sidecar. This is the friction reported in #726.

The three sibling processing dialogs (Conversion, Raster Tools, AI Segmentation) already gate this button on the desktop build via `isTauri()`/`desktop`; the Whitebox dialog was the only one missed.

## Change

Gate both the **Start server** and **Stop server** buttons in `ProcessingDialog.tsx` on `isTauri()`, so they only render in the desktop app.

This respects the nuance that a same-origin sidecar still works in the browser: when one is deployed, the runtime is **auto-detected** (`runtimeAvailable === true`) and no button is needed. When it is unavailable in the browser, the existing `SidecarHelpBanner` already explains the browser-only path ("keep Run locally (WASM) enabled"), so users get guidance instead of an offer-then-fail button.

## Verification

Drove the real web app with Playwright in **both light and dark themes**:
- Opened the Whitebox toolbox and disabled *Run locally (WASM)* to force a sidecar probe.
- Confirmed the runtime reports unavailable and **no Start/Stop server button renders**.
- Confirmed the `SidecarHelpBanner` appears with the browser-appropriate steps.

`npm run build` and `pre-commit` (eslint + npm build) pass.

Fixes #726

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Server control buttons now correctly display only on desktop environments in the processing dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->