### PR TITLE
fix(map): move bounds-locked badge to bottom-left to clear toolbar

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/BoundsRestrictionIndicator.tsx
+++ b/apps/geolibre-desktop/src/components/layout/BoundsRestrictionIndicator.tsx
@@ -12,7 +12,8 @@ import { useTranslation } from "react-i18next";
  * control plugins (GeoEditor, Basemaps, NASA Earthdata, ...) cluster, so a
  * top-left badge overlapped and hid the first plugin button. The small
  * bottom offset keeps it clear of the bottom-left scale control when that is
- * enabled.
+ * enabled. It assumes the scale is the only bottom-left control; if more are
+ * stacked there (e.g. the logo control), revisit the offset.
  */
 export function BoundsRestrictionIndicator() {
   const { t } = useTranslation();

--- a/apps/geolibre-desktop/src/components/layout/BoundsRestrictionIndicator.tsx
+++ b/apps/geolibre-desktop/src/components/layout/BoundsRestrictionIndicator.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from "react-i18next";
  *
  * Anchored to the bottom-left corner: the top-left corner is where most map
  * control plugins (GeoEditor, Basemaps, NASA Earthdata, ...) cluster, so a
- * top-left badge overlapped and hid the first plugin button (#742). The small
+ * top-left badge overlapped and hid the first plugin button. The small
  * bottom offset keeps it clear of the bottom-left scale control when that is
  * enabled.
  */

--- a/apps/geolibre-desktop/src/components/layout/BoundsRestrictionIndicator.tsx
+++ b/apps/geolibre-desktop/src/components/layout/BoundsRestrictionIndicator.tsx
@@ -7,6 +7,12 @@ import { useTranslation } from "react-i18next";
  * "Restrict map bounds" preference is enabled. It gives users a visible cue
  * that panning/zooming is intentionally constrained (rather than the app being
  * frozen), with a tooltip pointing them back to Settings to change it.
+ *
+ * Anchored to the bottom-left corner: the top-left corner is where most map
+ * control plugins (GeoEditor, Basemaps, NASA Earthdata, ...) cluster, so a
+ * top-left badge overlapped and hid the first plugin button (#742). The small
+ * bottom offset keeps it clear of the bottom-left scale control when that is
+ * enabled.
  */
 export function BoundsRestrictionIndicator() {
   const { t } = useTranslation();
@@ -20,7 +26,7 @@ export function BoundsRestrictionIndicator() {
 
   return (
     <div
-      className="pointer-events-auto absolute left-2 top-2 z-10 flex items-center gap-1 rounded-md border bg-background/90 px-2 py-1 text-xs font-medium text-foreground shadow-sm backdrop-blur-sm"
+      className="pointer-events-auto absolute bottom-8 left-2 z-10 flex items-center gap-1 rounded-md border bg-background/90 px-2 py-1 text-xs font-medium text-foreground shadow-sm backdrop-blur-sm"
       role="status"
       title={tooltip}
       data-testid="bounds-restriction-indicator"

--- a/apps/geolibre-desktop/src/components/layout/BoundsRestrictionIndicator.tsx
+++ b/apps/geolibre-desktop/src/components/layout/BoundsRestrictionIndicator.tsx
@@ -26,7 +26,7 @@ export function BoundsRestrictionIndicator() {
 
   return (
     <div
-      className="pointer-events-auto absolute bottom-8 left-2 z-10 flex items-center gap-1 rounded-md border bg-background/90 px-2 py-1 text-xs font-medium text-foreground shadow-sm backdrop-blur-sm"
+      className="pointer-events-auto absolute bottom-12 left-2 z-10 flex items-center gap-1 rounded-md border bg-background/90 px-2 py-1 text-xs font-medium text-foreground shadow-sm backdrop-blur-sm"
       role="status"
       title={tooltip}
       data-testid="bounds-restriction-indicator"


### PR DESCRIPTION
## Summary

Fixes #742.

The "Bounds locked" status badge was anchored to the **top-left** corner of the map. That is the same corner where most map-control plugins (GeoEditor, Basemaps, NASA Earthdata, Overture Maps, USGS LiDAR, ...) place their toolbars by default. When "Restrict map bounds" was enabled, the badge rendered directly on top of the first plugin button, hiding it and making it impossible to see or click (the red arrow in the issue screenshot).

## Fix

Anchor the badge to the **bottom-left** corner instead (`top-2` to `bottom-12`), so it stacks above the scale control with a comfortable gap when that is enabled. The bottom-left corner is far less likely to be crowded by plugin controls than the top-left.

Single-file change in `BoundsRestrictionIndicator.tsx`.

## Verification

Drove the real web app with Playwright using "Restrict map bounds" enabled:

- Activated the GeoEditor toolbar at the top-left: its first icon (and all drawing tools) are now fully visible and clickable, no longer covered by the badge.
- The badge now sits at the bottom-left, stacked above the scale bar with a clear ~16px gap (measured badge bottom 644px vs scale top 660px).
- Confirmed in both light and dark themes.
