### PR TITLE
fix(vector): 3D extrusion for Add Vector Layer polygons

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -76,7 +76,7 @@
     "maplibre-gl-swipe": "^0.9.1",
     "maplibre-gl-time-slider": "^1.1.0",
     "maplibre-gl-usgs-lidar": "^0.11.0",
-    "maplibre-gl-vector": "^0.7.0",
+    "maplibre-gl-vector": "^0.8.0",
     "openai": "^6.39.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
         "maplibre-gl-swipe": "^0.9.1",
         "maplibre-gl-time-slider": "^1.1.0",
         "maplibre-gl-usgs-lidar": "^0.11.0",
-        "maplibre-gl-vector": "^0.7.0",
+        "maplibre-gl-vector": "^0.8.0",
         "openai": "^6.39.0",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.7",
@@ -17957,9 +17957,9 @@
       }
     },
     "node_modules/maplibre-gl-vector": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.7.0.tgz",
-      "integrity": "sha512-yaOclG9PjWkd1bHSrU84xCCnipeFEhwYVAmjPrg0x8GWk3zH7ozanyE2tm2OeFGY6XrS4pw6JlDsb5pGe/WBGQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-vector/-/maplibre-gl-vector-0.8.0.tgz",
+      "integrity": "sha512-2YRSCPrq2scveyvqCOchojflTGRqHchg314350+ZSua8e6p6v4sIjSJGybby/rHAT7Vklory+05FREzmg8K4Gw==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2"
@@ -23812,7 +23812,7 @@
         "maplibre-gl-swipe": "^0.9.1",
         "maplibre-gl-time-slider": "^1.1.0",
         "maplibre-gl-usgs-lidar": "^0.11.0",
-        "maplibre-gl-vector": "^0.7.0",
+        "maplibre-gl-vector": "^0.8.0",
         "proj4": "^2.20.9",
         "shpjs": "^6.2.0",
         "three": "^0.184.0"

--- a/packages/core/src/vector-color.ts
+++ b/packages/core/src/vector-color.ts
@@ -445,3 +445,50 @@ export function vectorLineColorValue(style: LayerStyle): VectorColorValue {
           ];
   return withSimpleStyleColor(style, "stroke", resolved);
 }
+
+/**
+ * Resolves the 3D-extrusion height for a layer style into a MapLibre value: a
+ * plain meters number, or a data-driven expression. In advanced mode a valid
+ * `extrusionHeightExpression` wins; otherwise the height is the chosen property
+ * scaled by `extrusionHeightScale` (`["*", ["to-number", ["get", prop], 0],
+ * scale]`), or a flat `0` when no property is set (so the layer renders flat
+ * rather than erroring). Shared by the map's fill-extrusion paint and the
+ * Add Vector Layer control's extrusion mapping so both extrude identically.
+ *
+ * @param style - The layer style.
+ * @returns The extrusion height as a number or a MapLibre expression array.
+ */
+export function extrusionHeightValue(style: LayerStyle): number | unknown[] {
+  const advancedExpression = parseJsonExpression(
+    styleValue(style, "extrusionAdvancedStyleEnabled")
+      ? styleValue(style, "extrusionHeightExpression")
+      : "",
+  );
+  if (advancedExpression) return advancedExpression;
+  const property = styleValue(style, "extrusionHeightProperty").trim();
+  if (!property) return 0;
+  const scale = styleValue(style, "extrusionHeightScale");
+  return ["*", ["to-number", ["get", property], 0], scale];
+}
+
+/**
+ * Resolves the 3D-extrusion color for a layer style: a data-driven expression
+ * when the layer's symbology mode produces one (categorized/graduated/rule/
+ * expression) or an advanced `extrusionColorExpression` is set, otherwise the
+ * flat `extrusionColor`. Mirrors the fill-color contract so an extruded layer
+ * honors the same attribute-driven styling.
+ *
+ * @param style - The layer style.
+ * @returns A flat color string or a MapLibre color expression array.
+ */
+export function extrusionColorValue(style: LayerStyle): VectorColorValue {
+  const flat = styleValue(style, "extrusionColor");
+  const vectorExpression = vectorColorExpression(style, flat);
+  if (vectorExpression !== flat) return vectorExpression;
+  const advancedExpression = parseJsonExpression(
+    styleValue(style, "extrusionAdvancedStyleEnabled")
+      ? styleValue(style, "extrusionColorExpression")
+      : "",
+  );
+  return (advancedExpression as VectorColorValue | null) ?? flat;
+}

--- a/packages/map/src/style-mapper.ts
+++ b/packages/map/src/style-mapper.ts
@@ -1,11 +1,11 @@
 import {
   DEFAULT_LAYER_STYLE,
   circleRadiusValue,
+  extrusionColorValue,
+  extrusionHeightValue,
   lineWidthValue,
-  parseJsonExpression,
   simpleStyleNumberValue,
   vectorCircleColorValue,
-  vectorColorExpression,
   vectorFillColorValue,
   vectorLineColorValue,
   type LayerStyle,
@@ -53,36 +53,15 @@ export function fillPaint(style: LayerStyle, opacity: number) {
 function extrusionHeightPaintValue(
   style: LayerStyle,
 ): PropertyValueSpecification<number> {
-  const advancedExpression = parseJsonExpression(
-    styleValue(style, "extrusionAdvancedStyleEnabled")
-      ? styleValue(style, "extrusionHeightExpression")
-      : "",
-  ) as PropertyValueSpecification<number> | null;
-  if (advancedExpression) return advancedExpression;
-
-  const property = styleValue(style, "extrusionHeightProperty").trim();
-  const scale = styleValue(style, "extrusionHeightScale");
-  if (!property) return 0;
-  return ["*", ["to-number", ["get", property], 0], scale];
+  // Shared with the Add Vector Layer control mapping (vector-layer-sync) so
+  // both render-paths extrude to the same height.
+  return extrusionHeightValue(style) as PropertyValueSpecification<number>;
 }
 
 function extrusionColorPaintValue(
   style: LayerStyle,
 ): PropertyValueSpecification<string> {
-  const vectorExpression = vectorColorExpression(
-    style,
-    styleValue(style, "extrusionColor"),
-  ) as PropertyValueSpecification<string>;
-  if (vectorExpression !== styleValue(style, "extrusionColor")) {
-    return vectorExpression;
-  }
-
-  const advancedExpression = parseJsonExpression(
-    styleValue(style, "extrusionAdvancedStyleEnabled")
-      ? styleValue(style, "extrusionColorExpression")
-      : "",
-  ) as PropertyValueSpecification<string> | null;
-  return advancedExpression ?? styleValue(style, "extrusionColor");
+  return extrusionColorValue(style) as PropertyValueSpecification<string>;
 }
 
 export function fillExtrusionPaint(style: LayerStyle, opacity: number) {

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -51,7 +51,7 @@
     "maplibre-gl-swipe": "^0.9.1",
     "maplibre-gl-time-slider": "^1.1.0",
     "maplibre-gl-usgs-lidar": "^0.11.0",
-    "maplibre-gl-vector": "^0.7.0",
+    "maplibre-gl-vector": "^0.8.0",
     "proj4": "^2.20.9",
     "shpjs": "^6.2.0",
     "three": "^0.184.0"

--- a/packages/plugins/src/plugins/vector-layer-sync.ts
+++ b/packages/plugins/src/plugins/vector-layer-sync.ts
@@ -540,16 +540,16 @@ function savedVectorStyle(raw: unknown): Partial<VectorLayerStyle> | null {
   if (fraction(candidate.extrusionOpacity)) {
     style.extrusionOpacity = candidate.extrusionOpacity;
   }
+  // Height and base are meters; MapLibre clamps a negative
+  // fill-extrusion-height/base to 0, so reject negatives here (matching the
+  // >= 0 dimension guards) rather than restoring a value that renders flat.
   if (
     typeof candidate.extrusionBase === "number" &&
-    Number.isFinite(candidate.extrusionBase)
+    Number.isFinite(candidate.extrusionBase) &&
+    candidate.extrusionBase >= 0
   ) {
     style.extrusionBase = candidate.extrusionBase;
   }
-  // Height is in meters and has no meaningful negative value; MapLibre silently
-  // clamps a negative fill-extrusion-height to 0, so reject negatives here
-  // (matching the >= 0 dimension guards) rather than restoring a value that
-  // renders flat.
   if (
     typeof candidate.extrusionHeight === "number" &&
     Number.isFinite(candidate.extrusionHeight) &&

--- a/packages/plugins/src/plugins/vector-layer-sync.ts
+++ b/packages/plugins/src/plugins/vector-layer-sync.ts
@@ -1,5 +1,7 @@
 import {
   DEFAULT_LAYER_STYLE,
+  extrusionColorValue,
+  extrusionHeightValue,
   isVectorColorExpression,
   vectorCircleColorValue,
   vectorFillColorValue,
@@ -521,6 +523,42 @@ function savedVectorStyle(raw: unknown): Partial<VectorLayerStyle> | null {
     style.circleColorExpression = candidate.circleColorExpression;
   }
 
+  // 3D extrusion. Restored so a saved extruded polygon layer renders as an
+  // extrusion immediately on reopen (the control is seeded from this style),
+  // before the store sync re-pushes. The height can be a flat number or a
+  // MapLibre expression array, validated with the same bounded checks as the
+  // color expressions so a hand-edited project file cannot smuggle a blob in.
+  if (typeof candidate.extrusionEnabled === "boolean") {
+    style.extrusionEnabled = candidate.extrusionEnabled;
+  }
+  if (color(candidate.extrusionColor)) {
+    style.extrusionColor = candidate.extrusionColor;
+  }
+  if (colorExpression(candidate.extrusionColorExpression)) {
+    style.extrusionColorExpression = candidate.extrusionColorExpression;
+  }
+  if (fraction(candidate.extrusionOpacity)) {
+    style.extrusionOpacity = candidate.extrusionOpacity;
+  }
+  if (
+    typeof candidate.extrusionBase === "number" &&
+    Number.isFinite(candidate.extrusionBase)
+  ) {
+    style.extrusionBase = candidate.extrusionBase;
+  }
+  if (
+    typeof candidate.extrusionHeight === "number" &&
+    Number.isFinite(candidate.extrusionHeight)
+  ) {
+    style.extrusionHeight = candidate.extrusionHeight;
+  } else if (colorExpression(candidate.extrusionHeight)) {
+    // colorExpression only enforces "a small, well-formed JSON array", which is
+    // exactly the bound wanted for a height expression too; the name refers to
+    // its first use, not a color-only constraint.
+    style.extrusionHeight =
+      candidate.extrusionHeight as VectorLayerStyle["extrusionHeight"];
+  }
+
   // Attribute labels. The field name is length-capped like the color strings
   // (a real attribute name is short); the rest reuse the same color/number
   // guards so a hand-edited project file cannot smuggle blobs into the symbol
@@ -594,6 +632,19 @@ function layerStyleToVectorStyle(style: LayerStyle): VectorLayerStyle {
     fillColorExpression: colorExpressionField(vectorFillColorValue(style)),
     lineColorExpression: colorExpressionField(vectorLineColorValue(style)),
     circleColorExpression: colorExpressionField(vectorCircleColorValue(style)),
+    // 3D extrusion. The control renders a fill-extrusion layer for polygons
+    // when extrusionEnabled; height and color reuse GeoLibre's shared resolvers
+    // so a control-managed layer extrudes identically to the core fill-extrusion
+    // path. extrusionColorExpression carries the data-driven color (the flat
+    // extrusionColor is the fallback), matching the fill color contract above.
+    extrusionEnabled: style.extrusionEnabled,
+    extrusionColor: style.extrusionColor,
+    extrusionColorExpression: colorExpressionField(extrusionColorValue(style)),
+    extrusionOpacity: style.extrusionOpacity,
+    extrusionHeight: extrusionHeightValue(
+      style,
+    ) as VectorLayerStyle["extrusionHeight"],
+    extrusionBase: style.extrusionBase,
     // Point renderer: GeoLibre's "single" maps to the control's "circle".
     pointMode:
       (style.pointRenderer ?? "single") === "single"
@@ -739,6 +790,15 @@ function vectorStylesEqual(
     valuesEqual(left.fillColorExpression, right.fillColorExpression) &&
     valuesEqual(left.lineColorExpression, right.lineColorExpression) &&
     valuesEqual(left.circleColorExpression, right.circleColorExpression) &&
+    // Extrusion: a toggle, an opacity/base change, or a height/color change
+    // (the height is an array expression, so compare it deeply) must register
+    // so it is pushed to the control, which rebuilds or repaints accordingly.
+    left.extrusionEnabled === right.extrusionEnabled &&
+    left.extrusionColor === right.extrusionColor &&
+    left.extrusionOpacity === right.extrusionOpacity &&
+    left.extrusionBase === right.extrusionBase &&
+    valuesEqual(left.extrusionHeight, right.extrusionHeight) &&
+    valuesEqual(left.extrusionColorExpression, right.extrusionColorExpression) &&
     // Point renderer fields: a pointMode/heatmap/cluster change must register so
     // it is pushed to the control (which rebuilds the layers structurally).
     left.pointMode === right.pointMode &&

--- a/packages/plugins/src/plugins/vector-layer-sync.ts
+++ b/packages/plugins/src/plugins/vector-layer-sync.ts
@@ -546,9 +546,14 @@ function savedVectorStyle(raw: unknown): Partial<VectorLayerStyle> | null {
   ) {
     style.extrusionBase = candidate.extrusionBase;
   }
+  // Height is in meters and has no meaningful negative value; MapLibre silently
+  // clamps a negative fill-extrusion-height to 0, so reject negatives here
+  // (matching the >= 0 dimension guards) rather than restoring a value that
+  // renders flat.
   if (
     typeof candidate.extrusionHeight === "number" &&
-    Number.isFinite(candidate.extrusionHeight)
+    Number.isFinite(candidate.extrusionHeight) &&
+    candidate.extrusionHeight >= 0
   ) {
     style.extrusionHeight = candidate.extrusionHeight;
   } else if (colorExpression(candidate.extrusionHeight)) {
@@ -659,7 +664,7 @@ function layerStyleToVectorStyle(style: LayerStyle): VectorLayerStyle {
     // an empty labelField clears it.
     //
     // Only field-based labeling is wired here. LabelStyle.expression,
-    // .minZoom, and .maxZoom have no maplibre-gl-vector@0.7.0 equivalent, so
+    // .minZoom, and .maxZoom have no maplibre-gl-vector@0.8.0 equivalent, so
     // they are intentionally left out of this mapping, out of vectorStylesEqual,
     // and out of savedVectorStyle. The shared Style panel still shows those
     // controls, but for a control-managed layer they are no-ops; adding them

--- a/tests/vector-layer-sync.test.ts
+++ b/tests/vector-layer-sync.test.ts
@@ -964,4 +964,73 @@ describe("savedVectorState", () => {
     delete layer.metadata.vectorState;
     assert.deepEqual(savedVectorState(layer), {});
   });
+
+  it("restores 3D extrusion fields from the persisted style", () => {
+    const heightExpr = ["*", ["to-number", ["get", "height"], 0], 2];
+    const colorExpr = [
+      "match",
+      ["to-string", ["get", "kind"]],
+      "tower",
+      "#ff0000",
+      "#3388ff",
+    ];
+    const layer = createVectorStoreLayer(vectorInfo());
+    (layer.metadata.vectorState as Record<string, unknown>).style = {
+      ...vectorStyle(),
+      extrusionEnabled: true,
+      extrusionColor: "#abcdef",
+      extrusionColorExpression: colorExpr,
+      extrusionOpacity: 0.6,
+      extrusionBase: 3,
+      extrusionHeight: heightExpr,
+    };
+
+    const restored = savedVectorState(layer).style;
+    assert.ok(restored != null);
+    assert.equal(restored.extrusionEnabled, true);
+    assert.equal(restored.extrusionColor, "#abcdef");
+    assert.deepEqual(restored.extrusionColorExpression, colorExpr);
+    assert.equal(restored.extrusionOpacity, 0.6);
+    assert.equal(restored.extrusionBase, 3);
+    assert.deepEqual(restored.extrusionHeight, heightExpr);
+  });
+
+  it("restores a flat numeric extrusion height", () => {
+    const layer = createVectorStoreLayer(vectorInfo());
+    (layer.metadata.vectorState as Record<string, unknown>).style = {
+      ...vectorStyle(),
+      extrusionEnabled: true,
+      extrusionHeight: 12,
+    };
+
+    const restored = savedVectorState(layer).style;
+    assert.ok(restored != null);
+    assert.equal(restored.extrusionHeight, 12);
+  });
+
+  it("drops malformed extrusion fields from a hand-edited project file", () => {
+    const circular: unknown[] = [];
+    circular.push(circular);
+    const layer = createVectorStoreLayer(vectorInfo());
+    (layer.metadata.vectorState as Record<string, unknown>).style = {
+      fillColor: "#123456",
+      // MapLibre clamps a negative height/base to 0, so both are rejected.
+      extrusionHeight: -50,
+      extrusionBase: -10,
+      // Opacity must be a 0-1 fraction.
+      extrusionOpacity: 5,
+      // A circular array cannot serialize, so the height expression is dropped.
+      extrusionColorExpression: circular,
+      extrusionColor: `#${"f".repeat(200)}`,
+    };
+
+    const restored = savedVectorState(layer).style;
+    assert.ok(restored != null);
+    assert.equal(restored.fillColor, "#123456");
+    assert.equal("extrusionHeight" in restored, false);
+    assert.equal("extrusionBase" in restored, false);
+    assert.equal("extrusionOpacity" in restored, false);
+    assert.equal("extrusionColorExpression" in restored, false);
+    assert.equal("extrusionColor" in restored, false);
+  });
 });

--- a/tests/vector-layer-sync.test.ts
+++ b/tests/vector-layer-sync.test.ts
@@ -599,6 +599,15 @@ describe("wireVectorStoreSync", () => {
       labelHaloWidth: 1.5,
       labelPlacement: "point",
       labelAllowOverlap: false,
+      // Extrusion fields default through from DEFAULT_LAYER_STYLE; the height is
+      // the chosen property scaled (default property "height", scale 1) and the
+      // color resolves to a flat value so its expression field is undefined.
+      extrusionEnabled: false,
+      extrusionColor: "#3b82f6",
+      extrusionColorExpression: undefined,
+      extrusionOpacity: 0.8,
+      extrusionHeight: ["*", ["to-number", ["get", "height"], 0], 1],
+      extrusionBase: 0,
     };
     assert.deepEqual(calls, [
       { method: "setLayerStyle", args: ["vector-1", expectedStyle] },


### PR DESCRIPTION
## Summary

Fixes #811 — enabling **3D extrusion** on an Add Vector Layer polygon layer (e.g. buildings with a `height` attribute) did nothing; the polygons stayed flat.

## Root cause

Add Vector Layer renders through **maplibre-gl-vector**, whose `VectorControl` owns its own MapLibre layers (`fill`/`outline` for polygons). The control had no extrusion concept, so the Style panel's "3D extrusion" toggle set `extrusionEnabled` in the store but nothing turned it into a `fill-extrusion` layer. (These layers are `customLayerType` + `controlOwnsPaint`, so GeoLibre's own external-layer extrusion synthesis is deliberately skipped for them.)

## Fix

- Bump `maplibre-gl-vector` to **^0.8.0** (opengeos/maplibre-gl-vector#30, released v0.8.0), which adds a `fill-extrusion` render path driven by new `VectorLayerStyle` extrusion fields.
- Map GeoLibre's extrusion style onto the control's `VectorLayerStyle` in `vector-layer-sync.ts`: `extrusionEnabled`, flat + data-driven color, opacity, base, and the resolved height. The fields join `vectorStylesEqual` (so an edit is pushed) and `savedVectorStyle` (so a saved project restores them).
- Extract shared `extrusionHeightValue` / `extrusionColorValue` resolvers into `@geolibre/core`; the map's own `fill-extrusion` paint now uses them too, so a control-managed vector layer extrudes identically to the core path.

## Verification

Drove the real web app with Playwright using the issue's dataset (`test.geojson`, MultiPolygon buildings with a `height` attribute):

- Enabling "3D extrusion" replaces the flat `fill`/`outline` with a single `fill-extrusion` layer whose height is `["*", ["to-number", ["get", "height"], 0], 1]`; pitching the camera shows the buildings extruded.
- Toggling back to 2D cleanly restores the flat fill (no orphan extrusion layer).
- Confirmed in both **light and dark** themes, with the published `maplibre-gl-vector@0.8.0`.
- Full frontend test suite green; added/updated unit tests upstream and in `vector-layer-sync`.

Upstream PR: https://github.com/opengeos/maplibre-gl-vector/pull/30 (released as v0.8.0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for 3D polygon extrusion styling, including extrusion height and color (with expression-based options), plus opacity and base.
  * Enhanced vector style syncing to include extrusion properties during panel/control updates.

* **Bug Fixes**
  * Improved change detection to treat extrusion updates as real style changes.
  * Strengthened save/restore for extrusion settings, including validation and safe handling of malformed values.

* **Chores**
  * Updated the MapLibre GL vector dependency in desktop and plugins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->