### PR TITLE
fix(record-tour): make the Record Map Tour close button work (#876)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/RecordTourDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/RecordTourDialog.tsx
@@ -98,11 +98,11 @@ export function RecordTourDialog({
   const recording = status !== "idle";
 
   const onDragStart = (event: React.PointerEvent) => {
-    // The close button lives inside this drag handle. Starting a drag here
-    // captures the pointer, which would redirect the ensuing click away from
-    // the button and swallow it, so never begin a drag from an interactive
-    // control.
-    if ((event.target as HTMLElement).closest("button")) return;
+    // Starting a drag captures the pointer, which would redirect the ensuing
+    // click away from the close button and swallow it, so never begin a drag
+    // from an interactive control. (event.target may be the SVG icon inside the
+    // button, so cast to the Element ancestor type rather than HTMLElement.)
+    if ((event.target as Element).closest("button, a, [role='button']")) return;
     const rect = panelRef.current?.getBoundingClientRect();
     if (!rect) return;
     dragOffset.current = { x: event.clientX - rect.left, y: event.clientY - rect.top };

--- a/apps/geolibre-desktop/src/components/layout/RecordTourDialog.tsx
+++ b/apps/geolibre-desktop/src/components/layout/RecordTourDialog.tsx
@@ -98,6 +98,11 @@ export function RecordTourDialog({
   const recording = status !== "idle";
 
   const onDragStart = (event: React.PointerEvent) => {
+    // The close button lives inside this drag handle. Starting a drag here
+    // captures the pointer, which would redirect the ensuing click away from
+    // the button and swallow it, so never begin a drag from an interactive
+    // control.
+    if ((event.target as HTMLElement).closest("button")) return;
     const rect = panelRef.current?.getBoundingClientRect();
     if (!rect) return;
     dragOffset.current = { x: event.clientX - rect.left, y: event.clientY - rect.top };


### PR DESCRIPTION
## Summary

The close (X) button in the **Record Map Tour** panel did nothing, so users could not exit the recording window (#876).

## Root cause

The close button lives inside the panel's drag-handle title bar. That title bar has an `onPointerDown` handler that begins a drag and calls `setPointerCapture(pointerId)`. Pressing the X bubbled the `pointerdown` up to the title bar, which captured the pointer; with the pointer captured by the title bar, the subsequent `click` was dispatched to the title bar `div` instead of the button, so the button's `onClick` never fired and the panel stayed open.

## Fix

Bail out of `onDragStart` when the pointer goes down on an interactive control (the close button), so no pointer capture happens and the click reaches the button normally. Dragging the panel by the grip/title still works.

## Verification

Reproduced and verified in the real app with Playwright:

- Before: clicking Close left the dialog open.
- After: clicking Close closes the dialog, in both **light and dark** themes (real pointer click, not a synthetic `.click()`).
- Dragging the panel by the title bar still repositions it.
- `pre-commit run --files ...` passes (eslint + full npm build).

Fixes #876


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dialog drag behavior so clicking interactive controls inside the drag handle no longer starts a drag.
  * Fixed an issue where button clicks in the dialog header could be blocked, making controls like close buttons respond reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->