### PR TITLE
feat(controls): persistent mode banner for Directions and Reverse Geocode (#784)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -76,6 +76,7 @@ import {
 } from "../../hooks/useRightPanels";
 import { BoundsRestrictionIndicator } from "./BoundsRestrictionIndicator";
 import { CollaborationStatusBadge } from "./CollaborationStatusBadge";
+import { MapModeBanner } from "./MapModeBanner";
 import { MapGrid } from "./MapGrid";
 import { RemoteCursorsOverlay } from "./RemoteCursorsOverlay";
 import { useCommandBridge } from "../../hooks/useCommandBridge";
@@ -1530,6 +1531,7 @@ export function DesktopShell({
               <RemoteCursorsOverlay mapControllerRef={mapControllerRef} />
               <BoundsRestrictionIndicator />
               <CollaborationStatusBadge />
+              <MapModeBanner mapControllerRef={mapControllerRef} />
             </MapGrid>
           </SectionErrorBoundary>
           <SectionErrorBoundary label="Plugin floating panels">

--- a/apps/geolibre-desktop/src/components/layout/MapModeBanner.tsx
+++ b/apps/geolibre-desktop/src/components/layout/MapModeBanner.tsx
@@ -7,7 +7,7 @@ import {
   subscribeDirectionsState,
 } from "@geolibre/plugins";
 import type { MapController } from "@geolibre/map";
-import { MapPin, Navigation, Undo2, X } from "lucide-react";
+import { MapPin, Navigation, Trash2, Undo2, X } from "lucide-react";
 import { type RefObject, useSyncExternalStore } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@geolibre/ui";
@@ -95,6 +95,7 @@ export function MapModeBanner({ mapControllerRef }: MapModeBannerProps) {
               disabled={waypointCount === 0}
               onClick={clearDirectionsWaypoints}
             >
+              <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
               {t("map.directionsMode.clear")}
             </Button>
             <Button

--- a/apps/geolibre-desktop/src/components/layout/MapModeBanner.tsx
+++ b/apps/geolibre-desktop/src/components/layout/MapModeBanner.tsx
@@ -82,6 +82,9 @@ export function MapModeBanner({ mapControllerRef }: MapModeBannerProps) {
           {/* Visually-hidden live region so screen readers are told when the
               waypoint controls become available (0 → 1) or empty again, since
               the only visual cue is the buttons' disabled state. */}
+          {/* count: 0 resolves to the waypointCount_zero catalog key ("No
+              waypoints placed yet"); i18next honours _zero for count === 0
+              before falling through to _other, so that key is intentional. */}
           <span className="sr-only" aria-live="polite">
             {t("map.directionsMode.waypointCount", { count: waypointCount })}
           </span>

--- a/apps/geolibre-desktop/src/components/layout/MapModeBanner.tsx
+++ b/apps/geolibre-desktop/src/components/layout/MapModeBanner.tsx
@@ -71,6 +71,12 @@ export function MapModeBanner({ mapControllerRef }: MapModeBannerProps) {
               </p>
             </div>
           </div>
+          {/* Visually-hidden live region so screen readers are told when the
+              waypoint controls become available (0 → 1) or empty again, since
+              the only visual cue is the buttons' disabled state. */}
+          <span className="sr-only" aria-live="polite">
+            {t("map.directionsMode.waypointCount", { count: waypointCount })}
+          </span>
           <div className="flex flex-wrap items-center justify-end gap-2">
             <Button
               type="button"

--- a/apps/geolibre-desktop/src/components/layout/MapModeBanner.tsx
+++ b/apps/geolibre-desktop/src/components/layout/MapModeBanner.tsx
@@ -1,0 +1,135 @@
+import {
+  clearDirectionsWaypoints,
+  DIRECTIONS_PLUGIN_ID,
+  getDirectionsWaypointCount,
+  removeLastDirectionsWaypoint,
+  REVERSE_GEOCODE_PLUGIN_ID,
+  subscribeDirectionsState,
+} from "@geolibre/plugins";
+import type { MapController } from "@geolibre/map";
+import { MapPin, Navigation, Undo2, X } from "lucide-react";
+import { type RefObject, useSyncExternalStore } from "react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@geolibre/ui";
+import { createAppAPI, usePluginRegistry } from "../../hooks/usePlugins";
+
+interface MapModeBannerProps {
+  mapControllerRef: RefObject<MapController | null>;
+}
+
+/**
+ * Persistent banner shown over the map while a click-to-interact tool
+ * (Directions or Reverse Geocode) is active. These tools have no layer or
+ * panel of their own, so without a banner the map looks identical to the
+ * normal view and users have no cue that clicks now place waypoints or run a
+ * lookup, nor an obvious way to undo a misclick or leave the mode (issue #784).
+ *
+ * The banner explains the active mode and offers inline controls: for
+ * Directions, remove the last waypoint or clear them all; for either mode, an
+ * Exit button that toggles the plugin off. Routes are recalculated
+ * automatically as waypoints change, so no manual "calculate" action is needed.
+ */
+export function MapModeBanner({ mapControllerRef }: MapModeBannerProps) {
+  const { t } = useTranslation();
+  const { isActive, toggle } = usePluginRegistry();
+
+  // Live waypoint count, so the remove/clear actions can disable themselves
+  // when there is nothing to act on.
+  const waypointCount = useSyncExternalStore(
+    subscribeDirectionsState,
+    getDirectionsWaypointCount,
+    getDirectionsWaypointCount,
+  );
+
+  const directionsActive = isActive(DIRECTIONS_PLUGIN_ID);
+  const reverseGeocodeActive = isActive(REVERSE_GEOCODE_PLUGIN_ID);
+
+  if (!directionsActive && !reverseGeocodeActive) {
+    return null;
+  }
+
+  const exit = (id: string) => toggle(id, createAppAPI(mapControllerRef));
+
+  return (
+    <div className="pointer-events-none absolute left-1/2 top-3 z-20 flex w-[min(92vw,30rem)] -translate-x-1/2 flex-col gap-2">
+      {directionsActive ? (
+        <div
+          className="pointer-events-auto flex flex-col gap-2 rounded-md border bg-background/95 px-3 py-2 text-sm shadow-lg backdrop-blur-sm"
+          role="status"
+          data-testid="directions-mode-banner"
+        >
+          <div className="flex items-start gap-2">
+            <Navigation
+              className="mt-0.5 h-4 w-4 shrink-0 text-primary"
+              aria-hidden="true"
+            />
+            <div className="min-w-0">
+              <p className="font-medium">{t("map.directionsMode.title")}</p>
+              <p className="text-xs text-muted-foreground">
+                {t("map.directionsMode.hint")}
+              </p>
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center justify-end gap-2">
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              disabled={waypointCount === 0}
+              onClick={removeLastDirectionsWaypoint}
+            >
+              <Undo2 className="h-3.5 w-3.5" aria-hidden="true" />
+              {t("map.directionsMode.removeLast")}
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              disabled={waypointCount === 0}
+              onClick={clearDirectionsWaypoints}
+            >
+              {t("map.directionsMode.clear")}
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="secondary"
+              onClick={() => exit(DIRECTIONS_PLUGIN_ID)}
+            >
+              <X className="h-3.5 w-3.5" aria-hidden="true" />
+              {t("map.directionsMode.exit")}
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      {reverseGeocodeActive ? (
+        <div
+          className="pointer-events-auto flex items-center gap-2 rounded-md border bg-background/95 px-3 py-2 text-sm shadow-lg backdrop-blur-sm"
+          role="status"
+          data-testid="reverse-geocode-mode-banner"
+        >
+          <MapPin
+            className="h-4 w-4 shrink-0 text-primary"
+            aria-hidden="true"
+          />
+          <div className="min-w-0 flex-1">
+            <p className="font-medium">{t("map.reverseGeocodeMode.title")}</p>
+            <p className="text-xs text-muted-foreground">
+              {t("map.reverseGeocodeMode.hint")}
+            </p>
+          </div>
+          <Button
+            type="button"
+            size="sm"
+            variant="secondary"
+            onClick={() => exit(REVERSE_GEOCODE_PLUGIN_ID)}
+          >
+            <X className="h-3.5 w-3.5" aria-hidden="true" />
+            {t("map.reverseGeocodeMode.exit")}
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/MapModeBanner.tsx
+++ b/apps/geolibre-desktop/src/components/layout/MapModeBanner.tsx
@@ -100,7 +100,7 @@ export function MapModeBanner({ mapControllerRef }: MapModeBannerProps) {
               type="button"
               size="sm"
               variant="ghost"
-              disabled={waypointCount === 0}
+              disabled={waypointCount === 0 || removalInFlight}
               onClick={clearDirectionsWaypoints}
             >
               <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />

--- a/apps/geolibre-desktop/src/components/layout/MapModeBanner.tsx
+++ b/apps/geolibre-desktop/src/components/layout/MapModeBanner.tsx
@@ -2,6 +2,7 @@ import {
   clearDirectionsWaypoints,
   DIRECTIONS_PLUGIN_ID,
   getDirectionsWaypointCount,
+  isDirectionsRemovalInFlight,
   removeLastDirectionsWaypoint,
   REVERSE_GEOCODE_PLUGIN_ID,
   subscribeDirectionsState,
@@ -39,6 +40,13 @@ export function MapModeBanner({ mapControllerRef }: MapModeBannerProps) {
     subscribeDirectionsState,
     getDirectionsWaypointCount,
     getDirectionsWaypointCount,
+  );
+  // Disable "Remove last" while a removal awaits its route refetch, so rapid
+  // clicks can't queue concurrent calls against a stale waypoint count.
+  const removalInFlight = useSyncExternalStore(
+    subscribeDirectionsState,
+    isDirectionsRemovalInFlight,
+    isDirectionsRemovalInFlight,
   );
 
   const directionsActive = isActive(DIRECTIONS_PLUGIN_ID);
@@ -82,7 +90,7 @@ export function MapModeBanner({ mapControllerRef }: MapModeBannerProps) {
               type="button"
               size="sm"
               variant="ghost"
-              disabled={waypointCount === 0}
+              disabled={waypointCount === 0 || removalInFlight}
               onClick={removeLastDirectionsWaypoint}
             >
               <Undo2 className="h-3.5 w-3.5" aria-hidden="true" />

--- a/apps/geolibre-desktop/src/components/layout/MapModeBanner.tsx
+++ b/apps/geolibre-desktop/src/components/layout/MapModeBanner.tsx
@@ -100,7 +100,11 @@ export function MapModeBanner({ mapControllerRef }: MapModeBannerProps) {
               type="button"
               size="sm"
               variant="ghost"
-              disabled={waypointCount === 0 || removalInFlight}
+              // Unlike Remove last, Clear stays enabled during an in-flight
+              // removal: clearDirectionsWaypoints() aborts the pending refetch
+              // before clearing, so it is safe and lets the user dump waypoints
+              // immediately rather than waiting for a route load to finish.
+              disabled={waypointCount === 0}
               onClick={clearDirectionsWaypoints}
             >
               <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />

--- a/apps/geolibre-desktop/src/components/layout/MapModeBanner.tsx
+++ b/apps/geolibre-desktop/src/components/layout/MapModeBanner.tsx
@@ -55,7 +55,8 @@ export function MapModeBanner({ mapControllerRef }: MapModeBannerProps) {
       {directionsActive ? (
         <div
           className="pointer-events-auto flex flex-col gap-2 rounded-md border bg-background/95 px-3 py-2 text-sm shadow-lg backdrop-blur-sm"
-          role="status"
+          role="region"
+          aria-label={t("map.directionsMode.title")}
           data-testid="directions-mode-banner"
         >
           <div className="flex items-start gap-2">
@@ -106,7 +107,8 @@ export function MapModeBanner({ mapControllerRef }: MapModeBannerProps) {
       {reverseGeocodeActive ? (
         <div
           className="pointer-events-auto flex items-center gap-2 rounded-md border bg-background/95 px-3 py-2 text-sm shadow-lg backdrop-blur-sm"
-          role="status"
+          role="region"
+          aria-label={t("map.reverseGeocodeMode.title")}
           data-testid="reverse-geocode-mode-banner"
         >
           <MapPin

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -777,7 +777,19 @@
   },
   "map": {
     "boundsRestricted": "Bounds locked",
-    "boundsRestrictedTooltip": "Map bounds are restricted. You can change this in Settings."
+    "boundsRestrictedTooltip": "Map bounds are restricted. You can change this in Settings.",
+    "directionsMode": {
+      "title": "Directions mode active",
+      "hint": "Click the map to add waypoints. Drag a waypoint to move it, or click it to remove it. Routes update automatically.",
+      "removeLast": "Remove last",
+      "clear": "Clear",
+      "exit": "Exit"
+    },
+    "reverseGeocodeMode": {
+      "title": "Reverse Geocode mode active",
+      "hint": "Click anywhere on the map to look up the address at that point.",
+      "exit": "Exit"
+    }
   },
   "mapGrid": {
     "layers": "Layers",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -784,6 +784,7 @@
       "removeLast": "Remove last",
       "clear": "Clear",
       "exit": "Exit",
+      "waypointCount_zero": "No waypoints placed yet",
       "waypointCount_one": "{{count}} waypoint placed",
       "waypointCount_other": "{{count}} waypoints placed"
     },

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -783,7 +783,9 @@
       "hint": "Click the map to add waypoints. Drag a waypoint to move it, or click it to remove it. Routes update automatically.",
       "removeLast": "Remove last",
       "clear": "Clear",
-      "exit": "Exit"
+      "exit": "Exit",
+      "waypointCount_one": "{{count}} waypoint placed",
+      "waypointCount_other": "{{count}} waypoints placed"
     },
     "reverseGeocodeMode": {
       "title": "Reverse Geocode mode active",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -184,9 +184,13 @@ export {
 // re-exported: the app drives the panels through the functions above, and
 // the tests import the sync helpers from the module paths directly.
 export {
+  clearDirectionsWaypoints,
   DIRECTIONS_PLUGIN_ID,
+  getDirectionsWaypointCount,
   maplibreDirectionsPlugin,
+  removeLastDirectionsWaypoint,
   restoreDirections,
+  subscribeDirectionsState,
 } from "./plugins/maplibre-directions";
 export {
   REVERSE_GEOCODE_PLUGIN_ID,

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -187,6 +187,7 @@ export {
   clearDirectionsWaypoints,
   DIRECTIONS_PLUGIN_ID,
   getDirectionsWaypointCount,
+  isDirectionsRemovalInFlight,
   maplibreDirectionsPlugin,
   removeLastDirectionsWaypoint,
   restoreDirections,

--- a/packages/plugins/src/plugins/maplibre-directions.ts
+++ b/packages/plugins/src/plugins/maplibre-directions.ts
@@ -123,6 +123,9 @@ export function clearDirectionsWaypoints(): void {
   if (!directions) return;
   // clear() does not emit a waypoint event, so notify listeners directly.
   directions.clear();
+  // Clearing supersedes any in-flight removal: drop the flag so the post-clear
+  // state is consistent (the pending promise's .finally re-runs this harmlessly).
+  removalInFlight = false;
   notifyDirectionsState();
 }
 

--- a/packages/plugins/src/plugins/maplibre-directions.ts
+++ b/packages/plugins/src/plugins/maplibre-directions.ts
@@ -113,8 +113,16 @@ export function removeLastDirectionsWaypoint(): void {
     .removeWaypoint(count - 1)
     .catch((error: unknown) => {
       // An AbortError means clearDirectionsWaypoints() intentionally cancelled
-      // this refetch; that is expected, not a failure, so don't log it.
-      if (error instanceof DOMException && error.name === "AbortError") return;
+      // this refetch; that is expected, not a failure, so don't log it. Match on
+      // the name rather than the DOMException type so a library that re-wraps the
+      // native abort in a plain Error is still recognized.
+      if (
+        error != null &&
+        typeof error === "object" &&
+        (error as { name?: unknown }).name === "AbortError"
+      ) {
+        return;
+      }
       console.error("Directions: removeWaypoint failed", error);
     })
     .finally(() => {

--- a/packages/plugins/src/plugins/maplibre-directions.ts
+++ b/packages/plugins/src/plugins/maplibre-directions.ts
@@ -38,6 +38,12 @@ let loadToken = 0;
 type DirectionsStateListener = () => void;
 const directionsStateListeners = new Set<DirectionsStateListener>();
 
+// True while a removeLastDirectionsWaypoint() call is mid route-refetch. Exposed
+// so the banner can disable its "remove last" button until the async call
+// settles, which closes the rapid-click window where two clicks would both read
+// the same pre-removal count and target an index the first call already removed.
+let removalInFlight = false;
+
 function notifyDirectionsState(): void {
   // Isolate subscriber failures so one throwing listener does not block the
   // rest from receiving the update.
@@ -76,19 +82,37 @@ export function getDirectionsWaypointCount(): number {
 }
 
 /**
+ * Whether a waypoint removal is currently awaiting its route refetch.
+ *
+ * @returns True between the removeWaypoint call and its settlement.
+ */
+export function isDirectionsRemovalInFlight(): boolean {
+  return removalInFlight;
+}
+
+/**
  * Remove the most recently placed waypoint and re-fetch the route. No-op when
- * the tool is inactive or no waypoints have been placed.
+ * the tool is inactive, no waypoints have been placed, or a removal is already
+ * in flight (so rapid clicks cannot queue concurrent calls on a stale count).
  */
 export function removeLastDirectionsWaypoint(): void {
-  if (!directions) return;
+  if (!directions || removalInFlight) return;
   const count = directions.waypoints.length;
   if (count === 0) return;
+  removalInFlight = true;
+  notifyDirectionsState();
   // removeWaypoint re-fetches the route, which can reject (network/OSRM error).
   // Log rather than let it surface as an unhandled rejection, mirroring how
-  // attach() handles its load failure.
-  void directions.removeWaypoint(count - 1).catch((error: unknown) => {
-    console.error("Directions: removeWaypoint failed", error);
-  });
+  // attach() handles its load failure; clear the in-flight flag either way.
+  void directions
+    .removeWaypoint(count - 1)
+    .catch((error: unknown) => {
+      console.error("Directions: removeWaypoint failed", error);
+    })
+    .finally(() => {
+      removalInFlight = false;
+      notifyDirectionsState();
+    });
 }
 
 /**
@@ -150,6 +174,9 @@ function teardown(app: GeoLibreAppAPI): void {
   directions?.destroy();
   directions = null;
   directionsMap = null;
+  // A removal can't be pending once the instance is gone; clear the flag so a
+  // teardown mid-refetch doesn't leave the next session's button disabled.
+  removalInFlight = false;
   // Reset the count subscribers see to 0 now the session is gone.
   notifyDirectionsState();
 }

--- a/packages/plugins/src/plugins/maplibre-directions.ts
+++ b/packages/plugins/src/plugins/maplibre-directions.ts
@@ -121,10 +121,16 @@ export function removeLastDirectionsWaypoint(): void {
  */
 export function clearDirectionsWaypoints(): void {
   if (!directions) return;
+  // Abort any in-flight route refetch (e.g. from a pending removal) so its
+  // response can't redraw a route onto the map after we clear; clear() alone
+  // does not cancel the request. abortController only exists while a request is
+  // ongoing. This keeps clear() honoring its contract (always clears) rather
+  // than bailing out and silently no-op'ing when a removal is in flight.
+  directions.abortController?.abort();
   // clear() does not emit a waypoint event, so notify listeners directly.
   directions.clear();
   // Clearing supersedes any in-flight removal: drop the flag so the post-clear
-  // state is consistent (the pending promise's .finally re-runs this harmlessly).
+  // state is consistent (the aborted removal's .finally re-runs this harmlessly).
   removalInFlight = false;
   notifyDirectionsState();
 }

--- a/packages/plugins/src/plugins/maplibre-directions.ts
+++ b/packages/plugins/src/plugins/maplibre-directions.ts
@@ -171,6 +171,11 @@ function teardown(app: GeoLibreAppAPI): void {
     app.removeMapControl(loadingControl);
     loadingControl = null;
   }
+  // Detach our listeners before destroy() so teardown is self-contained and
+  // does not rely on the library's destroy() also tearing down its emitter.
+  directions?.off("addwaypoint", notifyDirectionsState);
+  directions?.off("removewaypoint", notifyDirectionsState);
+  directions?.off("setwaypoints", notifyDirectionsState);
   directions?.destroy();
   directions = null;
   directionsMap = null;

--- a/packages/plugins/src/plugins/maplibre-directions.ts
+++ b/packages/plugins/src/plugins/maplibre-directions.ts
@@ -112,6 +112,9 @@ export function removeLastDirectionsWaypoint(): void {
   void directions
     .removeWaypoint(count - 1)
     .catch((error: unknown) => {
+      // An AbortError means clearDirectionsWaypoints() intentionally cancelled
+      // this refetch; that is expected, not a failure, so don't log it.
+      if (error instanceof DOMException && error.name === "AbortError") return;
       console.error("Directions: removeWaypoint failed", error);
     })
     .finally(() => {

--- a/packages/plugins/src/plugins/maplibre-directions.ts
+++ b/packages/plugins/src/plugins/maplibre-directions.ts
@@ -30,6 +30,65 @@ let loadingControl: IControl | null = null;
 // it doesn't attach a directions instance to a tool that is no longer active.
 let loadToken = 0;
 
+// Listeners notified whenever the waypoint set changes (add/remove/clear) or the
+// instance is attached/torn down. The desktop shell's mode banner subscribes via
+// useSyncExternalStore so it can mirror the live waypoint count and enable or
+// disable its "remove last"/"clear" actions. Kept here (not in the app) so the
+// plugin stays the single owner of the directions instance.
+type DirectionsStateListener = () => void;
+const directionsStateListeners = new Set<DirectionsStateListener>();
+
+function notifyDirectionsState(): void {
+  for (const listener of directionsStateListeners) listener();
+}
+
+/**
+ * Subscribe to directions waypoint-set changes. The listener fires after every
+ * add, remove, clear, and on attach/teardown.
+ *
+ * @param listener Callback invoked on each change.
+ * @returns An unsubscribe function.
+ */
+export function subscribeDirectionsState(
+  listener: DirectionsStateListener,
+): () => void {
+  directionsStateListeners.add(listener);
+  return () => {
+    directionsStateListeners.delete(listener);
+  };
+}
+
+/**
+ * The number of waypoints currently placed in the active directions session.
+ *
+ * @returns The waypoint count, or 0 when the tool is inactive or still loading.
+ */
+export function getDirectionsWaypointCount(): number {
+  return directions ? directions.waypoints.length : 0;
+}
+
+/**
+ * Remove the most recently placed waypoint and re-fetch the route. No-op when
+ * the tool is inactive or no waypoints have been placed.
+ */
+export function removeLastDirectionsWaypoint(): void {
+  if (!directions) return;
+  const count = directions.waypoints.length;
+  if (count === 0) return;
+  void directions.removeWaypoint(count - 1);
+}
+
+/**
+ * Clear all waypoints and the rendered route from the active directions
+ * session. No-op when the tool is inactive.
+ */
+export function clearDirectionsWaypoints(): void {
+  if (!directions) return;
+  // clear() does not emit a waypoint event, so notify listeners directly.
+  directions.clear();
+  notifyDirectionsState();
+}
+
 function attach(app: GeoLibreAppAPI): void {
   const map = app.getMap?.();
   if (!map) return;
@@ -48,8 +107,17 @@ function attach(app: GeoLibreAppAPI): void {
       // this library version (it's absent from MapLibreGlDirectionsConfiguration).
       directions.interactive = true;
       directionsMap = currentMap;
+      // Mirror the live waypoint count to any subscribed UI (the mode banner).
+      // These events fire after the change is drawn, so the waypoints getter
+      // already reflects the new state when notifyDirectionsState reads it.
+      directions.on("addwaypoint", notifyDirectionsState);
+      directions.on("removewaypoint", notifyDirectionsState);
+      directions.on("setwaypoints", notifyDirectionsState);
       loadingControl = new LoadingIndicatorControl(directions);
       app.addMapControl(loadingControl, "top-right");
+      // The instance now exists; nudge subscribers so a banner that mounted
+      // before the lazy import resolved reads the (zeroed) count.
+      notifyDirectionsState();
     })
     .catch((error) => {
       console.error(
@@ -69,6 +137,8 @@ function teardown(app: GeoLibreAppAPI): void {
   directions?.destroy();
   directions = null;
   directionsMap = null;
+  // Reset the count subscribers see to 0 now the session is gone.
+  notifyDirectionsState();
 }
 
 /**

--- a/packages/plugins/src/plugins/maplibre-directions.ts
+++ b/packages/plugins/src/plugins/maplibre-directions.ts
@@ -101,6 +101,11 @@ export function removeLastDirectionsWaypoint(): void {
   if (count === 0) return;
   removalInFlight = true;
   notifyDirectionsState();
+  // Snapshot the session token: teardown()/attach() bump loadToken, so if the
+  // user exits (or exits and re-enters) before this settles, a stale token means
+  // we must not touch the now-current session's in-flight state or notify its
+  // subscribers (teardown already reset the flag for the session we belonged to).
+  const callToken = loadToken;
   // removeWaypoint re-fetches the route, which can reject (network/OSRM error).
   // Log rather than let it surface as an unhandled rejection, mirroring how
   // attach() handles its load failure; clear the in-flight flag either way.
@@ -110,6 +115,7 @@ export function removeLastDirectionsWaypoint(): void {
       console.error("Directions: removeWaypoint failed", error);
     })
     .finally(() => {
+      if (callToken !== loadToken) return;
       removalInFlight = false;
       notifyDirectionsState();
     });

--- a/packages/plugins/src/plugins/maplibre-directions.ts
+++ b/packages/plugins/src/plugins/maplibre-directions.ts
@@ -75,7 +75,12 @@ export function removeLastDirectionsWaypoint(): void {
   if (!directions) return;
   const count = directions.waypoints.length;
   if (count === 0) return;
-  void directions.removeWaypoint(count - 1);
+  // removeWaypoint re-fetches the route, which can reject (network/OSRM error).
+  // Log rather than let it surface as an unhandled rejection, mirroring how
+  // attach() handles its load failure.
+  void directions.removeWaypoint(count - 1).catch((error: unknown) => {
+    console.error("Directions: removeWaypoint failed", error);
+  });
 }
 
 /**

--- a/packages/plugins/src/plugins/maplibre-directions.ts
+++ b/packages/plugins/src/plugins/maplibre-directions.ts
@@ -39,7 +39,15 @@ type DirectionsStateListener = () => void;
 const directionsStateListeners = new Set<DirectionsStateListener>();
 
 function notifyDirectionsState(): void {
-  for (const listener of directionsStateListeners) listener();
+  // Isolate subscriber failures so one throwing listener does not block the
+  // rest from receiving the update.
+  for (const listener of directionsStateListeners) {
+    try {
+      listener();
+    } catch (error) {
+      console.error("Directions: state listener threw.", error);
+    }
+  }
 }
 
 /**

--- a/packages/plugins/src/plugins/maplibre-directions.ts
+++ b/packages/plugins/src/plugins/maplibre-directions.ts
@@ -43,6 +43,10 @@ const directionsStateListeners = new Set<DirectionsStateListener>();
 // settles, which closes the rapid-click window where two clicks would both read
 // the same pre-removal count and target an index the first call already removed.
 let removalInFlight = false;
+// Bumped on every removal start and on clear. A removal's finalizer compares its
+// captured value against this so a superseded removal (aborted by clear, then
+// replaced by a new removal) can't flip the flag back for the newer request.
+let removalToken = 0;
 
 function notifyDirectionsState(): void {
   // Isolate subscriber failures so one throwing listener does not block the
@@ -100,12 +104,15 @@ export function removeLastDirectionsWaypoint(): void {
   const count = directions.waypoints.length;
   if (count === 0) return;
   removalInFlight = true;
-  notifyDirectionsState();
   // Snapshot the session token: teardown()/attach() bump loadToken, so if the
   // user exits (or exits and re-enters) before this settles, a stale token means
   // we must not touch the now-current session's in-flight state or notify its
   // subscribers (teardown already reset the flag for the session we belonged to).
   const callToken = loadToken;
+  // Snapshot the removal token too: a clear (or a newer removal) bumps it, so a
+  // superseded finalizer can't reset removalInFlight for a later in-flight call.
+  const callRemovalToken = ++removalToken;
+  notifyDirectionsState();
   // removeWaypoint re-fetches the route, which can reject (network/OSRM error).
   // Log rather than let it surface as an unhandled rejection, mirroring how
   // attach() handles its load failure; clear the in-flight flag either way.
@@ -126,7 +133,9 @@ export function removeLastDirectionsWaypoint(): void {
       console.error("Directions: removeWaypoint failed", error);
     })
     .finally(() => {
-      if (callToken !== loadToken) return;
+      // Skip if the session changed or this removal was superseded (e.g. by a
+      // clear or a newer removal); that newer owner manages the flag itself.
+      if (callToken !== loadToken || callRemovalToken !== removalToken) return;
       removalInFlight = false;
       notifyDirectionsState();
     });
@@ -138,6 +147,8 @@ export function removeLastDirectionsWaypoint(): void {
  */
 export function clearDirectionsWaypoints(): void {
   if (!directions) return;
+  // Supersede any in-flight removal's finalizer so it can't later reset the flag.
+  ++removalToken;
   // Abort any in-flight route refetch (e.g. from a pending removal) so its
   // response can't redraw a route onto the map after we clear; clear() alone
   // does not cancel the request. abortController only exists while a request is

--- a/tests/directions.test.ts
+++ b/tests/directions.test.ts
@@ -32,17 +32,17 @@ describe("directions control surface (inactive)", () => {
     assert.equal(getDirectionsWaypointCount(), 0);
   });
 
-  it("returns a working unsubscribe from subscribeDirectionsState", () => {
-    let calls = 0;
-    const unsubscribe = subscribeDirectionsState(() => {
-      calls += 1;
-    });
+  it("returns an idempotent unsubscribe from subscribeDirectionsState", () => {
+    // The notify path needs a live routing instance (created by the lazy
+    // import on activate), which the Playwright verification exercises end to
+    // end. Here we only assert the subscribe contract that is reachable without
+    // one: unsubscribe is a function and can be called repeatedly without
+    // throwing, so a teardown that double-unsubscribes is safe.
+    const unsubscribe = subscribeDirectionsState(() => {});
     assert.equal(typeof unsubscribe, "function");
-    // clear() while inactive does not notify, so the count stays untouched and
-    // the listener is not called; the test asserts unsubscribe is callable and
-    // leaves no dangling subscription behind.
-    clearDirectionsWaypoints();
-    unsubscribe();
-    assert.equal(calls, 0);
+    assert.doesNotThrow(() => {
+      unsubscribe();
+      unsubscribe();
+    });
   });
 });

--- a/tests/directions.test.ts
+++ b/tests/directions.test.ts
@@ -4,6 +4,7 @@ import {
   clearDirectionsWaypoints,
   DIRECTIONS_PLUGIN_ID,
   getDirectionsWaypointCount,
+  isDirectionsRemovalInFlight,
   maplibreDirectionsPlugin,
   removeLastDirectionsWaypoint,
   subscribeDirectionsState,
@@ -30,6 +31,8 @@ describe("directions control surface (inactive)", () => {
     assert.doesNotThrow(() => removeLastDirectionsWaypoint());
     assert.doesNotThrow(() => clearDirectionsWaypoints());
     assert.equal(getDirectionsWaypointCount(), 0);
+    // A no-op removal must not leave the in-flight flag stuck on.
+    assert.equal(isDirectionsRemovalInFlight(), false);
   });
 
   it("returns an idempotent unsubscribe from subscribeDirectionsState", () => {

--- a/tests/directions.test.ts
+++ b/tests/directions.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  clearDirectionsWaypoints,
+  DIRECTIONS_PLUGIN_ID,
+  getDirectionsWaypointCount,
+  maplibreDirectionsPlugin,
+  removeLastDirectionsWaypoint,
+  subscribeDirectionsState,
+} from "../packages/plugins/src/plugins/maplibre-directions";
+
+describe("maplibreDirectionsPlugin", () => {
+  it("is a Controls toggle that is off by default", () => {
+    assert.equal(maplibreDirectionsPlugin.id, DIRECTIONS_PLUGIN_ID);
+    assert.equal(maplibreDirectionsPlugin.activeByDefault, undefined);
+    assert.equal(typeof maplibreDirectionsPlugin.activate, "function");
+    assert.equal(typeof maplibreDirectionsPlugin.deactivate, "function");
+  });
+});
+
+// The mode banner reads these without knowing whether the lazy-loaded library
+// has attached yet, so the inactive-state contract must be safe: a zero count
+// and no-op mutators that never throw.
+describe("directions control surface (inactive)", () => {
+  it("reports zero waypoints when the tool is inactive", () => {
+    assert.equal(getDirectionsWaypointCount(), 0);
+  });
+
+  it("treats remove-last and clear as no-ops when inactive", () => {
+    assert.doesNotThrow(() => removeLastDirectionsWaypoint());
+    assert.doesNotThrow(() => clearDirectionsWaypoints());
+    assert.equal(getDirectionsWaypointCount(), 0);
+  });
+
+  it("returns a working unsubscribe from subscribeDirectionsState", () => {
+    let calls = 0;
+    const unsubscribe = subscribeDirectionsState(() => {
+      calls += 1;
+    });
+    assert.equal(typeof unsubscribe, "function");
+    // clear() while inactive does not notify, so the count stays untouched and
+    // the listener is not called; the test asserts unsubscribe is callable and
+    // leaves no dangling subscription behind.
+    clearDirectionsWaypoints();
+    unsubscribe();
+    assert.equal(calls, 0);
+  });
+});

--- a/tests/directions.test.ts
+++ b/tests/directions.test.ts
@@ -21,7 +21,9 @@ describe("maplibreDirectionsPlugin", () => {
 
 // The mode banner reads these without knowing whether the lazy-loaded library
 // has attached yet, so the inactive-state contract must be safe: a zero count
-// and no-op mutators that never throw.
+// and no-op mutators that never throw. The active path where removalInFlight is
+// set true and then cleared by the removeWaypoint .finally needs a live routing
+// instance, so it is covered by the Playwright verification rather than here.
 describe("directions control surface (inactive)", () => {
   it("reports zero waypoints when the tool is inactive", () => {
     assert.equal(getDirectionsWaypointCount(), 0);


### PR DESCRIPTION
## Summary

Fixes #784.

The Directions and Reverse Geocode tools (Controls menu) are click-to-interact modes with no layer or panel of their own. Once enabled, the map looked identical to the normal view, so users had no cue that clicks now place waypoints / run a lookup, no way to undo a misclick, and no obvious way to leave the mode.

This adds a persistent banner over the map while either mode is active:

- **Directions:** explains the mode, plus inline controls to **Remove last** waypoint, **Clear** all waypoints, and **Exit** the mode. Routes recalculate automatically as waypoints change, so there is no separate "calculate" action. The Remove last / Clear buttons disable themselves when there are no waypoints.
- **Reverse Geocode:** explains the mode with an **Exit** button.

The banner mirrors the live waypoint count: the directions plugin now exposes a small reactive control surface (`subscribeDirectionsState`, `getDirectionsWaypointCount`, `removeLastDirectionsWaypoint`, `clearDirectionsWaypoints`) so the plugin stays the single owner of the routing instance and the React banner stays a thin consumer.

## Changes

- `packages/plugins/src/plugins/maplibre-directions.ts`: reactive waypoint-state listeners and exported remove-last / clear / count helpers.
- `packages/plugins/src/index.ts`: export the new helpers.
- `apps/geolibre-desktop/src/components/layout/MapModeBanner.tsx`: new banner component.
- `apps/geolibre-desktop/src/components/layout/DesktopShell.tsx`: render the banner over the map.
- `apps/geolibre-desktop/src/i18n/locales/en.json`: banner strings under `map.directionsMode` / `map.reverseGeocodeMode`.
- `tests/directions.test.ts`: cover the inactive-state contract of the new control surface.

## Verification

Verified in the real app (web dev build) in both light and dark themes:

- Enabling Directions shows the banner with disabled Remove last / Clear (no waypoints).
- Clicking the map places waypoints and enables the controls; Remove last and Clear work and re-disable at zero.
- Exit deactivates the plugin and removes the banner.
- Reverse Geocode shows its banner with a working Exit.

Frontend test suite green (1468 passing), `pre-commit run --files` clean including the full npm build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added always-on map overlay banners for **Directions** and **Reverse Geocode** when those modes are active.
  * Directions banner includes a live waypoint count, mode-specific actions (remove last, clear), and an **Exit** button.
  * Actions are automatically disabled/enabled to reflect “removal in flight” and prevent invalid operations.
* **Documentation**
  * Updated English UI strings for the new Directions/Reverse Geocode banner labels and hints.
* **Tests**
  * Added coverage for the directions plugin control surface, including inactive behavior and state subscription behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->