### PR TITLE
fix(swipe): list only visible layers in the Layer Swipe panel (#843)

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -74,7 +74,7 @@
     "maplibre-gl-raster": "^0.6.3",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
-    "maplibre-gl-swipe": "^0.9.1",
+    "maplibre-gl-swipe": "^0.10.0",
     "maplibre-gl-time-slider": "^1.1.0",
     "maplibre-gl-usgs-lidar": "^0.11.0",
     "maplibre-gl-vector": "^0.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
         "maplibre-gl-raster": "^0.6.3",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
-        "maplibre-gl-swipe": "^0.9.1",
+        "maplibre-gl-swipe": "^0.10.0",
         "maplibre-gl-time-slider": "^1.1.0",
         "maplibre-gl-usgs-lidar": "^0.11.0",
         "maplibre-gl-vector": "^0.8.0",
@@ -17902,9 +17902,9 @@
       }
     },
     "node_modules/maplibre-gl-swipe": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-swipe/-/maplibre-gl-swipe-0.9.1.tgz",
-      "integrity": "sha512-oP8IA1oP0NfEaiKvBWeYcmlfI8oURyzyedD/75siS9ABf3VOoeou/vAxfbhPeOVlXOy+dE1MSaFsGH0rDyNFRw==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-swipe/-/maplibre-gl-swipe-0.10.0.tgz",
+      "integrity": "sha512-RB/RQnq+mBGGuiAqdrNZPiNF+3I4ssNIjcz6es676zQT0ANNyyAJZAsx91t2pFn2Z9yyq9PXTD4CpJn82zQ8lQ==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -23816,7 +23816,7 @@
         "maplibre-gl-raster": "^0.6.3",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
-        "maplibre-gl-swipe": "^0.9.1",
+        "maplibre-gl-swipe": "^0.10.0",
         "maplibre-gl-time-slider": "^1.1.0",
         "maplibre-gl-usgs-lidar": "^0.11.0",
         "maplibre-gl-vector": "^0.8.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -48,7 +48,7 @@
     "maplibre-gl-planetary-computer": "^0.3.0",
     "maplibre-gl-raster": "^0.6.3",
     "maplibre-gl-streetview": "^0.7.0",
-    "maplibre-gl-swipe": "^0.9.1",
+    "maplibre-gl-swipe": "^0.10.0",
     "maplibre-gl-time-slider": "^1.1.0",
     "maplibre-gl-usgs-lidar": "^0.11.0",
     "maplibre-gl-vector": "^0.8.0",

--- a/packages/plugins/src/plugins/maplibre-swipe.ts
+++ b/packages/plugins/src/plugins/maplibre-swipe.ts
@@ -119,9 +119,7 @@ function getSwipeControlOptions(
     selectVisibleByDefault: previousState === undefined,
     basemapStyle: app.getActiveBasemap(),
     excludeLayers: ["gl-draw-*", "measure-*", "geolibre-highlight-*"],
-    // Only list layers that are currently visible in the main Layers panel
-    // (plus any already selected), and keep the lists in sync as visibility
-    // changes, so the swipe panel mirrors the active working set (#843).
+    // List only currently visible layers (plus any already selected), kept in sync live (#843).
     visibleLayersOnly: true,
   };
 }

--- a/packages/plugins/src/plugins/maplibre-swipe.ts
+++ b/packages/plugins/src/plugins/maplibre-swipe.ts
@@ -119,6 +119,10 @@ function getSwipeControlOptions(
     selectVisibleByDefault: previousState === undefined,
     basemapStyle: app.getActiveBasemap(),
     excludeLayers: ["gl-draw-*", "measure-*", "geolibre-highlight-*"],
+    // Only list layers that are currently visible in the main Layers panel
+    // (plus any already selected), and keep the lists in sync as visibility
+    // changes, so the swipe panel mirrors the active working set (#843).
+    visibleLayersOnly: true,
   };
 }
 


### PR DESCRIPTION
## Summary

The Layer Swipe panel listed **every** project layer under Left Layers and Right Layers, regardless of whether each layer was toggled on or off in the main Layers panel. With many layers this made the comparison panel cluttered and slow to configure.

This wires up the new `visibleLayersOnly` option in `maplibre-gl-swipe` so the panel's Left/Right lists only show layers that are currently visible in the main Layers panel, plus any layer already selected on either side (so a selected right-side layer the control hides on the main map still appears). Hidden, unselected layers are omitted, and the lists update live as visibility changes, without restarting the plugin.

## Changes

- Bump `maplibre-gl-swipe` to `^0.10.0` in `apps/geolibre-desktop/package.json` and `packages/plugins/package.json` (+ `package-lock.json`).
- Pass `visibleLayersOnly: true` when constructing the swipe control in `packages/plugins/src/plugins/maplibre-swipe.ts`.

The filtering itself lives upstream: opengeos/maplibre-gl-swipe#17, released as [v0.10.0](https://github.com/opengeos/maplibre-gl-swipe/releases/tag/v0.10.0).

## Testing

Verified in the running web app with two XYZ tile layers plus the basemap:

- With a layer hidden in the Layers panel, it no longer appears in either Left/Right list (only visible layers and the grouped Basemap are listed).
- Revealing a hidden layer makes it appear in both lists live; hiding a visible, unselected layer removes it live, without restarting the plugin.
- Confirmed in both light and dark themes.
- `npm run build` and scoped `pre-commit` pass.

Fixes #843