### PR TITLE
feat(plugins): move external plugin toolbar menus after the Help menu

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -933,9 +933,10 @@ export function TopToolbar({
           hiddenPluginIds={hiddenPluginIds}
         />
       )}
-      {/* Top-level toolbar menus registered by plugins via
-          app.registerToolbarMenu(); renders nothing when none exist. */}
-      <PluginToolbarMenus chrome={chrome} />
+      {/* Top-level toolbar menus registered by built-in plugins via
+          app.registerToolbarMenu(); external plugin menus render after Help
+          (below). Renders nothing when none exist. */}
+      <PluginToolbarMenus chrome={chrome} placement="builtin" />
       <SettingsDialog
         buttonClassName={toolbarButtonClass}
         buttonSize={toolbarButtonSize}
@@ -1023,6 +1024,9 @@ export function TopToolbar({
           onAbout={() => setAboutOpen(true)}
         />
       )}
+      {/* External plugin toolbar menus render after Help so third-party menus
+          sit at the end of the banner, past the built-in menus. */}
+      <PluginToolbarMenus chrome={chrome} placement="external" />
       <AddDataDialog
         kind={addDataKind}
         mapControllerRef={mapControllerRef}

--- a/apps/geolibre-desktop/src/components/layout/toolbar/PluginToolbarMenus.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/PluginToolbarMenus.tsx
@@ -144,6 +144,10 @@ export function PluginToolbarMenus({
   // source; menus with no owner (or an unknown one) fall in with the built-ins.
   const visible = entries.filter((entry) => {
     if (entry.menu.items.length === 0) return false;
+    // ownerPluginId by itself doesn't encode "external", so re-check the live
+    // source map. The two stay in sync because unregister always deactivates a
+    // plugin (which removes its menu, re-rendering this list) before dropping
+    // its source map entry, so a menu is never seen with a now-stale owner.
     const external = Boolean(
       entry.ownerPluginId && isExternalPluginId(entry.ownerPluginId),
     );

--- a/apps/geolibre-desktop/src/components/layout/toolbar/PluginToolbarMenus.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/PluginToolbarMenus.tsx
@@ -15,11 +15,19 @@ import {
 } from "@geolibre/ui";
 import { Puzzle } from "lucide-react";
 import { useToolbarMenus } from "../../../hooks/usePluginUiSurfaces";
+import { isExternalPluginId } from "../../../lib/external-plugins";
 import { isImageSource } from "../../../lib/icon-source";
 import type { ToolbarChrome } from "./constants";
 
 interface PluginToolbarMenusProps {
   chrome: ToolbarChrome;
+  /**
+   * Which menus to render by their owning plugin's origin: `"builtin"` renders
+   * menus from built-in plugins (and any untagged menu) beside the built-in
+   * menus; `"external"` renders menus from externally loaded plugins, placed
+   * after the Help menu. The toolbar renders one instance of each.
+   */
+  placement: "builtin" | "external";
 }
 
 function MenuIcon({ icon, className }: { icon?: string; className: string }) {
@@ -120,19 +128,32 @@ function PluginToolbarMenu({
 
 /**
  * Renders the top-level toolbar menus registered by plugins via
- * `app.registerToolbarMenu()`, one dropdown button per menu, beside the
- * built-in toolbar menus. Renders nothing when no plugin has registered a menu.
+ * `app.registerToolbarMenu()`, one dropdown button per menu. Built-in plugin
+ * menus render beside the built-in menus; external plugin menus render after
+ * the Help menu (selected by `placement`). Renders nothing when no menu in the
+ * requested group has any items.
  */
-export function PluginToolbarMenus({ chrome }: PluginToolbarMenusProps) {
-  const { menus } = useToolbarMenus();
+export function PluginToolbarMenus({
+  chrome,
+  placement,
+}: PluginToolbarMenusProps) {
+  const { entries } = useToolbarMenus();
   // Skip menus with no items so a plugin never shows a button that opens to a
-  // blank dropdown.
-  const nonEmpty = menus.filter((menu) => menu.items.length > 0);
-  if (nonEmpty.length === 0) return null;
+  // blank dropdown, and keep only the menus that belong in this placement. A
+  // menu is "external" when its owning plugin was loaded from an external
+  // source; menus with no owner (or an unknown one) fall in with the built-ins.
+  const visible = entries.filter((entry) => {
+    if (entry.menu.items.length === 0) return false;
+    const external = Boolean(
+      entry.ownerPluginId && isExternalPluginId(entry.ownerPluginId),
+    );
+    return placement === "external" ? external : !external;
+  });
+  if (visible.length === 0) return null;
   return (
     <>
-      {nonEmpty.map((menu) => (
-        <PluginToolbarMenu key={menu.id} menu={menu} chrome={chrome} />
+      {visible.map((entry) => (
+        <PluginToolbarMenu key={entry.menu.id} menu={entry.menu} chrome={chrome} />
       ))}
     </>
   );

--- a/apps/geolibre-desktop/src/lib/external-plugins.ts
+++ b/apps/geolibre-desktop/src/lib/external-plugins.ts
@@ -155,6 +155,16 @@ export async function loadExternalPlugins(
   };
 }
 
+/**
+ * Whether a plugin id was loaded from an external source (a zip archive, a
+ * manifest URL, a bundled drop-in, or a web "install from file"). Built-in
+ * plugins registered at module load are not tracked here and return false. The
+ * toolbar uses this to render external plugin menus after the Help menu.
+ */
+export function isExternalPluginId(pluginId: string): boolean {
+  return externallyLoadedPluginSources.has(pluginId);
+}
+
 async function loadFilesystemPluginBundles(
   additionalPluginDirectories: string[],
 ): Promise<ExternalPluginBundleLoadResult> {

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -315,6 +315,8 @@ const unregister = app.registerToolbarMenu?.({
 
 Each item is an **action** (`onSelect`, the default when `type` is omitted), a **submenu** (nested `items`), or a **separator**. Items typically open a right panel or a floating panel, but `onSelect` can run anything. Re-registering the same `id` replaces the menu, so you can rebuild it as your plugin's state changes.
 
+Menus from **external plugins** (loaded from a zip, a manifest URL, or a bundled drop-in) render at the end of the banner, after the Help menu, so third-party menus sit together past the built-in menus. Menus from built-in plugins render beside the built-in menus. The host decides placement from the menu's owning plugin, so you do not need to do anything special.
+
 ## Floating panels
 
 A floating panel is a draggable, closeable card the host overlays on the map's top-left corner. Unlike a dockable right panel (one active panel docked at a fixed position), several floating panels can be open at once and they do not shrink the map. The render contract is the same plain-DOM `render(container)` as right panels.

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -26,6 +26,7 @@ export {
   getToolbarMenusSnapshot,
   subscribeToolbarMenus,
   type ToolbarMenusSnapshot,
+  type ToolbarMenuEntry,
 } from "./toolbar-menu-registry";
 export {
   registerFloatingPanel,

--- a/packages/plugins/src/plugin-manager.ts
+++ b/packages/plugins/src/plugin-manager.ts
@@ -3,6 +3,7 @@ import type {
   GeoLibreAppAPI,
   GeoLibreMapControlPosition,
   GeoLibrePlugin,
+  GeoLibreToolbarMenu,
 } from "./types";
 
 export class PluginManager {
@@ -217,6 +218,10 @@ export class PluginManager {
   deactivate(id: string, app: GeoLibreAppAPI): void {
     const plugin = this.plugins.get(id);
     if (!plugin || !this.active.has(id)) return;
+    // Teardown gets the raw `app`, not the scoped one `activate` hands out:
+    // deactivate only ever calls unregisterToolbarMenu (by id), which needs no
+    // owner. If scopeAppToPlugin ever wraps a method that matters at teardown,
+    // scope this call too (and unregister/restoreProjectState's deactivations).
     plugin.deactivate(app);
     this.active.delete(id);
     this.notify();
@@ -443,9 +448,16 @@ function scopeAppToPlugin(
 ): GeoLibreAppAPI {
   const register = app.registerToolbarMenu;
   if (!register) return app;
+  // The public `registerToolbarMenu` is single-arg; the host's concrete impl
+  // accepts an owner id as a second argument (see toolbar-menu-registry). Cast
+  // here so the owner stays a host-side injection that plugins never see.
+  const registerWithOwner = register as (
+    menu: GeoLibreToolbarMenu,
+    ownerPluginId: string,
+  ) => () => void;
   return {
     ...app,
-    registerToolbarMenu: (menu) => register(menu, pluginId),
+    registerToolbarMenu: (menu) => registerWithOwner(menu, pluginId),
   };
 }
 

--- a/packages/plugins/src/plugin-manager.ts
+++ b/packages/plugins/src/plugin-manager.ts
@@ -68,7 +68,7 @@ export class PluginManager {
     if (!plugin) return;
     if (this.active.has(id)) {
       try {
-        plugin.deactivate(app);
+        plugin.deactivate(scopeAppToPlugin(app, id));
       } catch (error) {
         console.warn(
           `Plugin '${id}' threw while deactivating during unregister.`,
@@ -218,11 +218,7 @@ export class PluginManager {
   deactivate(id: string, app: GeoLibreAppAPI): void {
     const plugin = this.plugins.get(id);
     if (!plugin || !this.active.has(id)) return;
-    // Teardown gets the raw `app`, not the scoped one `activate` hands out:
-    // deactivate only ever calls unregisterToolbarMenu (by id), which needs no
-    // owner. If scopeAppToPlugin ever wraps a method that matters at teardown,
-    // scope this call too (and unregister/restoreProjectState's deactivations).
-    plugin.deactivate(app);
+    plugin.deactivate(scopeAppToPlugin(app, id));
     this.active.delete(id);
     this.notify();
   }
@@ -317,7 +313,10 @@ export class PluginManager {
         }
 
         try {
-          await plugin.handleUrlParameters(app, new URLSearchParams(params));
+          await plugin.handleUrlParameters(
+            scopeAppToPlugin(app, id),
+            new URLSearchParams(params),
+          );
         } catch (error) {
           // Unmark so a later dispatch for the same context retries the
           // plugin instead of silently skipping it after a failure.
@@ -342,7 +341,10 @@ export class PluginManager {
   ): void {
     const plugin = this.plugins.get(id);
     if (!plugin?.setMapControlPosition) return;
-    const updated = plugin.setMapControlPosition(app, position);
+    const updated = plugin.setMapControlPosition(
+      scopeAppToPlugin(app, id),
+      position,
+    );
     if (updated === false) return;
     this.notify();
   }
@@ -364,7 +366,7 @@ export class PluginManager {
       if (targetActive.has(id)) continue;
       const plugin = this.plugins.get(id);
       if (!plugin) continue;
-      plugin.deactivate(app);
+      plugin.deactivate(scopeAppToPlugin(app, id));
       this.active.delete(id);
       changed = true;
     }
@@ -373,12 +375,15 @@ export class PluginManager {
     // are inactive at this point, so applyProjectState only caches their state
     // for the upcoming activate() call rather than doing live DOM work.
     for (const [id, plugin] of this.plugins) {
+      // One scoped app per plugin so any menu it (re)registers from
+      // setMapControlPosition/applyProjectState is owner-tagged correctly.
+      const scopedApp = scopeAppToPlugin(app, id);
       const defaultPosition = this.defaultMapControlPositions.get(id);
       const targetPosition = state?.mapControlPositions[id] ?? defaultPosition;
       if (targetPosition && plugin.setMapControlPosition) {
         const currentPosition = plugin.getMapControlPosition?.();
         if (currentPosition !== targetPosition) {
-          const updated = plugin.setMapControlPosition(app, targetPosition);
+          const updated = plugin.setMapControlPosition(scopedApp, targetPosition);
           if (updated !== false) changed = true;
         }
       }
@@ -391,7 +396,7 @@ export class PluginManager {
         (hasSetting || options.resetMissingSettings)
       ) {
         const updated = plugin.applyProjectState(
-          app,
+          scopedApp,
           hasSetting ? state.settings[id] : undefined,
         );
         if (updated !== false) changed = true;
@@ -437,10 +442,12 @@ export class PluginManager {
 /**
  * Return an app API scoped to `pluginId`: a shallow copy whose
  * `registerToolbarMenu` tags each menu with the registering plugin's id so the
- * toolbar can place it by owner (e.g. external plugin menus after Help). The
- * plugin keeps this scoped object for the lifetime of its activation, so even a
- * menu it registers asynchronously (after an `await` in `activate`) is tagged.
- * Returns the app unchanged when the host exposes no `registerToolbarMenu`.
+ * toolbar can place it by owner (e.g. external plugin menus after Help). Every
+ * lifecycle callback that hands a plugin the app (activate, deactivate,
+ * handleUrlParameters, setMapControlPosition, applyProjectState) passes a scoped
+ * app, so a menu the plugin (re)registers from any of them is tagged correctly,
+ * including one registered asynchronously after the callback returns. Returns
+ * the app unchanged when the host exposes no `registerToolbarMenu`.
  */
 function scopeAppToPlugin(
   app: GeoLibreAppAPI,

--- a/packages/plugins/src/plugin-manager.ts
+++ b/packages/plugins/src/plugin-manager.ts
@@ -134,12 +134,13 @@ export class PluginManager {
   activate(id: string, app: GeoLibreAppAPI): void {
     const plugin = this.plugins.get(id);
     if (!plugin || this.active.has(id)) return;
-    const activated = plugin.activate(app);
+    const scopedApp = scopeAppToPlugin(app, id);
+    const activated = plugin.activate(scopedApp);
     if (activated === false) return;
     const generation = this.nextActivationGeneration(id);
     this.active.add(id);
     this.notify();
-    this.watchAsyncActivation(id, activated, app, generation);
+    this.watchAsyncActivation(id, activated, scopedApp, generation);
   }
 
   /**
@@ -396,7 +397,8 @@ export class PluginManager {
       if (this.active.has(id)) continue;
       const plugin = this.plugins.get(id);
       if (!plugin) continue;
-      const activated = plugin.activate(app);
+      const scopedApp = scopeAppToPlugin(app, id);
+      const activated = plugin.activate(scopedApp);
       if (activated === false) continue;
       const generation = this.nextActivationGeneration(id);
       this.active.add(id);
@@ -404,7 +406,7 @@ export class PluginManager {
       // Restoring a saved project re-activates plugins the same way the user
       // would, so an async mount that later fails (e.g. a stale chunk after a
       // redeploy) must roll back here too, not just from activate().
-      this.watchAsyncActivation(id, activated, app, generation);
+      this.watchAsyncActivation(id, activated, scopedApp, generation);
     }
 
     if (changed) this.notify();
@@ -425,6 +427,26 @@ export class PluginManager {
     this.activationGenerations.set(id, next);
     return next;
   }
+}
+
+/**
+ * Return an app API scoped to `pluginId`: a shallow copy whose
+ * `registerToolbarMenu` tags each menu with the registering plugin's id so the
+ * toolbar can place it by owner (e.g. external plugin menus after Help). The
+ * plugin keeps this scoped object for the lifetime of its activation, so even a
+ * menu it registers asynchronously (after an `await` in `activate`) is tagged.
+ * Returns the app unchanged when the host exposes no `registerToolbarMenu`.
+ */
+function scopeAppToPlugin(
+  app: GeoLibreAppAPI,
+  pluginId: string,
+): GeoLibreAppAPI {
+  const register = app.registerToolbarMenu;
+  if (!register) return app;
+  return {
+    ...app,
+    registerToolbarMenu: (menu) => register(menu, pluginId),
+  };
 }
 
 // Retaining several recent contexts (rather than only the latest) keeps dedup

--- a/packages/plugins/src/toolbar-menu-registry.ts
+++ b/packages/plugins/src/toolbar-menu-registry.ts
@@ -23,8 +23,12 @@ export interface ToolbarMenuEntry {
 /**
  * Reactive snapshot consumed by `useSyncExternalStore`. The `menus`/`entries`
  * array identities are stable between mutations so React can skip re-renders;
- * `version` is bumped on every change. `menus` is kept for callers that only
- * need the menus; `entries` additionally carries each menu's owning plugin id.
+ * `version` is bumped on every change.
+ *
+ * `menus` predates ownership tracking and is retained for snapshot-shape
+ * backward compatibility (external consumers may read it); `entries` is the
+ * richer form that additionally carries each menu's owning plugin id, and is
+ * what in-repo consumers use.
  */
 export interface ToolbarMenusSnapshot {
   menus: GeoLibreToolbarMenu[];

--- a/packages/plugins/src/toolbar-menu-registry.ts
+++ b/packages/plugins/src/toolbar-menu-registry.ts
@@ -11,24 +11,37 @@ import type { GeoLibreToolbarMenu } from "./types";
  */
 
 /**
- * Reactive snapshot consumed by `useSyncExternalStore`. The `menus` array
- * identity is stable between mutations so React can skip re-renders; `version`
- * is bumped on every change.
+ * A registered toolbar menu paired with the id of the plugin that registered it
+ * (when the host scoped the registration to a plugin). `ownerPluginId` lets the
+ * toolbar place a menu by its owner — e.g. external plugin menus after Help.
+ */
+export interface ToolbarMenuEntry {
+  menu: GeoLibreToolbarMenu;
+  ownerPluginId?: string;
+}
+
+/**
+ * Reactive snapshot consumed by `useSyncExternalStore`. The `menus`/`entries`
+ * array identities are stable between mutations so React can skip re-renders;
+ * `version` is bumped on every change. `menus` is kept for callers that only
+ * need the menus; `entries` additionally carries each menu's owning plugin id.
  */
 export interface ToolbarMenusSnapshot {
   menus: GeoLibreToolbarMenu[];
+  entries: ToolbarMenuEntry[];
   version: number;
 }
 
-const registry = new Map<string, GeoLibreToolbarMenu>();
+const registry = new Map<string, ToolbarMenuEntry>();
 const listeners = new Set<() => void>();
 
 let version = 0;
-let snapshot: ToolbarMenusSnapshot = { menus: [], version: 0 };
+let snapshot: ToolbarMenusSnapshot = { menus: [], entries: [], version: 0 };
 
 function emit(): void {
   version += 1;
-  snapshot = { menus: [...registry.values()], version };
+  const entries = [...registry.values()];
+  snapshot = { menus: entries.map((entry) => entry.menu), entries, version };
   for (const listener of listeners) {
     listener();
   }
@@ -38,8 +51,14 @@ function emit(): void {
  * Register a plugin-owned top toolbar menu. Returns an unregister function (call
  * it from the plugin's `deactivate` hook). Re-registering the same id replaces
  * the menu, so a plugin can rebuild its menu as its state changes.
+ *
+ * `ownerPluginId` is injected by the host (the PluginManager scopes each
+ * plugin's app API to its id); plugins call this with a single argument.
  */
-export function registerToolbarMenu(menu: GeoLibreToolbarMenu): () => void {
+export function registerToolbarMenu(
+  menu: GeoLibreToolbarMenu,
+  ownerPluginId?: string,
+): () => void {
   if (!menu || typeof menu.id !== "string" || menu.id.length === 0) {
     throw new Error("registerToolbarMenu requires a menu with a non-empty id.");
   }
@@ -52,10 +71,11 @@ export function registerToolbarMenu(menu: GeoLibreToolbarMenu): () => void {
   // Re-registering an id replaces the menu. The returned disposer only removes
   // the menu while this exact registration is still current, so a stale disposer
   // cannot evict a newer menu that reused the id.
-  registry.set(menu.id, menu);
+  const entry: ToolbarMenuEntry = { menu, ownerPluginId };
+  registry.set(menu.id, entry);
   emit();
   return () => {
-    if (registry.get(menu.id) === menu) unregisterToolbarMenu(menu.id);
+    if (registry.get(menu.id) === entry) unregisterToolbarMenu(menu.id);
   };
 }
 
@@ -67,7 +87,7 @@ export function unregisterToolbarMenu(id: string): void {
 
 /** All registered toolbar menus, in registration order. */
 export function listToolbarMenus(): GeoLibreToolbarMenu[] {
-  return [...registry.values()];
+  return [...registry.values()].map((entry) => entry.menu);
 }
 
 /** Current reactive snapshot for `useSyncExternalStore`. */
@@ -91,5 +111,5 @@ export function __resetToolbarMenuRegistryForTests(): void {
   registry.clear();
   listeners.clear();
   version = 0;
-  snapshot = { menus: [], version: 0 };
+  snapshot = { menus: [], entries: [], version: 0 };
 }

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -245,14 +245,11 @@ export interface GeoLibreAppAPI {
    * id replaces the menu. Typed optional for forward-compatibility with hosts
    * that have no top toolbar, so call it with optional chaining.
    *
-   * `ownerPluginId` is injected by the host (the PluginManager scopes each
-   * plugin's app API to its id so the toolbar can place the menu by owner, e.g.
-   * external plugin menus after Help). Plugins call this with a single argument.
+   * The host tracks which plugin owns each menu so the toolbar can place it by
+   * owner (e.g. external plugin menus after Help); that is injected internally
+   * by the PluginManager, so plugins never pass an owner here.
    */
-  registerToolbarMenu?: (
-    menu: GeoLibreToolbarMenu,
-    ownerPluginId?: string,
-  ) => () => void;
+  registerToolbarMenu?: (menu: GeoLibreToolbarMenu) => () => void;
   /** Remove a previously registered toolbar menu. */
   unregisterToolbarMenu?: (id: string) => void;
   /**

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -244,8 +244,15 @@ export interface GeoLibreAppAPI {
    * an unregister function (call it from `deactivate`). Re-registering the same
    * id replaces the menu. Typed optional for forward-compatibility with hosts
    * that have no top toolbar, so call it with optional chaining.
+   *
+   * `ownerPluginId` is injected by the host (the PluginManager scopes each
+   * plugin's app API to its id so the toolbar can place the menu by owner, e.g.
+   * external plugin menus after Help). Plugins call this with a single argument.
    */
-  registerToolbarMenu?: (menu: GeoLibreToolbarMenu) => () => void;
+  registerToolbarMenu?: (
+    menu: GeoLibreToolbarMenu,
+    ownerPluginId?: string,
+  ) => () => void;
   /** Remove a previously registered toolbar menu. */
   unregisterToolbarMenu?: (id: string) => void;
   /**

--- a/tests/plugin-manager.test.ts
+++ b/tests/plugin-manager.test.ts
@@ -700,4 +700,43 @@ describe("PluginManager toolbar menu scoping", () => {
 
     assert.deepEqual(seen, ["async-menu-plugin"]);
   });
+
+  it("tags a menu (re)registered from applyProjectState, not just activate", () => {
+    const manager = new PluginManager();
+    const seen: Array<string | undefined> = [];
+    const scopedApp = {
+      registerToolbarMenu: (
+        _menu: unknown,
+        ownerPluginId?: string,
+      ) => {
+        seen.push(ownerPluginId);
+        return () => undefined;
+      },
+    } as unknown as GeoLibreAppAPI;
+
+    manager.register(
+      testPlugin({
+        id: "settings-menu-plugin",
+        // Plugins rebuild their menu as state changes; that can happen from
+        // applyProjectState during a project load, not only from activate.
+        applyProjectState: (api) =>
+          void api.registerToolbarMenu?.({
+            id: "settings-menu",
+            label: "Workbench",
+            items: [],
+          }),
+      }),
+    );
+    manager.restoreProjectState(
+      {
+        manifestUrls: [],
+        activePluginIds: [],
+        mapControlPositions: {},
+        settings: { "settings-menu-plugin": {} },
+      },
+      scopedApp,
+    );
+
+    assert.deepEqual(seen, ["settings-menu-plugin"]);
+  });
 });

--- a/tests/plugin-manager.test.ts
+++ b/tests/plugin-manager.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { afterEach, describe, it } from "node:test";
 import { PluginManager } from "../packages/plugins/src/plugin-manager";
+import {
+  __resetToolbarMenuRegistryForTests,
+  getToolbarMenusSnapshot,
+  registerToolbarMenu,
+} from "../packages/plugins/src/toolbar-menu-registry";
 import type {
   GeoLibreAppAPI,
   GeoLibrePlugin,
@@ -633,10 +638,14 @@ describe("PluginManager async activation", () => {
 });
 
 describe("PluginManager toolbar menu scoping", () => {
+  afterEach(() => __resetToolbarMenuRegistryForTests());
+
   it("tags registerToolbarMenu with the activating plugin's id", () => {
     const manager = new PluginManager();
     const seen: Array<string | undefined> = [];
-    const scopedApp = {
+    // The raw mock app handed to activate(); the manager scopes it internally
+    // via scopeAppToPlugin before the plugin ever sees it.
+    const mockApp = {
       registerToolbarMenu: (
         _menu: unknown,
         ownerPluginId?: string,
@@ -659,15 +668,42 @@ describe("PluginManager toolbar menu scoping", () => {
           }),
       }),
     );
-    manager.activate("menu-plugin", scopedApp);
+    manager.activate("menu-plugin", mockApp);
 
     assert.deepEqual(seen, ["menu-plugin"]);
+  });
+
+  it("records the owner on the real registry when wired through activate", () => {
+    // Guards the TypeScript-invisible contract between scopeAppToPlugin's cast
+    // and the real registry's optional second parameter: drive the genuine
+    // registerToolbarMenu (not a mock) through activate and assert the snapshot
+    // carries the owner. Breaks if the registry ever drops the owner argument.
+    const manager = new PluginManager();
+    const realApp = { registerToolbarMenu } as unknown as GeoLibreAppAPI;
+
+    manager.register(
+      testPlugin({
+        id: "real-menu-plugin",
+        activate: (api) =>
+          void api.registerToolbarMenu?.({
+            id: "real-menu",
+            label: "Workbench",
+            items: [{ id: "open", label: "Open", onSelect: () => undefined }],
+          }),
+      }),
+    );
+    manager.activate("real-menu-plugin", realApp);
+
+    const { entries } = getToolbarMenusSnapshot();
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].menu.id, "real-menu");
+    assert.equal(entries[0].ownerPluginId, "real-menu-plugin");
   });
 
   it("scopes a menu registered asynchronously after activate resolves", async () => {
     const manager = new PluginManager();
     const seen: Array<string | undefined> = [];
-    const scopedApp = {
+    const mockApp = {
       registerToolbarMenu: (
         _menu: unknown,
         ownerPluginId?: string,
@@ -694,7 +730,7 @@ describe("PluginManager toolbar menu scoping", () => {
         },
       }),
     );
-    manager.activate("async-menu-plugin", scopedApp);
+    manager.activate("async-menu-plugin", mockApp);
     await Promise.resolve();
     register?.();
 
@@ -704,7 +740,7 @@ describe("PluginManager toolbar menu scoping", () => {
   it("tags a menu (re)registered from applyProjectState, not just activate", () => {
     const manager = new PluginManager();
     const seen: Array<string | undefined> = [];
-    const scopedApp = {
+    const mockApp = {
       registerToolbarMenu: (
         _menu: unknown,
         ownerPluginId?: string,
@@ -734,7 +770,7 @@ describe("PluginManager toolbar menu scoping", () => {
         mapControlPositions: {},
         settings: { "settings-menu-plugin": {} },
       },
-      scopedApp,
+      mockApp,
     );
 
     assert.deepEqual(seen, ["settings-menu-plugin"]);

--- a/tests/plugin-manager.test.ts
+++ b/tests/plugin-manager.test.ts
@@ -631,3 +631,73 @@ describe("PluginManager async activation", () => {
     assert.equal(manager.isActive("reactivated-plugin"), true);
   });
 });
+
+describe("PluginManager toolbar menu scoping", () => {
+  it("tags registerToolbarMenu with the activating plugin's id", () => {
+    const manager = new PluginManager();
+    const seen: Array<string | undefined> = [];
+    const scopedApp = {
+      registerToolbarMenu: (
+        _menu: unknown,
+        ownerPluginId?: string,
+      ) => {
+        seen.push(ownerPluginId);
+        return () => undefined;
+      },
+    } as unknown as GeoLibreAppAPI;
+
+    manager.register(
+      testPlugin({
+        id: "menu-plugin",
+        // A plugin registers its menu with a single argument; the host injects
+        // the owner id via the scoped app it was handed.
+        activate: (api) =>
+          void api.registerToolbarMenu?.({
+            id: "menu-plugin-menu",
+            label: "Workbench",
+            items: [],
+          }),
+      }),
+    );
+    manager.activate("menu-plugin", scopedApp);
+
+    assert.deepEqual(seen, ["menu-plugin"]);
+  });
+
+  it("scopes a menu registered asynchronously after activate resolves", async () => {
+    const manager = new PluginManager();
+    const seen: Array<string | undefined> = [];
+    const scopedApp = {
+      registerToolbarMenu: (
+        _menu: unknown,
+        ownerPluginId?: string,
+      ) => {
+        seen.push(ownerPluginId);
+        return () => undefined;
+      },
+    } as unknown as GeoLibreAppAPI;
+
+    let register: (() => void) | undefined;
+    manager.register(
+      testPlugin({
+        id: "async-menu-plugin",
+        activate: (api) => {
+          // The plugin keeps the scoped app and registers its menu later, after
+          // its activation has returned. The owner tag must still be applied.
+          register = () =>
+            api.registerToolbarMenu?.({
+              id: "async-menu",
+              label: "Late",
+              items: [],
+            });
+          return Promise.resolve(true);
+        },
+      }),
+    );
+    manager.activate("async-menu-plugin", scopedApp);
+    await Promise.resolve();
+    register?.();
+
+    assert.deepEqual(seen, ["async-menu-plugin"]);
+  });
+});

--- a/tests/plugin-ui-surfaces.test.ts
+++ b/tests/plugin-ui-surfaces.test.ts
@@ -90,6 +90,17 @@ describe("toolbar-menu registry", () => {
     assert.equal(listToolbarMenus().length, 1);
     assert.equal(listToolbarMenus()[0].label, "Second");
   });
+
+  it("records the owning plugin id on the snapshot entry", () => {
+    registerToolbarMenu(testMenu({ id: "builtin-menu" }));
+    registerToolbarMenu(testMenu({ id: "external-menu" }), "acme.plugin");
+    const { entries } = getToolbarMenusSnapshot();
+    assert.equal(entries.length, 2);
+    assert.equal(entries[0].menu.id, "builtin-menu");
+    assert.equal(entries[0].ownerPluginId, undefined);
+    assert.equal(entries[1].menu.id, "external-menu");
+    assert.equal(entries[1].ownerPluginId, "acme.plugin");
+  });
 });
 
 describe("floating-panel registry", () => {


### PR DESCRIPTION
## Summary

External plugin toolbar menus (registered via `app.registerToolbarMenu()`) now render at the **end of the banner, after the Help menu**, so third-party menus sit together past the built-in menus. Built-in plugin menus continue to render beside the built-in menus (their previous location).

## How it works

The toolbar-menu registry never knew which plugin owned a menu, and the built-in/external distinction lives only in `external-plugins.ts`. This PR wires the two together:

- **Menu ownership tracking** (`toolbar-menu-registry.ts`): each registered menu now carries an optional `ownerPluginId`, exposed on the snapshot as `entries`.
- **Per-plugin app scoping** (`plugin-manager.ts`): on activation the `PluginManager` hands each plugin an app whose `registerToolbarMenu` is bound to that plugin's id. Because the plugin keeps the scoped app, even a menu registered asynchronously (after an `await` in `activate`) is tagged correctly.
- **External lookup** (`external-plugins.ts`): new `isExternalPluginId(id)` checks the existing `externallyLoadedPluginSources` map.
- **Split rendering** (`PluginToolbarMenus.tsx` + `TopToolbar.tsx`): the component takes a `placement` prop and is rendered twice — `builtin` at the original spot, `external` after Help. Menus with no/unknown owner fall in with the built-ins.

## Tests

- Registry records `ownerPluginId` on the snapshot entry.
- `PluginManager` tags `registerToolbarMenu` with the activating plugin's id, including the async-registration case.
- Full frontend suite (1419 passing) and full build/typecheck green.

> Note: the local `node_modules` had a stale `maplibre-gl-vector@0.6.0` (the repo pins `^0.7.0` since #700); `npm install` synced it. No lockfile change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toolbar menus from external plugins are now rendered at the end of the toolbar banner, after the Help menu, separate from built-in plugin menus.
  * Toolbar menu registration now tracks which plugin owns each menu to ensure correct placement.
* **Documentation**
  * Updated the plugin API docs to explain external vs. built-in toolbar menu placement and how ownership is determined by the host.
* **Tests**
  * Added/extended tests to verify plugin scoping for toolbar menu ownership, including both immediate and async registration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->