### PR TITLE
fix(controls): disable Atmospheric Effects submenu outside globe view (#783)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/toolbar/ControlsMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ControlsMenu.tsx
@@ -341,10 +341,10 @@ function AtmosphereEffectsSubmenu({
       <DropdownMenuSubTrigger
         // Off the globe the effects render nothing, so the controls would be
         // busywork: disable opening the submenu and explain why on hover (#783).
-        // No pointer-events:none here, so the native title tooltip still fires.
+        // DropdownMenuSubTrigger greys out disabled state and keeps pointer
+        // events active, so the native title tooltip still fires.
         disabled={disabled}
         title={disabled ? t("toolbar.atmosphere.globeOnly") : undefined}
-        className={disabled ? "opacity-50" : undefined}
       >
         {t("toolbar.item.atmosphereEffects")}
         {active ? " ✓" : ""}

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ControlsMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ControlsMenu.tsx
@@ -339,15 +339,17 @@ function AtmosphereEffectsSubmenu({
       }}
     >
       <DropdownMenuSubTrigger
-        // Off the globe the effects render nothing, so the controls would be
-        // busywork: disable opening the submenu and explain why on hover (#783).
-        // DropdownMenuSubTrigger greys out disabled state and keeps pointer
-        // events active, so the native title tooltip still fires.
+        // Off the globe the effects render nothing, so disable the submenu and
+        // explain why on hover. The trigger keeps pointer-events active (see
+        // dropdown-menu.tsx) so the native title tooltip still fires (#783).
         disabled={disabled}
         title={disabled ? t("toolbar.atmosphere.globeOnly") : undefined}
       >
         {t("toolbar.item.atmosphereEffects")}
-        {active ? " ✓" : ""}
+        {/* Suppress the check on a disabled (Mercator) row: a ✓ on a greyed,
+            non-interactive entry reads ambiguously. The active state is kept and
+            the mark returns when globe view re-enables the row. */}
+        {!disabled && active ? " ✓" : ""}
       </DropdownMenuSubTrigger>
       <DropdownMenuSubContent className="w-64">
         <DropdownMenuItem

--- a/apps/geolibre-desktop/src/components/layout/toolbar/ControlsMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/ControlsMenu.tsx
@@ -79,6 +79,11 @@ export function ControlsMenu({
   const { t } = useTranslation();
   const uiProfile = useDesktopSettingsStore((s) => s.desktopSettings.uiProfile);
   const show = (id: string) => isMenuItemVisible(uiProfile, id);
+  // Atmospheric effects only render on the globe (the engine idles in Mercator),
+  // so the submenu is disabled while the map is in a flat projection (#783). The
+  // GlobeControl toggle syncs this preference via the map "projectiontransition"
+  // event, so the menu reacts the moment the user switches projections.
+  const globeActive = useAppStore((s) => s.preferences.map.projection === "globe");
   const restrictBounds = useAppStore((s) => s.preferences.map.restrictBounds);
   const setPreferences = useAppStore((s) => s.setPreferences);
   // The globe cannot spin while the map bounds are locked, so enabling spin
@@ -147,6 +152,7 @@ export function ControlsMenu({
           {show("controls.atmosphereEffects") && (
             <AtmosphereEffectsSubmenu
               active={effectsActive}
+              disabled={!globeActive}
               onToggle={onToggleEffects}
               getSettings={getEffectsSettings}
               onPreview={onPreviewEffectsSettings}
@@ -282,6 +288,8 @@ export function ControlsMenu({
 
 interface AtmosphereEffectsSubmenuProps {
   active: boolean;
+  /** Greyed out and non-interactive while the map is not in globe projection. */
+  disabled: boolean;
   onToggle: () => void;
   getSettings: () => EffectsSettings;
   onPreview: (next: Partial<EffectsSettings>) => void;
@@ -302,6 +310,7 @@ interface AtmosphereEffectsSubmenuProps {
  */
 function AtmosphereEffectsSubmenu({
   active,
+  disabled,
   onToggle,
   getSettings,
   onPreview,
@@ -329,7 +338,14 @@ function AtmosphereEffectsSubmenu({
         }
       }}
     >
-      <DropdownMenuSubTrigger>
+      <DropdownMenuSubTrigger
+        // Off the globe the effects render nothing, so the controls would be
+        // busywork: disable opening the submenu and explain why on hover (#783).
+        // No pointer-events:none here, so the native title tooltip still fires.
+        disabled={disabled}
+        title={disabled ? t("toolbar.atmosphere.globeOnly") : undefined}
+        className={disabled ? "opacity-50" : undefined}
+      >
         {t("toolbar.item.atmosphereEffects")}
         {active ? " ✓" : ""}
       </DropdownMenuSubTrigger>

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -952,7 +952,8 @@
       "haloExtentHint": "How far the atmospheric glow reaches past the globe. Lower keeps data tight to the surface; higher gives a wide, airy halo.",
       "haloOpacity": "Halo strength",
       "spaceColor": "Space color",
-      "reset": "Reset to defaults"
+      "reset": "Reset to defaults",
+      "globeOnly": "Atmospheric effects are only available when Globe view is enabled."
     },
     "setView": {
       "title": "Set View",

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -19,7 +19,11 @@ export const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex min-w-0 cursor-default select-none items-center gap-2 overflow-hidden rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent",
+      // Grey out when disabled, like DropdownMenuItem. Intentionally NOT
+      // `data-[disabled]:pointer-events-none`: pointer events must stay active
+      // so a disabled trigger's native `title` tooltip still fires on hover
+      // (Radix already blocks the submenu from opening while disabled).
+      "flex min-w-0 cursor-default select-none items-center gap-2 overflow-hidden rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[disabled]:opacity-50 data-[state=open]:bg-accent",
       inset && "pl-8",
       className,
     )}

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -19,10 +19,12 @@ export const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      // Grey out when disabled, like DropdownMenuItem. Intentionally NOT
+      // Grey out when disabled, like DropdownMenuItem, but intentionally NOT
       // `data-[disabled]:pointer-events-none`: pointer events must stay active
       // so a disabled trigger's native `title` tooltip still fires on hover
-      // (Radix already blocks the submenu from opening while disabled).
+      // (Radix already blocks the submenu from opening while disabled). Unlike
+      // DropdownMenuItem, a disabled SubTrigger therefore still receives pointer
+      // events; callers that need clicks suppressed must handle that themselves.
       "flex min-w-0 cursor-default select-none items-center gap-2 overflow-hidden rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[disabled]:opacity-50 data-[state=open]:bg-accent",
       inset && "pl-8",
       className,


### PR DESCRIPTION
## Summary

Fixes #783. The **Atmospheric Effects** submenu under **Controls** (halo color, halo extent, halo strength, space color) stayed fully interactive while the map was in flat Mercator projection. Those effects only render on the globe, so adjusting them in Mercator produced no visible change, creating confusing busywork.

## Changes

- The Atmospheric Effects submenu is now greyed out and non-interactive while the map is not in globe projection.
- Hovering the disabled row shows a tooltip: "Atmospheric effects are only available when Globe view is enabled."
- The control re-activates instantly when the user switches back to Globe view.

The projection is read reactively from `preferences.map.projection`, which the `GlobeControl` keeps in sync through the map's `projectiontransition` event, so the menu responds the moment the projection changes. Added the `toolbar.atmosphere.globeOnly` i18n string to `en.json`.

## Verification

Drove the real app in a browser:

- Globe view: submenu enabled and fully functional.
- Mercator view: submenu disabled (`aria-disabled`), greyed (opacity), tooltip shown, submenu no longer opens on hover.
- Toggling back to Globe re-enables it immediately.
- Confirmed in both light and dark themes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Atmospheric effects are now restricted to Globe view mode. When other map projections are selected, the atmosphere effects submenu is disabled, shows globe-only guidance, and uses a dimmed disabled state in the dropdown UI.
* **Documentation**
  * Added a new “globe only” label in the toolbar atmosphere text to clarify that atmospheric effects are only available when Globe view is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->