### PR TITLE
feat(packaging): add Windows portable zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,24 @@ jobs:
           }
           gh release upload "${{ github.event.release.tag_name }}" $msix --clobber
 
+      - name: Build portable zip
+        id: build_portable
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: ./packaging/portable/build-portable.ps1
+
+      - name: Upload portable zip release asset
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $portable = "${{ steps.build_portable.outputs.portable_path }}"
+          if (-not (Test-Path $portable)) {
+            throw "No portable zip was created at '$portable'."
+          }
+          gh release upload "${{ github.event.release.tag_name }}" $portable --clobber
+
   homebrew:
     name: Update Homebrew cask
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
           if (-not (Test-Path $msix)) {
             throw "No MSIX package was created at '$msix'."
           }
-          gh release upload "${{ github.event.release.tag_name }}" $msix --clobber
+          gh release upload "${{ github.event.release.tag_name }}" "$msix" --clobber
 
       - name: Build portable zip
         id: build_portable
@@ -141,7 +141,7 @@ jobs:
           if (-not (Test-Path $portable)) {
             throw "No portable zip was created at '$portable'."
           }
-          gh release upload "${{ github.event.release.tag_name }}" $portable --clobber
+          gh release upload "${{ github.event.release.tag_name }}" "$portable" --clobber
 
   homebrew:
     name: Update Homebrew cask

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -46,6 +46,21 @@ Download the Windows installer (`.msi` or `.exe`) from the latest
 is unsigned, so Windows SmartScreen may warn you; choose **More info → Run
 anyway** to proceed.
 
+### Portable (no install)
+
+Prefer not to install? Download the `*-x64-portable.zip` asset from the latest
+[release](https://github.com/opengeos/GeoLibre/releases), unzip it anywhere
+(including a USB drive), and run `geolibre-desktop.exe`. No installer, admin
+rights, or registry changes are involved, and the build does not auto-update, so
+download a newer zip to upgrade.
+
+The portable build relies on the Microsoft Edge WebView2 Runtime, which is
+preinstalled on Windows 11 and current Windows 10. If the app does not start,
+install the
+[Evergreen runtime](https://developer.microsoft.com/microsoft-edge/webview2/).
+The optional Python sidecar tools (Whitebox, raster, conversion) need Python
+available just as in the installed build; everything else runs without it.
+
 ## macOS installation
 
 Signing and notarization apply to **v1.4.1 and later**. For v1.4.0 and earlier

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "tauri": "npm run tauri -w geolibre-desktop",
     "tauri:dev": "npm run tauri dev -w geolibre-desktop",
     "tauri:build": "node scripts/tauri-build.mjs",
-    "msix:build": "pwsh -NoProfile -ExecutionPolicy Bypass -File packaging/msix/build-msix.ps1"
+    "msix:build": "pwsh -NoProfile -ExecutionPolicy Bypass -File packaging/msix/build-msix.ps1",
+    "portable:build": "pwsh -NoProfile -ExecutionPolicy Bypass -File packaging/portable/build-portable.ps1"
   },
   "engines": {
     "node": ">=22"

--- a/packaging/portable/README.md
+++ b/packaging/portable/README.md
@@ -1,0 +1,54 @@
+# Portable zip packaging (`build-portable.ps1`)
+
+[`build-portable.ps1`](build-portable.ps1) packages GeoLibre Desktop as a
+**portable Windows zip** from a finished Windows Tauri release build. The user
+unzips the folder anywhere and runs `geolibre-desktop.exe` directly: no
+installer, no admin rights, no registry changes.
+
+Unlike the NSIS / MSI / MSIX targets, this is not an installer. It stages the
+plain release binary, any sidecar DLLs next to it, and the Python sidecar under
+`backend\geolibre_server\`, then zips the lot with `Compress-Archive`. It
+**requires Windows** (it reads the Windows release binary), but needs no Windows
+SDK tooling.
+
+## Build
+
+```powershell
+npm run portable:build
+# or: pwsh ./packaging/portable/build-portable.ps1
+```
+
+Run a Windows Tauri release build first (the CI release workflow does this via
+`tauri-action`), otherwise the script throws because
+`target\release\geolibre-desktop.exe` does not exist.
+
+The zip is written to
+`apps/geolibre-desktop/src-tauri/target/release/bundle/portable/` and named
+`geolibre-desktop-<version>-x64-portable.zip`.
+
+## Layout
+
+The staged folder mirrors what the binary probes at runtime. `resource_dir()`
+resolves to the executable's own directory for an unbundled run, so the sidecar
+must sit at `backend\geolibre_server\` next to the exe, the first location
+`sidecar_project_dir()` checks (`apps/geolibre-desktop/src-tauri/src/lib.rs`).
+
+```
+geolibre-desktop-<version>-x64/
+  geolibre-desktop.exe
+  *.dll                       # e.g. WebView2Loader, if the build emits it
+  README.txt
+  backend/geolibre_server/    # Python sidecar (tests / caches stripped)
+```
+
+## Requirements for the end user
+
+- **Microsoft Edge WebView2 Runtime** — preinstalled on Windows 11 and current
+  Windows 10. The portable build relies on the system Evergreen runtime rather
+  than bundling a fixed-version copy; if the app does not launch, the user
+  installs it from the Microsoft WebView2 page.
+- **Python** for the optional sidecar features (Whitebox, raster, conversion),
+  exactly as in the installed build. Vector tools and everything client-side
+  run without it.
+
+The portable build has no auto-updater; upgrading means downloading a newer zip.

--- a/packaging/portable/README.md
+++ b/packaging/portable/README.md
@@ -33,7 +33,7 @@ resolves to the executable's own directory for an unbundled run, so the sidecar
 must sit at `backend\geolibre_server\` next to the exe, the first location
 `sidecar_project_dir()` checks (`apps/geolibre-desktop/src-tauri/src/lib.rs`).
 
-```
+```text
 geolibre-desktop-<version>-x64/
   geolibre-desktop.exe
   *.dll                       # e.g. WebView2Loader, if the build emits it

--- a/packaging/portable/build-portable.ps1
+++ b/packaging/portable/build-portable.ps1
@@ -56,6 +56,12 @@ Copy-Item -Force (Join-Path $targetDir "*.dll") $payloadDir -ErrorAction Silentl
 Copy-Item -Recurse -Force (Join-Path $backendDir "*") $backendPackageDir
 Get-ChildItem -Recurse -Path $backendPackageDir -Include "__pycache__", "*.pyc", "*.pyo", "tests", "test_*.py" |
   Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+# Strip developer-only artifacts so a locally built zip can never leak secrets
+# or balloon with a checked-out venv. None of these exist in a clean CI
+# checkout; the risk surface is `npm run portable:build` on a dev machine.
+$devArtifacts = @(".env", ".env.*", "venv", ".venv", "env", "*.egg-info", "dist", "build")
+Get-ChildItem -Recurse -Force -Path $backendPackageDir -Include $devArtifacts |
+  Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
 
 # Drop a short note alongside the binary so the zip is self-documenting.
 $readme = @"

--- a/packaging/portable/build-portable.ps1
+++ b/packaging/portable/build-portable.ps1
@@ -1,0 +1,86 @@
+param(
+  [string] $AppDir = "apps/geolibre-desktop",
+  [string] $Configuration = "release",
+  [ValidateSet("x64", "x86", "arm64")]
+  [string] $Architecture = "x64"
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not $IsWindows) {
+  throw "Portable packaging targets Windows and reads the Windows Tauri release binary."
+}
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+$appRoot = Resolve-Path (Join-Path $repoRoot $AppDir)
+$tauriDir = Join-Path $appRoot "src-tauri"
+$targetDir = Join-Path $tauriDir "target\$Configuration"
+$bundleDir = Join-Path $targetDir "bundle\portable"
+$configPath = Join-Path $tauriDir "tauri.conf.json"
+$cargoPath = Join-Path $tauriDir "Cargo.toml"
+$backendDir = Join-Path $repoRoot "backend\geolibre_server"
+
+$config = Get-Content -Raw $configPath | ConvertFrom-Json
+$version = [string] $config.version
+
+$cargo = Get-Content -Raw $cargoPath
+$binaryNameMatch = [regex]::Match($cargo, '(?ms)\[package\].*?^name\s*=\s*"([^"]+)"')
+if (-not $binaryNameMatch.Success) {
+  throw "Could not determine the Tauri binary name from $cargoPath."
+}
+
+$binaryName = $binaryNameMatch.Groups[1].Value
+$binaryPath = Join-Path $targetDir "$binaryName.exe"
+if (-not (Test-Path $binaryPath)) {
+  throw "Could not find $binaryPath. Run a Windows Tauri release build before portable packaging."
+}
+
+# Stage the app exactly as the binary expects to find it at runtime: the
+# Python sidecar lives in a `backend\geolibre_server` folder next to the exe,
+# which is the first location sidecar_project_dir() probes via resource_dir()
+# (see apps/geolibre-desktop/src-tauri/src/lib.rs). resource_dir() resolves to
+# the executable's own directory for an unbundled (portable) run, so this
+# layout works without an installer.
+$stagingDir = Join-Path $targetDir "portable-package"
+$payloadDir = Join-Path $stagingDir "$binaryName-$version-$Architecture"
+$backendPackageDir = Join-Path $payloadDir "backend\geolibre_server"
+$zipName = "$binaryName-$version-${Architecture}-portable.zip"
+$zipPath = Join-Path $bundleDir $zipName
+
+Remove-Item -Recurse -Force $stagingDir -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force -Path $payloadDir, $backendPackageDir, $bundleDir | Out-Null
+
+Copy-Item -Force $binaryPath (Join-Path $payloadDir "$binaryName.exe")
+# Ship any sidecar DLLs (e.g. WebView2Loader) the build emitted next to the exe.
+Copy-Item -Force (Join-Path $targetDir "*.dll") $payloadDir -ErrorAction SilentlyContinue
+Copy-Item -Recurse -Force (Join-Path $backendDir "*") $backendPackageDir
+Get-ChildItem -Recurse -Path $backendPackageDir -Include "__pycache__", "*.pyc", "*.pyo", "tests", "test_*.py" |
+  Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+
+# Drop a short note alongside the binary so the zip is self-documenting.
+$readme = @"
+GeoLibre Desktop $version (portable, $Architecture)
+
+Unzip this folder anywhere and run $binaryName.exe. No installation or admin
+rights are required.
+
+Requirements:
+  - Microsoft Edge WebView2 Runtime. Preinstalled on Windows 11 and current
+    Windows 10. If the app does not start, install the Evergreen runtime from
+    https://developer.microsoft.com/microsoft-edge/webview2/
+  - The optional Python sidecar (Whitebox, raster, and format-conversion tools)
+    needs Python available on your system, exactly as in the installed build.
+    Vector tools and everything else run without it.
+
+This portable build does not auto-update; download a newer zip to upgrade.
+"@
+Set-Content -Path (Join-Path $payloadDir "README.txt") -Value $readme -Encoding utf8
+
+Remove-Item -Force $zipPath -ErrorAction SilentlyContinue
+Compress-Archive -Path $payloadDir -DestinationPath $zipPath -CompressionLevel Optimal
+
+Write-Host "Portable package created at $zipPath"
+
+if ($env:GITHUB_OUTPUT) {
+  "portable_path=$zipPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+}


### PR DESCRIPTION
## Summary

Adds a **Windows portable zip** distribution alongside the existing NSIS / MSI / MSIX installers. Users download the zip, unzip it anywhere (including a USB drive), and run `geolibre-desktop.exe` — no installer, admin rights, or registry changes.

A Tauri v2 app is fundamentally the compiled binary plus its bundled resources, so a portable build is feasible by assembling the zip in CI after `tauri build`. Tauri has no built-in portable-zip bundle target, so this mirrors how the existing MSIX step works.

## Changes

- **`packaging/portable/build-portable.ps1`** — stages the release binary, any sidecar DLLs next to it, and the Python sidecar at `backend\geolibre_server\` (the first location `sidecar_project_dir()` probes via `resource_dir()`, which resolves to the exe's own directory for an unbundled run — see `apps/geolibre-desktop/src-tauri/src/lib.rs`). Strips test/cache files, drops a `README.txt`, and zips with `Compress-Archive`. Mirrors `build-msix.ps1`'s structure and the `$GITHUB_OUTPUT` contract.
- **`.github/workflows/release.yml`** — build + upload steps in the Windows matrix leg, producing `geolibre-desktop-<version>-x64-portable.zip` as a release asset.
- **`package.json`** — `npm run portable:build`.
- **`packaging/portable/README.md`** and **`docs/downloads.md`** — document the layout and the portable download.

## Notes / caveats (documented for users)

- **WebView2**: relies on the system Evergreen runtime (preinstalled on Windows 11 and current Windows 10) rather than bundling a fixed-version copy. Documented with a fallback link.
- **Python sidecar**: optional Whitebox/raster/conversion tools need Python available, exactly as in the installed build. Vector tools and everything client-side run without it.
- **No auto-update**: expected for a portable distribution; upgrade by downloading a newer zip.

## Testing

The PowerShell script is Windows-only (reads the Windows release binary), so it cannot be exercised on the Linux dev box. Logic and staging layout mirror the proven `build-msix.ps1`. `pre-commit run --files` passes on all changed files. The full path will be exercised by the next release build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Portable (no install)** Windows option to the release downloads, providing a `*-x64-portable.zip` asset that runs without installation or admin/registry changes (and does not auto-update).

* **Documentation**
  * Updated Windows installation guidance with clear steps to download, extract, and run the portable zip, including prerequisites for **Microsoft Edge WebView2 Runtime** and optional Python sidecar support.

* **Release/Packaging**
  * Improved release uploads to reliably publish the portable ZIP asset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->