### PR TITLE
feat(controls): rename "Graticule" to "Gridlines" (#872)

### DIFF
--- a/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
+++ b/apps/geolibre-desktop/src/components/layout/TopToolbar.tsx
@@ -808,7 +808,7 @@ export function TopToolbar({
       run: () => setAboutOpen(true),
     },
     // Plugins — one toggle per registered plugin. Atmospheric Effects,
-    // Directions, Reverse Geocode, Graticule, and the deck.gl viz renderer are
+    // Directions, Reverse Geocode, Gridlines, and the deck.gl viz renderer are
     // excluded here because they are surfaced under Controls / Add Data instead
     // (matching the menus).
     ...plugins

--- a/apps/geolibre-desktop/src/components/layout/toolbar/PluginsMenu.tsx
+++ b/apps/geolibre-desktop/src/components/layout/toolbar/PluginsMenu.tsx
@@ -136,7 +136,7 @@ export function PluginsMenu({
         <DropdownMenuLabel>{t("toolbar.item.activatePlugin")}</DropdownMenuLabel>
         <DropdownMenuSeparator />
         {plugins.map((p) => {
-          // Atmospheric Effects, Directions, Reverse Geocode, and Graticule are
+          // Atmospheric Effects, Directions, Reverse Geocode, and Gridlines are
           // toggled from the Controls menu instead, so they are omitted here to
           // avoid a duplicate toggle. The deck.gl viz overlay is an internal
           // renderer driven by the Add Data → "Deck.gl Layer" dialog, not a

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1492,7 +1492,7 @@
       "atmosphereEffects": "Atmospheric Effects",
       "atmosphereEnabled": "Enabled",
       "spinGlobe": "Spinning Globe",
-      "graticule": "Graticule",
+      "graticule": "Gridlines",
       "spinGlobeBoundsTitle": "Bounds are locked",
       "spinGlobeBoundsDesc": "The globe can't spin while the map bounds are locked.",
       "spinGlobeBoundsHint": "Unlocking the bounds lets the globe spin freely. You can re-lock them anytime in Settings.",
@@ -1645,8 +1645,8 @@
     "reverseFailed": "Reverse geocoding failed."
   },
   "graticule": {
-    "title": "Graticule",
-    "controlTitle": "Graticule settings",
+    "title": "Gridlines",
+    "controlTitle": "Gridlines settings",
     "spacing": "Spacing",
     "spacingAuto": "Auto (by zoom)",
     "spacingFixed": "Fixed interval",

--- a/packages/plugins/src/plugins/maplibre-graticule.ts
+++ b/packages/plugins/src/plugins/maplibre-graticule.ts
@@ -66,8 +66,8 @@ export interface GraticuleLabels {
 }
 
 export const DEFAULT_GRATICULE_LABELS: GraticuleLabels = {
-  title: "Graticule",
-  controlTitle: "Graticule settings",
+  title: "Gridlines",
+  controlTitle: "Gridlines settings",
   spacing: "Spacing",
   spacingAuto: "Auto (by zoom)",
   spacingFixed: "Fixed interval",
@@ -842,7 +842,7 @@ function isDefaultSettings(value: GraticuleSettings): boolean {
 
 export const maplibreGraticulePlugin: GeoLibrePlugin = {
   id: GRATICULE_PLUGIN_ID,
-  name: "Graticule",
+  name: "Gridlines",
   version: "0.1.0",
   activate: (app: GeoLibreAppAPI) => {
     const activeMap = app.getMap?.();


### PR DESCRIPTION
## Summary

Renames the user-facing term **"Graticule"** to the broader, more widely understood GIS term **"Gridlines"**, per the proposal in #872 (and the maintainer's agreement in the thread).

As noted in the issue, "Graticule" is technically specific to geographic lat/long lines, while "Gridlines" reads more intuitively and also covers projected grid systems, matching the terminology used by major GIS software.

## What changed

Only the **displayed strings** change:

- Controls menu item: "Graticule" → "Gridlines"
- Settings panel title: "Graticule" → "Gridlines"
- On-map control tooltip: "Graticule settings" → "Gridlines settings"

The plugin id (`maplibre-gl-graticule`), layer/source ids, i18n keys, and function/type names keep the `graticule` name so existing saved projects and internal references stay backward compatible.

Only `en.json` carried these strings; the other locale catalogs have no graticule keys and fall back to English, so no other locale files needed touching.

## Verification

Verified in the running app with the Gridlines control active (grid lines and edge labels drawn on the map), in both **light** and **dark** themes. The Controls menu item, the panel header, and the control button tooltip all read "Gridlines". Pre-commit (including the full npm build) passes.

Fixes #872

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated map grid overlay terminology across the app from “Graticule” to “Gridlines”.
  * Renamed related menu, section, and settings labels for a more consistent user-facing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->