### PR TITLE
feat(raster): show color ramp gradient swatches in the Styles panel

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
+++ b/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
@@ -16,7 +16,15 @@ import {
   savedRasterSymbology,
   warmColormapColors,
 } from "@geolibre/plugins";
-import { Input, Label, Select, Separator, Textarea } from "@geolibre/ui";
+import {
+  type ColorRampOption,
+  ColorRampSelect,
+  Input,
+  Label,
+  Select,
+  Separator,
+  Textarea,
+} from "@geolibre/ui";
 import { COLORMAP_OPTIONS } from "maplibre-gl-raster";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -229,6 +237,38 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [previewRamp, previewCustomKey]);
 
+  // Colors for every colormap so each option in the ramp picker can show its
+  // own swatch. Built-in ramps resolve synchronously (seeded once below); the
+  // remaining sprite colormaps are sampled once from the renderer's sprite and
+  // fill in as they resolve. Declared before the RGB early return so the hook
+  // order stays stable.
+  const [rampColors, setRampColors] = useState<
+    Record<string, readonly string[]>
+  >(() => {
+    const seed: Record<string, readonly string[]> = {};
+    for (const colormap of SORTED_COLORMAPS) {
+      const known = colormapColors(colormap.name);
+      if (known) seed[colormap.name] = known;
+    }
+    return seed;
+  });
+  useEffect(() => {
+    let cancelled = false;
+    for (const colormap of SORTED_COLORMAPS) {
+      // Built-in ramps were already seeded synchronously above.
+      if (colormapColors(colormap.name)) continue;
+      void warmColormapColors(colormap.name).then((colors) => {
+        if (cancelled || !colors) return;
+        setRampColors((prev) =>
+          prev[colormap.name] ? prev : { ...prev, [colormap.name]: colors },
+        );
+      });
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   function commit(options: {
     statePatch?: Partial<RasterStateRecord>;
     symbology?: RasterSymbology | null;
@@ -336,9 +376,6 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
   const reversed = state.reversed;
   const customColors = symbology?.customColors;
   const isCustom = (customColors?.length ?? 0) >= MIN_CUSTOM_COLORS;
-  // rampPreview (resolved above) holds the ramp's colors; mirror the reverse
-  // toggle for the preview gradient.
-  const orderedPreview = reversed ? [...rampPreview].reverse() : rampPreview;
   const rampSelectValue = isCustom ? CUSTOM_RAMP_VALUE : ramp;
 
   // A custom ramp is the only thing the upstream control can't express for a
@@ -401,6 +438,34 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
     }
   }
 
+  // The picker's options, each carrying its own colors so the dropdown shows a
+  // gradient swatch beside every ramp name. Plain (not memoized) because it is
+  // built after the RGB early return, where a hook would break hook order.
+  const rampOptions: ColorRampOption[] = [];
+  // A raster may arrive with a colormap name not in the list (e.g. the
+  // control's "palette" default); surface it so the picker reflects what is
+  // actually rendered instead of silently showing the first.
+  if (!isCustom && !COLORMAP_OPTIONS.some((o) => o.name === ramp)) {
+    rampOptions.push({
+      value: ramp,
+      label: ramp,
+      colors: rampColors[ramp] ?? rampPreview,
+    });
+  }
+  for (const colormap of SORTED_COLORMAPS) {
+    rampOptions.push({
+      value: colormap.name,
+      label: colormap.label,
+      colors: rampColors[colormap.name] ?? [],
+    });
+  }
+  rampOptions.push({
+    value: CUSTOM_RAMP_VALUE,
+    label: t("rasterSymbology.customRamp"),
+    // Preview the actual user-defined colors when a custom ramp is active.
+    colors: isCustom ? (customColors as string[]) : [],
+  });
+
   return (
     <div className="space-y-3">
       <Separator />
@@ -431,11 +496,13 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
 
       <div className="space-y-2">
         <Label htmlFor="rasterRamp">Color ramp</Label>
-        <Select
+        <ColorRampSelect
           id="rasterRamp"
+          aria-label="Color ramp"
           value={rampSelectValue}
-          onChange={(event) => {
-            const value = event.target.value;
+          reversed={reversed}
+          ramps={rampOptions}
+          onValueChange={(value) => {
             if (value === CUSTOM_RAMP_VALUE) {
               // Seed the editable list synchronously from the current ramp's
               // resolved colors (or the already-resolved preview), falling back
@@ -451,32 +518,6 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
             } else {
               selectNamedRamp(value);
             }
-          }}
-        >
-          {/* A raster may arrive with a colormap name not in the list (e.g. the
-              control's "palette" default); surface it so the select reflects
-              what is actually rendered instead of silently showing the first. */}
-          {!isCustom && !COLORMAP_OPTIONS.some((o) => o.name === ramp) && (
-            <option value={ramp}>{ramp}</option>
-          )}
-          {SORTED_COLORMAPS.map((colormap) => (
-            <option key={colormap.name} value={colormap.name}>
-              {colormap.label}
-            </option>
-          ))}
-          <option value={CUSTOM_RAMP_VALUE}>
-            {t("rasterSymbology.customRamp")}
-          </option>
-        </Select>
-        <div
-          aria-hidden="true"
-          className="h-4 rounded-sm border"
-          style={{
-            // Empty while a sprite colormap is still being sampled.
-            background:
-              orderedPreview.length >= 2
-                ? `linear-gradient(90deg, ${orderedPreview.join(", ")})`
-                : undefined,
           }}
         />
         {isCustom && (

--- a/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
+++ b/apps/geolibre-desktop/src/components/panels/RasterSymbologySection.tsx
@@ -265,6 +265,9 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
       });
     }
     return () => {
+      // Only guards state: in-flight warmColormapColors fetches keep populating
+      // the module-level anchorCache, so a remount picks them up synchronously
+      // via the colormapColors() seed above instead of re-fetching.
       cancelled = true;
     };
   }, []);
@@ -449,6 +452,9 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
     rampOptions.push({
       value: ramp,
       label: ramp,
+      // rampColors only warms names in SORTED_COLORMAPS, so for an
+      // out-of-catalog ramp rampColors[ramp] is always undefined; rampPreview
+      // (seeded by the previewRamp effect above) is the real source here.
       colors: rampColors[ramp] ?? rampPreview,
     });
   }
@@ -498,7 +504,7 @@ export function RasterSymbologySection({ layer }: { layer: GeoLibreLayer }) {
         <Label htmlFor="rasterRamp">Color ramp</Label>
         <ColorRampSelect
           id="rasterRamp"
-          aria-label="Color ramp"
+          aria-label={t("rasterSymbology.colorRampLabel")}
           value={rampSelectValue}
           reversed={reversed}
           ramps={rampOptions}

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1847,6 +1847,7 @@
     "hiddenByGroup": "Hidden because its group is not visible"
   },
   "rasterSymbology": {
+    "colorRampLabel": "Color ramp",
     "reverseRamp": "Reverse ramp",
     "customRamp": "Custom…",
     "customColors": "Custom colors",


### PR DESCRIPTION
## Summary

The raster **Color ramp** picker in the Styles panel was a plain `<Select>` that listed only ramp names, so there was no way to see what a ramp looked like without selecting it. This adds a gradient preview swatch beside every ramp name.

Native `<option>` elements can't render a gradient, so this swaps the `<Select>` for the existing `ColorRampSelect` component (already used by the vector Style panel), which draws each ramp's gradient next to its name and on the trigger.

## Changes

- Replace the raster color-ramp `<Select>` with `ColorRampSelect`.
- Resolve a gradient for every colormap: built-in GeoLibre ramps synchronously, the remaining sprite colormaps sampled once (and cached) from the renderer's sprite via `warmColormapColors`, filling in as they resolve.
- Keep the existing behaviors: the "Custom…" option, surfacing an out-of-catalog ramp name, and the reverse toggle (which now flips the swatches too).
- Drop the now-redundant full-width preview bar, since the picker previews the selected ramp itself, matching the vector Style panel.

## Verification

Drove the real web app with Playwright using the bundled **Elevation (DEM)** sample raster:

- Dropdown shows a gradient swatch beside every ramp name (Accent, afmhot, algae, balance, Blues, …).
- Selecting a ramp (Blues) applies to the raster with no console errors.
- The reverse toggle flips both the option swatches and the live render.
- Confirmed in **light and dark** themes.

Full `npm run build` and scoped `pre-commit` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **UI/UX Improvements**
  * Enhanced the color ramp selection interface in the raster symbology panel with a unified color ramp selector component.
  * Improved handling and preview of both built-in and custom color ramps.
  * Optimized color ramp preview loading for better application performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->