### PR TITLE
feat(storymap): compose chapters on the live map (#775)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -96,6 +96,7 @@ import {
 import { StylePanel } from "../panels/StylePanel";
 import { SharedSidebar } from "../panels/SharedSidebar";
 import { Layers, SlidersHorizontal } from "lucide-react";
+import { StoryMapComposeBar } from "../storymap/StoryMapComposeBar";
 import { StoryMapPanel } from "../storymap/StoryMapPanel";
 import { StoryMapPresenter } from "../storymap/StoryMapPresenter";
 import { DiagnosticsDialog } from "./DiagnosticsDialog";
@@ -1539,6 +1540,7 @@ export function DesktopShell({
               <BoundsRestrictionIndicator />
               <CollaborationStatusBadge />
               <MapModeBanner mapControllerRef={mapControllerRef} />
+              <StoryMapComposeBar mapControllerRef={mapControllerRef} />
             </MapGrid>
           </SectionErrorBoundary>
           <SectionErrorBoundary label="Plugin floating panels">

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapComposeBar.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapComposeBar.tsx
@@ -1,4 +1,4 @@
-import { type RefObject, useCallback } from "react";
+import { type RefObject, useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useAppStore } from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
@@ -40,18 +40,40 @@ export function StoryMapComposeBar({
   const handleSave = useCallback(() => {
     if (!composingId) return;
     const view = mapControllerRef.current?.readView();
-    if (view) {
-      updateChapter(composingId, {
-        location: {
-          center: view.center,
-          zoom: view.zoom,
-          pitch: view.pitch,
-          bearing: view.bearing,
-        },
-      });
-    }
+    // If the controller is somehow not ready there is nothing to capture; keep
+    // the bar open rather than silently returning to the editor unchanged.
+    if (!view) return;
+    updateChapter(composingId, {
+      location: {
+        center: view.center,
+        zoom: view.zoom,
+        pitch: view.pitch,
+        bearing: view.bearing,
+      },
+    });
     finish();
   }, [composingId, finish, mapControllerRef, updateChapter]);
+
+  // If the chapter being composed disappears (e.g. a collaborator deletes it),
+  // leave compose mode and restore the editor so the bar can't strand the user
+  // on the map with no Save/Cancel target.
+  useEffect(() => {
+    if (composingId && !chapter) {
+      setComposing(null);
+      setOpen(true);
+    }
+  }, [chapter, composingId, setComposing, setOpen]);
+
+  // Escape exits compose mode, mirroring how the presenter handles Escape, so
+  // keyboard-only users can dismiss the bar without clicking Cancel.
+  useEffect(() => {
+    if (!composingId) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") finish();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [composingId, finish]);
 
   // Bail out if compose mode is off, or if the chapter vanished (e.g. a project
   // load cleared the story) so the bar can't strand the user on the map.

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapComposeBar.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapComposeBar.tsx
@@ -1,4 +1,4 @@
-import { type RefObject, useCallback, useEffect } from "react";
+import { type RefObject, useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAppStore } from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
@@ -32,6 +32,11 @@ export function StoryMapComposeBar({
     ? storymap?.chapters.find((c) => c.id === composingId)
     : undefined;
 
+  // Disable Save while the camera is in motion. Entering compose flies to the
+  // chapter's saved view, and capturing a mid-flight camera would overwrite the
+  // intended location with an in-transit one; Save re-enables on `moveend`.
+  const [mapMoving, setMapMoving] = useState(false);
+
   const finish = useCallback(() => {
     setComposing(null);
     setOpen(true);
@@ -40,9 +45,13 @@ export function StoryMapComposeBar({
   const handleSave = useCallback(() => {
     if (!composingId) return;
     const view = mapControllerRef.current?.readView();
-    // If the controller is somehow not ready there is nothing to capture; keep
-    // the bar open rather than silently returning to the editor unchanged.
-    if (!view) return;
+    // The controller is always initialized while the bar is visible, so this is
+    // an unreachable guard; surface it in dev rather than silently no-op if the
+    // invariant ever breaks (the bar stays open so the user can retry).
+    if (!view) {
+      console.warn("[storymap] compose: map view unavailable, skipping save");
+      return;
+    }
     updateChapter(composingId, {
       location: {
         center: view.center,
@@ -58,11 +67,24 @@ export function StoryMapComposeBar({
   // leave compose mode and restore the editor so the bar can't strand the user
   // on the map with no Save/Cancel target.
   useEffect(() => {
-    if (composingId && !chapter) {
-      setComposing(null);
-      setOpen(true);
-    }
-  }, [chapter, composingId, setComposing, setOpen]);
+    if (composingId && !chapter) finish();
+  }, [chapter, composingId, finish]);
+
+  // Track camera motion so Save can disable itself mid-flight (see mapMoving).
+  useEffect(() => {
+    if (!composingId) return;
+    const map = mapControllerRef.current?.getMap();
+    if (!map) return;
+    setMapMoving(map.isMoving());
+    const onStart = () => setMapMoving(true);
+    const onEnd = () => setMapMoving(false);
+    map.on("movestart", onStart);
+    map.on("moveend", onEnd);
+    return () => {
+      map.off("movestart", onStart);
+      map.off("moveend", onEnd);
+    };
+  }, [composingId, mapControllerRef]);
 
   // Escape exits compose mode, mirroring how the presenter handles Escape, so
   // keyboard-only users can dismiss the bar without clicking Cancel.
@@ -110,7 +132,13 @@ export function StoryMapComposeBar({
             <X className="h-3.5 w-3.5" aria-hidden="true" />
             {t("storymap.composeMode.cancel")}
           </Button>
-          <Button type="button" size="sm" onClick={handleSave}>
+          <Button
+            type="button"
+            size="sm"
+            onClick={handleSave}
+            disabled={mapMoving}
+            title={mapMoving ? t("storymap.composeMode.waiting") : undefined}
+          >
             <Check className="h-3.5 w-3.5" aria-hidden="true" />
             {t("storymap.composeMode.save")}
           </Button>

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapComposeBar.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapComposeBar.tsx
@@ -1,0 +1,99 @@
+import { type RefObject, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { useAppStore } from "@geolibre/core";
+import type { MapController } from "@geolibre/map";
+import { Button } from "@geolibre/ui";
+import { Check, Frame, X } from "lucide-react";
+
+interface StoryMapComposeBarProps {
+  mapControllerRef: RefObject<MapController | null>;
+}
+
+/**
+ * Floating bar shown over the live map while a story chapter is being composed.
+ *
+ * The Story Map editor is a modal dialog whose full-screen overlay hides the
+ * map, so users could not see the camera while capturing a view. Compose mode
+ * (issue #775) closes the dialog and shows this bar instead: the user pans,
+ * zooms, and tilts the real map, then saves the resulting camera straight into
+ * the chapter and returns to the editor, or cancels to discard the changes.
+ */
+export function StoryMapComposeBar({
+  mapControllerRef,
+}: StoryMapComposeBarProps) {
+  const { t } = useTranslation();
+  const composingId = useAppStore((s) => s.ui.storymapComposingId);
+  const storymap = useAppStore((s) => s.storymap);
+  const setComposing = useAppStore((s) => s.setStorymapComposing);
+  const setOpen = useAppStore((s) => s.setStorymapPanelOpen);
+  const updateChapter = useAppStore((s) => s.updateStoryChapter);
+
+  const chapter = composingId
+    ? storymap?.chapters.find((c) => c.id === composingId)
+    : undefined;
+
+  const finish = useCallback(() => {
+    setComposing(null);
+    setOpen(true);
+  }, [setComposing, setOpen]);
+
+  const handleSave = useCallback(() => {
+    if (!composingId) return;
+    const view = mapControllerRef.current?.readView();
+    if (view) {
+      updateChapter(composingId, {
+        location: {
+          center: view.center,
+          zoom: view.zoom,
+          pitch: view.pitch,
+          bearing: view.bearing,
+        },
+      });
+    }
+    finish();
+  }, [composingId, finish, mapControllerRef, updateChapter]);
+
+  // Bail out if compose mode is off, or if the chapter vanished (e.g. a project
+  // load cleared the story) so the bar can't strand the user on the map.
+  if (!composingId || !chapter) return null;
+
+  const chapterTitle = chapter.title || t("storymap.untitledChapter");
+
+  return (
+    <div className="pointer-events-none absolute bottom-6 left-1/2 z-20 flex w-[min(92vw,34rem)] -translate-x-1/2 flex-col">
+      <div
+        className="pointer-events-auto flex flex-col gap-2 rounded-md border bg-background/95 px-3 py-2 text-sm shadow-lg backdrop-blur-sm"
+        role="region"
+        aria-label={t("storymap.composeMode.title")}
+        data-testid="storymap-compose-bar"
+      >
+        <div className="flex items-start gap-2">
+          <Frame
+            className="mt-0.5 h-4 w-4 shrink-0 text-primary"
+            aria-hidden="true"
+          />
+          <div className="min-w-0">
+            <p className="truncate font-medium">
+              {t("storymap.composeMode.title")}
+              {": "}
+              {chapterTitle}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {t("storymap.composeMode.hint")}
+            </p>
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          <Button type="button" size="sm" variant="ghost" onClick={finish}>
+            <X className="h-3.5 w-3.5" aria-hidden="true" />
+            {t("storymap.composeMode.cancel")}
+          </Button>
+          <Button type="button" size="sm" onClick={handleSave}>
+            <Check className="h-3.5 w-3.5" aria-hidden="true" />
+            {t("storymap.composeMode.save")}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
@@ -43,6 +43,7 @@ import {
   ChevronUp,
   Crosshair,
   Download,
+  Frame,
   MapPin,
   Play,
   Plus,
@@ -77,6 +78,7 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
   const open = useAppStore((s) => s.ui.storymapPanelOpen);
   const setOpen = useAppStore((s) => s.setStorymapPanelOpen);
   const setPresenting = useAppStore((s) => s.setStorymapPresenting);
+  const setComposing = useAppStore((s) => s.setStorymapComposing);
   const storymap = useAppStore((s) => s.storymap);
   const layers = useAppStore((s) => s.layers);
   const basemapStyleUrl = useAppStore((s) => s.basemapStyleUrl);
@@ -166,6 +168,19 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
       mapControllerRef.current?.flyToView(chapter.location);
     },
     [mapControllerRef],
+  );
+
+  const handleCompose = useCallback(
+    (chapter: StoryChapter) => {
+      // Reveal the live map by closing the dialog (its full-screen overlay
+      // otherwise hides the map), fly to the chapter's saved view so composing
+      // starts from where the slide currently sits, then enter compose mode.
+      // The floating compose bar takes over from here to save or cancel.
+      mapControllerRef.current?.flyToView(chapter.location);
+      setComposing(chapter.id);
+      setOpen(false);
+    },
+    [mapControllerRef, setComposing, setOpen],
   );
 
   const handlePresent = useCallback(() => {
@@ -305,7 +320,7 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button size="sm" variant="outline">
-                    <Upload className="mr-1 h-4 w-4" />
+                    <Download className="mr-1 h-4 w-4" />
                     {t("storymap.import")}
                   </Button>
                 </DropdownMenuTrigger>
@@ -321,7 +336,7 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button size="sm" variant="outline" disabled={chapters.length === 0}>
-                    <Download className="mr-1 h-4 w-4" />
+                    <Upload className="mr-1 h-4 w-4" />
                     {t("storymap.exportData")}
                   </Button>
                 </DropdownMenuTrigger>
@@ -385,6 +400,7 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
                   }
                   onCaptureView={() => handleCaptureView(chapter.id)}
                   onPreview={() => handlePreview(chapter)}
+                  onCompose={() => handleCompose(chapter)}
                 />
               ))}
             </div>
@@ -402,7 +418,7 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
               disabled={chapters.length === 0}
               onClick={() => void handleExport()}
             >
-              <Download className="mr-1 h-4 w-4" />
+              <Upload className="mr-1 h-4 w-4" />
               {t("storymap.exportHtml")}
             </Button>
             <Button
@@ -536,6 +552,7 @@ interface ChapterCardProps {
   onMove: (direction: "up" | "down") => void;
   onCaptureView: () => void;
   onPreview: () => void;
+  onCompose: () => void;
 }
 
 function ChapterCard({
@@ -551,6 +568,7 @@ function ChapterCard({
   onMove,
   onCaptureView,
   onPreview,
+  onCompose,
 }: ChapterCardProps) {
   const { center, zoom, pitch, bearing } = chapter.location;
   return (
@@ -568,6 +586,15 @@ function ChapterCard({
             {chapter.title || t("storymap.untitledChapter")}
           </span>
         </button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          title={t("storymap.composeOnMap")}
+          onClick={onCompose}
+        >
+          <Frame className="h-4 w-4" />
+        </Button>
         <Button
           variant="ghost"
           size="icon"
@@ -692,15 +719,26 @@ function ChapterCard({
                 {center[0].toFixed(4)}, {center[1].toFixed(4)} · z
                 {zoom.toFixed(1)} · p{pitch.toFixed(0)} · b{bearing.toFixed(0)}
               </span>
-              <Button
-                size="sm"
-                variant="outline"
-                className="h-7"
-                onClick={onCaptureView}
-              >
-                <Crosshair className="mr-1 h-3.5 w-3.5" />
-                {t("storymap.captureView")}
-              </Button>
+              <div className="flex items-center gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-7"
+                  onClick={onCaptureView}
+                >
+                  <Crosshair className="mr-1 h-3.5 w-3.5" />
+                  {t("storymap.captureView")}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-7"
+                  onClick={onCompose}
+                >
+                  <Frame className="mr-1 h-3.5 w-3.5" />
+                  {t("storymap.composeOnMap")}
+                </Button>
+              </div>
             </div>
           </div>
 

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
@@ -307,7 +307,15 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
           onChange={(e) => void handleImportFile(e)}
         />
 
-        <ScrollArea className="flex-1 overflow-y-auto px-5 py-4">
+        {/* Force the Radix viewport's inner wrapper to `display:block`
+            (it defaults to `display:table; min-width:100%`, which sizes to the
+            content's intrinsic width and spawns a spurious horizontal scrollbar
+            that, with the vertical one, covered the chapter action buttons —
+            #775). `!block` overrides the inline style. */}
+        <ScrollArea className="min-h-0 flex-1 [&_[data-radix-scroll-area-viewport]>div]:!block">
+          {/* Pad the content (not the ScrollArea root) so the overlay
+              scrollbar sits in the right gutter instead of over the content. */}
+          <div className="px-5 py-4">
           <StorySettings story={story} onChange={updateSettings} t={t} />
 
           <Separator className="my-4" />
@@ -320,7 +328,7 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button size="sm" variant="outline">
-                    <Download className="mr-1 h-4 w-4" />
+                    <Upload className="mr-1 h-4 w-4" />
                     {t("storymap.import")}
                   </Button>
                 </DropdownMenuTrigger>
@@ -336,7 +344,7 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button size="sm" variant="outline" disabled={chapters.length === 0}>
-                    <Upload className="mr-1 h-4 w-4" />
+                    <Download className="mr-1 h-4 w-4" />
                     {t("storymap.exportData")}
                   </Button>
                 </DropdownMenuTrigger>
@@ -405,6 +413,7 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
               ))}
             </div>
           )}
+          </div>
         </ScrollArea>
 
         <div className="flex items-center justify-between gap-2 border-t px-5 py-3">
@@ -418,7 +427,7 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
               disabled={chapters.length === 0}
               onClick={() => void handleExport()}
             >
-              <Upload className="mr-1 h-4 w-4" />
+              <Download className="mr-1 h-4 w-4" />
               {t("storymap.exportHtml")}
             </Button>
             <Button

--- a/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
+++ b/apps/geolibre-desktop/src/components/storymap/StoryMapPanel.tsx
@@ -1,4 +1,11 @@
-import { type RefObject, useCallback, useMemo, useRef, useState } from "react";
+import {
+  type RefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import {
@@ -94,6 +101,80 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
   const [exportError, setExportError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const importFormatRef = useRef<"json" | "csv">("json");
+
+  // Explicit dialog size once the user drags the bottom-right grip (null = the
+  // default responsive size). The dialog element is read for its live size.
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const [dialogSize, setDialogSize] = useState<{
+    width: number;
+    height: number;
+  } | null>(null);
+  // Tears down an in-progress resize drag (removes the window listeners and
+  // cancels the pending RAF) so it can't leak if the dialog unmounts mid-drag.
+  const resizeCleanupRef = useRef<(() => void) | null>(null);
+
+  // Resize the whole dialog from its bottom-right grip. The dialog is centred
+  // via a -50% transform, so the right/bottom edges move by half the size
+  // change; growing by 2x the pointer delta keeps the grip under the cursor.
+  const startDialogResize = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      event.currentTarget.setPointerCapture?.(event.pointerId);
+      const el = dialogRef.current;
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      const startX = event.clientX;
+      const startY = event.clientY;
+      const startW = rect.width;
+      const startH = rect.height;
+      let next = { width: startW, height: startH };
+      let frame: number | null = null;
+      const prevCursor = document.body.style.cursor;
+      const prevSelect = document.body.style.userSelect;
+      document.body.style.cursor = "nwse-resize";
+      document.body.style.userSelect = "none";
+
+      const onMove = (e: PointerEvent) => {
+        next = {
+          width: Math.max(
+            360,
+            Math.min(window.innerWidth - 16, startW + (e.clientX - startX) * 2),
+          ),
+          height: Math.max(
+            320,
+            Math.min(window.innerHeight - 16, startH + (e.clientY - startY) * 2),
+          ),
+        };
+        if (frame !== null) return;
+        frame = window.requestAnimationFrame(() => {
+          frame = null;
+          setDialogSize(next);
+        });
+      };
+      const cleanup = () => {
+        window.removeEventListener("pointermove", onMove);
+        window.removeEventListener("pointerup", onUp);
+        window.removeEventListener("pointercancel", onUp);
+        if (frame !== null) window.cancelAnimationFrame(frame);
+        document.body.style.cursor = prevCursor;
+        document.body.style.userSelect = prevSelect;
+        resizeCleanupRef.current = null;
+      };
+      const onUp = () => {
+        cleanup();
+        setDialogSize(next);
+      };
+      resizeCleanupRef.current = cleanup;
+      window.addEventListener("pointermove", onMove);
+      window.addEventListener("pointerup", onUp);
+      window.addEventListener("pointercancel", onUp);
+    },
+    [],
+  );
+
+  // Tear down an in-progress resize drag if the dialog unmounts mid-drag.
+  useEffect(() => () => resizeCleanupRef.current?.(), []);
 
   const story: StoryMap = storymap ?? DEFAULT_STORY_MAP;
   const chapters = story.chapters;
@@ -290,7 +371,39 @@ export function StoryMapPanel({ mapControllerRef }: StoryMapPanelProps) {
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogContent className="flex max-h-[88vh] w-[min(92vw,46rem)] flex-col gap-0 p-0">
+      <DialogContent
+        ref={dialogRef}
+        className="flex max-h-[88vh] w-[min(92vw,46rem)] flex-col gap-0 p-0"
+        style={
+          dialogSize
+            ? {
+                width: dialogSize.width,
+                height: dialogSize.height,
+                maxWidth: "none",
+                maxHeight: "none",
+              }
+            : undefined
+        }
+        bodyClassName="flex min-h-0 flex-1 flex-col gap-0 overflow-hidden p-0"
+        resizeHandle={
+          <div
+            role="separator"
+            aria-label={t("storymap.resizeDialog")}
+            title={t("storymap.resizeDialog")}
+            onPointerDown={startDialogResize}
+            className="absolute bottom-0 right-0 z-10 hidden h-5 w-5 cursor-nwse-resize touch-none select-none text-muted-foreground hover:text-foreground md:block"
+          >
+            <svg viewBox="0 0 16 16" className="h-full w-full" aria-hidden="true">
+              <path
+                d="M11 15L15 11M6 15L15 6"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              />
+            </svg>
+          </div>
+        }
+      >
         <DialogHeader className="border-b px-5 py-4">
           <DialogTitle className="flex items-center gap-2">
             <MapPin className="h-4 w-4" />

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1672,6 +1672,7 @@
     "preview": "Fly to this chapter",
     "captureView": "Set to current view",
     "composeOnMap": "Compose on map",
+    "resizeDialog": "Resize dialog",
     "composeMode": {
       "title": "Composing chapter",
       "hint": "Pan, zoom, and tilt the map, then save the view to this chapter.",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1676,7 +1676,8 @@
       "title": "Composing chapter",
       "hint": "Pan, zoom, and tilt the map, then save the view to this chapter.",
       "save": "Save view and return to Story Map",
-      "cancel": "Cancel"
+      "cancel": "Cancel",
+      "waiting": "Wait for the map to finish moving"
     },
     "moveUp": "Move up",
     "moveDown": "Move down",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1671,6 +1671,13 @@
     "exitPresentation": "Exit",
     "preview": "Fly to this chapter",
     "captureView": "Set to current view",
+    "composeOnMap": "Compose on map",
+    "composeMode": {
+      "title": "Composing chapter",
+      "hint": "Pan, zoom, and tilt the map, then save the view to this chapter.",
+      "save": "Save view and return to Story Map",
+      "cancel": "Cancel"
+    },
     "moveUp": "Move up",
     "moveDown": "Move down",
     "onEnter": "On enter",

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -196,6 +196,10 @@ export interface AppState {
     dashboardOpen: boolean;
     storymapPanelOpen: boolean;
     storymapPresenting: boolean;
+    // Id of the chapter currently being composed on the live map. When set, the
+    // Story Map dialog is hidden so the user can pan/zoom/tilt the real map and
+    // save the resulting camera back into this chapter (issue #775).
+    storymapComposingId: string | null;
     modelBuilderOpen: boolean;
     zoomToSelectedFeature: boolean;
     // Live-collaboration dialog visibility. Lifted into the store (rather than
@@ -272,6 +276,7 @@ export interface AppState {
   setDashboardOpen: (open: boolean) => void;
   setStorymapPanelOpen: (open: boolean) => void;
   setStorymapPresenting: (presenting: boolean) => void;
+  setStorymapComposing: (chapterId: string | null) => void;
   setModelBuilderOpen: (open: boolean) => void;
   setCollaborateDialogOpen: (open: boolean) => void;
   setZoomToSelectedFeature: (enabled: boolean) => void;
@@ -563,6 +568,7 @@ export const useAppStore = create<AppState>()(
         dashboardOpen: false,
         storymapPanelOpen: false,
         storymapPresenting: false,
+        storymapComposingId: null,
         modelBuilderOpen: false,
         zoomToSelectedFeature: false,
         collaborateDialogOpen: false,
@@ -752,6 +758,8 @@ export const useAppStore = create<AppState>()(
         set((s) => ({ ui: { ...s.ui, storymapPanelOpen: open } })),
       setStorymapPresenting: (presenting) =>
         set((s) => ({ ui: { ...s.ui, storymapPresenting: presenting } })),
+      setStorymapComposing: (chapterId) =>
+        set((s) => ({ ui: { ...s.ui, storymapComposingId: chapterId } })),
       setModelBuilderOpen: (open) =>
         set((s) => ({ ui: { ...s.ui, modelBuilderOpen: open } })),
       setCollaborateDialogOpen: (open) =>
@@ -1172,7 +1180,12 @@ export const useAppStore = create<AppState>()(
           pointerCoords: null,
           attributeFilter: "",
           // Don't carry an active story presentation into a different project.
-          ui: { ...s.ui, storymapPresenting: false, storymapPanelOpen: false },
+          ui: {
+            ...s.ui,
+            storymapPresenting: false,
+            storymapPanelOpen: false,
+            storymapComposingId: null,
+          },
         }));
         clearHistory();
       },
@@ -1199,6 +1212,7 @@ export const useAppStore = create<AppState>()(
             ...s.ui,
             storymapPresenting: presentStory,
             storymapPanelOpen: false,
+            storymapComposingId: null,
           },
         }));
         clearHistory();

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -755,7 +755,16 @@ export const useAppStore = create<AppState>()(
       setDashboardOpen: (open) =>
         set((s) => ({ ui: { ...s.ui, dashboardOpen: open } })),
       setStorymapPanelOpen: (open) =>
-        set((s) => ({ ui: { ...s.ui, storymapPanelOpen: open } })),
+        set((s) => ({
+          ui: {
+            ...s.ui,
+            storymapPanelOpen: open,
+            // Opening the editor must leave compose mode, or the menu item could
+            // re-open the dialog while the compose bar is still active over a
+            // now-hidden map (#775). Closing (entering compose) leaves it as-is.
+            ...(open ? { storymapComposingId: null } : {}),
+          },
+        })),
       setStorymapPresenting: (presenting) =>
         set((s) => ({ ui: { ...s.ui, storymapPresenting: presenting } })),
       setStorymapComposing: (chapterId) =>


### PR DESCRIPTION
## Summary

Implements the seamless Story Map authoring workflow requested in #775. The Story Map editor is a modal dialog whose full-screen overlay hides the map, so capturing a camera view meant a blind loop of open / adjust / close. This adds a **compose on map** mode so users can shape a scene on the live map and save it straight into a chapter.

## What changed

- **Compose on map (issue parts 1, 2 and 3).** Each chapter gets a "Compose on map" action: an icon in the chapter header row and a labelled button in the expanded card. Activating it flies the map to the chapter's saved view, closes the editor, and shows a floating bar over the now-visible map:
  - **Save view and return to Story Map** captures the current center, zoom, pitch, and bearing into that chapter and reopens the editor.
  - **Cancel** reopens the editor without saving.
  - Flying to the saved view on entry also covers the "quick-jump to review a scene" ask: enter compose, look around, cancel.
- **Import / Export icons (issue part 4).** Swapped so Import uses a download (arrow into tray) glyph and Export an upload (arrow out of tray) glyph, matching common convention.
- New transient store state `ui.storymapComposingId`, cleared on project load/present so compose mode can never strand the user on the map.
- New i18n strings under `storymap.*` (`composeOnMap`, `composeMode.*`).

## Notes / scope

- View capture stays camera-only (center/zoom/pitch/bearing), consistent with the existing "Set to current view" action. Per-chapter layer effects continue to be authored via the existing On enter / On exit editors rather than snapshotted here.

## Verification

Driven in the real app with Playwright using the built-in sample story, in **both light and dark themes**:

- Compose mode closes the dialog and shows the bar over a fully visible map (flew to the chapter location).
- Save captures a panned view back into the chapter (coordinate readout updated); Cancel discards the pan (readout unchanged).
- Import/Export buttons render the corrected icons.
- `npm run typecheck` (full build), `npm run test:frontend` (1475 passing), and `pre-commit` on the changed files all pass.

Fixes #775

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Compose on map” for story map chapters with a floating control bar to save or cancel.
  * Chapter cards now support entering compose mode and flying to the chapter’s saved map view.

* **UI Updates**
  * Added compose buttons to both compact and expanded chapter controls.
  * Updated story map import/export iconography to match the shown actions.

* **Behavior Improvements**
  * Press Escape to exit compose mode; compose mode ends automatically if the chapter is removed.
  * Save is disabled while the map is moving, and after cancel the editor panel is reopened.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->