### PR TITLE
fix(basemaps): rework provider-credential UX in the Basemaps panel

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -58,7 +58,7 @@
     "mapillary-js": "^4.1.2",
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.3",
-    "maplibre-gl-basemap-control": "^0.7.0",
+    "maplibre-gl-basemap-control": "^0.8.0",
     "maplibre-gl-components": "^0.25.1",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -145,6 +145,15 @@ VITE_HERE_API_KEY=your_here_api_key                 # HERE Traffic Flow
 
 Google Traffic reuses the same `VITE_GOOGLE_MAPS_API_KEY` as Street View; enable the **Map Tiles API** for that key in Google Cloud. A newly entered key takes effect immediately, without reopening the project. Until a provider's key is set, its overlay reports a missing-key error instead of loading tiles.
 
+The **Amazon Location** styles in the Basemaps control are keyed the same way:
+
+```env
+VITE_AMAZON_LOCATION_API_KEY=your_amazon_location_api_key   # Amazon Location styles
+VITE_AWS_REGION=us-east-1                                   # optional, defaults to us-east-1
+```
+
+You can also enter these directly in the panel's **API keys** view (the key button in the panel header) without setting an environment variable.
+
 ## Optional Python sidecar
 
 The optional FastAPI sidecar is reserved for heavier processing workflows and is not required for the desktop UI.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -145,14 +145,16 @@ VITE_HERE_API_KEY=your_here_api_key                 # HERE Traffic Flow
 
 Google Traffic reuses the same `VITE_GOOGLE_MAPS_API_KEY` as Street View; enable the **Map Tiles API** for that key in Google Cloud. A newly entered key takes effect immediately, without reopening the project. Until a provider's key is set, its overlay reports a missing-key error instead of loading tiles.
 
-The **Amazon Location** styles in the Basemaps control are keyed the same way:
+## Optional Amazon Location styles
+
+The **Amazon Location** entries in the Basemaps control are *style basemaps* (they replace the whole map style, unlike the traffic overlays above). They authenticate with your own Amazon Location API key, set in **Settings → Environment Variables** (or baked into `apps/geolibre-desktop/.env.local`):
 
 ```env
 VITE_AMAZON_LOCATION_API_KEY=your_amazon_location_api_key   # Amazon Location styles
-VITE_AWS_REGION=us-east-1                                   # optional, defaults to us-east-1
+VITE_AMAZON_LOCATION_AWS_REGION=us-east-1                   # optional, defaults to us-east-1
 ```
 
-You can also enter these directly in the panel's **API keys** view (the key button in the panel header) without setting an environment variable.
+A newly entered key takes effect immediately, without reopening the project. You can also enter the key (and region) directly in the panel's **API keys** view, opened from the key button in the panel header, without setting an environment variable.
 
 ## Optional Python sidecar
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -151,10 +151,10 @@ The **Amazon Location** entries in the Basemaps control are *style basemaps* (th
 
 ```env
 VITE_AMAZON_LOCATION_API_KEY=your_amazon_location_api_key   # Amazon Location styles
-VITE_AMAZON_LOCATION_AWS_REGION=us-east-1                   # optional, defaults to us-east-1
+VITE_AMAZON_LOCATION_AWS_REGION=us-east-1                   # optional; the control defaults to us-east-1 when omitted
 ```
 
-A newly entered key takes effect immediately, without reopening the project. You can also enter the key (and region) directly in the panel's **API keys** view, opened from the key button in the panel header, without setting an environment variable.
+A newly entered key takes effect immediately, without reopening the project; removing the key from the environment takes effect after a page reload. You can also enter the key (and region) directly in the panel's **API keys** view, opened from the key button in the panel header, without setting an environment variable.
 
 ## Optional Python sidecar
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -151,10 +151,10 @@ The **Amazon Location** entries in the Basemaps control are *style basemaps* (th
 
 ```env
 VITE_AMAZON_LOCATION_API_KEY=your_amazon_location_api_key   # Amazon Location styles
-VITE_AMAZON_LOCATION_AWS_REGION=us-east-1                   # optional; the control defaults to us-east-1 when omitted
+VITE_AMAZON_LOCATION_AWS_REGION=us-east-1                   # optional; omit to use the control's built-in default region
 ```
 
-A newly entered key takes effect immediately, without reopening the project; removing the key from the environment takes effect after a page reload. You can also enter the key (and region) directly in the panel's **API keys** view, opened from the key button in the panel header, without setting an environment variable.
+Keys set via **Settings → Environment Variables**, or typed directly into the panel's **API keys** view (the key button in the panel header), apply at runtime without reopening the project. A key baked into `apps/geolibre-desktop/.env.local` is read at build time and needs a dev server restart. When `VITE_AMAZON_LOCATION_API_KEY` is set in the environment it takes precedence over a key typed in the panel; removing it from the environment clears it on the next page reload.
 
 ## Optional Python sidecar
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "mapillary-js": "^4.1.2",
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.3",
-        "maplibre-gl-basemap-control": "^0.7.0",
+        "maplibre-gl-basemap-control": "^0.8.0",
         "maplibre-gl-components": "^0.25.1",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",
@@ -17378,9 +17378,9 @@
       "license": "MIT"
     },
     "node_modules/maplibre-gl-basemap-control": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-basemap-control/-/maplibre-gl-basemap-control-0.7.0.tgz",
-      "integrity": "sha512-kh/0I74antuiDIss848Y/IQijSJG5HMt14Zf+UjvLYdaPYV8P5pPayVIrwoZK51P6os7JM22fABLzcnkK+33dw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-basemap-control/-/maplibre-gl-basemap-control-0.8.0.tgz",
+      "integrity": "sha512-i0kbCmzktB4IrHRIIDCyXG6pKJxex3adp7uN5o71JUxA0KnKkbpGthKvkbMzx52+4zMHVcq9gylXUDNruDsQJA==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -23799,7 +23799,7 @@
         "jspdf": "^4.2.1",
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.3",
-        "maplibre-gl-basemap-control": "^0.7.0",
+        "maplibre-gl-basemap-control": "^0.8.0",
         "maplibre-gl-components": "^0.25.1",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -31,7 +31,7 @@
     "jspdf": "^4.2.1",
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.3",
-    "maplibre-gl-basemap-control": "^0.7.0",
+    "maplibre-gl-basemap-control": "^0.8.0",
     "maplibre-gl-components": "^0.25.1",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",

--- a/packages/plugins/src/plugins/maplibre-basemap-control.ts
+++ b/packages/plugins/src/plugins/maplibre-basemap-control.ts
@@ -53,7 +53,7 @@ function getBasemapCredentials(): {
     tomtomApiKey: env.VITE_TOMTOM_API_KEY?.trim() || "",
     hereApiKey: env.VITE_HERE_API_KEY?.trim() || "",
     amazonApiKey: env.VITE_AMAZON_LOCATION_API_KEY?.trim() || "",
-    awsRegion: env.VITE_AWS_REGION?.trim() || "us-east-1",
+    awsRegion: env.VITE_AMAZON_LOCATION_AWS_REGION?.trim() || "us-east-1",
   };
 }
 

--- a/packages/plugins/src/plugins/maplibre-basemap-control.ts
+++ b/packages/plugins/src/plugins/maplibre-basemap-control.ts
@@ -30,31 +30,40 @@ function getRuntimeEnvironment(): Record<string, string | undefined> {
 }
 
 /**
- * Provider credentials read from runtime environment variables (set in
- * Settings → Environment Variables), so users opt in with their own keys. This
- * covers the traffic overlays added in maplibre-gl-basemap-control 0.6.0
- * (Google/TomTom/HERE; Google Traffic reuses the same VITE_GOOGLE_MAPS_API_KEY
- * that the Street View plugin reads) and the Amazon Location styles. Returns
- * empty strings when unset, which the control treats as "no key" (the basemap
- * then surfaces a "Get a … API key" error rather than loading tiles). The AWS
- * region falls back to us-east-1 so Amazon styles work once only the key is set,
- * matching the control's own default.
+ * Traffic-overlay provider credentials (added in maplibre-gl-basemap-control
+ * 0.6.0) read from runtime environment variables (set in Settings → Environment
+ * Variables), so users opt in with their own keys. Google Traffic reuses the
+ * same VITE_GOOGLE_MAPS_API_KEY that the Street View plugin reads. Returns empty
+ * strings when unset, which the control treats as "no key" (the overlay then
+ * surfaces a "Get a … API key" error rather than loading tiles).
  */
 function getBasemapCredentials(): {
   googleMapsApiKey: string;
   tomtomApiKey: string;
   hereApiKey: string;
-  amazonApiKey: string;
-  awsRegion: string;
 } {
   const env = getRuntimeEnvironment();
   return {
     googleMapsApiKey: env.VITE_GOOGLE_MAPS_API_KEY?.trim() || "",
     tomtomApiKey: env.VITE_TOMTOM_API_KEY?.trim() || "",
     hereApiKey: env.VITE_HERE_API_KEY?.trim() || "",
-    amazonApiKey: env.VITE_AMAZON_LOCATION_API_KEY?.trim() || "",
-    awsRegion: env.VITE_AMAZON_LOCATION_AWS_REGION?.trim() || "us-east-1",
   };
+}
+
+/**
+ * Amazon Location credentials from runtime env, or null when no key is set.
+ * Unlike the always-applied traffic keys above, these are applied only when a
+ * key is actually configured, for two reasons: the user's primary way to enter
+ * an Amazon key is the panel's API keys view (#837), so an unrelated env change
+ * must not clobber a key typed there; and the region is omitted when unset so
+ * the control keeps its own default region rather than GeoLibre hardcoding one.
+ */
+function getAmazonCredentials(): { amazonApiKey: string; awsRegion?: string } | null {
+  const env = getRuntimeEnvironment();
+  const amazonApiKey = env.VITE_AMAZON_LOCATION_API_KEY?.trim() || "";
+  if (!amazonApiKey) return null;
+  const awsRegion = env.VITE_AMAZON_LOCATION_AWS_REGION?.trim() || undefined;
+  return awsRegion ? { amazonApiKey, awsRegion } : { amazonApiKey };
 }
 
 let basemapControlPosition: GeoLibreMapControlPosition = "top-left";
@@ -164,8 +173,11 @@ function getBasemapControlOptions(
     // Provider basemaps that need a key (the Google/TomTom/HERE traffic overlays
     // and the Amazon Location styles) authenticate with the user's own
     // credentials, read from runtime env. Unset keys are harmless: the basemap
-    // just reports a missing-key error instead of loading tiles.
+    // just reports a missing-key error instead of loading tiles. Amazon is
+    // spread only when its key is set, so an unset key leaves the control's own
+    // region default in place.
     ...getBasemapCredentials(),
+    ...(getAmazonCredentials() ?? {}),
     // A style basemap (e.g. OpenFreeMap 3D) swaps the whole map style and so
     // discards every stacked raster basemap. In stack mode that silently wiped
     // a carefully assembled stack, so confirm before the rasters are lost. See
@@ -194,12 +206,17 @@ function addRuntimeEnvListener(): void {
 
   const handleRuntimeEnvChange = () => {
     if (!basemapControl) return;
-    const { googleMapsApiKey, tomtomApiKey, hereApiKey, amazonApiKey, awsRegion } =
-      getBasemapCredentials();
+    const { googleMapsApiKey, tomtomApiKey, hereApiKey } = getBasemapCredentials();
     basemapControl.setGoogleMapsApiKey(googleMapsApiKey);
     basemapControl.setTomTomApiKey(tomtomApiKey);
     basemapControl.setHereApiKey(hereApiKey);
-    basemapControl.setAmazonCredentials(amazonApiKey, awsRegion);
+    // Only push Amazon credentials when a key is configured via env, so an
+    // unrelated env change never clears a key entered in the panel. The region
+    // is left undefined when unset, keeping the control's own default.
+    const amazon = getAmazonCredentials();
+    if (amazon) {
+      basemapControl.setAmazonCredentials(amazon.amazonApiKey, amazon.awsRegion);
+    }
   };
 
   window.addEventListener("geolibre:runtime-env-change", handleRuntimeEnvChange);

--- a/packages/plugins/src/plugins/maplibre-basemap-control.ts
+++ b/packages/plugins/src/plugins/maplibre-basemap-control.ts
@@ -37,7 +37,7 @@ function getRuntimeEnvironment(): Record<string, string | undefined> {
  * strings when unset, which the control treats as "no key" (the overlay then
  * surfaces a "Get a … API key" error rather than loading tiles).
  */
-function getBasemapCredentials(): {
+function getTrafficOverlayCredentials(): {
   googleMapsApiKey: string;
   tomtomApiKey: string;
   hereApiKey: string;
@@ -176,7 +176,7 @@ function getBasemapControlOptions(
     // just reports a missing-key error instead of loading tiles. Amazon is
     // spread only when its key is set, so an unset key leaves the control's own
     // region default in place.
-    ...getBasemapCredentials(),
+    ...getTrafficOverlayCredentials(),
     ...(getAmazonCredentials() ?? {}),
     // A style basemap (e.g. OpenFreeMap 3D) swaps the whole map style and so
     // discards every stacked raster basemap. In stack mode that silently wiped
@@ -206,7 +206,7 @@ function addRuntimeEnvListener(): void {
 
   const handleRuntimeEnvChange = () => {
     if (!basemapControl) return;
-    const { googleMapsApiKey, tomtomApiKey, hereApiKey } = getBasemapCredentials();
+    const { googleMapsApiKey, tomtomApiKey, hereApiKey } = getTrafficOverlayCredentials();
     basemapControl.setGoogleMapsApiKey(googleMapsApiKey);
     basemapControl.setTomTomApiKey(tomtomApiKey);
     basemapControl.setHereApiKey(hereApiKey);

--- a/packages/plugins/src/plugins/maplibre-basemap-control.ts
+++ b/packages/plugins/src/plugins/maplibre-basemap-control.ts
@@ -30,24 +30,30 @@ function getRuntimeEnvironment(): Record<string, string | undefined> {
 }
 
 /**
- * Provider credentials for the traffic overlays added in
- * maplibre-gl-basemap-control 0.6.0. The keys come from runtime environment
- * variables (set in Settings → Environment Variables), so users opt in with
- * their own API keys; Google Traffic reuses the same VITE_GOOGLE_MAPS_API_KEY
- * that the Street View plugin reads. Returns empty strings when unset, which the
- * control treats as "no key" (the overlay then surfaces a "Get a … API key"
- * error rather than loading tiles).
+ * Provider credentials read from runtime environment variables (set in
+ * Settings → Environment Variables), so users opt in with their own keys. This
+ * covers the traffic overlays added in maplibre-gl-basemap-control 0.6.0
+ * (Google/TomTom/HERE; Google Traffic reuses the same VITE_GOOGLE_MAPS_API_KEY
+ * that the Street View plugin reads) and the Amazon Location styles. Returns
+ * empty strings when unset, which the control treats as "no key" (the basemap
+ * then surfaces a "Get a … API key" error rather than loading tiles). The AWS
+ * region falls back to us-east-1 so Amazon styles work once only the key is set,
+ * matching the control's own default.
  */
 function getBasemapCredentials(): {
   googleMapsApiKey: string;
   tomtomApiKey: string;
   hereApiKey: string;
+  amazonApiKey: string;
+  awsRegion: string;
 } {
   const env = getRuntimeEnvironment();
   return {
     googleMapsApiKey: env.VITE_GOOGLE_MAPS_API_KEY?.trim() || "",
     tomtomApiKey: env.VITE_TOMTOM_API_KEY?.trim() || "",
     hereApiKey: env.VITE_HERE_API_KEY?.trim() || "",
+    amazonApiKey: env.VITE_AMAZON_LOCATION_API_KEY?.trim() || "",
+    awsRegion: env.VITE_AWS_REGION?.trim() || "us-east-1",
   };
 }
 
@@ -155,9 +161,10 @@ function getBasemapControlOptions(
     collapsed: false,
     position: basemapControlPosition,
     title: "Basemaps",
-    // Traffic overlays (Google/TomTom/HERE) authenticate with the user's own
-    // API keys, read from runtime env. Unset keys are harmless: the overlay just
-    // reports a missing-key error instead of loading tiles.
+    // Provider basemaps that need a key (the Google/TomTom/HERE traffic overlays
+    // and the Amazon Location styles) authenticate with the user's own
+    // credentials, read from runtime env. Unset keys are harmless: the basemap
+    // just reports a missing-key error instead of loading tiles.
     ...getBasemapCredentials(),
     // A style basemap (e.g. OpenFreeMap 3D) swaps the whole map style and so
     // discards every stacked raster basemap. In stack mode that silently wiped
@@ -187,11 +194,12 @@ function addRuntimeEnvListener(): void {
 
   const handleRuntimeEnvChange = () => {
     if (!basemapControl) return;
-    const { googleMapsApiKey, tomtomApiKey, hereApiKey } =
+    const { googleMapsApiKey, tomtomApiKey, hereApiKey, amazonApiKey, awsRegion } =
       getBasemapCredentials();
     basemapControl.setGoogleMapsApiKey(googleMapsApiKey);
     basemapControl.setTomTomApiKey(tomtomApiKey);
     basemapControl.setHereApiKey(hereApiKey);
+    basemapControl.setAmazonCredentials(amazonApiKey, awsRegion);
   };
 
   window.addEventListener("geolibre:runtime-env-change", handleRuntimeEnvChange);


### PR DESCRIPTION
Fixes #837.

The Basemaps panel is rendered by the upstream `maplibre-gl-basemap-control` package, so the reported problems were fixed there and released as **v0.8.0** (opengeos/maplibre-gl-basemap-control#20). This PR bumps the dependency to `^0.8.0` in both `apps/geolibre-desktop` and `packages/plugins`.

## What was wrong (from #837)

Selecting a basemap that needs a provider credential (e.g. an Amazon Location style) with no key configured led to a confusing, dead-ended flow: the panel asked the user to confirm discarding their basemap stack *before* checking for the key, the error text was clipped, every provider's input field was shown at once, and the error lingered while browsing for an alternative.

## What v0.8.0 changes

- **Validate before the destructive change.** Provider credentials for a style basemap are checked before the style-replace confirm, so stacked rasters are never discarded just to hit an "enter an API key" error.
- **Context-sensitive inline field.** A missing-credential error shows only the failing provider's field(s) right beside the message, and Enter re-attempts the basemap that failed.
- **Readable errors.** The error message wraps freely instead of clipping to one line.
- **Self-clearing error.** Searching or changing the provider/category filter clears a stale credential error.
- **Dedicated API keys view.** A key button in the panel header opens a centralized API keys view with every provider's credential grouped together; the standing provider-settings section is removed from the basemap list.

## Verification

Upstream: 78 unit tests passing, build green. Verified in the GeoLibre web app (Playwright) in both light and dark themes: selecting an Amazon style with no key shows the error and inline Amazon-only fields with no destructive prompt and no clipped text; searching clears the error; the header key button opens the centralized API keys view; entering a key and pressing Enter applies the basemap. GeoLibre `npm run build` and pre-commit pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Amazon Location style basemaps, including automatic use of API key/region settings.
  * Amazon key changes apply immediately; removing the key requires a page reload, and the basemap updates live in the app.
* **Documentation**
  * Updated the getting started guide with setup instructions for Amazon Location styles, including environment variable options and the optional region.
  * Noted you can enter the key/region directly in the app’s API keys view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->