### PR TITLE
feat(bookmarks): organize bookmarks into folders (#794)

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -58,7 +58,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.3",
     "maplibre-gl-basemap-control": "^0.7.0",
-    "maplibre-gl-components": "^0.23.0",
+    "maplibre-gl-components": "^0.24.0",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -58,7 +58,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.3",
     "maplibre-gl-basemap-control": "^0.7.0",
-    "maplibre-gl-components": "^0.22.9",
+    "maplibre-gl-components": "^0.23.0",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -406,6 +406,8 @@ export function DesktopShell({
       exportLabel: t("bookmark.export"),
       exportSelectedLabel: t("bookmark.exportSelected"),
       exportAllLabel: t("bookmark.exportAll"),
+      newFolderLabel: t("bookmark.newFolder"),
+      defaultFolderName: t("bookmark.defaultFolderName"),
     });
   }, [t]);
   // The map's Fullscreen control maximizes the map *canvas* (it calls

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -57,7 +57,9 @@
     "captureStateTooltip": "Applies to the bookmark you save next, not as a global setting. Leave it on to restore exactly this layer arrangement later.",
     "export": "Export",
     "exportSelected": "Export Selected",
-    "exportAll": "Export All"
+    "exportAll": "Export All",
+    "newFolder": "New Folder",
+    "defaultFolderName": "Folder"
   },
   "fileNamePrompt": {
     "title": "Save file as",

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.3",
         "maplibre-gl-basemap-control": "^0.7.0",
-        "maplibre-gl-components": "^0.23.0",
+        "maplibre-gl-components": "^0.24.0",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -187,9 +187,9 @@
       "license": "MIT"
     },
     "apps/geolibre-desktop/node_modules/maplibre-gl-components": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.23.0.tgz",
-      "integrity": "sha512-cJcH/NY9nkCTZ33JV9TiPkjQRYbpf7ref4MmSgNpVPAcHs6Zu2x3VhNe8J9oFqfp2eFzag4SXMlM3jJ661kZ9Q==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.24.0.tgz",
+      "integrity": "sha512-dRKjU+CjScITnZcJApI0k3PGvLqDMQmH9xEIdZi5PxnmhobQQ2VAyYffbHANfzaBsDCw/c4rS2Pmx/M7SRN3FQ==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",
@@ -24305,7 +24305,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.3",
         "maplibre-gl-basemap-control": "^0.7.0",
-        "maplibre-gl-components": "^0.23.0",
+        "maplibre-gl-components": "^0.24.0",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -24344,9 +24344,9 @@
       }
     },
     "packages/plugins/node_modules/maplibre-gl-components": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.23.0.tgz",
-      "integrity": "sha512-cJcH/NY9nkCTZ33JV9TiPkjQRYbpf7ref4MmSgNpVPAcHs6Zu2x3VhNe8J9oFqfp2eFzag4SXMlM3jJ661kZ9Q==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.24.0.tgz",
+      "integrity": "sha512-dRKjU+CjScITnZcJApI0k3PGvLqDMQmH9xEIdZi5PxnmhobQQ2VAyYffbHANfzaBsDCw/c4rS2Pmx/M7SRN3FQ==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.3",
         "maplibre-gl-basemap-control": "^0.7.0",
-        "maplibre-gl-components": "^0.22.9",
+        "maplibre-gl-components": "^0.23.0",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -187,9 +187,9 @@
       "license": "MIT"
     },
     "apps/geolibre-desktop/node_modules/maplibre-gl-components": {
-      "version": "0.22.9",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.22.9.tgz",
-      "integrity": "sha512-38MaKA1Hjao40SiTKsd8yXXWzQgf/2VRxDvlyZw0BL7YPtshSVVBy48neTt/5IT8HWk1EXWkPdioaXgozNFghQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.23.0.tgz",
+      "integrity": "sha512-cJcH/NY9nkCTZ33JV9TiPkjQRYbpf7ref4MmSgNpVPAcHs6Zu2x3VhNe8J9oFqfp2eFzag4SXMlM3jJ661kZ9Q==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",
@@ -24305,7 +24305,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.3",
         "maplibre-gl-basemap-control": "^0.7.0",
-        "maplibre-gl-components": "^0.22.9",
+        "maplibre-gl-components": "^0.23.0",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -24344,9 +24344,9 @@
       }
     },
     "packages/plugins/node_modules/maplibre-gl-components": {
-      "version": "0.22.9",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.22.9.tgz",
-      "integrity": "sha512-38MaKA1Hjao40SiTKsd8yXXWzQgf/2VRxDvlyZw0BL7YPtshSVVBy48neTt/5IT8HWk1EXWkPdioaXgozNFghQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.23.0.tgz",
+      "integrity": "sha512-cJcH/NY9nkCTZ33JV9TiPkjQRYbpf7ref4MmSgNpVPAcHs6Zu2x3VhNe8J9oFqfp2eFzag4SXMlM3jJ661kZ9Q==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -32,7 +32,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.3",
     "maplibre-gl-basemap-control": "^0.7.0",
-    "maplibre-gl-components": "^0.22.9",
+    "maplibre-gl-components": "^0.23.0",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -32,7 +32,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.3",
     "maplibre-gl-basemap-control": "^0.7.0",
-    "maplibre-gl-components": "^0.23.0",
+    "maplibre-gl-components": "^0.24.0",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -308,6 +308,8 @@ const bookmarkLabels = {
   exportLabel: "Export",
   exportSelectedLabel: "Export Selected",
   exportAllLabel: "Export All",
+  newFolderLabel: "New Folder",
+  defaultFolderName: "Folder",
 };
 
 /** Override the BookmarkControl labels with translated text. */
@@ -388,6 +390,11 @@ const BOOKMARK_OPTIONS = {
   // (issue #794), and drop the low-value zoom/date metadata from each card.
   showExportAll: true,
   showMetadata: false,
+  // Let users organize bookmarks into folders, mirroring the Layers panel's
+  // groups: create a folder, drag bookmarks in/out, expand/collapse (issue
+  // #794). Folder labels are applied per-instance in createBookmarkControl so
+  // they pick up the translated strings.
+  groupable: true,
   captureState: captureVisibleLayers,
   restoreState: restoreVisibleLayers,
 } satisfies BookmarkControlOptions;
@@ -2752,6 +2759,8 @@ function createBookmarkControl(
     exportLabel: bookmarkLabels.exportLabel,
     exportSelectedLabel: bookmarkLabels.exportSelectedLabel,
     exportAllLabel: bookmarkLabels.exportAllLabel,
+    newFolderLabel: bookmarkLabels.newFolderLabel,
+    defaultFolderName: bookmarkLabels.defaultFolderName,
   });
   routeBookmarkFileIoThroughHost(control, app);
   return control;


### PR DESCRIPTION
## Summary

Two improvements to the Bookmarks panel:

1. **Folders / grouping (issue #794, Part 6).** Users can organize saved views into folders, the same way the Layers panel organizes layers into groups: a **New Folder** button, drag a bookmark in (drop on the folder header) or out (drop on an ungrouped bookmark), rename/delete folders, and expand/collapse them. Folders persist alongside bookmarks (localStorage).
2. **Resizable panel with two bottom-corner grips.** The panel now resizes from **bottom-left and bottom-right** corner grips (replacing the single CSS resize grip), matching the data/HTML-GUI panels. The footer stays pinned.

## How it works

The bookmark panel is provided by the upstream `maplibre-gl-components` `BookmarkControl`. Both features were added there:
- Folder grouping behind an opt-in `groupable` option (opengeos/maplibre-gl-components#112).
- Bottom-corner resize grips, reusing the shared `addPanelResizeHandles` utility (opengeos/maplibre-gl-components#113).

This PR bumps `maplibre-gl-components` to **`^0.24.0`** in `apps/geolibre-desktop` and `packages/plugins` (0.24.0 is cumulative and carries both features), enables `groupable: true` in `BOOKMARK_OPTIONS`, and wires the translated `New Folder` / default folder-name labels through `setBookmarkLabels` and `en.json`. The resize grips need no GeoLibre wiring (the panel is resizable by default).

## Verification

Verified end to end in the real app with Playwright in **both light and dark themes**:
- Folders: created a folder, renamed inline, dragged a bookmark in, collapsed/expanded, confirmed it persists across reload.
- Resize: dragged each bottom-corner grip to resize the panel, confirmed min-width clamping and that the footer stays pinned, and that folder drag-and-drop still works alongside the grips.
- Import/Export: exercised **Export All** and **Export Selected** after the bump; no `BookmarkControl: _exportToFile/_importFromFile not found` warning, so the Tauri-aware override is still active. The private `_exportToFile`/`_importFromFile` members and the `exportBookmarks(mode)` overload are unchanged in 0.24.0.

0 console errors. `npm run build` and `pre-commit` pass.

Fixes #794