### PR TITLE
feat(style): info icons for layer zoom-visibility controls

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -36,6 +36,7 @@ import { RasterSymbologySection } from "./RasterSymbologySection";
 import {
   ChevronDown,
   ChevronUp,
+  Info,
   PanelRightClose,
   PanelRightOpen,
   Plus,
@@ -765,6 +766,12 @@ interface NumericStyleInputProps {
   max: number;
   step: number;
   onChange: (value: number) => void;
+  /**
+   * Optional explanatory text shown on hover/focus via an inline info icon next
+   * to the label. Helps novice users understand technical parameters such as
+   * the layer zoom-visibility range.
+   */
+  tooltip?: string;
 }
 
 function NumericStyleInput({
@@ -775,6 +782,7 @@ function NumericStyleInput({
   max,
   step,
   onChange,
+  tooltip,
 }: NumericStyleInputProps) {
   const normalize = (next: number) =>
     Number(clampNumber(next, min, max).toFixed(stepPrecision(step)));
@@ -785,7 +793,20 @@ function NumericStyleInput({
 
   return (
     <div className="space-y-2">
-      <Label htmlFor={id}>{label}</Label>
+      <div className="flex items-center gap-1.5">
+        <Label htmlFor={id}>{label}</Label>
+        {tooltip ? (
+          <span
+            role="img"
+            tabIndex={0}
+            aria-label={tooltip}
+            title={tooltip}
+            className="inline-flex cursor-help text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:text-foreground"
+          >
+            <Info className="h-3.5 w-3.5" aria-hidden="true" />
+          </span>
+        ) : null}
+      </div>
       <div className="relative">
         <Input
           id={id}
@@ -1654,7 +1675,8 @@ export function StylePanel({
     <div className="grid grid-cols-2 gap-3">
       <NumericStyleInput
         id={`${layer.id}-minZoom`}
-        label="Min zoom"
+        label={t("style.visibility.minZoom")}
+        tooltip={t("style.visibility.zoomTooltip")}
         min={MIN_LAYER_ZOOM}
         max={maxZoom}
         step={1}
@@ -1663,7 +1685,8 @@ export function StylePanel({
       />
       <NumericStyleInput
         id={`${layer.id}-maxZoom`}
-        label="Max zoom"
+        label={t("style.visibility.maxZoom")}
+        tooltip={t("style.visibility.zoomTooltip")}
         min={minZoom}
         max={MAX_LAYER_ZOOM}
         step={1}

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -769,7 +769,6 @@ interface NumericStyleInputProps {
   max: number;
   step: number;
   onChange: (value: number) => void;
-  /** When set, an info icon with this hover/focus tooltip is shown by the label. */
   tooltip?: string;
 }
 

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -796,15 +796,14 @@ function NumericStyleInput({
       <div className="flex items-center gap-1.5">
         <Label htmlFor={id}>{label}</Label>
         {tooltip ? (
-          <span
-            role="img"
-            tabIndex={0}
+          <button
+            type="button"
             aria-label={tooltip}
             title={tooltip}
-            className="inline-flex cursor-help text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:text-foreground"
+            className="inline-flex cursor-help rounded text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <Info className="h-3.5 w-3.5" aria-hidden="true" />
-          </span>
+          </button>
         ) : null}
       </div>
       <div className="relative">

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -27,6 +27,10 @@ import {
   Select,
   Separator,
   Slider,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
 } from "@geolibre/ui";
 import { RASTER_SOURCE_KIND, SKETCHES_SOURCE_KIND } from "@geolibre/plugins";
 import type { MapController } from "@geolibre/map";
@@ -796,14 +800,20 @@ function NumericStyleInput({
       <div className="flex items-center gap-1.5">
         <Label htmlFor={id}>{label}</Label>
         {tooltip ? (
-          <button
-            type="button"
-            aria-label={tooltip}
-            title={tooltip}
-            className="inline-flex cursor-help rounded text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            <Info className="h-3.5 w-3.5" aria-hidden="true" />
-          </button>
+          <TooltipProvider delayDuration={200}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label={tooltip}
+                  className="inline-flex cursor-help rounded text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <Info className="h-3.5 w-3.5" aria-hidden="true" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>{tooltip}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         ) : null}
       </div>
       <div className="relative">
@@ -1675,7 +1685,7 @@ export function StylePanel({
       <NumericStyleInput
         id={`${layer.id}-minZoom`}
         label={t("style.visibility.minZoom")}
-        tooltip={t("style.visibility.zoomTooltip")}
+        tooltip={t("style.visibility.minZoomTooltip")}
         min={MIN_LAYER_ZOOM}
         max={maxZoom}
         step={1}
@@ -1685,7 +1695,7 @@ export function StylePanel({
       <NumericStyleInput
         id={`${layer.id}-maxZoom`}
         label={t("style.visibility.maxZoom")}
-        tooltip={t("style.visibility.zoomTooltip")}
+        tooltip={t("style.visibility.maxZoomTooltip")}
         min={minZoom}
         max={MAX_LAYER_ZOOM}
         step={1}

--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -29,7 +29,6 @@ import {
   Slider,
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
 } from "@geolibre/ui";
 import { RASTER_SOURCE_KIND, SKETCHES_SOURCE_KIND } from "@geolibre/plugins";
@@ -770,11 +769,7 @@ interface NumericStyleInputProps {
   max: number;
   step: number;
   onChange: (value: number) => void;
-  /**
-   * Optional explanatory text shown on hover/focus via an inline info icon next
-   * to the label. Helps novice users understand technical parameters such as
-   * the layer zoom-visibility range.
-   */
+  /** When set, an info icon with this hover/focus tooltip is shown by the label. */
   tooltip?: string;
 }
 
@@ -800,20 +795,18 @@ function NumericStyleInput({
       <div className="flex items-center gap-1.5">
         <Label htmlFor={id}>{label}</Label>
         {tooltip ? (
-          <TooltipProvider delayDuration={200}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  aria-label={tooltip}
-                  className="inline-flex cursor-help rounded text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                >
-                  <Info className="h-3.5 w-3.5" aria-hidden="true" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent>{tooltip}</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label={tooltip}
+                className="inline-flex cursor-help rounded text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <Info className="h-3.5 w-3.5" aria-hidden="true" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>{tooltip}</TooltipContent>
+          </Tooltip>
         ) : null}
       </div>
       <div className="relative">

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1963,7 +1963,8 @@
     "visibility": {
       "minZoom": "Min zoom",
       "maxZoom": "Max zoom",
-      "zoomTooltip": "Set the zoom range at which this layer remains visible on the map."
+      "minZoomTooltip": "Lowest zoom level at which this layer stays visible. Higher numbers are more zoomed in.",
+      "maxZoomTooltip": "Highest zoom level at which this layer stays visible. Higher numbers are more zoomed in."
     },
     "labels": {
       "heading": "Labels",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1963,8 +1963,8 @@
     "visibility": {
       "minZoom": "Min zoom",
       "maxZoom": "Max zoom",
-      "minZoomTooltip": "Lowest zoom level at which this layer is visible. Higher numbers are more zoomed in.",
-      "maxZoomTooltip": "Zoom level at which this layer becomes hidden. Higher numbers are more zoomed in."
+      "minZoomTooltip": "Zoom level at which this layer appears. Higher numbers are more zoomed in.",
+      "maxZoomTooltip": "Zoom level at which this layer disappears. Higher numbers are more zoomed in."
     },
     "labels": {
       "heading": "Labels",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1963,8 +1963,8 @@
     "visibility": {
       "minZoom": "Min zoom",
       "maxZoom": "Max zoom",
-      "minZoomTooltip": "Lowest zoom level at which this layer stays visible. Higher numbers are more zoomed in.",
-      "maxZoomTooltip": "Highest zoom level at which this layer stays visible. Higher numbers are more zoomed in."
+      "minZoomTooltip": "Lowest zoom level at which this layer is visible. Higher numbers are more zoomed in.",
+      "maxZoomTooltip": "Zoom level at which this layer becomes hidden. Higher numbers are more zoomed in."
     },
     "labels": {
       "heading": "Labels",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1963,7 +1963,7 @@
     "visibility": {
       "minZoom": "Min zoom",
       "maxZoom": "Max zoom",
-      "zoomTooltip": "Set the minimum and maximum zoom levels at which this layer remains visible on the map."
+      "zoomTooltip": "Set the zoom range at which this layer remains visible on the map."
     },
     "labels": {
       "heading": "Labels",

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1960,6 +1960,11 @@
       "resetHint": "Reset adjustments to their default values",
       "exactValueHint": "Double-click to enter an exact value"
     },
+    "visibility": {
+      "minZoom": "Min zoom",
+      "maxZoom": "Max zoom",
+      "zoomTooltip": "Set the minimum and maximum zoom levels at which this layer remains visible on the map."
+    },
     "labels": {
       "heading": "Labels",
       "show": "Show labels",

--- a/apps/geolibre-desktop/src/main.tsx
+++ b/apps/geolibre-desktop/src/main.tsx
@@ -33,6 +33,7 @@ import "./lib/lidar-style";
 // created. See https://github.com/hyperknot/openfreemap/issues/118.
 import "./lib/rtl-text";
 import "./lib/swipe-style";
+import { TooltipProvider } from "@geolibre/ui";
 import { registerSW } from "virtual:pwa-register";
 import { I18nextProvider } from "react-i18next";
 // Initializes i18next (resolves the UI language from the `?locale`/`?lang` query
@@ -92,7 +93,9 @@ void Promise.all([import("./App"), import("./components/common/error-boundaries"
       <React.StrictMode>
         <I18nextProvider i18n={i18n}>
           <AppErrorBoundary>
-            <App />
+            <TooltipProvider delayDuration={200}>
+              <App />
+            </TooltipProvider>
           </AppErrorBoundary>
         </I18nextProvider>
       </React.StrictMode>,

--- a/apps/geolibre-desktop/src/main.tsx
+++ b/apps/geolibre-desktop/src/main.tsx
@@ -33,8 +33,8 @@ import "./lib/lidar-style";
 // created. See https://github.com/hyperknot/openfreemap/issues/118.
 import "./lib/rtl-text";
 import "./lib/swipe-style";
-import { TooltipProvider } from "@geolibre/ui";
 import { registerSW } from "virtual:pwa-register";
+import { TooltipProvider } from "@geolibre/ui";
 import { I18nextProvider } from "react-i18next";
 // Initializes i18next (resolves the UI language from the `?locale`/`?lang` query
 // param, stored settings, or the browser) before React renders, so the first

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -1,0 +1,25 @@
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import * as React from "react";
+import { cn } from "../lib/utils";
+
+export const TooltipProvider = TooltipPrimitive.Provider;
+export const Tooltip = TooltipPrimitive.Root;
+export const TooltipTrigger = TooltipPrimitive.Trigger;
+
+export const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 max-w-xs overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md data-[state=delayed-open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=delayed-open]:fade-in-0",
+        className,
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -15,7 +15,7 @@ export const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 max-w-xs overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md data-[state=delayed-open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=delayed-open]:fade-in-0",
+        "z-50 max-w-xs overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}
       {...props}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -12,6 +12,12 @@ export { Select } from "./components/select";
 export { Label } from "./components/label";
 export { Slider } from "./components/slider";
 export { Separator } from "./components/separator";
+export {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./components/tooltip";
 export { ScrollArea, type ScrollAreaProps } from "./components/scroll-area";
 export {
   Dialog,


### PR DESCRIPTION
## Summary

Adds an inline info icon next to the **Min zoom** and **Max zoom** labels in the layer style panel, as requested in #833. Hovering or focusing the icon shows a concise explanation:

> Set the minimum and maximum zoom levels at which this layer remains visible on the map.

This smooths the learning curve for users who are unfamiliar with these GIS parameters.

## Changes

- `NumericStyleInput` gains an optional `tooltip` prop. When provided, it renders a small lucide `Info` icon next to the label with an accessible `title`/`aria-label` (keyboard-focusable, consistent with the panel's existing native-`title` tooltip convention).
- The zoom range controls pass the explanation through the new prop on both inputs.
- The previously hardcoded "Min zoom" / "Max zoom" labels are now translatable via a new `style.visibility` i18n section in `en.json`.

## Verification

Verified in the running web app (Playwright) with an OpenStreetMap XYZ tile layer:

- Info icons render next to both Min zoom and Max zoom labels.
- The tooltip text is exposed as the icon's accessible name and `title`.
- Confirmed in both **light** and **dark** themes.
- No console errors; production build and pre-commit hooks pass.

Fixes #833

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added accessible info tooltips to numeric style fields, including hover/focus support.
  * Updated zoom visibility controls (min/max zoom) to display clearer translated tooltip guidance.
  * Introduced reusable tooltip components in the UI toolkit and enabled consistent tooltip behavior at the app level.
* **Documentation**
  * Added new i18n strings for min/max zoom labels and corresponding visibility tooltips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->