### PR TITLE
fix(project-url): add context to failed project-load notifications (#734)

### DIFF
--- a/apps/geolibre-desktop/src/hooks/useProjectUrlLoader.ts
+++ b/apps/geolibre-desktop/src/hooks/useProjectUrlLoader.ts
@@ -1,6 +1,6 @@
-import { parseProject, useAppStore } from "@geolibre/core";
+import { useAppStore } from "@geolibre/core";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { projectUrlFromLocation } from "../lib/project-url";
+import { fetchProjectFromUrl, projectUrlFromLocation } from "../lib/project-url";
 import { resolveProjectXyzLayers } from "../lib/xyz-url";
 
 export type ProjectUrlLoadState =
@@ -28,7 +28,7 @@ export function useProjectUrlLoader(): ProjectUrlLoadState {
       status: "loading",
     });
 
-    void loadProjectFromUrl(projectUrl, abortController.signal)
+    void fetchProjectFromUrl(projectUrl, { signal: abortController.signal })
       .then((project) =>
         resolveProjectXyzLayers(project, abortController.signal),
       )
@@ -69,19 +69,4 @@ export function useProjectUrlLoader(): ProjectUrlLoadState {
   }, [loadProject, projectUrl]);
 
   return state;
-}
-
-async function loadProjectFromUrl(projectUrl: string, signal: AbortSignal) {
-  const response = await fetch(projectUrl, {
-    headers: { Accept: "application/json, text/plain;q=0.9, */*;q=0.8" },
-    signal,
-  });
-
-  if (!response.ok) {
-    throw new Error(
-      `Could not load project URL: HTTP ${response.status} ${response.statusText}`,
-    );
-  }
-
-  return parseProject(await response.text());
 }

--- a/apps/geolibre-desktop/src/lib/project-url.ts
+++ b/apps/geolibre-desktop/src/lib/project-url.ts
@@ -61,12 +61,15 @@ export async function fetchProjectFromUrl(
 
   // Shared message for any rejection that means the bytes never arrived: the
   // initial request or the body stream. A bare browser TypeError ("Failed to
-  // fetch" / "Load failed") is replaced with the URL and the likely causes.
-  const networkError = () =>
+  // fetch" / "Load failed") is replaced with the URL and the likely causes,
+  // while the original error is preserved as `cause` so the stack survives in
+  // DevTools and error-monitoring tools.
+  const networkError = (cause: unknown) =>
     new Error(
       `Could not fetch the project from ${projectUrl}. The host may be ` +
         "unreachable or offline, or it may be blocking cross-origin requests " +
         "(CORS). Check the URL and your connection, then try again.",
+      { cause },
     );
 
   // A caller-initiated abort (dialog close / unmount) surfaces as an
@@ -83,7 +86,7 @@ export async function fetchProjectFromUrl(
     });
   } catch (error) {
     if (isAbort(error)) throw error;
-    throw networkError();
+    throw networkError(error);
   }
 
   if (!response.ok) {
@@ -105,7 +108,7 @@ export async function fetchProjectFromUrl(
     // The connection can still drop while the body is streaming, even after a
     // 200; that rejects with the same opaque TypeError, so treat it the same.
     if (isAbort(error)) throw error;
-    throw networkError();
+    throw networkError(error);
   }
 
   try {
@@ -115,12 +118,14 @@ export async function fetchProjectFromUrl(
     // or a file missing the required GeoLibre fields. Name the URL and the
     // underlying reason rather than leaking a bare JSON.parse SyntaxError. Strip
     // parseProject's own "Invalid GeoLibre project:" prefix so the wrapper does
-    // not repeat the noun it already states.
-    const detail = (error instanceof Error ? error.message : String(error))
-      .replace(/^Invalid GeoLibre project:\s*/i, "");
+    // not repeat the noun it already states, but fall back to the full message
+    // if stripping would leave nothing (so the colon never dangles).
+    const raw = error instanceof Error ? error.message : String(error);
+    const detail = raw.replace(/^Invalid GeoLibre project:\s*/i, "") || raw;
     throw new Error(
       `The file at ${projectUrl} is not a valid GeoLibre project ` +
         `(.geolibre.json): ${detail}`,
+      { cause: error },
     );
   }
 }

--- a/apps/geolibre-desktop/src/lib/project-url.ts
+++ b/apps/geolibre-desktop/src/lib/project-url.ts
@@ -113,8 +113,11 @@ export async function fetchProjectFromUrl(
   } catch (error) {
     // The fetch succeeded but the body is not a usable project: malformed JSON
     // or a file missing the required GeoLibre fields. Name the URL and the
-    // underlying reason rather than leaking a bare JSON.parse SyntaxError.
-    const detail = error instanceof Error ? error.message : String(error);
+    // underlying reason rather than leaking a bare JSON.parse SyntaxError. Strip
+    // parseProject's own "Invalid GeoLibre project:" prefix so the wrapper does
+    // not repeat the noun it already states.
+    const detail = (error instanceof Error ? error.message : String(error))
+      .replace(/^Invalid GeoLibre project:\s*/i, "");
     throw new Error(
       `The file at ${projectUrl} is not a valid GeoLibre project ` +
         `(.geolibre.json): ${detail}`,

--- a/apps/geolibre-desktop/src/lib/project-url.ts
+++ b/apps/geolibre-desktop/src/lib/project-url.ts
@@ -93,7 +93,7 @@ export async function fetchProjectFromUrl(
       ? `HTTP ${response.status} ${response.statusText}`
       : `HTTP ${response.status}`;
     throw new Error(
-      `Could not load the project from ${projectUrl}: the server responded ` +
+      `Could not fetch the project from ${projectUrl}: the server responded ` +
         `with ${status}.`,
     );
   }

--- a/apps/geolibre-desktop/src/lib/project-url.ts
+++ b/apps/geolibre-desktop/src/lib/project-url.ts
@@ -1,3 +1,5 @@
+import { parseProject } from "@geolibre/core";
+import type { GeoLibreProject } from "@geolibre/core";
 import { normalizeProjectUrl } from "./urls";
 
 // Query parameters that carry a `.geolibre.json` project URL deep link. A bare
@@ -30,6 +32,73 @@ export function projectUrlFromLocation(): string | null {
   return /^https?:\/\//i.test(bareQuery)
     ? normalizeProjectUrl(bareQuery)
     : null;
+}
+
+/**
+ * Fetches and parses a `.geolibre.json` project from a URL, turning every
+ * failure mode into a message that names the URL and the likely cause.
+ *
+ * A bare `fetch` rejects with an unhelpful `TypeError` ("Failed to fetch" in
+ * Chromium, "Load failed" in Safari) on a network or CORS failure, and
+ * `parseProject` throws a raw `SyntaxError` on malformed JSON. Both would
+ * otherwise reach the UI verbatim, leaving the user with no idea what went
+ * wrong (see issue #734). This wrapper distinguishes the three failure modes
+ * so the caller can surface actionable feedback.
+ *
+ * @param projectUrl - Absolute http(s) URL to a serialized project.
+ * @param options - `signal` aborts the request; `fetchImpl` is injected for
+ *   testing and defaults to the global `fetch`.
+ * @returns The parsed project.
+ * @throws {Error} With a descriptive message on a network/CORS failure, a
+ *   non-2xx response, or an unparseable/invalid project body. A
+ *   caller-initiated abort propagates as the original `AbortError`.
+ */
+export async function fetchProjectFromUrl(
+  projectUrl: string,
+  options: { signal?: AbortSignal; fetchImpl?: typeof fetch } = {},
+): Promise<GeoLibreProject> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const signal = options.signal;
+
+  let response: Response;
+  try {
+    response = await fetchImpl(projectUrl, {
+      headers: { Accept: "application/json, text/plain;q=0.9, */*;q=0.8" },
+      signal,
+    });
+  } catch (error) {
+    // A rejected fetch (as opposed to a non-2xx response) means the request
+    // never completed: the host is unreachable, the browser is offline, or the
+    // server blocked the cross-origin request. Let a caller-initiated abort
+    // (dialog close / unmount) propagate untouched so the caller can ignore it.
+    if (signal?.aborted) throw error;
+    throw new Error(
+      `Could not fetch the project from ${projectUrl}. The host may be ` +
+        "unreachable or offline, or it may be blocking cross-origin requests " +
+        "(CORS). Check the URL and your connection, then try again.",
+    );
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Could not load the project from ${projectUrl}: the server responded ` +
+        `with HTTP ${response.status} ${response.statusText}.`,
+    );
+  }
+
+  const text = await response.text();
+  try {
+    return parseProject(text);
+  } catch (error) {
+    // The fetch succeeded but the body is not a usable project: malformed JSON
+    // or a file missing the required GeoLibre fields. Name the URL and the
+    // underlying reason rather than leaking a bare JSON.parse SyntaxError.
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `The file at ${projectUrl} is not a valid GeoLibre project ` +
+        `(.geolibre.json): ${detail}`,
+    );
+  }
 }
 
 function safeDecodeURIComponent(value: string): string {

--- a/apps/geolibre-desktop/src/lib/project-url.ts
+++ b/apps/geolibre-desktop/src/lib/project-url.ts
@@ -1,5 +1,4 @@
-import { parseProject } from "@geolibre/core";
-import type { GeoLibreProject } from "@geolibre/core";
+import { parseProject, type GeoLibreProject } from "@geolibre/core";
 import { normalizeProjectUrl } from "./urls";
 
 // Query parameters that carry a `.geolibre.json` project URL deep link. A bare
@@ -60,6 +59,22 @@ export async function fetchProjectFromUrl(
   const fetchImpl = options.fetchImpl ?? fetch;
   const signal = options.signal;
 
+  // Shared message for any rejection that means the bytes never arrived: the
+  // initial request or the body stream. A bare browser TypeError ("Failed to
+  // fetch" / "Load failed") is replaced with the URL and the likely causes.
+  const networkError = () =>
+    new Error(
+      `Could not fetch the project from ${projectUrl}. The host may be ` +
+        "unreachable or offline, or it may be blocking cross-origin requests " +
+        "(CORS). Check the URL and your connection, then try again.",
+    );
+
+  // A caller-initiated abort (dialog close / unmount) surfaces as an
+  // `AbortError`; let it propagate untouched so the caller can ignore it,
+  // matching the abort handling in `share-geolibre.ts`.
+  const isAbort = (error: unknown) =>
+    error instanceof DOMException && error.name === "AbortError";
+
   let response: Response;
   try {
     response = await fetchImpl(projectUrl, {
@@ -67,26 +82,32 @@ export async function fetchProjectFromUrl(
       signal,
     });
   } catch (error) {
-    // A rejected fetch (as opposed to a non-2xx response) means the request
-    // never completed: the host is unreachable, the browser is offline, or the
-    // server blocked the cross-origin request. Let a caller-initiated abort
-    // (dialog close / unmount) propagate untouched so the caller can ignore it.
-    if (signal?.aborted) throw error;
-    throw new Error(
-      `Could not fetch the project from ${projectUrl}. The host may be ` +
-        "unreachable or offline, or it may be blocking cross-origin requests " +
-        "(CORS). Check the URL and your connection, then try again.",
-    );
+    if (isAbort(error)) throw error;
+    throw networkError();
   }
 
   if (!response.ok) {
+    // HTTP/2 drops reason phrases, so `statusText` is often empty; only append
+    // it when present to avoid a stray "HTTP 404 ." with a dangling period.
+    const status = response.statusText
+      ? `HTTP ${response.status} ${response.statusText}`
+      : `HTTP ${response.status}`;
     throw new Error(
       `Could not load the project from ${projectUrl}: the server responded ` +
-        `with HTTP ${response.status} ${response.statusText}.`,
+        `with ${status}.`,
     );
   }
 
-  const text = await response.text();
+  let text: string;
+  try {
+    text = await response.text();
+  } catch (error) {
+    // The connection can still drop while the body is streaming, even after a
+    // 200; that rejects with the same opaque TypeError, so treat it the same.
+    if (isAbort(error)) throw error;
+    throw networkError();
+  }
+
   try {
     return parseProject(text);
   } catch (error) {

--- a/tests/project-url.test.ts
+++ b/tests/project-url.test.ts
@@ -1,24 +1,17 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import {
-  fetchProjectFromUrl,
-} from "../apps/geolibre-desktop/src/lib/project-url";
-import { serializeProject, type GeoLibreProject } from "@geolibre/core";
+import { fetchProjectFromUrl } from "../apps/geolibre-desktop/src/lib/project-url";
 
 const PROJECT_URL = "https://example.com/Test.geolibre.json";
 
-function validProject(): GeoLibreProject {
-  return {
-    version: "1.0",
-    name: "Test",
-    mapView: { center: [0, 0], zoom: 2, bearing: 0, pitch: 0 },
-    basemapStyleUrl: "https://example.com/style.json",
-    basemapVisible: true,
-    basemapOpacity: 1,
-    layers: [],
-    styles: {},
-  } as unknown as GeoLibreProject;
-}
+// A serialized project carrying exactly the fields `parseProject` requires
+// (version, name, mapView). Kept as a string so the fixture stays decoupled
+// from the full `GeoLibreProject` shape.
+const VALID_PROJECT_JSON = JSON.stringify({
+  version: "1.0",
+  name: "Test",
+  mapView: { center: [0, 0], zoom: 2, bearing: 0, pitch: 0 },
+});
 
 /** A `fetchImpl` that returns the given body with a 200 OK response. */
 function okFetch(body: string): typeof fetch {
@@ -29,7 +22,7 @@ function okFetch(body: string): typeof fetch {
 describe("fetchProjectFromUrl", () => {
   it("returns the parsed project on a successful fetch", async () => {
     const project = await fetchProjectFromUrl(PROJECT_URL, {
-      fetchImpl: okFetch(serializeProject(validProject())),
+      fetchImpl: okFetch(VALID_PROJECT_JSON),
     });
     assert.equal(project.name, "Test");
   });
@@ -49,6 +42,62 @@ describe("fetchProjectFromUrl", () => {
         assert.match(error.message, /CORS/);
         // The opaque browser string must not be what the user sees.
         assert.notEqual(error.message, "Load failed");
+        return true;
+      },
+    );
+  });
+
+  it("wraps a network failure even when no signal is provided", async () => {
+    // Exercises the `options = {}` default branch: the `signal?.aborted`
+    // short-circuit must not fire when `signal` is undefined.
+    const fetchImpl = (async () => {
+      throw new TypeError("Failed to fetch");
+    }) as unknown as typeof fetch;
+
+    await assert.rejects(
+      () => fetchProjectFromUrl(PROJECT_URL, { fetchImpl }),
+      (error: Error) => {
+        assert.match(error.message, /Could not fetch the project from/);
+        assert.notEqual(error.message, "Failed to fetch");
+        return true;
+      },
+    );
+  });
+
+  it("wraps a body-streaming failure after a 200 response", async () => {
+    // The connection drops mid-stream: text() rejects with the same opaque
+    // TypeError, which must get the same network treatment as a failed request.
+    const fetchImpl = (async () => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      text: async () => {
+        throw new TypeError("Load failed");
+      },
+    })) as unknown as typeof fetch;
+
+    await assert.rejects(
+      () => fetchProjectFromUrl(PROJECT_URL, { fetchImpl }),
+      (error: Error) => {
+        assert.match(error.message, /Could not fetch the project from/);
+        assert.notEqual(error.message, "Load failed");
+        return true;
+      },
+    );
+  });
+
+  it("omits an empty statusText (HTTP/2) to avoid a dangling period", async () => {
+    const fetchImpl = (async () =>
+      new Response("Not found", {
+        status: 404,
+        statusText: "",
+      })) as unknown as typeof fetch;
+
+    await assert.rejects(
+      () => fetchProjectFromUrl(PROJECT_URL, { fetchImpl }),
+      (error: Error) => {
+        assert.match(error.message, /with HTTP 404\./);
+        assert.doesNotMatch(error.message, /HTTP 404 \./);
         return true;
       },
     );

--- a/tests/project-url.test.ts
+++ b/tests/project-url.test.ts
@@ -48,8 +48,8 @@ describe("fetchProjectFromUrl", () => {
   });
 
   it("wraps a network failure even when no signal is provided", async () => {
-    // Exercises the `options = {}` default branch: the `signal?.aborted`
-    // short-circuit must not fire when `signal` is undefined.
+    // Exercises the `options = {}` default branch, where `signal` is undefined:
+    // a non-abort rejection is still wrapped rather than rethrown.
     const fetchImpl = (async () => {
       throw new TypeError("Failed to fetch");
     }) as unknown as typeof fetch;

--- a/tests/project-url.test.ts
+++ b/tests/project-url.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  fetchProjectFromUrl,
+} from "../apps/geolibre-desktop/src/lib/project-url";
+import { serializeProject, type GeoLibreProject } from "@geolibre/core";
+
+const PROJECT_URL = "https://example.com/Test.geolibre.json";
+
+function validProject(): GeoLibreProject {
+  return {
+    version: "1.0",
+    name: "Test",
+    mapView: { center: [0, 0], zoom: 2, bearing: 0, pitch: 0 },
+    basemapStyleUrl: "https://example.com/style.json",
+    basemapVisible: true,
+    basemapOpacity: 1,
+    layers: [],
+    styles: {},
+  } as unknown as GeoLibreProject;
+}
+
+/** A `fetchImpl` that returns the given body with a 200 OK response. */
+function okFetch(body: string): typeof fetch {
+  return (async () =>
+    new Response(body, { status: 200 })) as unknown as typeof fetch;
+}
+
+describe("fetchProjectFromUrl", () => {
+  it("returns the parsed project on a successful fetch", async () => {
+    const project = await fetchProjectFromUrl(PROJECT_URL, {
+      fetchImpl: okFetch(serializeProject(validProject())),
+    });
+    assert.equal(project.name, "Test");
+  });
+
+  it("turns a rejected fetch (network/CORS) into a message naming the URL and CORS", async () => {
+    // Mimic the bare TypeError a browser throws on a network or CORS failure
+    // ("Failed to fetch" / "Load failed") rather than leaking it verbatim.
+    const fetchImpl = (async () => {
+      throw new TypeError("Load failed");
+    }) as unknown as typeof fetch;
+
+    await assert.rejects(
+      () => fetchProjectFromUrl(PROJECT_URL, { fetchImpl }),
+      (error: Error) => {
+        assert.match(error.message, /Could not fetch the project from/);
+        assert.ok(error.message.includes(PROJECT_URL));
+        assert.match(error.message, /CORS/);
+        // The opaque browser string must not be what the user sees.
+        assert.notEqual(error.message, "Load failed");
+        return true;
+      },
+    );
+  });
+
+  it("propagates a caller-initiated abort untouched", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const fetchImpl = (async () => {
+      throw new DOMException("Aborted", "AbortError");
+    }) as unknown as typeof fetch;
+
+    await assert.rejects(
+      () =>
+        fetchProjectFromUrl(PROJECT_URL, {
+          fetchImpl,
+          signal: controller.signal,
+        }),
+      (error: Error) => {
+        assert.equal(error.name, "AbortError");
+        return true;
+      },
+    );
+  });
+
+  it("reports a non-2xx response with its status", async () => {
+    const fetchImpl = (async () =>
+      new Response("Not found", {
+        status: 404,
+        statusText: "Not Found",
+      })) as unknown as typeof fetch;
+
+    await assert.rejects(
+      () => fetchProjectFromUrl(PROJECT_URL, { fetchImpl }),
+      (error: Error) => {
+        assert.match(error.message, /HTTP 404 Not Found/);
+        assert.ok(error.message.includes(PROJECT_URL));
+        return true;
+      },
+    );
+  });
+
+  it("reports a malformed body as an invalid project rather than a raw SyntaxError", async () => {
+    await assert.rejects(
+      () =>
+        fetchProjectFromUrl(PROJECT_URL, {
+          fetchImpl: okFetch("{ this is not json"),
+        }),
+      (error: Error) => {
+        assert.match(error.message, /is not a valid GeoLibre project/);
+        assert.ok(error.message.includes(PROJECT_URL));
+        return true;
+      },
+    );
+  });
+
+  it("reports a valid-JSON file that is missing required fields", async () => {
+    await assert.rejects(
+      () =>
+        fetchProjectFromUrl(PROJECT_URL, {
+          fetchImpl: okFetch(JSON.stringify({ not: "a project" })),
+        }),
+      (error: Error) => {
+        assert.match(error.message, /is not a valid GeoLibre project/);
+        assert.match(error.message, /missing required fields/);
+        return true;
+      },
+    );
+  });
+});

--- a/tests/project-url.test.ts
+++ b/tests/project-url.test.ts
@@ -86,6 +86,27 @@ describe("fetchProjectFromUrl", () => {
     );
   });
 
+  it("propagates an abort that happens during body streaming", async () => {
+    // The signal fires between the 200 response and the finished body read:
+    // text() rejects with AbortError, which must propagate untouched.
+    const fetchImpl = (async () => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      text: async () => {
+        throw new DOMException("Aborted", "AbortError");
+      },
+    })) as unknown as typeof fetch;
+
+    await assert.rejects(
+      () => fetchProjectFromUrl(PROJECT_URL, { fetchImpl }),
+      (error: Error) => {
+        assert.equal(error.name, "AbortError");
+        return true;
+      },
+    );
+  });
+
   it("omits an empty statusText (HTTP/2) to avoid a dangling period", async () => {
     const fetchImpl = (async () =>
       new Response("Not found", {
@@ -163,6 +184,9 @@ describe("fetchProjectFromUrl", () => {
       (error: Error) => {
         assert.match(error.message, /is not a valid GeoLibre project/);
         assert.match(error.message, /missing required fields/);
+        // parseProject's own "Invalid GeoLibre project:" prefix is stripped so
+        // the wrapper does not repeat the noun.
+        assert.doesNotMatch(error.message, /\): Invalid GeoLibre project:/);
         return true;
       },
     );

--- a/tests/project-url.test.ts
+++ b/tests/project-url.test.ts
@@ -30,8 +30,9 @@ describe("fetchProjectFromUrl", () => {
   it("turns a rejected fetch (network/CORS) into a message naming the URL and CORS", async () => {
     // Mimic the bare TypeError a browser throws on a network or CORS failure
     // ("Failed to fetch" / "Load failed") rather than leaking it verbatim.
+    const original = new TypeError("Load failed");
     const fetchImpl = (async () => {
-      throw new TypeError("Load failed");
+      throw original;
     }) as unknown as typeof fetch;
 
     await assert.rejects(
@@ -42,6 +43,8 @@ describe("fetchProjectFromUrl", () => {
         assert.match(error.message, /CORS/);
         // The opaque browser string must not be what the user sees.
         assert.notEqual(error.message, "Load failed");
+        // The original error is preserved as `cause` for diagnostics.
+        assert.equal(error.cause, original);
         return true;
       },
     );
@@ -183,7 +186,9 @@ describe("fetchProjectFromUrl", () => {
         }),
       (error: Error) => {
         assert.match(error.message, /is not a valid GeoLibre project/);
-        assert.match(error.message, /missing required fields/);
+        // Loosely assert the underlying reason carries through, without
+        // hard-coding parseProject's exact wording.
+        assert.match(error.message, /missing.*fields/i);
         // parseProject's own "Invalid GeoLibre project:" prefix is stripped so
         // the wrapper does not repeat the noun.
         assert.doesNotMatch(error.message, /\): Invalid GeoLibre project:/);


### PR DESCRIPTION
## Summary

Loading a project from a `?url=` deep link (also `?project=`, `?projectUrl=`, or a bare `?https://...` query) surfaced the **raw browser fetch error** in the top-center status banner: `Load failed` in Safari, `Failed to fetch` in Chromium. The user had no way to tell whether the cause was the network, a CORS block, a wrong URL, or a malformed file. This is the behavior reported in #734.

## Root cause

`useProjectUrlLoader` fetched and parsed the project inline. A rejected `fetch` (network/CORS) is a bare `TypeError` whose message is the opaque browser string, and `parseProject` throws a raw `SyntaxError` on malformed JSON. Both reached the banner verbatim via `error.message`.

## Fix

- New `fetchProjectFromUrl` helper in `lib/project-url.ts` that distinguishes the three failure modes and reports an actionable message naming the URL and the likely cause:
  - **Network / CORS:** "Could not fetch the project from `<url>`. The host may be unreachable or offline, or it may be blocking cross-origin requests (CORS). Check the URL and your connection, then try again."
  - **Non-2xx response:** includes the HTTP status and the URL.
  - **Malformed / invalid project:** "The file at `<url>` is not a valid GeoLibre project (.geolibre.json): `<reason>`."
- Caller-initiated aborts (dialog close / unmount) still propagate untouched so they are ignored, not shown.
- The helper takes an injectable `fetchImpl` (mirroring `share-geolibre.ts`), making it unit-testable.

## Verification

- Reproduced the original ambiguous banner in the running web app via a `?url=` deep link to an unreachable host, then confirmed each new message renders in **both light and dark themes**.
- Confirmed a valid project still loads with no regression.
- Added `tests/project-url.test.ts` (6 cases: success, network/CORS, abort, non-2xx, malformed JSON, missing fields).
- `npm run build`, full frontend suite (1422 passing), and scoped `pre-commit` all green.

Fixes #734


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading of projects from URLs with clearer, user-facing error messages for network/CORS failures, HTTP non-2xx responses, aborted requests, and invalid or malformed project content.

* **Tests**
  * Expanded automated test coverage for URL-based project loading, including success parsing, streaming/read failures, abort scenarios, non-2xx handling, and validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->