### PR TITLE
fix(controls): refine Minimap and View State panel UX

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -58,7 +58,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.3",
     "maplibre-gl-basemap-control": "^0.7.0",
-    "maplibre-gl-components": "^0.25.0",
+    "maplibre-gl-components": "^0.25.1",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",

--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -58,7 +58,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.3",
     "maplibre-gl-basemap-control": "^0.7.0",
-    "maplibre-gl-components": "^0.24.0",
+    "maplibre-gl-components": "^0.25.0",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -22,6 +22,7 @@ import {
   restoreThreeDTilesLayers,
   restoreVectorLayers,
   setBookmarkLabels,
+  setViewStateLabels,
   setNonTiledRasterHandler,
   startLayerGeometryEdit,
   subscribeGeometryEdit,
@@ -415,6 +416,7 @@ export function DesktopShell({
       newFolderLabel: t("bookmark.newFolder"),
       defaultFolderName: t("bookmark.defaultFolderName"),
     });
+    setViewStateLabels({ title: t("viewState.panelTitle") });
   }, [t]);
   // The map's Fullscreen control maximizes the map *canvas* (it calls
   // requestFullscreen on the map container). Chromium promotes that element to

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -22,8 +22,8 @@ import {
   restoreThreeDTilesLayers,
   restoreVectorLayers,
   setBookmarkLabels,
-  setViewStateLabels,
   setNonTiledRasterHandler,
+  setViewStateLabels,
   startLayerGeometryEdit,
   subscribeGeometryEdit,
 } from "@geolibre/plugins";

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -61,6 +61,9 @@
     "newFolder": "New Folder",
     "defaultFolderName": "Folder"
   },
+  "viewState": {
+    "panelTitle": "Info"
+  },
   "fileNamePrompt": {
     "title": "Save file as",
     "description": "Enter a file name. The file downloads to your browser's downloads folder.",

--- a/apps/geolibre-desktop/src/index.css
+++ b/apps/geolibre-desktop/src/index.css
@@ -967,6 +967,17 @@ body,
   --vs-chip-hover-bg: hsl(var(--accent));
 }
 
+/* Make the minimap toggle and collapse buttons follow the in-app theme. The
+   upstream control defaults to prefers-color-scheme, which can disagree with
+   GeoLibre's class-based theme (e.g. the collapse icon staying dark in dark
+   mode). */
+.geolibre-minimap-control {
+  --mm-button-bg: hsl(var(--popover));
+  --mm-button-hover-bg: hsl(var(--accent));
+  --mm-button-text: hsl(var(--popover-foreground));
+  --mm-button-ring: hsl(var(--border));
+}
+
 .geolibre-stac-search-control .maplibre-gl-stac-search-button {
   display: none !important;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.3",
         "maplibre-gl-basemap-control": "^0.7.0",
-        "maplibre-gl-components": "^0.25.0",
+        "maplibre-gl-components": "^0.25.1",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -187,9 +187,9 @@
       "license": "MIT"
     },
     "apps/geolibre-desktop/node_modules/maplibre-gl-components": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.25.0.tgz",
-      "integrity": "sha512-RkrlPZhQvjZbELGHbd1YybqHkn2PX0aFiU6Mx9EHXQkQ/wz6FogxTZHMBkJLSmYAi+bhI2BZkfuP8kO0a9zRwA==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.25.1.tgz",
+      "integrity": "sha512-witQScF0CnzkOyqMzpZ8MBH6GS4di31X0Fby6uQO7kId+zC9FF2X+1zhY4jIGIkJERamahASAzRC/NfYyDVGqA==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",
@@ -23793,7 +23793,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.3",
         "maplibre-gl-basemap-control": "^0.7.0",
-        "maplibre-gl-components": "^0.25.0",
+        "maplibre-gl-components": "^0.25.1",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -23832,9 +23832,9 @@
       }
     },
     "packages/plugins/node_modules/maplibre-gl-components": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.25.0.tgz",
-      "integrity": "sha512-RkrlPZhQvjZbELGHbd1YybqHkn2PX0aFiU6Mx9EHXQkQ/wz6FogxTZHMBkJLSmYAi+bhI2BZkfuP8kO0a9zRwA==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.25.1.tgz",
+      "integrity": "sha512-witQScF0CnzkOyqMzpZ8MBH6GS4di31X0Fby6uQO7kId+zC9FF2X+1zhY4jIGIkJERamahASAzRC/NfYyDVGqA==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.3",
         "maplibre-gl-basemap-control": "^0.7.0",
-        "maplibre-gl-components": "^0.24.0",
+        "maplibre-gl-components": "^0.25.0",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -187,9 +187,9 @@
       "license": "MIT"
     },
     "apps/geolibre-desktop/node_modules/maplibre-gl-components": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.24.0.tgz",
-      "integrity": "sha512-dRKjU+CjScITnZcJApI0k3PGvLqDMQmH9xEIdZi5PxnmhobQQ2VAyYffbHANfzaBsDCw/c4rS2Pmx/M7SRN3FQ==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.25.0.tgz",
+      "integrity": "sha512-RkrlPZhQvjZbELGHbd1YybqHkn2PX0aFiU6Mx9EHXQkQ/wz6FogxTZHMBkJLSmYAi+bhI2BZkfuP8kO0a9zRwA==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",
@@ -23793,7 +23793,7 @@
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.3",
         "maplibre-gl-basemap-control": "^0.7.0",
-        "maplibre-gl-components": "^0.24.0",
+        "maplibre-gl-components": "^0.25.0",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",
         "maplibre-gl-enviroatlas": "^0.1.1",
@@ -23832,9 +23832,9 @@
       }
     },
     "packages/plugins/node_modules/maplibre-gl-components": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.24.0.tgz",
-      "integrity": "sha512-dRKjU+CjScITnZcJApI0k3PGvLqDMQmH9xEIdZi5PxnmhobQQ2VAyYffbHANfzaBsDCw/c4rS2Pmx/M7SRN3FQ==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-components/-/maplibre-gl-components-0.25.0.tgz",
+      "integrity": "sha512-RkrlPZhQvjZbELGHbd1YybqHkn2PX0aFiU6Mx9EHXQkQ/wz6FogxTZHMBkJLSmYAi+bhI2BZkfuP8kO0a9zRwA==",
       "license": "MIT",
       "dependencies": {
         "@developmentseed/deck.gl-raster": ">=0.7.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -32,7 +32,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.3",
     "maplibre-gl-basemap-control": "^0.7.0",
-    "maplibre-gl-components": "^0.24.0",
+    "maplibre-gl-components": "^0.25.0",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -32,7 +32,7 @@
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.3",
     "maplibre-gl-basemap-control": "^0.7.0",
-    "maplibre-gl-components": "^0.25.0",
+    "maplibre-gl-components": "^0.25.1",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",
     "maplibre-gl-enviroatlas": "^0.1.1",

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -99,6 +99,7 @@ export {
   addCloudNetcdfLayer,
   type CloudNetcdfLayerOptions,
   setBookmarkLabels,
+  setViewStateLabels,
   subscribeBookmarkPanel,
   subscribeColorbarPanel,
   subscribeHtmlPanel,

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -418,8 +418,30 @@ const VIEW_STATE_OPTIONS = {
   maxHeight: 520,
   panelWidth: 280,
   position: viewStateControlPosition,
-  title: "Info",
+  // The panel title is applied per-instance in createViewStateControl so it
+  // picks up the translated string pushed via setViewStateLabels.
 } satisfies ViewStateControlOptions;
+
+/**
+ * User-facing strings for the ViewStateControl. The default is English; the
+ * desktop shell pushes a translated value via {@link setViewStateLabels} since
+ * this package is framework-agnostic and has no react-i18next access.
+ */
+const viewStateLabels = {
+  title: "Info",
+};
+
+/** Override the ViewStateControl labels with translated text. */
+export function setViewStateLabels(
+  labels: Partial<typeof viewStateLabels>
+): void {
+  for (const [key, value] of Object.entries(labels)) {
+    // Only overwrite when the caller actually supplied the key; an omitted key
+    // keeps the English default rather than being blanked out.
+    if (value !== undefined)
+      viewStateLabels[key as keyof typeof viewStateLabels] = value;
+  }
+}
 
 const PRINT_OPTIONS = {
   backgroundColor: "hsl(var(--popover))",
@@ -2877,7 +2899,10 @@ function createMinimapControl(
 function createViewStateControl(
   ViewStateControlClass: ViewStateControlConstructor
 ): ViewStateControl {
-  const control = new ViewStateControlClass(VIEW_STATE_OPTIONS);
+  const control = new ViewStateControlClass({
+    ...VIEW_STATE_OPTIONS,
+    title: viewStateLabels.title,
+  });
   return control;
 }
 

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -418,6 +418,7 @@ const VIEW_STATE_OPTIONS = {
   maxHeight: 520,
   panelWidth: 280,
   position: viewStateControlPosition,
+  title: "Info",
 } satisfies ViewStateControlOptions;
 
 const PRINT_OPTIONS = {


### PR DESCRIPTION
## Summary

Reworks the **Minimap** and **View State** map controls to address four UX
reports, consuming the new `maplibre-gl-components@0.25.0` release
(opengeos/maplibre-gl-components#114).

- Fixes #812
- Fixes #813
- Fixes #814
- Fixes #815

## What changed

### Minimap (#812) and View State (#815): inline window controls
Both panels now **hide their standalone toggle icon while expanded** and expose
an **inline collapse control** inside the panel. Collapsing shrinks the panel
back to a corner icon (which doubles as the minimized "still active" state);
clicking that icon restores the panel. No detached button sits outside the
frame while the panel is open.

### View State content (#813)
- Header titled **"Info"**.
- New **Projection** row showing globe / mercator, updated live.
- **Bounds** moved last (camera fields read first).
- **Draw BBox** now uses a pencil icon instead of the dashed-selection
  rectangle.
- The bbox **Copy / Clear** actions are aligned on one axis (upstream scoped the
  buttons so MapLibre's `display: block` no longer stacks the icon over its
  label).

### Unified camera copy (#814)
A **copy-view** button in the header copies the whole camera state
(`center`, `zoom`, `bearing`, `pitch`) to the clipboard as one string.

## Verification

Driven in the real app with Playwright using the published 0.25.0 package, in
**both light and dark themes**:
- Minimap and View State open in full from the menu with no external icon;
  inline collapse shrinks to the corner icon and back.
- View State shows the Info header, projection row (live), bounds last, pencil
  draw icon, aligned Copy/Clear, and the unified copy-view button copies
  `center: [...], zoom: ..., bearing: ..., pitch: ...`.
- `npm run build` and scoped `pre-commit` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a translated “Info” title for the View State panel.
  * Enabled the desktop app to update the View State panel label at runtime to match the selected language.

* **Chores**
  * Updated the map UI dependency in both the desktop app and plugin packages.
  * Refined minimap control button styling to better align with the in-app theme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->