### PR TITLE
fix(project): reload file-referenced local layers on reopen (#880)

### DIFF
--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -212,6 +212,8 @@ fn read_project_file(path: String) -> Result<String, String> {
 /// Local vector file extensions the restore path may re-read (lowercased, no
 /// dot). Mirrors `VECTOR_FILE_DIALOG_EXTENSIONS` in `tauri-io.ts`; keep the two
 /// in step.
+// SYNC: VECTOR_FILE_DIALOG_EXTENSIONS in src/lib/tauri-io.ts — grep "SYNC:" to
+// find the partner list and update both together.
 const RESTORABLE_VECTOR_EXTENSIONS: [&str; 17] = [
     "geojson",
     "json",

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -181,6 +181,7 @@ pub fn run() {
             install_external_plugin_archive,
             load_external_plugin_bundles,
             read_admin_profile,
+            read_local_file,
             read_project_file,
             read_shapefile_siblings,
             resolve_url_redirect,
@@ -206,6 +207,25 @@ pub fn run() {
 #[tauri::command]
 fn read_project_file(path: String) -> Result<String, String> {
     fs::read_to_string(&path).map_err(|error| format!("Could not read project file: {error}"))
+}
+
+/// Read a local file's raw bytes so a project's file-referenced vector layers
+/// can be re-read when the project is reopened.
+///
+/// On reopen, a layer saved as a file reference carries only its absolute
+/// `sourcePath` (stored in the `.geolibre.json`); that path was never picked or
+/// dropped this session, so it sits outside the `fs` plugin's runtime scope and
+/// the JS `readFile`/`readTextFile` reject it. This reads the file directly,
+/// mirroring `read_project_file` (which bypasses the same scope to read the
+/// project file itself). The frontend guards the path (absolute, no `..`
+/// traversal, known vector extension) before calling. Bytes are returned as a
+/// raw IPC response (an `ArrayBuffer` on the JS side) so a large GeoJSON does
+/// not pay the cost of a JSON number array.
+#[tauri::command]
+fn read_local_file(path: String) -> Result<tauri::ipc::Response, String> {
+    fs::read(&path)
+        .map(tauri::ipc::Response::new)
+        .map_err(|error| format!("Could not read local file: {error}"))
 }
 
 /// Shapefile sidecar extensions read alongside a `.shp` (lowercased, no dot).

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -209,6 +209,66 @@ fn read_project_file(path: String) -> Result<String, String> {
     fs::read_to_string(&path).map_err(|error| format!("Could not read project file: {error}"))
 }
 
+/// Local vector file extensions the restore path may re-read (lowercased, no
+/// dot). Mirrors `VECTOR_FILE_DIALOG_EXTENSIONS` in `tauri-io.ts`; keep the two
+/// in step.
+const RESTORABLE_VECTOR_EXTENSIONS: [&str; 17] = [
+    "geojson",
+    "json",
+    "gpkg",
+    "geoparquet",
+    "parquet",
+    "fgb",
+    "flatgeobuf",
+    "csv",
+    "tsv",
+    "kml",
+    "kmz",
+    "gml",
+    "gpx",
+    "dxf",
+    "tab",
+    "shp",
+    "zip",
+];
+
+/// Whether the renderer is permitted to re-read `path` through `read_local_file`:
+/// an absolute local path (POSIX `/...` or a Windows drive-letter `C:\...`, never
+/// a UNC `\\host\share`), free of `..` traversal segments, ending in a known
+/// vector extension.
+///
+/// This is a Rust-side backstop mirroring the frontend guard
+/// (`isAbsoluteLocalPath` + `hasPathTraversal` + `isRestorableVectorPath` in
+/// `tauri-io.ts`), so a compromised webview or rogue plugin cannot use the
+/// command to read arbitrary user-readable files. The checks are byte-oriented
+/// rather than `std::path` based so they behave identically for the Windows-style
+/// paths a project may carry regardless of the host the binary runs on.
+fn is_allowed_local_vector_path(path: &str) -> bool {
+    // Absolute local path only. UNC paths ("\\server\share") are rejected:
+    // reading one can make Windows auto-authenticate against a remote host.
+    let bytes = path.as_bytes();
+    let is_posix_absolute = path.starts_with('/');
+    let is_windows_drive = bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && (bytes[2] == b'\\' || bytes[2] == b'/');
+    if !is_posix_absolute && !is_windows_drive {
+        return false;
+    }
+
+    // Reject a "/../" or "\..\" traversal segment (but not a ".." inside a
+    // filename like "v1..2.gpkg"), matching `hasPathTraversal`.
+    if path.split(['/', '\\']).any(|segment| segment == "..") {
+        return false;
+    }
+
+    // Known vector extension, case-insensitive, matching `RESTORABLE_VECTOR_PATH`.
+    let lower = path.to_ascii_lowercase();
+    RESTORABLE_VECTOR_EXTENSIONS
+        .iter()
+        .any(|extension| lower.ends_with(&format!(".{extension}")))
+}
+
 /// Read a local file's raw bytes so a project's file-referenced vector layers
 /// can be re-read when the project is reopened.
 ///
@@ -217,12 +277,19 @@ fn read_project_file(path: String) -> Result<String, String> {
 /// dropped this session, so it sits outside the `fs` plugin's runtime scope and
 /// the JS `readFile`/`readTextFile` reject it. This reads the file directly,
 /// mirroring `read_project_file` (which bypasses the same scope to read the
-/// project file itself). The frontend guards the path (absolute, no `..`
-/// traversal, known vector extension) before calling. Bytes are returned as a
-/// raw IPC response (an `ArrayBuffer` on the JS side) so a large GeoJSON does
-/// not pay the cost of a JSON number array.
+/// project file itself). The path is validated here by
+/// `is_allowed_local_vector_path` (absolute, no `..` traversal, known vector
+/// extension) so the command cannot be abused to read arbitrary files even if
+/// the frontend guard is bypassed. Bytes are returned as a raw IPC response (an
+/// `ArrayBuffer` on the JS side) so a large GeoJSON does not pay the cost of a
+/// JSON number array.
 #[tauri::command]
 fn read_local_file(path: String) -> Result<tauri::ipc::Response, String> {
+    if !is_allowed_local_vector_path(&path) {
+        return Err(format!(
+            "Refusing to read \"{path}\": not an absolute local vector file path"
+        ));
+    }
     fs::read(&path)
         .map(tauri::ipc::Response::new)
         .map_err(|error| format!("Could not read local file: {error}"))
@@ -451,7 +518,11 @@ fn plugin_archive_file_name(id: &str) -> String {
         })
         .collect();
     let trimmed = sanitized.trim_start_matches('.');
-    let safe = if trimmed.is_empty() { "plugin" } else { trimmed };
+    let safe = if trimmed.is_empty() {
+        "plugin"
+    } else {
+        trimmed
+    };
     format!("{safe}.zip")
 }
 
@@ -647,9 +718,7 @@ fn load_external_plugin_archive(
 /// root `plugin.json`, otherwise returns the shallowest `*/plugin.json`, ignoring
 /// the `__MACOSX/` metadata folder macOS adds to archives. Returns the manifest's
 /// full path within the archive, or None when no plugin.json is present.
-fn find_zip_manifest_path<R: Read + std::io::Seek>(
-    archive: &zip::ZipArchive<R>,
-) -> Option<String> {
+fn find_zip_manifest_path<R: Read + std::io::Seek>(archive: &zip::ZipArchive<R>) -> Option<String> {
     let names: Vec<&str> = archive.file_names().collect();
     if names.iter().any(|name| *name == "plugin.json") {
         return Some("plugin.json".to_string());
@@ -1229,9 +1298,7 @@ fn start_jupyter_server_blocking(app: tauri::AppHandle) -> Result<JupyterServerI
     let welcome_dest = notebooks_dir.join("Welcome.ipynb");
     if !welcome_dest.exists() {
         let _ = fs::copy(
-            project_dir
-                .join("notebook_examples")
-                .join("Welcome.ipynb"),
+            project_dir.join("notebook_examples").join("Welcome.ipynb"),
             &welcome_dest,
         );
     }
@@ -1674,8 +1741,7 @@ fn is_geolibre_jupyter_process(pid: i32) -> bool {
         return false;
     };
     let command_line = String::from_utf8_lossy(&command_line);
-    command_line.contains("jupyter_server_config.py")
-        && command_line.contains("geolibre_server")
+    command_line.contains("jupyter_server_config.py") && command_line.contains("geolibre_server")
 }
 
 #[cfg(unix)]
@@ -2402,13 +2468,41 @@ fn configure_linux_webkit() {}
 
 #[cfg(test)]
 mod tests {
-    use super::{find_zip_manifest_path, plugin_archive_file_name};
+    use super::{find_zip_manifest_path, is_allowed_local_vector_path, plugin_archive_file_name};
     use std::io::{Cursor, Write};
+
+    #[test]
+    fn allows_absolute_vector_paths() {
+        assert!(is_allowed_local_vector_path("/home/u/cities.geojson"));
+        assert!(is_allowed_local_vector_path(
+            "C:\\Users\\smith\\Mile_Markers.geojson"
+        ));
+        assert!(is_allowed_local_vector_path("C:/data/roads.gpkg"));
+        // Case-insensitive extension; a ".." inside the filename is fine.
+        assert!(is_allowed_local_vector_path("/data/v1..2.SHP"));
+    }
+
+    #[test]
+    fn rejects_non_vector_relative_or_traversal_paths() {
+        // Non-vector extension.
+        assert!(!is_allowed_local_vector_path("/etc/passwd"));
+        // Relative path.
+        assert!(!is_allowed_local_vector_path("cities.geojson"));
+        // Directory traversal segments.
+        assert!(!is_allowed_local_vector_path("/data/../etc/secret.geojson"));
+        assert!(!is_allowed_local_vector_path(
+            "C:\\data\\..\\secret.geojson"
+        ));
+        // UNC network path.
+        assert!(!is_allowed_local_vector_path(
+            "\\\\server\\share\\x.geojson"
+        ));
+    }
 
     fn zip_with_names(names: &[&str]) -> Vec<u8> {
         let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
-        let options =
-            zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+        let options = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Stored);
         for name in names {
             writer.start_file(*name, options).unwrap();
             writer.write_all(b"x").unwrap();

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -244,14 +244,24 @@ const RESTORABLE_VECTOR_EXTENSIONS: [&str; 17] = [
 /// rather than `std::path` based so they behave identically for the Windows-style
 /// paths a project may carry regardless of the host the binary runs on.
 fn is_allowed_local_vector_path(path: &str) -> bool {
-    // Absolute local path only. UNC paths ("\\server\share") are rejected:
-    // reading one can make Windows auto-authenticate against a remote host.
     let bytes = path.as_bytes();
-    let is_posix_absolute = path.starts_with('/');
+    let is_separator = |byte: u8| byte == b'/' || byte == b'\\';
+
+    // Reject UNC paths first. Both the Windows form ("\\server\share") and the
+    // forward-slash form ("//server/share") start with two separators and can
+    // make Windows auto-authenticate against a remote host, so neither may slip
+    // through the POSIX-absolute check below.
+    if bytes.len() >= 2 && is_separator(bytes[0]) && is_separator(bytes[1]) {
+        return false;
+    }
+
+    // Absolute local path only: POSIX "/..." or a Windows drive-letter "C:\..."
+    // / "C:/...".
+    let is_posix_absolute = bytes.first() == Some(&b'/');
     let is_windows_drive = bytes.len() >= 3
         && bytes[0].is_ascii_alphabetic()
         && bytes[1] == b':'
-        && (bytes[2] == b'\\' || bytes[2] == b'/');
+        && is_separator(bytes[2]);
     if !is_posix_absolute && !is_windows_drive {
         return false;
     }
@@ -263,10 +273,11 @@ fn is_allowed_local_vector_path(path: &str) -> bool {
     }
 
     // Known vector extension, case-insensitive, matching `RESTORABLE_VECTOR_PATH`.
+    // `rsplit_once` takes the text after the final dot without allocating.
     let lower = path.to_ascii_lowercase();
-    RESTORABLE_VECTOR_EXTENSIONS
-        .iter()
-        .any(|extension| lower.ends_with(&format!(".{extension}")))
+    lower
+        .rsplit_once('.')
+        .is_some_and(|(_, extension)| RESTORABLE_VECTOR_EXTENSIONS.contains(&extension))
 }
 
 /// Read a local file's raw bytes so a project's file-referenced vector layers
@@ -2493,10 +2504,11 @@ mod tests {
         assert!(!is_allowed_local_vector_path(
             "C:\\data\\..\\secret.geojson"
         ));
-        // UNC network path.
+        // UNC network paths, both the backslash and forward-slash forms.
         assert!(!is_allowed_local_vector_path(
             "\\\\server\\share\\x.geojson"
         ));
+        assert!(!is_allowed_local_vector_path("//server/share/x.geojson"));
     }
 
     fn zip_with_names(names: &[&str]) -> Vec<u8> {

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -2515,6 +2515,11 @@ mod tests {
             "\\\\server\\share\\x.geojson"
         ));
         assert!(!is_allowed_local_vector_path("//server/share/x.geojson"));
+        // Empty string is not an absolute path.
+        assert!(!is_allowed_local_vector_path(""));
+        // No extension, and a trailing dot (empty extension).
+        assert!(!is_allowed_local_vector_path("/home/user/noextension"));
+        assert!(!is_allowed_local_vector_path("/home/user/file."));
     }
 
     fn zip_with_names(names: &[&str]) -> Vec<u8> {

--- a/apps/geolibre-desktop/src-tauri/src/lib.rs
+++ b/apps/geolibre-desktop/src-tauri/src/lib.rs
@@ -239,10 +239,15 @@ const RESTORABLE_VECTOR_EXTENSIONS: [&str; 17] = [
 ///
 /// This is a Rust-side backstop mirroring the frontend guard
 /// (`isAbsoluteLocalPath` + `hasPathTraversal` + `isRestorableVectorPath` in
-/// `tauri-io.ts`), so a compromised webview or rogue plugin cannot use the
-/// command to read arbitrary user-readable files. The checks are byte-oriented
-/// rather than `std::path` based so they behave identically for the Windows-style
-/// paths a project may carry regardless of the host the binary runs on.
+/// `tauri-io.ts`). It narrows the attack surface of a compromised webview or
+/// rogue plugin: arbitrary system files (`/etc/passwd`, SSH keys, most shell and
+/// app configs) are blocked. It does not make the command harmless — the
+/// allowlist still includes broad extensions like `json`, so a script that knows
+/// the path of a JSON-shaped secret could still read it — but it bounds reads to
+/// the vector formats the restore path actually needs. The checks are
+/// byte-oriented rather than `std::path` based so they behave identically for the
+/// Windows-style paths a project may carry regardless of the host the binary
+/// runs on.
 fn is_allowed_local_vector_path(path: &str) -> bool {
     let bytes = path.as_bytes();
     let is_separator = |byte: u8| byte == b'/' || byte == b'\\';
@@ -272,7 +277,8 @@ fn is_allowed_local_vector_path(path: &str) -> bool {
         return false;
     }
 
-    // Known vector extension, case-insensitive, matching `RESTORABLE_VECTOR_PATH`.
+    // Known vector extension, case-insensitive, matching the JS
+    // `RESTORABLE_VECTOR_PATH` regex (built from `VECTOR_FILE_DIALOG_EXTENSIONS`).
     // `rsplit_once` takes the text after the final dot without allocating.
     let lower = path.to_ascii_lowercase();
     lower

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -288,9 +288,18 @@ async function parseGeoJsonText(text: string): Promise<FeatureCollection> {
  * When a project is reopened, its file-referenced layer paths come from the
  * saved `.geolibre.json` rather than from a picker or drag-drop, so they sit
  * outside the `fs` plugin's runtime scope and `readFile` rejects them. The
- * command reads the file directly (the caller has already guarded the path), so
- * a referenced layer reloads after a fresh launch instead of failing with a
- * misleading "Could not convert this vector file with DuckDB-WASM" error.
+ * command reads the file directly, so a referenced layer reloads after a fresh
+ * launch instead of failing with a misleading "Could not convert this vector
+ * file with DuckDB-WASM" error.
+ *
+ * The fall-through is deliberately broad: it covers every `readFile` rejection,
+ * not just scope denials. The fs plugin does not expose a stable discriminant
+ * for an out-of-scope path (only a message we would have to substring-match, and
+ * a wrong guess would silently re-break the reload this fixes), so narrowing is
+ * not worth the fragility. The cost is one extra IPC round-trip on a genuine
+ * read failure (e.g. a moved file), where `read_local_file` fails too and its
+ * error surfaces instead of the plugin's. The command validates the path on the
+ * Rust side, so routing the read through it cannot widen what is readable.
  *
  * @param path - Absolute local path to read.
  * @returns The file's raw bytes.
@@ -310,7 +319,8 @@ async function readLocalFileBytes(
 /**
  * Text counterpart to {@link readLocalFileBytes}: read a local file as UTF-8,
  * falling back to the `read_local_file` Tauri command when the `fs` plugin
- * denies the path (e.g. a project-referenced layer after a fresh launch).
+ * denies the path (e.g. a project-referenced layer after a fresh launch). See
+ * {@link readLocalFileBytes} for why the fall-through catches every rejection.
  *
  * @param path - Absolute local path to read.
  * @returns The file's decoded UTF-8 text.

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -120,6 +120,10 @@ interface SaveTextFileOptions {
 interface SaveBinaryFileOptions extends SaveTextFileOptions {}
 
 const SHAPEFILE_SIDECAR_EXTENSIONS = ["dbf", "shx", "prj", "cpg"];
+// SYNC: RESTORABLE_VECTOR_EXTENSIONS in src-tauri/src/lib.rs must list the same
+// extensions, or a format added here would be rejected by the Rust restore
+// guard on every project reopen (the bug this PR fixes). Grep "SYNC:" to find
+// the partner list.
 const VECTOR_FILE_DIALOG_EXTENSIONS = [
   "geojson",
   "json",
@@ -343,7 +347,10 @@ async function readLocalFileText(path: string): Promise<string> {
       error,
     );
     const buffer = await invoke<ArrayBuffer>("read_local_file", { path });
-    return new TextDecoder().decode(buffer);
+    // `fatal: true` matches `readTextFile`, which rejects on malformed UTF-8
+    // rather than silently substituting U+FFFD: a corrupt KML/GPX/GeoJSON
+    // should surface a clear read error, not parse as garbled-but-valid text.
+    return new TextDecoder("utf-8", { fatal: true }).decode(buffer);
   }
 }
 
@@ -1606,7 +1613,10 @@ export async function loadDroppedVectorPaths(
       try {
         layers.push(...parseGpxTextLayers(await readLocalFileText(path), path));
       } catch (error) {
-        const detail = error instanceof Error ? error.message : "Unknown error";
+        // `read_local_file` rejects with a plain string, not an `Error`, so
+        // fall back to `String(error)` to keep that detail instead of a generic
+        // "Unknown error" when the fs-plugin fallback fails.
+        const detail = error instanceof Error ? error.message : String(error);
         throw new Error(`Could not read this GPX file. ${detail}`);
       }
       continue;

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -281,6 +281,50 @@ async function parseGeoJsonText(text: string): Promise<FeatureCollection> {
   return assertFeatureCollection(JSON.parse(text));
 }
 
+/**
+ * Read a local file's bytes, falling back to the `read_local_file` Tauri command
+ * when the JS `fs` plugin denies the path.
+ *
+ * When a project is reopened, its file-referenced layer paths come from the
+ * saved `.geolibre.json` rather than from a picker or drag-drop, so they sit
+ * outside the `fs` plugin's runtime scope and `readFile` rejects them. The
+ * command reads the file directly (the caller has already guarded the path), so
+ * a referenced layer reloads after a fresh launch instead of failing with a
+ * misleading "Could not convert this vector file with DuckDB-WASM" error.
+ *
+ * @param path - Absolute local path to read.
+ * @returns The file's raw bytes.
+ */
+async function readLocalFileBytes(
+  path: string,
+): Promise<Uint8Array<ArrayBuffer>> {
+  try {
+    return await readFile(path);
+  } catch (error) {
+    if (!isTauri()) throw error;
+    const buffer = await invoke<ArrayBuffer>("read_local_file", { path });
+    return new Uint8Array(buffer);
+  }
+}
+
+/**
+ * Text counterpart to {@link readLocalFileBytes}: read a local file as UTF-8,
+ * falling back to the `read_local_file` Tauri command when the `fs` plugin
+ * denies the path (e.g. a project-referenced layer after a fresh launch).
+ *
+ * @param path - Absolute local path to read.
+ * @returns The file's decoded UTF-8 text.
+ */
+async function readLocalFileText(path: string): Promise<string> {
+  try {
+    return await readTextFile(path);
+  } catch (error) {
+    if (!isTauri()) throw error;
+    const buffer = await invoke<ArrayBuffer>("read_local_file", { path });
+    return new TextDecoder().decode(buffer);
+  }
+}
+
 function parseGpxText(text: string): FeatureCollection {
   const result = parseGpxLayer(text);
   return mergeFeatureCollections([
@@ -723,7 +767,7 @@ async function loadTauriVectorFile(
   if (extension === "geojson" || extension === "json") {
     try {
       return {
-        data: await parseGeoJsonText(await readTextFile(path)),
+        data: await parseGeoJsonText(await readLocalFileText(path)),
         path,
       };
     } catch {
@@ -735,7 +779,7 @@ async function loadTauriVectorFile(
   if (extension === "zip") {
     try {
       return {
-        data: await parseShapefileZip(await readFile(path)),
+        data: await parseShapefileZip(await readLocalFileBytes(path)),
         path,
       };
     } catch {
@@ -746,7 +790,7 @@ async function loadTauriVectorFile(
   if (extension === "kmz") {
     try {
       return {
-        data: await parseKmz(await readFile(path), options),
+        data: await parseKmz(await readLocalFileBytes(path), options),
         path,
       };
     } catch (error) {
@@ -759,7 +803,7 @@ async function loadTauriVectorFile(
   if (extension === "kml") {
     try {
       return {
-        data: parseKmlText(await readTextFile(path)),
+        data: parseKmlText(await readLocalFileText(path)),
         path,
       };
     } catch {
@@ -770,7 +814,7 @@ async function loadTauriVectorFile(
   if (extension === "gpx") {
     try {
       return {
-        data: parseGpxText(await readTextFile(path)),
+        data: parseGpxText(await readLocalFileText(path)),
         path,
       };
     } catch (error) {
@@ -780,7 +824,7 @@ async function loadTauriVectorFile(
   }
 
   if (isDelimitedTextFileName(path)) {
-    const points = parseDelimitedTextFile(await readTextFile(path), path);
+    const points = parseDelimitedTextFile(await readLocalFileText(path), path);
     // No lon/lat columns: fall through to DuckDB so spatial CSV variants
     // (e.g. a WKT geometry column) still load.
     if (points) {
@@ -796,7 +840,7 @@ async function loadTauriVectorFile(
         {
           name: browserSafeFileName(path),
           extension,
-          data: await readFile(path),
+          data: await readLocalFileBytes(path),
           siblingFiles,
         },
         options,
@@ -1535,7 +1579,7 @@ export async function loadDroppedVectorPaths(
     if (SHAPEFILE_SIDECAR_EXTENSIONS.includes(extension)) continue;
     if (extension === "gpx") {
       try {
-        layers.push(...parseGpxTextLayers(await readTextFile(path), path));
+        layers.push(...parseGpxTextLayers(await readLocalFileText(path), path));
       } catch (error) {
         const detail = error instanceof Error ? error.message : "Unknown error";
         throw new Error(`Could not read this GPX file. ${detail}`);

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -751,8 +751,11 @@ export async function readVectorFileWithSidecars(
     return null;
   }
   try {
+    // Use the scope-tolerant reader: a project-reopened path was never picked
+    // or dropped this session, so the `fs` plugin scope rejects it and a raw
+    // `readFile` would throw — silently dropping the vector-control layer.
     const file = new File(
-      [toArrayBuffer(await readFile(path))],
+      [toArrayBuffer(await readLocalFileBytes(path))],
       browserSafeFileName(path),
     );
     const companionFiles =

--- a/apps/geolibre-desktop/src/lib/tauri-io.ts
+++ b/apps/geolibre-desktop/src/lib/tauri-io.ts
@@ -311,6 +311,14 @@ async function readLocalFileBytes(
     return await readFile(path);
   } catch (error) {
     if (!isTauri()) throw error;
+    // Log the original fs-plugin error before retrying so a genuine read
+    // failure (a moved/deleted file, not a scope denial) is still diagnosable
+    // even though the command's "Could not read local file" error is what
+    // ultimately surfaces.
+    console.debug(
+      `[GeoLibre] fs read of "${path}" failed; retrying via read_local_file.`,
+      error,
+    );
     const buffer = await invoke<ArrayBuffer>("read_local_file", { path });
     return new Uint8Array(buffer);
   }
@@ -330,6 +338,10 @@ async function readLocalFileText(path: string): Promise<string> {
     return await readTextFile(path);
   } catch (error) {
     if (!isTauri()) throw error;
+    console.debug(
+      `[GeoLibre] fs read of "${path}" failed; retrying via read_local_file.`,
+      error,
+    );
     const buffer = await invoke<ArrayBuffer>("read_local_file", { path });
     return new TextDecoder().decode(buffer);
   }


### PR DESCRIPTION
## Problem

Opening a project that saved local vector layers as **file references** (the desktop "Save file references" option) failed to reload any of them. Diagnostics showed, for every layer:

> Could not convert this vector file with DuckDB-WASM. Unknown error

even though the files were in the same location and unmodified (issue #880).

## Root cause

When a project is reopened, the layer paths come from the saved `.geolibre.json`, **not** from a file picker or drag-drop. Those paths are therefore outside the Tauri `fs` plugin's runtime scope (the capabilities grant `fs:allow-read-*` with no path scope; only picked/dropped paths are added at runtime). So the `readFile` / `readTextFile` calls in the desktop vector loader (`loadTauriVectorFile`) reject the path. The GeoJSON branch silently falls through to the DuckDB path, whose own scoped `readFile` rejects too, and the rejection (a non-`Error` value) surfaces as the misleading "Unknown error" conversion message.

This is the same scope limitation the project file itself hits, which is already solved by the `read_project_file` Tauri command that reads the file directly (bypassing the JS plugin scope). The layer reload simply wasn't given the same treatment.

## Fix

- Add a `read_local_file` Tauri command that reads a file's bytes directly, returned as a raw IPC response (an `ArrayBuffer` on the JS side, so a large GeoJSON does not pay the cost of a JSON number array). It mirrors `read_project_file`.
- In the desktop vector loader, route the file reads through `readLocalFileBytes` / `readLocalFileText` helpers that try the `fs` plugin first and fall back to `read_local_file` when the plugin denies the path.

The fast path (drag-drop / dialog picks, already in scope) is unchanged: the fallback only runs after a scope denial. The restore path already guards each path (absolute, no `..` traversal, known vector extension) before reading.

## Verification

- `npm run check:rust`, `npm run build` (tsc + vite), and `npm run test:frontend` (1612 passing) all green; `pre-commit` clean on the changed files.

Note on manual testing: this is a desktop-only Tauri **runtime fs-scope** behavior. It cannot be reproduced through the browser dev server (the web build never reaches `restoreLocalFileLayers`, and the browser uses the File System Access API rather than the Tauri `fs` scope), so the usual browser-Playwright dark/light verification does not apply here. The fix is grounded in the static analysis above and the existing in-repo `read_project_file` precedent that solves the identical scope problem for the project file.

Fixes #880

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved desktop local vector loading by adding a safer Tauri-backed fallback for files that are outside the normal in-app access scope.
  * Extended support across common vector formats, including text-based formats (GeoJSON/JSON, KML/KMZ, GPX, CSV/TSV) and byte-based/archived formats (e.g., shapefiles).
* **Bug Fixes**
  * Hardened local path handling to block unsafe or unsupported locations (such as network/UNC and path traversal).
  * Improved error details when loading dropped vector layers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->