### PR TITLE
fix(controls): auto-fit + resizable HTML control panel

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -58,7 +58,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.3",
     "maplibre-gl-basemap-control": "^0.7.0",
-    "maplibre-gl-components": "^0.22.7",
+    "maplibre-gl-components": "^0.22.8",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -58,7 +58,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.3",
     "maplibre-gl-basemap-control": "^0.7.0",
-    "maplibre-gl-components": "^0.22.8",
+    "maplibre-gl-components": "^0.22.9",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.3",
         "maplibre-gl-basemap-control": "^0.7.0",
-        "maplibre-gl-components": "^0.22.8",
+        "maplibre-gl-components": "^0.22.9",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -187,9 +187,9 @@
       "license": "MIT"
     },
     "apps/geolibre-desktop/node_modules/maplibre-gl-components": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.22.8.tgz",
-      "integrity": "sha512-jSVLzU0Cwu9RUSB9sXFY1Biwlm/hi/ycevb468jRVjCp1RXFVX1bUDc0gvs0gjv5hiwTdmgAaaY59gMGW36MKg==",
+      "version": "0.22.9",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.22.9.tgz",
+      "integrity": "sha512-38MaKA1Hjao40SiTKsd8yXXWzQgf/2VRxDvlyZw0BL7YPtshSVVBy48neTt/5IT8HWk1EXWkPdioaXgozNFghQ==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",
@@ -24305,7 +24305,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.3",
         "maplibre-gl-basemap-control": "^0.7.0",
-        "maplibre-gl-components": "^0.22.8",
+        "maplibre-gl-components": "^0.22.9",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -24344,9 +24344,9 @@
       }
     },
     "packages/plugins/node_modules/maplibre-gl-components": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.22.8.tgz",
-      "integrity": "sha512-jSVLzU0Cwu9RUSB9sXFY1Biwlm/hi/ycevb468jRVjCp1RXFVX1bUDc0gvs0gjv5hiwTdmgAaaY59gMGW36MKg==",
+      "version": "0.22.9",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.22.9.tgz",
+      "integrity": "sha512-38MaKA1Hjao40SiTKsd8yXXWzQgf/2VRxDvlyZw0BL7YPtshSVVBy48neTt/5IT8HWk1EXWkPdioaXgozNFghQ==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.3",
         "maplibre-gl-basemap-control": "^0.7.0",
-        "maplibre-gl-components": "^0.22.7",
+        "maplibre-gl-components": "^0.22.8",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -187,9 +187,9 @@
       "license": "MIT"
     },
     "apps/geolibre-desktop/node_modules/maplibre-gl-components": {
-      "version": "0.22.7",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.22.7.tgz",
-      "integrity": "sha512-1ubkGAmqjfonW1ao1Kc5/Mq7gH395Jya17fuIrxZB2+UapIVGLpuOfcSaCHCyJcr27zUzBot0gEEv7LuORBO5g==",
+      "version": "0.22.8",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.22.8.tgz",
+      "integrity": "sha512-jSVLzU0Cwu9RUSB9sXFY1Biwlm/hi/ycevb468jRVjCp1RXFVX1bUDc0gvs0gjv5hiwTdmgAaaY59gMGW36MKg==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",
@@ -24305,7 +24305,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.3",
         "maplibre-gl-basemap-control": "^0.7.0",
-        "maplibre-gl-components": "^0.22.7",
+        "maplibre-gl-components": "^0.22.8",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -24344,9 +24344,9 @@
       }
     },
     "packages/plugins/node_modules/maplibre-gl-components": {
-      "version": "0.22.7",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.22.7.tgz",
-      "integrity": "sha512-1ubkGAmqjfonW1ao1Kc5/Mq7gH395Jya17fuIrxZB2+UapIVGLpuOfcSaCHCyJcr27zUzBot0gEEv7LuORBO5g==",
+      "version": "0.22.8",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.22.8.tgz",
+      "integrity": "sha512-jSVLzU0Cwu9RUSB9sXFY1Biwlm/hi/ycevb468jRVjCp1RXFVX1bUDc0gvs0gjv5hiwTdmgAaaY59gMGW36MKg==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -32,7 +32,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.3",
     "maplibre-gl-basemap-control": "^0.7.0",
-    "maplibre-gl-components": "^0.22.8",
+    "maplibre-gl-components": "^0.22.9",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -32,7 +32,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.3",
     "maplibre-gl-basemap-control": "^0.7.0",
-    "maplibre-gl-components": "^0.22.7",
+    "maplibre-gl-components": "^0.22.8",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -469,10 +469,8 @@ const HTML_OPTIONS = {
   collapsed: false,
   fontColor: "hsl(var(--popover-foreground))",
   // Omit maxHeight so the control auto-fits the available viewport height
-  // (HtmlGuiControl gained this in maplibre-gl-components >= 0.22.8; the
-  // colorbar/legend panels got it earlier in 0.20.6). See COLORBAR_OPTIONS
-  // above. A fixed cap forced an internal scrollbar even when the HTML content
-  // was short and there was ample empty space below the panel.
+  // (HtmlGuiControl gained this in maplibre-gl-components >= 0.22.8); see
+  // COLORBAR_OPTIONS above for the full rationale.
   panelWidth: 340,
   position: htmlControlPosition,
 } satisfies HtmlGuiControlOptions;

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -468,7 +468,10 @@ const HTML_OPTIONS = {
   className: "geolibre-html-control",
   collapsed: false,
   fontColor: "hsl(var(--popover-foreground))",
-  maxHeight: 520,
+  // Omit maxHeight so the control auto-fits the available viewport height
+  // (maplibre-gl-components >= 0.20.6); see COLORBAR_OPTIONS above. A fixed cap
+  // forced an internal scrollbar even when the HTML content was short and there
+  // was ample empty space below the panel.
   panelWidth: 340,
   position: htmlControlPosition,
 } satisfies HtmlGuiControlOptions;

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -469,9 +469,10 @@ const HTML_OPTIONS = {
   collapsed: false,
   fontColor: "hsl(var(--popover-foreground))",
   // Omit maxHeight so the control auto-fits the available viewport height
-  // (maplibre-gl-components >= 0.20.6); see COLORBAR_OPTIONS above. A fixed cap
-  // forced an internal scrollbar even when the HTML content was short and there
-  // was ample empty space below the panel.
+  // (HtmlGuiControl gained this in maplibre-gl-components >= 0.22.8; the
+  // colorbar/legend panels got it earlier in 0.20.6). See COLORBAR_OPTIONS
+  // above. A fixed cap forced an internal scrollbar even when the HTML content
+  // was short and there was ample empty space below the panel.
   panelWidth: 340,
   position: htmlControlPosition,
 } satisfies HtmlGuiControlOptions;


### PR DESCRIPTION
## Summary

Two improvements to the **HTML Control** config panel, both delivered through `maplibre-gl-components` (bumped to **0.22.9**):

1. **Auto-fit height (fixes #793).** The panel showed an internal scrollbar even when the custom HTML content was short and there was empty space below it. Root cause was a fixed `maxHeight` cap both in GeoLibre's `HTML_OPTIONS` (`520`) and in the upstream `HtmlGuiControl` default (`500`). The panel now sizes to its content, capped to the available space, scrolling only when content would run past the map edge.
2. **Resizable panel (this follow-up).** The panel now has two bottom-corner resize grips, consistent with the Add Vector / Zarr / PMTiles data panels. Users can drag either bottom corner to adjust width and height, and the chosen size persists across re-opens.

## GeoLibre-side change

- Bump `maplibre-gl-components` `^0.22.7` → `^0.22.9` in `apps/geolibre-desktop` and `packages/plugins`.
- Drop the explicit `maxHeight` from `HTML_OPTIONS` so the panel auto-fits.

The resize grips are entirely upstream, so no other GeoLibre code change is needed.

## Upstream PRs / releases

- opengeos/maplibre-gl-components#110 — HtmlGuiControl auto-fit (v0.22.8)
- opengeos/maplibre-gl-components#111 — HtmlGuiControl bottom-corner resize grips (v0.22.9)

## Verification

Drove the real app with Playwright in **light and dark themes**:

- Default panel: `scrollHeight === clientHeight`, no internal scrollbar, full form + Add button visible.
- Two resize grips present; dragging the bottom-left and bottom-right grips grows the panel (e.g. 340x599 → 484x723); position stays `absolute` (float-beside-button layout preserved).

`npm run build` succeeds and `pre-commit` passes on the changed files.

Fixes #793