### PR TITLE
feat(add-data): add GeoRSS feed support (URL + file)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/AddDataDialog.tsx
@@ -15,6 +15,7 @@ import { KIND_I18N_KEY } from "./add-data/constants";
 import { ArcGISSource } from "./add-data/sources/ArcGISSource";
 import { DeckVizSource } from "./add-data/sources/DeckVizSource";
 import { DelimitedTextSource } from "./add-data/sources/DelimitedTextSource";
+import { GeoRssSource } from "./add-data/sources/GeoRssSource";
 import { GpxSource } from "./add-data/sources/GpxSource";
 import { MbtilesSource } from "./add-data/sources/MbtilesSource";
 import { PostgresSource } from "./add-data/sources/PostgresSource";
@@ -59,6 +60,8 @@ function renderSource(
       return <WmtsSource />;
     case "gpx":
       return <GpxSource />;
+    case "georss":
+      return <GeoRssSource />;
     case "delimited-text":
       return <DelimitedTextSource />;
     case "mbtiles":

--- a/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
@@ -20,6 +20,7 @@ export type KindI18nKey =
   | "wfs"
   | "wmts"
   | "gpx"
+  | "georss"
   | "delimitedText"
   | "mbtiles"
   | "arcgis"
@@ -38,6 +39,7 @@ export const KIND_I18N_KEY: Record<AddDataKind, KindI18nKey> = {
   wfs: "wfs",
   wmts: "wmts",
   gpx: "gpx",
+  georss: "georss",
   "delimited-text": "delimitedText",
   mbtiles: "mbtiles",
   arcgis: "arcgis",
@@ -57,6 +59,10 @@ export const DEFAULT_WMTS_URL =
   "https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/MapServer/tile/119/{z}/{y}/{x}";
 export const DEFAULT_GPX_URL =
   "https://data.source.coop/giswqs/opengeos/fells_loop.gpx";
+// USGS "Magnitude 2.5+ Earthquakes, Past Day" Atom feed: a live GeoRSS feed
+// using the Simple encoding (georss:point), refreshed continuously by USGS.
+export const DEFAULT_GEORSS_URL =
+  "https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/2.5_day.atom";
 export const DEFAULT_DELIMITED_TEXT_URL =
   "https://data.source.coop/giswqs/opengeos/us_cities.csv";
 export const DEFAULT_DELIMITED_TEXT_LATITUDE_FIELD = "latitude";

--- a/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/constants.ts
@@ -59,8 +59,7 @@ export const DEFAULT_WMTS_URL =
   "https://wayback.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/MapServer/tile/119/{z}/{y}/{x}";
 export const DEFAULT_GPX_URL =
   "https://data.source.coop/giswqs/opengeos/fells_loop.gpx";
-// USGS "Magnitude 2.5+ Earthquakes, Past Day" Atom feed: a live GeoRSS feed
-// using the Simple encoding (georss:point), refreshed continuously by USGS.
+// USGS "Magnitude 2.5+ Earthquakes, Past Day" Atom feed (Simple georss:point).
 export const DEFAULT_GEORSS_URL =
   "https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/2.5_day.atom";
 export const DEFAULT_DELIMITED_TEXT_URL =

--- a/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/helpers.ts
@@ -189,7 +189,13 @@ function isViteDevServer(): boolean {
   );
 }
 
-export function proxyGpxRequestUrl(url: string): string {
+/**
+ * Routes a feed request through the dev-server CORS proxy when running under
+ * Vite (so a `fetch()` for a remote GPX/GeoRSS file is not blocked by the
+ * feed host's missing CORS headers). In production builds the URL is returned
+ * unchanged. The proxy is generic; the `GPX_PROXY_PATH` name is historical.
+ */
+export function proxyFeedRequestUrl(url: string): string {
   return isViteDevServer()
     ? `${GPX_PROXY_PATH}?url=${encodeURIComponent(url)}`
     : url;

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/GeoRssSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/GeoRssSource.tsx
@@ -125,6 +125,7 @@ export function GeoRssSource() {
       onSubmit={handleSubmit}
       error={source.error}
       submitDisabled={source.isSubmitting}
+      // Globe icon, unlike GpxSource: GeoRSS lives under Web services and is primarily a live feed.
       useServiceIcon
     >
       <div className="space-y-3">

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/GeoRssSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/GeoRssSource.tsx
@@ -1,0 +1,181 @@
+import { Button, Input, Label, Select } from "@geolibre/ui";
+import { FileUp } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { parseGeoRssLayer } from "../../../../lib/georss";
+import { openLocalDataFileWithFallback } from "../../../../lib/tauri-io";
+import { DEFAULT_GEORSS_URL } from "../constants";
+import {
+  createBaseLayer,
+  errorMessage,
+  fileNameFromPath,
+  layerNameFromPath,
+  proxyFeedRequestUrl,
+} from "../helpers";
+import { AddDataSourceForm, SampleDataSelect, useAddDataSource } from "../shared";
+import type { GeoRssMode } from "../types";
+
+export function GeoRssSource() {
+  const { t } = useTranslation();
+  // Captured once on mount so the "did the user rename it?" comparisons below
+  // stay stable even if the UI language changes while the dialog is open.
+  const [defaultName] = useState(() => t("addData.georss.defaultName"));
+  const source = useAddDataSource(defaultName);
+  const [georssMode, setGeoRssMode] = useState<GeoRssMode>("url");
+  const [georssUrl, setGeoRssUrl] = useState("");
+  const [selectedFile, setSelectedFile] = useState<{
+    path: string;
+    text: string;
+  } | null>(null);
+
+  const handleModeChange = (mode: GeoRssMode) => {
+    setGeoRssMode(mode);
+    setSelectedFile(null);
+  };
+
+  const handleChooseFile = async () => {
+    source.setError(null);
+    try {
+      const result = await openLocalDataFileWithFallback({
+        filters: [
+          {
+            name: "GeoRSS",
+            extensions: ["xml", "rss", "atom"],
+          },
+        ],
+        accept: ".xml,.rss,.atom",
+        readText: true,
+      });
+      if (!result) return;
+      if (!result.text) throw new Error(t("addData.georss.errorFileMissing"));
+      setSelectedFile({
+        path: result.path,
+        text: result.text,
+      });
+      source.setLayerName((current) =>
+        current.trim() && current !== defaultName
+          ? current
+          : layerNameFromPath(result.path, defaultName),
+      );
+    } catch (err) {
+      source.setError(errorMessage(err, t("addData.georss.readError")));
+    }
+  };
+
+  const readGeoRssSource = async (): Promise<{
+    sourcePath: string;
+    text: string;
+  }> => {
+    if (georssMode === "file") {
+      if (!selectedFile) throw new Error(t("addData.georss.errorChooseFile"));
+      return {
+        sourcePath: selectedFile.path,
+        text: selectedFile.text,
+      };
+    }
+
+    const sourcePath = georssUrl.trim();
+    if (!sourcePath) throw new Error(t("addData.georss.errorUrl"));
+
+    const response = await fetch(proxyFeedRequestUrl(sourcePath));
+    if (!response.ok) {
+      throw new Error(
+        t("addData.common.requestFailed", { status: response.status }),
+      );
+    }
+    return {
+      sourcePath,
+      text: await response.text(),
+    };
+  };
+
+  const handleSubmit = source.runSubmit(async () => {
+    const { sourcePath, text } = await readGeoRssSource();
+    const result = parseGeoRssLayer(text);
+    const name = source.layerName.trim() || result.feedTitle || defaultName;
+
+    source.addAndClose(
+      {
+        ...createBaseLayer(
+          name,
+          "geojson",
+          {
+            type: "geojson",
+            url: sourcePath,
+          },
+          {
+            featureCount: result.featureCount,
+            feedTitle: result.feedTitle,
+            sourceKind: "georss",
+          },
+        ),
+        geojson: result.features,
+        sourcePath,
+      },
+      { fit: true },
+    );
+  });
+
+  return (
+    <AddDataSourceForm
+      layerName={source.layerName}
+      onLayerNameChange={source.setLayerName}
+      beforeLayerId={source.beforeLayerId}
+      onBeforeLayerIdChange={source.setBeforeLayerId}
+      onSubmit={handleSubmit}
+      error={source.error}
+      submitDisabled={source.isSubmitting}
+      useServiceIcon
+    >
+      <div className="space-y-3">
+        <SampleDataSelect
+          samples={[
+            { label: t("addData.georss.sampleLabel"), value: DEFAULT_GEORSS_URL },
+          ]}
+          onSelect={(url) => {
+            setGeoRssMode("url");
+            setSelectedFile(null);
+            setGeoRssUrl(url);
+          }}
+        />
+        <div className="space-y-1.5">
+          <Label htmlFor="georss-mode">{t("addData.common.sourceType")}</Label>
+          <Select
+            id="georss-mode"
+            value={georssMode}
+            onChange={(event) =>
+              handleModeChange(event.target.value as GeoRssMode)
+            }
+          >
+            <option value="url">{t("addData.georss.url")}</option>
+            <option value="file">{t("addData.georss.file")}</option>
+          </Select>
+        </div>
+
+        {georssMode === "file" ? (
+          <div className="flex flex-wrap items-center gap-2">
+            <Button type="button" variant="outline" onClick={handleChooseFile}>
+              <FileUp className="mr-2 h-3.5 w-3.5" />
+              {t("addData.common.chooseFile")}
+            </Button>
+            <span className="min-w-0 truncate text-xs text-muted-foreground">
+              {selectedFile
+                ? fileNameFromPath(selectedFile.path)
+                : t("addData.common.noFileSelected")}
+            </span>
+          </div>
+        ) : (
+          <div className="space-y-1.5">
+            <Label htmlFor="georss-url">{t("addData.georss.url")}</Label>
+            <Input
+              id="georss-url"
+              placeholder={t("addData.georss.urlPlaceholder")}
+              value={georssUrl}
+              onChange={(event) => setGeoRssUrl(event.target.value)}
+            />
+          </div>
+        )}
+      </div>
+    </AddDataSourceForm>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/GpxSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/GpxSource.tsx
@@ -12,7 +12,7 @@ import {
   errorMessage,
   fileNameFromPath,
   layerNameFromPath,
-  proxyGpxRequestUrl,
+  proxyFeedRequestUrl,
 } from "../helpers";
 import { AddDataSourceForm, SampleDataSelect, useAddDataSource } from "../shared";
 import type { GpxLayerKind, GpxMode } from "../types";
@@ -100,7 +100,7 @@ export function GpxSource() {
     const sourcePath = gpxUrl.trim();
     if (!sourcePath) throw new Error(t("addData.gpx.errorUrl"));
 
-    const response = await fetch(proxyGpxRequestUrl(sourcePath));
+    const response = await fetch(proxyFeedRequestUrl(sourcePath));
     if (!response.ok) {
       throw new Error(
         t("addData.common.requestFailed", { status: response.status }),

--- a/apps/geolibre-desktop/src/components/layout/add-data/types.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/types.ts
@@ -18,10 +18,10 @@ export type AddDataKind =
 
 /** A data source loadable either from a remote URL or a local file. */
 export type FeedMode = "url" | "file";
-export type GpxMode = "url" | "file";
+export type GpxMode = FeedMode;
 export type GpxLayerKind = "waypoints" | "tracks" | "routes";
 export type GeoRssMode = FeedMode;
-export type DelimitedTextMode = "url" | "file";
+export type DelimitedTextMode = FeedMode;
 export type DelimitedTextDelimiter =
   | "comma"
   | "tab"

--- a/apps/geolibre-desktop/src/components/layout/add-data/types.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/types.ts
@@ -8,6 +8,7 @@ export type AddDataKind =
   | "wfs"
   | "wmts"
   | "gpx"
+  | "georss"
   | "delimited-text"
   | "mbtiles"
   | "arcgis"
@@ -17,6 +18,7 @@ export type AddDataKind =
 
 export type GpxMode = "url" | "file";
 export type GpxLayerKind = "waypoints" | "tracks" | "routes";
+export type GeoRssMode = "url" | "file";
 export type DelimitedTextMode = "url" | "file";
 export type DelimitedTextDelimiter =
   | "comma"

--- a/apps/geolibre-desktop/src/components/layout/add-data/types.ts
+++ b/apps/geolibre-desktop/src/components/layout/add-data/types.ts
@@ -16,9 +16,11 @@ export type AddDataKind =
   | "deckgl-viz"
   | "video";
 
+/** A data source loadable either from a remote URL or a local file. */
+export type FeedMode = "url" | "file";
 export type GpxMode = "url" | "file";
 export type GpxLayerKind = "waypoints" | "tracks" | "routes";
-export type GeoRssMode = "url" | "file";
+export type GeoRssMode = FeedMode;
 export type DelimitedTextMode = "url" | "file";
 export type DelimitedTextDelimiter =
   | "comma"

--- a/apps/geolibre-desktop/src/components/layout/toolbar/AddDataMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/AddDataMenu.tsx
@@ -67,6 +67,7 @@ export function AddDataMenu({
     wfs: { onSelect: () => onSetAddDataKind("wfs") },
     wmts: { onSelect: () => onSetAddDataKind("wmts") },
     arcgis: { onSelect: () => onSetAddDataKind("arcgis") },
+    georss: { onSelect: () => onSetAddDataKind("georss") },
     stac: { onSelect: addLayer.stac },
     video: { onSelect: () => onSetAddDataKind("video") },
     "deckgl-viz": { onSelect: () => onSetAddDataKind("deckgl-viz") },

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -107,6 +107,10 @@
         "label": "Add GPX Layer",
         "description": "Add GPX waypoints, routes, and tracks as one or more vector layers."
       },
+      "georss": {
+        "label": "Add GeoRSS Layer",
+        "description": "Add a GeoRSS feed (RSS, Atom, or RDF) from a URL or file as a vector layer."
+      },
       "delimitedText": {
         "label": "Add Delimited Text Layer",
         "description": "Add a delimited text file or URL as a point layer using longitude and latitude fields."
@@ -252,6 +256,17 @@
       "file": "GPX file",
       "urlPlaceholder": "https://example.com/route.gpx",
       "layerTypes": "Layer types"
+    },
+    "georss": {
+      "defaultName": "GeoRSS Layer",
+      "sampleLabel": "USGS earthquakes (past day)",
+      "errorFileMissing": "GeoRSS file data is missing.",
+      "readError": "Could not read GeoRSS file.",
+      "errorChooseFile": "Choose a GeoRSS file.",
+      "errorUrl": "Enter a GeoRSS URL.",
+      "url": "GeoRSS URL",
+      "file": "GeoRSS file",
+      "urlPlaceholder": "https://example.com/feed.atom"
     },
     "delimitedText": {
       "defaultName": "Delimited Text Layer",
@@ -1063,6 +1078,7 @@
       "wfs": "WFS Layer",
       "wmts": "WMTS Layer",
       "arcgis": "ArcGIS Layer",
+      "georss": "GeoRSS Layer",
       "video": "Video Layer",
       "deckglViz": "Deck.gl Layer",
       "gltfModel": "3D Model (glTF)",

--- a/apps/geolibre-desktop/src/lib/georss.ts
+++ b/apps/geolibre-desktop/src/lib/georss.ts
@@ -1,0 +1,402 @@
+import type {
+  Feature,
+  FeatureCollection,
+  GeoJsonProperties,
+  Geometry,
+  LineString,
+  Point,
+  Polygon,
+  Position,
+} from "geojson";
+
+/**
+ * Result of parsing a GeoRSS feed into a single mixed-geometry layer.
+ *
+ * GeoRSS feeds routinely mix points, lines, and polygons in one document, so
+ * every feed item that carries a geometry becomes one feature in a single
+ * FeatureCollection (MapLibre renders the mixed collection as separate
+ * circle/line/fill layers).
+ */
+export interface GeoRssLayerResult {
+  /** All feed items that resolved to a valid geometry, as one collection. */
+  features: FeatureCollection;
+  /** Number of features produced (items with a usable geometry). */
+  featureCount: number;
+  /** The feed-level title, when present (used for layer naming/metadata). */
+  feedTitle?: string;
+}
+
+/**
+ * Parses a GeoRSS feed (RSS 2.0, Atom, or RSS 1.0/RDF) into a GeoJSON layer.
+ *
+ * Supports the three common GeoRSS geometry encodings:
+ * - **Simple**: `georss:point`, `georss:line`, `georss:polygon`, `georss:box`
+ * - **GML**: `georss:where` wrapping `gml:Point`/`LineString`/`Polygon`/`Envelope`
+ * - **W3C Geo**: legacy `geo:lat` / `geo:long` (point only)
+ *
+ * Item metadata (title, description/summary, link, published date, author, id,
+ * categories) is carried onto each feature's properties for the attribute table
+ * and popups. GeoRSS coordinates are `latitude longitude` ordered; GeoJSON
+ * output is `[longitude, latitude]`.
+ *
+ * @param text - The raw feed XML.
+ * @returns The parsed features plus counts and the feed title.
+ * @throws If the text is not valid XML, is not a recognized feed, or contains
+ *   no geolocated items.
+ */
+export function parseGeoRssLayer(text: string): GeoRssLayerResult {
+  const document = new DOMParser().parseFromString(text, "application/xml");
+  if (document.querySelector("parsererror")) {
+    throw new Error("The GeoRSS feed is not valid XML.");
+  }
+
+  const root = document.documentElement;
+  const rootName = root?.localName.toLowerCase();
+  let feedTitle: string | undefined;
+  let items: Element[] = [];
+
+  if (rootName === "feed") {
+    // Atom: <feed><entry>...
+    feedTitle = childText(root, "title");
+    items = directChildren(root, "entry");
+  } else if (rootName === "rss") {
+    // RSS 2.0: <rss><channel><item>...
+    const channel = directChildren(root, "channel")[0];
+    feedTitle = channel ? childText(channel, "title") : undefined;
+    items = channel ? directChildren(channel, "item") : [];
+  } else if (rootName === "rdf") {
+    // RSS 1.0 / RDF: <rdf:RDF><channel/><item>... (items are siblings).
+    const channel = directChildren(root, "channel")[0];
+    feedTitle = channel ? childText(channel, "title") : undefined;
+    items = directChildren(root, "item");
+  } else {
+    throw new Error("The file does not contain an RSS, Atom, or RDF feed.");
+  }
+
+  const features: Feature<Geometry, GeoJsonProperties>[] = [];
+  for (const [index, item] of items.entries()) {
+    const geometry = geometryFromItem(item);
+    if (!geometry) continue;
+    features.push({
+      type: "Feature",
+      geometry,
+      properties: {
+        ...itemProperties(item),
+        georss_index: index + 1,
+      },
+    });
+  }
+
+  if (features.length === 0) {
+    throw new Error("No geolocated entries were found in the GeoRSS feed.");
+  }
+
+  return {
+    features: { type: "FeatureCollection", features },
+    featureCount: features.length,
+    feedTitle,
+  };
+}
+
+/**
+ * Resolves a single feed item to a geometry, trying the GML, Simple, and W3C
+ * Geo encodings in turn. Returns null when the item carries no usable geometry.
+ */
+function geometryFromItem(item: Element): Geometry | null {
+  // 1. GML encoding: georss:where wrapping a GML geometry.
+  const where = directChildren(item, "where")[0];
+  if (where) {
+    const geometry = gmlGeometry(where);
+    if (geometry) return geometry;
+  }
+
+  // 2. Simple encoding: georss:point/line/polygon/box. The "point" element is
+  //    also how W3C geo:Point appears (localName "Point"); distinguish them by
+  //    whether it nests lat/long child elements (W3C) or holds text coords.
+  const point = directChildren(item, "point")[0];
+  if (point) {
+    const nestedLat = childText(point, "lat");
+    const nestedLong = childText(point, "long");
+    if (nestedLat && nestedLong) {
+      const coordinate = coordinate2d(nestedLong, nestedLat);
+      if (coordinate) return { type: "Point", coordinates: coordinate };
+    } else {
+      const coordinates = parseLatLonList(point.textContent);
+      if (coordinates[0]) return { type: "Point", coordinates: coordinates[0] };
+    }
+  }
+
+  const line = directChildren(item, "line")[0];
+  if (line) {
+    const coordinates = parseLatLonList(line.textContent);
+    if (coordinates.length >= 2) {
+      return { type: "LineString", coordinates } satisfies LineString;
+    }
+  }
+
+  const polygon = directChildren(item, "polygon")[0];
+  if (polygon) {
+    const ring = closeRing(parseLatLonList(polygon.textContent));
+    if (ring.length >= 4) {
+      return { type: "Polygon", coordinates: [ring] } satisfies Polygon;
+    }
+  }
+
+  const box = directChildren(item, "box")[0];
+  if (box) {
+    const geometry = polygonFromBox(parseLatLonList(box.textContent));
+    if (geometry) return geometry;
+  }
+
+  // 3. W3C Geo (point only): flat geo:lat / geo:long children.
+  const lat = childText(item, "lat");
+  const long = childText(item, "long");
+  if (lat && long) {
+    const coordinate = coordinate2d(long, lat);
+    if (coordinate) return { type: "Point", coordinates: coordinate };
+  }
+
+  return null;
+}
+
+/** Parses the GML geometry nested inside a `georss:where` element. */
+function gmlGeometry(where: Element): Geometry | null {
+  const geometryElement = Array.from(where.children)[0];
+  if (!geometryElement) return null;
+  const name = geometryElement.localName.toLowerCase();
+
+  if (name === "point") {
+    const coordinates = parseLatLonList(gmlPosText(geometryElement));
+    if (coordinates[0]) return { type: "Point", coordinates: coordinates[0] };
+    return null;
+  }
+
+  if (name === "linestring") {
+    const coordinates = parseLatLonList(gmlPosText(geometryElement));
+    if (coordinates.length >= 2) return { type: "LineString", coordinates };
+    return null;
+  }
+
+  if (name === "polygon") {
+    const exterior =
+      directChildren(geometryElement, "exterior")[0] ??
+      directChildren(geometryElement, "outerBoundaryIs")[0];
+    const linearRing = exterior
+      ? directChildren(exterior, "LinearRing")[0]
+      : directChildren(geometryElement, "LinearRing")[0];
+    if (!linearRing) return null;
+    const ring = closeRing(parseLatLonList(gmlPosText(linearRing)));
+    if (ring.length >= 4) return { type: "Polygon", coordinates: [ring] };
+    return null;
+  }
+
+  if (name === "envelope") {
+    const lower = parseLatLonList(childText(geometryElement, "lowerCorner"));
+    const upper = parseLatLonList(childText(geometryElement, "upperCorner"));
+    return polygonFromBox([...lower, ...upper]);
+  }
+
+  return null;
+}
+
+/**
+ * Collects the coordinate text from a GML geometry element, accepting either a
+ * single `gml:pos`/`gml:posList` or several `gml:pos` children (or, for legacy
+ * GML 2, `gml:coordinates`).
+ */
+function gmlPosText(element: Element): string {
+  const posList = directChildren(element, "posList")[0];
+  if (posList?.textContent) return posList.textContent;
+  const coordinates = directChildren(element, "coordinates")[0];
+  if (coordinates?.textContent) {
+    // GML 2 uses "lon,lat lon,lat"; normalize the commas to spaces. The
+    // lat/lon swap is handled downstream because GML 2 coordinates are
+    // lon,lat ordered, the reverse of GML 3 pos. Most GeoRSS uses GML 3, so
+    // this branch is a best-effort fallback.
+    return coordinates.textContent.replace(/,/g, " ");
+  }
+  const positions = directChildren(element, "pos");
+  if (positions.length > 0) {
+    return positions.map((pos) => pos.textContent ?? "").join(" ");
+  }
+  return "";
+}
+
+/** Builds a rectangular Polygon from a `[corner1, corner2]` coordinate pair. */
+function polygonFromBox(corners: Position[]): Polygon | null {
+  if (corners.length < 2) return null;
+  const [first, second] = corners;
+  const minLon = Math.min(first[0], second[0]);
+  const minLat = Math.min(first[1], second[1]);
+  const maxLon = Math.max(first[0], second[0]);
+  const maxLat = Math.max(first[1], second[1]);
+  return {
+    type: "Polygon",
+    coordinates: [
+      [
+        [minLon, minLat],
+        [maxLon, minLat],
+        [maxLon, maxLat],
+        [minLon, maxLat],
+        [minLon, minLat],
+      ],
+    ],
+  };
+}
+
+/**
+ * Parses a whitespace-separated `lat lon lat lon ...` string (GeoRSS/GML order)
+ * into `[lon, lat]` GeoJSON positions, dropping any out-of-range pair.
+ */
+function parseLatLonList(text: string | null | undefined): Position[] {
+  if (!text) return [];
+  const numbers = text
+    .trim()
+    .split(/\s+/)
+    .map(Number)
+    .filter((value) => Number.isFinite(value));
+  const positions: Position[] = [];
+  for (let i = 0; i + 1 < numbers.length; i += 2) {
+    const coordinate = makeCoordinate(numbers[i + 1], numbers[i]);
+    if (coordinate) positions.push(coordinate);
+  }
+  return positions;
+}
+
+/** Parses a `(lon, lat)` string pair into a validated GeoJSON position. */
+function coordinate2d(
+  longitude: string,
+  latitude: string,
+): Position | null {
+  return makeCoordinate(Number(longitude), Number(latitude));
+}
+
+/** Validates a `(lon, lat)` pair and returns it as a GeoJSON position. */
+function makeCoordinate(longitude: number, latitude: number): Position | null {
+  if (
+    !Number.isFinite(longitude) ||
+    !Number.isFinite(latitude) ||
+    longitude < -180 ||
+    longitude > 180 ||
+    latitude < -90 ||
+    latitude > 90
+  ) {
+    return null;
+  }
+  return [longitude, latitude];
+}
+
+/** Closes a polygon ring by repeating its first vertex when needed. */
+function closeRing(ring: Position[]): Position[] {
+  if (ring.length < 3) return ring;
+  const first = ring[0];
+  const last = ring[ring.length - 1];
+  if (first[0] === last[0] && first[1] === last[1]) return ring;
+  return [...ring, first];
+}
+
+const GEORSS_LINK_RELS_TO_SKIP = new Set(["self", "edit", "replies"]);
+
+/**
+ * Builds the GeoJSON properties for a feed item, carrying the common RSS/Atom
+ * metadata (title, description, link, published date, author, id, categories).
+ */
+function itemProperties(item: Element): GeoJsonProperties {
+  const properties: GeoJsonProperties = {};
+
+  const title = childText(item, "title");
+  if (title) properties.title = title;
+
+  // RSS: <description>; Atom: <summary> or <content>.
+  const description =
+    childText(item, "description") ??
+    childText(item, "summary") ??
+    childText(item, "content");
+  if (description) properties.description = description;
+
+  const link = itemLink(item);
+  if (link) properties.link = link;
+
+  // RSS: <pubDate>; Atom: <updated>/<published>; RSS 1.0: <dc:date>.
+  const published =
+    childText(item, "pubDate") ??
+    childText(item, "published") ??
+    childText(item, "updated") ??
+    childText(item, "date");
+  if (published) properties.published = published;
+
+  const author = itemAuthor(item);
+  if (author) properties.author = author;
+
+  const id = childText(item, "guid") ?? childText(item, "id");
+  if (id) properties.id = id;
+
+  const categories = itemCategories(item);
+  if (categories) properties.category = categories;
+
+  return properties;
+}
+
+/**
+ * Resolves an item's link. Atom uses `<link href>` (preferring the alternate
+ * relation); RSS uses the element's text content.
+ */
+function itemLink(item: Element): string | undefined {
+  const links = directChildren(item, "link");
+  if (links.length === 0) return undefined;
+
+  const withHref = links.filter((link) => link.getAttribute("href"));
+  if (withHref.length > 0) {
+    const alternate = withHref.find(
+      (link) => (link.getAttribute("rel") ?? "alternate") === "alternate",
+    );
+    const usable = withHref.find(
+      (link) => !GEORSS_LINK_RELS_TO_SKIP.has(link.getAttribute("rel") ?? ""),
+    );
+    const chosen = alternate ?? usable ?? withHref[0];
+    return chosen.getAttribute("href") ?? undefined;
+  }
+
+  return links[0].textContent?.trim() || undefined;
+}
+
+/** Resolves an item's author from RSS text or an Atom `<author><name>`. */
+function itemAuthor(item: Element): string | undefined {
+  const author = directChildren(item, "author")[0];
+  if (!author) {
+    // RSS 1.0 / Dublin Core creator.
+    return childText(item, "creator");
+  }
+  const name = childText(author, "name");
+  if (name) return name;
+  return author.textContent?.trim() || undefined;
+}
+
+/**
+ * Joins an item's categories into a comma-separated string. RSS categories hold
+ * text; Atom categories carry the value in the `term` attribute.
+ */
+function itemCategories(item: Element): string | undefined {
+  const categories = directChildren(item, "category")
+    .map(
+      (category) =>
+        category.getAttribute("term") ?? category.textContent?.trim() ?? "",
+    )
+    .filter(Boolean);
+  return categories.length > 0 ? categories.join(", ") : undefined;
+}
+
+/** Returns the direct child elements with the given (case-insensitive) name. */
+function directChildren(parent: Element, localName: string): Element[] {
+  const wanted = localName.toLowerCase();
+  return Array.from(parent.children).filter(
+    (child) => child.localName.toLowerCase() === wanted,
+  );
+}
+
+/** Returns the trimmed text of the first matching direct child, if any. */
+function childText(parent: Element, localName: string): string | undefined {
+  const child = directChildren(parent, localName)[0];
+  const value = child?.textContent?.trim();
+  return value || undefined;
+}

--- a/apps/geolibre-desktop/src/lib/georss.ts
+++ b/apps/geolibre-desktop/src/lib/georss.ts
@@ -39,12 +39,19 @@ export interface GeoRssLayerResult {
  * output is `[longitude, latitude]`.
  *
  * @param text - The raw feed XML.
+ * @param options - `allowEmpty` returns an empty layer instead of throwing when
+ *   the feed has no geolocated items (used on auto-refresh, where a feed can
+ *   transiently empty out and should not raise a recurring error).
  * @returns The parsed features plus counts and the feed title.
- * @throws If the text is not valid XML, is not a recognized feed, or contains
- *   no geolocated items. Messages are English-only (as in the GPX parser); the
- *   UI surfaces them verbatim, so a caller needing i18n must catch and translate.
+ * @throws If the text is not valid XML, is not a recognized feed, or (unless
+ *   `allowEmpty`) contains no geolocated items. Messages are English-only (as in
+ *   the GPX parser); the UI surfaces them verbatim, so an i18n caller must catch
+ *   and translate.
  */
-export function parseGeoRssLayer(text: string): GeoRssLayerResult {
+export function parseGeoRssLayer(
+  text: string,
+  options: { allowEmpty?: boolean } = {},
+): GeoRssLayerResult {
   const document = new DOMParser().parseFromString(text, "application/xml");
   if (document.querySelector("parsererror")) {
     throw new Error("The GeoRSS feed is not valid XML.");
@@ -87,7 +94,7 @@ export function parseGeoRssLayer(text: string): GeoRssLayerResult {
     });
   }
 
-  if (features.length === 0) {
+  if (features.length === 0 && !options.allowEmpty) {
     throw new Error("No geolocated entries were found in the GeoRSS feed.");
   }
 

--- a/apps/geolibre-desktop/src/lib/georss.ts
+++ b/apps/geolibre-desktop/src/lib/georss.ts
@@ -116,7 +116,7 @@ function geometryFromItem(item: Element): Geometry | null {
   const point = directChildren(item, "point")[0];
   if (point) {
     const nestedLat = childText(point, "lat");
-    const nestedLong = childText(point, "long");
+    const nestedLong = childText(point, "long") ?? childText(point, "lon");
     if (nestedLat && nestedLong) {
       const coordinate = coordinate2d(nestedLong, nestedLat);
       if (coordinate) return { type: "Point", coordinates: coordinate };
@@ -148,9 +148,10 @@ function geometryFromItem(item: Element): Geometry | null {
     if (geometry) return geometry;
   }
 
-  // 3. W3C Geo (point only): flat geo:lat / geo:long children.
+  // 3. W3C Geo (point only): flat geo:lat / geo:long children (also the
+  //    common geo:lon abbreviation).
   const lat = childText(item, "lat");
-  const long = childText(item, "long");
+  const long = childText(item, "long") ?? childText(item, "lon");
   if (lat && long) {
     const coordinate = coordinate2d(long, lat);
     if (coordinate) return { type: "Point", coordinates: coordinate };
@@ -319,8 +320,10 @@ function itemProperties(item: Element): GeoJsonProperties {
     childText(item, "content");
   if (description) properties.description = description;
 
+  // Keep only http(s) links; a feed could carry a javascript:/data: href that
+  // would become an XSS vector if the UI ever makes the link clickable.
   const link = itemLink(item);
-  if (link) properties.link = link;
+  if (link && /^https?:/i.test(link)) properties.link = link;
 
   // RSS: <pubDate>; Atom: <updated>/<published>; RSS 1.0: <dc:date>.
   const published =

--- a/apps/geolibre-desktop/src/lib/georss.ts
+++ b/apps/geolibre-desktop/src/lib/georss.ts
@@ -4,7 +4,6 @@ import type {
   GeoJsonProperties,
   Geometry,
   LineString,
-  Point,
   Polygon,
   Position,
 } from "geojson";
@@ -209,11 +208,18 @@ function gmlPosText(element: Element): string {
   if (posList?.textContent) return posList.textContent;
   const coordinates = directChildren(element, "coordinates")[0];
   if (coordinates?.textContent) {
-    // GML 2 uses "lon,lat lon,lat"; normalize the commas to spaces. The
-    // lat/lon swap is handled downstream because GML 2 coordinates are
-    // lon,lat ordered, the reverse of GML 3 pos. Most GeoRSS uses GML 3, so
-    // this branch is a best-effort fallback.
-    return coordinates.textContent.replace(/,/g, " ");
+    // GML 2 <coordinates> is "lon,lat lon,lat" (x,y), the reverse of GML 3
+    // pos. Re-order each pair to "lat lon" so the lat-first parseLatLonList
+    // below produces correct [lon, lat] GeoJSON positions.
+    return coordinates.textContent
+      .trim()
+      .split(/\s+/)
+      .map((pair) => {
+        const [lon, lat] = pair.split(",");
+        return lat && lon ? `${lat} ${lon}` : "";
+      })
+      .filter(Boolean)
+      .join(" ");
   }
   const positions = directChildren(element, "pos");
   if (positions.length > 0) {

--- a/apps/geolibre-desktop/src/lib/georss.ts
+++ b/apps/geolibre-desktop/src/lib/georss.ts
@@ -41,7 +41,8 @@ export interface GeoRssLayerResult {
  * @param text - The raw feed XML.
  * @returns The parsed features plus counts and the feed title.
  * @throws If the text is not valid XML, is not a recognized feed, or contains
- *   no geolocated items.
+ *   no geolocated items. Messages are English-only (as in the GPX parser); the
+ *   UI surfaces them verbatim, so a caller needing i18n must catch and translate.
  */
 export function parseGeoRssLayer(text: string): GeoRssLayerResult {
   const document = new DOMParser().parseFromString(text, "application/xml");
@@ -185,6 +186,7 @@ function gmlGeometry(where: Element): Geometry | null {
       : directChildren(geometryElement, "LinearRing")[0];
     if (!linearRing) return null;
     const ring = closeRing(parseLatLonList(gmlPosText(linearRing)));
+    // Interior rings (holes) are intentionally omitted; vanishingly rare in GeoRSS.
     if (ring.length >= 4) return { type: "Polygon", coordinates: [ring] };
     return null;
   }
@@ -226,7 +228,6 @@ function gmlPosText(element: Element): string {
   return "";
 }
 
-/** Builds a rectangular Polygon from a `[corner1, corner2]` coordinate pair. */
 function polygonFromBox(corners: Position[]): Polygon | null {
   if (corners.length < 2) return null;
   const [first, second] = corners;
@@ -267,7 +268,6 @@ function parseLatLonList(text: string | null | undefined): Position[] {
   return positions;
 }
 
-/** Parses a `(lon, lat)` string pair into a validated GeoJSON position. */
 function coordinate2d(
   longitude: string,
   latitude: string,
@@ -275,7 +275,6 @@ function coordinate2d(
   return makeCoordinate(Number(longitude), Number(latitude));
 }
 
-/** Validates a `(lon, lat)` pair and returns it as a GeoJSON position. */
 function makeCoordinate(longitude: number, latitude: number): Position | null {
   if (
     !Number.isFinite(longitude) ||
@@ -290,7 +289,6 @@ function makeCoordinate(longitude: number, latitude: number): Position | null {
   return [longitude, latitude];
 }
 
-/** Closes a polygon ring by repeating its first vertex when needed. */
 function closeRing(ring: Position[]): Position[] {
   if (ring.length < 3) return ring;
   const first = ring[0];

--- a/apps/geolibre-desktop/src/lib/georss.ts
+++ b/apps/geolibre-desktop/src/lib/georss.ts
@@ -208,9 +208,7 @@ function gmlPosText(element: Element): string {
   if (posList?.textContent) return posList.textContent;
   const coordinates = directChildren(element, "coordinates")[0];
   if (coordinates?.textContent) {
-    // GML 2 <coordinates> is "lon,lat lon,lat" (x,y), the reverse of GML 3
-    // pos. Re-order each pair to "lat lon" so the lat-first parseLatLonList
-    // below produces correct [lon, lat] GeoJSON positions.
+    // GML 2 <coordinates> is lon,lat order; swap each pair so the lat-first parseLatLonList holds.
     return coordinates.textContent
       .trim()
       .split(/\s+/)
@@ -313,7 +311,10 @@ function itemProperties(item: Element): GeoJsonProperties {
   const title = childText(item, "title");
   if (title) properties.title = title;
 
-  // RSS: <description>; Atom: <summary> or <content>.
+  // RSS: <description>; Atom: <summary> or <content>. Stored as raw text (RSS
+  // descriptions often hold CDATA-wrapped HTML); GeoLibre renders all property
+  // values as text nodes (identify popup setDOMContent + textContent, attribute
+  // table React children), so the markup is never parsed and needs no sanitizing.
   const description =
     childText(item, "description") ??
     childText(item, "summary") ??

--- a/apps/geolibre-desktop/src/lib/layer-refresh.ts
+++ b/apps/geolibre-desktop/src/lib/layer-refresh.ts
@@ -132,7 +132,9 @@ async function refreshGeoRssLayer(
   if (!response.ok) {
     throw new Error(`Request failed with status ${response.status}`);
   }
-  const result = parseGeoRssLayer(await response.text());
+  // allowEmpty: a live feed can transiently have no geolocated items, and a
+  // refresh should clear the layer rather than raise a recurring error.
+  const result = parseGeoRssLayer(await response.text(), { allowEmpty: true });
   return { geojson: result.features, featureCount: result.featureCount };
 }
 

--- a/apps/geolibre-desktop/src/lib/layer-refresh.ts
+++ b/apps/geolibre-desktop/src/lib/layer-refresh.ts
@@ -1,13 +1,19 @@
 import type { FeatureCollection } from "geojson";
 import type { GeoLibreLayer } from "@geolibre/core";
+import { parseGeoRssLayer } from "./georss";
 
-// Keep in sync with WFS_PROXY_PATH in vite.config.ts (the dev proxy binds it there).
+// Keep in sync with WFS_PROXY_PATH / GPX_PROXY_PATH in vite.config.ts (the dev
+// proxy binds them there). The GPX path is a generic feed CORS proxy reused for
+// GeoRSS refreshes; the name is historical.
 const WFS_PROXY_PATH = "/__geolibre_wfs_proxy";
+const GPX_PROXY_PATH = "/__geolibre_gpx_proxy";
 const FETCH_TIMEOUT_MS = 30_000;
 export const MIN_REFRESH_INTERVAL_MS = 1_000;
+const GEORSS_SOURCE_KIND = "georss";
 const REFRESHABLE_GEOJSON_SOURCE_KINDS = new Set([
   "wfs-getfeature",
   "geojson-url",
+  GEORSS_SOURCE_KIND,
 ]);
 
 // Add Vector Layer (maplibre-gl-vector) tags its store layers with this
@@ -93,6 +99,12 @@ export async function refreshGeoJsonLayer(
     throw new Error("This layer does not have a refreshable GeoJSON URL.");
   }
 
+  // GeoRSS feeds are XML, so re-fetch and re-parse them instead of routing
+  // through the GeoJSON fetch path (which would reject the XML response).
+  if (isGeoRssLayer(layer)) {
+    return refreshGeoRssLayer(sourceUrl);
+  }
+
   const data = await fetchGeoJsonFeatureCollection(sourceUrl, {
     useWfsProxy: isWfsLayer(layer),
   });
@@ -101,6 +113,27 @@ export async function refreshGeoJsonLayer(
     geojson: data,
     featureCount: data.features.length,
   };
+}
+
+async function refreshGeoRssLayer(
+  url: string,
+): Promise<{ geojson: FeatureCollection; featureCount: number }> {
+  let response: Response;
+  try {
+    response = await fetch(proxyFeedRequestUrl(url), {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "TimeoutError") {
+      throw new Error("The request timed out.");
+    }
+    throw error;
+  }
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+  const result = parseGeoRssLayer(await response.text());
+  return { geojson: result.features, featureCount: result.featureCount };
 }
 
 /**
@@ -239,6 +272,10 @@ function isWfsLayer(layer: GeoLibreLayer): boolean {
   );
 }
 
+function isGeoRssLayer(layer: GeoLibreLayer): boolean {
+  return layer.metadata.sourceKind === GEORSS_SOURCE_KIND;
+}
+
 function isViteDevServer(): boolean {
   return Boolean(
     (
@@ -252,6 +289,12 @@ function isViteDevServer(): boolean {
 function proxyWfsRequestUrl(url: string): string {
   return isViteDevServer()
     ? `${WFS_PROXY_PATH}?url=${encodeURIComponent(url)}`
+    : url;
+}
+
+function proxyFeedRequestUrl(url: string): string {
+  return isViteDevServer()
+    ? `${GPX_PROXY_PATH}?url=${encodeURIComponent(url)}`
     : url;
 }
 

--- a/apps/geolibre-desktop/src/lib/ui-profile.ts
+++ b/apps/geolibre-desktop/src/lib/ui-profile.ts
@@ -95,6 +95,7 @@ export const DATA_SOURCE_CATALOG: readonly DataSourceCatalogEntry[] = [
   { id: "wfs", section: "webServices", labelKey: "toolbar.layerType.wfs", tier: "intermediate" },
   { id: "wmts", section: "webServices", labelKey: "toolbar.layerType.wmts", tier: "intermediate" },
   { id: "arcgis", section: "webServices", labelKey: "toolbar.layerType.arcgis", tier: "intermediate" },
+  { id: "georss", section: "webServices", labelKey: "toolbar.layerType.georss", tier: "intermediate" },
   { id: "stac", section: "webServices", labelKey: "toolbar.item.stacLayer", tier: "advanced" },
   { id: "video", section: "webServices", labelKey: "toolbar.layerType.video", tier: "advanced" },
   { id: "deckgl-viz", section: "webServices", labelKey: "toolbar.layerType.deckglViz", tier: "advanced" },

--- a/apps/geolibre-desktop/vite.config.ts
+++ b/apps/geolibre-desktop/vite.config.ts
@@ -546,10 +546,16 @@ async function proxyBinaryRequest(
   res.setHeader("access-control-allow-origin", "*");
   res.setHeader("cache-control", "public, max-age=3600");
   res.setHeader("content-type", contentType);
-  for (const header of ["accept-ranges", "content-length", "content-range"]) {
+  for (const header of ["accept-ranges", "content-range"]) {
     const value = response.headers.get(header);
     if (value) res.setHeader(header, value);
   }
+  // Derive content-length from the buffered body, never the upstream header:
+  // fetch() transparently decompresses gzip/br responses, so the upstream
+  // content-length (the compressed size) would be smaller than the body we
+  // send and truncate it in the browser. The buffer length is correct for both
+  // full (200) and partial (206 + content-range) responses.
+  res.setHeader("content-length", String(body.byteLength));
   res.end(body);
 }
 

--- a/tests/layer-refresh.test.ts
+++ b/tests/layer-refresh.test.ts
@@ -122,4 +122,26 @@ describe("isVectorControlRefreshLayer / isRefreshableLayer", () => {
     assert.equal(isRefreshableLayer(layer), true);
     assert.equal(isVectorControlRefreshLayer(layer), false);
   });
+
+  it("treats a URL-backed GeoRSS layer as refreshable", () => {
+    const layer = makeLayer({
+      type: "geojson",
+      source: { type: "geojson", url: "https://example.com/feed.atom" },
+      sourcePath: "https://example.com/feed.atom",
+      metadata: { sourceKind: "georss" },
+    });
+
+    assert.equal(isRefreshableLayer(layer), true);
+  });
+
+  it("does not refresh a GeoRSS layer loaded from a local file", () => {
+    const layer = makeLayer({
+      type: "geojson",
+      source: { type: "geojson", url: "/home/user/feed.xml" },
+      sourcePath: "/home/user/feed.xml",
+      metadata: { sourceKind: "georss" },
+    });
+
+    assert.equal(isRefreshableLayer(layer), false);
+  });
 });


### PR DESCRIPTION
## Summary

Adds **GeoRSS** as an Add Data source (under *Web services*), closing #788. GeoRSS feeds are parsed entirely client-side into a single mixed-geometry GeoJSON vector layer, so no sidecar is required.

Supported encodings (all three common ones):

- **Simple**: `georss:point`, `georss:line`, `georss:polygon`, `georss:box`
- **GML**: `georss:where` wrapping `gml:Point` / `LineString` / `Polygon` / `Envelope`
- **W3C Geo**: legacy `geo:lat` / `geo:long` (point only)

RSS 2.0 (`<rss><channel><item>`), Atom (`<feed><entry>`), and RSS 1.0/RDF (`<rdf:RDF><item>`) feed shapes are all recognized. Each feed item with a usable geometry becomes one feature; item metadata (`title`, `description`/`summary`, `link`, published date, `author`, `id`, categories) is carried onto the feature properties for the attribute table and popups. Items without a geometry are skipped.

The dialog mirrors the GPX source: a URL mode (with the dev-server CORS proxy and a sample USGS earthquake feed) and a local-file mode (`.xml` / `.rss` / `.atom`).

## Proxy fix (incidental)

While testing the live USGS feed I found the dev-server feed proxy was truncating it. The proxy forwarded the upstream `content-length` (the compressed size) while `fetch()` transparently decompresses gzip/br bodies, so the browser cut the response off at the compressed length. `content-length` is now derived from the buffered body. The same proxy also backs GPX/WFS/raster, so this fixes a latent truncation there too (the small GPX sample never exposed it).

## Out of scope

The optional GeoRSS **export/write** path (GDAL driver via the Python sidecar) noted in the issue is not included here; this PR covers import, which is the core ask. It can be a follow-up.

## Verification

Drove the real app with Playwright in **both light and dark themes**:

- **URL + Atom + Simple point**: loaded the live USGS "M2.5+ past day" Atom feed; features rendered globally and the attribute table showed `title`, `description` (HTML summary), `link`, `published`, `id`, `category` (multiple Atom categories joined), `georss_index`.
- **Local file, mixed geometries**: a hand-built sample exercising `georss:point`/`line`/`polygon`/`box`, GML `Point`/`Polygon`, and W3C `geo:lat`/`geo:long` — all 7 geolocated items parsed (the geometry-less item correctly skipped) and rendered as mixed point/line/polygon on the map.
- `npm run test:frontend` (1460 pass), i18n catalog/parity tests pass, `npm run build` and scoped `pre-commit` (eslint + npm build) clean.

Following the existing GPX parser pattern, the parser itself has no unit test because the frontend test runner has no DOM (`DOMParser`); it is verified end to end in the app instead.

Fixes #788

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GeoRSS feed import to the Add Data dialog: enter a GeoRSS feed URL or select a local XML/RSS/Atom file to add a GeoRSS layer to the map.
  * GeoRSS is now available as a data source option in the toolbar for Intermediate and Advanced experience levels.
  * GeoRSS layers are now refreshable from their source automatically.
* **Bug Fixes**
  * Improved reliability of proxied content delivery for feed imports during development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Update: live refresh

GeoRSS feeds are live, so URL-backed GeoRSS layers now support **Refresh** and **Auto refresh** (fixed interval) from the layer-actions menu, the same controls WFS/GeoJSON layers use. Because a GeoRSS URL returns XML (not GeoJSON), a dedicated refresh branch re-fetches through the feed proxy and re-parses with `parseGeoRssLayer`. File-loaded GeoRSS layers stay non-refreshable (no HTTP source). Verified in the real app: manual refresh reloaded the live USGS feed ("Refreshed 40 features"), and a 15s auto-refresh interval fired automatically.
