### PR TITLE
fix(swipe): correct layer order, basemap label, and pause behavior (#842)

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -74,7 +74,7 @@
     "maplibre-gl-raster": "^0.6.3",
     "maplibre-gl-splat": "^0.2.8",
     "maplibre-gl-streetview": "^0.7.0",
-    "maplibre-gl-swipe": "^0.10.0",
+    "maplibre-gl-swipe": "^0.10.1",
     "maplibre-gl-time-slider": "^1.1.0",
     "maplibre-gl-usgs-lidar": "^0.11.0",
     "maplibre-gl-vector": "^0.8.0",

--- a/apps/geolibre-desktop/src/lib/swipe-style.ts
+++ b/apps/geolibre-desktop/src/lib/swipe-style.ts
@@ -259,8 +259,7 @@ const enhanceSwipeSelects = () => {
 
 let swipeEnhanceFrame: number | null = null;
 
-// Mirror the main layer manager, which labels the base layer "Background"
-// rather than "Basemap" (see issue #842).
+// Matches the label used by the main layer manager for the grouped base layer.
 const SWIPE_BASEMAP_LABEL = "Background";
 
 const getSwipeLayerLabel = (layerId: string): string => {

--- a/apps/geolibre-desktop/src/lib/swipe-style.ts
+++ b/apps/geolibre-desktop/src/lib/swipe-style.ts
@@ -259,8 +259,12 @@ const enhanceSwipeSelects = () => {
 
 let swipeEnhanceFrame: number | null = null;
 
+// Mirror the main layer manager, which labels the base layer "Background"
+// rather than "Basemap" (see issue #842).
+const SWIPE_BASEMAP_LABEL = "Background";
+
 const getSwipeLayerLabel = (layerId: string): string => {
-  if (layerId === "__basemap__") return "Basemap";
+  if (layerId === "__basemap__") return SWIPE_BASEMAP_LABEL;
   return (
     (window as GeoLibreLayerLabelWindow).__GEOLIBRE_LAYER_LABELS__?.[layerId] ??
     layerId
@@ -283,7 +287,9 @@ const syncSwipeLayerLabels = () => {
 
       const displayName = getSwipeLayerLabel(layerId);
       const title =
-        layerId === "__basemap__" ? "Basemap" : `${displayName} (${layerId})`;
+        layerId === "__basemap__"
+          ? SWIPE_BASEMAP_LABEL
+          : `${displayName} (${layerId})`;
       if (label.textContent !== displayName) {
         label.textContent = displayName;
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
         "maplibre-gl-raster": "^0.6.3",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
-        "maplibre-gl-swipe": "^0.10.0",
+        "maplibre-gl-swipe": "^0.10.1",
         "maplibre-gl-time-slider": "^1.1.0",
         "maplibre-gl-usgs-lidar": "^0.11.0",
         "maplibre-gl-vector": "^0.8.0",
@@ -17902,9 +17902,9 @@
       }
     },
     "node_modules/maplibre-gl-swipe": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-swipe/-/maplibre-gl-swipe-0.10.0.tgz",
-      "integrity": "sha512-RB/RQnq+mBGGuiAqdrNZPiNF+3I4ssNIjcz6es676zQT0ANNyyAJZAsx91t2pFn2Z9yyq9PXTD4CpJn82zQ8lQ==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-swipe/-/maplibre-gl-swipe-0.10.1.tgz",
+      "integrity": "sha512-m6f7SSDBVV7Oov7rHxLHGrboD6Sf0pFQEeIDhgpYLEJHDRTp3iJck6/YvxRGQSuJBNOt+M1HpjELYLLt2tfXkg==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -23816,7 +23816,7 @@
         "maplibre-gl-raster": "^0.6.3",
         "maplibre-gl-splat": "^0.2.8",
         "maplibre-gl-streetview": "^0.7.0",
-        "maplibre-gl-swipe": "^0.10.0",
+        "maplibre-gl-swipe": "^0.10.1",
         "maplibre-gl-time-slider": "^1.1.0",
         "maplibre-gl-usgs-lidar": "^0.11.0",
         "maplibre-gl-vector": "^0.8.0",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -48,7 +48,7 @@
     "maplibre-gl-planetary-computer": "^0.3.0",
     "maplibre-gl-raster": "^0.6.3",
     "maplibre-gl-streetview": "^0.7.0",
-    "maplibre-gl-swipe": "^0.10.0",
+    "maplibre-gl-swipe": "^0.10.1",
     "maplibre-gl-time-slider": "^1.1.0",
     "maplibre-gl-usgs-lidar": "^0.11.0",
     "maplibre-gl-vector": "^0.8.0",


### PR DESCRIPTION
## Summary

Fixes the three Layer Swipe panel inconsistencies reported in #842:

1. **Inverted layer order.** The panel's `LEFT LAYERS` / `RIGHT LAYERS` lists were in reverse stack order (bottom layer at the top). They now mirror the main layer manager, with the top-most layer first and the base layer at the bottom.
2. **Basemap label.** The grouped base layer was labeled `Basemap` while the main interface calls it `Background`. The swipe panel relabeling helper now uses `Background` to match.
3. **Pause behavior.** Toggling `Swipe Enabled` off tore down the entire split-screen comparison. It now freezes the comparison in place and locks the slider (dragging disabled, handle dimmed), keeping the side-by-side view and its layer/orientation controls meaningful.

## Changes

- Bump `maplibre-gl-swipe` to `^0.10.1`, which carries the order and pause fixes upstream (opengeos/maplibre-gl-swipe#18, released as v0.10.1).
- `swipe-style.ts`: the panel label helper returns `Background` for the grouped base layer (label and tooltip), matching the layer manager.

## Testing

- Verified in the running app (web) with two XYZ overlays plus the basemap, in **both light and dark themes**:
  - Lists read `Beta, Alpha, Background` top-to-bottom, matching the sidebar.
  - The base layer shows as `Background`.
  - Toggling `Swipe Enabled` off keeps the split view on screen with a locked slider; toggling on restores dragging.
- `npm run build` and `pre-commit run --files` (eslint + npm build) pass.

Fixes #842