### PR TITLE
fix(add-data): reposition sample-data dropdown and raise Cancel button contrast (#863)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/add-data/shared.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/shared.tsx
@@ -83,6 +83,11 @@ export function useAddDataSource(defaultLayerName: string) {
  * when no samples are supplied, and snaps back to the placeholder after a pick
  * so it reads as an action menu rather than a sticky selection.
  *
+ * Sits at the bottom of each source form as a secondary, low-frequency action,
+ * with a faint top divider so it reads as separate from the production fields
+ * above it (and is less likely to be triggered by accident — picking a sample
+ * overwrites the fields, including any access token typed for the prior entry).
+ *
  * @param samples - The named presets to offer.
  * @param onSelect - Applies the chosen preset's value to the source's fields.
  */
@@ -97,7 +102,7 @@ export function SampleDataSelect<T>({
   const selectId = useId();
   if (samples.length === 0) return null;
   return (
-    <div className="space-y-1.5">
+    <div className="space-y-1.5 border-t border-border/60 pt-3">
       <Label htmlFor={selectId}>{t("addData.shared.sampleData")}</Label>
       <Select
         id={selectId}

--- a/apps/geolibre-desktop/src/components/layout/add-data/shared.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/shared.tsx
@@ -229,7 +229,7 @@ export function AddDataFooter({
       <div className="flex justify-end gap-2">
         <Button
           type="button"
-          variant="ghost"
+          variant="outline"
           onClick={closeDialog}
           disabled={isSubmitting}
         >

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/ArcGISSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/ArcGISSource.tsx
@@ -92,27 +92,6 @@ export function ArcGISSource() {
       submitDisabled={source.isSubmitting}
     >
       <div className="space-y-3">
-        <SampleDataSelect
-          samples={[
-            {
-              label: t("addData.arcgis.sampleFeatureLabel"),
-              value: {
-                layerType: "feature",
-                sourceType: "url",
-                url: DEFAULT_ARCGIS_URLS.feature,
-              },
-            },
-            {
-              label: t("addData.arcgis.sampleVectorTileLabel"),
-              value: {
-                layerType: "vector-tile",
-                sourceType: "url",
-                url: DEFAULT_ARCGIS_URLS["vector-tile"],
-              },
-            },
-          ]}
-          onSelect={applyFields}
-        />
         <ServiceLibrarySection
           kind="arcgis"
           layerName={source.layerName}
@@ -196,6 +175,27 @@ export function ArcGISSource() {
             onChange={(event) => setArcgisAccessToken(event.target.value)}
           />
         </div>
+        <SampleDataSelect
+          samples={[
+            {
+              label: t("addData.arcgis.sampleFeatureLabel"),
+              value: {
+                layerType: "feature",
+                sourceType: "url",
+                url: DEFAULT_ARCGIS_URLS.feature,
+              },
+            },
+            {
+              label: t("addData.arcgis.sampleVectorTileLabel"),
+              value: {
+                layerType: "vector-tile",
+                sourceType: "url",
+                url: DEFAULT_ARCGIS_URLS["vector-tile"],
+              },
+            },
+          ]}
+          onSelect={applyFields}
+        />
       </div>
     </AddDataSourceForm>
   );

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/DelimitedTextSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/DelimitedTextSource.tsx
@@ -254,21 +254,6 @@ export function DelimitedTextSource() {
       }
     >
       <div className="space-y-3">
-        <SampleDataSelect
-          samples={[
-            { label: t("addData.delimitedText.sampleLabel"), value: DEFAULT_DELIMITED_TEXT_URL },
-          ]}
-          onSelect={(url) => {
-            setDelimitedTextMode("url");
-            setSelectedDelimitedText(null);
-            resetDelimitedTextColumns();
-            // The sample is a comma-delimited CSV, so reset the delimiter too;
-            // otherwise a previously chosen delimiter would misparse it.
-            setDelimitedTextDelimiter("comma");
-            setDelimitedTextCustomDelimiter("");
-            setDelimitedTextUrl(url);
-          }}
-        />
         <div className="space-y-1.5">
           <Label htmlFor="delimited-text-mode">
             {t("addData.common.sourceType")}
@@ -430,6 +415,21 @@ export function DelimitedTextSource() {
             </Select>
           </div>
         </div>
+        <SampleDataSelect
+          samples={[
+            { label: t("addData.delimitedText.sampleLabel"), value: DEFAULT_DELIMITED_TEXT_URL },
+          ]}
+          onSelect={(url) => {
+            setDelimitedTextMode("url");
+            setSelectedDelimitedText(null);
+            resetDelimitedTextColumns();
+            // The sample is a comma-delimited CSV, so reset the delimiter too;
+            // otherwise a previously chosen delimiter would misparse it.
+            setDelimitedTextDelimiter("comma");
+            setDelimitedTextCustomDelimiter("");
+            setDelimitedTextUrl(url);
+          }}
+        />
       </div>
     </AddDataSourceForm>
   );

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/GeoRssSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/GeoRssSource.tsx
@@ -129,16 +129,6 @@ export function GeoRssSource() {
       useServiceIcon
     >
       <div className="space-y-3">
-        <SampleDataSelect
-          samples={[
-            { label: t("addData.georss.sampleLabel"), value: DEFAULT_GEORSS_URL },
-          ]}
-          onSelect={(url) => {
-            setGeoRssMode("url");
-            setSelectedFile(null);
-            setGeoRssUrl(url);
-          }}
-        />
         <div className="space-y-1.5">
           <Label htmlFor="georss-mode">{t("addData.common.sourceType")}</Label>
           <Select
@@ -176,6 +166,16 @@ export function GeoRssSource() {
             />
           </div>
         )}
+        <SampleDataSelect
+          samples={[
+            { label: t("addData.georss.sampleLabel"), value: DEFAULT_GEORSS_URL },
+          ]}
+          onSelect={(url) => {
+            setGeoRssMode("url");
+            setSelectedFile(null);
+            setGeoRssUrl(url);
+          }}
+        />
       </div>
     </AddDataSourceForm>
   );

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/GpxSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/GpxSource.tsx
@@ -207,14 +207,6 @@ export function GpxSource() {
       submitDisabled={source.isSubmitting || !hasSelectedGpxLayerKind}
     >
       <div className="space-y-3">
-        <SampleDataSelect
-          samples={[{ label: t("addData.gpx.sampleLabel"), value: DEFAULT_GPX_URL }]}
-          onSelect={(url) => {
-            setGpxMode("url");
-            setSelectedGpx(null);
-            setGpxUrl(url);
-          }}
-        />
         <div className="space-y-1.5">
           <Label htmlFor="gpx-mode">{t("addData.common.sourceType")}</Label>
           <Select
@@ -288,6 +280,14 @@ export function GpxSource() {
             </label>
           </div>
         </div>
+        <SampleDataSelect
+          samples={[{ label: t("addData.gpx.sampleLabel"), value: DEFAULT_GPX_URL }]}
+          onSelect={(url) => {
+            setGpxMode("url");
+            setSelectedGpx(null);
+            setGpxUrl(url);
+          }}
+        />
       </div>
     </AddDataSourceForm>
   );

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/VideoSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/VideoSource.tsx
@@ -104,29 +104,6 @@ export function VideoSource() {
       submitDisabled={source.isSubmitting}
     >
       <div className="space-y-3">
-        <SampleDataSelect
-          samples={[
-            {
-              label: t("addData.video.sampleLabel"),
-              value: {
-                mp4: DEFAULT_VIDEO_MP4_URL,
-                webm: DEFAULT_VIDEO_WEBM_URL,
-                topLeft: DEFAULT_VIDEO_TOP_LEFT,
-                topRight: DEFAULT_VIDEO_TOP_RIGHT,
-                bottomRight: DEFAULT_VIDEO_BOTTOM_RIGHT,
-                bottomLeft: DEFAULT_VIDEO_BOTTOM_LEFT,
-              },
-            },
-          ]}
-          onSelect={(sample) => {
-            setVideoMp4Url(sample.mp4);
-            setVideoWebmUrl(sample.webm);
-            setVideoTopLeft(sample.topLeft);
-            setVideoTopRight(sample.topRight);
-            setVideoBottomRight(sample.bottomRight);
-            setVideoBottomLeft(sample.bottomLeft);
-          }}
-        />
         <div className="space-y-1.5">
           <Label htmlFor="video-mp4-url">{t("addData.video.primaryUrl")}</Label>
           <Input
@@ -190,6 +167,29 @@ export function VideoSource() {
         <p className="text-xs text-muted-foreground">
           {t("addData.video.cornersNote")}
         </p>
+        <SampleDataSelect
+          samples={[
+            {
+              label: t("addData.video.sampleLabel"),
+              value: {
+                mp4: DEFAULT_VIDEO_MP4_URL,
+                webm: DEFAULT_VIDEO_WEBM_URL,
+                topLeft: DEFAULT_VIDEO_TOP_LEFT,
+                topRight: DEFAULT_VIDEO_TOP_RIGHT,
+                bottomRight: DEFAULT_VIDEO_BOTTOM_RIGHT,
+                bottomLeft: DEFAULT_VIDEO_BOTTOM_LEFT,
+              },
+            },
+          ]}
+          onSelect={(sample) => {
+            setVideoMp4Url(sample.mp4);
+            setVideoWebmUrl(sample.webm);
+            setVideoTopLeft(sample.topLeft);
+            setVideoTopRight(sample.topRight);
+            setVideoBottomRight(sample.bottomRight);
+            setVideoBottomLeft(sample.bottomLeft);
+          }}
+        />
       </div>
     </AddDataSourceForm>
   );

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WfsSource.tsx
@@ -108,15 +108,6 @@ export function WfsSource() {
       useServiceIcon
     >
       <div className="space-y-3">
-        <SampleDataSelect
-          samples={[
-            {
-              label: t("addData.wfs.sampleLabel"),
-              value: { endpoint: DEFAULT_WFS_ENDPOINT, typeName: DEFAULT_WFS_TYPE_NAME },
-            },
-          ]}
-          onSelect={applyFields}
-        />
         <ServiceLibrarySection
           kind="wfs"
           layerName={source.layerName}
@@ -189,6 +180,15 @@ export function WfsSource() {
             />
           </div>
         </div>
+        <SampleDataSelect
+          samples={[
+            {
+              label: t("addData.wfs.sampleLabel"),
+              value: { endpoint: DEFAULT_WFS_ENDPOINT, typeName: DEFAULT_WFS_TYPE_NAME },
+            },
+          ]}
+          onSelect={applyFields}
+        />
       </div>
     </AddDataSourceForm>
   );

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WmsSource.tsx
@@ -85,15 +85,6 @@ export function WmsSource() {
       useServiceIcon
     >
       <div className="space-y-3">
-        <SampleDataSelect
-          samples={[
-            {
-              label: t("addData.wms.sampleLabel"),
-              value: { endpoint: DEFAULT_WMS_ENDPOINT, layers: DEFAULT_WMS_LAYERS },
-            },
-          ]}
-          onSelect={applyFields}
-        />
         <ServiceLibrarySection
           kind="wms"
           layerName={source.layerName}
@@ -159,6 +150,15 @@ export function WmsSource() {
           />
           {t("addData.wms.transparent")}
         </label>
+        <SampleDataSelect
+          samples={[
+            {
+              label: t("addData.wms.sampleLabel"),
+              value: { endpoint: DEFAULT_WMS_ENDPOINT, layers: DEFAULT_WMS_LAYERS },
+            },
+          ]}
+          onSelect={applyFields}
+        />
       </div>
     </AddDataSourceForm>
   );

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/WmtsSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/WmtsSource.tsx
@@ -58,12 +58,6 @@ export function WmtsSource() {
       useServiceIcon
     >
       <div className="space-y-3">
-        <SampleDataSelect
-          samples={[
-            { label: t("addData.wmts.sampleLabel"), value: { url: DEFAULT_WMTS_URL } },
-          ]}
-          onSelect={applyFields}
-        />
         <ServiceLibrarySection
           kind="wmts"
           layerName={source.layerName}
@@ -93,6 +87,12 @@ export function WmtsSource() {
             />
           </div>
         </div>
+        <SampleDataSelect
+          samples={[
+            { label: t("addData.wmts.sampleLabel"), value: { url: DEFAULT_WMTS_URL } },
+          ]}
+          onSelect={applyFields}
+        />
       </div>
     </AddDataSourceForm>
   );

--- a/apps/geolibre-desktop/src/components/layout/add-data/sources/XyzSource.tsx
+++ b/apps/geolibre-desktop/src/components/layout/add-data/sources/XyzSource.tsx
@@ -72,12 +72,6 @@ export function XyzSource() {
       submitDisabled={source.isSubmitting}
     >
       <div className="space-y-3">
-        <SampleDataSelect
-          samples={[
-            { label: t("addData.xyz.sampleLabel"), value: { url: DEFAULT_XYZ_URL } },
-          ]}
-          onSelect={applyFields}
-        />
         <ServiceLibrarySection
           kind="xyz"
           layerName={source.layerName}
@@ -119,6 +113,12 @@ export function XyzSource() {
           />
           {t("addData.xyz.shortUrl")}
         </label>
+        <SampleDataSelect
+          samples={[
+            { label: t("addData.xyz.sampleLabel"), value: { url: DEFAULT_XYZ_URL } },
+          ]}
+          onSelect={applyFields}
+        />
       </div>
     </AddDataSourceForm>
   );


### PR DESCRIPTION
## Summary

Addresses the two UX refinements reported in #863 for the **Add WFS Layer** dialog. Because the same layout pattern is shared across every Add Data source dialog, both fixes are applied consistently to all nine source dialogs (WFS, WMS, WMTS, XYZ, ArcGIS, GeoRSS, GPX, Delimited Text, Video).

### 1. Reposition the "Sample data" selection

The "Sample data" dropdown previously sat near the top of the form, above "Saved services" and ahead of the primary configuration fields. Loading sample data is a secondary, low-frequency onboarding action, so it has been moved to the very bottom of the form inputs, directly below the last field and right before the action buttons. Standard users can now fill out their production service details top to bottom without navigating past the sample options.

### 2. Raise the Cancel button contrast

The Cancel button in the shared Add Data footer used the `ghost` variant (plain text, no boundary), which made it hard to recognize as an interactive element next to the prominent "Add layer" button. It now uses the `outline` variant, giving it a subtle border, a background, and a neutral hover state so it clearly reads as a clickable action while keeping primary focus on "Add layer".

## Verification

Verified in the real app with Playwright against a running dev build:

- **Add WFS Layer** dialog in both **light and dark** themes: "Sample data" now appears at the bottom directly above the buttons, and the Cancel button shows a clear outline border.
- **Add WMS Layer** dialog: confirmed the same repositioning carried over to a second source dialog.
- `npm run build` and scoped `pre-commit` (eslint + npm build) pass.

Fixes #863

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the add-data workflow layout so the sample data pickers appear later in the form across multiple source types, providing a more consistent experience.
* **Bug Fixes**
  * Improved the “Cancel” button styling in the add-data footer by switching it to an outlined secondary style for clearer emphasis.
* **UI Polish**
  * Added a subtle divider above the sample-picker area to better separate it from the preceding fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->