### PR TITLE
fix(view): make Layer Swipe and split view mutually exclusive (#844)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -69,6 +69,7 @@ import {
   createAppAPI,
   getPluginManager,
   useExternalPluginsReady,
+  useSwipeSplitViewExclusivity,
 } from "../../hooks/usePlugins";
 import { registerMbtilesProtocol } from "../../lib/mbtiles";
 import { hasReverseGeocodeConsent } from "../../lib/reverse-geocode-consent";
@@ -535,6 +536,9 @@ export function DesktopShell({
   const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
   const diagnostics = useDiagnosticsSnapshot();
   const externalPluginsReady = useExternalPluginsReady(mapControllerRef);
+  // Keep Layer Swipe and split view mutually exclusive (#844): entering a
+  // multi-pane grid turns the swipe slider off.
+  useSwipeSplitViewExclusivity(mapControllerRef);
   // Live-collaboration session. Owned here (rather than in TopToolbar) so both
   // the Collaborate dialog and the on-canvas status badge share one socket, and
   // so the dialog stays mounted in toolbar-hidden layouts.

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -23,6 +23,7 @@ import {
   maplibreReverseGeocodePlugin,
   maplibreStreetViewPlugin,
   maplibreSwipePlugin,
+  SWIPE_PLUGIN_ID,
   maplibreTimeSliderPlugin,
   maplibreUsgsLidarPlugin,
   PluginManager,
@@ -264,6 +265,15 @@ export function usePluginRegistry() {
     getProjectState: () => manager.getProjectState(),
     toggle: (id: string, appApi: ReturnType<typeof createAppAPI>) => {
       const before = JSON.stringify(projectPluginStateSnapshot());
+      // Layer Swipe and split view are mutually exclusive comparison modes:
+      // stacking the swipe slider over a multi-pane grid fragments the
+      // workspace (#844). Activating swipe collapses the grid back to a single
+      // map first; the reverse direction (entering split view turns swipe off)
+      // is handled by useSwipeSplitViewExclusivity.
+      if (id === SWIPE_PLUGIN_ID && !manager.isActive(id)) {
+        const { mapLayout, setMapGrid } = useAppStore.getState();
+        if (mapLayout.rows * mapLayout.cols > 1) setMapGrid(1, 1);
+      }
       // Plugin controls are imperative MapLibre code, so a throw here escapes
       // React's error boundaries. Contain it so one bad plugin can't break the
       // toggle handler — surface it in diagnostics instead. Return without
@@ -365,6 +375,39 @@ export function useExternalPluginsReady(
     () => externalPluginsLoaded,
     () => externalPluginsLoaded,
   );
+}
+
+/**
+ * Enforces mutual exclusivity between Layer Swipe and split view (#844). The two
+ * are competing comparison tools: overlaying the swipe slider on a multi-pane
+ * grid fragments the workspace, so whenever the grid becomes multi-pane the
+ * Layer Swipe control is deactivated. The reverse direction (activating swipe
+ * collapses the grid to a single map) lives in `usePluginRegistry().toggle`.
+ *
+ * Mounted once near the app root so it covers every way into split view — the
+ * View menu, loading a project, or a plugin — not just the toolbar item.
+ */
+export function useSwipeSplitViewExclusivity(
+  mapControllerRef: RefObject<MapController | null>,
+): void {
+  const paneCount = useAppStore(
+    (state) => state.mapLayout.rows * state.mapLayout.cols,
+  );
+
+  useEffect(() => {
+    if (paneCount <= 1 || !manager.isActive(SWIPE_PLUGIN_ID)) return;
+    // Deactivate via the manager and persist, mirroring usePluginRegistry's
+    // toggle so the project records swipe as off and a stray throw from the
+    // imperative control can't escape React.
+    const before = JSON.stringify(projectPluginStateSnapshot());
+    try {
+      manager.toggle(SWIPE_PLUGIN_ID, createAppAPI(mapControllerRef));
+    } catch (error) {
+      reportPluginError(SWIPE_PLUGIN_ID, "toggle", error);
+      return;
+    }
+    persistProjectPluginState(before);
+  }, [paneCount, mapControllerRef]);
 }
 
 // Manifest URLs for plugins baked into the build under public/plugins/<id>/.

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -266,7 +266,7 @@ export { maplibreNasaEarthdataPlugin } from "./plugins/maplibre-nasa-earthdata";
 export { maplibreNationalMapPlugin } from "./plugins/maplibre-national-map";
 export { maplibreOvertureMapsPlugin } from "./plugins/maplibre-overture-maps";
 export { maplibreStreetViewPlugin } from "./plugins/maplibre-streetview";
-export { maplibreSwipePlugin } from "./plugins/maplibre-swipe";
+export { maplibreSwipePlugin, SWIPE_PLUGIN_ID } from "./plugins/maplibre-swipe";
 export {
   maplibreGraticulePlugin,
   GRATICULE_PLUGIN_ID,

--- a/packages/plugins/src/plugins/maplibre-swipe.ts
+++ b/packages/plugins/src/plugins/maplibre-swipe.ts
@@ -9,6 +9,12 @@ import type {
   GeoLibrePlugin,
 } from "../types";
 
+/**
+ * Plugin id for the Layer Swipe control. Exported so the app can coordinate it
+ * with split view (the two comparison modes are mutually exclusive — see #844).
+ */
+export const SWIPE_PLUGIN_ID = "maplibre-gl-swipe";
+
 let swipeControlPosition: GeoLibreMapControlPosition = "top-left";
 
 let swipeControl: SwipeControl | null = null;
@@ -16,7 +22,7 @@ let savedSwipeState: SwipeState | null = null;
 let unsubscribeBasemap: (() => void) | null = null;
 
 export const maplibreSwipePlugin: GeoLibrePlugin = {
-  id: "maplibre-gl-swipe",
+  id: SWIPE_PLUGIN_ID,
   name: "Layer Swipe",
   version: "0.9.1",
   activate: (app: GeoLibreAppAPI) => {


### PR DESCRIPTION
## Summary

Fixes #844. Layer Swipe and the multi-pane split view are competing map-comparison tools, but the app let both run at once. The result stacked the swipe slider and its panel over a fragmented grid of independent map windows (each with its own Layers menu, scale bar, and labels), cutting off the active workspace.

This makes the two modes mutually exclusive and switches between them gracefully:

- **Activating Layer Swipe** collapses the map grid back to a single map, so the swipe slider has one clean map to compare. Handled centrally in `usePluginRegistry().toggle`, covering the Plugins menu and the command palette.
- **Entering a multi-pane grid** turns Layer Swipe off, via a new `useSwipeSplitViewExclusivity` coordinator mounted in `DesktopShell`. Mounting it at the app root means it covers every way into split view (the View menu, loading a project, or a plugin), not just the toolbar item.

A `SWIPE_PLUGIN_ID` constant is exported from `@geolibre/plugins` so the app can reference the plugin id the same way it does for the other built-in plugins.

## Verification

Reproduced the original conflict in the running app, then verified the fix end to end with Playwright using both directions in light and dark themes:

- Grid (2×2) active, then activate Layer Swipe → grid collapses to a single map + swipe slider.
- Layer Swipe active, then choose a 2×2 grid → swipe deactivates, clean 4-pane grid.

DOM assertions confirmed the pane count and swipe-control presence at each step. `npm run build` and `pre-commit` on the changed files both pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved interaction between swipe comparison and multi-pane layouts so they no longer stay active at the same time.
  * Switching to swipe mode now automatically returns the workspace to a single view for a smoother comparison experience.

* **Bug Fixes**
  * Prevented swipe from remaining enabled when opening a grid or split view, reducing confusing layout conflicts.
  * Added safer state handling when layout changes occur, helping keep the comparison tools in sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->