### PR TITLE
feat(map): right-click context menu for coordinates and quick actions (#829)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -86,6 +86,7 @@ import { CollaborationStatusBadge } from "./CollaborationStatusBadge";
 import { CollaborateDialog } from "./CollaborateDialog";
 import { useCollaboration } from "../../hooks/useCollaboration";
 import { MapModeBanner } from "./MapModeBanner";
+import { MapContextMenu } from "./MapContextMenu";
 import { MapGrid } from "./MapGrid";
 import { RemoteCursorsOverlay } from "./RemoteCursorsOverlay";
 import { useCommandBridge } from "../../hooks/useCommandBridge";
@@ -1642,6 +1643,10 @@ export function DesktopShell({
                 onControllerReady={handleMapControllerReady}
               />
               <RemoteCursorsOverlay mapControllerRef={mapControllerRef} />
+              <MapContextMenu
+                mapControllerRef={mapControllerRef}
+                mapReadyGeneration={mapReadyGeneration}
+              />
               <BoundsRestrictionIndicator />
               {/* Isolate the collaboration badge in its own boundary: it renders
                   over the map, so a fault here must never take down the map

--- a/apps/geolibre-desktop/src/components/layout/MapContextMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/MapContextMenu.tsx
@@ -1,4 +1,3 @@
-import { useAppStore } from "@geolibre/core";
 import type { MapController } from "@geolibre/map";
 import {
   DropdownMenu,
@@ -78,7 +77,10 @@ export function MapContextMenu({
   mapReadyGeneration: number;
 }) {
   const { t } = useTranslation();
+  // `menu` keeps the last anchor/coordinate even while closing, so the exit
+  // animation plays from the right spot; `open` drives visibility separately.
   const [menu, setMenu] = useState<ContextMenuState | null>(null);
+  const [open, setOpen] = useState(false);
   const seqRef = useRef(0);
 
   useEffect(() => {
@@ -94,6 +96,7 @@ export function MapContextMenu({
         x: event.originalEvent.clientX,
         y: event.originalEvent.clientY,
       });
+      setOpen(true);
     };
 
     map.on("contextmenu", handleContextMenu);
@@ -101,8 +104,6 @@ export function MapContextMenu({
       map.off("contextmenu", handleContextMenu);
     };
   }, [mapControllerRef, mapReadyGeneration]);
-
-  const close = useCallback(() => setMenu(null), []);
 
   const copyCoords = useCallback(() => {
     if (!menu) return;
@@ -126,20 +127,25 @@ export function MapContextMenu({
 
   const zoomInHere = useCallback(() => {
     if (!menu) return;
-    const currentZoom = mapControllerRef.current?.getMap()?.getZoom() ?? 0;
+    // Read the live zoom; if the map was torn down between right-click and
+    // selection, omit zoom so the move still recenters instead of snapping to
+    // zoom 1. MapLibre clamps the +1 to the configured maxZoom on its own.
+    const currentZoom = mapControllerRef.current?.getMap()?.getZoom();
     mapControllerRef.current?.flyTo({
       center: [menu.lng, menu.lat],
-      zoom: currentZoom + 1,
+      ...(currentZoom !== undefined ? { zoom: currentZoom + 1 } : {}),
     });
   }, [menu, mapControllerRef]);
 
   return (
+    // Keyed by the right-click id so each new right-click remounts the menu with
+    // a fresh anchor at the cursor. The key is tied to `menu` (not `open`), so a
+    // normal close leaves the key stable and Radix can play its exit animation;
+    // only the next right-click forces the remount that repositions the popup.
     <DropdownMenu
-      key={menu?.id ?? "closed"}
-      open={menu !== null}
-      onOpenChange={(open: boolean) => {
-        if (!open) close();
-      }}
+      key={menu?.id ?? "init"}
+      open={open}
+      onOpenChange={setOpen}
     >
       <DropdownMenuTrigger asChild>
         <span

--- a/apps/geolibre-desktop/src/components/layout/MapContextMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/MapContextMenu.tsx
@@ -1,0 +1,186 @@
+import { useAppStore } from "@geolibre/core";
+import type { MapController } from "@geolibre/map";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@geolibre/ui";
+import type maplibregl from "maplibre-gl";
+import { Braces, Crosshair, MapPin, ZoomIn } from "lucide-react";
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+import { useTranslation } from "react-i18next";
+
+interface ContextMenuState {
+  /** Monotonic id so each right-click remounts the menu at the new anchor. */
+  id: number;
+  /** Clicked longitude/latitude in degrees. */
+  lng: number;
+  lat: number;
+  /** Cursor position in viewport pixels, used to anchor the popup. */
+  x: number;
+  y: number;
+}
+
+/** Decimal places used when formatting and copying coordinates. */
+const COORD_PRECISION = 6;
+
+/** Format a clicked point as "lat, lng" to mirror the Google Maps convention. */
+function formatCoords(lat: number, lng: number): string {
+  return `${lat.toFixed(COORD_PRECISION)}, ${lng.toFixed(COORD_PRECISION)}`;
+}
+
+async function copyText(value: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(value);
+  } catch {
+    // Clipboard access can be denied (insecure context, permissions). Fall back
+    // to a transient textarea + execCommand so the copy still works offline.
+    const textarea = document.createElement("textarea");
+    textarea.value = value;
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    try {
+      document.execCommand("copy");
+    } finally {
+      document.body.removeChild(textarea);
+    }
+  }
+}
+
+/**
+ * Renders the map's right-click context menu (issue #829).
+ *
+ * Listening to MapLibre's own `contextmenu` event (rather than a raw DOM
+ * handler) yields the clicked geographic coordinate directly. The top item
+ * shows that coordinate and copies it to the clipboard on click, Google-Maps
+ * style; below it sits a curated set of quick actions that operate on the
+ * clicked point (copy GeoJSON, recenter, zoom in).
+ *
+ * The menu is positioned with an invisible zero-size trigger pinned at the
+ * cursor: Radix anchors its content to that trigger. The whole menu is keyed by
+ * a monotonic id so each new right-click remounts it at the fresh anchor instead
+ * of leaving the popup stuck at the previous location.
+ *
+ * @param mapControllerRef - Ref to the live primary map controller.
+ * @param mapReadyGeneration - Bumped when the controller (re)initialises, so the
+ *   `contextmenu` listener re-attaches once the map is ready.
+ */
+export function MapContextMenu({
+  mapControllerRef,
+  mapReadyGeneration,
+}: {
+  mapControllerRef: RefObject<MapController | null>;
+  mapReadyGeneration: number;
+}) {
+  const { t } = useTranslation();
+  const [menu, setMenu] = useState<ContextMenuState | null>(null);
+  const seqRef = useRef(0);
+
+  useEffect(() => {
+    const map = mapControllerRef.current?.getMap();
+    if (!map) return;
+
+    const handleContextMenu = (event: maplibregl.MapMouseEvent) => {
+      seqRef.current += 1;
+      setMenu({
+        id: seqRef.current,
+        lng: event.lngLat.lng,
+        lat: event.lngLat.lat,
+        x: event.originalEvent.clientX,
+        y: event.originalEvent.clientY,
+      });
+    };
+
+    map.on("contextmenu", handleContextMenu);
+    return () => {
+      map.off("contextmenu", handleContextMenu);
+    };
+  }, [mapControllerRef, mapReadyGeneration]);
+
+  const close = useCallback(() => setMenu(null), []);
+
+  const copyCoords = useCallback(() => {
+    if (!menu) return;
+    void copyText(formatCoords(menu.lat, menu.lng));
+  }, [menu]);
+
+  const copyGeoJson = useCallback(() => {
+    if (!menu) return;
+    const feature = {
+      type: "Feature",
+      geometry: { type: "Point", coordinates: [menu.lng, menu.lat] },
+      properties: {},
+    };
+    void copyText(JSON.stringify(feature, null, 2));
+  }, [menu]);
+
+  const centerHere = useCallback(() => {
+    if (!menu) return;
+    mapControllerRef.current?.flyTo({ center: [menu.lng, menu.lat] });
+  }, [menu, mapControllerRef]);
+
+  const zoomInHere = useCallback(() => {
+    if (!menu) return;
+    const currentZoom = mapControllerRef.current?.getMap()?.getZoom() ?? 0;
+    mapControllerRef.current?.flyTo({
+      center: [menu.lng, menu.lat],
+      zoom: currentZoom + 1,
+    });
+  }, [menu, mapControllerRef]);
+
+  return (
+    <DropdownMenu
+      key={menu?.id ?? "closed"}
+      open={menu !== null}
+      onOpenChange={(open: boolean) => {
+        if (!open) close();
+      }}
+    >
+      <DropdownMenuTrigger asChild>
+        <span
+          aria-hidden
+          style={{
+            position: "fixed",
+            left: menu?.x ?? 0,
+            top: menu?.y ?? 0,
+            width: 0,
+            height: 0,
+          }}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" side="bottom" className="w-64">
+        <DropdownMenuItem
+          onSelect={copyCoords}
+          className="gap-2 font-mono text-xs"
+          title={t("mapContextMenu.copyCoordinatesHint")}
+        >
+          <MapPin className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <span className="truncate">
+            {menu ? formatCoords(menu.lat, menu.lng) : ""}
+          </span>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel className="text-xs text-muted-foreground">
+          {t("mapContextMenu.quickActions")}
+        </DropdownMenuLabel>
+        <DropdownMenuItem onSelect={copyGeoJson} className="gap-2">
+          <Braces className="h-4 w-4 shrink-0 text-muted-foreground" />
+          {t("mapContextMenu.copyGeoJson")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={centerHere} className="gap-2">
+          <Crosshair className="h-4 w-4 shrink-0 text-muted-foreground" />
+          {t("mapContextMenu.centerHere")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={zoomInHere} className="gap-2">
+          <ZoomIn className="h-4 w-4 shrink-0 text-muted-foreground" />
+          {t("mapContextMenu.zoomInHere")}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -911,6 +911,13 @@
     "labelLabel": "Label for map {{number}}",
     "removePane": "Remove map {{number}}"
   },
+  "mapContextMenu": {
+    "copyCoordinatesHint": "Copy coordinates to clipboard",
+    "quickActions": "Quick actions",
+    "copyGeoJson": "Copy as GeoJSON",
+    "centerHere": "Center map here",
+    "zoomInHere": "Zoom in here"
+  },
   "onboarding": {
     "title": "Welcome to GeoLibre",
     "description": "Choose your experience level to tailor the interface. You can change this any time in Settings → Interface.",


### PR DESCRIPTION
## Summary

Implements a right-click context menu on the map canvas (Fixes #829).

Right-clicking anywhere on the map opens a contextual popup anchored at the cursor:

- **Part 1 (core):** the top item shows the clicked point's coordinates as `latitude, longitude`. Clicking it copies the value to the clipboard and closes the menu, mirroring the Google Maps experience.
- **Part 2 (quick actions):** a curated set of shortcuts that act on the clicked point:
  - **Copy as GeoJSON** copies a GeoJSON `Point` feature for the location.
  - **Center map here** recenters the camera on the clicked point.
  - **Zoom in here** recenters and zooms in one level.

## Implementation notes

- New component `MapContextMenu` listens to MapLibre's own `contextmenu` event, so the geographic coordinate is read directly from the event rather than reverse-projected from a DOM handler.
- The menu reuses the existing Radix `DropdownMenu` primitive, anchored to an invisible zero-size trigger pinned at the cursor and keyed by a monotonic id so each right-click reopens at the fresh location.
- Clipboard writes fall back to a transient `textarea` + `execCommand` when the async Clipboard API is unavailable.
- New user-facing strings are added under a `mapContextMenu` namespace in `en.json` and accessed via `t()`.

This delivers the core requirement now; plugin-contributed context actions remain a natural follow-up, as the issue framed Part 2 as a future workflow expansion.

## Verification

Verified in the running app with Playwright using the desktop shell:

- Right-click opens the menu at the cursor; coordinate item shows `lat, lng`.
- Clicking the coordinate copies `40.000000, -100.000000` to the clipboard and auto-closes the menu.
- "Copy as GeoJSON" copies a valid GeoJSON Point feature.
- "Center map here" moves the camera (confirmed via the status bar bbox change).
- Confirmed in both light and dark themes; no console errors.
