### PR TITLE
fix(print-layout): scale feedback, customizable map frame, and dropdown polish

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -158,6 +158,10 @@ export function PrintLayoutDialog({
   const [showPageBorder, setShowPageBorder] = useState(false);
   const [pageBorderColor, setPageBorderColor] = useState("#111827");
   const [pageBorderWidth, setPageBorderWidth] = useState(2);
+  // Map frame (the border around the map body). Width is a 0–10 scale; 0 hides
+  // the frame. Defaults match the original hardcoded hairline (GH #749).
+  const [mapBorderColor, setMapBorderColor] = useState("#9ca3af");
+  const [mapBorderWidth, setMapBorderWidth] = useState(1);
   const [mapBackground, setMapBackground] = useState("#e5e7eb");
   // Draft for the free-form hex field; only complete #RGB / #RRGGBB values are
   // committed to mapBackground (which also drives <input type="color"> and the
@@ -261,6 +265,13 @@ export function PrintLayoutDialog({
   // what the user is typing.
   const scaleFocusedRef = useRef(false);
   const [scaleDraft, setScaleDraft] = useState("");
+  // Inline notice shown when a requested scale can't be reached at the map's
+  // zoom limits, so a clamped result is never silently swallowed (GH #743).
+  const [scaleNotice, setScaleNotice] = useState<string | null>(null);
+  // Fallback timer that forces a recapture if the map's "idle" event is delayed
+  // or never fires (e.g. WebKit throttling the occluded map canvas behind the
+  // dialog), so a scale change is never silently dropped (GH #743).
+  const idleFallbackRef = useRef<number | null>(null);
   // Width of the left controls column; dragged via the splitter handle.
   const [controlsWidth, setControlsWidth] = useState(CONTROLS_DEFAULT_WIDTH);
   // Mirror of controlsWidth so the resize handler can read the latest start
@@ -433,6 +444,10 @@ export function PrintLayoutDialog({
         map.off("idle", idleRecaptureRef.current);
         idleRecaptureRef.current = null;
       }
+      if (idleFallbackRef.current !== null) {
+        window.clearTimeout(idleFallbackRef.current);
+        idleFallbackRef.current = null;
+      }
       // An explicit override wins (used right after drawing, before state has
       // settled); otherwise clip to the stored extent only in extent mode.
       const clip =
@@ -484,6 +499,10 @@ export function PrintLayoutDialog({
       drawAbortRef.current?.abort();
       // Tear down an in-progress resize drag so its window listeners don't leak.
       resizeCleanupRef.current?.();
+      if (idleFallbackRef.current !== null) {
+        window.clearTimeout(idleFallbackRef.current);
+        idleFallbackRef.current = null;
+      }
       const map = mapControllerRef.current?.getMap();
       if (map) {
         if (idleRecaptureRef.current) {
@@ -528,6 +547,8 @@ export function PrintLayoutDialog({
       showPageBorder,
       pageBorderColor,
       pageBorderWidth,
+      mapBorderColor,
+      mapBorderWidth,
       mapBackground,
       colorbar: showColorbar
         ? {
@@ -596,6 +617,8 @@ export function PrintLayoutDialog({
       showPageBorder,
       pageBorderColor,
       pageBorderWidth,
+      mapBorderColor,
+      mapBorderWidth,
       mapBackground,
       showColorbar,
       colorbarRamp,
@@ -653,12 +676,28 @@ export function PrintLayoutDialog({
         return;
       }
       const newZoom = map.getZoom() + Math.log2(currentRatio / targetRatio);
-      const clampedZoom = Math.max(0, Math.min(24, newZoom));
-      // Drop a still-pending idle handler from a prior applyScale before
-      // registering a new one, so two quick scale changes don't both fire.
+      // Clamp to the map's own zoom limits (not a fixed 0–24) so the out-of-range
+      // notice reflects what this map can actually reach.
+      const minZoom = map.getMinZoom();
+      const maxZoom = map.getMaxZoom();
+      const clampedZoom = Math.max(minZoom, Math.min(maxZoom, newZoom));
+      // The requested scale needs a zoom past the map's limits, so it can only be
+      // applied partially: surface that instead of letting the value snap back
+      // with no explanation (GH #743). A reachable scale clears the notice.
+      setScaleNotice(
+        Math.abs(clampedZoom - newZoom) > 1e-3
+          ? t("printLayout.errors.scaleOutOfRange")
+          : null,
+      );
+      // Drop a still-pending idle handler / fallback timer from a prior applyScale
+      // before registering new ones, so two quick scale changes don't both fire.
       if (idleRecaptureRef.current) {
         map.off("idle", idleRecaptureRef.current);
         idleRecaptureRef.current = null;
+      }
+      if (idleFallbackRef.current !== null) {
+        window.clearTimeout(idleFallbackRef.current);
+        idleFallbackRef.current = null;
       }
       // No effective zoom change (already at target, or clamped): MapLibre won't
       // emit an "idle", so recapture directly rather than registering a handler
@@ -677,12 +716,28 @@ export function PrintLayoutDialog({
       const handler = () => {
         map.off("idle", handler);
         idleRecaptureRef.current = null;
+        if (idleFallbackRef.current !== null) {
+          window.clearTimeout(idleFallbackRef.current);
+          idleFallbackRef.current = null;
+        }
         recapture(null);
       };
       idleRecaptureRef.current = handler;
       map.on("idle", handler);
+      // Fallback: if "idle" is delayed or never arrives (some browsers throttle
+      // the occluded map canvas behind this dialog, so the zoom never settles and
+      // the scale would appear to silently do nothing), force the recapture after
+      // a short grace period. GH #743.
+      idleFallbackRef.current = window.setTimeout(() => {
+        idleFallbackRef.current = null;
+        if (idleRecaptureRef.current) {
+          map.off("idle", idleRecaptureRef.current);
+          idleRecaptureRef.current = null;
+          recapture(null);
+        }
+      }, 1500);
     },
-    [mapControllerRef, captureMode, currentRatio, recapture],
+    [mapControllerRef, captureMode, currentRatio, recapture, t],
   );
 
   // Hide the dialog so the map is interactive, let the user drag an extent box,
@@ -735,6 +790,9 @@ export function PrintLayoutDialog({
   const setMode = useCallback(
     (mode: "viewport" | "extent") => {
       if (mode === captureMode) return;
+      // The scale control is disabled in extent mode, so a stale out-of-range
+      // notice from a viewport scale attempt must not linger (GH #743).
+      if (mode === "extent") setScaleNotice(null);
       setCaptureMode(mode);
       recapture(mode === "extent" ? extentBbox : null);
     },
@@ -1082,6 +1140,39 @@ export function PrintLayoutDialog({
               </div>
             </div>
 
+            {/* Map frame border (color + thickness; 0 hides it). GH #749. */}
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="layout-map-border-color">
+                  {t("printLayout.mapBorderColor")}
+                </Label>
+                <input
+                  id="layout-map-border-color"
+                  type="color"
+                  className="h-9 w-full cursor-pointer rounded-md border border-input bg-background"
+                  value={mapBorderColor}
+                  onChange={(e) => setMapBorderColor(e.target.value)}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="layout-map-border-width">
+                  {t("printLayout.mapBorderWidth")}
+                </Label>
+                <Input
+                  id="layout-map-border-width"
+                  type="number"
+                  min={0}
+                  max={10}
+                  value={mapBorderWidth}
+                  onChange={(e) =>
+                    setMapBorderWidth(
+                      Math.max(0, Math.min(10, Number(e.target.value) || 0)),
+                    )
+                  }
+                />
+              </div>
+            </div>
+
             {isMmPage && (
               <div className="space-y-1.5">
                 <Label htmlFor="layout-scale">
@@ -1135,6 +1226,9 @@ export function PrintLayoutDialog({
                     ))}
                   </Select>
                 </div>
+                {scaleNotice && (
+                  <p className="text-xs text-destructive">{scaleNotice}</p>
+                )}
               </div>
             )}
 

--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -479,6 +479,10 @@ export function PrintLayoutDialog({
     const map = mapControllerRef.current?.getMap();
     if (open && !wasOpenRef.current) {
       setError(null);
+      // Clear any out-of-range scale notice from a prior session: the dialog is
+      // hidden (not unmounted) on close, so it would otherwise persist into the
+      // next open even though no scale was just attempted (GH #743).
+      setScaleNotice(null);
       setTitle((prev) => prev || (projectName ?? "").trim());
       setDateText((prev) => prev || new Date().toLocaleDateString());
       // Re-show a previously drawn extent box while composing.

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -632,8 +632,8 @@
     "unit": "Unit",
     "titlePlacement": "Title placement",
     "placement": {
-      "outside": "Outside map frame",
-      "inside": "Inside map frame"
+      "outside": "Outside frame",
+      "inside": "Inside frame"
     },
     "alignment": "Alignment",
     "align": {
@@ -721,11 +721,14 @@
     },
     "borderColor": "Border color",
     "borderWidth": "Border width",
+    "mapBorderColor": "Map frame color",
+    "mapBorderWidth": "Map frame width",
     "errors": {
       "mapNotReady": "Map is not ready yet. Try again in a moment.",
       "captureFailed": "Could not capture the map image.",
       "captureFirst": "Capture the map before exporting.",
-      "exportFailed": "Failed to export {{format}}."
+      "exportFailed": "Failed to export {{format}}.",
+      "scaleOutOfRange": "This scale is outside the range the current view can reach; showing the closest available scale."
     },
     "legend": {
       "section": "Legend",

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -206,6 +206,16 @@ export interface LayoutOptions {
   /** Page border thickness on a 1–10 scale (relative to page size). */
   pageBorderWidth?: number;
   /**
+   * Colour of the map frame (the border drawn around the map body). Defaults to
+   * a neutral grey when omitted. GH #749.
+   */
+  mapBorderColor?: string;
+  /**
+   * Map frame thickness on a 0–10 scale (relative to page size); 0 hides the
+   * frame. Defaults to 1 (the original hairline). GH #749.
+   */
+  mapBorderWidth?: number;
+  /**
    * Fill colour drawn behind the map image. Shows through wherever the capture
    * is transparent (most visibly the area around the sphere in globe
    * projection). Defaults to a light grey.
@@ -534,10 +544,17 @@ export function drawLayout(
   }
   ctx.restore();
 
-  // Body border.
-  ctx.strokeStyle = BORDER;
-  ctx.lineWidth = Math.max(1, unit * 0.2);
-  ctx.strokeRect(bodyX, bodyY, bodyW, bodyH);
+  // Body border (the map frame). Colour and thickness are user-customizable; a
+  // thickness of 0 hides the frame entirely (GH #749). The thickness is a 0–10
+  // scale relative to the page so it reads the same at any export resolution.
+  const mapBorderScale = Math.max(0, Math.min(10, opts.mapBorderWidth ?? 1));
+  const mapBorderWidth =
+    mapBorderScale > 0 ? Math.max(1, unit * 0.2 * mapBorderScale) : 0;
+  if (mapBorderWidth > 0) {
+    ctx.strokeStyle = opts.mapBorderColor ?? BORDER;
+    ctx.lineWidth = mapBorderWidth;
+    ctx.strokeRect(bodyX, bodyY, bodyW, bodyH);
+  }
 
   // --- Title block (inside the map) --------------------------------------
   // Overlaid at the top of the map body with a translucent backing for legibility.
@@ -564,8 +581,18 @@ export function drawLayout(
       padY * 2 +
       (hasTitleText ? titleSize : 0) +
       (hasSubtitleText ? (hasTitleText ? subtitleSize * 1.6 : subtitleSize * 1.2) : 0);
+    // Keep the translucent backing clear of the map frame so it does not wash
+    // out the dark border line at the top/left/right edges (GH #748). The body
+    // border is centred on the body edge, so its inner half lies inside this
+    // fill; inset by the full border width to leave the frame line crisp.
+    const frameInset = mapBorderWidth;
     ctx.fillStyle = "rgba(255,255,255,0.7)";
-    ctx.fillRect(bodyX, bodyY, bodyW, blockH);
+    ctx.fillRect(
+      bodyX + frameInset,
+      bodyY + frameInset,
+      bodyW - frameInset * 2,
+      blockH - frameInset,
+    );
     if (hasTitleText) {
       ctx.fillStyle = INK;
       ctx.font = `600 ${titleSize}px system-ui, -apple-system, sans-serif`;

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -582,10 +582,11 @@ export function drawLayout(
       (hasTitleText ? titleSize : 0) +
       (hasSubtitleText ? (hasTitleText ? subtitleSize * 1.6 : subtitleSize * 1.2) : 0);
     // Keep the translucent backing clear of the map frame so it does not wash
-    // out the dark border line at the top/left/right edges (GH #748). The body
-    // border is centred on the body edge, so its inner half lies inside this
-    // fill; inset by the full border width to leave the frame line crisp.
-    const frameInset = mapBorderWidth;
+    // out the dark border line at the top/left/right edges (GH #748). strokeRect
+    // centres the stroke on the body edge, so only its inner half (lineWidth/2)
+    // intrudes into the body; inset the fill by exactly that so it starts at the
+    // frame's inner edge with no gap and no overlap.
+    const frameInset = mapBorderWidth / 2;
     ctx.fillStyle = "rgba(255,255,255,0.7)";
     ctx.fillRect(
       bodyX + frameInset,

--- a/apps/geolibre-desktop/src/lib/print-layout.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout.ts
@@ -591,6 +591,8 @@ export function drawLayout(
       bodyX + frameInset,
       bodyY + frameInset,
       bodyW - frameInset * 2,
+      // Top shifted down by frameInset; shrink the height to keep the bottom
+      // edge at bodyY + blockH (which sits inside the body, off any frame line).
       blockH - frameInset,
     );
     if (hasTitleText) {

--- a/tests/print-layout.test.ts
+++ b/tests/print-layout.test.ts
@@ -376,9 +376,10 @@ function strokeRecordingCanvas(): {
 }
 
 describe("drawLayout map frame border (GH #749)", () => {
-  // The body rectangle starts at the page margin (5 units = 5% of the 400px
-  // shorter side with default margins), so the body border stroke begins at
-  // x=20 and spans most of the page width.
+  // These constants follow directly from computeBodyRect on a 400×400 canvas
+  // with the default "normal" margin: unit = min(400,400)/100 = 4, margin =
+  // unit*5 = 20, so bodyX = 20 and bodyW = 400 - 40 = 360 (> 200). If the unit
+  // formula or default margin changes, update these values.
   const isBodyBorder = (s: { x: number; w: number }) => s.x === 20 && s.w > 200;
 
   it("draws the frame in the chosen colour and thickness", () => {

--- a/tests/print-layout.test.ts
+++ b/tests/print-layout.test.ts
@@ -330,3 +330,76 @@ describe("computeScaleRatio", () => {
     assert.ok(Math.abs(b / a - 2) < 1e-9, "doubling mpp doubles the ratio");
   });
 });
+
+/**
+ * A recording context that captures every `strokeRect` with the stroke style and
+ * line width in effect at the moment of the draw, so tests can assert how the
+ * map frame border (GH #749) is rendered.
+ */
+function strokeRecordingCanvas(): {
+  canvas: HTMLCanvasElement;
+  strokes: { x: number; w: number; strokeStyle: string; lineWidth: number }[];
+} {
+  const strokes: {
+    x: number;
+    w: number;
+    strokeStyle: string;
+    lineWidth: number;
+  }[] = [];
+  const state: Record<string, unknown> = { strokeStyle: "", lineWidth: 0 };
+  const ctx = new Proxy(state, {
+    get(target, prop) {
+      if (prop === "measureText") return () => ({ width: 10 });
+      if (prop === "strokeRect") {
+        return (x: number, _y: number, w: number) =>
+          strokes.push({
+            x,
+            w,
+            strokeStyle: String(target.strokeStyle),
+            lineWidth: Number(target.lineWidth),
+          });
+      }
+      if (prop in target) return target[prop as string];
+      return () => {};
+    },
+    set(target, prop, value) {
+      target[prop as string] = value;
+      return true;
+    },
+  });
+  const canvas = {
+    width: 400,
+    height: 400,
+    getContext: () => ctx,
+  } as unknown as HTMLCanvasElement;
+  return { canvas, strokes };
+}
+
+describe("drawLayout map frame border (GH #749)", () => {
+  // The body rectangle starts at the page margin (5 units = 5% of the 400px
+  // shorter side with default margins), so the body border stroke begins at
+  // x=20 and spans most of the page width.
+  const isBodyBorder = (s: { x: number; w: number }) => s.x === 20 && s.w > 200;
+
+  it("draws the frame in the chosen colour and thickness", () => {
+    const { canvas, strokes } = strokeRecordingCanvas();
+    drawLayout(
+      canvas,
+      baseOptions({ mapBorderColor: "#123456", mapBorderWidth: 5 }),
+    );
+    const frame = strokes.find(
+      (s) => isBodyBorder(s) && s.strokeStyle === "#123456",
+    );
+    assert.ok(frame, "expected the map frame to use the custom colour");
+    assert.ok(frame.lineWidth > 1, "expected a thicker frame for width 5");
+  });
+
+  it("hides the frame when the thickness is 0", () => {
+    const { canvas, strokes } = strokeRecordingCanvas();
+    drawLayout(canvas, baseOptions({ mapBorderWidth: 0 }));
+    assert.ok(
+      !strokes.some(isBodyBorder),
+      "expected no map frame stroke when width is 0",
+    );
+  });
+});


### PR DESCRIPTION
Fixes #743
Fixes #745
Fixes #748
Fixes #749

All four reports are about the **Print Layout** composer. This PR addresses them together.

## #743 — Scale presets/changes silently rejected
The reporter saw a scale change get swallowed with no feedback. Root cause is timing/limit related rather than the apply logic itself (verified the apply path works in both directions). Changes:
- Clamp the target zoom to the **map's own** min/max zoom (not a fixed 0–24).
- When a requested scale can't be reached at those limits, show an inline notice and apply the closest available scale instead of letting the value snap back unexplained.
- Add an **idle fallback timeout** so a recapture still fires if the map's `idle` event is delayed or never arrives (some browsers throttle the occluded map canvas behind the dialog, which can make a scale change appear to do nothing).

## #745 — Truncated title placement text
The selected value `Inside map frame` clipped to `Inside map fran`. Shortened the labels to **`Inside frame`** / **`Outside frame`** (the reporter's own suggestion), which fit the field.

## #748 — Inside-frame title background obscured the map border
The translucent title backing was drawn to the body edge, washing out the dark map frame line. It is now **inset by the frame width** so the border stays crisp along the top and sides.

## #749 — User-definable map frame color and thickness
Added a **Map frame color** picker and a **Map frame width** (0–10, where 0 hides the frame) under the layout options. The frame draws live in the preview and the export. Defaults match the previous hairline so existing layouts are unchanged.

## Verification
Driven in the real app with Playwright in both light and dark themes:
- #743: presets apply in both zoom directions and update the scale field; the out-of-range notice fires for an unreachable scale (e.g. 1:1) and clears on a reachable one.
- #745: `Inside frame` displays in full.
- #748: the top frame line stays crisp behind an inside title (thin default and thick custom frame).
- #749: a custom thick black frame renders; width 0 hides it (covered by a unit test).

Added unit tests for the map frame border (custom color/width, and width 0 hiding it). `tsc -b`, the full frontend test suite (1428 passing), and pre-commit (eslint + npm build) are green.