### PR TITLE
feat(print): add Copy to Clipboard to Print Layout (#773)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -25,6 +25,8 @@ import {
 import {
   ArrowDown,
   ArrowUp,
+  Check,
+  ClipboardCopy,
   Crop,
   Eye,
   EyeOff,
@@ -57,6 +59,7 @@ import {
   applyLegendConfig,
   buildLegend,
   captureMapImage,
+  copyLayoutToClipboard,
   exportLayoutPdf,
   exportLayoutPng,
   legendEditorRows,
@@ -250,6 +253,9 @@ export function PrintLayoutDialog({
   // the default "cover" crop; "cover" (fill the frame) otherwise.
   const [mapFit, setMapFit] = useState<"cover" | "contain">("cover");
   const [exporting, setExporting] = useState(false);
+  // Brief "Copied" confirmation on the clipboard button (GH #773).
+  const [copied, setCopied] = useState(false);
+  const copiedTimeoutRef = useRef<number | null>(null);
   const [error, setError] = useState<string | null>(null);
   const previewRef = useRef<HTMLCanvasElement | null>(null);
   const previewBoxRef = useRef<HTMLDivElement | null>(null);
@@ -513,6 +519,10 @@ export function PrintLayoutDialog({
       if (idleFallbackRef.current !== null) {
         window.clearTimeout(idleFallbackRef.current);
         idleFallbackRef.current = null;
+      }
+      if (copiedTimeoutRef.current !== null) {
+        window.clearTimeout(copiedTimeoutRef.current);
+        copiedTimeoutRef.current = null;
       }
       const map = mapControllerRef.current?.getMap();
       if (map) {
@@ -869,6 +879,32 @@ export function PrintLayoutDialog({
       observer?.disconnect();
     };
   }, [open, options]);
+
+  // Copy the composed layout to the clipboard as a PNG, so it can be pasted
+  // straight into a document without saving a file first (GH #773).
+  const handleCopy = async () => {
+    if (!captured) {
+      setError(t("printLayout.errors.captureFirst"));
+      return;
+    }
+    setExporting(true);
+    setError(null);
+    try {
+      await copyLayoutToClipboard(options);
+      setCopied(true);
+      if (copiedTimeoutRef.current !== null) {
+        window.clearTimeout(copiedTimeoutRef.current);
+      }
+      copiedTimeoutRef.current = window.setTimeout(() => {
+        setCopied(false);
+        copiedTimeoutRef.current = null;
+      }, 2000);
+    } catch {
+      setError(t("printLayout.errors.clipboardFailed"));
+    } finally {
+      setExporting(false);
+    }
+  };
 
   const handleExport = async (kind: "png" | "pdf") => {
     if (!captured) {
@@ -1949,6 +1985,21 @@ export function PrintLayoutDialog({
         <div className="flex items-center justify-end gap-2 pt-2">
           <Button variant="ghost" onClick={() => onOpenChange(false)}>
             {t("common.close")}
+          </Button>
+          {/* Copy the composed layout straight to the clipboard (GH #773). */}
+          <Button
+            variant="outline"
+            disabled={exporting || !captured}
+            onClick={() => void handleCopy()}
+          >
+            {copied ? (
+              <Check className="mr-2 h-4 w-4" />
+            ) : (
+              <ClipboardCopy className="mr-2 h-4 w-4" />
+            )}
+            {copied
+              ? t("printLayout.copied")
+              : t("printLayout.copyToClipboard")}
           </Button>
           {/* Equal-weight export buttons: neither format is the "primary" one
               (GH #520). */}

--- a/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/PrintLayoutDialog.tsx
@@ -496,6 +496,14 @@ export function PrintLayoutDialog({
       // hidden (not unmounted) on close, so it would otherwise persist into the
       // next open even though no scale was just attempted (GH #743).
       setScaleNotice(null);
+      // Same reasoning for the clipboard "Copied" flag: a copy made just before
+      // the dialog was closed (within the 2s window) would otherwise re-open
+      // still showing the confirmation (GH #773).
+      if (copiedTimeoutRef.current !== null) {
+        window.clearTimeout(copiedTimeoutRef.current);
+        copiedTimeoutRef.current = null;
+      }
+      setCopied(false);
       setTitle((prev) => prev || (projectName ?? "").trim());
       setDateText((prev) => prev || new Date().toLocaleDateString());
       // Re-show a previously drawn extent box while composing.

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -641,6 +641,8 @@
     "resizeControls": "Resize controls panel",
     "resizeDialog": "Resize dialog",
     "recapture": "Recapture map",
+    "copyToClipboard": "Copy to Clipboard",
+    "copied": "Copied",
     "exportPng": "Export PNG",
     "exportPdf": "Export PDF",
     "titleLabel": "Title",
@@ -757,6 +759,7 @@
       "captureFailed": "Could not capture the map image.",
       "captureFirst": "Capture the map before exporting.",
       "exportFailed": "Failed to export {{format}}.",
+      "clipboardFailed": "Could not copy the layout to the clipboard.",
       "scaleOutOfRange": "This scale is outside the range the current view can reach; showing the closest available scale."
     },
     "legend": {

--- a/apps/geolibre-desktop/src/lib/print-layout-export.ts
+++ b/apps/geolibre-desktop/src/lib/print-layout-export.ts
@@ -282,6 +282,40 @@ export async function exportLayoutPng(
 }
 
 /**
+ * Render the layout and copy it to the system clipboard as a PNG image
+ * (GH #773), so users can paste it straight into a document without saving a
+ * file first.
+ *
+ * Uses the async Clipboard API (`navigator.clipboard.write`) with a
+ * `ClipboardItem`. The PNG blob is supplied as a promise so the write is
+ * initiated synchronously inside the originating user gesture, which Safari
+ * requires; Chromium-based browsers and Tauri webviews accept it too.
+ *
+ * @throws If the Clipboard image API is unavailable (e.g. an insecure context
+ *   or an older browser) or the browser denies the write, so the dialog can
+ *   surface an error instead of silently doing nothing.
+ */
+export async function copyLayoutToClipboard(
+  opts: LayoutOptions,
+  dpi = 150,
+): Promise<void> {
+  if (typeof ClipboardItem === "undefined" || !navigator.clipboard?.write) {
+    throw new Error("Clipboard image copy is not supported in this browser");
+  }
+  // Build the PNG blob inside a promise handed to ClipboardItem so the
+  // clipboard write stays within the user gesture (required by Safari).
+  const blob = (async () => {
+    const canvas = renderToCanvas(opts, dpi);
+    const png = await new Promise<Blob | null>((resolve) =>
+      canvas.toBlob((b) => resolve(b), "image/png"),
+    );
+    if (!png) throw new Error("Failed to render PNG for the clipboard");
+    return png;
+  })();
+  await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
+}
+
+/**
  * Export the layout as a PDF file at the given DPI (default 150).
  *
  * Generates the PDF bytes with jsPDF and saves them through


### PR DESCRIPTION
## Summary

Adds a **Copy to Clipboard** action to the Print Layout dialog, alongside the existing Export PNG and Export PDF buttons. Users can now copy the composed map layout straight to the system clipboard as a PNG and paste it directly into a word processor or document, skipping the save-file-then-import round trip.

Fixes #773

## Changes

- `print-layout-export.ts`: new `copyLayoutToClipboard()` helper that rasterizes the layout (same path as the PNG export) and writes it via the async Clipboard API (`navigator.clipboard.write` + `ClipboardItem`). The PNG blob is supplied as a promise so the write stays inside the user gesture, which Safari requires.
- `PrintLayoutDialog.tsx`: a **Copy to Clipboard** button in the footer with a brief "Copied" confirmation, error handling, and timeout cleanup on unmount.
- `en.json`: new strings `copyToClipboard`, `copied`, and `errors.clipboardFailed`.

## Verification

Verified in the running app with a real basemap view in **both light and dark themes**:

- Clicking the button populates the clipboard with an `image/png` item (confirmed via `navigator.clipboard.read()`).
- The button shows a transient "Copied" confirmation.
- No console errors; `npm run build` and pre-commit pass.