### PR TITLE
fix(lidar): re-stream COPC point clouds when a saved project is reopened

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -18,6 +18,7 @@ import {
   restoreReverseGeocode,
   REVERSE_GEOCODE_PLUGIN_ID,
   restoreEffects,
+  restoreLidarLayers,
   restoreRasterLayers,
   restoreThreeDTilesLayers,
   restoreVectorLayers,
@@ -813,6 +814,11 @@ export function DesktopShell({
     restoreThreeDTilesLayers(appAPI);
     restoreRasterLayers(appAPI);
     restoreVectorLayers(appAPI);
+    // Re-stream saved LiDAR (COPC) point clouds. A `lidar-url` layer restores
+    // into the store as inert metadata; the point cloud is loaded by the LiDAR
+    // control, not the store, so without this the layer shows in the panel but
+    // renders nothing.
+    void restoreLidarLayers(appAPI);
     // Re-read drag-dropped / Add Data local-file GeoJSON layers from disk
     // (their data was saved as a path, not embedded).
     void restoreLocalFileLayers();

--- a/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
+++ b/apps/geolibre-desktop/src/components/layout/DesktopShell.tsx
@@ -818,7 +818,9 @@ export function DesktopShell({
     // into the store as inert metadata; the point cloud is loaded by the LiDAR
     // control, not the store, so without this the layer shows in the panel but
     // renders nothing.
-    void restoreLidarLayers(appAPI);
+    void restoreLidarLayers(appAPI).catch((error: unknown) => {
+      console.warn("[lidar] failed to restore saved point clouds", error);
+    });
     // Re-read drag-dropped / Add Data local-file GeoJSON layers from disk
     // (their data was saved as a path, not embedded).
     void restoreLocalFileLayers();

--- a/packages/plugins/src/index.ts
+++ b/packages/plugins/src/index.ts
@@ -86,6 +86,7 @@ export {
   openHtmlPanel,
   openLegendPanel,
   openLidarLayerPanel,
+  restoreLidarLayers,
   openMeasurePanel,
   openMinimapPanel,
   openPMTilesLayerPanel,

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -741,6 +741,26 @@ let stacSearchStoreUnsubscribe: (() => void) | null = null;
 let zarrStoreUnsubscribe: (() => void) | null = null;
 let lidarStoreUnsubscribe: (() => void) | null = null;
 let splattingStoreUnsubscribe: (() => void) | null = null;
+
+// Re-streaming saved LiDAR layers on project open. The store only holds a
+// `lidar-url` layer's metadata; the point cloud itself is loaded by the LiDAR
+// control, not the store, so a reopened project shows the layer in the panel
+// but renders nothing until we ask the control to stream it again (see
+// restoreLidarLayers). Because loadPointCloud assigns a fresh id, this map
+// carries the saved layer's desired state, keyed by source URL, so the load
+// handler can reattach the loaded cloud to the saved layer instead of adding a
+// duplicate.
+interface PendingLidarRestore {
+  layerId: string;
+  name: string;
+  visible: boolean;
+  opacity: number;
+  style: GeoLibreLayer["style"];
+  beforeLayerId: string | null;
+}
+const pendingLidarRestores = new Map<string, PendingLidarRestore>();
+let lidarRestoreInFlight = false;
+
 let pluginActive = false;
 let componentsControlRevision = 0;
 let componentsConstructorsPromise: Promise<ComponentsConstructors> | null =
@@ -2433,13 +2453,20 @@ async function openStandaloneHtmlControl(
 }
 
 async function openStandaloneLidarControl(
-  app: GeoLibreAppAPI
+  app: GeoLibreAppAPI,
+  options: { reveal?: boolean } = {}
 ): Promise<boolean> {
+  // `reveal` shows and expands the panel (the default, for the Add LiDAR Layer
+  // menu action). Project restore mounts the control only to re-stream saved
+  // clouds, so it passes `reveal: false` to keep the panel out of the user's
+  // way; a freshly created control is hidden so it does not pop open on load.
+  const reveal = options.reveal ?? true;
   const {
     LidarControl: LidarControlClass,
     LidarLayerAdapter: LidarLayerAdapterClass,
   } = await getComponentsConstructors();
 
+  const created = !lidarControl;
   lidarControl ??= createLidarControl(
     LidarControlClass,
     LidarLayerAdapterClass
@@ -2457,10 +2484,94 @@ async function openStandaloneLidarControl(
   startLidarThemeSync();
 
   setTimeout(() => {
-    showLidarControl(lidarControl);
-    lidarControl?.expand();
+    if (reveal) {
+      showLidarControl(lidarControl);
+      lidarControl?.expand();
+    } else if (created) {
+      hideLidarControl(lidarControl);
+    }
   }, 0);
   return true;
+}
+
+/**
+ * Read the source URL of a `lidar-url` layer, preferring the dedicated
+ * `sourcePath` and falling back to `source.url`.
+ */
+function lidarLayerUrl(layer: GeoLibreLayer): string | null {
+  if (typeof layer.sourcePath === "string" && layer.sourcePath) {
+    return layer.sourcePath;
+  }
+  const url = (layer.source as { url?: unknown }).url;
+  return typeof url === "string" && url ? url : null;
+}
+
+/** Whether a restore is already queued or in flight for this layer. */
+function isLidarRestorePending(layer: GeoLibreLayer): boolean {
+  const url = lidarLayerUrl(layer);
+  if (url && pendingLidarRestores.has(url)) return true;
+  for (const pending of pendingLidarRestores.values()) {
+    if (pending.layerId === layer.id) return true;
+  }
+  return false;
+}
+
+/**
+ * Re-stream the point clouds for any restored `lidar-url` layers that are not
+ * yet loaded into the LiDAR control (e.g. after opening a saved project). The
+ * store only holds the layer metadata, so without this the layer appears in the
+ * Layers panel but renders nothing. The loaded cloud is reattached to the saved
+ * layer in {@link createLidarLoadHandler}, preserving its visibility, opacity,
+ * style, name, and position.
+ */
+export async function restoreLidarLayers(app: GeoLibreAppAPI): Promise<void> {
+  if (lidarRestoreInFlight) return;
+
+  const pending = useAppStore
+    .getState()
+    .layers.filter(
+      (layer) =>
+        isLidarControlLayer(layer) &&
+        !hasLidarPointCloud(layer.id) &&
+        !isLidarRestorePending(layer)
+    );
+  if (pending.length === 0) return;
+
+  lidarRestoreInFlight = true;
+  try {
+    const opened = await openStandaloneLidarControl(app, { reveal: false });
+    if (!opened || !lidarControl) return;
+    // The deck.gl point-cloud overlay only renders under the Mercator
+    // projection (the streaming loader's viewport math breaks under the default
+    // globe), matching the USGS LiDAR plugin and the other deck.gl controls.
+    ensureMercatorProjection(app.getMap?.());
+
+    for (const layer of pending) {
+      const url = lidarLayerUrl(layer);
+      if (!url) continue;
+      // Re-check against the live store: a layer may have been removed, already
+      // loaded, or queued while the control was loading asynchronously.
+      const current = useAppStore.getState().layers;
+      const index = current.findIndex((item) => item.id === layer.id);
+      if (index === -1) continue;
+      if (hasLidarPointCloud(layer.id) || isLidarRestorePending(layer)) continue;
+
+      pendingLidarRestores.set(url, {
+        layerId: layer.id,
+        name: layer.name,
+        visible: layer.visible,
+        opacity: layer.opacity,
+        style: layer.style,
+        beforeLayerId: current[index + 1]?.id ?? null,
+      });
+      lidarControl.loadPointCloud(url).catch((error: unknown) => {
+        pendingLidarRestores.delete(url);
+        console.warn("[lidar] failed to restore point cloud", url, error);
+      });
+    }
+  } finally {
+    lidarRestoreInFlight = false;
+  }
 }
 
 async function openStandaloneSplattingControl(
@@ -3297,6 +3408,7 @@ function setHtmlPanelVisible(visible: boolean): void {
 
 function teardownLidarControl(app: GeoLibreAppAPI): void {
   stopLidarThemeSync();
+  pendingLidarRestores.clear();
   lidarStoreUnsubscribe?.();
   lidarStoreUnsubscribe = null;
   lidarLayerAdapter?.destroy();
@@ -3326,6 +3438,48 @@ function createLidarLoadHandler(): LidarControlEventHandler {
 
     const store = useAppStore.getState();
     const layer = createLidarStoreLayer(event.pointCloud);
+
+    // Project restore: this load was triggered to re-stream a saved layer (see
+    // restoreLidarLayers). loadPointCloud assigns a fresh id, so swap the inert
+    // placeholder (saved id) for the loaded layer in place, carrying over the
+    // saved visibility, opacity, style, name, and position.
+    const restoreKey =
+      typeof event.pointCloud.source === "string"
+        ? event.pointCloud.source
+        : null;
+    const restore = restoreKey ? pendingLidarRestores.get(restoreKey) : null;
+    if (restore) {
+      pendingLidarRestores.delete(restoreKey as string);
+      const restored: GeoLibreLayer = {
+        ...layer,
+        name: restore.name || layer.name,
+        visible: restore.visible,
+        opacity: restore.opacity,
+        style: restore.style,
+      };
+      if (
+        restore.layerId !== restored.id &&
+        store.layers.some((item) => item.id === restore.layerId)
+      ) {
+        store.removeLayer(restore.layerId);
+      }
+      const beforeLayerId =
+        restore.beforeLayerId &&
+        useAppStore
+          .getState()
+          .layers.some((item) => item.id === restore.beforeLayerId)
+          ? restore.beforeLayerId
+          : null;
+      store.addLayer(restored, beforeLayerId);
+      if (!restored.visible) {
+        lidarLayerAdapter?.setVisibility(restored.id, false);
+      }
+      if (restored.opacity !== 1) {
+        lidarLayerAdapter?.setOpacity(restored.id, restored.opacity);
+      }
+      return;
+    }
+
     if (store.layers.some((item) => item.id === layer.id)) {
       store.updateLayer(layer.id, {
         metadata: layer.metadata,

--- a/packages/plugins/src/plugins/maplibre-components.ts
+++ b/packages/plugins/src/plugins/maplibre-components.ts
@@ -746,19 +746,21 @@ let splattingStoreUnsubscribe: (() => void) | null = null;
 // `lidar-url` layer's metadata; the point cloud itself is loaded by the LiDAR
 // control, not the store, so a reopened project shows the layer in the panel
 // but renders nothing until we ask the control to stream it again (see
-// restoreLidarLayers). Because loadPointCloud assigns a fresh id, this map
-// carries the saved layer's desired state, keyed by source URL, so the load
-// handler can reattach the loaded cloud to the saved layer instead of adding a
-// duplicate.
+// restoreLidarLayers). Because loadPointCloud assigns a fresh id, each entry
+// carries the saved layer's desired state so the load handler can reattach the
+// loaded cloud to the saved layer instead of adding a duplicate. The map is
+// keyed by source URL and holds a FIFO queue per URL, so two saved layers that
+// point at the same COPC file both restore (one entry consumed per load event).
 interface PendingLidarRestore {
   layerId: string;
   name: string;
   visible: boolean;
   opacity: number;
   style: GeoLibreLayer["style"];
+  groupId: string | undefined;
   beforeLayerId: string | null;
 }
-const pendingLidarRestores = new Map<string, PendingLidarRestore>();
+const pendingLidarRestores = new Map<string, PendingLidarRestore[]>();
 let lidarRestoreInFlight = false;
 
 let pluginActive = false;
@@ -2506,12 +2508,10 @@ function lidarLayerUrl(layer: GeoLibreLayer): string | null {
   return typeof url === "string" && url ? url : null;
 }
 
-/** Whether a restore is already queued or in flight for this layer. */
+/** Whether a restore is already queued or in flight for this specific layer. */
 function isLidarRestorePending(layer: GeoLibreLayer): boolean {
-  const url = lidarLayerUrl(layer);
-  if (url && pendingLidarRestores.has(url)) return true;
-  for (const pending of pendingLidarRestores.values()) {
-    if (pending.layerId === layer.id) return true;
+  for (const queue of pendingLidarRestores.values()) {
+    if (queue.some((pending) => pending.layerId === layer.id)) return true;
   }
   return false;
 }
@@ -2556,16 +2556,27 @@ export async function restoreLidarLayers(app: GeoLibreAppAPI): Promise<void> {
       if (index === -1) continue;
       if (hasLidarPointCloud(layer.id) || isLidarRestorePending(layer)) continue;
 
-      pendingLidarRestores.set(url, {
+      const entry: PendingLidarRestore = {
         layerId: layer.id,
         name: layer.name,
         visible: layer.visible,
         opacity: layer.opacity,
         style: layer.style,
+        groupId: layer.groupId,
         beforeLayerId: current[index + 1]?.id ?? null,
-      });
+      };
+      const queue = pendingLidarRestores.get(url);
+      if (queue) queue.push(entry);
+      else pendingLidarRestores.set(url, [entry]);
       lidarControl.loadPointCloud(url).catch((error: unknown) => {
-        pendingLidarRestores.delete(url);
+        // Drop only this layer's entry so a sibling restore for the same URL is
+        // not lost; clean up the map key once its queue empties.
+        const remaining = pendingLidarRestores.get(url);
+        if (remaining) {
+          const at = remaining.indexOf(entry);
+          if (at !== -1) remaining.splice(at, 1);
+          if (remaining.length === 0) pendingLidarRestores.delete(url);
+        }
         console.warn("[lidar] failed to restore point cloud", url, error);
       });
     }
@@ -3408,7 +3419,10 @@ function setHtmlPanelVisible(visible: boolean): void {
 
 function teardownLidarControl(app: GeoLibreAppAPI): void {
   stopLidarThemeSync();
+  // Clear restore bookkeeping so a teardown mid-restore (project reload, map
+  // re-init) cannot strand the in-flight guard and block later restores.
   pendingLidarRestores.clear();
+  lidarRestoreInFlight = false;
   lidarStoreUnsubscribe?.();
   lidarStoreUnsubscribe = null;
   lidarLayerAdapter?.destroy();
@@ -3447,15 +3461,21 @@ function createLidarLoadHandler(): LidarControlEventHandler {
       typeof event.pointCloud.source === "string"
         ? event.pointCloud.source
         : null;
-    const restore = restoreKey ? pendingLidarRestores.get(restoreKey) : null;
-    if (restore) {
-      pendingLidarRestores.delete(restoreKey as string);
+    const restoreQueue = restoreKey
+      ? pendingLidarRestores.get(restoreKey)
+      : undefined;
+    const restore = restoreQueue?.shift();
+    if (restore && restoreKey) {
+      if (restoreQueue && restoreQueue.length === 0) {
+        pendingLidarRestores.delete(restoreKey);
+      }
       const restored: GeoLibreLayer = {
         ...layer,
         name: restore.name || layer.name,
         visible: restore.visible,
         opacity: restore.opacity,
         style: restore.style,
+        ...(restore.groupId ? { groupId: restore.groupId } : {}),
       };
       if (
         restore.layerId !== restored.id &&


### PR DESCRIPTION
## Problem

Reopening a saved project that contains a LiDAR (COPC) layer shows the layer in the Layers panel but renders **nothing** on the map. Reported in #870.

Root cause: a `lidar-url` layer is restored into the store as inert metadata. The point cloud is streamed by the LiDAR control (`loadPointCloud`), not by the store layer sync, and there was no code path that re-streamed a restored layer. GeoLibre never called `loadPointCloud` outside the LiDAR panel's own UI, so a reopened project's point cloud was never fetched. (Verified in the real app: the layer is present, but no COPC request is issued and nothing renders, even for a CORS-friendly source.)

## Fix

Add `restoreLidarLayers`, invoked from the same project-restore effect in `DesktopShell` that already re-runs `restoreRasterLayers` / `restoreVectorLayers` / `restoreThreeDTilesLayers` (gated on `projectGeneration` / `mapReadyGeneration`):

- Finds `lidar-url` layers that are in the store but not yet loaded into the control, mounts the LiDAR control **hidden** (`reveal: false`, so the panel does not pop open), forces the Mercator projection the deck.gl point-cloud overlay needs (matching the USGS LiDAR plugin and the other deck.gl controls), and streams each one.
- Because `loadPointCloud` assigns a fresh id, the load handler reattaches the loaded cloud to the saved layer **in place**, preserving its visibility, opacity, style, name, and position instead of adding a duplicate.

## Verification

Drove the real app with Playwright using a saved project that references the Autzen sample COPC:

- Before: layer present in the panel, point cloud not rendered.
- After: point cloud streams and renders on reopen, in both **light and dark** themes, with the existing visibility/opacity sync intact (single layer entry, no duplicate).
- `npm run build`, `npm run test:frontend` (1612 pass), eslint, and pre-commit all green.

Fixes #870

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Restored projects now automatically reload saved LiDAR point clouds after reopening, bringing LiDAR content back without manual reconfiguration.
  * LiDAR layer properties (name, visibility, opacity, style, grouping, and order) are preserved during restore.

* **Bug Fixes**
  * Fixed LiDAR layers returning as metadata-only placeholders instead of fully restored point clouds.
  * Restoration now coordinates with plugin readiness to reliably reattach loaded LiDAR content and safely logs any restore issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->