### PR TITLE
feat(plugins): expose native raster/tile layer registration to the plugin API (#845)

### DIFF
--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -47,6 +47,8 @@ import type {
   GeoLibreExternalNativeLayerRegistration,
   GeoLibreFileDialogOptions,
   GeoLibreMapControlPosition,
+  GeoLibreTileLayerOptions,
+  GeoLibreWmsLayerOptions,
 } from "@geolibre/plugins";
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
@@ -66,6 +68,7 @@ import {
   type InstalledWebPlugin,
 } from "../lib/external-plugins";
 import { appendDiagnostic } from "../lib/diagnostics";
+import { createWmsTileUrl } from "../components/layout/add-data/helpers";
 import { createExternalNativeStoreLayer } from "../lib/external-native-layer";
 import { mergeStringLists } from "../lib/string-lists";
 import {
@@ -94,6 +97,17 @@ function ensureFileExtension(name: string, extensions: string[]): string {
 }
 
 const RASTER_PROXY_PATH = "/__geolibre_raster_proxy";
+
+/**
+ * Translate the public {@link GeoLibreTileLayerOptions} into the store's
+ * `addTileLayer` source/render options, dropping `beforeLayerId` (which the
+ * store takes as a separate positional argument).
+ */
+function tileLayerSourceOptions(options?: GeoLibreTileLayerOptions) {
+  if (!options) return {};
+  const { beforeLayerId: _beforeLayerId, ...rest } = options;
+  return rest;
+}
 
 /** Records a plugin failure in the diagnostics panel without crashing the app. */
 function reportPluginError(
@@ -473,6 +487,67 @@ export function createAppAPI(
     ) => {
       const id = store.addGeoJsonLayer(name, data, sourcePath);
       return id;
+    },
+    addTileLayer: (
+      name: string,
+      url: string,
+      options?: GeoLibreTileLayerOptions,
+    ) =>
+      store.addTileLayer(
+        name,
+        { type: "xyz", tiles: [url], url, ...tileLayerSourceOptions(options) },
+        options?.beforeLayerId ?? null,
+      ),
+    addWmtsLayer: (
+      name: string,
+      url: string,
+      options?: GeoLibreTileLayerOptions,
+    ) =>
+      store.addTileLayer(
+        name,
+        { type: "wmts", tiles: [url], url, ...tileLayerSourceOptions(options) },
+        options?.beforeLayerId ?? null,
+      ),
+    addWmsLayer: (name: string, options: GeoLibreWmsLayerOptions) => {
+      const {
+        beforeLayerId,
+        url,
+        layers,
+        styles,
+        format,
+        transparent,
+        ...tileOptions
+      } = options;
+      const tileSize = tileOptions.tileSize ?? 256;
+      const resolvedStyles = styles ?? "";
+      const resolvedFormat = format ?? "image/png";
+      const resolvedTransparent = transparent ?? true;
+      const tileUrl = createWmsTileUrl({
+        endpoint: url,
+        layers,
+        styles: resolvedStyles,
+        format: resolvedFormat,
+        transparent: resolvedTransparent,
+        tileSize,
+      });
+      return store.addTileLayer(
+        name,
+        {
+          type: "wms",
+          tiles: [tileUrl],
+          url,
+          // Persist the WMS request parameters so the layer round-trips through
+          // a saved project, mirroring the Add Data dialog's WMS source.
+          source: {
+            layers,
+            styles: resolvedStyles,
+            format: resolvedFormat,
+            transparent: resolvedTransparent,
+          },
+          ...tileOptions,
+        },
+        beforeLayerId ?? null,
+      );
     },
     getActiveBasemap: () => useAppStore.getState().basemapStyleUrl,
     onBasemapChange: (callback: (styleUrl: string) => void) =>

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -586,6 +586,9 @@ export function createAppAPI(
         url,
         name,
         ...(options?.bands !== undefined ? { bands: options.bands } : {}),
+        // The public option is a loose `string` (so JS plugins need not import
+        // the renderer's colormap union); the renderer validates the name and
+        // falls back to its default for anything it doesn't recognize.
         ...(options?.colormap !== undefined
           ? {
               colormap:

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -99,11 +99,13 @@ function ensureFileExtension(name: string, extensions: string[]): string {
 const RASTER_PROXY_PATH = "/__geolibre_raster_proxy";
 
 /**
- * Translate the public {@link GeoLibreTileLayerOptions} into the store's
- * `addTileLayer` source/render options, dropping `beforeLayerId` (which the
- * store takes as a separate positional argument).
+ * Translate the public {@link GeoLibreTileLayerOptions} into the option bag
+ * passed straight to `store.addTileLayer(name, opts, ...)`, dropping
+ * `beforeLayerId` (which the store takes as a separate positional argument).
+ * The remaining keys mix source-level fields (tileSize, bounds, ...) and
+ * layer-level ones (visible, opacity); the store reads each by name.
  */
-function tileLayerSourceOptions(options?: GeoLibreTileLayerOptions) {
+function tileLayerStoreOptions(options?: GeoLibreTileLayerOptions) {
   if (!options) return {};
   const { beforeLayerId: _beforeLayerId, ...rest } = options;
   return rest;
@@ -495,9 +497,13 @@ export function createAppAPI(
     ) =>
       store.addTileLayer(
         name,
-        { type: "xyz", tiles: [url], url, ...tileLayerSourceOptions(options) },
+        { type: "xyz", tiles: [url], url, ...tileLayerStoreOptions(options) },
         options?.beforeLayerId ?? null,
       ),
+    // Intentionally identical to addTileLayer except for the layer `type`.
+    // XYZ and WMTS tile templates render through the same syncRasterTileLayer
+    // path; the distinct type only changes how the layer is labelled/stored,
+    // so the two helpers share an implementation by design (not a copy-paste).
     addWmtsLayer: (
       name: string,
       url: string,
@@ -505,7 +511,7 @@ export function createAppAPI(
     ) =>
       store.addTileLayer(
         name,
-        { type: "wmts", tiles: [url], url, ...tileLayerSourceOptions(options) },
+        { type: "wmts", tiles: [url], url, ...tileLayerStoreOptions(options) },
         options?.beforeLayerId ?? null,
       ),
     addWmsLayer: (name: string, options: GeoLibreWmsLayerOptions) => {

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -1,5 +1,6 @@
 import { useAppStore } from "@geolibre/core";
 import {
+  addCogRasterLayer,
   maplibreAnnotationsPlugin,
   maplibreBasemapControlPlugin,
   maplibreComponentsPlugin,
@@ -43,6 +44,7 @@ import {
 } from "@geolibre/plugins";
 import type { MapController } from "@geolibre/map";
 import type {
+  GeoLibreCogLayerOptions,
   GeoLibreDeckGL,
   GeoLibreExternalNativeLayerRegistration,
   GeoLibreFileDialogOptions,
@@ -480,7 +482,10 @@ export function createAppAPI(
   mapControllerRef?: RefObject<MapController | null>,
 ) {
   const store = useAppStore.getState();
-  return {
+  // Captured so methods that delegate to plugin helpers taking the AppAPI
+  // itself (e.g. addCogLayer -> addCogRasterLayer) can pass `api`. Only read
+  // when those methods are called, which is always after assignment.
+  const api = {
     setBasemap: (url: string) => store.setBasemapStyleUrl(url),
     addGeoJsonLayer: (
       name: string,
@@ -555,6 +560,38 @@ export function createAppAPI(
         beforeLayerId ?? null,
       );
     },
+    // Unlike the tile helpers above, a COG is read client-side by the maplibre
+    // raster control (band/rescale/colormap/nodata), so it delegates to the
+    // components plugin's addCogRasterLayer rather than building a store layer
+    // here. It takes the AppAPI itself (to mount the control on demand), so we
+    // hand it the captured `api`.
+    addCogLayer: (
+      name: string,
+      url: string,
+      options?: GeoLibreCogLayerOptions,
+    ) =>
+      addCogRasterLayer(api, {
+        url,
+        name,
+        ...(options?.bands !== undefined ? { bands: options.bands } : {}),
+        ...(options?.colormap !== undefined
+          ? {
+              colormap:
+                options.colormap as Parameters<
+                  typeof addCogRasterLayer
+                >[1]["colormap"],
+            }
+          : {}),
+        ...(options?.rescaleMin !== undefined
+          ? { rescaleMin: options.rescaleMin }
+          : {}),
+        ...(options?.rescaleMax !== undefined
+          ? { rescaleMax: options.rescaleMax }
+          : {}),
+        ...(options?.nodata !== undefined ? { nodata: options.nodata } : {}),
+        ...(options?.opacity !== undefined ? { opacity: options.opacity } : {}),
+        beforeLayerId: options?.beforeLayerId ?? null,
+      }),
     getActiveBasemap: () => useAppStore.getState().basemapStyleUrl,
     onBasemapChange: (callback: (styleUrl: string) => void) =>
       useAppStore.subscribe((state, prev) => {
@@ -703,6 +740,7 @@ export function createAppAPI(
     closeFloatingPanel,
     getOpenFloatingPanels,
   };
+  return api;
 }
 
 async function fetchRemoteArrayBuffer(url: string): Promise<ArrayBuffer> {

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -529,6 +529,18 @@ export function createAppAPI(
         transparent,
         ...tileOptions
       } = options;
+      // TypeScript enforces these, but an untyped JS plugin can pass "" — an
+      // empty endpoint yields a relative GetMap URL that resolves against the
+      // app origin and passes the store's empty-tile guard, persisting a layer
+      // that only 404s. Reject at the API boundary instead.
+      if (!url) {
+        throw new Error("addWmsLayer: options.url must be a non-empty string.");
+      }
+      if (!layers) {
+        throw new Error(
+          "addWmsLayer: options.layers must be a non-empty string.",
+        );
+      }
       const tileSize = tileOptions.tileSize ?? 256;
       const resolvedStyles = styles ?? "";
       const resolvedFormat = format ?? "image/png";

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -76,6 +76,14 @@ export interface GeoLibreAppAPI {
     options?: GeoLibreTileLayerOptions,
   ) => string;
   addWmsLayer?: (name: string, options: GeoLibreWmsLayerOptions) => string;
+  // Native client-side COG (reads the GeoTIFF directly; band/rescale/colormap/
+  // nodata controls). Resolves with the new layer's id (see "Raster and tile
+  // layers" below).
+  addCogLayer?: (
+    name: string,
+    url: string,
+    options?: GeoLibreCogLayerOptions,
+  ) => Promise<string>;
   getActiveBasemap: () => string;
   onBasemapChange: (callback: (styleUrl: string) => void) => () => void;
   fetchArrayBuffer?: (url: string) => Promise<ArrayBuffer>;
@@ -285,6 +293,16 @@ export interface GeoLibreWmsLayerOptions extends GeoLibreTileLayerOptions {
   format?: string; // default "image/png"
   transparent?: boolean; // default true
 }
+
+export interface GeoLibreCogLayerOptions {
+  bands?: string; // "1" (single band) or "1,2,3" (RGB)
+  colormap?: string; // named colormap for a single-band COG, e.g. "terrain"
+  rescaleMin?: number;
+  rescaleMax?: number;
+  nodata?: number; // pixel value rendered transparent
+  opacity?: number; // default 1
+  beforeLayerId?: string;
+}
 ```
 
 ```typescript
@@ -304,7 +322,16 @@ app.addWmsLayer?.("LINZ Coverage", {
   layers: "coverage",
   transparent: true,
 });
+
+// COG — read the GeoTIFF directly (client-side), with raster controls.
+const cogId = await app.addCogLayer?.(
+  "LINZ DEM",
+  "https://cog.example.nz/dem.tif",
+  { colormap: "terrain", nodata: -9999 },
+);
 ```
+
+`addTileLayer`/`addWmtsLayer`/`addWmsLayer` expect **pre-rendered tiles** (e.g. a COG already served through a tiler such as titiler as an XYZ endpoint). `addCogLayer` is different: it loads the **GeoTIFF itself** and renders it client-side, exposing band selection, rescale, colormap, and nodata in the raster panel. It is async (it fetches the file's header), so it returns a `Promise<string>` and rejects if the COG cannot be read.
 
 The helpers are typed optional for forward-compatibility with host variants, so call them with optional chaining (`app.addTileLayer?.(...)`).
 

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -62,6 +62,20 @@ export interface GeoLibreAppAPI {
     data: FeatureCollection,
     sourcePath?: string,
   ) => void;
+  // Native raster/tile layers (see "Raster and tile layers" below). Each
+  // returns the new layer's id and the layer appears in the Layers panel and
+  // persists with the project, like addGeoJsonLayer does for vector data.
+  addTileLayer?: (
+    name: string,
+    url: string,
+    options?: GeoLibreTileLayerOptions,
+  ) => string;
+  addWmtsLayer?: (
+    name: string,
+    url: string,
+    options?: GeoLibreTileLayerOptions,
+  ) => string;
+  addWmsLayer?: (name: string, options: GeoLibreWmsLayerOptions) => string;
   getActiveBasemap: () => string;
   onBasemapChange: (callback: (styleUrl: string) => void) => () => void;
   fetchArrayBuffer?: (url: string) => Promise<ArrayBuffer>;
@@ -246,6 +260,53 @@ https://viewer.geolibre.app/?url=https://example.com/project.geolibre.json&examp
 ```
 
 A URL parameter activates only an already-registered (installed) plugin that owns it; it never loads a plugin from the URL. For external plugins, include the plugin manifest URL in the project `plugins` state (so the plugin is registered) before relying on its URL handler — the matching parameter then activates and dispatches it even if it is not in the active set.
+
+## Raster and tile layers
+
+`addGeoJsonLayer` registers vector data as a native layer. For raster and tile data there are three matching helpers — `addTileLayer` (XYZ), `addWmtsLayer` (WMTS), and `addWmsLayer` (WMS). Each returns the new layer's id, and the layer appears in the Layers panel with full opacity, reorder, and styling support and persists with the project, so a plugin no longer has to call `getMap().addSource()/addLayer()` directly (which leaves the layer invisible to GeoLibre's layer store).
+
+```typescript
+export interface GeoLibreTileLayerOptions {
+  tileSize?: number; // default 256
+  attribution?: string;
+  bounds?: [number, number, number, number]; // [west, south, east, north] in WGS84
+  minzoom?: number;
+  maxzoom?: number;
+  scheme?: "xyz" | "tms"; // default "xyz"
+  visible?: boolean; // default true
+  opacity?: number; // default 1
+  beforeLayerId?: string; // insert beneath this layer
+}
+
+export interface GeoLibreWmsLayerOptions extends GeoLibreTileLayerOptions {
+  url: string; // WMS GetMap endpoint
+  layers: string; // comma-separated layer name(s)
+  styles?: string;
+  format?: string; // default "image/png"
+  transparent?: boolean; // default true
+}
+```
+
+```typescript
+// XYZ tiles (e.g. an imagery, topo, or DEM hillshade endpoint).
+app.addTileLayer?.("LINZ Aerial Imagery", "https://tiles.example.nz/aerial/{z}/{x}/{y}.png", {
+  attribution: "Sourced from LINZ. CC BY 4.0",
+  maxzoom: 22,
+  bounds: [166.0, -47.5, 178.6, -34.0],
+});
+
+// WMTS tile URL template.
+app.addWmtsLayer?.("LINZ Topo50", "https://tiles.example.nz/topo50/{z}/{x}/{y}.png");
+
+// WMS — pass the request parameters; the host builds the GetMap tile URL.
+app.addWmsLayer?.("LINZ Coverage", {
+  url: "https://wms.example.nz/wms",
+  layers: "coverage",
+  transparent: true,
+});
+```
+
+The helpers are typed optional for forward-compatibility with host variants, so call them with optional chaining (`app.addTileLayer?.(...)`).
 
 ## Right sidebar panels
 

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -61,7 +61,7 @@ export interface GeoLibreAppAPI {
     name: string,
     data: FeatureCollection,
     sourcePath?: string,
-  ) => void;
+  ) => string;
   // Native raster/tile layers (see "Raster and tile layers" below). Each
   // returns the new layer's id and the layer appears in the Layers panel and
   // persists with the project, like addGeoJsonLayer does for vector data.
@@ -307,6 +307,8 @@ app.addWmsLayer?.("LINZ Coverage", {
 ```
 
 The helpers are typed optional for forward-compatibility with host variants, so call them with optional chaining (`app.addTileLayer?.(...)`).
+
+> **Desktop (Tauri) note:** The desktop app enforces a Content Security Policy that restricts which tile hosts the WebView can reach. If your plugin registers tiles from a host not already in the GeoLibre CSP allowlist, the layer is created but its tiles silently fail to load. For bundled (first-party) plugins, add the host to `connect-src` / `img-src` in `apps/geolibre-desktop/src-tauri/tauri.conf.json`; external plugins can only reach already-permitted hosts. The web build is unaffected.
 
 ## Right sidebar panels
 

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -1074,6 +1074,18 @@ export const useAppStore = create<AppState>()(
             "addTileLayer requires at least one non-empty tile URL template."
           );
         }
+        // MapLibre's addSource throws synchronously when maxzoom < minzoom, and
+        // syncRasterTileLayer does not catch it, which would strand a layer in
+        // the store with no rendered source. Reject the bad range up front.
+        if (
+          options.minzoom !== undefined &&
+          options.maxzoom !== undefined &&
+          options.minzoom > options.maxzoom
+        ) {
+          throw new Error(
+            `addTileLayer: minzoom (${options.minzoom}) must be <= maxzoom (${options.maxzoom}).`
+          );
+        }
         const layer: GeoLibreLayer = {
           id,
           name,

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -31,6 +31,7 @@ import {
   DEFAULT_STORY_MAP,
   MAX_DASHBOARD_COLUMNS,
   MIN_DASHBOARD_COLUMNS,
+  type AddTileLayerOptions,
   type CollaborationChatMessage,
   type CollaborationParticipant,
   type CollaborationPresence,
@@ -335,6 +336,18 @@ export interface AppState {
     name: string,
     geojson: FeatureCollection,
     sourcePath?: string,
+    beforeLayerId?: string | null
+  ) => string;
+  /**
+   * Add a native raster tile layer (XYZ, WMS, or WMTS) from one or more tile
+   * URL templates and return its id. The layer appears in the Layers panel and
+   * persists with the project exactly like a layer added through the Add Data
+   * dialog, so callers (e.g. an external plugin) do not have to touch MapLibre
+   * directly. See {@link AddTileLayerOptions}.
+   */
+  addTileLayer: (
+    name: string,
+    options: AddTileLayerOptions,
     beforeLayerId?: string | null
   ) => string;
 
@@ -1041,6 +1054,44 @@ export const useAppStore = create<AppState>()(
           metadata: {},
           geojson,
           sourcePath,
+        };
+        get().addLayer(layer, beforeLayerId);
+        return id;
+      },
+
+      addTileLayer: (name, options, beforeLayerId = null) => {
+        const id = uuidv4();
+        const tiles = options.tiles.filter(
+          (tile) => typeof tile === "string" && tile.trim() !== ""
+        );
+        const layer: GeoLibreLayer = {
+          id,
+          name,
+          type: options.type ?? "xyz",
+          source: {
+            // Extra source fields (e.g. WMS layers/styles) merge first so the
+            // required raster descriptor below always wins.
+            ...(options.source ?? {}),
+            type: "raster",
+            tiles,
+            tileSize: options.tileSize ?? 256,
+            ...(options.url !== undefined ? { url: options.url } : {}),
+            ...(options.attribution !== undefined
+              ? { attribution: options.attribution }
+              : {}),
+            ...(options.bounds !== undefined ? { bounds: options.bounds } : {}),
+            ...(options.minzoom !== undefined
+              ? { minzoom: options.minzoom }
+              : {}),
+            ...(options.maxzoom !== undefined
+              ? { maxzoom: options.maxzoom }
+              : {}),
+            ...(options.scheme !== undefined ? { scheme: options.scheme } : {}),
+          },
+          visible: options.visible ?? true,
+          opacity: options.opacity ?? 1,
+          style: { ...DEFAULT_LAYER_STYLE },
+          metadata: { ...(options.metadata ?? {}) },
         };
         get().addLayer(layer, beforeLayerId);
         return id;

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -1061,9 +1061,19 @@ export const useAppStore = create<AppState>()(
 
       addTileLayer: (name, options, beforeLayerId = null) => {
         const id = uuidv4();
-        const tiles = options.tiles.filter(
-          (tile) => typeof tile === "string" && tile.trim() !== ""
-        );
+        // Trim each template and drop blanks, then reject a registration that
+        // sanitizes down to nothing: syncRasterTileLayer returns early on an
+        // empty tile list, so without this the store would persist and select a
+        // layer that can never render.
+        const tiles = options.tiles
+          .filter((tile): tile is string => typeof tile === "string")
+          .map((tile) => tile.trim())
+          .filter((tile) => tile !== "");
+        if (tiles.length === 0) {
+          throw new Error(
+            "addTileLayer requires at least one non-empty tile URL template."
+          );
+        }
         const layer: GeoLibreLayer = {
           id,
           name,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -480,6 +480,52 @@ export interface GeoLibreLayer {
 }
 
 /**
+ * Options for {@link AppState.addTileLayer}: a native raster tile layer (XYZ,
+ * WMS, or WMTS) that appears in the Layers panel and persists with the project,
+ * just like a layer added through the Add Data dialog. Mirrors the raster
+ * `source` fields MapLibre understands so an external plugin can register tile
+ * layers without touching the map directly.
+ */
+export interface AddTileLayerOptions {
+  /**
+   * One or more XYZ tile URL templates (with `{x}`/`{y}`/`{z}` placeholders).
+   * At least one non-empty template is required, or the layer renders nothing.
+   */
+  tiles: string[];
+  /**
+   * Layer discriminator, controlling how the layer is labelled and (for WMS)
+   * dev-server proxied. Defaults to `"xyz"`.
+   */
+  type?: "xyz" | "wms" | "wmts" | "raster";
+  /** Service or base URL recorded on the source for display and restore. */
+  url?: string;
+  /** Tile size in pixels (default 256). */
+  tileSize?: number;
+  /** Attribution string shown in the map's attribution control. */
+  attribution?: string;
+  /** Visible extent as `[west, south, east, north]` in WGS84 degrees. */
+  bounds?: [number, number, number, number];
+  /** Minimum zoom at which tiles are requested. */
+  minzoom?: number;
+  /** Maximum zoom at which tiles are requested. */
+  maxzoom?: number;
+  /** Tile y-axis scheme; `"tms"` flips the y origin. Defaults to `"xyz"`. */
+  scheme?: "xyz" | "tms";
+  /** Initial visibility (default true). */
+  visible?: boolean;
+  /** Initial opacity in [0, 1] (default 1). */
+  opacity?: number;
+  /**
+   * Extra source fields merged onto the layer's `source` (e.g. the WMS
+   * `layers`/`styles`/`format` recorded for restore). The required `type`,
+   * `tiles`, and `tileSize` always win over keys supplied here.
+   */
+  source?: Record<string, unknown>;
+  /** Extra metadata merged onto the layer record. */
+  metadata?: Record<string, unknown>;
+}
+
+/**
  * A named, collapsible folder in the layer panel that organizes a contiguous
  * run of layers (single-level nesting; groups never contain other groups).
  *

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -1998,10 +1998,26 @@ function syncRasterTileLayer(
   const src = sourceId(layer.id);
   const lid = `layer-${layer.id}-raster`;
   const tiles = getRenderableRasterTiles(layer);
-  const tileSize = (layer.source.tileSize as number | undefined) ?? 256;
+  const tileSize = numberSource(layer.source.tileSize) ?? 256;
   if (tiles.length === 0) return;
   if (!map.getSource(src)) {
-    map.addSource(src, { type: "raster", tiles, tileSize });
+    const bounds = boundsSource(layer.source.bounds);
+    map.addSource(src, {
+      type: "raster",
+      tiles,
+      tileSize,
+      ...(numberSource(layer.source.minzoom) !== undefined
+        ? { minzoom: numberSource(layer.source.minzoom) }
+        : {}),
+      ...(numberSource(layer.source.maxzoom) !== undefined
+        ? { maxzoom: numberSource(layer.source.maxzoom) }
+        : {}),
+      ...(bounds ? { bounds } : {}),
+      ...(layer.source.scheme === "tms" ? { scheme: "tms" as const } : {}),
+      ...(stringSource(layer.source.attribution)
+        ? { attribution: stringSource(layer.source.attribution) }
+        : {}),
+    });
   }
   ensureLayer(
     map,

--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -2002,21 +2002,18 @@ function syncRasterTileLayer(
   if (tiles.length === 0) return;
   if (!map.getSource(src)) {
     const bounds = boundsSource(layer.source.bounds);
+    const minzoom = numberSource(layer.source.minzoom);
+    const maxzoom = numberSource(layer.source.maxzoom);
+    const attribution = stringSource(layer.source.attribution);
     map.addSource(src, {
       type: "raster",
       tiles,
       tileSize,
-      ...(numberSource(layer.source.minzoom) !== undefined
-        ? { minzoom: numberSource(layer.source.minzoom) }
-        : {}),
-      ...(numberSource(layer.source.maxzoom) !== undefined
-        ? { maxzoom: numberSource(layer.source.maxzoom) }
-        : {}),
+      ...(minzoom !== undefined ? { minzoom } : {}),
+      ...(maxzoom !== undefined ? { maxzoom } : {}),
       ...(bounds ? { bounds } : {}),
       ...(layer.source.scheme === "tms" ? { scheme: "tms" as const } : {}),
-      ...(stringSource(layer.source.attribution)
-        ? { attribution: stringSource(layer.source.attribution) }
-        : {}),
+      ...(attribution ? { attribution } : {}),
     });
   }
   ensureLayer(

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -83,6 +83,30 @@ export interface GeoLibreWmsLayerOptions extends GeoLibreTileLayerOptions {
 }
 
 /**
+ * Options for {@link GeoLibreAppAPI.addCogLayer}: a native Cloud-Optimized
+ * GeoTIFF layer read directly from a URL and rendered client-side, with band
+ * selection, rescale, colormap, and nodata handling exposed in the Style/raster
+ * panel. All fields are optional; the renderer infers sensible defaults from
+ * the GeoTIFF when they are omitted.
+ */
+export interface GeoLibreCogLayerOptions {
+  /** Band selection, e.g. `"1"` (single band) or `"1,2,3"` (RGB). */
+  bands?: string;
+  /** Named colormap applied to a single-band COG (e.g. `"terrain"`). */
+  colormap?: string;
+  /** Lower bound of the value range mapped to the colormap/contrast stretch. */
+  rescaleMin?: number;
+  /** Upper bound of the value range mapped to the colormap/contrast stretch. */
+  rescaleMax?: number;
+  /** Pixel value rendered as transparent (overrides the file's NoData tag). */
+  nodata?: number;
+  /** Initial opacity in [0, 1] (default 1). */
+  opacity?: number;
+  /** Insert the new layer directly beneath the layer with this id. */
+  beforeLayerId?: string;
+}
+
+/**
  * Describes the file-type filter shown by the host's save/open dialog so
  * plugins can label exports/imports (e.g. JSON, GeoJSON, CSV) without knowing
  * whether they run under Tauri or in a browser.
@@ -187,6 +211,21 @@ export interface GeoLibreAppAPI {
    * forward-compatibility, so call it with optional chaining.
    */
   addWmsLayer?: (name: string, options: GeoLibreWmsLayerOptions) => string;
+  /**
+   * Add a native Cloud-Optimized GeoTIFF (COG) layer read directly from a URL
+   * and rendered client-side, returning a promise for the new layer's id.
+   * Unlike {@link addTileLayer} (which expects pre-rendered XYZ tiles), this
+   * loads the GeoTIFF itself and exposes band/rescale/colormap/nodata controls,
+   * matching the host's own COG raster layers. The layer appears in the Layers
+   * panel and persists with the project. Resolves once the layer is registered;
+   * rejects if the COG cannot be loaded. Typed optional for
+   * forward-compatibility, so call it with optional chaining.
+   */
+  addCogLayer?: (
+    name: string,
+    url: string,
+    options?: GeoLibreCogLayerOptions,
+  ) => Promise<string>;
   getActiveBasemap: () => string;
   onBasemapChange: (callback: (styleUrl: string) => void) => () => void;
   fetchArrayBuffer?: (url: string) => Promise<ArrayBuffer>;

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -151,7 +151,7 @@ export interface GeoLibreAppAPI {
     name: string,
     data: FeatureCollection,
     sourcePath?: string,
-  ) => void;
+  ) => string;
   /**
    * Add a native XYZ raster tile layer from a tile URL template (with
    * `{x}`/`{y}`/`{z}` placeholders) and return its layer id. Unlike calling

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -92,7 +92,13 @@ export interface GeoLibreWmsLayerOptions extends GeoLibreTileLayerOptions {
 export interface GeoLibreCogLayerOptions {
   /** Band selection, e.g. `"1"` (single band) or `"1,2,3"` (RGB). */
   bands?: string;
-  /** Named colormap applied to a single-band COG (e.g. `"terrain"`). */
+  /**
+   * Named colormap applied to a single-band COG (e.g. `"terrain"`,
+   * `"viridis"`). Deliberately typed as a loose `string` so external JS
+   * plugins are not forced to import the renderer's internal colormap union;
+   * an unrecognized name falls back to the renderer default rather than
+   * erroring.
+   */
   colormap?: string;
   /** Lower bound of the value range mapped to the colormap/contrast stretch. */
   rescaleMin?: number;

--- a/packages/plugins/src/types.ts
+++ b/packages/plugins/src/types.ts
@@ -36,6 +36,53 @@ export interface GeoLibreExternalNativeLayerRegistration {
 }
 
 /**
+ * Options shared by the raster/tile registration helpers
+ * ({@link GeoLibreAppAPI.addTileLayer}, {@link GeoLibreAppAPI.addWmtsLayer},
+ * {@link GeoLibreAppAPI.addWmsLayer}). They mirror the MapLibre raster `source`
+ * fields a tile service typically advertises, so the layer renders with the
+ * right extent, zoom range, and attribution without the plugin touching the
+ * map.
+ */
+export interface GeoLibreTileLayerOptions {
+  /** Tile size in pixels (default 256). */
+  tileSize?: number;
+  /** Attribution string shown in the map's attribution control. */
+  attribution?: string;
+  /** Visible extent as `[west, south, east, north]` in WGS84 degrees. */
+  bounds?: [number, number, number, number];
+  /** Minimum zoom at which tiles are requested. */
+  minzoom?: number;
+  /** Maximum zoom at which tiles are requested. */
+  maxzoom?: number;
+  /** Tile y-axis scheme; `"tms"` flips the y origin. Defaults to `"xyz"`. */
+  scheme?: "xyz" | "tms";
+  /** Initial visibility (default true). */
+  visible?: boolean;
+  /** Initial opacity in [0, 1] (default 1). */
+  opacity?: number;
+  /** Insert the new layer directly beneath the layer with this id. */
+  beforeLayerId?: string;
+}
+
+/**
+ * Options for {@link GeoLibreAppAPI.addWmsLayer}. The GetMap tile URL is built
+ * from the service `url` plus `layers`, so the plugin passes the WMS request
+ * parameters instead of a tile URL template.
+ */
+export interface GeoLibreWmsLayerOptions extends GeoLibreTileLayerOptions {
+  /** WMS service endpoint (the GetMap base URL). */
+  url: string;
+  /** Comma-separated WMS layer name(s) to request. */
+  layers: string;
+  /** Comma-separated style name(s) (default empty: the server default). */
+  styles?: string;
+  /** Image format, e.g. `"image/png"` (default) or `"image/jpeg"`. */
+  format?: string;
+  /** Request transparent tiles (default true). */
+  transparent?: boolean;
+}
+
+/**
  * Describes the file-type filter shown by the host's save/open dialog so
  * plugins can label exports/imports (e.g. JSON, GeoJSON, CSV) without knowing
  * whether they run under Tauri or in a browser.
@@ -105,6 +152,41 @@ export interface GeoLibreAppAPI {
     data: FeatureCollection,
     sourcePath?: string,
   ) => void;
+  /**
+   * Add a native XYZ raster tile layer from a tile URL template (with
+   * `{x}`/`{y}`/`{z}` placeholders) and return its layer id. Unlike calling
+   * `getMap().addSource()/addLayer()` directly, the layer appears in the Layers
+   * panel with full opacity/reorder/styling support and persists with the
+   * project, matching {@link addGeoJsonLayer} for vector data. Typed optional
+   * for forward-compatibility with host variants, so call it with optional
+   * chaining.
+   */
+  addTileLayer?: (
+    name: string,
+    url: string,
+    options?: GeoLibreTileLayerOptions,
+  ) => string;
+  /**
+   * Add a native WMTS raster tile layer from a WMTS tile URL template and return
+   * its layer id. Behaves like {@link addTileLayer} (the layer is a first-class
+   * panel entry that persists with the project); the separate name keeps WMTS
+   * layers labelled distinctly. Typed optional for forward-compatibility, so
+   * call it with optional chaining.
+   */
+  addWmtsLayer?: (
+    name: string,
+    url: string,
+    options?: GeoLibreTileLayerOptions,
+  ) => string;
+  /**
+   * Add a native WMS raster layer and return its layer id. The host builds the
+   * GetMap tile URL from {@link GeoLibreWmsLayerOptions.url} and
+   * {@link GeoLibreWmsLayerOptions.layers}, so the plugin supplies the request
+   * parameters rather than a tile URL template. The layer persists with the
+   * project like {@link addTileLayer}. Typed optional for
+   * forward-compatibility, so call it with optional chaining.
+   */
+  addWmsLayer?: (name: string, options: GeoLibreWmsLayerOptions) => string;
   getActiveBasemap: () => string;
   onBasemapChange: (callback: (styleUrl: string) => void) => () => void;
   fetchArrayBuffer?: (url: string) => Promise<ArrayBuffer>;

--- a/tests/add-tile-layer.test.ts
+++ b/tests/add-tile-layer.test.ts
@@ -89,6 +89,25 @@ describe("store.addTileLayer", () => {
     assert.ok(!("bounds" in layer.source));
   });
 
+  it("trims surrounding whitespace on tile templates", () => {
+    const id = useAppStore.getState().addTileLayer("Spaced", {
+      tiles: ["  https://tiles.example.com/{z}/{x}/{y}.png  "],
+    });
+    const layer = useAppStore.getState().layers.find((l) => l.id === id);
+    assert.ok(layer);
+    assert.deepEqual(layer.source.tiles, [
+      "https://tiles.example.com/{z}/{x}/{y}.png",
+    ]);
+  });
+
+  it("rejects a registration that sanitizes down to no tiles", () => {
+    assert.throws(
+      () => useAppStore.getState().addTileLayer("Empty", { tiles: ["", "  "] }),
+      /at least one non-empty tile URL template/,
+    );
+    assert.equal(useAppStore.getState().layers.length, 0);
+  });
+
   it("merges extra source fields under the required raster descriptor", () => {
     const id = useAppStore.getState().addTileLayer("Coverage", {
       type: "wms",

--- a/tests/add-tile-layer.test.ts
+++ b/tests/add-tile-layer.test.ts
@@ -108,6 +108,19 @@ describe("store.addTileLayer", () => {
     assert.equal(useAppStore.getState().layers.length, 0);
   });
 
+  it("rejects an inverted minzoom/maxzoom range", () => {
+    assert.throws(
+      () =>
+        useAppStore.getState().addTileLayer("Inverted", {
+          tiles: ["https://tiles.example.com/{z}/{x}/{y}.png"],
+          minzoom: 12,
+          maxzoom: 4,
+        }),
+      /minzoom \(12\) must be <= maxzoom \(4\)/,
+    );
+    assert.equal(useAppStore.getState().layers.length, 0);
+  });
+
   it("merges extra source fields under the required raster descriptor", () => {
     const id = useAppStore.getState().addTileLayer("Coverage", {
       type: "wms",

--- a/tests/add-tile-layer.test.ts
+++ b/tests/add-tile-layer.test.ts
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import { beforeEach, describe, it } from "node:test";
+import { type GeoLibreLayer, useAppStore } from "@geolibre/core";
+import { syncLayer } from "../packages/map/src/layer-sync";
+
+// Records the maplibre operations a sync performs so a test can assert the
+// native raster path actually builds a source with the requested options.
+interface MapCall {
+  method: string;
+  args: unknown[];
+}
+
+function makeEmptyMapStub() {
+  const calls: MapCall[] = [];
+  const record =
+    (method: string) =>
+    (...args: unknown[]) => {
+      calls.push({ method, args });
+    };
+  const map = {
+    getStyle: () => ({ layers: [] }),
+    getLayer: () => undefined,
+    getSource: () => undefined,
+    setLayoutProperty: record("setLayoutProperty"),
+    setPaintProperty: record("setPaintProperty"),
+    setLayerZoomRange: record("setLayerZoomRange"),
+    moveLayer: record("moveLayer"),
+    removeLayer: record("removeLayer"),
+    removeSource: record("removeSource"),
+    addLayer: record("addLayer"),
+    addSource: record("addSource"),
+  };
+  return { map, calls };
+}
+
+describe("store.addTileLayer", () => {
+  beforeEach(() => {
+    useAppStore.getState().newProject({ name: "Tiles" });
+    useAppStore.temporal.getState().clear();
+  });
+
+  it("creates a native XYZ raster layer that carries every source option", () => {
+    const id = useAppStore.getState().addTileLayer("Imagery", {
+      tiles: ["https://tiles.example.com/{z}/{x}/{y}.png"],
+      url: "https://tiles.example.com/{z}/{x}/{y}.png",
+      tileSize: 512,
+      attribution: "© Example",
+      bounds: [166, -47, 178, -34],
+      minzoom: 2,
+      maxzoom: 22,
+      scheme: "tms",
+    });
+
+    const layer = useAppStore.getState().layers.find((l) => l.id === id);
+    assert.ok(layer, "expected the layer to be added to the store");
+    assert.equal(layer.type, "xyz");
+    assert.equal(layer.source.type, "raster");
+    assert.deepEqual(layer.source.tiles, [
+      "https://tiles.example.com/{z}/{x}/{y}.png",
+    ]);
+    assert.equal(layer.source.tileSize, 512);
+    assert.equal(layer.source.attribution, "© Example");
+    assert.deepEqual(layer.source.bounds, [166, -47, 178, -34]);
+    assert.equal(layer.source.minzoom, 2);
+    assert.equal(layer.source.maxzoom, 22);
+    assert.equal(layer.source.scheme, "tms");
+    assert.equal(layer.visible, true);
+    assert.equal(layer.opacity, 1);
+  });
+
+  it("defaults type to xyz and tileSize to 256, dropping empty tiles", () => {
+    const id = useAppStore.getState().addTileLayer("Topo", {
+      tiles: ["", "https://tiles.example.com/topo/{z}/{x}/{y}.png", "  "],
+      visible: false,
+      opacity: 0.5,
+    });
+
+    const layer = useAppStore.getState().layers.find((l) => l.id === id);
+    assert.ok(layer);
+    assert.equal(layer.type, "xyz");
+    assert.equal(layer.source.tileSize, 256);
+    assert.deepEqual(layer.source.tiles, [
+      "https://tiles.example.com/topo/{z}/{x}/{y}.png",
+    ]);
+    assert.equal(layer.visible, false);
+    assert.equal(layer.opacity, 0.5);
+    // Omitted options must not leave undefined keys on the source.
+    assert.ok(!("attribution" in layer.source));
+    assert.ok(!("bounds" in layer.source));
+  });
+
+  it("merges extra source fields under the required raster descriptor", () => {
+    const id = useAppStore.getState().addTileLayer("Coverage", {
+      type: "wms",
+      tiles: ["https://wms.example.com/wms?...&BBOX={bbox-epsg-3857}"],
+      source: { layers: "coverage", transparent: true },
+    });
+
+    const layer = useAppStore.getState().layers.find((l) => l.id === id);
+    assert.ok(layer);
+    assert.equal(layer.type, "wms");
+    assert.equal(layer.source.type, "raster");
+    assert.equal(layer.source.layers, "coverage");
+    assert.equal(layer.source.transparent, true);
+  });
+});
+
+describe("native raster tile sync", () => {
+  // A native XYZ layer (no externalNativeLayer metadata) takes the
+  // syncRasterTileLayer path, which must now forward bounds/attribution/zoom.
+  function nativeTileLayer(patch: Partial<GeoLibreLayer> = {}): GeoLibreLayer {
+    const id = useAppStore.getState().addTileLayer("Imagery", {
+      tiles: ["https://tiles.example.com/{z}/{x}/{y}.png"],
+      tileSize: 512,
+      attribution: "© Example",
+      bounds: [166, -47, 178, -34],
+      minzoom: 2,
+      maxzoom: 22,
+      scheme: "tms",
+    });
+    const layer = useAppStore.getState().layers.find((l) => l.id === id);
+    assert.ok(layer);
+    return { ...layer, ...patch };
+  }
+
+  beforeEach(() => {
+    useAppStore.getState().newProject({ name: "Tiles" });
+    useAppStore.temporal.getState().clear();
+  });
+
+  it("builds a raster source honoring bounds, attribution, zoom, and scheme", () => {
+    const layer = nativeTileLayer();
+    const { map, calls } = makeEmptyMapStub();
+
+    syncLayer(map as never, layer);
+
+    const addSource = calls.find((c) => c.method === "addSource");
+    assert.ok(addSource, "expected a raster source to be created");
+    assert.equal(addSource.args[0], `source-${layer.id}`);
+    const sourceSpec = addSource.args[1] as Record<string, unknown>;
+    assert.equal(sourceSpec.type, "raster");
+    assert.deepEqual(sourceSpec.tiles, [
+      "https://tiles.example.com/{z}/{x}/{y}.png",
+    ]);
+    assert.equal(sourceSpec.tileSize, 512);
+    assert.equal(sourceSpec.attribution, "© Example");
+    assert.deepEqual(sourceSpec.bounds, [166, -47, 178, -34]);
+    assert.equal(sourceSpec.minzoom, 2);
+    assert.equal(sourceSpec.maxzoom, 22);
+    assert.equal(sourceSpec.scheme, "tms");
+
+    const addLayer = calls.find((c) => c.method === "addLayer");
+    assert.ok(addLayer, "expected a raster layer to be created");
+    const layerSpec = addLayer.args[0] as Record<string, unknown>;
+    assert.equal(layerSpec.id, `layer-${layer.id}-raster`);
+    assert.equal(layerSpec.type, "raster");
+  });
+});

--- a/tests/add-tile-layer.test.ts
+++ b/tests/add-tile-layer.test.ts
@@ -174,4 +174,24 @@ describe("native raster tile sync", () => {
     assert.equal(layerSpec.id, `layer-${layer.id}-raster`);
     assert.equal(layerSpec.type, "raster");
   });
+
+  it("skips addSource on a re-sync when the source already exists", () => {
+    const layer = nativeTileLayer();
+    const { map, calls } = makeEmptyMapStub();
+    // Pre-seed the stub so getSource returns a truthy value: the source was
+    // built on a prior sync, so a second pass must not rebuild it.
+    (map as unknown as { getSource: () => object }).getSource = () => ({});
+
+    syncLayer(map as never, layer);
+
+    assert.equal(
+      calls.find((c) => c.method === "addSource"),
+      undefined,
+      "addSource must not run when the source already exists",
+    );
+    assert.ok(
+      calls.find((c) => c.method === "addLayer"),
+      "ensureLayer should still create the raster layer spec",
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Closes #845. Exposes native raster/tile layer registration to the external plugin API so a plugin can add raster layers the same way `addGeoJsonLayer` adds vector data: as first-class native layers that appear in the Layers panel with full opacity/reorder/styling support and persist with the project. Previously a plugin could only add raster tiles by calling `getMap().addSource()/addLayer()` directly, which left them invisible to GeoLibre's layer store.

## What changed

Three new methods on `GeoLibreAppAPI` (each returns the new layer id):

- `addTileLayer(name, url, options?)` — XYZ tile URL template
- `addWmtsLayer(name, url, options?)` — WMTS tile URL template
- `addWmsLayer(name, options)` — WMS; the host builds the GetMap tile URL from `url` + `layers`

`options` mirror the MapLibre raster `source` fields: `tileSize`, `attribution`, `bounds`, `minzoom`, `maxzoom`, `scheme` (`"xyz"`/`"tms"`), plus `visible`, `opacity`, and `beforeLayerId`.

Implementation details:

- New core store action `addTileLayer` builds the native raster layer record (single source of truth, mirrors `addGeoJsonLayer`).
- The native raster sync path (`syncRasterTileLayer`) now forwards `bounds`, `attribution`, `minzoom`/`maxzoom`, and the `tms` scheme from the source, so the new options actually take effect (it previously only read `tiles`/`tileSize`). This also benefits Add Data dialog layers.
- Docs: new "Raster and tile layers" section in `docs/plugin-api.md`.
- The methods are typed optional for forward-compatibility, so plugins call them with optional chaining.

## Testing

- New unit tests in `tests/add-tile-layer.test.ts` cover the store action (type/source defaults, empty-tile filtering, extra-source merge) and the native raster sync forwarding bounds/attribution/zoom/scheme. Full frontend suite green (1551 pass).
- `npm run build` green; pre-commit (eslint + build) green.
- Verified in the real app with a throwaway plugin: `addTileLayer` (OSM XYZ) and `addWmtsLayer` (CARTO) render real tiles with the passed attribution; `addWmsLayer` (USGS) adds a layer. All three show up as native, styleable, reorderable, hideable layers. Checked in both light and dark themes with no console errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added plugin API helpers to register native raster/tile layers (XYZ, WMTS, WMS) and return the created layer id, supporting insertion order.
  * Introduced core store support for native tile layers, including option sanitization/validation and consistent layer/source creation.
* **Bug Fixes**
  * Improved raster tile layer synchronization by forwarding additional source options (tileSize, bounds, zoom range, scheme, attribution).
  * WMS tile layers now apply defaults, validate required request fields, and persist/round-trip request parameters.
* **Documentation**
  * Updated the plugin API guide with new layer option types and usage notes.
* **Tests**
  * Added/extended coverage for tile-layer creation and raster tile syncing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### Update: native COG layer registration (`addCogLayer`)

Following review, added a fourth helper for the native client-side COG case (the tile helpers only cover pre-rendered XYZ/WMS/WMTS tiles):

- `addCogLayer(name, url, options?): Promise<string>` — reads the GeoTIFF directly and renders it client-side with band/rescale/colormap/nodata controls, matching the host's own COG raster layers. It delegates to the components plugin's existing `addCogRasterLayer` (which mounts the raster control on demand), so `createAppAPI` now captures the api object to pass through.

`GeoLibreCogLayerOptions`: `bands`, `colormap`, `rescaleMin`, `rescaleMax`, `nodata`, `opacity`, `beforeLayerId`.

Verified in the real app with a throwaway plugin against a public COG (`data.source.coop/.../dem.tif`): the layer loads, renders with the `terrain` colormap, zooms to its extent, supports pixel inspection, and the promise resolves with the layer id. Checked in light and dark themes; `npm run build` and pre-commit green.