### PR TITLE
chore(processing): bump geolibre-wasm to 0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14873,9 +14873,9 @@
       "link": true
     },
     "node_modules/geolibre-wasm": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/geolibre-wasm/-/geolibre-wasm-0.4.4.tgz",
-      "integrity": "sha512-C9Yo3kMIR1PL6hgrN2vNIyZ1gLCniZv9NuCMyEcrMzR7siAScgcdoMjFwOLZSHJCV28lw7+d1/AI6+kHUpENPw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/geolibre-wasm/-/geolibre-wasm-0.5.0.tgz",
+      "integrity": "sha512-S6h9qMjySiRV7Icqpo/Mwy12wsz/wv3oM/J2bIiO7dV/w+hWfLFqF0HdDIsp7nB1Y7zxyEXPoh0DEcLQqqliNA==",
       "license": "MIT",
       "dependencies": {
         "@bjorn3/browser_wasi_shim": "^0.4.2"
@@ -23957,7 +23957,7 @@
         "@turf/tin": "^7.3.5",
         "@turf/union": "^7.3.5",
         "@turf/voronoi": "^7.3.5",
-        "geolibre-wasm": "^0.4.4",
+        "geolibre-wasm": "^0.5.0",
         "geotiff": "^3.0.5"
       },
       "devDependencies": {

--- a/packages/processing/package.json
+++ b/packages/processing/package.json
@@ -32,7 +32,7 @@
     "@turf/tin": "^7.3.5",
     "@turf/union": "^7.3.5",
     "@turf/voronoi": "^7.3.5",
-    "geolibre-wasm": "^0.4.4",
+    "geolibre-wasm": "^0.5.0",
     "geotiff": "^3.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumps `geolibre-wasm` in `packages/processing` from `^0.4.4` to `^0.5.0`.

geolibre-rust v0.5.0 (just released to npm) adds the H3 DGGS toolset and a systemic manifest-inference fix, so the in-browser WASM toolbox now gets:

- New tools: `vector_to_h3`, `h3_to_vector`, `h3_polyfill`, `raster_to_h3`.
- Word-aware parameter inference for the ~750 whitebox tools (correct file / enum / number / bool controls instead of substring-mis-typed ones, e.g. `spatial_join.strategy` is now an enum rather than a LiDAR file picker).

## Verification
- `npm install` resolves and locks `geolibre-wasm@0.5.0`.
- Loaded the installed package's runner in Node: 751 tools total, all four new tools present, and `spatial_join.strategy` infers as `enum` (inference fix confirmed).
- `npm run build` (full web build) passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->