### PR TITLE
fix(python-console): recoverable error state and right-side editor split

### DIFF
--- a/apps/geolibre-desktop/src/components/common/error-boundaries.tsx
+++ b/apps/geolibre-desktop/src/components/common/error-boundaries.tsx
@@ -3,7 +3,7 @@ import {
   ErrorBoundary,
   type ErrorBoundaryFallbackProps,
 } from "@geolibre/ui";
-import { AlertTriangle, RefreshCw } from "lucide-react";
+import { AlertTriangle, RefreshCw, X } from "lucide-react";
 import type { ErrorInfo, ReactNode } from "react";
 
 import { appendDiagnostic } from "../../lib/diagnostics";
@@ -90,6 +90,7 @@ export function SectionErrorBoundary({
   children,
   fallbackClassName,
   resetKeys,
+  onClose,
 }: {
   label: string;
   children: ReactNode;
@@ -99,6 +100,13 @@ export function SectionErrorBoundary({
    */
   fallbackClassName?: string;
   resetKeys?: readonly unknown[];
+  /**
+   * When the crashed section owns its own close control (a dockable panel whose
+   * header is replaced by this fallback), pass a closer so the user is not
+   * stranded when Retry keeps re-throwing — the fallback then offers a "Close"
+   * action that dismisses the section entirely.
+   */
+  onClose?: () => void;
 }) {
   return (
     <ErrorBoundary
@@ -109,6 +117,7 @@ export function SectionErrorBoundary({
           label={label}
           reset={reset}
           className={fallbackClassName}
+          onClose={onClose}
         />
       )}
     >
@@ -121,9 +130,11 @@ function SectionErrorFallback({
   label,
   reset,
   className,
+  onClose,
 }: Pick<ErrorBoundaryFallbackProps, "reset"> & {
   label: string;
   className?: string;
+  onClose?: () => void;
 }) {
   return (
     <div
@@ -136,10 +147,18 @@ function SectionErrorFallback({
       <p className="text-sm text-muted-foreground">
         {label} failed to render. The rest of GeoLibre is still available.
       </p>
-      <Button variant="outline" size="sm" onClick={reset}>
-        <RefreshCw className="h-4 w-4" />
-        Retry
-      </Button>
+      <div className="flex items-center gap-2">
+        <Button variant="outline" size="sm" onClick={reset}>
+          <RefreshCw className="h-4 w-4" />
+          Retry
+        </Button>
+        {onClose ? (
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            <X className="h-4 w-4" />
+            Close
+          </Button>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/apps/geolibre-desktop/src/components/common/error-boundaries.tsx
+++ b/apps/geolibre-desktop/src/components/common/error-boundaries.tsx
@@ -5,6 +5,7 @@ import {
 } from "@geolibre/ui";
 import { AlertTriangle, RefreshCw, X } from "lucide-react";
 import type { ErrorInfo, ReactNode } from "react";
+import { useTranslation } from "react-i18next";
 
 import { appendDiagnostic } from "../../lib/diagnostics";
 
@@ -136,6 +137,7 @@ function SectionErrorFallback({
   className?: string;
   onClose?: () => void;
 }) {
+  const { t } = useTranslation();
   return (
     <div
       role="alert"
@@ -150,12 +152,12 @@ function SectionErrorFallback({
       <div className="flex items-center gap-2">
         <Button variant="outline" size="sm" onClick={reset}>
           <RefreshCw className="h-4 w-4" />
-          Retry
+          {t("common.retry")}
         </Button>
         {onClose ? (
           <Button variant="ghost" size="sm" onClick={onClose}>
             <X className="h-4 w-4" />
-            Close
+            {t("common.close")}
           </Button>
         ) : null}
       </div>

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -447,6 +447,7 @@ export function DesktopShell({
   const addGeoJsonLayer = useAppStore((s) => s.addGeoJsonLayer);
   const projectGeneration = useAppStore((s) => s.projectGeneration);
   const pythonConsoleOpen = useAppStore((s) => s.ui.pythonConsoleOpen);
+  const setPythonConsoleOpen = useAppStore((s) => s.setPythonConsoleOpen);
   const notebookOpen = useAppStore((s) => s.ui.notebookOpen);
   const storymapPresenting = useAppStore((s) => s.ui.storymapPresenting);
   // A plugin panel docks at one of four positions beside the Layers/Style
@@ -1640,7 +1641,10 @@ export function DesktopShell({
         </SectionErrorBoundary>
       ) : null}
       {pythonConsoleOpen ? (
-        <SectionErrorBoundary label="Python console">
+        <SectionErrorBoundary
+          label="Python console"
+          onClose={() => setPythonConsoleOpen(false)}
+        >
           <Suspense fallback={null}>
             <PythonConsolePanel mapControllerRef={mapControllerRef} />
           </Suspense>

--- a/apps/geolibre-desktop/src/components/panels/PythonConsolePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/PythonConsolePanel.tsx
@@ -2,6 +2,8 @@ import { useAppStore } from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
 import { Button, Textarea } from "@geolibre/ui";
 import {
+  ChevronDown,
+  ChevronUp,
   Eraser,
   Loader2,
   PanelRight,
@@ -86,6 +88,7 @@ export function PythonConsolePanel({
   const historyIndexRef = useRef<number | null>(null);
   const historyDraftRef = useRef("");
   const [height, setHeight] = useState(DEFAULT_CONSOLE_HEIGHT);
+  const [collapsed, setCollapsed] = useState(false);
   const [editorVisible, setEditorVisible] = useState(false);
   const [editorFraction, setEditorFraction] = useState(DEFAULT_EDITOR_FRACTION);
   const [code, setCode] = useState("");
@@ -378,15 +381,18 @@ export function PythonConsolePanel({
       ref={sectionRef}
       aria-label={t("pythonConsole.title")}
       className="relative flex shrink-0 flex-col border-t bg-card"
-      style={{ height }}
+      // Collapsed: drop the fixed height so the panel hugs its header.
+      style={collapsed ? undefined : { height }}
     >
-      <div
-        role="separator"
-        aria-orientation="horizontal"
-        aria-label={t("pythonConsole.resize")}
-        className="absolute -top-1 left-0 right-0 z-20 h-2 cursor-row-resize select-none border-t border-transparent hover:border-primary"
-        onMouseDown={startResize}
-      />
+      {collapsed ? null : (
+        <div
+          role="separator"
+          aria-orientation="horizontal"
+          aria-label={t("pythonConsole.resize")}
+          className="absolute -top-1 left-0 right-0 z-20 h-2 cursor-row-resize select-none border-t border-transparent hover:border-primary"
+          onMouseDown={startResize}
+        />
+      )}
       <div className="flex items-center gap-2 border-b px-3 py-1.5">
         <Terminal className="h-4 w-4 text-muted-foreground" />
         <span className="text-sm font-semibold">{t("pythonConsole.title")}</span>
@@ -430,6 +436,24 @@ export function PythonConsolePanel({
             variant="ghost"
             size="icon"
             className="h-8 w-8"
+            title={
+              collapsed
+                ? t("pythonConsole.expand")
+                : t("pythonConsole.collapse")
+            }
+            aria-expanded={!collapsed}
+            onClick={() => setCollapsed((v) => !v)}
+          >
+            {collapsed ? (
+              <ChevronUp className="h-4 w-4" />
+            ) : (
+              <ChevronDown className="h-4 w-4" />
+            )}
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
             title={t("pythonConsole.close")}
             onClick={() => setPythonConsoleOpen(false)}
           >
@@ -438,7 +462,12 @@ export function PythonConsolePanel({
         </div>
       </div>
 
-      <div ref={splitContainerRef} className="flex min-h-0 flex-1">
+      <div
+        ref={splitContainerRef}
+        // `hidden` (not unmount) keeps the runtime, scrollback, and editor
+        // buffer intact while the panel is collapsed to its header.
+        className={`flex min-h-0 flex-1 ${collapsed ? "hidden" : ""}`}
+      >
         <div className="flex min-w-0 flex-1 flex-col">
           <div
             ref={outputRef}

--- a/apps/geolibre-desktop/src/components/panels/PythonConsolePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/PythonConsolePanel.tsx
@@ -139,11 +139,14 @@ export function PythonConsolePanel({
     };
   }, [deps, t]);
 
-  // Keep the latest output in view.
+  // Keep the latest output in view. Skip while collapsed: the output lives in a
+  // `display: none` subtree where `scrollHeight` reads 0, which would otherwise
+  // reset the scroll to the top. Re-running on uncollapse scrolls to the bottom.
   useEffect(() => {
+    if (collapsed) return;
     const el = outputRef.current;
     if (el) el.scrollTop = el.scrollHeight;
-  }, [history]);
+  }, [history, collapsed]);
 
   // Apply a queued caret position after a history recall changes `code`.
   useEffect(() => {
@@ -321,6 +324,10 @@ export function PythonConsolePanel({
     event.stopPropagation();
     const container = splitContainerRef.current;
     if (!container) return;
+    // The container does not resize during a horizontal drag, so capture its
+    // geometry once instead of forcing a layout read on every mousemove.
+    const rect = container.getBoundingClientRect();
+    if (rect.width === 0) return;
     let nextFraction = editorFraction;
     let frame: number | null = null;
     const prevCursor = document.body.style.cursor;
@@ -329,8 +336,6 @@ export function PythonConsolePanel({
     document.body.style.userSelect = "none";
 
     const onMove = (moveEvent: MouseEvent) => {
-      const rect = container.getBoundingClientRect();
-      if (rect.width === 0) return;
       // Editor is the right pane: its width is the gap between the cursor and
       // the container's right edge.
       const raw = (rect.right - moveEvent.clientX) / rect.width;
@@ -442,6 +447,7 @@ export function PythonConsolePanel({
                 : t("pythonConsole.collapse")
             }
             aria-expanded={!collapsed}
+            aria-controls="python-console-body"
             onClick={() => setCollapsed((v) => !v)}
           >
             {collapsed ? (
@@ -463,6 +469,7 @@ export function PythonConsolePanel({
       </div>
 
       <div
+        id="python-console-body"
         ref={splitContainerRef}
         // `hidden` (not unmount) keeps the runtime, scrollback, and editor
         // buffer intact while the panel is collapsed to its header.
@@ -534,7 +541,7 @@ export function PythonConsolePanel({
             />
             <div
               ref={editorPaneRef}
-              className="flex min-w-0 shrink-0 grow-0 flex-col border-l"
+              className="flex shrink-0 grow-0 flex-col border-l"
               style={{ flexBasis: `${editorFraction * 100}%` }}
             >
               <PythonEditorPane

--- a/apps/geolibre-desktop/src/components/panels/PythonConsolePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/PythonConsolePanel.tsx
@@ -4,8 +4,8 @@ import { Button, Textarea } from "@geolibre/ui";
 import {
   Eraser,
   Loader2,
-  PanelLeft,
-  PanelLeftClose,
+  PanelRight,
+  PanelRightClose,
   Play,
   Terminal,
   X,
@@ -33,9 +33,11 @@ import { PythonEditorPane } from "./PythonEditorPane";
 const DEFAULT_CONSOLE_HEIGHT = 240;
 const MIN_CONSOLE_HEIGHT = 120;
 const MAX_CONSOLE_HEIGHT = 560;
-const DEFAULT_EDITOR_WIDTH = 360;
-const MIN_EDITOR_WIDTH = 220;
-const MAX_EDITOR_WIDTH = 900;
+// Share of the panel width given to the editor (the right pane), as a fraction.
+// Default 0.5 = an even split with the console.
+const DEFAULT_EDITOR_FRACTION = 0.5;
+const MIN_EDITOR_FRACTION = 0.2;
+const MAX_EDITOR_FRACTION = 0.8;
 const PANEL_RESIZE_START_EVENT = "geolibre:panel-resize-start";
 const PANEL_RESIZE_END_EVENT = "geolibre:panel-resize-end";
 
@@ -68,6 +70,9 @@ export function PythonConsolePanel({
   const outputRef = useRef<HTMLDivElement>(null);
   const consoleInputRef = useRef<HTMLTextAreaElement>(null);
   const editorPaneRef = useRef<HTMLDivElement>(null);
+  // The horizontal flex container holding the console (left) and editor (right);
+  // its width drives the drag-to-resize fraction.
+  const splitContainerRef = useRef<HTMLDivElement>(null);
   // Tear down an in-flight drag's window listeners; set while dragging so an
   // unmount mid-drag (e.g. closing the panel) doesn't leak them. One per drag
   // axis so a second drag can't overwrite the other's cleanup.
@@ -82,7 +87,7 @@ export function PythonConsolePanel({
   const historyDraftRef = useRef("");
   const [height, setHeight] = useState(DEFAULT_CONSOLE_HEIGHT);
   const [editorVisible, setEditorVisible] = useState(false);
-  const [editorWidth, setEditorWidth] = useState(DEFAULT_EDITOR_WIDTH);
+  const [editorFraction, setEditorFraction] = useState(DEFAULT_EDITOR_FRACTION);
   const [code, setCode] = useState("");
   const [history, setHistory] = useState<Entry[]>([]);
   const [running, setRunning] = useState(false);
@@ -305,13 +310,15 @@ export function PythonConsolePanel({
     };
   };
 
-  // Horizontal splitter between the editor (left) and the console (right).
+  // Horizontal splitter between the console (left) and the editor (right). The
+  // editor's width is tracked as a fraction of the panel so the split stays
+  // proportional as the window resizes.
   const startEditorResize = (event: ReactMouseEvent<HTMLDivElement>) => {
     event.preventDefault();
     event.stopPropagation();
-    const startX = event.clientX;
-    const startWidth = editorWidth;
-    let nextWidth = startWidth;
+    const container = splitContainerRef.current;
+    if (!container) return;
+    let nextFraction = editorFraction;
     let frame: number | null = null;
     const prevCursor = document.body.style.cursor;
     const prevSelect = document.body.style.userSelect;
@@ -319,16 +326,21 @@ export function PythonConsolePanel({
     document.body.style.userSelect = "none";
 
     const onMove = (moveEvent: MouseEvent) => {
-      nextWidth = Math.min(
-        MAX_EDITOR_WIDTH,
-        Math.max(MIN_EDITOR_WIDTH, startWidth + moveEvent.clientX - startX),
+      const rect = container.getBoundingClientRect();
+      if (rect.width === 0) return;
+      // Editor is the right pane: its width is the gap between the cursor and
+      // the container's right edge.
+      const raw = (rect.right - moveEvent.clientX) / rect.width;
+      nextFraction = Math.min(
+        MAX_EDITOR_FRACTION,
+        Math.max(MIN_EDITOR_FRACTION, raw),
       );
       // Throttle to one DOM write per frame; commit to state only on mouseup.
       if (frame !== null) return;
       frame = window.requestAnimationFrame(() => {
         frame = null;
         if (editorPaneRef.current) {
-          editorPaneRef.current.style.width = `${nextWidth}px`;
+          editorPaneRef.current.style.flexBasis = `${nextFraction * 100}%`;
         }
       });
     };
@@ -337,7 +349,7 @@ export function PythonConsolePanel({
       window.removeEventListener("mouseup", onUp);
       horizontalResizeCleanupRef.current = null;
       if (frame !== null) window.cancelAnimationFrame(frame);
-      setEditorWidth(nextWidth);
+      setEditorFraction(nextFraction);
       document.body.style.cursor = prevCursor;
       document.body.style.userSelect = prevSelect;
     };
@@ -400,9 +412,9 @@ export function PythonConsolePanel({
             onClick={() => setEditorVisible((v) => !v)}
           >
             {editorVisible ? (
-              <PanelLeftClose className="h-4 w-4" />
+              <PanelRightClose className="h-4 w-4" />
             ) : (
-              <PanelLeft className="h-4 w-4" />
+              <PanelRight className="h-4 w-4" />
             )}
           </Button>
           <Button
@@ -426,32 +438,7 @@ export function PythonConsolePanel({
         </div>
       </div>
 
-      <div className="flex min-h-0 flex-1">
-        {editorVisible ? (
-          <>
-            <div
-              ref={editorPaneRef}
-              className="flex min-w-0 flex-col border-r"
-              style={{ width: editorWidth }}
-            >
-              <PythonEditorPane
-                deps={deps}
-                ready={ready}
-                running={running}
-                runScript={runScript}
-                completionLabel={t("pythonConsole.completions")}
-              />
-            </div>
-            <div
-              role="separator"
-              aria-orientation="vertical"
-              aria-label={t("pythonConsole.resizeEditor")}
-              className="w-1 shrink-0 cursor-col-resize select-none bg-border hover:bg-primary"
-              onMouseDown={startEditorResize}
-            />
-          </>
-        ) : null}
-
+      <div ref={splitContainerRef} className="flex min-h-0 flex-1">
         <div className="flex min-w-0 flex-1 flex-col">
           <div
             ref={outputRef}
@@ -506,6 +493,31 @@ export function PythonConsolePanel({
             </Button>
           </div>
         </div>
+
+        {editorVisible ? (
+          <>
+            <div
+              role="separator"
+              aria-orientation="vertical"
+              aria-label={t("pythonConsole.resizeEditor")}
+              className="w-1 shrink-0 cursor-col-resize select-none bg-border hover:bg-primary"
+              onMouseDown={startEditorResize}
+            />
+            <div
+              ref={editorPaneRef}
+              className="flex min-w-0 shrink-0 grow-0 flex-col border-l"
+              style={{ flexBasis: `${editorFraction * 100}%` }}
+            >
+              <PythonEditorPane
+                deps={deps}
+                ready={ready}
+                running={running}
+                runScript={runScript}
+                completionLabel={t("pythonConsole.completions")}
+              />
+            </div>
+          </>
+        ) : null}
       </div>
     </section>
   );

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1503,6 +1503,8 @@
     "title": "Python Console",
     "resize": "Resize Python console",
     "clear": "Clear output",
+    "collapse": "Collapse Python console",
+    "expand": "Expand Python console",
     "close": "Close Python console",
     "run": "Run",
     "runHint": "Run (Ctrl/Cmd+Enter)",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -82,6 +82,7 @@
     "save": "Save",
     "cancel": "Cancel",
     "close": "Close",
+    "retry": "Retry",
     "reset": "Reset",
     "remove": "Remove",
     "add": "Add",


### PR DESCRIPTION
Fixes #776

## Problem

The issue reports the Python console showing the section error fallback ("Python console failed to render. The rest of GeoLibre is still available.") on Safari, with Retry simply looping back to the same message. The reporter also notes a concrete follow-on: **after the failure the panel cannot be closed**, because the error fallback replaces the entire panel, including its header and the close button. The only menu/toolbar entries set the console *open* (never closed), so the user is stranded.

## Changes

- **Recoverable error state.** `SectionErrorBoundary` now accepts an optional `onClose`. When provided, the fallback renders a **Close** action next to **Retry**. The Python console wires it to `setPythonConsoleOpen(false)`, so a user whose panel keeps re-throwing can dismiss it instead of being stuck on a Retry loop. This makes the failure recoverable regardless of what triggered the render error.
- **Editor on the right, even split.** The script editor now docks to the **right** of the console and defaults to an even 50/50 split. The divider position is tracked as a fraction of the panel width (instead of a fixed pixel width), so the split stays proportional as the window resizes. The show/hide toggle icon was updated to the right-panel variant to match.

## Verification

Verified in a real browser (Chrome) against the dev app, in both light and dark themes:

- Console opens and renders correctly; `>>> 1 + 1` evaluates to `2`.
- Editor appears on the right with a precise even split (measured 796px / 800px across the divider) on a fresh open.
- Dragging the divider resizes proportionally in the correct direction and respects the min/max clamps.
- Temporarily forcing the panel to throw confirmed the fallback shows both **Retry** and **Close**, and clicking **Close** dismisses the stuck panel.

`npm run test:frontend` (1468 passing) and `pre-commit run --files` (eslint + full build) are green.

## Note on the Safari-specific render crash

The underlying render crash reported on Safari could not be reproduced on Chrome or Firefox (consistent with the issue thread, where it does not occur on those browsers). Rather than guess at an engine-specific cause, this PR makes the error state fully recoverable so the user is never stranded, which directly addresses the reported "cannot close the panel" problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Python Console error messages now include a close button for easy dismissal
  * Python Console Panel supports full collapse/expand functionality with dedicated toggle buttons
  * Python Console editor pane now supports horizontal resizing with intelligent width constraints
  * Console panel state is preserved when collapsed, maintaining all editor content and history

<!-- end of auto-generated comment: release notes by coderabbit.ai -->