### PR TITLE
fix(split-view): use real checkboxes in the secondary pane layer menu (#840)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/MapGrid.tsx
+++ b/apps/geolibre-desktop/src/components/layout/MapGrid.tsx
@@ -181,6 +181,7 @@ function PaneLayerToggle({ viewId, index }: PaneLayerToggleProps) {
             return (
               <DropdownMenuCheckboxItem
                 key={layer.id}
+                indicator="box"
                 checked={visible}
                 onCheckedChange={(checked: boolean) =>
                   setSecondaryLayerVisibility(viewId, layer.id, checked)

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -115,12 +115,7 @@ DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
 export const DropdownMenuCheckboxItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem> & {
-    /**
-     * How the checked state is drawn. `"check"` (default) shows a bare checkmark
-     * only when checked. `"box"` renders a real checkbox: an always-visible
-     * square that fills and shows a checkmark when checked, matching the
-     * checkbox look used elsewhere in the app.
-     */
+    /** `"check"` (default): bare checkmark when checked. `"box"`: always-visible bordered square that fills on check. */
     indicator?: "check" | "box";
   }
 >(({ className, children, checked, indicator = "check", ...props }, ref) => (
@@ -139,10 +134,16 @@ export const DropdownMenuCheckboxItem = React.forwardRef<
           "absolute left-2 flex h-4 w-4 items-center justify-center rounded-[4px] border transition-colors",
           checked === true
             ? "border-primary bg-primary text-primary-foreground"
-            : "border-input",
+            : checked === "indeterminate"
+              ? "border-primary bg-primary/40 text-primary-foreground"
+              : "border-input",
         )}
       >
-        {checked === true ? <Check className="h-3 w-3" /> : null}
+        {checked === true ? (
+          <Check className="h-3 w-3" />
+        ) : checked === "indeterminate" ? (
+          <span className="h-0.5 w-2 rounded-full bg-current" />
+        ) : null}
       </span>
     ) : (
       <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -114,8 +114,16 @@ DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
 
 export const DropdownMenuCheckboxItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
->(({ className, children, checked, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem> & {
+    /**
+     * How the checked state is drawn. `"check"` (default) shows a bare checkmark
+     * only when checked. `"box"` renders a real checkbox: an always-visible
+     * square that fills and shows a checkmark when checked, matching the
+     * checkbox look used elsewhere in the app.
+     */
+    indicator?: "check" | "box";
+  }
+>(({ className, children, checked, indicator = "check", ...props }, ref) => (
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
@@ -125,11 +133,24 @@ export const DropdownMenuCheckboxItem = React.forwardRef<
     checked={checked}
     {...props}
   >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <DropdownMenuPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
-      </DropdownMenuPrimitive.ItemIndicator>
-    </span>
+    {indicator === "box" ? (
+      <span
+        className={cn(
+          "absolute left-2 flex h-4 w-4 items-center justify-center rounded-[4px] border transition-colors",
+          checked === true
+            ? "border-primary bg-primary text-primary-foreground"
+            : "border-input",
+        )}
+      >
+        {checked === true ? <Check className="h-3 w-3" /> : null}
+      </span>
+    ) : (
+      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <Check className="h-4 w-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+    )}
     {children}
   </DropdownMenuPrimitive.CheckboxItem>
 ));


### PR DESCRIPTION
## Summary

Addresses the "real checkboxes for map views" request in #840 (Issue 1).

In a split view, each secondary map pane has a **Layer visibility** dropdown so it can show a different subset of the shared layers. That dropdown drew only a bare checkmark next to selected layers, with nothing in front of unselected ones. As reported, this breaks the checkbox design language the rest of the app uses for layer selection.

This PR makes every layer in that menu show a **real checkbox**: an empty bordered box when the layer is off, a filled box with a checkmark when it is on.

## Changes

- `packages/ui` — `DropdownMenuCheckboxItem` gains an optional `indicator="box"` prop that renders an always-visible checkbox box (border when unchecked, filled + check when checked). The default (`"check"`) is unchanged, so the menu's other callers (View menu, Settings, Attribute Table) keep the existing checkmark style.
- `apps/geolibre-desktop` — the per-pane layer-visibility menu in `MapGrid.tsx` opts into `indicator="box"`.

## Scope

Limited to the checkbox UI (Issue 1). The split-view layer-stack-order and independent top-pane controls raised elsewhere in the issue are separate and not in scope here.

## Verification

Drove the real app in a browser (two XYZ layers, two-column split view) and confirmed in **both light and dark themes** that each layer in the pane menu now renders a real checkbox, toggling between empty box and filled-with-check.

Fixes #840

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `indicator` option for checkbox items in dropdown menus, supporting a boxed indicator style.
  * Updated layer visibility toggles to use the boxed indicator for clearer selection feedback.

* **Bug Fixes**
  * Improved the visual rendering of checked and indeterminate states in dropdown checkbox menus, making selected items easier to identify.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->