### PR TITLE
fix(view): collapse split-view grid only after swipe activation succeeds

### DIFF
--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -290,6 +290,11 @@ export function usePluginRegistry() {
       // user's split-view layout intact. Done synchronously before React flushes
       // effects so useSwipeSplitViewExclusivity sees the single-pane grid and
       // doesn't undo the activation it just allowed.
+      // Relies on maplibre-swipe activating synchronously (activate returns
+      // false/undefined, never a Promise). PluginManager.activate marks a plugin
+      // active optimistically and only rolls back async failures via
+      // watchAsyncActivation, so isActive() would read true here before an async
+      // mount confirms — revisit this guard if swipe ever gains a dynamic import.
       if (collapseGridForSwipe && manager.isActive(id)) {
         const { mapLayout, setMapGrid } = useAppStore.getState();
         if (mapLayout.rows * mapLayout.cols > 1) setMapGrid(1, 1);

--- a/apps/geolibre-desktop/src/hooks/usePlugins.ts
+++ b/apps/geolibre-desktop/src/hooks/usePlugins.ts
@@ -267,13 +267,10 @@ export function usePluginRegistry() {
       const before = JSON.stringify(projectPluginStateSnapshot());
       // Layer Swipe and split view are mutually exclusive comparison modes:
       // stacking the swipe slider over a multi-pane grid fragments the
-      // workspace (#844). Activating swipe collapses the grid back to a single
-      // map first; the reverse direction (entering split view turns swipe off)
-      // is handled by useSwipeSplitViewExclusivity.
-      if (id === SWIPE_PLUGIN_ID && !manager.isActive(id)) {
-        const { mapLayout, setMapGrid } = useAppStore.getState();
-        if (mapLayout.rows * mapLayout.cols > 1) setMapGrid(1, 1);
-      }
+      // workspace (#844). The reverse direction (entering split view turns
+      // swipe off) is handled by useSwipeSplitViewExclusivity.
+      const collapseGridForSwipe =
+        id === SWIPE_PLUGIN_ID && !manager.isActive(id);
       // Plugin controls are imperative MapLibre code, so a throw here escapes
       // React's error boundaries. Contain it so one bad plugin can't break the
       // toggle handler — surface it in diagnostics instead. Return without
@@ -287,6 +284,15 @@ export function usePluginRegistry() {
         // early return below; in-memory state is not rolled back.
         reportPluginError(id, "toggle", error);
         return;
+      }
+      // Collapse the grid only once swipe actually activated, so a failed
+      // activation (a throw above, or addMapControl returning false) leaves the
+      // user's split-view layout intact. Done synchronously before React flushes
+      // effects so useSwipeSplitViewExclusivity sees the single-pane grid and
+      // doesn't undo the activation it just allowed.
+      if (collapseGridForSwipe && manager.isActive(id)) {
+        const { mapLayout, setMapGrid } = useAppStore.getState();
+        if (mapLayout.rows * mapLayout.cols > 1) setMapGrid(1, 1);
       }
       persistProjectPluginState(before);
     },


### PR DESCRIPTION
Follow-up to #844 / #852 (merged).

## Problem

The merged change collapsed the map grid **before** confirming Layer Swipe activated:

```ts
if (id === SWIPE_PLUGIN_ID && !manager.isActive(id)) {
  if (mapLayout.rows * mapLayout.cols > 1) setMapGrid(1, 1);
}
// ... manager.toggle(id, appApi) can throw or no-op
```

If `manager.toggle` throws (caught and reported) or the control fails to attach (`addMapControl` returns false), the grid has already been collapsed to a single map. The user loses their split-view layout and gets no swipe to show for it.

## Fix

Activate first, then collapse the grid only once the swipe control is actually live:

```ts
const collapseGridForSwipe = id === SWIPE_PLUGIN_ID && !manager.isActive(id);
try { manager.toggle(id, appApi); } catch (error) { ...; return; }
if (collapseGridForSwipe && manager.isActive(id)) {
  if (mapLayout.rows * mapLayout.cols > 1) setMapGrid(1, 1);
}
```

The collapse still runs synchronously within the same `toggle` call, before React flushes effects, so `useSwipeSplitViewExclusivity` sees the single-pane grid and does not undo the activation it just permitted.

This addresses a CodeRabbit review note on #852 that posted just after the PR was merged, so it could not be folded into the original.

## Verification

Re-ran both directions in the real app (Playwright), light and dark themes:
- 2x2 grid active, then activate Layer Swipe -> grid collapses to a single map + swipe slider.
- Layer Swipe active, then choose a 2x2 grid -> swipe deactivates, clean 4-pane grid.

The success-path behaviour is unchanged from the merged fix; only a failed activation now preserves the grid. `npm run build` and `pre-commit` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Layer Swipe and split-view behavior so the layout only collapses after swipe mode is successfully enabled.
  * Prevented failed swipe toggles from unexpectedly changing the user’s split-view arrangement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->