### PR TITLE
fix(measure): smoother measure-tool workflow and neutral guidance styling

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -58,7 +58,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.3",
     "maplibre-gl-basemap-control": "^0.7.0",
-    "maplibre-gl-components": "^0.22.6",
+    "maplibre-gl-components": "^0.22.7",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.3",
         "maplibre-gl-basemap-control": "^0.7.0",
-        "maplibre-gl-components": "^0.22.6",
+        "maplibre-gl-components": "^0.22.7",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -187,9 +187,9 @@
       "license": "MIT"
     },
     "apps/geolibre-desktop/node_modules/maplibre-gl-components": {
-      "version": "0.22.6",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.22.6.tgz",
-      "integrity": "sha512-CjNcDUVwiQnX0F6MkE4Qq/f7ykIzzi9UDkQogHDA03FDWls5/zKWBGdpYn0ATv2oCyctBHL918qAVLR5eLqHmQ==",
+      "version": "0.22.7",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.22.7.tgz",
+      "integrity": "sha512-1ubkGAmqjfonW1ao1Kc5/Mq7gH395Jya17fuIrxZB2+UapIVGLpuOfcSaCHCyJcr27zUzBot0gEEv7LuORBO5g==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",
@@ -24305,7 +24305,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.3",
         "maplibre-gl-basemap-control": "^0.7.0",
-        "maplibre-gl-components": "^0.22.6",
+        "maplibre-gl-components": "^0.22.7",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -24344,9 +24344,9 @@
       }
     },
     "packages/plugins/node_modules/maplibre-gl-components": {
-      "version": "0.22.6",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.22.6.tgz",
-      "integrity": "sha512-CjNcDUVwiQnX0F6MkE4Qq/f7ykIzzi9UDkQogHDA03FDWls5/zKWBGdpYn0ATv2oCyctBHL918qAVLR5eLqHmQ==",
+      "version": "0.22.7",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.22.7.tgz",
+      "integrity": "sha512-1ubkGAmqjfonW1ao1Kc5/Mq7gH395Jya17fuIrxZB2+UapIVGLpuOfcSaCHCyJcr27zUzBot0gEEv7LuORBO5g==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -32,7 +32,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.3",
     "maplibre-gl-basemap-control": "^0.7.0",
-    "maplibre-gl-components": "^0.22.6",
+    "maplibre-gl-components": "^0.22.7",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",


### PR DESCRIPTION
## Summary

Fixes the Measure tool UX issues reported in #771 by consuming the new `maplibre-gl-components@0.22.7` (upstream PR: opengeos/maplibre-gl-components#109, released as v0.22.7). The three reported friction points are addressed:

1. **No mandatory "Start" click.** Selecting **Distance** or **Area** now arms drawing immediately, so clicking the map starts measuring right away. The tool also re-arms after a measurement finishes, so consecutive measurements need no extra click.
2. **Neutral guidance styling.** The helper text no longer uses a warning/amber background (which conventionally signals an alert). It now uses a neutral informational (soft blue) style in both light and dark themes.
3. **Open polyline in distance mode.** Finishing a line with a double-click previously left a duplicated final vertex and a zero-length trailing segment. The duplicate is now dropped, so a distance measurement stays an accurate open polyline.

Additional improvements from the same report: switching between Distance and Area mid-draw preserves the points already placed, and **right-click** now finishes a measurement (familiar from desktop GIS tools like QGIS).

## Changes

- Bump `maplibre-gl-components` `^0.22.6` -> `^0.22.7` in `apps/geolibre-desktop/package.json` and `packages/plugins/package.json`, and update `package-lock.json`.

## Verification

Verified in the real app (web dev build) with Playwright in **both light and dark themes** using the published `0.22.7`:

- Opening Measure puts the panel straight into drawing mode (primary button reads "Finish").
- Helper text background is informational blue (`rgb(239,246,255)` light / `rgba(59,130,246,0.12)` dark), not amber.
- A distance line finished with a double-click renders as an open polyline with two non-zero segments (no zero-length trailing segment).
- Mode toggle to Area mid-tool works; no console errors.

`npm run build` passes; `pre-commit run --files` passes on the changed files.

Fixes #771