### PR TITLE
fix(ci,backend): run the full backend suite, harden Whitebox runner, patch deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,24 +150,14 @@ jobs:
         run: npm ci
 
       - name: Install backend test dependencies
-        run: python -m pip install -e "backend/geolibre_server[dev]"
+        # The full test suite needs the optional engines; without them the
+        # vector/raster/SQL/ML tests skip themselves and CI is green but hollow.
+        run: python -m pip install -e "backend/geolibre_server[test]"
 
-      - name: Lint
-        run: npm run lint
-
-      - name: Build web app
-        run: npm run build
+      # Drive the documented `npm run ci` gate directly (lint -> build ->
+      # frontend+worker+backend coverage -> rust) so this workflow cannot drift
+      # from the script in package.json.
+      - name: Run CI gate (lint, build, frontend/worker/backend tests, rust)
+        run: npm run ci
         env:
           VITE_GEE_OAUTH_CLIENT_ID: ${{ secrets.VITE_GEE_OAUTH_CLIENT_ID }}
-
-      - name: Run frontend tests (with coverage summary)
-        run: npm run test:frontend:coverage
-
-      - name: Typecheck viewer worker
-        run: npm run test:worker
-
-      - name: Run backend tests (with coverage summary)
-        run: npm run test:backend:coverage
-
-      - name: Check Tauri Rust code
-        run: npm run check:rust

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,10 @@ yet (the report is informational, so a low number never fails CI). The frontend
 report only counts files a test actually imports, so a module with no test does
 not appear at all rather than as 0%. The backend coverage run (and `npm run ci`,
 which calls the `:coverage` variants) needs `pytest-cov` from the backend `dev`
-extra: `pip install -e "backend/geolibre_server[dev]"`.
+extra. Install the **`test`** extra to run the *full* backend suite — without
+the optional engines (geopandas/rasterio/sedona/httpx) the vector/raster/SQL/ML
+tests skip themselves and CI is green but hollow:
+`pip install -e "backend/geolibre_server[test]"`.
 
 `npm run test:e2e` builds the web app, serves it with `vite preview`, and drives
 it with Playwright (`@playwright/test`). First run: `npx playwright install

--- a/backend/geolibre_server/geolibre_server/app/whitebox.py
+++ b/backend/geolibre_server/geolibre_server/app/whitebox.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import json
+import logging
 import os
 import re
 import shutil
@@ -33,12 +34,31 @@ from .runtime import (
     _venv_python,
 )
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/whitebox", tags=["whitebox"])
 WHITEBOX_RUNTIME_PACKAGE = os.environ.get(
     "GEOLIBRE_WHITEBOX_PACKAGE",
     "whitebox-workflows>=2.0.2",
 )
 WHITEBOX_PYTHON_VERSION = os.environ.get("GEOLIBRE_WHITEBOX_PYTHON_VERSION", "3.12")
+
+
+def _whitebox_run_timeout_secs() -> int:
+    """Return the wall-clock timeout for a single Whitebox tool run.
+
+    Reads ``GEOLIBRE_WHITEBOX_RUN_TIMEOUT_SECS`` so deployments can tune the
+    cap for unusually long jobs; falls back to one hour when unset or invalid.
+    """
+    raw = os.environ.get("GEOLIBRE_WHITEBOX_RUN_TIMEOUT_SECS")
+    if raw:
+        try:
+            value = int(raw)
+            if value > 0:
+                return value
+        except ValueError:
+            pass
+    return 3600
 
 
 class WhiteboxRunRequest(BaseModel):
@@ -333,6 +353,8 @@ class ExternalRuntimeSession:
         )
         completed_result = ""
         errors: list[str] = []
+        timeout = _whitebox_run_timeout_secs()
+        timed_out = threading.Event()
         process = subprocess.Popen(
             [self.python_executable, "-c", runner, json.dumps(payload)],
             stdout=subprocess.PIPE,
@@ -345,36 +367,63 @@ class ExternalRuntimeSession:
             bufsize=1,
             **_subprocess_startup_kwargs(),
         )
-        if process.stdout is None:
-            raise RuntimeBootstrapError(
-                "Whitebox subprocess stdout is unexpectedly None"
-            )
-        for line in process.stdout:
-            line = line.rstrip("\r\n")
-            if line.startswith("__WBW_EVENT__"):
-                if callback:
-                    callback(
-                        base64.b64decode(line[len("__WBW_EVENT__") :]).decode(
-                            "utf-8", "replace"
-                        )
-                    )
-            elif line.startswith("__WBW_RESULT__"):
-                completed_result = base64.b64decode(
-                    line[len("__WBW_RESULT__") :]
-                ).decode("utf-8", "replace")
-            elif line.startswith("__WBW_ERROR__"):
-                errors.append(
-                    base64.b64decode(line[len("__WBW_ERROR__") :]).decode(
-                        "utf-8", "replace"
-                    )
+        try:
+            if process.stdout is None:
+                raise RuntimeBootstrapError(
+                    "Whitebox subprocess stdout is unexpectedly None"
                 )
-        stderr = process.stderr.read().strip() if process.stderr else ""
-        rc = process.wait()
-        if rc != 0 or errors:
-            raise RuntimeBootstrapError(
-                "\n".join(errors) or stderr or "Whitebox runtime execution failed"
+            # A watchdog kills the subprocess if it exceeds the deadline.
+            # ``for line in process.stdout`` blocks until the pipe closes, so a
+            # Whitebox tool that hangs without emitting further output would
+            # otherwise tie up this worker thread (and leak a child process)
+            # indefinitely; process.wait()'s own timeout cannot fire because the
+            # loop has already drained stdout.
+            watchdog = threading.Timer(
+                timeout,
+                lambda: (timed_out.set(), process.kill()),
             )
-        return completed_result or "{}"
+            watchdog.daemon = True
+            watchdog.start()
+            try:
+                for line in process.stdout:
+                    line = line.rstrip("\r\n")
+                    if line.startswith("__WBW_EVENT__"):
+                        if callback:
+                            callback(
+                                base64.b64decode(
+                                    line[len("__WBW_EVENT__") :]
+                                ).decode("utf-8", "replace")
+                            )
+                    elif line.startswith("__WBW_RESULT__"):
+                        completed_result = base64.b64decode(
+                            line[len("__WBW_RESULT__") :]
+                        ).decode("utf-8", "replace")
+                    elif line.startswith("__WBW_ERROR__"):
+                        errors.append(
+                            base64.b64decode(
+                                line[len("__WBW_ERROR__") :]
+                            ).decode("utf-8", "replace")
+                        )
+                stderr = process.stderr.read().strip() if process.stderr else ""
+                rc = process.wait()
+            finally:
+                watchdog.cancel()
+            if timed_out.is_set():
+                raise RuntimeBootstrapError(
+                    f"Whitebox tool run timed out after {timeout} seconds"
+                )
+            if rc != 0 or errors:
+                raise RuntimeBootstrapError(
+                    "\n".join(errors)
+                    or stderr
+                    or "Whitebox runtime execution failed"
+                )
+            return completed_result or "{}"
+        finally:
+            # Guard against leaking a still-running subprocess if an exception
+            # is raised before it exits (e.g. a callback error mid-stream).
+            if process.poll() is None:
+                process.kill()
 
 
 def create_runtime_session(include_pro: bool = False, tier: str = "open"):
@@ -779,10 +828,11 @@ def whitebox_status():
             "capabilities": None,
             "python": python,
         }
-    except Exception as exc:
+    except Exception:
+        logger.warning("Whitebox runtime unavailable", exc_info=True)
         return {
             "available": False,
-            "message": str(exc),
+            "message": "Whitebox runtime is unavailable",
             "capabilities": None,
             "python": None,
         }
@@ -794,7 +844,10 @@ def whitebox_tools(include_pro: bool = False, tier: str = "open"):
     try:
         tools = _load_catalog(include_pro=include_pro, tier=tier)
     except Exception as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+        logger.warning("Failed to load Whitebox tool catalog", exc_info=True)
+        raise HTTPException(
+            status_code=503, detail="Whitebox tool catalog is unavailable"
+        ) from exc
     return {"tools": tools, "tool_count": len(tools)}
 
 
@@ -805,7 +858,12 @@ def whitebox_tool(tool_id: str, include_pro: bool = False, tier: str = "open"):
         session = create_runtime_session(include_pro=include_pro, tier=tier)
         metadata = _parse_json_maybe(session.get_tool_metadata_json(tool_id))
     except Exception as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+        logger.warning(
+            "Failed to load metadata for Whitebox tool %s", tool_id, exc_info=True
+        )
+        raise HTTPException(
+            status_code=503, detail="Whitebox tool metadata is unavailable"
+        ) from exc
     return metadata
 
 

--- a/backend/geolibre_server/geolibre_server/app/whitebox.py
+++ b/backend/geolibre_server/geolibre_server/app/whitebox.py
@@ -396,7 +396,11 @@ class ExternalRuntimeSession:
 
         def _drain_stderr() -> None:
             if process.stderr is not None:
-                stderr_chunks.append(process.stderr.read())
+                # Keep only a bounded prefix for the one-line error message, then
+                # drain and discard the rest so a tool that floods stderr can't
+                # balloon sidecar memory (and the pipe never fills).
+                stderr_chunks.append(process.stderr.read(8192))
+                process.stderr.read()
 
         try:
             if process.stdout is None:

--- a/backend/geolibre_server/geolibre_server/app/whitebox.py
+++ b/backend/geolibre_server/geolibre_server/app/whitebox.py
@@ -437,7 +437,11 @@ class ExternalRuntimeSession:
                 rc = process.wait()
             finally:
                 watchdog.cancel()
-            stderr_thread.join(timeout=5)
+                # Join here (not after the block) so the drain thread is always
+                # awaited even when the stdout loop raises — the bounded timeout
+                # keeps it from blocking before the outer finally kills the
+                # process on the callback-exception path.
+                stderr_thread.join(timeout=5)
             stderr = (stderr_chunks[0] if stderr_chunks else "").strip()
             # ``timed_out`` is only set when the watchdog killed a still-running
             # process (see _on_timeout), so a set flag reliably means a genuine

--- a/backend/geolibre_server/geolibre_server/app/whitebox.py
+++ b/backend/geolibre_server/geolibre_server/app/whitebox.py
@@ -380,8 +380,14 @@ class ExternalRuntimeSession:
         )
 
         def _on_timeout() -> None:
-            timed_out.set()
-            _try_kill(process)
+            # Only flag a timeout if the process is still running: this avoids a
+            # false "timed out" when the timer fires in the narrow window after
+            # the process already exited (cleanly or with its own error) but
+            # before watchdog.cancel() runs. Gating on liveness is correct on
+            # every platform, unlike inspecting the sign of the exit code.
+            if process.poll() is None:
+                timed_out.set()
+                _try_kill(process)
 
         # Drain stderr in a background thread: a subprocess that fills the
         # stderr pipe buffer (~64 KB on Linux) while we are blocked reading
@@ -433,11 +439,10 @@ class ExternalRuntimeSession:
                 watchdog.cancel()
             stderr_thread.join(timeout=5)
             stderr = (stderr_chunks[0] if stderr_chunks else "").strip()
-            # Guard against the narrow race where the watchdog fires between
-            # process.wait() returning cleanly and watchdog.cancel(): a job that
-            # completed successfully always exits with rc == 0, so only treat a
-            # set flag as a real timeout when the process was actually killed.
-            if timed_out.is_set() and rc != 0:
+            # ``timed_out`` is only set when the watchdog killed a still-running
+            # process (see _on_timeout), so a set flag reliably means a genuine
+            # timeout regardless of the resulting exit code.
+            if timed_out.is_set():
                 raise RuntimeBootstrapError(
                     f"Whitebox tool run timed out after {timeout} seconds"
                 )

--- a/backend/geolibre_server/geolibre_server/app/whitebox.py
+++ b/backend/geolibre_server/geolibre_server/app/whitebox.py
@@ -11,7 +11,6 @@ import shutil
 import subprocess
 import tempfile
 import threading
-import traceback
 import uuid
 from pathlib import Path
 from typing import Any, Callable
@@ -439,8 +438,13 @@ class ExternalRuntimeSession:
         finally:
             # Guard against leaking a still-running subprocess if an exception
             # is raised before it exits (e.g. a callback error mid-stream).
+            # Reap the child after killing so it doesn't linger as a zombie.
             if process.poll() is None:
                 _try_kill(process)
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    pass
 
 
 def create_runtime_session(include_pro: bool = False, tier: str = "open"):
@@ -814,17 +818,17 @@ def _run_job(job_id: str, request: WhiteboxRunRequest) -> None:
             result=result,
             outputs=_extract_outputs(result, args, request.tool),
         )
-    except Exception as exc:
-        with _JOBS_LOCK:
-            current_messages = list(_JOBS[job_id].messages)
+    except Exception:
+        # The exception (a RuntimeBootstrapError) carries the subprocess's full
+        # traceback and interpreter path; log it server-side and surface only a
+        # generic message so /run and /jobs/{id} don't leak internals to clients
+        # (the sidecar is proxied to the browser build). Streamed progress
+        # messages are preserved untouched. Matches /status, /tools, /tools/{id}.
+        logger.warning("Whitebox job %s failed", job_id, exc_info=True)
         _job_update(
             job_id,
             status="failed",
-            error=str(exc),
-            messages=[
-                *current_messages,
-                traceback.format_exc(limit=8),
-            ],
+            error="Tool execution failed. See the sidecar logs for details.",
         )
     finally:
         for path in temp_paths:

--- a/backend/geolibre_server/geolibre_server/app/whitebox.py
+++ b/backend/geolibre_server/geolibre_server/app/whitebox.py
@@ -61,6 +61,19 @@ def _whitebox_run_timeout_secs() -> int:
     return 3600
 
 
+def _try_kill(process: subprocess.Popen) -> None:
+    """Kill a subprocess, ignoring the error if it has already exited.
+
+    ``Popen.kill`` raises ``ProcessLookupError`` (a subclass of ``OSError``) on
+    some platforms when the child is already gone. Swallowing it keeps the
+    watchdog Timer callback from leaking an unhandled traceback to stderr.
+    """
+    try:
+        process.kill()
+    except OSError:
+        pass
+
+
 class WhiteboxRunRequest(BaseModel):
     """Request body for a Whitebox tool run."""
 
@@ -380,7 +393,7 @@ class ExternalRuntimeSession:
             # loop has already drained stdout.
             watchdog = threading.Timer(
                 timeout,
-                lambda: (timed_out.set(), process.kill()),
+                lambda: (timed_out.set(), _try_kill(process)),
             )
             watchdog.daemon = True
             watchdog.start()
@@ -408,7 +421,11 @@ class ExternalRuntimeSession:
                 rc = process.wait()
             finally:
                 watchdog.cancel()
-            if timed_out.is_set():
+            # Guard against the narrow race where the watchdog fires between
+            # process.wait() returning cleanly and watchdog.cancel(): a job that
+            # completed successfully always exits with rc == 0, so only treat a
+            # set flag as a real timeout when the process was actually killed.
+            if timed_out.is_set() and rc != 0:
                 raise RuntimeBootstrapError(
                     f"Whitebox tool run timed out after {timeout} seconds"
                 )
@@ -423,7 +440,7 @@ class ExternalRuntimeSession:
             # Guard against leaking a still-running subprocess if an exception
             # is raised before it exits (e.g. a callback error mid-stream).
             if process.poll() is None:
-                process.kill()
+                _try_kill(process)
 
 
 def create_runtime_session(include_pro: bool = False, tier: str = "open"):

--- a/backend/geolibre_server/geolibre_server/app/whitebox.py
+++ b/backend/geolibre_server/geolibre_server/app/whitebox.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import contextlib
 import json
 import logging
 import os
@@ -67,10 +68,8 @@ def _try_kill(process: subprocess.Popen) -> None:
     some platforms when the child is already gone. Swallowing it keeps the
     watchdog Timer callback from leaking an unhandled traceback to stderr.
     """
-    try:
+    with contextlib.suppress(OSError):
         process.kill()
-    except OSError:
-        pass
 
 
 class WhiteboxRunRequest(BaseModel):
@@ -379,21 +378,34 @@ class ExternalRuntimeSession:
             bufsize=1,
             **_subprocess_startup_kwargs(),
         )
+
+        def _on_timeout() -> None:
+            timed_out.set()
+            _try_kill(process)
+
+        # Drain stderr in a background thread: a subprocess that fills the
+        # stderr pipe buffer (~64 KB on Linux) while we are blocked reading
+        # stdout would otherwise deadlock both ends until the watchdog fires.
+        stderr_chunks: list[str] = []
+
+        def _drain_stderr() -> None:
+            if process.stderr is not None:
+                stderr_chunks.append(process.stderr.read())
+
         try:
             if process.stdout is None:
                 raise RuntimeBootstrapError(
                     "Whitebox subprocess stdout is unexpectedly None"
                 )
+            stderr_thread = threading.Thread(target=_drain_stderr, daemon=True)
+            stderr_thread.start()
             # A watchdog kills the subprocess if it exceeds the deadline.
             # ``for line in process.stdout`` blocks until the pipe closes, so a
             # Whitebox tool that hangs without emitting further output would
             # otherwise tie up this worker thread (and leak a child process)
             # indefinitely; process.wait()'s own timeout cannot fire because the
             # loop has already drained stdout.
-            watchdog = threading.Timer(
-                timeout,
-                lambda: (timed_out.set(), _try_kill(process)),
-            )
+            watchdog = threading.Timer(timeout, _on_timeout)
             watchdog.daemon = True
             watchdog.start()
             try:
@@ -416,10 +428,11 @@ class ExternalRuntimeSession:
                                 line[len("__WBW_ERROR__") :]
                             ).decode("utf-8", "replace")
                         )
-                stderr = process.stderr.read().strip() if process.stderr else ""
                 rc = process.wait()
             finally:
                 watchdog.cancel()
+            stderr_thread.join(timeout=5)
+            stderr = (stderr_chunks[0] if stderr_chunks else "").strip()
             # Guard against the narrow race where the watchdog fires between
             # process.wait() returning cleanly and watchdog.cancel(): a job that
             # completed successfully always exits with rc == 0, so only treat a

--- a/backend/geolibre_server/pyproject.toml
+++ b/backend/geolibre_server/pyproject.toml
@@ -14,6 +14,13 @@ dev = [
   "pytest>=8.0.0",
   "pytest-cov>=5.0.0",
 ]
+# Everything required to run the FULL backend test suite. Without these extras
+# the vector/raster/SQL/ML tests skip themselves (via skipif/importorskip), so a
+# `[dev]`-only install reports a misleadingly green, near-empty run. CI installs
+# this group; run it locally with `pip install -e "backend/geolibre_server[test]"`.
+test = [
+  "geolibre-server[dev,vector,raster,conversion,ml,sedona]",
+]
 whitebox = [
   "whitebox-workflows>=2.0.2",
 ]

--- a/backend/geolibre_server/tests/test_whitebox_endpoints.py
+++ b/backend/geolibre_server/tests/test_whitebox_endpoints.py
@@ -47,6 +47,8 @@ def test_status_does_not_leak_internal_error(monkeypatch):
     assert result["available"] is False
     assert result["message"] == "Whitebox runtime is unavailable"
     assert _SECRET not in result["message"]
+    # The interpreter path must not leak through the python field either.
+    assert result["python"] is None
 
 
 def test_tools_does_not_leak_internal_error(monkeypatch):

--- a/backend/geolibre_server/tests/test_whitebox_endpoints.py
+++ b/backend/geolibre_server/tests/test_whitebox_endpoints.py
@@ -1,0 +1,74 @@
+"""Whitebox router endpoints: timeout config and non-leaky error handling.
+
+These exercise the failure paths directly (calling the route functions) so the
+sidecar never echoes internal exception text — including the interpreter path —
+back to the client, mirroring conversion.py/raster.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from geolibre_server.app import whitebox
+
+_SECRET = "/secret/path/to/python: boom traceback leak"
+
+
+def test_run_timeout_defaults_to_one_hour(monkeypatch):
+    """An unset or invalid override falls back to the 1-hour default."""
+    monkeypatch.delenv("GEOLIBRE_WHITEBOX_RUN_TIMEOUT_SECS", raising=False)
+    assert whitebox._whitebox_run_timeout_secs() == 3600
+
+    monkeypatch.setenv("GEOLIBRE_WHITEBOX_RUN_TIMEOUT_SECS", "not-a-number")
+    assert whitebox._whitebox_run_timeout_secs() == 3600
+
+    monkeypatch.setenv("GEOLIBRE_WHITEBOX_RUN_TIMEOUT_SECS", "0")
+    assert whitebox._whitebox_run_timeout_secs() == 3600
+
+
+def test_run_timeout_reads_positive_override(monkeypatch):
+    """A positive override is honoured so long jobs can be tuned per deployment."""
+    monkeypatch.setenv("GEOLIBRE_WHITEBOX_RUN_TIMEOUT_SECS", "120")
+    assert whitebox._whitebox_run_timeout_secs() == 120
+
+
+def test_status_does_not_leak_internal_error(monkeypatch):
+    """A runtime probe failure reports a generic, non-revealing message."""
+
+    def _boom():
+        raise RuntimeError(_SECRET)
+
+    monkeypatch.setattr(whitebox, "_runtime_import_status", _boom)
+    result = whitebox.whitebox_status()
+    assert result["available"] is False
+    assert result["message"] == "Whitebox runtime is unavailable"
+    assert _SECRET not in result["message"]
+
+
+def test_tools_does_not_leak_internal_error(monkeypatch):
+    """/tools maps a catalog failure to a stable 503 without the raw exception."""
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError(_SECRET)
+
+    monkeypatch.setattr(whitebox, "_load_catalog", _boom)
+    with pytest.raises(HTTPException) as excinfo:
+        whitebox.whitebox_tools()
+    assert excinfo.value.status_code == 503
+    assert excinfo.value.detail == "Whitebox tool catalog is unavailable"
+    assert _SECRET not in excinfo.value.detail
+
+
+def test_tool_metadata_does_not_leak_internal_error(monkeypatch):
+    """/tools/{id} maps a session failure to a stable 503 without leakage."""
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError(_SECRET)
+
+    monkeypatch.setattr(whitebox, "create_runtime_session", _boom)
+    with pytest.raises(HTTPException) as excinfo:
+        whitebox.whitebox_tool("some-tool")
+    assert excinfo.value.status_code == 503
+    assert excinfo.value.detail == "Whitebox tool metadata is unavailable"
+    assert _SECRET not in excinfo.value.detail

--- a/backend/geolibre_server/tests/test_whitebox_endpoints.py
+++ b/backend/geolibre_server/tests/test_whitebox_endpoints.py
@@ -26,6 +26,9 @@ def test_run_timeout_defaults_to_one_hour(monkeypatch):
     monkeypatch.setenv("GEOLIBRE_WHITEBOX_RUN_TIMEOUT_SECS", "0")
     assert whitebox._whitebox_run_timeout_secs() == 3600
 
+    monkeypatch.setenv("GEOLIBRE_WHITEBOX_RUN_TIMEOUT_SECS", "-1")
+    assert whitebox._whitebox_run_timeout_secs() == 3600
+
 
 def test_run_timeout_reads_positive_override(monkeypatch):
     """A positive override is honoured so long jobs can be tuned per deployment."""

--- a/backend/geolibre_server/tests/test_whitebox_endpoints.py
+++ b/backend/geolibre_server/tests/test_whitebox_endpoints.py
@@ -75,3 +75,39 @@ def test_tool_metadata_does_not_leak_internal_error(monkeypatch):
     assert excinfo.value.status_code == 503
     assert excinfo.value.detail == "Whitebox tool metadata is unavailable"
     assert _SECRET not in excinfo.value.detail
+
+
+def test_run_job_does_not_leak_error(monkeypatch):
+    """The background job runner stores only a generic, non-revealing error.
+
+    Exercises the main /run and /jobs/{id} security fix: a failing run must not
+    persist the raw exception (subprocess traceback + interpreter path) into the
+    job's ``error`` or ``messages`` fields.
+    """
+    job_id = "test-leak-job"
+    now = whitebox._utc_now()
+    with whitebox._JOBS_LOCK:
+        whitebox._JOBS[job_id] = whitebox.JobState(
+            id=job_id,
+            status="pending",
+            tool_id="noop",
+            created_at=now,
+            updated_at=now,
+        )
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError(_SECRET)
+
+    monkeypatch.setattr(whitebox, "create_runtime_session", _boom)
+    try:
+        whitebox._run_job(
+            job_id, whitebox.WhiteboxRunRequest(tool_id="noop")
+        )
+        job = whitebox._JOBS[job_id]
+        assert job.status == "failed"
+        assert job.error == "Tool execution failed. See the sidecar logs for details."
+        assert _SECRET not in (job.error or "")
+        assert all(_SECRET not in message for message in job.messages)
+    finally:
+        with whitebox._JOBS_LOCK:
+            whitebox._JOBS.pop(job_id, None)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2807,9 +2807,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260609.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260609.1.tgz",
-      "integrity": "sha512-AK8tYLQm+8BqQMzjZ55ZfuhfIm1eCkj+Ykxz6kWXojdACwjjU03MrwdM9fBDdgzU3upXOs4e1scOFHySlfVQjA==",
+      "version": "1.20260623.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260623.1.tgz",
+      "integrity": "sha512-MvDoIsRTsUJRzAl1/4hDXL839piyyjCeYatBHWgMc12Go7nHxkgbRih+1GJImEiKACSentu410bOupcutqFbpg==",
       "cpu": [
         "x64"
       ],
@@ -2824,9 +2824,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260609.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260609.1.tgz",
-      "integrity": "sha512-4kKXfr7ZHU6xQ/R9ShdSuj1A1bEouoRcHzUWdjnuMPBlRsAAVanlxAVYISotFUulLEinayOpRFbhpsfwzrpSSw==",
+      "version": "1.20260623.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260623.1.tgz",
+      "integrity": "sha512-sNqHQvHPMOj5/BJOadtEZekRPSG5qQ0/ulC30ZRHRLnmx6tj5O4Wb3Nf0oznnI0pmjXhbv6b7+TOpDkaFMjbBg==",
       "cpu": [
         "arm64"
       ],
@@ -2841,9 +2841,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260609.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260609.1.tgz",
-      "integrity": "sha512-T2Ebir2OPHAvvZ0HUh5mi1lN8q30sVi4lf7LIpc28AHoWtoOmJ0jA5AJK4IYJm1MKEbBldq+QsckaHOCQFmRpQ==",
+      "version": "1.20260623.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260623.1.tgz",
+      "integrity": "sha512-XYTWqTlZlCXqG+Po6awjXtlxw73hb3C39B/PP0sb4H9NI3V0eynq8Q7rXNe7DHJs2pWRfDJihQzpayQvpwf5wQ==",
       "cpu": [
         "x64"
       ],
@@ -2858,9 +2858,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260609.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260609.1.tgz",
-      "integrity": "sha512-INfcYoSsKqEIvPL69/3RkqYoP8WUR0VEN6loWN/3tekXLoJrVOj3E5NjIetsdS8MJN6zc3st/ae4bMuWRRzoDg==",
+      "version": "1.20260623.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260623.1.tgz",
+      "integrity": "sha512-PC5UDKA8oQB3Gek/Y+ysovdHNjp55CihOQZd7F9xPwpkv9qTBB0mhyHnfoG2YHtW1bb9CNhuwiThaNxegpE4mg==",
       "cpu": [
         "arm64"
       ],
@@ -2875,9 +2875,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260609.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260609.1.tgz",
-      "integrity": "sha512-EWhfxKI1aqUr7S8xuGxgmRCumEzB8iSsCIz6oEqJN+3pZuW3EWiKDGFW4EY1BmwNINLW1eO5VMGYb8Fj6FVYxA==",
+      "version": "1.20260623.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260623.1.tgz",
+      "integrity": "sha512-OTHLCVYyN0pEfrajpjjnrGg5zA1GDnpNYmMz3x2ESFtH/oXRODsUQBllP7oJpJvMURF3rXSYwAhMojaftGry8w==",
       "cpu": [
         "x64"
       ],
@@ -2892,9 +2892,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260610.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260610.1.tgz",
-      "integrity": "sha512-Mk/f3lUygeIHzQ4HnJjU/JvGg/kllgp9gISty9nylHE/2M2MFeKO+hgAKSgiPpmwUbuhewdYGgqFGgT/ADK0/g==",
+      "version": "4.20260624.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260624.1.tgz",
+      "integrity": "sha512-o8i70Nycnm6KpPPfdjHek09IkG3hoIAv88d1pn90Djn2oXcQ35dYuzKYZUBd0eE2Tpsd5yz8L/a6FvI6CKFBQw==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -3262,9 +3262,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -3279,9 +3279,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -3296,9 +3296,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -3313,9 +3313,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -3330,9 +3330,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -3347,9 +3347,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -3364,9 +3364,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -3381,9 +3381,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -3398,9 +3398,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -3415,9 +3415,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -3432,9 +3432,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -3449,9 +3449,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -3466,9 +3466,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -3483,9 +3483,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -3500,9 +3500,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -3517,9 +3517,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -3534,9 +3534,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -3551,9 +3551,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -3568,9 +3568,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -3585,9 +3585,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -3602,9 +3602,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -3619,9 +3619,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -3636,9 +3636,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -3653,9 +3653,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -3670,9 +3670,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -3687,9 +3687,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -4089,9 +4089,9 @@
       }
     },
     "node_modules/@google/earthengine": {
-      "version": "1.7.29",
-      "resolved": "https://registry.npmjs.org/@google/earthengine/-/earthengine-1.7.29.tgz",
-      "integrity": "sha512-QKK6PKWnIdnXIifeilbZfep8uj4wOj8QncHRZ8C0Z40WVCSC1Aa8VTwxJN0uCNRLgRjR0bNe87b1+F+1jXd5Kw==",
+      "version": "1.7.32",
+      "resolved": "https://registry.npmjs.org/@google/earthengine/-/earthengine-1.7.32.tgz",
+      "integrity": "sha512-PDtTPrtzF2wip4qDhEhFNpisJdBi8XFKm4xl1OhGkUZQ62en2ckKQcxD6DaEC4UDea94FtAQtiXHlDbOzrZh2w==",
       "license": "Apache-2.0",
       "dependencies": {
         "googleapis": "^92.0.0",
@@ -6210,12 +6210,6 @@
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
@@ -7999,9 +7993,9 @@
       "license": "MIT"
     },
     "node_modules/@speed-highlight/core": {
-      "version": "1.2.16",
-      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.16.tgz",
-      "integrity": "sha512-yNm/fYEcnpRjYduLMaddTK9XKYil6xB88+qFg79ZdZhHu1PadfoQmFW7pVTx7FZqMBNcUuThiAhxhENgtAO2/w==",
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
+      "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -13368,9 +13362,9 @@
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
     },
     "node_modules/dompurify": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
-      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -13676,9 +13670,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -13689,32 +13683,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -18193,17 +18187,17 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260609.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260609.0.tgz",
-      "integrity": "sha512-4ZfNh9ACDa/mKKQvTSO2vigyQS2MB7dEU02KRPle4FqL7S6nek+2Fq6WGzazZbt1OORYgb4OGVLnOCx+My2NNA==",
+      "version": "4.20260623.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260623.0.tgz",
+      "integrity": "sha512-p2YTeH01jMiMOjO4v9hb/+GJndja5LCxecGOWCaT9F414PRXgdddLDsK6MnqhGBB5tlU/WoBYIG1XZte5pQzOQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.34.5",
-        "undici": "7.24.8",
-        "workerd": "1.20260609.1",
-        "ws": "8.20.1",
+        "undici": "7.28.0",
+        "workerd": "1.20260623.1",
+        "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
       },
       "bin": {
@@ -18211,28 +18205,6 @@
       },
       "engines": {
         "node": ">=22.0.0"
-      }
-    },
-    "node_modules/miniflare/node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/minimatch": {
@@ -19230,9 +19202,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
-      "integrity": "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -19242,7 +19214,6 @@
         "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
@@ -21636,9 +21607,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
-      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -23180,9 +23151,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260609.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260609.1.tgz",
-      "integrity": "sha512-KF/Y/8f4VoXCk87NuU6RqmO0X5fdzcrxU3XzAgoPUpnH9t1ZyzRgX1O/9sJvjItxroCBTEBzKssda02Dz9i6BA==",
+      "version": "1.20260623.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260623.1.tgz",
+      "integrity": "sha512-9SJsdTSsehhqc26TUJIzyi1XgyYeqFym4hinZnWoAP1BkhEoMQ5Ygz7Xw9T+2ecU+y409JBEScBgWTdZ06mBrg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -23193,30 +23164,31 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260609.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260609.1",
-        "@cloudflare/workerd-linux-64": "1.20260609.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260609.1",
-        "@cloudflare/workerd-windows-64": "1.20260609.1"
+        "@cloudflare/workerd-darwin-64": "1.20260623.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260623.1",
+        "@cloudflare/workerd-linux-64": "1.20260623.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260623.1",
+        "@cloudflare/workerd-windows-64": "1.20260623.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.99.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.99.0.tgz",
-      "integrity": "sha512-i7GA2mZETTyq3ljWdEzM908FjLaMWZ1AaAHKaOJ8pFA/tonf2VqIWDyBGzKleIVBbNQxOTIY2wnbv0iaK3rC6g==",
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.104.0.tgz",
+      "integrity": "sha512-xCfbg2Oj93Bc7EMryFaSeRGDgV96dzrWoaK5q2q5XLEvumO4mysNP/1MDue0GUozEJAI6Z6vrGyYPLmfET/0sg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.5.0",
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
-        "esbuild": "0.27.3",
-        "miniflare": "4.20260609.0",
+        "esbuild": "0.28.1",
+        "miniflare": "4.20260623.0",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260609.1"
+        "workerd": "1.20260623.1"
       },
       "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
         "wrangler": "bin/wrangler.js",
         "wrangler2": "bin/wrangler.js"
       },
@@ -23227,496 +23199,12 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260609.1"
+        "@cloudflare/workers-types": "^4.20260623.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
           "optional": true
         }
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/wrangler/node_modules/esbuild": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.3",
-        "@esbuild/android-arm": "0.27.3",
-        "@esbuild/android-arm64": "0.27.3",
-        "@esbuild/android-x64": "0.27.3",
-        "@esbuild/darwin-arm64": "0.27.3",
-        "@esbuild/darwin-x64": "0.27.3",
-        "@esbuild/freebsd-arm64": "0.27.3",
-        "@esbuild/freebsd-x64": "0.27.3",
-        "@esbuild/linux-arm": "0.27.3",
-        "@esbuild/linux-arm64": "0.27.3",
-        "@esbuild/linux-ia32": "0.27.3",
-        "@esbuild/linux-loong64": "0.27.3",
-        "@esbuild/linux-mips64el": "0.27.3",
-        "@esbuild/linux-ppc64": "0.27.3",
-        "@esbuild/linux-riscv64": "0.27.3",
-        "@esbuild/linux-s390x": "0.27.3",
-        "@esbuild/linux-x64": "0.27.3",
-        "@esbuild/netbsd-arm64": "0.27.3",
-        "@esbuild/netbsd-x64": "0.27.3",
-        "@esbuild/openbsd-arm64": "0.27.3",
-        "@esbuild/openbsd-x64": "0.27.3",
-        "@esbuild/openharmony-arm64": "0.27.3",
-        "@esbuild/sunos-x64": "0.27.3",
-        "@esbuild/win32-arm64": "0.27.3",
-        "@esbuild/win32-ia32": "0.27.3",
-        "@esbuild/win32-x64": "0.27.3"
       }
     },
     "node_modules/wrap-ansi": {

--- a/tests/statistics-tools.test.ts
+++ b/tests/statistics-tools.test.ts
@@ -1,0 +1,264 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { DEFAULT_LAYER_STYLE, type GeoLibreLayer } from "@geolibre/core";
+import {
+  STATISTICS_TOOLS,
+  averageNearestNeighborTool,
+  getStatisticsTool,
+  getisOrdTool,
+  globalMoransITool,
+  kernelDensityTool,
+  localMoransITool,
+} from "@geolibre/processing";
+import type { Feature, FeatureCollection, Point } from "geojson";
+
+/** Build a point layer from [lon, lat, properties] tuples. */
+function pointLayer(
+  points: Array<[number, number, Record<string, unknown>]>,
+  id = "layer-a",
+): GeoLibreLayer {
+  const features: Feature<Point>[] = points.map(([lon, lat, properties]) => ({
+    type: "Feature",
+    properties,
+    geometry: { type: "Point", coordinates: [lon, lat] },
+  }));
+  return {
+    id,
+    name: "Layer A",
+    type: "geojson",
+    source: { type: "geojson" },
+    visible: true,
+    opacity: 1,
+    style: { ...DEFAULT_LAYER_STYLE },
+    metadata: {},
+    geojson: { type: "FeatureCollection", features },
+  };
+}
+
+interface RunOutcome {
+  messages: string[];
+  results: Array<{ name: string; geojson: FeatureCollection }>;
+}
+
+/** Run a statistics tool against a single layer, capturing logs and outputs. */
+function run(
+  tool: typeof globalMoransITool,
+  layer: GeoLibreLayer,
+  parameters: Record<string, unknown>,
+): RunOutcome {
+  const messages: string[] = [];
+  const results: RunOutcome["results"] = [];
+  tool.run({
+    layers: [layer],
+    // Every value-field tool here reads property "v"; ANN/KDE ignore "field".
+    parameters: { layer: layer.id, field: "v", ...parameters },
+    log: (message) => messages.push(message),
+    addResultLayer: (name, geojson) => results.push({ name, geojson }),
+  });
+  return { messages, results };
+}
+
+/** Parse the numeric value off a logged "Label: 1.2345" line. */
+function loggedNumber(messages: string[], needle: string): number {
+  const line = messages.find((m) => m.includes(needle));
+  assert.ok(line, `expected a log line containing "${needle}"`);
+  const value = Number.parseFloat(line.slice(line.indexOf(needle) + needle.length));
+  assert.ok(Number.isFinite(value), `could not parse a number from "${line}"`);
+  return value;
+}
+
+/** A line of points with monotonically increasing values (strong + autocorrelation). */
+function gradientLine(values: number[]): GeoLibreLayer {
+  return pointLayer(
+    values.map((v, i) => [i * 0.001, 0, { v }] as [number, number, Record<string, unknown>]),
+  );
+}
+
+describe("statistics tools registry", () => {
+  it("exposes all five spatial-statistics tools", () => {
+    assert.equal(STATISTICS_TOOLS.length, 5);
+    assert.deepEqual(
+      STATISTICS_TOOLS.map((t) => t.id).sort(),
+      [
+        "average-nearest-neighbor",
+        "getis-ord-gi",
+        "global-morans-i",
+        "kernel-density",
+        "local-morans-i",
+      ],
+    );
+  });
+
+  it("looks tools up by id", () => {
+    assert.equal(getStatisticsTool("global-morans-i"), globalMoransITool);
+    assert.equal(getStatisticsTool("getis-ord-gi"), getisOrdTool);
+    assert.equal(getStatisticsTool("nope"), undefined);
+  });
+});
+
+describe("global Moran's I", () => {
+  it("reports strong positive autocorrelation for a smooth gradient", () => {
+    const layer = gradientLine([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    const { messages } = run(globalMoransITool, layer, { k: 2, permutations: 99 });
+    const observed = loggedNumber(messages, "Moran's I:");
+    // Neighbors share near-identical values, so I should be close to 1.
+    assert.ok(observed > 0.5, `expected I > 0.5, got ${observed}`);
+    assert.ok(messages.some((m) => m.includes("clustered")));
+  });
+
+  it("reports negative autocorrelation for an alternating field", () => {
+    const layer = gradientLine([0, 10, 0, 10, 0, 10, 0, 10, 0, 10]);
+    const { messages } = run(globalMoransITool, layer, { k: 2, permutations: 99 });
+    const observed = loggedNumber(messages, "Moran's I:");
+    assert.ok(observed < 0, `expected I < 0, got ${observed}`);
+  });
+
+  it("errors on a constant field and on too few features", () => {
+    const constant = run(globalMoransITool, gradientLine([5, 5, 5, 5]), {
+      k: 2,
+    });
+    assert.ok(constant.messages.some((m) => m.includes("constant")));
+
+    const tooFew = run(globalMoransITool, gradientLine([1, 2]), { k: 1 });
+    assert.ok(tooFew.messages.some((m) => m.includes("at least 3")));
+  });
+});
+
+describe("Getis-Ord Gi*", () => {
+  it("flags the high cluster as hot and the low cluster as cold", () => {
+    // Two well-separated clusters: high values left, low values right.
+    const layer = pointLayer([
+      [0, 0, { v: 100 }],
+      [0.001, 0, { v: 98 }],
+      [0, 0.001, { v: 102 }],
+      [1, 0, { v: 1 }],
+      [1.001, 0, { v: 2 }],
+      [1, 0.001, { v: 1 }],
+    ]);
+    const { results } = run(getisOrdTool, layer, { k: 2 });
+    assert.equal(results.length, 1);
+    const z = results[0].geojson.features.map(
+      (f) => f.properties?.["v_gi_z"] as number,
+    );
+    // Indices 0-2 are the high cluster, 3-5 the low cluster.
+    assert.ok(
+      z.slice(0, 3).every((value) => value > 0),
+      `expected positive Gi* z in the high cluster, got ${z.slice(0, 3)}`,
+    );
+    assert.ok(
+      z.slice(3).every((value) => value < 0),
+      `expected negative Gi* z in the low cluster, got ${z.slice(3)}`,
+    );
+  });
+
+  it("errors when the value field is constant", () => {
+    const layer = pointLayer([
+      [0, 0, { v: 5 }],
+      [0.001, 0, { v: 5 }],
+      [0, 0.001, { v: 5 }],
+    ]);
+    const { messages } = run(getisOrdTool, layer, { k: 2 });
+    assert.ok(messages.some((m) => m.includes("constant")));
+  });
+});
+
+describe("local Moran's I (LISA)", () => {
+  it("classifies a high-value cluster as High-High (quadrant 1)", () => {
+    const layer = pointLayer([
+      [0, 0, { v: 100 }],
+      [0.001, 0, { v: 98 }],
+      [0, 0.001, { v: 102 }],
+      [1, 0, { v: 1 }],
+      [1.001, 0, { v: 2 }],
+      [1, 0.001, { v: 1 }],
+    ]);
+    const { results } = run(localMoransITool, layer, { k: 2, permutations: 99 });
+    assert.equal(results.length, 1);
+    const features = results[0].geojson.features;
+    // High-cluster members have a positive local I and sit in quadrant 1.
+    for (const f of features.slice(0, 3)) {
+      assert.equal(f.properties?.["v_lisa_q"], 1);
+      assert.ok((f.properties?.["v_lisa_I"] as number) > 0);
+    }
+  });
+});
+
+describe("average nearest neighbor", () => {
+  it("returns a sub-1 ratio for clustered points and a larger ratio for a grid", () => {
+    // Four tight knots at the corners of a ~1-degree extent: every point's
+    // nearest neighbor sits inside its own knot, far below the expected random
+    // spacing for the overall density -> a strongly clustered (<1) ratio.
+    const clustered = pointLayer(
+      ([
+        [0, 0],
+        [1, 0],
+        [0, 1],
+        [1, 1],
+      ] as Array<[number, number]>).flatMap(([lon, lat]) => [
+        [lon, lat, {}],
+        [lon + 0.0005, lat, {}],
+        [lon, lat + 0.0005, {}],
+      ] as Array<[number, number, Record<string, unknown>]>),
+    );
+    const clusteredRatio = loggedNumber(
+      run(averageNearestNeighborTool, clustered, {}).messages,
+      "NN ratio:",
+    );
+    assert.ok(clusteredRatio < 1, `expected clustered ratio < 1, got ${clusteredRatio}`);
+
+    // A 4x4 evenly spaced grid is close to a random/dispersed arrangement.
+    const grid: Array<[number, number, Record<string, unknown>]> = [];
+    for (let r = 0; r < 4; r++) {
+      for (let c = 0; c < 4; c++) grid.push([c * 0.01, r * 0.01, {}]);
+    }
+    const gridRatio = loggedNumber(
+      run(averageNearestNeighborTool, pointLayer(grid), {}).messages,
+      "NN ratio:",
+    );
+    assert.ok(
+      gridRatio > clusteredRatio,
+      `expected grid ratio (${gridRatio}) > clustered ratio (${clusteredRatio})`,
+    );
+  });
+
+  it("errors with fewer than two points", () => {
+    const { messages } = run(averageNearestNeighborTool, pointLayer([[0, 0, {}]]), {});
+    assert.ok(messages.some((m) => m.includes("at least 2")));
+  });
+});
+
+describe("kernel density", () => {
+  it("produces a normalized density grid peaking at 1", () => {
+    const layer = pointLayer([
+      [0, 0, {}],
+      [0.001, 0, {}],
+      [0, 0.001, {}],
+      [0.001, 0.001, {}],
+    ]);
+    const { results } = run(kernelDensityTool, layer, {
+      bandwidth: 1,
+      cellSize: 0.25,
+    });
+    assert.equal(results.length, 1);
+    const cells = results[0].geojson.features;
+    assert.ok(cells.length > 0);
+    const norms = cells.map((f) => f.properties?.["density_norm"] as number);
+    assert.ok(norms.every((value) => value > 0 && value <= 1));
+    assert.ok(
+      Math.max(...norms) === 1,
+      "the densest cell should normalize to exactly 1",
+    );
+  });
+
+  it("errors on a non-positive bandwidth", () => {
+    const layer = pointLayer([
+      [0, 0, {}],
+      [0.001, 0, {}],
+    ]);
+    const { messages } = run(kernelDensityTool, layer, {
+      bandwidth: 0,
+      cellSize: 0.25,
+    });
+    assert.ok(messages.some((m) => m.includes("must be positive")));
+  });
+});

--- a/tests/statistics-tools.test.ts
+++ b/tests/statistics-tools.test.ts
@@ -101,9 +101,10 @@ describe("global Moran's I", () => {
     const layer = gradientLine([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     const { messages } = run(globalMoransITool, layer, { k: 2, permutations: 99 });
     const observed = loggedNumber(messages, "Moran's I:");
-    // Neighbors share near-identical values, so I should be close to 1.
+    // Neighbors share near-identical values, so I should be close to 1. The
+    // observed statistic is deterministic; the pattern label depends on the
+    // permutation p-value, so it is intentionally not asserted here.
     assert.ok(observed > 0.5, `expected I > 0.5, got ${observed}`);
-    assert.ok(messages.some((m) => m.includes("clustered")));
   });
 
   it("reports negative autocorrelation for an alternating field", () => {
@@ -175,8 +176,14 @@ describe("local Moran's I (LISA)", () => {
     const { results } = run(localMoransITool, layer, { k: 2, permutations: 99 });
     assert.equal(results.length, 1);
     const features = results[0].geojson.features;
+    // Select the high-value members by attribute rather than position, so the
+    // assertion holds even if the tool ever reorders output features.
+    const highFeatures = features.filter(
+      (f) => (f.properties?.["v"] as number) > 50,
+    );
+    assert.equal(highFeatures.length, 3);
     // High-cluster members have a positive local I and sit in quadrant 1.
-    for (const f of features.slice(0, 3)) {
+    for (const f of highFeatures) {
       assert.equal(f.properties?.["v_lisa_q"], 1);
       assert.ok((f.properties?.["v_lisa_I"] as number) > 0);
     }
@@ -244,9 +251,10 @@ describe("kernel density", () => {
     assert.ok(cells.length > 0);
     const norms = cells.map((f) => f.properties?.["density_norm"] as number);
     assert.ok(norms.every((value) => value > 0 && value <= 1));
+    const maxNorm = Math.max(...norms);
     assert.ok(
-      Math.max(...norms) === 1,
-      "the densest cell should normalize to exactly 1",
+      Math.abs(maxNorm - 1) < 1e-9,
+      `the densest cell should normalize to 1 (got ${maxNorm})`,
     );
   });
 

--- a/tests/statistics-tools.test.ts
+++ b/tests/statistics-tools.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { DEFAULT_LAYER_STYLE, type GeoLibreLayer } from "@geolibre/core";
 import {
+  type ProcessingAlgorithm,
   STATISTICS_TOOLS,
   averageNearestNeighborTool,
   getStatisticsTool,
@@ -42,7 +43,7 @@ interface RunOutcome {
 
 /** Run a statistics tool against a single layer, capturing logs and outputs. */
 function run(
-  tool: typeof globalMoransITool,
+  tool: ProcessingAlgorithm,
   layer: GeoLibreLayer,
   parameters: Record<string, unknown>,
 ): RunOutcome {
@@ -76,7 +77,8 @@ function gradientLine(values: number[]): GeoLibreLayer {
 
 describe("statistics tools registry", () => {
   it("exposes all five spatial-statistics tools", () => {
-    assert.equal(STATISTICS_TOOLS.length, 5);
+    // The sorted-id comparison below fully pins membership; no separate
+    // (fragile) length assertion is needed.
     assert.deepEqual(
       STATISTICS_TOOLS.map((t) => t.id).sort(),
       [


### PR DESCRIPTION
This bundles the **high-** and **medium-impact** fixes from a repo review (the god-file refactors were deliberately left out for dedicated PRs to keep this reviewable).

## High impact

### 1. Backend tests were silently no-op in CI
CI installed only `backend/geolibre_server[dev]`, so every `test_vector*`, `test_raster`, `test_sql`, and `test_ml` test was gated behind extras that weren't installed and skipped itself — the green check exercised almost nothing of GeoPandas/rasterio/Sedona.

- Added a consolidated **`test`** extra (`pyproject.toml`) aggregating `vector,raster,conversion,ml,sedona`.
- CI now installs `[test]`.
- Result: backend suite went from **192 passed / 6 skipped** → **203 passed** (and now actually runs the optional engines).

### 2. Whitebox streaming runner could hang/leak forever
`run_tool_json_stream` had **no timeout** and **no kill-on-exception** — a tool that hung without emitting output blocked the worker thread and leaked a child process indefinitely (unlike `_invoke` and `conversion.py`, which guard this).

- Added a watchdog that kills the subprocess past a deadline (`GEOLIBRE_WHITEBOX_RUN_TIMEOUT_SECS`, default 1h) plus a `finally` that always kills it.

### 3. Dependency vulnerabilities
- `npm audit fix` (non-breaking) applied — clears the fixable advisories and deduplicates the lockfile.
- Remaining critical/high all report `fixAvailable=false` (dev-only `vite`/`vitest`/`ava`; `sweepline-intersections` under the `osmix` OSM parser) and need breaking changes or upstream releases — out of scope for a non-breaking PR.

## Medium impact

### 4. Spatial-statistics tools had zero assertions
Added `tests/statistics-tools.test.ts` — deterministic correctness tests for Moran's I, Getis-Ord Gi\*, LISA, average nearest neighbor, and kernel density (asserts only on non-random outputs; permutation p-values are excluded).

### 6. Whitebox endpoints leaked internal error strings
`/status`, `/tools`, `/tools/{id}` returned `str(exc)` (and the interpreter path). Now they log internally and return a stable generic message, matching `conversion.py`/`raster.py`. Added `test_whitebox_endpoints.py` proving no leakage + timeout-config parsing.

### 7. CI duplicated `npm run ci`
The `checks` job hand-reimplemented the `npm run ci` steps. It now calls `npm run ci` directly so the workflow can't drift from `package.json`.

## Verification
- `npm run lint` ✅ (0 errors)
- `npm run build` ✅
- `npm run test:frontend` ✅ (1493 pass, 1 pre-existing skip)
- `npm run test:worker` ✅
- backend `pytest` ✅ (203 passed)
- `pre-commit run --files <changed>` ✅ (incl. full npm build)

## Deliberately excluded
God-file splits (`maplibre-components.ts`, `StylePanel.tsx`, `SettingsDialog.tsx`) — large refactors that need their own PRs + Playwright verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable wall-clock timeout for Whitebox tool runs (default 3600s; supports positive overrides).

* **Bug Fixes**
  * Hardened Whitebox tool subprocess handling to enforce timeouts and prevent leaked/lingering processes.
  * Improved Whitebox endpoint error responses with stable, client-safe messages (including consistent 503 responses) while logging full server-side details.

* **Tests**
  * Added Whitebox endpoint tests for timeout behavior and non-leaky failure responses.
  * Added spatial statistics tools tests (expected results plus validation/error cases).

* **Chores**
  * Updated CI gating to run the full backend test suite using the dedicated backend `test` setup and simplified the workflow step.
  * Updated documentation for running the full backend tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->