### PR TITLE
fix(geolocate): guard permission query against synchronous throws

### DIFF
--- a/packages/map/src/map-controller.ts
+++ b/packages/map/src/map-controller.ts
@@ -1717,15 +1717,22 @@ export class MapController {
       queueMicrotask(recreate);
       return;
     }
-    permissions
-      .query({ name: "geolocation" as PermissionName })
-      .then((status) => {
-        // Only a pending "prompt" means the dialog was dismissed, so reset to
-        // allow a retry. "denied" keeps MapLibre's disabled state, and
-        // "granted" (a contradictory code-1) is left alone rather than reset.
-        if (status.state === "prompt") recreate();
-      })
-      .catch(() => recreate());
+    try {
+      permissions
+        .query({ name: "geolocation" as PermissionName })
+        .then((status) => {
+          // Only a pending "prompt" means the dialog was dismissed, so reset to
+          // allow a retry. "denied" keeps MapLibre's disabled state, and
+          // "granted" (a contradictory code-1) is left alone rather than reset.
+          if (status.state === "prompt") recreate();
+        })
+        .catch(() => recreate());
+    } catch {
+      // Some Permissions API implementations throw synchronously (partial
+      // support, CSP, private browsing). Fall back to a deferred reset so the
+      // user is never stuck.
+      queueMicrotask(recreate);
+    }
   };
 
   private removeGeolocateControl(): void {

--- a/tests/map-controller.test.ts
+++ b/tests/map-controller.test.ts
@@ -664,13 +664,20 @@ class FakeGeolocateControl {
   }
 }
 
-/** Replace the global `navigator` for a test; returns a restore function. */
-function stubNavigator(permissionState: string | null): () => void {
+/**
+ * Replace the global `navigator` for a test; returns a restore function.
+ * Pass `permissionState` of `null` to omit the Permissions API entirely, or a
+ * `queryOverride` to control how `permissions.query()` resolves/throws.
+ */
+function stubNavigator(
+  permissionState: string | null,
+  queryOverride?: () => Promise<unknown>,
+): () => void {
   const original = Object.getOwnPropertyDescriptor(globalThis, "navigator");
-  const value =
-    permissionState === null
-      ? {}
-      : { permissions: { query: async () => ({ state: permissionState }) } };
+  let value: unknown;
+  if (queryOverride) value = { permissions: { query: queryOverride } };
+  else if (permissionState === null) value = {};
+  else value = { permissions: { query: async () => ({ state: permissionState }) } };
   Object.defineProperty(globalThis, "navigator", { value, configurable: true });
   return () => {
     if (original) Object.defineProperty(globalThis, "navigator", original);
@@ -751,6 +758,36 @@ describe("MapController geolocate permission-denied recovery", () => {
   it("re-creates when the Permissions API is unavailable", () =>
     withStubbedControl(async () => {
       const restore = stubNavigator(null);
+      try {
+        const { internal, firstControl } = controllerWithGeolocate();
+        firstControl.handlers.error({ code: 1 });
+        await flush();
+        assert.notEqual(internal.geolocateControl, firstControl);
+      } finally {
+        restore();
+      }
+    }));
+
+  it("re-creates when the permission query rejects", () =>
+    withStubbedControl(async () => {
+      const restore = stubNavigator(null, () =>
+        Promise.reject(new Error("not supported")),
+      );
+      try {
+        const { internal, firstControl } = controllerWithGeolocate();
+        firstControl.handlers.error({ code: 1 });
+        await flush();
+        assert.notEqual(internal.geolocateControl, firstControl);
+      } finally {
+        restore();
+      }
+    }));
+
+  it("re-creates when the permission query throws synchronously", () =>
+    withStubbedControl(async () => {
+      const restore = stubNavigator(null, () => {
+        throw new Error("permissions blocked");
+      });
       try {
         const { internal, firstControl } = controllerWithGeolocate();
         firstControl.handlers.error({ code: 1 });


### PR DESCRIPTION
## Summary

Follow-up to #858 (merged). The final round of automated review on that PR landed two items after it was already merged, so this small PR carries them forward.

## Changes

- **Guard `permissions.query()` against a synchronous throw.** In `handleGeolocateError`, `.catch()` only intercepts async rejections. Some Permissions API implementations can throw *synchronously* (partial support, CSP restrictions, Firefox private browsing), which would escape the handler as an unhandled error. Wrap the query in `try/catch` and fall back to a deferred reset via `queueMicrotask` — consistent with the existing no-Permissions-API path, and it avoids tearing down the control mid error-dispatch.
- **Tests.** Add coverage for the rejected-promise (`.catch`) branch and the synchronous-throw branch of `handleGeolocateError`.

## Verification

- `tests/map-controller.test.ts` — 35 pass (9 in the geolocate recovery suite).
- `tsc -b` clean.

Relates to #839.