### PR TITLE
fix(toolbar): make the top menu bar horizontally scrollable on tablets

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -871,10 +871,7 @@ export function TopToolbar({
         "flex min-h-11 min-w-0 shrink-0 items-center gap-1 border-b bg-card py-1",
         compact
           ? "flex-nowrap overflow-x-auto px-1.5"
-          : // Below md the menus wrap to keep every item reachable; at md and
-            // above we switch to a single non-wrapping row and let it scroll
-            // horizontally so tablets/landscape phones can still reach the
-            // menus that overflow the viewport (e.g. Help, Settings) (#871).
+          : // Wrap below md; scroll a single row at md+ so tablets reach every menu (#871).
             "flex-wrap px-2 md:flex-nowrap md:overflow-x-auto",
       )}
     >

--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -871,7 +871,11 @@ export function TopToolbar({
         "flex min-h-11 min-w-0 shrink-0 items-center gap-1 border-b bg-card py-1",
         compact
           ? "flex-nowrap overflow-x-auto px-1.5"
-          : "flex-wrap px-2 md:flex-nowrap",
+          : // Below md the menus wrap to keep every item reachable; at md and
+            // above we switch to a single non-wrapping row and let it scroll
+            // horizontally so tablets/landscape phones can still reach the
+            // menus that overflow the viewport (e.g. Help, Settings) (#871).
+            "flex-wrap px-2 md:flex-nowrap md:overflow-x-auto",
       )}
     >
       <span className="mr-1 flex shrink-0 items-center gap-1.5 text-sm font-semibold text-primary md:mr-2">


### PR DESCRIPTION
## Summary

On iPad and landscape phones the top menu bar ran off the right edge of the screen with no way to reach the menus that overflowed (Settings, Help, the theme toggle, the project name). At the `md` breakpoint and above the toolbar switched to a single non-wrapping row (`md:flex-nowrap`) with no overflow handling, so any items past the viewport edge were simply clipped and unreachable.

This adds `md:overflow-x-auto` so the toolbar scrolls horizontally when its items do not fit, keeping every menu reachable. Behavior is unchanged elsewhere:

- Below `md` the toolbar still wraps to multiple rows as before.
- On a wide desktop where everything fits, there is no scrollbar and the project name still sits pinned to the far right.
- Compact/embed mode already scrolled horizontally and is untouched.

The branding (map icon + "GeoLibre" text) is kept per the maintainer's decision in the issue thread; this change keeps it while ensuring the rest of the menus stay accessible on small screens.

## Verification

Drove the real app in a browser with Playwright in both light and dark themes:

- At 800px wide the toolbar previously clipped Settings/Help with no scroll; after the fix the row scrolls horizontally (`scrollWidth` 1168 > `clientWidth` 800) and Settings, Help, the theme toggle, and the project name are all reachable.
- At 1440px wide the header fits exactly (`scrollWidth == clientWidth`, not scrollable) and the desktop layout is unchanged.

`pre-commit run --files` (including the full npm build) passes.

Fixes #871

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the top toolbar layout on larger screens so overflowing menu items can scroll horizontally instead of being cut off or wrapping awkwardly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->