### PR TITLE
fix(style): hide basemap layers behind advanced toggle in Insert before

### DIFF
--- a/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
+++ b/apps/geolibre-desktop/src/components/panels/StylePanel.tsx
@@ -1044,6 +1044,7 @@ export function StylePanel({
     }
   }, [autoCollapse, internalCollapsed, isControlled]);
   const [draftBeforeId, setDraftBeforeId] = useState("");
+  const [showBasemapStyleLayers, setShowBasemapStyleLayers] = useState(false);
   const [draftColorExpression, setDraftColorExpression] = useState("");
   const [draftHeightExpression, setDraftHeightExpression] = useState("");
   const [draftVectorStyleMode, setDraftVectorStyleMode] =
@@ -1181,6 +1182,13 @@ export function StylePanel({
     layer?.style.vectorStyleProperty,
     layer?.style.vectorStyleStops,
   ]);
+
+  // Reset the "show basemap layers" advanced toggle back to its clean default
+  // whenever a different layer is selected. Keyed on the layer id alone so it
+  // does not re-collapse while the user edits other style fields.
+  useEffect(() => {
+    setShowBasemapStyleLayers(false);
+  }, [layer?.id]);
 
   // Heatmap/cluster apply to point layers in two render paths: core GeoJSON
   // layers (drag-drop, processing results) and Add Vector Layer point layers in
@@ -1596,6 +1604,13 @@ export function StylePanel({
     !otherLayers.some((l) => l.id === draftBeforeId)
       ? draftBeforeId
       : null;
+  // The basemap style exposes dozens of internal layer ids that overwhelm the
+  // dropdown for standard users (issue #834). Keep them behind an opt-in
+  // "advanced" toggle so the default list only shows the user's own layers —
+  // but reveal them automatically if the current value is one of them.
+  const valueIsBasemapStyleLayer = basemapStyleLayerIds.includes(draftBeforeId);
+  const basemapStyleLayersVisible =
+    showBasemapStyleLayers || valueIsBasemapStyleLayer;
   const beforeIdControl = (
     <div className="space-y-2">
       <Label htmlFor="beforeId">Insert before</Label>
@@ -1619,7 +1634,7 @@ export function StylePanel({
             ))}
           </optgroup>
         )}
-        {basemapStyleLayerIds.length > 0 && (
+        {basemapStyleLayerIds.length > 0 && basemapStyleLayersVisible && (
           <optgroup label="Basemap layers">
             {basemapStyleLayerIds.map((styleLayerId) => (
               <option key={styleLayerId} value={styleLayerId}>
@@ -1629,6 +1644,17 @@ export function StylePanel({
           </optgroup>
         )}
       </Select>
+      {basemapStyleLayerIds.length > 0 && !valueIsBasemapStyleLayer && (
+        <label className="flex items-center gap-2 text-xs text-muted-foreground">
+          <input
+            type="checkbox"
+            aria-controls="beforeId"
+            checked={showBasemapStyleLayers}
+            onChange={(event) => setShowBasemapStyleLayers(event.target.checked)}
+          />
+          {t("addData.shared.showBasemapLayers")}
+        </label>
+      )}
     </div>
   );
   const minZoom = styleValue(style, "minZoom");


### PR DESCRIPTION
## Summary

The Style panel's **Insert before** dropdown listed every internal basemap style layer (`background`, `natural_earth`, `park`, `park_outline`, ...) by default, producing a 100+ entry list that overwhelms standard layer-ordering tasks (issue #834).

This applies the same treatment the Add Data dialog already uses (issue #453): the basemap style layers are collapsed behind an opt-in **Show basemap layers (advanced)** checkbox, so the default list shows only the user's own layers.

## Behavior

- **Default (basic) mode:** the dropdown shows only `Layer order (default)` plus the user's other loaded layers. Clean and scannable.
- **Advanced toggle:** a `Show basemap layers (advanced)` checkbox below the dropdown expands the full basemap style layer list when checked.
- **Auto-reveal:** if the current Insert before value already points at a basemap layer, the advanced list stays visible and the checkbox is hidden (so a saved selection is never lost).
- **Clean reset:** the toggle resets to its collapsed default when a different layer is selected.

## Verification

Drove the real app in the browser with Playwright using two sample vector layers (US cities, Countries):

- Default dropdown collapsed from 112 options to just the user layers.
- Toggling the checkbox expanded the `Basemap layers` group back to the full list.
- Selecting a basemap layer as the Insert before target auto-revealed the list and hid the checkbox.
- Confirmed correct rendering in both light and dark themes.

`npm run build` and `pre-commit` (eslint + npm build) pass.

Fixes #834
