### PR TITLE
fix(share): guide users to set a username when sharing fails

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/ShareProjectDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ShareProjectDialog.tsx
@@ -40,7 +40,9 @@ interface ShareProjectDialogProps {
   ) => Promise<{ content: string; filename: string }>;
 }
 
-const SETTINGS_TOKEN_URL = `${resolveShareBaseUrl()}/settings`;
+// The website's account settings page, where the user both creates API tokens
+// and sets the username required for sharing.
+const ACCOUNT_SETTINGS_URL = `${resolveShareBaseUrl()}/settings`;
 
 export function ShareProjectDialog({
   open,
@@ -181,7 +183,7 @@ export function ShareProjectDialog({
                 <Button
                   type="button"
                   variant="outline"
-                  onClick={() => void openExternalLink(SETTINGS_TOKEN_URL)}
+                  onClick={() => void openExternalLink(ACCOUNT_SETTINGS_URL)}
                 >
                   <ExternalLink className="mr-2 h-3.5 w-3.5" />
                   {t("share.getToken")}
@@ -267,20 +269,26 @@ export function ShareProjectDialog({
             </div>
 
             {errorCode === "username-required" ? (
-              <div className="space-y-2 rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+              <div
+                role="alert"
+                className="space-y-2 rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+              >
                 <p>{t("share.usernameRequired")}</p>
                 <Button
                   type="button"
                   variant="outline"
                   size="sm"
-                  onClick={() => void openExternalLink(SETTINGS_TOKEN_URL)}
+                  onClick={() => void openExternalLink(ACCOUNT_SETTINGS_URL)}
                 >
                   <ExternalLink className="mr-2 h-3.5 w-3.5" />
                   {t("share.openAccountSettings")}
                 </Button>
               </div>
             ) : error ? (
-              <p className="rounded-md bg-destructive/10 p-2 text-sm text-destructive">
+              <p
+                role="alert"
+                className="rounded-md bg-destructive/10 p-2 text-sm text-destructive"
+              >
                 {error}
               </p>
             ) : null}

--- a/apps/geolibre-desktop/src/components/layout/ShareProjectDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/ShareProjectDialog.tsx
@@ -18,7 +18,9 @@ import {
   isShareableTitle,
   MAX_PROJECT_TITLE_LENGTH,
   resolveShareBaseUrl,
+  ShareUploadError,
   uploadProjectToShare,
+  type ShareUploadErrorCode,
   type ShareUploadResult,
   type ShareVisibility,
 } from "../../lib/share-geolibre";
@@ -52,6 +54,7 @@ export function ShareProjectDialog({
   const [visibility, setVisibility] = useState<ShareVisibility>("unlisted");
   const [status, setStatus] = useState<"idle" | "uploading">("idle");
   const [error, setError] = useState<string | null>(null);
+  const [errorCode, setErrorCode] = useState<ShareUploadErrorCode | null>(null);
   const [result, setResult] = useState<ShareUploadResult | null>(null);
   const [copied, setCopied] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
@@ -67,6 +70,7 @@ export function ShareProjectDialog({
       setVisibility("unlisted");
       setStatus("idle");
       setError(null);
+      setErrorCode(null);
       setResult(null);
       setCopied(false);
     } else {
@@ -93,6 +97,7 @@ export function ShareProjectDialog({
     // renders would otherwise start a concurrent, non-idempotent upload.
     if (abortRef.current) return;
     setError(null);
+    setErrorCode(null);
     setStatus("uploading");
     const controller = new AbortController();
     abortRef.current = controller;
@@ -108,7 +113,15 @@ export function ShareProjectDialog({
       setResult(uploaded);
     } catch (err) {
       if (err instanceof DOMException && err.name === "AbortError") return;
-      setError(err instanceof Error ? err.message : t("share.errorFallback"));
+      // A missing account username gets dedicated, actionable UI (a deep link to
+      // the website's settings) rather than the raw server string.
+      if (err instanceof ShareUploadError && err.code === "username-required") {
+        setErrorCode("username-required");
+        setError(null);
+      } else {
+        setError(err instanceof Error ? err.message : t("share.errorFallback"));
+        setErrorCode(null);
+      }
     } finally {
       // Only the controller that is still current clears state, so an aborted
       // (superseded) request never flips a newer one back to idle.
@@ -253,11 +266,24 @@ export function ShareProjectDialog({
               </Select>
             </div>
 
-            {error && (
+            {errorCode === "username-required" ? (
+              <div className="space-y-2 rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+                <p>{t("share.usernameRequired")}</p>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void openExternalLink(SETTINGS_TOKEN_URL)}
+                >
+                  <ExternalLink className="mr-2 h-3.5 w-3.5" />
+                  {t("share.openAccountSettings")}
+                </Button>
+              </div>
+            ) : error ? (
               <p className="rounded-md bg-destructive/10 p-2 text-sm text-destructive">
                 {error}
               </p>
-            )}
+            ) : null}
 
             <div className="flex justify-end gap-2">
               {/* Stays enabled during upload: closing the dialog aborts the

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -603,7 +603,9 @@
     "visibilityPrivate": "Private (only you)",
     "shareButton": "Share",
     "sharing": "Sharing…",
-    "errorFallback": "Could not share the project."
+    "errorFallback": "Could not share the project.",
+    "usernameRequired": "Set a username on your share.geolibre.app account before sharing. Open your account settings to choose one, then try again.",
+    "openAccountSettings": "Open account settings"
   },
   "language": {
     "label": "Language",

--- a/apps/geolibre-desktop/src/lib/share-geolibre.ts
+++ b/apps/geolibre-desktop/src/lib/share-geolibre.ts
@@ -24,10 +24,19 @@ export class ShareUploadError extends Error {
 
   constructor(message: string, code?: ShareUploadErrorCode) {
     super(message);
+    // Restore the prototype chain so `instanceof ShareUploadError` holds even if
+    // this is ever transpiled to a target where `extends Error` loses it; the
+    // dialog's error branching depends on that check.
+    Object.setPrototypeOf(this, new.target.prototype);
     this.name = "ShareUploadError";
     this.code = code;
   }
 }
+
+// Sentinel the share server returns (as a plain 400 body) when an authenticated
+// account has no username yet. Kept as a named constant so the one coupling
+// point to the server's error vocabulary is obvious and easy to update.
+const USERNAME_REQUIRED_PATTERN = /username required/i;
 
 export interface ShareUploadResult {
   username: string;
@@ -213,7 +222,7 @@ async function uploadErrorInfo(
     // This substring must stay in sync with the server's error text: if the
     // server rephrases or localizes the message, the code falls back to
     // undefined and the dialog shows the raw server string instead.
-    const code = /username required/i.test(message)
+    const code = USERNAME_REQUIRED_PATTERN.test(message)
       ? ("username-required" as const)
       : undefined;
     return { message, code };

--- a/apps/geolibre-desktop/src/lib/share-geolibre.ts
+++ b/apps/geolibre-desktop/src/lib/share-geolibre.ts
@@ -6,6 +6,29 @@ import { DEFAULT_PROJECT_NAME } from "@geolibre/core";
 
 export type ShareVisibility = "public" | "unlisted" | "private";
 
+/**
+ * Machine-readable cause for an upload failure the dialog can react to. Only
+ * conditions that warrant dedicated UI (beyond showing the message) get a code.
+ * `username-required` means the account has no username yet, which the user must
+ * set on the share.geolibre.app website before any upload can succeed.
+ */
+export type ShareUploadErrorCode = "username-required";
+
+/**
+ * Error thrown by {@link uploadProjectToShare}. Carries a human-readable message
+ * plus an optional {@link ShareUploadErrorCode} so the dialog can render targeted
+ * guidance (e.g. a deep link to account settings) instead of a bare string.
+ */
+export class ShareUploadError extends Error {
+  readonly code?: ShareUploadErrorCode;
+
+  constructor(message: string, code?: ShareUploadErrorCode) {
+    super(message);
+    this.name = "ShareUploadError";
+    this.code = code;
+  }
+}
+
 export interface ShareUploadResult {
   username: string;
   slug: string;
@@ -146,7 +169,8 @@ export async function uploadProjectToShare(
   }
 
   if (!response.ok) {
-    throw new Error(await uploadErrorMessage(response));
+    const { message, code } = await uploadErrorInfo(response);
+    throw new ShareUploadError(message, code);
   }
 
   const payload = (await response.json().catch(() => ({}))) as ShareProjectResponse;
@@ -163,15 +187,17 @@ export async function uploadProjectToShare(
   };
 }
 
-async function uploadErrorMessage(response: Response): Promise<string> {
+async function uploadErrorInfo(
+  response: Response,
+): Promise<{ message: string; code?: ShareUploadErrorCode }> {
   if (response.status === 401) {
-    return "Invalid or expired API token. Update it in Settings.";
+    return { message: "Invalid or expired API token. Update it in Settings." };
   }
   if (response.status === 403) {
-    return "This API token is not allowed to upload projects.";
+    return { message: "This API token is not allowed to upload projects." };
   }
   if (response.status === 429) {
-    return "Too many uploads. Please wait a while and try again.";
+    return { message: "Too many uploads. Please wait a while and try again." };
   }
   const body = (await response.json().catch(() => null)) as
     | { error?: string }
@@ -180,7 +206,14 @@ async function uploadErrorMessage(response: Response): Promise<string> {
   // non-HTTPS share URL cannot render a wall of text in the dialog. Slice by
   // code point so the cap can't orphan a UTF-16 surrogate pair.
   if (typeof body?.error === "string" && body.error.trim()) {
-    return [...body.error].slice(0, 300).join("");
+    const message = [...body.error].slice(0, 300).join("");
+    // The share server returns this on a generic 400 when the account has no
+    // username yet. Flag it so the dialog can point the user at the website's
+    // account settings (where usernames are set), not the local app settings.
+    const code = /username required/i.test(message)
+      ? ("username-required" as const)
+      : undefined;
+    return { message, code };
   }
-  return `Upload failed (HTTP ${response.status}).`;
+  return { message: `Upload failed (HTTP ${response.status}).` };
 }

--- a/apps/geolibre-desktop/src/lib/share-geolibre.ts
+++ b/apps/geolibre-desktop/src/lib/share-geolibre.ts
@@ -210,6 +210,9 @@ async function uploadErrorInfo(
     // The share server returns this on a generic 400 when the account has no
     // username yet. Flag it so the dialog can point the user at the website's
     // account settings (where usernames are set), not the local app settings.
+    // This substring must stay in sync with the server's error text: if the
+    // server rephrases or localizes the message, the code falls back to
+    // undefined and the dialog shows the raw server string instead.
     const code = /username required/i.test(message)
       ? ("username-required" as const)
       : undefined;

--- a/tests/share-geolibre.test.ts
+++ b/tests/share-geolibre.test.ts
@@ -173,7 +173,9 @@ describe("uploadProjectToShare", () => {
     await assert.rejects(
       () => uploadProjectToShare({ ...baseArgs, fetchImpl: fn }),
       (err: ShareUploadError) =>
-        err instanceof ShareUploadError && err.code === "username-required",
+        err instanceof ShareUploadError &&
+        err.code === "username-required" &&
+        /username required/i.test(err.message),
     );
   });
 

--- a/tests/share-geolibre.test.ts
+++ b/tests/share-geolibre.test.ts
@@ -6,6 +6,7 @@ import {
   isShareableTitle,
   MAX_PROJECT_TITLE_LENGTH,
   resolveShareBaseUrl,
+  ShareUploadError,
   uploadProjectToShare,
 } from "../apps/geolibre-desktop/src/lib/share-geolibre";
 
@@ -158,7 +159,21 @@ describe("uploadProjectToShare", () => {
     const { fn } = fakeFetch(400, { error: "Project schema is invalid." });
     await assert.rejects(
       () => uploadProjectToShare({ ...baseArgs, fetchImpl: fn }),
-      /Project schema is invalid\./,
+      (err: ShareUploadError) =>
+        err instanceof ShareUploadError &&
+        err.code === undefined &&
+        /Project schema is invalid\./.test(err.message),
+    );
+  });
+
+  it("flags the missing-username 400 with a username-required code", async () => {
+    const { fn } = fakeFetch(400, {
+      error: "Username required before uploading projects",
+    });
+    await assert.rejects(
+      () => uploadProjectToShare({ ...baseArgs, fetchImpl: fn }),
+      (err: ShareUploadError) =>
+        err instanceof ShareUploadError && err.code === "username-required",
     );
   });
 


### PR DESCRIPTION
## Summary

Fixes #731.

When sharing a project, the Share dialog surfaced the share.geolibre.app server's raw `Username required before uploading projects` (HTTP 400) message with no actionable context. The username is set on the **website's** account settings page, not the local app settings, so the reporter (and any user) was left to hunt blindly.

This makes that failure state actionable:

- `uploadProjectToShare` now throws a typed `ShareUploadError` that carries a `username-required` code, detected from the server's 400 (the share server returns this from a generic catch-all, so it is matched by message).
- The Share dialog renders dedicated UI for that code: a clear explanation plus an **Open account settings** button that deep-links to `share.geolibre.app/settings`, where the username is set. All other errors render unchanged.

## Verification

Drove the real web app with Playwright, mocking the share endpoint to return the `Username required` 400 with a valid token configured:

- The dialog shows the new message and the **Open account settings** button.
- The button opens `https://share.geolibre.app/settings` in a new tab.
- Confirmed in both **light and dark** themes.

Unit tests in `tests/share-geolibre.test.ts` cover the new typed error and the `username-required` classification (and that other 400s stay un-coded). Full `npm run build` and scoped `pre-commit` pass.

## User-facing strings

Added `share.usernameRequired` and `share.openAccountSettings` to `en.json` (source of truth); other locales fall back to English.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error feedback when sharing projects fails due to missing username configuration, with a direct link to account settings for quick resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->