### PR TITLE
feat(collab): per-participant permissions and in-app chat (#754)

### DIFF
--- a/apps/geolibre-desktop/src/components/common/error-boundaries.tsx
+++ b/apps/geolibre-desktop/src/components/common/error-boundaries.tsx
@@ -127,6 +127,29 @@ export function SectionErrorBoundary({
   );
 }
 
+/**
+ * Boundary for a non-essential overlay (e.g. a badge floating over the map): on
+ * error it renders nothing rather than a visible fallback, but still reports to
+ * diagnostics. Use it so a faulty overlay can never take down the surrounding
+ * UI it shares a subtree with.
+ */
+export function SilentErrorBoundary({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <ErrorBoundary
+      onError={(error, info) => reportBoundaryError(label, error, info)}
+      fallback={() => null}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}
+
 function SectionErrorFallback({
   label,
   reset,

--- a/apps/geolibre-desktop/src/components/layout/CollaborateDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/CollaborateDialog.tsx
@@ -10,11 +10,21 @@ import {
   Label,
   Select,
 } from "@geolibre/ui";
-import { ArrowRight, Check, Copy, Loader2, LogOut, Users } from "lucide-react";
+import {
+  ArrowRight,
+  Check,
+  Copy,
+  Eye,
+  Loader2,
+  LogOut,
+  Pencil,
+  Users,
+} from "lucide-react";
 import { QRCodeSVG } from "qrcode.react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { CollaborationApi } from "../../hooks/useCollaboration";
+import { participantCanEdit } from "../../lib/collab-protocol";
 
 // A small fixed palette so participant colors stay distinct and legible. Each
 // entry pairs a hex value with a human-readable name for the swatch aria-label.
@@ -186,6 +196,7 @@ export function CollaborateDialog({
             onLeave={handleLeave}
             onDismiss={() => onOpenChange(false)}
             onSetMode={api.setMode}
+            onSetParticipantMode={api.setParticipantMode}
             onSetFollowHost={api.setFollowHost}
           />
         ) : (
@@ -371,6 +382,7 @@ function ActiveSession({
   onLeave,
   onDismiss,
   onSetMode,
+  onSetParticipantMode,
   onSetFollowHost,
 }: {
   shareLink: string;
@@ -379,6 +391,7 @@ function ActiveSession({
   onLeave: () => void;
   onDismiss: () => void;
   onSetMode: (mode: CollaborationMode) => void;
+  onSetParticipantMode: (clientId: string, canEdit: boolean) => void;
   onSetFollowHost: (enabled: boolean) => void;
 }) {
   const { t } = useTranslation();
@@ -482,25 +495,69 @@ function ActiveSession({
           count: collaboration.participants.length,
         })}</Label>
         <ul className="space-y-1">
-          {collaboration.participants.map((p) => (
-            <li key={p.clientId} className="flex items-center gap-2 text-sm">
-              <span
-                className="h-3 w-3 shrink-0 rounded-full"
-                style={{ backgroundColor: p.color }}
-              />
-              <span className="truncate">{p.displayName}</span>
-              {p.clientId === collaboration.clientId && (
-                <span className="text-xs text-muted-foreground">
-                  ({t("collaborate.you")})
-                </span>
-              )}
-              {p.role === "host" && (
-                <span className="rounded bg-muted px-1.5 py-0.5 text-xs">
-                  {t("collaborate.host")}
-                </span>
-              )}
-            </li>
-          ))}
+          {collaboration.participants.map((p) => {
+            const editable = participantCanEdit(p, collaboration.mode);
+            // The host can pin any guest (not themselves) to view-only / edit.
+            const showToggle = isHost && p.role !== "host";
+            return (
+              <li key={p.clientId} className="flex items-center gap-2 text-sm">
+                <span
+                  className="h-3 w-3 shrink-0 rounded-full"
+                  style={{ backgroundColor: p.color }}
+                />
+                <span className="truncate">{p.displayName}</span>
+                {p.clientId === collaboration.clientId && (
+                  <span className="text-xs text-muted-foreground">
+                    ({t("collaborate.you")})
+                  </span>
+                )}
+                {p.role === "host" && (
+                  <span className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                    {t("collaborate.host")}
+                  </span>
+                )}
+                {showToggle ? (
+                  <button
+                    type="button"
+                    onClick={() => onSetParticipantMode(p.clientId, !editable)}
+                    aria-pressed={editable}
+                    title={
+                      editable
+                        ? t("collaborate.setViewOnly")
+                        : t("collaborate.allowEdit")
+                    }
+                    className="ml-auto flex items-center gap-1 rounded border px-1.5 py-0.5 text-xs text-muted-foreground transition hover:bg-accent hover:text-foreground"
+                  >
+                    {editable ? (
+                      <>
+                        <Pencil className="h-3 w-3" aria-hidden="true" />
+                        {t("collaborate.canEdit")}
+                      </>
+                    ) : (
+                      <>
+                        <Eye className="h-3 w-3" aria-hidden="true" />
+                        {t("collaborate.viewOnly")}
+                      </>
+                    )}
+                  </button>
+                ) : (
+                  // Non-host viewers still see each guest's current permission.
+                  p.role !== "host" && (
+                    <span className="ml-auto flex items-center gap-1 text-xs text-muted-foreground">
+                      {editable ? (
+                        <Pencil className="h-3 w-3" aria-hidden="true" />
+                      ) : (
+                        <Eye className="h-3 w-3" aria-hidden="true" />
+                      )}
+                      {editable
+                        ? t("collaborate.canEdit")
+                        : t("collaborate.viewOnly")}
+                    </span>
+                  )
+                )}
+              </li>
+            );
+          })}
         </ul>
       </div>
 

--- a/apps/geolibre-desktop/src/components/layout/CollaborateDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/CollaborateDialog.tsx
@@ -10,21 +10,12 @@ import {
   Label,
   Select,
 } from "@geolibre/ui";
-import {
-  ArrowRight,
-  Check,
-  Copy,
-  Eye,
-  Loader2,
-  LogOut,
-  Pencil,
-  Users,
-} from "lucide-react";
+import { ArrowRight, Check, Copy, Loader2, LogOut, Users } from "lucide-react";
 import { QRCodeSVG } from "qrcode.react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { CollaborationApi } from "../../hooks/useCollaboration";
-import { participantCanEdit } from "../../lib/collab-protocol";
+import { CollaborationParticipantRow } from "./CollaborationParticipantRow";
 
 // A small fixed palette so participant colors stay distinct and legible. Each
 // entry pairs a hex value with a human-readable name for the swatch aria-label.
@@ -495,69 +486,16 @@ function ActiveSession({
           count: collaboration.participants.length,
         })}</Label>
         <ul className="space-y-1">
-          {collaboration.participants.map((p) => {
-            const editable = participantCanEdit(p, collaboration.mode);
-            // The host can pin any guest (not themselves) to view-only / edit.
-            const showToggle = isHost && p.role !== "host";
-            return (
-              <li key={p.clientId} className="flex items-center gap-2 text-sm">
-                <span
-                  className="h-3 w-3 shrink-0 rounded-full"
-                  style={{ backgroundColor: p.color }}
-                />
-                <span className="truncate">{p.displayName}</span>
-                {p.clientId === collaboration.clientId && (
-                  <span className="text-xs text-muted-foreground">
-                    ({t("collaborate.you")})
-                  </span>
-                )}
-                {p.role === "host" && (
-                  <span className="rounded bg-muted px-1.5 py-0.5 text-xs">
-                    {t("collaborate.host")}
-                  </span>
-                )}
-                {showToggle ? (
-                  <button
-                    type="button"
-                    onClick={() => onSetParticipantMode(p.clientId, !editable)}
-                    aria-pressed={editable}
-                    title={
-                      editable
-                        ? t("collaborate.setViewOnly")
-                        : t("collaborate.allowEdit")
-                    }
-                    className="ml-auto flex items-center gap-1 rounded border px-1.5 py-0.5 text-xs text-muted-foreground transition hover:bg-accent hover:text-foreground"
-                  >
-                    {editable ? (
-                      <>
-                        <Pencil className="h-3 w-3" aria-hidden="true" />
-                        {t("collaborate.canEdit")}
-                      </>
-                    ) : (
-                      <>
-                        <Eye className="h-3 w-3" aria-hidden="true" />
-                        {t("collaborate.viewOnly")}
-                      </>
-                    )}
-                  </button>
-                ) : (
-                  // Non-host viewers still see each guest's current permission.
-                  p.role !== "host" && (
-                    <span className="ml-auto flex items-center gap-1 text-xs text-muted-foreground">
-                      {editable ? (
-                        <Pencil className="h-3 w-3" aria-hidden="true" />
-                      ) : (
-                        <Eye className="h-3 w-3" aria-hidden="true" />
-                      )}
-                      {editable
-                        ? t("collaborate.canEdit")
-                        : t("collaborate.viewOnly")}
-                    </span>
-                  )
-                )}
-              </li>
-            );
-          })}
+          {collaboration.participants.map((p) => (
+            <CollaborationParticipantRow
+              key={p.clientId}
+              participant={p}
+              mode={collaboration.mode}
+              isSelf={p.clientId === collaboration.clientId}
+              canManage={isHost}
+              onSetParticipantMode={onSetParticipantMode}
+            />
+          ))}
         </ul>
       </div>
 

--- a/apps/geolibre-desktop/src/components/layout/CollaborationParticipantRow.tsx
+++ b/apps/geolibre-desktop/src/components/layout/CollaborationParticipantRow.tsx
@@ -72,7 +72,10 @@ export function CollaborationParticipantRow({
           <button
             type="button"
             onClick={() => onSetParticipantMode(p.clientId, !editable)}
-            aria-pressed={editable}
+            // A binary "can edit" vs "view-only" setting reads as a switch to
+            // assistive tech, rather than a momentary press (aria-pressed).
+            role="switch"
+            aria-checked={editable}
             title={
               editable
                 ? t("collaborate.setViewOnly")

--- a/apps/geolibre-desktop/src/components/layout/CollaborationParticipantRow.tsx
+++ b/apps/geolibre-desktop/src/components/layout/CollaborationParticipantRow.tsx
@@ -1,0 +1,97 @@
+import type { CollaborationMode, CollaborationParticipant } from "@geolibre/core";
+import { Eye, Pencil } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { participantCanEdit } from "../../lib/collab-protocol";
+
+interface CollaborationParticipantRowProps {
+  participant: CollaborationParticipant;
+  /** Current session mode, used to derive effective edit permission. */
+  mode: CollaborationMode;
+  /** True when this row is the local user (adds a "(you)" tag). */
+  isSelf: boolean;
+  /** True when the viewer is the host and may change this participant's
+   *  permission. A toggle button replaces the read-only indicator. The host's
+   *  own row never shows a control. */
+  canManage: boolean;
+  onSetParticipantMode: (clientId: string, canEdit: boolean) => void;
+  /** Render the smaller variant used in the on-canvas badge roster. */
+  compact?: boolean;
+}
+
+/**
+ * One participant row shared by the Collaborate dialog roster and the on-canvas
+ * status-badge roster (#754): color swatch, name, "you" / host tags, and either
+ * a host-only per-participant permission toggle or a read-only permission
+ * indicator. `compact` selects the badge's tighter sizing.
+ */
+export function CollaborationParticipantRow({
+  participant: p,
+  mode,
+  isSelf,
+  canManage,
+  onSetParticipantMode,
+  compact = false,
+}: CollaborationParticipantRowProps) {
+  const { t } = useTranslation();
+  const editable = participantCanEdit(p, mode);
+  const isHostRow = p.role === "host";
+  // The host can pin any guest (never themselves) to view-only / edit.
+  const showToggle = canManage && !isHostRow;
+  const permIcon = editable ? (
+    <Pencil className="h-3 w-3" aria-hidden="true" />
+  ) : (
+    <Eye className="h-3 w-3" aria-hidden="true" />
+  );
+  const permLabel = editable
+    ? t("collaborate.canEdit")
+    : t("collaborate.viewOnly");
+
+  return (
+    <li
+      className={`flex items-center gap-2 ${compact ? "text-xs" : "text-sm"}`}
+    >
+      <span
+        className={`${compact ? "h-2.5 w-2.5" : "h-3 w-3"} shrink-0 rounded-full`}
+        style={{ backgroundColor: p.color }}
+      />
+      <span className="truncate">{p.displayName}</span>
+      {isSelf && (
+        <span className="text-xs text-muted-foreground">
+          ({t("collaborate.you")})
+        </span>
+      )}
+      {isHostRow && (
+        <span
+          className={`rounded bg-muted py-0.5 ${compact ? "px-1 text-[10px]" : "px-1.5 text-xs"}`}
+        >
+          {t("collaborate.host")}
+        </span>
+      )}
+      {!isHostRow &&
+        (showToggle ? (
+          <button
+            type="button"
+            onClick={() => onSetParticipantMode(p.clientId, !editable)}
+            aria-pressed={editable}
+            title={
+              editable
+                ? t("collaborate.setViewOnly")
+                : t("collaborate.allowEdit")
+            }
+            className={`ml-auto flex shrink-0 items-center gap-1 rounded border py-0.5 text-muted-foreground transition hover:bg-accent hover:text-foreground ${compact ? "px-1 text-[10px]" : "px-1.5 text-xs"}`}
+          >
+            {permIcon}
+            {permLabel}
+          </button>
+        ) : (
+          // Non-host viewers still see each guest's current permission.
+          <span
+            className={`ml-auto flex shrink-0 items-center gap-1 text-muted-foreground ${compact ? "text-[10px]" : "text-xs"}`}
+          >
+            {permIcon}
+            {permLabel}
+          </span>
+        ))}
+    </li>
+  );
+}

--- a/apps/geolibre-desktop/src/components/layout/CollaborationStatusBadge.tsx
+++ b/apps/geolibre-desktop/src/components/layout/CollaborationStatusBadge.tsx
@@ -1,12 +1,30 @@
 import { useAppStore } from "@geolibre/core";
-import { Button } from "@geolibre/ui";
-import { ChevronUp, Settings2, Users, X } from "lucide-react";
+import { Button, Input } from "@geolibre/ui";
+import type { MapController } from "@geolibre/map";
+import {
+  ChevronUp,
+  Eye,
+  MapPin,
+  Pencil,
+  Send,
+  Settings2,
+  Users,
+  X,
+} from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import type { RefObject } from "react";
+import type { CollaborationApi } from "../../hooks/useCollaboration";
+import { participantCanEdit } from "../../lib/collab-protocol";
 
 interface Announcement {
   id: number;
   text: string;
+}
+
+interface CollaborationStatusBadgeProps {
+  api: CollaborationApi;
+  mapControllerRef: RefObject<MapController | null>;
 }
 
 // How long a join/leave announcement stays on screen before auto-dismissing.
@@ -27,7 +45,10 @@ const ANNOUNCEMENT_TTL_MS = 5000;
  * above the MapLibre scale control (and the bounds-restriction badge when it is
  * showing); the roster and announcements grow upward from the collapsed pill.
  */
-export function CollaborationStatusBadge() {
+export function CollaborationStatusBadge({
+  api,
+  mapControllerRef,
+}: CollaborationStatusBadgeProps) {
   const { t } = useTranslation();
   // Narrow selectors rather than the whole `collaboration` slice: remote cursor
   // presence updates that slice many times per second, and subscribing to the
@@ -41,6 +62,12 @@ export function CollaborationStatusBadge() {
   // me" and announces the local user joining. Server client ids are UUIDs, so
   // "" can never collide with a real participant.
   const selfId = useAppStore((s) => s.collaboration.clientId) ?? "";
+  // Narrow selectors (see above): role/mode gate the host-only permission
+  // toggles; chat drives the message drawer. None update on cursor moves.
+  const role = useAppStore((s) => s.collaboration.role);
+  const mode = useAppStore((s) => s.collaboration.mode);
+  const chat = useAppStore((s) => s.collaboration.chat);
+  const isHost = role === "host";
   const setCollaborateDialogOpen = useAppStore(
     (s) => s.setCollaborateDialogOpen,
   );
@@ -51,6 +78,16 @@ export function CollaborationStatusBadge() {
 
   const [expanded, setExpanded] = useState(false);
   const [announcements, setAnnouncements] = useState<Announcement[]>([]);
+  // Chat composer: the draft text and whether to attach the current map center
+  // (#754, Part 4). The pin captures the center at send time, not toggle time.
+  const [draft, setDraft] = useState("");
+  const [attachLocation, setAttachLocation] = useState(false);
+  // The scroll viewport for the message list, so new messages pin to the bottom.
+  const chatScrollRef = useRef<HTMLDivElement | null>(null);
+  // Unread chat count while the roster is collapsed, surfaced on the pill so a
+  // working host notices new messages without keeping the panel open.
+  const [unread, setUnread] = useState(0);
+  const lastSeenChatRef = useRef(0);
   // The participant set from the previous update, so we can diff join/leave.
   // Seeded on first activation so existing members (and self) aren't announced
   // as fresh arrivals when the dialog first connects.
@@ -81,6 +118,11 @@ export function CollaborationStatusBadge() {
       knownRef.current = null;
       setExpanded(false);
       setAnnouncements([]);
+      // Reset the chat composer so a fresh session starts clean.
+      setDraft("");
+      setAttachLocation(false);
+      setUnread(0);
+      lastSeenChatRef.current = 0;
       return;
     }
     const current = new Map(
@@ -143,6 +185,48 @@ export function CollaborationStatusBadge() {
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [expanded]);
 
+  // Track unread chat while the panel is collapsed; clear it (and remember the
+  // current length) whenever the panel is open, so the badge counts only
+  // messages that arrived while the host wasn't looking.
+  useEffect(() => {
+    if (!isActive) return;
+    if (expanded) {
+      lastSeenChatRef.current = chat.length;
+      setUnread(0);
+      return;
+    }
+    setUnread(Math.max(0, chat.length - lastSeenChatRef.current));
+  }, [isActive, expanded, chat.length]);
+
+  // Keep the message list pinned to the latest message while the panel is open.
+  useEffect(() => {
+    if (!expanded) return;
+    const el = chatScrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [expanded, chat.length]);
+
+  const handleSendChat = () => {
+    const text = draft.trim();
+    if (!text) return;
+    // Capture the live map center only when the pin is active, at send time.
+    const center =
+      attachLocation && mapControllerRef.current
+        ? mapControllerRef.current.getMap()?.getCenter()
+        : null;
+    api.sendChat(
+      text,
+      center ? { lng: center.lng, lat: center.lat } : null,
+    );
+    setDraft("");
+    setAttachLocation(false);
+  };
+
+  const flyToCoordinate = (coordinate: { lng: number; lat: number }) => {
+    mapControllerRef.current
+      ?.getMap()
+      ?.flyTo({ center: [coordinate.lng, coordinate.lat] });
+  };
+
   if (!isActive) return null;
 
   return (
@@ -196,30 +280,163 @@ export function CollaborationStatusBadge() {
               <X className="h-3.5 w-3.5" />
             </button>
           </div>
-          <ul className="max-h-48 space-y-1 overflow-y-auto p-2">
-            {participants.map((p) => (
-              <li
-                key={p.clientId}
-                className="flex items-center gap-2 text-xs"
-              >
-                <span
-                  className="h-2.5 w-2.5 shrink-0 rounded-full"
-                  style={{ backgroundColor: p.color }}
-                />
-                <span className="truncate">{p.displayName}</span>
-                {p.clientId === selfId && (
-                  <span className="text-muted-foreground">
-                    ({t("collaborate.you")})
-                  </span>
-                )}
-                {p.role === "host" && (
-                  <span className="rounded bg-muted px-1 py-0.5 text-[10px]">
-                    {t("collaborate.host")}
-                  </span>
-                )}
-              </li>
-            ))}
+          <ul className="max-h-40 space-y-1 overflow-y-auto p-2">
+            {participants.map((p) => {
+              const editable = participantCanEdit(p, mode);
+              // The host can pin any guest (not themselves) to view-only / edit.
+              const showToggle = isHost && p.role !== "host";
+              return (
+                <li
+                  key={p.clientId}
+                  className="flex items-center gap-2 text-xs"
+                >
+                  <span
+                    className="h-2.5 w-2.5 shrink-0 rounded-full"
+                    style={{ backgroundColor: p.color }}
+                  />
+                  <span className="truncate">{p.displayName}</span>
+                  {p.clientId === selfId && (
+                    <span className="text-muted-foreground">
+                      ({t("collaborate.you")})
+                    </span>
+                  )}
+                  {p.role === "host" && (
+                    <span className="rounded bg-muted px-1 py-0.5 text-[10px]">
+                      {t("collaborate.host")}
+                    </span>
+                  )}
+                  {showToggle ? (
+                    <button
+                      type="button"
+                      onClick={() =>
+                        api.setParticipantMode(p.clientId, !editable)
+                      }
+                      aria-pressed={editable}
+                      title={
+                        editable
+                          ? t("collaborate.setViewOnly")
+                          : t("collaborate.allowEdit")
+                      }
+                      className="ml-auto flex shrink-0 items-center gap-1 rounded border px-1 py-0.5 text-[10px] text-muted-foreground transition hover:bg-accent hover:text-foreground"
+                    >
+                      {editable ? (
+                        <Pencil className="h-3 w-3" aria-hidden="true" />
+                      ) : (
+                        <Eye className="h-3 w-3" aria-hidden="true" />
+                      )}
+                      {editable
+                        ? t("collaborate.canEdit")
+                        : t("collaborate.viewOnly")}
+                    </button>
+                  ) : (
+                    p.role !== "host" && (
+                      <span className="ml-auto flex shrink-0 items-center gap-1 text-[10px] text-muted-foreground">
+                        {editable ? (
+                          <Pencil className="h-3 w-3" aria-hidden="true" />
+                        ) : (
+                          <Eye className="h-3 w-3" aria-hidden="true" />
+                        )}
+                        {editable
+                          ? t("collaborate.canEdit")
+                          : t("collaborate.viewOnly")}
+                      </span>
+                    )
+                  )}
+                </li>
+              );
+            })}
           </ul>
+
+          {/* Chat drawer (#754, Part 4): a lightweight text channel with an
+              optional attached map coordinate that recenters on click. */}
+          <div className="flex flex-col border-t">
+            <div
+              ref={chatScrollRef}
+              className="flex max-h-40 min-h-[3rem] flex-col gap-1.5 overflow-y-auto p-2"
+              role="log"
+              aria-label={t("collaborate.chatLog")}
+            >
+              {chat.length === 0 ? (
+                <p className="px-1 py-2 text-center text-[11px] text-muted-foreground">
+                  {t("collaborate.chatEmpty")}
+                </p>
+              ) : (
+                chat.map((m) => (
+                  <div key={m.id} className="flex flex-col gap-0.5 text-xs">
+                    <div className="flex items-baseline gap-1.5">
+                      <span
+                        className="truncate font-medium"
+                        style={{ color: m.color }}
+                      >
+                        {m.clientId === selfId
+                          ? t("collaborate.you")
+                          : m.displayName}
+                      </span>
+                    </div>
+                    <p className="whitespace-pre-wrap break-words text-foreground">
+                      {m.text}
+                    </p>
+                    {m.coordinate && (
+                      <button
+                        type="button"
+                        onClick={() => flyToCoordinate(m.coordinate!)}
+                        className="flex w-fit items-center gap-1 rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground transition hover:bg-accent hover:text-foreground"
+                        title={t("collaborate.chatGoToLocation")}
+                      >
+                        <MapPin className="h-3 w-3" aria-hidden="true" />
+                        {m.coordinate.lat.toFixed(4)},{" "}
+                        {m.coordinate.lng.toFixed(4)}
+                      </button>
+                    )}
+                  </div>
+                ))
+              )}
+            </div>
+            <div className="flex items-center gap-1 border-t p-1.5">
+              <button
+                type="button"
+                onClick={() => setAttachLocation((v) => !v)}
+                aria-pressed={attachLocation}
+                title={
+                  attachLocation
+                    ? t("collaborate.chatLocationAttached")
+                    : t("collaborate.chatAttachLocation")
+                }
+                className={`flex shrink-0 items-center rounded p-1.5 transition ${
+                  attachLocation
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:bg-accent hover:text-foreground"
+                }`}
+              >
+                <MapPin className="h-3.5 w-3.5" aria-hidden="true" />
+              </button>
+              <Input
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    handleSendChat();
+                  }
+                }}
+                placeholder={t("collaborate.chatPlaceholder")}
+                maxLength={2000}
+                aria-label={t("collaborate.chatLog")}
+                className="h-8 text-xs"
+              />
+              <Button
+                type="button"
+                size="sm"
+                className="h-8 shrink-0 px-2"
+                disabled={!draft.trim()}
+                onClick={handleSendChat}
+                aria-label={t("collaborate.chatSend")}
+              >
+                <Send className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+          </div>
+
           <div className="border-t p-2">
             <Button
               type="button"
@@ -248,11 +465,15 @@ export function CollaborationStatusBadge() {
         // Only reference the roster while it is mounted (it is conditionally
         // rendered when collapsed), so the id target always exists.
         aria-controls={expanded ? "collab-roster-panel" : undefined}
-        // Describe the action the click performs, which flips with state.
+        // Describe the action the click performs, which flips with state. When
+        // collapsed with unread chat, fold the count into the label so it is
+        // announced rather than conveyed by the badge color alone.
         aria-label={
           expanded
             ? t("collaborate.collapseRoster")
-            : t("collaborate.sessionStatusTooltip")
+            : unread > 0
+              ? t("collaborate.sessionStatusUnread", { count: unread })
+              : t("collaborate.sessionStatusTooltip")
         }
         title={
           expanded
@@ -273,6 +494,13 @@ export function CollaborationStatusBadge() {
         </span>
         <Users className="h-3.5 w-3.5" aria-hidden="true" />
         <span>{participants.length}</span>
+        {/* Unread-chat count while collapsed, so a working host sees new
+            messages without keeping the panel open. */}
+        {!expanded && unread > 0 && (
+          <span className="flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold text-primary-foreground">
+            {unread > 99 ? "99+" : unread}
+          </span>
+        )}
         {/* The roster grows upward above the pill: point up when collapsed
             ("reveal above"), down when expanded ("collapse"). */}
         <ChevronUp

--- a/apps/geolibre-desktop/src/components/layout/CollaborationStatusBadge.tsx
+++ b/apps/geolibre-desktop/src/components/layout/CollaborationStatusBadge.tsx
@@ -421,7 +421,7 @@ export function CollaborationStatusBadge({
                 }}
                 placeholder={t("collaborate.chatPlaceholder")}
                 maxLength={2000}
-                aria-label={t("collaborate.chatLog")}
+                aria-label={t("collaborate.chatCompose")}
                 className="h-8 text-xs"
               />
               <Button

--- a/apps/geolibre-desktop/src/components/layout/CollaborationStatusBadge.tsx
+++ b/apps/geolibre-desktop/src/components/layout/CollaborationStatusBadge.tsx
@@ -80,7 +80,11 @@ export function CollaborationStatusBadge({
   // the last-seen message id (not the array length): the store keeps a bounded
   // tail, so once it is full new messages arrive without changing the length.
   const [unread, setUnread] = useState(0);
-  const lastSeenChatIdRef = useRef<string | null>(null);
+  // `undefined` = not yet initialised for this session; `null` = initialised
+  // against an empty chat. These must be distinct so the very first message in
+  // an empty session is still counted as unread (a single `null` sentinel would
+  // re-seed on that first message and swallow it).
+  const lastSeenChatIdRef = useRef<string | null | undefined>(undefined);
   // The participant set from the previous update, so we can diff join/leave.
   // Seeded on first activation so existing members (and self) aren't announced
   // as fresh arrivals when the dialog first connects.
@@ -115,7 +119,7 @@ export function CollaborationStatusBadge({
       setDraft("");
       setAttachLocation(false);
       setUnread(0);
-      lastSeenChatIdRef.current = null;
+      lastSeenChatIdRef.current = undefined;
       return;
     }
     const current = new Map(
@@ -188,7 +192,7 @@ export function CollaborationStatusBadge({
   // render of a session seeds the baseline so welcome history isn't unread.
   useEffect(() => {
     if (!isActive) return;
-    if (expanded || lastSeenChatIdRef.current === null) {
+    if (expanded || lastSeenChatIdRef.current === undefined) {
       lastSeenChatIdRef.current = lastMessageId;
       setUnread(0);
       return;

--- a/apps/geolibre-desktop/src/components/layout/CollaborationStatusBadge.tsx
+++ b/apps/geolibre-desktop/src/components/layout/CollaborationStatusBadge.tsx
@@ -57,7 +57,10 @@ export function CollaborationStatusBadge({
   // toggles; chat drives the message drawer. None update on cursor moves.
   const role = useAppStore((s) => s.collaboration.role);
   const mode = useAppStore((s) => s.collaboration.mode);
-  const chat = useAppStore((s) => s.collaboration.chat);
+  // Default to [] defensively: a relay that predates the chat protocol can send
+  // a `welcome` without `chat`, and an undefined slice would crash this badge
+  // (and, since it renders inside the map's error boundary, the whole map).
+  const chat = useAppStore((s) => s.collaboration.chat) ?? [];
   const isHost = role === "host";
   const setCollaborateDialogOpen = useAppStore(
     (s) => s.setCollaborateDialogOpen,

--- a/apps/geolibre-desktop/src/components/layout/CollaborationStatusBadge.tsx
+++ b/apps/geolibre-desktop/src/components/layout/CollaborationStatusBadge.tsx
@@ -1,21 +1,12 @@
 import { useAppStore } from "@geolibre/core";
 import { Button, Input } from "@geolibre/ui";
 import type { MapController } from "@geolibre/map";
-import {
-  ChevronUp,
-  Eye,
-  MapPin,
-  Pencil,
-  Send,
-  Settings2,
-  Users,
-  X,
-} from "lucide-react";
+import { ChevronUp, MapPin, Send, Settings2, Users, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { RefObject } from "react";
 import type { CollaborationApi } from "../../hooks/useCollaboration";
-import { participantCanEdit } from "../../lib/collab-protocol";
+import { CollaborationParticipantRow } from "./CollaborationParticipantRow";
 
 interface Announcement {
   id: number;
@@ -209,10 +200,22 @@ export function CollaborationStatusBadge({
   }, [isActive, expanded, lastMessageId, chat]);
 
   // Keep the message list pinned to the latest message while the panel is open.
+  // On open, always jump to the bottom (show the latest). For a message that
+  // arrives while it is already open, only auto-scroll when the user is at (or
+  // near) the bottom — otherwise a new message would yank them away from history
+  // they scrolled up to read.
+  const prevExpandedRef = useRef(false);
   useEffect(() => {
-    if (!expanded) return;
+    if (!expanded) {
+      prevExpandedRef.current = false;
+      return;
+    }
     const el = chatScrollRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
+    if (!el) return;
+    const justOpened = !prevExpandedRef.current;
+    prevExpandedRef.current = true;
+    const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 48;
+    if (justOpened || nearBottom) el.scrollTop = el.scrollHeight;
   }, [expanded, lastMessageId]);
 
   const handleSendChat = () => {
@@ -293,70 +296,17 @@ export function CollaborationStatusBadge({
             </button>
           </div>
           <ul className="max-h-40 space-y-1 overflow-y-auto p-2">
-            {participants.map((p) => {
-              const editable = participantCanEdit(p, mode);
-              // The host can pin any guest (not themselves) to view-only / edit.
-              const showToggle = isHost && p.role !== "host";
-              return (
-                <li
-                  key={p.clientId}
-                  className="flex items-center gap-2 text-xs"
-                >
-                  <span
-                    className="h-2.5 w-2.5 shrink-0 rounded-full"
-                    style={{ backgroundColor: p.color }}
-                  />
-                  <span className="truncate">{p.displayName}</span>
-                  {p.clientId === selfId && (
-                    <span className="text-muted-foreground">
-                      ({t("collaborate.you")})
-                    </span>
-                  )}
-                  {p.role === "host" && (
-                    <span className="rounded bg-muted px-1 py-0.5 text-[10px]">
-                      {t("collaborate.host")}
-                    </span>
-                  )}
-                  {showToggle ? (
-                    <button
-                      type="button"
-                      onClick={() =>
-                        api.setParticipantMode(p.clientId, !editable)
-                      }
-                      aria-pressed={editable}
-                      title={
-                        editable
-                          ? t("collaborate.setViewOnly")
-                          : t("collaborate.allowEdit")
-                      }
-                      className="ml-auto flex shrink-0 items-center gap-1 rounded border px-1 py-0.5 text-[10px] text-muted-foreground transition hover:bg-accent hover:text-foreground"
-                    >
-                      {editable ? (
-                        <Pencil className="h-3 w-3" aria-hidden="true" />
-                      ) : (
-                        <Eye className="h-3 w-3" aria-hidden="true" />
-                      )}
-                      {editable
-                        ? t("collaborate.canEdit")
-                        : t("collaborate.viewOnly")}
-                    </button>
-                  ) : (
-                    p.role !== "host" && (
-                      <span className="ml-auto flex shrink-0 items-center gap-1 text-[10px] text-muted-foreground">
-                        {editable ? (
-                          <Pencil className="h-3 w-3" aria-hidden="true" />
-                        ) : (
-                          <Eye className="h-3 w-3" aria-hidden="true" />
-                        )}
-                        {editable
-                          ? t("collaborate.canEdit")
-                          : t("collaborate.viewOnly")}
-                      </span>
-                    )
-                  )}
-                </li>
-              );
-            })}
+            {participants.map((p) => (
+              <CollaborationParticipantRow
+                key={p.clientId}
+                participant={p}
+                mode={mode}
+                isSelf={p.clientId === selfId}
+                canManage={isHost}
+                onSetParticipantMode={api.setParticipantMode}
+                compact
+              />
+            ))}
           </ul>
 
           {/* Chat drawer (#754, Part 4): a lightweight text channel with an

--- a/apps/geolibre-desktop/src/components/layout/CollaborationStatusBadge.tsx
+++ b/apps/geolibre-desktop/src/components/layout/CollaborationStatusBadge.tsx
@@ -327,35 +327,39 @@ export function CollaborationStatusBadge({
                   {t("collaborate.chatEmpty")}
                 </p>
               ) : (
-                chat.map((m) => (
-                  <div key={m.id} className="flex flex-col gap-0.5 text-xs">
-                    <div className="flex items-baseline gap-1.5">
-                      <span
-                        className="truncate font-medium"
-                        style={{ color: m.color }}
-                      >
-                        {m.clientId === selfId
-                          ? t("collaborate.you")
-                          : m.displayName}
-                      </span>
+                chat.map((m) => {
+                  // Bind to a const so the narrowing survives into the onClick
+                  // closure (a non-null assertion would otherwise be needed).
+                  const coord = m.coordinate;
+                  return (
+                    <div key={m.id} className="flex flex-col gap-0.5 text-xs">
+                      <div className="flex items-baseline gap-1.5">
+                        <span
+                          className="truncate font-medium"
+                          style={{ color: m.color }}
+                        >
+                          {m.clientId === selfId
+                            ? t("collaborate.you")
+                            : m.displayName}
+                        </span>
+                      </div>
+                      <p className="whitespace-pre-wrap break-words text-foreground">
+                        {m.text}
+                      </p>
+                      {coord && (
+                        <button
+                          type="button"
+                          onClick={() => flyToCoordinate(coord)}
+                          className="flex w-fit items-center gap-1 rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground transition hover:bg-accent hover:text-foreground"
+                          title={t("collaborate.chatGoToLocation")}
+                        >
+                          <MapPin className="h-3 w-3" aria-hidden="true" />
+                          {coord.lat.toFixed(4)}, {coord.lng.toFixed(4)}
+                        </button>
+                      )}
                     </div>
-                    <p className="whitespace-pre-wrap break-words text-foreground">
-                      {m.text}
-                    </p>
-                    {m.coordinate && (
-                      <button
-                        type="button"
-                        onClick={() => flyToCoordinate(m.coordinate!)}
-                        className="flex w-fit items-center gap-1 rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground transition hover:bg-accent hover:text-foreground"
-                        title={t("collaborate.chatGoToLocation")}
-                      >
-                        <MapPin className="h-3 w-3" aria-hidden="true" />
-                        {m.coordinate.lat.toFixed(4)},{" "}
-                        {m.coordinate.lng.toFixed(4)}
-                      </button>
-                    )}
-                  </div>
-                ))
+                  );
+                })
               )}
             </div>
             <div className="flex items-center gap-1 border-t p-1.5">
@@ -383,6 +387,10 @@ export function CollaborationStatusBadge({
                   if (e.key === "Enter" && !e.shiftKey) {
                     e.preventDefault();
                     handleSendChat();
+                  } else if (e.key === "Escape") {
+                    // Don't let Escape bubble to the window listener that
+                    // collapses the panel — while typing it should stay open.
+                    e.stopPropagation();
                   }
                 }}
                 placeholder={t("collaborate.chatPlaceholder")}

--- a/apps/geolibre-desktop/src/components/layout/CollaborationStatusBadge.tsx
+++ b/apps/geolibre-desktop/src/components/layout/CollaborationStatusBadge.tsx
@@ -85,9 +85,11 @@ export function CollaborationStatusBadge({
   // The scroll viewport for the message list, so new messages pin to the bottom.
   const chatScrollRef = useRef<HTMLDivElement | null>(null);
   // Unread chat count while the roster is collapsed, surfaced on the pill so a
-  // working host notices new messages without keeping the panel open.
+  // working host notices new messages without keeping the panel open. Tracked by
+  // the last-seen message id (not the array length): the store keeps a bounded
+  // tail, so once it is full new messages arrive without changing the length.
   const [unread, setUnread] = useState(0);
-  const lastSeenChatRef = useRef(0);
+  const lastSeenChatIdRef = useRef<string | null>(null);
   // The participant set from the previous update, so we can diff join/leave.
   // Seeded on first activation so existing members (and self) aren't announced
   // as fresh arrivals when the dialog first connects.
@@ -122,7 +124,7 @@ export function CollaborationStatusBadge({
       setDraft("");
       setAttachLocation(false);
       setUnread(0);
-      lastSeenChatRef.current = 0;
+      lastSeenChatIdRef.current = null;
       return;
     }
     const current = new Map(
@@ -185,29 +187,39 @@ export function CollaborationStatusBadge({
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [expanded]);
 
+  // The latest message's id; effects key on this (not chat.length) so a full,
+  // bounded tail still notices new arrivals.
+  const lastMessageId = chat.length ? chat[chat.length - 1].id : null;
+
   // Track unread chat while the panel is collapsed; clear it (and remember the
-  // current length) whenever the panel is open, so the badge counts only
-  // messages that arrived while the host wasn't looking.
+  // latest message id) whenever the panel is open, so the badge counts only
+  // messages that arrived while the host wasn't looking. The first collapsed
+  // render of a session seeds the baseline so welcome history isn't unread.
   useEffect(() => {
     if (!isActive) return;
-    if (expanded) {
-      lastSeenChatRef.current = chat.length;
+    if (expanded || lastSeenChatIdRef.current === null) {
+      lastSeenChatIdRef.current = lastMessageId;
       setUnread(0);
       return;
     }
-    setUnread(Math.max(0, chat.length - lastSeenChatRef.current));
-  }, [isActive, expanded, chat.length]);
+    const seenIdx = chat.findIndex((m) => m.id === lastSeenChatIdRef.current);
+    // If the last-seen message has aged out of the tail, every retained message
+    // is newer than it.
+    setUnread(seenIdx === -1 ? chat.length : chat.length - seenIdx - 1);
+  }, [isActive, expanded, lastMessageId, chat]);
 
   // Keep the message list pinned to the latest message while the panel is open.
   useEffect(() => {
     if (!expanded) return;
     const el = chatScrollRef.current;
     if (el) el.scrollTop = el.scrollHeight;
-  }, [expanded, chat.length]);
+  }, [expanded, lastMessageId]);
 
   const handleSendChat = () => {
     const text = draft.trim();
-    if (!text) return;
+    // Drop sends while reconnecting: api.sendChat silently no-ops when the
+    // socket isn't open, so clearing the draft here would lose the typed text.
+    if (!text || connecting) return;
     // Capture the live map center only when the pin is active, at send time.
     const center =
       attachLocation && mapControllerRef.current
@@ -428,7 +440,7 @@ export function CollaborationStatusBadge({
                 type="button"
                 size="sm"
                 className="h-8 shrink-0 px-2"
-                disabled={!draft.trim()}
+                disabled={connecting || !draft.trim()}
                 onClick={handleSendChat}
                 aria-label={t("collaborate.chatSend")}
               >

--- a/apps/geolibre-desktop/src/components/layout/CollaborationStatusBadge.tsx
+++ b/apps/geolibre-desktop/src/components/layout/CollaborationStatusBadge.tsx
@@ -20,6 +20,10 @@ interface CollaborationStatusBadgeProps {
 
 // How long a join/leave announcement stays on screen before auto-dismissing.
 const ANNOUNCEMENT_TTL_MS = 5000;
+// Client-side chat send floor, matching the relay's per-socket limit, so a
+// rapid second send is refused locally (keeping its draft) rather than sent and
+// silently dropped by the relay.
+const MIN_CHAT_SEND_INTERVAL_MS = 250;
 
 /**
  * Persistent on-canvas badge that surfaces a live collaboration session outside
@@ -76,6 +80,8 @@ export function CollaborationStatusBadge({
   // (#754, Part 4). The pin captures the center at send time, not toggle time.
   const [draft, setDraft] = useState("");
   const [attachLocation, setAttachLocation] = useState(false);
+  // Epoch-ms of the last accepted local send, for the client-side floor above.
+  const lastSentAtRef = useRef(0);
   // The scroll viewport for the message list, so new messages pin to the bottom.
   const chatScrollRef = useRef<HTMLDivElement | null>(null);
   // Unread chat count while the roster is collapsed, surfaced on the pill so a
@@ -230,6 +236,13 @@ export function CollaborationStatusBadge({
     // Drop sends while reconnecting: api.sendChat silently no-ops when the
     // socket isn't open, so clearing the draft here would lose the typed text.
     if (!text || connecting) return;
+    // Mirror the relay's per-socket chat floor client-side: if two sends land
+    // within the window the relay would silently drop the second, so refuse it
+    // here WITHOUT clearing the draft, rather than clearing optimistically and
+    // losing the text. (Human-paced typing never hits this; double-Enter does.)
+    const now = Date.now();
+    if (now - lastSentAtRef.current < MIN_CHAT_SEND_INTERVAL_MS) return;
+    lastSentAtRef.current = now;
     // Capture the live map center only when the pin is active, at send time.
     const center =
       attachLocation && mapControllerRef.current

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -76,6 +76,7 @@ import {
 } from "../../hooks/useRightPanels";
 import { BoundsRestrictionIndicator } from "./BoundsRestrictionIndicator";
 import { CollaborationStatusBadge } from "./CollaborationStatusBadge";
+import { useCollaboration } from "../../hooks/useCollaboration";
 import { MapModeBanner } from "./MapModeBanner";
 import { MapGrid } from "./MapGrid";
 import { RemoteCursorsOverlay } from "./RemoteCursorsOverlay";
@@ -518,6 +519,9 @@ export function DesktopShell({
   const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
   const diagnostics = useDiagnosticsSnapshot();
   const externalPluginsReady = useExternalPluginsReady(mapControllerRef);
+  // Live-collaboration session. Owned here (rather than in TopToolbar) so both
+  // the Collaborate dialog and the on-canvas status badge share one socket.
+  const collaboration = useCollaboration(mapControllerRef);
   // Sync the project with an embedding host (the GeoLibre Jupyter widget) over
   // postMessage. Inert when the app is not embedded.
   useEmbedBridge(mapControllerRef);
@@ -1433,6 +1437,7 @@ export function DesktopShell({
             showLabels={layoutOptions.toolbarLabels}
             showProjectInfo={layoutOptions.showProjectInfo}
             themeMode={themeMode}
+            collaboration={collaboration}
             onOpenDiagnostics={() => setDiagnosticsOpen(true)}
             onToggleThemeMode={onToggleThemeMode}
           />
@@ -1537,7 +1542,10 @@ export function DesktopShell({
               />
               <RemoteCursorsOverlay mapControllerRef={mapControllerRef} />
               <BoundsRestrictionIndicator />
-              <CollaborationStatusBadge />
+              <CollaborationStatusBadge
+                api={collaboration}
+                mapControllerRef={mapControllerRef}
+              />
               <MapModeBanner mapControllerRef={mapControllerRef} />
             </MapGrid>
           </SectionErrorBoundary>

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -86,7 +86,10 @@ import {
   appendDiagnostic,
   useDiagnosticsSnapshot,
 } from "../../lib/diagnostics";
-import { SectionErrorBoundary } from "../common/error-boundaries";
+import {
+  SectionErrorBoundary,
+  SilentErrorBoundary,
+} from "../common/error-boundaries";
 import { AttributeTable } from "../panels/AttributeTable";
 import { LayerPanel } from "../panels/LayerPanel";
 import { FloatingPanels } from "../panels/FloatingPanels";
@@ -1557,10 +1560,15 @@ export function DesktopShell({
               />
               <RemoteCursorsOverlay mapControllerRef={mapControllerRef} />
               <BoundsRestrictionIndicator />
-              <CollaborationStatusBadge
-                api={collaboration}
-                mapControllerRef={mapControllerRef}
-              />
+              {/* Isolate the collaboration badge in its own boundary: it renders
+                  over the map, so a fault here must never take down the map
+                  itself (it shares this subtree's error boundary otherwise). */}
+              <SilentErrorBoundary label="Collaboration status">
+                <CollaborationStatusBadge
+                  api={collaboration}
+                  mapControllerRef={mapControllerRef}
+                />
+              </SilentErrorBoundary>
               <MapModeBanner mapControllerRef={mapControllerRef} />
             </MapGrid>
           </SectionErrorBoundary>

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -76,6 +76,7 @@ import {
 } from "../../hooks/useRightPanels";
 import { BoundsRestrictionIndicator } from "./BoundsRestrictionIndicator";
 import { CollaborationStatusBadge } from "./CollaborationStatusBadge";
+import { CollaborateDialog } from "./CollaborateDialog";
 import { useCollaboration } from "../../hooks/useCollaboration";
 import { MapModeBanner } from "./MapModeBanner";
 import { MapGrid } from "./MapGrid";
@@ -520,8 +521,22 @@ export function DesktopShell({
   const diagnostics = useDiagnosticsSnapshot();
   const externalPluginsReady = useExternalPluginsReady(mapControllerRef);
   // Live-collaboration session. Owned here (rather than in TopToolbar) so both
-  // the Collaborate dialog and the on-canvas status badge share one socket.
+  // the Collaborate dialog and the on-canvas status badge share one socket, and
+  // so the dialog stays mounted in toolbar-hidden layouts.
   const collaboration = useCollaboration(mapControllerRef);
+  const collaborateDialogOpen = useAppStore((s) => s.ui.collaborateDialogOpen);
+  const setCollaborateDialogOpen = useAppStore(
+    (s) => s.setCollaborateDialogOpen,
+  );
+  // When opened via a `?collab=<code>` share link, auto-open the Collaborate
+  // dialog (which prefills the code) so the recipient only picks a name and
+  // joins, instead of having to find the Project menu first.
+  useEffect(() => {
+    if (!collaboration.enabled) return;
+    if (new URLSearchParams(window.location.search).get("collab")) {
+      setCollaborateDialogOpen(true);
+    }
+  }, [collaboration.enabled, setCollaborateDialogOpen]);
   // Sync the project with an embedding host (the GeoLibre Jupyter widget) over
   // postMessage. Inert when the app is not embedded.
   useEmbedBridge(mapControllerRef);
@@ -1552,6 +1567,15 @@ export function DesktopShell({
           <SectionErrorBoundary label="Plugin floating panels">
             <FloatingPanels />
           </SectionErrorBoundary>
+          {/* Rendered here (not in TopToolbar) so the dialog the status badge
+              reopens stays mounted even in toolbar-hidden layouts (#754). */}
+          {collaboration.enabled && (
+            <CollaborateDialog
+              open={collaborateDialogOpen}
+              onOpenChange={setCollaborateDialogOpen}
+              api={collaboration}
+            />
+          )}
         </main>
         {replaceStylePanelId ? (
           // Shared-rail mode (issue #765): the plugin panel shares the Style

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -95,7 +95,7 @@ import { NewProjectDialog } from "./NewProjectDialog";
 import { ManagePluginsDialog } from "./ManagePluginsDialog";
 import { ShareProjectDialog } from "./ShareProjectDialog";
 import { CollaborateDialog } from "./CollaborateDialog";
-import { useCollaboration } from "../../hooks/useCollaboration";
+import type { CollaborationApi } from "../../hooks/useCollaboration";
 import { SettingsDialog } from "./SettingsDialog";
 import { SetViewDialog } from "./SetViewDialog";
 import { PrintLayoutDialog } from "./PrintLayoutDialog";
@@ -139,6 +139,9 @@ interface TopToolbarProps {
   showLabels?: boolean;
   showProjectInfo?: boolean;
   themeMode: ThemeMode;
+  // Lifted to DesktopShell so the on-canvas status badge can share one live
+  // session (calling useCollaboration twice would open two sockets).
+  collaboration: CollaborationApi;
   onOpenDiagnostics: () => void;
   onToggleThemeMode: () => void;
 }
@@ -151,6 +154,7 @@ export function TopToolbar({
   showLabels = true,
   showProjectInfo = true,
   themeMode,
+  collaboration,
   onOpenDiagnostics,
   onToggleThemeMode,
 }: TopToolbarProps) {
@@ -278,7 +282,6 @@ export function TopToolbar({
   const projectFiles = useProjectFileActions(mapControllerRef);
   const osmPbf = useOsmPbfLoader(appApi, projectFiles.setActionError);
   const consent = useConsentGatedActions({ appApi, isActive, toggle });
-  const collaboration = useCollaboration(mapControllerRef);
   const viewportHistory = useViewportHistory(
     mapControllerRef,
     mapReadyGeneration,

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -94,7 +94,6 @@ import { AboutDialog } from "./AboutDialog";
 import { NewProjectDialog } from "./NewProjectDialog";
 import { ManagePluginsDialog } from "./ManagePluginsDialog";
 import { ShareProjectDialog } from "./ShareProjectDialog";
-import { CollaborateDialog } from "./CollaborateDialog";
 import type { CollaborationApi } from "../../hooks/useCollaboration";
 import { SettingsDialog } from "./SettingsDialog";
 import { SetViewDialog } from "./SetViewDialog";
@@ -233,7 +232,8 @@ export function TopToolbar({
   const setProjectName = useAppStore((s) => s.setProjectName);
   // The Collaborate dialog's visibility lives in the store so the on-canvas
   // session-status badge can reopen it from outside this component tree (#754).
-  const collaborateDialogOpen = useAppStore((s) => s.ui.collaborateDialogOpen);
+  // The dialog itself is rendered by DesktopShell (not here) so it survives
+  // toolbar-hidden layouts; the toolbar only triggers it via this setter.
   const setCollaborateDialogOpen = useAppStore(
     (s) => s.setCollaborateDialogOpen,
   );
@@ -287,16 +287,6 @@ export function TopToolbar({
     mapReadyGeneration,
     projectGeneration,
   );
-
-  // When opened via a `?collab=<code>` share link, auto-open the Collaborate
-  // dialog (which prefills the code) so the recipient only picks a name and
-  // joins, instead of having to find the Project menu first.
-  useEffect(() => {
-    if (!collaboration.enabled) return;
-    if (new URLSearchParams(window.location.search).get("collab")) {
-      setCollaborateDialogOpen(true);
-    }
-  }, [collaboration.enabled]);
 
   // Tracks an active IME composition so pressing Enter to confirm a CJK
   // candidate doesn't blur the project-name field mid-composition.
@@ -1059,13 +1049,6 @@ export function TopToolbar({
           return { content, filename: `${safeName}.geolibre.json` };
         }}
       />
-      {collaboration.enabled && (
-        <CollaborateDialog
-          open={collaborateDialogOpen}
-          onOpenChange={setCollaborateDialogOpen}
-          api={collaboration}
-        />
-      )}
       {isMenuVisible(uiProfile, "help") && (
         <HelpMenu
           chrome={chrome}

--- a/apps/geolibre-desktop/src/hooks/useCollaboration.ts
+++ b/apps/geolibre-desktop/src/hooks/useCollaboration.ts
@@ -119,7 +119,7 @@ export function useCollaboration(
     // A host-set per-participant override wins over the session mode (#754);
     // fall back to the mode when there is no override for us.
     const self = c.participants.find((p) => p.clientId === c.clientId);
-    return self?.editOverride ?? c.mode === "co-edit";
+    return self?.editOverride ?? (c.mode === "co-edit");
   };
 
   const sendSnapshot = (): void => {

--- a/apps/geolibre-desktop/src/hooks/useCollaboration.ts
+++ b/apps/geolibre-desktop/src/hooks/useCollaboration.ts
@@ -207,8 +207,10 @@ export function useCollaboration(
           mode: message.mode,
           participants: message.participants,
           // Bootstrap (or, on a reconnect, re-seed) the chat log from the relay's
-          // recent history so a late joiner sees the conversation so far.
-          chat: message.chat,
+          // recent history so a late joiner sees the conversation so far. Default
+          // to [] so an older relay that omits `chat` can't leave the slice
+          // undefined (which would crash the chat UI).
+          chat: message.chat ?? [],
           error: null,
         });
         // Bootstrap existing participants' cursors/viewports so they're visible

--- a/apps/geolibre-desktop/src/hooks/useCollaboration.ts
+++ b/apps/geolibre-desktop/src/hooks/useCollaboration.ts
@@ -42,8 +42,12 @@ export interface CollaborationApi {
   leave: () => void;
   /** Host-only: switch the session between view-only and co-edit. */
   setMode: (mode: CollaborationMode) => void;
+  /** Host-only: pin one participant to can-edit or view-only (#754). */
+  setParticipantMode: (clientId: string, canEdit: boolean) => void;
   /** Toggle whether this participant's camera follows the host's viewport. */
   setFollowHost: (enabled: boolean) => void;
+  /** Send a chat message to the session, optionally attaching a coordinate (#754). */
+  sendChat: (text: string, coordinate?: { lng: number; lat: number } | null) => void;
 }
 
 /**
@@ -110,7 +114,12 @@ export function useCollaboration(
     // Require an active (joined) session so a debounced snapshot can't fire in
     // the window between connect() and the `welcome` (where mode still holds its
     // default of "co-edit").
-    return c.isActive && (c.role === "host" || c.mode === "co-edit");
+    if (!c.isActive) return false;
+    if (c.role === "host") return true;
+    // A host-set per-participant override wins over the session mode (#754);
+    // fall back to the mode when there is no override for us.
+    const self = c.participants.find((p) => p.clientId === c.clientId);
+    return self?.editOverride ?? c.mode === "co-edit";
   };
 
   const sendSnapshot = (): void => {
@@ -197,6 +206,9 @@ export function useCollaboration(
           role: message.role,
           mode: message.mode,
           participants: message.participants,
+          // Bootstrap (or, on a reconnect, re-seed) the chat log from the relay's
+          // recent history so a late joiner sees the conversation so far.
+          chat: message.chat,
           error: null,
         });
         // Bootstrap existing participants' cursors/viewports so they're visible
@@ -261,6 +273,11 @@ export function useCollaboration(
       }
       case "mode":
         store.setCollaboration({ mode: message.mode });
+        break;
+      case "chat":
+        // The relay echoes our own messages back too, so the store is the single
+        // ordered source of truth; addCollaborationChat de-dupes by id.
+        store.addCollaborationChat(message.message);
         break;
       case "error":
         store.setCollaboration({ error: message.message });
@@ -449,6 +466,26 @@ export function useCollaboration(
     connRef.current?.send({ type: "set-mode", mode });
   }, []);
 
+  const setParticipantMode = useCallback(
+    (clientId: string, canEditFlag: boolean) => {
+      connRef.current?.send({
+        type: "set-participant-mode",
+        clientId,
+        canEdit: canEditFlag,
+      });
+    },
+    [],
+  );
+
+  const sendChat = useCallback(
+    (text: string, coordinate?: { lng: number; lat: number } | null) => {
+      const trimmed = text.trim();
+      if (!trimmed) return;
+      connRef.current?.send({ type: "chat", text: trimmed, coordinate });
+    },
+    [],
+  );
+
   const setFollowHost = useCallback((enabled: boolean) => {
     const store = useAppStore.getState();
     store.setCollaboration({ followHost: enabled });
@@ -465,7 +502,16 @@ export function useCollaboration(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return { enabled, start, join, leave, setMode, setFollowHost };
+  return {
+    enabled,
+    start,
+    join,
+    leave,
+    setMode,
+    setParticipantMode,
+    setFollowHost,
+    sendChat,
+  };
 }
 
 // Reference-compares the store fields that feed a project snapshot. Every

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -606,7 +606,20 @@
     "switchToCoEdit": "Allow everyone to edit",
     "switchToViewOnly": "Make view-only",
     "nameRequired": "Enter your name to continue.",
-    "codeRequired": "Enter a session code to join."
+    "codeRequired": "Enter a session code to join.",
+    "canEdit": "Can edit",
+    "viewOnly": "View-only",
+    "allowEdit": "Allow this person to edit",
+    "setViewOnly": "Set this person to view-only",
+    "chatLog": "Session chat",
+    "chatEmpty": "No messages yet.",
+    "chatPlaceholder": "Send a message…",
+    "chatSend": "Send message",
+    "chatAttachLocation": "Attach the current map location",
+    "chatLocationAttached": "Location attached (click to remove)",
+    "chatGoToLocation": "Go to this location",
+    "sessionStatusUnread_one": "Live collaboration session, {{count}} unread message. Click to see who's connected and chat.",
+    "sessionStatusUnread_other": "Live collaboration session, {{count}} unread messages. Click to see who's connected and chat."
   },
   "share": {
     "title": "Share project",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -612,6 +612,7 @@
     "allowEdit": "Allow this person to edit",
     "setViewOnly": "Set this person to view-only",
     "chatLog": "Session chat",
+    "chatCompose": "Type a message",
     "chatEmpty": "No messages yet.",
     "chatPlaceholder": "Send a message…",
     "chatSend": "Send message",

--- a/apps/geolibre-desktop/src/lib/collab-protocol.ts
+++ b/apps/geolibre-desktop/src/lib/collab-protocol.ts
@@ -6,6 +6,7 @@
 // `GeoLibreProject`. Keep the two `type` discriminants and field names in sync.
 
 import type {
+  CollaborationChatMessage,
   CollaborationMode,
   CollaborationParticipant,
   CollaborationRole,
@@ -18,6 +19,23 @@ export type { CollaborationMode, CollaborationRole };
 export interface CollabCursor {
   lng: number;
   lat: number;
+}
+
+/**
+ * Effective edit permission for a participant given the current session mode
+ * (#754). The host always edits; otherwise a host-set per-participant override
+ * wins, falling back to the session default.
+ *
+ * @param participant - The participant to evaluate.
+ * @param mode - The current session mode.
+ * @returns True when this participant may edit the project.
+ */
+export function participantCanEdit(
+  participant: CollaborationParticipant,
+  mode: CollaborationMode,
+): boolean {
+  if (participant.role === "host") return true;
+  return participant.editOverride ?? mode === "co-edit";
 }
 
 // Client -> server -----------------------------------------------------------
@@ -48,11 +66,27 @@ export interface SetModeMessage {
   mode: CollaborationMode;
 }
 
+/** Host-only: pin one participant to can-edit / view-only (#754). */
+export interface SetParticipantModeMessage {
+  type: "set-participant-mode";
+  clientId: string;
+  canEdit: boolean;
+}
+
+/** Send a chat message to the session (#754). */
+export interface ChatSendMessage {
+  type: "chat";
+  text: string;
+  coordinate?: CollabCursor | null;
+}
+
 export type ClientMessage =
   | JoinMessage
   | ClientSnapshotMessage
   | ClientPresenceMessage
-  | SetModeMessage;
+  | SetModeMessage
+  | SetParticipantModeMessage
+  | ChatSendMessage;
 
 // Server -> client -----------------------------------------------------------
 
@@ -66,6 +100,8 @@ export interface WelcomeMessage {
   /** Current presence of existing participants (keyed by clientId) so a late
    *  joiner sees their cursors/viewports without waiting for the next move. */
   presence: Record<string, PresenceEntry>;
+  /** Recent chat history so a late joiner sees the conversation so far (#754). */
+  chat: CollaborationChatMessage[];
   rev: number;
 }
 
@@ -98,6 +134,12 @@ export interface ModeMessage {
   mode: CollaborationMode;
 }
 
+/** Fan-out of a chat message to every participant (including the sender). */
+export interface ChatBroadcastMessage {
+  type: "chat";
+  message: CollaborationChatMessage;
+}
+
 export interface ErrorMessage {
   type: "error";
   code: "forbidden" | "too-large" | "bad-message" | "not-found";
@@ -110,4 +152,5 @@ export type ServerMessage =
   | ServerPresenceMessage
   | ParticipantsMessage
   | ModeMessage
+  | ChatBroadcastMessage
   | ErrorMessage;

--- a/apps/geolibre-desktop/src/lib/collab-protocol.ts
+++ b/apps/geolibre-desktop/src/lib/collab-protocol.ts
@@ -35,7 +35,7 @@ export function participantCanEdit(
   mode: CollaborationMode,
 ): boolean {
   if (participant.role === "host") return true;
-  return participant.editOverride ?? mode === "co-edit";
+  return participant.editOverride ?? (mode === "co-edit");
 }
 
 // Client -> server -----------------------------------------------------------

--- a/docs/collaboration.md
+++ b/docs/collaboration.md
@@ -15,6 +15,10 @@ small teams.
   (camera). Broadcast as whole-project snapshots.
 - **Presence** — each participant's live cursor position and viewport rectangle,
   plus a name + color. Presence is ephemeral and never persisted.
+- **Chat** — short text messages with an optional attached map coordinate (#754).
+  Bounded recent history is relayed to late joiners; never written to a project.
+- **Permissions** — the host's per-participant view-only / can-edit overrides
+  (#754), broadcast on the participant list as `editOverride`.
 
 ## Architecture
 
@@ -63,16 +67,19 @@ Client → server:
 | `snapshot` | `project, rev` | a debounced project push; co-editors only |
 | `presence` | `cursor?, view?` | throttled cursor / viewport |
 | `set-mode` | `mode` | host only |
+| `set-participant-mode` | `clientId, canEdit` | host only; pin one guest to can-edit / view-only (#754) |
+| `chat` | `text, coordinate?` | a chat message, with an optional attached map coordinate (#754) |
 
 Server → client:
 
 | type | payload | notes |
 | --- | --- | --- |
-| `welcome` | `clientId, role, mode, participants[], snapshot \| null, rev` | sent once on join; the late-joiner bootstrap |
+| `welcome` | `clientId, role, mode, participants[], snapshot \| null, presence, chat[], rev` | sent once on join; the late-joiner bootstrap |
 | `snapshot` | `project, origin, rev` | fan-out of a peer's snapshot |
 | `presence` | `clientId, cursor?, view?` | fan-out of a peer's presence |
-| `participants` | `participants[]` | on join / leave / role change |
+| `participants` | `participants[]` | on join / leave / role / permission change; each carries `editOverride` |
 | `mode` | `mode` | host changed the session mode |
+| `chat` | `message` | fan-out of a chat message (echoed to the sender, so order is server-authoritative) (#754) |
 | `error` | `code, message` | e.g. `forbidden`, `too-large` |
 
 ### Echo / feedback-loop prevention
@@ -103,12 +110,14 @@ accepted MVP limitation; a coalesced-history option is a v2 item.
 `CollabSession` uses the **WebSocket Hibernation API** so idle sessions evict
 from memory while keeping sockets open. Per-socket participant metadata is kept
 via `ws.serializeAttachment()` (survives hibernation). Durable storage holds the
-`latestSnapshot`, a monotonic `rev`, the `mode`, and the `hostToken`; presence is
-in-memory only. Server-side enforcement: a `snapshot` from a guest while the
-session is `view-only` is dropped with an `error: forbidden`; `set-mode` requires
-the host token. Oversized snapshots (> ~1 MiB, the Cloudflare frame cap) are
-rejected with `error: too-large`. An empty session is reclaimed after a TTL via a
-storage alarm.
+`latestSnapshot`, a monotonic `rev`, the `mode`, the `hostToken`, and a bounded
+`chat` log; presence and per-participant permission overrides are kept on the
+in-memory / per-socket attachment. Server-side enforcement: a `snapshot` from a
+guest who cannot edit (session `view-only`, or a host-set per-participant
+view-only override) is dropped with an `error: forbidden`; `set-mode` and
+`set-participant-mode` require the host token. Oversized snapshots (> ~1 MiB, the
+Cloudflare frame cap) are rejected with `error: too-large`. An empty session is
+reclaimed after a TTL via a storage alarm.
 
 ## Frontend
 
@@ -128,6 +137,12 @@ storage alarm.
 - `components/layout/RemoteCursorsOverlay.tsx` — renders remote cursors as
   MapLibre Markers and viewport rectangles as a dedicated GeoJSON line layer.
 - `components/layout/CollaborateDialog.tsx` + a flag-gated `TopToolbar` entry.
+- `components/layout/CollaborationStatusBadge.tsx` — the persistent on-canvas
+  badge that hosts the participant roster (with the host's per-participant
+  permission toggles) and the chat drawer (#754). `useCollaboration` is owned by
+  `DesktopShell` and passed to both the dialog and this badge, so they share one
+  socket. `participantCanEdit()` (in `lib/collab-protocol.ts`) is the shared
+  effective-permission helper used by the relay-mirrored client UI.
 
 ## Identity & permissions (MVP)
 
@@ -138,11 +153,41 @@ display name and a color. The host chooses the session **mode**:
   are rejected server-side.
 - **co-edit** — anyone with the link can edit.
 
-The host token (returned only to the creator) gates `set-mode`, so a guest can't
-escalate the session to co-edit. Codes are unguessable and sessions auto-expire.
-The relay assigns each participant's `clientId` server-side (the client-supplied
-value is ignored) so one participant can't claim another's identity, and it
-validates the `color` to a hex value before storing/broadcasting it.
+**Per-participant overrides (#754).** Beyond the session-wide mode, the host can
+pin an individual guest with `set-participant-mode { clientId, canEdit }`. The
+relay records the override on that socket's attachment (so it survives a
+hibernation wake) and re-broadcasts the participant list with an `editOverride`
+field (`true` / `false`, or `null` to follow the session mode). Effective edit
+permission, computed identically on the client and the relay, is: the host
+always edits; otherwise the override wins; otherwise the session mode applies. A
+guest pinned to view-only has their `snapshot` pushes rejected with
+`error: forbidden`, exactly like the session-wide view-only path. Overrides are
+keyed to the per-socket `clientId`, so a guest who reconnects reverts to the
+session default (acceptable for the ephemeral MVP). The host roster surfaces a
+per-guest toggle; other participants see each guest's current permission read-only.
+
+The host token (returned only to the creator) gates `set-mode` and
+`set-participant-mode`, so a guest can't escalate the session or another guest.
+Codes are unguessable and sessions auto-expire. The relay assigns each
+participant's `clientId` server-side (the client-supplied value is ignored) so
+one participant can't claim another's identity, and it validates the `color` to
+a hex value before storing/broadcasting it.
+
+## Chat (#754)
+
+A lightweight, in-session text channel. A `chat { text, coordinate? }` frame is
+validated server-side (non-empty, trimmed, capped at 2000 chars; the coordinate
+runs through the same finite-number sanitizer as presence) and fanned out to
+**every** participant including the sender, so the relay's ordering is the single
+source of truth (clients render from the echo rather than optimistically). Each
+message carries a server-assigned `id` and `ts`. The relay keeps a bounded,
+persisted history (last 50 messages) so a late joiner (or a post-hibernation
+welcome) sees the recent conversation via the `welcome.chat[]` bootstrap. Chat
+is open to everyone in the session, including view-only guests; only project
+edits are gated. A message can attach the sender's current map center as a
+clickable coordinate that recenters the recipient's map. Chat lives on the
+on-canvas status badge so it is reachable while working on the map; it is
+ephemeral and never written to a project file.
 
 > **Operator note:** `POST /sessions` is unauthenticated and currently responds
 > with `Access-Control-Allow-Origin: *`, so any page can create sessions. This is
@@ -203,7 +248,9 @@ Automated:
 
 - `npm run test:worker` typechecks `workers/collab`.
 - `npm run test:frontend` runs `tests/collab-protocol.test.ts` (protocol
-  round-trip, `resolveCollabBaseUrl` validation, echo-suppression logic).
+  round-trip including the `set-participant-mode` / `chat` frames,
+  `resolveCollabBaseUrl` validation, echo-suppression logic, and the
+  `participantCanEdit` effective-permission helper).
 
 ### Testing the full feature locally
 
@@ -245,6 +292,11 @@ it.
      changing a style, or panning in A reflects in B within ~300 ms; each window
      shows the other's live **cursor** and a dashed **viewport rectangle**;
      toggling A (the host) to *view-only* blocks B's edits.
+   - Verify Parts 3 & 4 (#754) via the on-canvas status badge (bottom-left,
+     click to expand): A (the host) can flip B between **Can edit** and
+     **View-only** per-participant in the roster, and either window can send a
+     **chat** message (optionally attaching the current map center, which the
+     other side can click to recenter).
 
 **Relay-only smoke test (no UI):** with `wrangler dev` running, `POST` to
 `http://127.0.0.1:8787/sessions` to mint a code, then open a WebSocket to

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -31,6 +31,7 @@ import {
   DEFAULT_STORY_MAP,
   MAX_DASHBOARD_COLUMNS,
   MIN_DASHBOARD_COLUMNS,
+  type CollaborationChatMessage,
   type CollaborationParticipant,
   type CollaborationPresence,
   type CollaborationState,
@@ -210,6 +211,8 @@ export interface AppState {
     clientId: string,
     presence: CollaborationPresence | null
   ) => void;
+  /** Append a chat message to the session log (bounded; #754). */
+  addCollaborationChat: (message: CollaborationChatMessage) => void;
   resetCollaboration: () => void;
   setMapView: (view: Partial<MapViewState>, markDirty?: boolean) => void;
   /**
@@ -367,8 +370,13 @@ export const DEFAULT_COLLABORATION_STATE: CollaborationState = Object.freeze({
     CollaborationPresence
   >,
   followHost: false,
+  chat: Object.freeze([] as CollaborationChatMessage[]) as CollaborationChatMessage[],
   error: null,
 });
+
+// Cap the in-store chat log so a long session can't grow it without bound; it
+// mirrors the relay's own history limit.
+const MAX_COLLABORATION_CHAT = 200;
 
 /** Derive a human-friendly display name from a file path or URL. */
 export function projectPathLabel(path: string): string {
@@ -583,6 +591,16 @@ export const useAppStore = create<AppState>()(
             next[clientId] = presence;
           }
           return { collaboration: { ...s.collaboration, presence: next } };
+        }),
+      addCollaborationChat: (message) =>
+        set((s) => {
+          // Ignore a duplicate id: the server broadcasts to the sender too, and a
+          // reconnect can replay recent history, so de-dupe defensively.
+          if (s.collaboration.chat.some((m) => m.id === message.id)) return s;
+          const chat = [...s.collaboration.chat, message].slice(
+            -MAX_COLLABORATION_CHAT
+          );
+          return { collaboration: { ...s.collaboration, chat } };
         }),
       resetCollaboration: () =>
         // Also close the Collaborate dialog: an unexpected disconnect resets the

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -374,8 +374,10 @@ export const DEFAULT_COLLABORATION_STATE: CollaborationState = Object.freeze({
   error: null,
 });
 
-// Cap the in-store chat log so a long session can't grow it without bound; it
-// mirrors the relay's own history limit.
+// Cap the in-store chat log so a long session can't grow it without bound. This
+// is intentionally larger than the relay's persisted history (50): the live
+// session accumulates messages locally, while the relay only retains the tail
+// for late joiners.
 const MAX_COLLABORATION_CHAT = 200;
 
 /** Derive a human-friendly display name from a file path or URL. */

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -596,12 +596,12 @@ export const useAppStore = create<AppState>()(
         }),
       addCollaborationChat: (message) =>
         set((s) => {
+          // Default to [] in case an older relay left the slice undefined.
+          const current = s.collaboration.chat ?? [];
           // Ignore a duplicate id: the server broadcasts to the sender too, and a
           // reconnect can replay recent history, so de-dupe defensively.
-          if (s.collaboration.chat.some((m) => m.id === message.id)) return s;
-          const chat = [...s.collaboration.chat, message].slice(
-            -MAX_COLLABORATION_CHAT
-          );
+          if (current.some((m) => m.id === message.id)) return s;
+          const chat = [...current, message].slice(-MAX_COLLABORATION_CHAT);
           return { collaboration: { ...s.collaboration, chat } };
         }),
       resetCollaboration: () =>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -585,6 +585,12 @@ export interface CollaborationParticipant {
   displayName: string;
   color: string;
   role: CollaborationRole;
+  /**
+   * Host-set per-participant edit override (#754). `null` follows the session
+   * `mode`; `true`/`false` pins this participant to can-edit / view-only. Always
+   * `null` for the host (the host can always edit).
+   */
+  editOverride: boolean | null;
 }
 
 /** A remote participant's live cursor + viewport, used to render presence. */
@@ -593,6 +599,21 @@ export interface CollaborationPresence {
   color: string;
   cursor?: { lng: number; lat: number } | null;
   view?: MapViewState | null;
+}
+
+/** One in-session chat message (#754). Ephemeral; never persisted to a project. */
+export interface CollaborationChatMessage {
+  /** Server-assigned id (stable React key / dedupe). */
+  id: string;
+  /** clientId of the author. */
+  clientId: string;
+  displayName: string;
+  color: string;
+  text: string;
+  /** Optional map coordinate the author attached; clickable to recenter. */
+  coordinate?: { lng: number; lat: number } | null;
+  /** Server-assigned epoch-ms timestamp. */
+  ts: number;
 }
 
 export interface CollaborationState {
@@ -611,6 +632,8 @@ export interface CollaborationState {
   presence: Record<string, CollaborationPresence>;
   /** When true, this participant's camera follows the host's viewport. */
   followHost: boolean;
+  /** Recent session chat, oldest first, capped to a bounded window (#754). */
+  chat: CollaborationChatMessage[];
   /** Last human-readable error, surfaced in the Collaborate dialog. */
   error: string | null;
 }

--- a/tests/collab-protocol.test.ts
+++ b/tests/collab-protocol.test.ts
@@ -7,10 +7,12 @@ import {
   resolveCollabBaseUrl,
   sessionWsUrl,
 } from "../apps/geolibre-desktop/src/lib/collab-client";
+import { participantCanEdit } from "../apps/geolibre-desktop/src/lib/collab-protocol";
 import type {
   ClientMessage,
   ServerMessage,
 } from "../apps/geolibre-desktop/src/lib/collab-protocol";
+import type { CollaborationParticipant } from "@geolibre/core";
 
 describe("resolveCollabBaseUrl", () => {
   it("accepts a wss host", () => {
@@ -62,6 +64,83 @@ describe("url derivation", () => {
     assert.equal(
       sessionWsUrl("wss://collab.geolibre.app", "AB CD"),
       "wss://collab.geolibre.app/sessions/AB%20CD/ws",
+    );
+  });
+});
+
+describe("participantCanEdit", () => {
+  const base = (
+    over: Partial<CollaborationParticipant>,
+  ): CollaborationParticipant => ({
+    clientId: "x",
+    displayName: "X",
+    color: "#000000",
+    role: "guest",
+    editOverride: null,
+    ...over,
+  });
+
+  it("always lets the host edit, regardless of mode", () => {
+    assert.equal(participantCanEdit(base({ role: "host" }), "view-only"), true);
+    assert.equal(participantCanEdit(base({ role: "host" }), "co-edit"), true);
+  });
+
+  it("follows the session mode when there is no override", () => {
+    assert.equal(participantCanEdit(base({}), "co-edit"), true);
+    assert.equal(participantCanEdit(base({}), "view-only"), false);
+  });
+
+  it("lets a host-set override win over the session mode", () => {
+    // Pinned to view-only inside an otherwise co-edit session.
+    assert.equal(
+      participantCanEdit(base({ editOverride: false }), "co-edit"),
+      false,
+    );
+    // Granted edit inside an otherwise view-only session.
+    assert.equal(
+      participantCanEdit(base({ editOverride: true }), "view-only"),
+      true,
+    );
+  });
+});
+
+describe("new protocol messages round-trip", () => {
+  it("serializes a set-participant-mode client message", () => {
+    const msg: ClientMessage = {
+      type: "set-participant-mode",
+      clientId: "guest-1",
+      canEdit: false,
+    };
+    assert.deepEqual(JSON.parse(JSON.stringify(msg)), msg);
+  });
+
+  it("serializes a chat send with an attached coordinate", () => {
+    const msg: ClientMessage = {
+      type: "chat",
+      text: "look here",
+      coordinate: { lng: -122.4, lat: 37.8 },
+    };
+    assert.deepEqual(JSON.parse(JSON.stringify(msg)), msg);
+  });
+
+  it("parses a chat broadcast server message", () => {
+    const server: ServerMessage = {
+      type: "chat",
+      message: {
+        id: "m1",
+        clientId: "c1",
+        displayName: "Alex",
+        color: "#2563eb",
+        text: "hi",
+        coordinate: null,
+        ts: 1_700_000_000_000,
+      },
+    };
+    const parsed = JSON.parse(JSON.stringify(server)) as ServerMessage;
+    assert.equal(parsed.type, "chat");
+    assert.equal(
+      parsed.type === "chat" ? parsed.message.text : null,
+      "hi",
     );
   });
 });
@@ -168,6 +247,8 @@ describe("CollabConnection", () => {
       mode: "co-edit",
       participants: [],
       snapshot: null,
+      presence: {},
+      chat: [],
       rev: 0,
     };
     socket.emit("message", { data: JSON.stringify(welcome) });

--- a/workers/collab/src/protocol.ts
+++ b/workers/collab/src/protocol.ts
@@ -14,11 +14,33 @@ export interface CollabParticipant {
   displayName: string;
   color: string;
   role: CollaborationRole;
+  /**
+   * Host-set per-participant edit override (#754, Part 3). `null` means "follow
+   * the session mode"; `true`/`false` pins this participant to can-edit /
+   * view-only regardless of the session default. Always `null` for the host
+   * (the host can always edit).
+   */
+  editOverride: boolean | null;
 }
 
 export interface CollabCursor {
   lng: number;
   lat: number;
+}
+
+/** One in-session chat message (#754, Part 4). Ephemeral session state. */
+export interface CollabChatMessage {
+  /** Server-assigned id (dedupes optimistic local rendering / React keys). */
+  id: string;
+  /** clientId of the author. */
+  clientId: string;
+  displayName: string;
+  color: string;
+  text: string;
+  /** Optional map coordinate the author attached; clickable in peers' UIs. */
+  coordinate?: CollabCursor | null;
+  /** Server-assigned epoch-ms timestamp. */
+  ts: number;
 }
 
 export interface CollabView {
@@ -57,11 +79,27 @@ export interface SetModeMessage {
   mode: CollaborationMode;
 }
 
+/** Host-only: pin one participant to can-edit / view-only (#754, Part 3). */
+export interface SetParticipantModeMessage {
+  type: "set-participant-mode";
+  clientId: string;
+  canEdit: boolean;
+}
+
+/** Send a chat message to the session (#754, Part 4). */
+export interface ChatSendMessage {
+  type: "chat";
+  text: string;
+  coordinate?: CollabCursor | null;
+}
+
 export type ClientMessage =
   | JoinMessage
   | ClientSnapshotMessage
   | ClientPresenceMessage
-  | SetModeMessage;
+  | SetModeMessage
+  | SetParticipantModeMessage
+  | ChatSendMessage;
 
 // Server -> client -----------------------------------------------------------
 
@@ -75,6 +113,8 @@ export interface WelcomeMessage {
   /** Current presence of existing participants (keyed by clientId) so a late
    *  joiner sees their cursors/viewports without waiting for the next move. */
   presence: Record<string, PresenceEntry>;
+  /** Recent chat history so a late joiner sees the conversation so far (#754). */
+  chat: CollabChatMessage[];
   rev: number;
 }
 
@@ -107,6 +147,13 @@ export interface ModeMessage {
   mode: CollaborationMode;
 }
 
+/** Fan-out of a chat message to every participant (including the sender, so the
+ *  server's ordering is authoritative). */
+export interface ChatBroadcastMessage {
+  type: "chat";
+  message: CollabChatMessage;
+}
+
 export interface ErrorMessage {
   type: "error";
   code: "forbidden" | "too-large" | "bad-message" | "not-found";
@@ -119,4 +166,5 @@ export type ServerMessage =
   | ServerPresenceMessage
   | ParticipantsMessage
   | ModeMessage
+  | ChatBroadcastMessage
   | ErrorMessage;

--- a/workers/collab/src/session.ts
+++ b/workers/collab/src/session.ts
@@ -80,6 +80,11 @@ const MAX_CHAT_TEXT_LENGTH = 2000;
 // How many recent chat messages to retain so a late joiner sees recent history.
 // Persisted (not in-memory) so it survives a hibernation between messages.
 const CHAT_HISTORY_LIMIT = 50;
+// Minimum gap between a socket's chat frames. Each chat costs a storage
+// read+write and a fan-out, so silently drop bursts faster than this floor to
+// keep one client from exhausting the session's storage-op budget. Generous
+// enough that normal typing/sending is never affected.
+const MIN_CHAT_INTERVAL_MS = 250;
 
 // Stateless and reused across frames (snapshots can arrive several times a
 // second), so we don't allocate a new encoder per message.
@@ -97,6 +102,8 @@ interface SocketAttachment {
    * never persisted to storage (it is keyed to a clientId, which is per-socket).
    */
   editOverride?: boolean;
+  /** Epoch-ms of this socket's last accepted chat frame, for rate-limiting. */
+  lastChatTs?: number;
 }
 
 /** Effective edit permission: the host always edits; otherwise a host-set
@@ -246,7 +253,7 @@ export class CollabSession extends DurableObject<Env> {
         await this.handleSetMode(ws, attachment, message.mode);
         break;
       case "set-participant-mode":
-        await this.handleSetParticipantMode(ws, attachment, message);
+        this.handleSetParticipantMode(ws, attachment, message);
         break;
       case "chat":
         await this.handleChat(ws, attachment, message);
@@ -447,11 +454,11 @@ export class CollabSession extends DurableObject<Env> {
     this.broadcast({ type: "mode", mode: next });
   }
 
-  private async handleSetParticipantMode(
+  private handleSetParticipantMode(
     ws: WebSocket,
     attachment: SocketAttachment,
     message: Extract<ClientMessage, { type: "set-participant-mode" }>,
-  ): Promise<void> {
+  ): void {
     if (attachment.role !== "host") {
       this.send(ws, {
         type: "error",
@@ -468,7 +475,10 @@ export class CollabSession extends DurableObject<Env> {
     const targetAttachment =
       target.deserializeAttachment() as SocketAttachment | null;
     if (!targetAttachment || targetAttachment.role === "host") return;
-    targetAttachment.editOverride = message.canEdit;
+    // Coerce to a strict boolean: `message` is untrusted JSON (the static type
+    // is erased at runtime), so a crafted `"canEdit": 1` must not store a
+    // non-boolean on the attachment.
+    targetAttachment.editOverride = message.canEdit === true;
     target.serializeAttachment(targetAttachment);
     // Everyone re-derives effective permission from the participants list (the
     // affected guest learns its own change here too), so a single broadcast
@@ -488,6 +498,18 @@ export class CollabSession extends DurableObject<Env> {
         ? message.text.trim().slice(0, MAX_CHAT_TEXT_LENGTH)
         : "";
     if (!text) return;
+    // Per-socket rate limit: silently drop a burst that arrives faster than the
+    // floor so one client can't flood the storage-op budget / fan-out. The last
+    // accepted timestamp rides on the attachment, so it survives a hibernation.
+    const now = Date.now();
+    if (
+      attachment.lastChatTs !== undefined &&
+      now - attachment.lastChatTs < MIN_CHAT_INTERVAL_MS
+    ) {
+      return;
+    }
+    attachment.lastChatTs = now;
+    ws.serializeAttachment(attachment);
     const chatMessage: CollabChatMessage = {
       id: crypto.randomUUID(),
       clientId: attachment.clientId,
@@ -497,7 +519,7 @@ export class CollabSession extends DurableObject<Env> {
       // Reuse the cursor sanitizer so a crafted coordinate can't reach peers'
       // map APIs as NaN/strings.
       coordinate: sanitizeCursor(message.coordinate),
-      ts: Date.now(),
+      ts: now,
     };
     // Persist a bounded history so a late joiner (or a post-hibernation welcome)
     // sees the recent conversation. Read-modify-write is safe: a Durable Object

--- a/workers/collab/src/session.ts
+++ b/workers/collab/src/session.ts
@@ -468,9 +468,11 @@ export class CollabSession extends DurableObject<Env> {
         clearedAny = true;
       }
     }
-    this.broadcast({ type: "mode", mode: next });
-    // Re-broadcast the roster so clients drop the now-cleared `editOverride`s.
+    // Broadcast the cleared roster first, then the new mode, so clients have
+    // dropped the stale `editOverride`s by the time they apply the mode change
+    // (the two frames are sent back-to-back with no await between them).
     if (clearedAny) this.broadcastParticipants();
+    this.broadcast({ type: "mode", mode: next });
   }
 
   private handleSetParticipantMode(

--- a/workers/collab/src/session.ts
+++ b/workers/collab/src/session.ts
@@ -495,6 +495,9 @@ export class CollabSession extends DurableObject<Env> {
     // (and any other host socket) is always an editor, so refuse to override one
     // — that keeps `editOverride` meaningful only for guests.
     const target = this.socketByClientId(message.clientId);
+    // Target disconnected between the host's click and this frame: the
+    // disconnect already broadcasts an updated roster, so the host's view (and
+    // the now-absent toggle) reconciles on its own; no error frame needed.
     if (!target) return;
     const targetAttachment =
       target.deserializeAttachment() as SocketAttachment | null;
@@ -552,16 +555,17 @@ export class CollabSession extends DurableObject<Env> {
     log.push(chatMessage);
     // Bound by count AND serialized bytes: 50 messages can still exceed the
     // ~128 KiB per-value storage cap when they hold long multi-byte (e.g. CJK)
-    // text, so drop the oldest until the JSON fits a safe budget.
+    // text, so drop the oldest until the JSON fits a safe budget. Track the byte
+    // length incrementally (encode once, then subtract each evicted entry plus
+    // its comma separator) so the loop stays O(n) rather than re-encoding the
+    // whole array each iteration.
     let trimmed = log.slice(-CHAT_HISTORY_LIMIT);
-    let serialized = JSON.stringify(trimmed);
-    while (
-      trimmed.length > 1 &&
-      ENCODER.encode(serialized).length > MAX_CHAT_STORAGE_BYTES
-    ) {
+    let byteLen = ENCODER.encode(JSON.stringify(trimmed)).length;
+    while (trimmed.length > 1 && byteLen > MAX_CHAT_STORAGE_BYTES) {
+      byteLen -= ENCODER.encode(JSON.stringify(trimmed[0])).length + 1;
       trimmed = trimmed.slice(1);
-      serialized = JSON.stringify(trimmed);
     }
+    const serialized = JSON.stringify(trimmed);
     try {
       await this.ctx.storage.put("chat", serialized);
     } catch {

--- a/workers/collab/src/session.ts
+++ b/workers/collab/src/session.ts
@@ -80,6 +80,9 @@ const MAX_CHAT_TEXT_LENGTH = 2000;
 // How many recent chat messages to retain so a late joiner sees recent history.
 // Persisted (not in-memory) so it survives a hibernation between messages.
 const CHAT_HISTORY_LIMIT = 50;
+// Hard byte budget for the persisted chat log, comfortably under Cloudflare's
+// ~128 KiB per-value storage cap (multi-byte text can blow the count limit).
+const MAX_CHAT_STORAGE_BYTES = 100_000;
 // Minimum gap between a socket's chat frames. Each chat costs a storage
 // read+write and a fan-out, so silently drop bursts faster than this floor to
 // keep one client from exhausting the session's storage-op budget. Generous
@@ -451,7 +454,23 @@ export class CollabSession extends DurableObject<Env> {
     }
     const next: CollaborationMode = mode === "view-only" ? "view-only" : "co-edit";
     await this.ctx.storage.put("mode", next);
+    // A session-wide mode change is authoritative: clear any per-participant
+    // overrides so the new mode applies to everyone. Without this, a guest the
+    // host previously pinned to can-edit would keep editing through a later
+    // switch to view-only (a "sticky override" footgun), and there is otherwise
+    // no path to reset an override back to "follow the session mode".
+    let clearedAny = false;
+    for (const socket of this.ctx.getWebSockets()) {
+      const a = socket.deserializeAttachment() as SocketAttachment | null;
+      if (a && a.editOverride !== undefined) {
+        a.editOverride = undefined;
+        socket.serializeAttachment(a);
+        clearedAny = true;
+      }
+    }
     this.broadcast({ type: "mode", mode: next });
+    // Re-broadcast the roster so clients drop the now-cleared `editOverride`s.
+    if (clearedAny) this.broadcastParticipants();
   }
 
   private handleSetParticipantMode(
@@ -467,6 +486,9 @@ export class CollabSession extends DurableObject<Env> {
       });
       return;
     }
+    // `message` is untrusted JSON, so guard the lookup key's type (mirrors the
+    // strict-boolean coercion below) before matching it against attachments.
+    if (typeof message.clientId !== "string") return;
     // Find the addressed participant's socket and pin its override. The host
     // (and any other host socket) is always an editor, so refuse to override one
     // — that keeps `editOverride` meaningful only for guests.
@@ -526,8 +548,25 @@ export class CollabSession extends DurableObject<Env> {
     // processes one message at a time and input-gates across the await.
     const log = parseStoredChat(await this.ctx.storage.get<string>("chat"));
     log.push(chatMessage);
-    const trimmed = log.slice(-CHAT_HISTORY_LIMIT);
-    await this.ctx.storage.put("chat", JSON.stringify(trimmed));
+    // Bound by count AND serialized bytes: 50 messages can still exceed the
+    // ~128 KiB per-value storage cap when they hold long multi-byte (e.g. CJK)
+    // text, so drop the oldest until the JSON fits a safe budget.
+    let trimmed = log.slice(-CHAT_HISTORY_LIMIT);
+    let serialized = JSON.stringify(trimmed);
+    while (
+      trimmed.length > 1 &&
+      ENCODER.encode(serialized).length > MAX_CHAT_STORAGE_BYTES
+    ) {
+      trimmed = trimmed.slice(1);
+      serialized = JSON.stringify(trimmed);
+    }
+    try {
+      await this.ctx.storage.put("chat", serialized);
+    } catch {
+      // Persisting failed (e.g. the single message still exceeds the value cap).
+      // Don't let it propagate and close the socket; the message is still fanned
+      // out below, it just won't join the late-joiner history.
+    }
     // Broadcast to everyone including the sender so the server's ordering is the
     // single source of truth (the sender renders from this echo, not optimistically).
     this.broadcast({ type: "chat", message: chatMessage });

--- a/workers/collab/src/session.ts
+++ b/workers/collab/src/session.ts
@@ -1,5 +1,6 @@
 import { DurableObject } from "cloudflare:workers";
 import type {
+  CollabChatMessage,
   CollabCursor,
   CollabParticipant,
   CollabView,
@@ -74,6 +75,12 @@ const MAX_SNAPSHOT_BYTES = 1_000_000;
 // abandoned codes don't accumulate. A rejoin before the alarm fires cancels it.
 const EMPTY_SESSION_TTL_MS = 2 * 60 * 60 * 1000;
 
+// Cap a single chat message so one frame can't store an unbounded string.
+const MAX_CHAT_TEXT_LENGTH = 2000;
+// How many recent chat messages to retain so a late joiner sees recent history.
+// Persisted (not in-memory) so it survives a hibernation between messages.
+const CHAT_HISTORY_LIMIT = 50;
+
 // Stateless and reused across frames (snapshots can arrive several times a
 // second), so we don't allocate a new encoder per message.
 const ENCODER = new TextEncoder();
@@ -83,6 +90,33 @@ interface SocketAttachment {
   displayName: string;
   color: string;
   role: CollaborationRole;
+  /**
+   * Host-set per-participant edit override (#754, Part 3). `undefined` means
+   * "follow the session mode"; `true`/`false` pins this socket to can-edit /
+   * view-only. Stored on the attachment so it survives a hibernation wake and is
+   * never persisted to storage (it is keyed to a clientId, which is per-socket).
+   */
+  editOverride?: boolean;
+}
+
+/** Effective edit permission: the host always edits; otherwise a host-set
+ *  override wins, falling back to the session mode. */
+function canEdit(attachment: SocketAttachment, mode: CollaborationMode): boolean {
+  if (attachment.role === "host") return true;
+  if (attachment.editOverride !== undefined) return attachment.editOverride;
+  return mode === "co-edit";
+}
+
+/** Parse the stored chat log defensively; a corrupt value yields an empty log
+ *  rather than throwing (which would lock joiners out of the welcome). */
+function parseStoredChat(raw: string | undefined): CollabChatMessage[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as CollabChatMessage[]) : [];
+  } catch {
+    return [];
+  }
 }
 
 type PresenceState = PresenceEntry;
@@ -211,6 +245,12 @@ export class CollabSession extends DurableObject<Env> {
       case "set-mode":
         await this.handleSetMode(ws, attachment, message.mode);
         break;
+      case "set-participant-mode":
+        await this.handleSetParticipantMode(ws, attachment, message);
+        break;
+      case "chat":
+        await this.handleChat(ws, attachment, message);
+        break;
     }
   }
 
@@ -261,11 +301,12 @@ export class CollabSession extends DurableObject<Env> {
     // close handler only deletes the current clientId).
     if (ws.deserializeAttachment()) return;
 
-    const [storedToken, mode, rev, snapshot] = await Promise.all([
+    const [storedToken, mode, rev, snapshot, chat] = await Promise.all([
       this.ctx.storage.get<string>("hostToken"),
       this.ctx.storage.get<CollaborationMode>("mode"),
       this.ctx.storage.get<number>("rev"),
       this.ctx.storage.get<string>("snapshot"),
+      this.ctx.storage.get<string>("chat"),
     ]);
 
     const role: CollaborationRole =
@@ -304,6 +345,8 @@ export class CollabSession extends DurableObject<Env> {
       snapshot: parseStoredSnapshot(snapshot),
       // Bootstrap the joiner with existing participants' live cursors/viewports.
       presence: Object.fromEntries(this.presence),
+      // Bootstrap the joiner with the recent chat history.
+      chat: parseStoredChat(chat),
       rev: rev ?? 0,
     });
 
@@ -320,11 +363,17 @@ export class CollabSession extends DurableObject<Env> {
   ): Promise<void> {
     const mode =
       (await this.ctx.storage.get<CollaborationMode>("mode")) ?? "co-edit";
-    if (attachment.role !== "host" && mode === "view-only") {
+    // A host-set per-participant override takes precedence over the session
+    // default, so a single guest can be pinned to view-only (or granted edit) in
+    // an otherwise co-edit (or view-only) session (#754, Part 3).
+    if (!canEdit(attachment, mode)) {
       this.send(ws, {
         type: "error",
         code: "forbidden",
-        message: "This session is view-only.",
+        message:
+          attachment.editOverride === false
+            ? "The host has set you to view-only."
+            : "This session is view-only.",
       });
       return;
     }
@@ -398,7 +447,79 @@ export class CollabSession extends DurableObject<Env> {
     this.broadcast({ type: "mode", mode: next });
   }
 
+  private async handleSetParticipantMode(
+    ws: WebSocket,
+    attachment: SocketAttachment,
+    message: Extract<ClientMessage, { type: "set-participant-mode" }>,
+  ): Promise<void> {
+    if (attachment.role !== "host") {
+      this.send(ws, {
+        type: "error",
+        code: "forbidden",
+        message: "Only the host can change participant permissions.",
+      });
+      return;
+    }
+    // Find the addressed participant's socket and pin its override. The host
+    // (and any other host socket) is always an editor, so refuse to override one
+    // — that keeps `editOverride` meaningful only for guests.
+    const target = this.socketByClientId(message.clientId);
+    if (!target) return;
+    const targetAttachment =
+      target.deserializeAttachment() as SocketAttachment | null;
+    if (!targetAttachment || targetAttachment.role === "host") return;
+    targetAttachment.editOverride = message.canEdit;
+    target.serializeAttachment(targetAttachment);
+    // Everyone re-derives effective permission from the participants list (the
+    // affected guest learns its own change here too), so a single broadcast
+    // suffices.
+    this.broadcastParticipants();
+  }
+
+  private async handleChat(
+    ws: WebSocket,
+    attachment: SocketAttachment,
+    message: Extract<ClientMessage, { type: "chat" }>,
+  ): Promise<void> {
+    // Chat is open to everyone in the session, including view-only guests; only
+    // project edits are gated. Reject an empty or non-string body.
+    const text =
+      typeof message.text === "string"
+        ? message.text.trim().slice(0, MAX_CHAT_TEXT_LENGTH)
+        : "";
+    if (!text) return;
+    const chatMessage: CollabChatMessage = {
+      id: crypto.randomUUID(),
+      clientId: attachment.clientId,
+      displayName: attachment.displayName,
+      color: attachment.color,
+      text,
+      // Reuse the cursor sanitizer so a crafted coordinate can't reach peers'
+      // map APIs as NaN/strings.
+      coordinate: sanitizeCursor(message.coordinate),
+      ts: Date.now(),
+    };
+    // Persist a bounded history so a late joiner (or a post-hibernation welcome)
+    // sees the recent conversation. Read-modify-write is safe: a Durable Object
+    // processes one message at a time and input-gates across the await.
+    const log = parseStoredChat(await this.ctx.storage.get<string>("chat"));
+    log.push(chatMessage);
+    const trimmed = log.slice(-CHAT_HISTORY_LIMIT);
+    await this.ctx.storage.put("chat", JSON.stringify(trimmed));
+    // Broadcast to everyone including the sender so the server's ordering is the
+    // single source of truth (the sender renders from this echo, not optimistically).
+    this.broadcast({ type: "chat", message: chatMessage });
+  }
+
   // -- helpers ----------------------------------------------------------------
+
+  private socketByClientId(clientId: string): WebSocket | null {
+    for (const socket of this.ctx.getWebSockets()) {
+      const a = socket.deserializeAttachment() as SocketAttachment | null;
+      if (a?.clientId === clientId) return socket;
+    }
+    return null;
+  }
 
   private participants(except?: WebSocket): CollabParticipant[] {
     const result: CollabParticipant[] = [];
@@ -411,6 +532,9 @@ export class CollabSession extends DurableObject<Env> {
           displayName: a.displayName,
           color: a.color,
           role: a.role,
+          // Normalize the attachment's `undefined` (follow session mode) to the
+          // wire's `null`; the host is always an editor with no override.
+          editOverride: a.role === "host" ? null : a.editOverride ?? null,
         });
       }
     }


### PR DESCRIPTION
Fixes #754 (Parts 3 and 4, completing the 4-part request; Parts 1 and 2 shipped in #761).

Both features build on the existing Cloudflare Durable Object relay with new wire-protocol messages. `useCollaboration` is lifted to `DesktopShell` so the Collaborate dialog and the on-canvas status badge share one socket.

## Part 3 - Granular per-participant permissions
The host can now pin an individual guest to **view-only** or **can edit**, beyond the session-wide mode.

- New host-only `set-participant-mode { clientId, canEdit }` frame. The relay records the override on that guest's socket attachment (so it survives a hibernation wake) and re-broadcasts the participant list with an `editOverride` field (`true` / `false` / `null` = follow session mode).
- Effective edit permission is computed identically on the relay and the client (`participantCanEdit`): the host always edits, otherwise a host-set override wins, otherwise the session mode applies. A guest pinned to view-only has their snapshot pushes rejected with `error: forbidden`, the same enforcement path as session-wide view-only.
- `set-participant-mode` requires the host token, so a guest cannot escalate themselves or another guest.
- The roster (in both the Collaborate dialog and the on-canvas badge) shows a per-guest permission toggle for the host; other participants see each guest's current permission read-only.

## Part 4 - In-session chat
A lightweight text channel reachable while working on the map.

- New `chat { text, coordinate? }` frame, validated server-side (non-empty, trimmed, 2000-char cap; the coordinate runs through the same finite-number sanitizer as presence) and fanned out to **every** participant including the sender, so the relay's ordering is the single source of truth.
- A bounded, persisted history (last 50 messages) bootstraps a late joiner (or a post-hibernation welcome) via `welcome.chat[]`. Chat is open to view-only guests; only project edits are gated.
- The on-canvas status badge gains a chat drawer: a scrollable message list, a composer that can attach the sender's current map center as a clickable coordinate (recenters the recipient's map), and an unread-count badge on the collapsed pill while it is closed.

## Not changed
No new accounts/identity, no CRDT. This stays within the experimental MVP's anonymous, last-write-wins model; overrides and chat are ephemeral session state (overrides are keyed to the per-socket clientId, so a reconnecting guest reverts to the session default).

## Verification
- `npm run build`, `npm run test:worker`, and `npm run test:frontend` (1481 pass) all green; `pre-commit run --files` clean (eslint + npm build).
- Extended `tests/collab-protocol.test.ts`: `participantCanEdit` truth table and round-trips for the new `set-participant-mode` / `chat` frames.
- Drove the real web app end to end against a local relay with Playwright (two independent browser sessions, host + guest), in **both light and dark themes**: host pins the guest to view-only and the guest's roster reflects it live; the guest sends a chat with an attached location and the host sees the message and clickable coordinate; the host replies and the guest receives it.

Docs updated in `docs/collaboration.md` (protocol tables, permissions, a Chat section, and the local test steps).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added host-controlled per-participant edit permissions during an active collaboration session.
  * Upgraded the collaboration roster to dedicated participant rows with host-only management controls.
  * Introduced in-session chat with recent-history loading, optional location attachment, “go to location” actions, and unread messaging (with `99+` cap on the collapsed indicator).
* **Bug Fixes**
  * Improved chat state handling by resetting chat/unread state when collaboration ends.
* **Documentation**
  * Updated collaboration documentation for the new permission and chat synchronization behavior.
* **Tests**
  * Added unit tests for per-participant permission logic and chat/protocol round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->