### PR TITLE
fix(bookmarks): clearer bookmark panel UX (#794)

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -58,7 +58,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.3",
     "maplibre-gl-basemap-control": "^0.7.0",
-    "maplibre-gl-components": "^0.22.5",
+    "maplibre-gl-components": "^0.22.6",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -21,7 +21,7 @@ import {
   restoreRasterLayers,
   restoreThreeDTilesLayers,
   restoreVectorLayers,
-  setBookmarkCaptureLabel,
+  setBookmarkLabels,
   setNonTiledRasterHandler,
   startLayerGeometryEdit,
   subscribeGeometryEdit,
@@ -394,12 +394,18 @@ export function DesktopShell({
   const { t } = useTranslation();
   const shellRef = useRef<HTMLDivElement>(null);
   const verticalResizeGuideRef = useRef<HTMLDivElement>(null);
-  // Push the translated bookmark capture-checkbox label into the
-  // framework-agnostic plugins package (which can't call t() itself). Done here
-  // rather than in TopToolbar so it still applies when the toolbar is hidden
-  // (e.g. `?maponly`), where the BookmarkControl overlay is still present.
+  // Push the translated bookmark labels into the framework-agnostic plugins
+  // package (which can't call t() itself). Done here rather than in TopToolbar
+  // so it still applies when the toolbar is hidden (e.g. `?maponly`), where the
+  // BookmarkControl overlay is still present.
   useEffect(() => {
-    setBookmarkCaptureLabel(t("bookmark.captureStateLabel"));
+    setBookmarkLabels({
+      captureStateLabel: t("bookmark.captureStateLabel"),
+      captureStateTooltip: t("bookmark.captureStateTooltip"),
+      exportLabel: t("bookmark.export"),
+      exportSelectedLabel: t("bookmark.exportSelected"),
+      exportAllLabel: t("bookmark.exportAll"),
+    });
   }, [t]);
   // The map's Fullscreen control maximizes the map *canvas* (it calls
   // requestFullscreen on the map container). Chromium promotes that element to

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -53,11 +53,15 @@
     }
   },
   "bookmark": {
-    "captureStateLabel": "Include visible layers"
+    "captureStateLabel": "Include complete layer state (active, inactive, and layer order)",
+    "captureStateTooltip": "Applies to the bookmark you save next, not as a global setting. Leave it on to restore exactly this layer arrangement later.",
+    "export": "Export",
+    "exportSelected": "Export Selected",
+    "exportAll": "Export All"
   },
   "fileNamePrompt": {
     "title": "Save file as",
-    "description": "Choose a file name. The file downloads to your browser's downloads folder.",
+    "description": "Enter a file name. The file downloads to your browser's downloads folder.",
     "label": "File name"
   },
   "newProject": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.3",
         "maplibre-gl-basemap-control": "^0.7.0",
-        "maplibre-gl-components": "^0.22.5",
+        "maplibre-gl-components": "^0.22.6",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -187,9 +187,9 @@
       "license": "MIT"
     },
     "apps/geolibre-desktop/node_modules/maplibre-gl-components": {
-      "version": "0.22.5",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.22.5.tgz",
-      "integrity": "sha512-sRnufE9oBEAt27G5iqlUSvRaC5da26oF0W4zhN1tdoyKT910KoIF9R4q4JcM1nyqNVKhF0kKGHunXeIbfRU4uw==",
+      "version": "0.22.6",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.22.6.tgz",
+      "integrity": "sha512-CjNcDUVwiQnX0F6MkE4Qq/f7ykIzzi9UDkQogHDA03FDWls5/zKWBGdpYn0ATv2oCyctBHL918qAVLR5eLqHmQ==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",
@@ -24305,7 +24305,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.3",
         "maplibre-gl-basemap-control": "^0.7.0",
-        "maplibre-gl-components": "^0.22.5",
+        "maplibre-gl-components": "^0.22.6",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -24344,9 +24344,9 @@
       }
     },
     "packages/plugins/node_modules/maplibre-gl-components": {
-      "version": "0.22.5",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.22.5.tgz",
-      "integrity": "sha512-sRnufE9oBEAt27G5iqlUSvRaC5da26oF0W4zhN1tdoyKT910KoIF9R4q4JcM1nyqNVKhF0kKGHunXeIbfRU4uw==",
+      "version": "0.22.6",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.22.6.tgz",
+      "integrity": "sha512-CjNcDUVwiQnX0F6MkE4Qq/f7ykIzzi9UDkQogHDA03FDWls5/zKWBGdpYn0ATv2oCyctBHL918qAVLR5eLqHmQ==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -32,7 +32,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.3",
     "maplibre-gl-basemap-control": "^0.7.0",
-    "maplibre-gl-components": "^0.22.5",
+    "maplibre-gl-components": "^0.22.6",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -98,7 +98,7 @@ export {
   openZarrLayerPanel,
   addCloudNetcdfLayer,
   type CloudNetcdfLayerOptions,
-  setBookmarkCaptureLabel,
+  setBookmarkLabels,
   subscribeBookmarkPanel,
   subscribeColorbarPanel,
   subscribeHtmlPanel,

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -315,7 +315,10 @@ export function setBookmarkLabels(
   labels: Partial<typeof bookmarkLabels>
 ): void {
   for (const [key, value] of Object.entries(labels)) {
-    if (value) bookmarkLabels[key as keyof typeof bookmarkLabels] = value;
+    // Only overwrite when the caller actually supplied the key; an omitted key
+    // keeps the English default rather than being blanked out.
+    if (value !== undefined)
+      bookmarkLabels[key as keyof typeof bookmarkLabels] = value;
   }
 }
 
@@ -2768,7 +2771,10 @@ function routeBookmarkFileIoThroughHost(
   // of BookmarkControl as of maplibre-gl-components@0.21.0. If a future version
   // renames them, the overrides below silently stop being called and file I/O
   // regresses to the WebView-incompatible Blob/file-input path — so warn loudly
-  // to flag it when bumping the dependency.
+  // to flag it when bumping the dependency. The public `exportBookmarks(mode?)`
+  // signature is load-bearing too (added in 0.22.6): if a future version drops
+  // the `mode` arg, "Export Selected" would silently export everything, since
+  // the extra argument becomes a no-op. Re-verify both when bumping.
   const io = control as unknown as {
     _exportToFile?: (mode?: BookmarkExportMode) => void;
     _importFromFile?: () => void;

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -23,6 +23,7 @@ import type {
   CogLayerInfo,
   BookmarkControl,
   BookmarkControlOptions,
+  BookmarkExportMode,
   ColorbarGuiControl,
   ColorbarGuiControlOptions,
   ControlGrid,
@@ -296,15 +297,26 @@ const MEASURE_OPTIONS = {
 } satisfies MeasureControlOptions;
 
 /**
- * Label for the bookmark "capture state" checkbox. Default is English; the
- * desktop shell pushes a translated value via {@link setBookmarkCaptureLabel}
- * since this package is framework-agnostic and has no react-i18next access.
+ * User-facing strings for the BookmarkControl. Defaults are English; the
+ * desktop shell pushes translated values via {@link setBookmarkLabels} since
+ * this package is framework-agnostic and has no react-i18next access.
  */
-let bookmarkCaptureLabel = "Include visible layers";
+const bookmarkLabels = {
+  captureStateLabel: "Include complete layer state (active, inactive, and layer order)",
+  captureStateTooltip:
+    "Applies to the bookmark you save next, not as a global setting. Leave it on to restore exactly this layer arrangement later.",
+  exportLabel: "Export",
+  exportSelectedLabel: "Export Selected",
+  exportAllLabel: "Export All",
+};
 
-/** Override the bookmark capture-state checkbox label with translated text. */
-export function setBookmarkCaptureLabel(label: string): void {
-  if (label) bookmarkCaptureLabel = label;
+/** Override the BookmarkControl labels with translated text. */
+export function setBookmarkLabels(
+  labels: Partial<typeof bookmarkLabels>
+): void {
+  for (const [key, value] of Object.entries(labels)) {
+    if (value) bookmarkLabels[key as keyof typeof bookmarkLabels] = value;
+  }
 }
 
 /**
@@ -365,10 +377,14 @@ const BOOKMARK_OPTIONS = {
   position: bookmarkControlPosition,
   storageKey: "geolibre-bookmarks",
   // Resizable panel and drag reordering are on by default upstream; enable
-  // per-bookmark export selection and visible-layer capture here. The
-  // capture-checkbox label is applied per-instance in createBookmarkControl so
-  // it can pick up the translated string.
+  // per-bookmark export selection and visible-layer capture here. Labels and
+  // the capture tooltip are applied per-instance in createBookmarkControl so
+  // they pick up the translated strings.
   selectable: true,
+  // Always offer an explicit "Export All" plus a contextual "Export Selected"
+  // (issue #794), and drop the low-value zoom/date metadata from each card.
+  showExportAll: true,
+  showMetadata: false,
   captureState: captureVisibleLayers,
   restoreState: restoreVisibleLayers,
 } satisfies BookmarkControlOptions;
@@ -2726,7 +2742,11 @@ function createBookmarkControl(
 ): BookmarkControl {
   const control = new BookmarkControlClass({
     ...BOOKMARK_OPTIONS,
-    captureStateLabel: bookmarkCaptureLabel,
+    captureStateLabel: bookmarkLabels.captureStateLabel,
+    captureStateTooltip: bookmarkLabels.captureStateTooltip,
+    exportLabel: bookmarkLabels.exportLabel,
+    exportSelectedLabel: bookmarkLabels.exportSelectedLabel,
+    exportAllLabel: bookmarkLabels.exportAllLabel,
   });
   routeBookmarkFileIoThroughHost(control, app);
   return control;
@@ -2750,9 +2770,9 @@ function routeBookmarkFileIoThroughHost(
   // regresses to the WebView-incompatible Blob/file-input path — so warn loudly
   // to flag it when bumping the dependency.
   const io = control as unknown as {
-    _exportToFile?: () => void;
+    _exportToFile?: (mode?: BookmarkExportMode) => void;
     _importFromFile?: () => void;
-    exportBookmarks: () => string;
+    exportBookmarks: (mode?: BookmarkExportMode) => string;
     importBookmarks: (bookmarks: MapBookmark[]) => unknown;
   };
   if (!io._exportToFile || !io._importFromFile) {
@@ -2773,12 +2793,16 @@ function routeBookmarkFileIoThroughHost(
     promptName: true,
   };
 
-  io._exportToFile = () => {
+  io._exportToFile = (mode) => {
     if (!app.exportTextFile) {
-      originalExport();
+      originalExport(mode);
       return;
     }
-    app.exportTextFile("bookmarks.json", io.exportBookmarks(), dialogOptions);
+    app.exportTextFile(
+      "bookmarks.json",
+      io.exportBookmarks(mode),
+      dialogOptions
+    );
   };
 
   io._importFromFile = () => {


### PR DESCRIPTION
Addresses the bookmark-management feedback in #794. Part 6 (bookmark grouping / folder hierarchy) is intentionally **deferred to a separate issue/PR**; this PR covers the other requests.

## Changes

| # | Request | Done |
|---|---------|------|
| 1 | Clarify the capture-state checkbox copy | ✅ Reworded to "Include complete layer state (active, inactive, and layer order)" |
| 2 | Explain global-vs-individual capture behavior | ✅ Info icon + tooltip next to the checkbox |
| 3 | "Export" → "Export Selected" when items are checked | ✅ Contextual "Export Selected" button |
| 4 | Dedicated "Export All" button | ✅ Always-present "Export All" |
| 5 | Remove low-value zoom/date metadata from cards | ✅ Metadata line hidden |
| 6 | Bookmark grouping / folder hierarchy | ⏸️ Deferred to a follow-up |
| 7 | Import/Export arrow direction | ✅ Import points inward (down), Export outward (up) |
| 8 | "Choose a file name" → "Enter a file name" | ✅ Reworded the file-name prompt |

The footer now shows **Import · Export All**, with **Export Selected** appearing only while one or more bookmarks are ticked.

## Upstream dependency

The control itself lives in `maplibre-gl-components`. The new behavior is added there in opengeos/maplibre-gl-components#108 (released as **0.22.6**) via additive options (`showExportAll`, `showMetadata`, `captureStateTooltip`, `exportLabel` / `exportSelectedLabel` / `exportAllLabel`) and the swapped Import/Export icons. This PR bumps the dependency to `^0.22.6` and wires the options + translated labels through `DesktopShell` / the plugins package.

## Verification

Driven in the real app with Playwright against the published `0.22.6`, in **both light and dark themes**: confirmed the new label + tooltip, the Export All / Export Selected buttons (including the conditional show/hide on selection), the removed metadata line, and the swapped icons. `npm run build`, `npm run test:frontend` (1464 pass), and `pre-commit` all pass.

Refs #794

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded bookmark controls with clearer capture-state wording plus a tooltip describing what the next bookmark will include.
  * Added explicit bookmark export options, including **Export Selected** and **Export All**, alongside existing export.
* **Chores**
  * Updated `maplibre-gl-components` to version **0.22.6**.
* **Style**
  * Refined file name and downloads-folder text in the export dialog for clearer prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->