### PR TITLE
fix(arcgis): load feature layers as GeoJSON so labels can be styled

### DIFF
--- a/packages/map/src/layer-sync.ts
+++ b/packages/map/src/layer-sync.ts
@@ -1308,6 +1308,9 @@ function syncGeoJsonLayer(
   }
 
   if (!map.getSource(src)) {
+    // Carry a source attribution (e.g. an ArcGIS service's copyrightText) into
+    // MapLibre's attribution control when the layer declares one.
+    const attribution = stringSource(layer.source.attribution);
     map.addSource(
       src,
       wantCluster
@@ -1317,8 +1320,13 @@ function syncGeoJsonLayer(
             cluster: true,
             clusterRadius,
             clusterMaxZoom,
+            ...(attribution ? { attribution } : {}),
           }
-        : { type: "geojson", data: layer.geojson! },
+        : {
+            type: "geojson",
+            data: layer.geojson!,
+            ...(attribution ? { attribution } : {}),
+          },
     );
   } else {
     (map.getSource(src) as maplibregl.GeoJSONSource).setData(layer.geojson!);

--- a/packages/plugins/src/plugins/arcgis-layer.ts
+++ b/packages/plugins/src/plugins/arcgis-layer.ts
@@ -245,22 +245,39 @@ async function addArcGISFeatureLayerAsGeoJson(
     );
   }
 
-  const queryUrl = appendArcGISParams(`${trimTrailingSlash(layerUrl)}/query`, {
+  // The token is kept out of the persisted refresh URL so it is never written
+  // to a saved project; it is only appended to the one-off request below.
+  const refreshUrl = appendArcGISParams(`${trimTrailingSlash(layerUrl)}/query`, {
     f: "geojson",
     outFields: "*",
     returnGeometry: "true",
-    token: options.token?.trim(),
     where: "1=1",
   });
-  const geojson = await fetchArcGISGeoJson(queryUrl);
+  const requestUrl = appendArcGISParams(refreshUrl, {
+    token: options.token?.trim(),
+  });
+  const geojson = await fetchArcGISGeoJson(requestUrl);
 
   const name =
     options.name?.trim() ||
     layerInfo.name ||
     layerNameFromArcGISInput(layerUrl, "ArcGIS Layer");
-  const id = useAppStore
-    .getState()
-    .addGeoJsonLayer(name, geojson, input, options.beforeLayerId ?? null);
+  const store = useAppStore.getState();
+  // Persist the GeoJSON query endpoint (not the service-description base URL) as
+  // the source path so the layer's GeoJSON refresh re-fetches valid features.
+  const id = store.addGeoJsonLayer(
+    name,
+    geojson,
+    refreshUrl,
+    options.beforeLayerId ?? null,
+  );
+
+  // Preserve the service's copyright watermark in MapLibre's attribution
+  // control, matching the prior URL-source behavior.
+  const attribution = layerInfo.copyrightText?.trim();
+  if (attribution) {
+    store.updateLayer(id, { source: { type: "geojson", attribution } });
+  }
 
   const bounds = arcgisExtentToBounds(layerInfo.extent);
   if (bounds) app.fitBounds?.(bounds);
@@ -284,10 +301,25 @@ async function fetchArcGISGeoJson(url: string): Promise<FeatureCollection> {
   if (!response.ok) {
     throw new Error(`ArcGIS feature query failed with ${response.status}.`);
   }
-  const json = (await response.json()) as FeatureCollection & {
+  // ArcGIS Enterprise (and services behind a WAF) can answer 200 with an HTML
+  // login/redirect page when a token is missing or expired. Read the body as
+  // text first so that surfaces as a clear message instead of a raw
+  // `SyntaxError: Unexpected token '<'` from JSON.parse.
+  const text = await response.text();
+  if (/^\s*</.test(text)) {
+    throw new Error(
+      "The ArcGIS service returned HTML instead of GeoJSON (the layer may require a token or sign-in).",
+    );
+  }
+  let json: FeatureCollection & {
     error?: { message?: string };
     exceededTransferLimit?: boolean;
   };
+  try {
+    json = JSON.parse(text);
+  } catch {
+    throw new Error("The ArcGIS feature layer did not return GeoJSON features.");
+  }
   if (json.error) {
     throw new Error(json.error.message || "ArcGIS feature query failed.");
   }

--- a/packages/plugins/src/plugins/arcgis-layer.ts
+++ b/packages/plugins/src/plugins/arcgis-layer.ts
@@ -271,7 +271,10 @@ async function addArcGISFeatureLayerAsGeoJson(
  * Fetch and validate a GeoJSON FeatureCollection from an ArcGIS query URL.
  *
  * ArcGIS can answer a `f=geojson` request with a JSON error envelope rather than
- * GeoJSON, so both the transport status and the payload shape are checked.
+ * GeoJSON, so both the transport status and the payload shape are checked. A
+ * result truncated at the service's `maxRecordCount` is loaded as-is but warned
+ * about, so a partial attribute table or export is not mistaken for the full
+ * dataset.
  *
  * @param url - The fully-built `/query?f=geojson` request URL.
  * @returns The parsed FeatureCollection.
@@ -283,6 +286,7 @@ async function fetchArcGISGeoJson(url: string): Promise<FeatureCollection> {
   }
   const json = (await response.json()) as FeatureCollection & {
     error?: { message?: string };
+    exceededTransferLimit?: boolean;
   };
   if (json.error) {
     throw new Error(json.error.message || "ArcGIS feature query failed.");
@@ -290,6 +294,16 @@ async function fetchArcGISGeoJson(url: string): Promise<FeatureCollection> {
   if (json.type !== "FeatureCollection" || !Array.isArray(json.features)) {
     throw new Error(
       "The ArcGIS feature layer did not return GeoJSON features.",
+    );
+  }
+  // ArcGIS caps a single query at the service's maxRecordCount and flags the
+  // shortfall with `exceededTransferLimit`. The partial data still loads (it is
+  // the same subset the previous URL-source path rendered), but the truncation
+  // is surfaced so the caller knows the layer is not the complete dataset.
+  if (json.exceededTransferLimit) {
+    console.warn(
+      `[GeoLibre] ArcGIS feature query was truncated at the service record ` +
+        `limit; loaded ${json.features.length} features (partial dataset).`,
     );
   }
   return json;

--- a/packages/plugins/src/plugins/arcgis-layer.ts
+++ b/packages/plugins/src/plugins/arcgis-layer.ts
@@ -9,6 +9,7 @@ import type {
   HostedLayer,
   VectorTileLayer,
 } from "@esri/maplibre-arcgis";
+import type { FeatureCollection } from "geojson";
 import type maplibregl from "maplibre-gl";
 import type { GeoLibreAppAPI } from "../types";
 
@@ -79,12 +80,22 @@ export async function addArcGISLayer(
   app: GeoLibreAppAPI,
   options: ArcGISLayerOptions,
 ): Promise<string> {
+  const input = getArcGISInput(options);
+
+  // A feature layer is just attributed vector data, so load it as a regular
+  // GeoJSON layer rather than an opaque external-native layer. That unlocks the
+  // host's full vector styling surface for it — labels (with uppercase/offset/
+  // rotation formatting), the attribute table, identify, symbology, and export —
+  // instead of only the fill/stroke paint an external-native layer exposes.
+  if (options.layerType === "feature") {
+    return addArcGISFeatureLayerAsGeoJson(app, options, input);
+  }
+
   const map = app.getMap?.();
   if (!map) {
     throw new Error("The map is not ready.");
   }
 
-  const input = getArcGISInput(options);
   const arcgis = await import("@esri/maplibre-arcgis");
   const hostedLayer = await createArcGISHostedLayer(arcgis, options, input);
   const id = createArcGISLayerId();
@@ -132,10 +143,6 @@ async function createArcGISHostedLayer(
     portalUrl: options.portalUrl?.trim() || undefined,
     token: options.token?.trim() || undefined,
   };
-
-  if (options.layerType === "feature") {
-    return createFallbackFeatureLayer(input, options);
-  }
 
   return options.sourceType === "url"
     ? (arcgis.VectorTileLayer as typeof VectorTileLayer).fromUrl(
@@ -204,29 +211,40 @@ function addArcGISRuntimeLayerToMap(
   }
 }
 
-async function createFallbackFeatureLayer(
-  input: string,
+/**
+ * Load an ArcGIS FeatureServer layer as a host-managed GeoJSON layer.
+ *
+ * The features are fetched up front (`/query?f=geojson`) and handed to the
+ * store's GeoJSON layer path, so the layer is a first-class vector layer with
+ * its attributes available — enabling labels and their formatting, the
+ * attribute table, identify, symbology, and export. Vector tile layers keep the
+ * external-native runtime path; only feature layers come through here.
+ *
+ * @param app - The host app API (used to fit the view to the layer extent).
+ * @param options - The ArcGIS layer options (source type, URL/item, token).
+ * @param input - The resolved service URL or portal item id from the options.
+ * @returns The new GeoLibre layer's id.
+ */
+async function addArcGISFeatureLayerAsGeoJson(
+  app: GeoLibreAppAPI,
   options: ArcGISLayerOptions,
-  cause: unknown = undefined,
-): Promise<ArcGISRuntimeLayer> {
+  input: string,
+): Promise<string> {
   const layerUrl =
     options.sourceType === "url"
-      ? await resolveFeatureLayerUrl(input, options, cause)
-      : await resolvePortalFeatureLayerUrl(input, options, cause);
+      ? await resolveFeatureLayerUrl(input, options, undefined)
+      : await resolvePortalFeatureLayerUrl(input, options, undefined);
   const layerInfo = await fetchArcGISJson<ArcGISFeatureLayerInfo>(
     layerUrl,
     options,
-    cause,
+    undefined,
   );
   if (!layerInfo.geometryType) {
-    throw new Error("The ArcGIS feature layer metadata is missing geometry type.", {
-      cause,
-    });
+    throw new Error(
+      "The ArcGIS feature layer metadata is missing geometry type.",
+    );
   }
 
-  const sourceId = layerInfo.name || layerNameFromArcGISInput(layerUrl, "arcgis");
-  const styleLayerType = arcgisGeometryLayerType(layerInfo.geometryType);
-  const styleLayerId = `${sourceId}-layer`;
   const queryUrl = appendArcGISParams(`${trimTrailingSlash(layerUrl)}/query`, {
     f: "geojson",
     outFields: "*",
@@ -234,25 +252,47 @@ async function createFallbackFeatureLayer(
     token: options.token?.trim(),
     where: "1=1",
   });
+  const geojson = await fetchArcGISGeoJson(queryUrl);
 
-  return createStaticArcGISRuntimeLayer({
-    bounds: arcgisExtentToBounds(layerInfo.extent),
-    layers: [
-      {
-        id: styleLayerId,
-        source: sourceId,
-        type: styleLayerType,
-        paint: arcgisFallbackPaint(styleLayerType),
-      } as maplibregl.LayerSpecification,
-    ],
-    sources: {
-      [sourceId]: {
-        type: "geojson",
-        data: queryUrl,
-        attribution: layerInfo.copyrightText || "ArcGIS Feature Service",
-      },
-    },
-  });
+  const name =
+    options.name?.trim() ||
+    layerInfo.name ||
+    layerNameFromArcGISInput(layerUrl, "ArcGIS Layer");
+  const id = useAppStore
+    .getState()
+    .addGeoJsonLayer(name, geojson, input, options.beforeLayerId ?? null);
+
+  const bounds = arcgisExtentToBounds(layerInfo.extent);
+  if (bounds) app.fitBounds?.(bounds);
+  return id;
+}
+
+/**
+ * Fetch and validate a GeoJSON FeatureCollection from an ArcGIS query URL.
+ *
+ * ArcGIS can answer a `f=geojson` request with a JSON error envelope rather than
+ * GeoJSON, so both the transport status and the payload shape are checked.
+ *
+ * @param url - The fully-built `/query?f=geojson` request URL.
+ * @returns The parsed FeatureCollection.
+ */
+async function fetchArcGISGeoJson(url: string): Promise<FeatureCollection> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`ArcGIS feature query failed with ${response.status}.`);
+  }
+  const json = (await response.json()) as FeatureCollection & {
+    error?: { message?: string };
+  };
+  if (json.error) {
+    throw new Error(json.error.message || "ArcGIS feature query failed.");
+  }
+  if (json.type !== "FeatureCollection" || !Array.isArray(json.features)) {
+    throw new Error(
+      "The ArcGIS feature layer did not return GeoJSON features.",
+    );
+  }
+  return json;
 }
 
 async function resolveFeatureLayerUrl(
@@ -338,42 +378,6 @@ async function fetchArcGISJson<T>(
     });
   }
   return json;
-}
-
-function createStaticArcGISRuntimeLayer(args: {
-  bounds?: [number, number, number, number];
-  layers: maplibregl.LayerSpecification[];
-  sources: Record<string, maplibregl.SourceSpecification>;
-}): ArcGISRuntimeLayer {
-  return {
-    get bounds() {
-      return args.bounds;
-    },
-    get layers() {
-      return args.layers;
-    },
-    get sources() {
-      return args.sources;
-    },
-    setSourceId(oldId: string, newId: string) {
-      args.sources[newId] = args.sources[oldId];
-      delete args.sources[oldId];
-      for (const layer of args.layers) {
-        if ("source" in layer && layer.source === oldId) {
-          layer.source = newId;
-        }
-      }
-    },
-    addSourcesAndLayersTo(map: maplibregl.Map) {
-      for (const [sourceId, source] of Object.entries(args.sources)) {
-        map.addSource(sourceId, source);
-      }
-      for (const layer of args.layers) {
-        map.addLayer(layer);
-      }
-      return this;
-    },
-  };
 }
 
 async function resolveArcGISLayerBounds(
@@ -483,39 +487,6 @@ function isGeoBounds(value: unknown): value is [number, number, number, number] 
     value[0] < value[2] &&
     value[1] < value[3]
   );
-}
-
-function arcgisGeometryLayerType(
-  geometryType: string,
-): "circle" | "fill" | "line" {
-  if (geometryType === "esriGeometryPoint") return "circle";
-  if (geometryType === "esriGeometryMultipoint") return "circle";
-  if (geometryType === "esriGeometryPolyline") return "line";
-  return "fill";
-}
-
-function arcgisFallbackPaint(
-  layerType: "circle" | "fill" | "line",
-): maplibregl.LayerSpecification["paint"] {
-  if (layerType === "circle") {
-    return {
-      "circle-color": DEFAULT_LAYER_STYLE.fillColor,
-      "circle-radius": DEFAULT_LAYER_STYLE.circleRadius,
-      "circle-stroke-color": DEFAULT_LAYER_STYLE.strokeColor,
-      "circle-stroke-width": DEFAULT_LAYER_STYLE.strokeWidth,
-    };
-  }
-  if (layerType === "line") {
-    return {
-      "line-color": DEFAULT_LAYER_STYLE.strokeColor,
-      "line-width": DEFAULT_LAYER_STYLE.strokeWidth,
-    };
-  }
-  return {
-    "fill-color": DEFAULT_LAYER_STYLE.fillColor,
-    "fill-opacity": DEFAULT_LAYER_STYLE.fillOpacity,
-    "fill-outline-color": DEFAULT_LAYER_STYLE.strokeColor,
-  };
 }
 
 function appendArcGISParams(

--- a/tests/arcgis-feature-layer.test.ts
+++ b/tests/arcgis-feature-layer.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { useAppStore } from "@geolibre/core";
+import type { GeoLibreAppAPI } from "../packages/plugins/src/types";
+import { addArcGISLayer } from "../packages/plugins/src/plugins/arcgis-layer";
+
+// Minimal ArcGIS FeatureServer layer metadata (the `?f=json` response) with a
+// geographic extent so the bounds resolve without Web Mercator reprojection.
+const LAYER_INFO = {
+  name: "USA Major Cities",
+  geometryType: "esriGeometryPoint",
+  extent: {
+    xmin: -160,
+    ymin: 18,
+    xmax: -154,
+    ymax: 23,
+    spatialReference: { wkid: 4326 },
+  },
+};
+
+// The `/query?f=geojson` response — features carry the attributes that the label
+// field picker (and attribute table) read once the layer is a GeoJSON layer.
+const QUERY_GEOJSON = {
+  type: "FeatureCollection",
+  features: [
+    {
+      type: "Feature",
+      geometry: { type: "Point", coordinates: [-157.8, 21.3] },
+      properties: { NAME: "Honolulu", POPULATION: 350000 },
+    },
+  ],
+};
+
+/** Routes the two ArcGIS requests by URL: the query endpoint returns GeoJSON. */
+function makeArcGISFetch(): typeof fetch {
+  return (async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const body = url.includes("/query") ? QUERY_GEOJSON : LAYER_INFO;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => body,
+    } as Response;
+  }) as typeof fetch;
+}
+
+describe("addArcGISLayer (feature layer)", () => {
+  let fitBoundsCalls: Array<[number, number, number, number]>;
+  let app: GeoLibreAppAPI;
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    useAppStore.getState().newProject({ name: "ArcGIS" });
+    useAppStore.temporal.getState().clear();
+    fitBoundsCalls = [];
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = makeArcGISFetch();
+    app = {
+      // The feature path never touches the map; only fitBounds is exercised.
+      getMap: () => null,
+      fitBounds: (bounds) => {
+        fitBoundsCalls.push(bounds);
+      },
+    } as unknown as GeoLibreAppAPI;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("loads a feature layer as a GeoJSON layer with its attributes intact", async () => {
+    const id = await addArcGISLayer(app, {
+      layerType: "feature",
+      sourceType: "url",
+      url: "https://example.com/arcgis/rest/services/Cities/FeatureServer/0",
+      name: "Cities",
+    });
+
+    const layer = useAppStore.getState().layers.find((l) => l.id === id);
+    assert.ok(layer, "expected the feature layer to be added to the store");
+    // A plain GeoJSON layer (not an opaque external-native "arcgis" layer) is
+    // what unlocks labels, the attribute table, identify, and symbology.
+    assert.equal(layer.type, "geojson");
+    assert.notEqual(layer.metadata.externalNativeLayer, true);
+    assert.equal(layer.geojson?.features.length, 1);
+    // The attributes the label field picker reads must survive the round trip.
+    assert.deepEqual(Object.keys(layer.geojson?.features[0]?.properties ?? {}), [
+      "NAME",
+      "POPULATION",
+    ]);
+    // The geographic extent is fitted directly (no Web Mercator conversion).
+    assert.deepEqual(fitBoundsCalls, [[-160, 18, -154, 23]]);
+  });
+
+  it("rejects a non-GeoJSON query response instead of adding an empty layer", async () => {
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const body = url.includes("/query")
+        ? { error: { message: "Token Required" } }
+        : LAYER_INFO;
+      return { ok: true, status: 200, json: async () => body } as Response;
+    }) as typeof fetch;
+
+    await assert.rejects(
+      addArcGISLayer(app, {
+        layerType: "feature",
+        sourceType: "url",
+        url: "https://example.com/arcgis/rest/services/Cities/FeatureServer/0",
+      }),
+      /Token Required/,
+    );
+    assert.equal(useAppStore.getState().layers.length, 0);
+  });
+});

--- a/tests/arcgis-feature-layer.test.ts
+++ b/tests/arcgis-feature-layer.test.ts
@@ -111,4 +111,62 @@ describe("addArcGISLayer (feature layer)", () => {
     );
     assert.equal(useAppStore.getState().layers.length, 0);
   });
+
+  it("warns but still loads when the query exceeds the service record limit", async () => {
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const body = url.includes("/query")
+        ? { ...QUERY_GEOJSON, exceededTransferLimit: true }
+        : LAYER_INFO;
+      return { ok: true, status: 200, json: async () => body } as Response;
+    }) as typeof fetch;
+
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    };
+    try {
+      const id = await addArcGISLayer(app, {
+        layerType: "feature",
+        sourceType: "url",
+        url: "https://example.com/arcgis/rest/services/Cities/FeatureServer/0",
+      });
+      // The partial dataset still loads — truncation must not block the layer.
+      const layer = useAppStore.getState().layers.find((l) => l.id === id);
+      assert.equal(layer?.geojson?.features.length, 1);
+    } finally {
+      console.warn = originalWarn;
+    }
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0] ?? "", /truncated/i);
+  });
+
+  it("resolves a portal-item feature layer through the portal item URL", async () => {
+    const serviceUrl =
+      "https://example.com/arcgis/rest/services/Cities/FeatureServer/0";
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      let body: unknown = LAYER_INFO;
+      if (url.includes("/content/items/")) {
+        body = { url: serviceUrl };
+      } else if (url.includes("/query")) {
+        body = QUERY_GEOJSON;
+      }
+      return { ok: true, status: 200, json: async () => body } as Response;
+    }) as typeof fetch;
+
+    const id = await addArcGISLayer(app, {
+      layerType: "feature",
+      sourceType: "portal-item",
+      itemId: "abc123def456",
+      name: "Cities",
+    });
+
+    const layer = useAppStore.getState().layers.find((l) => l.id === id);
+    assert.ok(layer, "expected the portal-item feature layer to be added");
+    assert.equal(layer.type, "geojson");
+    assert.equal(layer.geojson?.features.length, 1);
+    assert.deepEqual(fitBoundsCalls, [[-160, 18, -154, 23]]);
+  });
 });

--- a/tests/arcgis-feature-layer.test.ts
+++ b/tests/arcgis-feature-layer.test.ts
@@ -145,8 +145,10 @@ describe("addArcGISLayer (feature layer)", () => {
   it("resolves a portal-item feature layer through the portal item URL", async () => {
     const serviceUrl =
       "https://example.com/arcgis/rest/services/Cities/FeatureServer/0";
+    const fetchUrls: string[] = [];
     globalThis.fetch = (async (input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : input.toString();
+      fetchUrls.push(url);
       let body: unknown = LAYER_INFO;
       if (url.includes("/content/items/")) {
         body = { url: serviceUrl };
@@ -168,5 +170,15 @@ describe("addArcGISLayer (feature layer)", () => {
     assert.equal(layer.type, "geojson");
     assert.equal(layer.geojson?.features.length, 1);
     assert.deepEqual(fitBoundsCalls, [[-160, 18, -154, 23]]);
+    // Assert the portal path was genuinely walked: the item metadata lookup and
+    // a query against the resolved service URL both happened.
+    assert.ok(
+      fetchUrls.some((url) => url.includes("/content/items/abc123def456")),
+      "expected portal item metadata to be fetched",
+    );
+    assert.ok(
+      fetchUrls.some((url) => url.startsWith(`${serviceUrl}/query`)),
+      "expected the resolved service URL to be queried",
+    );
   });
 });

--- a/tests/arcgis-feature-layer.test.ts
+++ b/tests/arcgis-feature-layer.test.ts
@@ -5,10 +5,12 @@ import type { GeoLibreAppAPI } from "../packages/plugins/src/types";
 import { addArcGISLayer } from "../packages/plugins/src/plugins/arcgis-layer";
 
 // Minimal ArcGIS FeatureServer layer metadata (the `?f=json` response) with a
-// geographic extent so the bounds resolve without Web Mercator reprojection.
+// geographic extent so the bounds resolve without Web Mercator reprojection,
+// and a copyrightText so the attribution propagation can be asserted.
 const LAYER_INFO = {
   name: "USA Major Cities",
   geometryType: "esriGeometryPoint",
+  copyrightText: "© Example City Data",
   extent: {
     xmin: -160,
     ymin: 18,
@@ -31,16 +33,23 @@ const QUERY_GEOJSON = {
   ],
 };
 
+// addArcGISLayer reads layer metadata via `response.json()` and query results via
+// `response.text()` (it guards against HTML before parsing), so a mock response
+// must answer both. `raw` overrides the text body (for the HTML-page case).
+function jsonResponse(body: unknown, raw?: string): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+    text: async () => raw ?? JSON.stringify(body),
+  } as Response;
+}
+
 /** Routes the two ArcGIS requests by URL: the query endpoint returns GeoJSON. */
 function makeArcGISFetch(): typeof fetch {
   return (async (input: RequestInfo | URL) => {
     const url = typeof input === "string" ? input : input.toString();
-    const body = url.includes("/query") ? QUERY_GEOJSON : LAYER_INFO;
-    return {
-      ok: true,
-      status: 200,
-      json: async () => body,
-    } as Response;
+    return jsonResponse(url.includes("/query") ? QUERY_GEOJSON : LAYER_INFO);
   }) as typeof fetch;
 }
 
@@ -88,17 +97,45 @@ describe("addArcGISLayer (feature layer)", () => {
       "NAME",
       "POPULATION",
     ]);
+    // The persisted source path is the GeoJSON query endpoint (so a refresh
+    // re-fetches features), not the service-description base URL.
+    assert.match(layer.sourcePath ?? "", /\/FeatureServer\/0\/query\?/);
+    // The service copyright is carried into MapLibre's attribution control.
+    assert.equal(layer.source.attribution, "© Example City Data");
     // The geographic extent is fitted directly (no Web Mercator conversion).
     assert.deepEqual(fitBoundsCalls, [[-160, 18, -154, 23]]);
+  });
+
+  it("never persists the access token in the refresh URL", async () => {
+    const fetchUrls: string[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      fetchUrls.push(url);
+      return jsonResponse(url.includes("/query") ? QUERY_GEOJSON : LAYER_INFO);
+    }) as typeof fetch;
+
+    const id = await addArcGISLayer(app, {
+      layerType: "feature",
+      sourceType: "url",
+      url: "https://example.com/arcgis/rest/services/Cities/FeatureServer/0",
+      token: "secret-token-123",
+    });
+
+    const layer = useAppStore.getState().layers.find((l) => l.id === id);
+    // The token reaches the live request but must not be saved to the project.
+    assert.ok(
+      fetchUrls.some((url) => url.includes("token=secret-token-123")),
+      "expected the query request to carry the token",
+    );
+    assert.doesNotMatch(layer?.sourcePath ?? "", /token=/);
   });
 
   it("rejects a non-GeoJSON query response instead of adding an empty layer", async () => {
     globalThis.fetch = (async (input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : input.toString();
-      const body = url.includes("/query")
-        ? { error: { message: "Token Required" } }
-        : LAYER_INFO;
-      return { ok: true, status: 200, json: async () => body } as Response;
+      return url.includes("/query")
+        ? jsonResponse({ error: { message: "Token Required" } })
+        : jsonResponse(LAYER_INFO);
     }) as typeof fetch;
 
     await assert.rejects(
@@ -112,13 +149,31 @@ describe("addArcGISLayer (feature layer)", () => {
     assert.equal(useAppStore.getState().layers.length, 0);
   });
 
+  it("rejects an HTML login page returned with a 200 status", async () => {
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      return url.includes("/query")
+        ? jsonResponse(null, "<!DOCTYPE html><html><body>Sign in</body></html>")
+        : jsonResponse(LAYER_INFO);
+    }) as typeof fetch;
+
+    await assert.rejects(
+      addArcGISLayer(app, {
+        layerType: "feature",
+        sourceType: "url",
+        url: "https://example.com/arcgis/rest/services/Cities/FeatureServer/0",
+      }),
+      /HTML instead of GeoJSON/,
+    );
+    assert.equal(useAppStore.getState().layers.length, 0);
+  });
+
   it("warns but still loads when the query exceeds the service record limit", async () => {
     globalThis.fetch = (async (input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : input.toString();
-      const body = url.includes("/query")
-        ? { ...QUERY_GEOJSON, exceededTransferLimit: true }
-        : LAYER_INFO;
-      return { ok: true, status: 200, json: async () => body } as Response;
+      return url.includes("/query")
+        ? jsonResponse({ ...QUERY_GEOJSON, exceededTransferLimit: true })
+        : jsonResponse(LAYER_INFO);
     }) as typeof fetch;
 
     const warnings: string[] = [];
@@ -149,13 +204,10 @@ describe("addArcGISLayer (feature layer)", () => {
     globalThis.fetch = (async (input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : input.toString();
       fetchUrls.push(url);
-      let body: unknown = LAYER_INFO;
       if (url.includes("/content/items/")) {
-        body = { url: serviceUrl };
-      } else if (url.includes("/query")) {
-        body = QUERY_GEOJSON;
+        return jsonResponse({ url: serviceUrl });
       }
-      return { ok: true, status: 200, json: async () => body } as Response;
+      return jsonResponse(url.includes("/query") ? QUERY_GEOJSON : LAYER_INFO);
     }) as typeof fetch;
 
     const id = await addArcGISLayer(app, {


### PR DESCRIPTION
## Problem

Fixes #867. Label formatting options (uppercase, offset, rotation, and labeling in general) were not applicable to ArcGIS vector layers added from the Add Data **Load sample data** dropdown (e.g. "US major cities (feature)").

## Root cause

ArcGIS **feature** layers were registered as *external-native* layers (`externalNativeLayer: true`) whose GeoJSON source was a remote `/query?f=geojson` URL. The features were never stored on the layer record, so:

1. `getAttributePropertyNames()` in the Style panel found no attributes → the **Label field** dropdown was disabled showing "No attributes found", so no field could be picked.
2. `syncLayer()` returns early for external-native layers (`packages/map/src/layer-sync.ts`), so the label symbol layer that carries `text-transform` / `text-offset` / `text-rotate` was never created.

Inline-GeoJSON suggested layers (WFS, Delimited Text, GPX) store `layer.geojson` and were unaffected.

## Fix

A feature layer is just attributed vector data, so fetch the `/query?f=geojson` result up front and hand it to the store's GeoJSON layer path instead of building an external-native runtime layer. Feature layers now render as first-class `type: "geojson"` vector layers with their attributes available, which unlocks labels (and their uppercase/offset/rotation formatting), the attribute table, identify, symbology, and export. Vector tile layers keep the external-native runtime path. The now-dead fallback helpers were removed.

## Verification

Reproduced and verified in the real app with Playwright using the ArcGIS "US major cities (feature)" sample:

- Before: the layer's badge was `arcgis` and the **Label field** dropdown was disabled ("No attributes found").
- After: the badge is `vector`, the Label field lists the real attributes (NAME, POPULATION, STATE_ABBR, …), labels render, and **UPPERCASE** + **90° rotation** visibly apply. Confirmed in both **light and dark** themes.

Added `tests/arcgis-feature-layer.test.ts` covering the GeoJSON conversion (attributes preserved, bounds fitted) and the non-GeoJSON error path. Full frontend suite (1608 tests), `npm run build`, and pre-commit all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ArcGIS FeatureServer feature layers are now loaded via a GeoJSON flow for consistent in-app rendering.
  * Optional map fitting is applied from the ArcGIS-provided layer extent.
* **Bug Fixes**
  * Added stricter handling/validation for ArcGIS `/query?f=geojson` responses, including clear errors for non-GeoJSON (e.g., HTML/token issues).
  * When results are truncated, the app warns and still loads partial data.
  * GeoJSON layer attribution is now preserved during synchronization for both clustered and non-clustered maps.
* **Tests**
  * Added coverage for success, invalid responses, truncation warnings, token behavior, and portal-item source resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->