### PR TITLE
fix(plugins): revalidate external-plugin manifest and entry to avoid stale-cache version skew

### DIFF
--- a/apps/geolibre-desktop/src/lib/external-plugins.ts
+++ b/apps/geolibre-desktop/src/lib/external-plugins.ts
@@ -204,7 +204,19 @@ async function loadPluginUrlBundle(
   manifestUrl: string,
   signal?: AbortSignal,
 ): Promise<ExternalPluginBundle> {
-  const manifestResponse = await fetch(manifestUrl, { signal });
+  // Revalidate every request (manifest, entry, style) instead of serving from
+  // the HTTP cache. A static host can hand the manifest and the entry very
+  // different cache lifetimes (e.g. GitHub Pages / Fastly cache JSON for ~10
+  // minutes but JS for hours), so after a version bump the loader can otherwise
+  // read a fresh plugin.json against a stale, still-cached entry and reject the
+  // pair with "Exported plugin version does not match plugin.json." Forcing
+  // revalidation keeps the manifest and entry version-consistent. `no-cache`
+  // still allows a cheap 304 when nothing changed, so this is not a full
+  // re-download on every load.
+  const manifestResponse = await fetch(manifestUrl, {
+    cache: "no-cache",
+    signal,
+  });
   if (!manifestResponse.ok) {
     throw new Error(
       `Could not fetch plugin manifest: HTTP ${manifestResponse.status}`,
@@ -240,7 +252,10 @@ async function fetchPluginText(
   label: string,
   signal?: AbortSignal,
 ): Promise<string> {
-  const response = await fetch(url, { signal });
+  // `no-cache` revalidates so the entry/style stay in sync with the manifest
+  // version even when a static host caches them for much longer than the
+  // manifest (see loadPluginUrlBundle).
+  const response = await fetch(url, { cache: "no-cache", signal });
   if (!response.ok) {
     throw new Error(`Could not fetch ${label}: HTTP ${response.status}`);
   }


### PR DESCRIPTION
## Problem

Installing or updating an external plugin from a manifest URL can stall at **"installed and loading"** in Manage Plugins, with:

```
Skipped external plugin archive '…/plugin.json': Exported plugin version does not match plugin.json.
```

## Root cause

The loader fetches `plugin.json` and the entry (`index.js`) with the browser's **default HTTP caching**, and a static host can give them very different cache lifetimes. The GeoLibre plugin registry (GitHub Pages / Fastly) serves them with:

| File | `cache-control` |
|---|---|
| `plugin.json` | `max-age=600` (10 min) |
| `index.js` | `max-age=14400` (**4 hours**) |

So for up to ~4 hours after a version bump, the loader reads a **fresh** `plugin.json` (new version) against a **stale, still-cached** entry (old version). The strict equality check in `validateManifestMatchesPlugin` then rejects the pair, and the plugin never finishes loading. The user's local browser/webview cache holds the stale entry too, so it persists past a CDN refresh.

## Fix

Fetch the manifest, entry, and style with `cache: "no-cache"` so each is **revalidated** against the origin, keeping the manifest and entry version-consistent. `no-cache` still permits a cheap `304 Not Modified` when nothing changed, so it is not a full re-download on every load. One-line change at each of the two `fetch` sites in `loadPluginUrlBundle` / `fetchPluginText`.

## Verification

- **Mechanism reproduction** (headless Chromium + a local server mirroring the skew — manifest `no-store`, entry `max-age=3600`): after a version bump, default `fetch` reads manifest `2.0.0` against entry `1.0.0` (the exact mismatch); `cache: "no-cache"` reads both at `2.0.0`.
- **No regression**: a bundled drop-in plugin still loads cleanly (no version error, no console errors) with the fix.
- `npm run build` and `pre-commit` (eslint + npm build) green.

This is independent of the shared-rail feature (#769); it surfaced when the sample plugin was bumped to 1.2.0, but it affects **any** external plugin update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved external plugin fetching to prevent stale cached versions, ensuring plugins are always refreshed while still allowing efficient conditional revalidation for unchanged content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->