### PR TITLE
fix(whitebox): read locally loaded rasters in the WASM runner regardless of load path

### DIFF
--- a/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
+++ b/apps/geolibre-desktop/src/components/processing/ProcessingDialog.tsx
@@ -283,8 +283,9 @@ function layerPath(layer: GeoLibreLayer): string {
 async function fetchLayerBytes(layer: GeoLibreLayer): Promise<Uint8Array | null> {
   const src = layer.source as Record<string, unknown>;
   const tiles = Array.isArray(src.tiles) ? src.tiles : [];
-  // localBytesUrl is a blob URL retaining a File-loaded raster's bytes (see
-  // addRasterToMap); prefer it so locally dropped rasters are WASM-runnable.
+  // localBytesUrl is a blob URL retaining a File-loaded raster's bytes (the
+  // raster control's source.objectUrl, surfaced by the raster store sync);
+  // prefer it so locally loaded rasters are WASM-runnable.
   const candidates = [
     layer.metadata.localBytesUrl,
     src.url,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14880,9 +14880,9 @@
       "link": true
     },
     "node_modules/geolibre-wasm": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/geolibre-wasm/-/geolibre-wasm-0.5.0.tgz",
-      "integrity": "sha512-S6h9qMjySiRV7Icqpo/Mwy12wsz/wv3oM/J2bIiO7dV/w+hWfLFqF0HdDIsp7nB1Y7zxyEXPoh0DEcLQqqliNA==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/geolibre-wasm/-/geolibre-wasm-0.5.1.tgz",
+      "integrity": "sha512-HkvSSw99ZoR8/J/b6AIsDxK7RToaHnNCeMB7PW+SbwLQdXdWfpZgij+0yfDYLEfQ9MWf521iNl29RQXxVhLKRQ==",
       "license": "MIT",
       "dependencies": {
         "@bjorn3/browser_wasi_shim": "^0.4.2"
@@ -23964,7 +23964,7 @@
         "@turf/tin": "^7.3.5",
         "@turf/union": "^7.3.5",
         "@turf/voronoi": "^7.3.5",
-        "geolibre-wasm": "^0.5.0",
+        "geolibre-wasm": "^0.5.1",
         "geotiff": "^3.0.5"
       },
       "devDependencies": {

--- a/packages/plugins/src/plugins/maplibre-raster.ts
+++ b/packages/plugins/src/plugins/maplibre-raster.ts
@@ -100,10 +100,6 @@ let rasterControl: RasterControl | null = null;
 let rasterControlMounted = false;
 let restorePanelExpandTimeout: number | null = null;
 let rasterControlInterleaved = true;
-// Blob URLs minted for File-backed rasters (see addRasterToMap), keyed by
-// raster layer id. Tracked here so they can be revoked when the raster is
-// removed; otherwise each would leak until the page unloads.
-const localBytesUrls = new Map<string, string>();
 
 /**
  * Details of a local raster that the panel could not render because it is a
@@ -213,33 +209,14 @@ export async function addRasterToMap(
   if (!control) {
     throw new Error("The raster control could not be initialized.");
   }
-  const id = await control.addRaster(source, {
+  // For File-backed rasters the control retains the original bytes behind a
+  // blob URL (source.objectUrl), which the store sync surfaces as
+  // metadata.localBytesUrl so in-browser tools (the WASM Whitebox runner) can
+  // read the data back. No extra bookkeeping is needed here.
+  await control.addRaster(source, {
     name: options.name,
     zoomTo: true,
   });
-  // Retain the source bytes for File-backed rasters. The store layer only
-  // records the file name (no fetchable URL), so in-browser tools (the WASM
-  // Whitebox runner) could not read it back. Stamp a blob URL onto the layer
-  // so the data stays runnable for the lifetime of the session. The raster
-  // store sync preserves this key across its metadata rebuilds.
-  if (typeof source !== "string") {
-    const store = useAppStore.getState();
-    const layer = store.layers.find((current) => current.id === id);
-    if (layer) {
-      // Defensive: if this id ever reused an existing entry, revoke the old
-      // blob URL before replacing it so it cannot leak.
-      const previous = localBytesUrls.get(id);
-      if (previous) URL.revokeObjectURL(previous);
-      const blobUrl = URL.createObjectURL(source);
-      localBytesUrls.set(id, blobUrl);
-      store.updateLayer(id, {
-        metadata: {
-          ...layer.metadata,
-          localBytesUrl: blobUrl,
-        },
-      });
-    }
-  }
 }
 
 /**
@@ -510,16 +487,12 @@ function createRasterControl(
   for (const event of ["rasteradd", "rasterchange", "rasterremove"] as const) {
     control.on(event, () => syncRasterLayersToStoreForRuntime(control));
   }
-  // Free the per-layer classification GPU texture, and revoke any retained
-  // local-bytes blob URL, when its raster is dropped.
+  // Free the per-layer classification GPU texture when its raster is dropped.
+  // The control owns the File-backed bytes blob (source.objectUrl) and revokes
+  // it on removeRaster, so there is nothing to clean up here for that.
   control.on("rasterremove", (event) => {
     if (!event.layerId) return;
     disposeRasterClassification(event.layerId);
-    const blobUrl = localBytesUrls.get(event.layerId);
-    if (blobUrl) {
-      URL.revokeObjectURL(blobUrl);
-      localBytesUrls.delete(event.layerId);
-    }
   });
   // A striped (non-tiled) GeoTIFF cannot be streamed as tiles, so the upstream
   // fails the layer with a "not tiled" error. Offer the registered host handler

--- a/packages/plugins/src/plugins/raster-layer-sync.ts
+++ b/packages/plugins/src/plugins/raster-layer-sync.ts
@@ -69,6 +69,14 @@ export function createRasterStoreLayer(
 ): GeoLibreLayer {
   const interleaved = options.interleaved ?? true;
   const url = info.source.kind === "url" ? info.source.url : undefined;
+  // The control retains a File-backed raster's original bytes behind a blob
+  // URL (source.objectUrl). Surface it as metadata.localBytesUrl so in-browser
+  // tools (the WASM Whitebox runner, the symbology stats reader, raster export)
+  // can read the bytes back. This covers every File-add path - drag-and-drop,
+  // the Add Data > Raster Layer panel's own drop zone, and tool outputs - since
+  // they all funnel through the control's addRaster.
+  const localBytesUrl =
+    info.source.kind === "file" ? info.source.objectUrl : undefined;
   const sourcePath =
     url ?? (info.source.kind === "file" ? info.source.fileName : info.id);
   return {
@@ -106,6 +114,7 @@ export function createRasterStoreLayer(
       bandNames: serializeBandNames(info.bandNames),
       sourceIds: [],
       sourceKind: RASTER_SOURCE_KIND,
+      ...(localBytesUrl ? { localBytesUrl } : {}),
       ...(info.bounds
         ? {
             bounds: [

--- a/packages/processing/package.json
+++ b/packages/processing/package.json
@@ -32,7 +32,7 @@
     "@turf/tin": "^7.3.5",
     "@turf/union": "^7.3.5",
     "@turf/voronoi": "^7.3.5",
-    "geolibre-wasm": "^0.5.0",
+    "geolibre-wasm": "^0.5.1",
     "geotiff": "^3.0.5"
   },
   "devDependencies": {

--- a/tests/raster-layer-sync.test.ts
+++ b/tests/raster-layer-sync.test.ts
@@ -111,6 +111,8 @@ describe("createRasterStoreLayer", () => {
     assert.deepEqual(layer.metadata.nativeLayerIds, ["raster-1"]);
     // fitLayer falls back to metadata.bounds for zoom-to-layer.
     assert.deepEqual(layer.metadata.bounds, [-10, -5, 10, 5]);
+    // A URL raster is fetchable directly, so no retained-bytes blob is set.
+    assert.equal("localBytesUrl" in layer.metadata, false);
     assert.ok(isRasterControlStoreLayer(layer));
   });
 
@@ -125,6 +127,9 @@ describe("createRasterStoreLayer", () => {
     assert.equal(layer.sourcePath, "local.tif");
     assert.equal(layer.metadata.rasterSource, "file");
     assert.equal("bounds" in layer.metadata, false);
+    // The control's retained-bytes blob URL is surfaced so in-browser tools
+    // (the WASM Whitebox runner) can read a locally loaded raster back.
+    assert.equal(layer.metadata.localBytesUrl, "blob:x");
   });
 
   it("persists the visualization state and surfaces load errors", () => {


### PR DESCRIPTION
## Summary

Fixes #841. Two distinct failures stopped a local GeoTIFF from running in the Whitebox tools; this PR fixes both.

### 1. "Input "dem" is not a readable GeoTIFF in the browser (received an HTML/XML page)"

**Root cause:** the in-browser WASM Whitebox runner reads a raster layer's bytes via `metadata.localBytesUrl` (a blob URL retaining a File-loaded raster's original bytes). That key was only stamped on by `addRasterToMap`, the drag-and-drop / programmatic path. Rasters added through the **Add Data > Raster Layer** panel's own drop zone call the control's `addRaster` directly and bypassed it, so `localBytesUrl` was never set. `fetchLayerBytes` then fell back to fetching the bare file name as a URL, which returns the SPA's HTML.

**Fix:** the `maplibre-gl-raster` control already retains every File-backed raster's original bytes behind a blob URL (`source.objectUrl`) on **all** add paths. Surface it as `metadata.localBytesUrl` in the raster store sync (`createRasterStoreLayer`), so the bytes are available no matter how the raster was loaded (drag-and-drop, the Add Data panel drop zone, or chained tool outputs). The now-redundant blob bookkeeping in `addRasterToMap` is removed, since the control owns the `objectUrl` lifecycle and revokes it on `removeRaster`.

### 2. "unreachable" WASM trap on Fd8 Flow Accum (and other flow tools)

**Root cause (upstream):** with the read fixed, the `Fd8 Flow Accum` tool from the reporter's screenshot then trapped with a WASM `unreachable`. The D8/FD8 flow-routing tools fan work out with `std::thread::spawn`, which is unsupported on the wasm32 target GeoLibre ships. At runtime the spawn fails with `Os { code: 58, kind: Unsupported }`, the panic aborts (`panic = "abort"`), and the module traps.

**Fix:** the upstream `geolibre-wasm` 0.5.1 routes every worker fan-out through a dispatch helper that runs the closure inline on wasm32 (native multi-threaded performance is unchanged). This bumps the dependency to pick it up.

Both are resolved without any code change to the upstream packages in this PR (the `geolibre-wasm` fix was already published as 0.5.1).

## Verification

Reproduced and verified in the real web app (`npm run dev`) with the reporter's DEM and a second DEM, in **both light and dark themes**:

- **Before:** loading a raster via the Add Data > Raster Layer panel and running a Whitebox WASM tool failed with the "not a readable GeoTIFF (received an HTML/XML page)" error; `Fd8 Flow Accum` separately trapped with `unreachable`.
- **After:** the raster reads correctly, and `Fd8 Flow Accum` (and `Aspect`) run to completion and add their output raster as a new map layer.

Tests: extended `tests/raster-layer-sync.test.ts` (file rasters expose `localBytesUrl`, URL rasters do not). Full frontend suite passes (1547), `npm run build` passes, pre-commit passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File-based raster imports now preserve a local bytes reference, improving support for browser-based raster processing and inspection.

* **Bug Fixes**
  * Simplified raster cleanup so local file URLs are no longer tracked or revoked separately.
  * URL-based rasters no longer expose a local bytes reference, while local rasters do.

* **Tests**
  * Updated coverage to verify metadata behavior for both local and URL-based rasters.

* **Chores**
  * Updated the processing package’s WASM dependency to the latest patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->