### PR TITLE
feat(basemaps): add EOX Sentinel-2 cloudless satellite imagery

### DIFF
--- a/apps/geolibre-desktop/package.json
+++ b/apps/geolibre-desktop/package.json
@@ -58,7 +58,7 @@
     "mapillary-js": "^4.1.2",
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.3",
-    "maplibre-gl-basemap-control": "^0.8.0",
+    "maplibre-gl-basemap-control": "^0.9.0",
     "maplibre-gl-components": "^0.25.1",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "mapillary-js": "^4.1.2",
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.3",
-        "maplibre-gl-basemap-control": "^0.8.0",
+        "maplibre-gl-basemap-control": "^0.9.0",
         "maplibre-gl-components": "^0.25.1",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",
@@ -17378,9 +17378,9 @@
       "license": "MIT"
     },
     "node_modules/maplibre-gl-basemap-control": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl-basemap-control/-/maplibre-gl-basemap-control-0.8.0.tgz",
-      "integrity": "sha512-i0kbCmzktB4IrHRIIDCyXG6pKJxex3adp7uN5o71JUxA0KnKkbpGthKvkbMzx52+4zMHVcq9gylXUDNruDsQJA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl-basemap-control/-/maplibre-gl-basemap-control-0.9.0.tgz",
+      "integrity": "sha512-C5XRc+IVFrXP1AGEHu0JWYDho8sScgFVs4H6RyonT7ORywlb3bWnlfAHXHbNnKikcM3CCMdtvTDhTJ+txDr3zQ==",
       "license": "MIT",
       "peerDependencies": {
         "maplibre-gl": ">=3.0.0",
@@ -23799,7 +23799,7 @@
         "jspdf": "^4.2.1",
         "maplibre-gl": "^5.24.0",
         "maplibre-gl-3d-tiles": "^0.5.3",
-        "maplibre-gl-basemap-control": "^0.8.0",
+        "maplibre-gl-basemap-control": "^0.9.0",
         "maplibre-gl-components": "^0.25.1",
         "maplibre-gl-duckdb": "^0.2.3",
         "maplibre-gl-earth-engine": "^0.4.2",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -31,7 +31,7 @@
     "jspdf": "^4.2.1",
     "maplibre-gl": "^5.24.0",
     "maplibre-gl-3d-tiles": "^0.5.3",
-    "maplibre-gl-basemap-control": "^0.8.0",
+    "maplibre-gl-basemap-control": "^0.9.0",
     "maplibre-gl-components": "^0.25.1",
     "maplibre-gl-duckdb": "^0.2.3",
     "maplibre-gl-earth-engine": "^0.4.2",


### PR DESCRIPTION
## Summary

Adds the **EOX Sentinel-2 cloudless** satellite imagery basemap (and **EOX Terrain Light**) to the Basemaps plugin, as requested in #866.

These are free, non-commercial EOX Maps layers. Rather than wiring them into GeoLibre directly, they were added upstream in the `maplibre-gl-basemap-control` plugin (opengeos/maplibre-gl-basemap-control#22, released as v0.9.0), which the Basemaps plugin consumes. This PR simply bumps the dependency to `^0.9.0` in the two workspaces that declare it.

The new basemaps appear automatically in the Basemaps gallery under the **EOX** provider, and the required EOX / Copernicus attribution is added to the map's attribution control when a layer is loaded.

## Changes

- `maplibre-gl-basemap-control` `^0.8.0` → `^0.9.0` in `apps/geolibre-desktop/package.json` and `packages/plugins/package.json`, plus the lockfile update.

## Verification

- `npm run build` passes; `pre-commit` clean.
- Verified in the running web app (with the published 0.9.0 package): searching "EOX" in the Basemaps gallery shows both layers; selecting **EOX Sentinel-2 cloudless 2025** and **EOX Terrain Light** fetches tiles successfully (HTTP 200) and updates the attribution control. Confirmed in both light and dark themes.

Upstream: opengeos/maplibre-gl-basemap-control#22 (v0.9.0)

Fixes #866