### PR TITLE
fix(offline): bound the offline zoom range to the map's real max zoom

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/OfflineRegionDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/OfflineRegionDialog.tsx
@@ -405,6 +405,11 @@ export function OfflineRegionDialog({
                 min={1}
                 max={maxExtraLevels}
                 step={1}
+                // Clamp only the displayed value, not the `extraLevels` state:
+                // `maxExtraLevels` is derived from the view + map max zoom
+                // snapshotted at open time and `extraLevels` resets to 1 on open,
+                // so the two can't diverge within a session. planOfflineZoom
+                // clamps again, so the footer stays correct regardless.
                 value={[Math.min(extraLevels, maxExtraLevels)]}
                 onValueChange={(value: number[]) => setExtraLevels(value[0])}
                 disabled={controlsDisabled}

--- a/apps/geolibre-desktop/src/components/layout/OfflineRegionDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/OfflineRegionDialog.tsx
@@ -25,6 +25,7 @@ import {
   collectOfflineUrls,
   countOfflineTiles,
   hasActiveServiceWorker,
+  planOfflineZoom,
   warmUrls,
   type WarmProgress,
 } from "../../lib/offline-tiles";
@@ -52,6 +53,12 @@ const CACHED_TILE_HOST = /(?:^|\.)(?:openfreemap\.org|cartocdn\.com)$/;
 const AVG_TILE_BYTES = 30 * 1024;
 
 const MAX_EXTRA_LEVELS = 5;
+
+/**
+ * Fallback map max zoom when the live map can't be read. Matches MapLibre's
+ * default ceiling; the real value comes from the map's `getMaxZoom()`.
+ */
+const DEFAULT_MAX_ZOOM = 22;
 
 /** Default and bounds for the advanced concurrency control. */
 const DEFAULT_CONCURRENCY = 6;
@@ -103,16 +110,32 @@ export function OfflineRegionDialog({
   const progressRef = useRef(progress);
   progressRef.current = progress;
 
-  // Snapshot the view when the dialog opens; re-reading live would let the
-  // estimate drift while the user is interacting with the dialog.
+  // Snapshot the view (and the map's configured max zoom) when the dialog opens;
+  // re-reading live would let the estimate drift while the user is interacting
+  // with the dialog.
   const view = useMemo(() => {
     if (!open) return null;
     return mapControllerRef.current?.readView() ?? null;
   }, [open, mapControllerRef]);
+  const mapMaxZoom = useMemo(() => {
+    if (!open) return DEFAULT_MAX_ZOOM;
+    const max = mapControllerRef.current?.getMap()?.getMaxZoom();
+    return typeof max === "number" && Number.isFinite(max)
+      ? max
+      : DEFAULT_MAX_ZOOM;
+  }, [open, mapControllerRef]);
 
-  const baseZoom = view ? Math.floor(view.zoom) : 0;
-  const effectiveExtra = includeExtra ? extraLevels : 0;
-  const maxZoom = Math.min(22, baseZoom + effectiveExtra);
+  // Bound the extra-detail range by the map's real max zoom (configurable, up to
+  // 24) instead of a fixed ceiling, so the slider tracks what the map can render,
+  // every step has an effect, and the range never inverts at the top zoom (#750,
+  // #751).
+  const { baseZoom, maxZoom, maxExtraLevels, canIncludeExtra } = planOfflineZoom(
+    view?.zoom ?? 0,
+    mapMaxZoom,
+    includeExtra,
+    extraLevels,
+    MAX_EXTRA_LEVELS,
+  );
   const bbox = (view?.bbox ?? null) as Bbox | null;
 
   // Tile count is resolved asynchronously: it clamps each source to its own
@@ -349,18 +372,23 @@ export function OfflineRegionDialog({
         )}
 
         <div className="space-y-4 py-2">
-          <label className="flex items-center gap-2 text-sm font-medium">
-            <input
-              className="h-4 w-4"
-              type="checkbox"
-              checked={includeExtra}
-              disabled={controlsDisabled}
-              onChange={(event) => setIncludeExtra(event.target.checked)}
-            />
-            {t("offline.includeExtra")}
-          </label>
+          {/* At the map's max zoom there is no deeper detail to fetch, so the
+              "include extra" control is hidden — offering it would only produce
+              an empty (or inverted) range (#751). */}
+          {canIncludeExtra && (
+            <label className="flex items-center gap-2 text-sm font-medium">
+              <input
+                className="h-4 w-4"
+                type="checkbox"
+                checked={includeExtra}
+                disabled={controlsDisabled}
+                onChange={(event) => setIncludeExtra(event.target.checked)}
+              />
+              {t("offline.includeExtra")}
+            </label>
+          )}
 
-          {includeExtra ? (
+          {canIncludeExtra && includeExtra ? (
             <div className="space-y-4">
               <div className="flex items-center justify-between">
                 <Label>{t("offline.detailLevels")}</Label>
@@ -375,9 +403,9 @@ export function OfflineRegionDialog({
               <Slider
                 aria-label={t("offline.detailLevels")}
                 min={1}
-                max={MAX_EXTRA_LEVELS}
+                max={maxExtraLevels}
                 step={1}
-                value={[extraLevels]}
+                value={[Math.min(extraLevels, maxExtraLevels)]}
                 onValueChange={(value: number[]) => setExtraLevels(value[0])}
                 disabled={controlsDisabled}
               />

--- a/apps/geolibre-desktop/src/components/layout/OfflineRegionDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/OfflineRegionDialog.tsx
@@ -55,10 +55,12 @@ const AVG_TILE_BYTES = 30 * 1024;
 const MAX_EXTRA_LEVELS = 5;
 
 /**
- * Fallback map max zoom when the live map can't be read. Matches MapLibre's
- * default ceiling; the real value comes from the map's `getMaxZoom()`.
+ * Fallback map max zoom for the rare case where the live map can't be read at
+ * dialog-open time. Matches the project's default max zoom (see
+ * `DEFAULT_PROJECT_PREFERENCES.map.maxZoom`) so the degraded path doesn't revert
+ * to the old hard-coded 22 ceiling; the real value comes from `getMaxZoom()`.
  */
-const DEFAULT_MAX_ZOOM = 22;
+const DEFAULT_MAX_ZOOM = 24;
 
 /** Default and bounds for the advanced concurrency control. */
 const DEFAULT_CONCURRENCY = 6;

--- a/apps/geolibre-desktop/src/lib/offline-tiles.ts
+++ b/apps/geolibre-desktop/src/lib/offline-tiles.ts
@@ -89,6 +89,71 @@ function splitAntimeridian(bbox: Bbox): Bbox[] {
     : [bbox];
 }
 
+/** Resolved zoom plan for the offline download dialog. */
+export interface OfflineZoomPlan {
+  /** Lowest zoom to download — the snapshot view's integer zoom, never above the map's max. */
+  baseZoom: number;
+  /** Highest zoom to download. Always `>= baseZoom` (never an inverted range). */
+  maxZoom: number;
+  /**
+   * Highest extra-level value the slider should offer. Capped so every step has
+   * an effect (you can't add levels past the map's max zoom) and at least 1 so
+   * the slider stays valid even when no extra levels are available.
+   */
+  maxExtraLevels: number;
+  /**
+   * Whether extra higher-zoom detail can be added at all. False when the view is
+   * already at the map's maximum zoom, where there is nothing deeper to fetch —
+   * the dialog hides the "include extra" control in that case.
+   */
+  canIncludeExtra: boolean;
+}
+
+/**
+ * Resolve the zoom range an offline download should cover from the dialog's
+ * inputs, bounded by the map's actual maximum zoom rather than a fixed ceiling.
+ *
+ * This keeps the preview honest at high zoom: the extra-detail range tracks what
+ * the map can really render (its configurable max zoom, up to 24), the slider
+ * only offers levels that have an effect, and the resulting range is never
+ * inverted (e.g. a "24–22" backwards range at the top of the zoom range).
+ *
+ * Args:
+ *   viewZoom: The snapshot view's zoom (may be fractional).
+ *   mapMaxZoom: The map's configured maximum zoom.
+ *   includeExtra: Whether the "include extra detail levels" toggle is on.
+ *   extraLevels: The extra-levels slider value.
+ *   hardMaxExtraLevels: The slider's absolute upper bound (the dialog's cap).
+ *
+ * Returns:
+ *   The resolved {@link OfflineZoomPlan}.
+ */
+export function planOfflineZoom(
+  viewZoom: number,
+  mapMaxZoom: number,
+  includeExtra: boolean,
+  extraLevels: number,
+  hardMaxExtraLevels: number,
+): OfflineZoomPlan {
+  const ceil = Math.max(0, Math.floor(mapMaxZoom));
+  const baseZoom = Math.min(Math.max(0, Math.floor(viewZoom)), ceil);
+  const canIncludeExtra = baseZoom < ceil;
+  const maxExtraLevels = Math.max(
+    1,
+    Math.min(hardMaxExtraLevels, ceil - baseZoom),
+  );
+  const effectiveExtra =
+    includeExtra && canIncludeExtra
+      ? Math.min(Math.max(1, Math.floor(extraLevels)), maxExtraLevels)
+      : 0;
+  return {
+    baseZoom,
+    maxZoom: baseZoom + effectiveExtra,
+    maxExtraLevels,
+    canIncludeExtra,
+  };
+}
+
 /**
  * Count the tiles covering `bbox` across `[minZoom, maxZoom]` without
  * materializing them — used to preview download size before committing.

--- a/apps/geolibre-desktop/src/lib/offline-tiles.ts
+++ b/apps/geolibre-desktop/src/lib/offline-tiles.ts
@@ -126,6 +126,7 @@ export interface OfflineZoomPlan {
  *   extraLevels: The extra-levels slider value. Floored to an integer and
  *     treated as at least 1 when `includeExtra` is on.
  *   hardMaxExtraLevels: The slider's absolute upper bound (the dialog's cap).
+ *     Must be `>= 1`; the dialog passes a fixed positive constant.
  *
  * Returns:
  *   The resolved {@link OfflineZoomPlan}.
@@ -142,7 +143,8 @@ export function planOfflineZoom(
   const canIncludeExtra = baseZoom < ceil;
   // 0 when the view is already at the map's max zoom. The slider's `max` is
   // gated behind `canIncludeExtra` in the dialog, so it never receives 0; when
-  // it is shown, `ceil - baseZoom >= 1` guarantees a valid range.
+  // it is shown, `ceil - baseZoom >= 1` together with the `hardMaxExtraLevels
+  // >= 1` precondition guarantees a valid (non-inverted) range.
   const maxExtraLevels = Math.min(hardMaxExtraLevels, ceil - baseZoom);
   const effectiveExtra =
     includeExtra && canIncludeExtra

--- a/apps/geolibre-desktop/src/lib/offline-tiles.ts
+++ b/apps/geolibre-desktop/src/lib/offline-tiles.ts
@@ -123,7 +123,8 @@ export interface OfflineZoomPlan {
  *   viewZoom: The snapshot view's zoom (may be fractional).
  *   mapMaxZoom: The map's configured maximum zoom.
  *   includeExtra: Whether the "include extra detail levels" toggle is on.
- *   extraLevels: The extra-levels slider value.
+ *   extraLevels: The extra-levels slider value. Floored to an integer and
+ *     treated as at least 1 when `includeExtra` is on.
  *   hardMaxExtraLevels: The slider's absolute upper bound (the dialog's cap).
  *
  * Returns:
@@ -145,7 +146,9 @@ export function planOfflineZoom(
   const maxExtraLevels = Math.min(hardMaxExtraLevels, ceil - baseZoom);
   const effectiveExtra =
     includeExtra && canIncludeExtra
-      ? Math.min(Math.max(1, Math.floor(extraLevels)), maxExtraLevels)
+      ? // Sub-1 values are treated as 1 extra level; the dialog's slider enforces
+        // min=1, so this floor only guards out-of-range programmatic callers.
+        Math.min(Math.max(1, Math.floor(extraLevels)), maxExtraLevels)
       : 0;
   return {
     baseZoom,

--- a/apps/geolibre-desktop/src/lib/offline-tiles.ts
+++ b/apps/geolibre-desktop/src/lib/offline-tiles.ts
@@ -96,9 +96,10 @@ export interface OfflineZoomPlan {
   /** Highest zoom to download. Always `>= baseZoom` (never an inverted range). */
   maxZoom: number;
   /**
-   * Highest extra-level value the slider should offer. Capped so every step has
-   * an effect (you can't add levels past the map's max zoom) and at least 1 so
-   * the slider stays valid even when no extra levels are available.
+   * Number of extra zoom levels available above the base zoom, capped at the
+   * hard maximum. This is the slider's upper bound; it is `0` exactly when
+   * `canIncludeExtra` is false (the view is at the map's max zoom). Callers
+   * should gate on `canIncludeExtra` rather than relying on a non-zero value.
    */
   maxExtraLevels: number;
   /**
@@ -138,10 +139,10 @@ export function planOfflineZoom(
   const ceil = Math.max(0, Math.floor(mapMaxZoom));
   const baseZoom = Math.min(Math.max(0, Math.floor(viewZoom)), ceil);
   const canIncludeExtra = baseZoom < ceil;
-  const maxExtraLevels = Math.max(
-    1,
-    Math.min(hardMaxExtraLevels, ceil - baseZoom),
-  );
+  // 0 when the view is already at the map's max zoom. The slider's `max` is
+  // gated behind `canIncludeExtra` in the dialog, so it never receives 0; when
+  // it is shown, `ceil - baseZoom >= 1` guarantees a valid range.
+  const maxExtraLevels = Math.min(hardMaxExtraLevels, ceil - baseZoom);
   const effectiveExtra =
     includeExtra && canIncludeExtra
       ? Math.min(Math.max(1, Math.floor(extraLevels)), maxExtraLevels)

--- a/tests/offline-tiles.test.ts
+++ b/tests/offline-tiles.test.ts
@@ -234,6 +234,15 @@ describe("planOfflineZoom", () => {
     const plan = planOfflineZoom(10, 24, true, 3, HARD_MAX);
     assert.equal(plan.baseZoom, 10);
     assert.equal(plan.maxZoom, 13);
+    assert.equal(plan.canIncludeExtra, true);
+    assert.equal(plan.maxExtraLevels, HARD_MAX);
+  });
+
+  it("treats extraLevels below 1 as 1 when includeExtra is on", () => {
+    const plan = planOfflineZoom(10, 24, true, 0, HARD_MAX);
+    assert.equal(plan.baseZoom, 10);
+    assert.equal(plan.maxZoom, 11); // Math.max(1, 0) → 1 extra level applied
+    assert.equal(plan.canIncludeExtra, true);
   });
 
   it("caps the extra range at the map's max zoom rather than a fixed 22", () => {

--- a/tests/offline-tiles.test.ts
+++ b/tests/offline-tiles.test.ts
@@ -253,6 +253,19 @@ describe("planOfflineZoom", () => {
     assert.equal(plan.maxZoom, 24);
   });
 
+  it("caps maxExtraLevels to 1 when only one level separates base from ceiling", () => {
+    const plan = planOfflineZoom(23, 24, true, 5, HARD_MAX);
+    assert.equal(plan.maxExtraLevels, 1);
+    assert.equal(plan.maxZoom, 24);
+  });
+
+  it("floors a fractional mapMaxZoom", () => {
+    // getMaxZoom() can return a non-integer; floor(24.7) = 24.
+    const plan = planOfflineZoom(10, 24.7, true, 3, HARD_MAX);
+    assert.equal(plan.maxExtraLevels, HARD_MAX);
+    assert.equal(plan.maxZoom, 13);
+  });
+
   it("never produces an inverted range at the map's max zoom (#751)", () => {
     // At zoom 24 of a 24-max map there is nothing deeper to fetch: extra detail
     // is unavailable and the range stays at the base zoom, not a backwards

--- a/tests/offline-tiles.test.ts
+++ b/tests/offline-tiles.test.ts
@@ -6,6 +6,7 @@ import {
   enumerateTiles,
   expandTileUrl,
   lngLatToTile,
+  planOfflineZoom,
   tileRangeForBbox,
   tileToQuadkey,
   warmUrls,
@@ -215,5 +216,57 @@ describe("warmUrls", () => {
     // An abort short-circuits counting, so nothing is recorded as done/failed.
     assert.equal(result.done, 0);
     assert.equal(result.failed, 0);
+  });
+});
+
+describe("planOfflineZoom", () => {
+  const HARD_MAX = 5;
+
+  it("downloads the current view only when extra detail is off", () => {
+    const plan = planOfflineZoom(10.4, 24, false, 3, HARD_MAX);
+    assert.equal(plan.baseZoom, 10);
+    assert.equal(plan.maxZoom, 10);
+    assert.equal(plan.canIncludeExtra, true);
+    assert.equal(plan.maxExtraLevels, HARD_MAX);
+  });
+
+  it("adds the chosen extra levels on top of the base zoom", () => {
+    const plan = planOfflineZoom(10, 24, true, 3, HARD_MAX);
+    assert.equal(plan.baseZoom, 10);
+    assert.equal(plan.maxZoom, 13);
+  });
+
+  it("caps the extra range at the map's max zoom rather than a fixed 22", () => {
+    // baseZoom 22, map max 24 → only 2 levels are meaningful (22→24), and the
+    // slider's upper bound reflects that so every step has an effect (#750).
+    const plan = planOfflineZoom(22, 24, true, 5, HARD_MAX);
+    assert.equal(plan.maxExtraLevels, 2);
+    assert.equal(plan.maxZoom, 24);
+  });
+
+  it("never produces an inverted range at the map's max zoom (#751)", () => {
+    // At zoom 24 of a 24-max map there is nothing deeper to fetch: extra detail
+    // is unavailable and the range stays at the base zoom, not a backwards
+    // "24–22".
+    const plan = planOfflineZoom(24, 24, true, 3, HARD_MAX);
+    assert.equal(plan.canIncludeExtra, false);
+    assert.equal(plan.baseZoom, 24);
+    assert.equal(plan.maxZoom, 24);
+    assert.ok(plan.maxZoom >= plan.baseZoom);
+  });
+
+  it("clamps the base zoom to the map's max zoom", () => {
+    // A view zoom above the configured max (shouldn't happen, but guard it)
+    // still yields a sane, non-inverted plan.
+    const plan = planOfflineZoom(30, 24, false, 1, HARD_MAX);
+    assert.equal(plan.baseZoom, 24);
+    assert.equal(plan.maxZoom, 24);
+    assert.equal(plan.canIncludeExtra, false);
+  });
+
+  it("respects the hard cap on extra levels below the map's max zoom", () => {
+    const plan = planOfflineZoom(5, 24, true, 9, HARD_MAX);
+    assert.equal(plan.maxExtraLevels, HARD_MAX);
+    assert.equal(plan.maxZoom, 5 + HARD_MAX);
   });
 });

--- a/tests/offline-tiles.test.ts
+++ b/tests/offline-tiles.test.ts
@@ -252,6 +252,7 @@ describe("planOfflineZoom", () => {
     assert.equal(plan.canIncludeExtra, false);
     assert.equal(plan.baseZoom, 24);
     assert.equal(plan.maxZoom, 24);
+    assert.equal(plan.maxExtraLevels, 0);
     assert.ok(plan.maxZoom >= plan.baseZoom);
   });
 
@@ -262,6 +263,7 @@ describe("planOfflineZoom", () => {
     assert.equal(plan.baseZoom, 24);
     assert.equal(plan.maxZoom, 24);
     assert.equal(plan.canIncludeExtra, false);
+    assert.equal(plan.maxExtraLevels, 0); // no room for extra levels at the ceiling
   });
 
   it("respects the hard cap on extra levels below the map's max zoom", () => {


### PR DESCRIPTION
## Summary

The **Download Offline Area** dialog hard-coded a maximum zoom of `22` for the extra-detail range, while the map's configurable max zoom goes up to **24** (the project default). At high zoom levels this caused the cluster of UI bugs reported in #750 and #751:

- **#751-1** The extra-detail slider stopped at zoom 22, so it could not cover the higher-resolution tiles the map can render up to 24.
- **#751-2** At the map's max zoom (24), the "Include extra detail levels" toggle was still shown even though there is no deeper detail to fetch.
- **#751-3** Enabling the toggle at zoom 24 produced a backwards `Zoom 24–22` range with a negative `+-2 levels` count.
- **#750-2 / #750-3** Because the capped max zoom never changed above 22, the slider and the tile-count footer were frozen and ignored slider adjustments.

## Fix

Extracted a pure, unit-tested `planOfflineZoom` helper that derives the base/max zoom, the slider's effective upper bound, and whether extra detail is available at all, all bounded by the map's actual `getMaxZoom()` instead of a fixed `22`. The dialog now:

- reads the map's real max zoom when it opens,
- **hides** the "Include extra detail" control when the view is already at the map's max zoom (nothing deeper to fetch),
- caps the slider so every step has an effect (you can't add levels past the map's max zoom), and
- never produces an inverted range.

## Testing

- Added `planOfflineZoom` unit tests in `tests/offline-tiles.test.ts`; full frontend suite passes (1437 tests).
- Verified in the real app (production build + service worker) with Playwright in **both light and dark themes**:
  - At zoom 24: toggle hidden, shows "Current view only · Zoom 24", no reversed range.
  - At zoom 20: toggle shown, slider capped at 4 levels (20→24), forward "Zoom 20–21" range.
  - At zoom 12: dragging the slider updates both the range label ("Zoom 12–15") and the tile count (14 → 50), confirming the footer recalculates dynamically.

Fixes #750
Fixes #751

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Offline region download dialog now derives zoom limits from your map’s configured maximum zoom (with a safe fallback when unavailable), replacing fixed ceiling logic.
  * “Extra detail” is now shown only when it can be meaningfully applied, and the detail-level slider is constrained to valid ranges.
  * Zoom planning behavior is centralized to keep the dialog’s displayed zoom range consistent with available map zoom headroom.

* **Tests**
  * Added comprehensive test coverage for zoom planning calculations and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->