### PR TITLE
fix(geocoding): resolve contradictory Nominatim contact email helper text

### DIFF
--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1106,7 +1106,7 @@
       "reverseEndpoint": "Reverse endpoint (optional)",
       "email": "Contact email (optional)",
       "emailPlaceholder": "you@example.org",
-      "emailHint": "Only used by Nominatim, which asks for it to identify your application per its usage policy — sent only when provided.",
+      "emailHint": "Only used by Nominatim, which recommends providing it to help identify your application — sent only when provided.",
       "secretsWarning": "Keys are stored in plain text in the project file and may be exposed when the project is shared. They are also sent as query parameters, so they appear in geocoding request URLs visible in browser DevTools and any proxy logs.",
       "corsNote": "Google does not officially allow browser requests to its Geocoding API, so requests may be blocked unless served through a same-origin proxy."
     },

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1106,7 +1106,7 @@
       "reverseEndpoint": "Reverse endpoint (optional)",
       "email": "Contact email (optional)",
       "emailPlaceholder": "you@example.org",
-      "emailHint": "Only used by Nominatim, which recommends it to help identify your application. Sent only when provided.",
+      "emailHint": "Only used by Nominatim, which asks for it to identify your application per its usage policy — sent only when provided.",
       "secretsWarning": "Keys are stored in plain text in the project file and may be exposed when the project is shared. They are also sent as query parameters, so they appear in geocoding request URLs visible in browser DevTools and any proxy logs.",
       "corsNote": "Google does not officially allow browser requests to its Geocoding API, so requests may be blocked unless served through a same-origin proxy."
     },

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1106,7 +1106,7 @@
       "reverseEndpoint": "Reverse endpoint (optional)",
       "email": "Contact email (optional)",
       "emailPlaceholder": "you@example.org",
-      "emailHint": "Recommended by Nominatim to help identify your application. Sent only when provided.",
+      "emailHint": "Only used by Nominatim, which recommends it to help identify your application. Sent only when provided.",
       "secretsWarning": "Keys are stored in plain text in the project file and may be exposed when the project is shared. They are also sent as query parameters, so they appear in geocoding request URLs visible in browser DevTools and any proxy logs.",
       "corsNote": "Google does not officially allow browser requests to its Geocoding API, so requests may be blocked unless served through a same-origin proxy."
     },

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1106,7 +1106,7 @@
       "reverseEndpoint": "Reverse endpoint (optional)",
       "email": "Contact email (optional)",
       "emailPlaceholder": "you@example.org",
-      "emailHint": "Recommended by Nominatim to help identify your client. Sent only when provided.",
+      "emailHint": "Recommended by Nominatim to help identify your application. Sent only when provided.",
       "secretsWarning": "Keys are stored in plain text in the project file and may be exposed when the project is shared. They are also sent as query parameters, so they appear in geocoding request URLs visible in browser DevTools and any proxy logs.",
       "corsNote": "Google does not officially allow browser requests to its Geocoding API, so requests may be blocked unless served through a same-origin proxy."
     },

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1106,7 +1106,7 @@
       "reverseEndpoint": "Reverse endpoint (optional)",
       "email": "Contact email (optional)",
       "emailPlaceholder": "you@example.org",
-      "emailHint": "Recommended by Nominatim to help identify your client if usage issues arise. Sent only when provided.",
+      "emailHint": "Recommended by Nominatim to help identify your client. Sent only when provided.",
       "secretsWarning": "Keys are stored in plain text in the project file and may be exposed when the project is shared. They are also sent as query parameters, so they appear in geocoding request URLs visible in browser DevTools and any proxy logs.",
       "corsNote": "Google does not officially allow browser requests to its Geocoding API, so requests may be blocked unless served through a same-origin proxy."
     },

--- a/apps/geolibre-desktop/src/i18n/locales/en.json
+++ b/apps/geolibre-desktop/src/i18n/locales/en.json
@@ -1106,7 +1106,7 @@
       "reverseEndpoint": "Reverse endpoint (optional)",
       "email": "Contact email (optional)",
       "emailPlaceholder": "you@example.org",
-      "emailHint": "Sent to identify the client to Nominatim, per its usage policy.",
+      "emailHint": "Recommended by Nominatim to help identify your client if usage issues arise. Sent only when provided.",
       "secretsWarning": "Keys are stored in plain text in the project file and may be exposed when the project is shared. They are also sent as query parameters, so they appear in geocoding request URLs visible in browser DevTools and any proxy logs.",
       "corsNote": "Google does not officially allow browser requests to its Geocoding API, so requests may be blocked unless served through a same-origin proxy."
     },


### PR DESCRIPTION
## Summary

In Settings → Geocoding, the Nominatim **Contact email** field was labeled `(optional)` while its helper text read "Sent to identify the client to Nominatim, per its usage policy" — wording that implies the email is a policy requirement. The two statements contradicted each other.

The email is in fact only attached to a request when the user provides one (`if (options.email) url.searchParams.set("email", options.email)` in `packages/core/src/geocoding.ts`), so the field is genuinely optional. This applies issue #882's Option B: keep the `(optional)` label and reword the helper text as a recommendation.

## Change

`apps/geolibre-desktop/src/i18n/locales/en.json`

```diff
- "emailHint": "Sent to identify the client to Nominatim, per its usage policy.",
+ "emailHint": "Only used by Nominatim, which recommends it to help identify your application. Sent only when provided.",
```

Only `en.json` defines this key; the other locale catalogs fall back to it.

## Verification

Reproduced the contradiction in the running app, then confirmed the new helper text renders correctly in both light and dark themes via the Geocoding settings panel. `pre-commit run --files` (including the full npm build) passes.

Fixes #882


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the geocoding settings hint for the optional Nominatim contact email.
  * The message now explains that the email is only used by Nominatim to identify the application under its usage policy, and that it is sent only when provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->