### PR TITLE
feat(basemaps): add Openbasiskaart Netherlands basemap

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -57,7 +57,7 @@
     "mapillary-js": "^4.1.2",
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.3",
-    "maplibre-gl-basemap-control": "^0.6.0",
+    "maplibre-gl-basemap-control": "^0.7.0",
     "maplibre-gl-components": "^0.22.5",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "mapillary-js": "^4.1.2",
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.3",
-        "maplibre-gl-basemap-control": "^0.6.0",
+        "maplibre-gl-basemap-control": "^0.7.0",
         "maplibre-gl-components": "^0.22.5",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",
@@ -17377,9 +17377,9 @@
       "license": "MIT"
     },
     "node_modules/maplibre-gl-basemap-control": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-basemap-control/-/maplibre-gl-basemap-control-0.6.0.tgz",
-      "integrity": "sha512-+EH3v8V/8FgDAV6awwIzLYc9aSPA1BTTttM6bPu0b+BjOzrFm6vyJl3W93O2poYf69snl5fpLXWz6mrQ6KqhVg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-basemap-control/-/maplibre-gl-basemap-control-0.7.0.tgz",
+      "integrity": "sha512-kh/0I74antuiDIss848Y/IQijSJG5HMt14Zf+UjvLYdaPYV8P5pPayVIrwoZK51P6os7JM22fABLzcnkK+33dw==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -24304,7 +24304,7 @@
         "jspdf": "^4.2.1",
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.3",
-        "maplibre-gl-basemap-control": "^0.6.0",
+        "maplibre-gl-basemap-control": "^0.7.0",
         "maplibre-gl-components": "^0.22.5",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -31,7 +31,7 @@
     "jspdf": "^4.2.1",
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.3",
-    "maplibre-gl-basemap-control": "^0.6.0",
+    "maplibre-gl-basemap-control": "^0.7.0",
     "maplibre-gl-components": "^0.22.5",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",


### PR DESCRIPTION
## Summary

Adds **Openbasiskaart** as a selectable basemap in the Basemaps plugin, requested in #774. Openbasiskaart is an open, OpenStreetMap-based topographic background map for the Netherlands.

As discussed on the issue, Openbasiskaart is a raster (WMTS) service rather than vector tiles, so it belongs in the Basemaps plugin (`maplibre-gl-basemap-control`) rather than the vector basemap picker. The basemap was added upstream and released; this PR just consumes it.

## Changes

- Bump `maplibre-gl-basemap-control` 0.6.0 to 0.7.0 in `apps/geolibre-desktop` and `packages/plugins`, plus the lockfile.

## Upstream

- opengeos/maplibre-gl-basemap-control#18 (merged), released as [v0.7.0](https://github.com/opengeos/maplibre-gl-basemap-control/releases/tag/v0.7.0).
- The Google Maps Compatible layer (`osm-g`) is used because it is the only Openbasiskaart grid that maps directly to standard Web Mercator xyz tiles.

## Testing

- `npm run build` passes; pre-commit passes.
- Verified in the running app: activated the Basemaps plugin, searched and selected **Openbasiskaart**, flew to Amsterdam, and confirmed the Dutch topographic tiles render in both light and dark UI themes with no console errors.

Fixes #774

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated maplibre-gl-basemap-control dependency to version 0.7.0 across the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->