### PR TITLE
fix(attribute-table): place collapse icon next to the close icon

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AttributeTable.tsx
@@ -1193,22 +1193,6 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
         className="pointer-events-none fixed left-0 right-0 z-50 hidden h-px bg-primary shadow-[0_0_0_1px_hsl(var(--primary)/0.25)]"
       />
       <div className="flex flex-wrap items-center gap-2 border-b px-3 py-1.5 md:flex-nowrap">
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8"
-          title={collapsed ? "Expand attribute table" : "Collapse attribute table"}
-          aria-label={
-            collapsed ? "Expand attribute table" : "Collapse attribute table"
-          }
-          onClick={() => setCollapsed((value) => !value)}
-        >
-          {collapsed ? (
-            <PanelBottomOpen className="h-4 w-4" />
-          ) : (
-            <PanelBottomClose className="h-4 w-4" />
-          )}
-        </Button>
         <TableProperties className="h-4 w-4 text-muted-foreground" />
         <span className="text-sm font-semibold">Attribute table</span>
         {layer ? (
@@ -1492,6 +1476,22 @@ export function AttributeTable({ mapControllerRef }: AttributeTableProps) {
           onClick={() => selectFeature(null)}
         >
           <MousePointerSquareDashed className="h-3.5 w-3.5" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          title={collapsed ? "Expand attribute table" : "Collapse attribute table"}
+          aria-label={
+            collapsed ? "Expand attribute table" : "Collapse attribute table"
+          }
+          onClick={() => setCollapsed((value) => !value)}
+        >
+          {collapsed ? (
+            <PanelBottomOpen className="h-4 w-4" />
+          ) : (
+            <PanelBottomClose className="h-4 w-4" />
+          )}
         </Button>
         <Button
           variant="ghost"


### PR DESCRIPTION
## Summary

The collapse/expand toggle in the **Attribute table** header was placed at the far left of the toolbar, while the close (X) button was at the far right. Per #733, the collapse icon should sit next to the close icon, matching the **Dashboard panel** header layout.

This moves the collapse button so it renders directly before the close button at the right end of the header, and sizes it `h-7 w-7` to match the adjacent close button.

## Changes
- `apps/geolibre-desktop/src/components/panels/AttributeTable.tsx`: relocate the collapse/expand `Button` from the start of the header row to just before the close `Button`.

## Verification
Drove the real web app with Playwright using the US cities sample vector layer and opened the attribute table:
- Collapse icon now sits immediately to the left of the close X, matching the dashboard panel.
- Verified in both **light** and **dark** themes.
- Confirmed the collapse/expand toggle still works (table body collapses and expands).
- `npm run build` and `pre-commit` (eslint + npm build) pass.

Fixes #733

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the attribute table expand/collapse button positioning and sizing for improved layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->