### PR TITLE
fix(segmentation): hide desktop-only config form in the web build

### DIFF
--- a/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
@@ -233,18 +233,11 @@ export function SegmentationDialog({
   ]);
 
   const available = status?.available === true;
-  // In the browser build segmentation can never run (it needs the desktop
-  // sidecar + segment-geospatial). Rather than render a full configuration form
-  // whose inputs do nothing and a permanently disabled Segment button (issue
-  // #777), collapse the dialog to just the explanatory banner plus a link to
-  // the desktop download. The desktop build keeps the full form even when the
-  // server is not running yet, since the user can start it from here.
-  //
-  // We treat the form as hidden whenever the browser hasn't *confirmed*
-  // availability (status null mid-probe, or unavailable), so the form never
-  // flashes in on open before the async status probe resolves. On the rare web
-  // deployment where the proxied sidecar is reachable, `available` becomes true
-  // and the full form appears.
+  // Hide the form in the browser unless a proxied sidecar confirms
+  // availability. Gating on `available` (not on `status !== null`) prevents the
+  // form from flashing in during the async probe (issue #777); `available`
+  // becomes true only when a proxied sidecar is reachable, which also covers
+  // the rare web deployment where segmentation is actually usable.
   const webUnavailable = !isTauri() && !available;
 
   return (

--- a/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
@@ -20,6 +20,7 @@ import {
 import {
   AlertCircle,
   CheckCircle2,
+  Download,
   FolderOpen,
   Info,
   Loader2,
@@ -38,6 +39,7 @@ import { useTranslation } from "react-i18next";
 import { isTauri, openLocalDataFileWithFallback } from "../../lib/tauri-io";
 import { reprojectFeatureCollectionToWgs84 } from "../../lib/duckdb-vector-loader";
 import { startGeoLibreSidecar } from "../../lib/sidecar";
+import { UPDATE_URL } from "../../lib/updates";
 import {
   SidecarHelpBanner,
   SIDECAR_PORT,
@@ -231,6 +233,13 @@ export function SegmentationDialog({
   ]);
 
   const available = status?.available === true;
+  // In the browser build segmentation can never run (it needs the desktop
+  // sidecar + segment-geospatial). Rather than render a full configuration form
+  // whose inputs do nothing and a permanently disabled Segment button (issue
+  // #777), collapse the dialog to just the explanatory banner plus a link to
+  // the desktop download. The desktop build keeps the full form even when the
+  // server is not running yet, since the user can start it from here.
+  const webUnavailable = !isTauri() && status !== null && !available;
 
   return (
     <Dialog
@@ -263,7 +272,7 @@ export function SegmentationDialog({
               </p>
               {/* Launching the sidecar is a desktop-only (Tauri) capability;
                   hide the action in the browser build where it cannot work. */}
-              {isTauri() && (
+              {isTauri() ? (
                 <Button
                   type="button"
                   variant="outline"
@@ -278,10 +287,25 @@ export function SegmentationDialog({
                   )}
                   {t("segmentation.startServer")}
                 </Button>
+              ) : (
+                // Browser users cannot run segmentation here, so point them at
+                // the desktop download instead of the unusable "Start server"
+                // action (issue #777).
+                <Button asChild type="button" variant="outline" className="gap-2">
+                  <a href={UPDATE_URL} target="_blank" rel="noreferrer">
+                    <Download className="h-4 w-4" />
+                    {t("segmentation.downloadDesktop")}
+                  </a>
+                </Button>
               )}
             </div>
           )}
 
+          {/* The configuration form and Segment button only make sense where
+              segmentation can actually run. In the browser they are hidden so
+              the dialog shows just the banner + desktop download link. */}
+          {!webUnavailable && (
+            <>
           {/* Image source */}
           <div className="grid gap-1.5">
             <Label htmlFor="seg-image" className="text-xs">
@@ -381,6 +405,8 @@ export function SegmentationDialog({
               {t("segmentation.segment")}
             </Button>
           </div>
+            </>
+          )}
 
           {/* A failed "Start server" attempt becomes an interactive
               troubleshooting banner (issue #594). Segmentation has no WASM

--- a/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
@@ -240,6 +240,20 @@ export function SegmentationDialog({
   // the rare web deployment where segmentation is actually usable.
   const webUnavailable = !isTauri() && !available;
 
+  // Browser users cannot run segmentation here, so point them at the desktop
+  // download instead of the unusable "Start server" action (issue #777). This
+  // is rendered both in the resolved "unavailable" banner and while the status
+  // probe is still in flight, so a slow or hanging probe (e.g. a silent packet
+  // drop with no explicit fetch timeout) never leaves them without an action.
+  const downloadDesktopButton = (
+    <Button asChild variant="outline" className="gap-2">
+      <a href={UPDATE_URL} target="_blank" rel="noreferrer">
+        <Download className="h-4 w-4" />
+        {t("segmentation.downloadDesktop")}
+      </a>
+    </Button>
+  );
+
   return (
     <Dialog
       open={open}
@@ -257,10 +271,15 @@ export function SegmentationDialog({
 
         <div className="flex flex-col gap-3">
           {checking && (
-            <p className="flex items-center gap-2 text-sm text-muted-foreground">
-              <Loader2 className="h-4 w-4 animate-spin" />
-              {t("segmentation.status.checking")}
-            </p>
+            <div className="grid gap-2">
+              <p className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                {t("segmentation.status.checking")}
+              </p>
+              {/* Keep a download CTA visible while the probe runs so browser
+                  users always have an action, even if it never settles. */}
+              {!isTauri() && downloadDesktopButton}
+            </div>
           )}
 
           {!checking && status && !available && (
@@ -270,7 +289,8 @@ export function SegmentationDialog({
                 {status.message}
               </p>
               {/* Launching the sidecar is a desktop-only (Tauri) capability;
-                  hide the action in the browser build where it cannot work. */}
+                  in the browser build it cannot work, so offer the desktop
+                  download instead. */}
               {isTauri() ? (
                 <Button
                   type="button"
@@ -287,15 +307,7 @@ export function SegmentationDialog({
                   {t("segmentation.startServer")}
                 </Button>
               ) : (
-                // Browser users cannot run segmentation here, so point them at
-                // the desktop download instead of the unusable "Start server"
-                // action (issue #777).
-                <Button asChild variant="outline" className="gap-2">
-                  <a href={UPDATE_URL} target="_blank" rel="noreferrer">
-                    <Download className="h-4 w-4" />
-                    {t("segmentation.downloadDesktop")}
-                  </a>
-                </Button>
+                downloadDesktopButton
               )}
             </div>
           )}

--- a/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
@@ -247,7 +247,7 @@ export function SegmentationDialog({
   // drop with no explicit fetch timeout) never leaves them without an action.
   const downloadDesktopButton = (
     <Button asChild variant="outline" className="gap-2">
-      <a href={UPDATE_URL} target="_blank" rel="noreferrer">
+      <a href={UPDATE_URL} target="_blank" rel="noopener noreferrer">
         <Download className="h-4 w-4" />
         {t("segmentation.downloadDesktop")}
       </a>
@@ -277,8 +277,9 @@ export function SegmentationDialog({
                 {t("segmentation.status.checking")}
               </p>
               {/* Keep a download CTA visible while the probe runs so browser
-                  users always have an action, even if it never settles. */}
-              {!isTauri() && downloadDesktopButton}
+                  users always have an action, even if it never settles. During
+                  the probe `webUnavailable` reduces to `!isTauri()`. */}
+              {webUnavailable && downloadDesktopButton}
             </div>
           )}
 

--- a/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
@@ -233,11 +233,12 @@ export function SegmentationDialog({
   ]);
 
   const available = status?.available === true;
-  // Hide the form in the browser unless a proxied sidecar confirms
-  // availability. Gating on `available` (not on `status !== null`) prevents the
-  // form from flashing in during the async probe (issue #777); `available`
-  // becomes true only when a proxied sidecar is reachable, which also covers
-  // the rare web deployment where segmentation is actually usable.
+  // In the browser the form is shown but disabled rather than hidden (issue
+  // #777): web users still see the full capability they're missing, which
+  // motivates the desktop download, but cannot interact with inputs that do
+  // nothing. Gating on `available` (not on `status !== null`) keeps the form
+  // disabled during the async probe too; `available` becomes true only when a
+  // proxied sidecar is reachable, the rare web case where segmentation works.
   const webUnavailable = !isTauri() && !available;
 
   // Browser users cannot run segmentation here, so point them at the desktop
@@ -323,112 +324,114 @@ export function SegmentationDialog({
             </div>
           )}
 
-          {/* The configuration form and Segment button only make sense where
-              segmentation can actually run. In the browser they are hidden so
-              the dialog shows just the banner + desktop download link. */}
-          {!webUnavailable && (
+          {/* The configuration form is always rendered. In the browser it is
+              shown but disabled (`webUnavailable`) so web users still see the
+              full capability and are pointed to the desktop download above,
+              without being able to interact with inputs that do nothing. */}
+          {/* Image source */}
+          <div className="grid gap-1.5">
+            <Label htmlFor="seg-image" className="text-xs">
+              {t("segmentation.imageLabel")}
+              <span className="text-destructive"> *</span>
+            </Label>
+            <div className="grid grid-cols-[minmax(0,1fr)_2.25rem] gap-2">
+              <Input
+                id="seg-image"
+                readOnly
+                disabled={webUnavailable}
+                value={imageName}
+                placeholder={t("segmentation.imagePlaceholder")}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                title={t("segmentation.chooseImage")}
+                onClick={() => void pickImage()}
+                disabled={webUnavailable}
+              >
+                <FolderOpen className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+
+          {/* Mode */}
+          <div className="grid gap-1.5">
+            <Label htmlFor="seg-mode" className="text-xs">
+              {t("segmentation.modeLabel")}
+            </Label>
+            <Select
+              id="seg-mode"
+              value={mode}
+              disabled={webUnavailable}
+              onChange={(e) =>
+                setMode(e.target.value as "text" | "automatic")
+              }
+            >
+              <option value="text">{t("segmentation.modeText")}</option>
+              <option value="automatic">
+                {t("segmentation.modeAutomatic")}
+              </option>
+            </Select>
+          </div>
+
+          {mode === "text" && (
             <>
-              {/* Image source */}
               <div className="grid gap-1.5">
-                <Label htmlFor="seg-image" className="text-xs">
-                  {t("segmentation.imageLabel")}
+                <Label htmlFor="seg-prompt" className="text-xs">
+                  {t("segmentation.promptLabel")}
                   <span className="text-destructive"> *</span>
                 </Label>
-                <div className="grid grid-cols-[minmax(0,1fr)_2.25rem] gap-2">
-                  <Input
-                    id="seg-image"
-                    readOnly
-                    value={imageName}
-                    placeholder={t("segmentation.imagePlaceholder")}
-                  />
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    title={t("segmentation.chooseImage")}
-                    onClick={() => void pickImage()}
-                  >
-                    <FolderOpen className="h-4 w-4" />
-                  </Button>
-                </div>
+                <Input
+                  id="seg-prompt"
+                  value={prompt}
+                  disabled={webUnavailable}
+                  placeholder={t("segmentation.promptPlaceholder")}
+                  onChange={(e) => setPrompt(e.target.value)}
+                />
               </div>
-
-              {/* Mode */}
               <div className="grid gap-1.5">
-                <Label htmlFor="seg-mode" className="text-xs">
-                  {t("segmentation.modeLabel")}
+                <Label htmlFor="seg-confidence" className="text-xs">
+                  {t("segmentation.confidenceLabel")}
                 </Label>
-                <Select
-                  id="seg-mode"
-                  value={mode}
-                  onChange={(e) =>
-                    setMode(e.target.value as "text" | "automatic")
-                  }
-                >
-                  <option value="text">{t("segmentation.modeText")}</option>
-                  <option value="automatic">
-                    {t("segmentation.modeAutomatic")}
-                  </option>
-                </Select>
-              </div>
-
-              {mode === "text" && (
-                <>
-                  <div className="grid gap-1.5">
-                    <Label htmlFor="seg-prompt" className="text-xs">
-                      {t("segmentation.promptLabel")}
-                      <span className="text-destructive"> *</span>
-                    </Label>
-                    <Input
-                      id="seg-prompt"
-                      value={prompt}
-                      placeholder={t("segmentation.promptPlaceholder")}
-                      onChange={(e) => setPrompt(e.target.value)}
-                    />
-                  </div>
-                  <div className="grid gap-1.5">
-                    <Label htmlFor="seg-confidence" className="text-xs">
-                      {t("segmentation.confidenceLabel")}
-                    </Label>
-                    <Input
-                      id="seg-confidence"
-                      type="number"
-                      min={0}
-                      max={1}
-                      step={0.05}
-                      value={String(confidence)}
-                      onChange={(e) => {
-                        if (e.target.value === "") {
-                          setConfidence(0.4);
-                          return;
-                        }
-                        const parsed = Number(e.target.value);
-                        // Ignore non-numeric input and clamp to [0, 1] so a NaN or
-                        // out-of-range confidence is never sent to the backend.
-                        if (!Number.isFinite(parsed)) return;
-                        setConfidence(Math.min(1, Math.max(0, parsed)));
-                      }}
-                    />
-                  </div>
-                </>
-              )}
-
-              <div>
-                <Button
-                  onClick={() => void handleRun()}
-                  disabled={running || !available || !imageBytes}
-                  className="gap-2"
-                >
-                  {running ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <Play className="h-4 w-4" />
-                  )}
-                  {t("segmentation.segment")}
-                </Button>
+                <Input
+                  id="seg-confidence"
+                  type="number"
+                  min={0}
+                  max={1}
+                  step={0.05}
+                  disabled={webUnavailable}
+                  value={String(confidence)}
+                  onChange={(e) => {
+                    if (e.target.value === "") {
+                      setConfidence(0.4);
+                      return;
+                    }
+                    const parsed = Number(e.target.value);
+                    // Ignore non-numeric input and clamp to [0, 1] so a NaN or
+                    // out-of-range confidence is never sent to the backend.
+                    if (!Number.isFinite(parsed)) return;
+                    setConfidence(Math.min(1, Math.max(0, parsed)));
+                  }}
+                />
               </div>
             </>
           )}
+
+          <div>
+            <Button
+              onClick={() => void handleRun()}
+              disabled={running || !available || !imageBytes}
+              className="gap-2"
+            >
+              {running ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Play className="h-4 w-4" />
+              )}
+              {t("segmentation.segment")}
+            </Button>
+          </div>
 
           {/* A failed "Start server" attempt becomes an interactive
               troubleshooting banner (issue #594). Segmentation has no WASM

--- a/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
@@ -297,7 +297,7 @@ export function SegmentationDialog({
                 // Browser users cannot run segmentation here, so point them at
                 // the desktop download instead of the unusable "Start server"
                 // action (issue #777).
-                <Button asChild type="button" variant="outline" className="gap-2">
+                <Button asChild variant="outline" className="gap-2">
                   <a href={UPDATE_URL} target="_blank" rel="noreferrer">
                     <Download className="h-4 w-4" />
                     {t("segmentation.downloadDesktop")}

--- a/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
@@ -271,10 +271,17 @@ export function SegmentationDialog({
 
         <div className="flex flex-col gap-3">
           {checking && (
-            // Same panel framing as the resolved-unavailable banner below, so
-            // the download CTA keeps its frame instead of jumping when the
-            // probe settles.
-            <div className="grid gap-2 rounded-md border border-border bg-muted/40 p-3">
+            // For browser users the spinner shares the resolved banner's panel
+            // framing so the download CTA below it keeps its frame instead of
+            // jumping when the probe settles. Desktop has no CTA here, so it
+            // keeps the plain inline spinner it had before.
+            <div
+              className={
+                webUnavailable
+                  ? "grid gap-2 rounded-md border border-border bg-muted/40 p-3"
+                  : "grid gap-2"
+              }
+            >
               <p className="flex items-center gap-2 text-sm text-muted-foreground">
                 <Loader2 className="h-4 w-4 animate-spin" />
                 {t("segmentation.status.checking")}

--- a/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
@@ -312,105 +312,105 @@ export function SegmentationDialog({
               the dialog shows just the banner + desktop download link. */}
           {!webUnavailable && (
             <>
-            {/* Image source */}
-            <div className="grid gap-1.5">
-              <Label htmlFor="seg-image" className="text-xs">
-                {t("segmentation.imageLabel")}
-                <span className="text-destructive"> *</span>
-              </Label>
-              <div className="grid grid-cols-[minmax(0,1fr)_2.25rem] gap-2">
-                <Input
-                  id="seg-image"
-                  readOnly
-                  value={imageName}
-                  placeholder={t("segmentation.imagePlaceholder")}
-                />
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="icon"
-                  title={t("segmentation.chooseImage")}
-                  onClick={() => void pickImage()}
+              {/* Image source */}
+              <div className="grid gap-1.5">
+                <Label htmlFor="seg-image" className="text-xs">
+                  {t("segmentation.imageLabel")}
+                  <span className="text-destructive"> *</span>
+                </Label>
+                <div className="grid grid-cols-[minmax(0,1fr)_2.25rem] gap-2">
+                  <Input
+                    id="seg-image"
+                    readOnly
+                    value={imageName}
+                    placeholder={t("segmentation.imagePlaceholder")}
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    title={t("segmentation.chooseImage")}
+                    onClick={() => void pickImage()}
+                  >
+                    <FolderOpen className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+
+              {/* Mode */}
+              <div className="grid gap-1.5">
+                <Label htmlFor="seg-mode" className="text-xs">
+                  {t("segmentation.modeLabel")}
+                </Label>
+                <Select
+                  id="seg-mode"
+                  value={mode}
+                  onChange={(e) =>
+                    setMode(e.target.value as "text" | "automatic")
+                  }
                 >
-                  <FolderOpen className="h-4 w-4" />
+                  <option value="text">{t("segmentation.modeText")}</option>
+                  <option value="automatic">
+                    {t("segmentation.modeAutomatic")}
+                  </option>
+                </Select>
+              </div>
+
+              {mode === "text" && (
+                <>
+                  <div className="grid gap-1.5">
+                    <Label htmlFor="seg-prompt" className="text-xs">
+                      {t("segmentation.promptLabel")}
+                      <span className="text-destructive"> *</span>
+                    </Label>
+                    <Input
+                      id="seg-prompt"
+                      value={prompt}
+                      placeholder={t("segmentation.promptPlaceholder")}
+                      onChange={(e) => setPrompt(e.target.value)}
+                    />
+                  </div>
+                  <div className="grid gap-1.5">
+                    <Label htmlFor="seg-confidence" className="text-xs">
+                      {t("segmentation.confidenceLabel")}
+                    </Label>
+                    <Input
+                      id="seg-confidence"
+                      type="number"
+                      min={0}
+                      max={1}
+                      step={0.05}
+                      value={String(confidence)}
+                      onChange={(e) => {
+                        if (e.target.value === "") {
+                          setConfidence(0.4);
+                          return;
+                        }
+                        const parsed = Number(e.target.value);
+                        // Ignore non-numeric input and clamp to [0, 1] so a NaN or
+                        // out-of-range confidence is never sent to the backend.
+                        if (!Number.isFinite(parsed)) return;
+                        setConfidence(Math.min(1, Math.max(0, parsed)));
+                      }}
+                    />
+                  </div>
+                </>
+              )}
+
+              <div>
+                <Button
+                  onClick={() => void handleRun()}
+                  disabled={running || !available || !imageBytes}
+                  className="gap-2"
+                >
+                  {running ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Play className="h-4 w-4" />
+                  )}
+                  {t("segmentation.segment")}
                 </Button>
               </div>
-            </div>
-
-            {/* Mode */}
-            <div className="grid gap-1.5">
-              <Label htmlFor="seg-mode" className="text-xs">
-                {t("segmentation.modeLabel")}
-              </Label>
-              <Select
-                id="seg-mode"
-                value={mode}
-                onChange={(e) =>
-                  setMode(e.target.value as "text" | "automatic")
-                }
-              >
-                <option value="text">{t("segmentation.modeText")}</option>
-                <option value="automatic">
-                  {t("segmentation.modeAutomatic")}
-                </option>
-              </Select>
-            </div>
-
-            {mode === "text" && (
-              <>
-                <div className="grid gap-1.5">
-                  <Label htmlFor="seg-prompt" className="text-xs">
-                    {t("segmentation.promptLabel")}
-                    <span className="text-destructive"> *</span>
-                  </Label>
-                  <Input
-                    id="seg-prompt"
-                    value={prompt}
-                    placeholder={t("segmentation.promptPlaceholder")}
-                    onChange={(e) => setPrompt(e.target.value)}
-                  />
-                </div>
-                <div className="grid gap-1.5">
-                  <Label htmlFor="seg-confidence" className="text-xs">
-                    {t("segmentation.confidenceLabel")}
-                  </Label>
-                  <Input
-                    id="seg-confidence"
-                    type="number"
-                    min={0}
-                    max={1}
-                    step={0.05}
-                    value={String(confidence)}
-                    onChange={(e) => {
-                      if (e.target.value === "") {
-                        setConfidence(0.4);
-                        return;
-                      }
-                      const parsed = Number(e.target.value);
-                      // Ignore non-numeric input and clamp to [0, 1] so a NaN or
-                      // out-of-range confidence is never sent to the backend.
-                      if (!Number.isFinite(parsed)) return;
-                      setConfidence(Math.min(1, Math.max(0, parsed)));
-                    }}
-                  />
-                </div>
-              </>
-            )}
-
-            <div>
-              <Button
-                onClick={() => void handleRun()}
-                disabled={running || !available || !imageBytes}
-                className="gap-2"
-              >
-                {running ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <Play className="h-4 w-4" />
-                )}
-                {t("segmentation.segment")}
-              </Button>
-            </div>
             </>
           )}
 

--- a/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
@@ -239,7 +239,13 @@ export function SegmentationDialog({
   // #777), collapse the dialog to just the explanatory banner plus a link to
   // the desktop download. The desktop build keeps the full form even when the
   // server is not running yet, since the user can start it from here.
-  const webUnavailable = !isTauri() && status !== null && !available;
+  //
+  // We treat the form as hidden whenever the browser hasn't *confirmed*
+  // availability (status null mid-probe, or unavailable), so the form never
+  // flashes in on open before the async status probe resolves. On the rare web
+  // deployment where the proxied sidecar is reachable, `available` becomes true
+  // and the full form appears.
+  const webUnavailable = !isTauri() && !available;
 
   return (
     <Dialog
@@ -306,105 +312,105 @@ export function SegmentationDialog({
               the dialog shows just the banner + desktop download link. */}
           {!webUnavailable && (
             <>
-          {/* Image source */}
-          <div className="grid gap-1.5">
-            <Label htmlFor="seg-image" className="text-xs">
-              {t("segmentation.imageLabel")}
-              <span className="text-destructive"> *</span>
-            </Label>
-            <div className="grid grid-cols-[minmax(0,1fr)_2.25rem] gap-2">
-              <Input
-                id="seg-image"
-                readOnly
-                value={imageName}
-                placeholder={t("segmentation.imagePlaceholder")}
-              />
-              <Button
-                type="button"
-                variant="outline"
-                size="icon"
-                title={t("segmentation.chooseImage")}
-                onClick={() => void pickImage()}
+            {/* Image source */}
+            <div className="grid gap-1.5">
+              <Label htmlFor="seg-image" className="text-xs">
+                {t("segmentation.imageLabel")}
+                <span className="text-destructive"> *</span>
+              </Label>
+              <div className="grid grid-cols-[minmax(0,1fr)_2.25rem] gap-2">
+                <Input
+                  id="seg-image"
+                  readOnly
+                  value={imageName}
+                  placeholder={t("segmentation.imagePlaceholder")}
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  title={t("segmentation.chooseImage")}
+                  onClick={() => void pickImage()}
+                >
+                  <FolderOpen className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+
+            {/* Mode */}
+            <div className="grid gap-1.5">
+              <Label htmlFor="seg-mode" className="text-xs">
+                {t("segmentation.modeLabel")}
+              </Label>
+              <Select
+                id="seg-mode"
+                value={mode}
+                onChange={(e) =>
+                  setMode(e.target.value as "text" | "automatic")
+                }
               >
-                <FolderOpen className="h-4 w-4" />
+                <option value="text">{t("segmentation.modeText")}</option>
+                <option value="automatic">
+                  {t("segmentation.modeAutomatic")}
+                </option>
+              </Select>
+            </div>
+
+            {mode === "text" && (
+              <>
+                <div className="grid gap-1.5">
+                  <Label htmlFor="seg-prompt" className="text-xs">
+                    {t("segmentation.promptLabel")}
+                    <span className="text-destructive"> *</span>
+                  </Label>
+                  <Input
+                    id="seg-prompt"
+                    value={prompt}
+                    placeholder={t("segmentation.promptPlaceholder")}
+                    onChange={(e) => setPrompt(e.target.value)}
+                  />
+                </div>
+                <div className="grid gap-1.5">
+                  <Label htmlFor="seg-confidence" className="text-xs">
+                    {t("segmentation.confidenceLabel")}
+                  </Label>
+                  <Input
+                    id="seg-confidence"
+                    type="number"
+                    min={0}
+                    max={1}
+                    step={0.05}
+                    value={String(confidence)}
+                    onChange={(e) => {
+                      if (e.target.value === "") {
+                        setConfidence(0.4);
+                        return;
+                      }
+                      const parsed = Number(e.target.value);
+                      // Ignore non-numeric input and clamp to [0, 1] so a NaN or
+                      // out-of-range confidence is never sent to the backend.
+                      if (!Number.isFinite(parsed)) return;
+                      setConfidence(Math.min(1, Math.max(0, parsed)));
+                    }}
+                  />
+                </div>
+              </>
+            )}
+
+            <div>
+              <Button
+                onClick={() => void handleRun()}
+                disabled={running || !available || !imageBytes}
+                className="gap-2"
+              >
+                {running ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Play className="h-4 w-4" />
+                )}
+                {t("segmentation.segment")}
               </Button>
             </div>
-          </div>
-
-          {/* Mode */}
-          <div className="grid gap-1.5">
-            <Label htmlFor="seg-mode" className="text-xs">
-              {t("segmentation.modeLabel")}
-            </Label>
-            <Select
-              id="seg-mode"
-              value={mode}
-              onChange={(e) =>
-                setMode(e.target.value as "text" | "automatic")
-              }
-            >
-              <option value="text">{t("segmentation.modeText")}</option>
-              <option value="automatic">
-                {t("segmentation.modeAutomatic")}
-              </option>
-            </Select>
-          </div>
-
-          {mode === "text" && (
-            <>
-              <div className="grid gap-1.5">
-                <Label htmlFor="seg-prompt" className="text-xs">
-                  {t("segmentation.promptLabel")}
-                  <span className="text-destructive"> *</span>
-                </Label>
-                <Input
-                  id="seg-prompt"
-                  value={prompt}
-                  placeholder={t("segmentation.promptPlaceholder")}
-                  onChange={(e) => setPrompt(e.target.value)}
-                />
-              </div>
-              <div className="grid gap-1.5">
-                <Label htmlFor="seg-confidence" className="text-xs">
-                  {t("segmentation.confidenceLabel")}
-                </Label>
-                <Input
-                  id="seg-confidence"
-                  type="number"
-                  min={0}
-                  max={1}
-                  step={0.05}
-                  value={String(confidence)}
-                  onChange={(e) => {
-                    if (e.target.value === "") {
-                      setConfidence(0.4);
-                      return;
-                    }
-                    const parsed = Number(e.target.value);
-                    // Ignore non-numeric input and clamp to [0, 1] so a NaN or
-                    // out-of-range confidence is never sent to the backend.
-                    if (!Number.isFinite(parsed)) return;
-                    setConfidence(Math.min(1, Math.max(0, parsed)));
-                  }}
-                />
-              </div>
-            </>
-          )}
-
-          <div>
-            <Button
-              onClick={() => void handleRun()}
-              disabled={running || !available || !imageBytes}
-              className="gap-2"
-            >
-              {running ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <Play className="h-4 w-4" />
-              )}
-              {t("segmentation.segment")}
-            </Button>
-          </div>
             </>
           )}
 

--- a/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/SegmentationDialog.tsx
@@ -271,7 +271,10 @@ export function SegmentationDialog({
 
         <div className="flex flex-col gap-3">
           {checking && (
-            <div className="grid gap-2">
+            // Same panel framing as the resolved-unavailable banner below, so
+            // the download CTA keeps its frame instead of jumping when the
+            // probe settles.
+            <div className="grid gap-2 rounded-md border border-border bg-muted/40 p-3">
               <p className="flex items-center gap-2 text-sm text-muted-foreground">
                 <Loader2 className="h-4 w-4 animate-spin" />
                 {t("segmentation.status.checking")}

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1724,6 +1724,7 @@
     "title": "AI Segmentation",
     "description": "Turn imagery into vector features with SAM3 (segment-geospatial). Choose a GeoTIFF, describe what to segment, and get polygons back as a new layer.",
     "startServer": "Start server",
+    "downloadDesktop": "Download desktop app",
     "imageLabel": "Image (GeoTIFF)",
     "imagePlaceholder": "Choose a GeoTIFF…",
     "chooseImage": "Choose image",


### PR DESCRIPTION
## Summary

In the web version, the **AI Segmentation** dialog rendered the full desktop configuration form (Image, Mode, Prompt, Confidence threshold) as fully interactive even though segmentation cannot run in the browser, with only the Segment button disabled. The interactive-but-useless inputs implied the tool might accept setup parameters (issue #777).

This keeps the feature **discoverable** (the menu item, the dialog, the SAM3 description, and a clear path to desktop) while making it obvious the inputs are not usable in the browser:

- Show a **'not available in the browser'** banner with a **Download desktop app** button.
- Render the full form (Image, Mode, Prompt, Confidence, Segment) **disabled** in the browser, so web users see the full capability they're missing and are motivated to use the desktop app, without being able to interact with inputs that do nothing.

The desktop build is unchanged: the form is fully interactive, and a not-running local server still offers **Start server**.

## Changes
- `SegmentationDialog.tsx`: add `webUnavailable = !isTauri() && !available`; in the browser, render the form inputs and Choose-image button with `disabled={webUnavailable}` (the Segment button was already gated on `!available`). Add a **Download desktop app** link (to `UPDATE_URL`) in the banner, shown both in the resolved-unavailable banner and beside the in-flight 'Checking…' spinner so browser users always have an action.
- `en.json`: add `segmentation.downloadDesktop` string.

## Verification
Driven in a real browser with Playwright in both light and dark themes: the dialog shows the banner + download button on top, then the full form rendered disabled/greyed out. Production build and pre-commit pass.

Fixes #777