### PR TITLE
feat(settings): dedicated AI Providers section with provider dropdowns (#778)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -104,6 +104,7 @@ import {
 import {
   PROVIDER_DOCS_URL,
   PROVIDER_FIELDS,
+  type ProviderField,
 } from "../../lib/assistant/provider-fields";
 
 export type SettingsSection =
@@ -598,40 +599,59 @@ export function SettingsDialog({
     });
   };
 
-  // The value of an env-var-backed AI provider field, or "" when unset. Only an
-  // enabled row counts: a var the user disabled in the Environment section must
-  // read as empty here so the field matches the (also enabled-only) status, and
-  // editing it never silently re-enables a deliberately disabled var.
-  const getProviderField = (envKey: string): string =>
-    draftPreferences.environmentVariables.find(
-      (variable) => variable.key === envKey && variable.enabled,
-    )?.value ?? "";
+  // Every env var name a field is backed by: its canonical key plus any aliases
+  // provider.ts also accepts (e.g. GOOGLE_API_KEY for the Gemini field).
+  const fieldEnvKeys = (field: ProviderField): readonly string[] => [
+    field.envKey,
+    ...(field.aliases ?? []),
+  ];
 
-  // Write an AI provider field through to its backing env var. Upserts an
-  // enabled row (so provider.ts picks it up) and removes the row when cleared so
-  // the generic Environment variables list never accrues empty entries.
-  const setProviderField = (envKey: string, value: string) => {
-    setDraftPreferences((current) => {
-      const index = current.environmentVariables.findIndex(
-        (variable) => variable.key === envKey,
+  // The value of an env-var-backed AI provider field, or "" when unset. Only an
+  // enabled row counts: a var disabled in the Environment section must read as
+  // empty so the field matches the (also enabled-only) status banner. An aliased
+  // value (e.g. an existing GOOGLE_API_KEY) is surfaced rather than hidden.
+  const getProviderField = (field: ProviderField): string => {
+    for (const key of fieldEnvKeys(field)) {
+      const row = draftPreferences.environmentVariables.find(
+        (variable) => variable.key === key && variable.enabled,
       );
-      if (index === -1) {
-        if (value === "") return current;
-        return {
-          ...current,
-          environmentVariables: [
-            ...current.environmentVariables,
-            { id: createDraftId(), key: envKey, value, enabled: true },
-          ],
-        };
+      if (row) return row.value;
+    }
+    return "";
+  };
+
+  // Write an AI provider field through to its backing env var. Edits the enabled
+  // row the user already has (canonical or alias) so re-entering a credential
+  // never creates a duplicate key; otherwise drops any same-named disabled rows
+  // (so a deliberately disabled var is not silently re-enabled with its old
+  // value) and appends a fresh enabled row under the canonical name. Clearing
+  // removes the row so the Environment list never accrues empty entries.
+  const setProviderField = (field: ProviderField, value: string) => {
+    const keys = fieldEnvKeys(field);
+    setDraftPreferences((current) => {
+      const enabledIndex = current.environmentVariables.findIndex(
+        (variable) => keys.includes(variable.key) && variable.enabled,
+      );
+      if (enabledIndex !== -1) {
+        const next = current.environmentVariables.slice();
+        if (value === "") {
+          next.splice(enabledIndex, 1);
+        } else {
+          next[enabledIndex] = { ...next[enabledIndex], value };
+        }
+        return { ...current, environmentVariables: next };
       }
-      const next = current.environmentVariables.slice();
-      if (value === "") {
-        next.splice(index, 1);
-      } else {
-        next[index] = { ...next[index], value, enabled: true };
-      }
-      return { ...current, environmentVariables: next };
+      if (value === "") return current;
+      const kept = current.environmentVariables.filter(
+        (variable) => !keys.includes(variable.key),
+      );
+      return {
+        ...current,
+        environmentVariables: [
+          ...kept,
+          { id: createDraftId(), key: field.envKey, value, enabled: true },
+        ],
+      };
     });
     setError(null);
   };
@@ -1238,15 +1258,17 @@ export function SettingsDialog({
               {t("settings.menu.geocoding")}
             </DropdownMenuItem>
           )}
-          <DropdownMenuItem
-            onSelect={() => {
-              setSection("ai");
-              setOpen(true);
-            }}
-          >
-            <Bot className="mr-2 h-3.5 w-3.5" />
-            {t("settings.menu.ai")}
-          </DropdownMenuItem>
+          {showSettingsItem("settings.ai") && (
+            <DropdownMenuItem
+              onSelect={() => {
+                setSection("ai");
+                setOpen(true);
+              }}
+            >
+              <Bot className="mr-2 h-3.5 w-3.5" />
+              {t("settings.menu.ai")}
+            </DropdownMenuItem>
+          )}
           {showSettingsItem("settings.environment") && (
             <DropdownMenuItem
               onSelect={() => {
@@ -2125,9 +2147,9 @@ export function SettingsDialog({
                               }
                               autoComplete="off"
                               spellCheck={false}
-                              value={getProviderField(field.envKey)}
+                              value={getProviderField(field)}
                               onChange={(event) =>
-                                setProviderField(field.envKey, event.target.value)
+                                setProviderField(field, event.target.value)
                               }
                               placeholder={t(field.placeholderKey)}
                             />

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -35,10 +35,12 @@ import {
 } from "@geolibre/ui";
 import type { MapController } from "@geolibre/map";
 import {
+  Bot,
   Braces,
   Check,
   Crosshair,
   DownloadCloud,
+  ExternalLink,
   Eye,
   EyeOff,
   FolderCog,
@@ -93,6 +95,16 @@ import {
   presetHiddenSets,
   showsAdvancedNotices,
 } from "../../lib/ui-profile";
+import {
+  ASSISTANT_PROVIDER_IDS,
+  PROVIDER_LABELS,
+  availableProviders,
+  type AssistantProviderId,
+} from "../../lib/assistant/provider";
+import {
+  PROVIDER_DOCS_URL,
+  PROVIDER_FIELDS,
+} from "../../lib/assistant/provider-fields";
 
 export type SettingsSection =
   | "map"
@@ -100,6 +112,7 @@ export type SettingsSection =
   | "appearance"
   | "interface"
   | "geocoding"
+  | "ai"
   | "environment"
   | "updates";
 
@@ -165,6 +178,7 @@ const SECTION_ITEMS: Array<{
     icon: SlidersHorizontal,
   },
   { id: "geocoding", labelKey: "settings.section.geocoding", icon: Locate },
+  { id: "ai", labelKey: "settings.section.ai", icon: Bot },
   {
     id: "environment",
     labelKey: "settings.section.environment",
@@ -422,6 +436,25 @@ export function SettingsDialog({
       ).length,
     [draftPreferences.environmentVariables],
   );
+  // The AI provider whose credential template is shown in the AI section. Seeded
+  // to the first already-configured provider when the dialog opens (below), so a
+  // returning user lands on the provider they set up.
+  const [aiProvider, setAiProvider] = useState<AssistantProviderId>("google");
+  // The draft env vars as a plain name→value map (enabled, named only), matching
+  // what the live runtime env will hold after Save. Drives the per-provider
+  // "configured" status without re-implementing provider.ts resolution.
+  const draftEnv = useMemo(() => {
+    const env: Record<string, string> = {};
+    for (const variable of draftPreferences.environmentVariables) {
+      const key = variable.key.trim();
+      if (variable.enabled && key) env[key] = variable.value;
+    }
+    return env;
+  }, [draftPreferences.environmentVariables]);
+  const configuredProviders = useMemo(
+    () => new Set(availableProviders(draftEnv)),
+    [draftEnv],
+  );
 
   // Seed the draft from the store only when the dialog opens. Depending on
   // preferences would reset in-progress edits if the store changed while the
@@ -437,17 +470,28 @@ export function SettingsDialog({
       setPendingFocus(null);
       return;
     }
-    setDraftPreferences(clonePreferences(useAppStore.getState().preferences));
+    const seededPreferences = clonePreferences(
+      useAppStore.getState().preferences,
+    );
+    setDraftPreferences(seededPreferences);
     setDraftDesktopSettings(
       cloneDesktopSettings(useDesktopSettingsStore.getState().desktopSettings),
     );
+    // Land the AI section on a provider the user already configured, so editing
+    // existing credentials needs no extra click.
+    const seededEnv: Record<string, string> = {};
+    for (const variable of seededPreferences.environmentVariables) {
+      const key = variable.key.trim();
+      if (variable.enabled && key) seededEnv[key] = variable.value;
+    }
+    setAiProvider(availableProviders(seededEnv)[0] ?? "google");
     setRevealedValueIds(new Set());
     setError(null);
     setLiveProjection(mapControllerRef.current?.readProjection() ?? null);
   }, [open, mapControllerRef]);
 
   // Let other panels deep-link into a specific Settings section (e.g. the AI
-  // Assistant onboarding card opens Environment Variables to add a provider key).
+  // Assistant onboarding card opens the AI Providers section to add credentials).
   useEffect(() => {
     const onOpenSettings = (event: Event) => {
       const detail = (
@@ -552,6 +596,41 @@ export function SettingsDialog({
       }
       return next;
     });
+  };
+
+  // The value of an env-var-backed AI provider field, or "" when unset.
+  const getProviderField = (envKey: string): string =>
+    draftPreferences.environmentVariables.find(
+      (variable) => variable.key === envKey,
+    )?.value ?? "";
+
+  // Write an AI provider field through to its backing env var. Upserts an
+  // enabled row (so provider.ts picks it up) and removes the row when cleared so
+  // the generic Environment variables list never accrues empty entries.
+  const setProviderField = (envKey: string, value: string) => {
+    setDraftPreferences((current) => {
+      const index = current.environmentVariables.findIndex(
+        (variable) => variable.key === envKey,
+      );
+      if (index === -1) {
+        if (value === "") return current;
+        return {
+          ...current,
+          environmentVariables: [
+            ...current.environmentVariables,
+            { id: createDraftId(), key: envKey, value, enabled: true },
+          ],
+        };
+      }
+      const next = current.environmentVariables.slice();
+      if (value === "") {
+        next.splice(index, 1);
+      } else {
+        next[index] = { ...next[index], value, enabled: true };
+      }
+      return { ...current, environmentVariables: next };
+    });
+    setError(null);
   };
 
   const updateMapPreferences = (patch: Partial<MapPreferences>) => {
@@ -1156,6 +1235,15 @@ export function SettingsDialog({
               {t("settings.menu.geocoding")}
             </DropdownMenuItem>
           )}
+          <DropdownMenuItem
+            onSelect={() => {
+              setSection("ai");
+              setOpen(true);
+            }}
+          >
+            <Bot className="mr-2 h-3.5 w-3.5" />
+            {t("settings.menu.ai")}
+          </DropdownMenuItem>
           {showSettingsItem("settings.environment") && (
             <DropdownMenuItem
               onSelect={() => {
@@ -1948,6 +2036,141 @@ export function SettingsDialog({
                       </div>
                     );
                   })()}
+                </div>
+              ) : null}
+              {effectiveSection === "ai" ? (
+                <div className="space-y-5">
+                  <div className="space-y-1">
+                    <h3 className="text-sm font-semibold">
+                      {t("settings.ai.title")}
+                    </h3>
+                    <p className="text-xs text-muted-foreground">
+                      {t("settings.ai.description")}
+                    </p>
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label className="text-xs" htmlFor="settings-ai-provider">
+                      {t("settings.ai.providerLabel")}
+                    </Label>
+                    <Select
+                      id="settings-ai-provider"
+                      value={aiProvider}
+                      onChange={(event) =>
+                        setAiProvider(
+                          event.target.value as AssistantProviderId,
+                        )
+                      }
+                    >
+                      {ASSISTANT_PROVIDER_IDS.map((id) => (
+                        <option key={id} value={id}>
+                          {configuredProviders.has(id)
+                            ? `${PROVIDER_LABELS[id]} ${t("settings.ai.configuredMark")}`
+                            : PROVIDER_LABELS[id]}
+                        </option>
+                      ))}
+                    </Select>
+                    <p className="text-xs text-muted-foreground">
+                      {t("settings.ai.providerHint")}
+                    </p>
+                  </div>
+                  {configuredProviders.has(aiProvider) ? (
+                    <div className="flex items-center gap-1.5 rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-xs text-emerald-700 dark:text-emerald-300">
+                      <Check className="h-3.5 w-3.5 shrink-0" />
+                      <span>
+                        {t("settings.ai.statusReady", {
+                          provider: PROVIDER_LABELS[aiProvider],
+                        })}
+                      </span>
+                    </div>
+                  ) : (
+                    <div className="rounded-md border border-dashed px-3 py-2 text-xs text-muted-foreground">
+                      {t("settings.ai.statusIncomplete", {
+                        provider: PROVIDER_LABELS[aiProvider],
+                      })}
+                    </div>
+                  )}
+                  <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-700 dark:text-amber-300">
+                    <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0" />
+                    <span>{t("settings.env.secretsWarning")}</span>
+                  </div>
+                  <div className="space-y-4">
+                    {PROVIDER_FIELDS[aiProvider].map((field) => {
+                      const revealed = revealedValueIds.has(field.envKey);
+                      return (
+                        <div key={field.envKey} className="space-y-1.5">
+                          <div className="flex items-center justify-between gap-2">
+                            <Label
+                              className="text-xs"
+                              htmlFor={`settings-ai-${field.envKey}`}
+                            >
+                              {t(field.labelKey)}
+                              {field.required ? null : (
+                                <span className="ml-1 font-normal text-muted-foreground">
+                                  {t("settings.ai.optionalMark")}
+                                </span>
+                              )}
+                            </Label>
+                            <code className="font-mono text-[11px] text-muted-foreground">
+                              {field.envKey}
+                            </code>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <Input
+                              id={`settings-ai-${field.envKey}`}
+                              type={
+                                field.secret && !revealed ? "password" : "text"
+                              }
+                              autoComplete="off"
+                              spellCheck={false}
+                              value={getProviderField(field.envKey)}
+                              onChange={(event) =>
+                                setProviderField(field.envKey, event.target.value)
+                              }
+                              placeholder={t(field.placeholderKey)}
+                            />
+                            {field.secret ? (
+                              <Button
+                                type="button"
+                                size="icon"
+                                variant="ghost"
+                                onClick={() =>
+                                  toggleValueVisibility(field.envKey)
+                                }
+                                aria-label={
+                                  revealed
+                                    ? t("settings.ai.hideValue", {
+                                        name: t(field.labelKey),
+                                      })
+                                    : t("settings.ai.showValue", {
+                                        name: t(field.labelKey),
+                                      })
+                                }
+                              >
+                                {revealed ? (
+                                  <EyeOff className="h-3.5 w-3.5" />
+                                ) : (
+                                  <Eye className="h-3.5 w-3.5" />
+                                )}
+                              </Button>
+                            ) : null}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                  {PROVIDER_DOCS_URL[aiProvider] ? (
+                    <a
+                      className="inline-flex items-center gap-1 text-xs text-primary underline"
+                      href={PROVIDER_DOCS_URL[aiProvider]}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                    >
+                      <ExternalLink className="h-3 w-3" />
+                      {t("settings.ai.getCredentials", {
+                        provider: PROVIDER_LABELS[aiProvider],
+                      })}
+                    </a>
+                  ) : null}
                 </div>
               ) : null}
               {effectiveSection === "environment" ? (

--- a/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/SettingsDialog.tsx
@@ -598,10 +598,13 @@ export function SettingsDialog({
     });
   };
 
-  // The value of an env-var-backed AI provider field, or "" when unset.
+  // The value of an env-var-backed AI provider field, or "" when unset. Only an
+  // enabled row counts: a var the user disabled in the Environment section must
+  // read as empty here so the field matches the (also enabled-only) status, and
+  // editing it never silently re-enables a deliberately disabled var.
   const getProviderField = (envKey: string): string =>
     draftPreferences.environmentVariables.find(
-      (variable) => variable.key === envKey,
+      (variable) => variable.key === envKey && variable.enabled,
     )?.value ?? "";
 
   // Write an AI provider field through to its backing env var. Upserts an

--- a/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/AssistantPanel.tsx
@@ -605,7 +605,7 @@ export function AssistantPanel({ mapControllerRef }: AssistantPanelProps) {
           <Button
             size="sm"
             className="w-full"
-            onClick={() => openSettingsSection("environment")}
+            onClick={() => openSettingsSection("ai")}
           >
             <Settings className="mr-1 h-4 w-4" />
             {t("assistant.setupOpenSettings")}

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -835,6 +835,7 @@
       "appearance": "Appearance",
       "interface": "Interface",
       "geocoding": "Geocoding",
+      "ai": "AI Providers",
       "environment": "Environment",
       "updates": "Updates"
     },
@@ -844,6 +845,7 @@
       "appearanceSettings": "Appearance Settings",
       "interfaceSettings": "Interface Settings",
       "geocoding": "Geocoding",
+      "ai": "AI Providers",
       "environmentVariables": "Environment Variables",
       "updates": "Update Settings",
       "managePlugins": "Manage Plugins",
@@ -969,6 +971,42 @@
       "emailHint": "Sent to identify the client to Nominatim, per its usage policy.",
       "secretsWarning": "Keys are stored in plain text in the project file and may be exposed when the project is shared. They are also sent as query parameters, so they appear in geocoding request URLs visible in browser DevTools and any proxy logs.",
       "corsNote": "Google does not officially allow browser requests to its Geocoding API, so requests may be blocked unless served through a same-origin proxy."
+    },
+    "ai": {
+      "title": "AI Assistant providers",
+      "description": "Configure credentials for the AI Assistant. Choose a provider, fill in the fields it needs, then Save. Only one configured provider is required to start chatting.",
+      "providerLabel": "Provider",
+      "providerHint": "Choose a provider to reveal the exact fields it needs.",
+      "configuredMark": "(configured)",
+      "optionalMark": "(optional)",
+      "statusReady": "{{provider}} is configured and ready to use.",
+      "statusIncomplete": "Fill in the required fields below to enable {{provider}}.",
+      "getCredentials": "Where to get {{provider}} credentials",
+      "showValue": "Show {{name}}",
+      "hideValue": "Hide {{name}}",
+      "field": {
+        "apiKey": "API key",
+        "baseUrl": "Base URL",
+        "model": "Model",
+        "region": "Region",
+        "accessKeyId": "Access Key ID",
+        "secretAccessKey": "Secret Access Key",
+        "sessionToken": "Session token"
+      },
+      "placeholder": {
+        "geminiKey": "AIza…",
+        "anthropicKey": "sk-ant-…",
+        "openaiKey": "sk-…",
+        "ollamaBaseUrl": "http://localhost:11434",
+        "ollamaModel": "llama3.2",
+        "awsAccessKey": "AKIA…",
+        "awsSecretKey": "wJalrXUtnFEMI…",
+        "awsRegion": "us-east-1",
+        "awsSessionToken": "FwoGZXIvYXdz… (if using temporary credentials)",
+        "customBaseUrl": "https://api.example.com/v1",
+        "customModel": "model-id",
+        "customApiKey": "sk-… (if required)"
+      }
     }
   },
   "toolbar": {
@@ -1611,7 +1649,7 @@
     "setupTitle": "Set up the AI Assistant",
     "setupStatus": "The assistant needs an AI provider to do the thinking. Add credentials for any one provider below and the panel switches to chat mode as soon as you save.",
     "setupProviders": "Add credentials for any one provider",
-    "setupOpenSettings": "Open Settings → Environment Variables",
+    "setupOpenSettings": "Open Settings → AI Providers",
     "thinking": "Working…",
     "toolError": "failed",
     "provider": "LLM provider",

--- a/apps/geolibre-desktop/src/lib/assistant/provider-fields.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/provider-fields.ts
@@ -12,6 +12,10 @@ export interface ProviderField {
   secret: boolean;
   /** Whether the provider needs this field before it counts as configured. */
   required: boolean;
+  /** Other env var names {@link ./provider} also accepts for this field, so an
+   * existing value under an alias is surfaced (and edited) here rather than
+   * hidden behind a duplicate of the canonical name. */
+  aliases?: readonly string[];
 }
 
 /** The credential fields each provider exposes, mirroring what {@link ./provider.configForProvider} reads. */
@@ -23,6 +27,9 @@ export const PROVIDER_FIELDS = {
       placeholderKey: "settings.ai.placeholder.geminiKey",
       secret: true,
       required: true,
+      // provider.ts also honors these names; surface a value set under either
+      // so the field is not left empty while the status reads "configured".
+      aliases: ["GOOGLE_API_KEY", "GOOGLE_GENAI_API_KEY"],
     },
   ],
   anthropic: [

--- a/apps/geolibre-desktop/src/lib/assistant/provider-fields.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/provider-fields.ts
@@ -1,13 +1,6 @@
 import type { AssistantProviderId } from "./provider";
 
-/**
- * Declarative description of a single credential field for an AI provider, used
- * by the Settings → AI Providers section to render a labeled input instead of
- * asking the user to type a raw environment-variable name. Each field maps one
- * to one onto a runtime environment variable that {@link ./provider} already
- * reads, so the structured UI and the generic Environment variables list stay
- * two views of the same underlying storage.
- */
+/** One credential field for an AI provider, mapped onto the env var {@link ./provider} reads. */
 export interface ProviderField {
   /** The runtime environment variable this field reads from and writes to. */
   envKey: string;
@@ -21,13 +14,7 @@ export interface ProviderField {
   required: boolean;
 }
 
-/**
- * The credential fields each provider exposes, mirroring exactly what
- * {@link ./provider.configForProvider} reads. The first env var name in each
- * provider's key list is used (the alternates like `GOOGLE_API_KEY` remain
- * available through the generic Environment variables list). Selecting a
- * provider in the AI section renders this list as the dynamic template.
- */
+/** The credential fields each provider exposes, mirroring what {@link ./provider.configForProvider} reads. */
 export const PROVIDER_FIELDS = {
   google: [
     {

--- a/apps/geolibre-desktop/src/lib/assistant/provider-fields.ts
+++ b/apps/geolibre-desktop/src/lib/assistant/provider-fields.ts
@@ -1,0 +1,142 @@
+import type { AssistantProviderId } from "./provider";
+
+/**
+ * Declarative description of a single credential field for an AI provider, used
+ * by the Settings → AI Providers section to render a labeled input instead of
+ * asking the user to type a raw environment-variable name. Each field maps one
+ * to one onto a runtime environment variable that {@link ./provider} already
+ * reads, so the structured UI and the generic Environment variables list stay
+ * two views of the same underlying storage.
+ */
+export interface ProviderField {
+  /** The runtime environment variable this field reads from and writes to. */
+  envKey: string;
+  /** i18n key for the human-readable field label (e.g. "API key"). */
+  labelKey: string;
+  /** i18n key for the placeholder that hints the expected value format. */
+  placeholderKey: string;
+  /** Mask the value by default and offer a reveal toggle (secrets, keys). */
+  secret: boolean;
+  /** Whether the provider needs this field before it counts as configured. */
+  required: boolean;
+}
+
+/**
+ * The credential fields each provider exposes, mirroring exactly what
+ * {@link ./provider.configForProvider} reads. The first env var name in each
+ * provider's key list is used (the alternates like `GOOGLE_API_KEY` remain
+ * available through the generic Environment variables list). Selecting a
+ * provider in the AI section renders this list as the dynamic template.
+ */
+export const PROVIDER_FIELDS = {
+  google: [
+    {
+      envKey: "GEMINI_API_KEY",
+      labelKey: "settings.ai.field.apiKey",
+      placeholderKey: "settings.ai.placeholder.geminiKey",
+      secret: true,
+      required: true,
+    },
+  ],
+  anthropic: [
+    {
+      envKey: "ANTHROPIC_API_KEY",
+      labelKey: "settings.ai.field.apiKey",
+      placeholderKey: "settings.ai.placeholder.anthropicKey",
+      secret: true,
+      required: true,
+    },
+  ],
+  openai: [
+    {
+      envKey: "OPENAI_API_KEY",
+      labelKey: "settings.ai.field.apiKey",
+      placeholderKey: "settings.ai.placeholder.openaiKey",
+      secret: true,
+      required: true,
+    },
+  ],
+  ollama: [
+    {
+      envKey: "OLLAMA_BASE_URL",
+      labelKey: "settings.ai.field.baseUrl",
+      placeholderKey: "settings.ai.placeholder.ollamaBaseUrl",
+      secret: false,
+      required: true,
+    },
+    {
+      envKey: "OLLAMA_MODEL",
+      labelKey: "settings.ai.field.model",
+      placeholderKey: "settings.ai.placeholder.ollamaModel",
+      secret: false,
+      required: false,
+    },
+  ],
+  bedrock: [
+    {
+      envKey: "AWS_ACCESS_KEY_ID",
+      labelKey: "settings.ai.field.accessKeyId",
+      placeholderKey: "settings.ai.placeholder.awsAccessKey",
+      secret: true,
+      required: true,
+    },
+    {
+      envKey: "AWS_SECRET_ACCESS_KEY",
+      labelKey: "settings.ai.field.secretAccessKey",
+      placeholderKey: "settings.ai.placeholder.awsSecretKey",
+      secret: true,
+      required: true,
+    },
+    {
+      envKey: "AWS_REGION",
+      labelKey: "settings.ai.field.region",
+      placeholderKey: "settings.ai.placeholder.awsRegion",
+      secret: false,
+      required: false,
+    },
+    {
+      envKey: "AWS_SESSION_TOKEN",
+      labelKey: "settings.ai.field.sessionToken",
+      placeholderKey: "settings.ai.placeholder.awsSessionToken",
+      secret: true,
+      required: false,
+    },
+  ],
+  custom: [
+    {
+      envKey: "OPENAI_COMPATIBLE_BASE_URL",
+      labelKey: "settings.ai.field.baseUrl",
+      placeholderKey: "settings.ai.placeholder.customBaseUrl",
+      secret: false,
+      required: true,
+    },
+    {
+      envKey: "OPENAI_COMPATIBLE_MODEL",
+      labelKey: "settings.ai.field.model",
+      placeholderKey: "settings.ai.placeholder.customModel",
+      secret: false,
+      required: true,
+    },
+    {
+      envKey: "OPENAI_COMPATIBLE_API_KEY",
+      labelKey: "settings.ai.field.apiKey",
+      placeholderKey: "settings.ai.placeholder.customApiKey",
+      secret: true,
+      required: false,
+    },
+  ],
+} as const satisfies Record<AssistantProviderId, readonly ProviderField[]>;
+
+/**
+ * Where to obtain credentials for each provider, surfaced as a help link below
+ * the fields. Providers without a meaningful sign-up page (custom endpoints)
+ * are omitted.
+ */
+export const PROVIDER_DOCS_URL: Partial<Record<AssistantProviderId, string>> = {
+  google: "https://aistudio.google.com/apikey",
+  anthropic: "https://console.anthropic.com/settings/keys",
+  openai: "https://platform.openai.com/api-keys",
+  ollama: "https://ollama.com/download",
+  bedrock:
+    "https://docs.aws.amazon.com/bedrock/latest/userguide/getting-started.html",
+};

--- a/tests/assistant-provider-fields.test.ts
+++ b/tests/assistant-provider-fields.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  ASSISTANT_PROVIDER_IDS,
+  availableProviders,
+  type AssistantProviderId,
+  type RuntimeEnv,
+} from "../apps/geolibre-desktop/src/lib/assistant/provider";
+import {
+  PROVIDER_DOCS_URL,
+  PROVIDER_FIELDS,
+} from "../apps/geolibre-desktop/src/lib/assistant/provider-fields";
+
+// Build a runtime env that fills exactly the chosen fields of a provider with
+// plausible dummy values. URL-shaped fields need a real-looking URL so the
+// provider resolver (which normalizes/validates them) accepts them.
+function envFrom(
+  provider: AssistantProviderId,
+  envKeys: readonly string[],
+): RuntimeEnv {
+  const env: Record<string, string> = {};
+  for (const field of PROVIDER_FIELDS[provider]) {
+    if (!envKeys.includes(field.envKey)) continue;
+    env[field.envKey] = /URL$/.test(field.envKey)
+      ? "https://example.com/v1"
+      : `${field.envKey.toLowerCase()}-value`;
+  }
+  return env;
+}
+
+describe("PROVIDER_FIELDS", () => {
+  it("defines at least one field for every provider", () => {
+    for (const provider of ASSISTANT_PROVIDER_IDS) {
+      assert.ok(
+        PROVIDER_FIELDS[provider].length > 0,
+        `${provider} has no fields`,
+      );
+    }
+  });
+
+  it("uses non-empty, unique env keys within each provider", () => {
+    for (const provider of ASSISTANT_PROVIDER_IDS) {
+      const keys = PROVIDER_FIELDS[provider].map((field) => field.envKey);
+      for (const key of keys) {
+        assert.ok(key.trim().length > 0, `${provider} has a blank env key`);
+      }
+      assert.equal(
+        new Set(keys).size,
+        keys.length,
+        `${provider} repeats an env key`,
+      );
+    }
+  });
+
+  it("populates label and placeholder i18n keys for every field", () => {
+    for (const provider of ASSISTANT_PROVIDER_IDS) {
+      for (const field of PROVIDER_FIELDS[provider]) {
+        assert.ok(
+          field.labelKey.startsWith("settings.ai.field."),
+          `${field.envKey} has an unexpected labelKey`,
+        );
+        assert.ok(
+          field.placeholderKey.startsWith("settings.ai.placeholder."),
+          `${field.envKey} has an unexpected placeholderKey`,
+        );
+      }
+    }
+  });
+
+  it("marks a provider configured once all its required fields are filled", () => {
+    for (const provider of ASSISTANT_PROVIDER_IDS) {
+      const required = PROVIDER_FIELDS[provider]
+        .filter((field) => field.required)
+        .map((field) => field.envKey);
+      const env = envFrom(provider, required);
+      assert.ok(
+        availableProviders(env).includes(provider),
+        `${provider} not configured after filling required fields`,
+      );
+    }
+  });
+
+  it("leaves a provider unconfigured when any required field is missing", () => {
+    for (const provider of ASSISTANT_PROVIDER_IDS) {
+      const required = PROVIDER_FIELDS[provider]
+        .filter((field) => field.required)
+        .map((field) => field.envKey);
+      // Drop one required field at a time; the provider must not resolve.
+      for (const omitted of required) {
+        const env = envFrom(
+          provider,
+          required.filter((key) => key !== omitted),
+        );
+        assert.ok(
+          !availableProviders(env).includes(provider),
+          `${provider} resolved without required field ${omitted}`,
+        );
+      }
+    }
+  });
+
+  it("only links docs URLs over https", () => {
+    for (const url of Object.values(PROVIDER_DOCS_URL)) {
+      assert.match(url, /^https:\/\//);
+    }
+  });
+});

--- a/tests/assistant-provider-fields.test.ts
+++ b/tests/assistant-provider-fields.test.ts
@@ -11,9 +11,10 @@ import {
   PROVIDER_FIELDS,
 } from "../apps/geolibre-desktop/src/lib/assistant/provider-fields";
 
-// Build a runtime env that fills exactly the chosen fields of a provider with
-// plausible dummy values. URL-shaped fields need a real-looking URL so the
-// provider resolver (which normalizes/validates them) accepts them.
+// Build a runtime env that fills exactly the chosen fields of a provider. A
+// URL-shaped value satisfies every field the resolver inspects (API keys,
+// models, regions, and the base-URL fields it actually parses), so use one
+// dummy value rather than guessing which keys must look like URLs.
 function envFrom(
   provider: AssistantProviderId,
   envKeys: readonly string[],
@@ -21,9 +22,7 @@ function envFrom(
   const env: Record<string, string> = {};
   for (const field of PROVIDER_FIELDS[provider]) {
     if (!envKeys.includes(field.envKey)) continue;
-    env[field.envKey] = /URL$/.test(field.envKey)
-      ? "https://example.com/v1"
-      : `${field.envKey.toLowerCase()}-value`;
+    env[field.envKey] = "https://example.com/v1";
   }
   return env;
 }

--- a/tests/assistant-provider-fields.test.ts
+++ b/tests/assistant-provider-fields.test.ts
@@ -98,6 +98,29 @@ describe("PROVIDER_FIELDS", () => {
     }
   });
 
+  it("declares only aliases the resolver actually accepts", () => {
+    for (const provider of ASSISTANT_PROVIDER_IDS) {
+      for (const field of PROVIDER_FIELDS[provider]) {
+        const required = PROVIDER_FIELDS[provider]
+          .filter((f) => f.required)
+          .map((f) => f.envKey);
+        for (const alias of field.aliases ?? []) {
+          // Fill the required fields but swap this field's canonical key for the
+          // alias; the provider must still resolve, proving the alias is a real
+          // synonym in provider.ts rather than dead config.
+          const env: Record<string, string> = {};
+          for (const key of required) {
+            env[key === field.envKey ? alias : key] = "https://example.com/v1";
+          }
+          assert.ok(
+            availableProviders(env).includes(provider),
+            `${provider} did not accept alias ${alias}`,
+          );
+        }
+      }
+    }
+  });
+
   it("only links docs URLs over https", () => {
     for (const url of Object.values(PROVIDER_DOCS_URL)) {
       assert.match(url, /^https:\/\//);


### PR DESCRIPTION
## Summary

Implements the feature request in #778: a dedicated, structured **AI Providers** section in Settings so users no longer have to copy raw environment-variable names (`GEMINI_API_KEY`, `ANTHROPIC_API_KEY`, ...) from the AI Assistant onboarding card into a generic key/value list.

The section is a friendly front end over the **same runtime environment variables** the assistant already resolves, so it and the existing **Environment** section stay two views of one store. No change to how the assistant reads credentials.

### What it does (maps to the issue's four parts)

1. **Dedicated section** - a new "AI Providers" entry in the Settings nav and the Settings dropdown menu, with its own pane.
2. **Provider dropdown** - Google Gemini, Anthropic, OpenAI, Ollama (local), Amazon Bedrock, and Custom (OpenAI-compatible).
3. **Dynamic template** - selecting a provider reveals exactly the fields it needs:
   - Gemini -> one API key field
   - Bedrock -> Access Key ID + Secret Access Key (+ optional Region, Session token)
   - Custom -> Base URL + Model (+ optional API key)
4. **Status & validation** - per-field format placeholders, the backing env-var name shown beside each field, reveal toggles for secrets, a per-provider "configured" mark in the dropdown, and a green/dashed status banner showing whether the selected provider is ready. A help link points to where to obtain each provider's credentials.

The AI Assistant onboarding card's "Open Settings" button now deep-links into this section instead of the generic Environment list.

### Implementation notes

- New `apps/geolibre-desktop/src/lib/assistant/provider-fields.ts` declares the per-provider field schema (env key, label, placeholder, secret/required). It mirrors `configForProvider`, and a new test (`tests/assistant-provider-fields.test.ts`) guards that the two stay in sync (filling all required fields configures the provider; omitting any required field does not).
- Fields upsert an enabled env-var row and remove it when cleared, so the generic Environment list never accrues empty entries.
- New user-facing strings added via `t()` and `en.json`.

### Verification

Verified in the real app with Playwright in **both light and dark themes**:
- All six providers render in the dropdown; selecting Gemini / Bedrock / Custom shows the correct dynamic fields.
- Filling required fields flips the status to "configured" and marks the dropdown option; saving writes the keys into `window.__GEOLIBRE_RUNTIME_ENV__`.
- Reopening seeds the section to the already-configured provider; the same vars appear (enabled) in the Environment section.
- `npm run build`, full `npm run test:frontend` (1474 pass), and scoped `pre-commit` (eslint + npm build) all green.

Closes #778

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI Assistant provider settings section to configure credentials for multiple AI providers (Google, Anthropic, OpenAI, Ollama, AWS Bedrock, custom endpoints)
  * Users can select preferred AI provider and manage required credentials with secure field handling
  * Added provider configuration status indicators and documentation links for credential setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->