### PR TITLE
fix(collab): keep chat draft on dropped send; validate stored chat records

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/CollaborationStatusBadge.tsx
+++ b/apps/geolibre-desktop/src/components/layout/CollaborationStatusBadge.tsx
@@ -242,16 +242,20 @@ export function CollaborationStatusBadge({
     // losing the text. (Human-paced typing never hits this; double-Enter does.)
     const now = Date.now();
     if (now - lastSentAtRef.current < MIN_CHAT_SEND_INTERVAL_MS) return;
-    lastSentAtRef.current = now;
     // Capture the live map center only when the pin is active, at send time.
     const center =
       attachLocation && mapControllerRef.current
         ? mapControllerRef.current.getMap()?.getCenter()
         : null;
-    api.sendChat(
+    const sent = api.sendChat(
       text,
       center ? { lng: center.lng, lat: center.lat } : null,
     );
+    // Only clear the composer (and stamp the floor) when the message actually
+    // reached an open socket; otherwise keep the draft so a transient
+    // disconnect doesn't lose it.
+    if (!sent) return;
+    lastSentAtRef.current = now;
     setDraft("");
     setAttachLocation(false);
   };

--- a/apps/geolibre-desktop/src/hooks/useCollaboration.ts
+++ b/apps/geolibre-desktop/src/hooks/useCollaboration.ts
@@ -46,8 +46,15 @@ export interface CollaborationApi {
   setParticipantMode: (clientId: string, canEdit: boolean) => void;
   /** Toggle whether this participant's camera follows the host's viewport. */
   setFollowHost: (enabled: boolean) => void;
-  /** Send a chat message to the session, optionally attaching a coordinate (#754). */
-  sendChat: (text: string, coordinate?: { lng: number; lat: number } | null) => void;
+  /**
+   * Send a chat message to the session, optionally attaching a coordinate
+   * (#754). Returns true if it reached an open socket, so the caller can keep
+   * the draft when a send is dropped (socket not open).
+   */
+  sendChat: (
+    text: string,
+    coordinate?: { lng: number; lat: number } | null,
+  ) => boolean;
 }
 
 /**
@@ -482,8 +489,11 @@ export function useCollaboration(
   const sendChat = useCallback(
     (text: string, coordinate?: { lng: number; lat: number } | null) => {
       const trimmed = text.trim();
-      if (!trimmed) return;
-      connRef.current?.send({ type: "chat", text: trimmed, coordinate });
+      if (!trimmed) return false;
+      return (
+        connRef.current?.send({ type: "chat", text: trimmed, coordinate }) ??
+        false
+      );
     },
     [],
   );

--- a/apps/geolibre-desktop/src/lib/collab-client.ts
+++ b/apps/geolibre-desktop/src/lib/collab-client.ts
@@ -204,11 +204,19 @@ export class CollabConnection {
     this.reconnectTimer = setTimeout(() => this.open(), jittered);
   }
 
-  /** Send a client message if the socket is open; silently drops otherwise. */
-  send(message: ClientMessage): void {
+  /**
+   * Send a client message if the socket is open.
+   *
+   * @param message - The message to send.
+   * @returns True if it was written to an open socket; false if it was dropped
+   *   (no socket / not open), so callers can avoid discarding unsent state.
+   */
+  send(message: ClientMessage): boolean {
     if (this.ws && this.ws.readyState === this.WebSocketImpl.OPEN) {
       this.ws.send(JSON.stringify(message));
+      return true;
     }
+    return false;
   }
 
   /** Permanently close the connection and stop reconnecting. */

--- a/workers/collab/src/session.ts
+++ b/workers/collab/src/session.ts
@@ -126,18 +126,18 @@ function canEdit(attachment: SocketAttachment, mode: CollaborationMode): boolean
 function isValidChatMessage(m: unknown): m is CollabChatMessage {
   if (!m || typeof m !== "object") return false;
   const o = m as Record<string, unknown>;
+  const coord = o.coordinate as Record<string, unknown> | null | undefined;
   const coordOk =
-    o.coordinate === null ||
-    o.coordinate === undefined ||
-    (typeof o.coordinate === "object" &&
-      finite((o.coordinate as Record<string, unknown>).lng) &&
-      finite((o.coordinate as Record<string, unknown>).lat));
+    coord === null ||
+    coord === undefined ||
+    (typeof coord === "object" && finite(coord.lng) && finite(coord.lat));
   return (
     typeof o.id === "string" &&
     typeof o.clientId === "string" &&
     typeof o.displayName === "string" &&
-    // Match the write path's guarantees: a hex color and non-empty text, so a
-    // corrupt record can't reach clients with a hostile color or blank body.
+    // Reject records whose field types/shapes would crash or mislead a client:
+    // a non-hex color, a blank body, a non-finite timestamp, or a bad coordinate
+    // (which would crash `coordinate.lat.toFixed`). Not a full write-path mirror.
     typeof o.color === "string" &&
     HEX_COLOR_RE.test(o.color) &&
     typeof o.text === "string" &&
@@ -367,7 +367,12 @@ export class CollabSession extends DurableObject<Env> {
           .slice(0, 60) || "Guest",
       // Only accept a hex color; fall back to neutral grey so a hostile value
       // never reaches peers (defense-in-depth with the client's DOM rendering).
-      color: HEX_COLOR_RE.test(message.color) ? message.color : "#888888",
+      // Guard the type first: `.test()` coerces a non-string (number/array) to a
+      // string, which could spuriously pass and store a non-string color.
+      color:
+        typeof message.color === "string" && HEX_COLOR_RE.test(message.color)
+          ? message.color
+          : "#888888",
       role,
     };
     ws.serializeAttachment(attachment);

--- a/workers/collab/src/session.ts
+++ b/workers/collab/src/session.ts
@@ -117,13 +117,36 @@ function canEdit(attachment: SocketAttachment, mode: CollaborationMode): boolean
   return mode === "co-edit";
 }
 
+/** Validate a single stored chat entry's field types so a corrupt record can't
+ *  reach clients (where it would, e.g., crash `coordinate.lat.toFixed`). */
+function isValidChatMessage(m: unknown): m is CollabChatMessage {
+  if (!m || typeof m !== "object") return false;
+  const o = m as Record<string, unknown>;
+  const coordOk =
+    o.coordinate === null ||
+    o.coordinate === undefined ||
+    (typeof o.coordinate === "object" &&
+      finite((o.coordinate as Record<string, unknown>).lng) &&
+      finite((o.coordinate as Record<string, unknown>).lat));
+  return (
+    typeof o.id === "string" &&
+    typeof o.clientId === "string" &&
+    typeof o.displayName === "string" &&
+    typeof o.color === "string" &&
+    typeof o.text === "string" &&
+    typeof o.ts === "number" &&
+    coordOk
+  );
+}
+
 /** Parse the stored chat log defensively; a corrupt value yields an empty log
- *  rather than throwing (which would lock joiners out of the welcome). */
+ *  (rather than throwing, which would lock joiners out of the welcome) and any
+ *  malformed individual entries are dropped. */
 function parseStoredChat(raw: string | undefined): CollabChatMessage[] {
   if (!raw) return [];
   try {
     const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? (parsed as CollabChatMessage[]) : [];
+    return Array.isArray(parsed) ? parsed.filter(isValidChatMessage) : [];
   } catch {
     return [];
   }

--- a/workers/collab/src/session.ts
+++ b/workers/collab/src/session.ts
@@ -15,6 +15,10 @@ function finite(n: unknown): n is number {
   return typeof n === "number" && Number.isFinite(n);
 }
 
+// Accepted participant color: a 3- or 6-digit hex. Shared by the join path and
+// the stored-chat validator so both enforce the same shape.
+const HEX_COLOR_RE = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+
 /** Accept a cursor only when both coordinates are finite numbers, so a crafted
  *  frame can't push NaN/strings into peers' `marker.setLngLat`. */
 function sanitizeCursor(c: unknown): CollabCursor | null {
@@ -132,9 +136,13 @@ function isValidChatMessage(m: unknown): m is CollabChatMessage {
     typeof o.id === "string" &&
     typeof o.clientId === "string" &&
     typeof o.displayName === "string" &&
+    // Match the write path's guarantees: a hex color and non-empty text, so a
+    // corrupt record can't reach clients with a hostile color or blank body.
     typeof o.color === "string" &&
+    HEX_COLOR_RE.test(o.color) &&
     typeof o.text === "string" &&
-    typeof o.ts === "number" &&
+    o.text !== "" &&
+    finite(o.ts) &&
     coordOk
   );
 }
@@ -359,9 +367,7 @@ export class CollabSession extends DurableObject<Env> {
           .slice(0, 60) || "Guest",
       // Only accept a hex color; fall back to neutral grey so a hostile value
       // never reaches peers (defense-in-depth with the client's DOM rendering).
-      color: /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(message.color)
-        ? message.color
-        : "#888888",
+      color: HEX_COLOR_RE.test(message.color) ? message.color : "#888888",
       role,
     };
     ws.serializeAttachment(attachment);


### PR DESCRIPTION
Two small robustness follow-ups to #806 (issue #754), split out because they landed just after that PR was merged.

## 1. Keep the chat draft when a send is dropped
`CollabConnection.send` (and `sendChat`) now return whether the frame actually reached an open socket. The on-canvas chat composer clears the draft and stamps the per-socket send floor **only on a real send**. Previously the draft was cleared optimistically, so a message typed during a transient reconnect (where `sendChat` silently no-ops) or a rapid double-send the relay would rate-limit could vanish with no indication. Now the text stays in the box to retry.

## 2. Validate persisted chat records before serving them
`parseStoredChat` now checks each stored entry's field types and drops malformed records, in addition to the existing array-shape guard. The write path always constructs well-formed messages, so this is defense-in-depth for the one piece of relay state that is both persisted across hibernation **and** rendered directly by clients (a bad `coordinate` would otherwise crash `coordinate.lat.toFixed(...)` on a peer).

## Verification
- `npm run build`, `npm run test:worker`, and `tests/collab-protocol.test.ts` (21 pass) are green; `pre-commit` clean.
- Drove the live app with Playwright (host + guest) against a local relay: chat, attached coordinates, and per-participant permission toggles all still work; confirmed the composer keeps its text when a send is refused.

No protocol or schema changes; both are internal robustness fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented chat draft/attachment state from being cleared when a chat message can’t be delivered, avoiding lost work during connectivity issues
  * Hardened collaboration session loading by validating and sanitizing persisted chat history before it’s shared
  * Improved safety of collaboration metadata by enforcing consistent, validated color formatting during session joins
<!-- end of auto-generated comment: release notes by coderabbit.ai -->