### PR TITLE
fix(geolocate): reset control when the browser permission prompt is dismissed

### DIFF
--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -1694,8 +1694,17 @@ export class MapController {
     // unavailable) leave the button usable, so MapLibre's own handling is fine.
     if (!this.map || !this.geolocateControl || event?.code !== 1) return;
 
+    // Snapshot the control that errored. The reset always runs in a later
+    // microtask (the Permissions API query's `.then`, or `queueMicrotask`), so
+    // we never tear down the control mid error-dispatch. It also means the
+    // control could be torn down or replaced in between (e.g. the user toggles
+    // it off then on), so recreate() bails unless this exact instance is still
+    // mounted and never disturbs a healthy replacement.
+    const controlAtError = this.geolocateControl;
+
     const recreate = (): void => {
-      if (!this.controlVisibility.geolocate) return;
+      if (!this.map || !this.controlVisibility.geolocate) return;
+      if (this.geolocateControl !== controlAtError) return;
       // Re-create the control to clear MapLibre's permanently-disabled button.
       this.removeGeolocateControl();
       this.addGeolocateControl();
@@ -1705,7 +1714,6 @@ export class MapController {
       typeof navigator !== "undefined" ? navigator.permissions : undefined;
     if (!permissions?.query) {
       // No Permissions API: assume a dismissal so the user is never stuck.
-      // Defer so we don't tear down the control mid error-dispatch.
       queueMicrotask(recreate);
       return;
     }

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -1671,18 +1671,57 @@ export class MapController {
     ) {
       return false;
     }
-    this.geolocateControl = new maplibregl.GeolocateControl({
+    const control = new maplibregl.GeolocateControl({
       positionOptions: {
         enableHighAccuracy: true,
       },
       trackUserLocation: true,
     });
-    this.map.addControl(this.geolocateControl, this.controlPositions.geolocate);
+    // MapLibre permanently disables the GeolocateControl button on a
+    // PERMISSION_DENIED error (code 1). Browsers report code 1 both for a real
+    // denial and when the user simply dismisses the permission prompt without
+    // choosing, which leaves the button stuck in a blocked state with no way to
+    // retry (issue #839). Re-create the control whenever the permission was not
+    // actually denied so the button returns to a neutral, clickable state.
+    control.on("error", this.handleGeolocateError);
+    this.geolocateControl = control;
+    this.map.addControl(control, this.controlPositions.geolocate);
     return true;
   }
 
+  private handleGeolocateError = (event: { code?: number }): void => {
+    // Only react to PERMISSION_DENIED; other errors (timeout, position
+    // unavailable) leave the button usable, so MapLibre's own handling is fine.
+    if (!this.map || !this.geolocateControl || event?.code !== 1) return;
+
+    const recreate = (): void => {
+      if (!this.controlVisibility.geolocate) return;
+      // Re-create the control to clear MapLibre's permanently-disabled button.
+      this.removeGeolocateControl();
+      this.addGeolocateControl();
+    };
+
+    const permissions =
+      typeof navigator !== "undefined" ? navigator.permissions : undefined;
+    if (!permissions?.query) {
+      // No Permissions API: assume a dismissal so the user is never stuck.
+      // Defer so we don't tear down the control mid error-dispatch.
+      queueMicrotask(recreate);
+      return;
+    }
+    permissions
+      .query({ name: "geolocation" as PermissionName })
+      .then((status) => {
+        // A real, persistent denial keeps MapLibre's disabled state; a pending
+        // "prompt" means the dialog was dismissed, so reset to allow a retry.
+        if (status.state !== "denied") recreate();
+      })
+      .catch(() => recreate());
+  };
+
   private removeGeolocateControl(): void {
     if (!this.geolocateControl) return;
+    this.geolocateControl.off("error", this.handleGeolocateError);
     this.removeControl(this.geolocateControl);
     this.geolocateControl = null;
   }

--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -1720,9 +1720,10 @@ export class MapController {
     permissions
       .query({ name: "geolocation" as PermissionName })
       .then((status) => {
-        // A real, persistent denial keeps MapLibre's disabled state; a pending
-        // "prompt" means the dialog was dismissed, so reset to allow a retry.
-        if (status.state !== "denied") recreate();
+        // Only a pending "prompt" means the dialog was dismissed, so reset to
+        // allow a retry. "denied" keeps MapLibre's disabled state, and
+        // "granted" (a contradictory code-1) is left alone rather than reset.
+        if (status.state === "prompt") recreate();
       })
       .catch(() => recreate());
   };

--- a/tests/map-controller.test.ts
+++ b/tests/map-controller.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import maplibregl from "maplibre-gl";
 import {
   DEFAULT_LAYER_STYLE,
   type GeoLibreLayer,
@@ -642,4 +643,165 @@ describe("MapController built-in control positions", () => {
     // not propagate that.
     assert.doesNotThrow(() => controller.removeControl({} as never));
   });
+});
+
+// Internal surface used to drive the geolocate error handler in plain Node.
+interface GeolocateInternals {
+  map: unknown;
+  geolocateControl: { handlers: Record<string, (e: unknown) => void> } | null;
+  controlVisibility: Record<string, boolean>;
+  addGeolocateControl(): boolean;
+}
+
+/** Minimal stand-in for maplibregl.GeolocateControl that records listeners. */
+class FakeGeolocateControl {
+  handlers: Record<string, (e: unknown) => void> = {};
+  on(event: string, fn: (e: unknown) => void): void {
+    this.handlers[event] = fn;
+  }
+  off(event: string, fn: (e: unknown) => void): void {
+    if (this.handlers[event] === fn) delete this.handlers[event];
+  }
+}
+
+/** Replace the global `navigator` for a test; returns a restore function. */
+function stubNavigator(permissionState: string | null): () => void {
+  const original = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+  const value =
+    permissionState === null
+      ? {}
+      : { permissions: { query: async () => ({ state: permissionState }) } };
+  Object.defineProperty(globalThis, "navigator", { value, configurable: true });
+  return () => {
+    if (original) Object.defineProperty(globalThis, "navigator", original);
+    else delete (globalThis as { navigator?: unknown }).navigator;
+  };
+}
+
+/** Mount a fresh geolocate control on a controller backed by a fake map. */
+function controllerWithGeolocate(): {
+  controller: MapController;
+  internal: GeolocateInternals;
+  firstControl: { handlers: Record<string, (e: unknown) => void> };
+} {
+  const controller = createMapController();
+  const internal = controller as unknown as GeolocateInternals;
+  internal.map = { addControl() {}, removeControl() {} };
+  internal.controlVisibility.geolocate = true;
+  internal.addGeolocateControl();
+  return { controller, internal, firstControl: internal.geolocateControl! };
+}
+
+/** Flush pending microtasks (the async permission query and its `.then`). */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("MapController geolocate permission-denied recovery", () => {
+  const originalControl = maplibregl.GeolocateControl;
+
+  function withStubbedControl(run: () => Promise<void>): Promise<void> {
+    (maplibregl as { GeolocateControl: unknown }).GeolocateControl =
+      FakeGeolocateControl;
+    return run().finally(() => {
+      (maplibregl as { GeolocateControl: unknown }).GeolocateControl =
+        originalControl;
+    });
+  }
+
+  it("re-creates the control when the prompt was dismissed (state 'prompt')", () =>
+    withStubbedControl(async () => {
+      const restore = stubNavigator("prompt");
+      try {
+        const { internal, firstControl } = controllerWithGeolocate();
+        // A dismissed prompt surfaces as a PERMISSION_DENIED (code 1) error.
+        firstControl.handlers.error({ code: 1 });
+        await flush();
+        assert.notEqual(internal.geolocateControl, firstControl);
+        assert.ok(internal.geolocateControl instanceof FakeGeolocateControl);
+      } finally {
+        restore();
+      }
+    }));
+
+  it("leaves the control disabled on a genuine denial (state 'denied')", () =>
+    withStubbedControl(async () => {
+      const restore = stubNavigator("denied");
+      try {
+        const { internal, firstControl } = controllerWithGeolocate();
+        firstControl.handlers.error({ code: 1 });
+        await flush();
+        assert.equal(internal.geolocateControl, firstControl);
+      } finally {
+        restore();
+      }
+    }));
+
+  it("does not reset on a contradictory granted denial (state 'granted')", () =>
+    withStubbedControl(async () => {
+      const restore = stubNavigator("granted");
+      try {
+        const { internal, firstControl } = controllerWithGeolocate();
+        firstControl.handlers.error({ code: 1 });
+        await flush();
+        assert.equal(internal.geolocateControl, firstControl);
+      } finally {
+        restore();
+      }
+    }));
+
+  it("re-creates when the Permissions API is unavailable", () =>
+    withStubbedControl(async () => {
+      const restore = stubNavigator(null);
+      try {
+        const { internal, firstControl } = controllerWithGeolocate();
+        firstControl.handlers.error({ code: 1 });
+        await flush();
+        assert.notEqual(internal.geolocateControl, firstControl);
+      } finally {
+        restore();
+      }
+    }));
+
+  it("ignores non-permission errors (e.g. timeout, code 3)", () =>
+    withStubbedControl(async () => {
+      const restore = stubNavigator("prompt");
+      try {
+        const { internal, firstControl } = controllerWithGeolocate();
+        firstControl.handlers.error({ code: 3 });
+        await flush();
+        assert.equal(internal.geolocateControl, firstControl);
+      } finally {
+        restore();
+      }
+    }));
+
+  it("does not disturb a control that was replaced before the check resolved", () =>
+    withStubbedControl(async () => {
+      const restore = stubNavigator("prompt");
+      try {
+        const { internal, firstControl } = controllerWithGeolocate();
+        firstControl.handlers.error({ code: 1 });
+        // The control is swapped out (e.g. toggled off/on) before the async
+        // permission query resolves; the stale handler must not touch it.
+        const replacement = new FakeGeolocateControl();
+        internal.geolocateControl = replacement;
+        await flush();
+        assert.equal(internal.geolocateControl, replacement);
+      } finally {
+        restore();
+      }
+    }));
+
+  it("is a no-op when the map is destroyed before the check resolves", () =>
+    withStubbedControl(async () => {
+      const restore = stubNavigator("prompt");
+      try {
+        const { internal, firstControl } = controllerWithGeolocate();
+        firstControl.handlers.error({ code: 1 });
+        internal.map = null;
+        await flush();
+        assert.equal(internal.geolocateControl, firstControl);
+      } finally {
+        restore();
+      }
+    }));
 });


### PR DESCRIPTION
## Summary

Fixes #839.

MapLibre's built-in `GeolocateControl` **permanently disables its button** on any `PERMISSION_DENIED` (code 1) geolocation error. Browsers report code 1 both for a real denial *and* when the user merely dismisses/clicks away the permission prompt without making a choice. The result: dismissing the prompt left the geolocate button stuck in the blocked state (icon with a red line) with no way to retry, as reported in the issue.

## Fix

When the control fires a code-1 `error`, query the Permissions API:

- If the permission state is **not** `denied` (i.e. still `prompt` — the dialog was dismissed), re-create the control so its button returns to a neutral, clickable state. Clicking again re-initiates the browser permission prompt.
- A genuine, persistent **denial** keeps MapLibre's disabled state (unchanged behavior).
- If the Permissions API is unavailable, default to re-creating so the user is never permanently stuck.

The re-creation is the deactivate/reactivate approach noted in the issue discussion (the control is not otherwise customizable). The error listener is removed when the control is torn down.

## Verification

Drove the real web app with Playwright (geolocation + Permissions API mocked to fire a code-1 error), in **both light and dark themes**:

| Scenario | Before click | After dismiss (code-1 error) | Result |
| --- | --- | --- | --- |
| Prompt dismissed (light) | enabled "Find my location" | **enabled "Find my location"** | retry possible |
| Prompt dismissed (dark) | enabled | **enabled** | retry possible |
| Real denial | disabled "Location not available" | disabled (unchanged) | stays blocked |

Also: `npm run build` passes, `tests/map-controller.test.ts` (26 tests) passes, pre-commit clean.