### PR TITLE
feat(style): greyscale toggle, reset, and numeric input for raster paint controls

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -909,19 +909,35 @@ function RasterStyleSlider({
   // Double-clicking the value label (or the slider track) swaps the read-only
   // value for an inline numeric input, so users can type an exact value instead
   // of dragging to it (#832). Enter/blur commits the clamped value, Escape cancels.
+  const { t } = useTranslation();
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
   const precision = stepPrecision(step);
+  // Guard so each edit session commits (or cancels) at most once: Enter and
+  // Escape both tear down the input, and React still fires onBlur on the
+  // unmounting element. Without this, blur would re-commit after Enter or
+  // commit a cancelled draft after Escape.
+  const handledRef = useRef(false);
 
   const commit = (raw: string) => {
+    if (handledRef.current) return;
+    handledRef.current = true;
     const parsed = Number(raw);
-    if (Number.isFinite(parsed)) {
+    // Treat an empty/whitespace entry like Escape: cancel rather than commit 0
+    // (Number("") === 0 would otherwise silently reset the slider to its min).
+    if (raw.trim() !== "" && Number.isFinite(parsed)) {
       onChange(Number(clampNumber(parsed, min, max).toFixed(precision)));
     }
     setEditing(false);
   };
 
+  const cancel = () => {
+    handledRef.current = true;
+    setEditing(false);
+  };
+
   const startEditing = () => {
+    handledRef.current = false;
     setDraft(String(value));
     setEditing(true);
   };
@@ -948,7 +964,7 @@ function RasterStyleSlider({
                 commit((event.target as HTMLInputElement).value);
               } else if (event.key === "Escape") {
                 event.preventDefault();
-                setEditing(false);
+                cancel();
               }
             }}
           />
@@ -956,7 +972,7 @@ function RasterStyleSlider({
           <button
             type="button"
             className="shrink-0 cursor-text font-mono text-xs text-muted-foreground hover:text-foreground"
-            title="Double-click to enter an exact value"
+            title={t("style.raster.exactValueHint")}
             aria-label={`Edit ${label} value`}
             onDoubleClick={startEditing}
           >
@@ -2987,7 +3003,7 @@ export function StylePanel({
                   }
                   className="w-full"
                   aria-pressed={styleValue(style, "rasterSaturation") <= -1}
-                  title="Toggle a greyscale basemap (drives saturation to its minimum)"
+                  title={t("style.raster.greyscaleHint")}
                   onClick={() =>
                     setLayerStyle(layer.id, {
                       rasterSaturation:
@@ -2997,7 +3013,7 @@ export function StylePanel({
                     })
                   }
                 >
-                  Greyscale
+                  {t("style.raster.greyscale")}
                 </Button>
                 <RasterStyleSlider
                   label="Contrast"
@@ -3031,7 +3047,7 @@ export function StylePanel({
               size="sm"
               variant="outline"
               className="w-full"
-              title="Reset every adjustment slider to its default value"
+              title={t("style.raster.resetHint")}
               onClick={() => {
                 setLayerOpacity(layer.id, 1);
                 if (!isDeckRasterLayer) {
@@ -3047,7 +3063,7 @@ export function StylePanel({
                 }
               }}
             >
-              Reset
+              {t("style.raster.reset")}
             </Button>
           </div>
         </ScrollArea>

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -906,13 +906,63 @@ function RasterStyleSlider({
   onChange,
   format = (next) => next.toFixed(2),
 }: RasterStyleSliderProps) {
+  // Double-clicking the value label (or the slider track) swaps the read-only
+  // value for an inline numeric input, so users can type an exact value instead
+  // of dragging to it (#832). Enter/blur commits the clamped value, Escape cancels.
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const precision = stepPrecision(step);
+
+  const commit = (raw: string) => {
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed)) {
+      onChange(Number(clampNumber(parsed, min, max).toFixed(precision)));
+    }
+    setEditing(false);
+  };
+
+  const startEditing = () => {
+    setDraft(String(value));
+    setEditing(true);
+  };
+
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between gap-3">
         <Label className="text-xs">{label}</Label>
-        <span className="shrink-0 font-mono text-xs text-muted-foreground">
-          {format(value)}
-        </span>
+        {editing ? (
+          <Input
+            type="number"
+            min={min}
+            max={max}
+            step={step}
+            autoFocus
+            aria-label={`${label} value`}
+            className="h-6 w-20 px-1.5 py-0 text-right font-mono text-xs [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+            onBlur={(event) => commit(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                commit((event.target as HTMLInputElement).value);
+              } else if (event.key === "Escape") {
+                event.preventDefault();
+                setEditing(false);
+              }
+            }}
+          />
+        ) : (
+          <button
+            type="button"
+            className="shrink-0 cursor-text font-mono text-xs text-muted-foreground hover:text-foreground"
+            title="Double-click to enter an exact value"
+            aria-label={`Edit ${label} value`}
+            onDoubleClick={startEditing}
+          >
+            {format(value)}
+          </button>
+        )}
       </div>
       <Slider
         aria-label={label}
@@ -923,6 +973,7 @@ function RasterStyleSlider({
         onValueChange={([next]: number[]) => {
           if (typeof next === "number") onChange(next);
         }}
+        onDoubleClick={startEditing}
       />
     </div>
   );
@@ -2926,6 +2977,28 @@ export function StylePanel({
                     setLayerStyle(layer.id, { rasterSaturation: value })
                   }
                 />
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={
+                    styleValue(style, "rasterSaturation") <= -1
+                      ? "default"
+                      : "outline"
+                  }
+                  className="w-full"
+                  aria-pressed={styleValue(style, "rasterSaturation") <= -1}
+                  title="Toggle a greyscale basemap (drives saturation to its minimum)"
+                  onClick={() =>
+                    setLayerStyle(layer.id, {
+                      rasterSaturation:
+                        styleValue(style, "rasterSaturation") <= -1
+                          ? DEFAULT_LAYER_STYLE.rasterSaturation
+                          : -1,
+                    })
+                  }
+                >
+                  Greyscale
+                </Button>
                 <RasterStyleSlider
                   label="Contrast"
                   value={styleValue(style, "rasterContrast")}
@@ -2952,6 +3025,30 @@ export function StylePanel({
             {layer.metadata.sourceKind === RASTER_SOURCE_KIND && (
               <RasterSymbologySection layer={layer} />
             )}
+            <Separator />
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="w-full"
+              title="Reset every adjustment slider to its default value"
+              onClick={() => {
+                setLayerOpacity(layer.id, 1);
+                if (!isDeckRasterLayer) {
+                  setLayerStyle(layer.id, {
+                    rasterBrightnessMin:
+                      DEFAULT_LAYER_STYLE.rasterBrightnessMin,
+                    rasterBrightnessMax:
+                      DEFAULT_LAYER_STYLE.rasterBrightnessMax,
+                    rasterSaturation: DEFAULT_LAYER_STYLE.rasterSaturation,
+                    rasterContrast: DEFAULT_LAYER_STYLE.rasterContrast,
+                    rasterHueRotate: DEFAULT_LAYER_STYLE.rasterHueRotate,
+                  });
+                }
+              }}
+            >
+              Reset
+            </Button>
           </div>
         </ScrollArea>
         <Separator />

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1953,6 +1953,13 @@
     "collapse": "Collapse {{title}}"
   },
   "style": {
+    "raster": {
+      "greyscale": "Greyscale",
+      "greyscaleHint": "Toggle a greyscale basemap (drives saturation to its minimum)",
+      "reset": "Reset",
+      "resetHint": "Reset adjustments to their default values",
+      "exactValueHint": "Double-click to enter an exact value"
+    },
     "labels": {
       "heading": "Labels",
       "show": "Show labels",


### PR DESCRIPTION
## Summary

Implements the three style-menu enhancements requested in #832 for the raster basemap paint controls (the panel shown when a raster basemap / XYZ / WMS / COG layer is selected).

### Part 1 — Greyscale toggle
A **Greyscale** button sits directly below the Saturation slider. Clicking it drives saturation to its minimum (`-1`), instantly rendering the basemap in greyscale so it stops competing with overlying thematic layers. The button shows a pressed/active state while greyscale is on, and clicking again restores the default saturation, so it works as a true toggle.

### Part 2 — Reset
A **Reset** button at the bottom of the panel restores opacity and every raster paint slider (Brightness Min/Max, Saturation, Contrast, Hue Rotate) to their default values in a single click.

### Part 3 — Numerical value input
Double-clicking any raster slider, or its value label, swaps the read-only value for an inline numeric input. Type an exact value and press Enter to commit (Escape cancels). Values are clamped to each slider's valid range, so precise, reproducible styling no longer requires dragging.

## How it was verified

Driven in the real app with Playwright using an OpenStreetMap XYZ raster layer, in **both light and dark themes**:

- Greyscale sets saturation to `-1.00` (button shows pressed) and toggles back to `0.00`; the basemap visibly turns greyscale.
- Reset restores opacity to `1.00` and all sliders to their defaults after edits.
- Double-click opens the inline input; typing `-0.5` sets saturation to `-0.50`, and an out-of-range entry (`5`) clamps to the slider max (`1.00`).

`npm run build` and `pre-commit` on the changed file both pass.

Fixes #832


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline numeric editing for raster sliders, allowing values to be edited directly from the displayed control.
  * Added a **Greyscale** toggle for raster saturation controls.
  * Added a **Reset** action to quickly restore raster appearance settings to defaults.

* **Bug Fixes**
  * Improved value handling while editing sliders, including keyboard support, clamping, and canceling changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->